### PR TITLE
Add support for steering angle sensor precision

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -59,6 +59,7 @@ class CarInterfaceBase():
 
     # standard ALC params
     ret.steerControlType = car.CarParams.SteerControlType.torque
+    ret.steerAnglePrecision = 0.
     ret.steerMaxBP = [0.]
     ret.steerMaxV = [1.]
     ret.minSteerSpeed = 0.

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -46,6 +46,7 @@ class CarInterface(CarInterfaceBase):
     # Global tuning defaults, can be overridden per-vehicle
 
     ret.steerRateCost = 1.0
+    ret.steerAnglePrecision = 0.15
     ret.steerLimitTimer = 0.4
     ret.steerRatio = 15.6  # Let the params learner figure this out
     tire_stiffness_factor = 1.0  # Let the params learner figure this out

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -36,7 +36,7 @@ class LatControlPID():
       steer_feedforward = angle_steers_des_no_offset  # offset does not contribute to resistive torque
       steer_feedforward *= CS.vEgo**2  # proportional to realigning tire momentum (~ lateral accel)
 
-      deadzone = 0.0
+      deadzone = CP.steerAnglePrecision
 
       check_saturation = (CS.vEgo > 10) and not CS.steeringRateLimited and not CS.steeringPressed
       output_steer = self.pid.update(angle_steers_des, CS.steeringAngleDeg, check_saturation=check_saturation, override=CS.steeringPressed,


### PR DESCRIPTION
Potential improvement for PIF tuning/noise. Discussion (or rejection?) welcome.  Depends on commaai/cereal#164.

* Permit setting `carParams.steerAnglePrecision` within a car port, per-CAR if desired
* Default it to zero (no behavior/tuning change for any car port that doesn't use the new setting yet)
* Use that precision to set the deadzone for the lateral PIF controller
* Set the steering angle precision to 0.15° for VW MQB
  * Mainly as a test to show that process_replay rightfully breaks for VW but not for other ports
  * Significant follow-ups coming to improve the VW tune which is currently "meh"
  * I will very likely ask for revert of #20247 to regain 0.1° precision, looks like better tuning with Kale is the right path

Credit to @zorrobyte for the idea.