### PR TITLE
Increase reaction time of planner

### DIFF
--- a/selfdrive/controls/lib/speed_smoother.py
+++ b/selfdrive/controls/lib/speed_smoother.py
@@ -18,9 +18,9 @@ def speed_smoother(vEgo, aEgo, vT, aMax, aMin, jMax, jMin, ts):
 
   # recover quickly if dV is positive and aEgo is negative or viceversa
   if dV > 0. and aEgo < 0.:
-    jMax *= 3.
+    jMax *= 10.
   elif dV < 0. and aEgo > 0.:
-    jMin *= 3.
+    jMin *= 5.
 
   tDelta = get_delta_out_limits(aEgo, aMax, aMin, jMax, jMin)
 


### PR DESCRIPTION
If a lead crosses our path open pilot will brake late and even when the lead is gone card on braking for the next few moments. This fix should increase the reaction time and not leave you braking when there is no lead.