### PR TITLE
Networking: populate tethering password

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -125,8 +125,8 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   // Change tethering password
   editPasswordButton = new ButtonControl("Tethering Password", "EDIT");
   connect(editPasswordButton, &ButtonControl::released, [=]() {
-    QString pass = InputDialog::getText("Enter new tethering password", 8);
-    if (pass.size()) {
+    QString pass = InputDialog::getText("Enter new tethering password", 8, wifi->getTetheringPassword());
+    if (!pass.isEmpty()) {
       wifi->changeTetheringPassword(pass);
     }
   });

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -447,7 +447,7 @@ void WifiManager::addTetheringConnection() {
 }
 
 void WifiManager::enableTethering() {
-  if (isKnownConnection(tethering_ssid)) {
+  if (!isKnownConnection(tethering_ssid)) {
     addTetheringConnection();
   }
   activateWifiConnection(tethering_ssid.toUtf8());
@@ -468,7 +468,7 @@ bool WifiManager::tetheringEnabled() {
 }
 
 QString WifiManager::getTetheringPassword() {
-  if (isKnownConnection(tethering_ssid)) {
+  if (!isKnownConnection(tethering_ssid)) {
     addTetheringConnection();
   }
   const QDBusObjectPath &path = getConnectionPath(tethering_ssid);

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -365,7 +365,9 @@ void WifiManager::connectionRemoved(const QDBusObjectPath &path) {
 
 void WifiManager::newConnection(const QDBusObjectPath &path) {
   knownConnections[path] = getConnectionSsid(path);
-  activateWifiConnection(knownConnections[path]);
+  if (knownConnections[path] != tethering_ssid) {
+    activateWifiConnection(knownConnections[path]);
+  }
 }
 
 void WifiManager::disconnect() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -275,8 +275,8 @@ bool WifiManager::isWirelessAdapter(const QDBusObjectPath &path) {
 }
 
 void WifiManager::requestScan() {
-  QDBusInterface nm(nm_service, adapter, wireless_device_iface, bus);
-  nm.setTimeout(dbus_timeout);
+  QDBusInterface nm(NM_DBUS_SERVICE, adapter, NM_DBUS_INTERFACE_DEVICE_WIRELESS, bus);
+  nm.setTimeout(DBUS_TIMEOUT);
   nm.call("RequestScan", QVariantMap());
 }
 
@@ -470,8 +470,8 @@ QString WifiManager::getTetheringPassword() {
   addTetheringConnection();
   const QDBusObjectPath &path = getConnectionPath(tethering_ssid);
   if (!path.path().isEmpty()) {
-    QDBusInterface nm(nm_service, path.path(), nm_settings_conn_iface, bus);
-    nm.setTimeout(dbus_timeout);
+    QDBusInterface nm(NM_DBUS_INTERFACE, path.path(), NM_DBUS_INTERFACE_SETTINGS_CONNECTION, bus);
+    nm.setTimeout(DBUS_TIMEOUT);
 
     const QDBusReply<QMap<QString, QMap<QString, QVariant>>> response = nm.call("GetSecrets", "802-11-wireless-security");
     return response.value().value("802-11-wireless-security").value("psk").toString();
@@ -482,12 +482,10 @@ QString WifiManager::getTetheringPassword() {
 void WifiManager::changeTetheringPassword(const QString &newPassword) {
   const QDBusObjectPath &path = getConnectionPath(tethering_ssid);
   if (!path.path().isEmpty()) {
-    QDBusInterface nm(nm_service, path.path(), nm_settings_conn_iface, bus);
-    nm.setTimeout(dbus_timeout);
+    QDBusInterface nm(NM_DBUS_INTERFACE, path.path(), NM_DBUS_INTERFACE_SETTINGS_CONNECTION, bus);
+    nm.setTimeout(DBUS_TIMEOUT);
 
-    const QDBusReply<Connection> result = nm.call("GetSettings");
-    Connection settings = result.value();
-
+    Connection settings = QDBusReply<Connection>(nm.call("GetSettings")).value();
     settings["802-11-wireless-security"]["psk"] = newPassword;
     nm.call("Update", QVariant::fromValue(settings));
   }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -415,9 +415,6 @@ void WifiManager::activateWifiConnection(const QString &ssid) {
 
 // Functions for tethering
 void WifiManager::addTetheringConnection() {
-  if (isKnownConnection(tethering_ssid)) {
-    return;
-  }
   Connection connection;
   connection["connection"]["id"] = "Hotspot";
   connection["connection"]["uuid"] = QUuid::createUuid().toString().remove('{').remove('}');
@@ -450,7 +447,9 @@ void WifiManager::addTetheringConnection() {
 }
 
 void WifiManager::enableTethering() {
-  addTetheringConnection();
+  if (isKnownConnection(tethering_ssid)) {
+    addTetheringConnection();
+  }
   activateWifiConnection(tethering_ssid.toUtf8());
 }
 
@@ -469,7 +468,9 @@ bool WifiManager::tetheringEnabled() {
 }
 
 QString WifiManager::getTetheringPassword() {
-  addTetheringConnection();
+  if (isKnownConnection(tethering_ssid)) {
+    addTetheringConnection();
+  }
   const QDBusObjectPath &path = getConnectionPath(tethering_ssid);
   if (!path.path().isEmpty()) {
     QDBusInterface nm(NM_DBUS_INTERFACE, path.path(), NM_DBUS_INTERFACE_SETTINGS_CONNECTION, bus);

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -54,6 +54,7 @@ public:
   void addTetheringConnection();
   void activateWifiConnection(const QString &ssid);
   void changeTetheringPassword(const QString &newPassword);
+  QString getTetheringPassword();
 
 private:
   QVector<QByteArray> seen_ssids;
@@ -62,7 +63,7 @@ private:
   unsigned int raw_adapter_state;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState
   QString connecting_to_network;
   QString tethering_ssid;
-  QString tetheringPassword = "swagswagcommma";
+  const QString defaultTetheringPassword = "swagswagcommma";
 
   bool firstScan = true;
   QString getAdapter();

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -57,9 +57,10 @@ InputDialog::InputDialog(const QString &prompt_text, QWidget *parent) : QDialog(
 
 }
 
-QString InputDialog::getText(const QString &prompt, int minLength) {
+QString InputDialog::getText(const QString &prompt, int minLength, const QString &defaultText) {
   InputDialog d = InputDialog(prompt);
-  d.setMinLength(minLength);
+  d.minLength = minLength;
+  d.line->setText(defaultText);
   const int ret = d.exec();
   return ret ? d.text() : QString();
 }
@@ -106,10 +107,6 @@ void InputDialog::setMessage(const QString &message, bool clearInputField) {
   if (clearInputField) {
     line->setText("");
   }
-}
-
-void InputDialog::setMinLength(int length) {
-  minLength = length;
 }
 
 ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString &confirm_text, const QString &cancel_text,

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -59,8 +59,8 @@ InputDialog::InputDialog(const QString &prompt_text, QWidget *parent) : QDialog(
 
 QString InputDialog::getText(const QString &prompt, int minLength, const QString &defaultText) {
   InputDialog d = InputDialog(prompt);
-  d.minLength = minLength;
   d.line->setText(defaultText);
+  d.setMinLength(minLength);
   const int ret = d.exec();
   return ret ? d.text() : QString();
 }
@@ -107,6 +107,10 @@ void InputDialog::setMessage(const QString &message, bool clearInputField) {
   if (clearInputField) {
     line->setText("");
   }
+}
+
+void InputDialog::setMinLength(int length) {
+  minLength = length;
 }
 
 ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString &confirm_text, const QString &cancel_text,

--- a/selfdrive/ui/qt/widgets/input.h
+++ b/selfdrive/ui/qt/widgets/input.h
@@ -17,6 +17,7 @@ public:
   static QString getText(const QString &prompt, int minLength = -1, const QString &defaultText = "");
   QString text();
   void setMessage(const QString &message, bool clearInputField = true);
+  void setMinLength(int length);
   void show();
 
 private:

--- a/selfdrive/ui/qt/widgets/input.h
+++ b/selfdrive/ui/qt/widgets/input.h
@@ -14,10 +14,9 @@ class InputDialog : public QDialog {
 
 public:
   explicit InputDialog(const QString &prompt_text, QWidget* parent = 0);
-  static QString getText(const QString &prompt, int minLength = -1);
+  static QString getText(const QString &prompt, int minLength = -1, const QString &defaultText = "");
   QString text();
   void setMessage(const QString &message, bool clearInputField = true);
-  void setMinLength(int length);
   void show();
 
 private:


### PR DESCRIPTION
On clicking the edit or toggle, a tethering connection is created if it doesn't already exist. Then on editing the password we get and modify the connection settings.