### PR TITLE
Wait for adapter to setup WifiManager

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -26,26 +26,7 @@ void NetworkStrengthWidget::paintEvent(QPaintEvent* event) {
 Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), show_advanced(show_advanced) {
   main_layout = new QStackedLayout(this);
 
-  QLabel* warning = new QLabel("Network manager is inactive!");
-  warning->setAlignment(Qt::AlignCenter);
-  warning->setStyleSheet(R"(font-size: 65px;)");
-
-  main_layout->addWidget(warning);
-
-  QTimer* timer = new QTimer(this);
-  QObject::connect(timer, &QTimer::timeout, this, &Networking::requestScan);
-  timer->start(5000);
-  attemptInitialization();
-}
-
-void Networking::attemptInitialization() {
-  // Checks if network manager is active
-  try {
-    wifi = new WifiManager(this);
-  } catch (std::exception &e) {
-    return;
-  }
-
+  wifi = new WifiManager(this);
   connect(wifi, &WifiManager::wrongPassword, this, &Networking::wrongPassword);
   connect(wifi, &WifiManager::refreshSignal, this, &Networking::refresh);
 
@@ -66,7 +47,6 @@ void Networking::attemptInitialization() {
   wifiWidget->setObjectName("wifiWidget");
   connect(wifiWidget, &WifiUI::connectToNetwork, this, &Networking::connectToNetwork);
   vlayout->addWidget(new ScrollView(wifiWidget, this), 1);
-
   main_layout->addWidget(wifiScreen);
 
   an = new AdvancedNetworking(this, wifi);
@@ -89,29 +69,12 @@ void Networking::attemptInitialization() {
     }
   )");
   main_layout->setCurrentWidget(wifiScreen);
-  ui_setup_complete = true;
-  wifi->requestScan();
-}
-
-void Networking::requestScan() {
-  if (!this->isVisible()) {
-    return;
-  }
-  if (!ui_setup_complete) {
-    attemptInitialization();
-    if (!ui_setup_complete) {
-      return;
-    }
-  }
-  wifi->requestScan();
 }
 
 void Networking::refresh() {
-  if (this->isVisible() || firstRefresh) {
-    wifiWidget->refresh();
-    an->refresh();
-    firstRefresh = false;
-  }
+  qDebug() << "REFRESHED UI!";
+  wifiWidget->refresh();
+  an->refresh();
 }
 
 void Networking::connectToNetwork(const Network &n) {

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -72,7 +72,6 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QWidget(parent), s
 }
 
 void Networking::refresh() {
-  qDebug() << "REFRESHED UI!";
   wifiWidget->refresh();
   an->refresh();
 }

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -71,8 +71,6 @@ private:
 
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;
-  void attemptInitialization();
-  void requestScan();
 
 public slots:
   void refresh();

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -67,9 +67,7 @@ private:
   QStackedLayout* main_layout = nullptr; // nm_warning, wifiScreen, advanced
   QWidget* wifiScreen = nullptr;
   AdvancedNetworking* an = nullptr;
-  bool ui_setup_complete = false;
   bool show_advanced;
