### PR TITLE
Docs/tools: Update Tensorflow to 2.1 in readme and build script

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -88,7 +88,7 @@ pipenv install --system --deploy
 pip install -r tools/requirements.txt
 
 # to make modeld work on PC with nvidia GPU
-pip install tensorflow-gpu==2.0
+pip install tensorflow-gpu==2.1
 
 # for loggerd to work on ubuntu
 # TODO: PC should log somewhere else

--- a/tools/webcam/README.md
+++ b/tools/webcam/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/commaai/openpilot.git
 ```
 - Follow [this readme](https://github.com/commaai/openpilot/tree/master/tools) to install the requirements  
 - Add line "export PYTHONPATH=$HOME/openpilot" to your ~/.bashrc  
-- You also need to install tensorflow-gpu 2.0.0 and nvidia drivers: nvidia-xxx/cuda10.0/cudnn7.6.5  
+- You also need to install tensorflow-gpu 2.1.0 and nvidia drivers: nvidia-xxx/cuda10.0/cudnn7.6.5  
 - Install [OpenCL Driver](http://registrationcenter-download.intel.com/akdlm/irc_nas/12556/opencl_runtime_16.1.2_x64_rh_6.4.0.37.tgz)  
 - (Note: the code assumes cl platforms order to be 0.GPU/1.CPU when running clinfo; if reverse, change the -1 to -2 in selfdrive/modeld/modeld.cc#L130; helping us refactor this mess is encouraged)  
 - Install [OpenCV4](https://www.pyimagesearch.com/2018/08/15/how-to-install-opencv-4-on-ubuntu/)  


### PR DESCRIPTION
Update to Tensorflow 2.1 in a few forgotten places after 027deba:

- tools\ubuntu_setup.sh
- tools\webcam\README.md

TensorFlow 2.2 is also in it's [second RC](https://github.com/tensorflow/tensorflow/releases/tag/v2.2.0-rc2) btw