### PR TITLE
longitudinal: only apply overshoot prevention when braking

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -107,7 +107,7 @@ class LongControl():
 
       # Toyota starts braking more when it thinks you want to stop
       # Freeze the integrator so we don't accelerate to compensate, and don't allow positive acceleration
-      prevent_overshoot = not CP.stoppingControl and CS.vEgo < 1.5 and v_target > v_target_future < 0.7
+      prevent_overshoot = not CP.stoppingControl and CS.vEgo < 1.5 and v_target_future < 0.7 and v_target_future < v_target
       deadzone = interp(CS.vEgo, CP.longitudinalTuning.deadzoneBP, CP.longitudinalTuning.deadzoneV)
       freeze_integrator = prevent_overshoot
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -107,7 +107,7 @@ class LongControl():
 
       # Toyota starts braking more when it thinks you want to stop
       # Freeze the integrator so we don't accelerate to compensate, and don't allow positive acceleration
-      prevent_overshoot = not CP.stoppingControl and CS.vEgo < 1.5 and v_target_future < 0.7 and a_target < 0
+      prevent_overshoot = not CP.stoppingControl and CS.vEgo < 1.5 and v_target > v_target_future < 0.7
       deadzone = interp(CS.vEgo, CP.longitudinalTuning.deadzoneBP, CP.longitudinalTuning.deadzoneV)
       freeze_integrator = prevent_overshoot
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -107,7 +107,7 @@ class LongControl():
 
       # Toyota starts braking more when it thinks you want to stop
       # Freeze the integrator so we don't accelerate to compensate, and don't allow positive acceleration
-      prevent_overshoot = not CP.stoppingControl and CS.vEgo < 1.5 and v_target_future < 0.7
+      prevent_overshoot = not CP.stoppingControl and CS.vEgo < 1.5 and v_target_future < 0.7 and a_target < 0
       deadzone = interp(CS.vEgo, CP.longitudinalTuning.deadzoneBP, CP.longitudinalTuning.deadzoneV)
       freeze_integrator = prevent_overshoot
 


### PR DESCRIPTION
The previous code activated any time you're under 1.5 m/s and the v_target_future is less than 0.7 m/s, so essentially no acceleration would be commanded until after the future v_target got above a certain threshold, which instead we only want to apply this when braking. Adding an and so it only applies when requesting brake means we start accelerating ~0.8 seconds earlier in this example:

![Screenshot from 2021-11-20 00-01-06](https://user-images.githubusercontent.com/25857203/142716375-2d08403e-685e-4250-8431-0b2345107d49.png)

I have openpilot longitudinal in sng behaving nearly exactly like stock on TSS2, but I'll keep the changes to a minimum per PR and try to split them up under distinct fixes.