### PR TITLE
Disable encoder sync logic if only one rotate camera present

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -159,7 +159,7 @@ void encoder_thread(const LogCameraInfo &cam_info) {
       VisionBuf* buf = vipc_client.recv(&extra);
       if (buf == nullptr) continue;
 
-      if (cam_info.trigger_rotate && s.max_waiting > 1) {
+      if (cam_info.trigger_rotate && (s.max_waiting > 1)) {
         if (!ready) {
           LOGE("%s encoder ready", cam_info.filename);
           ++s.encoders_ready;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -159,7 +159,7 @@ void encoder_thread(const LogCameraInfo &cam_info) {
       VisionBuf* buf = vipc_client.recv(&extra);
       if (buf == nullptr) continue;
 
-      if (cam_info.trigger_rotate) {
+      if (cam_info.trigger_rotate && s.max_waiting > 1) {
         if (!ready) {
           LOGE("%s encoder ready", cam_info.filename);
           ++s.encoders_ready;
@@ -176,7 +176,9 @@ void encoder_thread(const LogCameraInfo &cam_info) {
             continue;
           }
         }
+      }
 
+      if (cam_info.trigger_rotate) {
         s.last_camera_seen_tms = millis_since_boot();
       }
 
@@ -340,7 +342,7 @@ int main(int argc, char** argv) {
   double start_ts = millis_since_boot();
   while (!do_exit) {
     // Check if all encoders are ready and start encoding at the same time
-    if (!s.encoders_synced && (s.encoders_ready == s.max_waiting)) {
+    if ((s.max_waiting > 1) && !s.encoders_synced && (s.encoders_ready == s.max_waiting)) {
       // Small margin in case one of the encoders already dropped the next frame
       s.start_frame_id = s.latest_frame_id + 2;
       s.encoders_synced = true;


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
