### PR TITLE
Car HUD Enhancement: Prevent Lane Lines From Flickering at Low Speed

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -563,8 +563,8 @@ class Controls:
     CC.hudControl.lanesVisible = self.enabled
     CC.hudControl.leadVisible = self.sm['longitudinalPlan'].hasLead
 
-    right_lane_visible = self.sm['lateralPlan'].rProb > 0.5
-    left_lane_visible = self.sm['lateralPlan'].lProb > 0.5
+    right_lane_visible = self.sm['lateralPlan'].rProb > 0.5 or CS.vEgo < LDW_MIN_SPEED
+    left_lane_visible = self.sm['lateralPlan'].lProb > 0.5 or CS.vEgo < LDW_MIN_SPEED
     CC.hudControl.rightLaneVisible = bool(right_lane_visible)
     CC.hudControl.leftLaneVisible = bool(left_lane_visible)
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -563,8 +563,8 @@ class Controls:
     CC.hudControl.lanesVisible = self.enabled
     CC.hudControl.leadVisible = self.sm['longitudinalPlan'].hasLead
 
-    right_lane_visible = self.sm['lateralPlan'].rProb > 0.5 or CS.vEgo < LDW_MIN_SPEED
-    left_lane_visible = self.sm['lateralPlan'].lProb > 0.5 or CS.vEgo < LDW_MIN_SPEED
+    right_lane_visible = self.sm['lateralPlan'].rProb > 0.5 and CS.vEgo > LDW_MIN_SPEED
+    left_lane_visible = self.sm['lateralPlan'].lProb > 0.5 and CS.vEgo > LDW_MIN_SPEED
     CC.hudControl.rightLaneVisible = bool(right_lane_visible)
     CC.hudControl.leftLaneVisible = bool(left_lane_visible)
 


### PR DESCRIPTION
**Description**
Keep `left_lane_visible` and `right_lane_visible` off at low speeds (below `LDW_MIN_SPEED`).

This prevents lane line indicators from turning on/off constantly on vehicle's HUD when a front car is blocking the view of openpilot.

Most stock LDW systems do this as well. 

Toyota vehicles also put out a warning like this to remind drivers.
![image](https://user-images.githubusercontent.com/12470297/138188269-0822b683-a781-4765-a7e0-028146e5fa1f.png)
