### PR TITLE
Fix realtime priority for modeld/dmonitoringd

### DIFF
--- a/selfdrive/modeld/dmonitoringmodeld.cc
+++ b/selfdrive/modeld/dmonitoringmodeld.cc
@@ -23,7 +23,7 @@ static void set_do_exit(int sig) {
 
 int main(int argc, char **argv) {
   int err;
-  set_realtime_priority(1);
+  set_realtime_priority(51);
 
   // messaging
   SubMaster sm({"dMonitoringState"});

--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -73,7 +73,7 @@ void* live_thread(void *arg) {
 
 int main(int argc, char **argv) {
   int err;
-  set_realtime_priority(1);
+  set_realtime_priority(51);
 
   // start calibration thread
   pthread_t live_thread_handle;


### PR DESCRIPTION
I missed these somehow during the sweep of realtime/affinity updates in #1638.