### PR TITLE
Add Kia Niro EV 2019 fw signature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Community Maintained Cars and Features
 | Jeep      | Grand Cherokee 2016-18        | Adaptive Cruise   | Stock            | 0mph               | 9mph         |
 | Jeep      | Grand Cherokee 2019-20        | Adaptive Cruise   | Stock            | 0mph               | 39mph        |
 | Kia       | Forte 2018-21                 | SCC + LKAS        | Stock            | 0mph               | 0mph         |
-| Kia       | Niro EV 2020-21               | SCC + LKAS        | Stock            | 0mph               | 0mph         |
+| Kia       | Niro EV 2019-21               | SCC + LKAS        | Stock            | 0mph               | 0mph         |
 | Kia       | Niro Hybrid 2021              | SCC + LKAS        | Stock            | 0mph               | 0mph         |
 | Kia       | Niro PHEV 2019                | SCC + LKAS        | Stock            | 10mph              | 32mph        |
 | Kia       | Optima 2017                   | SCC + LKAS        | Stock            | 0mph               | 32mph        |

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -562,6 +562,7 @@ FW_VERSIONS = {
     (Ecu.esp, 0x7D1, None): [
       b'\xf1\x00OS IEB \r 212 \x11\x13 58520-K4000\xf1\xa02.12',
       b'\xf1\x00OS IEB \r 212 \x11\x13 58520-K4000',
+      b'\xf1\xa01.06',
       b'\xf1\xa01.07',
     ],
     (Ecu.eps, 0x7D4, None): [


### PR DESCRIPTION
Add firmware for the Kia Niro EV 2019.

Dongle ID: 2f420386b5af90d7

Full fw signature, only esp needs to be added:
```
  (Ecu.fwdRadar, 0x7d0, None): [b'\xf1\x00DEev SCC F-CUP      1.00 1.03 96400-Q4100         \xf1\xa01.03']
  (Ecu.eps, 0x7d4, None): [b'\xf1\x00DE  MDPS C 1.00 1.05 56310Q4000\x00 4DEEC105']
  (Ecu.esp, 0x7d1, None): [b'\xf1\xa01.06']
  (Ecu.fwdCamera, 0x7c4, None): [b'\xf1\x00DEE MFC  AT USA LHD 1.00 1.03 95740-Q4000 180821']
```