### PR TITLE
fix logcatd_android: handle EAGAIN and EINTR on android_logger_list_read

### DIFF
--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -40,7 +40,10 @@ int main() {
       int err = android_logger_list_read(logger_list, &log_msg);
       if (err < 0) {
         if ((err == -1 && (errno == EINTR || errno == EAGAIN)) ||
-            (err == -EINTR || err == -EAGAIN)) continue;
+            (err == -EINTR || err == -EAGAIN)) {
+          util::sleep_for(100);
+          continue;
+        }
         break;
       }
 

--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -38,7 +38,11 @@ int main() {
     while (!do_exit) {
       log_msg log_msg;
       int err = android_logger_list_read(logger_list, &log_msg);
-      if (err <= 0) break;
+      if (err < 0) {
+        if ((err == -1 && (errno == EINTR || errno == EAGAIN)) ||
+            (err == -EINTR || err == -EAGAIN)) continue;
+        break;
+      }
 
       AndroidLogEntry entry;
       err = android_log_processLogBuffer(&log_msg.entry_v1, &entry);
@@ -55,7 +59,6 @@ int main() {
       androidEntry.setTid(entry.tid);
       androidEntry.setTag(entry.tag);
       androidEntry.setMessage(entry.message);
-
       pm.send("androidLog", msg);
     }
 

--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -59,6 +59,7 @@ int main() {
       androidEntry.setTid(entry.tid);
       androidEntry.setTag(entry.tag);
       androidEntry.setMessage(entry.message);
+
       pm.send("androidLog", msg);
     }
 


### PR DESCRIPTION
We should handle `EAGAIN`&`EINTR` on `android_logger_list_read` .or the logger will be closed and reopened continuously, resulting in lagging.
https://github.com/commaai/android_system_core/blob/53907edda9296b704a5a5cfa50fc3a4bafdde1da/liblog/log_read.c#L740-L880