### PR TITLE
cameras_qcom: refactor focus

### DIFF
--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -1105,17 +1105,17 @@ static void ops_thread(MultiCameraState *s) {
 static void setup_self_recover(CameraState *c, const uint16_t *lapres, size_t lapres_size) {
   std::lock_guard lk(c->focus_lock);
 
-  if (c->self_recover < 2 && (c->lens_true_pos < (dac_down + 1) || c->lens_true_pos > (dac_up - 1)) && is_blur(lapres, lapres_size)) {
+  if (c->self_recover < 2 && (c->lens_true_pos < (LP3_AF_DAC_DOWN + 1) || c->lens_true_pos > (LP3_AF_DAC_UP - 1)) && is_blur(lapres, lapres_size)) {
     // truly stuck, needs help
     if (--c->self_recover < -FOCUS_RECOVER_PATIENCE) {
       LOGD("road camera bad state detected. attempting recovery from %.1f, recover state is %d", c->lens_true_pos, c->self_recover);
       // parity determined by which end is stuck at
-      c->self_recover = FOCUS_RECOVER_STEPS + (lens_true_pos < LP3_AF_DAC_M ? 1 : 0);
+      c->self_recover = FOCUS_RECOVER_STEPS + (c->lens_true_pos < LP3_AF_DAC_M ? 1 : 0);
     }
-  } else if (c->self_recover < 2 && (lens_true_pos < (LP3_AF_DAC_M - LP3_AF_DAC_3SIG) || lens_true_pos > (LP3_AF_DAC_M + LP3_AF_DAC_3SIG))) {
+  } else if (c->self_recover < 2 && (c->lens_true_pos < (LP3_AF_DAC_M - LP3_AF_DAC_3SIG) || c->lens_true_pos > (LP3_AF_DAC_M + LP3_AF_DAC_3SIG))) {
     // in suboptimal position with high prob, but may still recover by itself
     if (--c->self_recover < -(FOCUS_RECOVER_PATIENCE * 3)) {
-      c->self_recover = FOCUS_RECOVER_STEPS / 2 + (lens_true_pos < LP3_AF_DAC_M ? 1 : 0);
+      c->self_recover = FOCUS_RECOVER_STEPS / 2 + (c->lens_true_pos < LP3_AF_DAC_M ? 1 : 0);
     }
   } else if (c->self_recover < 0) {
     c->self_recover += 1;  // reset if fine

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -1207,7 +1207,7 @@ void cameras_run(MultiCameraState *s) {
         meta_data = (FrameMetadata){
           .frame_id = isp_event_data->frame_id,
           .timestamp_eof = timestamp,
-          .frame_length = c->frame_length,
+          .frame_length = (uint32_t)c->cur_frame_length,
           .integ_lines = (uint32_t)c->cur_integ_lines,
           .global_gain = (uint32_t)c->cur_gain,
           .gain_frac = c->cur_gain_frac,

--- a/selfdrive/camerad/cameras/camera_qcom.h
+++ b/selfdrive/camerad/cameras/camera_qcom.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 #include <pthread.h>
 #include <memory>
-#include <atomic>
 #include "messaging.hpp"
 
 #include "msmb_isp.h"
@@ -75,17 +74,17 @@ typedef struct CameraState {
   camera_apply_exposure_func apply_exposure;
 
   // rear camera only,used for focusing
-  unique_fd actuator_fd;
-  std::atomic<float> focus_err;
-  std::atomic<float> last_sag_acc_z;
-  std::atomic<float> lens_true_pos;
-  std::atomic<int> self_recover; // af recovery counter, neg is patience, pos is active
-  uint16_t cur_step_pos;
-  uint16_t cur_lens_pos;
-  int16_t focus[NUM_FOCUS];
-  uint8_t confidence[NUM_FOCUS];
+  std::mutex focus_lock;
+  unique_fd actuator_fd, eeprom_fd;
+  float focus_err = 0.;
+  float last_sag_acc_z = 0.;
+  float lens_true_pos = 0.;
+  int self_recover = 0;  // af recovery counter, neg is patience, pos is active
+  uint16_t cur_step_pos = 0;
+  uint16_t cur_lens_pos = 0;
+  int16_t focus[NUM_FOCUS] = {};
+  uint8_t confidence[NUM_FOCUS] = {};
 } CameraState;
-
 
 typedef struct MultiCameraState {
   unique_fd ispif_fd;

--- a/selfdrive/camerad/cameras/camera_qcom.h
+++ b/selfdrive/camerad/cameras/camera_qcom.h
@@ -75,7 +75,7 @@ typedef struct CameraState {
 
   // rear camera only,used for focusing
   std::mutex focus_lock;
-  unique_fd actuator_fd, eeprom_fd;
+  unique_fd actuator_fd;
   float focus_err = 0.;
   float last_sag_acc_z = 0.;
   float lens_true_pos = 0.;


### PR DESCRIPTION
Consistent with the original code, the following refactor was performed:
-  ~Move focusing related code into class `RearCameraFocus`~
-  Use a single std::mutex to guarantee that the focusing procedure are real atomic and thread safe.(The code before refactoring is not,std::atomic can only guarantee that a single variable is atomic,not the whole procedure ) 