### PR TITLE
Block LCA if trailer is connected to vehicle. 

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -181,7 +181,7 @@ class Controls:
         self.events.add(EventName.calibrationInvalid)
 
     # Handle lane change
-    if not CS.trailerConnected:
+    if not CS.trailerConnected: 
       if self.sm['pathPlan'].laneChangeState == LaneChangeState.preLaneChange:
         direction = self.sm['pathPlan'].laneChangeDirection
         if (CS.leftBlindspot and direction == LaneChangeDirection.left) or \

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -181,20 +181,23 @@ class Controls:
         self.events.add(EventName.calibrationInvalid)
 
     # Handle lane change
-    if self.sm['pathPlan'].laneChangeState == LaneChangeState.preLaneChange:
-      direction = self.sm['pathPlan'].laneChangeDirection
-      if (CS.leftBlindspot and direction == LaneChangeDirection.left) or \
-         (CS.rightBlindspot and direction == LaneChangeDirection.right):
-        self.events.add(EventName.laneChangeBlocked)
-      else:
-        if direction == LaneChangeDirection.left:
-          self.events.add(EventName.preLaneChangeLeft)
+    if not CS.trailerConnected:
+      if self.sm['pathPlan'].laneChangeState == LaneChangeState.preLaneChange:
+        direction = self.sm['pathPlan'].laneChangeDirection
+        if (CS.leftBlindspot and direction == LaneChangeDirection.left) or \
+           (CS.rightBlindspot and direction == LaneChangeDirection.right):
+          self.events.add(EventName.laneChangeBlocked)
         else:
-          self.events.add(EventName.preLaneChangeRight)
-    elif self.sm['pathPlan'].laneChangeState in [LaneChangeState.laneChangeStarting,
-                                        LaneChangeState.laneChangeFinishing]:
-      self.events.add(EventName.laneChange)
-
+          if direction == LaneChangeDirection.left:
+            self.events.add(EventName.preLaneChangeLeft)
+          else:
+            self.events.add(EventName.preLaneChangeRight)
+      elif self.sm['pathPlan'].laneChangeState in [LaneChangeState.laneChangeStarting,
+                                          LaneChangeState.laneChangeFinishing]:
+        self.events.add(EventName.laneChange)
+    else:
+      self.events.add(EventName.laneChangeTrailer)
+      
     if self.can_rcv_error or (not CS.canValid and self.sm.frame > 5 / DT_CTRL):
       self.events.add(EventName.canError)
     if self.mismatch_counter >= 200:

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -463,6 +463,13 @@ EVENTS = {
       Priority.LOW, VisualAlert.steerRequired, AudibleAlert.none, .0, .1, .1),
   },
 
+  EventName.laneChangeTrailer: {
+    ET.WARNING: Alert(
+      "LCA Unavailable",
+      "LCA not available while trailer is connected",
+      AlertStatus.normal, AlertSize.mid,
+      Priority.LOW, VisualAlert.steerRequired, AudibleAlert.none, .0, .1, .1),
+  },
   EventName.steerSaturated: {
     ET.WARNING: Alert(
       "TAKE CONTROL",


### PR DESCRIPTION
Referencing cereal#65

LCA should be blocked if a trailer is connected. LCA could potentially cause the trailer to sway if the change is too abrupt, and the driver may lose control of the vehicle in that instance. The driver should manually make the lane change. 

Not all vehicles will have a can message for the 4/7 pin Trailer connector, but those that do should automatically block LCA when connected. 

Code fails test due to unmerged cereal pr. 