### PR TITLE
GM: Resume Required Alert should be triggered off of ECM state

### DIFF
--- a/selfdrive/car/gm/gmcan.py
+++ b/selfdrive/car/gm/gmcan.py
@@ -67,8 +67,8 @@ def create_friction_brake_command(packer, bus, apply_brake, idx, near_stop, at_f
   else:
     mode = 0xa
 
-    if at_full_stop:
-      mode = 0xd
+  if at_full_stop:
+    mode = 0xd
     # TODO: this is to have GM bringing the car to complete stop,
     # but currently it conflicts with OP controls, so turned off.
     #elif near_stop:

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -296,7 +296,7 @@ class CarInterface(CarInterfaceBase):
         events.append(create_event('pedalPressed', [ET.NO_ENTRY, ET.USER_DISABLE]))
       if ret.gasPressed:
         events.append(create_event('pedalPressed', [ET.PRE_ENABLE]))
-      if ret.cruiseState.standstill:
+      if self.CS.pcm_acc_status == AccState.STANDSTILL:
         events.append(create_event('resumeRequired', [ET.WARNING]))
       if self.CS.pcm_acc_status == AccState.FAULTED:
         events.append(create_event('controlsFailed', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -296,7 +296,7 @@ class CarInterface(CarInterfaceBase):
         events.append(create_event('pedalPressed', [ET.NO_ENTRY, ET.USER_DISABLE]))
       if ret.gasPressed:
         events.append(create_event('pedalPressed', [ET.PRE_ENABLE]))
-      if self.CS.pcm_acc_status == AccState.STANDSTILL:
+      if ret.cruiseState.standstill:
         events.append(create_event('resumeRequired', [ET.WARNING]))
       if self.CS.pcm_acc_status == AccState.FAULTED:
         events.append(create_event('controlsFailed', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE]))


### PR DESCRIPTION
On GM cars the ECM goes into cruise state 4 (standstill) and in order
for the ECM to accept cruise inputs, the resume button must be pressed
to drive it to state 1 (active).

Previously rather than testing for if the ECM was in state 4, the wheel
speed sensors were checked that the vehicle was going less than 0.5 m/s.

In some cases this could cause the resume required alert to be displayed
before the car actually came to a stop as far as the ECM was concerned.
If the alert is triggered before state 4 and OP demands acceleration,
its possible for OP to acelerate while the Resume Required Alert is
displayed created a very confusing UX.

This PR updates the alert to be triggered to fire when the ECM reports that it is in state 4.