### PR TITLE
GM: Correctly handle EPS warning vs error states

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -33,7 +33,7 @@ class CarController():
 
     # STEER
     if (frame % P.STEER_STEP) == 0:
-      lkas_enabled = enabled and not CS.out.steerWarning and CS.out.vEgo > P.MIN_STEER_SPEED
+      lkas_enabled = enabled and not (CS.out.steerWarning or CS.out.steerError) and CS.out.vEgo > P.MIN_STEER_SPEED
       if lkas_enabled:
         new_steer = int(round(actuators.steer * P.STEER_MAX))
         apply_steer = apply_std_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, P)

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -45,7 +45,8 @@ class CarState(CarStateBase):
 
     # 0 inactive, 1 active, 2 temporarily limited, 3 failed
     self.lkas_status = pt_cp.vl["PSCMStatus"]["LKATorqueDeliveredStatus"]
-    ret.steerWarning = self.lkas_status not in [0, 1]
+    ret.steerWarning = self.lkas_status == 2
+    ret.steerError = self.lkas_status == 3
 
     # 1 - open, 0 - closed
     ret.doorOpen = (pt_cp.vl["BCMDoorBeltStatus"]["FrontLeftDoor"] == 1 or


### PR DESCRIPTION
**Description**

The GM port never grew support for the separate steerError vs steerWarning states; they're newer than the GM port. As a result, it doesn't separately handle recoverable/temporary vs nonrecoverable/restart-required errors, and doesn't tell the driver when there's a permanent restart-required fault.

**Verification**

EPS LKA state 2 vs 3 was already documented in GM's carstate, and in the process of troubleshooting with an affected user, it was confirmed that 2 is recoverable and 3 requires a restart.

It's possible that users experiencing #21557 (which involves EPS LKA state 3) might think the problem has gotten worse after this fix. The underlying problem hasn't gotten worse, we're just doing a better job of reporting it, including while disengaged.

**Route**

Route: `e38a02cae1ef1e0c|2021-07-16--00-36-57`