### PR TITLE
logcatd:  fix bug: subsequent reads after the first always return empty

### DIFF
--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -5,57 +5,53 @@
 #include "common/util.h"
 #include "messaging.hpp"
 
-ExitHandler do_exit;
-log_time last_log_time = {};
-
-static void publish_log(PubMaster &pm) {
-  // setup android logging
-  logger_list *loggers =
-      last_log_time.tv_sec == 0
-          ? android_logger_list_alloc(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, 0, 0)
-          : android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0);
-  assert(loggers);
-
-  const log_id_t log_ids[] = {LOG_ID_MAIN, LOG_ID_RADIO, LOG_ID_SYSTEM, LOG_ID_CRASH, (log_id_t)5};
-  for (const auto &id : log_ids) {
-    struct logger *log = android_logger_open(loggers, id);
-    assert(log != nullptr);
-  }
-
-  while (!do_exit) {
-    log_msg log_msg;
-    int err = android_logger_list_read(loggers, &log_msg);
-    if (err <= 0) break;
-
-    AndroidLogEntry entry;
-    err = android_log_processLogBuffer(&log_msg.entry_v1, &entry);
-    if (err == 0) {
-      last_log_time.tv_sec = entry.tv_sec;
-      last_log_time.tv_nsec = entry.tv_nsec;
-
-      MessageBuilder msg;
-      auto androidEntry = msg.initEvent().initAndroidLog();
-      androidEntry.setId(log_msg.id());
-      androidEntry.setTs(entry.tv_sec * 1000000000ULL + entry.tv_nsec);
-      androidEntry.setPriority(entry.priority);
-      androidEntry.setPid(entry.pid);
-      androidEntry.setTid(entry.tid);
-      androidEntry.setTag(entry.tag);
-      androidEntry.setMessage(entry.message);
-
-      pm.send("androidLog", msg);
-    }
-  }
-
-  android_logger_list_free(loggers);
-}
+#define LOG_ID_KERNEL (log_id_t)5
 
 int main() {
+  ExitHandler do_exit;
+  log_time last_log_time = {};
+
   PubMaster pm({"androidLog"});
   while (!do_exit) {
-    publish_log(pm);
-    if (do_exit) break;
+    // setup android logging
+    logger_list *loggers =
+        last_log_time.tv_sec == 0
+            ? android_logger_list_alloc(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, 0, 0)
+            : android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0);
+    assert(loggers);
 
+    const log_id_t log_ids[] = {LOG_ID_MAIN, LOG_ID_RADIO, LOG_ID_SYSTEM, LOG_ID_CRASH, LOG_ID_KERNEL};
+    for (const auto &id : log_ids) {
+      struct logger *log = android_logger_open(loggers, id);
+      assert(log != nullptr);
+    }
+
+    while (!do_exit) {
+      log_msg log_msg;
+      int err = android_logger_list_read(loggers, &log_msg);
+      if (err <= 0) break;
+
+      AndroidLogEntry entry;
+      err = android_log_processLogBuffer(&log_msg.entry_v1, &entry);
+      if (err == 0) {
+        last_log_time.tv_sec = entry.tv_sec;
+        last_log_time.tv_nsec = entry.tv_nsec;
+
+        MessageBuilder msg;
+        auto androidEntry = msg.initEvent().initAndroidLog();
+        androidEntry.setId(log_msg.id());
+        androidEntry.setTs(entry.tv_sec * 1000000000ULL + entry.tv_nsec);
+        androidEntry.setPriority(entry.priority);
+        androidEntry.setPid(entry.pid);
+        androidEntry.setTid(entry.tid);
+        androidEntry.setTag(entry.tag);
+        androidEntry.setMessage(entry.message);
+
+        pm.send("androidLog", msg);
+      }
+    }
+
+    android_logger_list_free(loggers);
     util::sleep_for(500);
   }
   return 0;

--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -14,10 +14,9 @@ int main() {
   PubMaster pm({"androidLog"});
   while (!do_exit) {
     // setup android logging
-    logger_list *loggers =
-        last_log_time.tv_sec == 0
-            ? android_logger_list_alloc(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, 0, 0)
-            : android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0);
+    logger_list *loggers = last_log_time.tv_sec == 0 ?
+                           android_logger_list_alloc(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, 0, 0) :
+                           android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0);
     assert(loggers);
 
     const log_id_t log_ids[] = {LOG_ID_MAIN, LOG_ID_RADIO, LOG_ID_SYSTEM, LOG_ID_CRASH, LOG_ID_KERNEL};

