### PR TITLE
GM: remove refactor leftovers

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -12,15 +12,6 @@ try:
 except ImportError:
   CarController = None
 
-# Car chimes, beeps, blinker sounds etc
-class CM:
-  TOCK = 0x81
-  TICK = 0x82
-  LOW_BEEP = 0x84
-  HIGH_BEEP = 0x85
-  LOW_CHIME = 0x86
-  HIGH_CHIME = 0x87
-
 class CanBus(object):
   def __init__(self):
     self.powertrain = 0


### PR DESCRIPTION
0.5.6 moves chime definitions to values.py. This removes definitions at the old location.