### PR TITLE
Process all cameras in common function processing_thread

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -378,7 +378,7 @@ std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, pro
   return std::thread(processing_thread, cameras, cs, callback, is_frame_stream);
 }
 
-void common_process_driver_camera(CameraState *c, int cnt) {
+void common_process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder &framed, int cnt) {
   static SubMaster sm({"driverState"});
   static int x_min = 0, x_max = 0, y_min = 0, y_max = 0;
   static const bool is_rhd = Params().read_db_bool("IsRHD");

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -384,6 +384,8 @@ void common_process_driver_camera(MultiCameraState *s, CameraState *c, cereal::F
   static const bool is_rhd = Params().read_db_bool("IsRHD");
   const CameraBuf *b = &c->buf;
 
+  framed.setFrameType(cereal::FrameData::FrameType::FRONT);
+
   // auto exposure
   if (cnt % 3 == 0) {
     if (sm.update(0) > 0 && sm.updated("driverState")) {

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -419,8 +419,7 @@ float driver_cam_get_exp_grey_frac(CameraState *c) {
     }
   }
 
-  int skip = 1;
-  // use driver face crop for AE
+  int skip = 1;  // use driver face crop for AE
   if (x_max == 0) {
     // default setting
 #ifndef QCOM2
@@ -438,8 +437,8 @@ float driver_cam_get_exp_grey_frac(CameraState *c) {
     }
 
 #ifdef QCOM2
-    return get_exp_grey_frac(b, x_min, x_max, 2, y_min, y_max, skip, (int)c->analog_gain, true, true));
+    return get_exp_grey_frac(b, x_min, x_max, 2, y_min, y_max, skip, (int)c->analog_gain, true, true);
 #else
-    return get_exp_grey_frac(b, x_min, x_max, 2, y_min, y_max, skip, -1, false, false));
+    return get_exp_grey_frac(b, x_min, x_max, 2, y_min, y_max, skip, -1, false, false);
 #endif
 }

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -358,12 +358,12 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
         framed.setTransform(cs->buf.yuv_transform.v);
       }
 
-      if (callback) {
-        callback(cameras, cs, framed, frame_cnt);
-      }
-
       if (frame_cnt % 3 == 0) {
         camera_autoexposure(cameras, cs);
+      }
+
+      if (callback) {
+        callback(cameras, cs, framed, frame_cnt);
       }
 
       pm.send(pub_name, msg);

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -280,7 +280,7 @@ static void publish_thumbnail(PubMaster *pm, const CameraBuf *b) {
   free(thumbnail_buffer);
 }
 
-float set_exposure_target(const CameraBuf *b, int x_start, int x_end, int x_skip, int y_start, int y_end, int y_skip, int analog_gain, bool hist_ceil, bool hl_weighted) {
+float get_exp_grey_frac(const CameraBuf *b, int x_start, int x_end, int x_skip, int y_start, int y_end, int y_skip, int analog_gain, bool hist_ceil, bool hl_weighted) {
   const uint8_t *pix_ptr = b->cur_yuv_buf->y;
   uint32_t lum_binning[256] = {0};
   unsigned int lum_total = 0;
@@ -438,8 +438,8 @@ float driver_cam_get_exp_grey_frac(CameraState *c) {
     }
 
 #ifdef QCOM2
-    camera_autoexposure(c, set_exposure_target(b, x_min, x_max, 2, y_min, y_max, skip, (int)c->analog_gain, true, true));
+    return get_exp_grey_frac(b, x_min, x_max, 2, y_min, y_max, skip, (int)c->analog_gain, true, true));
 #else
-    camera_autoexposure(c, set_exposure_target(b, x_min, x_max, 2, y_min, y_max, skip, -1, false, false));
+    return get_exp_grey_frac(b, x_min, x_max, 2, y_min, y_max, skip, -1, false, false));
 #endif
 }

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -178,7 +178,7 @@ void CameraBuf::queue(size_t buf_idx) {
 
 // common functions
 
-void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data) {
+static void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data) {
   framed.setFrameId(frame_data.frame_id);
   framed.setTimestampEof(frame_data.timestamp_eof);
   framed.setTimestampSof(frame_data.timestamp_sof);
@@ -192,7 +192,7 @@ void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &fr
   framed.setGainFrac(frame_data.gain_frac);
 }
 
