### PR TITLE
Fix Lexus ES brake message

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -29,7 +29,7 @@ class CarState(CarStateBase):
                         cp.vl["SEATS_DOORS"]['DOOR_OPEN_RL'], cp.vl["SEATS_DOORS"]['DOOR_OPEN_RR']])
     ret.seatbeltUnlatched = cp.vl["SEATS_DOORS"]['SEATBELT_DRIVER_UNLATCHED'] != 0
 
-    ret.brakePressed = (cp.vl["BRAKE_MODULE"]['BRAKE_PRESSED'] != 0) or (cp.vl["BRAKE_MODULE2"]['BRAKE_PRESSED'] != 0)
+    ret.brakePressed = (cp.vl["BRAKE_MODULE"]['BRAKE_PRESSED'] != 0) or (cp.vl["BRAKE_2"]['BRAKE_PRESSED'] != 0)
     ret.brakeLights = bool(cp.vl["ESP_CONTROL"]['BRAKE_LIGHTS_ACC'] or ret.brakePressed)
     if self.CP.enableGasInterceptor:
       ret.gas = (cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS'] + cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS2']) / 2.
@@ -118,7 +118,7 @@ class CarState(CarStateBase):
       ("STEER_ANGLE", "STEER_ANGLE_SENSOR", 0),
       ("GEAR", "GEAR_PACKET", 0),
       ("BRAKE_PRESSED", "BRAKE_MODULE", 0),
-      ("BRAKE_PRESSED", "BRAKE_MODULE2", 0),
+      ("BRAKE_PRESSED", "BRAKE_2", 0),
       ("GAS_PEDAL", "GAS_PEDAL", 0),
       ("WHEEL_SPEED_FL", "WHEEL_SPEEDS", 0),
       ("WHEEL_SPEED_FR", "WHEEL_SPEEDS", 0),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -29,7 +29,7 @@ class CarState(CarStateBase):
                         cp.vl["SEATS_DOORS"]['DOOR_OPEN_RL'], cp.vl["SEATS_DOORS"]['DOOR_OPEN_RR']])
     ret.seatbeltUnlatched = cp.vl["SEATS_DOORS"]['SEATBELT_DRIVER_UNLATCHED'] != 0
 
-    ret.brakePressed = cp.vl["BRAKE_MODULE"]['BRAKE_PRESSED'] != 0
+    ret.brakePressed = (cp.vl["BRAKE_MODULE"]['BRAKE_PRESSED'] != 0) or (cp.vl["BRAKE_MODULE2"]['BRAKE_PRESSED'] != 0)
     ret.brakeLights = bool(cp.vl["ESP_CONTROL"]['BRAKE_LIGHTS_ACC'] or ret.brakePressed)
     if self.CP.enableGasInterceptor:
       ret.gas = (cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS'] + cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS2']) / 2.
@@ -118,6 +118,7 @@ class CarState(CarStateBase):
       ("STEER_ANGLE", "STEER_ANGLE_SENSOR", 0),
       ("GEAR", "GEAR_PACKET", 0),
       ("BRAKE_PRESSED", "BRAKE_MODULE", 0),
+      ("BRAKE_PRESSED", "BRAKE_MODULE2", 0),
       ("GAS_PEDAL", "GAS_PEDAL", 0),
       ("WHEEL_SPEED_FL", "WHEEL_SPEEDS", 0),
       ("WHEEL_SPEED_FR", "WHEEL_SPEEDS", 0),


### PR DESCRIPTION
**Description** Currently, Openpilot reads the BRAKE_PRESSED signal in the BRAKE_MODULE message in order to detect a brake press and disengage. It appears that there is a redundant brake module broadcasting the BRAKE_MODULE2 message, also containing a BRAKE_PRESSED signal. This bugfix logically ORs both signals for brake detection. 

There was an instance where pressing the brake pedal did *not* disengage OP. It was later found that the BRAKE_MODULE2 message was showing (correctly) that the brake was pressed, while the original BRAKE_MODULE message was not. This can be seen at around t=486s [here](https://my.comma.ai/cabana/?route=dc7629e7a6909176%7C2020-01-02--19-39-21&exp=1609555181&sig=ykGfLaAjc3OaQpGrsCsyXQe3ZsfbrXU1N4fAq12cfFs%3D&max=13&url=https%3A%2F%2Fchffrprivate-vzn.azureedge.net%2Fchffrprivate3%2Fv2%2Fdc7629e7a6909176%2F765ec378546d40a87b75faf6ce5882be_2020-01-02--19-39-21)

**Verification** This is difficult to verify, since a mismatch between BRAKE_MODULE and BRAKE_MODULE2 is an extremely rare event. However, this fix has been tested for thousands of miles in the past year and no issues with disengagement ever happened again.

**Route**
Route: https://my.comma.ai/37041c500fd30100/1609710437282/1609712371455 
