### PR TITLE
Specify comma containers come from ghcr.io in docker pull commands.

### DIFF
--- a/tools/sim/build_container.sh
+++ b/tools/sim/build_container.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR/../../
 
-docker pull commaai/openpilot-base:latest
+docker pull ghcr.io/commaai/openpilot-base:latest
 docker build \
   --cache-from commaai/openpilot-sim:latest \
   -t commaai/openpilot-sim:latest \

--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -3,7 +3,7 @@
 # expose X to the container
 xhost +local:root
 
-docker pull commaai/openpilot-sim:latest
+docker pull ghcr.io/commaai/openpilot-sim:latest
 
 docker run --net=host\
   --name openpilot_client \


### PR DESCRIPTION
**Description** 

This is a pull request to fix the pull-url of the openpilot docker containers.

I'm not sure what the `build_container.sh` script is used for but maybe the change is correct for it too. 

Please correct me if I'm wrong about this being a fix.

**Verification** 

I tried starting the simulation environment by following https://github.com/commaai/openpilot#testing-on-pc but I couldn't download the openpilot docker containers. I saw from the `Dockerfile.sim` that they are pulled from ghcr.io instead of the default docker repository, so I tried that and it worked. 