### PR TITLE
Calibrationd: check size of valid_blocks without current

### DIFF
--- a/selfdrive/locationd/calibrationd.py
+++ b/selfdrive/locationd/calibrationd.py
@@ -106,7 +106,7 @@ class Calibrator():
     return before_current + after_current
 
   def update_status(self):
-    if self.valid_blocks > 0:
+    if len(self.get_valid_idxs()) > 0:
       max_rpy_calib = np.array(np.max(self.rpys[self.get_valid_idxs()], axis=0))
       min_rpy_calib = np.array(np.min(self.rpys[self.get_valid_idxs()], axis=0))
       self.calib_spread = np.abs(max_rpy_calib - min_rpy_calib)
@@ -163,7 +163,7 @@ class Calibrator():
       self.block_idx += 1
       self.valid_blocks = max(self.block_idx, self.valid_blocks)
       self.block_idx = self.block_idx % INPUTS_WANTED
-    if self.valid_blocks > 0:
+    if len(self.get_valid_idxs()) > 0:
       self.rpy = np.mean(self.rpys[self.get_valid_idxs()], axis=0)
 
     self.update_status()


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
