### PR TITLE
networking: show correct strength for mesh networks

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -13,14 +13,6 @@
 #include "selfdrive/ui/qt/widgets/scrollview.h"
 
 
-bool compareByStrength(const Network &a, const Network &b) {
-  if (a.connected == ConnectedType::CONNECTED) return true;
-  if (b.connected == ConnectedType::CONNECTED) return false;
-  if (a.connected == ConnectedType::CONNECTING) return true;
-  if (b.connected == ConnectedType::CONNECTING) return false;
-  return a.strength > b.strength;
-}
-
 // Networking functions
 
 Networking::Networking(QWidget* parent, bool show_advanced) : QFrame(parent) {
@@ -219,7 +211,7 @@ void WifiUI::refresh() {
     return;
   }
   QList<Network> sortedNetworks = wifi->seenNetworks.values();
-  std::sort(sortedNetworks.begin(), sortedNetworks.end(), compareByStrength);
+  std::sort(sortedNetworks.begin(), sortedNetworks.end(), compare_by_strength);
 
   // add networks
   int i = 0;

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -13,6 +13,14 @@
 #include "selfdrive/ui/qt/widgets/scrollview.h"
 
 
+bool compareByStrength(const Network &a, const Network &b) {
+  if (a.connected == ConnectedType::CONNECTED) return true;
+  if (b.connected == ConnectedType::CONNECTED) return false;
+  if (a.connected == ConnectedType::CONNECTING) return true;
+  if (b.connected == ConnectedType::CONNECTING) return false;
+  return a.strength > b.strength;
+}
+
 // Networking functions
 
 Networking::Networking(QWidget* parent, bool show_advanced) : QFrame(parent) {
@@ -88,13 +96,11 @@ void Networking::connectToNetwork(const Network &n) {
 }
 
 void Networking::wrongPassword(const QString &ssid) {
-  for (Network n : wifi->seen_networks) {
-    if (n.ssid == ssid) {
-      QString pass = InputDialog::getText("Wrong password", this, "for \"" + n.ssid +"\"", true, 8);
-      if (!pass.isEmpty()) {
-        wifi->connect(n, pass);
-      }
-      return;
+  if (wifi->seenNetworks.contains(ssid)) {
+    const Network &n = wifi->seenNetworks.value(ssid);
+    QString pass = InputDialog::getText("Wrong password", this, "for \"" + n.ssid +"\"", true, 8);
+    if (!pass.isEmpty()) {
+      wifi->connect(n, pass);
     }
   }
 }
@@ -206,16 +212,18 @@ void WifiUI::refresh() {
   // TODO: don't rebuild this every time
   clearLayout(main_layout);
 
-  if (wifi->seen_networks.size() == 0) {
+  if (wifi->seenNetworks.size() == 0) {
     QLabel *scanning = new QLabel("Scanning for networks...");
     scanning->setStyleSheet("font-size: 65px;");
     main_layout->addWidget(scanning, 0, Qt::AlignCenter);
     return;
   }
+  QList<Network> sortedNetworks = wifi->seenNetworks.values();
+  std::sort(sortedNetworks.begin(), sortedNetworks.end(), compareByStrength);
 
   // add networks
   int i = 0;
-  for (Network &network : wifi->seen_networks) {
+  for (Network &network : sortedNetworks) {
     QHBoxLayout *hlayout = new QHBoxLayout;
     hlayout->setContentsMargins(44, 0, 73, 0);
     hlayout->setSpacing(50);
@@ -279,13 +287,13 @@ void WifiUI::refresh() {
 
     // Strength indicator
     QLabel *strength = new QLabel();
-    strength->setPixmap(strengths[std::clamp((int)network.strength/26, 0, 3)]);
+    strength->setPixmap(strengths[std::clamp((int)round(network.strength / 33.), 0, 3)]);
     hlayout->addWidget(strength, 0, Qt::AlignRight);
 
     main_layout->addLayout(hlayout);
 
     // Don't add the last horizontal line
-    if (i+1 < wifi->seen_networks.size()) {
+    if (i+1 < wifi->seenNetworks.size()) {
       main_layout->addWidget(horizontal_line(), 0);
     }
     i++;

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -20,6 +20,14 @@ T get_response(QDBusMessage response) {
   }
 }
 
+bool compare_by_strength(const Network &a, const Network &b) {
+  if (a.connected == ConnectedType::CONNECTED) return true;
+  if (b.connected == ConnectedType::CONNECTED) return false;
+  if (a.connected == ConnectedType::CONNECTING) return true;
+  if (b.connected == ConnectedType::CONNECTING) return false;
+  return a.strength > b.strength;
+}
+
 WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   qDBusRegisterMetaType<Connection>();
   qDBusRegisterMetaType<IpConfig>();

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -88,7 +88,8 @@ void WifiManager::refreshNetworks() {
   for (const QDBusObjectPath &path : response.value()) {
     const QByteArray &ssid = get_property(path.path(), "Ssid");
     unsigned int strength = get_ap_strength(path.path());
-    if (ssid.isEmpty() || (seenNetworks.contains(ssid) && strength <= seenNetworks.value(ssid).strength)) {
+    if (ssid.isEmpty() || (seenNetworks.contains(ssid) &&
+        strength <= seenNetworks.value(ssid).strength)) {
       continue;
     }
     SecurityType security = getSecurityType(path.path());

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -20,14 +20,6 @@ T get_response(QDBusMessage response) {
   }
 }
 
-bool compare_by_strength(const Network &a, const Network &b) {
-  if (a.connected == ConnectedType::CONNECTED) return true;
-  if (b.connected == ConnectedType::CONNECTED) return false;
-  if (a.connected == ConnectedType::CONNECTING) return true;
-  if (b.connected == ConnectedType::CONNECTING) return false;
-  return a.strength > b.strength;
-}
-
 WifiManager::WifiManager(QWidget* parent) : QWidget(parent) {
   qDBusRegisterMetaType<Connection>();
   qDBusRegisterMetaType<IpConfig>();
@@ -78,8 +70,7 @@ void WifiManager::refreshNetworks() {
   if (adapter.isEmpty()) {
     return;
   }
-  seen_networks.clear();
-  seen_ssids.clear();
+  seenNetworks.clear();
   ipv4_address = get_ipv4_address();
 
   QDBusInterface nm(NM_DBUS_SERVICE, adapter, NM_DBUS_INTERFACE_DEVICE_WIRELESS, bus);
@@ -87,11 +78,11 @@ void WifiManager::refreshNetworks() {
 
   const QDBusReply<QList<QDBusObjectPath>> &response = nm.call("GetAllAccessPoints");
   for (const QDBusObjectPath &path : response.value()) {
-    QByteArray ssid = get_property(path.path(), "Ssid");
-    if (ssid.isEmpty() || seen_ssids.contains(ssid)) {
+    const QByteArray &ssid = get_property(path.path(), "Ssid");
+    unsigned int strength = get_ap_strength(path.path());
+    if (ssid.isEmpty() || (seenNetworks.contains(ssid) && strength <= seenNetworks.value(ssid).strength)) {
       continue;
     }
-    unsigned int strength = get_ap_strength(path.path());
     SecurityType security = getSecurityType(path.path());
     ConnectedType ctype;
     QString activeSsid = (activeAp != "" && activeAp != "/") ? get_property(activeAp, "Ssid") : "";
@@ -104,11 +95,9 @@ void WifiManager::refreshNetworks() {
         ctype = ConnectedType::CONNECTED;
       }
     }
-    Network network = {path.path(), ssid, strength, ctype, security};
-    seen_ssids.push_back(ssid);
-    seen_networks.push_back(network);
+    Network network = {ssid, strength, ctype, security};
+    seenNetworks[ssid] = network;
   }
-  std::sort(seen_networks.begin(), seen_networks.end(), compare_by_strength);
 }
 
 QString WifiManager::get_ipv4_address() {

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -25,6 +25,7 @@ struct Network {
   ConnectedType connected;
   SecurityType security_type;
 };
+bool compare_by_strength(const Network &a, const Network &b);
 
 class WifiManager : public QWidget {
   Q_OBJECT

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -20,7 +20,6 @@ typedef QMap<QString, QMap<QString, QVariant>> Connection;
 typedef QVector<QMap<QString, QVariant>> IpConfig;
 
 struct Network {
-  QString path;
   QByteArray ssid;
   unsigned int strength;
   ConnectedType connected;
@@ -34,7 +33,7 @@ public:
   explicit WifiManager(QWidget* parent);
 
   void requestScan();
-  QVector<Network> seen_networks;
+  QMap<QString, Network> seenNetworks;
   QMap<QDBusObjectPath, QString> knownConnections;
   QString ipv4_address;
 
@@ -56,7 +55,6 @@ public:
   QString getTetheringPassword();
 
 private:
-  QVector<QByteArray> seen_ssids;
   QString adapter;  // Path to network manager wifi-device
   QDBusConnection bus = QDBusConnection::systemBus();
   unsigned int raw_adapter_state;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState


### PR DESCRIPTION
`wifiManager.cc` only uses the first seen AP, which isn't always the strongest. In this case,  that network name will be at the bottom of the list showing very little strength.