### PR TITLE
Small CPU improvement for UI

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -190,8 +190,8 @@ static int read_param_uint64_timeout(uint64_t* dest, const char* param_name, int
     (*timeout)--;
     return 0;
   } else {
-    return read_param_uint64(dest, param_name, persistent_param);
     *timeout = 2 * UI_FREQ; // 0.5Hz
+    return read_param_uint64(dest, param_name, persistent_param);
   }
 }
 


### PR DESCRIPTION
Recover 1% constant CPU usage in UI: fix a bug where `read_param_uint64_timeout()` never reached the code that set its timeout, so we were reading LastAthenaPingTime from disk (and performing associated flock()ing writes) for every single pass through the UI render thread, 30Hz instead of 0.5Hz.

As an aside, there are a bunch of constant params polling usage patterns in various OP processes that are really crying out for [inotify](http://man7.org/linux/man-pages/man7/inotify.7.html).