### PR TITLE
LoggerHandle: use std::mutex & simplify function logger_open

### DIFF
--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -28,9 +28,6 @@ int main(int argc, char** argv) {
   MessageBuilder init_msg;
   logger_build_init_data(init_msg);
 
-  char segment_path[4096];
-  logger_next(&logger, LOG_ROOT.c_str(), segment_path, sizeof(segment_path), nullptr);
-  LOGW("bootlog to %s", segment_path);
 
   // Open bootlog
   int r = logger_mkpath((char*)path.c_str());

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -28,6 +28,9 @@ int main(int argc, char** argv) {
   MessageBuilder init_msg;
   logger_build_init_data(init_msg);
 
+  char segment_path[4096];
+  logger_next(&logger, LOG_ROOT.c_str(), segment_path, sizeof(segment_path), nullptr);
+  LOGW("bootlog to %s", segment_path);
 
   // Open bootlog
   int r = logger_mkpath((char*)path.c_str());

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -154,8 +154,6 @@ static void log_sentinel(LoggerState *s, cereal::Sentinel::SentinelType type) {
 // ***** logging functions *****
 
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog) {
-  memset(s, 0, sizeof(*s));
-
   umask(0);
 
   pthread_mutex_init(&s->lock, NULL);

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <bzlib.h>
+#include <mutex>
 #include <kj/array.h>
 #include <capnp/serialize.h>
 
@@ -16,7 +17,7 @@ const std::string LOG_ROOT = util::getenv_default("HOME", "/.comma/media/0/reald
 #define LOGGER_MAX_HANDLES 16
 
 typedef struct LoggerHandle {
-  pthread_mutex_t lock;
+  std::mutex lock;
   int refcnt;
   char segment_path[4096];
   char log_path[4096];

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -167,7 +167,7 @@ struct LoggerdState {
   pthread_mutex_t rotate_lock;
   RotateState rotate_state[LOG_CAMERA_ID_MAX-1];
 };
-LoggerdState s;
+LoggerdState s = {};
 
 void encoder_thread(int cam_idx) {
   assert(cam_idx < LOG_CAMERA_ID_MAX-1);

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -490,8 +490,7 @@ int main(int argc, char** argv) {
       pthread_mutex_lock(&s.rotate_lock);
       last_rotate_tms = millis_since_boot();
 
-      int err = logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
-      assert(err == 0);
+      logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
       LOGW((s.logger.part == 0) ? "logging to %s" : "rotated to %s", s.segment_path);
 
       // rotate encoders


### PR DESCRIPTION
Use assert instead of goto in logger_open.because we cannot recover from the errors.