### PR TITLE
GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,14 +46,14 @@ jobs:
         run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
       - name: Run unit tests
         run: |
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover common"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover opendbc/can"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/boardd"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/controls"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/loggerd"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/car"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/locationd"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/athena"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover common"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover opendbc/can"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/boardd"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/controls"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/loggerd"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/car"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/locationd"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/athena"
 
   process_replay:
     name: process replay

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,39 +11,47 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-    - run: pwd && docker build -t tmppilot -f Dockerfile.openpilot .
+    - run: |
+        docker build -t tmppilot -f Dockerfile.openpilot .
+        docker save tmppilot:latest | gzip > tmppilot.tar.gz
     - uses: actions/upload-artifact@v1
       with:
-        name: tmppilot
-        path: tmppilot
+        name: tmppilot.tar.gz
+        path: tmppilot.tar.gz
 
   linter:
     name: linter
     runs-on: ubuntu-16.04
     needs: build
     steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: tmppilot
-    - name: flake8
-      run:
-        docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_opepnilot.sh"
-    - name: pylint
-      run:
-        docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./pylint.sh"
+      - uses: actions/download-artifact@v1
+        with:
+          name: tmppilot.tar.gz
+      - name: Load image
+        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+      - name: flake8
+        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_openilot.sh"
+      - name: pylint
+        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./pylint.sh"
 
-  unit_tests:
-    name: unit tests
-    runs-on: ubuntu-16.04
-    needs: linter
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: tmppilot
-    - run:
-        docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_opepnilot.sh"
-
-
-
-
+#  unit_tests:
+#    name: unit tests
+#    runs-on: ubuntu-16.04
+#    needs: build
+#    - uses: actions/download-artifact@v1
+#      with:
+#        name: tmppilot.tar.gz
+#    - run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+#    container: tmppilot
+#    steps:
+#      - run: |
+#          cd /tmp/openpilot
+#
+#          python -m unittest discover common
+#          python -m unittest discover opendbc/can
+#          python -m unittest discover selfdrive/boardd
+#          python -m unittest discover selfdrive/controls
+#          python -m unittest discover selfdrive/loggerd
+#          python -m unittest discover selfdrive/car
+#          python -m unittest discover selfdrive/locationd
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: test
+name: tests
 on: [push, pull_request]
 
 env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -30,28 +30,28 @@ jobs:
       - name: Load image
         run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
       - name: flake8
-        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_openilot.sh"
+        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_openpilot.sh"
       - name: pylint
         run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./pylint.sh"
 
-#  unit_tests:
-#    name: unit tests
-#    runs-on: ubuntu-16.04
-#    needs: build
-#    - uses: actions/download-artifact@v1
-#      with:
-#        name: tmppilot.tar.gz
-#    - run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
-#    container: tmppilot
-#    steps:
-#      - run: |
-#          cd /tmp/openpilot
-#
-#          python -m unittest discover common
-#          python -m unittest discover opendbc/can
-#          python -m unittest discover selfdrive/boardd
-#          python -m unittest discover selfdrive/controls
-#          python -m unittest discover selfdrive/loggerd
-#          python -m unittest discover selfdrive/car
-#          python -m unittest discover selfdrive/locationd
+  unit_tests:
+    name: unit tests
+    runs-on: ubuntu-16.04
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: tmppilot.tar.gz
+      - name: Load image
+        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+      - name: Run unit tests
+        run: |
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover common"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover opendbc/can"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/boardd"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/controls"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/loggerd"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/car"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/locationd"
+          docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/athena"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,8 @@
+name: test
 on: [push, pull_request]
 
 env:
   RUN: docker run --shm-size 1G --rm tmppilot /bin/sh -c
-  RUN_NO_RM: 
   LOAD: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
   UNIT_TEST: cd /tmp/openpilot && python -m unittest discover
 
@@ -82,19 +82,6 @@ jobs:
           name: process_replay_diff.txt
           path: diff.txt
 
