### PR TITLE
panda: refactor usb transfer related functions

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -101,8 +101,9 @@ void Panda::handle_usb_issue(int err, int retries, const char func[]) {
 int Panda::usb_transfer(libusb_endpoint_direction dir, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, unsigned int timeout) {
   const uint8_t bmRequestType = dir | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE;
   int r = -1, retries = 0;
-  std::lock_guard lk(usb_lock);
   while (connected && r < 0) {
+    // Release the lock before retrying on failure, so that other threads have a chance to do transfer
+    std::lock_guard lk(usb_lock);
     r = libusb_control_transfer(dev_handle, bmRequestType, bRequest, wValue, wIndex, NULL, 0, timeout);
     if (r < 0) handle_usb_issue(r, ++retries, __func__);
   }

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -127,6 +127,9 @@ std::tuple<int, int> Panda::usb_bulk_transfer(libusb_endpoint_direction dir, uns
     if ((err == 0 && (dir != LIBUSB_ENDPOINT_OUT || length == transferred)) || err == LIBUSB_ERROR_TIMEOUT) {
       break;
     }
+    if (err < 0) {
+      libusb_clear_halt(dev_handle, dir | endpoint);
+    }
     handle_usb_issue(err, ++retries, __func__);
   };
   return std::make_tuple(err, transferred);

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -127,11 +127,11 @@ std::tuple<int, int> Panda::usb_bulk_transfer(libusb_endpoint_direction dir, uns
     if ((err == 0 && (dir != LIBUSB_ENDPOINT_OUT || length == transferred)) || err == LIBUSB_ERROR_TIMEOUT) {
       break;
     }
-    if(err == LIBUSB_ERROR_PIPE)
+    if(err == LIBUSB_ERROR_PIPE) {
       libusb_clear_halt(dev_handle, dir | endpoint);
     }
     handle_usb_issue(err, ++retries, __func__);
-  };
+  }
   return std::make_tuple(err, transferred);
 }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -120,6 +120,7 @@ int Panda::usb_read(uint8_t bRequest, uint16_t wValue, uint16_t wIndex, unsigned
 
 std::tuple<int, int> Panda::usb_bulk_transfer(libusb_endpoint_direction dir, unsigned char endpoint, unsigned char* data, int length, unsigned int timeout) {
   int err = 0, retries = 0, transferred = 0;
+  // Keep the lock while retrying
   std::lock_guard lk(usb_lock);
   while (connected) {
     err = libusb_bulk_transfer(dev_handle, endpoint, data, length, &transferred, timeout);

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -127,7 +127,7 @@ std::tuple<int, int> Panda::usb_bulk_transfer(libusb_endpoint_direction dir, uns
     if ((err == 0 && (dir != LIBUSB_ENDPOINT_OUT || length == transferred)) || err == LIBUSB_ERROR_TIMEOUT) {
       break;
     }
-    if (err < 0) {
+    if(err == LIBUSB_ERROR_PIPE)
       libusb_clear_halt(dev_handle, dir | endpoint);
     }
     handle_usb_issue(err, ++retries, __func__);

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -45,8 +45,10 @@ class Panda {
   libusb_context *ctx = NULL;
   libusb_device_handle *dev_handle = NULL;
   std::mutex usb_lock;
-  void handle_usb_issue(int err, const char func[]);
+  void handle_usb_issue(int err, int retries, const char func[]);
   void cleanup();
+  int usb_transfer(libusb_endpoint_direction dir, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, unsigned int timeout);
+  std::tuple<int, int> usb_bulk_transfer(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout);
 
  public:
   Panda();

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -46,9 +46,9 @@ class Panda {
   libusb_device_handle *dev_handle = NULL;
   std::mutex usb_lock;
   void handle_usb_issue(int err, int retries, const char func[]);
-  void cleanup();
   int usb_transfer(libusb_endpoint_direction dir, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, unsigned int timeout);
-  std::tuple<int, int> usb_bulk_transfer(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout);
+  std::tuple<int, int> usb_bulk_transfer(libusb_endpoint_direction dir, unsigned char endpoint, unsigned char* data, int length, unsigned int timeout);
+  void cleanup();
 
  public:
   Panda();


### PR DESCRIPTION
1. added two private helper functons: `usb_transfer`, `usb_bulk_transfer`
2. disconnect USB after `USB_MAX_TRANSFER_RETRIES`  of retries.