### PR TITLE
VW MQB: Cleanup, prep for J533 gateway integration

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -229,12 +229,12 @@ class CarState(CarStateBase):
       checks += [("Motor_14", 10)]  # From J623 Engine control module
 
     # TODO: Detect ACC radar bus location
-    signals += MqbExtraSignals.fwd_radar[0]
-    checks += MqbExtraSignals.fwd_radar[1]
+    signals += MqbExtraSignals.fwd_radar_signals
+    checks += MqbExtraSignals.fwd_radar_checks
     # TODO: Detect BSM radar bus location
     if CP.enableBsm:
-      signals += MqbExtraSignals.bsm_radar[0]
-      checks += MqbExtraSignals.bsm_radar[1]
+      signals += MqbExtraSignals.bsm_radar_signals
+      checks += MqbExtraSignals.bsm_radar_checks
 
     return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.pt)
 
@@ -259,20 +259,22 @@ class CarState(CarStateBase):
 
 class MqbExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers
-  fwd_radar = ([
+  fwd_radar_signals = [
     ("ACC_Wunschgeschw", "ACC_02", 0),              # ACC set speed
     ("AWV2_Freigabe", "ACC_10", 0),                 # FCW brake jerk release
     ("ANB_Teilbremsung_Freigabe", "ACC_10", 0),     # AEB partial braking release
     ("ANB_Zielbremsung_Freigabe", "ACC_10", 0),     # AEB target braking release
-  ], [
+  ]
+  fwd_radar_checks = [
     ("ACC_10", 50),                                 # From J428 ACC radar control module
     ("ACC_02", 17),                                 # From J428 ACC radar control module
-  ])
-  bsm_radar = ([
+  ]
+  bsm_radar_signals = [
     ("SWA_Infostufe_SWA_li", "SWA_01", 0),          # Blind spot object info, left
     ("SWA_Warnung_SWA_li", "SWA_01", 0),            # Blind spot object warning, left
     ("SWA_Infostufe_SWA_re", "SWA_01", 0),          # Blind spot object info, right
     ("SWA_Warnung_SWA_re", "SWA_01", 0),            # Blind spot object warning, right
-  ], [
+  ]
+  bsm_radar_checks = [
     ("SWA_01", 20),                                 # From J1086 Lane Change Assist
-  ])
+  ]

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -214,7 +214,6 @@ class CarState(CarStateBase):
       ("Motor_14", 10),     # From J623 Engine control module
       ("Airbag_02", 5),     # From J234 Airbag control module
       ("Kombi_01", 2),      # From J285 Instrument cluster
-      ("Motor_16", 2),      # From J623 Engine control module
       ("Einheiten_01", 1),  # From J??? not known if gateway, cluster, or BCM
     ]
 

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -229,12 +229,12 @@ class CarState(CarStateBase):
       checks += [("Motor_14", 10)]  # From J623 Engine control module
 
     # TODO: Detect ACC radar bus location
-    signals += MqbExtraSignals.acc_radar[0]
-    checks += MqbExtraSignals.acc_radar[1]
+    signals += MqbExtraSignals.fwd_radar[0]
+    checks += MqbExtraSignals.fwd_radar[1]
     # TODO: Detect BSM radar bus location
     if CP.enableBsm:
-      signals += MqbExtraSignals.bsm[0]
-      checks += MqbExtraSignals.bsm[1]
+      signals += MqbExtraSignals.bsm_radar[0]
+      checks += MqbExtraSignals.bsm_radar[1]
 
     return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.pt)
 
@@ -259,7 +259,7 @@ class CarState(CarStateBase):
 
 class MqbExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers
-  acc_radar = ([
+  fwd_radar = ([
     ("ACC_Wunschgeschw", "ACC_02", 0),              # ACC set speed
     ("AWV2_Freigabe", "ACC_10", 0),                 # FCW brake jerk release
     ("ANB_Teilbremsung_Freigabe", "ACC_10", 0),     # AEB partial braking release
@@ -268,7 +268,7 @@ class MqbExtraSignals:
     ("ACC_10", 50),                                 # From J428 ACC radar control module
     ("ACC_02", 17),                                 # From J428 ACC radar control module
   ])
-  bsm = ([
+  bsm_radar = ([
     ("SWA_Infostufe_SWA_li", "SWA_01", 0),          # Blind spot object info, left
     ("SWA_Warnung_SWA_li", "SWA_01", 0),            # Blind spot object warning, left
     ("SWA_Infostufe_SWA_re", "SWA_01", 0),          # Blind spot object info, right

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -256,7 +256,7 @@ class CarState(CarStateBase):
       ("LDW_02", 10)        # From R242 Driver assistance camera
     ]
 
-    return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.cam, enforce_checks=False)
+    return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, CANBUS.cam)
 
 class MqbExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -228,7 +228,7 @@ class CarState(CarStateBase):
                   ("BCM1_Rueckfahrlicht_Schalter", "Gateway_72", 0)]  # Reverse light from BCM
       checks += [("Motor_14", 10)]  # From J623 Engine control module
 
-    # TODO: Detect ACC radar presence and bus location
+    # TODO: Detect ACC radar bus location
     signals += MqbExtraSignals.acc_radar[0]
     checks += MqbExtraSignals.acc_radar[1]
     # TODO: Detect BSM radar bus location


### PR DESCRIPTION
**Diff reduction with the VW Community Port**

Preparatory refactor for gateway integration: rearrange the ACC and BSM radar signal and message lists, such that we can add them to either (or neither) bus as circumstances dictate.

Remove unused signal `TSK_Fahrzeugmasse_02` and its associated check `Motor_16`.

Touch up some other signal and message comments.