### PR TITLE
fix replay did not restart from beginning if the last segment has a full 60 seconds data.

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -324,9 +324,12 @@ void Replay::stream() {
     // wait for frame to be sent before unlock.(frameReader may be deleted after unlock)
     camera_server_->waitFinish();
 
-    if (eit == events_->end() && (current_segment_ == segments_.rbegin()->first) && isSegmentLoaded(current_segment_)) {
-      qInfo() << "reaches the end of route, restart from beginning";
-      emit seekTo(0, false);
+    if (eit == events_->end()) {
+      int last_segment = segments_.rbegin()->first;
+      if (current_segment_ >= last_segment && isSegmentLoaded(last_segment)) {
+        qInfo() << "reaches the end of route, restart from beginning";
+        emit seekTo(0, false);
+      }
     }
   }
 }


### PR DESCRIPTION
if the last segment has a full 60 seconds data, the current_segment_ will greater than the last segment number. 