### PR TITLE
Refactor Python code to follow PEP8 guidelines and increase consistency

### DIFF
--- a/common/api/__init__.py
+++ b/common/api/__init__.py
@@ -4,10 +4,11 @@ from datetime import datetime, timedelta
 from common.basedir import PERSIST
 from selfdrive.version import version
 
-class Api():
+
+class Api:
   def __init__(self, dongle_id):
     self.dongle_id = dongle_id
-    with open(PERSIST+'/comma/id_rsa') as f:
+    with open(PERSIST + '/comma/id_rsa') as f:
       self.private_key = f.read()
 
   def get(self, *args, **kwargs):
@@ -29,13 +30,14 @@ class Api():
     }
     return jwt.encode(payload, self.private_key, algorithm='RS256').decode('utf8')
 
+
 def api_get(endpoint, method='GET', timeout=None, access_token=None, **params):
   backend = "https://api.commadotai.com/"
 
   headers = {}
   if access_token is not None:
-    headers['Authorization'] = "JWT "+access_token
+    headers['Authorization'] = "JWT " + access_token
 
   headers['User-Agent'] = "openpilot-" + version
 
-  return requests.request(method, backend+endpoint, timeout=timeout, headers=headers, params=params)
+  return requests.request(method, backend + endpoint, timeout=timeout, headers=headers, params=params)

--- a/common/file_helpers.py
+++ b/common/file_helpers.py
@@ -39,7 +39,7 @@ def get_tmpdir_on_same_filesystem(path):
   return "/tmp"
 
 
-class AutoMoveTempdir():
+class AutoMoveTempdir:
   def __init__(self, target_path, temp_dir=None):
     self._target_path = target_path
     self._path = tempfile.mkdtemp(dir=temp_dir)
@@ -61,7 +61,7 @@ class AutoMoveTempdir():
       shutil.rmtree(self._path)
 
 
-class NamedTemporaryDir():
+class NamedTemporaryDir:
   def __init__(self, temp_dir=None):
     self._path = tempfile.mkdtemp(dir=temp_dir)
 
@@ -84,6 +84,7 @@ def _get_fileobject_func(writer, temp_dir):
     file_obj = writer.get_fileobject(dir=temp_dir)
     os.chmod(file_obj.name, 0o644)
     return file_obj
+
   return _get_fileobject
 
 

--- a/common/filter_simple.py
+++ b/common/filter_simple.py
@@ -1,4 +1,4 @@
-class FirstOrderFilter():
+class FirstOrderFilter:
   # first order filter
   def __init__(self, x0, ts, dt):
     self.k = (dt / ts) / (1. + dt / ts)

--- a/common/lazy_property.py
+++ b/common/lazy_property.py
@@ -1,8 +1,9 @@
-class lazy_property():
+class lazy_property:
   """Defines a property whose value will be computed only once and as needed.
 
      This can only be used on instance methods.
   """
+
   def __init__(self, func):
     self._func = func
 

--- a/common/params.py
+++ b/common/params.py
@@ -122,7 +122,7 @@ def fsync_dir(path):
     os.close(fd)
 
 
-class FileLock():
+class FileLock:
   def __init__(self, path, create):
     self._path = path
     self._create = create
@@ -138,7 +138,7 @@ class FileLock():
       self._fd = None
 
 
-class DBAccessor():
+class DBAccessor:
   def __init__(self, path):
     self._path = path
     self._vals = None
@@ -284,7 +284,7 @@ class DBWriter(DBAccessor):
       finally:
         # If the rename worked, we can delete the old data. Otherwise delete the new one.
         success = new_data_path is not None and os.path.exists(data_path) and (
-          os.readlink(data_path) == os.path.basename(tempdir_path))
+                os.readlink(data_path) == os.path.basename(tempdir_path))
 
         if success:
           if old_data_path is not None:
@@ -337,7 +337,7 @@ def write_db(params_path, key, value):
     lock.release()
 
 
-class Params():
+class Params:
   def __init__(self, db=PARAMS):
     self.db = db
 

--- a/common/profiler.py
+++ b/common/profiler.py
@@ -1,6 +1,7 @@
 import time
 
-class Profiler():
+
+class Profiler:
   def __init__(self, enabled=False):
     self.enabled = enabled
     self.cp = {}
@@ -39,7 +40,7 @@ class Profiler():
     print("******* Profiling *******")
     for n, ms in sorted(self.cp.items(), key=lambda x: -x[1]):
       if n in self.cp_ignored:
-        print("%30s: %9.2f   percent: %3.0f   IGNORED" % (n, ms*1000.0, ms/self.tot*100))
+        print("%30s: %9.2f   percent: %3.0f   IGNORED" % (n, ms * 1000.0, ms / self.tot * 100))
       else:
-        print("%30s: %9.2f   percent: %3.0f" % (n, ms*1000.0, ms/self.tot*100))
-    print("Iter clock: %2.6f   TOTAL: %2.2f" % (self.tot/self.iter, self.tot))
+        print("%30s: %9.2f   percent: %3.0f" % (n, ms * 1000.0, ms / self.tot * 100))
+    print("Iter clock: %2.6f   TOTAL: %2.2f" % (self.tot / self.iter, self.tot))

--- a/common/realtime.py
+++ b/common/realtime.py
@@ -9,17 +9,16 @@ from cffi import FFI
 from common.hardware import ANDROID
 from common.common_pyx import sec_since_boot  # pylint: disable=no-name-in-module, import-error
 
-
 # time step for each process
 DT_CTRL = 0.01  # controlsd
 DT_MDL = 0.05  # model
 DT_DMON = 0.1  # driver monitoring
 DT_TRML = 0.5  # thermald and manager
 
-
 ffi = FFI()
 ffi.cdef("long syscall(long number, ...);")
 libc = ffi.dlopen(None)
+
 
 def _get_tid():
   if platform.machine() == "x86_64":
@@ -39,6 +38,7 @@ def set_realtime_priority(level):
 
   return subprocess.call(['chrt', '-f', '-p', str(level), str(_get_tid())])
 
+
 def set_core_affinity(core):
   if os.getuid() != 0:
     print("not setting affinity, not root")
@@ -50,7 +50,7 @@ def set_core_affinity(core):
     return -1
 
 
-class Ratekeeper():
+class Ratekeeper:
   def __init__(self, rate, print_delay_threshold=0.):
     """Rate in Hz for ratekeeping. print_delay_threshold must be nonnegative."""
     self._interval = 1. / rate

--- a/common/spinner.py
+++ b/common/spinner.py
@@ -3,7 +3,7 @@ import subprocess
 from common.basedir import BASEDIR
 
 
-class Spinner():
+class Spinner:
   def __init__(self, noop=False):
     # spinner is currently only implemented for android
     self.spinner_proc = None
@@ -45,6 +45,7 @@ class Spinner():
 
 if __name__ == "__main__":
   import time
+
   with Spinner() as s:
     s.update("Spinner text")
     time.sleep(5.0)

--- a/common/stat_live.py
+++ b/common/stat_live.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-class RunningStat():
+
+class RunningStat:
   # tracks realtime mean and standard deviation without storing any data
   def __init__(self, priors=None, max_trackable=-1):
     self.max_trackable = max_trackable
@@ -51,7 +52,8 @@ class RunningStat():
   def params_to_save(self):
     return [self.M, self.S, self.n]
 
-class RunningStatFilter():
+
+class RunningStatFilter:
   def __init__(self, raw_priors=None, filtered_priors=None, max_trackable=-1):
     self.raw_stat = RunningStat(raw_priors, -1)
     self.filtered_stat = RunningStat(filtered_priors, max_trackable)
@@ -70,4 +72,4 @@ class RunningStatFilter():
       pass
       # self.filtered_stat.push_data(self.filtered_stat.mean())
 
-# class SequentialBayesian():
+# class SequentialBayesian:

--- a/common/text_window.py
+++ b/common/text_window.py
@@ -5,7 +5,7 @@ import subprocess
 from common.basedir import BASEDIR
 
 
-class TextWindow():
+class TextWindow:
   def __init__(self, s, noop=False):
     # text window is only implemented for android currently
     self.text_proc = None

--- a/common/window.py
+++ b/common/window.py
@@ -2,7 +2,8 @@ import sys
 import pygame  # pylint: disable=import-error
 import cv2  # pylint: disable=import-error
 
-class Window():
+
+class Window:
   def __init__(self, w, h, caption="window", double=False):
     self.w = w
     self.h = h
@@ -10,14 +11,14 @@ class Window():
     pygame.display.set_caption(caption)
     self.double = double
     if self.double:
-      self.screen = pygame.display.set_mode((w*2, h*2))
+      self.screen = pygame.display.set_mode((w * 2, h * 2))
     else:
       self.screen = pygame.display.set_mode((w, h))
 
   def draw(self, out):
     pygame.event.pump()
     if self.double:
-      out2 = cv2.resize(out, (self.w*2, self.h*2))
+      out2 = cv2.resize(out, (self.w * 2, self.h * 2))
       pygame.surfarray.blit_array(self.screen, out2.swapaxes(0, 1))
     else:
       pygame.surfarray.blit_array(self.screen, out.swapaxes(0, 1))
@@ -38,8 +39,10 @@ class Window():
         mx, my = pygame.mouse.get_pos()
         return mx, my
 
+
 if __name__ == "__main__":
   import numpy as np
+
   win = Window(200, 200, double=True)
   img = np.zeros((200, 200, 3), np.uint8)
   while 1:

--- a/launch_openpilot.sh
+++ b/launch_openpilot.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/bash
-
 export PASSIVE="0"
 exec ./launch_chffrplus.sh
-

--- a/selfdrive/athena/test_helpers.py
+++ b/selfdrive/athena/test_helpers.py
@@ -9,7 +9,7 @@ from functools import wraps
 from multiprocessing import Process
 
 
-class EchoSocket():
+class EchoSocket:
   def __init__(self, port):
     self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     self.socket.bind(('127.0.0.1', port))
@@ -34,7 +34,7 @@ class EchoSocket():
       self.socket.close()
 
 
-class MockApi():
+class MockApi:
   def __init__(self, dongle_id):
     pass
 
@@ -42,7 +42,7 @@ class MockApi():
     return "fake-token"
 
 
-class MockParams():
+class MockParams:
   def __init__(self):
     self.params = {
       "DongleId": b"0000000000000000",
@@ -56,7 +56,7 @@ class MockParams():
     return ret
 
 
-class MockWebsocket():
+class MockWebsocket:
   def __init__(self, recv_queue, send_queue):
     self.recv_queue = recv_queue
     self.send_queue = send_queue

--- a/selfdrive/camerad/snapshot/visionipc.py
+++ b/selfdrive/camerad/snapshot/visionipc.py
@@ -70,7 +70,7 @@ class VisionIPCError(Exception):
   pass
 
 
-class VisionIPC():
+class VisionIPC:
   def __init__(self, front=False):
     self.clib = ffi.dlopen(os.path.join(gf_dir, "libvisionipc.so"))
 
@@ -89,5 +89,5 @@ class VisionIPC():
   def get(self):
     buf = self.clib.visionstream_get(self.s, ffi.NULL)
     pbuf = ffi.buffer(buf.addr, buf.len)
-    ret = np.frombuffer(pbuf, dtype=np.uint8).reshape((-1, self.buf_info.stride//3, 3))
+    ret = np.frombuffer(pbuf, dtype=np.uint8).reshape((-1, self.buf_info.stride // 3, 3))
     return ret[:self.buf_info.height, :self.buf_info.width, [2, 1, 0]]

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -4,7 +4,8 @@ from selfdrive.car.chrysler.chryslercan import create_lkas_hud, create_lkas_comm
 from selfdrive.car.chrysler.values import CAR, SteerLimitParams
 from opendbc.can.packer import CANPacker
 
-class CarController():
+
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
     self.ccframe = 0
@@ -30,10 +31,10 @@ class CarController():
     self.steer_rate_limited = new_steer != apply_steer
 
     moving_fast = CS.out.vEgo > CS.CP.minSteerSpeed  # for status message
-    if CS.out.vEgo > (CS.CP.minSteerSpeed - 0.5):  # for command high bit
+    if CS.out.vEgo > CS.CP.minSteerSpeed - 0.5:  # for command high bit
       self.gone_fast_yet = True
     elif self.car_fingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.JEEP_CHEROKEE_2019):
-      if CS.out.vEgo < (CS.CP.minSteerSpeed - 3.0):
+      if CS.out.vEgo < CS.CP.minSteerSpeed - 3.0:
         self.gone_fast_yet = False  # < 14.5m/s stock turns off this bit, but fine down to 13.5
     lkas_active = moving_fast and enabled
 
@@ -44,7 +45,7 @@ class CarController():
 
     can_sends = []
 
-    #*** control msgs ***
+    # *** control msgs ***
 
     if pcm_cancel_cmd:
       # TODO: would be better to start from frame_2b3
@@ -53,11 +54,11 @@ class CarController():
 
     # LKAS_HEARTBIT is forwarded by Panda so no need to send it here.
     # frame is 100Hz (0.01s period)
-    if (self.ccframe % 25 == 0):  # 0.25s period
-      if (CS.lkas_car_model != -1):
+    if self.ccframe % 25 == 0:  # 0.25s period
+      if CS.lkas_car_model != -1:
         new_msg = create_lkas_hud(
-            self.packer, CS.out.gearShifter, lkas_active, hud_alert,
-            self.hud_count, CS.lkas_car_model)
+          self.packer, CS.out.gearShifter, lkas_active, hud_alert,
+          self.hud_count, CS.lkas_car_model)
         can_sends.append(new_msg)
         self.hud_count += 1
 

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -8,7 +8,7 @@ from selfdrive.car.interfaces import CarInterfaceBase
 class CarInterface(CarInterfaceBase):
   @staticmethod
   def compute_gb(accel, speed):
-    return accel / 3.0
+    return float(accel) / 3.0
 
   @staticmethod
   def get_params(candidate, fingerprint=None, has_relay=False, car_fw=None):

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -8,7 +8,7 @@ from selfdrive.car.interfaces import CarInterfaceBase
 class CarInterface(CarInterfaceBase):
   @staticmethod
   def compute_gb(accel, speed):
-    return float(accel) / 3.0
+    return accel / 3.0
 
   @staticmethod
   def get_params(candidate, fingerprint=None, has_relay=False, car_fw=None):
@@ -28,7 +28,7 @@ class CarInterface(CarInterfaceBase):
     ret.mass = 2858. + STD_CARGO_KG  # kg curb weight Pacifica Hybrid 2017
     ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP = [[9., 20.], [9., 20.]]
     ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.15, 0.30], [0.03, 0.05]]
-    ret.lateralTuning.pid.kf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
+    ret.lateralTuning.pid.kf = 0.00006  # full torque for 10 deg at 80mph means 0.00007818594
     ret.steerActuatorDelay = 0.1
     ret.steerRateCost = 0.7
     ret.steerLimitTimer = 0.4
@@ -87,8 +87,7 @@ class CarInterface(CarInterfaceBase):
   # pass in a car.CarControl
   # to be called @ 100hz
   def apply(self, c):
-
-    if (self.CS.frame == -1):
+    if self.CS.frame == -1:
       return []  # if we haven't seen a frame 220, then do not update.
 
     can_sends = self.CC.update(c.enabled, self.CS, c.actuators, c.cruiseControl.cancel, c.hudControl.visualAlert)

--- a/selfdrive/car/chrysler/radar_interface.py
+++ b/selfdrive/car/chrysler/radar_interface.py
@@ -4,10 +4,11 @@ from cereal import car
 from selfdrive.car.interfaces import RadarInterfaceBase
 from selfdrive.car.chrysler.values import DBC
 
-RADAR_MSGS_C = list(range(0x2c2, 0x2d4+2, 2))  # c_ messages 706,...,724
-RADAR_MSGS_D = list(range(0x2a2, 0x2b4+2, 2))  # d_ messages
+RADAR_MSGS_C = list(range(0x2c2, 0x2d4 + 2, 2))  # c_ messages 706,...,724
+RADAR_MSGS_D = list(range(0x2a2, 0x2b4 + 2, 2))  # d_ messages
 LAST_MSG = max(RADAR_MSGS_C + RADAR_MSGS_D)
 NUMBER_MSGS = len(RADAR_MSGS_C) + len(RADAR_MSGS_D)
+
 
 def _create_radar_can_parser(car_fingerprint):
   msg_n = len(RADAR_MSGS_C)
@@ -21,22 +22,23 @@ def _create_radar_can_parser(car_fingerprint):
   # The factor and offset are applied by the dbc parsing library, so the
   # default values should be after the factor/offset are applied.
   signals = list(zip(['LONG_DIST'] * msg_n +
-                ['LAT_DIST'] * msg_n +
-                ['REL_SPEED'] * msg_n,
-                RADAR_MSGS_C * 2 +  # LONG_DIST, LAT_DIST
-                RADAR_MSGS_D,    # REL_SPEED
-                [0] * msg_n +  # LONG_DIST
-                [-1000] * msg_n +    # LAT_DIST
-                [-146.278] * msg_n))  # REL_SPEED set to 0, factor/offset to this
+                     ['LAT_DIST'] * msg_n +
+                     ['REL_SPEED'] * msg_n,
+                     RADAR_MSGS_C * 2 +  # LONG_DIST, LAT_DIST
+                     RADAR_MSGS_D,  # REL_SPEED
+                     [0] * msg_n +  # LONG_DIST
+                     [-1000] * msg_n +  # LAT_DIST
+                     [-146.278] * msg_n))  # REL_SPEED set to 0, factor/offset to this
   # TODO what are the checks actually used for?
   # honda only checks the last message,
   # toyota checks all the messages. Which do we want?
   checks = list(zip(RADAR_MSGS_C +
-               RADAR_MSGS_D,
-               [20]*msg_n +  # 20Hz (0.05s)
-               [20]*msg_n))  # 20Hz (0.05s)
+                    RADAR_MSGS_D,
+                    [20] * msg_n +  # 20Hz (0.05s)
+                    [20] * msg_n))  # 20Hz (0.05s)
 
   return CANParser(DBC[car_fingerprint]['radar'], signals, checks, 1)
