### PR TITLE
keyboard: replace backtick with apostrophe

### DIFF
--- a/selfdrive/ui/qt/widgets/keyboard.cc
+++ b/selfdrive/ui/qt/widgets/keyboard.cc
@@ -126,7 +126,7 @@ Keyboard::Keyboard(QWidget *parent) : QFrame(parent) {
   std::vector<QVector<QString>> specials = {
     {"[","]","{","}","#","%","^","*","+","="},
     {"_","\\","|","~","<",">","€","£","¥","•"},
-    {"123",".",",","?","!","`",BACKSPACE_KEY},
+    {"123","'",",","?","!","`",BACKSPACE_KEY},
     {"ABC","  ",".",ENTER_KEY},
   };
   main_layout->addWidget(new KeyboardLayout(this, specials));

--- a/selfdrive/ui/qt/widgets/keyboard.cc
+++ b/selfdrive/ui/qt/widgets/keyboard.cc
@@ -126,7 +126,7 @@ Keyboard::Keyboard(QWidget *parent) : QFrame(parent) {
   std::vector<QVector<QString>> specials = {
     {"[","]","{","}","#","%","^","*","+","="},
     {"_","\\","|","~","<",">","€","£","¥","•"},
-    {"123","'",",","?","!","`",BACKSPACE_KEY},
+    {"123",".",",","?","!","'",BACKSPACE_KEY},
     {"ABC","  ",".",ENTER_KEY},
   };
   main_layout->addWidget(new KeyboardLayout(this, specials));


### PR DESCRIPTION
Without `'`, I cannot type my WiFi password... though it might be time
to rotate it. This replaces a repeated period (`.`) with an apostrophe.

**Description** 
Apostrophe is missing from the layers of the qt keyboard. This was noticed when trying to type in a WiFi password.

**Verification**
No testing has been done on this patch.
Can test once the sim docker image is built, and I can build the source locally.