### PR TITLE
Update thermald to set ignition_seen back to False if Panda disconnected

### DIFF
--- a/selfdrive/thermald.py
+++ b/selfdrive/thermald.py
@@ -157,6 +157,7 @@ def thermald_thread():
     # clear car params when panda gets disconnected
     if health is None and health_prev is not None:
       params.panda_disconnect()
+      ignition_seen = False
     health_prev = health
 
     # loggerd is gated based on free space


### PR DESCRIPTION
Updates `thermald.py` to check for ignition via voltage, regardless of status of `ignition_seen`. Tested on my vehicle and now OP reliably fires up every time I unplug & replug the EON from Panda, while the car is on. No longer need to re-cycle the ignition or reboot the EON.

After this change, the `ignition_seen` variable seems redundant. Maybe the alternative fix is to set `ignition_seen` back to `False` when OP is shut down (ignition off)?