### PR TITLE
camera_webcam: add "thumbnail" to Pubmaster

### DIFF
--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -226,7 +226,7 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
               VISION_STREAM_RGB_BACK, VISION_STREAM_YUV_BACK);
   camera_init(v, &s->front, CAMERA_ID_LGC615, 10, device_id, ctx,
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
-  s->pm = new PubMaster({"frame", "frontFrame"});
+  s->pm = new PubMaster({"frame", "frontFrame", "thumbnail"});
 }
 
 void camera_autoexposure(CameraState *s, float grey_frac) {}


### PR DESCRIPTION
we publish the thumbnail message in `camera_common:processing_thread`, If "thumbnail" is not in Pubmaster, webcam will crash.
https://github.com/commaai/openpilot/blob/b80b33a9415ac4a141b9a15a3b1f1f2292d27470/selfdrive/camerad/cameras/camera_common.cc#L342-L358