### PR TITLE
LanePlanner: offsets cleanup

### DIFF
--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -12,11 +12,11 @@ TRAJECTORY_SIZE = 33
 # model path is in the frame of EON's camera. TICI is 0.1 m away,
 # however the average measured path offset difference is -0.04 m
 if EON:
-  CAMERA_OFFSET = 0.06
+  CAMERA_OFFSET = -0.06
   PATH_OFFSET = 0.0
 elif TICI:
-  CAMERA_OFFSET = -0.04
-  PATH_OFFSET = -0.04
+  CAMERA_OFFSET = 0.04
+  PATH_OFFSET = 0.04
 else:
   CAMERA_OFFSET = 0.0
   PATH_OFFSET = 0.0
@@ -51,8 +51,8 @@ class LanePlanner:
       self.ll_t = (np.array(lane_lines[1].t) + np.array(lane_lines[2].t))/2
       # left and right ll x is the same
       self.ll_x = lane_lines[1].x
-      self.lll_y = np.array(lane_lines[1].y) - self.camera_offset
-      self.rll_y = np.array(lane_lines[2].y) - self.camera_offset
+      self.lll_y = np.array(lane_lines[1].y) + self.camera_offset
+      self.rll_y = np.array(lane_lines[2].y) + self.camera_offset
       self.lll_prob = md.laneLineProbs[1]
       self.rll_prob = md.laneLineProbs[2]
       self.lll_std = md.laneLineStds[1]
@@ -66,7 +66,7 @@ class LanePlanner:
   def get_d_path(self, v_ego, path_t, path_xyz):
     # Reduce reliance on lanelines that are too far apart or
     # will be in a few seconds
-    path_xyz[:, 1] -= self.path_offset
+    path_xyz[:, 1] += self.path_offset
     l_prob, r_prob = self.lll_prob, self.rll_prob
     width_pts = self.rll_y - self.lll_y
     prob_mods = []

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -10,7 +10,7 @@ from selfdrive.swaglog import cloudlog
 TRAJECTORY_SIZE = 33
 # camera offset is meters from center car to camera
 # model path is in the frame of EON's camera. TICI is 0.1 m away,
-# however the average measured path offset difference is -0.04 m
+# however the average measured path difference is 0.04 m
 if EON:
   CAMERA_OFFSET = -0.06
   PATH_OFFSET = 0.0

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -9,6 +9,8 @@ from selfdrive.swaglog import cloudlog
 
 TRAJECTORY_SIZE = 33
 # camera offset is meters from center car to camera
+# model path is in the frame of EON's camera. TICI is 0.1 m away,
+# however the average measured path offset difference is -0.04 m
 if EON:
   CAMERA_OFFSET = 0.06
   PATH_OFFSET = 0.0
@@ -49,7 +51,6 @@ class LanePlanner:
       self.ll_t = (np.array(lane_lines[1].t) + np.array(lane_lines[2].t))/2
       # left and right ll x is the same
       self.ll_x = lane_lines[1].x
-      # only offset left and right lane lines; offsetting path does not make sense
       self.lll_y = np.array(lane_lines[1].y) - self.camera_offset
       self.rll_y = np.array(lane_lines[2].y) - self.camera_offset
       self.lll_prob = md.laneLineProbs[1]


### PR DESCRIPTION
Per #23329 I thought it'd be nice to update the comments in LanePlanner, as offsetting the path makes sense (for) now 😛.

Also since the model's y axis was flipped not too long ago (from left positive to left negative), getting the offsets in that same axis might make more sense.

Also added a comment about the average prediction difference between EON and TICI, can be removed when offset is fed into model