### PR TITLE
Allow to change the vel max ACC 5/5mph

### DIFF
--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -35,7 +35,7 @@ def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, acc_ty
     "ACC_TYPE": acc_type,
     "DISTANCE": 0,
     "MINI_CAR": lead,
-    "ALLOW_LONG_PRESS": 3,
+    "ALLOW_LONG_PRESS": 2,
     "PERMIT_BRAKING": 1,
     "RELEASE_STANDSTILL": not standstill_req,
     "CANCEL_REQ": pcm_cancel,


### PR DESCRIPTION
the value of ALLOW_LONG_PRESS needs to be 2 to maintain toyota's factory behavior:

Allow to change the vel max ACC 5/5mph (or 5/5kph) holding down
