### PR TITLE
Release GIL when calling C++ params functions

### DIFF
--- a/common/params_pxd.pxd
+++ b/common/params_pxd.pxd
@@ -17,12 +17,12 @@ cdef extern from "selfdrive/common/params.h":
     ALL
 
   cdef cppclass Params:
-    Params(bool)
-    Params(string)
+    Params(bool) nogil
+    Params(string) nogil
     string get(string, bool) nogil
-    bool getBool(string)
-    int remove(string)
-    int put(string, string)
-    int putBool(string, bool)
-    bool checkKey(string)
+    bool getBool(string) nogil
+    int remove(string) nogil
+    int put(string, string) nogil
+    int putBool(string, bool) nogil
+    bool checkKey(string) nogil
     void clearAll(ParamKeyType)

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -57,13 +57,12 @@ cdef class Params:
 
     return key
 
-  def get(self, key, block=False, encoding=None):
+  def get(self, key, bool block=False, encoding=None):
     cdef string k = self.check_key(key)
-    cdef bool b = block
 
     cdef string val
     with nogil:
-      val = self.p.get(k, b)
+      val = self.p.get(k, block)
 
     if val == b"":
       if block:
@@ -97,11 +96,10 @@ cdef class Params:
     with nogil:
       self.p.put(k, dat_bytes)
 
-  def put_bool(self, key, val):
+  def put_bool(self, key, bool val):
     cdef string k = self.check_key(key)
-    cdef bool b = val
     with nogil:
-      self.p.putBool(k, b)
+      self.p.putBool(k, val)
 
   def delete(self, key):
     cdef string k = self.check_key(key)

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -31,10 +31,14 @@ cdef class Params:
   cdef c_Params* p
 
   def __cinit__(self, d=None, bool persistent_params=False):
+    cdef string path
     if d is None:
-      self.p = new c_Params(persistent_params)
+      with nogil:
+        self.p = new c_Params(persistent_params)
     else:
-      self.p = new c_Params(<string>d.encode())
+      path = <string>d.encode()
+      with nogil:
+        self.p = new c_Params(path)
 
   def __dealloc__(self):
     del self.p
@@ -76,7 +80,10 @@ cdef class Params:
 
   def get_bool(self, key):
     cdef string k = self.check_key(key)
-    return self.p.getBool(k)
+    cdef bool r
+    with nogil:
+      r = self.p.getBool(k)
+    return r
 
   def put(self, key, dat):
     """
@@ -86,16 +93,20 @@ cdef class Params:
     in general try to avoid writing params as much as possible.
     """
     cdef string k = self.check_key(key)
-    dat = ensure_bytes(dat)
-    self.p.put(k, dat)
+    cdef string dat_bytes = ensure_bytes(dat)
+    with nogil:
+      self.p.put(k, dat_bytes)
 
   def put_bool(self, key, val):
     cdef string k = self.check_key(key)
-    self.p.putBool(k, val)
+    cdef bool b = val
+    with nogil:
+      self.p.putBool(k, b)
 
   def delete(self, key):
     cdef string k = self.check_key(key)
-    self.p.remove(k)
+    with nogil:
+      self.p.remove(k)
 
 
 def put_nonblocking(key, val, d=None):


### PR DESCRIPTION
Run updater continuously:
```python
import psutil

from selfdrive.updated import init_overlay, finalize_update

# Set low io priority (doesn't seem to affect the results much, but match updated)
proc = psutil.Process()
proc.ionice(psutil.IOPRIO_CLASS_BE, value=7)

init_overlay()
while True:
  finalize_update()
```

Try writing to params in the background. Observe this loop runs slower than 10 Hz indicating the GIL is not released.
```python
import time

from common.params import put_nonblocking
from common.realtime import set_realtime_priority

# set_realtime_priority(1)

t = time.time()
while True:
  dt = time.time() - t
  if dt > 0.2:
    print(dt)
  t = time.time()

  put_nonblocking("GitCommit", "abcdjkldsjflksfd")
  time.sleep(0.1)

```

Probably also the actual issue behind https://github.com/commaai/openpilot/issues/20675, although disabling the GC for paramsd was a good change as well.

Without these changes lags between 0.5 and 5 seconds are observed often. With the changes from this PR the situation is much better, but can still produce small lags (0.2-0.5) from time to time, not exactly sure yet where those come from. Pinning both scripts to a different core doesn't help.

By setting real time priority (even a very low one) this is fixed as well, but not sure if we want to do that for paramsd/locationd. Setting real time priority without the changes from this PR has no effect.