### PR TITLE
Subaru SNG

### DIFF
--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -10,9 +10,15 @@ class CarController:
     self.apply_steer_last = 0
     self.es_distance_cnt = -1
     self.es_lkas_cnt = -1
+    self.throttle_cnt = -1
     self.cruise_button_prev = 0
     self.steer_rate_limited = False
     self.frame = 0
+    self.sng_acc_resume = False
+    self.sng_acc_resume_cnt = -1
+    self.manual_hold = False
+    self.prev_cruise_state = 0
+    self.prev_close_distance = 0
 
     self.p = CarControllerParams(CP)
     self.packer = CANPacker(DBC[CP.carFingerprint]['pt'])
@@ -45,6 +51,49 @@ class CarController:
 
       self.apply_steer_last = apply_steer
 
+    # *** stop and go ***
+
+    throttle_cmd = False
+
+    if CS.CP.carFingerprint in PREGLOBAL_CARS:
+      if (enabled                                            # ACC active
+          and CS.car_follow == 1                             # lead car
+          and CS.out.standstill                              # must be standing still
+          and CS.close_distance > 3                          # acc resume trigger threshold
+          and CS.close_distance < 4.5                        # max operating distance to filter false positives
+          and CS.close_distance > self.prev_close_distance): # distance with lead car is increasing
+        self.sng_acc_resume = True
+    elif CS.CP.carFingerprint not in PREGLOBAL_CARS:
+      # Record manual hold set while in standstill and no car in front
+      if CS.out.standstill and self.prev_cruise_state == 1 and CS.cruise_state == 3 and CS.car_follow == 0:
+        self.manual_hold = True
+      # Cancel manual hold when car starts moving
+      if not CS.out.standstill:
+        self.manual_hold = False
+      if (enabled                                            # ACC active
+          and not self.manual_hold
+          and CS.car_follow == 1                             # lead car
+          and CS.cruise_state == 3                           # ACC HOLD (only with EPB)
+          and CS.out.standstill                              # must be standing still
+          and CS.close_distance > 150                        # acc resume trigger threshold
+          and CS.close_distance < 255                        # ignore max value
+          and CS.close_distance > self.prev_close_distance): # distance with lead car is increasing
+        self.sng_acc_resume = True
+      self.prev_cruise_state = CS.cruise_state
+
+    if self.sng_acc_resume:
+      if self.sng_acc_resume_cnt < 5:
+        throttle_cmd = True
+        self.sng_acc_resume_cnt += 1
+      else:
+        self.sng_acc_resume = False
+        self.sng_acc_resume_cnt = -1
+
+    # Cancel ACC if stopped, brake pressed and not stopped behind another car
+    if enabled and CS.out.brakePressed and CS.car_follow == 0 and CS.out.standstill:
+      pcm_cancel_cmd = True
+
+    self.prev_close_distance = CS.close_distance
 
     # *** alerts and pcm cancel ***
 
@@ -68,6 +117,10 @@ class CarController:
         can_sends.append(subarucan.create_preglobal_es_distance(self.packer, cruise_button, CS.es_distance_msg))
         self.es_distance_cnt = CS.es_distance_msg["COUNTER"]
 
+      if self.throttle_cnt != CS.throttle_msg["COUNTER"]:
+         can_sends.append(subarucan.create_preglobal_throttle(self.packer, CS.throttle_msg, throttle_cmd))
+         self.throttle_cnt = CS.throttle_msg["COUNTER"]
+
     else:
       if self.es_distance_cnt != CS.es_distance_msg["COUNTER"]:
         can_sends.append(subarucan.create_es_distance(self.packer, CS.es_distance_msg, pcm_cancel_cmd))
@@ -76,6 +129,10 @@ class CarController:
       if self.es_lkas_cnt != CS.es_lkas_msg["COUNTER"]:
         can_sends.append(subarucan.create_es_lkas(self.packer, CS.es_lkas_msg, CC.enabled, hud_control.visualAlert, hud_control.leftLaneVisible, hud_control.rightLaneVisible, hud_control.leftLaneDepart, hud_control.rightLaneDepart))
         self.es_lkas_cnt = CS.es_lkas_msg["COUNTER"]
