### PR TITLE
ui/api: singleton QNetworkAccessManager

### DIFF
--- a/selfdrive/ui/qt/api.h
+++ b/selfdrive/ui/qt/api.h
@@ -37,7 +37,7 @@ protected:
   QNetworkReply *reply = nullptr;
 
 private:
-  QNetworkAccessManager *networkAccessManager = nullptr;
+  static QNetworkAccessManager *nam();
   QTimer *networkTimer = nullptr;
   bool create_jwt;
 


### PR DESCRIPTION
in Qt document, they said:

>   One QNetworkAccessManager instance should be enough for the whole Qt application. 

since we clear network caches on multiple instances after timeout( which is expensive operation), think it's better to follow the recommendations in  document, use a singleton QNetworkAccessManager in HttpRequest
https://github.com/commaai/openpilot/blob/d97ad1302a5ad665caa4cb081ada3db477ebaee4/selfdrive/ui/qt/api.cc#L130-L134