### PR TITLE
ui: networking refactor

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -216,8 +216,8 @@ void WifiUI::refresh() {
 
     if (wifiManager->isKnownNetwork(network.ssid)) {
       QPushButton *forgetBtn = new QPushButton("\U0000274c");
-      forgetBtn->setFlat(true);
-      forgetBtn->setStyleSheet("QPushButton { border-radius: 0px; padding: 0px; font-size: 55px; background-color: transparent; color: #E22C2C; }");
+//      forgetBtn->setFlat(true);
+      forgetBtn->setStyleSheet("QPushButton { padding: 0px; font-size: 55px; background-color: #E22C2C; color: #dddddd }");
       forgetBtn->setFixedWidth(75);
 
       QObject::connect(forgetBtn, &QPushButton::released, [=]() {

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -1,4 +1,3 @@
-//#include <random>
 #include "selfdrive/ui/qt/offroad/networking.h"
 
 #include <QDebug>
@@ -39,7 +38,7 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
   // TODO: we can also add another timer that refreshes much less often in the background
   QTimer* timer = new QTimer(this);
   QObject::connect(timer, &QTimer::timeout, this, [=](){ refresh(false); });
-  timer->start(2000);
+  timer->start(5000);
 }
 
 void Networking::attemptInitialization() {
@@ -58,7 +57,7 @@ void Networking::attemptInitialization() {
     QPushButton* advancedSettings = new QPushButton("More Settings");  // TODO: fixup the name of the advanced settings class and button
     // TODO: make it so we don't have to hard code a weird margin, the connect buttons don't need this (yes, it's 9 px)
     advancedSettings->setStyleSheet("margin-right: 9px;");
-    advancedSettings->setFixedSize(425, 100);
+    advancedSettings->setFixedSize(500, 100);
     connect(advancedSettings, &QPushButton::released, [=]() { s->setCurrentWidget(an); });
     vlayout->addSpacing(10);
     vlayout->addWidget(advancedSettings, 0, Qt::AlignRight);
@@ -96,7 +95,7 @@ void Networking::attemptInitialization() {
   ui_setup_complete = true;
 }
 
-void Networking::refresh(bool force) {
+void Networking::refresh(bool force) {  // TODO why does this take almost a second to finish?
   if (!this->isVisible() && !force) {
     return;
   }
@@ -230,7 +229,7 @@ void WifiUI::refresh() {
       hlayout->addWidget(forgetBtn, 0, Qt::AlignLeft);
     } else {
       // TODO should be a label, but spacing is off
-      QPushButton *securityLabel = new QPushButton(rand() % 2 ? "\U0001F512" : "\U0001F513");
+      QPushButton *securityLabel = new QPushButton((network.security_type == SecurityType::WPA) ? "\U0001F512" : "\U0001F513");
 
       securityLabel->setStyleSheet("QPushButton { border-radius: 0px; padding: 0px; background-color: transparent; font-size: 55px }");
       securityLabel->setFixedWidth(75);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -26,10 +26,10 @@ class WifiUI : public QWidget {
   Q_OBJECT
 
 public:
-  explicit WifiUI(QWidget *parent = 0, WifiManager* wifi = 0);
+  explicit WifiUI(QWidget *parent = 0, WifiManager* wifiManager = 0);
 
 private:
-  WifiManager *wifi = nullptr;
+  WifiManager *wifiManager = nullptr;
   QVBoxLayout *vlayout;
 
   QButtonGroup *connectButtons;
@@ -46,12 +46,12 @@ public slots:
 class AdvancedNetworking : public QWidget {
   Q_OBJECT
 public:
-  explicit AdvancedNetworking(QWidget* parent = 0, WifiManager* wifi = 0);
+  explicit AdvancedNetworking(QWidget* parent = 0, WifiManager* wifiManager = 0);
 
 private:
   LabelControl* ipLabel;
   ButtonControl* editPasswordButton;
-  WifiManager* wifi = nullptr;
+  WifiManager* wifiManager = nullptr;
 
 signals:
   void backPress();
@@ -77,12 +77,12 @@ private:
   Network selectedNetwork;
 
   WifiUI* wifiWidget;
-  WifiManager* wifi = nullptr;
+  WifiManager* wifiManager = nullptr;
   void attemptInitialization();
 
 private slots:
   void connectToNetwork(const Network &n);
-  void refresh();
+  void refresh(bool force);
   void wrongPassword(const QString &ssid);
 };
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -289,31 +289,31 @@ void SoftwarePanel::updateLabels() {
 }
 
 QWidget * network_panel(QWidget * parent) {
-//#ifdef QCOM
-//  QVBoxLayout *layout = new QVBoxLayout;
-//  layout->setSpacing(30);
-//
-//  // wifi + tethering buttons
-//  layout->addWidget(new ButtonControl("WiFi Settings", "OPEN", "",
-//                                      [=]() { HardwareEon::launch_wifi(); }));
-//  layout->addWidget(horizontal_line());
-//
-//  layout->addWidget(new ButtonControl("Tethering Settings", "OPEN", "",
-//                                      [=]() { HardwareEon::launch_tethering(); }));
-//  layout->addWidget(horizontal_line());
-//
-//  // SSH key management
-//  layout->addWidget(new SshToggle());
-//  layout->addWidget(horizontal_line());
-//  layout->addWidget(new SshControl());
-//
-//  layout->addStretch(1);
-//
-//  QWidget *w = new QWidget(parent);
-//  w->setLayout(layout);
-//#else
+#ifdef QCOM
+  QVBoxLayout *layout = new QVBoxLayout;
+  layout->setSpacing(30);
+
+  // wifi + tethering buttons
+  layout->addWidget(new ButtonControl("WiFi Settings", "OPEN", "",
+                                      [=]() { HardwareEon::launch_wifi(); }));
+  layout->addWidget(horizontal_line());
+
+  layout->addWidget(new ButtonControl("Tethering Settings", "OPEN", "",
+                                      [=]() { HardwareEon::launch_tethering(); }));
+  layout->addWidget(horizontal_line());
+
+  // SSH key management
+  layout->addWidget(new SshToggle());
+  layout->addWidget(horizontal_line());
+  layout->addWidget(new SshControl());
+
+  layout->addStretch(1);
+
+  QWidget *w = new QWidget(parent);
+  w->setLayout(layout);
+#else
   Networking *w = new Networking(parent);
-//#endif
+#endif
   return w;
 }
 
@@ -392,6 +392,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
     nav_btns->addButton(btn);
     sidebar_layout->addWidget(btn, 0, Qt::AlignRight);
 
+//    int left_margin = name != "Network" ? 50 : 0;  // Network panel handles its own margin // TODO
     panel->setContentsMargins(50, 25, 50, 25);
 
     ScrollView *panel_frame = new ScrollView(panel, this);

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -289,31 +289,31 @@ void SoftwarePanel::updateLabels() {
 }
 
 QWidget * network_panel(QWidget * parent) {
-#ifdef QCOM
-  QVBoxLayout *layout = new QVBoxLayout;
-  layout->setSpacing(30);
-
-  // wifi + tethering buttons
-  layout->addWidget(new ButtonControl("WiFi Settings", "OPEN", "",
-                                      [=]() { HardwareEon::launch_wifi(); }));
-  layout->addWidget(horizontal_line());
-
-  layout->addWidget(new ButtonControl("Tethering Settings", "OPEN", "",
-                                      [=]() { HardwareEon::launch_tethering(); }));
-  layout->addWidget(horizontal_line());
-
-  // SSH key management
-  layout->addWidget(new SshToggle());
-  layout->addWidget(horizontal_line());
-  layout->addWidget(new SshControl());
-
-  layout->addStretch(1);
-
-  QWidget *w = new QWidget(parent);
-  w->setLayout(layout);
-#else
+//#ifdef QCOM
+//  QVBoxLayout *layout = new QVBoxLayout;
+//  layout->setSpacing(30);
+//
+//  // wifi + tethering buttons
+//  layout->addWidget(new ButtonControl("WiFi Settings", "OPEN", "",
+//                                      [=]() { HardwareEon::launch_wifi(); }));
+//  layout->addWidget(horizontal_line());
+//
+//  layout->addWidget(new ButtonControl("Tethering Settings", "OPEN", "",
+//                                      [=]() { HardwareEon::launch_tethering(); }));
+//  layout->addWidget(horizontal_line());
+//
+//  // SSH key management
+//  layout->addWidget(new SshToggle());
+//  layout->addWidget(horizontal_line());
+//  layout->addWidget(new SshControl());
+//
+//  layout->addStretch(1);
+//
+//  QWidget *w = new QWidget(parent);
+//  w->setLayout(layout);
+//#else
   Networking *w = new Networking(parent);
-#endif
+//#endif
   return w;
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -288,7 +288,7 @@ void WifiManager::forgetConnection(const QString &ssid) {
   }
 }
 
-void WifiManager::request_scan() {
+void WifiManager::requestScan() {
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
   nm.call("RequestScan",  QVariantMap());

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -279,7 +279,7 @@ QVector<QDBusObjectPath> WifiManager::get_active_connections() {
 }
 
 void WifiManager::forgetConnection(const QString &ssid) {
-  disconnect();
+  disconnect(ssid, true);  // only disconnects if forgetting current network
   for (QDBusObjectPath path : list_connections()) {
     if (ssid_from_path(path) == ssid) {
       QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
@@ -370,10 +370,13 @@ void WifiManager::change(unsigned int new_state, unsigned int previous_state, un
   }
 }
 
-void WifiManager::disconnect() {
+void WifiManager::disconnect(const QString &ssid, bool check_ssid) {
   QString active_ap = get_active_ap();
   if (active_ap != "" && active_ap != "/") {
-    deactivate_connections(get_property(active_ap, "Ssid"));
+    const QString active_ssid = get_property(active_ap, "Ssid");
+    if ((check_ssid && active_ssid == ssid) || (!check_ssid)) {
+      deactivate_connections(get_property(active_ap, "Ssid"));
+    }
   }
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -39,7 +39,7 @@ public:
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);
   void connect(const Network &ssid, const QString &username, const QString &password);
-  void disconnect();
+  void disconnect(const QString &ssid = "", bool check_ssid = false);
   void forgetConnection(const QString &ssid);
 
   // Tethering functions

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -30,7 +30,7 @@ class WifiManager : public QWidget {
 public:
   explicit WifiManager(QWidget* parent);
 
-  void request_scan();
+  void requestScan();
   QVector<Network> seen_networks;
   QString ipv4_address;
 
@@ -72,6 +72,7 @@ private:
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &ssid);
   QVector<QDBusObjectPath> list_connections();
+  QString ssid_from_path(const QDBusObjectPath &path);
 
 private slots:
   void change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,6 +34,7 @@ public:
   QVector<Network> seen_networks;
   QString ipv4_address;
 
+  bool isKnownNetwork(const QString &ssid);  // TODO: remove once other PR to add this is merged in, then rebase
   void refreshNetworks();
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -39,6 +39,7 @@ public:
   void connect(const Network &ssid, const QString &password);
   void connect(const Network &ssid, const QString &username, const QString &password);
   void disconnect();
+  void forgetConnection(const QString &ssid);
 
   // Tethering functions
   void enableTethering();
@@ -65,7 +66,6 @@ private:
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString get_active_ap();
   void deactivate_connections(const QString &ssid);
-  void clear_connections(const QString &ssid);
   QVector<QDBusObjectPath> get_active_connections();
   uint get_wifi_device_state();
   QByteArray get_property(const QString &network_path, const QString &property);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -364,7 +364,7 @@ void Device::updateBrightness(const UIState &s) {
 }
 
 void Device::updateWakefulness(const UIState &s) {
-  awake_timeout = std::max(awake_timeout - 1, 0);
+//  awake_timeout = std::max(awake_timeout - 1, 0);  // TODO: uncomment me
 
   bool should_wake = s.scene.started || s.scene.ignition;
   if (!should_wake) {


### PR DESCRIPTION
Main todo:
- [ ] Add forget button
- [ ] General clean up
- [ ] Fix lag in Networking::refresh() function so we can speed up frequency a bit
- [ ] Better icons, just emoji right now


Personal tracker and notes (ignore):
- [x] Make More Settings button same width as Back button
- [ ] Standardize the function naming conventions (some camel case, some snake case 🐍)
- [x] Instead of getting the map of variables for a path in each function that calls `list_connection` there's a helper function that gets the ssid from path
- [x] Cache wifi networks on UI init
  - [ ] We can also run a slow refresh timer in the background, so that it will usually be up to date when the user visits the wifi panel
