### PR TITLE
make brakePressed always bool

### DIFF
--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -309,9 +309,9 @@ class CarState(CarStateBase):
       ret.cruiseState.standstill = cp.vl["ACC_HUD"]['CRUISE_SPEED'] == 252.
       ret.cruiseState.speedOffset = calc_cruise_offset(0, ret.vEgo)
       if self.CP.carFingerprint in (CAR.CIVIC_BOSCH, CAR.CIVIC_BOSCH_DIESEL, CAR.ACCORDH, CAR.CRV_HYBRID, CAR.INSIGHT):
-        ret.brakePressed = cp.vl["POWERTRAIN_DATA"]['BRAKE_PRESSED'] != 0 or \
-                          (self.brake_switch and self.brake_switch_prev and
-                          cp.ts["POWERTRAIN_DATA"]['BRAKE_SWITCH'] != self.brake_switch_ts)
+        ret.brakePressed = bool(cp.vl["POWERTRAIN_DATA"]['BRAKE_PRESSED'] or
+                              (self.brake_switch and self.brake_switch_prev and
+                               cp.ts["POWERTRAIN_DATA"]['BRAKE_SWITCH'] != self.brake_switch_ts))
         self.brake_switch_prev = self.brake_switch
         self.brake_switch_ts = cp.ts["POWERTRAIN_DATA"]['BRAKE_SWITCH']
       else:


### PR DESCRIPTION
If the first message through this method results in `self.brake_switch` being `True` you will find that `self.brake_switch_prev` is `0` (and not `False`) which causes an attempt to assign `ret.brakePressed` to `0` and the following exception:
```
  File "/home/batman/openpilot/selfdrive/car/honda/carstate.py", line 312, in update
    ret.brakePressed = (cp.vl["POWERTRAIN_DATA"]['BRAKE_PRESSED'] or
  File "capnp/lib/capnp.pyx", line 1264, in capnp.lib.capnp._DynamicStructBuilder.__setattr__
  File "capnp/lib/capnp.pyx", line 1262, in capnp.lib.capnp._DynamicStructBuilder.__setattr__
  File "capnp/lib/capnp.pyx", line 1255, in capnp.lib.capnp._DynamicStructBuilder._set
  File "capnp/lib/capnp.pyx", line 705, in capnp.lib.capnp._setDynamicField
capnp.lib.capnp.KjException: capnp/dynamic.c++:1811: failed: expected reader.type == BOOL; Value type mismatch.
```

It looks like this was a sloppy duplication when adding bosch vehicles with nidec brake signals, so feel free to clean up the duplication if you want before merging (see what appears to be identical logic for honda nidec below)
https://github.com/commaai/openpilot/blob/a4e2cc405afa4c452913500a2d15535de1874076/selfdrive/car/honda/carstate.py#L327-L329