-  test_car_models:
-    name: test car models
-    runs-on: ubuntu-16.04
-    needs: build
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: tmppilot.tar.gz
-      - name: Load image
-        run: $LOAD
-      - name: Test car models
-        run: $RUN "mkdir -p /data/params && cd /tmp/openpilot/selfdrive/test/ && ./test_car_models.py"
-
   test_longitudinal:
     name: longitudinal
     runs-on: ubuntu-16.04
@@ -116,4 +103,17 @@ jobs:
         with:
           name: longitudinal
           path: out
+
+  test_car_models:
+    name: test car models
+    runs-on: ubuntu-16.04
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: tmppilot.tar.gz
+      - name: Load image
+        run: $LOAD
+      - name: Test car models
+        run: $RUN "mkdir -p /data/params && cd /tmp/openpilot/selfdrive/test/ && ./test_car_models.py"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: flake8
         run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_openpilot.sh"
       - name: pylint
-        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./pylint.sh"
+        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./pylint_openpilot.sh"
 
   unit_tests:
     name: unit tests
@@ -54,4 +54,43 @@ jobs:
           docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/car"
           docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/locationd"
           docker run --shm-size 1G --rm tmppilot /bin/sh -c "python -m unittest discover selfdrive/athena"
+
+  process_replay:
+    name: process replay
+    runs-on: ubuntu-16.04
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: tmppilot.tar.gz
+      - name: Load image
+        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+      - name: Replay processes
+        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
+
+  test_car_models:
+    name: test car models
+    runs-on: ubuntu-16.04
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: tmppilot.tar.gz
+      - name: Load image
+        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+      - name: Test car models
+        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "mkdir -p /data/params && cd /tmp/openpilot/selfdrive/test/ && ./test_car_models.py"
+
+  test_longitudinal:
+    name: longitudinal
+    runs-on: ubuntu-16.04
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: tmppilot.tar.gz
+      - name: Load image
+        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+      - name: Test Longitudinal
+        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,14 @@ jobs:
       - name: Load image
         run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
       - name: Replay processes
-        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
+        run: |
+          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
+          docker cp tmppilot:/tmp/openpilot/selfdrive/test/process_replay/diff.txt diff.txt
+          docker rm tmppilot
+      - uses: actions/upload-artifact@v1
+        with:
+          name: diff.txt
+          path: process_replay_diff.txt
 
   test_car_models:
     name: test car models
@@ -92,5 +99,12 @@ jobs:
       - name: Load image
         run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
       - name: Test Longitudinal
-        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+        run: |
+          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+          docker cp tmppilot:/tmp/openpilot/out/longitduinal/ out/
+          docker rm tmppilot
+      - uses: actions/upload-artifact@v1
+        with:
+          name: longitudinal_out
+          path: out
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,12 +6,12 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v2
-    - name: checkout submodules
+    - name: Checkout submodules
       run: |
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-    - run: docker build -t tmppilot -f Dockerfile.openpilot .
+    - run: pwd && docker build -t tmppilot -f Dockerfile.openpilot .
     - uses: actions/upload-artifact@v1
       with:
         name: tmppilot
@@ -25,7 +25,25 @@ jobs:
     - uses: actions/download-artifact@v1
       with:
         name: tmppilot
+    - name: flake8
+      run:
+        docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_opepnilot.sh"
+    - name: pylint
+      run:
+        docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./pylint.sh"
+
+  unit_tests:
+    name: unit tests
+    runs-on: ubuntu-16.04
+    needs: linter
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: tmppilot
     - run:
         docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_opepnilot.sh"
+
+
+
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+on: [push]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: docker build -t tmppilot -f Dockerfile.openpilot .
+    - uses: actions/upload-artifact@v1
+      with:
+        name: tmppilot
+        path: tmppilot
+
+  linter:
+    name: linter
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: tmppilot
+    - run:
+        docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_opepnilot.sh"
+
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,9 @@ on: [push, pull_request]
 
 env:
   RUN: docker run --shm-size 1G --rm tmppilot /bin/sh -c
+  RUN_NO_RM: 
   LOAD: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+  UNIT_TEST: cd /tmp/openpilot && python -m unittest discover
 
 jobs:
   build:
@@ -50,14 +52,14 @@ jobs:
         run: $LOAD
       - name: Run unit tests
         run: |
