### PR TITLE
Fixes wobble on new CRV

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -239,7 +239,7 @@ class CarInterface(object):
       ret.wheelbase = 2.66
       ret.centerToFront = ret.wheelbase * 0.41
       ret.steerRatio = 12.30
-      ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
+      ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
 
       ret.longitudinalKpBP = [0., 5., 35.]
       ret.longitudinalKpV = [1.2, 0.8, 0.5]


### PR DESCRIPTION
Prior to actuator delay update, I felt like .8/.24 was working well here. After this change though, steer oscillation is very apparent, maybe worst than before. Dropping this value proportionately by 1/4 seems to effectively remove wobble and drastically improves drive-quality.