### PR TITLE
hyundai: update palisade tuning

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -55,9 +55,9 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 1999. + STD_CARGO_KG
       ret.wheelbase = 2.90
-      ret.steerRatio = 13.75 * 1.15
+      ret.steerRatio = 20.28 # 15.6 is spec end-to-end
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.05]]
     elif candidate in [CAR.ELANTRA, CAR.ELANTRA_GT_I30]:
       ret.lateralTuning.pid.kf = 0.00006
       ret.mass = 1275. + STD_CARGO_KG

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -55,7 +55,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00005
       ret.mass = 1999. + STD_CARGO_KG
       ret.wheelbase = 2.90
-      ret.steerRatio = 20.28 # 15.6 is spec end-to-end
+      ret.steerRatio = 13.75 * 1.15
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.05]]
     elif candidate in [CAR.ELANTRA, CAR.ELANTRA_GT_I30]:


### PR DESCRIPTION
my steering ratio seems to still be climbing over time, so not sure if this is the final number (or if there is a problem)

steering accuracy with raised kp seems noticeably better, especially entering turns (it doesn't lag as much)
before:
```
angle:  0 | error: 0.21 | =: 16% | +:  40% | -: 42% | count: 8094
angle:  1 | error: 0.23 | =: 17% | +:  36% | -: 45% | count: 9421
angle:  2 | error: 0.32 | =: 11% | +:  33% | -: 54% | count: 4237
angle:  3 | error: 0.33 | =: 12% | +:  50% | -: 37% | count: 2581
angle:  4 | error: 0.33 | =: 10% | +:  49% | -: 39% | count: 3026
angle:  5 | error: 0.49 | =:  5% | +:  29% | -: 64% | count: 1294
angle:  6 | error: 0.63 | =:  3% | +:  55% | -: 40% | count:  737
angle:  7 | error: 0.45 | =:  9% | +:  63% | -: 27% | count: 1172
angle:  8 | error: 0.43 | =:  6% | +:  54% | -: 39% | count: 1518
angle:  9 | error: 0.34 | =: 12% | +:  49% | -: 38% | count: 1180
angle: 10 | error: 0.42 | =:  7% | +:  48% | -: 44% | count: 1412
```
after:
```
angle:  0 | error: 0.15 | =: 22% | +:  40% | -: 36% | count: 10430
angle:  1 | error: 0.19 | =: 21% | +:  34% | -: 44% | count: 7404
angle:  2 | error: 0.28 | =: 10% | +:  44% | -: 44% | count: 2825
angle:  3 | error: 0.30 | =: 11% | +:  42% | -: 46% | count: 2253
angle:  4 | error: 0.31 | =: 11% | +:  47% | -: 41% | count: 2697
angle:  5 | error: 0.36 | =: 13% | +:  32% | -: 54% | count: 1325
angle:  6 | error: 0.69 | =:  2% | +:  35% | -: 61% | count:  616
angle:  7 | error: 0.44 | =:  3% | +:  61% | -: 34% | count:  703
angle:  8 | error: 0.38 | =:  5% | +:  62% | -: 31% | count: 1629
angle:  9 | error: 0.41 | =:  8% | +:  44% | -: 46% | count: 1157
angle: 10 | error: 0.42 | =:  8% | +:  39% | -: 52% | count: 1216
```

interestingly, steering accuracy is always significantly worse at 6 deg