### PR TITLE
Stop logging rather than driving

### DIFF
--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -335,7 +335,7 @@ def manager_thread():
     else:
       start_managed_process("uploader")
 
-    if msg.thermal.freeSpace < 0.05:
+    if msg.thermal.freeSpace < 0.18:
       logger_dead = True
 
     if msg.thermal.started:


### PR DESCRIPTION
I know this is minor, but look at it this way.
Stopping driving upsets the user, you get a bit more disengaged data.
Having driver SSH in and delete everything is worse.
Its complained about daily, it will lessen the noise.