### PR TITLE
actuators.brake is a negative value

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -136,7 +136,7 @@ class CarController(object):
     if CS.CP.enableGasInterceptor:
       # send only negative accel if interceptor is detected. otherwise, send the regular value
       # +0.06 offset to reduce ABS pump usage when OP is engaged
-      apply_accel = 0.06 - actuators.brake
+      apply_accel = 0.06 + actuators.brake
     else:
       apply_accel = actuators.gas - actuators.brake
 


### PR DESCRIPTION
If the goal is to apply a +0.06 offset, then it would help if it wasn't applied as a -0.06 offset, as actuators.brake is a negative value.

Current implementation actually increases ABS pump usage, and braking by +0.06 (+6%)

This would also mean that the brakes are applied by 6% all of the time (0 - 0.06 = 0.06 (6%))

I'm in favor or just removing this offset completely. Could you explain why it was added? Stock OP doesn't offset the brakes (apply_accel = actuators.gas - actuators.brake)

@wocsor please review