### PR TITLE
loggerd: fix concurrency issues in sync encoders

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -321,6 +321,8 @@ selfdrive/loggerd/omx_encoder.cc
 selfdrive/loggerd/omx_encoder.h
 selfdrive/loggerd/logger.cc
 selfdrive/loggerd/logger.h
+selfdrive/loggerd/logging.cc
+selfdrive/loggerd/logging.h
 selfdrive/loggerd/loggerd.cc
 selfdrive/loggerd/bootlog.cc
 selfdrive/loggerd/raw_logger.cc

--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -141,3 +141,9 @@ public:
 private:
   float x_, k_;
 };
+
+template<typename T>
+void update_max_atomic(std::atomic<T>& max, T const& value) {
+  T prev = max;
+  while(prev < value && !max.compare_exchange_weak(prev, value)) {}
+}

--- a/selfdrive/common/util.h
+++ b/selfdrive/common/util.h
@@ -141,9 +141,3 @@ public:
 private:
   float x_, k_;
 };
-
-template<typename T>
-void update_max_atomic(std::atomic<T>& max, T const& value) {
-  T prev = max;
-  while(prev < value && !max.compare_exchange_weak(prev, value)) {}
-}

--- a/selfdrive/loggerd/SConscript
+++ b/selfdrive/loggerd/SConscript
@@ -1,7 +1,7 @@
 Import('env', 'arch', 'cereal', 'messaging', 'common', 'visionipc', 'gpucommon')
 
 
