### PR TITLE
Bug fixes for testing suite

### DIFF
--- a/selfdrive/test/plant/maneuver.py
+++ b/selfdrive/test/plant/maneuver.py
@@ -15,7 +15,7 @@ class Maneuver(object):
     self.grade_values = kwargs.get("grade_values", [0.0, 0.0])
     self.grade_breakpoints = kwargs.get("grade_breakpoints", [0.0, duration])
     self.speed_lead_values = kwargs.get("speed_lead_values", [0.0, 0.0])
-    self.speed_lead_breakpoints = kwargs.get("speed_lead_values", [0.0, duration])
+    self.speed_lead_breakpoints = kwargs.get("speed_lead_breakpoints", [0.0, duration])
 
     self.cruise_button_presses = kwargs.get("cruise_button_presses", [])
 

--- a/selfdrive/test/plant/plant.py
+++ b/selfdrive/test/plant/plant.py
@@ -181,7 +181,7 @@ class Plant(object):
 
     # *** radar model ***
     if self.lead_relevancy:
-      d_rel = np.maximum(0., self.distance_lead - distance)
+      d_rel = np.maximum(0., distance_lead - distance)
       v_rel = v_lead - speed
     else:
       d_rel = 200.


### PR DESCRIPTION
Changes to maneuver.py allow speed_lead_breakpoints to be set for a maneuver.
Changes to plant.py make use of the distance_lead variable used in the rest plant.py instead of self.distance_lead which is only set once at initialization.