### PR TITLE
locationd: Gyro bias initial covariance

### DIFF
--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -331,8 +331,8 @@ void Localizer::handle_cam_odo(double current_time, const cereal::CameraOdometry
   this->posenet_stds.push_back(trans_calib_std[0]);
 
   // Multiply by 10 to avoid to high certainty in kalman filter because of temporally correlated noise
-  trans_calib_std *= 10.0;
-  rot_calib_std *= 10.0;
+  trans_calib_std *= 5.0;
+  rot_calib_std *= 5.0;
   MatrixXdr rot_device_cov = rotate_std(this->device_from_calib, rot_calib_std).array().square().matrix().asDiagonal();
   MatrixXdr trans_device_cov = rotate_std(this->device_from_calib, trans_calib_std).array().square().matrix().asDiagonal();
   

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -331,8 +331,8 @@ void Localizer::handle_cam_odo(double current_time, const cereal::CameraOdometry
   this->posenet_stds.push_back(trans_calib_std[0]);
 
   // Multiply by 10 to avoid to high certainty in kalman filter because of temporally correlated noise
-  trans_calib_std *= 5.0;
-  rot_calib_std *= 5.0;
+  trans_calib_std *= 10.0;
+  rot_calib_std *= 10.0;
   MatrixXdr rot_device_cov = rotate_std(this->device_from_calib, rot_calib_std).array().square().matrix().asDiagonal();
   MatrixXdr trans_device_cov = rotate_std(this->device_from_calib, trans_calib_std).array().square().matrix().asDiagonal();
   

--- a/selfdrive/locationd/models/live_kf.py
+++ b/selfdrive/locationd/models/live_kf.py
@@ -74,7 +74,7 @@ class LiveKalman():
                      (0.05 / 60)**2, (0.05 / 60)**2, (0.05 / 60)**2])
 
   obs_noise_diag = {ObservationKind.ODOMETRIC_SPEED: np.array([0.2**2]),
-                    ObservationKind.PHONE_GYRO: np.array([0.025**2, 0.025**2, 0.025**2]),
+                    ObservationKind.PHONE_GYRO: np.array([0.05**2, 0.05**2, 0.05**2]),
                     ObservationKind.PHONE_ACCEL: np.array([.5**2, .5**2, .5**2]),
                     ObservationKind.CAMERA_ODO_ROTATION: np.array([0.05**2, 0.05**2, 0.05**2]),
                     ObservationKind.IMU_FRAME: np.array([0.05**2, 0.05**2, 0.05**2]),

--- a/selfdrive/locationd/models/live_kf.py
+++ b/selfdrive/locationd/models/live_kf.py
@@ -58,7 +58,7 @@ class LiveKalman():
                              10**2, 10**2, 10**2,
                              10**2, 10**2, 10**2,
                              1**2, 1**2, 1**2,
-                             0.05**2, 0.05**2, 0.05**2,
+                             1**2, 1**2, 1**2,
                              0.02**2,
                              1**2, 1**2, 1**2,
                              (0.01)**2, (0.01)**2, (0.01)**2])
@@ -74,7 +74,7 @@ class LiveKalman():
                      (0.05 / 60)**2, (0.05 / 60)**2, (0.05 / 60)**2])
 
   obs_noise_diag = {ObservationKind.ODOMETRIC_SPEED: np.array([0.2**2]),
-                    ObservationKind.PHONE_GYRO: np.array([0.05**2, 0.05**2, 0.05**2]),
+                    ObservationKind.PHONE_GYRO: np.array([0.025**2, 0.025**2, 0.025**2]),
                     ObservationKind.PHONE_ACCEL: np.array([.5**2, .5**2, .5**2]),
                     ObservationKind.CAMERA_ODO_ROTATION: np.array([0.05**2, 0.05**2, 0.05**2]),
                     ObservationKind.IMU_FRAME: np.array([0.05**2, 0.05**2, 0.05**2]),


### PR DESCRIPTION
Problem : At the beginning of the route in this [issue](https://github.com/commaai/openpilot/issues/22417), the gyro bias was incorrect, leading to incorrect fast angle offset values being learnt and the car drifting towards the right side of the lane. The reason for this was the low value of the initial covariance for gyro bias. 

Fix : Using a larger initial covariance for gyro bias, the gyro bias is learnt better, while everything else being the same (this is reflected in the lld_Report).

![image](https://user-images.githubusercontent.com/1649262/137986614-d717aa7a-d862-420e-bbc1-342cd3176094.png)
