### PR TITLE
fix sidebar shadow in network settings

### DIFF
--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -877,11 +877,14 @@ static void ui_draw_blank(UIState *s) {
 }
 
 void ui_draw(UIState *s) {
-  ui_draw_sidebar(s);
   if (s->vision_connected && s->active_app == cereal_UiLayoutState_App_home && s->status != STATUS_STOPPED) {
+    ui_draw_sidebar(s);
     ui_draw_vision(s);
   } else {
     ui_draw_blank(s);
+    if (!s->scene.uilayout_sidebarcollapsed) {
+      ui_draw_sidebar(s);
+    }
   }
 
   {


### PR DESCRIPTION
only draw collapsed sidebar shadow when device is onroad to indicate that it is expandable