### PR TITLE
Put bootlog in own folder

### DIFF
--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -1,19 +1,26 @@
 #include <assert.h>
 #include <string>
+#include <cstdio>
+
+#include <bzlib.h>
 
 #include "common/swaglog.h"
 #include "common/util.h"
-#include "logger.h"
 #include "messaging.hpp"
+#include "logger.h"
 
 int main(int argc, char** argv) {
-  LoggerState logger;
-  logger_init(&logger, "bootlog", false);
+  char filename[64] = {'\0'};
 
-  char segment_path[4096];
-  int err = logger_next(&logger, LOG_ROOT.c_str(), segment_path, sizeof(segment_path), nullptr);
-  assert(err == 0);
-  LOGW("bootlog to %s", segment_path);
+  time_t rawtime = time(NULL);
+  struct tm timeinfo;
+
+  localtime_r(&rawtime, &timeinfo);
+  strftime(filename, sizeof(filename),
+           "%Y-%m-%d--%H-%M-%S.bz2", &timeinfo);
+
+  std::string path = LOG_ROOT + "/boot/" + std::string(filename);
+  LOGW("bootlog to %s", path.c_str());
 
   MessageBuilder msg;
   auto boot = msg.initEvent().initBoot();
@@ -29,9 +36,28 @@ int main(int argc, char** argv) {
   std::string launchLog = util::read_file("/tmp/launch_log");
   boot.setLaunchLog(capnp::Text::Reader(launchLog.data(), launchLog.size()));
 
-  auto bytes = msg.toBytes();
-  logger_log(&logger, bytes.begin(), bytes.size(), false);
 
-  logger_close(&logger);
+  // Open bootlog
+  int r = logger_mkpath((char*)path.c_str());
+  assert(r == 0);
+
+  FILE * file = fopen(path.c_str(), "wb");
+  assert(file != nullptr);
+
+  // Open as bz2
+  int bzerror;
+  BZFILE* bz_file = BZ2_bzWriteOpen(&bzerror, file, 9, 0, 30);
+  assert(bzerror == BZ_OK);
+
+  // Write bootlog in bz2
+  auto bytes = msg.toBytes();
+  BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
+  assert(bzerror == BZ_OK);
+
+  // Close bz2 and file
+  BZ2_bzWriteClose(&bzerror, bz_file, 0, NULL, NULL);
+  assert(bzerror == BZ_OK);
+
+  fclose(file);
   return 0;
 }

--- a/selfdrive/loggerd/config.py
+++ b/selfdrive/loggerd/config.py
@@ -4,10 +4,8 @@ from selfdrive.hardware import PC
 
 if os.environ.get('LOGGERD_ROOT', False):
   ROOT = os.environ['LOGGERD_ROOT']
-  print("Custom loggerd root: ", ROOT)
 elif PC:
   ROOT = os.path.join(str(Path.home()), ".comma", "media", "0", "realdata")
-  print(ROOT)
 else:
   ROOT = '/data/media/0/realdata/'
 

--- a/selfdrive/loggerd/config.py
+++ b/selfdrive/loggerd/config.py
@@ -1,8 +1,13 @@
 import os
+from pathlib import Path
+from selfdrive.hardware import PC
 
 if os.environ.get('LOGGERD_ROOT', False):
   ROOT = os.environ['LOGGERD_ROOT']
   print("Custom loggerd root: ", ROOT)
+elif PC:
+  ROOT = os.path.join(str(Path.home()), ".comma", "media", "0", "realdata")
+  print(ROOT)
 else:
   ROOT = '/data/media/0/realdata/'
 

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -35,7 +35,6 @@ void append_property(const char* key, const char* value, void *cookie) {
   properties->push_back(std::make_pair(std::string(key), std::string(value)));
 }
 
-// TODO: this is a duplicate of mkdir_p from params.cc
 int logger_mkpath(char* file_path) {
   assert(file_path && *file_path);
   char* p;

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -35,7 +35,8 @@ void append_property(const char* key, const char* value, void *cookie) {
   properties->push_back(std::make_pair(std::string(key), std::string(value)));
 }
 
-static int mkpath(char* file_path) {
+// TODO: this is a duplicate of mkdir_p from params.cc
+int logger_mkpath(char* file_path) {
   assert(file_path && *file_path);
   char* p;
   for (p=strchr(file_path+1, '/'); p; p=strchr(p+1, '/')) {
@@ -174,7 +175,7 @@ static LoggerHandle* logger_open(LoggerState *s, const char* root_path) {
   snprintf(h->qlog_path, sizeof(h->qlog_path), "%s/qlog.bz2", h->segment_path);
   snprintf(h->lock_path, sizeof(h->lock_path), "%s.lock", h->log_path);
 
-  err = mkpath(h->log_path);
+  err = logger_mkpath(h->log_path);
   if (err) return NULL;
 
   FILE* lock_file = fopen(h->lock_path, "wb");

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -41,6 +41,8 @@ typedef struct LoggerState {
 } LoggerState;
 
 int logger_mkpath(char* file_path);
+void logger_build_boot(MessageBuilder &msg);
+void logger_build_init_data(MessageBuilder &msg);
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
 int logger_next(LoggerState *s, const char* root_path,
                             char* out_segment_path, size_t out_segment_path_len,

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -40,6 +40,7 @@ typedef struct LoggerState {
   LoggerHandle* cur_handle;
 } LoggerState;
 
+int logger_mkpath(char* file_path);
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
 int logger_next(LoggerState *s, const char* root_path,
                             char* out_segment_path, size_t out_segment_path_len,

--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -141,9 +141,7 @@ class TestLoggerd(unittest.TestCase):
     # check length
     assert len(lr) == 2  # boot + initData
 
-    # check initData and sentinel
     self._check_init_data(lr)
-    self._check_sentinel(lr, True)
 
     # check msgs
     bootlog_msgs = [m for m in lr if m.which() == 'boot']

--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -45,15 +45,23 @@ class TestLoggerd(unittest.TestCase):
         return path
     return None
 
+  def _get_log_fn(self, x):
+    for p in x.split(' '):
+      path = Path(p.strip())
+      if path.is_file():
+        return path
+    return None
+
   def _gen_bootlog(self):
     with Timeout(5):
       out = subprocess.check_output("./bootlog", cwd=os.path.join(BASEDIR, "selfdrive/loggerd"), encoding='utf-8')
 
+    log_fn = self._get_log_fn(out)
+
     # check existence
-    d = self._get_log_dir(out)
-    path = Path(os.path.join(d, "bootlog.bz2"))
-    assert path.is_file(), "failed to create bootlog file"
-    return path
+    assert log_fn is not None
+
+    return log_fn
 
   def _check_init_data(self, msgs):
     msg = msgs[0]
@@ -132,7 +140,7 @@ class TestLoggerd(unittest.TestCase):
 
     # check length
     assert len(lr) == 4 # boot + initData + 2x sentinel
-    
+
     # check initData and sentinel
     self._check_init_data(lr)
     self._check_sentinel(lr, True)

--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -139,7 +139,7 @@ class TestLoggerd(unittest.TestCase):
     lr = list(LogReader(str(bootlog_path)))
 
     # check length
-    assert len(lr) == 4 # boot + initData + 2x sentinel
+    assert len(lr) == 2  # boot + initData
 
     # check initData and sentinel
     self._check_init_data(lr)

--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -58,7 +58,7 @@ class Uploader():
     self.last_resp = None
     self.last_exc = None
 
-    self.immediate_folders = ["crash/", "log/"]
+    self.immediate_folders = ["crash/", "boot/"]
     self.immediate_priority = {"qlog.bz2": 0, "qcamera.ts": 1}
     self.high_priority = {"rlog.bz2": 0, "fcamera.hevc": 1, "dcamera.hevc": 2, "ecamera.hevc": 3}
 

--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -58,7 +58,7 @@ class Uploader():
     self.last_resp = None
     self.last_exc = None
 
-    self.immediate_folders = ["crash/"]
+    self.immediate_folders = ["crash/", "log/"]
     self.immediate_priority = {"qlog.bz2": 0, "qcamera.ts": 1}
     self.high_priority = {"rlog.bz2": 0, "fcamera.hevc": 1, "dcamera.hevc": 2, "ecamera.hevc": 3}
 


### PR DESCRIPTION
Fixes #19796

Decided that it was cleaner to just manually open/write the bz2 files than to try integrating this into the other loggerd code. Locking functionality is not needed since this is run by manager before uploader is started.

This PR also removes the sentinel from the bootlog. I don't think those make sense.