### PR TITLE
do not duplicate end start nodes

### DIFF
--- a/selfdrive/mapd/mapd_helpers.py
+++ b/selfdrive/mapd/mapd_helpers.py
@@ -346,6 +346,7 @@ class Way:
       if pnts is None:
         pnts = new_pnts
       else:
+        new_pnts = np.delete(new_pnts,[0,0,0], axis=0)
         pnts = np.vstack([pnts, new_pnts])
 
       # Check current lookahead distance


### PR DESCRIPTION
If we already have pnts. way.points_in_car_frame will give us a duplicate pnt because it gives us the start of the new line where the node of the last line had that point already. We can safely delete the first point to avoid high curvature values with two points being on top of one another.