### PR TITLE
Openpilot lane line indicators support for Subaru global dash display

### DIFF
--- a/opendbc/subaru_global_2017.dbc
+++ b/opendbc/subaru_global_2017.dbc
@@ -225,7 +225,11 @@ BO_ 802 ES_LKAS_State: 8 XXX
  SG_ LKAS_ENABLE_3 : 24|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 25|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_ENABLE_2 : 26|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 27|5@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 27|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Visible : 28|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal6 : 29|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Right_Line_Visible : 30|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal7 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ FCW_Cont_Beep : 32|1@1+ (1,0) [0|1] "" XXX
  SG_ FCW_Repeated_Beep : 33|1@1+ (1,0) [0|1] "" XXX
  SG_ Throttle_Management_Activated : 34|1@1+ (1,0) [0|1] "" XXX

--- a/panda/board/safety/safety_subaru.h
+++ b/panda/board/safety/safety_subaru.h
@@ -116,11 +116,16 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       return -1;
     }
     // global platform
+    // ES LKAS
     if (addr == 0x122) {
       return -1;
     }
     // ES Distance
     if (addr == 545) {
+      return -1;
+    }
+    // ES LKAS State
+    if (addr == 802) {
       return -1;
     }
 

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -36,7 +36,7 @@ class CarController(object):
     print(DBC)
     self.packer = CANPacker(DBC[car_fingerprint]['pt'])
 
-  def update(self, sendcan, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert):
+  def update(self, sendcan, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert, left_line, right_line):
     """ Controls thread """
 
     P = self.params
@@ -70,7 +70,7 @@ class CarController(object):
       self.es_distance_cnt = CS.es_distance_msg["Counter"]
 
     if self.es_lkas_cnt != CS.es_lkas_msg["Counter"]:
-      can_sends.append(subarucan.create_es_lkas(self.packer, CS.es_lkas_msg, visual_alert))
+      can_sends.append(subarucan.create_es_lkas(self.packer, CS.es_lkas_msg, visual_alert, left_line, right_line))
       self.es_lkas_cnt = CS.es_lkas_msg["Counter"]
 
     sendcan.send(can_list_to_can_capnp(can_sends, msgtype='sendcan').to_bytes())

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -217,5 +217,6 @@ class CarInterface(object):
 
   def apply(self, c):
     self.CC.update(self.sendcan, c.enabled, self.CS, self.frame, c.actuators,
-                   c.cruiseControl.cancel, c.hudControl.visualAlert)
+                   c.cruiseControl.cancel, c.hudControl.visualAlert,
+                   c.hudControl.leftLaneVisible, c.hudControl.rightLaneVisible)
     self.frame += 1

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -43,11 +43,21 @@ def create_es_distance(packer, es_distance_msg, pcm_cancel_cmd):
 
   return packer.make_can_msg("ES_Distance", 0, values)
 
-def create_es_lkas(packer, es_lkas_msg, visual_alert):
+def create_es_lkas(packer, es_lkas_msg, visual_alert, left_line, right_line):
 
   values = copy.copy(es_lkas_msg)
   if visual_alert == VisualAlert.steerRequired:
     values["Keep_Hands_On_Wheel"] = 1
+
+  if left_line:
+    values["LKAS_Left_Line_Visible"] = 1
+  else:
+    values["LKAS_Left_Line_Visible"] = 0
+
+  if right_line:
+    values["LKAS_Right_Line_Visible"] = 1
+  else:
+    values["LKAS_Right_Line_Visible"] = 0
 
   values["Checksum"] = subaru_checksum(packer, values, 802)
 


### PR DESCRIPTION
This PR adds Openpilot lane lines visible indicators support for Subaru global dash display. Tested and working with Subaru XV 2018