### PR TITLE
Make macos ci homebrew dep-caching fast

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,11 +67,8 @@ jobs:
         # key: ${{ hashFiles('tools/mac_setup.sh') }}
         key: asdfasdf4
     - name: Determine pre-existing Homebrew packages
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: |
-        echo 'EXISTING_DOWNLOADS<<EOF' >> $GITHUB_ENV
-        ls -1 ~/Library/Caches/Homebrew/downloads >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
         echo 'EXISTING_CELLAR<<EOF' >> $GITHUB_ENV
         ls -1 /usr/local/Cellar >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
@@ -80,16 +77,9 @@ jobs:
     # - name: Build openpilot
     #   run: eval "$(pyenv init -)" && scons -j$(nproc)
     - name: Remove pre-existing Homebrew packages for caching
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: |
-        new_downloads=$(ls ~/Library/Caches/Homebrew/downloads)
         new_cellar=$(ls /usr/local/Cellar)
-
-        echo "Removing previously existing files that don't need caching"
-        comm -12 <(echo "$EXISTING_DOWNLOADS") <(echo "$new_downloads") | while read file; do
-          echo "Removing ~/Library/Caches/Homebrew/downloads/$file"
-          rm ~/Library/Caches/Homebrew/downloads/"$file"
-        done
 
         comm -12 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | while read dir; do
           # need to keep zstd for caching to work
@@ -102,7 +92,6 @@ jobs:
         echo "NEW PACKAGES"
         comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar")
 