+
 
 def _address_to_track(address):
   if address in RADAR_MSGS_C:
@@ -44,6 +46,7 @@ def _address_to_track(address):
   if address in RADAR_MSGS_D:
     return (address - RADAR_MSGS_D[0]) // 2
   raise ValueError("radar received unexpected address %d" % address)
+
 
 class RadarInterface(RadarInterfaceBase):
   def __init__(self, CP):

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -8,7 +8,6 @@ from selfdrive.car.interfaces import CarInterfaceBase
 
 
 class CarInterface(CarInterfaceBase):
-
   @staticmethod
   def compute_gb(accel, speed):
     return float(accel) / 3.0
@@ -24,8 +23,8 @@ class CarInterface(CarInterfaceBase):
     ret.steerRatio = 14.8
     ret.mass = 3045. * CV.LB_TO_KG + STD_CARGO_KG
     ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
-    ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.01], [0.005]]     # TODO: tune this
-    ret.lateralTuning.pid.kf = 1. / MAX_ANGLE   # MAX Steer angle to normalize FF
+    ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.01], [0.005]]  # TODO: tune this
+    ret.lateralTuning.pid.kf = 1. / MAX_ANGLE  # MAX Steer angle to normalize FF
     ret.steerActuatorDelay = 0.1  # Default delay, not measured yet
     ret.steerLimitTimer = 0.8
     ret.steerRateCost = 1.0
@@ -71,7 +70,6 @@ class CarInterface(CarInterfaceBase):
   # pass in a car.CarControl
   # to be called @ 100hz
   def apply(self, c):
-
     can_sends = self.CC.update(c.enabled, self.CS, self.frame, c.actuators,
                                c.hudControl.visualAlert, c.cruiseControl.cancel)
 

--- a/selfdrive/car/ford/radar_interface.py
+++ b/selfdrive/car/ford/radar_interface.py
@@ -7,14 +7,16 @@ from selfdrive.car.interfaces import RadarInterfaceBase
 
 RADAR_MSGS = list(range(0x500, 0x540))
 
+
 def _create_radar_can_parser(car_fingerprint):
   msg_n = len(RADAR_MSGS)
   signals = list(zip(['X_Rel'] * msg_n + ['Angle'] * msg_n + ['V_Rel'] * msg_n,
                      RADAR_MSGS * 3,
                      [0] * msg_n + [0] * msg_n + [0] * msg_n))
-  checks = list(zip(RADAR_MSGS, [20]*msg_n))
+  checks = list(zip(RADAR_MSGS, [20] * msg_n))
 
   return CANParser(DBC[car_fingerprint]['radar'], signals, checks, 1)
+
 
 class RadarInterface(RadarInterfaceBase):
   def __init__(self, CP):
@@ -43,13 +45,13 @@ class RadarInterface(RadarInterfaceBase):
       cpt = self.rcp.vl[ii]
 
       if cpt['X_Rel'] > 0.00001:
-        self.validCnt[ii] = 0    # reset counter
+        self.validCnt[ii] = 0  # reset counter
 
       if cpt['X_Rel'] > 0.00001:
         self.validCnt[ii] += 1
       else:
         self.validCnt[ii] = max(self.validCnt[ii] - 1, 0)
-      #print ii, self.validCnt[ii], cpt['VALID'], cpt['X_Rel'], cpt['Angle']
+      # print ii, self.validCnt[ii], cpt['VALID'], cpt['X_Rel'], cpt['Angle']
 
       # radar point only valid if there have been enough valid measurements
       if self.validCnt[ii] > 0:

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -10,16 +10,16 @@ from opendbc.can.packer import CANPacker
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 
 
-class CarControllerParams():
+class CarControllerParams:
   def __init__(self):
     self.STEER_MAX = 300
-    self.STEER_STEP = 2              # how often we update the steer cmd
-    self.STEER_DELTA_UP = 7          # ~0.75s time to peak torque (255/50hz/0.75s)
-    self.STEER_DELTA_DOWN = 17       # ~0.3s from peak torque to zero
+    self.STEER_STEP = 2  # how often we update the steer cmd
+    self.STEER_DELTA_UP = 7  # ~0.75s time to peak torque (255/50hz/0.75s)
+    self.STEER_DELTA_DOWN = 17  # ~0.3s from peak torque to zero
     self.MIN_STEER_SPEED = 3.
-    self.STEER_DRIVER_ALLOWANCE = 50   # allowed driver torque before start limiting
-    self.STEER_DRIVER_MULTIPLIER = 4   # weight driver torque heavily
-    self.STEER_DRIVER_FACTOR = 100     # from dbc
+    self.STEER_DRIVER_ALLOWANCE = 50  # allowed driver torque before start limiting
+    self.STEER_DRIVER_MULTIPLIER = 4  # weight driver torque heavily
+    self.STEER_DRIVER_FACTOR = 100  # from dbc
     self.NEAR_STOP_BRAKE_PHASE = 0.5  # m/s, more aggressive braking near full stop
 
     # Takes case of "Service Adaptive Cruise" and "Service Front Camera"
@@ -28,9 +28,9 @@ class CarControllerParams():
     self.CAMERA_KEEPALIVE_STEP = 100
 
     # pedal lookups, only for Volt
-    MAX_GAS = 3072              # Only a safety limit
+    MAX_GAS = 3072  # Only a safety limit
     ZERO_GAS = 2048
-    MAX_BRAKE = 350             # Should be around 3.5m/s^2, including regen
+    MAX_BRAKE = 350  # Should be around 3.5m/s^2, including regen
     self.MAX_ACC_REGEN = 1404  # ACC Regen braking is slightly less powerful than max regen paddle
     self.GAS_LOOKUP_BP = [-0.25, 0., 0.5]
     self.GAS_LOOKUP_V = [self.MAX_ACC_REGEN, ZERO_GAS, MAX_GAS]
@@ -38,11 +38,11 @@ class CarControllerParams():
     self.BRAKE_LOOKUP_V = [MAX_BRAKE, 0]
 
 
-class CarController():
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.start_time = 0.
     self.apply_steer_last = 0
-    self.lka_icon_status_last = (False, False)
+    self.lka_icon_status_last = False, False
     self.steer_rate_limited = False
 
     self.params = CarControllerParams()
@@ -60,7 +60,7 @@ class CarController():
     can_sends = []
 
     # STEER
-    if (frame % P.STEER_STEP) == 0:
+    if frame % P.STEER_STEP == 0:
       lkas_enabled = enabled and not CS.out.steerWarning and CS.out.vEgo > P.MIN_STEER_SPEED
       if lkas_enabled:
         new_steer = actuators.steer * P.STEER_MAX
@@ -88,16 +88,16 @@ class CarController():
       apply_brake = int(round(interp(final_pedal, P.BRAKE_LOOKUP_BP, P.BRAKE_LOOKUP_V)))
 
     # Gas/regen and brakes - all at 25Hz
-    if (frame % 4) == 0:
+    if frame % 4 == 0:
       idx = (frame // 4) % 4
 
       at_full_stop = enabled and CS.out.standstill
-      near_stop = enabled and (CS.out.vEgo < P.NEAR_STOP_BRAKE_PHASE)
+      near_stop = enabled and CS.out.vEgo < P.NEAR_STOP_BRAKE_PHASE
       can_sends.append(gmcan.create_friction_brake_command(self.packer_ch, CanBus.CHASSIS, apply_brake, idx, near_stop, at_full_stop))
       can_sends.append(gmcan.create_gas_regen_command(self.packer_pt, CanBus.POWERTRAIN, apply_gas, idx, enabled, at_full_stop))
 
     # Send dashboard UI commands (ACC status), 25hz
-    if (frame % 4) == 0:
+    if frame % 4 == 0:
       send_fcw = hud_alert == VisualAlert.fcw
       can_sends.append(gmcan.create_acc_dashboard_command(self.packer_pt, CanBus.POWERTRAIN, enabled, hud_v_cruise * CV.MS_TO_KPH, hud_show_car, send_fcw))
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -9,6 +9,7 @@ from selfdrive.car.interfaces import CarInterfaceBase
 ButtonType = car.CarState.ButtonEvent.Type
 EventName = car.CarEvent.EventName
 
+
 class CarInterface(CarInterfaceBase):
 
   @staticmethod
@@ -37,7 +38,7 @@ class CarInterface(CarInterfaceBase):
     ret.minSteerSpeed = 7 * CV.MPH_TO_MS
     ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
     ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.00]]
-    ret.lateralTuning.pid.kf = 0.00004   # full torque for 20 deg at 80mph means 0.00007818594
+    ret.lateralTuning.pid.kf = 0.00004  # full torque for 20 deg at 80mph means 0.00007818594
     ret.steerRateCost = 1.0
     ret.steerActuatorDelay = 0.1  # Default delay, not measured yet
 

--- a/selfdrive/car/gm/radar_interface.py
+++ b/selfdrive/car/gm/radar_interface.py
@@ -15,6 +15,7 @@ NUM_SLOTS = 20
 # messages that are present in DBC
 LAST_RADAR_MSG = RADAR_HEADER_MSG + NUM_SLOTS
 
+
 def create_radar_can_parser(car_fingerprint):
   if car_fingerprint not in (CAR.VOLT, CAR.MALIBU, CAR.HOLDEN_ASTRA, CAR.ACADIA, CAR.CADILLAC_ATS):
     return None
@@ -22,21 +23,22 @@ def create_radar_can_parser(car_fingerprint):
   # C1A-ARS3-A by Continental
   radar_targets = list(range(SLOT_1_MSG, SLOT_1_MSG + NUM_SLOTS))
   signals = list(zip(['FLRRNumValidTargets',
-                 'FLRRSnsrBlckd', 'FLRRYawRtPlsblityFlt',
-                 'FLRRHWFltPrsntInt', 'FLRRAntTngFltPrsnt',
-                 'FLRRAlgnFltPrsnt', 'FLRRSnstvFltPrsntInt'] +
-                ['TrkRange'] * NUM_SLOTS + ['TrkRangeRate'] * NUM_SLOTS +
-                ['TrkRangeAccel'] * NUM_SLOTS + ['TrkAzimuth'] * NUM_SLOTS +
-                ['TrkWidth'] * NUM_SLOTS + ['TrkObjectID'] * NUM_SLOTS,
-                [RADAR_HEADER_MSG] * 7 + radar_targets * 6,
-                [0] * 7 +
-                [0.0] * NUM_SLOTS + [0.0] * NUM_SLOTS +
-                [0.0] * NUM_SLOTS + [0.0] * NUM_SLOTS +
-                [0.0] * NUM_SLOTS + [0] * NUM_SLOTS))
+                      'FLRRSnsrBlckd', 'FLRRYawRtPlsblityFlt',
+                      'FLRRHWFltPrsntInt', 'FLRRAntTngFltPrsnt',
+                      'FLRRAlgnFltPrsnt', 'FLRRSnstvFltPrsntInt'] +
+                     ['TrkRange'] * NUM_SLOTS + ['TrkRangeRate'] * NUM_SLOTS +
+                     ['TrkRangeAccel'] * NUM_SLOTS + ['TrkAzimuth'] * NUM_SLOTS +
+                     ['TrkWidth'] * NUM_SLOTS + ['TrkObjectID'] * NUM_SLOTS,
+                     [RADAR_HEADER_MSG] * 7 + radar_targets * 6,
+                     [0] * 7 +
+                     [0.0] * NUM_SLOTS + [0.0] * NUM_SLOTS +
+                     [0.0] * NUM_SLOTS + [0.0] * NUM_SLOTS +
+                     [0.0] * NUM_SLOTS + [0] * NUM_SLOTS))
 
   checks = []
 
   return CANParser(DBC[car_fingerprint]['radar'], signals, checks, CanBus.OBSTACLE)
+
 
 class RadarInterface(RadarInterfaceBase):
   def __init__(self, CP):
@@ -61,8 +63,8 @@ class RadarInterface(RadarInterfaceBase):
     ret = car.RadarData.new_message()
     header = self.rcp.vl[RADAR_HEADER_MSG]
     fault = header['FLRRSnsrBlckd'] or header['FLRRSnstvFltPrsntInt'] or \
-      header['FLRRYawRtPlsblityFlt'] or header['FLRRHWFltPrsntInt'] or \
-      header['FLRRAntTngFltPrsnt'] or header['FLRRAlgnFltPrsnt']
+            header['FLRRYawRtPlsblityFlt'] or header['FLRRHWFltPrsntInt'] or \
+            header['FLRRAntTngFltPrsnt'] or header['FLRRAlgnFltPrsnt']
     errors = []
     if not self.rcp.can_valid:
       errors.append("canError")

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -16,6 +16,7 @@ A_ACC_MAX = max(_A_CRUISE_MAX_V_FOLLOWING)
 ButtonType = car.CarState.ButtonEvent.Type
 EventName = car.CarEvent.EventName
 
+
 def compute_gb_honda(accel, speed):
   creep_brake = 0.0
   creep_speed = 2.3
@@ -83,14 +84,14 @@ class CarInterface(CarInterfaceBase):
       self.compute_gb = compute_gb_honda
 
   @staticmethod
-  def compute_gb(accel, speed): # pylint: disable=method-hidden
+  def compute_gb(accel, speed):  # pylint: disable=method-hidden
     raise NotImplementedError
 
   @staticmethod
   def calc_accel_override(a_ego, a_target, v_ego, v_target):
 
     # normalized max accel. Allowing max accel at low speed causes speed overshoots
-    max_accel_bp = [10, 20]    # m/s
+    max_accel_bp = [10, 20]  # m/s
     max_accel_v = [0.714, 1.0]  # unit of max accel
     max_accel = interp(v_ego, max_accel_bp, max_accel_v)
 
@@ -116,7 +117,7 @@ class CarInterface(CarInterfaceBase):
     # accelOverride is more or less the max throttle allowed to pcm: usually set to a constant
     # unless aTargetMax is very high and then we scale with it; this help in quicker restart
 
-    return float(max(max_accel, a_target / A_ACC_MAX)) * min(speedLimiter, accelLimiter)
+    return max(max_accel, a_target / A_ACC_MAX) * min(speedLimiter, accelLimiter)
 
   @staticmethod
   def get_params(candidate, fingerprint=gen_empty_fingerprint(), has_relay=False, car_fw=[]):  # pylint: disable=dangerous-default-value
@@ -410,7 +411,7 @@ class CarInterface(CarInterfaceBase):
     ret.gasMaxBP = [0.]  # m/s
     ret.gasMaxV = [0.6] if ret.enableGasInterceptor else [0.]  # max gas allowed
     ret.brakeMaxBP = [5., 20.]  # m/s
-    ret.brakeMaxV = [1., 0.8]   # max brake allowed
+    ret.brakeMaxV = [1., 0.8]  # max brake allowed
 
     ret.stoppingControl = True
     ret.startAccel = 0.5
@@ -489,7 +490,7 @@ class CarInterface(CarInterfaceBase):
     # it can happen that car cruise disables while comma system is enabled: need to
     # keep braking if needed or if the speed is very low
     if self.CP.enableCruise and not ret.cruiseState.enabled \
-       and (c.actuators.brake <= 0. or not self.CP.openpilotLongitudinalControl):
+            and (c.actuators.brake <= 0. or not self.CP.openpilotLongitudinalControl):
       # non loud alert if cruise disables below 25mph as expected (+ a little margin)
       if ret.vEgo < self.CP.minEnableSpeed + 2.:
         events.add(EventName.speedTooLow)
@@ -520,7 +521,7 @@ class CarInterface(CarInterfaceBase):
       if ((cur_time - self.last_enable_pressed) < 0.2 and
           (cur_time - self.last_enable_sent) > 0.2 and
           ret.cruiseState.enabled) or \
-         (enable_pressed and events.any(ET.NO_ENTRY)):
+              (enable_pressed and events.any(ET.NO_ENTRY)):
         events.add(EventName.buttonEnable)
         self.last_enable_sent = cur_time
     elif enable_pressed:

--- a/selfdrive/car/honda/radar_interface.py
+++ b/selfdrive/car/honda/radar_interface.py
@@ -4,13 +4,14 @@ from opendbc.can.parser import CANParser
 from selfdrive.car.interfaces import RadarInterfaceBase
 from selfdrive.car.honda.values import DBC
 
+
 def _create_nidec_can_parser(car_fingerprint):
   radar_messages = [0x400] + list(range(0x430, 0x43A)) + list(range(0x440, 0x446))
   signals = list(zip(['RADAR_STATE'] +
-                ['LONG_DIST'] * 16 + ['NEW_TRACK'] * 16 + ['LAT_DIST'] * 16 +
-                ['REL_SPEED'] * 16,
-                [0x400] + radar_messages[1:] * 4,
-                [0] + [255] * 16 + [1] * 16 + [0] * 16 + [0] * 16))
+                     ['LONG_DIST'] * 16 + ['NEW_TRACK'] * 16 + ['LAT_DIST'] * 16 +
+                     ['REL_SPEED'] * 16,
+                     [0x400] + radar_messages[1:] * 4,
+                     [0] + [255] * 16 + [1] * 16 + [0] * 16 + [0] * 16))
   checks = list(zip([0x445], [20]))
   return CANParser(DBC[car_fingerprint]['radar'], signals, checks, 1)
 
@@ -24,7 +25,7 @@ class RadarInterface(RadarInterfaceBase):
     self.radar_off_can = CP.radarOffCan
     self.radar_ts = CP.radarTimeStep
 
