### PR TITLE
convience script for starting manager

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -223,8 +223,7 @@ function launch {
   tmux capture-pane -pq -S-1000 > /tmp/launch_log
 
   # start manager
-  cd selfdrive/manager
-  ./build.py && ./manager.py
+  ./selfdrive/manager/start.sh
 
   # if broken, keep on screen error
   while true; do sleep 1; done

--- a/selfdrive/manager/start.sh
+++ b/selfdrive/manager/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+./build.py && ./manager.py


### PR DESCRIPTION
you used to be able to just start `manager.py` and it would build and start it, now that they are separated into `build.py` and `manager.py` it is more convenient to have a single script to run when killing/starting manager inside the existing tmux session