### PR TITLE
Reduce steering error with better lane width calculation

### DIFF
--- a/selfdrive/controls/lib/model_parser.py
+++ b/selfdrive/controls/lib/model_parser.py
@@ -46,9 +46,10 @@ class ModelParser(object):
     self.lane_width_certainty += 0.05 * decay_rate * (lr_prob - self.lane_width_certainty)
     current_lane_width = abs(l_poly[3] - r_poly[3])
     self.lane_width_estimate += 0.005 * decay_rate * (current_lane_width - self.lane_width_estimate)
-    speed_lane_width = interp(v_ego, [0., 31.], [2.8, 3.5])
+    speed_lane_width = interp(v_ego, [0., 31.], [3.0, 3.8])
     self.lane_width = self.lane_width_certainty * self.lane_width_estimate + \
                       (1 - self.lane_width_certainty) * speed_lane_width
+    
     self.lead_dist = md.lead.dist
     self.lead_prob = md.lead.prob
     self.lead_var = md.lead.std**2

--- a/selfdrive/controls/lib/model_parser.py
+++ b/selfdrive/controls/lib/model_parser.py
@@ -41,13 +41,14 @@ class ModelParser(object):
 
     # Find current lanewidth
     lr_prob = l_prob * r_prob
-    self.lane_width_certainty += 0.05 * (lr_prob - self.lane_width_certainty)
+    decay_rate = interp(lr_prob, [0., 0.5], [0.1, 0.3])
+    decay_rate *= v_ego / 31.0
+    self.lane_width_certainty += 0.05 * decay_rate * (lr_prob - self.lane_width_certainty)
     current_lane_width = abs(l_poly[3] - r_poly[3])
-    self.lane_width_estimate += 0.005 * (current_lane_width - self.lane_width_estimate)
+    self.lane_width_estimate += 0.005 * decay_rate * (current_lane_width - self.lane_width_estimate)
     speed_lane_width = interp(v_ego, [0., 31.], [2.8, 3.5])
-    self.lane_width = self.lane_width_certainty * self.lane_width_estimate + \
-                      (1 - self.lane_width_certainty) * speed_lane_width
-
+    self.lane_width = (self.lane_width_certainty * self.lane_width_estimate + \
+                       0.2 * speed_lane_width) / (0.2 + self.lane_width_certainty)
     self.lead_dist = md.lead.dist
     self.lead_prob = md.lead.prob
     self.lead_var = md.lead.std**2

--- a/selfdrive/controls/lib/model_parser.py
+++ b/selfdrive/controls/lib/model_parser.py
@@ -47,8 +47,8 @@ class ModelParser(object):
     current_lane_width = abs(l_poly[3] - r_poly[3])
     self.lane_width_estimate += 0.005 * decay_rate * (current_lane_width - self.lane_width_estimate)
     speed_lane_width = interp(v_ego, [0., 31.], [2.8, 3.5])
-    self.lane_width = (self.lane_width_certainty * self.lane_width_estimate + \
-                       0.2 * speed_lane_width) / (0.2 + self.lane_width_certainty)
+    self.lane_width = self.lane_width_certainty * self.lane_width_estimate + \
+                      (1 - self.lane_width_certainty) * speed_lane_width
     self.lead_dist = md.lead.dist
     self.lead_prob = md.lead.prob
     self.lead_var = md.lead.std**2


### PR DESCRIPTION
This change is related to [this PR](https://github.com/commaai/openpilot/pull/737) from a couple weeks ago, and was prompted by the comment today from @zorrobyte about steering error when 1 lane line disappeared before a turn.

After some discussion with with the community on Discord, I tested a few changes that made a very significant improvement for lateral stability.  

The root issues with the current lane width logic are:
* Lane width estimate changes too fast, which causes the MPC to overreact to noise in the lane lines
* Speed-based lane width has too much impact when 1 lane line has a low probability
* Lane width change is only time-based, not distance.

The proposed logic addresses all of those issues.

Below is a screen capture of my dashboard before and after this change on the same turn within a few minutes of each other.  
![image](https://user-images.githubusercontent.com/6308011/61676427-7d28c400-acc1-11e9-9417-cbc1cbfb77a4.png)

[Here](https://youtu.be/3zCy9t28ACM) is a video of the turn
![image](https://user-images.githubusercontent.com/6308011/61676813-ebba5180-acc2-11e9-9d11-6455a3b86398.png)

Here is a link to the drive in Cabana
https://my.comma.ai/cabana/?route=ddd3e089e7bbe0fc%7C2019-07-22--19-18-49&max=22&url=https%3A%2F%2Fchffrprivate-vzn.azureedge.net%2Fchffrprivate3%2Fv2%2Fddd3e089e7bbe0fc%2F6d8537a9b83f1a8c6695f84e3de7a108_2019-07-22--19-18-49