### PR TITLE
sidebar:  remove unnecessary checks on uilayout_sidebarcollapsed

### DIFF
--- a/selfdrive/ui/sidebar.cc
+++ b/selfdrive/ui/sidebar.cc
@@ -56,12 +56,15 @@ static void ui_draw_sidebar_network_type(UIState *s) {
       {cereal::ThermalData::NetworkType::CELL3_G, "3G"},
       {cereal::ThermalData::NetworkType::CELL4_G, "4G"},
       {cereal::ThermalData::NetworkType::CELL5_G, "5G"}};
+  const int network_x = 50;
+  const int network_y = 273;
+  const int network_w = 100;
   const char *network_type = network_type_map[s->scene.thermal.getNetworkType()];
   nvgFillColor(s->vg, COLOR_WHITE);
   nvgFontSize(s->vg, 48);
   nvgFontFaceId(s->vg, s->font_sans_regular);
   nvgTextAlign(s->vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
-  nvgTextBox(s->vg, 50, 273, 100, network_type ? network_type : "--", NULL);
+  nvgTextBox(s->vg, network_x, network_y, network_w, network_type ? network_type : "--", NULL);
 }
 
 static void ui_draw_sidebar_metric(UIState *s, const char* label_str, const char* value_str, const int severity, const int y_offset, const char* message_str) {

--- a/selfdrive/ui/sidebar.cc
+++ b/selfdrive/ui/sidebar.cc
@@ -10,17 +10,13 @@ static void ui_draw_sidebar_background(UIState *s) {
 }
 
 static void ui_draw_sidebar_settings_button(UIState *s) {
-  bool settingsActive = s->active_app == cereal::UiLayoutState::App::SETTINGS;
-  const int settings_btn_xr = !s->scene.uilayout_sidebarcollapsed ? settings_btn_x : -(sbr_w);
-
-  ui_draw_image(s->vg, settings_btn_xr, settings_btn_y, settings_btn_w, settings_btn_h, s->img_button_settings, settingsActive ? 1.0f : 0.65f);
+  const float alpha = s->active_app == cereal::UiLayoutState::App::SETTINGS ? 1.0f : 0.65f;
+  ui_draw_image(s->vg, settings_btn_x, settings_btn_y, settings_btn_w, settings_btn_h, s->img_button_settings, alpha);
 }
 
 static void ui_draw_sidebar_home_button(UIState *s) {
-  bool homeActive = s->active_app == cereal::UiLayoutState::App::HOME;
-  const int home_btn_xr = !s->scene.uilayout_sidebarcollapsed ? home_btn_x : -(sbr_w);
-
-  ui_draw_image(s->vg, home_btn_xr, home_btn_y, home_btn_w, home_btn_h, s->img_button_home, homeActive ? 1.0f : 0.65f);
+  const float alpha = s->active_app == cereal::UiLayoutState::App::HOME ? 1.0f : 0.65f;;
+  ui_draw_image(s->vg, home_btn_x, home_btn_y, home_btn_w, home_btn_h, s->img_button_home, alpha);
 }
 
 static void ui_draw_sidebar_network_strength(UIState *s) {
@@ -30,18 +26,14 @@ static void ui_draw_sidebar_network_strength(UIState *s) {
       {cereal::ThermalData::NetworkStrength::MODERATE, 3},
       {cereal::ThermalData::NetworkStrength::GOOD, 4},
       {cereal::ThermalData::NetworkStrength::GREAT, 5}};
-  const int network_img_h = 27;
-  const int network_img_w = 176;
-  const int network_img_x = !s->scene.uilayout_sidebarcollapsed ? 58 : -(sbr_w);
-  const int network_img_y = 196;
   const int img_idx = s->scene.thermal.getNetworkType() == cereal::ThermalData::NetworkType::NONE ? 0 : network_strength_map[s->scene.thermal.getNetworkStrength()];
-  ui_draw_image(s->vg, network_img_x, network_img_y, network_img_w, network_img_h, s->img_network[img_idx], 1.0f);
+  ui_draw_image(s->vg, 58, 196, 176, 27, s->img_network[img_idx], 1.0f);
 }
 
 static void ui_draw_sidebar_battery_icon(UIState *s) {
   const int battery_img_h = 36;
   const int battery_img_w = 76;
-  const int battery_img_x = !s->scene.uilayout_sidebarcollapsed ? 160 : -(sbr_w);
+  const int battery_img_x = 160;
   const int battery_img_y = 255;
 
   int battery_img = s->scene.thermal.getBatteryStatus() == "Charging" ? s->img_battery_charging : s->img_battery;
@@ -60,19 +52,16 @@ static void ui_draw_sidebar_network_type(UIState *s) {
       {cereal::ThermalData::NetworkType::CELL3_G, "3G"},
       {cereal::ThermalData::NetworkType::CELL4_G, "4G"},
       {cereal::ThermalData::NetworkType::CELL5_G, "5G"}};
-  const int network_x = !s->scene.uilayout_sidebarcollapsed ? 50 : -(sbr_w);
-  const int network_y = 273;
-  const int network_w = 100;
   const char *network_type = network_type_map[s->scene.thermal.getNetworkType()];
   nvgFillColor(s->vg, COLOR_WHITE);
   nvgFontSize(s->vg, 48);
   nvgFontFaceId(s->vg, s->font_sans_regular);
   nvgTextAlign(s->vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
-  nvgTextBox(s->vg, network_x, network_y, network_w, network_type ? network_type : "--", NULL);
+  nvgTextBox(s->vg, 50, 273, 100, network_type ? network_type : "--", NULL);
 }
 
 static void ui_draw_sidebar_metric(UIState *s, const char* label_str, const char* value_str, const int severity, const int y_offset, const char* message_str) {
-  const int metric_x = !s->scene.uilayout_sidebarcollapsed ? 30 : -(sbr_w);
+  const int metric_x = 30;
   const int metric_y = 338 + y_offset;
   const int metric_w = 240;
   const int metric_h = message_str ? strchr(message_str, '\n') ? 124 : 100 : 148;

--- a/selfdrive/ui/sidebar.cc
+++ b/selfdrive/ui/sidebar.cc
@@ -26,8 +26,12 @@ static void ui_draw_sidebar_network_strength(UIState *s) {
       {cereal::ThermalData::NetworkStrength::MODERATE, 3},
       {cereal::ThermalData::NetworkStrength::GOOD, 4},
       {cereal::ThermalData::NetworkStrength::GREAT, 5}};
+  const int network_img_h = 27;
+  const int network_img_w = 176;
+  const int network_img_x = 58;
+  const int network_img_y = 196;
   const int img_idx = s->scene.thermal.getNetworkType() == cereal::ThermalData::NetworkType::NONE ? 0 : network_strength_map[s->scene.thermal.getNetworkStrength()];
-  ui_draw_image(s->vg, 58, 196, 176, 27, s->img_network[img_idx], 1.0f);
+  ui_draw_image(s->vg, network_img_x, network_img_y, network_img_w, network_img_h, s->img_network[img_idx], 1.0f);
 }
 
 static void ui_draw_sidebar_battery_icon(UIState *s) {


### PR DESCRIPTION
ui_draw_sidebar_xxx will not be called if uilayout_sidebarcollapsed is true.
