### PR TITLE
Missing fingerprints should have higher priority than canError

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -197,7 +197,7 @@ class Controls:
                                                  LaneChangeState.laneChangeFinishing]:
       self.events.add(EventName.laneChange)
 
-    if self.can_rcv_error or (not CS.canValid and self.sm.frame > 5 / DT_CTRL):
+    if (self.can_rcv_error or (not CS.canValid and self.sm.frame > 5 / DT_CTRL)) and self.CP.carName != 'mock':
       self.events.add(EventName.canError)
     if self.mismatch_counter >= 200:
       self.events.add(EventName.controlsMismatch)


### PR DESCRIPTION
When mock car is detected, the canError can show up along with Dashcam mode. This makes troubleshooting with users very difficult. Dashcam mode, Car unrecognized should be shown even if there is a can error resulting of the missing fingerprint.
