### PR TITLE
slow down upload check when offroad

### DIFF
--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -256,8 +256,9 @@ def uploader_fn(exit_event):
       return
 
     d = uploader.next_file_to_upload(with_raw=allow_raw_upload and should_upload)
-    if d is None:
-      time.sleep(5)
+    if d is None:  # Nothing to upload
+      offroad = params.get("IsOffroad") == b'1'
+      time.sleep(60 if offroad else 5)
       continue
 
     key, fn = d


### PR DESCRIPTION
Checking for pending uploads is not cheap anymore now that we leave the files on device.