### PR TITLE
Firmware Versions for 2020 Hyundai Palisade

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -142,7 +142,7 @@ FW_VERSIONS = {
     (Ecu.eps, 0x7d4, None): [b'\xf1\x8756310L0010\x00\xf1\xa01.01'],
     (Ecu.fwdRadar, 0x7d0, None): [b'\xf1\x8799110L0000\xf1\xa01.00'],
     (Ecu.transmission, 0x7e1, None): [b'U903\x00\x00\x00\x00\x00\x00'],
-  }
+  },
   CAR.PALISADE: {
     (Ecu.esp, 0x7d1, None): [b'\xf1\xa01.02'],
     (Ecu.engine, 0x7e0, None): [b'640J0051\x00\x00\x00\x00\x00\x00\x00\x00'],

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -143,6 +143,13 @@ FW_VERSIONS = {
     (Ecu.fwdRadar, 0x7d0, None): [b'\xf1\x8799110L0000\xf1\xa01.00'],
     (Ecu.transmission, 0x7e1, None): [b'U903\x00\x00\x00\x00\x00\x00'],
   }
+  CAR.PALISADE: {
+    (Ecu.esp, 0x7d1, None): [b'\xf1\xa01.02'],
+    (Ecu.engine, 0x7e0, None): [b'640J0051\x00\x00\x00\x00\x00\x00\x00\x00'],
+    (Ecu.eps, 0x7d4, None): [b'\xf1\x8793571S1120\xf1\xa0100'],
+    (Ecu.fwdRadar, 0x7d0, None): [b'\xf1\xa01.04'],
+    (Ecu.transmission, 0x7e1, None): [b'U891\x00\x00\x00\x00\x00\x00'],
+  }
 }
 
 CHECKSUM = {


### PR DESCRIPTION
Firmware Versions for the 2020 Hyundai Palisade

```
carFw = [
      ( ecu = esp,
        fwVersion = "\xf1\xa01.02",
        address = 2001,
        subAddress = 0 ),
      ( ecu = fwdRadar,
        fwVersion = "\xf1\xa01.04",
        address = 2000,
        subAddress = 0 ),
      ( ecu = engine,
        fwVersion = "640J0051\x00\x00\x00\x00\x00\x00\x00\x00",
        address = 2016,
        subAddress = 0 ),
      ( ecu = eps,
        fwVersion = "\xf1\x8793571S1120\xf1\xa0100",
        address = 1953,
        subAddress = 0 ),
      ( ecu = transmission,
        fwVersion = "U891\x00\x00\x00\x00\x00\x00",
        address = 2017,
        subAddress = 0 ) ],
```