### PR TITLE
TSS2 INDI tuning

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -195,13 +195,19 @@ class CarInterface(CarInterfaceBase):
 
     elif candidate in [CAR.COROLLA_TSS2, CAR.COROLLAH_TSS2]:
       stop_and_go = True
-      ret.safetyParam = 73
       ret.wheelbase = 2.63906
-      ret.steerRatio = 13.9
-      tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 3060. * CV.LB_TO_KG + STD_CARGO_KG
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.1]]
-      ret.lateralTuning.pid.kf = 0.00007818594
+      ret.safetyParam = 53
+      ret.steerActuatorDelay = 0.60
+      ret.steerRatio = 15.33
+      tire_stiffness_factor = 0.996  # not optimized yet
+      ret.lateralTuning.init('indi')
+      ret.lateralTuning.indi.innerLoopGain = 9.0
+      ret.lateralTuning.indi.outerLoopGainBP = [20, 21, 25 ,26]
+      ret.lateralTuning.indi.outerLoopGainV = [5.0, 9.0, 9.0, 15.0]
+      ret.lateralTuning.indi.timeConstant = 5.5
+      ret.lateralTuning.indi.actuatorEffectiveness = 9.0
+      
 
     elif candidate in [CAR.LEXUS_ES_TSS2, CAR.LEXUS_ESH_TSS2]:
       stop_and_go = True

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -204,7 +204,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.init('indi')
       ret.lateralTuning.indi.innerLoopGain = 15.0
       ret.lateralTuning.indi.outerLoopGainBP = [20, 21, 25 ,26]
-      ret.lateralTuning.indi.outerLoopGainV = [4.0, 8.0, 8.0, 14.99]
+      ret.lateralTuning.indi.outerLoopGainV = [4.0, 8.5, 9.0, 14.99]
       ret.lateralTuning.indi.timeConstant = 5.5
       ret.lateralTuning.indi.actuatorEffectiveness = 15.0
       

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -204,7 +204,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.init('indi')
       ret.lateralTuning.indi.innerLoopGain = 15.0
       ret.lateralTuning.indi.outerLoopGainBP = [20, 21, 25 ,26]
-      ret.lateralTuning.indi.outerLoopGainV = [5.0, 9.0, 9.0, 14.99]
+      ret.lateralTuning.indi.outerLoopGainV = [4.0, 8.0, 8.0, 14.99]
       ret.lateralTuning.indi.timeConstant = 5.5
       ret.lateralTuning.indi.actuatorEffectiveness = 15.0
       

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -202,11 +202,11 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 15.33
       tire_stiffness_factor = 0.996  # not optimized yet
       ret.lateralTuning.init('indi')
-      ret.lateralTuning.indi.innerLoopGain = 9.0
+      ret.lateralTuning.indi.innerLoopGain = 15.0
       ret.lateralTuning.indi.outerLoopGainBP = [20, 21, 25 ,26]
-      ret.lateralTuning.indi.outerLoopGainV = [5.0, 9.0, 9.0, 15.0]
+      ret.lateralTuning.indi.outerLoopGainV = [5.0, 9.0, 9.0, 14.99]
       ret.lateralTuning.indi.timeConstant = 5.5
-      ret.lateralTuning.indi.actuatorEffectiveness = 9.0
+      ret.lateralTuning.indi.actuatorEffectiveness = 15.0
       
 
     elif candidate in [CAR.LEXUS_ES_TSS2, CAR.LEXUS_ESH_TSS2]:


### PR DESCRIPTION
i dont expect this to be merged. i just wanted to call attention to some of the values used and encourage others to resubmit this tune in a more complete format. in order for this to be merged it may need to have dbc edited for safetyparam 53 (probably needs to be lived tuned as it varies on average per trim and even changes within the same car per minute), this tune also requires outerBP V support which i did not add yet and hope someone else will resubmit this tune with it, this tune also requires at least 3 routes from 3 seperate individuals which i do not have yet. for this tune to be complete it also requires steerup15 in panda/values however it does work well without it and it could be merged without it for now. i am submitting this pr, knowing it wont be merged, just to get the values seriously considered as i work on, doing injection test of steerup15, getting routes, adding support in PR for outerBP, and finding out if dbc needs to be edited or if interface alone can be edited  to change safetyparam. about 7 people have tested this and like it and anyone who approves of it can feel free to submit a new, complete PR, and take credit for it. i only want to help others have a better tune. if anyone wants to test it, it is for corollatss2 only, it is on jamcar23 fork r2++(full tune) and shanes SA(with no steerup15). i look forward to a more complete PR in the future. thanks for your consideration.