### PR TITLE
Remove panda set power functions

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -578,8 +578,6 @@ int main() {
 #endif
   LOG("set affinity returns %d", err);
 
-  panda_set_power(true);
-
   while (!do_exit){
     std::vector<std::thread> threads;
     threads.push_back(std::thread(panda_state_thread, getenv("STARTED") != nullptr));

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -10,23 +10,6 @@
 #include "messaging.hpp"
 #include "panda.h"
 
-void panda_set_power(bool power){
-#ifdef QCOM2
-  int err = 0;
-
-  err += gpio_init(GPIO_STM_RST_N, true);
-  err += gpio_init(GPIO_STM_BOOT0, true);
-
-  err += gpio_set(GPIO_STM_RST_N, true);
-  err += gpio_set(GPIO_STM_BOOT0, false);
-
-  util::sleep_for(100); // 100 ms
-
-  err += gpio_set(GPIO_STM_RST_N, !power);
-  assert(err == 0);
-#endif
-}
-
 Panda::Panda(){
   // init libusb
   int err = libusb_init(&ctx);

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -39,8 +39,6 @@ struct __attribute__((packed)) health_t {
 };
 
 
-void panda_set_power(bool power);
-
 class Panda {
  private:
   libusb_context *ctx = NULL;

--- a/selfdrive/debug/internal/can_replay.py
+++ b/selfdrive/debug/internal/can_replay.py
@@ -9,7 +9,6 @@ os.environ['FILEREADER_CACHE'] = '1'
 
 from common.realtime import config_realtime_process, Ratekeeper
 from selfdrive.boardd.boardd import can_capnp_to_can_list
-from selfdrive.pandad import set_panda_power
 from tools.lib.logreader import LogReader
 
 from panda import Panda
@@ -78,7 +77,6 @@ def connect():
     time.sleep(1)
 
 if __name__ == "__main__":
-  set_panda_power(False)
   time.sleep(1)
 
   if "FLASH" in os.environ and PandaJungle is not None:

--- a/selfdrive/pandad.py
+++ b/selfdrive/pandad.py
@@ -5,27 +5,9 @@ import time
 
 from panda import BASEDIR as PANDA_BASEDIR, Panda, PandaDFU
 from common.basedir import BASEDIR
-from common.gpio import gpio_init, gpio_set
-from selfdrive.hardware import TICI
-from selfdrive.hardware.tici.pins import GPIO_HUB_RST_N, GPIO_STM_BOOT0, GPIO_STM_RST_N
 from selfdrive.swaglog import cloudlog
 
 PANDA_FW_FN = os.path.join(PANDA_BASEDIR, "board", "obj", "panda.bin.signed")
-
-
-def set_panda_power(power=True):
-  if not TICI:
-    return
-
-  gpio_init(GPIO_STM_RST_N, True)
-  gpio_init(GPIO_STM_BOOT0, True)
-
-  gpio_set(GPIO_STM_RST_N, True)
-  gpio_set(GPIO_HUB_RST_N, True)
-
-  time.sleep(0.1)
-
-  gpio_set(GPIO_STM_RST_N, not power)
 
 
 def get_expected_signature():
@@ -100,7 +82,6 @@ def update_panda():
 
 
 def main():
-  set_panda_power()
   update_panda()
 
   os.chdir(os.path.join(BASEDIR, "selfdrive/boardd"))


### PR DESCRIPTION
No longer necessary:
 - Hub reset is set on boot by gpio service
 - Panda reset line is now inverted, so default value is fine