### PR TITLE
HomeWindow: cleanup mousePressEvent

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -69,18 +69,7 @@ void HomeWindow::showDriverView(bool show) {
 void HomeWindow::mousePressEvent(QMouseEvent* e) {
   // Handle sidebar collapsing
   if (onroad->isVisible()) {
-
-    // TODO: Handle this without exposing pointer to map widget
-    // Hide map first if visible, then hide sidebar
-    if (onroad->map != nullptr && onroad->map->isVisible()) {
-      onroad->map->setVisible(false);
-    } else if (!sidebar->isVisible()) {
-      sidebar->setVisible(true);
-    } else {
-      sidebar->setVisible(false);
-
-      if (onroad->map != nullptr) onroad->map->setVisible(true);
-    }
+    sidebar->setVisible(!sidebar->isVisible() && !onroad->isMapVisible());
   }
 }
 

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -68,7 +68,7 @@ void HomeWindow::showDriverView(bool show) {
 
 void HomeWindow::mousePressEvent(QMouseEvent* e) {
   // Handle sidebar collapsing
-  if (onroad->isVisible() && (!sidebar->isVisible() || e->x() > sidebar->width())) {
+  if (onroad->isVisible()) {
 
     // TODO: Handle this without exposing pointer to map widget
     // Hide map first if visible, then hide sidebar

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -69,6 +69,15 @@ void OnroadWindow::updateState(const UIState &s) {
   }
 }
 
+void OnroadWindow::mousePressEvent(QMouseEvent* e) {
+  if (map != nullptr) {
+    bool sidebarVisible = geometry().x() > 0;
+    map->setVisible(!sidebarVisible && !map->isVisible());
+  }
+  // propagation event to parent(HomeWindow)
+  QWidget::mousePressEvent(e);
+}
+
 void OnroadWindow::offroadTransition(bool offroad) {
 #ifdef ENABLE_MAPS
   if (!offroad) {

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -54,14 +54,16 @@ class OnroadWindow : public QWidget {
 
 public:
   OnroadWindow(QWidget* parent = 0);
-  QWidget *map = nullptr;
+  bool isMapVisible() const { return map && map->isVisible(); }
 
 private:
   void paintEvent(QPaintEvent *event);
-
+  void mousePressEvent(QMouseEvent* e) override;
   OnroadAlerts *alerts;
   NvgWindow *nvg;
   QColor bg = bg_colors[STATUS_DISENGAGED];
+  QWidget *map = nullptr;
+  QStackedLayout *main_layout;
   QHBoxLayout* split;
 
 signals:

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -63,7 +63,6 @@ private:
   NvgWindow *nvg;
   QColor bg = bg_colors[STATUS_DISENGAGED];
   QWidget *map = nullptr;
-  QStackedLayout *main_layout;
   QHBoxLayout* split;
 
 signals:


### PR DESCRIPTION
sidebar has its own mousePressEvent handler, this event will not be propagated to HomeWindow.so when  HomeWindow::mousePressEvent is called, e->x() must be in onroad.