### PR TITLE
Mazda: limit hud warnings until we find a way to silence them

### DIFF
--- a/selfdrive/car/mazda/carcontroller.py
+++ b/selfdrive/car/mazda/carcontroller.py
@@ -52,7 +52,8 @@ class CarController():
       ldw = c.hudControl.visualAlert == VisualAlert.ldw
       steer_required = c.hudControl.visualAlert == VisualAlert.steerRequired
       # TODO: find a way to silence audible warnings so we can add more hud alerts
-      steer_required = steer_required and CS.lkas_allowed_speed
+      # steer_required = steer_required and CS.lkas_allowed_speed
+      steer_required = CS.out.steerWarning
       can_sends.append(mazdacan.create_alert_command(self.packer, CS.cam_laneinfo, ldw, steer_required))
 
     # send steering command


### PR DESCRIPTION
The hud warning is  bit annoying with a chime. Let us give ourselves some time to sort this out before we enable the hud warning for several  events. This PR limits the warning to steer lockout situations.

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>