### PR TITLE
Setup script improvements to MacOS / Ubuntu

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -16,6 +16,7 @@ brew install capnp \
              ffmpeg \
              glfw \
              libarchive \
+             libusb \
              libtool \
              llvm \
              pyenv \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash -e
 
-# install brew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+# Install brew if required.
+if [[ $(command -v brew) == "" ]]; then
+    echo "Installing Hombrew"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+else
+    echo "Updating Homebrew"
+    brew update
+fi
 
 brew install capnp \
              czmq \
@@ -15,12 +21,33 @@ brew install capnp \
              pyenv \
              zeromq
 
-# install python
+# Detect shell and pick correct RC file.
+if [[ $SHELL == "/bin/zsh" ]]; then
+  RC_FILE="$HOME/.zshrc"
+elif [[ $SHELL == "/bin/bash" ]]; then
+  RC_FILE="$HOME/.bash_profile"
+else
+  echo "-------------------------------------------------------------"
+  echo "Unsupported shell: \"$SHELL\", cannot install to RC file."
+  echo "Please run: echo \"source $OP_DIR/tools/openpilot_env.sh\" >> %YOUR SHELL's RC file%"
+  echo "-------------------------------------------------------------"
+fi
+
+# Install to RC file (only non-CI).
+if [ -z "$OPENPILOT_ENV" ] && [ -n "$RC_FILE" ] && [ -z "$CI" ]; then
+  OP_DIR=$(git rev-parse --show-toplevel)
+  echo "source $OP_DIR/tools/openpilot_env.sh" >> $RC_FILE
+  source $RC_FILE
+  echo "Added openpilot_env to RC file: $RC_FILE"
+else
+  echo "Skipped RC file installation"
+fi
+
+# Install python.
 pyenv install -s 3.8.2
 pyenv global 3.8.2
 pyenv rehash
-eval "$(pyenv init -)"
+eval "$(pyenv init -)" # CI doesn't use .bash_profile, and will use python2.7 if this line isn't here.
 
 pip install pipenv==2018.11.26
 pipenv install --system --deploy
-

--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -4,14 +4,13 @@ if [ -z "$OPENPILOT_ENV" ]; then
   unamestr=`uname`
   if [[ "$unamestr" == 'Linux' ]]; then
     export PATH="$HOME/.pyenv/bin:$PATH"
-    eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
   elif [[ "$unamestr" == 'Darwin' ]]; then
     # msgq doesn't work on mac
     export ZMQ=1
     export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
   fi
+  eval "$(pyenv init -)"
 
   export OPENPILOT_ENV=1
 fi
-

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -61,7 +61,8 @@ fi
 # install bashrc
 source ~/.bashrc
 if [ -z "$OPENPILOT_ENV" ]; then
-  echo "source $HOME/openpilot/tools/openpilot_env.sh" >> ~/.bashrc
+  OP_DIR=$(git rev-parse --show-toplevel)
+  echo "source $OP_DIR/tools/openpilot_env.sh" >> ~/.bashrc
   source ~/.bashrc
   echo "added openpilot_env to bashrc"
 fi


### PR DESCRIPTION
**Description**: Only install brew if required on MacOS + setup script improvements to MacOS / Ubuntu

**MacOS install script:**
MacOS setup script was installing Homebrew even if it was already installed. Now it'll only install if required, and will run `brew update` if an installation is found. This script will also auto detect zsh/bash shell and pick the appropriate RC file to install to.

**bashrc/zshrc changes:**
I've also modified the bashrc/zshrc install to detect the repository root directory. So it won't matter whether your working directory is `.` or `./tools` when you run the scripts.

**Verification**: I was able to simply run the script, then instantly run `scons` and openpilot built on MacOS 10.15.3.

Edit: 2020-08-12 - Just ran up a brand new install of MacOS 10.15.6 and installed. openpilot built after my recent `libusb` commit.