### PR TITLE
Panda: remove lock in destructor

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -72,9 +72,7 @@ fail:
 }
 
 Panda::~Panda(){
-  std::lock_guard lk(usb_lock);
   cleanup();
-  connected = false;
 }
 
 void Panda::cleanup(){


### PR DESCRIPTION
panda is deleted after` threads.join(),` we don't need lock in destructor. 