### PR TITLE
controlsd: check processes after receiving managerState

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -346,9 +346,10 @@ class Controls:
         self.events.add(EventName.localizerMalfunction)
 
       # Check if all manager processes are running
-      not_running = {p.name for p in self.sm['managerState'].processes if not p.running}
-      if self.sm.rcv_frame['managerState'] and (not_running - IGNORE_PROCESSES):
-        self.events.add(EventName.processNotRunning)
+      if self.sm.updated['managerState']:
+        not_running = {p.name for p in self.sm['managerState'].processes if not p.running}
+        if (not_running - IGNORE_PROCESSES):
+          self.events.add(EventName.processNotRunning)
 
     # Only allow engagement with brake pressed when stopped behind another stopped car
     speeds = self.sm['longitudinalPlan'].speeds


### PR DESCRIPTION
the managerState is updated at 1HZ, there is no need to generate a not_running set in each loop