### PR TITLE
Mazda: Fix steer lockout issue in CX-9 2021

### DIFF
--- a/selfdrive/car/mazda/carstate.py
+++ b/selfdrive/car/mazda/carstate.py
@@ -78,8 +78,8 @@ class CarState(CarStateBase):
         self.low_speed_lockout = False
         self.low_speed_alert = False
 
-    # On if no driver torque the last 5 seconds
-    ret.steerWarning = cp.vl["STEER_RATE"]["HANDS_OFF_5_SECONDS"] == 1
+    # Check if LKAS is disabled due to lack of driver torque
+    ret.steerWarning = (cp.vl["STEER_RATE"]["HANDS_OFF_5_SECONDS"] == 1) and (cp.vl["STEER_RATE"]["LKAS_BLOCK"] == 1)
 
     self.acc_active_last = ret.cruiseState.enabled
 


### PR DESCRIPTION
The hands off signal in CX-9 still happens and it alerts the driver after 5 seconds just like previous models, but unlike previous models it doesn't disable LKAS at the EPS level, only the camera stops sending LKAS commands. the new behavior is soft (camera) disable rather than hard (EPS)disable.  OP was looking only at the hands off  signal which causes frequent steer unavailable warning and triggering OP to disengage. By looking at both  the hands of signal and the LKAS blocked signal we only warn the driver that they have their hands off when LKAS is really unavailable, i.e, the EPS doesn't provide LKAS. 

After this update, the CX-9 stock system still  gives a single warning/chime after 5 seconds, but the EPS continues to accept LKAS (from OP) and the car  doesn't give any additional warnings. 

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>