-    self.delay = int(round(0.1 / CP.radarTimeStep))   # 0.1s delay of radar
+    self.delay = int(round(0.1 / CP.radarTimeStep))  # 0.1s delay of radar
 
     # Nidec
     if self.radar_off_can:

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -10,7 +10,7 @@ VisualAlert = car.CarControl.HUDControl.VisualAlert
 
 def process_hud_alert(enabled, fingerprint, visual_alert, left_lane,
                       right_lane, left_lane_depart, right_lane_depart):
-  sys_warning = (visual_alert == VisualAlert.steerRequired)
+  sys_warning = visual_alert == VisualAlert.steerRequired
 
   # initialize to no line visible
   sys_state = 1
@@ -35,7 +35,7 @@ def process_hud_alert(enabled, fingerprint, visual_alert, left_lane,
   return sys_warning, sys_state, left_lane_warning, right_lane_warning
 
 
-class CarController():
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
     self.car_fingerprint = CP.carFingerprint
@@ -62,7 +62,7 @@ class CarController():
 
     self.apply_steer_last = apply_steer
 
-    sys_warning, sys_state, left_lane_warning, right_lane_warning =\
+    sys_warning, sys_state, left_lane_warning, right_lane_warning = \
       process_hud_alert(enabled, self.car_fingerprint, visual_alert,
                         left_lane, right_lane, left_lane_depart, right_lane_depart)
 
@@ -76,7 +76,7 @@ class CarController():
       can_sends.append(create_clu11(self.packer, frame, CS.clu11, Buttons.CANCEL))
     elif CS.out.cruiseState.standstill:
       # send resume at a max freq of 5Hz
-      if (frame - self.last_resume_frame)*DT_CTRL > 0.2:
+      if (frame - self.last_resume_frame) * DT_CTRL > 0.2:
         can_sends.append(create_clu11(self.packer, frame, CS.clu11, Buttons.RES_ACCEL))
         self.last_resume_frame = frame
 

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -5,8 +5,8 @@ from selfdrive.car.hyundai.values import Ecu, ECU_FINGERPRINT, CAR, FINGERPRINTS
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, is_ecu_disconnected, gen_empty_fingerprint
 from selfdrive.car.interfaces import CarInterfaceBase
 
-class CarInterface(CarInterfaceBase):
 
+class CarInterface(CarInterfaceBase):
   @staticmethod
   def compute_gb(accel, speed):
     return float(accel) / 3.0
@@ -40,7 +40,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 1513. + STD_CARGO_KG
       ret.wheelbase = 2.84
-      ret.steerRatio = 13.27 * 1.15   # 15% higher at the center seems reasonable
+      ret.steerRatio = 13.27 * 1.15  # 15% higher at the center seems reasonable
       tire_stiffness_factor = 0.65
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
@@ -48,7 +48,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 4497. * CV.LB_TO_KG
       ret.wheelbase = 2.804
-      ret.steerRatio = 13.27 * 1.15   # 15% higher at the center seems reasonable
+      ret.steerRatio = 13.27 * 1.15  # 15% higher at the center seems reasonable
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
     elif candidate == CAR.PALISADE:
@@ -62,15 +62,15 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 1985. + STD_CARGO_KG
       ret.wheelbase = 2.78
-      ret.steerRatio = 14.4 * 1.1   # 10% higher at the center seems reasonable
+      ret.steerRatio = 14.4 * 1.1  # 10% higher at the center seems reasonable
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
     elif candidate in [CAR.ELANTRA, CAR.ELANTRA_GT_I30]:
       ret.lateralTuning.pid.kf = 0.00006
       ret.mass = 1275. + STD_CARGO_KG
       ret.wheelbase = 2.7
-      ret.steerRatio = 15.4            # 14 is Stock | Settled Params Learner values are steerRatio: 15.401566348670535
-      tire_stiffness_factor = 0.385    # stiffnessFactor settled on 1.0081302973865127
+      ret.steerRatio = 15.4  # 14 is Stock | Settled Params Learner values are steerRatio: 15.401566348670535
+      tire_stiffness_factor = 0.385  # stiffnessFactor settled on 1.0081302973865127
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
       ret.minSteerSpeed = 32 * CV.MPH_TO_MS
@@ -82,11 +82,11 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.16], [0.01]]
       ret.minSteerSpeed = 60 * CV.KPH_TO_MS
-    elif candidate == CAR.GENESIS_G70: 
-      ret.lateralTuning.pid.kf = 0.00005 
-      ret.mass = 1640. + STD_CARGO_KG 
-      ret.wheelbase = 2.84 
-      ret.steerRatio = 16.5 
+    elif candidate == CAR.GENESIS_G70:
+      ret.lateralTuning.pid.kf = 0.00005
+      ret.mass = 1640. + STD_CARGO_KG
+      ret.wheelbase = 2.84
+      ret.steerRatio = 16.5
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.16], [0.01]]
     elif candidate == CAR.GENESIS_G80:
@@ -114,7 +114,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 1825. + STD_CARGO_KG
       ret.wheelbase = 2.78
-      ret.steerRatio = 14.4 * 1.15   # 15% higher at the center seems reasonable
+      ret.steerRatio = 14.4 * 1.15  # 15% higher at the center seems reasonable
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
     elif candidate == CAR.KONA:
@@ -135,9 +135,9 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
     elif candidate in [CAR.IONIQ, CAR.IONIQ_EV_LTD]:
       ret.lateralTuning.pid.kf = 0.00006
-      ret.mass = 1490. + STD_CARGO_KG   #weight per hyundai site https://www.hyundaiusa.com/ioniq-electric/specifications.aspx
+      ret.mass = 1490. + STD_CARGO_KG  # weight per hyundai site https://www.hyundaiusa.com/ioniq-electric/specifications.aspx
       ret.wheelbase = 2.7
-      ret.steerRatio = 13.73   #Spec
+      ret.steerRatio = 13.73  # Spec
       tire_stiffness_factor = 0.385
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
@@ -157,10 +157,10 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 13.75 * 1.15
       tire_stiffness_factor = 0.5
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]  
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
 
-    # these cars require a special panda safety mode due to missing counters and checksums in the messages
-    if candidate in [CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_LTD, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_2019, 
+      # these cars require a special panda safety mode due to missing counters and checksums in the messages
+    if candidate in [CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_LTD, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_2019,
                      CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70]:
       ret.safetyModel = car.CarParams.SafetyModel.hyundaiLegacy
 
@@ -187,10 +187,10 @@ class CarInterface(CarInterfaceBase):
     ret.canValid = self.cp.can_valid and self.cp_cam.can_valid
 
     events = self.create_common_events(ret)
-    #TODO: addd abs(self.CS.angle_steers) > 90 to 'steerTempUnavailable' event
+    # TODO: addd abs(self.CS.angle_steers) > 90 to 'steerTempUnavailable' event
 
     # low speed steer alert hysteresis logic (only for cars with steer cut off above 10 m/s)
-    if ret.vEgo < (self.CP.minSteerSpeed + 2.) and self.CP.minSteerSpeed > 10.:
+    if ret.vEgo < self.CP.minSteerSpeed + 2. and self.CP.minSteerSpeed > 10.:
       self.low_speed_alert = True
     if ret.vEgo > (self.CP.minSteerSpeed + 4.):
       self.low_speed_alert = False

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -13,9 +13,10 @@ GearShifter = car.CarState.GearShifter
 EventName = car.CarEvent.EventName
 MAX_CTRL_SPEED = (V_CRUISE_MAX + 4) * CV.KPH_TO_MS  # 144 + 4 = 92 mph
 
+
 # generic car and radar interfaces
 
-class CarInterfaceBase():
+class CarInterfaceBase:
   def __init__(self, CP, CarController, CarState):
     self.CP = CP
     self.VM = VehicleModel(CP)
@@ -120,7 +121,7 @@ class CarInterfaceBase():
     # Optionally allow to press gas at zero speed to resume.
     # e.g. Chrysler does not spam the resume button yet, so resuming with gas is handy. FIXME!
     if (cs_out.gasPressed and (not self.CS.out.gasPressed) and cs_out.vEgo > gas_resume_speed) or \
-       (cs_out.brakePressed and (not self.CS.out.brakePressed or not cs_out.standstill)):
+            (cs_out.brakePressed and (not self.CS.out.brakePressed or not cs_out.standstill)):
       events.add(EventName.pedalPressed)
 
     # we engage when pcm is active (rising edge)
@@ -132,7 +133,8 @@ class CarInterfaceBase():
 
     return events
 
-class RadarInterfaceBase():
+
+class RadarInterfaceBase:
   def __init__(self, CP):
     self.pts = {}
     self.delay = 0
@@ -144,6 +146,7 @@ class RadarInterfaceBase():
     if not self.no_radar_sleep:
       time.sleep(self.radar_ts)  # radard runs on RI updates
     return ret
+
 
 class CarStateBase:
   def __init__(self, CP):

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -8,7 +8,7 @@ from selfdrive.boardd.boardd import can_list_to_can_capnp
 from panda.python.uds import CanClient, IsoTpMessage, FUNCTIONAL_ADDRS, get_rx_addr_for_tx_addr
 
 
-class IsoTpParallelQuery():
+class IsoTpParallelQuery:
   def __init__(self, sendcan, logcan, bus, addrs, request, response, functional_addr=False, debug=False):
     self.sendcan = sendcan
     self.logcan = logcan

--- a/selfdrive/car/mazda/carcontroller.py
+++ b/selfdrive/car/mazda/carcontroller.py
@@ -3,7 +3,8 @@ from selfdrive.car.mazda.values import SteerLimitParams, Buttons
 from opendbc.can.packer import CANPacker
 from selfdrive.car import apply_std_steer_torque_limits
 
-class CarController():
+
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
     self.packer = CANPacker(dbc_name)

--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -8,8 +8,8 @@ from selfdrive.car.interfaces import CarInterfaceBase
 ButtonType = car.CarState.ButtonEvent.Type
 EventName = car.CarEvent.EventName
 
-class CarInterface(CarInterfaceBase):
 
+class CarInterface(CarInterfaceBase):
   @staticmethod
   def compute_gb(accel, speed):
     return float(accel) / 4.0
@@ -31,7 +31,7 @@ class CarInterface(CarInterfaceBase):
     ret.steerActuatorDelay = 0.1
     ret.steerRateCost = 1.0
     ret.steerLimitTimer = 0.8
-    tire_stiffness_factor = 0.70   # not optimized yet
+    tire_stiffness_factor = 0.70  # not optimized yet
 
     if candidate in [CAR.CX5]:
       ret.mass = 3655 * CV.LB_TO_KG + STD_CARGO_KG

--- a/selfdrive/car/mazda/radar_interface.py
+++ b/selfdrive/car/mazda/radar_interface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/mock/interface.py
+++ b/selfdrive/car/mock/interface.py
@@ -42,8 +42,8 @@ class CarInterface(CarInterfaceBase):
     ret.wheelbase = 2.70
     ret.centerToFront = ret.wheelbase * 0.5
     ret.steerRatio = 13.  # reasonable
-    ret.tireStiffnessFront = 1e6    # very stiff to neglect slip
-    ret.tireStiffnessRear = 1e6     # very stiff to neglect slip
+    ret.tireStiffnessFront = 1e6  # very stiff to neglect slip
+    ret.tireStiffnessRear = 1e6  # very stiff to neglect slip
 
     return ret
 

--- a/selfdrive/car/mock/radar_interface.py
+++ b/selfdrive/car/mock/radar_interface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/nissan/carcontroller.py
+++ b/selfdrive/car/nissan/carcontroller.py
@@ -6,14 +6,14 @@ from selfdrive.car.nissan.values import CAR, STEER_THRESHOLD
 
 # Steer angle limits
 ANGLE_DELTA_BP = [0., 5., 15.]
-ANGLE_DELTA_V = [5., .8, .15]     # windup limit
-ANGLE_DELTA_VU = [5., 3.5, 0.4]   # unwind limit
-LKAS_MAX_TORQUE = 1               # A value of 1 is easy to overpower
+ANGLE_DELTA_V = [5., .8, .15]  # windup limit
+ANGLE_DELTA_VU = [5., 3.5, 0.4]  # unwind limit
+LKAS_MAX_TORQUE = 1  # A value of 1 is easy to overpower
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 
 
-class CarController():
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.CP = CP
     self.car_fingerprint = CP.carFingerprint
@@ -70,17 +70,17 @@ class CarController():
       cruise_cancel = 1
 
     if self.CP.carFingerprint in [CAR.ROGUE, CAR.XTRAIL] and cruise_cancel:
-        can_sends.append(nissancan.create_acc_cancel_cmd(self.packer, CS.cruise_throttle_msg, frame))
+      can_sends.append(nissancan.create_acc_cancel_cmd(self.packer, CS.cruise_throttle_msg, frame))
 
     # TODO: Find better way to cancel!
     # For some reason spamming the cancel button is unreliable on the Leaf
     # We now cancel by making propilot think the seatbelt is unlatched,
     # this generates a beep and a warning message every time you disengage
     if self.CP.carFingerprint == CAR.LEAF and frame % 2 == 0:
-        can_sends.append(nissancan.create_cancel_msg(self.packer, CS.cancel_msg, cruise_cancel))
+      can_sends.append(nissancan.create_cancel_msg(self.packer, CS.cancel_msg, cruise_cancel))
 
     can_sends.append(nissancan.create_steering_control(
-        self.packer, self.car_fingerprint, apply_angle, frame, enabled, self.lkas_max_torque))
+      self.packer, self.car_fingerprint, apply_angle, frame, enabled, self.lkas_max_torque))
 
     if frame % 2 == 0:
       can_sends.append(nissancan.create_lkas_hud_msg(

--- a/selfdrive/car/nissan/interface.py
+++ b/selfdrive/car/nissan/interface.py
@@ -4,6 +4,7 @@ from selfdrive.car.nissan.values import CAR
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
 from selfdrive.car.interfaces import CarInterfaceBase
 
+
 class CarInterface(CarInterfaceBase):
   def __init__(self, CP, CarController, CarState):
     super().__init__(CP, CarController, CarState)

--- a/selfdrive/car/nissan/radar_interface.py
+++ b/selfdrive/car/nissan/radar_interface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -4,18 +4,18 @@ from selfdrive.car.subaru.values import DBC, PREGLOBAL_CARS
 from opendbc.can.packer import CANPacker
 
 
-class CarControllerParams():
+class CarControllerParams:
   def __init__(self):
-    self.STEER_MAX = 2047              # max_steer 4095
-    self.STEER_STEP = 2                # how often we update the steer cmd
-    self.STEER_DELTA_UP = 50           # torque increase per refresh, 0.8s to max
-    self.STEER_DELTA_DOWN = 70         # torque decrease per refresh
-    self.STEER_DRIVER_ALLOWANCE = 60   # allowed driver torque before start limiting
+    self.STEER_MAX = 2047  # max_steer 4095
+    self.STEER_STEP = 2  # how often we update the steer cmd
+    self.STEER_DELTA_UP = 50  # torque increase per refresh, 0.8s to max
+    self.STEER_DELTA_DOWN = 70  # torque decrease per refresh
+    self.STEER_DRIVER_ALLOWANCE = 60  # allowed driver torque before start limiting
     self.STEER_DRIVER_MULTIPLIER = 10  # weight driver torque heavily
-    self.STEER_DRIVER_FACTOR = 1       # from dbc
+    self.STEER_DRIVER_FACTOR = 1  # from dbc
 
 
-class CarController():
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
     self.es_distance_cnt = -1
@@ -28,16 +28,13 @@ class CarController():
     self.packer = CANPacker(DBC[CP.carFingerprint]['pt'])
 
   def update(self, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert, left_line, right_line):
-
     can_sends = []
 
     # *** steering ***
-    if (frame % self.params.STEER_STEP) == 0:
-
+    if frame % self.params.STEER_STEP == 0:
       apply_steer = int(round(actuators.steer * self.params.STEER_MAX))
 
       # limits due to driver torque
-
       new_steer = int(round(apply_steer))
       apply_steer = apply_std_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, self.params)
       self.steer_rate_limited = new_steer != apply_steer
@@ -51,7 +48,6 @@ class CarController():
         can_sends.append(subarucan.create_steering_control(self.packer, apply_steer, frame, self.params.STEER_STEP))
 
       self.apply_steer_last = apply_steer
-
 
     # *** alerts and pcm cancel ***
 

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -4,8 +4,8 @@ from selfdrive.car.subaru.values import CAR, PREGLOBAL_CARS
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
 from selfdrive.car.interfaces import CarInterfaceBase
 
-class CarInterface(CarInterfaceBase):
 
+class CarInterface(CarInterfaceBase):
   @staticmethod
   def compute_gb(accel, speed):
     return float(accel) / 4.0
@@ -39,7 +39,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.89
       ret.centerToFront = ret.wheelbase * 0.5
       ret.steerRatio = 13.5
-      ret.steerActuatorDelay = 0.3   # end-to-end angle controller
+      ret.steerActuatorDelay = 0.3  # end-to-end angle controller
       ret.lateralTuning.pid.kf = 0.00003
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.0025, 0.1], [0.00025, 0.01]]
@@ -49,7 +49,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5
       ret.steerRatio = 15
-      ret.steerActuatorDelay = 0.4   # end-to-end angle controller
+      ret.steerActuatorDelay = 0.4  # end-to-end angle controller
       ret.lateralTuning.pid.kf = 0.00005
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
@@ -58,18 +58,18 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1568. + STD_CARGO_KG
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5
-      ret.steerRatio = 17           # learned, 14 stock
+      ret.steerRatio = 17  # learned, 14 stock
       ret.steerActuatorDelay = 0.1
       ret.lateralTuning.pid.kf = 0.000038
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 14., 23.], [0., 14., 23.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.01, 0.065, 0.2], [0.001, 0.015, 0.025]]
 
     if candidate in [CAR.FORESTER_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018]:
