### PR TITLE
loggerd: remove the segment variable from encoders

### DIFF
--- a/selfdrive/loggerd/encoder.h
+++ b/selfdrive/loggerd/encoder.h
@@ -6,8 +6,7 @@ class VideoEncoder {
 public:
   virtual ~VideoEncoder() {}
   virtual int encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const uint8_t *v_ptr,
-                           int in_width, int in_height,
-                           int *frame_segment, uint64_t ts) = 0;
-  virtual void encoder_open(const char* path, int segment) = 0;
+                           int in_width, int in_height, uint64_t ts) = 0;
+  virtual void encoder_open(const char* path) = 0;
   virtual void encoder_close() = 0;
 };

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -248,7 +248,7 @@ void encoder_thread(int cam_idx) {
           pthread_mutex_lock(&s.rotate_lock);
           for (auto &e : encoders) {
             e->encoder_close();
-            e->encoder_open(s.segment_path, s.rotate_segment);
+            e->encoder_open(s.segment_path);
           }
           rotate_state.cur_seg = s.rotate_segment;
           pthread_mutex_unlock(&s.rotate_lock);
@@ -266,10 +266,8 @@ void encoder_thread(int cam_idx) {
 
       // encode a frame
       for (int i = 0; i < encoders.size(); ++i) {
-        int out_segment = -1;
         int out_id = encoders[i]->encode_frame(buf->y, buf->u, buf->v,
-                                               buf->width, buf->height,
-                                               &out_segment, extra.timestamp_eof);
+                                               buf->width, buf->height, extra.timestamp_eof);
         if (i == 0 && out_id != -1) {
           // publish encode index
           MessageBuilder msg;
@@ -285,7 +283,7 @@ void encoder_thread(int cam_idx) {
           eidx.setType(cam_idx == LOG_CAMERA_ID_DCAMERA ? cereal::EncodeIndex::Type::FRONT : cereal::EncodeIndex::Type::FULL_H_E_V_C);
     #endif
           eidx.setEncodeId(cnt);
-          eidx.setSegmentNum(out_segment);
+          eidx.setSegmentNum(rotate_state.cur_seg);
           eidx.setSegmentId(out_id);
           if (lh) {
             auto bytes = msg.toBytes();

--- a/selfdrive/loggerd/omx_encoder.cc
+++ b/selfdrive/loggerd/omx_encoder.cc
@@ -392,8 +392,7 @@ void OmxEncoder::handle_out_buf(OmxEncoder *e, OMX_BUFFERHEADERTYPE *out_buf) {
 }
 
 int OmxEncoder::encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const uint8_t *v_ptr,
-                             int in_width, int in_height,
-                             int *frame_segment, uint64_t ts) {
+                             int in_width, int in_height, uint64_t ts) {
   int err;
   if (!this->is_open) {
     return -1;
@@ -466,17 +465,12 @@ int OmxEncoder::encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const u
 
   this->counter++;
 
-  if (frame_segment) {
-    *frame_segment = this->segment;
-  }
-
   return ret;
 }
 
-void OmxEncoder::encoder_open(const char* path, int segment) {
+void OmxEncoder::encoder_open(const char* path) {
   int err;
 
-  this->segment = segment;
   snprintf(this->vid_path, sizeof(this->vid_path), "%s/%s", path, this->filename);
   LOGD("encoder_open %s remuxing:%d", this->vid_path, this->remuxing);
 

--- a/selfdrive/loggerd/omx_encoder.h
+++ b/selfdrive/loggerd/omx_encoder.h
@@ -19,9 +19,8 @@ public:
   OmxEncoder(const char* filename, int width, int height, int fps, int bitrate, bool h265, bool downscale);
   ~OmxEncoder();
   int encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const uint8_t *v_ptr,
-                   int in_width, int in_height,
-                   int *frame_segment, uint64_t ts);
-  void encoder_open(const char* path, int segment);
+                   int in_width, int in_height, uint64_t ts);
+  void encoder_open(const char* path);
   void encoder_close();
 
   // OMX callbacks
@@ -42,7 +41,6 @@ private:
   bool is_open = false;
   bool dirty = false;
   int counter = 0;
-  int segment = -1;
 
   const char* filename;
   FILE *of;

--- a/selfdrive/loggerd/raw_logger.cc
+++ b/selfdrive/loggerd/raw_logger.cc
@@ -64,12 +64,11 @@ RawLogger::~RawLogger() {
   av_free(codec_ctx);
 }
 
-void RawLogger::encoder_open(const char* path, int segment) {
+void RawLogger::encoder_open(const char* path) {
   int err = 0;
 
   std::lock_guard<std::recursive_mutex> guard(lock);
 
-  this->segment = segment;
   vid_path = util::string_format("%s/%s.mkv", path, filename);
 
   // create camera lock file
@@ -128,8 +127,7 @@ void RawLogger::encoder_close() {
 }
 
 int RawLogger::encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const uint8_t *v_ptr,
-                            int in_width, int in_height,
-                            int *frame_segment, uint64_t ts) {
+                            int in_width, int in_height, uint64_t ts) {
   int err = 0;
 
   AVPacket pkt;

--- a/selfdrive/loggerd/raw_logger.h
+++ b/selfdrive/loggerd/raw_logger.h
@@ -22,16 +22,14 @@ public:
             int bitrate, bool h265, bool downscale);
   ~RawLogger();
   int encode_frame(const uint8_t *y_ptr, const uint8_t *u_ptr, const uint8_t *v_ptr,
-                   int in_width, int in_height,
-                   int *frame_segment, uint64_t ts);
-  void encoder_open(const char* path, int segment);
+                   int in_width, int in_height, uint64_t ts);
+  void encoder_open(const char* path);
   void encoder_close();
 
 private:
   const char* filename;
   int fps;
   int counter = 0;
-  int segment = -1;
   bool is_open = false;
 
   std::string vid_path, lock_path;


### PR DESCRIPTION
encoder's segment is always  `rotate_state.cur_seg,` no need to save a `segment` parameter in the encoder class.
In addition,`RawLogger:: encode_frame` does not assign a value to the parameter `*frame_segment`. that should be a bug.


