### PR TITLE
Don't auto-resume Honda Bosch ACC if we have an active steerRequired alert

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -161,7 +161,7 @@ class CarController():
       # If using stock ACC, spam cancel command to kill gas when OP disengages.
       if pcm_cancel_cmd:
         can_sends.append(hondacan.spam_buttons_command(self.packer, CruiseButtons.CANCEL, idx, CS.CP.carFingerprint, CS.CP.isPandaBlack))
-      elif CS.out.cruiseState.standstill:
+      elif CS.out.cruiseState.standstill and not hud.steer_required:
         can_sends.append(hondacan.spam_buttons_command(self.packer, CruiseButtons.RES_ACCEL, idx, CS.CP.carFingerprint, CS.CP.isPandaBlack))
 
     else:


### PR DESCRIPTION
This would cover all DM events like driver terminally distracted, low driver detection accuracy, and driver distracted but not yet terminal (because we're stopped). Also, it would prevent auto resuming if the driver has violated the safety model as the lead car has started to move but we haven't yet disengaged because of it (unlatched seatbelt, for example).

Once caveat is that it could also not resume if the vision model output is uncertain, but that would probably be a rare occurrence. Also, this doesn't enforce DM driver attentiveness for allowing auto resume.

Todo: Expand this to all makes and control styles.