### PR TITLE
Subaru Crosstrek Torque increase

### DIFF
--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -41,9 +41,9 @@ class CarInterface(CarInterfaceBase):
       ret.centerToFront = ret.wheelbase * 0.5
       ret.steerRatio = 15
       ret.steerActuatorDelay = 0.4   # end-to-end angle controller
-      ret.lateralTuning.pid.kf = 0.00005
+      ret.lateralTuning.pid.kf = 0.00003333
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.133, 0.2], [0.0133, 0.02]]
 
     if candidate == CAR.IMPREZA_2020:
       ret.mass = 1480. + STD_CARGO_KG

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -6,6 +6,8 @@ class CarControllerParams:
   def __init__(self, CP):
     if CP.carFingerprint == CAR.IMPREZA_2020:
       self.STEER_MAX = 1439
+    elif CP.carFingerprint == CAR.IMPREZA:
+      self.STEER_MAX = 3071
     else:
       self.STEER_MAX = 2047
     self.STEER_STEP = 2                # how often we update the steer cmd


### PR DESCRIPTION
Some EPS for Early Impreza/Crosstreks to not respond to the same torque requests as stock. 
The vehicle limits this message at 3071 on these EPS and this value works much better with the stock tune. 

I've done some joystick testing in the past with this and it's quite slow, not jerky/unsafe. 
Subaru EPS actually enforces a slew rate of about half what OP sets. 0-max torque in ~2 sec. 

I think my route with max torque in a curve just expired (3 days) but lateral acceleration can be verified as well. 

**Checklist**
- [x ] added to README
- [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_routes.py)
- [ ] route with stock system:
- [ ] route with openpilot:

The 3 EPS were tested by myself, prlifestyle, budney,  michaelhonan, Moodkiller. 
