### PR TITLE
Sidebar: set Qt::WA_OpaquePaintEvent attribute

### DIFF
--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -2,7 +2,6 @@
 
 #include <QMouseEvent>
 
-#include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/common/util.h"
 #include "selfdrive/hardware/hw.h"
 #include "selfdrive/ui/qt/util.h"
@@ -41,9 +40,9 @@ Sidebar::Sidebar(QWidget *parent) : QFrame(parent) {
 
   connect(this, &Sidebar::valueChanged, [=] { update(); });
 
+  setAttribute(Qt::WA_OpaquePaintEvent);
+  setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
   setFixedWidth(300);
-  setMinimumHeight(vwp_h);
-  setStyleSheet("background-color: rgb(57, 57, 57);");
 }
 
 void Sidebar::mouseReleaseEvent(QMouseEvent *event) {
@@ -102,6 +101,8 @@ void Sidebar::paintEvent(QPaintEvent *event) {
   QPainter p(this);
   p.setPen(Qt::NoPen);
   p.setRenderHint(QPainter::Antialiasing);
+
+  p.fillRect(rect(), QColor(57, 57, 57));
 
   // static imgs
   p.setOpacity(0.65);


### PR DESCRIPTION
paintEvent will be propagated to parents with a clipped rect(sidebar_width*sidebar_height), even if the setStyleSheet has been called to set background if we don't set WA_OpaquePaintEvent to true.