### PR TITLE
Add rate-based feed-forward for lateral control

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -341,6 +341,7 @@ struct CarParams {
   steerKpDEPRECATED @15 :Float32;
   steerKiDEPRECATED @16 :Float32;
   steerKf @25 :Float32;
+  rateFFGain @51 :Float32;
 
   # Kp and Ki for the longitudinal control
   longitudinalKpBP @36 :List(Float32);

--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -391,6 +391,9 @@ struct Live100Data {
   upSteer @8 :Float32;
   uiSteer @9 :Float32;
   ufSteer @34 :Float32;
+  angleFFRatio @52 :Float32;
+  rateFFGain @53 :Float32;
+  angleFFGain @54 :Float32;
   aTargetMinDEPRECATED @10 :Float32;
   aTargetMaxDEPRECATED @11 :Float32;
   aTarget @35 :Float32;

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -78,6 +78,7 @@ class CarInterface(object):
     ret.steerKf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
     ret.steerActuatorDelay = 0.1
     ret.steerRateCost = 0.7
+    ret.rateFFGain = 0.01
 
     if candidate in (CAR.JEEP_CHEROKEE, CAR.JEEP_CHEROKEE_2019):
       ret.wheelbase = 2.91  # in meters

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -77,6 +77,7 @@ class CarInterface(object):
     ret.steerKf = 1. / MAX_ANGLE   # MAX Steer angle to normalize FF
     ret.steerActuatorDelay = 0.1  # Default delay, not measured yet
     ret.steerRateCost = 1.0
+    ret.rateFFGain = 0.01
 
     f = 1.2
     tireStiffnessFront_civic *= f

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -190,6 +190,7 @@ class CarInterface(object):
     ret.steerActuatorDelay = 0.1  # Default delay, not measured yet
     ret.steerRateCost = 1.0
     ret.steerControlType = car.CarParams.SteerControlType.torque
+    ret.rateFFGain = 0.01
 
     return ret
 

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -186,6 +186,7 @@ class CarInterface(object):
     ret.steerKiBP, ret.steerKpBP = [[0.], [0.]]
 
     ret.steerKf = 0.00006 # conservative feed-forward
+    ret.rateFFGain = 0.01
 
     if candidate in [CAR.CIVIC, CAR.CIVIC_BOSCH]:
       stop_and_go = True

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -71,6 +71,7 @@ class CarInterface(object):
 
     ret.steerActuatorDelay = 0.1  # Default delay
     tire_stiffness_factor = 1.
+    ret.rateFFGain = 0.01
 
     if candidate == CAR.SANTA_FE:
       ret.steerKf = 0.00005

--- a/selfdrive/car/mock/interface.py
+++ b/selfdrive/car/mock/interface.py
@@ -61,6 +61,7 @@ class CarInterface(object):
     ret.tireStiffnessFront = 1e6    # very stiff to neglect slip
     ret.tireStiffnessRear = 1e6     # very stiff to neglect slip
     ret.steerRatioRear = 0.
+    ret.rateFFGain = 0.01
 
     ret.steerMaxBP = [0.]
     ret.steerMaxV = [0.]  # 2/3rd torque allowed above 45 kph

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -53,6 +53,7 @@ class CarInterface(object):
 
     std_cargo = 136
     ret.steerRateCost = 0.7
+    ret.rateFFGain = 0.01
 
     if candidate in [CAR.IMPREZA]:
       ret.mass = 1568 + std_cargo

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -75,6 +75,7 @@ class CarInterface(object):
 
     ret.steerKiBP, ret.steerKpBP = [[0.], [0.]]
     ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
+    ret.rateFFGain = 0.01
 
     if candidate == CAR.PRIUS:
       stop_and_go = True

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -350,10 +350,13 @@ def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruis
     "upSteer": float(LaC.pid.p),
     "uiSteer": float(LaC.pid.i),
     "ufSteer": float(LaC.pid.f),
+    "angleFFRatio": float(LaC.angle_ff_ratio),
     "vTargetLead": float(v_acc),
     "aTarget": float(a_acc),
     "jerkFactor": float(plan.jerkFactor),
     "angleModelBias": float(angle_model_bias),
+    "angleFFGain": float(LaC.angle_ff_gain),
+    "rateFFGain": float(LaC.rate_ff_gain),
     "gpsPlannerActive": plan.gpsPlannerActive,
     "vCurvature": plan.vCurvature,
     "decelForTurn": plan.decelForTurn,
@@ -378,8 +381,8 @@ def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruis
   carcontrol.send(cc_send.to_bytes())
 
   if (rk.frame % 36000) == 0:    # update angle offset every 6 minutes
-    params.put("ControlsParams", json.dumps({'angle_model_bias': angle_model_bias}))
-
+    params.put("ControlsParams", json.dumps({'angle_model_bias': angle_model_bias,
+              'angle_ff_gain': LaC.angle_ff_gain, 'rate_ff_gain': LaC.rate_ff_gain}))
   return CC
 
 
@@ -468,6 +471,8 @@ def controlsd_thread(gctx=None, rate=100):
     try:
       controls_params = json.loads(controls_params)
       angle_model_bias = controls_params['angle_model_bias']
+      LaC.angle_ff_gain = controls_params['angle_ff_gain']
+      LaC.rate_ff_gain = controls_params['rate_ff_gain']
     except (ValueError, KeyError):
       pass
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -382,7 +382,7 @@ def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruis
 
   if (rk.frame % 36000) == 0:    # update angle offset every 6 minutes
     params.put("ControlsParams", json.dumps({'angle_model_bias': angle_model_bias,
-              'angle_ff_gain': LaC.angle_ff_gain, 'rate_ff_gain': LaC.rate_ff_gain}))
+              'angle_ff_gain': LaC.angle_ff_gain}))
   return CC
 
 
