### PR TITLE
show warning if docker test fails

### DIFF
--- a/run_docker_tests.sh
+++ b/run_docker_tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -eE
+trap 'echo Warning: test failed, so quitting without running later tests.' ERR
 
 docker build -t tmppilot -f Dockerfile.openpilot .
 


### PR DESCRIPTION
Not sure if you actually want this change, but it makes it more obvious that test_longitudinal.py is not running due to pylint failing.