### PR TITLE
fix for PC: detach panda kernel driver if active

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -25,6 +25,9 @@ Panda::Panda(){
   dev_handle = libusb_open_device_with_vid_pid(ctx, 0xbbaa, 0xddcc);
   if (dev_handle == NULL) { goto fail; }
 
+  if (libusb_kernel_driver_active(dev_handle, 0) == 1) {
+    libusb_detach_kernel_driver(dev_handle, 0); }
+
   err = libusb_set_configuration(dev_handle, 1);
   if (err != 0) { goto fail; }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -26,7 +26,8 @@ Panda::Panda(){
   if (dev_handle == NULL) { goto fail; }
 
   if (libusb_kernel_driver_active(dev_handle, 0) == 1) {
-    libusb_detach_kernel_driver(dev_handle, 0); }
+    libusb_detach_kernel_driver(dev_handle, 0);
+  }
 
   err = libusb_set_configuration(dev_handle, 1);
   if (err != 0) { goto fail; }


### PR DESCRIPTION
I was not able to configure nor claim panda from Ubuntu 16.04, getting this error:
`usb error -6 "Resource busy" in usb_connect`
this fix the issue for me
