### PR TITLE
networking: fix connected type for multiple APs

### DIFF
--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -94,6 +94,7 @@ void WifiManager::refreshNetworks() {
     unsigned int strength = get_ap_strength(path.path());
     SecurityType security = getSecurityType(path.path());
     ConnectedType ctype;
+    QString activeSsid = (activeAp != "" && activeAp != "/") ? get_property(activeAp, "Ssid") : "";
     if (ssid != activeSsid) {
       ctype = ConnectedType::DISCONNECTED;
     } else {
@@ -327,7 +328,6 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
   } else if (interface == NM_DBUS_INTERFACE_DEVICE_WIRELESS && props.contains("ActiveAccessPoint")) {
     const QDBusObjectPath &path = props.value("ActiveAccessPoint").value<QDBusObjectPath>();
     activeAp = path.path();
-    activeSsid = get_property(activeAp, "Ssid");
   }
 }
 
@@ -351,7 +351,7 @@ void WifiManager::newConnection(const QDBusObjectPath &path) {
 
 void WifiManager::disconnect() {
   if (activeAp != "" && activeAp != "/") {
-    deactivateConnection(activeSsid);
+    deactivateConnection(get_property(activeAp, "Ssid"));
   }
 }
 
@@ -441,12 +441,12 @@ void WifiManager::initActiveAp() {
 
   const QDBusMessage &response = device_props.call("Get", NM_DBUS_INTERFACE_DEVICE_WIRELESS, "ActiveAccessPoint");
   activeAp = get_response<QDBusObjectPath>(response).path();
-  activeSsid = get_property(activeAp, "Ssid");
 }
+
 
 bool WifiManager::isTetheringEnabled() {
   if (activeAp != "" && activeAp != "/") {
-    return activeSsid == tethering_ssid;
+    return get_property(activeAp, "Ssid") == tethering_ssid;
   }
   return false;
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -94,7 +94,7 @@ void WifiManager::refreshNetworks() {
     unsigned int strength = get_ap_strength(path.path());
     SecurityType security = getSecurityType(path.path());
     ConnectedType ctype;
-    if (path.path() != activeAp) {
+    if (ssid != activeSsid) {
       ctype = ConnectedType::DISCONNECTED;
     } else {
       if (ssid == connecting_to_network) {
@@ -327,6 +327,7 @@ void WifiManager::propertyChange(const QString &interface, const QVariantMap &pr
   } else if (interface == NM_DBUS_INTERFACE_DEVICE_WIRELESS && props.contains("ActiveAccessPoint")) {
     const QDBusObjectPath &path = props.value("ActiveAccessPoint").value<QDBusObjectPath>();
     activeAp = path.path();
+    activeSsid = get_property(activeAp, "Ssid");
   }
 }
 
@@ -350,7 +351,7 @@ void WifiManager::newConnection(const QDBusObjectPath &path) {
 
 void WifiManager::disconnect() {
   if (activeAp != "" && activeAp != "/") {
-    deactivateConnection(get_property(activeAp, "Ssid"));
+    deactivateConnection(activeSsid);
   }
 }
 
@@ -440,12 +441,12 @@ void WifiManager::initActiveAp() {
 
   const QDBusMessage &response = device_props.call("Get", NM_DBUS_INTERFACE_DEVICE_WIRELESS, "ActiveAccessPoint");
   activeAp = get_response<QDBusObjectPath>(response).path();
+  activeSsid = get_property(activeAp, "Ssid");
 }
-
 
 bool WifiManager::isTetheringEnabled() {
   if (activeAp != "" && activeAp != "/") {
-    return get_property(activeAp, "Ssid") == tethering_ssid;
+    return activeSsid == tethering_ssid;
   }
   return false;
 }

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -70,6 +70,7 @@ private:
   QString get_ipv4_address();
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString activeAp;
+  QString activeSsid;
   void initActiveAp();
   void deactivateConnection(const QString &ssid);
   QVector<QDBusObjectPath> get_active_connections();

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -70,7 +70,6 @@ private:
   QString get_ipv4_address();
   void connect(const QByteArray &ssid, const QString &username, const QString &password, SecurityType security_type);
   QString activeAp;
-  QString activeSsid;
   void initActiveAp();
   void deactivateConnection(const QString &ssid);
   QVector<QDBusObjectPath> get_active_connections();


### PR DESCRIPTION
NetworkManager uses ssids to connect and disconnect so it can switch between APs, but `wifiManager` was checking for the path/specific AP.

For future PR: 
- [x] Update the strength of the saved `seenNetwork` if the duplicate ssid AP has a higher one, so it shows correctly in UI.