### PR TITLE
esp carFw missing. Car is 2021 Hyundai Sonata SEL

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -195,6 +195,7 @@ FW_VERSIONS = {
       b'\xf1\x00DN ESC \x06 104\x19\x08\x01 58910-L0100',
       b'\xf1\x8758910-L0100\xf1\x00DN ESC \x06 104\x19\x08\x01 58910-L0100\xf1\xa01.04',
       b'\xf1\x8758910-L0100\xf1\x00DN ESC \x07 104\x19\x08\x01 58910-L0100\xf1\xa01.04',
+      b'\xf1\x8758910-L0100\xf1\x00DN ESC \a 106 \a\x01 58910-L0100\xf1\xa01.06',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'HM6M2_0a0_BD0',


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->


**Description** 
Added another fingerprint for 2021 Hyundai Sonata SEL

**Verification** Made sure my car would be recognized by the comma two.

**Route**
Route: comma two 654df30d2b0bf782|2021-01-29--17-21-04