-          $RUN "cd /tmp/openpilot && python -m unittest discover common"
-          $RUN "cd /tmp/openpilot && python -m unittest discover opendbc/can"
-          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/boardd"
-          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/controls"
-          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/loggerd"
-          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/car"
-          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/locationd"
-          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/athena"
+          $RUN "$UNIT_TEST common"
+          $RUN "$UNIT_TEST opendbc/can"
+          $RUN "$UNIT_TEST selfdrive/boardd"
+          $RUN "$UNIT_TEST selfdrive/controls"
+          $RUN "$UNIT_TEST selfdrive/loggerd"
+          $RUN "$UNIT_TEST selfdrive/car"
+          $RUN "$UNIT_TEST selfdrive/locationd"
+          $RUN "$UNIT_TEST selfdrive/athena"
 
   process_replay:
     name: process replay
@@ -69,10 +71,10 @@ jobs:
           name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
-      - name: Replay processes
+      - name: Run replay
         run: |
           CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
-          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
+          docker run --shm-size 1G --name ${CONTAINER_NAME} tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
           docker cp $CONTAINER_NAME:/tmp/openpilot/selfdrive/test/process_replay/diff.txt diff.txt
           docker rm $CONTAINER_NAME
       - uses: actions/upload-artifact@v1
@@ -106,7 +108,7 @@ jobs:
       - name: Test longitudinal
         run: |
           CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
-          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+          docker run --shm-size 1G --name ${CONTAINER_NAME} tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
           mkdir out
           docker cp $CONTAINER_NAME:/tmp/openpilot/out/longitduinal/ out/
           docker rm $CONTAINER_NAME

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,8 +79,8 @@ jobs:
           docker rm $CONTAINER_NAME
       - uses: actions/upload-artifact@v1
         with:
-          name: diff.txt
-          path: process_replay_diff.txt
+          name: process_replay_diff.txt
+          path: diff.txt
 
   test_car_models:
     name: test car models
@@ -110,10 +110,10 @@ jobs:
           CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
           docker run --shm-size 1G --name ${CONTAINER_NAME} tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
           mkdir out
-          docker cp $CONTAINER_NAME:/tmp/openpilot/out/longitduinal/ out/
+          docker cp $CONTAINER_NAME:/tmp/openpilot/selfdrive/test/longitudinal_maneuvers/out/longitudinal/ out/
           docker rm $CONTAINER_NAME
       - uses: actions/upload-artifact@v1
         with:
-          name: longitudinal_out
+          name: longitudinal
           path: out
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,8 +67,9 @@ jobs:
         run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
       - name: Replay processes
         run: |
-          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
-          docker cp tmppilot:/tmp/openpilot/selfdrive/test/process_replay/diff.txt diff.txt
+          CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
+          docker run --name $CONTAINER_NAME --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
+          docker cp $CONTAINER_NAME:/tmp/openpilot/selfdrive/test/process_replay/diff.txt diff.txt
           docker rm tmppilot
       - uses: actions/upload-artifact@v1
         with:
@@ -100,8 +101,9 @@ jobs:
         run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
       - name: Test Longitudinal
         run: |
-          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
-          docker cp tmppilot:/tmp/openpilot/out/longitduinal/ out/
+          CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
+          docker run --name $CONTAINER_NAME --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+          docker cp $CONTAINER_NAME:/tmp/openpilot/out/longitduinal/ out/
           docker rm tmppilot
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 
+env:
+  RUN: docker run --shm-size 1G --rm tmppilot /bin/sh -c
+  LOAD: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+
 jobs:
   build:
     name: build
@@ -28,11 +32,11 @@ jobs:
         with:
           name: tmppilot.tar.gz
       - name: Load image
-        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+        run: $LOAD
       - name: flake8
-        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./flake8_openpilot.sh"
+        run: $RUN "cd /tmp/openpilot/ && ./flake8_openpilot.sh"
       - name: pylint
-        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot/ && ./pylint_openpilot.sh"
+        run: $RUN "cd /tmp/openpilot/ && ./pylint_openpilot.sh"
 
   unit_tests:
     name: unit tests
@@ -43,17 +47,17 @@ jobs:
         with:
           name: tmppilot.tar.gz
       - name: Load image
