### PR TITLE
FIX: It is not safe to call cameras_close before all threads are done.

### DIFF
--- a/selfdrive/camerad/cameras/camera_frame_stream.cc
+++ b/selfdrive/camerad/cameras/camera_frame_stream.cc
@@ -117,6 +117,7 @@ void cameras_run(MultiCameraState *s) {
   std::thread t = start_process_thread(s, "processing", &s->rear, camera_process_rear);
   set_thread_name("frame_streaming");
   run_frame_stream(s);
-  cameras_close(s);
+
   t.join();
+  cameras_close(s);
 }

--- a/selfdrive/camerad/cameras/camera_frame_stream.cc
+++ b/selfdrive/camerad/cameras/camera_frame_stream.cc
@@ -25,7 +25,7 @@ void camera_open(CameraState *s, bool rear) {
 }
 
 void camera_close(CameraState *s) {
-  s->buf.stop();
+  // empty
 }
 
 void camera_init(VisionIpcServer * v, CameraState *s, int camera_id, unsigned int fps, cl_device_id device_id, cl_context ctx, VisionStreamType rgb_type, VisionStreamType yuv_type) {
@@ -118,6 +118,10 @@ void cameras_run(MultiCameraState *s) {
   set_thread_name("frame_streaming");
   run_frame_stream(s);
 
+  s->front.buf.stop();
+  s->rear.buf.stop();
+
   t.join();
+
   cameras_close(s);
 }

--- a/selfdrive/camerad/cameras/camera_frame_stream.cc
+++ b/selfdrive/camerad/cameras/camera_frame_stream.cc
@@ -117,11 +117,6 @@ void cameras_run(MultiCameraState *s) {
   std::thread t = start_process_thread(s, "processing", &s->rear, camera_process_rear);
   set_thread_name("frame_streaming");
   run_frame_stream(s);
-
-  s->front.buf.stop();
-  s->rear.buf.stop();
-
   t.join();
-
   cameras_close(s);
 }

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -1491,8 +1491,6 @@ void cameras_open(MultiCameraState *s) {
 
 
 static void camera_close(CameraState *s) {
-  s->buf.stop();
-
   // ISP: STOP_STREAM
   s->stream_cfg.cmd = STOP_STREAM;
   int err = ioctl(s->isp_fd, VIDIOC_MSM_ISP_CFG_STREAM, &s->stream_cfg);
@@ -1779,6 +1777,9 @@ void cameras_run(MultiCameraState *s) {
   }
 
   LOG(" ************** STOPPING **************");
+  // stop CameraBuf to wakeup CameraBuf::acquire
+  s->rear.buf.stop();
+  s->front.buf.stop();
 
   err = pthread_join(ops_thread_handle, NULL);
   assert(err == 0);

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -1783,9 +1783,11 @@ void cameras_run(MultiCameraState *s) {
   err = pthread_join(ops_thread_handle, NULL);
   assert(err == 0);
 
-  cameras_close(s);
+  for (auto &t : threads) {
+    t.join();
+  }
 
-  for (auto &t : threads) t.join();
+  cameras_close(s);
 }
 
 void cameras_close(MultiCameraState *s) {

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -1777,16 +1777,11 @@ void cameras_run(MultiCameraState *s) {
   }
 
   LOG(" ************** STOPPING **************");
-  // stop CameraBuf to wakeup CameraBuf::acquire
-  s->rear.buf.stop();
-  s->front.buf.stop();
 
   err = pthread_join(ops_thread_handle, NULL);
   assert(err == 0);
 
-  for (auto &t : threads) {
-    t.join();
-  }
+  for (auto &t : threads) t.join();
 
   cameras_close(s);
 }

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1192,19 +1192,11 @@ void cameras_run(MultiCameraState *s) {
   }
 
   LOG(" ************** STOPPING **************");
-  // stop CameraBuf to wakeup CameraBuf::acquire
-  s->rear.buf.stop();
-  s->wide.buf.stop();
-  s->front.buf.stop();
 
   err = pthread_join(ae_thread_handle, NULL);
   assert(err == 0);
 
-  for (auto &t : threads) {
-    t.join();
-  }
+  for (auto &t : threads) t.join();
 
   cameras_close(s);
-
-  for (auto &t : threads) t.join();
 }

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -903,7 +903,6 @@ static void camera_close(CameraState *s) {
 
   ret = cam_control(s->video0_fd, CAM_REQ_MGR_DESTROY_SESSION, &s->req_mgr_session_info, sizeof(s->req_mgr_session_info));
   LOGD("destroyed session: %d", ret);
-  s->buf.stop();
 }
 
 static void cameras_close(MultiCameraState *s) {
@@ -1193,6 +1192,10 @@ void cameras_run(MultiCameraState *s) {
   }
 
   LOG(" ************** STOPPING **************");
+  // stop CameraBuf to wakeup CameraBuf::acquire
+  s->rear.buf.stop();
+  s->wide.buf.stop();
+  s->front.buf.stop();
 
   err = pthread_join(ae_thread_handle, NULL);
   assert(err == 0);

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1197,6 +1197,10 @@ void cameras_run(MultiCameraState *s) {
   err = pthread_join(ae_thread_handle, NULL);
   assert(err == 0);
 
+  for (auto &t : threads) {
+    t.join();
+  }
+
   cameras_close(s);
 
   for (auto &t : threads) t.join();

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -272,14 +272,9 @@ void cameras_run(MultiCameraState *s) {
   set_thread_name("webcam_thread");
   front_thread(&s->front);
 
-  s->rear.buf.stop();
-  s->front.buf.stop();
-
   t_rear.join();
 
-  for (auto &t : threads) {
-    t.join();
-  }
+  for (auto &t : threads) t.join();
 
   cameras_close(s);
 }

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -31,7 +31,7 @@ void camera_open(CameraState *s, bool rear) {
 }
 
 void camera_close(CameraState *s) {
-  s->buf.stop();
+  // empty
 }
 
 void camera_init(VisionIpcServer * v, CameraState *s, int camera_id, unsigned int fps, cl_device_id device_id, cl_context ctx, VisionStreamType rgb_type, VisionStreamType yuv_type) {
@@ -271,7 +271,12 @@ void cameras_run(MultiCameraState *s) {
   std::thread t_rear = std::thread(rear_thread, &s->rear);
   set_thread_name("webcam_thread");
   front_thread(&s->front);
+
+  s->rear.buf.stop();
+  s->front.buf.stop();
+
   t_rear.join();
+
   for (auto &t : threads) {
     t.join();
   }

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -272,7 +272,9 @@ void cameras_run(MultiCameraState *s) {
   set_thread_name("webcam_thread");
   front_thread(&s->front);
   t_rear.join();
-  cameras_close(s);
+  for (auto &t : threads) {
+    t.join();
+  }
 
-  for (auto &t : threads) t.join();
+  cameras_close(s);
 }


### PR DESCRIPTION
call cameras_close after Thread().join()