### PR TITLE
PQ-VW

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -608,3 +608,4 @@ opendbc/toyota_adas.dbc
 opendbc/toyota_tss2_adas.dbc
 
 opendbc/vw_mqb_2010.dbc
+opendbc/vw_golf_mk4.dbc

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -130,11 +130,11 @@ class CarController():
         hud_alert = MQB_LDW_MESSAGES["none"]
 
       can_sends.append(self.create_hud_control(self.packer_pt, CANBUS.pt, hcaEnabled,
-                                                            CS.out.steeringPressed, hud_alert, left_lane_visible,
-                                                            right_lane_visible, CS.ldw_lane_warning_left,
-                                                            CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
-                                                            CS.ldw_dlc, CS.ldw_tlc, CS.out.standstill,
-                                                            left_lane_depart, right_lane_depart))
+                                               CS.out.steeringPressed, hud_alert, left_lane_visible,
+                                               right_lane_visible, CS.ldw_lane_warning_left,
+                                               CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
+                                               CS.ldw_dlc, CS.ldw_tlc, CS.out.standstill,
+                                               left_lane_depart, right_lane_depart))
 
     #--------------------------------------------------------------------------
     #                                                                         #

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -18,6 +18,17 @@ class CarController():
     self.graMsgStartFramePrev = 0
     self.graMsgBusCounterPrev = 0
 
+    if CP.safetyModel == car.CarParams.SafetyModel.volkswagen:
+      self.create_steering_control = volkswagencan.create_mqb_steering_control
+      self.create_acc_buttons_control = volkswagencan.create_mqb_acc_buttons_control
+      self.create_hud_control = volkswagencan.create_mqb_hud_control
+      self.ldw_step = CarControllerParams.MQB_LDW_STEP
+    elif CP.safetyModel == car.CarParams.SafetyModel.volkswagenPq:
+      self.create_steering_control = volkswagencan.create_pq_steering_control
+      self.create_acc_buttons_control = volkswagencan.create_pq_acc_buttons_control
+      self.create_hud_control = volkswagencan.create_pq_hud_control
+      self.ldw_step = CarControllerParams.PQ_LDW_STEP
+
     self.steer_rate_limited = False
 
   def update(self, enabled, CS, frame, actuators, visual_alert, left_lane_visible, right_lane_visible, left_lane_depart, right_lane_depart):
@@ -96,7 +107,7 @@ class CarController():
 
       self.apply_steer_last = apply_steer
       idx = (frame / P.HCA_STEP) % 16
