### PR TITLE
lfs: easier to use config

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,3 +1,4 @@
 [lfs]
 	url = https://gitlab.com/commaai/openpilot-lfs.git/info/lfs
-	pushurl = 
+	pushurl = ssh://git@gitlab.com/commaai/openpilot-lfs.git
+	locksverify = false

--- a/lfs-push.sh
+++ b/lfs-push.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-git -c lfs.pushurl=ssh://git@gitlab.com/commaai/openpilot-lfs.git push


### PR DESCRIPTION
- we don't care about lfs locks and the pre-commit check was throwing a confusing warning for forks
  ```
  Remote "origin" does not support the LFS locking API...
  ```
- seems like the ssh push url can always be present so no need for a special push script