### PR TITLE
onroad ui speed 'max' -> 'set'

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -216,7 +216,7 @@ void OnroadHud::paintEvent(QPaintEvent *event) {
   p.setPen(Qt::NoPen);
 
   configFont(p, "Open Sans", 48, "Regular");
-  drawText(p, rc.center().x(), 118, "MAX", is_cruise_set ? 200 : 100);
+  drawText(p, rc.center().x(), 118, "SET", is_cruise_set ? 200 : 100);
   if (is_cruise_set) {
     configFont(p, "Open Sans", 88, is_cruise_set ? "Bold" : "SemiBold");
     drawText(p, rc.center().x(), 212, maxSpeed, 255);


### PR DESCRIPTION
**Description** Change onroad cruise set point string from "MAX" to "SET"

**Verification** Ran replay --demo and ui:

![image](https://user-images.githubusercontent.com/42746943/149670015-14d53dad-8f4f-4f4b-b227-dd3486b19650.png)