### PR TITLE
VW MQB: Get steering rate-change sign from the correct signal

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -29,7 +29,7 @@ class CarState(CarStateBase):
     # Update steering angle, rate, yaw rate, and driver input torque. VW send
     # the sign/direction in a separate signal so they must be recombined.
     ret.steeringAngleDeg = pt_cp.vl["LWI_01"]['LWI_Lenkradwinkel'] * (1, -1)[int(pt_cp.vl["LWI_01"]['LWI_VZ_Lenkradwinkel'])]
-    ret.steeringRateDeg = pt_cp.vl["LWI_01"]['LWI_Lenkradw_Geschw'] * (1, -1)[int(pt_cp.vl["LWI_01"]['LWI_VZ_Lenkradwinkel'])]
+    ret.steeringRateDeg = pt_cp.vl["LWI_01"]['LWI_Lenkradw_Geschw'] * (1, -1)[int(pt_cp.vl["LWI_01"]['LWI_VZ_Lenkradw_Geschw'])]
     ret.steeringTorque = pt_cp.vl["EPS_01"]['Driver_Strain'] * (1, -1)[int(pt_cp.vl["EPS_01"]['Driver_Strain_VZ'])]
     ret.steeringPressed = abs(ret.steeringTorque) > CarControllerParams.STEER_DRIVER_ALLOWANCE
     ret.yawRate = pt_cp.vl["ESP_02"]['ESP_Gierrate'] * (1, -1)[int(pt_cp.vl["ESP_02"]['ESP_VZ_Gierrate'])] * CV.DEG_TO_RAD


### PR DESCRIPTION
**Diff reduction with the VW Community Port**

Fix a very old bug processing the steeringRateDeg signal from the car. It was reading the absolute rate correctly, but not the sign (positive/negative, left/right). This would cause steeringRateDeg to be inverted quite frequently. We got away with this for a long time because PID lateral control doesn't consume steeringRateDeg.

**Verification**

Several months in the community port. Test driven as a standalone change to upstream master.

**Route**

2018 Volkswagen Golf R: cae14e88932eb364|2021-03-04--16-08-22