### PR TITLE
CameraBuf: init krnl_debayer to nullptr

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -100,7 +100,7 @@ class CameraBuf {
 private:
   VisionIpcServer *vipc_server;
   CameraState *camera_state;
-  cl_kernel krnl_debayer;
+  cl_kernel krnl_debayer = nullptr;
 
   std::unique_ptr<Rgb2Yuv> rgb2yuv;
 


### PR DESCRIPTION
krnl_debayer should be initialized to null, otherwise  an invalid value may be sent to `clReleaseKernel`
https://github.com/commaai/openpilot/blob/01e779ef2d9da40ea0675466054e4f4eb22eb2dd/selfdrive/camerad/cameras/camera_common.cc#L104