### PR TITLE
CARLA: save calibration params as capnp

### DIFF
--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -368,9 +368,10 @@ if __name__ == "__main__":
   # make sure params are in a good state
   set_params_enabled()
 
-  params = Params()
-  params.delete("Offroad_ConnectivityNeeded")
-  params.put("CalibrationParams", '{"calib_radians": [0,0,0], "valid_blocks": 20}')
+  msg = messaging.new_message('liveCalibration')
+  msg.liveCalibration.validBlocks = 20
+  msg.liveCalibration.rpyCalib = [0.0, 0.0, 0.0]
+  Params().put("CalibrationParams", msg.to_bytes())
 
   from multiprocessing import Process, Queue
   q: Any = Queue()


### PR DESCRIPTION
<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->
When starting simulation on latest master, OP tells us **Calibration in Progress**. However, nothing happens as we cannot drive over 15mph.
The problem is that the calibration data changed from JSON format to a message byte stream in OP. This change was not reflected in bridge.py in the simulator.