### PR TITLE
Add firmware values for 2021 Acura RDX

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -930,6 +930,7 @@ FW_VERSIONS = {
   },
   CAR.ACURA_RDX_3G: {
     (Ecu.programmedFuelInjection, 0x18da10f1, None): [
+      b'37805-5YF-C210\x00\x00',
       b'37805-5YF-A230\x00\x00',
       b'37805-5YF-A420\x00\x00',
       b'37805-5YF-A430\x00\x00',
@@ -951,11 +952,13 @@ FW_VERSIONS = {
       b'28102-5YK-A711\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
+      b'78109-TJB-AW10\x00\x00',
       b'78109-TJB-AB10\x00\x00',
       b'78109-TJB-AD10\x00\x00',
       b'78109-TJB-AF10\x00\x00',
     ],
     (Ecu.srs, 0x18da53f1, None): [
+      b'77959-TJB-A210\x00\x00',
       b'77959-TJB-A040\x00\x00',
     ],
     (Ecu.electricBrakeBooster, 0x18da2bf1, None): [
@@ -963,9 +966,11 @@ FW_VERSIONS = {
       b'46114-TJB-A060\x00\x00',
     ],
     (Ecu.gateway, 0x18daeff1, None): [
+      b'38897-TJB-A120\x00\x00',
       b'38897-TJB-A110\x00\x00',
     ],
     (Ecu.eps, 0x18da30f1, None): [
+      b'39990-TJB-A040\x00\x00',
       b'39990-TJB-A030\x00\x00',
     ],
   },


### PR DESCRIPTION
Added firmware values for 2021 Acura RDX to ACURA_RDX_3G

Drive 1: https://my.comma.ai/useradmin/?onebox=2d775b5b04dc3026%7C2021-03-08--17-24-33
Drive 2: https://my.comma.ai/useradmin/?onebox=2d775b5b04dc3026%7C2021-03-08--17-12-54