### PR TITLE
[README.md] Add missing mapd and orbd dirs into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Directory structure
         ├── locationd       # Soon to be home of precise location
         ├── logcatd         # Android logcat as a service
         ├── loggerd         # Logger and uploader of car data
+        ├── mapd            # Fetches map data and computes next global path
+        ├── orbd            # Computes ORB features from frames
         ├── proclogd        # Logs information from proc
         ├── sensord         # IMU / GPS interface code
         ├── test            # Car simulator running code through virtual maneuvers


### PR DESCRIPTION
I've noticed that they were missing in README.md. Not 100% sure about wording tho.