### PR TITLE
util: add new function create_directories with unit tests

### DIFF
--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -4,7 +4,6 @@
 #define _GNU_SOURCE
 #endif  // _GNU_SOURCE
 
-#include <dirent.h>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -41,27 +40,10 @@ int fsync_dir(const char* path) {
   return result;
 }
 
-int mkdir_p(std::string path) {
-  char * _path = (char *)path.c_str();
-
-  for (char *p = _path + 1; *p; p++) {
-    if (*p == '/') {
-      *p = '\0'; // Temporarily truncate
-      if (mkdir(_path, 0775) != 0) {
-        if (errno != EEXIST) return -1;
-      }
-      *p = '/';
-    }
-  }
-  if (mkdir(_path, 0775) != 0) {
-    if (errno != EEXIST) return -1;
-  }
-  return 0;
-}
 
 bool create_params_path(const std::string &param_path, const std::string &key_path) {
   // Make sure params path exists
-  if (!util::file_exists(param_path) && mkdir_p(param_path) != 0) {
+  if (!util::file_exists(param_path) && util::create_directories(param_path, 0777) != 0) {
     return false;
   }
 

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -4,6 +4,7 @@
 #define _GNU_SOURCE
 #endif  // _GNU_SOURCE
 
+#include <dirent.h>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -43,7 +44,7 @@ int fsync_dir(const char* path) {
 
 bool create_params_path(const std::string &param_path, const std::string &key_path) {
   // Make sure params path exists
-  if (!util::file_exists(param_path) && !util::create_directories(param_path, 0777)) {
+  if (!util::file_exists(param_path) && !util::create_directories(param_path, 0775)) {
     return false;
   }
 

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -43,7 +43,7 @@ int fsync_dir(const char* path) {
 
 bool create_params_path(const std::string &param_path, const std::string &key_path) {
   // Make sure params path exists
-  if (!util::file_exists(param_path) && util::create_directories(param_path, 0777) != 0) {
+  if (!util::file_exists(param_path) && !util::create_directories(param_path, 0777)) {
     return false;
   }
 

--- a/selfdrive/common/tests/test_util.cc
+++ b/selfdrive/common/tests/test_util.cc
@@ -116,11 +116,7 @@ TEST_CASE("util::create_directories") {
     REQUIRE(util::create_directories(dir + "/file/1/2/3", 0775) == false);
   }
   SECTION("end with slashs") {
-    // one slashs
     REQUIRE(util::create_directories(dir + "/", 0775));
-    // multiple slashs
-    REQUIRE(util::create_directories(dir + "///", 0775));
-    REQUIRE(check_dir_permissions(dir, 0775) == true);
   }
   SECTION("empty") {
     REQUIRE(util::create_directories("", 0775) == false);

--- a/selfdrive/common/tests/test_util.cc
+++ b/selfdrive/common/tests/test_util.cc
@@ -90,25 +90,39 @@ TEST_CASE("util::read_files_in_dir") {
   for (auto& [k, v] : result) {
     REQUIRE(k == v);
 TEST_CASE("util::create_directories") {
+  system("rm /tmp/test_create_directories -rf");
+  std::string dir = "/tmp/test_create_directories/a/b/c/d/e/f";
+
   auto check_dir_permissions = [](const std::string &dir, mode_t mode) -> bool {
     struct stat st = {};
     return stat(dir.c_str(), &st) == 0 && (st.st_mode & S_IFMT) == S_IFDIR && (st.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO)) == mode;
   };
-  system("rm /tmp/test_create_directories -rf");
-  std::string dir = "/tmp/test_create_directories/a/b/c/d/e/f";
 
-  SECTION("with umask") {
-    REQUIRE(util::create_directories(dir, 0777, true, true));
-    REQUIRE(check_dir_permissions(dir, 0777));
+  SECTION("create_directories") {
+    REQUIRE(util::create_directories(dir, 0775));
+    REQUIRE(check_dir_permissions(dir, 0775));
   }
-  SECTION("without umask") {
-    REQUIRE(util::create_directories(dir, 0777, true, false));
-    REQUIRE(check_dir_permissions(dir, 0777) == false);
-    mode_t mask = umask(0);
-    mode_t required = 0777;
-    required &=~mask;
-    REQUIRE(check_dir_permissions(dir, required) == true);
-    umask(mask);
+  SECTION("dir already exists") {
+    REQUIRE(util::create_directories(dir, 0775));
+    REQUIRE(util::create_directories(dir, 0775));
+  }
+  SECTION("a file exists with the same name") {
+    REQUIRE(util::create_directories(dir, 0775));
+    int f = open((dir + "/file").c_str(), O_RDWR | O_CREAT);
+    REQUIRE(f != -1);
+    close(f);
+    REQUIRE(util::create_directories(dir + "/file", 0775) == false);
+    REQUIRE(util::create_directories(dir + "/file/1/2/3", 0775) == false);
+  }
+  SECTION("end with slashs") {
+    // one slashs
+    REQUIRE(util::create_directories(dir + "/", 0775, true));
+    // multiple slashs
+    REQUIRE(util::create_directories(dir + "///", 0775, true));
+    REQUIRE(check_dir_permissions(dir, 0775) == true);
+  }
+  SECTION("empty") {
+    REQUIRE(util::create_directories("", 0775, true) == false);
   }
   SECTION("reset permissions") {
     REQUIRE(util::create_directories(dir, 0775));
@@ -116,33 +130,11 @@ TEST_CASE("util::create_directories") {
 
     // don't reset permissions
     REQUIRE(util::create_directories(dir, 0666, false));
+    REQUIRE(check_dir_permissions(dir, 0666) == false);
     REQUIRE(check_dir_permissions(dir, 0775) == true);
     // reset permissions
     REQUIRE(util::create_directories(dir, 0666, true));
     REQUIRE(check_dir_permissions(dir, 0666) == true);
   }
-  SECTION("dir already exists") {
-    REQUIRE(util::create_directories(dir, 0777));
-    REQUIRE(util::create_directories(dir, 0777));
-  }
-  SECTION("a file exists with the same name") {
-    REQUIRE(util::create_directories(dir, 0777));
-    int f = open((dir + "/file").c_str(), O_RDWR | O_CREAT);
-    REQUIRE(f != -1);
-    close(f);
-    REQUIRE(util::create_directories(dir + "/file", 0777) == false);
-    REQUIRE(util::create_directories(dir + "/file/1/2/3", 0777) == false);
-  }
-  SECTION("end with slashs") {
-    // one slashs
-    REQUIRE(util::create_directories(dir + "/", 0777, true));
-    REQUIRE(check_dir_permissions(dir, 0777) == true);
-    // multiple slashs
-    REQUIRE(util::create_directories(dir + "///", 0777, true));
-    REQUIRE(check_dir_permissions(dir, 0777) == true);
-  }
-  SECTION("empty") {
-    bool ret = util::create_directories("", 0777, true);
-    REQUIRE(ret == false);
-  }
+  
 }

--- a/selfdrive/common/tests/test_util.cc
+++ b/selfdrive/common/tests/test_util.cc
@@ -104,7 +104,11 @@ TEST_CASE("util::create_directories") {
   SECTION("without umask") {
     REQUIRE(util::create_directories(dir, 0777, true, false));
     REQUIRE(check_dir_permissions(dir, 0777) == false);
-    REQUIRE(check_dir_permissions(dir, 0775) == true);
+    mode_t mask = umask(0);
+    mode_t required = 0777;
+    required &=~mask;
+    REQUIRE(check_dir_permissions(dir, required) == true);
+    umask(mask);
   }
   SECTION("reset permissions") {
     REQUIRE(util::create_directories(dir, 0775));

--- a/selfdrive/common/tests/test_util.cc
+++ b/selfdrive/common/tests/test_util.cc
@@ -90,6 +90,9 @@ TEST_CASE("util::read_files_in_dir") {
   REQUIRE(result.size() == std::size(files));
   for (auto& [k, v] : result) {
     REQUIRE(k == v);
+  }
+}
+
 TEST_CASE("util::create_directories") {
   system("rm /tmp/test_create_directories -rf");
   std::string dir = "/tmp/test_create_directories/a/b/c/d/e/f";
@@ -100,25 +103,25 @@ TEST_CASE("util::create_directories") {
   };
 
   SECTION("create_directories") {
-    REQUIRE(util::create_directories(dir, 0775));
-    REQUIRE(check_dir_permissions(dir, 0775));
+    REQUIRE(util::create_directories(dir, 0755));
+    REQUIRE(check_dir_permissions(dir, 0755));
   }
   SECTION("dir already exists") {
-    REQUIRE(util::create_directories(dir, 0775));
-    REQUIRE(util::create_directories(dir, 0775));
+    REQUIRE(util::create_directories(dir, 0755));
+    REQUIRE(util::create_directories(dir, 0755));
   }
   SECTION("a file exists with the same name") {
-    REQUIRE(util::create_directories(dir, 0775));
+    REQUIRE(util::create_directories(dir, 0755));
     int f = open((dir + "/file").c_str(), O_RDWR | O_CREAT);
     REQUIRE(f != -1);
     close(f);
-    REQUIRE(util::create_directories(dir + "/file", 0775) == false);
-    REQUIRE(util::create_directories(dir + "/file/1/2/3", 0775) == false);
+    REQUIRE(util::create_directories(dir + "/file", 0755) == false);
+    REQUIRE(util::create_directories(dir + "/file/1/2/3", 0755) == false);
   }
   SECTION("end with slashs") {
-    REQUIRE(util::create_directories(dir + "/", 0775));
+    REQUIRE(util::create_directories(dir + "/", 0755));
   }
   SECTION("empty") {
-    REQUIRE(util::create_directories("", 0775) == false);
+    REQUIRE(util::create_directories("", 0755) == false);
   }
 }

--- a/selfdrive/common/tests/test_util.cc
+++ b/selfdrive/common/tests/test_util.cc
@@ -1,4 +1,5 @@
 
+#include <dirent.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -116,25 +117,12 @@ TEST_CASE("util::create_directories") {
   }
   SECTION("end with slashs") {
     // one slashs
-    REQUIRE(util::create_directories(dir + "/", 0775, true));
+    REQUIRE(util::create_directories(dir + "/", 0775));
     // multiple slashs
-    REQUIRE(util::create_directories(dir + "///", 0775, true));
+    REQUIRE(util::create_directories(dir + "///", 0775));
     REQUIRE(check_dir_permissions(dir, 0775) == true);
   }
   SECTION("empty") {
-    REQUIRE(util::create_directories("", 0775, true) == false);
+    REQUIRE(util::create_directories("", 0775) == false);
   }
-  SECTION("reset permissions") {
-    REQUIRE(util::create_directories(dir, 0775));
-    REQUIRE(check_dir_permissions(dir, 0775) == true);
-
-    // don't reset permissions
-    REQUIRE(util::create_directories(dir, 0666, false));
-    REQUIRE(check_dir_permissions(dir, 0666) == false);
-    REQUIRE(check_dir_permissions(dir, 0775) == true);
-    // reset permissions
-    REQUIRE(util::create_directories(dir, 0666, true));
-    REQUIRE(check_dir_permissions(dir, 0666) == true);
-  }
-  
 }

--- a/selfdrive/common/util.cc
+++ b/selfdrive/common/util.cc
@@ -150,9 +150,9 @@ static bool createDirectory(std::string dir, mode_t mode, bool reset_mode) {
   return errno == EEXIST && verify_dir(dir, reset_mode ? mode : 0);
 }
 
-bool create_directories(const std::string& dir, mode_t mode, bool reset_mode, bool with_umask) {
+bool create_directories(const std::string& dir, mode_t mode, bool reset_mode, bool no_umask) {
   if (dir.empty()) return false;
-  if (with_umask) {
+  if (no_umask) {
     mode_t prev_mask = ::umask(0);
     bool ret = createDirectory(dir, mode, reset_mode);
     ::umask(prev_mask);

--- a/selfdrive/common/util.cc
+++ b/selfdrive/common/util.cc
@@ -125,9 +125,7 @@ bool file_exists(const std::string& fn) {
 static bool createDirectory(std::string dir, mode_t mode) {
   auto verify_dir = [](const std::string& dir) -> bool {
     struct stat st = {};
-    if (stat(dir.c_str(), &st) == -1) return false;
-    if ((st.st_mode & S_IFMT) != S_IFDIR) return false;
-    return true;
+    return (stat(dir.c_str(), &st) == 0 && (st.st_mode & S_IFMT) == S_IFDIR);
   };
   // remove trailing /'s
   while (dir.size() > 1 && dir.back() == '/') {

--- a/selfdrive/common/util.cc
+++ b/selfdrive/common/util.cc
@@ -150,16 +150,9 @@ static bool createDirectory(std::string dir, mode_t mode, bool reset_mode) {
   return errno == EEXIST && verify_dir(dir, reset_mode ? mode : 0);
 }
 
-bool create_directories(const std::string& dir, mode_t mode, bool reset_mode, bool no_umask) {
+bool create_directories(const std::string& dir, mode_t mode, bool reset_mode) {
   if (dir.empty()) return false;
-  if (no_umask) {
-    mode_t prev_mask = ::umask(0);
-    bool ret = createDirectory(dir, mode, reset_mode);
-    ::umask(prev_mask);
-    return ret;
-  } else {
-    return createDirectory(dir, mode, reset_mode);
-  }
+  return createDirectory(dir, mode, reset_mode);
 }
 
 std::string getenv(const char* key, const char* default_val) {

--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -77,7 +77,7 @@ std::map<std::string, std::string> read_files_in_dir(const std::string& path);
 int write_file(const char* path, const void* data, size_t size, int flags = O_WRONLY, mode_t mode = 0664);
 std::string readlink(const std::string& path);
 bool file_exists(const std::string& fn);
-bool create_directories(const std::string &dir, mode_t mode, bool reset_mode = true, bool with_umask = true);
+bool create_directories(const std::string &dir, mode_t mode, bool reset_mode = true, bool no_umask = true);
 
 inline void sleep_for(const int milliseconds) {
   std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -77,7 +77,7 @@ std::map<std::string, std::string> read_files_in_dir(const std::string& path);
 int write_file(const char* path, const void* data, size_t size, int flags = O_WRONLY, mode_t mode = 0664);
 std::string readlink(const std::string& path);
 bool file_exists(const std::string& fn);
-bool create_directories(const std::string &dir, mode_t mode, bool reset_mode = true, bool no_umask = true);
+bool create_directories(const std::string &dir, mode_t mode, bool reset_mode = true);
 
 inline void sleep_for(const int milliseconds) {
   std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -76,6 +77,7 @@ std::map<std::string, std::string> read_files_in_dir(const std::string& path);
 int write_file(const char* path, const void* data, size_t size, int flags = O_WRONLY, mode_t mode = 0664);
 std::string readlink(const std::string& path);
 bool file_exists(const std::string& fn);
+bool create_directories(const std::string &dir, mode_t mode, bool reset_mode = true, bool with_umask = true);
 
 inline void sleep_for(const int milliseconds) {
   std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -77,7 +77,7 @@ std::map<std::string, std::string> read_files_in_dir(const std::string& path);
 int write_file(const char* path, const void* data, size_t size, int flags = O_WRONLY, mode_t mode = 0664);
 std::string readlink(const std::string& path);
 bool file_exists(const std::string& fn);
-bool create_directories(const std::string &dir, mode_t mode, bool reset_mode = true);
+bool create_directories(const std::string &dir, mode_t mode);
 
 inline void sleep_for(const int milliseconds) {
   std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
   LOGW("bootlog to %s", path.c_str());
 
   // Open bootlog
-  bool r = util::create_directories(path, 0777);
+  bool r = util::create_directories(LOG_ROOT + "/boot/", 0777);
   assert(r);
 
   BZFile bz_file(path.c_str());

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
   LOGW("bootlog to %s", path.c_str());
 
   // Open bootlog
-  int r = logger_mkpath((char*)path.c_str());
+  int r = util::create_directories(path, 0777);
   assert(r == 0);
 
   BZFile bz_file(path.c_str());

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -40,8 +40,8 @@ int main(int argc, char** argv) {
   LOGW("bootlog to %s", path.c_str());
 
   // Open bootlog
-  int r = util::create_directories(path, 0777);
-  assert(r == 0);
+  bool r = util::create_directories(path, 0777);
+  assert(r);
 
   BZFile bz_file(path.c_str());
 

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
   LOGW("bootlog to %s", path.c_str());
 
   // Open bootlog
-  bool r = util::create_directories(LOG_ROOT + "/boot/", 0777);
+  bool r = util::create_directories(LOG_ROOT + "/boot/", 0775);
   assert(r);
 
   BZFile bz_file(path.c_str());

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -156,7 +156,7 @@ static LoggerHandle* logger_open(LoggerState *s, const char* root_path) {
   h->end_sentinel_type = SentinelType::END_OF_SEGMENT;
   h->exit_signal = 0;
 
-  if (!util::create_directories(h->log_path, 0777)) return nullptr;
+  if (!util::create_directories(h->segment_path, 0777)) return nullptr;
 
   FILE* lock_file = fopen(h->lock_path, "wb");
   if (lock_file == NULL) return NULL;

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -138,8 +138,6 @@ void logger_init(LoggerState *s, const char* log_name, bool has_qlog) {
 }
 
 static LoggerHandle* logger_open(LoggerState *s, const char* root_path) {
-  int err;
-
   LoggerHandle *h = NULL;
   for (int i=0; i<LOGGER_MAX_HANDLES; i++) {
     if (s->handles[i].refcnt == 0) {
@@ -158,8 +156,7 @@ static LoggerHandle* logger_open(LoggerState *s, const char* root_path) {
   h->end_sentinel_type = SentinelType::END_OF_SEGMENT;
   h->exit_signal = 0;
 
-  err = util::create_directories(h->log_path, 0777);
-  if (err) return NULL;
+  if (!util::create_directories(h->log_path, 0777)) return nullptr;
 
   FILE* lock_file = fopen(h->lock_path, "wb");
   if (lock_file == NULL) return NULL;

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -30,22 +30,6 @@ void append_property(const char* key, const char* value, void *cookie) {
   properties->push_back(std::make_pair(std::string(key), std::string(value)));
 }
 
-int logger_mkpath(char* file_path) {
-  assert(file_path && *file_path);
-  char* p;
-  for (p=strchr(file_path+1, '/'); p; p=strchr(p+1, '/')) {
-    *p = '\0';
-    if (mkdir(file_path, 0775)==-1) {
-      if (errno != EEXIST) {
-        *p = '/';
-        return -1;
-      }
-    }
-    *p = '/';
-  }
-  return 0;
-}
-
 // ***** log metadata *****
 kj::Array<capnp::word> logger_build_init_data() {
   MessageBuilder msg;
@@ -174,7 +158,7 @@ static LoggerHandle* logger_open(LoggerState *s, const char* root_path) {
   h->end_sentinel_type = SentinelType::END_OF_SEGMENT;
   h->exit_signal = 0;
 
-  err = logger_mkpath(h->log_path);
+  err = util::create_directories(h->log_path, 0777);
   if (err) return NULL;
 
   FILE* lock_file = fopen(h->lock_path, "wb");

--- a/selfdrive/loggerd/logger.cc
+++ b/selfdrive/loggerd/logger.cc
@@ -156,7 +156,7 @@ static LoggerHandle* logger_open(LoggerState *s, const char* root_path) {
   h->end_sentinel_type = SentinelType::END_OF_SEGMENT;
   h->exit_signal = 0;
 
-  if (!util::create_directories(h->segment_path, 0777)) return nullptr;
+  if (!util::create_directories(h->segment_path, 0775)) return nullptr;
 
   FILE* lock_file = fopen(h->lock_path, "wb");
   if (lock_file == NULL) return NULL;

--- a/selfdrive/loggerd/logger.h
+++ b/selfdrive/loggerd/logger.h
@@ -83,7 +83,6 @@ typedef struct LoggerState {
   LoggerHandle* cur_handle;
 } LoggerState;
 
-int logger_mkpath(char* file_path);
 kj::Array<capnp::word> logger_build_init_data();
 std::string logger_get_route_name();
 void logger_init(LoggerState *s, const char* log_name, bool has_qlog);


### PR DESCRIPTION
`std::filesystem::create_directories` does not has the explicit permissions (mode) argument, I think it's better to implement  our own `util::create_directories`.

replacing `mkdir_p` with the following improvements :
1. return false if a file exists with the same name.
2. better performance.`util::create_directories`  iterates over the directory from right to left, it's pretty fast if the directory or it's parents already exists.
2. better error handling.