-logger_lib = env.Library('logger', ["logger.cc"])
+logger_lib = env.Library('logger', ['logger.cc', 'logging.cc'])
 libs = [logger_lib, common, cereal, messaging, visionipc,
         'zmq', 'capnp', 'kj', 'z',
         'avformat', 'avcodec', 'swscale', 'avutil',
@@ -28,4 +28,4 @@ env.Program(src, LIBS=libs)
 env.Program('bootlog.cc', LIBS=libs)
 
 if GetOption('test'):
-  env.Program('tests/test_logger', ['tests/test_runner.cc', 'tests/test_logger.cc'], LIBS=[libs])
+  env.Program('tests/test_logger', ['tests/test_runner.cc', 'tests/test_logger.cc', 'tests/test_logging.cc'], LIBS=[libs])

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -19,9 +19,6 @@
 
 #include "cereal/messaging/messaging.h"
 #include "cereal/services.h"
-#include "cereal/visionipc/visionipc.h"
-#include "cereal/visionipc/visionipc_client.h"
-#include "selfdrive/camerad/cameras/camera_common.h"
 #include "selfdrive/common/params.h"
 #include "selfdrive/common/swaglog.h"
 #include "selfdrive/common/timing.h"
@@ -29,7 +26,8 @@
 #include "selfdrive/hardware/hw.h"
 
 #include "selfdrive/loggerd/encoder.h"
-#include "selfdrive/loggerd/logger.h"
+#include "selfdrive/loggerd/logging.h"
+
 #if defined(QCOM) || defined(QCOM2)
 #include "selfdrive/loggerd/omx_encoder.h"
 #define Encoder OmxEncoder
@@ -102,46 +100,7 @@ const LogCameraInfo qcam_info = {
   .frame_height = Hardware::TICI() ? 330 : 360 // keep pixel count the same?
 };
 
-const int MAX_CAMERAS = WideRoadCam + 1;
-struct LoggerdState {
-  Context *ctx;
-  LoggerState logger = {};
-  char segment_path[4096];
-  std::mutex rotate_lock;
-  std::condition_variable rotate_cv;
-  std::atomic<int> rotate_segment;
-  std::atomic<double> last_camera_seen_tms;
-  std::atomic<int> waiting_rotate;
-  int max_waiting = 0;
-  double last_rotate_tms = 0.;
-
-  // Sync logic for startup
-  std::atomic<int> encoders_ready = 0;
-  std::atomic<uint32_t> latest_frame_id = 0;
-  bool camera_ready[MAX_CAMERAS] = {};
-};
 LoggerdState s;
-
-
-// Wait for all encoders to reach the same frame id
-bool sync_encoders(CameraType cam_type, uint32_t frame_id) {
-  if (s.max_waiting > 1 && s.encoders_ready != s.max_waiting) {
-    if (std::exchange(s.camera_ready[cam_type], true) == false) {
-      ++s.encoders_ready;
-      LOGE("camera %d encoder ready", cam_type);
-    }
-    if (s.latest_frame_id < frame_id) {
-      s.latest_frame_id = frame_id;
-    }
-    return false;
-  } else {
-    // Small margin in case one of the encoders already dropped the next frame
-    uint32_t start_frame_id = s.latest_frame_id + 2;
-    bool synced = frame_id >= start_frame_id;
-    if (!synced) LOGE("camera %d waiting for frame %d, cur %d", cam_type, start_frame_id, frame_id);
-    return synced;
-  }
-}
 
 void encoder_thread(const LogCameraInfo &cam_info) {
   set_thread_name(cam_info.filename);
@@ -178,7 +137,7 @@ void encoder_thread(const LogCameraInfo &cam_info) {
       VisionBuf* buf = vipc_client.recv(&extra);
       if (buf == nullptr) continue;
 
-      if (cam_info.trigger_rotate && !sync_encoders(cam_info.type, extra.frame_id)) continue;
+      if (cam_info.trigger_rotate && !sync_encoders(&s, cam_info.type, extra.frame_id)) continue;
 
       if (cam_info.trigger_rotate) {
         s.last_camera_seen_tms = millis_since_boot();

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -116,9 +116,8 @@ struct LoggerdState {
   double last_rotate_tms = 0.;
 
   // Sync logic for startup
-  std::mutex sync_lock;
-  int encoders_ready = 0;
-  uint32_t latest_frame_id = 0;
+  std::atomic<int> encoders_ready = 0;
+  std::atomic<uint32_t> latest_frame_id = 0;
   bool camera_ready[MAX_CAMERAS] = {};
 };
 LoggerdState s;
@@ -126,7 +125,6 @@ LoggerdState s;
 
 // Wait for all encoders to reach the same frame id
 bool sync_encoders(CameraType cam_type, uint32_t frame_id) {
-  std::unique_lock lk(s.sync_lock);
   if (s.max_waiting > 1 && s.encoders_ready != s.max_waiting) {
     if (std::exchange(s.camera_ready[cam_type], true) == false) {
       ++s.encoders_ready;

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -123,27 +123,25 @@ struct LoggerdState {
 };
 LoggerdState s;
 
+
+// Wait for all encoders to reach the same frame id
 bool sync_encoders(CameraType cam_type, uint32_t frame_id) {
   std::unique_lock lk(s.sync_lock);
   if (s.max_waiting > 1 && s.encoders_ready != s.max_waiting) {
-    if (s.latest_frame_id < frame_id) {
-      s.latest_frame_id = frame_id;
-    }
-    if (!s.camera_ready[cam_type]) {
-      s.camera_ready[cam_type] = true;
+    if (std::exchange(s.camera_ready[cam_type], true) == false) {
       ++s.encoders_ready;
       LOGE("camera %d encoder ready", cam_type);
+    }
+    if (s.latest_frame_id < frame_id) {
+      s.latest_frame_id = frame_id;
     }
     return false;
   } else {
     // Small margin in case one of the encoders already dropped the next frame
     uint32_t start_frame_id = s.latest_frame_id + 2;
-    // Wait for all encoders to reach the same frame id
-    if (frame_id < start_frame_id) {
-      LOGE("camera %d waiting for frame %d, cur %d", cam_type, start_frame_id, frame_id);
-      return false;
-    }
-    return true;
+    bool synced = frame_id >= start_frame_id;
+    if (!synced) LOGE("camera %d waiting for frame %d, cur %d", cam_type, start_frame_id, frame_id);
+    return synced;
   }
 }
 

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -160,14 +160,13 @@ void encoder_thread(const LogCameraInfo &cam_info) {
       if (buf == nullptr) continue;
 
       if (cam_info.trigger_rotate && (s.max_waiting > 1)) {
-        if (!ready) {
-          LOGE("%s encoder ready", cam_info.filename);
-          ++s.encoders_ready;
-          ready = true;
-        }
-
         if (!s.encoders_synced) {
           update_max_atomic(s.latest_frame_id, extra.frame_id);
+          if (!ready) {
+            LOGE("%s encoder ready", cam_info.filename);
+            ++s.encoders_ready;
+            ready = true;
+          }
           continue;
         } else {
           // Wait for all encoders to reach the same frame id

--- a/selfdrive/loggerd/logging.cc
+++ b/selfdrive/loggerd/logging.cc
@@ -1,0 +1,20 @@
+#include "selfdrive/loggerd/logging.h"
+// Wait for all encoders to reach the same frame id
+bool sync_encoders(LoggerdState *s, CameraType cam_type, uint32_t frame_id) {
+  if (s->max_waiting > 1 && s->encoders_ready != s->max_waiting) {
+    if (std::exchange(s->camera_ready[cam_type], true) == false) {
+      ++s->encoders_ready;
+      LOGE("camera %d encoder ready", cam_type);
+    }
+    if (s->latest_frame_id < frame_id) {
+      s->latest_frame_id = frame_id;
+    }
+    return false;
+  } else {
+    // Small margin in case one of the encoders already dropped the next frame
+    uint32_t start_frame_id = s->latest_frame_id + 2;
+    bool synced = frame_id >= start_frame_id;
+    if (!synced) LOGE("camera %d waiting for frame %d, cur %d", cam_type, start_frame_id, frame_id);
+    return synced;
+  }
+}

--- a/selfdrive/loggerd/logging.cc
+++ b/selfdrive/loggerd/logging.cc
@@ -1,13 +1,14 @@
 #include "selfdrive/loggerd/logging.h"
+
+#include "selfdrive/common/util.h"
+
 // Wait for all encoders to reach the same frame id
 bool sync_encoders(LoggerdState *s, CameraType cam_type, uint32_t frame_id) {
   if (s->max_waiting > 1 && s->encoders_ready != s->max_waiting) {
+    update_max_atomic(s->latest_frame_id, frame_id);
     if (std::exchange(s->camera_ready[cam_type], true) == false) {
       ++s->encoders_ready;
       LOGE("camera %d encoder ready", cam_type);
-    }
-    if (s->latest_frame_id < frame_id) {
-      s->latest_frame_id = frame_id;
     }
     return false;
   } else {

--- a/selfdrive/loggerd/logging.h
+++ b/selfdrive/loggerd/logging.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "cereal/visionipc/visionipc.h"
+#include "cereal/visionipc/visionipc_client.h"
+
+#include "selfdrive/camerad/cameras/camera_common.h"
+#include "selfdrive/loggerd/logger.h"
+
+const int MAX_CAMERAS = WideRoadCam + 1;
+struct LoggerdState {
+  Context *ctx;
+  LoggerState logger = {};
+  char segment_path[4096];
+  std::mutex rotate_lock;
+  std::condition_variable rotate_cv;
+  std::atomic<int> rotate_segment;
+  std::atomic<double> last_camera_seen_tms;
+  std::atomic<int> waiting_rotate;
+  int max_waiting = 0;
+  double last_rotate_tms = 0.;
+
+  // Sync logic for startup
+  std::atomic<int> encoders_ready = 0;
+  std::atomic<uint32_t> latest_frame_id = 0;
+  bool camera_ready[MAX_CAMERAS] = {};
+};
+
+bool sync_encoders(LoggerdState *s, CameraType cam_type, uint32_t frame_id);

--- a/selfdrive/loggerd/tests/test_logging.cc
+++ b/selfdrive/loggerd/tests/test_logging.cc
@@ -1,29 +1,28 @@
+#include <future>
+
 #include "catch2/catch.hpp"
 #include "selfdrive/common/util.h"
 #include "selfdrive/loggerd/logger.h"
 #include "selfdrive/loggerd/logging.h"
 
 TEST_CASE("sync encoders") {
-  auto thread_func = [](LoggerdState *s, CameraType cam_type, int frame_id, int start_frame[]) {
+  auto thread_func = [](LoggerdState *s, CameraType cam_type, int frame_id) -> int {
     while (!sync_encoders(s, cam_type, frame_id)) {
       ++frame_id;
       util::sleep_for(0);
     }
-    start_frame[cam_type] = frame_id;
+    return frame_id;
   };
 
   LoggerdState s;
   s.max_waiting = MAX_CAMERAS;
-  int encoder_start_frame[MAX_CAMERAS] = {};
   int start_frame_id[MAX_CAMERAS] = {10, 20, 30};
-  std::vector<std::thread> threads;
+  std::future<int> futures[MAX_CAMERAS];
   for (int i = 0; i < MAX_CAMERAS; ++i) {
-    threads.emplace_back(thread_func, &s, (CameraType)i, start_frame_id[i], encoder_start_frame);
+    futures[i] = std::async(std::launch::async, thread_func, &s, (CameraType)i, start_frame_id[i]);
   }
-  for (auto &t : threads) t.join();
-
   int start_id = *std::max_element(start_frame_id, start_frame_id + MAX_CAMERAS) + 2;
-  REQUIRE(encoder_start_frame[RoadCam] == start_id);
-  REQUIRE(encoder_start_frame[DriverCam] == start_id);
-  REQUIRE(encoder_start_frame[WideRoadCam] == start_id);
+  for (auto &f : futures) {
+    REQUIRE(f.get() == start_id);
+  }
 }

--- a/selfdrive/loggerd/tests/test_logging.cc
+++ b/selfdrive/loggerd/tests/test_logging.cc
@@ -1,0 +1,29 @@
+#include "catch2/catch.hpp"
+#include "selfdrive/common/util.h"
+#include "selfdrive/loggerd/logger.h"
+#include "selfdrive/loggerd/logging.h"
+
+TEST_CASE("sync encoders") {
+  auto thread_func = [](LoggerdState *s, CameraType cam_type, int frame_id, int start_frame[]) {
+    while (!sync_encoders(s, cam_type, frame_id)) {
+      ++frame_id;
+      util::sleep_for(0);
+    }
+    start_frame[cam_type] = frame_id;
+  };
+
+  LoggerdState s;
+  s.max_waiting = MAX_CAMERAS;
+  int encoder_start_frame[MAX_CAMERAS] = {};
+  int start_frame_id[MAX_CAMERAS] = {10, 20, 30};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < MAX_CAMERAS; ++i) {
+    threads.emplace_back(thread_func, &s, (CameraType)i, start_frame_id[i], encoder_start_frame);
+  }
+  for (auto &t : threads) t.join();
+
+  int start_id = *std::max_element(start_frame_id, start_frame_id + MAX_CAMERAS) + 2;
+  REQUIRE(encoder_start_frame[RoadCam] == start_id);
+  REQUIRE(encoder_start_frame[DriverCam] == start_id);
+  REQUIRE(encoder_start_frame[WideRoadCam] == start_id);
+}


### PR DESCRIPTION
The frame_id of the last camera may not be sent to update_max_atomic for comparison