### PR TITLE
Update plotjuggler readme for streaming, and cabana url input

### DIFF
--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -11,15 +11,15 @@ Once you've cloned and are in openpilot, download PlotJuggler and install our pl
 ## Usage
 
 ```
-batman@z840-openpilot:~/openpilot/tools/plotjuggler$ ./juggle.py -h
+$ ./juggle.py -h
 usage: juggle.py [-h] [--qlog] [--can] [--stream] [--layout [LAYOUT]] [route_name] [segment_number] [segment_count]
 
 PlotJuggler plugin for reading openpilot logs
 
 positional arguments:
-  route_name         The name of the route that will be plotted. (default: None)
-  segment_number     The index of the segment that will be plotted (default: None)
-  segment_count      The number of segments that will be plotted (default: 1)
+  route_name         The route name to plot, cabana share url accepted (default: None)
+  segment_number     The index of the segment to plot (default: None)
+  segment_count      The number of segments to plot (default: 1)
 
 optional arguments:
   -h, --help         show this help message and exit

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -35,7 +35,7 @@ Example:
 
 ## Streaming
 
-Explore live data from your car! (If running openpilot locally, skip right to `./juggle.py --stream`.)
+Explore live data from your car! (If running openpilot locally, skip to `./juggle.py --stream`.)
 
 - On comma device:
   - Enable wifi tethering

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -35,17 +35,13 @@ Example:
 
 ## Streaming
 
-Explore live data from your car! (If running openpilot locally, skip to `./juggle.py --stream`.)
+Explore live data from your car! Follow these steps to stream from your comma device to your laptop:
+- Enable wifi tethering on your comma device
+- [SSH into your device](https://github.com/commaai/openpilot/wiki/SSH) and run `cd /data/openpilot && ./cereal/messaging/bridge`
+- On your laptop, connect to the device's wifi hotspot
+- Start PlotJuggler with `ZMQ=1 ./juggle.py --stream`, find the `Cereal Subscriber` plugin in the dropdown under Streaming, and click `Start`.
 
-- On comma device:
-  - Enable wifi tethering
-- On laptop:
-  - `export ZMQ=1` in plotjuggler's environment, to tell the streaming plugin to use ZMQ.
-  - Connect to comma device wifi
-- [ssh into comma device](https://github.com/commaai/openpilot/wiki/SSH):
-  - Run `./cereal/messaging/bridge` to re-broadcast openpilot's MSGQ to ZMQ over the network.
-
-Start PlotJuggler with `./juggle.py --stream`, find the `Cereal Subscriber` plugin in the dropdown under Streaming, and click Start. Observe live messages from [openpilot's services](https://github.com/commaai/cereal/blob/master/services.py)!
+If streaming to PlotJuggler from a replay on your PC, simply run: `./juggle.py --stream` and start the cereal subscriber.
 
 ## Demo
 

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -35,14 +35,17 @@ Example:
 
 ## Streaming
 
-To get started exploring and plotting data live in your car, you can start PlotJuggler in streaming mode: `./juggle.py --stream`.
+Explore live data from your car! (If running openpilot locally, skip right to `./juggle.py --stream`.)
 
-For this to work, you'll need a few things:
-- Enable tethering on your comma device and connect your laptop.
-- Run `export ZMQ=1` on the computer, which tells the streaming plugin backend to use ZMQ. If you're streaming locally, you can omit this step as ZMQ is used to transport data over the network.
-- Most importantly: openpilot by default uses the MSGQ backend, so you'll need to [ssh into your device](https://github.com/commaai/openpilot/wiki/SSH) and run bridge. This simply re-broadcasts each message over ZMQ: `./cereal/messaging/bridge`.
+- On comma device:
+  - Enable wifi tethering
+- On laptop:
+  - `export ZMQ=1` in plotjuggler's environment, to tell the streaming plugin to use ZMQ.
+  - Connect to comma device wifi
+- [ssh into comma device](https://github.com/commaai/openpilot/wiki/SSH):
+  - Run `./cereal/messaging/bridge` to re-broadcast openpilot's MSGQ to ZMQ over the network.
 
-Now start PlotJuggler using the above `juggle.py` command, and find the `Cereal Subscriber` plugin in the dropdown under Streaming. Click Start and enter the IP address of the comma two. You should now be seeing all the messages for each [service in openpilot](https://github.com/commaai/cereal/blob/master/services.py) received live from your car!
+Start PlotJuggler with `./juggle.py --stream`, find the `Cereal Subscriber` plugin in the dropdown under Streaming, and click Start. Observe live messages from [openpilot's services](https://github.com/commaai/cereal/blob/master/services.py)!
 
 ## Demo
 

--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -17,7 +17,7 @@ usage: juggle.py [-h] [--qlog] [--can] [--stream] [--layout [LAYOUT]] [route_nam
 PlotJuggler plugin for reading openpilot logs
 
 positional arguments:
-  route_name         The route name to plot, cabana share url accepted (default: None)
+  route_name         The route name to plot (cabana share URL accepted) (default: None)
   segment_number     The index of the segment to plot (default: None)
   segment_count      The number of segments to plot (default: 1)
 

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -101,9 +101,9 @@ def get_arg_parser():
   parser.add_argument("--can", action="store_true", help="Parse CAN data")
   parser.add_argument("--stream", action="store_true", help="Start PlotJuggler without a route to stream data using Cereal")
   parser.add_argument("--layout", nargs='?', help="Run PlotJuggler with a pre-defined layout")
-  parser.add_argument("route_name", nargs='?', help="The name of the route that will be plotted.")
-  parser.add_argument("segment_number", type=int, nargs='?', help="The index of the segment that will be plotted")
-  parser.add_argument("segment_count", type=int, nargs='?', help="The number of segments that will be plotted", default=1)
+  parser.add_argument("route_name", nargs='?', help="The route name to plot, cabana share url accepted")
+  parser.add_argument("segment_number", type=int, nargs='?', help="The index of the segment to plot")
+  parser.add_argument("segment_count", type=int, nargs='?', help="The number of segments to plot", default=1)
   return parser
 
 if __name__ == "__main__":

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -101,7 +101,7 @@ def get_arg_parser():
   parser.add_argument("--can", action="store_true", help="Parse CAN data")
   parser.add_argument("--stream", action="store_true", help="Start PlotJuggler without a route to stream data using Cereal")
   parser.add_argument("--layout", nargs='?', help="Run PlotJuggler with a pre-defined layout")
-  parser.add_argument("route_name", nargs='?', help="The route name to plot, cabana share url accepted")
+  parser.add_argument("route_name", nargs='?', help="The route name to plot (cabana share URL accepted)")
   parser.add_argument("segment_number", type=int, nargs='?', help="The index of the segment to plot")
   parser.add_argument("segment_count", type=int, nargs='?', help="The number of segments to plot", default=1)
   return parser


### PR DESCRIPTION
**Description** Improve the readme on streaming - device IP is hardcoded, order was tricky to follow

**Verification** Copied output of `juggle.py -h`