### PR TITLE
UI: fix video frame drop

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -83,18 +83,8 @@ void ui_update_vision(UIState *s) {
     }
   }
 
-  if (s->vision_connected) {
-    if (!s->started) goto destroy;
-
-    // poll for a new frame
-    struct pollfd fds[1] = {{
-      .fd = s->stream.ipc_fd,
-      .events = POLLOUT,
-    }};
-    int ret = poll(fds, 1, 100);
-    if (ret > 0) {
-      if (!visionstream_get(&s->stream, nullptr)) goto destroy;
-    }
+  if (s->vision_connected && (!s->started || !visionstream_get(&s->stream, nullptr))) {
+    goto destroy;
   }
 
   return;


### PR DESCRIPTION
possible fix for: https://github.com/commaai/openpilot/issues/19579

`poll` did not work as expected due to inappropriate flag: `POLLOUT`(should be `POLLIN`) ,it also return -1 when `EINTR` occurred.that may cause some necessary `visionstream_get` calls be skipped,causing frame drop. 
I don't understand why there was no such issue before. May be related to this PR : https://github.com/commaai/openpilot/pull/19589 the combination of these two problematic codes caused  frame drop.



