### PR TITLE
ui/alert: add blinking back

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -163,7 +163,6 @@ void NvgWindow::fillAlertBackground() {
     return 0.375 * cos((millis_since_boot() / 1000) * 2 * M_PI * blink_rate) + 0.625;
   };
 
-  // double t1 = millis_since_boot();
   QPainter p(this);
 
   const int h = getAlertHeight(alert.size, height());
@@ -182,8 +181,6 @@ void NvgWindow::fillAlertBackground() {
   p.setCompositionMode(QPainter::CompositionMode_DestinationOver);
   p.setBrush(QBrush(g));
   p.fillRect(r, g);
-  // double t2 = millis_since_boot();
-  // printf("fillAlertBackground %f\n", t2 - t1);
 }
 
 void NvgWindow::paintGL() {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -54,6 +54,7 @@ void OnroadWindow::updateState(const UIState &s) {
   if (alert.type == "controlsUnresponsive") {
     bgColor = bg_colors[STATUS_ALERT];
   }
+
   alerts->updateAlert(alert, bgColor);
   nvg->updateAlert(alert, bgColor);
   if (bg != bgColor) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -11,10 +11,12 @@
 #endif
 
 int getAlertHeight(cereal::ControlsState::AlertSize size, int full_height) {
-  if (size == cereal::ControlsState::AlertSize::SMALL) return 271;
-  if (size == cereal::ControlsState::AlertSize::MID) return 420;
-  if (size == cereal::ControlsState::AlertSize::FULL) return full_height;
-  return 0;
+  switch (size) {
+    case cereal::ControlsState::AlertSize::SMALL: return 271;
+    case cereal::ControlsState::AlertSize::MID: return 420;
+    case cereal::ControlsState::AlertSize::FULL: return full_height;
+    default: return 0;
+  }
 }
 
 OnroadWindow::OnroadWindow(QWidget *parent) : QWidget(parent) {

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -30,11 +30,16 @@ class NvgWindow : public CameraViewWidget {
 
 public:
   explicit NvgWindow(VisionStreamType type, QWidget* parent = 0) : CameraViewWidget(type, true, parent) {}
+  void updateAlert(const Alert &a, const QColor &color);
 
 protected:
   void paintGL() override;
   void initializeGL() override;
+  void fillAlertBackground();
+
   double prev_draw_t = 0;
+  QColor alert_bg;
+  Alert alert = {};
 };
 
 // container for all onroad widgets

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -80,7 +80,7 @@ struct Alert {
         // car is started, but controls is lagging or died
         return {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
                 "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
-                AudibleAlert::CHIME_WARNING_REPEAT, .75};
+                AudibleAlert::CHIME_WARNING_REPEAT};
       }
     }
     return {};

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -54,8 +54,10 @@ struct Alert {
   QString text1;
   QString text2;
   QString type;
-  cereal::ControlsState::AlertSize size;
+  cereal::ControlsState::AlertSize size = cereal::ControlsState::AlertSize::NONE;
   AudibleAlert sound;
+  float blinking_rate = 0;
+
   bool equal(const Alert &a2) {
     return text1 == a2.text1 && text2 == a2.text2 && type == a2.type;
   }
@@ -65,7 +67,7 @@ struct Alert {
       const cereal::ControlsState::Reader &cs = sm["controlsState"].getControlsState();
       return {cs.getAlertText1().cStr(), cs.getAlertText2().cStr(),
               cs.getAlertType().cStr(), cs.getAlertSize(),
-              cs.getAlertSound()};
+              cs.getAlertSound(), cs.getAlertBlinkingRate()};
     } else if ((sm.frame - started_frame) > 5 * UI_FREQ) {
       const int CONTROLS_TIMEOUT = 5;
       // Handle controls timeout
@@ -78,7 +80,7 @@ struct Alert {
         // car is started, but controls is lagging or died
         return {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
                 "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
-                AudibleAlert::CHIME_WARNING_REPEAT};
+                AudibleAlert::CHIME_WARNING_REPEAT, .75};
       }
     }
     return {};

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -55,7 +55,7 @@ struct Alert {
   QString text2;
   QString type;
   cereal::ControlsState::AlertSize size = cereal::ControlsState::AlertSize::NONE;
-  AudibleAlert sound;
+  AudibleAlert sound = AudibleAlert::NONE;
   float blinking_rate = 0;
 
   bool equal(const Alert &a2) {


### PR DESCRIPTION
 fill rect in NvgWindow is much more faster than in OnroadAlerts(0.05ms, full screen). the CPU usage almost will not increase while blinking

https://user-images.githubusercontent.com/27770/141195181-1ada9b05-c47d-49e4-8d57-cda5aec9602e.mp4

