### PR TITLE
Also use sentry for capnp exceptions

### DIFF
--- a/selfdrive/crash.py
+++ b/selfdrive/crash.py
@@ -1,7 +1,4 @@
 """Install exception handler for process crash."""
-import sys
-import capnp
-
 from selfdrive.swaglog import cloudlog
 from selfdrive.version import version
 
@@ -9,11 +6,9 @@ import sentry_sdk
 from sentry_sdk.integrations.threading import ThreadingIntegration
 
 def capture_exception(*args, **kwargs):
-  exc_info = sys.exc_info()
-  if not exc_info[0] is capnp.lib.capnp.KjException:
-    sentry_sdk.capture_exception(*args, **kwargs)
-    sentry_sdk.flush()  # https://github.com/getsentry/sentry-python/issues/291
   cloudlog.error("crash", exc_info=kwargs.get('exc_info', 1))
+  sentry_sdk.capture_exception(*args, **kwargs)
+  sentry_sdk.flush()  # https://github.com/getsentry/sentry-python/issues/291
 
 def bind_user(**kwargs):
   sentry_sdk.set_user(kwargs)

--- a/selfdrive/crash.py
+++ b/selfdrive/crash.py
@@ -12,7 +12,7 @@ def capture_exception(*args, **kwargs):
     sentry_sdk.capture_exception(*args, **kwargs)
     sentry_sdk.flush()  # https://github.com/getsentry/sentry-python/issues/291
   except Exception:
-    pass
+    cloudlog.exception("sentry exception")
 
 def bind_user(**kwargs):
   sentry_sdk.set_user(kwargs)

--- a/selfdrive/crash.py
+++ b/selfdrive/crash.py
@@ -7,8 +7,12 @@ from sentry_sdk.integrations.threading import ThreadingIntegration
 
 def capture_exception(*args, **kwargs):
   cloudlog.error("crash", exc_info=kwargs.get('exc_info', 1))
-  sentry_sdk.capture_exception(*args, **kwargs)
-  sentry_sdk.flush()  # https://github.com/getsentry/sentry-python/issues/291
+
+  try:
+    sentry_sdk.capture_exception(*args, **kwargs)
+    sentry_sdk.flush()  # https://github.com/getsentry/sentry-python/issues/291
+  except Exception:
+    pass
 
 def bind_user(**kwargs):
   sentry_sdk.set_user(kwargs)


### PR DESCRIPTION
I add this check a while back because sending capnp exceptions can fail to produce a valid stacktrace when you hit the maximum traversal limit causing another exception when you try. However, there are other exceptions that we do want to capture, e.g. https://github.com/commaai/openpilot/pull/20895

Send the cloudlog first. If sending the capnp exception to sentry fails it's not a big deal.

Test: https://sentry.io/organizations/commaai/issues/2398861967/?project=77924&query=is%3Aunresolved