### PR TITLE
Hyundai radar parser

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -572,6 +572,7 @@ opendbc/honda_insight_ex_2019_can_generated.dbc
 opendbc/acura_ilx_2016_nidec.dbc
 
 opendbc/hyundai_kia_generic.dbc
+opendbc/hyundai_kia_mando_fron_radar_gen.dbc
 
 opendbc/mazda_2017.dbc
 

--- a/release/files_common
+++ b/release/files_common
@@ -572,7 +572,7 @@ opendbc/honda_insight_ex_2019_can_generated.dbc
 opendbc/acura_ilx_2016_nidec.dbc
 
 opendbc/hyundai_kia_generic.dbc
-opendbc/hyundai_kia_mando_fron_radar_gen.dbc
+opendbc/hyundai_kia_mando_front_radar.dbc
 
 opendbc/mazda_2017.dbc
 

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -4,6 +4,7 @@ from panda import Panda
 from common.params import Params
 from selfdrive.config import Conversions as CV
 from selfdrive.car.hyundai.values import CAR, EV_CAR, HYBRID_CAR, Buttons, CarControllerParams
+from selfdrive.car.hyundai.radar_interface import RADAR_START_ADDR
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
 from selfdrive.car.interfaces import CarInterfaceBase
 from selfdrive.car.disable_ecu import disable_ecu
@@ -22,7 +23,7 @@ class CarInterface(CarInterfaceBase):
 
     ret.carName = "hyundai"
     ret.safetyModel = car.CarParams.SafetyModel.hyundai
-    ret.radarOffCan = True
+    ret.radarOffCan = RADAR_START_ADDR not in fingerprint[1]
 
     ret.openpilotLongitudinalControl = Params().get_bool("DisableRadar") and candidate in [CAR.SONATA, CAR.PALISADE]
     ret.safetyParam = 0

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -76,9 +76,10 @@ class RadarInterface(RadarInterfaceBase):
 
       valid = msg['STATE'] == 3
       if valid:
+        azimuth = math.radians(msg['AZIMUTH'])
         self.pts[addr].measured = True
-        self.pts[addr].dRel = msg['LONG_DIST']
-        self.pts[addr].yRel = 0.5 * -math.sin(math.radians(msg['AZIMUTH'])) * msg['LONG_DIST']
+        self.pts[addr].dRel = math.cos(azimuth) * msg['LONG_DIST']
+        self.pts[addr].yRel = 0.5 * -math.sin(azimuth) * msg['LONG_DIST']
         self.pts[addr].vRel = msg['REL_SPEED']
         self.pts[addr].aRel = msg['REL_ACCEL'] 
         self.pts[addr].yvRel = float('nan')

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -17,11 +17,11 @@ def get_radar_can_parser(CP):
   for addr in range(RADAR_START_ADDR, RADAR_START_ADDR + RADAR_MSG_COUNT):
     msg = f"R_{hex(addr)}"
     signals += [
-      ("NEW_SIGNAL_2", msg, 0),
-      ("NEW_SIGNAL_3", msg, 0),
-      ("NEW_SIGNAL_4", msg, 0),
-      ("NEW_SIGNAL_5", msg, 0),
-      ("NEW_SIGNAL_9", msg, 0),
+      ("STATE", msg, 0),
+      ("AZIMUTH", msg, 0),
+      ("LONG_DIST", msg, 0),
+      ("REL_ACCEL", msg, 0),
+      ("REL_SPEED", msg, 0),
     ]
     checks += [(msg, 50)]
   return CANParser(DBC[CP.carFingerprint]['radar'], signals, checks, 1)
@@ -71,18 +71,15 @@ class RadarInterface(RadarInterfaceBase):
         self.pts[addr].trackId = self.track_id
         self.track_id += 1
 
-      valid = cpt[msg]['NEW_SIGNAL_3'] in [3, 3]
+      valid = cpt[msg]['STATE'] == 3
       if valid:
         self.pts[addr].measured = True
