### PR TITLE
camerad: refactor exposure related functions

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -360,9 +360,8 @@ void road_cam_auto_exposure(CameraState *c) {
   camera_autoexposure(c, set_exposure_target(&c->buf, rect, analog_gain, false, false));
 }
 
-static void driver_cam_auto_exposure(CameraState *c) {
+static void driver_cam_auto_exposure(CameraState *c, SubMaster &sm) {
   static const bool is_rhd = Params().getBool("IsRHD");
-  static SubMaster sm({"driverState"});
   
   const CameraBuf *b = &c->buf;
 #ifndef QCOM2
@@ -399,8 +398,11 @@ static void driver_cam_auto_exposure(CameraState *c) {
 }
 
 void common_process_driver_camera(PubMaster *pm, CameraState *c, int cnt) {
+  static SubMaster sm({"driverState"});
+
   if (cnt % 3 == 0) {
-    driver_cam_auto_exposure(c);
+    sm.update(0);
+    driver_cam_auto_exposure(c, sm);
   }
   MessageBuilder msg;
   auto framed = msg.initEvent().initDriverCameraState();

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -124,13 +124,16 @@ public:
   void queue(size_t buf_idx);
 };
 
+struct ExpRect {int x1, x2, x_skip, y1, y2, y_skip;};
+float set_exposure_target(const CameraBuf *b, const ExpRect& rect, int analog_gain, bool hist_ceil, bool hl_weighted);
+void road_cam_auto_exposure(CameraState *c);
+
 typedef void (*process_thread_cb)(MultiCameraState *s, CameraState *c, int cnt);
 
 void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data);
 kj::Array<uint8_t> get_frame_image(const CameraBuf *b);
-float set_exposure_target(const CameraBuf *b, int x_start, int x_end, int x_skip, int y_start, int y_end, int y_skip, int analog_gain, bool hist_ceil, bool hl_weighted);
 std::thread start_process_thread(MultiCameraState *cameras, CameraState *cs, process_thread_cb callback);
-void common_process_driver_camera(SubMaster *sm, PubMaster *pm, CameraState *c, int cnt);
+void common_process_driver_camera(PubMaster *pm, CameraState *c, int cnt);
 
 void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx);
 void cameras_open(MultiCameraState *s);

--- a/selfdrive/camerad/cameras/camera_frame_stream.h
+++ b/selfdrive/camerad/cameras/camera_frame_stream.h
@@ -27,6 +27,5 @@ typedef struct MultiCameraState {
   CameraState road_cam;
   CameraState driver_cam;
 
-  SubMaster *sm;
   PubMaster *pm;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_qcom.cc
+++ b/selfdrive/camerad/cameras/camera_qcom.cc
@@ -221,7 +221,6 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
               /*max_gain=*/510, 10, device_id, ctx,
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
 
-  s->sm = new SubMaster({"driverState"});
   s->pm = new PubMaster({"roadCameraState", "driverCameraState", "thumbnail"});
 
   for (int i = 0; i < FRAME_BUF_COUNT; i++) {
@@ -1083,7 +1082,7 @@ static void setup_self_recover(CameraState *c, const uint16_t *lapres, size_t la
 }
 
 void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) {
-  common_process_driver_camera(s->sm, s->pm, c, cnt);
+  common_process_driver_camera(s->pm, c, cnt);
 }
 
 // called by processing_thread
@@ -1107,9 +1106,7 @@ void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
   s->pm->send("roadCameraState", msg);
 
   if (cnt % 3 == 0) {
-    const int x = 290, y = 322, width = 560, height = 314;
-    const int skip = 1;
-    camera_autoexposure(c, set_exposure_target(b, x, x + width, skip, y, y + height, skip, -1, false, false));
+    road_cam_auto_exposure(c);
   }
 }
 
@@ -1195,6 +1192,5 @@ void cameras_close(MultiCameraState *s) {
   }
 
   delete s->lap_conv;
