### PR TITLE
Move shutdown/reboot handling to manager

### DIFF
--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -100,6 +100,8 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"DisableRadar", PERSISTENT}, // WARNING: THIS DISABLES AEB
     {"DisableUpdates", PERSISTENT},
     {"DongleId", PERSISTENT},
+    {"DoReboot", CLEAR_ON_MANAGER_START},
+    {"DoShutdown", CLEAR_ON_MANAGER_START},
     {"DoUninstall", CLEAR_ON_MANAGER_START},
     {"EnableWideCamera", CLEAR_ON_MANAGER_START},
     {"EndToEndToggle", PERSISTENT},

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -158,9 +158,8 @@ def manager_thread():
     msg.managerState.processes = [p.get_process_state_msg() for p in managed_processes.values()]
     pm.send('managerState', msg)
 
-    # TODO: let UI handle this
-    # Exit main loop when uninstall is needed
-    if params.get_bool("DoUninstall"):
+    # Exit main loop when uninstall/shutdown/reboot is needed
+    if any(params.get_bool(p) for p in ("DoUninstall", "DoShutdown", "DoReboot")):
       break
 
 
@@ -189,9 +188,16 @@ def main():
   finally:
     manager_cleanup()
 
-  if Params().get_bool("DoUninstall"):
+  params = Params()
+  if params.get_bool("DoUninstall"):
     cloudlog.warning("uninstalling")
     HARDWARE.uninstall()
+  elif params.get_bool("DoReboot"):
+    cloudlog.warning("reboot")
+    HARDWARE.reboot()
+  elif params.get_bool("DoShutdown"):
+    cloudlog.warning("shutdown")
+    HARDWARE.shutdown()
 
 
 if __name__ == "__main__":

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -159,7 +159,13 @@ def manager_thread():
     pm.send('managerState', msg)
 
     # Exit main loop when uninstall/shutdown/reboot is needed
-    if any(params.get_bool(p) for p in ("DoUninstall", "DoShutdown", "DoReboot")):
+    shutdown = False
+    for param in ("DoUninstall", "DoShutdown", "DoReboot"):
+      if params.get_bool(param):
+        cloudlog.warning(f"Shutting down manager - {param} set")
+        shutdown = True
+
+    if shutdown:
       break
 
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -168,7 +168,7 @@ DevicePanel::DevicePanel(QWidget* parent) : ListWidget(parent) {
   power_layout->addWidget(reboot_btn);
   QObject::connect(reboot_btn, &QPushButton::clicked, [=]() {
     if (ConfirmationDialog::confirm("Are you sure you want to reboot?", this)) {
-      Hardware::reboot();
+      Params().putBool("DoReboot", true);
     }
   });
 
@@ -177,7 +177,7 @@ DevicePanel::DevicePanel(QWidget* parent) : ListWidget(parent) {
   power_layout->addWidget(poweroff_btn);
   QObject::connect(poweroff_btn, &QPushButton::clicked, [=]() {
     if (ConfirmationDialog::confirm("Are you sure you want to power off?", this)) {
-      Hardware::poweroff();
+      Params().putBool("DoShutdown", true);
     }
   });
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -167,8 +167,15 @@ DevicePanel::DevicePanel(QWidget* parent) : ListWidget(parent) {
   reboot_btn->setObjectName("reboot_btn");
   power_layout->addWidget(reboot_btn);
   QObject::connect(reboot_btn, &QPushButton::clicked, [=]() {
-    if (ConfirmationDialog::confirm("Are you sure you want to reboot?", this)) {
-      Params().putBool("DoReboot", true);
+    if (QUIState::ui_state.status == UIStatus::STATUS_DISENGAGED) {
+      if (ConfirmationDialog::confirm("Are you sure you want to reboot?", this)) {
+        // Check engaged again in case it changed while the dialog was open
+        if (QUIState::ui_state.status == UIStatus::STATUS_DISENGAGED) {
+          Params().putBool("DoReboot", true);
+        }
+      }
+    } else {
+      ConfirmationDialog::alert("Reboot not Possible While Engaged", this);
     }
   });
 
@@ -176,8 +183,15 @@ DevicePanel::DevicePanel(QWidget* parent) : ListWidget(parent) {
   poweroff_btn->setObjectName("poweroff_btn");
   power_layout->addWidget(poweroff_btn);
   QObject::connect(poweroff_btn, &QPushButton::clicked, [=]() {
-    if (ConfirmationDialog::confirm("Are you sure you want to power off?", this)) {
-      Params().putBool("DoShutdown", true);
+    if (QUIState::ui_state.status == UIStatus::STATUS_DISENGAGED) {
+      if (ConfirmationDialog::confirm("Are you sure you want to power off?", this)) {
+        // Check engaged again in case it changed while the dialog was open
+        if (QUIState::ui_state.status == UIStatus::STATUS_DISENGAGED) {
+          Params().putBool("DoShutdown", true);
+        }
+      }
+    } else {
+      ConfirmationDialog::alert("Power Off not Possible While Engaged", this);
     }
   });
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -175,7 +175,7 @@ DevicePanel::DevicePanel(QWidget* parent) : ListWidget(parent) {
         }
       }
     } else {
-      ConfirmationDialog::alert("Reboot not Possible While Engaged", this);
+      ConfirmationDialog::alert("Disengage to Reboot", this);
     }
   });
 
@@ -191,7 +191,7 @@ DevicePanel::DevicePanel(QWidget* parent) : ListWidget(parent) {
         }
       }
     } else {
-      ConfirmationDialog::alert("Power Off not Possible While Engaged", this);
+      ConfirmationDialog::alert("Disengage to Power Off", this);
     }
   });
 


### PR DESCRIPTION
Closes #22821

We should probably add something to boardd to put the panda back into elm/no output mode when it's shut down cleanly. Think that should go in a separate PR.

![2021-11-12-151102_2140x1072_scrot](https://user-images.githubusercontent.com/1314752/141480409-b73b06e7-9d6e-42c5-ba56-e389ef766fff.png)
![2021-11-12-151047_2148x1072_scrot](https://user-images.githubusercontent.com/1314752/141480414-761bd981-a24a-4b34-81ae-bb90391dea22.png)