-        self.pts[addr].dRel = cpt[msg]['NEW_SIGNAL_4']
-        self.pts[addr].yRel = 0.5 * -math.sin(math.radians(cpt[msg]['NEW_SIGNAL_2'])) * cpt[msg]['NEW_SIGNAL_4']
-        self.pts[addr].vRel = cpt[msg]['NEW_SIGNAL_9']
-
-        self.pts[addr].aRel = float('nan')
+        self.pts[addr].dRel = cpt[msg]['LONG_DIST']
+        self.pts[addr].yRel = 0.5 * -math.sin(math.radians(cpt[msg]['AZIMUTH'])) * cpt[msg]['LONG_DIST']
+        self.pts[addr].vRel = cpt[msg]['REL_SPEED']
+        self.pts[addr].aRel = cpt[msg]['REL_ACCEL'] 
         self.pts[addr].yvRel = float('nan')
 
-        # sign?
-        # self.pts[addr].aRel = -cpt[msg]['NEW_SIGNAL_5'] 
       else:
         del self.pts[addr]
 

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import math
+
 from cereal import car
 from opendbc.can.parser import CANParser
 from selfdrive.car.interfaces import RadarInterfaceBase
@@ -6,18 +8,19 @@ from selfdrive.car.hyundai.values import DBC
 
 
 def get_radar_can_parser(CP):
-  signals = [
-    # sig_name, sig_address, default
-    ("ACC_ObjStatus", "SCC11", 0),
-    ("ACC_ObjLatPos", "SCC11", 0),
-    ("ACC_ObjDist", "SCC11", 0),
-    ("ACC_ObjRelSpd", "SCC11", 0),
-  ]
-  checks = [
-    # address, frequency
-    ("SCC11", 50),
-  ]
-  return CANParser(DBC[CP.carFingerprint]['pt'], signals, checks, 0)
+  signals = []
+  checks = []
+
+  for addr in range(0x500, 0x500 + 32):
+    msg = f"R_{hex(addr)}"
+    signals += [
+      ("NEW_SIGNAL_2", msg, 0),
+      ("NEW_SIGNAL_3", msg, 0),
+      ("NEW_SIGNAL_4", msg, 0),
+      ("NEW_SIGNAL_5", msg, 0),
+    ]
+    checks += [(msg, 50)]
+  return CANParser(DBC[CP.carFingerprint]['radar'], signals, checks, 1)
 
 
 class RadarInterface(RadarInterfaceBase):
@@ -25,9 +28,11 @@ class RadarInterface(RadarInterfaceBase):
     super().__init__(CP)
     self.rcp = get_radar_can_parser(CP)
     self.updated_messages = set()
-    self.trigger_msg = 0x420
+    self.trigger_msg = 0x500 + 31
     self.track_id = 0
-    self.radar_off_can = CP.radarOffCan
+
+     # TODO: set based of fingerprint
+    self.radar_off_can = False 
 
   def update(self, can_strings):
     if self.radar_off_can:
@@ -47,24 +52,30 @@ class RadarInterface(RadarInterfaceBase):
   def _update(self, updated_messages):
     ret = car.RadarData.new_message()
     cpt = self.rcp.vl
+
     errors = []
     if not self.rcp.can_valid:
       errors.append("canError")
     ret.errors = errors
 
-    valid = cpt["SCC11"]['ACC_ObjStatus']
-    if valid:
-      for ii in range(2):
-        if ii not in self.pts:
-          self.pts[ii] = car.RadarData.RadarPoint.new_message()
-          self.pts[ii].trackId = self.track_id
-          self.track_id += 1
-        self.pts[ii].dRel = cpt["SCC11"]['ACC_ObjDist']  # from front of car
-        self.pts[ii].yRel = -cpt["SCC11"]['ACC_ObjLatPos']  # in car frame's y axis, left is negative
-        self.pts[ii].vRel = cpt["SCC11"]['ACC_ObjRelSpd']
-        self.pts[ii].aRel = float('nan')
-        self.pts[ii].yvRel = float('nan')
-        self.pts[ii].measured = True
+    for addr in range(0x500, 0x500 + 32):
+      msg = f"R_{hex(addr)}"
+
+      if addr not in self.pts:
+        self.pts[addr] = car.RadarData.RadarPoint.new_message()
+        self.pts[addr].trackId = self.track_id
+        self.track_id += 1
+
+      valid = cpt[msg]['NEW_SIGNAL_3'] in [3, 3]
+      if valid:
+        self.pts[addr].measured = True
+        self.pts[addr].dRel = cpt[msg]['NEW_SIGNAL_4']
+        self.pts[addr].yRel = 0.5 * -math.sin(math.radians(cpt[msg]['NEW_SIGNAL_2'])) * cpt[msg]['NEW_SIGNAL_4']
+        self.pts[addr].vRel = -cpt[msg]['NEW_SIGNAL_5'] 
+        self.pts[addr].aRel = float('nan')
+        self.pts[addr].yvRel = float('nan')
+      else:
+        del self.pts[addr]
 
     ret.points = list(self.pts.values())
     return ret

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -74,7 +74,7 @@ class RadarInterface(RadarInterfaceBase):
         self.pts[addr].trackId = self.track_id
         self.track_id += 1
 
