### PR TITLE
Present alert if fan isn't spinning

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -173,9 +173,9 @@ class Controls:
       self.events.add(EventName.lowMemory)
 
     if self.hw_type in [HwType.uno, HwType.dos]:
-      if self.sm['health'].fanSpeedRpm < (self.last_desired_fan_speed/2):
+      if self.sm['health'].fanSpeedRpm == 0 and self.last_desired_fan_speed > 50:
         self.events.add(EventName.fanMalfunction)
-      self.last_desired_fan_speed = self.sm['thermal'].fanSpeedRpm
+      self.last_desired_fan_speed = self.sm['thermal'].fanSpeed
 
     # Handle calibration status
     cal_status = self.sm['liveCalibration'].calStatus

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -159,12 +159,14 @@ class Controls:
       self.events.add(self.startup_event)
       self.startup_event = None
 
-    # Create events for battery, temperature, disk space, and memory
+    # Create events for battery, temperature, disk space, fan, and memory
     if self.sm['thermal'].batteryPercent < 1 and self.sm['thermal'].chargingError:
       # at zero percent battery, while discharging, OP should not allowed
       self.events.add(EventName.lowBattery)
     if self.sm['thermal'].thermalStatus >= ThermalStatus.red:
       self.events.add(EventName.overheat)
+    if not self.sm['thermal'].fanIsSpinning:
+      self.events.add(EventName.fanNotSpinning)
     if self.sm['thermal'].freeSpace < 0.07:
       # under 7% of space free no enable allowed
       self.events.add(EventName.outOfSpace)

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -471,6 +471,15 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
       Priority.LOW, VisualAlert.steerRequired, AudibleAlert.chimePrompt, 1., 2., 3.),
   },
 
+  EventName.fanNotSpinning: {
+    ET.WARNING: Alert(
+      "Device Fan Not Spinning",
+      "Risk of overheating",
+      AlertStatus.normal, AlertSize.mid,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, 0., 0., .2),
+    ET.NO_ENTRY: NoEntryAlert("Device fan is not spinning"),
+  },
+
   # ********** events that affect controls state transitions **********
 
   EventName.pcmEnable: {

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -471,12 +471,12 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
       Priority.LOW, VisualAlert.steerRequired, AudibleAlert.chimePrompt, 1., 2., 3.),
   },
 
-  EventName.fanNotSpinning: {
-    ET.WARNING: Alert(
-      "Device Fan Not Spinning",
+  EventName.fanMalfunction: {
+    ET.PERMANENT: Alert(
+      "Device Fan Malfunction",
       "Risk of overheating",
       AlertStatus.normal, AlertSize.mid,
-      Priority.LOW, VisualAlert.none, AudibleAlert.none, 0., 0., .2),
+      Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0., 0., .2)
   },
 
   # ********** events that affect controls state transitions **********

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -211,8 +211,6 @@ def wrong_car_mode_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: boo
 EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, bool], Alert]]]] = {
   # ********** events with no alerts **********
 
-  EventName.fanMalfunction: {},
-
   # ********** events only containing alerts displayed in all states **********
 
   EventName.debugAlert: {
@@ -474,7 +472,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
   EventName.fanMalfunction: {
     ET.PERMANENT: Alert(
       "Fan Malfunction",
-      "Reboot your Device",
+      "Contact Support",
       AlertStatus.normal, AlertSize.mid,
       Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0., 0., .2)
   },

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -473,8 +473,8 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
 
   EventName.fanMalfunction: {
     ET.PERMANENT: Alert(
-      "Device Fan Malfunction",
-      "Risk of overheating",
+      "Fan Malfunction",
+      "Reboot your Device",
       AlertStatus.normal, AlertSize.mid,
       Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0., 0., .2)
   },

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -477,7 +477,6 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
       "Risk of overheating",
       AlertStatus.normal, AlertSize.mid,
       Priority.LOW, VisualAlert.none, AudibleAlert.none, 0., 0., .2),
-    ET.NO_ENTRY: NoEntryAlert("Device fan is not spinning"),
   },
 
   # ********** events that affect controls state transitions **********

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -205,6 +205,11 @@ def thermald_thread():
 
     if health is not None:
       usb_power = health.health.usbPowerMode != log.HealthData.UsbPowerMode.client
+      # Previously attempted to set the fan speed 10+% but the fan is running at 0 rpm
+      if EON:
+        msg.thermal.fanIsSpinning = not (health.health.fanSpeedRpm == 0 and fan_speed >= 6553.5)
+      else:
+        msg.thermal.fanIsSpinning = not (health.health.fanSpeedRpm == 0 and fan_speed >= 10)
 
       # If we lose connection to the panda, wait 5 seconds before going offroad
       if health.health.hwType == log.HealthData.HwType.unknown:

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -205,11 +205,6 @@ def thermald_thread():
 
     if health is not None:
       usb_power = health.health.usbPowerMode != log.HealthData.UsbPowerMode.client
-      # Previously attempted to set the fan speed 10+% but the fan is running at 0 rpm
-      if EON:
-        msg.thermal.fanIsSpinning = not (health.health.fanSpeedRpm == 0 and fan_speed >= 6553.5)
-      else:
-        msg.thermal.fanIsSpinning = not (health.health.fanSpeedRpm == 0 and fan_speed >= 10)
 
       # If we lose connection to the panda, wait 5 seconds before going offroad
       if health.health.hwType == log.HealthData.HwType.unknown:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_car_models](../../selfdrive/test/test_car_models.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->

When a fan is spinning at 0 RPM but requested to spin at 10+% power, display a warning.