### PR TITLE
soundd: Set volume on receiving carState

### DIFF
--- a/selfdrive/ui/soundd.cc
+++ b/selfdrive/ui/soundd.cc
@@ -63,6 +63,9 @@ private slots:
       // scale volume with speed
       volume = util::map_val((*sm)["carState"].getCarState().getVEgo(), 0.f, 20.f,
                              Hardware::MIN_VOLUME, Hardware::MAX_VOLUME);
+      for (auto &[s, loops] : sounds) {
+        s->setVolume(std::round(100 * volume) / 100);
+      }
     }
     if (sm->updated("controlsState")) {
       const cereal::ControlsState::Reader &cs = (*sm)["controlsState"].getControlsState();
@@ -91,7 +94,6 @@ private slots:
       if (alert.sound != AudibleAlert::NONE) {
         auto &[s, loops] = sounds[alert.sound];
         s->setLoopCount(loops);
-        s->setVolume(volume);
         s->play();
       }
     }


### PR DESCRIPTION
There is a delay to setVolume taking effect. If we call it only just before playing the sound, the first part of the sound will be played with the old volume.