### PR TITLE
Support streaming in juggle.py

### DIFF
--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -1,6 +1,6 @@
 # PlotJuggler
 
-We've extended [PlotJuggler](https://github.com/facontidavide/PlotJuggler) to plot all of your openpilot logs. Check out our plugin: https://github.com/commaai/PlotJuggler.
+We've extended [PlotJuggler](https://github.com/facontidavide/PlotJuggler) to plot all of your openpilot logs. Check out our plugins: https://github.com/commaai/PlotJuggler.
 
 ## Installation
 
@@ -16,7 +16,7 @@ Usage requires an installation of PlotJuggler. On systems with snap (e.g. Ubuntu
 
 ```
 batman@z840-openpilot:~/openpilot/tools/plotjuggler$ ./juggle.py -h
-usage: juggle.py [-h] [--qlog] [--layout [LAYOUT]] [route_name] [segment_number]
+usage: juggle.py [-h] [--qlog] [--can] [--stream] [--layout [LAYOUT]] [route_name] [segment_number]
 
 PlotJuggler plugin for reading rlogs
 
@@ -27,12 +27,25 @@ positional arguments:
 optional arguments:
   -h, --help         show this help message and exit
   --qlog             Use qlogs (default: False)
+  --can              Parse CAN data (default: False)
+  --stream           Start PlotJuggler without a route to stream data using Cereal (default: False)
   --layout [LAYOUT]  Run PlotJuggler with a pre-defined layout (default: None)
 ```
 
 Example:
 
 `./juggle.py "0982d79ebb0de295|2021-01-17--17-13-08"`
+
+### Streaming
+
+To get started exploring and plotting data live in your car, you can start PlotJuggler in streaming mode via the command `./juggle.py --stream`.
+
+For this to work, you'll need a few things:
+- Start a Wi-Fi hotspot on your comma two and connect your laptop to it.
+- Run `export ZMQ=` which tells the streaming plugin backend to use ZMQ. If you're streaming locally, you can omit this step as ZMQ is used to transport data over the network.
+- Most importantly: openpilot by default uses the MSGQ backend, so you'll need to [ssh into your device](https://github.com/commaai/openpilot/wiki/SSH) and run bridge. This simply re-broadcasts each message over ZMQ: `./cereal/messaging/bridge`
+
+Now start PlotJuggler using the above `juggle.py` command, and find the `Cereal Subscriber` plugin in the dropdown under Streaming. Click Start and enter the IP address of the comma two. You should now be seeing all the messages for each [service in openpilot](https://github.com/commaai/cereal/blob/master/services.py) received live from your car!
 
 ## Demo:
 

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -47,7 +47,7 @@ For this to work, you'll need a few things:
 
 Now start PlotJuggler using the above `juggle.py` command, and find the `Cereal Subscriber` plugin in the dropdown under Streaming. Click Start and enter the IP address of the comma two. You should now be seeing all the messages for each [service in openpilot](https://github.com/commaai/cereal/blob/master/services.py) received live from your car!
 
-## Demo:
+## Demo
 
 For a quick demo, go through the installation step and run this command:
 

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -38,11 +38,11 @@ Example:
 
 ### Streaming
 
-To get started exploring and plotting data live in your car, you can start PlotJuggler in streaming mode via the command `./juggle.py --stream`.
+To get started exploring and plotting data live in your car, you can start PlotJuggler in streaming mode: `./juggle.py --stream`.
 
 For this to work, you'll need a few things:
-- Start a Wi-Fi hotspot on your comma two and connect your laptop to it.
-- Run `export ZMQ=` which tells the streaming plugin backend to use ZMQ. If you're streaming locally, you can omit this step as ZMQ is used to transport data over the network.
+- Enable tethering on your comma device and connect your laptop.
+- Run `export ZMQ=1` which tells the streaming plugin backend to use ZMQ. If you're streaming locally, you can omit this step as ZMQ is used to transport data over the network.
 - Most importantly: openpilot by default uses the MSGQ backend, so you'll need to [ssh into your device](https://github.com/commaai/openpilot/wiki/SSH) and run bridge. This simply re-broadcasts each message over ZMQ: `./cereal/messaging/bridge`
 
 Now start PlotJuggler using the above `juggle.py` command, and find the `Cereal Subscriber` plugin in the dropdown under Streaming. Click Start and enter the IP address of the comma two. You should now be seeing all the messages for each [service in openpilot](https://github.com/commaai/cereal/blob/master/services.py) received live from your car!

--- a/tools/plotjuggler/install.sh
+++ b/tools/plotjuggler/install.sh
@@ -7,6 +7,10 @@ wget https://github.com/commaai/PlotJuggler/releases/download/latest/libDataLoad
 tar -xf libDataLoadRlog.so.tar.gz
 rm libDataLoadRlog.so.tar.gz
 
+wget https://github.com/commaai/PlotJuggler/releases/download/latest/libDataStreamCereal.so.tar.gz
+tar -xf libDataStreamCereal.so.tar.gz
+rm libDataStreamCereal.so.tar.gz
+
 wget https://github.com/commaai/PlotJuggler/releases/download/latest/plotjuggler.tar.gz
 tar -xf plotjuggler.tar.gz
 rm plotjuggler.tar.gz

--- a/tools/plotjuggler/install.sh
+++ b/tools/plotjuggler/install.sh
@@ -3,14 +3,8 @@
 mkdir -p bin
 cd bin
 
-wget https://github.com/commaai/PlotJuggler/releases/download/latest/libDataLoadRlog.so.tar.gz
-tar -xf libDataLoadRlog.so.tar.gz
-rm libDataLoadRlog.so.tar.gz
-
-wget https://github.com/commaai/PlotJuggler/releases/download/latest/libDataStreamCereal.so.tar.gz
-tar -xf libDataStreamCereal.so.tar.gz
-rm libDataStreamCereal.so.tar.gz
-
-wget https://github.com/commaai/PlotJuggler/releases/download/latest/plotjuggler.tar.gz
-tar -xf plotjuggler.tar.gz
-rm plotjuggler.tar.gz
+for lib_name in libDataLoadRlog.so libDataStreamCereal.so plotjuggler; do
+  wget https://github.com/commaai/PlotJuggler/releases/download/latest/${lib_name}.tar.gz
+  tar -xf ${lib_name}.tar.gz
+  rm ${lib_name}.tar.gz
+done

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -24,23 +24,32 @@ def load_segment(segment_name):
     print(f"Error parsing {segment_name}: {e}")
     return []
 
-def juggle_file(fn, dbc=None, layout=None):
+def start_juggler(fn=None, dbc=None, layout=None):
   env = os.environ.copy()
   env["BASEDIR"] = BASEDIR
 
   if dbc:
     env["DBC_NAME"] = dbc
 
-  pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
-  extra_args = ""
+  extra_args = []
+  if fn is None:  # streaming
+    print("Select \"Cereal Subscriber\" in plugin list and click Start!")
+  else:
+    extra_args.append(f'-d {fn}')
+
   if layout is not None:
-    extra_args += f'-l {layout}'
-  subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} -d {fn} {extra_args}', shell=True, env=env, cwd=juggle_dir)
+    extra_args.append(f'-l {layout}')
+
+  extra_args = " ".join(extra_args)
+  pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
+  print(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}')
+  subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True, env=env, cwd=juggle_dir)
 
 def juggle_route(route_name, segment_number, qlog, can, stream, layout):
   has_route = route_name is not None
   if route_name is None and stream:
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
+    start_juggler()
     env = os.environ.copy()
     env["BASEDIR"] = BASEDIR  # TODO: use --can to enable can streaming and parsing
 
@@ -93,7 +102,7 @@ def juggle_route(route_name, segment_number, qlog, can, stream, layout):
   save_log(tempfile.name, all_data, compress=False)
   del all_data
 
-  juggle_file(tempfile.name, dbc, layout)
+  start_juggler(tempfile.name, dbc, layout)
 
 def get_arg_parser():
   parser = argparse.ArgumentParser(description="PlotJuggler plugin for reading rlogs",

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -33,10 +33,7 @@ def start_juggler(fn=None, dbc=None, layout=None):
     env["DBC_NAME"] = dbc
 
   extra_args = []
-  if fn is None:  # streaming, just start PJ
-    print("Select \"Cereal Subscriber\" in plugin list and click Start!")
-    print("Make sure to set environment variable `ZMQ` if needed")
-  else:
+  if fn is not None:  # if None, we're streaming
     extra_args.append(f'-d {fn}')
 
   if layout is not None:
@@ -46,9 +43,9 @@ def start_juggler(fn=None, dbc=None, layout=None):
   subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True, env=env, cwd=juggle_dir)
 
 def juggle_route(route_name, segment_number, qlog, can, stream, layout):
-  has_route = route_name is not None
   if route_name is None and stream:
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
+    print("Make sure to set environment variable `ZMQ` if needed")
     start_juggler()
     return
 

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -42,8 +42,8 @@ def start_juggler(fn=None, dbc=None, layout=None):
   extra_args = " ".join(extra_args)
   subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True, env=env, cwd=juggle_dir)
 
-def juggle_route(route_name, segment_number, qlog, can, layout):
-  if route_name is None:
+def juggle_route(route_name, segment_number, qlog, can, stream, layout):
+  if route_name is None and stream:
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
     print("Make sure to set the `ZMQ` environment variable if needed\n")
     start_juggler()
@@ -98,6 +98,7 @@ def get_arg_parser():
 
   parser.add_argument("--qlog", action="store_true", help="Use qlogs")
   parser.add_argument("--can", action="store_true", help="Parse CAN data")
+  parser.add_argument("--stream", action="store_true", help="Start PlotJuggler without a route to stream data using Cereal")
   parser.add_argument("--layout", nargs='?', help="Run PlotJuggler with a pre-defined layout")
   parser.add_argument("route_name", nargs='?', help="The name of the route that will be plotted.")
   parser.add_argument("segment_number", type=int, nargs='?', help="The index of the segment that will be plotted")
@@ -106,4 +107,4 @@ def get_arg_parser():
 if __name__ == "__main__":
   arg_parser = get_arg_parser()
   args = arg_parser.parse_args(sys.argv[1:])
-  juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.layout)
+  juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.stream, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -33,7 +33,7 @@ def start_juggler(fn=None, dbc=None, layout=None):
     env["DBC_NAME"] = dbc
 
   extra_args = []
