### PR TITLE
Discussion-only PR for Volkswagen FPv2

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -7,9 +7,12 @@ from selfdrive.swaglog import cloudlog
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from panda.python.uds import CanClient, IsoTpMessage, FUNCTIONAL_ADDRS, get_rx_addr_for_tx_addr
 
+class RX_OFFSET:
+  DEFAULT = 0x8
+  VOLKSWAGEN = 0x6A
 
 class IsoTpParallelQuery():
-  def __init__(self, sendcan, logcan, bus, addrs, request, response, functional_addr=False, debug=False):
+  def __init__(self, sendcan, logcan, bus, addrs, request, response, response_offset=RX_OFFSET.DEFAULT, functional_addr=False, debug=False):
     self.sendcan = sendcan
     self.logcan = logcan
     self.bus = bus
@@ -25,7 +28,7 @@ class IsoTpParallelQuery():
       else:
         self.real_addrs.append((a, None))
 
-    self.msg_addrs = {tx_addr: get_rx_addr_for_tx_addr(tx_addr[0]) for tx_addr in self.real_addrs}
+    self.msg_addrs = {tx_addr: get_rx_addr_for_tx_addr(tx_addr[0], rx_offset=response_offset) for tx_addr in self.real_addrs}
     self.msg_buffer = defaultdict(list)
 
   def rx(self):

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -26,40 +26,42 @@ class CarInterface(CarInterfaceBase):
     # VW port is a community feature, since we don't own one to test
     ret.communityFeature = True
 
-    if candidate == CAR.GOLF:
-      # Set common MQB parameters that will apply globally
-      ret.carName = "volkswagen"
-      ret.radarOffCan = True
-      ret.safetyModel = car.CarParams.SafetyModel.volkswagen
+    # Set common MQB parameters that will apply globally
+    ret.carName = "volkswagen"
+    ret.radarOffCan = True
+    ret.safetyModel = car.CarParams.SafetyModel.volkswagen
 
-      # Additional common MQB parameters that may be overridden per-vehicle
-      ret.steerRateCost = 0.5
-      ret.steerActuatorDelay = 0.05 # Hopefully all MQB racks are similar here
-      ret.steerLimitTimer = 0.4
+    # Additional common MQB parameters that may be overridden per-vehicle
+    ret.steerRateCost = 0.5
+    ret.steerActuatorDelay = 0.05  # Hopefully all MQB racks are similar here
+    ret.steerLimitTimer = 0.4
 
-      # As a starting point for speed-adjusted lateral tuning, use the example
-      # map speed breakpoints from a VW Tiguan (SSP 399 page 9). It's unclear
-      # whether the driver assist map breakpoints have any direct bearing on
-      # HCA assist torque, but if they're good breakpoints for the driver,
-      # they're probably good breakpoints for HCA as well. OP won't be driving
-      # 250kph/155mph but it provides interpolation scaling above 100kmh/62mph.
-      ret.lateralTuning.pid.kpBP = [0., 15 * CV.KPH_TO_MS, 50 * CV.KPH_TO_MS]
-      ret.lateralTuning.pid.kiBP = [0., 15 * CV.KPH_TO_MS, 50 * CV.KPH_TO_MS]
-
-      # FIXME: Per-vehicle parameters need to be reintegrated.
-      # For the time being, per-vehicle stuff is being archived since we
-      # can't auto-detect very well yet. Now that tuning is figured out,
-      # averaged params should work reasonably on a range of cars. Owners
-      # can tweak here, as needed, until we have car type auto-detection.
-
-      ret.mass = 1700 + STD_CARGO_KG
-      ret.wheelbase = 2.75
+    if candidate == CAR.VW_ATLAS_MK1:
+      ret.mass = 2042 + STD_CARGO_KG
+      ret.wheelbase = 2.98
+      ret.centerToFront = ret.wheelbase * 0.45
+      ret.steerRatio = 16.3
+      ret.lateralTuning.pid.kf = 0.00006
+      ret.lateralTuning.pid.kpV = [0.6]
+      ret.lateralTuning.pid.kiV = [0.2]
+    elif candidate == CAR.VW_GOLF_R_MK7:
+      ret.mass = 1500 + STD_CARGO_KG
+      ret.wheelbase = 2.64
       ret.centerToFront = ret.wheelbase * 0.45
       ret.steerRatio = 15.6
       ret.lateralTuning.pid.kf = 0.00006
-      ret.lateralTuning.pid.kpV = [0.15, 0.25, 0.60]
-      ret.lateralTuning.pid.kiV = [0.05, 0.05, 0.05]
-      tire_stiffness_factor = 0.6
+      ret.lateralTuning.pid.kpV = [0.6]
+      ret.lateralTuning.pid.kiV = [0.2]
+    elif candidate == CAR.VW_TIGUAN_MK2:
+      ret.mass = 1745 + STD_CARGO_KG
+      ret.wheelbase = 2.79
+      ret.centerToFront = ret.wheelbase * 0.45
+      ret.steerRatio = 15.6
+      ret.lateralTuning.pid.kf = 0.00006
+      ret.lateralTuning.pid.kpV = [0.6]
+      ret.lateralTuning.pid.kiV = [0.2]
+    else:
+      assert False  # Unsupported vehicle
 
     ret.enableCamera = True # Stock camera detection doesn't apply to VW
     ret.transmissionType = car.CarParams.TransmissionType.automatic

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -44,15 +44,36 @@ MQB_LDW_MESSAGES = {
 }
 
 class CAR:
