### PR TITLE
CameraBuf: private variables

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -91,37 +91,35 @@ struct MultiCameraState;
 struct CameraState;
 
 class CameraBuf {
-public:
+private:
   VisionIpcServer *vipc_server;
   CameraState *camera_state;
   cl_kernel krnl_debayer;
-  cl_command_queue q;
 
   RGBToYUVState rgb_to_yuv_state;
 
-  mat3 yuv_transform;
-
   FrameMetadata yuv_metas[YUV_COUNT];
-
   VisionStreamType rgb_type, yuv_type;
-  int rgb_width, rgb_height, rgb_stride;
-
-  FrameMetadata cur_frame_data;
-
-  VisionBuf *cur_rgb_buf;
-  VisionBuf *cur_yuv_buf;
+  
   int cur_buf_idx;
 
   std::mutex frame_queue_mutex;
   std::condition_variable frame_queue_cv;
   std::queue<size_t> frame_queue;
 
+  int frame_buf_count;
+  release_cb release_callback;
+
+public:
+  cl_command_queue q;
+  FrameMetadata cur_frame_data;
+  VisionBuf *cur_rgb_buf;
+  VisionBuf *cur_yuv_buf;
   std::unique_ptr<VisionBuf[]> camera_bufs;
   std::unique_ptr<FrameMetadata[]> camera_bufs_metadata;
-
-  int frame_buf_count;
-
-  release_cb release_callback;
+  int rgb_width, rgb_height, rgb_stride;
+  
+  mat3 yuv_transform;
 
   CameraBuf() = default;
   ~CameraBuf();


### PR DESCRIPTION
Set the variables that are only accessed by `CameraBuf` to private