### PR TITLE
safety_setter_thread: exit on ignition low

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -57,7 +57,7 @@ bool safety_setter_thread(Panda *panda) {
 
   // switch to SILENT when CarVin param is read
   while (true) {
-    if (do_exit || !panda->connected) {
+    if (do_exit || !panda->connected || !ignition) {
       return false;
     };
 
@@ -77,7 +77,7 @@ bool safety_setter_thread(Panda *panda) {
   std::string params;
   LOGW("waiting for params to set safety model");
   while (true) {
-    if (do_exit || !panda->connected) {
+    if (do_exit || !panda->connected || !ignition) {
       return false;
     };
 
@@ -309,7 +309,7 @@ bool send_panda_state(PubMaster *pm, Panda *panda, bool spoofing_started) {
     }
   }
   pm->send("pandaState", msg);
-  
+
   return ignition;
 }
 


### PR DESCRIPTION
The thread never finishes if you go offroad before the fingerprinting finishes. The panda state threat then puts you back in noOutput and you're stuck. The safety setter thread should also exit when ignition goes low.