### PR TITLE
GM: no speed limit to resume

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -5,7 +5,7 @@ from selfdrive.config import Conversions as CV
 from selfdrive.can.parser import CANParser
 from selfdrive.car.gm.values import DBC, CAR, parse_gear_shifter, \
                                     CruiseButtons, is_eps_status_ok, \
-                                    STEER_THRESHOLD
+                                    STEER_THRESHOLD, AccState
 
 def get_powertrain_can_parser(CP, canbus):
   # this function generates lists for signal, messages and initial values

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -5,7 +5,8 @@ from selfdrive.config import Conversions as CV
 from selfdrive.controls.lib.drive_helpers import create_event, EventTypes as ET
 from selfdrive.controls.lib.vehicle_model import VehicleModel
 from selfdrive.car.gm.values import DBC, CAR
-from selfdrive.car.gm.carstate import CarState, CruiseButtons, get_powertrain_can_parser
+from selfdrive.car.gm.carstate import CarState, CruiseButtons, \
+                                      AccState, get_powertrain_can_parser
 
 try:
   from selfdrive.car.gm.carcontroller import CarController
@@ -78,8 +79,12 @@ class CarInterface(object):
     std_cargo = 136
 
     if candidate == CAR.VOLT:
-      # supports stop and go, but initial engage must be above 18mph (which include conservatism)
-      ret.minEnableSpeed = 18 * CV.MPH_TO_MS
+      # initial engage must be above ~18mph, and resume
+      # can happen at any speed, unless brake pedal was pressed,
+      # in which case resume can only happen above ~7mph.
+      # TODO: track PCM state to know exactly when set/res are allowed,
+      # instead of disengaging on a PCM fault.
+      ret.minEnableSpeed = -1
       # kg of standard extra cargo to count for drive, gas, etc...
       ret.mass = 1607 + std_cargo
       ret.safetyModel = car.CarParams.SafetyModels.gm
@@ -194,9 +199,9 @@ class CarInterface(object):
 
     # cruise state
     ret.cruiseState.available = bool(self.CS.main_on)
-    cruiseEnabled = self.CS.pcm_acc_status != 0
+    cruiseEnabled = self.CS.pcm_acc_status in [AccState.ACTIVE, AccState.STANDSTILL]
     ret.cruiseState.enabled = cruiseEnabled
-    ret.cruiseState.standstill = self.CS.pcm_acc_status == 4
+    ret.cruiseState.standstill = self.CS.pcm_acc_status == AccState.STANDSTILL
 
     ret.leftBlinker = self.CS.left_blinker_on
     ret.rightBlinker = self.CS.right_blinker_on
@@ -281,6 +286,8 @@ class CarInterface(object):
         events.append(create_event('pedalPressed', [ET.PRE_ENABLE]))
       if ret.cruiseState.standstill:
         events.append(create_event('resumeRequired', [ET.WARNING]))
+      if self.CS.pcm_acc_status == AccState.FAULTED:
+        events.append(create_event('speedTooLow', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))
 
       # handle button presses
       for b in ret.buttonEvents:

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -12,6 +12,12 @@ class CruiseButtons:
   MAIN        = 5
   CANCEL      = 6
 
+class AccState:
+  OFF        = 0
+  ACTIVE     = 1
+  FAULTED    = 3
+  STANDSTILL = 4
+
 def is_eps_status_ok(eps_status, car_fingerprint):
   valid_eps_status = []
   if car_fingerprint == CAR.VOLT:


### PR DESCRIPTION
Remove "18mph to engage" limit, through catching a PCM fault and showing the same "Speed too low" error instead.

Pros:
- "resume" re-engagement is possible at much lower speeds. For 2017 Volt:
  - resume works at any speed, if brake pedal was not pressed since disengagement. Heh, I was able to resume from rolling backwards against an uphill (resume from negative speed?).
  - resume works above ~7 mph if brake pedal was pressed since disengagement.
- 2018 has even lower limit to engage for both "set" and "res". With this change, we have a precise speed limit for engagement, no need for overshooting the limit, no need to dig for PCM states for various years.

Cons:
- If PCM fault happens due to an unrelated bug, "Speed too low" would be a wrong message to show.
- Different user experience compared to "wrong gear" and other known state errors: instead of showing "Speed too low" right away, PCM fault catching & message will happen split second after openpilot engages.