### PR TITLE
hyundai: increase number of resume messages sent at a time

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -76,7 +76,8 @@ class CarController():
     elif CS.out.cruiseState.standstill:
       # send resume at a max freq of 10Hz
       if (frame - self.last_resume_frame)*DT_CTRL > 0.1:
-        can_sends.extend([create_clu11(self.packer, frame, CS.clu11, Buttons.RES_ACCEL)] * 20)
+        # send 25 messages at a time to increases the likelyhood of resume being accepted
+        can_sends.extend([create_clu11(self.packer, frame, CS.clu11, Buttons.RES_ACCEL)] * 25)
         self.last_resume_frame = frame
 
     # 20 Hz LFA MFA message

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -76,7 +76,7 @@ class CarController():
     elif CS.out.cruiseState.standstill:
       # send resume at a max freq of 10Hz
       if (frame - self.last_resume_frame)*DT_CTRL > 0.1:
-        # send 25 messages at a time to increases the likelyhood of resume being accepted
+        # send 25 messages at a time to increases the likelihood of resume being accepted
         can_sends.extend([create_clu11(self.packer, frame, CS.clu11, Buttons.RES_ACCEL)] * 25)
         self.last_resume_frame = frame
 


### PR DESCRIPTION
I had an instance where resume spamming didn't work for more than 3 seconds
increase it to 25 messages at a time since that seemed to be reliable: https://github.com/commaai/openpilot/pull/2314