### PR TITLE
fixe OpenCL depreciation warnings

### DIFF
--- a/selfdrive/camerad/cameras/camera_frame_stream.h
+++ b/selfdrive/camerad/cameras/camera_frame_stream.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #ifdef __APPLE__
 #include <OpenCL/cl.h>
 #else

--- a/selfdrive/common/visionbuf.h
+++ b/selfdrive/common/visionbuf.h
@@ -1,6 +1,7 @@
 #ifndef IONBUF_H
 #define IONBUF_H
 
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #ifdef __APPLE__
 #include <OpenCL/cl.h>
 #else

--- a/selfdrive/common/visionbuf_cl.c
+++ b/selfdrive/common/visionbuf_cl.c
@@ -8,6 +8,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #ifdef __APPLE__
 #include <OpenCL/cl.h>
 #else

--- a/selfdrive/modeld/models/commonmodel.h
+++ b/selfdrive/modeld/models/commonmodel.h
@@ -1,6 +1,7 @@
 #ifndef COMMONMODEL_H
 #define COMMONMODEL_H
 
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #include <CL/cl.h>
 
 #include "common/mat.h"

--- a/selfdrive/modeld/transforms/transform.h
+++ b/selfdrive/modeld/transforms/transform.h
@@ -4,6 +4,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #ifdef __APPLE__
 #include <OpenCL/cl.h>
 #else


### PR DESCRIPTION
Fix OpenCL depreciation warnings:

> warning: 'clCreateCommandQueue' is deprecated [-Wdeprecated-declarations]
    q = clCreateCommandQueue(context, device_id, 0, &err);
        ^
phonelibs/opencl/include/CL/cl.h:1430:72: note: 'clCreateCommandQueue' has been explicitly marked deprecated here
                     cl_int *                       /* errcode_ret */) CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED;
                                                                       ^
phonelibs/opencl/include/CL/cl_platform.h:117:74: note: expanded from macro 'CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED'
            #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED __attribute__((deprecated))
                                                                         ^