### PR TITLE
Use access point signals

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -128,7 +128,7 @@ void Networking::connectToNetwork(const Network &n) {
 }
 
 void Networking::wrongPassword(const QString &ssid) {
-  for (Network n : wifi->seen_networks) {
+  for (Network n : wifi->seenNetworks) {
     if (n.ssid == ssid) {
       QString pass = InputDialog::getText("Wrong password for \"" + n.ssid +"\"", 8);
       if (!pass.isEmpty()) {
@@ -172,7 +172,7 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   main_layout->addWidget(horizontal_line(), 0);
 
   // IP address
-  ipLabel = new LabelControl("IP Address", wifi->ipv4_address);
+  ipLabel = new LabelControl("IP Address", wifi->ip4Address);
   main_layout->addWidget(ipLabel, 0);
   main_layout->addWidget(horizontal_line(), 0);
 
@@ -185,7 +185,7 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
 }
 
 void AdvancedNetworking::refresh() {
-  ipLabel->setText(wifi->ipv4_address);
+  ipLabel->setText(wifi->ip4Address);
   update();
 }
 
@@ -214,7 +214,7 @@ void WifiUI::refresh() {
   clearLayout(main_layout);
 
   int i = 0;
-  for (Network &network : wifi->seen_networks) {
+  for (Network &network : wifi->seenNetworks) {
     QHBoxLayout *hlayout = new QHBoxLayout;
 
     QLabel *ssid_label = new QLabel(QString::fromUtf8(network.ssid));
@@ -260,7 +260,7 @@ void WifiUI::refresh() {
     hlayout->addWidget(btn, 0, Qt::AlignRight);
     main_layout->addLayout(hlayout, 1);
     // Don't add the last horizontal line
-    if (i+1 < wifi->seen_networks.size()) {
+    if (i+1 < wifi->seenNetworks.size()) {
       main_layout->addWidget(horizontal_line(), 0);
     }
     i++;

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -39,8 +39,8 @@ const QString ipv4config_iface       = "org.freedesktop.NetworkManager.IP4Config
 
 const QString nm_service             = "org.freedesktop.NetworkManager";
 
-const int state_connected = 100;
 const int state_need_auth = 60;
+const int state_connected = 100;
 const int reason_wrong_password = 8;
 const int dbus_timeout = 100;
 
@@ -154,17 +154,14 @@ QList<Network> WifiManager::get_networks() {
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
 
-  QDBusMessage response = nm.call("GetAllAccessPoints");
-  QVariant first =  response.arguments().at(0);
+  const QString active_ap = get_active_ap();
+  const QDBusReply<QList<QDBusObjectPath>> response = nm.call("GetAllAccessPoints");
 
-  QString active_ap = get_active_ap();
-  const QDBusArgument &args = first.value<QDBusArgument>();
-  args.beginArray();
-  while (!args.atEnd()) {
-    QDBusObjectPath path;
-    args >> path;
-
+  for (const QDBusObjectPath &path : response.value()) {
     QByteArray ssid = get_property(path.path(), "Ssid");
+    if (ssid.isEmpty()) {
+      continue;
+    }
     unsigned int strength = get_ap_strength(path.path());
     SecurityType security = getSecurityType(path.path());
     ConnectedType ctype;
@@ -178,12 +175,8 @@ QList<Network> WifiManager::get_networks() {
       }
     }
     Network network = {path.path(), ssid, strength, ctype, security};
-
-    if (ssid.length()) {
-      r.push_back(network);
-    }
+    r.push_back(network);
   }
-  args.endArray();
 
   std::sort(r.begin(), r.end(), compare_by_strength);
   return r;
@@ -340,17 +333,10 @@ QString WifiManager::get_adapter() {
   QDBusInterface nm(nm_service, nm_path, nm_iface, bus);
   nm.setTimeout(dbus_timeout);
 
-  QDBusMessage response = nm.call("GetDevices");
-  QVariant first =  response.arguments().at(0);
-
+  const QDBusReply<QList<QDBusObjectPath>> response = nm.call("GetDevices");
   QString adapter_path = "";
 
-  const QDBusArgument &args = first.value<QDBusArgument>();
-  args.beginArray();
-  while (!args.atEnd()) {
-    QDBusObjectPath path;
-    args >> path;
-
+  for (const QDBusObjectPath &path : response.value()) {
     // Get device type
     QDBusInterface device_props(nm_service, path.path(), props_iface, bus);
     device_props.setTimeout(dbus_timeout);
@@ -363,15 +349,13 @@ QString WifiManager::get_adapter() {
       break;
     }
   }
-  args.endArray();
-
   return adapter_path;
 }
 
 void WifiManager::stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason) {
   raw_adapter_state = new_state;
   if (new_state == state_need_auth && change_reason == reason_wrong_password) {
-    knownConnections.remove(getConnectionPath(connecting_to_network));
+    forgetConnection(connecting_to_network);
     emit wrongPassword(connecting_to_network);
   } else if (new_state == state_connected) {
     connecting_to_network = "";
@@ -401,7 +385,7 @@ void WifiManager::newConnection(const QDBusObjectPath &path) {
 }
 
 void WifiManager::disconnect() {
-  QString active_ap = get_active_ap();
+  const QString &active_ap = get_active_ap();
   if (active_ap != "" && active_ap != "/") {
     deactivateConnection(get_property(active_ap, "Ssid"));
   }
@@ -439,7 +423,7 @@ void WifiManager::activateWifiConnection(const QString &ssid) {
   const QDBusObjectPath &path = getConnectionPath(ssid);
   if (!path.path().isEmpty()) {
     connecting_to_network = ssid;
-    QString devicePath = get_adapter();
+    const QString &devicePath = get_adapter();  // why does this need to be updated each time?
     QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
     nm3.setTimeout(dbus_timeout);
     nm3.call("ActivateConnection", QVariant::fromValue(path), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -23,6 +23,7 @@ struct Network {
   unsigned int strength;
   ConnectedType connected;
   SecurityType security_type;
+  bool known;
 };
 
 class WifiManager : public QWidget {
@@ -31,9 +32,8 @@ public:
   explicit WifiManager(QWidget* parent);
 
   void requestScan();
-  QVector<Network> seen_networks;
-  QMap<QDBusObjectPath, QString> knownConnections;
-  QString ipv4_address;
+  QVector<Network> seenNetworks;
+  QString ip4Address;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
@@ -54,6 +54,8 @@ public:
   void changeTetheringPassword(const QString &newPassword);
 
 private:
+  QMap<QDBusObjectPath, QString> knownConnections;
+
   QVector<QByteArray> seen_ssids;
   QString adapter;  // Path to network manager wifi-device
   QDBusConnection bus = QDBusConnection::systemBus();
@@ -63,14 +65,13 @@ private:
   QString tetheringPassword = "swagswagcommma";
 
   QString get_adapter();
-  QString get_ipv4_address();
-  QList<Network> get_networks();
+  QString getIp4Address(const QDBusObjectPath &path);
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString get_active_ap();
   void deactivateConnection(const QString &ssid);
   QVector<QDBusObjectPath> get_active_connections();
   uint get_wifi_device_state();
-  QByteArray get_property(const QString &network_path, const QString &property);
+  QByteArray getApProperty(const QString &network_path, const QString &property);
   unsigned int get_ap_strength(const QString &network_path);
   SecurityType getSecurityType(const QString &path);
   QDBusObjectPath getConnectionPath(const QString &ssid);
@@ -86,4 +87,6 @@ private slots:
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
   void connectionRemoved(const QDBusObjectPath &path);
   void newConnection(const QDBusObjectPath &path);
+  void accessPointAdded(const QDBusObjectPath &path);
+  void accessPointRemoved(const QDBusObjectPath &path);
 };


### PR DESCRIPTION
- [ ] Never execute UI blocking code in the background (only update list from signals)
- [ ] Use access point signals to add and remove `seen_networks`
- [ ] Only update UI when entered, since WifiManager will have an up to date list with no need to use any DBus commands to draw all UI elements (known, strength, etc)
- [x] Fix empty ssid logging