### PR TITLE
accel/decel button metric increments

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -369,7 +369,7 @@ class Controls:
 
     # if stock cruise is completely disabled, then we can use our own set speed logic
     if not self.CP.pcmCruise:
-      self.v_cruise_kph = update_v_cruise(self.v_cruise_kph, CS.buttonEvents, self.button_timers, self.enabled)
+      self.v_cruise_kph = update_v_cruise(self.v_cruise_kph, CS.buttonEvents, self.button_timers, self.enabled, self.is_metric)
     elif self.CP.pcmCruise and CS.cruiseState.enabled:
       self.v_cruise_kph = CS.cruiseState.speed * CV.MS_TO_KPH
 

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -1,16 +1,25 @@
 import math
 from cereal import car
 from common.numpy_fast import clip, interp
+from common.params import Params
 from common.realtime import DT_MDL
 from selfdrive.config import Conversions as CV
 from selfdrive.modeld.constants import T_IDXS
 
+IS_METRIC = Params().get_bool("IsMetric")
 
 # kph
 V_CRUISE_MAX = 135
-V_CRUISE_MIN = 8
-V_CRUISE_DELTA = 1.6
-V_CRUISE_ENABLE_MIN = 40
+if IS_METRIC:
+  V_CRUISE_DELTA = 1
+  FAST_CRUISE_MULTIPLIER = 10
+  V_CRUISE_ENABLE_MIN = 30
+  V_CRUISE_MIN = 5
+else:
+  V_CRUISE_DELTA = 1.6
+  FAST_CRUISE_MULTIPLIER = 5
+  V_CRUISE_ENABLE_MIN = 40
+  V_CRUISE_MIN = 8
 LAT_MPC_N = 16
 LON_MPC_N = 32
 CONTROL_N = 17
@@ -75,7 +84,7 @@ def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled):
         break
 
   if button_type:
-    v_cruise_delta = V_CRUISE_DELTA * (5 if long_press else 1)
+    v_cruise_delta = V_CRUISE_DELTA * (FAST_CRUISE_MULTIPLIER if long_press else 1)
     if long_press and v_cruise_kph % v_cruise_delta != 0: # partial interval
       v_cruise_kph = CRUISE_NEAREST_FUNC[button_type](v_cruise_kph / v_cruise_delta) * v_cruise_delta
     else:

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -1,25 +1,15 @@
 import math
 from cereal import car
 from common.numpy_fast import clip, interp
-from common.params import Params
 from common.realtime import DT_MDL
 from selfdrive.config import Conversions as CV
 from selfdrive.modeld.constants import T_IDXS
 
-IS_METRIC = Params().get_bool("IsMetric")
-
 # kph
 V_CRUISE_MAX = 135
-if IS_METRIC:
-  V_CRUISE_DELTA = 1
-  FAST_CRUISE_MULTIPLIER = 10
-  V_CRUISE_ENABLE_MIN = 30
-  V_CRUISE_MIN = 5
-else:
-  V_CRUISE_DELTA = 1.6
-  FAST_CRUISE_MULTIPLIER = 5
-  V_CRUISE_ENABLE_MIN = 40
-  V_CRUISE_MIN = 8
+V_CRUISE_MIN = 8
+V_CRUISE_ENABLE_MIN = 40
+
 LAT_MPC_N = 16
 LON_MPC_N = 32
 CONTROL_N = 17
@@ -61,7 +51,7 @@ def get_steer_max(CP, v_ego):
   return interp(v_ego, CP.steerMaxBP, CP.steerMaxV)
 
 
-def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled):
+def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled, metric):
   # handle button presses. TODO: this should be in state_control, but a decelCruise press
   # would have the effect of both enabling and changing speed is checked after the state transition
   if not enabled:
@@ -69,6 +59,9 @@ def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled):
 
   long_press = False
   button_type = None
+
+  v_cruise_delta = 1 if metric else 1.6
+  fast_cruise_multiplier = 10 if metric else 5
 
   for b in buttonEvents:
     if b.type.raw in button_timers and not b.pressed:
@@ -84,7 +77,7 @@ def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled):
         break
 
   if button_type:
-    v_cruise_delta = V_CRUISE_DELTA * (FAST_CRUISE_MULTIPLIER if long_press else 1)
+    v_cruise_delta = v_cruise_delta * (fast_cruise_multiplier if long_press else 1)
     if long_press and v_cruise_kph % v_cruise_delta != 0: # partial interval
       v_cruise_kph = CRUISE_NEAREST_FUNC[button_type](v_cruise_kph / v_cruise_delta) * v_cruise_delta
     else:

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -60,7 +60,7 @@ def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled, metric):
   long_press = False
   button_type = None
 
-  v_cruise_delta = 1 if metric else 1.6
+  v_cruise_delta = 1 if metric else CV.MPH_TO_KPH
   fast_cruise_multiplier = 10 if metric else 5
 
   for b in buttonEvents:


### PR DESCRIPTION
Freedom units have weird multiples compared to metric. Modified so that it increments by 10 km/h on long press and 1 km/h on short press, rather than 8 and 1.6 km/h. This mimics stock hyundai behaviour on metric vehicles.