### PR TITLE
release2 cleanup

### DIFF
--- a/release/build_devel.sh
+++ b/release/build_devel.sh
@@ -84,6 +84,7 @@ echo -n "1" > /data/params/d/CommunityFeaturesToggle
 
 PYTHONPATH="$TARGET_DIR:$TARGET_DIR/pyextra" nosetests -s selfdrive/test/test_openpilot.py
 PYTHONPATH="$TARGET_DIR:$TARGET_DIR/pyextra" GET_CPU_USAGE=1 selfdrive/manager.py
+PYTHONPATH="$TARGET_DIR:$TARGET_DIR/pyextra" selfdrive/car/tests/test_car_interfaces.py
 
 echo "[-] testing panda build T=$SECONDS"
 pushd panda/board/

--- a/release/build_release2.sh
+++ b/release/build_release2.sh
@@ -44,11 +44,22 @@ popd
 ln -sfn /data/openpilot /data/pythonpath
 export PYTHONPATH="/data/openpilot:/data/openpilot/pyextra"
 SCONS_CACHE=1 scons -j3
+
+# Run tests
 nosetests -s selfdrive/test/test_openpilot.py
+GET_CPU_USAGE=1 selfdrive/manager.py
+selfdrive/car/tests/test_car_models.py
 
 # Cleanup
+find . -name '*.a' -delete
+find . -name '*.o' -delete
+find . -name '*.os' -delete
 find . -name '*.pyc' -delete
+find . -name '__pycache__' -delete
 rm .sconsign.dblite
+
+# Restore phonelibs
+git checkout phonelibs/
 
 # Mark as prebuilt release
 touch prebuilt
@@ -56,6 +67,9 @@ touch prebuilt
 # Add built files to git
 git add -f .
 git commit --amend -m "openpilot v$VERSION"
+
+# Print committed files that are normally gitignored
+#git status --ignored
 
 # Push to release2-staging
 git push -f origin release2-staging

--- a/release/build_release2.sh
+++ b/release/build_release2.sh
@@ -47,8 +47,7 @@ SCONS_CACHE=1 scons -j3
 
 # Run tests
 nosetests -s selfdrive/test/test_openpilot.py
-GET_CPU_USAGE=1 selfdrive/manager.py
-selfdrive/car/tests/test_car_models.py
+selfdrive/car/tests/test_car_interfaces.py
 
 # Cleanup
 find . -name '*.a' -delete


### PR DESCRIPTION
Preview branch: https://github.com/commaai/openpilot/tree/release2_cleanup_preview

* [x] cleanup unnecessary files
  * [x] intermediate build files (resolves #1667)
* [x] run subset of the tests with final release2

0.7.6 release2
```
426M    total
252M    ./selfdrive
58M     ./phonelibs
51M     ./models
25M     ./opendbc
18M     ./cereal
14M     ./apk
9.2M    ./panda
2.4M    ./installer
432K    ./common
236K    ./rednose
28K     ./pyextra
28K     ./README.md
24K     ./RELEASES.md
16K     ./.github
12K     ./scripts
8.0K    ./SConstruct
4.0K    ./lgtm.yml
4.0K    ./launch_openpilot.sh
4.0K    ./launch_chffrplus.sh
4.0K    ./codecov.yml
4.0K    ./SAFETY.md
4.0K    ./LICENSE
4.0K    ./CONTRIBUTING.md
4.0K    ./.gitignore
0       ./prebuilt
0       ./openpilot
```

after cleanup 
```
234M    total
120M    ./selfdrive
51M     ./models
28M     ./phonelibs
14M     ./apk
8.3M    ./cereal
6.6M    ./opendbc
3.4M    ./panda
2.4M    ./installer
2.4M    ./common
236K    ./rednose
28K     ./README.md
24K     ./RELEASES.md
16K     ./.github
12K     ./scripts
8.0K    ./pyextra
8.0K    ./SConstruct
4.0K    ./launch_openpilot.sh
4.0K    ./launch_chffrplus.sh
4.0K    ./SAFETY.md
4.0K    ./LICENSE
4.0K    ./CONTRIBUTING.md
4.0K    ./.gitignore
0       ./prebuilt
```