### PR TITLE
cameras_qcom2: more readable camera_process_frame

### DIFF
--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1102,18 +1102,18 @@ void camera_process_frame(MultiCameraState *s, CameraState *c, int cnt) {
   MessageBuilder msg;
   if (c == &s->rear) {
     auto framed = msg.initEvent().initFrame();
-    fill_frame_data(framed, b->cur_frame_data, cnt);  
+    fill_frame_data(framed, b->cur_frame_data, cnt);
     framed.setTransform(b->yuv_transform.v);
     s->pm->send("frame", msg);
     if (env_send_rear) {
-      fill_frame_image(framed, b);  
+      fill_frame_image(framed, b);
     }
   } else {
     auto framed = msg.initEvent().initWideFrame();
-    fill_frame_data(framed, b->cur_frame_data, cnt);  
+    fill_frame_data(framed, b->cur_frame_data, cnt);
     s->pm->send("wideFrame", msg);
     if (env_send_wide) {
-      fill_frame_image(framed, b);  
+      fill_frame_image(framed, b);
     }
   }
 

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1102,7 +1102,7 @@ void camera_process_frame(MultiCameraState *s, CameraState *c, int cnt) {
   MessageBuilder msg;
   if (c == &s->rear) {
     auto framed = msg.initEvent().initFrame();
-    fill_frame_data(framed, b->cur_frame_data, cnt);
+    fill_frame_data(framed, b->cur_frame_data);
     framed.setTransform(b->yuv_transform.v);
     s->pm->send("frame", msg);
     if (env_send_rear) {
@@ -1110,7 +1110,7 @@ void camera_process_frame(MultiCameraState *s, CameraState *c, int cnt) {
     }
   } else {
     auto framed = msg.initEvent().initWideFrame();
-    fill_frame_data(framed, b->cur_frame_data, cnt);
+    fill_frame_data(framed, b->cur_frame_data);
     s->pm->send("wideFrame", msg);
     if (env_send_wide) {
       framed.setImage(get_frame_image(b));

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1106,14 +1106,14 @@ void camera_process_frame(MultiCameraState *s, CameraState *c, int cnt) {
     framed.setTransform(b->yuv_transform.v);
     s->pm->send("frame", msg);
     if (env_send_rear) {
-      fill_frame_image(framed, b);
+      framed.setImage(get_frame_image(b));
     }
   } else {
     auto framed = msg.initEvent().initWideFrame();
     fill_frame_data(framed, b->cur_frame_data, cnt);
     s->pm->send("wideFrame", msg);
     if (env_send_wide) {
-      fill_frame_image(framed, b);
+      framed.setImage(get_frame_image(b));
     }
   }
 


### PR DESCRIPTION
Too many ternary, use one "if else" to make it more readable.