### PR TITLE
Shebang Fix

### DIFF
--- a/scripts/get_fan_control_type.py
+++ b/scripts/get_fan_control_type.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 import os
 from smbus2 import SMBus
 

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 import json
 import os
 import hashlib

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 import os
 import time
 import sys

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 import os
 import json
 import copy


### PR DESCRIPTION
Per George's "I'd merge a PR replacing the 4 python3.7 with python3" on Discord. George updated Python to 3.8.2 for webcam tools, which broke manager from launching nicely. Instead of chasing the exact version, it seems more reasonable to fall back to 3.