### PR TITLE
make toyota accelation gentler at higher speed. It has better gas mileage as well

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -70,8 +70,7 @@ class CarController():
       apply_accel = actuators.gas - actuators.brake
 
     apply_accel, self.accel_steady = accel_hysteresis(apply_accel, self.accel_steady, enabled)
-
-    accel_max = interp(CS.v_ego, SPEEDS, ACCELS)
+    accel_max = interp(CS.out.vEgo, SPEEDS, ACCELS)
     scale = max(accel_max, -ACCEL_MIN)
     apply_accel = clip(apply_accel * scale, ACCEL_MIN, accel_max)
 


### PR DESCRIPTION
**Description** [] Toyota's acceleration max is set at 1.5 m/s2 as a constant. This fix is to lower the accel_max as the speed increases. The car will driver smoother and gas mileage will be better

**Verification** []I have been using this fix since March. You can read the code and test it.

**Route**
Route: highway, local ...
