### PR TITLE
Locationd: only process valid log messages

### DIFF
--- a/selfdrive/locationd/locationd.py
+++ b/selfdrive/locationd/locationd.py
@@ -304,7 +304,7 @@ def locationd_thread(sm, pm, disabled_logs=None):
     sm.update()
 
     for sock, updated in sm.updated.items():
-      if updated:
+      if updated and sm.valid[sock]:
         t = sm.logMonoTime[sock] * 1e-9
         if sock == "sensorEvents":
           localizer.handle_sensors(t, sm[sock])


### PR DESCRIPTION
cameraOdometry will be invalid when the frames are too old, don't process when that's the case.