### PR TITLE
Added fingerprint for 2020 Honda HRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Supported Cars
 | Honda     | CR-V 2017-20                  | Honda Sensing     | Stock            | 0mph               | 12mph             |
 | Honda     | CR-V Hybrid 2017-2019         | Honda Sensing     | Stock            | 0mph               | 12mph             |
 | Honda     | Fit 2018-19                   | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |
-| Honda     | HR-V 2019                     | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |
+| Honda     | HR-V 2019-20                  | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 12mph             |
 | Honda     | Insight 2019-20               | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Inspire 2018                  | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Odyssey 2018-20               | Honda Sensing     | openpilot        | 25mph<sup>1</sup>  | 0mph              |

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -946,6 +946,7 @@ FW_VERSIONS = {
   CAR.HRV: {
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-T7A-A010\x00\x00',
+      b'38897-T7A-A110\x00\x00',
     ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-THX-A020\x00\x00',
@@ -953,6 +954,7 @@ FW_VERSIONS = {
     (Ecu.fwdRadar, 0x18dab0f1, None): [
       b'36161-T7A-A140\x00\x00',
       b'36161-T7A-A240\x00\x00',
+      b'36161-T7A-C440\x00\x00',
     ],
     (Ecu.srs, 0x18da53f1, None): [
       b'77959-T7A-A230\x00\x00',
@@ -960,6 +962,7 @@ FW_VERSIONS = {
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-THX-A110\x00\x00',
       b'78109-THX-A210\x00\x00',
+      b'78109-THX-C220\x00\x00',
     ],
   },
 }


### PR DESCRIPTION
Added fingerprint for Canadian 2020 Honda HRV.

Dongle ID: a1feef02f9fa40de

Thanks to Discord user cptmher.