### PR TITLE
Toyota: Only use gas interceptor under 19 mph

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -72,8 +72,8 @@ class CarInterfaceBase():
     ret.openpilotLongitudinalControl = False
     ret.startAccel = 0.0
     ret.minSpeedCan = 0.3
-    ret.stoppingBrakeRate = 0.2  # brake_travel/s while trying to stop
-    ret.startingBrakeRate = 0.8  # brake_travel/s while releasing on restart
+    ret.stoppingBrakeRate = 0.2 # brake_travel/s while trying to stop
+    ret.startingBrakeRate = 0.8 # brake_travel/s while releasing on restart
     ret.stoppingControl = False
     ret.longitudinalTuning.deadzoneBP = [0.]
     ret.longitudinalTuning.deadzoneV = [0.]

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -72,8 +72,8 @@ class CarInterfaceBase():
     ret.openpilotLongitudinalControl = False
     ret.startAccel = 0.0
     ret.minSpeedCan = 0.3
-    ret.stoppingBrakeRate = 0.2 # brake_travel/s while trying to stop
-    ret.startingBrakeRate = 0.8 # brake_travel/s while releasing on restart
+    ret.stoppingBrakeRate = 0.2  # brake_travel/s while trying to stop
+    ret.startingBrakeRate = 0.8  # brake_travel/s while releasing on restart
     ret.stoppingControl = False
     ret.longitudinalTuning.deadzoneBP = [0.]
     ret.longitudinalTuning.deadzoneV = [0.]

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -4,7 +4,7 @@ from selfdrive.car import apply_toyota_steer_torque_limits, create_gas_command, 
 from selfdrive.car.toyota.toyotacan import create_steer_command, create_ui_command, \
                                            create_accel_command, create_acc_cancel_command, \
                                            create_fcw_command
-from selfdrive.car.toyota.values import Ecu, CAR, STATIC_MSGS, NO_STOP_TIMER_CAR, CarControllerParams
+from selfdrive.car.toyota.values import Ecu, CAR, STATIC_MSGS, NO_STOP_TIMER_CAR, MIN_ACC_SPEED, CarControllerParams
 from opendbc.can.packer import CANPacker
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
@@ -52,7 +52,7 @@ class CarController():
 
     apply_gas = clip(actuators.gas, 0., 1.)
 
-    if CS.CP.enableGasInterceptor:
+    if CS.CP.enableGasInterceptor and CS.out.vEgo < MIN_ACC_SPEED:
       # send only negative accel if interceptor is detected. otherwise, send the regular value
       # +0.06 offset to reduce ABS pump usage when OP is engaged
       apply_accel = 0.06 - actuators.brake
@@ -117,7 +117,7 @@ class CarController():
       else:
         can_sends.append(create_accel_command(self.packer, 0, pcm_cancel_cmd, False, lead))
 
