### PR TITLE
rgb_yuv_init: remove memset

### DIFF
--- a/selfdrive/camerad/transforms/rgb_to_yuv.cc
+++ b/selfdrive/camerad/transforms/rgb_to_yuv.cc
@@ -6,7 +6,6 @@
 #include "rgb_to_yuv.h"
 
 void rgb_to_yuv_init(RGBToYUVState* s, cl_context ctx, cl_device_id device_id, int width, int height, int rgb_stride) {
-  memset(s, 0, sizeof(*s));
   printf("width %d, height %d, rgb_stride %d\n", width, height, rgb_stride);
   assert(width % 2 == 0);
   assert(height % 2 == 0);

--- a/selfdrive/camerad/transforms/rgb_to_yuv.h
+++ b/selfdrive/camerad/transforms/rgb_to_yuv.h
@@ -15,7 +15,5 @@ typedef struct {
 } RGBToYUVState;
 
 void rgb_to_yuv_init(RGBToYUVState* s, cl_context ctx, cl_device_id device_id, int width, int height, int rgb_stride);
-
 void rgb_to_yuv_destroy(RGBToYUVState* s);
-
 void rgb_to_yuv_queue(RGBToYUVState* s, cl_command_queue q, cl_mem rgb_cl, cl_mem yuv_cl);


### PR DESCRIPTION
remove unnecessary memset, all three member variables:`width`, `height`,`rgb_to_yuv_krnl`  have been initialized in rgb_yuv_init