### PR TITLE
Fix second lead car indicator for cut-in detection

### DIFF
--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -144,7 +144,7 @@ static void ui_draw_world(UIState *s) {
     if (lead_one.getProb() > .5) {
       draw_lead(s, lead_one, s->scene.lead_vertices[0]);
     }
-   if (lead_two.getProb() > .5 && (std::abs(lead_one.getX()[0] - lead_two.getX()[0]) > 3.0)) {
+    if (lead_two.getProb() > .5 && (std::abs(lead_one.getX()[0] - lead_two.getX()[0]) > 3.0)) {
       draw_lead(s, lead_two, s->scene.lead_vertices[1]);
     }
   }


### PR DESCRIPTION
**Description**: The second lead car indicator has been missing since 0.8.10 `master`. Second lead car indicator does not show up and only the first lead car indicator moves behind the cut-in car when being cut-in.

**Verification**: Second lead car indicator is showing up along with the first lead car indicator, and it moves behind the cut-in car independently when the car is being cut-in.