### PR TITLE
pass, if failed to delete instead of crashing

### DIFF
--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -250,7 +250,10 @@ class Uploader(object):
       stat = self.normal_upload(key, fn)
       if stat is not None and stat.status_code in (200, 201):
         cloudlog.event("upload_success", key=key, fn=fn, sz=sz)
-        os.unlink(fn) # delete the file
+        try:
+          os.unlink(fn) # delete the file
+        except OSError:
+          pass
         success = True
       else:
         cloudlog.event("upload_failed", stat=stat, exc=self.last_exc, key=key, fn=fn, sz=sz)


### PR DESCRIPTION
Some auto delete scripts out there will crash because the file is not longer on the system but the unlink function throws an exception.

If the file does not exsist then return success because the file does not exsist anymore.