### PR TITLE
Subaru: fix missing commas in fingerprints

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -112,7 +112,7 @@ FW_VERSIONS = {
       b'\xaa!`u\a',
       b'\xaa!dq\a',
       b'\xaa!dt\a',
-      b'\xf1\x00\xa2\x10\t'
+      b'\xf1\x00\xa2\x10\t',
       b'\xc5!dr\a',
       b'\xc5!ar\a',
       b'\xbe!as\a',
@@ -131,7 +131,7 @@ FW_VERSIONS = {
       b'\xe3\xf5G\x00\x00',
       b'\xe3\xf5\a\x00\x00',
       b'\xe3\xf5C\x00\x00',
-      b'\xf1\x00\xa4\x10@'
+      b'\xf1\x00\xa4\x10@',
       b'\xe5\xf5B\x00\x00',
       b'\xe5\xf5$\000\000',
       b'\xe4\xf5\a\000\000',
@@ -197,7 +197,7 @@ FW_VERSIONS = {
       b'\032\xf6B0\000',
       b'\032\xf6F`\000',
       b'\032\xf6b`\000',
-      b'\032\xf6B`\000'
+      b'\032\xf6B`\000',
       b'\xf1\x00\xa4\x10@',
     ],
   },
@@ -298,7 +298,7 @@ FW_VERSIONS = {
       b'\xab"@s\a',
       b'\xab+@@\a',
       b'\xb4"@r\a',
-      b'\xa0+@@\x07'
+      b'\xa0+@@\x07',
       b'\xa0\"@\x80\a',
     ],
     (Ecu.transmission, 0x7e1, None): [

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -131,7 +131,6 @@ FW_VERSIONS = {
       b'\xe3\xf5G\x00\x00',
       b'\xe3\xf5\a\x00\x00',
       b'\xe3\xf5C\x00\x00',
-      b'\xf1\x00\xa4\x10@',
       b'\xe5\xf5B\x00\x00',
       b'\xe5\xf5$\000\000',
       b'\xe4\xf5\a\000\000',

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -113,7 +113,6 @@ FW_VERSIONS = {
       b'\xaa!dq\a',
       b'\xaa!dt\a',
       b'\xf1\x00\xa2\x10\t',
-      b'\xc5!dr\a',
       b'\xc5!ar\a',
       b'\xbe!as\a',
       b'\xc5!ds\a',


### PR DESCRIPTION
comma.ai was missing some commas.

*****Bug fix*****

**Description** 
Without the comma, python does string concatenation across lines.

**Verification**
Nothing beyond the automated tests. If you'd like someone with a Subaru to test this, please let me know.

