### PR TITLE
VW MQB: Simplify adding new cars (2 of 2)

### DIFF
--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -49,11 +49,11 @@ class CarInterface(CarInterfaceBase):
     # Optional per-CAR attributes, with defaults
     ret.steerActuatorDelay = ATTRIBUTES[candidate].setdefault("steer_actuator_delay", 0.05)  # Seems good for most MQB
     ret.steerRatio = ATTRIBUTES[candidate].setdefault("steer_ratio", 15.6)  # Updated by params learner
+    tire_stiffness_factor = ATTRIBUTES[candidate].setdefault("tire_stiffness", 1.0)  # Updated by params learner
 
     # Tuning values, currently using the same tune for all MQB
     # If we need to tune individual models, we'll need a dict lookup by EPS parameterization, not just CAR
     ret.steerRateCost = 1.0
-    tire_stiffness_factor = 1.0  # Updated by params learner
     [ ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP,
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV,
       ret.lateralTuning.pid.kf ] = ([0.], [0.], [0.6], [0.2], 0.00006)

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -72,7 +72,7 @@ class CAR:
   SKODA_OCTAVIA_MK3 = "SKODA OCTAVIA 3RD GEN" # Chassis NE, Mk3 Skoda Octavia and variants
 
 # Required attributes: mass, wheelbase
-# Optional attributes: steer_actuator_delay, steer_ratio
+# Optional attributes: steer_actuator_delay, steer_ratio, tire_stiffness
 
 ATTRIBUTES = {
   CAR.ATLAS_MK1: { "mass": 2011., "wheelbase": 2.98 },

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -71,6 +71,26 @@ class CAR:
   SKODA_SUPERB_MK3 = "SKODA SUPERB 3RD GEN"   # Chassis 3V/NP, Mk3 Skoda Superb and variants
   SKODA_OCTAVIA_MK3 = "SKODA OCTAVIA 3RD GEN" # Chassis NE, Mk3 Skoda Octavia and variants
 
+# Required attributes: mass, wheelbase
+# Optional attributes: steer_actuator_delay, steer_ratio
+
+ATTRIBUTES = {
+  CAR.ATLAS_MK1: { "mass": 2011., "wheelbase": 2.98 },
+  CAR.GOLF_MK7: {"mass": 1397., "wheelbase": 2.62 },
+  CAR.JETTA_MK7: {"mass": 1328., "wheelbase": 2.71 },
+  CAR.PASSAT_MK8: {"mass": 1551., "wheelbase": 2.79 },
+  CAR.TIGUAN_MK2: {"mass": 1715., "wheelbase": 2.74 },
+  CAR.TOURAN_MK2: {"mass": 1516., "wheelbase": 2.79 },
+  CAR.AUDI_A3_MK3: {"mass": 1335., "wheelbase": 2.61 },
+  CAR.AUDI_Q2_MK1: {"mass": 1205., "wheelbase": 2.61 },
+  CAR.SEAT_ATECA_MK1: {"mass": 1900., "wheelbase": 2.64 },
+  CAR.SEAT_LEON_MK3: {"mass": 1227., "wheelbase": 2.64 },
+  CAR.SKODA_KODIAQ_MK1: {"mass": 1569., "wheelbase": 2.79 },
+  CAR.SKODA_OCTAVIA_MK3: {"mass": 1388., "wheelbase": 2.68 },
+  CAR.SKODA_SCALA_MK1: {"mass": 1192., "wheelbase": 2.65 },
+  CAR.SKODA_SUPERB_MK3: {"mass": 1505., "wheelbase": 2.84 },
+}
+
 # All supported cars should return FW from the engine, srs, eps, and fwdRadar. Cars
 # with a manual trans won't return transmission firmware, but all other cars will.
 #


### PR DESCRIPTION
The `get_params()` if-elif chain is starting to get a little out of control, and it's only going to get worse. Refactor the ugly key-value lookup pattern into an actual key-value lookup pattern.

It's not clear if we'll end up needing per-car tunes at all, so I haven't added a tune dict at this time. If we do end up needing per-car tunes, I'll have to write something to look at a couple bytes of the 0xF182 parameterization identifier, in order to know what sub-model we have (e.g., base Golf vs Golf R, I'm not making CARs for all those) and do a separate tune-table dict lookup from there.

Additional cleanup and consolidation to the top of `get_params()` for better alignment with a future PQ port. Fixed the scope of the new enableBsm check to be MQB-only, PQ will use a different message.