### PR TITLE
Use ZSTD in loggerd

### DIFF
--- a/selfdrive/loggerd/SConscript
+++ b/selfdrive/loggerd/SConscript
@@ -3,7 +3,7 @@ Import('env', 'arch', 'messaging', 'common', 'visionipc')
 src = ['loggerd.cc', 'logger.c']
 libs = ['zmq', 'czmq', 'capnp', 'kj', 'z',
   'avformat', 'avcodec', 'swscale', 'avutil',
-  'yuv', 'bz2', common, 'json', messaging, visionipc]
+  'yuv', 'bz2', common, 'json', messaging, visionipc, 'zstd']
 
 if arch == "aarch64":
   src += ['encoder.c', 'raw_logger.cc']

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <bzlib.h>
+#include <zstd.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,11 +20,17 @@ typedef struct LoggerHandle {
   char log_path[4096];
   char lock_path[4096];
   FILE* log_file;
-  BZFILE* bz_file;
+  //BZFILE* bz_file;
 
   FILE* qlog_file;
   char qlog_path[4096];
-  BZFILE* bz_qlog;
+  //BZFILE* bz_qlog;
+
+  ZSTD_CCtx* zstd_ctx_rlog;
+  ZSTD_CCtx* zstd_ctx_qlog;
+
+  size_t zstd_out_buf_sz;
+  void * zstd_out_buf;
 } LoggerHandle;
 
 typedef struct LoggerState {
@@ -39,6 +46,8 @@ typedef struct LoggerState {
 
   LoggerHandle handles[LOGGER_MAX_HANDLES];
   LoggerHandle* cur_handle;
+
+
 } LoggerState;
 
 void logger_init(LoggerState *s, const char* log_name, const uint8_t* init_data, size_t init_data_len, bool has_qlog);


### PR DESCRIPTION
```
zstd 5 (23% cpu):
-rw-rw-rw-  1 root root 2.7M Feb 14 20:14 qlog.zst
-rw-rw-rw-  1 root root 3.7M Feb 14 20:14 rlog.zst
zstd 10 (28% cpu):
-rw-rw-rw-  1 root root 2.5M Feb 14 20:16 qlog.zst
-rw-rw-rw-  1 root root 3.5M Feb 14 20:16 rlog.zst
zstd 19 (max compression, 70% cpu):
-rw-rw-rw-  1 root root 2.2M Feb 14 20:19 qlog.zst
-rw-rw-rw-  1 root root 3.0M Feb 14 20:19 rlog.zst
bz2 (38% cpu)
-rw-rw-rw-  1 root root 2.7M Feb 14 20:08 qlog.bz2
-rw-rw-rw-  1 root root 3.7M Feb 14 20:08 rlog.bz2
```