### PR TITLE
Fix SIGSEGV bug 

### DIFF
--- a/selfdrive/modeld/dmonitoringmodeld.cc
+++ b/selfdrive/modeld/dmonitoringmodeld.cc
@@ -56,7 +56,6 @@ int main(int argc, char **argv) {
       buf = visionstream_get(&stream, &extra);
       if (buf == NULL) {
         printf("visionstream get failed\n");
-        visionstream_destroy(&stream);
         break;
       }
       //printf("frame_id: %d %dx%d\n", extra.frame_id, buf_info.width, buf_info.height);
@@ -84,10 +83,8 @@ int main(int argc, char **argv) {
       LOGD("dmonitoring process: %.2fms, from last %.2fms", t2-t1, t1-last);
       last = t1;
     }
-
+    visionstream_destroy(&stream);
   }
-
-  visionstream_destroy(&stream);
 
   dmonitoring_free(&dmonitoringmodel);
 

--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -190,7 +190,6 @@ int main(int argc, char **argv) {
       buf = visionstream_get(&stream, &extra);
       if (buf == NULL) {
         LOGW("visionstream get failed");
-        visionstream_destroy(&stream);
         break;
       }
 
@@ -239,9 +238,8 @@ int main(int argc, char **argv) {
 
     }
     visionbuf_free(&yuv_ion);
+    visionstream_destroy(&stream);
   }
-
-  visionstream_destroy(&stream);
 
   model_free(&model);
 


### PR DESCRIPTION
if do_exit is true while trying reconnecting , visionstream_destroy will be called incorrectly after exiting loop