### PR TITLE
bootlog: fix dangling pointer problem in logger_build_boot

### DIFF
--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -35,13 +35,15 @@ int main(int argc, char** argv) {
   assert(bzerror == BZ_OK);
 
   // Write initdata
-  kj::Array<capnp::byte> init_msg = logger_build_init_data();
-  BZ2_bzWrite(&bzerror, bz_file, init_msg.begin(), init_msg.size());
+  kj::Array<capnp::word> init_msg = logger_build_init_data();
+  auto bytes = init_msg.asBytes();
+  BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
   assert(bzerror == BZ_OK);
 
   // Write bootlog
-  kj::Array<capnp::byte> boot_msg = logger_build_boot();
-  BZ2_bzWrite(&bzerror, bz_file, boot_msg.begin(), boot_msg.size());
+  kj::Array<capnp::word> boot_msg = logger_build_boot();
+  bytes = boot_msg.asBytes();
+  BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
   assert(bzerror == BZ_OK);
 
   // Close bz2 and file

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -22,13 +22,6 @@ int main(int argc, char** argv) {
   std::string path = LOG_ROOT + "/boot/" + std::string(filename);
   LOGW("bootlog to %s", path.c_str());
 
-  MessageBuilder boot_msg;
-  logger_build_boot(boot_msg);
-
-  MessageBuilder init_msg;
-  logger_build_init_data(init_msg);
-
-
   // Open bootlog
   int r = logger_mkpath((char*)path.c_str());
   assert(r == 0);
@@ -42,12 +35,15 @@ int main(int argc, char** argv) {
   assert(bzerror == BZ_OK);
 
   // Write initdata
+  MessageBuilder init_msg;
+  logger_build_init_data(init_msg);
   auto bytes = init_msg.toBytes();
   BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
   assert(bzerror == BZ_OK);
 
   // Write bootlog
-  bytes = boot_msg.toBytes();
+  kj::Array<capnp::word> boot_msg = logger_build_boot();
+  bytes = boot_msg.asBytes();
   BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
   assert(bzerror == BZ_OK);
 

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -35,9 +35,8 @@ int main(int argc, char** argv) {
   assert(bzerror == BZ_OK);
 
   // Write initdata
-  MessageBuilder init_msg;
-  logger_build_init_data(init_msg);
-  auto bytes = init_msg.toBytes();
+  kj::Array<capnp::word> init_msg = logger_build_init_data();
+  auto bytes = init_msg.asBytes();
   BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
   assert(bzerror == BZ_OK);
 

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -35,15 +35,13 @@ int main(int argc, char** argv) {
   assert(bzerror == BZ_OK);
 
   // Write initdata
-  kj::Array<capnp::word> init_msg = logger_build_init_data();
-  auto bytes = init_msg.asBytes();
-  BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
+  kj::Array<capnp::byte> init_msg = logger_build_init_data();
+  BZ2_bzWrite(&bzerror, bz_file, init_msg.begin(), init_msg.size());
   assert(bzerror == BZ_OK);
 
   // Write bootlog
-  kj::Array<capnp::word> boot_msg = logger_build_boot();
-  bytes = boot_msg.asBytes();
-  BZ2_bzWrite(&bzerror, bz_file, bytes.begin(), bytes.size());
+  kj::Array<capnp::byte> boot_msg = logger_build_boot();
+  BZ2_bzWrite(&bzerror, bz_file, boot_msg.begin(), boot_msg.size());
   assert(bzerror == BZ_OK);
 
   // Close bz2 and file

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -52,7 +52,7 @@ int logger_mkpath(char* file_path) {
 }
 
 // ***** log metadata *****
-kj::Array<capnp::word> logger_build_boot() {
+kj::Array<capnp::byte> logger_build_boot() {
   MessageBuilder msg;
   auto boot = msg.initEvent().initBoot();
 
@@ -66,10 +66,10 @@ kj::Array<capnp::word> logger_build_boot() {
 
   std::string launchLog = util::read_file("/tmp/launch_log");
   boot.setLaunchLog(capnp::Text::Reader(launchLog.data(), launchLog.size()));
-  return capnp::messageToFlatArray(msg);
+  return capnp::messageToFlatArray(msg).releaseAsBytes();
 }
 
-kj::Array<capnp::word> logger_build_init_data() {
+kj::Array<capnp::byte> logger_build_init_data() {
   MessageBuilder msg;
   auto init = msg.initEvent().initInitData();
 
@@ -135,13 +135,12 @@ kj::Array<capnp::word> logger_build_init_data() {
       i++;
     }
   }
-  return capnp::messageToFlatArray(msg);
+  return capnp::messageToFlatArray(msg).releaseAsBytes();
 }
 
 void log_init_data(LoggerState *s) {
-  kj::Array<capnp::word> data = logger_build_init_data();
-  auto bytes = data.asBytes();
-  logger_log(s, bytes.begin(), bytes.size(), s->has_qlog);
+  kj::Array<capnp::byte> data = logger_build_init_data();
+  logger_log(s, data.begin(), data.size(), s->has_qlog);
 }
 
 

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -52,7 +52,8 @@ int logger_mkpath(char* file_path) {
 }
 
 // ***** log metadata *****
-void logger_build_boot(MessageBuilder &msg) {
+kj::Array<capnp::word> logger_build_boot() {
+  MessageBuilder msg;
   auto boot = msg.initEvent().initBoot();
 
   boot.setWallTimeNanos(nanos_since_epoch());
@@ -65,6 +66,7 @@ void logger_build_boot(MessageBuilder &msg) {
 
   std::string launchLog = util::read_file("/tmp/launch_log");
   boot.setLaunchLog(capnp::Text::Reader(launchLog.data(), launchLog.size()));
+  return capnp::messageToFlatArray(msg);
 }
 
 void logger_build_init_data(MessageBuilder &msg) {

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -139,8 +139,7 @@ kj::Array<capnp::word> logger_build_init_data() {
 }
 
 void log_init_data(LoggerState *s) {
-  kj::Array<capnp::word> data = logger_build_init_data();
-  auto bytes = data.asBytes();
+  auto bytes = s->init_data.asBytes();
   logger_log(s, bytes.begin(), bytes.size(), s->has_qlog);
 }
 
@@ -157,8 +156,6 @@ static void log_sentinel(LoggerState *s, cereal::Sentinel::SentinelType type) {
 // ***** logging functions *****
 
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog) {
-  memset(s, 0, sizeof(*s));
-
   umask(0);
 
   pthread_mutex_init(&s->lock, NULL);
@@ -173,6 +170,8 @@ void logger_init(LoggerState *s, const char* log_name, bool has_qlog) {
   strftime(s->route_name, sizeof(s->route_name),
            "%Y-%m-%d--%H-%M-%S", &timeinfo);
   snprintf(s->log_name, sizeof(s->log_name), "%s", log_name);
+
+  s->init_data = logger_build_init_data();
 }
 
 static LoggerHandle* logger_open(LoggerState *s, const char* root_path) {

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -69,7 +69,8 @@ kj::Array<capnp::word> logger_build_boot() {
   return capnp::messageToFlatArray(msg);
 }
 
-void logger_build_init_data(MessageBuilder &msg) {
+kj::Array<capnp::word> logger_build_init_data() {
+  MessageBuilder msg;
   auto init = msg.initEvent().initInitData();
 
   if (util::file_exists("/EON")) {
@@ -134,12 +135,12 @@ void logger_build_init_data(MessageBuilder &msg) {
       i++;
     }
   }
+  return capnp::messageToFlatArray(msg);
 }
 
 void log_init_data(LoggerState *s) {
-  MessageBuilder msg;
-  logger_build_init_data(msg);
-  auto bytes = msg.toBytes();
+  kj::Array<capnp::word> data = logger_build_init_data();
+  auto bytes = data.asBytes();
   logger_log(s, bytes.begin(), bytes.size(), s->has_qlog);
 }
 

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -52,7 +52,7 @@ int logger_mkpath(char* file_path) {
 }
 
 // ***** log metadata *****
-kj::Array<capnp::byte> logger_build_boot() {
+kj::Array<capnp::word> logger_build_boot() {
   MessageBuilder msg;
   auto boot = msg.initEvent().initBoot();
 
@@ -66,10 +66,10 @@ kj::Array<capnp::byte> logger_build_boot() {
 
   std::string launchLog = util::read_file("/tmp/launch_log");
   boot.setLaunchLog(capnp::Text::Reader(launchLog.data(), launchLog.size()));
-  return capnp::messageToFlatArray(msg).releaseAsBytes();
+  return capnp::messageToFlatArray(msg);
 }
 
-kj::Array<capnp::byte> logger_build_init_data() {
+kj::Array<capnp::word> logger_build_init_data() {
   MessageBuilder msg;
   auto init = msg.initEvent().initInitData();
 
@@ -135,12 +135,13 @@ kj::Array<capnp::byte> logger_build_init_data() {
       i++;
     }
   }
-  return capnp::messageToFlatArray(msg).releaseAsBytes();
+  return capnp::messageToFlatArray(msg);
 }
 
 void log_init_data(LoggerState *s) {
-  kj::Array<capnp::byte> data = logger_build_init_data();
-  logger_log(s, data.begin(), data.size(), s->has_qlog);
+  kj::Array<capnp::word> data = logger_build_init_data();
+  auto bytes = data.asBytes();
+  logger_log(s, bytes.begin(), bytes.size(), s->has_qlog);
 }
 
 

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -32,6 +32,7 @@ typedef struct LoggerHandle {
 typedef struct LoggerState {
   pthread_mutex_t lock;
   int part;
+  kj::Array<capnp::word> init_data;
   char route_name[64];
   char log_name[64];
   bool has_qlog;

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -42,7 +42,7 @@ typedef struct LoggerState {
 
 int logger_mkpath(char* file_path);
 kj::Array<capnp::word> logger_build_boot();
-void logger_build_init_data(MessageBuilder &msg);
+kj::Array<capnp::word> logger_build_init_data();
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
 int logger_next(LoggerState *s, const char* root_path,
                             char* out_segment_path, size_t out_segment_path_len,

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -41,7 +41,7 @@ typedef struct LoggerState {
 } LoggerState;
 
 int logger_mkpath(char* file_path);
-void logger_build_boot(MessageBuilder &msg);
+kj::Array<capnp::word> logger_build_boot();
 void logger_build_init_data(MessageBuilder &msg);
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
 int logger_next(LoggerState *s, const char* root_path,

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -41,8 +41,8 @@ typedef struct LoggerState {
 } LoggerState;
 
 int logger_mkpath(char* file_path);
-kj::Array<capnp::word> logger_build_boot();
-kj::Array<capnp::word> logger_build_init_data();
+kj::Array<capnp::byte> logger_build_boot();
+kj::Array<capnp::byte> logger_build_init_data();
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
 int logger_next(LoggerState *s, const char* root_path,
                             char* out_segment_path, size_t out_segment_path_len,

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -41,8 +41,8 @@ typedef struct LoggerState {
 } LoggerState;
 
 int logger_mkpath(char* file_path);
-kj::Array<capnp::byte> logger_build_boot();
-kj::Array<capnp::byte> logger_build_init_data();
+kj::Array<capnp::word> logger_build_boot();
+kj::Array<capnp::word> logger_build_init_data();
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
 int logger_next(LoggerState *s, const char* root_path,
                             char* out_segment_path, size_t out_segment_path_len,

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -161,7 +161,7 @@ private:
 
 struct LoggerdState {
   Context *ctx;
-  LoggerState logger;
+  LoggerState logger = {};
   char segment_path[4096];
   int rotate_segment;
   pthread_mutex_t rotate_lock;


### PR DESCRIPTION
1.fix dangling pointer problem in function  `logger_build_boot` and `logger_build_init_data` : string will be deleted after function return,capnp::Data::Reader is just a refer to that address.
2. cache `init_data` in `LogState,` fix each segment in a route having a different initial logMonoTime : https://github.com/commaai/openpilot/pull/19947