-        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+        run: $LOAD
       - name: Run unit tests
         run: |
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover common"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover opendbc/can"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/boardd"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/controls"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/loggerd"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/car"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/locationd"
-          docker run --shm-size 1G --rm tmppilot /bin/sh -c "cd /tmp/openpilot && python -m unittest discover selfdrive/athena"
+          $RUN "cd /tmp/openpilot && python -m unittest discover common"
+          $RUN "cd /tmp/openpilot && python -m unittest discover opendbc/can"
+          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/boardd"
+          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/controls"
+          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/loggerd"
+          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/car"
+          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/locationd"
+          $RUN "cd /tmp/openpilot && python -m unittest discover selfdrive/athena"
 
   process_replay:
     name: process replay
@@ -64,13 +68,13 @@ jobs:
         with:
           name: tmppilot.tar.gz
       - name: Load image
-        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+        run: $LOAD
       - name: Replay processes
         run: |
           CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
-          docker run --name $CONTAINER_NAME --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
+          $RUN "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
           docker cp $CONTAINER_NAME:/tmp/openpilot/selfdrive/test/process_replay/diff.txt diff.txt
-          docker rm tmppilot
+          docker rm $CONTAINER_NAME
       - uses: actions/upload-artifact@v1
         with:
           name: diff.txt
@@ -85,9 +89,9 @@ jobs:
         with:
           name: tmppilot.tar.gz
       - name: Load image
-        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+        run: $LOAD
       - name: Test car models
-        run: docker run --shm-size 1G --rm tmppilot /bin/sh -c "mkdir -p /data/params && cd /tmp/openpilot/selfdrive/test/ && ./test_car_models.py"
+        run: $RUN "mkdir -p /data/params && cd /tmp/openpilot/selfdrive/test/ && ./test_car_models.py"
 
   test_longitudinal:
     name: longitudinal
@@ -98,13 +102,13 @@ jobs:
         with:
           name: tmppilot.tar.gz
       - name: Load image
-        run: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+        run: $LOAD
       - name: Test Longitudinal
         run: |
           CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
-          docker run --name $CONTAINER_NAME --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+          $RUN "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
           docker cp $CONTAINER_NAME:/tmp/openpilot/out/longitduinal/ out/
-          docker rm tmppilot
+          docker rm $CONTAINER_NAME
       - uses: actions/upload-artifact@v1
         with:
           name: longitudinal_out

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Replay processes
         run: |
           CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
-          $RUN "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
+          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/process_replay && CI=1 ./test_processes.py"
           docker cp $CONTAINER_NAME:/tmp/openpilot/selfdrive/test/process_replay/diff.txt diff.txt
           docker rm $CONTAINER_NAME
       - uses: actions/upload-artifact@v1
@@ -103,10 +103,11 @@ jobs:
           name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
-      - name: Test Longitudinal
+      - name: Test longitudinal
         run: |
           CONTAINER_NAME="tmppilot_${GITHUB_SHA}"
-          $RUN "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+          docker run --shm-size 1G tmppilot /bin/sh -c "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+          mkdir out
           docker cp $CONTAINER_NAME:/tmp/openpilot/out/longitduinal/ out/
           docker rm $CONTAINER_NAME
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,11 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v2
+    - name: checkout submodules
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
     - run: docker build -t tmppilot -f Dockerfile.openpilot .
     - uses: actions/upload-artifact@v1
       with:
@@ -15,6 +20,7 @@ jobs:
   linter:
     name: linter
     runs-on: ubuntu-16.04
+    needs: build
     steps:
     - uses: actions/download-artifact@v1
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: required
-language: minimal
-
-services:
-  - docker
-
-script:
-  - ./run_docker_tests.sh


### PR DESCRIPTION
Improvements over Travis:
* Run tests in parallel (without external docker registry)
* Debug artifacts from process replay and longitudinal test
* [Nicer interface](https://github.com/quillford/openpilot/actions) and output isn't one giant block of text
* Possible docker layer caching built-in, still looking into this
* Seems to run automatically as long as the config file is in the repo, unlike Travis, so forks would automatically have CI