### PR TITLE
DevicePanel: set specific stylesheet for reboot&poweroff buttons

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -52,6 +52,7 @@ void Networking::attemptInitialization() {
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
   if (show_advanced) {
     QPushButton* advancedSettings = new QPushButton("Advanced");
+    advancedSettings->setObjectName("advancedBtn");
     advancedSettings->setStyleSheet("margin-right: 30px;");
     advancedSettings->setFixedSize(350, 100);
     connect(advancedSettings, &QPushButton::released, [=]() { main_layout->setCurrentWidget(an); });
@@ -61,6 +62,7 @@ void Networking::attemptInitialization() {
   }
 
   wifiWidget = new WifiUI(this, wifi);
+  wifiWidget->setObjectName("wifiWidget");
   connect(wifiWidget, &WifiUI::connectToNetwork, this, &Networking::connectToNetwork);
   vlayout->addWidget(new ScrollView(wifiWidget, this), 1);
 
@@ -71,7 +73,7 @@ void Networking::attemptInitialization() {
   main_layout->addWidget(an);
 
   setStyleSheet(R"(
-    QPushButton {
+    #wifiWidget > QPushButton, #back_btn, #advancedBtn {
       font-size: 50px;
       margin: 0px;
       padding: 15px;
@@ -80,7 +82,7 @@ void Networking::attemptInitialization() {
       color: #dddddd;
       background-color: #444444;
     }
-    QPushButton:disabled {
+    #wifiWidget > QPushButton:disabled {
       color: #777777;
       background-color: #222222;
     }
@@ -134,6 +136,7 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
 
   // Back button
   QPushButton* back = new QPushButton("Back");
+  back->setObjectName("back_btn");
   back->setFixedSize(500, 100);
   connect(back, &QPushButton::released, [=]() { emit backPress(); });
   main_layout->addWidget(back, 0, Qt::AlignLeft);

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -178,6 +178,7 @@ DevicePanel::DevicePanel(QWidget* parent) : QWidget(parent) {
   power_layout->setSpacing(30);
 
   QPushButton *reboot_btn = new QPushButton("Reboot");
+  reboot_btn->setStyleSheet("height: 120px;border-radius: 15px;background-color: #393939;");
   power_layout->addWidget(reboot_btn);
   QObject::connect(reboot_btn, &QPushButton::released, [=]() {
     if (ConfirmationDialog::confirm("Are you sure you want to reboot?", this)) {
@@ -186,7 +187,7 @@ DevicePanel::DevicePanel(QWidget* parent) : QWidget(parent) {
   });
 
   QPushButton *poweroff_btn = new QPushButton("Power Off");
-  poweroff_btn->setStyleSheet("background-color: #E22C2C;");
+  poweroff_btn->setStyleSheet("height: 120px;border-radius: 15px;background-color: #E22C2C;");
   power_layout->addWidget(poweroff_btn);
   QObject::connect(poweroff_btn, &QPushButton::released, [=]() {
     if (ConfirmationDialog::confirm("Are you sure you want to power off?", this)) {
@@ -195,15 +196,6 @@ DevicePanel::DevicePanel(QWidget* parent) : QWidget(parent) {
   });
 
   main_layout->addLayout(power_layout);
-
-  setStyleSheet(R"(
-    QPushButton {
-      padding: 0;
-      height: 120px;
-      border-radius: 15px;
-      background-color: #393939;
-    }
-  )");
 }
 
 SoftwarePanel::SoftwarePanel(QWidget* parent) : QWidget(parent) {

--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -54,8 +54,6 @@ AbstractControl::AbstractControl(const QString &title, const QString &desc, cons
       description->setVisible(!description->isVisible());
     });
   }
-
-  setStyleSheet("background-color: transparent;");
 }
 
 void AbstractControl::hideEvent(QHideEvent *e) {


### PR DESCRIPTION
The current setstylesheet  has affected all pushbuttons in this page, including the title button in AbstractControl:

![12345](https://user-images.githubusercontent.com/27770/122751717-b2315d00-d2c2-11eb-904c-46144f942f09.png)
