### PR TITLE
Chrysler change accel pedal message to avoid false disengage on 2018 Jeeps at low speeds while using ACC.

### DIFF
--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -27,7 +27,7 @@ def get_can_parser(CP):
     ("DOOR_OPEN_RL", "DOORS", 0),
     ("DOOR_OPEN_RR", "DOORS", 0),
     ("BRAKE_PRESSED_2", "BRAKE_2", 0),
-    ("ACCEL_PEDAL", "ACCEL_PEDAL_MSG", 0),
+    ("ACCEL_134", "ACCEL_GAS_134", 0),
     ("SPEED_LEFT", "SPEED_1", 0),
     ("SPEED_RIGHT", "SPEED_1", 0),
     ("WHEEL_SPEED_FL", "WHEEL_SPEEDS", 0),
@@ -112,7 +112,7 @@ class CarState(object):
     self.seatbelt = (cp.vl["SEATBELT_STATUS"]['SEATBELT_DRIVER_UNLATCHED'] == 0)
 
     self.brake_pressed = cp.vl["BRAKE_2"]['BRAKE_PRESSED_2'] == 5 # human-only
-    self.pedal_gas = cp.vl["ACCEL_PEDAL_MSG"]['ACCEL_PEDAL']
+    self.pedal_gas = cp.vl["ACCEL_GAS_134"]['ACCEL_134']
     self.car_gas = self.pedal_gas
     self.esp_disabled = (cp.vl["TRACTION_BUTTON"]['TRACTION_OFF'] == 1)
 

--- a/selfdrive/car/chrysler/carstate_test.py
+++ b/selfdrive/car/chrysler/carstate_test.py
@@ -1,0 +1,20 @@
+from selfdrive.car.chrysler import carstate
+from selfdrive.car.chrysler.interface import CarInterface
+from selfdrive.car.chrysler.values import CAR
+
+
+import unittest
+
+
+class TestCarstate(unittest.TestCase):
+
+  def test_get_can_parser(self):
+    CP = CarInterface.get_params(CAR.PACIFICA_2017_HYBRID, {})
+    cpNew = carstate.get_can_parser(CP)
+    cpCamNew = carstate.get_camera_parser(CP)
+    CS = carstate.CarState(CP)
+    CS.update(cpNew, cpCamNew)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/selfdrive/car/chrysler/run_tests.sh
+++ b/selfdrive/car/chrysler/run_tests.sh
@@ -1,1 +1,2 @@
 PYTHONPATH=`realpath ../../../` python chryslercan_test.py
+PYTHONPATH=`realpath ../../../` python carstate_test.py


### PR DESCRIPTION
Verified with multiple cabana drives from users.
Analysis is here: https://www.youtube.com/watch?v=Iu1e4UvAU4c