### PR TITLE
VW MQB: Add FW for 2020 Volkswagen Tiguan

### DIFF
--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -332,6 +332,7 @@ FW_VERSIONS = {
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x8709G927158DT\xf1\x893698',
       b'\xf1\x870DL300011N \xf1\x892001',
+      b'\xf1\x870DL300011N \xf1\x892012',
       b'\xf1\x870DL300013A \xf1\x893005',
       b'\xf1\x870DL300013G \xf1\x892120',
     ],


### PR DESCRIPTION
Add firmware for the 2020 Volkswagen Tiguan.

**Dongle ID:** 21aed36c451a54e9

Thanks to community Tiguan owner mikkelamby.