### PR TITLE
VW MQB: Integration support, bugfixes, minor cleanup

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,7 +1,7 @@
 from cereal import car
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.volkswagen import volkswagencan
-from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
+from selfdrive.car.volkswagen.values import DBC, CANBUS, NetworkLocation, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
 from opendbc.can.packer import CANPacker
 
 
@@ -17,6 +17,11 @@ class CarController():
     self.graMsgSentCount = 0
     self.graMsgStartFramePrev = 0
     self.graMsgBusCounterPrev = 0
+
+    if CP.networkLocation == NetworkLocation.fwdCamera:
+      self.ext_can = CANBUS.pt
+    else:
+      self.ext_can = CANBUS.cam
 
     self.steer_rate_limited = False
 
@@ -119,7 +124,9 @@ class CarController():
 
       can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, hcaEnabled,
                                                             CS.out.steeringPressed, hud_alert, leftLaneVisible,
-                                                            rightLaneVisible))
+                                                            rightLaneVisible, CS.ldw_lane_warning_left,
+                                                            CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
+                                                            CS.ldw_dlc, CS.ldw_tlc))
 
     #--------------------------------------------------------------------------
     #                                                                         #
@@ -176,7 +183,7 @@ class CarController():
         if self.graMsgSentCount == 0:
           self.graMsgStartFramePrev = frame
         idx = (CS.graMsgBusCounter + 1) % 16
-        can_sends.append(volkswagencan.create_mqb_acc_buttons_control(self.packer_pt, CANBUS.pt, self.graButtonStatesToSend, CS, idx))
+        can_sends.append(volkswagencan.create_mqb_acc_buttons_control(self.packer_pt, self.ext_can, self.graButtonStatesToSend, CS, idx))
         self.graMsgSentCount += 1
         if self.graMsgSentCount >= P.GRA_VBP_COUNT:
           self.graButtonStatesToSend = None

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -1,6 +1,6 @@
 from cereal import car
 from selfdrive.swaglog import cloudlog
-from selfdrive.car.volkswagen.values import CAR, BUTTON_STATES, TransmissionType, GearShifter
+from selfdrive.car.volkswagen.values import CAR, BUTTON_STATES, NetworkLocation, TransmissionType, GearShifter
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
 from selfdrive.car.interfaces import CarInterfaceBase
 
@@ -13,6 +13,9 @@ class CarInterface(CarInterfaceBase):
 
     self.displayMetricUnitsPrev = None
     self.buttonStatesPrev = BUTTON_STATES.copy()
+
+    # Alias Extended CAN parser to PT/CAM parser, based on detected network location
+    self.cp_ext = self.cp if CP.networkLocation == NetworkLocation.fwdCamera else self.cp_cam
 
   @staticmethod
   def compute_gb(accel, speed):
@@ -42,6 +45,12 @@ class CarInterface(CarInterfaceBase):
         # No trans message at all, must be a true stick-shift manual
         ret.transmissionType = TransmissionType.manual
       cloudlog.info("Detected transmission type: %s", ret.transmissionType)
+
+      if 0xfd in fingerprint[1]:  # ESP_21 present on bus 1, we're hooked up at the CAN gateway
+        ret.networkLocation = NetworkLocation.gateway
+      else:  # We're hooked up at the LKAS camera
+        ret.networkLocation = NetworkLocation.fwdCamera
+      cloudlog.info("Detected network location: %s", ret.networkLocation)
 
     # Global tuning defaults, can be overridden per-vehicle
 
@@ -87,7 +96,7 @@ class CarInterface(CarInterfaceBase):
     self.cp.update_strings(can_strings)
     self.cp_cam.update_strings(can_strings)
 
-    ret = self.CS.update(self.cp, self.CP.transmissionType)
+    ret = self.CS.update(self.cp, self.cp_cam, self.cp_ext, self.CP.transmissionType)
     ret.canValid = self.cp.can_valid and self.cp_cam.can_valid
     ret.steeringRateLimited = self.CC.steer_rate_limited if self.CC is not None else False
 

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -2,7 +2,11 @@
 
 from selfdrive.car import dbc_dict
 from cereal import car
+
 Ecu = car.CarParams.Ecu
+NetworkLocation = car.CarParams.NetworkLocation
+TransmissionType = car.CarParams.TransmissionType
+GearShifter = car.CarState.GearShifter
 
 class CarControllerParams:
   HCA_STEP = 2                   # HCA_01 message frequency 50Hz
@@ -25,9 +29,6 @@ class CarControllerParams:
 class CANBUS:
   pt = 0
   cam = 2
-
-TransmissionType = car.CarParams.TransmissionType
-GearShifter = car.CarState.GearShifter
 
 BUTTON_STATES = {
   "accelCruise": False,

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -15,23 +15,26 @@ def create_mqb_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
   }
   return packer.make_can_msg("HCA_01", bus, values, idx)
 
-def create_mqb_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert, leftLaneVisible, rightLaneVisible):
-
+def create_mqb_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
+                           ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc):
   if hca_enabled:
-    leftlanehud = 3 if leftLaneVisible else 1
-    rightlanehud = 3 if rightLaneVisible else 1
+    left_lane_hud = 3 if left_lane_visible else 1
+    right_lane_hud = 3 if right_lane_visible else 1
   else:
-    leftlanehud = 2 if leftLaneVisible else 1
-    rightlanehud = 2 if rightLaneVisible else 1
+    left_lane_hud = 2 if left_lane_visible else 1
+    right_lane_hud = 2 if right_lane_visible else 1
 
   values = {
-    "LDW_SW_Warnung_links": 0,  # FIXME: to be store-and-forwarded from the stock camera
-    "LDW_SW_Warnung_rechts": 1,  # FIXME: to be store-and-forwarded from the stock camera
     "LDW_Status_LED_gelb": 1 if hca_enabled and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if hca_enabled and not steering_pressed else 0,
-    "LDW_Lernmodus_links": leftlanehud,
-    "LDW_Lernmodus_rechts": rightlanehud,
+    "LDW_Lernmodus_links": left_lane_hud,
+    "LDW_Lernmodus_rechts": right_lane_hud,
     "LDW_Texte": hud_alert,
+    "LDW_SW_Warnung_links": ldw_lane_warning_left,
+    "LDW_SW_Warnung_rechts": ldw_lane_warning_right,
+    "LDW_Seite_DLCTLC": ldw_side_dlc_tlc,
+    "LDW_DLC": ldw_dlc,
+    "LDW_TLC": ldw_tlc
   }
   return packer.make_can_msg("LDW_02", bus, values)
 


### PR DESCRIPTION
**Bug fixes and integration support from the VW Community Port**

- Feature: auto-detect whether we're hooked up at the LKAS camera or CAN gateway, move messages and signals to match
- Bugfix: pass-through lane-departure warning info from the LKAS camera to the blind-spot warning radars
- Bugfix: garbage-collect some signals from ACC_06 that we haven't used for a long time
- Style: camelCase -> PEP8

**Verification**

This is a refactored version of what we've been running in community since the very beginning. The refactor has been tested successfully against several community cars before opening this PR.

**Merge Review**

The LDW bugfix will change LDW_02 messages as seen by process_replay. The change is correct and desired.

**Route**

cae14e88932eb364|2021-03-25--16-23-20 (still uploading)