### PR TITLE
OffroadHome::refresh(): remove emit before closeAlerts() 

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -175,7 +175,7 @@ void OffroadHome::refresh() {
 
   alerts_widget->refresh();
   if (!alerts_widget->alertCount && !alerts_widget->updateAvailable) {
-    emit closeAlerts();
+    closeAlerts();
     alert_notification->setVisible(false);
     return;
   }


### PR DESCRIPTION
emit a slot does not make sense