### PR TITLE
Missing alertmanager entry causes silent failure of OP

### DIFF
--- a/selfdrive/controls/lib/alertmanager.py
+++ b/selfdrive/controls/lib/alertmanager.py
@@ -94,6 +94,12 @@ class AlertManager(object):
         AlertStatus.userPrompt, AlertSize.mid,
         Priority.LOW, None, None, .2, .2, .2),
 
+    "steerTempUnavailableMuteNoEntry": Alert(
+        "TAKE CONTROL",
+        "Steering Temporarily Unavailable",
+        AlertStatus.userPrompt, AlertSize.mid,
+        Priority.LOW, None, None, .2, .2, .2),
+
     "preDriverDistracted": Alert(
         "TAKE CONTROL",
         "User Appears Distracted",


### PR DESCRIPTION
Added missing steerTempUnavailableMuteNoEntry - This appears it may have been created / used by Ford code. I used it in Tesla code and saw OP crash (stopped steering) with no visual warning - All looks normal visually. 

This is needed because in selfdrive/controls/controlsd.py adds a NoEntry for every active alert:

`  # DISABLED
  if state == State.disabled:
    if get_events(events, [ET.ENABLE]):
      if get_events(events, [ET.NO_ENTRY]):
        for e in get_events(events, [ET.NO_ENTRY]):
          AM.add(str(e) + "NoEntry", enabled)
`

Another option would be in alertmanager.py (I didn't write down error line, I think):
`    added_alert = copy.copy(self.alerts[alert_type])
`

This could have a try around it so that if the alert doesn't exist we ignore it with some logged error (?). It's a bit unsafe to crash the alertmanager, which doesn't ever auto recover, due to this - I'm sure other ports will make the mistake in the future.

Great work on the models and the project, this thing works amazing in the Teslas! Thank you!