### PR TITLE
nav: Send DELETE to clear next destination on server

### DIFF
--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -80,7 +80,7 @@ bool HttpRequest::active() {
   return reply != nullptr;
 }
 
-void HttpRequest::sendRequest(const QString &requestURL) {
+void HttpRequest::sendRequest(const QString &requestURL, const HttpRequest::Method method) {
   if (active()) {
     qDebug() << "HttpRequest is active";
     return;
@@ -98,7 +98,11 @@ void HttpRequest::sendRequest(const QString &requestURL) {
   request.setUrl(QUrl(requestURL));
   request.setRawHeader(QByteArray("Authorization"), ("JWT " + token).toUtf8());
 
-  reply = networkAccessManager->get(request);
+  if (method == HttpRequest::Method::GET) {
+    reply = networkAccessManager->get(request);
+  } else if (method == HttpRequest::Method::DELETE) {
+    reply = networkAccessManager->deleteResource(request);
+  }
 
   networkTimer->start();
   connect(reply, &QNetworkReply::finished, this, &HttpRequest::requestFinished);

--- a/selfdrive/ui/qt/api.h
+++ b/selfdrive/ui/qt/api.h
@@ -20,8 +20,10 @@ class HttpRequest : public QObject {
   Q_OBJECT
 
 public:
+  enum class Method {GET, DELETE};
+
   explicit HttpRequest(QObject* parent, bool create_jwt = true, int timeout = 20000);
-  void sendRequest(const QString &requestURL);
+  void sendRequest(const QString &requestURL, const Method method = Method::GET);
   bool active();
 
 protected:

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -105,10 +105,11 @@ MapPanel::MapPanel(QWidget* parent) : QWidget(parent) {
 
     // Destination set while offline
     {
-      std::string url = "https://api.commadotai.com/v1/navigation/" + dongle_id + "/next";
-      RequestRepeater* repeater = new RequestRepeater(this, QString::fromStdString(url), "", 10, true);
+      QString url = QString::fromStdString("https://api.commadotai.com/v1/navigation/" + dongle_id + "/next");
+      RequestRepeater* repeater = new RequestRepeater(this, url, "", 10, true);
+      HttpRequest* deleter = new HttpRequest(this);
 
-      QObject::connect(repeater, &RequestRepeater::receivedResponse, [](QString resp) {
+      QObject::connect(repeater, &RequestRepeater::receivedResponse, [=](QString resp) {
         auto params = Params();
         if (resp != "null") {
           if (params.get("NavDestination").empty()) {
@@ -117,6 +118,9 @@ MapPanel::MapPanel(QWidget* parent) : QWidget(parent) {
           } else {
             qWarning() << "Got location from /next, but NavDestination already set";
           }
+
+          // Send DELETE to clear destination server side
+          deleter->sendRequest(url, HttpRequest::Method::DELETE);
         }
       });
     }


### PR DESCRIPTION
This fixes a potential bug where the request for `/next` times out. In that case it might be deleted from the server but is never received by the device.