### PR TITLE
Mazda: Fix OP steer warning in cars with lockout

### DIFF
--- a/selfdrive/car/mazda/carstate.py
+++ b/selfdrive/car/mazda/carstate.py
@@ -78,8 +78,9 @@ class CarState(CarStateBase):
         self.low_speed_lockout = False
         self.low_speed_alert = False
 
-    # Check if LKAS is disabled due to lack of driver torque
-    ret.steerWarning = (cp.vl["STEER_RATE"]["HANDS_OFF_5_SECONDS"] == 1) and (cp.vl["STEER_RATE"]["LKAS_BLOCK"] == 1)
+    # Check if LKAS is disabled due to lack of driver torque when all other states indicate
+    # it should be enabled (steer lockout)
+    ret.steerWarning = self.lkas_allowed and (cp.vl["STEER_RATE"]["LKAS_BLOCK"] == 1)
 
     self.acc_active_last = ret.cruiseState.enabled
 


### PR DESCRIPTION
It turned out cars with lockout don't have LKAS_BLOCK at the same time when HANDS_OFF signal is set. Once LKAS_BLOCK is set the other is unset causing OP warning to not show. Restore the old logic, but limit it to cars with lockout since it is only applicable to those, and it causes disengage in cars without lockout.
  
Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>