### PR TITLE
UI: cleanup draw_alerts condition

### DIFF
--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -416,8 +416,7 @@ void ui_draw(UIState *s) {
     s->scene.viz_rect.w -= sbr_w;
   }
 
-  const bool draw_alerts = s->started && s->status != STATUS_OFFROAD &&
-                           s->active_app == cereal::UiLayoutState::App::NONE;
+  const bool draw_alerts = s->started && s->active_app == cereal::UiLayoutState::App::NONE;
   const bool draw_vision = draw_alerts && s->vipc_client->connected;
 
   // GL drawing functions


### PR DESCRIPTION
remove `s->status != STATUS_OFFROAD`.it's always true if started.

https://github.com/commaai/openpilot/blob/e54db636f7453665d5e8317d9c9fb4c54196dc3e/selfdrive/ui/ui.cc#L248-L255