### PR TITLE
Fix rounding of minSteerSpeed in events

### DIFF
--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -44,7 +44,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
       # No steer below disable speed
-      ret.minSteerSpeed = round(LKAS_LIMITS.DISABLE_SPEED * CV.KPH_TO_MS)
+      ret.minSteerSpeed = LKAS_LIMITS.DISABLE_SPEED * CV.KPH_TO_MS
 
     ret.centerToFront = ret.wheelbase * 0.41
 

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -158,7 +158,7 @@ class EngagementAlert(Alert):
                      audible_alert, .2, 0., 0.),
 
 def below_steer_speed_alert(CP, sm, metric):
-  speed = CP.minSteerSpeed * (CV.MS_TO_KPH if metric else CV.MS_TO_MPH)
+  speed = int(round(CP.minSteerSpeed * (CV.MS_TO_KPH if metric else CV.MS_TO_MPH)))
   unit = "kph" if metric else "mph"
   return Alert(
     "TAKE CONTROL",


### PR DESCRIPTION
I thought I was missing a rounding in Mazda code, but it turned
out to be a missing rounding after the recent event refactoring

Python3 interpreter:
```
>>> print(" %d  %d" % (1.6,1.4))
 1  1
>>> print(" %d  %d" % (round(1.6),round(1.4)))
 2  1
>>> print(" %d  %d" % (int(round(1.6)),round(1.4)))
 2  1
>>> print(" %d  %d" % (int(round(1.6)),int(round(1.4))))
 2  1
```
Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>