### PR TITLE
fix mac setup script for zsh

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -53,7 +53,8 @@ if [ -z "$OPENPILOT_ENV" ] && [ -n "$RC_FILE" ] && [ -z "$CI" ]; then
   OP_DIR=$(git rev-parse --show-toplevel)
   echo "export PATH=\"\$PATH:$HOME/.cargo/bin\"" >> $RC_FILE
   echo "source $OP_DIR/tools/openpilot_env.sh" >> $RC_FILE
-  source $RC_FILE
+  export PATH="$PATH:\"\$HOME/.cargo/bin\""
+  source "$OP_DIR/tools/openpilot_env.sh"
   echo "Added openpilot_env to RC file: $RC_FILE"
 fi
 
@@ -64,3 +65,8 @@ eval "$(pyenv init -)"
 
 pip install pipenv==2020.8.13
 pipenv install --system --deploy
+
+echo
+echo "----   FINISH OPENPILOT SETUP   ----"
+echo "Configure your active shell env by running:"
+echo "source $RC_FILE"


### PR DESCRIPTION
### *** Bug fix ***


**Description** 
This commit fixes an issue where mac_setup.sh fails when executing from zsh on line 56:
`source $RC_FILE` 
because the default $RC_FILE in bash will still lead to ~/.zshrc, this will probably error out for 99% of mac users 

instead, this executes the commands we just piped to the rc file directly. also adds a message to remind user to source their profile for active session.

**Verification**
Tested with both bash and zsh as default shell, lgtm.

This PR is for the purpose of streamlining the developer experience for 3rd party contributors.  