### PR TITLE
replay: override operator new for class Event to allocate memory in pool

### DIFF
--- a/selfdrive/ui/replay/logreader.cc
+++ b/selfdrive/ui/replay/logreader.cc
@@ -42,10 +42,6 @@ LogReader::LogReader(size_t memory_pool_block_size) : memory_pool_(memory_pool_b
   events.reserve(memory_pool_block_size);
 }
 
-LogReader::~LogReader() {
-  for (auto e : events) delete e;
-}
-
 bool LogReader::load(const std::string &file) {
   bool is_bz2 = file.rfind(".bz2") == file.length() - 4;
   if (is_bz2) {

--- a/selfdrive/ui/replay/logreader.cc
+++ b/selfdrive/ui/replay/logreader.cc
@@ -38,7 +38,9 @@ Event::Event(const kj::ArrayPtr<const capnp::word> &amsg, bool frame) : reader(a
 
 // class LogReader
 
-LogReader::LogReader(size_t memory_pool_block_size) : memory_pool_(memory_pool_block_size) {}
+LogReader::LogReader(size_t memory_pool_block_size) : memory_pool_(memory_pool_block_size) {
+  events.reserve(memory_pool_block_size);
+}
 
 LogReader::~LogReader() {
   for (auto e : events) delete e;

--- a/selfdrive/ui/replay/logreader.h
+++ b/selfdrive/ui/replay/logreader.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <memory_resource>
 
 #include "cereal/gen/cpp/log.capnp.h"

--- a/selfdrive/ui/replay/logreader.h
+++ b/selfdrive/ui/replay/logreader.h
@@ -53,7 +53,6 @@ public:
 class LogReader {
 public:
   LogReader(size_t memory_pool_block_size = DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE);
-  ~LogReader();
   bool load(const std::string &file);
 
   std::vector<Event*> events;

--- a/selfdrive/ui/replay/logreader.h
+++ b/selfdrive/ui/replay/logreader.h
@@ -1,11 +1,23 @@
 #pragma once
 
+#include <cassert>
+#include <memory_resource>
+
 #include <capnp/serialize.h>
 #include "cereal/gen/cpp/log.capnp.h"
 #include "selfdrive/camerad/cameras/camera_common.h"
 
 const CameraType ALL_CAMERAS[] = {RoadCam, DriverCam, WideRoadCam};
 const int MAX_CAMERAS = std::size(ALL_CAMERAS);
+const int DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE = 65000;
+
+class EventMemoryPool {
+public:
+  EventMemoryPool(size_t block_size);
+  ~EventMemoryPool();
+  std::pmr::monotonic_buffer_resource *mbr_ = nullptr;
+  void *buffer_ = nullptr;
+};
 
 class Event {
 public:
@@ -23,6 +35,13 @@ public:
     }
   };
 
+  void *operator new(size_t size, EventMemoryPool& pool) {
+    return pool.mbr_->allocate(size);
+  }
+  void operator delete(void *ptr) {
+    // No-op. memory used by EventMemoryPool increases monotonically until the logReader is destroyed. 
+  }
+
   uint64_t mono_time;
   cereal::Event::Which which;
   cereal::Event::Reader event;
@@ -33,7 +52,7 @@ public:
 
 class LogReader {
 public:
-  LogReader() = default;
+  LogReader(size_t memory_pool_block_size = DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE);
   ~LogReader();
   bool load(const std::string &file);
 
@@ -41,4 +60,5 @@ public:
 
 private:
   std::string raw_;
+  EventMemoryPool memory_pool_;
 };

--- a/selfdrive/ui/replay/logreader.h
+++ b/selfdrive/ui/replay/logreader.h
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <memory_resource>
 
-#include <capnp/serialize.h>
 #include "cereal/gen/cpp/log.capnp.h"
 #include "selfdrive/camerad/cameras/camera_common.h"
 


### PR DESCRIPTION
use monotonic_buffer_resource to save hundreds of thousands of memory allocations to improve performance and reduce memory fragmentation. the loop in load() is much faster than before, since events are in a contiguous memory block now, sorting and accessing the events will also be faster.
the default memory pool size is ~21mb (65000*344(sizeof(Event)==344)) for one segment. (the number of events for most segments is less than 65000, if the pool is exhausted, additional buffers will be obtained from heap by monotonic_buffer_resource)