### PR TITLE
STEER_RATE is defined in interface.py, not drive_helpers.py

### DIFF
--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -13,7 +13,6 @@ class MPC_COST_LAT:
   PATH = 1.0
   LANE = 3.0
   HEADING = 1.0
-  STEER_RATE = 1.0
 
 
 class MPC_COST_LONG:


### PR DESCRIPTION
This variable is depreciated and hasn't been used for a long time.