### PR TITLE
painter opacity should be reset in OnroadHud::drawIcon to prevent wro…

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -258,6 +258,7 @@ void OnroadHud::drawIcon(QPainter &p, int x, int y, QPixmap &img, QBrush bg, flo
   p.drawEllipse(x - radius / 2, y - radius / 2, radius, radius);
   p.setOpacity(opacity);
   p.drawPixmap(x - img_size / 2, y - img_size / 2, img);
+  p.setOpacity(1.0);
 }
 
 // NvgWindow


### PR DESCRIPTION
painter opacity should be reset in `OnroadHud::drawIcon` to prevent wrong opacity in future painter operations
