### PR TITLE
VW MQB: Support for other transmission types

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -165,7 +165,6 @@ class CarState(CarStateBase):
       ("ZV_HD_offen", "Gateway_72", 0),             # Trunk or hatch open
       ("BH_Blinker_li", "Gateway_72", 0),           # Left turn signal on
       ("BH_Blinker_re", "Gateway_72", 0),           # Right turn signal on
-      ("GE_Fahrstufe", "Getriebe_11", 0),           # Auto trans gear selector position
       ("AB_Gurtschloss_FA", "Airbag_02", 0),        # Seatbelt status, driver
       ("AB_Gurtschloss_BF", "Airbag_02", 0),        # Seatbelt status, passenger
       ("ESP_Fahrer_bremst", "ESP_05", 0),           # Brake pedal pressed
@@ -217,7 +216,6 @@ class CarState(CarStateBase):
       ("TSK_06", 50),       # From J623 Engine control module
       ("GRA_ACC_01", 33),   # From J??? steering wheel control buttons
       ("ACC_02", 17),       # From J428 ACC radar control module
-      ("Getriebe_11", 20),  # From J743 Auto transmission control module
       ("Gateway_72", 10),   # From J533 CAN gateway (aggregated data)
       ("Motor_14", 10),     # From J623 Engine control module
       ("Airbag_02", 5),     # From J234 Airbag control module

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -224,13 +224,13 @@ class CarState(CarStateBase):
       ("Einheiten_01", 1),  # From J??? not known if gateway, cluster, or BCM
     ]
 
-    if CP.transmissionType == TRANS.automatic:
+    if CP.transmissionType == TransmissionType.automatic:
       signals += [("GE_Fahrstufe", "Getriebe_11", 0)]  # Auto trans gear selector position
       checks += [("Getriebe_11", 20)]  # From J743 Auto transmission control module
-    elif CP.transmissionType == TRANS.direct:
+    elif CP.transmissionType == TransmissionType.direct:
       signals += [("GearPosition", "EV_Gearshift", 0)]  # EV gear selector position
       checks += [("EV_Gearshift", 10)]  # From J??? unknown EV control module
-    elif CP.transmissionType == TRANS.manual:
+    elif CP.transmissionType == TransmissionType.manual:
       signals += [("MO_Kuppl_schalter", "Motor_14", 0),  # Clutch switch
                   ("BCM1_Rueckfahrlicht_Schalter", "Gateway_72", 0)]  # Reverse light from BCM
       checks += [("Motor_14", 10)]  # From J623 Engine control module

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -81,7 +81,7 @@ class CarInterface(CarInterfaceBase):
     self.cp.update_strings(can_strings)
     self.cp_cam.update_strings(can_strings)
 
-    ret = self.CS.update(self.cp)
+    ret = self.CS.update(self.cp, self.CP.transmissionType)
     ret.canValid = self.cp.can_valid and self.cp_cam.can_valid
     ret.steeringRateLimited = self.CC.steer_rate_limited if self.CC is not None else False
 

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -1,4 +1,5 @@
 from cereal import car
+from selfdrive.swaglog import cloudlog
 from selfdrive.car.volkswagen.values import CAR, BUTTON_STATES, TRANS, GEAR
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
 from selfdrive.car.interfaces import CarInterfaceBase

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -49,12 +49,11 @@ class CarInterface(CarInterfaceBase):
 
     ret.enableCamera = True  # Stock camera detection doesn't apply to VW
 
-    # Determine transmission type by CAN message(s) present on the bus
     if 0xAD in fingerprint[0]:
-      # Getribe_11 message detected: traditional automatic or DSG gearbox
+      # Getribe_11 detected: traditional automatic or DSG gearbox
       ret.transmissionType = TRANS.automatic
     elif 0x187 in fingerprint[0]:
-      # EV_Gearshift message detected: e-Golf or similar direct-drive electric
+      # EV_Gearshift detected: e-Golf or similar direct-drive electric
       ret.transmissionType = TRANS.direct
     else:
       # No trans message at all, must be a true stick-shift manual

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -1,6 +1,6 @@
 from cereal import car
 from selfdrive.swaglog import cloudlog
-from selfdrive.car.volkswagen.values import CAR, BUTTON_STATES, TRANS, GEAR
+from selfdrive.car.volkswagen.values import CAR, BUTTON_STATES, TransmissionType, GearShifter
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
 from selfdrive.car.interfaces import CarInterfaceBase
 
@@ -52,13 +52,13 @@ class CarInterface(CarInterfaceBase):
 
     if 0xAD in fingerprint[0]:
       # Getriebe_11 detected: traditional automatic or DSG gearbox
-      ret.transmissionType = TRANS.automatic
+      ret.transmissionType = TransmissionType.automatic
     elif 0x187 in fingerprint[0]:
       # EV_Gearshift detected: e-Golf or similar direct-drive electric
-      ret.transmissionType = TRANS.direct
+      ret.transmissionType = TransmissionType.direct
     else:
       # No trans message at all, must be a true stick-shift manual
-      ret.transmissionType = TRANS.manual
+      ret.transmissionType = TransmissionType.manual
     cloudlog.info("Detected transmission type: %s", ret.transmissionType)
 
     # TODO: get actual value, for now starting with reasonable value for
@@ -101,7 +101,7 @@ class CarInterface(CarInterfaceBase):
         be.pressed = self.CS.buttonStates[button]
         buttonEvents.append(be)
 
-    events = self.create_common_events(ret, extra_gears=[GEAR.eco, GEAR.sport])
+    events = self.create_common_events(ret, extra_gears=[GearShifter.eco, GearShifter.sport])
 
     # Vehicle health and operation safety checks
     if self.CS.parkingBrakeSet:

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -51,7 +51,7 @@ class CarInterface(CarInterfaceBase):
     ret.enableCamera = True  # Stock camera detection doesn't apply to VW
 
     if 0xAD in fingerprint[0]:
-      # Getribe_11 detected: traditional automatic or DSG gearbox
+      # Getriebe_11 detected: traditional automatic or DSG gearbox
       ret.transmissionType = TRANS.automatic
     elif 0x187 in fingerprint[0]:
       # EV_Gearshift detected: e-Golf or similar direct-drive electric

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+from cereal import car
 from selfdrive.car import dbc_dict
 
 class CarControllerParams:

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -25,8 +25,8 @@ class CANBUS:
   pt = 0
   cam = 2
 
-TRANS = car.CarParams.TransmissionType
-GEAR = car.CarState.GearShifter
+TransmissionType = car.CarParams.TransmissionType
+GearShifter = car.CarState.GearShifter
 
 BUTTON_STATES = {
   "accelCruise": False,

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -24,6 +24,9 @@ class CANBUS:
   pt = 0
   cam = 2
 
+TRANS = car.CarParams.TransmissionType
+GEAR = car.CarState.GearShifter
+
 BUTTON_STATES = {
   "accelCruise": False,
   "decelCruise": False,


### PR DESCRIPTION
**Diff reduction with the VW Community Port**

Add some necessary pieces to support the Volkswagen e-Golf, which has no transmission and needs to find gearshift position from a different signal. Also add support for manual transmission vehicles, which can be had with ACC and LKAS.

**Verification**

Test driven as a standalone change to upstream master. I myself can only test the auto trans branch of the code, but many others in the community have exercised this same code for months in the community port.

**Route**

2018 Volkswagen Golf R: cae14e88932eb364|2021-03-05--18-47-48