### PR TITLE
Angle based tuning for variable steer ratio for Prius INDI

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -89,7 +89,7 @@ class CarInterface(object):
       ret.lateralTuning.init('indi')
       ret.lateralTuning.indi.innerLoopGain = 4.0
       ret.lateralTuning.indi.outerLoopGain = 3.0
-      ret.lateralTuning.indi.timeConstant = 1.0
+      ret.lateralTuning.indi.timeConstant = 2.0
       ret.lateralTuning.indi.actuatorEffectiveness = 1.0
 
       ret.steerActuatorDelay = 0.5

--- a/selfdrive/controls/lib/latcontrol_indi.py
+++ b/selfdrive/controls/lib/latcontrol_indi.py
@@ -64,6 +64,13 @@ class LatControlINDI(object):
       self.angle_steers_des = path_plan.angleSteers
       self.rate_steers_des = path_plan.rateSteers
 
+      if abs(angle_steers) < 3:
+          self.G = CP.lateralTuning.indi.actuatorEffectiveness
+          self.RC = CP.lateralTuning.indi.timeConstant
+      else:
+          self.G = (CP.lateralTuning.indi.actuatorEffectiveness * 2)
+          self.RC = (CP.lateralTuning.indi.timeConstant * 2)
+
       steers_des = math.radians(self.angle_steers_des)
       rate_des = math.radians(self.rate_steers_des)
 


### PR DESCRIPTION
Greetings.

It's been a long known fact that you can either tune for straight-line performance, or tune for curves for Prius. However, without variable parameters, you cannot have both. This has been the case with Prius since introduction of the vehicle into OP.

The most likely reasoning for this is Variable Steer Ratio and that the Prius has its EPS motor on the steering shaft/column. This means that for a specified movement of the steering wheel, wheel angle is inconsistent across the rack.

![IMG_1834](https://user-images.githubusercontent.com/7257172/58279677-075db600-7d6d-11e9-9434-20afd2b16efc.jpeg)

![3-s2 0-B9780750651318500105-f09-37-9780750651318](https://user-images.githubusercontent.com/7257172/58279743-31af7380-7d6d-11e9-8426-2fc77c3c4c7f.gif)

Here is stock OP at specified (stock) settings on a repeatable test loop:

ret.lateralTuning.indi.innerLoopGain = 4.0
      ret.lateralTuning.indi.outerLoopGain = 3.0
      ret.lateralTuning.indi.timeConstant = 1
      ret.lateralTuning.indi.actuatorEffectiveness = 1
<img width="1460" alt="Screen Shot 2019-05-23 at 12 48 14 PM" src="https://user-images.githubusercontent.com/7257172/58279781-45f37080-7d6d-11e9-9a53-c56b9ad7e7c7.png">

Here is stock OP at specified (modified) settings on a repeatable test loop:

ret.lateralTuning.indi.innerLoopGain = 4.0
      ret.lateralTuning.indi.outerLoopGain = 3.0
      ret.lateralTuning.indi.timeConstant = 2.5
      ret.lateralTuning.indi.actuatorEffectiveness = 2
<img width="1442" alt="Screen Shot 2019-05-23 at 12 48 20 PM" src="https://user-images.githubusercontent.com/7257172/58279843-67545c80-7d6d-11e9-95c2-e3888b6a4f54.png">

As one can objectively see, cornering performance is enhanced, at the expense of straight line performance.

This PR accomplishes the union of the best INDI parameters to best suit the Prius's Variable Ratio Steering rack. 

Durther enhancement would require comma.ai to measure the wheel vs steering wheel angle to ascertain the exact ratios across the controllable OP steering range and interpolate parameters accordingly. It would also be beneficial for MPC/Pathplanner to be aware of the variable ratio for accurate path perdition, but such is hard and requires major modifications to OpenPilot. I have tried this personally, and have failed due to ParamsLearner complications regarding angle_offset (which led to severe lane hugging).

I hope that this PR helps open the discussion on how to best account for vehicles with variable ratio steering as such knowledge applies to at least the Prius, and Rav 4, and likely many other supported OP vehicles.

Here is the same concept applied for PID control that Rav 4 users have regarded highly in terms of lateral performance: https://github.com/zorrobyte/openpilot/tree/devel_modStockPID

Full discussion, including testing parameters are here in the #tuning channel
https://discordapp.com/channels/469524606043160576/574796986822295569/581161857465712641

I've set timeConstant = 2 due to enhanced straight line performance.