### PR TITLE
Add 2020 Honda CRV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Supported Cars
 | Honda     | Civic Sedan/Coupe 2016-18     | Honda Sensing     | openpilot        | 0mph               | 12mph             |
 | Honda     | Civic Sedan/Coupe 2019-20     | Honda Sensing     | Stock            | 0mph               | 2mph<sup>2</sup>  |
 | Honda     | CR-V 2015-16                  | Touring           | openpilot        | 25mph<sup>1</sup>  | 12mph             |
-| Honda     | CR-V 2017-19                  | Honda Sensing     | Stock            | 0mph               | 12mph             |
+| Honda     | CR-V 2017-20                  | Honda Sensing     | Stock            | 0mph               | 12mph             |
 | Honda     | CR-V Hybrid 2017-2019         | Honda Sensing     | Stock            | 0mph               | 12mph             |
 | Honda     | Fit 2018-19                   | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |
 | Honda     | HR-V 2019                     | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -469,6 +469,7 @@ FW_VERSIONS = {
       b'37805-5PA-A870\x00\x00',
       b'37805-5PA-A880\x00\x00',
       b'37805-5PA-A890\x00\x00',
+      b'37805-5PA-9640\x00\x00',
       b'37805-5PD-Q630\x00\x00',
     ],
     (Ecu.transmission, 0x18da1ef1, None): [
@@ -476,6 +477,7 @@ FW_VERSIONS = {
       b'28101-5RG-A030\x00\x00',
       b'28101-5RG-A040\x00\x00',
       b'28101-5RG-A120\x00\x00',
+      b'28101-5RG-A220\x00\x00',
       b'28101-5RH-A030\x00\x00',
       b'28101-5RH-A040\x00\x00',
       b'28101-5RH-A120\x00\x00',
@@ -485,21 +487,25 @@ FW_VERSIONS = {
       b'57114-TLA-A040\x00\x00',
       b'57114-TLA-A050\x00\x00',
       b'57114-TLA-A060\x00\x00',
+      b'57114-TLB-A830\x00\x00',
       b'57114-TMC-Z050\x00\x00',
     ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-TLA,A040\x00\x00',
       b'39990-TLA-A040\x00\x00',
+      b'39990-TLA-A220\x00\x00',
       b'39990-TMT-T010\x00\x00',
     ],
     (Ecu.electricBrakeBooster, 0x18da2bf1, None): [
       b'46114-TLA-A040\x00\x00',
       b'46114-TLA-A050\x00\x00',
+      b'46114-TLA-A930\x00\x00',
       b'46114-TMC-U020\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TLA-A110\x00\x00',
       b'78109-TLA-A210\x00\x00',
+      b'78109-TLA-A220\x00\x00',
       b'78109-TLA-C210\x00\x00',
       b'78109-TLB-A110\x00\x00',
       b'78109-TLB-A210\x00\x00',
@@ -507,6 +513,7 @@ FW_VERSIONS = {
     ],
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-TLA-A010\x00\x00',
+      b'38897-TLA-A110\x00\x00',
       b'38897-TNY-G010\x00\x00',
     ],
     (Ecu.fwdRadar, 0x18dab0f1, None): [
@@ -514,12 +521,14 @@ FW_VERSIONS = {
       b'36802-TLA-A050\x00\x00',
       b'36802-TLA-A060\x00\x00',
       b'36802-TMC-Q070\x00\x00',
+      b'36802-TNY-A030\x00\x00',
     ],
     (Ecu.fwdCamera, 0x18dab5f1, None): [
       b'36161-TLA-A060\x00\x00',
       b'36161-TLA-A070\x00\x00',
       b'36161-TLA-A080\x00\x00',
       b'36161-TMC-Q040\x00\x00',
+      b'36161-TNY-A020\x00\x00',
     ],
     (Ecu.srs, 0x18da53f1, None): [
       b'77959-TLA-A240\x00\x00',


### PR DESCRIPTION
Drive > https://my.comma.ai/cabana/?route=243d0daa5d208cdd%7C2020-05-04--13-14-09&exp=1620158889&sig=b2O1Uj7wq5fxDPB7Fi6m5iGkvTm2tznZQxXRjTa1IO0%3D&max=23&url=https%3A%2F%2Fchffrprivate-vzn.azureedge.net%2Fchffrprivate3%2Fv2%2F243d0daa5d208cdd%2F4645f7e8fce3c2c37994cbea4363a9c1_2020-05-04--13-14-09

Looks like normal CRV_5G to me.