### PR TITLE
Toyota: handle models with permanent low speed lockout

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -115,9 +115,9 @@ class CarController():
       if pcm_cancel_cmd and CS.CP.carFingerprint == CAR.LEXUS_IS:
         can_sends.append(create_acc_cancel_command(self.packer))
       elif CS.CP.openpilotLongitudinalControl:
-        can_sends.append(create_accel_command(self.packer, pcm_accel_cmd, pcm_cancel_cmd, self.standstill_req, lead))
+        can_sends.append(create_accel_command(self.packer, pcm_accel_cmd, pcm_cancel_cmd, self.standstill_req, lead, CS.acc_type))
       else:
-        can_sends.append(create_accel_command(self.packer, 0, pcm_cancel_cmd, False, lead))
+        can_sends.append(create_accel_command(self.packer, 0, pcm_cancel_cmd, False, lead, CS.acc_type))
 
     if frame % 2 == 0 and CS.CP.enableGasInterceptor:
       # send exactly zero if gas cmd is zero. Interceptor will send the max between read value and gas cmd.

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -210,6 +210,6 @@ class CarState(CarStateBase):
 
     if CP.carFingerprint in TSS2_CAR:
       signals.append(("ACC_TYPE", "ACC_CONTROL", 1))
-      checks.append(("ACC_CONTROL", 33))
+      checks.append(("ACC_CONTROL", 0))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 2)

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -164,7 +164,7 @@ class CarState(CarStateBase):
     ]
 
     if CP.carFingerprint in TSS2_CAR:
-      signals.append(("SET_ME_X01", "ACC_CONTROL", 0))
+      signals.append(("SET_ME_X01", "ACC_CONTROL", 1))
       checks.append(("ACC_CONTROL", 33))
 
     if CP.carFingerprint == CAR.LEXUS_IS:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -85,7 +85,9 @@ class CarState(CarStateBase):
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
-    # these cars are identified by an ACC_TYPE value of 2
+    # these cars are identified by an ACC_TYPE value of 2.
+    # TODO: it may be possible to avoid the lockout and gain stop and go if you
+    # send your own ACC_CONTROL msg on startup with ACC_TYPE set to 1
     if (self.CP.carFingerprint not in TSS2_CAR and self.CP.carFingerprint != CAR.LEXUS_IS) or \
        (self.CP.carFingerprint in TSS2_CAR and self.acc_type == 1):
       self.low_speed_lockout = cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -201,8 +201,4 @@ class CarState(CarStateBase):
       ("ACC_CONTROL", 0),
     ]
 
-    if CP.carFingerprint in TSS2_CAR:
-      signals.append(("ACC_TYPE", "ACC_CONTROL", 1))
-      checks.append(("ACC_CONTROL", 0))
-
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 2)

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -82,8 +82,8 @@ class CarState(CarStateBase):
 
     self.pcm_acc_status = cp.vl["PCM_CRUISE"]["CRUISE_STATE"]
 
-    # some TSS2 cars have low speed lockout permanently set. ignore those cars, while still checking all others.
-    # when a car has a permanent low speed lockout, ACC_TYPE is 2
+    # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
+    # these cars are identified by an ACC_TYPE value of 2
     self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
     if self.CP.carFingerprint != CAR.LEXUS_IS and (self.CP.carFingerprint not in TSS2_CAR or
                              (self.CP.carFingerprint in TSS2_CAR and self.acc_type == 1)):

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -85,8 +85,8 @@ class CarState(CarStateBase):
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
     # these cars are identified by an ACC_TYPE value of 2
     self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
-    if self.CP.carFingerprint != CAR.LEXUS_IS and (self.CP.carFingerprint not in TSS2_CAR or
-                             (self.CP.carFingerprint in TSS2_CAR and self.acc_type == 1)):
+    if (self.CP.carFingerprint not in TSS2_CAR and self.CP.carFingerprint != CAR.LEXUS_IS) or \
+       (self.CP.carFingerprint in TSS2_CAR and self.acc_type == 1):
       self.low_speed_lockout = cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2
 
     if self.CP.carFingerprint in NO_STOP_TIMER_CAR or self.CP.enableGasInterceptor:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -88,10 +88,10 @@ class CarState(CarStateBase):
     self.pcm_acc_status = cp.vl["PCM_CRUISE"]["CRUISE_STATE"]
 
     # some TSS2 cars have low speed lockout permanently set. ignore those cars, while still checking all others.
