### PR TITLE
ui: resizable on PC by mouse drag

### DIFF
--- a/selfdrive/hardware/hw.h
+++ b/selfdrive/hardware/hw.h
@@ -13,7 +13,7 @@
 class HardwarePC : public HardwareNone {
 public:
   static std::string get_os_version() { return "openpilot for PC"; }
-  static bool PC() { return true; }
+  static constexpr bool PC() { return true; }
   static bool TICI() { return util::getenv("TICI", 0) == 1; }
 };
 #define Hardware HardwarePC

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -52,8 +52,10 @@ void DriverViewScene::paintEvent(QPaintEvent* event) {
   if (!frame_updated) {
     p.setPen(Qt::white);
     p.setRenderHint(QPainter::TextAntialiasing);
-    configFont(p, "Inter", 100, "Bold");
-    p.drawText(geometry(), Qt::AlignCenter, "camera starting");
+    const QRect r(geometry());
+    const QString text("camera starting");
+    configFont(p, r, "Inter", 100, "Bold", text);
+    p.drawText(geometry(), Qt::AlignCenter, text);
     return;
   }
 

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -122,18 +122,60 @@ void OnroadAlerts::updateAlert(const Alert &a, const QColor &color) {
   }
 }
 
+struct Rects
+{
+  int x, y, w, h;     // bounding box for total text area
+  int x1, y1, w1, h1; // bounding box for alert text 1
+  int x2, y2, w2, h2; // bounding box for alert text 2
+
+  Rects()
+  {
+    memset(this, 0, sizeof(Rects));
+  }
+};
+
+template<typename T>
+void getRects(T t, Rects &r, Alert alert) {
+  // returns bounding boxes for text area, alert1, alert2
+  // w - width, h - height, windows starting position x, y
+
+  const int heightMax = 1080; // adjust to change text box scale
+  const int width = t->width();
+  const int height = t->height();
+
+  switch (alert.size) {
+    case cereal::ControlsState::AlertSize::SMALL:
+      r.h = height * (271.0 / heightMax);
+      break;
+    case cereal::ControlsState::AlertSize::MID:
+      r.h = height * (420.0 / heightMax);
+      break;
+    case cereal::ControlsState::AlertSize::FULL:
+      r.h = height;
+      break;
+    case cereal::ControlsState::AlertSize::NONE:
+      break;
+  }
+
+  r.w = width;
+  r.w1 = r.w;
+  r.w2 = r.w1;
+
+  r.h1 = r.h / 2.0;
+  r.h2 = r.h1;
+
+  r.y = height - r.h;
+  r.y1 = r.y;
+  r.y2 = r.y1 + r.h1;
+}
+
 void OnroadAlerts::paintEvent(QPaintEvent *event) {
   if (alert.size == cereal::ControlsState::AlertSize::NONE) {
     return;
   }
-  static std::map<cereal::ControlsState::AlertSize, const int> alert_sizes = {
-    {cereal::ControlsState::AlertSize::SMALL, 271},
-    {cereal::ControlsState::AlertSize::MID, 420},
-    {cereal::ControlsState::AlertSize::FULL, height()},
-  };
-  int h = alert_sizes[alert.size];
-  QRect r = QRect(0, height() - h, width(), h);
-
+  Rects R;
+  getRects(this, R, alert);
+  QRect r = QRect(R.x, R.y, R.w, R.h);
   QPainter p(this);
 
   // draw background + gradient
@@ -153,23 +195,28 @@ void OnroadAlerts::paintEvent(QPaintEvent *event) {
   p.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
   // text
-  const QPoint c = r.center();
   p.setPen(QColor(0xff, 0xff, 0xff));
   p.setRenderHint(QPainter::TextAntialiasing);
+
+  const QRect a1 = QRect(R.x1, R.y1, R.w1, R.h1);
+  const QRect a2 = QRect(R.x2, R.y2, R.w2, R.h2);
+
+  const int textBoxFlag = Qt::AlignCenter;
+
   if (alert.size == cereal::ControlsState::AlertSize::SMALL) {
-    configFont(p, "Open Sans", 74, "SemiBold");
-    p.drawText(r, Qt::AlignCenter, alert.text1);
+    configFont(p, r, "Open Sans", 74, "SemiBold", alert.text1);
+    p.drawText(r, textBoxFlag, alert.text1);
   } else if (alert.size == cereal::ControlsState::AlertSize::MID) {
-    configFont(p, "Open Sans", 88, "Bold");
-    p.drawText(QRect(0, c.y() - 125, width(), 150), Qt::AlignHCenter | Qt::AlignTop, alert.text1);
-    configFont(p, "Open Sans", 66, "Regular");
-    p.drawText(QRect(0, c.y() + 21, width(), 90), Qt::AlignHCenter, alert.text2);
+    configFont(p, a1, "Open Sans", 88, "Bold", alert.text1);
+    p.drawText(a1, textBoxFlag, alert.text1);
+    configFont(p, a2, "Open Sans", 66, "Regular", alert.text2);
+    p.drawText(a2, textBoxFlag, alert.text2);
   } else if (alert.size == cereal::ControlsState::AlertSize::FULL) {
     bool l = alert.text1.length() > 15;
-    configFont(p, "Open Sans", l ? 132 : 177, "Bold");
-    p.drawText(QRect(0, r.y() + (l ? 240 : 270), width(), 600), Qt::AlignHCenter | Qt::TextWordWrap, alert.text1);
-    configFont(p, "Open Sans", 88, "Regular");
-    p.drawText(QRect(0, r.height() - (l ? 361 : 420), width(), 300), Qt::AlignHCenter | Qt::TextWordWrap, alert.text2);
+    configFont(p, a1, "Open Sans", l ? 132 : 177, "Bold", alert.text1);
+    p.drawText(a1, textBoxFlag, alert.text1);
+    configFont(p, a2, "Open Sans", 88, "Regular", alert.text2);
+    p.drawText(a2, textBoxFlag, alert.text2);
   }
 }
 

--- a/selfdrive/ui/qt/qt_window.cc
+++ b/selfdrive/ui/qt/qt_window.cc
@@ -3,9 +3,14 @@
 void setMainWindow(QWidget *w) {
   const bool wide = (QGuiApplication::primaryScreen()->size().width() >= WIDE_WIDTH) ^
                     (getenv("INVERT_WIDTH") != NULL);
-  const float scale = util::getenv("SCALE", 1.0f);
+  if constexpr (Hardware::PC()) {
+    w->setMinimumSize(QSize(640, 480));
+    w->setMaximumSize(QSize(WIDE_WIDTH, 1080));
+    w->resize(QSize(1920, 1080));
+  } else {
+    w->setFixedSize(QSize(wide ? WIDE_WIDTH : 1920, 1080));
+  }
 
-  w->setFixedSize(QSize(wide ? WIDE_WIDTH : 1920, 1080) * scale);
   w->show();
 
 #ifdef QCOM2

--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -20,8 +20,8 @@ void Sidebar::drawMetric(QPainter &p, const QString &label, QColor c, int y) {
   p.drawRoundedRect(rect, 20, 20);
 
   p.setPen(QColor(0xff, 0xff, 0xff));
-  configFont(p, "Open Sans", 35, "Bold");
   const QRect r = QRect(rect.x() + 30, rect.y(), rect.width() - 40, rect.height());
+  configFont(p, r, "Open Sans", 35, "Bold", label);
   p.drawText(r, Qt::AlignCenter, label);
 }
 
@@ -99,9 +99,9 @@ void Sidebar::paintEvent(QPaintEvent *event) {
     x += 37;
   }
 
-  configFont(p, "Open Sans", 35, "Regular");
   p.setPen(QColor(0xff, 0xff, 0xff));
   const QRect r = QRect(50, 247, 100, 50);
+  configFont(p, r, "Open Sans", 35, "Regular", net_type);
   p.drawText(r, Qt::AlignCenter, net_type);
 
   // metrics

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -33,6 +33,32 @@ void configFont(QPainter &p, const QString &family, int size, const QString &sty
   p.setFont(f);
 }
 
+void configFont(QPainter &p, const QRect &r, const QString &family, int size,
+    const QString &style, const QString &text) {
+  if constexpr (Hardware::PC()) {
+    int szTemp = 1;
+    QFont f(family);
+    f.setStyleName(style);
+    while (true) {
+      f.setPixelSize(szTemp);
+      QRect rTemp = QFontMetrics(f).boundingRect(r, Qt::AlignCenter, text);
+      if (rTemp.height() < r.height() &&
+          rTemp.width() < r.width() &&
+          szTemp <= size) {
+        ++szTemp;
+      } else {
+        p.setFont(f);
+        return;
+      }
+    }
+  } else {
+    QFont f(family);
+    f.setPixelSize(size);
+    f.setStyleName(style);
+    p.setFont(f);
+  }
+}
+
 void clearLayout(QLayout* layout) {
   while (QLayoutItem* item = layout->takeAt(0)) {
     if (QWidget* widget = item->widget()) {

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -13,6 +13,8 @@ QString getBrand();
 QString getBrandVersion();
 std::optional<QString> getDongleId();
 void configFont(QPainter &p, const QString &family, int size, const QString &style);
+void configFont(QPainter &p, const QRect &r, const QString &family, int size,
+    const QString &style, const QString &text);
 void clearLayout(QLayout* layout);
 void setQtSurfaceFormat();
 QString timeAgo(const QDateTime &date);


### PR DESCRIPTION
ui on PC resize to replace SCALE environment variable
- dynamic scale of alert text, and nvg icons
- does not attempt to scale Offroad, Settings, and other widgets, as their dimensions are fixed at compile-time, and would require quite a bit of refactoring

![demo](https://user-images.githubusercontent.com/13343076/140869370-ad1730d0-7525-419e-bc32-ab931cb14fef.gif)

