### PR TITLE
VW MQB: Updated message and signal data, round 1

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -245,7 +245,7 @@ class CarState(CarStateBase):
 
     signals = [
       # sig_name, sig_address, default
-      ("KLDW_Status_LED_gelb", "LDW_02", 0),            # Lane Assist status LED
+      ("KLDW_Status_LED_gruen", "LDW_02", 0),            # Lane Assist status LED
     ]
 
     checks = [

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -245,7 +245,7 @@ class CarState(CarStateBase):
 
     signals = [
       # sig_name, sig_address, default
-      ("Kombi_Lamp_Green", "LDW_02", 0),            # Lane Assist status LED
+      ("KLDW_Status_LED_gelb", "LDW_02", 0),            # Lane Assist status LED
     ]
 
     checks = [

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -31,9 +31,9 @@ class CarState(CarStateBase):
 
     # Update steering angle, rate, yaw rate, and driver input torque. VW send
     # the sign/direction in a separate signal so they must be recombined.
-    ret.steeringAngleDeg = pt_cp.vl["EPS_01"]['Steering_Wheel_Angle'] * (1, -1)[int(pt_cp.vl["EPS_01"]['Steering_Wheel_Angle_VZ'])]
+    ret.steeringAngleDeg = pt_cp.vl["LH_EPS_03"]['EPS_Berechneter_LW'] * (1, -1)[int(pt_cp.vl["LH_EPS_03"]['EPS_VZ_BLW'])]
     ret.steeringRateDeg = pt_cp.vl["LWI_01"]['LWI_Lenkradw_Geschw'] * (1, -1)[int(pt_cp.vl["LWI_01"]['LWI_VZ_Lenkradw_Geschw'])]
-    ret.steeringTorque = pt_cp.vl["EPS_01"]['Driver_Strain'] * (1, -1)[int(pt_cp.vl["EPS_01"]['Driver_Strain_VZ'])]
+    ret.steeringTorque = pt_cp.vl["LH_EPS_03"]['EPS_Lenkmoment'] * (1, -1)[int(pt_cp.vl["LH_EPS_03"]['EPS_VZ_Lenkmoment'])]
     ret.steeringPressed = abs(ret.steeringTorque) > CarControllerParams.STEER_DRIVER_ALLOWANCE
     ret.yawRate = pt_cp.vl["ESP_02"]['ESP_Gierrate'] * (1, -1)[int(pt_cp.vl["ESP_02"]['ESP_VZ_Gierrate'])] * CV.DEG_TO_RAD
 
@@ -135,7 +135,7 @@ class CarState(CarStateBase):
 
     # Check to make sure the electric power steering rack is configured to
     # accept and respond to HCA_01 messages and has not encountered a fault.
-    self.steeringFault = not pt_cp.vl["EPS_01"]["HCA_Ready"]
+    self.steeringFault = not pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"]
 
     # Additional safety checks performed in CarInterface.
     self.parkingBrakeSet = bool(pt_cp.vl["Kombi_01"]['KBI_Handbremse'])  # FIXME: need to include an EPB check as well
@@ -148,8 +148,8 @@ class CarState(CarStateBase):
     # this function generates lists for signal, messages and initial values
     signals = [
       # sig_name, sig_address, default
-      ("Steering_Wheel_Angle", "EPS_01", 0),        # Absolute steering angle
-      ("Steering_Wheel_Angle_VZ", "EPS_01", 0),     # Steering angle sign
+      ("EPS_Berechneter_LW", "LH_EPS_03", 0),       # Absolute steering angle
+      ("EPS_VZ_BLW", "LH_EPS_03", 0),               # Steering angle sign
       ("LWI_Lenkradw_Geschw", "LWI_01", 0),         # Absolute steering rate
       ("LWI_VZ_Lenkradw_Geschw", "LWI_01", 0),      # Steering rate sign
       ("ESP_VL_Radgeschw_02", "ESP_19", 0),         # ABS wheel speed, front left
@@ -172,9 +172,9 @@ class CarState(CarStateBase):
       ("ESP_Bremsdruck", "ESP_05", 0),              # Brake pressure applied
       ("MO_Fahrpedalrohwert_01", "Motor_20", 0),    # Accelerator pedal value
       ("MO_Kuppl_schalter", "Motor_14", 0),         # Clutch switch
-      ("Driver_Strain", "EPS_01", 0),               # Absolute driver torque input
-      ("Driver_Strain_VZ", "EPS_01", 0),            # Driver torque input sign
-      ("HCA_Ready", "EPS_01", 0),                   # Steering rack HCA support configured
+      ("EPS_Lenkmoment", "LH_EPS_03", 0),           # Absolute driver torque input
+      ("EPS_VZ_Lenkmoment", "LH_EPS_03", 0),        # Driver torque input sign
+      ("EPS_HCA_Status", "LH_EPS_03", 0),           # Steering rack HCA support configured
       ("ESP_Tastung_passiv", "ESP_21", 0),          # Stability control disabled
       ("KBI_MFA_v_Einheit_02", "Einheiten_01", 0),  # MPH vs KMH speed display
       ("KBI_Handbremse", "Kombi_01", 0),            # Manual handbrake applied
@@ -206,7 +206,7 @@ class CarState(CarStateBase):
     checks = [
       # sig_address, frequency
       ("LWI_01", 100),      # From J500 Steering Assist with integrated sensors
-      ("EPS_01", 100),      # From J500 Steering Assist with integrated sensors
+      ("LH_EPS_03", 100),   # From J500 Steering Assist with integrated sensors
       ("ESP_19", 100),      # From J104 ABS/ESP controller
       ("ESP_05", 50),       # From J104 ABS/ESP controller
       ("ESP_21", 50),       # From J104 ABS/ESP controller

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -245,7 +245,7 @@ class CarState(CarStateBase):
 
     signals = [
       # sig_name, sig_address, default
-      ("KLDW_Status_LED_gruen", "LDW_02", 0),            # Lane Assist status LED
+      ("LDW_Status_LED_gruen", "LDW_02", 0),            # Lane Assist status LED
     ]
 
     checks = [

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -25,7 +25,7 @@ def create_mqb_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert
     rightlanehud = 2 if rightLaneVisible else 1
 
   values = {
-    "LDW_SW_Warnung_links": 1,  # FIXME: to be store-and-forwarded from the stock camera
+    "LDW_SW_Warnung_links": 0,  # FIXME: to be store-and-forwarded from the stock camera
     "LDW_SW_Warnung_rechts": 1,  # FIXME: to be store-and-forwarded from the stock camera
     "LDW_Status_LED_gelb": 1 if hca_enabled and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if hca_enabled and not steering_pressed else 0,

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -25,12 +25,13 @@ def create_mqb_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert
     rightlanehud = 2 if rightLaneVisible else 1
 
   values = {
-    "LDW_Unknown": 2,  # FIXME: possible speed or attention relationship
-    "Kombi_Lamp_Orange": 1 if hca_enabled and steering_pressed else 0,
-    "Kombi_Lamp_Green": 1 if hca_enabled and not steering_pressed else 0,
-    "Left_Lane_Status": leftlanehud,
-    "Right_Lane_Status": rightlanehud,
-    "Alert_Message": hud_alert,
+    "LDW_SW_Warnung_links": 1,  # FIXME: to be store-and-forwarded from the stock camera
+    "LDW_SW_Warnung_rechts": 1,  # FIXME: to be store-and-forwarded from the stock camera
+    "LDW_Status_LED_gelb": 1 if hca_enabled and steering_pressed else 0,
+    "LDW_Status_LED_gruen": 1 if hca_enabled and not steering_pressed else 0,
+    "LDW_Lernmodus_links": leftlanehud,
+    "LDW_Lernmodus_rechts": rightlanehud,
+    "LDW_Texte": hud_alert,
   }
   return packer.make_can_msg("LDW_02", bus, values)
 


### PR DESCRIPTION
**Diff reduction with the VW Community Port**

Match commaai/opendbc#357 with improved and mostly-canonical message naming, signal naming, and scaling properties for LH_EPS_03 (formerly known as EPS_01) and LDW_02. The LDW_02 additions are required for an upcoming stock BSM bug fix.

**Verification**

Null effective change; renaming only except for one fixed two-byte signal that's now split into two fixed one-byte signals. Several months in the community port. Test driven as a standalone change to upstream master.

**Merge Review**

Requires both commaai/opendbc#357 and commaai/panda#632. Getting CI to pass prior to merge on all three will be tricky due to cross-dependencies in CI testing between opendbc, panda, and openpilot. Maybe merge opendbc, bump the opendbc submodule ref in this branch, pass CI here, merge this to master, then update panda's CI test refs to openpilot master to pass CI there, merge panda, then bump openpilot's master panda ref?

**Route**

2018 Volkswagen Golf R: cae14e88932eb364|2021-03-10--06-42-27