### PR TITLE
Read from usb/present instead of usb/online

### DIFF
--- a/selfdrive/thermald.py
+++ b/selfdrive/thermald.py
@@ -201,7 +201,7 @@ def thermald_thread():
       msg.thermal.batteryCurrent = int(f.read())
     with open("/sys/class/power_supply/battery/voltage_now") as f:
       msg.thermal.batteryVoltage = int(f.read())
-    with open("/sys/class/power_supply/usb/online") as f:
+    with open("/sys/class/power_supply/usb/present") as f:
       msg.thermal.usbOnline = bool(int(f.read()))
 
     current_filter.update(msg.thermal.batteryCurrent / 1e6)


### PR DESCRIPTION
This is the fix for #483 as per @vanillagorillaa 

I tested in my vehicle with `PASSIVE=1` and the EON started a drive when I started the vehicle.

I also switched back to the devel branch and confirmed that it _did not_ start a drive when I started the vehicle with `PASSIVE=1`