### PR TITLE
add supported FW version for Palisade 2022

### DIFF
--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -38,6 +38,11 @@ SUPPORTED_FW_VERSIONS = {
     "default_config": b"\x00\x00\x00\x01\x00\x00",
     "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
   },
+  # 2022 PALISADE
+  b"LX2_ SCC FHCUP      1.00 1.00 99110-S8110!\x04\x05\x17\x01    ": {
+    "default_config": b"\x00\x00\x00\x01\x00\x00",
+    "tracks_enabled": b"\x00\x00\x00\x01\x00\x01",
+  },
   # 2020 SANTA FE
   b"TM__ SCC F-CUP      1.00 1.03 99110-S2000\x19\x050\x13'    ": {
     "default_config": b"\x00\x00\x00\x01\x00\x00",


### PR DESCRIPTION
Radar track seems to be working from Cabana after Radar has been disabled. 

Route: ea0d8e2a4cf9ce46|2021-12-27--17-02-09--9

And the output from the enable radar tracks command

`comma@tici:/data/openpilot$ python /data/openpilot/selfdrive/debug/hyundai_enable_radar_points.py
power on the vehicle keeping the engine off (press start button twice) then type OK to continue: OK
opening device 240056001751393037323631 0xddcc
connected

[START DIAGNOSTIC SESSION]
[HARDWARE/SOFTWARE VERSION]
b'LX2_ SCC FHCUP      1.00 1.00 99110-S8110!\x04\x05\x17\x01    '
[GET CONFIGURATION]
current config: 0x000000010000
[CHANGE CONFIGURATION]
new config:     0x000000010001
[DONE]

restart your vehicle and ensure there are no faults
you can run this script again with --default to go back to the original `