### PR TITLE
ui: remove fb_w fb_h, clip to +/-32767 pixels

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -278,8 +278,6 @@ void NvgWindow::updateFrameMat(int w, int h) {
   CameraViewWidget::updateFrameMat(w, h);
 
   UIState *s = uiState();
-  s->fb_w = w;
-  s->fb_h = h;
   auto intrinsic_matrix = s->wide_camera ? ecam_intrinsic_matrix : fcam_intrinsic_matrix;
   float zoom = ZOOM / intrinsic_matrix.v[0];
   if (s->wide_camera) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -17,8 +17,8 @@
 // Projects a point in car to space to the corresponding point in full frame
 // image space.
 static bool calib_frame_to_full_frame(const UIState *s, float in_x, float in_y, float in_z, QPointF *out) {
-  const float margin = 500.0f;
-  const QRectF clip_region{-margin, -margin, s->fb_w + 2 * margin, s->fb_h + 2 * margin};
+  constexpr float qt_coord_limit = std::numeric_limits<int16_t>::max();
+  static constexpr QRectF clip_region{-qt_coord_limit, -qt_coord_limit, qt_coord_limit * 2, qt_coord_limit * 2};
 
   const vec3 pt = (vec3){{in_x, in_y, in_z}};
   const vec3 Ep = matvecmul3(s->scene.view_from_calib, pt);

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -117,8 +117,6 @@ public:
     return sm->rcv_frame("liveCalibration") > scene.started_frame;
   };
 
-  int fb_w = 0, fb_h = 0;
-
   std::unique_ptr<SubMaster> sm;
 
   UIStatus status;


### PR DESCRIPTION
The previous nanovg's clipping problem was due to the pointer may exceeds +-32767 pixels,  qt has the same restriction too. 
it's safe to use +/-std::numeric_limits<int16_t>::max() as the clip_region. and I think it's better than using window_rect +/- a hardcoded margin.