### PR TITLE
add gnureadline to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -117,6 +117,7 @@ onnx = "*"
 onnxruntime = "*"
 timezonefinder = "*"
 sentry-sdk = "*"
+gnureadline = "*"
 
 [requires]
 python_version = "3.8"


### PR DESCRIPTION
I'm not sure of the practice for adding packages, how easy it is, but this package adds Python readline functionality to the interactive Python environment, so you can actually use your arrow keys to go to previous lines or left and right. Really speeds up quick dev work where you want to jot something down on your C3!