### PR TITLE
Mazda: Slower rate for ACC cancel msg to avoid cruise disable

### DIFF
--- a/selfdrive/car/mazda/carcontroller.py
+++ b/selfdrive/car/mazda/carcontroller.py
@@ -23,17 +23,17 @@ class CarController():
                                                   CS.out.steeringTorque, SteerLimitParams)
       self.steer_rate_limited = new_steer != apply_steer
 
-      if CS.out.standstill and frame % 50 == 0:
+      if CS.out.standstill and frame % 20 == 0:
         # Mazda Stop and Go requires a RES button (or gas) press if the car stops more than 3 seconds
-        # Send Resume button at 2hz if we're engaged at standstill to support full stop and go!
+        # Send Resume button at 5hz if we're engaged at standstill to support full stop and go!
         # TODO: improve the resume trigger logic by looking at actual radar data
         can_sends.append(mazdacan.create_button_cmd(self.packer, CS.CP.carFingerprint, Buttons.RESUME))
     else:
       apply_steer = 0
       self.steer_rate_limited = False
-      if CS.out.cruiseState.enabled and frame % 10 == 0:
+      if CS.out.cruiseState.enabled and frame % 20 == 0:
         # Cancel Stock ACC if it's enabled while OP is disengaged
-        # Match stock message rate which is sent at 10hz
+        # Send at a rate of 5hz until we sync with stock ACC state
         can_sends.append(mazdacan.create_button_cmd(self.packer, CS.CP.carFingerprint, Buttons.CANCEL))
 
     self.apply_steer_last = apply_steer

--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -44,7 +44,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
       # No steer below disable speed
-      ret.minSteerSpeed = LKAS_LIMITS.DISABLE_SPEED * CV.KPH_TO_MS
+      ret.minSteerSpeed = round(LKAS_LIMITS.DISABLE_SPEED * CV.KPH_TO_MS)
 
     ret.centerToFront = ret.wheelbase * 0.41
 


### PR DESCRIPTION
 Sending ACC cancel message at 10hz may end up disabling
main cruise state. That is because stoc ACC use the same
signal for both functions. If cruise is already enabled
the signal canceles it, otherwise cruise is disabled.
10hz seems to be still fast in some cases not allowing
the state to sync up between OP and the Stock state.
5hz avoids that issue. Also, the resume message was also
updated to 5hz as that seems to work better as well.

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>