### PR TITLE
VW: improve car's lane assist indication

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,4 +1,5 @@
 from cereal import car
+from common.params import Params
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.volkswagen import volkswagencan
 from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
@@ -18,9 +19,11 @@ class CarController():
     self.graMsgStartFramePrev = 0
     self.graMsgBusCounterPrev = 0
 
+    self.use_lanelines = Params().get('EndToEndToggle') != b'1'
+
     self.steer_rate_limited = False
 
-  def update(self, enabled, CS, frame, actuators, visual_alert, left_lane_visible, right_lane_visible):
+  def update(self, enabled, CS, frame, actuators, visual_alert, left_lane_visible, right_lane_visible, left_lane_depart, right_lane_depart):
     """ Controls thread """
 
     P = CarControllerParams
@@ -110,18 +113,20 @@ class CarController():
     # filters LDW_02 from the factory camera and OP emits LDW_02 at 10Hz.
 
     if frame % P.LDW_STEP == 0:
-      hcaEnabled = True if enabled and not CS.out.standstill else False
-
       if visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired:
         hud_alert = MQB_LDW_MESSAGES["laneAssistTakeOverSilent"]
       else:
         hud_alert = MQB_LDW_MESSAGES["none"]
 
-      can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, hcaEnabled,
+      left_lane_visible = (left_lane_visible and not CS.out.standstill) if self.use_lanelines else True
+      right_lane_visible = (right_lane_visible and not CS.out.standstill) if self.use_lanelines else True
+
+      can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, enabled,
                                                             CS.out.steeringPressed, hud_alert, left_lane_visible,
                                                             right_lane_visible, CS.ldw_lane_warning_left,
                                                             CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
-                                                            CS.ldw_dlc, CS.ldw_tlc))
+                                                            CS.ldw_dlc, CS.ldw_tlc,
+                                                            left_lane_depart, right_lane_depart))
 
     #--------------------------------------------------------------------------
     #                                                                         #

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,5 +1,4 @@
 from cereal import car
-from common.params import Params
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.volkswagen import volkswagencan
 from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
@@ -18,8 +17,6 @@ class CarController():
     self.graMsgSentCount = 0
     self.graMsgStartFramePrev = 0
     self.graMsgBusCounterPrev = 0
-
-    self.use_lanelines = Params().get('EndToEndToggle') != b'1'
 
     self.steer_rate_limited = False
 
@@ -118,14 +115,12 @@ class CarController():
       else:
         hud_alert = MQB_LDW_MESSAGES["none"]
 
-      left_lane_visible = (left_lane_visible and not CS.out.standstill) if self.use_lanelines else True
-      right_lane_visible = (right_lane_visible and not CS.out.standstill) if self.use_lanelines else True
 
       can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, enabled,
                                                             CS.out.steeringPressed, hud_alert, left_lane_visible,
                                                             right_lane_visible, CS.ldw_lane_warning_left,
                                                             CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
-                                                            CS.ldw_dlc, CS.ldw_tlc,
+                                                            CS.ldw_dlc, CS.ldw_tlc, CS.out.standstill,
                                                             left_lane_depart, right_lane_depart))
 
     #--------------------------------------------------------------------------

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -168,6 +168,8 @@ class CarInterface(CarInterfaceBase):
     can_sends = self.CC.update(c.enabled, self.CS, self.frame, c.actuators,
                    c.hudControl.visualAlert,
                    c.hudControl.leftLaneVisible,
-                   c.hudControl.rightLaneVisible)
+                   c.hudControl.rightLaneVisible,
+                   c.hudControl.leftLaneDepart,
+                   c.hudControl.rightLaneDepart)
     self.frame += 1
     return can_sends

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -15,18 +15,22 @@ def create_mqb_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
   }
   return packer.make_can_msg("HCA_01", bus, values, idx)
 
-def create_mqb_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
-                           ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc):
-  if hca_enabled:
-    left_lane_hud = 3 if left_lane_visible else 1
-    right_lane_hud = 3 if right_lane_visible else 1
-  else:
+def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
+                           ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
+                           left_lane_depart, right_lane_depart):
+  if enabled:
     left_lane_hud = 2 if left_lane_visible else 1
     right_lane_hud = 2 if right_lane_visible else 1
+  else:
+    left_lane_hud = 0
+    right_lane_hud = 0
+
+  left_lane_hud = 3 if left_lane_depart else left_lane_hud
+  right_lane_hud = 3 if right_lane_depart else right_lane_hud
 
   values = {
-    "LDW_Status_LED_gelb": 1 if hca_enabled and steering_pressed else 0,
-    "LDW_Status_LED_gruen": 1 if hca_enabled and not steering_pressed else 0,
+    "LDW_Status_LED_gelb": 1 if enabled and steering_pressed else 0,
+    "LDW_Status_LED_gruen": 1 if enabled and not steering_pressed else 0,
     "LDW_Lernmodus_links": left_lane_hud,
     "LDW_Lernmodus_rechts": right_lane_hud,
     "LDW_Texte": hud_alert,

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -17,13 +17,13 @@ def create_mqb_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
 
 def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
                            ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
-                           left_lane_depart, right_lane_depart):
+                           standstill, left_lane_depart, right_lane_depart):
   if enabled:
-    left_lane_hud = 2 if left_lane_visible else 1
-    right_lane_hud = 2 if right_lane_visible else 1
+    left_lane_hud = 3 if left_lane_visible and not standstill else 2
+    right_lane_hud = 3 if right_lane_visible and not standstill else 2
   else:
-    left_lane_hud = 0
-    right_lane_hud = 0
+    left_lane_hud = 1
+    right_lane_hud = 1
 
   left_lane_hud = 3 if left_lane_depart else left_lane_hud
   right_lane_hud = 3 if right_lane_depart else right_lane_hud


### PR DESCRIPTION
This makes a few small improvements to the car's lane assist status display for VW, Audi and other VW group brands.

The values display this, VW car display data from @jyoung8607:
- 0: nothing
- 1: grey lane line (used to show lane assist is active but not detecting lines)
- 2: green lane line, without arrow in VW (used to show lane assist is active and detecting lines, or active centering in Audi cars)
- 3: red lane line in Audi, green lane line with arrow in VW (used to show lane departure in Audi/VW, or active centering in VW)

To map openpilot as close as possible to the stock behaviour, after this diff the following is done:

- In any case, always show state 3 for lane departure
- With laneless: show state 2 when engaged, state 0 when disengaged
- With lanes (lane-specific states): show state 1 when engaged and no lane lines are visible, or forced when at a standstill (to avoid visual jitter), state 2 when engaged and lane lines detected, state 0 when disengaged

Test drives with my Audi A3:
892d124b54261a3a|2021-03-31--19-02-51 with lanes
892d124b54261a3a|2021-03-31--19-14-31 laneless