-kj::Array<uint8_t> get_frame_image(const CameraBuf *b) {
+static kj::Array<uint8_t> get_frame_image(const CameraBuf *b) {
   static const int x_min = getenv("XMIN") ? atoi(getenv("XMIN")) : 0;
   static const int y_min = getenv("YMIN") ? atoi(getenv("YMIN")) : 0;
   static const int env_xmax = getenv("XMAX") ? atoi(getenv("XMAX")) : -1;
@@ -317,7 +317,7 @@ float set_exposure_target(const CameraBuf *b, int x_start, int x_end, int x_skip
   return lum_med / 256.0;
 }
 
-void processing_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback) {
+static void processing_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback) {
   const char *thread_name = nullptr;
   const char *pub_name = nullptr;
   bool framed_set_image = false, framed_set_transform = false;
@@ -362,9 +362,7 @@ void processing_thread(MultiCameraState *cameras, CameraState *cs, process_threa
       callback(cameras, cs, framed, cnt);
     }
 
-    // framed.setFrameType(cereal::FrameData::FrameType::FRONT);
     cameras->pm->send(pub_name, msg);
-
     if (pub_thumbnail && cnt % 100 == 3) {
       // this takes 10ms???
       publish_thumbnail(cameras->pm, &(cs->buf));

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -321,25 +321,25 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
   static PubMaster pm({"roadCameraState", "driverCameraState", "wideRoadCameraState", "thumbnail"});
 
   const char *pub_name = nullptr;
-  bool framed_set_image = false, framed_set_transform = false;
+  bool set_image = false, set_transform = false;
   bool pub_thumbnail = false;
   ::cereal::FrameData::Builder (cereal::Event::Builder::*init_cam_state_func)() = nullptr;
 
   if (cs == &cameras->road_cam) {
     set_thread_name("RoadCamera");
     pub_name = "roadCameraState";
-    framed_set_image = getenv("SEND_ROAD") != NULL;
-    pub_thumbnail = framed_set_transform = true;
+    set_image = getenv("SEND_ROAD") != NULL;
+    pub_thumbnail = set_transform = true;
     init_cam_state_func = &cereal::Event::Builder::initRoadCameraState;
   } else if (cs == &cameras->driver_cam) {
     set_thread_name("DriverCamera");
     pub_name = "driverCameraState";
-    framed_set_image = getenv("SEND_DRIVER") != NULL;
+    set_image = getenv("SEND_DRIVER") != NULL;
     init_cam_state_func = &cereal::Event::Builder::initDriverCameraState;
   } else {
     set_thread_name("WideRoadCamera");
     pub_name = "wideRoadCameraState";
-    framed_set_image = getenv("SEND_WIDE_ROAD") != NULL;
+    set_image = getenv("SEND_WIDE_ROAD") != NULL;
     init_cam_state_func = &cereal::Event::Builder::initWideRoadCameraState;
   }
 
@@ -351,10 +351,10 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
       MessageBuilder msg;
       cereal::FrameData::Builder framed = (msg.initEvent().*init_cam_state_func)();
       fill_frame_data(framed, cs->buf.cur_frame_data);
-      if (framed_set_image) {
+      if (set_image) {
         framed.setImage(get_frame_image(&cs->buf));
       }
-      if (framed_set_transform) {
+      if (set_transform) {
         framed.setTransform(cs->buf.yuv_transform.v);
       }
 

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -343,7 +343,7 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
     init_cam_state_func = &cereal::Event::Builder::initWideRoadCameraState;
   }
 
-  uint32_t cnt = 0;
+  uint32_t frame_cnt = 0;
   while (!do_exit) {
     if (!cs->buf.acquire()) continue;
 
@@ -359,22 +359,22 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
       }
 
       if (callback) {
-        callback(cameras, cs, framed, cnt);
+        callback(cameras, cs, framed, frame_cnt);
       }
 
-      if (cnt % 3 == 0) {
+      if (frame_cnt % 3 == 0) {
         camera_autoexposure(cameras, cs);
       }
 
       pm.send(pub_name, msg);
-      if (pub_thumbnail && cnt % 100 == 3) {
+      if (pub_thumbnail && frame_cnt % 100 == 3) {
         // this takes 10ms???
         publish_thumbnail(&pm, &(cs->buf));
       }
     }
 
     cs->buf.release();
-    ++cnt;
+    ++frame_cnt;
   }
 }
 

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -367,6 +367,7 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
       }
 
       pm.send(pub_name, msg);
+
       if (pub_thumbnail && frame_cnt % 100 == 3) {
         // this takes 10ms???
         publish_thumbnail(&pm, &(cs->buf));

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -25,6 +25,8 @@
 #include "modeldata.h"
 #include "imgproc/utils.h"
 
+extern ExitHandler do_exit;
+
 static cl_program build_debayer_program(cl_device_id device_id, cl_context context, const CameraInfo *ci, const CameraBuf *b, const CameraState *s) {
   char args[4096];
   snprintf(args, sizeof(args),
@@ -314,8 +316,6 @@ float set_exposure_target(const CameraBuf *b, int x_start, int x_end, int x_skip
 
   return lum_med / 256.0;
 }
-
-extern ExitHandler do_exit;
 
 void processing_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback) {
   const char *thread_name = nullptr;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -318,7 +318,7 @@ float set_exposure_target(const CameraBuf *b, int x_start, int x_end, int x_skip
 }
 
 static void processing_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback, bool is_frame_stream) {
-  PubMaster pm({"roadCameraState", "driverCameraState", "wideRoadCameraState", "thumbnail"});
+  static PubMaster pm({"roadCameraState", "driverCameraState", "wideRoadCameraState", "thumbnail"});
 
   const char *pub_name = nullptr;
   bool framed_set_image = false, framed_set_transform = false;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -378,7 +378,9 @@ std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, pro
   return std::thread(processing_thread, cameras, cs, callback, is_frame_stream);
 }
 
-void common_process_driver_camera(SubMaster *sm, CameraState *c, int cnt) {
+void common_process_driver_camera(CameraState *c, int cnt) {
+  static SubMaster sm({"driverState"});
+
   const CameraBuf *b = &c->buf;
 
   static int x_min = 0, x_max = 0, y_min = 0, y_max = 0;
@@ -386,8 +388,8 @@ void common_process_driver_camera(SubMaster *sm, CameraState *c, int cnt) {
 
   // auto exposure
   if (cnt % 3 == 0) {
-    if (sm->update(0) > 0 && sm->updated("driverState")) {
-      auto state = (*sm)["driverState"].getDriverState();
+    if (sm.update(0) > 0 && sm.updated("driverState")) {
+      auto state = sm["driverState"].getDriverState();
       // set driver camera metering target
       if (state.getFaceProb() > 0.4) {
         auto face_position = state.getFacePosition();

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -343,7 +343,7 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
     init_cam_state_func = &cereal::Event::Builder::initWideRoadCameraState;
   }
 
-  uint32_t frame_cnt = 0;
+  uint32_t cnt = 0;
   while (!do_exit) {
     if (!cs->buf.acquire()) continue;
 
@@ -358,24 +358,24 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
         framed.setTransform(cs->buf.yuv_transform.v);
       }
 
-      if (frame_cnt % 3 == 0) {
+      if (cnt % 3 == 0) {
         camera_autoexposure(cameras, cs);
       }
 
       if (callback) {
-        callback(cameras, cs, framed, frame_cnt);
+        callback(cameras, cs, framed, cnt);
       }
 
       pm.send(pub_name, msg);
 
-      if (pub_thumbnail && frame_cnt % 100 == 3) {
+      if (pub_thumbnail && cnt % 100 == 3) {
         // this takes 10ms???
         publish_thumbnail(&pm, &(cs->buf));
       }
     }
 
     cs->buf.release();
-    ++frame_cnt;
+    ++cnt;
   }
 }
 

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -380,11 +380,9 @@ std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, pro
 
 void common_process_driver_camera(CameraState *c, int cnt) {
   static SubMaster sm({"driverState"});
-
-  const CameraBuf *b = &c->buf;
-
   static int x_min = 0, x_max = 0, y_min = 0, y_max = 0;
   static const bool is_rhd = Params().read_db_bool("IsRHD");
+  const CameraBuf *b = &c->buf;
 
   // auto exposure
   if (cnt % 3 == 0) {

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -339,7 +339,6 @@ static void processing_thread(MultiCameraState *cameras, CameraState *cs, proces
     pub_name = "wideRoadCameraState";
     framed_set_image = getenv("SEND_WIDE_ROAD") != NULL;
     init_cam_state_func = &cereal::Event::Builder::initWideRoadCameraState;
-    
   }
 
   uint32_t cnt = 0;

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -122,12 +122,9 @@ public:
 
 typedef void (*process_thread_cb)(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder &framed, int cnt);
 std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback, bool is_frame_stream = false);
-
-void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data);
-kj::Array<uint8_t> get_frame_image(const CameraBuf *b);
 float set_exposure_target(const CameraBuf *b, int x_start, int x_end, int x_skip, int y_start, int y_end, int y_skip, int analog_gain, bool hist_ceil, bool hl_weighted);
 std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback);
-void common_process_driver_camera(SubMaster *sm, PubMaster *pm, CameraState *c, int cnt);
+void common_process_driver_camera(CameraState *c, int cnt);
 
 void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx);
 void cameras_open(MultiCameraState *s);

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -121,11 +121,9 @@ public:
 };
 
 typedef void (*process_thread_cb)(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder &framed, int cnt);
-std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback, bool is_frame_stream = false);
-float set_exposure_target(const CameraBuf *b, int x_start, int x_end, int x_skip, int y_start, int y_end, int y_skip, int analog_gain, bool hist_ceil, bool hl_weighted);
-std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback);
-void common_process_driver_camera(CameraState *c, int cnt);
-
+std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback = nullptr, bool is_frame_stream = false);
+float get_exp_grey_frac(const CameraBuf *b, int x_start, int x_end, int x_skip, int y_start, int y_end, int y_skip, int analog_gain, bool hist_ceil, bool hl_weighted);
+float driver_cam_get_exp_grey_frac(CameraState *c);
 void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx);
 void cameras_open(MultiCameraState *s);
 void cameras_run(MultiCameraState *s);

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -39,10 +39,6 @@
 #define HLC_A 80
 #define HISTO_CEIL_K 5
 
-const bool env_send_driver = getenv("SEND_DRIVER") != NULL;
-const bool env_send_road = getenv("SEND_ROAD") != NULL;
-const bool env_send_wide_road = getenv("SEND_WIDE_ROAD") != NULL;
-
 typedef void (*release_cb)(void *cookie, int buf_idx);
 
 typedef struct CameraInfo {
@@ -124,7 +120,7 @@ public:
   void queue(size_t buf_idx);
 };
 
-typedef void (*process_thread_cb)(MultiCameraState *s, CameraState *c, int cnt);
+typedef void (*process_thread_cb)(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder &framed, int cnt);
 
 void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data);
 kj::Array<uint8_t> get_frame_image(const CameraBuf *b);

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -121,6 +121,7 @@ public:
 };
 
 typedef void (*process_thread_cb)(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder &framed, int cnt);
