### PR TITLE
boardd: release claimed interface before closing usb

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -142,6 +142,15 @@ void *safety_setter_thread(void *s) {
   return NULL;
 }
 
+void usb_close() {
+  if (!dev_handle) {
+    return;
+  }
+  libusb_release_interface(dev_handle, 0);
+  libusb_close(dev_handle);
+  dev_handle = NULL;
+}
+
 // must be called before threads or with mutex
 bool usb_connect() {
   int err, err2;
@@ -154,10 +163,7 @@ bool usb_connect() {
 
   ignition_last = false;
 
-  if (dev_handle != NULL){
-    libusb_close(dev_handle);
-    dev_handle = NULL;
-  }
+  usb_close();
 
   dev_handle = libusb_open_device_with_vid_pid(ctx, 0xbbaa, 0xddcc);
   if (dev_handle == NULL) { goto fail; }
@@ -945,6 +951,6 @@ int main() {
 
   // destruct libusb
 
-  libusb_close(dev_handle);
+  usb_close();
   libusb_exit(ctx);
 }

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -142,7 +142,7 @@ void *safety_setter_thread(void *s) {
   return NULL;
 }
 
-void usb_close() {
+void usb_close(libusb_device_handle* &dev_handle) {
   if (!dev_handle) {
     return;
   }
@@ -163,7 +163,7 @@ bool usb_connect() {
 
   ignition_last = false;
 
-  usb_close();
+  usb_close(dev_handle);
 
   dev_handle = libusb_open_device_with_vid_pid(ctx, 0xbbaa, 0xddcc);
   if (dev_handle == NULL) { goto fail; }
@@ -937,7 +937,6 @@ int main() {
   assert(err == 0);
 
   // join threads
-
   err = pthread_join(can_recv_thread_handle, NULL);
   assert(err == 0);
 
@@ -947,10 +946,7 @@ int main() {
   err = pthread_join(can_health_thread_handle, NULL);
   assert(err == 0);
 
-  //while (!do_exit) usleep(1000);
-
   // destruct libusb
-
-  usb_close();
+  usb_close(dev_handle);
   libusb_exit(ctx);
 }


### PR DESCRIPTION
All the claimed interfaces on a device must be released before closing the device.otherwise,the next call to libusb_claim_interface may fail.