### PR TITLE
VW MQB: Add FW for 2020 Volkswagen Tiguan

### DIFF
--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -267,15 +267,19 @@ FW_VERSIONS = {
   },
   CAR.TIGUAN_MK2: {
     (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x8704L906027G \xf1\x899893',
       b'\xf1\x8783A907115B \xf1\x890005',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x8709G927158DT\xf1\x893698',
+      b'\xf1\x870DL300013A \xf1\x893005',
     ],
     (Ecu.srs, 0x715, None): [
       b'\xf1\x875Q0959655BM\xf1\x890403\xf1\x82\02316143231313500314641011750179333423100',
+      b'\xf1\x875Q0959655BT\xf1\x890403\xf1\x82\02331310031333336313140013950399333423100',
     ],
     (Ecu.eps, 0x712, None): [
+      b'\xf1\x875QF909144B \xf1\x895582\xf1\x82\00571A60634A1',
       b'\xf1\x875QM909144C \xf1\x891082\xf1\x82\00521A60804A1',
     ],
     (Ecu.fwdRadar, 0x757, None): [


### PR DESCRIPTION
New FW values from a 2020 Tiguan.

**Dongle ID:** 2e1c21ee8a27c5f6

Thanks to community Tiguan owner DominikO.