### PR TITLE
GM: soft disengage on PCM fault

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -73,6 +73,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
     lowBattery @48;
     invalidGiraffeHonda @49;
     vehicleModelInvalid @50;
+    controlsFailed @51;
   }
 }
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -4,7 +4,8 @@ from common.realtime import sec_since_boot
 from selfdrive.config import Conversions as CV
 from selfdrive.controls.lib.drive_helpers import create_event, EventTypes as ET
 from selfdrive.controls.lib.vehicle_model import VehicleModel
-from selfdrive.car.gm.values import DBC, CAR, STOCK_CONTROL_MSGS, AUDIO_HUD, SUPERCRUISE_CARS
+from selfdrive.car.gm.values import DBC, CAR, STOCK_CONTROL_MSGS, AUDIO_HUD, \
+                                    SUPERCRUISE_CARS, AccState
 from selfdrive.car.gm.carstate import CarState, CruiseButtons, get_powertrain_can_parser
 
 try:
@@ -231,7 +232,7 @@ class CarInterface(object):
 
     # cruise state
     ret.cruiseState.available = bool(self.CS.main_on)
-    cruiseEnabled = self.CS.pcm_acc_status != 0
+    cruiseEnabled = self.CS.pcm_acc_status != AccState.OFF
     ret.cruiseState.enabled = cruiseEnabled
     ret.cruiseState.standstill = self.CS.pcm_acc_status == 4
 
@@ -323,6 +324,8 @@ class CarInterface(object):
         events.append(create_event('pedalPressed', [ET.PRE_ENABLE]))
       if ret.cruiseState.standstill:
         events.append(create_event('resumeRequired', [ET.WARNING]))
+      if self.CS.pcm_acc_status == AccState.FAULTED:
+        events.append(create_event('controlsFailed', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))
 
       # handle button presses
       for b in ret.buttonEvents:

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -30,6 +30,12 @@ class CM:
   LOW_CHIME = 0x86
   HIGH_CHIME = 0x87
 
+class AccState:
+  OFF        = 0
+  ACTIVE     = 1
+  FAULTED    = 3
+  STANDSTILL = 4
+
 AUDIO_HUD = {
   AudibleAlert.none: (0, 0),
   AudibleAlert.chimeEngage: (CM.HIGH_CHIME, 1),


### PR DESCRIPTION
Happens when
- first attempt to engage is done with "resume" instead lf "set" button.
- attempt to engage outside of PCM's speed limits (shouldn't happen unless people override min allowed engage speed).
- pre-enable doesn't work on 2018 Volt.

In all those cases, showing openpilot as engages is confusing, because car ignores gas commands.