### PR TITLE
commonmodel.h: move global model size into class ModelFrame

### DIFF
--- a/selfdrive/modeld/models/commonmodel.h
+++ b/selfdrive/modeld/models/commonmodel.h
@@ -16,10 +16,6 @@
 #include "selfdrive/modeld/transforms/loadyuv.h"
 #include "selfdrive/modeld/transforms/transform.h"
 
-constexpr int MODEL_WIDTH = 512;
-constexpr int MODEL_HEIGHT = 256;
-constexpr int MODEL_FRAME_SIZE = MODEL_WIDTH * MODEL_HEIGHT * 3 / 2;
-
 const bool send_raw_pred = getenv("SEND_RAW_PRED") != NULL;
 
 void softmax(const float* input, float* output, size_t len);
@@ -27,14 +23,17 @@ float softplus(float input);
 float sigmoid(float input);
 
 class ModelFrame {
- public:
+public:
   ModelFrame(cl_device_id device_id, cl_context context);
   ~ModelFrame();
   float* prepare(cl_mem yuv_cl, int width, int height, const mat3& transform, cl_mem *output);
 
+  const int MODEL_WIDTH = 512;
+  const int MODEL_HEIGHT = 256;
+  const int MODEL_FRAME_SIZE = MODEL_WIDTH * MODEL_HEIGHT * 3 / 2;
   const int buf_size = MODEL_FRAME_SIZE * 2;
 
- private:
+private:
   Transform transform;
   LoadYUVState loadyuv;
   cl_command_queue q;

--- a/selfdrive/modeld/models/dmonitoring.cc
+++ b/selfdrive/modeld/models/dmonitoring.cc
@@ -10,9 +10,8 @@
 
 #include "selfdrive/modeld/models/dmonitoring.h"
 
-#define MODEL_WIDTH 320
-#define MODEL_HEIGHT 640
-#define FULL_W 852 // should get these numbers from camerad
+constexpr int MODEL_WIDTH = 320;
+constexpr int MODEL_HEIGHT = 640;
 
 template <class T>
 static inline T *get_buffer(std::vector<T> &buf, const size_t size) {


### PR DESCRIPTION
the global MODEL_WIDTH & MODEL_HEIGHT in commonmodel.h has been shadowed by macros in dmonitoring.cc
https://github.com/commaai/openpilot/blob/321b08a0e92a01cb2d375ada9c0a50df4b024b01/selfdrive/modeld/models/dmonitoring.cc#L13-L14