### PR TITLE
Upgrade pip in ubuntu setup

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -85,6 +85,9 @@ pyenv rehash
 
 # **** in python env ****
 
+#upgrades pip
+pip install --upgrade pip==20.2.4
+
 # install pipenv
 pip install pipenv==2020.8.13
 

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -85,7 +85,7 @@ pyenv rehash
 
 # **** in python env ****
 
-#upgrades pip
+# upgrade pip
 pip install --upgrade pip==20.2.4
 
 # install pipenv


### PR DESCRIPTION
Would previously get stuck at 119/230 indefinitely during the pipenv install process. Upgrading pip from 19.2.3 to 20.2.4 solves this. Tested using a fresh Ubuntu 20.04 installation.