### PR TITLE
C++ Process Replay improvements  - Part 2

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -446,7 +446,7 @@ def cpp_replay_process(cfg, lr, fingerprint=None):
     time.sleep(0)
 
   # Make sure all subscribers are connected
-  sockets = {s: messaging.sub_sock(s, timeout=1000) for s in sub_sockets}
+  sockets = {s: messaging.sub_sock(s, timeout=2000) for s in sub_sockets}
   for s in sub_sockets:
     messaging.recv_one_or_none(sockets[s])
 


### PR DESCRIPTION
- Choose test receive timeout 2x higher than process under test submaster timeout. In case the signal get's lost, we give the process one more time to retry the receive. Still not sure why this would be lost in the first place