### PR TITLE
onboarding: set the Qt::WA_OpaquePaintEvent attribute

### DIFF
--- a/selfdrive/ui/qt/offroad/onboarding.cc
+++ b/selfdrive/ui/qt/offroad/onboarding.cc
@@ -11,6 +11,10 @@
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/input.h"
 
+TrainingGuide::TrainingGuide(QWidget *parent) : QFrame(parent) {
+  setAttribute(Qt::WA_OpaquePaintEvent);
+}
+
 void TrainingGuide::mouseReleaseEvent(QMouseEvent *e) {
   if (boundingRect[currentIndex].contains(e->x(), e->y())) {
     if (currentIndex == 9) {

--- a/selfdrive/ui/qt/offroad/onboarding.h
+++ b/selfdrive/ui/qt/offroad/onboarding.h
@@ -13,7 +13,7 @@ class TrainingGuide : public QFrame {
   Q_OBJECT
 
 public:
-  explicit TrainingGuide(QWidget *parent = 0) : QFrame(parent) {};
+  explicit TrainingGuide(QWidget *parent = 0);
 
 private:
   void showEvent(QShowEvent *event) override;


### PR DESCRIPTION
we don't need to erases the background before the paintEvent() call