### PR TITLE
Make updated more resilient

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -44,7 +44,7 @@ function launch {
           cd $BASEDIR
 
           # Partial mitigation for symlink-related filesystem corruption
-          # Make sure all files match the repo versions after update
+          # Ensure all files match the repo versions after update
           git reset --hard
           git submodule foreach --recursive git reset --hard
 

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -41,9 +41,12 @@ function launch {
 
           mv $BASEDIR /data/safe_staging/old_openpilot
           mv "${STAGING_ROOT}/finalized" $BASEDIR
+          cd $BASEDIR
 
-          # The mv changed our working directory to /data/safe_staging/old_openpilot
-          cd "${BASEDIR}"
+          # Partial mitigation for symlink-related filesystem corruption
+          # Make sure all files match the repo versions after update
+          git reset --hard
+          git submodule foreach --recursive git reset --hard
 
           echo "Restarting launch script ${LAUNCHER_LOCATION}"
           exec "${LAUNCHER_LOCATION}"

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -32,6 +32,7 @@ import signal
 from pathlib import Path
 import fcntl
 import threading
+import time
 from cffi import FFI
 
 from common.basedir import BASEDIR
@@ -335,6 +336,10 @@ def main():
     fcntl.flock(ov_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
   except IOError:
     raise RuntimeError("couldn't get overlay lock; is another updated running?")
+
+  # Wait a short time before our first update attempt
+  # Avoids race with IsOffroad not being set, reduces manager startup load
+  time.sleep(30)
 
   while True:
     update_failed_count += 1


### PR DESCRIPTION
Sleep 30 seconds before kicking off the first `updated` run cycle. Actually makes the first check faster, since much of the time we were "winning" a race with IsOffroad not yet being set, resulting in a 10 minute wait before the first successful check.

On bootup, after swapping in a finalized overlay upgrade of openpilot, do a `git reset --hard` of all files. This is a mitigation (not a fix) of the intermittent filesystem damage we've been seeing, wherein random file contents are replaced with the name of a symlink target somewhere else in the openpilot tree. It won't save us from corrupted files in `.git`, but if that's shown to be a problem, we can explore some repo integrity checks before the overlay swap-in.