### PR TITLE
build script that uses docker container

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -31,6 +31,7 @@ Setup
 1. Run ubuntu_setup.sh, make sure everything completed correctly
 
 2. Compile openpilot by running ```scons``` in the openpilot directory
+   or alternatively run ```./openpilot_build.sh``` (uses a pre-configured docker container)
 
 3. Add some folders to root
     ```bash

--- a/tools/openpilot_build.sh
+++ b/tools/openpilot_build.sh
@@ -1,0 +1,1 @@
+docker run --rm -v $(pwd):/tmp/openpilot -it commaai/openpilot bash -c 'cd /tmp/openpilot && scons -j$(nproc)'


### PR DESCRIPTION
building with our `commaai/openpilot` docker container is a lot easier than setting everything up on ubuntu
(this is also an easy way to get things running on ubuntu 20.04)