### PR TITLE
Fix grinding with Honda pedal + Civic specific pedal tuning

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -176,9 +176,9 @@ class CarInterface(CarInterfaceBase):
 
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.8], [0.24]]
       ret.longitudinalTuning.kpBP = [0., 5., 35.]
-      ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
+      ret.longitudinalTuning.kpV = [0.8, 0.56, 0.38] if ret.enableGasInterceptor else [3.6, 2.4, 1.5]
       ret.longitudinalTuning.kiBP = [0., 35.]
-      ret.longitudinalTuning.kiV = [0.54, 0.36]
+      ret.longitudinalTuning.kiV = [0.16, 0.11] if ret.enableGasInterceptor else [0.54, 0.36]
 
     elif candidate in (CAR.ACCORD, CAR.ACCORD_15, CAR.ACCORDH):
       stop_and_go = True
@@ -353,8 +353,13 @@ class CarInterface(CarInterfaceBase):
     ret.steerMaxBP = [0.]  # m/s
     ret.steerMaxV = [1.]   # max steer allowed
 
-    ret.gasMaxBP = [0.]  # m/s
-    ret.gasMaxV = [0.6] if ret.enableGasInterceptor else [0.] # max gas allowed
+    if ret.enableGasInterceptor:
+       ret.gasMaxBP = [0., 9., 35]
+       ret.gasMaxV = [0.2, 0.5, 0.7]
+    else:
+       ret.gasMaxBP = [0.]
+       ret.gasMaxV = [0.]
+
     ret.brakeMaxBP = [5., 20.]  # m/s
     ret.brakeMaxV = [1., 0.8]   # max brake allowed
 


### PR DESCRIPTION
This pull request solves 3 issues relating to the Honda Pedal.

### 1. Pedal fix discovered by @runchman
This change improves brake pump logic for Honda vehicles allowing for reduced stress on the brake pump. It also fixes the grinding noise found in many cars such as the Odyssey and Civic while using a Honda pedal during low speed braking. (under 15mph)

[Here's an example of the sound that is now fixed in my Civic.](https://www.youtube.com/watch?v=CrcZB59LmAc)

### 2. Gas breakpoints
The Toyota interface.py has code that greatly improves the pedal feel and greatly reduces the ability for the pedal to jerk the car unexpectedly at low speeds. This wasn't present in the Honda file, I've added this.

### 3. Civic specific tuning
The Civic needed pedal tuning more than any car due to the very high kpV compared to all other Honda cars. The stock values would make the car constantly floor the gas and slam the brakes until around ~20mph. The new values reduced that issue greatly.

I still do believe pedal tuning will still need some work in the future. It never seems to be as smooth as lets say a Toyota with full stop and go controlled by openpilot. I believe it may need the decoupling of gas and braking into two PI loops. Trying to tune the pedal to accel slower from 0 causes the brakes to be affected and for the car to not stop in time.
Another potential solution would be to allow tuning over the accel_max at low speeds. It seems no matter how low I make the PI loop, the pedal still finds a way to quickly rise to gasMaxV.

With that being said, this pull request turns the Civic pedal experience from being awful and dangerous to slightly jerky at low speeds but still a decent experience. I think for now this is the best we're going to get.

-VC 😀