### PR TITLE
GM: Fix to allow brakes to release on resume press

### DIFF
--- a/selfdrive/car/gm/gmcan.py
+++ b/selfdrive/car/gm/gmcan.py
@@ -35,14 +35,12 @@ def create_gas_regen_command(packer, bus, throttle, idx, acc_engaged, at_full_st
   return packer.make_can_msg("ASCMGasRegenCmd", bus, values)
 
 def create_friction_brake_command(packer, bus, apply_brake, idx, near_stop, at_full_stop):
-
-  if apply_brake == 0:
-    mode = 0x1
-  else:
+  mode = 0x1
+  if apply_brake > 0:
     mode = 0xa
+    if at_full_stop:
+      mode = 0xd
 
-  if at_full_stop:
-    mode = 0xd
     # TODO: this is to have GM bringing the car to complete stop,
     # but currently it conflicts with OP controls, so turned off.
     #elif near_stop:


### PR DESCRIPTION
**Description**
Fixes issue where GM vehicles can't resume from a stop by pressing the resume button.

A previous PR better matched the OEM brake mode transitions, however it created a regression.

Once mode 0xd (at full stop) has been entered, even sending a request for 0 brakes will not cause the brakes to be released.

This change updates the logic such that when a request for 0 brakes is sent, the mode is forced to mode 0x1. Which allows the brakes to release on resume press.

**Verification**
In the stopped state, verified the resume on button press functions as expected.

**Route**
Route: 160b5ba4a44512f2|2020-12-05--17-48-53--7