### PR TITLE
hyundai: update steer warning

### DIFF
--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -34,7 +34,7 @@ class CarState(CarStateBase):
     ret.steeringTorque = cp.vl["MDPS12"]['CR_Mdps_StrColTq']
     ret.steeringTorqueEps = cp.vl["MDPS12"]['CR_Mdps_OutTq']
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
-    ret.steerWarning = cp.vl["MDPS12"]['CF_Mdps_ToiUnavail'] != 0 or cp.vl["MDPS12"]['CF_Mdps_FailStat'] != 0
+    ret.steerWarning = cp.vl["MDPS12"]['CF_Mdps_ToiUnavail'] != 0 or cp.vl["MDPS12"]['CF_Mdps_ToiFlt'] != 0
 
     # cruise state
     if self.CP.openpilotLongitudinalControl:
@@ -194,7 +194,7 @@ class CarState(CarStateBase):
       ("CR_Mdps_StrColTq", "MDPS12", 0),
       ("CF_Mdps_ToiActive", "MDPS12", 0),
       ("CF_Mdps_ToiUnavail", "MDPS12", 0),
-      ("CF_Mdps_FailStat", "MDPS12", 0),
+      ("CF_Mdps_ToiFlt", "MDPS12", 0),
       ("CR_Mdps_OutTq", "MDPS12", 0),
 
       ("SAS_Angle", "SAS11", 0),

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -34,7 +34,7 @@ class CarState(CarStateBase):
     ret.steeringTorque = cp.vl["MDPS12"]['CR_Mdps_StrColTq']
     ret.steeringTorqueEps = cp.vl["MDPS12"]['CR_Mdps_OutTq']
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
-    ret.steerWarning = cp.vl["MDPS12"]['CF_Mdps_ToiUnavail'] != 0
+    ret.steerWarning = cp.vl["MDPS12"]['CF_Mdps_ToiUnavail'] != 0 or cp.vl["MDPS12"]['CF_Mdps_FailStat'] != 0
 
     # cruise state
     if self.CP.openpilotLongitudinalControl:


### PR DESCRIPTION
current steer unavailable warning for hyundai does not include:
* LKAS11 CF_Lkas_ToiFlt == 1
* LKAS11 CF_Lkas_Chksum invalid
* LKAS11 CF_Lkas_MsgCount invalid
* LKAS11 CF_Lkas_ActToi == 0 and LKAS11 CR_Lkas_StrToqReq != 0
* LKAS11 CR_Lkas_StrToqReq > 2.8 Nm for more than a long period of time (105s?)
* LKAS11 CR_Lkas_StrToqReq > 3.2 Nm for more than a short period of time (0.1s?)
* LKAS11 CR_Lkas_StrToqReq changes by more than 0.078125 Nm (10 request units) per time step
* MDPS11 CR_Mdps_DrvTq > 6.0 Nm
* CLU11 CF_Clu_Vanz > 128 MPH
* SAS11 SAS_Angle > 90 degrees
(values based on palisade power steering firmware, could be different for other vehicles)

I believe you recover from these errors by sending zero torque for a short period of time

another very similar signal is CF_Mdps_ToiFlt which looks the same as above except it excludes:
* LKAS11 CF_Lkas_ToiFlt == 1

also, if setting LKAS11 CF_Lkas_ToiFlt = 1 when openpilot transitions from enabled to disabled causes a controlled wind-down of torque instead of the immediate drop to zero that currently happens, do we want to start setting it?