### PR TITLE
fix building dmonitoringmodeld on pc

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -108,6 +108,7 @@ else:
     ]
 
   rpath = [
+    "phonelibs/snpe/x86_64-linux-clang",
     "external/tensorflow/lib",
     "cereal",
     "selfdrive/common"


### PR DESCRIPTION
running scons on ubuntu 20.04 fails:
```
$ scons
scons: Reading SConscript files ...

scons: warning: Could not detect qt, using moc executable as a hint (QTDIR=/usr)
File "/home/greg/openpilot/SConstruct", line 213, in <module>
scons: done reading SConscript files.
scons: Building targets ...
clang++ -o selfdrive/modeld/_dmonitoringmodeld -Wl,-rpath=/home/greg/openpilot/external/tensorflow/lib -Wl,-rpath=/home/greg/openpilot/cereal -Wl,-rpath=/home/greg/openpilot/selfdrive/common selfdrive/modeld/dmonitoringmodeld.o selfdrive/modeld/models/dmonitoring.o selfdrive/modeld/models/commonmodel.o selfdrive/modeld/runners/snpemodel.o selfdrive/modeld/transforms/loadyuv.o selfdrive/modeld/transforms/transform.o selfdrive/modeld/runners/tfmodel.o -Lphonelibs/snpe/x86_64-linux-clang -Lphonelibs/libyuv/x64/lib -Lexternal/tensorflow/lib -Lcereal -Lselfdrive/common -L/usr/lib -L/usr/local/lib -Lcereal -Lselfdrive/common -Lphonelibs cereal/libcereal.a cereal/libmessaging.a selfdrive/common/libcommon.a -ljson11 -lOpenCL -lSNPE -lsymphony-cpu -lcapnp -lzmq -lkj -lyuv selfdrive/common/libgpucommon.a -lGL selfdrive/common/libvisionipc.a -lpthread
/usr/bin/ld: warning: libomp.so, needed by phonelibs/snpe/x86_64-linux-clang/libSNPE.so, not found (try using -rpath or -rpath-link)
/usr/bin/ld: phonelibs/snpe/x86_64-linux-clang/libSNPE.so: undefined reference to `__kmpc_end_single@VERSION'
/usr/bin/ld: phonelibs/snpe/x86_64-linux-clang/libSNPE.so: undefined reference to `omp_set_num_threads@VERSION'
/usr/bin/ld: phonelibs/snpe/x86_64-linux-clang/libSNPE.so: undefined reference to `__kmpc_single@VERSION'
/usr/bin/ld: phonelibs/snpe/x86_64-linux-clang/libSNPE.so: undefined reference to `omp_get_num_threads@VERSION'
/usr/bin/ld: phonelibs/snpe/x86_64-linux-clang/libSNPE.so: undefined reference to `__kmpc_global_thread_num@VERSION'
/usr/bin/ld: phonelibs/snpe/x86_64-linux-clang/libSNPE.so: undefined reference to `__kmpc_fork_call@VERSION'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [selfdrive/modeld/_dmonitoringmodeld] Error 1
scons: building terminated because of errors.
```

clang version:
```
$ clang --version
clang version 10.0.0-4ubuntu1 
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```