### PR TITLE
Subaru Global generated dbc and new signals

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
 	url = ../../commaai/panda.git
 [submodule "opendbc"]
 	path = opendbc
-	url = ../../commaai/opendbc.git
+	url = ../../martinl/opendbc.git
+	branch = feature-subaru-long
 [submodule "laika_repo"]
 	path = laika_repo
 	url = ../../commaai/laika.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "panda"]
 	path = panda
-	url = ../../commaai/panda.git
+	url = ../../martinl/panda.git
+	branch = subaru-global-carstate
 [submodule "opendbc"]
 	path = opendbc
 	url = ../../martinl/opendbc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "panda"]
 	path = panda
-	url = ../../martinl/panda.git
-	branch = subaru-global-carstate
+	url = ../../commaai/panda.git
 [submodule "opendbc"]
 	path = opendbc
-	url = ../../martinl/opendbc.git
-	branch = subaru-global-2020
+	url = ../../commaai/opendbc.git
 [submodule "laika_repo"]
 	path = laika_repo
 	url = ../../commaai/laika.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "opendbc"]
 	path = opendbc
 	url = ../../martinl/opendbc.git
-	branch = feature-subaru-long
+	branch = subaru-global-2020
 [submodule "laika_repo"]
 	path = laika_repo
 	url = ../../commaai/laika.git

--- a/release/files_common
+++ b/release/files_common
@@ -529,7 +529,7 @@ opendbc/mazda_2017.dbc
 opendbc/nissan_x_trail_2017.dbc
 opendbc/nissan_leaf_2018.dbc
 
-opendbc/subaru_global_2017.dbc
+opendbc/subaru_global_2017_generated.dbc
 
 opendbc/toyota_rav4_hybrid_2017_pt_generated.dbc
 opendbc/toyota_rav4_2017_pt_generated.dbc

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -117,6 +117,7 @@ class CarState(CarStateBase):
   def get_cam_can_parser(CP):
     signals = [
       ("Cruise_Set_Speed", "ES_DashStatus", 0),
+      ("Conventional_Cruise", "ES_DashStatus", 0),
 
       ("Counter", "ES_Distance", 0),
       ("Signal1", "ES_Distance", 0),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -48,11 +48,15 @@ class CarState(CarStateBase):
     ret.steeringTorque = cp.vl["Steering_Torque"]['Steer_Torque_Sensor']
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD[self.car_fingerprint]
 
+    ret.steerError = cp.vl["Steering_Torque"]['Steer_Error_1'] == 1
+    ret.steerWarning = cp.vl["Steering_Torque"]['Steer_Warning'] == 1
+
     ret.cruiseState.enabled = cp.vl["CruiseControl"]['Cruise_Activated'] != 0
     ret.cruiseState.available = cp.vl["CruiseControl"]['Cruise_On'] != 0
     ret.cruiseState.speed = cp_cam.vl["ES_DashStatus"]['Cruise_Set_Speed'] * CV.KPH_TO_MS
-    # EDM Impreza: 1 = mph, UDM Forester: 7 = mph
-    if cp.vl["Dash_State"]['Units'] in [1, 7]:
+    ret.cruiseState.nonAdaptive = cp.vl["ES_DashStatus"]['Conventional_Cruise'] == 1
+    # EDM Impreza: 1,2 = mph, UDM Forester: 7 = mph
+    if cp.vl["Dash_State"]['Units'] in [1, 2, 7]:
       ret.cruiseState.speed *= CV.MPH_TO_KPH
 
     ret.seatbeltUnlatched = cp.vl["Dashlights"]['SEATBELT_FL'] == 1
@@ -73,6 +77,8 @@ class CarState(CarStateBase):
       # sig_name, sig_address, default
       ("Steer_Torque_Sensor", "Steering_Torque", 0),
       ("Steering_Angle", "Steering_Torque", 0),
+      ("Steer_Error_1", "Steering_Torque", 0),
+      ("Steer_Warning", "Steering_Torque", 0),
       ("Cruise_On", "CruiseControl", 0),
       ("Cruise_Activated", "CruiseControl", 0),
       ("Brake_Pedal", "Brake_Pedal", 0),
@@ -114,9 +120,21 @@ class CarState(CarStateBase):
 
       ("Counter", "ES_Distance", 0),
       ("Signal1", "ES_Distance", 0),
+      ("Cruise_Fault", "ES_Distance", 0),
+      ("Cruise_Throttle", "ES_Distance", 0),
       ("Signal2", "ES_Distance", 0),
-      ("Main", "ES_Distance", 0),
+      ("Car_Follow", "ES_Distance", 0),
       ("Signal3", "ES_Distance", 0),
+      ("Cruise_Brake_Active", "ES_Distance", 0),
+      ("Distance_Swap", "ES_Distance", 0),
+      ("Cruise_EPB", "ES_Distance", 0),
+      ("Signal4", "ES_Distance", 0),
+      ("Close_Distance", "ES_Distance", 0),
+      ("Signal5", "ES_Distance", 0),
+      ("Cruise_Cancel", "ES_Distance", 0),
+      ("Cruise_Set", "ES_Distance", 0),
+      ("Cruise_Resume", "ES_Distance", 0),
+      ("Signal6", "ES_Distance", 0),
 
       ("Counter", "ES_LKAS_State", 0),
       ("Keep_Hands_On_Wheel", "ES_LKAS_State", 0),
@@ -126,23 +144,21 @@ class CarState(CarStateBase):
       ("Signal2", "ES_LKAS_State", 0),
       ("Backward_Speed_Limit_Menu", "ES_LKAS_State", 0),
       ("LKAS_ENABLE_3", "ES_LKAS_State", 0),
-      ("Signal3", "ES_LKAS_State", 0),
+      ("LKAS_Left_Line_Light_Blink", "ES_LKAS_State", 0),
       ("LKAS_ENABLE_2", "ES_LKAS_State", 0),
-      ("Signal4", "ES_LKAS_State", 0),
+      ("LKAS_Right_Line_Light_Blink", "ES_LKAS_State", 0),
       ("LKAS_Left_Line_Visible", "ES_LKAS_State", 0),
-      ("Signal6", "ES_LKAS_State", 0),
+      ("LKAS_Left_Line_Green", "ES_LKAS_State", 0),
       ("LKAS_Right_Line_Visible", "ES_LKAS_State", 0),
-      ("Signal7", "ES_LKAS_State", 0),
-      ("FCW_Cont_Beep", "ES_LKAS_State", 0),
-      ("FCW_Repeated_Beep", "ES_LKAS_State", 0),
-      ("Throttle_Management_Activated", "ES_LKAS_State", 0),
-      ("Traffic_light_Ahead", "ES_LKAS_State", 0),
-      ("Right_Depart", "ES_LKAS_State", 0),
-      ("Signal5", "ES_LKAS_State", 0),
+      ("LKAS_Right_Line_Green", "ES_LKAS_State", 0),
+      ("LKAS_Alert", "ES_LKAS_State", 0),
+      ("Signal3", "ES_LKAS_State", 0),
     ]
 
     checks = [
       ("ES_DashStatus", 10),
+      ("ES_Distance", 20),
+      ("ES_LKAS_State", 10),
     ]
 
     return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, 2)

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -54,7 +54,7 @@ class CarState(CarStateBase):
     ret.cruiseState.enabled = cp.vl["CruiseControl"]['Cruise_Activated'] != 0
     ret.cruiseState.available = cp.vl["CruiseControl"]['Cruise_On'] != 0
     ret.cruiseState.speed = cp_cam.vl["ES_DashStatus"]['Cruise_Set_Speed'] * CV.KPH_TO_MS
