### PR TITLE
Reduce uploader lag while vehicle being driven and controlsd process -20 niceness

### DIFF
--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -284,15 +284,15 @@ def uploader_fn(exit_event):
     if exit_event.is_set():
       return
 
-    d = uploader.next_file_to_compress()
-    if d is not None:
-      key, fn, _ = d
-      uploader.compress(key, fn)
-      continue
-
     if not should_upload:
       time.sleep(5)
       continue
+    else:
+      d = uploader.next_file_to_compress()
+      if d is not None:
+        key, fn, _ = d
+        uploader.compress(key, fn)
+        continue
 
     d = uploader.next_file_to_upload(with_video=True)
     if d is None:

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -197,6 +197,11 @@ def start_managed_process(name):
     cloudlog.info("starting process %s" % name)
     running[name] = Process(name=name, target=nativelauncher, args=(pargs, cwd))
   running[name].start()
+  if name == "controlsd":
+    try:
+      subprocess.call(["renice", "-n", "-20", str(running[name].pid)])
+    except:
+      pass
 
 def prepare_managed_process(p):
   proc = managed_processes[p]


### PR DESCRIPTION
Recently a few of us have been having random occurrences of openpilot disengage steering while remaining fully active and without any errors on Arne's branch. The bzip2 command in uploader is known to cause a bit of lag, and usually is one of the biggest causes for these disengagements.

This sets the priority of `controlsd` to -20 and changes when openpilot compresses videos to only when the user is on a Wi-Fi connection at home or `allow_cellular` is true.

https://streamable.com/272mu