### PR TITLE
add missing header file

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include <QDebug>
+#include <QPainterPath>
 
 #include "selfdrive/common/swaglog.h"
 #include "selfdrive/ui/ui.h"


### PR DESCRIPTION

**Description**
FIxes a compiling problem on Ubuntu 21 caused by QPainterPath definition not being available. 
