### PR TITLE
2019 RDX Tech fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Supported Cars
 | ----------| ------------------------------| ------------------| -----------------| -------------------| ------------------|
 | Acura     | ILX 2016-19                   | AcuraWatch Plus   | openpilot        | 25mph<sup>1</sup>  | 25mph             |
 | Acura     | RDX 2016-18                   | AcuraWatch Plus   | openpilot        | 25mph<sup>1</sup>  | 12mph             |
-| Acura     | RDX 2020-21                   | All               | Stock            | 0mph               | 3mph              |
+| Acura     | RDX 2019-21                   | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Accord 2018-20                | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Accord Hybrid 2018-20         | All               | Stock            | 0mph               | 3mph              |
 | Honda     | Civic Hatchback 2017-21       | Honda Sensing     | Stock            | 0mph               | 12mph             |

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -941,6 +941,7 @@ FW_VERSIONS = {
       b'37805-5YF-A430\x00\x00',
       b'37805-5YF-C210\x00\x00',
       b'37805-5YF-A330\x00\x00',
+      b'37805-5YF-A870\x00\x00',
     ],
     (Ecu.vsa, 0x18da28f1, None): [
       b'57114-TJB-A040\x00\x00',
@@ -959,6 +960,7 @@ FW_VERSIONS = {
       b'28102-5YK-A700\x00\x00',
       b'28102-5YK-A711\x00\x00',
       b'28102-5YL-A700\x00\x00',
+      b'28102-5YK-A630\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TJB-AB10\x00\x00',
@@ -966,6 +968,7 @@ FW_VERSIONS = {
       b'78109-TJB-AF10\x00\x00',
       b'78109-TJB-AW10\x00\x00',
       b'78109-TJC-AA10\x00\x00',
+      b'78109-TJB-A240\x00\x00',
     ],
     (Ecu.srs, 0x18da53f1, None): [
       b'77959-TJB-A040\x00\x00',
@@ -978,6 +981,7 @@ FW_VERSIONS = {
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-TJB-A110\x00\x00',
       b'38897-TJB-A120\x00\x00',
+      b'38897-TJB-A040\x00\x00',
     ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-TJB-A030\x00\x00',

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -937,11 +937,11 @@ FW_VERSIONS = {
   CAR.ACURA_RDX_3G: {
     (Ecu.programmedFuelInjection, 0x18da10f1, None): [
       b'37805-5YF-A230\x00\x00',
+      b'37805-5YF-A330\x00\x00',
       b'37805-5YF-A420\x00\x00',
       b'37805-5YF-A430\x00\x00',
-      b'37805-5YF-C210\x00\x00',
-      b'37805-5YF-A330\x00\x00',
       b'37805-5YF-A870\x00\x00',
+      b'37805-5YF-C210\x00\x00',
     ],
     (Ecu.vsa, 0x18da28f1, None): [
       b'57114-TJB-A040\x00\x00',
@@ -957,18 +957,18 @@ FW_VERSIONS = {
       b'54008-TJB-A520\x00\x00',
     ],
     (Ecu.transmission, 0x18da1ef1, None): [
+      b'28102-5YK-A630\x00\x00',
       b'28102-5YK-A700\x00\x00',
       b'28102-5YK-A711\x00\x00',
       b'28102-5YL-A700\x00\x00',
-      b'28102-5YK-A630\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
+      b'78109-TJB-A240\x00\x00',
       b'78109-TJB-AB10\x00\x00',
       b'78109-TJB-AD10\x00\x00',
       b'78109-TJB-AF10\x00\x00',
       b'78109-TJB-AW10\x00\x00',
       b'78109-TJC-AA10\x00\x00',
-      b'78109-TJB-A240\x00\x00',
     ],
     (Ecu.srs, 0x18da53f1, None): [
       b'77959-TJB-A040\x00\x00',
@@ -979,9 +979,9 @@ FW_VERSIONS = {
       b'46114-TJB-A060\x00\x00',
     ],
     (Ecu.gateway, 0x18daeff1, None): [
+      b'38897-TJB-A040\x00\x00',
       b'38897-TJB-A110\x00\x00',
       b'38897-TJB-A120\x00\x00',
-      b'38897-TJB-A040\x00\x00',
     ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-TJB-A030\x00\x00',


### PR DESCRIPTION
***** Template: Car bug fix *****

**Description** 
2019 RDX Tech fingerprint

**Verification**
Test driven. It will disengage periodically on master branch, this didn't happen though when running on release-2. On both branches there were bad oscillations, I hope to add some steering improvements in a later PR.

**Route**
6a8fa21108f02593%7C2021-04-11--08-41-17--0

Dongle ID 6a8fa21108f02593


