### PR TITLE
PC: dynamically set PYTHONPATH from real openpilot path

### DIFF
--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,5 +1,5 @@
 if [ -z "$OPENPILOT_ENV" ]; then
-  OP_ROOT="$(dirname "$(dirname "$(realpath -s "$0")")")"
+  OP_ROOT="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
   export PYTHONPATH="$OP_ROOT:$PYTHONPATH"
   export PATH="$HOME/.pyenv/bin:$PATH"
 

--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,5 +1,5 @@
 if [ -z "$OPENPILOT_ENV" ]; then
-  OP_ROOT=$(git rev-parse --show-toplevel)
+  OP_ROOT="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
   export PYTHONPATH="$OP_ROOT:$PYTHONPATH"
   export PATH="$HOME/.pyenv/bin:$PATH"
 

--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,5 +1,5 @@
 if [ -z "$OPENPILOT_ENV" ]; then
-  OP_ROOT="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+  OP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
   export PYTHONPATH="$OP_ROOT:$PYTHONPATH"
   export PATH="$HOME/.pyenv/bin:$PATH"
 

--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,5 +1,5 @@
-OP_ROOT=$(git rev-parse --show-toplevel)
 if [ -z "$OPENPILOT_ENV" ]; then
+  OP_ROOT=$(git rev-parse --show-toplevel)
   export PYTHONPATH="$OP_ROOT:$PYTHONPATH"
   export PATH="$HOME/.pyenv/bin:$PATH"
 

--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,5 +1,6 @@
+OP_ROOT=$(git rev-parse --show-toplevel)
 if [ -z "$OPENPILOT_ENV" ]; then
-  export PYTHONPATH="$HOME/openpilot:$PYTHONPATH"
+  export PYTHONPATH="$OP_ROOT:$PYTHONPATH"
   export PATH="$HOME/.pyenv/bin:$PATH"
 
   # Pyenv suggests we place the below two lines in .profile before we source

--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,5 +1,5 @@
 if [ -z "$OPENPILOT_ENV" ]; then
-  OP_ROOT="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+  OP_ROOT="$(dirname "$(dirname "$(realpath -s "$0")")")"
   export PYTHONPATH="$OP_ROOT:$PYTHONPATH"
   export PATH="$HOME/.pyenv/bin:$PATH"
 


### PR DESCRIPTION
As a person who installs openpilot at `~/openpilot/openpilot` I find myself changing the openpilot_env.sh file often to make sure my PYTHONPATH is correct for the openpilot modules. This should let you install openpilot wherever you want!