### PR TITLE
Remove unneeded definition

### DIFF
--- a/selfdrive/debug/mpc/live_lateral_mpc.py
+++ b/selfdrive/debug/mpc/live_lateral_mpc.py
@@ -35,8 +35,6 @@ def mpc_vwr_thread(addr="127.0.0.1"):
   path_x = np.arange(0, 100)
   mpc_path_x = np.arange(0, 49)
 
-  p_path_y = np.zeros(100)
-
   l_path_y = np.zeros(100)
   r_path_y = np.zeros(100)
   mpc_path_y = np.zeros(49)


### PR DESCRIPTION
p_path_y was assigned never used then reassigned to something else. So I removed the initial unneeded assignment.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_car_models](../../selfdrive/test/test_car_models.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
