### PR TITLE
Restore openpilot backup if manager fails to run

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -86,10 +86,13 @@ function launch {
 
   # start manager
   cd selfdrive
-  ./manager.py
+  ./manager.py > runtime.log
 
-  # if broken, keep on screen error
-  while true; do sleep 1; done
+  # restore openpilot.bak if manager fails to run
+  mv runtime.log /data/openpilot/runtime.log
+  mv /data/openpilot /data/openpilot-failed-$(date +"%F-%H-%M")
+  cp -r /data/openpilot.bak /data/openpilot
+  reboot
 }
 
 launch


### PR DESCRIPTION
In the case where we install a bad build of openpilot, we are stuck with a black screen until we go in and fix it with ssh. This change swaps out the build with a backup kept in openpilot.bak so that we can get back to a running state. Workbench executes the following command by default when Install Openpilot is selected.

`cd /data;mv ./openpilot ./openpilot.bak;git clone %git_url% openpilot;cd openpilot;git checkout %git_branch%`

So newer users can rely on having a openpilot.bak available to failover into.

Also added redirecting the manager.py output to a log file to keep with the old build to diagnose what broke.