### PR TITLE
Fix gyro orientation offset for EONs with OP3T mainboards

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -101,8 +101,8 @@ function launch {
 
   # One-time fix for a subset of OP3T with gyro orientation offsets.
   # Remove and regenerate qcom sensor registry. Only done on OP3T mainboards.
-  # Performed exactly once. Existing registry is preserved just-in-case, and
-  # doubles as a flag denoting we've already done the reset once.
+  # Performed exactly once. The old registry is preserved just-in-case, and
+  # doubles as a flag denoting we've already done the reset.
   # TODO: we should really grow per-platform detect and setup routines
   if ! $(grep -q "letv" /proc/cmdline) && [ ! -f "/persist/comma/op3t-sns-reg-backup" ]; then
     echo "Performing OP3T sensor registry reset"

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -99,6 +99,18 @@ function launch {
     fi
   fi
 
+  # One-time fix for a subset of OP3T with gyro orientation offsets.
+  # Remove and regenerate qcom sensor registry. Only done on OP3T mainboards.
+  # Performed exactly once. Existing registry is preserved just-in-case, and
+  # doubles as a flag denoting we've already done the reset once.
+  # TODO: we should really grow per-platform detect and setup routines
+  if [ ! $(grep -q "letv" /proc/cmdline) ] && [ ! -f "/persist/comma/op3t-sns-reg-backup" ]; then
+    echo "Performing OP3T sensor registry reset"
+    mv /persist/sensors/sns.reg /persist/comma/op3t-sns-reg-backup &&
+      rm -f /persist/sensors/sensors_settings /persist/sensors/error_log /persist/sensors/gyro_sensitity_cal &&
+      echo "restart" > /sys/kernel/debug/msm_subsys/slpi &&
+      sleep 3  # Give Android sensor subsystem a moment to recover
+  fi
 
   # handle pythonpath
   ln -sfn $(pwd) /data/pythonpath

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -109,7 +109,7 @@ function launch {
     mv /persist/sensors/sns.reg /persist/comma/op3t-sns-reg-backup &&
       rm -f /persist/sensors/sensors_settings /persist/sensors/error_log /persist/sensors/gyro_sensitity_cal &&
       echo "restart" > /sys/kernel/debug/msm_subsys/slpi &&
-      sleep 3  # Give Android sensor subsystem a moment to recover
+      sleep 5  # Give Android sensor subsystem a moment to recover
   fi
 
   # handle pythonpath

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -104,7 +104,7 @@ function launch {
   # Performed exactly once. Existing registry is preserved just-in-case, and
   # doubles as a flag denoting we've already done the reset once.
   # TODO: we should really grow per-platform detect and setup routines
-  if [ ! $(grep -q "letv" /proc/cmdline) ] && [ ! -f "/persist/comma/op3t-sns-reg-backup" ]; then
+  if ! $(grep -q "letv" /proc/cmdline) && [ ! -f "/persist/comma/op3t-sns-reg-backup" ]; then
     echo "Performing OP3T sensor registry reset"
     mv /persist/sensors/sns.reg /persist/comma/op3t-sns-reg-backup &&
       rm -f /persist/sensors/sensors_settings /persist/sensors/error_log /persist/sensors/gyro_sensitity_cal &&


### PR DESCRIPTION
The localizer in 0.8 exposed a problem with some devices reporting orientation with an strange offset. Only OP3T-based devices seem affected, and only a subset of those. Resetting the sensor HAL registry and letting the device rebuild it seems to clear the issue. The origin of the bad sensor registry data isn't clear. No other devices seem to be affected.

As of this change, all OP3T will have their sensor registry reset and rebuilt, exactly one time. The old sensor registry is kept as a backup (in case this has unforeseen fallout) and it serves as a flag that we've already performed the reset on this device.