### PR TITLE
Move MCLK freq on tici

### DIFF
--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -287,7 +287,7 @@ void sensors_init(int video0_fd, int sensor_fd, int camera_num) {
   power->count = 1;
   power->cmd_type = CAMERA_SENSOR_CMD_TYPE_PWR_UP;
   power->power_settings[0].power_seq_type = 0;
-  power->power_settings[0].config_val_low = 28000000; //Hz
+  power->power_settings[0].config_val_low = 24000000; //Hz
   power = (struct cam_cmd_power *)((char*)power + (sizeof(struct cam_cmd_power) + (power->count-1)*sizeof(struct cam_power_settings)));
 
   unconditional_wait = (struct cam_cmd_unconditional_wait *)power;

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -287,7 +287,7 @@ void sensors_init(int video0_fd, int sensor_fd, int camera_num) {
   power->count = 1;
   power->cmd_type = CAMERA_SENSOR_CMD_TYPE_PWR_UP;
   power->power_settings[0].power_seq_type = 0;
-  power->power_settings[0].config_val_low = 24000000; //Hz
+  power->power_settings[0].config_val_low = 28000000; //Hz
   power = (struct cam_cmd_power *)((char*)power + (sizeof(struct cam_cmd_power) + (power->count-1)*sizeof(struct cam_power_settings)));
 
   unconditional_wait = (struct cam_cmd_unconditional_wait *)power;

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -266,8 +266,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x30B0, 0x0800}, // DIGITAL_TEST
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
-  {0x302E, 0x0006}, // PRE_PLL_CLK_DIV
-  {0x3030, 0x009A}, // PLL_MULTIPLIER
+  {0x302E, 0x0007}, // PRE_PLL_CLK_DIV
+  {0x3030, 0x0084}, // PLL_MULTIPLIER
   {0x3036, 0x000A}, // OP_WORD_CLK_DIV
   {0x3038, 0x0001}, // OP_SYS_CLK_DIV
   {0x30B0, 0x0800}, // DIGITAL_TEST

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -266,8 +266,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x30B0, 0x0800}, // DIGITAL_TEST
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
-  {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
-  {0x3030, 0x002C}, // PLL_MULTIPLIER
+  {0x302E, 0x0006}, // PRE_PLL_CLK_DIV
+  {0x3030, 0x009A}, // PLL_MULTIPLIER
   {0x3036, 0x000A}, // OP_WORD_CLK_DIV
   {0x3038, 0x0001}, // OP_SYS_CLK_DIV
   {0x30B0, 0x0800}, // DIGITAL_TEST

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -266,8 +266,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x30B0, 0x0800}, // DIGITAL_TEST
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
-  {0x302E, 0x0007}, // PRE_PLL_CLK_DIV
-  {0x3030, 0x0084}, // PLL_MULTIPLIER
+  {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
+  {0x3030, 0x0028}, // PLL_MULTIPLIER
   {0x3036, 0x000A}, // OP_WORD_CLK_DIV
   {0x3038, 0x0001}, // OP_SYS_CLK_DIV
   {0x30B0, 0x0800}, // DIGITAL_TEST


### PR DESCRIPTION
GPS really dislikes the 24MHz clock. This moves it out of the band.