### PR TITLE
fix panda: call libusb_free_device_list  before libusb_exit

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -81,10 +81,10 @@ Panda::Panda(std::string serial) {
   return;
 
 fail:
-  cleanup();
   if (dev_list != NULL) {
     libusb_free_device_list(dev_list, 1);
   }
+  cleanup();
   throw std::runtime_error("Error connecting to panda");
 }
 
@@ -138,11 +138,11 @@ std::vector<std::string> Panda::list() {
   }
 
 finish:
-  if (context) {
-    libusb_exit(context);
-  }
   if (dev_list != NULL) {
     libusb_free_device_list(dev_list, 1);
+  }
+  if (context) {
+    libusb_exit(context);
   }
   return serials;
 }


### PR DESCRIPTION
`void libusb_exit(libusb_context *ctx) Deinitialise libusb. Must be called at the end of the application. Other libusb routines may not be called after this function. `

ctx needs to be valid when free devcie list in function libusb_free_device_list:

```
usbi_mutex_lock(&dev->ctx->usb_devs_lock);
list_del(&dev->list);
usbi_mutex_unlock(&dev->ctx->usb_devs_lock);
```