-    # when a car has a permanent low speed lockout, SET_ME_X01 is 2
+    # when a car has a permanent low speed lockout, ACC_TYPE is 2
     self.low_speed_lockout = False
     if self.CP.carFingerprint != CAR.LEXUS_IS and (self.CP.carFingerprint not in TSS2_CAR or
-                             (self.CP.carFingerprint in TSS2_CAR and cp_cam.vl["ACC_CONTROL"]["SET_ME_X01"] == 1)):
+                             (self.CP.carFingerprint in TSS2_CAR and cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"] == 1)):
       self.low_speed_lockout = cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2
 
     if self.CP.carFingerprint in NO_STOP_TIMER_CAR or self.CP.enableGasInterceptor:
@@ -209,7 +209,7 @@ class CarState(CarStateBase):
     ]
 
     if CP.carFingerprint in TSS2_CAR:
-      signals.append(("SET_ME_X01", "ACC_CONTROL", 1))
+      signals.append(("ACC_TYPE", "ACC_CONTROL", 1))
       checks.append(("ACC_CONTROL", 33))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 2)

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -81,7 +81,7 @@ class CarState(CarStateBase):
       ret.cruiseState.available = cp.vl["PCM_CRUISE_2"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["PCM_CRUISE_2"]["SET_SPEED"] * CV.KPH_TO_MS
 
-    if not self.CP.enableDsu:
+    if not self.CP.enableDsu and self.CP.openpilotLongitudinalControl:
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
@@ -203,7 +203,7 @@ class CarState(CarStateBase):
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
     ]
 
-    if not CP.enableDsu:
+    if not CP.enableDsu and CP.openpilotLongitudinalControl:
       signals.append(("ACC_TYPE", "ACC_CONTROL", 0))
       checks.append(("ACC_CONTROL", 33))
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -190,13 +190,15 @@ class CarState(CarStateBase):
 
     signals = [
       ("FORCE", "PRE_COLLISION", 0),
-      ("PRECOLLISION_ACTIVE", "PRE_COLLISION", 0)
+      ("PRECOLLISION_ACTIVE", "PRE_COLLISION", 0),
+      ("ACC_TYPE", "ACC_CONTROL", 1),
     ]
 
     # use steering message to check if panda is connected to frc
     checks = [
       ("STEERING_LKA", 42),
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
+      ("ACC_CONTROL", 0),
     ]
 
     if CP.carFingerprint in TSS2_CAR:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -91,7 +91,7 @@ class CarState(CarStateBase):
     # when a car has a permanent low speed lockout, SET_ME_X01 on bus 0 is 2
     self.low_speed_lockout = False
     if self.CP.carFingerprint != CAR.LEXUS_IS and (self.CP.carFingerprint not in TSS2_CAR or
-                             (self.CP.carFingerprint in TSS2_CAR and cp.vl["ACC_CONTROL"]["SET_ME_X01"] == 1)):
+                             (self.CP.carFingerprint in TSS2_CAR and cp_cam.vl["ACC_CONTROL"]["SET_ME_X01"] == 1)):
       self.low_speed_lockout = cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2
 
     if self.CP.carFingerprint in NO_STOP_TIMER_CAR or self.CP.enableGasInterceptor:
@@ -163,10 +163,6 @@ class CarState(CarStateBase):
       ("STEER_TORQUE_SENSOR", 50),
     ]
 
-    if CP.carFingerprint in TSS2_CAR:
-      signals.append(("SET_ME_X01", "ACC_CONTROL", 1))
-      checks.append(("ACC_CONTROL", 33))
-
     if CP.carFingerprint == CAR.LEXUS_IS:
       signals.append(("MAIN_ON", "DSU_CRUISE", 0))
       signals.append(("SET_SPEED", "DSU_CRUISE", 0))
@@ -211,5 +207,9 @@ class CarState(CarStateBase):
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
       ("ACC_CONTROL", 0),
     ]
+
+    if CP.carFingerprint in TSS2_CAR:
+      signals.append(("SET_ME_X01", "ACC_CONTROL", 1))
+      checks.append(("ACC_CONTROL", 33))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 2)

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -81,7 +81,7 @@ class CarState(CarStateBase):
       ret.cruiseState.available = cp.vl["PCM_CRUISE_2"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["PCM_CRUISE_2"]["SET_SPEED"] * CV.KPH_TO_MS
 
-    if not self.CP.enableDsu and self.CP.openpilotLongitudinalControl:
+    if self.CP.carFingerprint in TSS2_CAR:
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
@@ -203,7 +203,7 @@ class CarState(CarStateBase):
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
     ]
 
-    if not CP.enableDsu and CP.openpilotLongitudinalControl:
+    if CP.carFingerprint in TSS2_CAR:
       signals.append(("ACC_TYPE", "ACC_CONTROL", 0))
       checks.append(("ACC_CONTROL", 33))
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -88,7 +88,7 @@ class CarState(CarStateBase):
     self.pcm_acc_status = cp.vl["PCM_CRUISE"]["CRUISE_STATE"]
 
     # some TSS2 cars have low speed lockout permanently set. ignore those cars, while still checking all others.
