### PR TITLE
tools: configure PYTHONPATH in pipenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+.env
 .clang-format
 .DS_Store
 .tags

--- a/tools/openpilot_env.sh
+++ b/tools/openpilot_env.sh
@@ -1,6 +1,4 @@
 if [ -z "$OPENPILOT_ENV" ]; then
-  OP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
-  export PYTHONPATH="$OP_ROOT:$PYTHONPATH"
   export PATH="$HOME/.pyenv/bin:$PATH"
 
   # Pyenv suggests we place the below two lines in .profile before we source

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -32,6 +32,7 @@ if [ -d "./xx" ]; then
 fi
 
 if [ -z "$PIPENV_SYSTEM" ]; then
+  echo "PYTHONPATH=${PWD}" > .env
   RUN="pipenv run"
 else
   RUN=""


### PR DESCRIPTION
https://pipenv-fork.readthedocs.io/en/latest/advanced.html#automatic-loading-of-env

I wish I didn't have to generate the .env file, but I didn't find a way to create a .env file which automatically resolves the root directory of the venv (this won't handle directory renaming or moving)