### PR TITLE
cltuil.c:fix build warning 

### DIFF
--- a/selfdrive/common/clutil.c
+++ b/selfdrive/common/clutil.c
@@ -85,7 +85,7 @@ void cl_print_info(cl_platform_id platform, cl_device_id device) {
 
   size_t sz;
   clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_GROUP_SIZE, sizeof(sz), &sz, NULL);
-  printf("max work group size: %u\n", sz);
+  printf("max work group size: %zu\n", sz);
 
   cl_device_type type;
   clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(type), &type, NULL);


### PR DESCRIPTION
selfdrive/common/clutil.c:88:39: warning: format specifies type 'unsigned int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  printf("max work group size: %u\n", sz);
                               ~~     ^~
                               %zu