### PR TITLE
Keep steering on radar fault

### DIFF
--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -449,9 +449,9 @@ class Planner(object):
     if self.model_dead:
       events.append(create_event('modelCommIssue', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))
     if self.radar_dead or 'commIssue' in self.radar_errors:
-      events.append(create_event('radarCommIssue', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))
+      events.append(create_event('radarCommIssue', [ET.NO_ENTRY, ET.SOFT_DISABLE]))
     if 'fault' in self.radar_errors:
-      events.append(create_event('radarFault', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))
+      events.append(create_event('radarFault', [ET.NO_ENTRY, ET.SOFT_DISABLE]))
     if LaC.mpc_solution[0].cost > 10000. or LaC.mpc_nans:   # TODO: find a better way to detect when MPC did not converge
       events.append(create_event('plannerError', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))
 


### PR DESCRIPTION
GM radar is somewhat flaky. Couple people had reported radar faulted on them in the middle of the turn, and since openpilot disengages immediately, it's an unpleasant experience to catch steering wheel that lost LKA torque.
I was asked if it's possible to keep steering when openpilot detects that the radar went out of calibration.