### PR TITLE
replay: improve segment downloading

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -131,7 +131,6 @@ void Replay::queueSegment() {
   if (cur != segments_.end() && cur->second == nullptr) {
     // just load one segment on starting replay or seeking
     end++;
-    enableHttpLogging(true);
   } else {
     for (int i = 0; i < BACKWARD_SEGS && begin != segments_.begin(); ++i) {
       --begin;
@@ -139,7 +138,6 @@ void Replay::queueSegment() {
     for (int i = 0; i <= FORWARD_SEGS && end != segments_.end(); ++i) {
       ++end;
     }
-    enableHttpLogging(false);
   }
 
   // load & merge segments
@@ -162,9 +160,12 @@ void Replay::queueSegment() {
   }
 
   // start stream thread
-  if (stream_thread_ == nullptr && cur != segments_.end() && cur->second->isLoaded()) {
+  bool current_segment_loaded = (cur != segments_.end() && cur->second->isLoaded());
+  if (stream_thread_ == nullptr && current_segment_loaded) {
     startStream(cur->second.get());
   }
+
+  enableHttpLogging(!current_segment_loaded);
 }
 
 void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end) {

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -131,6 +131,7 @@ void Replay::queueSegment() {
   if (cur != segments_.end() && cur->second == nullptr) {
     // just load one segment on starting replay or seeking
     end++;
+    enableHttpLogging(true);
   } else {
     for (int i = 0; i < BACKWARD_SEGS && begin != segments_.begin(); ++i) {
       --begin;
@@ -138,6 +139,7 @@ void Replay::queueSegment() {
     for (int i = 0; i <= FORWARD_SEGS && end != segments_.end(); ++i) {
       ++end;
     }
+    enableHttpLogging(false);
   }
 
   // load & merge segments

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -127,9 +127,9 @@ void Segment::loadFile(int id, const std::string file) {
 
   if (!file_ready && is_remote) {
     int retries = 0;
-    while (true) {
+    while (!aborting_) {
       file_ready = httpMultiPartDownload(file, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_);
-      if (file_ready) break;
+      if (file_ready || aborting_) break;
 
       if (++retries > max_retries_) {
         qInfo() << "download failed after retries" << max_retries_;

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -126,8 +126,10 @@ void Segment::loadFile(int id, const std::string file) {
   bool file_ready = util::file_exists(local_file);
 
   if (!file_ready && is_remote) {
-    // TODO: retry on failure
-    file_ready = httpMultiPartDownload(file, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_);
+    int retries = 0;
+    while (!file_ready && retries++ < max_retries_) {
+      file_ready = httpMultiPartDownload(file, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_);
+    }
   }
 
   if (!aborting_ && file_ready) {

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -127,8 +127,15 @@ void Segment::loadFile(int id, const std::string file) {
 
   if (!file_ready && is_remote) {
     int retries = 0;
-    while (!file_ready && retries++ < max_retries_) {
+    while (true) {
       file_ready = httpMultiPartDownload(file, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_);
+      if (file_ready) break;
+
+      if (++retries > max_retries_) {
+        qInfo() << "download failed after retries" << max_retries_;
+        break;
+      }
+      qInfo() << "download failed, retrying" << retries;
     }
   }
 

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -122,53 +122,13 @@ Segment::~Segment() {
   }
 }
 
-void Segment::download_callback(void *param, size_t cur_written, size_t total_size) {
-  auto [s, id] = *(static_cast<std::pair<Segment *, int> *>(param));
-  double current_ts = millis_since_boot();
-  std::unique_lock lk(s->lock);
-
-  s->download_written_ += cur_written;
-  s->remote_file_size[id] = total_size;
-  if (s->last_print_ == 0) {
-    s->last_print_ = current_ts;
-  } else if ((current_ts - s->last_print_) > 5 * 1000) {
-    size_t total_size = 0;
-    for (auto [n, size] : s->remote_file_size) {
-      if (size == 0) return;
-
-      total_size += size;
-    }
-    int avg_speed = s->download_written_ / ((current_ts - s->start_ts_) / 1000);
-    QString percent = QString("%1%").arg((int)((s->download_written_ / (double)total_size) * 100));
-    QString eta = avg_speed > 0 ? QString("%1 s").arg((total_size - s->download_written_) / avg_speed) : "--";
-    qDebug() << "downloading segment" << qPrintable(QString("[%1]").arg(s->seg_num)) << ":"
-             << qPrintable(QLocale().formattedDataSize(total_size)) << qPrintable(percent) << "eta:" << qPrintable(eta);
-    s->last_print_ = current_ts;
-  }
-}
-
 void Segment::loadFile(int id, const std::string file) {
   const bool is_remote = file.find("https://") == 0;
   const std::string local_file = is_remote ? cacheFilePath(file) : file;
   bool file_ready = util::file_exists(local_file);
 
   if (!file_ready && is_remote) {
-    {
-      std::unique_lock lk(lock);
-      remote_file_size[id] = 0;
-    }
-    std::pair<Segment *, int> pair {this, id};
-    int retries = 0;
-    while (!aborting_) {
-      file_ready = httpMultiPartDownload(file, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_, &Segment::download_callback, &pair);
-      if (file_ready || aborting_) break;
-
-      if (++retries > max_retries_) {
-        qInfo() << "download failed after retries" << max_retries_;
-        break;
-      }
-      qInfo() << "download failed, retrying" << retries;
-    }
+    file_ready = downloadFile(id, file, local_file);
   }
 
   if (!aborting_ && file_ready) {
@@ -188,6 +148,53 @@ void Segment::loadFile(int id, const std::string file) {
 
   if (!aborting_ && --loading_ == 0) {
     emit loadFinished(success_);
+  }
+}
+
+bool Segment::downloadFile(int id, const std::string &url, const std::string local_file) {
+  {
+    std::unique_lock lk(lock);
+    remote_file_size[id] = 0;
+  }
+  int retries = 0;
+  bool ret = false;
+  std::pair<Segment *, int> pair{this, id};
+  while (!aborting_) {
+    ret = httpMultiPartDownload(url, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_, &Segment::download_callback, &pair);
+    if (ret || aborting_) break;
+
+    if (++retries > max_retries_) {
+      qInfo() << "download failed after retries" << max_retries_;
+      break;
+    }
+    qInfo() << "download failed, retrying" << retries;
+  }
+  return ret;
+}
+
+void Segment::download_callback(void *param, size_t cur_written, size_t remote_size) {
+  auto [s, id] = *(static_cast<std::pair<Segment *, int> *>(param));
+  double current_ts = millis_since_boot();
+
+  std::unique_lock lk(s->lock);
+
+  s->download_written_ += cur_written;
+  s->remote_file_size[id] = remote_size;
+  if (s->last_print_ == 0) {
+    s->last_print_ = current_ts;
+  } else if ((current_ts - s->last_print_) > 5 * 1000) {
+    size_t segment_size = 0;
+    for (auto [n, size] : s->remote_file_size) {
+      if (size == 0) return;
+
+      segment_size += size;
+    }
+    int avg_speed = s->download_written_ / ((current_ts - s->start_ts_) / 1000);
+    QString percent = QString("%1%").arg((int)((s->download_written_ / (double)segment_size) * 100));
+    QString eta = avg_speed > 0 ? QString("%1 s").arg((segment_size - s->download_written_) / avg_speed) : "--";
+    qDebug() << "downloading segment" << qPrintable(QString("[%1]").arg(s->seg_num)) << ":"
+             << qPrintable(QLocale().formattedDataSize(segment_size)) << qPrintable(percent) << "eta:" << qPrintable(eta);
+    s->last_print_ = current_ts;
   }
 }
 

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -1,7 +1,6 @@
 #include "selfdrive/ui/replay/route.h"
 
 #include <QEventLoop>
-#include <QLocale>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QRegExp>

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -126,11 +126,12 @@ void Segment::download_callback(void *param, size_t cur_written, size_t total_si
   auto [s, id] = *(static_cast<std::pair<Segment *, int> *>(param));
   double current_ts = millis_since_boot();
   std::unique_lock lk(s->lock);
+
   s->download_written_ += cur_written;
   s->remote_file_size[id] = total_size;
   if (s->last_print_ == 0) {
     s->last_print_ = current_ts;
-  } else if ((current_ts- s->last_print_) > 5 * 1000) {
+  } else if ((current_ts - s->last_print_) > 5 * 1000) {
     size_t total_size = 0;
     for (auto [n, size] : s->remote_file_size) {
       if (size == 0) return;
@@ -139,7 +140,7 @@ void Segment::download_callback(void *param, size_t cur_written, size_t total_si
     }
     int avg_speed = s->download_written_ / ((current_ts - s->start_ts_) / 1000);
     QString percent = QString("%1%").arg((int)((s->download_written_ / (double)total_size) * 100));
-    QString eta = avg_speed > 0 ? QString("%1 s").arg((total_size - s->download_written_) / avg_speed) :"--";
+    QString eta = avg_speed > 0 ? QString("%1 s").arg((total_size - s->download_written_) / avg_speed) : "--";
     qDebug() << "downloading segment" << qPrintable(QString("[%1]").arg(s->seg_num)) << ":"
              << qPrintable(QLocale().formattedDataSize(total_size)) << qPrintable(percent) << "eta:" << qPrintable(eta);
     s->last_print_ = current_ts;

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -105,7 +105,6 @@ Segment::Segment(int n, const SegmentFile &files, bool load_dcam, bool load_ecam
       load_ecam ? files.wide_road_cam : "",
       files.rlog.isEmpty() ? files.qlog : files.rlog,
   };
-  start_ts_ = millis_since_boot();
   for (int i = 0; i < std::size(file_list); i++) {
     if (!file_list[i].isEmpty()) {
       loading_++;
@@ -152,15 +151,10 @@ void Segment::loadFile(int id, const std::string file) {
 }
 
 bool Segment::downloadFile(int id, const std::string &url, const std::string local_file) {
-  {
-    std::unique_lock lk(lock);
-    remote_file_size[id] = 0;
-  }
-  int retries = 0;
   bool ret = false;
-  std::pair<Segment *, int> pair{this, id};
+  int retries = 0;
   while (!aborting_) {
-    ret = httpMultiPartDownload(url, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_, &Segment::download_callback, &pair);
+    ret = httpMultiPartDownload(url, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_);
     if (ret || aborting_) break;
 
     if (++retries > max_retries_) {
@@ -170,32 +164,6 @@ bool Segment::downloadFile(int id, const std::string &url, const std::string loc
     qInfo() << "download failed, retrying" << retries;
   }
   return ret;
-}
-
-void Segment::download_callback(void *param, size_t cur_written, size_t remote_size) {
-  auto [s, id] = *(static_cast<std::pair<Segment *, int> *>(param));
-  double current_ts = millis_since_boot();
-
-  std::unique_lock lk(s->lock);
-
-  s->download_written_ += cur_written;
-  s->remote_file_size[id] = remote_size;
-  if (s->last_print_ == 0) {
-    s->last_print_ = current_ts;
-  } else if ((current_ts - s->last_print_) > 5 * 1000) {
-    size_t segment_size = 0;
-    for (auto [n, size] : s->remote_file_size) {
-      if (size == 0) return;
-
-      segment_size += size;
-    }
-    int avg_speed = s->download_written_ / ((current_ts - s->start_ts_) / 1000);
-    QString percent = QString("%1%").arg((int)((s->download_written_ / (double)segment_size) * 100));
-    QString eta = avg_speed > 0 ? QString("%1 s").arg((segment_size - s->download_written_) / avg_speed) : "--";
-    qDebug() << "downloading segment" << qPrintable(QString("[%1]").arg(s->seg_num)) << ":"
-             << qPrintable(QLocale().formattedDataSize(segment_size)) << qPrintable(percent) << "eta:" << qPrintable(eta);
-    s->last_print_ = current_ts;
-  }
 }
 
 std::string Segment::cacheFilePath(const std::string &file) {

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -157,8 +157,8 @@ void Segment::loadFile(int id, const std::string file) {
       std::unique_lock lk(lock);
       remote_file_size[id] = 0;
     }
-    int retries = 0;
     std::pair<Segment *, int> pair {this, id};
+    int retries = 0;
     while (!aborting_) {
       file_ready = httpMultiPartDownload(file, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_, &Segment::download_callback, &pair);
       if (file_ready || aborting_) break;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -60,11 +60,5 @@ protected:
   std::atomic<bool> success_ = true, aborting_ = false;
   std::atomic<int> loading_ = 0;
   std::vector<QThread*> loading_threads_;
-  
-  std::mutex lock;
-  std::map<int, size_t> remote_file_size;
-  double start_ts_ = 0;
-  double last_print_ = 0;
-  size_t download_written_ = 0;
   const int max_retries_ = 3;
 };

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -55,7 +55,6 @@ protected:
   void loadFile(int id, const std::string file);
   bool downloadFile(int id, const std::string &url, const std::string local_file);
   std::string cacheFilePath(const std::string &file);
-  static void download_callback(void *param, size_t downloaded, size_t remote_size);
 
   std::atomic<bool> success_ = true, aborting_ = false;
   std::atomic<int> loading_ = 0;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -57,5 +57,6 @@ protected:
 
   std::atomic<bool> success_ = true, aborting_ = false;
   std::atomic<int> loading_ = 0;
-  std::list<QThread*> loading_threads_;
+  std::vector<QThread*> loading_threads_;
+  const int max_retries_ = 3;
 };

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <set>
 #include <QDir>
 #include <QThread>
 

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include <QDir>
 #include <QThread>
 
@@ -54,9 +55,16 @@ signals:
 protected:
   void loadFile(int id, const std::string file);
   std::string cacheFilePath(const std::string &file);
+  static void download_callback(void *param, size_t downloaded, size_t total_size);
 
   std::atomic<bool> success_ = true, aborting_ = false;
   std::atomic<int> loading_ = 0;
   std::vector<QThread*> loading_threads_;
+  
+  std::mutex lock;
+  std::map<int, size_t> remote_file_size;
+  double start_ts_ = 0;
+  double last_print_ = 0;
+  size_t download_written_ = 0;
   const int max_retries_ = 3;
 };

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -53,8 +53,9 @@ signals:
 
 protected:
   void loadFile(int id, const std::string file);
+  bool downloadFile(int id, const std::string &url, const std::string local_file);
   std::string cacheFilePath(const std::string &file);
-  static void download_callback(void *param, size_t downloaded, size_t total_size);
+  static void download_callback(void *param, size_t downloaded, size_t remote_size);
 
   std::atomic<bool> success_ = true, aborting_ = false;
   std::atomic<int> loading_ = 0;

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -19,7 +19,7 @@ TEST_CASE("httpMultiPartDownload") {
   SECTION("5 connections") {
     REQUIRE(httpMultiPartDownload(stream_url, filename, 5));
   }
-  SECTION("1 connections") {
+  SECTION("1 connection") {
     REQUIRE(httpMultiPartDownload(stream_url, filename, 1));
   }
   std::string content = util::read_file(filename);

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -13,20 +13,19 @@ std::string sha_256(const QString &dat) {
 
 TEST_CASE("httpMultiPartDownload") {
   char filename[] = "/tmp/XXXXXX";
-  int fd = mkstemp(filename);
-  close(fd);
+  close(mkstemp(filename));
 
-  const char *stream_url = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/fcamera.hevc";
-  SECTION("http 200") {
+  const char *stream_url = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/rlog.bz2";
+  SECTION("5 connections") {
     REQUIRE(httpMultiPartDownload(stream_url, filename, 5));
-    std::string content = util::read_file(filename);
-    REQUIRE(content.size() == 37495242);
-    std::string checksum = sha_256(QString::fromStdString(content));
-    REQUIRE(checksum == "d8ff81560ce7ed6f16d5fb5a6d6dd13aba06c8080c62cfe768327914318744c4");
   }
-  SECTION("http 404") {
-    REQUIRE(httpMultiPartDownload(util::string_format("%s_abc", stream_url), filename, 5) == false);
+  SECTION("1 connections") {
+    REQUIRE(httpMultiPartDownload(stream_url, filename, 1));
   }
+  std::string content = util::read_file(filename);
+  REQUIRE(content.size() == 9112651);
+  std::string checksum = sha_256(QString::fromStdString(content));
+  REQUIRE(checksum == "e44edfbb545abdddfd17020ced2b18b6ec36506152267f32b6a8e3341f8126d6");
 }
 
 int random_int(int min, int max) {

--- a/selfdrive/ui/replay/util.cc
+++ b/selfdrive/ui/replay/util.cc
@@ -146,7 +146,7 @@ bool httpMultiPartDownload(const std::string &url, const std::string &target_fil
           std::cout << "Download failed: http error code: " << res_status << std::endl;
         }
       } else {
-        std::cout << "Download failed: connection failue" << std::endl;
+        std::cout << "Download failed: connection failure: " << msg->data.result << std::endl;
       }
     }
   }

--- a/selfdrive/ui/replay/util.cc
+++ b/selfdrive/ui/replay/util.cc
@@ -104,7 +104,7 @@ bool httpMultiPartDownload(const std::string &url, const std::string &target_fil
           std::cout << "Download failed: http error code: " << res_status << std::endl;
         }
       } else {
-        std::cout << "Download failed: connection failue";
+        std::cout << "Download failed: connection failue" << std::endl;
       }
     }
   }

--- a/selfdrive/ui/replay/util.cc
+++ b/selfdrive/ui/replay/util.cc
@@ -125,7 +125,7 @@ bool httpMultiPartDownload(const std::string &url, const std::string &target_fil
     if ((ts - last_print_ts) > 2 * 1000) {
       if (enable_http_logging && last_print_ts > 0) {
         size_t average = (total_written - prev_total_written) / ((ts - last_print_ts) / 1000.);
-        std::cout << "downloading segments at" << formattedDataSize(average) << "/S" << std::endl;
+        std::cout << "downloading segments at " << formattedDataSize(average) << "/S" << std::endl;
       }
       prev_total_written = total_written;
       last_print_ts = ts;

--- a/selfdrive/ui/replay/util.cc
+++ b/selfdrive/ui/replay/util.cc
@@ -119,8 +119,8 @@ bool httpMultiPartDownload(const std::string &url, const std::string &target_fil
     int cur_written = written - prev_written;
     prev_written = written;
 
-    double ts = millis_since_boot();
     std::lock_guard lk(lock);
+    double ts = millis_since_boot();
     total_written += cur_written;
     if ((ts - last_print_ts) > 2 * 1000) {
       if (enable_http_logging && last_print_ts > 0) {

--- a/selfdrive/ui/replay/util.h
+++ b/selfdrive/ui/replay/util.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <functional>
 #include <ostream>
 #include <string>
 #include <vector>

--- a/selfdrive/ui/replay/util.h
+++ b/selfdrive/ui/replay/util.h
@@ -3,7 +3,6 @@
 #include <atomic>
 #include <ostream>
 #include <string>
-#include <vector>
 
 void precise_nano_sleep(long sleep_ns);
 bool readBZ2File(const std::string_view file, std::ostream &stream);

--- a/selfdrive/ui/replay/util.h
+++ b/selfdrive/ui/replay/util.h
@@ -8,5 +8,5 @@
 
 void precise_nano_sleep(long sleep_ns);
 bool readBZ2File(const std::string_view file, std::ostream &stream);
-bool httpMultiPartDownload(const std::string &url, const std::string &target_file, int parts,
-                           std::atomic<bool> *abort = nullptr, std::function<void(void *, size_t, size_t)> func = nullptr, void *param = nullptr, const std::string log_name = {});
+bool httpMultiPartDownload(const std::string &url, const std::string &target_file, int parts, std::atomic<bool> *abort = nullptr,
+                           std::function<void(void *, size_t, size_t)> func = nullptr, void *param = nullptr);

--- a/selfdrive/ui/replay/util.h
+++ b/selfdrive/ui/replay/util.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <ostream>
 #include <string>
 #include <vector>
 
 void precise_nano_sleep(long sleep_ns);
 bool readBZ2File(const std::string_view file, std::ostream &stream);
-bool httpMultiPartDownload(const std::string &url, const std::string &target_file, int parts, std::atomic<bool> *abort = nullptr);
+bool httpMultiPartDownload(const std::string &url, const std::string &target_file, int parts,
+                           std::atomic<bool> *abort = nullptr, std::function<void(void *, size_t, size_t)> func = nullptr, void *param = nullptr, const std::string log_name = {});

--- a/selfdrive/ui/replay/util.h
+++ b/selfdrive/ui/replay/util.h
@@ -8,5 +8,5 @@
 
 void precise_nano_sleep(long sleep_ns);
 bool readBZ2File(const std::string_view file, std::ostream &stream);
-bool httpMultiPartDownload(const std::string &url, const std::string &target_file, int parts, std::atomic<bool> *abort = nullptr,
-                           std::function<void(void *, size_t, size_t)> func = nullptr, void *param = nullptr);
+void enableHttpLogging(bool enable);
+bool httpMultiPartDownload(const std::string &url, const std::string &target_file, int parts, std::atomic<bool> *abort = nullptr);


### PR DESCRIPTION
- [x] better error handling
- [x] retry on failure
- [x] log download information when it's blocking the replay. resolve https://github.com/commaai/openpilot/issues/22429:
`downloading segments at: 736.25 KB/S`
