### PR TITLE
DBC VAL_ parser

### DIFF
--- a/common/dbc.py
+++ b/common/dbc.py
@@ -4,7 +4,7 @@ import struct
 import bitstring
 import sys
 import numbers
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 
 def int_or_float(s):
   # return number, trying to maintain int format
@@ -28,6 +28,7 @@ class dbc(object):
     bo_regexp = re.compile(r"^BO\_ (\w+) (\w+) *: (\w+) (\w+)")
     sg_regexp = re.compile(r"^SG\_ (\w+) : (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*)")
     sgm_regexp = re.compile(r"^SG\_ (\w+) (\w+) *: (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*)")
+    val_regexp = re.compile(r"VAL\_ (\w+) (\w+) (\s*[-+]?[0-9]+\s+\".+?\"[^;]*)")
 
     # A dictionary which maps message ids to tuples ((name, size), signals).
     #   name is the ASCII name of the message.
@@ -35,6 +36,9 @@ class dbc(object):
     #   signals is a list signals contained in the message.
     # signals is a list of DBCSignal in order of increasing start_bit.
     self.msgs = {}
+
+    # A dictionary which maps message ids to a list of tuples (signal name, definition value pairs)
+    self.def_vals = defaultdict(list)
 
     # lookup to bit reverse each byte
     self.bits_index = [(i & ~0b111) + ((-i-1) & 0b111) for i in xrange(64)]
@@ -80,6 +84,30 @@ class dbc(object):
         self.msgs[ids][1].append(
           DBCSignal(sgname, start_bit, signal_size, is_little_endian,
                     is_signed, factor, offset, tmin, tmax, units))
+
+      if l.startswith("VAL_ "):
+        # new signal value/definition
+        dat = val_regexp.match(l)
+
+        if dat is None:
+          print "bad VAL", l
+        ids = int(dat.group(1), 0) # could be hex
+        sgname = dat.group(2)
+        defvals = dat.group(3)
+
+        defvals = defvals.replace("?","\?") #escape sequence in C++
+        defvals = defvals.split('"')[:-1]
+
+        defs = defvals[1::2]
+        #cleanup, convert to UPPER_CASE_WITH_UNDERSCORES
+        for i,d in enumerate(defs):
+          d = defs[i].strip().upper()
+          defs[i] = d.replace(" ","_")
+
+        defvals[1::2] = defs
+        defvals = '"'+"".join(str(i) for i in defvals)+'"'
+
+        self.def_vals[ids].append((sgname, defvals))
 
     for msg in self.msgs.viewvalues():
       msg[1].sort(key=lambda x: x.start_bit)
@@ -218,3 +246,4 @@ if __name__ == "__main__":
 
    dbc_test = dbc(os.path.join(DBC_PATH, sys.argv[1]))
    print dbc_test.get_signals(0xe4)
+

--- a/selfdrive/can/common.h
+++ b/selfdrive/can/common.h
@@ -60,10 +60,19 @@ struct Msg {
   const Signal *sigs;
 };
 
+struct Val {
+  const char* name;
+  uint32_t address;
+  const char* def_val;
+  const Signal *sigs;
+};
+
 struct DBC {
   const char* name;
   size_t num_msgs;
   const Msg *msgs;
+  const Val *vals;
+  size_t num_vals;
 };
 
 const DBC* dbc_lookup(const std::string& dbc_name);

