### PR TITLE
C++ Process replay improvements

### DIFF
--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -340,8 +340,8 @@ kj::ArrayPtr<capnp::byte> Localizer::get_message_bytes(MessageBuilder& msg_build
 int Localizer::locationd_thread() {
   const std::initializer_list<const char *> service_list =
       { "gpsLocationExternal", "sensorEvents", "cameraOdometry", "liveCalibration", "carState" };
-  SubMaster sm(service_list, nullptr, { "gpsLocationExternal" });
   PubMaster pm({ "liveLocationKalman" });
+  SubMaster sm(service_list, nullptr, { "gpsLocationExternal" });
 
   Params params;
 

--- a/selfdrive/locationd/ubloxd.cc
+++ b/selfdrive/locationd/ubloxd.cc
@@ -13,12 +13,13 @@ int main() {
   AlignedBuffer aligned_buf;
   UbloxMsgParser parser;
 
+  PubMaster pm({"ubloxGnss", "gpsLocationExternal"});
+
   Context * context = Context::create();
   SubSocket * subscriber = SubSocket::create(context, "ubloxRaw");
   assert(subscriber != NULL);
   subscriber->setTimeout(100);
 
-  PubMaster pm({"ubloxGnss", "gpsLocationExternal"});
 
   while (!do_exit) {
     Message * msg = subscriber->receive();

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -453,8 +453,11 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
 
     resp_sockets = cfg.pub_sub[msg.which()] if cfg.should_recv_callback is None else cfg.should_recv_callback(msg)
     for s in resp_sockets:
-      response = messaging.recv_one_retry(sockets[s])
-      log_msgs.append(response)
+      response = messaging.recv_one(sockets[s])
+      if response is None:
+        print("Warning, no response received")
+      else:
+        log_msgs.append(response)
 
     if not len(resp_sockets):
       while not pm.all_readers_updated(msg.which()):

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -459,7 +459,7 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
       else:
         log_msgs.append(response)
 
-    if not len(resp_sockets):
+    if not len(resp_sockets):  # We only need to wait if we didn't already wait for a response
       while not pm.all_readers_updated(msg.which()):
         time.sleep(0)
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -454,6 +454,11 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
     resp_sockets = cfg.pub_sub[msg.which()] if cfg.should_recv_callback is None else cfg.should_recv_callback(msg)
     for s in resp_sockets:
       response = messaging.recv_one(sockets[s])
+
+      # Try once more after timeout is hit
+      if response is None:
+        response = messaging.recv_one_or_none(sockets[s])
+
       if response is None:
         print("Warning, no response received")
       else:

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -443,10 +443,11 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
   while not all(pm.all_readers_updated(s) for s in cfg.pub_sub.keys()):
     time.sleep(0)
 
-  log_msgs = []
+  # Make sure all subscribers are connected
   for s in sub_sockets:
     messaging.recv_one_or_none(sockets[s])
 
+  log_msgs = []
   for msg in tqdm(pub_msgs, disable=CI):
     pm.send(msg.which(), msg.as_builder())
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -449,19 +449,15 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
     messaging.recv_one_or_none(sockets[s])
 
   log_msgs = []
-  for msg in tqdm(pub_msgs, disable=CI):
+  for i, msg in enumerate(tqdm(pub_msgs, disable=CI)):
     pm.send(msg.which(), msg.as_builder())
 
     resp_sockets = cfg.pub_sub[msg.which()] if cfg.should_recv_callback is None else cfg.should_recv_callback(msg)
     for s in resp_sockets:
       response = messaging.recv_one(sockets[s])
 
-      # Try once more after timeout is hit
       if response is None:
-        response = messaging.recv_one_or_none(sockets[s])
-
-      if response is None:
-        print("Warning, no response received")
+        print(f"Warning, no response received {i}")
       else:
         log_msgs.append(response)
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -436,6 +436,7 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
   all_msgs = sorted(lr, key=lambda msg: msg.logMonoTime)
   pub_msgs = [msg for msg in all_msgs if msg.which() in list(cfg.pub_sub.keys())]
 
+  os.environ["SIMULATION"] = "1"  # Disable submaster alive checks
   managed_processes[cfg.proc_name].prepare()
   managed_processes[cfg.proc_name].start()
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -432,7 +432,6 @@ def python_replay_process(cfg, lr, fingerprint=None):
 def cpp_replay_process(cfg, lr, fingerprint=None):
   sub_sockets = [s for _, sub in cfg.pub_sub.items() for s in sub]  # We get responses here
   pm = messaging.PubMaster(cfg.pub_sub.keys())
-  sockets = {s: messaging.sub_sock(s, timeout=1000) for s in sub_sockets}
 
   all_msgs = sorted(lr, key=lambda msg: msg.logMonoTime)
   pub_msgs = [msg for msg in all_msgs if msg.which() in list(cfg.pub_sub.keys())]
@@ -444,6 +443,7 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
     time.sleep(0)
 
   # Make sure all subscribers are connected
+  sockets = {s: messaging.sub_sock(s, timeout=1000) for s in sub_sockets}
   for s in sub_sockets:
     messaging.recv_one_or_none(sockets[s])
 


### PR DESCRIPTION
- Replace startup sleep by checking if all subscribers are connected
- Fix errors with inputsOK by disabling frequency checks
- Some small changes that might improve stability

To do for part 2:
 - Figure out why sometimes 1 message is dropped