### PR TITLE
Add down-sampled raw CAN data stream

### DIFF
--- a/op
+++ b/op
@@ -1,0 +1,2 @@
+PYTHONPATH=/data/openpilot/ python /data/openpilot/selfdrive/controls/controlsd.py
+

--- a/selfdrive/can/parser.cc
+++ b/selfdrive/can/parser.cc
@@ -284,12 +284,15 @@ class CANParser {
           next_can_forward_ns += can_forward_period_ns;
           // next_can_forward_ns starts at 0, so it needs to be reset.  Also handle delays.
           if (sec > next_can_forward_ns) next_can_forward_ns = sec + can_forward_period_ns;
+          std::string canOut = "";
           for (auto src : raw_can_values) {
               for (auto pid : src.second) {
                   std::string canOut = std::to_string(src.first) + " " + std::to_string(pid.first) + " " + std::to_string(pid.second);
                   zmq_send(forwarder, canOut.data(), canOut.size(), 0);
+                  canOut = canOut + std::to_string(src.first) + " " + std::to_string(pid.first) + " " + std::to_string(pid.second) + "|";
               }
           }
+          zmq_send(forwarder, canOut.data(), canOut.size(), 0);
       }
   }
 

--- a/selfdrive/can/parser.cc
+++ b/selfdrive/can/parser.cc
@@ -166,6 +166,9 @@ class CANParser {
     subscriber = zmq_socket(context, ZMQ_SUB);
     zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0);
 
