### PR TITLE
Fix loggerd to handle binary params properly part 2 of 3

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -458,7 +458,7 @@ kj::Array<capnp::word> gen_init_data() {
     for (auto& kv : params_map) {
       auto lentry = lparams[i];
       lentry.setKey(kv.first);
-      lentry.setValue(kv.second);
+      lentry.setValue(capnp::Data::Reader((const kj::byte*)kv.second.data(), kv.second.size()));
       i++;
     }
   }


### PR DESCRIPTION
**Description** This issue has been discovered while investigating failure of the tools/lib/logreader.py to decode latest rlog with the following exception:

```
  root@localhost:/data/openpilot$ python tools/lib/logreader.py /tmp/xxx_2021-01-04--21-40-41--0--rlog
  Traceback (most recent call last):
    File "tools/lib/logreader.py", line 147, in <module>
      print(msg)
    File "capnp/lib/capnp.pyx", line 1091, in capnp.lib.capnp._DynamicStructReader.str
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd5 in position 30118: invalid continuation byte
```
Further investigation and [discussion](https://github.com/capnproto/capnproto/pull/1143) revealed that the loggerd is abusing log.capn schema by storing binary blob into a value declared as Text:
```
        ( key = "PandaFirmware",
          value = "\x11\x01[\x16|GSe\xd5\x1a+\x94\xff\\f|" ),
```
while key/value declared as:
```
struct InitData {
[...]
  params @17 :Map(Text, Text);
```
Not only that, the binary blob also gets truncated at '\0'. The real value is as follows:
```
        ( key = "PandaFirmware",
          value = (
            bin = "\021\001[\026|GSe\325\032+\224\377\\f|\000\241\321\366j\360\247\354E?:\274\205\301\035\241\241T\370X\224\031\367P\257\350*eY\223rt\246\204=\223\301u\207\277\027xE\tn\365?J\234$\032\375\226\300a\215MB\326\342 }\r\366]5\250\236\006\312\000\025\353>Y\v+U\340C\321\017M\231\0307\220\236\303\005\327\'gJ\302Kv\270V\301F8\246\030\206[\344\2239T\003\275" ) ),
```

This is part two of the change, there is also matching change for the [cereal to convert Text into Union{Text, Data}](https://github.com/commaai/cereal/pull/109) and also bug in the capnproto to pretty-print [binary data properly in python3](https://github.com/capnproto/capnproto/pull/1143). 

**Verification** Log has been collected with both cereal and this change applied and then decoded on a machine with patched pycapnp. Data is decoded correctly without any exceptions.

**Note** The automated test(s) would be failing until https://github.com/commaai/cereal/pull/109 is merged and submodule is updated. The test completes after that as can bee seen in my working branch here: https://github.com/sobomax/openpilot/actions/runs/470280650
