### PR TITLE
add `optional` header for include in common params

### DIFF
--- a/selfdrive/common/params.h
+++ b/selfdrive/common/params.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <optional>
 
 enum ParamKeyType {
   PERSISTENT = 0x02,


### PR DESCRIPTION
For successful build on Ubuntu 20.04

**Description** Attempted to build using `scons` on Ubuntu 20.04. Failed to build initially and suspected there were issues with my C++17 headers. Ended up having to include the `optional` header for successful build.

**Verification** Build success after adding `include`. Ran the UI and main program for replay successfully following build.
![openpilot-ui](https://user-images.githubusercontent.com/307913/137264083-b197be7a-0d74-4d08-829e-42fb67860b88.jpg)


