### PR TITLE
EGLImageTexture: pass nullptr to glTexImage2d in last argument

### DIFF
--- a/selfdrive/common/visionimg.cc
+++ b/selfdrive/common/visionimg.cc
@@ -53,7 +53,7 @@ EGLImageTexture::~EGLImageTexture() {
 EGLImageTexture::EGLImageTexture(const VisionBuf *buf) {
   glGenTextures(1, &frame_tex);
   glBindTexture(GL_TEXTURE_2D, frame_tex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, buf->width, buf->height, 0, GL_RGB, GL_UNSIGNED_BYTE, buf->addr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, buf->width, buf->height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
   glGenerateMipmap(GL_TEXTURE_2D);
 }
 


### PR DESCRIPTION
No need to upload texture during initialization. save ~60-100 ms