### PR TITLE
HomeWindow: small cleanup

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -36,7 +36,6 @@ HomeWindow::HomeWindow(QWidget* parent) : QWidget(parent) {
 
   home = new OffroadHome();
   slayout->addWidget(home);
-  QObject::connect(this, &HomeWindow::openSettings, home, &OffroadHome::refresh);
 
   driver_view = new DriverViewWindow(this);
   connect(driver_view, &DriverViewWindow::done, [=] {


### PR DESCRIPTION
@adeebshihadeh OffroadHome will be refreshed on showEvent. It seems that this connection is unnecessary,am I right? In addition, I don’t understand why we need to refresh alerts when open settings