@@ -472,7 +472,6 @@ def controlsd_thread(gctx=None, rate=100):
       controls_params = json.loads(controls_params)
       angle_model_bias = controls_params['angle_model_bias']
       LaC.angle_ff_gain = controls_params['angle_ff_gain']
-      LaC.rate_ff_gain = controls_params['rate_ff_gain']
     except (ValueError, KeyError):
       pass
 

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -25,11 +25,6 @@ class LatControl(object):
     self.angle_steers_noise = _NOISE_THRESHOLD
     self.angle_ff_bp = [[0.5, 5.0],[0.0, 1.0]]
 
-    # TODO: add the feedforward parameters to LiveParameters
-    self.angle_ff_gain = 1.0
-    self.rate_ff_gain = 0.02
-    self.angle_ff_bp = [[0.5, 5.0],[0.0, 1.0]]
-
   def reset(self):
     self.pid.reset()
 

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -71,7 +71,7 @@ class LatControl(object):
         rate_feedforward = (1.0 - self.angle_ff_ratio) * self.rate_ff_gain * path_plan.rateSteers
         steer_feedforward = v_ego**2 * (rate_feedforward + angle_feedforward)
 
-        if not steer_override and v_ego > 10.0:
+        if v_ego > 10.0:
           if abs(angle_steers) > (self.angle_ff_bp[0][1] / 2.0):
             self.adjust_angle_gain()
           else:

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -19,8 +19,8 @@ class LatControl(object):
     self.angle_steers_des = 0.
 
     # TODO: add the feedforward parameters to LiveParameters
-    self.angle_ff_gain = 2.0
-    self.rate_ff_gain = 0.2
+    self.angle_ff_gain = 1.0
+    self.rate_ff_gain = 0.02
     self.angle_ff_bp = [[0.5, 5.0],[0.0, 1.0]]
 
   def reset(self):

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -18,6 +18,11 @@ class LatControl(object):
     self.last_cloudlog_t = 0.0
     self.angle_steers_des = 0.
 
+    # TODO: add the feedforward parameters to LiveParameters
+    self.angle_ff_gain = 2.0
+    self.rate_ff_gain = 0.2
+    self.angle_ff_bp = [[0.5, 5.0],[0.0, 1.0]]
+
   def reset(self):
     self.pid.reset()
 
@@ -37,9 +42,12 @@ class LatControl(object):
       self.pid.neg_limit = -steers_max
       steer_feedforward = self.angle_steers_des   # feedforward desired angle
       if CP.steerControlType == car.CarParams.SteerControlType.torque:
-        # TODO: feedforward something based on path_plan.rateSteers
-        steer_feedforward -= path_plan.angleOffset   # subtract the offset, since it does not contribute to resistive torque
-        steer_feedforward *= v_ego**2  # proportional to realigning tire momentum (~ lateral accel)
+        angle_feedforward = steer_feedforward - path_plan.angleOffset
+        angle_ff_ratio = interp(abs(angle_feedforward), self.angle_ff_bp[0], self.angle_ff_bp[1])
+        angle_feedforward *= angle_ff_ratio * self.angle_ff_gain
+        rate_feedforward = (1.0 - angle_ff_ratio) * self.rate_ff_gain * path_plan.rateSteers
+        steer_feedforward = v_ego**2 * (rate_feedforward + angle_feedforward)
+
       deadzone = 0.0
       output_steer = self.pid.update(self.angle_steers_des, angle_steers, check_saturation=(v_ego > 10), override=steer_override,
                                      feedforward=steer_feedforward, speed=v_ego, deadzone=deadzone)

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -4,6 +4,7 @@ from cereal import car
 
 _DT = 0.01    # 100Hz
 _DT_MPC = 0.05  # 20Hz
