### PR TITLE
replay: fix hangling on shutdown while downloading.

### DIFF
--- a/selfdrive/ui/replay/route.h
+++ b/selfdrive/ui/replay/route.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QDir>
-#include <QFutureSynchronizer>
+#include <QThread>
 
 #include "selfdrive/common/util.h"
 #include "selfdrive/ui/replay/framereader.h"
@@ -57,5 +57,5 @@ protected:
 
   std::atomic<bool> success_ = true, aborting_ = false;
   std::atomic<int> loading_ = 0;
-  QFutureSynchronizer<void> synchronizer_;
+  std::list<QThread*> loading_threads_;
 };


### PR DESCRIPTION
QFuture/QtConcurrent will block the qApp->exit() until it finishes executing. `aborting_ = true` in` Segment::~Segment() `will not be called before downloading finished.