### PR TITLE
Panda: do not hold the lock in the destructor

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -83,9 +83,7 @@ fail:
 }
 
 Panda::~Panda(){
-  std::lock_guard lk(usb_lock);
   cleanup();
-  connected = false;
 }
 
 void Panda::cleanup(){


### PR DESCRIPTION
hold lock here is unnecessary, panda will be deleted only after all threads are stopped.
