### PR TITLE
ui/map:  manually call map::offroadTransition after creating the map

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -79,6 +79,7 @@ void OnroadWindow::offroadTransition(bool offroad) {
     if (map == nullptr && (uiState()->has_prime || !MAPBOX_TOKEN.isEmpty())) {
       MapWindow * m = new MapWindow(get_mapbox_settings());
       m->setFixedWidth(topWidget(this)->width() / 2);
+      m->offroadTransition(offroad);
       QObject::connect(uiState(), &UIState::offroadTransition, m, &MapWindow::offroadTransition);
       split->addWidget(m, 0, Qt::AlignRight);
       map = m;


### PR DESCRIPTION
Manually call `map::offroadTransition` after creating the map to fix https://github.com/commaai/openpilot/issues/23281

The map is created  after `uiState` emitted signal `offroadTransition`.  the `map::offroadTransition` will not be triggered at this time, and the map will be displayed by default.