### PR TITLE
VW MQB: Fixes for network location detection

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -61,7 +61,7 @@ void safety_setter_thread(Panda *panda) {
       LOGW("got CarVin %s", value_vin.c_str());
       break;
     }
-    util::sleep_for(100);
+    util::sleep_for(20);
   }
 
   // VIN query done, stop listening to OBDII
@@ -170,7 +170,7 @@ static Panda *usb_retry_connect() {
       LOGW("connected to board");
       return panda;
     }
-    util::sleep_for(100); 
+    util::sleep_for(100);
   };
   return nullptr;
 }

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -120,7 +120,7 @@ def fingerprint(logcan, sendcan):
   finger = gen_empty_fingerprint()
   candidate_cars = {i: all_legacy_fingerprint_cars() for i in [0, 1]}  # attempt fingerprint on both bus 0 and 1
   frame = 0
-  frame_fingerprint = 20  # 0.2s
+  frame_fingerprint = 10  # 0.1s
   car_fingerprint = None
   done = False
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -120,7 +120,7 @@ def fingerprint(logcan, sendcan):
   finger = gen_empty_fingerprint()
   candidate_cars = {i: all_legacy_fingerprint_cars() for i in [0, 1]}  # attempt fingerprint on both bus 0 and 1
   frame = 0
-  frame_fingerprint = 10  # 0.1s
+  frame_fingerprint = 20  # 0.2s
   car_fingerprint = None
   done = False
 

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -39,7 +39,7 @@ class CarInterface(CarInterfaceBase):
       else:
         ret.transmissionType = TransmissionType.manual
 
-      if [msg for msg in [0x40, 0x86, 0xB2] if msg in fingerprint[1]]:  # Airbag_01, LWI_01, ESP_19
+      if any(msg in fingerprint[1] for msg in [0x40, 0x86, 0xB2]):  # Airbag_01, LWI_01, ESP_19
         ret.networkLocation = NetworkLocation.gateway
       else:
         ret.networkLocation = NetworkLocation.fwdCamera

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -30,18 +30,18 @@ class CarInterface(CarInterfaceBase):
     if True:  # pylint: disable=using-constant-test
       # Set global MQB parameters
       ret.safetyModel = car.CarParams.SafetyModel.volkswagen
-      ret.enableBsm = 0x30F in fingerprint[0]
+      ret.enableBsm = 0x30F in fingerprint[0]  # SWA_01
 
       if 0xAD in fingerprint[0]:  # Getriebe_11
         ret.transmissionType = TransmissionType.automatic
       elif 0x187 in fingerprint[0]:  # EV_Gearshift
         ret.transmissionType = TransmissionType.direct
-      else:  # No trans message at all, must be a true stick-shift manual
+      else:
         ret.transmissionType = TransmissionType.manual
 
-      if 0x86 in fingerprint[1]:  # LWI_01 seen on bus 1, we're wired to the CAN gateway
+      if [msg for msg in [0x40, 0x86, 0xB2] if msg in fingerprint[1]]:  # Airbag_01, LWI_01, ESP_19
         ret.networkLocation = NetworkLocation.gateway
-      else:  # We're wired to the LKAS camera
+      else:
         ret.networkLocation = NetworkLocation.fwdCamera
 
     # Global tuning defaults, can be overridden per-vehicle


### PR DESCRIPTION
**Description**

Resolve two issues that create intermittent problems with auto network location detect:

* Extend the legacy CAN fingerprint window from 100ms to 200ms to better capture messages on bus 1.

* For additional assurance, look for any of three messages on startup instead of just one.

**Verification**

Local testing on my 2018 Golf R with a prototype comma J533 harness. I'm leaving this in Draft for a few days to make sure the intermittent problems are truly gone in my community fork, but I'd appreciate any comma feedback in the meantime.

**Route**

Route: `3cfdec54aa035f3f|2021-09-09--13-10-51`

**Additional context**

Bus 1 has unique fingerprinting problems, because once `controlsd` gets the VIN, the [`boardd` polling loop](https://github.com/commaai/openpilot/blob/02a83fdcb342d6ed284d4b42adc8a0b3f6e2a4cc/selfdrive/boardd/boardd.cc#L57-L64) can take up to 100ms to switch the bus mux from 3 back to 1, which eats directly into the 100ms legacy FP timer.

Extending the legacy FP timer is simplest, but if comma feels that could negatively affect other cars, I'm okay with extending only for VW similar to `only_toyota_left()`. Our cars work fine with openpilot starting an arbitrary time after ignition-on.

The set of messages chosen were verified as 50Hz or 100Hz for reliable detection in our 100ms window, should pass detection on all supported cars, and should pass detection whether bus 1 is hooked up to powertrain or convenience CAN.