-      ret.safetyParam = 1 # Outback 2018-2019 and Forester have reversed driver torque signal
+      ret.safetyParam = 1  # Outback 2018-2019 and Forester have reversed driver torque signal
       ret.mass = 1568 + STD_CARGO_KG
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5
-      ret.steerRatio = 20           # learned, 14 stock
+      ret.steerRatio = 20  # learned, 14 stock
       ret.steerActuatorDelay = 0.1
       ret.lateralTuning.pid.kf = 0.000039
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 10., 20.], [0., 10., 20.]]
@@ -79,7 +79,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1568 + STD_CARGO_KG
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5
-      ret.steerRatio = 12.5   # 14.5 stock
+      ret.steerRatio = 12.5  # 14.5 stock
       ret.steerActuatorDelay = 0.15
       ret.lateralTuning.pid.kf = 0.00005
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
@@ -89,7 +89,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1568 + STD_CARGO_KG
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5
-      ret.steerRatio = 20           # learned, 14 stock
+      ret.steerRatio = 20  # learned, 14 stock
       ret.steerActuatorDelay = 0.1
       ret.lateralTuning.pid.kf = 0.000039
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 10., 20.], [0., 10., 20.]]

--- a/selfdrive/car/subaru/radar_interface.py
+++ b/selfdrive/car/subaru/radar_interface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -15,8 +15,8 @@ ACCEL_MAX = 1.5  # 1.5 m/s2
 ACCEL_MIN = -3.0  # 3   m/s2
 ACCEL_SCALE = max(ACCEL_MAX, -ACCEL_MIN)
 
-def accel_hysteresis(accel, accel_steady, enabled):
 
+def accel_hysteresis(accel, accel_steady, enabled):
   # for small accel oscillations within ACCEL_HYST_GAP, don't change the accel command
   if not enabled:
     # send 0 when disabled, otherwise acc faults
@@ -101,8 +101,8 @@ class CarController():
 
     can_sends = []
 
-    #*** control msgs ***
-    #print("steer {0} {1} {2} {3}".format(apply_steer, min_lim, max_lim, CS.steer_torque_motor)
+    # *** control msgs ***
+    # print("steer {0} {1} {2} {3}".format(apply_steer, min_lim, max_lim, CS.steer_torque_motor)
 
     # toyota can trace shows this message at 42Hz, with counter adding alternatively 1 and 2;
     # sending it at 100Hz seem to allow a higher rate limit, as the rate limit seems imposed
@@ -117,7 +117,7 @@ class CarController():
 
     # we can spam can to cancel the system even if we are using lat only control
     if (frame % 3 == 0 and CS.CP.openpilotLongitudinalControl) or (pcm_cancel_cmd and Ecu.fwdCamera in self.fake_ecus):
-      lead = lead or CS.out.vEgo < 12.    # at low speed we always assume the lead is present do ACC can be engaged
+      lead = lead or CS.out.vEgo < 12.  # at low speed we always assume the lead is present do ACC can be engaged
 
       # Lexus IS uses a different cancellation message
       if pcm_cancel_cmd and CS.CP.carFingerprint == CAR.LEXUS_IS:
@@ -130,7 +130,7 @@ class CarController():
     if (frame % 2 == 0) and (CS.CP.enableGasInterceptor):
       # send exactly zero if apply_gas is zero. Interceptor will send the max between read value and apply_gas.
       # This prevents unexpected pedal range rescaling
