### PR TITLE
Fix toyota_eps_factor.py script

### DIFF
--- a/selfdrive/debug/toyota_eps_factor.py
+++ b/selfdrive/debug/toyota_eps_factor.py
@@ -18,14 +18,12 @@ def to_signed(n, bits):
 
 
 def get_eps_factor(lr, plot=False):
-  all_msgs = sorted(lr, key=lambda msg: msg.logMonoTime)
-
   engaged = False
   steering_pressed = False
   torque_cmd, eps_torque = None, None
   cmds, eps = [], []
 
-  for msg in all_msgs:
+  for msg in lr:
     if msg.which() != 'can':
       continue
 

--- a/selfdrive/debug/toyota_eps_factor.py
+++ b/selfdrive/debug/toyota_eps_factor.py
@@ -2,26 +2,32 @@
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn import linear_model # pylint: disable=import-error
+from sklearn import linear_model  # pylint: disable=import-error
 
 from tools.lib.route import Route
 from tools.lib.logreader import MultiLogIterator
 
+MIN_SAMPLES = 30 * 100
 
-MIN_SAMPLES = 30*100
 
 def to_signed(n, bits):
   if n >= (1 << max((bits - 1), 0)):
     n = n - (1 << max(bits, 0))
   return n
 
+
 def get_eps_factor(lr, plot=False):
+  all_msgs = sorted(lr, key=lambda msg: msg.logMonoTime)
 
   engaged = False
+  steering_pressed = False
   torque_cmd, eps_torque = None, None
   cmds, eps = [], []
 
-  for msg in lr:
+  for msg in all_msgs:
+    if msg.which() == 'carState':
+      steering_pressed = msg.carState.steeringpressed
+
     if msg.which() != 'can':
       continue
 
@@ -32,7 +38,7 @@ def get_eps_factor(lr, plot=False):
       elif m.address == 0x260 and m.src == 0:
         eps_torque = to_signed((m.dat[5] << 8) | m.dat[6], 16)
 
-    if engaged and torque_cmd is not None and eps_torque is not None:
+    if engaged and torque_cmd is not None and eps_torque is not None and not steering_pressed:
       cmds.append(torque_cmd)
       eps.append(eps_torque)
     else:
@@ -45,13 +51,14 @@ def get_eps_factor(lr, plot=False):
 
   lm = linear_model.LinearRegression(fit_intercept=False)
   lm.fit(np.array(cmds).reshape(-1, 1), eps)
-  scale_factor = 1./lm.coef_[0]
+  scale_factor = 1. / lm.coef_[0]
 
   if plot:
-    plt.plot(np.array(eps)*scale_factor)
+    plt.plot(np.array(eps) * scale_factor)
     plt.plot(cmds)
     plt.show()
   return scale_factor
+
 
 if __name__ == "__main__":
   r = Route(sys.argv[1])

--- a/selfdrive/debug/toyota_eps_factor.py
+++ b/selfdrive/debug/toyota_eps_factor.py
@@ -3,6 +3,7 @@ import sys
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn import linear_model  # pylint: disable=import-error
+from selfdrive.car.toyota.values import STEER_THRESHOLD
 
 from tools.lib.route import Route
 from tools.lib.logreader import MultiLogIterator
@@ -25,9 +26,6 @@ def get_eps_factor(lr, plot=False):
   cmds, eps = [], []
 
   for msg in all_msgs:
-    if msg.which() == 'carState':
-      steering_pressed = msg.carState.steeringPressed
-
     if msg.which() != 'can':
       continue
 
@@ -37,6 +35,7 @@ def get_eps_factor(lr, plot=False):
         torque_cmd = to_signed((m.dat[1] << 8) | m.dat[2], 16)
       elif m.address == 0x260 and m.src == 0:
         eps_torque = to_signed((m.dat[5] << 8) | m.dat[6], 16)
+        steering_pressed = abs(to_signed((m.dat[1] << 8) | m.dat[2], 16)) > STEER_THRESHOLD
 
     if engaged and torque_cmd is not None and eps_torque is not None and not steering_pressed:
       cmds.append(torque_cmd)

--- a/selfdrive/debug/toyota_eps_factor.py
+++ b/selfdrive/debug/toyota_eps_factor.py
@@ -26,7 +26,7 @@ def get_eps_factor(lr, plot=False):
 
   for msg in all_msgs:
     if msg.which() == 'carState':
-      steering_pressed = msg.carState.steeringpressed
+      steering_pressed = msg.carState.steeringPressed
 
     if msg.which() != 'can':
       continue


### PR DESCRIPTION
Previously the script was using samples where the user was touching the wheel, when that happens the EPS torque starts to behave similarly to `driverTorque`, not ideal. This now skips those samples.

What happens when `steeringPressed` is true:

![Screenshot_27](https://user-images.githubusercontent.com/25857203/100534542-acb0e000-31d5-11eb-8fab-5991af63d9d2.png)

I'm on my Windows laptop which doesn't have Docker to test this, anyone want to see how this changes the results? They should be much more consistent. Previously, I would get widely varied results from the same car from different routes.