### PR TITLE
Audible alert for steer unavailable below X speed

### DIFF
--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -190,7 +190,7 @@ def below_steer_speed_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: 
     "TAKE CONTROL",
     "Steer Unavailable Below %d %s" % (speed, unit),
     AlertStatus.userPrompt, AlertSize.mid,
-    Priority.MID, VisualAlert.steerRequired, AudibleAlert.none, 0., 0.4, .3)
+    Priority.MID, VisualAlert.steerRequired, AudibleAlert.chimePrompt, 0., 0.4, .3)
 
 
 def calibration_incomplete_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: bool) -> Alert:


### PR DESCRIPTION
On cars with high ALC speeds such as Chrysler Pacifica, Pacifica Hybrid, Jeep Grand Cherokee 2019+, and some Hyundais, they lose steering at around 40mph. This changes the alert to also have a beep when that happens, to prevent things like https://github.com/commaai/openpilot/issues/21200.