### PR TITLE
Toyota: use single DBC for Lexus NXH, Lexus RXH, HighlanderH, Rav4H

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -592,12 +592,11 @@ opendbc/subaru_outback_2015_generated.dbc
 opendbc/subaru_outback_2019_generated.dbc
 opendbc/subaru_forester_2017_generated.dbc
 
-opendbc/toyota_rav4_hybrid_2017_pt_generated.dbc
+opendbc/toyota_tnga_k_tss_p_hybrid_generated.dbc
 opendbc/toyota_rav4_2017_pt_generated.dbc
 opendbc/toyota_prius_2017_pt_generated.dbc
 opendbc/toyota_corolla_2017_pt_generated.dbc
 opendbc/lexus_rx_350_2016_pt_generated.dbc
-opendbc/lexus_rx_hybrid_2017_pt_generated.dbc
 opendbc/toyota_nodsu_pt_generated.dbc
 opendbc/toyota_nodsu_hybrid_pt_generated.dbc
 opendbc/toyota_highlander_2017_pt_generated.dbc

--- a/release/files_common
+++ b/release/files_common
@@ -606,7 +606,6 @@ opendbc/toyota_avalon_2017_pt_generated.dbc
 opendbc/toyota_sienna_xle_2018_pt_generated.dbc
 opendbc/lexus_is_2018_pt_generated.dbc
 opendbc/lexus_ct200h_2018_pt_generated.dbc
-opendbc/lexus_nx300h_2018_pt_generated.dbc
 opendbc/lexus_nx300_2018_pt_generated.dbc
 opendbc/toyota_adas.dbc
 opendbc/toyota_tss2_adas.dbc

--- a/release/files_common
+++ b/release/files_common
@@ -601,7 +601,6 @@ opendbc/lexus_rx_hybrid_2017_pt_generated.dbc
 opendbc/toyota_nodsu_pt_generated.dbc
 opendbc/toyota_nodsu_hybrid_pt_generated.dbc
 opendbc/toyota_highlander_2017_pt_generated.dbc
-opendbc/toyota_highlander_hybrid_2018_pt_generated.dbc
 opendbc/toyota_avalon_2017_pt_generated.dbc
 opendbc/toyota_sienna_xle_2018_pt_generated.dbc
 opendbc/lexus_is_2018_pt_generated.dbc

--- a/release/files_common
+++ b/release/files_common
@@ -592,7 +592,7 @@ opendbc/subaru_outback_2015_generated.dbc
 opendbc/subaru_outback_2019_generated.dbc
 opendbc/subaru_forester_2017_generated.dbc
 
-opendbc/toyota_tnga_k_tss_p_hybrid_generated.dbc
+opendbc/toyota_tssp_hybrid_generated.dbc
 opendbc/toyota_rav4_2017_pt_generated.dbc
 opendbc/toyota_prius_2017_pt_generated.dbc
 opendbc/toyota_corolla_2017_pt_generated.dbc

--- a/release/files_common
+++ b/release/files_common
@@ -600,7 +600,6 @@ opendbc/lexus_rx_350_2016_pt_generated.dbc
 opendbc/toyota_nodsu_pt_generated.dbc
 opendbc/toyota_nodsu_hybrid_pt_generated.dbc
 opendbc/toyota_highlander_2017_pt_generated.dbc
