### PR TITLE
Fix interp to be consistent with np.interp

### DIFF
--- a/common/numpy_fast.py
+++ b/common/numpy_fast.py
@@ -6,13 +6,14 @@ def clip(x, lo, hi):
 
 def interp(x, xp, fp):
   N = len(xp)
+  T = len(fp)
 
   def get_interp(xv):
     hi = 0
     while hi < N and xv > xp[hi]:
       hi += 1
     low = hi - 1
-    return fp[-1] if hi == N and xv > xp[low] else (
+    return fp[-1] if hi >= T or (hi == N and xv > xp[low]) or (N < T and xv == xp[-1]) else (
       fp[0] if hi == 0 else
       (xv - xp[low]) * (fp[hi] - fp[low]) / (xp[hi] - xp[low]) + fp[low])
 

--- a/common/tests/test_numpy_fast.py
+++ b/common/tests/test_numpy_fast.py
@@ -20,6 +20,43 @@ class InterpTest(unittest.TestCase):
       expected = np.interp(v_ego, _A_CRUISE_MIN_BP, _A_CRUISE_MIN_V)
       actual = interp(v_ego, _A_CRUISE_MIN_BP, _A_CRUISE_MIN_V)
       np.testing.assert_equal(actual, expected)
+  
+  def test_short_bp_long_v(self):
+    bp_test_cases = ([0], [0, 5], [0., 5., 10.], [0., 5., 10., 20], [-1., 2., 13., 16])
+    bp_expected_cases = ([0, 0, 0, 0, 0], [0, 5, 5, 5, 5], [0., 5., 10., 10., 10.], [0., 5., 10., 20., 20.], [-1., 2., 13., 16, 16.])
+    _A_CRUISE_MIN_V = np.asarray([-1.0, -.8, -.67, -.5, -.30])
+    v_ego_arr = [-1, -1e-12, 0, 4, 5, 6, 7, 10, 11, 15.2, 20, 21, 39,
+                 39.999999, 40, 41]
+
+    for bp_a, bp_e in zip(bp_test_cases, bp_expected_cases):
+      with self.subTest(msg='Checking if bp_a equals bp_e', bp_a=bp_a, bp_e=bp_e):
+        expected = np.interp(v_ego_arr, bp_e, _A_CRUISE_MIN_V)
+        actual = interp(v_ego_arr, bp_a, _A_CRUISE_MIN_V)
+
+        np.testing.assert_equal(actual, expected)
+
+        for v_ego in v_ego_arr:
+          expected = np.interp(v_ego, bp_e, _A_CRUISE_MIN_V)
+          actual = interp(v_ego, bp_a, _A_CRUISE_MIN_V)
+          np.testing.assert_equal(actual, expected)
+  
+  def test_long_bp_short_v(self):
+    _A_CRUISE_MIN_BP = np.asarray([0., 5., 10., 20., 40.])
+    v_test_cases = ([-1.0], [-1.0, -.8], [-1.0, -.8, -.67], [-1.0, -.8, -.67, -.5])
+    v_expected_cases = ([-1.0, -1., -1., -1., -1.], [-1.0, -.8, -.8, -.8, -.8], [-1.0, -.8, -.67, -.67, -.67], [-1.0, -.8, -.67, -.5, -.5])
+    v_ego_arr = [-1, -1e-12, 0, 4, 5, 6, 7, 10, 11, 15.2, 20, 21, 39,
+                 39.999999, 40, 41]
+
+    for v_a, v_e in zip(v_test_cases, v_expected_cases):
+      with self.subTest(msg='Checking if v_a equals v_e', v_a=v_a, v_e=v_e):
+        expected = np.interp(v_ego_arr, _A_CRUISE_MIN_BP, v_e)
+        actual = interp(v_ego_arr, _A_CRUISE_MIN_BP, v_a)
+        np.testing.assert_equal(actual, expected)
+
+        for v_ego in v_ego_arr:
+          expected = np.interp(v_ego, _A_CRUISE_MIN_BP, v_e)
+          actual = interp(v_ego, _A_CRUISE_MIN_BP, v_a)
+          np.testing.assert_equal(actual, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description** 
`interp` in `numpy_fast` doesn't match `np.interp` in the event the arguments differ in length. 

**Verification** 
Wrote unit tests to test current function with varied length arrays, tests failed. Update function to be consistent with numpy, tests pass.

**Warning**
Potentially breaking change in when interp's `xp` (which is usually `BP`) is shorter than `fp` (which is usually `V`). This change would would make the fast interp consistent with numpy but it's different than before. See the below unit test result, notice how numpy skips `-0.67` and jumps straight to `-0.3`:

```
======================================================================
FAIL: test_short_bp_long_v (tests.test_numpy_fast.InterpTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/openpilot/common/tests/test_numpy_fast.py", line 34, in test_short_bp_long_v
    np.testing.assert_equal(actual, expected)
  File "/root/.pyenv/versions/3.8.2/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 342, in assert_equal
    return assert_array_equal(actual, desired, err_msg, verbose)
  File "/root/.pyenv/versions/3.8.2/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 930, in assert_array_equal
    assert_array_compare(operator.__eq__, x, y, err_msg=err_msg,
  File "/root/.pyenv/versions/3.8.2/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 840, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Arrays are not equal

Mismatched elements: 1 / 16 (6.25%)
Max absolute difference: 0.37
Max relative difference: 1.23333333
 x: array([-1.   , -1.   , -1.   , -0.84 , -0.8  , -0.774, -0.748, -0.67 ,
       -0.3  , -0.3  , -0.3  , -0.3  , -0.3  , -0.3  , -0.3  , -0.3  ])
 y: array([-1.   , -1.   , -1.   , -0.84 , -0.8  , -0.774, -0.748, -0.3  ,
       -0.3  , -0.3  , -0.3  , -0.3  , -0.3  , -0.3  , -0.3  , -0.3  ])
```