### PR TITLE
logcatd: fix sd_journal_seek_tail doesn't go to end

### DIFF
--- a/selfdrive/logcatd/logcatd_systemd.cc
+++ b/selfdrive/logcatd/logcatd_systemd.cc
@@ -23,6 +23,7 @@ int main(int argc, char *argv[]) {
   assert(err >= 0);
   err = sd_journal_seek_tail(journal);
   assert(err >= 0);
+  sd_journal_previous_skip(journal, 1);
 
   while (!do_exit) {
     err = sd_journal_next(journal);

--- a/selfdrive/logcatd/logcatd_systemd.cc
+++ b/selfdrive/logcatd/logcatd_systemd.cc
@@ -23,6 +23,9 @@ int main(int argc, char *argv[]) {
   assert(err >= 0);
   err = sd_journal_seek_tail(journal);
   assert(err >= 0);
+
+  // workaround for bug https://github.com/systemd/systemd/issues/9934
+  // call sd_journal_previous_skip after sd_journal_seek_tail (like journalctl -f does) to makes things work.
   sd_journal_previous_skip(journal, 1);
 
   while (!do_exit) {


### PR DESCRIPTION
Workaround for bug https://github.com/systemd/systemd/issues/9934,  we may get dozens or hundreds of old log messages due to this bug.

invoke `sd_journal_previous_skip (journal, 1)`  after `sd_journal_seek_tail` (like journalctl -f does) to makes things work.