### PR TITLE
Add input parameter to SubMaster.update() to wait for specific services

### DIFF
--- a/cereal/messaging/__init__.py
+++ b/cereal/messaging/__init__.py
@@ -162,14 +162,16 @@ class SubMaster():
   def __getitem__(self, s):
     return self.data[s]
 
-  def update(self, timeout=1000):
+  def update(self, wait_for=None):
     msgs = []
-    for sock in self.poller.poll(timeout):
-      msgs.append(recv_one_or_none(sock))
+    for s in self.sock:
+      if wait_for is not None and s in wait_for:
+        msgs.append(recv_one(self.sock[s]))
+      else:
+        msgs.append(recv_one_or_none(self.sock[s]))
     self.update_msgs(sec_since_boot(), msgs)
 
   def update_msgs(self, cur_time, msgs):
-    # TODO: add optional input that specify the service to wait for
     self.frame += 1
     self.updated = dict.fromkeys(self.updated, False)
     for msg in msgs:


### PR DESCRIPTION
I couldn't find the `messaging/__init__.py` file on master, so I just opened this temporary PR for now.

This adds the ability to specify a list of services to wait for when updating with SubMaster. I took out the poller simply because I didn't know if it was possible to identify which socket/service it is from the poller. I was debating if it was better or not to send the `wait_for` list when we initialize the SubMaster, or for better modularity, keep it inside the update function. So let me know if there's anything I can improve