### PR TITLE
Interpolate desired angle between MPC updates

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -617,6 +617,8 @@ struct PathPlan {
   paramsValid @10 :Bool;
   modelValid @12 :Bool;
   angleOffset @11 :Float32;
+  mpcAngles @14 :List(Float32);
+  mpcTimes @15 :List(Float32);
 }
 
 struct LiveLocationData {

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -1,9 +1,7 @@
 from selfdrive.controls.lib.pid import PIController
 from common.numpy_fast import interp
 from cereal import car
-
-_DT = 0.01    # 100Hz
-_DT_MPC = 0.05  # 20Hz
+from common.realtime import sec_since_boot
 
 
 def get_steer_max(CP, v_ego):
@@ -26,11 +24,7 @@ class LatControl(object):
       output_steer = 0.0
       self.pid.reset()
     else:
-      # TODO: ideally we should interp, but for tuning reasons we keep the mpc solution
-      # constant for 0.05s.
-      #dt = min(cur_time - self.angle_steers_des_time, _DT_MPC + _DT) + _DT  # no greater than dt mpc + dt, to prevent too high extraps
-      #self.angle_steers_des = self.angle_steers_des_prev + (dt / _DT_MPC) * (self.angle_steers_des_mpc - self.angle_steers_des_prev)
-      self.angle_steers_des = path_plan.angleSteers  # get from MPC/PathPlanner
+      self.angle_steers_des = interp(sec_since_boot(), path_plan.mpcTimes, path_plan.mpcAngles)
 
       steers_max = get_steer_max(CP, v_ego)
       self.pid.pos_limit = steers_max

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -10,6 +10,8 @@ from selfdrive.controls.lib.drive_helpers import MPC_COST_LAT
 from selfdrive.controls.lib.model_parser import ModelParser
 import selfdrive.messaging as messaging
 
+_DT_MPC = 0.05
+_DT_HALF_MPC = 0.025
 
 def calc_states_after_delay(states, v_ego, steer_angle, curvature_factor, steer_ratio, delay):
   states[0].x = v_ego * delay
@@ -20,10 +22,10 @@ def calc_states_after_delay(states, v_ego, steer_angle, curvature_factor, steer_
 class PathPlanner(object):
   def __init__(self, CP):
     self.MP = ModelParser()
-    
+
     self.l_poly = [0., 0., 0., 0.]
     self.r_poly = [0., 0., 0., 0.]
-    
+
     self.last_cloudlog_t = 0
 
     context = zmq.Context()
@@ -43,6 +45,8 @@ class PathPlanner(object):
     self.cur_state[0].y = 0.0
     self.cur_state[0].psi = 0.0
     self.cur_state[0].delta = 0.0
+    self.mpc_angles = [0.0, 0.0, 0.0]
+    self.mpc_times = [0.0, 0.0, 0.0]
 
     self.angle_steers_des = 0.0
     self.angle_steers_des_mpc = 0.0
@@ -53,14 +57,13 @@ class PathPlanner(object):
     v_ego = CS.carState.vEgo
     angle_steers = CS.carState.steeringAngle
     active = live100.live100.active
+    cur_time = sec_since_boot()
 
     angle_offset_average = live_parameters.liveParameters.angleOffsetAverage
     angle_offset_bias = live100.live100.angleModelBias + angle_offset_average
 
     self.MP.update(v_ego, md)
 
-    # Run MPC
-    self.angle_steers_des_prev = self.angle_steers_des_mpc
     VM.update_params(live_parameters.liveParameters.stiffnessFactor, live_parameters.liveParameters.steerRatio)
     curvature_factor = VM.curvature_factor(v_ego)
 
@@ -70,33 +73,40 @@ class PathPlanner(object):
 
     # account for actuation delay
     self.cur_state = calc_states_after_delay(self.cur_state, v_ego, angle_steers - angle_offset_average, curvature_factor, VM.sR, CP.steerActuatorDelay)
+    self.angle_steers_des_prev = np.interp(cur_time, self.mpc_times, self.mpc_angles)
+
+    # reset to current steer angle if not active or overriding
+    if active:
+      self.cur_state[0].delta = math.radians(self.angle_steers_des_prev - angle_offset_bias) / VM.sR
+    else:
+      rate_desired = 0.0
+      self.cur_state[0].delta = math.radians(angle_steers - angle_offset_bias) / VM.sR
 
     v_ego_mpc = max(v_ego, 5.0)  # avoid mpc roughness due to low speed
     self.libmpc.run_mpc(self.cur_state, self.mpc_solution,
                         l_poly, r_poly, p_poly,
                         self.MP.l_prob, self.MP.r_prob, self.MP.p_prob, curvature_factor, v_ego_mpc, self.MP.lane_width)
 
-    # reset to current steer angle if not active or overriding
-    if active:
-      delta_desired = self.mpc_solution[0].delta[1]
-      rate_desired = math.degrees(self.mpc_solution[0].rate[0] * VM.sR)
-    else:
-      delta_desired = math.radians(angle_steers - angle_offset_bias) / VM.sR
-      rate_desired = 0.0
-
-    self.cur_state[0].delta = delta_desired
-
-    self.angle_steers_des_mpc = float(math.degrees(delta_desired * VM.sR) + angle_offset_bias)
-
     #  Check for infeasable MPC solution
     mpc_nans = np.any(np.isnan(list(self.mpc_solution[0].delta)))
-    t = sec_since_boot()
-    if mpc_nans:
+
+    if not mpc_nans:
+      self.mpc_angles = [self.angle_steers_des_prev,
+                        float(math.degrees(self.mpc_solution[0].delta[1] * CP.steerRatio) + angle_offset_bias),
+                        float(math.degrees(self.mpc_solution[0].delta[2] * CP.steerRatio) + angle_offset_bias)]
+
+      self.mpc_times = [cur_time,
+                        cur_time + _DT_HALF_MPC,
+                        cur_time + _DT_HALF_MPC + _DT_MPC]
+
+      self.angle_steers_des_mpc = self.mpc_angles[1]
+      rate_desired = math.degrees(self.mpc_solution[0].rate[0] * VM.sR)
+    else:
       self.libmpc.init(MPC_COST_LAT.PATH, MPC_COST_LAT.LANE, MPC_COST_LAT.HEADING, CP.steerRateCost)
       self.cur_state[0].delta = math.radians(angle_steers) / VM.sR
 
-      if t > self.last_cloudlog_t + 5.0:
-        self.last_cloudlog_t = t
+      if cur_time > self.last_cloudlog_t + 5.0:
+        self.last_cloudlog_t = cur_time
         cloudlog.warning("Lateral mpc - nan: True")
 
     if self.mpc_solution[0].cost > 20000. or mpc_nans:   # TODO: find a better way to detect when MPC did not converge
@@ -117,6 +127,8 @@ class PathPlanner(object):
     plan_send.pathPlan.rPoly = [float(x) for x in r_poly]
     plan_send.pathPlan.rProb = float(self.MP.r_prob)
     plan_send.pathPlan.angleSteers = float(self.angle_steers_des_mpc)
+    plan_send.pathPlan.mpcAngles = map(float, self.mpc_angles)
+    plan_send.pathPlan.mpcTimes = map(float, self.mpc_times)
     plan_send.pathPlan.rateSteers = float(rate_desired)
     plan_send.pathPlan.angleOffset = float(angle_offset_average)
     plan_send.pathPlan.valid = bool(plan_valid)

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -92,8 +92,8 @@ class PathPlanner(object):
 
     if not mpc_nans:
       self.mpc_angles = [self.angle_steers_des_prev,
-                        float(math.degrees(self.mpc_solution[0].delta[1] * CP.steerRatio) + angle_offset_bias),
-                        float(math.degrees(self.mpc_solution[0].delta[2] * CP.steerRatio) + angle_offset_bias)]
+                        float(math.degrees(self.mpc_solution[0].delta[1] * VM.sR) + angle_offset_bias),
+                        float(math.degrees(self.mpc_solution[0].delta[2] * VM.sR) + angle_offset_bias)]
 
       self.mpc_times = [cur_time,
                         cur_time + _DT_HALF_MPC,


### PR DESCRIPTION
This enhancement is part of a large group of enhancements included in a [different PR](https://github.com/commaai/openpilot/pull/529), and is an update to [this PR](https://github.com/commaai/openpilot/pull/553) from 2 months ago.

The existing lateral control logic does not interpolate between MPC updates, which creates a significant amount of noise in controls. Also, since controls and planning run in separate threads without any synchronization, the number and offset of control cycles per MPC update is irregular, creating additional noise.

This enhancement eliminates both of those noise sources by interpolating between multiple points using system time. Below are examples of standard vs interpolated values over a 2 second period.

Standard values
![non-interpolated](https://user-images.githubusercontent.com/6308011/53920335-72cb9d80-4032-11e9-8fbe-b3e92e67f1d0.png)

Interpolated values
![interpolated](https://user-images.githubusercontent.com/6308011/53920336-72cb9d80-4032-11e9-829a-29baab58c047.png)

Note that I have altered the calculation of MPC times to compensate for the effective time delay caused by interpolation.  In the sketch below, the top image shows how interpolating from previous angle to the new angle creates a delay of 0.05 seconds before the new desired angle is requested.  However, by reducing the first time offset to half the length of an MPC cycle, the phase is corrected.

If you prefer a different approach, please let me know.

![image](https://user-images.githubusercontent.com/6308011/57786942-118f0d00-76fa-11e9-8bde-327a4beb86b8.png)

