### PR TITLE
Updated README to add '18 Subaru Impreza as supported vehicle

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Community Maintained Cars and Features
 | Nissan    | Leaf 2019                     | Propilot          | Stock            | 0mph               | 0mph         |
 | Nissan    | X-Trail 2018                  | Propilot          | Stock            | 0mph               | 0mph         |
 | Subaru    | Crosstrek 2018-19             | EyeSight          | Stock            | 0mph               | 0mph         |
-| Subaru    | Impreza 2019-20               | EyeSight          | Stock            | 0mph               | 0mph         |
+| Subaru    | Impreza 2018-20               | EyeSight          | Stock            | 0mph               | 0mph         |
 | Volkswagen| Golf 2016-19<sup>3</sup>      | Driver Assistance | Stock            | 0mph               | 0mph         |
 
 <sup>1</sup>Requires a [panda](https://comma.ai/shop/products/panda-obd-ii-dongle) and [community built giraffe](https://zoneos.com/volt/). ***NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).*** <br />


### PR DESCRIPTION
This is a pull request to correct the Community Maintained Cars and Features section of the README file.

I personally have a 2018 Subaru Impreza (as well as a few others in #subaru), and OpenPilot works as intended on stock OP.

Simple PR to correct the minimum year from 2019 to 2018.