### PR TITLE
driving.cc: Use circular buffer to reduce memory copy

### DIFF
--- a/selfdrive/modeld/models/driving.h
+++ b/selfdrive/modeld/models/driving.h
@@ -52,6 +52,7 @@ struct ModelDataRaw {
 typedef struct ModelState {
   ModelFrame frame;
   float *output;
+  std::unique_ptr <float[]> input_frames_buf;
   float *input_frames;
   RunModel *m;
 #ifdef DESIRE


### PR DESCRIPTION
Save 768kb of memory copy per cycle

