### PR TITLE
Also shutdown after one hour if no ignition seen

### DIFF
--- a/selfdrive/thermald/power_monitoring.py
+++ b/selfdrive/thermald/power_monitoring.py
@@ -19,6 +19,7 @@ CAR_CHARGING_RATE_W = 45
 VBATT_PAUSE_CHARGING = 11.0           # Lower limit on the LPF car battery voltage
 VBATT_INSTANT_PAUSE_CHARGING = 7.0    # Lower limit on the instant car battery voltage measurements to avoid triggering on instant power loss
 MAX_TIME_OFFROAD_S = 30*3600
+MIN_ON_TIME_S = 3600
 
 class PowerMonitoring:
   def __init__(self):
@@ -184,5 +185,5 @@ class PowerMonitoring:
     # Wait until we have shut down charging before powering down
     should_shutdown |= (not panda_charging and self.should_disable_charging(pandaState, offroad_timestamp))
     should_shutdown |= ((HARDWARE.get_battery_capacity() < BATT_PERC_OFF) and (not HARDWARE.get_battery_charging()) and ((now - offroad_timestamp) > 60))
-    should_shutdown &= started_seen
+    should_shutdown &= started_seen or (now > MIN_ON_TIME_S)
     return should_shutdown


### PR DESCRIPTION
Previously disabling charging would turn off the C2, this is no longer the case. So a device that hasn't been onroad was able to drain a battery.