### PR TITLE
adding pqtimebomb bypass

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -56,6 +56,10 @@ class CarController():
       # commanding HCA if there's a fault, so the steering rack recovers.
       if enabled and not (CS.out.standstill or CS.steeringFault):
 
+        #STUFF FOR PQTIMEBOMB BYPASS
+        if CS.out.stopSteering:
+          apply_steer = 0
+
         # FAULT AVOIDANCE: Requested HCA torque must not exceed 3.0 Nm. This
         # is inherently handled by scaling to STEER_MAX. The rack doesn't seem
         # to care about up/down rate, but we have some evidence it may do its

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -479,6 +479,38 @@ EVENTS: Dict[int, Dict[str, Union[Alert, Callable[[Any, messaging.SubMaster, boo
       Priority.LOW, VisualAlert.steerRequired, AudibleAlert.chimePrompt, 1., 1., 1.),
   },
 
+  EventName.pqTimebombWarn: {
+    ET.WARNING: Alert(
+      "WARNING",
+      "Grab wheel to start bypass",
+      AlertStatus.normal, AlertSize.mid,
+      Priority.LOW, VisualAlert.steerRequired, AudibleAlert.chimePrompt, 1., 2., 3., alert_rate=0.75),
+  },
+  
+  EventName.pqTimebombBypassing: {
+    ET.WARNING: Alert(
+      "BYPASSING",
+      "HOLD WHEEL",
+      AlertStatus.userPrompt, AlertSize.mid,
+      Priority.LOW, VisualAlert.steerRequired, AudibleAlert.none, 1., 2., 3.),
+  },
+  
+  EventName.pqTimebombBypassed: {
+    ET.WARNING: Alert(
+      "Bypassed!",
+      "Release wheel when ready",
+      AlertStatus.normal, AlertSize.mid,
+      Priority.LOW, VisualAlert.steerRequired, AudibleAlert.none, 1., 2., 3.),
+  },
+  
+  EventName.pqTimebombTERMINAL: {
+    ET.WARNING: Alert(
+      "TIMEBOMB IMMINENT",
+      "Grab wheel now!",
+      AlertStatus.critical, AlertSize.full,
+      Priority.HIGH, VisualAlert.steerRequired, AudibleAlert.chimeWarningRepeat, .1, .1, .1),
+  },
+
   EventName.fanMalfunction: {
     ET.PERMANENT: NormalPermanentAlert("Fan Malfunction", "Contact Support"),
   },


### PR DESCRIPTION
So I couldnt figure out how to update the dang cereal submodule
Just add this:
`	
    pqTimebombWarn @99;
    pqTimebombBypassing @100;
    pqTimebombBypassed @101;
    pqTimebombTERMINAL @102;`
into the "enum EventName @0xbaa8c5d505f727de {" list

NOTE: This code does NOT differenciate between a PQ and an MQB vehicle!! So you will get the grab wheel message on both PQ and MQB as this code sits!

What this code does:
It starts a counter once you engage OP
Once this counter reaches its time limit it prompts for the driver to grab the wheel, once the driver grabs the wheel it shuts **off** HCA for 1.05 seconds. If the driver does NOT grab the wheel in time it will sound an alarm "TERMINAL" and do the bypass automagically. This is to prevent OP from hitting the timebomb rendering OP steering helpless and useless until you manually disengage and re-engage

It is worth noting, if you do hit the timebomb you must wait 2-3 seconds before sending HCA commands again. However not sending HCA commands for 1.05 seconds any time BEFORE the timebomb resets the counter.

The value for the timebomb on the steering rack is 360, 6 minutes.

Here is the car.capnp file to go along with this commit, as again I could not noodle out the submodule
[car.capnp.zip](https://github.com/commaai/openpilot/files/6543411/car.capnp.zip)

