### PR TITLE
api: send User-Agent on network requests

### DIFF
--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -90,6 +90,7 @@ void HttpRequest::sendRequest(const QString &requestURL, const HttpRequest::Meth
 
   QNetworkRequest request;
   request.setUrl(QUrl(requestURL));
+  request.setRawHeader("User-Agent", getUserAgent().toUtf8());
 
   if (!token.isEmpty()) {
     request.setRawHeader(QByteArray("Authorization"), ("JWT " + token).toUtf8());

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -17,7 +17,8 @@ QString getBrandVersion() {
 }
 
 QString getUserAgent() {
-  return "openpilot-" + QString::fromStdString(Params().get("Version"));
+  static QString version =  QString::fromStdString(Params().get("Version");
+  return "openpilot-" + version);
 }
 
 std::optional<QString> getDongleId() {

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -8,17 +8,21 @@
 #include "selfdrive/common/swaglog.h"
 #include "selfdrive/hardware/hw.h"
 
+QString getVersion() {
+  static QString version =  QString::fromStdString(Params().get("Version"));
+  return version;
+}
+
 QString getBrand() {
   return Params().getBool("Passive") ? "dashcam" : "openpilot";
 }
 
 QString getBrandVersion() {
-  return getBrand() + " v" + QString::fromStdString(Params().get("Version")).left(14).trimmed();
+  return getBrand() + " v" + getVersion().left(14).trimmed();
 }
 
 QString getUserAgent() {
-  static QString version =  QString::fromStdString(Params().get("Version"));
-  return "openpilot-" + version;
+  return "openpilot-" + getVersion();
 }
 
 std::optional<QString> getDongleId() {

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -17,8 +17,8 @@ QString getBrandVersion() {
 }
 
 QString getUserAgent() {
-  static QString version =  QString::fromStdString(Params().get("Version");
-  return "openpilot-" + version);
+  static QString version =  QString::fromStdString(Params().get("Version"));
+  return "openpilot-" + version;
 }
 
 std::optional<QString> getDongleId() {

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -16,6 +16,10 @@ QString getBrandVersion() {
   return getBrand() + " v" + QString::fromStdString(Params().get("Version")).left(14).trimmed();
 }
 
+QString getUserAgent() {
+  return "openpilot-" + QString::fromStdString(Params().get("Version"));
+}
+
 std::optional<QString> getDongleId() {
   std::string id = Params().get("DongleId");
 

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -9,6 +9,7 @@
 #include <QSurfaceFormat>
 #include <QWidget>
 
+QString getVersion();
 QString getBrand();
 QString getBrandVersion();
 QString getUserAgent();

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -11,6 +11,7 @@
 
 QString getBrand();
 QString getBrandVersion();
+QString getUserAgent();
 std::optional<QString> getDongleId();
 void configFont(QPainter &p, const QString &family, int size, const QString &style);
 void clearLayout(QLayout* layout);


### PR DESCRIPTION
The format of the User-Agent header matches the format in `common/api/__init__.py`.

Closes #22954.