-  bool firstRefresh = true;
 
   WifiUI* wifiWidget;
   WifiManager* wifi = nullptr;

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -500,9 +500,11 @@ void WifiManager::disableTethering() {
 }
 
 bool WifiManager::tetheringEnabled() {
-  QString active_ap = get_active_ap();
-  if (active_ap != "" && active_ap != "/") {
-    return get_property(active_ap, "Ssid") == tethering_ssid;
+  if (adapter != "" && adapter != "/") {
+    QString active_ap = get_active_ap();
+    if (active_ap != "" && active_ap != "/") {
+      return get_property(active_ap, "Ssid") == tethering_ssid;
+    }
   }
   return false;
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -75,7 +75,7 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   tethering_ssid = "weedle";
   std::string bytes = Params().get("DongleId");
   if (bytes.length() >= 4) {
-    tethering_ssid+="-"+QString::fromStdString(bytes.substr(0,4));
+    tethering_ssid += "-" + QString::fromStdString(bytes.substr(0,4));
   }
 
   adapter = getAdapter();

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -388,7 +388,7 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
       knownConnections = listConnections();
     }
     if (this->isVisible()) {
-      refreshNetworks();  // TODO: only refresh on first scan, then use AccessPointAdded and Removed signals
+      refreshNetworks();
       emit refreshSignal();
     }
   }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -111,6 +111,7 @@ void WifiManager::setup() {
   device_props.setTimeout(dbus_timeout);
   QDBusMessage response = device_props.call("Get", device_iface, "State");
   raw_adapter_state = get_response<uint>(response);
+  requestScan();
 }
 
 void WifiManager::refreshNetworks() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -266,7 +266,7 @@ void WifiManager::deactivateConnection(const QString &ssid) {
     nm.setTimeout(dbus_timeout);
 
     QDBusObjectPath pth = get_response<QDBusObjectPath>(nm.call("Get", connection_iface, "SpecificObject"));
-    if (validPath(pth.path())) {
+    if (pth.path() != "" && pth.path() != "/") {
       QString Ssid = get_property(pth.path(), "Ssid");
       if (Ssid == ssid) {
         QDBusInterface nm2(nm_service, nm_path, nm_iface, bus);
@@ -312,10 +312,6 @@ bool WifiManager::isWirelessAdapter(const QDBusObjectPath &path) {
   device_props.setTimeout(dbus_timeout);
   const uint deviceType = get_response<uint>(device_props.call("Get", device_iface, "DeviceType"));
   return deviceType == device_type_wifi;
-}
-
-bool WifiManager::validPath(const QString &path) {
-  return !path.isEmpty() && path != "/";
 }
 
 void WifiManager::requestScan() {
@@ -399,7 +395,7 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
 }
 
 void WifiManager::deviceAdded(const QDBusObjectPath &path) {
-  if (isWirelessAdapter(path) && !validPath(adapter)) {
+  if (isWirelessAdapter(path) && (adapter.isEmpty() || adapter == "/")) {
     adapter = path.path();
     setup();
   }
@@ -416,7 +412,7 @@ void WifiManager::newConnection(const QDBusObjectPath &path) {
 
 void WifiManager::disconnect() {
   QString active_ap = get_active_ap();
-  if (validPath(active_ap)) {
+  if (active_ap != "" && active_ap != "/") {
     deactivateConnection(get_property(active_ap, "Ssid"));
   }
 }
@@ -504,11 +500,9 @@ void WifiManager::disableTethering() {
 }
 
 bool WifiManager::tetheringEnabled() {
-  if (validPath(adapter)) {
-    QString active_ap = get_active_ap();
-    if (validPath(active_ap)) {
-      return get_property(active_ap, "Ssid") == tethering_ssid;
-    }
+  QString active_ap = get_active_ap();
+  if (active_ap != "" && active_ap != "/") {
+    return get_property(active_ap, "Ssid") == tethering_ssid;
   }
   return false;
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -92,11 +92,6 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
     }
   });
   timer->start(5000);
-
-  // Create dbus interface for tethering button. This populates the introspection cache,
-  // making sure all future creations are non-blocking
-  // https://bugreports.qt.io/browse/QTBUG-14485
-  QDBusInterface(nm_service, nm_settings_path, nm_settings_iface, bus);
 }
 
 void WifiManager::setup() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -41,6 +41,7 @@ const QString nm_service             = "org.freedesktop.NetworkManager";
 
 const int state_connected = 100;
 const int state_need_auth = 60;
+const int device_type_wifi = 2;
 const int reason_wrong_password = 8;
 const int dbus_timeout = 100;
 
@@ -69,13 +70,36 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   qDBusRegisterMetaType<Connection>();
   qDBusRegisterMetaType<IpConfig>();
   connecting_to_network = "";
-  adapter = get_adapter();
 
-  bool has_adapter = adapter != "";
-  if (!has_adapter) {
-    throw std::runtime_error("Error connecting to NetworkManager");
+  // Set tethering ssid as "weedle" + first 4 characters of a dongle id
+  tethering_ssid = "weedle";
+  std::string bytes = Params().get("DongleId");
+  if (bytes.length() >= 4) {
+    tethering_ssid+="-"+QString::fromStdString(bytes.substr(0,4));
   }
 
+  adapter = getAdapter();
+  if (!adapter.isEmpty()) {
+    setup();
+  } else {
+    bus.connect(nm_service, nm_path, nm_iface, "DeviceAdded", this, SLOT(deviceAdded(QDBusObjectPath)));
+  }
+
+  QTimer* timer = new QTimer(this);
+  QObject::connect(timer, &QTimer::timeout, this, [=]() {
+    if (!adapter.isEmpty() && this->isVisible()) {
+      requestScan();
+    }
+  });
+  timer->start(5000);
+
+  // Create dbus interface for tethering button. This populates the introspection cache,
+  // making sure all future creations are non-blocking
+  // https://bugreports.qt.io/browse/QTBUG-14485
+  QDBusInterface(nm_service, nm_settings_path, nm_settings_iface, bus);
+}
+
+void WifiManager::setup() {
   QDBusInterface nm(nm_service, adapter, device_iface, bus);
   bus.connect(nm_service, adapter, device_iface, "StateChanged", this, SLOT(stateChange(unsigned int, unsigned int, unsigned int)));
   bus.connect(nm_service, adapter, props_iface, "PropertiesChanged", this, SLOT(propertyChange(QString, QVariantMap, QStringList)));
@@ -87,18 +111,6 @@ WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   device_props.setTimeout(dbus_timeout);
   QDBusMessage response = device_props.call("Get", device_iface, "State");
   raw_adapter_state = get_response<uint>(response);
-
-  // Set tethering ssid as "weedle" + first 4 characters of a dongle id
-  tethering_ssid = "weedle";
-  std::string bytes = Params().get("DongleId");
-  if (bytes.length() >= 4) {
-    tethering_ssid+="-"+QString::fromStdString(bytes.substr(0,4));
-  }
-
-  // Create dbus interface for tethering button. This populates the introspection cache,
-  // making sure all future creations are non-blocking
-  // https://bugreports.qt.io/browse/QTBUG-14485
-  QDBusInterface(nm_service, nm_settings_path, nm_settings_iface, bus);
 }
 
 void WifiManager::refreshNetworks() {
@@ -295,6 +307,13 @@ void WifiManager::forgetConnection(const QString &ssid) {
   }
 }
 
+bool WifiManager::isWirelessAdapter(const QDBusObjectPath &path) {
+  QDBusInterface device_props(nm_service, path.path(), props_iface, bus);
+  device_props.setTimeout(dbus_timeout);
+  const uint deviceType = get_response<uint>(device_props.call("Get", device_iface, "DeviceType"));
+  return deviceType == device_type_wifi;
+}
+
 void WifiManager::requestScan() {
   QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
   nm.setTimeout(dbus_timeout);
@@ -335,36 +354,17 @@ unsigned int WifiManager::get_ap_strength(const QString &network_path) {
   return get_response<unsigned int>(response);
 }
 
-QString WifiManager::get_adapter() {
+QString WifiManager::getAdapter() {
   QDBusInterface nm(nm_service, nm_path, nm_iface, bus);
   nm.setTimeout(dbus_timeout);
 
-  QDBusMessage response = nm.call("GetDevices");
-  QVariant first =  response.arguments().at(0);
-
-  QString adapter_path = "";
-
-  const QDBusArgument &args = first.value<QDBusArgument>();
-  args.beginArray();
-  while (!args.atEnd()) {
-    QDBusObjectPath path;
-    args >> path;
-
-    // Get device type
-    QDBusInterface device_props(nm_service, path.path(), props_iface, bus);
-    device_props.setTimeout(dbus_timeout);
-
-    QDBusMessage response = device_props.call("Get", device_iface, "DeviceType");
-    uint device_type = get_response<uint>(response);
-
-    if (device_type == 2) { // Wireless
-      adapter_path = path.path();
-      break;
+  const QDBusReply<QList<QDBusObjectPath>> &response = nm.call("GetDevices");
+  for (const QDBusObjectPath &path : response.value()) {
+    if (isWirelessAdapter(path)) {
+      return path.path();
     }
   }
-  args.endArray();
-
-  return adapter_path;
+  return "";
 }
 
 void WifiManager::stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason) {
@@ -391,6 +391,13 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
       refreshNetworks();  // TODO: only refresh on first scan, then use AccessPointAdded and Removed signals
       emit refreshSignal();
     }
+  }
+}
+
+void WifiManager::deviceAdded(const QDBusObjectPath &path) {
+  if (isWirelessAdapter(path) && (adapter.isEmpty() || adapter == "/")) {
+    adapter = path.path();
+    setup();
   }
 }
 
@@ -442,10 +449,9 @@ void WifiManager::activateWifiConnection(const QString &ssid) {
   const QDBusObjectPath &path = getConnectionPath(ssid);
   if (!path.path().isEmpty()) {
     connecting_to_network = ssid;
-    QString devicePath = get_adapter();
     QDBusInterface nm3(nm_service, nm_path, nm_iface, bus);
     nm3.setTimeout(dbus_timeout);
-    nm3.call("ActivateConnection", QVariant::fromValue(path), QVariant::fromValue(QDBusObjectPath(devicePath)), QVariant::fromValue(QDBusObjectPath("/")));
+    nm3.call("ActivateConnection", QVariant::fromValue(path), QVariant::fromValue(QDBusObjectPath(adapter)), QVariant::fromValue(QDBusObjectPath("/")));
   }
 }
 
@@ -495,7 +501,10 @@ void WifiManager::disableTethering() {
 
 bool WifiManager::tetheringEnabled() {
   QString active_ap = get_active_ap();
-  return get_property(active_ap, "Ssid") == tethering_ssid;
+  if (active_ap != "" && active_ap != "/") {
+    return get_property(active_ap, "Ssid") == tethering_ssid;
+  }
+  return false;
 }
 
 void WifiManager::changeTetheringPassword(const QString &newPassword) {

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -62,7 +62,8 @@ private:
   QString tethering_ssid;
   QString tetheringPassword = "swagswagcommma";
 
-  QString get_adapter();
+  QString getAdapter();
+  bool isWirelessAdapter(const QDBusObjectPath &path);
   QString get_ipv4_address();
   QList<Network> get_networks();
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
@@ -76,6 +77,7 @@ private:
   QDBusObjectPath getConnectionPath(const QString &ssid);
   QMap<QDBusObjectPath, QString> listConnections();
   QString getConnectionSsid(const QDBusObjectPath &path);
+  void setup();
 
 signals:
   void wrongPassword(const QString &ssid);
@@ -84,6 +86,7 @@ signals:
 private slots:
   void stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason);
   void propertyChange(const QString &interface, const QVariantMap &props, const QStringList &invalidated_props);
+  void deviceAdded(const QDBusObjectPath &path);
   void connectionRemoved(const QDBusObjectPath &path);
   void newConnection(const QDBusObjectPath &path);
 };

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -33,7 +33,7 @@ public:
   void requestScan();
   QVector<Network> seen_networks;
   QMap<QDBusObjectPath, QString> knownConnections;
-  QString ipv4_address;
+  QString ipv4_address = "";
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -33,7 +33,7 @@ public:
   void requestScan();
   QVector<Network> seen_networks;
   QMap<QDBusObjectPath, QString> knownConnections;
-  QString ipv4_address;
+  QString ipv4_address = "";
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
@@ -64,6 +64,7 @@ private:
 
   QString getAdapter();
   bool isWirelessAdapter(const QDBusObjectPath &path);
+  bool validPath(const QString &path);
   QString get_ipv4_address();
   QList<Network> get_networks();
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -33,7 +33,7 @@ public:
   void requestScan();
   QVector<Network> seen_networks;
   QMap<QDBusObjectPath, QString> knownConnections;
-  QString ipv4_address = "";
+  QString ipv4_address;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);
@@ -64,7 +64,6 @@ private:
 
   QString getAdapter();
   bool isWirelessAdapter(const QDBusObjectPath &path);
-  bool validPath(const QString &path);
   QString get_ipv4_address();
   QList<Network> get_networks();
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -33,7 +33,7 @@ public:
   void requestScan();
   QVector<Network> seen_networks;
   QMap<QDBusObjectPath, QString> knownConnections;
-  QString ipv4_address = "";
+  QString ipv4_address;
 
   void refreshNetworks();
   void forgetConnection(const QString &ssid);


### PR DESCRIPTION
Should start a scan immediately when the correct wifi adapter is detected, instead of checking every 5 seconds previously

- Wait for a `DeviceAdded` signal to start scanning immediately (on setup)
- When adapter is available (should be always), get tethering status as normal on init. In setup it is assumed false.