### PR TITLE
Remove snap installed PlotJuggler

### DIFF
--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -4,7 +4,7 @@ We've extended [PlotJuggler](https://github.com/facontidavide/PlotJuggler) to pl
 
 ## Installation
 
-Once you've cloned openpilot, download PlotJuggler and install our plugins with this command:
+Once you've cloned and are in openpilot, download PlotJuggler and install our plugins with this command:
 
 `cd tools/plotjuggler && ./install.sh`
 

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -4,13 +4,9 @@ We've extended [PlotJuggler](https://github.com/facontidavide/PlotJuggler) to pl
 
 ## Installation
 
-Once you've cloned openpilot, install our plugin with this command:
+Once you've cloned openpilot, download PlotJuggler and install our plugins with this command:
 
 `cd tools/plotjuggler && ./install.sh`
-
-Usage requires an installation of PlotJuggler. On systems with snap (e.g. Ubuntu), you can install PlotJuggler with this command:
-
- `sudo snap install plotjuggler`
 
 ## Usage
 
@@ -36,7 +32,7 @@ Example:
 
 `./juggle.py "0982d79ebb0de295|2021-01-17--17-13-08"`
 
-### Streaming
+## Streaming
 
 To get started exploring and plotting data live in your car, you can start PlotJuggler in streaming mode: `./juggle.py --stream`.
 

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -27,7 +27,7 @@ def load_segment(segment_name):
 def start_juggler(fn=None, dbc=None, layout=None):
   env = os.environ.copy()
   env["BASEDIR"] = BASEDIR
-  pj = os.getenv("PLOTJUGGLER_PATH", "plotjuggler")
+  pj = os.getenv("PLOTJUGGLER_PATH", os.path.join(juggle_dir, "bin/plotjuggler"))
 
   if dbc:
     env["DBC_NAME"] = dbc


### PR DESCRIPTION
*Temporarily. We want to open a PR to upstream PlotJuggler to allow access of files outside the plugin's cwd