### PR TITLE
Honda: improved RDX tuning

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -219,7 +219,7 @@ class CarInterface(CarInterfaceBase):
       ret.centerToFront = ret.wheelbase * 0.41
       ret.steerRatio = 11.95  # as spec
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 3840], [0, 3840]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.18]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.06]]
       tire_stiffness_factor = 0.677
 
     elif candidate == CAR.ODYSSEY:


### PR DESCRIPTION
---
name: Tuning
about: For openpilot tuning changes
title: ‘Fix steering oscillations in 2019 RDX’
labels: 'tuning'
assignees: ''
---

**Description**

2019 RDX steering wheel oscillations when driving a straight line at almost any speed. Oscillations were pretty bad, the steering wheel cycled more than once every second. After this fix the steering is smooth and no cycles.

**Verification**

We ran the tests for lateral, the before route is 6dce577e927e86b3 and the after is 6dce577e927e86b3.

I wasn’t able to get PlotJuggler to work, I get an error

```
./install.sh
./juggle.py 6dce577e927e86b3 --layout layouts/tuning.xml

ModuleNotFoundError: No module named 'common'
```


I’m running python 3 on a mac and not sure where `common` is supposed to come from or if I missed an install step.


