### PR TITLE
Nidec Pedal: Accel Limit Exception

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -25,7 +25,10 @@ class CarInterface(CarInterfaceBase):
       # so limit limits of pid to prevent windup
       ACCEL_MAX_VALS = [CarControllerParams.NIDEC_ACCEL_MAX, 0.2]
       ACCEL_MAX_BP = [cruise_speed - 2., cruise_speed - .2]
-      return CarControllerParams.NIDEC_ACCEL_MIN, interp(current_speed, ACCEL_MAX_BP, ACCEL_MAX_VALS)
+      if CP.enableGasInterceptor:
+        return CarControllerParams.NIDEC_ACCEL_MIN, CarControllerParams.NIDEC_ACCEL_MAX
+      else:
+        return CarControllerParams.NIDEC_ACCEL_MIN, interp(current_speed, ACCEL_MAX_BP, ACCEL_MAX_VALS)
 
   @staticmethod
   def get_params(candidate, fingerprint=gen_empty_fingerprint(), car_fw=[]):  # pylint: disable=dangerous-default-value


### PR DESCRIPTION
Recently, some new logic was added to prevent PID windup on Nidec Hondas using pcm accel (https://github.com/commaai/openpilot/commit/ebf2a2279d837feb3ce55a7bc44c7f0053e77f27) but it doesn't take the pedal into consideration. As a result, with a pedal the car never reaches the set speed and will always stop accel 2-3mph under it on flat ground.

An exception like this is needed to bring back the correct behavior.

Old route:
`fe918256455798ff|2021-10-06--23-16-53`
Route with this fix applied:
`fe918256455798ff|2021-10-07--00-08-59`