--- a/selfdrive/can/dbc_template.cc
+++ b/selfdrive/can/dbc_template.cc
@@ -20,6 +20,7 @@ const Signal sigs_{{address}}[] = {
       .is_signed = {{"true" if sig.is_signed else "false"}},
       .factor = {{sig.factor}},
       .offset = {{sig.offset}},
+	  .is_little_endian = {{"true" if sig.is_little_endian else "false"}},
       {% if checksum_type == "honda" and sig.name == "CHECKSUM" %}
       .type = SignalType::HONDA_CHECKSUM,
       {% elif checksum_type == "honda" and sig.name == "COUNTER" %}
@@ -64,10 +65,10 @@ const Val vals[] = {
 }
 const DBC {{dbc.name}} = {
   .name = "{{dbc.name}}",
-  .num_msgs = ARRAYSIZE(msgs),   
+  .num_msgs = ARRAYSIZE(msgs),
   .msgs = msgs,
   .vals = vals,
-  .num_vals = ARRAYSIZE(vals)
+  .num_vals = ARRAYSIZE(vals),
 };
 
 dbc_init({{dbc.name}})

--- a/selfdrive/can/dbc_template.cc
+++ b/selfdrive/can/dbc_template.cc
@@ -20,7 +20,6 @@ const Signal sigs_{{address}}[] = {
       .is_signed = {{"true" if sig.is_signed else "false"}},
       .factor = {{sig.factor}},
       .offset = {{sig.offset}},
-      .is_little_endian = {{"true" if sig.is_little_endian else "false"}},
       {% if checksum_type == "honda" and sig.name == "CHECKSUM" %}
       .type = SignalType::HONDA_CHECKSUM,
       {% elif checksum_type == "honda" and sig.name == "COUNTER" %}
@@ -48,12 +47,27 @@ const Msg msgs[] = {
 {% endfor %}
 };
 
-}
+const Val vals[] = {
+{% for address, sig in def_vals %}
+  {% for sg_name, def_val in sig %}
+    {% set address_hex = "0x%X" % address %}
+    {
+      .name = "{{sg_name}}",
+      .address = {{address_hex}},
+      .def_val = {{def_val}},
+      .sigs = sigs_{{address}},
+    },
+  {% endfor %}
+{% endfor %}
+};
 
+}
 const DBC {{dbc.name}} = {
   .name = "{{dbc.name}}",
-  .num_msgs = ARRAYSIZE(msgs),
+  .num_msgs = ARRAYSIZE(msgs),   
   .msgs = msgs,
+  .vals = vals,
+  .num_vals = ARRAYSIZE(vals)
 };
 
 dbc_init({{dbc.name}})

