### PR TITLE
fix: fix pathing issues in ubuntu_setup.sh and openpilot_env.sh

### DIFF
--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,9 +1,18 @@
 if [ -z "$OPENPILOT_ENV" ]; then
-  export PYTHONPATH="$HOME/openpilot"
+  export PYTHONPATH="$HOME/openpilot:$PYTHONPATH"
 
   unamestr=`uname`
   if [[ "$unamestr" == 'Linux' ]]; then
     export PATH="$HOME/.pyenv/bin:$PATH"
+
+    # Pyenv suggests we place the below two lines in .profile before we source
+    # .bashrc, but there is no simple way to guarantee we do this correctly
+    # programmatically across heterogeneous systems. For end-user convenience,
+    # we add the lines here as a workaround.
+    # https://github.com/pyenv/pyenv/issues/1906
+    export PYENV_ROOT="$HOME/.pyenv"
+    eval "$(pyenv init --path)"
+
     eval "$(pyenv virtualenv-init -)"
   elif [[ "$unamestr" == 'Darwin' ]]; then
     # msgq doesn't work on mac

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -71,7 +71,6 @@ fi
 # in the openpilot repo
 cd $HOME/openpilot
 
-# maybe extend bashrc
 source ~/.bashrc
 if [ -z "$OPENPILOT_ENV" ]; then
   OP_DIR=$(git rev-parse --show-toplevel)

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -68,17 +68,17 @@ if ! command -v "pyenv" > /dev/null 2>&1; then
   curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
 fi
 
-# install bashrc
+# in the openpilot repo
+cd $HOME/openpilot
+
+# maybe extend bashrc
 source ~/.bashrc
 if [ -z "$OPENPILOT_ENV" ]; then
   OP_DIR=$(git rev-parse --show-toplevel)
-  echo "source $OP_DIR/tools/openpilot_env.sh" >> ~/.bashrc
+  printf "\nsource %s/tools/openpilot_env.sh" "$OP_DIR" >> ~/.bashrc
   source ~/.bashrc
   echo "added openpilot_env to bashrc"
 fi
-
-# in the openpilot repo
-cd $HOME/openpilot
 
 # do the rest of the git checkout
 git lfs pull


### PR DESCRIPTION
**Intro**

Hi all, this is my first MR here, so I took some low-hanging fruit to get used to the process.

**Description**

The [openpilot tools setup instructions](https://github.com/commaai/openpilot/blob/master/tools/README.md#setup) does not work as-is.

When run from the home directory, git operations fail before `cd`'ing into the git tree. We could solve this by telling people to `cd` into the git tree, but it requires another step for the end-user, so I wanted to handle it programmatically.

Also, `pyenv` is not set up correctly, causing executables managed by it to not be on the `PATH`. This includes things like `scons`, without which we cannot build.

Additionally, `PYTHONPATH` [is `PATH`-like](https://docs.python.org/3.8/using/cmdline.html#envvar-PYTHONPATH), so we now extend it instead of overwriting it.

**Other Things**
This also writes a newline into .bashrc before extending it, to visually separate openpilot additions from existing content.

**Verification**

In short, I followed the setup instructions again with my changes in place.

In detail, I:
1. Removed my `pyenv` installation: `rm -rf ~/.pyenv`
2. Changed to my home directory
3. Ran `openpilot/tools/ubuntu_setup.sh`
4. [EDIT] Sourced my .bashrc
4. Confirmed `pyenv`, `scons`, etc. are on my path
5. Ran a successful build with `scons -j$(nproc)`