### PR TITLE
replay/camera: publish each camera in a separate thread

### DIFF
--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -5,41 +5,46 @@
 
 const int YUV_BUF_COUNT = 50;
 
-CameraServer::CameraServer() {
-  camera_thread_ = std::thread(&CameraServer::thread, this);
-}
+CameraServer::CameraServer() {}
 
 CameraServer::~CameraServer() {
-  queue_.push({});
-  camera_thread_.join();
+  // exit all camera threads
+  for (auto &cam : cameras_) {
+    if (cam.thread.joinable()) {
+      cam.queue.push({});
+      cam.thread.join();
+    }
+  }
   vipc_server_.reset(nullptr);
 }
 
+void CameraServer::start(std::pair<int, int> camera_size[MAX_CAMERAS]) {
+  for (auto type : ALL_CAMERAS) {
+    std::tie(cameras_[type].width, cameras_[type].height) = camera_size[type];
+  }
+  startVipcServer();
+}
+
 void CameraServer::startVipcServer() {
-  std::cout << (vipc_server_ ? "restart" : "start") << " vipc server" << std::endl;
   vipc_server_.reset(new VisionIpcServer("camerad"));
-  for (auto &cam : cameras_) {
+  for (auto &type : ALL_CAMERAS) {
+    auto &cam = cameras_[type];
     if (cam.width > 0 && cam.height > 0) {
       vipc_server_->create_buffers(cam.rgb_type, UI_BUF_COUNT, true, cam.width, cam.height);
       vipc_server_->create_buffers(cam.yuv_type, YUV_BUF_COUNT, false, cam.width, cam.height);
+      // Create thread on demand to handle new incoming camera
+      if (!cam.thread.joinable()) {
+        cam.thread = std::thread(&CameraServer::cameraThread, this, type, std::ref(cam));
+      }
     }
   }
   vipc_server_->start_listener();
 }
 
-void CameraServer::thread() {
+void CameraServer::cameraThread(CameraType type, Camera &cam) {
   while (true) {
-    const auto [type, fr, eidx] = queue_.pop();
+    const auto [fr, eidx] = cam.queue.pop();
     if (!fr) break;
-
-    auto &cam = cameras_[type];
-    // start|restart the vipc server if frame size changed
-    if (cam.width != fr->width || cam.height != fr->height) {
-      cam.width = fr->width;
-      cam.height = fr->height;
-      std::cout << "camera[" << type << "] frame size " << cam.width << "x" << cam.height << std::endl;
-      startVipcServer();
-    }
 
     // send frame
     if (auto dat = fr->get(eidx.getSegmentId())) {
@@ -60,5 +65,22 @@ void CameraServer::thread() {
     } else {
       std::cout << "camera[" << type << "] failed to get frame:" << eidx.getSegmentId() << std::endl;
     }
+
+    --publishing_;
   }
+}
+
+void CameraServer::pushFrame(CameraType type, FrameReader *fr, const cereal::EncodeIndex::Reader &eidx) {
+  auto &cam = cameras_[type];
+  if (cam.width != fr->width || cam.height != fr->height) {
+    cam.width = fr->width;
+    cam.height = fr->height;
+    std::cout << "camera[" << type << "] frame size " << cam.width << "x" << cam.height << std::endl;
+    // wait until all cameras have finished publishing before restart vipc server.
+    waitFinish();
+    startVipcServer();
+  }
+
+  ++publishing_;
+  cam.queue.push({fr, eidx});
 }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -28,8 +28,11 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
   if (sm == nullptr) {
     pm = new PubMaster(s);
   }
+
   route_ = std::make_unique<Route>(route, data_dir);
   events_ = new std::vector<Event *>();
+  camera_server_ = std::make_unique<CameraServer>();
+
   // doSeek & queueSegment are always executed in the same thread
   connect(this, &Replay::seekTo, this, &Replay::doSeek);
   connect(this, &Replay::segmentChanged, this, &Replay::queueSegment);
@@ -75,7 +78,6 @@ bool Replay::load() {
 void Replay::start(int seconds) {
   seekTo(seconds, false);
 
-  camera_server_ = std::make_unique<CameraServer>();
   // start stream thread
   stream_thread_ = new QThread(this);
   QObject::connect(stream_thread_, &QThread::started, [=]() { stream(); });

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -30,6 +30,7 @@ protected slots:
 
 protected:
   typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;
+  void initStream(const Segment *segment);
   void stream();
   void setCurrentSegment(int n);
   void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);


### PR DESCRIPTION
1. ~Initialize all cameras from framereaders  before  streaming.~ moved to #22575
2. publish each camera in a separate thread to improve the stability of frame rate.
