### PR TITLE
Fix Impreza supported model years

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Community Maintained Cars and Features
 | Nissan    | X-Trail 2017<sup>2</sup>      | Propilot          | Stock            | 0mph               | 0mph         |
 | Subaru    | Crosstrek 2018-19             | EyeSight          | Stock            | 0mph               | 0mph         |
 | Subaru    | Forester 2019                 | EyeSight          | Stock            | 0mph               | 0mph         |
-| Subaru    | Impreza 2017-20               | EyeSight          | Stock            | 0mph               | 0mph         |
+| Subaru    | Impreza 2017-19               | EyeSight          | Stock            | 0mph               | 0mph         |
 | Volkswagen| Golf 2015-19                  | Driver Assistance | Stock            | 0mph               | 0mph         |
 
 <sup>1</sup>Requires an [OBD-II car harness](https://comma.ai/shop/products/comma-car-harness) and [community built giraffe](https://github.com/commaai/openpilot/wiki/GM). ***NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).*** <br />


### PR DESCRIPTION
2020 Impreza and Crosstrek require different tuning (and introduce cruise fault on some turns). We are currently working on adding support for 2020 models and testing mitigation for the cruise fault