### PR TITLE
VW MQB: Add FW for 2018 Volkswagen Atlas

### DIFF
--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -71,6 +71,7 @@ FW_VERSIONS = {
   CAR.ATLAS_MK1: {
     (Ecu.engine, 0x7e0, None): [
       b'\xf1\x8703H906026AA\xf1\x899970',
+      b'\xf1\x8703H906026F \xf1\x896696',
       b'\xf1\x8703H906026F \xf1\x899970',
     ],
     (Ecu.transmission, 0x7e1, None): [
@@ -87,6 +88,7 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdRadar, 0x757, None): [
       b'\xf1\x875Q0907572H \xf1\x890620',
+      b'\xf1\x875Q0907572J \xf1\x890654',
       b'\xf1\x875Q0907572P \xf1\x890682',
     ],
   },


### PR DESCRIPTION
New FW values from a 2018 Atlas.

**Dongle ID:** ca233a3d46aaedea

Thanks to community Atlas owner liltimtim.