### PR TITLE
VW MQB: Cleanup stock LKAS signal forwarding

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -79,9 +79,7 @@ class CarController():
 
       can_sends.append(volkswagencan.create_mqb_hud_control(self.packer_pt, CANBUS.pt, enabled,
                                                             CS.out.steeringPressed, hud_alert, left_lane_visible,
-                                                            right_lane_visible, CS.ldw_lane_warning_left,
-                                                            CS.ldw_lane_warning_right, CS.ldw_side_dlc_tlc,
-                                                            CS.ldw_dlc, CS.ldw_tlc, CS.out.standstill,
+                                                            right_lane_visible, CS.ldw_stock_values,
                                                             left_lane_depart, right_lane_depart))
 
     # **** ACC Button Controls ********************************************** #

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -22,14 +22,15 @@ def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, le
   # 1 (LKAS enabled, no lane detected) - dark gray
   # 2 (LKAS enabled, lane detected) - light gray on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpit on a 2018 A3 e-Tron its green.
   # 3 (LKAS enabled, lane departure detected) - white on VW, red on Audi
-  values = {
+  values = ldw_stock_values.copy()
+  values.update({
     "LDW_Status_LED_gelb": 1 if enabled and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if enabled and not steering_pressed else 0,
     "LDW_Lernmodus_links": 3 if left_lane_depart else 1 + left_lane_visible,
     "LDW_Lernmodus_rechts": 3 if right_lane_depart else 1 + right_lane_visible,
     "LDW_Texte": hud_alert,
-  }
-  return packer.make_can_msg("LDW_02", bus, {**values, **ldw_stock_values})
+  })
+  return packer.make_can_msg("LDW_02", bus, values)
 
 def create_mqb_acc_buttons_control(packer, bus, buttonStatesToSend, CS, idx):
   values = {

--- a/selfdrive/car/volkswagen/volkswagencan.py
+++ b/selfdrive/car/volkswagen/volkswagencan.py
@@ -16,27 +16,20 @@ def create_mqb_steering_control(packer, bus, apply_steer, idx, lkas_enabled):
   return packer.make_can_msg("HCA_01", bus, values, idx)
 
 def create_mqb_hud_control(packer, bus, enabled, steering_pressed, hud_alert, left_lane_visible, right_lane_visible,
-                           ldw_lane_warning_left, ldw_lane_warning_right, ldw_side_dlc_tlc, ldw_dlc, ldw_tlc,
-                           standstill, left_lane_depart, right_lane_depart):
+                           ldw_stock_values, left_lane_depart, right_lane_depart):
   # Lane color reference:
-  # 0 (LKAS disabled) - off 
-  # 1 (LKAS enabled, no lane detected) - dark gray 
-  # 2 (LKAS enabled, lane detected) - light gray on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpit on a 2018 A3 e-Tron its green. 
-  # 3 (LKAS enabled, lane departure detected) - white on VW, red on Audi 
-
+  # 0 (LKAS disabled) - off
+  # 1 (LKAS enabled, no lane detected) - dark gray
+  # 2 (LKAS enabled, lane detected) - light gray on VW, green or white on Audi depending on year or virtual cockpit.  On a color MFD on a 2015 A3 TDI it is white, virtual cockpit on a 2018 A3 e-Tron its green.
+  # 3 (LKAS enabled, lane departure detected) - white on VW, red on Audi
   values = {
     "LDW_Status_LED_gelb": 1 if enabled and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if enabled and not steering_pressed else 0,
     "LDW_Lernmodus_links": 3 if left_lane_depart else 1 + left_lane_visible,
     "LDW_Lernmodus_rechts": 3 if right_lane_depart else 1 + right_lane_visible,
     "LDW_Texte": hud_alert,
-    "LDW_SW_Warnung_links": ldw_lane_warning_left,
-    "LDW_SW_Warnung_rechts": ldw_lane_warning_right,
-    "LDW_Seite_DLCTLC": ldw_side_dlc_tlc,
-    "LDW_DLC": ldw_dlc,
-    "LDW_TLC": ldw_tlc
   }
-  return packer.make_can_msg("LDW_02", bus, values)
+  return packer.make_can_msg("LDW_02", bus, {**values, **ldw_stock_values})
 
 def create_mqb_acc_buttons_control(packer, bus, buttonStatesToSend, CS, idx):
   values = {


### PR DESCRIPTION
**Description**

Simplify stock Lane Assist signal forwarding to the Lane Change Assist / Rear Cross Traffic Assist radars, and only forward those signals when we're integrated at the Lane Assist camera.

**Verification**

`process_replay` output is identical for a camera-integrated vehicle.

**Additional context**

When integrated at the gateway, incorporating this data in LDW_02 doesn't matter because SWA already sees it straight from the source anyway, so don't bother.

Since we no longer do checks on LDW_02 when integrated at the gateway, we can now accommodate many community vehicles that don't have factory Lane Assist cameras at all. #22133 will be resubmitted.

This approach no longer relies on commaai/cereal#156, so it can be backed out or deprecated.