-    # when a car has a permanent low speed lockout, SET_ME_X01 on bus 0 is 2
+    # when a car has a permanent low speed lockout, SET_ME_X01 is 2
     self.low_speed_lockout = False
     if self.CP.carFingerprint != CAR.LEXUS_IS and (self.CP.carFingerprint not in TSS2_CAR or
                              (self.CP.carFingerprint in TSS2_CAR and cp_cam.vl["ACC_CONTROL"]["SET_ME_X01"] == 1)):

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -20,6 +20,8 @@ class CarState(CarStateBase):
     self.accurate_steer_angle_seen = False
     self.angle_offset = 0.
 
+    self.low_speed_lockout = False
+
   def update(self, cp, cp_cam):
     ret = car.CarState.new_message()
 
@@ -82,9 +84,9 @@ class CarState(CarStateBase):
 
     # some TSS2 cars have low speed lockout permanently set. ignore those cars, while still checking all others.
     # when a car has a permanent low speed lockout, ACC_TYPE is 2
-    self.low_speed_lockout = False
+    self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
     if self.CP.carFingerprint != CAR.LEXUS_IS and (self.CP.carFingerprint not in TSS2_CAR or
-                             (self.CP.carFingerprint in TSS2_CAR and cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"] == 1)):
+                             (self.CP.carFingerprint in TSS2_CAR and self.acc_type == 1)):
       self.low_speed_lockout = cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2
 
     if self.CP.carFingerprint in NO_STOP_TIMER_CAR or self.CP.enableGasInterceptor:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -195,14 +195,16 @@ class CarState(CarStateBase):
     signals = [
       ("FORCE", "PRE_COLLISION", 0),
       ("PRECOLLISION_ACTIVE", "PRE_COLLISION", 0),
-      ("ACC_TYPE", "ACC_CONTROL", 0),
     ]
 
     # use steering message to check if panda is connected to frc
     checks = [
       ("STEERING_LKA", 42),
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
-      ("ACC_CONTROL", 0),
     ]
+
+    if not CP.enableDsu:
+      signals.append(("ACC_TYPE", "ACC_CONTROL", 0))
+      checks.append(("ACC_CONTROL", 33))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 2)

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -32,7 +32,7 @@ def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead):
   # TODO: find the exact canceling bit that does not create a chime
   values = {
     "ACCEL_CMD": accel,
-    "SET_ME_X01": 1,
+    "ACC_TYPE": 1,
     "DISTANCE": 0,
     "MINI_CAR": lead,
     "SET_ME_X3": 3,

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -28,11 +28,11 @@ def create_lta_steer_command(packer, steer, steer_req, raw_cnt):
   return packer.make_can_msg("STEERING_LTA", 0, values)
 
 
-def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead):
+def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, acc_type):
   # TODO: find the exact canceling bit that does not create a chime
   values = {
     "ACCEL_CMD": accel,
-    "ACC_TYPE": 1,
+    "ACC_TYPE": acc_type,
     "DISTANCE": 0,
     "MINI_CAR": lead,
     "SET_ME_X3": 3,


### PR DESCRIPTION
If `SET_ME_X01` isn't 1, low speed lockout should be guaranteed to be 2. Going to verify with a few routes from always faulting cars and never faulting cars

Cars experiencing `lowSpeedLockout`s:
- Toyota Camry Nightshade 2021 (US) - `SET_ME_X01` is `2` on startup (during stock route)
- Toyota / Camry LE 2021 (US) - `SET_ME_X01` is `2` on startup
- Toyota Corolla non-hybrid 2021 (Brazil made - Argentina market) - `SET_ME_X01` is `2` on startup
- Corolla Hybrid 2021 (Brazil made - Brazilian market) - `SET_ME_X01` is `2` on startup
- Toyota / Corolla Hybrid 2020 (Brazil made - Latinamerican market) - `SET_ME_X01` is `2` on startup
- Toyota Corolla Cross Hybrid (Thailand made and Asian market eg Thailand, Vietnam and Taiwan) - `SET_ME_X01` is `2` on startup

Cars not experiencing `lowSpeedLockout`s:
- 2021 Camry Hybrid TSS 2.5 - `SET_ME_X01` is `1` on startup
- TSS2 Corolla from test_routes.py - `SET_ME_X01` is `1` on startup

Not in this PR, but perhaps if you block 343 while the device is coming up and send your own with `SET_ME_X01` set to 1 you may be able to get stop and go acceleration