### PR TITLE
update rav4h_tss2 tune 

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -167,9 +167,9 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.68986
       ret.steerRatio = 14.3
       tire_stiffness_factor = 0.7933
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.15], [0.05]]
       ret.mass = 3800. * CV.LB_TO_KG + STD_CARGO_KG
-      ret.lateralTuning.pid.kf = 0.00007818594
+      ret.lateralTuning.pid.kf = 0.00004
 
     elif candidate in [CAR.COROLLA_TSS2, CAR.COROLLAH_TSS2]:
       stop_and_go = True

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -157,9 +157,9 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.68986
       ret.steerRatio = 14.3
       tire_stiffness_factor = 0.7933
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.15], [0.05]]
       ret.mass = 3370. * CV.LB_TO_KG + STD_CARGO_KG
-      ret.lateralTuning.pid.kf = 0.00007818594
+      ret.lateralTuning.pid.kf = 0.00004
 
     elif candidate == CAR.RAV4H_TSS2:
       stop_and_go = True


### PR DESCRIPTION
Reduce pid gain for rav4h_tss2 to reduce ping pong at local speed big turns.  There are several discord members have the same issue.  The tuning is based on TaiFeng's work https://github.com/illumiN8i/openpilot/pull/2/files
The following is two drive on the same road.

* Before, big oscillation of steer_rate. peak to peak is often around 90
https://my.comma.ai/cabana/?route=b2fec0be8f33145c%7C2020-03-21--14-56-58&exp=1616359452&sig=umM4XWXjk6QJHEzRIG4dTP4QnT3US%2BWgKMP9lXNrt7c%3D&max=9&url=https%3A%2F%2Fchffrprivate-vzn.azureedge.net%2Fchffrprivate3%2Fv2%2Fb2fec0be8f33145c%2F69a4e0ba71cdee05d57c3f46960087ee_2020-03-21--14-56-58
![stock tune](https://user-images.githubusercontent.com/43092209/77237228-b3924800-6b9c-11ea-9c80-43e190798f9f.png)

*After, much smoother.  steer_rate peak to peak  is closer to 30
https://my.comma.ai/cabana/?route=b2fec0be8f33145c%7C2020-03-21--15-15-46&exp=1616359651&sig=5PoE7pYVVSasSabZTb6PBGHxNNXjDdYknjRK23Zyi1Y%3D&max=9&url=https%3A%2F%2Fchffrprivate-vzn.azureedge.net%2Fchffrprivate3%2Fv2%2Fb2fec0be8f33145c%2F558fa08d6abb53bb0a09abe1d270171e_2020-03-21--15-15-46
![modified tune](https://user-images.githubusercontent.com/43092209/77237244-c9a00880-6b9c-11ea-90c2-ab9b10177d1e.PNG)

