### PR TITLE
util.h: extern C for write_file

### DIFF
--- a/selfdrive/common/util.cc
+++ b/selfdrive/common/util.cc
@@ -45,7 +45,7 @@ void* read_file(const char* path, size_t* out_len) {
   return buf;
 }
 
-int write_file(const char* path, const void* data, size_t size) {
+extern "C" int write_file(const char* path, const void* data, size_t size) {
   int fd = open(path, O_WRONLY);
   if (fd == -1) {
     return -1;

--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -25,7 +25,7 @@ typedef void (*sighandler_t)(int sig);
 // Returns NULL on failure, otherwise the NULL-terminated file contents.
 // The result must be freed by the caller.
 void* read_file(const char* path, size_t* out_len);
-int write_file(const char* path, const void* data, size_t size);
+extern "C" int write_file(const char* path, const void* data, size_t size);
 
 void set_thread_name(const char* name);
 


### PR DESCRIPTION
write_file is still called by C function such as set_brightness in framebuffer.cc(which is used by text.c too)