### PR TITLE
General networking improvements

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -108,6 +108,7 @@ void Networking::requestScan() {
 
 void Networking::refresh() {
   if (this->isVisible() || wifi->firstScan) {
+    qDebug() << "REFRESHING UI";
     wifiWidget->refresh();
     an->refresh();
     wifi->firstScan = false;
@@ -115,8 +116,9 @@ void Networking::refresh() {
 }
 
 void Networking::connectToNetwork(const Network &n) {
-  if (wifi->isKnownConnection(n.ssid)) {
-    wifi->activateWifiConnection(n.ssid);
+  int conn_index = wifi->getConnectionIndex(n.ssid);
+  if (conn_index != -1) {
+    wifi->activateConnection(wifi->known_connections.at(conn_index));
   } else if (n.security_type == SecurityType::OPEN) {
     wifi->connect(n);
   } else if (n.security_type == SecurityType::WPA) {
@@ -221,7 +223,7 @@ void WifiUI::refresh() {
     ssid_label->setStyleSheet("font-size: 55px;");
     hlayout->addWidget(ssid_label, 1, Qt::AlignLeft);
 
-    if (wifi->isKnownConnection(network.ssid) && !wifi->tetheringEnabled()) {
+    if ((wifi->getConnectionIndex(network.ssid) != -1) && !wifi->tetheringEnabled()) {
       QPushButton *forgetBtn = new QPushButton();
       QPixmap pix("../assets/offroad/icon_close.svg");
 

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -107,10 +107,10 @@ void Networking::requestScan() {
 }
 
 void Networking::refresh() {
-  if (this->isVisible() || wifi->firstRefresh) {
+  if (this->isVisible() || wifi->firstScan) {
     wifiWidget->refresh();
     an->refresh();
-    wifi->firstRefresh = false;
+    wifi->firstScan = false;
   }
 }
 

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -108,7 +108,6 @@ void Networking::requestScan() {
 
 void Networking::refresh() {
   if (this->isVisible() || wifi->firstScan) {
-    qDebug() << "REFRESHING UI";
     wifiWidget->refresh();
     an->refresh();
     wifi->firstScan = false;
@@ -116,9 +115,8 @@ void Networking::refresh() {
 }
 
 void Networking::connectToNetwork(const Network &n) {
-  int conn_index = wifi->getConnectionIndex(n.ssid);
-  if (conn_index != -1) {
-    wifi->activateConnection(wifi->known_connections.at(conn_index));
+  if (wifi->isKnownConnection(n.ssid)) {
+    wifi->activateWifiConnection(n.ssid);
   } else if (n.security_type == SecurityType::OPEN) {
     wifi->connect(n);
   } else if (n.security_type == SecurityType::WPA) {
@@ -223,7 +221,7 @@ void WifiUI::refresh() {
     ssid_label->setStyleSheet("font-size: 55px;");
     hlayout->addWidget(ssid_label, 1, Qt::AlignLeft);
 
-    if ((wifi->getConnectionIndex(network.ssid) != -1) && !wifi->tetheringEnabled()) {
+    if (wifi->isKnownConnection(network.ssid) && !wifi->tetheringEnabled()) {
       QPushButton *forgetBtn = new QPushButton();
       QPixmap pix("../assets/offroad/icon_close.svg");
 

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -118,7 +118,9 @@ void Networking::connectToNetwork(const Network &n) {
     wifi->connect(n);
   } else if (n.security_type == SecurityType::WPA) {
     QString pass = InputDialog::getText("Enter password for \"" + n.ssid + "\"", 8);
-    wifi->connect(n, pass);
+    if (!pass.isEmpty()) {
+      wifi->connect(n, pass);
+    }
   }
 }
 
@@ -126,7 +128,9 @@ void Networking::wrongPassword(const QString &ssid) {
   for (Network n : wifi->seen_networks) {
     if (n.ssid == ssid) {
       QString pass = InputDialog::getText("Wrong password for \"" + n.ssid +"\"", 8);
-      wifi->connect(n, pass);
+      if (!pass.isEmpty()) {
+        wifi->connect(n, pass);
+      }
       return;
     }
   }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -47,7 +47,7 @@ void Networking::attemptInitialization() {
   }
 
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
-  connect(wifi, &WifiManager::refreshSignal, this, &Networking::refreshSlot);
+  connect(wifi, &WifiManager::refreshSignal, this, &Networking::refresh);
 
   QWidget* wifiScreen = new QWidget(this);
   QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
@@ -106,9 +106,12 @@ void Networking::requestScan() {
   wifi->requestScan();
 }
 
-void Networking::refreshSlot() {
-  wifiWidget->refresh();
-  an->refresh();
+void Networking::refresh() {
+  if (this->isVisible() || wifi->firstRefresh) {
+    wifiWidget->refresh();
+    an->refresh();
+    wifi->firstRefresh = false;
+  }
 }
 
 void Networking::connectToNetwork(const Network &n) {

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -30,7 +30,6 @@ private:
   WifiManager *wifi = nullptr;
   QVBoxLayout* main_layout;
 
-  QButtonGroup *connectButtons;
   bool tetheringEnabled;
 
 signals:
@@ -38,7 +37,6 @@ signals:
 
 public slots:
   void refresh();
-  void handleButton(QAbstractButton* m_button);
 };
 
 class AdvancedNetworking : public QWidget {

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -76,7 +76,7 @@ private:
   void requestScan();
 
 public slots:
-  void refreshSlot();
+  void refresh();
 
 private slots:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -68,6 +68,7 @@ bool compare_by_strength(const Network &a, const Network &b) {
 WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   qDBusRegisterMetaType<Connection>();
   qDBusRegisterMetaType<IpConfig>();
+  qDBusRegisterMetaType<QDBusObjectPath>();
   connecting_to_network = "";
   adapter = get_adapter();
 
@@ -79,6 +80,8 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   QDBusInterface nm(nm_service, adapter, device_iface, bus);
   bus.connect(nm_service, adapter, device_iface, "StateChanged", this, SLOT(stateChange(unsigned int, unsigned int, unsigned int)));
   bus.connect(nm_service, adapter, props_iface, "PropertiesChanged", this, SLOT(propertyChange(QString, QVariantMap, QStringList)));
+//  qDebug() << "removed:" << bus.connect(nm_service, adapter, props_iface, "ConnectionRemoved", this, SLOT(connectionRemoved(QDBusObjectPath)));
+//  qDebug() << "new con:" << bus.connect(nm_service, adapter, props_iface, "NewConnection", this, SLOT(newConnection(QDBusObjectPath)));
 
   QDBusInterface device_props(nm_service, adapter, props_iface, bus);
   device_props.setTimeout(dbus_timeout);
@@ -372,7 +375,17 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
   if (interface == wireless_device_iface && props.contains("LastScan")) {
     refreshNetworks();  // TODO: only refresh on firstScan, then use AccessPointAdded and Removed signals
     emit refreshSignal();
+  } else if (props.contains("AvailableConnections")) {
+    qDebug() << props;
   }
+}
+
+void WifiManager::connectionRemoved(const QDBusObjectPath &path) {
+  qDebug() << "CONNECTION REMOVED!";
+}
+
+void WifiManager::newConnection(const QDBusObjectPath &path) {
+  qDebug() << "CONNECTION REMOVED!";
 }
 
 void WifiManager::disconnect() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -371,7 +371,6 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
   if (interface == wireless_device_iface && props.contains("LastScan")) {
     if (firstRefresh) {
       known_connections = listConnections();
-      firstRefresh = false;
     }
     refreshNetworks();
     emit refreshSignal();

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -149,7 +149,6 @@ QList<Network> WifiManager::get_networks() {
   QList<Network> r;
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
-  updateConnections();
 
   const QString active_ap = get_active_ap();
   const QDBusReply<QList<QDBusObjectPath>> response = nm.call("GetAllAccessPoints");
@@ -358,6 +357,7 @@ QString WifiManager::get_adapter() {
 void WifiManager::stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason) {
   raw_adapter_state = new_state;
   if (new_state == state_need_auth && change_reason == reason_wrong_password) {
+    forgetConnection(connecting_to_network);
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
@@ -369,6 +369,10 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan")) {
+    if (firstRefresh) {
+      known_connections = listConnections();
+      firstRefresh = false;
+    }
     refreshNetworks();
     emit refreshSignal();
   }
@@ -392,8 +396,8 @@ int WifiManager::getConnectionIndex(const QString &ssid) {
   return -1;
 }
 
-void WifiManager::updateConnections() {
-  known_connections.clear();
+QVector<QPair<QString, QDBusObjectPath>> WifiManager::listConnections() {
+  QVector<QPair<QString, QDBusObjectPath>> connections;
   QDBusInterface nm(nm_service, nm_settings_path, nm_settings_iface, bus);
   nm.setTimeout(dbus_timeout);
 
@@ -406,8 +410,9 @@ void WifiManager::updateConnections() {
     const QDBusReply<QMap<QString, QMap<QString, QVariant>>> map = nm2.call("GetSettings");
     const QString ssid = map.value().value("802-11-wireless").value("ssid").toString();
 
-    known_connections.push_back(qMakePair(ssid, path));
+    connections.push_back(qMakePair(ssid, path));
   }
+  return connections;
 }
 
 void WifiManager::activateWifiConnection(const QString &ssid) {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -369,10 +369,10 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan")) {
-    if (firstRefresh) {
+    if (firstScan) {
       known_connections = listConnections();
     }
-    refreshNetworks();
+    refreshNetworks();  // TODO: only refresh on firstScan, then use AccessPointAdded and Removed signals
     emit refreshSignal();
   }
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -150,6 +150,7 @@ QList<Network> WifiManager::get_networks() {
   QList<Network> r;
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
+//  updateConnections();
 
   const QString active_ap = get_active_ap();
   const QDBusReply<QList<QDBusObjectPath>> response = nm.call("GetAllAccessPoints");
@@ -237,6 +238,7 @@ void WifiManager::connect(const QByteArray &ssid, const QString &username, const
   nm_settings.setTimeout(dbus_timeout);
 
   const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
+//  updateConnections();
 }
 
 void WifiManager::deactivateConnection(const QString &ssid) {
@@ -281,6 +283,7 @@ void WifiManager::forgetConnection(const QString &ssid) {
     const QDBusObjectPath &path = known_connections.at(index).second;
     QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
     nm2.call("Delete");
+//    updateConnections();
   }
 }
 
@@ -444,6 +447,19 @@ void WifiManager::activateConnection(const QPair<QString, QDBusObjectPath> &conn
   nm3.call("ActivateConnection", QVariant::fromValue(conn.second), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
 }
 
+void WifiManager::activateWifiConnection(const QString &ssid) {
+  const int index = getConnectionIndex(ssid);
+  if (index != -1) {
+    const QDBusObjectPath &path = known_connections.at(index).second;
+    connecting_to_network = ssid;
+
+    QString devicePath = get_adapter();
+    QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
+    nm3.setTimeout(dbus_timeout);
+    nm3.call("ActivateConnection", QVariant::fromValue(path), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
+  }
+}
+
 // Functions for tethering
 void WifiManager::addTetheringConnection() {
   Connection connection;
@@ -476,16 +492,14 @@ void WifiManager::addTetheringConnection() {
   nm_settings.setTimeout(dbus_timeout);
 
   const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
+//  updateConnections();
 }
 
 void WifiManager::enableTethering() {
   if (getConnectionIndex(tethering_ssid.toUtf8()) == -1) {
     addTetheringConnection();
   }
-  int index = getConnectionIndex(tethering_ssid.toUtf8()) == -1;
-  if (index != -1) {
-    activateConnection(known_connections.at(index));
-  }
+//  activateWifiConnection(tethering_ssid.toUtf8());
 }
 
 void WifiManager::disableTethering() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -414,6 +414,8 @@ void WifiManager::activateWifiConnection(const QString &ssid) {
   const int index = getConnectionIndex(ssid);
   if (index != -1) {
     const QDBusObjectPath &path = known_connections.at(index).second;
+    connecting_to_network = ssid;
+
     QString devicePath = get_adapter();
     QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
     nm3.setTimeout(dbus_timeout);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -150,7 +150,6 @@ QList<Network> WifiManager::get_networks() {
   QList<Network> r;
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
-//  updateConnections();
 
   const QString active_ap = get_active_ap();
   const QDBusReply<QList<QDBusObjectPath>> response = nm.call("GetAllAccessPoints");
@@ -238,7 +237,6 @@ void WifiManager::connect(const QByteArray &ssid, const QString &username, const
   nm_settings.setTimeout(dbus_timeout);
 
   const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
-//  updateConnections();
 }
 
 void WifiManager::deactivateConnection(const QString &ssid) {
@@ -283,7 +281,6 @@ void WifiManager::forgetConnection(const QString &ssid) {
     const QDBusObjectPath &path = known_connections.at(index).second;
     QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
     nm2.call("Delete");
-//    updateConnections();
   }
 }
 
@@ -447,19 +444,6 @@ void WifiManager::activateConnection(const QPair<QString, QDBusObjectPath> &conn
   nm3.call("ActivateConnection", QVariant::fromValue(conn.second), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
 }
 
-void WifiManager::activateWifiConnection(const QString &ssid) {
-  const int index = getConnectionIndex(ssid);
-  if (index != -1) {
-    const QDBusObjectPath &path = known_connections.at(index).second;
-    connecting_to_network = ssid;
-
-    QString devicePath = get_adapter();
-    QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
-    nm3.setTimeout(dbus_timeout);
-    nm3.call("ActivateConnection", QVariant::fromValue(path), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
-  }
-}
-
 // Functions for tethering
 void WifiManager::addTetheringConnection() {
   Connection connection;
@@ -492,14 +476,16 @@ void WifiManager::addTetheringConnection() {
   nm_settings.setTimeout(dbus_timeout);
 
   const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
-//  updateConnections();
 }
 
 void WifiManager::enableTethering() {
   if (getConnectionIndex(tethering_ssid.toUtf8()) == -1) {
     addTetheringConnection();
   }
-//  activateWifiConnection(tethering_ssid.toUtf8());
+  int index = getConnectionIndex(tethering_ssid.toUtf8()) == -1;
+  if (index != -1) {
+    activateConnection(known_connections.at(index));
+  }
 }
 
 void WifiManager::disableTethering() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -68,7 +68,6 @@ bool compare_by_strength(const Network &a, const Network &b) {
 WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   qDBusRegisterMetaType<Connection>();
   qDBusRegisterMetaType<IpConfig>();
-  qDBusRegisterMetaType<QDBusObjectPath>();
   connecting_to_network = "";
   adapter = get_adapter();
 
@@ -80,8 +79,6 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   QDBusInterface nm(nm_service, adapter, device_iface, bus);
   bus.connect(nm_service, adapter, device_iface, "StateChanged", this, SLOT(stateChange(unsigned int, unsigned int, unsigned int)));
   bus.connect(nm_service, adapter, props_iface, "PropertiesChanged", this, SLOT(propertyChange(QString, QVariantMap, QStringList)));
-//  qDebug() << "removed:" << bus.connect(nm_service, adapter, props_iface, "ConnectionRemoved", this, SLOT(connectionRemoved(QDBusObjectPath)));
-//  qDebug() << "new con:" << bus.connect(nm_service, adapter, props_iface, "NewConnection", this, SLOT(newConnection(QDBusObjectPath)));
 
   QDBusInterface device_props(nm_service, adapter, props_iface, bus);
   device_props.setTimeout(dbus_timeout);
@@ -375,17 +372,7 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
   if (interface == wireless_device_iface && props.contains("LastScan")) {
     refreshNetworks();  // TODO: only refresh on firstScan, then use AccessPointAdded and Removed signals
     emit refreshSignal();
-  } else if (props.contains("AvailableConnections")) {
-    qDebug() << props;
   }
-}
-
-void WifiManager::connectionRemoved(const QDBusObjectPath &path) {
-  qDebug() << "CONNECTION REMOVED!";
-}
-
-void WifiManager::newConnection(const QDBusObjectPath &path) {
-  qDebug() << "CONNECTION REMOVED!";
 }
 
 void WifiManager::disconnect() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -236,7 +236,7 @@ void WifiManager::connect(const QByteArray &ssid, const QString &username, const
   QDBusInterface nm_settings(nm_service, nm_settings_path, nm_settings_iface, bus);
   nm_settings.setTimeout(dbus_timeout);
 
-  const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
+  nm_settings.call("AddConnection", QVariant::fromValue(connection));
   updateConnections();
   activateWifiConnection(QString(ssid));
 }
@@ -455,7 +455,7 @@ void WifiManager::addTetheringConnection() {
   QDBusInterface nm_settings(nm_service, nm_settings_path, nm_settings_iface, bus);
   nm_settings.setTimeout(dbus_timeout);
 
-  const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
+  nm_settings.call("AddConnection", QVariant::fromValue(connection));
   updateConnections();
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -457,7 +457,9 @@ void WifiManager::addTetheringConnection() {
 
   QDBusInterface nm_settings(nm_service, nm_settings_path, nm_settings_iface, bus);
   nm_settings.setTimeout(dbus_timeout);
-  nm_settings.call("AddConnection", QVariant::fromValue(connection));
+
+  const QDBusReply<QDBusObjectPath> response = nm_settings.call("AddConnection", QVariant::fromValue(connection));
+  known_connections.push_back(qMakePair(QString(tethering_ssid), response.value()));
 }
 
 void WifiManager::enableTethering() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -80,6 +80,8 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   QDBusInterface nm(nm_service, adapter, device_iface, bus);
   bus.connect(nm_service, adapter, device_iface, "StateChanged", this, SLOT(stateChange(unsigned int, unsigned int, unsigned int)));
   bus.connect(nm_service, adapter, props_iface, "PropertiesChanged", this, SLOT(propertyChange(QString, QVariantMap, QStringList)));
+//  qDebug() << "removed:" << bus.connect(nm_service, adapter, props_iface, "ConnectionRemoved", this, SLOT(connectionRemoved(QDBusObjectPath)));
+//  qDebug() << "new con:" << bus.connect(nm_service, adapter, props_iface, "NewConnection", this, SLOT(newConnection(QDBusObjectPath)));
 
   QDBusInterface device_props(nm_service, adapter, props_iface, bus);
   device_props.setTimeout(dbus_timeout);
@@ -150,7 +152,7 @@ QList<Network> WifiManager::get_networks() {
   QList<Network> r;
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
-//  updateConnections();
+  updateConnections();
 
   const QString active_ap = get_active_ap();
   const QDBusReply<QList<QDBusObjectPath>> response = nm.call("GetAllAccessPoints");
@@ -238,7 +240,8 @@ void WifiManager::connect(const QByteArray &ssid, const QString &username, const
   nm_settings.setTimeout(dbus_timeout);
 
   const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
-//  updateConnections();
+  updateConnections();
+  activateWifiConnection(QString(ssid));
 }
 
 void WifiManager::deactivateConnection(const QString &ssid) {
@@ -277,13 +280,17 @@ QVector<QDBusObjectPath> WifiManager::get_active_connections() {
   return conns;
 }
 
+bool WifiManager::isKnownConnection(const QString &ssid) {
+  return getConnectionIndex(ssid) != -1;
+}
+
 void WifiManager::forgetConnection(const QString &ssid) {
   const int index = getConnectionIndex(ssid);
   if (index != -1) {
     const QDBusObjectPath &path = known_connections.at(index).second;
     QDBusInterface nm2(nm_service, path.path(), nm_settings_conn_iface, bus);
     nm2.call("Delete");
-//    updateConnections();
+    updateConnections();
   }
 }
 
@@ -366,41 +373,19 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 // https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan")) {
-    if (firstScan) {
-      updateConnections();
-    }
     refreshNetworks();  // TODO: only refresh on firstScan, then use AccessPointAdded and Removed signals
-    qDebug() << "REFRESHED, EMITTING";
     emit refreshSignal();
-
   } else if (props.contains("AvailableConnections")) {
-    known_connections.clear();
-    qDebug() << props.value("AvailableConnections");
-
-    const QDBusArgument &dbusArgs = props.value("AvailableConnections").value<QDBusArgument>();
-    dbusArgs.beginArray();
-    while (!dbusArgs.atEnd()) {
-      QDBusObjectPath path;
-      dbusArgs >> path;
-
-      QDBusInterface nm(nm_service, path.path(), nm_settings_conn_iface, bus);
-      nm.setTimeout(dbus_timeout);
-
-      const QDBusReply<Connection> result = nm.call("GetSettings");
-      const QString ssid = result.value().value("802-11-wireless").value("ssid").toString();
-
-      const QPair<QString, QDBusObjectPath> conn = qMakePair(ssid, path);
-      if (ssid == connecting_to_network) {
-        qDebug() << "Activating now!";
-        activateConnection(conn);
-      }
-
-      qDebug() << ssid << "path:" << path.path();
-      known_connections.push_back(conn);
-    }
-    dbusArgs.endArray();
-    emit refreshSignal();
+    qDebug() << props;
   }
+}
+
+void WifiManager::connectionRemoved(const QDBusObjectPath &path) {
+  qDebug() << "CONNECTION REMOVED!";
+}
+
+void WifiManager::newConnection(const QDBusObjectPath &path) {
+  qDebug() << "CONNECTION REMOVED!";
 }
 
 void WifiManager::disconnect() {
@@ -437,14 +422,6 @@ void WifiManager::updateConnections() {
 
     known_connections.push_back(qMakePair(ssid, path));
   }
-}
-
-void WifiManager::activateConnection(const QPair<QString, QDBusObjectPath> &conn) {
-  connecting_to_network = conn.first;
-  QString devicePath = get_adapter();
-  QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
-  nm3.setTimeout(dbus_timeout);
-  nm3.call("ActivateConnection", QVariant::fromValue(conn.second), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
 }
 
 void WifiManager::activateWifiConnection(const QString &ssid) {
@@ -492,14 +469,14 @@ void WifiManager::addTetheringConnection() {
   nm_settings.setTimeout(dbus_timeout);
 
   const QDBusReply<QDBusObjectPath> result = nm_settings.call("AddConnection", QVariant::fromValue(connection));
-//  updateConnections();
+  updateConnections();
 }
 
 void WifiManager::enableTethering() {
-  if (getConnectionIndex(tethering_ssid.toUtf8()) == -1) {
+  if (!isKnownConnection(tethering_ssid.toUtf8())) {
     addTetheringConnection();
   }
-//  activateWifiConnection(tethering_ssid.toUtf8());
+  activateWifiConnection(tethering_ssid.toUtf8());
 }
 
 void WifiManager::disableTethering() {

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -38,7 +38,7 @@ public:
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
-  int getConnectionIndex(const QString &ssid);
+  bool isKnownConnection(const QString &ssid);
 
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);
@@ -52,7 +52,6 @@ public:
 
   void addTetheringConnection();
   void activateWifiConnection(const QString &ssid);
-  void activateConnection(const QPair<QString, QDBusObjectPath> &conn);
   void changeTetheringPassword(const QString &newPassword);
 
 private:
@@ -75,6 +74,7 @@ private:
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &path);
+  int getConnectionIndex(const QString &ssid);
   void updateConnections();
 
 signals:
@@ -84,4 +84,6 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
+  void connectionRemoved(const QDBusObjectPath &path);
+  void newConnection(const QDBusObjectPath &path);
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -51,7 +51,6 @@ public:
   bool tetheringEnabled();
 
   void addTetheringConnection();
-  void activateWifiConnection(const QString &ssid);
   void activateConnection(const QPair<QString, QDBusObjectPath> &conn);
   void changeTetheringPassword(const QString &newPassword);
 

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -32,7 +32,8 @@ public:
 
   void requestScan();
   QVector<Network> seen_networks;
-  QVector<QPair<QString, QDBusObjectPath>> known_connections;
+//  QVector<QPair<QString, QDBusObjectPath>> known_connections;
+  QMap<QDBusObjectPath, QString> known_connections;
   QString ipv4_address;
   bool firstScan = true;
 
@@ -74,8 +75,8 @@ private:
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &path);
-  int getConnectionIndex(const QString &ssid);
-  void updateConnections();
+  QDBusObjectPath getConnectionPath(const QString &ssid);
+  QMap<QDBusObjectPath, QString> listConnections();
 
 signals:
   void wrongPassword(const QString &ssid);
@@ -84,4 +85,6 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
+  void connectionRemoved(const QDBusObjectPath &path);
+  void newConnection(const QDBusObjectPath &path);
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -77,6 +77,7 @@ private:
   SecurityType getSecurityType(const QString &path);
   QDBusObjectPath getConnectionPath(const QString &ssid);
   QMap<QDBusObjectPath, QString> listConnections();
+  QString getConnectionSsid(const QDBusObjectPath &path);
 
 signals:
   void wrongPassword(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -51,6 +51,7 @@ public:
   bool tetheringEnabled();
 
   void addTetheringConnection();
+  void activateWifiConnection(const QString &ssid);
   void activateConnection(const QPair<QString, QDBusObjectPath> &conn);
   void changeTetheringPassword(const QString &newPassword);
 

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,6 +34,7 @@ public:
   QVector<Network> seen_networks;
   QVector<QPair<QString, QDBusObjectPath>> known_connections;
   QString ipv4_address;
+  bool firstRefresh = true;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
@@ -74,7 +75,7 @@ private:
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &path);
   int getConnectionIndex(const QString &ssid);
-  void updateConnections();
+  QVector<QPair<QString, QDBusObjectPath>> listConnections();
 
 signals:
   void wrongPassword(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -32,11 +32,12 @@ public:
 
   void requestScan();
   QVector<Network> seen_networks;
+  QVector<QPair<QString, QDBusObjectPath>> known_connections;
   QString ipv4_address;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
-  bool isKnownNetwork(const QString &ssid);
+  bool isKnownConnection(const QString &ssid);
 
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);
@@ -72,8 +73,8 @@ private:
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &path);
-  QDBusObjectPath pathFromSsid(const QString &ssid);
-  QVector<QPair<QString, QDBusObjectPath>> listConnections();
+  int getConnectionIndex(const QString &ssid);
+  void updateConnections();
 
 signals:
   void wrongPassword(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -84,4 +84,6 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
+  void connectionRemoved(const QDBusObjectPath &path);
+  void newConnection(const QDBusObjectPath &path);
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -84,6 +84,4 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
-  void connectionRemoved(const QDBusObjectPath &path);
-  void newConnection(const QDBusObjectPath &path);
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -38,7 +38,7 @@ public:
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
-  bool isKnownConnection(const QString &ssid);
+  int getConnectionIndex(const QString &ssid);
 
   void connect(const Network &ssid);
   void connect(const Network &ssid, const QString &password);
@@ -52,6 +52,7 @@ public:
 
   void addTetheringConnection();
   void activateWifiConnection(const QString &ssid);
+  void activateConnection(const QPair<QString, QDBusObjectPath> &conn);
   void changeTetheringPassword(const QString &newPassword);
 
 private:
@@ -74,7 +75,6 @@ private:
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &path);
-  int getConnectionIndex(const QString &ssid);
   void updateConnections();
 
 signals:
@@ -84,6 +84,4 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
-  void connectionRemoved(const QDBusObjectPath &path);
-  void newConnection(const QDBusObjectPath &path);
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,7 +34,7 @@ public:
   QVector<Network> seen_networks;
   QVector<QPair<QString, QDBusObjectPath>> known_connections;
   QString ipv4_address;
-  bool firstRefresh = true;
+  bool firstScan = true;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -75,7 +75,7 @@ private:
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &path);
   int getConnectionIndex(const QString &ssid);
-  QVector<QPair<QString, QDBusObjectPath>> listConnections();
+  void updateConnections();
 
 signals:
   void wrongPassword(const QString &ssid);


### PR DESCRIPTION
- Fix race condition; individually connect buttons to `connectToNetwork`, passing the network
- Instead of calling `ListConnections` each time we call `pathFromSsid` (checking if connection is known, activating a connection, forgetting a network, etc) we update class variable `known_connections` once per update, and when a connection is added or removed by user.
- Shorter syntax to parse data from nm calls

Previous avg time to update UI: 208, 187, 210, 189, 207, 207, 212, 200, 188. AVG: 200.89 ms
New avg time to update UI: 84, 70, 81, 83, 84, 89, 81, 81, 85. AVG: 82 ms