### PR TITLE
Added 2019 Atlas SE w/ tech engine FW

### DIFF
--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -95,6 +95,7 @@ FW_VERSIONS = {
       b'\xf1\x8703H906026F \xf1\x896696',
       b'\xf1\x8703H906026F \xf1\x899970',
       b'\xf1\x8703H906026S \xf1\x896693',
+      b'\xf1\x8703H906026S \xf1\x899970',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x8709G927158A \xf1\x893387',


### PR DESCRIPTION
Add firmware for the 2019 Volkswagen Atlas. Extracted from Atlas SE w/ Tech and long distance remote start.

Dongle ID: ede8445ee46e2b7d

Validated by editing values.py comma 2.