### PR TITLE
fix bugs in params.cc and use blocking read&write

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -129,7 +129,7 @@ bool usb_connect() {
 
   const char *fw_sig_buf = panda->get_firmware_version();
   if (fw_sig_buf){
-    write_db_value("PandaFirmware", fw_sig_buf, 128);
+    write_db_value_blocking("PandaFirmware", fw_sig_buf, 128);
 
     // Convert to hex for offroad
     char fw_sig_hex_buf[16] = {0};
@@ -138,7 +138,7 @@ bool usb_connect() {
       fw_sig_hex_buf[2*i+1] = NIBBLE_TO_HEX((uint8_t)fw_sig_buf[i] & 0xF);
     }
 
-    write_db_value("PandaFirmwareHex", fw_sig_hex_buf, 16);
+    write_db_value_blocking("PandaFirmwareHex", fw_sig_hex_buf, 16);
     LOGW("fw signature: %.*s", 16, fw_sig_hex_buf);
 
     delete[] fw_sig_buf;
@@ -149,7 +149,7 @@ bool usb_connect() {
   if (serial_buf) {
     size_t serial_sz = strnlen(serial_buf, 16);
 
-    write_db_value("PandaDongleId", serial_buf, serial_sz);
+    write_db_value_blocking("PandaDongleId", serial_buf, serial_sz);
     LOGW("panda serial: %.*s", serial_sz, serial_buf);
 
     delete[] serial_buf;

--- a/selfdrive/common/params.h
+++ b/selfdrive/common/params.h
@@ -28,7 +28,9 @@ int delete_db_value(const char* key, bool persistent_param = false);
 
 // Reads a value from the params database, blocking until successful.
 // Inputs are the same as read_db_value.
-void read_db_value_blocking(const char* key, char** value, size_t* value_sz, bool persistent_param = false);
+int  read_db_value_blocking(const char* key, char** value, size_t* value_sz, bool persistent_param = false);
+
+int write_db_value_blocking(const char* key, const char* value, size_t value_size, bool persistent_param = false);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/selfdrive/ui/android/ui.cc
+++ b/selfdrive/ui/android/ui.cc
@@ -120,7 +120,7 @@ static void handle_vision_touch(UIState *s, int touch_x, int touch_y) {
     if (!s->scene.frontview) {
       s->scene.uilayout_sidebarcollapsed = !s->scene.uilayout_sidebarcollapsed;
     } else {
-      write_db_value("IsDriverViewEnabled", "0", 1);
+      write_db_value_blocking("IsDriverViewEnabled", "0", 1);
     }
   }
 }

--- a/selfdrive/ui/qt/settings.cc
+++ b/selfdrive/ui/qt/settings.cc
@@ -61,7 +61,7 @@ ParamsToggle::ParamsToggle(QString param, QString title, QString description, QS
 
 void ParamsToggle::checkboxClicked(int state){
   char value = state ? '1': '0';
-  write_db_value(param.toStdString().c_str(), &value, 1);
+  write_db_value_blocking(param.toStdString().c_str(), &value, 1);
 }
 
 SettingsWindow::SettingsWindow(QWidget *parent) : QWidget(parent) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -19,7 +19,7 @@ extern volatile sig_atomic_t do_exit;
 int write_param_float(float param, const char* param_name, bool persistent_param) {
   char s[16];
   int size = snprintf(s, sizeof(s), "%f", param);
-  return write_db_value(param_name, s, size < sizeof(s) ? size : sizeof(s), persistent_param);
+  return write_db_value_blocking(param_name, s, size < sizeof(s) ? size : sizeof(s), persistent_param);
 }
 
 void ui_init(UIState *s) {

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -210,7 +210,7 @@ int read_param(T* param, const char *param_name, bool persistent_param = false){
   char *value;
   size_t sz;
 
-  int result = read_db_value(param_name, &value, &sz, persistent_param);
+  int result = read_db_value_blocking(param_name, &value, &sz, persistent_param);
   if (result == 0){
     std::string s = std::string(value, sz); // value is not null terminated
     free(value);


### PR DESCRIPTION
1. fixed two bugs in params.cc:
   - read_db_bytes will return an Incorrect empty value if failed to get the lock.
   - read_db_value_blocking runs into a infinite loop if db file not exists.
2. add&use function write_db_value_blocking() to do blocking write