### PR TITLE
Add Port for 2019 Honda Odyssey Exclusive (China version)

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -138,6 +138,8 @@ class CarController(object):
       STEER_MAX = 0xF00
     elif CS.CP.carFingerprint in (CAR.CRV, CAR.ACURA_RDX):
       STEER_MAX = 0x3e8  # CR-V only uses 12-bits and requires a lower value (max value from energee)
+    elif CS.CP.carFingerprint in (CAR.ODYSSEY_CHN):
+      STEER_MAX = 0x7FFF
     else:
       STEER_MAX = 0x1000
 

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -60,14 +60,23 @@ def get_can_signals(CP):
       ("ENGINE_DATA", 100),
       ("WHEEL_SPEEDS", 50),
       ("STEERING_SENSORS", 100),
-      ("SCM_FEEDBACK", 10),
       ("GEARBOX", 100),
       ("SEATBELT_STATUS", 10),
       ("CRUISE", 10),
       ("POWERTRAIN_DATA", 100),
       ("VSA_STATUS", 50),
-      ("SCM_BUTTONS", 25),
   ]
+
+  if CP.carFingerprint == CAR.ODYSSEY_CHN:
+    checks += [
+      ("SCM_FEEDBACK", 25),
+      ("SCM_BUTTONS", 50),
+    ]
+  else:
+    checks += [
+      ("SCM_FEEDBACK", 10),
+      ("SCM_BUTTONS", 25),
+    ]
 
   if CP.radarOffCan:
     # Civic is only bosch to use the same brake message as other hondas.
@@ -85,11 +94,17 @@ def get_can_signals(CP):
                 ("BRAKE_ERROR_2", "STANDSTILL", 1),
                 ("CRUISE_SPEED_PCM", "CRUISE", 0),
                 ("CRUISE_SPEED_OFFSET", "CRUISE_PARAMS", 0)]
-    checks += [("CRUISE_PARAMS", 50),
-               ("STANDSTILL", 50)]
+    checks += [("STANDSTILL", 50)]
+
+    if CP.carFingerprint == CAR.ODYSSEY_CHN:
+      checks += [("CRUISE_PARAMS", 10)]
+    else:
+      checks += [("CRUISE_PARAMS", 50)]
 
   if CP.carFingerprint in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH, CAR.CIVIC_BOSCH):
     signals += [("DRIVERS_DOOR_OPEN", "SCM_FEEDBACK", 1)]
+  elif CP.carFingerprint == CAR.ODYSSEY_CHN:
+    signals += [("DRIVERS_DOOR_OPEN", "SCM_BUTTONS", 1)]
   else:
     signals += [("DOOR_OPEN_FL", "DOORS_STATUS", 1),
                 ("DOOR_OPEN_FR", "DOORS_STATUS", 1),
@@ -114,6 +129,10 @@ def get_can_signals(CP):
   elif CP.carFingerprint == CAR.PILOT:
     signals += [("MAIN_ON", "SCM_BUTTONS", 0),
                 ("CAR_GAS", "GAS_PEDAL_2", 0)]
+  elif CP.carFingerprint == CAR.ODYSSEY_CHN:
+    signals += [("MAIN_ON", "SCM_BUTTONS", 0),
+                ("EPB_STATE", "EPB_STATUS", 0)]
+    checks += [("EPB_STATUS", 50)]
 
   # add gas interceptor reading if we are using it
   if CP.enableGasInterceptor:
@@ -130,9 +149,9 @@ def get_can_parser(CP):
 def get_cam_can_parser(CP):
   signals = []
 
-  # all hondas except CRV and RDX use 0xe4 for steering
+  # all hondas except CRV, RDX and 2019 Odyssey@China use 0xe4 for steering
   checks = [(0xe4, 100)]
-  if CP.carFingerprint in [CAR.CRV, CAR.ACURA_RDX]:
+  if CP.carFingerprint in [CAR.CRV, CAR.ACURA_RDX, CAR.ODYSSEY_CHN]:
     checks = [(0x194, 100)]
 
   cam_bus = 1 if CP.carFingerprint in HONDA_BOSCH else 2
@@ -192,6 +211,9 @@ class CarState(object):
     if self.CP.carFingerprint in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH, CAR.CIVIC_BOSCH): # TODO: find wheels moving bit in dbc
       self.standstill = cp.vl["ENGINE_DATA"]['XMISSION_SPEED'] < 0.1
       self.door_all_closed = not cp.vl["SCM_FEEDBACK"]['DRIVERS_DOOR_OPEN']
