### PR TITLE
GM: use GM safety model even if passive

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -440,7 +440,9 @@ def controlsd_thread(gctx=None, rate=100, default_bias=0.):
     passive = True
     sendcan = None
 
-  if passive:
+  # GM needs CAN-based ignition hook, part of GM safety code.
+  # GM safety has internal logic to go completely silent in stock.
+  if passive and CP.safetyModel != car.CarParams.SafetyModels.gm:
     CP.safetyModel = car.CarParams.SafetyModels.noOutput
 
   # Get FCW toggle from settings


### PR DESCRIPTION
Symptom:
On some GM cars, in stock, openpilot will start-stop recording arbitrarily during the drive.

Problem:
"car started" on GM uses CAN-based ignition hook, and on cars where battery voltage drops below openpilot's threshold (e.g. when engine turns off on a full stop), drive recording stops. Main two cases are 1) chffrplus, and 2) openpilot forced to passive mode because stock LKA / ACC modules are online.

Proposal:
Instead of tweaking battery voltage threshold (doesn't fix the problem for soft hybrids), always use GM's CAN-based ignition logic on GM cars, even in chffrplus / passive openpilot.

Pros:
- Setting safety model to noOutput is redundant, since controlsd sets sendcan to None if passive.
- If either LKA or ACC commands are being sent by stock modules, GM safety model in Panda goes to full silence, not even chimes or radar configuration will be sent.

Cons:
- GM safety model in Panda doesn't know if openpilot is running in passive mode, and, for example, will still set controls_allowed to 1, if driver presses "set" / "reset". On GM cars without LKA/ACC features, or with those modules disconnected, chffrplus would drive on sending-ready panda.

Let me know if you guys can think of a better solution, or if GM safety model needs a special "passive" mode, for example, entered by passing a special CarParams.safetyParam.