### PR TITLE
OffroadAlert: add stretch at the bottom

### DIFF
--- a/selfdrive/ui/qt/widgets/offroad_alerts.cc
+++ b/selfdrive/ui/qt/widgets/offroad_alerts.cc
@@ -82,6 +82,7 @@ void OffroadAlert::refresh() {
       l->setVisible(false);
       alerts_layout->addWidget(l);
     }
+    alerts_layout->addStretch(1);
   }
 
   updateAlerts();


### PR DESCRIPTION
The alert is displayed at the bottom with a large blank space at the top. add a stretch at the bottom to fix it. 