### PR TITLE
UI: reset interactivity timeout on PC

### DIFF
--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -80,12 +80,10 @@ void MainWindow::closeSettings() {
 }
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event) {
-  const static QSet<QEvent::Type> filter_events(
-      {QEvent::MouseButtonPress, QEvent::MouseMove,
-       QEvent::TouchBegin, QEvent::TouchUpdate, QEvent::TouchEnd});
+  const QSet<QEvent::Type> evts({QEvent::MouseButtonPress, QEvent::MouseMove,
+                                 QEvent::TouchBegin, QEvent::TouchUpdate, QEvent::TouchEnd});
 
-  const bool touched = filter_events.contains(event->type());
-  if (touched) {
+  if (evts.contains(event->type())) {
     device.resetInteractiveTimout();
 #ifdef QCOM
     // filter out touches while in android activity

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -80,19 +80,22 @@ void MainWindow::closeSettings() {
 }
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event) {
-  if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::TouchBegin) {
-    device.resetInteractiveTimout();
-  }
+  const static QSet<QEvent::Type> filter_events(
+      {QEvent::MouseButtonPress, QEvent::MouseMove,
+       QEvent::TouchBegin, QEvent::TouchUpdate, QEvent::TouchEnd});
 
+  const bool touched = filter_events.contains(event->type());
+  if (touched) {
+    device.resetInteractiveTimout();
 #ifdef QCOM
-  // filter out touches while in android activity
-  const static QSet<QEvent::Type> filter_events({QEvent::MouseButtonPress, QEvent::MouseMove, QEvent::TouchBegin, QEvent::TouchUpdate, QEvent::TouchEnd});
-  if (HardwareEon::launched_activity && filter_events.contains(event->type())) {
-    HardwareEon::check_activity();
+    // filter out touches while in android activity
     if (HardwareEon::launched_activity) {
-      return true;
+      HardwareEon::check_activity();
+      if (HardwareEon::launched_activity) {
+        return true;
+      }
     }
-  }
 #endif
+  }
   return false;
 }


### PR DESCRIPTION
only clicks can update Interactive timeout on PC,which results in a sudden switch to the main screen even when scrolling with mouse.