### PR TITLE
Fix warning popup for file not found, batman.

### DIFF
--- a/tools/plotjuggler/demo_layout.xml
+++ b/tools/plotjuggler/demo_layout.xml
@@ -77,12 +77,6 @@
   <plugin status="idle" ID="ROS Topic Re-Publisher"/>
  </Plugins>
  <!-- - - - - - - - - - - - - - - -->
- <previouslyLoaded_Datafiles>
-  <fileInfo filename="/home/batman/openpilot/tools/plotjuggler/tmps2q85e2d.rlog" prefix="">
-   <selected_datasources value=""/>
-   <plugin ID="DataLoad Rlog"/>
-  </fileInfo>
- </previouslyLoaded_Datafiles>
  <!-- - - - - - - - - - - - - - - -->
  <customMathEquations>
   <snippet name="dv/dt">


### PR DESCRIPTION

**Description** PlotJuggler warning popup for file-not-found on previously loaded files.

**Verification** Ran demo again after removing this XML region, no warning popup for file not found.

`./juggle.py "https://commadataci.blob.core.windows.net/openpilotci/d83f36766f8012a5/2020-02-05--18-42-21/0/rlog.bz2" --layout=demo_layout.xml`