### PR TITLE
VW lane lines visual indicator changes

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,4 +1,5 @@
 from cereal import car
+from common.params import Params
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.volkswagen import volkswagencan
 from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
@@ -18,9 +19,11 @@ class CarController():
     self.graMsgStartFramePrev = 0
     self.graMsgBusCounterPrev = 0
 
+    self.use_lanelines = Params().get('EndToEndToggle') != b'1'
+
     self.steer_rate_limited = False
 
-  def update(self, enabled, CS, frame, actuators, visual_alert, left_lane_visible, right_lane_visible):
+  def update(self, enabled, CS, frame, actuators, visual_alert, left_lane_visible, right_lane_visible, left_lane_depart, right_lane_depart):
     """ Controls thread """
 
     P = CarControllerParams
@@ -110,18 +113,20 @@ class CarController():
     # filters LDW_02 from the factory camera and OP emits LDW_02 at 10Hz.
 
     if frame % P.LDW_STEP == 0:
-      hcaEnabled = True if enabled and not CS.out.standstill else False
-
       if visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired:
         hud_alert = MQB_LDW_MESSAGES["laneAssistTakeOverSilent"]
       else:
         hud_alert = MQB_LDW_MESSAGES["none"]
 
-      can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, hcaEnabled,
+      left_lane_visible = (left_lane_visible and not CS.out.standstill) if self.use_lanelines else True
+      right_lane_visible = (right_lane_visible and not CS.out.standstill) if self.use_lanelines else True
+
+      can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, enabled,
                                                             CS.out.steeringPressed, hud_alert, left_lane_visible,
                                                             right_lane_visible, CS.ldw_lane_warning_left,
                                                             CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
-                                                            CS.ldw_dlc, CS.ldw_tlc))
+                                                            CS.ldw_dlc, CS.ldw_tlc,
+                                                            left_lane_depart, right_lane_depart))
 
     #--------------------------------------------------------------------------
     #                                                                         #

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,5 +1,4 @@
 from cereal import car
-from common.params import Params
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.volkswagen import volkswagencan
 from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
@@ -18,8 +17,6 @@ class CarController():
     self.graMsgSentCount = 0
     self.graMsgStartFramePrev = 0
     self.graMsgBusCounterPrev = 0
-
-    self.use_lanelines = Params().get('EndToEndToggle') != b'1'
 
     self.steer_rate_limited = False
 
@@ -118,14 +115,12 @@ class CarController():
       else:
         hud_alert = MQB_LDW_MESSAGES["none"]
 
-      left_lane_visible = (left_lane_visible and not CS.out.standstill) if self.use_lanelines else True
-      right_lane_visible = (right_lane_visible and not CS.out.standstill) if self.use_lanelines else True
 
       can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, enabled,
                                                             CS.out.steeringPressed, hud_alert, left_lane_visible,
                                                             right_lane_visible, CS.ldw_lane_warning_left,
                                                             CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
-                                                            CS.ldw_dlc, CS.ldw_tlc,
+                                                            CS.ldw_dlc, CS.ldw_tlc, CS.out.standstill,
                                                             left_lane_depart, right_lane_depart))
 
     #--------------------------------------------------------------------------

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -168,6 +168,8 @@ class CarInterface(CarInterfaceBase):
     can_sends = self.CC.update(c.enabled, self.CS, self.frame, c.actuators,
                    c.hudControl.visualAlert,
                    c.hudControl.leftLaneVisible,
-                   c.hudControl.rightLaneVisible)
+                   c.hudControl.rightLaneVisible,
+                   c.hudControl.leftLaneDepart,
+                   c.hudControl.rightLaneDepart)
     self.frame += 1
     return can_sends

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -15,18 +15,22 @@ def create_mqb_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
   }
   return packer.make_can_msg("HCA_01", bus, values, idx)
 
-def create_mqb_hud_control(packer, bus, hca_enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
-                           ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc):
-  if hca_enabled:
-    left_lane_hud = 3 if left_lane_visible else 1
-    right_lane_hud = 3 if right_lane_visible else 1
-  else:
+def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
+                           ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
+                           left_lane_depart, right_lane_depart):
+  if enabled:
     left_lane_hud = 2 if left_lane_visible else 1
     right_lane_hud = 2 if right_lane_visible else 1
