### PR TITLE
replay: fix seek problems

### DIFF
--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -110,10 +110,12 @@ int main(int argc, char *argv[]){
   }
 
   Replay *replay = new Replay(route, allow, block, nullptr, flags, &app);
-  if (replay->load()) {
-    replay->start(parser.value("start").toInt());
+  if (!replay->load()) {
+    app.exit(0);
+    return 0;
   }
 
+  replay->start(parser.value("start").toInt());
   // start keyboard control thread
   QThread *t = QThread::create(keyboardThread, replay);
   QObject::connect(t, &QThread::finished, t, &QThread::deleteLater);

--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -46,24 +46,24 @@ void keyboardThread(Replay *replay) {
       try {
         if (r[0] == '#') {
           r.erase(0, 1);
-          replay->seekTo(std::stoi(r) * 60);
+          replay->seekTo(std::stoi(r) * 60, false);
         } else {
-          replay->seekTo(std::stoi(r));
+          replay->seekTo(std::stoi(r), false);
         }
       } catch (std::invalid_argument) {
         qDebug() << "invalid argument";
       }
       getch();  // remove \n from entering seek
     } else if (c == 'm') {
-      replay->relativeSeek(+60);
+      replay->seekTo(+60, true);
     } else if (c == 'M') {
-      replay->relativeSeek(-60);
+      replay->seekTo(-60, true);
     } else if (c == 's') {
-      replay->relativeSeek(+10);
+      replay->seekTo(+10, true);
     } else if (c == 'S') {
-      replay->relativeSeek(-10);
+      replay->seekTo(-10, true);
     } else if (c == 'G') {
-      replay->relativeSeek(0);
+      replay->seekTo(0, true);
     } else if (c == ' ') {
       replay->pause(!replay->isPaused());
     }

--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -97,18 +97,17 @@ int main(int argc, char *argv[]){
   QStringList allow = parser.value("allow").isEmpty() ? QStringList{} : parser.value("allow").split(",");
   QStringList block = parser.value("block").isEmpty() ? QStringList{} : parser.value("block").split(",");
 
-  uint32_t flags = Replay::Flags::None;
   std::pair<QString, Replay::Flags> flag_map[] = {
     {"dcam", Replay::Flags::LoadDriverCam},
     {"ecam", Replay::Flags::LoadWideRoadCam},
     {"qlog", Replay::Flags::FallbackToQLog},
   };
+  uint32_t flags = Replay::Flags::None;
   for (const auto &[key, flag] : flag_map) {
     if (parser.isSet(key)) {
       flags |= flag;
     }
   }
-
   Replay *replay = new Replay(route, allow, block, nullptr, flags, &app);
   if (!replay->load()) {
     app.exit(0);

--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -97,13 +97,13 @@ int main(int argc, char *argv[]){
   QStringList allow = parser.value("allow").isEmpty() ? QStringList{} : parser.value("allow").split(",");
   QStringList block = parser.value("block").isEmpty() ? QStringList{} : parser.value("block").split(",");
 
-  std::map<QString, Replay::Flags> flag_map = {
-      {"dcam", Replay::Flags::LoadDriverCam},
-      {"ecam", Replay::Flags::LoadWideRoadCam},
-      {"qlog", Replay::Flags::FallbackToQLog},
-  };
   uint32_t flags = Replay::Flags::None;
-  for (auto [key, flag] : flag_map) {
+  std::pair<QString, Replay::Flags> flag_map[] = {
+    {"dcam", Replay::Flags::LoadDriverCam},
+    {"ecam", Replay::Flags::LoadWideRoadCam},
+    {"qlog", Replay::Flags::FallbackToQLog},
+  };
+  for (const auto &[key, flag] : flag_map) {
     if (parser.isSet(key)) {
       flags |= flag;
     }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -92,10 +92,10 @@ void Replay::doSeek(int seconds, bool relative) {
     if (relative) {
       seconds += ((cur_mono_time_ - route_start_ts_) * 1e-9);
     }
-    qInfo() << "seeking to" << seconds << QThread::currentThreadId();
+    qInfo() << "seeking to" << seconds;
     cur_mono_time_ = route_start_ts_ + std::clamp(seconds, 0, (int)segments_.size() * 60) * 1e9;
     current_segment_ = std::min(seconds / 60, (int)segments_.size() - 1);
-    return isSegmentLoaded(current_segment_);
+    return false;
   });
   queueSegment();
 }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -30,7 +30,7 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
 
   route_ = std::make_unique<Route>(route);
   events_ = new std::vector<Event *>();
-  // doSeek & queueSegment are always executed in the main thread
+  // doSeek & queueSegment are always executed in the same thread
   connect(this, &Replay::seekTo, this, &Replay::doSeek);
   connect(this, &Replay::segmentChanged, this, &Replay::queueSegment);
 }
@@ -152,7 +152,6 @@ void Replay::mergeSegments(int cur_seg, int end_idx) {
 
   if (segments_need_merge != segments_merged_) {
     qDebug() << "merge segments" << segments_need_merge;
-
     // merge & sort events
     std::vector<Event *> *new_events = new std::vector<Event *>();
     new_events->reserve(std::accumulate(segments_need_merge.begin(), segments_need_merge.end(), 0,

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -44,14 +44,14 @@ protected:
   void publishFrame(const Event *e);
   inline bool isSegmentLoaded(int n) { return segments_[n] && segments_[n]->isLoaded(); }
 
-  QThread *stream_thread_ = nullptr;
-
   // logs
   std::mutex stream_lock_;
   std::condition_variable stream_cv_;
   std::atomic<bool> updating_events_ = false;
   std::atomic<int> current_segment_ = -1;
+  std::unique_ptr<Route> route_;
   std::vector<std::unique_ptr<Segment>> segments_;
+  std::unique_ptr<CameraServer> camera_server_;
   // the following variables must be protected with stream_lock_
   bool exit_ = false;
   bool paused_ = false;
@@ -65,8 +65,7 @@ protected:
   SubMaster *sm = nullptr;
   PubMaster *pm = nullptr;
   std::vector<const char*> sockets_;
-  std::unique_ptr<Route> route_;
-  std::unique_ptr<CameraServer> camera_server_;
 
   uint32_t flags_ = None;
+  QThread *stream_thread_ = nullptr;
 };

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -35,6 +35,7 @@ protected:
   void mergeSegments(int begin_idx, int end_idx);
   void updateEvents(const std::function<bool()>& lambda);
   void publishFrame(const Event *e);
+  inline bool isSegmentLoaded(int n) { return segments_[n] && segments_[n]->isLoaded(); }
 
   QThread *stream_thread_ = nullptr;
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -25,8 +25,8 @@ public:
   ~Replay();
   bool load();
   void start(int seconds = 0);
-  bool isPaused() const { return paused_; }
   void pause(bool pause);
+  bool isPaused() const { return paused_; }
 
 signals:
  void segmentChanged();
@@ -43,7 +43,9 @@ protected:
   void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);
   void updateEvents(const std::function<bool()>& lambda);
   void publishFrame(const Event *e);
-  inline bool isSegmentLoaded(int n) { return segments_[n] && segments_[n]->isLoaded(); }
+
+  uint32_t flags_ = None;
+  QThread *stream_thread_ = nullptr;
 
   // logs
   std::mutex stream_lock_;
@@ -53,7 +55,7 @@ protected:
   std::unique_ptr<Route> route_;
   SegmentMap segments_;
   std::vector<int> segments_merged_;
-  std::unique_ptr<CameraServer> camera_server_;
+  
   
   // the following variables must be protected with stream_lock_
   bool exit_ = false;
@@ -67,7 +69,5 @@ protected:
   SubMaster *sm = nullptr;
   PubMaster *pm = nullptr;
   std::vector<const char*> sockets_;
-
-  uint32_t flags_ = None;
-  QThread *stream_thread_ = nullptr;
+  std::unique_ptr<CameraServer> camera_server_;
 };

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -14,7 +14,14 @@ class Replay : public QObject {
   Q_OBJECT
 
 public:
-  Replay(QString route, QStringList allow, QStringList block, SubMaster *sm = nullptr, bool dcam = false, bool ecam = false, QObject *parent = 0);
+  enum Flags {
+    None = 0,
+    LoadDriverCam = 0x1,
+    LoadWideRoadCam = 0x2,
+    FallbackToQLog = 0x4
+  };
+
+  Replay(QString route, QStringList allow, QStringList block, SubMaster *sm = nullptr, uint32_t flag = None, QObject *parent = 0);
   ~Replay();
   bool load();
   void start(int seconds = 0);
@@ -59,6 +66,7 @@ protected:
   PubMaster *pm = nullptr;
   std::vector<const char*> sockets_;
   std::unique_ptr<Route> route_;
-  bool load_dcam = false, load_ecam = false;
   std::unique_ptr<CameraServer> camera_server_;
+
+  uint32_t flags_ = None;
 };

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -37,9 +37,10 @@ protected slots:
   void doSeek(int seconds, bool relative);
 
 protected:
+  typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;
   void stream();
   void setCurrentSegment(int n);
-  void mergeSegments(int begin_idx, int end_idx);
+  void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);
   void updateEvents(const std::function<bool()>& lambda);
   void publishFrame(const Event *e);
   inline bool isSegmentLoaded(int n) { return segments_[n] && segments_[n]->isLoaded(); }
@@ -50,8 +51,10 @@ protected:
   std::atomic<bool> updating_events_ = false;
   std::atomic<int> current_segment_ = -1;
   std::unique_ptr<Route> route_;
-  std::vector<std::unique_ptr<Segment>> segments_;
+  SegmentMap segments_;
+  std::vector<int> segments_merged_;
   std::unique_ptr<CameraServer> camera_server_;
+  
   // the following variables must be protected with stream_lock_
   bool exit_ = false;
   bool paused_ = false;
@@ -59,7 +62,6 @@ protected:
   uint64_t route_start_ts_ = 0;
   uint64_t cur_mono_time_ = 0;
   std::vector<Event *> *events_ = nullptr;
-  std::vector<int> segments_merged_;
 
   // messaging
   SubMaster *sm = nullptr;

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -18,16 +18,16 @@ public:
   ~Replay();
   bool load();
   void start(int seconds = 0);
-  void seekTo(int seconds, bool relative = false);
-  void relativeSeek(int seconds) { seekTo(seconds, true); }
-  void pause(bool pause);
   bool isPaused() const { return paused_; }
+  void pause(bool pause);
 
 signals:
  void segmentChanged();
+ void seekTo(int seconds, bool relative);
 
 protected slots:
   void queueSegment();
+  void doSeek(int seconds, bool relative);
 
 protected:
   void stream();

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -77,7 +77,6 @@ Segment::Segment(int n, const SegmentFile &segment_files, bool load_dcam, bool l
   // fallback to qcamera/qlog
   road_cam_path_ = files_.road_cam.isEmpty() ? files_.qcamera : files_.road_cam;
   log_path_ = files_.rlog.isEmpty() ? files_.qlog : files_.rlog;
-
   assert (!log_path_.isEmpty() && !road_cam_path_.isEmpty());
 
   if (!load_dcam) {

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -78,8 +78,7 @@ Segment::Segment(int n, const SegmentFile &segment_files, bool load_dcam, bool l
   road_cam_path_ = files_.road_cam.isEmpty() ? files_.qcamera : files_.road_cam;
   log_path_ = files_.rlog.isEmpty() ? files_.qlog : files_.rlog;
 
-  valid_ = !log_path_.isEmpty() && !road_cam_path_.isEmpty();
-  if (!valid_) return;
+  assert (!log_path_.isEmpty() && !road_cam_path_.isEmpty());
 
   if (!load_dcam) {
     files_.driver_cam = "";
@@ -151,7 +150,7 @@ void Segment::load() {
   }
 
   int success_cnt = std::accumulate(futures.begin(), futures.end(), 0, [=](int v, auto &f) { return f.get() + v; });
-  loaded_ = valid_ = (success_cnt == futures.size());
+  loaded_ = (success_cnt == futures.size());
   emit loadFinished();
 }
 

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -25,17 +25,15 @@ class Route {
 public:
   Route(const QString &route);
   bool load();
-
   inline const QString &name() const { return route_; };
   inline int size() const { return segments_.size(); }
   inline SegmentFile &at(int n) { return segments_[n]; }
 
-  // public for unit tests
-  std::vector<SegmentFile> segments_;
-
 protected:
   bool loadFromJson(const QString &json);
+
   QString route_;
+  std::vector<SegmentFile> segments_;
 };
 
 class Segment : public QObject {
@@ -44,7 +42,6 @@ class Segment : public QObject {
 public:
   Segment(int n, const SegmentFile &segment_files, bool load_dcam, bool load_ecam);
   ~Segment();
-  inline bool isValid() const { return valid_; };
   inline bool isLoaded() const { return loaded_; }
   inline bool isQLog() const { return files_.rlog.isEmpty() || files_.road_cam.isEmpty(); }
 
@@ -59,7 +56,7 @@ protected:
   void downloadFile(const QString &url);
   QString localPath(const QUrl &url);
 
-  std::atomic<bool> loaded_ = false, valid_ = false;
+  std::atomic<bool> loaded_ = false;
   std::atomic<bool> aborting_ = false;
   std::atomic<int> downloading_ = 0;
   int seg_num_ = 0;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -46,6 +46,7 @@ public:
   ~Segment();
   inline bool isValid() const { return valid_; };
   inline bool isLoaded() const { return loaded_; }
+  inline bool isQLog() const { return files_.rlog.isEmpty() || files_.road_cam.isEmpty(); }
 
   std::unique_ptr<LogReader> log;
   std::unique_ptr<FrameReader> frames[MAX_CAMERAS] = {};

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -31,7 +31,6 @@ public:
 
 protected:
   bool loadFromJson(const QString &json);
-
   QString route_;
   std::vector<SegmentFile> segments_;
 };

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -120,7 +120,11 @@ void TestReplay::testSeekTo(int seek_to, const std::set<int> &invalid_segments) 
     std::unique_lock lk(stream_lock_);
     stream_cv_.wait(lk, [=]() { return events_updated_ == true; });
     events_updated_ = false;
-    if (cur_mono_time_ != route_start_ts_ + seek_to * 1e9) continue;
+    if (cur_mono_time_ != route_start_ts_ + seek_to * 1e9) {
+      // this event is fired by merg, skip it.
+      continue;
+    }
+
     INFO("seek to [" << seek_to << "s segment " << seek_to / 60 << "]" << route_start_ts_);
     REQUIRE(uint64_t(route_start_ts_ + seek_to * 1e9) == cur_mono_time_);
 

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -100,7 +100,7 @@ TEST_CASE("Segment") {
   });
   loop.exec();
 }
-/*
+
 // helper class for unit tests
 class TestReplay : public Replay {
 public:
@@ -191,4 +191,4 @@ TEST_CASE("Replay") {
   REQUIRE(replay.load());
   replay.test_seek();
 }
-*/
+

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -85,8 +85,6 @@ TEST_CASE("Segment") {
 
   QEventLoop loop;
   Segment segment(0, demo_route.at(0), false, false);
-  REQUIRE(segment.isValid() == true);
-  REQUIRE(segment.isLoaded() == false);
   QObject::connect(&segment, &Segment::loadFinished, [&]() {
     REQUIRE(segment.isLoaded() == true);
     REQUIRE(segment.log != nullptr);

--- a/selfdrive/ui/replay/util.cc
+++ b/selfdrive/ui/replay/util.cc
@@ -39,7 +39,6 @@ int64_t getDownloadContentLength(const std::string &url) {
   if (res == CURLE_OK) {
     res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &content_length);
   }
-  printf("%s %d %f\n", url.c_str(), res, content_length);
   curl_easy_cleanup(curl);
   return res == CURLE_OK ? (int64_t)content_length : -1;
 }

--- a/selfdrive/ui/replay/util.cc
+++ b/selfdrive/ui/replay/util.cc
@@ -39,6 +39,7 @@ int64_t getDownloadContentLength(const std::string &url) {
   if (res == CURLE_OK) {
     res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &content_length);
   }
+  printf("%s %d %f\n", url.c_str(), res, content_length);
   curl_easy_cleanup(curl);
   return res == CURLE_OK ? (int64_t)content_length : -1;
 }


### PR DESCRIPTION
resolve  #22429 .
- [x] fix seek problems. do seek  in the same thread as `mergeSegment`. otherwise, there will be many synchronization problems need to be solved.
- [x]  only keep valid segments in Replay::segments_ to simplify seek&queue&merge events. 
