### PR TITLE
replay: fix segfault or hanging on quit

### DIFF
--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -11,15 +11,11 @@
 
 const QString DEMO_ROUTE = "4cf7a6ad03080c90|2021-09-29--13-46-36";
 struct termios oldt = {};
-Replay *replay = nullptr;
 
 void sigHandler(int s) {
   std::signal(s, SIG_DFL);
   if (oldt.c_lflag) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-  }
-  if (replay) {
-    replay->stop();
   }
   qApp->quit();
 }
@@ -134,7 +130,7 @@ int main(int argc, char *argv[]) {
       replay_flags |= flag;
     }
   }
-  replay = new Replay(route, allow, block, nullptr, replay_flags, parser.value("data_dir"), &app);
+  Replay *replay = new Replay(route, allow, block, nullptr, replay_flags, parser.value("data_dir"), &app);
   if (!replay->load()) {
     return 0;
   }

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -36,10 +36,6 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
 }
 
 Replay::~Replay() {
-  stop();
-}
-
-void Replay::stop() {
   if (!stream_thread_ && segments_.empty()) return;
 
   qDebug() << "shutdown: in progress...";

--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -28,7 +28,6 @@ public:
   ~Replay();
   bool load();
   void start(int seconds = 0);
-  void stop();
   void pause(bool pause);
   bool isPaused() const { return paused_; }
 


### PR DESCRIPTION
replay->stop (in sigHandler)  may be called in  different thread which will cause a segfault or hanging on quit.

How to reproduce this bug:
quickly press the M key multiple times after starting replay , and then press ctrl+c to exit. :

```
merge segments std::vector(0)
camera[0] frame size 1928x1208
Starting listener for: camerad
seeking to 61 s, segment 1
seeking to 121 s, segment 2
loading segment 2 ...
merge segments std::vector()
waiting for events...
seeking to 181 s, segment 3
loading segment 3 ...
seeking to 241 s, segment 4
loading segment 4 ...
shutdown: in progress...
Stopping listener for: camerad
shutdown: done
Segmentation fault (core dumped)

```


