### PR TITLE
Honda Bosch longitudinal: show AEB disabled status on HUD

### DIFF
--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -115,6 +115,7 @@ def create_ui_commands(packer, pcm_speed, hud, car_fingerprint, is_metric, idx, 
         'ACC_ON': hud.car != 0,
         'SET_TO_X1': 1,
         'IMPERIAL_UNIT': int(not is_metric),
+        'FCM_OFF': 1,
       }
     else:
       acc_hud_values = {

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -145,7 +145,8 @@ def create_ui_commands(packer, pcm_speed, hud, car_fingerprint, is_metric, idx, 
 
   if radar_disabled and car_fingerprint in HONDA_BOSCH:
     radar_hud_values = {
-      'SET_TO_1' : 0x01,
+      'CMBS_OFF': 0x01,
+      'SET_TO_1': 0x01,
     }
     commands.append(packer.make_can_msg('RADAR_HUD', bus_pt, radar_hud_values, idx))
 


### PR DESCRIPTION
resolves #22602 

It might be possible to turn the car amber, but it seems like the stock system only does that when something is actually broken, not when the user turns it off. However, with the stock system AEB will always be turned on after power cycle.

![Image from iOS (2)](https://user-images.githubusercontent.com/1314752/137921412-66cfae98-138f-4c24-a524-d1cd40a30c6d.jpg)
![Image from iOS (1)](https://user-images.githubusercontent.com/1314752/137921406-095aa8fc-dfe4-4808-b346-9c0f4f26f40d.jpg)



Before this PR:
![IMG_3853](https://user-images.githubusercontent.com/1314752/137922971-d8f659c5-748b-48b1-9dab-82d9dc4502ca.jpg)

