### PR TITLE
replay.cc/main: don't splits empty strings

### DIFF
--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -76,7 +76,9 @@ int main(int argc, char *argv[]){
   }
 
   const QString route = args.empty() ? DEMO_ROUTE : args.first();
-  Replay *replay = new Replay(route, parser.value("allow").split(","), parser.value("block").split(","));
+  QStringList allow = parser.value("allow").isEmpty() ? QStringList{} : parser.value("allow").split(",");
+  QStringList block = parser.value("block").isEmpty() ? QStringList{} : parser.value("block").split(",");
+  Replay *replay = new Replay(route, allow, block);
   replay->start();
 
   // start keyboard control thread


### PR DESCRIPTION
Otherwise, the following statement is always false
https://github.com/commaai/openpilot/blob/a1fcedda21d1ff7d53bd647dc4359c5e5941bf47/selfdrive/ui/replay/replay.cc#L14