-      valid = msg['STATE'] == 3
+      valid = msg['STATE'] in [3, 4]
       if valid:
         azimuth = math.radians(msg['AZIMUTH'])
         self.pts[addr].measured = True

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -18,6 +18,7 @@ def get_radar_can_parser(CP):
       ("NEW_SIGNAL_3", msg, 0),
       ("NEW_SIGNAL_4", msg, 0),
       ("NEW_SIGNAL_5", msg, 0),
+      ("NEW_SIGNAL_9", msg, 0),
     ]
     checks += [(msg, 50)]
   return CANParser(DBC[CP.carFingerprint]['radar'], signals, checks, 1)
@@ -71,9 +72,13 @@ class RadarInterface(RadarInterfaceBase):
         self.pts[addr].measured = True
         self.pts[addr].dRel = cpt[msg]['NEW_SIGNAL_4']
         self.pts[addr].yRel = 0.5 * -math.sin(math.radians(cpt[msg]['NEW_SIGNAL_2'])) * cpt[msg]['NEW_SIGNAL_4']
-        self.pts[addr].vRel = -cpt[msg]['NEW_SIGNAL_5'] 
+        self.pts[addr].vRel = cpt[msg]['NEW_SIGNAL_9'] / 3.0
+
         self.pts[addr].aRel = float('nan')
         self.pts[addr].yvRel = float('nan')
+
+        # sign?
+        # self.pts[addr].aRel = -cpt[msg]['NEW_SIGNAL_5'] 
       else:
         del self.pts[addr]
 

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -66,7 +66,7 @@ class RadarInterface(RadarInterfaceBase):
       errors.append("canError")
     ret.errors = errors
 
-    for addr in range(0x500, 0x500 + 32):
+    for addr in range(RADAR_START_ADDR, RADAR_START_ADDR + RADAR_MSG_COUNT):
       msg = self.rcp.vl[f"R_{hex(addr)}"]
 
       if addr not in self.pts:

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -60,7 +60,6 @@ class RadarInterface(RadarInterfaceBase):
     if self.rcp is None:
       return ret
 
-    cpt = self.rcp.vl
     errors = []
 
     if not self.rcp.can_valid:
@@ -68,20 +67,20 @@ class RadarInterface(RadarInterfaceBase):
     ret.errors = errors
 
     for addr in range(0x500, 0x500 + 32):
-      msg = f"R_{hex(addr)}"
+      msg = self.rcp.vl[f"R_{hex(addr)}"]
 
       if addr not in self.pts:
         self.pts[addr] = car.RadarData.RadarPoint.new_message()
         self.pts[addr].trackId = self.track_id
         self.track_id += 1
 
-      valid = cpt[msg]['STATE'] == 3
+      valid = msg['STATE'] == 3
       if valid:
         self.pts[addr].measured = True
