### PR TITLE
Kia Niro EV - replace \000 by \x00

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -798,7 +798,7 @@ FW_VERSIONS = {
       b'\xf1\x00DEev SCC F-CUP      1.00 1.03 96400-Q4100         ',
       b'\xf1\x8799110Q4000\xf1\x00DEev SCC F-CUP      1.00 1.00 99110-Q4000         ',
       b'\xf1\x8799110Q4100\xf1\x00DEev SCC F-CUP      1.00 1.00 99110-Q4100         ',
-      b'\xf1\x8799110Q4500\xf1\000DEev SCC F-CUP      1.00 1.00 99110-Q4500         ',
+      b'\xf1\x8799110Q4500\xf1\x00DEev SCC F-CUP      1.00 1.00 99110-Q4500         ',
       b'\xf1\x8799110Q4600\xf1\x00DEev SCC FNCUP      1.00 1.00 99110-Q4600         ',
       b'\xf1\x8799110Q4600\xf1\x00DEev SCC FHCUP      1.00 1.00 99110-Q4600         ',
     ],
@@ -807,7 +807,7 @@ FW_VERSIONS = {
       b'\xf1\x00DE  MDPS C 1.00 1.05 56310Q4100\x00 4DEEC105',
     ],
     (Ecu.fwdCamera, 0x7C4, None): [
-      b'\xf1\000DEE MFC  AT EUR LHD 1.00 1.00 99211-Q4100 200706',
+      b'\xf1\x00DEE MFC  AT EUR LHD 1.00 1.00 99211-Q4100 200706',
       b'\xf1\x00DEE MFC  AT EUR LHD 1.00 1.00 99211-Q4000 191211',
       b'\xf1\x00DEE MFC  AT USA LHD 1.00 1.00 99211-Q4000 191211',
       b'\xf1\x00DEE MFC  AT USA LHD 1.00 1.03 95740-Q4000 180821',


### PR DESCRIPTION
**Description**
While testing OP-long on the Kia Niro EV hoomoose#7428 noticed that my radar firmware was miss typed.

**Verification** 
carParams from *06d2b4f33202cc03|2022-01-13--11-30-33--0*
```
'carFw': [
...
  {'address': 2004, 
  'ecu': 'eps', 
  'fwVersion': b'\xf1\x00DE  MDPS C 1.00 1.05 56310Q4100\x00 4DEEC105', 
  'subAddress': 0},
   {'address': 2000,
    'ecu': 'fwdRadar',
    'fwVersion': b'\xf1\x8799110Q4500\xf1\x00DEev SCC F-CUP      1.00 1.00 99110-Q4500         ',
    'subAddress': 0},
   {'address': 1988,
    'ecu': 'fwdCamera',
    'fwVersion': b'\xf1\x00DEE MFC  AT EUR LHD 1.00 1.00 99211-Q4100 200706',
    'subAddress': 0}],
...
```

**Route**
06d2b4f33202cc03|2022-01-13--11-30-33--0
