### PR TITLE
pass in vTargetFuture for LoC.reset

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -238,7 +238,7 @@ def state_control(frame, rcv_frame, plan, path_plan, CS, CP, state, events, v_cr
 
   if state in [State.preEnabled, State.disabled]:
     LaC.reset()
-    LoC.reset(v_pid=CS.vEgo)
+    LoC.reset(v_pid=plan.vTargetFuture)
 
   elif state in [State.enabled, State.softDisabling]:
     # parse warnings from car specific interface


### PR DESCRIPTION
When engaging you need to press the gas. This causes an acceleration that is positive. 
Passing in v_ego causes the car to try and stop the acceleration shortly and so brake when enabling.
This should help the initial pid calculation to be possitive and not 0.