### PR TITLE
refactor LogCameraInfo

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -30,11 +30,6 @@
 
 #define UI_BUF_COUNT 4
 #define YUV_COUNT 40
-#define LOG_CAMERA_ID_FCAMERA 0
-#define LOG_CAMERA_ID_DCAMERA 1
-#define LOG_CAMERA_ID_ECAMERA 2
-#define LOG_CAMERA_ID_QCAMERA 3
-#define LOG_CAMERA_ID_MAX 4
 
 const bool env_send_driver = getenv("SEND_DRIVER") != NULL;
 const bool env_send_road = getenv("SEND_ROAD") != NULL;
@@ -50,7 +45,13 @@ typedef struct CameraInfo {
   bool hdr;
 } CameraInfo;
 
+enum CameraType {
+  ROAD_CAM,
+  DRIVER_CAM,
+  WIDE_ROAD_CAM
+};
 typedef struct LogCameraInfo {
+  CameraType type;
   const char* filename;
   const char* frame_packet_name;
   const char* encode_idx_name;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -347,11 +347,11 @@ int main(int argc, char** argv) {
     poller->registerSocket(sock);
     socks.push_back(sock);
 
-    for (auto &cam_info : cameras_logged) {
-      if (strcmp(it.name, cam_info.frame_packet_name) == 0 &&
-          (cam_info.type != DRIVER_CAM || Params().read_db_bool("RecordFront"))) {
-        s.rotate_states.push_back(std::make_unique<RotateState>(sock, cam_info));
-      }
+    auto cam_info = std::find_if(std::begin(cameras_logged), std::end(cameras_logged), [it](auto &ci) { 
+      return strcmp(it.name, ci.frame_packet_name) == 0; 
+    });
+    if (cam_info != std::end(cameras_logged) && (cam_info->type != DRIVER_CAM || Params().read_db_bool("RecordFront"))) {
+      s.rotate_states.push_back(std::make_unique<RotateState>(sock, *cam_info));
     }
     qlog_states[sock] = {.counter = 0, .freq = it.decimation};
   }

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <sys/resource.h>
 
+#include <algorithm>
 #include <string>
 #include <thread>
 #include <mutex>
@@ -44,13 +45,11 @@ namespace {
 constexpr int MAIN_FPS = 20;
 
 #ifndef QCOM2
-constexpr int MAIN_BITRATE = 5000000;
-constexpr int MAX_CAM_IDX = LOG_CAMERA_ID_DCAMERA;
-constexpr int DCAM_BITRATE = 2500000;
+#define MAIN_BITRATE 5000000
+#define DCAM_BITRATE 2500000
 #else
-constexpr int MAIN_BITRATE = 10000000;
-constexpr int MAX_CAM_IDX = LOG_CAMERA_ID_ECAMERA;
-constexpr int DCAM_BITRATE = MAIN_BITRATE;
+#define MAIN_BITRATE 10000000
+#define DCAM_BITRATE MAIN_BITRATE
 #endif
 
 #define NO_CAMERA_PATIENCE 500 // fall back to time-based rotation if all cameras are dead
@@ -59,8 +58,8 @@ const int SEGMENT_LENGTH = getenv("LOGGERD_TEST") ? atoi(getenv("LOGGERD_SEGMENT
 
 ExitHandler do_exit;
 
-LogCameraInfo cameras_logged[LOG_CAMERA_ID_MAX] = {
-  [LOG_CAMERA_ID_FCAMERA] = {
+LogCameraInfo cameras_logged[] = {
+  { .type = ROAD_CAM,
     .stream_type = VISION_STREAM_YUV_BACK,
     .filename = "fcamera.hevc",
     .frame_packet_name = "roadCameraState",
@@ -70,7 +69,8 @@ LogCameraInfo cameras_logged[LOG_CAMERA_ID_MAX] = {
     .downscale = false,
     .has_qcamera = true
   },
-  [LOG_CAMERA_ID_DCAMERA] = {
+#if defined(QCOM) || defined(QCOM2)
+  { .type = DRIVER_CAM,
     .stream_type = VISION_STREAM_YUV_FRONT,
     .filename = "dcamera.hevc",
     .frame_packet_name = "driverCameraState",
@@ -80,7 +80,9 @@ LogCameraInfo cameras_logged[LOG_CAMERA_ID_MAX] = {
     .downscale = false,
     .has_qcamera = false
   },
-  [LOG_CAMERA_ID_ECAMERA] = {
+#endif
+#ifdef QCOM2
+  { .type = WIDE_ROAD_CAM,
     .stream_type = VISION_STREAM_YUV_WIDE,
     .filename = "ecamera.hevc",
     .frame_packet_name = "wideRoadCameraState",
@@ -90,7 +92,10 @@ LogCameraInfo cameras_logged[LOG_CAMERA_ID_MAX] = {
     .downscale = false,
     .has_qcamera = false
   },
-  [LOG_CAMERA_ID_QCAMERA] = {
+#endif
+};
+
+LogCameraInfo qcam_info = {
     .filename = "qcamera.ts",
     .fps = MAIN_FPS,
     .bitrate = 256000,
@@ -101,19 +106,19 @@ LogCameraInfo cameras_logged[LOG_CAMERA_ID_MAX] = {
 #else
     .frame_width = 526, .frame_height = 330 // keep pixel count the same?
 #endif
-  },
 };
 
 class RotateState {
 public:
   SubSocket* fpkt_sock;
   uint32_t stream_frame_id, log_frame_id, last_rotate_frame_id;
-  bool enabled, should_rotate, initialized;
+  LogCameraInfo cam_info;
+  bool should_rotate, initialized;
   std::atomic<bool> rotating;
   std::atomic<int> cur_seg;
 
-  RotateState() : fpkt_sock(nullptr), stream_frame_id(0), log_frame_id(0),
-                  last_rotate_frame_id(UINT32_MAX), enabled(false), should_rotate(false), initialized(false), rotating(false), cur_seg(-1) {};
+  RotateState(SubSocket *sock, const LogCameraInfo& info) : fpkt_sock(sock), cam_info(info), stream_frame_id(0), log_frame_id(0),
+                  last_rotate_frame_id(UINT32_MAX), should_rotate(false), initialized(false), rotating(false), cur_seg(-1) {};
 
   void waitLogThread() {
     std::unique_lock<std::mutex> lk(fid_lock);
@@ -143,11 +148,9 @@ public:
   }
 
   void rotate() {
-    if (enabled) {
-      std::unique_lock<std::mutex> lk(fid_lock);
-      should_rotate = true;
-      last_rotate_frame_id = stream_frame_id;
-    }
+    std::unique_lock<std::mutex> lk(fid_lock);
+    should_rotate = true;
+    last_rotate_frame_id = stream_frame_id;
   }
 
   void finish_rotate() {
@@ -166,16 +169,12 @@ struct LoggerdState {
   char segment_path[4096];
   int rotate_segment;
   pthread_mutex_t rotate_lock;
-  RotateState rotate_state[LOG_CAMERA_ID_MAX-1];
+  std::vector<std::unique_ptr<RotateState>> rotate_states;
 };
 LoggerdState s;
 
-void encoder_thread(int cam_idx) {
-  assert(cam_idx < LOG_CAMERA_ID_MAX-1);
-
-  LogCameraInfo &cam_info = cameras_logged[cam_idx];
-  RotateState &rotate_state = s.rotate_state[cam_idx];
-
+void encoder_thread(RotateState *rs) {
+  LogCameraInfo &cam_info = rs->cam_info;
   set_thread_name(cam_info.filename);
 
   int cnt = 0;
@@ -200,7 +199,6 @@ void encoder_thread(int cam_idx) {
 
       // qcamera encoder
       if (cam_info.has_qcamera) {
-        LogCameraInfo &qcam_info = cameras_logged[LOG_CAMERA_ID_QCAMERA];
         encoders.push_back(new Encoder(qcam_info.filename,
                                        qcam_info.frame_width, qcam_info.frame_height,
                                        qcam_info.fps, qcam_info.bitrate, qcam_info.is_h265, qcam_info.downscale));
@@ -222,17 +220,17 @@ void encoder_thread(int cam_idx) {
         pthread_mutex_unlock(&s.rotate_lock);
 
         // wait if camera pkt id is older than stream
-        rotate_state.waitLogThread();
+        rs->waitLogThread();
 
         if (do_exit) break;
 
         // rotate the encoder if the logger is on a newer segment
-        if (rotate_state.should_rotate) {
-          LOGW("camera %d rotate encoder to %s", cam_idx, s.segment_path);
+        if (rs->should_rotate) {
+          LOGW("camera %d rotate encoder to %s", cam_info.type, s.segment_path);
 
-          if (!rotate_state.initialized) {
-            rotate_state.last_rotate_frame_id = extra.frame_id - 1;
-            rotate_state.initialized = true;
+          if (!rs->initialized) {
+            rs->last_rotate_frame_id = extra.frame_id - 1;
+            rs->initialized = true;
           }
 
           // get new logger handle for new segment
@@ -242,9 +240,9 @@ void encoder_thread(int cam_idx) {
           lh = logger_get_handle(&s.logger);
 
           // wait for all to start rotating
-          rotate_state.rotating = true;
-          for(auto &r : s.rotate_state) {
-             while(r.enabled && !r.rotating && !do_exit) util::sleep_for(5);
+          rs->rotating = true;
+          for(auto &r : s.rotate_states) {
+             while(!r->rotating && !do_exit) util::sleep_for(5);
           }
 
           pthread_mutex_lock(&s.rotate_lock);
@@ -252,19 +250,19 @@ void encoder_thread(int cam_idx) {
             e->encoder_close();
             e->encoder_open(s.segment_path);
           }
-          rotate_state.cur_seg = s.rotate_segment;
+          rs->cur_seg = s.rotate_segment;
           pthread_mutex_unlock(&s.rotate_lock);
 
           // wait for all to finish rotating
-          for(auto &r : s.rotate_state) {
-             while(r.enabled && r.cur_seg != s.rotate_segment && !do_exit) util::sleep_for(5);
+          for(auto &r : s.rotate_states) {
+             while(r->cur_seg != s.rotate_segment && !do_exit) util::sleep_for(5);
           }
-          rotate_state.rotating = false;
-          rotate_state.finish_rotate();
+          rs->rotating = false;
+          rs->finish_rotate();
         }
       }
 
-      rotate_state.setStreamFrameId(extra.frame_id);
+      rs->setStreamFrameId(extra.frame_id);
 
       // encode a frame
       for (int i = 0; i < encoders.size(); ++i) {
@@ -274,18 +272,18 @@ void encoder_thread(int cam_idx) {
           // publish encode index
           MessageBuilder msg;
           // this is really ugly
-          auto eidx = cam_idx == LOG_CAMERA_ID_DCAMERA ? msg.initEvent().initDriverEncodeIdx() :
-                     (cam_idx == LOG_CAMERA_ID_ECAMERA ? msg.initEvent().initWideRoadEncodeIdx() : msg.initEvent().initRoadEncodeIdx());
+          auto eidx = cam_info.type == DRIVER_CAM ? msg.initEvent().initDriverEncodeIdx() :
+                     (cam_info.type == WIDE_ROAD_CAM ? msg.initEvent().initWideRoadEncodeIdx() : msg.initEvent().initRoadEncodeIdx());
           eidx.setFrameId(extra.frame_id);
           eidx.setTimestampSof(extra.timestamp_sof);
           eidx.setTimestampEof(extra.timestamp_eof);
     #ifdef QCOM2
           eidx.setType(cereal::EncodeIndex::Type::FULL_H_E_V_C);
     #else
-          eidx.setType(cam_idx == LOG_CAMERA_ID_DCAMERA ? cereal::EncodeIndex::Type::FRONT : cereal::EncodeIndex::Type::FULL_H_E_V_C);
+          eidx.setType(cam_info.type == DRIVER_CAM ? cereal::EncodeIndex::Type::FRONT : cereal::EncodeIndex::Type::FULL_H_E_V_C);
     #endif
           eidx.setEncodeId(cnt);
-          eidx.setSegmentNum(rotate_state.cur_seg);
+          eidx.setSegmentNum(rs->cur_seg);
           eidx.setSegmentId(out_id);
           if (lh) {
             auto bytes = msg.toBytes();
@@ -349,9 +347,10 @@ int main(int argc, char** argv) {
     poller->registerSocket(sock);
     socks.push_back(sock);
 
-    for (int cid=0; cid<=MAX_CAM_IDX; cid++) {
-      if (std::string(it.name) == cameras_logged[cid].frame_packet_name) {
-        s.rotate_state[cid].fpkt_sock = sock;
+    for (auto &cam_info : cameras_logged) {
+      if (strcmp(it.name, cam_info.frame_packet_name) == 0 &&
+          (cam_info.type != DRIVER_CAM || Params().read_db_bool("RecordFront"))) {
+        s.rotate_states.push_back(std::make_unique<RotateState>(sock, cam_info));
       }
     }
     qlog_states[sock] = {.counter = 0, .freq = it.decimation};
@@ -363,23 +362,10 @@ int main(int argc, char** argv) {
   // init encoders
   pthread_mutex_init(&s.rotate_lock, NULL);
 
-  // TODO: create these threads dynamically on frame packet presence
   std::vector<std::thread> encoder_threads;
-  encoder_threads.push_back(std::thread(encoder_thread, LOG_CAMERA_ID_FCAMERA));
-  s.rotate_state[LOG_CAMERA_ID_FCAMERA].enabled = true;
-
-#if defined(QCOM) || defined(QCOM2)
-  bool record_front = Params().read_db_bool("RecordFront");
-  if (record_front) {
-    encoder_threads.push_back(std::thread(encoder_thread, LOG_CAMERA_ID_DCAMERA));
-    s.rotate_state[LOG_CAMERA_ID_DCAMERA].enabled = true;
+  for (auto &rs : s.rotate_states) {
+    encoder_threads.push_back(std::thread(encoder_thread, rs.get()));
   }
-
-#ifdef QCOM2
-  encoder_threads.push_back(std::thread(encoder_thread, LOG_CAMERA_ID_ECAMERA));
-  s.rotate_state[LOG_CAMERA_ID_ECAMERA].enabled = true;
-#endif
-#endif
 
   uint64_t msg_count = 0;
   uint64_t bytes_count = 0;
@@ -417,14 +403,8 @@ int main(int argc, char** argv) {
       }
 
       if (last_msg) {
-        int fpkt_id = -1;
-        for (int cid = 0; cid <=MAX_CAM_IDX; cid++) {
-          if (sock == s.rotate_state[cid].fpkt_sock) {
-            fpkt_id=cid;
-            break;
-          }
-        }
-        if (fpkt_id >= 0) {
+        auto it = std::find_if(s.rotate_states.begin(), s.rotate_states.end(), [&](auto &r) {return r->fpkt_sock == sock;});
+        if (it != s.rotate_states.end()) {
           // track camera frames to sync to encoder
           // only process last frame
           const uint8_t* data = (uint8_t*)last_msg->getData();
@@ -438,12 +418,13 @@ int main(int argc, char** argv) {
           capnp::FlatArrayMessageReader cmsg(buf);
           cereal::Event::Reader event = cmsg.getRoot<cereal::Event>();
 
-          if (fpkt_id == LOG_CAMERA_ID_FCAMERA) {
-            s.rotate_state[fpkt_id].setLogFrameId(event.getRoadCameraState().getFrameId());
-          } else if (fpkt_id == LOG_CAMERA_ID_DCAMERA) {
-            s.rotate_state[fpkt_id].setLogFrameId(event.getDriverCameraState().getFrameId());
-          } else if (fpkt_id == LOG_CAMERA_ID_ECAMERA) {
-            s.rotate_state[fpkt_id].setLogFrameId(event.getWideRoadCameraState().getFrameId());
+          auto &rs = *it;
+          if (rs->cam_info.type == ROAD_CAM) {
+            rs->setLogFrameId(event.getRoadCameraState().getFrameId());
+          } else if (rs->cam_info.type == DRIVER_CAM) {
+            rs->setLogFrameId(event.getDriverCameraState().getFrameId());
+          } else if (rs->cam_info.type == WIDE_ROAD_CAM) {
+            rs->setLogFrameId(event.getWideRoadCameraState().getFrameId());
           }
           last_camera_seen_tms = millis_since_boot();
         }
@@ -456,11 +437,10 @@ int main(int argc, char** argv) {
       double tms = millis_since_boot();
       if (tms - last_camera_seen_tms <= NO_CAMERA_PATIENCE && encoder_threads.size() > 0) {
         new_segment = true;
-        for (auto &r : s.rotate_state) {
+        for (auto &r : s.rotate_states) {
           // this *should* be redundant on tici since all camera frames are synced
-          new_segment &= (((r.stream_frame_id >= r.last_rotate_frame_id + SEGMENT_LENGTH * MAIN_FPS) &&
-                          (!r.should_rotate) && (r.initialized)) ||
-                          (!r.enabled));
+          new_segment &= (((r->stream_frame_id >= r->last_rotate_frame_id + SEGMENT_LENGTH * MAIN_FPS) &&
+                          (!r->should_rotate) && (r->initialized)));
 #ifndef QCOM2
           break; // only look at fcamera frame id if not QCOM2
 #endif
@@ -483,13 +463,13 @@ int main(int argc, char** argv) {
       LOGW((s.logger.part == 0) ? "logging to %s" : "rotated to %s", s.segment_path);
 
       // rotate encoders
-      for (auto &r : s.rotate_state) r.rotate();
+      for (auto &r : s.rotate_states) r->rotate();
       pthread_mutex_unlock(&s.rotate_lock);
     }
   }
 
   LOGW("closing encoders");
-  for (auto &r : s.rotate_state) r.cancelWait();
+  for (auto &r : s.rotate_states) r->cancelWait();
   for (auto &t : encoder_threads) t.join();
 
   LOGW("closing logger");


### PR DESCRIPTION
refactor `LogCameraInfo` to simplify the initialization of encoders according to the device type