### PR TITLE
stop pc from spamming logs

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -753,7 +753,7 @@ int main(int argc, char** argv) {
 
     if (s.logger.part > -1) {
       new_segment = true;
-      if (tms - last_camera_seen_tms <= NO_CAMERA_PATIENCE) {
+      if (tms - last_camera_seen_tms <= NO_CAMERA_PATIENCE && s.num_encoder > 0) {
         for (int cid=0;cid<=MAX_CAM_IDX;cid++) {
           // this *should* be redundant on tici since all camera frames are synced
           new_segment &= (((s.rotate_state[cid].stream_frame_id >= s.rotate_state[cid].last_rotate_frame_id + segment_length * MAIN_FPS) &&


### PR DESCRIPTION
fix a bug where openpilot on pc will keep generating new segments if there is no encoder