### PR TITLE
UI: add decline page for the Terms and Conditions

### DIFF
--- a/selfdrive/ui/qt/offroad/onboarding.cc
+++ b/selfdrive/ui/qt/offroad/onboarding.cc
@@ -10,6 +10,8 @@
 #include "selfdrive/common/params.h"
 #include "selfdrive/common/util.h"
 #include "selfdrive/ui/qt/home.h"
+#include "selfdrive/ui/qt/widgets/input.h"
+
 
 void TrainingGuide::mouseReleaseEvent(QMouseEvent *e) {
   QPoint touch = QPoint(e->x(), e->y()) - imageCorner;
@@ -77,11 +79,13 @@ void TermsPage::showEvent(QShowEvent *event) {
   QObject *obj = (QObject*)text->rootObject();
   QObject::connect(obj, SIGNAL(qmlSignal()), SLOT(enableAccept()));
 
-  // TODO: add decline page
   QHBoxLayout* buttons = new QHBoxLayout;
   main_layout->addLayout(buttons);
 
-  buttons->addWidget(new QPushButton("Decline"));
+  decline_btn = new QPushButton("Decline");
+  buttons->addWidget(decline_btn);
+  QObject::connect(decline_btn, &QPushButton::released, this, &TermsPage::declinedTerms);
+
   buttons->addSpacing(50);
 
   accept_btn = new QPushButton("Scroll to accept");
@@ -104,6 +108,46 @@ void TermsPage::enableAccept(){
   accept_btn->setText("Accept");
   accept_btn->setEnabled(true);
   return;
+}
+
+void DeclinePage::showEvent(QShowEvent *event) {
+  QVBoxLayout *main_layout = new QVBoxLayout;
+  main_layout->setMargin(40);
+  main_layout->setSpacing(40);
+
+  QLabel *text = new QLabel(this);
+  text->setText("You must accept the Terms and Conditions in order to use openpilot!");
+  text->setStyleSheet(R"(font-size: 50px;)");
+  main_layout->addWidget(text, 0, Qt::AlignCenter);
+
+  QHBoxLayout* buttons = new QHBoxLayout;
+  main_layout->addLayout(buttons);
+
+  back_btn = new QPushButton("Back");
+  buttons->addWidget(back_btn);
+  buttons->addSpacing(50);
+
+  QObject::connect(back_btn, &QPushButton::released, this, &DeclinePage::getBack);
+
+  poweroff_btn = new QPushButton("Power Off");
+  poweroff_btn->setStyleSheet("background-color: #E22C2C;");
+  buttons->addWidget(poweroff_btn);
+
+  QObject::connect(poweroff_btn, &QPushButton::released, [=](){
+    if (ConfirmationDialog::confirm("Are you sure you want to power off?", this)) {
+      Hardware::poweroff();
+    }
+  });
+
+  setLayout(main_layout);
+  setStyleSheet(R"(
+    QPushButton {
+      padding: 50px;
+      font-size: 50px;
+      border-radius: 10px;
+      background-color: #292929;
+    }
+  )");
 }
 
 void OnboardingWindow::updateActiveScreen() {
@@ -138,6 +182,17 @@ OnboardingWindow::OnboardingWindow(QWidget *parent) : QStackedWidget(parent) {
     updateActiveScreen();
   });
   addWidget(tr);
+
+  DeclinePage* declinePage = new DeclinePage(this);
+  addWidget(declinePage);
+
+  connect(terms, &TermsPage::declinedTerms, [=](){
+    setCurrentIndex(2);
+  });
+
+  connect(declinePage, &DeclinePage::getBack, [=](){
+    updateActiveScreen();
+  });
 
   setStyleSheet(R"(
     * {

--- a/selfdrive/ui/qt/offroad/onboarding.cc
+++ b/selfdrive/ui/qt/offroad/onboarding.cc
@@ -111,6 +111,10 @@ void TermsPage::enableAccept(){
 }
 
 void DeclinePage::showEvent(QShowEvent *event) {
+  if (layout()) {
+    return;
+  }
+
   QVBoxLayout *main_layout = new QVBoxLayout;
   main_layout->setMargin(40);
   main_layout->setSpacing(40);
@@ -129,13 +133,13 @@ void DeclinePage::showEvent(QShowEvent *event) {
 
   QObject::connect(back_btn, &QPushButton::released, this, &DeclinePage::getBack);
 
-  poweroff_btn = new QPushButton("Power Off");
-  poweroff_btn->setStyleSheet("background-color: #E22C2C;");
-  buttons->addWidget(poweroff_btn);
+  uninstall_btn = new QPushButton("Decline, uninstall openpilot");
+  uninstall_btn->setStyleSheet("background-color: #E22C2C;");
+  buttons->addWidget(uninstall_btn);
 
-  QObject::connect(poweroff_btn, &QPushButton::released, [=](){
-    if (ConfirmationDialog::confirm("Are you sure you want to power off?", this)) {
-      Hardware::poweroff();
+  QObject::connect(uninstall_btn, &QPushButton::released, [=](){
+    if (ConfirmationDialog::confirm("Are you sure you want to uninstall?", this)) {
+      Params().putBool("DoUninstall", true);
     }
   });
 

--- a/selfdrive/ui/qt/offroad/onboarding.h
+++ b/selfdrive/ui/qt/offroad/onboarding.h
@@ -64,12 +64,31 @@ protected:
 
 private:
   QPushButton *accept_btn;
+  QPushButton *decline_btn;
 
 public slots:
   void enableAccept();
 
 signals:
   void acceptedTerms();
+  void declinedTerms();
+};
+
+class DeclinePage : public QFrame {
+  Q_OBJECT
+
+public:
+  explicit DeclinePage(QWidget *parent = 0) : QFrame(parent) {};
+
+protected:
+  void showEvent(QShowEvent *event) override;
+
+private:
+  QPushButton *back_btn;
+  QPushButton *poweroff_btn;
+
+signals:
+  void getBack();
 };
 
 class OnboardingWindow : public QStackedWidget {

--- a/selfdrive/ui/qt/offroad/onboarding.h
+++ b/selfdrive/ui/qt/offroad/onboarding.h
@@ -85,7 +85,7 @@ protected:
 
 private:
   QPushButton *back_btn;
-  QPushButton *poweroff_btn;
+  QPushButton *uninstall_btn;
 
 signals:
   void getBack();


### PR DESCRIPTION
Add a decline page as per this TODO:

https://github.com/commaai/openpilot/blob/533bc30c2e4ecac5e022f2ba4f3919842dfa0a1a/selfdrive/ui/qt/offroad/onboarding.cc#L80

It looks like this:

![decline](https://user-images.githubusercontent.com/27537531/118376195-7b19ae80-b594-11eb-89a5-1c569edbf650.png)

Let me know if something is wrong/bad with this