### PR TITLE
refactor c++ replay

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -108,7 +108,7 @@ if GetOption('setup'):
 if arch in ['x86_64', 'Darwin'] and os.path.exists(Dir("#tools/").get_abspath()):
   qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 
-  replay_lib_src = ["replay/replay.cc", "replay/filereader.cc", "replay/framereader.cc"]
+  replay_lib_src = ["replay/replay.cc", "replay/filereader.cc", "replay/framereader.cc", "replay/route.cc"]
 
   replay_lib = qt_env.Library("qt_replay", replay_lib_src, LIBS=base_libs)
   replay_libs = [replay_lib, 'avutil', 'avcodec', 'avformat', 'swscale', 'bz2'] + qt_libs

--- a/selfdrive/ui/replay/filereader.cc
+++ b/selfdrive/ui/replay/filereader.cc
@@ -1,5 +1,6 @@
 #include "selfdrive/ui/replay/filereader.h"
 
+#include <cassert>
 #include <bzlib.h>
 #include "selfdrive/common/util.h"
 
@@ -59,10 +60,11 @@ bool LogReader::load(const std::string &file) {
           break;
       }
       words = kj::arrayPtr(evt->reader.getEnd(), words.end());
-      events.insert(evt->mono_time, evt.release());
+      events.push_back(evt.release());
     } catch (const kj::Exception &e) {
       return false;
     }
   }
+  std::sort(events.begin(), events.end(), Event::lessThan());
   return true;
 }

--- a/selfdrive/ui/replay/filereader.cc
+++ b/selfdrive/ui/replay/filereader.cc
@@ -1,7 +1,7 @@
 #include "selfdrive/ui/replay/filereader.h"
 
 #include <bzlib.h>
