### PR TITLE
VW MQB: Improve auto network location detect

### DIFF
--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -38,7 +38,7 @@ class CarInterface(CarInterfaceBase):
       else:
         ret.transmissionType = TransmissionType.manual
 
-      if any(msg in fingerprint[1] for msg in [0x40, 0x86, 0xB2]):  # Airbag_01, LWI_01, ESP_19
+      if any(msg in fingerprint[1] for msg in [0x40, 0x86, 0xB2, 0xFD]):  # Airbag_01, LWI_01, ESP_19, ESP_21
         ret.networkLocation = NetworkLocation.gateway
       else:
         ret.networkLocation = NetworkLocation.fwdCamera


### PR DESCRIPTION
**Description**

Improve auto network location detect for a subset of users with bus 1 wired to convenience instead of powertrain CAN.

**Verification**

The involved user tested this change, and it fixed his problem.

**Route**

`6342f7098c2d0578|2021-09-25--19-41-26`
