### PR TITLE
simplify building message

### DIFF
--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -2143,11 +2143,11 @@ void camera_process_frame(MultiCameraState *s, CameraState *c, int cnt) {
     if (env_send_rear) {
       fill_frame_image(framed, (uint8_t*)b->cur_rgb_buf->addr, b->rgb_width, b->rgb_height, b->rgb_stride);
     }
-    framed.setFocusVal(kj::ArrayPtr<const int16_t>(&s->rear.focus[0], NUM_FOCUS));
-    framed.setFocusConf(kj::ArrayPtr<const uint8_t>(&s->rear.confidence[0], NUM_FOCUS));
-    framed.setSharpnessScore(kj::ArrayPtr<const uint16_t>(&s->lapres[0], ARRAYSIZE(s->lapres)));
+    framed.setFocusVal(s->rear.focus);
+    framed.setFocusConf(s->rear.confidence);
+    framed.setSharpnessScore(s->lapres);
     framed.setRecoverState(self_recover);
-    framed.setTransform(kj::ArrayPtr<const float>(&b->yuv_transform.v[0], 9));
+    framed.setTransform(b->yuv_transform.v);
     s->pm->send("frame", msg);
   }
 

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1114,7 +1114,7 @@ void camera_process_frame(MultiCameraState *s, CameraState *c, int cnt) {
     fill_frame_image(framed, (uint8_t*)b->cur_rgb_buf->addr, b->rgb_width, b->rgb_height, b->rgb_stride);
   }
   if (c == &s->rear) {
-    framed.setTransform(kj::ArrayPtr<const float>(&b->yuv_transform.v[0], 9));
+    framed.setTransform(b->yuv_transform.v);
   }
   s->pm->send(c == &s->rear ? "frame" : "wideFrame", msg);
 

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -267,7 +267,7 @@ void camera_process_rear(MultiCameraState *s, CameraState *c, int cnt) {
   auto framed = msg.initEvent().initFrame();
   fill_frame_data(framed, b->cur_frame_data, cnt);
   framed.setImage(kj::arrayPtr((const uint8_t *)b->yuv_ion[b->cur_yuv_idx].addr, b->yuv_buf_size));
-  framed.setTransform(kj::ArrayPtr<const float>(&b->yuv_transform.v[0], 9));
+  framed.setTransform(b->yuv_transform.v);
   s->pm->send("frame", msg);
 }
 

