### PR TITLE
dmonitoringmodeld: remove unused SubMaster

### DIFF
--- a/selfdrive/modeld/dmonitoringmodeld.cc
+++ b/selfdrive/modeld/dmonitoringmodeld.cc
@@ -32,8 +32,6 @@ int main(int argc, char **argv) {
   signal(SIGINT, (sighandler_t)set_do_exit);
   signal(SIGTERM, (sighandler_t)set_do_exit);
 
-  // messaging
-  SubMaster sm({"dMonitoringState"});
   PubMaster pm({"driverState"});
 
   // init the models


### PR DESCRIPTION
SubMaster is unused after https://github.com/commaai/openpilot/commit/349040d9580bf7c9b98273dd2745fc4b147d3254