### PR TITLE
Add Flags to Control Simulator

### DIFF
--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -25,3 +25,17 @@ You can control openpilot driving in the simulation with the following keys
 |   3   |   Cruise cancel   |
 |   q   |     Exit all      |
 
+## Arguments
+Arguments for `start_openpilot_docker.sh`:
+```
+  -h, --help            show this help message and exit
+  --joystick
+  --town TOWN
+  --spawn_point NUM_SELECTED_SPAWN_POINT
+  --cloudyness CLOUDYNESS
+  --precipitation PRECIPITATION
+  --precipitation_deposits PRECIPITATION_DEPOSITS
+  --wind_intensity WIND_INTENSITY
+  --sun_azimuth_angle SUN_AZIMUTH_ANGLE
+  --sun_altitude_angle SUN_ALTITUDE_ANGLE
+```

--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -25,17 +25,5 @@ You can control openpilot driving in the simulation with the following keys
 |   3   |   Cruise cancel   |
 |   q   |     Exit all      |
 
-## Arguments
-Arguments for `start_openpilot_docker.sh`:
-```
-  -h, --help            show this help message and exit
-  --joystick
-  --town TOWN
-  --spawn_point NUM_SELECTED_SPAWN_POINT
-  --cloudyness CLOUDYNESS
-  --precipitation PRECIPITATION
-  --precipitation_deposits PRECIPITATION_DEPOSITS
-  --wind_intensity WIND_INTENSITY
-  --sun_azimuth_angle SUN_AZIMUTH_ANGLE
-  --sun_altitude_angle SUN_ALTITUDE_ANGLE
-```
+To see the options for changing the environment, such as the town, spawn point or precipitation, you can run `./start_openpilot_docker.sh --help`.
+This will print the help output inside the docker container. You need to exit the docker container before running `./start_openpilot_docker.sh` again.

--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -14,4 +14,4 @@ docker run --net=host\
   --shm-size 1G \
   -e DISPLAY=$DISPLAY \
   commaai/openpilot-sim:latest \
-  /bin/bash -c "cd tools && cd sim && sh tmux_script.sh"
+  /bin/bash -c "cd tools && cd sim && sh tmux_script.sh $*"

--- a/tools/sim/tmux_script.sh
+++ b/tools/sim/tmux_script.sh
@@ -2,5 +2,5 @@
 tmux new -d -s htop
 tmux send-keys "./launch_openpilot.sh" ENTER
 tmux neww
-tmux send-keys "./bridge.py" ENTER
+tmux send-keys "./bridge.py $*" ENTER
 tmux a


### PR DESCRIPTION
This PR adds flags to control the simulator environment, e.g. the town, spawn point and precipitation.
The docker image needs to be rebuild of course, so `bridge.py` and `tmux_script.sh` are updated.
