### PR TITLE
Fix cruise button mph increment and switch metric long press to 5 km/h

### DIFF
--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -60,8 +60,7 @@ def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled, metric):
   long_press = False
   button_type = None
 
-  v_cruise_delta = 1 if metric else CV.MPH_TO_KPH
-  fast_cruise_multiplier = 10 if metric else 5
+  v_cruise_delta = 1 if metric else 1.6
 
   for b in buttonEvents:
     if b.type.raw in button_timers and not b.pressed:
@@ -77,7 +76,7 @@ def update_v_cruise(v_cruise_kph, buttonEvents, button_timers, enabled, metric):
         break
 
   if button_type:
-    v_cruise_delta = v_cruise_delta * (fast_cruise_multiplier if long_press else 1)
+    v_cruise_delta = v_cruise_delta * (5 if long_press else 1)
     if long_press and v_cruise_kph % v_cruise_delta != 0: # partial interval
       v_cruise_kph = CRUISE_NEAREST_FUNC[button_type](v_cruise_kph / v_cruise_delta) * v_cruise_delta
     else:


### PR DESCRIPTION
Using the actual value of 1 mph causes rounding errors. Switch back to 1.6 km/h