-  if fn is not None:  # if None, we're streaming
+  if fn is not None:
     extra_args.append(f'-d {fn}')
 
   if layout is not None:

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -105,8 +105,5 @@ def get_arg_parser():
 
 if __name__ == "__main__":
   arg_parser = get_arg_parser()
-  if len(sys.argv) == 1:
-    arg_parser.print_help()
-    sys.exit()
   args = arg_parser.parse_args(sys.argv[1:])
   juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -106,8 +106,6 @@ if __name__ == "__main__":
   args = arg_parser.parse_args(sys.argv[1:])
 
   if args.stream:
-    print("Select \"Cereal Subscriber\" in plugin list and click Start!")
-    print("Make sure to set the `ZMQ` environment variable if needed\n")
     start_juggler()
   else:
     juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -27,13 +27,15 @@ def load_segment(segment_name):
 def start_juggler(fn=None, dbc=None, layout=None):
   env = os.environ.copy()
   env["BASEDIR"] = BASEDIR
+  pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
 
   if dbc:
     env["DBC_NAME"] = dbc
 
   extra_args = []
-  if fn is None:  # streaming
+  if fn is None:  # streaming, just start PJ
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
+    print("Make sure to set environment variable `ZMQ` if needed")
   else:
     extra_args.append(f'-d {fn}')
 