+std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback);
 
 void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data);
 kj::Array<uint8_t> get_frame_image(const CameraBuf *b);

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -121,7 +121,7 @@ public:
 };
 
 typedef void (*process_thread_cb)(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder &framed, int cnt);
-std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback);
+std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback, bool is_frame_stream = false);
 
 void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data);
 kj::Array<uint8_t> get_frame_image(const CameraBuf *b);

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -130,4 +130,4 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
 void cameras_open(MultiCameraState *s);
 void cameras_run(MultiCameraState *s);
 void cameras_close(MultiCameraState *s);
-void camera_autoexposure(CameraState *s, float grey_frac);
+void camera_autoexposure(MultiCameraState *s, CameraState *c);

--- a/selfdrive/camerad/cameras/camera_frame_stream.cc
+++ b/selfdrive/camerad/cameras/camera_frame_stream.cc
@@ -83,10 +83,9 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
 void cameras_open(MultiCameraState *s) {}
 void cameras_close(MultiCameraState *s) {}
 void camera_autoexposure(CameraState *s, float grey_frac) {}
-void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {}
 
 void cameras_run(MultiCameraState *s) {
-  std::thread t = start_process_thread(s, &s->road_cam, process_road_camera);
+  std::thread t = start_process_thread(s, &s->road_cam, nullptr);
   set_thread_name("frame_streaming");
   run_frame_stream(s->road_cam, "roadCameraState");
   t.join();

--- a/selfdrive/camerad/cameras/camera_frame_stream.cc
+++ b/selfdrive/camerad/cameras/camera_frame_stream.cc
@@ -82,7 +82,7 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
 
 void cameras_open(MultiCameraState *s) {}
 void cameras_close(MultiCameraState *s) {}
-void camera_autoexposure(CameraState *s, float grey_frac) {}
+void camera_autoexposure(MultiCameraState *s, CameraState *c) {}
 
 void cameras_run(MultiCameraState *s) {
   std::thread t = start_process_thread(s, &s->road_cam, nullptr, true);

--- a/selfdrive/camerad/cameras/camera_frame_stream.cc
+++ b/selfdrive/camerad/cameras/camera_frame_stream.cc
@@ -85,7 +85,7 @@ void cameras_close(MultiCameraState *s) {}
 void camera_autoexposure(CameraState *s, float grey_frac) {}
 
 void cameras_run(MultiCameraState *s) {
-  std::thread t = start_process_thread(s, &s->road_cam, nullptr);
+  std::thread t = start_process_thread(s, &s->road_cam, nullptr, true);
   set_thread_name("frame_streaming");
   run_frame_stream(s->road_cam, "roadCameraState");
   t.join();

--- a/selfdrive/camerad/cameras/camera_frame_stream.h
+++ b/selfdrive/camerad/cameras/camera_frame_stream.h
@@ -28,5 +28,4 @@ typedef struct MultiCameraState {
   CameraState driver_cam;
 
   SubMaster *sm;
-  PubMaster *pm;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_frame_stream.h
+++ b/selfdrive/camerad/cameras/camera_frame_stream.h
@@ -26,5 +26,4 @@ typedef struct CameraState {
 typedef struct MultiCameraState {
   CameraState road_cam;
   CameraState driver_cam;
-
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_frame_stream.h
+++ b/selfdrive/camerad/cameras/camera_frame_stream.h
@@ -27,5 +27,4 @@ typedef struct MultiCameraState {
   CameraState road_cam;
   CameraState driver_cam;
 
-  SubMaster *sm;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -215,7 +215,6 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
 
   s->sm = new SubMaster({"driverState"});
-  s->pm = new PubMaster({"roadCameraState", "driverCameraState", "thumbnail"});
 
   for (int i = 0; i < FRAME_BUF_COUNT; i++) {
     // TODO: make lengths correct
@@ -1119,8 +1118,8 @@ static void setup_self_recover(CameraState *c, const uint16_t *lapres, size_t la
   c->self_recover.store(self_recover);
 }
 
-void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) {
-  common_process_driver_camera(s->sm, s->pm, c, cnt);
+void process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framd, int cnt) {
+  common_process_driver_camera(s->sm, c, cnt);
 }
 
 // called by processing_thread
@@ -1225,5 +1224,4 @@ void cameras_close(MultiCameraState *s) {
 
   delete s->lap_conv;
   delete s->sm;
-  delete s->pm;
 }

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -1116,10 +1116,6 @@ static void setup_self_recover(CameraState *c, const uint16_t *lapres, size_t la
   c->self_recover.store(self_recover);
 }
 
-void process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framd, int cnt) {
-  common_process_driver_camera(c, cnt);
-}
-
 // called by processing_thread
 static void process_road_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framed, int cnt) {
   const CameraBuf *b = &c->buf;
@@ -1143,7 +1139,7 @@ void cameras_run(MultiCameraState *s) {
   std::vector<std::thread> threads;
   threads.push_back(std::thread(ops_thread, s));
   threads.push_back(start_process_thread(s, &s->road_cam, process_road_camera));
-  threads.push_back(start_process_thread(s, &s->driver_cam, process_driver_camera));
+  threads.push_back(start_process_thread(s, &s->driver_cam, common_process_driver_camera));
 
   CameraState* cameras[2] = {&s->road_cam, &s->driver_cam};
 

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -921,7 +921,7 @@ void camera_autoexposure(MultiCameraState *s, CameraState *c) {
   if (c->camera_num == 0) {
     const int x = 290, y = 322, width = 560, height = 314;
     const int skip = 1;
-    float grey_frac = get_exp_grey_frac(c, x, x + width, skip, y, y + height, skip);
+    float grey_frac = get_exp_grey_frac(&c->buf, x, x + width, skip, y, y + height, skip, -1, false ,false);
     CameraExpInfo tmp = road_cam_exp.load();
     tmp.op_id++;
     tmp.grey_frac = grey_frac;

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -214,8 +214,6 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
               /*max_gain=*/510, 10, device_id, ctx,
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
 
-  s->sm = new SubMaster({"driverState"});
-
   for (int i = 0; i < FRAME_BUF_COUNT; i++) {
     // TODO: make lengths correct
     s->focus_bufs[i].allocate(0xb80);
@@ -1119,7 +1117,7 @@ static void setup_self_recover(CameraState *c, const uint16_t *lapres, size_t la
 }
 
 void process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framd, int cnt) {
-  common_process_driver_camera(s->sm, c, cnt);
+  common_process_driver_camera(c, cnt);
 }
 
 // called by processing_thread
@@ -1222,6 +1220,11 @@ void cameras_close(MultiCameraState *s) {
     s->stats_bufs[i].free();
   }
 
+<<<<<<< HEAD
   delete s->lap_conv;
   delete s->sm;
+=======
+  CL_CHECK(clReleaseKernel(s->krnl_rgb_laplacian));
+  CL_CHECK(clReleaseProgram(s->prg_rgb_laplacian));
+>>>>>>> move submaster to common_process_driver_camera
 }

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -1133,7 +1133,7 @@ static void process_road_camera(MultiCameraState *s, CameraState *c, cereal::Fra
   framed.setFocusConf(s->road_cam.confidence);
   framed.setRecoverState(s->road_cam.self_recover);
   framed.setSharpnessScore(s->lapres);
-  
+
   if (cnt % 3 == 0) {
     const int x = 290, y = 322, width = 560, height = 314;
     const int skip = 1;

--- a/selfdrive/camerad/cameras/camera_qcom.h
+++ b/selfdrive/camerad/cameras/camera_qcom.h
@@ -99,8 +99,6 @@ typedef struct MultiCameraState {
   CameraState road_cam;
   CameraState driver_cam;
 
-  SubMaster *sm;
-  PubMaster *pm;
   LapConv *lap_conv;
 } MultiCameraState;
 

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1092,25 +1092,13 @@ static void ae_thread(MultiCameraState *s) {
   }
 }
 
-void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) {
+void process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framed, int cnt) {
   common_process_driver_camera(s->sm, s->pm, c, cnt);
 }
 
 // called by processing_thread
-void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
+static void process_road_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framed, int cnt) {
   const CameraBuf *b = &c->buf;
-
-  MessageBuilder msg;
-  auto framed = c == &s->road_cam ? msg.initEvent().initRoadCameraState() : msg.initEvent().initWideRoadCameraState();
-  fill_frame_data(framed, b->cur_frame_data);
-  if ((c == &s->road_cam && env_send_road) || (c == &s->wide_road_cam && env_send_wide_road)) {
-    framed.setImage(get_frame_image(b));
-  }
-  if (c == &s->road_cam) {
-    framed.setTransform(b->yuv_transform.v);
-  }
-  s->pm->send(c == &s->road_cam ? "roadCameraState" : "wideRoadCameraState", msg);
-
   if (cnt % 3 == 0) {
     const auto [x, y, w, h] = (c == &s->wide_road_cam) ? std::tuple(96, 250, 1734, 524) : std::tuple(96, 160, 1734, 986);
     const int skip = 2;

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -799,7 +799,6 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
   printf("driver camera initted \n");
 
   s->sm = new SubMaster({"driverState"});
-  s->pm = new PubMaster({"roadCameraState", "driverCameraState", "wideRoadCameraState", "thumbnail"});
 }
 
 void cameras_open(MultiCameraState *s) {
@@ -904,7 +903,6 @@ void cameras_close(MultiCameraState *s) {
   camera_close(&s->driver_cam);
 
   delete s->sm;
-  delete s->pm;
 }
 
 // ******************* just a helper *******************
@@ -1093,7 +1091,7 @@ static void ae_thread(MultiCameraState *s) {
 }
 
 void process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framed, int cnt) {
-  common_process_driver_camera(s->sm, s->pm, c, cnt);
+  common_process_driver_camera(s->sm, c, cnt);
 }
 
 // called by processing_thread

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -797,8 +797,6 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
   camera_init(v, &s->driver_cam, CAMERA_ID_AR0231, 2, 20, device_id, ctx,
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
   printf("driver camera initted \n");
-
-  s->sm = new SubMaster({"driverState"});
 }
 
 void cameras_open(MultiCameraState *s) {
@@ -901,8 +899,6 @@ void cameras_close(MultiCameraState *s) {
   camera_close(&s->road_cam);
   camera_close(&s->wide_road_cam);
   camera_close(&s->driver_cam);
-
-  delete s->sm;
 }
 
 // ******************* just a helper *******************
@@ -1091,7 +1087,7 @@ static void ae_thread(MultiCameraState *s) {
 }
 
 void process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framed, int cnt) {
-  common_process_driver_camera(s->sm, c, cnt);
+  common_process_driver_camera(c, cnt);
 }
 
 // called by processing_thread

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1086,10 +1086,6 @@ static void ae_thread(MultiCameraState *s) {
   }
 }
 
-void process_driver_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framed, int cnt) {
-  common_process_driver_camera(c, cnt);
-}
-
 // called by processing_thread
 static void process_road_camera(MultiCameraState *s, CameraState *c, cereal::FrameData::Builder& framed, int cnt) {
   const CameraBuf *b = &c->buf;
@@ -1105,7 +1101,7 @@ void cameras_run(MultiCameraState *s) {
   std::vector<std::thread> threads;
   threads.push_back(std::thread(ae_thread, s));
   threads.push_back(start_process_thread(s, &s->road_cam, process_road_camera));
-  threads.push_back(start_process_thread(s, &s->driver_cam, process_driver_camera));
+  threads.push_back(start_process_thread(s, &s->driver_cam, common_process_driver_camera));
   threads.push_back(start_process_thread(s, &s->wide_road_cam, process_road_camera));
 
   // start devices

--- a/selfdrive/camerad/cameras/camera_qcom2.h
+++ b/selfdrive/camerad/cameras/camera_qcom2.h
@@ -76,6 +76,4 @@ typedef struct MultiCameraState {
   CameraState driver_cam;
 
   pthread_mutex_t isp_lock;
-
-  SubMaster *sm;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_qcom2.h
+++ b/selfdrive/camerad/cameras/camera_qcom2.h
@@ -78,5 +78,4 @@ typedef struct MultiCameraState {
   pthread_mutex_t isp_lock;
 
   SubMaster *sm;
-  PubMaster *pm;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -227,7 +227,6 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
               VISION_STREAM_RGB_BACK, VISION_STREAM_YUV_BACK);
   camera_init(v, &s->driver_cam, CAMERA_ID_LGC615, 10, device_id, ctx,
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
-  s->pm = new PubMaster({"roadCameraState", "driverCameraState", "thumbnail"});
 }
 
 void camera_autoexposure(CameraState *s, float grey_frac) {}
@@ -243,7 +242,6 @@ void cameras_open(MultiCameraState *s) {
 void cameras_close(MultiCameraState *s) {
   camera_close(&s->road_cam);
   camera_close(&s->driver_cam);
-  delete s->pm;
 }
 
 void cameras_run(MultiCameraState *s) {

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -229,7 +229,7 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
 }
 
-void camera_autoexposure(CameraState *s, float grey_frac) {}
+void camera_autoexposure(MultiCameraState *s, CameraState *c) {}
 
 void cameras_open(MultiCameraState *s) {
   // LOG("*** open driver camera ***");
@@ -246,8 +246,8 @@ void cameras_close(MultiCameraState *s) {
 
 void cameras_run(MultiCameraState *s) {
   std::vector<std::thread> threads;
-  threads.push_back(start_process_thread(s, &s->road_cam, nullptr));
-  threads.push_back(start_process_thread(s, &s->driver_cam, nullptr));
+  threads.push_back(start_process_thread(s, &s->road_cam));
+  threads.push_back(start_process_thread(s, &s->driver_cam));
 
   std::thread t_rear = std::thread(road_camera_thread, &s->road_cam);
   set_thread_name("webcam_thread");

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -246,28 +246,10 @@ void cameras_close(MultiCameraState *s) {
   delete s->pm;
 }
 
-void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) {
-  MessageBuilder msg;
-  auto framed = msg.initEvent().initDriverCameraState();
-  framed.setFrameType(cereal::FrameData::FrameType::FRONT);
-  fill_frame_data(framed, c->buf.cur_frame_data);
-  s->pm->send("driverCameraState", msg);
-}
-
-void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
-  const CameraBuf *b = &c->buf;
-  MessageBuilder msg;
-  auto framed = msg.initEvent().initRoadCameraState();
-  fill_frame_data(framed, b->cur_frame_data);
-  framed.setImage(kj::arrayPtr((const uint8_t *)b->cur_yuv_buf->addr, b->cur_yuv_buf->len));
-  framed.setTransform(b->yuv_transform.v);
-  s->pm->send("roadCameraState", msg);
-}
-
 void cameras_run(MultiCameraState *s) {
   std::vector<std::thread> threads;
-  threads.push_back(start_process_thread(s, &s->road_cam, process_road_camera));
-  threads.push_back(start_process_thread(s, &s->driver_cam, process_driver_camera));
+  threads.push_back(start_process_thread(s, &s->road_cam, nullptr));
+  threads.push_back(start_process_thread(s, &s->driver_cam, nullptr));
 
   std::thread t_rear = std::thread(road_camera_thread, &s->road_cam);
   set_thread_name("webcam_thread");

--- a/selfdrive/camerad/cameras/camera_webcam.h
+++ b/selfdrive/camerad/cameras/camera_webcam.h
@@ -24,6 +24,4 @@ typedef struct CameraState {
 typedef struct MultiCameraState {
   CameraState road_cam;
   CameraState driver_cam;
-
-  SubMaster *sm;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_webcam.h
+++ b/selfdrive/camerad/cameras/camera_webcam.h
@@ -26,5 +26,4 @@ typedef struct MultiCameraState {
   CameraState driver_cam;
 
   SubMaster *sm;
-  PubMaster *pm;
 } MultiCameraState;

--- a/selfdrive/camerad/test/ae_gray_test.cc
+++ b/selfdrive/camerad/test/ae_gray_test.cc
@@ -1,4 +1,4 @@
-// unittest for set_exposure_target
+// unittest for get_exp_grey_frac
 
 #include <assert.h>
 #include <cstring>
@@ -7,7 +7,7 @@
 #include "selfdrive/camerad/cameras/camera_common.h"
 #include "selfdrive/camerad/test/ae_gray_test.h"
 
-void camera_autoexposure(CameraState *s, float grey_frac) {}
+void camera_autoexposure(MultiCameraState *s, CameraState *c) {}
 
 int main() {
   // set up fake camerabuf
@@ -44,7 +44,7 @@ int main() {
               memset(&fb_y[h_0*W+h_1*W], l[2], h_2*W);
               memset(&fb_y[h_0*W+h_1*W+h_2*W], l[3], h_3*W);
               memset(&fb_y[h_0*W+h_1*W+h_2*W+h_3*W], l[4], h_4*W);
-              float ev = set_exposure_target((const CameraBuf*) &cb, 0, W-1, 1, 0, H-1, 1, g*10, (bool)is_qcom2, (bool)is_qcom2);
+              float ev = get_exp_grey_frac((const CameraBuf*) &cb, 0, W-1, 1, 0, H-1, 1, g*10, (bool)is_qcom2, (bool)is_qcom2);
               // printf("%d/%d/%d/%d/%d ev is %f\n", h_0, h_1, h_2, h_3, h_4, ev);
               // printf("%f\n", ev);
 


### PR DESCRIPTION
1.Remove functions `process_driver_camera`, `process_road_camera`, `common_process_driver_camera` from cameras
2.Process all cameras in function `processing_thread`(common.cc)