### PR TITLE
Add fingerprint for EU 2019 Civic Hatch

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -447,6 +447,7 @@ FW_VERSIONS = {
       b'37805-5BB-C630\x00\x00',
       b'37805-5BB-L540\x00\x00',
       b'37805-5BB-L640\x00\x00',
+      b'37805-5AZ-G740\x00\x00',
     ],
     (Ecu.transmission, 0x18da1ef1, None): [
       b'28101-5CG-A920\x00\x00',
@@ -463,6 +464,7 @@ FW_VERSIONS = {
       b'28101-5DJ-A610\x00\x00',
       b'28101-5DJ-A710\x00\x00',
       b'28101-5DV-E330\x00\x00',
+      b'28101-5DV-E610\x00\x00',
     ],
     (Ecu.vsa, 0x18da28f1, None): [
       b'57114-TBG-A340\x00\x00',
@@ -506,6 +508,7 @@ FW_VERSIONS = {
       b'78109-TGG-A810\x00\x00',
       b'78109-TGG-A820\x00\x00',
       b'78109-TGL-G120\x00\x00',
+      b'78109-TGL-G130\x00\x00',
     ],
     (Ecu.fwdRadar, 0x18dab0f1, None): [
       b'36802-TBA-A150\x00\x00',
@@ -523,6 +526,7 @@ FW_VERSIONS = {
       b'36161-TGG-A080\x00\x00',
       b'36161-TGG-A120\x00\x00',
       b'36161-TGL-G050\x00\x00',
+      b'36161-TGL-G070\x00\x00',
     ],
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-TBA-A110\x00\x00',
@@ -598,6 +602,7 @@ FW_VERSIONS = {
       b'46114-TLA-A050\x00\x00',
       b'46114-TLA-A930\x00\x00',
       b'46114-TMC-U020\x00\x00',
+      b'39494-TGL-G030\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TLA-A110\x00\x00',

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -600,7 +600,7 @@ FW_VERSIONS = {
       b'46114-TLA-A040\x00\x00',
       b'46114-TLA-A050\x00\x00',
       b'46114-TLA-A930\x00\x00',
-      b'46114-TMC-U020\x00\x00',      
+      b'46114-TMC-U020\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TLA-A110\x00\x00',

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -474,7 +474,6 @@ FW_VERSIONS = {
       b'57114-TGG-L320\x00\x00',
       b'57114-TGG-L330\x00\x00',
       b'57114-TGL-G330\x00\x00',
-
     ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-TBA-C020\x00\x00',
@@ -601,8 +600,7 @@ FW_VERSIONS = {
       b'46114-TLA-A040\x00\x00',
       b'46114-TLA-A050\x00\x00',
       b'46114-TLA-A930\x00\x00',
-      b'46114-TMC-U020\x00\x00',
-      b'39494-TGL-G030\x00\x00',
+      b'46114-TMC-U020\x00\x00',      
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TLA-A110\x00\x00',


### PR DESCRIPTION
Please close/delete PR #2695 and use this PR instead.

dongle ID: 88628232a4259218

This is for an EU 2019 Honda Civic hatchback, which was probably why the US Civic fingerprints didn't work.

Thanks to Discord user dave237.