### PR TITLE
Prius steer rate factor is wrong

### DIFF
--- a/opendbc/toyota_prius_2017_pt_generated.dbc
+++ b/opendbc/toyota_prius_2017_pt_generated.dbc
@@ -77,7 +77,7 @@ BO_ 36 KINEMATICS: 8 XXX
 BO_ 37 STEER_ANGLE_SENSOR: 8 XXX
  SG_ STEER_ANGLE : 3|12@0- (1.5,0) [-500|500] "deg" XXX
  SG_ STEER_FRACTION : 39|4@0- (0.1,0) [-0.7|0.7] "deg" XXX
- SG_ STEER_RATE : 35|12@0- (1,0) [-2000|2000] "deg/s" XXX
+ SG_ STEER_RATE : 35|12@0- (0.01,0) [-2000|2000] "deg/s" XXX
 
 BO_ 166 BRAKE: 8 XXX
  SG_ BRAKE_AMOUNT : 7|8@0+ (1,0) [0|255] "" XXX
@@ -248,7 +248,7 @@ CM_ SG_ 36 ACCEL_Y "unit is tbd";
 CM_ SG_ 36 YAW_RATE "verify";
 CM_ SG_ 36 STEERING_TORQUE "does not seem the steer torque, tbd";
 CM_ SG_ 37 STEER_FRACTION "1/15th of the signal STEER_ANGLE, which is 1.5 deg; note that 0x8 is never set";
-CM_ SG_ 37 STEER_RATE "factor is tbd";
+CM_ SG_ 37 STEER_RATE "factor contributed by zorrobyte";
 CM_ SG_ 466 ACCEL_NET "net acceleration produced by the system, given ACCEL_CMD, road grade and other factors";
 CM_ SG_ 467 SET_SPEED "43 kph are shown as 28mph, so conversion isnt perfect";
 CM_ SG_ 467 LOW_SPEED_LOCKOUT "in low speed lockout, system would always disengage below 28mph";


### PR DESCRIPTION
The rate factor in the DBC was commented "TBD", so I went ahead and calculated it for you with my good sensor.

Stock OP:
![unknown-14](https://user-images.githubusercontent.com/7257172/62377251-6e87ab80-b510-11e9-8ea6-f8abc87abc80.png)

This PR:
<img width="1093" alt="Screenshot 2019-08-02 10 23 18" src="https://user-images.githubusercontent.com/7257172/62377487-da6a1400-b510-11e9-988a-1598212c20cd.png">


@pd0wm Not sure if this would screw up your INDI Kalman Filter, but the plus side is - I'm now uploading accurate rate data from this point on. Not sure if it'd help you refine the actuator model:
```
BO_ 35 SECONDARY_STEER_ANGLE: 8 XXX
  SG_ ZORRO_STEER : 7|32@0- (0.004901594652,0) [-500|500] "" XXX
  SG_ ZORRO_RATE : 39|24@0- (0.004901594652,0) [-500|500] "" XXX
```
https://github.com/zorrobyte/openpilot/blob/devel_ZSS/opendbc/toyota_prius_2017_pt_generated.dbc