### PR TITLE
Is there a bug in test_swaglog?

### DIFF
--- a/selfdrive/common/tests/test_swaglog.cc
+++ b/selfdrive/common/tests/test_swaglog.cc
@@ -64,6 +64,7 @@ void recv_log(void *zctx, int thread_cnt, int thread_msg_cnt) {
     thread_msgs[thread_id]++;
   }
   for (int i = 0; i < thread_cnt; ++i) {
+    INFO("thread :" << i);
     REQUIRE(thread_msgs[i] == thread_msg_cnt);
   }
   zmq_close(sock);


### PR DESCRIPTION
Found that `test_swaglog` reported an error in `selfdrive/unit tests`. I didn't have this problem running it locally, I'll test it here temporarily