-    ret.cruiseState.nonAdaptive = cp.vl["ES_DashStatus"]['Conventional_Cruise'] == 1
+    ret.cruiseState.nonAdaptive = cp_cam.vl["ES_DashStatus"]['Conventional_Cruise'] == 1
     # EDM Impreza: 1,2 = mph, UDM Forester: 7 = mph
     if cp.vl["Dash_State"]['Units'] in [1, 2, 7]:
       ret.cruiseState.speed *= CV.MPH_TO_KPH

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -24,7 +24,7 @@ def create_es_distance(packer, es_distance_msg, pcm_cancel_cmd):
 
   values = copy.copy(es_distance_msg)
   if pcm_cancel_cmd:
-    values["Main"] = 1
+    values["Cruise_Cancel"] = 1
 
   return packer.make_can_msg("ES_Distance", 0, values)
 

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -43,7 +43,7 @@ ECU_FINGERPRINT = {
 }
 
 DBC = {
-  CAR.ASCENT: dbc_dict('subaru_global_2017', None),
-  CAR.IMPREZA: dbc_dict('subaru_global_2017', None),
-  CAR.FORESTER: dbc_dict('subaru_global_2017', None),
+  CAR.ASCENT: dbc_dict('subaru_global_2017_generated', None),
+  CAR.IMPREZA: dbc_dict('subaru_global_2017_generated', None),
+  CAR.FORESTER: dbc_dict('subaru_global_2017_generated', None),
 }


### PR DESCRIPTION
This PR:
- switches to generated version of subaru global dbc (in preparation for adding support for hybrid and 2020+ models)
- updates carstate and subarucan to match signals in generated dbc
- adds ES_Distance and ES_LKAS_State frequency checks to carstate
- adds following signals to subaru carstate:
  - ret.steerError
  - ret.steerWarning
  - ret.cruiseState.nonAdaptive

Prerequsites:
- [x] https://github.com/commaai/opendbc/pull/277
- [ ] https://github.com/commaai/panda/pull/575