### PR TITLE
add start_time parameter to unlogger

### DIFF
--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -164,7 +164,7 @@ static void update_track_data(UIState *s, const cereal::ModelDataV2::XYZTData::R
 
   vertex_data *v = &pvd->v[0];
   const float margin = 500.0f;
-  for (int i = 0; line.getX()[i] <= path_length and i < TRAJECTORY_SIZE; i++) {
+  for (int i = 0; i < TRAJECTORY_SIZE and line.getX()[i] <= path_length; i++) {
     v += car_space_to_full_frame(s, line.getX()[i], -line.getY()[i] - off, -line.getZ()[i], &v->x, &v->y, margin);
     max_idx = i;
   }

--- a/selfdrive/ui/qt/widgets/drive_stats.cc
+++ b/selfdrive/ui/qt/widgets/drive_stats.cc
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <iostream>
 
 #include <QFile>

--- a/tools/replay/unlogger.py
+++ b/tools/replay/unlogger.py
@@ -104,7 +104,10 @@ class UnloggerWorker(object):
         # Frame exists, make sure we have a framereader.
         # load the frame readers as needed
         s1 = time.time()
-        img = self._frame_reader.get(frame_id, pix_fmt="rgb24")
+        try:
+          img = self._frame_reader.get(frame_id, pix_fmt="rgb24")
+        except Exception:
+          pass
         fr_time = time.time() - s1
         if fr_time > 0.05:
           print("FRAME(%d) LAG -- %.2f ms" % (frame_id, fr_time*1000.0))
@@ -380,6 +383,10 @@ def get_arg_parser():
     "--bind-early", action="store_true", default=False,
     help="Bind early to avoid dropping messages.")
 
+  parser.add_argument(
+    "--start-time", type=float, default=0.,
+    help="Seek to this absolute time (in seconds) upon starting playback.")
+
   return parser
 
 def main(argv):
@@ -401,7 +408,7 @@ def main(argv):
     else:
       route_start_time = 0
     command_sock.send_pyobj(
-      SetRoute(args.route_name, 0, args.data_dir))
+      SetRoute(args.route_name, args.start_time, args.data_dir))
   else:
     print("waiting for external command...")
     route_start_time = 0


### PR DESCRIPTION
Also fix a few issues I came across:
* paint.cc crashes while replaying certain situations in unlogger
* drive_stats.cc has `assert` calls that my compiler can't handle
* unlogger occasionally crashes trying to read frames