### PR TITLE
Chevy Volt PI tuning, 0.7.7 localizer live params

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -46,9 +46,13 @@ class CarInterface(CarInterfaceBase):
       ret.minEnableSpeed = 18 * CV.MPH_TO_MS
       ret.mass = 1607. + STD_CARGO_KG
       ret.wheelbase = 2.69
-      ret.steerRatio = 15.7
+      ret.steerRatio = 16.38 # live params w/ localizer, stock 15.7
+      tire_stiffness_factor = 0.465 # live params w/ localizer, stock Michelin Energy Saver A/S
       ret.steerRatioRear = 0.
       ret.centerToFront = ret.wheelbase * 0.4  # wild guess
+      ret.lateralTuning.pid.kiBP = ret.lateralTuning.pid.kpBP = [5., 35.]
+      ret.lateralTuning.pid.kiV = [0.03, 0.05]
+      ret.lateralTuning.pid.kpV = [0.07, 0.12]
 
     elif candidate == CAR.MALIBU:
       # supports stop and go, but initial engage must be above 18mph (which include conservatism)


### PR DESCRIPTION
kp 0.12 and ki 0.05 have legacy with kegman custom fork, adding a 5 m/s breakpoint with 0.07 kp reduces jerky oversteering-and-correction on high curvature low speed side roads.

Steer ratio and tire stiffness are from 0.7.7 master-ci this weekend, with localizer live params, one block from the exit ramp after 20 highway miles. If that is invalid, I can repeat on the road.