### PR TITLE
replay: print current time when paused

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -110,6 +110,10 @@ void Replay::seekTo(int seconds, bool relative) {
 void Replay::pause(bool pause) {
   updateEvents([=]() {
     qDebug() << (pause ? "paused..." : "resuming");
+    if (pause) {
+      float current_ts = (cur_mono_time_ - route_start_ts_) / 1e9;
+      qInfo() << "at " << current_ts << "s";
+    }
     paused_ = pause;
     return true;
   });


### PR DESCRIPTION
I like to pause the replay to capture the exact time at which something occurred

```
$ ./selfdrive/ui/replay/replay --demo
services  std::vector(sensorEvents, gpsNMEA, deviceState, can, controlsState, pandaState, peripheralState, radarState, roadEncodeIdx, liveTracks, sendcan, logMessage, liveCalibration, androidLog, carState, carControl, longitudinalPlan, procLog, gpsLocationExternal, ubloxGnss, clocks, ubloxRaw, liveLocationKalman, liveParameters, cameraOdometry, lateralPlan, thumbnail, carEvents, carParams, roadCameraState, driverCameraState, driverEncodeIdx, driverState, driverMonitoringState, wideRoadEncodeIdx, wideRoadCameraState, modelV2, managerState, uploaderState, testJoystick)
load route "4cf7a6ad03080c90|2021-09-29--13-46-36" 11 segments
seeking to 0
waiting for events...
merge segments std::vector(0)
merge segments std::vector(0, 1)
camera[0] frame size 1928x1208
restart vipc server
Starting listener for: camerad
merge segments std::vector(0, 1, 2)
paused...
at  2.40029 s
resuming
shutdown: in progress...
Stopping listener for: camerad
shutdown: done
```