### PR TITLE
Update CI tests for CAN fingerprinting deprecation

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -2,7 +2,7 @@ import os
 from common.params import Params
 from common.basedir import BASEDIR
 from selfdrive.version import comma_remote, tested_branch
-from selfdrive.car.fingerprints import eliminate_incompatible_cars, all_known_cars
+from selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 from selfdrive.car.vin import get_vin, VIN_UNKNOWN
 from selfdrive.car.fw_versions import get_fw_versions, match_fw_to_car
 from selfdrive.swaglog import cloudlog
@@ -115,7 +115,7 @@ def fingerprint(logcan, sendcan):
   Params().put("CarVin", vin)
 
   finger = gen_empty_fingerprint()
-  candidate_cars = {i: all_known_cars() for i in [0, 1]}  # attempt fingerprint on both bus 0 and 1
+  candidate_cars = {i: all_legacy_fingerprint_cars() for i in [0, 1]}  # attempt fingerprint on both bus 0 and 1
   frame = 0
   frame_fingerprint = 10  # 0.1s
   car_fingerprint = None

--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -70,6 +70,11 @@ def eliminate_incompatible_cars(msg, candidate_cars):
   return compatible_cars
 
 
-def all_known_cars():
-  """Returns a list of all known car strings."""
+def all_legacy_fingerprint_cars():
+  """Returns a list of all known car strings, FPv1 only."""
   return list(_FINGERPRINTS.keys())
+
+
+def all_known_cars():
+  """Returns a list of all known car strings, FPv1 and FPv2."""
+  return list({*FW_VERSIONS.keys(), *_FINGERPRINTS.keys()})

--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -70,11 +70,11 @@ def eliminate_incompatible_cars(msg, candidate_cars):
   return compatible_cars
 
 
+def all_known_cars():
+  """Returns a list of all known car strings."""
+  return list({*FW_VERSIONS.keys(), *_FINGERPRINTS.keys()})
+
+
 def all_legacy_fingerprint_cars():
   """Returns a list of all known car strings, FPv1 only."""
   return list(_FINGERPRINTS.keys())
-
-
-def all_known_cars():
-  """Returns a list of all known car strings. """
-  return list({*FW_VERSIONS.keys(), *_FINGERPRINTS.keys()})

--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -76,5 +76,5 @@ def all_legacy_fingerprint_cars():
 
 
 def all_known_cars():
-  """Returns a list of all known car strings, FPv1 and FPv2."""
+  """Returns a list of all known car strings. """
   return list({*FW_VERSIONS.keys(), *_FINGERPRINTS.keys()})

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -6,14 +6,17 @@ from parameterized import parameterized
 from cereal import car
 from selfdrive.car.fingerprints import all_known_cars
 from selfdrive.car.car_helpers import interfaces
-from selfdrive.car.fingerprints import _FINGERPRINTS as FINGERPRINTS, FW_VERSIONS
+from selfdrive.car.fingerprints import _FINGERPRINTS as FINGERPRINTS
 
 class TestCarInterfaces(unittest.TestCase):
 
   @parameterized.expand([(car,) for car in all_known_cars()])
   def test_car_interfaces(self, car_name):
     print(car_name)
-    fingerprint = FINGERPRINTS[car_name][0]
+    if car_name in FINGERPRINTS:
+      fingerprint = FINGERPRINTS[car_name][0]
+    else:
+      fingerprint = {}
 
     CarInterface, CarController, CarState = interfaces[car_name]
     fingerprints = {

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -6,7 +6,7 @@ from parameterized import parameterized
 from cereal import car
 from selfdrive.car.fingerprints import all_known_cars
 from selfdrive.car.car_helpers import interfaces
-from selfdrive.car.fingerprints import _FINGERPRINTS as FINGERPRINTS
+from selfdrive.car.fingerprints import _FINGERPRINTS as FINGERPRINTS, FW_VERSIONS
 
 class TestCarInterfaces(unittest.TestCase):
 

--- a/selfdrive/debug/show_matching_cars.py
+++ b/selfdrive/debug/show_matching_cars.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-from selfdrive.car.fingerprints import eliminate_incompatible_cars, all_known_cars
+from selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 import cereal.messaging as messaging
 
 
 # rav4 2019 and corolla tss2
 fingerprint = {896: 8, 898: 8, 900: 6, 976: 1, 1541: 8, 902: 6, 905: 8, 810: 2, 1164: 8, 1165: 8, 1166: 8, 1167: 8, 1552: 8, 1553: 8, 1556: 8, 1571: 8, 921: 8, 1056: 8, 544: 4, 1570: 8, 1059: 1, 36: 8, 37: 8, 550: 8, 935: 8, 552: 4, 170: 8, 812: 8, 944: 8, 945: 8, 562: 6, 180: 8, 1077: 8, 951: 8, 1592: 8, 1076: 8, 186: 4, 955: 8, 956: 8, 1001: 8, 705: 8, 452: 8, 1788: 8, 464: 8, 824: 8, 466: 8, 467: 8, 761: 8, 728: 8, 1572: 8, 1114: 8, 933: 8, 800: 8, 608: 8, 865: 8, 610: 8, 1595: 8, 934: 8, 998: 5, 1745: 8, 1000: 8, 764: 8, 1002: 8, 999: 7, 1789: 8, 1649: 8, 1779: 8, 1568: 8, 1017: 8, 1786: 8, 1787: 8, 1020: 8, 426: 6, 1279: 8}
 
-candidate_cars = all_known_cars()
+candidate_cars = all_legacy_fingerprint_cars()
 
 
 for addr, l in fingerprint.items():


### PR DESCRIPTION
`test_car_interfaces.py` and `test_models.py` weren't running at all for cars without a legacy CAN fingerprint. Should fix CI passing incorrectly in cases like #21013.