### PR TITLE
framereader: replace swscale with libyuv,  reduce cpu usage by half 

### DIFF
--- a/selfdrive/camerad/SConscript
+++ b/selfdrive/camerad/SConscript
@@ -21,7 +21,7 @@ else:
     if USE_FRAME_STREAM:
       cameras = ['cameras/camera_frame_stream.cc']
     else:
-      libs += ['avutil', 'avcodec', 'avformat', 'swscale', 'bz2', 'ssl', 'curl', 'crypto']
+      libs += ['avutil', 'avcodec', 'avformat', 'bz2', 'ssl', 'curl', 'crypto']
       # TODO: import replay_lib from root SConstruct
       cameras = ['cameras/camera_replay.cc', 
         env.Object('camera-util', '#/selfdrive/ui/replay/util.cc'),

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -116,7 +116,7 @@ if arch in ['x86_64', 'Darwin'] or GetOption('extras'):
   replay_lib_src = ["replay/replay.cc", "replay/camera.cc", "replay/filereader.cc", "replay/logreader.cc", "replay/framereader.cc", "replay/route.cc", "replay/util.cc"]
 
   replay_lib = qt_env.Library("qt_replay", replay_lib_src, LIBS=base_libs)
-  replay_libs = [replay_lib, 'avutil', 'avcodec', 'avformat', 'bz2', 'curl', 'swscale', 'yuv'] + qt_libs
+  replay_libs = [replay_lib, 'avutil', 'avcodec', 'avformat', 'bz2', 'curl', 'yuv'] + qt_libs
   qt_env.Program("replay/replay", ["replay/main.cc"], LIBS=replay_libs)
 
   qt_env.Program("watch3", ["watch3.cc"], LIBS=qt_libs + ['common', 'json11'])

--- a/selfdrive/ui/replay/framereader.h
+++ b/selfdrive/ui/replay/framereader.h
@@ -42,9 +42,7 @@ private:
     bool failed = false;
   };
   std::vector<Frame> frames_;
-  AVPixelFormat sws_src_format = AV_PIX_FMT_YUV420P;
-  SwsContext *rgb_sws_ctx_ = nullptr, *yuv_sws_ctx_ = nullptr;
-  std::unique_ptr<AVFrame, AVFrameDeleter>av_frame_, sws_frame, hw_frame;
+  std::unique_ptr<AVFrame, AVFrameDeleter>av_frame_, hw_frame;
   AVFormatContext *input_ctx = nullptr;
   AVCodecContext *decoder_ctx = nullptr;
   int key_frames_count_ = 0;
@@ -53,4 +51,5 @@ private:
 
   AVPixelFormat hw_pix_fmt = AV_PIX_FMT_NONE;
   AVBufferRef *hw_device_ctx = nullptr;
+  std::vector<uint8_t> nv12toyuv_buffer;
 };

--- a/selfdrive/ui/replay/framereader.h
+++ b/selfdrive/ui/replay/framereader.h
@@ -9,8 +9,6 @@
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
-#include <libswscale/swscale.h>
-#include <libavutil/imgutils.h>
 }
 
 struct AVFrameDeleter {


### PR DESCRIPTION
libyuv has better performace than libswscale