### PR TITLE
Fix hard deceleration after user accelerates above set cruise speed

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -85,7 +85,7 @@ class LongControl():
 
     v_ego_pid = max(CS.vEgo, MIN_CAN_SPEED)  # Without this we get jumps, CAN bus reports 0 when speed < 0.3
 
-    if self.long_control_state == LongCtrlState.off:
+    if self.long_control_state == LongCtrlState.off or CS.gasPressed:
       self.v_pid = v_ego_pid
       self.pid.reset()
       output_gb = 0.

--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -129,7 +129,7 @@ class Planner():
     following = lead_1.status and lead_1.dRel < 45.0 and lead_1.vLeadK > v_ego and lead_1.aLeadK > 0.0
 
     # Calculate speed for normal cruise control
-    if enabled and not self.first_loop:
+    if enabled and not self.first_loop and not sm['carState'].gasPressed:
       accel_limits = [float(x) for x in calc_cruise_accel_limits(v_ego, following)]
       jerk_limits = [min(-0.1, accel_limits[0]), max(0.1, accel_limits[1])]  # TODO: make a separate lookup for jerk tuning
       accel_limits_turns = limit_accel_in_turns(v_ego, sm['carState'].steeringAngle, accel_limits, self.CP)


### PR DESCRIPTION
This shouldn't affect stock openpilot since behavior on stock is to immediately disengage. This only removes the need for forks to make these changes after enabling unsafe_mode: `UNSAFE_DISABLE_DISENGAGE_ON_GAS`. All it does is simply change behavior from hard braking after user accelerates above the set speed to behavior similar to resuming from above the set speed when gas is released; a smooth deceleration.

- When gas is pressed, reset longcontrol PI loop (mainly worried about integral building up while gas is pressed)
- When gas is pressed, reset `self.v_cruise` to `v_ego` (and others)