### PR TITLE
fixed dependency

### DIFF
--- a/requirements_openpilot.txt
+++ b/requirements_openpilot.txt
@@ -1,7 +1,7 @@
 Cython==0.27.3
 bitstring==3.1.5
 fastcluster==1.1.20
-libusb1==1.5.0
+libusb1==1.6.4
 pycapnp==0.6.3
 pyzmq==15.4.0
 raven==5.23.0


### PR DESCRIPTION
This PR will fix the following issue:

`pandacan 0.0.8 has requirement libusb1>=1.6.4, but you'll have libusb1 1.5.0 which is incompatible.`
