### PR TITLE
fix FileLock: fd could be closed twice

### DIFF
--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -134,7 +134,6 @@ class FileLock {
       return;
     }
     if (HANDLE_EINTR(flock(fd_, op_)) < 0) {
-      close(fd_);
       LOGE("Failed to lock file %s, errno=%d", fn_.c_str(), errno);
     }
   }


### PR DESCRIPTION
since we no longer throw exception in the `lock()`, we should only close fd_ in `unlock()`