### PR TITLE
Make orange DM alert infinite

### DIFF
--- a/selfdrive/ui/qt/sound.hpp
+++ b/selfdrive/ui/qt/sound.hpp
@@ -12,7 +12,7 @@ static std::map<AudibleAlert, std::pair<const char *, int>> sound_map {
   {AudibleAlert::CHIME_ENGAGE, {"../assets/sounds/engaged.wav", 0}},
   {AudibleAlert::CHIME_WARNING1, {"../assets/sounds/warning_1.wav", 0}},
   {AudibleAlert::CHIME_WARNING2, {"../assets/sounds/warning_2.wav", 0}},
-  {AudibleAlert::CHIME_WARNING2_REPEAT, {"../assets/sounds/warning_2.wav", 3}},
+  {AudibleAlert::CHIME_WARNING2_REPEAT, {"../assets/sounds/warning_2.wav", -1}},
   {AudibleAlert::CHIME_WARNING_REPEAT, {"../assets/sounds/warning_repeat.wav", -1}},
   {AudibleAlert::CHIME_ERROR, {"../assets/sounds/error.wav", 0}},
   {AudibleAlert::CHIME_PROMPT, {"../assets/sounds/error.wav", 0}}


### PR DESCRIPTION
My Corolla is very loud road-noise wise so it can be very easy to not hear the prompt alert to pay attention, and for someone new to openpilot (like my dad who isn't used to looking up at the EON/C2 to keep up to date with its status) it can be very easy to miss just the three times the quiet warning sound plays. I've actually seen him be jolted by the terminal alert (multiple times!) because he didn't notice it (before when I had only wheel touch).

This also kept happening to my friend who tried openpilot at night with an EON, even though it was a bright screen he simply didn't know to look at it and touch the wheel every 30 seconds when the orange alert came up + it was too quiet and didn't play long enough (same with him, I had to remind him multiple times to watch the screen for the pre and prompt alert so it wouldn't disengage).

This makes it repeat until the terminal alert is shown.

Before: https://photos.app.goo.gl/a7xcLAebiHjpbbCQA

After: https://photos.app.goo.gl/J5PEjFFFrimsduct9