### PR TITLE
Fix broken relative URL in car port PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/car_port.md
+++ b/.github/PULL_REQUEST_TEMPLATE/car_port.md
@@ -9,6 +9,6 @@ assignees: ''
 **Checklist**
 
 - [ ] added to README
-- [ ] test route added to [test_routes.py](../../selfdrive/test/test_routes.py)
+- [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_models.py)
 - [ ] route with openpilot:
 - [ ] route with stock system:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ Route: [a route with the bug fix]
 
 **Checklist**
 - [ ] added to README
-- [ ] test route added to [test_routes.py](../../selfdrive/test/test_routes.py)
+- [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_models.py)
 - [ ] route with openpilot:
 - [ ] route with stock system:
 


### PR DESCRIPTION
**Description**

The car port PR template uses a relative URL to point to test_models.py. It happens to work when you're [looking at the PR template](https://github.com/commaai/openpilot/blob/master/.github/PULL_REQUEST_TEMPLATE/car_port.md), but not for the opened PR, because the base URL is different. Change it to an absolute URL.

**Verification**

Link is NFG in my recent car port PRs, example #20881. Changed it by hand in my most recent PR #21013.