### PR TITLE
honda nidec: fix no acceleration with pedal

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -232,7 +232,7 @@ class CarController():
             gas_mult = interp(CS.out.vEgo, [0., 10.], [0.4, 1.0])
             # send exactly zero if apply_gas is zero. Interceptor will send the max between read value and apply_gas.
             # This prevents unexpected pedal range rescaling
-            apply_gas = clip(gas_mult * (gas - brake + wind_brake*3/4), 0., 1.)
+            apply_gas = clip(gas_mult * gas, 0., 1.)
             can_sends.append(create_gas_command(self.packer, apply_gas, idx))
 
     hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_car,


### PR DESCRIPTION
reverts line from 4e939a9648bc9fd22890dab62063560f80c740a2 that broke acceleration