+    forwarder = zmq_socket(context, ZMQ_PUB);
+    zmq_bind(forwarder, "tcp://*:8592");
+
     std::string tcp_addr_str;
 
     if (sendcan) {
@@ -244,6 +247,13 @@ class CANParser {
       // parse the messages
       for (int i = 0; i < msg_count; i++) {
         auto cmsg = cans[i];
+
+        if (cmsg.getDat().size() > 8) continue; //shouldnt ever happen
+        uint8_t dat[8] = {0};
+        memcpy(dat, cmsg.getDat().begin(), cmsg.getDat().size());
+
+        if (can_forward_period_ns > 0) raw_can_values[cmsg.getSrc()][cmsg.getAddress()] = read_u64_be(dat);
+
         if (cmsg.getSrc() != bus) {
           // DEBUG("skip %d: wrong bus\n", cmsg.getAddress());
           continue;
@@ -254,10 +264,6 @@ class CANParser {
           continue;
         }
 
-        if (cmsg.getDat().size() > 8) continue; //shouldnt ever happen
-        uint8_t dat[8] = {0};
-        memcpy(dat, cmsg.getDat().begin(), cmsg.getDat().size());
-
         // Assumes all signals in the message are of the same type (little or big endian)
         // TODO: allow signals within the same message to have different endianess
         auto& sig = message_states[cmsg.getAddress()].parse_sigs[0];
@@ -265,7 +271,7 @@ class CANParser {
             p = read_u64_le(dat);
         } else {
             p = read_u64_be(dat);
-        }
+        } 
 
         DEBUG("  proc %X: %llx\n", cmsg.getAddress(), p);
 
@@ -273,8 +279,22 @@ class CANParser {
       }
   }
 
+  void ForwardCANData(uint64_t sec) {
+      if (sec > next_can_forward_ns) {
+          next_can_forward_ns += can_forward_period_ns;
+          // next_can_forward_ns starts at 0, so it needs to be reset.  Also handle delays.
+          if (sec > next_can_forward_ns) next_can_forward_ns = sec + can_forward_period_ns;
+          for (auto src : raw_can_values) {
+              for (auto pid : src.second) {
+                  std::string canOut = std::to_string(src.first) + " " + std::to_string(pid.first) + " " + std::to_string(pid.second);
+                  zmq_send(forwarder, canOut.data(), canOut.size(), 0);
+              }
+          }
+      }
+  }
+
   void UpdateValid(uint64_t sec) {
-    can_valid = true;
+    can_valid = true; 
     for (const auto& kv : message_states) {
       const auto& state = kv.second;
       if (state.check_threshold > 0 && (sec - state.seen) > state.check_threshold) {
@@ -317,6 +337,8 @@ class CANParser {
       UpdateCans(sec, cans);
     }
 
+    if (can_forward_period_ns > 0) ForwardCANData(sec);
+
     UpdateValid(sec);
 
     zmq_msg_close(&msg);
@@ -350,6 +372,11 @@ class CANParser {
   // zmq vars
   void *context = NULL;
   void *subscriber = NULL;
+
+  void *forwarder = NULL;
+  uint64_t can_forward_period_ns = 100000000;
+  uint64_t next_can_forward_ns = 0;
+  std::unordered_map<uint32_t, std::unordered_map<uint32_t, uint64_t>> raw_can_values;
 
   const DBC *dbc = NULL;
   std::unordered_map<uint32_t, MessageState> message_states;

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -120,7 +120,7 @@ class CarController(object):
       STEER_MAX = 0xF00
     elif CS.CP.carFingerprint in (CAR.CRV, CAR.ACURA_RDX):
       STEER_MAX = 0x3e8  # CR-V only uses 12-bits and requires a lower value (max value from energee)
-    elif CS.CP.carFingerprint in  in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
+    elif CS.CP.carFingerprint in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
       STEER_MAX = min(0x3dff, abs(CS.angle_steers) + 0x1000)
     else:
       STEER_MAX = 0x1000
@@ -129,7 +129,7 @@ class CarController(object):
     apply_gas = clip(actuators.gas, 0., 1.)
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
 
-    if CS.CP.steerControlType = car.CarParams.SteerControlType.angle
+    if CS.CP.steerControlType == car.CarParams.SteerControlType.angle:
       apply_steer = int(clip(actuators.angleSteer, -STEER_MAX, STEER_MAX))
     else:
       apply_steer = int(clip(actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -71,7 +71,7 @@ class CarController(object):
     self.steerData = ""
 
   def update(self, sendcan, enabled, CS, frame, actuators, \
-             pcm_speed, pcm_override, pcm_cancel_cmd, LaC, pcm_accel, \
+             pcm_speed, pcm_override, pcm_cancel_cmd, pcm_accel, \
              radar_error, hud_v_cruise, hud_show_lanes, hud_show_car, \
              hud_alert, snd_beep, snd_chime):
 

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -127,7 +127,7 @@ class CarController(object):
     elif CS.CP.carFingerprint in (CAR.CRV, CAR.ACURA_RDX):
       STEER_MAX = 0x3e8  # CR-V only uses 12-bits and requires a lower value (max value from energee)
     elif CS.CP.carFingerprint in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
-      STEER_MAX = min(0x3dff, abs(CS.angle_steers * 1000) + 0x3800)
+      STEER_MAX = 0x7dff
     else:
       STEER_MAX = 0x1000
 
@@ -138,7 +138,7 @@ class CarController(object):
     if CS.CP.steerControlType == car.CarParams.SteerControlType.angle:
       apply_steer = int(clip(-actuators.steerAngle * 1000, -STEER_MAX, STEER_MAX))
     else:
-      apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
+      apply_steer = clip(STEER_MAX * -actuators.steer * (1 - (CS.angle_steers / 60)) ** 4, -STEER_MAX, STEER_MAX)
 
     # any other cp.vl[0x18F]['STEER_STATUS'] is common and can happen during user override. sending 0 torque to avoid EPS sending error 5
     lkas_active = enabled and not CS.steer_not_allowed

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -120,13 +120,19 @@ class CarController(object):
       STEER_MAX = 0xF00
     elif CS.CP.carFingerprint in (CAR.CRV, CAR.ACURA_RDX):
       STEER_MAX = 0x3e8  # CR-V only uses 12-bits and requires a lower value (max value from energee)
+    elif CS.CP.carFingerprint in  in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
+      STEER_MAX = min(0x3dff, abs(CS.angle_steers) + 0x1000)
     else:
       STEER_MAX = 0x1000
 
     # steer torque is converted back to CAN reference (positive when steering right)
     apply_gas = clip(actuators.gas, 0., 1.)
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
-    apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
+
+    if CS.CP.steerControlType = car.CarParams.SteerControlType.angle
+      apply_steer = int(clip(actuators.angleSteer, -STEER_MAX, STEER_MAX))
+    else:
+      apply_steer = int(clip(actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
 
     # any other cp.vl[0x18F]['STEER_STATUS'] is common and can happen during user override. sending 0 torque to avoid EPS sending error 5
     lkas_active = enabled and not CS.steer_not_allowed

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -121,7 +121,7 @@ class CarController(object):
     elif CS.CP.carFingerprint in (CAR.CRV, CAR.ACURA_RDX):
       STEER_MAX = 0x3e8  # CR-V only uses 12-bits and requires a lower value (max value from energee)
     elif CS.CP.carFingerprint in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
-      STEER_MAX = min(0x3dff, abs(CS.angle_steers) + 0x1000)
+      STEER_MAX = min(0x3dff, abs(CS.angle_steers * 1000) + 0x3800)
     else:
       STEER_MAX = 0x1000
 
@@ -130,9 +130,9 @@ class CarController(object):
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
 
     if CS.CP.steerControlType == car.CarParams.SteerControlType.angle:
-      apply_steer = int(clip(actuators.angleSteer, -STEER_MAX, STEER_MAX))
+      apply_steer = int(clip(-actuators.steerAngle * 1000, -STEER_MAX, STEER_MAX))
     else:
-      apply_steer = int(clip(actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
+      apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
 
     # any other cp.vl[0x18F]['STEER_STATUS'] is common and can happen during user override. sending 0 torque to avoid EPS sending error 5
     lkas_active = enabled and not CS.steer_not_allowed

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -232,7 +232,7 @@ class CarInterface(object):
     ret.steerLimitAlert = True
     ret.startAccel = 0.5
 
-    ret.steerActuatorDelay = 0.4
+    ret.steerActuatorDelay = 0.1
     ret.steerRateCost = 0.5
 
     return ret

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -180,7 +180,7 @@ class CarInterface(object):
       ret.mass = mass_civic
       ret.wheelbase = wheelbase_civic
       ret.centerToFront = centerToFront_civic
-      ret.steerRatio = -14.63  # 10.93 is end-to-end spec
+      ret.steerRatio = 14.63  # 10.93 is end-to-end spec
       tire_stiffness_factor = 1.
       # Civic at comma has modified steering FW, so different tuning for the Neo in that car
       is_fw_modified = os.getenv("DONGLE_ID") in ['99c94dc769b5d96e']
@@ -197,7 +197,7 @@ class CarInterface(object):
       ret.mass = 2916. * CV.LB_TO_KG + std_cargo
       ret.wheelbase = wheelbase_civic
       ret.centerToFront = centerToFront_civic
-      ret.steerRatio = -14.63  # 10.93 is spec end-to-end
+      ret.steerRatio = 14.63  # 10.93 is spec end-to-end
       tire_stiffness_factor = 1.
       ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -212,7 +212,7 @@ class CarInterface(object):
       ret.mass = 3279. * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.83
       ret.centerToFront = ret.wheelbase * 0.39
-      ret.steerRatio = -15.96  # 11.82 is spec end-to-end
+      ret.steerRatio = 15.96  # 11.82 is spec end-to-end
       tire_stiffness_factor = 0.8467
       ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -226,7 +226,7 @@ class CarInterface(object):
       ret.mass = 3095 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.37
-      ret.steerRatio = -18.61  # 15.3 is spec end-to-end
+      ret.steerRatio = 18.61  # 15.3 is spec end-to-end
       tire_stiffness_factor = 0.72
       # Acura at comma has modified steering FW, so different tuning for the Neo in that car
       is_fw_modified = os.getenv("DONGLE_ID") in ['ff83f397542ab647']
@@ -243,7 +243,7 @@ class CarInterface(object):
       ret.mass = 3572 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.62
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = -15.3         # as spec
+      ret.steerRatio = 15.3         # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -257,7 +257,7 @@ class CarInterface(object):
       ret.mass = 3410. * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.66
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = -16.0   # 12.3 is spec end-to-end
+      ret.steerRatio = 16.0   # 12.3 is spec end-to-end
       tire_stiffness_factor = 0.677
       ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -270,7 +270,7 @@ class CarInterface(object):
       ret.mass = 3935 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.68
       ret.centerToFront = ret.wheelbase * 0.38
-      ret.steerRatio = -15.0         # as spec
+      ret.steerRatio = 15.0         # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -283,7 +283,7 @@ class CarInterface(object):
       ret.mass = 4471 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 3.00
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = -14.35        # as spec
+      ret.steerRatio = 14.35        # as spec
       tire_stiffness_factor = 0.82
       ret.steerKpV, ret.steerKiV = [[0.45], [0.135]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -296,7 +296,7 @@ class CarInterface(object):
       ret.mass = 4303 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.81
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = -16.0         # as spec
+      ret.steerRatio = 16.0         # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -309,7 +309,7 @@ class CarInterface(object):
       ret.mass = 4515 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 3.18
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = -15.59        # as spec
+      ret.steerRatio = 15.59        # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
       ret.longitudinalKpBP = [0., 5., 35.]

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -136,6 +136,7 @@ class CarInterface(object):
     ret = car.CarParams.new_message()
     ret.carName = "honda"
     ret.carFingerprint = candidate
+    ret.steerControlType = car.CarParams.SteerControlType.torque
 
     if candidate in HONDA_BOSCH:
       ret.safetyModel = car.CarParams.SafetyModels.hondaBosch
@@ -179,7 +180,7 @@ class CarInterface(object):
       ret.mass = mass_civic
       ret.wheelbase = wheelbase_civic
       ret.centerToFront = centerToFront_civic
-      ret.steerRatio = 14.63  # 10.93 is end-to-end spec
+      ret.steerRatio = -14.63  # 10.93 is end-to-end spec
       tire_stiffness_factor = 1.
       # Civic at comma has modified steering FW, so different tuning for the Neo in that car
       is_fw_modified = os.getenv("DONGLE_ID") in ['99c94dc769b5d96e']
@@ -196,7 +197,7 @@ class CarInterface(object):
       ret.mass = 2916. * CV.LB_TO_KG + std_cargo
       ret.wheelbase = wheelbase_civic
       ret.centerToFront = centerToFront_civic
-      ret.steerRatio = 14.63  # 10.93 is spec end-to-end
+      ret.steerRatio = -14.63  # 10.93 is spec end-to-end
       tire_stiffness_factor = 1.
       ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -211,20 +212,21 @@ class CarInterface(object):
       ret.mass = 3279. * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.83
       ret.centerToFront = ret.wheelbase * 0.39
-      ret.steerRatio = 15.96  # 11.82 is spec end-to-end
+      ret.steerRatio = -15.96  # 11.82 is spec end-to-end
       tire_stiffness_factor = 0.8467
       ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
       ret.longitudinalKpBP = [0., 5., 35.]
       ret.longitudinalKpV = [1.2, 0.8, 0.5]
       ret.longitudinalKiBP = [0., 35.]
       ret.longitudinalKiV = [0.18, 0.12]
+      ret.steerControlType = car.CarParams.SteerControlType.angle
 
     elif candidate == CAR.ACURA_ILX:
       stop_and_go = False
       ret.mass = 3095 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.37
-      ret.steerRatio = 18.61  # 15.3 is spec end-to-end
+      ret.steerRatio = -18.61  # 15.3 is spec end-to-end
       tire_stiffness_factor = 0.72
       # Acura at comma has modified steering FW, so different tuning for the Neo in that car
       is_fw_modified = os.getenv("DONGLE_ID") in ['ff83f397542ab647']
@@ -241,7 +243,7 @@ class CarInterface(object):
       ret.mass = 3572 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.62
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 15.3         # as spec
+      ret.steerRatio = -15.3         # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -255,7 +257,7 @@ class CarInterface(object):
       ret.mass = 3410. * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.66
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 16.0   # 12.3 is spec end-to-end
+      ret.steerRatio = -16.0   # 12.3 is spec end-to-end
       tire_stiffness_factor = 0.677
       ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -268,7 +270,7 @@ class CarInterface(object):
       ret.mass = 3935 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.68
       ret.centerToFront = ret.wheelbase * 0.38
-      ret.steerRatio = 15.0         # as spec
+      ret.steerRatio = -15.0         # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -281,7 +283,7 @@ class CarInterface(object):
       ret.mass = 4471 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 3.00
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 14.35        # as spec
+      ret.steerRatio = -14.35        # as spec
       tire_stiffness_factor = 0.82
       ret.steerKpV, ret.steerKiV = [[0.45], [0.135]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -294,7 +296,7 @@ class CarInterface(object):
       ret.mass = 4303 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 2.81
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 16.0         # as spec
+      ret.steerRatio = -16.0         # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -307,7 +309,7 @@ class CarInterface(object):
       ret.mass = 4515 * CV.LB_TO_KG + std_cargo
       ret.wheelbase = 3.18
       ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 15.59        # as spec
+      ret.steerRatio = -15.59        # as spec
       tire_stiffness_factor = 0.444 # not optimized yet
       ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
       ret.longitudinalKpBP = [0., 5., 35.]
@@ -317,8 +319,6 @@ class CarInterface(object):
 
     else:
       raise ValueError("unsupported car %s" % candidate)
-
-    ret.steerControlType = car.CarParams.SteerControlType.torque
 
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter. Otherwise, add 0.5 mph margin to not

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -173,7 +173,7 @@ class CarInterface(object):
 
     ret.steerKiBP, ret.steerKpBP = [[0.], [0.]]
 
-    ret.steerKf = 0.00006    #  0.00006 # conservative feed-forward
+    ret.steerKf =  0.00006 # conservative feed-forward
 
     if candidate == CAR.CIVIC:
       stop_and_go = True
@@ -570,7 +570,7 @@ class CarInterface(object):
 
   # pass in a car.CarControl
   # to be called @ 100hz
-  def apply(self, c, perception_state=log.Live20Data.new_message(), LaC=None):
+  def apply(self, c, perception_state=log.Live20Data.new_message()):
     if c.hudControl.speedVisible:
       hud_v_cruise = c.hudControl.setSpeed * CV.MS_TO_KPH
     else:
@@ -602,7 +602,6 @@ class CarInterface(object):
       c.cruiseControl.speedOverride, \
       c.cruiseControl.override, \
       c.cruiseControl.cancel, \
-      LaC, \
       pcm_accel, \
       perception_state.radarErrors, \
       hud_v_cruise, c.hudControl.lanesVisible, \

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -173,39 +173,9 @@ class CarInterface(object):
 
     ret.steerKiBP, ret.steerKpBP = [[0.], [0.]]
 
-    ret.steerKf = 0.00006 # conservative feed-forward
+    ret.steerKf = 0.00006    #  0.00006 # conservative feed-forward
 
-    if candidate == CAR.CIVIC:
-      stop_and_go = True
-      ret.mass = mass_civic
-      ret.wheelbase = wheelbase_civic
-      ret.centerToFront = centerToFront_civic
-      ret.steerRatio = 14.63  # 10.93 is end-to-end spec
-      tire_stiffness_factor = 1.
-      # Civic at comma has modified steering FW, so different tuning for the Neo in that car
-      is_fw_modified = os.getenv("DONGLE_ID") in ['99c94dc769b5d96e']
-      ret.steerKpV, ret.steerKiV = [[0.33], [0.10]] if is_fw_modified else [[0.8], [0.24]]
-      if is_fw_modified:
-        ret.steerKf = 0.00003
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [3.6, 2.4, 1.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.54, 0.36]
-
-    elif candidate == CAR.CIVIC_HATCH:
-      stop_and_go = True
-      ret.mass = 2916. * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = wheelbase_civic
-      ret.centerToFront = centerToFront_civic
-      ret.steerRatio = 14.63  # 10.93 is spec end-to-end
-      tire_stiffness_factor = 1.
-      ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
-    elif candidate in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
+    if candidate in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
       stop_and_go = True
       if not candidate == CAR.ACCORDH: # Hybrid uses same brake msg as hatch
         ret.safetyParam = 1 # Accord and CRV 5G use an alternate user brake msg
@@ -214,109 +184,12 @@ class CarInterface(object):
       ret.centerToFront = ret.wheelbase * 0.39
       ret.steerRatio = 15.96  # 11.82 is spec end-to-end
       tire_stiffness_factor = 0.8467
-      ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
+      ret.steerKpV, ret.steerKiV = [[.6], [0.18]]   # [[0.6], [0.18]]
       ret.longitudinalKpBP = [0., 5., 35.]
       ret.longitudinalKpV = [1.2, 0.8, 0.5]
       ret.longitudinalKiBP = [0., 35.]
       ret.longitudinalKiV = [0.18, 0.12]
       ret.steerControlType = car.CarParams.SteerControlType.angle
-
-    elif candidate == CAR.ACURA_ILX:
-      stop_and_go = False
-      ret.mass = 3095 * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = 2.67
-      ret.centerToFront = ret.wheelbase * 0.37
-      ret.steerRatio = 18.61  # 15.3 is spec end-to-end
-      tire_stiffness_factor = 0.72
-      # Acura at comma has modified steering FW, so different tuning for the Neo in that car
-      is_fw_modified = os.getenv("DONGLE_ID") in ['ff83f397542ab647']
-      ret.steerKpV, ret.steerKiV = [[0.45], [0.00]] if is_fw_modified else [[0.8], [0.24]]
-      if is_fw_modified:
-        ret.steerKf = 0.00003
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
-    elif candidate == CAR.CRV:
-      stop_and_go = False
-      ret.mass = 3572 * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = 2.62
-      ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 15.3         # as spec
-      tire_stiffness_factor = 0.444 # not optimized yet
-      ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
-    elif candidate == CAR.CRV_5G:
-      stop_and_go = True
-      ret.safetyParam = 1 # Accord and CRV 5G use an alternate user brake msg
-      ret.mass = 3410. * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = 2.66
-      ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 16.0   # 12.3 is spec end-to-end
-      tire_stiffness_factor = 0.677
-      ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
-    elif candidate == CAR.ACURA_RDX:
-      stop_and_go = False
-      ret.mass = 3935 * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = 2.68
-      ret.centerToFront = ret.wheelbase * 0.38
-      ret.steerRatio = 15.0         # as spec
-      tire_stiffness_factor = 0.444 # not optimized yet
-      ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
-    elif candidate == CAR.ODYSSEY:
-      stop_and_go = False
-      ret.mass = 4471 * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = 3.00
-      ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 14.35        # as spec
-      tire_stiffness_factor = 0.82
-      ret.steerKpV, ret.steerKiV = [[0.45], [0.135]]
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
-    elif candidate in (CAR.PILOT, CAR.PILOT_2019):
-      stop_and_go = False
-      ret.mass = 4303 * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = 2.81
-      ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 16.0         # as spec
-      tire_stiffness_factor = 0.444 # not optimized yet
-      ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
-    elif candidate == CAR.RIDGELINE:
-      stop_and_go = False
-      ret.mass = 4515 * CV.LB_TO_KG + std_cargo
-      ret.wheelbase = 3.18
-      ret.centerToFront = ret.wheelbase * 0.41
-      ret.steerRatio = 15.59        # as spec
-      tire_stiffness_factor = 0.444 # not optimized yet
-      ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
-      ret.longitudinalKpBP = [0., 5., 35.]
-      ret.longitudinalKpV = [1.2, 0.8, 0.5]
-      ret.longitudinalKiBP = [0., 35.]
-      ret.longitudinalKiV = [0.18, 0.12]
-
     else:
       raise ValueError("unsupported car %s" % candidate)
 
@@ -359,7 +232,7 @@ class CarInterface(object):
     ret.steerLimitAlert = True
     ret.startAccel = 0.5
 
-    ret.steerActuatorDelay = 0.1
+    ret.steerActuatorDelay = 0.4
     ret.steerRateCost = 0.5
 
     return ret
@@ -568,7 +441,7 @@ class CarInterface(object):
 
   # pass in a car.CarControl
   # to be called @ 100hz
-  def apply(self, c, perception_state=log.Live20Data.new_message()):
+  def apply(self, c, perception_state=log.Live20Data.new_message(), LaC=None):
     if c.hudControl.speedVisible:
       hud_v_cruise = c.hudControl.setSpeed * CV.MS_TO_KPH
     else:
@@ -600,6 +473,7 @@ class CarInterface(object):
       c.cruiseControl.speedOverride, \
       c.cruiseControl.override, \
       c.cruiseControl.cancel, \
+      LaC, \
       pcm_accel, \
       perception_state.radarErrors, \
       hud_v_cruise, c.hudControl.lanesVisible, \

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -175,7 +175,37 @@ class CarInterface(object):
 
     ret.steerKf = 0.00006    #  0.00006 # conservative feed-forward
 
-    if candidate in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
+    if candidate == CAR.CIVIC:
+      stop_and_go = True
+      ret.mass = mass_civic
+      ret.wheelbase = wheelbase_civic
+      ret.centerToFront = centerToFront_civic
+      ret.steerRatio = 14.63  # 10.93 is end-to-end spec
+      tire_stiffness_factor = 1.
+      # Civic at comma has modified steering FW, so different tuning for the Neo in that car
+      is_fw_modified = os.getenv("DONGLE_ID") in ['99c94dc769b5d96e']
+      ret.steerKpV, ret.steerKiV = [[0.33], [0.10]] if is_fw_modified else [[0.8], [0.24]]
+      if is_fw_modified:
+        ret.steerKf = 0.00003
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [3.6, 2.4, 1.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.54, 0.36]
+
+    elif candidate == CAR.CIVIC_HATCH:
+      stop_and_go = True
+      ret.mass = 2916. * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = wheelbase_civic
+      ret.centerToFront = centerToFront_civic
+      ret.steerRatio = 14.63  # 10.93 is spec end-to-end
+      tire_stiffness_factor = 1.
+      ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
+    elif candidate in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
       stop_and_go = True
       if not candidate == CAR.ACCORDH: # Hybrid uses same brake msg as hatch
         ret.safetyParam = 1 # Accord and CRV 5G use an alternate user brake msg
@@ -184,14 +214,113 @@ class CarInterface(object):
       ret.centerToFront = ret.wheelbase * 0.39
       ret.steerRatio = 15.96  # 11.82 is spec end-to-end
       tire_stiffness_factor = 0.8467
-      ret.steerKpV, ret.steerKiV = [[.6], [0.18]]   # [[0.6], [0.18]]
+      #ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
+      ret.steerKpV, ret.steerKiV = [[0.13], [0.02]]
       ret.longitudinalKpBP = [0., 5., 35.]
       ret.longitudinalKpV = [1.2, 0.8, 0.5]
       ret.longitudinalKiBP = [0., 35.]
       ret.longitudinalKiV = [0.18, 0.12]
-      ret.steerControlType = car.CarParams.SteerControlType.angle
+
+    elif candidate == CAR.ACURA_ILX:
+      stop_and_go = False
+      ret.mass = 3095 * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = 2.67
+      ret.centerToFront = ret.wheelbase * 0.37
+      ret.steerRatio = 18.61  # 15.3 is spec end-to-end
+      tire_stiffness_factor = 0.72
+      # Acura at comma has modified steering FW, so different tuning for the Neo in that car
+      is_fw_modified = os.getenv("DONGLE_ID") in ['ff83f397542ab647']
+      ret.steerKpV, ret.steerKiV = [[0.45], [0.00]] if is_fw_modified else [[0.8], [0.24]]
+      if is_fw_modified:
+        ret.steerKf = 0.00003
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
+    elif candidate == CAR.CRV:
+      stop_and_go = False
+      ret.mass = 3572 * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = 2.62
+      ret.centerToFront = ret.wheelbase * 0.41
+      ret.steerRatio = 15.3         # as spec
+      tire_stiffness_factor = 0.444 # not optimized yet
+      ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
+    elif candidate == CAR.CRV_5G:
+      stop_and_go = True
+      ret.safetyParam = 1 # Accord and CRV 5G use an alternate user brake msg
+      ret.mass = 3410. * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = 2.66
+      ret.centerToFront = ret.wheelbase * 0.41
+      ret.steerRatio = 16.0   # 12.3 is spec end-to-end
+      tire_stiffness_factor = 0.677
+      ret.steerKpV, ret.steerKiV = [[0.6], [0.18]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
+    elif candidate == CAR.ACURA_RDX:
+      stop_and_go = False
+      ret.mass = 3935 * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = 2.68
+      ret.centerToFront = ret.wheelbase * 0.38
+      ret.steerRatio = 15.0         # as spec
+      tire_stiffness_factor = 0.444 # not optimized yet
+      ret.steerKpV, ret.steerKiV = [[0.8], [0.24]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
+    elif candidate == CAR.ODYSSEY:
+      stop_and_go = False
+      ret.mass = 4471 * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = 3.00
+      ret.centerToFront = ret.wheelbase * 0.41
+      ret.steerRatio = 14.35        # as spec
+      tire_stiffness_factor = 0.82
+      ret.steerKpV, ret.steerKiV = [[0.45], [0.135]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
+    elif candidate in (CAR.PILOT, CAR.PILOT_2019):
+      stop_and_go = False
+      ret.mass = 4303 * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = 2.81
+      ret.centerToFront = ret.wheelbase * 0.41
+      ret.steerRatio = 16.0         # as spec
+      tire_stiffness_factor = 0.444 # not optimized yet
+      ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
+    elif candidate == CAR.RIDGELINE:
+      stop_and_go = False
+      ret.mass = 4515 * CV.LB_TO_KG + std_cargo
+      ret.wheelbase = 3.18
+      ret.centerToFront = ret.wheelbase * 0.41
+      ret.steerRatio = 15.59        # as spec
+      tire_stiffness_factor = 0.444 # not optimized yet
+      ret.steerKpV, ret.steerKiV = [[0.38], [0.11]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
     else:
       raise ValueError("unsupported car %s" % candidate)
+
+    ret.steerControlType = car.CarParams.SteerControlType.torque
 
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter. Otherwise, add 0.5 mph margin to not
@@ -229,10 +358,10 @@ class CarInterface(object):
     ret.longPidDeadzoneV = [0.]
 
     ret.stoppingControl = True
-    ret.steerLimitAlert = True
+    ret.steerLimitAlert = False
     ret.startAccel = 0.5
 
-    ret.steerActuatorDelay = 0.1
+    ret.steerActuatorDelay = 0.01
     ret.steerRateCost = 0.5
 
     return ret

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -277,10 +277,10 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
 
   if rk.frame % 5 == 2 and plan.lateralValid:
     # *** run this at 20hz again ***
-    angle_offset = abs(learn_angle_offset(active, CS.vEgo, angle_offset,
-                                      PL.PP.c_poly, PL.PP.c_prob, -CS.steeringAngle,
-                                      CS.steeringPressed))
-
+    angle_offset = learn_angle_offset(active, CS.vEgo, angle_offset,
+                                      PL.PP.c_poly, PL.PP.c_prob, CS.steeringAngle,
+                                      CS.steeringPressed)
+  angle_offset = -1
   # *** gas/brake PID loop ***
   actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
                                               v_cruise_kph, plan.vTarget, plan.vTargetFuture, plan.aTarget,
@@ -288,7 +288,7 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
 
   # *** steering PID loop ***
   actuators.steer, actuators.steerAngle = LaC.update(active, CS.vEgo, CS.steeringAngle,
-                                                     CS.steeringPressed, plan.dPoly, -angle_offset, VM, PL)
+                                                     CS.steeringPressed, plan.dPoly, angle_offset, VM, PL)
   print(angle_offset, CS.steeringAngle, actuators.steerAngle)
   # send a "steering required alert" if saturation count has reached the limit
   if LaC.sat_flag and CP.steerLimitAlert:
@@ -337,9 +337,9 @@ def data_send(perception_state, plan, plan_ts, CS, CI, CP, VM, state, events, ac
     CC.hudControl.leadVisible = plan.hasLead
     CC.hudControl.visualAlert = AM.visual_alert
     CC.hudControl.audibleAlert = AM.audible_alert
-
+    
     # send car controls over can
-    CI.apply(CC, perception_state)
+    CI.apply(CC, perception_state, LaC)
 
   # ***** publish state to logger *****
   # publish controls state at 100Hz

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -277,9 +277,9 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
 
   if rk.frame % 5 == 2 and plan.lateralValid:
     # *** run this at 20hz again ***
-    angle_offset = learn_angle_offset(active, CS.vEgo, angle_offset,
-                                      PL.PP.c_poly, PL.PP.c_prob, CS.steeringAngle,
-                                      CS.steeringPressed)
+    angle_offset = abs(learn_angle_offset(active, CS.vEgo, angle_offset,
+                                      PL.PP.c_poly, PL.PP.c_prob, -CS.steeringAngle,
+                                      CS.steeringPressed))
 
   # *** gas/brake PID loop ***
   actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
@@ -288,8 +288,8 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
 
   # *** steering PID loop ***
   actuators.steer, actuators.steerAngle = LaC.update(active, CS.vEgo, CS.steeringAngle,
-                                                     CS.steeringPressed, plan.dPoly, angle_offset, VM, PL)
-
+                                                     CS.steeringPressed, plan.dPoly, -angle_offset, VM, PL)
+  print(angle_offset, CS.steeringAngle, actuators.steerAngle)
   # send a "steering required alert" if saturation count has reached the limit
   if LaC.sat_flag and CP.steerLimitAlert:
     AM.add("steerSaturated", enabled)

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -288,7 +288,7 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
   # *** steering PID loop ***
   actuators.steer, actuators.steerAngle = LaC.update(active, CS.vEgo, CS.steeringAngle,
                                                      CS.steeringPressed, plan.dPoly, angle_offset, VM, PL)
-  print(angle_offset, CS.steeringAngle, actuators.steerAngle)
+  #print(angle_offset, CS.steeringAngle, actuators.steerAngle)
   # send a "steering required alert" if saturation count has reached the limit
   if LaC.sat_flag and CP.steerLimitAlert:
     AM.add("steerSaturated", enabled)
@@ -338,7 +338,7 @@ def data_send(perception_state, plan, plan_ts, CS, CI, CP, VM, state, events, ac
     CC.hudControl.audibleAlert = AM.audible_alert
     
     # send car controls over can
-    CI.apply(CC, perception_state, LaC)
+    CI.apply(CC, perception_state)
 
   # ***** publish state to logger *****
   # publish controls state at 100Hz

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -280,7 +280,7 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
     angle_offset = learn_angle_offset(active, CS.vEgo, angle_offset,
                                       PL.PP.c_poly, PL.PP.c_prob, CS.steeringAngle,
                                       CS.steeringPressed)
-  angle_offset = -1
+  angle_offset = -0.7
   # *** gas/brake PID loop ***
   actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
                                               v_cruise_kph, plan.vTarget, plan.vTargetFuture, plan.aTarget,

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -280,7 +280,6 @@ def state_control(plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, 
     angle_offset = learn_angle_offset(active, CS.vEgo, angle_offset,
                                       PL.PP.c_poly, PL.PP.c_prob, CS.steeringAngle,
                                       CS.steeringPressed)
-  angle_offset = -0.7
   # *** gas/brake PID loop ***
   actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
                                               v_cruise_kph, plan.vTarget, plan.vTargetFuture, plan.aTarget,

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -99,22 +99,24 @@ class LatControl(object):
 
     if v_ego < 0.3 or not active:
       output_steer = 0.0
+      self.angle_steers_des = 0.0
       self.pid.reset()
     else:
-      # TODO: ideally we should interp, but for tuning reasons we keep the mpc solution
-      # constant for 0.05s.
-      #dt = min(cur_time - self.angle_steers_des_time, _DT_MPC + _DT) + _DT  # no greater than dt mpc + dt, to prevent too high extraps
-      #self.angle_steers_des = self.angle_steers_des_prev + (dt / _DT_MPC) * (self.angle_steers_des_mpc - self.angle_steers_des_prev)
-      self.angle_steers_des = self.angle_steers_des_mpc
-      steers_max = get_steer_max(VM.CP, v_ego)
-      self.pid.pos_limit = steers_max
-      self.pid.neg_limit = -steers_max
-      steer_feedforward = self.angle_steers_des   # feedforward desired angle
       if VM.CP.steerControlType == car.CarParams.SteerControlType.torque:
+        # TODO: ideally we should interp, but for tuning reasons we keep the mpc solution
+        # constant for 0.05s.
+        self.angle_steers_des = self.angle_steers_des_mpc
+        steers_max = get_steer_max(VM.CP, v_ego)
+        self.pid.pos_limit = steers_max
+        self.pid.neg_limit = -steers_max
+        steer_feedforward = self.angle_steers_des   # feedforward desired angle
         steer_feedforward *= v_ego**2  # proportional to realigning tire momentum (~ lateral accel)
-      deadzone = 0.0
-      output_steer = self.pid.update(self.angle_steers_des, angle_steers, check_saturation=(v_ego > 10), override=steer_override,
+        deadzone = 0.0
+        output_steer = self.pid.update(self.angle_steers_des, angle_steers, check_saturation=(v_ego > 10), override=steer_override,
                                      feedforward=steer_feedforward, speed=v_ego, deadzone=deadzone)
+        self.sat_flag = self.pid.saturated
+      else:
+        dt = min(cur_time - self.angle_steers_des_time, _DT_MPC + _DT) + _DT  # no greater than dt mpc + dt, to prevent too high extraps
+        self.angle_steers_des = self.angle_steers_des_prev + (dt / _DT_MPC) * (self.angle_steers_des_mpc - self.angle_steers_des_prev)
 
-    self.sat_flag = self.pid.saturated
     return output_steer, float(self.angle_steers_des)

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -24,6 +24,7 @@ class PIController(object):
     self.i_rate = 1.0 / rate
     self.sat_limit = sat_limit
     self.convert = convert
+    self.speed = 0
 
     self.reset()
 

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -85,12 +85,12 @@ from selfdrive.loggerd.config import ROOT
 managed_processes = {
   "thermald": "selfdrive.thermald",
   "uploader": "selfdrive.loggerd.uploader",
-  "controlsd": "selfdrive.controls.controlsd",
+  #"controlsd": "selfdrive.controls.controlsd",
   "radard": "selfdrive.controls.radard",
   "ubloxd": "selfdrive.locationd.ubloxd",
   "loggerd": ("selfdrive/loggerd", ["./loggerd"]),
   "logmessaged": "selfdrive.logmessaged",
-  "tombstoned": "selfdrive.tombstoned",
+  #"tombstoned": "selfdrive.tombstoned",
   "logcatd": ("selfdrive/logcatd", ["./logcatd"]),
   "proclogd": ("selfdrive/proclogd", ["./proclogd"]),
   "boardd": ("selfdrive/boardd", ["./boardd"]),   # not used directly
@@ -101,7 +101,7 @@ managed_processes = {
   "sensord": ("selfdrive/sensord", ["./sensord"]),
   "gpsd": ("selfdrive/sensord", ["./gpsd"]),
   "orbd": ("selfdrive/orbd", ["./orbd_wrapper.sh"]),
-  "updated": "selfdrive.updated",
+  #"updated": "selfdrive.updated",
 }
 android_packages = ("ai.comma.plus.offroad", "ai.comma.plus.frame")
 
@@ -119,15 +119,15 @@ persistent_processes = [
   'thermald',
   'logmessaged',
   'logcatd',
-  'tombstoned',
+  #'tombstoned',
   'uploader',
   'ui',
   'gpsd',
-  'updated',
+  #'updated',
 ]
 
 car_started_processes = [
-  'controlsd',
+  #'controlsd',
   'loggerd',
   'sensord',
   'radard',

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -85,12 +85,12 @@ from selfdrive.loggerd.config import ROOT
 managed_processes = {
   "thermald": "selfdrive.thermald",
   "uploader": "selfdrive.loggerd.uploader",
-  #"controlsd": "selfdrive.controls.controlsd",
+  "controlsd": "selfdrive.controls.controlsd",
   "radard": "selfdrive.controls.radard",
   "ubloxd": "selfdrive.locationd.ubloxd",
   "loggerd": ("selfdrive/loggerd", ["./loggerd"]),
   "logmessaged": "selfdrive.logmessaged",
-  #"tombstoned": "selfdrive.tombstoned",
+  "tombstoned": "selfdrive.tombstoned",
   "logcatd": ("selfdrive/logcatd", ["./logcatd"]),
   "proclogd": ("selfdrive/proclogd", ["./proclogd"]),
   "boardd": ("selfdrive/boardd", ["./boardd"]),   # not used directly
@@ -101,7 +101,7 @@ managed_processes = {
   "sensord": ("selfdrive/sensord", ["./sensord"]),
   "gpsd": ("selfdrive/sensord", ["./gpsd"]),
   "orbd": ("selfdrive/orbd", ["./orbd_wrapper.sh"]),
-  #"updated": "selfdrive.updated",
+  "updated": "selfdrive.updated",
 }
 android_packages = ("ai.comma.plus.offroad", "ai.comma.plus.frame")
 
@@ -119,15 +119,15 @@ persistent_processes = [
   'thermald',
   'logmessaged',
   'logcatd',
-  #'tombstoned',
+  'tombstoned',
   'uploader',
   'ui',
   'gpsd',
-  #'updated',
+  'updated',
 ]
 
 car_started_processes = [
-  #'controlsd',
+  'controlsd',
   'loggerd',
   'sensord',
   'radard',


### PR DESCRIPTION
This change adds a very efficient **live stream** of **raw** CAN data on a new ZMQ port.  The data is **not serialized**, so the subscribers **do not need capnp**.  The data is continuously updated in memory, but is only **published on the ZMQ port periodically** (default is 10 times per second).

Before / after CPU loading on the EON looks unchanged, but WiFi traffic **dropped by 90%** when comparing 2 external processes that monitor the serialized ZMQ port (8006) vs the new ZMQ port.  Also, since this is a **generic data stream**, it can be used by virtually any consumer.

I am using this new interface to feed an instance of [influxDB](https://www.influxdata.com/products/) on my laptop via tethered WiFi connection from the EON.  InfluxDB is a very efficient **time-series database**, which can easily be used by visualization platforms like [Grafana](https://grafana.com/) for **historical or real-time analysis**.

I believe this enhancement will enable the community to improve their turn-around time to create new ports for OpenPilot.  

Below are a few videos of my dashboards made possible by this change.

Real-Time Dual Panda Wireless OpenPilot / OBDII CAN Data Browser / Logger / Analyzer
https://www.youtube.com/watch?v=ePzaA5c4ET4

Screen capture of templated analog and binary views:
https://www.youtube.com/watch?v=E_Wzj4h7aHY

Stock Honda LKAS data stream:
https://www.youtube.com/watch?v=_lni8V6kJ38