### PR TITLE
Fixed build issues on macOS

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -104,7 +104,7 @@ if GetOption('setup'):
 
 
 # build headless replay
-if arch == 'x86_64' and os.path.exists(Dir("#tools/").get_abspath()):
+if arch in ['x86_64', 'Darwin'] and os.path.exists(Dir("#tools/").get_abspath()):
   qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 
   replay_lib_src = ["replay/replay.cc", "replay/filereader.cc", "replay/framereader.cc"]

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -50,7 +50,7 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QFrame(parent) {
   main_layout->addWidget(an);
 
   QPalette pal = palette();
-  pal.setColor(QPalette::Background, QColor(0x29, 0x29, 0x29));
+  pal.setColor(QPalette::Window, QColor(0x29, 0x29, 0x29));
   setAutoFillBackground(true);
   setPalette(pal);
 

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -225,7 +225,7 @@ void Replay::stream() {
       }
 
       uint64_t tm = e.getLogMonoTime();
-      current_ts = std::max(tm - route_start_ts, (unsigned long)0) / 1e9;
+      current_ts = std::max(tm - route_start_ts, (uint64_t)0) / 1e9;
 
       if (socks.contains(type)) {
         float timestamp = (tm - route_start_ts)/1e9;


### PR DESCRIPTION
**Description** 
- QPalette::Background is obsolete causing deprecated build error using qt5 from homebrew, so changed to use QPalette::Window, which is same value. QPalette::Background was already deprecated more than 15 years ago.
- ui/replay isn't triggered to build on macOS, so added to run build.
- One of the std::max was called with unsigned long vs uint64 causing unknown function error, so casted to match type. 

**Verification**
Build succeeded, and I was able to run binary on both intel and arm macOS 11. No change to other devices and OS.