### PR TITLE
Torque unification testing

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -41,6 +41,10 @@ class CarInterfaceBase():
     return 1.
 
   @staticmethod
+  def compute_torque(torque, speed):
+    return float(torque)
+
+  @staticmethod
   def compute_gb(accel, speed):
     raise NotImplementedError
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -11,6 +11,19 @@ EventName = car.CarEvent.EventName
 
 class CarInterface(CarInterfaceBase):
   @staticmethod
+  def compute_torque(torque, speed):
+    def std_feedforward(_speed):
+      return _speed ** 2
+
+    def acc_feedforward(_speed):
+      return 0.35189607550172824 * _speed ** 2 + 7.506201251644202 * _speed + 69.226826411091
+
+    # todo: find nicer way to avoid multiplier going to inf
+    speed = max(speed, 20 * CV.MPH_TO_MS)
+    torque_mult = acc_feedforward(speed) / std_feedforward(speed)
+    return float(torque) * torque_mult
+
+  @staticmethod
   def compute_gb(accel, speed):
     return float(accel) / CarControllerParams.ACCEL_SCALE
 
@@ -93,8 +106,9 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 18.27
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
-      ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.08], [0.01]]
+      # todo: refit function on current kf
+      ret.lateralTuning.pid.kf = 0.00003 * 1.833   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:
       stop_and_go = True

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -108,10 +108,11 @@ class Controls:
     self.LoC = LongControl(self.CP, self.CI.compute_gb)
     self.VM = VehicleModel(self.CP)
 
+    # todo: implement convert for other controllers (make sure to convert before clip)
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       self.LaC = LatControlAngle(self.CP)
     elif self.CP.lateralTuning.which() == 'pid':
-      self.LaC = LatControlPID(self.CP)
+      self.LaC = LatControlPID(self.CP, self.CI.compute_torque)
     elif self.CP.lateralTuning.which() == 'indi':
       self.LaC = LatControlINDI(self.CP)
     elif self.CP.lateralTuning.which() == 'lqr':

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -6,11 +6,11 @@ from cereal import log
 
 
 class LatControlPID():
-  def __init__(self, CP):
+  def __init__(self, CP, compute_torque):
     self.pid = PIController((CP.lateralTuning.pid.kpBP, CP.lateralTuning.pid.kpV),
                             (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
                             k_f=CP.lateralTuning.pid.kf, pos_limit=1.0, neg_limit=-1.0,
-                            sat_limit=CP.steerLimitTimer)
+                            sat_limit=CP.steerLimitTimer, convert=compute_torque)
 
   def reset(self):
     self.pid.reset()

--- a/selfdrive/debug/torque_unification.py
+++ b/selfdrive/debug/torque_unification.py
@@ -1,0 +1,53 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from selfdrive.config import Conversions as CV
+
+
+def std_feedforward(angle, speed, mph=False):
+  """
+  What latcontrol_pid uses and is technically correct (~lateral accel)
+  """
+  speed = CV.MPH_TO_MS * speed if mph else speed
+  return speed ** 2 * angle
+
+
+def acc_feedforward(angle, speed, mph=False):
+  """
+  Fitted from data from 2017 Corolla. Much more accurate at low speeds
+  (Torque almost drops to 0 at low speeds with std feedforward)
+  """
+  speed = CV.MPH_TO_MS * speed if mph else speed
+  # todo: this is a bit out of date, it was fitted assuming 0.12s of delay
+  _c1, _c2, _c3 = 0.35189607550172824, 7.506201251644202, 69.226826411091
+  return (_c1 * speed ** 2 + _c2 * speed + _c3) * angle
+
+
+def convert_torque_corolla(speed, mph=False):
+  """Returns a multiplier to convert universal torque to vehicle-specific torque"""
+  # todo: can we fit a function that outputs this without calculating both feedforwards?
+  speed = CV.MPH_TO_MS * speed if mph else speed
+  mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
+  return mult
+
+
+# Plot how multiplier changes with speed
+spds = np.linspace(10, 70, 61)
+mults = convert_torque_corolla(spds, mph=True)
+plt.title('output of torque conversion function')
+plt.plot(spds, mults, label='torque multiplier')
+plt.xlabel('speed (mph)')
+plt.legend()
+
+
+# Plot comparison between std ff and more accurate fitted ff
+plt.figure()
+deg = 10
+plt.title(f'torque response at {deg} degrees')
+torques = std_feedforward(deg, spds, mph=True)
+plt.plot(spds, torques, label='standard feedforward (~lateral accel)')
+
+torques = acc_feedforward(deg, spds, mph=True)
+plt.plot(spds, torques, label='custom-fit \'17 Corolla feedforward')
+plt.xlabel('speed (mph)')
+plt.ylabel('torque')
+plt.legend()


### PR DESCRIPTION
Just a draft for now to record changes and receive feedback.

With the current ~lateral accel model for torque (from latcontrol_pid), it applies too little at low speeds and too much at high speeds. This normalizes the response, assuming `speed ^ 2` is correct for required torque at any speed. We add a new function similar to `compute_gb` that converts the torque before clipping.

Todo:
- [ ] Fit an (*accurate*) ff function for many cars and implement
- [x] Fit a starting point ff function for '17 Corolla and implement (fitted on only one car at 0.12 sec delay)
- [x] Implement in latcontrol_pid (uses pid's `convert` functionality)
- [ ] ~See what is needed to fit a function to output multiplier without calculating both standard ff and car-specific ff~
  - Edit: Calculating both standard ff and car-specific ff each frame usually is quicker than a fitted function, and more accurate. Will look into this more
- [ ] Implement convert function in other latcontrollers (can't do in carcontroller or controlsd because it should be applied before range clipping. ie. we'd never be able to reach max torque when multiplier is under 1)
- [ ] Quantify results. Maybe compare stock, unification on whole torque output, and just modifying feedforward (not prop and integral)

Results so far is much better control at a higher range of speeds, it should increase the chances that a single proportional and integral gain works over a larger speed range.