### PR TITLE
sim: fix race condition in tmux script

### DIFF
--- a/tools/sim/tmux_script.sh
+++ b/tools/sim/tmux_script.sh
@@ -3,4 +3,4 @@ tmux new -d -s htop
 tmux send-keys "./launch_openpilot.sh" ENTER
 tmux neww
 tmux send-keys "./bridge.py $*" ENTER
-tmux a
+tmux a -t htop

--- a/tools/sim/tmux_script.sh
+++ b/tools/sim/tmux_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-tmux new -d -s htop
+tmux new -d -s carla-sim
 tmux send-keys "./launch_openpilot.sh" ENTER
 tmux neww
 tmux send-keys "./bridge.py $*" ENTER
-tmux a -t htop
+tmux a -t carla-sim


### PR DESCRIPTION
Potential bug fix at [tools/sim/tmux_script.sh](https://github.com/commaai/openpilot/blob/d95641a59450a92e2694c1cbf5089668cf0d27f4/tools/sim/tmux_script.sh). 
It can look as follows:

* user launches tmux script
* simultaneously other tmux session is created
* `tmux a` attaches to last used session
* `tmux a -t htop` would always attach to session named `htop`

Although bash scripts are fast and the bug I described is really not likely to happen, it's better to be cautious especially when the fix doesn't take away anything.