### PR TITLE
UI: add function ui_read_params

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -29,7 +29,6 @@ void ui_init(UIState *s) {
   s->started = false;
   s->status = STATUS_OFFROAD;
   s->scene.satelliteCount = -1;
-  read_param(&s->is_metric, "IsMetric");
 
   s->fb = framebuffer_init("ui", 0, true, &s->fb_w, &s->fb_h);
   assert(s->fb);
@@ -238,8 +237,27 @@ void update_sockets(UIState *s) {
   s->started = scene.thermal.getStarted() || scene.frontview;
 }
 
-void ui_update(UIState *s) {
+static void ui_read_params(UIState *s) {
+  static uint64_t frame = 0;
+  if (frame % (5*UI_FREQ) == 0) {
+    read_param(&s->is_metric, "IsMetric");
+  } else if (frame % (6*UI_FREQ) == 0) {
+    uint64_t last_athena_ping = 0;
+    int param_read = read_param(&last_athena_ping, "LastAthenaPingTime");
+    if (param_read != 0) { // Failed to read param
+      s->scene.athenaStatus = NET_DISCONNECTED;
+    } else if (nanos_since_boot() - last_athena_ping < 70e9) {
+      s->scene.athenaStatus = NET_CONNECTED;
+    } else {
+      s->scene.athenaStatus = NET_ERROR;
+    }
+  }
 
+  ++frame;
+}
+
+void ui_update(UIState *s) {
+  ui_read_params(s);
   update_sockets(s);
   ui_update_vision(s);
 
@@ -291,20 +309,6 @@ void ui_update(UIState *s) {
       s->scene.alert_size = cereal::ControlsState::AlertSize::FULL;
       s->status = STATUS_DISENGAGED;
       s->sound->stop();
-    }
-  }
-
-  // Read params
-  if ((s->sm)->frame % (5*UI_FREQ) == 0) {
-    read_param(&s->is_metric, "IsMetric");
-  } else if ((s->sm)->frame % (6*UI_FREQ) == 0) {
-    int param_read = read_param(&s->last_athena_ping, "LastAthenaPingTime");
-    if (param_read != 0) { // Failed to read param
-      s->scene.athenaStatus = NET_DISCONNECTED;
-    } else if (nanos_since_boot() - s->last_athena_ping < 70e9) {
-      s->scene.athenaStatus = NET_CONNECTED;
-    } else {
-      s->scene.athenaStatus = NET_ERROR;
     }
   }
 }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -239,6 +239,7 @@ void update_sockets(UIState *s) {
 
 static void ui_read_params(UIState *s) {
   static uint64_t frame = 0;
+
   if (frame % (5*UI_FREQ) == 0) {
     read_param(&s->is_metric, "IsMetric");
   } else if (frame % (6*UI_FREQ) == 0) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -238,7 +238,7 @@ void update_sockets(UIState *s) {
 }
 
 static void ui_read_params(UIState *s) {
-  static uint64_t frame = 0;
+  const uint64_t frame = s->sm->frame;
 
   if (frame % (5*UI_FREQ) == 0) {
     read_param(&s->is_metric, "IsMetric");
@@ -253,8 +253,6 @@ static void ui_read_params(UIState *s) {
       s->scene.athenaStatus = NET_ERROR;
     }
   }
-
-  ++frame;
 }
 
 void ui_update(UIState *s) {

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -192,7 +192,6 @@ typedef struct UIState {
   bool ignition;
   bool is_metric;
   bool longitudinal_control;
-  uint64_t last_athena_ping;
   uint64_t started_frame;
 
   bool alert_blinked;


### PR DESCRIPTION
Read all paramaters in  `ui_read_params()`.

because `frame` starts from 0, all parameters will be read at the first time call of `ui_read_params()`. so we don’t need to read them in `ui_init`.