### PR TITLE
nav: fix receiving navRoute while map is loading

### DIFF
--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -114,6 +114,7 @@ private:
   MapETA* map_eta;
 
   void clearRoute();
+  uint64_t route_rcv_frame = 0;
 
 private slots:
   void timerUpdate();


### PR DESCRIPTION
If the map was still loading the function would return early, causing `sm->updated("navRoute")` to no longer be set once it was loaded. Look at the recv frame instead.