### PR TITLE
c++ replay: fast and reliable merge events

### DIFF
--- a/selfdrive/ui/replay/filereader.cc
+++ b/selfdrive/ui/replay/filereader.cc
@@ -120,13 +120,14 @@ void LogReader::parseEvents(const QByteArray &dat) {
           break;
       }
       words = kj::arrayPtr(evt->reader.getEnd(), words.end());
-      events.insert(evt->mono_time, evt.release());
+      events.push_back(evt.release());
     } catch (const kj::Exception &e) {
       valid_ = false;
       break;
     }
   }
   if (!exit_) {
+    std::sort(events.begin(), events.end(), Event::lessThan());
     emit finished(valid_);  
   }
 }

--- a/selfdrive/ui/replay/filereader.h
+++ b/selfdrive/ui/replay/filereader.h
@@ -3,7 +3,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <QMultiMap>
 #include <QNetworkAccessManager>
 #include <QString>
 #include <QThread>

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -166,7 +166,7 @@ void Replay::stream() {
     if (!next_evt) {
       lk.unlock();
       qDebug() << "waiting for events";
-      QThread::msleep(10);
+      QThread::msleep(100);
       continue;
     }
     seek_ts = -1;

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -35,6 +35,8 @@ public slots:
   void mergeEvents();
 
 private:
+  std::optional<std::vector<Event*>::iterator> nextEvent(cereal::Event::Which which, uint64_t mono_time);
+
   float last_print = 0;
   uint64_t route_start_ts;
   std::atomic<int> seek_ts = 0;
@@ -48,7 +50,7 @@ private:
   // logs
   std::mutex lock;
   std::atomic<bool> updating_events = false;
-  QMultiMap<uint64_t, Event *> *events = nullptr;
+  std::vector<Event *> *events = nullptr;
   std::unordered_map<uint32_t, EncodeIdx> *eidx = nullptr;
 
   HttpRequest *http;

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -37,8 +37,7 @@ public slots:
 private:
   std::optional<std::vector<Event*>::iterator> nextEvent(cereal::Event::Which which, uint64_t mono_time);
 
-  float last_print = 0;
-  uint64_t route_start_ts;
+  uint64_t route_start_ts = 0;
   std::atomic<int> seek_ts = 0;
   std::atomic<int> current_ts = 0;
   std::atomic<int> current_segment = 0;

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 
+#include "selfdrive/ui/replay/filereader.h"
 #include "selfdrive/ui/replay/framereader.h"
 
 const char *stream_url = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/fcamera.hevc";
@@ -31,4 +32,8 @@ TEST_CASE("FrameReader") {
     REQUIRE(fr.valid() == false);
     REQUIRE(fr.getFrameCount() < 1200);
   }
+}
+
+TEST_CASE("Replay") {
+  
 }

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -1,7 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 
-#include "selfdrive/ui/replay/filereader.h"
 #include "selfdrive/ui/replay/framereader.h"
 
 const char *stream_url = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/fcamera.hevc";
@@ -32,8 +31,4 @@ TEST_CASE("FrameReader") {
     REQUIRE(fr.valid() == false);
     REQUIRE(fr.getFrameCount() < 1200);
   }
-}
-
-TEST_CASE("Replay") {
-  
 }


### PR DESCRIPTION
fast and reliable merge events with std::vector. sort events by mono_time and which, the time for merge and sort 5 segments is less than 4ms.

QMultiMap is not suitable for events. it can't guarantee that the events are sent in the correct order without duplicates （mono_time is not UUID), it also takes up more memory and  merging  time. QMultipMap::lower_bound  will also cause the last event to be sent again.