### PR TITLE
UI: reducing CPU usage from 13% to 4% when offroad

### DIFF
--- a/selfdrive/common/utilpp.h
+++ b/selfdrive/common/utilpp.h
@@ -7,6 +7,8 @@
 #include <memory>
 #include <sstream>
 #include <fstream>
+#include <thread>
+#include <chrono>
 
 namespace util {
 
@@ -69,7 +71,9 @@ inline std::string getenv_default(const char* env_var, const char * suffix, cons
   }
 }
 
-
+inline void sleep_for(const int milliseconds) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+}
 }
 
 struct unique_fd {

--- a/selfdrive/ui/android/ui.cc
+++ b/selfdrive/ui/android/ui.cc
@@ -4,8 +4,6 @@
 #include <sys/resource.h>
 
 #include <algorithm>
-#include <thread>
-#include <chrono>
 
 #include "common/util.h"
 #include "common/utilpp.h"
@@ -150,7 +148,7 @@ int main(int argc, char* argv[]) {
 
   while (!do_exit) {
     if (!s->started) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      util::sleep_for(50);
     }
     double u1 = millis_since_boot();
 

--- a/selfdrive/ui/android/ui.cc
+++ b/selfdrive/ui/android/ui.cc
@@ -4,6 +4,8 @@
 #include <sys/resource.h>
 
 #include <algorithm>
+#include <thread>
+#include <chrono>
 
 #include "common/util.h"
 #include "common/utilpp.h"
@@ -148,7 +150,7 @@ int main(int argc, char* argv[]) {
 
   while (!do_exit) {
     if (!s->started) {
-      usleep(50 * 1000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
     double u1 = millis_since_boot();
 


### PR DESCRIPTION
`use std::sleep_for `to accurately control the UI frequency.

`usleep` will be interrupted by a signal at any time, that will cause the UI freq to be very unstable and high. it will also cause the screen to go to sleep too quickly(less than 10s which is expected to 30s)

 