-opendbc/toyota_avalon_2017_pt_generated.dbc
 opendbc/toyota_sienna_xle_2018_pt_generated.dbc
 opendbc/lexus_is_2018_pt_generated.dbc
 opendbc/lexus_ct200h_2018_pt_generated.dbc

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -1667,7 +1667,7 @@ DBC = {
   CAR.LEXUS_IS: dbc_dict('lexus_is_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_CTH: dbc_dict('lexus_ct200h_2018_pt_generated', 'toyota_adas'),
   CAR.RAV4H_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
-  CAR.LEXUS_NXH: dbc_dict('lexus_nx300h_2018_pt_generated', 'toyota_adas'),
+  CAR.LEXUS_NXH: dbc_dict('toyota_rav4_hybrid_2017_pt_generated', 'toyota_adas'),
   CAR.LEXUS_NX: dbc_dict('lexus_nx300_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_NX_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
   CAR.PRIUS_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -1634,13 +1634,13 @@ FW_VERSIONS = {
 STEER_THRESHOLD = 100
 
 DBC = {
-  CAR.RAV4H: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
+  CAR.RAV4H: dbc_dict('toyota_tssp_hybrid_generated', 'toyota_adas'),
   CAR.RAV4: dbc_dict('toyota_rav4_2017_pt_generated', 'toyota_adas'),
   CAR.PRIUS: dbc_dict('toyota_prius_2017_pt_generated', 'toyota_adas'),
   CAR.COROLLA: dbc_dict('toyota_corolla_2017_pt_generated', 'toyota_adas'),
   CAR.LEXUS_RC: dbc_dict('lexus_is_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_RX: dbc_dict('lexus_rx_350_2016_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_RXH: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
+  CAR.LEXUS_RXH: dbc_dict('toyota_tssp_hybrid_generated', 'toyota_adas'),
   CAR.LEXUS_RX_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
   CAR.LEXUS_RXH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.CHR: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
@@ -1651,7 +1651,7 @@ DBC = {
   CAR.CAMRYH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.HIGHLANDER: dbc_dict('toyota_highlander_2017_pt_generated', 'toyota_adas'),
   CAR.HIGHLANDER_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.HIGHLANDERH: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
+  CAR.HIGHLANDERH: dbc_dict('toyota_tssp_hybrid_generated', 'toyota_adas'),
   CAR.HIGHLANDERH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.AVALON: dbc_dict('toyota_avalon_2017_pt_generated', 'toyota_adas'),
   CAR.AVALON_2019: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
@@ -1667,7 +1667,7 @@ DBC = {
   CAR.LEXUS_IS: dbc_dict('lexus_is_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_CTH: dbc_dict('lexus_ct200h_2018_pt_generated', 'toyota_adas'),
   CAR.RAV4H_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
-  CAR.LEXUS_NXH: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
+  CAR.LEXUS_NXH: dbc_dict('toyota_tssp_hybrid_generated', 'toyota_adas'),
   CAR.LEXUS_NX: dbc_dict('lexus_nx300_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_NX_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
   CAR.PRIUS_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -1651,7 +1651,7 @@ DBC = {
   CAR.CAMRYH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.HIGHLANDER: dbc_dict('toyota_highlander_2017_pt_generated', 'toyota_adas'),
   CAR.HIGHLANDER_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.HIGHLANDERH: dbc_dict('toyota_highlander_hybrid_2018_pt_generated', 'toyota_adas'),
+  CAR.HIGHLANDERH: dbc_dict('toyota_rav4_hybrid_2017_pt_generated', 'toyota_adas'),
   CAR.HIGHLANDERH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.AVALON: dbc_dict('toyota_avalon_2017_pt_generated', 'toyota_adas'),
   CAR.AVALON_2019: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -1634,13 +1634,13 @@ FW_VERSIONS = {
 STEER_THRESHOLD = 100
 
 DBC = {
-  CAR.RAV4H: dbc_dict('toyota_rav4_hybrid_2017_pt_generated', 'toyota_adas'),
+  CAR.RAV4H: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
   CAR.RAV4: dbc_dict('toyota_rav4_2017_pt_generated', 'toyota_adas'),
   CAR.PRIUS: dbc_dict('toyota_prius_2017_pt_generated', 'toyota_adas'),
   CAR.COROLLA: dbc_dict('toyota_corolla_2017_pt_generated', 'toyota_adas'),
   CAR.LEXUS_RC: dbc_dict('lexus_is_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_RX: dbc_dict('lexus_rx_350_2016_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_RXH: dbc_dict('lexus_rx_hybrid_2017_pt_generated', 'toyota_adas'),
+  CAR.LEXUS_RXH: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
   CAR.LEXUS_RX_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
   CAR.LEXUS_RXH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.CHR: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
@@ -1651,7 +1651,7 @@ DBC = {
   CAR.CAMRYH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.HIGHLANDER: dbc_dict('toyota_highlander_2017_pt_generated', 'toyota_adas'),
   CAR.HIGHLANDER_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.HIGHLANDERH: dbc_dict('toyota_rav4_hybrid_2017_pt_generated', 'toyota_adas'),
+  CAR.HIGHLANDERH: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
   CAR.HIGHLANDERH_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
   CAR.AVALON: dbc_dict('toyota_avalon_2017_pt_generated', 'toyota_adas'),
   CAR.AVALON_2019: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
@@ -1667,7 +1667,7 @@ DBC = {
   CAR.LEXUS_IS: dbc_dict('lexus_is_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_CTH: dbc_dict('lexus_ct200h_2018_pt_generated', 'toyota_adas'),
   CAR.RAV4H_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),
-  CAR.LEXUS_NXH: dbc_dict('toyota_rav4_hybrid_2017_pt_generated', 'toyota_adas'),
+  CAR.LEXUS_NXH: dbc_dict('toyota_tnga_k_tss_p_hybrid_generated', 'toyota_adas'),
   CAR.LEXUS_NX: dbc_dict('lexus_nx300_2018_pt_generated', 'toyota_adas'),
   CAR.LEXUS_NX_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
   CAR.PRIUS_TSS2: dbc_dict('toyota_nodsu_hybrid_pt_generated', 'toyota_tss2_adas'),


### PR DESCRIPTION
For commaai/opendbc/pull/503

The two dbcs are basically the same, so removing nxh and use rav4h's instead