### PR TITLE
LongControl: remove redundant check on active

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -26,8 +26,7 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target_fut
 
   else:
     if long_control_state == LongCtrlState.off:
-      if active:
-        long_control_state = LongCtrlState.pid
+      long_control_state = LongCtrlState.pid
 
     elif long_control_state == LongCtrlState.pid:
       if stopping_condition:


### PR DESCRIPTION
I know it's useless, but there is a chinese proverb: "勿以善小而不为" (Don't miss doing any good thing no matter how insignificant it looks.).  so I still submitted this PR