### PR TITLE
networking: speed up refreshing

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -99,7 +99,7 @@ void Networking::connectToNetwork(const Network &n) {
 void Networking::wrongPassword(const QString &ssid) {
   if (wifi->seenNetworks.contains(ssid)) {
     const Network &n = wifi->seenNetworks.value(ssid);
-    QString pass = InputDialog::getText("Wrong password for \"" + n.ssid +"\"", this, 8);
+    QString pass = InputDialog::getText("Wrong password", this, "for \"" + n.ssid +"\"", true, 8);
     if (!pass.isEmpty()) {
       wifi->connect(n, pass);
     }

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -84,7 +84,7 @@ void Networking::refresh() {
 }
 
 void Networking::connectToNetwork(const Network &n) {
-  if (wifi->isKnownConnection(n.ssid)) {
+  if (n.known) {
     wifi->activateWifiConnection(n.ssid);
   } else if (n.security_type == SecurityType::OPEN) {
     wifi->connect(n);
@@ -201,7 +201,7 @@ void WifiUI::refresh() {
     ssid_label->setStyleSheet("font-size: 55px;");
     hlayout->addWidget(ssid_label, 1, Qt::AlignLeft);
 
-    if (wifi->isKnownConnection(network.ssid) && !wifi->isTetheringEnabled()) {
+    if (network.known && !wifi->isTetheringEnabled()) {
       QPushButton *forgetBtn = new QPushButton();
       QPixmap pix("../assets/offroad/icon_close.svg");
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -84,11 +84,11 @@ void WifiManager::addNetwork(const QDBusObjectPath &path) {
     }
   }
   Network network = {path.path(), ssid, strength, ctype, security, isKnownConnection(ssid)};
+  mutex.lock();
   if (!seenNetworks.contains(ssid)) {
-    mutex.lock();
     seenNetworks[ssid] = network;
-    mutex.unlock();
   }
+  mutex.unlock();
 }
 
 void WifiManager::refreshNetworks() {

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -25,6 +25,7 @@ struct Network {
   unsigned int strength;
   ConnectedType connected;
   SecurityType security_type;
+  bool known;
 };
 
 class WifiManager : public QWidget {
@@ -33,11 +34,12 @@ public:
   explicit WifiManager(QWidget* parent);
 
   void requestScan();
-  QVector<Network> seen_networks;
+  QMap<QString, Network> seenNetworks;
   QMap<QDBusObjectPath, QString> knownConnections;
   QString ipv4_address;
 
   void refreshNetworks();
+  void addNetwork(const QDBusObjectPath &path);
   void forgetConnection(const QString &ssid);
   bool isKnownConnection(const QString &ssid);
   void activateWifiConnection(const QString &ssid);
@@ -55,7 +57,6 @@ public:
   QString getTetheringPassword();
 
 private:
-  QVector<QByteArray> seen_ssids;
   QString adapter;  // Path to network manager wifi-device
   QDBusConnection bus = QDBusConnection::systemBus();
   unsigned int raw_adapter_state;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState
@@ -80,6 +81,7 @@ private:
   void initConnections();
   QString getConnectionSsid(const QDBusObjectPath &path);
   void setup();
+  std::mutex mutex;
 
 signals:
   void wrongPassword(const QString &ssid);


### PR DESCRIPTION
Pools threads to get attributes of each AP.

For 16-20 networks, previous times per network were: 10.23 ms, 10.9 ms, 11.31 ms, 10.97 ms, 11.3219 ms, 12.01 ms, 12.31 ms (mean: 11.29 ms)
For 11-17 networks now: 3.27 ms, 3.787 ms, 3.12 ms, 2.65 ms, 3.05 ms, 2.72 ms, 2.48 ms (mean: 3.011 ms)

~3.75x speed increase

Current times:
```
selfdrive/ui/qt/offroad/networking.cc: Refreshing took 73.651 ms for 25 networks - 2.94604 ms/network
selfdrive/ui/qt/offroad/networking.cc: Drawing took 41.6182 ms for 25 networks - 1.66473 ms/network
```