### PR TITLE
Add Linux Mint 20.2 support

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -102,6 +102,9 @@ if [ -f "/etc/os-release" ]; then
     "ubuntu 20.04")
       install_ubuntu_lts_requirements
       ;;
+    "linuxmint 20.2")
+      install_ubuntu_lts_requirements
+      ;;
     *)
       echo "$ID $VERSION_ID is unsupported. This setup script is written for Ubuntu 20.04."
       exit 1


### PR DESCRIPTION
**Description** [] Added Linux Mint 20.2 to list of supported versions in ubuntu_setup.sh. Linux Mint 20.2 is based on Ubuntu 20.04 LTS. Prior to the addition of the case statement, the script worked without error

**Verification** [] Ran script in clean Linux Mint 20.2 install, launched pipenv shell, ran pre-commit and scons; built and flashed panda / pedal. OP UI ran prior to the addition of these conditions.