### PR TITLE
test car models: fix random hanging

### DIFF
--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -43,7 +43,12 @@ def get_route_log(route_name):
 
   if not os.path.isfile(log_path):
     log_url = "https://commadataci.blob.core.windows.net/openpilotci/%s/0/%s" % (route_name.replace("|", "/"), "rlog.bz2")
-    r = requests.get(log_url, timeout=15)
+
+    # if request fails, try again once and let it throw exception if fails again
+    try:
+      r = requests.get(log_url, timeout=15)
+    except:
+      r = requests.get(log_url, timeout=15)
 
     if r.status_code == 200:
       with open(log_path, "wb") as f:

--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -43,7 +43,7 @@ def get_route_log(route_name):
 
   if not os.path.isfile(log_path):
     log_url = "https://commadataci.blob.core.windows.net/openpilotci/%s/0/%s" % (route_name.replace("|", "/"), "rlog.bz2")
-    r = requests.get(log_url)
+    r = requests.get(log_url, timeout=15)
 
     if r.status_code == 200:
       with open(log_path, "wb") as f:

--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -38,20 +38,19 @@ def wait_for_sockets(socks, timeout=10.0):
         recvd.append(s)
   return recvd
 
-def get_route_logs(route_name):
-  for log_f in ["rlog.bz2", "fcamera.hevc"]:
-    log_path = os.path.join("/tmp", "%s--0--%s" % (route_name.replace("|", "_"), log_f))
+def get_route_log(route_name):
+  log_path = os.path.join("/tmp", "%s--0--%s" % (route_name.replace("|", "_"), "rlog.bz2"))
 
-    if not os.path.isfile(log_path):
-      log_url = "https://commadataci.blob.core.windows.net/openpilotci/%s/0/%s" % (route_name.replace("|", "/"), log_f)
-      r = requests.get(log_url)
+  if not os.path.isfile(log_path):
+    log_url = "https://commadataci.blob.core.windows.net/openpilotci/%s/0/%s" % (route_name.replace("|", "/"), "rlog.bz2")
+    r = requests.get(log_url)
 
-      if r.status_code == 200:
-        with open(log_path, "wb") as f:
-          f.write(r.content)
-      else:
-        print("failed to download test log %s" % route_name)
-        sys.exit(-1)
+    if r.status_code == 200:
+      with open(log_path, "wb") as f:
+        f.write(r.content)
+    else:
+      print("failed to download test log %s" % route_name)
+      sys.exit(-1)
 
 routes = {
 
@@ -491,7 +490,7 @@ if __name__ == "__main__":
   for route, checks in routes.items():
     if route not in non_public_routes:
       print("GETTING ROUTE LOGS")
-      get_route_logs(route)
+      get_route_log(route)
       print("DONE GETTING ROUTE LOGS")
     elif "UNLOGGER_PATH" not in os.environ:
       continue
@@ -514,7 +513,7 @@ if __name__ == "__main__":
       unlogger_cmd = [os.path.join(BASEDIR, os.environ['UNLOGGER_PATH']), route]
     else:
       unlogger_cmd = [os.path.join(BASEDIR, 'tools/replay/unlogger.py'), route, '/tmp']
-    unlogger = subprocess.Popen(unlogger_cmd + ['--disable', 'frame,plan,pathPlan,liveLongitudinalMpc,radarState,controlsState,liveTracks,liveMpc,sendcan,carState,carControl,carEvents,carParams', '--no-interactive'], preexec_fn=os.setsid)
+    unlogger = subprocess.Popen(unlogger_cmd + ['--disable', 'frame,encodeIdx,plan,pathPlan,liveLongitudinalMpc,radarState,controlsState,liveTracks,liveMpc,sendcan,carState,carControl,carEvents,carParams', '--no-interactive'], preexec_fn=os.setsid)
 
     print("Check sockets")
     extra_socks = []

--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -490,7 +490,9 @@ if __name__ == "__main__":
   results = {}
   for route, checks in routes.items():
     if route not in non_public_routes:
+      print("GETTING ROUTE LOGS")
       get_route_logs(route)
+      print("DONE GETTING ROUTE LOGS")
     elif "UNLOGGER_PATH" not in os.environ:
       continue
 


### PR DESCRIPTION
Running locally, I reproduced a similar failure to the one seen in CI recently. It would get stuck downloading the front camera video, which was unnecessary, and was probably only done to make unlogger happy. Not having to download those videos each time should speed up the test a bit. Also added a timeout to the request so it doesn't just wait forever.

Fixes #1043 