-  GOLF = "Volkswagen Golf"
+  VW_ATLAS_MK1 = "Volkswagen Atlas 1st Gen"
+  VW_GOLF_R_MK7 = "Volkswagen Golf R 7th Gen"
+  VW_TIGUAN_MK2 = "Volkswagen Tiguan 2nd Gen"
 
-FINGERPRINTS = {
-  CAR.GOLF: [
-  # 76b83eb0245de90e|2019-10-21--17-40-42 - jyoung8607 car
-  {64: 8, 134: 8, 159: 8, 173: 8, 178: 8, 253: 8, 257: 8, 260: 8, 262: 8, 264: 8, 278: 8, 279: 8, 283: 8, 286: 8, 288: 8, 289: 8, 290: 8, 294: 8, 299: 8, 302: 8, 346: 8, 385: 8, 418: 8, 427: 8, 668: 8, 679: 8, 681: 8, 695: 8, 779: 8, 780: 8, 783: 8, 792: 8, 795: 8, 804: 8, 806: 8, 807: 8, 808: 8, 809: 8, 870: 8, 896: 8, 897: 8, 898: 8, 901: 8, 917: 8, 919: 8, 949: 8, 958: 8, 960: 4, 981: 8, 987: 8, 988: 8, 991: 8, 997: 8, 1000: 8, 1019: 8, 1120: 8, 1122: 8, 1123: 8, 1124: 8, 1153: 8, 1162: 8, 1175: 8, 1312: 8, 1385: 8, 1413: 8, 1440: 5, 1514: 8, 1515: 8, 1520: 8, 1600: 8, 1601: 8, 1603: 8, 1605: 8, 1624: 8, 1626: 8, 1629: 8, 1631: 8, 1646: 8, 1648: 8, 1712: 6, 1714: 8, 1716: 8, 1717: 8, 1719: 8, 1720: 8, 1721: 8
-  }],
+MQB_CARS = {
+  CAR.VW_ATLAS_MK1,
+  CAR.VW_GOLF_R_MK7,
+  CAR.VW_TIGUAN_MK2
+}
+
+# Volkswagen port using FP 2.0 exclusively
+FINGERPRINTS = {}
+
+FW_VERSIONS = {
+  CAR.VW_ATLAS_MK1: {
+    # Mk1 2018-2020 and Mk1.5 facelift 2021
+    (Ecu.eps, 0x712, None): [b'\x0571B60924A1'],  # 2019 Atlas
+  },
+  CAR.VW_GOLF_R_MK7: {
+    # Mk7 2013-2017 and Mk7.5 facelift 2018-2020
+    (Ecu.eps, 0x712, None): [b'\x0571A0JA15A1'],  # 2018 Golf R
+  },
+  CAR.VW_TIGUAN_MK2: {
+    # Mk2 2018-2020
+    (Ecu.eps, 0x712, None): [b'\x0521A60804A1'],  # 2020 Tiguan SEL Premium R-Line
+  },
 }
 
 DBC = {
-  CAR.GOLF: dbc_dict('vw_mqb_2010', None),
+  CAR.VW_ATLAS_MK1: dbc_dict('vw_mqb_2010', None),
+  CAR.VW_GOLF_R_MK7: dbc_dict('vw_mqb_2010', None),
+  CAR.VW_TIGUAN_MK2: dbc_dict('vw_mqb_2010', None),
 }

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -1,4 +1,6 @@
+from cereal import car
 from selfdrive.car import dbc_dict
+Ecu = car.CarParams.Ecu
 
 class CarControllerParams:
   HCA_STEP = 2                   # HCA_01 message frequency 50Hz


### PR DESCRIPTION
Do not merge, discussion only. CI expected to fail.

This is an example of minimally viable FPv2 for Volkswagen MQB. It adds support for different rx_addr offsets to the UDS and ISO-TP code in a way that tries to avoid affecting queries for other cars. Identification is done by querying the steering characteristic parameters from the EPS rack. A version of this does work on my development vehicle.

Further discussion: https://github.com/commaai/openpilot/issues/1238#issuecomment-620142101

**TL;DR:** I am not in favor of the steering-rack parameter ONLY approach to identification, but I'll implement it if that's what Comma wants. I still strongly advocate for using the VIN, backed up by UDS validation of versions, as the most correct and future-proof solution. It could be done in a way that only affects car port(s) that want to use the VIN as part of the identity mix.

Thoughts requested from @gregjhogan and @pd0wm based on our DM discussions.