### PR TITLE
OMXEncoder: Fix problematic realloc

### DIFF
--- a/selfdrive/loggerd/omx_encoder.cc
+++ b/selfdrive/loggerd/omx_encoder.cc
@@ -356,12 +356,10 @@ void OmxEncoder::handle_out_buf(OmxEncoder *e, OMX_BUFFERHEADERTYPE *out_buf) {
 
   if (e->remuxing) {
     if (!e->wrote_codec_config && e->codec_config_len > 0) {
-      if (e->codec_ctx->extradata_size < e->codec_config_len) {
-        e->codec_ctx->extradata = (uint8_t *)realloc(e->codec_ctx->extradata, e->codec_config_len + AV_INPUT_BUFFER_PADDING_SIZE);
-      }
+      // extradata will be freed by av_free() in avcodec_free_context()
+      e->codec_ctx->extradata = (uint8_t*)av_mallocz(e->codec_config_len + AV_INPUT_BUFFER_PADDING_SIZE);
       e->codec_ctx->extradata_size = e->codec_config_len;
       memcpy(e->codec_ctx->extradata, e->codec_config, e->codec_config_len);
-      memset(e->codec_ctx->extradata + e->codec_ctx->extradata_size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
 
       err = avcodec_parameters_from_context(e->out_stream->codecpar, e->codec_ctx);
       assert(err >= 0);


### PR DESCRIPTION
Replace `realloc()` and  `memset(0)`  by `av_mallocz()`

`extradata` will be freed and set to NULL by `av_free()` in `avcodec_free_context()` (https://ffmpeg.org/doxygen/4.0/libavcodec_2options_8c_source.html#l00171) when `encoder_close` is called. but extradata_size may not set to zero.calling realloc() by `if (e->codec_ctx->extradata_size < e->codec_config_len)`  is meaningless and dangerous.

In any case, it is more reasonable to use az_mallocz
