### PR TITLE
Discuss: don't dispatch tbuffer in CameraBuf::accquire

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -195,13 +195,11 @@ bool CameraBuf::acquire() {
   // keep another reference around till were done processing
   pool_acquire(&yuv_pool, cur_yuv_idx);
   pool_push(&yuv_pool, cur_yuv_idx);
-
-  tbuffer_dispatch(&ui_tb, cur_rgb_idx);
-
   return true;
 }
 
 void CameraBuf::release() {
+  tbuffer_dispatch(&ui_tb, cur_rgb_idx);
   pool_release(&yuv_pool, cur_yuv_idx);
 }
 


### PR DESCRIPTION
I don’t think we can call tbuffer_dispatch in CameraBuf::acquire. we still use this buffer(cur_rgb_buffer) at somewhere else such as  camera_process_frame(),dispatch it earyly may cause problems(Maybe the UI will also hang).

@ZwX1616  am I right?

related PR: https://github.com/commaai/openpilot/pull/2613