### PR TITLE
athena: change test tearDown to setUp

### DIFF
--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -31,7 +31,7 @@ class TestAthenadMethods(unittest.TestCase):
     athenad.Api = MockApi
     athenad.LOCAL_PORT_WHITELIST = set([cls.SOCKET_PORT])
 
-  def tearDown(self):
+  def setUp(self):
     athenad.upload_queue = queue.Queue()
     athenad.cur_upload_items.clear()
 


### PR DESCRIPTION
makes it easier to inspect state when a test fails, and if exceptions occur in set up the test won't run instead of leaving things in a state where the next test might fail as a consequence of it happening in tear down.