### PR TITLE
VW MQB: Add manumatic to allowed openpilot gears

### DIFF
--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -152,7 +152,7 @@ class CarInterface(CarInterfaceBase):
         be.pressed = self.CS.buttonStates[button]
         buttonEvents.append(be)
 
-    events = self.create_common_events(ret, extra_gears=[GearShifter.eco, GearShifter.sport])
+    events = self.create_common_events(ret, extra_gears=[GearShifter.eco, GearShifter.sport, GearShifter.manumatic])
 
     # Vehicle health and operation safety checks
     if self.CS.parkingBrakeSet:


### PR DESCRIPTION
VW stock ACC allows use of Tiptronic (manumatic shifting) gears. It doesn't make a ton of sense to do so, but it's allowed. I get a fair number of complaints that openpilot doesn't allow it.

It's not because people want to drive that way, but because it's easy to accidentally bump a steering-wheel paddle-shifter. Ordinarily that would just bump you up-or-down a gear for a few seconds, and then automatically revert to Drive/Sport/Eco. However, if you do so while openpilot is engaged, it throws a spectacular audiovisual tantrum to warn you of impending doom.

Go ahead and permit manumatic as an openpilot gear for VW MQB. This might get revisited (perhaps a softer alert?) when I implement openpilot long control on MQB.