### PR TITLE
replay: merge previous segment

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -166,8 +166,8 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
     new_events->reserve(std::accumulate(segments_need_merge.begin(), segments_need_merge.end(), 0,
                                         [=](int v, int n) { return v + segments_[n]->log->events.size(); }));
     for (int n : segments_need_merge) {
-      auto &log = segments_[n]->log;
-      auto middle = new_events->insert(new_events->end(), log->events.begin(), log->events.end());
+      auto &e = segments_[n]->log->events;
+      auto middle = new_events->insert(new_events->end(), e.begin(), e.end());
       std::inplace_merge(new_events->begin(), middle, new_events->end(), Event::lessThan());
     }
     // update events

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -15,14 +15,13 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
   auto event_struct = capnp::Schema::from<cereal::Event>().asStruct();
   sockets_.resize(event_struct.getUnionFields().size());
   for (const auto &it : services) {
-    if ((allow.size() == 0 || allow.contains(it.name)) &&
-        !block.contains(it.name)) {
+    if ((allow.empty() || allow.contains(it.name)) && !block.contains(it.name)) {
       s.push_back(it.name);
       uint16_t which = event_struct.getFieldByName(it.name).getProto().getDiscriminantValue();
       sockets_[which] = it.name;
     }
   }
-  qDebug() << "services " << s;
+  qDebug() << "services" << s;
 
   if (sm == nullptr) {
     pm = new PubMaster(s);
@@ -36,14 +35,12 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
 
 Replay::~Replay() {
   qDebug() << "shutdown: in progress...";
-  exit_ = true;
-  updating_events_ = true;
+  exit_ = updating_events_ = true;
   if (stream_thread_) {
     stream_cv_.notify_one();
     stream_thread_->quit();
     stream_thread_->wait();
   }
-
   delete pm;
   delete events_;
   segments_.clear();

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -6,7 +6,7 @@
 #include "selfdrive/ui/replay/route.h"
 
 constexpr int FORWARD_SEGS = 2;
-constexpr int BACKWARD_SEGS = 2;
+constexpr int BACKWARD_SEGS = 1;
 
 class Replay : public QObject {
   Q_OBJECT


### PR DESCRIPTION
1. merge one segment backward. this fix the following 2 issues after #22463:
   -  get stuck for a while when playing to the next segment
   - the event time between segments is not continuous, if the previous segment is not merged, there may be duplicate messages sent when playing to the next segment
2. fix can't seek to the last segment.
 