### PR TITLE
Remove minSpeedCan

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -82,6 +82,7 @@ class CarInterfaceBase():
     ret.minEnableSpeed = -1. # enable is done by stock ACC, so ignore this
     ret.steerRatioRear = 0.  # no rear steering, at least on the listed cars aboveA
     ret.openpilotLongitudinalControl = False
+    ret.minSpeedCan = 0.3
     ret.startAccel = -0.8
     ret.stopAccel = -2.0
     ret.startingAccelRate = 3.2 # brake_travel/s while releasing on restart

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -82,7 +82,6 @@ class CarInterfaceBase():
     ret.minEnableSpeed = -1. # enable is done by stock ACC, so ignore this
     ret.steerRatioRear = 0.  # no rear steering, at least on the listed cars aboveA
     ret.openpilotLongitudinalControl = False
-    ret.minSpeedCan = 0.3
     ret.startAccel = -0.8
     ret.stopAccel = -2.0
     ret.startingAccelRate = 3.2 # brake_travel/s while releasing on restart

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -7,20 +7,21 @@ from selfdrive.modeld.constants import T_IDXS
 
 LongCtrlState = car.CarControl.Actuators.LongControlState
 
-STOPPING_TARGET_SPEED_OFFSET = 0.01
-
 # As per ISO 15622:2018 for all speeds
 ACCEL_MIN_ISO = -3.5  # m/s^2
 ACCEL_MAX_ISO = 2.0  # m/s^2
 
 
-def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_future, v_pid,
-                             output_accel, brake_pressed, cruise_standstill, min_speed_can):
+def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_future, v_target,
+                             output_accel, brake_pressed, cruise_standstill):
   """Update longitudinal control state machine"""
-  stopping_target_speed = min_speed_can + STOPPING_TARGET_SPEED_OFFSET
+  # TODO: may be overthinking this, but see if it's correct to have both vTarget and vTargetFuture, or if we can get by with just vTargetFuture
+  # My thinking is that if the lead is super far away and stopped, and we're 1-2 mph, vTargetFuture will say to stop in 10 seconds, but vTarget will say to move up slowly until then
+  # So we'll stop too soon
+  # But this is an edge case and can be fixed by changing vTargetFuture to 2 seconds instead of 10, like it was before
   stopping_condition = (v_ego < 2.0 and cruise_standstill) or \
                        (v_ego < CP.vEgoStopping and
-                        ((v_pid < stopping_target_speed and v_target_future < stopping_target_speed) or
+                        ((v_target < CP.vEgoStopping and v_target_future < CP.vEgoStopping) or
                          brake_pressed))
 
   starting_condition = v_target_future > CP.vEgoStarting and not cruise_standstill
@@ -91,8 +92,8 @@ class LongControl():
     # Update state machine
     output_accel = self.last_output_accel
     self.long_control_state = long_control_state_trans(CP, active, self.long_control_state, CS.vEgo,
-                                                       v_target_future, self.v_pid, output_accel,
-                                                       CS.brakePressed, CS.cruiseState.standstill, CP.minSpeedCan)
+                                                       v_target_future, v_target, output_accel,
+                                                       CS.brakePressed, CS.cruiseState.standstill)
 
     if self.long_control_state == LongCtrlState.off or CS.gasPressed:
       self.reset(CS.vEgo)
@@ -119,7 +120,6 @@ class LongControl():
       if not CS.standstill or output_accel > CP.stopAccel:
         output_accel -= CP.stoppingDecelRate * DT_CTRL
       output_accel = clip(output_accel, accel_limits[0], accel_limits[1])
-
       self.reset(CS.vEgo)
 
     # Intention is to move again, release brake fast before handing control to PID

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -7,8 +7,6 @@ from selfdrive.modeld.constants import T_IDXS
 
 LongCtrlState = car.CarControl.Actuators.LongControlState
 
-STOPPING_TARGET_SPEED = 0.31
-
 # As per ISO 15622:2018 for all speeds
 ACCEL_MIN_ISO = -3.5  # m/s^2
 ACCEL_MAX_ISO = 2.0  # m/s^2
@@ -19,7 +17,7 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_fut
   """Update longitudinal control state machine"""
   stopping_condition = (v_ego < 2.0 and cruise_standstill) or \
                        (v_ego < CP.vEgoStopping and
-                        (v_target_future < STOPPING_TARGET_SPEED or brake_pressed))
+                        (v_target_future < CP.vEgoStopping or brake_pressed))
 
   starting_condition = v_target_future > CP.vEgoStarting and not cruise_standstill
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -17,7 +17,7 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_fut
   """Update longitudinal control state machine"""
   stopping_condition = (v_ego < 2.0 and cruise_standstill) or \
                        (v_ego < CP.vEgoStopping and
-                        (v_target_future < CP.vEgoStopping or brake_pressed))
+                        (v_target_future < 0.31 or brake_pressed))
 
   starting_condition = v_target_future > CP.vEgoStarting and not cruise_standstill
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -7,6 +7,8 @@ from selfdrive.modeld.constants import T_IDXS
 
 LongCtrlState = car.CarControl.Actuators.LongControlState
 
+STOPPING_TARGET_SPEED = 0.31
+
 # As per ISO 15622:2018 for all speeds
 ACCEL_MIN_ISO = -3.5  # m/s^2
 ACCEL_MAX_ISO = 2.0  # m/s^2
@@ -17,7 +19,7 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_fut
   """Update longitudinal control state machine"""
   stopping_condition = (v_ego < 2.0 and cruise_standstill) or \
                        (v_ego < CP.vEgoStopping and
-                        (v_target_future < CP.vEgoStopping or brake_pressed))
+                        (v_target_future < STOPPING_TARGET_SPEED or brake_pressed))
 
   starting_condition = v_target_future > CP.vEgoStarting and not cruise_standstill
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -17,7 +17,7 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_fut
   """Update longitudinal control state machine"""
   stopping_condition = (v_ego < 2.0 and cruise_standstill) or \
                        (v_ego < CP.vEgoStopping and
-                        (v_target_future < 0.31 or brake_pressed))
+                        (v_target_future < CP.vEgoStopping or brake_pressed))
 
   starting_condition = v_target_future > CP.vEgoStarting and not cruise_standstill
 


### PR DESCRIPTION
Doesn't seem to make sense to keep `minSpeedCan` since it's not being compared to raw CAN data, and is now more used as a stopping speed threshold. With this PR we compare whether `vEgo` and `vTargetFuture` is less than `vEgoStopping`, so that we only stop if we're in the correct speed range, and the future desired speed is telling us to stop soon.

Changes in behavior:
- When in starting state, we can enter stopping state again up to 0.5 m/s instead of 0.3 m/s. Shouldn't matter that much since the car has a large delay to acceleration, and we exit starting state when output_accel is high enough, which is pretty quick.
- When coming to a stop, [vTarget is ideally essentially vEgo](https://i.imgur.com/9HudeRn.png), so previously the stopping state condition was: `vEgo < 0.5 and (vEgo < 0.31 and vTargetFuture < 0.31)`, now it's `vEgo < 0.5 and vTargetFuture < 0.5`

As expected, we now enter a stopping state when vEgo is less than 0.5, and vTargetFuture is already less than 0.3 m/s, so that didn't seem to be the limiting factor: https://i.imgur.com/jEg21FQ.png