### PR TITLE
put logcat in bootlog

### DIFF
--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -14,8 +14,10 @@ int main() {
   ExitHandler do_exit;
   PubMaster pm({"androidLog"});
 
-  log_time last_log_time = {};
-  logger_list *logger_list = android_logger_list_alloc(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, 0, 0);
+  struct timespec cur_time;
+  clock_gettime(CLOCK_REALTIME, &cur_time);
+  log_time last_log_time(cur_time);
+  logger_list *logger_list = nullptr;
 
   while (!do_exit) {
     // setup android logging

--- a/selfdrive/logcatd/logcatd_android.cc
+++ b/selfdrive/logcatd/logcatd_android.cc
@@ -1,8 +1,6 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
-#include <memory>
-
 #include <android/log.h>
 #include <log/logger.h>
 #include <log/logprint.h>
@@ -19,28 +17,29 @@ int main() {
   struct timespec cur_time;
   clock_gettime(CLOCK_REALTIME, &cur_time);
   log_time last_log_time(cur_time);
+  logger_list *logger_list = nullptr;
 
   while (!do_exit) {
     // setup android logging
-    std::unique_ptr<logger_list, decltype(&android_logger_list_free)> logger_list(
-        android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0),
-        &android_logger_list_free);
+    if (!logger_list) {
+      logger_list = android_logger_list_alloc_time(ANDROID_LOG_RDONLY | ANDROID_LOG_NONBLOCK, last_log_time, 0);
+    }
     assert(logger_list);
 
-    struct logger *main_logger = android_logger_open(logger_list.get(), LOG_ID_MAIN);
+    struct logger *main_logger = android_logger_open(logger_list, LOG_ID_MAIN);
     assert(main_logger);
-    struct logger *radio_logger = android_logger_open(logger_list.get(), LOG_ID_RADIO);
+    struct logger *radio_logger = android_logger_open(logger_list, LOG_ID_RADIO);
     assert(radio_logger);
-    struct logger *system_logger = android_logger_open(logger_list.get(), LOG_ID_SYSTEM);
+    struct logger *system_logger = android_logger_open(logger_list, LOG_ID_SYSTEM);
     assert(system_logger);
-    struct logger *crash_logger = android_logger_open(logger_list.get(), LOG_ID_CRASH);
+    struct logger *crash_logger = android_logger_open(logger_list, LOG_ID_CRASH);
     assert(crash_logger);
-    struct logger *kernel_logger = android_logger_open(logger_list.get(), (log_id_t)5); // LOG_ID_KERNEL
+    struct logger *kernel_logger = android_logger_open(logger_list, (log_id_t)5); // LOG_ID_KERNEL
     assert(kernel_logger);
 
     while (!do_exit) {
       log_msg log_msg;
-      int err = android_logger_list_read(logger_list.get(), &log_msg);
+      int err = android_logger_list_read(logger_list, &log_msg);
       if (err <= 0) break;
 
       AndroidLogEntry entry;
@@ -62,7 +61,13 @@ int main() {
       pm.send("androidLog", msg);
     }
 
+    android_logger_list_free(logger_list);
+    logger_list = NULL;
     util::sleep_for(500);
+  }
+
+  if (logger_list) {
+    android_logger_list_free(logger_list);
   }
 
   return 0;

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -11,6 +11,8 @@ static kj::Array<capnp::word> build_boot_log() {
   if (Hardware::TICI()) {
     bootlog_commands.push_back("journalctl");
     bootlog_commands.push_back("sudo nvme smart-log --output-format=json /dev/nvme0");
+  } else if(Hardware::EON()) {
+    bootlog_commands.push_back("logcat");
   }
 
   MessageBuilder msg;

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -11,8 +11,8 @@ static kj::Array<capnp::word> build_boot_log() {
   if (Hardware::TICI()) {
     bootlog_commands.push_back("journalctl");
     bootlog_commands.push_back("sudo nvme smart-log --output-format=json /dev/nvme0");
-  } else if(Hardware::EON()) {
-    bootlog_commands.push_back("logcat");
+  } else if (Hardware::EON()) {
+    bootlog_commands.push_back("logcat -d");
   }
 
   MessageBuilder msg;


### PR DESCRIPTION
Thousands of logs will be pushed every time logcatd is started. It may be better to put the system logs at startup in the bootlog

1. put system logs in bootlog
2. only log the latest messages to androidLog