### PR TITLE
Fix panda:  dangling pointer problem in can_receive

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -337,7 +337,8 @@ int Panda::can_receive(kj::Array<capnp::word>& out_buf) {
   uint32_t data[RECV_SIZE/4];
   int recv = usb_bulk_read(0x81, (unsigned char*)data, RECV_SIZE);
 
-  if (recv <= 0) return 0;
+  // Not sure if this can happen
+  if (recv < 0) recv = 0;
  
   if (recv == RECV_SIZE) {
     LOGW("Receive buffer full");

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -7,6 +7,7 @@
 #include "common/swaglog.h"
 #include "common/gpio.h"
 #include "common/util.h"
+#include "messaging.hpp"
 #include "panda.h"
 
 #ifdef QCOM2
@@ -332,19 +333,19 @@ void Panda::can_send(capnp::List<cereal::CanData>::Reader can_data_list){
   delete[] send;
 }
 
-int Panda::can_receive(cereal::Event::Builder &event){
+int Panda::can_receive(kj::Array<capnp::word>& out_buf) {
   uint32_t data[RECV_SIZE/4];
   int recv = usb_bulk_read(0x81, (unsigned char*)data, RECV_SIZE);
 
-  // Not sure if this can happen
-  if (recv < 0) recv = 0;
-
+  if (recv <= 0) return 0;
+ 
   if (recv == RECV_SIZE) {
     LOGW("Receive buffer full");
   }
 
   size_t num_msg = recv / 0x10;
-  auto canData = event.initCan(num_msg);
+  MessageBuilder msg;
+  auto canData = msg.initEvent().initCan(num_msg);
 
   // populate message
   for (int i = 0; i < num_msg; i++) {
@@ -361,6 +362,6 @@ int Panda::can_receive(cereal::Event::Builder &event){
     canData[i].setDat(kj::arrayPtr((uint8_t*)&data[i*4+2], len));
     canData[i].setSrc((data[i*4+1] >> 4) & 0xff);
   }
-
+  out_buf = capnp::messageToFlatArray(msg);
   return recv;
 }

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -77,6 +77,5 @@ class Panda {
   void set_usb_power_mode(cereal::HealthData::UsbPowerMode power_mode);
   void send_heartbeat();
   void can_send(capnp::List<cereal::CanData>::Reader can_data_list);
-  int can_receive(cereal::Event::Builder &event);
-
+  int can_receive(kj::Array<capnp::word>& out_buf);
 };


### PR DESCRIPTION
1. Fix dangling pointer problem, we're returning a dangling pointer here:
    https://github.com/commaai/openpilot/blob/c9679222aebfcbf0dcce7ac00d2e03d19101a81f/selfdrive/boardd/panda.cc#L361
    dat is defined as `@2 :Data;`, the `capnp::Data::Reader` doesn't make a copy, it just reference to the `data` .
2. Do not publish empty "can" messages when there is no data 