### PR TITLE
Honda Fit Ki/Kp Tune - Fixes wheel oscillations

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -286,7 +286,7 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 13.06
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
       tire_stiffness_factor = 0.75
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.06]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
       ret.longitudinalTuning.kpBP = [0., 5., 35.]
       ret.longitudinalTuning.kpV = [1.2, 0.8, 0.5]
       ret.longitudinalTuning.kiBP = [0., 35.]


### PR DESCRIPTION
**Description**
With the previous ki and kp values the wheel on the fit would oscillate when OP was first engaged and after steering down.

With this value modification the Fit handles both curves and straight roads better.

**Verification** 
Drove under circumstances that would previously trigger wheel oscillations. 

**Route**
Route: 52f3e9ae60c0d886