### PR TITLE
Update ui fixes

### DIFF
--- a/selfdrive/common/params.h
+++ b/selfdrive/common/params.h
@@ -43,7 +43,7 @@ public:
     return get(key.c_str(), block);
   }
 
-  inline std::string get_params_path() {
+  inline std::string get_params_path() const {
     return params_path;
   }
 

--- a/selfdrive/common/params.h
+++ b/selfdrive/common/params.h
@@ -43,6 +43,10 @@ public:
     return get(key.c_str(), block);
   }
 
+  inline std::string get_params_path() {
+    return params_path;
+  }
+
   template <class T>
   std::optional<T> get(const char *key, bool block = false) {
     std::istringstream iss(get(key, block));

--- a/selfdrive/common/params.h
+++ b/selfdrive/common/params.h
@@ -43,7 +43,7 @@ public:
     return get(key.c_str(), block);
   }
 
-  inline std::string get_params_path() const {
+  inline std::string getParamsPath() {
     return params_path;
   }
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -211,9 +211,11 @@ DeveloperPanel::DeveloperPanel(QWidget* parent) : QFrame(parent) {
 
 
   QFileSystemWatcher *fs_watch = new QFileSystemWatcher(this);
-  fs_watch->addPath(QString::fromStdString(Params().get_params_path()) + "/d/LastUpdateTime");
+  QString update_param_path = QString::fromStdString(Params().get_params_path()) + "/d/LastUpdateTime";
+  fs_watch->addPath(update_param_path);
 
   QObject::connect(fs_watch, &QFileSystemWatcher::fileChanged, [=](const QString path) {
+    fs_watch->addPath(update_param_path); // Add again after the param was renamed
     updateLabels();
   });
 }

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -209,13 +209,9 @@ DeveloperPanel::DeveloperPanel(QWidget* parent) : QFrame(parent) {
   setLayout(main_layout);
   setStyleSheet(R"(QLabel {font-size: 50px;})");
 
-
-  QFileSystemWatcher *fs_watch = new QFileSystemWatcher(this);
-  QString update_param_path = QString::fromStdString(Params().get_params_path()) + "/d/LastUpdateTime";
-  fs_watch->addPath(update_param_path);
+  fs_watch = new QFileSystemWatcher(this);
 
   QObject::connect(fs_watch, &QFileSystemWatcher::fileChanged, [=](const QString path) {
-    fs_watch->addPath(update_param_path); // Add again after the param was renamed
     updateLabels();
   });
 }
@@ -228,25 +224,31 @@ void DeveloperPanel::updateLabels() {
   Params params = Params();
   std::string brand = params.getBool("Passive") ? "dashcam" : "openpilot";
   QList<QPair<QString, std::string>> dev_params = {
-    {"Git Branch", params.get("GitBranch", false)},
-    {"Git Commit", params.get("GitCommit", false).substr(0, 10)},
-    {"Panda Firmware", params.get("PandaFirmwareHex", false)},
+    {"Git Branch", params.get("GitBranch")},
+    {"Git Commit", params.get("GitCommit").substr(0, 10)},
+    {"Panda Firmware", params.get("PandaFirmwareHex")},
     {"OS Version", Hardware::get_os_version()},
   };
 
-  QString version = QString::fromStdString(brand + " v" + params.get("Version", false).substr(0, 14)).trimmed();
-  QDateTime lastUpdateDate = QDateTime::fromString(QString::fromStdString(params.get("LastUpdateTime", false)), Qt::ISODate);
-  QString lastUpdateTime = timeAgo(lastUpdateDate);
+  QString version = QString::fromStdString(brand + " v" + params.get("Version").substr(0, 14)).trimmed();
+  QString lastUpdateTime = "";
+
+  std::string last_update_param = params.get("LastUpdateTime");
+  if (!last_update_param.empty()){
+    QDateTime lastUpdateDate = QDateTime::fromString(QString::fromStdString(last_update_param + "Z"), Qt::ISODate);
+    lastUpdateTime = timeAgo(lastUpdateDate);
+  }
 
   if (labels.size() < dev_params.size()) {
-    versionLbl = new LabelControl("Version", version, QString::fromStdString(params.get("ReleaseNotes", false)).trimmed());
+    versionLbl = new LabelControl("Version", version, QString::fromStdString(params.get("ReleaseNotes")).trimmed());
     layout()->addWidget(versionLbl);
     layout()->addWidget(horizontal_line());
 
     lastUpdateTimeLbl = new LabelControl("Last Update Check", lastUpdateTime, "The last time openpilot checked for an update.");
     connect(lastUpdateTimeLbl, &LabelControl::showDescription, [=]() {
-      std::system("pkill -1 -f selfdrive.updated");
+      fs_watch->addPath(QString::fromStdString(params.get_params_path()) + "/d/LastUpdateTime");
       lastUpdateTimeLbl->setText("checking...");
+      std::system("pkill -1 -f selfdrive.updated");
     });
     layout()->addWidget(lastUpdateTimeLbl);
     layout()->addWidget(horizontal_line());

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -210,7 +210,6 @@ DeveloperPanel::DeveloperPanel(QWidget* parent) : QFrame(parent) {
   setStyleSheet(R"(QLabel {font-size: 50px;})");
 
   fs_watch = new QFileSystemWatcher(this);
-
   QObject::connect(fs_watch, &QFileSystemWatcher::fileChanged, [=](const QString path) {
     updateLabels();
   });

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -243,11 +243,14 @@ void DeveloperPanel::updateLabels() {
     layout()->addWidget(versionLbl);
     layout()->addWidget(horizontal_line());
 
-    lastUpdateTimeLbl = new LabelControl("Last Update Check", lastUpdateTime, "The last time openpilot checked for an update.");
+    lastUpdateTimeLbl = new LabelControl("Last Update Check", lastUpdateTime, "The last time openpilot checked for an update. Updates are only checked while off-road.");
     connect(lastUpdateTimeLbl, &LabelControl::showDescription, [=]() {
-      fs_watch->addPath(QString::fromStdString(params.get_params_path()) + "/d/LastUpdateTime");
-      lastUpdateTimeLbl->setText("checking...");
-      std::system("pkill -1 -f selfdrive.updated");
+      Params params = Params();
+      if (params.getBool("IsOffroad")) {
+        fs_watch->addPath(QString::fromStdString(params.getParamsPath()) + "/d/LastUpdateTime");
+        lastUpdateTimeLbl->setText("checking...");
+        std::system("pkill -1 -f selfdrive.updated");
+      }
     });
     layout()->addWidget(lastUpdateTimeLbl);
     layout()->addWidget(horizontal_line());

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -42,6 +42,8 @@ private:
   LabelControl *versionLbl;
   LabelControl *lastUpdateTimeLbl;
   void updateLabels();
+
+  QFileSystemWatcher *fs_watch;
 };
 
 class SettingsWindow : public QFrame {

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QButtonGroup>
+#include <QFileSystemWatcher>
 #include <QFrame>
 #include <QLabel>
 #include <QPushButton>
@@ -8,6 +9,7 @@
 #include <QStackedWidget>
 #include <QTimer>
 #include <QWidget>
+
 
 #include "selfdrive/ui/qt/widgets/controls.h"
 
@@ -39,6 +41,7 @@ private:
   QList<LabelControl *> labels;
   LabelControl *versionLbl;
   LabelControl *lastUpdateTimeLbl;
+  void updateLabels();
 };
 
 class SettingsWindow : public QFrame {

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -22,7 +22,7 @@ inline void clearLayout(QLayout* layout) {
 }
 
 inline QString timeAgo(const QDateTime &date) {
-  int diff = date.secsTo(QDateTime::currentDateTime());
+  int diff = date.secsTo(QDateTime::currentDateTimeUtc());
 
   QString s;
   if (diff < 60) {


### PR DESCRIPTION
- Correctly parse `LastUpdateTime` as UTC to prevent any timezone issues.
- Change text to "checking..." after initiating an update to indicate something is happening
- Set up a file watch on `LastUpdateTime` to update the ui when the check is done
- Handle case where LastUpdateTime is not set. Show nothing instead of "now".