### PR TITLE
replay: cleanup output

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -234,7 +234,6 @@ void Replay::stream() {
       continue;
     }
 
-    qDebug() << "unlogging at" << (int)((cur_mono_time_ - route_start_ts_) * 1e-9);
     uint64_t evt_start_ts = cur_mono_time_;
     uint64_t loop_start_ts = nanos_since_boot();
 


### PR DESCRIPTION
remove "unlogging at".
It will be called continuously when new segments merged in. If the time is less than one second, user will be confused and think that replay was stuck
the following output is enough
` qInfo() << "at " << current_ts << "s";`