### PR TITLE
tools/setup: do not change global state

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -62,12 +62,11 @@ fi
 # install python
 PYENV_PYTHON_VERSION=$(cat $OP_ROOT/.python-version)
 pyenv install -s ${PYENV_PYTHON_VERSION}
-pyenv global ${PYENV_PYTHON_VERSION}
 pyenv rehash
 eval "$(pyenv init -)"
 
 pip install pipenv==2020.8.13
-pipenv install --system --deploy
+pipenv install --dev --deploy
 
 echo
 echo "----   FINISH OPENPILOT SETUP   ----"

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -136,14 +136,13 @@ git submodule update
 PYENV_PYTHON_VERSION=$(cat $OP_ROOT/.python-version)
 PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH
 pyenv install -s ${PYENV_PYTHON_VERSION}
-pyenv global ${PYENV_PYTHON_VERSION}
 pyenv rehash
 eval "$(pyenv init -)"
 
 # **** in python env ****
 pip install --upgrade pip==20.2.4
 pip install pipenv==2020.8.13
-pipenv install --dev --system --deploy
+pipenv install --dev --deploy
 
 echo
 echo "----   FINISH OPENPILOT SETUP   ----"

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -140,8 +140,8 @@ pyenv rehash
 eval "$(pyenv init -)"
 
 # **** in python env ****
-pip install --upgrade pip==20.2.4
-pip install pipenv==2020.8.13
+pip install --upgrade pip==21.3.1
+pip install pipenv==2021.5.29
 pipenv install --dev --deploy
 
 echo

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -140,7 +140,7 @@ pyenv rehash
 eval "$(pyenv init -)"
 
 # **** in python env ****
-pip install --upgrade pip==21.3.1
+pip install pip==21.3.1
 pip install pipenv==2021.5.29
 pipenv install --dev --deploy
 

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -28,7 +28,7 @@ if ! command -v pipenv &> /dev/null; then
 fi
 
 echo "update pip"
-pip install --upgrade pip==21.3.1
+pip install pip==21.3.1
 pip install pipenv==2021.5.29
 
 echo "pip packages install ..."

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -32,8 +32,12 @@ pip install --upgrade pip
 pip install pipenv
 
 echo "pip packages install ..."
-[ -d "./xx" ] && export PIPENV_PIPFILE=./xx/Pipfile
-pipenv install --dev --deploy
+if [ -d "./xx" ]; then
+    export PIPENV_PIPFILE=./xx/Pipfile
+    pipenv install --system --dev --deploy
+else
+    pipenv install --dev --deploy
+fi
 # update shims for newly installed executables (e.g. scons)
 pyenv rehash
 

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -48,5 +48,5 @@ echo "precommit install ..."
 $RUN pre-commit install
 
 # for internal comma repos
-[ -d "./xx" ] && (cd xx && pre-commit install)
-[ -d "./notebooks" ] && (cd notebooks && pre-commit install)
+[ -d "./xx" ] && (cd xx && $RUN pre-commit install)
+[ -d "./notebooks" ] && (cd notebooks && $RUN pre-commit install)

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -33,16 +33,19 @@ pip install pipenv==2021.5.29
 
 echo "pip packages install ..."
 if [ -d "./xx" ]; then
-    export PIPENV_PIPFILE=./xx/Pipfile
-    pipenv install --system --dev --deploy
+  export PIPENV_PIPFILE=./xx/Pipfile
+  pipenv install --system --dev --deploy
+  RUN=""
 else
-    pipenv install --dev --deploy
+  pipenv install --dev --deploy
+  RUN="pipenv run"
 fi
+
 # update shims for newly installed executables (e.g. scons)
 pyenv rehash
 
 echo "precommit install ..."
-pre-commit install
+$RUN pre-commit install
 
 # for internal comma repos
 [ -d "./xx" ] && (cd xx && pre-commit install)

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -28,8 +28,8 @@ if ! command -v pipenv &> /dev/null; then
 fi
 
 echo "update pip"
-pip install --upgrade pip
-pip install pipenv
+pip install --upgrade pip==21.3.1
+pip install pipenv==2021.5.29
 
 echo "pip packages install ..."
 if [ -d "./xx" ]; then

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -33,7 +33,7 @@ pip install pipenv
 
 echo "pip packages install ..."
 [ -d "./xx" ] && export PIPENV_PIPFILE=./xx/Pipfile
-pipenv install --dev --deploy --system
+pipenv install --dev --deploy
 # update shims for newly installed executables (e.g. scons)
 pyenv rehash
 


### PR DESCRIPTION
Fixes #22588. Docs already require developers to use `pipenv shell`, all that was left was removing `--system` from pipenv install and removing `pyenv global` in setup scripts. 