--- a/selfdrive/can/dbc_template.cc
+++ b/selfdrive/can/dbc_template.cc
@@ -20,7 +20,7 @@ const Signal sigs_{{address}}[] = {
       .is_signed = {{"true" if sig.is_signed else "false"}},
       .factor = {{sig.factor}},
       .offset = {{sig.offset}},
-	  .is_little_endian = {{"true" if sig.is_little_endian else "false"}},
+      .is_little_endian = {{"true" if sig.is_little_endian else "false"}},
       {% if checksum_type == "honda" and sig.name == "CHECKSUM" %}
       .type = SignalType::HONDA_CHECKSUM,
       {% elif checksum_type == "honda" and sig.name == "COUNTER" %}

--- a/selfdrive/can/libdbc_py.py
+++ b/selfdrive/can/libdbc_py.py
@@ -59,8 +59,17 @@ typedef struct {
 
 typedef struct {
   const char* name;
+  uint32_t address;
+  const char* def_val;
+  const Signal *sigs;
+} Val;
+
+typedef struct {
+  const char* name;
   size_t num_msgs;
   const Msg *msgs;
+  const Val *vals;
+  size_t num_vals;
 } DBC;
 
 

--- a/selfdrive/can/parser.py
+++ b/selfdrive/can/parser.py
@@ -93,6 +93,28 @@ class CANParser(object):
     libdbc.can_update(self.can, sec, wait)
     return self.update_vl(sec)
 
+
+class CANDefine(object):
+  def __init__(self, dbc_name):
+    self.dv = defaultdict(dict)
+    self.dbc_name = dbc_name
+    self.dbc = libdbc.dbc_lookup(dbc_name)
+
+    num_vals = self.dbc[0].num_vals
+    for i in range(num_vals):
+      val = self.dbc[0].vals[i]
+
+      sgname = ffi.string(val.name)
+      def_val = ffi.string(val.def_val)
+
+      #separate definition/value pairs
+      def_val = def_val.split()
+      values = [int(v) for v in def_val[::2]]
+      defs = def_val[1::2]
+
+      self.dv[sgname] = {d: v for d, v in zip(defs, values)} #build dict
+
+
 if __name__ == "__main__":
   from common.realtime import sec_since_boot
 

--- a/selfdrive/can/process_dbc.py
+++ b/selfdrive/can/process_dbc.py
@@ -24,10 +24,13 @@ with open(template_fn, "r") as template_f:
 msgs = [(address, msg_name, msg_size, sorted(msg_sigs, key=lambda s: s.name not in ("COUNTER", "CHECKSUM"))) # process counter and checksums first
         for address, ((msg_name, msg_size), msg_sigs) in sorted(can_dbc.msgs.iteritems()) if msg_sigs]
 
+def_vals = {a: set(b) for a,b in can_dbc.def_vals.items()} #remove duplicates
+def_vals = [(address, sig) for address, sig in sorted(def_vals.iteritems())]
+
 if can_dbc.name.startswith("honda") or can_dbc.name.startswith("acura"):
   checksum_type = "honda"
   checksum_size = 4
-elif can_dbc.name.startswith("toyota") or can_dbc.name.startswith("lexus"):
+elif can_dbc.name.startswith("toyota"):
   checksum_type = "toyota"
   checksum_size = 8
 else:
@@ -49,13 +52,13 @@ for address, msg_name, msg_size, sigs in msgs:
         sys.exit("COUNTER starts at wrong bit %s" % msg_name)
 
 
-# Fail on duplicate message names
+# Fail on duplicate messgae names
 c = Counter([msg_name for address, msg_name, msg_size, sigs in msgs])
 for name, count in c.items():
   if count > 1:
     sys.exit("Duplicate message name in DBC file %s" % name)
 
-parser_code = template.render(dbc=can_dbc, checksum_type=checksum_type, msgs=msgs, len=len)
+parser_code = template.render(dbc=can_dbc, checksum_type=checksum_type, msgs=msgs, def_vals=def_vals, len=len)
 
 with open(out_fn, "w") as out_f:
   out_f.write(parser_code)

--- a/selfdrive/can/process_dbc.py
+++ b/selfdrive/can/process_dbc.py
@@ -30,7 +30,7 @@ def_vals = [(address, sig) for address, sig in sorted(def_vals.iteritems())]
 if can_dbc.name.startswith("honda") or can_dbc.name.startswith("acura"):
   checksum_type = "honda"
   checksum_size = 4
-elif can_dbc.name.startswith("toyota"):
+elif can_dbc.name.startswith("toyota") or can_dbc.name.startswith("lexus"):
   checksum_type = "toyota"
   checksum_size = 8
 else:
@@ -52,7 +52,7 @@ for address, msg_name, msg_size, sigs in msgs:
         sys.exit("COUNTER starts at wrong bit %s" % msg_name)
 
 
-# Fail on duplicate messgae names
+# Fail on duplicate message names
 c = Counter([msg_name for address, msg_name, msg_size, sigs in msgs])
 for name, count in c.items():
   if count > 1:


### PR DESCRIPTION
This parser, CANDefine, pulls definition-value pairs from the respective dbc. It shares a similar call structure with CANParser. 
For example:
given,
`VAL_ 399 STEER_STATUS 5 "fault" 4 "no torque alert 2" 2 " no torque alert 1 " 0 "normal" ;`
the value of 2 corresponding to "no torque alert 1" is callable by: 
`cd.dv["STEER_STATUS"]['NO_TORQUE_ALERT_1']`
Repeated lines in the dbc are removed, leading and trailing white space is removed in each def/val pair, and naming is converted to uppercase with underscores for convention.
This is a very forgiving parser, but it requires a unique naming call--this is by design
`VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw" ;`
will only return FCW : 1 and NO_FCW : 0. 

This will greatly reduce gear shifter logic in carstate and also removes other hard coding.