### PR TITLE
Fix division by zero in lateral_planner.py

### DIFF
--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -188,7 +188,7 @@ class LateralPlanner():
     next_curvature = interp(delay, self.t_idxs[:MPC_N+1], self.mpc_solution.curvature)
     psi = interp(delay, self.t_idxs[:MPC_N+1], self.mpc_solution.psi)
     next_curvature_rate = self.mpc_solution.curvature_rate[0]
-    next_curvature_from_psi = psi/(v_ego*delay)
+    next_curvature_from_psi = psi/(v_ego*delay) if v_ego > 0 else 0
     if psi > self.mpc_solution.curvature[0] * delay * v_ego:
       next_curvature = max(next_curvature_from_psi, next_curvature)
     else:

--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -188,7 +188,7 @@ class LateralPlanner():
     next_curvature = interp(delay, self.t_idxs[:MPC_N+1], self.mpc_solution.curvature)
     psi = interp(delay, self.t_idxs[:MPC_N+1], self.mpc_solution.psi)
     next_curvature_rate = self.mpc_solution.curvature_rate[0]
-    next_curvature_from_psi = psi/(v_ego*delay) if v_ego > 0 else 0
+    next_curvature_from_psi = psi/(max(v_ego, 1e-1) * delay)
     if psi > self.mpc_solution.curvature[0] * delay * v_ego:
       next_curvature = max(next_curvature_from_psi, next_curvature)
     else:


### PR DESCRIPTION
lateral_planner.py:191: RuntimeWarning: invalid value encountered in double_scalars

When v_ego = 0 and OP activated we are getting division by 0 which sets value to nan, so param angleSteers becomes set to nan and could potentially break other code.

How to reproduce: TSS2 Corolla, shift D, enable brake hold, enable ACC, enable OpenPilot. tmux will throw an error and ZMQ will publish lateralPlan with param angleSteers: nan while car is not moving.