-        self.pts[addr].dRel = cpt[msg]['LONG_DIST']
-        self.pts[addr].yRel = 0.5 * -math.sin(math.radians(cpt[msg]['AZIMUTH'])) * cpt[msg]['LONG_DIST']
-        self.pts[addr].vRel = cpt[msg]['REL_SPEED']
-        self.pts[addr].aRel = cpt[msg]['REL_ACCEL'] 
+        self.pts[addr].dRel = msg['LONG_DIST']
+        self.pts[addr].yRel = 0.5 * -math.sin(math.radians(msg['AZIMUTH'])) * msg['LONG_DIST']
+        self.pts[addr].vRel = msg['REL_SPEED']
+        self.pts[addr].aRel = msg['REL_ACCEL'] 
         self.pts[addr].yvRel = float('nan')
 
       else:

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -76,7 +76,7 @@ class RadarInterface(RadarInterfaceBase):
         self.pts[addr].measured = True
         self.pts[addr].dRel = cpt[msg]['NEW_SIGNAL_4']
         self.pts[addr].yRel = 0.5 * -math.sin(math.radians(cpt[msg]['NEW_SIGNAL_2'])) * cpt[msg]['NEW_SIGNAL_4']
-        self.pts[addr].vRel = cpt[msg]['NEW_SIGNAL_9'] / 3.0
+        self.pts[addr].vRel = cpt[msg]['NEW_SIGNAL_9']
 
         self.pts[addr].aRel = float('nan')
         self.pts[addr].yvRel = float('nan')

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -737,6 +737,8 @@ FEATURES = {
 HYBRID_CAR = set([CAR.IONIQ_PHEV, CAR.ELANTRA_HEV_2021, CAR.KIA_NIRO_HEV, CAR.KIA_NIRO_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_HEV])  # these cars use a different gas signal
 EV_CAR = set([CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_NIRO_EV])
 
+# If 0x500 is present on bus 1 it probably has a Mando radar outputting radar points.
+# If no points are outputted by default it might be possible to turn it on using  selfdrive/debug/hyundai_enable_radar_points.py
 DBC = {
   CAR.ELANTRA: dbc_dict('hyundai_kia_generic', None),
   CAR.ELANTRA_2021: dbc_dict('hyundai_kia_generic', None),
@@ -748,23 +750,23 @@ DBC = {
   CAR.HYUNDAI_GENESIS: dbc_dict('hyundai_kia_generic', None),
   CAR.IONIQ_PHEV: dbc_dict('hyundai_kia_generic', None),
   CAR.IONIQ_EV_2020: dbc_dict('hyundai_kia_generic', None),
-  CAR.IONIQ_EV_LTD: dbc_dict('hyundai_kia_generic', None),
+  CAR.IONIQ_EV_LTD: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.IONIQ: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_FORTE: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_NIRO_EV: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_NIRO_HEV: dbc_dict('hyundai_kia_generic', None),
+  CAR.KIA_NIRO_HEV: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.KIA_NIRO_HEV_2021: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_OPTIMA: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_OPTIMA_H: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_SELTOS: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_SORENTO: dbc_dict('hyundai_kia_generic', None),
+  CAR.KIA_SORENTO: dbc_dict('hyundai_kia_generic', None), # Has 0x5XX messages, but different format
   CAR.KIA_STINGER: dbc_dict('hyundai_kia_generic', None),
   CAR.KONA: dbc_dict('hyundai_kia_generic', None),
   CAR.KONA_EV: dbc_dict('hyundai_kia_generic', None),
   CAR.KONA_HEV: dbc_dict('hyundai_kia_generic', None),
   CAR.SANTA_FE: dbc_dict('hyundai_kia_generic', None),
   CAR.SONATA: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
-  CAR.SONATA_LF: dbc_dict('hyundai_kia_generic', None),
+  CAR.SONATA_LF: dbc_dict('hyundai_kia_generic', None), # Has 0x5XX messages, but different format
   CAR.PALISADE: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.VELOSTER: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_CEED: dbc_dict('hyundai_kia_generic', None),

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -763,7 +763,7 @@ DBC = {
   CAR.KONA_EV: dbc_dict('hyundai_kia_generic', None),
   CAR.KONA_HEV: dbc_dict('hyundai_kia_generic', None),
   CAR.SANTA_FE: dbc_dict('hyundai_kia_generic', None),
-  CAR.SONATA: dbc_dict('hyundai_kia_generic', None),
+  CAR.SONATA: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.SONATA_LF: dbc_dict('hyundai_kia_generic', None),
   CAR.PALISADE: dbc_dict('hyundai_kia_generic', None),
   CAR.VELOSTER: dbc_dict('hyundai_kia_generic', None),

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -765,7 +765,7 @@ DBC = {
   CAR.SANTA_FE: dbc_dict('hyundai_kia_generic', None),
   CAR.SONATA: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.SONATA_LF: dbc_dict('hyundai_kia_generic', None),
-  CAR.PALISADE: dbc_dict('hyundai_kia_generic', None),
+  CAR.PALISADE: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.VELOSTER: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_CEED: dbc_dict('hyundai_kia_generic', None),
   CAR.SONATA_HYBRID: dbc_dict('hyundai_kia_generic', None),

--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import sys
+import argparse
+from subprocess import check_output, CalledProcessError
+
+from panda.python import Panda
+from panda.python.uds import UdsClient, SESSION_TYPE, DATA_IDENTIFIER_TYPE
+
+SUPPORTED_FW_VERSIONS = {
+  # 2020 SONATA
+  b"DN8_ SCC FHCUP      1.00 1.00 99110-L0000         ": {
+    "default_config": b"\x00\x00\x00\x01\x00\x00",
+    "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
+  },
+  # 2020 PALISADE
+  b"LX2_ SCC FHCUP      1.00 1.04 99110-S8100         ": {
+    "default_config": b"\x00\x00\x00\x01\x00\x00",
+    "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
+  },
+}
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='configure radar to output points (or reset to default)')
+  parser.add_argument('--default', action="store_true", default=False, help='reset to default configuration (default: false)')
+  parser.add_argument('--debug', action="store_true", default=False, help='enable debug output (default: false)')
+  parser.add_argument('--bus', type=int, default=0, help='can bus to use (default: 0)')
+  args = parser.parse_args()
+
+  try:
+    check_output(["pidof", "boardd"])
+    print("boardd is running, please kill openpilot before running this script! (aborted)")
+    sys.exit(1)
+  except CalledProcessError as e:
+    if e.returncode != 1: # 1 == no process found (boardd not running)
+      raise e
+
+  confirm = input("put your vehicle in accessory mode now and type OK to continue: ").upper().strip()
+  if confirm != "OK":
+    print("\nyou didn't type 'OK! (aborted)")
+    sys.exit(0)
+
+  panda = Panda() # type: ignore
+  panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  uds_client = UdsClient(panda, 0x7D0, bus=args.bus, debug=args.debug)
+
+  print("\n[START DIAGNOSTIC SESSION]")
+  session_type : SESSION_TYPE = 0x07 # type: ignore
+  uds_client.diagnostic_session_control(session_type)
+
+  print("[HARDWARE/SOFTWARE VERSION]")
+  fw_version_data_id : DATA_IDENTIFIER_TYPE = 0xf100 # type: ignore
+  fw_version = uds_client.read_data_by_identifier(fw_version_data_id)
+  print(fw_version)
+  if fw_version != SUPPORTED_FW_VERSIONS:
+    print("radar not supported! (aborted)")
+    sys.exit(1)
+
+  print("[GET CONFIGURATION]")
+  config_data_id : DATA_IDENTIFIER_TYPE = 0x0142 # type: ignore
+  current_config = uds_client.read_data_by_identifier(config_data_id)
+  new_config = SUPPORTED_FW_VERSIONS[fw_version]["default_config" if args.default else "tracks_enabled"]
+  print(f"current config: 0x{current_config.hex()}")
+  if current_config != new_config:
+    print("[CHANGE CONFIGURATION]")
+    print(f"new config:     0x{new_config.hex()}")
+    uds_client.write_data_by_identifier(config_data_id, new_config)
+    if not args.default and current_config != SUPPORTED_FW_VERSIONS[fw_version]["default_config"]:
+      print("\ncurrent config does not match expected default! (aborted)")
+      sys.exit(1)
+
+    print("[DONE]")
+    print("\nrestart your vehicle and ensure there are no faults")
+    print("you can run this script again with --default to go back to the original (factory) settings")
+  else:
+    print("[DONE]")
+    print("\ncurrent config is already the desired configuration")
+    sys.exit(0)

--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -6,6 +6,8 @@ firmware versions. If you want to try on a new radar make sure to note the defau
 in case it's different from the other radars and you need to revert the changes.
 
 After changing the config the car should not show any faults when openpilot is not running. 
+These config changes are persistent accross car reboots. You need to run this script again
+to go back to the default values.
 
 USE AT YOUR OWN RISK! Safety features, like AEB and FCW, might be affected by these changes."""
 

--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+"""Some Hyundai radars can be reconfigured to output (debug) radar points on bus 1.
+Reconfiguration is done over UDS by reading/writing to 0x0142 using the Read/Write Data By Identifier
+endpoints (0x22 & 0x2E). This script checks your radar firmware version against a list of known 
+firmware versions. If you want to try on a new radar make sure to note the default config value
+in case it's different from the other radars and you need to revert the changes.
+
+After changing the config the car should not show any faults when openpilot is not running. 
+
+USE AT YOUR OWN RISK! Safety features, like AEB and FCW, might be affected by these changes."""
+
 import sys
 import argparse
 from subprocess import check_output, CalledProcessError
@@ -6,6 +16,8 @@ from subprocess import check_output, CalledProcessError
 from panda.python import Panda
 from panda.python.uds import UdsClient, SESSION_TYPE, DATA_IDENTIFIER_TYPE
 
+# If your radar supports changing data identifier 0x0142 as well make a PR to
+# this file to add your firmware version. Make sure to post a drive as proof!
 SUPPORTED_FW_VERSIONS = {
   # 2020 SONATA
   b"DN8_ SCC FHCUP      1.00 1.00 99110-L0000         ": {

--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -20,17 +20,20 @@ from panda.python.uds import UdsClient, SESSION_TYPE, DATA_IDENTIFIER_TYPE
 
 # If your radar supports changing data identifier 0x0142 as well make a PR to
 # this file to add your firmware version. Make sure to post a drive as proof!
+# NOTE: these firmware versions do not match what openpilot uses
+#       because this script uses a different diagnostic session type
 SUPPORTED_FW_VERSIONS = {
   # 2020 SONATA
   b"DN8_ SCC FHCUP      1.00 1.00 99110-L0000\x19\x08)\x15T    ": {
     "default_config": b"\x00\x00\x00\x01\x00\x00",
     "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
   },
-  # 2020 PALISADE
-  b"LX2_ SCC FHCUP      1.00 1.04 99110-S8100         ": {
-    "default_config": b"\x00\x00\x00\x01\x00\x00",
-    "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
-  },
+  # TODO: verify palisade fw version for diagnostic session type 7
+  # # 2020 PALISADE
+  # b"LX2_ SCC FHCUP      1.00 1.04 99110-S8100         ": {
+  #   "default_config": b"\x00\x00\x00\x01\x00\x00",
+  #   "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
+  # },
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
See `selfdrive/debug/hyundai_enable_radar_points.py` to enable radar points on some cars.

> Some Hyundai radars can be reconfigured to output (debug) radar points on bus 1.
> Reconfiguration is done over UDS by reading/writing to 0x0142 using the Read/Write Data By Identifier
> endpoints (0x22 & 0x2E). This script checks your radar firmware version against a list of known 
> firmware versions. If you want to try on a new radar make sure to note the default config value
> in case it's different from the other radars and you need to revert the changes.
> 
> After changing the config the car should not show any faults when openpilot is not running. 
> These config changes are persistent accross car reboots. You need to run this script again
> to go back to the default values.
> 
> USE AT YOUR OWN RISK! Safety features, like AEB and FCW, might be affected by these changes.


Looks like some cars already have this enabled by default. A quick check on our test routes showed the following cars:
- ~KIA_SORENTO_GT_LINE_2018~ Wrong format
- HYUNDAI_IONIQ_ELECTRIC_LIMITED_2019
- KIA_NIRO_HYBRID_2019
- GENESIS_G80_2017
- ~HYUNDAI_SONATA_2019~ Wrong format
