### PR TITLE
networking: improve drawing

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -347,7 +347,11 @@ void WifiUI::refresh() {
       main_layout->insertLayout(i, hlayout, 1);
       qDebug() << network.ssid << "is not in drawn networks, add it!";
     } else {
-      QHBoxLayout *hlayout = qobject_cast<QHBoxLayout*>(main_layout->itemAt(i)->layout());
+      int widgetIndex = drawnSsids.indexOf(network.ssid);
+      QHBoxLayout *hlayout = qobject_cast<QHBoxLayout*>(main_layout->takeAt(i)->layout());
+      if (widgetIndex != i) {
+        main_layout->insertLayout(i, hlayout, 1);
+      }
       updateNetworkWidget(hlayout, network, isTetheringEnabled);
     }
     i++;

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -88,13 +88,11 @@ void Networking::connectToNetwork(const Network &n) {
 }
 
 void Networking::wrongPassword(const QString &ssid) {
-  for (Network n : wifi->seen_networks) {
-    if (n.ssid == ssid) {
-      QString pass = InputDialog::getText("Wrong password", this, "for \"" + n.ssid +"\"", true, 8);
-      if (!pass.isEmpty()) {
-        wifi->connect(n, pass);
-      }
-      return;
+  if (wifi->seenNetworks.contains(ssid)) {
+    const Network &n = wifi->seenNetworks.value(ssid);
+    QString pass = InputDialog::getText("Wrong password", this, "for \"" + n.ssid +"\"", true, 8);
+    if (!pass.isEmpty()) {
+      wifi->connect(n, pass);
     }
   }
 }
@@ -206,7 +204,7 @@ void WifiUI::refresh() {
   // TODO: don't rebuild this every time
   clearLayout(main_layout);
 
-  if (wifi->seen_networks.size() == 0) {
+  if (wifi->seenNetworks.size() == 0) {
     QLabel *scanning = new QLabel("Scanning for networks...");
     scanning->setStyleSheet("font-size: 65px;");
     main_layout->addWidget(scanning, 0, Qt::AlignCenter);
@@ -215,7 +213,7 @@ void WifiUI::refresh() {
 
   // add networks
   int i = 0;
-  for (Network &network : wifi->seen_networks) {
+  for (Network &network : wifi->seenNetworks) {
     QHBoxLayout *hlayout = new QHBoxLayout;
     hlayout->setContentsMargins(44, 0, 73, 0);
     hlayout->setSpacing(50);
@@ -285,7 +283,7 @@ void WifiUI::refresh() {
     main_layout->addLayout(hlayout, 1);
 
     // Don't add the last horizontal line
-    if (i+1 < wifi->seen_networks.size()) {
+    if (i+1 < wifi->seenNetworks.size()) {
       main_layout->addWidget(horizontal_line(), 0);
     }
     i++;

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -248,7 +248,7 @@ void WifiUI::updateStatusIcon(QLabel *statusIcon, const Network &network) {
 QHBoxLayout* WifiUI::buildNetworkWidget(const Network &network, bool isTetheringEnabled) {
   QHBoxLayout *hlayout = new QHBoxLayout;
   hlayout->setContentsMargins(44, 0, 73, 0);
-  hlayout->setObjectName(network.ssid);
+  hlayout->setProperty("ssid", network.ssid);
   hlayout->setSpacing(50);
 
   // Clickable SSID label
@@ -319,7 +319,7 @@ void WifiUI::refresh() {
   // Update or delete all drawn networks by checking seenNetworks
   int i = 0;
   while (i < main_layout->count()) {
-    const QString &networkSsid = main_layout->itemAt(i)->layout()->objectName();
+    const QString &networkSsid = main_layout->itemAt(i)->layout()->property("ssid").toString();
     if (!networkSsid.isEmpty()) {
       if (wifi->seenNetworks.contains(networkSsid)) {
         qDebug() << "UPDATING:" << networkSsid;
@@ -343,15 +343,15 @@ void WifiUI::refresh() {
     return;
   }
 
-  QVector<QString> objectNames;  // ssids already added to main_layout
+  QVector<QString> drawnSsids;  // ssids already added to main_layout
   for (int i = 0; i < main_layout->count(); i++) {
-    objectNames.push_back(main_layout->itemAt(i)->layout()->objectName());
+    drawnSsids.push_back(main_layout->itemAt(i)->layout()->property("ssid").toString());
   }
 
   // add networks
   i = 0;
   for (Network &network : wifi->seenNetworks) {
-    if (!objectNames.contains(network.ssid)) {
+    if (!drawnSsids.contains(network.ssid)) {
       QHBoxLayout *hlayout = buildNetworkWidget(network, isTetheringEnabled);
       main_layout->addLayout(hlayout, 1);
       qDebug() << network.ssid << "is not in drawn networks, add it!";

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -176,9 +176,9 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
   lock = QPixmap(ASSET_PATH + "offroad/icon_lock_closed.svg").scaledToWidth(49, Qt::SmoothTransformation);
   checkmark = QPixmap(ASSET_PATH + "offroad/icon_checkmark.svg").scaledToWidth(49, Qt::SmoothTransformation);
 
-  QLabel *scanning = new QLabel("Scanning for networks...");
-  scanning->setStyleSheet("font-size: 65px;");
-  main_layout->addWidget(scanning, 0, Qt::AlignCenter);
+//  QLabel *scanning = new QLabel("Scanning for networks...");
+//  scanning->setStyleSheet("font-size: 65px;");
+//  main_layout->addWidget(scanning, 0, Qt::AlignCenter);
 
   setStyleSheet(R"(
     QScrollBar::handle:vertical {
@@ -200,93 +200,133 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
   )");
 }
 
-void WifiUI::refresh() {
-  // TODO: don't rebuild this every time
-  clearLayout(main_layout);
+QHBoxLayout* WifiUI::buildNetworkWidget(const Network &network) {
+  QHBoxLayout *hlayout = new QHBoxLayout;
+  hlayout->setContentsMargins(44, 0, 73, 0);
+  hlayout->setObjectName(network.ssid);
+  hlayout->setSpacing(50);
 
-  if (wifi->seenNetworks.size() == 0) {
-    QLabel *scanning = new QLabel("Scanning for networks...");
-    scanning->setStyleSheet("font-size: 65px;");
-    main_layout->addWidget(scanning, 0, Qt::AlignCenter);
-    return;
+  // Clickable SSID label
+  QPushButton *ssid_label = new QPushButton(network.ssid);
+  ssid_label->setEnabled(network.connected != ConnectedType::CONNECTED &&
+                         network.connected != ConnectedType::CONNECTING &&
+                         network.security_type != SecurityType::UNSUPPORTED);
+  int weight = network.connected == ConnectedType::DISCONNECTED ? 300 : 500;
+  ssid_label->setStyleSheet(QString(R"(
+    font-size: 55px;
+    font-weight: %1;
+    text-align: left;
+    border: none;
+    padding-top: 50px;
+    padding-bottom: 50px;
+  )").arg(weight));
+  QObject::connect(ssid_label, &QPushButton::clicked, this, [=]() { emit connectToNetwork(network); });
+  hlayout->addWidget(ssid_label, network.connected == ConnectedType::CONNECTING ? 0 : 1);
+
+  if (network.connected == ConnectedType::CONNECTING) {
+    QPushButton *connecting = new QPushButton("CONNECTING...");
+    connecting->setStyleSheet(R"(
+      font-size: 32px;
+      font-weight: 600;
+      color: white;
+      border-radius: 0;
+      padding: 27px;
+      padding-left: 43px;
+      padding-right: 43px;
+      background-color: black;
+    )");
+    hlayout->addWidget(connecting, 2, Qt::AlignLeft);
   }
 
-  // add networks
+  // Forget button
+  if (wifi->isKnownConnection(network.ssid) && !wifi->isTetheringEnabled()) {
+    QPushButton *forgetBtn = new QPushButton("FORGET");
+    forgetBtn->setObjectName("forgetBtn");
+    QObject::connect(forgetBtn, &QPushButton::clicked, [=]() {
+      if (ConfirmationDialog::confirm("Forget WiFi Network \"" + QString::fromUtf8(network.ssid) + "\"?", this)) {
+        wifi->forgetConnection(network.ssid);
+      }
+    });
+    hlayout->addWidget(forgetBtn, 0, Qt::AlignRight);
+  }
+
+  // Status icon
+  if (network.connected == ConnectedType::CONNECTED) {
+    QLabel *connectIcon = new QLabel();
+    connectIcon->setPixmap(checkmark);
+    hlayout->addWidget(connectIcon, 0, Qt::AlignRight);
+  } else if (network.security_type == SecurityType::WPA) {
+    QLabel *lockIcon = new QLabel();
+    lockIcon->setPixmap(lock);
+    hlayout->addWidget(lockIcon, 0, Qt::AlignRight);
+  } else {
+    hlayout->addSpacing(lock.width() + hlayout->spacing());
+  }
+
+  // Strength indicator
+  QLabel *strength = new QLabel();
+  strength->setPixmap(strengths[std::clamp((int)network.strength/26, 0, 3)]);
+  hlayout->addWidget(strength, 0, Qt::AlignRight);
+  return hlayout;
+}
+
+void WifiUI::refresh() {
+  // TODO: don't rebuild this every time
+//  clearLayout(main_layout);
+
+
+  // Update or delete all drawn networks by checking seenNetworks
+  if (idx > 2) wifi->seenNetworks.remove("SHANE-EPC");
+  idx++;
   int i = 0;
-  for (Network &network : wifi->seenNetworks) {
-    QHBoxLayout *hlayout = new QHBoxLayout;
-    hlayout->setContentsMargins(44, 0, 73, 0);
-    hlayout->setSpacing(50);
+  while (i < main_layout->count()) {
+    const QString &networkSsid = main_layout->itemAt(i)->layout()->objectName();
+    if (!networkSsid.isEmpty()) {
+      if (!wifi->seenNetworks.contains(networkSsid)) {
+        qDebug() << "DELETING:" << networkSsid;
+        QLayoutItem *item = main_layout->takeAt(i);
+        QHBoxLayout *hlayout = qobject_cast<QHBoxLayout*>(item->layout());
+        clearLayout(hlayout);
 
-    // Clickable SSID label
-    QPushButton *ssid_label = new QPushButton(network.ssid);
-    ssid_label->setEnabled(network.connected != ConnectedType::CONNECTED &&
-                           network.connected != ConnectedType::CONNECTING &&
-                           network.security_type != SecurityType::UNSUPPORTED);
-    int weight = network.connected == ConnectedType::DISCONNECTED ? 300 : 500;
-    ssid_label->setStyleSheet(QString(R"(
-      font-size: 55px;
-      font-weight: %1;
-      text-align: left;
-      border: none;
-      padding-top: 50px;
-      padding-bottom: 50px;
-    )").arg(weight));
-    QObject::connect(ssid_label, &QPushButton::clicked, this, [=]() { emit connectToNetwork(network); });
-    hlayout->addWidget(ssid_label, network.connected == ConnectedType::CONNECTING ? 0 : 1);
-
-    if (network.connected == ConnectedType::CONNECTING) {
-      QPushButton *connecting = new QPushButton("CONNECTING...");
-      connecting->setStyleSheet(R"(
-        font-size: 32px;
-        font-weight: 600;
-        color: white;
-        border-radius: 0;
-        padding: 27px;
-        padding-left: 43px;
-        padding-right: 43px;
-        background-color: black;
-      )");
-      hlayout->addWidget(connecting, 2, Qt::AlignLeft);
-    }
-
-    // Forget button
-    if (wifi->isKnownConnection(network.ssid) && !wifi->isTetheringEnabled()) {
-      QPushButton *forgetBtn = new QPushButton("FORGET");
-      forgetBtn->setObjectName("forgetBtn");
-      QObject::connect(forgetBtn, &QPushButton::clicked, [=]() {
-        if (ConfirmationDialog::confirm("Forget WiFi Network \"" + QString::fromUtf8(network.ssid) + "\"?", this)) {
-          wifi->forgetConnection(network.ssid);
-        }
-      });
-      hlayout->addWidget(forgetBtn, 0, Qt::AlignRight);
-    }
-
-    // Status icon
-    if (network.connected == ConnectedType::CONNECTED) {
-      QLabel *connectIcon = new QLabel();
-      connectIcon->setPixmap(checkmark);
-      hlayout->addWidget(connectIcon, 0, Qt::AlignRight);
-    } else if (network.security_type == SecurityType::WPA) {
-      QLabel *lockIcon = new QLabel();
-      lockIcon->setPixmap(lock);
-      hlayout->addWidget(lockIcon, 0, Qt::AlignRight);
-    } else {
-      hlayout->addSpacing(lock.width() + hlayout->spacing());
-    }
-
-    // Strength indicator
-    QLabel *strength = new QLabel();
-    strength->setPixmap(strengths[std::clamp((int)network.strength/26, 0, 3)]);
-    hlayout->addWidget(strength, 0, Qt::AlignRight);
-
-    main_layout->addLayout(hlayout, 1);
-
-    // Don't add the last horizontal line
-    if (i+1 < wifi->seenNetworks.size()) {
-      main_layout->addWidget(horizontal_line(), 0);
+        delete item;
+        i--;
+      } else {
+        qDebug() << "UPDATING:" << networkSsid;
+      }
     }
     i++;
   }
-  main_layout->addStretch(2);
+
+  if (wifi->seenNetworks.size() == 0) {
+//    QLabel *scanning = new QLabel("Scanning for networks...");
+//    scanning->setStyleSheet("font-size: 65px;");
+//    main_layout->addWidget(scanning, 0, Qt::AlignCenter);
+    return;
+  }
+
+  QVector<QString> objectNames;  // ssids already added to main_layout
+  for (int i = 0; i < main_layout->count(); i++) {
+    objectNames.push_back(main_layout->itemAt(i)->layout()->objectName());
+  }
+
+  // add networks
+  i = 0;
+  for (Network &network : wifi->seenNetworks) {
+    if (!objectNames.contains(network.ssid)) {
+      QHBoxLayout *hlayout = buildNetworkWidget(network);
+      main_layout->addLayout(hlayout, 1);
+      qDebug() << network.ssid << "is not in drawn networks, add it!";
+
+//    } else {
+//      // update: strength, connecting, connected (security type also?)
+    }
+
+    // Don't add the last horizontal line
+    if (i+1 < wifi->seenNetworks.size()) {
+//      main_layout->addWidget(horizontal_line(), 0);
+    }
+    i++;
+  }
+  qDebug() << "-------";
+//  main_layout->addStretch(2);
 }

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -20,6 +20,7 @@ private:
   WifiManager *wifi = nullptr;
   QVBoxLayout* main_layout;
   QHBoxLayout* buildNetworkWidget(const Network &network);
+  void updateNetworkWidget(QHBoxLayout *hlayout, const Network &network);
   QPixmap lock;
   QPixmap checkmark;
   QVector<QPixmap> strengths;

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -24,6 +24,7 @@ private:
   QVector<QPixmap> strengths;
 
   QHBoxLayout* buildNetworkWidget(const Network &network, bool isTetheringEnabled);
+  QVector<QString> drawnSsids();
   void updateNetworkWidget(QHBoxLayout *hlayout, const Network &network, bool isTetheringEnabled);
   void updateSsidLabel(QPushButton *ssidLabel, const Network &network);
   void updateStatusIcon(QLabel *statusIcon, const Network &network);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -21,6 +21,8 @@ private:
   QVBoxLayout* main_layout;
   QHBoxLayout* buildNetworkWidget(const Network &network);
   void updateNetworkWidget(QHBoxLayout *hlayout, const Network &network);
+  void updateSsidLabel(QPushButton *ssid_label, const Network &network);
+  void updateStatusIcon(QLabel *statusIcon, const Network &network);
   QPixmap lock;
   QPixmap checkmark;
   QVector<QPixmap> strengths;

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -19,9 +19,11 @@ public:
 private:
   WifiManager *wifi = nullptr;
   QVBoxLayout* main_layout;
+  QHBoxLayout* buildNetworkWidget(const Network &network);
   QPixmap lock;
   QPixmap checkmark;
   QVector<QPixmap> strengths;
+  int idx = 0;
 
 signals:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -19,14 +19,14 @@ public:
 private:
   WifiManager *wifi = nullptr;
   QVBoxLayout* main_layout;
+  QPixmap lock;
+  QPixmap checkmark;
+  QVector<QPixmap> strengths;
+
   QHBoxLayout* buildNetworkWidget(const Network &network, bool isTetheringEnabled);
   void updateNetworkWidget(QHBoxLayout *hlayout, const Network &network, bool isTetheringEnabled);
   void updateSsidLabel(QPushButton *ssidLabel, const Network &network);
   void updateStatusIcon(QLabel *statusIcon, const Network &network);
-  QPixmap lock;
-  QPixmap checkmark;
-  QVector<QPixmap> strengths;
-  int idx = 0;
 
 signals:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -19,9 +19,9 @@ public:
 private:
   WifiManager *wifi = nullptr;
   QVBoxLayout* main_layout;
-  QHBoxLayout* buildNetworkWidget(const Network &network);
-  void updateNetworkWidget(QHBoxLayout *hlayout, const Network &network);
-  void updateSsidLabel(QPushButton *ssid_label, const Network &network);
+  QHBoxLayout* buildNetworkWidget(const Network &network, bool isTetheringEnabled);
+  void updateNetworkWidget(QHBoxLayout *hlayout, const Network &network, bool isTetheringEnabled);
+  void updateSsidLabel(QPushButton *ssidLabel, const Network &network);
   void updateStatusIcon(QLabel *statusIcon, const Network &network);
   QPixmap lock;
   QPixmap checkmark;

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -78,8 +78,7 @@ void WifiManager::refreshNetworks() {
   if (adapter.isEmpty()) {
     return;
   }
-  seen_networks.clear();
-  seen_ssids.clear();
+  seenNetworks.clear();
   ipv4_address = get_ipv4_address();
 
   QDBusInterface nm(NM_DBUS_SERVICE, adapter, NM_DBUS_INTERFACE_DEVICE_WIRELESS, bus);
@@ -88,7 +87,7 @@ void WifiManager::refreshNetworks() {
   const QDBusReply<QList<QDBusObjectPath>> &response = nm.call("GetAllAccessPoints");
   for (const QDBusObjectPath &path : response.value()) {
     QByteArray ssid = get_property(path.path(), "Ssid");
-    if (ssid.isEmpty() || seen_ssids.contains(ssid)) {
+    if (ssid.isEmpty() || seenNetworks.contains(ssid)) {
       continue;
     }
     unsigned int strength = get_ap_strength(path.path());
@@ -104,10 +103,8 @@ void WifiManager::refreshNetworks() {
       }
     }
     Network network = {path.path(), ssid, strength, ctype, security};
-    seen_ssids.push_back(ssid);
-    seen_networks.push_back(network);
+    seenNetworks[ssid] = network;
   }
-  std::sort(seen_networks.begin(), seen_networks.end(), compare_by_strength);
 }
 
 QString WifiManager::get_ipv4_address() {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -20,14 +20,6 @@ T get_response(QDBusMessage response) {
   }
 }
 
-bool compare_by_strength(const Network &a, const Network &b) {
-  if (a.connected == ConnectedType::CONNECTED) return true;
-  if (b.connected == ConnectedType::CONNECTED) return false;
-  if (a.connected == ConnectedType::CONNECTING) return true;
-  if (b.connected == ConnectedType::CONNECTING) return false;
-  return a.strength > b.strength;
-}
-
 WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   qDBusRegisterMetaType<Connection>();
   qDBusRegisterMetaType<IpConfig>();

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -34,7 +34,7 @@ public:
   explicit WifiManager(QWidget* parent);
 
   void requestScan();
-  QVector<Network> seen_networks;
+  QMap<QString, Network> seenNetworks;
   QMap<QDBusObjectPath, QString> knownConnections;
   QString ipv4_address;
 
@@ -56,7 +56,6 @@ public:
   QString getTetheringPassword();
 
 private:
-  QVector<QByteArray> seen_ssids;
   QString adapter;  // Path to network manager wifi-device
   QDBusConnection bus = QDBusConnection::systemBus();
   unsigned int raw_adapter_state;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState


### PR DESCRIPTION
Doesn't fully clear layout so you can scroll while it's updating (previously you had to release the screen if it updated).

Previous times:
```
Took 3.89342 ms to draw 15 networks - 0.259562 ms/network
Took 4.17598 ms to draw 15 networks - 0.278399 ms/network
Took 3.18949 ms to draw 17 networks - 0.187617 ms/network
Took 4.54225 ms to draw 20 networks - 0.227113 ms/network
```
New times:
```
Took 0.523483 ms to draw 19 networks - 0.0275517 ms/network
Took 0.667017 ms to draw 20 networks - 0.0333509 ms/network
Took 0.540173 ms to draw 20 networks - 0.0270087 ms/network
Took 0.533784 ms to draw 20 networks - 0.0266892 ms/network
```

- [ ] Do sorting