### PR TITLE
update openpilot simulation device option

### DIFF
--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -20,7 +20,8 @@ docker run --net=host\
   --rm \
   -it \
   --gpus all \
-  --device=/dev/dri \
+  --device=/dev/dri:/dev/dri \
+  --device=/dev/input:/dev/input \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
   --shm-size 1G \
   -e DISPLAY=$DISPLAY \


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_routes.py](../../selfdrive/test/test_routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->

Description : There was an error for connect joystick to bridge.py because of ```--device``` option configuration.

*** Optional report
Although this one resolved device error, but I found another bug that ```manual_ctrl.py``` couldn't import ``` evdev ``` library. It could be resolved by manually install ``` evdev ``` with pip in container, but  when stop docker it flash.
I think ``` evdev ``` should be installed when build openpilot docker but I can't find how to do it.  Is there any idea?