### PR TITLE
SConstruct: add -DKJ_NDEBUG to CCFLAGS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -173,6 +173,10 @@ if arch != "Darwin":
 cflags += ["-DSWAGLOG"]
 cxxflags += ["-DSWAGLOG"]
 
+# Disable capnp's asserts
+cflags += ["-DKJ_NDEBUG"]
+cxxflags += ["-DKJ_NDEBUG"]
+
 env = Environment(
   ENV=lenv,
   CCFLAGS=[


### PR DESCRIPTION
This is one of the capnp's Tip & best practices : https://capnproto.org/cxx.html

> The Cap’n Proto library has lots of debug-only asserts that are removed if you #define NDEBUG, including in headers. If you care at all about performance, you should compile your production binaries with the -DNDEBUG compiler flag. 

https://github.com/capnproto/capnproto/blob/09b91a303073a5c6d7ea8409f3fddf6686b03d76/c%2B%2B/src/kj/debug.h#L103-L105

we can use -DKJ_NDEBUG to disable these asserts 
