### PR TITLE
boardd: delete params "CarVin"&"CarParams" in safety_setter_thread

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -124,7 +124,6 @@ void safety_setter_thread() {
   safety_setter_thread_running = false;
 }
 
-
 bool usb_connect() {
   std::unique_ptr<Panda> tmp_panda;
   try {


### PR DESCRIPTION
According to the current logic,  it may be better to delete them in the `safety_setter_thread()`  to ensure the integrity of the operation