### PR TITLE
Subaru Impreza 2018 tuning

### DIFF
--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -61,8 +61,8 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 15
       ret.steerActuatorDelay = 0.4   # end-to-end angle controller
       ret.lateralTuning.pid.kf = 0.00005
-      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
+      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 15.], [0., 15.]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.05, 0.25], [0.1, 0.05]]
       ret.steerMaxBP = [0.] # m/s
       ret.steerMaxV = [1.]
 


### PR DESCRIPTION
## Tuning
This pull request modifies the Subaru Impreza tuning values that were presumably placeholder values since Subaru support was added. The original values caused a lot of overshooting on bends, and unstable steering wobble at low speeds. For the most part (outside of some extreme edge cases), these issues have been solved with the tuning values specified.

## Description
An update to Subaru Impreza 2017-2019 (2020?) tuning that provide a smoother lateral control experience.

## Testing
Been monitoring and modifying these values through trial and error over the past few months and I've stuck with these values for the past month or so. Very happy with the results, as OP no longer overshoots on easy turns, and is a lot more stable when taking off from standstill, and steering at low speeds.
