### PR TITLE
Planner acceleration vs CarController

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -144,7 +144,7 @@ class CarController(object):
     if apply_accel < 0:
       apply_accel = -clip((-apply_accel) ** 2 * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
     else:
-      apply_accel = clip(apply_accel ** 2 * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
+      apply_accel = clip(apply_accel * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
 
     # steer torque
     apply_steer = int(round(actuators.steer * SteerLimitParams.STEER_MAX))

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -141,7 +141,10 @@ class CarController(object):
       apply_accel = actuators.gas - actuators.brake
 
     apply_accel, self.accel_steady = accel_hysteresis(apply_accel, self.accel_steady, enabled)
-    apply_accel = clip(apply_accel * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
+    if apply_accel < 0:
+      apply_accel = -clip((-apply_accel) ** 2 * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
+    else:
+      apply_accel = clip(apply_accel ** 2 * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
 
     # steer torque
     apply_steer = int(round(actuators.steer * SteerLimitParams.STEER_MAX))

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -141,10 +141,7 @@ class CarController(object):
       apply_accel = actuators.gas - actuators.brake
 
     apply_accel, self.accel_steady = accel_hysteresis(apply_accel, self.accel_steady, enabled)
-    if apply_accel < 0:
-      apply_accel = -clip((-apply_accel) ** 2 * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
-    else:
-      apply_accel = clip(apply_accel * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
+    apply_accel = clip(apply_accel * ACCEL_SCALE, ACCEL_MIN, ACCEL_MAX)
 
     # steer torque
     apply_steer = int(round(actuators.steer * SteerLimitParams.STEER_MAX))

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -253,7 +253,7 @@ def state_control(frame, rcv_frame, plan, path_plan, CS, CP, state, events, v_cr
 
   # Gas/Brake PID loop
   actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
-                                              v_cruise_kph, v_acc_sol, plan.vTargetFuture, a_acc_sol, CP)
+                                              v_cruise_kph, v_acc_sol, plan.vTargetFuture, a_acc_sol, CP, driver_status.awareness < 0)
   # Steering PID loop and lateral MPC
   actuators.steer, actuators.steerAngle, lac_log = LaC.update(active, CS.vEgo, CS.steeringAngle, CS.steeringRate,
                                                               CS.steeringPressed, CP, VM, path_plan)

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -253,7 +253,7 @@ def state_control(frame, rcv_frame, plan, path_plan, CS, CP, state, events, v_cr
 
   # Gas/Brake PID loop
   actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
-                                              v_cruise_kph, v_acc_sol, plan.vTargetFuture, a_acc_sol, CP, driver_status.awareness < 0)
+                                              v_cruise_kph, v_acc_sol, plan.vTargetFuture, a_acc_sol, CP, driver_status.awareness < 0, plan.longitudinalPlanSource)
   # Steering PID loop and lateral MPC
   actuators.steer, actuators.steerAngle, lac_log = LaC.update(active, CS.vEgo, CS.steeringAngle, CS.steeringRate,
                                                               CS.steeringPressed, CP, VM, path_plan)

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -60,6 +60,7 @@ class LongControl(object):
     self.long_control_state = LongCtrlState.off  # initialized to off
     self.pid = PIController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),
                             (CP.longitudinalTuning.kiBP, CP.longitudinalTuning.kiV),
+                            k_f=0.6,
                             rate=RATE,
                             sat_limit=0.8,
                             convert=compute_gb)

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -60,7 +60,7 @@ class LongControl(object):
     self.long_control_state = LongCtrlState.off  # initialized to off
     self.pid = PIController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),
                             (CP.longitudinalTuning.kiBP, CP.longitudinalTuning.kiV),
-                            k_f=0.6,
+                            k_f=1.0,
                             rate=RATE,
                             sat_limit=0.8,
                             convert=compute_gb)

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -104,8 +104,8 @@ class LongControl(object):
       deadzone = interp(v_ego_pid, CP.longitudinalTuning.deadzoneBP, CP.longitudinalTuning.deadzoneV)
       if force_decel and not self.lastdecel:
         self.lastdecel = True
-        self.pid._k_p = ([0], [0])
-        self.pid._k_i = ([0], [0])
+        self.pid._k_p = ([0.], [0.])
+        self.pid._k_i = ([0.], [0.])
         self.pid.i = 0.0
       if self.lastdecel and not force_decel:
         self.lastdecel = False

--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -167,6 +167,7 @@ class Planner(object):
         # if required so, force a smooth deceleration
         accel_limits_turns[1] = min(accel_limits_turns[1], AWARENESS_DECEL)
         accel_limits_turns[0] = min(accel_limits_turns[0], accel_limits_turns[1])
+        self.a_acc_start = AWARENESS_DECEL
 
       self.v_cruise, self.a_cruise = speed_smoother(self.v_acc_start, self.a_acc_start,
                                                     v_cruise_setpoint,


### PR DESCRIPTION
If planner requires small amounts of deceleration carcontroller brakes harshly. At least with much more deceleration than was requested.
The acceleration that comes from the planner that finally ends up here goes through the longcontrol pid. I am not sure if the linear scaling is correct and so I have applied a ^2 to the apply_accel to get the required decceleration from planner to match closer to the actual deceleration of the car. 

From tests ^2.5 is too little and ^.1.5 is too much braking. Maybe this change needs to be made somewhere else in the PID. But you guys can have a look at it.