### PR TITLE
Angle offsets are a mess and broken, some sent as 0, like for Vehicle Model

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -442,7 +442,7 @@ struct ControlsState @0x97ff69c53601abf1 {
   alertSoundDEPRECATED @45 :Text;
   alertSound @56 :Car.CarControl.HUDControl.AudibleAlert;
   awarenessStatus @26 :Float32;
-  angleModelBias @27 :Float32;
+  angleModelBiasDEPRECATED @27 :Float32;
   gpsPlannerActive @40 :Bool;
   engageable @41 :Bool;  # can OP be engaged?
   driverMonitoringOn @43 :Bool;

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -350,7 +350,7 @@ def data_send(sm, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, rk, ca
     "vEgo": CS.vEgo,
     "vEgoRaw": CS.vEgoRaw,
     "angleSteers": CS.steeringAngle,
-    "curvature": VM.calc_curvature((CS.steeringAngle - sm['pathPlan'].angleOffset) * CV.DEG_TO_RAD, CS.vEgo),
+    "curvature": VM.calc_curvature((CS.steeringAngle) * CV.DEG_TO_RAD, CS.vEgo),
     "steerOverride": CS.steeringPressed,
     "state": state,
     "engageable": not bool(get_events(events, [ET.NO_ENTRY])),

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -54,8 +54,7 @@ class PathPlanner(object):
     angle_steers = sm['carState'].steeringAngle
     active = sm['controlsState'].active
 
-    angle_offset_average = sm['liveParameters'].angleOffsetAverage
-    angle_offset_bias = sm['controlsState'].angleModelBias + angle_offset_average
+    angle_offset = sm['liveParameters'].angleOffsetAverage
 
     self.LP.update(v_ego, sm['model'])
 
@@ -73,7 +72,7 @@ class PathPlanner(object):
     #   self.path_offset_i = 0.0
 
     # account for actuation delay
-    self.cur_state = calc_states_after_delay(self.cur_state, v_ego, angle_steers - angle_offset_average, curvature_factor, VM.sR, CP.steerActuatorDelay)
+    self.cur_state = calc_states_after_delay(self.cur_state, v_ego, angle_steers, curvature_factor, VM.sR, CP.steerActuatorDelay)
 
     v_ego_mpc = max(v_ego, 5.0)  # avoid mpc roughness due to low speed
     self.libmpc.run_mpc(self.cur_state, self.mpc_solution,
@@ -85,19 +84,19 @@ class PathPlanner(object):
       delta_desired = self.mpc_solution[0].delta[1]
       rate_desired = math.degrees(self.mpc_solution[0].rate[0] * VM.sR)
     else:
-      delta_desired = math.radians(angle_steers - angle_offset_bias) / VM.sR
+      delta_desired = math.radians(angle_steers - angle_offset) / VM.sR
       rate_desired = 0.0
 
     self.cur_state[0].delta = delta_desired
 
-    self.angle_steers_des_mpc = float(math.degrees(delta_desired * VM.sR) + angle_offset_bias)
+    self.angle_steers_des_mpc = float(math.degrees(delta_desired * VM.sR) + angle_offset)
 
     #  Check for infeasable MPC solution
     mpc_nans = np.any(np.isnan(list(self.mpc_solution[0].delta)))
     t = sec_since_boot()
     if mpc_nans:
       self.libmpc.init(MPC_COST_LAT.PATH, MPC_COST_LAT.LANE, MPC_COST_LAT.HEADING, CP.steerRateCost)
-      self.cur_state[0].delta = math.radians(angle_steers - angle_offset_bias) / VM.sR
+      self.cur_state[0].delta = math.radians(angle_steers) / VM.sR
 
       if t > self.last_cloudlog_t + 5.0:
         self.last_cloudlog_t = t
@@ -121,7 +120,7 @@ class PathPlanner(object):
 
     plan_send.pathPlan.angleSteers = float(self.angle_steers_des_mpc)
     plan_send.pathPlan.rateSteers = float(rate_desired)
-    plan_send.pathPlan.angleOffset = float(self.path_offset_i)
+    plan_send.pathPlan.angleOffset = float(angle_offset)
     plan_send.pathPlan.mpcSolutionValid = bool(plan_solution_valid)
     plan_send.pathPlan.paramsValid = bool(sm['liveParameters'].valid)
     plan_send.pathPlan.sensorValid = bool(sm['liveParameters'].sensorValid)


### PR DESCRIPTION
angleModelBias (def learn_angle_model_bias) was dropped from usage back in 5.11 or so, yet the bias variable remains. Also, your new `self.path_offset_i` is currently commented out and initialized as `0`, `plan_send.pathPlan.angleOffset = 0` is sent to vehicle model for calc curvature.

Looking at the blame for path planner, only these were offset since like 0.5.7 forever:
`delta_desired = math.radians(angle_steers - angle_offset) / CP.steerRatio
self.angle_steers_des_mpc = float(math.degrees(delta_desired * CP.steerRatio) + angle_offset)`

Didn't really make sense why `self.path_offset_i` is being worked on when `learn_angle_model_bias` did the same thing, and was already implemented with driver override, etc. Also doesn't make sense why you'd offset both the steering angle, and the desired angle.

@pd0wm @rbiasini maybe it's time for an audit of offsetting before the next version and get it cleaned up. These issues could be why there's been complaints of only oversteering in left/right hand curves, hugging, etc.

This is how angle offset used to be implemented:
https://github.com/commaai/openpilot/blame/be5c2aef3a043c5e84e1286cac8ceb750bdd176b/selfdrive/controls/lib/pathplanner.py#L53

On my 3,000 mile trip, ParamsLearner had a +2 degree offset. INDI oversteered, and oversteered more in left hand curves on 0.6.3, leading to this dumb code for acceptable cornering performance:

 if self.angle_steers_des > 0.5:
          self.angle_steers_des = round(path_plan.angleSteers / (interp(abs(path_plan.angleSteers), [0,10], [1.1, 1.2])), 2)
      elif self.angle_steers_des < -0.5:
          self.angle_steers_des = round(path_plan.angleSteers / (interp(abs(path_plan.angleSteers), [0,10], [1.0, 1.2])), 2)
      else:
          self.angle_steers_des = round(path_plan.angleSteers, 2)

Something is amiss :D