### PR TITLE
fix: util::read_files_in_dir does not always return a correct result

### DIFF
--- a/selfdrive/common/tests/test_util.cc
+++ b/selfdrive/common/tests/test_util.cc
@@ -75,3 +75,20 @@ TEST_CASE("util::file_exists") {
   }
   ::remove(filename);
 }
+
+TEST_CASE("util::read_files_in_dir") {
+  char tmp_path[] = "/tmp/test_XXXXXX";
+  const std::string test_path = mkdtemp(tmp_path);
+  const std::string files[] = {".test1", "'test2'", "test3"};
+  for (auto fn : files) {
+    std::ofstream{test_path + "/" + fn} << fn;
+  }
+  mkdir((test_path + "/dir").c_str(), 0777);
+
+  std::map<std::string, std::string> result = util::read_files_in_dir(test_path);
+  REQUIRE(result.find("dir") == result.end());
+  REQUIRE(result.size() == std::size(files));
+  for (auto& [k, v] : result) {
+    REQUIRE(k == v);
+  }
+}

--- a/selfdrive/common/util.cc
+++ b/selfdrive/common/util.cc
@@ -85,7 +85,7 @@ std::map<std::string, std::string> read_files_in_dir(const std::string &path) {
 
   struct dirent *de = NULL;
   while ((de = readdir(d))) {
-    if (isalnum(de->d_name[0])) {
+    if (de->d_type != DT_DIR) {
       ret[de->d_name] = util::read_file(path + "/" + de->d_name);
     }
   }

--- a/selfdrive/common/util.cc
+++ b/selfdrive/common/util.cc
@@ -85,7 +85,7 @@ std::map<std::string, std::string> read_files_in_dir(const std::string &path) {
 
   struct dirent *de = NULL;
   while ((de = readdir(d))) {
-    if (de->d_type == DT_REG) {
+    if (de->d_type != DT_DIR) {
       ret[de->d_name] = util::read_file(path + "/" + de->d_name);
     }
   }

--- a/selfdrive/common/util.cc
+++ b/selfdrive/common/util.cc
@@ -85,7 +85,7 @@ std::map<std::string, std::string> read_files_in_dir(const std::string &path) {
 
   struct dirent *de = NULL;
   while ((de = readdir(d))) {
-    if (de->d_type != DT_DIR) {
+    if (de->d_type == DT_REG) {
       ret[de->d_name] = util::read_file(path + "/" + de->d_name);
     }
   }


### PR DESCRIPTION
fix two problems:
1.  return dir's name in map with empty value.
2.  can't return files which name starts with an non alphanumeric character.(e.g.  `.file`, `'file 1'`.