### PR TITLE
AcuraWatch is standard on 2019+ Acura RDX

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Supported Cars
 | ----------| ------------------------------| ------------------| -----------------| -------------------| ------------------|
 | Acura     | ILX 2016-18                   | AcuraWatch Plus   | openpilot        | 25mph<sup>1</sup>  | 25mph             |
 | Acura     | RDX 2016-18                   | AcuraWatch Plus   | openpilot        | 25mph<sup>1</sup>  | 12mph             |
-| Acura     | RDX 2020                      | AcuraWatch        | Stock            | 0mph               | 3mph              |
+| Acura     | RDX 2020                      | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Accord 2018-20                | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Accord Hybrid 2018-20         | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Civic Hatchback 2017-19       | Honda Sensing     | Stock            | 0mph               | 12mph             |


### PR DESCRIPTION
**Description**: Fix the supported car list in README. AcuraWatch is standard on the 3rd generation Acura RDX.

**Verification**: Acura's sales documentation