### PR TITLE
boardd:   wait for safety_setter_thread to finish while quitting panda_state_thread

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -36,6 +36,7 @@
 #define CUTOFF_IL 200
 #define SATURATE_IL 1600
 #define NIBBLE_TO_HEX(n) ((n) < 10 ? (n) + '0' : ((n) - 10) + 'a')
+using namespace std::chrono_literals;
 
 std::atomic<bool> ignition(false);
 

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -348,6 +348,7 @@ void send_peripheral_state(PubMaster *pm, Panda *panda) {
 void panda_state_thread(PubMaster *pm, Panda * peripheral_panda, Panda *panda, bool spoofing_started) {
   Params params;
   bool ignition_last = false;
+  std::future<bool> safety_future;
 
   LOGD("start panda state thread");
 

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -42,7 +42,6 @@ std::atomic<bool> ignition(false);
 
 ExitHandler do_exit;
 
-
 std::string get_time_str(const struct tm &time) {
   char s[30] = {'\0'};
   std::strftime(s, std::size(s), "%Y-%m-%d %H:%M:%S", &time);


### PR DESCRIPTION
use std::future to wait for `safety_setter_thread` to finish before quitting.

`safety_setter_thread` should not run after `panda_state_thread`,  or the `panda ` could be set to nullptr

