### PR TITLE
logger: move function logger_build_boot into bootlog.cc

### DIFF
--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -2,6 +2,24 @@
 #include <string>
 #include "common/swaglog.h"
 #include "logger.h"
+#include "messaging.hpp"
+
+static kj::Array<capnp::word> build_boot_log() {
+  MessageBuilder msg;
+  auto boot = msg.initEvent().initBoot();
+
+  boot.setWallTimeNanos(nanos_since_epoch());
+
+  std::string lastKmsg = util::read_file("/sys/fs/pstore/console-ramoops");
+  boot.setLastKmsg(capnp::Data::Reader((const kj::byte*)lastKmsg.data(), lastKmsg.size()));
+
+  std::string lastPmsg = util::read_file("/sys/fs/pstore/pmsg-ramoops-0");
+  boot.setLastPmsg(capnp::Data::Reader((const kj::byte*)lastPmsg.data(), lastPmsg.size()));
+
+  std::string launchLog = util::read_file("/tmp/launch_log");
+  boot.setLaunchLog(capnp::Text::Reader(launchLog.data(), launchLog.size()));
+  return capnp::messageToFlatArray(msg);
+}
 
 int main(int argc, char** argv) {
   char filename[64] = {'\0'};
@@ -26,7 +44,7 @@ int main(int argc, char** argv) {
   bz_file.write(logger_build_init_data().asBytes());
 
   // Write bootlog
-  bz_file.write(logger_build_boot().asBytes());
+  bz_file.write(build_boot_log().asBytes());
 
   return 0;
 }

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -49,23 +49,6 @@ int logger_mkpath(char* file_path) {
 }
 
 // ***** log metadata *****
-kj::Array<capnp::word> logger_build_boot() {
-  MessageBuilder msg;
-  auto boot = msg.initEvent().initBoot();
-
-  boot.setWallTimeNanos(nanos_since_epoch());
-
-  std::string lastKmsg = util::read_file("/sys/fs/pstore/console-ramoops");
-  boot.setLastKmsg(capnp::Data::Reader((const kj::byte*)lastKmsg.data(), lastKmsg.size()));
-
-  std::string lastPmsg = util::read_file("/sys/fs/pstore/pmsg-ramoops-0");
-  boot.setLastPmsg(capnp::Data::Reader((const kj::byte*)lastPmsg.data(), lastPmsg.size()));
-
-  std::string launchLog = util::read_file("/tmp/launch_log");
-  boot.setLaunchLog(capnp::Text::Reader(launchLog.data(), launchLog.size()));
-  return capnp::messageToFlatArray(msg);
-}
-
 kj::Array<capnp::word> logger_build_init_data() {
   MessageBuilder msg;
   auto init = msg.initEvent().initInitData();

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -74,7 +74,6 @@ typedef struct LoggerState {
 } LoggerState;
 
 int logger_mkpath(char* file_path);
-kj::Array<capnp::word> logger_build_boot();
 kj::Array<capnp::word> logger_build_init_data();
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);
 int logger_next(LoggerState *s, const char* root_path,


### PR DESCRIPTION
`logger_build_boot` is only called by `bootlog`, I think putting it in `bootlog.cc` may be more readable and  can also reduce code in `logger.cc`
