### PR TITLE
setup: remove duplicate pipenv install

### DIFF
--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -17,13 +17,9 @@ if ! pyenv prefix ${PYENV_PYTHON_VERSION} &> /dev/null; then
   CONFIGURE_OPTS="--enable-shared" pyenv install -f ${PYENV_PYTHON_VERSION}
 fi
 
-if ! command -v pipenv &> /dev/null; then
-  echo "pipenv install ..."
-  pip install pipenv
-fi
-
-echo "update pip"
+echo "pip install ..."
 pip install pip==21.3.1
+echo "pipenv install ..."
 pip install pipenv==2021.11.23
 
 if [ -d "./xx" ]; then


### PR DESCRIPTION
no reason to run `pip install pipenv` twice on the first run