### PR TITLE
Fix unlogger read from files

### DIFF
--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -78,8 +78,6 @@ def ffprobe(fn, fmt=None):
     "-v", "quiet",
     "-print_format", "json",
     "-show_format", "-show_streams"]
-  if fmt:
-    cmd += ["-format", fmt]
   cmd += [fn]
 
   try:

--- a/tools/replay/unlogger.py
+++ b/tools/replay/unlogger.py
@@ -114,7 +114,6 @@ class UnloggerWorker(object):
           print("FRAME(%d) LAG -- %.2f ms" % (frame_id, fr_time*1000.0))
 
         if img is not None:
-          img = img[:, :, ::-1] # Convert RGB to BGR, which is what the camera outputs
           img = img.flatten()
           smsg.frame.image = img.tobytes()
 

--- a/tools/replay/unlogger.py
+++ b/tools/replay/unlogger.py
@@ -114,6 +114,7 @@ class UnloggerWorker(object):
           print("FRAME(%d) LAG -- %.2f ms" % (frame_id, fr_time*1000.0))
 
         if img is not None:
+          img = img[:, :, ::-1] # Convert RGB to BGR, which is what the camera outputs
           img = img.flatten()
           smsg.frame.image = img.tobytes()
 


### PR DESCRIPTION
When reading from .hvec files downloaded from cabana unlogger adds the unknown -format option to ffprobe and then tries to convert an already correct format video file