-        (du -shc ~/Library/Caches/Homebrew/* | sort -h) || true
         (du -shc /usr/local/Cellar/* | sort -h) || true
 
   build_webcam:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
         echo "NEW PACKAGES"
         comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar")
 
-        (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+        (du -shc ~/Library/Caches/Homebrew/* | sort -h) || true
         (du -shc /usr/local/Cellar/* | sort -h) || true
 
   build_webcam:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Determine pre-existing Homebrew packages
+      if: steps.dependency-cache.outputs.cache-hit != 'true'
+      run: |
+        echo 'EXISTING_CELLAR<<EOF' >> $GITHUB_ENV
+        ls -1 /usr/local/Cellar >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
     - name: Cache dependencies
       id: dependency-cache
       uses: actions/cache@v2
@@ -64,14 +70,15 @@ jobs:
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
           /usr/local/Cellar
+          ~/github_cache_entries.txt
         # key: ${{ hashFiles('tools/mac_setup.sh') }}
         key: asdfasdf5
-    - name: Determine pre-existing Homebrew packages
-      if: steps.dependency-cache.outputs.cache-hit != 'true'
+    - name: Brew link restored dependencies
+      if: steps.dependency-cache.outputs.cache-hit == 'true'
       run: |
-        echo 'EXISTING_CELLAR<<EOF' >> $GITHUB_ENV
-        ls -1 /usr/local/Cellar >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
+        while read package; do
+          brew link "$package"
+        done < ~/github_cache_entries.txt
     - name: Install dependencies
       run: ./tools/mac_setup.sh
     # - name: Build openpilot
@@ -89,7 +96,7 @@ jobs:
         done
 
         echo "NEW PACKAGES"
-        comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar")
+        comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | tee ~/github_cache_entries.txt
 
         (du -shc /usr/local/Cellar/* | sort -h) || true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,31 +70,34 @@ jobs:
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
           /usr/local/Cellar
-          ~/github_cache_entries.txt
-        # key: ${{ hashFiles('tools/mac_setup.sh') }}
-        key: asdfasdf7
+          ~/github_brew_cache_entries.txt
+        key: deps-${{ hashFiles('tools/mac_setup.sh') }}
+        restore-keys: deps-
     - name: Brew link restored dependencies
       if: steps.dependency-cache.outputs.cache-hit == 'true'
       run: |
         while read package; do
           brew link "$package"
-        done < ~/github_cache_entries.txt
+        done < ~/github_brew_cache_entries.txt
     - name: Install dependencies
       run: ./tools/mac_setup.sh
-    # - name: Build openpilot
-    #   run: eval "$(pyenv init -)" && scons -j$(nproc)
+    - name: Build openpilot
+      run: eval "$(pyenv init -)" && scons -j$(nproc)
     - name: Remove pre-existing Homebrew packages for caching
       if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: |
-        new_cellar=$(ls /usr/local/Cellar)
+        new_cellar=$(ls -1 /usr/local/Cellar)
         comm -12 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | while read dir; do
           if [[ $dir != "zstd" ]]; then # caching step needs zstd
             echo "Removing /usr/local/Cellar/$dir"
             rm -rf "/usr/local/Cellar/$dir"
           fi
         done
-        echo "Newly installed packages:"
+
+        echo "\n\nNewly installed packages:"
         comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | tee ~/github_cache_entries.txt
+
+        echo "\n\nThe following will be cached:"
         (du -shc /usr/local/Cellar/* | sort -h) || true
 
   build_webcam:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,6 @@ env:
 jobs:
   build_release:
     name: build release
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     env:
@@ -71,13 +70,13 @@ jobs:
           ~/Library/Caches/pipenv
           /usr/local/Cellar
           ~/github_brew_cache_entries.txt
-        key: deps-${{ hashFiles('tools/mac_setup.sh') }}
-        restore-keys: deps-
+        key: macos-deps-${{ hashFiles('tools/mac_setup.sh') }}
+        restore-keys: macos-deps-
     - name: Brew link restored dependencies
       if: steps.dependency-cache.outputs.cache-hit == 'true'
       run: |
         while read package; do
-          brew link "$package"
+          brew link --force "$package" # `--force` for keg-only packages
         done < ~/github_brew_cache_entries.txt
     - name: Install dependencies
       run: ./tools/mac_setup.sh
@@ -94,15 +93,14 @@ jobs:
           fi
         done
 
-        echo "\n\nNewly installed packages:"
-        comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | tee ~/github_cache_entries.txt
+        printf "\n\nNewly installed packages:\n"
+        comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | tee ~/github_brew_cache_entries.txt
 
-        echo "\n\nThe following will be cached:"
+        printf "\n\nThe following will be cached:\n"
         (du -shc /usr/local/Cellar/* | sort -h) || true
 
   build_webcam:
     name: build webcam
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 90
     env:
@@ -165,7 +163,6 @@ jobs:
 
   static_analysis:
     name: static analysis
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -179,7 +176,6 @@ jobs:
 
   valgrind:
     name: valgrind
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -205,7 +201,6 @@ jobs:
 
   unit_tests:
     name: unit tests
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -235,7 +230,6 @@ jobs:
 
   process_replay:
     name: process replay
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -269,7 +263,6 @@ jobs:
 
   test_longitudinal:
     name: longitudinal
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -294,7 +287,6 @@ jobs:
 
   test_car_models:
     name: car models
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
           ~/.pyenv
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
-          ~/Library/Caches/Homebrew
+          /usr/local
         key: ${{ hashFiles('tools/mac_setup.sh') }}
     - name: Install dependencies
       run: ./tools/mac_setup.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,14 +63,15 @@ jobs:
           ~/.pyenv
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
-          /usr/local
+          ~/Library/Caches/Homebrew
+          /usr/local/Homebrew
         key: ${{ hashFiles('tools/mac_setup.sh') }}
     - name: Install dependencies
       run: ./tools/mac_setup.sh
-    - name: Build openpilot
-      run: eval "$(pyenv init -)" && scons -j$(nproc)
-    - name: Brew cleanup
-      run: brew cleanup || true # keeps our cache small
+    # - name: Build openpilot
+    #   run: eval "$(pyenv init -)" && scons -j$(nproc)
+    # - name: Brew cleanup
+    #   run: brew cleanup || true # keeps our cache small
 
   build_webcam:
     name: build webcam

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,9 +63,9 @@ jobs:
           ~/.pyenv
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
-          /usr/local/Cellar
+          ~/Library/Caches/Homebrew
         # key: ${{ hashFiles('tools/mac_setup.sh') }}
-        key: asdfasdf1
+        key: asdfasdf2
     - name: Determine pre-existing Homebrew packages
       if: steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,9 +63,9 @@ jobs:
           ~/.pyenv
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
-          ~/Library/Caches/Homebrew
+          /usr/local/Cellar
         # key: ${{ hashFiles('tools/mac_setup.sh') }}
-        key: asdfasdf2
+        key: asdfasdf4
     - name: Determine pre-existing Homebrew packages
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
@@ -92,8 +92,11 @@ jobs:
         done
 
         comm -12 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | while read dir; do
-          echo "Removing /usr/local/Cellar/$dir"
-          rm -rf "/usr/local/Cellar/$dir"
+          # need to keep zstd for caching to work
+          if [ $line != "zstd" ]; then
+            echo "Removing /usr/local/Cellar/$dir"
+            rm -rf "/usr/local/Cellar/$dir"
+          fi
         done
 
         echo "NEW PACKAGES"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
           /usr/local/Cellar
           ~/github_cache_entries.txt
         # key: ${{ hashFiles('tools/mac_setup.sh') }}
-        key: asdfasdf5
+        key: asdfasdf7
     - name: Brew link restored dependencies
       if: steps.dependency-cache.outputs.cache-hit == 'true'
       run: |
@@ -87,17 +87,14 @@ jobs:
       if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: |
         new_cellar=$(ls /usr/local/Cellar)
-
         comm -12 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | while read dir; do
-          if [[ "$line" != "zstd" ]]; then # need to keep zstd for caching step to work
+          if [[ $dir != "zstd" ]]; then # caching step needs zstd
             echo "Removing /usr/local/Cellar/$dir"
             rm -rf "/usr/local/Cellar/$dir"
           fi
         done
-
-        echo "NEW PACKAGES"
+        echo "Newly installed packages:"
         comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | tee ~/github_cache_entries.txt
-
         (du -shc /usr/local/Cellar/* | sort -h) || true
 
   build_webcam:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ env:
 jobs:
   build_release:
     name: build release
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     env:
@@ -73,6 +74,7 @@ jobs:
 
   build_webcam:
     name: build webcam
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 90
     env:
@@ -135,6 +137,7 @@ jobs:
 
   static_analysis:
     name: static analysis
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -148,6 +151,7 @@ jobs:
 
   valgrind:
     name: valgrind
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -173,6 +177,7 @@ jobs:
 
   unit_tests:
     name: unit tests
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -202,6 +207,7 @@ jobs:
 
   process_replay:
     name: process replay
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -235,6 +241,7 @@ jobs:
 
   test_longitudinal:
     name: longitudinal
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
@@ -259,6 +266,7 @@ jobs:
 
   test_car_models:
     name: car models
+    if: ${{ false }}
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,14 +64,15 @@ jobs:
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
           ~/Library/Caches/Homebrew
-          /usr/local/Homebrew
+          /usr/local/Cellar
         key: ${{ hashFiles('tools/mac_setup.sh') }}
     - name: Install dependencies
       run: ./tools/mac_setup.sh
     # - name: Build openpilot
     #   run: eval "$(pyenv init -)" && scons -j$(nproc)
-    # - name: Brew cleanup
-    #   run: brew cleanup || true # keeps our cache small
+    - name: Brew cleanup
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: brew cleanup -s || true # keeps our cache small
 
   build_webcam:
     name: build webcam

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,13 +66,41 @@ jobs:
           ~/Library/Caches/Homebrew
           /usr/local/Cellar
         key: ${{ hashFiles('tools/mac_setup.sh') }}
+    - name: Determine pre-existing Homebrew packages
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        echo 'EXISTING_DOWNLOADS<<EOF' >> $GITHUB_ENV
+        ls -1 ~/Library/Caches/Homebrew/downloads >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+        echo 'EXISTING_CELLAR<<EOF' >> $GITHUB_ENV
+        ls -1 /usr/local/Cellar >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
     - name: Install dependencies
       run: ./tools/mac_setup.sh
     # - name: Build openpilot
     #   run: eval "$(pyenv init -)" && scons -j$(nproc)
-    - name: Brew cleanup
+    - name: Remove pre-existing Homebrew packages for caching
       if: steps.cache.outputs.cache-hit != 'true'
-      run: brew cleanup -s || true # keeps our cache small
+      run: |
+        new_downloads=$(ls ~/Library/Caches/Homebrew/downloads)
+        new_cellar=$(ls /usr/local/Cellar)
+
+        echo "Removing previously existing files that don't need caching"
+        comm -12 <(echo "$EXISTING_DOWNLOADS") <(echo "$new_downloads") | while read file; do
+          echo "Removing ~/Library/Caches/Homebrew/downloads/$file"
+          rm ~/Library/Caches/Homebrew/downloads/"$file"
+        done
+
+        comm -12 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | while read dir; do
+          echo "Removing /usr/local/Cellar/$dir"
+          rm -rf "/usr/local/Cellar/$dir"
+        done
+
+        echo "NEW PACKAGES"
+        comm -13 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar")
+
+        (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+        (du -shc /usr/local/Cellar/* | sort -h) || true
 
   build_webcam:
     name: build webcam

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
           ~/Library/Caches/pipenv
           /usr/local/Cellar
         # key: ${{ hashFiles('tools/mac_setup.sh') }}
-        key: asdfasdf4
+        key: asdfasdf5
     - name: Determine pre-existing Homebrew packages
       if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: |
@@ -82,8 +82,7 @@ jobs:
         new_cellar=$(ls /usr/local/Cellar)
 
         comm -12 <(echo "$EXISTING_CELLAR") <(echo "$new_cellar") | while read dir; do
-          # need to keep zstd for caching to work
-          if [ $line != "zstd" ]; then
+          if [[ "$line" != "zstd" ]]; then # need to keep zstd for caching step to work
             echo "Removing /usr/local/Cellar/$dir"
             rm -rf "/usr/local/Cellar/$dir"
           fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,9 +63,9 @@ jobs:
           ~/.pyenv
           ~/Library/Caches/pip
           ~/Library/Caches/pipenv
-          ~/Library/Caches/Homebrew
           /usr/local/Cellar
-        key: ${{ hashFiles('tools/mac_setup.sh') }}
+        # key: ${{ hashFiles('tools/mac_setup.sh') }}
+        key: asdfasdf1
     - name: Determine pre-existing Homebrew packages
       if: steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -320,7 +320,7 @@ static void ui_draw_vision_maxspeed(UIState *s) {
     snprintf(maxspeed_str, sizeof(maxspeed_str), "%d", maxspeed_calc);
     ui_draw_text(s->vg, text_x, 242, maxspeed_str, 48 * 2.5, COLOR_WHITE, s->font_sans_bold);
   } else {
-    ui_draw_text(s->vg, text_x, 242, "N/A", 42 * 2.5, COLOR_WHITE_ALPHA(100), s->font_sans_semibold);
+    ui_draw_text(s->vg, text_x, 242, "N/A", 42 * 2.5, COLOR_WHITE_ALPHA(100), s->font_sans_semibold);//
   }
 }
 

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -320,7 +320,7 @@ static void ui_draw_vision_maxspeed(UIState *s) {
     snprintf(maxspeed_str, sizeof(maxspeed_str), "%d", maxspeed_calc);
     ui_draw_text(s->vg, text_x, 242, maxspeed_str, 48 * 2.5, COLOR_WHITE, s->font_sans_bold);
   } else {
-    ui_draw_text(s->vg, text_x, 242, "N/A", 42 * 2.5, COLOR_WHITE_ALPHA(100), s->font_sans_semibold);//
+    ui_draw_text(s->vg, text_x, 242, "N/A", 42 * 2.5, COLOR_WHITE_ALPHA(100), s->font_sans_semibold);
   }
 }
 

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -11,7 +11,6 @@ if [[ $(command -v ffmpeg) != "" ]]; then
   ffmpeg -version
 fi
 
-
 brew install ffmpeg \
  capnp \
             #  coreutils \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -6,11 +6,6 @@ if [[ $(command -v brew) == "" ]]; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
-if [[ $(command -v ffmpeg) != "" ]]; then
-  ffmpeg -version
-  echo "Cache worked!"
-fi
-
 brew install capnp \
              coreutils \
              eigen \
@@ -24,11 +19,6 @@ brew install capnp \
              pyenv \
              qt5 \
              zeromq
-
-if [[ $(command -v ffmpeg) != "" ]]; then
-  echo "ffmpeg exists"
-  ffmpeg -version
-fi
 
 if [[ $SHELL == "/bin/zsh" ]]; then
   RC_FILE="$HOME/.zshrc"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -7,36 +7,39 @@ if [[ $(command -v brew) == "" ]]; then
 fi
 
 brew install capnp \
-             coreutils \
-             eigen \
-             ffmpeg \
-             glfw \
-             libarchive \
-             libusb \
-             libtool \
-             llvm \
-	     openssl \
-             pyenv \
-             qt5 \
-             zeromq
+            #  coreutils \
+            #  eigen \
+            #  ffmpeg \
+            #  glfw \
+            #  libarchive \
+            #  libusb \
+            #  libtool \
+            #  llvm \
+            #  openssl \
+            #  pyenv \
+            #  qt5 \
+            #  zeromq
 
-if [[ $SHELL == "/bin/zsh" ]]; then
-  RC_FILE="$HOME/.zshrc"
-elif [[ $SHELL == "/bin/bash" ]]; then
-  RC_FILE="$HOME/.bash_profile"
-fi
+find /usr/local/Homebrew -type d
+find ~/Library/Caches/Homebrew -type d
 
-if [ -z "$OPENPILOT_ENV" ] && [ -n "$RC_FILE" ] && [ -z "$CI" ]; then
-  OP_DIR=$(git rev-parse --show-toplevel)
-  echo "source $OP_DIR/tools/openpilot_env.sh" >> $RC_FILE
-  source $RC_FILE
-  echo "Added openpilot_env to RC file: $RC_FILE"
-fi
+# if [[ $SHELL == "/bin/zsh" ]]; then
+#   RC_FILE="$HOME/.zshrc"
+# elif [[ $SHELL == "/bin/bash" ]]; then
+#   RC_FILE="$HOME/.bash_profile"
+# fi
 
-pyenv install -s 3.8.2
-pyenv global 3.8.2
-pyenv rehash
-eval "$(pyenv init -)"
+# if [ -z "$OPENPILOT_ENV" ] && [ -n "$RC_FILE" ] && [ -z "$CI" ]; then
+#   OP_DIR=$(git rev-parse --show-toplevel)
+#   echo "source $OP_DIR/tools/openpilot_env.sh" >> $RC_FILE
+#   source $RC_FILE
+#   echo "Added openpilot_env to RC file: $RC_FILE"
+# fi
 
-pip install pipenv==2020.8.13
-pipenv install --system --deploy
+# pyenv install -s 3.8.2
+# pyenv global 3.8.2
+# pyenv rehash
+# eval "$(pyenv init -)"
+
+# pip install pipenv==2020.8.13
+# pipenv install --system --deploy

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -45,9 +45,13 @@ brew install zeromq
 after=$(ls ~/Library/Caches/Homebrew/downloads)
 
 echo "NEW FILES"
-new=$(comm -13 <(echo "$before") <(echo "$after"))
-echo "$new"
-diff <(echo "$before") <(echo "$after")
+comm -13 <(echo "$before") <(echo "$after")
+
+echo "Removing previously existing files that don't need caching"
+comm -12 <(echo "$before") <(echo "$after") | while read file; do
+  ls -l "~/Library/Caches/Homebrew/downloads/$file" || true
+  rm "~/Library/Caches/Homebrew/downloads/$file" || true
+done
 
 if [[ $(command -v ffmpeg) != "" ]]; then
   echo "ffmpeg exists"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -11,7 +11,7 @@ fi
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
 (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
 
-before=$(ls ~/Library/Caches/Homebrew/downloads)
+before=$(ls -1 ~/Library/Caches/Homebrew/downloads)
 
 # rm -rf /usr/local/Homebrew/*
 # find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
@@ -42,7 +42,7 @@ brew install zeromq
 # (du -shc /usr/local/Cellar/* | sort -h) || true
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
 (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
-after=$(ls ~/Library/Caches/Homebrew/downloads)
+after=$(ls -1 ~/Library/Caches/Homebrew/downloads)
 
 echo "NEW FILES"
 new=$(comm -13 <(echo $before) <(echo $after))

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -6,6 +6,17 @@ if [[ $(command -v brew) == "" ]]; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
+(du -shc /usr/local/Homebrew/Library/* | sort -h) || true
+(du -shc /usr/local/Cellar/* | sort -h) || true
+(du -shc /usr/local/Caskroom/* | sort -h) || true
+(du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+
+# rm -rf /usr/local/Homebrew/*
+# find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
+rm -rf /usr/local/Cellar/*
+rm -rf /usr/local/Caskroom/*
+rm -rf ~/Library/Caches/Homebrew/*
+
 brew install capnp \
             #  coreutils \
             #  eigen \
@@ -20,8 +31,10 @@ brew install capnp \
             #  qt5 \
             #  zeromq
 
-find /usr/local/Homebrew -type d
-find ~/Library/Caches/Homebrew -type d
+(du -shc /usr/local/Homebrew/* | sort -h) || true
+(du -shc /usr/local/Cellar/* | sort -h) || true
+(du -shc /usr/local/Caskroom/* | sort -h) || true
+(du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
 
 # if [[ $SHELL == "/bin/zsh" ]]; then
 #   RC_FILE="$HOME/.zshrc"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -7,48 +7,46 @@ if [[ $(command -v brew) == "" ]]; then
 fi
 
 if [[ $(command -v ffmpeg) != "" ]]; then
-  echo "Cache worked!"
   ffmpeg -version
+  echo "Cache worked!"
 fi
 
-
-brew install ffmpeg \
- capnp \
-            #  coreutils \
-            #  eigen \
-            #  ffmpeg \
-            #  glfw \
-            #  libarchive \
-            #  libusb \
-            #  libtool \
-            #  llvm \
-            #  openssl \
-            #  pyenv \
-            #  qt5 \
-            #  zeromq
+brew install capnp \
+             coreutils \
+             eigen \
+             ffmpeg \
+             glfw \
+             libarchive \
+             libusb \
+             libtool \
+             llvm \
+             openssl \
+             pyenv \
+             qt5 \
+             zeromq
 
 if [[ $(command -v ffmpeg) != "" ]]; then
   echo "ffmpeg exists"
   ffmpeg -version
 fi
 
-# if [[ $SHELL == "/bin/zsh" ]]; then
-#   RC_FILE="$HOME/.zshrc"
-# elif [[ $SHELL == "/bin/bash" ]]; then
-#   RC_FILE="$HOME/.bash_profile"
-# fi
+if [[ $SHELL == "/bin/zsh" ]]; then
+  RC_FILE="$HOME/.zshrc"
+elif [[ $SHELL == "/bin/bash" ]]; then
+  RC_FILE="$HOME/.bash_profile"
+fi
 
-# if [ -z "$OPENPILOT_ENV" ] && [ -n "$RC_FILE" ] && [ -z "$CI" ]; then
-#   OP_DIR=$(git rev-parse --show-toplevel)
-#   echo "source $OP_DIR/tools/openpilot_env.sh" >> $RC_FILE
-#   source $RC_FILE
-#   echo "Added openpilot_env to RC file: $RC_FILE"
-# fi
+if [ -z "$OPENPILOT_ENV" ] && [ -n "$RC_FILE" ] && [ -z "$CI" ]; then
+  OP_DIR=$(git rev-parse --show-toplevel)
+  echo "source $OP_DIR/tools/openpilot_env.sh" >> $RC_FILE
+  source $RC_FILE
+  echo "Added openpilot_env to RC file: $RC_FILE"
+fi
 
-# pyenv install -s 3.8.2
-# pyenv global 3.8.2
-# pyenv rehash
-# eval "$(pyenv init -)"
+pyenv install -s 3.8.2
+pyenv global 3.8.2
+pyenv rehash
+eval "$(pyenv init -)"
 
-# pip install pipenv==2020.8.13
-# pipenv install --system --deploy
+pip install pipenv==2020.8.13
+pipenv install --system --deploy

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -11,6 +11,7 @@ if [[ $(command -v ffmpeg) != "" ]]; then
   ffmpeg -version
 fi
 
+
 brew install ffmpeg
 #  capnp \
             #  coreutils \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -9,7 +9,7 @@ fi
 # (du -shc /usr/local/Homebrew/Library/* | sort -h) || true
 # (du -shc /usr/local/Cellar/* | sort -h) || true
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
-(du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+# (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
 
 before=$(ls ~/Library/Caches/Homebrew/downloads)
 
@@ -23,7 +23,7 @@ if [[ $(command -v ffmpeg) != "" ]]; then
   echo "Cache worked!"
 fi
 
-brew install zeromq
+brew install ffmpeg
 #  capnp \
             #  coreutils \
             #  eigen \
@@ -41,16 +41,17 @@ brew install zeromq
 # (du -shc /usr/local/Homebrew/Library/* | sort -h) || true
 # (du -shc /usr/local/Cellar/* | sort -h) || true
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
-(du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+# (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
 after=$(ls ~/Library/Caches/Homebrew/downloads)
 
 echo "NEW FILES"
 comm -13 <(echo "$before") <(echo "$after")
+echo "\n\n"
 
 echo "Removing previously existing files that don't need caching"
 comm -12 <(echo "$before") <(echo "$after") | while read file; do
-  ls -l "~/Library/Caches/Homebrew/downloads/$file" || true
-  rm "~/Library/Caches/Homebrew/downloads/$file" || true
+  echo "Removing ~/Library/Caches/Homebrew/downloads/$file"
+  rm ~/Library/Caches/Homebrew/downloads/"$file"
 done
 
 if [[ $(command -v ffmpeg) != "" ]]; then

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -13,8 +13,8 @@ fi
 
 
 brew install ffmpeg \
- capnp \
-             coreutils \
+#  capnp \
+            #  coreutils \
             #  eigen \
             #  ffmpeg \
             #  glfw \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -11,8 +11,9 @@ if [[ $(command -v ffmpeg) != "" ]]; then
   ffmpeg -version
 fi
 
-brew install ffmpeg \
- capnp \
+brew link ffmpeg || brew install ffmpeg
+brew link capnp || brew install capnp
+brew link coreutils || brew install coreutils
             #  coreutils \
             #  eigen \
             #  ffmpeg \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -11,7 +11,7 @@ fi
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
 (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
 
-before=$(ls -1 ~/Library/Caches/Homebrew/downloads)
+before=$(ls ~/Library/Caches/Homebrew/downloads)
 
 # rm -rf /usr/local/Homebrew/*
 # find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
@@ -42,12 +42,12 @@ brew install zeromq
 # (du -shc /usr/local/Cellar/* | sort -h) || true
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
 (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
-after=$(ls -1 ~/Library/Caches/Homebrew/downloads)
+after=$(ls ~/Library/Caches/Homebrew/downloads)
 
 echo "NEW FILES"
-new=$(comm -13 <(echo $before) <(echo $after))
-echo $new
-diff <(echo $before) <(echo $after)
+new=$(comm -13 <(echo "$before") <(echo "$after"))
+echo "$new"
+diff <(echo "$before") <(echo "$after")
 
 if [[ $(command -v ffmpeg) != "" ]]; then
   echo "ffmpeg exists"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -6,22 +6,9 @@ if [[ $(command -v brew) == "" ]]; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
-# (du -shc /usr/local/Homebrew/Library/* | sort -h) || true
-# (du -shc /usr/local/Cellar/* | sort -h) || true
-# (du -shc /usr/local/Caskroom/* | sort -h) || true
-# (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
-
-before_downloads=$(ls ~/Library/Caches/Homebrew/downloads)
-before_cellar=$(ls /usr/local/Cellar)
-
-# rm -rf /usr/local/Homebrew/*
-# find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
-# rm -rf /usr/local/Cellar/*
-# rm -rf /usr/local/Caskroom/*
-# rm -rf ~/Library/Caches/Homebrew/*
-
 if [[ $(command -v ffmpeg) != "" ]]; then
   echo "Cache worked!"
+  ffmpeg -version
 fi
 
 brew install ffmpeg
@@ -39,29 +26,9 @@ brew install ffmpeg
             #  qt5 \
             #  zeromq
 
-# (du -shc /usr/local/Homebrew/Library/* | sort -h) || true
-# (du -shc /usr/local/Cellar/* | sort -h) || true
-# (du -shc /usr/local/Caskroom/* | sort -h) || true
-# (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
-after_downloads=$(ls ~/Library/Caches/Homebrew/downloads)
-after_cellar=$(ls /usr/local/Cellar)
-
-echo "Removing previously existing files that don't need caching"
-comm -12 <(echo "$before_downloads") <(echo "$after_downloads") | while read file; do
-  echo "Removing ~/Library/Caches/Homebrew/downloads/$file"
-  rm ~/Library/Caches/Homebrew/downloads/"$file"
-done
-
-comm -12 <(echo "$before_cellar") <(echo "$after_cellar") | while read file; do
-  echo "Removing /usr/local/Cellar/$file"
-  rm /usr/local/Cellar/"$file"
-done
-
-(du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
-(du -shc /usr/local/Cellar/* | sort -h) || true
-
 if [[ $(command -v ffmpeg) != "" ]]; then
   echo "ffmpeg exists"
+  ffmpeg -version
 fi
 
 # if [[ $SHELL == "/bin/zsh" ]]; then

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -11,7 +11,8 @@ fi
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
 # (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
 
-before=$(ls ~/Library/Caches/Homebrew/downloads)
+before_downloads=$(ls ~/Library/Caches/Homebrew/downloads)
+before_cellar=$(ls /usr/local/Cellar)
 
 # rm -rf /usr/local/Homebrew/*
 # find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
@@ -42,17 +43,22 @@ brew install ffmpeg
 # (du -shc /usr/local/Cellar/* | sort -h) || true
 # (du -shc /usr/local/Caskroom/* | sort -h) || true
 # (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
-after=$(ls ~/Library/Caches/Homebrew/downloads)
-
-echo "NEW FILES"
-comm -13 <(echo "$before") <(echo "$after")
-echo "\n\n"
+after_downloads=$(ls ~/Library/Caches/Homebrew/downloads)
+after_cellar=$(ls /usr/local/Cellar)
 
 echo "Removing previously existing files that don't need caching"
-comm -12 <(echo "$before") <(echo "$after") | while read file; do
+comm -12 <(echo "$before_downloads") <(echo "$after_downloads") | while read file; do
   echo "Removing ~/Library/Caches/Homebrew/downloads/$file"
   rm ~/Library/Caches/Homebrew/downloads/"$file"
 done
+
+comm -12 <(echo "$before_cellar") <(echo "$after_cellar") | while read file; do
+  echo "Removing /usr/local/Cellar/$file"
+  rm /usr/local/Cellar/"$file"
+done
+
+(du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+(du -shc /usr/local/Cellar/* | sort -h) || true
 
 if [[ $(command -v ffmpeg) != "" ]]; then
   echo "ffmpeg exists"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -12,8 +12,8 @@ if [[ $(command -v ffmpeg) != "" ]]; then
 fi
 
 
-brew install ffmpeg
-#  capnp \
+brew install ffmpeg \
+ capnp \
             #  coreutils \
             #  eigen \
             #  ffmpeg \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -11,10 +11,10 @@ if [[ $(command -v ffmpeg) != "" ]]; then
   ffmpeg -version
 fi
 
-brew link ffmpeg || brew install ffmpeg
-brew link capnp || brew install capnp
-brew link coreutils || brew install coreutils
-            #  coreutils \
+
+brew install ffmpeg \
+ capnp \
+             coreutils \
             #  eigen \
             #  ffmpeg \
             #  glfw \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -13,7 +13,7 @@ fi
 
 
 brew install ffmpeg \
-#  capnp \
+ capnp \
             #  coreutils \
             #  eigen \
             #  ffmpeg \

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -6,18 +6,25 @@ if [[ $(command -v brew) == "" ]]; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
-(du -shc /usr/local/Homebrew/Library/* | sort -h) || true
-(du -shc /usr/local/Cellar/* | sort -h) || true
-(du -shc /usr/local/Caskroom/* | sort -h) || true
+# (du -shc /usr/local/Homebrew/Library/* | sort -h) || true
+# (du -shc /usr/local/Cellar/* | sort -h) || true
+# (du -shc /usr/local/Caskroom/* | sort -h) || true
 (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+
+before=$(ls ~/Library/Caches/Homebrew/downloads)
 
 # rm -rf /usr/local/Homebrew/*
 # find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
-rm -rf /usr/local/Cellar/*
-rm -rf /usr/local/Caskroom/*
-rm -rf ~/Library/Caches/Homebrew/*
+# rm -rf /usr/local/Cellar/*
+# rm -rf /usr/local/Caskroom/*
+# rm -rf ~/Library/Caches/Homebrew/*
 
-brew install capnp \
+if [[ $(command -v ffmpeg) != "" ]]; then
+  echo "Cache worked!"
+fi
+
+brew install zeromq
+#  capnp \
             #  coreutils \
             #  eigen \
             #  ffmpeg \
@@ -31,10 +38,20 @@ brew install capnp \
             #  qt5 \
             #  zeromq
 
-(du -shc /usr/local/Homebrew/* | sort -h) || true
-(du -shc /usr/local/Cellar/* | sort -h) || true
-(du -shc /usr/local/Caskroom/* | sort -h) || true
+# (du -shc /usr/local/Homebrew/Library/* | sort -h) || true
+# (du -shc /usr/local/Cellar/* | sort -h) || true
+# (du -shc /usr/local/Caskroom/* | sort -h) || true
 (du -shc ~/Library/Caches/Homebrew/downloads/* | sort -h) || true
+after=$(ls ~/Library/Caches/Homebrew/downloads)
+
+echo "NEW FILES"
+new=$(comm -13 <(echo $before) <(echo $after))
+echo $new
+diff <(echo $before) <(echo $after)
+
+if [[ $(command -v ffmpeg) != "" ]]; then
+  echo "ffmpeg exists"
+fi
 
 # if [[ $SHELL == "/bin/zsh" ]]; then
 #   RC_FILE="$HOME/.zshrc"


### PR DESCRIPTION
Resolves #19627

1. Instead of caching the tar.gz downloads (that are then installed into Cellar during `brew install`), the Cellar directories themselves are now cached and `brew link`-ed on cache restore
2. Since the github action macos environment already has a bunch of homebrew things installed, they're now excluded from our cache to save several GBs of cache space/bandwidth
3. Use `restore-keys` to have fast dep installation when `mac_setup.sh` changes - still updates cache with new deps when cache key isn't an exact match - see [these docs](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key) for more info
4. A fully cached build took [less than 6 minutes](https://github.com/mayfieldiv/openpilot/runs/1637997427) in my fork, and partial caching (from `restore-keys`) will speed up other builds as well, though I didn't test the timing for that