### PR TITLE
fix yuv420_to_jpeg: thumbnail_width & thumbnail_height must be aliged with 16 pixel.

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -217,9 +217,8 @@ kj::Array<uint8_t> get_frame_image(const CameraBuf *b) {
 }
 
 static kj::Array<capnp::byte> yuv420_to_jpeg(const CameraBuf *b, int thumbnail_width, int thumbnail_height) {
-
-  // make the buffer big enough for the jpeg_write_raw_data.
-  std::unique_ptr<uint8[]> buf(new uint8_t[(thumbnail_width * thumbnail_height * 3)]);
+  // jpeg_write_raw_data requires 16-pixels aligned height to be used.
+  std::unique_ptr<uint8[]> buf(new uint8_t[(thumbnail_width * ((thumbnail_height + 15) & ~15) * 3) / 2]);
   uint8_t *y_plane = buf.get();
   uint8_t *u_plane = y_plane + thumbnail_width * thumbnail_height;
   uint8_t *v_plane = u_plane + (thumbnail_width * thumbnail_height) / 4;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -217,7 +217,7 @@ kj::Array<uint8_t> get_frame_image(const CameraBuf *b) {
 }
 
 static kj::Array<capnp::byte> yuv420_to_jpeg(const CameraBuf *b, int thumbnail_width, int thumbnail_height) {
-  // jpeg_write_raw_data requires 16-pixels aligned height to be used.
+  // make the buffer big enough. jpeg_write_raw_data requires 16-pixels aligned height to be used.
   std::unique_ptr<uint8[]> buf(new uint8_t[(thumbnail_width * ((thumbnail_height + 15) & ~15) * 3) / 2]);
   uint8_t *y_plane = buf.get();
   uint8_t *u_plane = y_plane + thumbnail_width * thumbnail_height;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -218,6 +218,7 @@ kj::Array<uint8_t> get_frame_image(const CameraBuf *b) {
 
 static kj::Array<capnp::byte> yuv420_to_jpeg(const CameraBuf *b, int thumbnail_width, int thumbnail_height) {
 
+  // make the buffer big enough for the jpeg_write_raw_data.
   std::unique_ptr<uint8[]> buf(new uint8_t[(thumbnail_width * thumbnail_height * 3)]);
   uint8_t *y_plane = buf.get();
   uint8_t *u_plane = y_plane + thumbnail_width * thumbnail_height;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -217,11 +217,8 @@ kj::Array<uint8_t> get_frame_image(const CameraBuf *b) {
 }
 
 static kj::Array<capnp::byte> yuv420_to_jpeg(const CameraBuf *b, int thumbnail_width, int thumbnail_height) {
-  
-  thumbnail_width = (thumbnail_width + 15) & ~15;
-  thumbnail_height = (thumbnail_height + 15) & ~15;
 
-  std::unique_ptr<uint8[]> buf(new uint8_t[(thumbnail_width * thumbnail_height * 3) / 2]);
+  std::unique_ptr<uint8[]> buf(new uint8_t[(thumbnail_width * thumbnail_height * 3)]);
   uint8_t *y_plane = buf.get();
   uint8_t *u_plane = y_plane + thumbnail_width * thumbnail_height;
   uint8_t *v_plane = u_plane + (thumbnail_width * thumbnail_height) / 4;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -217,6 +217,10 @@ kj::Array<uint8_t> get_frame_image(const CameraBuf *b) {
 }
 
 static kj::Array<capnp::byte> yuv420_to_jpeg(const CameraBuf *b, int thumbnail_width, int thumbnail_height) {
+  
+  thumbnail_width = (thumbnail_width + 15) & ~15;
+  thumbnail_height = (thumbnail_height + 15) & ~15;
+
   std::unique_ptr<uint8[]> buf(new uint8_t[(thumbnail_width * thumbnail_height * 3) / 2]);
   uint8_t *y_plane = buf.get();
   uint8_t *u_plane = y_plane + thumbnail_width * thumbnail_height;


### PR DESCRIPTION
from document: https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/libjpeg.txt
`The MCU height is max_v_samp_factor = 2 DCT rows so you must pass at least 16 scanlines on each call to jpeg_write_raw_data()`
 It will cause illegal memory violation  if the height is not aligned with 16pixel.

sorry for this silly mistake.