### PR TITLE
Fix registration's params get_git_remote()

### DIFF
--- a/selfdrive/registration.py
+++ b/selfdrive/registration.py
@@ -22,7 +22,9 @@ def get_git_branch():
   return subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
 
 def get_git_remote():
-  return subprocess.check_output(["git", "config", "--get", "remote.origin.url"]).strip()
+  local_branch = subprocess.check_output(["git", "name-rev", "--name-only", "HEAD"]).strip()
+  tracking_remote = subprocess.check_output(["git", "config", "branch."+local_branch+".remote"]).strip()
+  return subprocess.check_output(["git", "config", "remote."+tracking_remote+".url"]).strip()
 
 def register():
   params = Params()


### PR DESCRIPTION
registration's `get_git_remote()` currently returns potentially the incorrect git remote if the user has multiple remotes set up.

Thanks to @sippiecup for reporting the problem!