### PR TITLE
GM: Switch to AcceleratorPedal2

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -36,7 +36,7 @@ class CarState(CarStateBase):
     if ret.brake < 10/0xd0:
       ret.brake = 0.
 
-    ret.gas = pt_cp.vl["AcceleratorPedal"]["AcceleratorPedal"] / 254.
+    ret.gas = pt_cp.vl["AcceleratorPedal2"]["AcceleratorPedal2"] / 254.
     ret.gasPressed = ret.gas > 1e-5
 
     ret.steeringAngleDeg = pt_cp.vl["PSCMSteeringAngle"]["SteeringWheelAngle"]
@@ -90,7 +90,7 @@ class CarState(CarStateBase):
       ("LeftSeatBelt", "BCMDoorBeltStatus", 0),
       ("RightSeatBelt", "BCMDoorBeltStatus", 0),
       ("TurnSignals", "BCMTurnSignals", 0),
-      ("AcceleratorPedal", "AcceleratorPedal", 0),
+      ("AcceleratorPedal2", "AcceleratorPedal2", 0),
       ("CruiseState", "AcceleratorPedal2", 0),
       ("ACCButtons", "ASCMSteeringButton", CruiseButtons.UNPRESS),
       ("SteeringWheelAngle", "PSCMSteeringAngle", 0),
@@ -117,7 +117,6 @@ class CarState(CarStateBase):
       ("EPBStatus", 20),
       ("EBCMWheelSpdFront", 20),
       ("EBCMWheelSpdRear", 20),
-      ("AcceleratorPedal", 33),
       ("AcceleratorPedal2", 33),
       ("ASCMSteeringButton", 33),
       ("ECMEngineStatus", 100),


### PR DESCRIPTION
**Description** [] Update carstate to use AcceleratorPedal2 for gas and remove the requirement for AcceleratorPedal. The Pedal value in the two messages is identical, but AcceleratorPedal is not present on the 2020 Silverado.

**Verification** [] Has been running without issue on several vehicles. I also checked all the fingerprints to confirm that if 417 is present, 452 is also -- meaning it is unlikely to cause any problems. passes testing.

Pairs with Panda PR https://github.com/commaai/panda/pull/813