### PR TITLE
Temp Good

### DIFF
--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -59,12 +59,12 @@ void Sidebar::updateState(const UIState &s) {
   }
   setProperty("connectStatus", QVariant::fromValue(connectStatus));
 
-  ItemStatus tempStatus = {"HIGH\nTEMP", danger_color};
+  ItemStatus tempStatus = {"TEMP\nHIGH", danger_color};
   auto ts = deviceState.getThermalStatus();
   if (ts == cereal::DeviceState::ThermalStatus::GREEN) {
-    tempStatus = {"GOOD\nTEMP", good_color};
+    tempStatus = {"TEMP\nGOOD", good_color};
   } else if (ts == cereal::DeviceState::ThermalStatus::YELLOW) {
-    tempStatus = {"OK\nTEMP", warning_color};
+    tempStatus = {"TEMP\nOK", warning_color};
   }
   setProperty("tempStatus", QVariant::fromValue(tempStatus));
 


### PR DESCRIPTION
This fixes an annoying variation between the temp, connect, and panda status fields in the UI of openpilot.

GOOD
TEMP

is now

TEMP
GOOD

which is more inline with the better structure of

CONNECT (item of interest)
ONLINE (condition)
