### PR TITLE
Use Honda's HUD for OP's LDW. Use ldw from VisualAlert instead of steer_required.

### DIFF
--- a/selfdrive/car/chrysler/chryslercan.py
+++ b/selfdrive/car/chrysler/chryslercan.py
@@ -8,7 +8,7 @@ VisualAlert = car.CarControl.HUDControl.VisualAlert
 def create_lkas_hud(packer, gear, lkas_active, hud_alert, hud_count, lkas_car_model):
   # LKAS_HUD 0x2a6 (678) Controls what lane-keeping icon is displayed.
 
-  if hud_alert == VisualAlert.steerRequired:
+  if hud_alert in [VisualAlert.steerRequired, VisualAlert.ldw]:
     msg = b'\x00\x00\x00\x03\x00\x00\x00\x00'
     return make_can_msg(0x2a6, msg, 0)
 

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -21,7 +21,7 @@ class CarController():
   def update(self, enabled, CS, frame, actuators, visual_alert, pcm_cancel):
 
     can_sends = []
-    steer_alert = visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired
+    steer_alert = visual_alert in [car.CarControl.HUDControl.VisualAlert.steerRequired, car.CarControl.HUDControl.VisualAlert.ldw]
 
     apply_steer = actuators.steer
 

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -128,7 +128,7 @@ class CarController():
     lka_critical = lka_active and abs(actuators.steer) > 0.9
     lka_icon_status = (lka_active, lka_critical)
     if frame % P.CAMERA_KEEPALIVE_STEP == 0 or lka_icon_status != self.lka_icon_status_last:
-      steer_alert = hud_alert == VisualAlert.steerRequired
+      steer_alert = hud_alert in [VisualAlert.steerRequired, VisualAlert.ldw]
       can_sends.append(gmcan.create_lka_icon_command(CanBus.SW_GMLAN, lka_active, lka_critical, steer_alert))
       self.lka_icon_status_last = lka_icon_status
 

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -58,21 +58,24 @@ def process_hud_alert(hud_alert):
   fcw_display = 0
   steer_required = 0
   acc_alert = 0
+  ldw = 0
 
   # priority is: FCW, steer required, all others
   if hud_alert == VisualAlert.fcw:
     fcw_display = VISUAL_HUD[hud_alert.raw]
   elif hud_alert == VisualAlert.steerRequired:
     steer_required = VISUAL_HUD[hud_alert.raw]
+  elif hud_alert == VisualAlert.ldw:
+    ldw = VISUAL_HUD[hud_alert.raw]
   else:
     acc_alert = VISUAL_HUD[hud_alert.raw]
 
-  return fcw_display, steer_required, acc_alert
+  return fcw_display, steer_required, acc_alert, ldw
 
 
 HUDData = namedtuple("HUDData",
                      ["pcm_accel", "v_cruise",  "car",
-                     "lanes", "fcw", "acc_alert", "steer_required"])
+                     "lanes", "fcw", "acc_alert", "steer_required", "ldw"])
 
 class CarControllerParams():
   def __init__(self, CP):
@@ -127,10 +130,10 @@ class CarController():
     else:
       hud_car = 0
 
-    fcw_display, steer_required, acc_alert = process_hud_alert(hud_alert)
+    fcw_display, steer_required, acc_alert, ldw = process_hud_alert(hud_alert)
 
     hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_car,
