### PR TITLE
HttpRequest:  use a single QNetworkAccessManager instance

### DIFF
--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -9,7 +9,10 @@
 #include <QDebug>
 #include <QFile>
 #include <QJsonDocument>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QTimer>
 
 #include "selfdrive/common/params.h"
 #include "selfdrive/common/util.h"
@@ -68,7 +71,6 @@ QString create_jwt(const QJsonObject &payloads, int expiry) {
 }  // namespace CommaApi
 
 HttpRequest::HttpRequest(QObject *parent, const QString &requestURL, bool create_jwt_) : create_jwt(create_jwt_), QObject(parent) {
-  networkAccessManager = new QNetworkAccessManager(this);
   reply = NULL;
 
   networkTimer = new QTimer(this);
@@ -93,7 +95,7 @@ void HttpRequest::sendRequest(const QString &requestURL) {
   request.setUrl(QUrl(requestURL));
   request.setRawHeader(QByteArray("Authorization"), ("JWT " + token).toUtf8());
 
-  reply = networkAccessManager->get(request);
+  reply = getNam()->get(request);
 
   networkTimer->start();
   connect(reply, &QNetworkReply::finished, this, &HttpRequest::requestFinished);
@@ -120,4 +122,9 @@ void HttpRequest::requestFinished() {
   }
   reply->deleteLater();
   reply = NULL;
+}
+
+QNetworkAccessManager *HttpRequest::getNam() {
+  static QNetworkAccessManager qnam; // instantiated on first use.
+  return &qnam;
 }

--- a/selfdrive/ui/qt/api.h
+++ b/selfdrive/ui/qt/api.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <QJsonObject>
-#include <QNetworkReply>
+#include <QObject>
 #include <QString>
-#include <QTimer>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+class QTimer;
 
 namespace CommaApi {
 
@@ -27,7 +30,7 @@ protected:
   QNetworkReply *reply;
 
 private:
-  QNetworkAccessManager *networkAccessManager;
+  static QNetworkAccessManager *getNam();
   QTimer *networkTimer;
   bool create_jwt;
 


### PR DESCRIPTION
https://doc.qt.io/qt-5/qnetworkaccessmanager.html#details

> . It contains the proxy and cache configuration, as well as the signals related to such issues, and reply signals that can be used to monitor the progress of a network operation. One QNetworkAccessManager instance should be enough for the whole Qt application.