### PR TITLE
FIX: Tesla spamming "LKAS fault"

### DIFF
--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -42,7 +42,7 @@ class CarState(CarStateBase):
     ret.steeringRateDeg = -cp.vl["STW_ANGLHP_STAT"]["StW_AnglHP_Spd"] # This is from a different angle sensor, and at different rate
     ret.steeringTorque = -cp.vl["EPAS_sysStatus"]["EPAS_torsionBarTorque"]
     ret.steeringPressed = (self.hands_on_level > 0)
-    ret.steerError = steer_status in ["EAC_FAULT", "EAC_INHIBITED"]
+    ret.steerError = steer_status == "EAC_FAULT"
     ret.steerWarning = self.steer_warning in ["EAC_ERROR_MAX_SPEED", "EAC_ERROR_MIN_SPEED", "EAC_ERROR_TMP_FAULT", "SNA"]  # TODO: not sure if this list is complete
 
     # Cruise state


### PR DESCRIPTION
 EAC_INHIBITED is not an actual error, when this is removed all "LKAS fault" errors are fixed.

<!-- Please copy and paste the relevant template -->

**Description**
Tesla is throwing "LKAS fault" errors.

**Verification**
Testdrive and tried to get the errors to show up, but they are gone.

**Route**
Route: 6c14ee12b74823ce|2021-07-02--15-27-53

