### PR TITLE
Move loggerd rotation logic to encoder thread

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -154,11 +154,10 @@ LoggerdState s;
 static void trigger_rotate() {
   int err = logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
   assert(err == 0);
-  LOGW("rotated to %s", s.segment_path);
 
   for (auto &r : s.rotate_state) r.rotate();
-
   s.last_rotate_tms = millis_since_boot();
+  LOGW("rotated to %s", s.segment_path);
 }
 
 void encoder_thread(int cam_idx) {
@@ -429,7 +428,6 @@ int main(int argc, char** argv) {
         delete msg;
       }
     }
-
 
     pthread_mutex_lock(&s.rotate_lock);
     double tms = millis_since_boot();

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -401,8 +401,6 @@ int main(int argc, char** argv) {
   uint64_t bytes_count = 0;
   AlignedBuffer aligned_buf;
 
-
-
   double start_ts = seconds_since_boot();
   while (!do_exit) {
     // TODO: fix msgs from the first poll getting dropped

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -208,9 +208,6 @@ void encoder_thread(int cam_idx) {
       if (new_segment) {
         pthread_mutex_lock(&s.rotate_lock);
 
-        int err = logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
-        assert(err == 0);
-        LOGW("rotated to %s", s.segment_path);
 
         // rotate encoders
         for (auto &r : s.rotate_state) r.rotate();
@@ -233,19 +230,25 @@ void encoder_thread(int cam_idx) {
             rotate_state.initialized = true;
           }
 
-          // get new logger handle for new segment
-          if (lh) {
-            lh_close(lh);
-          }
-          lh = logger_get_handle(&s.logger);
 
           // wait for all to start rotating
+          LOGW("camera %d waiting for all encoders to start rotating", cam_idx);
           rotate_state.rotating = true;
           for(auto &r : s.rotate_state) {
              while(r.enabled && !r.rotating && !do_exit) util::sleep_for(5);
           }
+          LOGW("camera %d done waiting", cam_idx);
 
           pthread_mutex_lock(&s.rotate_lock);
+
+          // First camera takes care of rotating the log
+          if (cam_idx == 0){
+            int err = logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
+            assert(err == 0);
+            LOGW("rotated to %s", s.segment_path);
+          }
+
+          LOGW("camera %d rotating", cam_idx);
           for (auto &e : encoders) {
             e->encoder_close();
             e->encoder_open(s.segment_path);
@@ -254,11 +257,20 @@ void encoder_thread(int cam_idx) {
           pthread_mutex_unlock(&s.rotate_lock);
 
           // wait for all to finish rotating
+          LOGW("camera %d waiting for all encoders to finish rotating", cam_idx);
           for(auto &r : s.rotate_state) {
              while(r.enabled && r.cur_seg != s.rotate_segment && !do_exit) util::sleep_for(5);
           }
+          LOGW("camera %d done waiting", cam_idx);
+
           rotate_state.rotating = false;
           rotate_state.finish_rotate();
+
+          // get new logger handle for new segment
+          if (lh) {
+            lh_close(lh);
+          }
+          lh = logger_get_handle(&s.logger);
         }
       }
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -113,7 +113,7 @@ public:
   std::atomic<int> cur_seg;
 
   RotateState() : fpkt_sock(nullptr), stream_frame_id(0),
-                  last_rotate_frame_id(UINT32_MAX), enabled(false), should_rotate(false), initialized(false), rotating(false), cur_seg(-1) {};
+                  last_rotate_frame_id(UINT32_MAX), enabled(false), should_rotate(true), initialized(false), rotating(false), cur_seg(-1) {};
 
 
   void setStreamFrameId(uint32_t frame_id) {

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -223,11 +223,6 @@ void encoder_thread(int cam_idx) {
 
       // check if this encoder needs to rotate
       {
-        pthread_mutex_lock(&s.rotate_lock);
-        pthread_mutex_unlock(&s.rotate_lock);
-
-        if (do_exit) break;
-
         // rotate the encoder if the logger is on a newer segment
         if (rotate_state.should_rotate) {
           LOGW("camera %d rotate encoder to %s", cam_idx, s.segment_path);

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -146,6 +146,8 @@ struct LoggerdState {
   int rotate_segment;
   pthread_mutex_t rotate_lock;
   RotateState rotate_state[LOG_CAMERA_ID_MAX-1];
+
+  std::atomic<double> last_camera_seen_tms, last_rotate_tms;
 };
 LoggerdState s;
 
@@ -196,6 +198,9 @@ void encoder_thread(int cam_idx) {
       // Decide if we should rotate
       pthread_mutex_lock(&s.rotate_lock);
 
+      double tms = millis_since_boot();
+      s.last_camera_seen_tms = tms;
+
       bool new_segment = true;
       for (auto &r : s.rotate_state) {
         new_segment &= (((r.stream_frame_id >= r.last_rotate_frame_id + SEGMENT_LENGTH * MAIN_FPS) &&
@@ -213,6 +218,8 @@ void encoder_thread(int cam_idx) {
         LOGW("rotated to %s", s.segment_path);
 
         for (auto &r : s.rotate_state) r.rotate();
+
+        s.last_rotate_tms = tms;
       }
       pthread_mutex_unlock(&s.rotate_lock);
 
@@ -366,6 +373,16 @@ int main(int argc, char** argv) {
   // init encoders
   pthread_mutex_init(&s.rotate_lock, NULL);
 
+  int err = logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
+  assert(err == 0);
+  LOGW("logging to %s", s.segment_path);
+
+  // Trigger first rotate for all the encoders
+  for (auto &r : s.rotate_state) r.rotate();
+  double tms = millis_since_boot();
+  s.last_rotate_tms = tms;
+  s.last_camera_seen_tms = tms;
+
   // TODO: create these threads dynamically on frame packet presence
   std::vector<std::thread> encoder_threads;
   encoder_threads.push_back(std::thread(encoder_thread, LOG_CAMERA_ID_FCAMERA));
@@ -388,12 +405,7 @@ int main(int argc, char** argv) {
   uint64_t bytes_count = 0;
   AlignedBuffer aligned_buf;
 
-  int err = logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
-  assert(err == 0);
-  LOGW("logging to %s", s.segment_path);
 
-  // Trigger first roate for all the encoders
-  for (auto &r : s.rotate_state) r.rotate();
 
   double start_ts = seconds_since_boot();
   while (!do_exit) {
@@ -424,7 +436,22 @@ int main(int argc, char** argv) {
       }
     }
 
-    // TODO: rotate if camera frames time out
+
+    pthread_mutex_lock(&s.rotate_lock);
+    tms = millis_since_boot();
+    if ((tms - s.last_camera_seen_tms > NO_CAMERA_PATIENCE) || (encoder_threads.size() == 0)) {
+      if (tms - s.last_rotate_tms > SEGMENT_LENGTH * 1000) {
+        LOGW("no camera packet seen. auto rotating");
+
+        int err = logger_next(&s.logger, LOG_ROOT.c_str(), s.segment_path, sizeof(s.segment_path), &s.rotate_segment);
+        assert(err == 0);
+        LOGW("rotated to %s", s.segment_path);
+        for (auto &r : s.rotate_state) r.rotate();
+
+        s.last_rotate_tms = tms;
+      }
+    }
+    pthread_mutex_unlock(&s.rotate_lock);
   }
 
   LOGW("closing encoders");

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -204,12 +204,9 @@ void encoder_thread(int cam_idx) {
 #endif
       }
 
-      // rotate logger and all encoders to new segment
+      // Trigger rotation
       if (new_segment) {
         pthread_mutex_lock(&s.rotate_lock);
-
-
-        // rotate encoders
         for (auto &r : s.rotate_state) r.rotate();
         pthread_mutex_unlock(&s.rotate_lock);
       }

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -206,7 +206,6 @@ void encoder_thread(int cam_idx) {
 
       // Decide if we should rotate
       pthread_mutex_lock(&s.rotate_lock);
-
       s.last_camera_seen_tms = millis_since_boot();
 
       bool new_segment = true;
@@ -219,10 +218,7 @@ void encoder_thread(int cam_idx) {
 #endif
       }
 
-      // Trigger rotation
-      if (new_segment) {
-        trigger_rotate();
-      }
+      if (new_segment) trigger_rotate();
       pthread_mutex_unlock(&s.rotate_lock);
 
       // check if this encoder needs to rotate

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -242,15 +242,12 @@ void encoder_thread(int cam_idx) {
           }
 
           // wait for all to start rotating
-          LOGW("camera %d waiting for all encoders to start rotating", cam_idx);
           rotate_state.rotating = true;
           for(auto &r : s.rotate_state) {
              while(r.enabled && !r.rotating && !do_exit) util::sleep_for(5);
           }
-          LOGW("camera %d done waiting", cam_idx);
 
           pthread_mutex_lock(&s.rotate_lock);
-          LOGW("camera %d rotating", cam_idx);
           for (auto &e : encoders) {
             e->encoder_close();
             e->encoder_open(s.segment_path);
@@ -259,11 +256,9 @@ void encoder_thread(int cam_idx) {
           pthread_mutex_unlock(&s.rotate_lock);
 
           // wait for all to finish rotating
-          LOGW("camera %d waiting for all encoders to finish rotating", cam_idx);
           for(auto &r : s.rotate_state) {
              while(r.enabled && r.cur_seg != s.rotate_segment && !do_exit) util::sleep_for(5);
           }
-          LOGW("camera %d done waiting", cam_idx);
 
           rotate_state.rotating = false;
           rotate_state.finish_rotate();


### PR DESCRIPTION
After this PR it's no longer guaranteed that the `XXXCameraState` packets are in the same segment as the actual frame, however it makes the rotation logic more stable.