### PR TITLE
networking: reuse drawn layouts

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -257,9 +257,7 @@ QHBoxLayout* WifiUI::emptyNetworkLayout() {  // TODO: try setting the ssid label
   return hlayout;
 }
 
-QVBoxLayout* WifiUI::updateNetworkLayout(QVBoxLayout *vlayout, const Network &network, bool tethering) {
-  QHBoxLayout *hlayout = qobject_cast<QHBoxLayout*>(vlayout->itemAt(0)->layout());
-
+QHBoxLayout* WifiUI::updateNetworkLayout(QHBoxLayout *hlayout, const Network &network, bool tethering) {
   // Clickable SSID label
   QPushButton *ssidLabel = qobject_cast<QPushButton*>(hlayout->itemAt(0)->widget());
   ssidLabel->setText(network.ssid);
@@ -297,7 +295,7 @@ QVBoxLayout* WifiUI::updateNetworkLayout(QVBoxLayout *vlayout, const Network &ne
   // Strength indicator
   QLabel *strength = qobject_cast<QLabel*>(hlayout->itemAt(4)->widget());
   strength->setPixmap(strengths[std::clamp((int)network.strength/26, 0, 3)]);
-  return vlayout;
+  return hlayout;
 }
 
 void WifiUI::refresh() {
@@ -311,14 +309,13 @@ void WifiUI::refresh() {
     QVBoxLayout *vlayout;
     if (i < networks_layout->count() - 1) {  // replace current network layout
       vlayout = qobject_cast<QVBoxLayout*>(networks_layout->itemAt(i)->layout());
-      updateNetworkLayout(vlayout, network, tethering);
+      QHBoxLayout *hlayout = qobject_cast<QHBoxLayout*>(vlayout->itemAt(0)->layout());
+      updateNetworkLayout(hlayout, network, tethering);
     } else {  // add new one
       vlayout = new QVBoxLayout;
-      vlayout->addLayout(emptyNetworkLayout());
+      vlayout->addLayout(updateNetworkLayout(emptyNetworkLayout(), network, tethering));
       vlayout->addWidget(horizontal_line(), 0);
-
       networks_layout->insertLayout(i, vlayout);
-      vlayout = updateNetworkLayout(vlayout, network, tethering);
     }
     vlayout->itemAt(1)->widget()->setVisible(i < wifi->seen_networks.size() - 1);  // hides last horizontal line
     i++;

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QButtonGroup>
 #include <QHBoxLayout>
 #include <QStackedWidget>
 #include <QVBoxLayout>
@@ -23,8 +24,8 @@ private:
   QPixmap checkmark;
   QVector<QPixmap> strengths;
 
-  QVBoxLayout* updateNetworkWidget(QVBoxLayout *vlayout, const Network &network, bool isTetheringEnabled);
-  QHBoxLayout* emptyWifiWidget();
+  QVBoxLayout* updateNetworkLayout(QVBoxLayout *vlayout, const Network &network, bool tethering);
+  QHBoxLayout* emptyNetworkLayout();
 
 signals:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QButtonGroup>
-#include <QMovie>
+#include <QHBoxLayout>
+#include <QStackedWidget>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -10,7 +10,7 @@
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
 
-class WifiUI : public QWidget {
+class WifiUI : public QStackedWidget {
   Q_OBJECT
 
 public:
@@ -18,10 +18,13 @@ public:
 
 private:
   WifiManager *wifi = nullptr;
-  QVBoxLayout* main_layout;
+  QVBoxLayout* networks_layout;
   QPixmap lock;
   QPixmap checkmark;
   QVector<QPixmap> strengths;
+
+  QVBoxLayout* updateNetworkWidget(QVBoxLayout *vlayout, const Network &network, bool isTetheringEnabled);
+  QHBoxLayout* emptyWifiWidget();
 
 signals:
   void connectToNetwork(const Network &n);

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -24,7 +24,7 @@ private:
   QPixmap checkmark;
   QVector<QPixmap> strengths;
 
-  QVBoxLayout* updateNetworkLayout(QVBoxLayout *vlayout, const Network &network, bool tethering);
+  QHBoxLayout* updateNetworkLayout(QHBoxLayout *hlayout, const Network &network, bool tethering);
   QHBoxLayout* emptyNetworkLayout();
 
 signals:

--- a/selfdrive/ui/qt/setup/setup.h
+++ b/selfdrive/ui/qt/setup/setup.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QButtonGroup>
 #include <QStackedWidget>
 #include <QString>
 #include <QWidget>

--- a/selfdrive/ui/qt/setup/setup.h
+++ b/selfdrive/ui/qt/setup/setup.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QButtonGroup>
 #include <QStackedWidget>
 #include <QString>
 #include <QWidget>


### PR DESCRIPTION
Iterates through `seen_networks` and checks if there's already an `hlayout` at that index to update with the new network's info. If not, add it. If networks are removed from `seen_networks`, the loop after the first removes extra layouts. This is all so that we don't lose focus while scrolling, since every widget is removed and re-added.

- [x] Horizontal lines
- [x] Layout design is the same
- [x] Can scroll while updating
- [x] Fix Scanning widget
- [ ] fix stuttering when adding many network layouts