### PR TITLE
params: support sub keys

### DIFF
--- a/common/params_pxd.pxd
+++ b/common/params_pxd.pxd
@@ -20,9 +20,12 @@ cdef extern from "selfdrive/common/params.h":
     Params() nogil
     Params(string) nogil
     string get(string, bool) nogil
+    string get_subkey(string, string) nogil
     bool getBool(string) nogil
     int remove(string) nogil
+    int remove_subkey(string, string) nogil
     int put(string, string) nogil
+    int put_subkey(string, string, string) nogil
     int putBool(string, bool) nogil
     bool checkKey(string) nogil
     void clearAll(ParamKeyType)

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -77,6 +77,21 @@ cdef class Params:
     else:
       return val
 
+  def get_subkey(self, key, subkey, encoding=None):
+    cdef string k = self.check_key(key)
+    cdef string sub_key = ensure_bytes(subkey)
+    cdef string val
+    with nogil:
+      val = self.p.get_subkey(k, sub_key)
+    
+    if val == b"":
+      return None
+    
+    if encoding is not None:
+      return val.decode(encoding)
+    else:
+      return val
+
   def get_bool(self, key):
     cdef string k = self.check_key(key)
     cdef bool r
@@ -95,6 +110,14 @@ cdef class Params:
     cdef string dat_bytes = ensure_bytes(dat)
     with nogil:
       self.p.put(k, dat_bytes)
+  
+  def put_subkey(self, key, subkey, dat):
+    cdef string k = self.check_key(key)
+    cdef string dat_bytes = ensure_bytes(dat)
+    cdef string sub_key = ensure_bytes(subkey)
+    with nogil:
+      self.p.put_subkey(k, sub_key, dat_bytes)
+
 
   def put_bool(self, key, bool val):
     cdef string k = self.check_key(key)
@@ -105,6 +128,12 @@ cdef class Params:
     cdef string k = self.check_key(key)
     with nogil:
       self.p.remove(k)
+
+  def delete_subkey(self, key, subkey):
+    cdef string k = self.check_key(key)
+    cdef string sub_key = ensure_bytes(subkey)
+    with nogil:
+      self.p.remove_subkey(k, sub_key)
 
 
 def put_nonblocking(key, val, d=None):

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -71,11 +71,7 @@ cdef class Params:
         raise KeyboardInterrupt
       else:
         return None
-
-    if encoding is not None:
-      return val.decode(encoding)
-    else:
-      return val
+    return val.decode(encoding) if encoding is not None else val
 
   def get_subkey(self, key, subkey, encoding=None):
     cdef string k = self.check_key(key)
@@ -83,14 +79,10 @@ cdef class Params:
     cdef string val
     with nogil:
       val = self.p.get_subkey(k, sub_key)
-    
+
     if val == b"":
       return None
-    
-    if encoding is not None:
-      return val.decode(encoding)
-    else:
-      return val
+    return val.decode(encoding) if encoding is not None else val
 
   def get_bool(self, key):
     cdef string k = self.check_key(key)

--- a/common/tests/test_params.py
+++ b/common/tests/test_params.py
@@ -38,8 +38,6 @@ class TestParams(unittest.TestCase):
         self.params.delete_subkey("OffroadAlerts", key)
         assert self.params.get_subkey("OffroadAlerts", key) is None
 
