### PR TITLE
apply_steer rate limit comparison needs int(round( initial_steer ))

### DIFF
--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -24,7 +24,7 @@ class CarController():
 
     # *** compute control surfaces ***
     # steer torque
-    new_steer = actuators.steer * CarControllerParams.STEER_MAX
+    new_steer = int(round(actuators.steer * CarControllerParams.STEER_MAX))
     apply_steer = apply_toyota_steer_torque_limits(new_steer, self.apply_steer_last,
                                                    CS.out.steeringTorqueEps, CarControllerParams)
     self.steer_rate_limited = new_steer != apply_steer

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -35,7 +35,7 @@ class CarController():
     if (frame % P.STEER_STEP) == 0:
       lkas_enabled = enabled and not CS.out.steerWarning and CS.out.vEgo > P.MIN_STEER_SPEED
       if lkas_enabled:
-        new_steer = actuators.steer * P.STEER_MAX
+        new_steer = int(round(actuators.steer * P.STEER_MAX))
         apply_steer = apply_std_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, P)
         self.steer_rate_limited = new_steer != apply_steer
       else:

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -45,7 +45,7 @@ class CarController():
   def update(self, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert,
              left_lane, right_lane, left_lane_depart, right_lane_depart):
     # Steering Torque
-    new_steer = actuators.steer * self.p.STEER_MAX
+    new_steer = int(round(actuators.steer * self.p.STEER_MAX))
     apply_steer = apply_std_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, self.p)
     self.steer_rate_limited = new_steer != apply_steer
 


### PR DESCRIPTION
**Description** CC.steer_rate_limited (thus CS.steeringRateLimited) was almost always true on GM, because the original float rarely equals its rounded value.

**Verification** Not tested yet, just inspection. I'll confirm on GM.

Alternative fix (I prefer it) is to return boolean from apply_std_steer_torque_limits() when limiting occurs.
`
apply_steer, limited = apply_std_steer_torque_limits(apply_steer, self.apply_steer_last, CS.out.steeringTorque, P)`