### PR TITLE
Hyundai Veloster fingerprint

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -235,7 +235,10 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7e0, None): [b'\x01TJS-JNU06F200H0A', ],
     (Ecu.eps, 0x7d4, None): [b'\xf1\x00JSL MDPS C 1.00 1.03 56340-J3000 8308', ],
     (Ecu.fwdCamera, 0x7c4, None): [b'\xf1\x00JS  LKAS AT USA LHD 1.00 1.02 95740-J3000 K32', ],
-    (Ecu.transmission, 0x7e1, None): [b'\xf1\x816U2V8051\x00\x00\xf1\x006U2V0_C2\x00\x006U2V8051\x00\x00DJS0T16NS1\xba\x02\xb8\x80', ],
+    (Ecu.transmission, 0x7e1, None): [
+      b'\xf1\x816U2V8051\x00\x00\xf1\x006U2V0_C2\x00\x006U2V8051\x00\x00DJS0T16NS1\xba\x02\xb8\x80',
+      b'\xf1\x816U2V8051\x00\x00\xf1\x006U2V0_C2\x00\x006U2V8051\x00\x00DJS0T16NS1\x00\x00\x00\x00',
+    ],
   },
   CAR.GENESIS_G70: {
     (Ecu.fwdRadar, 0x7d0, None): [b'\xf1\x00IK__ SCC F-CUP      1.00 1.02 96400-G9100         \xf1\xa01.02', ],

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -7,7 +7,7 @@ Ecu = car.CarParams.Ecu
 # Steer torque limits
 class SteerLimitParams:
   def __init__(self, CP):
-    if CP.carFingerprint in [CAR.SONATA, CAR.PALISADE]:
+    if CP.carFingerprint in [CAR.SONATA, CAR.PALISADE, CAR.VELOSTER]:
       self.STEER_MAX = 384
     else:
       self.STEER_MAX = 255

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -7,7 +7,7 @@ Ecu = car.CarParams.Ecu
 # Steer torque limits
 class SteerLimitParams:
   def __init__(self, CP):
-    if CP.carFingerprint in [CAR.SONATA, CAR.PALISADE, CAR.VELOSTER]:
+    if CP.carFingerprint in [CAR.SONATA, CAR.PALISADE]:
       self.STEER_MAX = 384
     else:
       self.STEER_MAX = 255


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->
**Description** At times the Veloster is not detected on Comma Two boot, which requires power cycle of the Comma Two until it works. I believe the issue is that the carFw is detecting transmission differently each time mock is shown in user admin, so I've added the alternate fw detected there to the array.
Also noticed that Veloster was not included with 384 STEER_MAX, I have tested this extensively and never had an issue.

**Verification** Have tested a few starts since and the issue has not occurred again. 384 STEER_MAX has also never caused an issue for my vehicle with months of testing.

**Route**
Route: d624b3d19adce635