### PR TITLE
hw.h: trim os version string

### DIFF
--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -42,6 +42,11 @@ inline bool starts_with(const std::string &s, const std::string &prefix) {
   return s.compare(0, prefix.size(), prefix) == 0;
 }
 
+inline std::string rtrimmed(const std::string& s) {
+  size_t end = s.find_last_not_of(" \n\r\t\f\v");
+  return (end == std::string::npos) ? "" : s.substr(0, end + 1);
+}
+
 template <typename... Args>
 inline std::string string_format(const std::string& format, Args... args) {
   size_t size = snprintf(nullptr, 0, format.c_str(), args...) + 1;

--- a/selfdrive/hardware/hw.h
+++ b/selfdrive/hardware/hw.h
@@ -27,7 +27,7 @@ public:
 class HardwareEon : public HardwareNone {
 public:
   static std::string get_os_version() {
-    return "NEOS " + util::read_file("/VERSION");
+    return "NEOS " + util::rtrimmed(util::read_file("/VERSION"));
   };
 
   static void reboot() { std::system("reboot"); };
@@ -44,7 +44,7 @@ public:
 class HardwareTici : public HardwareNone {
 public:
   static std::string get_os_version() {
-    return "AGNOS " + util::read_file("/VERSION");
+    return "AGNOS " + util::rtrimmed(util::read_file("/VERSION"));
   };
 
   static void reboot() { std::system("sudo reboot"); };


### PR DESCRIPTION
the version string ends with a line terminator.cause the display of the `os version` in the devel panel  to be misplaced.

