### PR TITLE
VW MQB: Cleanup Audi list order and packages

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -79,10 +79,10 @@ Community Maintained Cars and Features
 
 | Make      | Model (US Market Reference)   | Supported Package | ACC              | No ACC accel below | No ALC below |
 | ----------| ------------------------------| ------------------| -----------------| -------------------| -------------|
-| Audi      | A3 2014-19                    | Prestige          | Stock            | 0mph               | 0mph         |
-| Audi      | A3 Sportback e-tron 2017-18   | Prestige          | Stock            | 0mph               | 0mph         |
-| Audi      | S3 2015                       | Prestige          | Stock            | 0mph               | 0mph         |
-| Audi      | Q2 2018                       | Driver Assistance | Stock            | 0mph               | 0mph         |
+| Audi      | A3 2014-19                    | ACC + Lane Assist | Stock            | 0mph               | 0mph         |
+| Audi      | A3 Sportback e-tron 2017-18   | ACC + Lane Assist | Stock            | 0mph               | 0mph         |
+| Audi      | Q2 2018                       | ACC + Lane Assist | Stock            | 0mph               | 0mph         |
+| Audi      | S3 2015                       | ACC + Lane Assist | Stock            | 0mph               | 0mph         |
 | Buick     | Regal 2018<sup>1</sup>        | Adaptive Cruise   | openpilot        | 0mph               | 7mph         |
 | Cadillac  | ATS 2018<sup>1</sup>          | Adaptive Cruise   | openpilot        | 0mph               | 7mph         |
 | Chevrolet | Malibu 2017<sup>1</sup>       | Adaptive Cruise   | openpilot        | 0mph               | 7mph         |


### PR DESCRIPTION
Minor cleanup to CARS:

* Show ACC + Lane Assist as the supported package for all Audi. The actual package can vary per-model, per-world-region, with ACC and LKAS optional under some lower packages and standard with higher packages, and there are differences in packaging and options for the same car between different model-years. It's too complex to deal with and it's not necessary. End users just need to check for ACC and Active Lane Assist.
* Fix my alphabetization error when I added S3.
