### PR TITLE
controlsd: wait for initialized to add events

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -190,9 +190,6 @@ class Controls:
     """Compute carEvents from carState"""
 
     self.events.clear()
-    self.events.add_from_msg(CS.events)
-    self.events.add_from_msg(self.sm['driverMonitoringState'].events)
-
     # Handle startup event
     if self.startup_event is not None:
       self.events.add(self.startup_event)
@@ -202,6 +199,9 @@ class Controls:
     if not self.initialized:
       self.events.add(EventName.controlsInitializing)
       return
+
+    self.events.add_from_msg(CS.events)
+    self.events.add_from_msg(self.sm['driverMonitoringState'].events)
 
     # Create events for battery, temperature, disk space, and memory
     if EON and (self.sm['peripheralState'].pandaType != PandaType.uno) and \
@@ -598,7 +598,7 @@ class Controls:
     ldw_allowed = self.is_ldw_enabled and CS.vEgo > LDW_MIN_SPEED and not recent_blinker \
                     and not self.active and self.sm['liveCalibration'].calStatus == Calibration.CALIBRATED
 
-    model_v2 = self.sm['modelV2'] 
+    model_v2 = self.sm['modelV2']
     desire_prediction = model_v2.meta.desirePrediction
     if len(desire_prediction) and ldw_allowed:
       right_lane_visible = self.sm['lateralPlan'].rProb > 0.5

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -190,6 +190,7 @@ class Controls:
     """Compute carEvents from carState"""
 
     self.events.clear()
+
     # Handle startup event
     if self.startup_event is not None:
       self.events.add(self.startup_event)


### PR DESCRIPTION
When starting the device while driving, and if you engage before the relay trips, various alerts can show, like `doorOpen`, `seatbeltNotLatched`, `espDisabled`, `commIssue`, etc. Wait until we're initialized for any alerts besides `controlsInitializing` and the startup alerts.

`initialized` at most should take 3.5 seconds, are there any alerts we need to show before then? I'm thinking not, but I haven't worked with the events that much before.

![Screenshot from 2022-01-08 23-20-57](https://user-images.githubusercontent.com/25857203/148671642-d77b5786-c4d7-441d-b859-6238708cdd3b.png)

Segment with a bunch of events being added for a frame: `f15e3c37c118e841|2022-01-08--21-20-46--0`