@@ -41,9 +43,6 @@ def start_juggler(fn=None, dbc=None, layout=None):
     extra_args.append(f'-l {layout}')
 
   extra_args = " ".join(extra_args)
-
-  pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
-  print(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}')
   subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True, env=env, cwd=juggle_dir)
 
 def juggle_route(route_name, segment_number, qlog, can, stream, layout):

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -37,7 +37,20 @@ def juggle_file(fn, dbc=None, layout=None):
     extra_args += f'-l {layout}'
   subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} -d {fn} {extra_args}', shell=True, env=env, cwd=juggle_dir)
 
-def juggle_route(route_name, segment_number, qlog, can, layout):
+def juggle_route(route_name, segment_number, qlog, can, stream, layout):
+  has_route = route_name is not None
+  if route_name is None and stream:
+    print("Select \"Cereal Subscriber\" in plugin list and click Start!")
+    env = os.environ.copy()
+    env["BASEDIR"] = BASEDIR  # TODO: use --can to enable can streaming and parsing
+
+    pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
+    extra_args = ""
+    if layout is not None:
+      extra_args += f'-l {layout}'
+    subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True,
+                    env=env, cwd=juggle_dir)
+    return
 
   if route_name.startswith("http://") or route_name.startswith("https://") or os.path.isfile(route_name):
     logs = [route_name]
@@ -88,6 +101,7 @@ def get_arg_parser():
 
   parser.add_argument("--qlog", action="store_true", help="Use qlogs")
   parser.add_argument("--can", action="store_true", help="Parse CAN data")
+  parser.add_argument("--stream", action="store_true", help="Start PlotJuggler without a route to stream data using Cereal")
   parser.add_argument("--layout", nargs='?', help="Run PlotJuggler with a pre-defined layout")
   parser.add_argument("route_name", nargs='?', help="The name of the route that will be plotted.")
   parser.add_argument("segment_number", type=int, nargs='?', help="The index of the segment that will be plotted")
@@ -99,4 +113,4 @@ if __name__ == "__main__":
     arg_parser.print_help()
     sys.exit()
   args = arg_parser.parse_args(sys.argv[1:])
