### PR TITLE
Add tool for splitting keras model for faster loading

### DIFF
--- a/models/dmonitoring_model.model.keras
+++ b/models/dmonitoring_model.model.keras
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13856f9d455d59abe2a628e1c8b2ce4bc0d7edd09ef0d6f4282f0c5f306bb022
+size 17826

--- a/models/dmonitoring_model.weights.keras
+++ b/models/dmonitoring_model.weights.keras
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2dd3a9f91bf9be247ad124d1124244daa6466b07baeedc96dad75f90261a5d8
+size 794160

--- a/models/supercombo.model.keras
+++ b/models/supercombo.model.keras
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dbef403cb7968be09e086c463e1b00c311a947caf8e6e3c3a6a6f6e4b2ee746
+size 135034

--- a/models/supercombo.weights.keras
+++ b/models/supercombo.weights.keras
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:698f21eaae133f57a7890d065b417b8d45434bc7f8b47a71bab8e52ed148bfd1
+size 27381280

--- a/selfdrive/modeld/runners/keras_runner.py
+++ b/selfdrive/modeld/runners/keras_runner.py
@@ -8,7 +8,7 @@ import sys
 import tensorflow.keras as keras
 import numpy as np
 from tensorflow.keras.models import Model
-from tensorflow.keras.models import load_model
+from tensorflow.keras.models import model_from_json
 
 def read(sz):
   dd = []
@@ -38,8 +38,10 @@ if __name__ == "__main__":
   gpus = tf.config.experimental.list_physical_devices('GPU')
   if len(gpus) > 0:
     tf.config.experimental.set_virtual_device_configuration(gpus[0], [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=2048)])
-
-  m = load_model(sys.argv[1])
+  name = sys.argv[1].split('.keras')[0]
+  with open(f"{name}.model.keras", "r") as json_file:
+    m = model_from_json(json_file.read())
+  m.load_weights(f"{name}.weights.keras")
   print(m, file=sys.stderr)
   bs = [int(np.product(ii.shape[1:])) for ii in m.inputs]
   ri = keras.layers.Input((sum(bs),))
@@ -55,4 +57,3 @@ if __name__ == "__main__":
   no = keras.layers.Concatenate()(m(tii))
   m = Model(inputs=ri, outputs=[no])
   run_loop(m)
-

--- a/tools/keras/split_keras.py
+++ b/tools/keras/split_keras.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import tensorflow as tf
+import os
+import sys
+import tensorflow.keras as keras
+import numpy as np
+from tensorflow.keras.models import Model
+from tensorflow.keras.models import load_model
+from pathlib import Path
+
+
+name = sys.argv[1].split('.keras')[0]
+model = load_model(sys.argv[1])
+model.save_weights(f"{name}.weights.keras")
+model_json = model.to_json()
+with open(f"{name}.model.keras", "w") as json_file:
+    json_file.write(model_json)
+json_file.close()


### PR DESCRIPTION
By splitting the Keras model, initialization and first frame output is reduced from over 2 minutes to under 20 seconds on Jetson TX2 hardware. The split model and original files are an exact binary match when loaded and does not change its output in any way.

This PR also provides the tool to split the models with the command:

```python ./tools/keras/split_keras.py ./models/supercombo.keras```