### PR TITLE
sensors_qcom2:  fix segmentation fault, use orphans to build sensor events

### DIFF
--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -43,7 +43,7 @@ fail:
   return ret;
 }
 
-void BMX055_Accel::get_event(cereal::SensorEventData::Builder &event) {
+bool BMX055_Accel::get_event(cereal::SensorEventData::Builder &event) {
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
   int len = read_register(BMX055_ACCEL_I2C_REG_X_LSB, buffer, sizeof(buffer));
@@ -65,5 +65,5 @@ void BMX055_Accel::get_event(cereal::SensorEventData::Builder &event) {
   auto svec = event.initAcceleration();
   svec.setV(xyz);
   svec.setStatus(true);
-
+  return true;
 }

--- a/selfdrive/sensord/sensors/bmx055_accel.h
+++ b/selfdrive/sensord/sensors/bmx055_accel.h
@@ -33,5 +33,5 @@ class BMX055_Accel : public I2CSensor {
 public:
   BMX055_Accel(I2CBus *bus);
   int init();
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -54,7 +54,7 @@ fail:
   return ret;
 }
 
-void BMX055_Gyro::get_event(cereal::SensorEventData::Builder &event) {
+bool BMX055_Gyro::get_event(cereal::SensorEventData::Builder &event) {
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
   int len = read_register(BMX055_GYRO_I2C_REG_RATE_X_LSB, buffer, sizeof(buffer));
@@ -76,5 +76,5 @@ void BMX055_Gyro::get_event(cereal::SensorEventData::Builder &event) {
   auto svec = event.initGyroUncalibrated();
   svec.setV(xyz);
   svec.setStatus(true);
-
+  return true;
 }

--- a/selfdrive/sensord/sensors/bmx055_gyro.h
+++ b/selfdrive/sensord/sensors/bmx055_gyro.h
@@ -33,5 +33,5 @@ class BMX055_Gyro : public I2CSensor {
 public:
   BMX055_Gyro(I2CBus *bus);
   int init();
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/bmx055_magn.cc
+++ b/selfdrive/sensord/sensors/bmx055_magn.cc
@@ -213,14 +213,14 @@ bool BMX055_Magn::parse_xyz(uint8_t buffer[8], int16_t *x, int16_t *y, int16_t *
 }
 
 
-void BMX055_Magn::get_event(cereal::SensorEventData::Builder &event) {
+bool BMX055_Magn::get_event(cereal::SensorEventData::Builder &event) {
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[8];
   int16_t _x, _y, x, y, z;
 
   int len = read_register(BMX055_MAGN_I2C_REG_DATAX_LSB, buffer, sizeof(buffer));
   assert(len == sizeof(buffer));
-
+  bool ret = false;
   if (parse_xyz(buffer, &_x, &_y, &z)) {
     event.setSource(cereal::SensorEventData::SensorSource::BMX055);
     event.setVersion(2);
@@ -240,6 +240,7 @@ void BMX055_Magn::get_event(cereal::SensorEventData::Builder &event) {
     auto svec = event.initMagneticUncalibrated();
     svec.setV(xyz);
     svec.setStatus(true);
+    ret = true;
   }
 
   // The BMX055 Magnetometer has no FIFO mode. Self running mode only goes
@@ -247,4 +248,5 @@ void BMX055_Magn::get_event(cereal::SensorEventData::Builder &event) {
   // at a 100 Hz. When reading the registers we have to check the ready bit
   // To verify the measurement was comleted this cycle.
   set_register(BMX055_MAGN_I2C_REG_MAG, BMX055_MAGN_FORCED);
+  return ret;
 }

--- a/selfdrive/sensord/sensors/bmx055_magn.h
+++ b/selfdrive/sensord/sensors/bmx055_magn.h
@@ -59,5 +59,5 @@ class BMX055_Magn : public I2CSensor{
 public:
   BMX055_Magn(I2CBus *bus);
   int init();
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/bmx055_temp.cc
+++ b/selfdrive/sensord/sensors/bmx055_temp.cc
@@ -28,7 +28,7 @@ fail:
   return ret;
 }
 
-void BMX055_Temp::get_event(cereal::SensorEventData::Builder &event) {
+bool BMX055_Temp::get_event(cereal::SensorEventData::Builder &event) {
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[1];
   int len = read_register(BMX055_ACCEL_I2C_REG_TEMP, buffer, sizeof(buffer));
@@ -41,4 +41,5 @@ void BMX055_Temp::get_event(cereal::SensorEventData::Builder &event) {
   event.setType(SENSOR_TYPE_AMBIENT_TEMPERATURE);
   event.setTimestamp(start_time);
   event.setTemperature(temp);
+  return true;
 }

--- a/selfdrive/sensord/sensors/bmx055_temp.h
+++ b/selfdrive/sensord/sensors/bmx055_temp.h
@@ -8,5 +8,5 @@ class BMX055_Temp : public I2CSensor {
 public:
   BMX055_Temp(I2CBus *bus);
   int init();
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/file_sensor.h
+++ b/selfdrive/sensord/sensors/file_sensor.h
@@ -14,5 +14,5 @@ public:
   FileSensor(std::string filename);
   ~FileSensor();
   int init();
-  virtual void get_event(cereal::SensorEventData::Builder &event) = 0;
+  virtual bool get_event(cereal::SensorEventData::Builder &event) = 0;
 };

--- a/selfdrive/sensord/sensors/i2c_sensor.h
+++ b/selfdrive/sensord/sensors/i2c_sensor.h
@@ -21,5 +21,5 @@ public:
   int read_register(uint register_address, uint8_t *buffer, uint8_t len);
   int set_register(uint register_address, uint8_t data);
   virtual int init() = 0;
-  virtual void get_event(cereal::SensorEventData::Builder &event) = 0;
+  virtual bool get_event(cereal::SensorEventData::Builder &event) = 0;
 };

--- a/selfdrive/sensord/sensors/light_sensor.cc
+++ b/selfdrive/sensord/sensors/light_sensor.cc
@@ -5,7 +5,7 @@
 #include "selfdrive/common/timing.h"
 #include "selfdrive/sensord/sensors/constants.h"
 
-void LightSensor::get_event(cereal::SensorEventData::Builder &event) {
+bool LightSensor::get_event(cereal::SensorEventData::Builder &event) {
   uint64_t start_time = nanos_since_boot();
   file.clear();
   file.seekg(0);
@@ -19,4 +19,5 @@ void LightSensor::get_event(cereal::SensorEventData::Builder &event) {
   event.setType(SENSOR_TYPE_LIGHT);
   event.setTimestamp(start_time);
   event.setLight(value);
+  return true;
 }

--- a/selfdrive/sensord/sensors/light_sensor.h
+++ b/selfdrive/sensord/sensors/light_sensor.h
@@ -4,5 +4,5 @@
 class LightSensor : public FileSensor {
 public:
   LightSensor(std::string filename) : FileSensor(filename){};
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.cc
@@ -34,7 +34,7 @@ fail:
   return ret;
 }
 
-void LSM6DS3_Accel::get_event(cereal::SensorEventData::Builder &event) {
+bool LSM6DS3_Accel::get_event(cereal::SensorEventData::Builder &event) {
 
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
@@ -56,5 +56,5 @@ void LSM6DS3_Accel::get_event(cereal::SensorEventData::Builder &event) {
   auto svec = event.initAcceleration();
   svec.setV(xyz);
   svec.setStatus(true);
-
+  return true;
 }

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.h
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.h
@@ -20,5 +20,5 @@ class LSM6DS3_Accel : public I2CSensor {
 public:
   LSM6DS3_Accel(I2CBus *bus);
   int init();
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -38,7 +38,7 @@ fail:
   return ret;
 }
 
-void LSM6DS3_Gyro::get_event(cereal::SensorEventData::Builder &event) {
+bool LSM6DS3_Gyro::get_event(cereal::SensorEventData::Builder &event) {
 
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
@@ -60,5 +60,5 @@ void LSM6DS3_Gyro::get_event(cereal::SensorEventData::Builder &event) {
   auto svec = event.initGyroUncalibrated();
   svec.setV(xyz);
   svec.setStatus(true);
-
+  return true;
 }

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.h
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.h
@@ -20,5 +20,5 @@ class LSM6DS3_Gyro : public I2CSensor {
 public:
   LSM6DS3_Gyro(I2CBus *bus);
   int init();
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_temp.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_temp.cc
@@ -27,7 +27,7 @@ fail:
   return ret;
 }
 
-void LSM6DS3_Temp::get_event(cereal::SensorEventData::Builder &event) {
+bool LSM6DS3_Temp::get_event(cereal::SensorEventData::Builder &event) {
 
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[2];
@@ -41,5 +41,5 @@ void LSM6DS3_Temp::get_event(cereal::SensorEventData::Builder &event) {
   event.setType(SENSOR_TYPE_AMBIENT_TEMPERATURE);
   event.setTimestamp(start_time);
   event.setTemperature(temp);
-
+  return true;
 }

--- a/selfdrive/sensord/sensors/lsm6ds3_temp.h
+++ b/selfdrive/sensord/sensors/lsm6ds3_temp.h
@@ -18,5 +18,5 @@ class LSM6DS3_Temp : public I2CSensor {
 public:
   LSM6DS3_Temp(I2CBus *bus);
   int init();
-  void get_event(cereal::SensorEventData::Builder &event);
+  bool get_event(cereal::SensorEventData::Builder &event);
 };

--- a/selfdrive/sensord/sensors/sensor.h
+++ b/selfdrive/sensord/sensors/sensor.h
@@ -6,5 +6,5 @@ class Sensor {
 public:
   virtual ~Sensor() {};
   virtual int init() = 0;
-  virtual void get_event(cereal::SensorEventData::Builder &event) = 0;
+  virtual bool get_event(cereal::SensorEventData::Builder &event) = 0;
 };

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -25,7 +25,7 @@
 ExitHandler do_exit;
 
 int sensor_loop() {
-  I2CBus *i2c_bus_imu;
+  I2CBus *i2c_bus_imu = nullptr;
 
   try {
     i2c_bus_imu = new I2CBus(I2C_BUS_IMU);
@@ -46,19 +46,23 @@ int sensor_loop() {
   LightSensor light("/sys/class/i2c-adapter/i2c-2/2-0038/iio:device1/in_intensity_both_raw");
 
   // Sensor init
-  Sensor *sensors[] = {&bmx055_accel,
-                       &bmx055_gyro,
-                       &bmx055_magn,
-                       &bmx055_temp,
-                       &lsm6ds3_accel,
-                       &lsm6ds3_gyro,
-                       &lsm6ds3_temp,
-                       &light};
+    std::vector<Sensor *> sensors;
+  sensors.push_back(&bmx055_accel);
+  sensors.push_back(&bmx055_gyro);
+  sensors.push_back(&bmx055_magn);
+  sensors.push_back(&bmx055_temp);
+
+  sensors.push_back(&lsm6ds3_accel);
+  sensors.push_back(&lsm6ds3_gyro);
+  sensors.push_back(&lsm6ds3_temp);
+
+  sensors.push_back(&light);
 
   for (Sensor * sensor : sensors) {
     int err = sensor->init();
     if (err < 0) {
       LOGE("Error initializing sensors");
+      delete i2c_bus_imu;
       return -1;
     }
   }
@@ -89,6 +93,8 @@ int sensor_loop() {
     std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
     std::this_thread::sleep_for(std::chrono::milliseconds(10) - (end - begin));
   }
+
+  delete i2c_bus_imu;
   return 0;
 }
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -180,18 +180,12 @@ static void update_state(UIState *s) {
   if (sm.updated("carParams")) {
     scene.longitudinal_control = sm["carParams"].getCarParams().getOpenpilotLongitudinalControl();
   }
-  if (sm.updated("sensorEvents")) {
+  if (!scene.started && sm.updated("sensorEvents")) {
     for (auto sensor : sm["sensorEvents"].getSensorEvents()) {
-      if (!scene.started && sensor.which() == cereal::SensorEventData::ACCELERATION) {
-        auto accel = sensor.getAcceleration().getV();
-        if (accel.totalSize().wordCount) { // TODO: sometimes empty lists are received. Figure out why
-          scene.accel_sensor = accel[2];
-        }
-      } else if (!scene.started && sensor.which() == cereal::SensorEventData::GYRO_UNCALIBRATED) {
-        auto gyro = sensor.getGyroUncalibrated().getV();
-        if (gyro.totalSize().wordCount) {
-          scene.gyro_sensor = gyro[1];
-        }
+      if (sensor.which() == cereal::SensorEventData::ACCELERATION) {
+        scene.accel_sensor = sensor.getAcceleration().getV()[2];
+      } else if (sensor.which() == cereal::SensorEventData::GYRO_UNCALIBRATED) {
+        scene.gyro_sensor = sensor.getGyroUncalibrated().getV()[1];
       }
     }
   }


### PR DESCRIPTION
If get_event fails, it will return an empty `SensorEventData` with default type `SensorEventData::ACCELERATION(0)`, that will cause segmentation fault when get value from `getAcceleration().getV()`