### PR TITLE
Fixes for C3 LTE connection being deleted

### DIFF
--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -341,9 +341,14 @@ void WifiManager::connectionRemoved(const QDBusObjectPath &path) {
 }
 
 void WifiManager::newConnection(const QDBusObjectPath &path) {
-  knownConnections[path] = getConnectionSettings(path).value("802-11-wireless").value("ssid").toString();
-  if (knownConnections[path] != tethering_ssid) {
-    activateWifiConnection(knownConnections[path]);
+  const Connection &settings = getConnectionSettings(path);
+  if (settings.value("connection").value("type") == "802-11-wireless") {
+    knownConnections[path] = settings.value("802-11-wireless").value("ssid").toString();
+    if (knownConnections[path] != tethering_ssid) {
+      activateWifiConnection(knownConnections[path]);
+    }
+  } else if (path.path() != "/") {
+    lteConnectionPath = path.path();
   }
 }
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -303,7 +303,7 @@ QString WifiManager::getAdapter() {
 
 void WifiManager::stateChange(unsigned int new_state, unsigned int previous_state, unsigned int change_reason) {
   raw_adapter_state = new_state;
-  if (new_state == NM_DEVICE_STATE_NEED_AUTH && change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT) {
+  if (new_state == NM_DEVICE_STATE_NEED_AUTH && change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT && !connecting_to_network.isEmpty()) {
     forgetConnection(connecting_to_network);
     emit wrongPassword(connecting_to_network);
   } else if (new_state == NM_DEVICE_STATE_ACTIVATED) {

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -347,8 +347,6 @@ void WifiManager::newConnection(const QDBusObjectPath &path) {
     if (knownConnections[path] != tethering_ssid) {
       activateWifiConnection(knownConnections[path]);
     }
-  } else if (path.path() != "/") {
-    lteConnectionPath = path.path();
   }
 }
 


### PR DESCRIPTION
**Description**

Partially resolve #22115 by fixing two `wifiManager.cc` code paths that could delete the LTE connection. 

The first fix will make it so we don't wrongly try to forget connections outside of `ui`'s new connection process. It was possible to trigger this if wpa_supplicant tried to re-authenticate to an existing Wifi network while driving out of range. In that case, it didn't even try to delete the current Wifi connection; instead it was trying to delete an empty SSID connection.

The second fix will make sure the LTE connection can't possibly make it onto the `knownConnections` SSID list. We prevent that at init time, but there was a possible path if NetworkManager ever sent a DBus NewConnection event for the LTE. Unsure if this would do it, but it's possible that `ui` could come up before the LTE modem finishes booting and enumerating. If that ever happened, the first bug that was trying to forget empty SSID connections could actually match the empty SSID LTE connection. 

**Verification**

None. The associated bug is difficult to reproduce on-demand; I've made no attempt. Please feel 150% free to check my logic.

**Additional context**

As already noted in the bug, we should also make an AGNOS-side fix to always un-delete the LTE connection at boot-up. If nothing else, we need to recover LTE on any devices that got stuck in this state before receiving the fix.

Related to the current issue, I think the current `ui` assumption that `lteConnection` is the only non-802-11-wireless connection is asking for trouble when we can hook up USB Ethernet devices. I don't have a USB Ethernet interface handy to write code for handling that case tonight.