### PR TITLE
Reduce C2 dcamera noise at night

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -33,8 +33,8 @@
 
 #define MAX_IR_POWER 0.5f
 #define MIN_IR_POWER 0.0f
-#define CUTOFF_GAIN 0.125f  // iso100
-#define SATURATE_GAIN 0.4f  // iso320
+#define CUTOFF_IL 200
+#define SATURATE_IL 1600
 #define NIBBLE_TO_HEX(n) ((n) < 10 ? (n) + '0' : ((n) - 10) + 'a')
 #define VOLTAGE_K 0.091  // LPF gain for 5s tau (dt/tau / (dt/tau + 1))
 
@@ -690,15 +690,15 @@ void *hardware_control_thread(void *crap) {
     }
     if (sm.updated("frontFrame")){
       auto event = sm["frontFrame"];
-      float cur_front_gain = event.getFrontFrame().getGainFrac();
+      int cur_integ_lines = event.getFrontFrame().getIntegLines();
       last_front_frame_t = event.getLogMonoTime();
 
-      if (cur_front_gain <= CUTOFF_GAIN) {
+      if (cur_integ_lines <= CUTOFF_IL) {
         ir_pwr = 100.0 * MIN_IR_POWER;
-      } else if (cur_front_gain > SATURATE_GAIN) {
+      } else if (cur_integ_lines > SATURATE_IL) {
         ir_pwr = 100.0 * MAX_IR_POWER;
       } else {
-        ir_pwr = 100.0 * (MIN_IR_POWER + ((cur_front_gain - CUTOFF_GAIN) * (MAX_IR_POWER - MIN_IR_POWER) / (SATURATE_GAIN - CUTOFF_GAIN)));
+        ir_pwr = 100.0 * (MIN_IR_POWER + ((cur_integ_lines - CUTOFF_IL) * (MAX_IR_POWER - MIN_IR_POWER) / (SATURATE_IL - CUTOFF_IL)));
       }
     }
     // Disable ir_pwr on front frame timeout

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -33,8 +33,8 @@
 
 #define MAX_IR_POWER 0.5f
 #define MIN_IR_POWER 0.0f
-#define CUTOFF_GAIN 0.015625f  // iso400
-#define SATURATE_GAIN 0.0625f  // iso1600
+#define CUTOFF_GAIN 0.125f  // iso100
+#define SATURATE_GAIN 0.4f  // iso320
 #define NIBBLE_TO_HEX(n) ((n) < 10 ? (n) + '0' : ((n) - 10) + 'a')
 #define VOLTAGE_K 0.091  // LPF gain for 5s tau (dt/tau / (dt/tau + 1))
 

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -425,7 +425,7 @@ static void do_autoexposure(CameraState *s, float grey_frac) {
     const unsigned int exposure_time_max = frame_length - 11; // copied from set_exposure()
 
     float exposure_factor = pow(1.05, (target_grey - grey_frac) / 0.05);
-    if (s->cur_gain_frac > 0.25 && exposure_factor < 1) {
+    if (s->cur_gain_frac > 0.125 && exposure_factor < 1) {
       s->cur_gain_frac *= exposure_factor;
     } else if (s->cur_integ_lines * exposure_factor <= exposure_time_max && s->cur_integ_lines * exposure_factor >= exposure_time_min) { // adjust exposure time first
       s->cur_exposure_frac *= exposure_factor;

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -390,7 +390,7 @@ static void set_exposure(CameraState *s, float exposure_frac, float gain_frac) {
 
     if (s->apply_exposure == ov8865_apply_exposure) {
       int sensor_gain = 8 * gain_frac;
-      gain = 100 * sensor_gain; // ISO
+      gain = 800 * gain_frac; // ISO
       err = s->apply_exposure(s, sensor_gain, integ_lines, frame_length);
     } else if (s->apply_exposure) {
       err = s->apply_exposure(s, gain, integ_lines, frame_length);


### PR DESCRIPTION
get sensory ready for BIG model
adjust exposure time first instead of gain, upper-limited to 1/10s
usage of fine gain should reduce icon flickering
<img src="https://user-images.githubusercontent.com/7658937/86058961-a942de00-ba16-11ea-8a6f-e0b736ec66ab.jpg" height="330" width="440">
<img src="https://user-images.githubusercontent.com/7658937/86058970-ae079200-ba16-11ea-9173-047614943330.jpg" height="330" width="440">
