### PR TITLE
GitHub Actions: Fix Update Pipfile.lock workflow

### DIFF
--- a/.github/workflows/update-pipfile.yml
+++ b/.github/workflows/update-pipfile.yml
@@ -24,3 +24,4 @@ jobs:
       with:
         title: "Update Pipfile.lock (dependencies)"
         branch: update-pipfile
+        commit-message: "[Bot] Update Pipfile.lock dependencies"

--- a/.github/workflows/update-pipfile.yml
+++ b/.github/workflows/update-pipfile.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
     - 'Pipfile'
+    - '.github/workflows/update-pipfile.yml'
 
 jobs:
   piplock:
@@ -14,7 +15,7 @@ jobs:
     - uses: actions/setup-python@v2
     - run: pip install wheel
     - run: pip install pipenv
-    - run: pipenv lock --requirements
+    - run: pipenv lock
     - uses: actions/upload-artifact@v2
       with:
         name: "Pipfile lock"


### PR DESCRIPTION
Small patch after #1542.

Weekly [run ran](https://github.com/commaai/openpilot/actions/runs/114523851), but didn't update the Pipfile.lock and therefore didn't open an PR.

Since we don't use a requirements.txt the `--requirements` can be dropped. It also modifies the workflow to run when changing the _Update Pipfile.lock_ workflow.

The PR from github-actions now merged into this branch will be opened next week against the master branch.