### PR TITLE
Update Subaru Impreza supported years in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Community Maintained Cars and Features
 | Nissan    | Rogue 2019<sup>2</sup>        | Propilot          | Stock            | 0mph               | 0mph         |
 | Nissan    | X-Trail 2017<sup>2</sup>      | Propilot          | Stock            | 0mph               | 0mph         |
 | Subaru    | Crosstrek 2018-19             | EyeSight          | Stock            | 0mph               | 0mph         |
-| Subaru    | Impreza 2018-20               | EyeSight          | Stock            | 0mph               | 0mph         |
+| Subaru    | Impreza 2017-20               | EyeSight          | Stock            | 0mph               | 0mph         |
 | Volkswagen| Golf 2015-19                  | Driver Assistance | Stock            | 0mph               | 0mph         |
 
 <sup>1</sup>Requires a [panda](https://comma.ai/shop/products/panda-obd-ii-dongle) and [community built giraffe](https://zoneos.com/volt/). ***NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).*** <br />


### PR DESCRIPTION
"Impreza 2018-20" should be "Impreza 2017-20".

There are multiple users in Discord (e.g. Frye0453, ₿en2357) that have successfully used EON/C2 with their 2017 Imprezas. Wiki has been updated to reflect this.