### PR TITLE
replay: improve seeking, queuing segments

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -91,16 +91,15 @@ void Replay::doSeek(int seconds, bool relative) {
     if (relative) {
       seconds += currentSeconds();
     }
-    uint64_t mono_time = route_start_ts_ + seconds * 1e9;
     int seg = seconds / 60;
     if (segments_.find(seg) == segments_.end()) {
-      qInfo() << "can't seek to" << seconds << ", segment" << seg << "is invalid";
+      qInfo() << "can't seek to" << seconds << "s, segment" << seg << "is invalid";
       return true;
     }
 
-    qInfo() << "seeking to" << seconds << "s, segment:" << seg;
-    cur_mono_time_ = mono_time;
+    qInfo() << "seeking to" << seconds << "s, segment" << seg;
     current_segment_ = seg;
+    cur_mono_time_ = route_start_ts_ + seconds * 1e9;
     return segments_[seg] && segments_[seg]->isLoaded();
   });
   queueSegment();

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -100,7 +100,7 @@ void Replay::doSeek(int seconds, bool relative) {
     qInfo() << "seeking to" << seconds << "s, segment" << seg;
     current_segment_ = seg;
     cur_mono_time_ = route_start_ts_ + seconds * 1e9;
-    return segments_[seg] && segments_[seg]->isLoaded();
+    return isSegmentLoaded(seg);
   });
   queueSegment();
 }

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -38,7 +38,7 @@ protected:
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);
   inline int currentSeconds() const { return (cur_mono_time_ - route_start_ts_) / 1e9; }
-  inline bool isSegmentLoaded(int n) {
+  inline bool isSegmentMerged(int n) {
     return std::find(segments_merged_.begin(), segments_merged_.end(), n) != segments_merged_.end();
   }
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -6,7 +6,6 @@
 #include "selfdrive/ui/replay/route.h"
 
 constexpr int FORWARD_SEGS = 2;
-constexpr int BACKWARD_SEGS = 1;
 
 class Replay : public QObject {
   Q_OBJECT

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -48,7 +48,7 @@ protected:
   std::mutex stream_lock_;
   std::condition_variable stream_cv_;
   std::atomic<bool> updating_events_ = false;
-  std::atomic<int> current_segment_ = -1;
+  std::atomic<int> current_segment_ = 0;
   SegmentMap segments_;
   // the following variables must be protected with stream_lock_
   bool exit_ = false;

--- a/selfdrive/ui/replay/tests/test_replay.cc
+++ b/selfdrive/ui/replay/tests/test_replay.cc
@@ -112,15 +112,8 @@ void TestReplay::test_seek() {
   stream_thread_ = new QThread(this);
   QEventLoop loop;
   std::thread thread = std::thread([&]() {
-    for (int i = 0; i < 50; ++i) {
-      testSeekTo(random_int(0, 3 * 60));
-    }
-    // remove 3 segments
-    for (int n : {5, 6, 8}) {
-      segments_.erase(n);
-    }
-    for (int i =0; i < 50; ++i) {
-      testSeekTo(random_int(4 * 60, 9 * 60));
+    for (int i = 0; i < 100; ++i) {
+      testSeekTo(random_int(0, 5 * 60));
     }
     loop.quit();
   });


### PR DESCRIPTION
improve seeking:
1. check if segments_.empty() to prevent the crash when all segments are failed to load and removed from this->segments_.
2. print error and return if seeking to an invalid segment.
3. return true to wake up the stream thread immediately if segment is already loaded.

improve seeking:

1. check if segments_.empty(), simplify code
2. only merge the previous adjacent segment if it is already loaded. (If the previous one is not adjacent, or is seeking to a new segment, merge the previous one is just a waste of time.)
