### PR TITLE
Attempt to fetch FW versions with grey panda

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -92,8 +92,13 @@ def fingerprint(logcan, sendcan, has_relay):
 
     fw_candidates = match_fw_to_car(car_fw)
   else:
+    bus = 0
     vin = VIN_UNKNOWN
-    fw_candidates, car_fw = set(), []
+    car_fw = get_fw_versions(logcan, sendcan, bus)
+    if car_fw is None:
+      fw_candidates, car_fw = set(), []
+    else:
+      fw_candidates = match_fw_to_car(car_fw)
 
   cloudlog.warning("VIN %s", vin)
   Params().put("CarVin", vin)

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -71,15 +71,14 @@ def only_toyota_left(candidate_cars):
 
 # **** for use live only ****
 def fingerprint(logcan, sendcan, has_relay):
+  cached_params = Params().get("CarParamsCache")
+  if cached_params is not None:
+    cached_params = car.CarParams.from_bytes(cached_params)
+    if cached_params.carName == "mock":
+      cached_params = None
   if has_relay:
     # Vin query only reliably works thorugh OBDII
     bus = 1
-
-    cached_params = Params().get("CarParamsCache")
-    if cached_params is not None:
-      cached_params = car.CarParams.from_bytes(cached_params)
-      if cached_params.carName == "mock":
-        cached_params = None
 
     if cached_params is not None and len(cached_params.carFw) > 0 and cached_params.carVin is not VIN_UNKNOWN:
       cloudlog.warning("Using cached CarParams")
@@ -93,12 +92,19 @@ def fingerprint(logcan, sendcan, has_relay):
     fw_candidates = match_fw_to_car(car_fw)
   else:
     bus = 0
-    vin = VIN_UNKNOWN
-    car_fw = get_fw_versions(logcan, sendcan, bus)
-    if car_fw is None:
-      fw_candidates, car_fw = set(), []
+
+    if cached_params is not None and len(cached_params.carFw) > 0:
+      cloudlog.warning("Using cached CarParams")
+      vin = cached_params.carVin
+      car_fw = list(cached_params.carFw)
     else:
-      fw_candidates = match_fw_to_car(car_fw)
+      cloudlog.warning("Getting VIN & FW versions")
+      vin = VIN_UNKNOWN
+      car_fw = get_fw_versions(logcan, sendcan, bus)
+      if car_fw is None:
+        fw_candidates, car_fw = set(), []
+      else:
+        fw_candidates = match_fw_to_car(car_fw)
 
   cloudlog.warning("VIN %s", vin)
   Params().put("CarVin", vin)


### PR DESCRIPTION
Issue: FW versions are unavailable to detect if the EPS is modded. These FW versions are unavailable because the editted `if` statement will not return anything if you do not `has_relay`(have a black panda).

Credit to: @wirelessnet2