### PR TITLE
controlsd: verify unsafe mode consistency

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -161,7 +161,8 @@ bool safety_setter_thread(std::vector<Panda *> pandas) {
   int safety_param;
 
   auto safety_configs = car_params.getSafetyConfigs();
-  for (uint32_t i=0; i<pandas.size(); i++) {
+  uint16_t unsafe_mode = car_params.getUnsafeMode();
+  for (uint32_t i = 0; i < pandas.size(); i++) {
     auto panda = pandas[i];
 
     if (safety_configs.size() > i) {
@@ -173,9 +174,8 @@ bool safety_setter_thread(std::vector<Panda *> pandas) {
       safety_param = 0;
     }
 
-    LOGW("panda %d: setting safety model: %d with param %d", i, (int)safety_model, safety_param);
-
-    panda->set_unsafe_mode(0);  // see safety_declarations.h for allowed values
+    LOGW("panda %d: setting safety model: %d, param: %d, unsafe mode: %d", i, (int)safety_model, safety_param, unsafe_mode);
+    panda->set_unsafe_mode(unsafe_mode);
     panda->set_safety_model(safety_model, safety_param);
   }
 
@@ -315,7 +315,7 @@ bool send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool s
     pandaStates.push_back(pandaState);
   }
 
-  for (uint32_t i=0; i<pandas.size(); i++) {
+  for (uint32_t i = 0; i < pandas.size(); i++) {
     auto panda = pandas[i];
     const auto &pandaState = pandaStates[i];
 
@@ -353,6 +353,7 @@ bool send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool s
     ps.setPandaType(panda->hw_type);
     ps.setSafetyModel(cereal::CarParams::SafetyModel(pandaState.safety_model));
     ps.setSafetyParam(pandaState.safety_param);
+    ps.setUnsafeMode(pandaState.unsafe_mode);
     ps.setFaultStatus(cereal::PandaState::FaultStatus(pandaState.fault_status));
     ps.setPowerSaveEnabled((bool)(pandaState.power_save_enabled));
     ps.setHeartbeatLost((bool)(pandaState.heartbeat_lost));

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -353,10 +353,10 @@ bool send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool s
     ps.setPandaType(panda->hw_type);
     ps.setSafetyModel(cereal::CarParams::SafetyModel(pandaState.safety_model));
     ps.setSafetyParam(pandaState.safety_param);
-    ps.setUnsafeMode(pandaState.unsafe_mode);
     ps.setFaultStatus(cereal::PandaState::FaultStatus(pandaState.fault_status));
     ps.setPowerSaveEnabled((bool)(pandaState.power_save_enabled));
     ps.setHeartbeatLost((bool)(pandaState.heartbeat_lost));
+    ps.setUnsafeMode(pandaState.unsafe_mode);
     ps.setHarnessStatus(cereal::PandaState::HarnessStatus(pandaState.car_harness_status));
 
     // Convert faults bitset to capnp list

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -42,6 +42,7 @@ struct __attribute__((packed)) health_t {
   uint8_t usb_power_mode;
   uint8_t safety_model;
   int16_t safety_param;
+  int16_t unsafe_mode;
   uint8_t fault_status;
   uint8_t power_save_enabled;
   uint8_t heartbeat_lost;

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -45,7 +45,7 @@ struct __attribute__((packed)) health_t {
   uint8_t fault_status;
   uint8_t power_save_enabled;
   uint8_t heartbeat_lost;
-  int16_t unsafe_mode;
+  uint16_t unsafe_mode;
 };
 
 struct __attribute__((packed)) can_header {

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -42,10 +42,10 @@ struct __attribute__((packed)) health_t {
   uint8_t usb_power_mode;
   uint8_t safety_model;
   int16_t safety_param;
-  int16_t unsafe_mode;
   uint8_t fault_status;
   uint8_t power_save_enabled;
   uint8_t heartbeat_lost;
+  int16_t unsafe_mode;
 };
 
 struct __attribute__((packed)) can_header {

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -72,6 +72,7 @@ class CarInterfaceBase(ABC):
   def get_std_params(candidate, fingerprint):
     ret = car.CarParams.new_message()
     ret.carFingerprint = candidate
+    ret.unsafeMode = 0  # see safety_declarations.h for allowed values
 
     # standard ALC params
     ret.steerControlType = car.CarParams.SteerControlType.torque

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -253,7 +253,9 @@ class Controls:
     for i, pandaState in enumerate(self.sm['pandaStates']):
       # All pandas must match the list of safetyConfigs, and if outside this list, must be silent or noOutput
       if i < len(self.CP.safetyConfigs):
-        safety_mismatch = pandaState.safetyModel != self.CP.safetyConfigs[i].safetyModel or pandaState.safetyParam != self.CP.safetyConfigs[i].safetyParam
+        safety_mismatch = pandaState.safetyModel != self.CP.safetyConfigs[i].safetyModel or \
+                          pandaState.safetyParam != self.CP.safetyConfigs[i].safetyParam or \
+                          pandaState.unsafeMode != self.CP.unsafeMode
       else:
         safety_mismatch = pandaState.safetyModel not in IGNORED_SAFETY_MODES
 


### PR DESCRIPTION
To satisfy some of https://github.com/commaai/openpilot/pull/23538's pre-requisites.

Accompanying PRs:
- [x] cereal: https://github.com/commaai/cereal/pull/242
- [x] panda: https://github.com/commaai/panda/pull/829

Showing it being set to 1 when the safety mode is set: https://user-images.githubusercontent.com/25857203/149882760-4301fd1e-6165-4c34-b289-634079891d6f.png