### PR TITLE
Name openpilot docker container

### DIFF
--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -5,6 +5,7 @@ xhost +local:root
 docker pull commaai/openpilot-sim:latest
 
 docker run --net=host\
+  --name openpilot_client \
   --rm \
   -it \
   --gpus all \


### PR DESCRIPTION
This PR names the docker container, which makes it easier to address.
For example it's easier to kill the container:
```
docker kill openpilot_client
```
