### PR TITLE
fix VW trans type detection

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -148,7 +148,7 @@ def fingerprint(logcan, sendcan):
           car_fingerprint = candidate_cars[b][0]
 
     # bail if no cars left or we've been waiting for more than 2s
-    failed = all(len(cc) == 0 for cc in candidate_cars.values()) or frame > 200
+    failed = (all(len(cc) == 0 for cc in candidate_cars.values()) and frame > frame_fingerprint) or frame > 200
     succeeded = car_fingerprint is not None
     done = failed or succeeded
 


### PR DESCRIPTION
437e054d1133d7e5251eeb63b04fe725dd5120a2 broke process replay for the Audi A3 since it removed the last VW from CAN fingerprinting. None of the other make's fingerprints look like VW, so CAN fingerprinting bailed too quickly to catch the message we use to identify the transmission type. This enforces a short minimum time to ensure we see that message.

Tested on our Audi A3, but the minimum fingerprinting time may need to be increased for other cars.