### PR TITLE
ui: elided button

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -243,12 +243,12 @@ void WifiUI::refresh() {
     hlayout->setSpacing(50);
 
     // Clickable SSID label
-    QPushButton *ssidLabel = new QPushButton(network.ssid);
+    ElidedButton *ssidLabel = new ElidedButton(network.ssid);
     ssidLabel->setObjectName("ssidLabel");
     ssidLabel->setEnabled(network.connected == ConnectedType::DISCONNECTED &&
                           network.security_type != SecurityType::UNSUPPORTED);
     ssidLabel->setProperty("disconnected", network.connected == ConnectedType::DISCONNECTED);
-    QObject::connect(ssidLabel, &QPushButton::clicked, this, [=]() { emit connectToNetwork(network); });
+    QObject::connect(ssidLabel, &ElidedButton::clicked, this, [=]() { emit connectToNetwork(network); });
     hlayout->addWidget(ssidLabel, network.connected == ConnectedType::CONNECTING ? 0 : 1);
 
     if (network.connected == ConnectedType::CONNECTING) {

--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -87,6 +87,33 @@ ButtonControl::ButtonControl(const QString &title, const QString &text, const QS
   hlayout->addWidget(&btn);
 }
 
+// ElidedButton
+
+ElidedButton::ElidedButton(QWidget *parent) : ElidedButton({}, parent) {}
+
+ElidedButton::ElidedButton(const QString &text, QWidget *parent) : QPushButton(text.trimmed(), parent) {
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+  setMinimumWidth(1);
+}
+
+void ElidedButton::resizeEvent(QResizeEvent* event) {
+  QPushButton::resizeEvent(event);
+  lastText_ = elidedText_ = "";
+}
+
+void ElidedButton::paintEvent(QPaintEvent *event) {
+  const QString curText = text();
+  if (curText != lastText_) {
+    elidedText_ = fontMetrics().elidedText(curText, Qt::ElideRight, contentsRect().width());
+    lastText_ = curText;
+  }
+
+  QPainter painter(this);
+  QStyleOption opt;
+  opt.initFrom(this);
+  style()->drawItemText(&painter, contentsRect(), Qt::AlignLeft | Qt::AlignVCenter, opt.palette, isEnabled(), elidedText_, foregroundRole());
+}
+
 // ElidedLabel
 
 ElidedLabel::ElidedLabel(QWidget *parent) : ElidedLabel({}, parent) {}

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -23,6 +23,19 @@ class ElidedLabel : public QLabel {
   QString lastText_, elidedText_;
 };
 
+class ElidedButton : public QPushButton {
+  Q_OBJECT
+
+ public:
+  explicit ElidedButton(QWidget *parent = 0);
+  explicit ElidedButton(const QString &text, QWidget *parent = 0);
+
+ protected:
+  void paintEvent(QPaintEvent *event) override;
+  void resizeEvent(QResizeEvent* event) override;
+  QString lastText_, elidedText_;
+};
+
 class AbstractControl : public QFrame {
   Q_OBJECT
 

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -10,12 +10,12 @@
 
 QFrame *horizontal_line(QWidget *parent = nullptr);
 
-class ElidedLabel : public QLabel {
+class ElidedButton : public QPushButton {
   Q_OBJECT
 
  public:
-  explicit ElidedLabel(QWidget *parent = 0);
-  explicit ElidedLabel(const QString &text, QWidget *parent = 0);
+  explicit ElidedButton(QWidget *parent = 0);
+  explicit ElidedButton(const QString &text, QWidget *parent = 0);
 
  protected:
   void paintEvent(QPaintEvent *event) override;
@@ -23,12 +23,12 @@ class ElidedLabel : public QLabel {
   QString lastText_, elidedText_;
 };
 
-class ElidedButton : public QPushButton {
+class ElidedLabel : public QLabel {
   Q_OBJECT
 
  public:
-  explicit ElidedButton(QWidget *parent = 0);
-  explicit ElidedButton(const QString &text, QWidget *parent = 0);
+  explicit ElidedLabel(QWidget *parent = 0);
+  explicit ElidedLabel(const QString &text, QWidget *parent = 0);
 
  protected:
   void paintEvent(QPaintEvent *event) override;


### PR DESCRIPTION
Converted the `ElidedLabel` from deanlee's #21277

Fixes ssid being cut off if too long (and connecting)

Code for Qt's ElidedLabel: https://doc.qt.io/qt-5/qtwidgets-widgets-elidedlabel-example.html

QObject classes don't support templates