### PR TITLE
ui: fix prime widget w/ no internet

### DIFF
--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -268,8 +268,10 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
 
 void SetupWidget::parseError(const QString &response) {
   show();
-  showQr = false;
-  mainLayout->setCurrentIndex(0);
+  if (mainLayout->currentIndex() == 1) {
+    showQr = false;
+    mainLayout->setCurrentIndex(0);
+  }
 }
 
 void SetupWidget::showQrCode() {


### PR DESCRIPTION
Caching was working and set the prime widget correctly on startup, but after `period` the API request returned unsuccessfully, calling `parseError` and setting the current widget back to the "unpaired" widget.

Now it only resets the current widget if we're showing the qr code (not paired or no cache).