### PR TITLE
set cpubw perf governor

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -19,6 +19,9 @@ function two_init {
   # openpilot gets all the cores
   echo 0-3 > /dev/cpuset/app/cpus
 
+  # set the cpubw governor to performance
+  echo "performance" > /sys/devices/soc/soc:qcom,cpubw/devfreq/soc:qcom,cpubw/governor
+
   # Collect RIL and other possibly long-running I/O interrupts onto CPU 1
   echo 1 > /proc/irq/78/smp_affinity_list # qcom,smd-modem (LTE radio)
   echo 1 > /proc/irq/33/smp_affinity_list # ufshcd (flash storage)


### PR DESCRIPTION
I don't know the power or thermal implications of this, but CPU <-> GPU transfers (which I think is just memcpy) are 4x faster with the change.

To be fair, I think if camerad is running this governor always sets the max frequency. But still.

With:

```
root@localhost:/data/data/com.termux/files/build/clmem$ ./a.out --mode=range --start=268435456 --end=268435456 --increment=1
[a.out] starting...

./a.out Starting...

WARNING: NVIDIA OpenCL platform not found - defaulting to first platform!

Running on...

QUALCOMM Adreno(TM)

Range Mode

Host to Device Bandwidth, 1 Device(s), Paged memory, direct access
   Transfer Size (Bytes)        Bandwidth(MB/s)
   268435456                    6281.2

Device to Host Bandwidth, 1 Device(s), Paged memory, direct access
   Transfer Size (Bytes)        Bandwidth(MB/s)
   268435456                    6558.0

Device to Device Bandwidth, 1 Device(s)
   Transfer Size (Bytes)        Bandwidth(MB/s)
   268435456                    19980.6

[a.out] test results...
PASSED

> exiting in 3 seconds: 3...2...1...done!
```

Without (powersave):

```
root@localhost:/data/data/com.termux/files/build/clmem$ ./a.out --mode=range --start=268435456 --end=268435456 --increment=1
[a.out] starting...

./a.out Starting...

WARNING: NVIDIA OpenCL platform not found - defaulting to first platform!

Running on...

QUALCOMM Adreno(TM)

Range Mode

Host to Device Bandwidth, 1 Device(s), Paged memory, direct access
   Transfer Size (Bytes)        Bandwidth(MB/s)
   268435456                    1204.1

Device to Host Bandwidth, 1 Device(s), Paged memory, direct access
   Transfer Size (Bytes)        Bandwidth(MB/s)
   268435456                    1201.8

Device to Device Bandwidth, 1 Device(s)
   Transfer Size (Bytes)        Bandwidth(MB/s)
   268435456                    19688.4

[a.out] test results...
PASSED

> exiting in 3 seconds: 3...2...1...done!
```