### PR TITLE
VW MQB: Škoda Octavia Mk3

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Community Maintained Cars and Features
 | Nissan    | X-Trail 2017                  | ProPILOT          | Stock            | 0mph               | 0mph         |
 | SEAT      | Ateca 2018                    | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Kodiaq 2018                   | Driver Assistance | Stock            | 0mph               | 0mph         |
+| Škoda     | Octavia 2015, 2019            | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Scala 2020                    | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Superb 2015-18                | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Subaru    | Ascent 2019                   | EyeSight          | Stock            | 0mph               | 0mph         |

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -97,6 +97,11 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1569 + STD_CARGO_KG
       ret.wheelbase = 2.79
 
+    elif candidate == CAR.SKODA_OCTAVIA_MK3:
+      # Averages of all 5E/NE Octavia variants
+      ret.mass = 1388 + STD_CARGO_KG
+      ret.wheelbase = 2.68
+
     elif candidate == CAR.SKODA_SCALA_MK1:
       # Averages of all NW Scala variants
       ret.mass = 1192 + STD_CARGO_KG

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -65,6 +65,7 @@ class CAR:
   SKODA_KODIAQ_MK1 = "SKODA KODIAQ 1ST GEN"   # Chassis NS, Mk1 Skoda Kodiaq
   SKODA_SCALA_MK1 = "SKODA SCALA 1ST GEN"     # Chassis NW, Mk1 Skoda Scala and Skoda Kamiq
   SKODA_SUPERB_MK3 = "SKODA SUPERB 3RD GEN"   # Chassis 3V/NP, Mk3 Skoda Superb and variants
+  SKODA_OCTAVIA_MK3 = "SKODA OCTAVIA 3RD GEN" # Chassis NE, Mk3 Skoda Octavia and variants
 
 FINGERPRINTS = {
   CAR.ATLAS_MK1: [{
@@ -376,6 +377,28 @@ FW_VERSIONS = {
       b'\xf1\x872Q0907572Q \xf1\x890342',
     ],
   },
+  CAR.SKODA_OCTAVIA_MK3: {
+    (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x8704E906027HD\xf1\x893742',
+      b'\xf1\x8704L906021DT\xf1\x898127',
+    ],
+    (Ecu.transmission, 0x7e1, None): [
+      b'\xf1\x870CW300043B \xf1\x891601',
+      b'\xf1\x870D9300041P \xf1\x894507',
+    ],
+    (Ecu.srs, 0x715, None): [
+      b'\xf1\x873Q0959655AC\xf1\x890200\xf1\x82\r11120011100010022212110200',
+      b'\xf1\x873Q0959655CN\xf1\x890720\xf1\x82\x0e3221003221002105755331052100',
+    ],
+    (Ecu.eps, 0x712, None): [
+      b'\xf1\x875Q0909144AB\xf1\x891082\xf1\x82\x0521T00403A1',
+      b'\xf1\x875Q0909144R \xf1\x891061\xf1\x82\x0516A00604A1',
+    ],
+    (Ecu.fwdRadar, 0x757, None): [
+      b'\xf1\x875Q0907572D \xf1\x890304\xf1\x82\x0101',
+      b'\xf1\x875Q0907572P \xf1\x890682',
+    ],
+  },
   CAR.SKODA_SCALA_MK1: {
     (Ecu.engine, 0x7e0, None): [
       b'\xf1\x8704C906025AK\xf1\x897053',
@@ -430,6 +453,7 @@ DBC = {
   CAR.AUDI_A3_MK3: dbc_dict('vw_mqb_2010', None),
   CAR.SEAT_ATECA_MK1: dbc_dict('vw_mqb_2010', None),
   CAR.SKODA_KODIAQ_MK1: dbc_dict('vw_mqb_2010', None),
+  CAR.SKODA_OCTAVIA_MK3: dbc_dict('vw_mqb_2010', None),
   CAR.SKODA_SCALA_MK1: dbc_dict('vw_mqb_2010', None),
   CAR.SKODA_SUPERB_MK3: dbc_dict('vw_mqb_2010', None),
 }

--- a/selfdrive/test/test_routes.py
+++ b/selfdrive/test/test_routes.py
@@ -442,6 +442,10 @@ routes: dict = {
     'carFingerprint': VOLKSWAGEN.SKODA_KODIAQ_MK1,
     'enableCamera': True,
   },
+  "66e5edc3a16459c5|2021-05-25--19-00-29": {
+    'carFingerprint': VOLKSWAGEN.SKODA_OCTAVIA_MK3,
+    'enableCamera': True,
+  },
   "026b6d18fba6417f|2021-03-26--09-17-04": {
     'carFingerprint': VOLKSWAGEN.SKODA_SCALA_MK1,
     'enableCamera': True,

--- a/selfdrive/test/test_routes.py
+++ b/selfdrive/test/test_routes.py
@@ -442,6 +442,10 @@ routes: dict = {
     'carFingerprint': VOLKSWAGEN.SKODA_KODIAQ_MK1,
     'enableCamera': True,
   },
+  "66e5edc3a16459c5|2021-05-23--23-44-46": {
+    'carFingerprint': VOLKSWAGEN.SKODA_OCTAVIA_MK3,
+    'enableCamera': True,
+  },
   "026b6d18fba6417f|2021-03-26--09-17-04": {
     'carFingerprint': VOLKSWAGEN.SKODA_SCALA_MK1,
     'enableCamera': True,

--- a/selfdrive/test/test_routes.py
+++ b/selfdrive/test/test_routes.py
@@ -442,10 +442,6 @@ routes: dict = {
     'carFingerprint': VOLKSWAGEN.SKODA_KODIAQ_MK1,
     'enableCamera': True,
   },
-  "66e5edc3a16459c5|2021-05-23--23-44-46": {
-    'carFingerprint': VOLKSWAGEN.SKODA_OCTAVIA_MK3,
-    'enableCamera': True,
-  },
   "026b6d18fba6417f|2021-03-26--09-17-04": {
     'carFingerprint': VOLKSWAGEN.SKODA_SCALA_MK1,
     'enableCamera': True,


### PR DESCRIPTION
**Škoda Octavia Mk3**

Covers all variants of the third generation Octavia (2013-2019).

- [x] added to README
- [x] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_models.py)
- [x] route with openpilot: 66e5edc3a16459c5|2021-05-25--19-00-29

Thanks to community Octavia owners cben (2015) and some friend of Saber422's (2019).