### PR TITLE
Add Genesis G80 to special panda safety mode

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -181,7 +181,7 @@ class CarInterface(CarInterfaceBase):
 
     # these cars require a special panda safety mode due to missing counters and checksums in the messages
     if candidate in [CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_LTD, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_2019,
-                     CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70]:
+                     CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70, CAR.GENESIS_G80]:
       ret.safetyModel = car.CarParams.SafetyModel.hyundaiLegacy
 
     ret.centerToFront = ret.wheelbase * 0.4


### PR DESCRIPTION
**Description** Upon activating OP in 2018 Genesis G80, screen immediately shows "Take Control Immediately, Controls Mismatch" and disengages. This PR is to add the G80 to special panda safety mode to resolve this issue.

**Verification** I was able to verify by driving my G80 on my fork and engage OP without encountering the Controls Mismatch screen. I am unable to provide the exact route because I am unable to connect my device with Comma Connect (scanning QR code doesn't do anything), so I don't have access to useradmin.

**Route**
Route: 6b301bf83f10aa90\|2020-11-22--16-45-07
