### PR TITLE
fix wrong order of cleanup calls

### DIFF
--- a/selfdrive/logcatd/logcatd.cc
+++ b/selfdrive/logcatd/logcatd.cc
@@ -64,8 +64,8 @@ int main() {
 
   android_logger_list_close(logger_list);
 
-  delete c;
   delete androidLog;
+  delete c;
 
   return 0;
 }

--- a/selfdrive/proclogd/proclogd.cc
+++ b/selfdrive/proclogd/proclogd.cc
@@ -240,8 +240,8 @@ int main() {
     usleep(2000000); // 2 secs
   }
 
-  delete c;
   delete publisher;
+  delete c;
 
   return 0;
 }


### PR DESCRIPTION
delete Context before publisher can potentially hang forever

> Killing old publisher: androidLog
Killing old publisher: androidLog
Killing old publisher: androidLog
Killing old publisher: androidLog
Killing old publisher: androidLog
Killing old publisher: androidLog