### PR TITLE
Necessary changes for the LEXUS IS Hybrid were never merged in; Remove entry in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Supported Cars
 | Lexus     | ES Hybrid 2017-18             | LSS               | Stock<sup>3</sup>| 0mph               | 0mph              |
 | Lexus     | ES Hybrid 2019                | All               | openpilot        | 0mph               | 0mph              |
 | Lexus     | IS 2017-2019                  | All               | Stock            | 22mph              | 0mph              |
-| Lexus     | IS Hybrid 2017                | All               | Stock            | 0mph               | 0mph              |
 | Lexus     | NX 2018                       | All               | Stock<sup>3</sup>| 0mph               | 0mph              |
 | Lexus     | NX 2020                       | All               | openpilot        | 0mph               | 0mph              |
 | Lexus     | NX Hybrid 2018                | All               | Stock<sup>3</sup>| 0mph               | 0mph              |


### PR DESCRIPTION
https://github.com/commaai/openpilot/pull/536 was never merged in.

`master` currently does not contain anything remotely equivalent to the changes in that PR.

Considering the signal changes in that PR for the IS Hybrid, there's no way the IS Hybrid will work with current `master`. 

I have found no evidence of an IS 300H being used successfully with openpilot in Discord. In fact, the one user who was struggling on Discord was confused by @eFiniLan 's Youtube videos of the system working. There does seem to be support in the dragonpilot fork: 

https://github.com/dragonpilot-community/dragonpilot/blob/ce48b036784dc817d141f9fbd2f887f044843b2c/selfdrive/car/toyota/carstate.py#L174

I'll be working with a user to refurbish @eFiniLan 's changes and hopefully this entry in the README can be re-added. 😄

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_routes.py](../../selfdrive/test/test_routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
