### PR TITLE
VW MQB: Original design J533 harness support

### DIFF
--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -1,3 +1,4 @@
+from os import environ
 from cereal import car
 from selfdrive.car.volkswagen.values import CAR, BUTTON_STATES, CANBUS, NetworkLocation, TransmissionType, GearShifter
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
@@ -39,7 +40,11 @@ class CarInterface(CarInterfaceBase):
       else:
         ret.transmissionType = TransmissionType.manual
 
-      if any(msg in fingerprint[1] for msg in [0x40, 0x86, 0xB2]):  # Airbag_01, LWI_01, ESP_19
+      # For very old community-built harnesses only; no new harnesses should depend on this
+      legacy_j533_harness = environ.get("LEGACY_J533_HARNESS", False)
+      ret.communityFeature = legacy_j533_harness or ret.communityFeature
+
+      if any(msg in fingerprint[1] for msg in [0x40, 0x86, 0xB2]) or legacy_j533_harness:  # Airbag_01, LWI_01, ESP_19
         ret.networkLocation = NetworkLocation.gateway
       else:
         ret.networkLocation = NetworkLocation.fwdCamera


### PR DESCRIPTION
Enhancement to allow use of original design J533 harnesses with stock openpilot.

Back in the day, a bunch of early Black Panda / C2 harnesses were built without bus 1 hooked up. This was before we realized we needed to tweak the design to help autodetect network location. I built and sold some of these myself, and my Tiguan still uses one of those harnesses. Others in the community DIYed and sold them as well.

Most of the end users aren't equipped to update the harness wiring on their own. They're stuck on my old community 0.7.9 branch, which has a Param hack to force network location. This PR will help retire the last of my community branches that a BP/C2/C3 owner would ever need.

It's hard to say exactly how many people are affected. Let's say more than 10, less than 100.

Proposal is to have those users manually put `export LEGACY_J533_HARNESS=1` in the top of `continue.sh`. Once they do that, stock comma openpilot will work, and they can receive and install updates without losing the change. This can be flagged as community supported forever.

I know it's not pretty, but I'd take it as a kindness if you would consider helping out some loyal BP/C2 early adopters. Happy to consider other approaches if you have something to suggest.