### PR TITLE
Chrysler: Fix standstill departure EPS fault

### DIFF
--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -35,6 +35,8 @@ class CarController():
     elif self.car_fingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
       if CS.out.vEgo < (CS.CP.minSteerSpeed - 3.0):
         self.gone_fast_yet = False  # < 14.5m/s stock turns off this bit, but fine down to 13.5
+
+    # Explicit check for gas press is required to prevent steering during gas-press resume from standstill
     lkas_active = moving_fast and active and not CS.out.gasPressed
 
     if not lkas_active:

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -17,7 +17,7 @@ class CarController():
 
     self.packer = CANPacker(dbc_name)
 
-  def update(self, enabled, CS, actuators, pcm_cancel_cmd, hud_alert):
+  def update(self, active, CS, actuators, pcm_cancel_cmd, hud_alert):
     # this seems needed to avoid steering faults and to force the sync with the EPS counter
     frame = CS.lkas_counter
     if self.prev_frame == frame:
@@ -35,7 +35,7 @@ class CarController():
     elif self.car_fingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
       if CS.out.vEgo < (CS.CP.minSteerSpeed - 3.0):
         self.gone_fast_yet = False  # < 14.5m/s stock turns off this bit, but fine down to 13.5
-    lkas_active = moving_fast and enabled
+    lkas_active = moving_fast and active and not CS.out.gasPressed
 
     if not lkas_active:
       apply_steer = 0

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -80,4 +80,4 @@ class CarInterface(CarInterfaceBase):
     if (self.CS.frame == -1):
       return car.CarControl.Actuators.new_message(), []  # if we haven't seen a frame 220, then do not update.
 
-    return self.CC.update(c.enabled, self.CS, c.actuators, c.cruiseControl.cancel, c.hudControl.visualAlert)
+    return self.CC.update(c.active, self.CS, c.actuators, c.cruiseControl.cancel, c.hudControl.visualAlert)


### PR DESCRIPTION
**Description**
Make sure we send zero lateral torque if gas is pressed. For the Chrysler port, which doesn't support button spam auto-resume, this is important if the driver uses the gas pedal to resume from standstill and continues holding it past the EPS minimum steer speed. This avoids Panda dropping steering messages and the ensuing controls mismatch / LKAS fault condition.

Credit to @adhintz for identifying the triggering condition. Drew, does this work for you?

Resolves #23398
Resolves #20724
Probably takes a bite out of #2253

**Verification**
Seems self-evidently correct, but holding in Draft till someone can test.

**Route**
TBD