### PR TITLE
Fix Radar Parser Variable for Santa Fe

### DIFF
--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -40,7 +40,7 @@ SUPPORTED_FW_VERSIONS = {
   },
   # 2020 SANTA FE
   b"TM__ SCC F-CUP      1.00 1.03 99110-S2000\x19\x050\x13'    ": {
-    "default config": b"\x00\x00\x00\x01\x00\x00",
+    "default_config": b"\x00\x00\x00\x01\x00\x00",
     "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
   }
 }


### PR DESCRIPTION
Adding an underscore to the `default_config` variable for `2020 Santa Fe`, which would cause the script to error out with the missing underscore.