### PR TITLE
It wasn't clear where to run export ZMQ=1 for plotjuggler

### DIFF
--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -39,7 +39,7 @@ To get started exploring and plotting data live in your car, you can start PlotJ
 For this to work, you'll need a few things:
 - Enable tethering on your comma device and connect your laptop.
 - Run `export ZMQ=1` on the computer, which tells the streaming plugin backend to use ZMQ. If you're streaming locally, you can omit this step as ZMQ is used to transport data over the network.
-- Most importantly: openpilot by default uses the MSGQ backend, so you'll need to [ssh into your device](https://github.com/commaai/openpilot/wiki/SSH) and run bridge. This simply re-broadcasts each message over ZMQ: `./cereal/messaging/bridge`. Note that you can use something like `nohup ./cereal/messaging/bridge` so bridge doesn't quit if the ssh session is dropped.
+- Most importantly: openpilot by default uses the MSGQ backend, so you'll need to [ssh into your device](https://github.com/commaai/openpilot/wiki/SSH) and run bridge. This simply re-broadcasts each message over ZMQ: `./cereal/messaging/bridge`.
 
 Now start PlotJuggler using the above `juggle.py` command, and find the `Cereal Subscriber` plugin in the dropdown under Streaming. Click Start and enter the IP address of the comma two. You should now be seeing all the messages for each [service in openpilot](https://github.com/commaai/cereal/blob/master/services.py) received live from your car!
 

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -38,8 +38,8 @@ To get started exploring and plotting data live in your car, you can start PlotJ
 
 For this to work, you'll need a few things:
 - Enable tethering on your comma device and connect your laptop.
-- Run `export ZMQ=1` which tells the streaming plugin backend to use ZMQ. If you're streaming locally, you can omit this step as ZMQ is used to transport data over the network.
-- Most importantly: openpilot by default uses the MSGQ backend, so you'll need to [ssh into your device](https://github.com/commaai/openpilot/wiki/SSH) and run bridge. This simply re-broadcasts each message over ZMQ: `./cereal/messaging/bridge`
+- Run `export ZMQ=1` on the computer, which tells the streaming plugin backend to use ZMQ. If you're streaming locally, you can omit this step as ZMQ is used to transport data over the network.
+- Most importantly: openpilot by default uses the MSGQ backend, so you'll need to [ssh into your device](https://github.com/commaai/openpilot/wiki/SSH) and run bridge. This simply re-broadcasts each message over ZMQ: `./cereal/messaging/bridge`. Note that you can use something like `nohup ./cereal/messaging/bridge` so bridge doesn't quit if the ssh session is dropped.
 
 Now start PlotJuggler using the above `juggle.py` command, and find the `Cereal Subscriber` plugin in the dropdown under Streaming. Click Start and enter the IP address of the comma two. You should now be seeing all the messages for each [service in openpilot](https://github.com/commaai/cereal/blob/master/services.py) received live from your car!
 


### PR DESCRIPTION
clockenessmnstr — Today at 2:14 PM
I'm having trouble getting plot juggler connected. Tried running bridge while ssh'd in and nothing updates in PJ cereal subscriber. No publishers/data.
The C2 is just powered up on the table but there should be some services broadcasting right?
clockenessmnstr — Today at 4:03 PM
Do you just run ./cereal/messaging/bridge on the C2 and start cereal subscriber on JP GUI?
zorrobyte — Today at 4:22 PM
Yeah, after setting ZMQ
In the directory
clockenessmnstr — Today at 4:26 PM
Thanks! I was setting ZMQ on the C2 :person_facepalming:
zorrobyte — Today at 4:29 PM
The docs could be better, I'll be submitting PRs today