### PR TITLE
Fix UnicodeDecodeError in get_network_strength

### DIFF
--- a/common/android.py
+++ b/common/android.py
@@ -232,7 +232,7 @@ def get_network_strength(network_type):
   if network_type == NetworkType.none:
     return network_strength
   if network_type == NetworkType.wifi:
-    out = subprocess.check_output('dumpsys connectivity', shell=True).decode('ascii')
+    out = subprocess.check_output('dumpsys connectivity', shell=True).decode('utf-8')
     network_strength = NetworkStrength.unknown
     for line in out.split('\n'):
       signal_str = "SignalStrength: "
@@ -251,7 +251,7 @@ def get_network_strength(network_type):
     return network_strength
   else:
     # check cell strength
-    out = subprocess.check_output('dumpsys telephony.registry', shell=True).decode('ascii')
+    out = subprocess.check_output('dumpsys telephony.registry', shell=True).decode('utf-8')
     for line in out.split('\n'):
       if "mSignalStrength" in line:
         arr = line.split(' ')


### PR DESCRIPTION
subprocess.check_output will throw an UnicodeDecodeError  if the result contain non-ASCII characters, such as chinese or japense.

for example,the result from China Telecom Card:
>   Phone Id=0
  mCallState=0
  mCallIncomingNumber=
  mServiceState=0 0 voice home data home 中国电信 CT 46011 中国电信 CT 46011  1xRTT LTE_CA CSS not supported 302 14137 RoamInd=1 DefRoamInd=0 EmergOnly=false IsDataRoamingFromRegistration=false
  mSignalStrength=SignalStrength: 99 0 -68 -70 -120 -1 -1 26 -90 -9 228 2147483647 2147483647 gsm|lte