### PR TITLE
Compute on-road screen brightness based on camera exposure

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -179,7 +179,7 @@ static void update_state(UIState *s) {
     for (auto sensor : sm["sensorEvents"].getSensorEvents()) {
       // Use light sensor when offroad, camera exposure when onroad
       if (!scene.started && Hardware::EON() && sensor.which() == cereal::SensorEventData::LIGHT) {
-        scene.light_sensor = std::clamp<float>(sensor.getLight(), 0.0, 1023.0);
+        scene.light_sensor = std::clamp<float>(10.0 * sensor.getLight(), 0.0, 1023.0);
       }
       if (!scene.started && sensor.which() == cereal::SensorEventData::ACCELERATION) {
         auto accel = sensor.getAcceleration().getV();
@@ -322,7 +322,7 @@ void QUIState::update() {
 
 Device::Device(QObject *parent) : brightness_filter(BACKLIGHT_OFFROAD, BACKLIGHT_TS, BACKLIGHT_DT), QObject(parent) {
   brightness_b = Params(true).get<float>("BRIGHTNESS_B").value_or(10.0);
-  brightness_m = Params(true).get<float>("BRIGHTNESS_M").value_or(0.1);
+  brightness_m = Params(true).get<float>("BRIGHTNESS_M").value_or(2.6) / 26.0;
 }
 
 void Device::update(const UIState &s) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -16,7 +16,7 @@
 
 #define BACKLIGHT_DT 0.25
 #define BACKLIGHT_TS 2.00
-#define BACKLIGHT_OFFROAD 50
+#define BACKLIGHT_OFFROAD 75
 
 
 // Projects a point in car to space to the corresponding point in full frame

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -194,10 +194,10 @@ static void update_state(UIState *s) {
     auto camera_state = sm["roadCameraState"].getRoadCameraState();
     if (Hardware::EON()) {
       float gain = camera_state.getGainFrac();
-      scene.light_sensor = std::clamp<float>((1023.0 / 5408.0) * (5408.0 - camera_state.getIntegLines()) * (1.0 - gain), 0.0, 1023.0);
+      scene.light_sensor = std::clamp<float>((1023.0 / 5408.0) * (5408.0 - camera_state.getIntegLines() * gain), 0.0, 1023.0);
     } else if (Hardware::TICI()) {
       float gain = camera_state.getGainFrac() * (camera_state.getGlobalGain() > 100 ? 2.5 : 1.0) / 10.0;
-      scene.light_sensor = std::clamp<float>((1023.0 / 1757.0) * (1757.0 - camera_state.getIntegLines()) * (1.0 - gain), 0.0, 1023.0);
+      scene.light_sensor = std::clamp<float>((1023.0 / 1757.0) * (1757.0 - camera_state.getIntegLines() * gain), 0.0, 1023.0);
     }
   }
   scene.started = sm["deviceState"].getDeviceState().getStarted() || scene.driver_view;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -193,8 +193,7 @@ static void update_state(UIState *s) {
   if (sm.updated("roadCameraState")) {
     auto camera_state = sm["roadCameraState"].getRoadCameraState();
 
-    // Theoretical maximum, EON: 5408, TICI: 1757
-    float max_lines = Hardware::EON() ? 5408 : 1757; // TICI: 1757
+    float max_lines = Hardware::EON() ? 5408 : 1757;
     float gain = camera_state.getGainFrac();
 
     if (Hardware::TICI()) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -177,10 +177,6 @@ static void update_state(UIState *s) {
   }
   if (sm.updated("sensorEvents")) {
     for (auto sensor : sm["sensorEvents"].getSensorEvents()) {
-      // Use light sensor when offroad, camera exposure when onroad
-      if (!scene.started && Hardware::EON() && sensor.which() == cereal::SensorEventData::LIGHT) {
-        scene.light_sensor = std::clamp<float>(10.0 * sensor.getLight(), 0.0, 1023.0);
-      }
       if (!scene.started && sensor.which() == cereal::SensorEventData::ACCELERATION) {
         auto accel = sensor.getAcceleration().getV();
         if (accel.totalSize().wordCount){ // TODO: sometimes empty lists are received. Figure out why
@@ -348,7 +344,7 @@ void Device::setAwake(bool on, bool reset) {
 
 void Device::updateBrightness(const UIState &s) {
   float clipped_brightness = std::min(100.0f, (s.scene.light_sensor * brightness_m) + brightness_b);
-  if (Hardware::TICI() && !s.scene.started) {
+  if (!s.scene.started) {
     clipped_brightness = BACKLIGHT_OFFROAD;
   }
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_models.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
