### PR TITLE
panda.cc: struct for CAN header, counter complexity, cleanup for readability

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -460,10 +460,8 @@ bool Panda::can_receive(std::vector<can_frame>& out_vec) {
         canData.address = header.addr;
         canData.src = header.bus + bus_offset;
 
-        bool rejected = header.rejected;
-        bool returned = header.returned;
-        if (rejected) { canData.src += CANPACKET_REJECTED; }
-        if (returned) { canData.src += CANPACKET_RETURNED; }
+        if (header.rejected) { canData.src += CANPACKET_REJECTED; }
+        if (header.returned) { canData.src += CANPACKET_RETURNED; }
         canData.dat.assign((char*)&chunk[pos+CANPACKET_HEAD_SIZE], data_len);
 
         pos += pckt_len;

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -364,7 +364,9 @@ uint8_t Panda::len_to_dlc(uint8_t len) {
 }
 
 void Panda::can_send(capnp::List<cereal::CanData>::Reader can_data_list) {
-  send.resize(can_data_list.size() * CANPACKET_MAX_SIZE);
+  if send.size() < (can_data_list.size() * CANPACKET_MAX_SIZE) {
+    send.resize(can_data_list.size() * CANPACKET_MAX_SIZE);
+  }
 
   int msg_count = 0;
   while (msg_count < can_data_list.size()) {

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -364,7 +364,7 @@ uint8_t Panda::len_to_dlc(uint8_t len) {
 }
 
 void Panda::can_send(capnp::List<cereal::CanData>::Reader can_data_list) {
-  if send.size() < (can_data_list.size() * CANPACKET_MAX_SIZE) {
+  if (send.size() < (can_data_list.size() * CANPACKET_MAX_SIZE)) {
     send.resize(can_data_list.size() * CANPACKET_MAX_SIZE);
   }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -447,12 +447,14 @@ bool Panda::can_receive(std::vector<can_frame>& out_vec) {
       uint8_t pckt_len = CANPACKET_HEAD_SIZE + data_len;
       if (pckt_len <= (chunk_len - pos)) {
         can_frame canData;
+        can_header header;
+        memcpy(&header, &chunk[pos], 5);
         canData.busTime = 0;
-        canData.address = (*(uint32_t*)&chunk[pos+1]) >> 3;
-        canData.src = ((chunk[pos] >> 1) & 0x7) + bus_offset;
+        canData.address = header.addr;
+        canData.src = header.bus + bus_offset;
 
-        bool rejected = chunk[pos+1] & 0x1;
-        bool returned = (chunk[pos+1] >> 1) & 0x1;
+        bool rejected = header.rejected;
+        bool returned = header.returned;
         if (rejected) { canData.src += CANPACKET_REJECTED; }
         if (returned) { canData.src += CANPACKET_RETURNED; }
         canData.dat.assign((char*)&chunk[pos+5], data_len);

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -13,11 +13,12 @@
 #include "cereal/gen/cpp/car.capnp.h"
 #include "cereal/gen/cpp/log.capnp.h"
 
-// double the FIFO size
-#define RECV_SIZE (0x4000)
 #define TIMEOUT 0
 #define PANDA_BUS_CNT 4
-#define CANPACKET_HEAD_SIZE (0x5U)
+#define RECV_SIZE (0x4000U)
+#define USB_TX_SOFT_LIMIT   (0x100U)
+#define CANPACKET_HEAD_SIZE 5U
+#define CANPACKET_MAX_SIZE  72U
 #define CANPACKET_REJECTED  (0xC0U)
 #define CANPACKET_RETURNED  (0x80U)
 

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -44,6 +44,16 @@ struct __attribute__((packed)) health_t {
   uint8_t heartbeat_lost;
 };
 
+struct __attribute__((packed)) can_header {
+  uint8_t reserved : 1;
+  uint8_t bus : 3;
+  uint8_t data_len_code : 4;
+  uint8_t rejected : 1;
+  uint8_t returned : 1;
+  uint8_t extended : 1;
+  uint32_t addr : 29;
+};
+
 struct can_frame {
 	long address;
 	std::string dat;


### PR DESCRIPTION
1. Moved CAN header to struct for readability
2. Removed N^2 complexity from adding counter in can_send func
3. Few cleanups and comments to make the code more readable
4. Resize send vector only when it is needed.