### PR TITLE
ui: fix invalid line vertices on startup

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -109,12 +109,6 @@ static void update_state(UIState *s) {
   SubMaster &sm = *(s->sm);
   UIScene &scene = s->scene;
 
-  if (sm.updated("modelV2")) {
-    update_model(s, sm["modelV2"].getModelV2());
-  }
-  if (sm.updated("radarState") && sm.rcv_frame("modelV2") >= s->scene.started_frame) {
-    update_leads(s, sm["radarState"].getRadarState(), sm["modelV2"].getModelV2().getPosition());
-  }
   if (sm.updated("liveCalibration")) {
     auto rpy_list = sm["liveCalibration"].getLiveCalibration().getRpyCalib();
     Eigen::Vector3d rpy;
@@ -129,6 +123,14 @@ static void update_state(UIState *s) {
       for (int j = 0; j < 3; j++) {
         scene.view_from_calib.v[i*3 + j] = view_from_calib(i,j);
       }
+    }
+  }
+  if (s->worldObjectsVisible()) {
+    if (sm.updated("modelV2")) {
+      update_model(s, sm["modelV2"].getModelV2());
+    }
+    if (sm.updated("radarState") && sm.rcv_frame("modelV2") >= s->scene.started_frame) {
+      update_leads(s, sm["radarState"].getRadarState(), sm["modelV2"].getModelV2().getPosition());
     }
   }
   if (sm.updated("pandaStates")) {


### PR DESCRIPTION
`update_model & update_leads `should be called after the value of `view_from_calib` is valid. otherwise all points in line vertices are invalid.


How to reproduce this bug:
start replay, and start the ui, the following error will appear in the console:

> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> selfdrive/ui/qt/onroad.cc: slow frame time: 83.54
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> : Painter path exceeds +/-32767 pixels.
> 