### PR TITLE
replay: Add next engagement / disengagement jump capabilities

### DIFF
--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -69,6 +69,10 @@ void keyboardThread(Replay *replay_) {
       replay_->seekTo(-10, true);
     } else if (c == 'G') {
       replay_->seekTo(0, true);
+    } else if (c == 'e') {
+      replay_->seekToFlag(FindFlag::nextEngagement);
+    } else if (c == 'd') {
+      replay_->seekToFlag(FindFlag::nextDisEngagement);
     } else if (c == ' ') {
       replay_->pause(!replay_->isPaused());
     }

--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -59,6 +59,10 @@ void keyboardThread(Replay *replay_) {
         qDebug() << "invalid argument";
       }
       getch();  // remove \n from entering seek
+    } else if (c == 'e') {
+      replay_->seekToFlag(FindFlag::nextEngagement);
+    } else if (c == 'd') {
+      replay_->seekToFlag(FindFlag::nextDisEngagement);
     } else if (c == 'm') {
       replay_->seekTo(+60, true);
     } else if (c == 'M') {
@@ -69,10 +73,6 @@ void keyboardThread(Replay *replay_) {
       replay_->seekTo(-10, true);
     } else if (c == 'G') {
       replay_->seekTo(0, true);
-    } else if (c == 'e') {
-      replay_->seekToFlag(FindFlag::nextEngagement);
-    } else if (c == 'd') {
-      replay_->seekToFlag(FindFlag::nextDisEngagement);
     } else if (c == ' ') {
       replay_->pause(!replay_->isPaused());
     }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -115,14 +115,22 @@ void Replay::doSeek(int seconds, bool relative) {
 
 void Replay::doSeekToFlag(FindFlag flag) {
   if (flag == FindFlag::nextEngagement) {
-    qInfo() << "seeking to the next engagement...";  
+    qInfo() << "seeking to the next engagement...";
   } else if (flag == FindFlag::nextDisEngagement) {
-    qInfo() << "seeking to the disengagement...";  
+    qInfo() << "seeking to the disengagement...";
   }
 
   updateEvents([&]() {
     if (auto next = find(flag)) {
-      cur_mono_time_ = *next - 2 * 1e9; // seek to 2 seconds before next;
+      uint64_t tm = *next - 2 * 1e9;  // seek to 2 seconds before next
+      if (tm <= cur_mono_time_) {
+        if (flag == FindFlag::nextEngagement) {
+          qInfo() << "already in engagement";
+        }
+        return true;
+      }
+
+      cur_mono_time_ = tm;
       current_segment_ = currentSeconds() / 60;
       return isSegmentMerged(current_segment_);
     } else {

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -151,15 +151,15 @@ std::optional<uint64_t> Replay::find(FindFlag flag) {
     bool cache_to_local = true;  // cache qlog to local for fast seek
     if (!log.load(route_->at(n).qlog.toStdString(), nullptr, cache_to_local, 0, 3)) continue;
 
-    for (const Event *evt : log.events) {
-      if (evt->mono_time > cur_mono_time_) {
+    for (const Event *e : log.events) {
+      if (e->mono_time > cur_mono_time_) {
         if (flag == FindFlag::nextEngagement) {
-          if (evt->which == cereal::Event::Which::CONTROLS_STATE && evt->event.getControlsState().getEnabled()) {
-            return evt->mono_time;
+          if (e->which == cereal::Event::Which::CONTROLS_STATE && e->event.getControlsState().getEnabled()) {
+            return e->mono_time;
           }
         } else if (flag == FindFlag::nextDisEngagement) {
-          if (evt->which == cereal::Event::Which::CONTROLS_STATE && !evt->event.getControlsState().getEnabled()) {
-            return evt->mono_time;
+          if (e->which == cereal::Event::Which::CONTROLS_STATE && !e->event.getControlsState().getEnabled()) {
+            return e->mono_time;
           }
         }
       }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -122,12 +122,7 @@ void Replay::doSeekToFlag(FindFlag flag) {
 
   updateEvents([&]() {
     if (auto next = find(flag)) {
-      double tm = *next - 2 * 1e9; // seek to 2 seconds before next
-      if (tm <= cur_mono_time_ && flag == FindFlag::nextEngagement) {
-        qInfo() << "already in engagement";
-      }
-
-      cur_mono_time_ = tm;
+      cur_mono_time_ = *next - 2 * 1e9; // seek to 2 seconds before next;
       current_segment_ = currentSeconds() / 60;
       return isSegmentMerged(current_segment_);
     } else {

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -144,14 +144,14 @@ void Replay::doSeekToFlag(FindFlag flag) {
 
 std::optional<uint64_t> Replay::find(FindFlag flag) {
   // Search in all segments
-  for (auto &[n, _] : segments_) {
+  for (const auto &[n, _] : segments_) {
     if (n < current_segment_) continue;
 
     LogReader log;
-    bool cache_to_local = true; // cache qlog to local for fast seek
+    bool cache_to_local = true;  // cache qlog to local for fast seek
     if (!log.load(route_->at(n).qlog.toStdString(), nullptr, cache_to_local, 0, 3)) continue;
 
-    for (auto evt : log.events) {
+    for (const Event *evt : log.events) {
       if (evt->mono_time > cur_mono_time_) {
         if (flag == FindFlag::nextEngagement) {
           if (evt->which == cereal::Event::Which::CONTROLS_STATE && evt->event.getControlsState().getEnabled()) {

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -115,9 +115,9 @@ void Replay::doSeek(int seconds, bool relative) {
 
 void Replay::doSeekToFlag(FindFlag flag) {
   if (flag == FindFlag::nextEngagement) {
-    qInfo() << "seeking to next engagement...";  
+    qInfo() << "seeking to the next engagement...";  
   } else {
-    qInfo() << "seeking to next disengagement...";  
+    qInfo() << "seeking to the disengagement...";  
   }
 
   updateEvents([&]() {
@@ -135,21 +135,21 @@ void Replay::doSeekToFlag(FindFlag flag) {
 }
 
 std::optional<uint64_t> Replay::find(FindFlag flag) {
-  for (auto &[n, seg] : segments_) {
+  for (auto &[n, _] : segments_) {
     if (n < current_segment_) continue;
 
     LogReader log;
-    if (log.load(route_->at(n).qlog.toStdString(), nullptr, true, 0, 3)) {
-      for (auto evt : log.events) {
-        if (evt->mono_time > cur_mono_time_) {
-          if (flag == FindFlag::nextEngagement) {
-            if (evt->which == cereal::Event::Which::CONTROLS_STATE && evt->event.getControlsState().getEnabled()) {
-              return evt->mono_time - 2 * 1e9;
-            }
-          } else if (flag == FindFlag::nextDisEngagement) {
-            if (evt->which == cereal::Event::Which::CONTROLS_STATE && !evt->event.getControlsState().getEnabled()) {
-              return evt->mono_time - 2 * 1e9;
-            }
+    if (!log.load(route_->at(n).qlog.toStdString(), nullptr, true, 0, 3)) continue;
+
+    for (auto evt : log.events) {
+      if (evt->mono_time > cur_mono_time_) {
+        if (flag == FindFlag::nextEngagement) {
+          if (evt->which == cereal::Event::Which::CONTROLS_STATE && evt->event.getControlsState().getEnabled()) {
+            return evt->mono_time - 2 * 1e9;
+          }
+        } else if (flag == FindFlag::nextDisEngagement) {
+          if (evt->which == cereal::Event::Which::CONTROLS_STATE && !evt->event.getControlsState().getEnabled()) {
+            return evt->mono_time - 2 * 1e9;
           }
         }
       }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -158,9 +158,6 @@ std::optional<uint64_t> Replay::find(FindFlag flag) {
   return std::nullopt;
 }
 
-void Replay::nextDisengagement() {
-}
-
 void Replay::pause(bool pause) {
   updateEvents([=]() {
     qInfo() << (pause ? "paused..." : "resuming");

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -116,7 +116,7 @@ void Replay::doSeek(int seconds, bool relative) {
 void Replay::doSeekToFlag(FindFlag flag) {
   if (flag == FindFlag::nextEngagement) {
     qInfo() << "seeking to the next engagement...";  
-  } else if (flag == FindFlag::nextEngagement) {
+  } else if (flag == FindFlag::nextDisEngagement) {
     qInfo() << "seeking to the disengagement...";  
   }
 

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -36,8 +36,6 @@ public:
   void stop();
   void pause(bool pause);
   bool isPaused() const { return paused_; }
-  void nextEngagement();
-  void nextDisengagement();
 
 signals:
   void segmentChanged();

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -19,6 +19,11 @@ enum REPLAY_FLAGS {
   REPLAY_FLAG_NO_CUDA = 0x0100,
 };
 
+enum class FindFlag {
+  nextEngagement,
+  nextDisEngagement
+};
+
 class Replay : public QObject {
   Q_OBJECT
 
@@ -31,18 +36,23 @@ public:
   void stop();
   void pause(bool pause);
   bool isPaused() const { return paused_; }
+  void nextEngagement();
+  void nextDisengagement();
 
 signals:
   void segmentChanged();
   void seekTo(int seconds, bool relative);
+  void seekToFlag(FindFlag flag);
 
 protected slots:
   void queueSegment();
   void doSeek(int seconds, bool relative);
+  void doSeekToFlag(FindFlag flag);
   void segmentLoadFinished(bool sucess);
 
 protected:
   typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;
+  std::optional<uint64_t> find(FindFlag flag);
   void startStream(const Segment *cur_segment);
   void stream();
   void setCurrentSegment(int n);


### PR DESCRIPTION
use qlogs to do a quick search for the next engagement/disengagement  in route. resolve https://github.com/commaai/openpilot/issues/23242
`e `- seek to 2 seconds before the next engagement
`d` - seek to 2 secconds before the disengagement 