### PR TITLE
hyundai: adjust tire_stiffness_factor for palisade

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -74,6 +74,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1999. + STD_CARGO_KG
       ret.wheelbase = 2.90
       ret.steerRatio = 15.6 * 1.15
+      tire_stiffness_factor = 0.63
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.05]]
     elif candidate in [CAR.ELANTRA, CAR.ELANTRA_GT_I30]:


### PR DESCRIPTION
`tire_stiffness_factor` seems to consistently be way too low for the palisade

here is a route that is the same road out and back with the `tire_stiffness_factor` set to 0.63
24804955a125718c|2021-10-05--14-37-45
![image](https://user-images.githubusercontent.com/4112046/136124864-8b947c94-bc39-4788-bfef-e0d5d65b2431.png)

and here is another shorter route:
24804955a125718c|2021-10-05--12-39-06
![image](https://user-images.githubusercontent.com/4112046/136125112-5e346506-ce6b-43d8-ab7a-8a6a8ab6e382.png)

should we go lower? I have noticed it often now goes up slightly at the beginning of drives but then still drops (as seen above)

seems like a number of hyundai vehicles use the default value of 1 so someone may want to look into those vehicles, too