### PR TITLE
Subaru global imperial/metric ACC speed fix

### DIFF
--- a/opendbc/subaru_global_2017.dbc
+++ b/opendbc/subaru_global_2017.dbc
@@ -321,10 +321,11 @@ BO_ 1658 NEW_MSG_39: 8 XXX
  SG_ NEW_SIGNAL_3 : 33|1@1+ (1,0) [0|3] "" XXX
  SG_ NEW_SIGNAL_4 : 31|1@0+ (1,0) [0|3] "" XXX
 
-BO_ 1677 NEW_MSG_40: 8 XXX
+BO_ 1677 Dash_State: 8 XXX
  SG_ Checksum : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_3 : 16|4@1+ (1,0) [0|15] "" XXX
+ SG_ Units : 27|5@1+ (1,0) [5|27] "" XXX
 
 BO_ 1743 NEW_MSG_41: 8 XXX
  SG_ Checksum : 0|8@1+ (1,0) [0|255] "" XXX

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -26,6 +26,7 @@ def get_powertrain_can_parser(CP):
     ("DOOR_OPEN_FL", "BodyInfo", 1),
     ("DOOR_OPEN_RR", "BodyInfo", 1),
     ("DOOR_OPEN_RL", "BodyInfo", 1),
+    ("Units", "Dash_State", 5),
   ]
 
   checks = [
@@ -89,6 +90,7 @@ class CarState(object):
     self.steer_torque_driver = 0
     self.steer_not_allowed = False
     self.main_on = False
+    self.is_metric = False
 
     # vEgo kalman filter
     dt = 0.01
@@ -114,7 +116,13 @@ class CarState(object):
     self.v_wheel_rl = cp.vl["Wheel_Speeds"]['RL'] * CV.KPH_TO_MS
     self.v_wheel_rr = cp.vl["Wheel_Speeds"]['RR'] * CV.KPH_TO_MS
 
-    self.v_cruise_pcm = cp_cam.vl["ES_DashStatus"]["Cruise_Set_Speed"] * CV.MPH_TO_KPH
+    # 5 = imperial, 27 = metric
+    self.is_metric = cp.vl["Dash_State"]['Units'] == 27
+
+    if self.is_metric:
+      self.v_cruise_pcm = cp_cam.vl["ES_DashStatus"]['Cruise_Set_Speed']
+    else:
+      self.v_cruise_pcm = cp_cam.vl["ES_DashStatus"]['Cruise_Set_Speed'] * CV.MPH_TO_KPH
 
     v_wheel = (self.v_wheel_fl + self.v_wheel_fr + self.v_wheel_rl + self.v_wheel_rr) / 4.
     # Kalman filter, even though Hyundai raw wheel speed is heaviliy filtered by default


### PR DESCRIPTION
Openpilot shows Subaru global ACC set speed incorrectly when car has been set to use metric units in dash menu. This PR adds CAN units signal to dbc and conditional mph to kph ACC speed unit conversion according to units signal value