### PR TITLE
Refactor loggerd rotations

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -56,7 +56,6 @@ enum LogCameraId {
 typedef struct LogCameraInfo {
   LogCameraId id;
   const char* filename;
-  const char* frame_packet_name;
   const char* encode_idx_name;
   VisionStreamType stream_type;
   int frame_width, frame_height;

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -48,13 +48,13 @@ typedef struct CameraInfo {
   bool hdr;
 } CameraInfo;
 
-enum LogCameraId {
-  F_CAMERA,
-  D_CAMERA,
-  E_CAMERA
+enum CameraType {
+  ROAD_CAM = 0,
+  DRIVER_CAM,
+  WIDE_ROAD_CAM
 };
 typedef struct LogCameraInfo {
-  LogCameraId id;
+  CameraType type;
   const char* filename;
   const char* encode_idx_name;
   VisionStreamType stream_type;

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -29,11 +29,6 @@
 
 #define UI_BUF_COUNT 4
 #define YUV_COUNT 40
-#define LOG_CAMERA_ID_FCAMERA 0
-#define LOG_CAMERA_ID_DCAMERA 1
-#define LOG_CAMERA_ID_ECAMERA 2
-#define LOG_CAMERA_ID_QCAMERA 3
-#define LOG_CAMERA_ID_MAX 4
 
 #define HLC_THRESH 222
 #define HLC_A 80
@@ -53,7 +48,13 @@ typedef struct CameraInfo {
   bool hdr;
 } CameraInfo;
 
+enum LogCameraId {
+  F_CAMERA,
+  D_CAMERA,
+  E_CAMERA
+};
 typedef struct LogCameraInfo {
+  LogCameraId id;
   const char* filename;
   const char* frame_packet_name;
   const char* encode_idx_name;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -2,7 +2,6 @@
 #include <sys/resource.h>
 
 #include <ftw.h>
-#include <algorithm>
 #include "common/timing.h"
 #include "common/params.h"
 #include "common/swaglog.h"
@@ -315,7 +314,6 @@ int main(int argc, char** argv) {
   s.encoders_waiting = 0;
   s.cv.notify_all();
   for (auto &e : s.encoder_states) { delete e; }
-
   for (auto &[sock, socket_state] : sockets) { delete socket_state; }
   LOGW("closing logger");
   logger_close(&s.logger);

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -26,13 +26,12 @@ namespace {
 constexpr int MAIN_FPS = 20;
 
 #ifndef QCOM2
-constexpr int MAIN_BITRATE = 5000000;
-constexpr int DCAM_BITRATE = 2500000;
-const bool IS_QCOM2 = false;
+#define MAIN_BITRATE 5000000
 #define DCAM_BITRATE 2500000
+const bool IS_QCOM2 = false;
 #else
-constexpr int MAIN_BITRATE = 10000000;
-constexpr int DCAM_BITRATE = MAIN_BITRATE;
+#define MAIN_BITRATE 10000000
+#define  DCAM_BITRATE MAIN_BITRATE
 const bool IS_QCOM2 = true;
 #endif
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -43,30 +43,30 @@ const int SEGMENT_LENGTH = getenv("LOGGERD_TEST") ? atoi(getenv("LOGGERD_SEGMENT
 ExitHandler do_exit;
 
 std::map<std::string, LogCameraInfo> cameras_logged = {
-  {"frame", LogCameraInfo{.id = F_CAMERA,
+  {"roadCameraState", LogCameraInfo{
+    .id = F_CAMERA,
     .stream_type = VISION_STREAM_YUV_BACK,
     .filename = "fcamera.hevc",
-    .frame_packet_name = "roadCameraState",
     .fps = MAIN_FPS,
     .bitrate = MAIN_BITRATE,
     .is_h265 = true,
     .downscale = false,
     .has_qcamera = true}},
 #if defined(QCOM) || defined(QCOM2)
-  {"frontFrame", LogCameraInfo{.id = D_CAMERA,
+  {"driverCameraState", LogCameraInfo{
+    .id = D_CAMERA,
     .stream_type = VISION_STREAM_YUV_FRONT,
     .filename = "dcamera.hevc",
-    .frame_packet_name = "driverCameraState",
     .fps = MAIN_FPS, // on EONs, more compressed this way
     .bitrate = DCAM_BITRATE,
     .is_h265 = true,
     .downscale = false,
     .has_qcamera = false}},
 #ifdef QCOM2
-  {"wideFrame", LogCameraInfo{.id = E_CAMERA,
+  {"wideRoadCameraState", LogCameraInfo{
+    .id = E_CAMERA,
     .stream_type = VISION_STREAM_YUV_WIDE,
     .filename = "ecamera.hevc",
-    .frame_packet_name = "wideRoadCameraState",
     .fps = MAIN_FPS,
     .bitrate = MAIN_BITRATE,
     .is_h265 = true,
@@ -209,7 +209,7 @@ void EncoderState::encoder_thread() {
           // publish encode index
           MessageBuilder msg;
           // this is really ugly
-          auto eidx = ci_.id == D_CAMERA ? msg.initEvent().initFrontEncodeIdx() : (ci_.id == E_CAMERA ? msg.initEvent().initWideEncodeIdx() : msg.initEvent().initEncodeIdx());
+          auto eidx = ci_.id == D_CAMERA ? msg.initEvent().initDriverEncodeIdx() : (ci_.id == E_CAMERA ? msg.initEvent().initWideRoadEncodeIdx() : msg.initEvent().initRoadEncodeIdx());
           eidx.setFrameId(extra.frame_id);
           eidx.setTimestampSof(extra.timestamp_sof);
           eidx.setTimestampEof(extra.timestamp_eof);

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -318,6 +318,10 @@ int main(int argc, char** argv) {
   LOGW("closing logger");
   logger_close(&s.logger);
 
+  if (do_exit.power_failure){
+    LOGE("power failure");
+    sync();
+  }
   delete poller;
   delete ctx;
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -329,26 +329,19 @@ int main(int argc, char** argv) {
     s.encoders_waiting = 0;
   }
   s.cv.notify_all();
+
+  for (auto &[sock, qs] : qlog_states) delete sock;
+  delete poller;
   
   for (auto &t : encoder_threads) t.join();
 
   LOGW("closing logger");
   logger_close(&s.logger);
 
-  if (do_exit.power_failure){
-    LOGE("power failure");
-    sync();
-  }
-
-  // messaging cleanup
-  for (auto &[sock, qs] : qlog_states) delete sock;
-
   for (auto &es : s.encoder_states) {
     delete es->frame_sock;
     delete es;
   }
-
-  delete poller;
   delete s.ctx;
   return 0;
 }

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -1,6 +1,4 @@
-#include <cstdio>
 #include <cassert>
-#include <unistd.h>
 #include <sys/resource.h>
 
 #include <string>
@@ -8,8 +6,6 @@
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
-#include <random>
-
 #include <ftw.h>
 
 #include "common/timing.h"
@@ -18,13 +14,11 @@
 #include "common/util.h"
 #include "camerad/cameras/camera_common.h"
 #include "logger.h"
-#include "messaging.hpp"
 #include "services.h"
 
 #include "visionipc.h"
 #include "visionipc_client.h"
 #include "encoder.h"
-
 #if defined(QCOM) || defined(QCOM2)
 #include "omx_encoder.h"
 #define Encoder OmxEncoder
@@ -59,7 +53,8 @@ LogCameraInfo cameras_logged[] = {
     .bitrate = MAIN_BITRATE,
     .is_h265 = true,
     .downscale = false,
-    .has_qcamera = true},
+    .has_qcamera = true
+  },
   {.id = D_CAMERA,
     .stream_type = VISION_STREAM_YUV_FRONT,
     .filename = "dcamera.hevc",
@@ -68,7 +63,8 @@ LogCameraInfo cameras_logged[] = {
     .bitrate = IS_QCOM2 ? MAIN_BITRATE : 2500000,
     .is_h265 = true,
     .downscale = false,
-    .has_qcamera = false},
+    .has_qcamera = false
+  },
 #ifdef QCOM2
   {.id = E_CAMERA,
     .stream_type = VISION_STREAM_YUV_WIDE,
@@ -82,7 +78,6 @@ LogCameraInfo cameras_logged[] = {
   },
 #endif
 };
-
 const LogCameraInfo qcam_info = {
     .filename = "qcamera.ts",
     .fps = MAIN_FPS,
@@ -225,9 +220,10 @@ void encoder_thread(EncoderState *es) {
         eidx.setEncodeId(total_frame_cnt);
         eidx.setSegmentNum(encoder_segment);
         eidx.setSegmentId(out_id);
-
-        auto bytes = msg.toBytes();
-        lh_log(lh, bytes.begin(), bytes.size(), false);
+        if (lh) {
+          auto bytes = msg.toBytes();
+          lh_log(lh, bytes.begin(), bytes.size(), false);
+        }
       }
       ++segment_frame_cnt;
       ++total_frame_cnt;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -136,7 +136,7 @@ void encoder_thread(EncoderState *es) {
   set_thread_name(es->ci.filename);
 
   uint32_t total_frame_cnt = 0, segment_frame_cnt = 0;
-  LoggerHandle *lh = nullptr;
+  LoggerHandle *lh = NULL;
   std::vector<Encoder *> encoders;
   int encoder_segment = -1;
   std::string segment_path;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
   logger_init(&s.logger, "rlog", true);
   loggerd_logger_next();
 
-  const bool record_front = Params().read_db_bool("RecordFront");
+  const bool record_front = Params().getBool("RecordFront");
   // setup messaging
   std::map<SubSocket *, SocketState *> sockets;
   Context *ctx = Context::create();

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -38,12 +38,15 @@ const bool IS_QCOM2 = true;
 #endif
 
 #define NO_CAMERA_PATIENCE 500 // fall back to time-based rotation if all cameras are dead
+
 const int SEGMENT_LENGTH = getenv("LOGGERD_TEST") ? atoi(getenv("LOGGERD_SEGMENT_LENGTH")) : 60;
 
 ExitHandler do_exit;
 
 LogCameraInfo cameras_logged[] = {
+  {.id = F_CAMERA,
     .stream_type = VISION_STREAM_YUV_BACK,
+    .filename = "fcamera.hevc",
     .frame_packet_name = "roadCameraState",
     .fps = MAIN_FPS,
     .bitrate = MAIN_BITRATE,
@@ -84,8 +87,6 @@ const LogCameraInfo qcam_info = {
 #endif
 };
 
-
-namespace {
 
 typedef struct QlogState {
   int counter, freq;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -193,8 +193,6 @@ void encoder_thread(EncoderState *es) {
           should_rotate = true;
           s.encoders_waiting++;
           s.cv.wait(lk, [&] { return s.encoders_waiting == 0; });
-
-          if (do_exit) break;
         }
         if (should_rotate) {
           encoder_segment = s.rotate_segment;
@@ -203,6 +201,8 @@ void encoder_thread(EncoderState *es) {
         }
       }
       if (should_rotate) {
+        if (do_exit) break;
+
         LOGW("camera %d rotate encoder to %s", es->ci.id, segment_path.c_str());
         if (lh) {
           lh_close(lh);

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -28,11 +28,9 @@
 #if defined(QCOM) || defined(QCOM2)
 #include "omx_encoder.h"
 #define Encoder OmxEncoder
-const std::string LOG_ROOT = "/data/media/0/realdata";
 #else
 #include "raw_logger.h"
 #define Encoder RawLogger
-const std::string LOG_ROOT = util::getenv_default("HOME", "/.comma/media/0/realdata", "/data/media/0/realdata");
 #endif
 
 namespace {

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -117,7 +117,7 @@ struct LoggerdState {
 };
 LoggerdState s;
 
-static void drain_socket(LoggerHandle *lh, SubSocket *sock, QlogState &qs) {
+void drain_socket(LoggerHandle *lh, SubSocket *sock, QlogState &qs) {
   if (!lh) return;
 
   Message *msg = nullptr;
@@ -239,7 +239,7 @@ void encoder_thread(EncoderState *es) {
   }
 }
 
-static int clear_locks_fn(const char* fpath, const struct stat *sb, int tyupeflag) {
+int clear_locks_fn(const char* fpath, const struct stat *sb, int tyupeflag) {
   const char* dot = strrchr(fpath, '.');
   if (dot && strcmp(dot, ".lock") == 0) {
     unlink(fpath);
@@ -247,7 +247,7 @@ static int clear_locks_fn(const char* fpath, const struct stat *sb, int tyupefla
   return 0;
 }
 
-static void clear_locks() {
+void clear_locks() {
   ftw(LOG_ROOT.c_str(), clear_locks_fn, 16);
 }
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -197,7 +197,6 @@ void encoder_thread(EncoderState *es) {
         if (should_rotate) {
           encoder_segment = s.rotate_segment;
           segment_path = s.segment_path;
-          segment_frame_cnt = 0;
         }
       }
       if (should_rotate) {
@@ -210,6 +209,7 @@ void encoder_thread(EncoderState *es) {
           e->encoder_close();
           e->encoder_open(segment_path.c_str());
         }
+        segment_frame_cnt = 0;
       }
 
       // log frame socket


### PR DESCRIPTION
1. Remove class `RotateState`, only use one mutex `rotate_lock` to control all rotations.
2. Log frame socket in the encoder thread, sync frame id is no longer required.
3. Minimize the use of locks
