### PR TITLE
Update lane line indicators on car HUD to be linked to OP enabled state

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -521,8 +521,10 @@ class Controls:
 
     right_lane_visible = self.sm['lateralPlan'].rProb > 0.5
     left_lane_visible = self.sm['lateralPlan'].lProb > 0.5
-    CC.hudControl.rightLaneVisible = bool(right_lane_visible)
-    CC.hudControl.leftLaneVisible = bool(left_lane_visible)
+
+    #Do this since it causes A LOT of flickering on the HUD at times.
+    CC.hudControl.rightLaneVisible = self.enabled
+    CC.hudControl.leftLaneVisible = self.enabled
 
     recent_blinker = (self.sm.frame - self.last_blinker_frame) * DT_CTRL < 5.0  # 5s blinker cooldown
     ldw_allowed = self.is_ldw_enabled and CS.vEgo > LDW_MIN_SPEED and not recent_blinker \


### PR DESCRIPTION
The lane line indicators on the car HUD flicker a lot at times
since there are times when the lane probability fluctuates a lot
in places like parking lots. The purpose of the lane line indicators
on most of the car HUDs is to indicate whether the system detects
lane lines and if both are there, the system is available (mostly).
Since OP can be enabled pretty much anywhere, I think this change
makes sense.

Can be verified by enabling OP, lane indicators on HUD should turn on.
Otherwise, they are off.

Video of said issue can be found here: https://cdn.discordapp.com/attachments/524328425415245827/851598155585945639/20210607_190620.mp4
