### PR TITLE
remove redundant ret.steerControlType line

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -386,8 +386,6 @@ class CarInterface(CarInterfaceBase):
     else:
       raise ValueError("unsupported car %s" % candidate)
 
-    ret.steerControlType = car.CarParams.SteerControlType.torque
-
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter. Otherwise, add 0.5 mph margin to not
     # conflict with PCM acc

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -120,9 +120,9 @@ class CarController():
         can_sends.append(create_accel_command(self.packer, 0, pcm_cancel_cmd, False, lead))
 
     if (frame % 2 == 0) and (CS.CP.enableGasInterceptor):
-        # send exactly zero if apply_gas is zero. Interceptor will send the max between read value and apply_gas.
-        # This prevents unexpected pedal range rescaling
-        can_sends.append(create_gas_command(self.packer, apply_gas, frame//2))
+      # send exactly zero if apply_gas is zero. Interceptor will send the max between read value and apply_gas.
+      # This prevents unexpected pedal range rescaling
+      can_sends.append(create_gas_command(self.packer, apply_gas, frame//2))
 
     # ui mesg is at 100Hz but we send asap if:
     # - there is something to display


### PR DESCRIPTION
Very simple PR, just removed redundant line in honda/interface.py since it inherits it from `CarInterfaceBase`. Also removed two spaces before a few lines in toyota/carcontroller so that indentation matches with rest of file.