### PR TITLE
Only create known_connections on first refresh

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -116,7 +116,9 @@ void Networking::connectToNetwork(const Network &n) {
     wifi->connect(n);
   } else if (n.security_type == SecurityType::WPA) {
     QString pass = InputDialog::getText("Enter password for \"" + n.ssid + "\"", 8);
-    wifi->connect(n, pass);
+    if (!pass.isEmpty()) {
+      wifi->connect(n, pass);
+    }
   }
 }
 
@@ -124,7 +126,9 @@ void Networking::wrongPassword(const QString &ssid) {
   for (Network n : wifi->seen_networks) {
     if (n.ssid == ssid) {
       QString pass = InputDialog::getText("Wrong password for \"" + n.ssid +"\"", 8);
-      wifi->connect(n, pass);
+      if (!pass.isEmpty()) {
+        wifi->connect(n, pass);
+      }
       return;
     }
   }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -394,10 +394,10 @@ int WifiManager::getConnectionIndex(const QString &ssid) {
 }
 
 QVector<QPair<QString, QDBusObjectPath>> WifiManager::listConnections() {
+  QVector<QPair<QString, QDBusObjectPath>> connections;
   QDBusInterface nm(nm_service, nm_settings_path, nm_settings_iface, bus);
   nm.setTimeout(dbus_timeout);
 
-  QVector<QPair<QString, QDBusObjectPath>> connections;
   const QDBusReply<QList<QDBusObjectPath>> response = nm.call("ListConnections");
 
   for (const QDBusObjectPath &path : response.value()) {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -354,6 +354,7 @@ QString WifiManager::get_adapter() {
 void WifiManager::stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason) {
   raw_adapter_state = new_state;
   if (new_state == state_need_auth && change_reason == reason_wrong_password) {
+    forgetConnection(connecting_to_network);
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
@@ -366,10 +367,8 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
 void WifiManager::propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props) {
   if (interface == wireless_device_iface && props.contains("LastScan")) {
     if (firstRefresh) {
-      QElapsedTimer timer;
-      timer.start();
       known_connections = listConnections();
-      qDebug() << "listConnections:" << timer.nsecsElapsed() / 1e+6;
+      firstRefresh = false;
     }
     refreshNetworks();
     emit refreshSignal();

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,6 +34,7 @@ public:
   QVector<Network> seen_networks;
   QVector<QPair<QString, QDBusObjectPath>> known_connections;
   QString ipv4_address;
+  bool firstRefresh = true;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
@@ -74,7 +75,7 @@ private:
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &ssid);
   int getConnectionIndex(const QString &ssid);
-  void updateConnections();
+  QVector<QPair<QString, QDBusObjectPath>> listConnections();
 
 signals:
   void wrongPassword(const QString &ssid);


### PR DESCRIPTION
`listConnections` takes 7 to 11 ms so wait for first scan to complete to create the list once. The only two cases a known connection should be added or removed is when a user adds a new network or when a user forgets a network, which both should be handled correctly.

Todo:
- [x] Make sure adding a connection with a wrong password is handled properly (ie. removed if wrongPassword emitted)