### PR TITLE
fix build warning: libusb_set_debug is deprecated

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -943,7 +943,12 @@ int main() {
   // init libusb
   err = libusb_init(&ctx);
   assert(err == 0);
+
+#if LIBUSB_API_VERSION >= 0x01000106
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 3);
+#else
   libusb_set_debug(ctx, 3);
+#endif
 
   pthread_t can_health_thread_handle;
   err = pthread_create(&can_health_thread_handle, NULL,

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -945,7 +945,7 @@ int main() {
   assert(err == 0);
 
 #if LIBUSB_API_VERSION >= 0x01000106
-  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 3);
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
 #else
   libusb_set_debug(ctx, 3);
 #endif


### PR DESCRIPTION
selfdrive/boardd/boardd.cc:952:3: warning: 'libusb_set_debug' is deprecated [-Wdeprecated-declarations]
  libusb_set_debug(ctx, 3);