### PR TITLE
LanePlanner: correct path offset for TICI

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -605,8 +605,8 @@ class Controls:
       left_lane_visible = self.sm['lateralPlan'].lProb > 0.5
       l_lane_change_prob = meta.desirePrediction[Desire.laneChangeLeft - 1]
       r_lane_change_prob = meta.desirePrediction[Desire.laneChangeRight - 1]
-      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 - CAMERA_OFFSET))
-      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 + CAMERA_OFFSET))
+      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 + CAMERA_OFFSET))
+      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 - CAMERA_OFFSET))
 
       CC.hudControl.leftLaneDepart = bool(l_lane_change_prob > LANE_DEPARTURE_THRESHOLD and l_lane_close)
       CC.hudControl.rightLaneDepart = bool(r_lane_change_prob > LANE_DEPARTURE_THRESHOLD and r_lane_close)

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -605,8 +605,8 @@ class Controls:
       left_lane_visible = self.sm['lateralPlan'].lProb > 0.5
       l_lane_change_prob = meta.desirePrediction[Desire.laneChangeLeft - 1]
       r_lane_change_prob = meta.desirePrediction[Desire.laneChangeRight - 1]
-      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 + CAMERA_OFFSET))
-      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 - CAMERA_OFFSET))
+      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 - CAMERA_OFFSET))
+      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 + CAMERA_OFFSET))
 
       CC.hudControl.leftLaneDepart = bool(l_lane_change_prob > LANE_DEPARTURE_THRESHOLD and l_lane_close)
       CC.hudControl.rightLaneDepart = bool(r_lane_change_prob > LANE_DEPARTURE_THRESHOLD and r_lane_close)

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -9,11 +9,11 @@ from selfdrive.swaglog import cloudlog
 
 TRAJECTORY_SIZE = 33
 # model path is 0.06 m left of car center
-MODEL_PATH_OFFSET = -0.06
+MODEL_PATH_OFFSET = 0.06
 if EON:
-  CAMERA_OFFSET = -0.06
+  CAMERA_OFFSET = 0.06
 elif TICI:
-  CAMERA_OFFSET = 0.04
+  CAMERA_OFFSET = -0.04
 else:
   CAMERA_OFFSET = 0.0
 
@@ -39,7 +39,7 @@ class LanePlanner:
     self.r_lane_change_prob = 0.
 
     self.camera_offset = -CAMERA_OFFSET if wide_camera else CAMERA_OFFSET
-    self.path_offset = MODEL_PATH_OFFSET - self.camera_offset
+    self.path_offset = self.camera_offset - MODEL_PATH_OFFSET
 
   def parse_model(self, md):
     if len(md.laneLines) == 4 and len(md.laneLines[0].t) == TRAJECTORY_SIZE:
@@ -47,8 +47,8 @@ class LanePlanner:
       # left and right ll x is the same
       self.ll_x = md.laneLines[1].x
       # only offset left and right lane lines; offsetting path does not make sense
-      self.lll_y = np.array(md.laneLines[1].y) + self.camera_offset
-      self.rll_y = np.array(md.laneLines[2].y) + self.camera_offset
+      self.lll_y = np.array(md.laneLines[1].y) - self.camera_offset
+      self.rll_y = np.array(md.laneLines[2].y) - self.camera_offset
       self.lll_prob = md.laneLineProbs[1]
       self.rll_prob = md.laneLineProbs[2]
       self.lll_std = md.laneLineStds[1]

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -11,9 +11,9 @@ TRAJECTORY_SIZE = 33
 # model path is 0.06 m left of center
 MODEL_PATH_OFFSET = -0.06
 if EON:
-  CAMERA_OFFSET = 0.06
+  CAMERA_OFFSET = -0.06
 elif TICI:
-  CAMERA_OFFSET = -0.04
+  CAMERA_OFFSET = 0.04
 else:
   CAMERA_OFFSET = 0.0
 
@@ -39,7 +39,7 @@ class LanePlanner:
     self.r_lane_change_prob = 0.
 
     self.camera_offset = -CAMERA_OFFSET if wide_camera else CAMERA_OFFSET
-    self.path_offset = MODEL_PATH_OFFSET + self.camera_offset
+    self.path_offset = MODEL_PATH_OFFSET - self.camera_offset
 
   def parse_model(self, md):
     if len(md.laneLines) == 4 and len(md.laneLines[0].t) == TRAJECTORY_SIZE:
@@ -47,8 +47,8 @@ class LanePlanner:
       # left and right ll x is the same
       self.ll_x = md.laneLines[1].x
       # only offset left and right lane lines; offsetting path does not make sense
-      self.lll_y = np.array(md.laneLines[1].y) - self.camera_offset
-      self.rll_y = np.array(md.laneLines[2].y) - self.camera_offset
+      self.lll_y = np.array(md.laneLines[1].y) + self.camera_offset
+      self.rll_y = np.array(md.laneLines[2].y) + self.camera_offset
       self.lll_prob = md.laneLineProbs[1]
       self.rll_prob = md.laneLineProbs[2]
       self.lll_std = md.laneLineStds[1]

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -8,16 +8,14 @@ from selfdrive.swaglog import cloudlog
 
 
 TRAJECTORY_SIZE = 33
-# camera offset is meters from center car to camera
+# model path is 0.06 m left of center
+MODEL_PATH_OFFSET = -0.06
 if EON:
   CAMERA_OFFSET = 0.06
-  PATH_OFFSET = 0.0
 elif TICI:
   CAMERA_OFFSET = -0.04
-  PATH_OFFSET = -0.04
 else:
   CAMERA_OFFSET = 0.0
-  PATH_OFFSET = 0.0
 
 
 class LanePlanner:
@@ -41,7 +39,7 @@ class LanePlanner:
     self.r_lane_change_prob = 0.
 
     self.camera_offset = -CAMERA_OFFSET if wide_camera else CAMERA_OFFSET
-    self.path_offset = -PATH_OFFSET if wide_camera else PATH_OFFSET
+    self.path_offset = MODEL_PATH_OFFSET + self.camera_offset
 
   def parse_model(self, md):
     if len(md.laneLines) == 4 and len(md.laneLines[0].t) == TRAJECTORY_SIZE:

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -8,7 +8,7 @@ from selfdrive.swaglog import cloudlog
 
 
 TRAJECTORY_SIZE = 33
-# model path is 0.06 m left of center
+# model path is 0.06 m left of car center
 MODEL_PATH_OFFSET = -0.06
 if EON:
   CAMERA_OFFSET = -0.06


### PR DESCRIPTION
The model's path predictions are in the perspective of the EON/C2's left camera of -0.06 m, however with TICI it's treated as it's centered, but it should be offsetting the path extra 0.06 m to the right, this might be causing some minor left hugging.

Even if offsetting doesn't fully offset the path due to the model behaving unexpectedly with path offsets, since they were added at all I think getting it right is a good idea.

Or with the smaller offset are we sacrificing hugging for less path oscillation if the model behaves unexpectedly with path offsets? 