### PR TITLE
remove green temp processes

### DIFF
--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -208,9 +208,6 @@ interrupt_processes: List[str] = []
 # processes to end with SIGKILL instead of SIGTERM
 kill_processes = ['sensord']
 
-# processes to end if thermal conditions exceed Green parameters
-green_temp_processes = ['uploader']
-
 persistent_processes = [
   'thermald',
   'logmessaged',
@@ -480,16 +477,6 @@ def manager_thread():
 
   while 1:
     msg = messaging.recv_sock(thermal_sock, wait=True)
-
-    # heavyweight batch processes are gated on favorable thermal conditions
-    if msg.thermal.thermalStatus >= ThermalStatus.yellow:
-      for p in green_temp_processes:
-        if p in persistent_processes:
-          kill_managed_process(p)
-    else:
-      for p in green_temp_processes:
-        if p in persistent_processes:
-          start_managed_process(p)
 
     if msg.thermal.freeSpace < 0.05:
       logger_dead = True


### PR DESCRIPTION
We only upload qlogs while onroad now, and uploader doesn't use much in resources anymore. 