+_NOISE_THRESHOLD = 1.2
 
 
 def get_steer_max(CP, v_ego):
@@ -17,19 +18,41 @@ class LatControl(object):
                             k_f=CP.steerKf, pos_limit=1.0)
     self.last_cloudlog_t = 0.0
     self.angle_steers_des = 0.
-
-    # TODO: add the feedforward parameters to LiveParameters
-    self.angle_ff_gain = 2.0
-    self.rate_ff_gain = 0.2
+    self.angle_ff_ratio = 0.0
+    self.angle_ff_gain = 1.0
+    self.rate_ff_gain = 0.01
+    self.average_angle_steers = 0.
+    self.angle_steers_noise = _NOISE_THRESHOLD
     self.angle_ff_bp = [[0.5, 5.0],[0.0, 1.0]]
 
   def reset(self):
     self.pid.reset()
 
+  def adjust_angle_gain(self):
+    if self.pid.i > self.previous_integral:
+      if self.pid.f > 0 and self.pid.i > 0:
+        self.angle_ff_gain *= 1.0001
+      else:
+        self.angle_ff_gain *= 0.9999
+    elif self.pid.i < self.previous_integral:
+      if self.pid.f < 0 and self.pid.i < 0:
+        self.angle_ff_gain *= 1.0001
+      else:
+        self.angle_ff_gain *= 0.9999
+    self.previous_integral = self.pid.i
+
+  def adjust_rate_gain(self, angle_steers):
+    self.angle_steers_noise += 0.0001 * ((angle_steers - self.average_angle_steers)**2 - self.angle_steers_noise)
+    if self.angle_steers_noise > _NOISE_THRESHOLD:
+      self.rate_ff_gain *= 0.9999
+    else:
+      self.rate_ff_gain *= 1.0001
+
   def update(self, active, v_ego, angle_steers, steer_override, CP, VM, path_plan):
     if v_ego < 0.3 or not active:
       output_steer = 0.0
       self.pid.reset()
+      self.previous_integral = 0.0
     else:
       # TODO: ideally we should interp, but for tuning reasons we keep the mpc solution
       # constant for 0.05s.
@@ -43,14 +66,22 @@ class LatControl(object):
       steer_feedforward = self.angle_steers_des   # feedforward desired angle
       if CP.steerControlType == car.CarParams.SteerControlType.torque:
         angle_feedforward = steer_feedforward - path_plan.angleOffset
-        angle_ff_ratio = interp(abs(angle_feedforward), self.angle_ff_bp[0], self.angle_ff_bp[1])
-        angle_feedforward *= angle_ff_ratio * self.angle_ff_gain
-        rate_feedforward = (1.0 - angle_ff_ratio) * self.rate_ff_gain * path_plan.rateSteers
+        self.angle_ff_ratio = interp(abs(angle_feedforward), self.angle_ff_bp[0], self.angle_ff_bp[1])
+        angle_feedforward *= self.angle_ff_ratio * self.angle_ff_gain
+        rate_feedforward = (1.0 - self.angle_ff_ratio) * self.rate_ff_gain * path_plan.rateSteers
         steer_feedforward = v_ego**2 * (rate_feedforward + angle_feedforward)
+
+        if not steer_override and v_ego > 10.0:
+          if abs(angle_steers) > (self.angle_ff_bp[0][1] / 2.0):
+            self.adjust_angle_gain()
+          else:
+            self.previous_integral = self.pid.i
+            self.adjust_rate_gain(angle_steers)
 
       deadzone = 0.0
       output_steer = self.pid.update(self.angle_steers_des, angle_steers, check_saturation=(v_ego > 10), override=steer_override,
                                      feedforward=steer_feedforward, speed=v_ego, deadzone=deadzone)
 
     self.sat_flag = self.pid.saturated
+    self.average_angle_steers += 0.01 * (angle_steers - self.average_angle_steers)
     return output_steer, float(self.angle_steers_des)

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -4,7 +4,6 @@ from cereal import car
 
 _DT = 0.01    # 100Hz
 _DT_MPC = 0.05  # 20Hz
-_NOISE_THRESHOLD = 1.2
 
 
 def get_steer_max(CP, v_ego):
@@ -21,32 +20,17 @@ class LatControl(object):
     self.angle_ff_ratio = 0.0
     self.angle_ff_gain = 1.0
     self.rate_ff_gain = 0.01
-    self.average_angle_steers = 0.
-    self.angle_steers_noise = _NOISE_THRESHOLD
     self.angle_ff_bp = [[0.5, 5.0],[0.0, 1.0]]
 
   def reset(self):
     self.pid.reset()
 
   def adjust_angle_gain(self):