+
+      if self.throttle_cnt != CS.throttle_msg["COUNTER"]:
+         can_sends.append(subarucan.create_throttle(self.packer, CS.throttle_msg, throttle_cmd))
+         self.throttle_cnt = CS.throttle_msg["COUNTER"]
 
     new_actuators = actuators.copy()
     new_actuators.steer = self.apply_steer_last / self.p.STEER_MAX

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -59,8 +59,8 @@ class CarController:
       if (enabled                                            # ACC active
           and CS.car_follow == 1                             # lead car
           and CS.out.standstill                              # must be standing still
-          and CS.close_distance > 3                          # acc resume trigger threshold
-          and CS.close_distance < 4.5                        # max operating distance to filter false positives
+          and CS.close_distance > 3                          # acc resume min trigger threshold (m)
+          and CS.close_distance < 4.5                        # acc resume max trigger threshold (m)
           and CS.close_distance > self.prev_close_distance): # distance with lead car is increasing
         self.sng_acc_resume = True
     elif CS.CP.carFingerprint not in PREGLOBAL_CARS:
@@ -75,8 +75,8 @@ class CarController:
           and CS.car_follow == 1                             # lead car
           and CS.cruise_state == 3                           # ACC HOLD (only with EPB)
           and CS.out.standstill                              # must be standing still
-          and CS.close_distance > 150                        # acc resume trigger threshold
-          and CS.close_distance < 255                        # ignore max value
+          and CS.close_distance > 3                          # acc resume min trigger threshold (m)
+          and CS.close_distance < 4.5                        # acc resume max trigger threshold (m)
           and CS.close_distance > self.prev_close_distance): # distance with lead car is increasing
         self.sng_acc_resume = True
       self.prev_cruise_state = CS.cruise_state

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -56,7 +56,7 @@ class CarController:
     throttle_cmd = False
 
     if CS.CP.carFingerprint in PREGLOBAL_CARS:
-      if (enabled                                            # ACC active
+      if (c.enabled                                            # ACC active
           and CS.car_follow == 1                             # lead car
           and CS.out.standstill                              # must be standing still
           and CS.close_distance > 3                          # acc resume min trigger threshold (m)
@@ -70,7 +70,7 @@ class CarController:
       # Cancel manual hold when car starts moving
       if not CS.out.standstill:
         self.manual_hold = False
-      if (enabled                                            # ACC active
+      if (c.enabled                                            # ACC active
           and not self.manual_hold
           and CS.car_follow == 1                             # lead car
           and CS.cruise_state == 3                           # ACC HOLD (only with EPB)
@@ -90,7 +90,7 @@ class CarController:
         self.sng_acc_resume_cnt = -1
 
     # Cancel ACC if stopped, brake pressed and not stopped behind another car
-    if enabled and CS.out.brakePressed and CS.car_follow == 0 and CS.out.standstill:
+    if c.enabled and CS.out.brakePressed and CS.car_follow == 0 and CS.out.standstill:
       pcm_cancel_cmd = True
 
     self.prev_close_distance = CS.close_distance

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -118,8 +118,8 @@ class CarController:
         self.es_distance_cnt = CS.es_distance_msg["COUNTER"]
 
       if self.throttle_cnt != CS.throttle_msg["COUNTER"]:
-         can_sends.append(subarucan.create_preglobal_throttle(self.packer, CS.throttle_msg, throttle_cmd))
-         self.throttle_cnt = CS.throttle_msg["COUNTER"]
+        can_sends.append(subarucan.create_preglobal_throttle(self.packer, CS.throttle_msg, throttle_cmd))
+        self.throttle_cnt = CS.throttle_msg["COUNTER"]
 
     else:
       if self.es_distance_cnt != CS.es_distance_msg["COUNTER"]:
@@ -131,8 +131,8 @@ class CarController:
         self.es_lkas_cnt = CS.es_lkas_msg["COUNTER"]
 
       if self.throttle_cnt != CS.throttle_msg["COUNTER"]:
-         can_sends.append(subarucan.create_throttle(self.packer, CS.throttle_msg, throttle_cmd))
-         self.throttle_cnt = CS.throttle_msg["COUNTER"]
+        can_sends.append(subarucan.create_throttle(self.packer, CS.throttle_msg, throttle_cmd))
+        self.throttle_cnt = CS.throttle_msg["COUNTER"]
 
     new_actuators = actuators.copy()
     new_actuators.steer = self.apply_steer_last / self.p.STEER_MAX

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -164,17 +164,16 @@ class CarState(CarStateBase):
         ("Brake_Pedal", "Brake_Pedal"),
       ]
 
+      checks.append(("BodyInfo", 1))
       checks.append(("Dash_State2", 1))
       checks.append(("Brake_Pedal", 50))
+      checks.append(("CruiseControl", 50))
 
     if CP.carFingerprint == CAR.FORESTER_PREGLOBAL:
       checks.append(("Dashlights", 20))
-      checks.append(("BodyInfo", 1))
-      checks.append(("CruiseControl", 50))
 
     if CP.carFingerprint in (CAR.LEGACY_PREGLOBAL, CAR.OUTBACK_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018):
       checks.append(("Dashlights", 10))
-      checks.append(("CruiseControl", 50))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 0)
 

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -71,6 +71,10 @@ class CarState(CarStateBase):
       ret.steerFaultTemporary = cp.vl["Steering_Torque"]["Steer_Warning"] == 1
       ret.cruiseState.nonAdaptive = cp_cam.vl["ES_DashStatus"]["Conventional_Cruise"] == 1
       self.es_lkas_msg = copy.copy(cp_cam.vl["ES_LKAS_State"])
+      self.cruise_state = cp_cam.vl["ES_DashStatus"]["Cruise_State"]
+    self.car_follow = cp_cam.vl["ES_Distance"]["Car_Follow"]
+    self.close_distance = cp_cam.vl["ES_Distance"]["Close_Distance"]
+    self.throttle_msg = copy.copy(cp.vl["Throttle"])
     self.es_distance_msg = copy.copy(cp_cam.vl["ES_Distance"])
 
     return ret
@@ -84,7 +88,6 @@ class CarState(CarStateBase):
       ("Steer_Error_1", "Steering_Torque"),
       ("Cruise_On", "CruiseControl"),
       ("Cruise_Activated", "CruiseControl"),
-      ("Brake_Pedal", "Brake_Pedal"),
       ("Throttle_Pedal", "Throttle"),
       ("LEFT_BLINKER", "Dashlights"),
       ("RIGHT_BLINKER", "Dashlights"),
@@ -104,11 +107,9 @@ class CarState(CarStateBase):
       # sig_address, frequency
       ("Throttle", 100),
       ("Dashlights", 10),
-      ("Brake_Pedal", 50),
       ("Wheel_Speeds", 50),
       ("Transmission", 100),
       ("Steering_Torque", 50),
-      ("BodyInfo", 1),
     ]
 
     if CP.enableBsm:
@@ -122,6 +123,16 @@ class CarState(CarStateBase):
 
     if CP.carFingerprint not in PREGLOBAL_CARS:
       signals += [
+        ("Counter", "Throttle"),
+        ("Signal1", "Throttle"),
+        ("Engine_RPM", "Throttle"),
+        ("Signal2", "Throttle"),
+        ("Throttle_Pedal", "Throttle"),
+        ("Throttle_Cruise", "Throttle"),
+        ("Throttle_Combo", "Throttle"),
+        ("Signal1", "Throttle"),
+        ("Off_Accel", "Throttle"),
+
         ("Steer_Warning", "Steering_Torque"),
         ("Brake", "Brake_Status"),
         ("UNITS", "Dashlights"),
@@ -134,22 +145,36 @@ class CarState(CarStateBase):
         ("CruiseControl", 20),
       ]
     else:
-      signals.append(("UNITS", "Dash_State2"))
+      signals += [
+        ("Throttle_Pedal", "Throttle"),
+        ("Counter", "Throttle"),
+        ("Signal1", "Throttle"),
+        ("Not_Full_Throttle", "Throttle"),
+        ("Signal2", "Throttle"),
+        ("Engine_RPM", "Throttle"),
+        ("Off_Throttle", "Throttle"),
+        ("Signal3", "Throttle"),
+        ("Throttle_Cruise", "Throttle"),
+        ("Throttle_Combo", "Throttle"),
+        ("Throttle_Body", "Throttle"),
+        ("Off_Throttle_2", "Throttle"),
+        ("Signal4", "Throttle"),
+
+        ("UNITS", "Dash_State2"),
+        ("Brake_Pedal", "Brake_Pedal"),
+      ]
 
       checks.append(("Dash_State2", 1))
+      checks.append(("Brake_Pedal", 50))
 
     if CP.carFingerprint == CAR.FORESTER_PREGLOBAL:
-      checks += [
-        ("Dashlights", 20),
-        ("BodyInfo", 1),
-        ("CruiseControl", 50),
-      ]
+      checks.append(("Dashlights", 20))
+      checks.append(("BodyInfo", 1))
+      checks.append(("CruiseControl", 50))
 
     if CP.carFingerprint in (CAR.LEGACY_PREGLOBAL, CAR.OUTBACK_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018):
-      checks += [
-        ("Dashlights", 10),
-        ("CruiseControl", 50),
-      ]
+      checks.append(("Dashlights", 10))
+      checks.append(("CruiseControl", 50))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 0)
 