-      can_sends.append(create_gas_command(self.packer, apply_gas, frame//2))
+      can_sends.append(create_gas_command(self.packer, apply_gas, frame // 2))
 
     # ui mesg is at 100Hz but we send asap if:
     # - there is something to display
@@ -140,7 +140,7 @@ class CarController():
 
     send_ui = False
     if ((fcw_alert or steer_alert) and not self.alert_active) or \
-       (not (fcw_alert or steer_alert) and self.alert_active):
+            (not (fcw_alert or steer_alert) and self.alert_active):
       send_ui = True
       self.alert_active = not self.alert_active
     elif pcm_cancel_cmd:
@@ -153,7 +153,7 @@ class CarController():
     if frame % 100 == 0 and Ecu.dsu in self.fake_ecus:
       can_sends.append(create_fcw_command(self.packer, fcw_alert))
 
-    #*** static msgs ***
+    # *** static msgs ***
 
     for (addr, ecu, cars, bus, fr_step, vl) in STATIC_MSGS:
       if frame % fr_step == 0 and ecu in self.fake_ecus and CS.CP.carFingerprint in cars:

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -10,7 +10,7 @@ from opendbc.can.packer import CANPacker
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 
 # Accel limits
-ACCEL_HYST_GAP = 0.02  # don't change accel command for small oscilalitons within this value
+ACCEL_HYST_GAP = 0.02  # don't change accel command for small oscillations within this value
 ACCEL_MAX = 1.5  # 1.5 m/s2
 ACCEL_MIN = -3.0  # 3   m/s2
 ACCEL_SCALE = max(ACCEL_MAX, -ACCEL_MIN)
@@ -30,7 +30,7 @@ def accel_hysteresis(accel, accel_steady, enabled):
   return accel, accel_steady
 
 
-class CarController():
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.last_steer = 0
     self.accel_steady = 0.
@@ -78,7 +78,7 @@ class CarController():
       self.last_fault_frame = frame
 
     # Cut steering for 2s after fault
-    if not enabled or (frame - self.last_fault_frame < 200):
+    if not enabled or frame - self.last_fault_frame < 200:
       apply_steer = 0
       apply_steer_req = 0
     else:
@@ -127,7 +127,7 @@ class CarController():
       else:
         can_sends.append(create_accel_command(self.packer, 0, pcm_cancel_cmd, False, lead))
 
-    if (frame % 2 == 0) and (CS.CP.enableGasInterceptor):
+    if (frame % 2 == 0) and CS.CP.enableGasInterceptor:
       # send exactly zero if apply_gas is zero. Interceptor will send the max between read value and apply_gas.
       # This prevents unexpected pedal range rescaling
       can_sends.append(create_gas_command(self.packer, apply_gas, frame // 2))

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -8,6 +8,7 @@ from selfdrive.car.interfaces import CarInterfaceBase
 
 EventName = car.CarEvent.EventName
 
+
 class CarInterface(CarInterfaceBase):
   @staticmethod
   def compute_gb(accel, speed):
@@ -31,8 +32,8 @@ class CarInterface(CarInterfaceBase):
       stop_and_go = True
       ret.safetyParam = 66  # see conversion factor for STEER_TORQUE_EPS in dbc file
       ret.wheelbase = 2.70
-      ret.steerRatio = 15.74   # unknown end-to-end spec
-      tire_stiffness_factor = 0.6371   # hand-tune
+      ret.steerRatio = 15.74  # unknown end-to-end spec
+      tire_stiffness_factor = 0.6371  # hand-tune
       ret.mass = 3045. * CV.LB_TO_KG + STD_CARGO_KG
 
       ret.lateralTuning.init('indi')
@@ -43,10 +44,10 @@ class CarInterface(CarInterfaceBase):
       ret.steerActuatorDelay = 0.5
 
     elif candidate in [CAR.RAV4, CAR.RAV4H]:
-      stop_and_go = True if (candidate in CAR.RAV4H) else False
+      stop_and_go = True if candidate in CAR.RAV4H else False
       ret.safetyParam = 73
       ret.wheelbase = 2.65
-      ret.steerRatio = 16.88   # 14.5 is spec end-to-end
+      ret.steerRatio = 16.88  # 14.5 is spec end-to-end
       tire_stiffness_factor = 0.5533
       ret.mass = 3650. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.init('lqr')
@@ -69,7 +70,7 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
-      ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.kf = 0.00003  # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:
       stop_and_go = True
@@ -89,7 +90,7 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 4481. * CV.LB_TO_KG + STD_CARGO_KG  # mean between min and max
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
-      ret.lateralTuning.pid.kf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.kf = 0.00006  # full torque for 10 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX_TSS2:
       stop_and_go = True
@@ -279,7 +280,7 @@ class CarInterface(CarInterfaceBase):
 
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter.
-    ret.minEnableSpeed = -1. if (stop_and_go or ret.enableGasInterceptor) else 19. * CV.MPH_TO_MS
+    ret.minEnableSpeed = -1. if stop_and_go or ret.enableGasInterceptor else 19. * CV.MPH_TO_MS
 
     # removing the DSU disables AEB and it's considered a community maintained feature
     # intercepting the DSU is a community feature since it requires unofficial hardware
@@ -338,7 +339,6 @@ class CarInterface(CarInterfaceBase):
   # pass in a car.CarControl
   # to be called @ 100hz
   def apply(self, c):
-
     can_sends = self.CC.update(c.enabled, self.CS, self.frame,
                                c.actuators, c.cruiseControl.cancel,
                                c.hudControl.visualAlert, c.hudControl.leftLaneVisible,

--- a/selfdrive/car/toyota/radar_interface.py
+++ b/selfdrive/car/toyota/radar_interface.py
@@ -4,6 +4,7 @@ from cereal import car
 from selfdrive.car.toyota.values import NO_DSU_CAR, DBC, TSS2_CAR
 from selfdrive.car.interfaces import RadarInterfaceBase
 
+
 def _create_radar_can_parser(car_fingerprint):
   if car_fingerprint in TSS2_CAR:
     RADAR_A_MSGS = list(range(0x180, 0x190))
@@ -16,13 +17,14 @@ def _create_radar_can_parser(car_fingerprint):
   msg_b_n = len(RADAR_B_MSGS)
 
   signals = list(zip(['LONG_DIST'] * msg_a_n + ['NEW_TRACK'] * msg_a_n + ['LAT_DIST'] * msg_a_n +
-                ['REL_SPEED'] * msg_a_n + ['VALID'] * msg_a_n + ['SCORE'] * msg_b_n,
-                RADAR_A_MSGS * 5 + RADAR_B_MSGS,
-                [255] * msg_a_n + [1] * msg_a_n + [0] * msg_a_n + [0] * msg_a_n + [0] * msg_a_n + [0] * msg_b_n))
+                     ['REL_SPEED'] * msg_a_n + ['VALID'] * msg_a_n + ['SCORE'] * msg_b_n,
+                     RADAR_A_MSGS * 5 + RADAR_B_MSGS,
+                     [255] * msg_a_n + [1] * msg_a_n + [0] * msg_a_n + [0] * msg_a_n + [0] * msg_a_n + [0] * msg_b_n))
 
-  checks = list(zip(RADAR_A_MSGS + RADAR_B_MSGS, [20]*(msg_a_n + msg_b_n)))
+  checks = list(zip(RADAR_A_MSGS + RADAR_B_MSGS, [20] * (msg_a_n + msg_b_n)))
 
   return CANParser(DBC[car_fingerprint]['radar'], signals, checks, 1)
+
 
 class RadarInterface(RadarInterfaceBase):
   def __init__(self, CP):
@@ -74,13 +76,13 @@ class RadarInterface(RadarInterfaceBase):
         cpt = self.rcp.vl[ii]
 
         if cpt['LONG_DIST'] >= 255 or cpt['NEW_TRACK']:
-          self.valid_cnt[ii] = 0    # reset counter
+          self.valid_cnt[ii] = 0  # reset counter
         if cpt['VALID'] and cpt['LONG_DIST'] < 255:
           self.valid_cnt[ii] += 1
         else:
           self.valid_cnt[ii] = max(self.valid_cnt[ii] - 1, 0)
 
-        score = self.rcp.vl[ii+16]['SCORE']
+        score = self.rcp.vl[ii + 16]['SCORE']
         # print ii, self.valid_cnt[ii], score, cpt['VALID'], cpt['LONG_DIST'], cpt['LAT_DIST']
 
         # radar point only valid if it's a valid measurement and score is above 50

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -5,7 +5,7 @@ from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTO
 from opendbc.can.packer import CANPacker
 
 
-class CarController():
+class CarController:
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
 
@@ -28,11 +28,11 @@ class CarController():
     # Send CAN commands.
     can_sends = []
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     #                                                                         #
     # Prepare HCA_01 Heading Control Assist messages with steering torque.    #
     #                                                                         #
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
 
     # The factory camera sends at 50Hz while steering and 1Hz when not. When
     # OP is active, Panda filters HCA_01 from the factory camera and OP emits
@@ -99,12 +99,12 @@ class CarController():
       can_sends.append(volkswagencan.create_mqb_steering_control(self.packer_pt, CANBUS.pt, apply_steer,
                                                                  idx, hcaEnabled))
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     #                                                                         #
     # Prepare LDW_02 HUD messages with lane borders, confidence levels, and   #
     # the LKAS status LED.                                                    #
     #                                                                         #
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
 
     # The factory camera emits this message at 10Hz. When OP is active, Panda
     # filters LDW_02 from the factory camera and OP emits LDW_02 at 10Hz.
@@ -121,11 +121,11 @@ class CarController():
                                                             CS.out.steeringPressed, hud_alert, leftLaneVisible,
                                                             rightLaneVisible))
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     #                                                                         #
     # Prepare GRA_ACC_01 ACC control messages with button press events.       #
     #                                                                         #
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
 
     # The car sends this message at 33hz. OP sends it on-demand only for
     # virtual button presses.

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -6,6 +6,7 @@ from selfdrive.car.interfaces import CarInterfaceBase
 GEAR = car.CarState.GearShifter
 EventName = car.CarEvent.EventName
 
+
 class CarInterface(CarInterfaceBase):
   def __init__(self, CP, CarController, CarState):
     super().__init__(CP, CarController, CarState)
@@ -78,7 +79,7 @@ class CarInterface(CarInterfaceBase):
     # TODO: add a field for this to carState, car interface code shouldn't write params
     # Update the device metric configuration to match the car at first startup,
     # or if there's been a change.
-    #if self.CS.displayMetricUnits != self.displayMetricUnitsPrev:
+    # if self.CS.displayMetricUnits != self.displayMetricUnitsPrev:
     #  put_nonblocking("IsMetric", "1" if self.CS.displayMetricUnits else "0")
 
     # Check for and process state-change events (button press or release) from
@@ -110,9 +111,9 @@ class CarInterface(CarInterfaceBase):
 
   def apply(self, c):
     can_sends = self.CC.update(c.enabled, self.CS, self.frame, c.actuators,
-                   c.hudControl.visualAlert,
-                   c.hudControl.audibleAlert,
-                   c.hudControl.leftLaneVisible,
-                   c.hudControl.rightLaneVisible)
+                               c.hudControl.visualAlert,
+                               c.hudControl.audibleAlert,
+                               c.hudControl.leftLaneVisible,
+                               c.hudControl.rightLaneVisible)
     self.frame += 1
     return can_sends

--- a/selfdrive/car/volkswagen/radar_interface.py
+++ b/selfdrive/car/volkswagen/radar_interface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/controls/lib/alertmanager.py
+++ b/selfdrive/controls/lib/alertmanager.py
@@ -13,7 +13,6 @@ AlertStatus = log.ControlsState.AlertStatus
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 AudibleAlert = car.CarControl.HUDControl.AudibleAlert
 
-
 with open(os.path.join(BASEDIR, "selfdrive/controls/lib/alerts_offroad.json")) as f:
   OFFROAD_ALERTS = json.load(f)
 
@@ -29,8 +28,7 @@ def set_offroad_alert(alert, show_alert, extra_text=None):
     Params().delete(alert)
 
 
-class AlertManager():
-
+class AlertManager:
   def __init__(self):
     self.activealerts = []
 

--- a/selfdrive/controls/lib/fcw.py
+++ b/selfdrive/controls/lib/fcw.py
@@ -7,7 +7,7 @@ _FCW_A_ACT_V = [-3., -2.]
 _FCW_A_ACT_BP = [0., 30.]
 
 
-class FCWChecker():
+class FCWChecker:
   def __init__(self):
     self.reset_lead(0.0)
     self.common_counters = defaultdict(lambda: 0)
@@ -35,7 +35,7 @@ class FCWChecker():
     a_rel = np.minimum(a_rel, v_lead / t_decel)
 
     # delta of the quadratic equation to solve for ttc
-    delta = v_rel**2 + 2 * x_lead * a_rel
+    delta = v_rel ** 2 + 2 * x_lead * a_rel
 
     # assign an arbitrary high ttc value if there is no solution to ttc
     if delta < 0.1 or (np.sqrt(delta) + v_rel < 0.1):
@@ -53,7 +53,7 @@ class FCWChecker():
     self.common_counters['blinkers'] = self.common_counters['blinkers'] + 10.0 / (20 * 3.0) if not blinkers else 0
     self.common_counters['v_ego'] = self.common_counters['v_ego'] + 1 if v_ego > 5.0 else 0
 
-    if (fcw_lead > 0.99):
+    if fcw_lead > 0.99:
       ttc = self.calc_ttc(v_ego, a_ego, x_lead, v_lead, a_lead)
       self.counters['ttc'] = self.counters['ttc'] + 1 if ttc < 2.5 else 0
       self.counters['v_lead_max'] = self.counters['v_lead_max'] + 1 if self.v_lead_max > 2.5 else 0

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -7,8 +7,8 @@ CAMERA_OFFSET = 0.06  # m from center car to camera
 
 def compute_path_pinv(l=50):
   deg = 3
-  x = np.arange(l*1.0)
-  X = np.vstack(tuple(x**n for n in range(deg, -1, -1))).T
+  x = np.arange(l * 1.0)
+  X = np.vstack(tuple(x ** n for n in range(deg, -1, -1))).T
   pinv = np.linalg.pinv(X)
   return pinv
 
@@ -18,7 +18,7 @@ def model_polyfit(points, path_pinv):
 
 
 def eval_poly(poly, x):
-  return poly[3] + poly[2]*x + poly[1]*x**2 + poly[0]*x**3
+  return poly[3] + poly[2] * x + poly[1] * x ** 2 + poly[0] * x ** 3
 
 
 def calc_d_poly(l_poly, r_poly, p_poly, l_prob, r_prob, lane_width, v_ego):
@@ -45,7 +45,7 @@ def calc_d_poly(l_poly, r_poly, p_poly, l_prob, r_prob, lane_width, v_ego):
   return lr_prob * d_poly_lane + (1.0 - lr_prob) * p_poly
 
 
-class LanePlanner():
+class LanePlanner:
   def __init__(self):
     self.l_poly = [0., 0., 0., 0.]
     self.r_poly = [0., 0., 0., 0.]

--- a/selfdrive/controls/lib/latcontrol_indi.py
+++ b/selfdrive/controls/lib/latcontrol_indi.py
@@ -9,7 +9,7 @@ from selfdrive.car import apply_toyota_steer_torque_limits
 from selfdrive.controls.lib.drive_helpers import get_steer_max
 
 
-class LatControlINDI():
+class LatControlINDI:
   def __init__(self, CP):
     self.angle_steers_des = 0.
 

--- a/selfdrive/controls/lib/latcontrol_lqr.py
+++ b/selfdrive/controls/lib/latcontrol_lqr.py
@@ -5,7 +5,7 @@ from common.realtime import DT_CTRL
 from cereal import log
 
 
-class LatControlLQR():
+class LatControlLQR:
   def __init__(self, CP):
     self.scale = CP.lateralTuning.lqr.scale
     self.ki = CP.lateralTuning.lqr.ki
@@ -47,7 +47,7 @@ class LatControlLQR():
     lqr_log = log.ControlsState.LateralLQRState.new_message()
 
     steers_max = get_steer_max(CP, CS.vEgo)
-    torque_scale = (0.45 + CS.vEgo / 60.0)**2  # Scale actuator model with speed
+    torque_scale = (0.45 + CS.vEgo / 60.0) ** 2  # Scale actuator model with speed
 
     steering_angle = CS.steeringAngle
 
@@ -80,7 +80,7 @@ class LatControlLQR():
         control = lqr_output + i
 
         if (error >= 0 and (control <= steers_max or i < 0.0)) or \
-           (error <= 0 and (control >= -steers_max or i > 0.0)):
+                (error <= 0 and (control >= -steers_max or i > 0.0)):
           self.i_lqr = i
 
       self.output_steer = lqr_output + self.i_lqr

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -4,7 +4,7 @@ from cereal import car
 from cereal import log
 
 
-class LatControlPID():
+class LatControlPID:
   def __init__(self, CP):
     self.pid = PIController((CP.lateralTuning.pid.kpBP, CP.lateralTuning.pid.kpV),
                             (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
@@ -30,14 +30,14 @@ class LatControlPID():
       steers_max = get_steer_max(CP, CS.vEgo)
       self.pid.pos_limit = steers_max
       self.pid.neg_limit = -steers_max
-      steer_feedforward = self.angle_steers_des   # feedforward desired angle
+      steer_feedforward = self.angle_steers_des  # feedforward desired angle
       if CP.steerControlType == car.CarParams.SteerControlType.torque:
         # TODO: feedforward something based on path_plan.rateSteers
-        steer_feedforward -= path_plan.angleOffset   # subtract the offset, since it does not contribute to resistive torque
-        steer_feedforward *= CS.vEgo**2  # proportional to realigning tire momentum (~ lateral accel)
+        steer_feedforward -= path_plan.angleOffset  # subtract the offset, since it does not contribute to resistive torque
+        steer_feedforward *= CS.vEgo ** 2  # proportional to realigning tire momentum (~ lateral accel)
       deadzone = 0.0
 
-      check_saturation = (CS.vEgo > 10) and not CS.steeringRateLimited and not CS.steeringPressed
+      check_saturation = CS.vEgo > 10 and not CS.steeringRateLimited and not CS.steeringPressed
       output_steer = self.pid.update(self.angle_steers_des, CS.steeringAngle, check_saturation=check_saturation, override=CS.steeringPressed,
                                      feedforward=steer_feedforward, speed=CS.vEgo, deadzone=deadzone)
       pid_log.active = True

--- a/selfdrive/controls/lib/long_mpc.py
+++ b/selfdrive/controls/lib/long_mpc.py
@@ -11,7 +11,7 @@ from selfdrive.controls.lib.drive_helpers import MPC_COST_LONG
 LOG_MPC = os.environ.get('LOG_MPC', False)
 
 
-class LongitudinalMpc():
+class LongitudinalMpc:
   def __init__(self, mpc_id):
     self.mpc_id = mpc_id
 
@@ -67,7 +67,7 @@ class LongitudinalMpc():
       v_lead = max(0.0, lead.vLead)
       a_lead = lead.aLeadK
 
-      if (v_lead < 0.1 or -a_lead / 2.0 > v_lead):
+      if v_lead < 0.1 or -a_lead / 2.0 > v_lead:
         v_lead = 0.0
         a_lead = 0.0
 
@@ -111,7 +111,7 @@ class LongitudinalMpc():
       if t > self.last_cloudlog_t + 5.0:
         self.last_cloudlog_t = t
         cloudlog.warning("Longitudinal mpc %d reset - backwards: %s crashing: %s nan: %s" % (
-                          self.mpc_id, backwards, crashing, nans))
+          self.mpc_id, backwards, crashing, nans))
 
       self.libmpc.init(MPC_COST_LONG.TTC, MPC_COST_LONG.DISTANCE,
                        MPC_COST_LONG.ACCELERATION, MPC_COST_LONG.JERK)

--- a/selfdrive/controls/lib/long_mpc_model.py
+++ b/selfdrive/controls/lib/long_mpc_model.py
@@ -6,7 +6,7 @@ from common.realtime import sec_since_boot
 from selfdrive.controls.lib.longitudinal_mpc_model import libmpc_py
 
 
-class LongitudinalMpcModel():
+class LongitudinalMpcModel:
   def __init__(self):
 
     self.setup_mpc()

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -26,7 +26,7 @@ def long_control_state_trans(active, long_control_state, v_ego, v_target, v_pid,
   stopping_condition = (v_ego < 2.0 and cruise_standstill) or \
                        (v_ego < STOPPING_EGO_SPEED and
                         ((v_pid < STOPPING_TARGET_SPEED and v_target < STOPPING_TARGET_SPEED) or
-                        brake_pressed))
+                         brake_pressed))
 
   starting_condition = v_target > STARTING_TARGET_SPEED and not cruise_standstill
 
@@ -55,7 +55,7 @@ def long_control_state_trans(active, long_control_state, v_ego, v_target, v_pid,
   return long_control_state
 
 
-class LongControl():
+class LongControl:
   def __init__(self, CP, compute_gb):
     self.long_control_state = LongCtrlState.off  # initialized to off
     self.pid = PIController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -46,7 +46,7 @@ def calc_states_after_delay(states, v_ego, steer_angle, curvature_factor, steer_
   return states
 
 
-class PathPlanner():
+class PathPlanner:
   def __init__(self, CP):
     self.LP = LanePlanner()
 
@@ -106,7 +106,7 @@ class PathPlanner():
     elif sm['carState'].rightBlinker:
       self.lane_change_direction = LaneChangeDirection.right
 
-    if (not active) or (self.lane_change_timer > LANE_CHANGE_TIME_MAX) or (not one_blinker) or (not self.lane_change_enabled):
+    if not active or self.lane_change_timer > LANE_CHANGE_TIME_MAX or not one_blinker or not self.lane_change_enabled:
       self.lane_change_state = LaneChangeState.off
       self.lane_change_direction = LaneChangeDirection.none
     else:
@@ -135,7 +135,7 @@ class PathPlanner():
       # starting
       elif self.lane_change_state == LaneChangeState.laneChangeStarting:
         # fade out over .5s
-        self.lane_change_ll_prob = max(self.lane_change_ll_prob - 2*DT_MDL, 0.0)
+        self.lane_change_ll_prob = max(self.lane_change_ll_prob - 2 * DT_MDL, 0.0)
         # 98% certainty
         if lane_change_prob < 0.02 and self.lane_change_ll_prob < 0.01:
           self.lane_change_state = LaneChangeState.laneChangeFinishing
@@ -195,7 +195,7 @@ class PathPlanner():
         self.last_cloudlog_t = t
         cloudlog.warning("Lateral mpc - nan: True")
 
-    if self.mpc_solution[0].cost > 20000. or mpc_nans:   # TODO: find a better way to detect when MPC did not converge
+    if self.mpc_solution[0].cost > 20000. or mpc_nans:  # TODO: find a better way to detect when MPC did not converge
       self.solution_invalid_cnt += 1
     else:
       self.solution_invalid_cnt = 0

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -1,6 +1,7 @@
 import numpy as np
 from common.numpy_fast import clip, interp
 
+
 def apply_deadzone(error, deadzone):
   if error > deadzone:
     error -= deadzone
@@ -10,7 +11,8 @@ def apply_deadzone(error, deadzone):
     error = 0.
   return error
 
-class PIController():
+
+class PIController:
   def __init__(self, k_p, k_i, k_f=1., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.8, convert=None):
     self._k_p = k_p  # proportional gain
     self._k_i = k_i  # integral gain
@@ -36,7 +38,7 @@ class PIController():
     return interp(self.speed, self._k_i[0], self._k_i[1])
 
   def _check_saturation(self, control, check_saturation, error):
-    saturated = (control < self.neg_limit) or (control > self.pos_limit)
+    saturated = control < self.neg_limit or control > self.pos_limit
 
     if saturated and check_saturation and abs(error) > 0.1:
       self.sat_count += self.sat_count_rate
@@ -75,7 +77,7 @@ class PIController():
       # or when i will move towards the sign of the error
       if ((error >= 0 and (control <= self.pos_limit or i < 0.0)) or
           (error <= 0 and (control >= self.neg_limit or i > 0.0))) and \
-         not freeze_integrator:
+              not freeze_integrator:
         self.i = i
 
     control = self.p + self.f + self.i

--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -19,18 +19,18 @@ MAX_SPEED = 255.0
 
 LON_MPC_STEP = 0.2  # first step is 0.2s
 MAX_SPEED_ERROR = 2.0
-AWARENESS_DECEL = -0.2     # car smoothly decel at .2m/s^2 when user is distracted
+AWARENESS_DECEL = -0.2  # car smoothly decel at .2m/s^2 when user is distracted
 
 # lookup tables VS speed to determine min and max accels in cruise
 # make sure these accelerations are smaller than mpc limits
 _A_CRUISE_MIN_V = [-1.0, -.8, -.67, -.5, -.30]
-_A_CRUISE_MIN_BP = [   0., 5.,  10., 20.,  40.]
+_A_CRUISE_MIN_BP = [0., 5., 10., 20., 40.]
 
 # need fast accel at very low speed for stop and go
 # make sure these accelerations are smaller than mpc limits
 _A_CRUISE_MAX_V = [1.2, 1.2, 0.65, .4]
 _A_CRUISE_MAX_V_FOLLOWING = [1.6, 1.6, 0.65, .4]
-_A_CRUISE_MAX_BP = [0.,  6.4, 22.5, 40.]
+_A_CRUISE_MAX_BP = [0., 6.4, 22.5, 40.]
 
 # Lookup table for turns
 _A_TOTAL_MAX_V = [1.7, 3.2]
@@ -57,13 +57,13 @@ def limit_accel_in_turns(v_ego, angle_steers, a_target, CP):
   """
 
   a_total_max = interp(v_ego, _A_TOTAL_MAX_BP, _A_TOTAL_MAX_V)
-  a_y = v_ego**2 * angle_steers * CV.DEG_TO_RAD / (CP.steerRatio * CP.wheelbase)
-  a_x_allowed = math.sqrt(max(a_total_max**2 - a_y**2, 0.))
+  a_y = v_ego ** 2 * angle_steers * CV.DEG_TO_RAD / (CP.steerRatio * CP.wheelbase)
+  a_x_allowed = math.sqrt(max(a_total_max ** 2 - a_y ** 2, 0.))
 
   return [a_target[0], min(a_target[1], a_x_allowed)]
 
 
-class Planner():
+class Planner:
   def __init__(self, CP):
     self.CP = CP
 
@@ -125,7 +125,7 @@ class Planner():
     lead_1 = sm['radarState'].leadOne
     lead_2 = sm['radarState'].leadTwo
 
-    enabled = (long_control_state == LongCtrlState.pid) or (long_control_state == LongCtrlState.stopping)
+    enabled = long_control_state == LongCtrlState.pid or long_control_state == LongCtrlState.stopping
     following = lead_1.status and lead_1.dRel < 45.0 and lead_1.vLeadK > v_ego and lead_1.aLeadK > 0.0
 
     # Calculate speed for normal cruise control

--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -1,19 +1,18 @@
 from common.kalman.simple_kalman import KF1D
 from selfdrive.config import RADAR_TO_CAMERA
 
-
 # the longer lead decels, the more likely it will keep decelerating
 # TODO is this a good default?
 _LEAD_ACCEL_TAU = 1.5
 
 # radar tracks
-SPEED, ACCEL = 0, 1   # Kalman filter states enum
+SPEED, ACCEL = 0, 1  # Kalman filter states enum
 
 # stationary qualification parameters
-v_ego_stationary = 4.   # no stationary object flag below this speed
+v_ego_stationary = 4.  # no stationary object flag below this speed
 
 
-class Track():
+class Track:
   def __init__(self, v_lead, kalman_params):
     self.cnt = 0
     self.aLeadTau = _LEAD_ACCEL_TAU
@@ -24,11 +23,11 @@ class Track():
 
   def update(self, d_rel, y_rel, v_rel, v_lead, measured):
     # relative values, copy
-    self.dRel = d_rel   # LONG_DIST
-    self.yRel = y_rel   # -LAT_DIST
-    self.vRel = v_rel   # REL_SPEED
+    self.dRel = d_rel  # LONG_DIST
+    self.yRel = y_rel  # -LAT_DIST
+    self.vRel = v_rel  # REL_SPEED
     self.vLead = v_lead
-    self.measured = measured   # measured or estimate
+    self.measured = measured  # measured or estimate
 
     # computed velocity and accelerations
     if self.cnt > 0:
@@ -47,18 +46,19 @@ class Track():
 
   def get_key_for_cluster(self):
     # Weigh y higher since radar is inaccurate in this dimension
-    return [self.dRel, self.yRel*2, self.vRel]
+    return [self.dRel, self.yRel * 2, self.vRel]
 
   def reset_a_lead(self, aLeadK, aLeadTau):
     self.kf = KF1D([[self.vLead], [aLeadK]], self.K_A, self.K_C, self.K_K)
     self.aLeadK = aLeadK
     self.aLeadTau = aLeadTau
 
+
 def mean(l):
   return sum(l) / len(l)
 
 
-class Cluster():
+class Cluster:
   def __init__(self):
     self.tracks = set()
 

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -14,16 +14,16 @@ from selfdrive.controls.lib.radar_helpers import Cluster, Track
 from selfdrive.swaglog import cloudlog
 
 
-class KalmanParams():
+class KalmanParams:
   def __init__(self, dt):
     # Lead Kalman Filter params, calculating K from A, C, Q, R requires the control library.
     # hardcoding a lookup table to compute K for values of radar_ts between 0.1s and 1.0s
     assert dt > .01 and dt < .1, "Radar time step must be between .01s and 0.1s"
     self.A = [[1.0, dt], [0.0, 1.0]]
     self.C = [1.0, 0.0]
-    #Q = np.matrix([[10., 0.0], [0.0, 100.]])
-    #R = 1e3
-    #K = np.matrix([[ 0.05705578], [ 0.03073241]])
+    # Q = np.matrix([[10., 0.0], [0.0, 100.]])
+    # R = 1e3
+    # K = np.matrix([[ 0.05705578], [ 0.03073241]])
     dts = [dt * 0.01 for dt in range(1, 11)]
     K0 = [0.12288, 0.14557, 0.16523, 0.18282, 0.19887, 0.21372, 0.22761, 0.24069, 0.2531, 0.26491]
     K1 = [0.29666, 0.29331, 0.29043, 0.28787, 0.28555, 0.28342, 0.28144, 0.27958, 0.27783, 0.27617]
@@ -32,7 +32,7 @@ class KalmanParams():
 
 def laplacian_cdf(x, mu, b):
   b = max(b, 1e-4)
-  return math.exp(-abs(x-mu)/b)
+  return math.exp(-abs(x - mu) / b)
 
 
 def match_vision_to_cluster(v_ego, lead, clusters):
@@ -51,7 +51,7 @@ def match_vision_to_cluster(v_ego, lead, clusters):
 
   # if no 'sane' match is found return -1
   # stationary radar points can be false positives
-  dist_sane = abs(cluster.dRel - offset_vision_dist) < max([(offset_vision_dist)*.25, 5.0])
+  dist_sane = abs(cluster.dRel - offset_vision_dist) < max([offset_vision_dist * .25, 5.0])
   vel_sane = (abs(cluster.vRel - lead.relVel) < 10) or (v_ego + cluster.vRel > 3)
   if dist_sane and vel_sane:
     return cluster
@@ -78,13 +78,13 @@ def get_lead(v_ego, ready, clusters, lead_msg, low_speed_override=True):
       closest_cluster = min(low_speed_clusters, key=lambda c: c.dRel)
 
       # Only choose new cluster if it is actually closer than the previous one
-      if (not lead_dict['status']) or (closest_cluster.dRel < lead_dict['dRel']):
+      if not lead_dict['status'] or closest_cluster.dRel < lead_dict['dRel']:
         lead_dict = closest_cluster.get_RadarState()
 
   return lead_dict
 
 
-class RadarD():
+class RadarD:
   def __init__(self, radar_ts, delay=0):
     self.current_time = 0
 
@@ -95,12 +95,12 @@ class RadarD():
 
     # v_ego
     self.v_ego = 0.
-    self.v_ego_hist = deque([0], maxlen=delay+1)
+    self.v_ego_hist = deque([0], maxlen=delay + 1)
 
     self.ready = False
 
   def update(self, frame, sm, rr, has_radar):
-    self.current_time = 1e-9*max([sm.logMonoTime[key] for key in sm.logMonoTime.keys()])
+    self.current_time = 1e-9 * max([sm.logMonoTime[key] for key in sm.logMonoTime.keys()])
 
     if sm.updated['controlsState']:
       self.active = sm['controlsState'].active
@@ -212,7 +212,7 @@ def radard_thread(sm=None, pm=None, can_sock=None):
     sm.update(0)
 
     dat = RD.update(rk.frame, sm, rr, has_radar)
-    dat.radarState.cumLagMs = -rk.remaining*1000.
+    dat.radarState.cumLagMs = -rk.remaining * 1000.
 
     pm.send('radarState', dat)
 

--- a/selfdrive/controls/tests/test_following_distance.py
+++ b/selfdrive/controls/tests/test_following_distance.py
@@ -15,7 +15,7 @@ def RW(v_ego, v_l):
   return (v_ego * TR - (v_l - v_ego) * TR + v_ego * v_ego / (2 * G) - v_l * v_l / (2 * G))
 
 
-class FakePubMaster():
+class FakePubMaster:
   def send(self, s, data):
     assert data
 

--- a/selfdrive/locationd/calibrationd.py
+++ b/selfdrive/locationd/calibrationd.py
@@ -19,13 +19,13 @@ MAX_YAW_RATE_FILTER = np.radians(2)  # per second
 
 # This is all 20Hz, blocks needed for efficiency
 BLOCK_SIZE = 100
-INPUTS_NEEDED = 5   # allow to update VP every so many frames
-INPUTS_WANTED = 50   # We want a little bit more than we need for stability
+INPUTS_NEEDED = 5  # allow to update VP every so many frames
+INPUTS_WANTED = 50  # We want a little bit more than we need for stability
 WRITE_CYCLES = 10  # write every 1000 cycles
-VP_INIT = np.array([W/2., H/2.])
+VP_INIT = np.array([W / 2., H / 2.])
 
 # These values are needed to accomodate biggest modelframe
-VP_VALIDITY_CORNERS = np.array([[W//2 - 63, 300], [W//2 + 63, 520]])
+VP_VALIDITY_CORNERS = np.array([[W // 2 - 63, 300], [W // 2 + 63, 520]])
 DEBUG = os.getenv("DEBUG") is not None
 
 
@@ -48,7 +48,7 @@ def intrinsics_from_vp(vp):
     [  0.,    0.,     1.]])
 
 
-class Calibrator():
+class Calibrator:
   def __init__(self, param_put=False):
     self.param_put = param_put
     self.vp = copy.copy(VP_INIT)
@@ -102,10 +102,10 @@ class Calibrator():
       # intrinsics are not eon intrinsics, since this is calibrated frame
       intrinsics = intrinsics_from_vp(self.vp)
       new_vp = intrinsics.dot(view_frame_from_device_frame.dot(trans))
-      new_vp = new_vp[:2]/new_vp[2]
+      new_vp = new_vp[:2] / new_vp[2]
       new_vp = sanity_clip(new_vp)
 
-      self.vps[self.block_idx] = (self.idx*self.vps[self.block_idx] + (BLOCK_SIZE - self.idx) * new_vp) / float(BLOCK_SIZE)
+      self.vps[self.block_idx] = (self.idx * self.vps[self.block_idx] + (BLOCK_SIZE - self.idx) * new_vp) / float(BLOCK_SIZE)
       self.idx = (self.idx + 1) % BLOCK_SIZE
       if self.idx == 0:
         self.block_idx += 1

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -21,7 +21,7 @@ def _slice(n):
   return s
 
 
-class States():
+class States:
   # Vehicle model params
   STIFFNESS = _slice(1)  # [-]
   STEER_RATIO = _slice(1)  # [-]
@@ -49,23 +49,23 @@ class CarKalman(KalmanFilter):
 
   # process noise
   Q = np.diag([
-    (.05 / 100)**2,
-    .01**2,
-    math.radians(0.02)**2,
-    math.radians(0.25)**2,
+    (.05 / 100) ** 2,
+    .01 ** 2,
+    math.radians(0.02) ** 2,
+    math.radians(0.25) ** 2,
 
-    .1**2, .01**2,
-    math.radians(0.1)**2,
-    math.radians(0.1)**2,
+    .1 ** 2, .01 ** 2,
+    math.radians(0.1) ** 2,
+    math.radians(0.1) ** 2,
   ])
   P_initial = Q.copy()
 
   obs_noise: Dict[int, Any] = {
-    ObservationKind.STEER_ANGLE: np.atleast_2d(math.radians(0.01)**2),
-    ObservationKind.ANGLE_OFFSET_FAST: np.atleast_2d(math.radians(10.0)**2),
-    ObservationKind.STEER_RATIO: np.atleast_2d(5.0**2),
-    ObservationKind.STIFFNESS: np.atleast_2d(5.0**2),
-    ObservationKind.ROAD_FRAME_X_SPEED: np.atleast_2d(0.1**2),
+    ObservationKind.STEER_ANGLE: np.atleast_2d(math.radians(0.01) ** 2),
+    ObservationKind.ANGLE_OFFSET_FAST: np.atleast_2d(math.radians(10.0) ** 2),
+    ObservationKind.STEER_RATIO: np.atleast_2d(5.0 ** 2),
+    ObservationKind.STIFFNESS: np.atleast_2d(5.0 ** 2),
+    ObservationKind.ROAD_FRAME_X_SPEED: np.atleast_2d(0.1 ** 2),
   }
 
   global_vars = [
@@ -106,7 +106,7 @@ class CarKalman(KalmanFilter):
     A[0, 0] = -(cF + cR) / (m * u)
     A[0, 1] = -(cF * aF - cR * aR) / (m * u) - u
     A[1, 0] = -(cF * aF - cR * aR) / (j * u)
-    A[1, 1] = -(cF * aF**2 + cR * aR**2) / (j * u)
+    A[1, 1] = -(cF * aF ** 2 + cR * aR ** 2) / (j * u)
 
     B = sp.Matrix(np.zeros((2, 1)))
     B[0, 0] = cF / m / sR

--- a/selfdrive/locationd/models/gnss_kf.py
+++ b/selfdrive/locationd/models/gnss_kf.py
@@ -10,7 +10,7 @@ from selfdrive.locationd.models.constants import ObservationKind
 from selfdrive.locationd.models.loc_kf import parse_pr, parse_prr
 
 
-class States():
+class States:
   ECEF_POS = slice(0, 3)  # x, y and z in ECEF in meters
   ECEF_VELOCITY = slice(3, 6)
   CLOCK_BIAS = slice(6, 7)  # clock bias in light-meters,
@@ -20,7 +20,7 @@ class States():
   GLONASS_FREQ_SLOPE = slice(10, 11)  # GLONASS bias in m expressed as bias + freq_num*freq_slope
 
 
-class GNSSKalman():
+class GNSSKalman:
   name = 'gnss'
 
   x_initial = np.array([-2712700.6008, -4281600.6679, 3859300.1830,
@@ -87,22 +87,22 @@ class GNSSKalman():
 
     h_pseudorange_sym = sp.Matrix([
       sp.sqrt(
-        (x - sat_x)**2 +
-        (y - sat_y)**2 +
-        (z - sat_z)**2
+        (x - sat_x) ** 2 +
+        (y - sat_y) ** 2 +
+        (z - sat_z) ** 2
       ) + cb
     ])
 
     h_pseudorange_glonass_sym = sp.Matrix([
       sp.sqrt(
-        (x - sat_x)**2 +
-        (y - sat_y)**2 +
-        (z - sat_z)**2
+        (x - sat_x) ** 2 +
+        (y - sat_y) ** 2 +
+        (z - sat_z) ** 2
       ) + cb + glonass_bias + glonass_freq_slope * glonass_freq
     ])
 
     los_vector = (sp.Matrix(sat_pos_vel_sym[0:3]) - sp.Matrix([x, y, z]))
-    los_vector = los_vector / sp.sqrt(los_vector[0]**2 + los_vector[1]**2 + los_vector[2]**2)
+    los_vector = los_vector / sp.sqrt(los_vector[0] ** 2 + los_vector[1] ** 2 + los_vector[2] ** 2)
     h_pseudorange_rate_sym = sp.Matrix([los_vector[0] * (sat_vx - vx) +
                                         los_vector[1] * (sat_vy - vy) +
                                         los_vector[2] * (sat_vz - vz) +

--- a/selfdrive/loggerd/tests/loggerd_tests_common.py
+++ b/selfdrive/loggerd/tests/loggerd_tests_common.py
@@ -7,32 +7,35 @@ import unittest
 
 import selfdrive.loggerd.uploader as uploader
 
+
 def create_random_file(file_path, size_mb, lock=False):
-    try:
-      os.mkdir(os.path.dirname(file_path))
-    except OSError:
-      pass
+  try:
+    os.mkdir(os.path.dirname(file_path))
+  except OSError:
+    pass
 
-    lock_path = file_path + ".lock"
-    os.close(os.open(lock_path, os.O_CREAT | os.O_EXCL))
+  lock_path = file_path + ".lock"
+  os.close(os.open(lock_path, os.O_CREAT | os.O_EXCL))
 
-    chunks = 128
-    chunk_bytes = int(size_mb * 1024 * 1024 / chunks)
-    data = os.urandom(chunk_bytes)
+  chunks = 128
+  chunk_bytes = int(size_mb * 1024 * 1024 / chunks)
+  data = os.urandom(chunk_bytes)
 
-    with open(file_path, 'wb') as f:
-      for _ in range(chunks):
-        f.write(data)
+  with open(file_path, 'wb') as f:
+    for _ in range(chunks):
+      f.write(data)
 
-    if not lock:
-        os.remove(lock_path)
+  if not lock:
+    os.remove(lock_path)
 
-class MockResponse():
+
+class MockResponse:
   def __init__(self, text, status_code):
     self.text = text
     self.status_code = status_code
 
-class MockApi():
+
+class MockApi:
   def __init__(self, dongle_id):
     pass
 
@@ -42,7 +45,8 @@ class MockApi():
   def get_token(self):
     return "fake-token"
 
-class MockApiIgnore():
+
+class MockApiIgnore:
   def __init__(self, dongle_id):
     pass
 
@@ -52,7 +56,8 @@ class MockApiIgnore():
   def get_token(self):
     return "fake-token"
 
-class MockParams():
+
+class MockParams:
   def __init__(self):
     self.params = {
       "DongleId": b"0000000000000000",
@@ -62,6 +67,7 @@ class MockParams():
 
   def get(self, k):
     return self.params[k]
+
 
 class UploaderTestCase(unittest.TestCase):
   f_type = "UNKNOWN"

--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -26,6 +26,7 @@ UPLOAD_ATTR_VALUE = b'1'
 
 fake_upload = os.getenv("FAKEUPLOAD") is not None
 
+
 def raise_on_thread(t, exctype):
   '''Raises an exception in the threads with id tid'''
   for ctid, tobj in threading._active.items():
@@ -48,8 +49,10 @@ def raise_on_thread(t, exctype):
     ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, 0)
     raise SystemError("PyThreadState_SetAsyncExc failed")
 
+
 def get_directory_sort(d):
   return list(map(lambda s: s.rjust(10, '0'), d.rsplit('--', 1)))
+
 
 def listdir_by_creation(d):
   try:
@@ -59,6 +62,7 @@ def listdir_by_creation(d):
   except OSError:
     cloudlog.exception("listdir_by_creation failed")
     return list()
+
 
 def clear_locks(root):
   for logname in os.listdir(root):
@@ -70,20 +74,23 @@ def clear_locks(root):
     except OSError:
       cloudlog.exception("clear_locks failed")
 
+
 def is_on_wifi():
   return HARDWARE.get_network_type() == NetworkType.wifi
+
 
 def is_on_hotspot():
   try:
     result = subprocess.check_output(["ifconfig", "wlan0"], stderr=subprocess.STDOUT, encoding='utf8')
     result = re.findall(r"inet addr:((\d+\.){3}\d+)", result)[0][0]
-    return (result.startswith('192.168.43.') or # android
-            result.startswith('172.20.10.') or # ios
-            result.startswith('10.0.2.')) # toyota entune
+    return (result.startswith('192.168.43.') or  # android
+            result.startswith('172.20.10.') or  # ios
+            result.startswith('10.0.2.'))  # toyota entune
   except Exception:
     return False
 
-class Uploader():
+
+class Uploader:
   def __init__(self, dongle_id, root):
     self.dongle_id = dongle_id
     self.api = Api(dongle_id)
@@ -152,7 +159,7 @@ class Uploader():
 
   def do_upload(self, key, fn):
     try:
-      url_resp = self.api.get("v1.3/"+self.dongle_id+"/upload_url/", timeout=10, path=key, access_token=self.api.get_token())
+      url_resp = self.api.get("v1.3/" + self.dongle_id + "/upload_url/", timeout=10, path=key, access_token=self.api.get_token())
       if url_resp.status_code == 412:
         self.last_resp = url_resp
         return
@@ -165,7 +172,7 @@ class Uploader():
       if fake_upload:
         cloudlog.info("*** WARNING, THIS IS A FAKE UPLOAD TO %s ***" % url)
 
-        class FakeResponse():
+        class FakeResponse:
           def __init__(self):
             self.status_code = 200
 
@@ -223,6 +230,7 @@ class Uploader():
 
     return success
 
+
 def uploader_fn(exit_event):
   cloudlog.info("uploader_fn")
 
@@ -258,11 +266,13 @@ def uploader_fn(exit_event):
     else:
       cloudlog.info("backoff %r", backoff)
       time.sleep(backoff + random.uniform(0, backoff))
-      backoff = min(backoff*2, 120)
+      backoff = min(backoff * 2, 120)
     cloudlog.info("upload done, success=%r", success)
+
 
 def main():
   uploader_fn(threading.Event())
+
 
 if __name__ == "__main__":
   main()

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -12,9 +12,9 @@ import textwrap
 from typing import Dict, List
 from selfdrive.swaglog import cloudlog, add_logentries_handler
 
-
 from common.basedir import BASEDIR, PARAMS
 from common.hardware import HARDWARE, ANDROID, PC
+
 WEBCAM = os.getenv("WEBCAM") is not None
 sys.path.append(os.path.join(BASEDIR, "pyextra"))
 os.environ['BASEDIR'] = BASEDIR
@@ -33,6 +33,7 @@ except PermissionError:
 if ANDROID:
   os.chmod("/dev/shm", 0o777)
 
+
 def unblock_stdout():
   # get a non-blocking stdout
   child_pid, child_pty = os.forkpty()
@@ -43,7 +44,7 @@ def unblock_stdout():
     signal.signal(signal.SIGTERM, lambda signum, frame: os.kill(child_pid, signal.SIGTERM))
 
     fcntl.fcntl(sys.stdout, fcntl.F_SETFL,
-       fcntl.fcntl(sys.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
+                fcntl.fcntl(sys.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
 
     while True:
       try:
@@ -115,7 +116,7 @@ if not prebuilt:
 
     if scons.returncode != 0:
       # Read remaining output
-      r = scons.stderr.read().split(b'\n')   # type: ignore
+      r = scons.stderr.read().split(b'\n')  # type: ignore
       compile_output += r
 
       if retry:
@@ -176,7 +177,7 @@ managed_processes = {
   "tombstoned": "selfdrive.tombstoned",
   "logcatd": ("selfdrive/logcatd", ["./logcatd"]),
   "proclogd": ("selfdrive/proclogd", ["./proclogd"]),
-  "boardd": ("selfdrive/boardd", ["./boardd"]),   # not used directly
+  "boardd": ("selfdrive/boardd", ["./boardd"]),  # not used directly
   "pandad": "selfdrive.pandad",
   "ui": ("selfdrive/ui", ["./ui"]),
   "calibrationd": "selfdrive.locationd.calibrationd",
@@ -197,6 +198,7 @@ daemon_processes = {
 running: Dict[str, Process] = {}
 def get_running():
   return running
+
 
 # due to qualcomm kernel bugs SIGKILLing camerad sometimes causes page table corruption
 unkillable_processes = ['camerad']
@@ -277,6 +279,7 @@ def register_managed_process(name, desc, car_started=False):
   else:
     persistent_processes.append(name)
 
+
 # ****************** process management functions ******************
 def nativelauncher(pargs, cwd):
   # exec the process
@@ -286,6 +289,7 @@ def nativelauncher(pargs, cwd):
   os.chmod(pargs[0], 0o700)
 
   os.execvp(pargs[0], pargs)
+
 
 def start_managed_process(name):
   if name in running or name not in managed_processes:
@@ -300,6 +304,7 @@ def start_managed_process(name):
     cloudlog.info("starting process %s" % name)
     running[name] = Process(name=name, target=nativelauncher, args=(pargs, cwd))
   running[name].start()
+
 
 def start_daemon_process(name):
   params = Params()
@@ -326,6 +331,7 @@ def start_daemon_process(name):
 
   params.put(pid_param, str(proc.pid))
 
+
 def prepare_managed_process(p):
   proc = managed_processes[p]
   if isinstance(proc, str):
@@ -339,7 +345,7 @@ def prepare_managed_process(p):
       subprocess.check_call(["make", "-j4"], cwd=os.path.join(BASEDIR, proc[0]))
     except subprocess.CalledProcessError:
       # make clean if the build failed
-      cloudlog.warning("building %s failed, make clean" % (proc, ))
+      cloudlog.warning("building %s failed, make clean" % (proc,))
       subprocess.check_call(["make", "clean"], cwd=os.path.join(BASEDIR, proc[0]))
       subprocess.check_call(["make", "-j4"], cwd=os.path.join(BASEDIR, proc[0]))
 
@@ -416,7 +422,7 @@ def manager_init(should_register=True):
     else:
       raise Exception("server registration failed")
   else:
-    dongle_id = "c"*16
+    dongle_id = "c" * 16
 
   # set dongle id
   cloudlog.info("dongle id is " + dongle_id)
@@ -441,6 +447,7 @@ def manager_init(should_register=True):
     os.chmod(BASEDIR, 0o755)
     os.chmod(os.path.join(BASEDIR, "cereal"), 0o755)
     os.chmod(os.path.join(BASEDIR, "cereal", "libmessaging_shared.so"), 0o755)
+
 
 def manager_thread():
   # now loop
@@ -528,6 +535,7 @@ def manager_thread():
     if params.get("DoUninstall", encoding='utf8') == "1":
       break
 
+
 def manager_prepare(spinner=None):
   # build all processes
   os.chdir(os.path.dirname(os.path.abspath(__file__)))
@@ -540,12 +548,14 @@ def manager_prepare(spinner=None):
       spinner.update("%d" % ((100.0 - total) + total * (i + 1) / len(managed_processes),))
     prepare_managed_process(p)
 
+
 def uninstall():
   cloudlog.warning("uninstalling")
   with open('/cache/recovery/command', 'w') as f:
     f.write('--wipe_data\n')
   # IPowerManager.reboot(confirm=false, reason="recovery", wait=true)
   HARDWARE.reboot(reason="recovery")
+
 
 def main():
   os.environ['PARAMS_PATH'] = PARAMS

--- a/selfdrive/modeld/visiontest.py
+++ b/selfdrive/modeld/visiontest.py
@@ -14,7 +14,7 @@ except Exception:
   pass
 
 
-class VisionTest():
+class VisionTest:
   """A version of the vision model that can be run on a desktop.
 
      WARNING: This class is not thread safe. VisionTest objects cannot be

--- a/selfdrive/monitoring/test_monitoring.py
+++ b/selfdrive/monitoring/test_monitoring.py
@@ -20,7 +20,8 @@ _INVISIBLE_SECONDS_TO_ORANGE = _AWARENESS_TIME - _AWARENESS_PROMPT_TIME_TILL_TER
 _INVISIBLE_SECONDS_TO_RED = _AWARENESS_TIME + 1
 _UNCERTAIN_SECONDS_TO_GREEN = _HI_STD_TIMEOUT + 0.5
 
-class fake_DM_msg():
+
+class fake_DM_msg:
   def __init__(self, is_face_detected, is_distracted=False, is_model_uncertain=False):
     self.faceOrientation = [0., 0., 0.]
     self.facePosition = [0., 0.]
@@ -29,8 +30,8 @@ class fake_DM_msg():
     self.rightEyeProb = 1.
     self.leftBlinkProb = 1. * is_distracted
     self.rightBlinkProb = 1. * is_distracted
-    self.faceOrientationStd = [1.*is_model_uncertain, 1.*is_model_uncertain, 1.*is_model_uncertain]
-    self.facePositionStd = [1.*is_model_uncertain, 1.*is_model_uncertain]
+    self.faceOrientationStd = [1. * is_model_uncertain, 1. * is_model_uncertain, 1. * is_model_uncertain]
+    self.facePositionStd = [1. * is_model_uncertain, 1. * is_model_uncertain]
     self.sgProb = 0.
 
 
@@ -40,7 +41,7 @@ msg_ATTENTIVE = fake_DM_msg(is_face_detected=True)
 msg_DISTRACTED = fake_DM_msg(is_face_detected=True, is_distracted=True)
 msg_ATTENTIVE_UNCERTAIN = fake_DM_msg(is_face_detected=True, is_model_uncertain=True)
 msg_DISTRACTED_UNCERTAIN = fake_DM_msg(is_face_detected=True, is_distracted=True, is_model_uncertain=True)
-msg_DISTRACTED_BUT_SOMEHOW_UNCERTAIN = fake_DM_msg(is_face_detected=True, is_distracted=True, is_model_uncertain=_POSESTD_THRESHOLD*1.5)
+msg_DISTRACTED_BUT_SOMEHOW_UNCERTAIN = fake_DM_msg(is_face_detected=True, is_distracted=True, is_model_uncertain=_POSESTD_THRESHOLD * 1.5)
 
 # driver interaction with car
 car_interaction_DETECTED = True
@@ -55,11 +56,12 @@ car_STANDSTILL = True
 car_NOT_STANDSTILL = False
 
 # some common state vectors
-always_no_face = [msg_NO_FACE_DETECTED] * int(_TEST_TIMESPAN/DT_DMON)
-always_attentive = [msg_ATTENTIVE] * int(_TEST_TIMESPAN/DT_DMON)
-always_distracted = [msg_DISTRACTED] * int(_TEST_TIMESPAN/DT_DMON)
-always_true = [True] * int(_TEST_TIMESPAN/DT_DMON)
-always_false = [False] * int(_TEST_TIMESPAN/DT_DMON)
+always_no_face = [msg_NO_FACE_DETECTED] * int(_TEST_TIMESPAN / DT_DMON)
+always_attentive = [msg_ATTENTIVE] * int(_TEST_TIMESPAN / DT_DMON)
+always_distracted = [msg_DISTRACTED] * int(_TEST_TIMESPAN / DT_DMON)
+always_true = [True] * int(_TEST_TIMESPAN / DT_DMON)
+always_false = [False] * int(_TEST_TIMESPAN / DT_DMON)
+
 
 def run_DState_seq(driver_state_msgs, driver_car_interaction, openpilot_status, car_standstill_status):
   # inputs are all 10Hz
@@ -76,6 +78,7 @@ def run_DState_seq(driver_state_msgs, driver_car_interaction, openpilot_status, 
   assert len(events_from_DM) == len(driver_state_msgs), 'somethings wrong'
   return events_from_DM, DS
 
+
 class TestMonitoring(unittest.TestCase):
   # 0. op engaged, driver is doing fine all the time
   def test_fully_aware_driver(self):
@@ -85,40 +88,40 @@ class TestMonitoring(unittest.TestCase):
   # 1. op engaged, driver is distracted and does nothing
   def test_fully_distracted_driver(self):
     events_output, d_status = run_DState_seq(always_distracted, always_false, always_true, always_false)
-    self.assertTrue(len(events_output[int((_DISTRACTED_TIME-_DISTRACTED_PRE_TIME_TILL_TERMINAL)/2/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_DISTRACTED_TIME-_DISTRACTED_PRE_TIME_TILL_TERMINAL +
-                      ((_DISTRACTED_PRE_TIME_TILL_TERMINAL-_DISTRACTED_PROMPT_TIME_TILL_TERMINAL)/2))/DT_DMON)].names[0], EventName.preDriverDistracted)
-    self.assertEqual(events_output[int((_DISTRACTED_TIME-_DISTRACTED_PROMPT_TIME_TILL_TERMINAL +
-                      ((_DISTRACTED_PROMPT_TIME_TILL_TERMINAL)/2))/DT_DMON)].names[0], EventName.promptDriverDistracted)
+    self.assertTrue(len(events_output[int((_DISTRACTED_TIME - _DISTRACTED_PRE_TIME_TILL_TERMINAL) / 2 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_DISTRACTED_TIME - _DISTRACTED_PRE_TIME_TILL_TERMINAL +
+                                        ((_DISTRACTED_PRE_TIME_TILL_TERMINAL - _DISTRACTED_PROMPT_TIME_TILL_TERMINAL) / 2)) / DT_DMON)].names[0], EventName.preDriverDistracted)
+    self.assertEqual(events_output[int((_DISTRACTED_TIME - _DISTRACTED_PROMPT_TIME_TILL_TERMINAL +
+                                        ((_DISTRACTED_PROMPT_TIME_TILL_TERMINAL) / 2)) / DT_DMON)].names[0], EventName.promptDriverDistracted)
     self.assertEqual(events_output[int((_DISTRACTED_TIME +
-                      ((_TEST_TIMESPAN-10-_DISTRACTED_TIME)/2))/DT_DMON)].names[0], EventName.driverDistracted)
+                                        ((_TEST_TIMESPAN - 10 - _DISTRACTED_TIME) / 2)) / DT_DMON)].names[0], EventName.driverDistracted)
     self.assertIs(type(d_status.awareness), float)
 
   # 2. op engaged, no face detected the whole time, no action
   def test_fully_invisible_driver(self):
     events_output = run_DState_seq(always_no_face, always_false, always_true, always_false)[0]
