### PR TITLE
Fast CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
         cd $TEST_DIR
         mkdir pyextra laika laika_repo tools release
     - name: Build Docker image
-      run: cd $TEST_DIR && eval $BUILD
+      run: cd $TEST_DIR && eval "$BUILD"
         docker pull $(grep -ioP '(?<=^from)\s+\S+' Dockerfile.openpilot) || true
         docker pull docker.io/commaai/openpilot:latest || true
         docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
@@ -58,7 +58,7 @@ jobs:
         with:
           submodules: true
       - name: Build Docker image
-        run: eval $BUILD
+        run: eval "$BUILD"
       - name: Push to dockerhub
         run: |
           docker login -u wmelching -p ${{ secrets.DOCKERHUB_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
         with:
           submodules: true
       - name: Build Docker image
-        run: eval $BUILD
+        run: eval "$BUILD"
       - name: flake8
         run: $RUN "cd /tmp/openpilot/ && ./flake8_openpilot.sh"
       - name: pylint
@@ -87,7 +87,7 @@ jobs:
         with:
           submodules: true
       - name: Build Docker image
-        run: eval $BUILD
+        run: eval "$BUILD"
       - name: Run unit tests
         run: |
           $PERSIST "cd /tmp/openpilot && \
@@ -116,7 +116,7 @@ jobs:
         with:
           submodules: true
       - name: Build Docker image
-        run: eval $BUILD
+        run: eval "$BUILD"
       - name: Run replay
         run: |
           $PERSIST "cd /tmp/openpilot && \
@@ -148,7 +148,7 @@ jobs:
         with:
           submodules: true
       - name: Build Docker image
-        run: eval $BUILD
+        run: eval "$BUILD"
       - name: Test longitudinal
         run: |
           $PERSIST "mkdir -p /tmp/openpilot/selfdrive/test/out && \
@@ -176,7 +176,7 @@ jobs:
         with:
           submodules: true
       - name: Build Docker image
-        run: eval $BUILD
+        run: eval "$BUILD"
       - name: Test car models
         run: |
           $PERSIST "mkdir -p /data/params && \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
   build_release:
     name: build release
     runs-on: ubuntu-16.04
-    timeout-minutes: 30
+    timeout-minutes: 50
     env:
       TEST_DIR: tmppilot
     steps:
@@ -110,7 +110,7 @@ jobs:
   process_replay:
     name: process replay
     runs-on: ubuntu-16.04
-    timeout-minutes: 30
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v2
         with:
@@ -142,7 +142,7 @@ jobs:
   test_longitudinal:
     name: longitudinal
     runs-on: ubuntu-16.04
-    timeout-minutes: 30
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v2
         with:
@@ -170,7 +170,7 @@ jobs:
   test_car_models:
     name: test car models
     runs-on: ubuntu-16.04
-    timeout-minutes: 30
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,6 +109,7 @@ jobs:
       - name: Run unit tests
         run: |
           $PERSIST "cd /tmp/openpilot && \
+                    scons -j$(nproc) && \
                     coverage run selfdrive/test/test_fingerprints.py && \
                     $UNIT_TEST common && \
                     $UNIT_TEST opendbc/can && \
@@ -137,7 +138,9 @@ jobs:
         run: $LOAD
       - name: Run replay
         run: |
-          $PERSIST "cd /tmp/openpilot && CI=1 coverage run selfdrive/test/process_replay/test_processes.py"
+          $PERSIST "cd /tmp/openpilot && \
+                    scons -j$(nproc) && \
+                    CI=1 coverage run selfdrive/test/process_replay/test_processes.py"
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci
@@ -168,7 +171,11 @@ jobs:
         run: $LOAD
       - name: Test longitudinal
         run: |
-          $PERSIST "cd /tmp/openpilot/selfdrive/test/longitudinal_maneuvers && OPTEST=1 ./test_longitudinal.py"
+          $PERSIST "mkdir -p /tmp/openpilot/selfdrive/test/out && \
+                    cd /tmp/openpilot/ && \
+                    scons -j$(nproc) && \
+                    cd selfdrive/test/longitudinal_maneuvers && \
+                    OPTEST=1 ./test_longitudinal.py"
       - name: Copy artifacts
         if: always()
         run: |
@@ -193,7 +200,11 @@ jobs:
         run: $LOAD
       - name: Test car models
         run: |
-          $PERSIST "mkdir -p /data/params && cd /tmp/openpilot && coverage run --parallel-mode --concurrency=multiprocessing --rcfile=./.coveragerc-app selfdrive/test/test_car_models.py && coverage combine"
+          $PERSIST "mkdir -p /data/params && \
+                    cd /tmp/openpilot && \
+                    scons -j$(nproc) && \
+                    coverage run --parallel-mode --concurrency=multiprocessing --rcfile=./.coveragerc-app selfdrive/test/test_car_models.py && \
+                    coverage combine"
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,12 +56,14 @@ jobs:
            .coveragerc-app $TEST_DIR
         cd $TEST_DIR
         mkdir pyextra laika laika_repo tools release
-    - name: Build
+    - name: Build docker image
       run: |
         cd $TEST_DIR
         docker pull $(grep -ioP '(?<=^from)\s+\S+' Dockerfile.openpilot) || true
         docker pull docker.io/commaai/openpilot:latest || true
         docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
+    - name: Build openpilot
+      run: $RUN "cd /tmp/openpilot && scons -j$(nproc)"
 
   push:
     name: push

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
   RUN: docker run --shm-size 1G --rm tmppilot /bin/sh -c
   PERSIST: docker run --shm-size 1G --name tmppilot tmppilot /bin/sh -c
-  LOAD: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
+  LOAD: docker load < tmppilot/tmppilot
   CI_RUN: docker run -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID --rm tmppilotci /bin/bash -c
   UNIT_TEST: coverage run --append -m unittest discover
 
@@ -22,11 +22,11 @@ jobs:
         docker pull docker.io/commaai/openpilot:latest || true
 
         docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
-        docker save tmppilot:latest | gzip > tmppilot.tar.gz
+        docker save tmppilot:latest > tmppilot
     - uses: actions/upload-artifact@v2
       with:
-        name: tmppilot.tar.gz
-        path: tmppilot.tar.gz
+        name: tmppilot
+        path: tmppilot
 
   build_release:
     name: build release
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot.tar.gz
+          name: tmppilot
       - name: Load image
         run: $LOAD
       - name: Login to dockerhub
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot.tar.gz
+          name: tmppilot
       - name: Load image
         run: $LOAD
       - name: flake8
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot.tar.gz
+          name: tmppilot
       - name: Load image
         run: $LOAD
       - name: Run unit tests
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot.tar.gz
+          name: tmppilot
       - name: Load image
         run: $LOAD
       - name: Run replay
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot.tar.gz
+          name: tmppilot
       - name: Load image
         run: $LOAD
       - name: Test longitudinal
@@ -196,7 +196,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot.tar.gz
+          name: tmppilot
       - name: Load image
         run: $LOAD
       - name: Test car models

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,17 +42,14 @@ jobs:
         mkdir pyextra laika laika_repo tools release
     - name: Build Docker image
       run: cd $TEST_DIR && eval "$BUILD"
-        docker pull $(grep -ioP '(?<=^from)\s+\S+' Dockerfile.openpilot) || true
-        docker pull docker.io/commaai/openpilot:latest || true
-        docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
     - name: Build openpilot
       run: $RUN "cd /tmp/openpilot && scons -j$(nproc)"
 
   docker_push:
     name: docker push
     runs-on: ubuntu-16.04
-    #if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
-    if: github.repository == 'commaai/openpilot'
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
+    needs: linter # hack to ensure slow tests run first since this and linter are fast
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
   RUN: docker run --shm-size 1G --rm tmppilot /bin/sh -c
   PERSIST: docker run --shm-size 1G --name tmppilot tmppilot /bin/sh -c
-  LOAD: docker load < tmppilot/tmppilot
+  LOAD: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
   CI_RUN: docker run -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID --rm tmppilotci /bin/bash -c
   UNIT_TEST: coverage run --append -m unittest discover
 
@@ -22,11 +22,11 @@ jobs:
         docker pull docker.io/commaai/openpilot:latest || true
 
         docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
-        docker save tmppilot:latest > tmppilot
+        docker save tmppilot:latest | gzip > tmppilot.tar.gz
     - uses: actions/upload-artifact@v2
       with:
-        name: tmppilot
-        path: tmppilot
+        name: tmppilot.tar.gz
+        path: tmppilot.tar.gz
 
   build_release:
     name: build release
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot
+          name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
       - name: Login to dockerhub
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot
+          name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
       - name: flake8
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot
+          name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
       - name: Run unit tests
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot
+          name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
       - name: Run replay
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot
+          name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
       - name: Test longitudinal
@@ -196,7 +196,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: tmppilot
+          name: tmppilot.tar.gz
       - name: Load image
         run: $LOAD
       - name: Test car models

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,33 +1,17 @@
-name: Openpilot Tests
+name: openpilot tests
 on: [push, pull_request]
 
 env:
   RUN: docker run --shm-size 1G --rm tmppilot /bin/sh -c
   PERSIST: docker run --shm-size 1G --name tmppilot tmppilot /bin/sh -c
-  LOAD: docker load -i tmppilot.tar.gz/tmppilot.tar.gz
   CI_RUN: docker run -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID --rm tmppilotci /bin/bash -c
   UNIT_TEST: coverage run --append -m unittest discover
+  BUILD: |
+      docker pull $(grep -ioP '(?<=^from)\s+\S+' Dockerfile.openpilot) || true
+      docker pull docker.io/commaai/openpilot:latest || true
+      docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
 
 jobs:
-  build:
-    name: build
-    runs-on: ubuntu-16.04
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Build docker image
-      run: |
-        docker pull $(grep -ioP '(?<=^from)\s+\S+' Dockerfile.openpilot) || true
-        docker pull docker.io/commaai/openpilot:latest || true
-
-        docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
-        docker save tmppilot:latest | gzip > tmppilot.tar.gz
-    - uses: actions/upload-artifact@v2
-      with:
-        name: tmppilot.tar.gz
-        path: tmppilot.tar.gz
-
   build_release:
     name: build release
     runs-on: ubuntu-16.04
@@ -56,44 +40,40 @@ jobs:
            .coveragerc-app $TEST_DIR
         cd $TEST_DIR
         mkdir pyextra laika laika_repo tools release
-    - name: Build docker image
-      run: |
-        cd $TEST_DIR
+    - name: Build Docker image
+      run: cd $TEST_DIR && eval $BUILD
         docker pull $(grep -ioP '(?<=^from)\s+\S+' Dockerfile.openpilot) || true
         docker pull docker.io/commaai/openpilot:latest || true
         docker build --cache-from docker.io/commaai/openpilot:latest -t tmppilot -f Dockerfile.openpilot .
     - name: Build openpilot
       run: $RUN "cd /tmp/openpilot && scons -j$(nproc)"
 
-  push:
-    name: push
+  docker_push:
+    name: docker push
     runs-on: ubuntu-16.04
-    needs: build
     #if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
     if: github.repository == 'commaai/openpilot'
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/checkout@v2
         with:
-          name: tmppilot.tar.gz
-      - name: Load image
-        run: $LOAD
-      - name: Login to dockerhub
-        run: docker login -u wmelching -p ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Tag image
-        run: docker tag tmppilot docker.io/commaai/openpilot:latest
-      - name: Push image
-        run: docker push docker.io/commaai/openpilot:latest
+          submodules: true
+      - name: Build Docker image
+        run: eval $BUILD
+      - name: Push to dockerhub
+        run: |
+          docker login -u wmelching -p ${{ secrets.DOCKERHUB_TOKEN }}
+          docker tag tmppilot docker.io/commaai/openpilot:latest
+          docker push docker.io/commaai/openpilot:latest
 
   linter:
     name: linter
     runs-on: ubuntu-16.04
-    needs: build
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/checkout@v2
         with:
-          name: tmppilot.tar.gz
-      - name: Load image
-        run: $LOAD
+          submodules: true
+      - name: Build Docker image
+        run: eval $BUILD
       - name: flake8
         run: $RUN "cd /tmp/openpilot/ && ./flake8_openpilot.sh"
       - name: pylint
@@ -102,13 +82,12 @@ jobs:
   unit_tests:
     name: unit tests
     runs-on: ubuntu-16.04
-    needs: build
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/checkout@v2
         with:
-          name: tmppilot.tar.gz
-      - name: Load image
-        run: $LOAD
+          submodules: true
+      - name: Build Docker image
+        run: eval $BUILD
       - name: Run unit tests
         run: |
           $PERSIST "cd /tmp/openpilot && \
@@ -131,14 +110,13 @@ jobs:
   process_replay:
     name: process replay
     runs-on: ubuntu-16.04
-    needs: build
     timeout-minutes: 30
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/checkout@v2
         with:
-          name: tmppilot.tar.gz
-      - name: Load image
-        run: $LOAD
+          submodules: true
+      - name: Build Docker image
+        run: eval $BUILD
       - name: Run replay
         run: |
           $PERSIST "cd /tmp/openpilot && \
@@ -164,14 +142,13 @@ jobs:
   test_longitudinal:
     name: longitudinal
     runs-on: ubuntu-16.04
-    needs: build
     timeout-minutes: 30
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/checkout@v2
         with:
-          name: tmppilot.tar.gz
-      - name: Load image
-        run: $LOAD
+          submodules: true
+      - name: Build Docker image
+        run: eval $BUILD
       - name: Test longitudinal
         run: |
           $PERSIST "mkdir -p /tmp/openpilot/selfdrive/test/out && \
@@ -193,14 +170,13 @@ jobs:
   test_car_models:
     name: test car models
     runs-on: ubuntu-16.04
-    needs: build
     timeout-minutes: 30
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/checkout@v2
         with:
-          name: tmppilot.tar.gz
-      - name: Load image
-        run: $LOAD
+          submodules: true
+      - name: Build Docker image
+        run: eval $BUILD
       - name: Test car models
         run: |
           $PERSIST "mkdir -p /data/params && \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,8 @@ jobs:
     name: push
     runs-on: ubuntu-16.04
     needs: build
-    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
+    #if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
+    if: github.repository == 'commaai/openpilot'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -81,6 +81,3 @@ COPY ./panda /tmp/openpilot/panda
 COPY ./selfdrive /tmp/openpilot/selfdrive
 
 COPY SConstruct /tmp/openpilot/SConstruct
-
-RUN mkdir -p /tmp/openpilot/selfdrive/test/out
-RUN cd /tmp/openpilot && scons -j$(nproc)

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -1,5 +1,6 @@
 FROM ubuntu:16.04
 ENV PYTHONUNBUFFERED 1
+ENV PYTHONPATH /tmp/openpilot:${PYTHONPATH}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
@@ -37,13 +38,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-pip \
     sudo \
     wget \
-    && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+# Install python dependencies
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
 ENV PATH="/root/.pyenv/bin:/root/.pyenv/shims:${PATH}"
 
@@ -53,30 +55,31 @@ RUN pyenv install 3.8.2 && \
     pyenv rehash && \
     pip install --no-cache-dir pipenv==2018.11.26 && \
     cd /tmp && \
-    pipenv install --system --deploy
-
-# Install subset of dev dependencies needed for CI
-RUN pip install --no-cache-dir \
-    matplotlib==3.1.1 \
-    dictdiffer==0.8.0 \
-    fastcluster==1.1.25 \
-    aenum==2.2.1 \
-    lru-dict==1.1.6 \
-    scipy==1.4.1 \
-    tenacity==5.1.1 \
-    azure-common==1.1.23 \
-    azure-nspkg==3.0.2 \
-    azure-storage-blob==2.1.0 \
-    azure-storage-common==2.1.0 \
-    azure-storage-nspkg==3.1.0 \
-    pycurl==7.43.0.3 \
-    coverage==5.1
-
-ENV PYTHONPATH /tmp/openpilot:${PYTHONPATH}
+    pipenv install --system --deploy --clear && \
+    pip install --no-cache-dir \ # Install subset of dev dependencies needed for CI
+      matplotlib==3.1.1 \
+      dictdiffer==0.8.0 \
+      fastcluster==1.1.25 \
+      aenum==2.2.1 \
+      lru-dict==1.1.6 \
+      scipy==1.4.1 \
+      tenacity==5.1.1 \
+      azure-common==1.1.23 \
+      azure-nspkg==3.0.2 \
+      azure-storage-blob==2.1.0 \
+      azure-storage-common==2.1.0 \
+      azure-storage-nspkg==3.1.0 \
+      pycurl==7.43.0.3 \
+      coverage==5.1
 
 RUN mkdir -p /tmp/openpilot
 
-COPY ./flake8_openpilot.sh ./pylint_openpilot.sh ./.pylintrc ./.coveragerc-app /tmp/openpilot/
+COPY SConstruct \
+     ./flake8_openpilot.sh \
+     ./pylint_openpilot.sh \
+     ./.pylintrc \
+     ./.coveragerc-app \
+     /tmp/openpilot/
 
 COPY ./pyextra /tmp/openpilot/pyextra
 COPY ./phonelibs /tmp/openpilot/phonelibs
@@ -90,5 +93,3 @@ COPY ./opendbc /tmp/openpilot/opendbc
 COPY ./cereal /tmp/openpilot/cereal
 COPY ./panda /tmp/openpilot/panda
 COPY ./selfdrive /tmp/openpilot/selfdrive
-
-COPY SConstruct /tmp/openpilot/SConstruct

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     cmake \
     curl \
-    git \
     ffmpeg \
+    git \
     libarchive-dev \
     libbz2-dev \
     libcurl4-openssl-dev \
@@ -53,7 +53,7 @@ RUN pyenv install 3.8.2 && \
     pyenv rehash && \
     pip install --no-cache-dir pipenv==2018.11.26 && \
     cd /tmp && \
-    pipenv install --sytem --deploy
+    pipenv install --system --deploy
 
 # Install subset of dev dependencies needed for CI
 RUN pip install --no-cache-dir \

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     cmake \
     curl \
+    ffmpeg \
     git \
     libarchive-dev \
     libbz2-dev \

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -56,23 +56,22 @@ RUN pyenv install 3.8.2 && \
     pip install --no-cache-dir pipenv==2018.11.26 && \
     cd /tmp && \
     pipenv install --system --deploy --clear && \
-    # TODO: check if this is worth it
-    #pip uninstall -y pipenv && \
+    pip uninstall -y pipenv && \
     pip install --no-cache-dir \
-    matplotlib==3.1.1 \
-    dictdiffer==0.8.0 \
-    fastcluster==1.1.25 \
-    aenum==2.2.1 \
-    lru-dict==1.1.6 \
-    scipy==1.4.1 \
-    tenacity==5.1.1 \
-    azure-common==1.1.23 \
-    azure-nspkg==3.0.2 \
-    azure-storage-blob==2.1.0 \
-    azure-storage-common==2.1.0 \
-    azure-storage-nspkg==3.1.0 \
-    pycurl==7.43.0.3 \
-    coverage==5.1
+      matplotlib==3.1.1 \
+      dictdiffer==0.8.0 \
+      fastcluster==1.1.25 \
+      aenum==2.2.1 \
+      lru-dict==1.1.6 \
+      scipy==1.4.1 \
+      tenacity==5.1.1 \
+      azure-common==1.1.23 \
+      azure-nspkg==3.0.2 \
+      azure-storage-blob==2.1.0 \
+      azure-storage-common==2.1.0 \
+      azure-storage-nspkg==3.1.0 \
+      pycurl==7.43.0.3 \
+      coverage==5.1
 
 RUN mkdir -p /tmp/openpilot
 

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     cmake \
     curl \
-    ffmpeg \
     git \
     libarchive-dev \
     libbz2-dev \

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -56,21 +56,23 @@ RUN pyenv install 3.8.2 && \
     pip install --no-cache-dir pipenv==2018.11.26 && \
     cd /tmp && \
     pipenv install --system --deploy --clear && \
-    pip install --no-cache-dir \ # Install subset of dev dependencies needed for CI
-      matplotlib==3.1.1 \
-      dictdiffer==0.8.0 \
-      fastcluster==1.1.25 \
-      aenum==2.2.1 \
-      lru-dict==1.1.6 \
-      scipy==1.4.1 \
-      tenacity==5.1.1 \
-      azure-common==1.1.23 \
-      azure-nspkg==3.0.2 \
-      azure-storage-blob==2.1.0 \
-      azure-storage-common==2.1.0 \
-      azure-storage-nspkg==3.1.0 \
-      pycurl==7.43.0.3 \
-      coverage==5.1
+    # TODO: check if this is worth it
+    #pip uninstall -y pipenv && \
+    pip install --no-cache-dir \
+    matplotlib==3.1.1 \
+    dictdiffer==0.8.0 \
+    fastcluster==1.1.25 \
+    aenum==2.2.1 \
+    lru-dict==1.1.6 \
+    scipy==1.4.1 \
+    tenacity==5.1.1 \
+    azure-common==1.1.23 \
+    azure-nspkg==3.0.2 \
+    azure-storage-blob==2.1.0 \
+    azure-storage-common==2.1.0 \
+    azure-storage-nspkg==3.1.0 \
+    pycurl==7.43.0.3 \
+    coverage==5.1
 
 RUN mkdir -p /tmp/openpilot
 

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglfw3-dev \
     libglib2.0-0 \
     liblzma-dev \
-    libmysqlclient-dev \
     libomp-dev \
     libopencv-dev \
     libssl-dev \

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     curl \
     git \
+    ffmpeg \
     libarchive-dev \
     libbz2-dev \
     libcurl4-openssl-dev \
@@ -26,7 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libopencv-dev \
     libssl-dev \
     libsqlite3-dev \
-    libtool \
     libusb-1.0-0-dev \
     libczmq-dev \
     libzmq3-dev \

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libomp-dev \
     libopencv-dev \
     libssl-dev \
+    libsqlite3-dev \
     libusb-1.0-0-dev \
     libczmq-dev \
     libzmq3-dev \
@@ -44,19 +45,32 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-
 ENV PATH="/root/.pyenv/bin:/root/.pyenv/shims:${PATH}"
-RUN pyenv install 3.8.2 && pyenv global 3.8.2
-RUN pyenv rehash
-
-RUN pip install --no-cache-dir pipenv==2018.11.26
 
 COPY Pipfile Pipfile.lock /tmp/
-
-RUN cd /tmp && pipenv install --system --deploy
+RUN pyenv install 3.8.2 && \
+    pyenv global 3.8.2 && \
+    pyenv rehash && \
+    pip install --no-cache-dir pipenv==2018.11.26 && \
+    cd /tmp && \
+    pipenv install --sytem --deploy
 
 # Install subset of dev dependencies needed for CI
-RUN pip install --no-cache-dir matplotlib==3.1.1 dictdiffer==0.8.0 fastcluster==1.1.25 aenum==2.2.1 lru-dict==1.1.6 scipy==1.4.1 tenacity==5.1.1 azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 pycurl==7.43.0.3 coverage==5.1
+RUN pip install --no-cache-dir \
+    matplotlib==3.1.1 \
+    dictdiffer==0.8.0 \
+    fastcluster==1.1.25 \
+    aenum==2.2.1 \
+    lru-dict==1.1.6 \
+    scipy==1.4.1 \
+    tenacity==5.1.1 \
+    azure-common==1.1.23 \
+    azure-nspkg==3.0.2 \
+    azure-storage-blob==2.1.0 \
+    azure-storage-common==2.1.0 \
+    azure-storage-nspkg==3.1.0 \
+    pycurl==7.43.0.3 \
+    coverage==5.1
 
 ENV PYTHONPATH /tmp/openpilot:${PYTHONPATH}
 

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -76,10 +76,10 @@ RUN pyenv install 3.8.2 && \
 RUN mkdir -p /tmp/openpilot
 
 COPY SConstruct \
-     ./flake8_openpilot.sh \
-     ./pylint_openpilot.sh \
-     ./.pylintrc \
-     ./.coveragerc-app \
+     flake8_openpilot.sh \
+     pylint_openpilot.sh \
+     .pylintrc \
+     .coveragerc-app \
      /tmp/openpilot/
 
 COPY ./pyextra /tmp/openpilot/pyextra

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     liblzma-dev \
     libomp-dev \
-    libopencv-dev \
     libssl-dev \
     libsqlite3-dev \
     libusb-1.0-0-dev \

--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     liblzma-dev \
     libomp-dev \
+    libopencv-dev \
     libssl-dev \
-    libsqlite3-dev \
     libusb-1.0-0-dev \
     libczmq-dev \
     libzmq3-dev \


### PR DESCRIPTION
Average CI time should now be less than 12 minutes. Before we were lucky if our docker build job was 10-15 minutes, which every other job waited on. Compressed docker image is about 70MB smaller, but image size shouldn't affect CI runtime too much anymore. Also resolves #1422 by completely avoiding the buggy upload/download artifact for passing the docker image around. 

change in commit-to-green-check-mark times for individual tests:
* build release: 27 -> 4 minutes
* linter: 20 -> 2.5 minutes
* unit tests: 20 -> 6 minutes
* process replay: 23 -> 10 minutes
* longitudinal: 22 -> 7.5 minutes
* test car models: 26 -> 11 minutes

Overhead from docker/github actions is pretty minimal now, so any improvements in commit-to-green-check-mark time will come from improving our slower tests.