### PR TITLE
Allow to lock safety mode to keep gm/tesla cars supported

### DIFF
--- a/common/params.py
+++ b/common/params.py
@@ -80,6 +80,7 @@ keys = {
   "Passive": [TxType.PERSISTENT],
   "RecordFront": [TxType.PERSISTENT],
   "ReleaseNotes": [TxType.PERSISTENT],
+  "SafetyModelLock": [TxType.PERSISTENT],
   "ShouldDoUpdate": [TxType.CLEAR_ON_MANAGER_START],
   "SpeedLimitOffset": [TxType.PERSISTENT],
   "SubscriberInfo": [TxType.PERSISTENT],

--- a/selfdrive/car/lock_safety_model.py
+++ b/selfdrive/car/lock_safety_model.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import sys
+from cereal import car
+from common.params import Params
+
+# This script locks the safety model to a given value.
+# When the safety model is locked, boardd will preset panda to the locked safety model
+
+# run example:
+# ./lock_safety_model.py gm
+
+if __name__ == "__main__":
+
+  params = Params()
+
+  if len(sys.argv) < 2:
+    params.delete("SafetyModelLock")
+    print("Clear locked safety model")
+
+  else:
+    safety_model = getattr(car.CarParams.SafetyModel, sys.argv[1])
+    if type(safety_model) != int:
+      raise Exception("Invalid safety model: " + sys.argv[1])
+    if safety_model == car.CarParams.SafetyModel.allOutput:
+      raise Exception("Locking the safety model to allOutput is not allowed")
+    params.put("SafetyModelLock", str(safety_model))
+    print("Locked safety model: " + sys.argv[1])

--- a/selfdrive/thermald.py
+++ b/selfdrive/thermald.py
@@ -129,7 +129,6 @@ def thermald_thread():
 
   off_ts = None
   started_ts = None
-  ignition_seen = False
   started_seen = False
   thermal_status = ThermalStatus.green
   thermal_status_prev = ThermalStatus.green
@@ -151,7 +150,6 @@ def thermald_thread():
     # clear car params when panda gets disconnected
     if health is None and health_prev is not None:
       params.panda_disconnect()
-      ignition_seen = False
     health_prev = health
 
     if health is not None:
@@ -233,11 +231,6 @@ def thermald_thread():
 
     # start constellation of processes when the car starts
     ignition = health is not None and health.health.started
-    ignition_seen = ignition_seen or ignition
-
-    # add voltage check for ignition
-    if not ignition_seen and health is not None and health.health.voltage > 13500:
-      ignition = True
 
     do_uninstall = params.get("DoUninstall") == b"1"
     accepted_terms = params.get("HasAcceptedTerms") == terms_version


### PR DESCRIPTION
# Feature
Allow to lock safety mode to keep gm/tesla cars supported

## Description
Added a script to lock the safety mode. Example:
```
selfdrive/car/lock_safety_model.py gm
```
This script writes a parameter called `SafetyModelLock`. Boardd reads such parameter on usb_connect and immediately initializes panda to the safety model specified in the param.  