### PR TITLE
DevicePanel: fix dangling reference to params

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -105,8 +105,6 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
 }
 
 DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
-  Params params = Params();
-
   setSpacing(50);
   addItem(new LabelControl("Dongle ID", getDongleId().value_or("N/A")));
   addItem(new LabelControl("Serial", params.get("HardwareSerial").c_str()));

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -47,6 +47,9 @@ private slots:
   void poweroff();
   void reboot();
   void updateCalibDescription();
+
+private:
+  Params params;
 };
 
 class TogglesPanel : public ListWidget {


### PR DESCRIPTION
params in lambda is a dangling reference
https://github.com/commaai/openpilot/blob/2e0c73fc0cbac64e442085390dd22e6b408d0478/selfdrive/ui/qt/offroad/settings.cc#L123-L127