### PR TITLE
WIP: Bugfix for Subaru Imperial-units dashboard and OP cruise speed mismatch

### DIFF
--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -118,8 +118,8 @@ class CarState():
     self.v_wheel_rr = cp.vl["Wheel_Speeds"]['RR'] * CV.KPH_TO_MS
 
     self.v_cruise_pcm = cp_cam.vl["ES_DashStatus"]['Cruise_Set_Speed']
-    # 1 = imperial, 6 = metric
-    if cp.vl["Dash_State"]['Units'] == 1:
+    # 0, 1 = imperial, 6 = metric
+    if cp.vl["Dash_State"]['Units'] in [0, 1]:
       self.v_cruise_pcm *= CV.MPH_TO_KPH
 
     v_wheel = (self.v_wheel_fl + self.v_wheel_fr + self.v_wheel_rl + self.v_wheel_rr) / 4.

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -119,7 +119,7 @@ class CarState():
 
     self.v_cruise_pcm = cp_cam.vl["ES_DashStatus"]['Cruise_Set_Speed']
     # 0, 1 = imperial, 6 = metric
-    if cp.vl["Dash_State"]['Units'] in [0, 1]:
+    if cp.vl["Dash_State"]['Units'] in [0, 1, 2]:
       self.v_cruise_pcm *= CV.MPH_TO_KPH
 
     v_wheel = (self.v_wheel_fl + self.v_wheel_fr + self.v_wheel_rl + self.v_wheel_rr) / 4.


### PR DESCRIPTION
Note: this is a work-in-progress - ongoing data gathering and discussion taking place in discord/subaru on the different values present for `Units` - and a test of the high bit may be the most appropriate solution. The data gathered so far indicates the high bit setting of `1` indicates metric, `0` indicates imperial.

This pull request fixes a bug observed on 2019 Subaru Crosstreks and other Subarus using Imperial units. These cars use Imperial units and set `Dash_State` field `Units` to `0` or `2`. The code adjusts the value of `v_cruise_pcm` for vehicles using Imperial units, but prior to this PR it only made this adjustment if Units was set to `1`. This updates this to also treat Units value `0`and a value of `2`  as Imperial.

My vehicle  (2019 Subaru Crosstrek) reports a value of `0`, and Bugsy has has a vehicle (2020 Outback Onyx XT) reporting a value of `2`.

Behavior prior to bugfix: A cruise set speed indicated on the vehicle dash of 40mph would appear as 25 on the EON (incorrectly displayed speed based on the assumption of a kph value).

Behavior after bugfix: Verified on vehicle - cruise set speed on dashboard and EON now agree.
