### PR TITLE
Fix loggerd not rotating encoder if dcamera upload disabled

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -268,6 +268,12 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
           encoder_open(&encoder, encoder.next_path);
           encoder.segment = encoder.next_segment;
           encoder.rotating = false;
+          if (has_encoder_alt) {
+            encoder_close(&encoder_alt);
+            encoder_open(&encoder_alt, encoder_alt.next_path);
+            encoder_alt.segment = encoder_alt.next_segment;
+            encoder_alt.rotating = false;
+          }
           s.finish_close += 1;
           pthread_mutex_unlock(&s.rotate_lock);
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -118,10 +118,13 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
     LOGW("recording front camera");
 #endif
     set_thread_name("FrontCameraEncoder");
+    s.num_encoder += 1;
   } else if (cam_idx == CAM_IDX_FCAM) {
     set_thread_name("RearCameraEncoder");
+    s.num_encoder += 1;
   } else if (cam_idx == CAM_IDX_ECAM) {
     set_thread_name("WideCameraEncoder");
+    s.num_encoder += 1;
   } else {
     LOGE("unexpected camera index provided");
     assert(false);
@@ -607,16 +610,13 @@ int main(int argc, char** argv) {
 #ifndef DISABLE_ENCODER
   // rear camera
   std::thread encoder_thread_handle(encoder_thread, is_streaming, false, CAM_IDX_FCAM);
-  s.num_encoder += 1;
 
   // front camera
   std::thread front_encoder_thread_handle(encoder_thread, false, false, CAM_IDX_DCAM);
-  s.num_encoder += 1;
 
   #ifdef QCOM2
   // wide camera
   std::thread wide_encoder_thread_handle(encoder_thread, false, false, CAM_IDX_ECAM);
-  s.num_encoder += 1;
   #endif
 #endif
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -112,11 +112,11 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
   // 0:f, 1:d, 2:e
   if (cam_idx == CAM_IDX_DCAM) {
   // TODO: add this back
-#ifndef QCOM2
+  #ifndef QCOM2
     std::vector<char> value = read_db_bytes("RecordFront");
     if (value.size() == 0 || value[0] != '1') return;
     LOGW("recording front camera");
-#endif
+  #endif
     set_thread_name("FrontCameraEncoder");
   } else if (cam_idx == CAM_IDX_FCAM) {
     set_thread_name("RearCameraEncoder");
@@ -134,7 +134,11 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
   EncoderState encoder_alt;
   bool has_encoder_alt = false;
 
+  pthread_mutex_lock(&s.rotate_lock);
+  int my_idx = s.num_encoder;
   s.num_encoder += 1;
+  pthread_mutex_unlock(&s.rotate_lock);
+
   int encoder_segment = -1;
   int cnt = 0;
 
@@ -215,10 +219,10 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
                  && !do_exit) {
             s.cv.wait(lk);
           }
-          should_rotate = extra.frame_id > s.rotate_last_frame_id && encoder_segment < s.rotate_segment && s.rotate_seq_id == cam_idx;
+          should_rotate = extra.frame_id > s.rotate_last_frame_id && encoder_segment < s.rotate_segment && s.rotate_seq_id == my_idx;
         } else {
           // front camera is best effort
-          should_rotate = encoder_segment < s.rotate_segment && s.rotate_seq_id == cam_idx;
+          should_rotate = encoder_segment < s.rotate_segment && s.rotate_seq_id == my_idx;
         }
         if (do_exit) break;
 
@@ -227,7 +231,7 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
           LOG("rotate encoder to %s", s.segment_path);
 
           encoder_rotate(&encoder, s.segment_path, s.rotate_segment);
-          s.rotate_seq_id = (cam_idx + 1) % s.num_encoder;
+          s.rotate_seq_id = (my_idx + 1) % s.num_encoder;
 
           if (has_encoder_alt) {
             encoder_rotate(&encoder_alt, s.segment_path, s.rotate_segment);
@@ -250,7 +254,7 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
           pthread_mutex_unlock(&s.rotate_lock);
 
           while(s.should_close > 0 && s.should_close < s.num_encoder) {
-            // printf("%d waiting for others to reach close, %d/%d \n", cam_idx, s.should_close, s.num_encoder);
+            // printf("%d waiting for others to reach close, %d/%d \n", my_idx, s.should_close, s.num_encoder);
             s.cv.wait(lk);
           }
 
@@ -268,7 +272,7 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
           pthread_mutex_unlock(&s.rotate_lock);
 
           while(s.finish_close > 0 && s.finish_close < s.num_encoder) {
-            // printf("%d waiting for others to actually close, %d/%d \n", cam_idx, s.finish_close, s.num_encoder);
+            // printf("%d waiting for others to actually close, %d/%d \n", my_idx, s.finish_close, s.num_encoder);
             s.cv.wait(lk);
           }
           s.finish_close = 0;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -118,13 +118,10 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
     LOGW("recording front camera");
 #endif
     set_thread_name("FrontCameraEncoder");
-    s.num_encoder += 1;
   } else if (cam_idx == CAM_IDX_FCAM) {
     set_thread_name("RearCameraEncoder");
-    s.num_encoder += 1;
   } else if (cam_idx == CAM_IDX_ECAM) {
     set_thread_name("WideCameraEncoder");
-    s.num_encoder += 1;
   } else {
     LOGE("unexpected camera index provided");
     assert(false);
@@ -137,6 +134,7 @@ void encoder_thread(bool is_streaming, bool raw_clips, int cam_idx) {
   EncoderState encoder_alt;
   bool has_encoder_alt = false;
 
+  s.num_encoder += 1;
   int encoder_segment = -1;
   int cnt = 0;
 

--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -89,7 +89,7 @@ class TestLoggerd(unittest.TestCase):
         # check frame count
         cmd = f"ffprobe -v error -count_frames -select_streams v:0 -show_entries stream=nb_read_frames \
                -of default=nokey=1:noprint_wrappers=1 {file_path}"
-        expected_frames = self.segment_length * CAMERA_FPS
+        expected_frames = self.segment_length * CAMERA_FPS // 2 if (EON and camera=='dcamera') else self.segment_length * CAMERA_FPS
         frame_count = int(subprocess.check_output(cmd, shell=True, encoding='utf8').strip())
         self.assertTrue(abs(expected_frames - frame_count) <= FRAME_TOLERANCE,
                         f"{camera} failed frame count check: expected {expected_frames}, got {frame_count}")

--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -12,7 +12,6 @@ from tqdm import trange
 
 from common.params import Params
 from common.hardware import EON, TICI
-from common.timeout import Timeout
 from selfdrive.test.helpers import with_processes
 from selfdrive.loggerd.config import ROOT, CAMERA_FPS
 

--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -26,6 +26,8 @@ if EON:
   }
 elif TICI:
   CAMERAS = {f"{c}camera": FULL_SIZE for c in ["f", "e", "d"]}
+else:
+  CAMERAS = {}
 
 ALL_CAMERA_COMBINATIONS = [(cameras,) for cameras in [CAMERAS, {k:CAMERAS[k] for k in CAMERAS if k!='dcamera'}]]
 

--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -22,6 +22,7 @@ if EON:
   CAMERAS = {
     "fcamera": FULL_SIZE,
     "dcamera": 770920,
+    "qcamera": 38533,
   }
 elif TICI:
   CAMERAS = {f"{c}camera": FULL_SIZE for c in ["f", "e", "d"]}
@@ -78,13 +79,17 @@ class TestLoggerd(unittest.TestCase):
     for i in trange(num_segments):
       # check each camera file size
       for camera, size in cameras.items():
-        file_path = f"{route_prefix_path}--{i}/{camera}.hevc"
+        ext = "ts" if camera=='qcamera' else "hevc"
+        file_path = f"{route_prefix_path}--{i}/{camera}.{ext}"
 
         # check file size
         self.assertTrue(os.path.exists(file_path), f"couldn't find {file_path}")
         file_size = os.path.getsize(file_path)
         self.assertTrue(math.isclose(file_size, size, rel_tol=FILE_SIZE_TOLERANCE),
                         f"{camera} failed size check: expected {size}, got {file_size}")
+
+        if camera == 'qcamera':
+          continue
 
         # check frame count
         cmd = f"ffprobe -v error -count_frames -select_streams v:0 -show_entries stream=nb_read_frames \


### PR DESCRIPTION
**Description** as described in title, this is a bug introduced in #1953, and didn't get caught by the tests. should be a straightforward fix.
**Verification** include both test cases