### PR TITLE
UI minor changes to make it translation friendly

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -178,6 +178,6 @@ void OffroadHome::refresh() {
   update_notif->setVisible(updateAvailable);
   alert_notif->setVisible(alerts);
   if (alerts) {
-    alert_notif->setText(QString::number(alerts) + " ALERT" + (alerts > 1 ? "S" : ""));
+    alert_notif->setText(QString::number(alerts) + (alerts > 1 ? " ALERTS" : " ALERT"));
   }
 }

--- a/selfdrive/ui/qt/offroad/onboarding.cc
+++ b/selfdrive/ui/qt/offroad/onboarding.cc
@@ -145,7 +145,7 @@ void DeclinePage::showEvent(QShowEvent *event) {
 
   QObject::connect(back_btn, &QPushButton::clicked, this, &DeclinePage::getBack);
 
-  QPushButton *uninstall_btn = new QPushButton("Decline, uninstall " + getBrand());
+  QPushButton *uninstall_btn = new QPushButton(QString("Decline, uninstall %1").arg(getBrand()));
   uninstall_btn->setStyleSheet("background-color: #B73D3D");
   buttons->addWidget(uninstall_btn);
   QObject::connect(uninstall_btn, &QPushButton::clicked, [=]() {

--- a/selfdrive/ui/qt/widgets/ssh_keys.cc
+++ b/selfdrive/ui/qt/widgets/ssh_keys.cc
@@ -46,13 +46,13 @@ void SshControl::getUserKeys(const QString &username) {
       params.put("GithubUsername", username.toStdString());
       params.put("GithubSshKeys", resp.toStdString());
     } else {
-      ConfirmationDialog::alert("Username '" + username + "' has no keys on GitHub", this);
+      ConfirmationDialog::alert(QString("Username '%1' has no keys on GitHub").arg(username), this);
     }
     refresh();
     request->deleteLater();
   });
   QObject::connect(request, &HttpRequest::failedResponse, [=] {
-    ConfirmationDialog::alert("Username '" + username + "' doesn't exist on GitHub", this);
+    ConfirmationDialog::alert(QString("Username '%1' doesn't exist on GitHub").arg(username), this);
     refresh();
     request->deleteLater();
   });


### PR DESCRIPTION
* SshControl - add a button state instead of text() to check it's status, so we can safely translate "ADD", "REMOVE", "LOADING"
* having "ALERT" and "ALERTS" as 2 string instead of appending "S".