### PR TITLE
Scan for networks on UI init

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -23,27 +23,19 @@ void NetworkStrengthWidget::paintEvent(QPaintEvent* event) {
 
 // Networking functions
 
-Networking::Networking(QWidget* parent, bool is_setup) : QWidget(parent), is_setup(is_setup) {
+Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), show_advanced(show_advanced) {
   main_layout = new QStackedLayout(this);
 
-  QLabel* scanning = new QLabel("Scanning for networks");
-  scanning->setAlignment(Qt::AlignCenter);
-  scanning->setStyleSheet(R"(font-size: 65px;)");
-  main_layout->addWidget(scanning);
+  QLabel* warning = new QLabel("Network manager is inactive!");
+  warning->setAlignment(Qt::AlignCenter);
+  warning->setStyleSheet(R"(font-size: 65px;)");
 
-  if (is_setup) {
-    while (!ui_setup_complete) {
-      attemptInitialization();
-      qDebug() << "Attempted initialization";
-    }
-    refresh(true);
-  } else {
-    attemptInitialization();
-    wifi->requestScan();
-  }
+  main_layout->addWidget(warning);
 
+  attemptInitialization();
+  wifi->requestScan();
   QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, [=] { refresh(false); });
+  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
   timer->start(5000);
 }
 
@@ -60,7 +52,7 @@ void Networking::attemptInitialization() {
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
-  if (!is_setup) {
+  if (show_advanced) {
     QPushButton* advancedSettings = new QPushButton("Advanced");
     advancedSettings->setStyleSheet("margin-right: 30px;");
     advancedSettings->setFixedSize(350, 100);
@@ -99,10 +91,8 @@ void Networking::attemptInitialization() {
   ui_setup_complete = true;
 }
 
-void Networking::refresh(bool force) {
-  qDebug() << "Refresh, force:" << force;
-  if (!this->isVisible() && !force) {
-    qDebug() << "Not refreshing";
+void Networking::refresh() {
+  if (!this->isVisible()) {
     return;
   }
   if (!ui_setup_complete) {

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -34,9 +34,9 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
 
   attemptInitialization();
   wifi->requestScan();
-  timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
-  timer->setInterval(5000);
+  refreshTimer = new QTimer(this);
+  QObject::connect(refreshTimer, &QTimer::timeout, this, &Networking::refresh);
+  refreshTimer->setInterval(5000);
 }
 
 void Networking::attemptInitialization() {
@@ -124,11 +124,11 @@ void Networking::wrongPassword(const QString &ssid) {
 }
 
 void Networking::hideEvent(QHideEvent* event) {
-  timer->stop();
+  refreshTimer->stop();
 }
 
 void Networking::showEvent(QShowEvent* event) {
-  timer->start();
+  refreshTimer->start();
 }
 
 // AdvancedNetworking functions

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -34,9 +34,9 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
 
   attemptInitialization();
   wifi->requestScan();
-  refreshTimer = new QTimer(this);
-  QObject::connect(refreshTimer, &QTimer::timeout, this, &Networking::refresh);
-  refreshTimer->setInterval(5000);
+  QTimer* timer = new QTimer(this);
+  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
+  timer->start(5000);
 }
 
 void Networking::attemptInitialization() {
@@ -48,7 +48,7 @@ void Networking::attemptInitialization() {
   }
 
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
-  connect(wifi, &WifiManager::refreshed, this, &Networking::refresh);
+  connect(wifi, &WifiManager::refreshNow, this, &Networking::refresh);
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
@@ -92,6 +92,9 @@ void Networking::attemptInitialization() {
 }
 
 void Networking::refresh() {
+  if (!this->isVisible()) {
+    return;
+  }
   if (!ui_setup_complete) {
     attemptInitialization();
     if (!ui_setup_complete) {
@@ -121,14 +124,6 @@ void Networking::wrongPassword(const QString &ssid) {
       return;
     }
   }
-}
-
-void Networking::hideEvent(QHideEvent* event) {
-  refreshTimer->stop();
-}
-
-void Networking::showEvent(QShowEvent* event) {
-  refreshTimer->start();
 }
 
 // AdvancedNetworking functions

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -23,19 +23,27 @@ void NetworkStrengthWidget::paintEvent(QPaintEvent* event) {
 
 // Networking functions
 
-Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), show_advanced(show_advanced) {
+Networking::Networking(QWidget* parent, bool is_setup) : QWidget(parent), is_setup(is_setup) {
   main_layout = new QStackedLayout(this);
 
-  QLabel* warning = new QLabel("Network manager is inactive!");
-  warning->setAlignment(Qt::AlignCenter);
-  warning->setStyleSheet(R"(font-size: 65px;)");
+  QLabel* scanning = new QLabel("Scanning for networks");
+  scanning->setAlignment(Qt::AlignCenter);
+  scanning->setStyleSheet(R"(font-size: 65px;)");
+  main_layout->addWidget(scanning);
 
-  main_layout->addWidget(warning);
+  if (is_setup) {
+    while (!ui_setup_complete) {
+      attemptInitialization();
+      qDebug() << "Attempted initialization";
+    }
+    refresh(true);
+  } else {
+    attemptInitialization();
+    wifi->requestScan();
+  }
 
-  attemptInitialization();
-  wifi->requestScan();
   QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
+  QObject::connect(timer, &QTimer::timeout, this, [=] { refresh(false); });
   timer->start(5000);
 }
 
@@ -52,7 +60,7 @@ void Networking::attemptInitialization() {
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
-  if (show_advanced) {
+  if (!is_setup) {
     QPushButton* advancedSettings = new QPushButton("Advanced");
     advancedSettings->setStyleSheet("margin-right: 30px;");
     advancedSettings->setFixedSize(350, 100);
@@ -91,8 +99,10 @@ void Networking::attemptInitialization() {
   ui_setup_complete = true;
 }
 
-void Networking::refresh() {
-  if (!this->isVisible()) {
+void Networking::refresh(bool force) {
+  qDebug() << "Refresh, force:" << force;
+  if (!this->isVisible() && !force) {
+    qDebug() << "Not refreshing";
     return;
   }
   if (!ui_setup_complete) {

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -35,7 +35,7 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
   attemptInitialization();
   wifi->requestScan();
   QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
+  QObject::connect(timer, &QTimer::timeout, this, [=] { refresh(false); });
   timer->start(5000);
 }
 
@@ -91,8 +91,8 @@ void Networking::attemptInitialization() {
   ui_setup_complete = true;
 }
 
-void Networking::refresh() {
-  if (!this->isVisible()) {
+void Networking::refresh(bool force) {
+  if (!this->isVisible() && !force) {
     return;
   }
   if (!ui_setup_complete) {

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -33,9 +33,9 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
   main_layout->addWidget(warning);
 
   attemptInitialization();
-  emit requestScan();
+  wifi->requestScan();
   timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, [=](){ emit requestScan(); });
+  QObject::connect(timer, &QTimer::timeout, wifi, &WifiManager::requestScan);
   timer->setInterval(5000);
 }
 
@@ -49,7 +49,6 @@ void Networking::attemptInitialization() {
 
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
   connect(wifi, &WifiManager::refreshed, this, &Networking::refresh);
-  connect(this, &Networking::requestScan, wifi, &WifiManager::requestScan);
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
@@ -189,7 +188,6 @@ void AdvancedNetworking::toggleTethering(bool enable) {
   }
   editPasswordButton->setEnabled(!enable);
 }
-
 
 // WifiUI functions
 

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -32,11 +32,10 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
 
   main_layout->addWidget(warning);
 
-  attemptInitialization();
-  wifi->requestScan();
   QTimer* timer = new QTimer(this);
   QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
   timer->start(5000);
+  attemptInitialization();
 }
 
 void Networking::attemptInitialization() {
@@ -89,6 +88,7 @@ void Networking::attemptInitialization() {
   )");
   main_layout->setCurrentWidget(wifiScreen);
   ui_setup_complete = true;
+  wifi->requestScan();
 }
 
 void Networking::refresh() {

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -198,8 +198,8 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
 }
 
 void WifiUI::refresh() {
-  wifi->requestScan();
   wifi->refreshNetworks();
+  wifi->requestScan();
   clearLayout(main_layout);
 
   connectButtons = new QButtonGroup(this); // TODO check if this is a leak

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -33,8 +33,7 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
   main_layout->addWidget(warning);
 
   QTimer* timer = new QTimer(this);
-//  QObject::connect(timer, &QTimer::timeout, this, &Networking::requestScan);
-  QObject::connect(timer, &QTimer::timeout, this, [=]() { requestScan(); qDebug() << "Requested scan!"; });
+  QObject::connect(timer, &QTimer::timeout, this, &Networking::requestScan);
   timer->start(5000);
   attemptInitialization();
 }
@@ -49,7 +48,6 @@ void Networking::attemptInitialization() {
 
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
   connect(wifi, &WifiManager::refreshSignal, this, &Networking::refresh);
-//  connect(this, &Networking::requestScan, wifi, &WifiManager::requestScan);
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
@@ -107,16 +105,6 @@ void Networking::requestScan() {
 }
 
 void Networking::refresh() {
-//  if (!this->isVisible() && !wifi->firstRefresh) {
-//    return;
-//  }
-//  if (!ui_setup_complete) {
-//    attemptInitialization();
-//    if (!ui_setup_complete) {
-//      return;
-//    }
-//  }
-//  wifi->firstRefresh = false;
   wifiWidget->refresh();
   an->refresh();
 }
@@ -213,9 +201,6 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
 }
 
 void WifiUI::refresh() {
-//  wifi->refreshNetworks();
-//  wifi->requestScan();
-  qDebug() << "Refreshing UI (no network stuff)";
   clearLayout(main_layout);
 
   connectButtons = new QButtonGroup(this); // TODO check if this is a leak

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -33,7 +33,8 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
   main_layout->addWidget(warning);
 
   QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
+//  QObject::connect(timer, &QTimer::timeout, this, &Networking::requestScan);
+  QObject::connect(timer, &QTimer::timeout, this, [=]() { requestScan(); qDebug() << "Requested scan!"; });
   timer->start(5000);
   attemptInitialization();
 }
@@ -48,6 +49,7 @@ void Networking::attemptInitialization() {
 
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
   connect(wifi, &WifiManager::refreshSignal, this, &Networking::refresh);
+//  connect(this, &Networking::requestScan, wifi, &WifiManager::requestScan);
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
@@ -91,8 +93,8 @@ void Networking::attemptInitialization() {
   wifi->requestScan();
 }
 
-void Networking::refresh() {
-  if (!this->isVisible() && !wifi->firstRefresh) {
+void Networking::requestScan() {
+  if (!this->isVisible()) {
     return;
   }
   if (!ui_setup_complete) {
@@ -101,7 +103,20 @@ void Networking::refresh() {
       return;
     }
   }
-  wifi->firstRefresh = false;
+  wifi->requestScan();
+}
+
+void Networking::refresh() {
+//  if (!this->isVisible() && !wifi->firstRefresh) {
+//    return;
+//  }
+//  if (!ui_setup_complete) {
+//    attemptInitialization();
+//    if (!ui_setup_complete) {
+//      return;
+//    }
+//  }
+//  wifi->firstRefresh = false;
   wifiWidget->refresh();
   an->refresh();
 }
@@ -198,8 +213,9 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
 }
 
 void WifiUI::refresh() {
-  wifi->refreshNetworks();
-  wifi->requestScan();
+//  wifi->refreshNetworks();
+//  wifi->requestScan();
+  qDebug() << "Refreshing UI (no network stuff)";
   clearLayout(main_layout);
 
   connectButtons = new QButtonGroup(this); // TODO check if this is a leak
@@ -263,8 +279,6 @@ void WifiUI::refresh() {
 
 void WifiUI::handleButton(QAbstractButton* button) {
   QPushButton* btn = static_cast<QPushButton*>(button);
-  btn->setDisabled(true);
-  btn->setText("Connecting");
   Network n = wifi->seen_networks[connectButtons->id(btn)];
   emit connectToNetwork(n);
 }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -34,11 +34,9 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
 
   attemptInitialization();
   emit requestScan();
-  QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, [=](){if (this->isVisible()) {
-                                                          emit requestScan();
-                                                        }});
-  timer->start(5000);
+  timer = new QTimer(this);
+  QObject::connect(timer, &QTimer::timeout, this, [=](){ emit requestScan(); });
+  timer->setInterval(5000);
 }
 
 void Networking::attemptInitialization() {
@@ -124,6 +122,14 @@ void Networking::wrongPassword(const QString &ssid) {
       return;
     }
   }
+}
+
+void Networking::hideEvent(QHideEvent* event) {
+  timer->stop();
+}
+
+void Networking::showEvent(QShowEvent* event) {
+  timer->start();
 }
 
 // AdvancedNetworking functions

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -47,7 +47,7 @@ void Networking::attemptInitialization() {
   }
 
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
-  connect(wifi, &WifiManager::refreshNow, this, &Networking::refresh);
+  connect(wifi, &WifiManager::refreshSignal, this, &Networking::refresh);
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -32,10 +32,10 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
 
   main_layout->addWidget(warning);
 
+  refresh(true);
   QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
+  QObject::connect(timer, &QTimer::timeout, this, [=](){ refresh(); });
   timer->start(5000);
-  attemptInitialization();
 }
 
 void Networking::attemptInitialization() {
@@ -89,8 +89,8 @@ void Networking::attemptInitialization() {
   ui_setup_complete = true;
 }
 
-void Networking::refresh() {
-  if (!this->isVisible()) {
+void Networking::refresh(const bool force) {
+  if (!this->isVisible() && !force) {
     return;
   }
   if (!ui_setup_complete) {
@@ -261,6 +261,8 @@ void WifiUI::refresh() {
 
 void WifiUI::handleButton(QAbstractButton* button) {
   QPushButton* btn = static_cast<QPushButton*>(button);
+  btn->setDisabled(true);
+  btn->setText("Connecting");
   Network n = wifi->seen_networks[connectButtons->id(btn)];
   emit connectToNetwork(n);
 }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -35,7 +35,7 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
   attemptInitialization();
   wifi->requestScan();
   QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, [=] { refresh(false); });
+  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
   timer->start(5000);
 }
 
@@ -91,8 +91,8 @@ void Networking::attemptInitialization() {
   ui_setup_complete = true;
 }
 
-void Networking::refresh(bool force) {
-  if (!this->isVisible() && !force) {
+void Networking::refresh() {
+  if (!this->isVisible() && !wifi->firstRefresh) {
     return;
   }
   if (!ui_setup_complete) {
@@ -101,6 +101,7 @@ void Networking::refresh(bool force) {
       return;
     }
   }
+  wifi->firstRefresh = false;
   wifiWidget->refresh();
   an->refresh();
 }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -35,7 +35,7 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
   attemptInitialization();
   wifi->requestScan();
   timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, wifi, &WifiManager::requestScan);
+  QObject::connect(timer, &QTimer::timeout, this, &Networking::refresh);
   timer->setInterval(5000);
 }
 
@@ -202,6 +202,8 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
 }
 
 void WifiUI::refresh() {
+  wifi->requestScan();
+  wifi->refreshNetworks();
   clearLayout(main_layout);
 
   connectButtons = new QButtonGroup(this); // TODO check if this is a leak

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -47,7 +47,7 @@ void Networking::attemptInitialization() {
   }
 
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
-  connect(wifi, &WifiManager::refreshSignal, this, &Networking::refresh);
+  connect(wifi, &WifiManager::refreshSignal, this, &Networking::refreshSlot);
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
@@ -104,7 +104,7 @@ void Networking::requestScan() {
   wifi->requestScan();
 }
 
-void Networking::refresh() {
+void Networking::refreshSlot() {
   wifiWidget->refresh();
   an->refresh();
 }

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -63,21 +63,21 @@ class Networking : public QWidget {
   Q_OBJECT
 
 public:
-  explicit Networking(QWidget* parent = 0, bool is_setup = false);
+  explicit Networking(QWidget* parent = 0, bool show_advanced = true);
 
 private:
   QStackedLayout* main_layout = nullptr; // nm_warning, wifiScreen, advanced
   QWidget* wifiScreen = nullptr;
   AdvancedNetworking* an = nullptr;
   bool ui_setup_complete = false;
-  bool is_setup;
+  bool show_advanced;
 
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
   void attemptInitialization();
 
 public slots:
-  void refresh(bool force);
+  void refresh();
 
 private slots:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -77,7 +77,7 @@ private:
   void attemptInitialization();
 
 public slots:
-  void refresh();
+  void refresh(bool force);
 
 private slots:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -63,21 +63,21 @@ class Networking : public QWidget {
   Q_OBJECT
 
 public:
-  explicit Networking(QWidget* parent = 0, bool show_advanced = true);
+  explicit Networking(QWidget* parent = 0, bool is_setup = false);
 
 private:
   QStackedLayout* main_layout = nullptr; // nm_warning, wifiScreen, advanced
   QWidget* wifiScreen = nullptr;
   AdvancedNetworking* an = nullptr;
   bool ui_setup_complete = false;
-  bool show_advanced;
+  bool is_setup;
 
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
   void attemptInitialization();
 
 public slots:
-  void refresh();
+  void refresh(bool force);
 
 private slots:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -71,20 +71,15 @@ private:
   AdvancedNetworking* an = nullptr;
   bool ui_setup_complete = false;
   bool show_advanced;
-  QTimer* timer;
-
-  Network selectedNetwork;
 
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
   void attemptInitialization();
+  QTimer* timer;
 
 protected:
   void hideEvent(QHideEvent *event) override;
   void showEvent(QShowEvent *event) override;
-
-signals:
-  void requestScan();
 
 public slots:
   void refresh();

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -75,11 +75,6 @@ private:
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
   void attemptInitialization();
-  QTimer* refreshTimer;
-
-protected:
-  void hideEvent(QHideEvent *event) override;
-  void showEvent(QShowEvent *event) override;
 
 public slots:
   void refresh();

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -75,7 +75,7 @@ private:
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
   void attemptInitialization();
-  QTimer* timer;
+  QTimer* refreshTimer;
 
 protected:
   void hideEvent(QHideEvent *event) override;

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -75,6 +75,10 @@ private:
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
   void attemptInitialization();
+  void requestScan();
+
+//signals:
+//  void requestScan();
 
 public slots:
   void refresh();

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -71,12 +71,17 @@ private:
   AdvancedNetworking* an = nullptr;
   bool ui_setup_complete = false;
   bool show_advanced;
+  QTimer* timer;
 
   Network selectedNetwork;
 
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
   void attemptInitialization();
+
+protected:
+  void hideEvent(QHideEvent *event) override;
+  void showEvent(QShowEvent *event) override;
 
 signals:
   void requestScan();

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -77,7 +77,7 @@ private:
   void attemptInitialization();
 
 public slots:
-  void refresh(bool force);
+  void refresh();
 
 private slots:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -78,8 +78,13 @@ private:
   WifiManager* wifi = nullptr;
   void attemptInitialization();
 
+signals:
+  void requestScan();
+
+public slots:
+  void refresh();
+
 private slots:
   void connectToNetwork(const Network &n);
-  void refresh(const bool force = false);
   void wrongPassword(const QString &ssid);
 };

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -80,7 +80,6 @@ private:
 
 private slots:
   void connectToNetwork(const Network &n);
-  void refresh();
+  void refresh(const bool force = false);
   void wrongPassword(const QString &ssid);
 };
-

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -77,9 +77,6 @@ private:
   void attemptInitialization();
   void requestScan();
 
-//signals:
-//  void requestScan();
-
 public slots:
   void refresh();
 

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -78,7 +78,7 @@ private:
   void requestScan();
 
 public slots:
-  void refresh();
+  void refreshSlot();
 
 private slots:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -82,7 +82,6 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   device_props.setTimeout(dbus_timeout);
   QDBusMessage response = device_props.call("Get", device_iface, "State");
   raw_adapter_state = get_response<uint>(response);
-  state_change(raw_adapter_state, 0, 0);
 
   // Set tethering ssid as "weedle" + first 4 characters of a dongle id
   tethering_ssid = "weedle";

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -369,8 +369,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
-    refreshNetworks();
-    emit refreshed();
+    emit refreshNow();
   }
 }
 
@@ -378,8 +377,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan") && firstScan) {
     firstScan = false;
-    refreshNetworks();
-    emit refreshed();
+    emit refreshNow();
   }
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -376,7 +376,8 @@ void WifiManager::state_change(unsigned int new_state, unsigned int previous_sta
 
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::property_change(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
-  if (interface == wireless_device_iface && props.contains("LastScan")) {
+  if (interface == wireless_device_iface && props.contains("LastScan") && firstScan) {
+    firstScan = false;
     refreshNetworks();
     emit refreshed();
   }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -369,7 +369,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
-    emit refreshNow();
+    emit refreshNow(true);
   }
 }
 
@@ -377,7 +377,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan") && firstScan) {
     firstScan = false;
-    emit refreshNow();
+    emit refreshNow(true);
   }
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -369,7 +369,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
-    emit refreshNow(true);
+    emit refreshNow();
   }
 }
 
@@ -377,7 +377,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan") && firstScan) {
     firstScan = false;
-    emit refreshNow(true);
+    emit refreshNow();
   }
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -369,13 +369,16 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
+    refreshNetworks();
     emit refreshSignal();
   }
 }
 
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
-  if (interface == wireless_device_iface && props.contains("LastScan") && firstRefresh) {
+  if (interface == wireless_device_iface && props.contains("LastScan")) {
+    qDebug() << "SCAN COMPLETE, REFRESHING NETWORKS!";
+    refreshNetworks();
     emit refreshSignal();
   }
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -376,7 +376,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan") && firstRefresh) {
-    emit refreshNow(true);
+    emit refreshNow();
   }
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -430,6 +430,7 @@ QVector<QPair<QString, QDBusObjectPath>> WifiManager::listConnections() {
 void WifiManager::activateWifiConnection(const QString &ssid) {
   QDBusObjectPath path = pathFromSsid(ssid);
   if (!path.path().isEmpty()) {
+    connecting_to_network = ssid;
     QString devicePath = get_adapter();
     QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
     nm3.setTimeout(dbus_timeout);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -96,46 +96,18 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   QDBusInterface(nm_service, nm_settings_path, nm_settings_iface, bus);
 }
 
-ConnectedType WifiManager::getConnectedType(const QString &path, const QString &ssid, const QString &active_ap) {
-  if (ssid == connecting_to_network) {
-    return ConnectedType::CONNECTING;
-  } else if (path != active_ap) {
-    return ConnectedType::DISCONNECTED;
-  } else {
-    return ConnectedType::CONNECTED;
-  }
-}
-
-void WifiManager::refreshNetworks(const QVector<QDBusObjectPath> &paths) {
-  qDebug() << "Got ALL APs!";
+void WifiManager::refreshNetworks() {
   seen_networks.clear();
   seen_ssids.clear();
   ipv4_address = get_ipv4_address();
-  QString active_ap = get_active_ap();  // TODO use ActiveAccessPoint signal for a non blocking solution
-
-  for (const QDBusObjectPath &path : paths) {
-    QByteArray ssid = get_property(path.path(), "Ssid");
-    if (seen_ssids.count(ssid) != 0 || ssid.length() == 0) {
+  for (Network &network : get_networks()) {
+    if (seen_ssids.count(network.ssid)) {
       continue;
     }
-    unsigned int strength = get_ap_strength(path.path());
-    SecurityType security = getSecurityType(path.path());
-    ConnectedType ctype = getConnectedType(path.path(), ssid, active_ap);
-
-    Network network = {path.path(), ssid, strength, ctype, security};
+    seen_ssids.push_back(network.ssid);
     seen_networks.push_back(network);
-    seen_ssids.push_back(ssid);
   }
-  std::sort(seen_networks.begin(), seen_networks.end(), compare_by_strength);
-}
 
-// Sorts networks for UI
-void WifiManager::sortNetworks() {
-  QString active_ap = get_active_ap();  // TODO use ActiveAccessPoint signal for a non blocking solution
-  for (Network &network : seen_networks) {
-    network.connected = getConnectedType(network.path, network.ssid, active_ap);
-  }
-  std::sort(seen_networks.begin(), seen_networks.end(), compare_by_strength);
 }
 
 QString WifiManager::get_ipv4_address() {
@@ -170,6 +142,46 @@ QString WifiManager::get_ipv4_address() {
     }
   }
   return "";
+}
+
+QList<Network> WifiManager::get_networks() {
+  QList<Network> r;
+  QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
+  nm.setTimeout(dbus_timeout);
+
+  QDBusMessage response = nm.call("GetAllAccessPoints");
+  QVariant first =  response.arguments().at(0);
+
+  QString active_ap = get_active_ap();
+  const QDBusArgument &args = first.value<QDBusArgument>();
+  args.beginArray();
+  while (!args.atEnd()) {
+    QDBusObjectPath path;
+    args >> path;
+
+    QByteArray ssid = get_property(path.path(), "Ssid");
+    unsigned int strength = get_ap_strength(path.path());
+    SecurityType security = getSecurityType(path.path());
+    ConnectedType ctype;
+    if (path.path() != active_ap) {
+      ctype = ConnectedType::DISCONNECTED;
+    } else {
+      if (ssid == connecting_to_network) {
+        ctype = ConnectedType::CONNECTING;
+      } else {
+        ctype = ConnectedType::CONNECTED;
+      }
+    }
+    Network network = {path.path(), ssid, strength, ctype, security};
+
+    if (ssid.length()) {
+      r.push_back(network);
+    }
+  }
+  args.endArray();
+
+  std::sort(r.begin(), r.end(), compare_by_strength);
+  return r;
 }
 
 SecurityType WifiManager::getSecurityType(const QString &path) {
@@ -280,11 +292,9 @@ void WifiManager::forgetConnection(const QString &ssid) {
 }
 
 void WifiManager::requestScan() {
-  qDebug() << "Requesting scan!";
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
-  nm.call("RequestScan", QVariantMap());  // a signal is sent to WifiManager::property_change once the scan is complete
-//  nm.call("GetAllAccessPoints");
+  nm.call("RequestScan",  QVariantMap());  // a signal is sent to WifiManager::property_change once the scan is complete
 }
 
 uint WifiManager::get_wifi_device_state() {
@@ -345,7 +355,6 @@ QString WifiManager::get_adapter() {
 
     if (device_type == 2) { // Wireless
       adapter_path = path.path();
-      qDebug() << "Wireless path:" << adapter_path;
       break;
     }
   }
@@ -360,31 +369,16 @@ void WifiManager::state_change(unsigned int new_state, unsigned int previous_sta
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
-//    refreshNetworks();
-    sortNetworks();
+    refreshNetworks();
     emit refreshed();
   }
 }
 
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::property_change(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
-  if (interface == wireless_device_iface && props.contains("LastScan")) {  // TODO remove?
-//    refreshNetworks();
-    sortNetworks();
+  if (interface == wireless_device_iface && props.contains("LastScan")) {
+    refreshNetworks();
     emit refreshed();
-  } else if (interface == wireless_device_iface && props.contains("AccessPoints")) {
-    QVector<QDBusObjectPath> paths;
-
-    const QDBusArgument dbusArgs = props.value("AccessPoints").value<QDBusArgument>();
-    dbusArgs.beginArray();
-    while (!dbusArgs.atEnd())
-    {
-      QDBusObjectPath path;
-      dbusArgs >> path;
-      paths.push_back(path);
-    }
-    dbusArgs.endArray();
-    refreshNetworks(paths);
   }
 }
 
@@ -411,7 +405,6 @@ QVector<QPair<QString, QDBusObjectPath>> WifiManager::listConnections() {
   nm.setTimeout(dbus_timeout);
 
   QDBusMessage response = nm.call("ListConnections");
-//  qDebug() << "LISTCONNECTIONS:" << response;
   QVariant first =  response.arguments().at(0);
   const QDBusArgument &args = first.value<QDBusArgument>();
   args.beginArray();

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -375,8 +375,7 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
-  if (interface == wireless_device_iface && props.contains("LastScan") && firstScan) {
-    firstScan = false;
+  if (interface == wireless_device_iface && props.contains("LastScan") && firstRefresh) {
     emit refreshNow(true);
   }
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -75,8 +75,8 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   }
 
   QDBusInterface nm(nm_service, adapter, device_iface, bus);
-  bus.connect(nm_service, adapter, device_iface, "StateChanged", this, SLOT(state_change(unsigned int, unsigned int, unsigned int)));
-  bus.connect(nm_service, adapter, props_iface, "PropertiesChanged", this, SLOT(property_change(QString, QVariantMap, QStringList)));
+  bus.connect(nm_service, adapter, device_iface, "StateChanged", this, SLOT(stateChange(unsigned int, unsigned int, unsigned int)));
+  bus.connect(nm_service, adapter, props_iface, "PropertiesChanged", this, SLOT(propertyChange(QString, QVariantMap, QStringList)));
 
   QDBusInterface device_props(nm_service, adapter, props_iface, bus);
   device_props.setTimeout(dbus_timeout);
@@ -294,7 +294,7 @@ void WifiManager::forgetConnection(const QString &ssid) {
 void WifiManager::requestScan() {
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
-  nm.call("RequestScan",  QVariantMap());  // a signal is sent to WifiManager::property_change once the scan is complete
+  nm.call("RequestScan",  QVariantMap());
 }
 
 uint WifiManager::get_wifi_device_state() {
@@ -363,7 +363,7 @@ QString WifiManager::get_adapter() {
   return adapter_path;
 }
 
-void WifiManager::state_change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason) {
+void WifiManager::stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason) {
   raw_adapter_state = new_state;
   if (new_state == state_need_auth && change_reason == reason_wrong_password) {
     emit wrongPassword(connecting_to_network);
@@ -375,7 +375,7 @@ void WifiManager::state_change(unsigned int new_state, unsigned int previous_sta
 }
 
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
-void WifiManager::property_change(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
+void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan") && firstScan) {
     firstScan = false;
     refreshNetworks();

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -490,8 +490,6 @@ bool WifiManager::tetheringEnabled() {
 
 void WifiManager::changeTetheringPassword(const QString &newPassword) {
   tetheringPassword = newPassword;
-  if (isKnownNetwork(tethering_ssid.toUtf8())) {
-    forgetConnection(tethering_ssid.toUtf8());
-  }
+  forgetNetwork(tethering_ssid.toUtf8());
   addTetheringConnection();
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -369,8 +369,9 @@ void WifiManager::state_change(unsigned int new_state, unsigned int previous_sta
   if (new_state == state_need_auth && change_reason == reason_wrong_password) {
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
-    emit successfulConnection(connecting_to_network);
     connecting_to_network = "";
+    refreshNetworks();
+    emit refreshed();
   }
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -377,7 +377,6 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan")) {
-    qDebug() << "SCAN COMPLETE, REFRESHING NETWORKS!";
     refreshNetworks();
     emit refreshSignal();
   }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -369,14 +369,14 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
-    emit refreshNow(true);
+    emit refreshSignal();
   }
 }
 
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan") && firstRefresh) {
-    emit refreshNow();
+    emit refreshSignal();
   }
 }
 
@@ -487,6 +487,6 @@ bool WifiManager::tetheringEnabled() {
 
 void WifiManager::changeTetheringPassword(const QString &newPassword) {
   tetheringPassword = newPassword;
-  forgetNetwork(tethering_ssid.toUtf8());
+  forgetConnection(tethering_ssid.toUtf8());
   addTetheringConnection();
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -59,6 +59,7 @@ private:
   QString connecting_to_network;
   QString tethering_ssid;
   QString tetheringPassword = "swagswagcommma";
+  bool firstScan = true;
 
   QString get_adapter();
   QString get_ipv4_address();

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -77,7 +77,7 @@ private:
 
 signals:
   void wrongPassword(const QString &ssid);
-  void refreshNow(bool force);
+  void refreshNow();
 
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -30,6 +30,7 @@ class WifiManager : public QWidget {
 public:
   explicit WifiManager(QWidget* parent);
 
+  void requestScan();
   QVector<Network> seen_networks;
   QString ipv4_address;
 
@@ -53,9 +54,9 @@ public:
 
 private:
   QVector<QByteArray> seen_ssids;
-  QString adapter;//Path to network manager wifi-device
+  QString adapter;  // Path to network manager wifi-device
   QDBusConnection bus = QDBusConnection::systemBus();
-  unsigned int raw_adapter_state;//Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState
+  unsigned int raw_adapter_state;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState
   QString connecting_to_network;
   QString tethering_ssid;
   QString tetheringPassword = "swagswagcommma";
@@ -77,9 +78,6 @@ private:
 signals:
   void wrongPassword(const QString &ssid);
   void refreshed();
-
-public slots:
-  void requestScan();
 
 private slots:
   void state_change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -77,7 +77,7 @@ private:
 
 signals:
   void wrongPassword(const QString &ssid);
-  void refreshed();
+  void refreshNow();
 
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -30,6 +30,7 @@ class WifiManager : public QWidget {
 public:
   explicit WifiManager(QWidget* parent);
 
+  void requestScan();
   QVector<Network> seen_networks;
   QString ipv4_address;
 
@@ -81,7 +82,4 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
-
-public slots:
-  void requestScan();
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,8 +34,6 @@ public:
   QVector<Network> seen_networks;
   QString ipv4_address;
 
-  void refreshNetworks();
-  void forgetConnection(const QString &ssid);
   bool isKnownNetwork(const QString &ssid);
 
   void connect(const Network &ssid);
@@ -53,6 +51,9 @@ public:
   void changeTetheringPassword(const QString &newPassword);
 
 private:
+  void sortNetworks();
+  void refreshNetworks(const QVector<QDBusObjectPath> &paths);
+
   QVector<QByteArray> seen_ssids;
   QString adapter;  // Path to network manager wifi-device
   QDBusConnection bus = QDBusConnection::systemBus();
@@ -63,7 +64,6 @@ private:
 
   QString get_adapter();
   QString get_ipv4_address();
-  QList<Network> get_networks();
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString get_active_ap();
   void deactivateConnection(const QString &ssid);
@@ -74,6 +74,7 @@ private:
   SecurityType getSecurityType(const QString &ssid);
   QDBusObjectPath pathFromSsid(const QString &ssid);
   QVector<QPair<QString, QDBusObjectPath>> listConnections();
+  ConnectedType getConnectedType(const QString &path, const QString &ssid, const QString &active_ap);
 
 signals:
   void wrongPassword(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -76,7 +76,6 @@ private:
 
 signals:
   void wrongPassword(const QString &ssid);
-  void successfulConnection(const QString &ssid);
   void refreshed();
 
 public slots:

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -77,7 +77,6 @@ private:
 signals:
   void wrongPassword(const QString &ssid);
   void successfulConnection(const QString &ssid);
-  void refresh();
   void refreshed();
 
 public slots:

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,6 +34,7 @@ public:
   QVector<Network> seen_networks;
   QString ipv4_address;
 
+  void refreshNetworks();
   bool isKnownNetwork(const QString &ssid);
 
   void connect(const Network &ssid);
@@ -51,9 +52,6 @@ public:
   void changeTetheringPassword(const QString &newPassword);
 
 private:
-  void sortNetworks();
-  void refreshNetworks(const QVector<QDBusObjectPath> &paths);
-
   QVector<QByteArray> seen_ssids;
   QString adapter;  // Path to network manager wifi-device
   QDBusConnection bus = QDBusConnection::systemBus();
@@ -64,6 +62,7 @@ private:
 
   QString get_adapter();
   QString get_ipv4_address();
+  QList<Network> get_networks();
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString get_active_ap();
   void deactivateConnection(const QString &ssid);
@@ -74,7 +73,6 @@ private:
   SecurityType getSecurityType(const QString &ssid);
   QDBusObjectPath pathFromSsid(const QString &ssid);
   QVector<QPair<QString, QDBusObjectPath>> listConnections();
-  ConnectedType getConnectedType(const QString &path, const QString &ssid, const QString &active_ap);
 
 signals:
   void wrongPassword(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -33,6 +33,7 @@ public:
   void requestScan();
   QVector<Network> seen_networks;
   QString ipv4_address;
+  bool firstRefresh = true;
 
   void refreshNetworks();
   bool isKnownNetwork(const QString &ssid);
@@ -59,7 +60,6 @@ private:
   QString connecting_to_network;
   QString tethering_ssid;
   QString tetheringPassword = "swagswagcommma";
-  bool firstScan = true;
 
   QString get_adapter();
   QString get_ipv4_address();

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -32,7 +32,6 @@ public:
 
   QVector<Network> seen_networks;
   QString ipv4_address;
-  bool firstRefresh = true;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -77,7 +77,7 @@ private:
 
 signals:
   void wrongPassword(const QString &ssid);
-  void refreshNow();
+  void refreshNow(bool force);
 
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -30,7 +30,6 @@ class WifiManager : public QWidget {
 public:
   explicit WifiManager(QWidget* parent);
 
-  void requestScan();
   QVector<Network> seen_networks;
   QString ipv4_address;
   bool firstRefresh = true;
@@ -83,4 +82,7 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
+
+public slots:
+  void requestScan();
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -36,6 +36,7 @@ public:
   bool firstRefresh = true;
 
   void refreshNetworks();
+  void forgetConnection(const QString &ssid);
   bool isKnownNetwork(const QString &ssid);
 
   void connect(const Network &ssid);
@@ -77,7 +78,7 @@ private:
 
 signals:
   void wrongPassword(const QString &ssid);
-  void refreshNow();
+  void refreshSignal();
 
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -30,7 +30,6 @@ class WifiManager : public QWidget {
 public:
   explicit WifiManager(QWidget* parent);
 
-  void request_scan();
   QVector<Network> seen_networks;
   QString ipv4_address;
 
@@ -75,10 +74,16 @@ private:
   QDBusObjectPath pathFromSsid(const QString &ssid);
   QVector<QPair<QString, QDBusObjectPath>> listConnections();
 
-private slots:
-  void change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
 signals:
   void wrongPassword(const QString &ssid);
   void successfulConnection(const QString &ssid);
   void refresh();
+  void refreshed();
+
+public slots:
+  void requestScan();
+
+private slots:
+  void state_change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
+  void property_change(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -80,6 +80,6 @@ signals:
   void refreshed();
 
 private slots:
-  void state_change(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
-  void property_change(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
+  void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
+  void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
 };

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -90,7 +90,7 @@ QWidget * Setup::getting_started() {
 }
 
 QWidget * Setup::network_setup() {
-  Networking *wifi = new Networking(this, false);
+  Networking *wifi = new Networking(this, true);
   return build_page("Connect to WiFi", wifi, true, true);
 }
 

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -90,7 +90,7 @@ QWidget * Setup::getting_started() {
 }
 
 QWidget * Setup::network_setup() {
-  Networking *wifi = new Networking(this, true);
+  Networking *wifi = new Networking(this, false);
   return build_page("Connect to WiFi", wifi, true, true);
 }
 


### PR DESCRIPTION
On start up ***only*** we request a scan from NM which when complete a signal is sent to `propertyChange` to update the networks and UI. Without waiting, we only see the current connection and have to wait 5 seconds to see the rest, which takes longer.