### PR TITLE
Toyota: Display Blue Barriers When Engaged, Matches OEM Design

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -120,7 +120,7 @@ class CarController():
       send_ui = True
 
     if (frame % 100 == 0 or send_ui):
-      can_sends.append(create_ui_command(self.packer, steer_alert, pcm_cancel_cmd, left_line, right_line, left_lane_depart, right_lane_depart))
+      can_sends.append(create_ui_command(self.packer, steer_alert, pcm_cancel_cmd, left_line, right_line, left_lane_depart, right_lane_depart, enabled))
 
     if frame % 100 == 0 and CS.CP.enableDsu:
       can_sends.append(create_fcw_command(self.packer, fcw_alert))

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -67,11 +67,11 @@ def create_fcw_command(packer, fcw):
   return packer.make_can_msg("ACC_HUD", 0, values)
 
 
-def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_depart, right_lane_depart):
+def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_depart, right_lane_depart, enabled):
   values = {
     "RIGHT_LINE": 3 if right_lane_depart else 1 if right_line else 2,
     "LEFT_LINE": 3 if left_lane_depart else 1 if left_line else 2,
-    "BARRIERS" : 3 if left_lane_depart else 2 if right_lane_depart else 0,
+    "BARRIERS" : 1 if enabled else 0,
     "SET_ME_X0C": 0x0c,
     "SET_ME_X2C": 0x2c,
     "SET_ME_X38": 0x38,


### PR DESCRIPTION
**Description** The Toyota OEM system displays the blue barriers whenever it is contributing to steering.  So when the LKAS system is engaged it looks like this:

![PXL_20211021_163532657-3](https://user-images.githubusercontent.com/3046315/144931027-7a7c0a92-f819-4552-b7a7-bdd40bf7b80f.jpg)

Whereas currently when OP is engaged the blue barriers are not present.

This PR changes the `barriers` value based on the engaged state of OP in the LKAS_HUD can message. So that OP matches the OEM system.

*Note* 
The original code linked the blue barrier with lane departure warnings which doesn't match the OEM system.  In the OEM system a single blue barrier is only used with lane departure + steering assist, in other words when the car is contributing to steering.  If you depart the lane at an angle steeper than what steering assist will work on, then no blue barrier is displayed only the orange lane marker.

Since the OP lane departure warnings do not include steering assist, a single blue barrier does not need to be displayed ever.  The Orange lane markers are still displayed as part of the lane departure warnings.

**Verification** I used the OEM system with OP disabled and monitored how the HUD display changed when the LKAS system was engaged and not.  I then ran this commit on my device with OP engaged and verified that it displayed the same HUD contents when OP was engaged.

**Route**
Route:  d50727925674b294|2021-12-06--16-38-13