+    elif self.CP.carFingerprint == CAR.ODYSSEY_CHN:
+      self.standstill = cp.vl["ENGINE_DATA"]['XMISSION_SPEED'] < 0.1
+      self.door_all_closed = not cp.vl["SCM_BUTTONS"]['DRIVERS_DOOR_OPEN']
     else:
       self.standstill = not cp.vl["STANDSTILL"]['WHEELS_MOVING']
       self.door_all_closed = not any([cp.vl["DOORS_STATUS"]['DOOR_OPEN_FL'], cp.vl["DOORS_STATUS"]['DOOR_OPEN_FR'],
@@ -251,6 +273,9 @@ class CarState(object):
     if self.CP.carFingerprint in (CAR.CIVIC, CAR.ODYSSEY, CAR.CRV_5G, CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH, CAR.CIVIC_BOSCH):
       self.park_brake = cp.vl["EPB_STATUS"]['EPB_STATE'] != 0
       self.main_on = cp.vl["SCM_FEEDBACK"]['MAIN_ON']
+    elif self.CP.carFingerprint == CAR.ODYSSEY_CHN:
+      self.park_brake = cp.vl["EPB_STATUS"]['EPB_STATE'] != 0
+      self.main_on = cp.vl["SCM_BUTTONS"]['MAIN_ON']
     else:
       self.park_brake = 0  # TODO
       self.main_on = cp.vl["SCM_BUTTONS"]['MAIN_ON']
@@ -260,7 +285,7 @@ class CarState(object):
 
     self.pedal_gas = cp.vl["POWERTRAIN_DATA"]['PEDAL_GAS']
     # crv doesn't include cruise control
-    if self.CP.carFingerprint in (CAR.CRV, CAR.ODYSSEY, CAR.ACURA_RDX, CAR.RIDGELINE, CAR.PILOT_2019):
+    if self.CP.carFingerprint in (CAR.CRV, CAR.ODYSSEY, CAR.ACURA_RDX, CAR.RIDGELINE, CAR.PILOT_2019, CAR.ODYSSEY_CHN):
       self.car_gas = self.pedal_gas
     else:
       self.car_gas = cp.vl["GAS_PEDAL_2"]['CAR_GAS']

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -59,22 +59,14 @@ def create_ui_commands(packer, pcm_speed, hud, car_fingerprint, idx):
   if car_fingerprint in HONDA_BOSCH:
     bus = 2
   else:
-
-    x03 = 0x03
-    x03_2 = 0x03
-
-    if car_fingerprint == CAR.ODYSSEY_CHN:
-      x03 = 0x01
-      x03_2 = 0x02
-
     acc_hud_values = {
       'PCM_SPEED': pcm_speed * CV.MS_TO_KPH,
       'PCM_GAS': hud.pcm_accel,
       'CRUISE_SPEED': hud.v_cruise,
       'ENABLE_MINI_CAR': hud.mini_car,
       'HUD_LEAD': hud.car,
-      'SET_ME_X03': x03,
-      'SET_ME_X03_2': x03_2,
+      'SET_ME_X03': 0x01 if car_fingerprint == CAR.ODYSSEY_CHN else 0x03,
+      'SET_ME_X03_2': 0x02 if car_fingerprint == CAR.ODYSSEY_CHN else 0x03,
       'SET_ME_X01': 0x01,
     }
     commands.append(packer.make_can_msg("ACC_HUD", 0, acc_hud_values, idx))

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -59,14 +59,22 @@ def create_ui_commands(packer, pcm_speed, hud, car_fingerprint, idx):
   if car_fingerprint in HONDA_BOSCH:
     bus = 2
   else:
+
+    x03 = 0x03
+    x03_2 = 0x03
+
+    if car_fingerprint == CAR.ODYSSEY_CHN:
+      x03 = 0x01
+      x03_2 = 0x02
+
     acc_hud_values = {
       'PCM_SPEED': pcm_speed * CV.MS_TO_KPH,
       'PCM_GAS': hud.pcm_accel,
       'CRUISE_SPEED': hud.v_cruise,
       'ENABLE_MINI_CAR': hud.mini_car,
       'HUD_LEAD': hud.car,
-      'SET_ME_X03': 0x03,
-      'SET_ME_X03_2': 0x03,
+      'SET_ME_X03': x03,
+      'SET_ME_X03_2': x03_2,
       'SET_ME_X01': 0x01,
     }
     commands.append(packer.make_can_msg("ACC_HUD", 0, acc_hud_values, idx))

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -286,6 +286,19 @@ class CarInterface(object):
       ret.longitudinalKiBP = [0., 35.]
       ret.longitudinalKiV = [0.18, 0.12]
 
+    elif candidate == CAR.ODYSSEY_CHN:
+      stop_and_go = False
+      ret.mass = 1849.2 + std_cargo # mean of 4 models in kg
+      ret.wheelbase = 2.90 # spec
+      ret.centerToFront = ret.wheelbase * 0.41 # from CAR.ODYSSEY
+      ret.steerRatio = 14.35 # from CAR.ODYSSEY
+      tire_stiffness_factor = 0.82 # from CAR.ODYSSEY
+      ret.steerKpV, ret.steerKiV = [[0.45], [0.135]]
+      ret.longitudinalKpBP = [0., 5., 35.]
+      ret.longitudinalKpV = [1.2, 0.8, 0.5]
+      ret.longitudinalKiBP = [0., 35.]
+      ret.longitudinalKiV = [0.18, 0.12]
+
     elif candidate in (CAR.PILOT, CAR.PILOT_2019):
       stop_and_go = False
       ret.mass = 4303 * CV.LB_TO_KG + std_cargo

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -66,6 +66,7 @@ class CAR:
   CRV = "HONDA CR-V 2016 TOURING"
   CRV_5G = "HONDA CR-V 2017 EX"
   ODYSSEY = "HONDA ODYSSEY 2018 EX-L"
+  ODYSSEY_CHN = "HONDA ODYSSEY 2019 EXCLUSIVE CHN"
   ACURA_RDX = "ACURA RDX 2018 ACURAWATCH PLUS"
   PILOT = "HONDA PILOT 2017 TOURING"
   PILOT_2019 = "HONDA PILOT 2019 ELITE"
@@ -109,6 +110,9 @@ FINGERPRINTS = {
   {
     57: 3, 148: 8, 228: 5, 229: 4, 304: 8, 342: 6, 344: 8, 380: 8, 399: 7, 411: 5, 419: 8, 420: 8, 427: 3, 432: 7, 440: 8, 450: 8, 463: 8, 464: 8, 476: 4, 490: 8, 506: 8, 507: 1, 542: 7, 545: 6, 597: 8, 662: 4, 773: 7, 777: 8, 780: 8, 795: 8, 800: 8, 804: 8, 806: 8, 808: 8, 817: 4, 819: 7, 821: 5, 825: 4, 829: 5, 837: 5, 856: 7, 862: 8, 871: 8, 881: 8, 882: 4, 884: 8, 891: 8, 892: 8, 905: 8, 923: 2, 927: 8, 929: 8, 963: 8, 965: 8, 966: 8, 967: 8, 983: 8, 985: 3, 1029: 8, 1036: 8, 1052: 8, 1064: 7, 1088: 8, 1089: 8, 1092: 1, 1108: 8, 1110: 8, 1125: 8, 1296: 8, 1302: 8, 1600: 5, 1601: 8, 1612: 5, 1613: 5, 1614: 5, 1616: 5, 1619: 5, 1623: 5, 1668: 5
   }],
+  CAR.ODYSSEY_CHN: [{
+    57: 3, 145: 8, 316: 8, 342: 6, 344: 8, 380: 8, 398: 3, 399: 7, 401: 8, 404: 4, 411: 5, 420: 8, 422: 8, 423: 2, 426: 8, 432: 7, 450: 8, 464: 8, 490: 8, 506: 8, 507: 1, 597: 8, 610: 8, 611: 8, 612: 8, 617: 8, 660: 8, 661: 4, 773: 7, 780: 8, 804: 8, 808: 8, 829: 5, 862: 8, 884: 7, 892: 8, 923: 2, 929: 8, 1030: 5, 1137: 8, 1302: 8, 1348: 5, 1361: 5, 1365: 5, 1600: 5, 1601: 8, 1639: 8
+  }],
   # 2017 Pilot Touring AND 2016 Pilot EX-L w/ Added Comma Pedal Support (512L & 513L)
   CAR.PILOT: [{
     57: 3, 145: 8, 228: 5, 229: 4, 308: 5, 316: 8, 334: 8, 339: 7, 342: 6, 344: 8, 379: 8, 380: 8, 392: 6, 399: 7, 419: 8, 420: 8, 422: 8, 425: 8, 426: 8, 427: 3, 432: 7, 463: 8, 464: 8, 476: 4, 490: 8, 506: 8, 507: 1, 512: 6, 513: 6, 538: 3, 542: 7, 545: 5, 546: 3, 597: 8, 660: 8, 773: 7, 777: 8, 780: 8, 795: 8, 800: 8, 804: 8, 808: 8, 819: 7, 821: 5, 829: 5, 837: 5, 856: 7, 871: 8, 882: 2, 884: 7, 891: 8, 892: 8, 923: 2, 929: 8, 963: 8, 965: 8, 966: 8, 967: 8, 983: 8, 985: 3, 1027: 5, 1029: 8, 1036: 8, 1039: 8, 1064: 7, 1088: 8, 1089: 8, 1108: 8, 1125: 8, 1296: 8, 1424: 5, 1600: 5, 1601: 8, 1612: 5, 1613: 5, 1616: 5, 1618: 5, 1668: 5
@@ -141,6 +145,7 @@ DBC = {
   CAR.CRV: dbc_dict('honda_crv_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
   CAR.CRV_5G: dbc_dict('honda_crv_ex_2017_can_generated', None),
   CAR.ODYSSEY: dbc_dict('honda_odyssey_exl_2018_generated', 'acura_ilx_2016_nidec'),
+  CAR.ODYSSEY_CHN: dbc_dict('honda_odyssey_extreme_edition_2018_china_can', 'acura_ilx_2016_nidec'),
   CAR.PILOT: dbc_dict('honda_pilot_touring_2017_can_generated', 'acura_ilx_2016_nidec'),
   CAR.PILOT_2019: dbc_dict('honda_pilot_touring_2017_can_generated', 'acura_ilx_2016_nidec'),
   CAR.RIDGELINE: dbc_dict('honda_ridgeline_black_edition_2017_can_generated', 'acura_ilx_2016_nidec'),
@@ -157,6 +162,7 @@ STEER_THRESHOLD = {
   CAR.CRV: 1200,
   CAR.CRV_5G: 1200,
   CAR.ODYSSEY: 1200,
+  CAR.ODYSSEY_CHN: 1200,
   CAR.PILOT: 1200,
   CAR.PILOT_2019: 1200,
   CAR.RIDGELINE: 1200,
@@ -173,6 +179,7 @@ SPEED_FACTOR = {
   CAR.CRV: 1.025,
   CAR.CRV_5G: 1.025,
   CAR.ODYSSEY: 1.,
+  CAR.ODYSSEY_CHN: 1.,
   CAR.PILOT: 1.,
   CAR.PILOT_2019: 1.,
   CAR.RIDGELINE: 1.,


### PR DESCRIPTION
Existing port won't work with China version of 2019 Honda Odyssey:
* The steering command is on 0x194 instead of 0xE4.
* ACC HUD needs to send different value to display kph instead of mph.
* Port has been tested and confirmed by ccnomis#7751 at discord.

OP Cabana log:
https://community.comma.ai/cabana/?route=81722949a62ea724%7C2019-04-06--15-19-25&max=25&url=https%3A%2F%2Fchffrprivate.blob.core.windows.net%2Fchffrprivate3%2Fv2%2F81722949a62ea724%2Feadeaf4be6b01d3881011644ae8a2e8c_2019-04-06--15-19-25

Stock Cabana Log:
https://community.comma.ai/cabana/?route=81722949a62ea724%7C2019-03-29--15-51-26&max=25&url=https%3A%2F%2Fchffrprivate.blob.core.windows.net%2Fchffrprivate3%2Fv2%2F81722949a62ea724%2F32c02dff3628ecc8c0dc8db8383e1584_2019-03-29--15-51-26
* highest torque is visible @ between 848-849