### PR TITLE
replay: add missing import for optional

### DIFF
--- a/selfdrive/ui/replay/replay.h
+++ b/selfdrive/ui/replay/replay.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <QThread>
 
 #include "selfdrive/ui/replay/camera.h"


### PR DESCRIPTION
Failed to build the repo after the changes to `replay`, I think in #23248. I'm not sure why it builds for CI but not locally. I already ran `ubuntu_setup.sh` and `update_requirements.sh`, and had been able to build OP successfully for the last few weeks.

![Screenshot from 2022-01-05 13-57-17](https://user-images.githubusercontent.com/4038174/148255798-d60d1b24-b6ac-4e68-a4a9-df8e9a795708.png)

Anyway, adding this import fixed the problem for me.