### PR TITLE
boardd always send can packet

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -43,6 +43,7 @@ volatile sig_atomic_t do_exit = 0;
 bool spoofing_started = false;
 bool fake_send = false;
 bool connected_once = false;
+bool ignition = false;
 
 struct tm get_time(){
   time_t rawtime;
@@ -252,7 +253,9 @@ void can_recv_thread() {
       useconds_t sleep = remaining / 1000;
       usleep(sleep);
     } else {
-      LOGW("missed cycles (%d) %lld", (int)-1*remaining/dt, remaining);
+      if (ignition){
+        LOGW("missed cycles (%d) %lld", (int)-1*remaining/dt, remaining);
+      }
       next_frame_time = cur_time;
     }
 
@@ -293,7 +296,7 @@ void can_health_thread() {
       panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
     }
 
-    bool ignition = ((health.ignition_line != 0) || (health.ignition_can != 0));
+    ignition = ((health.ignition_line != 0) || (health.ignition_can != 0));
 
     if (ignition) {
       no_ignition_cnt = 0;

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -190,10 +190,8 @@ void can_recv(PubMaster &pm) {
   // create message
   MessageBuilder msg;
   auto event = msg.initEvent();
-  int recv = panda->can_receive(event);
-  if (recv){
-    pm.send("can", msg);
-  }
+  panda->can_receive(event);
+  pm.send("can", msg);
 }
 
 void can_send_thread() {

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -321,11 +321,10 @@ int Panda::can_receive(cereal::Event::Builder &event){
   uint32_t data[RECV_SIZE/4];
   int recv = usb_bulk_read(0x81, (unsigned char*)data, RECV_SIZE);
 
-  // return if length is 0
-  if (recv <= 0) {
-    event.initCan(0);
-    return 0;
-  } else if (recv == RECV_SIZE) {
+  // Not sure if this can happen
+  if (recv < 0) recv = 0;
+
+  if (recv == RECV_SIZE) {
     LOGW("Receive buffer full");
   }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -323,6 +323,7 @@ int Panda::can_receive(cereal::Event::Builder &event){
 
   // return if length is 0
   if (recv <= 0) {
+    event.initCan(0);
     return 0;
   } else if (recv == RECV_SIZE) {
     LOGW("Receive buffer full");


### PR DESCRIPTION
Previously if no messages were seen on the bus the message would not be sent. This makes timing analysis a lot harder.