### PR TITLE
add missing optional ref back to ui.h (fix Ubuntu 21.10 build)

### DIFF
--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <optional>
 
 #include <QObject>
 #include <QTimer>


### PR DESCRIPTION

**Description** [](Build broken in ubuntu 21.10; reference to optional removed from ui.h in commit 20f571db3c37c6d009ca3d9a646874769aa07acd)

**Verification** [](Added the line, tested that build now succeeds)
![Screenshot from 2021-12-07 16-24-11](https://user-images.githubusercontent.com/29778397/145110316-8f978a32-9a22-429f-bc15-9b14a107298f.png)