-#include <QtNetwork>
+#include "selfdrive/common/util.h"
 
 static bool decompressBZ2(std::vector<uint8_t> &dest, const char srcData[], size_t srcSize,
                           size_t outputSizeIncrement = 0x100000U) {
@@ -25,85 +25,24 @@ static bool decompressBZ2(std::vector<uint8_t> &dest, const char srcData[], size
   return ret == BZ_STREAM_END;
 }
 
-// class FileReader
-
-FileReader::FileReader(const QString &fn, QObject *parent) : url_(fn), QObject(parent) {}
-
-void FileReader::read() {
-  if (url_.isLocalFile()) {
-    QFile file(url_.toLocalFile());
-    if (file.open(QIODevice::ReadOnly)) {
-      emit finished(file.readAll());
-    } else {
-      emit failed(QString("Failed to read file %1").arg(url_.toString()));
-    }
-  } else {
-    startHttpRequest();
-  }
-}
-
-void FileReader::startHttpRequest() {
-  QNetworkAccessManager *qnam = new QNetworkAccessManager(this);
-  QNetworkRequest request(url_);
-  request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-  reply_ = qnam->get(request);
-  connect(reply_, &QNetworkReply::finished, [=]() {
-    if (!reply_->error()) {
-      emit finished(reply_->readAll());
-    } else {
-      emit failed(reply_->errorString());
-    }
-    reply_->deleteLater();
-    reply_ = nullptr;
-  });
-}
-
-void FileReader::abort() {
-  if (reply_) reply_->abort();
-}
-
-// class LogReader
-
-LogReader::LogReader(const QString &file, QObject *parent) : QObject(parent) {
-  file_reader_ = new FileReader(file);
-  file_reader_->moveToThread(&thread_);
-  connect(&thread_, &QThread::started, file_reader_, &FileReader::read);
-  connect(&thread_, &QThread::finished, file_reader_, &FileReader::deleteLater);
-  connect(file_reader_, &FileReader::finished, [=](const QByteArray &dat) {
-    parseEvents(dat);
-  });
-  connect(file_reader_, &FileReader::failed, [=](const QString &err) {
-    qDebug() << err;
-  });
-  thread_.start();
-}
-
 LogReader::~LogReader() {
-  // wait until thread is finished.
-  exit_ = true;
-  file_reader_->abort();
-  thread_.quit();
-  thread_.wait();
-
-  // clear events
-  for (auto e : events) {
-    delete e;
-  }
+  for (auto e : events) delete e;
 }
 
-void LogReader::parseEvents(const QByteArray &dat) {
+bool LogReader::load(const std::string &file) {
   raw_.resize(1024 * 1024 * 64);
-  if (!decompressBZ2(raw_, dat.data(), dat.size())) {
-    qWarning() << "bz2 decompress failed";
+  std::string dat = util::read_file(file);
+  if (dat.empty() || !decompressBZ2(raw_, dat.data(), dat.size())) {
+    LOGW("bz2 decompress failed");
+    return false;
   }
 
   auto insertEidx = [&](CameraType type, const cereal::EncodeIndex::Reader &e) {
     eidx[type][e.getFrameId()] = {e.getSegmentNum(), e.getSegmentId()};
   };
 
-  valid_ = true;
   kj::ArrayPtr<const capnp::word> words((const capnp::word *)raw_.data(), raw_.size() / sizeof(capnp::word));
-  while (!exit_ && words.size() > 0) {
+  while (words.size() > 0) {
     try {
       std::unique_ptr<Event> evt = std::make_unique<Event>(words);
       switch (evt->which) {
@@ -122,11 +61,8 @@ void LogReader::parseEvents(const QByteArray &dat) {
       words = kj::arrayPtr(evt->reader.getEnd(), words.end());
       events.insert(evt->mono_time, evt.release());
     } catch (const kj::Exception &e) {
-      valid_ = false;
-      break;
+      return false;
     }
   }
-  if (!exit_) {
-    emit finished(valid_);  
-  }
+  return true;
 }

--- a/selfdrive/ui/replay/filereader.h
+++ b/selfdrive/ui/replay/filereader.h
@@ -1,14 +1,11 @@
 #pragma once
 
+#include <QMultiMap>
 #include <unordered_map>
 #include <vector>
 
-#include <QMultiMap>
-
 #include <capnp/serialize.h>
-
 #include "cereal/gen/cpp/log.capnp.h"
-
 #include "selfdrive/camerad/cameras/camera_common.h"
 
 const CameraType ALL_CAMERAS[] = {RoadCam, DriverCam, WideRoadCam};

--- a/selfdrive/ui/replay/filereader.h
+++ b/selfdrive/ui/replay/filereader.h
@@ -3,11 +3,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <QElapsedTimer>
 #include <QMultiMap>
-#include <QNetworkAccessManager>
-#include <QString>
-#include <QThread>
 
 #include <capnp/serialize.h>
 
@@ -15,32 +11,12 @@
 
 #include "selfdrive/camerad/cameras/camera_common.h"
 
-class FileReader : public QObject {
-  Q_OBJECT
-
-public:
-  FileReader(const QString &fn, QObject *parent = nullptr);
-  void read();
-  void abort();
-
-signals:
-  void finished(const QByteArray &dat);
-  void failed(const QString &err);
-
-private:
-  void startHttpRequest();
-  QNetworkReply *reply_ = nullptr;
-  QUrl url_;
-};
-
 const CameraType ALL_CAMERAS[] = {RoadCam, DriverCam, WideRoadCam};
 const int MAX_CAMERAS = std::size(ALL_CAMERAS);
-
 struct EncodeIdx {
   int segmentNum;
   uint32_t frameEncodeId;
 };
-
 class Event {
 public:
   Event(const kj::ArrayPtr<const capnp::word> &amsg) : reader(amsg) {
@@ -58,27 +34,16 @@ public:
   kj::ArrayPtr<const capnp::word> words;
 };
 
-class LogReader : public QObject {
-  Q_OBJECT
-
+class LogReader {
 public:
-  LogReader(const QString &file, QObject *parent = nullptr);
+  LogReader() = default;
   ~LogReader();
-  inline bool valid() const { return valid_; }
+  bool load(const std::string &file);
 
   QMultiMap<uint64_t, Event*> events;
   std::unordered_map<uint32_t, EncodeIdx> eidx[MAX_CAMERAS] = {};
 
-signals:
-  void finished(bool success);
-
 private:
   void parseEvents(const QByteArray &dat);
-
-  std::atomic<bool> exit_ = false;
-  std::atomic<bool> valid_ = false;
   std::vector<uint8_t> raw_;
-
-  FileReader *file_reader_ = nullptr;
-  QThread thread_;
 };

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -1,7 +1,5 @@
 #include "selfdrive/ui/replay/framereader.h"
 
-#include <unistd.h>
-
 #include <cassert>
 
 static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op) {

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -3,7 +3,6 @@
 #include <unistd.h>
 
 #include <cassert>
-#include "selfdrive/common/timing.h"
 
 static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op) {
   std::mutex *mutex = (std::mutex *)*arg;
@@ -35,7 +34,7 @@ public:
   ~AVInitializer() { avformat_network_deinit(); }
 };
 
-FrameReader::FrameReader(const std::string &url, int timeout_sec) : url_(url), timeout_(timeout_sec) {
+FrameReader::FrameReader() {
   static AVInitializer av_initializer;
 }
 
@@ -74,24 +73,14 @@ FrameReader::~FrameReader() {
   }
 }
 
-int FrameReader::check_interrupt(void *p) {
-  FrameReader *fr = static_cast<FrameReader*>(p);
-  return fr->exit_ || (fr->timeout_ > 0 && millis_since_boot() > fr->timeout_ms_);
-}
-
-bool FrameReader::process() {
+bool FrameReader::load(const std::string &url) {
   pFormatCtx_ = avformat_alloc_context();
-  pFormatCtx_->interrupt_callback.callback = &FrameReader::check_interrupt;
-  pFormatCtx_->interrupt_callback.opaque = (void *)this;
-  if (timeout_ > 0) {
-    timeout_ms_ = millis_since_boot() + timeout_ * 1000;
-  }
-  if (avformat_open_input(&pFormatCtx_, url_.c_str(), NULL, NULL) != 0) {
-    printf("error loading %s\n", url_.c_str());
+  if (avformat_open_input(&pFormatCtx_, url.c_str(), NULL, NULL) != 0) {
+    printf("error loading %s\n", url.c_str());
     return false;
   }
   avformat_find_stream_info(pFormatCtx_, NULL);
-  av_dump_format(pFormatCtx_, 0, url_.c_str(), 0);
+  av_dump_format(pFormatCtx_, 0, url.c_str(), 0);
 
   auto pCodecCtxOrig = pFormatCtx_->streams[0]->codec;
   auto pCodec = avcodec_find_decoder(pCodecCtxOrig->codec_id);

--- a/selfdrive/ui/replay/framereader.h
+++ b/selfdrive/ui/replay/framereader.h
@@ -19,9 +19,9 @@ extern "C" {
 
 class FrameReader {
 public:
-  FrameReader(const std::string &url, int timeout_sec = 0);
+  FrameReader();
   ~FrameReader();
-  bool process();
+  bool load(const std::string &url);
   uint8_t *get(int idx);
   int getRGBSize() const { return width * height * 3; }
   size_t getFrameCount() const { return frames_.size(); }
@@ -32,7 +32,6 @@ public:
 private:
   void decodeThread();
   uint8_t *decodeFrame(AVPacket *pkt);
-  static int check_interrupt(void *p);
   struct Frame {
     AVPacket pkt = {};
     uint8_t *data = nullptr;
@@ -52,8 +51,5 @@ private:
   int decode_idx_ = 0;
   std::atomic<bool> exit_ = false;
   bool valid_ = false;
-  std::string url_;
   std::thread decode_thread_;
-  int timeout_ = 0;
-  double timeout_ms_ = 0;
 };

--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -1,5 +1,6 @@
 #include "selfdrive/ui/replay/replay.h"
 
+#include <iostream>
 #include <termios.h>
 
 #include <QApplication>

--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -68,6 +68,7 @@ int main(int argc, char *argv[]){
   parser.addPositionalArgument("route", "the drive to replay. find your drives at connect.comma.ai");
   parser.addOption({{"a", "allow"}, "whitelist of services to send", "allow"});
   parser.addOption({{"b", "block"}, "blacklist of services to send", "block"});
+  parser.addOption({{"s", "start"}, "start from <seconds>", "seconds"});
   parser.addOption({"demo", "use a demo route instead of providing your own"});
 
   parser.process(a);
@@ -80,7 +81,7 @@ int main(int argc, char *argv[]){
   QStringList allow = parser.value("allow").isEmpty() ? QStringList{} : parser.value("allow").split(",");
   QStringList block = parser.value("block").isEmpty() ? QStringList{} : parser.value("block").split(",");
   Replay *replay = new Replay(route, allow, block);
-  replay->start();
+  replay->start(parser.value("start").toInt());
 
   // start keyboard control thread
   QThread *t = QThread::create(keyboardThread, replay);

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -189,12 +189,12 @@ void Replay::stream() {
       }
 
       if (socks.find(type) != socks.end()) {
-        setCurrentSegment(current_ts / 60);
         if (std::abs(current_ts - last_print) > 5.0) {
           last_print = current_ts;
           qInfo() << "at " << int(last_print) << "s";
         }
 
+        setCurrentSegment(current_ts / 60);
         // keep time
         long etime = cur_mono_time - evt_start_ts;
         long rtime = nanos_since_boot() - loop_start_ts;

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -17,7 +17,7 @@ public:
   Replay(QString route, QStringList allow, QStringList block, SubMaster *sm = nullptr, QObject *parent = 0);
   ~Replay();
 
-  void start();
+  void start(int seconds = 0);
   void relativeSeek(int seconds);
   void seekTo(int seconds);
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -43,7 +43,7 @@ protected:
   // logs
   std::mutex lock;
   std::atomic<bool> updating_events = false;
-  QMultiMap<uint64_t, Event *> *events = nullptr;
+  std::vector<Event *> *events = nullptr;
   std::unordered_map<uint32_t, EncodeIdx> *eidx = nullptr;
   std::vector<std::unique_ptr<Segment>> segments;
   std::vector<int> segments_merged;

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QThread>
-#include <QVector>
+#include <set>
 
 #include <capnp/dynamic.h>
 #include "cereal/visionipc/visionipc_server.h"
@@ -51,7 +51,7 @@ protected:
   // messaging
   SubMaster *sm;
   PubMaster *pm;
-  QVector<std::string> socks;
+  std::set<std::string> socks;
   VisionIpcServer *vipc_server = nullptr;
   std::unique_ptr<Route> route_;
 };

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <iostream>
-
 #include <QThread>
 #include <QVector>
-#include <capnp/dynamic.h>
 
+#include <capnp/dynamic.h>
 #include "cereal/visionipc/visionipc_server.h"
 #include "selfdrive/ui/replay/route.h"
 
@@ -17,6 +15,7 @@ class Replay : public QObject {
 
 public:
   Replay(QString route, QStringList allow, QStringList block, SubMaster *sm = nullptr, QObject *parent = 0);
+  ~Replay();
 
   void start();
   void relativeSeek(int seconds);

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -2,16 +2,12 @@
 
 #include <iostream>
 
-#include <QJsonArray>
 #include <QThread>
-
+#include <QVector>
 #include <capnp/dynamic.h>
 
 #include "cereal/visionipc/visionipc_server.h"
-#include "selfdrive/common/util.h"
-#include "selfdrive/ui/qt/api.h"
-#include "selfdrive/ui/replay/filereader.h"
-#include "selfdrive/ui/replay/framereader.h"
+#include "selfdrive/ui/replay/route.h"
 
 constexpr int FORWARD_SEGS = 2;
 constexpr int BACKWARD_SEGS = 2;
@@ -23,43 +19,40 @@ public:
   Replay(QString route, QStringList allow, QStringList block, SubMaster *sm = nullptr, QObject *parent = 0);
 
   void start();
-  void addSegment(int n);
   void relativeSeek(int seconds);
   void seekTo(int seconds);
 
+signals:
+ void segmentChanged(int);
+
+protected slots:
+  void queueSegment();
+
+protected:
   void stream();
-  void segmentQueueThread();
+  void setCurrentSegment(int n);
+  void mergeSegments(int begin_idx, int end_idx);
 
-public slots:
-  void parseResponse(const QString &response);
-  void mergeEvents();
-
-private:
   float last_print = 0;
-  uint64_t route_start_ts;
+  uint64_t route_start_ts = 0;
   std::atomic<int> seek_ts = 0;
   std::atomic<int> current_ts = 0;
-  std::atomic<int> current_segment = 0;
+  std::atomic<int> current_segment = -1;
 
   QThread *thread;
-  QThread *kb_thread;
-  QThread *queue_thread;
 
   // logs
   std::mutex lock;
   std::atomic<bool> updating_events = false;
   QMultiMap<uint64_t, Event *> *events = nullptr;
   std::unordered_map<uint32_t, EncodeIdx> *eidx = nullptr;
-
-  HttpRequest *http;
-  QJsonArray camera_paths;
-  QJsonArray log_paths;
-  QMap<int, LogReader*> lrs;
-  QMap<int, FrameReader*> frs;
+  std::vector<std::unique_ptr<Segment>> segments;
+  std::vector<int> segments_merged;
 
   // messaging
   SubMaster *sm;
   PubMaster *pm;
   QVector<std::string> socks;
   VisionIpcServer *vipc_server = nullptr;
+  std::unique_ptr<Route> route_;
 };

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -1,0 +1,153 @@
+#include "selfdrive/ui/replay/route.h"
+
+#include <QDir>
+#include <QEventLoop>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QRegExp>
+#include <future>
+
+#include "selfdrive/hardware/hw.h"
+#include "selfdrive/ui/qt/api.h"
+
+Route::Route(const QString &route) : route_(route) {
+  if (!QDir(CACHE_DIR).exists()) {
+    QDir().mkdir(CACHE_DIR);
+  }
+}
+
+bool Route::load() {
+  QEventLoop loop;
+  auto onError = [&loop](const QString &err) {
+    qInfo() << err;
+    loop.quit();
+  };
+
+  bool ret = false;
+  HttpRequest http(nullptr, !Hardware::PC());
+  QObject::connect(&http, &HttpRequest::failedResponse, onError);
+  QObject::connect(&http, &HttpRequest::timeoutResponse, onError);
+  QObject::connect(&http, &HttpRequest::receivedResponse, [&](const QString json) {
+    ret = loadFromJson(json);
+    loop.quit();
+  });
+  http.sendRequest("https://api.commadotai.com/v1/route/" + route_ + "/files");
+  loop.exec();
+  return ret;
+}
+
+bool Route::loadFromJson(const QString &json) {
+  QJsonObject route_files = QJsonDocument::fromJson(json.trimmed().toUtf8()).object();
+  if (route_files.empty()) {
+    qInfo() << "JSON Parse failed";
+    return false;
+  }
+
+  QRegExp rx(R"(\/(\d+)\/)");
+  for (const QString &key : route_files.keys()) {
+    for (const auto &url : route_files[key].toArray()) {
+      QString url_str = url.toString();
+      if (rx.indexIn(url_str) != -1) {
+        const int seg_num = rx.cap(1).toInt();
+        if (segments_.size() <= seg_num) {
+          segments_.resize(seg_num + 1);
+        }
+        if (key == "logs") {
+          segments_[seg_num].rlog = url_str;
+        } else if (key == "qlogs") {
+          segments_[seg_num].qlog = url_str;
+        } else if (key == "cameras") {
+          segments_[seg_num].road_cam = url_str;
+        } else if (key == "dcameras") {
+          segments_[seg_num].driver_cam = url_str;
+        } else if (key == "ecameras") {
+          segments_[seg_num].wide_road_cam = url_str;
+        } else if (key == "qcameras") {
+          segments_[seg_num].qcamera = url_str;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// class Segment
+
+Segment::Segment(int n, const SegmentFile &segment_files) : seg_num_(n), files_(segment_files) {
+  // fallback to qcamera
+  road_cam_path_ = files_.road_cam.isEmpty() ? files_.qcamera : files_.road_cam;
+  valid_ = !files_.rlog.isEmpty() && !road_cam_path_.isEmpty();
+  if (!valid_) return;
+
+  int files_need_download = 0;
+  if (!QUrl(files_.rlog).isLocalFile()) {
+    for (auto &url : {files_.rlog, road_cam_path_, files_.driver_cam, files_.wide_road_cam}) {
+      if (!url.isEmpty() && !QFile::exists(localPath(url))) {
+        qDebug() << "download" << url;
+        downloadFile(url);
+        ++files_need_download;
+      }
+    }
+  }
+  if (files_need_download == 0) {
+    QTimer::singleShot(0, this, &Segment::load);
+  }
+}
+
+Segment::~Segment() {
+  // cancel download, qnam will not abort requests, need to abort them manually
+  deleting_ = true;
+  for (QNetworkReply *replay : replies_) {
+    if (replay->isRunning()) {
+      replay->abort();
+    }
+    replay->deleteLater();
+  }
+}
+
+void Segment::downloadFile(const QString &url) {
+  QNetworkReply *reply = qnam_.get(QNetworkRequest(url));
+  replies_.insert(reply);
+  connect(reply, &QNetworkReply::finished, [=]() {
+    if (reply->error() == QNetworkReply::NoError) {
+      QFile file(localPath(url));
+      if (file.open(QIODevice::WriteOnly)) {
+        file.write(reply->readAll());
+      }
+    }
+    if (!deleting_) {
+      auto it = std::find_if(replies_.begin(), replies_.end(), [=](auto r) { return !r->isFinished(); });
+      if (it == replies_.end()) {
+        load();
+      }
+    }
+  });
+}
+
+// load concurrency
+void Segment::load() {
+  std::vector<std::future<bool>> futures;
+
+  log = std::make_unique<LogReader>();
+  futures.emplace_back(std::async(std::launch::async, [=]() { return log->load(localPath(files_.rlog).toStdString()); }));
+
+  QString camera_files[] = {road_cam_path_, files_.driver_cam, files_.wide_road_cam};
+  for (int i = 0; i < std::size(camera_files); ++i) {
+    if (!camera_files[i].isEmpty()) {
+      frames[i] = std::make_unique<FrameReader>();
+      futures.emplace_back(std::async(std::launch::async, [=]() { return frames[i]->load(localPath(camera_files[i]).toStdString()); }));
+    }
+  }
+
+  int success_cnt = std::accumulate(futures.begin(), futures.end(), 0, [=](int v, auto &f) { return f.get() + v; });
+  loaded_ = valid_ = (success_cnt == futures.size());
+  emit loadFinished();
+}
+
+QString Segment::localPath(const QUrl &url) {
+  if (url.isLocalFile()) return url.toString();
+
+  QByteArray url_no_query = url.toString(QUrl::RemoveQuery).toUtf8();
+  return CACHE_DIR + QString(QCryptographicHash::hash(url_no_query, QCryptographicHash::Sha256).toHex());
+}

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -35,7 +35,7 @@ protected:
 };
 
 class Segment : public QObject {
-Q_OBJECT
+  Q_OBJECT
 
 public:
   Segment(int n, const SegmentFile &segment_files);
@@ -49,13 +49,14 @@ public:
 signals:
   void loadFinished();
 
-protected: 
+protected:
   void load();
   void downloadFile(const QString &url);
   QString localPath(const QUrl &url);
 
   bool loaded_ = false, valid_ = false;
-  bool deleting_ = false;
+  bool aborting_ = false;
+  int downloading_ = 0;
   int seg_num_ = 0;
   SegmentFile files_;
   QString road_cam_path_;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <QNetworkAccessManager>
+#include <QString>
+#include <vector>
+
+#include "selfdrive/common/util.h"
+#include "selfdrive/ui/replay/filereader.h"
+#include "selfdrive/ui/replay/framereader.h"
+
+const QString CACHE_DIR = util::getenv("COMMA_CACHE", "/tmp/comma_download_cache/").c_str();
+
+struct SegmentFile {
+  QString rlog;
+  QString qlog;
+  QString road_cam;
+  QString driver_cam;
+  QString wide_road_cam;
+  QString qcamera;
+};
+
+class Route {
+public:
+  Route(const QString &route);
+  bool load();
+
+  inline const QString &name() const { return route_; };
+  inline int size() const { return segments_.size(); }
+  inline SegmentFile &at(int n) { return segments_[n]; }
+
+protected:
+  bool loadFromJson(const QString &json);
+  QString route_;
+  std::vector<SegmentFile> segments_;
+};
+
+class Segment : public QObject {
+Q_OBJECT
+
+public:
+  Segment(int n, const SegmentFile &segment_files);
+  ~Segment();
+  inline bool isValid() const { return valid_; };
+  inline bool isLoaded() const { return loaded_; }
+
+  std::unique_ptr<LogReader> log;
+  std::unique_ptr<FrameReader> frames[MAX_CAMERAS] = {};
+
+signals:
+  void loadFinished();
+
+protected: 
+  void load();
+  void downloadFile(const QString &url);
+  QString localPath(const QUrl &url);
+
+  bool loaded_ = false, valid_ = false;
+  bool deleting_ = false;
+  int seg_num_ = 0;
+  SegmentFile files_;
+  QString road_cam_path_;
+  QSet<QNetworkReply *> replies_;
+  QNetworkAccessManager qnam_;
+};

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -1,29 +1,15 @@
-#include "selfdrive/ui/replay/framereader.h"
-#include "selfdrive/ui/replay/replay.h"
-#include "selfdrive/ui/replay/route.h"
-
-#define CATCH_CONFIG_RUNNER
-#include <QCoreApplication>
-
+#define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
-
-int main(int argc, char **argv) {
-  // unit tests for Qt
-  QCoreApplication app(argc, argv);
-  const int res = Catch::Session().run(argc, argv);
-  return (res < 0xff ? res : 0xff);
-}
+#include "selfdrive/ui/replay/framereader.h"
 
 const char *stream_url = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/fcamera.hevc";
 
 TEST_CASE("FrameReader") {
   SECTION("process&get") {
     FrameReader fr;
-    bool ret = fr.load(stream_url);
-    REQUIRE(ret == true);
+    REQUIRE(fr.load(stream_url) == true);
     REQUIRE(fr.valid() == true);
     REQUIRE(fr.getFrameCount() == 1200);
-
     // random get 50 frames
     // srand(time(NULL));
     // for (int i = 0; i < 50; ++i) {
@@ -34,46 +20,5 @@ TEST_CASE("FrameReader") {
     for (int i = 0; i < 50; ++i) {
       REQUIRE(fr.get(i) != nullptr);
     }
-  }
-}
-
-TEST_CASE("route") {
-  QString route_name = "0982d79ebb0de295|2021-01-17--17-13-08";
-  Route route(route_name);
-  REQUIRE(route.load());
-  REQUIRE(route.size() == 27);
-  for (int i = 0; i < route.size(); ++i) {
-    REQUIRE(!route.at(i).rlog.isEmpty());
-    REQUIRE(!route.at(i).road_cam.isEmpty());
-  }
-
-  SECTION("load segment") {
-    QEventLoop loop;
-    Segment segment(0, route.at(0));
-    REQUIRE(segment.isValid());
-    REQUIRE(!segment.isLoaded());
-    QObject::connect(&segment, &Segment::loadFinished, [&]() {
-      REQUIRE(segment.isLoaded());
-      REQUIRE(segment.log != nullptr);
-      REQUIRE(segment.frames[RoadCam] != nullptr);
-      REQUIRE(segment.frames[DriverCam] == nullptr);
-      REQUIRE(segment.frames[WideRoadCam] == nullptr);
-      loop.quit();
-    });
-    loop.exec();
-  }
-
-  SECTION("load segment, http error") {
-    QEventLoop loop;
-    SegmentFile files = route.at(0);
-    files.rlog = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/rlog_invalid.bz2";
-    Segment segment(0, files);
-    REQUIRE(segment.isValid());
-    QObject::connect(&segment, &Segment::loadFinished, [&]() {
-      REQUIRE(segment.isLoaded() == false);
-      REQUIRE(segment.isValid() == false);
-      loop.quit();
-    });
-    loop.exec();
   }
 }


### PR DESCRIPTION
- [x]  cache route files
- [x]  skip invalid/missing segments.
- [x]  read frames from all cameras.(fall back to qcamera)
- [x]  thread safe merging segments in correct order
- [x] cancel downloading & remove segments in time
- [x] merged #22239 

resolve #22221 :
1. fallback to qcams, ideally we don't require video either
2. stop replay while waiting for video to load (the time is still progressing)
3.  work with only 1 segment routes
4. show error when route is not found
5. sometimes replay starts in the second segment
6. add optional argument for start time
7. segfaults randomly

the remain issues related with camera will be resolved in #22195 
seeking related issues will be fixed in #22319