--- a/selfdrive/locationd/ublox_msg.cc
+++ b/selfdrive/locationd/ublox_msg.cc
@@ -213,8 +213,7 @@ kj::Array<capnp::word> UbloxMsgParser::gen_solution() {
   std::time_t utc_tt = timegm(&timeinfo);
   gpsLoc.setTimestamp(utc_tt * 1e+03 + msg->nano * 1e-06);
   float f[] = { msg->velN * 1e-03f, msg->velE * 1e-03f, msg->velD * 1e-03f };
-  kj::ArrayPtr<const float> ap(&f[0], sizeof(f) / sizeof(f[0]));
-  gpsLoc.setVNED(ap);
+  gpsLoc.setVNED(f);
   gpsLoc.setVerticalAccuracy(msg->vAcc * 1e-03);
   gpsLoc.setSpeedAccuracy(msg->sAcc * 1e-03);
   gpsLoc.setBearingAccuracy(msg->headAcc * 1e-05);
@@ -318,10 +317,8 @@ kj::Array<capnp::word> UbloxMsgParser::gen_nav_data() {
       eph.setTgd(ephem_data.Tgd);
       eph.setIonoCoeffsValid(ephem_data.ionoCoeffsValid);
       if(ephem_data.ionoCoeffsValid) {
-        kj::ArrayPtr<const double> apa(&ephem_data.ionoAlpha[0], sizeof(ephem_data.ionoAlpha) / sizeof(ephem_data.ionoAlpha[0]));
-        eph.setIonoAlpha(apa);
-        kj::ArrayPtr<const double> apb(&ephem_data.ionoBeta[0], sizeof(ephem_data.ionoBeta) / sizeof(ephem_data.ionoBeta[0]));
-        eph.setIonoBeta(apb);
+        eph.setIonoAlpha(ephem_data.ionoAlpha);
+        eph.setIonoBeta(ephem_data.ionoBeta);
       } else {
         eph.setIonoAlpha(kj::ArrayPtr<const double>());
         eph.setIonoBeta(kj::ArrayPtr<const double>());

--- a/selfdrive/modeld/models/dmonitoring.cc
+++ b/selfdrive/modeld/models/dmonitoring.cc
@@ -191,14 +191,10 @@ void dmonitoring_publish(PubMaster &pm, uint32_t frame_id, const DMonitoringResu
   framed.setFrameId(frame_id);
   framed.setModelExecutionTime(execution_time);
 
-  kj::ArrayPtr<const float> face_orientation(&res.face_orientation[0], ARRAYSIZE(res.face_orientation));
-  kj::ArrayPtr<const float> face_orientation_std(&res.face_orientation_meta[0], ARRAYSIZE(res.face_orientation_meta));
-  kj::ArrayPtr<const float> face_position(&res.face_position[0], ARRAYSIZE(res.face_position));
-  kj::ArrayPtr<const float> face_position_std(&res.face_position_meta[0], ARRAYSIZE(res.face_position_meta));
-  framed.setFaceOrientation(face_orientation);
-  framed.setFaceOrientationStd(face_orientation_std);
-  framed.setFacePosition(face_position);
-  framed.setFacePositionStd(face_position_std);
+  framed.setFaceOrientation(res.face_orientation);
+  framed.setFaceOrientationStd(res.face_orientation_meta);
+  framed.setFacePosition(res.face_position);
+  framed.setFacePositionStd(res.face_position_meta);
   framed.setFaceProb(res.face_prob);
   framed.setLeftEyeProb(res.left_eye_prob);
   framed.setRightEyeProb(res.right_eye_prob);

--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -62,10 +62,8 @@ void BMX055_Accel::get_event(cereal::SensorEventData::Builder &event){
   event.setTimestamp(start_time);
 
   float xyz[] = {x, y, z};
-  kj::ArrayPtr<const float> vs(&xyz[0], 3);
-
   auto svec = event.initAcceleration();
-  svec.setV(vs);
+  svec.setV(xyz);
   svec.setStatus(true);
 
 }

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -72,10 +72,8 @@ void BMX055_Gyro::get_event(cereal::SensorEventData::Builder &event){
   event.setTimestamp(start_time);
 
   float xyz[] = {x, y, z};
-  kj::ArrayPtr<const float> vs(&xyz[0], 3);
-
   auto svec = event.initGyroUncalibrated();
-  svec.setV(vs);
+  svec.setV(xyz);
   svec.setStatus(true);
 
 }

--- a/selfdrive/sensord/sensors/bmx055_magn.cc
+++ b/selfdrive/sensord/sensors/bmx055_magn.cc
@@ -96,10 +96,8 @@ void BMX055_Magn::get_event(cereal::SensorEventData::Builder &event){
     event.setTimestamp(start_time);
 
     float xyz[] = {x, y, z};
-    kj::ArrayPtr<const float> vs(&xyz[0], 3);
-
     auto svec = event.initMagneticUncalibrated();
-    svec.setV(vs);
+    svec.setV(xyz);
     svec.setStatus(true);
   }
 

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.cc
@@ -53,10 +53,8 @@ void LSM6DS3_Accel::get_event(cereal::SensorEventData::Builder &event){
   event.setTimestamp(start_time);
 
   float xyz[] = {y, -x, z};
-  kj::ArrayPtr<const float> vs(&xyz[0], 3);
-
   auto svec = event.initAcceleration();
-  svec.setV(vs);
+  svec.setV(xyz);
   svec.setStatus(true);
 
 }

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -56,10 +56,8 @@ void LSM6DS3_Gyro::get_event(cereal::SensorEventData::Builder &event){
   event.setTimestamp(start_time);
 
   float xyz[] = {y, -x, z};
-  kj::ArrayPtr<const float> vs(&xyz[0], 3);
-
   auto svec = event.initGyroUncalibrated();
-  svec.setV(vs);
+  svec.setV(xyz);
   svec.setStatus(true);
 
 }

--- a/selfdrive/sensord/sensors_qcom.cc
+++ b/selfdrive/sensord/sensors_qcom.cc
@@ -150,8 +150,7 @@ void sensor_loop() {
         switch (data.type) {
         case SENSOR_TYPE_ACCELEROMETER: {
           auto svec = log_event.initAcceleration();
-          kj::ArrayPtr<const float> vs(&data.acceleration.v[0], 3);
-          svec.setV(vs);
+          svec.setV(data.acceleration.v);
           svec.setStatus(data.acceleration.status);
           break;
         }
@@ -164,8 +163,7 @@ void sensor_loop() {
         }
         case SENSOR_TYPE_MAGNETIC_FIELD: {
           auto svec = log_event.initMagnetic();
-          kj::ArrayPtr<const float> vs(&data.magnetic.v[0], 3);
-          svec.setV(vs);
+          svec.setV(data.magnetic.v);
           svec.setStatus(data.magnetic.status);
           break;
         }
@@ -178,8 +176,7 @@ void sensor_loop() {
         }
         case SENSOR_TYPE_GYROSCOPE: {
           auto svec = log_event.initGyro();
-          kj::ArrayPtr<const float> vs(&data.gyro.v[0], 3);
-          svec.setV(vs);
+          svec.setV(data.gyro.v);
           svec.setStatus(data.gyro.status);
           break;
         }


### PR DESCRIPTION
KJ::ArrayPtr can be constructed from a native C-style array.

```
template <size_t size>
  inline constexpr ArrayPtr(T (&native)[size]): ptr(native), size_(size) {
```