### PR TITLE
remove Pacifica 2019 from supported car list

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Supported Cars
 | Chevrolet<sup>3</sup>| Volt 2017-18             | Adaptive Cruise      | Yes     | Yes            | 0mph             | 7mph           | Custom<sup>7</sup>|
 | Cadillac<sup>3</sup> | ATS 2018                 | Adaptive Cruise      | Yes     | Yes            | 0mph             | 7mph           | Custom<sup>7</sup>|
 | Chrysler             | Pacifica 2018            | Adaptive Cruise      | Yes     | Stock          | 0mph             | 9mph           | FCA               |
-| Chrysler             | Pacifica Hybrid 2017-19  | Adaptive Cruise      | Yes     | Stock          | 0mph             | 9mph           | FCA               |
+| Chrysler             | Pacifica Hybrid 2017-18  | Adaptive Cruise      | Yes     | Stock          | 0mph             | 9mph           | FCA               |
 | GMC<sup>3</sup>      | Acadia Denali 2018       | Adaptive Cruise      | Yes     | Yes            | 0mph             | 7mph           | Custom<sup>7</sup>|
 | Holden<sup>3</sup>   | Astra 2017               | Adaptive Cruise      | Yes     | Yes            | 0mph             | 7mph           | Custom<sup>7</sup>|
 | Honda                | Accord 2018              | All                  | Yes     | Stock          | 0mph             | 3mph           | Bosch             |


### PR DESCRIPTION
Although there's a fingerprint and LKAS constant for the 2019 Pacifica, it doesn't work well enough that I'd consider it supported.

P.S. I have an idea for how to support all Chrysler with one code base, even those I've never looked at. Forward can0 to the stock LKAS (can2) so that the stock LKAS is active. Then read the stock LKAS messages on can2 to both get the vehicle's LKAS constant, any status messages, and perhaps a more reliable counter. I'll try to code it up this weekend.