### PR TITLE
VW MQB: Fix bug with HCA state handling

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -43,7 +43,7 @@ class CarController():
 
       # FAULT AVOIDANCE: HCA must not be enabled at standstill. Also stop
       # commanding HCA if there's a fault, so the steering rack recovers.
-      if enabled and not (CS.out.standstill or CS.steeringFault):
+      if enabled and not (CS.out.standstill or CS.out.steerError or CS.out.steerWarning):
 
         # FAULT AVOIDANCE: Requested HCA torque must not exceed 3.0 Nm. This
         # is inherently handled by scaling to STEER_MAX. The rack doesn't seem

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -183,7 +183,7 @@ class CarState(CarStateBase):
       ("MO_Kuppl_schalter", "Motor_14", 0),         # Clutch switch
       ("EPS_Lenkmoment", "LH_EPS_03", 0),           # Absolute driver torque input
       ("EPS_VZ_Lenkmoment", "LH_EPS_03", 0),        # Driver torque input sign
-      ("EPS_HCA_Status", "LH_EPS_03", 1),           # EPS HCA control status
+      ("EPS_HCA_Status", "LH_EPS_03", 3),           # EPS HCA control status
       ("ESP_Tastung_passiv", "ESP_21", 0),          # Stability control disabled
       ("KBI_MFA_v_Einheit_02", "Einheiten_01", 0),  # MPH vs KMH speed display
       ("KBI_Handbremse", "Kombi_01", 0),            # Manual handbrake applied

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -40,8 +40,8 @@ class CarState(CarStateBase):
 
     # Verify EPS readiness to accept steering commands
     hca_status = self.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
-    ret.steerError = hca_status in ["disabled", "fault"]
-    ret.steerWarning = hca_status in ["initializing", "rejected"]
+    ret.steerError = hca_status in ["DISABLED", "FAULT"]
+    ret.steerWarning = hca_status in ["INITIALIZING", "REJECTED"]
 
     # Update gas, brakes, and gearshift.
     ret.gas = pt_cp.vl["Motor_20"]["MO_Fahrpedalrohwert_01"] / 100.0

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -183,7 +183,7 @@ class CarState(CarStateBase):
       ("MO_Kuppl_schalter", "Motor_14", 0),         # Clutch switch
       ("EPS_Lenkmoment", "LH_EPS_03", 0),           # Absolute driver torque input
       ("EPS_VZ_Lenkmoment", "LH_EPS_03", 0),        # Driver torque input sign
-      ("EPS_HCA_Status", "LH_EPS_03", 0),           # Steering rack HCA support configured
+      ("EPS_HCA_Status", "LH_EPS_03", 1),           # EPS HCA control status
       ("ESP_Tastung_passiv", "ESP_21", 0),          # Stability control disabled
       ("KBI_MFA_v_Einheit_02", "Einheiten_01", 0),  # MPH vs KMH speed display
       ("KBI_Handbremse", "Kombi_01", 0),            # Manual handbrake applied

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -167,8 +167,6 @@ class CarInterface(CarInterfaceBase):
     # Vehicle health and operation safety checks
     if self.CS.parkingBrakeSet:
       events.add(EventName.parkBrake)
-    if self.CS.steeringFault:
-      events.add(EventName.steerTempUnavailable)
 
     ret.events = events.to_msg()
     ret.buttonEvents = buttonEvents


### PR DESCRIPTION
**Description**

We inadvertently lost detection of HCA "fault", "refused", and possibly "initializing" states while doing some DBC refactoring in 042c877. It so happened that "disabled" still worked, so we were still catching the most common case of HCA not being configured on a car with no LKAS camera.

We rarely encounter these states during normal operation. "Initializing" is only for a second or two at startup, "fault" means something *really* broke with the EPS or with communication, and much of `volkswagen/carcontroller.py` is dedicated to avoiding all the "refused" situations.

This PR returns us to a "good enough" state, filling in the proper carState fields and using the new common events. In a perfect world, we would also have a continuous check that HCA is "active" while engaged. But that will need some more logic around standstill, timeout workarounds, etc with additional testing in community.

**Verification**

* `2cef8a0b898f331a|2021-06-01--11-50-14`: "disabled" state from EPS rack reconfigured w/o HCA support
* `2cef8a0b898f331a|2021-06-01--17-03-38`: "fault" state from comms disruption (OP torque > Panda safety)
* `2cef8a0b898f331a|2021-06-01--17-11-15`: "refused" state from (OP torque & Panda safety) > EPS limit
* `2cef8a0b898f331a|2021-06-01--17-16-33`: normal drive

**Additional Context**

Requires an opendbc bump for the [HCA states](https://github.com/commaai/opendbc/blob/a9ae16ef4870fa6a8c7743b71ee06297930e7921/vw_mqb_2010.dbc#L1382). I've done so in this PR, but not to current, only as far as I needed it.

The "fault" state, when it arises from comms disruption, is technically recoverable without an ignition cycle. However, other origins of "fault" may not be, and it still means something bad has happened. I prefer to give it the `steerUnavailable` treatment because the `steerTempUnavailable` treatment doesn't communicate the severity of the problem.

process_replay sees a new `steerTempUnavailable` event at the beginning. The initial value of `LH_EPS_03.EPS_HCA_Status` applies before any CAN signals have been read-in, and we are now correctly treating that as invalid for openpilot engagement.