### PR TITLE
Hyundai: Add Kona and Kona EV to STEER_MAX = 384

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -12,7 +12,7 @@ class CarControllerParams:
   def __init__(self, CP):
     if CP.carFingerprint in [CAR.SONATA, CAR.PALISADE, CAR.SANTA_FE, CAR.VELOSTER, CAR.GENESIS_G70,
                              CAR.IONIQ_EV_2020, CAR.KIA_CEED, CAR.KIA_SELTOS, CAR.ELANTRA_2021,
-                             CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_HEV, CAR.SANTA_FE_2022, CAR.KIA_K5_2021]:
+                             CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_HEV, CAR.SANTA_FE_2022, CAR.KIA_K5_2021, CAR.KONA_EV, CAR.KONA]:
       self.STEER_MAX = 384
     else:
       self.STEER_MAX = 255


### PR DESCRIPTION
Kona and Kona EV use the same steering assembly (Rack and Pinion assembly, steering column, etc.) as the Kona HEV, they are capable of using as much of the STEER_MAX of 384 as the other applicable Hyundai cars.

Kona steering assembly from Hyundai: [Rack and Pinion Assembly](https://www.hyundaioempartsdirect.com/oem-parts/hyundai-rack-and-pinion-assembly-56500k4000?c=Zz1zdGVlcmluZyZzPXN0ZWVyaW5nLWdlYXItYW5kLWxpbmthZ2UmbD0xJm49QXNzZW1ibGllcyBQYWdlJmE9aHl1bmRhaSZvPWtvbmEtZWxlY3RyaWMmeT0yMDIwJnQ9c2VsJmU9ZWxlY3RyaWM%3D)