### PR TITLE
generate jwt every registration call

### DIFF
--- a/selfdrive/registration.py
+++ b/selfdrive/registration.py
@@ -43,7 +43,6 @@ def register(show_spinner=False):
     # Create registration token, in the future, this key will make JWTs directly
     private_key = open(PERSIST+"/comma/id_rsa").read()
     public_key = open(PERSIST+"/comma/id_rsa.pub").read()
-    register_token = jwt.encode({'register': True, 'exp': datetime.utcnow() + timedelta(hours=1)}, private_key, algorithm='RS256')
 
     # Block until we get the imei
     imei1, imei2 = None, None
@@ -58,8 +57,10 @@ def register(show_spinner=False):
     params.put("IMEI", imei1)
     params.put("HardwareSerial", serial)
 
+    backoff = 0
     while True:
       try:
+        register_token = jwt.encode({'register': True, 'exp': datetime.utcnow() + timedelta(hours=1)}, private_key, algorithm='RS256')
         cloudlog.info("getting pilotauth")
         resp = api_get("v2/pilotauth/", method='POST', timeout=15,
                        imei=imei1, imei2=imei2, serial=serial, public_key=public_key, register_token=register_token)
@@ -74,7 +75,8 @@ def register(show_spinner=False):
         break
       except Exception:
         cloudlog.exception("failed to authenticate")
-        time.sleep(1)
+        backoff = max(backoff + 1, 15)
+        time.sleep(backoff)
 
     if show_spinner:
       spinner.close()

--- a/selfdrive/registration.py
+++ b/selfdrive/registration.py
@@ -75,7 +75,7 @@ def register(show_spinner=False):
         break
       except Exception:
         cloudlog.exception("failed to authenticate")
-        backoff = max(backoff + 1, 15)
+        backoff = min(backoff + 1, 15)
         time.sleep(backoff)
 
     if show_spinner:


### PR DESCRIPTION
if there is a registration issue on the backend the device will spin forever waiting for it to resolve, but the jwt expires after one hour