@@ -187,6 +212,7 @@ class CarState(CarStateBase):
       signals = [
         ("Cruise_Set_Speed", "ES_DashStatus"),
         ("Conventional_Cruise", "ES_DashStatus"),
+        ("Cruise_State", "ES_DashStatus"),
 
         ("COUNTER", "ES_Distance"),
         ("Signal1", "ES_Distance"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -123,7 +123,7 @@ class CarState(CarStateBase):
 
     if CP.carFingerprint not in PREGLOBAL_CARS:
       signals += [
-        ("Counter", "Throttle"),
+        ("COUNTER", "Throttle"),
         ("Signal1", "Throttle"),
         ("Engine_RPM", "Throttle"),
         ("Signal2", "Throttle"),
@@ -147,7 +147,7 @@ class CarState(CarStateBase):
     else:
       signals += [
         ("Throttle_Pedal", "Throttle"),
-        ("Counter", "Throttle"),
+        ("COUNTER", "Throttle"),
         ("Signal1", "Throttle"),
         ("Not_Full_Throttle", "Throttle"),
         ("Signal2", "Throttle"),

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -60,6 +60,15 @@ def create_es_lkas(packer, es_lkas_msg, enabled, visual_alert, left_line, right_
 
   return packer.make_can_msg("ES_LKAS_State", 0, values)
 
+def create_throttle(packer, throttle_msg, throttle_cmd):
+
+  values = copy.copy(throttle_msg)
+  if throttle_cmd:
+    values["Throttle_Pedal"] = 5
+
+  return packer.make_can_msg("Throttle", 2, values)
+
+
 # *** Subaru Pre-global ***
 
 def subaru_preglobal_checksum(packer, values, addr):
@@ -86,3 +95,13 @@ def create_preglobal_es_distance(packer, cruise_button, es_distance_msg):
   values["Checksum"] = subaru_preglobal_checksum(packer, values, "ES_Distance")
 
   return packer.make_can_msg("ES_Distance", 0, values)
+
+def create_preglobal_throttle(packer, throttle_msg, throttle_cmd):
+
+  values = copy.copy(throttle_msg)
+  if throttle_cmd:
+    values["Throttle_Pedal"] = 5
+
+  values["Checksum"] = subaru_preglobal_checksum(packer, values, "Throttle")
+
+  return packer.make_can_msg("Throttle", 2, values)


### PR DESCRIPTION
***** Template: Refactor *****

**Description**
Subaru Stop and Go support for both global and preglobal models (for initial review).

Subaru stock ACC stops behind stopped cars but does not resume automatically. We send Throttle:Throttle_Pedal signal from openpilot to ACC when car in front starts moving to resume from ACC Hold state (mimicking stock ACC resume using gas press behaviour). It works for cars with electric parking brake and does not change stock ACC behaviour for cars with manual parking brake (which disengage 3 seconds after stopping).

For Global models, we also allow setting ACC hold manually when stopped with no lead car (eg at intersection/traffic light) and resume from manual hold only using ACC resume button press, same as stock ACC behaviour.

We tried to resume by sending ACC resume button press signals but that did not work since ACC buttons are directly wired to Eyesight and not accepted as input from CAN messages.

Prerequisites:
- https://github.com/commaai/opendbc/pull/474
- https://github.com/commaai/panda/pull/794
- https://github.com/commaai/openpilot/pull/23024
- https://github.com/commaai/opendbc/pull/604

**Verification**
Subaru SNG implementation has been tested for several months in subaru-community branch. I will submit sample routes once this is ready to merge

Credit for initial implementation: @letsdudiss1