-
-
   def test_params_get_cleared_panda_disconnect(self):
     self.params.put("CarParams", "test")
     self.params.put("DongleId", "cb38263377b873ee")

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -327,7 +327,7 @@ void Params::clearAll(ParamKeyType key_type) {
 
 int Params::put_subkey(const std::string &key, const std::string &subkey, const std::string &val) {
   FileLock file_lock(params_path + "/.lock", LOCK_EX);
-  std::lock_guard<FileLock> lk(file_lock);
+  std::lock_guard lk(file_lock);
   
   auto json = read_json_object(params_path + "/d/" + key);
   json[subkey] = val;
@@ -337,7 +337,7 @@ int Params::put_subkey(const std::string &key, const std::string &subkey, const 
 
 int Params::remove_subkey(const std::string &key, const std::string &subkey) {
   FileLock file_lock(params_path + "/.lock", LOCK_EX);
-  std::lock_guard<FileLock> lk(file_lock);
+  std::lock_guard lk(file_lock);
 
   auto json = read_json_object(params_path + "/d/" + key);
   if (auto it = json.find(subkey); it != json.end()) {
@@ -350,7 +350,7 @@ int Params::remove_subkey(const std::string &key, const std::string &subkey) {
 
 std::string Params::get_subkey(const std::string &key, const std::string& subkey) {
   FileLock file_lock(params_path + "/.lock", LOCK_EX);
-  std::lock_guard<FileLock> lk(file_lock);
+  std::lock_guard lk(file_lock);
 
   auto json = read_json_object(params_path + "/d/" + key);
   auto it = json.find(subkey);

--- a/selfdrive/common/params.h
+++ b/selfdrive/common/params.h
@@ -34,7 +34,6 @@ public:
 
   // helpers for reading values
   std::string get(const char *key, bool block = false);
-
   inline std::string get(const std::string &key, bool block = false) {
     return get(key.c_str(), block);
   }
@@ -60,7 +59,7 @@ public:
   }
 
   // helpers for writing values
-  int put(const char* key, const char* val, size_t value_size);
+  int put(const char* key, const char* val, size_t value_size, bool lock = true);
 
   inline int put(const std::string &key, const std::string &val) {
     return put(key.c_str(), val.data(), val.size());
@@ -73,6 +72,11 @@ public:
   inline int putBool(const std::string &key, bool val) {
     return putBool(key.c_str(), val);
   }
+
+  // sub keys
+  std::string get_subkey(const std::string &key, const std::string& subkey);
+  int put_subkey(const std::string &key, const std::string &subkey, const std::string &val);
+  int remove_subkey(const std::string &key, const std::string &subkey);
 
 private:
   const std::string params_path;

--- a/selfdrive/common/params.h
+++ b/selfdrive/common/params.h
@@ -34,6 +34,7 @@ public:
 
   // helpers for reading values
   std::string get(const char *key, bool block = false);
+
   inline std::string get(const std::string &key, bool block = false) {
     return get(key.c_str(), block);
   }
@@ -73,7 +74,7 @@ public:
     return putBool(key.c_str(), val);
   }
 
-  // sub keys
+  // sub key functions
   std::string get_subkey(const std::string &key, const std::string& subkey);
   int put_subkey(const std::string &key, const std::string &subkey, const std::string &val);
   int remove_subkey(const std::string &key, const std::string &subkey);

--- a/selfdrive/controls/lib/alertmanager.py
+++ b/selfdrive/controls/lib/alertmanager.py
@@ -21,9 +21,9 @@ def set_offroad_alert(alert: str, show_alert: bool, extra_text: Optional[str] = 
     if extra_text is not None:
       a = copy.copy(OFFROAD_ALERTS[alert])
       a['text'] += extra_text
-    Params().put(alert, json.dumps(a))
+    Params().put_subkey('OffroadAlerts', alert, json.dumps(a))
   else:
-    Params().delete(alert)
+    Params().delete_subkey('OffroadAlerts', alert)
 
 
 class AlertManager:

--- a/selfdrive/controls/tests/test_alerts.py
+++ b/selfdrive/controls/tests/test_alerts.py
@@ -90,11 +90,11 @@ class TestAlerts(unittest.TestCase):
       # set the alert
       alert = self.offroad_alerts[a]
       set_offroad_alert(a, True)
-      self.assertTrue(json.dumps(alert) == params.get(a, encoding='utf8'))
+      self.assertTrue(json.dumps(alert) == params.get_subkey('OffroadAlerts', a, encoding='utf8'))
 
       # then delete it
       set_offroad_alert(a, False)
-      self.assertTrue(params.get(a) is None)
+      self.assertTrue(params.get_subkey('OffroadAlerts', a) is None)
 
   def test_offroad_alerts_extra_text(self):
     params = Params()
@@ -105,7 +105,7 @@ class TestAlerts(unittest.TestCase):
       set_offroad_alert(a, True, extra_text="a"*i)
 
       expected_txt = alert['text'] + "a"*i
-      written_txt = json.loads(params.get(a, encoding='utf8'))['text']
+      written_txt = json.loads(params.get_subkey('OffroadAlerts', a, encoding='utf8'))['text']
       self.assertTrue(expected_txt == written_txt)
 
 if __name__ == "__main__":

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -255,6 +255,8 @@ def thermald_thread():
         if pandaState.pandaState.pandaType == log.PandaState.PandaType.unknown and \
           pandaState_prev.pandaState.pandaType != log.PandaState.PandaType.unknown:
           params.clear_all(ParamKeyType.CLEAR_ON_PANDA_DISCONNECT)
+          params.delete_subkey("OffroadAlerts", "Offroad_ChargeDisabled")
+          params.delete_subkey("OffroadAlerts", "Offroad_PandaFirmwareMismatch")
       pandaState_prev = pandaState
 
     # get_network_type is an expensive call. update every 10s

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -97,7 +97,7 @@ MapPanel::MapPanel(QWidget* parent) : QWidget(parent) {
     // Fetch favorite and recent locations
     {
       QString url = CommaApi::BASE_URL + "/v1/navigation/" + *dongle_id + "/locations";
-      RequestRepeater* repeater = new RequestRepeater(this, url, "ApiCache_NavDestinations", 30, true);
+      RequestRepeater* repeater = new RequestRepeater(this, url, "NavDestinations", 30, true);
       QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &MapPanel::parseResponse);
       QObject::connect(repeater, &RequestRepeater::failedResponse, this, &MapPanel::failedResponse);
     }

--- a/selfdrive/ui/qt/request_repeater.cc
+++ b/selfdrive/ui/qt/request_repeater.cc
@@ -13,13 +13,13 @@ RequestRepeater::RequestRepeater(QObject *parent, const QString &requestURL, con
   timer->start(period * 1000);
 
   if (!cacheKey.isEmpty()) {
-    prevResp = QString::fromStdString(params.get(cacheKey.toStdString()));
+    prevResp = QString::fromStdString(params.get_subkey("ApiCache", cacheKey.toStdString()));
     if (!prevResp.isEmpty()) {
       QTimer::singleShot(500, [=]() { emit receivedResponse(prevResp); });
     }
     QObject::connect(this, &HttpRequest::receivedResponse, [=](const QString &resp) {
       if (resp != prevResp) {
-        params.put(cacheKey.toStdString(), resp.toStdString());
+        params.put_subkey("ApiCache", cacheKey.toStdString(), resp.toStdString());
         prevResp = resp;
       }
     });

--- a/selfdrive/ui/qt/widgets/drive_stats.cc
+++ b/selfdrive/ui/qt/widgets/drive_stats.cc
@@ -49,7 +49,7 @@ DriveStats::DriveStats(QWidget* parent) : QFrame(parent) {
 
   if (auto dongleId = getDongleId()) {
     QString url = CommaApi::BASE_URL + "/v1.1/devices/" + *dongleId + "/stats";
-    RequestRepeater* repeater = new RequestRepeater(this, url, "ApiCache_DriveStats", 30);
+    RequestRepeater* repeater = new RequestRepeater(this, url, "DriveStats", 30);
     QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &DriveStats::parseResponse);
   }
 

--- a/selfdrive/ui/qt/widgets/offroad_alerts.cc
+++ b/selfdrive/ui/qt/widgets/offroad_alerts.cc
@@ -76,11 +76,12 @@ int OffroadAlert::refresh() {
   }
 
   int alertCount = 0;
+  auto offroad_alerts = QJsonDocument::fromJson(params.get("OffroadAlerts").c_str());
   for (const auto &[key, label] : alerts) {
     QString text;
-    std::string bytes = params.get(key);
-    if (bytes.size()) {
-      auto doc_par = QJsonDocument::fromJson(bytes.c_str());
+    QString v = offroad_alerts[key.c_str()].toString();
+    if (!v.isEmpty()) {
+      auto doc_par = QJsonDocument::fromJson(v.toUtf8());
       text = doc_par["text"].toString();
     }
     label->setText(text);

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -112,7 +112,7 @@ PrimeUserWidget::PrimeUserWidget(QWidget* parent) : QWidget(parent) {
   // set up API requests
   if (auto dongleId = getDongleId()) {
     QString url = CommaApi::BASE_URL + "/v1/devices/" + *dongleId + "/owner";
-    RequestRepeater *repeater = new RequestRepeater(this, url, "ApiCache_Owner", 6);
+    RequestRepeater *repeater = new RequestRepeater(this, url, "Owner", 6);
     QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &PrimeUserWidget::replyFinished);
   }
 }
@@ -257,7 +257,7 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
   // set up API requests
   if (auto dongleId = getDongleId()) {
     QString url = CommaApi::BASE_URL + "/v1.1/devices/" + *dongleId + "/";
-    RequestRepeater* repeater = new RequestRepeater(this, url, "ApiCache_Device", 5);
+    RequestRepeater* repeater = new RequestRepeater(this, url, "Device", 5);
 
     QObject::connect(repeater, &RequestRepeater::receivedResponse, this, &SetupWidget::replyFinished);
     QObject::connect(repeater, &RequestRepeater::failedResponse, this, &SetupWidget::parseError);


### PR DESCRIPTION
It can be used to group other parameters later, and can also be used to track the logging directories without the .lock files.

