### PR TITLE
Ship UDS fingerprint dev tool with release2

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -523,6 +523,7 @@ panda/VERSION
 panda/board/**
 panda/certs/**
 panda/crypto/**
+panda/examples/query_fw_versions.py
 panda/python/**
 
 opendbc/.gitignore


### PR DESCRIPTION
Temporarily ship `panda/examples/query_fw_versions.py` with release2, to help facilitate data-gathering for community ports trying to migrate off legacy CAN fingerprinting. May also help debug odd results from certain HKG queries.