### PR TITLE
Reduce unnecessary unwind of integral

### DIFF
--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -10,7 +10,7 @@ class LatControlPID(object):
                             (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
                             k_f=CP.lateralTuning.pid.kf, pos_limit=1.0)
     self.angle_steers_des = 0.
-    self.prev_angle_steers =0.
+    self.prev_angle_steers = 0.
 
   def reset(self):
     self.pid.reset()


### PR DESCRIPTION
This enhancements relates to [this PR](https://github.com/commaai/openpilot/pull/726), and only applies to PID / torque type steering.  

The current lateral control logic triggers the override flag in PID whenever the steering system reports an input greater than a predetermined threshold.  It does not consider the direction of that input.  This results in the integral often unwinding to 0, even when the driver is NOT opposing the desired path.  

Below is a screen capture of the control output, consisting of integration (yellow) and proportional response (red).  The dark blue boxes indicate the detection of a steering override.

Note how the yellow diminishes quickly after every detected override.

![image](https://user-images.githubusercontent.com/6308011/60634469-97633680-9dd4-11e9-97cd-d0e737aab573.png)

Here is a test after this enhancement, which was surprisingly difficult to demonstrate intentionally.  I've hidden the proportional response so that the integral is more clear.  As you can see, the yellow region does not diminish during the first "long" steer override, but it does diminish quickly during the second long steer override.  The difference between the 2 overrides is the direction of the override.

I performed positive and negative testing of this to ensure that the comparison operator is correct.

![image](https://user-images.githubusercontent.com/6308011/60634739-ad252b80-9dd5-11e9-9d8d-daa57ec4cfd2.png)
