### PR TITLE
Only draw lead car indicators when controlling longitudinal

### DIFF
--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -368,11 +368,14 @@ static void ui_draw_world(UIState *s) {
   // Draw lane edges and vision/mpc tracks
   ui_draw_vision_lanes(s);
 
-  if (scene->lead_data[0].getStatus()) {
-    draw_lead(s, scene->lead_data[0]);
-  }
-  if (scene->lead_data[1].getStatus() && (std::abs(scene->lead_data[0].getDRel() - scene->lead_data[1].getDRel()) > 3.0)) {
-    draw_lead(s, scene->lead_data[1]);
+  // Draw lead indicators if openpilot is handling longitudinal
+  if (s->longitudinal_control) {
+    if (scene->lead_data[0].getStatus()) {
+      draw_lead(s, scene->lead_data[0]);
+    }
+    if (scene->lead_data[1].getStatus() && (std::abs(scene->lead_data[0].getDRel() - scene->lead_data[1].getDRel()) > 3.0)) {
+      draw_lead(s, scene->lead_data[1]);
+    }
   }
   nvgRestore(s->vg);
 }


### PR DESCRIPTION
resolves #1905 