-    if (frame % 2 == 0) and (CS.CP.enableGasInterceptor):
+    if frame % 2 == 0 and CS.CP.enableGasInterceptor and CS.out.vEgo < MIN_ACC_SPEED:
       # send exactly zero if apply_gas is zero. Interceptor will send the max between read value and apply_gas.
       # This prevents unexpected pedal range rescaling
       can_sends.append(create_gas_command(self.packer, apply_gas, frame//2))

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -17,12 +17,12 @@ def compute_gb_gas_interceptor(accel, speed):
   # This converts desired positive acceleration at a speed to gas percentage
   # It's only accurate up to MIN_ACC_SPEED (19 mph) for now since the function was fitted on data up to that speed
   # Once we reach that speed, we switch to sending acceleration anyway so this isn't a problem
-  def accel_to_gas(_speed, _accel):  # converts accel to gas using current speed
-    _c1, _c2, _c3, _c4 = [0.04412016647510183, 0.018224465923095633, 0.09983653162564889, 0.08837909527049172]
-    return (_accel * _c1 + (_c4 * (_speed * _c2 + 1))) * (_speed * _c3 + 1)
-
   if accel > -0.1 and speed <= MIN_ACC_SPEED:  # todo: -0.1 is smooth but in data user was giving gas when a_ego was down to -0.5
-    return accel_to_gas(speed, accel)
+    _c1, _c2, _c3, _c4 = [0.04412016647510183, 0.018224465923095633, 0.09983653162564889, 0.08837909527049172]
+    # fixme: this function is arbitrary, plot how accel and speed relate to gas and then make a cleaner function
+    # my guess is speed isn't linear but accel is?
+    return (accel * _c1 + (_c4 * (speed * _c2 + 1))) * (speed * _c3 + 1)
+
   return float(accel) / CarControllerParams.ACCEL_SCALE
 
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -320,10 +320,8 @@ class CarInterface(CarInterfaceBase):
     ret.communityFeature = ret.enableGasInterceptor or ret.enableDsu or smartDsu
 
     if ret.enableGasInterceptor:
-      ret.gasMaxBP = [0., 9., 35]
-      ret.gasMaxV = [0.2, 0.5, 0.7]
-      ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
-      ret.longitudinalTuning.kiV = [0.18, 0.12]
+      ret.gasMaxBP = [0., MIN_ACC_SPEED]
+      ret.gasMaxV = [0.2, 0.5]
 
     return ret
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -23,7 +23,6 @@ class CarInterface(CarInterfaceBase):
 
     ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
     ret.steerLimitTimer = 0.4
-    stop_and_go = True
 
     # Default longitudinal tune
     ret.longitudinalTuning.deadzoneBP = [0., 9.]
@@ -32,6 +31,7 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.kiBP = [0., 35.]
     ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
     ret.longitudinalTuning.kiV = [0.54, 0.36]
+    stop_and_go = True
 
     if candidate not in [CAR.PRIUS, CAR.RAV4, CAR.RAV4H]:  # These cars use LQR/INDI
       ret.lateralTuning.init('pid')

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from cereal import car
 from selfdrive.config import Conversions as CV
-from selfdrive.car.toyota.values import Ecu, ECU_FINGERPRINT, CAR, TSS2_CAR, FINGERPRINTS, CarControllerParams
+from selfdrive.car.toyota.values import Ecu, ECU_FINGERPRINT, CAR, TSS2_CAR, FINGERPRINTS, MIN_ACC_SPEED, CarControllerParams
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, is_ecu_disconnected, gen_empty_fingerprint
 from selfdrive.swaglog import cloudlog
 from selfdrive.car.interfaces import CarInterfaceBase
@@ -313,7 +313,7 @@ class CarInterface(CarInterfaceBase):
 
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter.
-    ret.minEnableSpeed = -1. if (stop_and_go or ret.enableGasInterceptor) else 19. * CV.MPH_TO_MS
+    ret.minEnableSpeed = -1. if (stop_and_go or ret.enableGasInterceptor) else MIN_ACC_SPEED
 
     # removing the DSU disables AEB and it's considered a community maintained feature
     # intercepting the DSU is a community feature since it requires unofficial hardware

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -31,13 +31,13 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.kiBP = [0., 35.]
     ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
     ret.longitudinalTuning.kiV = [0.54, 0.36]
+    stop_and_go = True
 
     if candidate not in [CAR.PRIUS, CAR.RAV4, CAR.RAV4H]:  # These cars use LQR/INDI
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
 
     if candidate == CAR.PRIUS:
-      stop_and_go = True
       ret.safetyParam = 66  # see conversion factor for STEER_TORQUE_EPS in dbc file
       ret.wheelbase = 2.70
       ret.steerRatio = 15.74   # unknown end-to-end spec
@@ -85,7 +85,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 14.8
@@ -95,7 +94,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.LEXUS_RXH:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 16.  # 14.8 is spec end-to-end
@@ -105,7 +103,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX_TSS2:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 14.8
@@ -115,7 +112,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate == CAR.LEXUS_RXH_TSS2:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 16.0  # 14.8 is spec end-to-end
@@ -125,7 +121,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate in [CAR.CHR, CAR.CHRH]:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.63906
       ret.steerRatio = 13.6
@@ -135,7 +130,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate in [CAR.CAMRY, CAR.CAMRYH, CAR.CAMRY_TSS2, CAR.CAMRYH_TSS2]:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.82448
       ret.steerRatio = 13.7
@@ -145,7 +139,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate in [CAR.HIGHLANDER_TSS2, CAR.HIGHLANDERH_TSS2]:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.84988  # 112.2 in = 2.84988 m
       ret.steerRatio = 16.0
@@ -155,7 +148,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00012  # community tuning
 
     elif candidate in [CAR.HIGHLANDER, CAR.HIGHLANDERH]:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.78
       ret.steerRatio = 16.0
@@ -175,7 +167,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.RAV4_TSS2:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.68986
       ret.steerRatio = 14.3
@@ -191,7 +182,6 @@ class CarInterface(CarInterfaceBase):
           break
 
     elif candidate == CAR.RAV4H_TSS2:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.68986
       ret.steerRatio = 14.3
@@ -207,7 +197,6 @@ class CarInterface(CarInterfaceBase):
           break
 
     elif candidate in [CAR.COROLLA_TSS2, CAR.COROLLAH_TSS2]:
-      stop_and_go = True
       ret.minSpeedCan = 0.375
       ret.safetyParam = 73
       ret.wheelbase = 2.67  # Average between 2.70 for sedan and 2.64 for hatchback
@@ -218,7 +207,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate in [CAR.LEXUS_ES_TSS2, CAR.LEXUS_ESH_TSS2]:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.8702
       ret.steerRatio = 16.0  # not optimized
@@ -228,7 +216,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate == CAR.LEXUS_ESH:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.8190
       ret.steerRatio = 16.06
@@ -238,7 +225,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate == CAR.SIENNA:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 3.03
       ret.steerRatio = 15.5
@@ -258,7 +244,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.LEXUS_CTH:
-      stop_and_go = True
       ret.safetyParam = 100
       ret.wheelbase = 2.60
       ret.steerRatio = 18.6
@@ -268,7 +253,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007
 
     elif candidate in [CAR.LEXUS_NXH, CAR.LEXUS_NX]:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.66
       ret.steerRatio = 14.7
@@ -278,7 +262,6 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.PRIUS_TSS2:
-      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.70002  # from toyota online sepc.
       ret.steerRatio = 13.4   # True steerRation from older prius

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -23,6 +23,7 @@ class CarInterface(CarInterfaceBase):
 
     ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
     ret.steerLimitTimer = 0.4
+    stop_and_go = True
 
     # Default longitudinal tune
     ret.longitudinalTuning.deadzoneBP = [0., 9.]
@@ -31,7 +32,6 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.kiBP = [0., 35.]
     ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
     ret.longitudinalTuning.kiV = [0.54, 0.36]
-    stop_and_go = True
 
     if candidate not in [CAR.PRIUS, CAR.RAV4, CAR.RAV4H]:  # These cars use LQR/INDI
       ret.lateralTuning.init('pid')

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -31,13 +31,13 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.kiBP = [0., 35.]
     ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
     ret.longitudinalTuning.kiV = [0.54, 0.36]
-    stop_and_go = True
 
     if candidate not in [CAR.PRIUS, CAR.RAV4, CAR.RAV4H]:  # These cars use LQR/INDI
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
 
     if candidate == CAR.PRIUS:
+      stop_and_go = True
       ret.safetyParam = 66  # see conversion factor for STEER_TORQUE_EPS in dbc file
       ret.wheelbase = 2.70
       ret.steerRatio = 15.74   # unknown end-to-end spec
@@ -85,6 +85,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 14.8
@@ -94,6 +95,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.LEXUS_RXH:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 16.  # 14.8 is spec end-to-end
@@ -103,6 +105,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX_TSS2:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 14.8
@@ -112,6 +115,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate == CAR.LEXUS_RXH_TSS2:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.79
       ret.steerRatio = 16.0  # 14.8 is spec end-to-end
@@ -121,6 +125,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate in [CAR.CHR, CAR.CHRH]:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.63906
       ret.steerRatio = 13.6
@@ -130,6 +135,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate in [CAR.CAMRY, CAR.CAMRYH, CAR.CAMRY_TSS2, CAR.CAMRYH_TSS2]:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.82448
       ret.steerRatio = 13.7
@@ -139,6 +145,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate in [CAR.HIGHLANDER_TSS2, CAR.HIGHLANDERH_TSS2]:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.84988  # 112.2 in = 2.84988 m
       ret.steerRatio = 16.0
@@ -148,6 +155,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00012  # community tuning
 
     elif candidate in [CAR.HIGHLANDER, CAR.HIGHLANDERH]:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.78
       ret.steerRatio = 16.0
@@ -167,6 +175,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.RAV4_TSS2:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.68986
       ret.steerRatio = 14.3
@@ -182,6 +191,7 @@ class CarInterface(CarInterfaceBase):
           break
 
     elif candidate == CAR.RAV4H_TSS2:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.68986
       ret.steerRatio = 14.3
@@ -197,6 +207,7 @@ class CarInterface(CarInterfaceBase):
           break
 
     elif candidate in [CAR.COROLLA_TSS2, CAR.COROLLAH_TSS2]:
+      stop_and_go = True
       ret.minSpeedCan = 0.375
       ret.safetyParam = 73
       ret.wheelbase = 2.67  # Average between 2.70 for sedan and 2.64 for hatchback
@@ -207,6 +218,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate in [CAR.LEXUS_ES_TSS2, CAR.LEXUS_ESH_TSS2]:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.8702
       ret.steerRatio = 16.0  # not optimized
@@ -216,6 +228,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate == CAR.LEXUS_ESH:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.8190
       ret.steerRatio = 16.06
@@ -225,6 +238,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007818594
 
     elif candidate == CAR.SIENNA:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 3.03
       ret.steerRatio = 15.5
@@ -244,6 +258,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.LEXUS_CTH:
+      stop_and_go = True
       ret.safetyParam = 100
       ret.wheelbase = 2.60
       ret.steerRatio = 18.6
@@ -253,6 +268,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00007
 
     elif candidate in [CAR.LEXUS_NXH, CAR.LEXUS_NX]:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.66
       ret.steerRatio = 14.7
@@ -262,6 +278,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     elif candidate == CAR.PRIUS_TSS2:
+      stop_and_go = True
       ret.safetyParam = 73
       ret.wheelbase = 2.70002  # from toyota online sepc.
       ret.steerRatio = 13.4   # True steerRation from older prius

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -1,8 +1,11 @@
 # flake8: noqa
 
 from selfdrive.car import dbc_dict
+from selfdrive.config import Conversions as CV
 from cereal import car
 Ecu = car.CarParams.Ecu
+
+MIN_ACC_SPEED = 19. * CV.MPH_TO_MS  # for non-stop-and-go cars only
 
 class CarControllerParams:
   ACCEL_HYST_GAP = 0.02  # don't change accel command for small oscilalitons within this value


### PR DESCRIPTION
Above 19 mph, the min ACC speed for most older Corollas, we switch from sending a gas command (which isn't what the longcontrol loop is set up to do) to sending acceleration, just like if we didn't have a comma pedal installed.

This fixes:

- oscillations that occurred above 19 mph due to the longcontrol loop being set up to control acceleration, but was actually being sent as a gas percentage
- late braking when lead slows down quickly, or with large speed differences (sometimes causing fcw). previously different pedal tuning was used which affected braking when it shouldn't have.

Also declared `stop_and_go` to start as true which removes some duplicate lines in interface

What still needs to be done:

- [x] when engaging at a stop with no lead (or even with a lead), gas is jerky and uncomfortable.
  - I used to think that it was hitting the planner acceleration limit, but now I think it's caused by the controller being set up to output acceleration instead of gas. For example, we start by commanding some small amount of acceleration from a stop, which a sng car would reach quite quickly and smoothly, but since it's actually a gas value, the output isn't enough to reach the speed/accel quick enough. Then either integral or the MPC commands a burst of "acceleration" to get us up to speed causing overshoot and then braking. I still need to download the logs and look at the data to know for sure, since you can't see any of that in Cabana

This is what accelerating from a stop with no lead looks like: https://i.imgur.com/LAxVm5h.png
