### PR TITLE
Fixes for various merge and refactoring fallout, typo fixes.

### DIFF
--- a/selfdrive/can/common.pxd
+++ b/selfdrive/can/common.pxd
@@ -17,7 +17,9 @@ cdef extern from "common.h":
     HONDA_COUNTER,
     TOYOTA_CHECKSUM,
     PEDAL_CHECKSUM,
-    PEDAL_COUNTER
+    PEDAL_COUNTER,
+    VOLKSWAGEN_CHECKSUM,
+    VOLKSWAGEN_COUNTER
 
   cdef struct Signal:
     const char* name

--- a/selfdrive/can/dbc_template.cc
+++ b/selfdrive/can/dbc_template.cc
@@ -25,7 +25,7 @@ const Signal sigs_{{address}}[] = {
       .type = SignalType::HONDA_COUNTER,
       {% elif checksum_type == "toyota" and sig.name == "CHECKSUM" %}
       .type = SignalType::TOYOTA_CHECKSUM,
-	  {% elif checksum_type == "volkswagen" and sig.name == "CHECKSUM" %}
+      {% elif checksum_type == "volkswagen" and sig.name == "CHECKSUM" %}
       .type = SignalType::VOLKSWAGEN_CHECKSUM,
       {% elif checksum_type == "volkswagen" and sig.name == "COUNTER" %}
       .type = SignalType::VOLKSWAGEN_COUNTER,

--- a/selfdrive/can/dbc_template.cc
+++ b/selfdrive/can/dbc_template.cc
@@ -25,7 +25,7 @@ const Signal sigs_{{address}}[] = {
       .type = SignalType::HONDA_COUNTER,
       {% elif checksum_type == "toyota" and sig.name == "CHECKSUM" %}
       .type = SignalType::TOYOTA_CHECKSUM,
-	    {% elif checksum_type == "volkswagen" and sig.name == "CHECKSUM" %}
+	  {% elif checksum_type == "volkswagen" and sig.name == "CHECKSUM" %}
       .type = SignalType::VOLKSWAGEN_CHECKSUM,
       {% elif checksum_type == "volkswagen" and sig.name == "COUNTER" %}
       .type = SignalType::VOLKSWAGEN_COUNTER,

--- a/selfdrive/can/parser.cc
+++ b/selfdrive/can/parser.cc
@@ -55,7 +55,6 @@ bool MessageState::parse(uint64_t sec, uint16_t ts_, uint8_t * dat) {
       }
     } else if (sig.type == SignalType::VOLKSWAGEN_COUNTER) {
         if (!update_counter_generic(tmp, sig.b2)) {
-        INFO("0x%X CHECKSUM FAIL\n", address);
         return false;
       }
     } else if (sig.type == SignalType::PEDAL_CHECKSUM) {
@@ -84,7 +83,7 @@ bool MessageState::update_counter_generic(int64_t v, int cnt_size) {
   if (((old_counter+1) & ((1 << cnt_size) -1)) != v) {
     counter_fail += 1;
     if (counter_fail > 1) {
-      INFO("%X COUNTER FAIL %d -- %d vs %d\n", address, counter_fail, old_counter, (int)v);
+      INFO("0x%X COUNTER FAIL %d -- %d vs %d\n", address, counter_fail, old_counter, (int)v);
     }
     if (counter_fail >= MAX_BAD_COUNTER) {
       return false;
@@ -125,7 +124,7 @@ CANParser::CANParser(int abus, const std::string& dbc_name,
       }
     }
     if (!msg) {
-      fprintf(stderr, "CANParser: could not find message 0x%X in dnc %s\n", op.address, dbc_name.c_str());
+      fprintf(stderr, "CANParser: could not find message 0x%X in DBC %s\n", op.address, dbc_name.c_str());
       assert(false);
     }
 
@@ -193,7 +192,7 @@ void CANParser::UpdateValid(uint64_t sec) {
     const auto& state = kv.second;
     if (state.check_threshold > 0 && (sec - state.seen) > state.check_threshold) {
       if (state.seen > 0) {
-        DEBUG("%X TIMEOUT\n", state.address);
+        DEBUG("0x%X TIMEOUT\n", state.address);
       }
       can_valid = false;
     }

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -181,7 +181,7 @@ class CarController():
         idx = (CS.graMsgBusCounter + 1) % 16
         can_sends.append(volkswagencan.create_mqb_acc_buttons_control(self.packer_gw, canbus.extended, self.graButtonStatesToSend, CS, idx))
         self.graMsgSentCount += 1
-        if self.graMsgSentCount >= 16:
+        if self.graMsgSentCount >= P.GRA_VBP_COUNT:
           self.graButtonStatesToSend = None
           self.graMsgSentCount = 0
 

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -51,13 +51,6 @@ FINGERPRINTS = {
   }],
 }
 
-class ECU:
-  CAM = 0
-
-ECU_FINGERPRINT = {
-  ECU.CAM: [294, 919],                    # HCA_01 Heading Control Assist, LDW_02 Lane Departure Warning
-}
-
 DBC = {
   CAR.GOLF: dbc_dict('vw_mqb_2010', None),
 }


### PR DESCRIPTION
# Cleanup
This pull request performs some minor cleanup of things lost-in-translation during the merge of Volkswagen MQB support and the simultaneous DBC code refactor.

* can/common.pxd: Add VOLKSWAGEN_CHECKSUM and VOLKSWAGEN_COUNTER for consistency with the other copies of the SignalType enum, although I can't find any ill effect from them being missing here.

* can/dbc_template.cc: Correct an indentation issue that crept in IDK when.

* can/parser.cc: Remove incorrect debug printf. Restore "0x" prefixing before debug error printfs, to clarify a hex rather than decimal address is being printed, and fix another typo.

* car/volkswagen/carcontroller.py: Make use of an existing, named param value rather than an undocumented constant.

* car/volkswagen/values.py: Discard objects that were only used for camera detection, which is not required on VW MQB and got removed from interface.py before upstream.

# Testing
Passes Docker testing here.