### PR TITLE
fix url typo

### DIFF
--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -3,7 +3,7 @@ Replay driving data
 
 **Hardware needed**: none
 
-`unlogger.py` replays data collected with [dashcam](https://github.com/commaai/openpilot/tree/dashcam) or [openpilot](https://githucommaai/openpilot).
+`unlogger.py` replays data collected with [dashcam](https://github.com/commaai/openpilot/tree/dashcam) or [openpilot](https://github.com/commaai/openpilot).
 
 Unlogger with remote data:
 


### PR DESCRIPTION
Hyperlink typo in the replay readme, original was: 
https://githucommaai/openpilot

corrected to:
https://github.com/commaai/openpilot