### PR TITLE
VW MQB: Simplify adding new cars (1 of 2)

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -10,7 +10,7 @@ class CarController():
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
 
-    self.packer_pt = CANPacker(dbc_dict('vw_mqb_2010', None)["pt"])
+    self.packer_pt = CANPacker("vw_mqb_2010")
 
     self.hcaSameTorqueCount = 0
     self.hcaEnabledFrameCount = 0

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,5 +1,5 @@
 from cereal import car
-from selfdrive.car import apply_std_steer_torque_limits, dbc_dict
+from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.volkswagen import volkswagencan
 from selfdrive.car.volkswagen.values import CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
 from opendbc.can.packer import CANPacker

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,7 +1,7 @@
 from cereal import car
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.volkswagen import volkswagencan
-from selfdrive.car.volkswagen.values import CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
+from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
 from opendbc.can.packer import CANPacker
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
@@ -10,7 +10,7 @@ class CarController():
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
 
-    self.packer_pt = CANPacker("vw_mqb_2010")
+    self.packer_pt = CANPacker(DBC.mqb)
 
     self.hcaSameTorqueCount = 0
     self.hcaEnabledFrameCount = 0

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,7 +1,7 @@
 from cereal import car
-from selfdrive.car import apply_std_steer_torque_limits
+from selfdrive.car import apply_std_steer_torque_limits, dbc_dict
 from selfdrive.car.volkswagen import volkswagencan
-from selfdrive.car.volkswagen.values import DBC, CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
+from selfdrive.car.volkswagen.values import CANBUS, MQB_LDW_MESSAGES, BUTTON_STATES, CarControllerParams
 from opendbc.can.packer import CANPacker
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
@@ -10,7 +10,7 @@ class CarController():
   def __init__(self, dbc_name, CP, VM):
     self.apply_steer_last = 0
 
-    self.packer_pt = CANPacker(DBC[CP.carFingerprint]['pt'])
+    self.packer_pt = CANPacker(dbc_dict('vw_mqb_2010', None)["pt"])
 
     self.hcaSameTorqueCount = 0
     self.hcaEnabledFrameCount = 0

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -10,7 +10,7 @@ from selfdrive.car.volkswagen.values import CANBUS, TransmissionType, GearShifte
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
-    can_define = CANDefine(dbc_dict('vw_mqb_2010', None)["pt"])
+    can_define = CANDefine("vw_mqb_2010")
     if CP.transmissionType == TransmissionType.automatic:
       self.shifter_values = can_define.dv["Getriebe_11"]["GE_Fahrstufe"]
     elif CP.transmissionType == TransmissionType.direct:
@@ -240,7 +240,7 @@ class CarState(CarStateBase):
       signals += MqbExtraSignals.bsm_radar_signals
       checks += MqbExtraSignals.bsm_radar_checks
 
-    return CANParser(dbc_dict('vw_mqb_2010', None)["pt"], signals, checks, CANBUS.pt)
+    return CANParser("vw_mqb_2010", signals, checks, CANBUS.pt)
 
   @staticmethod
   def get_cam_can_parser(CP):
@@ -259,7 +259,7 @@ class CarState(CarStateBase):
       ("LDW_02", 10)        # From R242 Driver assistance camera
     ]
 
-    return CANParser(dbc_dict('vw_mqb_2010', None)["pt"], signals, checks, CANBUS.cam)
+    return CANParser("vw_mqb_2010", signals, checks, CANBUS.cam)
 
 class MqbExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -1,7 +1,6 @@
 import numpy as np
 from cereal import car
 from selfdrive.config import Conversions as CV
-from selfdrive.car import dbc_dict
 from selfdrive.car.interfaces import CarStateBase
 from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -1,15 +1,16 @@
 import numpy as np
 from cereal import car
 from selfdrive.config import Conversions as CV
+from selfdrive.car import dbc_dict
 from selfdrive.car.interfaces import CarStateBase
 from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine
-from selfdrive.car.volkswagen.values import DBC, CANBUS, TransmissionType, GearShifter, BUTTON_STATES, CarControllerParams
+from selfdrive.car.volkswagen.values import CANBUS, TransmissionType, GearShifter, BUTTON_STATES, CarControllerParams
 
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
-    can_define = CANDefine(DBC[CP.carFingerprint]["pt"])
+    can_define = CANDefine(dbc_dict('vw_mqb_2010', None)["pt"])
     if CP.transmissionType == TransmissionType.automatic:
       self.shifter_values = can_define.dv["Getriebe_11"]["GE_Fahrstufe"]
     elif CP.transmissionType == TransmissionType.direct:
