### PR TITLE
camerad: close ops_sock in camera_close

### DIFF
--- a/selfdrive/camerad/cameras/camera_qcom.h
+++ b/selfdrive/camerad/cameras/camera_qcom.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <pthread.h>
+#include <czmq.h>
 #include "messaging.hpp"
 
 #include "msmb_isp.h"
@@ -61,7 +62,8 @@ typedef struct CameraState {
 
   int device;
 
-  void* ops_sock;
+  void* ops_sock_handle;
+  zsock_t * ops_sock;
 
   uint32_t pixel_clock;
   uint32_t line_length_pclk;


### PR DESCRIPTION
this PR fix the  issue:

> E: 20-08-08 13:14:41 dangling 'PUSH' socket created at selfdrive/camerad/cameras/camera_qcom.cc:128
> E: 20-08-08 13:14:41 dangling 'PUSH' socket created at selfdrive/camerad/cameras/camera_qcom.cc:128
> E: 20-08-08 13:14:41 dangling sockets: cannot terminate ZMQ safely
> 
> 