### PR TITLE
GM: go passive if detected ASCM or LKA camera

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -55,7 +55,7 @@ def actuator_hystereses(final_pedal, pedal_steady):
 
 
 class CarController(object):
-  def __init__(self, canbus, car_fingerprint):
+  def __init__(self, canbus, car_fingerprint, allow_controls):
     self.pedal_steady = 0.
     self.start_time = sec_since_boot()
     self.chime = 0
@@ -64,6 +64,7 @@ class CarController(object):
     self.steer_idx = 0
     self.apply_steer_last = 0
     self.car_fingerprint = car_fingerprint
+    self.allow_controls = allow_controls
 
     # Setup detection helper. Routes commands to
     # an appropriate CAN bus number.
@@ -76,6 +77,10 @@ class CarController(object):
   def update(self, sendcan, enabled, CS, frame, actuators, \
              hud_v_cruise, hud_show_lanes, hud_show_car, chime, chime_cnt):
     """ Controls thread """
+
+    # Sanity check.
+    if not self.allow_controls:
+      return
 
     P = self.params
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -21,18 +21,16 @@ class CM:
   LOW_CHIME = 0x86
   HIGH_CHIME = 0x87
 
-# GM cars have 4 CAN buses, which creates many ways
-# of how the car can be connected to.
-# This ia a helper class for the interface to be setup-agnostic.
-# Supports single Panda setup (connected to OBDII port),
-# and a CAN forwarding setup (connected to camera module connector).
-
 class CanBus(object):
   def __init__(self):
     self.powertrain = 0
     self.obstacle = 1
     self.chassis = 2
     self.sw_gmlan = 3
+
+# 384 = "ASCMLKASteeringCmd"
+# 715 = "ASCMGasRegenCmd"
+CONTROL_MSGS = [384, 715]
 
 class CarInterface(object):
   def __init__(self, CP, sendcan=None):
@@ -54,7 +52,7 @@ class CarInterface(object):
     # sending if read only is False
     if sendcan is not None:
       self.sendcan = sendcan
-      self.CC = CarController(canbus, CP.carFingerprint)
+      self.CC = CarController(canbus, CP.carFingerprint, CP.enableCamera)
 
   @staticmethod
   def compute_gb(accel, speed):
@@ -73,8 +71,11 @@ class CarInterface(object):
 
     ret.enableCruise = False
 
-    # TODO: gate this on detection
-    ret.enableCamera = True
+    # Presence of a camera on the object bus is ok.
+    # Have to go passive if ASCM is online (ACC-enabled cars),
+    # or camera is on powertrain bus (LKA cars without ACC).
+    ret.enableCamera = not any(x for x in CONTROL_MSGS if x in fingerprint)
+
     std_cargo = 136
 
     if candidate == CAR.VOLT:


### PR DESCRIPTION
When people don't unplug ASCM, panda's safety (ensures openpilot is passive) results in "control mismatch" error on engagement attempt that people don't understand.

With "enableCamera" flag set to false, controlsd ensures openpilot is in passive mode.

This PR also applies to non-ACC, LKA-only GM cars, with camera still connected (to powertrain CAN).