### PR TITLE
Fix build error after merge utilpp.h to util.h

### DIFF
--- a/selfdrive/common/visionimg.cc
+++ b/selfdrive/common/visionimg.cc
@@ -25,7 +25,6 @@
 
 #endif // ifdef QCOM
 
-#include "common/util.h"
 #include "common/visionimg.h"
 
 #ifdef QCOM

--- a/selfdrive/common/visionimg.h
+++ b/selfdrive/common/visionimg.h
@@ -1,6 +1,4 @@
-#ifndef VISIONIMG_H
-#define VISIONIMG_H
-
+#pragma once
 #include "visionbuf.h"
 #include "common/glutil.h"
 
@@ -11,10 +9,6 @@
 #else
 typedef int EGLImageKHR;
 typedef void *EGLClientBuffer;
-#endif
-
-#ifdef __cplusplus
-extern "C" {
 #endif
 
 #define VISIONIMG_FORMAT_RGB24 1
@@ -29,9 +23,3 @@ typedef struct VisionImg {
 
 GLuint visionimg_to_gl(const VisionImg *img, EGLImageKHR *pkhr, void **pph);
 void visionimg_destroy_gl(EGLImageKHR khr, void *ph);
-
-#ifdef __cplusplus
-}  // extern "C"
-#endif
-
-#endif


### PR DESCRIPTION
fix the following compile error after merged utipp.h to util.h (relate PR:https://github.com/commaai/openpilot/pull/19710)

```
In file included from selfdrive/common/visionimg.cc:28:
In file included from selfdrive/common/util.h:6:
In file included from /system/comma/usr/bin/../include/c++/v1/string:500:
In file included from /system/comma/usr/bin/../include/c++/v1/string_view:176:
In file included from /system/comma/usr/bin/../include/c++/v1/__string:56:
In file included from /system/comma/usr/bin/../include/c++/v1/algorithm:644:
In file included from /system/comma/usr/bin/../include/c++/v1/memory:668:
/system/comma/usr/bin/../include/c++/v1/atomic:1314:1: error: C++ requires a type specifier for all declarations
atomic_compare_exchange_weak(volatile atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NOEXCEPT

```
@adeebshihadeh my bad, this PR fix the compile problem on QCOM
