### PR TITLE
Log android system shutdown to param

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -255,6 +255,7 @@ selfdrive/hardware/base.py
 selfdrive/hardware/hw.h
 selfdrive/hardware/eon/__init__.py
 selfdrive/hardware/eon/androidd.py
+selfdrive/hardware/eon/shutdownd.py
 selfdrive/hardware/eon/hardware.h
 selfdrive/hardware/eon/hardware.py
 selfdrive/hardware/eon/neos.py

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -133,6 +133,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"LastGPSPosition", PERSISTENT},
     {"LastPeripheralPandaType", PERSISTENT},
     {"LastPowerDropDetected", CLEAR_ON_MANAGER_START},
+    {"LastSystemShutdown", CLEAR_ON_MANAGER_START},
     {"LastUpdateException", PERSISTENT},
     {"LastUpdateTime", PERSISTENT},
     {"LiveParameters", PERSISTENT},

--- a/selfdrive/hardware/eon/shutdownd.py
+++ b/selfdrive/hardware/eon/shutdownd.py
@@ -10,6 +10,7 @@ from selfdrive.swaglog import cloudlog
 def main():
   params = Params()
   while True:
+    # 0 for shutdown, 1 for reboot
     prop = getprop("sys.shutdown.requested")
     if prop is not None and len(prop) > 0:
       os.system("pkill -9 loggerd")

--- a/selfdrive/hardware/eon/shutdownd.py
+++ b/selfdrive/hardware/eon/shutdownd.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import os
+import time
+import datetime
+
+from common.params import Params
+from selfdrive.hardware.eon.hardware import getprop
+from selfdrive.swaglog import cloudlog
+
+def main():
+  params = Params()
+  while True:
+    prop = getprop("sys.shutdown.requested")
+    if prop is not None and len(prop) > 0:
+      os.system("pkill -9 loggerd")
+      params.put("LastSystemShutdown", f"'{prop}' {datetime.datetime.now()}")
+      print("shutdown detected", repr(prop))
+
+      time.sleep(120)
+      cloudlog.error('shutdown false positive')
+      break
+
+    time.sleep(0.1)
+
+if __name__ == "__main__":
+  main()

--- a/selfdrive/manager/process_config.py
+++ b/selfdrive/manager/process_config.py
@@ -1,7 +1,7 @@
 import os
 
-from selfdrive.manager.process import PythonProcess, NativeProcess, DaemonProcess
 from selfdrive.hardware import EON, TICI, PC
+from selfdrive.manager.process import PythonProcess, NativeProcess, DaemonProcess
 
 WEBCAM = os.getenv("USE_WEBCAM") is not None
 
@@ -40,6 +40,7 @@ procs = [
 
   # EON only
   PythonProcess("rtshield", "selfdrive.rtshield", enabled=EON),
+  PythonProcess("shutdownd", "selfdrive.hardware.eon.shutdownd", enabled=EON),
   PythonProcess("androidd", "selfdrive.hardware.eon.androidd", enabled=EON, persistent=True),
 ]
 


### PR DESCRIPTION
fixes #23387

`sys.shutdown.requested` gets written immediately once Android is committed to shutting down. Seems to consistently give 1+ seconds of notice, which is enough for loggerd to exit cleanly.