### PR TITLE
PID backward-Euler implementation. add Derivative, track actual actuator output, back-calculate integrator. 

### DIFF
--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -16,6 +16,9 @@ class CarController():
 
     self.packer = CANPacker(dbc_name)
 
+  def get_last_output(self):
+    return self.apply_steer_last / CarControllerParams.STEER_MAX
+
   def update(self, enabled, CS, actuators, pcm_cancel_cmd, hud_alert):
     # this seems needed to avoid steering faults and to force the sync with the EPS counter
     frame = CS.lkas_counter

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -11,6 +11,7 @@ TOGGLE_DEBUG = False
 
 class CarController():
   def __init__(self, dbc_name, CP, VM):
+    self.apply_steer_last = 0.0
     self.packer = CANPacker(dbc_name)
     self.enabled_last = False
     self.main_on_last = False
@@ -25,6 +26,7 @@ class CarController():
     steer_alert = visual_alert in [VisualAlert.steerRequired, VisualAlert.ldw]
 
     apply_steer = actuators.steer
+    self.apply_steer_last = apply_steer
 
     if pcm_cancel:
       #print "CANCELING!!!!"

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -23,6 +23,9 @@ class CarController():
     self.packer_obj = CANPacker(DBC[CP.carFingerprint]['radar'])
     self.packer_ch = CANPacker(DBC[CP.carFingerprint]['chassis'])
 
