### PR TITLE
Kill loggerd when red thermal status

### DIFF
--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -8,6 +8,7 @@ import traceback
 
 import cereal.messaging as messaging
 import selfdrive.crash as crash
+from cereal import log
 from common.basedir import BASEDIR
 from common.params import Params
 from common.text_window import TextWindow
@@ -21,6 +22,9 @@ from selfdrive.swaglog import cloudlog, add_file_handler
 from selfdrive.version import dirty, get_git_commit, version, origin, branch, commit, \
                               terms_version, training_version, \
                               get_git_branch, get_git_remote
+
+ThermalStatus = log.DeviceState.ThermalStatus
+
 
 def manager_init():
 
@@ -130,7 +134,7 @@ def manager_thread():
     sm.update()
     not_run = ignore[:]
 
-    if sm['deviceState'].freeSpacePercent < 5:
+    if sm['deviceState'].freeSpacePercent < 5 or sm['deviceState'].thermalStatus >= ThermalStatus.red:
       not_run.append("loggerd")
 
     started = sm['deviceState'].started


### PR DESCRIPTION
Kills loggerd (uses a fair amount of CPU when onroad) when thermal status is red (engage is disallowed anyway) so the temperature comes down quicker.

Let me know if this would affect anything else, I haven't extensively tested it or anything, it just seems like a good idea when you can leave your C2 in the car on 100F+ days.