### PR TITLE
Try to fix TSS2 creep with higher stopping target

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -10,9 +10,9 @@ STOPPING_TARGET_SPEED = MIN_CAN_SPEED + 0.01
 STARTING_TARGET_SPEED = 0.5
 BRAKE_THRESHOLD_TO_PID = 0.2
 
-STOPPING_BRAKE_RATE = 0.2  # brake_travel/s while trying to stop
-STARTING_BRAKE_RATE = 0.8  # brake_travel/s while releasing on restart
-BRAKE_STOPPING_TARGET = 0.5  # apply at least this amount of brake to maintain the vehicle stationary
+STOPPING_BRAKE_RATE = 2 * 0.2  # brake_travel/s while trying to stop
+STARTING_BRAKE_RATE = 2 * 0.8  # brake_travel/s while releasing on restart
+BRAKE_STOPPING_TARGET = 2 * 0.5  # apply at least this amount of brake to maintain the vehicle stationary
 
 RATE = 100.0
 


### PR DESCRIPTION
If these tuning values fix the TSS2 creep, and still provide smooth stopping I can put them in carParams so they can be tuned on a vehicle by vehicle basis.

Original discussion: https://github.com/commaai/openpilot/issues/1270

I think we need to increase start/stopping speed as well to maintain the same resume speed from a stop. If these values work we also need to make sure we only change them for the vehicles that need it and keep other cars the same.