### PR TITLE
fix memory leak in encoder_close

### DIFF
--- a/selfdrive/loggerd/encoder.c
+++ b/selfdrive/loggerd/encoder.c
@@ -637,7 +637,7 @@ void encoder_close(EncoderState *s) {
     if (s->remuxing) {
       av_write_trailer(s->ofmt_ctx);
       avio_closep(&s->ofmt_ctx->pb);
-      avcodec_free_context(s->codec_ctx);
+      avcodec_free_context(&s->codec_ctx);
       avformat_free_context(s->ofmt_ctx);
     } else {
       fclose(s->of);

--- a/selfdrive/loggerd/encoder.c
+++ b/selfdrive/loggerd/encoder.c
@@ -637,6 +637,7 @@ void encoder_close(EncoderState *s) {
     if (s->remuxing) {
       av_write_trailer(s->ofmt_ctx);
       avio_closep(&s->ofmt_ctx->pb);
+      avcodec_free_context(s->codec_ctx);
       avformat_free_context(s->ofmt_ctx);
     } else {
       fclose(s->of);


### PR DESCRIPTION
From the  [document](https://ffmpeg.org/doxygen/trunk/group__lavc__core.html#gae80afec6f26df6607eaacf39b561c315) about avcodec_alloc_context3:

> The resulting struct should be freed with avcodec_free_context().