### PR TITLE
replay: refactor Route and Segment

### DIFF
--- a/selfdrive/ui/replay/logreader.cc
+++ b/selfdrive/ui/replay/logreader.cc
@@ -32,7 +32,8 @@ LogReader::~LogReader() {
 }
 
 bool LogReader::load(const std::string &file) {
-  if (file.rfind(".bz2") == file.length() - 4) {
+  bool is_bz2 = file.rfind(".bz2") == file.length() - 4;
+  if (is_bz2) {
     std::ostringstream stream;
     if (!readBZ2File(file, stream)) {
       LOGW("bz2 decompress failed");

--- a/selfdrive/ui/replay/logreader.cc
+++ b/selfdrive/ui/replay/logreader.cc
@@ -32,8 +32,8 @@ LogReader::~LogReader() {
   for (auto e : events) delete e;
 }
 
-bool LogReader::load(const std::string &file, bool is_bz2file) {
-  if (is_bz2file) {
+bool LogReader::load(const std::string &file) {
+  if (file.rfind(".bz2") == file.length() - 4) {
     std::ostringstream stream;
     if (!readBZ2File(file, stream)) {
       LOGW("bz2 decompress failed");

--- a/selfdrive/ui/replay/logreader.cc
+++ b/selfdrive/ui/replay/logreader.cc
@@ -1,6 +1,5 @@
 #include "selfdrive/ui/replay/logreader.h"
 
-#include <cassert>
 #include <sstream>
 #include "selfdrive/common/util.h"
 #include "selfdrive/ui/replay/util.h"

--- a/selfdrive/ui/replay/logreader.h
+++ b/selfdrive/ui/replay/logreader.h
@@ -38,7 +38,7 @@ class LogReader {
 public:
   LogReader() = default;
   ~LogReader();
-  bool load(const std::string &file, bool is_bz2file);
+  bool load(const std::string &file);
 
   std::vector<Event*> events;
 

--- a/selfdrive/ui/replay/logreader.h
+++ b/selfdrive/ui/replay/logreader.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <unordered_map>
-#include <cassert>
-
 #include <capnp/serialize.h>
 #include "cereal/gen/cpp/log.capnp.h"
 #include "selfdrive/camerad/cameras/camera_common.h"

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -190,7 +190,7 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
     });
     delete prev_events;
   } else {
-    updateEvents([=]() { return begin->second->isLoaded(); });
+    updateEvents([=]() { return true; });
   }
 }
 

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -202,7 +202,7 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
   }
 }
 
-void Replay::publisMessage(const Event *e) {
+void Replay::publishMessage(const Event *e) {
   if (sm == nullptr) {
     auto bytes = e->bytes();
     int ret = pm->send(sockets_[e->which], (capnp::byte *)bytes.begin(), bytes.size());
@@ -291,7 +291,7 @@ void Replay::stream() {
         if (evt->frame) {
           publishFrame(evt);
         } else {
-          publisMessage(evt);
+          publishMessage(evt);
         }
       }
     }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -125,7 +125,7 @@ void Replay::setCurrentSegment(int n) {
 void Replay::segmentLoadFinished(bool success) {
   if (!success) {
     Segment *seg = qobject_cast<Segment *>(sender());
-    qInfo() << "failed to load segment" << seg->seg_num << ", remove it from current replay list";
+    qInfo() << "failed to load segment " << seg->seg_num << ", removing it from current replay list";
     segments_.erase(seg->seg_num);
   }
   queueSegment();

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -146,7 +146,7 @@ void Replay::queueSegment() {
     auto &[n, seg] = *it;
     if (!seg) {
       seg = std::make_unique<Segment>(n, route_->at(n), load_dcam, load_ecam);
-      QObject::connect(seg.get(), &Segment::loadFinished, this, &Replay::queueSegment);
+      QObject::connect(seg.get(), &Segment::loadFinished, this, &Replay::segmentLoadFinished);
       qInfo() << "loading segment" << n << "...";
     }
   }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -124,7 +124,7 @@ void Replay::setCurrentSegment(int n) {
 void Replay::segmentLoadFinished(bool success) {
   if (!success) {
     Segment *seg = qobject_cast<Segment *>(sender());
-    qInfo() << "failed to load segment" << seg->seg_num << ".remove it from current replay list";
+    qInfo() << "failed to load segment" << seg->seg_num << ", remove it from current replay list";
     segments_.erase(seg->seg_num);
   }
   queueSegment();

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -57,10 +57,9 @@ bool Replay::load() {
     return false;
   }
 
-  for (int i = 0; i < route_->size(); ++i) {
-    const SegmentFile &f = route_->at(i);
+  for (auto &[n, f] : route_->segments()) {
     if ((!f.rlog.isEmpty() || !f.qlog.isEmpty()) && (!f.road_cam.isEmpty() || !f.qcamera.isEmpty())) {
-      segments_[i] = nullptr;
+      segments_[n] = nullptr;
     }
   }
   if (segments_.empty()) {

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -121,6 +121,15 @@ void Replay::setCurrentSegment(int n) {
   }
 }
 
+void Replay::segmentLoadFinished(bool success) {
+  Segment *segment = qobject_cast<Segment *>(sender());
+  if (!success) {
+    // remove segment if it failed to load
+    segments_.erase(segment->seg_num);
+  }
+  queueSegment();
+}
+
 // maintain the segment window
 void Replay::queueSegment() {
   // forward fetch segments
@@ -130,7 +139,7 @@ void Replay::queueSegment() {
     auto &[n, seg] = *end;
     if (!seg) {
       seg = std::make_unique<Segment>(n, route_->at(n), load_dcam, load_ecam);
-      QObject::connect(seg.get(), &Segment::loadFinished, this, &Replay::queueSegment);
+      QObject::connect(seg.get(), &Segment::loadFinished, this, &Replay::segmentLoadFinished);
     }
   }
   // merge segments

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -122,10 +122,10 @@ void Replay::setCurrentSegment(int n) {
 }
 
 void Replay::segmentLoadFinished(bool success) {
-  Segment *segment = qobject_cast<Segment *>(sender());
   if (!success) {
-    // remove segment if it failed to load
-    segments_.erase(segment->seg_num);
+    Segment *seg = qobject_cast<Segment *>(sender());
+    qInfo() << "failed to load segment" << seg->seg_num << ".remove it from current replay list";
+    segments_.erase(seg->seg_num);
   }
   queueSegment();
 }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -140,6 +140,7 @@ void Replay::queueSegment() {
     if (!seg) {
       seg = std::make_unique<Segment>(n, route_->at(n), load_dcam, load_ecam);
       QObject::connect(seg.get(), &Segment::loadFinished, this, &Replay::segmentLoadFinished);
+      qInfo() << "loading segment" << n << "...";
     }
   }
   // merge segments

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -35,6 +35,7 @@ protected:
   void setCurrentSegment(int n);
   void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);
   void updateEvents(const std::function<bool()>& lambda);
+  void publisMessage(const Event *e);
   void publishFrame(const Event *e);
   inline int currentSeconds() const { return (cur_mono_time_ - route_start_ts_) / 1e9; }
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -27,6 +27,7 @@ signals:
 protected slots:
   void queueSegment();
   void doSeek(int seconds, bool relative);
+  void segmentLoadFinished(bool sucess);
 
 protected:
   typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -35,7 +35,7 @@ protected:
   void setCurrentSegment(int n);
   void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);
   void updateEvents(const std::function<bool()>& lambda);
-  void publisMessage(const Event *e);
+  void publishMessage(const Event *e);
   void publishFrame(const Event *e);
   inline int currentSeconds() const { return (cur_mono_time_ - route_start_ts_) / 1e9; }
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -6,7 +6,7 @@
 #include "selfdrive/ui/replay/route.h"
 
 constexpr int FORWARD_SEGS = 2;
-constexpr int BACKWARD_SEGS = 2;
+constexpr int BACKWARD_SEGS = 1;
 
 class Replay : public QObject {
   Q_OBJECT

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -63,10 +63,13 @@ bool Route::loadFromLocal() {
   if (folders.isEmpty()) return false;
 
   for (auto folder : folders) {
-    const int seg_num = folder.split("--")[2].toInt();
-    QDir segment_dir(log_dir.filePath(folder));
-    for (auto f : segment_dir.entryList(QDir::Files)) {
-      addFileToSegment(seg_num, segment_dir.absoluteFilePath(f));
+    int seg_num_pos = folder.lastIndexOf("--");
+    if (seg_num_pos != -1) {
+      const int seg_num = folder.mid(seg_num_pos + 2).toInt();
+      QDir segment_dir(log_dir.filePath(folder));
+      for (auto f : segment_dir.entryList(QDir::Files)) {
+        addFileToSegment(seg_num, segment_dir.absoluteFilePath(f));
+      }
     }
   }
   return true;

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -136,6 +136,8 @@ void Segment::loadFile(int id, const QString file) {
   std::string decompressed_file = local_file + ".decompressed";
 
   if (file.startsWith("https://")  && !util::file_exists(local_file)) {
+    if (id == 0) qDebug() << "downloading segment" << seg_num_ << "...";
+
     bool ret = httpMultiPartDownload(file.toStdString(), local_file, connections_per_file, &aborting_);
     if (ret && id == MAX_CAMERAS) {
       // pre-decompress log file.
@@ -152,7 +154,7 @@ void Segment::loadFile(int id, const QString file) {
       frames[id] = std::make_unique<FrameReader>();
       frames[id]->load(local_file);
     }
-    if (--loading_ == 0) {
+    if (--loading_ == 0 && !aborting_) {
       emit loadFinished();
     }
   }

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -131,7 +131,7 @@ void Segment::loadFile(int id, const std::string file) {
     file_ready = httpMultiPartDownload(file, local_file, id < MAX_CAMERAS ? 3 : 1, &aborting_);
   }
 
-  if (!aborting_) {
+  if (!aborting_ && file_ready) {
     if (id < MAX_CAMERAS) {
       frames[id] = std::make_unique<FrameReader>();
       success_ = success_ && frames[id]->load(local_file);
@@ -145,9 +145,9 @@ void Segment::loadFile(int id, const std::string file) {
       log = std::make_unique<LogReader>();
       success_ = success_ && log->load(decompressed);
     }
-    if (!aborting_ && --loading_ == 0) {
-      emit loadFinished(success_);
-    }
+  }
+  if (!aborting_ && --loading_ == 0) {
+    emit loadFinished(success_);
   }
 }
 

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -10,8 +10,6 @@
 #include "selfdrive/ui/qt/api.h"
 #include "selfdrive/ui/replay/util.h"
 
-Route::Route(const QString &route, const QString &data_dir) : route_(route), data_dir_(data_dir) {}
-
 bool Route::load() {
   if (data_dir_.isEmpty()) {
     return loadFromServer();
@@ -49,8 +47,7 @@ bool Route::loadFromJson(const QString &json) {
     for (const auto &url : route_files[key].toArray()) {
       QString url_str = url.toString();
       if (rx.indexIn(url_str) != -1) {
-        const int seg_num = rx.cap(1).toInt();
-        addFileToSegment(seg_num, url_str);
+        addFileToSegment(rx.cap(1).toInt(), url_str);
       }
     }
   }
@@ -76,22 +73,20 @@ bool Route::loadFromLocal() {
 }
 
 void Route::addFileToSegment(int n, const QString &file) {
-  if (segments_.size() <= n) {
-    segments_.resize(n + 1);
-  }
-  QString name = QUrl(file).fileName();
+  auto &seg = segments_[n]; 
+  const QString name = QUrl(file).fileName();
   if (name == "rlog.bz2") {
-    segments_[n].rlog = file;
+    seg.rlog = file;
   } else if (name == "qlog.bz2") {
-    segments_[n].qlog = file;
+    seg.qlog = file;
   } else if (name == "fcamera.hevc") {
-    segments_[n].road_cam = file;
+    seg.road_cam = file;
   } else if (name == "dcamera.hevc") {
-    segments_[n].driver_cam = file;
+    seg.driver_cam = file;
   } else if (name == "ecamera.hevc") {
-    segments_[n].wide_road_cam = file;
+    seg.wide_road_cam = file;
   } else if (name == "qcamera.ts") {
-    segments_[n].qcamera = file;
+    seg.qcamera = file;
   }
 }
 

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -143,7 +143,7 @@ void Segment::loadFile(int id, const std::string file) {
       log = std::make_unique<LogReader>();
       log->load(decompressed);
     }
-    if (--loading_ == 0 && !aborting_) {
+    if (!aborting_ && --loading_ == 0) {
       emit loadFinished();
     }
   }

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -134,7 +134,7 @@ Segment::~Segment() {
 void Segment::loadFile(int id, const std::string file) {
   bool is_remote_file = file.find("https://") == 0;
   std::string local_file = is_remote_file ? cacheFilePath(file) : file;
-  if (is_remote_file  && !util::file_exists(local_file)) {
+  if (is_remote_file && !util::file_exists(local_file)) {
     httpMultiPartDownload(file, local_file, connections_per_file, &aborting_);
   }
 
@@ -159,6 +159,8 @@ void Segment::loadFile(int id, const std::string file) {
 }
 
 std::string Segment::cacheFilePath(const std::string &file) {
-  QByteArray url_no_query = QUrl(file.c_str()).toString(QUrl::RemoveQuery).toUtf8();
-  return CACHE_DIR.filePath(QString(QCryptographicHash::hash(url_no_query, QCryptographicHash::Sha256).toHex())).toStdString();
+  QUrl url(file.c_str());
+  QByteArray url_no_query = url.toString(QUrl::RemoveQuery).toUtf8();
+  QString sha256 = QCryptographicHash::hash(url_no_query, QCryptographicHash::Sha256).toHex();
+  return CACHE_DIR.filePath(sha256 + "." + QFileInfo(url.fileName()).suffix()).toStdString();
 }

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -73,20 +73,19 @@ bool Route::loadFromLocal() {
 }
 
 void Route::addFileToSegment(int n, const QString &file) {
-  auto &seg = segments_[n]; 
   const QString name = QUrl(file).fileName();
   if (name == "rlog.bz2") {
-    seg.rlog = file;
+    segments_[n].rlog = file;
   } else if (name == "qlog.bz2") {
-    seg.qlog = file;
+    segments_[n].qlog = file;
   } else if (name == "fcamera.hevc") {
-    seg.road_cam = file;
+    segments_[n].road_cam = file;
   } else if (name == "dcamera.hevc") {
-    seg.driver_cam = file;
+    segments_[n].driver_cam = file;
   } else if (name == "ecamera.hevc") {
-    seg.wide_road_cam = file;
+    segments_[n].wide_road_cam = file;
   } else if (name == "qcamera.ts") {
-    seg.qcamera = file;
+    segments_[n].qcamera = file;
   }
 }
 

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -118,8 +118,7 @@ Segment::Segment(int n, const SegmentFile &segment_files, bool load_dcam, bool l
   if (!load_ecam) {
     files_.wide_road_cam = "";
   }
-
-  if (!QUrl(log_path_).isLocalFile()) {
+  if (log_path_.startsWith("https://")) {
     for (auto &url : {log_path_, road_cam_path_, files_.driver_cam, files_.wide_road_cam}) {
       if (!url.isEmpty() && !QFile::exists(localPath(url))) {
         downloadFile(url);
@@ -186,9 +185,9 @@ void Segment::load() {
   emit loadFinished();
 }
 
-QString Segment::localPath(const QUrl &url) {
-  if (url.isLocalFile() || QFile(url.toString()).exists()) return url.toString();
+QString Segment::localPath(const QString &file) {
+  if (!file.startsWith("https://")) return file;
 
-  QByteArray url_no_query = url.toString(QUrl::RemoveQuery).toUtf8();
+  QByteArray url_no_query = QUrl(file).toString(QUrl::RemoveQuery).toUtf8();
   return CACHE_DIR.filePath(QString(QCryptographicHash::hash(url_no_query, QCryptographicHash::Sha256).toHex()));
 }

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -134,7 +134,7 @@ void Segment::loadFile(int id, const std::string file) {
       frames[id] = std::make_unique<FrameReader>();
       frames[id]->load(local_file);
     } else {
-      // pre-decompress log file.
+      // decompress log file.
       std::string decompressed = cacheFilePath(local_file + ".decompressed");
       if (!util::file_exists(decompressed)) {
         std::ofstream ostrm(decompressed, std::ios::binary);

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -125,8 +125,9 @@ Segment::Segment(int n, const SegmentFile &files, bool load_dcam, bool load_ecam
 
 Segment::~Segment() {
   aborting_ = true;
-  for (auto &t : threads_) {
+  for (QThread *t : threads_) {
     if (t->isRunning()) t->wait();
+    delete t;
   }
 }
 

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -55,8 +55,8 @@ signals:
 
 protected:
   void load();
-  void downloadFile(const QString &url);
-  QString localPath(const QString &file);
+  void download(const std::string &url, const std::string &local_file);
+  std::string localPath(const QString &file);
 
   std::atomic<bool> loaded_ = false;
   std::atomic<bool> aborting_ = false;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDir>
+#include <QFutureSynchronizer>
 
 #include "selfdrive/common/util.h"
 #include "selfdrive/ui/replay/framereader.h"
@@ -56,5 +57,5 @@ protected:
   std::atomic<bool> aborting_ = false;
   std::atomic<int> loading_ = 0;
   int seg_num_ = 0;
-  std::vector<QThread*> threads_;
+  QFutureSynchronizer<void> synchronizer_;
 };

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -55,7 +55,7 @@ signals:
 
 protected:
   void load();
-  void download(const std::string &url, const std::string &local_file);
+  void download(const std::string &url, const std::string &cache_file);
   std::string localPath(const QString &file);
 
   std::atomic<bool> loaded_ = false;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -42,20 +42,20 @@ class Segment : public QObject {
 public:
   Segment(int n, const SegmentFile &files, bool load_dcam, bool load_ecam);
   ~Segment();
-  inline bool isLoaded() const { return loading_ == 0; }
+  inline bool isLoaded() const { return !loading_ && success_; }
 
+  const int seg_num = 0;
   std::unique_ptr<LogReader> log;
   std::unique_ptr<FrameReader> frames[MAX_CAMERAS] = {};
 
 signals:
-  void loadFinished();
+  void loadFinished(bool success);
 
 protected:
   void loadFile(int id, const std::string file);
   std::string cacheFilePath(const std::string &file);
 
-  std::atomic<bool> aborting_ = false;
+  std::atomic<bool> success_ = true, aborting_ = false;
   std::atomic<int> loading_ = 0;
-  int seg_num_ = 0;
   QFutureSynchronizer<void> synchronizer_;
 };

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -54,8 +54,8 @@ signals:
   void loadFinished();
 
 protected:
-  void loadFile(int id, const QString file);
-  std::string localPath(const QString &file);
+  void loadFile(int id, const std::string file);
+  std::string cacheFilePath(const std::string &file);
 
   std::atomic<bool> aborting_ = false;
   std::atomic<int> loading_ = 0;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <QDir>
-#include <QString>
-#include <vector>
 
 #include "selfdrive/common/util.h"
 #include "selfdrive/ui/replay/framereader.h"
@@ -21,11 +19,11 @@ struct SegmentFile {
 
 class Route {
 public:
-  Route(const QString &route, const QString &data_dir = {});
+  Route(const QString &route, const QString &data_dir = {}) : route_(route), data_dir_(data_dir) {};
   bool load();
   inline const QString &name() const { return route_; };
-  inline int size() const { return segments_.size(); }
-  inline SegmentFile &at(int n) { return segments_[n]; }
+  inline const std::map<int, SegmentFile> &segments() const { return segments_; }
+  inline SegmentFile &at(int n) { return segments_.at(n); }
 
 protected:
   bool loadFromLocal();
@@ -34,7 +32,7 @@ protected:
   void addFileToSegment(int seg_num, const QString &file);
   QString route_;
   QString data_dir_;
-  std::vector<SegmentFile> segments_;
+  std::map<int, SegmentFile> segments_;
 };
 
 class Segment : public QObject {

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -31,7 +31,9 @@ public:
 
 protected:
   bool loadFromLocal();
+  bool loadFromServer();
   bool loadFromJson(const QString &json);
+  void addFileToSegment(int seg_num, const QString &file);
   QString route_;
   QString data_dir_;
   std::vector<SegmentFile> segments_;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -10,7 +10,6 @@
 #include "selfdrive/ui/replay/logreader.h"
 
 const QDir CACHE_DIR(util::getenv("COMMA_CACHE", "/tmp/comma_download_cache/").c_str());
-const int connections_per_file = 3;
 
 struct SegmentFile {
   QString rlog;

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -43,9 +43,9 @@ class Segment : public QObject {
   Q_OBJECT
 
 public:
-  Segment(int n, const SegmentFile &segment_files, bool load_dcam, bool load_ecam);
+  Segment(int n, const SegmentFile &files, bool load_dcam, bool load_ecam);
   ~Segment();
-  inline bool isLoaded() const { return loaded_; }
+  inline bool isLoaded() const { return loading_ == 0; }
 
   std::unique_ptr<LogReader> log;
   std::unique_ptr<FrameReader> frames[MAX_CAMERAS] = {};
@@ -54,16 +54,11 @@ signals:
   void loadFinished();
 
 protected:
-  void load();
-  void download(const std::string &url, const std::string &cache_file);
+  void loadFile(int id, const QString file);
   std::string localPath(const QString &file);
 
-  std::atomic<bool> loaded_ = false;
   std::atomic<bool> aborting_ = false;
-  std::atomic<int> downloading_ = 0;
+  std::atomic<int> loading_ = 0;
   int seg_num_ = 0;
-  SegmentFile files_;
-  QString road_cam_path_;
-  QString log_path_;
-  std::vector<QThread*> download_threads_;
+  std::vector<QThread*> threads_;
 };

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QDir>
-#include <QObject>
 #include <QString>
 #include <vector>
 

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -23,7 +23,7 @@ public:
   bool load();
   inline const QString &name() const { return route_; };
   inline const std::map<int, SegmentFile> &segments() const { return segments_; }
-  inline SegmentFile &at(int n) { return segments_.at(n); }
+  inline const SegmentFile &at(int n) { return segments_.at(n); }
 
 protected:
   bool loadFromLocal();

--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -56,7 +56,7 @@ signals:
 protected:
   void load();
   void downloadFile(const QString &url);
-  QString localPath(const QUrl &url);
+  QString localPath(const QString &file);
 
   std::atomic<bool> loaded_ = false;
   std::atomic<bool> aborting_ = false;

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -14,7 +14,6 @@ std::string sha_256(const QString &dat) {
 TEST_CASE("httpMultiPartDownload") {
   char filename[] = "/tmp/XXXXXX";
   int fd = mkstemp(filename);
-  REQUIRE(fd != -1);
   close(fd);
 
   const char *stream_url = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/fcamera.hevc";

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -54,7 +54,7 @@ bool is_events_ordered(const std::vector<Event *> &events) {
 TEST_CASE("Segment") {
   Route demo_route(DEMO_ROUTE);
   REQUIRE(demo_route.load());
-  REQUIRE(demo_route.size() == 11);
+  REQUIRE(demo_route.segments().size() == 11);
 
   QEventLoop loop;
   Segment segment(0, demo_route.at(0), false, false);

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -132,7 +132,6 @@ void TestReplay::test_seek() {
       segments_.erase(n);
     }
     for (int i =0; i < 50; ++i) {
-      testSeekTo(520);
       testSeekTo(random_int(4 * 60, 9 * 60));
     }
     loop.quit();

--- a/selfdrive/ui/replay/util.cc
+++ b/selfdrive/ui/replay/util.cc
@@ -49,10 +49,12 @@ bool httpMultiPartDownload(const std::string &url, const std::string &target_fil
   int64_t content_length = getDownloadContentLength(url);
   if (content_length == -1) return false;
 
+  // create a tmp sparse file
   std::string tmp_file = target_file + ".tmp";
   FILE *fp = fopen(tmp_file.c_str(), "wb");
-  // create a sparse file
-  fseek(fp, content_length, SEEK_SET);
+  assert(fp);
+  fseek(fp, content_length - 1, SEEK_SET);
+  fwrite("\0", 1, 1, fp);
 
   CURLM *cm = curl_multi_init();
   std::map<CURL *, MultiPartWriter> writers;


### PR DESCRIPTION
- [x] refactor to simplify code and improve readability.
- [x] handle segment download/load failure
- [x] fix issues with loading from local route
- [x] fix can't seek to the last segment.
- [x] merge one segment backward. this fix the following 2 issue:
   1.  get stuck for a while when playing to the next segment
   2. the event time between segments is not continuous, if the previous segment is not merged, there may be duplicate messages sent when playing to the next segment
- [x] fix other known issues, improve robustness.