### PR TITLE
Ubuntu setup script now works if openpilot not in $HOME

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -69,7 +69,8 @@ if ! command -v "pyenv" > /dev/null 2>&1; then
 fi
 
 # in the openpilot repo
-cd $HOME/openpilot
+TOOLS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$(dirname $TOOLS_DIR)"
 
 source ~/.bashrc
 if [ -z "$OPENPILOT_ENV" ]; then


### PR DESCRIPTION
**Description** 
Ubuntu setup script assumed openpilot repo's root was in $HOME/openpilot. Now the script assumes openpilot repo's root is the directory above openpilot/tools (which it is).

**Verification** 
Re-ran ./ubuntu_setup.sh after making fix.
