### PR TITLE
LogReader: add arg to sort by time

### DIFF
--- a/tools/lib/robust_logreader.py
+++ b/tools/lib/robust_logreader.py
@@ -13,7 +13,7 @@ from cereal import log as capnp_log
 
 
 class RobustLogReader(LogReader):
-  def __init__(self, fn, canonicalize=True, only_union_types=False):  # pylint: disable=super-init-not-called
+  def __init__(self, fn, canonicalize=True, only_union_types=False, sort_by_time=False):  # pylint: disable=super-init-not-called
     data_version = None
     _, ext = os.path.splitext(urllib.parse.urlparse(fn).path)
     with FileReader(fn) as f:
@@ -45,7 +45,7 @@ class RobustLogReader(LogReader):
     while True:
       try:
         ents = capnp_log.Event.read_multiple_bytes(dat)
-        self._ents = list(ents)
+        self._ents = list(sorted(ents, key=lambda x: x.logMonoTime) if sort_by_time else ents)
         break
       except capnp.lib.capnp.KjException:
         if progress is None:


### PR DESCRIPTION
It is often useful to iterate through the data in chronological order.