### PR TITLE
[Docs] Models: README: Fix channel number

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -8,7 +8,7 @@ To view the architecture of the ONNX networks, you can use [netron](https://netr
     * Each 256 * 512 image is represented in YUV420 with 6 channels : 6 * 128 * 256
       * Channels 0,1,2,3 represent the full-res Y channel and are represented in numpy as Y[::2, ::2], Y[::2, 1::2], Y[1::2, ::2], and Y[1::2, 1::2]
       * Channel 4 represents the half-res U channel
-      * Channel 4 represents the half-res V channel
+      * Channel 5 represents the half-res V channel
 * **desire**
   * one-hot encoded vector to command model to execute certain actions, bit only needs to be sent for 1 frame : 8
 * **traffic convention**


### PR DESCRIPTION
Small nitpick after https://github.com/commaai/openpilot/pull/22523.

Fix the channel number for the V-channel of the supercombo input image stream. Both the U and V channels were listed as using Channel 4, the latter should probably be 5.

@HaraldSchafer is that correct?