+  else:
+    left_lane_hud = 0
+    right_lane_hud = 0
+
+  left_lane_hud = 3 if left_lane_depart else left_lane_hud
+  right_lane_hud = 3 if right_lane_depart else right_lane_hud
 
   values = {
-    "LDW_Status_LED_gelb": 1 if hca_enabled and steering_pressed else 0,
-    "LDW_Status_LED_gruen": 1 if hca_enabled and not steering_pressed else 0,
+    "LDW_Status_LED_gelb": 1 if enabled and steering_pressed else 0,
+    "LDW_Status_LED_gruen": 1 if enabled and not steering_pressed else 0,
     "LDW_Lernmodus_links": left_lane_hud,
     "LDW_Lernmodus_rechts": right_lane_hud,
     "LDW_Texte": hud_alert,

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -24,12 +24,6 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
   # 2 (LKAS enabled, lane detected) - light gray on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpit on a 2018 A3 e-Tron its green. 
   # 3 (LKAS enabled, lane departure detected) - white on VW, red on Audi 
 
-  # not using standstill state right now, though we may want to do something with this if there's too much jitter at a stop to just freeze lane visibility.
-
-  # since the LDW_Status_LED already indicates whether OP is enabled or not, we can always show the lane visibility.
-  # this does differ from stock where it would always be 0 if LKAS is disabled, but this should be less distracting and users should use the status LED as a visual indicator of OP enabled ment state instead of the absence or presence of lane lines.
-  # as OP will notify users of LDW regardless of enablement state, this should provide the best user experience and users shouldn't go from 0/1 directly to 3.
-
   values = {
     "LDW_Status_LED_gelb": 1 if enabled and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if enabled and not steering_pressed else 0,

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -17,13 +17,13 @@ def create_mqb_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
 
 def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
                            ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
-                           left_lane_depart, right_lane_depart):
+                           standstill, left_lane_depart, right_lane_depart):
   if enabled:
-    left_lane_hud = 2 if left_lane_visible else 1
-    right_lane_hud = 2 if right_lane_visible else 1
+    left_lane_hud = 3 if left_lane_visible and not standstill else 2
+    right_lane_hud = 3 if right_lane_visible and not standstill else 2
   else:
-    left_lane_hud = 0
-    right_lane_hud = 0
+    left_lane_hud = 1
+    right_lane_hud = 1
 
   left_lane_hud = 3 if left_lane_depart else left_lane_hud
   right_lane_hud = 3 if right_lane_depart else right_lane_hud

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -24,22 +24,17 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
   # 2 (LKAS enabled, lane detected) - green on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpict on a 2018 A3 e-Tron its green. 
   # 3 (LKAS enabled, lane departure detected) - green with arrow on VW, red on Audi 
 
-  # not using standstill right now
+  # not using standstill state right now, though we may want to do something with this if there's too much jitter at a stop to just freeze lane visibility.
 
   # since the LDW_Status_LED already indicates whether OP is enabled or not, we can always show the lane visibility.
   # this does differ from stock where it would always be 0 if LKAS is disabled, but this should be less distracting and users should use the status LED as a visual indicator of OP enabled ment state instead of the absence or presence of lane lines.
   # as OP will notify users of LDW regardless of enablement state, this should provide the best user experience and users shouldn't go from 0/1 directly to 3.
-  left_lane_hud = 2 if left_lane_visible else 1
-  right_lane_hud = 2 if right_lane_visible else 1
-
-  left_lane_hud = 3 if left_lane_depart else left_lane_hud
-  right_lane_hud = 3 if right_lane_depart else right_lane_hud
 
   values = {
     "LDW_Status_LED_gelb": 1 if enabled and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if enabled and not steering_pressed else 0,
-    "LDW_Lernmodus_links": left_lane_hud,
-    "LDW_Lernmodus_rechts": right_lane_hud,
+    "LDW_Lernmodus_links": 3 if left_lane_depart else 1 + left_lane_visible,
+    "LDW_Lernmodus_rechts": 3 if right_lane_depart else 1 + right_lane_visible,
     "LDW_Texte": hud_alert,
     "LDW_SW_Warnung_links": ldw_lane_warning_left,
     "LDW_SW_Warnung_rechts": ldw_lane_warning_right,

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -18,10 +18,19 @@ def create_mqb_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
 def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
                            ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
                            standstill, left_lane_depart, right_lane_depart):
+  # Lane color reference:
+  # 0 - nothing (LKAS disabled)
+  # 1 - gray (LKAS enabled, no lane line detected)
+  # 2 - green on VW, green or white on Audi depedning on year or virtual cockpit (LKAS enabled, lane detected)
+  # 3 - green with arrow on VW, red on Audi (LKAS enabled, lane departure detected)
+
+  # not using standstill right now
+
   if enabled:
-    left_lane_hud = 3 if left_lane_visible and not standstill else 2
-    right_lane_hud = 3 if right_lane_visible and not standstill else 2
+    left_lane_hud = 2 if left_lane_visible else 1
+    right_lane_hud = 2 if right_lane_visible else 1
   else:
+    # On stock, this would be 0, but on stock you'd never go from 0 to 3.  Currently OP will still detect lane departures so always be at least 1.
     left_lane_hud = 1
     right_lane_hud = 1
 

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -26,9 +26,9 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
 
   # not using standstill right now
 
-
   # since the LDW_Status_LED already indicates whether OP is enabled or not, we can always show the lane visibility.
   # this does differ from stock where it would always be 0 if LKAS is disabled, but this should be less distracting and users should use the status LED as a visual indicator of OP enabled ment state instead of the absence or presence of lane lines.
