### PR TITLE
Camry TSS2: ignore low speed lockout

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -74,12 +74,16 @@ class CarState(CarStateBase):
     if self.CP.carFingerprint == CAR.LEXUS_IS:
       ret.cruiseState.available = cp.vl["DSU_CRUISE"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["DSU_CRUISE"]["SET_SPEED"] * CV.KPH_TO_MS
-      self.low_speed_lockout = False
     else:
       ret.cruiseState.available = cp.vl["PCM_CRUISE_2"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["PCM_CRUISE_2"]["SET_SPEED"] * CV.KPH_TO_MS
-      self.low_speed_lockout = cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2
     self.pcm_acc_status = cp.vl["PCM_CRUISE"]["CRUISE_STATE"]
+
+    if self.CP.carFingerprint == CAR.CAMRY_TSS2:
+      self.low_speed_lockout = False
+    else:
+      self.low_speed_lockout = cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2
+
     if self.CP.carFingerprint in NO_STOP_TIMER_CAR or self.CP.enableGasInterceptor:
       # ignore standstill in hybrid vehicles, since pcm allows to restart without
       # receiving any special command. Also if interceptor is detected


### PR DESCRIPTION
From https://www.toyota.com/camry/features/mpg/2532/2515/2557 only the Hybrid 2021 Camry's seem to have full-speed (DRCC), while non-hybrid can only accelerate from 28 mph (19 mph after installing openpilot, just like TSSP).