### PR TITLE
ignore_avg_freq of longitudinalPlan, which is triggered by radarState

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -59,7 +59,7 @@ class Controls:
       self.sm = messaging.SubMaster(['deviceState', 'pandaState', 'modelV2', 'liveCalibration',
                                      'driverMonitoringState', 'longitudinalPlan', 'lateralPlan', 'liveLocationKalman',
                                      'roadCameraState', 'driverCameraState', 'managerState', 'liveParameters', 'radarState'],
-                                     ignore_alive=ignore, ignore_avg_freq=['radarState'])
+                                     ignore_alive=ignore, ignore_avg_freq=['radarState', 'longitudinalPlan'])
 
     self.can_sock = can_sock
     if can_sock is None:


### PR DESCRIPTION
**Description** GM radar updates at 15 Hz not standard 20 Hz. 'radarState' and subsequent longitudinal plan is published at 15 Hz. The expected frequency is set to 20 Hz in cereal/services.py. This causes commIssue on engage for GM.

Related:
https://github.com/commaai/openpilot/commit/64d2ec38f290f7146af4196d240fb70cc11653b0
https://github.com/commaai/openpilot/pull/20558

**Verification** Engaged openpilot successful, no commIssue.

**Route**
Route: Uploading