### PR TITLE
ModelDataRaw struct with fixed size arrays

### DIFF
--- a/selfdrive/modeld/models/driving.cc
+++ b/selfdrive/modeld/models/driving.cc
@@ -363,10 +363,10 @@ void posenet_publish(PubMaster &pm, uint32_t vipc_frame_id, uint32_t vipc_droppe
 
   for (int i =0; i < 3; i++) {
     trans_arr[i] = net_outputs.pose->trans_arr[i];
-    trans_std_arr[i] = exp(net_outputs.pose->trans_std_arr[6 + i]);
+    trans_std_arr[i] = exp(net_outputs.pose->trans_std_arr[i]);
 
-    rot_arr[i] = net_outputs.pose->rot_arr[3 + i];
-    rot_std_arr[i] = exp(net_outputs.pose->rot_std_arr[9 + i]);
+    rot_arr[i] = net_outputs.pose->rot_arr[i];
+    rot_std_arr[i] = exp(net_outputs.pose->rot_std_arr[i]);
   }
 
   MessageBuilder msg;

--- a/selfdrive/modeld/models/driving.cc
+++ b/selfdrive/modeld/models/driving.cc
@@ -118,7 +118,7 @@ ModelDataRaw model_eval_frame(ModelState* s, cl_mem yuv_cl, int width, int heigh
   net_outputs.lead = &s->output[LEAD_IDX];
   net_outputs.lead_prob = &s->output[LEAD_PROB_IDX];
   net_outputs.meta = &s->output[DESIRE_STATE_IDX];
-  net_outputs.pose = &s->output[POSE_IDX];
+  net_outputs.pose = (ModelDataRawPose*)&s->output[POSE_IDX];
   return net_outputs;
 }
 
@@ -362,11 +362,11 @@ void posenet_publish(PubMaster &pm, uint32_t vipc_frame_id, uint32_t vipc_droppe
   float rot_std_arr[3];
 
   for (int i =0; i < 3; i++) {
-    trans_arr[i] = net_outputs.pose[i];
-    trans_std_arr[i] = exp(net_outputs.pose[6 + i]);
+    trans_arr[i] = net_outputs.pose->trans_arr[i];
+    trans_std_arr[i] = exp(net_outputs.pose->trans_std_arr[6 + i]);
 
-    rot_arr[i] = net_outputs.pose[3 + i];
-    rot_std_arr[i] = exp(net_outputs.pose[9 + i]);
+    rot_arr[i] = net_outputs.pose->rot_arr[3 + i];
+    rot_std_arr[i] = exp(net_outputs.pose->rot_std_arr[9 + i]);
   }
 
   MessageBuilder msg;

--- a/selfdrive/modeld/models/driving.h
+++ b/selfdrive/modeld/models/driving.h
@@ -18,6 +18,13 @@ constexpr int DESIRE_LEN = 8;
 constexpr int TRAFFIC_CONVENTION_LEN = 2;
 constexpr int MODEL_FREQ = 20;
 
+struct ModelDataRawPose {
+  float trans_arr[3];
+  float rot_arr[3];
+  float trans_std_arr[3];
+  float rot_std_arr[3];
+};
+
 struct ModelDataRaw {
   float *plan;
   float *lane_lines;
@@ -28,7 +35,7 @@ struct ModelDataRaw {
   float *desire_state;
   float *meta;
   float *desire_pred;
-  float *pose;
+  ModelDataRawPose *pose;
 };
 
 typedef struct ModelState {


### PR DESCRIPTION
All of these hand calculated numbers seem prone to error and like they will be a PITA the next time we change something
https://github.com/commaai/openpilot/blob/master/models/README.md

Perhaps we can use a struct with doc strings (or something similar) to generate this instead?

I converted pose as an example to get started, looks like some of the other outputs will require some more serious refactoring to do the same, but still seems possible.

In the end we should be able to cast the `ModelState` output `&s->output` as the struct instead of copying a bunch of pointers?
https://github.com/commaai/openpilot/blob/cbac96f50cbd959841e8fb24e33d95bd11a89b91/selfdrive/modeld/models/driving.cc#L113-L122

This should also make it easier for others to play with the model outside openpilot (we could even add a simple pyx wrapper if we wanted to).