### PR TITLE
reset self.lane_change_direction every iteration

### DIFF
--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -90,6 +90,7 @@ class PathPlanner():
     self.LP.parse_model(sm['model'])
 
     # Lane change logic
+    self.lane_change_direction = LaneChangeDirection.none
     one_blinker = sm['carState'].leftBlinker != sm['carState'].rightBlinker
     below_lane_change_speed = v_ego < LANE_CHANGE_SPEED_MIN
 


### PR DESCRIPTION
This should be equivalent to 0.7.1's behavior.
Without, openpilot sometimes continues to lane change even with the blinker off.