+  # as OP will notify users of LDW regardless of enablement state, this should provide the best user experience and users shouldn't go from 0/1 directly to 3.
   left_lane_hud = 2 if left_lane_visible else 1
   right_lane_hud = 2 if right_lane_visible else 1
 

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -19,10 +19,10 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
                            ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
                            standstill, left_lane_depart, right_lane_depart):
   # Lane color reference:
-  # 0 (LKAS disabled) - nothing 
-  # 1 (LKAS enabled, no lane detected) - gray 
-  # 2 (LKAS enabled, lane detected) - green on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpit on a 2018 A3 e-Tron its green. 
-  # 3 (LKAS enabled, lane departure detected) - green with arrow on VW, red on Audi 
+  # 0 (LKAS disabled) - off 
+  # 1 (LKAS enabled, no lane detected) - dark gray 
+  # 2 (LKAS enabled, lane detected) - light gray on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpit on a 2018 A3 e-Tron its green. 
+  # 3 (LKAS enabled, lane departure detected) - white on VW, red on Audi 
 
   # not using standstill state right now, though we may want to do something with this if there's too much jitter at a stop to just freeze lane visibility.
 

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -21,7 +21,7 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
   # Lane color reference:
   # 0 (LKAS disabled) - nothing 
   # 1 (LKAS enabled, no lane detected) - gray 
-  # 2 (LKAS enabled, lane detected) - green on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpict on a 2018 A3 e-Tron its green. 
+  # 2 (LKAS enabled, lane detected) - green on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpit on a 2018 A3 e-Tron its green. 
   # 3 (LKAS enabled, lane departure detected) - green with arrow on VW, red on Audi 
 
   # not using standstill state right now, though we may want to do something with this if there's too much jitter at a stop to just freeze lane visibility.

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -26,13 +26,11 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
 
   # not using standstill right now
 
-  if enabled:
-    left_lane_hud = 2 if left_lane_visible else 1
-    right_lane_hud = 2 if right_lane_visible else 1
-  else:
-    # On stock, this would be 0, but on stock you'd never go from 0 to 3.  Currently OP will still detect lane departures so always be at least 1.
-    left_lane_hud = 1
-    right_lane_hud = 1
+
+  # since the LDW_Status_LED already indicates whether OP is enabled or not, we can always show the lane visibility.
+  # this does differ from stock where it would always be 0 if LKAS is disabled, but this should be less distracting and users should use the status LED as a visual indicator of OP enabled ment state instead of the absence or presence of lane lines.
+  left_lane_hud = 2 if left_lane_visible else 1
+  right_lane_hud = 2 if right_lane_visible else 1
 
   left_lane_hud = 3 if left_lane_depart else left_lane_hud
   right_lane_hud = 3 if right_lane_depart else right_lane_hud

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -19,10 +19,10 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
                            ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
                            standstill, left_lane_depart, right_lane_depart):
   # Lane color reference:
-  # 0 - nothing (LKAS disabled)
-  # 1 - gray (LKAS enabled, no lane line detected)
-  # 2 - green on VW, green or white on Audi depedning on year or virtual cockpit (LKAS enabled, lane detected)
-  # 3 - green with arrow on VW, red on Audi (LKAS enabled, lane departure detected)
+  # 0 (LKAS disabled) - nothing 
+  # 1 (LKAS enabled, no lane detected) - gray 
+  # 2 (LKAS enabled, lane detected) - green on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpict on a 2018 A3 e-Tron its green. 
+  # 3 (LKAS enabled, lane departure detected) - green with arrow on VW, red on Audi 
 
   # not using standstill right now
 

--- a/selfdrive/test/test_routes.py
+++ b/selfdrive/test/test_routes.py
@@ -424,7 +424,7 @@ routes = {
     'carFingerprint': VOLKSWAGEN.TIGUAN_MK2,
     'enableCamera': True,
   },
-  "07667b885add75fd|2021-01-23--19-48-42": {
+  "07667b885add75fd|2021-04-13--13-53-11": {
     'carFingerprint': VOLKSWAGEN.AUDI_A3_MK3,
     'enableCamera': True,
   },

--- a/selfdrive/test/test_routes.py
+++ b/selfdrive/test/test_routes.py
@@ -424,7 +424,7 @@ routes = {
     'carFingerprint': VOLKSWAGEN.TIGUAN_MK2,
     'enableCamera': True,
   },
-  "07667b885add75fd|2021-04-13--13-53-11": {
+  "07667b885add75fd|2021-01-23--19-48-42": {
     'carFingerprint': VOLKSWAGEN.AUDI_A3_MK3,
     'enableCamera': True,
   },


### PR DESCRIPTION
**Description** more updates of #20553 to make the car's indicators more in line with stock, especially on audi.  this also keeps visual indicators online regardless of OP enablement state, as we already have the status LED for this function.

**Verification**

**Route**
Route: 07667b885add75fd|2021-04-13--13-53-11

