### PR TITLE
ui/alert: return std::optional<alert>

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -41,13 +41,14 @@ OnroadWindow::OnroadWindow(QWidget *parent) : QWidget(parent) {
 
 void OnroadWindow::updateState(const UIState &s) {
   QColor bgColor = bg_colors[s.status];
-  Alert alert = Alert::get(*(s.sm), s.scene.started_frame);
-  if (s.sm->updated("controlsState") || !alert.equal({})) {
-    alerts->updateAlert(alert, bgColor);
+  std::optional<Alert> alert = Alert::get(*(s.sm), s.scene.started_frame);
+  if (alert) {
+    if (alert->type == "controlsUnresponsive") {
+      bgColor = bg_colors[STATUS_ALERT];
+    }
+    alerts->updateAlert(*alert, bgColor);
   }
-  if (alert.type == "controlsUnresponsive") {
-    bgColor = bg_colors[STATUS_ALERT];
-  }
+
   if (bg != bgColor) {
     // repaint border
     bg = bgColor;

--- a/selfdrive/ui/soundd/sound.cc
+++ b/selfdrive/ui/soundd/sound.cc
@@ -49,7 +49,8 @@ void Sound::update() {
     }
   }
 
-  setAlert(Alert::get(sm, started_frame));
+  std::optional<Alert> alert = Alert::get(sm, started_frame);
+  setAlert(alert ? *alert : Alert{});
 }
 
 void Sound::setAlert(const Alert &alert) {


### PR DESCRIPTION
update bgColor before `alerts->updateAlert` to fix the wrong bg of controlsUnresponsive:

![Screenshot from 2021-11-16 22-03-07](https://user-images.githubusercontent.com/27770/141999564-8150b477-d99e-47d8-932b-8e6446ca10fa.png)

@adeebshihadeh  I think it may makes more sense to return an std::optional now. 