### PR TITLE
Safe Updater: Part Deux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ venv/
 .tags
 .ipynb_checkpoints
 .idea
+.overlay_canary
+.overlay_consistent
 .sconsign.dblite
 .vscode
 model2.png

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ venv/
 .tags
 .ipynb_checkpoints
 .idea
-.overlay_canary
+.overlay_init
 .overlay_consistent
 .sconsign.dblite
 .vscode

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -14,14 +14,6 @@ function launch {
   # Wifi scan
   wpa_cli IFNAME=wlan0 SCAN
 
-  # apply update
-  if [ "$(git rev-parse HEAD)" != "$(git rev-parse @{u})" ]; then
-    git reset --hard @{u} &&
-    git clean -xdf &&
-
-    exec "${BASH_SOURCE[0]}"
-  fi
-
   # no cpu rationing for now
   echo 0-3 > /dev/cpuset/background/cpus
   echo 0-3 > /dev/cpuset/system-background/cpus

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -6,13 +6,49 @@ export NUMEXPR_NUM_THREADS=1
 export OPENBLAS_NUM_THREADS=1
 export VECLIB_MAXIMUM_THREADS=1
 
+if [ -z "$BASEDIR" ]; then
+  BASEDIR="/data/openpilot"
+fi
+
 if [ -z "$PASSIVE" ]; then
   export PASSIVE="1"
 fi
 
+STAGING_ROOT="/data/safe_staging"
+
 function launch {
   # Wifi scan
   wpa_cli IFNAME=wlan0 SCAN
+
+  # Check to see if there's a valid overlay-based update available. Conditions
+  # are as follows:
+  #
+  # 1. The BASEDIR init file has to exist, with a newer modtime than anything in
+  #    the BASEDIR Git repo. This checks for local development work or the user
+  #    switching branches/forks, which should not be overwritten.
+  # 2. The FINALIZED consistent file has to exist, indicating there's an update
+  #    that completed successfully and synced to disk.
+
+  if [ -f "${BASEDIR}/.overlay_init" ]; then
+    find ${BASEDIR}/.git -newer ${BASEDIR}/.overlay_init | grep -q '.' 2> /dev/null
+    if [ $? -eq 0 ]; then
+      echo "${BASEDIR} has been modified, skipping overlay update installation"
+    else
+      if [ -f "${STAGING_ROOT}/finalized/.overlay_consistent" ]; then
+        echo "Valid overlay update found, installing"
+        LAUNCHER_LOCATION="${BASH_SOURCE[0]}"
+
+        mv $BASEDIR /data/safe_staging/old_openpilot
+        mv "${STAGING_ROOT}/finalized" $BASEDIR
+
+        # The mv changed our working directory to /data/safe_staging/old_openpilot
+        cd "${BASEDIR}"
+
+        echo "Restarting launch script ${LAUNCHER_LOCATION}"
+        exec "${LAUNCHER_LOCATION}"
+      fi
+    fi
+  fi
 
   # no cpu rationing for now
   echo 0-3 > /dev/cpuset/background/cpus

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -29,7 +29,7 @@ function launch {
   fi
 
   # Check for NEOS update
-  if [ $(< /VERSION) != "13" ]; then
+  if [ $(< /VERSION) != "14" ]; then
     if [ -f "$DIR/scripts/continue.sh" ]; then
       cp "$DIR/scripts/continue.sh" "/data/data/com.termux/files/continue.sh"
     fi

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -127,6 +127,9 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
   st = os.lstat(os.path.join(OVERLAY_MERGED, source_obj))
   target_obj = os.path.join(target_dir, source_obj)
 
+  # Debugging
+  print(f"dup_ovfs_object: source_obj ${source_obj} target_obj ${target_obj}")
+
   if S_ISREG(st[ST_MODE]):
     # Hardlink all regular files; ownership and permissions are shared.
     link(inode_map[st[ST_INO]], target_obj)

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -268,5 +268,5 @@ def main(gctx=None):
     wait_between_updates()
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22a98471092387401928740921983742
+  # Commit noise to test updates 22a9412341234123483742
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -140,7 +140,7 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
     if S_ISDIR(st[ST_MODE]):
       os.mkdir(os.path.join(FINALIZED, source_obj), S_IMODE(st[ST_MODE]))
     elif S_ISLNK(st[ST_MODE]):
-      os.symlink(os.readlink(source_obj), target_obj)
+      os.symlink(os.readlink(source_full_path), target_obj)
       os.chmod(target_obj, S_IMODE(st[ST_MODE]), follow_symlinks=False)
     else:
       # Ran into a FIFO, socket, etc. Should not happen in OP install dir.

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -276,5 +276,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283123asdfasdfasdfasdf37893
+  # Commit noise to test updates 9283123abvdbasjdlhfhgasdfjgyhsaasdf37893
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -275,5 +275,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22345213413413413412345243
+  # Commit noise to test updates 2234598723495729384712983742
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -169,10 +169,10 @@ def finalize_from_ovfs():
   os.mkdir(FINALIZED)
   for root, dirs, files in os.walk(OVERLAY_MERGED, topdown=True):
     for obj_name in dirs:
-      relative_path_name = os.path.relpath(os.path.join(root, obj_name), OVERLAY_MERGED)
+      relative_path_name = os.path.relpath(os.path.join(root, obj_name), FINALIZED)
       dup_ovfs_object(inode_map, relative_path_name, FINALIZED)
     for obj_name in files:
-      relative_path_name = os.path.relpath(os.path.join(root, obj_name), OVERLAY_MERGED)
+      relative_path_name = os.path.relpath(os.path.join(root, obj_name), FINALIZED)
       dup_ovfs_object(inode_map, relative_path_name, FINALIZED)
 
 def attempt_update():

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -236,6 +236,7 @@ def update_params(with_date=False, new_version=False):
 
 def main(gctx=None):
   overlay_init_done = False
+  signal_monitor = SignalHandler()
 
   if not os.geteuid() == 0:
     raise RuntimeError("updated must be launched as root!")
@@ -246,7 +247,7 @@ def main(gctx=None):
   except IOError:
     raise RuntimeError("couldn't get overlay lock; is another updated running?")
 
-  while SignalHandler.continue_running:
+  while signal_monitor.continue_running:
     time_wrong = datetime.datetime.now().year < 2019
     ping_failed = subprocess.call(["ping", "-W", "4", "-c", "1", "8.8.8.8"])
     if ping_failed or time_wrong:

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -1,57 +1,276 @@
 #!/usr/bin/env python3
 
-# simple service that waits for network access and tries to update every hour
+# Safe Update: A simple service that waits for network access and tries to
+# update every 10 minutes. It's intended to make the OP update process more
+# robust in the face of local Git repository or EON filesystem corruption.
+#
+# During normal operation, both onroad and offroad, the update process makes
+# no changes to the BASEDIR install of OP. All update attempts are performed
+# in a disposable staging area provided by OverlayFS.
+#
+# If an update succeeds, a flag is set, and the update is swapped in at the
+# next reboot. If an update is interrupted or otherwise fails, the OverlayFS
+# upper layer and metadata can be discarded before trying again.
+#
+# The swap on boot is triggered by /data/data/com.termux/files/continue.sh,
+# gated on the existence of $FINALIZED/.update_succeeded.
 
+# Short term roadmap:
+# FIXME: Handle case of Git being corrupt before we even start (cloudlog git fsck and then re-clone?)
+# (INPROG) FIXME: make sure updated is reentry safe (must be able to tolerate CLI invocation while running as daemon)
+# TODO: design change: need to finalize after reboot as part of the switch process, will fix several issues below
+# TODO: consider impact of SIGINT/SIGTERM and whether we should catch and dismount/finalize/etc?
+# TODO: explore doing git gc, and/or limited-depth clones
+
+# Long term roadmap:
+# TODO: test suite to compare merged-to-finalized, even though manual compare looks good now
+# TODO: scons prebuild the update, maybe from manager so it can run offroad-only and be interrupted at onroad
+# TODO: download any required NEOS update in the background
+
+
+import os
 import datetime
 import subprocess
+from stat import *  # FIXME: expand to specific imports to silence pylint
+import shutil
 import time
+import signal
+from pathlib import Path
+import fcntl
+from cffi import FFI
 
+from common.basedir import BASEDIR
 from common.params import Params
 from selfdrive.swaglog import cloudlog
 
+STAGING_ROOT = "/data/safe_staging"
+OVERLAY_LOCK = "/tmp/safe_staging_overlay.lock"
+
+OVERLAY_UPPER = os.path.join(STAGING_ROOT, "upper")
+OVERLAY_METADATA = os.path.join(STAGING_ROOT, "metadata")
+OVERLAY_MERGED = os.path.join(STAGING_ROOT, "merged")
+FINALIZED = os.path.join(STAGING_ROOT, "finalized")
+
 NICE_LOW_PRIORITY = ["nice", "-n", "19"]
-def main(gctx=None):
+SHORT = os.getenv("SHORT") is not None
+
+class SignalHandler:
+  continue_running = True  # Reset to False on receipt of SIGINT or SIGTERM
+
+  def __init__(self):
+    signal.signal(signal.SIGTERM, self.graceful_shutdown)
+    signal.signal(signal.SIGINT, self.graceful_shutdown)
+    signal.signal(signal.SIGHUP, self.update_now)
+
+  def graceful_shutdown(self, signum, frame):
+    cloudlog.info(f"caught {signal.Signals(signum).name}, graceful shutdown in progress")
+    self.continue_running = False
+
+  def update_now(self, signum, frame):
+    # Just returns, having interrupted the sleep() in wait_between_updates()
+    cloudlog.info(f"caught {signal.Signals(signum).name}, running update check immediately")
+
+# Workaround for the EON/termux build of Python having os.link removed.
+ffi = FFI()
+ffi.cdef("int link(const char *oldpath, const char *newpath);")
+libc = ffi.dlopen(None)
+
+# **** helper functions ****
+
+def wait_between_updates():
+  if SHORT:
+    time.sleep(10)
+  else:
+    time.sleep(60 * 10)
+
+def link(src, dest):
+  # Workaround for the EON/termux build of Python having os.link removed.
+  return libc.link(src.encode(), dest.encode())
+
+def run(cmd, cwd=None):
+  return subprocess.check_output(cmd, cwd=cwd, stderr=subprocess.STDOUT, encoding='utf8')
+
+# **** meaty functions ****
+
+def init_ovfs():
+  if os.path.ismount(OVERLAY_MERGED):
+    cloudlog.error("cleaning up stale overlay mount")
+    run(["umount", OVERLAY_MERGED])
+
+  cloudlog.info("preparing new staging area")
+  if os.path.isdir(STAGING_ROOT):
+    shutil.rmtree(STAGING_ROOT)
+
+  for dirname in [STAGING_ROOT, OVERLAY_UPPER, OVERLAY_METADATA, OVERLAY_MERGED, FINALIZED]:
+    os.mkdir(dirname, 0o755)
+  if not os.lstat(BASEDIR).st_dev == os.lstat(OVERLAY_MERGED).st_dev:
+    raise RuntimeError("base and overlay merge directories are on different filesystems; not valid for overlay FS!")
+
+  if os.path.isfile(os.path.join(BASEDIR, ".finalized_overlay_valid")):
+    os.remove(os.path.join(BASEDIR, ".finalized_overlay_valid"))
+
+  overlay_opts = f"lowerdir={BASEDIR},upperdir={OVERLAY_UPPER},workdir={OVERLAY_METADATA}"
+  run(["mount", "-t", "overlay", "-o", overlay_opts, "none", OVERLAY_MERGED])
+
+def inodes_in_tree(search_dir):
+  # Given a search root, produce a dictionary mapping of inodes to relative
+  # pathnames of regular files (no directories, symlinks, or special files).
+  inode_map = {}
+  os.chdir(search_dir)
+  for root, dirs, files in os.walk('.', topdown=True):
+    for file_name in files:
+      full_name = os.path.join(search_dir, root, file_name)
+      st = os.lstat(full_name)
+      if S_ISREG(st[ST_MODE]):
+        inode_map[st[ST_INO]] = full_name
+  return inode_map
+
+def dup_ovfs_object(inode_map, source_obj, target_dir):
+  # Given a relative pathname to copy, and a new target root, duplicate the
+  # source object in the target root, using hardlinks for regular files.
+
+  st = os.lstat(source_obj)
+  target_obj = os.path.join(target_dir, source_obj)
+
+  if S_ISREG(st[ST_MODE]):
+    # Hardlink all regular files; ownership and permissions are shared.
+    link(inode_map[st[ST_INO]], target_obj)
+  else:
+    # Recreate all directories and symlinks; copy ownership and permissions.
+    if S_ISDIR(st[ST_MODE]):
+      os.mkdir(os.path.join(FINALIZED, source_obj), S_IMODE(st[ST_MODE]))
+    elif S_ISLNK(st[ST_MODE]):
+      os.symlink(os.readlink(source_obj), target_obj)
+      os.chmod(target_obj, S_IMODE(st[ST_MODE]), follow_symlinks=False)
+    else:
+      # Ran into a FIFO, socket, etc. Should not happen in OP install dir.
+      # Ignore without copying for the time being; revisit later if needed.
+      pass
+    os.chown(target_obj, st[ST_UID], st[ST_GID], follow_symlinks=False)
+
+  # Sync target mtimes to the cached lstat() value from each source object.
+  # Restores shared inode mtimes after linking, fixes symlinks and dirs.
+  os.utime(target_obj, (st[ST_ATIME], st[ST_MTIME]), follow_symlinks=False)
+
+def finalize_from_ovfs():
+  # Take the current OverlayFS merged view and finalize a copy outside of
+  # OverlayFS, ready to be swapped-in at BASEDIR.
+  cloudlog.info("creating finalized version of the overlay")
+
+  # The "copy" is done with hardlinks, but since the OverlayFS merge looks
+  # like a different filesystem, and hardlinks can't cross filesystems, we
+  # have to borrow a source pathname from the upper or lower layer.
+  inode_map = inodes_in_tree(BASEDIR)
+  inode_map.update(inodes_in_tree(OVERLAY_UPPER))
+
+  shutil.rmtree(FINALIZED)
+  os.umask(0o077)
+  os.mkdir(FINALIZED)
+  os.chdir(OVERLAY_MERGED)
+  for root, dirs, files in os.walk('.', topdown=True):
+    for obj_name in dirs:
+      dup_ovfs_object(inode_map, os.path.join(root, obj_name), FINALIZED)
+    for obj_name in files:
+      dup_ovfs_object(inode_map, os.path.join(root, obj_name), FINALIZED)
+  os.chdir(BASEDIR)  # otherwise umount will fail later with "target is busy"
+
+def attempt_update():
+  cloudlog.info("attempting git update inside staging overlay")
+  os.chdir(OVERLAY_MERGED)
+
+  # Un-set the validity flag to prevent the finalized tree from being
+  # activated later if the update attempt is interrupted.
+  if os.path.isfile(os.path.join(FINALIZED, ".finalized_overlay_valid")):
+    os.remove(os.path.join(FINALIZED, ".finalized_overlay_valid"))
+  os.system("sync")
+
+  r = run(NICE_LOW_PRIORITY + ["git", "fetch"], OVERLAY_MERGED)
+  cloudlog.info("git fetch success: %s", r)
+
+  cur_hash = run(["git", "rev-parse", "HEAD"], OVERLAY_MERGED).rstrip()
+  upstream_hash = run(["git", "rev-parse", "@{u}"], OVERLAY_MERGED).rstrip()
+
+  cloudlog.info("comparing %s to %s" % (cur_hash, upstream_hash))
+  if cur_hash != upstream_hash:
+    cloudlog.info("git reset in progress")
+    r = [run(NICE_LOW_PRIORITY + ["git", "reset", "--hard", "@{u}"], OVERLAY_MERGED),
+         run(NICE_LOW_PRIORITY + ["git", "clean", "-xdf"], OVERLAY_MERGED),
+         run(NICE_LOW_PRIORITY + ["git", "submodule", "init"], OVERLAY_MERGED),
+         run(NICE_LOW_PRIORITY + ["git", "submodule", "update"], OVERLAY_MERGED)]
+    cloudlog.info("git reset success: %s", '\n'.join(r))
+    # TODO: scons prebuild
+    # TODO: NEOS background download
+    finalize_from_ovfs()
+    update_params(with_date=True, new_version=True)
+    cloudlog.info("update successful!")
+  else:
+    update_params(with_date=True, new_version=False)
+    cloudlog.info("nothing new from git at this time")
+
+  # Make sure the validity flag lands on disk LAST, only when the local git
+  # repo and OP install are in a consistent state.
+  os.system("sync")
+  Path(os.path.join(FINALIZED, ".finalized_overlay_valid")).touch()
+  os.system("sync")
+
+def update_params(with_date=False, new_version=False):
   params = Params()
-
-  while True:
-    time_wrong = datetime.datetime.now().year < 2019
-    ping_failed = subprocess.call(["ping", "-W", "4", "-c", "1", "8.8.8.8"])
-    if ping_failed or time_wrong:
-      time.sleep(60)
-      continue
-
-    # download application update
+  if new_version:
     try:
-      r = subprocess.check_output(NICE_LOW_PRIORITY + ["git", "fetch"], stderr=subprocess.STDOUT).decode('utf8')
-    except subprocess.CalledProcessError as e:
-      cloudlog.event("git fetch failed",
-        cmd=e.cmd,
-        output=e.output,
-        returncode=e.returncode)
-      time.sleep(60)
-      continue
-    cloudlog.info("git fetch success: %s", r)
-
-    # Write update available param
-    try:
-      cur_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).rstrip()
-      upstream_hash = subprocess.check_output(["git", "rev-parse", "@{u}"]).rstrip()
-      params.put("UpdateAvailable", str(int(cur_hash != upstream_hash)))
-    except:
-      params.put("UpdateAvailable", "0")
-
-    # Write latest release notes to param
-    try:
-      r = subprocess.check_output(["git", "--no-pager", "show", "@{u}:RELEASES.md"])
-      r = r[:r.find(b'\n\n')] # Slice latest release notes
+      with open(os.path.join(FINALIZED, "RELEASES.md"), "rb") as f:
+        r = f.read()
+      r = r[:r.find(b'\n\n')]  # Slice latest release notes
       params.put("ReleaseNotes", r + b"\n")
-    except:
+    except Exception:
       params.put("ReleaseNotes", "")
+    params.put("UpdateAvailable", "1")
+  else:
+    params.put("UpdateAvailable", "0")
 
+  if with_date:
     t = datetime.datetime.now().isoformat()
     params.put("LastUpdateTime", t.encode('utf8'))
 
-    time.sleep(60*60)
+# **** main loop ****
+
+def main(gctx=None):
+  if not os.geteuid() == 0:
+    raise RuntimeError("updated must be launched as root!")
+
+  ov_lock_fd = open(OVERLAY_LOCK, 'r')
+  try:
+    fcntl.flock(ov_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    init_ovfs()
+  except IOError:
+    raise RuntimeError("couldn't get overlay lock; is another updated running?")
+
+  update_params()
+
+  while SignalHandler.continue_running:
+    time_wrong = datetime.datetime.now().year < 2019
+    ping_failed = subprocess.call(["ping", "-W", "4", "-c", "1", "8.8.8.8"])
+    if ping_failed or time_wrong:
+      wait_between_updates()
+      continue
+
+    try:
+      attempt_update()
+    except subprocess.CalledProcessError as e:
+      cloudlog.event("update process failed",
+        cmd=e.cmd,
+        output=e.output,
+        returncode=e.returncode)
+      return False
+    except Exception:
+      cloudlog.exception("uncaught updated exception, shouldn't happen")
+
+    wait_between_updates()
+
+  # SignalHandler caught SIGINT or SIGTERM
+  run(["umount", OVERLAY_MERGED])
+  cloudlog.info("graceful shutdown complete!")
+
 
 if __name__ == "__main__":
+  # Commit noise to test updates 9283597823atrsfdw324323e1y
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -278,5 +278,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283123412341234237893
+  # Commit noise to test updates 9283123asdfasdfasdfasdf37893
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -293,5 +293,5 @@ def main(gctx=None):
   sys.exit(0)
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22a94112341234123412432
+  # Commit noise to test updates 22a9975826tweryweior2
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -117,9 +117,7 @@ def inodes_in_tree(search_dir):
       full_path_name = os.path.join(root, file_name)
       st = os.lstat(full_path_name)
       if S_ISREG(st[ST_MODE]):
-        # Debugging
-        print(f"adding to inode tree: {st[ST_INO]} - {os.path.relpath(full_path_name, search_dir)}")
-        inode_map[st[ST_INO]] = os.path.relpath(full_path_name, search_dir)
+        inode_map[st[ST_INO]] = full_path_name
   return inode_map
 
 def dup_ovfs_object(inode_map, source_obj, target_dir):

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -173,9 +173,6 @@ def finalize_from_ovfs():
 def attempt_update():
   cloudlog.info("attempting git update inside staging overlay")
 
-  # If this is our first run
-  if os.path.isfile(os.path.join(BASEDIR, ".overlay_consistent")):
-
   # Un-set the validity flag to prevent the finalized tree from being
   # activated later if the update attempt is interrupted.
   if os.path.isfile(os.path.join(FINALIZED, ".overlay_consistent")):

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -274,5 +274,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 223452345234523452345243
+  # Commit noise to test updates 22345213413413413412345243
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -54,12 +54,12 @@ class SignalHandler:
     signal.signal(signal.SIGHUP, self.update_now)
 
   def graceful_shutdown(self, signum, frame):
-    cloudlog.info(f"caught {signal.Signals(signum).name}, graceful shutdown in progress")
+    cloudlog.info(f"caught SIGINT/SIGTERM, graceful shutdown in progress")
     self.continue_running = False
 
   def update_now(self, signum, frame):
     # Just returns, having interrupted the sleep() in wait_between_updates()
-    cloudlog.info(f"caught {signal.Signals(signum).name}, running update check immediately")
+    cloudlog.info(f"caught SIGHUP, running update check immediately")
 
 # Workaround for the EON/termux build of Python having os.link removed.
 ffi = FFI()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -275,5 +275,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22345943213413242983742
+  # Commit noise to test updates 22aiwu4ytiuawyeihas;oedfhjas983742
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -75,12 +75,12 @@ libc = ffi.dlopen(None)
 
 # **** helper functions ****
 
-def wait_between_updates(wait_helper):
-  wait_helper.ready_event.clear()
+def wait_between_updates(ready_event):
+  ready_event.clear()
   if SHORT:
-    wait_helper.wait(timeout=10)
+    ready_event.wait(timeout=10)
   else:
-    wait_helper.wait(timeout=60*10)
+    ready_event.wait(timeout=60*10)
 
 def link(src, dest):
   # Workaround for the EON/termux build of Python having os.link removed.

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -76,6 +76,7 @@ libc = ffi.dlopen(None)
 # **** helper functions ****
 
 def wait_between_updates(wait_helper):
+  wait_helper.ready_event.clear()
   if SHORT:
     wait_helper.wait(timeout=10)
   else:

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -199,7 +199,7 @@ def attempt_update():
     cloudlog.info("git reset success: %s", '\n'.join(r))
     # TODO: scons prebuild in background (offroad only, preferably interruptible if ignition comes on)
     # TODO: NEOS download in background (can and probably should do this outside the overlay)
-    # finalize_from_ovfs()
+    finalize_from_ovfs()
     update_params(with_date=True, new_version=True)
     cloudlog.info("update successful!")
   else:
@@ -270,9 +270,6 @@ def main(gctx=None):
       cloudlog.exception("uncaught updated exception, shouldn't happen")
 
     wait_between_updates()
-
-  # SignalHandler caught SIGINT or SIGTERM
-
 
 if __name__ == "__main__":
   # Commit noise to test updates 22aiwu4ytiuawyeihas;oedfhjas983742

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -293,5 +293,5 @@ def main(gctx=None):
   sys.exit(0)
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22a9975826tweryweior2
+  # Commit noise to test updates 225987612340964598793472or2
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -52,8 +52,8 @@ class SignalHandler:
     signal.signal(signal.SIGHUP, self.update_now)
 
   def graceful_shutdown(self, signum, frame):
-    cloudlog.info(f"caught SIGINT/SIGTERM, dismounting overlay")
-    run(["umount", "-f", OVERLAY_MERGED])
+    # cloudlog.info(f"caught SIGINT/SIGTERM, dismounting overlay")
+    # run(["umount", "-f", OVERLAY_MERGED])
     sys.exit(0)
 
   def update_now(self, signum, frame):

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -287,5 +287,5 @@ def main(gctx=None):
   sys.exit(0)
 
 if __name__ == "__main__":
-  # Commit noise to test updates 225987612340964598793472or2
+  # Commit noise to test updates 2259945872394857234978472or2
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -234,7 +234,7 @@ def main(gctx=None):
   if not os.geteuid() == 0:
     raise RuntimeError("updated must be launched as root!")
 
-  ov_lock_fd = open(OVERLAY_LOCK, 'r')
+  ov_lock_fd = open(OVERLAY_LOCK, 'w')
   try:
     fcntl.flock(ov_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
   except IOError:

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -276,5 +276,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 928323453424234234233
+  # Commit noise to test updates 9283234534242 asdfasdfa sdfasd
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -276,5 +276,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283234532234234234233
+  # Commit noise to test updates 9283234534234234234233
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -275,5 +275,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 928323453224322343
+  # Commit noise to test updates 9283234532234234234233
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -270,5 +270,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283597823atrsfdw3243225322q3e432
+  # Commit noise to test updates 928323453225322q3e432
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -268,5 +268,5 @@ def main(gctx=None):
     wait_between_updates()
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22a9412341234123483742
+  # Commit noise to test updates 22a94112341234123412432
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -124,7 +124,7 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
   # Given a relative pathname to copy, and a new target root, duplicate the
   # source object in the target root, using hardlinks for regular files.
 
-  st = os.lstat(source_obj)
+  st = os.lstat(os.path.join(OVERLAY_MERGED, source_obj))
   target_obj = os.path.join(target_dir, source_obj)
 
   if S_ISREG(st[ST_MODE]):

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -288,5 +288,5 @@ def main(gctx=None):
   dismount_ovfs()
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22599123412341234123413241232or2
+  # Commit noise to test updates 22599141230740192834232or2
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -274,5 +274,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9292r4uwef37893
+  # Commit noise to test updates 223452345234523452345243
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -131,7 +131,7 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
   target_obj = os.path.join(target_dir, source_obj)
 
   # Debugging
-  print(f"dup_ovfs_object: source_obj {source_obj} target_obj {target_obj}")
+  print(f"dup_ovfs_object: source_obj {source_obj} target_dir {target_dir} target_obj {target_obj}")
 
   if S_ISREG(st[ST_MODE]):
     # Hardlink all regular files; ownership and permissions are shared.
@@ -169,10 +169,10 @@ def finalize_from_ovfs():
   os.mkdir(FINALIZED)
   for root, dirs, files in os.walk(OVERLAY_MERGED, topdown=True):
     for obj_name in dirs:
-      relative_path_name = os.path.relpath(os.path.join(root, obj_name), FINALIZED)
+      relative_path_name = os.path.relpath(os.path.join(root, obj_name), OVERLAY_MERGED)
       dup_ovfs_object(inode_map, relative_path_name, FINALIZED)
     for obj_name in files:
-      relative_path_name = os.path.relpath(os.path.join(root, obj_name), FINALIZED)
+      relative_path_name = os.path.relpath(os.path.join(root, obj_name), OVERLAY_MERGED)
       dup_ovfs_object(inode_map, relative_path_name, FINALIZED)
 
 def attempt_update():

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -35,7 +35,6 @@ from common.params import Params
 from selfdrive.swaglog import cloudlog
 
 STAGING_ROOT = "/data/safe_staging"
-OVERLAY_LOCK = "/tmp/safe_staging_overlay.lock"
 
 OVERLAY_UPPER = os.path.join(STAGING_ROOT, "upper")
 OVERLAY_METADATA = os.path.join(STAGING_ROOT, "metadata")
@@ -234,7 +233,7 @@ def main(gctx=None):
   if not os.geteuid() == 0:
     raise RuntimeError("updated must be launched as root!")
 
-  ov_lock_fd = open(OVERLAY_LOCK, 'w')
+  ov_lock_fd = open('/tmp/safe_staging_overlay.lock', 'w')
   try:
     fcntl.flock(ov_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
   except IOError:
@@ -271,5 +270,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283597823atrsfdw324323e1y
+  # Commit noise to test updates 9283597823atrsfdw3243225322q3e432
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -273,5 +273,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 928323453225322q3e432
+  # Commit noise to test updates 92832345322523423432
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -277,5 +277,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283242978789327893
+  # Commit noise to test updates 9283123412341234237893
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -273,5 +273,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 92832345322523423432
+  # Commit noise to test updates 928323453224322343
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -126,7 +126,8 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
   # Given a relative pathname to copy, and a new target root, duplicate the
   # source object in the target root, using hardlinks for regular files.
 
-  st = os.lstat(os.path.join(OVERLAY_MERGED, source_obj))
+  source_obj = os.path.join(OVERLAY_MERGED, source_obj)
+  st = os.lstat(source_obj)
   target_obj = os.path.join(target_dir, source_obj)
 
   # Debugging

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -276,5 +276,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283234534234234234233
+  # Commit noise to test updates 92832345342423423423423423423
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -16,7 +16,7 @@
 #
 # The swap on boot is triggered by /data/data/com.termux/files/continue.sh,
 # gated on the existence of $FINALIZED/.overlay_consistent and also the
-# existence and mtime of $BASEDIR/.overlay_canary.
+# existence and mtime of $BASEDIR/.overlay_init.
 #
 # Other than build byproducts, BASEDIR should not be modified while this
 # service is running. Developers modifying code directly in BASEDIR should
@@ -118,11 +118,11 @@ def init_ovfs():
   run(["git", "config", "core.trustctime", "false"], BASEDIR)
 
   # Leave a timestamped canary in BASEDIR to check at startup. The EON clock
-  # should be correct by the time we get here. If the canary disappears, or
-  # critical mtimes in BASEDIR are newer than the canary, continue.sh assumes
-  # that BASEDIR is being modified or used for local development, and discards
-  # the overlay.
-  Path(os.path.join(BASEDIR, ".overlay_canary")).touch()
+  # should be correct by the time we get here. If the init file disappears, or
+  # critical mtimes in BASEDIR are newer than .overlay_init, continue.sh can
+  # assume that BASEDIR has used for local development or otherwise modified,
+  # and skips the update activation attempt.
+  Path(os.path.join(BASEDIR, ".overlay_init")).touch()
 
   overlay_opts = f"lowerdir={BASEDIR},upperdir={OVERLAY_UPPER},workdir={OVERLAY_METADATA}"
   run(["mount", "-t", "overlay", "-o", overlay_opts, "none", OVERLAY_MERGED])

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -135,6 +135,7 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
 
   if S_ISREG(st[ST_MODE]):
     # Hardlink all regular files; ownership and permissions are shared.
+    print(f"stat inode to look up: {st[ST_INO]} result: {inode_map[st[ST_INO]]}")
     link(inode_map[st[ST_INO]], target_obj)
   else:
     # Recreate all directories and symlinks; copy ownership and permissions.

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -131,7 +131,7 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
   target_obj = os.path.join(target_dir, source_obj)
 
   # Debugging
-  print(f"dup_ovfs_object: source_obj {source_obj} target_dir {target_dir} target_obj {target_obj}")
+  print(f"dup_ovfs_object: source_obj {source_obj} source_full_path {source_full_path} target_dir {target_dir} target_obj {target_obj}")
 
   if S_ISREG(st[ST_MODE]):
     # Hardlink all regular files; ownership and permissions are shared.

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -275,5 +275,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 2234598723495729384712983742
+  # Commit noise to test updates 22345943213413242983742
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -23,7 +23,6 @@
 # disable this service.
 
 import os
-import sys
 import datetime
 import subprocess
 from stat import S_ISREG, S_ISDIR, S_ISLNK, S_IMODE, ST_MODE, ST_INO, ST_UID, ST_GID, ST_ATIME, ST_MTIME

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -276,5 +276,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 928323454iu8tywakdhfra;wue;7d
+  # Commit noise to test updates 9283242978789327893
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -272,5 +272,5 @@ def main(gctx=None):
     wait_between_updates()
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22aiwu4ytiuawyeihas;oedfhjas983742
+  # Commit noise to test updates 22a98471092387401928740921983742
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -274,5 +274,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283123abvdbasjdlhfhgasdfjgyhsaasdf37893
+  # Commit noise to test updates 9283asda sasdasdfad gyhsaasdf37893
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -276,5 +276,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283234534242 asdfasdfa sdfasd
+  # Commit noise to test updates 928323454iu8tywakdhfra;wue;7d
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -117,6 +117,8 @@ def inodes_in_tree(search_dir):
       full_path_name = os.path.join(root, file_name)
       st = os.lstat(full_path_name)
       if S_ISREG(st[ST_MODE]):
+        # Debugging
+        print(f"adding to inode tree: {st[ST_INO]} - {os.path.relpath(full_path_name, search_dir)}")
         inode_map[st[ST_INO]] = os.path.relpath(full_path_name, search_dir)
   return inode_map
 
@@ -128,7 +130,7 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
   target_obj = os.path.join(target_dir, source_obj)
 
   # Debugging
-  print(f"dup_ovfs_object: source_obj ${source_obj} target_obj ${target_obj}")
+  print(f"dup_ovfs_object: source_obj {source_obj} target_obj {target_obj}")
 
   if S_ISREG(st[ST_MODE]):
     # Hardlink all regular files; ownership and permissions are shared.

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -288,5 +288,5 @@ def main(gctx=None):
   dismount_ovfs()
 
 if __name__ == "__main__":
-  # Commit noise to test updates 2259945872394857234978472or2
+  # Commit noise to test updates 22599123412341234123413241232or2
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -126,8 +126,8 @@ def dup_ovfs_object(inode_map, source_obj, target_dir):
   # Given a relative pathname to copy, and a new target root, duplicate the
   # source object in the target root, using hardlinks for regular files.
 
-  source_obj = os.path.join(OVERLAY_MERGED, source_obj)
-  st = os.lstat(source_obj)
+  source_full_path = os.path.join(OVERLAY_MERGED, source_obj)
+  st = os.lstat(source_full_path)
   target_obj = os.path.join(target_dir, source_obj)
 
   # Debugging

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -287,5 +287,4 @@ def main(gctx=None):
   dismount_ovfs()
 
 if __name__ == "__main__":
-  # Commit noise to test updates 22599141230740192834232or2
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -276,5 +276,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 92832345342423423423423423423
+  # Commit noise to test updates 928323453424234234233
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -274,5 +274,5 @@ def main(gctx=None):
 
 
 if __name__ == "__main__":
-  # Commit noise to test updates 9283asda sasdasdfad gyhsaasdf37893
+  # Commit noise to test updates 9292r4uwef37893
   main()

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -199,7 +199,7 @@ def attempt_update():
     cloudlog.info("git reset success: %s", '\n'.join(r))
     # TODO: scons prebuild in background (offroad only, preferably interruptible if ignition comes on)
     # TODO: NEOS download in background (can and probably should do this outside the overlay)
-    finalize_from_ovfs()
+    # finalize_from_ovfs()
     update_params(with_date=True, new_version=True)
     cloudlog.info("update successful!")
   else:

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -99,6 +99,13 @@ def init_ovfs():
   if os.path.isfile(os.path.join(BASEDIR, ".overlay_consistent")):
     os.remove(os.path.join(BASEDIR, ".overlay_consistent"))
 
+  # We sync FS object atimes (which EON doesn't use) and mtimes, but ctimes
+  # are outside user control. Make sure Git is set up to ignore system ctimes,
+  # because they change when we make hard links during finalize. Otherwise,
+  # there is a lot of unnecessary churn. This appears to be a common need on
+  # OSX as well: https://www.git-tower.com/blog/make-git-rebase-safe-on-osx/
+  run(["git", "config", "core.trustctime", "false"], BASEDIR)
+
   # Leave a timestamped canary in BASEDIR to check at startup. If the canary
   # disappears, or critical mtimes in BASEDIR are newer than the canary,
   # continue.sh assumes that BASEDIR is being modified or used for local

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -256,6 +256,7 @@ def main(gctx=None):
       # Wait until we have a valid datetime to initialize the overlay
       if not overlay_init_done:
         init_ovfs()
+        overlay_init_done = True
 
       attempt_update()
 


### PR DESCRIPTION
# Feature
This is a revised and tested version of the safe updater I've been working on with @rbiasini and @pd0wm. It should be pretty robust in the face of typical crash or power failure situations, most stupid user tricks, and even a couple smart user tricks.

I believe this incorporates all the feedback from Willem on the last round #909. I was able to solve the finalize problem without pushing it off to next bootup.

# Validation
* Works for me
* Does not break the Docker build
* Absolutely noCamelCaseWhatSoEver

I don't know that I can perform overlay mounts in Docker containers and cloud CI services, but if you want, I can write up some unit tests that exercise the rest of the tree copy-by-hardlink operation.

Per our discussion a couple weeks ago, Comma can and should test this using their own EONs to explore failure scenarios I don't have available to test here. I also expect you'll need to tweak the continue.sh part for your internal needs.

# Extra Requirements
* NEOS 14 with OverlayFS in the kernel, commaai/android_kernel_comma_msm8996#2
* Update to continue.sh, wherever that comes from... the installer? NEOS userland? Pasted below.

```
#!/usr/bin/env bash

BASEDIR="/data/openpilot"
STAGING_ROOT="/data/safe_staging"

# Check to see if there's a valid overlay-based update available. Conditions
# are as follows:
#
# 1. The BASEDIR init file has to exist, with a newer modtime than anything in
#    the BASEDIR Git repo. This checks for local development work or the user
#    switching branches/forks, which should not be overwritten.
# 2. The FINALIZED consistent file has to exist, indicating there's an update
#    that completed successfully and synced to disk.

if [ -f "${BASEDIR}/.overlay_init" ]; then
  find ${BASEDIR}/.git -newer ${BASEDIR}/.overlay_init | grep -q '.' 2> /dev/null
  if [ $? -eq 0 ]; then
    echo "${BASEDIR} has been modified, skipping overlay update installation"
  else
    if [ -f "${STAGING_ROOT}/finalized/.overlay_consistent" ]; then
      echo "Valid overlay update found, installing"
      mv $BASEDIR /data/safe_staging/old_openpilot
      mv "${STAGING_ROOT}/finalized" $BASEDIR
    else
      echo "No valid overlay update found, skipping overlay update installation"
    fi
  fi
else
  echo "No update performed or ${BASEDIR} has been modified, skipping overlay update installation"
fi

cd /data/openpilot
exec ./launch_openpilot.sh
```