### PR TITLE
C3: Fix keyboard buttons on the right getting stuck in pressed state

### DIFF
--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -13,7 +13,6 @@ QDialogBase::QDialogBase(QWidget *parent) : QDialog(parent) {
   Q_ASSERT(parent != nullptr);
   parent->installEventFilter(this);
 
-  setWindowFlags(Qt::Popup);
   setStyleSheet(R"(
     * {
       outline: none;

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -1,6 +1,7 @@
 #include "selfdrive/ui/qt/widgets/input.h"
 
 #include <QPushButton>
+#include <QTimer>
 
 #include "selfdrive/hardware/hw.h"
 #include "selfdrive/ui/qt/util.h"
@@ -107,6 +108,7 @@ InputDialog::InputDialog(const QString &title, QWidget *parent, const QString &s
   )");
 
   line = new QLineEdit();
+  QTimer::singleShot(0, [=]() { line->setFocus(Qt::MouseFocusReason); });
   line->setStyleSheet("lineedit-password-character: 8226; lineedit-password-mask-delay: 1500;");
   textbox_layout->addWidget(line, 1);
 

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -1,7 +1,6 @@
 #include "selfdrive/ui/qt/widgets/input.h"
 
 #include <QPushButton>
-#include <QTimer>
 
 #include "selfdrive/hardware/hw.h"
 #include "selfdrive/ui/qt/util.h"
@@ -107,7 +106,6 @@ InputDialog::InputDialog(const QString &title, QWidget *parent, const QString &s
   )");
 
   line = new QLineEdit();
-  QTimer::singleShot(0, [=]() { line->setFocus(Qt::MouseFocusReason); });
   line->setStyleSheet("lineedit-password-character: 8226; lineedit-password-mask-delay: 1500;");
   textbox_layout->addWidget(line, 1);
 

--- a/selfdrive/ui/qt/widgets/keyboard.cc
+++ b/selfdrive/ui/qt/widgets/keyboard.cc
@@ -31,6 +31,9 @@ bool KeyButton::event(QEvent *event) {
       QMouseEvent mouseEvent(mouseType, touchEvent->touchPoints().front().pos(), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
       QPushButton::event(&mouseEvent);
       event->accept();
+      if (mouseType == QEvent::MouseButtonRelease) {
+        parentWidget()->update();
+      }
       return true;
     }
   }


### PR DESCRIPTION
fixed #21907
This is not the final solution.there is no problem with KeyButton.  KeyButton::PaintEvent and QAbstractButton::setDown(https://code.woboq.org/qt5/qtbase/src/widgets/widgets/qabstractbutton.cpp.html#_ZN15QAbstractButton7setDownEb) are always be called with correct state. 
but the relevant area of ​​the screen is not updated. I don't know the reason yet. the quick solution is to call parentWidget()->update() in KeyButton::event  or set focus on line edit.




