### PR TITLE
PC/Carla simulation fixes

### DIFF
--- a/selfdrive/common/modeldata.h
+++ b/selfdrive/common/modeldata.h
@@ -41,7 +41,7 @@ const auto X_IDXS_FLOAT = convert_array_to_type<double, float, TRAJECTORY_SIZE>(
 #include "selfdrive/common/mat.h"
 #include "selfdrive/hardware/hw.h"
 const mat3 fcam_intrinsic_matrix =
-    Hardware::EON() ? (mat3){{910., 0., 1164.0 / 2,
+    (Hardware::EON() || Hardware::PC()) ? (mat3){{910., 0., 1164.0 / 2,
                               0., 910., 874.0 / 2,
                               0., 0., 1.}}
                     : (mat3){{2648.0, 0.0, 1928.0 / 2,
@@ -54,7 +54,7 @@ const mat3 ecam_intrinsic_matrix = (mat3){{620.0, 0.0, 1928.0 / 2,
                                            0.0, 0.0, 1.0}};
 
 static inline mat3 get_model_yuv_transform(bool bayer = true) {
-  float db_s = Hardware::EON() ? 0.5 : 1.0; // debayering does a 2x downscale on EON
+  float db_s = (Hardware::EON() || Hardware::PC()) ? 0.5 : 1.0; // debayering does a 2x downscale on EON
   const mat3 transform = (mat3){{
     1.0, 0.0, 0.0,
     0.0, 1.0, 0.0,

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -294,7 +294,7 @@ class Controls:
     # Check for mismatch between openpilot and car's PCM
     cruise_mismatch = CS.cruiseState.enabled and (not self.enabled or not self.CP.pcmCruise)
     self.cruise_mismatch_counter = self.cruise_mismatch_counter + 1 if cruise_mismatch else 0
-    if self.cruise_mismatch_counter > int(1. / DT_CTRL):
+    if self.cruise_mismatch_counter > int(1. / DT_CTRL) and not SIMULATION:
       self.events.add(EventName.cruiseMismatch)
 
     # Check for FCW

--- a/selfdrive/hardware/hw.h
+++ b/selfdrive/hardware/hw.h
@@ -20,17 +20,20 @@ public:
 #endif
 
 namespace Path {
-inline static std::string HOME = util::getenv("HOME");
 inline std::string log_root() {
-  if (const char *env = getenv("LOG_ROOT")) {
+  const char *env;
+  if ((env = getenv("LOG_ROOT")) && (*env != 0)) { 
     return env;
   }
-  return Hardware::PC() ? HOME + "/.comma/media/0/realdata" : "/data/media/0/realdata";
+  return Hardware::PC() ? util::getenv("HOME") + "/.comma/media/0/realdata"
+  			 : "/data/media/0/realdata";
 }
 inline std::string params() {
-  return Hardware::PC() ? HOME + "/.comma/params" : "/data/params";
+  return Hardware::PC() ? util::getenv("HOME") + "/.comma/params" 
+  			 : "/data/params";
 }
 inline std::string rsa_file() {
-  return Hardware::PC() ? HOME + "/.comma/persist/comma/id_rsa" : "/persist/comma/id_rsa";
+  return Hardware::PC() ? util::getenv("HOME") + "/.comma/persist/comma/id_rsa"
+  			 : "/persist/comma/id_rsa";
 }
 }  // namespace Path

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -332,7 +332,8 @@ int main(int argc, char** argv) {
   // subscribe to all socks
   for (const auto& it : services) {
     if (!it.should_log) continue;
-
+    if(strstr(it.name,"CameraState") && getenv("USE_FRAME_STREAM")) continue;
+    
     SubSocket * sock = SubSocket::create(s.ctx, it.name);
     assert(sock != NULL);
     poller->registerSocket(sock);

--- a/selfdrive/modeld/runners/onnx_runner.py
+++ b/selfdrive/modeld/runners/onnx_runner.py
@@ -38,22 +38,23 @@ def run_loop(m):
 
 
 if __name__ == "__main__":
-  print(ort.get_available_providers(), file=sys.stderr)
+  print("Onnx available providers: ", ort.get_available_providers(), file=sys.stderr)
+  options = ort.SessionOptions()
   if 'OpenVINOExecutionProvider' in ort.get_available_providers() and 'ONNXCPU' not in os.environ:
-    print("OnnxJit is using openvino", file=sys.stderr)
-    options = ort.SessionOptions()
     options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
     provider = 'OpenVINOExecutionProvider'
+  elif 'CUDAExecutionProvider' in ort.get_available_providers() and 'ONNXCPU' not in os.environ:
+    options.intra_op_num_threads = 2
+    options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    provider = 'CUDAExecutionProvider'
   else:
-    print("OnnxJit is using CPU", file=sys.stderr)
-    options = ort.SessionOptions()
     options.intra_op_num_threads = 4
     options.inter_op_num_threads = 8
     options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
     options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
-
     provider = 'CPUExecutionProvider'
-
-  ort_session = ort.InferenceSession(sys.argv[1], options)
-  ort_session.set_providers([provider], None)
+    
+  print("Onnx selected provider: ", [provider], file=sys.stderr)
+  ort_session = ort.InferenceSession(sys.argv[1], options, providers=[provider])
+  print("Onnx using ", ort_session.get_providers(), file=sys.stderr)
   run_loop(ort_session)

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -36,8 +36,8 @@ typedef cereal::CarControl::HUDControl::AudibleAlert AudibleAlert;
 
 // TODO: this is also hardcoded in common/transformations/camera.py
 // TODO: choose based on frame input size
-const float y_offset = Hardware::EON() ? 0.0 : 150.0;
-const float ZOOM = Hardware::EON() ? 2138.5 : 2912.8;
+const float y_offset = (Hardware::EON() || Hardware::PC()) ? 0.0 : 150.0;
+const float ZOOM = (Hardware::EON() || Hardware::PC()) ? 2138.5 : 2912.8;
 
 typedef struct Rect {
   int x, y, w, h;

--- a/tools/sim/lib/can.py
+++ b/tools/sim/lib/can.py
@@ -62,6 +62,7 @@ def can_function(pm, speed, angle, idx, cruise_button, is_engaged):
   msg.append(packer.make_can_msg("CRUISE", 0, {}, idx))
   msg.append(packer.make_can_msg("SCM_FEEDBACK", 0, {"MAIN_ON": 1}, idx))
   msg.append(packer.make_can_msg("POWERTRAIN_DATA", 0, {"ACC_STATUS": int(is_engaged)}, idx))
+  msg.append(packer.make_can_msg("HUD_SETTING", 0, {}, idx))
 
   # *** cam bus ***
   msg.append(packer.make_can_msg("STEERING_CONTROL", 2, {}, idx))


### PR DESCRIPTION
This PR addresses multiple issues affecting simulation on a PC
1) prevent excessive CPU usage by loggerd (#22837)
2) fix PC intrinsics selection (#22705,#22546)
3) add missing "HUD_SETTING" message in can.py (#22705)
4) don't alert on cruise_mismatch when simulating (#22780)
5) add onnx CUDAExecutionProvider (#22736)
6) fix PC path setup (#22705)

An additional change is needed to get good simulation. Adding the missing can message revealed a problem in the simulated car's database, which lacks COUNTER and CHECKSUM values for "HUD_SETTING" messages in the opendbc/generator/honda/honda_civic_touring_2016_can.dbc file. The following appears to work:

BO_ 493 HUD_SETTING: 8 XXX
 SG_ IMPERIAL_UNIT : 5|1@0+ (1,0) [0|1] "" EON
 SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
