### PR TITLE
dommonmodel.c: unmap a previously mapped buff

### DIFF
--- a/selfdrive/modeld/models/driving.cc
+++ b/selfdrive/modeld/models/driving.cc
@@ -112,6 +112,8 @@ ModelDataRaw model_eval_frame(ModelState* s, cl_command_queue q,
     assert(1==2);
   #endif
 
+  clEnqueueUnmapMemObject(q, s->frame.net_input, (void*)new_frame_buf, 0, NULL, NULL);
+
   // net outputs
   ModelDataRaw net_outputs;
   net_outputs.path = &s->output[PATH_IDX];


### PR DESCRIPTION
resolve #1397 