### PR TITLE
remove unnecessarily cancel spamming

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -387,7 +387,7 @@ class Controls:
     CC.actuators = actuators
 
     CC.cruiseControl.override = True
-    CC.cruiseControl.cancel = not self.CP.enableCruise or (not self.enabled and CS.cruiseState.enabled)
+    CC.cruiseControl.cancel = not self.enabled and CS.cruiseState.enabled
 
     # Some override values for Honda
     # brake discount removes a sharp nonlinearity


### PR DESCRIPTION
this causes HKG cars to send cancel continuously when change enableCruise param
I don't see why OP should  spams the car with cruise cancel button when Cruise control is off