### PR TITLE
Mention 2021 prius prime support on 0.8.2 release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,7 @@ Version 0.8.2 (2021-02-26)
  * Nissan Altima 2020 support thanks to avolmensky!
  * Lexus ES Hybrid 2018 support thanks to TheInventorMan!
  * Toyota Camry Hybrid 2021 support thanks to alancyau!
+ * Toyota Prius Prime 2021 support thanks to VirtuallyChris!
 
 Version 0.8.1 (2020-12-21)
 ========================


### PR DESCRIPTION
[This PR adds the fingerprint for the 2021 Prius Prime](https://github.com/commaai/openpilot/pull/19651/files).

But said PR did not include the corresponding change to release notes. I've been fielding questions from friends asking when support for this would come in. This change mentions that support has been added on 0.8.2!

Also this is a minor change that doesn't seem to match any of the templates. Let me know if I need to change the description.