### PR TITLE
boardd: fix context leak in init_usb_ctx

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -11,17 +11,19 @@
 #include "selfdrive/common/swaglog.h"
 #include "selfdrive/common/util.h"
 
-static int init_usb_ctx(libusb_context *context) {
-  int err = libusb_init(&context);
+static int init_usb_ctx(libusb_context **context) {
+  assert(context != nullptr);
+
+  int err = libusb_init(context);
   if (err != 0) {
     LOGE("libusb initialization error");
     return err;
   }
 
 #if LIBUSB_API_VERSION >= 0x01000106
-  libusb_set_option(context, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
+  libusb_set_option(*context, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
 #else
-  libusb_set_debug(context, 3);
+  libusb_set_debug(*context, 3);
 #endif
 
   return err;
@@ -32,7 +34,7 @@ Panda::Panda(std::string serial) {
   // init libusb
   ssize_t num_devices;
   libusb_device **dev_list = NULL;
-  int err = init_usb_ctx(ctx);
+  int err = init_usb_ctx(&ctx);
   if (err != 0) { goto fail; }
 
   // connect by serial
@@ -113,7 +115,7 @@ std::vector<std::string> Panda::list() {
   libusb_device **dev_list = NULL;
   std::vector<std::string> serials;
 
-  int err = init_usb_ctx(context);
+  int err = init_usb_ctx(&context);
   if (err != 0) { return serials; }
 
   num_devices = libusb_get_device_list(context, &dev_list);


### PR DESCRIPTION
This was the actual cause of the leak. `libusb_init` got a `libusb_context **` that was pointing to the argument of the `init_usb_ctx` not the context that the caller passed in.

Introduced in https://github.com/commaai/openpilot/commit/603ad435bef2a1db28b294b36768fda5f53fc814

Fixes https://github.com/commaai/openpilot/issues/22423