### PR TITLE
Simulator: mount OP working dir to the same dir inside the container

### DIFF
--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -11,8 +11,8 @@ docker pull ghcr.io/commaai/openpilot-sim:latest
 OPENPILOT_DIR="/openpilot"
 if ! [[ -z "$MOUNT_OPENPILOT" ]]
 then
-  EXTRA_ARGS="-v $PWD/../..:/root/openpilot -e PYTHONPATH=/root/openpilot:$PYTHONPATH"
-  OPENPILOT_DIR="/root/openpilot"
+  OPENPILOT_DIR="$(dirname $(dirname $DIR))"
+  EXTRA_ARGS="-v $OPENPILOT_DIR:$OPENPILOT_DIR -e PYTHONPATH=$OPENPILOT_DIR:$PYTHONPATH"
 fi
 
 docker run --net=host\


### PR DESCRIPTION
**Description** 
Cloned the OP repo, performed ubuntu setup and built with scons. When starting the simulator with the `MOUNT_OPENPILOT=1` env variable set, the bridge as well as the openpilot terminal show following error:
_ImportError: /home/markus/openpilot/opendbc/can/libdbc.so: cannot open shared object file: No such file or directory_

Mounting the OP working directory to the same location within the container solves this issue, and simulating OP built from your working dir works flawlessly.

**Verification**
Clone, set up, build as described in the OP Readme(s). Start simulation with  `MOUNT_OPENPILOT=1` variable set.
    
    MOUNT_OPENPILOT=1 ./start_openpilot_docker.sh

Simulation starts without any issue. (Except [that one](https://discord.com/channels/469524606043160576/684457101455786017/841788306970247198)... which is [easy to solve](https://discord.com/channels/469524606043160576/684457101455786017/841953842991595570))

Might be relevant for:
#2572
