### PR TITLE
UI:  change light_sensor to  std::atomic<float>

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -208,8 +208,7 @@ static void update_offroad_layout_timeout(UIState *s, int* timeout) {
 }
 
 static void ui_init(UIState *s) {
-  memset(s, 0, sizeof(UIState));
-
+  
   pthread_mutex_init(&s->lock, NULL);
   s->sm = new SubMaster({"model", "controlsState", "uiLayoutState", "liveCalibration", "radarState", "thermal",
                          "health", "ubloxGnss", "driverState", "dMonitoringState", "offroadLayout"
@@ -810,7 +809,7 @@ int main(int argc, char* argv[]) {
   zsys_handler_set(NULL);
   signal(SIGINT, (sighandler_t)set_do_exit);
 
-  UIState uistate;
+  UIState uistate = {};
   UIState *s = &uistate;
   ui_init(s);
   enable_event_processing(true);

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -13,7 +13,7 @@
 #define NANOVG_GLES3_IMPLEMENTATION
 #define nvgCreate nvgCreateGLES3
 #endif
-
+#include <atomic>
 #include <pthread.h>
 #include "nanovg.h"
 
@@ -269,7 +269,7 @@ typedef struct UIState {
   bool thermal_started, preview_started;
   bool vision_seen;
 
-  float light_sensor;
+  std::atomic<float> light_sensor;
 
   int touch_fd;
 


### PR DESCRIPTION
- change light_sensor to an atomic variable.plain float should not be used  in multi thread.
- Use brace initialization to initialize uistate.