### PR TITLE
Fix UI crash when going onroad after onboarding

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -260,7 +260,9 @@ static void update_status(UIState *s) {
       s->wide_camera = Hardware::TICI() ? Params().getBool("EnableWideCamera") : false;
 
       // Update intrinsics matrix after possible wide camera toggle change
-      ui_resize(s, s->fb_w, s->fb_h);
+      if (s->vg) {
+        ui_resize(s, s->fb_w, s->fb_h);
+      }
 
       // Choose vision ipc client
       if (s->wide_camera){


### PR DESCRIPTION
Fixes a crash when onboarding is shown as the first top level widget. When the HomeWindow is shown first instead of OnboardWindow (as is normally the case except on first startup), NvgWindow::initializeGL is called as it may be shown. However, when OnboardingWindow is shown first, NvgWindow is clearly hidden, so NvgWindow::initializeGL isn't called until NvgWindow is visible, which crashes UI due to ui_resize getting called before ui_nvg_init. 