### PR TITLE
encoder: use LogCameraInfo as constructor parameters

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -217,15 +217,13 @@ void encoder_thread(int cam_idx) {
       LOGD("encoder init %dx%d", buf_info.width, buf_info.height);
 
       // main encoder
-      encoders.push_back(new Encoder(cam_info.filename, buf_info.width, buf_info.height,
-                                     cam_info.fps, cam_info.bitrate, cam_info.is_h265, cam_info.downscale));
+      cam_info.frame_width = buf_info.width;
+      cam_info.frame_height = buf_info.height;
+      encoders.push_back(new Encoder(cam_info));
 
       // qcamera encoder
       if (cam_info.has_qcamera) {
-        LogCameraInfo &qcam_info = cameras_logged[LOG_CAMERA_ID_QCAMERA];
-        encoders.push_back(new Encoder(qcam_info.filename,
-                                       qcam_info.frame_width, qcam_info.frame_height,
-                                       qcam_info.fps, qcam_info.bitrate, qcam_info.is_h265, qcam_info.downscale));
+        encoders.push_back(new Encoder(cameras_logged[LOG_CAMERA_ID_QCAMERA]));
       }
     }
 

--- a/selfdrive/loggerd/omx_encoder.h
+++ b/selfdrive/loggerd/omx_encoder.h
@@ -14,12 +14,13 @@ extern "C" {
 
 #include "encoder.h"
 #include "common/cqueue.h"
+#include "camerad/cameras/camera_common.h"
 #include "visionipc.h"
 
 // OmxEncoder, lossey codec using hardware hevc
 class OmxEncoder : public VideoEncoder {
 public:
-  OmxEncoder(const char* filename, int width, int height, int fps, int bitrate, bool h265, bool downscale);
+  OmxEncoder(const LogCameraInfo& ci);
   ~OmxEncoder();
   int encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const uint8_t *v_ptr,
                    int in_width, int in_height,

--- a/selfdrive/loggerd/raw_logger.cc
+++ b/selfdrive/loggerd/raw_logger.cc
@@ -20,10 +20,9 @@ extern "C" {
 
 #include "raw_logger.h"
 
-RawLogger::RawLogger(const char* filename, int width, int height, int fps,
-                     int bitrate, bool h265, bool downscale)
-  : filename(filename),
-    fps(fps) {
+RawLogger::RawLogger(const LogCameraInfo& ci)
+  : filename(ci.filename),
+    fps(ci.fps) {
 
   int err = 0;
 
@@ -34,8 +33,8 @@ RawLogger::RawLogger(const char* filename, int width, int height, int fps,
 
   codec_ctx = avcodec_alloc_context3(codec);
   assert(codec_ctx);
-  codec_ctx->width = width;
-  codec_ctx->height = height;
+  codec_ctx->width = ci.frame_width;
+  codec_ctx->height = ci.frame_height;
   codec_ctx->pix_fmt = AV_PIX_FMT_YUV420P;
 
   // codec_ctx->thread_count = 2;
@@ -51,11 +50,11 @@ RawLogger::RawLogger(const char* filename, int width, int height, int fps,
   frame = av_frame_alloc();
   assert(frame);
   frame->format = codec_ctx->pix_fmt;
-  frame->width = width;
-  frame->height = height;
-  frame->linesize[0] = width;
-  frame->linesize[1] = width/2;
-  frame->linesize[2] = width/2;
+  frame->width = ci.frame_width;
+  frame->height = ci.frame_height;
+  frame->linesize[0] = ci.frame_width;
+  frame->linesize[1] = ci.frame_width/2;
+  frame->linesize[2] = ci.frame_width/2;
 }
 
 RawLogger::~RawLogger() {

--- a/selfdrive/loggerd/raw_logger.h
+++ b/selfdrive/loggerd/raw_logger.h
@@ -16,11 +16,11 @@ extern "C" {
 }
 
 #include "encoder.h"
+#include "camerad/cameras/camera_common.h"
 
 class RawLogger : public VideoEncoder {
 public:
-  RawLogger(const char* filename, int width, int height, int fps,
-            int bitrate, bool h265, bool downscale);
+  RawLogger(const LogCameraInfo& ci);
   ~RawLogger();
   int encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const uint8_t *v_ptr,
                    int in_width, int in_height,


### PR DESCRIPTION
since we already have struct `LogCameraInfo,` I think it’s better to pass it directly to the constructor

