### PR TITLE
Ford: Add FPv2 Support

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -104,6 +104,7 @@ def fingerprint(logcan, sendcan, has_relay):
       cloudlog.warning("Getting VIN & FW versions")
       _, vin = get_vin(logcan, sendcan, bus)
       car_fw = get_fw_versions(logcan, sendcan, bus)
+      car_fw += get_fw_versions(logcan, sendcan, 0)
 
     fw_candidates = match_fw_to_car(car_fw)
   else:

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -8,6 +8,7 @@ MAX_ANGLE = 87.  # make sure we never command the extremes (0xfff) which cause l
 
 class CAR:
   FUSION = "FORD FUSION 2018"
+  F150 = "FORD F150" 
 
 FINGERPRINTS = {
   CAR.FUSION: [{
@@ -18,7 +19,29 @@ FINGERPRINTS = {
 ECU_FINGERPRINT = {
   Ecu.fwdCamera: [970, 973, 984]
 }
-
+FW_VERSIONS = {
+  CAR.F150: {
+    (Ecu.fwdCamera, 0x706, None): [
+      b'FL3T-14G019-DE\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+    ],
+    (Ecu.eps, 0x730, None): [
+      b'GL34-14D003-AD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    ],
+    (Ecu.esp, 0x760, None): [
+      b'FL34-2D053-BA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    ],
+    (Ecu.fwdRadar, 0x764, None): [
+      b'FL3T-14D049-AF\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    ],
+    (Ecu.engine, 0x7e0, None): [
+      b'FL3A-14C204-ABL\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    ],
+    (Ecu.srs, 0x737, None): [
+      b'GR3T-14C028-AA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    ],
+  }
+}
 DBC = {
   CAR.FUSION: dbc_dict('ford_fusion_2018_pt', 'ford_fusion_2018_adas'),
+  CAR.F150: dbc_dict('ford_fusion_2018_pt', None),
 }

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -59,6 +59,11 @@ TOYOTA_VERSION_RESPONSE = b'\x5a\x88\x01'
 OBD_VERSION_REQUEST = b'\x09\x04'
 OBD_VERSION_RESPONSE = b'\x49\x04'
 
+FORD_VERSION_REQUEST = b'\x22\xf1\x88'
+FORD_VERSION_RESPONSE = b'\x62\xf1\x88'
+
+FORD_VERSION_REQUEST_A = b'\x22\xf1\x89'
+FORD_VERSION_RESPONSE_A = b'\x62\xf1\x89'
 
 # supports subaddressing, request, response
 REQUESTS = [
@@ -99,6 +104,17 @@ REQUESTS = [
     "toyota",
     [TESTER_PRESENT_REQUEST, DEFAULT_DIAGNOSTIC_REQUEST, EXTENDED_DIAGNOSTIC_REQUEST, UDS_VERSION_REQUEST],
     [TESTER_PRESENT_RESPONSE, DEFAULT_DIAGNOSTIC_RESPONSE, EXTENDED_DIAGNOSTIC_RESPONSE, UDS_VERSION_RESPONSE],
+  ),
+    # Ford
+  (
+    "ford",
+    [TESTER_PRESENT_REQUEST, FORD_VERSION_REQUEST],
+    [TESTER_PRESENT_RESPONSE, FORD_VERSION_RESPONSE],
+  ),
+  (
+    "ford",
+    [TESTER_PRESENT_REQUEST, FORD_VERSION_REQUEST_A],
+    [TESTER_PRESENT_RESPONSE, FORD_VERSION_RESPONSE_A],
   )
 ]
 
@@ -236,6 +252,7 @@ if __name__ == "__main__":
 
   t = time.time()
   fw_vers = get_fw_versions(logcan, sendcan, 1, extra=extra, debug=args.debug, progress=True)
+  fw_vers += get_fw_versions(logcan, sendcan, 0, extra=extra, debug=args.debug, progress=True)
   candidates = match_fw_to_car(fw_vers)
 
   print()

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -11,10 +11,12 @@ from selfdrive.car.fw_versions import match_fw_to_car
 from selfdrive.car.toyota.values import FW_VERSIONS as TOYOTA_FW_VERSIONS
 from selfdrive.car.honda.values import FW_VERSIONS as HONDA_FW_VERSIONS
 from selfdrive.car.hyundai.values import FW_VERSIONS as HYUNDAI_FW_VERSIONS
+from selfdrive.car.ford.values import FW_VERSIONS as FORD_FW_VERSIONS
 
 from selfdrive.car.toyota.values import FINGERPRINTS as TOYOTA_FINGERPRINTS
 from selfdrive.car.honda.values import FINGERPRINTS as HONDA_FINGERPRINTS
 from selfdrive.car.hyundai.values import FINGERPRINTS as HYUNDAI_FINGERPRINTS
+from selfdrive.car.ford.values import FINGERPRINTS as FORD_FINGERPRINTS
 
 
 if __name__ == "__main__":
@@ -64,7 +66,7 @@ if __name__ == "__main__":
           if args.car is not None:
             live_fingerprint = args.car
 
-          if live_fingerprint not in list(TOYOTA_FINGERPRINTS.keys()) + list(HONDA_FINGERPRINTS.keys()) + list(HYUNDAI_FINGERPRINTS.keys()):
+          if live_fingerprint not in list(TOYOTA_FINGERPRINTS.keys()) + list(HONDA_FINGERPRINTS.keys()) + list(HYUNDAI_FINGERPRINTS.keys()) + list(FORD_FINGERPRINTS.keys()):
             continue
 
           candidates = match_fw_to_car(car_fw)
@@ -83,7 +85,7 @@ if __name__ == "__main__":
 
           print("Mismatches")
           found = False
-          for car_fws in [TOYOTA_FW_VERSIONS, HONDA_FW_VERSIONS, HYUNDAI_FW_VERSIONS]:
+          for car_fws in [TOYOTA_FW_VERSIONS, HONDA_FW_VERSIONS, HYUNDAI_FW_VERSIONS, FORD_FW_VERSIONS]:
             if live_fingerprint in car_fws:
               found = True
               expected = car_fws[live_fingerprint]


### PR DESCRIPTION
Added support for FPv2 on Ford. 

Requests have to be sent on both bus 0 and bus 1. 