-                  hud_lanes, fcw_display, acc_alert, steer_required)
+                  hud_lanes, fcw_display, acc_alert, steer_required, ldw)
 
     # **** process the car messages ****
 

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -141,8 +141,12 @@ def create_ui_commands(packer, pcm_speed, hud, car_fingerprint, is_metric, idx, 
     commands.append(packer.make_can_msg("ACC_HUD", bus_pt, acc_hud_values, idx))
 
   lkas_hud_values = {
-    'SET_ME_X41': 0x41,
-    'SET_ME_X48': 0x48,
+    'RDM_OFF': 1,
+    'RDM_ON': 0,
+    'RDM_ON_2': 0,
+    'RDM_HUD': hud.ldw,  # this triggers the hud warning
+    'RDM_HUD_2': 0,  # secondary bit for RDM. isn't always set by the car
+    'LKAS_READY': 1,
     'STEERING_REQUIRED': hud.steer_required,
     'SOLID_LANES': hud.lanes,
     'BEEP': 0,

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -21,7 +21,8 @@ VISUAL_HUD = {
   VisualAlert.brakePressed: 10,
   VisualAlert.wrongGear: 6,
   VisualAlert.seatbeltUnbuckled: 5,
-  VisualAlert.speedTooHigh: 8}
+  VisualAlert.speedTooHigh: 8,
+  VisualAlert.ldw: 1}
 
 class CAR:
   ACCORD = "HONDA ACCORD 2018 SPORT 2T"

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -10,7 +10,7 @@ VisualAlert = car.CarControl.HUDControl.VisualAlert
 
 def process_hud_alert(enabled, fingerprint, visual_alert, left_lane,
                       right_lane, left_lane_depart, right_lane_depart):
-  sys_warning = (visual_alert == VisualAlert.steerRequired)
+  sys_warning = (visual_alert in [VisualAlert.steerRequired, VisualAlert.ldw])
 
   # initialize to no line visible
   sys_state = 1

--- a/selfdrive/car/nissan/carcontroller.py
+++ b/selfdrive/car/nissan/carcontroller.py
@@ -36,7 +36,7 @@ class CarController():
     lkas_hud_info_msg = CS.lkas_hud_info_msg
     apply_angle = actuators.steerAngle
 
-    steer_hud_alert = 1 if hud_alert == VisualAlert.steerRequired else 0
+    steer_hud_alert = 1 if hud_alert in [VisualAlert.steerRequired, VisualAlert.ldw] else 0
 
     if enabled:
       # # windup slower

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -30,7 +30,7 @@ def create_es_distance(packer, es_distance_msg, pcm_cancel_cmd):
 def create_es_lkas(packer, es_lkas_msg, visual_alert, left_line, right_line):
 
   values = copy.copy(es_lkas_msg)
-  if visual_alert == VisualAlert.steerRequired:
+  if visual_alert in [VisualAlert.steerRequired, VisualAlert.ldw]:
     values["Keep_Hands_On_Wheel"] = 1
 
   values["LKAS_Left_Line_Visible"] = int(left_line)

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -136,7 +136,7 @@ class CarController():
     # - there is something to display
     # - there is something to stop displaying
     fcw_alert = hud_alert == VisualAlert.fcw
-    steer_alert = hud_alert == VisualAlert.steerRequired
+    steer_alert = hud_alert in [VisualAlert.steerRequired, VisualAlert.ldw]
 
     send_ui = False
     if ((fcw_alert or steer_alert) and not self.alert_active) or \

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -4,6 +4,8 @@ from selfdrive.car.volkswagen import volkswagencan
 from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
 from opendbc.can.packer import CANPacker
 
+VisualAlert = car.CarControl.HUDControl.VisualAlert
+
 
 class CarController():
   def __init__(self, dbc_name, CP, VM):
@@ -112,7 +114,7 @@ class CarController():
     if frame % P.LDW_STEP == 0:
       hcaEnabled = True if enabled and not CS.out.standstill else False
 
-      if visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired:
+      if visual_alert in [VisualAlert.steerRequired, VisualAlert.ldw]:
         hud_alert = MQB_LDW_MESSAGES["laneAssistTakeOverSilent"]
       else:
         hud_alert = MQB_LDW_MESSAGES["none"]

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -324,7 +324,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
       "TAKE CONTROL",
       "Lane Departure Detected",
       AlertStatus.userPrompt, AlertSize.mid,
-      Priority.LOW, VisualAlert.steerRequired, AudibleAlert.chimePrompt, 1., 2., 3.),
+      Priority.LOW, VisualAlert.ldw, AudibleAlert.chimePrompt, 1., 2., 3.),
   },
 
   # ********** events only containing alerts that display while engaged **********


### PR DESCRIPTION
**What's new:**

- Change OP's ldw alert to use the ldw value from VisualAlert in cereal. This minor change affects all car makes.
- Use the "Lane Departure" stock hud warning on Hondas for OP's lane departure alert instead of Steering Required.

Requires: https://github.com/commaai/opendbc/pull/252

**Todo:**
- [x] Remove submodule edit
- [x] Final test on Nidec
- [x] Final test on Bosch
- [ ] Ensure tests pass ([DBC PR required](https://github.com/commaai/opendbc/pull/252))