### PR TITLE
LoggerState: refactor to class

### DIFF
--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
   int r = logger_mkpath((char*)path.c_str());
   assert(r == 0);
 
-  BZFile bz_file(path.c_str());
+  BZFile bz_file(path);
 
   // Write initdata
   bz_file.write(logger_build_init_data().asBytes());

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #ifdef QCOM
 #include <cutils/properties.h>
 #endif
@@ -157,9 +158,9 @@ LoggerHandle::LoggerHandle(const std::string& route_path, int part) : part(part)
   int err = logger_mkpath((char*)log_path.c_str());
   assert(err == 0);
 
-  FILE* lock_file = fopen(lock_path.c_str(), "wb");
-  assert(lock_file != nullptr);
-  fclose(lock_file);
+  int flock = open(lock_path.c_str(), O_RDWR | O_CREAT);
+  assert(flock != -1);
+  close(flock);
 
   log = std::make_unique<BZFile>(log_path);
   qlog = std::make_unique<BZFile>(qlog_path);

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -9,6 +9,7 @@
 #include "common/version.h"
 #include "logger.h"
 
+typedef cereal::Sentinel::SentinelType SentinelType;
 
 // ***** logging helpers *****
 
@@ -114,7 +115,6 @@ std::string logger_get_route_name() {
   return route_name;
 }
 
