### PR TITLE
replay: unlock mutex before sleep

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -201,6 +201,7 @@ void Replay::stream() {
     std::unique_lock lk(lock);
 
     if (!events || events->size() == 0) {
+      lk.unlock();
       qDebug() << "waiting for events";
       QThread::msleep(100);
       continue;
@@ -285,6 +286,7 @@ void Replay::stream() {
         }
       }
     }
+    lk.unlock();
     updating_events = false;
     usleep(0);
   }


### PR DESCRIPTION
unlock mutex before sleep to guarantee that the merge thread can get the lock immediately.