### PR TITLE
c++ replay: refactor FrameReader

### DIFF
--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -42,19 +42,14 @@ void CameraServer::thread() {
     }
 
     // send frame
-    if (auto dat = fr->get(eidx.getSegmentId())) {
-      auto [rgb_dat, yuv_dat] = *dat;
+    VisionBuf *rgb_buf = vipc_server_->get_buffer(cam.rgb_type);
+    VisionBuf *yuv_buf = vipc_server_->get_buffer(cam.yuv_type);
+    if (fr->get(eidx.getSegmentId(), (uint8_t *)rgb_buf->addr, (uint8_t *)yuv_buf->addr)) {
       VisionIpcBufExtra extra = {
           .frame_id = eidx.getFrameId(),
           .timestamp_sof = eidx.getTimestampSof(),
           .timestamp_eof = eidx.getTimestampEof(),
       };
-
-      VisionBuf *rgb_buf = vipc_server_->get_buffer(cam.rgb_type);
-      memcpy(rgb_buf->addr, rgb_dat, fr->getRGBSize());
-      VisionBuf *yuv_buf = vipc_server_->get_buffer(cam.yuv_type);
-      memcpy(yuv_buf->addr, yuv_dat, fr->getYUVSize());
-
       vipc_server_->send(rgb_buf, &extra, false);
       vipc_server_->send(yuv_buf, &extra, false);
     } else {

--- a/selfdrive/ui/replay/framereader.cc
+++ b/selfdrive/ui/replay/framereader.cc
@@ -1,34 +1,13 @@
 #include "selfdrive/ui/replay/framereader.h"
 
 #include <cassert>
+ #include <unistd.h>
 
-static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op) {
-  std::mutex *mutex = (std::mutex *)*arg;
-  switch (op) {
-  case AV_LOCK_CREATE:
-    mutex = new std::mutex();
-    break;
-  case AV_LOCK_OBTAIN:
-    mutex->lock();
-    break;
-  case AV_LOCK_RELEASE:
-    mutex->unlock();
-  case AV_LOCK_DESTROY:
-    delete mutex;
-    break;
-  }
-  return 0;
-}
-
-class AVInitializer {
-public:
+struct AVInitializer {
   AVInitializer() {
-    int ret = av_lockmgr_register(ffmpeg_lockmgr_cb);
-    assert(ret >= 0);
     av_register_all();
     avformat_network_init();
   }
-
   ~AVInitializer() { avformat_network_deinit(); }
 };
 
@@ -37,17 +16,8 @@ FrameReader::FrameReader() {
 }
 
 FrameReader::~FrameReader() {
-  // wait until thread is finished.
-  exit_ = true;
-  cv_decode_.notify_all();
-  cv_frame_.notify_all();
-  if (decode_thread_.joinable()) {
-    decode_thread_.join();
-  }
-
-  // free all.
-  for (auto &f : frames_) {
-    av_free_packet(&f.pkt);
+  for (auto &pkt : packets_) {
+    av_free_packet(&pkt);
   }
   if (frmRgb_) {
     av_frame_free(&frmRgb_);
@@ -78,8 +48,12 @@ bool FrameReader::load(const std::string &url) {
   if (!pCodec) return false;
 
   pCodecCtx_ = avcodec_alloc_context3(pCodec);
+
   int ret = avcodec_copy_context(pCodecCtx_, pCodecCtxOrig);
   if (ret != 0) return false;
+
+  pCodecCtx_->thread_count = 0;
+  pCodecCtx_->thread_type = FF_THREAD_FRAME;
 
   ret = avcodec_open2(pCodecCtx_, pCodec, NULL);
   if (ret < 0) return false;
@@ -95,95 +69,57 @@ bool FrameReader::load(const std::string &url) {
   frmRgb_ = av_frame_alloc();
   if (!frmRgb_) return false;
 
-  frames_.reserve(60 * 20);  // 20fps, one minute
-  do {
-    Frame &frame = frames_.emplace_back();
-    int err = av_read_frame(pFormatCtx_, &frame.pkt);
+  packets_.reserve(60 * 20);  // 20fps, one minute
+  while (true) {
+    AVPacket &pkt = packets_.emplace_back();
+    int err = av_read_frame(pFormatCtx_, &pkt);
     if (err < 0) {
-      frames_.pop_back();
+      packets_.pop_back();
       valid_ = (err == AVERROR_EOF);
       break;
     }
-  } while (!exit_);
-
-  if (valid_) {
-    decode_thread_ = std::thread(&FrameReader::decodeThread, this);
-  }
+  };
   return valid_;
 }
 
-std::optional<std::pair<uint8_t *, uint8_t *>> FrameReader::get(int idx) {
-  if (!valid_ || idx < 0 || idx >= frames_.size()) {
-    return std::nullopt;
-  }
-  std::unique_lock lk(mutex_);
-  decode_idx_ = idx;
-  cv_decode_.notify_one();
-  cv_frame_.wait(lk, [=] { return exit_ || frames_[idx].rgb_data || frames_[idx].failed; });
-  if (!frames_[idx].rgb_data) {
-    return std::nullopt;
-  }
-  return std::make_pair(frames_[idx].rgb_data.get(), frames_[idx].yuv_data.get());
+bool FrameReader::get(int idx, uint8_t *rgb_dat, uint8_t *yuv_dat) {
+  if (!valid_ || idx < 0 || idx >= packets_.size()) return false;
+  return decodeFrame(&packets_[idx], rgb_dat, yuv_dat);
 }
 
-void FrameReader::decodeThread() {
-  int idx = 0;
-  while (!exit_) {
-    const int from = std::max(idx - 15, 0);
-    const int to = std::min(idx + 20, (int)frames_.size());
-    for (int i = 0; i < frames_.size() && !exit_; ++i) {
-      Frame &frame = frames_[i];
-      if (i >= from && i < to) {
-        if (frame.rgb_data || frame.failed) continue;
-
-        auto [rgb_data, yuv_data] = decodeFrame(&frame.pkt);
-        std::unique_lock lk(mutex_);
-        frame.rgb_data.reset(rgb_data);
-        frame.yuv_data.reset(yuv_data);
-        frame.failed = !rgb_data;
-        cv_frame_.notify_all();
-      } else {
-        frame.rgb_data.reset(nullptr);
-        frame.yuv_data.reset(nullptr);
-        frame.failed = false;
-      }
-    }
-
-    // sleep & wait
-    std::unique_lock lk(mutex_);
-    cv_decode_.wait(lk, [=] { return exit_ || decode_idx_ != -1; });
-    idx = decode_idx_;
-    decode_idx_ = -1;
-  }
-}
-
-std::pair<uint8_t *, uint8_t *> FrameReader::decodeFrame(AVPacket *pkt) {
-  uint8_t *rgb_data = nullptr, *yuv_data = nullptr;
+bool FrameReader::decodeFrame(AVPacket *pkt, uint8_t *rgb_dat, uint8_t *yuv_dat) {
+  bool success = false;
   int gotFrame = 0;
   AVFrame *f = av_frame_alloc();
-  avcodec_decode_video2(pCodecCtx_, f, &gotFrame, pkt);
+  while (true) {
+    int ret = avcodec_decode_video2(pCodecCtx_, f, &gotFrame, pkt);
+    if (ret > 0 && !gotFrame) {
+      // decode thread is still receiving the initial packets
+      usleep(0);
+    } else {
+      break;
+    }
+  }
   if (gotFrame) {
-    rgb_data = new uint8_t[getRGBSize()];
-    yuv_data = new uint8_t[getYUVSize()];
-    int i, j, k;
-    for (i = 0; i < f->height; i++) {
-      memcpy(yuv_data + f->width * i, f->data[0] + f->linesize[0] * i, f->width);
+    if (yuv_dat) {
+      int i, j, k;
+      for (i = 0; i < f->height; i++) {
+        memcpy(yuv_dat + f->width * i, f->data[0] + f->linesize[0] * i, f->width);
+      }
+      for (j = 0; j < f->height / 2; j++) {
+        memcpy(yuv_dat + f->width * i + f->width / 2 * j, f->data[1] + f->linesize[1] * j, f->width / 2);
+      }
+      for (k = 0; k < f->height / 2; k++) {
+        memcpy(yuv_dat + f->width * i + f->width / 2 * j + f->width / 2 * k, f->data[2] + f->linesize[2] * k, f->width / 2);
+      }
+      success = true;
     }
-    for (j = 0; j < f->height / 2; j++) {
-      memcpy(yuv_data + f->width * i + f->width / 2 * j, f->data[1] + f->linesize[1] * j, f->width / 2);
-    }
-    for (k = 0; k < f->height / 2; k++) {
-      memcpy(yuv_data + f->width * i + f->width / 2 * j + f->width / 2 * k, f->data[2] + f->linesize[2] * k, f->width / 2);
-    }
-
-    int ret = avpicture_fill((AVPicture *)frmRgb_, rgb_data, AV_PIX_FMT_BGR24, f->width, f->height);
-    assert(ret > 0);
-    if (sws_scale(sws_ctx_, (const uint8_t **)f->data, f->linesize, 0, f->height, frmRgb_->data, frmRgb_->linesize) <= 0) {
-      delete[] rgb_data;
-      delete[] yuv_data;
-      rgb_data = yuv_data = nullptr;
+    if (rgb_dat) {
+      int ret = avpicture_fill((AVPicture *)frmRgb_, rgb_dat, AV_PIX_FMT_BGR24, f->width, f->height);
+      assert(ret > 0);
+      success = sws_scale(sws_ctx_, (const uint8_t **)f->data, f->linesize, 0, f->height, frmRgb_->data, frmRgb_->linesize) > 0;
     }
   }
   av_frame_free(&f);
-  return {rgb_data, yuv_data};
+  return success;
 }

--- a/selfdrive/ui/replay/framereader.h
+++ b/selfdrive/ui/replay/framereader.h
@@ -1,14 +1,8 @@
 #pragma once
 
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
-#include <optional>
 #include <string>
-#include <thread>
 #include <vector>
 
-// independent of QT, needs ffmpeg
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
@@ -20,35 +14,21 @@ public:
   FrameReader();
   ~FrameReader();
   bool load(const std::string &url);
-  std::optional<std::pair<uint8_t *, uint8_t*>> get(int idx);
+  bool get(int idx, uint8_t* rgb_dat, uint8_t *yuv_dat = nullptr);
   int getRGBSize() const { return width * height * 3; }
   int getYUVSize() const { return width * height * 3 / 2; }
-  size_t getFrameCount() const { return frames_.size(); }
+  size_t getFrameCount() const { return packets_.size(); }
   bool valid() const { return valid_; }
 
   int width = 0, height = 0;
 
 private:
-  void decodeThread();
-  std::pair<uint8_t *, uint8_t *> decodeFrame(AVPacket *pkt);
-  struct Frame {
-    AVPacket pkt = {};
-    std::unique_ptr<uint8_t[]> rgb_data = nullptr;
-    std::unique_ptr<uint8_t[]> yuv_data = nullptr;
-    bool failed = false;
-  };
-  std::vector<Frame> frames_;
+  bool decodeFrame(AVPacket *pkt, uint8_t *rgb_dat, uint8_t *yuv_dat = nullptr);
 
+  std::vector<AVPacket> packets_;
   AVFormatContext *pFormatCtx_ = nullptr;
   AVCodecContext *pCodecCtx_ = nullptr;
   AVFrame *frmRgb_ = nullptr;
   struct SwsContext *sws_ctx_ = nullptr;
-
-  std::mutex mutex_;
-  std::condition_variable cv_decode_;
-  std::condition_variable cv_frame_;
-  int decode_idx_ = 0;
-  std::atomic<bool> exit_ = false;
   bool valid_ = false;
-  std::thread decode_thread_;
 };


### PR DESCRIPTION
 the decode time of each frame is reduced from ~20ms to less than 1ms after refactor.there is no need to use a separate decode thread in FrameReader now.
If the performance is still not enough, we can do additional caching in CameraServer #22195

