### PR TITLE
Add 2020 Rav4 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Supported Cars
 | Toyota    | Prius Prime 2017-20           | All               | Stock<sup>5</sup>| 0mph               | 0mph              |
 | Toyota    | Rav4 2016                     | TSS-P             | Stock<sup>5</sup>| 20mph<sup>6</sup>  | 0mph              |
 | Toyota    | Rav4 2017-18                  | All               | Stock<sup>5</sup>| 20mph<sup>6</sup>  | 0mph              |
-| Toyota    | Rav4 2019                     | All               | openpilot        | 0mph               | 0mph              |
+| Toyota    | Rav4 2019-20                  | All               | openpilot        | 0mph               | 0mph              |
 | Toyota    | Rav4 Hybrid 2016              | TSS-P             | Stock<sup>5</sup>| 0mph               | 0mph              |
 | Toyota    | Rav4 Hybrid 2017-18           | All               | Stock<sup>5</sup>| 0mph               | 0mph              |
 | Toyota    | Rav4 Hybrid 2019-20           | All               | openpilot        | 0mph               | 0mph              |


### PR DESCRIPTION
CrumResearch from Discord confirmed his 2020 Rav4 works out of the box after fixing his hardware issues. 

His dongleid is 4e8f40e4006e9f1c