### PR TITLE
replay: start streaming after segment loaded

### DIFF
--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -15,6 +15,13 @@ CameraServer::~CameraServer() {
   vipc_server_.reset(nullptr);
 }
 
+void CameraServer::start(std::pair<int, int> cameras[MAX_CAMERAS]) {
+  for (auto type : ALL_CAMERAS) {
+    std::tie(cameras_[type].width, cameras_[type].height) = cameras[type];
+  }
+  startVipcServer();
+}
+
 void CameraServer::startVipcServer() {
   std::cout << (vipc_server_ ? "restart" : "start") << " vipc server" << std::endl;
   vipc_server_.reset(new VisionIpcServer("camerad"));
@@ -33,7 +40,7 @@ void CameraServer::thread() {
     if (!fr) break;
 
     auto &cam = cameras_[type];
-    // start|restart the vipc server if frame size changed
+    // restart the vipc server if frame size changed
     if (cam.width != fr->width || cam.height != fr->height) {
       cam.width = fr->width;
       cam.height = fr->height;

--- a/selfdrive/ui/replay/camera.cc
+++ b/selfdrive/ui/replay/camera.cc
@@ -6,13 +6,13 @@
 const int YUV_BUF_COUNT = 50;
 
 CameraServer::CameraServer(std::pair<int, int> cameras[MAX_CAMERAS]) {
-  camera_thread_ = std::thread(&CameraServer::thread, this);
   if (cameras) {
     for (auto type : ALL_CAMERAS) {
       std::tie(cameras_[type].width, cameras_[type].height) = cameras[type];
     }
     startVipcServer();
   }
+  camera_thread_ = std::thread(&CameraServer::thread, this);
 }
 
 CameraServer::~CameraServer() {

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -8,9 +8,8 @@
 
 class CameraServer {
 public:
-  CameraServer();
+  CameraServer(std::pair<int, int> cameras[MAX_CAMERAS] = nullptr);
   ~CameraServer();
-  void start(std::pair<int, int> cameras[MAX_CAMERAS]);
   void pushFrame(CameraType type, FrameReader* fr, const cereal::EncodeIndex::Reader& eidx);
   inline void waitFinish() {
     while (publishing_ > 0) usleep(0);

--- a/selfdrive/ui/replay/camera.h
+++ b/selfdrive/ui/replay/camera.h
@@ -10,6 +10,7 @@ class CameraServer {
 public:
   CameraServer();
   ~CameraServer();
+  void start(std::pair<int, int> cameras[MAX_CAMERAS]);
   void pushFrame(CameraType type, FrameReader* fr, const cereal::EncodeIndex::Reader& eidx);
   inline void waitFinish() {
     while (publishing_ > 0) usleep(0);

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -320,8 +320,12 @@ void Replay::stream() {
         }
       }
     }
-
     // wait for frame to be sent before unlock.(frameReader may be deleted after unlock)
     camera_server_->waitFinish();
+
+    if (eit == events_->end() && (current_segment_ == segments_.rbegin()->first)) {
+      qInfo() << "reaches the end of route, restart from beginning";
+      emit seekTo(0, false);
+    }
   }
 }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -137,18 +137,19 @@ void Replay::queueSegment() {
     ++end;
   }
 
-  // load segments
-  for (auto it = begin; it != end; ++it) {
+  // merge segments
+  std::vector<int> merge_segments;
+  for (auto it = begin, prev = segments_.end(); it != end; prev = it, ++it) {
     auto &[n, seg] = *it;
     if (!seg) {
       seg = std::make_unique<Segment>(n, route_->at(n), load_dcam, load_ecam);
       QObject::connect(seg.get(), &Segment::loadFinished, this, &Replay::segmentLoadFinished);
       qInfo() << "loading segment" << n << "...";
+    } else if (seg->isLoaded() && (prev == segments_.end() || prev->second->isLoaded())) {
+      merge_segments.push_back(n);
     }
   }
-
-  // merge segments
-  mergeSegments(begin, end);
+  mergeSegments(merge_segments);
 
   // free segments out of current semgnt window.
   for (auto it = segments_.begin(); it != begin; ++it) {
@@ -158,26 +159,18 @@ void Replay::queueSegment() {
     it->second.reset(nullptr);
   }
 
-  // start stream thread
   if (stream_thread_ == nullptr && cur != segments_.end() && cur->second->isLoaded()) {
     startStream(cur->second.get());
   }
 }
 
-void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end) {
-  // segments must be merged in sequence.
-  std::vector<int> segments_need_merge;
-  for (auto it = begin; it != end && it->second->isLoaded(); ++it) {
-    segments_need_merge.push_back(it->first);
-  }
-
-  if (segments_need_merge != segments_merged_) {
-    qDebug() << "merge segments" << segments_need_merge;
-    // merge & sort events
+void Replay::mergeSegments(const std::vector<int> &merge_segments) {
+  if (merge_segments != segments_merged_) {
+    qDebug() << "merge segments" << merge_segments;
     std::vector<Event *> *new_events = new std::vector<Event *>();
-    new_events->reserve(std::accumulate(segments_need_merge.begin(), segments_need_merge.end(), 0,
+    new_events->reserve(std::accumulate(merge_segments.begin(), merge_segments.end(), 0,
                                         [=](int v, int n) { return v + segments_[n]->log->events.size(); }));
-    for (int n : segments_need_merge) {
+    for (int n : merge_segments) {
       auto &e = segments_[n]->log->events;
       auto middle = new_events->insert(new_events->end(), e.begin(), e.end());
       std::inplace_merge(new_events->begin(), middle, new_events->end(), Event::lessThan());
@@ -186,7 +179,7 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
     auto prev_events = events_;
     updateEvents([&]() {
       events_ = new_events;
-      segments_merged_ = segments_need_merge;
+      segments_merged_ = merge_segments;
       return true;
     });
     delete prev_events;

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -175,7 +175,7 @@ void Replay::mergeSegments(const std::vector<int> &merge_segments) {
       auto middle = new_events->insert(new_events->end(), e.begin(), e.end());
       std::inplace_merge(new_events->begin(), middle, new_events->end(), Event::lessThan());
     }
-    // update events
+
     auto prev_events = events_;
     updateEvents([&]() {
       events_ = new_events;
@@ -212,8 +212,7 @@ void Replay::startStream(const Segment *cur_segment) {
       cameras[type] = {fr->width, fr->height};
     }
   }
-  camera_server_ = std::make_unique<CameraServer>();
-  camera_server_->start(cameras);
+  camera_server_ = std::make_unique<CameraServer>(cameras);
 
   // start stream thread
   stream_thread_ = QThread::create(&Replay::stream, this);

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -216,6 +216,7 @@ void Replay::startStream(const Segment *cur_segment) {
 
   // start stream thread
   stream_thread_ = QThread::create(&Replay::stream, this);
+  QObject::connect(stream_thread_, &QThread::finished, stream_thread_, &QThread::deleteLater);
   stream_thread_->start();
 }
 

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -159,6 +159,7 @@ void Replay::queueSegment() {
     it->second.reset(nullptr);
   }
 
+  // start streaming
   if (stream_thread_ == nullptr && cur != segments_.end() && cur->second->isLoaded()) {
     startStream(cur->second.get());
   }

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -34,7 +34,7 @@ protected:
   void startStream(const Segment *cur_segment);
   void stream();
   void setCurrentSegment(int n);
-  void mergeSegments(const std::vector<int> &merge_segments);
+  void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);
   void updateEvents(const std::function<bool()>& lambda);
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -39,7 +39,9 @@ protected:
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);
   inline int currentSeconds() const { return (cur_mono_time_ - route_start_ts_) / 1e9; }
-  inline bool isSegmentLoaded(int n);
+  inline bool isSegmentLoaded(int n) {
+    return std::find(segments_merged_.begin(), segments_merged_.end(), n) != segments_merged_.end();
+  }
 
   QThread *stream_thread_ = nullptr;
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -34,7 +34,7 @@ protected:
   void startStream(const Segment *cur_segment);
   void stream();
   void setCurrentSegment(int n);
-  void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);
+  void mergeSegments(const std::vector<int> &merge_segments);
   void updateEvents(const std::function<bool()>& lambda);
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -39,6 +39,7 @@ protected:
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);
   inline int currentSeconds() const { return (cur_mono_time_ - route_start_ts_) / 1e9; }
+  inline bool isSegmentLoaded(int n);
 
   QThread *stream_thread_ = nullptr;
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -31,6 +31,7 @@ protected slots:
 
 protected:
   typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;
+  void startStream(const Segment *cur_segment);
   void stream();
   void setCurrentSegment(int n);
   void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -74,7 +74,6 @@ public:
 void TestReplay::testSeekTo(int seek_to) {
   seekTo(seek_to, false);
 
-  // wait for the seek to finish
   while (true) {
     std::unique_lock lk(stream_lock_);
     stream_cv_.wait(lk, [=]() { return events_updated_ == true; });
@@ -108,14 +107,12 @@ void TestReplay::testSeekTo(int seek_to) {
 void TestReplay::test_seek() {
   // create a dummy stream thread
   stream_thread_ = new QThread(this);
-
   QEventLoop loop;
   std::thread thread = std::thread([&]() {
-    // random seek 50 times in 3 segments
     for (int i = 0; i < 50; ++i) {
       testSeekTo(random_int(0, 3 * 60));
     }
-    // random seek 50 times in routes with invalid segments
+    // remove 3 segments
     for (int n : {5, 6, 8}) {
       segments_.erase(n);
     }

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -106,8 +106,8 @@ void TestReplay::testSeekTo(int seek_to) {
 }
 
 void TestReplay::test_seek() {
-  // create a dummy stream thread
-  stream_thread_ = new QThread(this);
+  // pause streaming while testing seek
+  pause(true);
 
   QEventLoop loop;
   std::thread thread = std::thread([&]() {

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -106,8 +106,8 @@ void TestReplay::testSeekTo(int seek_to) {
 }
 
 void TestReplay::test_seek() {
-  // pause streaming while testing seek
-  pause(true);
+  // create a dummy stream thread
+  stream_thread_ = new QThread(this);
 
   QEventLoop loop;
   std::thread thread = std::thread([&]() {


### PR DESCRIPTION
- [x]  start streaming after segment loaded
- [x]  write CarParams before  streaming (resolve #22429)
- [x]  start vipc server  before  streaming, to avoid  restarting it multiple time. ( that may lead to a vipc client crash on connect, e.g. `ui/watch3`
- [x] loop from beginning if reaches the end 