### PR TITLE
dump fingerprints from all CAN buses into /data/my_car/my_fingerprint…

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -117,7 +117,7 @@ def fingerprint(logcan, sendcan, has_relay):
   return car_fingerprint, finger, vin, car_fw
 
 
-def dump_fingerprints(fingerprints):
+def dump_fingerprints(candidate, fingerprints):
   """
   dump all fingerprints from various CAN buses into /data/my_car/my_fingerprints.txt
 
@@ -128,6 +128,7 @@ def dump_fingerprints(fingerprints):
   os.makedirs(my_own_dir, exist_ok=True)
   outfile = os.path.join(my_own_dir, 'my_fingerprints.txt')
   with open(outfile, 'wt') as fout:
+    fout.write(f"Candidate Car: {candidate}\n\n")
     for key in fingerprints:
       d = fingerprints[key]
       fout.write(f"CAN={key}:\n")
@@ -137,7 +138,7 @@ def dump_fingerprints(fingerprints):
 
 def get_car(logcan, sendcan, has_relay=False):
   candidate, fingerprints, vin, car_fw = fingerprint(logcan, sendcan, has_relay)
-  dump_fingerprints(fingerprints)
+  dump_fingerprints(candidate, fingerprints)
 
   if candidate is None:
     cloudlog.warning("car doesn't match any fingerprints: %r", fingerprints)

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -117,8 +117,27 @@ def fingerprint(logcan, sendcan, has_relay):
   return car_fingerprint, finger, vin, car_fw
 
 
+def dump_fingerprints(fingerprints):
+  """
+  dump all fingerprints from various CAN buses into /data/my_car/my_fingerprints.txt
+
+  :param fingerprints: dict, fingerprints from CAN buses 0 - 3. possible keys are 0, 1, 2, 3
+  :return:
+  """
+  my_own_dir = '/data/my_car'
+  os.makedirs(my_own_dir, exist_ok=True)
+  outfile = os.path.join(my_own_dir, 'my_fingerprints.txt')
+  with open(outfile, 'wt') as fout:
+    for key in fingerprints:
+      d = fingerprints[key]
+      fout.write(f"CAN={key}:\n")
+      fingerprint = '{' + ', '.join("%d: %d" % v for v in sorted(d.items())) + '}'
+      fout.write(fingerprint+'\n\n')
+
+
 def get_car(logcan, sendcan, has_relay=False):
   candidate, fingerprints, vin, car_fw = fingerprint(logcan, sendcan, has_relay)
+  dump_fingerprints(fingerprints)
 
   if candidate is None:
     cloudlog.warning("car doesn't match any fingerprints: %r", fingerprints)


### PR DESCRIPTION
Currently new users needs to get fingerprints with get_fingerprint.py when EON is connected but OEM ACC/LKAS is enabled. I found this process cumbersome and unreliable, based on my own experience and frustrations expressed on Discord. This change is to dump out fingerprints the OP receives when OP is in enabled. The output file is /data/my_car/my_fingerprints.txt. This file gets created every time when OP is enabled, whether the car can be recognized or not. Benefit:

1. No longer need a separate process to get fingerprints
2. much easier for new users and support on fingerprint-related issues

I ran tests with my 2019 Honda Accord LX (Bosch). All were successful. No impact on any other aspects of OP.