### PR TITLE
Fix timeout in longitudinal test

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import gc
 import capnp
 from cereal import car, log
@@ -440,7 +441,8 @@ def controlsd_thread(gctx=None):
   logcan.close()
 
   # TODO: Use the logcan socket from above, but that will currenly break the tests
-  can_sock = messaging.sub_sock(service_list['can'].port, timeout=100)
+  can_timeout = 0 if os.environ.get('NO_CAN_TIMEOUT', False) else 100
+  can_sock = messaging.sub_sock(service_list['can'].port, timeout=can_timeout)
 
   car_recognized = CP.carName != 'mock'
   # If stock camera is disconnected, we loaded car controls and it's not chffrplus

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -441,7 +441,7 @@ def controlsd_thread(gctx=None):
   logcan.close()
 
   # TODO: Use the logcan socket from above, but that will currenly break the tests
-  can_timeout = 0 if os.environ.get('NO_CAN_TIMEOUT', False) else 100
+  can_timeout = None if os.environ.get('NO_CAN_TIMEOUT', False) else 100
   can_sock = messaging.sub_sock(service_list['can'].port, timeout=can_timeout)
 
   car_recognized = CP.carName != 'mock'

--- a/selfdrive/test/tests/plant/test_longitudinal.py
+++ b/selfdrive/test/tests/plant/test_longitudinal.py
@@ -325,6 +325,7 @@ def setup_output():
 class LongitudinalControl(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
+    os.environ['NO_CAN_TIMEOUT'] = "1"
 
     setup_output()
 


### PR DESCRIPTION
The longitudinal control test on Travis CI sometimes lags for a bit, causing a `canError` and a disengagement. In turn this causes the test to fail.