-    if self.pid.i > self.previous_integral:
-      if self.pid.f > 0 and self.pid.i > 0:
-        self.angle_ff_gain *= 1.0001
-      else:
-        self.angle_ff_gain *= 0.9999
-    elif self.pid.i < self.previous_integral:
-      if self.pid.f < 0 and self.pid.i < 0:
-        self.angle_ff_gain *= 1.0001
-      else:
-        self.angle_ff_gain *= 0.9999
+    if (self.pid.f > 0) == (self.pid.i > 0) and abs(self.pid.i) >= abs(self.previous_integral):
+      self.angle_ff_gain *= 1.0001
+    elif self.angle_ff_gain > 1.0:
+      self.angle_ff_gain *= 0.9999
     self.previous_integral = self.pid.i
-
-  def adjust_rate_gain(self, angle_steers):
-    self.angle_steers_noise += 0.0001 * ((angle_steers - self.average_angle_steers)**2 - self.angle_steers_noise)
-    if self.angle_steers_noise > _NOISE_THRESHOLD:
-      self.rate_ff_gain *= 0.9999
-    else:
-      self.rate_ff_gain *= 1.0001
 
   def update(self, active, v_ego, angle_steers, steer_override, CP, VM, path_plan):
     if v_ego < 0.3 or not active:
@@ -76,12 +60,10 @@ class LatControl(object):
             self.adjust_angle_gain()
           else:
             self.previous_integral = self.pid.i
-            self.adjust_rate_gain(angle_steers)
 
       deadzone = 0.0
       output_steer = self.pid.update(self.angle_steers_des, angle_steers, check_saturation=(v_ego > 10), override=steer_override,
                                      feedforward=steer_feedforward, speed=v_ego, deadzone=deadzone)
 
     self.sat_flag = self.pid.saturated
-    self.average_angle_steers += 0.01 * (angle_steers - self.average_angle_steers)
     return output_steer, float(self.angle_steers_des)


### PR DESCRIPTION
This enhancement combines desired steering rate with desired angle to calculate a more effective feed-forward input to the PID / PIF function for steering torque.  The benefits are significant, but the logic is rather simple.

Since _**angle**_-based feed-forward is increasingly problematic near steering center, the proposed logic only uses **_rate_**-based feed-forward when the desired steering angle is close to center.  However, since _**rate**_-based feed-forward is increasingly problematic in the outer steering range, the proposed logic interpolates the transition from rate-based to angle-based feed-forward as the desired steering angle departs from center.

I have found this to be very effective for reducing "lane hugging", typically caused by high steering angle offsets or alignment problems.  It also improves lane centering, and reduces "ping-pong", which I believe is a problem with angle-based feed-forward in general.  For cars with high actuator latency (like Toyota's), the ability to adjust steering behavior in the inner and outer steering ranges separately should improve overall performance tremendously.

A side benefit to the proposed logic is that it removes the need to be so conservative with angle-based feed-forward.  By increasing angle-based feed-forward gain, the reliance on proportional and integral error is reduced.  This improves steering response and reduces over-correction that's commonly caused by high proportional error.  This is especially beneficial for cars with limited steering torque (like Honda's), where over-correction in the outer steering range comes at a high cost. 

[EDIT]: I forgot to mention that I tested a broad range of gain values, and found that the logic is very forgiving of large and small values.  I tested rate-based gain values in the range of 0.1 to 3.0, and observed that the steering was very relaxed at 0.1, but very "knife-edged" at 3.0.  The behavior between those values seemed proportional to the value.  I tested angle-based gain values in the range of 1.0 to 5.0, and observed that steering was similar to standard at 1.0, but had a tendency toward the inside lane line at 5.0. 

I believe the gain values could be optimized dynamically in ParamsLearner, so that they don't need to be manually tuned.  The rate-based gain could be optimized based on PIF noise near the zero crossing.  The angle-based gain could be optimized based on the percentage of feedforward within PIF when target angle is in the outer range.

![image](https://user-images.githubusercontent.com/6308011/55672140-0a542400-585d-11e9-91e5-277e8d147349.png)

[Here](https://snapshot.raintank.io/dashboard/snapshot/CJ603rss5q0VPgDnXfalbOkkjSrF5ULu) is a Grafana snapshot from a drive in my 2018 Accord on the highway.  The snapshot is interactive, so you can zoom in / out, and pan left / right by clicking the buttons on the page OR using keyboard shortcuts.

I've also captures some screen prints of a few significant segments below.

![image](https://user-images.githubusercontent.com/6308011/55677947-01903c00-58b7-11e9-87de-3175f2e746cf.png)

![image](https://user-images.githubusercontent.com/6308011/55677964-49af5e80-58b7-11e9-8852-a3579b0ffb17.png)
