### PR TITLE
Subaru false positive brake pressed when ACC is braking

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -124,11 +124,14 @@ class CarInterfaceBase():
       else:
         events.add(EventName.steerTempUnavailable)
 
-    # Disable on rising edge of gas or brake. Also disable on brake when speed > 0.
+    # Disable on rising edge of gas.
+    # Disable on rising edge of brake if vehicle is speed = 0
+    # Debounce rising edge of brake AND Disable on brake while speed > 0.
     # Optionally allow to press gas at zero speed to resume.
     # e.g. Chrysler does not spam the resume button yet, so resuming with gas is handy. FIXME!
     if (cs_out.gasPressed and (not self.CS.out.gasPressed) and cs_out.vEgo > gas_resume_speed) or \
-       (cs_out.brakePressed and (not self.CS.out.brakePressed or not cs_out.standstill)):
+       (cs_out.brakePressed and not self.CS.out.brakePressed and cs_out.standstill) or \
+       (cs_out.brakePressed and self.CS.out.brakePressed and not cs_out.standstill):
       events.add(EventName.pedalPressed)
 
     # we engage when pcm is active (rising edge)


### PR DESCRIPTION
<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

Single messages for user braking are appearing on Subaru vehicles causing unsafe ACC cancelation.
The vehicle cancels ACC and "coast" into/towards a vehicle that should be being braked for.
It seems to happen with moderate braking when a new lead is acquired.
It is also appearing more frequently with gas pedal enabled.

My testing is only on subaru_global but change preserves the previous logic to ensure compatibility with all vehicles.
When vehicle is in motion this checks for 2 consecutive brake messages before exiting controls.
This prevents ACC from being canceled by itself if OP or stock ACC is actively braking. I do not know if this would be an issue with long vehicles but I imagine it would be similar behavior.

Panda PR https://github.com/commaai/panda/pull/645