### PR TITLE
UI: skip SetupWidget if the dongle id is not valid

### DIFF
--- a/selfdrive/ui/qt/widgets/setup.cc
+++ b/selfdrive/ui/qt/widgets/setup.cc
@@ -102,11 +102,9 @@ PrimeUserWidget::PrimeUserWidget(QWidget* parent) : QWidget(parent) {
 
   // set up API requests
   std::string dongleId = Params().get("DongleId");
-  if (util::is_valid_dongle_id(dongleId)) {
-    std::string url = "https://api.commadotai.com/v1/devices/" + dongleId + "/owner";
-    RequestRepeater *repeater = new RequestRepeater(this, QString::fromStdString(url), "ApiCache_Owner", 6);
-    QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &PrimeUserWidget::replyFinished);
-  }
+  std::string url = "https://api.commadotai.com/v1/devices/" + dongleId + "/owner";
+  RequestRepeater *repeater = new RequestRepeater(this, QString::fromStdString(url), "ApiCache_Owner", 6);
+  QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &PrimeUserWidget::replyFinished);
 }
 
 void PrimeUserWidget::replyFinished(const QString &response) {
@@ -152,6 +150,11 @@ PrimeAdWidget::PrimeAdWidget(QWidget* parent) : QWidget(parent) {
 
 
 SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
+  std::string dongleId = Params().get("DongleId");
+  if (!util::is_valid_dongle_id(dongleId)) {
+    return;
+  }
+
   mainLayout = new QStackedWidget;
 
   // Unpaired, registration prompt layout
@@ -230,14 +233,12 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
   setSizePolicy(sp_retain);
 
   // set up API requests
-  std::string dongleId = Params().get("DongleId");
-  if (util::is_valid_dongle_id(dongleId)) {
-    std::string url = "https://api.commadotai.com/v1.1/devices/" + dongleId + "/";
-    RequestRepeater* repeater = new RequestRepeater(this, QString::fromStdString(url), "ApiCache_Device", 5);
+  std::string url = "https://api.commadotai.com/v1.1/devices/" + dongleId + "/";
+  RequestRepeater* repeater = new RequestRepeater(this, QString::fromStdString(url), "ApiCache_Device", 5);
 
-    QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &SetupWidget::replyFinished);
-    QObject::connect(repeater, &RequestRepeater::failedResponse, this, &SetupWidget::parseError);
-  }
+  QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &SetupWidget::replyFinished);
+  QObject::connect(repeater, &RequestRepeater::failedResponse, this, &SetupWidget::parseError);
+
   hide(); // Only show when first request comes back
 }
 


### PR DESCRIPTION
Since #21275 openpilot does not show the SetupWidget if the dongle id is not valid, therefore we can skip most of the constructor + PrimeUserWidget, PrimeAdWidget and PairingQRWidget