### PR TITLE
panda: refactor get_serial, return std::string

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -151,14 +151,9 @@ bool usb_connect() {
   } else { return false; }
 
   // get panda serial
-  const char *serial_buf = panda->get_serial();
-  if (serial_buf) {
-    size_t serial_sz = strnlen(serial_buf, 16);
-
-    params.write_db_value("PandaDongleId", serial_buf, serial_sz);
-    LOGW("panda serial: %.*s", serial_sz, serial_buf);
-
-    delete[] serial_buf;
+  if (auto serial = panda->get_serial(); serial) {
+    params.write_db_value("PandaDongleId", serial->c_str(), serial->length());
+    LOGW("panda serial: %s", serial->c_str());
   } else { return false; }
 
   // power on charging, only the first time. Panda can also change mode and it causes a brief disconneciton

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -277,17 +277,10 @@ const char* Panda::get_firmware_version(){
   return NULL;
 }
 
-const char* Panda::get_serial(){
-  const char* serial_buf = new char[16]();
-
-  int err = usb_read(0xd0, 0, 0, (unsigned char*)serial_buf, 16);
-
-  if (err >= 0) {
-    return serial_buf;
-  }
-
-  delete[] serial_buf;
-  return NULL;
+std::optional<std::string> Panda::get_serial() {
+  char serial_buf[17] = {'\0'};
+  int err = usb_read(0xd0, 0, 0, (uint8_t*)serial_buf, 16);
+  return err >= 0 ? std::make_optional(serial_buf) : std::nullopt;
 }
 
 void Panda::set_power_saving(bool power_saving){

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <pthread.h>
 #include <mutex>
+#include <optional>
 
 #include <libusb-1.0/libusb.h>
 
@@ -73,7 +74,7 @@ class Panda {
   health_t get_health();
   void set_loopback(bool loopback);
   const char* get_firmware_version();
-  const char* get_serial();
+  std::optional<std::string> get_serial();
   void set_power_saving(bool power_saving);
   void set_usb_power_mode(cereal::HealthData::UsbPowerMode power_mode);
   void send_heartbeat();


### PR DESCRIPTION
return `std::vector` instead of `char *`