### PR TITLE
Quiet steer temp unavailable alert at standstill

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -144,10 +144,10 @@ class CarInterfaceBase():
     elif cs_out.steerWarning:
       # only escalate to the harsher alert after the condition has
       # persisted for 0.5s and we're certain that the user isn't overriding
-      if self.steering_unpressed > int(0.5/DT_CTRL) and self.steer_warning > int(0.5/DT_CTRL):
-        events.add(EventName.steerTempUnavailable)
-      elif not cs_out.standstill:
+      if self.steering_unpressed < int(0.5 / DT_CTRL) or self.steer_warning < int(0.5 / DT_CTRL):
         events.add(EventName.steerTempUnavailableSilent)
+      elif not cs_out.standstill:
+        events.add(EventName.steerTempUnavailable)
 
     # Disable on rising edge of gas or brake. Also disable on brake when speed > 0.
     # Optionally allow to press gas at zero speed to resume.

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -144,10 +144,11 @@ class CarInterfaceBase():
     elif cs_out.steerWarning:
       # only escalate to the harsher alert after the condition has
       # persisted for 0.5s and we're certain that the user isn't overriding
-      if self.steering_unpressed < int(0.5 / DT_CTRL) or self.steer_warning < int(0.5 / DT_CTRL):
-        events.add(EventName.steerTempUnavailableSilent)
-      elif not cs_out.standstill:
+      if not cs_out.standstill and self.steering_unpressed > int(0.5 / DT_CTRL) and \
+         self.steer_warning > int(0.5 / DT_CTRL):
         events.add(EventName.steerTempUnavailable)
+      else:
+        events.add(EventName.steerTempUnavailableSilent)
 
     # Disable on rising edge of gas or brake. Also disable on brake when speed > 0.
     # Optionally allow to press gas at zero speed to resume.

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -146,7 +146,7 @@ class CarInterfaceBase():
       # persisted for 0.5s and we're certain that the user isn't overriding
       if self.steering_unpressed > int(0.5/DT_CTRL) and self.steer_warning > int(0.5/DT_CTRL):
         events.add(EventName.steerTempUnavailable)
-      else:
+      elif not cs_out.standstill:
         events.add(EventName.steerTempUnavailableSilent)
 
     # Disable on rising edge of gas or brake. Also disable on brake when speed > 0.


### PR DESCRIPTION
When adjusting the wheel at low speeds or at a standstill, the red critical alert is almost always sure to go off just because of the high angle rates you can achieve at low speeds easily. The orange userPrompt alert should probably be enough at a standstill, debatable at low speeds (under 5-10 mph).