-  delete s->sm;
   delete s->pm;
 }

--- a/selfdrive/camerad/cameras/camera_qcom.h
+++ b/selfdrive/camerad/cameras/camera_qcom.h
@@ -99,7 +99,6 @@ typedef struct MultiCameraState {
   CameraState road_cam;
   CameraState driver_cam;
 
-  SubMaster *sm;
   PubMaster *pm;
   LapConv *lap_conv;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -766,7 +766,6 @@ void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_i
               VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
   printf("driver camera initted \n");
 
-  s->sm = new SubMaster({"driverState"});
   s->pm = new PubMaster({"roadCameraState", "driverCameraState", "wideRoadCameraState", "thumbnail"});
 }
 
@@ -866,7 +865,6 @@ void cameras_close(MultiCameraState *s) {
   camera_close(&s->wide_road_cam);
   camera_close(&s->driver_cam);
 
-  delete s->sm;
   delete s->pm;
 }
 
@@ -1056,7 +1054,7 @@ static void ae_thread(MultiCameraState *s) {
 }
 
 void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) {
-  common_process_driver_camera(s->sm, s->pm, c, cnt);
+  common_process_driver_camera(s->pm, c, cnt);
 }
 
 // called by processing_thread
@@ -1075,9 +1073,7 @@ void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
   s->pm->send(c == &s->road_cam ? "roadCameraState" : "wideRoadCameraState", msg);
 
   if (cnt % 3 == 0) {
-    const auto [x, y, w, h] = (c == &s->wide_road_cam) ? std::tuple(96, 250, 1734, 524) : std::tuple(96, 160, 1734, 986);
-    const int skip = 2;
-    camera_autoexposure(c, set_exposure_target(b, x, x + w, skip, y, y + h, skip, (int)c->analog_gain, true, true));
+    road_cam_auto_exposure(c);
   }
 }
 

--- a/selfdrive/camerad/cameras/camera_qcom2.h
+++ b/selfdrive/camerad/cameras/camera_qcom2.h
@@ -74,6 +74,5 @@ typedef struct MultiCameraState {
 
   pthread_mutex_t isp_lock;
 
-  SubMaster *sm;
   PubMaster *pm;
 } MultiCameraState;

--- a/selfdrive/camerad/cameras/camera_webcam.h
+++ b/selfdrive/camerad/cameras/camera_webcam.h
@@ -25,6 +25,5 @@ typedef struct MultiCameraState {
   CameraState road_cam;
   CameraState driver_cam;
 
-  SubMaster *sm;
   PubMaster *pm;
 } MultiCameraState;

--- a/selfdrive/camerad/test/ae_gray_test.cc
+++ b/selfdrive/camerad/test/ae_gray_test.cc
@@ -44,7 +44,7 @@ int main() {
               memset(&fb_y[h_0*W+h_1*W], l[2], h_2*W);
               memset(&fb_y[h_0*W+h_1*W+h_2*W], l[3], h_3*W);
               memset(&fb_y[h_0*W+h_1*W+h_2*W+h_3*W], l[4], h_4*W);
-              float ev = set_exposure_target((const CameraBuf*) &cb, 0, W-1, 1, 0, H-1, 1, g*10, (bool)is_qcom2, (bool)is_qcom2);
+              float ev = set_exposure_target((const CameraBuf*) &cb, {0, W-1, 1, 0, H-1, 1}, g*10, (bool)is_qcom2, (bool)is_qcom2);
               // printf("%d/%d/%d/%d/%d ev is %f\n", h_0, h_1, h_2, h_3, h_4, ev);
               // printf("%f\n", ev);
 


### PR DESCRIPTION
1.  use struct `ExpRect` as parameter for `set_exposure_target`.
2.  remove  `SubMaster *sm` from `MultiCameraState`. use static SubMaster in `driver_cam_auto_exposure`
3. new function `road_cam_auto_exposure` in `camera_common`