-    self.assertTrue(len(events_output[int((_AWARENESS_TIME-_AWARENESS_PRE_TIME_TILL_TERMINAL)/2/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_AWARENESS_TIME-_AWARENESS_PRE_TIME_TILL_TERMINAL +
-                      ((_AWARENESS_PRE_TIME_TILL_TERMINAL-_AWARENESS_PROMPT_TIME_TILL_TERMINAL)/2))/DT_DMON)].names[0], EventName.preDriverUnresponsive)
-    self.assertEqual(events_output[int((_AWARENESS_TIME-_AWARENESS_PROMPT_TIME_TILL_TERMINAL +
-                      ((_AWARENESS_PROMPT_TIME_TILL_TERMINAL)/2))/DT_DMON)].names[0], EventName.promptDriverUnresponsive)
+    self.assertTrue(len(events_output[int((_AWARENESS_TIME - _AWARENESS_PRE_TIME_TILL_TERMINAL) / 2 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_AWARENESS_TIME - _AWARENESS_PRE_TIME_TILL_TERMINAL +
+                                        ((_AWARENESS_PRE_TIME_TILL_TERMINAL - _AWARENESS_PROMPT_TIME_TILL_TERMINAL) / 2)) / DT_DMON)].names[0], EventName.preDriverUnresponsive)
+    self.assertEqual(events_output[int((_AWARENESS_TIME - _AWARENESS_PROMPT_TIME_TILL_TERMINAL +
+                                        ((_AWARENESS_PROMPT_TIME_TILL_TERMINAL) / 2)) / DT_DMON)].names[0], EventName.promptDriverUnresponsive)
     self.assertEqual(events_output[int((_AWARENESS_TIME +
-                      ((_TEST_TIMESPAN-10-_AWARENESS_TIME)/2))/DT_DMON)].names[0], EventName.driverUnresponsive)
+                                        ((_TEST_TIMESPAN - 10 - _AWARENESS_TIME) / 2)) / DT_DMON)].names[0], EventName.driverUnresponsive)
 
   # 3. op engaged, down to orange, driver pays attention, back to normal; then down to orange, driver touches wheel
   #  - should have short orange recovery time and no green afterwards; should recover rightaway on wheel touch
   def test_normal_driver(self):
