### PR TITLE
Do not disable loggerd when below 5% space

### DIFF
--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -141,9 +141,6 @@ def manager_thread() -> None:
     sm.update()
     not_run = ignore[:]
 
-    if sm['deviceState'].freeSpacePercent < 5:
-      not_run.append("loggerd")
-
     started = sm['deviceState'].started
     driverview = params.get_bool("IsDriverViewEnabled")
     ensure_running(managed_processes.values(), started, driverview, not_run)


### PR DESCRIPTION
We already have an alert in controlsd that alerts when space is below 7%. Let's check if the outOfSpace event ever triggers before merging this.