### PR TITLE
Updates to supported cars

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,17 @@ Supported Cars
 | Honda         | Accord 2018               | All                  | Yes     | Stock          | 0mph             | 3mph           |
 | Honda         | Civic 2016                | Honda Sensing        | Yes     | Yes            | 0mph             | 12mph          |
 | Honda         | Civic 2017                | Honda Sensing        | Yes     | Yes            | 0mph             | 12mph          |
-| Honda         | Civic 2017 *(Hatch)*      | Honda Sensing        | Yes     | Stock          | 0mph             | 12mph          |
+| Honda         | Civic 2017 *(Hatch)*      | Honda Sensing        | Yes     | Stock          | 0mph             | 12mph 
+   |
+| Honda         | Civic 2018 *(Hatch)*      | Honda Sensing        | Yes     | Stock          | 0mph             | 12mph 
+   |
 | Honda         | Civic 2018                | Honda Sensing        | Yes     | Yes            | 0mph             | 12mph          |
-| Honda         | CR-V 2015                 | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
-| Honda         | CR-V 2016                 | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
+| Honda         | CR-V 2015                 | Touring              | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
+| Honda         | CR-V 2016                 | Touring              | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
 | Honda         | CR-V 2017                 | Honda Sensing        | Yes     | Stock          | 0mph             | 12mph          |
 | Honda         | CR-V 2018                 | Honda Sensing        | Yes     | Stock          | 0mph             | 12mph          |
-| Honda         | Odyssey 2017              | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
-| Honda         | Odyssey 2018              | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
+| Honda         | Odyssey 2017              | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 0mph          |
+| Honda         | Odyssey 2018              | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 0mph          |
 | Honda         | Pilot 2017                | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
 | Honda         | Pilot 2018                | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |
 | Honda         | Ridgeline 2017            | Honda Sensing        | Yes     | Yes            | 25mph<sup>1</sup>| 12mph          |


### PR DESCRIPTION
* Only Touring has Honda sensing on 15 and 16 CR-V
* 2018 Hatch Supported
* Odyssey steers down to 0, not 12