### PR TITLE
Parameterized deadzone

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -350,6 +350,7 @@ struct CarParams {
     kiBP @2 :List(Float32);
     kiV @3 :List(Float32);
     kf @4 :Float32;
+    deadzone @5 :Float32;
   }
 
   struct LongitudinalPIDTuning {

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -61,6 +61,7 @@ class CarInterface(object):
     ret.lateralTuning.pid.kf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
     ret.steerActuatorDelay = 0.1
     ret.steerRateCost = 0.7
+    ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     if candidate in (CAR.JEEP_CHEROKEE, CAR.JEEP_CHEROKEE_2019):
       ret.wheelbase = 2.91  # in meters

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -62,6 +62,7 @@ class CarInterface(object):
     ret.steerRateCost = 1.0
     ret.centerToFront = ret.wheelbase * 0.44
     tire_stiffness_factor = 0.5328
+    ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter.

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -180,6 +180,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.54, 0.36]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
       stop_and_go = True
@@ -195,6 +196,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.ACURA_ILX:
       stop_and_go = False
@@ -208,6 +210,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.CRV:
       stop_and_go = False
@@ -221,6 +224,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.CRV_5G:
       stop_and_go = True
@@ -235,6 +239,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.CRV_HYBRID:
       stop_and_go = True
@@ -249,6 +254,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.ACURA_RDX:
       stop_and_go = False
@@ -262,6 +268,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.ODYSSEY:
       stop_and_go = False
@@ -275,6 +282,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.ODYSSEY_CHN:
       stop_and_go = False
@@ -288,6 +296,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate in (CAR.PILOT, CAR.PILOT_2019):
       stop_and_go = False
@@ -301,6 +310,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.RIDGELINE:
       stop_and_go = False
@@ -314,6 +324,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
       ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     else:
       raise ValueError("unsupported car %s" % candidate)

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -68,6 +68,7 @@ class CarInterface(object):
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[9., 22.], [9., 22.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.35], [0.05, 0.09]]
       ret.minSteerSpeed = 0.
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
     elif candidate == CAR.KIA_SORENTO:
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 1985. + STD_CARGO_KG
@@ -76,6 +77,7 @@ class CarInterface(object):
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
       ret.minSteerSpeed = 0.
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
     elif candidate == CAR.ELANTRA:
       ret.lateralTuning.pid.kf = 0.00006
       ret.mass = 1275. + STD_CARGO_KG
@@ -85,6 +87,7 @@ class CarInterface(object):
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
       ret.minSteerSpeed = 32 * CV.MPH_TO_MS
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
     elif candidate == CAR.GENESIS:
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 2060. + STD_CARGO_KG
@@ -93,6 +96,7 @@ class CarInterface(object):
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.16], [0.01]]
       ret.minSteerSpeed = 35 * CV.MPH_TO_MS
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
     elif candidate == CAR.KIA_OPTIMA:
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 3558. * CV.LB_TO_KG
@@ -101,6 +105,7 @@ class CarInterface(object):
       tire_stiffness_factor = 0.5
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
     elif candidate == CAR.KIA_STINGER:
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 1825. + STD_CARGO_KG
@@ -109,6 +114,7 @@ class CarInterface(object):
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
       ret.minSteerSpeed = 0.
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     ret.minEnableSpeed = -1.   # enable is done by stock ACC, so ignore this
     ret.longitudinalTuning.kpBP = [0.]

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -65,6 +65,7 @@ class CarInterface(object):
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
       ret.steerMaxBP = [0.] # m/s
       ret.steerMaxV = [1.]
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     ret.steerControlType = car.CarParams.SteerControlType.torque
     ret.steerRatioRear = 0.

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -116,6 +116,7 @@ class CarInterface(object):
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
       ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.LEXUS_RXH:
       stop_and_go = True
@@ -126,6 +127,7 @@ class CarInterface(object):
       ret.mass = 4481. * CV.LB_TO_KG + STD_CARGO_KG  # mean between min and max
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
       ret.lateralTuning.pid.kf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate in [CAR.CHR, CAR.CHRH]:
       stop_and_go = True
@@ -136,6 +138,7 @@ class CarInterface(object):
       ret.mass = 3300. * CV.LB_TO_KG + STD_CARGO_KG
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.723], [0.0428]]
       ret.lateralTuning.pid.kf = 0.00006
+      ret.lateralTuning.pid.deadzone = 0.056 # Torque angle sensor factor
 
     elif candidate in [CAR.CAMRY, CAR.CAMRYH]:
       stop_and_go = True
