### PR TITLE
Force deceleration for seatbelt unlatched or door open

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -489,8 +489,8 @@ class Controls:
       can_sends = self.CI.apply(CC)
       self.pm.send('sendcan', can_list_to_can_capnp(can_sends, msgtype='sendcan', valid=CS.canValid))
 
-    force_decel = (self.sm['driverMonitoringState'].awarenessStatus < 0.) or \
-                  (self.state == State.softDisabling)
+    force_decel = (self.sm['driverMonitoringState'].awarenessStatus < 0. or
+                   self.state == State.softDisabling or CS.seatbeltUnlatched or CS.doorOpen)
 
     # Curvature & Steering angle
     params = self.sm['liveParameters']

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -601,12 +601,20 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
   },
 
   EventName.doorOpen: {
-    ET.SOFT_DISABLE: SoftDisableAlert("Door Open"),
+    ET.WARNING: Alert(
+      "DISENGAGE IMMEDIATELY",
+      "Door Open",
+      AlertStatus.critical, AlertSize.full,
+      Priority.HIGH, VisualAlert.steerRequired, AudibleAlert.chimeWarningRepeat, .1, .1, .1),
     ET.NO_ENTRY: NoEntryAlert("Door Open"),
   },
 
   EventName.seatbeltNotLatched: {
-    ET.SOFT_DISABLE: SoftDisableAlert("Seatbelt Unlatched"),
+    ET.WARNING: Alert(
+      "DISENGAGE IMMEDIATELY",
+      "Seatbelt Unlatched",
+      AlertStatus.critical, AlertSize.full,
+      Priority.HIGH, VisualAlert.steerRequired, AudibleAlert.chimeWarningRepeat, .1, .1, .1),
     ET.NO_ENTRY: NoEntryAlert("Seatbelt Unlatched"),
   },
 


### PR DESCRIPTION
Changes the previous behavior of disabling after a few seconds to forcing deceleration and still steering.

I think it's a little nicer to not stop steering, for example: if a driver is in the middle of a sweeping turn on a highway and they open their door to make sure it's closed/not ajar, or any other reason and they aren't aware that openpilot disengages under these circumstances. The deceleration rate is pretty slow though, if you're going up a steep hill it will still accelerate hard, and it takes quite a while to come to a stop on flat road. For example, it will theoretically take almost 2 minutes to come to a stop at 45 mph.

With this code though, the driver can close the door or relatch the seatbelt and openpilot will continue driving, but I can make the alert and decel stick until a disengage occurs, even if they close the door, etc. if that's desired