-      can_sends.append(volkswagencan.create_mqb_steering_control(self.packer_pt, CANBUS.pt, apply_steer,
+      can_sends.append(self.create_steering_control(self.packer_pt, CANBUS.pt, apply_steer,
                                                                  idx, hcaEnabled))
 
     #--------------------------------------------------------------------------
@@ -109,14 +120,16 @@ class CarController():
     # The factory camera emits this message at 10Hz. When OP is active, Panda
     # filters LDW_02 from the factory camera and OP emits LDW_02 at 10Hz.
 
-    if frame % P.LDW_STEP == 0:
+    if frame % self.ldw_step == 0:
+      hcaEnabled = True if enabled and not CS.out.standstill else False
+
+      # FIXME: drive this down to the MQB/PQ specific create_hud_control functions
       if visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired:
         hud_alert = MQB_LDW_MESSAGES["laneAssistTakeOverSilent"]
       else:
         hud_alert = MQB_LDW_MESSAGES["none"]
 
-
-      can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, enabled,
+      can_sends.append(self.create_hud_control(self.packer_pt, CANBUS.pt, hcaEnabled,
                                                             CS.out.steeringPressed, hud_alert, left_lane_visible,
                                                             right_lane_visible, CS.ldw_lane_warning_left,
                                                             CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
@@ -178,7 +191,7 @@ class CarController():
         if self.graMsgSentCount == 0:
           self.graMsgStartFramePrev = frame
         idx = (CS.graMsgBusCounter + 1) % 16
-        can_sends.append(volkswagencan.create_mqb_acc_buttons_control(self.packer_pt, CANBUS.pt, self.graButtonStatesToSend, CS, idx))
+        can_sends.append(self.create_acc_buttons_control(self.packer_pt, CANBUS.pt, self.graButtonStatesToSend, CS, idx))
         self.graMsgSentCount += 1
         if self.graMsgSentCount >= P.GRA_VBP_COUNT:
           self.graButtonStatesToSend = None

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -257,7 +257,6 @@ class CarState(CarStateBase):
 
     # Pick up the GRA_ACC_01 CAN message counter so we can sync to it for
     # later cruise-control button spamming.
-    # FIXME: will need msg counter and checksum algo to spoof GRA_neu
     self.graMsgBusCounter = pt_cp.vl["GRA_Neu"]['GRA_Neu_Zaehler']
 
     # Check to make sure the electric power steering rack is configured to

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -408,15 +408,13 @@ class CarState(CarStateBase):
       ("Motor_2", 50),            # From J623 Engine control module
       ("Lenkhilfe_2", 20),        # From J500 Steering Assist with integrated sensors
       ("Bremse_1", 100),          # From J104 ABS/ESP controller
-      ("Gate_Komf_1", 10),        # From J533 CAN gateway
     ]
 
     if CP.transmissionType == TransmissionType.automatic:
       signals += [("Waehlhebelposition__Getriebe_1_", "Getriebe_1", 0)]  # Auto trans gear selector position
       checks += [("Getriebe_1", 100)]  # From J743 Auto transmission control module
     elif CP.transmissionType == TransmissionType.manual:
-      signals += [("Kupplungsschalter", "Motor_1", 0),  # Clutch switch
-                  ("GK1_Rueckfahr", "Gate_Komf_1", 0)]  # Reverse light from BCM
+      signals += [("Kupplungsschalter", "Motor_1", 0)]  # Clutch switch
       checks += [("Motor_1", 100)]  # From J623 Engine control module
 
     # FIXME: ignoring ACC signals until we detect its presence and bus location

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -10,13 +10,26 @@ class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
     can_define = CANDefine(DBC[CP.carFingerprint]['pt'])
-    if CP.transmissionType == TransmissionType.automatic:
-      self.shifter_values = can_define.dv["Getriebe_11"]['GE_Fahrstufe']
-    elif CP.transmissionType == TransmissionType.direct:
-      self.shifter_values = can_define.dv["EV_Gearshift"]['GearPosition']
+
+    if CP.safetyModel == car.CarParams.SafetyModel.volkswagenPq:
+      # Configure for PQ35/PQ46/NMS network messaging
+      self.get_can_parser = self.get_pq_can_parser
+      self.get_cam_can_parser = self.get_pq_cam_can_parser
+      self.update = self.update_pq
+      if CP.transmissionType == TransmissionType.automatic:
+        self.shifter_values = can_define.dv["Getriebe_1"]['Waehlhebelposition__Getriebe_1_']
+    else:
+      # Configure for MQB network messaging (default)
+      self.get_can_parser = self.get_mqb_can_parser
+      self.get_cam_can_parser = self.get_mqb_cam_can_parser
+      self.update = self.update_mqb
+      if CP.transmissionType == TransmissionType.automatic:
+        self.shifter_values = can_define.dv["Getriebe_11"]['GE_Fahrstufe']
+      elif CP.transmissionType == TransmissionType.direct:
+        self.shifter_values = can_define.dv["EV_Gearshift"]['GearPosition']
     self.buttonStates = BUTTON_STATES.copy()
 
-  def update(self, pt_cp, cam_cp, trans_type):
+  def update_mqb(self, pt_cp, cam_cp, trans_type):
     ret = car.CarState.new_message()
     # Update vehicle speed and acceleration from ABS wheel speeds.
     ret.wheelSpeeds.fl = pt_cp.vl["ESP_19"]['ESP_VL_Radgeschw_02'] * CV.KPH_TO_MS
@@ -152,8 +165,112 @@ class CarState(CarStateBase):
 
     return ret
 
+  def update_pq(self, pt_cp, cam_cp, trans_type):
+    ret = car.CarState.new_message()
+    # Update vehicle speed and acceleration from ABS wheel speeds.
+    ret.wheelSpeeds.fl = pt_cp.vl["Bremse_3"]['Radgeschw__VL_4_1'] * CV.KPH_TO_MS
+    ret.wheelSpeeds.fr = pt_cp.vl["Bremse_3"]['Radgeschw__VR_4_1'] * CV.KPH_TO_MS
+    ret.wheelSpeeds.rl = pt_cp.vl["Bremse_3"]['Radgeschw__HL_4_1'] * CV.KPH_TO_MS
+    ret.wheelSpeeds.rr = pt_cp.vl["Bremse_3"]['Radgeschw__HR_4_1'] * CV.KPH_TO_MS
+
+    ret.vEgoRaw = float(np.mean([ret.wheelSpeeds.fl, ret.wheelSpeeds.fr, ret.wheelSpeeds.rl, ret.wheelSpeeds.rr]))
+    ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
+
+    ret.standstill = ret.vEgoRaw < 0.1
+
+    # Update steering angle, rate, yaw rate, and driver input torque. VW send
+    # the sign/direction in a separate signal so they must be recombined.
+    ret.steeringAngleDeg = pt_cp.vl["Lenkhilfe_3"]['LH3_BLW'] * (1, -1)[int(pt_cp.vl["Lenkhilfe_3"]['LH3_BLWSign'])]
+    ret.steeringRateDeg = pt_cp.vl["Lenkwinkel_1"]['Lenkradwinkel_Geschwindigkeit'] * (1, -1)[int(pt_cp.vl["Lenkwinkel_1"]['Lenkradwinkel_Geschwindigkeit_S'])]
+    ret.steeringTorque = pt_cp.vl["Lenkhilfe_3"]['LH3_LM'] * (1, -1)[int(pt_cp.vl["Lenkhilfe_3"]['LH3_LMSign'])]
+    ret.steeringPressed = abs(ret.steeringTorque) > CarControllerParams.STEER_DRIVER_ALLOWANCE
+    ret.yawRate = pt_cp.vl["Bremse_5"]['Giergeschwindigkeit'] * (1, -1)[int(pt_cp.vl["Bremse_5"]['Vorzeichen_der_Giergeschwindigk'])] * CV.DEG_TO_RAD
+
+    # Update gas, brakes, and gearshift.
+    ret.gas = pt_cp.vl["Motor_3"]['Fahrpedal_Rohsignal'] / 100.0
+    ret.gasPressed = ret.gas > 0
+    ret.brake = pt_cp.vl["Bremse_5"]['Bremsdruck'] / 250.0  # FIXME: this is pressure in Bar, not sure what OP expects
+    ret.brakePressed = bool(pt_cp.vl["Motor_2"]['Bremstestschalter'])
+    ret.brakeLights = bool(pt_cp.vl["Motor_2"]['Bremslichtschalter'])
+
+    # Update gear and/or clutch position data.
+    if trans_type == TransmissionType.automatic:
+      ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(pt_cp.vl["Getriebe_1"]['Waehlhebelposition__Getriebe_1_'], None))
+    elif trans_type == TransmissionType.manual:
+      ret.clutchPressed = not pt_cp.vl["Motor_1"]['Kupplungsschalter']
+      reverse_light = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Rueckfahr'])
+      if reverse_light:
+        ret.gearShifter = GearShifter.reverse
+      else:
+        ret.gearShifter = GearShifter.drive
+
+    # Update door and trunk/hatch lid open status.
+    # TODO: need to locate signals for other three doors if possible
+    ret.doorOpen = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Fa_Tuerkont'])
+
+    # Update seatbelt fastened status.
+    ret.seatbeltUnlatched = not bool(pt_cp.vl["Airbag_1"]["Gurtschalter_Fahrer"])
+
+    # Update driver preference for metric. VW stores many different unit
+    # preferences, including separate units for for distance vs. speed.
+    # We use the speed preference for OP.
+    self.displayMetricUnits = not pt_cp.vl["Einheiten_1"]["MFA_v_Einheit_02"]
+
+    # TODO: Consume blind spot data from factory radar, if present
+    # TODO: Consume lane departure data from factory camera, if present
+    self.ldw_lane_warning_left = False
+    self.ldw_lane_warning_right = False
+    self.ldw_side_dlc_tlc = None
+    self.ldw_dlc = None
+    self.ldw_tlc = None
+    # TODO: Consume FCW/AEB data from factory radar, if present
+
+    # Update ACC radar status.
+    ret.cruiseState.available = bool(pt_cp.vl["GRA_Neu"]['GRA_Hauptschalt'])
+    ret.cruiseState.enabled = True if pt_cp.vl["Motor_2"]['GRA_Status'] in [1, 2] else False
+
+    # Update ACC setpoint. When the setpoint reads as 255, the driver has not
+    # yet established an ACC setpoint, so treat it as zero.
+    # FIXME: for now this is the CC setpoint, the radar setpoint is in ACC_GRA_Anziege.ACA_V_Wunsch
+    ret.cruiseState.speed = pt_cp.vl["Motor_2"]['Soll_Geschwindigkeit_bei_GRA_Be'] * CV.KPH_TO_MS
+    if ret.cruiseState.speed > 70:  # 255 kph in m/s == no current setpoint
+      ret.cruiseState.speed = 0
+
+    # Update control button states for turn signals and ACC controls.
+    self.buttonStates["accelCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Up_kurz']) or bool(pt_cp.vl["GRA_Neu"]['GRA_Up_lang'])
+    self.buttonStates["decelCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Down_kurz']) or bool(pt_cp.vl["GRA_Neu"]['GRA_Down_lang'])
+    self.buttonStates["cancel"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Abbrechen'])
+    self.buttonStates["setCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Neu_Setzen'])
+    self.buttonStates["resumeCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Recall'])
+    self.buttonStates["gapAdjustCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Zeitluecke'])
+    ret.leftBlinker = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Blinker_li'])
+    ret.rightBlinker = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Blinker_re'])
+
+    # Read ACC hardware button type configuration info that has to pass thru
+    # to the radar. Ends up being different for steering wheel buttons vs
+    # third stalk type controls.
+    self.graHauptschalter = pt_cp.vl["GRA_Neu"]['GRA_Hauptschalt']
+    self.graSenderCoding = pt_cp.vl["GRA_Neu"]['GRA_Sender']
+    self.graTypHauptschalter = False
+    self.graButtonTypeInfo = False
+    self.graTipStufe2 = False
+    # Pick up the GRA_ACC_01 CAN message counter so we can sync to it for
+    # later cruise-control button spamming.
+    # FIXME: will need msg counter and checksum algo to spoof GRA_neu
+    self.graMsgBusCounter = pt_cp.vl["GRA_Neu"]['GRA_Neu_Zaehler']
+
+    # Check to make sure the electric power steering rack is configured to
+    # accept and respond to HCA_01 messages and has not encountered a fault.
+    self.steeringFault = pt_cp.vl["Lenkhilfe_2"]['LH2_Sta_HCA'] not in [1, 3, 5, 7]
+
+    # Additional safety checks performed in CarInterface.
+    self.parkingBrakeSet = bool(pt_cp.vl["Kombi_1"]['Bremsinfo'])  # FIXME: need to include an EPB check as well
+    ret.espDisabled = bool(pt_cp.vl["Bremse_1"]['ESP_Passiv_getastet'])
+
+    return ret
+
   @staticmethod
-  def get_can_parser(CP):
+  def get_mqb_can_parser(CP):
     # this function generates lists for signal, messages and initial values
     signals = [
       # sig_name, sig_address, default
@@ -252,7 +369,83 @@ class CarState(CarStateBase):
     return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.pt)
 
   @staticmethod
-  def get_cam_can_parser(CP):
+  def get_pq_can_parser(CP):
+    signals = [
+      # sig_name, sig_address, default
+      ("LH3_BLW", "Lenkhilfe_3", 0),                # Absolute steering angle
+      ("LH3_BLWSign", "Lenkhilfe_3", 0),            # Steering angle sign
+      ("LH3_LM", "Lenkhilfe_3", 0),                 # Absolute driver torque input
+      ("LH3_LMSign", "Lenkhilfe_3", 0),             # Driver torque input sign
+      ("LH2_Sta_HCA", "Lenkhilfe_2", 0),            # Steering rack HCA status
+      ("Lenkradwinkel_Geschwindigkeit", "Lenkwinkel_1", 0),  # Absolute steering rate
+      ("Lenkradwinkel_Geschwindigkeit_S", "Lenkwinkel_1", 0),  # Steering rate sign
+      ("Radgeschw__VL_4_1", "Bremse_3", 0),         # ABS wheel speed, front left
+      ("Radgeschw__VR_4_1", "Bremse_3", 0),         # ABS wheel speed, front right
+      ("Radgeschw__HL_4_1", "Bremse_3", 0),         # ABS wheel speed, rear left
+      ("Radgeschw__HR_4_1", "Bremse_3", 0),         # ABS wheel speed, rear right
+      ("Giergeschwindigkeit", "Bremse_5", 0),       # Absolute yaw rate
+      ("Vorzeichen_der_Giergeschwindigk", "Bremse_5", 0),  # Yaw rate sign
+      ("GK1_Fa_Tuerkont", "Gate_Komf_1", 0),        # Door open, driver
+      # TODO: locate passenger and rear door states
+      ("GK1_Blinker_li", "Gate_Komf_1", 0),         # Left turn signal on
+      ("GK1_Blinker_re", "Gate_Komf_1", 0),         # Right turn signal on
+      ("Gurtschalter_Fahrer", "Airbag_1", 0),       # Seatbelt status, driver
+      ("Gurtschalter_Beifahrer", "Airbag_1", 0),    # Seatbelt status, passenger
+      ("Bremstestschalter", "Motor_2", 0),          # Brake pedal pressed (brake light test switch)
+      ("Bremslichtschalter", "Motor_2", 0),         # Brakes applied (brake light switch)
+      ("Bremsdruck", "Bremse_5", 0),                # Brake pressure applied
+      ("Vorzeichen_Bremsdruck", "Bremse_5", 0),     # Brake pressure applied sign (???)
+      ("Fahrpedal_Rohsignal", "Motor_3", 0),        # Accelerator pedal value
+      ("ESP_Passiv_getastet", "Bremse_1", 0),       # Stability control disabled
+      ("MFA_v_Einheit_02", "Einheiten_1", 0),       # MPH vs KMH speed display
+      ("Bremsinfo", "Kombi_1", 0),                  # Manual handbrake applied
+      ("GRA_Status", "Motor_2", 0),                 # ACC engagement status
+      ("Soll_Geschwindigkeit_bei_GRA_Be", "Motor_2", 0),  # FIXME: CC setpoint from ECU, does this work for ACC?
+      ("GRA_Hauptschalt", "GRA_Neu", 0),            # ACC button, on/off
+      ("GRA_Abbrechen", "GRA_Neu", 0),              # ACC button, cancel
+      ("GRA_Neu_Setzen", "GRA_Neu", 0),             # ACC button, set
+      ("GRA_Up_lang", "GRA_Neu", 0),                # ACC button, increase or accel, long press
+      ("GRA_Down_lang", "GRA_Neu", 0),              # ACC button, decrease or decel, long press
+      ("GRA_Up_kurz", "GRA_Neu", 0),                # ACC button, increase or accel, short press
+      ("GRA_Down_kurz", "GRA_Neu", 0),              # ACC button, decrease or decel, short press
+      ("GRA_Recall", "GRA_Neu", 0),                 # ACC button, resume
+      ("GRA_Zeitluecke", "GRA_Neu", 0),             # ACC button, time gap adj
+      ("GRA_Neu_Zaehler", "GRA_Neu", 0),            # ACC button, time gap adj
+      ("GRA_Sender", "GRA_Neu", 0),                 # GRA Sender Coding
+    ]
+
+    checks = [
+      # sig_address, frequency
+      ("Bremse_3", 100),          # From J104 ABS/ESP controller
+      ("Lenkhilfe_3", 100),       # From J500 Steering Assist with integrated sensors
+      ("Lenkwinkel_1", 100),      # From J500 Steering Assist with integrated sensors
+      ("Motor_3", 100),           # From J623 Engine control module
+      ("Airbag_1", 50),           # From J234 Airbag control module
+      ("Bremse_5", 50),           # From J104 ABS/ESP controller
+      ("GRA_Neu", 50),            # From J??? steering wheel control buttons
+      ("Kombi_1", 50),            # From J285 Instrument cluster
+      ("Motor_2", 50),            # From J623 Engine control module
+      ("Lenkhilfe_2", 20),        # From J500 Steering Assist with integrated sensors
+      ("Gate_Komf_1", 10),        # From J533 CAN gateway
+      ("Einheiten_1", 1),         # From J??? cluster or gateway
+    ]
+
+    if CP.transmissionType == TransmissionType.automatic:
+      signals += [("Waehlhebelposition__Getriebe_1_", "Getriebe_1", 0)]  # Auto trans gear selector position
+      checks += [("Getriebe_1", 100)]  # From J743 Auto transmission control module
+    elif CP.transmissionType == TransmissionType.manual:
+      signals += [("Kupplungsschalter", "Motor_1", 0),  # Clutch switch
+                  ("GK1_Rueckfahr", "Gate_Komf_1", 0)]  # Reverse light from BCM
+      checks += [("Motor_1", 100)]  # From J623 Engine control module
+
+    # FIXME: ignoring ACC signals until we detect its presence and bus location
+    #   signals += [("ACA_V_Wunsch", "ACC_GRA_Anziege", 0)]  # ACC set speed
+    #   checks += [("ACC_GRA_Anziege", 25)]  # From J428 ACC radar control module
+
+    return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.pt)
+
+  @staticmethod
+  def get_mqb_cam_can_parser(CP):
 
     signals = [
       # sig_name, sig_address, default
@@ -267,5 +460,17 @@ class CarState(CarStateBase):
       # sig_address, frequency
       ("LDW_02", 10)        # From R242 Driver assistance camera
     ]
+
+    return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.cam)
+
+  @staticmethod
+  def get_pq_cam_can_parser(CP):
+    # TODO: Need to monitor LKAS camera, if present, for TLC/DLC/warning signals for passthru to SWA
+    signals = []
+    checks = []
+
+    # FIXME: ignoring ACC signals until we detect its presence and bus location
+    #   signals += [("ACA_V_Wunsch", "ACC_GRA_Anziege", 0)]  # ACC set speed
+    #   checks += [("ACC_GRA_Anziege", 25)]  # From J428 ACC radar control module
 
     return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.cam)

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -227,7 +227,7 @@ class CarState(CarStateBase):
 
     # Update ACC radar status.
     ret.cruiseState.available = bool(pt_cp.vl["GRA_Neu"]['GRA_Hauptschalt'])
-    ret.cruiseState.enabled = True if pt_cp.vl["Motor_2"]['GRA_Status'] in [1, 2] else False
+    ret.cruiseState.enabled = pt_cp.vl["Motor_2"]['GRA_Status'] in [1, 2]
 
     # Update ACC setpoint. When the setpoint reads as 255, the driver has not
     # yet established an ACC setpoint, so treat it as zero.
@@ -254,6 +254,7 @@ class CarState(CarStateBase):
     self.graTypHauptschalter = False
     self.graButtonTypeInfo = False
     self.graTipStufe2 = False
+
     # Pick up the GRA_ACC_01 CAN message counter so we can sync to it for
     # later cruise-control button spamming.
     # FIXME: will need msg counter and checksum algo to spoof GRA_neu

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -465,4 +465,12 @@ class CarState(CarStateBase):
 
   @staticmethod
   def get_pq_cam_can_parser(CP):
-    return None
+    # TODO: Need to monitor LKAS camera, if present, for TLC/DLC/warning signals for passthru to SWA
+    signals = []
+    checks = []
+
+    # FIXME: ignoring ACC signals until we detect its presence and bus location
+    #   signals += [("ACA_V_Wunsch", "ACC_GRA_Anziege", 0)]  # ACC set speed
+    #   checks += [("ACC_GRA_Anziege", 25)]  # From J428 ACC radar control module
+
+    return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.cam)

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -407,6 +407,8 @@ class CarState(CarStateBase):
       ("Bremse_5", 50),           # From J104 ABS/ESP controller
       ("Motor_2", 50),            # From J623 Engine control module
       ("Lenkhilfe_2", 20),        # From J500 Steering Assist with integrated sensors
+      ("Bremse_1", 100),          # From J104 ABS/ESP controller
+      ("Gate_Komf_1", 10),        # From J533 CAN gateway
     ]
 
     if CP.transmissionType == TransmissionType.automatic:

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -198,7 +198,7 @@ class CarState(CarStateBase):
       ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(pt_cp.vl["Getriebe_1"]['Waehlhebelposition__Getriebe_1_'], None))
     elif trans_type == TransmissionType.manual:
       ret.clutchPressed = not pt_cp.vl["Motor_1"]['Kupplungsschalter']
-      reverse_light = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Rueckfahr'])
+      reverse_light = bool(cam_cp.vl["Gate_Komf_1"]['GK1_Rueckfahr'])
       if reverse_light:
         ret.gearShifter = GearShifter.reverse
       else:
@@ -206,7 +206,7 @@ class CarState(CarStateBase):
 
     # Update door and trunk/hatch lid open status.
     # TODO: need to locate signals for other three doors if possible
-    ret.doorOpen = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Fa_Tuerkont'])
+    ret.doorOpen = bool(cam_cp.vl["Gate_Komf_1"]['GK1_Fa_Tuerkont'])
 
     # Update seatbelt fastened status.
     ret.seatbeltUnlatched = not bool(pt_cp.vl["Airbag_1"]["Gurtschalter_Fahrer"])
@@ -214,7 +214,7 @@ class CarState(CarStateBase):
     # Update driver preference for metric. VW stores many different unit
     # preferences, including separate units for for distance vs. speed.
     # We use the speed preference for OP.
-    self.displayMetricUnits = not pt_cp.vl["Einheiten_1"]["MFA_v_Einheit_02"]
+    self.displayMetricUnits = False
 
     # TODO: Consume blind spot data from factory radar, if present
     # TODO: Consume lane departure data from factory camera, if present
@@ -226,7 +226,7 @@ class CarState(CarStateBase):
     # TODO: Consume FCW/AEB data from factory radar, if present
 
     # Update ACC radar status.
-    ret.cruiseState.available = bool(pt_cp.vl["GRA_Neu"]['GRA_Hauptschalt'])
+    ret.cruiseState.available = bool(cam_cp.vl["GRA_Neu"]['GRA_Hauptschalt'])
     ret.cruiseState.enabled = pt_cp.vl["Motor_2"]['GRA_Status'] in [1, 2]
 
     # Update ACC setpoint. When the setpoint reads as 255, the driver has not
@@ -237,34 +237,34 @@ class CarState(CarStateBase):
       ret.cruiseState.speed = 0
 
     # Update control button states for turn signals and ACC controls.
-    self.buttonStates["accelCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Up_kurz']) or bool(pt_cp.vl["GRA_Neu"]['GRA_Up_lang'])
-    self.buttonStates["decelCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Down_kurz']) or bool(pt_cp.vl["GRA_Neu"]['GRA_Down_lang'])
-    self.buttonStates["cancel"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Abbrechen'])
-    self.buttonStates["setCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Neu_Setzen'])
-    self.buttonStates["resumeCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Recall'])
-    self.buttonStates["gapAdjustCruise"] = bool(pt_cp.vl["GRA_Neu"]['GRA_Zeitluecke'])
-    ret.leftBlinker = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Blinker_li'])
-    ret.rightBlinker = bool(pt_cp.vl["Gate_Komf_1"]['GK1_Blinker_re'])
+    self.buttonStates["accelCruise"] = bool(cam_cp.vl["GRA_Neu"]['GRA_Up_kurz']) or bool(cam_cp.vl["GRA_Neu"]['GRA_Up_lang'])
+    self.buttonStates["decelCruise"] = bool(cam_cp.vl["GRA_Neu"]['GRA_Down_kurz']) or bool(cam_cp.vl["GRA_Neu"]['GRA_Down_lang'])
+    self.buttonStates["cancel"] = bool(cam_cp.vl["GRA_Neu"]['GRA_Abbrechen'])
+    self.buttonStates["setCruise"] = bool(cam_cp.vl["GRA_Neu"]['GRA_Neu_Setzen'])
+    self.buttonStates["resumeCruise"] = bool(cam_cp.vl["GRA_Neu"]['GRA_Recall'])
+    self.buttonStates["gapAdjustCruise"] = bool(cam_cp.vl["GRA_Neu"]['GRA_Zeitluecke'])
+    ret.leftBlinker = bool(cam_cp.vl["Gate_Komf_1"]['GK1_Blinker_li'])
+    ret.rightBlinker = bool(cam_cp.vl["Gate_Komf_1"]['GK1_Blinker_re'])
 
     # Read ACC hardware button type configuration info that has to pass thru
     # to the radar. Ends up being different for steering wheel buttons vs
     # third stalk type controls.
-    self.graHauptschalter = pt_cp.vl["GRA_Neu"]['GRA_Hauptschalt']
-    self.graSenderCoding = pt_cp.vl["GRA_Neu"]['GRA_Sender']
+    self.graHauptschalter = cam_cp.vl["GRA_Neu"]['GRA_Hauptschalt']
+    self.graSenderCoding = cam_cp.vl["GRA_Neu"]['GRA_Sender']
     self.graTypHauptschalter = False
     self.graButtonTypeInfo = False
     self.graTipStufe2 = False
 
     # Pick up the GRA_ACC_01 CAN message counter so we can sync to it for
     # later cruise-control button spamming.
-    self.graMsgBusCounter = pt_cp.vl["GRA_Neu"]['GRA_Neu_Zaehler']
+    self.graMsgBusCounter = cam_cp.vl["GRA_Neu"]['GRA_Neu_Zaehler']
 
     # Check to make sure the electric power steering rack is configured to
     # accept and respond to HCA_01 messages and has not encountered a fault.
     self.steeringFault = pt_cp.vl["Lenkhilfe_2"]['LH2_Sta_HCA'] not in [1, 3, 5, 7]
 
     # Additional safety checks performed in CarInterface.
-    self.parkingBrakeSet = bool(pt_cp.vl["Kombi_1"]['Bremsinfo'])  # FIXME: need to include an EPB check as well
+    self.parkingBrakeSet = bool(cam_cp.vl["Kombi_1"]['Bremsinfo'])  # FIXME: need to include an EPB check as well
     ret.espDisabled = bool(pt_cp.vl["Bremse_1"]['ESP_Passiv_getastet'])
 
     return ret
@@ -385,10 +385,6 @@ class CarState(CarStateBase):
       ("Radgeschw__HR_4_1", "Bremse_3", 0),         # ABS wheel speed, rear right
       ("Giergeschwindigkeit", "Bremse_5", 0),       # Absolute yaw rate
       ("Vorzeichen_der_Giergeschwindigk", "Bremse_5", 0),  # Yaw rate sign
-      ("GK1_Fa_Tuerkont", "Gate_Komf_1", 0),        # Door open, driver
-      # TODO: locate passenger and rear door states
-      ("GK1_Blinker_li", "Gate_Komf_1", 0),         # Left turn signal on
-      ("GK1_Blinker_re", "Gate_Komf_1", 0),         # Right turn signal on
       ("Gurtschalter_Fahrer", "Airbag_1", 0),       # Seatbelt status, driver
       ("Gurtschalter_Beifahrer", "Airbag_1", 0),    # Seatbelt status, passenger
       ("Bremstestschalter", "Motor_2", 0),          # Brake pedal pressed (brake light test switch)
@@ -397,21 +393,8 @@ class CarState(CarStateBase):
       ("Vorzeichen_Bremsdruck", "Bremse_5", 0),     # Brake pressure applied sign (???)
       ("Fahrpedal_Rohsignal", "Motor_3", 0),        # Accelerator pedal value
       ("ESP_Passiv_getastet", "Bremse_1", 0),       # Stability control disabled
-      ("MFA_v_Einheit_02", "Einheiten_1", 0),       # MPH vs KMH speed display
-      ("Bremsinfo", "Kombi_1", 0),                  # Manual handbrake applied
       ("GRA_Status", "Motor_2", 0),                 # ACC engagement status
       ("Soll_Geschwindigkeit_bei_GRA_Be", "Motor_2", 0),  # FIXME: CC setpoint from ECU, does this work for ACC?
-      ("GRA_Hauptschalt", "GRA_Neu", 0),            # ACC button, on/off
-      ("GRA_Abbrechen", "GRA_Neu", 0),              # ACC button, cancel
-      ("GRA_Neu_Setzen", "GRA_Neu", 0),             # ACC button, set
-      ("GRA_Up_lang", "GRA_Neu", 0),                # ACC button, increase or accel, long press
-      ("GRA_Down_lang", "GRA_Neu", 0),              # ACC button, decrease or decel, long press
-      ("GRA_Up_kurz", "GRA_Neu", 0),                # ACC button, increase or accel, short press
-      ("GRA_Down_kurz", "GRA_Neu", 0),              # ACC button, decrease or decel, short press
-      ("GRA_Recall", "GRA_Neu", 0),                 # ACC button, resume
-      ("GRA_Zeitluecke", "GRA_Neu", 0),             # ACC button, time gap adj
-      ("GRA_Neu_Zaehler", "GRA_Neu", 0),            # ACC button, time gap adj
-      ("GRA_Sender", "GRA_Neu", 0),                 # GRA Sender Coding
     ]
 
     checks = [
@@ -422,12 +405,8 @@ class CarState(CarStateBase):
       ("Motor_3", 100),           # From J623 Engine control module
       ("Airbag_1", 50),           # From J234 Airbag control module
       ("Bremse_5", 50),           # From J104 ABS/ESP controller
-      ("GRA_Neu", 50),            # From J??? steering wheel control buttons
-      ("Kombi_1", 50),            # From J285 Instrument cluster
       ("Motor_2", 50),            # From J623 Engine control module
       ("Lenkhilfe_2", 20),        # From J500 Steering Assist with integrated sensors
-      ("Gate_Komf_1", 10),        # From J533 CAN gateway
-      ("Einheiten_1", 1),         # From J??? cluster or gateway
     ]
 
     if CP.transmissionType == TransmissionType.automatic:
@@ -465,12 +444,32 @@ class CarState(CarStateBase):
 
   @staticmethod
   def get_pq_cam_can_parser(CP):
-    # TODO: Need to monitor LKAS camera, if present, for TLC/DLC/warning signals for passthru to SWA
-    signals = []
-    checks = []
+    signals = [
+      ("GK1_Fa_Tuerkont", "Gate_Komf_1", 0),        # Door open, driver
+      # TODO: locate passenger and rear door states
+      ("GK1_Blinker_li", "Gate_Komf_1", 0),         # Left turn signal on
+      ("GK1_Blinker_re", "Gate_Komf_1", 0),         # Right turn signal on
+      ("Bremsinfo", "Kombi_1", 0),                  # Manual handbrake applied
+      ("GRA_Hauptschalt", "GRA_Neu", 0),            # ACC button, on/off
+      ("GRA_Abbrechen", "GRA_Neu", 0),              # ACC button, cancel
+      ("GRA_Neu_Setzen", "GRA_Neu", 0),             # ACC button, set
+      ("GRA_Up_lang", "GRA_Neu", 0),                # ACC button, increase or accel, long press
+      ("GRA_Down_lang", "GRA_Neu", 0),              # ACC button, decrease or decel, long press
+      ("GRA_Up_kurz", "GRA_Neu", 0),                # ACC button, increase or accel, short press
+      ("GRA_Down_kurz", "GRA_Neu", 0),              # ACC button, decrease or decel, short press
+      ("GRA_Recall", "GRA_Neu", 0),                 # ACC button, resume
+      ("GRA_Zeitluecke", "GRA_Neu", 0),             # ACC button, time gap adj
+      ("GRA_Neu_Zaehler", "GRA_Neu", 0),            # ACC button, time gap adj
+      ("GRA_Sender", "GRA_Neu", 0),                 # GRA Sender Coding
+    ]
 
-    # FIXME: ignoring ACC signals until we detect its presence and bus location
-    #   signals += [("ACA_V_Wunsch", "ACC_GRA_Anziege", 0)]  # ACC set speed
-    #   checks += [("ACC_GRA_Anziege", 25)]  # From J428 ACC radar control module
+    if CP.transmissionType == TransmissionType.manual:
+      signals += [("GK1_Rueckfahr", "Gate_Komf_1", 0)]  # Reverse light from BCM
+
+    checks = [
+      ("Gate_Komf_1", 10),        # From J533 CAN gateway
+      ("Kombi_1", 50),            # From J285 Instrument cluster
+      ("GRA_Neu", 50),            # From J??? steering wheel control buttons
+    ]
 
     return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.cam)

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -465,12 +465,4 @@ class CarState(CarStateBase):
 
   @staticmethod
   def get_pq_cam_can_parser(CP):
-    # TODO: Need to monitor LKAS camera, if present, for TLC/DLC/warning signals for passthru to SWA
-    signals = []
-    checks = []
-
-    # FIXME: ignoring ACC signals until we detect its presence and bus location
-    #   signals += [("ACA_V_Wunsch", "ACC_GRA_Anziege", 0)]  # ACC set speed
-    #   checks += [("ACC_GRA_Anziege", 25)]  # From J428 ACC radar control module
-
-    return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.cam)
+    return None

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -145,15 +145,10 @@ class CarInterface(CarInterfaceBase):
     # The camera CAN has no signals we use at this time, but we process it
     # anyway so we can test connectivity with can_valid
     self.cp.update_strings(can_strings)
-    if self.cp_cam is not None:
-      self.cp_cam.update_strings(can_strings)
+    self.cp_cam.update_strings(can_strings)
 
     ret = self.CS.update(self.cp, self.cp_cam, self.CP.transmissionType)
-
-    ret.canValid = self.cp.can_valid
-    if self.cp_cam is not None:
-      ret.canValid = ret.canValid and self.cp_cam.can_valid
-
+    ret.canValid = self.cp.can_valid and self.cp_cam.can_valid
     ret.steeringRateLimited = self.CC.steer_rate_limited if self.CC is not None else False
 
     # TODO: add a field for this to carState, car interface code shouldn't write params

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -145,10 +145,15 @@ class CarInterface(CarInterfaceBase):
     # The camera CAN has no signals we use at this time, but we process it
     # anyway so we can test connectivity with can_valid
     self.cp.update_strings(can_strings)
-    self.cp_cam.update_strings(can_strings)
+    if self.cp_cam is not None:
+      self.cp_cam.update_strings(can_strings)
 
     ret = self.CS.update(self.cp, self.cp_cam, self.CP.transmissionType)
-    ret.canValid = self.cp.can_valid and self.cp_cam.can_valid
+
+    ret.canValid = self.cp.can_valid
+    if self.cp_cam is not None:
+      ret.canValid = ret.canValid and self.cp_cam.can_valid
+
     ret.steeringRateLimited = self.CC.steer_rate_limited if self.CC is not None else False
 
     # TODO: add a field for this to carState, car interface code shouldn't write params

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -74,7 +74,7 @@ class CarInterface(CarInterfaceBase):
       # Averages of all 1K/5K/AJ Golf variants
       ret.mass = 1379 + STD_CARGO_KG
       ret.wheelbase = 2.58
-      ret.minSteerSpeed = 50 * CV.MPH_TO_MS  # May be higher/lower depending on model-year
+      ret.minSteerSpeed = 50 * CV.KPH_TO_MS  # May be lower depending on model-year/EPS FW
 
     elif candidate == CAR.GOLF_MK7:
       # Averages of all AU Golf variants
@@ -178,6 +178,8 @@ class CarInterface(CarInterfaceBase):
       events.add(EventName.parkBrake)
     if self.CS.steeringFault:
       events.add(EventName.steerTempUnavailable)
+    if ret.vEgo < self.CP.minSteerSpeed:
+      events.add(car.CarEvent.EventName.belowSteerSpeed)
 
     ret.events = events.to_msg()
     ret.buttonEvents = buttonEvents

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -6,7 +6,8 @@ Ecu = car.CarParams.Ecu
 
 class CarControllerParams:
   HCA_STEP = 2                   # HCA_01 message frequency 50Hz
-  LDW_STEP = 10                  # LDW_02 message frequency 10Hz
+  MQB_LDW_STEP = 10              # LDW_02 message frequency 10Hz on MQB
+  PQ_LDW_STEP = 5                # LDW message frequency 20Hz on PQ35/PQ46/NMS
   GRA_ACC_STEP = 3               # GRA_ACC_01 message frequency 33Hz
 
   GRA_VBP_STEP = 100             # Send ACC virtual button presses once a second
@@ -55,6 +56,7 @@ MQB_LDW_MESSAGES = {
 # FW_VERSIONS for that existing CAR.
 
 class CAR:
+  GOLF_MK6 = "VOLKSWAGEN GOLF 6TH GEN"        # Chassis 1K/5K/AJ, includes Mk6 Golf and variants, or 5th gen with retrofits
   GOLF_MK7 = "VOLKSWAGEN GOLF 7TH GEN"        # Chassis 5G/AU/BA/BE, Mk7 VW Golf and variants
   JETTA_MK7 = "VOLKSWAGEN JETTA 7TH GEN"      # Chassis BU, Mk7 Jetta
   PASSAT_MK8 = "VOLKSWAGEN PASSAT 8TH GEN"    # Chassis 3G, Mk8 Passat and variants
@@ -65,7 +67,14 @@ class CAR:
   SKODA_SCALA_MK1 = "SKODA SCALA 1ST GEN"     # Chassis NW, Mk1 Skoda Scala and Skoda Kamiq
   SKODA_SUPERB_MK3 = "SKODA SUPERB 3RD GEN"   # Chassis 3V/NP, Mk3 Skoda Superb and variants
 
+# All PQ35/PQ46/NMS platform CARs should be on this list
+
+PQ_CARS = [CAR.GOLF_MK6]
+
 FINGERPRINTS = {
+  CAR.GOLF_MK6: [{
+    80: 4, 194: 8, 208: 6, 416: 8, 640: 8, 644: 6, 648: 8, 672: 8, 800: 8, 896: 8, 906: 4, 912: 8, 914: 8, 919: 8, 928: 8, 976: 6, 978: 7, 1056: 8, 1152: 8, 1160: 8, 1164: 8, 1184: 8, 1192: 8, 1306: 8, 1312: 8, 1344: 8, 1360: 8, 1386: 8, 1392: 5, 1394: 1, 1408: 8, 1416: 8, 1420: 8, 1423: 8, 1440: 8, 1488: 8, 1490: 8, 1500: 8, 1504: 8, 1654: 2, 1824: 7, 1827: 7, 2000: 8
+  }],
   CAR.GOLF_MK7: [{
     64: 8, 134: 8, 159: 8, 173: 8, 178: 8, 253: 8, 257: 8, 260: 8, 262: 8, 264: 8, 278: 8, 279: 8, 283: 8, 286: 8, 288: 8, 289: 8, 290: 8, 294: 8, 299: 8, 302: 8, 346: 8, 385: 8, 418: 8, 427: 8, 668: 8, 679: 8, 681: 8, 695: 8, 779: 8, 780: 8, 783: 8, 792: 8, 795: 8, 804: 8, 806: 8, 807: 8, 808: 8, 809: 8, 870: 8, 896: 8, 897: 8, 898: 8, 901: 8, 917: 8, 919: 8, 927: 8, 949: 8, 958: 8, 960: 4, 981: 8, 987: 8, 988: 8, 991: 8, 997: 8, 1000: 8, 1019: 8, 1120: 8, 1122: 8, 1123: 8, 1124: 8, 1153: 8, 1162: 8, 1175: 8, 1312: 8, 1385: 8, 1413: 8, 1440: 5, 1514: 8, 1515: 8, 1520: 8, 1529: 8, 1600: 8, 1601: 8, 1603: 8, 1605: 8, 1624: 8, 1626: 8, 1629: 8, 1631: 8, 1646: 8, 1648: 8, 1712: 6, 1714: 8, 1716: 8, 1717: 8, 1719: 8, 1720: 8, 1721: 8
   }],
@@ -378,6 +387,7 @@ FW_VERSIONS = {
 }
 
 DBC = {
+  CAR.GOLF_MK6: dbc_dict('vw_golf_mk4', None),
   CAR.GOLF_MK7: dbc_dict('vw_mqb_2010', None),
   CAR.JETTA_MK7: dbc_dict('vw_mqb_2010', None),
   CAR.PASSAT_MK8: dbc_dict('vw_mqb_2010', None),

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -53,3 +53,46 @@ def create_mqb_acc_buttons_control(packer, bus, buttonStatesToSend, CS, idx):
     "GRA_ButtonTypeInfo": CS.graButtonTypeInfo
   }
   return packer.make_can_msg("GRA_ACC_01", bus, values, idx)
+
+def create_pq_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
+  values = {
+    "HCA_Zaehler": idx,
+    "LM_Offset": abs(apply_steer),
+    "LM_OffSign": 1 if apply_steer < 0 else 0,
+    "HCA_Status": 5 if (lkas_enabled and apply_steer != 0) else 3,
+    "Vib_Freq": 16,
+  }
+
+  dat = packer.make_can_msg("HCA_1", bus, values)[2]
+  values["HCA_Checksumme"] = dat[1] ^ dat[2] ^ dat[3] ^ dat[4]
+  return packer.make_can_msg("HCA_1", bus, values)
+
+def create_pq_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
+                          ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc):
+  if hca_enabled:
+    left_lane_hud = 3 if left_lane_visible else 1
+    right_lane_hud = 3 if right_lane_visible else 1
+  else:
+    left_lane_hud = 2 if left_lane_visible else 1
+    right_lane_hud = 2 if right_lane_visible else 1
+
+  values = {
+    "Right_Lane_Status": right_lane_hud,
+    "Left_Lane_Status": left_lane_hud,
+    "SET_ME_X1": 1,
+    "Kombi_Lamp_Orange": 1 if hca_enabled and steering_pressed else 0,
+    "Kombi_Lamp_Green": 1 if hca_enabled and not steering_pressed else 0,
+  }
+  return packer.make_can_msg("LDW_1", bus, values)
+
+def create_pq_acc_buttons_control(packer, bus, buttonStatesToSend, CS, idx):
+  values = {
+    "GRA_Neu_Zaehler": idx,
+    "GRA_Sender": CS.graSenderCoding,
+    "GRA_Abbrechen": 1 if (buttonStatesToSend["cancel"] or CS.buttonStates["cancel"]) else 0,
+    "GRA_Hauptschalt": CS.graHauptschalter,
+  }
+
+  dat = packer.make_can_msg("GRA_Neu", bus, values)[2]
+  values["GRA_Checksum"] = dat[1] ^ dat[2] ^ dat[3]
+  return packer.make_can_msg("GRA_Neu", bus, values)

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -68,13 +68,14 @@ def create_pq_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
   return packer.make_can_msg("HCA_1", bus, values)
 
 def create_pq_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
-                          ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc):
+                          ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
+                          standstill, left_lane_depart, right_lane_depart):
   if hca_enabled:
-    left_lane_hud = 3 if left_lane_visible else 1
-    right_lane_hud = 3 if right_lane_visible else 1
+    left_lane_hud = 3 if left_lane_depart else 1 + left_lane_visible
+    right_lane_hud = 3 if right_lane_depart else 1 + right_lane_visible
   else:
-    left_lane_hud = 2 if left_lane_visible else 1
-    right_lane_hud = 2 if right_lane_visible else 1
+    left_lane_hud = 0
+    right_lane_hud = 0
 
   values = {
     "Right_Lane_Status": right_lane_hud,

--- a/selfdrive/test/test_routes.py
+++ b/selfdrive/test/test_routes.py
@@ -403,6 +403,10 @@ routes: dict = {
     'enableCamera': True,
     'enableDsu': False,
   },
+  "132ebef7693c6c4b|2021-04-12--19-22-03": {
+    'carFingerprint': VOLKSWAGEN.GOLF_MK6,
+    'enableCamera': True,
+  },
   "cae14e88932eb364|2021-03-26--14-43-28": {
     'carFingerprint': VOLKSWAGEN.GOLF_MK7,
     'enableCamera': True,


### PR DESCRIPTION
Not sure if this will be upstreamed yet. For internal testing only.

Known bugs:
- [ ] No warning for the 6 minute steering lockout
- [x] No warning for no steering below minimum steer speed
- [ ] Disengage on gas only sometimes works


Our hardware currently intercepts the powertrain, requiring moving some signals to the `cam` parser. Once we start using the official J533 harness this will be reverted, and all signals will be send/received from bus 1 (instead of 0 and 2).