### PR TITLE
UI refactor : move driverview out of ui

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -324,6 +324,7 @@ selfdrive/ui/SConscript
 selfdrive/ui/*.cc
 selfdrive/ui/*.hpp
 selfdrive/ui/ui
+selfdrive/ui/driverview
 selfdrive/ui/spinner/Makefile
 selfdrive/ui/spinner/spinner
 selfdrive/ui/spinner/spinner.c

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -180,6 +180,7 @@ managed_processes = {
   "boardd": ("selfdrive/boardd", ["./boardd"]),   # not used directly
   "pandad": "selfdrive.pandad",
   "ui": ("selfdrive/ui", ["./ui"]),
+  "driverview": ("selfdrive/ui", ["./driverview"]),
   "calibrationd": "selfdrive.locationd.calibrationd",
   "paramsd": "selfdrive.locationd.paramsd",
   "camerad": ("selfdrive/camerad", ["./camerad"]),
@@ -244,7 +245,8 @@ car_started_processes = [
 driver_view_processes = [
   'camerad',
   'dmonitoringd',
-  'dmonitoringmodeld'
+  'dmonitoringmodeld',
+  'driverview'
 ]
 
 if WEBCAM:

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -1,17 +1,19 @@
 Import('env', 'arch', 'common', 'messaging', 'gpucommon', 'visionipc', 'cereal')
+lenv = env.Clone()
+common_src = ['uicommon.cc', '#phonelibs/nanovg/nanovg.c']
 
-src = ['ui.cc', 'paint.cc', 'sidebar.cc', '#phonelibs/nanovg/nanovg.c']
+ui_src = ['ui.cc', 'paint.cc', 'sidebar.cc']
 libs = [common, 'zmq', 'czmq', 'capnp', 'kj', 'm', cereal, messaging, gpucommon, visionipc]
-
 if arch == "aarch64":
-  src += ['sound.cc']
+  ui_src += ['sound.cc']
   libs += ['EGL', 'GLESv3', 'gnustl_shared', 'log', 'utils', 'gui', 'hardware', 'ui', 'CB', 'gsl', 'adreno_utils', 'OpenSLES', 'cutils', 'uuid', 'OpenCL']
   linkflags = ['-Wl,-rpath=/system/lib64,-rpath=/system/comma/usr/lib']
 else:
-  src += ['linux.cc']
+  common_src += ['linux.cc']
   libs += ['pthread', 'glfw']
   linkflags = []
 
-env.Program('_ui', src,
-  LINKFLAGS=linkflags,
-  LIBS=libs)
+common = lenv.Object(common_src)
+
+lenv.Program('_ui', ui_src+common, LINKFLAGS=linkflags, LIBS=libs)
+lenv.Program('_driverview', ['driverview.cc']+common, LINKFLAGS=linkflags, LIBS=libs)

--- a/selfdrive/ui/driverview
+++ b/selfdrive/ui/driverview
@@ -1,0 +1,4 @@
+#!/bin/sh
+export LD_LIBRARY_PATH="/system/lib64:$LD_LIBRARY_PATH"
+exec ./_driverview
+

--- a/selfdrive/ui/driverview.cc
+++ b/selfdrive/ui/driverview.cc
@@ -1,0 +1,152 @@
+#include <assert.h>
+#include <signal.h>
+#include <stdlib.h>
+
+#include <cmath>
+
+#include "common/params.h"
+#include "common/swaglog.h"
+#include "common/util.h"
+#include "uicommon.hpp"
+
+#include "nanovg_gl.h"
+
+volatile sig_atomic_t do_exit = 0;
+
+static void set_do_exit(int sig) {
+  do_exit = 1;
+}
+
+class DriverView {
+ public:
+  DriverView() {
+    vision.init(true);
+    sm = new SubMaster({"driverState", "dMonitoringState"});
+
+#ifdef QCOM
+    // on QCOM, we enable MSAA
+    vg = nvgCreate(0);
+#else
+    vg = nvgCreate(NVG_ANTIALIAS | NVG_STENCIL_STROKES | NVG_DEBUG);
+#endif
+    assert(vg);
+
+    img_face = nvgCreateImage(vg, "../assets/img_driver_face.png", 1);
+    assert(img_face != 0);
+    touch_init(&touch);
+  }
+
+  void run() {
+    int touch_x = -1, touch_y = -1;
+    int touched = touch_poll(&touch, &touch_x, &touch_y, 0);
+    if (touched == 1) {
+      write_db_value("IsDriverViewEnabled", "0", 1);
+    }
+    if (sm->update(0) > 0) {
+      if (sm->updated("driverState")) {
+        driver_state = (*sm)["driverState"].getDriverState();
+      }
+      if (sm->updated("dMonitoringState")) {
+        dmonitoring_state = (*sm)["dMonitoringState"].getDMonitoringState();
+      }
+    }
+
+    vision.ui_update();
+
+    glClearColor(0, 0, 0, 1.0);
+    glClear(GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glViewport(0, 0, vision.fb_w, vision.fb_h);
+    nvgBeginFrame(vg, vision.fb_w, vision.fb_h, 1.0f);
+
+    glEnable(GL_SCISSOR_TEST);
+    glViewport(bdr_s, bdr_s, vision.fb_w - bdr_s * 2, vision.fb_h - bdr_s * 2);
+    glScissor(bdr_s, bdr_s, vision.fb_w - bdr_s * 2, vision.fb_h - bdr_s * 2);
+    vision.draw_frame();
+    glDisable(GL_SCISSOR_TEST);
+
+    glViewport(0, 0, vision.fb_w, vision.fb_h);
+    ui_draw_driver_view();
+
+    nvgEndFrame(vg);
+    glDisable(GL_BLEND);
+
+    vision.swap();
+  }
+
+  void ui_draw_driver_view() {
+    const int ff_xoffset = 32;
+    const int frame_x = bdr_s;
+    const int frame_w = vision.fb_w;
+    const int valid_frame_w = 4 * box_h / 3;
+    const int valid_frame_x = frame_x + (frame_w - valid_frame_w) / 2 + ff_xoffset;
+
+    bool is_rhd = dmonitoring_state.getIsRHD();
+    // blackout
+    NVGpaint gradient = nvgLinearGradient(vg, is_rhd ? valid_frame_x : (valid_frame_x + valid_frame_w),
+                                          box_y,
+                                          is_rhd ? (valid_frame_w - box_h / 2) : (valid_frame_x + box_h / 2), box_y,
+                                          nvgRGBA(0, 0, 0, 255), nvgRGBA(0, 0, 0, 0));
+    ui_draw_rect(vg, is_rhd ? valid_frame_x : (valid_frame_x + box_h / 2), box_y, valid_frame_w - box_h / 2, box_h, gradient);
+    ui_draw_rect(vg, is_rhd ? valid_frame_x : valid_frame_x + box_h / 2, box_y, valid_frame_w - box_h / 2, box_h, nvgRGBA(0, 0, 0, 144));
+
+    // borders
+    ui_draw_rect(vg, frame_x, box_y, valid_frame_x - frame_x, box_h, nvgRGBA(23, 51, 73, 255));
+    ui_draw_rect(vg, valid_frame_x + valid_frame_w, box_y, frame_w - valid_frame_w - (valid_frame_x - frame_x), box_h, nvgRGBA(23, 51, 73, 255));
+
+    // draw face box
+    if (dmonitoring_state.getFaceDetected()) {
+      auto fxy_list = driver_state.getFacePosition();
+      const float face_x = fxy_list[0];
+      const float face_y = fxy_list[1];
+      float fbox_x;
+      float fbox_y = box_y + (face_y + 0.5) * box_h - 0.5 * 0.6 * box_h / 2;
+      ;
+      if (!is_rhd) {
+        fbox_x = valid_frame_x + (1 - (face_x + 0.5)) * (box_h / 2) - 0.5 * 0.6 * box_h / 2;
+      } else {
+        fbox_x = valid_frame_x + valid_frame_w - box_h / 2 + (face_x + 0.5) * (box_h / 2) - 0.5 * 0.6 * box_h / 2;
+      }
+
+      if (std::abs(face_x) <= 0.35 && std::abs(face_y) <= 0.4) {
+        ui_draw_rect(vg, fbox_x, fbox_y, 0.6 * box_h / 2, 0.6 * box_h / 2,
+                     nvgRGBAf(1.0, 1.0, 1.0, 0.8 - ((std::abs(face_x) > std::abs(face_y) ? std::abs(face_x) : std::abs(face_y))) * 0.6 / 0.375),
+                     35, 10);
+      } else {
+        ui_draw_rect(vg, fbox_x, fbox_y, 0.6 * box_h / 2, 0.6 * box_h / 2, nvgRGBAf(1.0, 1.0, 1.0, 0.2), 35, 10);
+      }
+    }
+
+    // draw face icon
+    const int face_size = 85;
+    const int x = (valid_frame_x + face_size + (bdr_s * 2)) + (is_rhd ? valid_frame_w - box_h / 2 : 0);
+    const int y = (box_y + box_h - face_size - bdr_s - (bdr_s * 1.5));
+    ui_draw_circle_image(vg, x, y, face_size, img_face, dmonitoring_state.getFaceDetected());
+  }
+
+  ~DriverView() {
+    delete sm;
+    nvgDelete(vg);
+  }
+
+  UIVision vision;
+  TouchState touch = {};
+  NVGcontext* vg;
+  SubMaster* sm;
+  cereal::DriverState::Reader driver_state;
+  cereal::DMonitoringState::Reader dmonitoring_state;
+  int img_face;
+};
+
+int main(int argc, char* argv[]) {
+  signal(SIGINT, (sighandler_t)set_do_exit);
+  signal(SIGTERM, (sighandler_t)set_do_exit);
+
+  DriverView driver_view;
+  while (!do_exit) {
+    driver_view.run();
+  }
+  return 0;
+}

--- a/selfdrive/ui/driverview.cc
+++ b/selfdrive/ui/driverview.cc
@@ -35,7 +35,7 @@ class DriverView {
       }
     }
 
-    vision.update();
+    vision.update(&do_exit);
 
     glClearColor(0, 0, 0, 1.0);
     glClear(GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
@@ -139,7 +139,6 @@ int main(int argc, char* argv[]) {
       write_db_value("IsDriverViewEnabled", "0", 1);
       break;
     }
-
     driver_view.run();
   }
   return 0;

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -530,7 +530,7 @@ static void ui_draw_vision_footer(UIState *s) {
 #endif
 }
 
-void ui_draw_vision_alert(UIState *s, cereal::ControlsState::AlertSize va_size, int va_color,
+static void ui_draw_vision_alert(UIState *s, cereal::ControlsState::AlertSize va_size, int va_color,
                           const char* va_text1, const char* va_text2) {
   static std::map<cereal::ControlsState::AlertSize, const int> alert_size_map = {
       {cereal::ControlsState::AlertSize::NONE, 0},

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -1,9 +1,6 @@
 #include "ui.hpp"
-#include <assert.h>
 #include <map>
-#include <cmath>
 #include "common/util.h"
-
 #include "nanovg_gl.h"
 
 // TODO: this is also hardcoded in common/transformations/camera.py
@@ -587,7 +584,7 @@ static void ui_draw_vision(UIState *s) {
   glEnable(GL_SCISSOR_TEST);
   glViewport(scene->ui_viz_rx+scene->ui_viz_ro, s->vision.fb_h-(box_y+box_h), viz_w, box_h);
   glScissor(scene->ui_viz_rx, s->vision.fb_h-(box_y+box_h), scene->ui_viz_rw, box_h);
-  s->vision.draw_frame();
+  s->vision.draw();
   glDisable(GL_SCISSOR_TEST);
 
   glViewport(0, 0, s->vision.fb_w, s->vision.fb_h);
@@ -640,7 +637,6 @@ void ui_nvg_init(UIState *s) {
 #else
   s->vg = nvgCreate(NVG_ANTIALIAS | NVG_STENCIL_STROKES | NVG_DEBUG);
 #endif
-
   assert(s->vg);
 
   s->font_sans_regular = nvgCreateFont(s->vg, "sans-regular", "../assets/fonts/opensans_regular.ttf");

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -205,7 +205,7 @@ static void ui_draw_track(UIState *s, bool is_mpc, track_vertices_data *pvd) {
 }
 
 static inline bool valid_frame_pt(UIState *s, float x, float y) {
-  return x >= 0 && x <= s->vision.rgb_width && y >= 0 && y <= s->vision.rgb_height;
+  return x >= 0 && x <= s->vision.getRgbWidth() && y >= 0 && y <= s->vision.getRgbHeight();
 
 }
 static void update_lane_line_data(UIState *s, const float *points, float off, model_path_vertices_data *pvd, float valid_len) {
@@ -299,7 +299,7 @@ static void ui_draw_world(UIState *s) {
   nvgTranslate(s->vg, 240.0f, 0.0);
   nvgTranslate(s->vg, -1440.0f / 2, -1080.0f / 2);
   nvgScale(s->vg, 2.0, 2.0);
-  nvgScale(s->vg, 1440.0f / s->vision.rgb_width, 1080.0f / s->vision.rgb_height);
+  nvgScale(s->vg, 1440.0f / s->vision.getRgbWidth(), 1080.0f / s->vision.getRgbHeight());
 
   // Draw lane edges and vision/mpc tracks
   ui_draw_vision_lanes(s);

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -670,3 +670,7 @@ void ui_nvg_init(UIState *s) {
     assert(s->img_network[i] != 0);
   }
 }
+
+void ui_nvg_delete(UIState *s) {
+  nvgDelete(s->vg);
+}

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -5,6 +5,7 @@
 #include "common/timing.h"
 #include "common/swaglog.h"
 #include "common/params.h"
+#include "common/util.h"
 #include "common/utilpp.h"
 #include "ui.hpp"
 
@@ -523,7 +524,7 @@ int main(int argc, char* argv[]) {
       s->scene.hwType = cereal::HealthData::HwType::UNKNOWN;
     }
     update_offroad_layout_state(s);
-    
+
     // Don't waste resources on drawing in case screen is off
     if (!s->awake || s->scene.frontview) {
       continue;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -345,12 +345,6 @@ void handle_message(UIState *s, SubMaster &sm) {
       update_status(s, STATUS_STOPPED);
       s->controls_seen = false;
       s->active_app = cereal::UiLayoutState::App::HOME;
-
-      #ifndef QCOM
-      // disconnect from visionipc on PC
-      close(s->vision.ipc_fd);
-      s->vision.ipc_fd = -1;
-      #endif
     } 
   } else if (s->status == STATUS_STOPPED) {
     update_status(s, STATUS_DISENGAGED);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -1,17 +1,9 @@
 #include <stdio.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <unistd.h>
-#include <assert.h>
-#include <sys/mman.h>
-#include <string>
 #include <sstream>
 #include <sys/resource.h>
 #include <czmq.h>
-#include "common/util.h"
 #include "common/timing.h"
 #include "common/swaglog.h"
-#include "common/touch.h"
 #include "common/params.h"
 #include "common/utilpp.h"
 #include "ui.hpp"
@@ -514,7 +506,7 @@ int main(int argc, char* argv[]) {
     } else {
       // Car started, fetch a new rgb image from ipc
       set_awake(s, true);
-      s->vision.ui_update();
+      s->vision.update();
 
       check_messages(s);
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -329,7 +329,7 @@ void handle_message(UIState *s, SubMaster &sm) {
   }
 
   // timeout on frontview
-  if ((sm.frame - sm.rcv_frame("dMonitoringState")) > 1*UI_FREQ) {
+  if (scene.frontview && (sm.frame - sm.rcv_frame("dMonitoringState")) > 1*UI_FREQ) {
     scene.frontview = false;
   }
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -333,6 +333,7 @@ void handle_message(UIState *s, SubMaster &sm) {
     scene.frontview = false;
   }
 
+  // make sure the driverview shw
   if (prev_frontview != scene.frontview) {
     s->scene.uilayout_sidebarcollapsed = scene.frontview;
     s->active_app = scene.frontview ? cereal::UiLayoutState::App::NONE : cereal::UiLayoutState::App::SETTINGS;
@@ -483,6 +484,7 @@ int main(int argc, char* argv[]) {
       s->vision.update(&do_exit);
       if (!prev_started) {
         s->controls_timeout = 5 * UI_FREQ;
+        s->scene.uilayout_sidebarcollapsed = true;
       }
 
     } else {
@@ -579,6 +581,7 @@ int main(int argc, char* argv[]) {
   // join light_sensor_thread?
 #endif
 
+  ui_nvg_delete(s);
   delete s->sm;
   delete s->pm;
   return 0;

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -170,8 +170,6 @@ typedef struct UIState {
 } UIState;
 
 // API
-void ui_draw_vision_alert(UIState *s, cereal::ControlsState::AlertSize va_size, int va_color,
-                          const char* va_text1, const char* va_text2);
 void ui_draw(UIState *s);
 void ui_draw_sidebar(UIState *s);
 void ui_nvg_init(UIState *s);

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -132,7 +132,6 @@ typedef struct UIState {
   cereal::UiLayoutState::App active_app;
   UIVision vision;
   UIScene scene;
-
   bool awake;
 
   // timeouts

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -173,3 +173,4 @@ typedef struct UIState {
 void ui_draw(UIState *s);
 void ui_draw_sidebar(UIState *s);
 void ui_nvg_init(UIState *s);
+void ui_nvg_delete(UIState *s);

--- a/selfdrive/ui/uicommon.cc
+++ b/selfdrive/ui/uicommon.cc
@@ -170,9 +170,8 @@ void UIVision::initVision() {
   assert(glGetError() == GL_NO_ERROR);
 }
 
-void UIVision::update() {
-  bool do_exits = false;
-  while (!do_exits) {
+void UIVision::update(volatile sig_atomic_t *do_exit) {
+  while (!(*do_exit)) {
     if (!vision_connected) {
       int err = visionstream_init(&stream, front_view ? VISION_STREAM_RGB_FRONT : VISION_STREAM_RGB_BACK, true, nullptr);
       if (err) {
@@ -190,7 +189,7 @@ void UIVision::update() {
       vision_connected = false;
       continue;
     }
-    
+
     break;
   }
 }

--- a/selfdrive/ui/uicommon.cc
+++ b/selfdrive/ui/uicommon.cc
@@ -1,0 +1,384 @@
+#include <assert.h>
+#include <czmq.h>
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include "common/swaglog.h"
+#include "common/timing.h"
+#include "common/util.h"
+#include "uicommon.hpp"
+
+#ifndef QCOM
+  #define UI_60FPS
+#endif
+
+#ifdef NANOVG_GL3_IMPLEMENTATION
+static const char frame_vertex_shader[] =
+  "#version 150 core\n"
+  "in vec4 aPosition;\n"
+  "in vec4 aTexCoord;\n"
+  "uniform mat4 uTransform;\n"
+  "out vec4 vTexCoord;\n"
+  "void main() {\n"
+  "  gl_Position = uTransform * aPosition;\n"
+  "  vTexCoord = aTexCoord;\n"
+  "}\n";
+
+static const char frame_fragment_shader[] =
+  "#version 150 core\n"
+  "precision mediump float;\n"
+  "uniform sampler2D uTexture;\n"
+  "in vec4 vTexCoord;\n"
+  "out vec4 colorOut;\n"
+  "void main() {\n"
+  "  colorOut = texture(uTexture, vTexCoord.xy);\n"
+  "}\n";
+#else
+static const char frame_vertex_shader[] =
+  "attribute vec4 aPosition;\n"
+  "attribute vec4 aTexCoord;\n"
+  "uniform mat4 uTransform;\n"
+  "varying vec4 vTexCoord;\n"
+  "void main() {\n"
+  "  gl_Position = uTransform * aPosition;\n"
+  "  vTexCoord = aTexCoord;\n"
+  "}\n";
+
+static const char frame_fragment_shader[] =
+  "precision mediump float;\n"
+  "uniform sampler2D uTexture;\n"
+  "varying vec4 vTexCoord;\n"
+  "void main() {\n"
+  "  gl_FragColor = texture2D(uTexture, vTexCoord.xy);\n"
+  "}\n";
+#endif
+
+static const mat4 device_transform = {{
+  1.0,  0.0, 0.0, 0.0,
+  0.0,  1.0, 0.0, 0.0,
+  0.0,  0.0, 1.0, 0.0,
+  0.0,  0.0, 0.0, 1.0,
+}};
+
+// frame from 4/3 to box size with a 2x zoom
+static const mat4 frame_transform = {{
+  2*(4./3.)/((float)viz_w/box_h), 0.0, 0.0, 0.0,
+  0.0, 2.0, 0.0, 0.0,
+  0.0, 0.0, 1.0, 0.0,
+  0.0, 0.0, 0.0, 1.0,
+}};
+
+// frame from 4/3 to 16/9 display
+static const mat4 full_to_wide_frame_transform = {{
+  .75,  0.0, 0.0, 0.0,
+  0.0,  1.0, 0.0, 0.0,
+  0.0,  0.0, 1.0, 0.0,
+  0.0,  0.0, 0.0, 1.0,
+}};
+
+void UIVision::init(bool front) {
+  front_view = front;
+  ipc_fd = -1;
+  fb = framebuffer_init("ui", 0, true, &fb_w, &fb_h);
+  assert(fb);
+
+  // init gl
+  frame_program = load_program(frame_vertex_shader, frame_fragment_shader);
+  assert(frame_program);
+
+  frame_pos_loc = glGetAttribLocation(frame_program, "aPosition");
+  frame_texcoord_loc = glGetAttribLocation(frame_program, "aTexCoord");
+
+  frame_texture_loc = glGetUniformLocation(frame_program, "uTexture");
+  frame_transform_loc = glGetUniformLocation(frame_program, "uTransform");
+
+  glViewport(0, 0, fb_w, fb_h);
+
+  glDisable(GL_DEPTH_TEST);
+
+  assert(glGetError() == GL_NO_ERROR);
+
+  float x1, x2, y1, y2;
+  if (front) {
+    // flip horizontally so it looks like a mirror
+    x1 = 0.0;
+    x2 = 1.0;
+    y1 = 1.0;
+    y2 = 0.0;
+  } else {
+    x1 = 1.0;
+    x2 = 0.0;
+    y1 = 1.0;
+    y2 = 0.0;
+  }
+  const uint8_t frame_indicies[] = {0, 1, 2, 0, 2, 3};
+  const float frame_coords[4][4] = {
+      {-1.0, -1.0, x2, y1},  //bl
+      {-1.0, 1.0, x2, y2},   //tl
+      {1.0, 1.0, x1, y2},    //tr
+      {1.0, -1.0, x1, y1},   //br
+  };
+
+  glGenVertexArrays(1, &frame_vao);
+  glBindVertexArray(frame_vao);
+  glGenBuffers(1, &frame_vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, frame_vbo);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(frame_coords), frame_coords, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(frame_pos_loc);
+  glVertexAttribPointer(frame_pos_loc, 2, GL_FLOAT, GL_FALSE,
+                        sizeof(frame_coords[0]), (const void *)0);
+  glEnableVertexAttribArray(frame_texcoord_loc);
+  glVertexAttribPointer(frame_texcoord_loc, 2, GL_FLOAT, GL_FALSE,
+                        sizeof(frame_coords[0]), (const void *)(sizeof(float) * 2));
+  glGenBuffers(1, &frame_ibo);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, frame_ibo);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(frame_indicies), frame_indicies, GL_STATIC_DRAW);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindVertexArray(0);
+
+  frame_mat = matmul(device_transform, front_view ? full_to_wide_frame_transform : frame_transform);
+}
+
+static int vision_subscribe(int fd, VisionPacket *rp, VisionStreamType type) {
+  int err;
+  LOGW("vision_subscribe type:%d", type);
+
+  VisionPacket p1 = {
+    .type = VIPC_STREAM_SUBSCRIBE,
+    .d = { .stream_sub = { .type = type, .tbuffer = true, }, },
+  };
+  err = vipc_send(fd, &p1);
+  if (err < 0) {
+    close(fd);
+    return 0;
+  }
+
+  do {
+    err = vipc_recv(fd, rp);
+    if (err <= 0) {
+      close(fd);
+      return 0;
+    }
+
+    // release what we aren't ready for yet
+    if (rp->type == VIPC_STREAM_ACQUIRE) {
+      VisionPacket rep = {
+        .type = VIPC_STREAM_RELEASE,
+        .d = { .stream_rel = {
+          .type = rp->d.stream_acq.type,
+          .idx = rp->d.stream_acq.idx,
+        }},
+      };
+      vipc_send(fd, &rep);
+    }
+  } while (rp->type != VIPC_STREAM_BUFS || rp->d.stream_bufs.type != type);
+
+  return 1;
+}
+
+
+void UIVision::vision_connect() {
+  bool do_exit = false;
+  while (!do_exit) {
+    int fd = vipc_connect();
+    if (fd < 0) {
+      usleep(100000);
+      continue;
+    }
+
+    VisionPacket vp;
+    if (!vision_subscribe(fd, &vp, front_view ? VISION_STREAM_RGB_FRONT : VISION_STREAM_RGB_BACK)) continue;
+    ipc_fd = fd;
+    ui_init_vision(vp);
+
+    vision_connected = true;
+    break;
+  }
+}
+
+void UIVision::swap(){
+  framebuffer_swap(fb);
+}    
+
+void UIVision::ui_init_vision(const VisionPacket& vp) {
+  assert(vp.num_fds == UI_BUF_COUNT);
+  const VisionStreamBufs& vs_bufs = vp.d.stream_bufs;
+  vipc_bufs_load(bufs, &vs_bufs, vp.num_fds, vp.fds);
+
+  cur_vision_idx = -1;
+
+  rgb_width = vs_bufs.width;
+  rgb_height = vs_bufs.height;
+  rgb_stride = vs_bufs.stride;
+  rgb_buf_len = vs_bufs.buf_len;
+
+  for (int i = 0; i < UI_BUF_COUNT; i++) {
+    if (khr[i] != 0) {
+      visionimg_destroy_gl(khr[i], priv_hnds[i]);
+      glDeleteTextures(1, &frame_texs[i]);
+    }
+
+    VisionImg img = {
+        .fd = bufs[i].fd,
+        .format = VISIONIMG_FORMAT_RGB24,
+        .width = rgb_width,
+        .height = rgb_height,
+        .stride = rgb_stride,
+        .bpp = 3,
+        .size = rgb_buf_len,
+    };
+#ifndef QCOM
+    priv_hnds[i] = bufs[i].addr;
+#endif
+    frame_texs[i] = visionimg_to_gl(&img, &khr[i], &priv_hnds[i]);
+
+    glBindTexture(GL_TEXTURE_2D, frame_texs[i]);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+    // BGR
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_GREEN);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
+  }
+  assert(glGetError() == GL_NO_ERROR);
+}
+
+
+bool UIVision::ui_update() {
+  if (!vision_connected) {
+      vision_connect();
+  }
+  zmq_pollitem_t polls[1] = {{0}};
+  // Take an rgb image from visiond if there is one
+  while (true) {
+    if (ipc_fd < 0) {
+      // TODO: rethink this, for now it should only trigger on PC
+      LOGW("vision disconnected by other thread");
+      vision_connected = false;
+      return false;
+    }
+    polls[0].fd = ipc_fd;
+    polls[0].events = ZMQ_POLLIN;
+#ifdef UI_60FPS
+    // uses more CPU in both UI and surfaceflinger
+    // 16% / 21%
+    int ret = zmq_poll(polls, 1, 1);
+#else
+    // 9% / 13% = a 14% savings
+    int ret = zmq_poll(polls, 1, 1000);
+#endif
+    if (ret < 0) {
+      if (errno == EINTR || errno == EAGAIN) continue;
+
+      LOGE("poll failed (%d - %d)", ret, errno);
+      close(ipc_fd);
+      ipc_fd = -1;
+      vision_connected = false;
+      return false;
+    } else if (ret == 0) {
+      break;
+    }
+    // vision ipc event
+    VisionPacket rp;
+    int err = vipc_recv(ipc_fd, &rp);
+    if (err <= 0) {
+      LOGW("vision disconnected");
+      close(ipc_fd);
+      ipc_fd = -1;
+      vision_connected = false;
+      return false;
+    }
+    if (rp.type == VIPC_STREAM_ACQUIRE) {
+      int idx = rp.d.stream_acq.idx;
+
+      int release_idx = cur_vision_idx;
+      if (release_idx >= 0) {
+        VisionPacket rep = {
+            .type = VIPC_STREAM_RELEASE,
+            .d = {.stream_rel = {
+                      .type = rp.d.stream_acq.type,
+                      .idx = release_idx,
+                  }},
+        };
+        vipc_send(ipc_fd, &rep);
+      }
+
+      assert(idx < UI_BUF_COUNT);
+      cur_vision_idx = idx;
+    } else {
+      assert(false);
+    }
+    break;
+  }
+  return true;
+}
+
+void UIVision::draw_frame() {
+  glBindVertexArray(frame_vao);
+  glActiveTexture(GL_TEXTURE0);
+  if (cur_vision_idx >= 0) {
+    glBindTexture(GL_TEXTURE_2D, frame_texs[cur_vision_idx]);
+    if (!front_view) {
+#ifndef QCOM
+      // TODO: a better way to do this?
+      //printf("%d\n", ((int*)s->priv_hnds[s->cur_vision_idx])[0]);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 1164, 874, 0, GL_RGB, GL_UNSIGNED_BYTE, priv_hnds[cur_vision_idx]);
+#endif
+    }
+  }
+
+  glUseProgram(frame_program);
+  glUniform1i(frame_texture_loc, 0);
+  glUniformMatrix4fv(frame_transform_loc, 1, GL_TRUE, frame_mat.v);
+
+  assert(glGetError() == GL_NO_ERROR);
+  glEnableVertexAttribArray(0);
+  glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, (const void*)0);
+  glDisableVertexAttribArray(0);
+  glBindVertexArray(0);
+}
+
+void ui_draw_image(NVGcontext *vg, float x, float y, float w, float h, int image, float alpha){
+  nvgBeginPath(vg);
+  NVGpaint imgPaint = nvgImagePattern(vg, x, y, w, h, 0, image, alpha);
+  nvgRect(vg, x, y, w, h);
+  nvgFillPaint(vg, imgPaint);
+  nvgFill(vg);
+}
+
+void ui_draw_rect(NVGcontext *vg, float x, float y, float w, float h, NVGcolor color, float r, int width) {
+  nvgBeginPath(vg);
+  r > 0? nvgRoundedRect(vg, x, y, w, h, r) : nvgRect(vg, x, y, w, h);
+  if (width) {
+    nvgStrokeColor(vg, color);
+    nvgStrokeWidth(vg, width);
+    nvgStroke(vg);
+  } else {
+    nvgFillColor(vg, color);
+    nvgFill(vg);
+  }
+}
+
+void ui_draw_rect(NVGcontext *vg, float x, float y, float w, float h, NVGpaint &paint, float r){
+  nvgBeginPath(vg);
+  r > 0? nvgRoundedRect(vg, x, y, w, h, r) : nvgRect(vg, x, y, w, h);
+  nvgFillPaint(vg, paint);
+  nvgFill(vg);
+}
+
+void ui_draw_circle_image(NVGcontext *vg, float x, float y, int size, int image, NVGcolor color, float img_alpha, int img_y) {
+  const int img_size = size * 1.5;
+  nvgBeginPath(vg);
+  nvgCircle(vg, x, y + (bdr_s * 1.5), size);
+  nvgFillColor(vg, color);
+  nvgFill(vg);
+  ui_draw_image(vg, x - (img_size / 2), img_y ? img_y : y - (size / 4), img_size, img_size, image, img_alpha);
+}
+
+void ui_draw_circle_image(NVGcontext *vg, float x, float y, int size, int image, bool active) {
+  float bg_alpha = active ? 0.3f : 0.1f;
+  float img_alpha = active ? 1.0f : 0.15f;
+  ui_draw_circle_image(vg, x, y, size, image, nvgRGBA(0, 0, 0, (255 * bg_alpha)), img_alpha);
+}

--- a/selfdrive/ui/uicommon.cc
+++ b/selfdrive/ui/uicommon.cc
@@ -200,6 +200,8 @@ void UIVision::closeStream() {
     if (khr[i] != 0) {
       visionimg_destroy_gl(khr[i], priv_hnds[i]);
       glDeleteTextures(1, &frame_texs[i]);
+      khr[i] = 0;
+      frame_texs[i] = 0;
     }
   }
 }

--- a/selfdrive/ui/uicommon.cc
+++ b/selfdrive/ui/uicommon.cc
@@ -178,7 +178,7 @@ void UIVision::update(volatile sig_atomic_t *do_exit) {
         usleep(100000);
         continue;
       }
-      vision_connected = true;
+      vision_connected = true;      
     }
     VIPCBuf *buf = visionstream_get(&stream, nullptr);
     if (buf == NULL) {
@@ -195,13 +195,13 @@ void UIVision::update(volatile sig_atomic_t *do_exit) {
 void UIVision::closeStream() {
   if (vision_connected) {
     visionstream_destroy(&stream);
-  }
-  for (int i = 0; i < UI_BUF_COUNT; i++) {
-    if (khr[i] != 0) {
-      visionimg_destroy_gl(khr[i], priv_hnds[i]);
-      glDeleteTextures(1, &frame_texs[i]);
-      khr[i] = 0;
-      frame_texs[i] = 0;
+    for (int i = 0; i < UI_BUF_COUNT; i++) {
+      if (khr[i] != 0) {
+        visionimg_destroy_gl(khr[i], priv_hnds[i]);
+        glDeleteTextures(1, &frame_texs[i]);
+        khr[i] = 0;
+        frame_texs[i] = 0;
+      }
     }
   }
 }

--- a/selfdrive/ui/uicommon.cc
+++ b/selfdrive/ui/uicommon.cc
@@ -141,6 +141,7 @@ bool UIVision::openStream() {
   if (err) {
     return false;
   }
+  // init buffers
   assert(stream.num_bufs == UI_BUF_COUNT);
   for (int i = 0; i < UI_BUF_COUNT; i++) {
     VisionImg img = {

--- a/selfdrive/ui/uicommon.cc
+++ b/selfdrive/ui/uicommon.cc
@@ -137,7 +137,8 @@ void UIVision::swap() {
 }
 
 bool UIVision::openStream() {
-  int err = visionstream_init(&stream, front_view ? VISION_STREAM_RGB_FRONT : VISION_STREAM_RGB_BACK, true, nullptr);
+  VisionStreamType type = front_view ? VISION_STREAM_RGB_FRONT : VISION_STREAM_RGB_BACK;
+  int err = visionstream_init(&stream, type, true, nullptr);
   if (err) {
     return false;
   }

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -2,6 +2,7 @@
 #include "messaging.hpp"
 #include <assert.h>
 #include <cmath>
+#include <signal.h>
 #ifdef __APPLE__
 #include <OpenGL/gl3.h>
 #define NANOVG_GL3_IMPLEMENTATION
@@ -37,7 +38,7 @@ const int viz_w = vwp_w - (bdr_s * 2);
 class UIVision {
  public:
   void init(bool front = false);
-  void update();
+  void update(volatile sig_atomic_t *do_exit);
   void draw();
   void swap();
   inline int getRgbWidth() const { return stream.bufs_info.width; }

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cmath>
+#include <assert.h>
 #include "messaging.hpp"
 #ifdef __APPLE__
 #include <OpenGL/gl3.h>
@@ -35,8 +37,8 @@ const int viz_w = vwp_w-(bdr_s*2);
 class UIVision {
  public:
   void init(bool front=false);
-  bool ui_update();
-  void draw_frame();
+  bool update();
+  void draw();
   void swap();
   
   int rgb_width, rgb_height, rgb_stride;
@@ -46,8 +48,8 @@ class UIVision {
   int fb_w=0, fb_h=0;
 
 private:
-  void ui_init_vision(const VisionPacket& vp);
-  void vision_connect();
+  void initVision(const VisionPacket& vp);
+  void connect();
 
   VIPCBuf bufs[UI_BUF_COUNT]={};
   int cur_vision_idx = 0;

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <cmath>
-#include <assert.h>
 #include "messaging.hpp"
+#include <assert.h>
+#include <cmath>
 #ifdef __APPLE__
 #include <OpenGL/gl3.h>
 #define NANOVG_GL3_IMPLEMENTATION
@@ -14,57 +14,54 @@
 #define nvgCreate nvgCreateGLES3
 #define nvgDelete nvgDeleteGLES3
 #endif
-
-#include "nanovg.h"
 #include "common/framebuffer.h"
 #include "common/mat.h"
+#include "common/touch.h"
 #include "common/visionimg.h"
 #include "common/visionipc.h"
-#include "common/touch.h"
+#include "nanovg.h"
 
 #define UI_BUF_COUNT 4
 const int vwp_w = 1920;
 const int vwp_h = 1080;
 const int nav_w = 640;
-const int nav_ww= 760;
+const int nav_ww = 760;
 const int sbr_w = 300;
 const int bdr_s = 30;
-const int box_x = sbr_w+bdr_s;
+const int box_x = sbr_w + bdr_s;
 const int box_y = bdr_s;
-const int box_w = vwp_w-sbr_w-(bdr_s*2);
-const int box_h = vwp_h-(bdr_s*2);
-const int viz_w = vwp_w-(bdr_s*2);
+const int box_w = vwp_w - sbr_w - (bdr_s * 2);
+const int box_h = vwp_h - (bdr_s * 2);
+const int viz_w = vwp_w - (bdr_s * 2);
+
 class UIVision {
  public:
-  void init(bool front=false);
+  void init(bool front = false);
   void update();
   void draw();
   void swap();
-  
-  int rgb_width, rgb_height, rgb_stride;
-  int ipc_fd = -1;
- 
-  FramebufferState *fb = nullptr;
-  int fb_w=0, fb_h=0;
+  inline int getRgbWidth() const { return stream.bufs_info.width; }
+  inline int getRgbHeight() const { return stream.bufs_info.height; }
 
-private:
-  void initVision(const VisionStreamBufs& buf_info);
+  FramebufferState *fb = nullptr;
+  int fb_w = 0, fb_h = 0;
+
+ private:
+  void initVision();
 
   VisionStream stream;
 
   GLuint frame_program;
-  GLuint frame_texs[UI_BUF_COUNT]={};
-  EGLImageKHR khr[UI_BUF_COUNT]={};
-  void *priv_hnds[UI_BUF_COUNT]={};
+  GLuint frame_texs[UI_BUF_COUNT] = {};
+  EGLImageKHR khr[UI_BUF_COUNT] = {};
+  void *priv_hnds[UI_BUF_COUNT] = {};
   GLint frame_pos_loc, frame_texcoord_loc;
   GLint frame_texture_loc, frame_transform_loc;
   GLuint frame_vao, frame_vbo, frame_ibo;
   mat4 frame_mat;
 
   bool vision_connected = false;
-  
   bool front_view = false;
-  size_t rgb_buf_len = 0;
 };
 
 void ui_draw_image(NVGcontext *vg, float x, float y, float w, float h, int image, float alpha);

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -1,0 +1,74 @@
+#pragma once
+#include "messaging.hpp"
+#ifdef __APPLE__
+#include <OpenGL/gl3.h>
+#define NANOVG_GL3_IMPLEMENTATION
+#define nvgCreate nvgCreateGL3
+#define nvgDelete nvgDeleteGL3
+#else
+#include <EGL/egl.h>
+#include <GLES3/gl3.h>
+#define NANOVG_GLES3_IMPLEMENTATION
+#define nvgCreate nvgCreateGLES3
+#define nvgDelete nvgDeleteGLES3
+#endif
+
+#include "nanovg.h"
+#include "common/framebuffer.h"
+#include "common/mat.h"
+#include "common/visionimg.h"
+#include "common/visionipc.h"
+#include "common/touch.h"
+
+#define UI_BUF_COUNT 4
+const int vwp_w = 1920;
+const int vwp_h = 1080;
+const int nav_w = 640;
+const int nav_ww= 760;
+const int sbr_w = 300;
+const int bdr_s = 30;
+const int box_x = sbr_w+bdr_s;
+const int box_y = bdr_s;
+const int box_w = vwp_w-sbr_w-(bdr_s*2);
+const int box_h = vwp_h-(bdr_s*2);
+const int viz_w = vwp_w-(bdr_s*2);
+class UIVision {
+ public:
+  void init(bool front=false);
+  bool ui_update();
+  void draw_frame();
+  void swap();
+  
+  int rgb_width, rgb_height, rgb_stride;
+  int ipc_fd = -1;
+ 
+  FramebufferState *fb = nullptr;
+  int fb_w=0, fb_h=0;
+
+private:
+  void ui_init_vision(const VisionPacket& vp);
+  void vision_connect();
+
+  VIPCBuf bufs[UI_BUF_COUNT]={};
+  int cur_vision_idx = 0;
+
+  GLuint frame_program;
+  GLuint frame_texs[UI_BUF_COUNT]={};
+  EGLImageKHR khr[UI_BUF_COUNT]={};
+  void *priv_hnds[UI_BUF_COUNT]={};
+  GLint frame_pos_loc, frame_texcoord_loc;
+  GLint frame_texture_loc, frame_transform_loc;
+  GLuint frame_vao, frame_vbo, frame_ibo;
+  mat4 frame_mat;
+
+  bool vision_connected = false;
+  
+  bool front_view=false;
+  size_t rgb_buf_len;
+};
+
+void ui_draw_image(NVGcontext *vg, float x, float y, float w, float h, int image, float alpha);
+void ui_draw_rect(NVGcontext *vg, float x, float y, float w, float h, NVGcolor color, float r = 0, int width = 0);
+void ui_draw_rect(NVGcontext *vg, float x, float y, float w, float h, NVGpaint &paint, float r = 0);
+void ui_draw_circle_image(NVGcontext *vg, float x, float y, int size, int image, bool active);
+void ui_draw_circle_image(NVGcontext *vg, float x, float y, int size, int image, NVGcolor color, float img_alpha, int img_y = 0);

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -37,7 +37,7 @@ const int viz_w = vwp_w-(bdr_s*2);
 class UIVision {
  public:
   void init(bool front=false);
-  bool update();
+  void update();
   void draw();
   void swap();
   
@@ -48,11 +48,9 @@ class UIVision {
   int fb_w=0, fb_h=0;
 
 private:
-  void initVision(const VisionPacket& vp);
-  void connect();
+  void initVision(const VisionStreamBufs& buf_info);
 
-  VIPCBuf bufs[UI_BUF_COUNT]={};
-  int cur_vision_idx = 0;
+  VisionStream stream;
 
   GLuint frame_program;
   GLuint frame_texs[UI_BUF_COUNT]={};
@@ -65,8 +63,8 @@ private:
 
   bool vision_connected = false;
   
-  bool front_view=false;
-  size_t rgb_buf_len;
+  bool front_view = false;
+  size_t rgb_buf_len = 0;
 };
 
 void ui_draw_image(NVGcontext *vg, float x, float y, float w, float h, int image, float alpha);

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -52,8 +52,8 @@ class UIVision {
   int fb_w = 0, fb_h = 0;
 
  private:
-  void initVision();
-  void freeBuffers();
+  bool openStream();
+  void closeStream();
 
   VisionStream stream;
 

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <assert.h>
 #include <signal.h>
-
 #include <cmath>
 
 #include "messaging.hpp"
@@ -39,6 +38,9 @@ const int viz_w = vwp_w - (bdr_s * 2);
 
 class UIVision {
  public:
+  FramebufferState *fb = nullptr;
+  int fb_w = 0, fb_h = 0;
+
   UIVision() = default;
   ~UIVision();
   void init(bool front = false);
@@ -48,14 +50,13 @@ class UIVision {
   inline int getRgbWidth() const { return stream.bufs_info.width; }
   inline int getRgbHeight() const { return stream.bufs_info.height; }
 
-  FramebufferState *fb = nullptr;
-  int fb_w = 0, fb_h = 0;
-
  private:
   bool openStream();
   void closeStream();
 
   VisionStream stream;
+  bool vision_connected = false;
+  bool front_view = false;
 
   GLuint frame_program;
   GLuint frame_texs[UI_BUF_COUNT] = {};
@@ -65,9 +66,6 @@ class UIVision {
   GLint frame_texture_loc, frame_transform_loc;
   GLuint frame_vao, frame_vbo, frame_ibo;
   mat4 frame_mat;
-
-  bool vision_connected = false;
-  bool front_view = false;
 };
 
 void ui_draw_image(NVGcontext *vg, float x, float y, float w, float h, int image, float alpha);

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -54,7 +54,7 @@ class UIVision {
   bool openStream();
   void closeStream();
 
-  VisionStream stream;
+  VisionStream stream = {};
   bool vision_connected = false;
   bool front_view = false;
 

--- a/selfdrive/ui/uicommon.hpp
+++ b/selfdrive/ui/uicommon.hpp
@@ -1,8 +1,10 @@
 #pragma once
-#include "messaging.hpp"
 #include <assert.h>
-#include <cmath>
 #include <signal.h>
+
+#include <cmath>
+
+#include "messaging.hpp"
 #ifdef __APPLE__
 #include <OpenGL/gl3.h>
 #define NANOVG_GL3_IMPLEMENTATION
@@ -37,6 +39,8 @@ const int viz_w = vwp_w - (bdr_s * 2);
 
 class UIVision {
  public:
+  UIVision() = default;
+  ~UIVision();
   void init(bool front = false);
   void update(volatile sig_atomic_t *do_exit);
   void draw();
@@ -49,6 +53,7 @@ class UIVision {
 
  private:
   void initVision();
+  void freeBuffers();
 
   VisionStream stream;
 


### PR DESCRIPTION
run driverview in a separate process.

- move common functions to uicommon
- using VisionStream instead of raw vipc functions
- handle offroadLayout message in  ui to make sure driverview is shown correctly

CPU usage:

|  |  ui   | driverview  |
| ---- |  ----  | ----  |
| driver preview  | 0.3%  | 2.3% |
| on road  | 6.5%  | - |
| off road  | 10.5%  | - |
| sleep  | 0.3%  | - |
