### PR TITLE
Refactor UIScene,prepare for update data in background thread

### DIFF
--- a/selfdrive/ui/android/ui.cc
+++ b/selfdrive/ui/android/ui.cc
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) {
     }
 
     // up one notch every 5 m/s
-    s->sound->setVolume(fmin(MAX_VOLUME, MIN_VOLUME + s->scene.controls_state.getVEgo() / 5));
+    s->sound->setVolume(fmin(MAX_VOLUME, MIN_VOLUME + s->scene.v_ego / 5));
 
     // set brightness
     float clipped_brightness = fmin(512, (s->scene.light_sensor*brightness_m) + brightness_b);

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -340,7 +340,7 @@ static void ui_draw_vision_face(UIState *s) {
   const int face_size = 96;
   const int face_x = (s->viz_rect.x + face_size + (bdr_s * 2));
   const int face_y = (s->viz_rect.bottom() - footer_h + ((footer_h - face_size) / 2));
-  ui_draw_circle_image(s->vg, face_x, face_y, face_size, s->img_face, s->scene.dmonitoring_state.getFaceDetected());
+  ui_draw_circle_image(s->vg, face_x, face_y, face_size, s->img_face, s->scene.face_detected);
 }
 
 static void ui_draw_driver_view(UIState *s) {
@@ -368,10 +368,9 @@ static void ui_draw_driver_view(UIState *s) {
   ui_draw_rect(s->vg, valid_frame_x + valid_frame_w, box_y, frame_w - valid_frame_w - (valid_frame_x - frame_x), box_h, nvgRGBA(23, 51, 73, 255));
 
   // draw face box
-  if (scene->dmonitoring_state.getFaceDetected()) {
-    auto fxy_list = scene->driver_state.getFacePosition();
-    const float face_x = fxy_list[0];
-    const float face_y = fxy_list[1];
+  if (scene->face_detected) {
+    const float face_x = scene->face_position[0];
+    const float face_y = scene->face_position[1];
     float fbox_x;
     float fbox_y = box_y + (face_y + 0.5) * box_h - 0.5 * 0.6 * box_h / 2;;
     if (!scene->is_rhd) {
@@ -393,7 +392,7 @@ static void ui_draw_driver_view(UIState *s) {
   const int face_size = 85;
   const int x = (valid_frame_x + face_size + (bdr_s * 2)) + (scene->is_rhd ? valid_frame_w - box_h / 2:0);
   const int y = (box_y + box_h - face_size - bdr_s - (bdr_s * 1.5));
-  ui_draw_circle_image(s->vg, x, y, face_size, s->img_face, scene->dmonitoring_state.getFaceDetected());
+  ui_draw_circle_image(s->vg, x, y, face_size, s->img_face, scene->face_detected);
 }
 
 static void ui_draw_vision_header(UIState *s) {

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -320,7 +320,7 @@ static void ui_draw_vision_event(UIState *s) {
   const int viz_event_w = 220;
   const int viz_event_x = s->viz_rect.right() - (viz_event_w + bdr_s*2);
   const int viz_event_y = s->viz_rect.y + (bdr_s*1.5);
-  if (s->scene.controls_state.getDecelForModel() && s->scene.controls_state.getEnabled()) {
+  if (s->scene.decel_for_model && s->scene.controls_enabled) {
     // draw winding road sign
     const int img_turn_size = 160*1.5;
     const Rect rect = {viz_event_x - (img_turn_size / 4), viz_event_y + bdr_s - 25, img_turn_size, img_turn_size};

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -112,13 +112,13 @@ static void ui_draw_circle_image(NVGcontext *vg, int x, int y, int size, int ima
   ui_draw_circle_image(vg, x, y, size, image, nvgRGBA(0, 0, 0, (255 * bg_alpha)), img_alpha);
 }
 
-static void draw_lead(UIState *s, const cereal::RadarState::LeadData::Reader &lead){
+static void draw_lead(UIState *s, const UIScene::LeadData &lead){
   // Draw lead car indicator
   float fillAlpha = 0;
   float speedBuff = 10.;
   float leadBuff = 40.;
-  float d_rel = lead.getDRel();
-  float v_rel = lead.getVRel();
+  float d_rel = lead.d_rel;
+  float v_rel = lead.v_rel;
   if (d_rel < leadBuff) {
     fillAlpha = 255*(1.0-(d_rel/leadBuff));
     if (v_rel < 0) {
@@ -126,7 +126,7 @@ static void draw_lead(UIState *s, const cereal::RadarState::LeadData::Reader &le
     }
     fillAlpha = (int)(fmin(fillAlpha, 255));
   }
-  draw_chevron(s, d_rel, lead.getYRel(), 25, nvgRGBA(201, 34, 49, fillAlpha), COLOR_YELLOW);
+  draw_chevron(s, d_rel, lead.y_rel, 25, nvgRGBA(201, 34, 49, fillAlpha), COLOR_YELLOW);
 }
 
 static void ui_draw_line(UIState *s, const vertex_data *v, const int cnt, NVGcolor *color, NVGpaint *paint) {
@@ -152,7 +152,7 @@ static void update_track_data(UIState *s, const cereal::ModelDataV2::XYZTData::R
   int max_idx = -1;
   float lead_d;
   if (s->sm->updated("radarState")) {
-    lead_d = scene->lead_data[0].getDRel()*2.;
+    lead_d = scene->lead[0].d_rel*2.;
   } else {
     lead_d = MAX_DRAW_DISTANCE;
   }
@@ -278,11 +278,11 @@ static void ui_draw_world(UIState *s) {
 
   // Draw lead indicators if openpilot is handling longitudinal
   if (scene->longitudinal_control) {
-    if (scene->lead_data[0].getStatus()) {
-      draw_lead(s, scene->lead_data[0]);
+    if (scene->lead[0].status) {
+      draw_lead(s, scene->lead[0]);
     }
-    if (scene->lead_data[1].getStatus() && (std::abs(scene->lead_data[0].getDRel() - scene->lead_data[1].getDRel()) > 3.0)) {
-      draw_lead(s, scene->lead_data[1]);
+    if (scene->lead[1].status && (std::abs(scene->lead[0].d_rel - scene->lead[1].d_rel) > 3.0)) {
+      draw_lead(s, scene->lead[1]);
     }
   }
   nvgRestore(s->vg);

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -289,11 +289,11 @@ static void ui_draw_world(UIState *s) {
 }
 
 static void ui_draw_vision_maxspeed(UIState *s) {
-  float maxspeed = s->scene.controls_state.getVCruise();
+  float maxspeed = s->scene.v_cruise;
   const bool is_cruise_set = maxspeed != 0 && maxspeed != SET_SPEED_NA;
-  if (is_cruise_set && !s->is_metric) { maxspeed *= 0.6225; }
+  if (is_cruise_set && !s->scene.is_metric) { maxspeed *= 0.6225; }
 
-  auto [x, y, w, h] = std::tuple(s->scene.viz_rect.x + (bdr_s * 2), s->scene.viz_rect.y + (bdr_s * 1.5), 184, 202);
+  auto [x, y, w, h] = std::tuple(s->viz_rect.x + (bdr_s * 2), s->viz_rect.y + (bdr_s * 1.5), 184, 202);
 
   ui_draw_rect(s->vg, x, y, w, h, COLOR_BLACK_ALPHA(100), 30);
   ui_draw_rect(s->vg, x, y, w, h, COLOR_WHITE_ALPHA(100), 20, 10);
@@ -309,11 +309,11 @@ static void ui_draw_vision_maxspeed(UIState *s) {
 }
 
 static void ui_draw_vision_speed(UIState *s) {
-  const float speed = s->scene.controls_state.getVEgo() * (s->is_metric ? 3.6 : 2.2369363);
+  const float speed = s->scene.v_ego * (s->scene.is_metric ? 3.6 : 2.2369363);
   const std::string speed_str = std::to_string((int)std::nearbyint(speed));
   nvgTextAlign(s->vg, NVG_ALIGN_CENTER | NVG_ALIGN_BASELINE);
-  ui_draw_text(s->vg, s->scene.viz_rect.centerX(), 240, speed_str.c_str(), 96 * 2.5, COLOR_WHITE, s->font_sans_bold);
-  ui_draw_text(s->vg, s->scene.viz_rect.centerX(), 320, s->is_metric ? "km/h" : "mph", 36 * 2.5, COLOR_WHITE_ALPHA(200), s->font_sans_regular);
+  ui_draw_text(s->vg, s->viz_rect.centerX(), 240, speed_str.c_str(), 96 * 2.5, COLOR_WHITE, s->font_sans_bold);
+  ui_draw_text(s->vg, s->viz_rect.centerX(), 320, s->scene.is_metric ? "km/h" : "mph", 36 * 2.5, COLOR_WHITE_ALPHA(200), s->font_sans_regular);
 }
 
 static void ui_draw_vision_event(UIState *s) {
@@ -325,7 +325,7 @@ static void ui_draw_vision_event(UIState *s) {
     const int img_turn_size = 160*1.5;
     const Rect rect = {viz_event_x - (img_turn_size / 4), viz_event_y + bdr_s - 25, img_turn_size, img_turn_size};
     ui_draw_image(s->vg, rect, s->img_turn, 1.0f);
-  } else if (s->scene.controls_state.getEngageable()) {
+  } else if (s->scene.engageable) {
     // draw steering wheel
     const int bg_wheel_size = 96;
     const int bg_wheel_x = viz_event_x + (viz_event_w-bg_wheel_size);
@@ -424,8 +424,8 @@ static void ui_draw_vision_alert(UIState *s) {
   color.a *= scene->alert_blinking_alpha;
   int alr_s = alert_size_map[scene->alert_size];
 
-  const int alr_x = scene->viz_rect.x - bdr_s;
-  const int alr_w = scene->viz_rect.w + (bdr_s * 2);
+  const int alr_x = s->viz_rect.x - bdr_s;
+  const int alr_w = s->viz_rect.w + (bdr_s * 2);
   const int alr_h = alr_s + bdr_s;
   const int alr_y = s->fb_h - alr_h;
 

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -151,13 +151,13 @@ void HomeWindow::mousePressEvent(QMouseEvent *e) {
   glWindow->wake();
 
   // Settings button click
-  if (!ui_state->scene.sidebar_collapsed && settings_btn.ptInRect(e->x(), e->y())) {
+  if (!ui_state->sidebar_collapsed && settings_btn.ptInRect(e->x(), e->y())) {
     emit openSettings();
   }
 
   // Vision click
-  if (ui_state->started && (e->x() >= ui_state->scene.viz_rect.x - bdr_s)) {
-    ui_state->scene.sidebar_collapsed = !ui_state->scene.sidebar_collapsed;
+  if (ui_state->scene.started && (e->x() >= ui_state->viz_rect.x - bdr_s)) {
+    ui_state->sidebar_collapsed = !ui_state->sidebar_collapsed;
   }
 }
 
@@ -166,7 +166,7 @@ static void handle_display_state(UIState *s, int dt, bool user_input) {
   static int awake_timeout = 0;
   awake_timeout = std::max(awake_timeout-dt, 0);
 
-  if (user_input || s->ignition || s->started) {
+  if (user_input || s->scene.ignition || s->scene.started) {
     s->awake = true;
     awake_timeout = 30*UI_FREQ;
   } else if (awake_timeout == 0) {
@@ -227,7 +227,7 @@ void GLWindow::backlightUpdate() {
   // Update brightness
   float k = (BACKLIGHT_DT / BACKLIGHT_TS) / (1.0f + BACKLIGHT_DT / BACKLIGHT_TS);
 
-  float clipped_brightness = std::min(1023.0f, (ui_state->light_sensor*brightness_m) + brightness_b);
+  float clipped_brightness = std::min(1023.0f, (ui_state->scene.light_sensor*brightness_m) + brightness_b);
   smooth_brightness = clipped_brightness * k + smooth_brightness * (1.0f - k);
   int brightness = smooth_brightness;
 
@@ -239,8 +239,8 @@ void GLWindow::backlightUpdate() {
 }
 
 void GLWindow::timerUpdate() {
-  if (ui_state->started != onroad) {
-    onroad = ui_state->started;
+  if (ui_state->scene.started != onroad) {
+    onroad = ui_state->scene.started;
     emit offroadTransition(!onroad);
 #ifdef QCOM2
     timer->setInterval(onroad ? 0 : 1000);

--- a/selfdrive/ui/sidebar.cc
+++ b/selfdrive/ui/sidebar.cc
@@ -33,15 +33,15 @@ static void ui_draw_sidebar_network_strength(UIState *s) {
       {cereal::ThermalData::NetworkStrength::GOOD, 4},
       {cereal::ThermalData::NetworkStrength::GREAT, 5}};
   const Rect rect = {58, 196, 176, 27};
-  const int img_idx = s->scene.thermal.getNetworkType() == cereal::ThermalData::NetworkType::NONE ? 0 : network_strength_map[s->scene.thermal.getNetworkStrength()];
+  const int img_idx = s->scene.network_type == cereal::ThermalData::NetworkType::NONE ? 0 : network_strength_map[s->scene.network_strength];
   ui_draw_image(s->vg, rect, s->img_network[img_idx], 1.0f);
 }
 
 static void ui_draw_sidebar_battery_icon(UIState *s) {
-  int battery_img = s->scene.thermal.getBatteryStatus() == "Charging" ? s->img_battery_charging : s->img_battery;
+  int battery_img = s->scene.battery_status == "Charging" ? s->img_battery_charging : s->img_battery;
   const Rect rect = {160, 255, 76, 36};
   ui_draw_rect(s->vg, rect.x + 6, rect.y + 5,
-               ((rect.w - 19) * (s->scene.thermal.getBatteryPercent() * 0.01)), rect.h - 11, COLOR_WHITE);
+               ((rect.w - 19) * (s->scene.battery_percent * 0.01)), rect.h - 11, COLOR_WHITE);
   ui_draw_image(s->vg, rect, battery_img, 1.0f);
 }
 

--- a/selfdrive/ui/sidebar.cc
+++ b/selfdrive/ui/sidebar.cc
@@ -56,7 +56,7 @@ static void ui_draw_sidebar_network_type(UIState *s) {
   const int network_x = 50;
   const int network_y = 273;
   const int network_w = 100;
-  const char *network_type = network_type_map[s->scene.thermal.getNetworkType()];
+  const char *network_type = network_type_map[s->scene.network_type];
   nvgFillColor(s->vg, COLOR_WHITE);
   nvgFontSize(s->vg, 48);
   nvgFontFaceId(s->vg, s->font_sans_regular);
@@ -115,8 +115,8 @@ static void ui_draw_sidebar_temp_metric(UIState *s) {
       {cereal::ThermalData::ThermalStatus::YELLOW, 1},
       {cereal::ThermalData::ThermalStatus::RED, 2},
       {cereal::ThermalData::ThermalStatus::DANGER, 3}};
-  std::string temp_val = std::to_string((int)s->scene.thermal.getAmbient()) + "°C";
-  ui_draw_sidebar_metric(s, "TEMP", temp_val.c_str(), temp_severity_map[s->scene.thermal.getThermalStatus()], 0, NULL);
+  std::string temp_val = std::to_string((int)s->scene.ambient) + "°C";
+  ui_draw_sidebar_metric(s, "TEMP", temp_val.c_str(), temp_severity_map[s->scene.thermal_status], 0, NULL);
 }
 
 static void ui_draw_sidebar_panda_metric(UIState *s) {

--- a/selfdrive/ui/sidebar.cc
+++ b/selfdrive/ui/sidebar.cc
@@ -127,7 +127,7 @@ static void ui_draw_sidebar_panda_metric(UIState *s) {
   if (s->scene.hwType == cereal::HealthData::HwType::UNKNOWN) {
     panda_severity = 2;
     panda_message = "NO\nVEHICLE";
-  } else if (s->started) {
+  } else if (s->scene.started) {
     if (s->scene.satelliteCount < 6) {
       panda_severity = 1;
       panda_message = "VEHICLE\nNO GPS";
@@ -150,7 +150,7 @@ static void ui_draw_sidebar_connectivity(UIState *s) {
 }
 
 void ui_draw_sidebar(UIState *s) {
-  if (s->scene.sidebar_collapsed) {
+  if (s->sidebar_collapsed) {
     return;
   }
   ui_draw_sidebar_background(s);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -115,31 +115,36 @@ void update_sockets(UIState *s) {
 
   if (scene.started && sm.updated("controlsState")) {
     auto event = sm["controlsState"];
-    scene.controls_state = event.getControlsState();
+    const auto cs = event.getControlsState();
+    scene.v_cruise = cs.getVCruise();
+    scene.v_ego = cs.getVEgo();
+    scene.decel_for_model = cs.getDecelForModel();
+    scene.controls_enabled = cs.getEnabled();
+    scene.engageable = cs.getEngageable();
 
     // TODO: the alert stuff shouldn't be handled here
-    auto alert_sound = scene.controls_state.getAlertSound();
-    if (scene.alert_type.compare(scene.controls_state.getAlertType()) != 0) {
+    auto alert_sound = cs.getAlertSound();
+    if (scene.alert_type.compare(cs.getAlertType()) != 0) {
       if (alert_sound == AudibleAlert::NONE) {
         s->sound->stop();
       } else {
         s->sound->play(alert_sound);
       }
     }
-    scene.alert_text1 = scene.controls_state.getAlertText1();
-    scene.alert_text2 = scene.controls_state.getAlertText2();
-    scene.alert_size = scene.controls_state.getAlertSize();
-    scene.alert_type = scene.controls_state.getAlertType();
-    auto alertStatus = scene.controls_state.getAlertStatus();
+    scene.alert_text1 = cs.getAlertText1();
+    scene.alert_text2 = cs.getAlertText2();
+    scene.alert_size = cs.getAlertSize();
+    scene.alert_type = cs.getAlertType();
+    auto alertStatus = cs.getAlertStatus();
     if (alertStatus == cereal::ControlsState::AlertStatus::USER_PROMPT) {
       scene.status = STATUS_WARNING;
     } else if (alertStatus == cereal::ControlsState::AlertStatus::CRITICAL) {
       scene.status = STATUS_ALERT;
     } else {
-      scene.status = scene.controls_state.getEnabled() ? STATUS_ENGAGED : STATUS_DISENGAGED;
+      scene.status = cs.getEnabled() ? STATUS_ENGAGED : STATUS_DISENGAGED;
     }
 
-    float alert_blinkingrate = scene.controls_state.getAlertBlinkingRate();
+    float alert_blinkingrate = cs.getAlertBlinkingRate();
     if (alert_blinkingrate > 0.) {
       if (scene.alert_blinked) {
         if (scene.alert_blinking_alpha > 0.0 && scene.alert_blinking_alpha < 1.0) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -199,7 +199,13 @@ void update_sockets(UIState *s) {
     s->sidebar_collapsed = data.getSidebarCollapsed();
   }
   if (sm.updated("thermal")) {
-    scene.thermal = sm["thermal"].getThermal();
+    const auto thermal = sm["thermal"].getThermal();
+    scene.network_type = thermal.getNetworkType();
+    scene.network_strength = thermal.getNetworkStrength();
+    scene.battery_status = thermal.getBatteryStatus();
+    scene.battery_percent = thermal.getBatteryPercent();
+    scene.ambient = thermal.getAmbient();
+    scene.thermal_status = thermal.getThermalStatus();
   }
   if (sm.updated("ubloxGnss")) {
     auto data = sm["ubloxGnss"].getUbloxGnss();
@@ -242,7 +248,7 @@ void update_sockets(UIState *s) {
     }
   }
 
-  scene.started = scene.thermal.getStarted() || scene.frontview;
+  scene.started =  sm["thermal"].getThermal().getStarted() || scene.frontview;
 }
 
 static void ui_read_params(UIState *s) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -236,10 +236,10 @@ void update_sockets(UIState *s) {
     scene.face_position[1] = fact_position[1];
   }
   if (sm.updated("dMonitoringState")) {
-    scene.dmonitoring_state = sm["dMonitoringState"].getDMonitoringState();
-    scene.is_rhd = scene.dmonitoring_state.getIsRHD();
-    scene.frontview = scene.dmonitoring_state.getIsPreview();
-    scene.face_detected = scene.dmonitoring_state.getFaceDetected();
+    const auto dm_state = sm["dMonitoringState"].getDMonitoringState();
+    scene.is_rhd = dm_state.getIsRHD();
+    scene.frontview = dm_state.getIsPreview();
+    scene.face_detected = dm_state.getFaceDetected();
   } else if (scene.frontview && (sm.frame - sm.rcv_frame("dMonitoringState")) > UI_FREQ/2) {
     scene.frontview = false;
   }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -104,6 +104,13 @@ destroy:
   s->vision_connected = false;
 }
 
+static void update_lead(const cereal::RadarState::LeadData::Reader &lead, UIScene::LeadData &lead_data) {
+  lead_data = {.status = lead.getStatus(),
+               .d_rel = lead.getDRel(),
+               .v_rel = lead.getVRel(),
+               .y_rel = lead.getYRel()};
+}
+
 void update_sockets(UIState *s) {
 
   UIScene &scene = s->scene;
@@ -163,9 +170,9 @@ void update_sockets(UIState *s) {
     }
   }
   if (sm.updated("radarState")) {
-    auto data = sm["radarState"].getRadarState();
-    scene.lead_data[0] = data.getLeadOne();
-    scene.lead_data[1] = data.getLeadTwo();
+    const auto radar_state = sm["radarState"].getRadarState();
+    update_lead(radar_state.getLeadOne(), scene.lead[0]);
+    update_lead(radar_state.getLeadTwo(), scene.lead[1]);
   }
   if (sm.updated("liveCalibration")) {
     s->world_objects_visible = true;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -218,12 +218,15 @@ void update_sockets(UIState *s) {
     scene.longitudinal_control = sm["carParams"].getCarParams().getOpenpilotLongitudinalControl();
   }
   if (sm.updated("driverState")) {
-    scene.driver_state = sm["driverState"].getDriverState();
+    const auto fact_position = sm["driverState"].getDriverState().getFacePosition();
+    scene.face_position[0] = fact_position[0];
+    scene.face_position[1] = fact_position[1];
   }
   if (sm.updated("dMonitoringState")) {
     scene.dmonitoring_state = sm["dMonitoringState"].getDMonitoringState();
     scene.is_rhd = scene.dmonitoring_state.getIsRHD();
     scene.frontview = scene.dmonitoring_state.getIsPreview();
+    scene.face_detected = scene.dmonitoring_state.getFaceDetected();
   } else if (scene.frontview && (sm.frame - sm.rcv_frame("dMonitoringState")) > UI_FREQ/2) {
     scene.frontview = false;
   }

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -128,9 +128,12 @@ typedef struct UIScene {
   int satelliteCount;
   NetStatus athenaStatus;
 
+  // driverState
+  float face_position[2] = {};
+  bool face_detected = false;
+
   cereal::ThermalData::Reader thermal;
   cereal::RadarState::LeadData::Reader lead_data[2];
-  cereal::DriverState::Reader driver_state;
   cereal::DMonitoringState::Reader dmonitoring_state;
 
   // modelV2

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -184,7 +184,6 @@ typedef struct UIState {
 
   Sound *sound;
   UIScene scene;
-  cereal::UiLayoutState::App active_app;
 
   // vision state
   bool vision_connected;
@@ -206,6 +205,9 @@ typedef struct UIState {
 
   uint64_t started_frame;
   Rect video_rect, viz_rect;
+
+  // accessed from ui & state thread
+  cereal::UiLayoutState::App active_app;
   bool sidebar_collapsed, world_objects_visible;
 } UIState;
 

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -111,8 +111,6 @@ typedef struct UIScene {
 
   mat4 extrinsic_matrix;      // Last row is 0 so we can use mat4.
 
-  
-
   // alert
   std::string alert_text1;
   std::string alert_text2;
@@ -121,6 +119,10 @@ typedef struct UIScene {
   bool alert_blinked;
   float alert_blinking_alpha;
 
+  // controlsState
+  float v_cruise = 0., v_ego = 0.;
+  bool controls_enabled = false, engageable = false, decel_for_model = false;
+
   bool ignition;
   cereal::HealthData::HwType hwType;
   int satelliteCount;
@@ -128,7 +130,6 @@ typedef struct UIScene {
 
   cereal::ThermalData::Reader thermal;
   cereal::RadarState::LeadData::Reader lead_data[2];
-  cereal::ControlsState::Reader controls_state;
   cereal::DriverState::Reader driver_state;
   cereal::DMonitoringState::Reader dmonitoring_state;
 

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -140,7 +140,12 @@ typedef struct UIScene {
   int16_t battery_percent;
   float ambient;
 
-  cereal::RadarState::LeadData::Reader lead_data[2];
+  // radarState
+  struct LeadData{
+    bool status;
+    float d_rel, v_rel, y_rel;
+  } lead[2] = {};
+
   cereal::DMonitoringState::Reader dmonitoring_state;
 
   // modelV2

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -107,14 +107,12 @@ typedef struct {
 
 typedef struct UIScene {
   UIStatus status;
-  bool started = false, is_rhd = false, frontview = false, longitudinal_control = false;
+  bool started = false, longitudinal_control = false;
 
   mat4 extrinsic_matrix;      // Last row is 0 so we can use mat4.
 
   // alert
-  std::string alert_text1;
-  std::string alert_text2;
-  std::string alert_type;
+  std::string alert_type, alert_text1, alert_text2;
   cereal::ControlsState::AlertSize alert_size;
   bool alert_blinked;
   float alert_blinking_alpha;
@@ -123,14 +121,18 @@ typedef struct UIScene {
   float v_cruise = 0., v_ego = 0.;
   bool controls_enabled = false, engageable = false, decel_for_model = false;
 
-  bool ignition;
-  cereal::HealthData::HwType hwType;
+  // ubloxGnss
   int satelliteCount;
-  NetStatus athenaStatus;
+
+  // health
+  bool ignition = false;
+  cereal::HealthData::HwType hwType = cereal::HealthData::HwType::UNKNOWN;
 
   // driverState
   float face_position[2] = {};
-  bool face_detected = false;
+
+  // dMonitoringState
+  bool is_rhd = false, frontview = false, face_detected = false;
 
   // thermal
   cereal::ThermalData::ThermalStatus thermal_status;
@@ -145,8 +147,6 @@ typedef struct UIScene {
     bool status;
     float d_rel, v_rel, y_rel;
   } lead[2] = {};
-
-  cereal::DMonitoringState::Reader dmonitoring_state;
 
   // modelV2
   cereal::ModelDataV2::Reader model;
@@ -164,13 +164,12 @@ typedef struct UIScene {
   line_vertices_data lane_line_vertices[4];
   line_vertices_data road_edge_vertices[2];
 
-  
-
   // sensors
   float light_sensor = 0, accel_sensor = 0, gyro_sensor = 0;
 
   // paramaters
   bool is_metric = false;
+  NetStatus athenaStatus;
 } UIScene;
 
 typedef struct UIState {

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -91,45 +91,6 @@ typedef struct {
   float z[TRAJECTORY_SIZE];
 } line;
 
-
-typedef struct UIScene {
-
-  mat4 extrinsic_matrix;      // Last row is 0 so we can use mat4.
-  bool world_objects_visible;
-
-  bool is_rhd;
-  bool frontview;
-  bool sidebar_collapsed;
-  // responsive layout
-  Rect viz_rect;
-
-  std::string alert_text1;
-  std::string alert_text2;
-  std::string alert_type;
-  cereal::ControlsState::AlertSize alert_size;
-
-  cereal::HealthData::HwType hwType;
-  int satelliteCount;
-  NetStatus athenaStatus;
-
-  cereal::ThermalData::Reader thermal;
-  cereal::RadarState::LeadData::Reader lead_data[2];
-  cereal::ControlsState::Reader controls_state;
-  cereal::DriverState::Reader driver_state;
-  cereal::DMonitoringState::Reader dmonitoring_state;
-  cereal::ModelDataV2::Reader model;
-  line path;
-  line outer_left_lane_line;
-  line left_lane_line;
-  line right_lane_line;
-  line outer_right_lane_line;
-  line left_road_edge;
-  line right_road_edge;
-  float max_distance;
-  float lane_line_probs[4];
-  float road_edge_stds[2];
-} UIScene;
-
 typedef struct {
   float x, y;
 } vertex_data;
@@ -144,6 +105,57 @@ typedef struct {
   int cnt;
 } track_vertices_data;
 
+typedef struct UIScene {
+  UIStatus status;
+  bool started = false, is_rhd = false, frontview = false, longitudinal_control = false;
+
+  mat4 extrinsic_matrix;      // Last row is 0 so we can use mat4.
+
+  
+
+  // alert
+  std::string alert_text1;
+  std::string alert_text2;
+  std::string alert_type;
+  cereal::ControlsState::AlertSize alert_size;
+  bool alert_blinked;
+  float alert_blinking_alpha;
+
+  bool ignition;
+  cereal::HealthData::HwType hwType;
+  int satelliteCount;
+  NetStatus athenaStatus;
+
+  cereal::ThermalData::Reader thermal;
+  cereal::RadarState::LeadData::Reader lead_data[2];
+  cereal::ControlsState::Reader controls_state;
+  cereal::DriverState::Reader driver_state;
+  cereal::DMonitoringState::Reader dmonitoring_state;
+
+  // modelV2
+  cereal::ModelDataV2::Reader model;
+  line path;
+  line outer_left_lane_line;
+  line left_lane_line;
+  line right_lane_line;
+  line outer_right_lane_line;
+  line left_road_edge;
+  line right_road_edge;
+  float max_distance;
+  float lane_line_probs[4];
+  float road_edge_stds[2];
+  track_vertices_data track_vertices;
+  line_vertices_data lane_line_vertices[4];
+  line_vertices_data road_edge_vertices[2];
+
+  
+
+  // sensors
+  float light_sensor = 0, accel_sensor = 0, gyro_sensor = 0;
+
+  // paramaters
+  bool is_metric = false;
+} UIScene;
 
 typedef struct UIState {
   // framebuffer
@@ -169,7 +181,6 @@ typedef struct UIState {
   SubMaster *sm;
 
   Sound *sound;
-  UIStatus status;
   UIScene scene;
   cereal::UiLayoutState::App active_app;
 
@@ -190,22 +201,12 @@ typedef struct UIState {
 
   // device state
   bool awake;
-  float light_sensor, accel_sensor, gyro_sensor;
-
-  bool started;
-  bool ignition;
-  bool is_metric;
-  bool longitudinal_control;
+  
   uint64_t started_frame;
 
-  bool alert_blinked;
-  float alert_blinking_alpha;
+  Rect video_rect, viz_rect;
 
-  track_vertices_data track_vertices;
-  line_vertices_data lane_line_vertices[4];
-  line_vertices_data road_edge_vertices[2];
-
-  Rect video_rect;
+  bool sidebar_collapsed, world_objects_visible;
 } UIState;
 
 void ui_init(UIState *s);

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -86,12 +86,6 @@ static std::map<UIStatus, NVGcolor> bg_colors = {
 };
 
 typedef struct {
-  float x[TRAJECTORY_SIZE];
-  float y[TRAJECTORY_SIZE];
-  float z[TRAJECTORY_SIZE];
-} line;
-
-typedef struct {
   float x, y;
 } vertex_data;
 
@@ -150,13 +144,6 @@ typedef struct UIScene {
 
   // modelV2
   cereal::ModelDataV2::Reader model;
-  line path;
-  line outer_left_lane_line;
-  line left_lane_line;
-  line right_lane_line;
-  line outer_right_lane_line;
-  line left_road_edge;
-  line right_road_edge;
   float max_distance;
   float lane_line_probs[4];
   float road_edge_stds[2];

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -203,11 +203,9 @@ typedef struct UIState {
 
   // device state
   bool awake;
-  
+
   uint64_t started_frame;
-
   Rect video_rect, viz_rect;
-
   bool sidebar_collapsed, world_objects_visible;
 } UIState;
 

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -132,7 +132,14 @@ typedef struct UIScene {
   float face_position[2] = {};
   bool face_detected = false;
 
-  cereal::ThermalData::Reader thermal;
+  // thermal
+  cereal::ThermalData::ThermalStatus thermal_status;
+  cereal::ThermalData::NetworkType network_type;
+  cereal::ThermalData::NetworkStrength network_strength;
+  std::string battery_status;
+  int16_t battery_percent;
+  float ambient;
+
   cereal::RadarState::LeadData::Reader lead_data[2];
   cereal::DMonitoringState::Reader dmonitoring_state;
 


### PR DESCRIPTION
Because we need to update and populate data  in the background thread later,the main thread is only responsible for the drawing routines.so we need to rearrange the data structure and put all the data that needs to be updated by background thread in the structure `UIScene`, and then we can copy it to the UI thread.
This PR modifies the data structure of `UIScene` and prepares for future background updates.

- [x] Put the data that needs to be updated in the background into `UIScene`
- [x] Put the data that needs to be updated by both threads into `UIState`(they should be protected by std::atomic later)
- [x] Use variables instead of ceal::read to save data for thread safety. (Except model, to make this one easier to review)

