### PR TITLE
fix: sim: gracefully shutdown the bridge

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -161,7 +161,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=capnp.* cereal.* pygame.* zmq.* setproctitle.* smbus2.* usb1.* serial.* cv2.* ft4222.*
+generated-members=capnp.* cereal.* pygame.* zmq.* setproctitle.* smbus2.* usb1.* serial.* cv2.* ft4222.* carla.*
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/tools/sim/lib/keyboard_ctrl.py
+++ b/tools/sim/lib/keyboard_ctrl.py
@@ -35,7 +35,7 @@ def getch() -> str:
     termios.tcsetattr(STDIN_FD, termios.TCSADRAIN, old_settings)
   return ch
 
-def keyboard_poll_thread(q: 'Queue[str]') -> NoReturn:
+def keyboard_poll_thread(q: 'Queue[str]'):
   while True:
     c = getch()
     # print("got %s" % c)
@@ -54,7 +54,8 @@ def keyboard_poll_thread(q: 'Queue[str]') -> NoReturn:
     elif c == 'd':
       q.put("steer_%f" % -0.15)
     elif c == 'q':
-      exit(0)
+      q.put("quit")
+      break
 
 def test(q: 'Queue[str]') -> NoReturn:
   while True:


### PR DESCRIPTION
# Description

Currently pressing `q` in the simulator to shut the bridge down "just works" but is not a true graceful exit. This MR adjusts the control flow and management of threads and processes to achieve graceful shutdown.

## In Detail

We need multiple changes to address the control flow issues.

Currently `bridge` was attempting to clean up CARLA resources in a function registered with `atexit`. However, `bridge` runs as a subprocess, so functions registered in it with `atexit` are not invoked. (We can confirm this visually--`destroy()`'s print statements were not executing.) We fix this by cleaning up the resources ourselves at the end of `bridge`.

Currently `bridge` is terminated immediately when the keyboard-polling function reads `q` from its message queue. Instead of terminating immediately, they keyboard-polling function now emits a `quit` message when it encounters `q`, and then the keyboard-polling function itself returns. In `main`, we can now join the `bridge` process and wait for it to exit gracefully.

`bridge` also spawns some threads, and `join`ing `bridge` hangs until those threads are shut down. So, we now create a queue for each thread and use the queue to issue control flow messages to the threads so that we may stop their loops and join the threads at shutdown time.

### Design Decisions for Threads

There are many choices for issuing the shutdown signal to the threads. One is global variables, but I'd like to avoid those at all costs. The others are mostly all synchronization primitives from `threading` or `multiprocessing`, for example `Event`. I chose queues because the semantics are most obvious with them. Synchronization primitives suggest that threads suspend execution for some time while waiting for a signal, which is not what we're doing here.

## Limitations

This fix doesn't cover using joystick input. I don't have access to a joystick-like device right now and so can't test any modifications to such functions.

# Verification

1. Start the simulator [as directed by the docs](https://github.com/commaai/openpilot/blob/master/tools/sim/README.md), except start openpilot with `MOUNT_OPENPILOT=1 ./start_openpilot_docker.sh` for development's sake.
2. Engage openpilot and let it run for a couple frames.
3. Press `q`.
4. The sim will show a red CAN error warning, and the terminal will show nothing concerning.

```text
root# ./bridge.py 
frame:  engaged: False ; throttle:  0.0 ; steer(c/deg):  -0.0 0.0 ; brake:  0.0
frame:  engaged: False ; throttle:  0.0 ; steer(c/deg):  -0.0 0.0 ; brake:  0.0
frame:  engaged: False ; throttle:  0.0 ; steer(c/deg):  -0.0 0.0 ; brake:  0.0
frame:  engaged: True ; throttle:  0.125 ; steer(c/deg):  -0.003 3.368 ; brake:  -0.0
frame:  engaged: True ; throttle:  0.146 ; steer(c/deg):  0.004 -3.803 ; brake:  -0.0
frame:  engaged: True ; throttle:  0.54 ; steer(c/deg):  0.004 -4.425 ; brake:  -0.0
frame:  engaged: True ; throttle:  0.548 ; steer(c/deg):  0.002 -2.045 ; brake:  -0.0
root#
```

# Future Work

`bridge.py` needs some more love. In my next passes, I'll be doing things like cleaning up the control flow in large functions more and getting rid of some cruft.