### PR TITLE
Prepare for NEOS update

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -86,6 +86,12 @@ function launch {
       cp "$DIR/scripts/continue.sh" "/data/data/com.termux/files/continue.sh"
     fi
 
+    if [ ! -f "$BASEDIR/prebuilt" ]; then
+      echo "Clearing build products and resetting scons state prior to NEOS update"
+      cd $BASEDIR && scons --clean
+      rm -rf /tmp/scons_cache
+      rm -r $BASEDIR/.sconsign.dblite
+    fi
     "$DIR/installer/updater/updater" "file://$DIR/installer/updater/update.json"
   fi
 


### PR DESCRIPTION
To be prepared in case of unforeseen issues with NEOS 15, we need to handle a NEOS 15-to-14 rollback without manual SSH/CLI intervention or other end-user heroics. To do this, we need to teach the final NEOS 14 version of OP how to clear out Python 3.8 build products. In any case, for users of master/devel or forks, it's probably a good idea to rebuild after NEOS version changes anyway.

One would think `scons` could handle this on its own, but one of the build products is a `scons` build state/dependency database serialized with Python pickle format v5, which can't be read with Python 3.7. So, we zap everything to its non-built state unless they're running pre-built release2.