### PR TITLE
Fix lane centering with single lane line

### DIFF
--- a/selfdrive/controls/lib/model_parser.py
+++ b/selfdrive/controls/lib/model_parser.py
@@ -44,7 +44,7 @@ class ModelParser(object):
     self.lane_width_certainty += 0.05 * (lr_prob - self.lane_width_certainty)
     current_lane_width = abs(l_poly[3] - r_poly[3])
     self.lane_width_estimate += 0.005 * (current_lane_width - self.lane_width_estimate)
-    speed_lane_width = interp(v_ego, [0., 31.], [3., 3.8])
+    speed_lane_width = interp(v_ego, [0., 31.], [2.8, 3.5])
     self.lane_width = self.lane_width_certainty * self.lane_width_estimate + \
                       (1 - self.lane_width_certainty) * speed_lane_width
 


### PR DESCRIPTION
This is to fix the new lane centering issue that was introduced by [changes to the 0.6 MPC](https://github.com/commaai/openpilot/blob/devel/selfdrive/controls/lib/lateral_mpc/generator.cpp#L60).  The new MPC logic does improve OP performance with single lane lines IF the lane is wide.  However, if the lane is not wider than the US Interstate Highway standard, then the values below will cause the MPC to steer the vehicle too far away from the 1 visible lane line.  This fix will prevent that by using a more conservative default width, which will draw the vehicle closer to the 1 visible lane line.