### PR TITLE
Similar change to support latest Acado

### DIFF
--- a/selfdrive/controls/lib/lateral_mpc/Makefile
+++ b/selfdrive/controls/lib/lateral_mpc/Makefile
@@ -14,9 +14,9 @@ QPOASES_FLAGS = -I$(PHONELIBS)/qpoases -I$(PHONELIBS)/qpoases/INCLUDE -I$(PHONEL
 ACADO_FLAGS = -I$(PHONELIBS)/acado/include -I$(PHONELIBS)/acado/include/acado
 
 ifeq ($(UNAME_M),aarch64)
-ACADO_LIBS := -L $(PHONELIBS)/acado/aarch64/lib -l:libacado_toolkit.a -l:libacado_casadi.a -l:libacado_csparse.a
+ACADO_LIBS := -L $(PHONELIBS)/acado/aarch64/lib -l:libacado_toolkit_s.so -l:libacado_casadi.a -l:libacado_csparse.a
 else
-ACADO_LIBS := -L $(PHONELIBS)/acado/x64/lib -l:libacado_toolkit.a -l:libacado_casadi.a -l:libacado_csparse.a
+ACADO_LIBS := -L $(PHONELIBS)/acado/x64/lib -l:libacado_toolkit_s.so -l:libacado_casadi.a -l:libacado_csparse.a
 endif
 
 OBJS = \
@@ -84,7 +84,7 @@ generator: generator.cpp
 
 .PHONY: generate
 generate: generator
-	./generator
+	LD_LIBRARY_PATH=../../../../phonelibs/acado/x64/lib ./generator
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The library file has been renamed and the execution of the generator requires the library path to be given.