### PR TITLE
Fix loggcatd: removed duplicate call to android_logger_list_free

### DIFF
--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -63,7 +63,6 @@ int main() {
     pm.send("androidLog", msg);
   }
 
-  android_logger_list_close(logger_list);
   android_logger_list_free(logger_list);
   return 0;
 }


### PR DESCRIPTION
`android_logger_list_close` is defined as `android_logger_list_free`.

logger.h,184 line: `#define android_logger_list_close android_logger_list_free`