### PR TITLE
panda/can_send: remove pos++

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -401,7 +401,6 @@ void Panda::can_send(capnp::List<cereal::CanData>::Reader can_data_list) {
       for (int i = 0; i < pos; i += 64) {
         send.insert(send.begin() + i, counter);
         counter++;
-        pos++;
       }
       usb_bulk_write(3, (uint8_t*)send.data(), pos, 5);
     }


### PR DESCRIPTION
I don’t understand why pos++ is here,  it might be a mistake, right?