### PR TITLE
VW MQB: Update to CARS footnotes

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -138,9 +138,9 @@ Community Maintained Cars and Features
 | Subaru    | Crosstrek 2018-19             | EyeSight          | Stock            | 0mph               | 0mph         |
 | Subaru    | Forester 2019-21              | EyeSight          | Stock            | 0mph               | 0mph         |
 | Subaru    | Impreza 2017-19               | EyeSight          | Stock            | 0mph               | 0mph         |
-| Volkswagen| Arteon 2021                   | Driver Assistance | Stock            | 0mph               | 0mph         |
+| Volkswagen| Arteon 2021<sup>4</sup>       | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| Atlas 2018-19                 | Driver Assistance | Stock            | 0mph               | 0mph         |
-| Volkswagen| California 2021               | Driver Assistance | Stock            | 0mph               | 0mph         |
+| Volkswagen| California 2021<sup>4</sup>   | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| e-Golf 2014, 2019-20          | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| Golf 2015-20                  | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| Golf Alltrack 2017-18         | Driver Assistance | Stock            | 0mph               | 0mph         |
@@ -159,6 +159,8 @@ Community Maintained Cars and Features
 <sup>1</sup>Requires an [OBD-II car harness](https://comma.ai/shop/products/comma-car-harness) and [community built ASCM harness](https://github.com/commaai/openpilot/wiki/GM#hardware). ***NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).*** <br />
 <sup>2</sup>Not including the China market Kamiq, which is based on the (currently) unsupported PQ34 platform. <br />
 <sup>3</sup>Only includes the MQB Passat sold outside of North America. The NMS Passat made in Chattanooga, TN is not yet supported. <br />
+<sup>4</sup>Model-years 2021 and beyond require a new camera harness design, which isn't yet available from the comma store. In the interim,
+choose "VW J533 Development" from the vehicle drop-down for a harness that integrates at the CAN gateway inside the dashboard. <br />
 Community Maintained Cars and Features are not verified by comma to meet our [safety model](SAFETY.md). Be extra cautious using them. They are only available after enabling the toggle in `Settings->Developer->Enable Community Features`.
 
 To promote a car from community maintained, it must meet a few requirements. We must own one from the brand, we must sell the harness for it, has full ISO26262 in both panda and openpilot, there must be a path forward for longitudinal control, it must have AEB still enabled, and it must support fingerprinting 2.0

--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -152,15 +152,16 @@ Community Maintained Cars and Features
 | Volkswagen| Jetta 2018-20                 | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| Jetta GLI 2021                | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| Passat 2016-17<sup>3</sup>    | Driver Assistance | Stock            | 0mph               | 0mph         |
-| Volkswagen| T-Cross 2021                  | Driver Assistance | Stock            | 0mph               | 0mph         |
+| Volkswagen| T-Cross 2021<sup>4</sup>      | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| Tiguan 2020                   | Driver Assistance | Stock            | 0mph               | 0mph         |
 | Volkswagen| Touran 2017                   | Driver Assistance | Stock            | 0mph               | 0mph         |
 
 <sup>1</sup>Requires an [OBD-II car harness](https://comma.ai/shop/products/comma-car-harness) and [community built ASCM harness](https://github.com/commaai/openpilot/wiki/GM#hardware). ***NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).*** <br />
 <sup>2</sup>Not including the China market Kamiq, which is based on the (currently) unsupported PQ34 platform. <br />
-<sup>3</sup>Only includes the MQB Passat sold outside of North America. The NMS Passat made in Chattanooga, TN is not yet supported. <br />
-<sup>4</sup>Model-years 2021 and beyond require a new camera harness design, which isn't yet available from the comma store. In the interim,
-choose "VW J533 Development" from the vehicle drop-down for a harness that integrates at the CAN gateway inside the dashboard. <br />
+<sup>3</sup>Not including the USA/China market Passat, which is based on the (currently) unsupported PQ35/NMS platform. <br />
+<sup>4</sup>Model-years 2021 and beyond may have a new camera harness design, which isn't yet available from the comma store. Before ordering,
+remove the Lane Assist camera cover and check to see if the connector is black (older design) or light brown (newer design). For the newer design,
+in the interim, choose "VW J533 Development" from the vehicle drop-down for a harness that integrates at the CAN gateway inside the dashboard.<br />
 Community Maintained Cars and Features are not verified by comma to meet our [safety model](SAFETY.md). Be extra cautious using them. They are only available after enabling the toggle in `Settings->Developer->Enable Community Features`.
 
 To promote a car from community maintained, it must meet a few requirements. We must own one from the brand, we must sell the harness for it, has full ISO26262 in both panda and openpilot, there must be a path forward for longitudinal control, it must have AEB still enabled, and it must support fingerprinting 2.0


### PR DESCRIPTION
Add a temporary footnote to cars for which we don't yet have a compatible camera harness. Hopefully to be removed shortly. While I'm here, tweak the NMS Passat footnote to match the China Kamiq footnote.

I'm not very comfortable right now making blanket model-year statements about VW harness A vs VW harness B. At this time I don't have better guidance than opening the camera cover and looking. I'll do what I can to narrow the window where we need users to look before ordering.

As a general statement, it looks like all MQBs will be switching to the B variant, but production is switching at different points for different models, and I see cases where production is switching mid-model-year. I can determine it myself for a given car using PL24 to dip into the VAG factory database for a particular VIN, but that's not exactly scalable. It's mostly happening around MY2021, although there's at least one 2020 (one we don't have upstreamed yet).