### PR TITLE
Hyundai: Add Hyundai Ioniq Hybrid 2017-2019 to CARS.md

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -101,6 +101,7 @@ Community Maintained Cars and Features
 | Hyundai   | Genesis 2015-16               | SCC + LKAS        | Stock            | 19mph              | 37mph        |
 | Hyundai   | Ioniq Electric 2019           | SCC + LKAS        | Stock            | 0mph               | 32mph        |
 | Hyundai   | Ioniq Electric 2020           | SCC + LKAS        | Stock            | 0mph               | 0mph         |
+| Hyundai   | Ioniq Hybrid 2017-2019        | SCC + LKAS        | Stock            | 0mph               | 32mph        |
 | Hyundai   | Ioniq PHEV 2020-21            | SCC + LKAS        | Stock            | 0mph               | 0mph         |
 | Hyundai   | Kona 2020                     | SCC + LKAS        | Stock            | 0mph               | 0mph         |
 | Hyundai   | Kona EV 2018-19               | SCC + LKAS        | Stock            | 0mph               | 0mph         |

--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -101,7 +101,7 @@ Community Maintained Cars and Features
 | Hyundai   | Genesis 2015-16               | SCC + LKAS        | Stock            | 19mph              | 37mph        |
 | Hyundai   | Ioniq Electric 2019           | SCC + LKAS        | Stock            | 0mph               | 32mph        |
 | Hyundai   | Ioniq Electric 2020           | SCC + LKAS        | Stock            | 0mph               | 0mph         |
-| Hyundai   | Ioniq Hybrid 2017-2019        | SCC + LKAS        | Stock            | 0mph               | 32mph        |
+| Hyundai   | Ioniq Hybrid 2017-19          | SCC + LKAS        | Stock            | 0mph               | 32mph        |
 | Hyundai   | Ioniq PHEV 2020-21            | SCC + LKAS        | Stock            | 0mph               | 0mph         |
 | Hyundai   | Kona 2020                     | SCC + LKAS        | Stock            | 0mph               | 0mph         |
 | Hyundai   | Kona EV 2018-19               | SCC + LKAS        | Stock            | 0mph               | 0mph         |


### PR DESCRIPTION
Add 2017-2019 Hyundai Ioniq Hybrid to CARS.md since it is currently supported.