### PR TITLE
hyundai: cruiseState.standstill does not exist for openpilot longitudinal

### DIFF
--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -40,7 +40,7 @@ class CarState(CarStateBase):
     if self.CP.openpilotLongitudinalControl:
       ret.cruiseState.available = cp.vl["TCS13"]["ACCEnable"] == 0
       ret.cruiseState.enabled = cp.vl["TCS13"]["ACC_REQ"] == 1
-      ret.cruiseState.standstill = cp.vl["TCS13"]["StandStill"] == 1
+      ret.cruiseState.standstill = False
     else:
       ret.cruiseState.available = cp.vl["SCC11"]["MainMode_ACC"] == 1
       ret.cruiseState.enabled = cp.vl["SCC12"]["ACCMode"] != 0


### PR DESCRIPTION
`curiseState.standstill`  is supposed to be when the user is stopped and prompted to hit resume to continue, which will never happen if openpilot is controlling longitudinal

without this fix `LongControl` will never transition from the stopping state to the starting state