### PR TITLE
Qt/spinner: reduce cpu usage from 12% to 9%

### DIFF
--- a/selfdrive/ui/qt/spinner.cc
+++ b/selfdrive/ui/qt/spinner.cc
@@ -15,20 +15,24 @@
 #include "selfdrive/ui/qt/util.h"
 
 TrackWidget::TrackWidget(QWidget *parent) : QWidget(parent) {
+  setAttribute(Qt::WA_OpaquePaintEvent);
   setFixedSize(spinner_size);
-  setAutoFillBackground(true);
-  setPalette(Qt::black);
 
   // pre-compute all the track imgs. make this a gif instead?
   QPixmap comma_img = QPixmap("../assets/img_spinner_comma.png").scaled(spinner_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-  QTransform transform(1, 0, 0, 1, width() / 2, height() / 2);
   QPixmap track_img = QPixmap("../assets/img_spinner_track.png").scaled(spinner_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-  for (QPixmap &img : track_imgs) {
-    img = comma_img;
-    QPainter p(&img);
-    p.setRenderHint(QPainter::SmoothPixmapTransform);
+
+  QTransform transform(1, 0, 0, 1, width() / 2, height() / 2);
+  QPixmap pm(spinner_size);
+  QPainter p(&pm);
+  p.setRenderHint(QPainter::SmoothPixmapTransform);
+  for (int i = 0; i < track_imgs.size(); ++i) {
+    p.resetTransform();
+    p.fillRect(0, 0, spinner_size.width(), spinner_size.height(), Qt::black);
+    p.drawPixmap(0, 0, comma_img);
     p.setTransform(transform.rotate(360 / spinner_fps));
     p.drawPixmap(-width() / 2, -height() / 2, track_img);
+    track_imgs[i] = pm.copy();
   }
 
   m_anim.setDuration(1000);

--- a/selfdrive/ui/qt/spinner.cc
+++ b/selfdrive/ui/qt/spinner.cc
@@ -30,12 +30,12 @@ TrackWidget::TrackWidget(QWidget *parent) : QWidget(parent) {
     p.resetTransform();
     p.fillRect(0, 0, spinner_size.width(), spinner_size.height(), Qt::black);
     p.drawPixmap(0, 0, comma_img);
-    p.setTransform(transform.rotate(360 / spinner_fps));
+    p.setTransform(transform.rotate(360 / track_imgs.size()));
     p.drawPixmap(-width() / 2, -height() / 2, track_img);
     track_imgs[i] = pm.copy();
   }
 
-  m_anim.setDuration(1000);
+  m_anim.setDuration(1000 * ((float)track_imgs.size() / spinner_fps));
   m_anim.setStartValue(0);
   m_anim.setEndValue(int(track_imgs.size() -1));
   m_anim.setLoopCount(-1);

--- a/selfdrive/ui/qt/spinner.cc
+++ b/selfdrive/ui/qt/spinner.cc
@@ -30,12 +30,12 @@ TrackWidget::TrackWidget(QWidget *parent) : QWidget(parent) {
     p.resetTransform();
     p.fillRect(0, 0, spinner_size.width(), spinner_size.height(), Qt::black);
     p.drawPixmap(0, 0, comma_img);
-    p.setTransform(transform.rotate(360 / track_imgs.size()));
+    p.setTransform(transform.rotate(360 / spinner_fps));
     p.drawPixmap(-width() / 2, -height() / 2, track_img);
     track_imgs[i] = pm.copy();
   }
 
-  m_anim.setDuration(1000 * ((float)track_imgs.size() / spinner_fps));
+  m_anim.setDuration(1000);
   m_anim.setStartValue(0);
   m_anim.setEndValue(int(track_imgs.size() -1));
   m_anim.setLoopCount(-1);

--- a/selfdrive/ui/qt/spinner.h
+++ b/selfdrive/ui/qt/spinner.h
@@ -7,8 +7,8 @@
 #include <QVariantAnimation>
 #include <QWidget>
 
-constexpr int spinner_fps = 30;
-constexpr QSize spinner_size = QSize(360, 360);
+const int spinner_fps = 20;
+const QSize spinner_size = QSize(360, 360);
 
 class TrackWidget : public QWidget  {
   Q_OBJECT
@@ -17,7 +17,7 @@ public:
 
 private:
   void paintEvent(QPaintEvent *event) override;
-  std::array<QPixmap, spinner_fps> track_imgs;
+  std::array<QPixmap, 30> track_imgs;
   QVariantAnimation m_anim;
 };
 

--- a/selfdrive/ui/qt/spinner.h
+++ b/selfdrive/ui/qt/spinner.h
@@ -7,8 +7,8 @@
 #include <QVariantAnimation>
 #include <QWidget>
 
-const int spinner_fps = 20;
-const QSize spinner_size = QSize(360, 360);
+constexpr int spinner_fps = 30;
+constexpr QSize spinner_size = QSize(360, 360);
 
 class TrackWidget : public QWidget  {
   Q_OBJECT
@@ -17,7 +17,7 @@ public:
 
 private:
   void paintEvent(QPaintEvent *event) override;
-  std::array<QPixmap, 30> track_imgs;
+  std::array<QPixmap, spinner_fps> track_imgs;
   QVariantAnimation m_anim;
 };
 


### PR DESCRIPTION
continue #21495.  

1. do not fill background, use `WA_OpaquePaintEvent` to paint all in `paintEvent` (cpu recuded from 12% to 9%)
2. ~set fps to 20, But the angle of rotation at each step is the same as 30fps.  (cpu recuded from 9% to 6%)~