### PR TITLE
small keyboard fixes

### DIFF
--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -35,6 +35,7 @@ InputDialog::InputDialog(const QString &prompt_text, QWidget *parent) : QDialogB
     padding-right: 45px;
     padding-left: 45px;
     border-radius: 7px;
+    border: 0px;
     font-size: 45px;
     background-color: #444444;
   )");

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -35,7 +35,6 @@ InputDialog::InputDialog(const QString &prompt_text, QWidget *parent) : QDialogB
     padding-right: 45px;
     padding-left: 45px;
     border-radius: 7px;
-    border: 0px;
     font-size: 45px;
     background-color: #444444;
   )");
@@ -64,6 +63,7 @@ InputDialog::InputDialog(const QString &prompt_text, QWidget *parent) : QDialogB
   setStyleSheet(R"(
     * {
       outline: none;
+      border: 0px;
       color: white;
       font-family: Inter;
       background-color: black;

--- a/selfdrive/ui/qt/widgets/keyboard.cc
+++ b/selfdrive/ui/qt/widgets/keyboard.cc
@@ -54,6 +54,7 @@ KeyboardLayout::KeyboardLayout(QWidget* parent, const std::vector<QVector<QStrin
       margin: 0px;
       padding: 0px;
       border-radius: 10px;
+      border: 0px;
       color: #dddddd;
       background-color: #444444;
     }
@@ -120,7 +121,7 @@ void Keyboard::handleButton(QAbstractButton* btn) {
   if (!QString::compare(key, "#+=")) {
     main_layout->setCurrentIndex(3);
   }
-  if (!QString::compare(key, BACKSPACE_KEY)) {
+  if (!QString::compare(key, ENTER_KEY)) {
     main_layout->setCurrentIndex(0);
   }
   if ("A" <= key && key <= "Z") {


### PR DESCRIPTION
Keys had white border around them in setup from `setup.cc`'s `border: 7px solid white;`