@@ -239,7 +240,7 @@ class CarState(CarStateBase):
       signals += MqbExtraSignals.bsm_radar_signals
       checks += MqbExtraSignals.bsm_radar_checks
 
-    return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, CANBUS.pt)
+    return CANParser(dbc_dict('vw_mqb_2010', None)["pt"], signals, checks, CANBUS.pt)
 
   @staticmethod
   def get_cam_can_parser(CP):
@@ -258,7 +259,7 @@ class CarState(CarStateBase):
       ("LDW_02", 10)        # From R242 Driver assistance camera
     ]
 
-    return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, CANBUS.cam)
+    return CANParser(dbc_dict('vw_mqb_2010', None)["pt"], signals, checks, CANBUS.cam)
 
 class MqbExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -4,12 +4,12 @@ from selfdrive.config import Conversions as CV
 from selfdrive.car.interfaces import CarStateBase
 from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine
-from selfdrive.car.volkswagen.values import CANBUS, TransmissionType, GearShifter, BUTTON_STATES, CarControllerParams
+from selfdrive.car.volkswagen.values import DBC, CANBUS, TransmissionType, GearShifter, BUTTON_STATES, CarControllerParams
 
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
-    can_define = CANDefine("vw_mqb_2010")
+    can_define = CANDefine(DBC.mqb)
     if CP.transmissionType == TransmissionType.automatic:
       self.shifter_values = can_define.dv["Getriebe_11"]["GE_Fahrstufe"]
     elif CP.transmissionType == TransmissionType.direct:
@@ -239,7 +239,7 @@ class CarState(CarStateBase):
       signals += MqbExtraSignals.bsm_radar_signals
       checks += MqbExtraSignals.bsm_radar_checks
 
-    return CANParser("vw_mqb_2010", signals, checks, CANBUS.pt)
+    return CANParser(DBC.mqb, signals, checks, CANBUS.pt)
 
   @staticmethod
   def get_cam_can_parser(CP):
@@ -258,7 +258,7 @@ class CarState(CarStateBase):
       ("LDW_02", 10)        # From R242 Driver assistance camera
     ]
 
-    return CANParser("vw_mqb_2010", signals, checks, CANBUS.cam)
+    return CANParser(DBC.mqb, signals, checks, CANBUS.cam)
 
 class MqbExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -517,20 +517,3 @@ FW_VERSIONS = {
     ],
   },
 }
-
-DBC = {
-  CAR.ATLAS_MK1: dbc_dict('vw_mqb_2010', None),
-  CAR.GOLF_MK7: dbc_dict('vw_mqb_2010', None),
-  CAR.JETTA_MK7: dbc_dict('vw_mqb_2010', None),
-  CAR.PASSAT_MK8: dbc_dict('vw_mqb_2010', None),
-  CAR.TIGUAN_MK2: dbc_dict('vw_mqb_2010', None),
-  CAR.TOURAN_MK2: dbc_dict('vw_mqb_2010', None),
-  CAR.AUDI_A3_MK3: dbc_dict('vw_mqb_2010', None),
-  CAR.AUDI_Q2_MK1: dbc_dict('vw_mqb_2010', None),
-  CAR.SEAT_ATECA_MK1: dbc_dict('vw_mqb_2010', None),
-  CAR.SEAT_LEON_MK3: dbc_dict('vw_mqb_2010', None),
-  CAR.SKODA_KODIAQ_MK1: dbc_dict('vw_mqb_2010', None),
-  CAR.SKODA_OCTAVIA_MK3: dbc_dict('vw_mqb_2010', None),
-  CAR.SKODA_SCALA_MK1: dbc_dict('vw_mqb_2010', None),
-  CAR.SKODA_SUPERB_MK3: dbc_dict('vw_mqb_2010', None),
-}

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -25,6 +25,9 @@ class CANBUS:
   pt = 0
   cam = 2
 
+class DBC:
+  mqb = "vw_mqb_2010"
+
 TransmissionType = car.CarParams.TransmissionType
 GearShifter = car.CarState.GearShifter
 

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 
-from selfdrive.car import dbc_dict
 from cereal import car
 Ecu = car.CarParams.Ecu
 

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -26,7 +26,7 @@ class CANBUS:
   cam = 2
 
 class DBC:
-  mqb = "vw_mqb_2010"
+  mqb = "vw_mqb_2010"  # Used for all cars with MQB-style CAN messaging
 
 TransmissionType = car.CarParams.TransmissionType
 GearShifter = car.CarState.GearShifter


### PR DESCRIPTION
We don't need different DBCs for every car, so lose the extra steps and extra code needed to onboard new models. If/when PQ comes onboard, those will be using entirely different CAN parser and packer functions anyway.