### PR TITLE
Add missing ESP f/w for CAR.CAMRY_TSS2

### DIFF
--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -472,6 +472,7 @@ FW_VERSIONS = {
     ],
     (Ecu.esp, 0x7b0, None): [
       b'\x01F152606370\x00\x00\x00\x00\x00\x00',
+      b'\x01F152606390\x00\x00\x00\x00\x00\x00',
       b'\x01F152606400\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.engine, 0x700, None): [


### PR DESCRIPTION
@EmergingPath845#9792 DongleID/route 7daa325856f00d40|2021-02-28--15-44-48

Confirmed it fingerprints properly now, though it hits this known issue...
https://github.com/commaai/openpilot/issues/19654

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_car_models](../../selfdrive/test/test_car_models.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
