### PR TITLE
Toyota: don't cut steering for 2 seconds after fault recovery

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -38,7 +38,6 @@ class CarController():
     self.last_standstill = False
     self.standstill_req = False
 
-    self.last_fault_frame = -200
     self.steer_rate_limited = False
 
     self.fake_ecus = set()
@@ -73,12 +72,8 @@ class CarController():
     apply_steer = apply_toyota_steer_torque_limits(new_steer, self.last_steer, CS.out.steeringTorqueEps, SteerLimitParams)
     self.steer_rate_limited = new_steer != apply_steer
 
-    # only cut torque when steer state is a known fault
-    if CS.steer_state in [9, 25]:
-      self.last_fault_frame = frame
-
-    # Cut steering for 2s after fault
-    if not enabled or (frame - self.last_fault_frame < 200):
+    # Cut steering while we're in a known fault state (2s)
+    if not enabled or CS.steer_state in [9, 25]:
       apply_steer = 0
       apply_steer_req = 0
     else:

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -519,7 +519,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
       "TAKE CONTROL",
       "Steering Temporarily Unavailable",
       AlertStatus.userPrompt, AlertSize.mid,
-      Priority.LOW, VisualAlert.steerRequired, AudibleAlert.chimeWarning1, .4, 2., 3.),
+      Priority.LOW, VisualAlert.steerRequired, AudibleAlert.chimeWarning1, .4, 2., 1.),
     ET.NO_ENTRY: NoEntryAlert("Steering Temporarily Unavailable",
                               duration_hud_alert=0.),
   },


### PR DESCRIPTION
When a fault occurs, LKA_STATE is 25 on rising edge, then 9 for ~200 frames. Since the code in carcontroller kept resetting the `last_fault_frame` variable, it only started the 2 second timer once the fault was over and steering was possible. Now instead it will start steering immediately after state returns to normal, so 4 seconds to 2 seconds of loss of control after a fault.

You can see here that after the first 2 seconds, the state is 1 (not applying torque but ready) for another 2 seconds when we could be steering again. I'm wondering if this breaks anything for other Toyotas, though It worked perfectly for my 17 Corolla.

![Screenshot_137](https://user-images.githubusercontent.com/25857203/102369853-08bf8680-3f82-11eb-9b0d-a9d94e18a880.png)