-    ds_vector = [msg_DISTRACTED] * int(_DISTRACTED_SECONDS_TO_ORANGE/DT_DMON) + \
-                [msg_ATTENTIVE] * int(_DISTRACTED_SECONDS_TO_ORANGE/DT_DMON) + \
-                [msg_DISTRACTED] * (int(_TEST_TIMESPAN/DT_DMON)-int(_DISTRACTED_SECONDS_TO_ORANGE*2/DT_DMON))
-    interaction_vector = [car_interaction_NOT_DETECTED] * int(_DISTRACTED_SECONDS_TO_ORANGE*3/DT_DMON) + \
-                        [car_interaction_DETECTED] * (int(_TEST_TIMESPAN/DT_DMON)-int(_DISTRACTED_SECONDS_TO_ORANGE*3/DT_DMON))
+    ds_vector = [msg_DISTRACTED] * int(_DISTRACTED_SECONDS_TO_ORANGE / DT_DMON) + \
+                [msg_ATTENTIVE] * int(_DISTRACTED_SECONDS_TO_ORANGE / DT_DMON) + \
+                [msg_DISTRACTED] * (int(_TEST_TIMESPAN / DT_DMON) - int(_DISTRACTED_SECONDS_TO_ORANGE * 2 / DT_DMON))
+    interaction_vector = [car_interaction_NOT_DETECTED] * int(_DISTRACTED_SECONDS_TO_ORANGE * 3 / DT_DMON) + \
+                         [car_interaction_DETECTED] * (int(_TEST_TIMESPAN / DT_DMON) - int(_DISTRACTED_SECONDS_TO_ORANGE * 3 / DT_DMON))
     events_output = run_DState_seq(ds_vector, interaction_vector, always_true, always_false)[0]
-    self.assertTrue(len(events_output[int(_DISTRACTED_SECONDS_TO_ORANGE*0.5/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE-0.1)/DT_DMON)].names[0], EventName.promptDriverDistracted)
-    self.assertTrue(len(events_output[int(_DISTRACTED_SECONDS_TO_ORANGE*1.5/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE*3-0.1)/DT_DMON)].names[0], EventName.promptDriverDistracted)
-    self.assertTrue(len(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE*3+0.1)/DT_DMON)]) == 0)
+    self.assertTrue(len(events_output[int(_DISTRACTED_SECONDS_TO_ORANGE * 0.5 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE - 0.1) / DT_DMON)].names[0], EventName.promptDriverDistracted)
+    self.assertTrue(len(events_output[int(_DISTRACTED_SECONDS_TO_ORANGE * 1.5 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE * 3 - 0.1) / DT_DMON)].names[0], EventName.promptDriverDistracted)
+    self.assertTrue(len(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE * 3 + 0.1) / DT_DMON)]) == 0)
 
   # 4. op engaged, down to orange, driver dodges camera, then comes back still distracted, down to red, \
   #                          driver dodges, and then touches wheel to no avail, disengages and reengages
@@ -128,37 +131,37 @@ class TestMonitoring(unittest.TestCase):
     ds_vector = always_distracted[:]
     interaction_vector = always_false[:]
     op_vector = always_true[:]
-    ds_vector[int(_DISTRACTED_SECONDS_TO_ORANGE/DT_DMON):int((_DISTRACTED_SECONDS_TO_ORANGE+_invisible_time)/DT_DMON)] = [msg_NO_FACE_DETECTED] * int(_invisible_time/DT_DMON)
-    ds_vector[int((_DISTRACTED_SECONDS_TO_RED+_invisible_time)/DT_DMON):int((_DISTRACTED_SECONDS_TO_RED+2*_invisible_time)/DT_DMON)] = [msg_NO_FACE_DETECTED] * int(_invisible_time/DT_DMON)
-    interaction_vector[int((_DISTRACTED_SECONDS_TO_RED+2*_invisible_time+0.5)/DT_DMON):int((_DISTRACTED_SECONDS_TO_RED+2*_invisible_time+1.5)/DT_DMON)] = [True] * int(1/DT_DMON)
-    op_vector[int((_DISTRACTED_SECONDS_TO_RED+2*_invisible_time+2.5)/DT_DMON):int((_DISTRACTED_SECONDS_TO_RED+2*_invisible_time+3)/DT_DMON)] = [False] * int(0.5/DT_DMON)
+    ds_vector[int(_DISTRACTED_SECONDS_TO_ORANGE / DT_DMON):int((_DISTRACTED_SECONDS_TO_ORANGE + _invisible_time) / DT_DMON)] = [msg_NO_FACE_DETECTED] * int(_invisible_time / DT_DMON)
+    ds_vector[int((_DISTRACTED_SECONDS_TO_RED + _invisible_time) / DT_DMON):int((_DISTRACTED_SECONDS_TO_RED + 2 * _invisible_time) / DT_DMON)] = [msg_NO_FACE_DETECTED] * int(_invisible_time / DT_DMON)
+    interaction_vector[int((_DISTRACTED_SECONDS_TO_RED + 2 * _invisible_time + 0.5) / DT_DMON):int((_DISTRACTED_SECONDS_TO_RED + 2 * _invisible_time + 1.5) / DT_DMON)] = [True] * int(1 / DT_DMON)
+    op_vector[int((_DISTRACTED_SECONDS_TO_RED + 2 * _invisible_time + 2.5) / DT_DMON):int((_DISTRACTED_SECONDS_TO_RED + 2 * _invisible_time + 3) / DT_DMON)] = [False] * int(0.5 / DT_DMON)
     events_output = run_DState_seq(ds_vector, interaction_vector, op_vector, always_false)[0]
-    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE+0.5*_invisible_time)/DT_DMON)].names[0], EventName.promptDriverDistracted)
-    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_RED+1.5*_invisible_time)/DT_DMON)].names[0], EventName.driverDistracted)
-    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_RED+2*_invisible_time+1.5)/DT_DMON)].names[0], EventName.driverDistracted)
-    self.assertTrue(len(events_output[int((_DISTRACTED_SECONDS_TO_RED+2*_invisible_time+3.5)/DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_ORANGE + 0.5 * _invisible_time) / DT_DMON)].names[0], EventName.promptDriverDistracted)
+    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_RED + 1.5 * _invisible_time) / DT_DMON)].names[0], EventName.driverDistracted)
+    self.assertEqual(events_output[int((_DISTRACTED_SECONDS_TO_RED + 2 * _invisible_time + 1.5) / DT_DMON)].names[0], EventName.driverDistracted)
+    self.assertTrue(len(events_output[int((_DISTRACTED_SECONDS_TO_RED + 2 * _invisible_time + 3.5) / DT_DMON)]) == 0)
 
   # 5. op engaged, invisible driver, down to orange, driver touches wheel; then down to orange again, driver appears
   #  - both actions should clear the alert, but momentary appearence should not
   def test_sometimes_transparent_commuter(self):
