### PR TITLE
include PACIFICA_2020 in late-model behavior

### DIFF
--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -32,7 +32,7 @@ class CarController():
     moving_fast = CS.out.vEgo > CS.CP.minSteerSpeed  # for status message
     if CS.out.vEgo > (CS.CP.minSteerSpeed - 0.5):  # for command high bit
       self.gone_fast_yet = True
-    elif self.car_fingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.JEEP_CHEROKEE_2019):
+    elif self.car_fingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
       if CS.out.vEgo < (CS.CP.minSteerSpeed - 3.0):
         self.gone_fast_yet = False  # < 14.5m/s stock turns off this bit, but fine down to 13.5
     lkas_active = moving_fast and enabled


### PR DESCRIPTION
These models need to turn off gone_fast_yet bit at -3 to avoid LKAS faults.

This was likely an accidental omission from PR #1297 

To avoid future similar mistakes, we could define a list of these cars in values.py instead of having the list in multiple places.