-  juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.layout)
+  juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.stream, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -45,7 +45,7 @@ def start_juggler(fn=None, dbc=None, layout=None):
 def juggle_route(route_name, segment_number, qlog, can, stream, layout):
   if route_name is None and stream:
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
-    print("Make sure to set environment variable `ZMQ` if needed")
+    print("Make sure to set environment variable `ZMQ` if needed\n")
     start_juggler()
     return
 

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -41,6 +41,7 @@ def start_juggler(fn=None, dbc=None, layout=None):
     extra_args.append(f'-l {layout}')
 
   extra_args = " ".join(extra_args)
+
   pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
   print(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}')
   subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True, env=env, cwd=juggle_dir)
@@ -50,15 +51,6 @@ def juggle_route(route_name, segment_number, qlog, can, stream, layout):
   if route_name is None and stream:
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
     start_juggler()
-    env = os.environ.copy()
-    env["BASEDIR"] = BASEDIR  # TODO: use --can to enable can streaming and parsing
-
-    pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
-    extra_args = ""
-    if layout is not None:
-      extra_args += f'-l {layout}'
-    subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True,
-                    env=env, cwd=juggle_dir)
     return
 
   if route_name.startswith("http://") or route_name.startswith("https://") or os.path.isfile(route_name):

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -45,7 +45,7 @@ def start_juggler(fn=None, dbc=None, layout=None):
 def juggle_route(route_name, segment_number, qlog, can, layout):
   if route_name is None:
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
-    print("Make sure to set environment variable `ZMQ` if needed\n")
+    print("Make sure to set the `ZMQ` environment variable if needed\n")
     start_juggler()
     return
 

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -42,8 +42,8 @@ def start_juggler(fn=None, dbc=None, layout=None):
   extra_args = " ".join(extra_args)
   subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True, env=env, cwd=juggle_dir)
 
-def juggle_route(route_name, segment_number, qlog, can, stream, layout):
-  if route_name is None and stream:
+def juggle_route(route_name, segment_number, qlog, can, layout):
+  if route_name is None:
     print("Select \"Cereal Subscriber\" in plugin list and click Start!")
     print("Make sure to set environment variable `ZMQ` if needed\n")
     start_juggler()
@@ -98,7 +98,6 @@ def get_arg_parser():
 
   parser.add_argument("--qlog", action="store_true", help="Use qlogs")
   parser.add_argument("--can", action="store_true", help="Parse CAN data")
-  parser.add_argument("--stream", action="store_true", help="Start PlotJuggler without a route to stream data using Cereal")
   parser.add_argument("--layout", nargs='?', help="Run PlotJuggler with a pre-defined layout")
   parser.add_argument("route_name", nargs='?', help="The name of the route that will be plotted.")
   parser.add_argument("segment_number", type=int, nargs='?', help="The index of the segment that will be plotted")
@@ -110,4 +109,4 @@ if __name__ == "__main__":
     arg_parser.print_help()
     sys.exit()
   args = arg_parser.parse_args(sys.argv[1:])
-  juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.stream, args.layout)
+  juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -42,13 +42,7 @@ def start_juggler(fn=None, dbc=None, layout=None):
   extra_args = " ".join(extra_args)
   subprocess.call(f'{pj} --plugin_folders {os.path.join(juggle_dir, "bin")} {extra_args}', shell=True, env=env, cwd=juggle_dir)
 
-def juggle_route(route_name, segment_number, qlog, can, stream, layout):
-  if route_name is None and stream:
-    print("Select \"Cereal Subscriber\" in plugin list and click Start!")
-    print("Make sure to set the `ZMQ` environment variable if needed\n")
-    start_juggler()
-    return
-
+def juggle_route(route_name, segment_number, qlog, can, layout):
   if route_name.startswith("http://") or route_name.startswith("https://") or os.path.isfile(route_name):
     logs = [route_name]
   else:
@@ -110,4 +104,10 @@ if __name__ == "__main__":
     arg_parser.print_help()
     sys.exit()
   args = arg_parser.parse_args(sys.argv[1:])
-  juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.stream, args.layout)
+
+  if args.stream:
+    print("Select \"Cereal Subscriber\" in plugin list and click Start!")
+    print("Make sure to set the `ZMQ` environment variable if needed\n")
+    start_juggler()
+  else:
+    juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -106,5 +106,8 @@ def get_arg_parser():
 
 if __name__ == "__main__":
   arg_parser = get_arg_parser()
+  if len(sys.argv) == 1:
+    arg_parser.print_help()
+    sys.exit()
   args = arg_parser.parse_args(sys.argv[1:])
   juggle_route(args.route_name, args.segment_number, args.qlog, args.can, args.stream, args.layout)


### PR DESCRIPTION
When `--stream` is passed to juggle.py, it starts PlotJuggler without a route so you can select the Cereal Subscriber plugin and start streaming! Set the `ZMQ` environment variable to use ZMQ (via `export ZMQ=`), by default it uses MSGQ.