### PR TITLE
Docker environment breaking

### DIFF
--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && apt-get install -y build-essential clang vim screen wget bzip2 git libglib2.0-0 python-pip capnproto libcapnp-dev libzmq5-dev libffi-dev libusb-1.0-0
-RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib==2.2.3
+RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib==2.1.2
 
 COPY requirements_openpilot.txt /tmp/
 RUN pip install -r /tmp/requirements_openpilot.txt

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && apt-get install -y build-essential clang vim screen wget bzip2 git libglib2.0-0 python-pip capnproto libcapnp-dev libzmq5-dev libffi-dev libusb-1.0-0
-RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib
+RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib==2.2.3
 
 COPY requirements_openpilot.txt /tmp/
 RUN pip install -r /tmp/requirements_openpilot.txt


### PR DESCRIPTION
Latest version of matplotlib is now 3.0.0 and requires Python 3.5 so needed to declare version number:

```Step 4/14 : RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib
 ---> Running in b5822357e618
Collecting numpy==1.11.2
  Downloading https://files.pythonhosted.org/packages/5e/d5/3433e015f3e4a1f309dbb110e8557947f68887fe9b8438d50a4b7790a954/numpy-1.11.2-cp27-cp27mu-manylinux1_x86_64.whl (15.3MB)
Collecting scipy==0.18.1
  Downloading https://files.pythonhosted.org/packages/13/cb/8e74d28e1519b34636e4d985d49d01c23778064e01eb102914f844cd6051/scipy-0.18.1-cp27-cp27mu-manylinux1_x86_64.whl (40.3MB)
Collecting matplotlib
  Downloading https://files.pythonhosted.org/packages/ec/06/def4fb2620cbe671ba0cb6462cbd8653fbffa4acd87d6d572659e7c71c13/matplotlib-3.0.0.tar.gz (36.3MB)
    Complete output from command python setup.py egg_info:
    
    Matplotlib 3.0+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, or 3.4.
    Beginning with Matplotlib 3.0, Python 3.5 and above is required.
    
    This may be due to an out of date pip.
    
    Make sure you have pip >= 9.0.1.```