### PR TITLE
swaglog: Fix random test failure

### DIFF
--- a/selfdrive/common/tests/test_swaglog.cc
+++ b/selfdrive/common/tests/test_swaglog.cc
@@ -1,8 +1,8 @@
 #include <zmq.h>
-
 #include <iostream>
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
+
 #include "json11.hpp"
 #include "selfdrive/common/swaglog.h"
 #include "selfdrive/common/util.h"
@@ -36,7 +36,7 @@ void recv_log(void *zctx, int thread_cnt, int thread_msg_cnt) {
 
   while (true) {
     char buf[4096] = {};
-    if (zmq_recv(sock, buf, sizeof(buf), 0) < 0) {
+    if (zmq_recv(sock, buf, sizeof(buf), 0) <= 0) {
       if (errno == EAGAIN || errno == EINTR || errno == EFSM) continue;
       break;
     }

--- a/selfdrive/common/tests/test_swaglog.cc
+++ b/selfdrive/common/tests/test_swaglog.cc
@@ -12,10 +12,12 @@
 const char *SWAGLOG_ADDR = "ipc:///tmp/logmessage";
 std::string daemon_name = "testy";
 std::string dongle_id = "test_dongle_id";
+int LINE_NO = 0;
 
 void log_thread(int msg, int msg_cnt) {
   for (int i = 0; i < msg_cnt; ++i) {
     LOGD("%d", msg);
+    LINE_NO = __LINE__ - 1;
     usleep(1);
   }
 }
@@ -48,7 +50,7 @@ void recv_log(void *zctx, int thread_cnt, int thread_msg_cnt) {
     REQUIRE(msg["levelnum"].int_value() == CLOUDLOG_DEBUG);
     REQUIRE_THAT(msg["filename"].string_value(), Catch::Contains("test_swaglog.cc"));
     REQUIRE(msg["funcname"].string_value() == "log_thread");
-    REQUIRE(msg["lineno"].int_value() == 18);  // TODO: do this automatically
+    REQUIRE(msg["lineno"].int_value() == LINE_NO);
 
     auto ctx = msg["ctx"];
     REQUIRE(ctx["daemon"].string_value() == daemon_name);

--- a/selfdrive/common/tests/test_swaglog.cc
+++ b/selfdrive/common/tests/test_swaglog.cc
@@ -14,9 +14,9 @@ std::string daemon_name = "testy";
 std::string dongle_id = "test_dongle_id";
 int LINE_NO = 0;
 
-void log_thread(int msg, int msg_cnt) {
+void log_thread(int thread_id, int msg_cnt) {
   for (int i = 0; i < msg_cnt; ++i) {
-    LOGD("%d", msg);
+    LOGD("%d", thread_id);
     LINE_NO = __LINE__ - 1;
     usleep(1);
   }

--- a/selfdrive/common/tests/test_swaglog.cc
+++ b/selfdrive/common/tests/test_swaglog.cc
@@ -64,6 +64,7 @@ void recv_log(void *zctx, int thread_cnt, int thread_msg_cnt) {
     thread_msgs[thread_id]++;
   }
   for (int i = 0; i < thread_cnt; ++i) {
+    INFO("thread :" << i);
     REQUIRE(thread_msgs[i] == thread_msg_cnt);
   }
   zmq_close(sock);


### PR DESCRIPTION
got random test failure in test_swaglog:
```

    selfdrive/common/tests/test_swaglog.cc:67: FAILED:
    REQUIRE( thread_msgs[i] == thread_msg_cnt )
    with expansion:
    0 == 100

```
fixed this issue by retrying zmq_recv on errors