### PR TITLE
pandad: only reset pandas on first run

### DIFF
--- a/selfdrive/pandad.py
+++ b/selfdrive/pandad.py
@@ -13,7 +13,7 @@ from common.params import Params
 from selfdrive.swaglog import cloudlog
 
 
-def get_expected_signature(panda : Panda) -> bytes:
+def get_expected_signature(panda: Panda) -> bytes:
   fn = DEFAULT_H7_FW_FN if (panda.get_mcu_type() == MCU_TYPE_H7) else DEFAULT_FW_FN
 
   try:
@@ -23,7 +23,7 @@ def get_expected_signature(panda : Panda) -> bytes:
     return b""
 
 
-def flash_panda(panda_serial : str) -> Panda:
+def flash_panda(panda_serial: str) -> Panda:
   panda = Panda(panda_serial)
 
   fw_signature = get_expected_signature(panda)
@@ -54,7 +54,8 @@ def flash_panda(panda_serial : str) -> Panda:
 
   return panda
 
-def panda_sort_cmp(a : Panda, b : Panda):
+
+def panda_sort_cmp(a: Panda, b: Panda):
   a_type = a.get_type()
   b_type = b.get_type()
 
@@ -71,7 +72,10 @@ def panda_sort_cmp(a : Panda, b : Panda):
   # last resort: sort by serial number
   return a.get_usb_serial() < b.get_usb_serial()
 
+
 def main() -> NoReturn:
+  first_run = True
+
   while True:
     try:
       # Flash all Pandas in DFU mode
@@ -98,8 +102,9 @@ def main() -> NoReturn:
           Params().put_bool("PandaHeartbeatLost", True)
           cloudlog.event("heartbeat lost", deviceState=health, serial=panda.get_usb_serial())
 
-        cloudlog.info(f"Resetting panda {panda.get_usb_serial()}")
-        panda.reset()
+        if first_run:
+          cloudlog.info(f"Resetting panda {panda.get_usb_serial()}")
+          panda.reset()
 
       # sort pandas to have deterministic order
       pandas.sort(key=cmp_to_key(panda_sort_cmp))
@@ -112,6 +117,8 @@ def main() -> NoReturn:
       # a panda was disconnected while setting everything up. let's try again
       cloudlog.exception("Panda USB exception while setting up")
       continue
+
+    first_run = False
 
     # run boardd with all connected serials as arguments
     os.chdir(os.path.join(BASEDIR, "selfdrive/boardd"))


### PR DESCRIPTION
We don't want to reset it when we're potentially onroad and mess with uptime stats or safety modes.