### PR TITLE
2017 Toyota Corolla tuning (comma pedal)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,18 @@
 Choose one of the templates below:
 
 # Fingerprint
-This pull requests adds a fingerprint for <Make - Model - Year - Trim>.
+This pull request adds a fingerprint for <Make - Model - Year - Trim>.
 
 This is an explorer link to a drive with the stock system enabled: ...
 
 # Car support
-This pull requests adds support for <Make - Model - Year - Trim>.
+This pull request adds support for <Make - Model - Year - Trim>.
 
 This is an explorer link to a drive with the stock system enabled: ...
 This is an explorer link to a drive with openpilot system enabled: ...
 
 # Feature
-This pull requests adds feature X
+This pull request adds feature X
 
 ## Description
 Explain what the feature does

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -127,8 +127,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
       ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
       if ret.enableGasInterceptor:
-        ret.gasMaxBP = [0., 9., 35]
-        ret.gasMaxV = [0.2, 0.5, 0.7]
         ret.longitudinalTuning.kpV = [1.0, 0.66, 0.42]
         ret.longitudinalTuning.kiV = [0.135, 0.09]
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -55,6 +55,17 @@ class CarInterface(CarInterfaceBase):
 
     ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
 
+    if ret.enableGasInterceptor:
+      ret.gasMaxBP = [0., 9., 35]
+      ret.gasMaxV = [0.2, 0.5, 0.7]
+      ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
+      ret.longitudinalTuning.kiV = [0.18, 0.12]
+    else:
+      ret.gasMaxBP = [0.]
+      ret.gasMaxV = [0.5]
+      ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
+      ret.longitudinalTuning.kiV = [0.54, 0.36]
+
     if candidate not in [CAR.PRIUS, CAR.RAV4, CAR.RAV4H]: # These cars use LQR/INDI
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
@@ -110,11 +121,16 @@ class CarInterface(CarInterfaceBase):
       stop_and_go = False
       ret.safetyParam = 100
       ret.wheelbase = 2.70
-      ret.steerRatio = 18.27
+      ret.steerRatio = 17.8
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
       ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
+      if ret.enableGasInterceptor:
+        ret.gasMaxBP = [0., 9., 35]
+        ret.gasMaxV = [0.2, 0.5, 0.7]
+        ret.longitudinalTuning.kpV = [1.0, 0.66, 0.42]
+        ret.longitudinalTuning.kiV = [0.135, 0.09]
 
     elif candidate == CAR.LEXUS_RXH:
       stop_and_go = True
@@ -270,17 +286,6 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.kiBP = [0., 35.]
     ret.stoppingControl = False
     ret.startAccel = 0.0
-
-    if ret.enableGasInterceptor:
-      ret.gasMaxBP = [0., 9., 35]
-      ret.gasMaxV = [0.2, 0.5, 0.7]
-      ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
-      ret.longitudinalTuning.kiV = [0.18, 0.12]
-    else:
-      ret.gasMaxBP = [0.]
-      ret.gasMaxV = [0.5]
-      ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
-      ret.longitudinalTuning.kiV = [0.54, 0.36]
 
     return ret
 


### PR DESCRIPTION
# Tuning
This pull request updates the lateral steering ratio based off the official ratio for the 17 Corolla found here: https://www.socalpreowned.net/vehicle-details/2017-toyota-corolla-l-sedan-5e07d0f3d980184aa8c519977a67e0a9https://www.socalpreowned.net/vehicle-details/2017-toyota-corolla-l-sedan-5e07d0f3d980184aa8c519977a67e0a9

I also tuned longitudinal control for Corolla with pedal, as since the last few releases, openpilot will drive above the set speed by a few mph, then brake back down to under the set speed. It also gets unsafely close to lead vehicles, then brakes to back up on the highway, with the lead going a constant speed. Both behaviors repeat themselves in a loop.

## Description
Tuning for 2017 Corolla with comma pedal. Moved the section where the longitudinal values are initialized to the beginning of the car list so that we can specify custom tunes for vehicles that don't perform well on stock tuning. Also changed `This pull requests` to `This pull request` in the PR template file.

## Testing
Got to test this exact tune tonight a few minutes ago and it performed a lot better with these values. Now it doesn't overshoot the speed by up to 4 mph when there was no lead, it perfectly kept its set speed. Also better performance with leads, not getting too close like previously. With the old tuning, the car would delay braking (and even continue accelerating) when the lead was coming to a stop, so openpilot always mashed the brakes. Now it feels a lot smoother and starts braking slightly sooner.