### PR TITLE
loggerd: refactor cameras_logged

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -30,11 +30,6 @@
 
 #define UI_BUF_COUNT 4
 #define YUV_COUNT 40
-#define LOG_CAMERA_ID_FCAMERA 0
-#define LOG_CAMERA_ID_DCAMERA 1
-#define LOG_CAMERA_ID_ECAMERA 2
-#define LOG_CAMERA_ID_QCAMERA 3
-#define LOG_CAMERA_ID_MAX 4
 
 const bool env_send_front = getenv("SEND_FRONT") != NULL;
 const bool env_send_rear = getenv("SEND_REAR") != NULL;
@@ -51,9 +46,14 @@ typedef struct CameraInfo {
   bool hdr;
 } CameraInfo;
 
+enum LogCameraId {
+  F_CAMERA,
+  D_CAMERA,
+  E_CAMERA
+};
 typedef struct LogCameraInfo {
+  LogCameraId id;
   const char* filename;
-  const char* frame_packet_name;
   const char* encode_idx_name;
   VisionStreamType stream_type;
   int frame_width, frame_height;


### PR DESCRIPTION
refactor `struct LogCameraInfo`, simplify the logic of initializing `RotateState` and creating encoder threads. (split #19839 into smaller PRS)