### PR TITLE
refactor ButtonControl

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -145,7 +145,8 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   main_layout->addWidget(horizontal_line(), 0);
 
   // Change tethering password
-  editPasswordButton = new ButtonControl("Tethering Password", "EDIT", "", [=]() {
+  editPasswordButton = new ButtonControl("Tethering Password", "EDIT");
+  connect(editPasswordButton, &ButtonControl::released, [=]() {
     QString pass = InputDialog::getText("Enter new tethering password", 8);
     if (pass.size()) {
       wifi->changeTetheringPassword(pass);

--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -63,3 +63,25 @@ void AbstractControl::hideEvent(QHideEvent *e) {
     description->hide();
   }
 }
+
+// controls
+
+ButtonControl::ButtonControl(const QString &title, const QString &text, const QString &desc, QWidget *parent) : AbstractControl(title, desc, "", parent) {
+  btn.setText(text);
+  btn.setStyleSheet(R"(
+    QPushButton {
+      padding: 0;
+      border-radius: 50px;
+      font-size: 35px;
+      font-weight: 500;
+      color: #E4E4E4;
+      background-color: #393939;
+    }
+    QPushButton:disabled {
+      color: #33E4E4E4;
+    }
+  )");
+  btn.setFixedSize(250, 100);
+  QObject::connect(&btn, &QPushButton::released, this, &ButtonControl::released);
+  hlayout->addWidget(&btn);
+}

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -56,32 +56,15 @@ class ButtonControl : public AbstractControl {
   Q_OBJECT
 
 public:
-  template <typename Functor>
-  ButtonControl(const QString &title, const QString &text, const QString &desc, Functor functor, const QString &icon = "", QWidget *parent = nullptr) : AbstractControl(title, desc, icon, parent) {
-    btn.setText(text);
-    btn.setStyleSheet(R"(
-      QPushButton {
-        padding: 0;
-        border-radius: 50px;
-        font-size: 35px;
-        font-weight: 500;
-        color: #E4E4E4;
-        background-color: #393939;
-      }
-      QPushButton:disabled {
-        color: #33E4E4E4;
-      }
-    )");
-    btn.setFixedSize(250, 100);
-    QObject::connect(&btn, &QPushButton::released, functor);
-    hlayout->addWidget(&btn);
-  }
-  void setText(const QString &text) { btn.setText(text); }
+  ButtonControl(const QString &title, const QString &text, const QString &desc = "", QWidget *parent = nullptr);
+  inline void setText(const QString &text) { btn.setText(text); }
+  inline QString text() const { return btn.text(); }
+
+signals:
+  void released();
 
 public slots:
-  void setEnabled(bool enabled) {
-    btn.setEnabled(enabled);
-  };
+  void setEnabled(bool enabled) { btn.setEnabled(enabled); };
 
 private:
   QPushButton btn;

--- a/selfdrive/ui/qt/widgets/ssh_keys.cc
+++ b/selfdrive/ui/qt/widgets/ssh_keys.cc
@@ -4,32 +4,17 @@
 #include "selfdrive/ui/qt/api.h"
 #include "selfdrive/ui/qt/widgets/input.h"
 
-SshControl::SshControl() : AbstractControl("SSH Keys", "Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.", "") {
-
-  // setup widget
-  hlayout->addStretch(1);
-
-  username_label.setAlignment(Qt::AlignVCenter);
+SshControl::SshControl() : ButtonControl("SSH Keys", "", "Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.") {
+  username_label.setAlignment(Qt::AlignRight | Qt::AlignVCenter);
   username_label.setStyleSheet("color: #aaaaaa");
-  hlayout->addWidget(&username_label);
+  hlayout->insertWidget(1, &username_label);
 
-  btn.setStyleSheet(R"(
-    padding: 0;
-    border-radius: 50px;
-    font-size: 35px;
-    font-weight: 500;
-    color: #E4E4E4;
-    background-color: #393939;
-  )");
-  btn.setFixedSize(250, 100);
-  hlayout->addWidget(&btn);
-
-  QObject::connect(&btn, &QPushButton::released, [=]() {
-    if (btn.text() == "ADD") {
+  QObject::connect(this, &ButtonControl::released, [=]() {
+    if (text() == "ADD") {
       QString username = InputDialog::getText("Enter your GitHub username");
       if (username.length() > 0) {
-        btn.setText("LOADING");
-        btn.setEnabled(false);
+        setText("LOADING");
+        setEnabled(false);
         getUserKeys(username);
       }
     } else {
@@ -46,12 +31,12 @@ void SshControl::refresh() {
   QString param = QString::fromStdString(params.get("GithubSshKeys"));
   if (param.length()) {
     username_label.setText(QString::fromStdString(params.get("GithubUsername")));
-    btn.setText("REMOVE");
+    setText("REMOVE");
   } else {
     username_label.setText("");
-    btn.setText("ADD");
+    setText("ADD");
   }
-  btn.setEnabled(true);
+  setEnabled(true);
 }
 
 void SshControl::getUserKeys(const QString &username) {

--- a/selfdrive/ui/qt/widgets/ssh_keys.h
+++ b/selfdrive/ui/qt/widgets/ssh_keys.h
@@ -18,7 +18,7 @@ public:
 };
 
 // SSH key management widget
-class SshControl : public AbstractControl {
+class SshControl : public ButtonControl {
   Q_OBJECT
 
 public:


### PR DESCRIPTION
1. use normal ctor & signal instead of `teamplate<Functor>`
2. inherit SshControl from ButtonControl. (no need to re-define the same stylesheet, and  there is also a lack of  disabled style for ssh button)