### PR TITLE
webcam: add /usr/include/opencv4 to CPPPATH

### DIFF
--- a/selfdrive/camerad/SConscript
+++ b/selfdrive/camerad/SConscript
@@ -16,7 +16,7 @@ else:
     env = env.Clone()
     env.Append(CXXFLAGS = '-DWEBCAM')
     env.Append(CFLAGS = '-DWEBCAM')
-    env.Append(CPPPATH = '/usr/local/include/opencv4')
+    env.Append(CPPPATH = ['/usr/include/opencv4', '/usr/local/include/opencv4'])
   else:
     if USE_FRAME_STREAM:
       cameras = ['cameras/camera_frame_stream.cc']


### PR DESCRIPTION
opencv-python has already installed opencv4 in /usr/include/opencv4, basically we do not need to recompile and install opencv4 to /usr/local/include/opencv4 again if it's already in /usr/include/opencv4