### PR TITLE
honda bosch disable radar

### DIFF
--- a/common/params.py
+++ b/common/params.py
@@ -108,6 +108,7 @@ keys = {
   "Offroad_PandaFirmwareMismatch": [TxType.CLEAR_ON_MANAGER_START, TxType.CLEAR_ON_PANDA_DISCONNECT],
   "Offroad_InvalidTime": [TxType.CLEAR_ON_MANAGER_START],
   "Offroad_IsTakingSnapshot": [TxType.CLEAR_ON_MANAGER_START],
+  "VisionRadarToggle": [TxType.PERSISTENT],
 }
 
 

--- a/selfdrive/car/disable_ecu.py
+++ b/selfdrive/car/disable_ecu.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import traceback
+
+import cereal.messaging as messaging
+from selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
+from selfdrive.swaglog import cloudlog
+
+EXT_DIAG_REQUEST = b'\x10\x03'
+EXT_DIAG_RESPONSE = b'\x50\x03'
+COM_CONT_REQUEST = b'\x28\x83\x03'
+COM_CONT_RESPONSE = b''
+
+def disable_ecu(ecu_addr, logcan, sendcan, bus, timeout=0.1, retry=5, debug=False):
+  print(f"ecu disable {hex(ecu_addr)} ...")
+  for i in range(retry):
+    try:
+      # enter extended diagnostic session
+      query = IsoTpParallelQuery(sendcan, logcan, bus, [ecu_addr], [EXT_DIAG_REQUEST], [EXT_DIAG_RESPONSE], debug=debug)
+      for addr, dat in query.get_data(timeout).items():
+        print(f"ecu communication control disable tx/rx ...")
+        # communication control disable tx and rx
+        query = IsoTpParallelQuery(sendcan, logcan, bus, [ecu_addr], [COM_CONT_REQUEST], [COM_CONT_RESPONSE], debug=debug)
+        query.get_data(0)
+        return True
+      print(f"ecu disable retry ({i+1}) ...")
+    except Exception:
+      cloudlog.warning(f"ecu disable exception: {traceback.format_exc()}")
+
+  return False
+
+
+if __name__ == "__main__":
+  import time
+  sendcan = messaging.pub_sock('sendcan')
+  logcan = messaging.sub_sock('can')
+  time.sleep(1)
+  disabled = disable_ecu(0x18DAB0F1, logcan, sendcan, 1, debug=False)
+  print(f"disabled: {disabled}")

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -5,7 +5,7 @@ from selfdrive.controls.lib.drive_helpers import rate_limit
 from common.numpy_fast import clip, interp
 from selfdrive.car import create_gas_command
 from selfdrive.car.honda import hondacan
-from selfdrive.car.honda.values import CruiseButtons, CAR, VISUAL_HUD
+from selfdrive.car.honda.values import CruiseButtons, CAR, VISUAL_HUD, HONDA_BOSCH
 from opendbc.can.packer import CANPacker
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
@@ -143,6 +143,12 @@ class CarController():
 
     # Send CAN commands.
     can_sends = []
+
+    if CS.CP.carFingerprint in HONDA_BOSCH and CS.CP.openpilotLongitudinalControl:
+      # TODO: radar disable hacked together to see if it works
+      if (frame % 10) == 0:
+        # tester present - w/ no response (keeps radar disabled)
+        can_sends.append([0x18DAB0F1, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 1 if CS.CP.isPandaBlack else 0])
 
     # Send steering command.
     idx = frame % 4

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -11,6 +11,7 @@ import cereal.messaging as messaging
 from selfdrive.config import Conversions as CV
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from selfdrive.car.car_helpers import get_car, get_startup_alert
+from selfdrive.car.disable_ecu import disable_ecu
 from selfdrive.controls.lib.lane_planner import CAMERA_OFFSET
 from selfdrive.controls.lib.drive_helpers import get_events, \
                                                  create_event, \
@@ -491,6 +492,9 @@ def controlsd_thread(sm=None, pm=None, can_sock=None):
   params.put("CarParams", cp_bytes)
   put_nonblocking("CarParamsCache", cp_bytes)
   put_nonblocking("LongitudinalControl", "1" if CP.openpilotLongitudinalControl else "0")
+
+  if CP.openpilotLongitudinalControl and CP.safetyModel in [car.CarParams.SafetyModel.hondaBoschGiraffe, car.CarParams.SafetyModel.hondaBoschHarness]:
+    disable_ecu(0x18DAB0F1, can_sock, pm.sock['sendcan'], 1 if has_relay else 0, timeout=1, retry=10)
 
   CC = car.CarControl.new_message()
   AM = AlertManager()


### PR DESCRIPTION
the following steps disable the radar:
* enter extended diagnostic session
* send communication control message for disable tx and rx with suppress response bit
* send tester present with suppress response bit periodically to keep radar silent
  (radar wakes back up if it doesn't get a tester present message for a few seconds)

disabling an ecu in this manner is not unique to honda