### PR TITLE
add car harness as checkbox on car port template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/car_port.md
+++ b/.github/PULL_REQUEST_TEMPLATE/car_port.md
@@ -12,3 +12,4 @@ assignees: ''
 - [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_models.py)
 - [ ] route with openpilot:
 - [ ] route with stock system:
+- [ ] car harness used (if comma doesn't sell it, put N/A):


### PR DESCRIPTION
Most of the time Hyundais get merged, I have to reach out to the user to find out which harness type they're using before adding it to our compatibility flow on the website. This should hopefully fix that!