-
 static void log_sentinel(LoggerHandle *h, SentinelType type) {
   MessageBuilder msg;
   msg.initEvent().initSentinel().setType(type);
@@ -131,6 +131,8 @@ LoggerState::LoggerState(const std::string& log_root) : part(-1) {
 
 std::shared_ptr<LoggerHandle> LoggerState::next() {
   SentinelType sentinel_type = cur_handle ? SentinelType::START_OF_SEGMENT : SentinelType::START_OF_ROUTE;
+  if (cur_handle) log_sentinel(cur_handle.get(), SentinelType::END_OF_SEGMENT);
+
   cur_handle = std::make_shared<LoggerHandle>(route_path, ++part);
 
   // log init data
@@ -141,7 +143,7 @@ std::shared_ptr<LoggerHandle> LoggerState::next() {
 }
 
 LoggerState::~LoggerState() {
-  if (cur_handle) log_sentinel(cur_handle.get(), SentinelType::END_OF_SEGMENT);
+  if (cur_handle) log_sentinel(cur_handle.get(), SentinelType::END_OF_ROUTE);
 }
 
 // LoggerHandle

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <stdio.h>
-#include <stdint.h>
 #include <memory>
 #include <mutex>
 #include <bzlib.h>
@@ -13,8 +11,6 @@ const std::string LOG_ROOT = "/data/media/0/realdata";
 #else
 const std::string LOG_ROOT = util::getenv_default("HOME", "/.comma/media/0/realdata", "/data/media/0/realdata");
 #endif
-
-#define LOGGER_MAX_HANDLES 16
 
 class BZFile {
  public:
@@ -50,7 +46,6 @@ class BZFile {
   BZFILE* bz_file = nullptr;
 };
 
-typedef cereal::Sentinel::SentinelType SentinelType;
 class LoggerHandle {
  public:
   LoggerHandle(const std::string& route_path, int part);

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -52,8 +52,8 @@ class LoggerHandle {
   ~LoggerHandle();
   void write(uint8_t* data, size_t data_size, bool in_qlog);
   inline void write(kj::ArrayPtr<capnp::byte> array, bool in_qlog) { write(array.begin(), array.size(), in_qlog); }
-  inline std::string get_segment_path() const { return segment_path; }
   inline int get_segment() const { return part; }
+  inline std::string get_segment_path() const { return segment_path; }
 
  private:
   std::mutex lock;

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -2,11 +2,10 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <pthread.h>
 #include <memory>
+#include <mutex>
 #include <bzlib.h>
-#include <kj/array.h>
-#include <capnp/serialize.h>
+#include "messaging.hpp"
 #include "common/util.h"
 
 #if defined(QCOM) || defined(QCOM2)
@@ -19,8 +18,8 @@ const std::string LOG_ROOT = util::getenv_default("HOME", "/.comma/media/0/reald
 
 class BZFile {
  public:
-  BZFile(const char* path) {
-    file = fopen(path, "wb");
+  BZFile(const std::string &path) {
+    file = fopen(path.c_str(), "wb");
     assert(file != nullptr);
     int bzerror;
     bz_file = BZ2_bzWriteOpen(&bzerror, file, 9, 0, 30);
@@ -51,38 +50,37 @@ class BZFile {
   BZFILE* bz_file = nullptr;
 };
 
-typedef struct LoggerHandle {
-  pthread_mutex_t lock;
-  int refcnt;
-  char segment_path[4096];
-  char log_path[4096];
-  char qlog_path[4096];
-  char lock_path[4096];
-  std::unique_ptr<BZFile> log, q_log;
-} LoggerHandle;
+typedef cereal::Sentinel::SentinelType SentinelType;
+class LoggerHandle {
+ public:
+  LoggerHandle(const std::string& route_path, int part);
+  ~LoggerHandle();
+  void write(uint8_t* data, size_t data_size, bool in_qlog);
+  inline void write(kj::ArrayPtr<capnp::byte> array, bool in_qlog) { write(array.begin(), array.size(), in_qlog); }
+  inline std::string get_segment_path() const { return segment_path; }
+  inline int get_segment() const { return part; }
 
-typedef struct LoggerState {
-  pthread_mutex_t lock;
+ private:
+  std::mutex lock;
+  const int part;
+  std::string segment_path, lock_path;
+  std::unique_ptr<BZFile> log, qlog;
+};
+
+class LoggerState {
+ public:
+  LoggerState(const std::string& log_root);
+  ~LoggerState();
+  std::shared_ptr<LoggerHandle> next();
+  inline std::shared_ptr<LoggerHandle> get_handle() { return cur_handle; };
+
+ private:
   int part;
+  std::string route_path;
   kj::Array<capnp::word> init_data;
-  std::string route_name;
-  char log_name[64];
-  bool has_qlog;
-
-  LoggerHandle handles[LOGGER_MAX_HANDLES];
-  LoggerHandle* cur_handle;
-} LoggerState;
+  std::shared_ptr<LoggerHandle> cur_handle;
+};
 
 int logger_mkpath(char* file_path);
 kj::Array<capnp::word> logger_build_init_data();
 std::string logger_get_route_name();
-void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
-int logger_next(LoggerState *s, const char* root_path,
-                            char* out_segment_path, size_t out_segment_path_len,
-                            int* out_part);
-LoggerHandle* logger_get_handle(LoggerState *s);
-void logger_close(LoggerState *s);
-void logger_log(LoggerState *s, uint8_t* data, size_t data_size, bool in_qlog);
-
-void lh_log(LoggerHandle* h, uint8_t* data, size_t data_size, bool in_qlog);
-void lh_close(LoggerHandle* h);

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -53,7 +53,7 @@ class LoggerHandle {
   void write(uint8_t* data, size_t data_size, bool in_qlog);
   inline void write(kj::ArrayPtr<capnp::byte> array, bool in_qlog) { write(array.begin(), array.size(), in_qlog); }
   inline int get_segment() const { return part; }
-  inline std::string get_segment_path() const { return segment_path; }
+  inline const std::string& get_segment_path() const { return segment_path; }
 
  private:
   std::mutex lock;
@@ -70,7 +70,7 @@ class LoggerState {
   inline std::shared_ptr<LoggerHandle> get_handle() { return cur_handle; };
 
  private:
-  int part;
+  int part = -1;
   std::string route_path;
   kj::Array<capnp::word> init_data;
   std::shared_ptr<LoggerHandle> cur_handle;

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -67,7 +67,7 @@ class LoggerState {
   LoggerState(const std::string& log_root);
   ~LoggerState();
   std::shared_ptr<LoggerHandle> next();
-  inline std::shared_ptr<LoggerHandle> get_handle() { return cur_handle; };
+  inline std::shared_ptr<LoggerHandle> get_handle() { assert(cur_handle); return cur_handle; };
 
  private:
   int part = -1;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -346,7 +346,7 @@ int main(int argc, char** argv) {
 
   // init logger
   s.logger = std::make_unique<LoggerState>(LOG_ROOT);
-  std::shared_ptr<LoggerHandle> lh = s.logger->next();
+  std::shared_ptr<LoggerHandle> lh;
 
   // init encoders
   pthread_mutex_init(&s.rotate_lock, NULL);

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -346,7 +346,7 @@ int main(int argc, char** argv) {
 
   // init logger
   s.logger = std::make_unique<LoggerState>(LOG_ROOT);
-  std::shared_ptr<LoggerHandle> log = s.logger->get_handle();
+  std::shared_ptr<LoggerHandle> lh = s.logger->next();
 
   // init encoders
   pthread_mutex_init(&s.rotate_lock, NULL);
@@ -392,7 +392,7 @@ int main(int argc, char** argv) {
         last_msg = msg;
 
         QlogState& qs = qlog_states[sock];
-        log->write((uint8_t*)msg->getData(), msg->getSize(), qs.counter == 0 && qs.freq != -1);
+        lh->write((uint8_t*)msg->getData(), msg->getSize(), qs.counter == 0 && qs.freq != -1);
         if (qs.freq != -1) {
           qs.counter = (qs.counter + 1) % qs.freq;
         }
@@ -456,8 +456,8 @@ int main(int argc, char** argv) {
       pthread_mutex_lock(&s.rotate_lock);
       last_rotate_tms = millis_since_boot();
 
-      log = s.logger->next();
-      LOGW((log->get_segment() == 0) ? "logging to %s" : "rotated to %s", log->get_segment_path().c_str());
+      lh = s.logger->next();
+      LOGW((lh->get_segment() == 0) ? "logging to %s" : "rotated to %s", lh->get_segment_path().c_str());
 
       // rotate encoders
       for (auto &r : s.rotate_state) r.rotate();

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -245,7 +245,7 @@ void encoder_thread(int cam_idx) {
           pthread_mutex_lock(&s.rotate_lock);
           for (auto &e : encoders) {
             e->encoder_close();
-            e->encoder_open(s.segment_path);
+            e->encoder_open(lh->get_segment_path().c_str());
           }
           rotate_state.cur_seg = lh->get_segment();
           pthread_mutex_unlock(&s.rotate_lock);

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -177,7 +177,7 @@ void encoder_thread(int cam_idx) {
   set_thread_name(cam_info.filename);
 
   int cnt = 0;
-  std::shared_ptr<LoggerHandle> lh = NULL;
+  std::shared_ptr<LoggerHandle> lh = nullptr;
   std::vector<Encoder *> encoders;
   VisionIpcClient vipc_client = VisionIpcClient("camerad", cam_info.stream_type, false);
 
@@ -226,21 +226,20 @@ void encoder_thread(int cam_idx) {
 
         // rotate the encoder if the logger is on a newer segment
         if (rotate_state.should_rotate) {
-          LOGW("camera %d rotate encoder to %s", cam_idx, lh->get_segment_path().c_str());
-
           if (!rotate_state.initialized) {
             rotate_state.last_rotate_frame_id = extra.frame_id - 1;
             rotate_state.initialized = true;
           }
-
-          // get new logger handle for new segment
-          lh = s.logger->get_handle();
 
           // wait for all to start rotating
           rotate_state.rotating = true;
           for(auto &r : s.rotate_state) {
              while(r.enabled && !r.rotating && !do_exit) util::sleep_for(5);
           }
+
+          // get new logger handle for new segment
+          lh = s.logger->get_handle();
+          LOGW("camera %d rotate encoder to %s", cam_idx, lh->get_segment_path().c_str());
 
           pthread_mutex_lock(&s.rotate_lock);
           for (auto &e : encoders) {
@@ -347,7 +346,7 @@ int main(int argc, char** argv) {
 
   // init logger
   s.logger = std::make_unique<LoggerState>(LOG_ROOT);
-  std::shared_ptr<LoggerHandle> lh;
+  std::shared_ptr<LoggerHandle> lh = nullptr;
 
   // init encoders
   pthread_mutex_init(&s.rotate_lock, NULL);
@@ -432,8 +431,8 @@ int main(int argc, char** argv) {
       delete last_msg;
     }
 
-    bool new_segment = !lh;
-    if (lh) {
+    bool new_segment = (lh == nullptr);
+    if (!new_segment) {
       double tms = millis_since_boot();
       if (tms - last_camera_seen_tms <= NO_CAMERA_PATIENCE && encoder_threads.size() > 0) {
         new_segment = true;


### PR DESCRIPTION
1. convert structs to classes.
2. use std::shared_ptr to encapsulate Logger handles.
3. get `segment_path`&`part` from LoggerHandle to ensure thread-safety 