### PR TITLE
GM: no speed limit to engage

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -5,7 +5,7 @@ from selfdrive.config import Conversions as CV
 from selfdrive.can.parser import CANParser
 from selfdrive.car.gm.values import DBC, CAR, parse_gear_shifter, \
                                     CruiseButtons, is_eps_status_ok, \
-                                    STEER_THRESHOLD
+                                    STEER_THRESHOLD, AccState
 
 def get_powertrain_can_parser(CP, canbus):
   # this function generates lists for signal, messages and initial values


### PR DESCRIPTION
Remove "18mph to engage" limit to engage openpilot, through catching a PCM fault and showing the same "Speed too low" error instead.
Since openpilot must be first enabled with the "set" button, this change also disables "resume" button before openpilot is first engaged with "set": "Speed too low" would be a wrong message to show in that case.

Pros:
- re-engagement is possible at much lower speeds. For 2017 Volt:
  - both "set" and "resume" re-engagement work at any speed, if brake pedal was not pressed since disengagement.
  - if brake pedal was pressed since disengagement, resume works above ~7 mph and set works above ~18mph.
- 2018 might have different conditions to engage. With this change, we have a precise speed limit for engagement, no need for overshooting the limit, no need to dig for PCM states for various model years.

Cons:
- If PCM fault happens due to an unrelated bug, "Speed too low" would be a wrong message to show.
- Different user experience compared to "wrong gear" and other known state errors: instead of showing "Speed too low" right away, PCM fault catching & message will happen split second after openpilot engages.