### PR TITLE
Added pyenv-virtualenv to ubuntu install script

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -60,6 +60,7 @@ fi
 # install pyenv
 if ! command -v "pyenv" > /dev/null 2>&1; then
   curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+  git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
 fi
 
 # install bashrc


### PR DESCRIPTION
**Description**

~~After a fresh install on Ubuntu 20.04. `pyenv-virtualenv` was not installed, and caused an error when running `openpilot_env.sh`. Updated the install script to include `pyenv-virtualenv`.~~

This was in error. Openpilot was not cloned to `~/openpilot` and so that caused installation problems. Probably will work out a way to improve the script to prevent this in future...

**Verification**

~~I ran the exact command I added into the install script, and was successfully able to run `openpilot_env.sh`.~~