### PR TITLE
camerad: new class CameraServerBase

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -324,7 +324,7 @@ void *processing_thread(MultiCameraState *cameras, CameraState *cs, process_thre
 
     callback(cameras, cs, cnt);
 
-    if (cs->cam_type == RoadCam && cameras->pm && cnt % 100 == 3) {
+    if (cs->cam_type == RoadCam && cnt % 100 == 3) {
       // this takes 10ms???
       publish_thumbnail(cameras->pm, &(cs->buf));
     }

--- a/selfdrive/camerad/cameras/camera_frame_stream.cc
+++ b/selfdrive/camerad/cameras/camera_frame_stream.cc
@@ -34,14 +34,14 @@ CameraInfo cameras_supported[CAMERA_ID_MAX] = {
   },
 };
 
-void camera_init(VisionIpcServer * v, CameraState *s, int camera_id, unsigned int fps, cl_device_id device_id, cl_context ctx, VisionStreamType rgb_type, VisionStreamType yuv_type) {
+void camera_init(MultiCameraState *server, CameraState *s, int camera_id, unsigned int fps) {
   assert(camera_id < std::size(cameras_supported));
   s->ci = cameras_supported[camera_id];
   assert(s->ci.frame_width != 0);
 
   s->camera_num = camera_id;
   s->fps = fps;
-  s->buf.init(device_id, ctx, s, v, FRAME_BUF_COUNT, rgb_type, yuv_type);
+  s->buf.init(server, s, FRAME_BUF_COUNT);
 }
 
 void run_frame_stream(CameraState &camera, const char* frame_pkt) {
@@ -72,11 +72,9 @@ void run_frame_stream(CameraState &camera, const char* frame_pkt) {
 
 }  // namespace
 
-void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx) {
-  camera_init(v, &s->road_cam, CAMERA_ID_IMX298, 20, device_id, ctx,
-              VISION_STREAM_RGB_BACK, VISION_STREAM_YUV_BACK);
-  camera_init(v, &s->driver_cam, CAMERA_ID_OV8865, 10, device_id, ctx,
-              VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
+void cameras_init(MultiCameraState *s) {
+  camera_init(s, &s->road_cam, CAMERA_ID_IMX298, 20);
+  camera_init(s, &s->driver_cam, CAMERA_ID_OV8865, 10);
 }
 
 void cameras_open(MultiCameraState *s) {}

--- a/selfdrive/camerad/cameras/camera_frame_stream.h
+++ b/selfdrive/camerad/cameras/camera_frame_stream.h
@@ -12,6 +12,7 @@
 #define FRAME_BUF_COUNT 16
 
 typedef struct CameraState {
+  CameraType cam_type;
   int camera_num;
   CameraInfo ci;
 
@@ -21,10 +22,8 @@ typedef struct CameraState {
   CameraBuf buf;
 } CameraState;
 
-typedef struct MultiCameraState {
-  CameraState road_cam;
-  CameraState driver_cam;
-
-  SubMaster *sm;
-  PubMaster *pm;
-} MultiCameraState;
+class MultiCameraState : public CameraServerBase {
+public:
+  CameraState road_cam{.cam_type = RoadCam};
+  CameraState driver_cam{.cam_type = DriverCam};
+};

--- a/selfdrive/camerad/cameras/camera_qcom.h
+++ b/selfdrive/camerad/cameras/camera_qcom.h
@@ -40,6 +40,7 @@ typedef struct StreamState {
 } StreamState;
 
 typedef struct CameraState {
+  CameraType cam_type;
   int camera_num;
   int camera_id;
 
@@ -86,7 +87,9 @@ typedef struct CameraState {
 } CameraState;
 
 
-typedef struct MultiCameraState {
+class MultiCameraState : public CameraServerBase {
+public:
+  MultiCameraState() = default;
   unique_fd ispif_fd;
   unique_fd msmcfg_fd;
   unique_fd v4l_fd;
@@ -95,13 +98,11 @@ typedef struct MultiCameraState {
   VisionBuf focus_bufs[FRAME_BUF_COUNT];
   VisionBuf stats_bufs[FRAME_BUF_COUNT];
 
-  CameraState road_cam;
-  CameraState driver_cam;
+  CameraState road_cam{.cam_type = RoadCam};
+  CameraState driver_cam{.cam_type = DriverCam};
 
-  SubMaster *sm;
-  PubMaster *pm;
   LapConv *lap_conv;
-} MultiCameraState;
+};
 
 void actuator_move(CameraState *s, uint16_t target);
 int sensor_write_regs(CameraState *s, struct msm_camera_i2c_reg_array* arr, size_t size, int data_type);

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -516,7 +516,7 @@ void enqueue_req_multi(struct CameraState *s, int start, int n, bool dp) {
 
 // ******************* camera *******************
 
-static void camera_init(MultiCameraState *multi_cam_state, VisionIpcServer * v, CameraState *s, int camera_id, int camera_num, unsigned int fps, cl_device_id device_id, cl_context ctx, VisionStreamType rgb_type, VisionStreamType yuv_type) {
+static void camera_init(MultiCameraState *multi_cam_state, CameraState *s, int camera_id, int camera_num, unsigned int fps) {
   LOGD("camera init %d", camera_num);
   s->multi_cam_state = multi_cam_state;
   assert(camera_id < std::size(cameras_supported));
@@ -537,7 +537,7 @@ static void camera_init(MultiCameraState *multi_cam_state, VisionIpcServer * v, 
   s->exposure_time = 5;
   s->cur_ev[0] = s->cur_ev[1] = s->cur_ev[2] = (s->dc_gain_enabled ? DC_GAIN : 1) * sensor_analog_gains[s->gain_idx] * s->exposure_time;
 
-  s->buf.init(device_id, ctx, s, v, FRAME_BUF_COUNT, rgb_type, yuv_type);
+  s->buf.init(multi_cam_state, s, FRAME_BUF_COUNT);
 }
 
 // TODO: refactor this to somewhere nicer, perhaps use in camera_qcom as well
@@ -761,19 +761,13 @@ static void camera_open(CameraState *s) {
   enqueue_req_multi(s, 1, FRAME_BUF_COUNT, 0);
 }
 
-void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx) {
-  camera_init(s, v, &s->road_cam, CAMERA_ID_AR0231, 1, 20, device_id, ctx,
-              VISION_STREAM_RGB_BACK, VISION_STREAM_YUV_BACK); // swap left/right
+void cameras_init(MultiCameraState *s) {
+  camera_init(s, &s->road_cam, CAMERA_ID_AR0231, 1, 20); // swap left/right
   printf("road camera initted \n");
-  camera_init(s, v, &s->wide_road_cam, CAMERA_ID_AR0231, 0, 20, device_id, ctx,
-              VISION_STREAM_RGB_WIDE, VISION_STREAM_YUV_WIDE);
+  camera_init(s, &s->wide_road_cam, CAMERA_ID_AR0231, 0, 20);
   printf("wide road camera initted \n");
-  camera_init(s, v, &s->driver_cam, CAMERA_ID_AR0231, 2, 20, device_id, ctx,
-              VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
+  camera_init(s, &s->driver_cam, CAMERA_ID_AR0231, 2, 20);
   printf("driver camera initted \n");
-
-  s->sm = new SubMaster({"driverState"});
-  s->pm = new PubMaster({"roadCameraState", "driverCameraState", "wideRoadCameraState", "thumbnail"});
 }
 
 void cameras_open(MultiCameraState *s) {
@@ -871,9 +865,6 @@ void cameras_close(MultiCameraState *s) {
   camera_close(&s->road_cam);
   camera_close(&s->wide_road_cam);
   camera_close(&s->driver_cam);
-
-  delete s->sm;
-  delete s->pm;
 }
 
 // ******************* just a helper *******************

--- a/selfdrive/camerad/cameras/camera_qcom2.h
+++ b/selfdrive/camerad/cameras/camera_qcom2.h
@@ -10,6 +10,7 @@
 #define FRAME_BUF_COUNT 4
 #define DEBAYER_LOCAL_WORKSIZE 16
 typedef struct CameraState {
+  CameraType cam_type;
   MultiCameraState *multi_cam_state;
   CameraInfo ci;
 
@@ -53,7 +54,10 @@ typedef struct CameraState {
   CameraBuf buf;
 } CameraState;
 
-typedef struct MultiCameraState {
+class MultiCameraState : public CameraServerBase {
+public:
+  MultiCameraState() = default;
+
   unique_fd video0_fd;
   unique_fd video1_fd;
   unique_fd isp_fd;
@@ -61,10 +65,7 @@ typedef struct MultiCameraState {
   int cdm_iommu;
 
 
-  CameraState road_cam;
-  CameraState wide_road_cam;
-  CameraState driver_cam;
-
-  SubMaster *sm;
-  PubMaster *pm;
-} MultiCameraState;
+  CameraState road_cam{.cam_type = RoadCam};
+  CameraState wide_road_cam{.cam_type = WideRoadCam};
+  CameraState driver_cam{.cam_type = DriverCam};
+};

--- a/selfdrive/camerad/cameras/camera_qcom2.h
+++ b/selfdrive/camerad/cameras/camera_qcom2.h
@@ -64,7 +64,6 @@ public:
   int device_iommu;
   int cdm_iommu;
 
-
   CameraState road_cam{.cam_type = RoadCam};
   CameraState wide_road_cam{.cam_type = WideRoadCam};
   CameraState driver_cam{.cam_type = DriverCam};

--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -50,7 +50,7 @@ CameraInfo cameras_supported[CAMERA_ID_MAX] = {
   },
 };
 
-void camera_open(CameraState *s, bool rear) {
+void camera_open(CameraState *s) {
   // empty
 }
 
@@ -58,14 +58,14 @@ void camera_close(CameraState *s) {
   // empty
 }
 
-void camera_init(VisionIpcServer * v, CameraState *s, int camera_id, unsigned int fps, cl_device_id device_id, cl_context ctx, VisionStreamType rgb_type, VisionStreamType yuv_type) {
+void camera_init(MultiCameraState *server, CameraState *s, int camera_id, unsigned int fps) {
   assert(camera_id < std::size(cameras_supported));
   s->ci = cameras_supported[camera_id];
   assert(s->ci.frame_width != 0);
 
   s->camera_num = camera_id;
   s->fps = fps;
-  s->buf.init(device_id, ctx, s, v, FRAME_BUF_COUNT, rgb_type, yuv_type);
+  s->buf.init(server, s, FRAME_BUF_COUNT);
 }
 
 void run_camera(CameraState *s, cv::VideoCapture &video_cap, float *ts) {
@@ -139,27 +139,23 @@ void driver_camera_thread(CameraState *s) {
 
 }  // namespace
 
-void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx) {
-  camera_init(v, &s->road_cam, CAMERA_ID_LGC920, 20, device_id, ctx,
-              VISION_STREAM_RGB_BACK, VISION_STREAM_YUV_BACK);
-  camera_init(v, &s->driver_cam, CAMERA_ID_LGC615, 10, device_id, ctx,
-              VISION_STREAM_RGB_FRONT, VISION_STREAM_YUV_FRONT);
-  s->pm = new PubMaster({"roadCameraState", "driverCameraState", "thumbnail"});
+void cameras_init(MultiCameraState *s) {
+  camera_init(s, &s->road_cam, CAMERA_ID_LGC920, 20);
+  camera_init(s, &s->driver_cam, CAMERA_ID_LGC615, 10);
 }
 
 void camera_autoexposure(CameraState *s, float grey_frac) {}
 
 void cameras_open(MultiCameraState *s) {
   // LOG("*** open driver camera ***");
-  camera_open(&s->driver_cam, false);
+  camera_open(&s->driver_cam);
   // LOG("*** open road camera ***");
-  camera_open(&s->road_cam, true);
+  camera_open(&s->road_cam);
 }
 
 void cameras_close(MultiCameraState *s) {
   camera_close(&s->road_cam);
   camera_close(&s->driver_cam);
-  delete s->pm;
 }
 
 void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) {

--- a/selfdrive/camerad/cameras/camera_webcam.h
+++ b/selfdrive/camerad/cameras/camera_webcam.h
@@ -11,6 +11,7 @@
 #define FRAME_BUF_COUNT 16
 
 typedef struct CameraState {
+  CameraType cam_type;
   CameraInfo ci;
   int camera_num;
   int fps;
@@ -19,10 +20,8 @@ typedef struct CameraState {
 } CameraState;
 
 
-typedef struct MultiCameraState {
-  CameraState road_cam;
-  CameraState driver_cam;
-
-  SubMaster *sm;
-  PubMaster *pm;
-} MultiCameraState;
+class MultiCameraState : public CameraServerBase {
+public:
+  CameraState road_cam{.cam_type = RoadCam};
+  CameraState driver_cam{.cam_type = DriverCam};
+};

--- a/selfdrive/camerad/main.cc
+++ b/selfdrive/camerad/main.cc
@@ -1,17 +1,3 @@
-#include <poll.h>
-#include <sys/socket.h>
-#include <unistd.h>
-
-#include <cassert>
-#include <cstdio>
-#include <thread>
-
-#include "libyuv.h"
-
-#include "cereal/visionipc/visionipc_server.h"
-#include "selfdrive/common/clutil.h"
-#include "selfdrive/common/params.h"
-#include "selfdrive/common/swaglog.h"
 #include "selfdrive/common/util.h"
 #include "selfdrive/hardware/hw.h"
 
@@ -27,21 +13,16 @@
 
 ExitHandler do_exit;
 
-void party(cl_device_id device_id, cl_context context) {
-  MultiCameraState cameras = {};
-  VisionIpcServer vipc_server("camerad", device_id, context);
+void party() {
+  MultiCameraState server;
+  server.init();
 
-  cameras_init(&vipc_server, &cameras, device_id, context);
-  cameras_open(&cameras);
+  cameras_init(&server);
+  cameras_open(&server);
 
-  vipc_server.start_listener();
-
-  cameras_run(&cameras);
+  server.start();
+  cameras_run(&server);
 }
-
-#ifdef QCOM
-#include "CL/cl_ext_qcom.h"
-#endif
 
 int main(int argc, char *argv[]) {
   set_realtime_priority(53);
@@ -51,17 +32,5 @@ int main(int argc, char *argv[]) {
     set_core_affinity(6);
   }
 
-  cl_device_id device_id = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT);
-
-   // TODO: do this for QCOM2 too
-#if defined(QCOM)
-  const cl_context_properties props[] = {CL_CONTEXT_PRIORITY_HINT_QCOM, CL_PRIORITY_HINT_HIGH_QCOM, 0};
-  cl_context context = CL_CHECK_ERR(clCreateContext(props, 1, &device_id, NULL, NULL, &err));
-#else
-  cl_context context = CL_CHECK_ERR(clCreateContext(NULL, 1, &device_id, NULL, NULL, &err));
-#endif
-
-  party(device_id, context);
-
-  CL_CHECK(clReleaseContext(context));
+  party();
 }

--- a/selfdrive/ui/replay/filereader.h
+++ b/selfdrive/ui/replay/filereader.h
@@ -13,6 +13,8 @@
 
 #include "cereal/gen/cpp/log.capnp.h"
 
+#include "selfdrive/camerad/cameras/camera_common.h"
+
 class FileReader : public QObject {
   Q_OBJECT
 
@@ -31,11 +33,6 @@ private:
   QUrl url_;
 };
 
-enum CameraType {
-  RoadCam = 0,
-  DriverCam,
-  WideRoadCam
-};
 const CameraType ALL_CAMERAS[] = {RoadCam, DriverCam, WideRoadCam};
 const int MAX_CAMERAS = std::size(ALL_CAMERAS);
 


### PR DESCRIPTION
This is part of #20653,  only does  two things:
1. keep the following variables in  CameraServerBase:
```
  cl_device_id device_id;
  cl_context context;
  VisionIpcServer *vipc_server;
  SubMaster *sm;
  PubMaster *pm;
```
2. add `enum CameraType` to `struct CameraState`
