### PR TITLE
Test to check return type of get_token()

### DIFF
--- a/common/tests/test_get_token.py
+++ b/common/tests/test_get_token.py
@@ -1,0 +1,29 @@
+import unittest
+import os
+
+from common.api import Api
+from common.file_helpers import mkdirs_exists_ok
+from common.basedir import PERSIST
+
+class TestApiGetToken(unittest.TestCase):
+	def is_private_key_generated():
+		mkdirs_exists_ok(PERSIST+"/comma")
+		assert os.system("openssl genrsa -out "+PERSIST+"/comma/id_rsa.tmp 2048") == 0
+		assert os.system("openssl rsa -in "+PERSIST+"/comma/id_rsa.tmp -pubout -out "+PERSIST+"/comma/id_rsa.tmp.pub") == 0
+		os.rename(PERSIST+"/comma/id_rsa.tmp", PERSIST+"/comma/id_rsa")
+		os.rename(PERSIST+"/comma/id_rsa.tmp.pub", PERSIST+"/comma/id_rsa.pub")
+	
+	def test_get_token(self):
+		# This is prerequisite to create jwt token
+		self.is_private_key_generated()
+		
+		# Create Api class object with dummy DongleId
+		test_obj = Api("cb38263377b873ee")
+		# Obtain a jwt token
+		test_token = test_obj.get_token()	
+		
+		# The token must be a string
+		assert isinstance(test_token, str) == True
+		
+if __name__ == "__main__":
+	unittest.main()		

--- a/common/tests/test_get_token.py
+++ b/common/tests/test_get_token.py
@@ -6,7 +6,7 @@ from common.file_helpers import mkdirs_exists_ok
 from common.basedir import PERSIST
 
 class TestApiGetToken(unittest.TestCase):
-	def is_private_key_generated():
+	def is_private_key_generated(self):
 		mkdirs_exists_ok(PERSIST+"/comma")
 		assert os.system("openssl genrsa -out "+PERSIST+"/comma/id_rsa.tmp 2048") == 0
 		assert os.system("openssl rsa -in "+PERSIST+"/comma/id_rsa.tmp -pubout -out "+PERSIST+"/comma/id_rsa.tmp.pub") == 0


### PR DESCRIPTION
The get_token() must return a `str`, but for PyJWT version < 2.0.0 the jwt.encode() returns `bytes`. This test is to make sure if token returned by get_token() is `str`.
Check issue #19958 .

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_car_models](../../selfdrive/test/test_car_models.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
