### PR TITLE
VW MQB: Škoda Superb Mk3

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Community Maintained Cars and Features
 | SEAT      | Ateca 2018                    | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Kodiaq 2018                   | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Scala 2020                    | Driver Assistance | Stock            | 0mph               | 0mph         |
+| Škoda     | Superb 2018                   | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Subaru    | Ascent 2019                   | EyeSight          | Stock            | 0mph               | 0mph         |
 | Subaru    | Crosstrek 2018-19             | EyeSight          | Stock            | 0mph               | 0mph         |
 | Subaru    | Forester 2019-20              | EyeSight          | Stock            | 0mph               | 0mph         |

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -92,6 +92,11 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1192 + STD_CARGO_KG
       ret.wheelbase = 2.65
 
+    elif candidate == CAR.SKODA_SUPERB_MK3:
+      # Averages of all 3V/NP Scala variants
+      ret.mass = 1505 + STD_CARGO_KG
+      ret.wheelbase = 2.84
+
     ret.centerToFront = ret.wheelbase * 0.45
 
     ret.enableCamera = True  # Stock camera detection doesn't apply to VW

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -62,6 +62,7 @@ class CAR:
   SEAT_ATECA_MK1 = "SEAT ATECA 1ST GEN"       # Chassis 5F, Mk1 SEAT Ateca and CUPRA Ateca
   SKODA_KODIAQ_MK1 = "SKODA KODIAQ 1ST GEN"   # Chassis NS, Mk1 Skoda Kodiaq
   SKODA_SCALA_MK1 = "SKODA SCALA 1ST GEN"     # Chassis NW, Mk1 Skoda Scala and Skoda Kamiq