--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -10,21 +10,21 @@ log_time last_log_time = {};
 
 static void publish_log(PubMaster &pm) {
   // setup android logging
-  logger_list *logger_list =
+  logger_list *loggers =
       last_log_time.tv_sec == 0
           ? android_logger_list_alloc(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, 0, 0)
           : android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0);
-  assert(logger_list);
+  assert(loggers);
 
   const log_id_t log_ids[] = {LOG_ID_MAIN, LOG_ID_RADIO, LOG_ID_SYSTEM, LOG_ID_CRASH, (log_id_t)5};
   for (const auto &id : log_ids) {
-    struct logger *log = android_logger_open(logger_list, id);
+    struct logger *log = android_logger_open(loggers, id);
     assert(log != nullptr);
   }
 
   while (!do_exit) {
     log_msg log_msg;
-    int err = android_logger_list_read(logger_list, &log_msg);
+    int err = android_logger_list_read(loggers, &log_msg);
     if (err <= 0) break;
 
     AndroidLogEntry entry;
@@ -47,7 +47,7 @@ static void publish_log(PubMaster &pm) {
     }
   }
 
-  android_logger_list_free(logger_list);
+  android_logger_list_free(loggers);
 }
 
 int main() {

--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -1,30 +1,21 @@
-#include <unistd.h>
-#include <cstdio>
-#include <cstdlib>
-#include <cassert>
-#include <csignal>
-#include <memory>
-#include <cerrno>
-
 #include <android/log.h>
 #include <log/logger.h>
 #include <log/logprint.h>
 
-#include "common/timing.h"
 #include "common/util.h"
 #include "messaging.hpp"
 
 ExitHandler do_exit;
-
-log_time last_log_timestamp = {};
+log_time last_log_time = {};
 
 static void publish_log(PubMaster &pm) {
   // setup android logging
-  struct logger_list *logger_list =
-      last_log_timestamp.tv_sec == 0
+  logger_list *logger_list =
+      last_log_time.tv_sec == 0
           ? android_logger_list_alloc(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, 0, 0)
-          : android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_timestamp, 0);
+          : android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0);
   assert(logger_list);
+
   const log_id_t log_ids[] = {LOG_ID_MAIN, LOG_ID_RADIO, LOG_ID_SYSTEM, LOG_ID_CRASH, (log_id_t)5};
   for (const auto &id : log_ids) {
     struct logger *log = android_logger_open(logger_list, id);
@@ -38,38 +29,34 @@ static void publish_log(PubMaster &pm) {
 
     AndroidLogEntry entry;
     err = android_log_processLogBuffer(&log_msg.entry_v1, &entry);
-    if (err < 0) {
-      continue;
+    if (err == 0) {
+      last_log_time.tv_sec = entry.tv_sec;
+      last_log_time.tv_nsec = entry.tv_nsec;
+
+      MessageBuilder msg;
+      auto androidEntry = msg.initEvent().initAndroidLog();
+      androidEntry.setId(log_msg.id());
+      androidEntry.setTs(entry.tv_sec * 1000000000ULL + entry.tv_nsec);
+      androidEntry.setPriority(entry.priority);
+      androidEntry.setPid(entry.pid);
+      androidEntry.setTid(entry.tid);
+      androidEntry.setTag(entry.tag);
+      androidEntry.setMessage(entry.message);
+
+      pm.send("androidLog", msg);
     }
-
-    last_log_timestamp.tv_sec = entry.tv_sec;
-    last_log_timestamp.tv_nsec = entry.tv_nsec;
-    MessageBuilder msg;
-    auto androidEntry = msg.initEvent().initAndroidLog();
-    androidEntry.setId(log_msg.id());
-    androidEntry.setTs(entry.tv_sec * 1000000000ULL + entry.tv_nsec);
-    androidEntry.setPriority(entry.priority);
-    androidEntry.setPid(entry.pid);
-    androidEntry.setTid(entry.tid);
-    androidEntry.setTag(entry.tag);
-    androidEntry.setMessage(entry.message);
-
-    pm.send("androidLog", msg);
   }
 
   android_logger_list_free(logger_list);
 }
 
 int main() {
-  
   PubMaster pm({"androidLog"});
-
   while (!do_exit) {
     publish_log(pm);
     if (do_exit) break;
 
     util::sleep_for(500);
   }
-    
   return 0;
 }


### PR DESCRIPTION
retry the `-EAGAIN` caused this bug.  the `errno` is `ENOENT` when `-EAGAIN` return, continuing to call `android_logger_list_read`  will only return the same error again.

we need to reopen&read log when `-EAGAIN` was returned in non blocking mode. 