### PR TITLE
Updated RouteFrameReader to work on routes with missing segments

### DIFF
--- a/tools/lib/route_framereader.py
+++ b/tools/lib/route_framereader.py
@@ -16,7 +16,7 @@ class _FrameReaderDict(dict):
     self._framereader_kwargs = framereader_kwargs
 
   def __missing__(self, key):
-    if key < len(self._camera_paths) and self._camera_paths[key] is not None:
+    if self._camera_paths.get(key) is not None:
       frame_reader = FrameReader(self._camera_paths[key],
                                  self._cache_paths.get(key), **self._framereader_kwargs)
       self[key] = frame_reader
@@ -36,7 +36,10 @@ class RouteFrameReader(object):
         kwargs: Forwarded to the FrameReader function. If cache_prefix is included, that path
                 will also be used for frame position indices.
     """
-    self._first_camera_idx = next(i for i in range(len(camera_paths)) if camera_paths[i] is not None)
+    if not isinstance(camera_paths, dict):
+      camera_paths = {int(k.split('/')[-2]):k for k in camera_paths}
+
+    self._first_camera_idx = min(key for key, value in camera_paths.items() if value is not None)
     self._frame_readers = _FrameReaderDict(camera_paths, cache_paths, kwargs)
     self._frame_id_lookup = frame_id_lookup
 


### PR DESCRIPTION
**Description:** RouteFrameReader uses an array for camera_paths, so segment_num doesn't match the array indices unless all segments are present. Fixed by switching camera_paths to a dict.

**Verification:** Tested RouteFrameReader with unlogger on a route with most segments missing and confirmed that framereaders are looked up correctly based on segment_num and that _first_camera_idx gets set properly based on the segment_nums instead of array indices.