+  SKODA_SUPERB_MK3 = "SKODA SUPERB 3RD GEN"   # Chassis 3V/NP, Mk3 Skoda Superb and variants
   AUDI_A3 = "AUDI A3"                         # Chassis 8V/FF, Mk3 Audi A3 and variants
 
 FINGERPRINTS = {
@@ -89,9 +90,12 @@ FINGERPRINTS = {
   CAR.SKODA_SCALA_MK1: [{
     64: 8, 134: 8, 159: 8, 173: 8, 178: 8, 253: 8, 257: 8, 262: 8, 278: 8, 279: 8, 283: 8, 286: 8, 288: 8, 289: 8, 290: 8, 294: 8, 299: 8, 302: 8, 346: 8, 418: 8, 427: 8, 506: 8, 568: 8, 569: 8, 572: 8, 573: 8, 679: 8, 681: 8, 684: 8, 695: 8, 779: 8, 780: 8, 783: 8, 787: 8, 788: 8, 789: 8, 792: 8, 795: 8, 804: 8, 806: 8, 807: 8, 808: 8, 809: 8, 826: 8, 827: 8, 828: 8, 870: 8, 879: 8, 884: 8, 888: 8, 891: 8, 901: 8, 913: 8, 917: 8, 919: 8, 949: 8, 958: 8, 960: 4, 981: 8, 987: 8, 988: 8, 991: 8, 997: 8, 1000: 8, 1019: 8, 1122: 8, 1123: 8, 1124: 8, 1153: 8, 1156: 8, 1157: 8, 1158: 8, 1162: 8, 1175: 8, 1312: 8, 1343: 8, 1385: 8, 1413: 8, 1440: 5, 1514: 8, 1515: 8, 1520: 8, 1600: 8, 1601: 8, 1603: 8, 1605: 8, 1624: 8, 1626: 8, 1629: 8, 1631: 8, 1635: 8, 1646: 8, 1648: 8, 1712: 6, 1714: 8, 1716: 8, 1717: 8, 1719: 8, 1720: 8, 1721: 8, 1792: 8, 1872: 8, 1879: 8, 1976: 8, 1977: 8, 1982: 8, 1985: 8
   }],
+  CAR.SKODA_SUPERB_MK3: [{
+    64: 8, 134: 8, 159: 8, 178: 8, 253: 8, 257: 8, 260: 8, 262: 8, 278: 8, 279: 8, 283: 8, 286: 8, 288: 8, 289: 8, 290: 8, 294: 8, 295: 8, 299: 8, 302: 8, 346: 8, 418: 8, 427: 8, 679: 8, 681: 8, 695: 8, 779: 8, 780: 8, 783: 8, 791: 8, 792: 8, 795: 8, 799: 8, 804: 8, 806: 8, 807: 8, 808: 8, 809: 8, 838: 8, 839: 8, 840: 8, 841: 8, 842: 8, 843: 8, 844: 8, 845: 8, 870: 8, 896: 8, 897: 8, 898: 8, 901: 8, 917: 8, 919: 8, 949: 8, 958: 8, 960: 4, 981: 8, 987: 8, 988: 8, 991: 8, 997: 8, 1000: 8, 1019: 8, 1153: 8, 1162: 8, 1175: 8, 1312: 8, 1385: 8, 1413: 8, 1440: 5, 1514: 8, 1515: 8, 1520: 8, 1600: 8, 1601: 8, 1603: 8, 1624: 8, 1626: 8, 1629: 8, 1631: 8, 1646: 8, 1648: 8, 1712: 6, 1714: 8, 1716: 8, 1717: 8, 1719: 8, 1720: 8, 1792: 8, 1872: 8, 1879: 8, 1976: 8, 1977: 8, 1985: 8, 2017: 8
+  }],
 }
 
-IGNORED_FINGERPRINTS = [CAR.JETTA_MK7, CAR.PASSAT_MK8, CAR.TIGUAN_MK2, CAR.SEAT_ATECA_MK1, CAR.SKODA_KODIAQ_MK1, CAR.SKODA_SCALA_MK1]
+IGNORED_FINGERPRINTS = [CAR.JETTA_MK7, CAR.PASSAT_MK8, CAR.TIGUAN_MK2, CAR.SEAT_ATECA_MK1, CAR.SKODA_KODIAQ_MK1, CAR.SKODA_SCALA_MK1, CAR.SKODA_SUPERB_MK3]
 
 FW_VERSIONS = {
   CAR.AUDI_A3: {
@@ -249,6 +253,21 @@ FW_VERSIONS = {
       b'\xf1\x872Q0907572R \xf1\x890372',
     ],
   },
+  CAR.SKODA_SUPERB_MK3: {
+    (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x8704L906026KB\xf1\x894071',
+    ],
+    (Ecu.transmission, 0x7e1, None): [],  # Only onboarded Superb is a manual
+    (Ecu.srs, 0x715, None): [
+      b'\xf1\x875Q0959655BH\xf1\x890336\xf1\x82\02331310031313100313131013141319331413100',
+    ],
+    (Ecu.eps, 0x712, None): [
+      b'\xf1\x875Q0910143B \xf1\x892201\xf1\x82\00563UZ060700',
+    ],
+    (Ecu.fwdRadar, 0x757, None): [
+      b'\xf1\x873Q0907572C \xf1\x890195',
+    ],
+  },
 }
 
 DBC = {
@@ -260,4 +279,5 @@ DBC = {
   CAR.SEAT_ATECA_MK1: dbc_dict('vw_mqb_2010', None),
   CAR.SKODA_KODIAQ_MK1: dbc_dict('vw_mqb_2010', None),
   CAR.SKODA_SCALA_MK1: dbc_dict('vw_mqb_2010', None),
+  CAR.SKODA_SUPERB_MK3: dbc_dict('vw_mqb_2010', None),
 }

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -257,7 +257,7 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7e0, None): [
       b'\xf1\x8704L906026KB\xf1\x894071',
     ],
-    (Ecu.transmission, 0x7e1, None): [],  # Only onboarded Superb is a manual
+    # Only onboarded Superb so far is a manual (Ecu.transmission, 0x7e1, None): [],
     (Ecu.srs, 0x715, None): [
       b'\xf1\x875Q0959655BH\xf1\x890336\xf1\x82\02331310031313100313131013141319331413100',
     ],

--- a/selfdrive/test/test_car_models.py
+++ b/selfdrive/test/test_car_models.py
@@ -469,6 +469,10 @@ routes = {
     'carFingerprint': VOLKSWAGEN.SKODA_SCALA_MK1,
     'enableCamera': True,
   },
+  "b2e9858e29db492b|2021-03-26--16-58-42": {
+    'carFingerprint': VOLKSWAGEN.SKODA_SUPERB_MK3,
+    'enableCamera': True,
+  },
   "3c8f0c502e119c1c|2020-06-30--12-58-02": {
     'carFingerprint': SUBARU.ASCENT,
     'enableCamera': True,


### PR DESCRIPTION
**Škoda Superb Mk3**

Covers all variants of the third generation Superb (2015-2019?).

- [x] added to README
- [x] test route added to [test_car_models](../../selfdrive/test/test_car_models.py)
- [x] route with openpilot: b2e9858e29db492b|2021-03-26--16-58-42

Thanks to community Superb owner johndoe (2018).