### PR TITLE
C2: add button to launch wifi settings in text window

### DIFF
--- a/selfdrive/ui/qt/text.cc
+++ b/selfdrive/ui/qt/text.cc
@@ -2,6 +2,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QScrollBar>
+#include <QSet>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -55,7 +56,7 @@ int main(int argc, char *argv[]) {
   if (!Hardware::PC()) {
 #ifdef QCOM
     QPushButton *wifiBtn = new QPushButton("Wi-Fi Settings");
-    QObject::connect(wifiBtn, &ButtonControl::clicked, []() { 
+    QObject::connect(wifiBtn, &QPushButton::clicked, []() { 
       HardwareEon::launch_wifi(); 
     });
     button_layout->addWidget(wifiBtn);

--- a/selfdrive/ui/qt/text.cc
+++ b/selfdrive/ui/qt/text.cc
@@ -31,17 +31,26 @@ int main(int argc, char *argv[]) {
     scroll->verticalScrollBar()->setValue(scroll->verticalScrollBar()->maximum());
   });
 
-  QPushButton *btn = new QPushButton();
-#ifdef __aarch64__
-  btn->setText("Reboot");
-  QObject::connect(btn, &QPushButton::clicked, [=]() {
-    Hardware::reboot();
-  });
-#else
-  btn->setText("Exit");
-  QObject::connect(btn, &QPushButton::clicked, &a, &QApplication::quit);
+  QHBoxLayout *button_layout = new QHBoxLayout();
+  if (!Hardware::PC()) {
+#ifdef QCOM
+    QPushButton *wifiBtn = new QPushButton("Wi-Fi Settings");
+    QObject::connect(wifiBtn, &ButtonControl::clicked, [=]() { 
+      HardwareEon::launch_wifi(); 
+    });
+    button_layout->addWidget(wifiBtn);
 #endif
-  main_layout->addWidget(btn, 0, 0, Qt::AlignRight | Qt::AlignBottom);
+    QPushButton *btn = new QPushButton("Reboot");
+    QObject::connect(btn, &QPushButton::clicked, [=]() {
+      Hardware::reboot();
+    });
+    button_layout->addWidget(btn);
+  } else {
+    QPushButton *btn = new QPushButton("Exit");
+    QObject::connect(btn, &QPushButton::clicked, &a, &QApplication::quit);
+    button_layout->addWidget(btn);
+  }
+  main_layout->addLayout(button_layout, 0, 0, Qt::AlignRight | Qt::AlignBottom);
 
   window.setStyleSheet(R"(
     * {


### PR DESCRIPTION
If there is a startup error and the Wifi is not automatically connected, the only way to ssh to the C2 is re-flash the device, and run setup again