### PR TITLE
The correct (factory) way of displaying barriers on toyotas

### DIFF
--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -69,7 +69,7 @@ def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_dep
   values = {
     "RIGHT_LINE": 3 if right_lane_depart else 1 if right_line else 2,
     "LEFT_LINE": 3 if left_lane_depart else 1 if left_line else 2,
-    "BARRIERS" : 3 if left_lane_depart or right_lane_depart else 0,
+    "BARRIERS" : 3 if left_lane_depart else 2 if right_lane_depart else 0,
     "SET_ME_X0C": 0x0c,
     "SET_ME_X2C": 0x2c,
     "SET_ME_X38": 0x38,


### PR DESCRIPTION
**Description**
Currently, when departing lanes, only the left barrier is displayed on Toyota's MFD, this PR makes the MFD display the left hand side barrier when departing left lane and display the right hand side barrier when departing the right lane. (essentially partially mimicking the factory system's behaviour.)

**Verification**
I intentionally departed lanes and verified this works as expected and did not create any problems.

The image below shows what the MFD would display when the barrier signal is set to 0, 1, 2, and 3.
![barrier](https://user-images.githubusercontent.com/12470297/95178970-bfc5b600-080b-11eb-9cbc-7290ff461894.jpg)
