### PR TITLE
Add 2020 Insight FW

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Supported Cars
 | Honda     | CR-V Hybrid 2017-2019         | Honda Sensing     | Stock            | 0mph               | 12mph             |
 | Honda     | Fit 2018-19                   | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |
 | Honda     | HR-V 2019                     | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |
-| Honda     | Insight 2019                  | Honda Sensing     | Stock            | 0mph               | 3mph              |
+| Honda     | Insight 2019-20               | Honda Sensing     | Stock            | 0mph               | 3mph              |
 | Honda     | Odyssey 2018-20               | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 0mph              |
 | Honda     | Passport 2019                 | All               | openpilot        | 25mph<sup>1</sup>  | 12mph             |
 | Honda     | Pilot 2016-18                 | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -885,9 +885,22 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x18dab5f1, None): [
       b'36161-TXM-A050\x00\x00',
+      b'36161-TXM-A060\x00\x00',
     ],
     (Ecu.srs, 0x18da53f1, None): [
       b'77959-TXM-A230\x00\x00',
+    ],
+    (Ecu.vsa, 0x18da28f1, None): [
+      b'57114-TXM-A040\x00\x00',
+    ],
+    (Ecu.shiftByWire, 0x18da0bf1, None): [
+      b'54008-TWA-A910\x00\x00',
+    ],
+    (Ecu.gateway, 0x18daeff1, None): [
+      b'38897-TXM-A020\x00\x00',
+    ],
+    (Ecu.combinationMeter, 0x18da60f1, None): [
+      b'78109-TXM-A020\x00\x00',
     ],
   },
   CAR.HRV: {


### PR DESCRIPTION
This car is the same as the 2019, just with newer firmware IDs.

Route ID: d952837313c3e269|2020-07-13--18-53-09
User is using OP 0.7.6.1 due to Camera Refocus alerts from a recent commit of master.

This change will break Insight users still on giraffe due to not being able to query all now necessary (i.e. Ecu.eps) firmware IDs from the car. <Thanks to @theantihero for that info.