### PR TITLE
Ensure that first segment starts with all cameras on the same frameId

### DIFF
--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -141,3 +141,9 @@ public:
 private:
   float x_, k_;
 };
+
+template<typename T>
+void update_max_atomic(std::atomic<T>& max, T const& value) {
+  T prev = max;
+  while(prev < value && !max.compare_exchange_weak(prev, value)) {}
+}

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -46,7 +46,8 @@ const int DCAM_BITRATE = Hardware::TICI() ? MAIN_BITRATE : 2500000;
 
 #define NO_CAMERA_PATIENCE 500 // fall back to time-based rotation if all cameras are dead
 
-const int SEGMENT_LENGTH = getenv("LOGGERD_TEST") ? atoi(getenv("LOGGERD_SEGMENT_LENGTH")) : 60;
+const bool LOGGERD_TEST = getenv("LOGGERD_TEST");
+const int SEGMENT_LENGTH = LOGGERD_TEST ? atoi(getenv("LOGGERD_SEGMENT_LENGTH")) : 60;
 
 ExitHandler do_exit;
 
@@ -262,7 +263,8 @@ void rotate_if_needed() {
 
   double tms = millis_since_boot();
   if ((tms - s.last_rotate_tms) > SEGMENT_LENGTH * 1000 &&
-      (tms - s.last_camera_seen_tms) > NO_CAMERA_PATIENCE) {
+      (tms - s.last_camera_seen_tms) > NO_CAMERA_PATIENCE &&
+      !LOGGERD_TEST) {
     LOGW("no camera packet seen. auto rotating");
     logger_rotate();
   }

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -116,9 +116,9 @@ struct LoggerdState {
 
   // Sync logic for startup
   std::atomic<bool> encoders_synced;
-  std::atomic<int> start_frame_id;
   std::atomic<int> encoders_ready;
-  std::atomic<int> latest_frame_id;
+  std::atomic<uint32_t> start_frame_id;
+  std::atomic<uint32_t> latest_frame_id;
 };
 LoggerdState s;
 
@@ -167,10 +167,7 @@ void encoder_thread(const LogCameraInfo &cam_info) {
         }
 
         if (!s.encoders_synced) {
-          // TODO: use atomic max() function
-          if (extra.frame_id > s.latest_frame_id) {
-            s.latest_frame_id = extra.frame_id;
-          }
+          update_max_atomic(s.latest_frame_id, extra.frame_id);
           continue;
         } else {
           // Wait for all encoders to reach the same frame id
@@ -348,7 +345,7 @@ int main(int argc, char** argv) {
         // Small margin in case one of the encoders already dropped the next frame
         s.start_frame_id = s.latest_frame_id + 2;
         s.encoders_synced = true;
-        LOGE("Starting encoders at frame id %d", s.start_frame_id.load());
+        LOGE("starting encoders at frame id %d", s.start_frame_id.load());
       }
     }
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -135,7 +135,7 @@ void encoder_thread(const LogCameraInfo &cam_info) {
 
   while (!do_exit) {
     if (!vipc_client.connect(false)) {
-      util::sleep_for(1);
+      util::sleep_for(5);
       continue;
     }
 
@@ -340,13 +340,11 @@ int main(int argc, char** argv) {
   double start_ts = millis_since_boot();
   while (!do_exit) {
     // Check if all encoders are ready and start encoding at the same time
-    if (!s.encoders_synced) {
-      if (s.encoders_ready == s.max_waiting) {
-        // Small margin in case one of the encoders already dropped the next frame
-        s.start_frame_id = s.latest_frame_id + 2;
-        s.encoders_synced = true;
-        LOGE("starting encoders at frame id %d", s.start_frame_id.load());
-      }
+    if (!s.encoders_synced && (s.encoders_ready == s.max_waiting)) {
+      // Small margin in case one of the encoders already dropped the next frame
+      s.start_frame_id = s.latest_frame_id + 2;
+      s.encoders_synced = true;
+      LOGE("starting encoders at frame id %d", s.start_frame_id.load());
     }
 
 

--- a/selfdrive/loggerd/tests/test_encoder.py
+++ b/selfdrive/loggerd/tests/test_encoder.py
@@ -84,6 +84,7 @@ class TestEncoder(unittest.TestCase):
     def check_seg(i):
       # check each camera file size
       counts = []
+      first_frames = []
       for camera, fps, size, encode_idx_name in CAMERAS:
         if not record_front and "dcamera" in camera:
           continue
@@ -119,6 +120,7 @@ class TestEncoder(unittest.TestCase):
 
           segment_idxs = [getattr(m, encode_idx_name).segmentId for m in LogReader(rlog_path) if m.which() == encode_idx_name]
           encode_idxs = [getattr(m, encode_idx_name).encodeId for m in LogReader(rlog_path) if m.which() == encode_idx_name]
+          frame_idxs = [getattr(m, encode_idx_name).frameId for m in LogReader(rlog_path) if m.which() == encode_idx_name]
 
           # Check frame count
           self.assertEqual(frame_count, len(segment_idxs))
@@ -130,7 +132,10 @@ class TestEncoder(unittest.TestCase):
 
           if not eon_dcam:
             self.assertEqual(expected_frames * i, encode_idxs[0])
+            first_frames.append(frame_idxs[0])
           self.assertEqual(len(set(encode_idxs)), len(encode_idxs))
+
+      self.assertEqual(1, len(set(first_frames)))
 
       if TICI:
         expected_frames = fps * SEGMENT_LENGTH


### PR DESCRIPTION
If logging starts at the wrong time the first frame of the video file can be mismatched between cameras. This then persists for the whole drive.