### PR TITLE
add missing base package for WSL2 (ubuntu 20)

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -67,7 +67,8 @@ function install_ubuntu_common_requirements() {
     libqt5sql5-sqlite \
     libqt5svg5-dev \
     libqt5x11extras5-dev \
-    libreadline-dev
+    libreadline-dev \
+    libdw1
 }
 
 # Install Ubuntu 21.10 packages


### PR DESCRIPTION
**Description** 

cannot run plotjuggler in WSL2.

**Verification** 

before:
```
lafcadio@DEADBEEF:~/openpilot/tools/plotjuggler$ ./juggle.py "https://commadataci.blob.core.windows.net/openpilotci/d83f36766f8012a5/2020-02-05--18-42-21/0/rlog.bz2" --layout=demo_layout.xml
Loading https://commadataci.blob.core.windows.net/openpilotci/d83f36766f8012a5/2020-02-05--18-42-21/0/rlog.bz2
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 53811/53811 [00:00<00:00, 441868.29it/s]
/home/lafcadio/openpilot/tools/plotjuggler/bin/plotjuggler: error while loading shared libraries: libdw.so.1: cannot open shared object file: No such file or directory
```

after:
```
lafcadio@DEADBEEF:~/openpilot/tools/plotjuggler$ ./juggle.py "https://commadataci.blob.core.windows.net/openpilotci/d83f36766f8012a5/2020-02-05--18-42-21/0/rlog.bz2" --layout=demo_layout.xml
Loading https://commadataci.blob.core.windows.net/openpilotci/d83f36766f8012a5/2020-02-05--18-42-21/0/rlog.bz2
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 53811/53811 [00:00<00:00, 439426.76it/s]
Loading compatible plugins from directory:  "/home/lafcadio/openpilot/tools/plotjuggler/bin"
"libDataLoadRlog.so" : is a DataLoader plugin
"libDataStreamCereal.so" : is a DataStreamer plugin
Number of plugins loaded:  2

Loading compatible plugins from directory:  "/home/lafcadio/.local/share/PlotJuggler"
Number of plugins loaded:  0

NVD3D10: CPU cyclestats are disabled on client virtualization
NVD3D10: CPU cyclestats are disabled on client virtualization
Done reading Rlog data
```

![image](https://user-images.githubusercontent.com/21319730/139110846-69452eab-cc31-435b-b3b7-16af0d877c3d.png)
