### PR TITLE
INDI use limited torque of CC.apply_last_steer

### DIFF
--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -50,7 +50,7 @@ class CarInterface(CarInterfaceBase):
     ret.tireStiffnessFront, ret.tireStiffnessRear = scale_tire_stiffness(ret.mass, ret.wheelbase, ret.centerToFront)
 
     ret.enableCamera = True
-    
+
     ret.enableBsm = 720 in fingerprint[0]
 
     return ret
@@ -77,9 +77,7 @@ class CarInterface(CarInterfaceBase):
 
     ret.events = events.to_msg()
 
-    # copy back carState packet to CS
     self.CS.out = ret.as_reader()
-
     return self.CS.out
 
   # pass in a car.CarControl

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -171,9 +171,7 @@ class CarInterface(CarInterfaceBase):
 
     ret.events = events.to_msg()
 
-    # copy back carState packet to CS
     self.CS.out = ret.as_reader()
-
     return self.CS.out
 
   def apply(self, c):

--- a/selfdrive/car/mock/carstate.py
+++ b/selfdrive/car/mock/carstate.py
@@ -1,0 +1,7 @@
+from selfdrive.car.interfaces import CarStateBase
+
+class CarState(CarStateBase):
+
+  @staticmethod
+  def get_can_parser(CP):
+    return None

--- a/selfdrive/car/mock/interface.py
+++ b/selfdrive/car/mock/interface.py
@@ -84,7 +84,8 @@ class CarInterface(CarInterfaceBase):
     curvature = self.yaw_rate / max(self.speed, 1.)
     ret.steeringAngleDeg = curvature * self.CP.steerRatio * self.CP.wheelbase * CV.RAD_TO_DEG
 
-    return ret.as_reader()
+    self.CS.out = ret.as_reader()
+    return self.CS.out
 
   def apply(self, c):
     # in mock no carcontrols

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -444,7 +444,7 @@ class Controls:
     actuators.gas, actuators.brake = self.LoC.update(self.active, CS, v_acc_sol, long_plan.vTargetFuture, a_acc_sol, self.CP)
 
     # Steering PID loop and lateral MPC
-    actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(self.active, CS, self.CP, self.VM, params, lat_plan)
+    actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(self.active, self.CI, self.VM, params, lat_plan)
 
     # Check for difference between desired angle and angle for angle based control
     angle_control_saturated = self.CP.steerControlType == car.CarParams.SteerControlType.angle and \

--- a/selfdrive/controls/lib/latcontrol_angle.py
+++ b/selfdrive/controls/lib/latcontrol_angle.py
@@ -9,7 +9,8 @@ class LatControlAngle():
   def reset(self):
     pass
 
-  def update(self, active, CS, CP, VM, params, lat_plan):
+  def update(self, active, CI, VM, params, lat_plan):
+    CS = CI.CS.out
     angle_log = log.ControlsState.LateralAngleState.new_message()
 
     if CS.vEgo < 0.3 or not active:

--- a/selfdrive/controls/lib/latcontrol_lqr.py
+++ b/selfdrive/controls/lib/latcontrol_lqr.py
@@ -44,7 +44,9 @@ class LatControlLQR():
 
     return self.sat_count > self.sat_limit
 
-  def update(self, active, CS, CP, VM, params, lat_plan):
+  def update(self, active, CI, VM, params, lat_plan):
+    CP = CI.CP
+    CS = CI.CS.out
     lqr_log = log.ControlsState.LateralLQRState.new_message()
 
     steers_max = get_steer_max(CP, CS.vEgo)

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -15,7 +15,9 @@ class LatControlPID():
   def reset(self):
     self.pid.reset()
 
-  def update(self, active, CS, CP, VM, params, lat_plan):
+  def update(self, active, CI, VM, params, lat_plan):
+    CP = CI.CP
+    CS = CI.CS.out
     pid_log = log.ControlsState.LateralPIDState.new_message()
     pid_log.steeringAngleDeg = float(CS.steeringAngleDeg)
     pid_log.steeringRateDeg = float(CS.steeringRateDeg)


### PR DESCRIPTION
**Description** 

Start with `selfdrive/controls/lib/latcontrol_indi.py` :
INDI for Toyota uses locally-applied torque and torque rate limits, by importing Toyota specific code. This is useful for any car. Adding CarInterface to all the lateral controller's update() signatures gives access to CarController's apply_last_steer and params.STEER_MAX, used to scale back to [-1,1] output. So, the exact torque-limited steer output is available to the INDI controller regardless of control frequency or unique torque-limit methods.

This was useful to me because GM steer control is 50 Hz, and it's tricky to apply the same rate limits at 100 Hz after rounding and all.

To use CS.out and pass unit tests, we add CS.out to Mock CarInterface.update() and CarState, and clean up Chrysler and GM to match style of all other makes.

**Verification**
* Process replay for Toyota Prius (INDI) proves no change to actuation - right?
* In use for Volt INDI tuning.