### PR TITLE
fix AttributeError: 'FakeSpinner' object has no attribute 'close'

### DIFF
--- a/common/spinner.py
+++ b/common/spinner.py
@@ -50,6 +50,9 @@ class FakeSpinner():
   def update(self, _):
     pass
 
+  def close(self):
+    pass
+
   def __exit__(self, type, value, traceback):
     pass
 


### PR DESCRIPTION
This error occurred when run in webcam mode.