### PR TITLE
Add speed limit indicator

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -299,6 +299,8 @@ selfdrive/locationd/models/constants.py
 
 selfdrive/locationd/calibrationd.py
 
+selfdrive/locationd/speedlimitd.py
+
 selfdrive/logcatd/SConscript
 selfdrive/logcatd/logcatd_android.cc
 selfdrive/logcatd/logcatd_systemd.cc

--- a/selfdrive/debug/cpu_usage_stat.py
+++ b/selfdrive/debug/cpu_usage_stat.py
@@ -34,7 +34,7 @@ monitored_proc_names = [
   'controlsd', 'locationd', 'loggerd','plannerd',
   'ubloxd', 'thermald', 'uploader', 'deleter', 'radard', 'logmessaged', 'tombstoned',
   'logcatd', 'proclogd', 'boardd', 'pandad', './ui', 'ui', 'calibrationd', 'params_learner', 'modeld', 'dmonitoringd',
-  'dmonitoringmodeld', 'camerad', 'sensord', 'updated', 'gpsd', 'athena', 'locationd', 'paramsd',
+  'dmonitoringmodeld', 'camerad', 'sensord', 'updated', 'gpsd', 'athena', 'locationd', 'paramsd', 'speedlimitd',
 
   'ai.comma.plus.offroad',
 

--- a/selfdrive/locationd/speedlimitd.py
+++ b/selfdrive/locationd/speedlimitd.py
@@ -26,7 +26,7 @@ def try_fetch_speed_limit(gps_entries):
   json = None
   try:
     access_token = get_mapbox_access_token()
-    if access_token == None:
+    if access_token is None:
       cloudlog.info("Mapbox access token not found:", MAPBOX_ACCESS_TOKEN_PATH)
       return None
     data = {
@@ -37,7 +37,7 @@ def try_fetch_speed_limit(gps_entries):
       'tidy': 'true',
     }
     # print(data)
-    response = requests.post('https://api.mapbox.com/matching/v5/mapbox/driving?access_token=' + access_token, data=data)
+    response = requests.post('https://api.mapbox.com/matching/v5/mapbox/driving?access_token=' + access_token, data=data, timeout=10)
     json = response.json()
     # print(json)
 
@@ -83,7 +83,7 @@ def main(sm=None, pm=None):
       if len(gps_entries) > 2: # min allowed coordinates in an api call
         speed_limit = try_fetch_speed_limit(gps_entries)
         # print('SPEED LIMIT', speed_limit)
-        if speed_limit != None:
+        if speed_limit is not None:
           msg.liveMapData.speedLimitValid = True
           msg.liveMapData.speedLimit = speed_limit
         else:

--- a/selfdrive/locationd/speedlimitd.py
+++ b/selfdrive/locationd/speedlimitd.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import os
+from collections import deque
+
+import requests
+
+import cereal.messaging as messaging
+from common.basedir import PERSIST
+from selfdrive.config import Conversions as CV
+
+MAPBOX_ACCESS_TOKEN_PATH = PERSIST + '/mapbox/access_token'
+# permissions that match comma api rsa private key
+# os.chmod(PERSIST + '/mapbox/', 0o755)
+# os.chmod(PERSIST + '/mapbox/access_token', 0o744)
+
+
+def get_mapbox_access_token():
+  if not os.path.isfile(MAPBOX_ACCESS_TOKEN_PATH):
+    return None
+  with open(MAPBOX_ACCESS_TOKEN_PATH, 'r') as f:
+    return f.read().strip()
+
+
+def try_fetch_speed_limit(gps_entries):
+  try:
+    access_token = get_mapbox_access_token()
+    if access_token == None:
+      print("Mapbox access token not found:", MAPBOX_ACCESS_TOKEN_PATH)
+      return None
+    data = {
+      'coordinates': ';'.join(f"{x.longitude},{x.latitude}" for x in gps_entries),
+      'timestamps': ';'.join(str(x.timestamp) for x in gps_entries),
+      'overview': 'full',
+      'annotations': 'maxspeed',
+      'tidy': 'true',
+    }
+    # print(data)
+    response = requests.post('https://api.mapbox.com/matching/v5/mapbox/driving?access_token=' + access_token, data=data)
+    json = response.json()
+
+    for maxspeed in json['matchings'][-1]['legs'][-1]['annotation']['maxspeed']:
+      if 'unknown' in maxspeed:
+        continue
+      elif maxspeed['unit'] == 'km/h':
+        return maxspeed['speed']
+      elif maxspeed['unit'] == 'mph':
+        return maxspeed['speed'] * CV.MPH_TO_KPH
+  except Exception: # as e:
+    # print('Unable to retrieve speed limit from %s:' % json, e)
+    pass
+
+  return None
+
+
+def main(sm=None, pm=None):
+  if sm is None:
+    sm = messaging.SubMaster(['gpsLocationExternal'])
+  if pm is None:
+    pm = messaging.PubMaster(['liveMapData'])
+
+  gps_entries = deque(maxlen=10) # the max allowed coordinates in an api call is 100, but we shouldn't need that many
+
+  while True:
+    sm.update()
+
+    if sm.updated['gpsLocationExternal']:
+      gps = sm['gpsLocationExternal']
+
+      if len(gps_entries) > 0:
+        if gps.timestamp - gps_entries[0].timestamp < -5_000:
+          gps_entries.clear() # reset history if time's out of whack (like from skipping around in unlogger)
+        elif gps.timestamp - gps_entries[-1].timestamp < 5_000:
+          continue # api recommends 5 second sample rate
+
+      gps_entries.append(gps)
+
+      msg = messaging.new_message('liveMapData')
+      msg.logMonoTime = sm.logMonoTime['gpsLocationExternal']
+      msg.liveMapData.lastGps = gps
+
+      if len(gps_entries) > 2: # min allowed coordinates in an api call
+        speed_limit = try_fetch_speed_limit(gps_entries)
+        # print('SPEED LIMIT', speed_limit)
+        if speed_limit != None:
+          msg.liveMapData.speedLimitValid = True
+          msg.liveMapData.speedLimit = speed_limit
+        else:
+          gps_entries.clear()
+
+      pm.send('liveMapData', msg)
+
+
+if __name__ == "__main__":
+  main()

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -179,6 +179,7 @@ managed_processes = {
   "dmonitoringmodeld": ("selfdrive/modeld", ["./dmonitoringmodeld"]),
   "modeld": ("selfdrive/modeld", ["./modeld"]),
   "rtshield": "selfdrive.rtshield",
+  "speedlimitd": "selfdrive.locationd.speedlimitd",
 }
 
 daemon_processes = {
@@ -226,6 +227,7 @@ car_started_processes = [
   'proclogd',
   'locationd',
   'clocksd',
+  'speedlimitd',
 ]
 
 driver_view_processes = [

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -164,7 +164,7 @@ static void update_track_data(UIState *s, const cereal::ModelDataV2::XYZTData::R
 
   vertex_data *v = &pvd->v[0];
   const float margin = 500.0f;
-  for (int i = 0; line.getX()[i] <= path_length and i < TRAJECTORY_SIZE; i++) {
+  for (int i = 0; i < TRAJECTORY_SIZE and line.getX()[i] <= path_length; i++) {
     v += car_space_to_full_frame(s, line.getX()[i], -line.getY()[i] - off, -line.getZ()[i], &v->x, &v->y, margin);
     max_idx = i;
   }

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -317,7 +317,7 @@ static void ui_draw_vision_maxspeed(UIState *s) {
 
   nvgTextAlign(s->vg, NVG_ALIGN_CENTER | NVG_ALIGN_BASELINE);
   const int text_x = viz_maxspeed_x + (viz_maxspeed_xo / 2) + (viz_maxspeed_w / 2);
-  ui_draw_text(s->vg, text_x, 148, "MAX", 26 * 2.5, COLOR_WHITE_ALPHA(is_cruise_set ? 200 : 100), s->font_sans_regular);
+  ui_draw_text(s->vg, text_x, 148, "SET", 26 * 2.5, COLOR_WHITE_ALPHA(is_cruise_set ? 200 : 100), s->font_sans_regular);
 
   if (is_cruise_set) {
     snprintf(maxspeed_str, sizeof(maxspeed_str), "%d", maxspeed_calc);
@@ -325,6 +325,40 @@ static void ui_draw_vision_maxspeed(UIState *s) {
   } else {
     ui_draw_text(s->vg, text_x, 242, "N/A", 42 * 2.5, COLOR_WHITE_ALPHA(100), s->font_sans_semibold);
   }
+}
+
+static void ui_draw_vision_speed_limit(UIState *s) {
+  if (!s->scene.live_map_data.getSpeedLimitValid()) {
+    return;
+  }
+
+  char speedlimit_str[32];
+  float speedlimit = s->scene.live_map_data.getSpeedLimit();
+  int speedlimit_calc = speedlimit * 0.6225 + 0.5;
+  if (s->is_metric) {
+    speedlimit_calc = speedlimit + 0.5;
+  }
+
+  int viz_speedlimit_w = 184;
+  int viz_speedlimit_h = 202;
+  int viz_speedlimit_x = s->scene.viz_rect.x + (bdr_s*9);
+  int viz_speedlimit_y = s->scene.viz_rect.y + (bdr_s*1.5);
+
+  // background
+  ui_draw_rect(s->vg, viz_speedlimit_x, viz_speedlimit_y, viz_speedlimit_w, viz_speedlimit_h, COLOR_BLACK_ALPHA(100), 30);
+
+  // border
+  ui_draw_rect(s->vg, viz_speedlimit_x, viz_speedlimit_y, viz_speedlimit_w, viz_speedlimit_h, COLOR_WHITE_ALPHA(100), 20, 10);
+
+  // title
+  nvgTextAlign(s->vg, NVG_ALIGN_CENTER | NVG_ALIGN_BASELINE);
+  const int text_x = viz_speedlimit_x + (viz_speedlimit_w / 2);
+  ui_draw_text(s->vg, text_x, 125, "SPEED", 18 * 2.5, COLOR_WHITE_ALPHA(255), s->font_sans_semibold);
+  ui_draw_text(s->vg, text_x, 160, "LIMIT", 18 * 2.5, COLOR_WHITE_ALPHA(255), s->font_sans_semibold);
+
+  // value
+  snprintf(speedlimit_str, sizeof(speedlimit_str), "%d", speedlimit_calc);
+  ui_draw_text(s->vg, text_x, 242, speedlimit_str, 48 * 2.5, COLOR_WHITE, s->font_sans_bold);
 }
 
 static void ui_draw_vision_speed(UIState *s) {
@@ -436,6 +470,7 @@ static void ui_draw_vision_header(UIState *s) {
   ui_draw_rect(s->vg, viz_rect.x, viz_rect.y, viz_rect.w, header_h, gradient);
 
   ui_draw_vision_maxspeed(s);
+  ui_draw_vision_speed_limit(s);
   ui_draw_vision_speed(s);
   ui_draw_vision_event(s);
 }

--- a/selfdrive/ui/qt/widgets/drive_stats.cc
+++ b/selfdrive/ui/qt/widgets/drive_stats.cc
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <iostream>
 
 #include <QFile>

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -24,7 +24,7 @@ int write_param_float(float param, const char* param_name, bool persistent_param
 
 void ui_init(UIState *s) {
   s->sm = new SubMaster({"modelV2", "controlsState", "uiLayoutState", "liveCalibration", "radarState", "thermal", "frame",
-                         "health", "carParams", "ubloxGnss", "driverState", "dMonitoringState", "sensorEvents"});
+                         "health", "carParams", "ubloxGnss", "driverState", "dMonitoringState", "sensorEvents", "liveMapData"});
 
   s->started = false;
   s->status = STATUS_OFFROAD;
@@ -233,6 +233,9 @@ void update_sockets(UIState *s) {
         s->gyro_sensor = sensor.getGyroUncalibrated().getV()[1];
       }
     }
+  }
+  if (sm.updated("liveMapData")) {
+    scene.live_map_data = sm["liveMapData"].getLiveMapData();
   }
 
   s->started = scene.thermal.getStarted() || scene.frontview;

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -114,6 +114,7 @@ typedef struct UIScene {
   cereal::DriverState::Reader driver_state;
   cereal::DMonitoringState::Reader dmonitoring_state;
   cereal::ModelDataV2::Reader model;
+  cereal::LiveMapData::Reader live_map_data;
   line path;
   line outer_left_lane_line;
   line left_lane_line;

--- a/tools/replay/unlogger.py
+++ b/tools/replay/unlogger.py
@@ -104,7 +104,10 @@ class UnloggerWorker(object):
         # Frame exists, make sure we have a framereader.
         # load the frame readers as needed
         s1 = time.time()
-        img = self._frame_reader.get(frame_id, pix_fmt="rgb24")
+        try:
+          img = self._frame_reader.get(frame_id, pix_fmt="rgb24")
+        except Exception:
+          pass
         fr_time = time.time() - s1
         if fr_time > 0.05:
           print("FRAME(%d) LAG -- %.2f ms" % (frame_id, fr_time*1000.0))
@@ -380,6 +383,10 @@ def get_arg_parser():
     "--bind-early", action="store_true", default=False,
     help="Bind early to avoid dropping messages.")
 
+  parser.add_argument(
+    "--start-time", type=float, default=0.,
+    help="Time to start route.")
+
   return parser
 
 def main(argv):
@@ -401,7 +408,7 @@ def main(argv):
     else:
       route_start_time = 0
     command_sock.send_pyobj(
-      SetRoute(args.route_name, 0, args.data_dir))
+      SetRoute(args.route_name, args.start_time, args.data_dir))
   else:
     print("waiting for external command...")
     route_start_time = 0


### PR DESCRIPTION
Made a new service `speedlimitd` that uses gps long/lat from `gpsLocationExternal`, looks up the recent road segments in Mapbox's map matching API, and publishes `liveMapData`, which is previously unused as far as I can tell.

Here's a showcase of it from a drive earlier this evening: https://youtube.com/watch?v=GkIRIIrR5ik

The biggest downside of the feature is that right now, it needs a Mapbox access token to work (located at a new path `/persist/mapbox/access_token`). So either each person wanting to use the feature needs to get their own Mapbox account and access token, or it could be a comma prime feature where y'all could expose a new endpoint backed by Mapbox.

This branch also includes a couple other minor fixes/improvements

Looking forward to the feedback!