### PR TITLE
Volt: Fix resume bug on high resistance (steep hills etc)

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -141,7 +141,7 @@ class CarController(object):
       if (frame % 4) == 0:
         idx = (frame / 4) % 4
 
-        want_full_stop = enabled and CS.standstill and apply_gas < P.ZERO_GAS
+        want_full_stop = enabled and CS.standstill and apply_gas < 2048
         near_stop = enabled and (CS.v_ego < P.NEAR_STOP_BRAKE_PHASE)
         can_sends.append(gmcan.create_friction_brake_command(self.packer_ch, canbus.chassis, apply_brake, idx, near_stop, want_full_stop))
 

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -141,7 +141,7 @@ class CarController(object):
       if (frame % 4) == 0:
         idx = (frame / 4) % 4
 
-        want_full_stop = enabled and CS.standstill and apply_gas < 1
+        want_full_stop = enabled and CS.standstill and apply_gas < P.ZERO_GAS
         near_stop = enabled and (CS.v_ego < P.NEAR_STOP_BRAKE_PHASE)
         can_sends.append(gmcan.create_friction_brake_command(self.packer_ch, canbus.chassis, apply_brake, idx, near_stop, want_full_stop))
 

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -28,11 +28,11 @@ class CarControllerParams():
     self.ADAS_KEEPALIVE_STEP = 10
     # pedal lookups, only for Volt
     MAX_GAS = 3072              # Only a safety limit
-    ZERO_GAS = 2048
+    self.ZERO_GAS = 2048
     MAX_BRAKE = 350             # Should be around 3.5m/s^2, including regen
     self.MAX_ACC_REGEN = 1404  # ACC Regen braking is slightly less powerful than max regen paddle
     self.GAS_LOOKUP_BP = [-0.25, 0., 0.5]
-    self.GAS_LOOKUP_V = [self.MAX_ACC_REGEN, ZERO_GAS, MAX_GAS]
+    self.GAS_LOOKUP_V = [self.MAX_ACC_REGEN, self.ZERO_GAS, MAX_GAS]
     self.BRAKE_LOOKUP_BP = [-1., -0.25]
     self.BRAKE_LOOKUP_V = [MAX_BRAKE, 0]
 
@@ -141,7 +141,7 @@ class CarController(object):
       if (frame % 4) == 0:
         idx = (frame / 4) % 4
 
-        want_full_stop = enabled and CS.standstill and apply_gas < 2048
+        want_full_stop = enabled and CS.standstill and apply_gas < P.ZERO_GAS
         near_stop = enabled and (CS.v_ego < P.NEAR_STOP_BRAKE_PHASE)
         can_sends.append(gmcan.create_friction_brake_command(self.packer_ch, canbus.chassis, apply_brake, idx, near_stop, want_full_stop))
 

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -141,12 +141,12 @@ class CarController(object):
       if (frame % 4) == 0:
         idx = (frame / 4) % 4
 
-        at_full_stop = enabled and CS.standstill
+        want_full_stop = enabled and CS.standstill
         near_stop = enabled and (CS.v_ego < P.NEAR_STOP_BRAKE_PHASE)
-        can_sends.append(gmcan.create_friction_brake_command(self.packer_ch, canbus.chassis, apply_brake, idx, near_stop, at_full_stop))
+        can_sends.append(gmcan.create_friction_brake_command(self.packer_ch, canbus.chassis, apply_brake, idx, near_stop, want_full_stop))
 
-        at_full_stop = enabled and CS.standstill
-        can_sends.append(gmcan.create_gas_regen_command(self.packer_pt, canbus.powertrain, apply_gas, idx, enabled, at_full_stop))
+        want_full_stop = enabled and CS.standstill
+        can_sends.append(gmcan.create_gas_regen_command(self.packer_pt, canbus.powertrain, apply_gas, idx, enabled, want_full_stop))
 
       # Send dashboard UI commands (ACC status), 25hz
       if (frame % 4) == 0:

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -141,11 +141,10 @@ class CarController(object):
       if (frame % 4) == 0:
         idx = (frame / 4) % 4
 
-        want_full_stop = enabled and CS.standstill
+        want_full_stop = enabled and CS.standstill and apply_gas < 1
         near_stop = enabled and (CS.v_ego < P.NEAR_STOP_BRAKE_PHASE)
         can_sends.append(gmcan.create_friction_brake_command(self.packer_ch, canbus.chassis, apply_brake, idx, near_stop, want_full_stop))
 
-        want_full_stop = enabled and CS.standstill
         can_sends.append(gmcan.create_gas_regen_command(self.packer_pt, canbus.powertrain, apply_gas, idx, enabled, want_full_stop))
 
       # Send dashboard UI commands (ACC status), 25hz

--- a/selfdrive/car/gm/gmcan.py
+++ b/selfdrive/car/gm/gmcan.py
@@ -39,13 +39,13 @@ def create_adas_keepalive(bus):
   dat = "\x00\x00\x00\x00\x00\x00\x00"
   return [[0x409, 0, dat, bus], [0x40a, 0, dat, bus]]
 
-def create_gas_regen_command(packer, bus, throttle, idx, acc_engaged, at_full_stop):
+def create_gas_regen_command(packer, bus, throttle, idx, acc_engaged, want_full_stop):
   values = {
     "GasRegenCmdActive": acc_engaged,
     "RollingCounter": idx,
     "GasRegenCmdActiveInv": 1 - acc_engaged,
     "GasRegenCmd": throttle,
-    "GasRegenFullStopActive": at_full_stop,
+    "GasRegenFullStopActive": want_full_stop,
     "GasRegenAlwaysOne": 1,
     "GasRegenAlwaysOne2": 1,
     "GasRegenAlwaysOne3": 1,
@@ -58,14 +58,14 @@ def create_gas_regen_command(packer, bus, throttle, idx, acc_engaged, at_full_st
 
   return packer.make_can_msg("ASCMGasRegenCmd", bus, values)
 
-def create_friction_brake_command(packer, bus, apply_brake, idx, near_stop, at_full_stop):
+def create_friction_brake_command(packer, bus, apply_brake, idx, near_stop, want_full_stop):
 
   if apply_brake == 0:
     mode = 0x1
   else:
     mode = 0xa
 
-    if at_full_stop:
+    if want_full_stop:
       mode = 0xd
     # TODO: this is to have GM bringing the car to complete stop,
     # but currently it conflicts with OP controls, so turned off.


### PR DESCRIPTION
@vntarasov @rbiasini 

Fixed :)

apply_gas is the best determination I could find to figure out when OP wants to "go." We need to release the want_full_stop "request" when accelerating from a full stop. Previous code was working because it was winding up the PID loop to heavy (max) acceleration.

Side bonus is that the resume acceleration is much smoother/gentler (too gentle?)