### PR TITLE
Temporarily disable allowing codecov to fail CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci
-          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -Z -F unit_tests"
+          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -Z -F unit_tests"
 
   process_replay:
     name: process replay
@@ -145,7 +145,7 @@ jobs:
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci
-          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -Z -F process_replay"
+          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -Z -F process_replay"
       - name: Print diff
         if: always()
         run: |
@@ -205,4 +205,4 @@ jobs:
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci
-          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -Z -F test_car_models"
+          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -Z -F test_car_models"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci
-          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -Z -F unit_tests"
+          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -F unit_tests"
 
   process_replay:
     name: process replay
@@ -145,7 +145,7 @@ jobs:
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci
-          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -Z -F process_replay"
+          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -F process_replay"
       - name: Print diff
         if: always()
         run: |
@@ -205,4 +205,4 @@ jobs:
       - name: Upload coverage to Codecov
         run: |
           docker commit tmppilot tmppilotci
-          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -Z -F test_car_models"
+          $CI_RUN "cd /tmp/openpilot && bash <(curl -s https://codecov.io/bash) -v -F test_car_models"


### PR DESCRIPTION
Revert this after this codecov bug is fixed: https://github.com/codecov/codecov-bash/issues/330