### PR TITLE
BMX055 don't use FIFO registers

### DIFF
--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -46,7 +46,7 @@ fail:
 void BMX055_Accel::get_event(cereal::SensorEventData::Builder &event){
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
-  int len = read_register(BMX055_ACCEL_I2C_REG_FIFO, buffer, sizeof(buffer));
+  int len = read_register(BMX055_ACCEL_I2C_REG_X_LSB, buffer, sizeof(buffer));
   assert(len == 6);
 
   // 12 bit = +-2g

--- a/selfdrive/sensord/sensors/bmx055_accel.hpp
+++ b/selfdrive/sensord/sensors/bmx055_accel.hpp
@@ -7,6 +7,7 @@
 
 // Registers of the chip
 #define BMX055_ACCEL_I2C_REG_ID     0x00
+#define BMX055_ACCEL_I2C_REG_X_LSB  0x02
 #define BMX055_ACCEL_I2C_REG_TEMP   0x08
 #define BMX055_ACCEL_I2C_REG_BW     0x10
 #define BMX055_ACCEL_I2C_REG_HBW    0x13

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -56,7 +56,7 @@ fail:
 void BMX055_Gyro::get_event(cereal::SensorEventData::Builder &event){
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
-  int len = read_register(BMX055_GYRO_I2C_REG_FIFO, buffer, sizeof(buffer));
+  int len = read_register(BMX055_GYRO_I2C_REG_RATE_X_LSB, buffer, sizeof(buffer));
   assert(len == 6);
 
   // 16 bit = +- 125 deg/s

--- a/selfdrive/sensord/sensors/bmx055_gyro.hpp
+++ b/selfdrive/sensord/sensors/bmx055_gyro.hpp
@@ -6,11 +6,12 @@
 #define BMX055_GYRO_I2C_ADDR        0x68
 
 // Registers of the chip
-#define BMX055_GYRO_I2C_REG_ID      0x00
-#define BMX055_GYRO_I2C_REG_RANGE   0x0F
-#define BMX055_GYRO_I2C_REG_BW      0x10
-#define BMX055_GYRO_I2C_REG_HBW     0x13
-#define BMX055_GYRO_I2C_REG_FIFO    0x3F
+#define BMX055_GYRO_I2C_REG_ID         0x00
+#define BMX055_GYRO_I2C_REG_RATE_X_LSB 0x02
+#define BMX055_GYRO_I2C_REG_RANGE      0x0F
+#define BMX055_GYRO_I2C_REG_BW         0x10
+#define BMX055_GYRO_I2C_REG_HBW        0x13
+#define BMX055_GYRO_I2C_REG_FIFO       0x3F
 
 // Constants
 #define BMX055_GYRO_CHIP_ID         0x0F


### PR DESCRIPTION
Saw weird spikes in the gyro y channel which might be related to a broken implementation of the FIFO in bypass mode.