### PR TITLE
 UI: add timeout to close settings window while onroad

### DIFF
--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -44,7 +44,7 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
       closeSettings();
     }
   });
-  QObject::connect(&device, &Device::displayPowerChanged, [=]() {
+  QObject::connect(&device, &Device::interactiveTimout, [=]() {
      if(main_layout->currentWidget() != onboardingWindow) {
        closeSettings();
      }

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -37,7 +37,6 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     main_layout->setCurrentWidget(onboardingWindow);
   }
 
-  device.resetInteractiveTimout();
   QObject::connect(&qs, &QUIState::uiUpdate, &device, &Device::update);
   QObject::connect(&qs, &QUIState::offroadTransition, [=](bool offroad) {
     if (!offroad) {

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -45,9 +45,9 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     }
   });
   QObject::connect(&device, &Device::interactiveTimout, [=]() {
-     if(main_layout->currentWidget() != onboardingWindow) {
-       closeSettings();
-     }
+    if (main_layout->currentWidget() == settingsWindow) {
+      closeSettings();
+    }
   });
 
   // load fonts

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -37,7 +37,7 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     main_layout->setCurrentWidget(onboardingWindow);
   }
 
-  device.setAwake(true);
+  device.resetInteractiveTimout();
   QObject::connect(&qs, &QUIState::uiUpdate, &device, &Device::update);
   QObject::connect(&qs, &QUIState::offroadTransition, [=](bool offroad) {
     if (!offroad) {
@@ -86,9 +86,8 @@ void MainWindow::closeSettings() {
 }
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event) {
-  // wake screen on tap
   if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::TouchBegin) {
-    device.setAwake(true);
+    device.resetInteractiveTimout();
   }
 
 #ifdef QCOM

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -37,7 +37,7 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     main_layout->setCurrentWidget(onboardingWindow);
   }
 
-  device.setAwake(true, true);
+  device.setAwake(true);
   QObject::connect(&qs, &QUIState::uiUpdate, &device, &Device::update);
   QObject::connect(&qs, &QUIState::offroadTransition, [=](bool offroad) {
     if (!offroad) {
@@ -88,7 +88,7 @@ void MainWindow::closeSettings() {
 bool MainWindow::eventFilter(QObject *obj, QEvent *event) {
   // wake screen on tap
   if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::TouchBegin) {
-    device.setAwake(true, true);
+    device.setAwake(true);
   }
 
 #ifdef QCOM

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -294,16 +294,12 @@ bool Device::userClicked(const UIState &s) {
   // tap detection while display is off
   if (!awake && s.sm->updated("sensorEvents")) {
     for (auto sensor : (*s.sm)["sensorEvents"].getSensorEvents()) {
+      if (sensor.getTimestamp() == 0) continue;
+
       if (sensor.which() == cereal::SensorEventData::ACCELERATION) {
-        auto accel = sensor.getAcceleration().getV();
-        if (accel.totalSize().wordCount) {  // TODO: sometimes empty lists are received. Figure out why
-          accel_sensor = accel[2];
-        }
+        accel_sensor = sensor.getAcceleration().getV()[2];
       } else if (sensor.which() == cereal::SensorEventData::GYRO_UNCALIBRATED) {
-        auto gyro = sensor.getGyroUncalibrated().getV();
-        if (gyro.totalSize().wordCount) {
-          gyro_sensor = gyro[1];
-        }
+        gyro_sensor = sensor.getGyroUncalibrated().getV()[1];
       }
     }
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -290,7 +290,7 @@ void Device::updateBrightness(const UIState &s) {
 }
 
 bool Device::userClicked(const UIState &s) {
-  bool user_click = false;
+  bool user_clicked = false;
   // tap detection while display is off
   if (!awake && s.sm->updated("sensorEvents")) {
     for (auto sensor : (*s.sm)["sensorEvents"].getSensorEvents()) {
@@ -309,11 +309,11 @@ bool Device::userClicked(const UIState &s) {
 
     bool accel_trigger = abs(accel_sensor - accel_prev) > 0.2;
     bool gyro_trigger = abs(gyro_sensor - gyro_prev) > 0.15;
-    user_click = (accel_trigger && gyro_trigger);
+    user_clicked = (accel_trigger && gyro_trigger);
     gyro_prev = gyro_sensor;
     accel_prev = (accel_prev * (accel_samples - 1) + accel_sensor) / accel_samples;
   }
-  return user_click;
+  return user_clicked;
 }
 
 void Device::updateWakefulness(const UIState &s) {
@@ -327,6 +327,4 @@ void Device::updateWakefulness(const UIState &s) {
   }
 
   setAwake(s.scene.ignition || interactive_timeout > 0);
-
-  
 }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -236,6 +236,8 @@ void QUIState::update() {
 }
 
 Device::Device(QObject *parent) : brightness_filter(BACKLIGHT_OFFROAD, BACKLIGHT_TS, BACKLIGHT_DT), QObject(parent) {
+  setAwake(true);
+  resetInteractiveTimout();
 }
 
 void Device::update(const UIState &s) {
@@ -315,7 +317,8 @@ bool Device::userClicked(const UIState &s) {
 }
 
 void Device::updateWakefulness(const UIState &s) {
-  if ((!s.scene.ignition && ignition_prev) || userClicked(s)) {
+  bool ignition_just_turned_off = !s.scene.ignition && ignition_prev;
+  if (ignition_just_turned_off || userClicked(s)) {
     resetInteractiveTimout();
   } else if (interactive_timeout > 0 && --interactive_timeout == 0) {
     emit interactiveTimout();

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -261,7 +261,7 @@ void Device::update(const UIState &s) {
   QUIState::ui_state.awake = awake;
 }
 
-void Device::setAwake(bool on, bool reset) {
+void Device::setAwake(bool on, bool reset_timeout) {
   if (on != awake) {
     awake = on;
     Hardware::set_display_power(awake);
@@ -269,7 +269,7 @@ void Device::setAwake(bool on, bool reset) {
     emit displayPowerChanged(awake);
   }
 
-  if (reset) {
+  if (reset_timeout) {
     awake_timeout = 30 * UI_FREQ;
   }
 }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -258,7 +258,7 @@ void Device::setAwake(bool on) {
 }
 
 void Device::resetInteractiveTimout() {
-  interactive_timeout = 30 * UI_FREQ;
+  interactive_timeout = (ignition_on ? 10 : 30) * UI_FREQ;
 }
 
 void Device::updateBrightness(const UIState &s) {
@@ -317,7 +317,9 @@ bool Device::userClicked(const UIState &s) {
 }
 
 void Device::updateWakefulness(const UIState &s) {
-  bool ignition_just_turned_off = !s.scene.ignition && ignition_prev;
+  bool ignition_just_turned_off = !s.scene.ignition && ignition_on;
+  ignition_on = s.scene.ignition;
+
   if (ignition_just_turned_off || userClicked(s)) {
     resetInteractiveTimout();
   } else if (interactive_timeout > 0 && --interactive_timeout == 0) {
@@ -326,5 +328,5 @@ void Device::updateWakefulness(const UIState &s) {
 
   setAwake(s.scene.ignition || interactive_timeout > 0);
 
-  ignition_prev = s.scene.ignition;
+  
 }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -305,10 +305,6 @@ void Device::updateBrightness(const UIState &s) {
 }
 
 bool Device::motionTriggered(const UIState &s) {
-  if (awake) {
-    return false;
-  }
-
   static float accel_prev = 0;
   static float gyro_prev = 0;
 
@@ -318,7 +314,7 @@ bool Device::motionTriggered(const UIState &s) {
   gyro_prev = s.scene.gyro_sensor;
   accel_prev = (accel_prev * (accel_samples - 1) + s.scene.accel_sensor) / accel_samples;
 
-  return (accel_trigger && gyro_trigger);
+  return (!awake && accel_trigger && gyro_trigger);
 }
 
 void Device::updateWakefulness(const UIState &s) {

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -168,7 +168,7 @@ signals:
   void interactiveTimout();
 
 public slots:
-  void setAwake(bool on, bool reset);
+  void setAwake(bool on, bool reset_timeout = true);
   void update(const UIState &s);
 };
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -159,8 +159,6 @@ private:
   int last_brightness = 0;
   FirstOrderFilter brightness_filter;
 
-  QTimer *timer;
-
   void updateBrightness(const UIState &s);
   void updateWakefulness(const UIState &s);
   bool userClicked(const UIState &s);

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -155,7 +155,7 @@ private:
   int interactive_timeout = 0;
   float accel_sensor = 0, accel_prev = 0;
   float gyro_sensor = 0, gyro_prev = 0;
-  bool ignition_prev = false;
+  bool ignition_on = false;
   int last_brightness = 0;
   FirstOrderFilter brightness_filter;
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -148,7 +148,6 @@ public:
   Device(QObject *parent = 0);
 
 private:
-
   // auto brightness
   const float accel_samples = 5*UI_FREQ;
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -96,7 +96,7 @@ typedef struct UIScene {
   // lead
   QPointF lead_vertices[2];
 
-  float light_sensor, accel_sensor, gyro_sensor;
+  float light_sensor;
   bool started, ignition, is_metric, longitudinal_control, end_to_end;
   uint64_t started_frame;
 } UIScene;
@@ -148,13 +148,15 @@ public:
   Device(QObject *parent = 0);
 
 private:
+
   // auto brightness
   const float accel_samples = 5*UI_FREQ;
 
   bool awake = false;
-  int awake_timeout = 0;
-  float accel_prev = 0;
-  float gyro_prev = 0;
+  int interactive_timeout = 0;
+  float accel_sensor = 0, accel_prev = 0;
+  float gyro_sensor = 0, gyro_prev = 0;
+  bool ignition_prev = false;
   int last_brightness = 0;
   FirstOrderFilter brightness_filter;
 
@@ -162,13 +164,15 @@ private:
 
   void updateBrightness(const UIState &s);
   void updateWakefulness(const UIState &s);
+  bool userClicked(const UIState &s);
+  void setAwake(bool on);
 
 signals:
   void displayPowerChanged(bool on);
   void interactiveTimout();
 
 public slots:
-  void setAwake(bool on, bool reset_timeout = true);
+  void resetInteractiveTimout();
   void update(const UIState &s);
 };
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -165,6 +165,7 @@ private:
 
 signals:
   void displayPowerChanged(bool on);
+  void interactiveTimout();
 
 public slots:
   void setAwake(bool on, bool reset);

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -96,7 +96,7 @@ typedef struct UIScene {
   // lead
   QPointF lead_vertices[2];
 
-  float light_sensor;
+  float light_sensor, accel_sensor, gyro_sensor;
   bool started, ignition, is_metric, longitudinal_control, end_to_end;
   uint64_t started_frame;
 } UIScene;
@@ -153,15 +153,13 @@ private:
 
   bool awake = false;
   int interactive_timeout = 0;
-  float accel_sensor = 0, accel_prev = 0;
-  float gyro_sensor = 0, gyro_prev = 0;
   bool ignition_on = false;
   int last_brightness = 0;
   FirstOrderFilter brightness_filter;
 
   void updateBrightness(const UIState &s);
   void updateWakefulness(const UIState &s);
-  bool userClicked(const UIState &s);
+  bool motionTriggered(const UIState &s);
   void setAwake(bool on);
 
 signals:


### PR DESCRIPTION
resolved https://github.com/commaai/openpilot/issues/22978

1. close settings window and set display off if user does not tap the screen within 30s while off-road.
2. close settings window and return to onroad window if user does not tap the screen within 10s while on-road