### PR TITLE
replay: get EncoderIndex from capnp::AnyStruct

### DIFF
--- a/selfdrive/ui/replay/logreader.cc
+++ b/selfdrive/ui/replay/logreader.cc
@@ -14,17 +14,7 @@ Event::Event(const kj::ArrayPtr<const capnp::word> &amsg, bool frame) : reader(a
   // 1) Send video data at t=timestampEof/timestampSof
   // 2) Send encodeIndex packet at t=logMonoTime
   if (frame) {
-    cereal::EncodeIndex::Reader idx;
-    if (which == cereal::Event::ROAD_ENCODE_IDX) {
-      idx = event.getRoadEncodeIdx();
-    } else if (which == cereal::Event::DRIVER_ENCODE_IDX) {
-      idx = event.getDriverEncodeIdx();
-    } else if (which == cereal::Event::WIDE_ROAD_ENCODE_IDX) {
-      idx = event.getWideRoadEncodeIdx();
-    } else {
-      assert(false);
-    }
-
+    auto idx = capnp::AnyStruct::Reader(event).getPointerSection()[0].getAs<cereal::EncodeIndex>();
     // C2 only has eof set, and some older routes have neither
     uint64_t sof = idx.getTimestampSof();
     uint64_t eof = idx.getTimestampEof();

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -187,7 +187,7 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
 }
 
 void Replay::publishFrame(const Event *e) {
-  static std::map<cereal::Event::Which, CameraType> cam_types{
+  static const std::map<cereal::Event::Which, CameraType> cam_types{
       {cereal::Event::ROAD_ENCODE_IDX, RoadCam},
       {cereal::Event::DRIVER_ENCODE_IDX, DriverCam},
       {cereal::Event::WIDE_ROAD_ENCODE_IDX, WideRoadCam},
@@ -197,7 +197,7 @@ void Replay::publishFrame(const Event *e) {
     // eidx's segment is not loaded
     return;
   }
-  CameraType cam = cam_types[e->which];
+  CameraType cam = cam_types.at(e->which);
   auto &fr = segments_[eidx.getSegmentNum()]->frames[cam];
   if (fr && eidx.getType() == cereal::EncodeIndex::Type::FULL_H_E_V_C) {
     camera_server_->pushFrame(cam, fr.get(), eidx);


### PR DESCRIPTION
`AnyPointer.getAs` do exactly the same thing as `getXXXEncoderIndex` (they share same implementation internally) 