### PR TITLE
Add Hyundai routes for non tested cars

### DIFF
--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -200,6 +200,10 @@ routes = {
     'carFingerprint': HYUNDAI.IONIQ,
     'enableCamera': True,
   },
+  "6fe86b4e410e4c37|2020-07-22--16-27-13": {
+    'carFingerprint': HYUNDAI.HYUNDAI_GENESIS,
+    'enableCamera': True,
+  },
   "f7b6be73e3dfd36c|2019-05-12--18-07-16": {
     'carFingerprint': TOYOTA.AVALON,
     'enableCamera': False,
@@ -418,7 +422,6 @@ non_tested_cars = [
   HYUNDAI.ELANTRA_GT_I30,
   HYUNDAI.GENESIS_G80,
   HYUNDAI.GENESIS_G90,
-  HYUNDAI.HYUNDAI_GENESIS,
   HYUNDAI.KIA_FORTE,
   HYUNDAI.KIA_OPTIMA,
   HYUNDAI.KIA_OPTIMA_H,

--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -204,6 +204,10 @@ routes = {
     'carFingerprint': HYUNDAI.HYUNDAI_GENESIS,
     'enableCamera': True,
   },
+  "5dddcbca6eb66c62|2020-07-26--13-24-19--0": {
+    'carFingerprint': HYUNDAI.KIA_STINGER,
+    'enableCamera': True,
+  },
   "f7b6be73e3dfd36c|2019-05-12--18-07-16": {
     'carFingerprint': TOYOTA.AVALON,
     'enableCamera': False,
@@ -426,7 +430,6 @@ non_tested_cars = [
   HYUNDAI.KIA_OPTIMA,
   HYUNDAI.KIA_OPTIMA_H,
   HYUNDAI.KIA_SORENTO,
-  HYUNDAI.KIA_STINGER,
   HYUNDAI.KONA,
   HYUNDAI.KONA_EV,
   TOYOTA.CAMRYH,

--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -200,7 +200,7 @@ routes = {
     'carFingerprint': HYUNDAI.IONIQ,
     'enableCamera': True,
   },
-  "6fe86b4e410e4c37|2020-07-22--16-27-13": {
+  "6fe86b4e410e4c37|2020-07-22--16-27-13--0": {
     'carFingerprint': HYUNDAI.HYUNDAI_GENESIS,
     'enableCamera': True,
   },


### PR DESCRIPTION
Added-
HYUNDAI.HYUNDAI_GENESIS

Remaining-
  HYUNDAI.ELANTRA,
  HYUNDAI.ELANTRA_GT_I30,
  HYUNDAI.GENESIS_G80,
  HYUNDAI.GENESIS_G90,
  HYUNDAI.KIA_FORTE,
  HYUNDAI.KIA_OPTIMA,
  HYUNDAI.KIA_OPTIMA_H,
  HYUNDAI.KIA_SORENTO,
  HYUNDAI.KIA_STINGER,
  HYUNDAI.KONA,
  HYUNDAI.KONA_EV,