-      _visible_time = np.random.choice([1, 10])  # seconds
-      # print _visible_time
-      ds_vector = always_no_face[:]*2
-      interaction_vector = always_false[:]*2
-      ds_vector[int((2*_INVISIBLE_SECONDS_TO_ORANGE+1)/DT_DMON):int((2*_INVISIBLE_SECONDS_TO_ORANGE+1+_visible_time)/DT_DMON)] = [msg_ATTENTIVE] * int(_visible_time/DT_DMON)
-      interaction_vector[int((_INVISIBLE_SECONDS_TO_ORANGE)/DT_DMON):int((_INVISIBLE_SECONDS_TO_ORANGE+1)/DT_DMON)] = [True] * int(1/DT_DMON)
-      events_output = run_DState_seq(ds_vector, interaction_vector, 2*always_true, 2*always_false)[0]
-      self.assertTrue(len(events_output[int(_INVISIBLE_SECONDS_TO_ORANGE*0.5/DT_DMON)]) == 0)
-      self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE-0.1)/DT_DMON)].names[0], EventName.promptDriverUnresponsive)
-      self.assertTrue(len(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE+0.1)/DT_DMON)]) == 0)
-      if _visible_time == 1:
-        self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE*2+1-0.1)/DT_DMON)].names[0], EventName.promptDriverUnresponsive)
-        self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE*2+1+0.1+_visible_time)/DT_DMON)].names[0], EventName.preDriverUnresponsive)
-      elif _visible_time == 10:
-        self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE*2+1-0.1)/DT_DMON)].names[0], EventName.promptDriverUnresponsive)
-        self.assertTrue(len(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE*2+1+0.1+_visible_time)/DT_DMON)]) == 0)
-      else:
-        pass
+    _visible_time = np.random.choice([1, 10])  # seconds
+    # print _visible_time
+    ds_vector = always_no_face[:] * 2
+    interaction_vector = always_false[:] * 2
+    ds_vector[int((2 * _INVISIBLE_SECONDS_TO_ORANGE + 1) / DT_DMON):int((2 * _INVISIBLE_SECONDS_TO_ORANGE + 1 + _visible_time) / DT_DMON)] = [msg_ATTENTIVE] * int(_visible_time / DT_DMON)
+    interaction_vector[int((_INVISIBLE_SECONDS_TO_ORANGE) / DT_DMON):int((_INVISIBLE_SECONDS_TO_ORANGE + 1) / DT_DMON)] = [True] * int(1 / DT_DMON)
+    events_output = run_DState_seq(ds_vector, interaction_vector, 2 * always_true, 2 * always_false)[0]
+    self.assertTrue(len(events_output[int(_INVISIBLE_SECONDS_TO_ORANGE * 0.5 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE - 0.1) / DT_DMON)].names[0], EventName.promptDriverUnresponsive)
+    self.assertTrue(len(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE + 0.1) / DT_DMON)]) == 0)
+    if _visible_time == 1:
+      self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE * 2 + 1 - 0.1) / DT_DMON)].names[0], EventName.promptDriverUnresponsive)
+      self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE * 2 + 1 + 0.1 + _visible_time) / DT_DMON)].names[0], EventName.preDriverUnresponsive)
+    elif _visible_time == 10:
+      self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE * 2 + 1 - 0.1) / DT_DMON)].names[0], EventName.promptDriverUnresponsive)
+      self.assertTrue(len(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE * 2 + 1 + 0.1 + _visible_time) / DT_DMON)]) == 0)
+    else:
+      pass
 
   # 6. op engaged, invisible driver, down to red, driver appears and then touches wheel, then disengages/reengages
   #  - only disengage will clear the alert
@@ -167,16 +170,16 @@ class TestMonitoring(unittest.TestCase):
     ds_vector = always_no_face[:]
     interaction_vector = always_false[:]
     op_vector = always_true[:]
-    ds_vector[int(_INVISIBLE_SECONDS_TO_RED/DT_DMON):int((_INVISIBLE_SECONDS_TO_RED+_visible_time)/DT_DMON)] = [msg_ATTENTIVE] * int(_visible_time/DT_DMON)
-    interaction_vector[int((_INVISIBLE_SECONDS_TO_RED+_visible_time)/DT_DMON):int((_INVISIBLE_SECONDS_TO_RED+_visible_time+1)/DT_DMON)] = [True] * int(1/DT_DMON)
-    op_vector[int((_INVISIBLE_SECONDS_TO_RED+_visible_time+1)/DT_DMON):int((_INVISIBLE_SECONDS_TO_RED+_visible_time+0.5)/DT_DMON)] = [False] * int(0.5/DT_DMON)
+    ds_vector[int(_INVISIBLE_SECONDS_TO_RED / DT_DMON):int((_INVISIBLE_SECONDS_TO_RED + _visible_time) / DT_DMON)] = [msg_ATTENTIVE] * int(_visible_time / DT_DMON)
+    interaction_vector[int((_INVISIBLE_SECONDS_TO_RED + _visible_time) / DT_DMON):int((_INVISIBLE_SECONDS_TO_RED + _visible_time + 1) / DT_DMON)] = [True] * int(1 / DT_DMON)
+    op_vector[int((_INVISIBLE_SECONDS_TO_RED + _visible_time + 1) / DT_DMON):int((_INVISIBLE_SECONDS_TO_RED + _visible_time + 0.5) / DT_DMON)] = [False] * int(0.5 / DT_DMON)
     events_output = run_DState_seq(ds_vector, interaction_vector, op_vector, always_false)[0]
-    self.assertTrue(len(events_output[int(_INVISIBLE_SECONDS_TO_ORANGE*0.5/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE-0.1)/DT_DMON)].names[0], EventName.promptDriverUnresponsive)
-    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_RED-0.1)/DT_DMON)].names[0], EventName.driverUnresponsive)
-    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_RED+0.5*_visible_time)/DT_DMON)].names[0], EventName.driverUnresponsive)
-    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_RED+_visible_time+0.5)/DT_DMON)].names[0], EventName.driverUnresponsive)
-    self.assertTrue(len(events_output[int((_INVISIBLE_SECONDS_TO_RED+_visible_time+1+0.1)/DT_DMON)]) == 0)
+    self.assertTrue(len(events_output[int(_INVISIBLE_SECONDS_TO_ORANGE * 0.5 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_ORANGE - 0.1) / DT_DMON)].names[0], EventName.promptDriverUnresponsive)
+    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_RED - 0.1) / DT_DMON)].names[0], EventName.driverUnresponsive)
+    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_RED + 0.5 * _visible_time) / DT_DMON)].names[0], EventName.driverUnresponsive)
+    self.assertEqual(events_output[int((_INVISIBLE_SECONDS_TO_RED + _visible_time + 0.5) / DT_DMON)].names[0], EventName.driverUnresponsive)
+    self.assertTrue(len(events_output[int((_INVISIBLE_SECONDS_TO_RED + _visible_time + 1 + 0.1) / DT_DMON)]) == 0)
 
   # 7. op not engaged, always distracted driver
   #  - dm should stay quiet when not engaged
@@ -189,38 +192,39 @@ class TestMonitoring(unittest.TestCase):
   def test_long_traffic_light_victim(self):
     _redlight_time = 60  # seconds
     standstill_vector = always_true[:]
-    standstill_vector[int(_redlight_time/DT_DMON):] = [False] * int((_TEST_TIMESPAN-_redlight_time)/DT_DMON)
+    standstill_vector[int(_redlight_time / DT_DMON):] = [False] * int((_TEST_TIMESPAN - _redlight_time) / DT_DMON)
     events_output = run_DState_seq(always_distracted, always_false, always_true, standstill_vector)[0]
-    self.assertEqual(events_output[int((_DISTRACTED_TIME-_DISTRACTED_PRE_TIME_TILL_TERMINAL+1)/DT_DMON)].names[0], EventName.preDriverDistracted)
-    self.assertEqual(events_output[int((_redlight_time-0.1)/DT_DMON)].names[0], EventName.preDriverDistracted)
-    self.assertEqual(events_output[int((_redlight_time+0.5)/DT_DMON)].names[0], EventName.promptDriverDistracted)
+    self.assertEqual(events_output[int((_DISTRACTED_TIME - _DISTRACTED_PRE_TIME_TILL_TERMINAL + 1) / DT_DMON)].names[0], EventName.preDriverDistracted)
+    self.assertEqual(events_output[int((_redlight_time - 0.1) / DT_DMON)].names[0], EventName.preDriverDistracted)
+    self.assertEqual(events_output[int((_redlight_time + 0.5) / DT_DMON)].names[0], EventName.promptDriverDistracted)
 
   # 9. op engaged, model is extremely uncertain. driver first attentive, then distracted
   #  - should only pop the green alert about model uncertainty
   #  - (note: this's just for sanity check, std output should never be this high)
   def test_one_indecisive_model(self):
-    ds_vector = [msg_ATTENTIVE_UNCERTAIN] * int(_UNCERTAIN_SECONDS_TO_GREEN/DT_DMON) + \
-                [msg_ATTENTIVE] * int(_DISTRACTED_SECONDS_TO_ORANGE/DT_DMON) + \
-                [msg_DISTRACTED_UNCERTAIN] * (int(_TEST_TIMESPAN/DT_DMON)-int((_DISTRACTED_SECONDS_TO_ORANGE+_UNCERTAIN_SECONDS_TO_GREEN)/DT_DMON))
+    ds_vector = [msg_ATTENTIVE_UNCERTAIN] * int(_UNCERTAIN_SECONDS_TO_GREEN / DT_DMON) + \
+                [msg_ATTENTIVE] * int(_DISTRACTED_SECONDS_TO_ORANGE / DT_DMON) + \
+                [msg_DISTRACTED_UNCERTAIN] * (int(_TEST_TIMESPAN / DT_DMON) - int((_DISTRACTED_SECONDS_TO_ORANGE + _UNCERTAIN_SECONDS_TO_GREEN) / DT_DMON))
     interaction_vector = always_false[:]
     events_output = run_DState_seq(ds_vector, interaction_vector, always_true, always_false)[0]
-    self.assertTrue(len(events_output[int(_UNCERTAIN_SECONDS_TO_GREEN*0.5/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_UNCERTAIN_SECONDS_TO_GREEN-0.1)/DT_DMON)].names[0], EventName.driverMonitorLowAcc)
-    self.assertTrue(len(events_output[int((_UNCERTAIN_SECONDS_TO_GREEN+_DISTRACTED_SECONDS_TO_ORANGE-0.5)/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_TEST_TIMESPAN-5.)/DT_DMON)].names[0], EventName.driverMonitorLowAcc)
+    self.assertTrue(len(events_output[int(_UNCERTAIN_SECONDS_TO_GREEN * 0.5 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_UNCERTAIN_SECONDS_TO_GREEN - 0.1) / DT_DMON)].names[0], EventName.driverMonitorLowAcc)
+    self.assertTrue(len(events_output[int((_UNCERTAIN_SECONDS_TO_GREEN + _DISTRACTED_SECONDS_TO_ORANGE - 0.5) / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_TEST_TIMESPAN - 5.) / DT_DMON)].names[0], EventName.driverMonitorLowAcc)
 
   # 10. op engaged, model is somehow uncertain and driver is distracted
   #  - should slow down the alert countdown but it still gets there
   def test_somehow_indecisive_model(self):
-    ds_vector = [msg_DISTRACTED_BUT_SOMEHOW_UNCERTAIN] * int(_TEST_TIMESPAN/DT_DMON)
+    ds_vector = [msg_DISTRACTED_BUT_SOMEHOW_UNCERTAIN] * int(_TEST_TIMESPAN / DT_DMON)
     interaction_vector = always_false[:]
     events_output = run_DState_seq(ds_vector, interaction_vector, always_true, always_false)[0]
-    self.assertTrue(len(events_output[int(_UNCERTAIN_SECONDS_TO_GREEN*0.5/DT_DMON)]) == 0)
-    self.assertEqual(events_output[int((_UNCERTAIN_SECONDS_TO_GREEN)/DT_DMON)].names[0], EventName.driverMonitorLowAcc)
-    self.assertEqual(events_output[int((2.5*(_DISTRACTED_TIME-_DISTRACTED_PRE_TIME_TILL_TERMINAL))/DT_DMON)].names[1], EventName.preDriverDistracted)
-    self.assertEqual(events_output[int((2.5*(_DISTRACTED_TIME-_DISTRACTED_PROMPT_TIME_TILL_TERMINAL))/DT_DMON)].names[1], EventName.promptDriverDistracted)
-    self.assertEqual(events_output[int((_DISTRACTED_TIME+1)/DT_DMON)].names[1], EventName.promptDriverDistracted)
-    self.assertEqual(events_output[int((_DISTRACTED_TIME*2.5)/DT_DMON)].names[1], EventName.promptDriverDistracted)  # set_timer blocked
+    self.assertTrue(len(events_output[int(_UNCERTAIN_SECONDS_TO_GREEN * 0.5 / DT_DMON)]) == 0)
+    self.assertEqual(events_output[int((_UNCERTAIN_SECONDS_TO_GREEN) / DT_DMON)].names[0], EventName.driverMonitorLowAcc)
+    self.assertEqual(events_output[int((2.5 * (_DISTRACTED_TIME - _DISTRACTED_PRE_TIME_TILL_TERMINAL)) / DT_DMON)].names[1], EventName.preDriverDistracted)
+    self.assertEqual(events_output[int((2.5 * (_DISTRACTED_TIME - _DISTRACTED_PROMPT_TIME_TILL_TERMINAL)) / DT_DMON)].names[1], EventName.promptDriverDistracted)
+    self.assertEqual(events_output[int((_DISTRACTED_TIME + 1) / DT_DMON)].names[1], EventName.promptDriverDistracted)
+    self.assertEqual(events_output[int((_DISTRACTED_TIME * 2.5) / DT_DMON)].names[1], EventName.promptDriverDistracted)  # set_timer blocked
+
 
 if __name__ == "__main__":
   print('MAX_TERMINAL_ALERTS', MAX_TERMINAL_ALERTS)

--- a/selfdrive/test/longitudinal_maneuvers/maneuver.py
+++ b/selfdrive/test/longitudinal_maneuvers/maneuver.py
@@ -4,7 +4,7 @@ from selfdrive.test.longitudinal_maneuvers.plant import Plant
 import numpy as np
 
 
-class Maneuver():
+class Maneuver:
   def __init__(self, title, duration, **kwargs):
     # Was tempted to make a builder class
     self.distance_lead = kwargs.get("initial_distance_lead", 200.0)
@@ -58,7 +58,7 @@ class Maneuver():
 
       if last_controls_state:
         # print(last_controls_state)
-        #develop plots
+        # develop plots
         plot.add_data(
           time=plant.current_time(),
           gas=log['gas'], brake=log['brake'], steer_torque=log['steer_torque'],

--- a/selfdrive/test/longitudinal_maneuvers/maneuverplots.py
+++ b/selfdrive/test/longitudinal_maneuvers/maneuverplots.py
@@ -6,7 +6,8 @@ import pylab
 
 from selfdrive.config import Conversions as CV
 
-class ManeuverPlot():
+
+class ManeuverPlot:
   def __init__(self, title=None):
     self.time_array = []
 
@@ -39,8 +40,8 @@ class ManeuverPlot():
     self.title = title
 
   def add_data(self, time, gas, brake, steer_torque, distance, speed,
-    acceleration, up_accel_cmd, ui_accel_cmd, uf_accel_cmd, d_rel, v_rel,
-    v_lead, v_target_lead, pid_speed, cruise_speed, jerk_factor, a_target, fcw):
+               acceleration, up_accel_cmd, ui_accel_cmd, uf_accel_cmd, d_rel, v_rel,
+               v_lead, v_target_lead, pid_speed, cruise_speed, jerk_factor, a_target, fcw):
     self.time_array.append(time)
     self.gas_array.append(gas)
     self.brake_array.append(brake)

--- a/selfdrive/test/profiling/lib.py
+++ b/selfdrive/test/profiling/lib.py
@@ -7,7 +7,7 @@ class ReplayDone(Exception):
   pass
 
 
-class SubSocket():
+class SubSocket:
   def __init__(self, msgs, trigger):
     self.i = 0
     self.trigger = trigger
@@ -30,7 +30,7 @@ class SubSocket():
       return msg.to_bytes()
 
 
-class PubSocket():
+class PubSocket:
   def send(self, data):
     pass
 

--- a/tools/lib/api.py
+++ b/tools/lib/api.py
@@ -1,9 +1,11 @@
 import os
 import requests
 from tools.lib.auth_config import clear_token
+
 API_HOST = os.getenv('API_HOST', 'https://api.commadotai.com')
 
-class CommaApi():
+
+class CommaApi:
   def __init__(self, token=None):
     self.session = requests.Session()
     self.session.headers['User-agent'] = 'OpenpilotTools'
@@ -29,8 +31,10 @@ class CommaApi():
   def post(self, endpoint, **kwargs):
     return self.request('POST', endpoint, **kwargs)
 
+
 class APIError(Exception):
   pass
+
 
 class UnauthorizedError(Exception):
   pass

--- a/tools/sim/lib/helpers.py
+++ b/tools/sim/lib/helpers.py
@@ -1,11 +1,11 @@
-class FakeSteeringWheel():
+class FakeSteeringWheel:
   def __init__(self, dt=0.01):
     # physical params
     self.DAC = 4. / 0.625  # convert torque value from can to Nm
     self.k = 0.035
     self.centering_k = 4.1 * 0.9
     self.b = 0.1 * 0.8
-    self.I = 1 * 1.36 * (0.175**2)
+    self.I = 1 * 1.36 * (0.175 ** 2)
     self.dt = dt
     # ...
 


### PR DESCRIPTION
Some changes I wanted to make to follow some PEP8 guidelines as well as make the coding style more consistent across openpilot
- Remove redundant parentheses (for if checks as well as class declarations with no bases)
- Correct spacing
  - For comments
  - Between functions
  - Between classes
  - For global variables under imports
  - For if checks