### PR TITLE
Upload when on ethernet

### DIFF
--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -260,10 +260,10 @@ def uploader_fn(exit_event):
         time.sleep(60 if offroad else 5)
       continue
 
-    on_wifi = network_type == NetworkType.wifi
+    good_internet = network_type in [NetworkType.wifi, NetworkType.ethernet]
     allow_raw_upload = params.get_bool("UploadRaw")
 
-    d = uploader.next_file_to_upload(with_raw=allow_raw_upload and on_wifi and offroad)
+    d = uploader.next_file_to_upload(with_raw=allow_raw_upload and good_internet and offroad)
     if d is None:  # Nothing to upload
       if allow_sleep:
         time.sleep(60 if offroad else 5)


### PR DESCRIPTION
in addition to when on wifi
issue #22187

**Description**
`uploader.py` only uploads high priority files when on wifi. Refactor the `on_wifi` variable to `good_internet` and include both wifi and ethernet network types.

**Verification**
Tested that high priority files are still uploaded on both wifi and ethernet connections.
