### PR TITLE
fix for Ubuntu build

### DIFF
--- a/selfdrive/loggerd/SConscript
+++ b/selfdrive/loggerd/SConscript
@@ -12,6 +12,6 @@ elif arch == "larch64":
   src += ['encoder.c', 'raw_logger.cc']
   libs += ['OmxVenc', 'OmxCore', 'pthread']
 else:
-  libs += ['pthread']
+  libs += ['pthread', 'zmq']
 
 env.Program(src, LIBS=libs)


### PR DESCRIPTION
I was getting this error when compile boggerd from Ubuntu 16.04:
```
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
clang++ -o selfdrive/loggerd/loggerd -Wl,-rpath=/home/xx979xx/openpilot/external/tensorflow/lib -Wl,-rpath=/home/xx979xx/openpilot/cereal -Wl,-rpath=/home/xx979xx/openpilot/selfdrive/common selfdrive/loggerd/loggerd.o selfdrive/loggerd/logger.o -Lphonelibs/snpe/x86_64-linux-clang -Lphonelibs/libyuv/x64/lib -Lexternal/tensorflow/lib -Lcereal -Lselfdrive/common -L/usr/lib -L/usr/local/lib -Lcereal -Lselfdrive/common -Lphonelibs -lzmq -lczmq -lcapnp -lkj -lz -lavformat -lavcodec -lswscale -lavutil -lyuv -lbz2 selfdrive/common/libcommon.a -ljson11 cereal/libcereal.a cereal/libmessaging.a selfdrive/common/libvisionipc.a -lpthread
/usr/bin/ld: /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../x86_64-linux-gnu/libczmq.so: undefined reference to symbol 'zmq_msg_init'
//usr/lib/x86_64-linux-gnu/libzmq.so.5: error adding symbols: DSO missing from command line
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [selfdrive/loggerd/loggerd] Error 1
scons: building terminated because of errors.

```
this fix it for me