+  def get_last_output(self):
+    return self.apply_steer_last / self.params.STEER_MAX
+
   def update(self, enabled, CS, frame, actuators,
              hud_v_cruise, hud_show_lanes, hud_show_car, hud_alert):
 

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -79,6 +79,7 @@ HUDData = namedtuple("HUDData",
 
 class CarController():
   def __init__(self, dbc_name, CP, VM):
+    self.apply_steer_last = 0.
     self.braking = False
     self.brake_steady = 0.
     self.brake_last = 0.
@@ -87,6 +88,9 @@ class CarController():
     self.packer = CANPacker(dbc_name)
 
     self.params = CarControllerParams(CP)
+
+  def get_last_output(self):
+    return -self.apply_steer_last / self.params.STEER_MAX
 
   def update(self, enabled, CS, frame, actuators,
              pcm_speed, pcm_override, pcm_cancel_cmd, pcm_accel,
@@ -132,6 +136,8 @@ class CarController():
     apply_steer = int(interp(-actuators.steer * P.STEER_MAX, P.STEER_LOOKUP_BP, P.STEER_LOOKUP_V))
 
     lkas_active = enabled and not CS.steer_not_allowed
+
+    self.appy_steer_last = apply_steer
 
     # Send CAN commands.
     can_sends = []

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -42,6 +42,9 @@ class CarController():
     self.steer_rate_limited = False
     self.last_resume_frame = 0
 
+  def get_last_output(self):
+    return self.apply_steer_last / self.p.STEER_MAX
+
   def update(self, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert,
              left_lane, right_lane, left_lane_depart, right_lane_depart):
     # Steering Torque

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -40,7 +40,7 @@ class CarInterfaceBase():
     self.CC = None
     if CarController is not None:
       self.CC = CarController(self.cp.dbc_name, CP, self.VM)
-
+  
   @staticmethod
   def calc_accel_override(a_ego, a_target, v_ego, v_target):
     return 1.
@@ -93,6 +93,12 @@ class CarInterfaceBase():
     ret.longitudinalTuning.kiV = [1.]
     return ret
 
+  def calc_last_outputs(self, request):
+    lat_out = request
+    if hasattr(self.CC, 'get_last_output'):
+      lat_out = self.CC.get_last_output()
+    return lat_out
+    
   # returns a car.CarState, pass in car.CarControl
   def update(self, c, can_strings):
     raise NotImplementedError

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -40,7 +40,7 @@ class CarInterfaceBase():
     self.CC = None
     if CarController is not None:
       self.CC = CarController(self.cp.dbc_name, CP, self.VM)
-  
+
   @staticmethod
   def calc_accel_override(a_ego, a_target, v_ego, v_target):
     return 1.

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -69,6 +69,9 @@ class CarInterfaceBase():
     ret.steerMaxV = [1.]
     ret.minSteerSpeed = 0.
 
+    ret.lateralTuning.pid.kdBP = [0.]
+    ret.lateralTuning.pid.kdV = [0.]
+
     ret.pcmCruise = True     # openpilot's state is tied to the PCM's cruise state on most cars
     ret.minEnableSpeed = -1. # enable is done by stock ACC, so ignore this
     ret.steerRatioRear = 0.  # no rear steering, at least on the listed cars aboveA

--- a/selfdrive/car/mazda/carcontroller.py
+++ b/selfdrive/car/mazda/carcontroller.py
@@ -9,6 +9,9 @@ class CarController():
     self.packer = CANPacker(dbc_name)
     self.steer_rate_limited = False
 
+  def get_last_output(self):
+    return self.apply_steer_last / CarControllerParams.STEER_MAX
+
   def update(self, enabled, CS, frame, actuators):
     """ Controls thread """
 

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -15,6 +15,9 @@ class CarController():
 
     self.packer = CANPacker(DBC[CP.carFingerprint]['pt'])
 
+  def get_last_output(self):
+    return self.apply_steer_last / CarControllerParams.STEER_MAX
+
   def update(self, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert, left_line, right_line, left_lane_depart, right_lane_depart):
 
     can_sends = []

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -38,6 +38,9 @@ class CarController():
 
     self.packer = CANPacker(dbc_name)
 
+  def get_last_output(self):
+    return self.last_steer / CarControllerParams.STEER_MAX
+
   def update(self, enabled, CS, frame, actuators, pcm_cancel_cmd, hud_alert,
              left_line, right_line, lead, left_lane_depart, right_lane_depart):
 

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -21,6 +21,9 @@ class CarController():
 
     self.steer_rate_limited = False
 
+  def get_last_output(self):
+    return self.apply_steer_last / P.STEER_MAX
+
   def update(self, enabled, CS, frame, ext_bus, actuators, visual_alert, left_lane_visible, right_lane_visible, left_lane_depart, right_lane_depart):
     """ Controls thread """
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -467,7 +467,7 @@ class Controls:
                                                                              lat_plan.psis,
                                                                              lat_plan.curvatures,
                                                                              lat_plan.curvatureRates)
-      actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(self.active, CS, self.CP, self.VM, params,
+      actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(self.active, CS, self.CP, self.CI, self.VM, params,
                                                                              desired_curvature, desired_curvature_rate)
     else:
       lac_log = log.ControlsState.LateralDebugState.new_message()

--- a/selfdrive/controls/lib/latcontrol_angle.py
+++ b/selfdrive/controls/lib/latcontrol_angle.py
@@ -9,7 +9,7 @@ class LatControlAngle():
   def reset(self):
     pass
 
-  def update(self, active, CS, CP, VM, params, desired_curvature, desired_curvature_rate):
+  def update(self, active, CS, CP, CI, VM, params, desired_curvature, desired_curvature_rate):
     angle_log = log.ControlsState.LateralAngleState.new_message()
 
     if CS.vEgo < 0.3 or not active:

--- a/selfdrive/controls/lib/latcontrol_indi.py
+++ b/selfdrive/controls/lib/latcontrol_indi.py
@@ -82,7 +82,7 @@ class LatControlINDI():
 
     return self.sat_count > self.sat_limit
 
-  def update(self, active, CS, CP, VM, params, curvature, curvature_rate):
+  def update(self, active, CS, CP, CI, VM, params, curvature, curvature_rate):
     self.speed = CS.vEgo
     # Update Kalman filter
     y = np.array([[math.radians(CS.steeringAngleDeg)], [math.radians(CS.steeringRateDeg)]])

--- a/selfdrive/controls/lib/latcontrol_lqr.py
+++ b/selfdrive/controls/lib/latcontrol_lqr.py
@@ -44,7 +44,7 @@ class LatControlLQR():
 
     return self.sat_count > self.sat_limit
 
-  def update(self, active, CS, CP, VM, params, desired_curvature, desired_curvature_rate):
+  def update(self, active, CS, CP, CI, VM, params, desired_curvature, desired_curvature_rate):
     lqr_log = log.ControlsState.LateralLQRState.new_message()
 
     steers_max = get_steer_max(CP, CS.vEgo)

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -1,16 +1,17 @@
 import math
 
-from selfdrive.controls.lib.pid import PIController
+from selfdrive.controls.lib.pid import PIDController
 from selfdrive.controls.lib.drive_helpers import get_steer_max
 from cereal import log
 
 
 class LatControlPID():
   def __init__(self, CP):
-    self.pid = PIController((CP.lateralTuning.pid.kpBP, CP.lateralTuning.pid.kpV),
-                            (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
-                            k_f=CP.lateralTuning.pid.kf, pos_limit=1.0, neg_limit=-1.0,
-                            sat_limit=CP.steerLimitTimer)
+    self.pid = PIDController((CP.lateralTuning.pid.kpBP, CP.lateralTuning.pid.kpV),
+                                (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
+                                (CP.lateralTuning.pid.kdBP, CP.lateralTuning.pid.kdV),
+                                k_f=CP.lateralTuning.pid.kf, pos_limit=1.0, neg_limit=-1.0,
+                                sat_limit=CP.steerLimitTimer)
 
   def reset(self):
     self.pid.reset()
@@ -42,8 +43,10 @@ class LatControlPID():
       output_steer = self.pid.update(angle_steers_des, CS.steeringAngleDeg, check_saturation=check_saturation, override=CS.steeringPressed,
                                      feedforward=steer_feedforward, speed=CS.vEgo, deadzone=deadzone)
       pid_log.active = True
+      pid_log.angleError = float(CS.steeringAngleDeg) - angle_steers_des
       pid_log.p = self.pid.p
       pid_log.i = self.pid.i
+      pid_log.d = self.pid.d
       pid_log.f = self.pid.f
       pid_log.output = output_steer
       pid_log.saturated = bool(self.pid.saturated)

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -110,7 +110,7 @@ class LongControl():
       prevent_overshoot = not CP.stoppingControl and CS.vEgo < 1.5 and v_target_future < 0.7
       deadzone = interp(v_ego_pid, CP.longitudinalTuning.deadzoneBP, CP.longitudinalTuning.deadzoneV)
 
-      output_gb = self.pid.update(self.v_pid, v_ego_pid, speed=v_ego_pid, deadzone=deadzone, feedforward=a_target, freeze_integrator=prevent_overshoot)
+      output_gb = self.pid.update(self.v_pid, v_ego_pid, self.last_output_gb, speed=v_ego_pid, deadzone=deadzone, feedforward=a_target, freeze_integrator=prevent_overshoot)
 
       if prevent_overshoot:
         output_gb = min(output_gb, 0.0)

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -1,7 +1,6 @@
 import numpy as np
 from common.numpy_fast import clip, interp
 from common.realtime import DT_CTRL
-from common.filter_simple import FirstOrderFilter
 
 def apply_deadzone(error, deadzone):
   if error > deadzone:
@@ -13,13 +12,11 @@ def apply_deadzone(error, deadzone):
   return error
 
 class PIDController():
-  def __init__(self, k_p, k_i, k_d, k_f=0., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.4, convert=None):
+  def __init__(self, k_p, k_i, k_d, k_f=0., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.8, convert=None):
     self._k_p = k_p  # proportional gain
     self._k_i = k_i  # integral gain
     self._k_d = k_d  # derivative gain
     self.k_f = k_f  # feedforward gain
-
-    self.error = FirstOrderFilter(0, 5, DT_CTRL, hz_mode=True)
 
     self.pos_limit = pos_limit
     self.neg_limit = neg_limit
@@ -62,8 +59,6 @@ class PIDController():
     self.e0, self.e1, self.e2 = 0.0, 0.0, 0.0
     self.bf1, self.bf2 = 0.0, 0.0
 
-    self.error.reset(0)
-
     self.p, self.p1, self.p2 = 0.0, 0.0, 0.0
     self.i, self.i1, self.i2 = 0.0, 0.0, 0.0
     self.d, self.d1, self.d2 = 0.0, 0.0, 0.0
@@ -79,7 +74,7 @@ class PIDController():
     self.speed = speed
 
     k_bf = 1.0
-    _N = 30
+    _N = 20
     _Ts = DT_CTRL
     
     Kp, Ki, Kd = self.k_p, self.k_i, self.k_d
@@ -96,8 +91,6 @@ class PIDController():
     self.u2, self.u1 = self.u1, self.u0
     
     self.e0 = float(apply_deadzone(setpoint - measurement, deadzone))
-    self.e0 = self.error.update(self.e0)
-
     self.u0 =  self.ke0*self.e0 + self.ke1*self.e1 + self.ke2*self.e2 - self.ku1*self.u1 - self.ku2*self.u2
 
     #back-feed / back-calculate integrator anti-windup

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -119,7 +119,7 @@ class PIDController():
     return clip(control, self.neg_limit, self.pos_limit)
 
 class PIController():
-  def __init__(self, k_p, k_i, k_f=0., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.8, convert=None):
+  def __init__(self, k_p, k_i, k_f=1., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.8, convert=None):
     self._k_p = k_p  # proportional gain
     self._k_i = k_i  # integral gain
     self.k_f = k_f  # feedforward gain
@@ -144,7 +144,7 @@ class PIController():
     return interp(self.speed, self._k_i[0], self._k_i[1])
 
   def _check_saturation(self, control, check_saturation, error):
-    saturated = (control <= self.neg_limit) or (control >= self.pos_limit)
+    saturated = (control < self.neg_limit) or (control > self.pos_limit)
 
     if saturated and check_saturation and abs(error) > 0.1:
       self.sat_count += self.sat_count_rate

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -1,5 +1,7 @@
 import numpy as np
 from common.numpy_fast import clip, interp
+from common.realtime import DT_CTRL
+from math import exp
 
 def apply_deadzone(error, deadzone):
   if error > deadzone:
@@ -9,6 +11,133 @@ def apply_deadzone(error, deadzone):
   else:
     error = 0.
   return error
+
+class LPF():
+  def __init__(self, omega): # 100 rad/s @ 100 hz ( e^-wT )
+    self.alpha = exp(-omega * DT_CTRL)
+    self.y = 0.0
+
+  def filter(self, x):
+    self.y = self.y * self.alpha + (1 - self.alpha) * x
+    return self.y
+
+class PIDController():
+  def __init__(self, k_p, k_i, k_d, k_f=1., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.8, convert=None):
+    self._k_p = k_p  # proportional gain
+    self._k_i = k_i  # integral gain
+    self._k_d = k_d  # derivative gain
+    self.k_f = k_f  # feedforward gain
+
+    self.pos_limit = pos_limit
+    self.neg_limit = neg_limit
+
+    self.sat_count_rate = 1.0 / rate
+    self.sat_limit = sat_limit
+
+    self.convert = convert
+
+    self.input = LPF(20)
+
+    self.reset()
+
+  @property
+  def k_p(self):
+    return interp(self.speed, self._k_p[0], self._k_p[1])
+
+  @property
+  def k_i(self):
+    return interp(self.speed, self._k_i[0], self._k_i[1])
+
+  @property
+  def k_d(self):
+    return interp(self.speed, self._k_d[0], self._k_d[1])
+
+  def _check_saturation(self, control, check_saturation, error):
+    saturated = (control < self.neg_limit) or (control > self.pos_limit)
+
+    if saturated and check_saturation and abs(error) > 0.1:
+      self.sat_count += self.sat_count_rate
+    else:
+      self.sat_count -= self.sat_count_rate
+
+    self.sat_count = clip(self.sat_count, 0.0, 1.0)
+
+    return self.sat_count > self.sat_limit
+
+  def reset(self):
+    self.u0, self.u1, self.u2 = 0.0, 0.0, 0.0
+    self.e0, self.e1, self.e2 = 0.0, 0.0, 0.0
+
+    self.p, self.p1, self.p2 = 0.0, 0.0, 0.0
+    self.i, self.i1, self.i2 = 0.0, 0.0, 0.0
+    self.d, self.d1, self.d2 = 0.0, 0.0, 0.0
+    self.f = 0.0
+
+    self.sat_count = 0.0
+    self.saturated = False
+    self.control = 0
+
+  def update(self, setpoint, measurement, speed=0.0, check_saturation=True, override=False, feedforward=0., deadzone=0., freeze_integrator=False, output_steer_last=0.):
+    self.speed = speed    
+
+    #TODO: param
+    _N = int(1. / DT_CTRL)
+    _Ts = DT_CTRL
+    
+    Kp = self.k_p
+    Ki = self.k_i
+    Kd = self.k_d
+
+    a0 = (1 + _N*_Ts)
+    a1 = -(2 + _N*_Ts)
+    a2 = 1
+    
+    b0 = Kp*a0 + Ki*_Ts*a0 + Kd*_N
+    b1 = Kp*a1 - Ki*_Ts  - 2*Kd*_N
+    b2 = Kp    +             Kd*_N
+    
+    #ku[0] = 1
+    self.ku1 = a1 / a0
+    self.ku2 = a2 / a0
+    
+    self.ke0 = b0 / a0
+    self.ke1 = b1 / a0
+    self.ke2 = b2 / a0
+
+    self.e2 = self.e1
+    self.e1 = self.e0
+    self.u2 = self.u1
+    self.u1 = self.u0
+    
+    self.e0 = float(apply_deadzone(setpoint - measurement, deadzone))
+    self.e0 = self.input.filter(self.e0)
+
+    self.u0 =  self.ke0*self.e0 + self.ke1*self.e1 + self.ke2*self.e2 - self.ku1*self.u1 - self.ku2*self.u2
+
+    #logging only
+    self.p2 = self.p1
+    self.p1 = self.p
+    self.i2 =  self.i1
+    self.i1 = self.i
+    self.d2 =  self.d1
+    self.d1 = self.d
+
+    self.p = (Kp*(    a0*self.e0 + a1*self.e1 + self.e2) / a0) -self.ku1*self.p1 - self.ku2*self.p2
+    self.i = (Ki*_Ts*(a0*self.e0 -    self.e1)           / a0) -self.ku1*self.i1 - self.ku2*self.i2
+    self.d = (Kd*_N*(    self.e0 -  2*self.e1 + self.e2) / a0) -self.ku1*self.d1 - self.ku2*self.d2
+    #ylno gniggol
+
+    self.f = self.k_f*feedforward
+    self.f = clip(self.f, self.neg_limit, self.pos_limit)
+
+    control = self.u0 + self.f
+    self.saturated = self._check_saturation(control, check_saturation, self.e0)
+    self.control = clip(control, self.neg_limit, self.pos_limit)
+
+    if self.convert is not None:
+      control = self.convert(control, speed=self.speed)
+
+    return self.control
 
 class PIController():
   def __init__(self, k_p, k_i, k_f=1., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.8, convert=None):
@@ -36,7 +165,7 @@ class PIController():
     return interp(self.speed, self._k_i[0], self._k_i[1])
 
   def _check_saturation(self, control, check_saturation, error):
-    saturated = (control < self.neg_limit) or (control > self.pos_limit)
+    saturated = (control <= self.neg_limit) or (control >= self.pos_limit)
 
     if saturated and check_saturation and abs(error) > 0.1:
       self.sat_count += self.sat_count_rate


### PR DESCRIPTION
I have been running this controller for a few weeks. 

Using a derivative term and back-calculating the integrator based on the actual commanded output from saturating the torque ramp up allows for much better tunes without hitting instabilities from actuator / safety saturation. 

There is also a input filter to reduce the noise in the P-term. most of the noise seems to be in the Desired angle so it should not be vehicle dependent.

Includes/depends/related:
https://github.com/commaai/openpilot/pull/21336
https://github.com/commaai/openpilot/pull/21005

Cereal updates for kdBP, kdV, pid.d

PI portion of the controller has the same behavior with current tunes. Only difference would be the 5hz LPF on the error currently.
