### PR TITLE
implement display power

### DIFF
--- a/selfdrive/hardware/tici/hardware.h
+++ b/selfdrive/hardware/tici/hardware.h
@@ -28,7 +28,7 @@ public:
   static void set_display_power(bool on) {
     std::ofstream bl_power_control("/sys/class/backlight/panel0-backlight/bl_power");
     if (bl_power_control.is_open()) {
-      bl_power_control << (on ? "0" : "1") << "\n";
+      bl_power_control << (on ? "0" : "4") << "\n";
       bl_power_control.close();
     }
   };

--- a/selfdrive/hardware/tici/hardware.h
+++ b/selfdrive/hardware/tici/hardware.h
@@ -25,7 +25,13 @@ public:
       brightness_control.close();
     }
   };
-  static void set_display_power(bool on) {};
+  static void set_display_power(bool on) {
+    std::ofstream bl_power_control("/sys/class/backlight/panel0-backlight/bl_power");
+    if (bl_power_control.is_open()) {
+      bl_power_control << (on ? "0" : "1") << "\n";
+      bl_power_control.close();
+    }
+  };
 
   static bool get_ssh_enabled() { return Params().getBool("SshEnabled"); };
   static void set_ssh_enabled(bool enabled) { Params().putBool("SshEnabled", enabled); };


### PR DESCRIPTION
no permissions. Can also set display brightness, and default to 65 when `on` but it may flicker if the brightness filter isn't 65 at that time