### PR TITLE
Fuzzy match on ECU FW versions

### DIFF
--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -142,10 +142,18 @@ def match_fw_to_car_fuzzy(fw_versions_dict):
   that were matched uniquely to that specific car. If multiple ECUs uniquely match to different cars
   the match is rejected."""
 
+  # These ECUs are known to be shared between models (EPS only between hybrid/ICE version)
+  # Getting this exactly right isn't crucial, but excluding camera and radar makes it almost
+  # impossible to get 3 matching versions, even if two models with shared parts are released at the same
+  # time and only one is in our database.
+  exclude_types = [Ecu.fwdCamera, Ecu.fwdRadar, Ecu.eps]
+
   # Build lookup table from (addr, subaddr, fw) to list of candidate cars
   all_fw_versions = defaultdict(list)
   for candidate, fw_by_addr in FW_VERSIONS.items():
     for addr, fws in fw_by_addr.items():
+      if addr[0] in exclude_types:
+        continue
       for f in fws:
         all_fw_versions[(addr[1], addr[2], f)].append(candidate)
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -146,7 +146,7 @@ def build_fw_dict(fw_versions):
   return fw_versions_dict
 
 
-def match_fw_to_car_fuzzy(fw_versions_dict):
+def match_fw_to_car_fuzzy(fw_versions_dict, log=True, exclude=None):
   """Do a fuzzy FW match. This function will return a match, and the number of firmware version
   that were matched uniquely to that specific car. If multiple ECUs uniquely match to different cars
   the match is rejected."""
@@ -160,6 +160,9 @@ def match_fw_to_car_fuzzy(fw_versions_dict):
   # Build lookup table from (addr, subaddr, fw) to list of candidate cars
   all_fw_versions = defaultdict(list)
   for candidate, fw_by_addr in FW_VERSIONS.items():
+    if candidate == exclude:
+      continue
+
     for addr, fws in fw_by_addr.items():
       if addr[0] in exclude_types:
         continue
@@ -180,8 +183,9 @@ def match_fw_to_car_fuzzy(fw_versions_dict):
       elif candidate != candidates[0]:
         return set()
 
-  if match_count >= 3:
-    cloudlog.error(f"Fingerprinted {candidate} using fuzzy match. {match_count} matching ECUs")
+  if match_count >= 2:
+    if log:
+      cloudlog.error(f"Fingerprinted {candidate} using fuzzy match. {match_count} matching ECUs")
     return set([candidate])
   else:
     return set()

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -137,7 +137,7 @@ def chunks(l, n=128):
     yield l[i:i + n]
 
 
-def match_fw_to_car_fuzzy(fw_versions):
+def match_fw_to_car_fuzzy(fw_versions_dict):
   """Do a fuzzy FW match. This function will return a match, and the number of firmware version
   that were matched uniquely to that specific car. If multiple ECUs uniquely match to different cars
   the match is rejected."""
@@ -149,15 +149,8 @@ def match_fw_to_car_fuzzy(fw_versions):
       for f in fws:
         all_fw_versions[(addr[1], addr[2], f)].append(candidate)
 
-  fw_versions_dict = {}
-  for fw in fw_versions:
-    addr = fw.address
-    sub_addr = fw.subAddress if fw.subAddress != 0 else None
-    fw_versions_dict[(addr, sub_addr)] = fw.fwVersion
-
   match_count = 0
   candidate = None
-
   for addr, version in fw_versions_dict.items():
     # All cars that have this FW response on the specified address
     candidates = all_fw_versions[(addr[0], addr[1], version)]
@@ -207,7 +200,7 @@ def match_fw_to_car(fw_versions, allow_fuzzy=True):
   matches = set(candidates.keys()) - set(invalid)
 
   if allow_fuzzy and len(matches) == 0:
-    match_count, candidate = match_fw_to_car_fuzzy(fw_versions)
+    match_count, candidate = match_fw_to_car_fuzzy(fw_versions_dict)
     if candidate is not None and match_count >= 3:
       cloudlog.error(f"Fingerprinted {candidate} using fuzzy match. {match_count} matching ECUs")
       matches = set([candidate])

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -178,9 +178,13 @@ def match_fw_to_car_fuzzy(fw_versions_dict):
         candidate = candidates[0]
       # We uniquely matched two different cars. No fuzzy match possible
       elif candidate != candidates[0]:
-        return 0, None
+        return set()
 
-  return match_count, candidate
+  if match_count >= 3:
+    cloudlog.error(f"Fingerprinted {candidate} using fuzzy match. {match_count} matching ECUs")
+    return set([candidate])
+  else:
+    return set()
 
 
 def match_fw_to_car_exact(fw_versions_dict):
@@ -221,10 +225,10 @@ def match_fw_to_car(fw_versions, allow_fuzzy=True):
 
   exact_match = True
   if allow_fuzzy and len(matches) == 0:
-    match_count, candidate = match_fw_to_car_fuzzy(fw_versions_dict)
-    if candidate is not None and match_count >= 3:
-      cloudlog.error(f"Fingerprinted {candidate} using fuzzy match. {match_count} matching ECUs")
-      matches = set([candidate])
+    matches = match_fw_to_car_fuzzy(fw_versions_dict)
+
+    # Fuzzy match found
+    if len(matches) == 1:
       exact_match = False
 
   return exact_match, matches

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -177,6 +177,7 @@ def match_fw_to_car_fuzzy(fw_versions_dict):
 def match_fw_to_car(fw_versions, allow_fuzzy=True):
   candidates = FW_VERSIONS
   invalid = []
+  exact_match = True
 
   fw_versions_dict = {}
   for fw in fw_versions:
@@ -212,8 +213,10 @@ def match_fw_to_car(fw_versions, allow_fuzzy=True):
     if candidate is not None and match_count >= 3:
       cloudlog.error(f"Fingerprinted {candidate} using fuzzy match. {match_count} matching ECUs")
       matches = set([candidate])
+      exact_match = False
 
-  return matches
+  return exact_match, matches
+
 
 def get_fw_versions(logcan, sendcan, bus, extra=None, timeout=0.1, debug=False, progress=False):
   ecu_types = {}
@@ -309,7 +312,7 @@ if __name__ == "__main__":
 
   t = time.time()
   fw_vers = get_fw_versions(logcan, sendcan, 1, extra=extra, debug=args.debug, progress=True)
-  candidates = match_fw_to_car(fw_vers)
+  _, candidates = match_fw_to_car(fw_vers)
 
   print()
   print("Found FW versions")

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -28,7 +28,8 @@ class TestFwFingerprint(unittest.TestCase):
         fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions),
                    "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
       CP.carFw = fw
-      self.assertFingerprints(match_fw_to_car(CP.carFw), car_model)
+      _, matches = match_fw_to_car(CP.carFw)
+      self.assertFingerprints(matches, car_model)
 
   def test_no_duplicate_fw_versions(self):
     passed = True

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -88,7 +88,8 @@ class Controls:
 
     # If stock camera is disconnected, we loaded car controls and it's not dashcam mode
     controller_available = self.CP.enableCamera and self.CI.CC is not None and not passive and not self.CP.dashcamOnly
-    community_feature_disallowed = self.CP.communityFeature and not community_feature_toggle
+    community_feature = self.CP.communityFeature or fuzzy_fingerprint
+    community_feature_disallowed = community_feature and (not community_feature_toggle)
     self.read_only = not car_recognized or not controller_available or \
                        self.CP.dashcamOnly or community_feature_disallowed
     if self.read_only:

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -84,6 +84,8 @@ class Controls:
     sounds_available = HARDWARE.get_sound_card_online()
 
     car_recognized = self.CP.carName != 'mock'
+    fuzzy_fingerprint = self.CP.fuzzyFingerprint
+
     # If stock camera is disconnected, we loaded car controls and it's not dashcam mode
     controller_available = self.CP.enableCamera and self.CI.CC is not None and not passive and not self.CP.dashcamOnly
     community_feature_disallowed = self.CP.communityFeature and not community_feature_toggle
@@ -137,7 +139,7 @@ class Controls:
     self.sm['driverMonitoringState'].faceDetected = False
     self.sm['liveParameters'].valid = True
 
-    self.startup_event = get_startup_event(car_recognized, controller_available)
+    self.startup_event = get_startup_event(car_recognized, controller_available, fuzzy_fingerprint)
 
     if not sounds_available:
       self.events.add(EventName.soundsUnavailable, static=True)

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -211,7 +211,7 @@ def wrong_car_mode_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: boo
 def startup_fuzzy_fingerprint_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: bool) -> Alert:
   return Alert(
     "WARNING: No exact match on car model",
-    f"Closest match: {CP.carFingerprint}",
+    f"Closest match: {CP.carFingerprint.title()}",
     AlertStatus.userPrompt, AlertSize.mid,
     Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0., 0., 15.)
 

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -208,6 +208,13 @@ def wrong_car_mode_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: boo
     text = "Main Switch Off"
   return NoEntryAlert(text, duration_hud_alert=0.)
 
+def startup_fuzzy_fingerprint_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: bool) -> Alert:
+  return Alert(
+    "WARNING: No exact match on car model",
+    f"Closest match: {CP.carFingerprint}",
+    AlertStatus.userPrompt, AlertSize.mid,
+    Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0., 0., 15.)
+
 EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, bool], Alert]]]] = {
   # ********** events with no alerts **********
 
@@ -251,6 +258,10 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
       "Always keep hands on wheel and eyes on road",
       AlertStatus.normal, AlertSize.mid,
       Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0., 0., 15.),
+  },
+
+  EventName.startupFuzzyFingerprint: {
+    ET.PERMANENT: startup_fuzzy_fingerprint_alert,
   },
 
   EventName.dashcamMode: {

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -210,8 +210,8 @@ def wrong_car_mode_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: boo
 
 def startup_fuzzy_fingerprint_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: bool) -> Alert:
   return Alert(
-    "WARNING: No exact match on car model",
-    f"Closest match: {CP.carFingerprint.title()}",
+    "WARNING: No Exact Match on Car Model",
+    f"Closest Match: {CP.carFingerprint.title()[:40]}",
     AlertStatus.userPrompt, AlertSize.mid,
     Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0., 0., 15.)
 

--- a/selfdrive/debug/internal/fuzz_fw_fingerprint.py
+++ b/selfdrive/debug/internal/fuzz_fw_fingerprint.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# type: ignore
+import random
+from collections import defaultdict
+
+from tqdm import tqdm
+
+from selfdrive.car.fw_versions import match_fw_to_car_fuzzy
+from selfdrive.car.toyota.values import FW_VERSIONS as TOYOTA_FW_VERSIONS
+from selfdrive.car.honda.values import FW_VERSIONS as HONDA_FW_VERSIONS
+from selfdrive.car.hyundai.values import FW_VERSIONS as HYUNDAI_FW_VERSIONS
+from selfdrive.car.volkswagen.values import FW_VERSIONS as VW_FW_VERSIONS
+
+
+FWS = {}
+FWS.update(TOYOTA_FW_VERSIONS)
+FWS.update(HONDA_FW_VERSIONS)
+FWS.update(HYUNDAI_FW_VERSIONS)
+FWS.update(VW_FW_VERSIONS)
+
+if __name__ == "__main__":
+  total = 0
+  match = 0
+  wrong_match = 0
+  confusions = defaultdict(set)
+
+  for _ in tqdm(range(1000)):
+    for candidate, fws in FWS.items():
+      fw_dict = {}
+      for (tp, addr, subaddr), fw_list in fws.items():
+        fw_dict[(addr, subaddr)] = random.choice(fw_list)
+
+      matches = match_fw_to_car_fuzzy(fw_dict, log=False, exclude=candidate)
+
+      total += 1
+      if len(matches) == 1:
+        if list(matches)[0] == candidate:
+          match += 1
+        else:
+          confusions[candidate] |= matches
+          wrong_match += 1
+
+  print()
+  for candidate, wrong_matches in sorted(confusions.items()):
+    print(candidate, wrong_matches)
+
+  print()
+  print(f"Total fuzz cases: {total}")
+  print(f"Correct matches:  {match}")
+  print(f"Wrong matches:    {wrong_match}")
+
+

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -19,6 +19,7 @@ from selfdrive.car.hyundai.values import FINGERPRINTS as HYUNDAI_FINGERPRINTS
 from selfdrive.car.volkswagen.values import FINGERPRINTS as VW_FINGERPRINTS
 
 SUPPORTED_CARS = list(TOYOTA_FINGERPRINTS.keys()) + list(HONDA_FINGERPRINTS.keys()) + list(HYUNDAI_FINGERPRINTS.keys())+ list(VW_FINGERPRINTS.keys())
+FUZZY = 'FUZZY' in os.environ
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Run FW fingerprint on Qlog of route or list of routes')
@@ -50,7 +51,7 @@ if __name__ == "__main__":
 
       for msg in lr:
         if msg.which() == "pandaState":
-          if msg.pandaState.pandaType not in ['uno', 'blackPanda']:
+          if msg.pandaState.pandaType not in ['uno', 'blackPanda', 'dos']:
             dongles.append(dongle_id)
             break
 
@@ -70,7 +71,7 @@ if __name__ == "__main__":
           if live_fingerprint not in SUPPORTED_CARS:
             break
 
-          candidates = match_fw_to_car(car_fw)
+          candidates = match_fw_to_car(car_fw, allow_fuzzy=FUZZY)
           if (len(candidates) == 1) and (list(candidates)[0] == live_fingerprint):
             good += 1
             print("Correct", live_fingerprint, dongle_id)

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -47,6 +47,9 @@ if __name__ == "__main__":
     route = route.rstrip()
     dongle_id, time = route.split('|')
 
+    if dongle_id in dongles:
+      continue
+
     if NO_API:
       qlog_path = f"cd:/{dongle_id}/{time}/0/qlog.bz2"
     else:
@@ -56,16 +59,13 @@ if __name__ == "__main__":
     if qlog_path is None:
       continue
 
-    if dongle_id in dongles:
-      continue
-
     try:
       lr = LogReader(qlog_path)
+      dongles.append(dongle_id)
 
       for msg in lr:
         if msg.which() == "pandaState":
           if msg.pandaState.pandaType not in ['uno', 'blackPanda', 'dos']:
-            dongles.append(dongle_id)
             break
 
         elif msg.which() == "carParams":
@@ -75,7 +75,6 @@ if __name__ == "__main__":
           if len(car_fw) == 0:
             break
 
-          dongles.append(dongle_id)
           live_fingerprint = msg.carParams.carFingerprint
 
           if args.car is not None:

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
 
   print()
   # Print FW versions that need to be added seperated out by car and address
-  for car, m in mismatches.items():
+  for car, m in sorted(mismatches.items()):
     print(car)
     addrs = defaultdict(list)
     for (addr, sub_addr, version) in m:

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
           if live_fingerprint not in SUPPORTED_CARS:
             break
 
-          candidates = match_fw_to_car(car_fw, allow_fuzzy=FUZZY)
+          _, candidates = match_fw_to_car(car_fw, allow_fuzzy=FUZZY)
           if (len(candidates) == 1) and (list(candidates)[0] == live_fingerprint):
             good += 1
             print("Correct", live_fingerprint, dongle_id)


### PR DESCRIPTION
TODO:
- [x] Add startup alert for fuzzy matched car
- [x] Add to test_startup.py
- [x] Write test to remove a certain car model from the database and then make sure it does't fingerprint as a different car
- [x] Write test to try fuzzy match on routes and make sure it matches the correct car or doesn't return a match


Wrote two tests to check the impact of the number of required ECU matches on results. For each candidate car I can choose a random selection of firmware versions, pretend this car doesn't exist in the database (completely remove the whole model) and then make sure it doesn't fingerprint as a different car. This is supposed to simulate a worst case situation where a new unknown to us car is released. 

I also went through a subset of random 0.8.3 routes and looked for cars that didn't fingerprint using FW version (but did using fingerprint 1.0), and checked how many of them would match using the fuzzy match. This shows the tradeoff in false positives vs false negatives when increasing the number of required matches.

`match_count >= 1`
```
AUDI A3 3RD GEN {'VOLKSWAGEN GOLF 7TH GEN'}
HONDA ACCORD 2018 HYBRID TOURING {'HONDA INSIGHT 2019 TOURING'}
HONDA ACCORD 2018 LX 1.5T {'HONDA ACCORD 2018 SPORT 2T', 'HONDA ACCORD 2018 HYBRID TOURING'}
HONDA ACCORD 2018 SPORT 2T {'HONDA ACCORD 2018 LX 1.5T'}
HONDA INSIGHT 2019 TOURING {'HONDA ACCORD 2018 HYBRID TOURING'}
TOYOTA C-HR 2018 {'TOYOTA C-HR HYBRID 2018'}
TOYOTA C-HR HYBRID 2018 {'TOYOTA C-HR 2018'}
TOYOTA CAMRY 2018 {'TOYOTA CAMRY HYBRID 2018'}
TOYOTA CAMRY HYBRID 2018 {'TOYOTA CAMRY 2018'}
TOYOTA COROLLA 2017 {'TOYOTA COROLLA TSS2 2019'}
TOYOTA COROLLA HYBRID TSS2 2019 {'TOYOTA RAV4 HYBRID 2019'}
TOYOTA COROLLA TSS2 2019 {'TOYOTA COROLLA 2017'}
TOYOTA RAV4 HYBRID 2019 {'TOYOTA COROLLA HYBRID TSS2 2019'}
VOLKSWAGEN GOLF 7TH GEN {'AUDI A3 3RD GEN'}
```
```
Number of dongle ids checked: 1492
Fingerprinted:                1060
Not fingerprinted:            166
  of which had a fuzzy match: 128

Correct fuzzy matches:        1050
Wrong fuzzy matches:          0
```

`match_count >= 2`
```
HONDA ACCORD 2018 LX 1.5T {'HONDA ACCORD 2018 SPORT 2T'}
HONDA ACCORD 2018 SPORT 2T {'HONDA ACCORD 2018 LX 1.5T'}
```

```
Number of dongle ids checked: 1492
Fingerprinted:                1060
Not fingerprinted:            166
  of which had a fuzzy match: 82

Correct fuzzy matches:        1040
Wrong fuzzy matches:          0
```

`match_count >= 3`
```
HONDA ACCORD 2018 LX 1.5T {'HONDA ACCORD 2018 SPORT 2T'}
HONDA ACCORD 2018 SPORT 2T {'HONDA ACCORD 2018 LX 1.5T'}
```

```
Number of dongle ids checked: 1492
Fingerprinted:                1060
Not fingerprinted:            166
  of which had a fuzzy match: 47

Correct fuzzy matches:        538
Wrong fuzzy matches:          0
```

`match_count >= 4`
```
HONDA ACCORD 2018 LX 1.5T {'HONDA ACCORD 2018 SPORT 2T'}
HONDA ACCORD 2018 SPORT 2T {'HONDA ACCORD 2018 LX 1.5T'}
```

```
Number of dongle ids checked: 1492
Fingerprinted:                1060
Not fingerprinted:            166
  of which had a fuzzy match: 32

Correct fuzzy matches:        248
Wrong fuzzy matches:          0
```

The Accord 1.5/Accord 2.0T seem to generate false positives in all cases. I think these two cars should have been combined since they only differ in their gearbox (CVT vs 10 speed auto). For this analysis I won't put as much weight on confusion between these cars. Also they only generate false positive in this hypothetical situation were one of them is removed from the database. In practice the algorithm sees the overlap between the cars and prevents a fingerprint as either of them.

Given the sharp dropoff at `match_count >= 3`, I'll be choosing a 2 as minimum number of matches. This has a reasonable rate of recognizing cars, with (except for the Accord) no false positives in a worst-case scenario or in real-world data.