### PR TITLE
swaglog: retry zmq_send on EAGAIN

### DIFF
--- a/selfdrive/common/swaglog.cc
+++ b/selfdrive/common/swaglog.cc
@@ -43,6 +43,11 @@ static void cloudlog_init() {
 
   int timeout = 100; // 100 ms timeout on shutdown for messages to be received by logmessaged
   zmq_setsockopt(s.sock, ZMQ_LINGER, &timeout, sizeof(timeout));
+  int t = 0;
+  size_t t_s = sizeof(t);
+  zmq_getsockopt(s.sock, ZMQ_SNDHWM, &t, &t_s);
+  printf("size %d\n", t);
+  // assert(0);
 
   zmq_connect(s.sock, "ipc:///tmp/logmessage");
 
@@ -92,7 +97,7 @@ static void log(char levelnum, const char* filename, int lineno, const char* fun
   while (true) {
     int err = zmq_send(s.sock, buf.c_str(), buf.length(), ZMQ_NOBLOCK);
     if (err == -1 && errno == EAGAIN && retries++ < 10) {
-      // retry 10 times if the underline queue is full.
+      // retry 10 times if the underlying queue is full.
       continue;
     }
     break;

--- a/selfdrive/common/swaglog.cc
+++ b/selfdrive/common/swaglog.cc
@@ -43,11 +43,6 @@ static void cloudlog_init() {
 
   int timeout = 100; // 100 ms timeout on shutdown for messages to be received by logmessaged
   zmq_setsockopt(s.sock, ZMQ_LINGER, &timeout, sizeof(timeout));
-  int t = 0;
-  size_t t_s = sizeof(t);
-  zmq_getsockopt(s.sock, ZMQ_SNDHWM, &t, &t_s);
-  printf("size %d\n", t);
-  // assert(0);
 
   zmq_connect(s.sock, "ipc:///tmp/logmessage");
 

--- a/selfdrive/common/swaglog.cc
+++ b/selfdrive/common/swaglog.cc
@@ -82,12 +82,16 @@ static void cloudlog_init() {
   s.inited = true;
 }
 
-static void log(int levelnum, const char* filename, int lineno, const char* func, const char* msg, const std::string& log_s) {
+static void log(char levelnum, const char* filename, int lineno, const char* func, const char* msg, const std::string& log_s) {
   if (levelnum >= s.print_level) {
     printf("%s: %s\n", filename, msg);
   }
-  char levelnum_c = levelnum;
-  zmq_send(s.sock, (levelnum_c + log_s).c_str(), log_s.length() + 1, ZMQ_NOBLOCK);
+
+  const std::string buf = levelnum + log_s;
+  int err = 0;
+  do {
+    err = zmq_send(s.sock, buf.c_str(), buf.length(), ZMQ_NOBLOCK);
+  } while (err == -1 && errno == EAGAIN);
 }
 
 void cloudlog_e(int levelnum, const char* filename, int lineno, const char* func,

--- a/selfdrive/common/tests/test_swaglog.cc
+++ b/selfdrive/common/tests/test_swaglog.cc
@@ -81,7 +81,7 @@ TEST_CASE("swaglog") {
   setenv("DONGLE_ID", dongle_id.c_str(), 1);
   setenv("dirty", "1", 1);
   const int thread_cnt = 5;
-  const int thread_msg_cnt = 1000;
+  const int thread_msg_cnt = 100;
 
   void *zctx = zmq_ctx_new();
   send_stop_msg(zctx);

--- a/selfdrive/common/tests/test_swaglog.cc
+++ b/selfdrive/common/tests/test_swaglog.cc
@@ -81,7 +81,7 @@ TEST_CASE("swaglog") {
   setenv("DONGLE_ID", dongle_id.c_str(), 1);
   setenv("dirty", "1", 1);
   const int thread_cnt = 5;
-  const int thread_msg_cnt = 100;
+  const int thread_msg_cnt = 1000;
 
   void *zctx = zmq_ctx_new();
   send_stop_msg(zctx);


### PR DESCRIPTION
From zmq documentation zmq_send(3)  http://api.zeromq.org/3-2:zmq-send:

```
EAGAIN
    Non-blocking mode was requested and the message cannot be sent at the moment.
```