### PR TITLE
fix build warning

### DIFF
--- a/selfdrive/common/util.c
+++ b/selfdrive/common/util.c
@@ -52,7 +52,7 @@ int write_file(const char* path, const void* data, size_t size) {
   }
   ssize_t n = write(fd, data, size);
   close(fd);
-  return n == (ssize_t)size ? 0 : -1;
+  return (n >= 0 && (size_t)n == size) ? 0 : -1;
 }
 
 void set_thread_name(const char* name) {

--- a/selfdrive/common/util.c
+++ b/selfdrive/common/util.c
@@ -52,7 +52,7 @@ int write_file(const char* path, const void* data, size_t size) {
   }
   ssize_t n = write(fd, data, size);
   close(fd);
-  return n == size ? 0 : -1;
+  return n == (ssize_t)size ? 0 : -1;
 }
 
 void set_thread_name(const char* name) {


### PR DESCRIPTION
`util.c:55:12: warning: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]`