### PR TITLE
UI: add update in settings

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -239,6 +239,7 @@ UpdateResult::UpdateResult(QWidget* parent) : QFrame(parent) {
   rebootBtn.setVisible(false);
   layout->addWidget(&rebootBtn, 0, Qt::AlignRight);
   QObject::connect(&rebootBtn, &QPushButton::released, [=]() { Hardware::reboot(); });
+  QObject::connect(parent, SIGNAL(offroadTransition(bool)), &rebootBtn, SLOT(setEnabled(bool)));
 
   setLayout(layout);
   setStyleSheet(R"(
@@ -295,7 +296,7 @@ UpdatePanel::UpdatePanel(QWidget* parent) : QWidget(parent) {
   QObject::connect(parent, SIGNAL(offroadTransition(bool)), downloadUpdateBtn, SLOT(setEnabled(bool)));
   update_layout->addWidget(downloadUpdateBtn);
 
-  updateResult = new UpdateResult();
+  updateResult = new UpdateResult(parent);
   updateResult->setVisible(false);
   update_layout->addWidget(updateResult);
 
@@ -313,7 +314,7 @@ UpdatePanel::UpdatePanel(QWidget* parent) : QWidget(parent) {
   QObject::connect(parent, SIGNAL(offroadTransition(bool)), viewReleaseNoteBtn, SLOT(setEnabled(bool)));
   update_layout->addWidget(viewReleaseNoteBtn);
 
-  releaseNotes = new ReleaseNotes();
+  releaseNotes = new ReleaseNotes(parent);
   releaseNotes->setVisible(false);
   update_layout->addWidget(releaseNotes);
 

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -9,6 +9,7 @@
 #include <QTimer>
 #include <QWidget>
 
+#include "selfdrive/ui/qt/widgets/scrollview.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
 
 // ********** settings window + top-level panels **********
@@ -25,6 +26,29 @@ class TogglesPanel : public QWidget {
   Q_OBJECT
 public:
   explicit TogglesPanel(QWidget *parent = nullptr);
+};
+
+class ReleaseNotes : public QFrame {
+  Q_OBJECT
+
+public:
+  explicit ReleaseNotes(QWidget *parent = 0);
+
+private:
+  Params params;
+
+  QLabel releaseNotes;
+  ScrollView *releaseNotesScroll;
+};
+
+class UpdatePanel : public QWidget {
+  Q_OBJECT
+public:
+  explicit UpdatePanel(QWidget *parent = nullptr);
+
+private:
+  ReleaseNotes* releaseNotes;
+  ButtonControl* viewReleaseNoteBtn; 
 };
 
 class DeveloperPanel : public QFrame {

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -45,18 +45,22 @@ class UpdateResult : public QFrame {
 
 public:
   explicit UpdateResult(QWidget *parent = 0);
-  QPushButton rebootBtn;
-  QLabel result;
+  void setText(const QString &text) { result.setText(text); }
+  void setBtnVisible(bool visible) { rebootBtn.setVisible(visible); }
 
 private:
   Params params;
   ScrollView *resultScroll;
+  QLabel result;
+  QPushButton rebootBtn;
 };
 
 class UpdatePanel : public QWidget {
   Q_OBJECT
 public:
   explicit UpdatePanel(QWidget *parent = nullptr);
+  void closeReleaseNote();
+  void closeDownloadUpdate();
 
 private slots:
   void refreshUpdate();
@@ -70,6 +74,7 @@ private:
   std::string updateFailedCount;
   std::string lastUpdate;
   QTimer *timer;
+  bool isDownloading = false;
 };
 
 class DeveloperPanel : public QFrame {

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -36,9 +36,21 @@ public:
 
 private:
   Params params;
-
   QLabel releaseNotes;
   ScrollView *releaseNotesScroll;
+};
+
+class UpdateResult : public QFrame {
+  Q_OBJECT
+
+public:
+  explicit UpdateResult(QWidget *parent = 0);
+  QPushButton rebootBtn;
+  QLabel result;
+
+private:
+  Params params;
+  ScrollView *resultScroll;
 };
 
 class UpdatePanel : public QWidget {
@@ -46,9 +58,18 @@ class UpdatePanel : public QWidget {
 public:
   explicit UpdatePanel(QWidget *parent = nullptr);
 
+private slots:
+  void refreshUpdate();
+
 private:
   ReleaseNotes* releaseNotes;
+  UpdateResult* updateResult;
   ButtonControl* viewReleaseNoteBtn; 
+  ButtonControl* downloadUpdateBtn;
+  Params params;
+  std::string updateFailedCount;
+  std::string lastUpdate;
+  QTimer *timer;
 };
 
 class DeveloperPanel : public QFrame {


### PR DESCRIPTION
Addressing #20983

This currently adds a new Panel in the settings but could be changed if you want.

Because of how updated.py is currently made, sending a SIGHUP will trigger a full fetch and not just a quick update check, hence why it is a Download and not just check for updates.

Currently the timer to check the status of the update (in progress, done, error, unavailable) is set at every 5 secondes but could be changed.

Since updated is not enabled on PC, you must edit process_config.py in order to test/use the Download feature on PC.

This is a design tentative. Let me know if something is wrong/bad with any of this.

![main](https://user-images.githubusercontent.com/27537531/119601816-f448ab00-bdb7-11eb-8adf-a2785fba5edf.png)
![notes](https://user-images.githubusercontent.com/27537531/119601817-f448ab00-bdb7-11eb-8677-63e6f24290fa.png)
![updates](https://user-images.githubusercontent.com/27537531/119601819-f448ab00-bdb7-11eb-97f9-ff843d2f06af.png)
![no_updates](https://user-images.githubusercontent.com/27537531/119601818-f448ab00-bdb7-11eb-88b6-b22374808f68.png)
![checking](https://user-images.githubusercontent.com/27537531/119601815-f3b01480-bdb7-11eb-91fa-56a8e27ef6e1.png)