### PR TITLE
Add `, Shift+S key bind to save tmux scrollback

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -228,8 +228,8 @@ function launch {
     tici_init
   fi
 
-  # write tmux scrollback to a file
-  tmux capture-pane -pq -S-1000 > /tmp/launch_log
+  # bind key to write tmux scrollback to a file
+  tmux bind-key S command-prompt -p 'Save history to file:' -I '/tmp/launch_log' 'capture-pane -S-1000; save-buffer %1; delete-buffer'
 
   # start manager
   cd selfdrive


### PR DESCRIPTION
The current `capture-pane` line only saved up to then, it wouldn't ever write what happened after openpilot/manager actually started. This makes it a bit easier for the user to save the log to a file whenever they're trying to get help with an issue from community members by pressing the prefix (`) then Shift+S, then the Enter key.