### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
           ~/Library/Caches/pipenv
           /usr/local/Cellar
           ~/github_brew_cache_entries.txt
-        key: macos-cache-${{ hashFiles('tools/mac_setup.sh') }}
+        key: macos-cache-${{ hashFiles('**/tools/mac_setup.sh') }}
         restore-keys: macos-cache-
     - name: Brew link restored dependencies
       if: steps.dependency-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,8 +70,7 @@ jobs:
           ~/Library/Caches/pipenv
           /usr/local/Cellar
           ~/github_brew_cache_entries.txt
-        key: macos-cache-${{ hashFiles('**/tools/mac_setup.sh') }}
-        restore-keys: macos-cache-
+        key: macos-cache-${{ hashFiles('tools/mac_setup.sh') }}
     - name: Brew link restored dependencies
       if: steps.dependency-cache.outputs.cache-hit == 'true'
       run: |

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -18,7 +18,7 @@ brew install capnp \
              openssl \
              pyenv \
              qt5 \
-             zeromq || true
+             zeromq
 
 if [[ $SHELL == "/bin/zsh" ]]; then
   RC_FILE="$HOME/.zshrc"


### PR DESCRIPTION
Restore key doesn't look like it's working due to version mismatches. See https://github.com/commaai/openpilot/runs/1721452536.
The setup script doesn't change that much, so this shouldn't be a problem.