### PR TITLE
Support WPS with no security

### DIFF
--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -163,7 +163,7 @@ QList<Network> WifiManager::get_networks() {
 
     QByteArray ssid = get_property(path.path(), "Ssid");
     unsigned int strength = get_ap_strength(path.path());
-    SecurityType security = getSecurityType(path.path(), ssid);
+    SecurityType security = getSecurityType(path.path());
     ConnectedType ctype;
     if (path.path() != active_ap) {
       ctype = ConnectedType::DISCONNECTED;
@@ -186,7 +186,7 @@ QList<Network> WifiManager::get_networks() {
   return r;
 }
 
-SecurityType WifiManager::getSecurityType(const QString &path, const QString &ssid) {
+SecurityType WifiManager::getSecurityType(const QString &path) {
   int sflag = get_property(path, "Flags").toInt();
   int wpaflag = get_property(path, "WpaFlags").toInt();
   int rsnflag = get_property(path, "RsnFlags").toInt();
@@ -195,17 +195,7 @@ SecurityType WifiManager::getSecurityType(const QString &path, const QString &ss
   // obtained by looking at flags of networks in the office as reported by an Android phone
   const int supports_wpa = NM_802_11_AP_SEC_PAIR_WEP40 | NM_802_11_AP_SEC_PAIR_WEP104 | NM_802_11_AP_SEC_GROUP_WEP40 | NM_802_11_AP_SEC_GROUP_WEP104 | NM_802_11_AP_SEC_KEY_MGMT_PSK;
 
-//  if (ssid == "STRESS_TEST") {
-    qDebug() << ssid;
-    qDebug() << "sflag:" << sflag;
-    qDebug() << "wpaflag:" << wpaflag;
-    qDebug() << "rsnflag:" << rsnflag;
-    qDebug() << "wpa_props:" << wpa_props;
-    qDebug() << "supports_wpa:" << (wpa_props & supports_wpa);
-    qDebug() << "---\n";
-//  }
-
-  if ((sflag == NM_802_11_AP_FLAGS_NONE) || (sflag & NM_802_11_AP_FLAGS_WPS && !(wpa_props & supports_wpa))) {
+  if ((sflag == NM_802_11_AP_FLAGS_NONE) || ((sflag & NM_802_11_AP_FLAGS_WPS) && !(wpa_props & supports_wpa))) {
     return SecurityType::OPEN;
   } else if ((sflag & NM_802_11_AP_FLAGS_PRIVACY) && (wpa_props & supports_wpa) && !(wpa_props & NM_802_11_AP_SEC_KEY_MGMT_802_1X)) {
     return SecurityType::WPA;

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -200,6 +200,7 @@ SecurityType WifiManager::getSecurityType(const QString &path) {
   } else if ((sflag & NM_802_11_AP_FLAGS_PRIVACY) && (wpa_props & supports_wpa) && !(wpa_props & NM_802_11_AP_SEC_KEY_MGMT_802_1X)) {
     return SecurityType::WPA;
   } else {
+    LOGW("Unsupported network! sflag: %d, wpaflag: %d, rsnflag: %d", sflag, wpaflag, rsnflag);
     return SecurityType::UNSUPPORTED;
   }
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -71,7 +71,7 @@ private:
   uint get_wifi_device_state();
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
-  SecurityType getSecurityType(const QString &ssid);
+  SecurityType getSecurityType(const QString &path, const QString &ssid);
   QDBusObjectPath pathFromSsid(const QString &ssid);
   QVector<QPair<QString, QDBusObjectPath>> listConnections();
 

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -71,7 +71,7 @@ private:
   uint get_wifi_device_state();
   QByteArray get_property(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
-  SecurityType getSecurityType(const QString &path, const QString &ssid);
+  SecurityType getSecurityType(const QString &path);
   QDBusObjectPath pathFromSsid(const QString &ssid);
   QVector<QPair<QString, QDBusObjectPath>> listConnections();
 


### PR DESCRIPTION
Apparently you need security if you're using WPS, but `STRESS_TEST` has the WPS flag with no WPA security