### PR TITLE
Honda block lane change on blindspot alert

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -510,6 +510,7 @@ opendbc/honda_civic_hatchback_ex_2017_can_generated.dbc
 opendbc/honda_civic_sedan_16_diesel_2019_can_generated.dbc
 opendbc/honda_crv_touring_2016_can_generated.dbc
 opendbc/honda_crv_ex_2017_can_generated.dbc
+opendbc/honda_crv_ex_2017_body_generated.dbc
 opendbc/honda_crv_executive_2016_can_generated.dbc
 opendbc/honda_crv_hybrid_2019_can_generated.dbc
 opendbc/honda_fit_ex_2018_can_generated.dbc

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -40,8 +40,8 @@ def scale_tire_stiffness(mass, wheelbase, center_to_front, tire_stiffness_factor
   return tire_stiffness_front, tire_stiffness_rear
 
 
-def dbc_dict(pt_dbc, radar_dbc, chassis_dbc=None):
-  return {'pt': pt_dbc, 'radar': radar_dbc, 'chassis': chassis_dbc}
+def dbc_dict(pt_dbc, radar_dbc, chassis_dbc=None, body_dbc=None):
+  return {'pt': pt_dbc, 'radar': radar_dbc, 'chassis': chassis_dbc, 'body': body_dbc}
 
 
 def apply_std_steer_torque_limits(apply_torque, apply_torque_last, driver_torque, LIMITS):

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -83,7 +83,7 @@ class CarInterface(CarInterfaceBase):
       self.compute_gb = compute_gb_honda
 
   @staticmethod
-  def compute_gb(accel, speed):
+  def compute_gb(accel, speed): # pylint: disable=method-hidden
     raise NotImplementedError
 
   @staticmethod
@@ -426,10 +426,12 @@ class CarInterface(CarInterfaceBase):
     # ******************* do can recv *******************
     self.cp.update_strings(can_strings)
     self.cp_cam.update_strings(can_strings)
+    if self.cp_body:
+      self.cp_body.update_strings(can_strings)
 
-    ret = self.CS.update(self.cp, self.cp_cam)
+    ret = self.CS.update(self.cp, self.cp_cam, self.cp_body)
 
-    ret.canValid = self.cp.can_valid and self.cp_cam.can_valid
+    ret.canValid = self.cp.can_valid and self.cp_cam.can_valid and (self.cp_body is None or self.cp_body.can_valid)
     ret.yawRate = self.VM.yaw_rate(ret.steeringAngle * CV.DEG_TO_RAD, ret.vEgo)
     # FIXME: read sendcan for brakelights
     brakelights_threshold = 0.02 if self.CS.CP.carFingerprint == CAR.CIVIC else 0.1

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -922,7 +922,7 @@ DBC = {
   CAR.CIVIC_BOSCH: dbc_dict('honda_civic_hatchback_ex_2017_can_generated', None),
   CAR.CIVIC_BOSCH_DIESEL: dbc_dict('honda_civic_sedan_16_diesel_2019_can_generated', None),
   CAR.CRV: dbc_dict('honda_crv_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.CRV_5G: dbc_dict('honda_crv_ex_2017_can_generated', None),
+  CAR.CRV_5G: dbc_dict('honda_crv_ex_2017_can_generated', None, body_dbc='honda_crv_ex_2017_body_generated'),
   CAR.CRV_EU: dbc_dict('honda_crv_executive_2016_can_generated', 'acura_ilx_2016_nidec'),
   CAR.CRV_HYBRID: dbc_dict('honda_crv_hybrid_2019_can_generated', None),
   CAR.FIT: dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -27,6 +27,7 @@ class CarInterfaceBase():
       self.CS = CarState(CP)
       self.cp = self.CS.get_can_parser(CP)
       self.cp_cam = self.CS.get_cam_can_parser(CP)
+      self.cp_body = self.CS.get_body_can_parser(CP)
 
     self.CC = None
     if CarController is not None:
@@ -174,4 +175,8 @@ class CarStateBase:
 
   @staticmethod
   def get_cam_can_parser(CP):
+    return None
+
+  @staticmethod
+  def get_body_can_parser(CP):
     return None


### PR DESCRIPTION
Working on 2017 CR-V

BSM radars output a message on B-CAN with a bit that indicates whether the BSM indicator is on. A white panda acts as gateway to forward B-CAN messages to a CAN bus that openpilot has access to.

The fake ethernet port is the easy way to get messages from B-CAN to openpilot because it is already run down to the OBD port which is close to several connectors with B-CAN.  However, the fake ethernet connector has CAN0 which on Honda vehicles with a Bosch radar is the radar bus.  This means B-CAN is being forwarded to the radar bus, which is annoying, but does work with the addition of another CAN parser in openpilot.

Is this an acceptable approach for integrating B-CAN in general?  The BSM alert integration is the first of multiple features that would be a nice additions (controlling blinkers/hazards, locking doors through athena, etc...)

#### B-CAN DBC
```
BO_ 318291879 BSM_STATUS_RIGHT: 8 XXX
 SG_ BSM_ALERT : 4|1@0+ (1,0) [0|1] "" XXX
 SG_ BSM_MODE : 6|2@0+ (1,0) [0|3] "" XXX

BO_ 318291615 BSM_STATUS_LEFT: 8 XXX
 SG_ BSM_ALERT : 4|1@0+ (1,0) [0|1] "" XXX
 SG_ BSM_MODE : 6|2@0+ (1,0) [0|3] "" XXX

VAL_ 318291879 BSM_MODE 2 "blind_spot" 1 "cross_traffic" 0 "off";
VAL_ 318291615 BSM_MODE 2 "blind_spot" 1 "cross_traffic" 0 "off";
```
[example dbc](https://github.com/gregjhogan/opendbc/blob/458970f4adcfcb9d8433090b9dc632be26530c46/generator/honda/honda_crv_ex_2017_body.dbc)

#### gateway panda setup:
* CAN0 on gateway panda connected to fake ethernet CAN0
* CAN1 on gateway panda connected to B-CAN
* flash with firmware that forwards B-CAN to fake ethernet CAN0 [example code](https://github.com/gregjhogan/panda/tree/bcan-fwd)

#### easy places to connect to B-CAN:
* 6 pin accessory lighting connector (may be present on many Honda vehicles)
  ![image](https://user-images.githubusercontent.com/4112046/87235373-62e36c80-c390-11ea-8213-18a6d4a30468.png)
  [image from here](https://www.civicx.com/forum/threads/vehicle-6-pin-connector.20774/)
* Blue 36 pin body control module connector (may be specific to CR-V and Civic)
  ![image](https://user-images.githubusercontent.com/4112046/87235327-e0f34380-c38f-11ea-8887-011eaa3eaaae.png)
  [image from here](https://directechs.blob.core.windows.net/documents/dball2-honda7_en_ig_th20170104.pdf)
