### PR TITLE
Toyota: 'Cruise Fault' fix when ignition. Not a TSS2 related fix.

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -181,7 +181,7 @@ static bool usb_retry_connect() {
 
 void can_recv(PubMaster &pm) {
   kj::Array<capnp::word> can_data;
-  panda->can_receive(can_data);
+  if (panda->can_receive(can_data) <= 0) return;
   auto bytes = can_data.asBytes();
   pm.send("can", bytes.begin(), bytes.size());
 }

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -288,7 +288,7 @@ int Panda::can_receive(kj::Array<capnp::word>& out_buf) {
   int recv = usb_bulk_read(0x81, (unsigned char*)data, RECV_SIZE);
 
   // Not sure if this can happen
-  if (recv < 0) recv = 0;
+  if (recv <= 0) return 0;
 
   if (recv == RECV_SIZE) {
     LOGW("Receive buffer full");


### PR DESCRIPTION
**Description** 
  Link: https://github.com/commaai/openpilot/issues/20703#issuecomment-855509195
  Symptom: After ignition on Toyota cars, 'Cruise Fault' alerts appears. When turn-off and turn-on ignition again, it disappears.
  Cause: This bug started since version 0.7.10. Because of timeout exception processing in can_recv() and can_received() were removed. That caused garbage message(s).

**Verification** 
  1. Reboot EON 
  2. Wait until 'VEHICLE ONLINE' appears
  3.  Car Ignition ON 
  4. No 'Cruise Fault' message

**Notes**
  This fix is not directly related to issue #20703.