### PR TITLE
VW MQB: Add FW for 2017 SEAT Leon

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Community Maintained Cars and Features
 | Nissan    | Rogue 2018-20                 | ProPILOT          | Stock            | 0mph               | 0mph         |
 | Nissan    | X-Trail 2017                  | ProPILOT          | Stock            | 0mph               | 0mph         |
 | SEAT      | Ateca 2018                    | Driver Assistance | Stock            | 0mph               | 0mph         |
-| SEAT      | Leon 2020                     | Driver Assistance | Stock            | 0mph               | 0mph         |
+| SEAT      | Leon 2017, 2020               | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Kodiaq 2018                   | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Octavia 2015, 2019            | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Škoda     | Scala 2020                    | Driver Assistance | Stock            | 0mph               | 0mph         |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ Version 0.8.5 (2021-XX-XX)
  * Smart model-based Forward Collision Warning
  * Hyundai Elantra 2021 support thanks to CruiseBrantley!
  * Lexus UX Hybrid 2019 support thanks to brianhaugen2!
- * SEAT Leon 2020 support thanks to jyoung8607!
+ * SEAT Leon 2017 & 2020 support thanks to jyoung8607!
  * Škoda Octavia 2015 & 2019 support thanks to jyoung8607!
 
 Version 0.8.4 (2021-05-17)

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -331,18 +331,23 @@ FW_VERSIONS = {
   },
   CAR.SEAT_LEON_MK3: {
     (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x8704L906026BP\xf1\x891198',
       b'\xf1\x8705E906018AS\xf1\x899596',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x870CW300050J \xf1\x891908',
+      b'\xf1\x870D9300042M \xf1\x895016',
     ],
     (Ecu.srs, 0x715, None): [
+      b'\xf1\x873Q0959655AS\xf1\x890200\xf1\x82\r12110012120012021612110200',
       b'\xf1\x873Q0959655CM\xf1\x890720\xf1\x82\0161312001313001305171311052900',
     ],
     (Ecu.eps, 0x712, None): [
       b'\xf1\x875Q0909144AB\xf1\x891082\xf1\x82\00521N01342A1',
+      b'\xf1\x875Q0909144T \xf1\x891072\xf1\x82\00521N05808A1',
     ],
     (Ecu.fwdRadar, 0x757, None): [
+      b'\xf1\x875Q0907572H \xf1\x890620',
       b'\xf1\x875Q0907572P \xf1\x890682',
     ],
   },


### PR DESCRIPTION
One of the two vehicles we had trouble classifying from @pd0wm's sweep of the 0.8.3 data, the owner showed up in Discord today. It was a SEAT Leon being misidentified as an Audi A3 under the now-retired FPv1. Haven't heard from the other one yet.

Model-year 2017 added to README and RELEASES.

Thanks to community 2017 SEAT Leon owner fodys!