### PR TITLE
Improve update reliability and responsiveness

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -14,11 +14,16 @@ if [ -z "$PASSIVE" ]; then
   export PASSIVE="1"
 fi
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
 STAGING_ROOT="/data/safe_staging"
 
 function launch {
   # Wifi scan
   wpa_cli IFNAME=wlan0 SCAN
+
+  # Remove orphaned git lock if it exists on boot
+  [ -f "$DIR/.git/index.lock" ] && rm -f $DIR/.git/index.lock
 
   # Check to see if there's a valid overlay-based update available. Conditions
   # are as follows:
@@ -75,7 +80,6 @@ function launch {
   [ -d "/proc/irq/733" ] && echo 3 > /proc/irq/733/smp_affinity_list # USB for LeEco
   [ -d "/proc/irq/736" ] && echo 3 > /proc/irq/736/smp_affinity_list # USB for OP3T
 
-  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
   # Remove old NEOS update file
   # TODO: move this code to the updater

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -263,7 +263,7 @@ def main():
 
     # Check for internet every 30s
     time_wrong = datetime.datetime.utcnow().year < 2019
-    ping_failed = subprocess.call(["ping", "-W", "4", "-c", "1", "8.8.8.8"])
+    ping_failed = os.system("git ls-remote --tags --quiet") != 0
     if ping_failed or time_wrong:
       wait_helper.sleep(30)
       continue


### PR DESCRIPTION
Bug fixes
* fixes orphaned git locks blocking git operations in updated
  * currently unrecoverable unless the user manually removes the lock

Responsiveness improvements
* use `git ls-remote` instead of ping
  * seeing lots of network issues in the logs, so this being a stricter check should make some of the 10 minute waits into 30 sec waits
* trigger an update after going offroad