### PR TITLE
optimize Events

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -700,7 +700,7 @@ class Controls:
       ce_send = messaging.new_message('carEvents', len(self.events))
       ce_send.carEvents = car_events
       self.pm.send('carEvents', ce_send)
-    self.events_prev = self.events.names.copy()
+    self.events_prev = self.events.names
 
     # carParams - logged every 50 seconds (> 1 per segment)
     if (self.sm.frame % int(50. / DT_CTRL) == 0):

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -78,7 +78,7 @@ class Events:
         if not isinstance(alert, Alert):
           alert = alert(*callback_args)
 
-        if DT_CTRL * (self.events_prev[e]) >= alert.creation_delay:
+        if (DT_CTRL * self.events_prev[e]) >= alert.creation_delay:
           alert.alert_type = f"{EVENT_NAME[e]}/{et}"
           alert.event_type = et
           ret.append(alert)

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -48,10 +48,10 @@ class Events:
 
   @property
   def names(self) -> List[int]:
-    return self.events
+    return list(chain(self.static_events, self.events))
 
   def __len__(self) -> int:
-    return len(self.events)
+    return len(self.static_events) + len(self.events)
 
   def add(self, event_name: int, static: bool=False) -> None:
     if static:

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -78,7 +78,7 @@ class Events:
         if not isinstance(alert, Alert):
           alert = alert(*callback_args)
 
-        if DT_CTRL * (self.events_prev[e] + 1) >= alert.creation_delay:
+        if DT_CTRL * (self.events_prev[e]) >= alert.creation_delay:
           alert.alert_type = f"{EVENT_NAME[e]}/{et}"
           alert.event_type = et
           ret.append(alert)


### PR DESCRIPTION
The `Events.clear()`  rebuilds `events_prev` from all EVENTS  every time and deep copy `static_events`, which can hurt performance.

it should be 20-30x faster when there are events, and almost zero overhead when there are no events