### PR TITLE
Added flicker handling for blinkers in Subarus

### DIFF
--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -86,12 +86,18 @@ class CarState():
   def __init__(self, CP):
     # initialize can parser
     self.CP = CP
-
     self.car_fingerprint = CP.carFingerprint
+
     self.left_blinker_on = False
     self.prev_left_blinker_on = False
+    self.prev_left_blinker_light_on = False
+    self.left_blinker_interval = 0
+
     self.right_blinker_on = False
     self.prev_right_blinker_on = False
+    self.prev_right_blinker_light_on = False
+    self.right_blinker_interval = 0
+
     self.steer_torque_driver = 0
     self.steer_not_allowed = False
     self.main_on = False
@@ -134,10 +140,45 @@ class CarState():
     self.a_ego = float(v_ego_x[1])
     self.standstill = self.v_ego_raw < 0.01
 
+    ## Hacks required for blinkers because we don't have the blinker status itself,
+    ## we have only the dashlights, which flicker.
+
+    # Set previous states for BLINKER status (not the lights)
     self.prev_left_blinker_on = self.left_blinker_on
     self.prev_right_blinker_on = self.right_blinker_on
-    self.left_blinker_on = cp.vl["Dashlights"]['LEFT_BLINKER'] == 1
-    self.right_blinker_on = cp.vl["Dashlights"]['RIGHT_BLINKER'] == 1
+
+    temp_left_blinker_light_on = cp.vl["Dashlights"]['LEFT_BLINKER'] == 1
+    temp_right_blinker_light_on = cp.vl["Dashlights"]['RIGHT_BLINKER'] == 1
+
+    # Reset the timer when blinker state changes.
+    if temp_left_blinker_light_on != self.prev_left_blinker_light_on:
+      self.left_blinker_interval = 0
+      if temp_left_blinker_light_on:
+        self.left_blinker_on = True
+
+    if temp_right_blinker_light_on != self.prev_right_blinker_light_on:
+      self.right_blinker_interval = 0
+      if temp_right_blinker_light_on:
+        self.right_blinker_on = True
+
+    # Counts frames that blinker has been off, and if it's been off for 50+ frames, then reset the blinker state.
+    BLINKER_INTERVAL = 50
+    if self.left_blinker_interval < BLINKER_INTERVAL:
+      if not temp_left_blinker_light_on:
+        self.left_blinker_interval += 1
+    else:
+      self.left_blinker_on = False
+
+    if self.right_blinker_interval < BLINKER_INTERVAL:
+      if not temp_right_blinker_light_on:
+        self.right_blinker_interval += 1
+    else:
+      self.right_blinker_on = False
+
+    # Set previous states for blinker lights.
+    self.prev_left_blinker_light_on = temp_left_blinker_light_on
+    self.prev_right_blinker_light_on = temp_right_blinker_light_on
+
     self.seatbelt_unlatched = cp.vl["Dashlights"]['SEATBELT_FL'] == 1
     self.steer_torque_driver = cp.vl["Steering_Torque"]['Steer_Torque_Sensor']
     self.acc_active = cp.vl["CruiseControl"]['Cruise_Activated']


### PR DESCRIPTION
# Description
Testing the unreleased ALC feature revealed a flaw in the CarState values for the blinkers. The values for the blinkersare mapped to the Dashlights in the DBC, and this means that when the blinkers are activated, they flicker between True and False at the same rate that the blinkers "blink". 

This issue causes ALC to act strangely, having the lines disappear and reappear in accordance to the value of the blinkers in CarState.

My solution uses a counter that counts up to a certain threshold (50 atm, little longer than the blink rate, which is ~32) every frame with the counter resetting to 0 after every blinker light state change. After the threshold is hit, it then sets the indicator status to False. 

A few other cars may require a similar change if they do not have a constant value when the blinkers are activated.

# Testing
I've been running ALC for the past few hours, and it's been working. Print tests in tmux show good consistent results as well.