### PR TITLE
ui: draw all radard leads

### DIFF
--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -64,15 +64,15 @@ static void ui_draw_circle_image(const UIState *s, int center_x, int center_y, i
   ui_draw_circle_image(s, center_x, center_y, radius, image, nvgRGBA(0, 0, 0, (255 * bg_alpha)), img_alpha);
 }
 
-static void draw_lead(UIState *s, const cereal::ModelDataV2::LeadDataV3::Reader &lead_data, const vertex_data &vd) {
+static void draw_lead(UIState *s, const cereal::RadarState::LeadData::Reader &lead_data, const vertex_data &vd) {
   // Draw lead car indicator
   auto [x, y] = vd;
 
   float fillAlpha = 0;
   float speedBuff = 10.;
   float leadBuff = 40.;
-  float d_rel = lead_data.getX()[0];
-  float v_rel = lead_data.getV()[0];
+  float d_rel = lead_data.getDRel();
+  float v_rel = lead_data.getVRel();
   if (d_rel < leadBuff) {
     fillAlpha = 255*(1.0-(d_rel/leadBuff));
     if (v_rel < 0) {
@@ -139,12 +139,12 @@ static void ui_draw_world(UIState *s) {
 
   // Draw lead indicators if openpilot is handling longitudinal
   if (s->scene.longitudinal_control) {
-    auto lead_one = (*s->sm)["modelV2"].getModelV2().getLeadsV3()[0];
-    auto lead_two = (*s->sm)["modelV2"].getModelV2().getLeadsV3()[1];
-    if (lead_one.getProb() > .5) {
+    auto lead_one = (*s->sm)["radarState"].getRadarState().getLeadOne();
+    auto lead_two = (*s->sm)["radarState"].getRadarState().getLeadTwo();
+    if (lead_one.getStatus()) {
       draw_lead(s, lead_one, s->scene.lead_vertices[0]);
     }
-    if (lead_two.getProb() > .5 && (std::abs(lead_one.getX()[0] - lead_two.getX()[0]) > 3.0)) {
+    if (lead_two.getStatus() && (std::abs(lead_one.getDRel() - lead_two.getDRel()) > 3.0)) {
       draw_lead(s, lead_two, s->scene.lead_vertices[1]);
     }
   }

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -144,7 +144,7 @@ static void ui_draw_world(UIState *s) {
     if (lead_one.getProb() > .5) {
       draw_lead(s, lead_one.getX()[0], lead_one.getV()[0], s->scene.lead_vertices[0]);
     } else if (v_ego < 4. && lead_one_radar.getStatus()) {  // draw leads from low speed override
-      draw_lead(s, lead_one_radar.getDRel(), lead_one_radar.getVRel(), s->scene.lead_vertices[0]);
+      draw_lead(s, lead_one_radar.getDRel(), v_ego + lead_one_radar.getVRel(), s->scene.lead_vertices[0]);
     }
     if (lead_two.getProb() > .5 && (std::abs(lead_one.getX()[0] - lead_two.getX()[0]) > 3.0)) {
       draw_lead(s, lead_two.getX()[0], lead_two.getV()[0], s->scene.lead_vertices[1]);

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -64,13 +64,15 @@ static void ui_draw_circle_image(const UIState *s, int center_x, int center_y, i
   ui_draw_circle_image(s, center_x, center_y, radius, image, nvgRGBA(0, 0, 0, (255 * bg_alpha)), img_alpha);
 }
 
-static void draw_lead(UIState *s, float d_rel, float v_rel, const vertex_data &vd) {
+static void draw_lead(UIState *s, const cereal::ModelDataV2::LeadDataV3::Reader &lead_data, const vertex_data &vd) {
   // Draw lead car indicator
   auto [x, y] = vd;
 
   float fillAlpha = 0;
   float speedBuff = 10.;
   float leadBuff = 40.;
+  float d_rel = lead_data.getX()[0];
+  float v_rel = lead_data.getV()[0];
   if (d_rel < leadBuff) {
     fillAlpha = 255*(1.0-(d_rel/leadBuff));
     if (v_rel < 0) {
@@ -137,17 +139,13 @@ static void ui_draw_world(UIState *s) {
 
   // Draw lead indicators if openpilot is handling longitudinal
   if (s->scene.longitudinal_control) {
-    const float v_ego = (*s->sm)["carState"].getCarState().getVEgo();
-    auto lead_one_radar = (*s->sm)["radarState"].getRadarState().getLeadOne();
     auto lead_one = (*s->sm)["modelV2"].getModelV2().getLeadsV3()[0];
     auto lead_two = (*s->sm)["modelV2"].getModelV2().getLeadsV3()[1];
     if (lead_one.getProb() > .5) {
-      draw_lead(s, lead_one.getX()[0], lead_one.getV()[0], s->scene.lead_vertices[0]);
-    } else if (v_ego < 4. && lead_one_radar.getStatus()) {  // draw leads from low speed override
-      draw_lead(s, lead_one_radar.getDRel(), v_ego + lead_one_radar.getVRel(), s->scene.lead_vertices[0]);
+      draw_lead(s, lead_one, s->scene.lead_vertices[0]);
     }
     if (lead_two.getProb() > .5 && (std::abs(lead_one.getX()[0] - lead_two.getX()[0]) > 3.0)) {
-      draw_lead(s, lead_two.getX()[0], lead_two.getV()[0], s->scene.lead_vertices[1]);
+      draw_lead(s, lead_two, s->scene.lead_vertices[1]);
     }
   }
   nvgResetScissor(s->vg);

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -143,7 +143,7 @@ static void ui_draw_world(UIState *s) {
     auto lead_two = (*s->sm)["modelV2"].getModelV2().getLeadsV3()[1];
     if (lead_one.getProb() > .5) {
       draw_lead(s, lead_one.getX()[0], lead_one.getV()[0], s->scene.lead_vertices[0]);
-    } else if (v_ego < 4. && lead_one_radar.getStatus()) {  // draw leads detected from low speed override
+    } else if (v_ego < 4. && lead_one_radar.getStatus()) {  // draw leads from low speed override
       draw_lead(s, lead_one_radar.getDRel(), lead_one_radar.getVRel(), s->scene.lead_vertices[0]);
     }
     if (lead_two.getProb() > .5 && (std::abs(lead_one.getX()[0] - lead_two.getX()[0]) > 3.0)) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -45,12 +45,16 @@ static int get_path_length_idx(const cereal::ModelDataV2::XYZTData::Reader &line
 }
 
 static void update_leads(UIState *s, const cereal::ModelDataV2::Reader &model) {
+  const float v_ego = (*s->sm)["carState"].getCarState().getVEgo();
+  auto lead_one_radar = (*s->sm)["radarState"].getRadarState().getLeadOne();
   auto leads = model.getLeadsV3();
   auto model_position = model.getPosition();
   for (int i = 0; i < 2; ++i) {
     if (leads[i].getProb() > 0.5) {
       float z = model_position.getZ()[get_path_length_idx(model_position, leads[i].getX()[0])];
       calib_frame_to_full_frame(s, leads[i].getX()[0], leads[i].getY()[0], z + 1.22, &s->scene.lead_vertices[i]);
+    } else if (i == 0 && v_ego < 4. && lead_one_radar.getStatus()) {
+      calib_frame_to_full_frame(s, lead_one_radar.getDRel(), leads[i].getYRel(), 1.22, &s->scene.lead_vertices[i]);
     }
   }
 }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -54,7 +54,7 @@ static void update_leads(UIState *s, const cereal::ModelDataV2::Reader &model) {
       float z = model_position.getZ()[get_path_length_idx(model_position, leads[i].getX()[0])];
       calib_frame_to_full_frame(s, leads[i].getX()[0], leads[i].getY()[0], z + 1.22, &s->scene.lead_vertices[i]);
     } else if (i == 0 && v_ego < 4. && lead_one_radar.getStatus()) {
-      calib_frame_to_full_frame(s, lead_one_radar.getDRel(), leads[i].getYRel(), 1.22, &s->scene.lead_vertices[i]);
+      calib_frame_to_full_frame(s, lead_one_radar.getDRel(), lead_one_radar.getYRel(), 1.22, &s->scene.lead_vertices[i]);
     }
   }
 }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -45,16 +45,12 @@ static int get_path_length_idx(const cereal::ModelDataV2::XYZTData::Reader &line
 }
 
 static void update_leads(UIState *s, const cereal::ModelDataV2::Reader &model) {
-  const float v_ego = (*s->sm)["carState"].getCarState().getVEgo();
-  auto lead_one_radar = (*s->sm)["radarState"].getRadarState().getLeadOne();
   auto leads = model.getLeadsV3();
   auto model_position = model.getPosition();
   for (int i = 0; i < 2; ++i) {
     if (leads[i].getProb() > 0.5) {
       float z = model_position.getZ()[get_path_length_idx(model_position, leads[i].getX()[0])];
       calib_frame_to_full_frame(s, leads[i].getX()[0], leads[i].getY()[0], z + 1.22, &s->scene.lead_vertices[i]);
-    } else if (i == 0 && v_ego < 4. && lead_one_radar.getStatus()) {
-      calib_frame_to_full_frame(s, lead_one_radar.getDRel(), lead_one_radar.getYRel(), 1.22, &s->scene.lead_vertices[i]);
     }
   }
 }
@@ -229,7 +225,7 @@ static void update_status(UIState *s) {
 
 QUIState::QUIState(QObject *parent) : QObject(parent) {
   ui_state.sm = std::make_unique<SubMaster, const std::initializer_list<const char *>>({
-    "modelV2", "radarState", "controlsState", "liveCalibration", "deviceState", "roadCameraState",
+    "modelV2", "controlsState", "liveCalibration", "deviceState", "roadCameraState",
     "pandaStates", "carParams", "driverMonitoringState", "sensorEvents", "carState", "liveLocationKalman",
   });
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -225,7 +225,7 @@ static void update_status(UIState *s) {
 
 QUIState::QUIState(QObject *parent) : QObject(parent) {
   ui_state.sm = std::make_unique<SubMaster, const std::initializer_list<const char *>>({
-    "modelV2", "controlsState", "liveCalibration", "deviceState", "roadCameraState",
+    "modelV2", "radarState", "controlsState", "liveCalibration", "deviceState", "roadCameraState",
     "pandaStates", "carParams", "driverMonitoringState", "sensorEvents", "carState", "liveLocationKalman",
   });
 


### PR DESCRIPTION
This draws any lead that the long MPC would stop for, specifically leads detected by the radar at low speed where the model doesn't agree.

Like in this example, radarState and modelV2 disagree if there's a lead (happens to be a speed bump the radar is picking up in low speed override mode). It could be confusing why the car is stopping or not accelerating when there's no indication of a lead on the screen. Just a temp fix. Real fix: remove radard

(`f15e3c37c118e841|2021-11-13--17-47-08--34`)
![Screenshot from 2021-11-13 19-29-48](https://user-images.githubusercontent.com/25857203/141664399-9b393e97-0e6e-4a1f-bdfe-7ca8578ba697.png)