### PR TITLE
Stock Max Request 2NM

### DIFF
--- a/panda/board/safety/safety_hyundai.h
+++ b/panda/board/safety/safety_hyundai.h
@@ -1,4 +1,4 @@
-const int HYUNDAI_MAX_STEER = 250;
+const int HYUNDAI_MAX_STEER = 255;
 const int HYUNDAI_MAX_RT_DELTA = 112;          // max delta torque allowed for real time checks
 const int32_t HYUNDAI_RT_INTERVAL = 250000;    // 250ms between real time checks
 const int HYUNDAI_MAX_RATE_UP = 3;

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -10,7 +10,7 @@ from selfdrive.can.packer import CANPacker
 # Steer torque limits
 
 class SteerLimitParams:
-  STEER_MAX = 250   # 409 is the max
+  STEER_MAX = 255   # 409 is the max
   STEER_DELTA_UP = 3
   STEER_DELTA_DOWN = 7
   STEER_DRIVER_ALLOWANCE = 50


### PR DESCRIPTION
Unknown if decision was made on purpose to limit capability. Stock OEM LKAS module can and will request max 2NM.