### PR TITLE
Update TSS1 Corolla minCanSpeed and steerRatio

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -90,11 +90,12 @@ class CarInterface(CarInterfaceBase):
       stop_and_go = False
       ret.safetyParam = 88
       ret.wheelbase = 2.70
-      ret.steerRatio = 18.27
+      ret.steerRatio = 17.43
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
       ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
+      ret.minSpeedCan = 0.1 * CV.KPH_TO_MS
 
     elif candidate == CAR.LEXUS_RX:
       stop_and_go = True

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -91,11 +91,11 @@ class CarInterface(CarInterfaceBase):
       ret.safetyParam = 88
       ret.wheelbase = 2.70
       ret.steerRatio = 17.43
+      ret.minSpeedCan = 0.1 * CV.KPH_TO_MS
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
       ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
-      ret.minSpeedCan = 0.1 * CV.KPH_TO_MS
 
     elif candidate == CAR.LEXUS_RX:
       stop_and_go = True


### PR DESCRIPTION
openpilot has settled at around 17.4 (`{"carFingerprint": "TOYOTA COROLLA 2017", "steerRatio": 17.431434631347656, "stiffnessFactor": 0.999917209148407, "angleOffsetAverageDeg": 0.20000874996185303}`) for me, which is closer to the factory spec of 17.8 (found [here](https://www.socalpreowned.net/vehicle-details/2017-toyota-corolla-l-sedan-5e07d0f3d980184aa8c519977a67e0a9) and [here](https://www.anmautosales.com/vehicle-details/2017-toyota-corolla-se-sedan-a3c926baf2fd8349a2ed8423971c5429)) compared to what's there now.

For `minSpeedCan` I found the smallest value reported by any wheel before it drops to 0:

![Screenshot_185](https://user-images.githubusercontent.com/25857203/109092586-6f78c300-76dc-11eb-859e-57c75e92e38b.png)
![Screenshot_186](https://user-images.githubusercontent.com/25857203/109092589-70a9f000-76dc-11eb-8e20-0a4dc92791a4.png)
