### PR TITLE
Adds check to bosch for passive mode

### DIFF
--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && apt-get install -y build-essential clang vim screen wget bzip2 git libglib2.0-0 python-pip capnproto libcapnp-dev libzmq5-dev libffi-dev libusb-1.0-0
-RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib==2.1.2
+RUN pip install numpy==1.11.2 scipy==0.18.1 matplotlib==2.2.3
 
 COPY requirements_openpilot.txt /tmp/
 RUN pip install -r /tmp/requirements_openpilot.txt


### PR DESCRIPTION
Allows passive mode on Bosch vehicles.

In order to use Honda Sensing in any bosch, you must unplug your EON which means you can't record drives.

If Can 2 and 3 are jumped on Bosch giraffe, openpilot should check for this and switch to passive mode.