### PR TITLE
Joystick: learn axis min/max

### DIFF
--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -34,7 +34,8 @@ class Keyboard:
 
 class Joystick:
   def __init__(self):
-    self.max_axis_value = 255  # tune based on your joystick, 0 to this
+    self.min_axis_value = 0
+    self.max_axis_value = 255
     self.cancel_button = 'BTN_TRIGGER'
     self.axes_values = {'ABS_Y': 0., 'ABS_RZ': 0.}  # gb, steer
 
@@ -45,7 +46,11 @@ class Joystick:
     if event[0] == self.cancel_button and event[1] == 0:  # state 0 is falling edge
       self.cancel = True
     elif event[0] in self.axes_values:
-      norm = -interp(event[1], [0, self.max_axis_value], [-1., 1.])
+      if event[1] > self.max_axis_value:
+        self.max_axis_value = event[1]
+      elif event[1] < self.min_axis_value:
+        self.min_axis_value = event[1]
+      norm = -interp(event[1], [self.min_axis_value, self.max_axis_value], [-1., 1.])
       self.axes_values[event[0]] = norm if abs(norm) > 0.05 else 0.  # center can be noisy, deadzone of 5%
     else:
       return False

--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -46,10 +46,9 @@ class Joystick:
     if event[0] == self.cancel_button and event[1] == 0:  # state 0 is falling edge
       self.cancel = True
     elif event[0] in self.axes_values:
-      if event[1] > self.max_axis_value:
-        self.max_axis_value = event[1]
-      elif event[1] < self.min_axis_value:
-        self.min_axis_value = event[1]
+      self.max_axis_value = max(event[1], self.max_axis_value)
+      self.min_axis_value = min(event[1], self.min_axis_value)
+
       norm = -interp(event[1], [self.min_axis_value, self.max_axis_value], [-1., 1.])
       self.axes_values[event[0]] = norm if abs(norm) > 0.05 else 0.  # center can be noisy, deadzone of 5%
     else:


### PR DESCRIPTION
Some joysticks/gamepads have negative values in the axes, [-x, x], not just in the range [0, x]. These changes allow for negative values, and for both axes values to be learnt when we see a new higher value. This means the values don't have to be modified in the code when plugging in a new controller, just move the controller to the maximum positions of each axis at least once before engaging.