### PR TITLE
Fix throttle scaling in simulator

### DIFF
--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -297,7 +297,7 @@ def bridge(q):
     if is_openpilot_engaged:
       sm.update(0)
       # TODO gas and brake is deprecated
-      throttle_op = clip(sm['carControl'].actuators.accel/4.0, 0.0, 1.0)
+      throttle_op = clip(sm['carControl'].actuators.accel/1.6, 0.0, 1.0)
       brake_op = clip(-sm['carControl'].actuators.accel/4.0, 0.0, 1.0)
       steer_op = sm['carControl'].actuators.steeringAngleDeg
 


### PR DESCRIPTION
Description:
In simulator OP best stuck at 53km/h.

Fix:
Scaled gas command to match a value of `1.0` to the defined `NIDEC_ACCEL_MAX` (1.6) in Honda CarControlParams.
