### PR TITLE
Subtract standard camera offset from CAMERA_OFFSET with p_poly

### DIFF
--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -45,7 +45,7 @@ def calc_d_poly(l_poly, r_poly, p_poly, l_prob, r_prob, lane_width, v_ego):
   return lr_prob * d_poly_lane + (1.0 - lr_prob) * p_poly
 
 
-class LanePlanner():
+class LanePlanner:
   def __init__(self):
     self.l_poly = [0., 0., 0., 0.]
     self.r_poly = [0., 0., 0., 0.]

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -82,9 +82,10 @@ class LanePlanner():
       self.r_lane_change_prob = md.meta.desireState[log.PathPlan.Desire.laneChangeRight - 1]
 
   def update_d_poly(self, v_ego):
-    # only offset left and right lane lines; offsetting p_poly does not make sense
+    # only offset left and right lane lines; p_poly is the path of the camera
     self.l_poly[3] += CAMERA_OFFSET
     self.r_poly[3] += CAMERA_OFFSET
+    self.p_poly[3] += CAMERA_OFFSET - 0.06
 
     # Find current lanewidth
     self.lane_width_certainty += 0.05 * (self.l_prob * self.r_prob - self.lane_width_certainty)

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -82,7 +82,7 @@ class LanePlanner:
       self.r_lane_change_prob = md.meta.desireState[log.PathPlan.Desire.laneChangeRight - 1]
 
   def update_d_poly(self, v_ego):
-    # only offset left and right lane lines; p_poly is the path of the camera
+    # only offset left and right lane lines; p_poly is the path of the camera, not car
     self.l_poly[3] += CAMERA_OFFSET
     self.r_poly[3] += CAMERA_OFFSET
     self.p_poly[3] += CAMERA_OFFSET - 0.06


### PR DESCRIPTION
Just so if a user changes their camera offset offline or with a fork to compensate for their mount, it doesn't introduce oscillation when the lane lines are fading in and out, or if they are low confidence. Since they will be mismatched if not offsetting pPoly with the difference of the offset already in the path from the model.

This should have no effect on stock openpilot