### PR TITLE
sidebar: simplify updateState with QPair

### DIFF
--- a/selfdrive/ui/qt/sidebar.h
+++ b/selfdrive/ui/qt/sidebar.h
@@ -6,14 +6,13 @@
 #include "selfdrive/common/params.h"
 #include "selfdrive/ui/ui.h"
 
+typedef QPair<QString, QColor> ItemStatus;
+Q_DECLARE_METATYPE(ItemStatus);
 class Sidebar : public QFrame {
   Q_OBJECT
-  Q_PROPERTY(QString connectStr MEMBER connect_str NOTIFY valueChanged);
-  Q_PROPERTY(QColor connectStatus MEMBER connect_status NOTIFY valueChanged);
-  Q_PROPERTY(QString pandaStr MEMBER panda_str NOTIFY valueChanged);
-  Q_PROPERTY(QColor pandaStatus MEMBER panda_status NOTIFY valueChanged);
-  Q_PROPERTY(int tempVal MEMBER temp_val NOTIFY valueChanged);
-  Q_PROPERTY(QColor tempStatus MEMBER temp_status NOTIFY valueChanged);
+  Q_PROPERTY(ItemStatus connectStatus MEMBER connect_status NOTIFY valueChanged);
+  Q_PROPERTY(ItemStatus pandaStatus MEMBER panda_status NOTIFY valueChanged);
+  Q_PROPERTY(ItemStatus tempStatus MEMBER temp_status NOTIFY valueChanged);
   Q_PROPERTY(QString netType MEMBER net_type NOTIFY valueChanged);
   Q_PROPERTY(int netStrength MEMBER net_strength NOTIFY valueChanged);
 
@@ -30,8 +29,6 @@ public slots:
 protected:
   void paintEvent(QPaintEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
-
-private:
   void drawMetric(QPainter &p, const QString &label, const QString &val, QColor c, int y);
 
   QImage home_img, settings_img;
@@ -51,12 +48,7 @@ private:
   const QColor danger_color = QColor(201, 34, 49);
 
   Params params;
-  QString connect_str = "OFFLINE";
-  QColor connect_status = warning_color;
-  QString panda_str = "NO\nPANDA";
-  QColor panda_status = warning_color;
-  int temp_val = 0;
-  QColor temp_status = warning_color;
+  ItemStatus connect_status, panda_status, temp_status;
   QString net_type;
   int net_strength = 0;
 };

--- a/selfdrive/ui/qt/sidebar.h
+++ b/selfdrive/ui/qt/sidebar.h
@@ -8,6 +8,7 @@
 
 typedef QPair<QString, QColor> ItemStatus;
 Q_DECLARE_METATYPE(ItemStatus);
+
 class Sidebar : public QFrame {
   Q_OBJECT
   Q_PROPERTY(ItemStatus connectStatus MEMBER connect_status NOTIFY valueChanged);


### PR DESCRIPTION
`updateState` is always called before `paintevent`, so there is no need to initializing status in header