### PR TITLE
Add STEER_TORQUE to car kalman filter

### DIFF
--- a/selfdrive/locationd/models/constants.py
+++ b/selfdrive/locationd/models/constants.py
@@ -37,6 +37,7 @@ class ObservationKind:
   STIFFNESS = 28  # [-]
   STEER_RATIO = 29  # [-]
   ROAD_FRAME_X_SPEED = 30  # (x) [m/s]
+  STEER_TORQUE = 31  # [torques?]
 
   names = [
     'Unknown',
@@ -68,6 +69,8 @@ class ObservationKind:
     'Fast Angle Offset',
     'Stiffness',
     'Steer Ratio',
+    'Road Frame x speed',
+    'Steer Torque',
   ]
 
   @classmethod


### PR DESCRIPTION
Some cars have bad angle sensors. If we switch the PID loop to use this, they will be improved.

I even wonder if this will make the angle offset more accurate across the board, since it feels the torque. But I don't really know.

Need to fix the hardcoded constants and do large scale stability tests.