### PR TITLE
ui: networking enhancements

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -232,6 +232,17 @@ void WifiUI::refresh() {
     QPushButton* btn = new QPushButton(network.security_type == SecurityType::UNSUPPORTED ? "Unsupported" : (network.connected == ConnectedType::CONNECTED ? "Connected" : (network.connected == ConnectedType::CONNECTING ? "Connecting" : "Connect")));
     btn->setDisabled(network.connected == ConnectedType::CONNECTED || network.connected == ConnectedType::CONNECTING || network.security_type == SecurityType::UNSUPPORTED);
     btn->setFixedWidth(350);
+
+    QPushButton *forget_btn = new QPushButton("Forget");
+    forget_btn->setStyleSheet("background-color: #E22C2C;");
+    hlayout->addWidget(forget_btn, 0, Qt::AlignRight);
+    QObject::connect(forget_btn, &QPushButton::released, [=]() {
+      if (ConfirmationDialog::confirm("Are you sure you want to forget " + QString::fromUtf8(network.ssid) + "?", this)) {
+        Network n = wifi->seen_networks[ssidButtons->id(btn)];
+        emit forgetNetwork(n);
+      }
+    });
+
     hlayout->addWidget(btn, 0, Qt::AlignRight);
 
     connectButtons->addButton(btn, i);

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -199,21 +199,25 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
 }
 
 void WifiUI::refresh() {
+  qDebug() << "WifiUI::refresh()";
   wifi->request_scan();
   wifi->refreshNetworks();
   clearLayout(vlayout);
 
   connectButtons = new QButtonGroup(this); // TODO check if this is a leak
-  QObject::connect(connectButtons, qOverload<QAbstractButton*>(&QButtonGroup::buttonClicked), this, &WifiUI::handleButton);
+  ssidButtons = new QButtonGroup(this);
+  QObject::connect(connectButtons, qOverload<QAbstractButton*>(&QButtonGroup::buttonClicked), this, &WifiUI::handleConnectButton);
+  QObject::connect(ssidButtons, qOverload<QAbstractButton*>(&QButtonGroup::buttonClicked), this, &WifiUI::handleSsidButton);
 
   int i = 0;
   for (Network &network : wifi->seen_networks) {
     QHBoxLayout *hlayout = new QHBoxLayout;
     hlayout->addSpacing(50);
 
-    QLabel *ssid_label = new QLabel(QString::fromUtf8(network.ssid));
-    ssid_label->setStyleSheet("font-size: 55px;");
-    hlayout->addWidget(ssid_label, 1, Qt::AlignLeft);
+    QPushButton *ssid_button = new QPushButton(QString::fromUtf8(network.ssid));
+    ssid_button->setStyleSheet("font-size: 55px; background-color: transparent");
+    ssid_button->setFlat(true);
+    hlayout->addWidget(ssid_button, 1, Qt::AlignLeft);  // TODO: make label clickable for network options
 
     // strength indicator
     unsigned int strength_scale = network.strength / 17;
@@ -237,8 +241,15 @@ void WifiUI::refresh() {
   vlayout->addStretch(3);
 }
 
-void WifiUI::handleButton(QAbstractButton* button) {
+void WifiUI::handleConnectButton(QAbstractButton* button) {
   QPushButton* btn = static_cast<QPushButton*>(button);
   Network n = wifi->seen_networks[connectButtons->id(btn)];
   emit connectToNetwork(n);
+}
+
+void WifiUI::handleSsidButton(QAbstractButton* button) {
+  QPushButton* btn = static_cast<QPushButton*>(button);
+  qDebug() << ssidButtons->id(btn);
+//  Network n = wifi->seen_networks[connectButtons->id(btn)];
+//  emit connectToNetwork(n);  // TODO: emit delete network
 }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -115,6 +115,10 @@ void Networking::connectToNetwork(const Network &n) {
   }
 }
 
+void Networking::forgetNetwork(const Network &n) {
+  wifi->forget(n);
+}
+
 void Networking::wrongPassword(const QString &ssid) {
   for (Network n : wifi->seen_networks) {
     if (n.ssid == ssid) {
@@ -250,6 +254,9 @@ void WifiUI::handleConnectButton(QAbstractButton* button) {
 void WifiUI::handleSsidButton(QAbstractButton* button) {
   QPushButton* btn = static_cast<QPushButton*>(button);
   qDebug() << ssidButtons->id(btn);
-//  Network n = wifi->seen_networks[connectButtons->id(btn)];
-//  emit connectToNetwork(n);  // TODO: emit delete network
+  if (ConfirmationDialog::confirm("Do you want to forget this network?", this)) {
+    qDebug() << "Removing network!";
+  }
+  Network n = wifi->seen_networks[ssidButtons->id(btn)];
+  emit forgetNetwork(n);
 }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -54,16 +54,28 @@ void Networking::attemptInitialization(){
   if (show_advanced) {
     QHBoxLayout* menu_bar = new QHBoxLayout;
 
+    QPushButton *forgetBtn = new QPushButton("Forget");
+    forgetBtn->setStyleSheet("background-color: #E22C2C; margin-right: 30px;");
+    forgetBtn->setFixedSize(350, 100);
+    menu_bar->addWidget(forgetBtn, 0, Qt::AlignRight);
+
     QPushButton* advancedBtn = new QPushButton("Advanced");
     advancedBtn->setStyleSheet("margin-right: 30px;");
     advancedBtn->setFixedSize(350, 100);
     connect(advancedBtn, &QPushButton::released, [=](){ s->setCurrentWidget(an); });
     menu_bar->addWidget(advancedBtn, 0, Qt::AlignRight);
 
-    QPushButton *forgetBtn = new QPushButton("Forget");
-    forgetBtn->setStyleSheet("background-color: #E22C2C; margin-right: 30px;");
-    forgetBtn->setFixedSize(350, 100);
-    menu_bar->addWidget(forgetBtn, 0, Qt::AlignRight);
+    // forget button
+    if (network.connected == ConnectedType::CONNECTED) {
+      QPushButton *forget_btn = new QPushButton("Forget");
+      forget_btn->setStyleSheet("background-color: #E22C2C;");
+      hlayout->addWidget(forget_btn, 0, Qt::AlignRight);
+      QObject::connect(forget_btn, &QPushButton::released, [=]() {
+        if (ConfirmationDialog::confirm("Are you sure you want to forget " + QString::fromUtf8(network.ssid) + "?", this)) {
+          emit forgetNetwork(network);
+        }
+      });
+    }
 
     vlayout->addSpacing(10);
     vlayout->addLayout(menu_bar, 1);
@@ -229,18 +241,6 @@ void WifiUI::refresh() {
     QLabel *ssid_label = new QLabel(QString::fromUtf8(network.ssid));
     ssid_label->setStyleSheet("font-size: 55px;");
     hlayout->addWidget(ssid_label, 1, Qt::AlignLeft);
-
-    // forget button
-    if (network.connected == ConnectedType::CONNECTED) {
-      QPushButton *forget_btn = new QPushButton("Forget");
-      forget_btn->setStyleSheet("background-color: #E22C2C;");
-      hlayout->addWidget(forget_btn, 0, Qt::AlignRight);
-      QObject::connect(forget_btn, &QPushButton::released, [=]() {
-        if (ConfirmationDialog::confirm("Are you sure you want to forget " + QString::fromUtf8(network.ssid) + "?", this)) {
-          emit forgetNetwork(network);
-        }
-      });
-    }
 
     // strength indicator
     unsigned int strength_scale = network.strength / 17;

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -117,7 +117,7 @@ void Networking::connectToNetwork(const Network &n) {
 }
 
 void Networking::forgetNetwork(const Network &n) {
-  wifi->forget(n);
+  wifi->forgetConnection(n);
 }
 
 void Networking::wrongPassword(const QString &ssid) {
@@ -222,7 +222,7 @@ void WifiUI::refresh() {
     QPushButton *ssid_button = new QPushButton(QString::fromUtf8(network.ssid));
     ssid_button->setStyleSheet("font-size: 55px; background-color: transparent");
     ssid_button->setFlat(true);
-    hlayout->addWidget(ssid_button, 1, Qt::AlignLeft);  // TODO: make label clickable for network options
+    hlayout->addWidget(ssid_button, 1, Qt::AlignLeft);
 
     // strength indicator
     unsigned int strength_scale = network.strength / 17;

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -108,7 +108,7 @@ void Networking::refresh(){
 }
 
 void Networking::connectToNetwork(const Network &n) {
-  if (n.security_type == SecurityType::OPEN) {
+  if ((n.security_type == SecurityType::OPEN) || wifi->isKnownNetwork(n.ssid)) {
     wifi->connect(n);
   } else if (n.security_type == SecurityType::WPA) {
     QString pass = InputDialog::getText("Enter password for \"" + n.ssid + "\"", 8);

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -117,7 +117,7 @@ void Networking::connectToNetwork(const Network &n) {
 }
 
 void Networking::forgetNetwork(const Network &n) {
-  wifi->forgetConnection(n);
+  wifi->forgetConnection(n.ssid);
 }
 
 void Networking::wrongPassword(const QString &ssid) {

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -210,19 +210,16 @@ void WifiUI::refresh() {
   clearLayout(vlayout);
 
   connectButtons = new QButtonGroup(this); // TODO check if this is a leak
-  ssidButtons = new QButtonGroup(this);
   QObject::connect(connectButtons, qOverload<QAbstractButton*>(&QButtonGroup::buttonClicked), this, &WifiUI::handleConnectButton);
-  QObject::connect(ssidButtons, qOverload<QAbstractButton*>(&QButtonGroup::buttonClicked), this, &WifiUI::handleSsidButton);
 
   int i = 0;
   for (Network &network : wifi->seen_networks) {
     QHBoxLayout *hlayout = new QHBoxLayout;
     hlayout->addSpacing(50);
 
-    QPushButton *ssid_button = new QPushButton(QString::fromUtf8(network.ssid));
-    ssid_button->setStyleSheet("font-size: 55px; background-color: transparent");
-    ssid_button->setFlat(true);
-    hlayout->addWidget(ssid_button, 1, Qt::AlignLeft);
+    QLabel *ssid_label = new QLabel(QString::fromUtf8(network.ssid));
+    ssid_label->setStyleSheet("font-size: 55px;");
+    hlayout->addWidget(ssid_label, 1, Qt::AlignLeft);
 
     // forget button
     if (network.connected == ConnectedType::CONNECTED) {
@@ -248,7 +245,6 @@ void WifiUI::refresh() {
     hlayout->addWidget(btn, 0, Qt::AlignRight);
 
     connectButtons->addButton(btn, i);
-    ssidButtons->addButton(ssid_button, i);
 
     vlayout->addLayout(hlayout, 1);
     // Don't add the last horizontal line
@@ -264,14 +260,4 @@ void WifiUI::handleConnectButton(QAbstractButton* button) {
   QPushButton* btn = static_cast<QPushButton*>(button);
   Network n = wifi->seen_networks[connectButtons->id(btn)];
   emit connectToNetwork(n);
-}
-
-void WifiUI::handleSsidButton(QAbstractButton* button) {
-  QPushButton* btn = static_cast<QPushButton*>(button);
-  qDebug() << ssidButtons->id(btn);
-  if (ConfirmationDialog::confirm("Do you want to forget this network?", this)) {
-    qDebug() << "Removing network!";
-    Network n = wifi->seen_networks[ssidButtons->id(btn)];
-    emit forgetNetwork(n);
-  }
 }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -59,6 +59,11 @@ void Networking::attemptInitialization(){
     vlayout->addSpacing(10);
     vlayout->addWidget(advancedSettings, 0, Qt::AlignRight);
     vlayout->addSpacing(10);
+
+    QPushButton *forget_btn = new QPushButton("Forget");
+    forget_btn->setStyleSheet("background-color: #E22C2C; margin-right: 30px;");
+    forget_btn->setFixedSize(350, 100);
+    vlayout->addWidget(forget_btn, 0, Qt::AlignRight);
   }
 
   wifiWidget = new WifiUI(this, wifi);
@@ -210,7 +215,7 @@ void WifiUI::refresh() {
   clearLayout(vlayout);
 
   connectButtons = new QButtonGroup(this); // TODO check if this is a leak
-  QObject::connect(connectButtons, qOverload<QAbstractButton*>(&QButtonGroup::buttonClicked), this, &WifiUI::handleConnectButton);
+  QObject::connect(connectButtons, qOverload<QAbstractButton*>(&QButtonGroup::buttonClicked), this, &WifiUI::handleButton);
 
   int i = 0;
   for (Network &network : wifi->seen_networks) {
@@ -256,7 +261,7 @@ void WifiUI::refresh() {
   vlayout->addStretch(3);
 }
 
-void WifiUI::handleConnectButton(QAbstractButton* button) {
+void WifiUI::handleButton(QAbstractButton* button) {
   QPushButton* btn = static_cast<QPushButton*>(button);
   Network n = wifi->seen_networks[connectButtons->id(btn)];
   emit connectToNetwork(n);

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -234,6 +234,7 @@ void WifiUI::refresh() {
     hlayout->addWidget(btn, 0, Qt::AlignRight);
 
     connectButtons->addButton(btn, i);
+    ssidButtons->addButton(ssid_button, i);
 
     vlayout->addLayout(hlayout, 1);
     // Don't add the last horizontal line
@@ -256,7 +257,7 @@ void WifiUI::handleSsidButton(QAbstractButton* button) {
   qDebug() << ssidButtons->id(btn);
   if (ConfirmationDialog::confirm("Do you want to forget this network?", this)) {
     qDebug() << "Removing network!";
+    Network n = wifi->seen_networks[ssidButtons->id(btn)];
+    emit forgetNetwork(n);
   }
-  Network n = wifi->seen_networks[ssidButtons->id(btn)];
-  emit forgetNetwork(n);
 }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -224,6 +224,18 @@ void WifiUI::refresh() {
     ssid_button->setFlat(true);
     hlayout->addWidget(ssid_button, 1, Qt::AlignLeft);
 
+    // forget button
+    if (network.connected == ConnectedType::CONNECTED) {
+      QPushButton *forget_btn = new QPushButton("Forget");
+      forget_btn->setStyleSheet("background-color: #E22C2C;");
+      hlayout->addWidget(forget_btn, 0, Qt::AlignRight);
+      QObject::connect(forget_btn, &QPushButton::released, [=]() {
+        if (ConfirmationDialog::confirm("Are you sure you want to forget " + QString::fromUtf8(network.ssid) + "?", this)) {
+          emit forgetNetwork(network);
+        }
+      });
+    }
+
     // strength indicator
     unsigned int strength_scale = network.strength / 17;
     hlayout->addWidget(new NetworkStrengthWidget(strength_scale), 0, Qt::AlignRight);
@@ -232,16 +244,6 @@ void WifiUI::refresh() {
     QPushButton* btn = new QPushButton(network.security_type == SecurityType::UNSUPPORTED ? "Unsupported" : (network.connected == ConnectedType::CONNECTED ? "Connected" : (network.connected == ConnectedType::CONNECTING ? "Connecting" : "Connect")));
     btn->setDisabled(network.connected == ConnectedType::CONNECTED || network.connected == ConnectedType::CONNECTING || network.security_type == SecurityType::UNSUPPORTED);
     btn->setFixedWidth(350);
-
-    QPushButton *forget_btn = new QPushButton("Forget");
-    forget_btn->setStyleSheet("background-color: #E22C2C;");
-    hlayout->addWidget(forget_btn, 0, Qt::AlignRight);
-    QObject::connect(forget_btn, &QPushButton::released, [=]() {
-      if (ConfirmationDialog::confirm("Are you sure you want to forget " + QString::fromUtf8(network.ssid) + "?", this)) {
-        Network n = wifi->seen_networks[ssidButtons->id(btn)];
-        emit forgetNetwork(n);
-      }
-    });
 
     hlayout->addWidget(btn, 0, Qt::AlignRight);
 

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -52,18 +52,22 @@ void Networking::attemptInitialization(){
   QVBoxLayout* vlayout = new QVBoxLayout;
 
   if (show_advanced) {
-    QPushButton* advancedSettings = new QPushButton("Advanced");
-    advancedSettings->setStyleSheet("margin-right: 30px;");
-    advancedSettings->setFixedSize(350, 100);
-    connect(advancedSettings, &QPushButton::released, [=](){ s->setCurrentWidget(an); });
-    vlayout->addSpacing(10);
-    vlayout->addWidget(advancedSettings, 0, Qt::AlignRight);
-    vlayout->addSpacing(10);
+    QHBoxLayout* menu_bar = new QHBoxLayout;
 
-    QPushButton *forget_btn = new QPushButton("Forget");
-    forget_btn->setStyleSheet("background-color: #E22C2C; margin-right: 30px;");
-    forget_btn->setFixedSize(350, 100);
-    vlayout->addWidget(forget_btn, 0, Qt::AlignRight);
+    QPushButton* advancedBtn = new QPushButton("Advanced");
+    advancedBtn->setStyleSheet("margin-right: 30px;");
+    advancedBtn->setFixedSize(350, 100);
+    connect(advancedBtn, &QPushButton::released, [=](){ s->setCurrentWidget(an); });
+    menu_bar->addWidget(advancedBtn, 0, Qt::AlignRight);
+
+    QPushButton *forgetBtn = new QPushButton("Forget");
+    forgetBtn->setStyleSheet("background-color: #E22C2C; margin-right: 30px;");
+    forgetBtn->setFixedSize(350, 100);
+    menu_bar->addWidget(forgetBtn, 0, Qt::AlignRight);
+
+    vlayout->addSpacing(10);
+    vlayout->addLayout(menu_bar, 1);
+    vlayout->addSpacing(10);
   }
 
   wifiWidget = new WifiUI(this, wifi);

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -63,6 +63,7 @@ void Networking::attemptInitialization(){
 
   wifiWidget = new WifiUI(this, wifi);
   connect(wifiWidget, &WifiUI::connectToNetwork, this, &Networking::connectToNetwork);
+  connect(wifiWidget, &WifiUI::forgetNetwork, this, &Networking::forgetNetwork);
   vlayout->addWidget(new ScrollView(wifiWidget, this), 1);
 
   QWidget* wifiScreen = new QWidget(this);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -38,6 +38,7 @@ private:
 
 signals:
   void connectToNetwork(const Network &n);
+  void forgetNetwork(const Network &n);
 
 public slots:
   void refresh();
@@ -84,6 +85,7 @@ private:
 
 private slots:
   void connectToNetwork(const Network &n);
+  void forgetNetwork(const Network &n);
   void refresh();
   void wrongPassword(const QString &ssid);
 };

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -33,6 +33,7 @@ private:
   QVBoxLayout *vlayout;
 
   QButtonGroup *connectButtons;
+  QButtonGroup *ssidButtons;
   bool tetheringEnabled;
 
 signals:
@@ -40,7 +41,8 @@ signals:
 
 public slots:
   void refresh();
-  void handleButton(QAbstractButton* m_button);
+  void handleConnectButton(QAbstractButton* m_button);
+  void handleSsidButton(QAbstractButton* m_button);
 };
 
 class AdvancedNetworking : public QWidget {

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -41,7 +41,7 @@ signals:
 
 public slots:
   void refresh();
-  void handleConnectButton(QAbstractButton* m_button);
+  void handleButton(QAbstractButton* m_button);
 };
 
 class AdvancedNetworking : public QWidget {

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -33,7 +33,6 @@ private:
   QVBoxLayout *vlayout;
 
   QButtonGroup *connectButtons;
-  QButtonGroup *ssidButtons;
   bool tetheringEnabled;
 
 signals:
@@ -43,7 +42,6 @@ signals:
 public slots:
   void refresh();
   void handleConnectButton(QAbstractButton* m_button);
-  void handleSsidButton(QAbstractButton* m_button);
 };
 
 class AdvancedNetworking : public QWidget {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -203,24 +203,7 @@ SecurityType WifiManager::getSecurityType(const QString &path) {
 }
 
 void WifiManager::forget(const Network &n) {
-//  clear_connections(n.ssid);
-  qDebug() << "in forget()";
-  for (QDBusObjectPath active_connection_raw : get_active_connections()) {
-    QString active_connection = active_connection_raw.path();
-    qDebug() << active_connection;
-//    QDBusInterface nm(nm_service, active_connection, props_iface, bus);
-//    nm.setTimeout(dbus_timeout);
-//
-//    QDBusObjectPath pth = get_response<QDBusObjectPath>(nm.call("Get", connection_iface, "SpecificObject"));
-//    if (pth.path() != "" && pth.path() != "/") {
-//      QString Ssid = get_property(pth.path(), "Ssid");
-//      if (Ssid == ssid) {
-//        QDBusInterface nm2(nm_service, nm_path, nm_iface, bus);
-//        nm2.setTimeout(dbus_timeout);
-//        nm2.call("DeactivateConnection", QVariant::fromValue(active_connection_raw));// TODO change to disconnect
-//      }
-//    }
-  }
+  clear_connections(n.ssid);
 }
 
 void WifiManager::connect(const Network &n) {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -278,6 +278,31 @@ QVector<QDBusObjectPath> WifiManager::get_active_connections() {
   return conns;
 }
 
+bool WifiManager::isKnownNetwork(const QString &ssid) {  // TODO: gotta be a simpler way to do this, i'll check once it works
+  for(QDBusObjectPath path : list_connections()){
+    QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
+    nm2.setTimeout(dbus_timeout);
+
+    QDBusMessage response = nm2.call("GetSettings");
+
+    const QDBusArgument &dbusArg = response.arguments().at(0).value<QDBusArgument>();
+
+    QMap<QString, QMap<QString,QVariant>> map;
+    dbusArg >> map;
+    for (auto &inner : map) {
+      for (auto &val : inner) {
+        QString key = inner.key(val);
+        if (key == "ssid") {
+          if (val == ssid) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 void WifiManager::forgetConnection(const QString &ssid) {
   for(QDBusObjectPath path : list_connections()){
     QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -70,7 +70,7 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   adapter = get_adapter();
 
   bool has_adapter = adapter != "";
-  if (!has_adapter){
+  if (!has_adapter) {
     throw std::runtime_error("Error connecting to NetworkManager");
   }
 
@@ -110,12 +110,12 @@ void WifiManager::refreshNetworks() {
 
 }
 
-QString WifiManager::get_ipv4_address(){
-  if (raw_adapter_state != state_connected){
+QString WifiManager::get_ipv4_address() {
+  if (raw_adapter_state != state_connected) {
     return "";
   }
   QVector<QDBusObjectPath> conns = get_active_connections();
-  for (auto &p : conns){
+  for (auto &p : conns) {
     QString active_connection = p.path();
     QDBusInterface nm(nm_service, active_connection, props_iface, bus);
     nm.setTimeout(dbus_timeout);
@@ -132,7 +132,7 @@ QString WifiManager::get_ipv4_address(){
       const QDBusArgument &arr = get_response<QDBusArgument>(nm2.call("Get", ipv4config_iface, "AddressData"));
       QMap<QString, QVariant> pth2;
       arr.beginArray();
-      while (!arr.atEnd()){
+      while (!arr.atEnd()) {
         arr >> pth2;
         QString ipv4 = pth2.value("address").value<QString>();
         arr.endArray();
@@ -391,7 +391,7 @@ void WifiManager::disconnect() {
 QVector<QPair<QString, QDBusObjectPath>> WifiManager::list_connections_ssid() {
   QVector<QPair<QString, QDBusObjectPath>> connections;
 
-  for(QDBusObjectPath path : list_connections()){
+  for(QDBusObjectPath path : list_connections()) {
     QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
     nm2.setTimeout(dbus_timeout);
 
@@ -417,7 +417,7 @@ QVector<QPair<QString, QDBusObjectPath>> WifiManager::list_connections_ssid() {
   return connections;
 }
 
-QVector<QDBusObjectPath> WifiManager::list_connections(){
+QVector<QDBusObjectPath> WifiManager::list_connections() {
   QVector<QDBusObjectPath> connections;
   QDBusInterface nm(nm_service, nm_settings_path, nm_settings_iface, bus);
   nm.setTimeout(dbus_timeout);
@@ -434,15 +434,14 @@ QVector<QDBusObjectPath> WifiManager::list_connections(){
   return connections;
 }
 
-bool WifiManager::activate_wifi_connection(const QString &ssid){
+bool WifiManager::activate_wifi_connection(const QString &ssid) {
   QString devicePath = get_adapter();
 
   for (QPair<QString, QDBusObjectPath> conn : list_connections_ssid()) {
     if (conn.first == ssid) {
       QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
       nm3.setTimeout(dbus_timeout);
-      nm3.call("ActivateConnection", QVariant::fromValue(conn.second.path()), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
-
+      nm3.call("ActivateConnection", QVariant::fromValue(conn.second), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
       return true;
     }
   }
@@ -450,35 +449,21 @@ bool WifiManager::activate_wifi_connection(const QString &ssid){
 }
 
 //Functions for tethering
-bool WifiManager::activate_tethering_connection(){
+bool WifiManager::activate_tethering_connection() {
   QString devicePath = get_adapter();
 
-  for(QDBusObjectPath path : list_connections()){
-    QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
-    nm2.setTimeout(dbus_timeout);
-
-    QDBusMessage response = nm2.call("GetSettings");
-    const QDBusArgument &dbusArg = response.arguments().at(0).value<QDBusArgument>();
-
-    QMap<QString, QMap<QString,QVariant>> map;
-    dbusArg >> map;
-    for (auto &inner : map) {
-      for (auto &val : inner) {
-        QString key = inner.key(val);
-        if (key == "ssid") {
-          if (val == tethering_ssid.toUtf8()) {
-            QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
-            nm3.setTimeout(dbus_timeout);
-            nm3.call("ActivateConnection", QVariant::fromValue(path), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
-            return true;
-          }
-        }
-      }
+  for (QPair<QString, QDBusObjectPath> conn : list_connections_ssid()) {
+    if (conn.first == tethering_ssid.toUtf8()) {
+      QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
+      nm3.setTimeout(dbus_timeout);
+      nm3.call("ActivateConnection", QVariant::fromValue(conn.second), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
+      return true;
     }
   }
   return false;
 }
-void WifiManager::addTetheringConnection(){
+
+void WifiManager::addTetheringConnection() {
   Connection connection;
   connection["connection"]["id"] = "Hotspot";
   connection["connection"]["uuid"] = QUuid::createUuid().toString().remove('{').remove('}');
@@ -510,7 +495,7 @@ void WifiManager::addTetheringConnection(){
 }
 
 void WifiManager::enableTethering() {
-  if(activate_tethering_connection()){
+  if (activate_tethering_connection()) {
     return;
   }
   addTetheringConnection();

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -203,7 +203,24 @@ SecurityType WifiManager::getSecurityType(const QString &path) {
 }
 
 void WifiManager::forget(const Network &n) {
-  clear_connections(n.ssid);
+//  clear_connections(n.ssid);
+  qDebug() << "in forget()";
+  for (QDBusObjectPath active_connection_raw : get_active_connections()) {
+    QString active_connection = active_connection_raw.path();
+    qDebug() << active_connection;
+//    QDBusInterface nm(nm_service, active_connection, props_iface, bus);
+//    nm.setTimeout(dbus_timeout);
+//
+//    QDBusObjectPath pth = get_response<QDBusObjectPath>(nm.call("Get", connection_iface, "SpecificObject"));
+//    if (pth.path() != "" && pth.path() != "/") {
+//      QString Ssid = get_property(pth.path(), "Ssid");
+//      if (Ssid == ssid) {
+//        QDBusInterface nm2(nm_service, nm_path, nm_iface, bus);
+//        nm2.setTimeout(dbus_timeout);
+//        nm2.call("DeactivateConnection", QVariant::fromValue(active_connection_raw));// TODO change to disconnect
+//      }
+//    }
+  }
 }
 
 void WifiManager::connect(const Network &n) {
@@ -265,7 +282,7 @@ void WifiManager::deactivate_connections(const QString &ssid) {
   }
 }
 
-QVector<QDBusObjectPath> WifiManager::get_active_connections() {
+QVector<QDBusObjectPath> WifiManager::get_active_connections() {  // TODO: rename to get_connections and have it return all known connections if active=false
   QDBusInterface nm(nm_service, nm_path, props_iface, bus);
   nm.setTimeout(dbus_timeout);
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -415,7 +415,7 @@ void WifiManager::disconnect() {
     deactivate_connections(get_property(active_ap, "Ssid"));
   }
 }
-
+QMap<QString, QMap<QString,QVariant>>
 QVector<QDBusObjectPath> WifiManager::list_connections(){
   QVector<QDBusObjectPath> connections;
   QDBusInterface nm(nm_service, nm_settings_path, nm_settings_iface, bus);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -294,6 +294,7 @@ bool WifiManager::isKnownNetwork(const QString &ssid) {
 }
 
 void WifiManager::forgetConnection(const QString &ssid) {
+  disconnect();
   for (QPair<QString, QDBusObjectPath> conn : list_connections_ssid()) {
     if (conn.first == ssid) {
       QDBusInterface nm2(nm_service, conn.second.path(), nm_settings_conn_iface, bus);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -280,8 +280,12 @@ QVector<QDBusObjectPath> WifiManager::get_active_connections() {
 
 bool WifiManager::isKnownNetwork(const QString &ssid) {
   for (QPair<QString, QDBusObjectPath> conn : list_connections_ssid()) {
-    if (conn.first == ssid) return true;
+    if (conn.first == ssid) {
+      qDebug() << "known network!";
+      return true;
+    }
   }
+  qDebug() << "unknown network!";
   return false;
 }
 
@@ -385,17 +389,8 @@ void WifiManager::disconnect() {
 
 QVector<QPair<QString, QDBusObjectPath>> WifiManager::list_connections_ssid() {
   QVector<QPair<QString, QDBusObjectPath>> connections;
-  QDBusInterface nm(nm_service, nm_settings_path, nm_settings_iface, bus);
-  nm.setTimeout(dbus_timeout);
 
-  QDBusMessage response = nm.call("ListConnections");
-  QVariant first =  response.arguments().at(0);
-  const QDBusArgument &args = first.value<QDBusArgument>();
-  args.beginArray();
-  while (!args.atEnd()) {
-    QDBusObjectPath path;
-    args >> path;
-
+  for(QDBusObjectPath path : list_connections()){
     QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
     nm2.setTimeout(dbus_timeout);
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -291,6 +291,7 @@ bool WifiManager::isKnownNetwork(const QString &ssid) {
 
 void WifiManager::forgetConnection(const QString &ssid) {
   disconnect();
+
   for (QDBusObjectPath path : list_connections()) {
     if (ssid_from_path(path) == ssid) {
       QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
@@ -428,7 +429,6 @@ QVector<QDBusObjectPath> WifiManager::list_connections() {
 
 bool WifiManager::activate_wifi_connection(const QString &ssid) {
   QString devicePath = get_adapter();
-
   for (QDBusObjectPath path : list_connections()) {
     if (ssid_from_path(path) == ssid) {
       QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -282,30 +282,14 @@ bool WifiManager::isKnownNetwork(const QString &ssid) {
   for (QPair<QString, QDBusObjectPath> conn : list_connections_ssid()) {
     if (conn.first == ssid) return true;
   }
-  qDebug() << "not a known network!";
   return false;
 }
 
 void WifiManager::forgetConnection(const QString &ssid) {
-  for(QDBusObjectPath path : list_connections()){
-    QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
-    nm2.setTimeout(dbus_timeout);
-
-    QDBusMessage response = nm2.call("GetSettings");
-
-    const QDBusArgument &dbusArg = response.arguments().at(0).value<QDBusArgument>();
-
-    QMap<QString, QMap<QString,QVariant>> map;
-    dbusArg >> map;
-    for (auto &inner : map) {
-      for (auto &val : inner) {
-        QString key = inner.key(val);
-        if (key == "ssid") {
-          if (val == ssid) {
-            nm2.call("Delete");
-          }
-        }
-      }
+  for (QPair<QString, QDBusObjectPath> conn : list_connections_ssid()) {
+    if (conn.first == ssid) {
+      QDBusInterface nm2(nm_service, conn.second.path(), nm_settings_conn_iface, bus);
+      nm2.call("Delete");
     }
   }
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -429,7 +429,7 @@ QVector<QPair<QString, QDBusObjectPath>> WifiManager::list_connections_ssid() {
         }
       }
     }
-    QMap<QString, QDBusObjectPath> conn;
+    QPair<QString, QDBusObjectPath> conn;
     conn.first = ssid;
     conn.second = path;
     connections.push_back(conn);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -203,7 +203,11 @@ SecurityType WifiManager::getSecurityType(const QString &path) {
 }
 
 void WifiManager::connect(const Network &n) {
-  return connect(n, "", "");
+  if (isKnownNetwork(n.ssid)) {
+    activate_wifi_connection(n.ssid);
+  } else {
+    return connect(n, "", "");
+  }
 }
 
 void WifiManager::connect(const Network &n, const QString &password) {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -202,6 +202,10 @@ SecurityType WifiManager::getSecurityType(const QString &path) {
   }
 }
 
+void WifiManager::forget(const Network &n) {
+  clear_connections(n.ssid);
+}
+
 void WifiManager::connect(const Network &n) {
   return connect(n, "", "");
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -202,10 +202,6 @@ SecurityType WifiManager::getSecurityType(const QString &path) {
   }
 }
 
-void WifiManager::forget(const Network &n) {
-  clear_connections(n.ssid);
-}
-
 void WifiManager::connect(const Network &n) {
   return connect(n, "", "");
 }
@@ -216,8 +212,7 @@ void WifiManager::connect(const Network &n, const QString &password) {
 
 void WifiManager::connect(const Network &n, const QString &username, const QString &password) {
   connecting_to_network = n.ssid;
-  // disconnect();
-  clear_connections(n.ssid); //Clear all connections that may already exist to the network we are connecting
+  disconnect();
   connect(n.ssid, username, password, n.security_type);
 }
 
@@ -259,13 +254,13 @@ void WifiManager::deactivate_connections(const QString &ssid) {
       if (Ssid == ssid) {
         QDBusInterface nm2(nm_service, nm_path, nm_iface, bus);
         nm2.setTimeout(dbus_timeout);
-        nm2.call("DeactivateConnection", QVariant::fromValue(active_connection_raw));// TODO change to disconnect
+        nm2.call("DeactivateConnection", QVariant::fromValue(active_connection_raw));  // deactivate is disconnect
       }
     }
   }
 }
 
-QVector<QDBusObjectPath> WifiManager::get_active_connections() {  // TODO: rename to get_connections and have it return all known connections if active=false
+QVector<QDBusObjectPath> WifiManager::get_active_connections() {
   QDBusInterface nm(nm_service, nm_path, props_iface, bus);
   nm.setTimeout(dbus_timeout);
 
@@ -283,7 +278,7 @@ QVector<QDBusObjectPath> WifiManager::get_active_connections() {  // TODO: renam
   return conns;
 }
 
-void WifiManager::clear_connections(const QString &ssid) {
+void WifiManager::forgetConnection(const QString &ssid) {
   for(QDBusObjectPath path : list_connections()){
     QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
     nm2.setTimeout(dbus_timeout);
@@ -520,6 +515,6 @@ bool WifiManager::tetheringEnabled() {
 
 void WifiManager::changeTetheringPassword(const QString &newPassword) {
   tetheringPassword = newPassword;
-  clear_connections(tethering_ssid.toUtf8());
+  forgetConnection(tethering_ssid.toUtf8());
   addTetheringConnection();
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -35,6 +35,7 @@ public:
   QString ipv4_address;
 
   void refreshNetworks();
+  void forget(const Network &ssid);
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);
   void connect(const Network &ssid, const QString &username, const QString &password);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -74,8 +74,8 @@ private:
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &ssid);
-  QVector<QDBusObjectPath> list_connections();
-  QVector<QPair<QString, QDBusObjectPath>> list_connections_ssid();
+  QVector<QPair<QString, QDBusObjectPath>> list_connections();
+  QString ssid_from_path(const QDBusObjectPath &path);
 
 private slots:
   void change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -75,7 +75,7 @@ private:
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &ssid);
   QVector<QDBusObjectPath> list_connections();
-  QVector<QMap<QString, QDBusObjectPath>> list_connections_ssid();
+  QVector<QPair<QString, QDBusObjectPath>> list_connections_ssid();
 
 private slots:
   void change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,11 +34,15 @@ public:
   QVector<Network> seen_networks;
   QString ipv4_address;
 
+  // Network functions
   void refreshNetworks();
+  void forgetConnection(const QString &ssid);
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);
   void connect(const Network &ssid, const QString &username, const QString &password);
   void disconnect();
+
+  bool isKnownNetwork(const QString &ssid);
 
   // Tethering functions
   void enableTethering();
@@ -65,7 +69,6 @@ private:
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString get_active_ap();
   void deactivate_connections(const QString &ssid);
-  void forgetConnection(const QString &ssid);
   QVector<QDBusObjectPath> get_active_connections();
   uint get_wifi_device_state();
   QByteArray get_property(const QString &network_path, const QString &property);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -75,6 +75,7 @@ private:
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &ssid);
   QVector<QDBusObjectPath> list_connections();
+  QVector<QMap<QString, QDBusObjectPath>> list_connections_ssid();
 
 private slots:
   void change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -35,7 +35,6 @@ public:
   QString ipv4_address;
 
   void refreshNetworks();
-  void forget(const Network &ssid);
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);
   void connect(const Network &ssid, const QString &username, const QString &password);
@@ -66,7 +65,7 @@ private:
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString get_active_ap();
   void deactivate_connections(const QString &ssid);
-  void clear_connections(const QString &ssid);
+  void forgetConnection(const QString &ssid);
   QVector<QDBusObjectPath> get_active_connections();
   uint get_wifi_device_state();
   QByteArray get_property(const QString &network_path, const QString &property);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -74,7 +74,7 @@ private:
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &ssid);
-  QVector<QPair<QString, QDBusObjectPath>> list_connections();
+  QVector<QDBusObjectPath> list_connections();
   QString ssid_from_path(const QDBusObjectPath &path);
 
 private slots:


### PR DESCRIPTION
Todo:
- [ ] Able to forget a connected network (do we want to press the ssid name, or have a separate button?)
- [x] Detect if a network is active (connected at any point) and don't ask for password.
- [x] See how many times we can reuse list_connections_ssid, or completely replace the old function (some functions use it differently, need to look into that)
- [ ] How should we handle Forget button for hotspot network?
- [ ] Make refreshing more responsive