### PR TITLE
qt/api.cc: refactor create_jwt

### DIFF
--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -1,15 +1,15 @@
 #include "selfdrive/ui/qt/api.h"
 
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+
+#include <QCryptographicHash>
 #include <QDateTime>
 #include <QDebug>
 #include <QFile>
 #include <QJsonDocument>
-#include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QRandomGenerator>
-#include <QString>
-#include <QTimer>
-#include <QWidget>
 
 #include "selfdrive/common/params.h"
 #include "selfdrive/common/util.h"

--- a/selfdrive/ui/qt/api.h
+++ b/selfdrive/ui/qt/api.h
@@ -5,12 +5,11 @@
 #include <openssl/rsa.h>
 
 #include <QCryptographicHash>
+#include <QJsonObject>
 #include <QJsonValue>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QPair>
 #include <QString>
-#include <QVector>
 #include <QWidget>
 #include <atomic>
 
@@ -19,7 +18,7 @@ class CommaApi : public QObject {
 
 public:
   static QByteArray rsa_sign(const QByteArray &data);
-  static QString create_jwt(const QVector<QPair<QString, QJsonValue>> &payloads = {}, int expiry = 3600);
+  static QString create_jwt(const QJsonObject &payloads = {}, int expiry = 3600);
 };
 
 /**

--- a/selfdrive/ui/qt/api.h
+++ b/selfdrive/ui/qt/api.h
@@ -1,17 +1,9 @@
 #pragma once
 
-#include <openssl/bio.h>
-#include <openssl/pem.h>
-#include <openssl/rsa.h>
-
-#include <QCryptographicHash>
 #include <QJsonObject>
-#include <QJsonValue>
 #include <QNetworkReply>
-#include <QNetworkRequest>
 #include <QString>
-#include <QWidget>
-#include <atomic>
+#include <QTimer>
 
 class CommaApi : public QObject {
   Q_OBJECT


### PR DESCRIPTION
- Constructs `QJsonObject` from initialization list.
- Pass payloads as `QJsonObject` 
- Cleanup includes