### PR TITLE
PlotJuggler: Parse routes from connect

### DIFF
--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -121,8 +121,6 @@ if __name__ == "__main__":
   else:
     route = DEMO_ROUTE if args.demo else args.route_name.strip()
     if route.count("--") > 1:
-      route_seg = route.rpartition("--")
-      route = route_seg[0]
-      args.segment_number = int(route_seg[-1])
-    print(route, args.segment_number)
+      route, args.segment_number = route.rsplit("--", 1)
+      args.segment_number = int(args.segment_number)
     juggle_route(route, args.segment_number, args.segment_count, args.qlog, args.can, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -120,4 +120,9 @@ if __name__ == "__main__":
     start_juggler(layout=args.layout)
   else:
     route = DEMO_ROUTE if args.demo else args.route_name.strip()
+    if route.count("--") > 1:
+      route_seg = route.rpartition("--")
+      route = route_seg[0]
+      args.segment_number = int(route_seg[-1])
+    print(route, args.segment_number)
     juggle_route(route, args.segment_number, args.segment_count, args.qlog, args.can, args.layout)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -122,5 +122,4 @@ if __name__ == "__main__":
     route = DEMO_ROUTE if args.demo else args.route_name.strip()
     if route.count("--") > 1:
       route, args.segment_number = route.rsplit("--", 1)
-      args.segment_number = int(args.segment_number)
-    juggle_route(route, args.segment_number, args.segment_count, args.qlog, args.can, args.layout)
+    juggle_route(route, int(args.segment_number), args.segment_count, args.qlog, args.can, args.layout)


### PR DESCRIPTION
This makes it a bit easier to start inspecting data when copy/pasting a route name from comma connect. Instead of dealing with an inconspicuous error message and then manually fixing the route name for juggle.py, this PR parses the segment number correctly from the pasted string.