### PR TITLE
Use math instead of numpy for calculating TTC, on average 80% faster

### DIFF
--- a/selfdrive/controls/lib/fcw.py
+++ b/selfdrive/controls/lib/fcw.py
@@ -41,7 +41,7 @@ class FCWChecker():
     if delta < 0.1 or (math.sqrt(delta) + v_rel < 0.1):
       ttc = max_ttc
     else:
-      ttc = math.minimum(2 * x_lead / (math.sqrt(delta) + v_rel), max_ttc)
+      ttc = min(2 * x_lead / (math.sqrt(delta) + v_rel), max_ttc)
     return ttc
 
   def update(self, mpc_solution, cur_time, active, v_ego, a_ego, x_lead, v_lead, a_lead, y_lead, vlat_lead, fcw_lead, blinkers):

--- a/selfdrive/controls/lib/fcw.py
+++ b/selfdrive/controls/lib/fcw.py
@@ -1,4 +1,4 @@
-import numpy as np
+import math
 from collections import defaultdict
 
 from common.numpy_fast import interp
@@ -32,16 +32,16 @@ class FCWChecker():
     # then limit ARel so that v_lead will get to zero in no sooner than t_decel.
     # This helps underweighting ARel when v_lead is close to zero.
     t_decel = 2.
-    a_rel = np.minimum(a_rel, v_lead / t_decel)
+    a_rel = min(a_rel, v_lead / t_decel)
 
     # delta of the quadratic equation to solve for ttc
     delta = v_rel**2 + 2 * x_lead * a_rel
 
     # assign an arbitrary high ttc value if there is no solution to ttc
-    if delta < 0.1 or (np.sqrt(delta) + v_rel < 0.1):
+    if delta < 0.1 or (math.sqrt(delta) + v_rel < 0.1):
       ttc = max_ttc
     else:
-      ttc = np.minimum(2 * x_lead / (np.sqrt(delta) + v_rel), max_ttc)
+      ttc = math.minimum(2 * x_lead / (math.sqrt(delta) + v_rel), max_ttc)
     return ttc
 
   def update(self, mpc_solution, cur_time, active, v_ego, a_ego, x_lead, v_lead, a_lead, y_lead, vlat_lead, fcw_lead, blinkers):


### PR DESCRIPTION
Code I used to benchmark: https://pastebin.com/ryBV3Lby

Benchmark:

```
run(1000)
Numpy took 0.005 seconds
Math took 0.001 seconds
79.9933% faster
run(10000)
Numpy took 0.04801 seconds
Math took 0.008 seconds
83.3333% faster
run(100000)
Numpy took 0.49011 seconds
Math took 0.08602 seconds
82.4489% faster
run(1000000)
Numpy took 4.97812 seconds
Math took 0.84819 seconds
82.9617% faster
```