### PR TITLE
read carParams from namedtuple instead of pycapnp

### DIFF
--- a/common/namedtuple.py
+++ b/common/namedtuple.py
@@ -1,0 +1,18 @@
+import collections
+
+
+def create_namedtuple_from_dict(obj):
+  if isinstance(obj, dict):
+    fields = sorted(obj.keys())
+    namedtuple_type = collections.namedtuple(typename='OPNamedType', field_names=fields, rename=True, defaults=(None,))
+    field_value_pairs = collections.OrderedDict((str(field), create_namedtuple_from_dict(obj[field])) for field in fields)
+    return namedtuple_type(**field_value_pairs)
+  elif isinstance(obj, (list, set, tuple, frozenset)):
+    return [create_namedtuple_from_dict(item) for item in obj]
+  else:
+    return obj
+
+
+def create_namedtuple_from_capnp(reader):
+  d = reader.to_dict(verbose=True, ordered=True)
+  return create_namedtuple_from_dict(d)

--- a/release/files_common
+++ b/release/files_common
@@ -26,6 +26,7 @@ common/file_helpers.py
 common/logging_extra.py
 common/numpy_fast.py
 common/markdown.py
+common/namedtuple.py
 common/params.py
 common/params_pyx.pyx
 common/xattr.py

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from cereal import car
+from common.namedtuple import create_namedtuple_from_capnp
 from common.params import Params
 from common.realtime import Priority, config_realtime_process
 from selfdrive.swaglog import cloudlog
@@ -14,7 +15,8 @@ def plannerd_thread(sm=None, pm=None):
 
   cloudlog.info("plannerd is waiting for CarParams")
   params = Params()
-  CP = car.CarParams.from_bytes(params.get("CarParams", block=True))
+  car_params = car.CarParams.from_bytes(params.get("CarParams", block=True))
+  CP = create_namedtuple_from_capnp(car_params)
   cloudlog.info("plannerd got CarParams: %s", CP.carName)
 
   use_lanelines = not params.get_bool('EndToEndToggle')

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -5,6 +5,7 @@ from collections import defaultdict, deque
 
 import cereal.messaging as messaging
 from cereal import car
+from common.namedtuple import create_namedtuple_from_capnp
 from common.numpy_fast import interp
 from common.params import Params
 from common.realtime import Ratekeeper, Priority, config_realtime_process
@@ -185,7 +186,8 @@ def radard_thread(sm=None, pm=None, can_sock=None):
 
   # wait for stats about the car to come in from controls
   cloudlog.info("radard is waiting for CarParams")
-  CP = car.CarParams.from_bytes(Params().get("CarParams", block=True))
+  car_params = car.CarParams.from_bytes(Params().get("CarParams", block=True))
+  CP = create_namedtuple_from_capnp(car_params)
   cloudlog.info("radard got CarParams")
 
   # import the radar from the fingerprint

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import cereal.messaging as messaging
 from cereal import car
+from common.namedtuple import create_namedtuple_from_capnp
 from common.params import Params, put_nonblocking
 from common.realtime import set_realtime_priority, DT_MDL
 from common.numpy_fast import clip
@@ -104,7 +105,8 @@ def main(sm=None, pm=None):
   params_reader = Params()
   # wait for stats about the car to come in from controls
   cloudlog.info("paramsd is waiting for CarParams")
-  CP = car.CarParams.from_bytes(params_reader.get("CarParams", block=True))
+  car_params = car.CarParams.from_bytes(params_reader.get("CarParams", block=True))
+  CP = create_namedtuple_from_capnp(car_params)
   cloudlog.info("paramsd got CarParams")
 
   min_sr, max_sr = 0.5 * CP.steerRatio, 2.0 * CP.steerRatio


### PR DESCRIPTION
Use namedtuple to read CarParams for faster and safer state(the namedtuple is immutable). it is nearly identical to native performance.