### PR TITLE
Panda::list: remove call to libusb_release_interface

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -129,7 +129,6 @@ std::vector<std::string> Panda::list() {
       libusb_open(device, &handle);
       unsigned char desc_serial[26] = { 0 };
       int ret = libusb_get_string_descriptor_ascii(handle, desc.iSerialNumber, desc_serial, std::size(desc_serial));
-      libusb_release_interface(handle, 0);
       libusb_close(handle);
 
       if (ret < 0) { goto finish; }


### PR DESCRIPTION
we should not call libusb_release_interface here. it's used to release interface previously claimed with libusb_claim_interface()