### PR TITLE
c++ replay: send YUV/RGB for all cameras

### DIFF
--- a/selfdrive/camerad/cameras/camera_replay.cc
+++ b/selfdrive/camerad/cameras/camera_replay.cc
@@ -53,11 +53,11 @@ void run_camera(CameraState *s) {
       // loop stream
       stream_frame_id = 0;
     }
-    uint8_t *dat = s->frame->get(stream_frame_id++);
-    if (dat) {
+    if (auto dat = s->frame->get(stream_frame_id++)) {
+      auto [rgb_buf, yuv_buf] = *dat;
       s->buf.camera_bufs_metadata[buf_idx] = {.frame_id = frame_id};
       auto &buf = s->buf.camera_bufs[buf_idx];
-      CL_CHECK(clEnqueueWriteBuffer(buf.copy_q, buf.buf_cl, CL_TRUE, 0, s->frame->getRGBSize(), dat, 0, NULL, NULL));
+      CL_CHECK(clEnqueueWriteBuffer(buf.copy_q, buf.buf_cl, CL_TRUE, 0, s->frame->getRGBSize(), rgb_buf, 0, NULL, NULL));
       s->buf.queue(buf_idx);
       ++frame_id;
       buf_idx = (buf_idx + 1) % FRAME_BUF_COUNT;

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -108,7 +108,7 @@ if GetOption('setup'):
 if arch in ['x86_64', 'Darwin'] and os.path.exists(Dir("#tools/").get_abspath()):
   qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 
-  replay_lib_src = ["replay/replay.cc", "replay/logreader.cc", "replay/framereader.cc", "replay/route.cc"]
+  replay_lib_src = ["replay/replay.cc", "replay/camera.cc", "replay/logreader.cc", "replay/framereader.cc", "replay/route.cc"]
 
   replay_lib = qt_env.Library("qt_replay", replay_lib_src, LIBS=base_libs)
   replay_libs = [replay_lib, 'avutil', 'avcodec', 'avformat', 'swscale', 'bz2'] + qt_libs

--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -37,6 +37,7 @@ void CameraServer::thread() {
 
     auto &cam = cameras_[type];
     if (cam.width != fr->width || cam.height != fr->height) {
+      // camera frame size changed, need to start|restart the vipc server
       cam.width = fr->width;
       cam.height = fr->height;
       std::cout << "camera[" << type << "] frame size " << cam.width << "x" << cam.height << std::endl;

--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -19,6 +19,7 @@ CameraServer::~CameraServer() {
 }
 
 void CameraServer::startVipcServer() {
+  std::cout << (vipc_server_ ? "start" : "restart") << " vipc server" << std::endl;
   vipc_server_.reset(new VisionIpcServer("camerad", device_id_, context_));
   for (auto &cam : cameras_) {
     if (cam.width > 0 && cam.height > 0) {
@@ -38,7 +39,7 @@ void CameraServer::thread() {
     if (cam.width != fr->width || cam.height != fr->height) {
       cam.width = fr->width;
       cam.height = fr->height;
-      std::cout << "camera[" << type << "] frame size changed, restart vipc server" << std::endl;
+      std::cout << "camera[" << type << "] frame size " << cam.width << "x" << cam.height << std::endl;
       startVipcServer();
     }
 

--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -43,7 +43,7 @@ void CameraServer::pushFrame(CameraType type, FrameReader *fr, uint32_t encodeFr
   if (cam.width != fr->width || cam.height != fr->height) {
     cam.width = fr->width;
     cam.height = fr->height;
-    std::cout << "frame changed, restart vipc server" << std::endl;
+    std::cout << "camera["<< type << "] frame changed, restart vipc server" << std::endl;
     stop();
     start();
   }

--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -1,0 +1,64 @@
+#include "selfdrive/ui/replay/camera.h"
+
+#include <cassert>
+#include <iostream>
+
+static const VisionStreamType stream_types[] = {
+    [RoadCam] = VISION_STREAM_RGB_BACK,
+    [DriverCam] = VISION_STREAM_RGB_FRONT,
+    [WideRoadCam] = VISION_STREAM_RGB_WIDE,
+};
+
+CameraServer::CameraServer() {
+  device_id_ = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT);
+  context_ = CL_CHECK_ERR(clCreateContext(NULL, 1, &device_id_, NULL, NULL, &err));
+
+  camera_thread_ = std::thread(&CameraServer::thread, this);
+  start();
+}
+
+CameraServer::~CameraServer() {
+  // stop camera thread
+  queue_.push({});
+  camera_thread_.join();
+
+  delete vipc_server_;
+  CL_CHECK(clReleaseContext(context_));
+}
+
+void CameraServer::start() {
+  vipc_server_ = new VisionIpcServer("camerad", device_id_, context_);
+  vipc_server_->start_listener();
+}
+
+void CameraServer::thread() {
+  while (true) {
+    const auto [cam_type, fr, encodeId] = queue_.pop();
+    if (!fr) break;
+
+    Camera &cam = cameras_[cam_type];
+    if (cam.width != fr->width || cam.height != fr->height) {
+      bool buffer_initialized = cam.width > 0 && cam.height > 0;
+      cam.width = fr->width;
+      cam.height = fr->height;
+      if (!buffer_initialized) {
+        vipc_server_->create_buffers(stream_types[cam_type], UI_BUF_COUNT, true, cam.width, cam.height);
+      } else {
+        std::cout << "frame size changed, restart vipc server" << std::endl;
+        delete vipc_server_;
+        cameras_.fill({});
+        start();
+        continue;
+      }
+    }
+
+    if (uint8_t *dat = fr->get(encodeId)) {
+      VisionIpcBufExtra extra = {};
+      VisionBuf *buf = vipc_server_->get_buffer(stream_types[cam_type]);
+      memcpy(buf->addr, dat, fr->getRGBSize());
+      vipc_server_->send(buf, &extra, false);
+    } else {
+      std::cout << "failed get frame. camera:" << cam_type << ", encodeId:" << encodeId << std::endl;
+    }
+  }
+}

--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -13,8 +13,8 @@ CameraServer::CameraServer() {
   device_id_ = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT);
   context_ = CL_CHECK_ERR(clCreateContext(NULL, 1, &device_id_, NULL, NULL, &err));
 
-  camera_thread_ = std::thread(&CameraServer::thread, this);
   start();
+  camera_thread_ = std::thread(&CameraServer::thread, this);
 }
 
 CameraServer::~CameraServer() {

--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -62,7 +62,6 @@ void CameraServer::thread(Camera *cam) {
           frame_data.getTimestampSof(),
           frame_data.getTimestampEof(),
       };
-
       VisionBuf *rgb_buf = vipc_server_->get_buffer(cam->rgb_type);
       memcpy(rgb_buf->addr, rgb_dat, fr->getRGBSize());
       vipc_server_->send(rgb_buf, &extra, false);

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -2,8 +2,8 @@
 
 #include "cereal/visionipc/visionipc_server.h"
 #include "selfdrive/common/queue.h"
-#include "selfdrive/ui/replay/filereader.h"
 #include "selfdrive/ui/replay/framereader.h"
+#include "selfdrive/ui/replay/logreader.h"
 
 class CameraServer {
 public:

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -13,27 +13,25 @@ public:
   void waitFramesSent();
 
 protected:
+  void start();
+  void stop();
+  void thread();
+
   struct Camera {
-    CameraType cam_type;
     VisionStreamType rgb_type;
     VisionStreamType yuv_type;
     int width;
     int height;
-    std::thread thread;
-    SafeQueue<std::tuple<FrameReader*, uint32_t, const cereal::FrameData::Reader>> queue;
   };
 
-  void start();
-  void stop();
-  void thread(Camera *cam);
-
   Camera cameras_[MAX_CAMERAS] = {
-      {.cam_type = RoadCam, .rgb_type = VISION_STREAM_RGB_BACK, .yuv_type = VISION_STREAM_YUV_BACK},
-      {.cam_type = DriverCam, .rgb_type = VISION_STREAM_RGB_FRONT, .yuv_type = VISION_STREAM_YUV_FRONT},
-      {.cam_type = WideRoadCam, .rgb_type = VISION_STREAM_RGB_WIDE, .yuv_type = VISION_STREAM_YUV_WIDE},
+      {.rgb_type = VISION_STREAM_RGB_BACK, .yuv_type = VISION_STREAM_YUV_BACK},
+      {.rgb_type = VISION_STREAM_RGB_FRONT, .yuv_type = VISION_STREAM_YUV_FRONT},
+      {.rgb_type = VISION_STREAM_RGB_WIDE, .yuv_type = VISION_STREAM_YUV_WIDE},
   };
   cl_device_id device_id_ = nullptr;
   cl_context context_ = nullptr;
   VisionIpcServer* vipc_server_ = nullptr;
   std::thread camera_thread_;
+  SafeQueue<std::tuple<CameraType, FrameReader*, uint32_t, const cereal::FrameData::Reader>> queue_;
 };

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "cereal/visionipc/visionipc_server.h"
+#include "selfdrive/common/queue.h"
+#include "selfdrive/ui/replay/filereader.h"
+#include "selfdrive/ui/replay/framereader.h"
+
+class CameraServer {
+public:
+  CameraServer();
+  ~CameraServer();
+  inline void pushFrame(CameraType type, FrameReader* fr, uint32_t encodeFrameId) {
+    queue_.push({type, fr, encodeFrameId});
+  }
+  inline void waitFramesSent() {
+    while (!queue_.empty()) {
+      std::this_thread::yield();
+    }
+  }
+
+protected:
+  void start();
+  void thread();
+
+  struct Camera {
+    int width;
+    int height;
+  };
+
+  std::array<Camera, MAX_CAMERAS> cameras_ = {};
+  cl_device_id device_id_ = nullptr;
+  cl_context context_ = nullptr;
+  VisionIpcServer* vipc_server_ = nullptr;
+  SafeQueue<std::tuple<CameraType, FrameReader*, uint32_t>> queue_;
+  std::thread camera_thread_;
+};

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -9,7 +9,9 @@ class CameraServer {
 public:
   CameraServer();
   ~CameraServer();
-  void pushFrame(CameraType type, FrameReader* fr, uint32_t encodeFrameId, const cereal::FrameData::Reader &frame_data);
+  inline void pushFrame(CameraType type, FrameReader* fr, uint32_t encodeFrameId, const cereal::FrameData::Reader &frame_data) {
+    queue_.push({type, fr, encodeFrameId, frame_data});
+  }
   void waitFramesSent();
 
 protected:

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -15,8 +15,7 @@ public:
   void waitFramesSent();
 
 protected:
-  void start();
-  void stop();
+  void startVipcServer();
   void thread();
 
   struct Camera {
@@ -31,9 +30,9 @@ protected:
       {.rgb_type = VISION_STREAM_RGB_FRONT, .yuv_type = VISION_STREAM_YUV_FRONT},
       {.rgb_type = VISION_STREAM_RGB_WIDE, .yuv_type = VISION_STREAM_YUV_WIDE},
   };
-  cl_device_id device_id_ = nullptr;
-  cl_context context_ = nullptr;
-  VisionIpcServer* vipc_server_ = nullptr;
+  cl_device_id device_id_;
+  cl_context context_;
   std::thread camera_thread_;
+  std::unique_ptr<VisionIpcServer> vipc_server_;
   SafeQueue<std::tuple<CameraType, FrameReader*, uint32_t, const cereal::FrameData::Reader>> queue_;
 };

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unistd.h>
 #include "cereal/visionipc/visionipc_server.h"
 #include "selfdrive/common/queue.h"
 #include "selfdrive/ui/replay/framereader.h"
@@ -9,10 +10,12 @@ class CameraServer {
 public:
   CameraServer();
   ~CameraServer();
-  inline void pushFrame(CameraType type, FrameReader* fr, uint32_t encodeFrameId, const cereal::FrameData::Reader &frame_data) {
+  inline void pushFrame(CameraType type, FrameReader* fr, uint32_t encodeFrameId, const cereal::FrameData::Reader& frame_data) {
     queue_.push({type, fr, encodeFrameId, frame_data});
   }
-  void waitFramesSent();
+  inline void waitFramesSent() {
+    while (!queue_.empty()) usleep(0);
+  }
 
 protected:
   void startVipcServer();

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -5,17 +5,17 @@
 static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op) {
   std::mutex *mutex = (std::mutex *)*arg;
   switch (op) {
-    case AV_LOCK_CREATE:
-      mutex = new std::mutex();
-      break;
-    case AV_LOCK_OBTAIN:
-      mutex->lock();
-      break;
-    case AV_LOCK_RELEASE:
-      mutex->unlock();
-    case AV_LOCK_DESTROY:
-      delete mutex;
-      break;
+  case AV_LOCK_CREATE:
+    mutex = new std::mutex();
+    break;
+  case AV_LOCK_OBTAIN:
+    mutex->lock();
+    break;
+  case AV_LOCK_RELEASE:
+    mutex->unlock();
+  case AV_LOCK_DESTROY:
+    delete mutex;
+    break;
   }
   return 0;
 }
@@ -159,7 +159,7 @@ void FrameReader::decodeThread() {
 
 std::pair<uint8_t *, uint8_t *> FrameReader::decodeFrame(AVPacket *pkt) {
   uint8_t *rgb_data = nullptr, *yuv_data = nullptr;
-  int gotFrame;
+  int gotFrame = 0;
   AVFrame *f = av_frame_alloc();
   avcodec_decode_video2(pCodecCtx_, f, &gotFrame, pkt);
   if (gotFrame) {
@@ -182,8 +182,7 @@ std::pair<uint8_t *, uint8_t *> FrameReader::decodeFrame(AVPacket *pkt) {
                   f->height, frmRgb_->data, frmRgb_->linesize) <= 0) {
       delete[] rgb_data;
       delete[] yuv_data;
-      rgb_data = nullptr;
-      yuv_data = nullptr;
+      rgb_data = yuv_data = nullptr;
     }
   }
   av_frame_free(&f);

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -71,7 +71,7 @@ bool FrameReader::load(const std::string &url) {
     return false;
   }
   avformat_find_stream_info(pFormatCtx_, NULL);
-  av_dump_format(pFormatCtx_, 0, url.c_str(), 0);
+  // av_dump_format(pFormatCtx_, 0, url.c_str(), 0);
 
   auto pCodecCtxOrig = pFormatCtx_->streams[0]->codec;
   auto pCodec = avcodec_find_decoder(pCodecCtxOrig->codec_id);

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -21,7 +21,7 @@ static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op) {
 }
 
 class AVInitializer {
- public:
+public:
   AVInitializer() {
     int ret = av_lockmgr_register(ffmpeg_lockmgr_cb);
     assert(ret >= 0);
@@ -178,8 +178,7 @@ std::pair<uint8_t *, uint8_t *> FrameReader::decodeFrame(AVPacket *pkt) {
 
     int ret = avpicture_fill((AVPicture *)frmRgb_, rgb_data, AV_PIX_FMT_BGR24, f->width, f->height);
     assert(ret > 0);
-    if (sws_scale(sws_ctx_, (const uint8_t **)f->data, f->linesize, 0,
-                  f->height, frmRgb_->data, frmRgb_->linesize) <= 0) {
+    if (sws_scale(sws_ctx_, (const uint8_t **)f->data, f->linesize, 0, f->height, frmRgb_->data, frmRgb_->linesize) <= 0) {
       delete[] rgb_data;
       delete[] yuv_data;
       rgb_data = yuv_data = nullptr;

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -5,23 +5,23 @@
 static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op) {
   std::mutex *mutex = (std::mutex *)*arg;
   switch (op) {
-  case AV_LOCK_CREATE:
-    mutex = new std::mutex();
-    break;
-  case AV_LOCK_OBTAIN:
-    mutex->lock();
-    break;
-  case AV_LOCK_RELEASE:
-    mutex->unlock();
-  case AV_LOCK_DESTROY:
-    delete mutex;
-    break;
+    case AV_LOCK_CREATE:
+      mutex = new std::mutex();
+      break;
+    case AV_LOCK_OBTAIN:
+      mutex->lock();
+      break;
+    case AV_LOCK_RELEASE:
+      mutex->unlock();
+    case AV_LOCK_DESTROY:
+      delete mutex;
+      break;
   }
   return 0;
 }
 
 class AVInitializer {
-public:
+ public:
   AVInitializer() {
     int ret = av_lockmgr_register(ffmpeg_lockmgr_cb);
     assert(ret >= 0);
@@ -48,13 +48,6 @@ FrameReader::~FrameReader() {
   // free all.
   for (auto &f : frames_) {
     av_free_packet(&f.pkt);
-    if (f.data) {
-      delete[] f.data;
-    }
-  }
-  while (!buffer_pool.empty()) {
-    delete[] buffer_pool.front();
-    buffer_pool.pop();
   }
   if (frmRgb_) {
     av_frame_free(&frmRgb_);
@@ -119,15 +112,18 @@ bool FrameReader::load(const std::string &url) {
   return valid_;
 }
 
-uint8_t *FrameReader::get(int idx) {
+std::optional<std::pair<uint8_t *, uint8_t *>> FrameReader::get(int idx) {
   if (!valid_ || idx < 0 || idx >= frames_.size()) {
-    return nullptr;
+    return std::nullopt;
   }
   std::unique_lock lk(mutex_);
   decode_idx_ = idx;
   cv_decode_.notify_one();
-  cv_frame_.wait(lk, [=] { return exit_ || frames_[idx].data || frames_[idx].failed; });
-  return frames_[idx].data;
+  cv_frame_.wait(lk, [=] { return exit_ || frames_[idx].rgb_data || frames_[idx].failed; });
+  if (!frames_[idx].rgb_data) {
+    return std::nullopt;
+  }
+  return std::make_pair(frames_[idx].rgb_data.get(), frames_[idx].yuv_data.get());
 }
 
 void FrameReader::decodeThread() {
@@ -138,16 +134,17 @@ void FrameReader::decodeThread() {
     for (int i = 0; i < frames_.size() && !exit_; ++i) {
       Frame &frame = frames_[i];
       if (i >= from && i < to) {
-        if (frame.data || frame.failed) continue;
+        if (frame.rgb_data || frame.failed) continue;
 
-        uint8_t *dat = decodeFrame(&frame.pkt);
+        auto [rgb_data, yuv_data] = decodeFrame(&frame.pkt);
         std::unique_lock lk(mutex_);
-        frame.data = dat;
-        frame.failed = !dat;
+        frame.rgb_data.reset(rgb_data);
+        frame.yuv_data.reset(yuv_data);
+        frame.failed = !rgb_data;
         cv_frame_.notify_all();
-      } else if (frame.data) {
-        buffer_pool.push(frame.data);
-        frame.data = nullptr;
+      } else {
+        frame.rgb_data.reset(nullptr);
+        frame.yuv_data.reset(nullptr);
         frame.failed = false;
       }
     }
@@ -160,28 +157,35 @@ void FrameReader::decodeThread() {
   }
 }
 
-uint8_t *FrameReader::decodeFrame(AVPacket *pkt) {
+std::pair<uint8_t *, uint8_t *> FrameReader::decodeFrame(AVPacket *pkt) {
+  uint8_t *rgb_data = nullptr, *yuv_data = nullptr;
   int gotFrame;
   AVFrame *f = av_frame_alloc();
   avcodec_decode_video2(pCodecCtx_, f, &gotFrame, pkt);
-
-  uint8_t *dat = nullptr;
   if (gotFrame) {
-    if (!buffer_pool.empty()) {
-      dat = buffer_pool.front();
-      buffer_pool.pop();
-    } else {
-      dat = new uint8_t[getRGBSize()];
+    rgb_data = new uint8_t[getRGBSize()];
+    yuv_data = new uint8_t[getYUVSize()];
+    int i, j, k;
+    for (i = 0; i < f->height; i++) {
+      memcpy(yuv_data + f->width * i, f->data[0] + f->linesize[0] * i, f->width);
+    }
+    for (j = 0; j < f->height / 2; j++) {
+      memcpy(yuv_data + f->width * i + f->width / 2 * j, f->data[1] + f->linesize[1] * j, f->width / 2);
+    }
+    for (k = 0; k < f->height / 2; k++) {
+      memcpy(yuv_data + f->width * i + f->width / 2 * j + f->width / 2 * k, f->data[2] + f->linesize[2] * k, f->width / 2);
     }
 
-    int ret = avpicture_fill((AVPicture *)frmRgb_, dat, AV_PIX_FMT_BGR24, f->width, f->height);
+    int ret = avpicture_fill((AVPicture *)frmRgb_, rgb_data, AV_PIX_FMT_BGR24, f->width, f->height);
     assert(ret > 0);
     if (sws_scale(sws_ctx_, (const uint8_t **)f->data, f->linesize, 0,
                   f->height, frmRgb_->data, frmRgb_->linesize) <= 0) {
-      delete[] dat;
-      dat = nullptr;
+      delete[] rgb_data;
+      delete[] yuv_data;
+      rgb_data = nullptr;
+      yuv_data = nullptr;
     }
   }
   av_frame_free(&f);
-  return dat;
+  return {rgb_data, yuv_data};
 }

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -156,7 +156,7 @@ void FrameReader::decodeThread() {
     decode_idx_ = -1;
   }
 }
-#include "selfdrive/common/timing.h"
+
 std::pair<uint8_t *, uint8_t *> FrameReader::decodeFrame(AVPacket *pkt) {
   uint8_t *rgb_data = nullptr, *yuv_data = nullptr;
   int gotFrame = 0;

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -156,7 +156,7 @@ void FrameReader::decodeThread() {
     decode_idx_ = -1;
   }
 }
-
+#include "selfdrive/common/timing.h"
 std::pair<uint8_t *, uint8_t *> FrameReader::decodeFrame(AVPacket *pkt) {
   uint8_t *rgb_data = nullptr, *yuv_data = nullptr;
   int gotFrame = 0;

--- a/selfdrive/ui/replay/framereader.h
+++ b/selfdrive/ui/replay/framereader.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <unistd.h>
-
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <optional>
-#include <queue>
 #include <string>
 #include <thread>
 #include <vector>

--- a/selfdrive/ui/replay/framereader.h
+++ b/selfdrive/ui/replay/framereader.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <string>
 #include <thread>
@@ -22,8 +23,9 @@ public:
   FrameReader();
   ~FrameReader();
   bool load(const std::string &url);
-  uint8_t *get(int idx);
+  std::optional<std::pair<uint8_t *, uint8_t*>> get(int idx);
   int getRGBSize() const { return width * height * 3; }
+  int getYUVSize() const { return width * height * 3 / 2; }
   size_t getFrameCount() const { return frames_.size(); }
   bool valid() const { return valid_; }
 
@@ -31,10 +33,11 @@ public:
 
 private:
   void decodeThread();
-  uint8_t *decodeFrame(AVPacket *pkt);
+  std::pair<uint8_t *, uint8_t *> decodeFrame(AVPacket *pkt);
   struct Frame {
     AVPacket pkt = {};
-    uint8_t *data = nullptr;
+    std::unique_ptr<uint8_t[]> rgb_data = nullptr;
+    std::unique_ptr<uint8_t[]> yuv_data = nullptr;
     bool failed = false;
   };
   std::vector<Frame> frames_;
@@ -42,7 +45,6 @@ private:
   AVFormatContext *pFormatCtx_ = nullptr;
   AVCodecContext *pCodecCtx_ = nullptr;
   AVFrame *frmRgb_ = nullptr;
-  std::queue<uint8_t *> buffer_pool;
   struct SwsContext *sws_ctx_ = nullptr;
 
   std::mutex mutex_;

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -168,7 +168,9 @@ void Replay::mergeSegments(int cur_seg, int end_idx) {
 void Replay::publishFrame(CameraType cam_type, uint32_t frame_id) {
   auto it = eidx[cam_type].find(frame_id);
   if (it == eidx[cam_type].end()) {
-    qDebug() << "camera" << cam_type << "no encode id for frame" << frame_id;
+    if (cam_type != DriverCam) {
+      qDebug() << "camera[" << cam_type << "]: no encode id for frame" << frame_id;
+    }
     return;
   }
 

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -257,6 +257,10 @@ void Replay::stream() {
         }
       }
     }
+
+    // wait for all frames to be sent before unlock.(frameReader may be deleted after unlock)
+    camera_server_->waitFramesSent();
+
     lk.unlock();
     usleep(0);
   }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -165,20 +165,17 @@ void Replay::mergeSegments(int cur_seg, int end_idx) {
 }
 
 void Replay::publishFrame(CameraType cam_type, const cereal::FrameData::Reader &frame) {
-  uint32_t frame_id = frame.getFrameId();
-  auto it = eidx[cam_type].find(frame_id);
+  auto it = eidx[cam_type].find(frame.getFrameId());
   if (it == eidx[cam_type].end()) {
     if (cam_type != DriverCam) {
-      qDebug() << "camera[" << cam_type << "]: no encode id for frame" << frame_id;
+      qDebug() << "camera[" << cam_type << "] no encode id for frame" << frame.getFrameId();
     }
     return;
   }
 
-  const EncodeIdx &e = it->second;
-  if (auto &seg = segments[e.segmentNum]; seg && seg->isLoaded()) {
-    if (auto &fr = seg->frames[cam_type]) {
-      camera_server_->pushFrame(cam_type, fr.get(), e.frameEncodeId, frame);
-    }
+  auto &seg = segments[it->second.segmentNum];
+  if (seg && seg->isLoaded() && seg->frames[cam_type]) {
+    camera_server_->pushFrame(cam_type, seg->frames[cam_type].get(), it->second.frameEncodeId, frame);
   }
 }
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -33,7 +33,7 @@ protected:
   void stream();
   void setCurrentSegment(int n);
   void mergeSegments(int begin_idx, int end_idx);
-  void publishFrame(CameraType cam_type, uint32_t frame_id);
+  void publishFrame(CameraType cam_type, const cereal::FrameData::Reader &frame);
 
   bool load_dcam = false, load_ecam = false;
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -4,7 +4,7 @@
 #include <set>
 
 #include <capnp/dynamic.h>
-#include "cereal/visionipc/visionipc_server.h"
+#include "selfdrive/ui/replay/camera.h"
 #include "selfdrive/ui/replay/route.h"
 
 constexpr int FORWARD_SEGS = 2;
@@ -33,6 +33,7 @@ protected:
   void stream();
   void setCurrentSegment(int n);
   void mergeSegments(int begin_idx, int end_idx);
+  void publishFrame(CameraType cam_type, uint32_t frame_id);
 
   bool load_dcam = false, load_ecam = false;
 
@@ -58,6 +59,6 @@ protected:
   SubMaster *sm;
   PubMaster *pm;
   std::set<std::string> socks;
-  VisionIpcServer *vipc_server = nullptr;
   std::unique_ptr<Route> route_;
+  std::unique_ptr<CameraServer> camera_server_;
 };

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -18,7 +18,10 @@ TEST_CASE("FrameReader") {
     // }
     // sequence get 50 frames {
     for (int i = 0; i < 50; ++i) {
-      REQUIRE(fr.get(i) != nullptr);
+      auto dat = fr.get(i);
+      REQUIRE(dat);
+      REQUIRE(dat->first != nullptr);
+      REQUIRE(dat->second != nullptr);
     }
   }
 }

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -18,10 +18,7 @@ TEST_CASE("FrameReader") {
     // }
     // sequence get 50 frames {
     for (int i = 0; i < 50; ++i) {
-      auto dat = fr.get(i);
-      REQUIRE(dat);
-      REQUIRE(dat->first != nullptr);
-      REQUIRE(dat->second != nullptr);
+      REQUIRE(fr.get(i));
     }
   }
 }


### PR DESCRIPTION
send YUV/RGB for all cameras

resolve #20991 :
- [x]  fallback to qcams
~- [ ] occasional OpenCL error on VisionIPC init~
- [x] send YUV/RGB for all cameras ( FrameReader need to be refactored)
