### PR TITLE
ui.cc: cleanup includes

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -2,12 +2,8 @@
 #include <cmath>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <signal.h>
 #include <unistd.h>
 #include <assert.h>
-#include <math.h>
-#include <poll.h>
-#include <sys/mman.h>
 
 #include "common/util.h"
 #include "common/swaglog.h"


### PR DESCRIPTION
We don’t need to include `signal.h` and `poll.h` after visionipc2.0

remove unused `math.h`,`sys/mman.h` too