### PR TITLE
ui/device: fix uninitialized variable awake

### DIFF
--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -188,7 +188,7 @@ private:
   // auto brightness
   const float accel_samples = 5*UI_FREQ;
 
-  bool awake;
+  bool awake = false;
   int awake_timeout = 0;
   float accel_prev = 0;
   float gyro_prev = 0;


### PR DESCRIPTION
awake is uninitialized. it's a random number at startup.