### PR TITLE
Tss1.5 offset fix - instead of reverting to bad angle

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -98,7 +98,7 @@ class CarState(object):
     self.left_blinker_on = 0
     self.right_blinker_on = 0
     self.offset = 0.
-    self.isoffset = 0
+    self.is_offset_set = False
 
     # initialize can parser
     self.car_fingerprint = CP.carFingerprint
@@ -147,11 +147,11 @@ class CarState(object):
     self.a_ego = float(v_ego_x[1])
     self.standstill = not v_wheel > 0.001
 
-    if self.CP.carFingerprint in NO_DSU_CAR: # Vehicle that needs offsetting
+    if self.CP.carFingerprint in NO_DSU_CAR and self.CP.carFingerprint not in TSS2_CAR: # Vehicle that needs offsetting
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE'] - self.offset
-      if self.isoffset == 0:
+      if not self.isoffset:
         self.offset = self.angle_steers - cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
-        self.isoffset = 1
+        self.isoffset = True
     elif self.CP.carFingerprint in TSS2_CAR:
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE']
     else:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -148,10 +148,9 @@ class CarState(object):
     self.standstill = not v_wheel > 0.001
 
     if self.CP.carFingerprint in NO_DSU_CAR: # Vehicle that needs offsetting
-      self.angle_steers_wheel = cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE'] - self.offset
       if not self.isoffset:
-        self.offset = self.angle_steers - self.angle_steers_wheel
+        self.offset = self.angle_steers - cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
         self.isoffset = True
     elif self.CP.carFingerprint in TSS2_CAR:
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE']

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -3,7 +3,7 @@ from common.kalman.simple_kalman import KF1D
 from selfdrive.can.can_define import CANDefine
 from selfdrive.can.parser import CANParser
 from selfdrive.config import Conversions as CV
-from selfdrive.car.toyota.values import CAR, DBC, STEER_THRESHOLD, NO_DSU_CAR
+from selfdrive.car.toyota.values import CAR, DBC, STEER_THRESHOLD, NO_DSU_CAR, TSS2_CAR
 
 def parse_gear_shifter(gear, vals):
 
@@ -150,10 +150,10 @@ class CarState(object):
     if self.CP.carFingerprint in NO_DSU_CAR: # Vehicle that needs offsetting
       self.angle_steers_wheel = cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE'] - self.offset
-            if self.isoffset == 0:
-                self.offset = self.angle_steers - self.angle_steers_wheel
-                self.isoffset = 1
-    elif CP.carFingerprint in TSS2_CAR:
+      if self.isoffset == 0:
+        self.offset = self.angle_steers - self.angle_steers_wheel
+        self.isoffset = 1
+    elif self.CP.carFingerprint in TSS2_CAR:
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE']
     else:
       self.angle_steers = cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -3,7 +3,7 @@ from common.kalman.simple_kalman import KF1D
 from selfdrive.can.can_define import CANDefine
 from selfdrive.can.parser import CANParser
 from selfdrive.config import Conversions as CV
-from selfdrive.car.toyota.values import CAR, DBC, STEER_THRESHOLD, TSS2_CAR
+from selfdrive.car.toyota.values import CAR, DBC, STEER_THRESHOLD, NO_DSU_CAR
 
 def parse_gear_shifter(gear, vals):
 
@@ -59,7 +59,7 @@ def get_can_parser(CP):
     ("EPS_STATUS", 25),
   ]
 
-  if CP.carFingerprint in TSS2_CAR:
+  if CP.carFingerprint in NO_DSU_CAR:
     signals += [("STEER_ANGLE", "STEER_TORQUE_SENSOR", 0)]
   else:
     signals += [("STEER_ANGLE", "STEER_ANGLE_SENSOR", 0)]
@@ -142,7 +142,7 @@ class CarState(object):
     self.a_ego = float(v_ego_x[1])
     self.standstill = not v_wheel > 0.001
 
-    if self.CP.carFingerprint in TSS2_CAR:
+    if self.CP.carFingerprint in NO_DSU_CAR:
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE']
     else:
       self.angle_steers = cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -98,7 +98,7 @@ class CarState(object):
     self.left_blinker_on = 0
     self.right_blinker_on = 0
     self.offset = 0.
-    self.isoffset = False
+    self.isoffset = 0
 
     # initialize can parser
     self.car_fingerprint = CP.carFingerprint
@@ -149,9 +149,9 @@ class CarState(object):
 
     if self.CP.carFingerprint in NO_DSU_CAR: # Vehicle that needs offsetting
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE'] - self.offset
-      if not self.isoffset:
+      if self.isoffset == 0:
         self.offset = self.angle_steers - cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
-        self.isoffset = True
+        self.isoffset = 1
     elif self.CP.carFingerprint in TSS2_CAR:
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE']
     else:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -148,7 +148,7 @@ class CarState(object):
     if self.CP.carFingerprint in NO_DSU_CAR and self.CP.carFingerprint not in TSS2_CAR: # Vehicle that needs offsetting
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE'] - self.offset
       if not self.isoffset:
-        self.offset = self.angle_steers - cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
+        self.offset = self.angle_steers - cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] - cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
         self.isoffset = True
     elif self.CP.carFingerprint in TSS2_CAR:
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE']

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -97,8 +97,8 @@ class CarState(object):
     self.shifter_values = self.can_define.dv["GEAR_PACKET"]['GEAR']
     self.left_blinker_on = 0
     self.right_blinker_on = 0
-    self.offset = 0
-    self.isoffset = 0
+    self.offset = 0.
+    self.isoffset = False
 
     # initialize can parser
     self.car_fingerprint = CP.carFingerprint
@@ -150,9 +150,9 @@ class CarState(object):
     if self.CP.carFingerprint in NO_DSU_CAR: # Vehicle that needs offsetting
       self.angle_steers_wheel = cp.vl["STEER_ANGLE_SENSOR"]['STEER_ANGLE'] + cp.vl["STEER_ANGLE_SENSOR"]['STEER_FRACTION']
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE'] - self.offset
-      if self.isoffset == 0:
+      if not self.isoffset:
         self.offset = self.angle_steers - self.angle_steers_wheel
-        self.isoffset = 1
+        self.isoffset = True
     elif self.CP.carFingerprint in TSS2_CAR:
       self.angle_steers = cp.vl["STEER_TORQUE_SENSOR"]['STEER_ANGLE']
     else:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -97,8 +97,6 @@ class CarState(object):
     self.shifter_values = self.can_define.dv["GEAR_PACKET"]['GEAR']
     self.left_blinker_on = 0
     self.right_blinker_on = 0
-    self.offset = 0.
-    self.is_offset_set = False
 
     # initialize can parser
     self.car_fingerprint = CP.carFingerprint


### PR DESCRIPTION
Lateral control is greatly impacted by angle data and it'd be a shame if we gutted NO_DSU_CAR because of startup offsetting.

This PR offsets NO_DSU_CAR on startup to get around the non-absolute offsetting issue, just as I've used successfully in my custom steering sensor project (it's a non-absolute sensor):
https://github.com/zorrobyte/betterToyotaAngleSensorForOP

Community feedback:
https://discordapp.com/channels/469524606043160576/574796986822295569/603199697200480256
https://discordapp.com/channels/469524606043160576/574796986822295569/603205157957664808 -- not this PR, but this branch: https://github.com/commaai/openpilot/compare/devel...zorrobyte:offset_goodsteeringangle

@bugsy said that he'll be testing this PR on his Camry and have feedback to share in this PR by Saturday.