### PR TITLE
Show driver camera preview in SettingsWindow

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -33,12 +33,6 @@ HomeWindow::HomeWindow(QWidget* parent) : QWidget(parent) {
 
   QObject::connect(this, &HomeWindow::update, onroad, &OnroadWindow::updateStateSignal);
   QObject::connect(this, &HomeWindow::offroadTransitionSignal, onroad, &OnroadWindow::offroadTransitionSignal);
-
-  driver_view = new DriverViewWindow(this);
-  connect(driver_view, &DriverViewWindow::done, [=] {
-    showDriverView(false);
-  });
-  slayout->addWidget(driver_view);
   setAttribute(Qt::WA_NoSystemBackground);
 }
 
@@ -54,16 +48,6 @@ void HomeWindow::offroadTransition(bool offroad) {
     slayout->setCurrentWidget(onroad);
   }
   emit offroadTransitionSignal(offroad);
-}
-
-void HomeWindow::showDriverView(bool show) {
-  if (show) {
-    emit closeSettings();
-    slayout->setCurrentWidget(driver_view);
-  } else {
-    slayout->setCurrentWidget(home);
-  }
-  sidebar->setVisible(show == false);
 }
 
 void HomeWindow::mousePressEvent(QMouseEvent* e) {

--- a/selfdrive/ui/qt/home.h
+++ b/selfdrive/ui/qt/home.h
@@ -40,7 +40,6 @@ public:
 
 signals:
   void openSettings();
-  void closeSettings();
 
   // forwarded signals
   void displayPowerChanged(bool on);

--- a/selfdrive/ui/qt/home.h
+++ b/selfdrive/ui/qt/home.h
@@ -7,7 +7,6 @@
 #include <QTimer>
 #include <QWidget>
 
-#include "selfdrive/ui/qt/offroad/driverview.h"
 #include "selfdrive/ui/qt/onroad.h"
 #include "selfdrive/ui/qt/sidebar.h"
 #include "selfdrive/ui/qt/widgets/offroad_alerts.h"
@@ -50,7 +49,6 @@ signals:
 
 public slots:
   void offroadTransition(bool offroad);
-  void showDriverView(bool show);
   void showSidebar(bool show);
 
 protected:
@@ -60,6 +58,5 @@ private:
   Sidebar *sidebar;
   OffroadHome *home;
   OnroadWindow *onroad;
-  DriverViewWindow *driver_view;
   QStackedLayout *slayout;
 };

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -8,6 +8,8 @@
 const int FACE_IMG_SIZE = 130;
 
 DriverViewWindow::DriverViewWindow(QWidget* parent) : QWidget(parent) {
+  Params().putBool("IsDriverViewEnabled", true);
+
   setAttribute(Qt::WA_OpaquePaintEvent);
   layout = new QStackedLayout(this);
   layout->setStackingMode(QStackedLayout::StackAll);
@@ -21,22 +23,15 @@ DriverViewWindow::DriverViewWindow(QWidget* parent) : QWidget(parent) {
   layout->setCurrentWidget(scene);
 }
 
-void DriverViewWindow::mousePressEvent(QMouseEvent* e) {
-  emit done();
+DriverViewWindow::~DriverViewWindow() {
+  Params().putBool("IsDriverViewEnabled", false);
 }
+
+// DriverViewScene
 
 DriverViewScene::DriverViewScene(QWidget* parent) : sm({"driverState"}), QWidget(parent) {
   face = QImage("../assets/img_driver_face.png").scaled(FACE_IMG_SIZE, FACE_IMG_SIZE, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-}
-
-void DriverViewScene::showEvent(QShowEvent* event) {
-  frame_updated = false;
-  is_rhd = params.getBool("IsRHD");
-  params.putBool("IsDriverViewEnabled", true);
-}
-
-void DriverViewScene::hideEvent(QHideEvent* event) {
-  params.putBool("IsDriverViewEnabled", false);
+  is_rhd = Params().getBool("IsRHD");
 }
 
 void DriverViewScene::frameUpdated() {

--- a/selfdrive/ui/qt/offroad/driverview.h
+++ b/selfdrive/ui/qt/offroad/driverview.h
@@ -16,12 +16,8 @@ public:
 public slots:
   void frameUpdated();
 
-protected:
-  void showEvent(QShowEvent *event) override;
-  void hideEvent(QHideEvent *event) override;
-  void paintEvent(QPaintEvent *event) override;
-
 private:
+  void paintEvent(QPaintEvent *event) override;
   Params params;
   SubMaster sm;
   QImage face;
@@ -34,14 +30,13 @@ class DriverViewWindow : public QWidget {
 
 public:
   explicit DriverViewWindow(QWidget *parent);
+  ~DriverViewWindow();
 
 signals:
-  void done();
-
-protected:
-  void mousePressEvent(QMouseEvent* e) override;
+  void clicked();
 
 private:
+  void mousePressEvent(QMouseEvent* e) override { emit clicked(); }
   CameraViewWidget *cameraView;
   DriverViewScene *scene;
   QStackedLayout *layout;

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -105,8 +105,9 @@ DevicePanel::DevicePanel(QWidget* parent) : QWidget(parent) {
 
   // offroad-only buttons
 
-  auto dcamBtn = new ButtonControl("Driver Camera", "PREVIEW",
-                                        "Preview the driver facing camera to help optimize device mounting position for best driver monitoring experience. (vehicle must be off)");
+  auto dcamBtn = new ButtonControl(
+    "Driver Camera", "PREVIEW",
+    "Preview the driver facing camera to help optimize device mounting position for best driver monitoring experience. (vehicle must be off)");
   connect(dcamBtn, &ButtonControl::clicked, [=]() { emit showDriverView(); });
 
   QString resetCalibDesc = "openpilot requires the device to be mounted within 4° left or right and within 5° up or down. openpilot is continuously calibrating, resetting is rarely required.";
@@ -385,8 +386,24 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
   )");
 }
 
+void SettingsWindow::showDriverView() {
+  if (!driver_view) {
+    driver_view = new DriverViewWindow(this);
+    connect(driver_view, &DriverViewWindow::clicked, [=]() {
+      driver_view->deleteLater();
+      driver_view = nullptr;
+    });
+    driver_view->setFixedSize(width(), height());
+    driver_view->show();
+  }
+}
+
 void SettingsWindow::hideEvent(QHideEvent *event) {
 #ifdef QCOM
   HardwareEon::close_activities();
 #endif
+  if (driver_view) {
+    driver_view->deleteLater();
+    driver_view = nullptr;
+  }
 }

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -10,6 +10,7 @@
 
 
 #include "selfdrive/ui/qt/widgets/controls.h"
+#include "selfdrive/ui/qt/offroad/driverview.h"
 
 // ********** settings window + top-level panels **********
 
@@ -54,19 +55,19 @@ class SettingsWindow : public QFrame {
 public:
   explicit SettingsWindow(QWidget *parent = 0);
 
-protected:
-  void hideEvent(QHideEvent *event) override;
-  void showEvent(QShowEvent *event) override;
-
 signals:
   void closeSettings();
   void offroadTransition(bool offroad);
   void reviewTrainingGuide();
+
+protected:
+  void hideEvent(QHideEvent *event) override;
+  void showEvent(QShowEvent *event) override;
   void showDriverView();
 
-private:
   QPushButton *sidebar_alert_widget;
   QWidget *sidebar_widget;
   QButtonGroup *nav_btns;
   QStackedWidget *panel_widget;
+  DriverViewWindow *driver_view = nullptr;
 };

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -30,9 +30,6 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
   QObject::connect(settingsWindow, &SettingsWindow::reviewTrainingGuide, [=]() {
     main_layout->setCurrentWidget(onboardingWindow);
   });
-  QObject::connect(settingsWindow, &SettingsWindow::showDriverView, [=] {
-    homeWindow->showDriverView(true);
-  });
 
   device.setAwake(true, true);
   QObject::connect(&qs, &QUIState::uiUpdate, &device, &Device::update);

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -17,7 +17,6 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
   homeWindow = new HomeWindow(this);
   main_layout->addWidget(homeWindow);
   QObject::connect(homeWindow, &HomeWindow::openSettings, this, &MainWindow::openSettings);
-  QObject::connect(homeWindow, &HomeWindow::closeSettings, this, &MainWindow::closeSettings);
   QObject::connect(&qs, &QUIState::uiUpdate, homeWindow, &HomeWindow::update);
   QObject::connect(&qs, &QUIState::offroadTransition, homeWindow, &HomeWindow::offroadTransition);
   QObject::connect(&qs, &QUIState::offroadTransition, homeWindow, &HomeWindow::offroadTransitionSignal);


### PR DESCRIPTION
move `DriverViewWindow`  to `SettingsWindow`. stay in the device panel after previewing.
