### PR TITLE
Add argument to ui executable that forces the drawing of the UI

### DIFF
--- a/selfdrive/ui/ui
+++ b/selfdrive/ui/ui
@@ -1,4 +1,3 @@
 #!/bin/sh
 export LD_LIBRARY_PATH="/system/lib64:$LD_LIBRARY_PATH"
-exec ./_ui
-
+exec ./_ui "$@"

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -751,8 +751,12 @@ int main(int argc, char* argv[]) {
   bool debug_ui = false;
   if (argc == 2) {
     if (strcmp(argv[1], "debug") == 0) {
+      printf("DEBUGGING!\n");
       debug_ui = true;
     }
+  }
+  if (!debug_ui) {
+    printf("NOT DEBUGGING!\n");
   }
 
   while (!do_exit) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -751,12 +751,8 @@ int main(int argc, char* argv[]) {
   bool debug_ui = false;
   if (argc == 2) {
     if (strcmp(argv[1], "debug") == 0) {
-      printf("DEBUGGING!\n");
       debug_ui = true;
     }
-  }
-  if (!debug_ui) {
-    printf("NOT DEBUGGING!\n");
   }
 
   while (!do_exit) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -748,8 +748,22 @@ int main(int argc, char* argv[]) {
   assert(s->sound.init(MIN_VOLUME));
 
   int draws = 0;
+  bool debug_ui = false;
+  if (argc == 2) {
+    if (strcmp(argv[1], "debug") == 0) {
+      debug_ui = true;
+    }
+  }
 
   while (!do_exit) {
+    if (debug_ui) {
+      s->started = true;
+      s->status = STATUS_DISENGAGED;
+      s->controls_seen = true;
+      s->vision_seen = true;
+      s->active_app = cereal::UiLayoutState::App::NONE;
+      s->controls_timeout = UI_FREQ;
+    }
     bool should_swap = false;
     if (!s->started) {
       // Delay a while to avoid 9% cpu usage while car is not started and user is keeping touching on the screen.


### PR DESCRIPTION
This allows developers to start the UI by typing `./ui debug` so you can see your design without plugging the C2/EON into your car and starting it up. Everything works as intended when starting ui without debug argument.

If there's a better way to draw the UI in paint.cc without setting all these variables every loop, let me know. It seems to work fine though as this PR stands.