### PR TITLE
lag compensation by steering actuator delay

### DIFF
--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -71,14 +71,15 @@ def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates):
   # TODO this needs more thought, use .2s extra for now to estimate other delays
   delay = CP.steerActuatorDelay + .2
   current_curvature = curvatures[0]
-  psi = interp(delay, T_IDXS[:CONTROL_N], psis)
-  desired_curvature_rate = curvature_rates[0]
+  desired_curvature = interp(delay, T_IDXS[:CONTROL_N], curvatures)
+  #psi = interp(delay, T_IDXS[:CONTROL_N], psis)
+  desired_curvature_rate = interp(delay, T_IDXS[:CONTROL_N], curvature_rates)
 
   # MPC can plan to turn the wheel and turn back before t_delay. This means
   # in high delay cases some corrections never even get commanded. So just use
   # psi to calculate a simple linearization of desired curvature
-  curvature_diff_from_psi = psi / (max(v_ego, 1e-1) * delay) - current_curvature
-  desired_curvature = current_curvature + 2 * curvature_diff_from_psi
+  #curvature_diff_from_psi = psi / (max(v_ego, 1e-1) * delay) - current_curvature
+  #desired_curvature = current_curvature + 2 * curvature_diff_from_psi
 
   max_curvature_rate = interp(v_ego, MAX_CURVATURE_RATE_SPEEDS, MAX_CURVATURE_RATES)
   safe_desired_curvature_rate = clip(desired_curvature_rate,


### PR DESCRIPTION
The current lag compensation doesn't seem to be functioning correctly. 

actuator delay can be compensated by simply using the curvatures + curvature_rates future values. 
The biggest improvement was with KL which was previously unusable. So far KL is now as usable or better than the regular model. 
Previously standard model would be entering turns correctly and then KL would be very early. 

I'm very interested to understand how psi is supposed to work but it should not be unstable at delay values approaching 0. 
it also seems that psi includes vEgo so could be able to compensate for long acceleration but I could not tell if accelerating in a turn affected the logged psi values. 
