### PR TITLE
Fix Terms and Training guide skip when the screen turns off

### DIFF
--- a/selfdrive/ui/qt/offroad/onboarding.cc
+++ b/selfdrive/ui/qt/offroad/onboarding.cc
@@ -107,8 +107,7 @@ void TermsPage::enableAccept(){
 }
 
 void OnboardingWindow::updateActiveScreen() {
-  bool accepted_terms = params.get("HasAcceptedTerms", false).compare(current_terms_version) == 0;
-  bool training_done = params.get("CompletedTrainingVersion", false).compare(current_training_version) == 0;
+  updateOnboardingStatus();
 
   if (!accepted_terms) {
     setCurrentIndex(0);
@@ -156,4 +155,14 @@ OnboardingWindow::OnboardingWindow(QWidget *parent) : QStackedWidget(parent) {
   )");
 
   updateActiveScreen();
+}
+
+void OnboardingWindow::updateOnboardingStatus() {
+  accepted_terms = params.get("HasAcceptedTerms", false).compare(current_terms_version) == 0;
+  training_done = params.get("CompletedTrainingVersion", false).compare(current_training_version) == 0;
+}
+
+bool OnboardingWindow::isOnboardingDone() {
+  updateOnboardingStatus();
+  return accepted_terms && training_done;
 }

--- a/selfdrive/ui/qt/offroad/onboarding.h
+++ b/selfdrive/ui/qt/offroad/onboarding.h
@@ -77,11 +77,15 @@ class OnboardingWindow : public QStackedWidget {
 
 public:
   explicit OnboardingWindow(QWidget *parent = 0);
+  bool isOnboardingDone();
 
 private:
   Params params;
   std::string current_terms_version;
   std::string current_training_version;
+  bool accepted_terms = false;
+  bool training_done = false;
+  void updateOnboardingStatus();
 
 signals:
   void onboardingDone();

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -22,10 +22,14 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
   QObject::connect(settingsWindow, &SettingsWindow::reviewTrainingGuide, this, &MainWindow::reviewTrainingGuide);
 
   onboardingWindow = new OnboardingWindow(this);
+  onboardingDone = onboardingWindow->isOnboardingDone();
   main_layout->addWidget(onboardingWindow);
 
   main_layout->setCurrentWidget(onboardingWindow);
-  QObject::connect(onboardingWindow, &OnboardingWindow::onboardingDone, this, &MainWindow::closeSettings);
+  QObject::connect(onboardingWindow, &OnboardingWindow::onboardingDone, [=](){
+    onboardingDone = true;
+    closeSettings();
+  });
   onboardingWindow->updateActiveScreen();
 
   device.setAwake(true, true);
@@ -59,10 +63,13 @@ void MainWindow::openSettings() {
 }
 
 void MainWindow::closeSettings() {
-  main_layout->setCurrentWidget(homeWindow);
+  if(onboardingDone) {
+    main_layout->setCurrentWidget(homeWindow);
+  }
 }
 
 void MainWindow::reviewTrainingGuide() {
+  onboardingDone = false;
   main_layout->setCurrentWidget(onboardingWindow);
   onboardingWindow->updateActiveScreen();
 }

--- a/selfdrive/ui/qt/window.h
+++ b/selfdrive/ui/qt/window.h
@@ -25,6 +25,7 @@ private:
   HomeWindow *homeWindow;
   SettingsWindow *settingsWindow;
   OnboardingWindow *onboardingWindow;
+  bool onboardingDone = false;
 
 public slots:
   void offroadTransition(bool offroad);


### PR DESCRIPTION
Fixes this issue #20926

**Description:**
After ~30s of doing nothing, the Terms  and Training guide were closed/skipped and replaced by the home screen.

The closeSettings function in window.cc was setting the current widget to the home screen without checking for anything.  
Also fix the same problem when you want to review the training guide in the settings.

Let me know if something is wrong/bad with this