### PR TITLE
Disable raw upload while onroad

### DIFF
--- a/selfdrive/loggerd/tests/loggerd_tests_common.py
+++ b/selfdrive/loggerd/tests/loggerd_tests_common.py
@@ -57,6 +57,7 @@ class MockParams():
     self.params = {
       "DongleId": b"0000000000000000",
       "IsUploadRawEnabled": b"1",
+      "IsOffroad": b"1",
     }
 
   def get(self, k):

--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -247,7 +247,8 @@ def uploader_fn(exit_event):
 
   backoff = 0.1
   while True:
-    allow_raw_upload = (params.get("IsUploadRawEnabled") != b"0")
+    offroad = params.get("IsOffroad") == b'1'
+    allow_raw_upload = (params.get("IsUploadRawEnabled") != b"0") and offroad
     on_hotspot = is_on_hotspot()
     on_wifi = is_on_wifi()
     should_upload = on_wifi and not on_hotspot
@@ -257,7 +258,6 @@ def uploader_fn(exit_event):
 
     d = uploader.next_file_to_upload(with_raw=allow_raw_upload and should_upload)
     if d is None:  # Nothing to upload
-      offroad = params.get("IsOffroad") == b'1'
       time.sleep(60 if offroad else 5)
       continue
 


### PR DESCRIPTION
Saves about 10% of a core if a user is connected to wifi