### PR TITLE
Updated README to include 2020-2021 Honda Civic Hatchback

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Supported Cars
 | Acura     | RDX 2020                      | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Accord 2018-20                | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Accord Hybrid 2018-20         | All               | Stock            | 0mph               | 3mph              |
-| Honda     | Civic Hatchback 2017-19       | Honda Sensing     | Stock            | 0mph               | 12mph             |
+| Honda     | Civic Hatchback 2017-21       | Honda Sensing     | Stock            | 0mph               | 12mph             |
 | Honda     | Civic Sedan/Coupe 2016-18     | Honda Sensing     | openpilot        | 0mph               | 12mph             |
 | Honda     | Civic Sedan/Coupe 2019-20     | All               | Stock            | 0mph               | 2mph<sup>2</sup>  |
 | Honda     | CR-V 2015-16                  | Touring           | openpilot        | 25mph<sup>1</sup>  | 12mph             |


### PR DESCRIPTION
2020-2021 Honda Civic hatchbacks are currently working based on some user feedback.

2021 hatchback: 
https://discordapp.com/channels/469524606043160576/469532500335656972/779774528539983872

2020 hatchback:
https://discordapp.com/channels/469524606043160576/469532500335656972/771192621049053195