### PR TITLE
Athena: increase timeouts

### DIFF
--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -54,7 +54,7 @@ def handle_long_poll(ws):
 
   threads = [
     threading.Thread(target=ws_recv, args=(ws, end_event), name='ws_recv'),
-    threading.Thread(target=ws_send, args=(ws, end_event), name='wc_send'),
+    threading.Thread(target=ws_send, args=(ws, end_event), name='ws_send'),
     threading.Thread(target=upload_handler, args=(end_event,), name='upload_handler'),
     threading.Thread(target=log_handler, args=(end_event,), name='log_handler'),
   ] + [

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -116,7 +116,7 @@ def _do_upload(upload_item):
     return requests.put(upload_item.url,
                         data=f,
                         headers={**upload_item.headers, 'Content-Length': str(size)},
-                        timeout=10)
+                        timeout=30)
 
 
 # security: user should be able to request any message from their car
@@ -479,8 +479,7 @@ def main():
       ws = create_connection(ws_uri,
                              cookie="jwt=" + api.get_token(),
                              enable_multithread=True,
-                             timeout=1.0)
-      ws.settimeout(1)
+                             timeout=30.0)
       cloudlog.event("athenad.main.connected_ws", ws_uri=ws_uri)
 
       manage_tokens(api)


### PR DESCRIPTION
1 seconds is probably too low for certain network conditions. Looks we've been operating right on the edge of the 1 second timeout with snapshots from both cameras over prime. The problem has been made worse with uploading cloudlogs over athena. Those can be up to 256k and will never upload in time over prime, increasing the risk on a connection drop when the packets are larger.

This can be improved further by not sending all the data in a single frame, but breaking it up into smaller chunks. Then the timeout on individual chunks can be lower. This makes recovering from broken connections faster.