### PR TITLE
VW MQB: Fix min steer speed alerts

### DIFF
--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -180,7 +180,7 @@ class CarInterface(CarInterfaceBase):
       events.add(EventName.parkBrake)
 
     # Low speed steer alert hysteresis logic
-    if ret.vEgo < (self.CP.minSteerSpeed + 1.):
+    if self.CP.minSteerSpeed > 0. and ret.vEgo < (self.CP.minSteerSpeed + 1.):
       self.low_speed_alert = True
     elif ret.vEgo > (self.CP.minSteerSpeed + 2.):
       self.low_speed_alert = False


### PR DESCRIPTION
Fix logic error introduced in #22324: don't show low-speed alerts when stopping for cars that steer down to zero.