### PR TITLE
[Feature] Enable Wifi tethering when on road

### DIFF
--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -198,6 +198,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"ShouldDoUpdate", CLEAR_ON_MANAGER_START},
     {"SubscriberInfo", PERSISTENT},
     {"SshEnabled", PERSISTENT},
+    {"TetherEnabled", PERSISTENT},
     {"TermsVersion", PERSISTENT},
     {"Timezone", PERSISTENT},
     {"TrainingVersion", PERSISTENT},

--- a/selfdrive/hardware/eon/hardware.h
+++ b/selfdrive/hardware/eon/hardware.h
@@ -42,6 +42,27 @@ public:
     std::system(cmd.c_str());
   };
 
+  static bool get_tether_enabled() {
+    return std::system("getprop persist.neos.tether | grep -qF '1'") == 0;
+  };
+
+  static void set_tether_enabled(bool enabled) {
+    std::string cmd = util::string_format("setprop persist.neos.tether %d", enabled ? 1 : 0);
+    std::system(cmd.c_str());
+  };
+
+  static void toggle_tether(bool car_started) {
+    std::string cmd;
+    if(get_tether_enabled()) {
+      if(car_started) {
+        cmd = "service call wifi 37 i32 0 i32 1";
+      } else {
+        cmd = "service call wifi 37 i32 0 i32 0";
+      }
+      std::system(cmd.c_str());
+    }
+  };
+
   // android only
   inline static bool launched_activity = false;
   static void check_activity() {

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -20,7 +20,7 @@ if arch == "Darwin":
   qt_env['FRAMEWORKS'] += ['OpenCL']
 
 widgets_src = ["qt/widgets/input.cc", "qt/widgets/drive_stats.cc",
-               "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/controls.cc",
+               "qt/widgets/ssh_keys.cc", "qt/widgets/tether.cc", "qt/widgets/toggle.cc", "qt/widgets/controls.cc",
                "qt/widgets/offroad_alerts.cc", "qt/widgets/setup.cc", "qt/widgets/keyboard.cc",
                "qt/widgets/scrollview.cc", "qt/widgets/cameraview.cc", "#phonelibs/qrcode/QrCode.cc", "qt/api.cc",
                "qt/request_repeater.cc"]

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -164,6 +164,8 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   vlayout->addWidget(new SshToggle());
   vlayout->addWidget(horizontal_line(), 0);
   vlayout->addWidget(new SshControl());
+  vlayout->addWidget(horizontal_line(), 0);
+  vlayout->addWidget(new TetherToggle());
 
   vlayout->addStretch(1);
   setLayout(vlayout);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -9,7 +9,8 @@
 #include "selfdrive/ui/qt/offroad/wifiManager.h"
 #include "selfdrive/ui/qt/widgets/input.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
-#include "selfdrive/ui/qt/widgets/toggle.h"
+#include "selfdrive/ui/qt/widgets/tether.h"
+##include "selfdrive/ui/qt/widgets/toggle.h"
 
 class NetworkStrengthWidget : public QWidget {
   Q_OBJECT

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -19,6 +19,7 @@
 #include "selfdrive/ui/qt/widgets/offroad_alerts.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
+#include "selfdrive/ui/qt/widgets/tether.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
 #include "selfdrive/ui/ui.h"
 #include "selfdrive/ui/qt/util.h"
@@ -306,6 +307,8 @@ QWidget * network_panel(QWidget * parent) {
   layout->addWidget(new SshToggle());
   layout->addWidget(horizontal_line());
   layout->addWidget(new SshControl());
+  layout->addWidget(horizontal_line());
+  layout->addWidget(new TetherToggle());
 
   layout->addStretch(1);
 

--- a/selfdrive/ui/qt/widgets/tether.cc
+++ b/selfdrive/ui/qt/widgets/tether.cc
@@ -1,0 +1,8 @@
+#include "tether.h"
+
+#include <QHBoxLayout>
+#include <QNetworkReply>
+
+#include "selfdrive/common/params.h"
+#include "selfdrive/ui/qt/api.h"
+#include "selfdrive/ui/qt/widgets/input.h"

--- a/selfdrive/ui/qt/widgets/tether.h
+++ b/selfdrive/ui/qt/widgets/tether.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QPushButton>
+
+#include "selfdrive/hardware/hw.h"
+#include "selfdrive/ui/qt/widgets/controls.h"
+
+// Tether enable toggle
+class TetherToggle : public ToggleControl {
+  Q_OBJECT
+
+public:
+  TetherToggle() : ToggleControl("Enable tethering when driving", "", "", Hardware::get_tether_enabled()) {
+    QObject::connect(this, &TetherToggle::toggleFlipped, [=](bool state) {
+      Hardware::set_tether_enabled(state);
+    });
+  }
+};

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -311,6 +311,7 @@ void QUIState::update() {
     started_prev = ui_state.scene.started;
     emit offroadTransition(!ui_state.scene.started);
 
+    Hardware::toggle_tether(ui_state.scene.started);
     // Change timeout to 0 when onroad, this will call update continously.
     // This puts visionIPC in charge of update frequency, reducing video latency
     timer->start(ui_state.scene.started ? 0 : 1000 / UI_FREQ);


### PR DESCRIPTION
Enable wifi tethering when car is started,  disable it when car is stopped.

I realize where I put the activation code, `ui.cc` might not be the best place. Happy to move it to a better one if suggested.

Code is tested and working on my C2 in my pacifica.