@@ -146,6 +149,7 @@ class CarInterface(object):
       ret.mass = 3400. * CV.LB_TO_KG + STD_CARGO_KG #mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
       ret.lateralTuning.pid.kf = 0.00006
+      ret.lateralTuning.pid.deadzone = 0.056 # Torque angle sensor factor
 
     elif candidate in [CAR.HIGHLANDER, CAR.HIGHLANDERH]:
       stop_and_go = True
@@ -156,6 +160,7 @@ class CarInterface(object):
       ret.mass = 4607. * CV.LB_TO_KG + STD_CARGO_KG #mean between normal and hybrid limited
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.18], [0.015]]  # community tuning
       ret.lateralTuning.pid.kf = 0.00012  # community tuning
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.AVALON:
       stop_and_go = False
@@ -166,6 +171,7 @@ class CarInterface(object):
       ret.mass = 3505. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.17], [0.03]]
       ret.lateralTuning.pid.kf = 0.00006
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     elif candidate == CAR.RAV4_TSS2:
       stop_and_go = True
@@ -176,6 +182,7 @@ class CarInterface(object):
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
       ret.mass = 3370. * CV.LB_TO_KG + STD_CARGO_KG
       ret.lateralTuning.pid.kf = 0.00007818594
+      ret.lateralTuning.pid.deadzone = 0.056 # Torque angle sensor factor
 
     elif candidate == CAR.COROLLA_TSS2:
       stop_and_go = True
@@ -186,6 +193,7 @@ class CarInterface(object):
       ret.mass = 3060. * CV.LB_TO_KG + STD_CARGO_KG
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
       ret.lateralTuning.pid.kf = 0.00007818594
+      ret.lateralTuning.pid.deadzone = 0.056 # Torque angle sensor factor
 
     elif candidate == CAR.LEXUS_ESH_TSS2:
       stop_and_go = True
@@ -196,6 +204,7 @@ class CarInterface(object):
       ret.mass = 3704. * CV.LB_TO_KG + STD_CARGO_KG
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
       ret.lateralTuning.pid.kf = 0.00007818594
+      ret.lateralTuning.pid.deadzone = 0.056 # Torque angle sensor factor
 
     elif candidate == CAR.SIENNA:
       stop_and_go = True
@@ -206,6 +215,7 @@ class CarInterface(object):
       ret.mass = 4590. * CV.LB_TO_KG + STD_CARGO_KG
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.05]]
       ret.lateralTuning.pid.kf = 0.00007818594
+      ret.lateralTuning.pid.deadzone = 0.0 # Unknown, check Cabana for steering angle factor
 
     ret.steerRateCost = 1.
     ret.centerToFront = ret.wheelbase * 0.44

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -34,7 +34,7 @@ class LatControlPID(object):
         # TODO: feedforward something based on path_plan.rateSteers
         steer_feedforward -= path_plan.angleOffset   # subtract the offset, since it does not contribute to resistive torque
         steer_feedforward *= v_ego**2  # proportional to realigning tire momentum (~ lateral accel)
-      deadzone = 0.0
+      deadzone = CP.lateralTuning.pid.deadzone
       output_steer = self.pid.update(self.angle_steers_des, angle_steers, check_saturation=(v_ego > 10), override=steer_override,
                                      feedforward=steer_feedforward, speed=v_ego, deadzone=deadzone)
       pid_log.active = True


### PR DESCRIPTION
PID Control is enhanced when an accurate deadzone is supplied per each model's steering angle sensor (signal factor) to reduce windup/noise.

This should be obvious, but just in case; PID will continue sending torque to achieve zero delta, which is not exactly possible when an imprecise sensor is used, such as TSS2/NO_DSU Toyotas with their 0.056 degree precise sensor.

This enhancement parameterizes PID's deadzone parameter, and should be easily settable per vehicle by looking at Cabana.

Note that in my testing, MPC's desired angle is usually several decimal places precise and even a small deadzone for vehicles with precise sensors (ZSS 0.005) will reduce PID/steering jitter (such as 0.01).

Put another way:

Regardless of what controls scheme is used, or car (INDI, PID, LQR) I've found that MPC's desired angle is usually several decimals precise (1.43456456) which isn't needed, as even the most precise sensor (Tesla) is 0.001 degrees precise. Obviously if you are trying to reach 0 delta (error), the desired angle should be in line with what can be sensed. Also, you don't really need more than 0.01 degree precision for accurate lat control for real world use cases. Anything else just creates noise.

I round both the desired angle for INDI and my 0.005 degree precise steering angle to two decimal places, for example, on my personal branch with good results.