### PR TITLE
pigeon_publish_raw: use capnp::Data::Reader instead of Builder

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -460,8 +460,7 @@ void hardware_control_thread() {
 static void pigeon_publish_raw(PubMaster &pm, const std::string &dat) {
   // create message
   MessageBuilder msg;
-  capnp::Data::Builder ublox_row((uint8_t*)dat.data(), dat.length());
-  msg.initEvent().setUbloxRaw(ublox_row);
+  msg.initEvent().setUbloxRaw(capnp::Data::Reader((uint8_t*)dat.data(), dat.length()));
   pm.send("ubloxRaw", msg);
 }
 


### PR DESCRIPTION
@pd0wm  I should use reader here.although the builder can do well too, but there is an extra call to `Builder::asReader()`.