### PR TITLE
Honda carstate: fix forcing is_metric to False

### DIFF
--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -348,7 +348,8 @@ class CarState(CarStateBase):
         ret.brakePressed = True
 
     # TODO: discover the CAN msg that has the imperial unit bit for all other cars
-    self.is_metric = not cp.vl["HUD_SETTING"]["IMPERIAL_UNIT"] if self.CP.carFingerprint in (CAR.CIVIC) else False
+    if self.CP.carFingerprint == CAR.CIVIC:
+      self.is_metric = not cp.vl["HUD_SETTING"]["IMPERIAL_UNIT"]
 
     if self.CP.carFingerprint in HONDA_BOSCH:
       ret.stockAeb = (not self.CP.openpilotLongitudinalControl) and bool(cp.vl["ACC_CONTROL"]["AEB_STATUS"] and cp.vl["ACC_CONTROL"]["ACCEL_COMMAND"] < -1e-5)


### PR DESCRIPTION
A bug in !CIVIC case would override the user's IsMetric option with False, and subsequently that forced value is written back to the car HUD (via IMPERIAL_UNIT).