### PR TITLE
Abstract set_unsafe_mode function to Panda

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -107,6 +107,8 @@ void safety_setter_thread() {
   cereal::CarParams::Reader car_params = cmsg.getRoot<cereal::CarParams>();
   cereal::CarParams::SafetyModel safety_model = car_params.getSafetyModel();
 
+  panda->set_unsafe_mode(0);  // see safety_declarations.h for allowed values
+
   auto safety_param = car_params.getSafetyParam();
   LOGW("setting safety model: %d with param %d", (int)safety_model, safety_param);
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -188,7 +188,7 @@ void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, int sa
   usb_write(0xdc, (uint16_t)safety_model, safety_param);
 }
 
-void Panda::set_unsafe_mode(int unsafe_mode) {
+void Panda::set_unsafe_mode(uint16_t unsafe_mode) {
   usb_write(0xdf, unsafe_mode, 0);
 }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -189,7 +189,7 @@ void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, int sa
 }
 
 void Panda::set_unsafe_mode(int unsafe_mode) {
-  panda->usb_write(0xdf, unsafe_mode, 0);
+  usb_write(0xdf, unsafe_mode, 0);
 }
 
 cereal::HealthData::HwType Panda::get_hw_type() {

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -188,6 +188,10 @@ void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, int sa
   usb_write(0xdc, (uint16_t)safety_model, safety_param);
 }
 
+void Panda::set_unsafe_mode(int unsafe_mode) {
+  panda->usb_write(0xdf, unsafe_mode, 0);
+}
+
 cereal::HealthData::HwType Panda::get_hw_type() {
   unsigned char hw_query[1] = {0};
 

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -63,6 +63,7 @@ class Panda {
   // Panda functionality
   cereal::HealthData::HwType get_hw_type();
   void set_safety_model(cereal::CarParams::SafetyModel safety_model, int safety_param=0);
+  void set_unsafe_mode(int unsafe_mode);
   void set_rtc(struct tm sys_time);
   struct tm get_rtc();
   void set_fan_speed(uint16_t fan_speed);

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -63,7 +63,7 @@ class Panda {
   // Panda functionality
   cereal::HealthData::HwType get_hw_type();
   void set_safety_model(cereal::CarParams::SafetyModel safety_model, int safety_param=0);
-  void set_unsafe_mode(int unsafe_mode);
+  void set_unsafe_mode(uint16_t unsafe_mode);
   void set_rtc(struct tm sys_time);
   struct tm get_rtc();
   void set_fan_speed(uint16_t fan_speed);


### PR DESCRIPTION
Provides an easy function for forkers to use to set various unsafe modes without modifying panda fw or using a raw USB command.