### PR TITLE
fix event_handler:unlock a mutex that has not been locked

### DIFF
--- a/selfdrive/loggerd/encoder.c
+++ b/selfdrive/loggerd/encoder.c
@@ -58,8 +58,6 @@ static OMX_ERRORTYPE event_handler(OMX_HANDLETYPE component, OMX_PTR app_data, O
     break;
   }
 
-  pthread_mutex_unlock(&s->state_lock);
-
   return OMX_ErrorNone;
 }
 


### PR DESCRIPTION
From the [document](https://linux.die.net/man/3/pthread_mutex_unlock) about pthread_mutex_unlock:

>  If a thread attempts to unlock a mutex that it has not locked or a mutex which is unlocked, undefined behavior results.