### PR TITLE
Fix for subaru 0.6.5 dashcam mode

### DIFF
--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -48,7 +48,7 @@ class CarInterface(CarInterfaceBase):
     ret.enableCruise = True
     ret.steerLimitAlert = True
 
-    ret.enableCamera = is_ecu_disconnected(fingerprint[0], FINGERPRINTS, ECU_FINGERPRINT, candidate, ECU.CAM) or has_relay
+    ret.enableCamera = True
 
     ret.steerRateCost = 0.7
 

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -48,6 +48,7 @@ class CarInterface(CarInterfaceBase):
     ret.enableCruise = True
     ret.steerLimitAlert = True
 
+    # always enable since Eyesight is not disconnected and LKAS can messages are always present in fingerprint
     ret.enableCamera = True
 
     ret.steerRateCost = 0.7


### PR DESCRIPTION
# Feature
This pull request fixes dashcam only mode for supported Subaru models in 0.6.5

## Description
sets enableCamera = True in interface.py since Eyesight is not disconnected and LKAS can messages are always present in fingerprint

## Testing
Tested with martinl subaru-giraffe-devel branch and Subaru XV 2018, pressing ACC set button engages openpilot now, like in previous versions
