### PR TITLE
ui/setup: check http status code

### DIFF
--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -37,7 +37,9 @@ void Setup::download(QString url) {
   curl_easy_setopt(curl, CURLOPT_USERAGENT, USER_AGENT);
 
   int ret = curl_easy_perform(curl);
-  if (ret != CURLE_OK) {
+  long res_status = 0;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &res_status);
+  if (ret != CURLE_OK || res_status != 200) {
     emit finished(false);
     return;
   }

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -46,11 +46,11 @@ void Setup::download(QString url) {
 
   long res_status = 0;
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &res_status);
-  if (ret != CURLE_OK || res_status != 200) {
-    emit finished(false);
-  } else {
+  if (ret == CURLE_OK && res_status == 200) {
     rename(tmpfile, "/tmp/installer");
     emit finished(true);
+  } else {
+    emit finished(false);
   }
 
   curl_easy_cleanup(curl);

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -41,13 +41,13 @@ void Setup::download(QString url) {
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &res_status);
   if (ret != CURLE_OK || res_status != 200) {
     emit finished(false);
-    return;
+  } else {
+    rename(tmpfile, "/tmp/installer");
+    emit finished(true);
   }
+
   curl_easy_cleanup(curl);
   fclose(fp);
-
-  rename(tmpfile, "/tmp/installer");
-  emit finished(true);
 }
 
 QWidget * Setup::low_voltage() {

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -19,13 +19,7 @@
 const char* USER_AGENT = "AGNOSSetup-0.1";
 const QString DASHCAM_URL = "https://dashcam.comma.ai";
 
-struct CURLGlobalInitializer {
-  CURLGlobalInitializer() { curl_global_init(CURL_GLOBAL_DEFAULT); }
-  ~CURLGlobalInitializer() { curl_global_cleanup(); }
-};
-
 void Setup::download(QString url) {
-  static CURLGlobalInitializer curl_initializer;
   CURL *curl = curl_easy_init();
   if (!curl) {
     emit finished(false);

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -19,7 +19,13 @@
 const char* USER_AGENT = "AGNOSSetup-0.1";
 const QString DASHCAM_URL = "https://dashcam.comma.ai";
 
+struct CURLGlobalInitializer {
+  CURLGlobalInitializer() { curl_global_init(CURL_GLOBAL_DEFAULT); }
+  ~CURLGlobalInitializer() { curl_global_cleanup(); }
+};
+
 void Setup::download(QString url) {
+  static CURLGlobalInitializer curl_initializer;
   CURL *curl = curl_easy_init();
   if (!curl) {
     emit finished(false);

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -43,6 +43,7 @@ void Setup::download(QString url) {
   curl_easy_setopt(curl, CURLOPT_USERAGENT, USER_AGENT);
 
   int ret = curl_easy_perform(curl);
+
   long res_status = 0;
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &res_status);
   if (ret != CURLE_OK || res_status != 200) {


### PR DESCRIPTION
1. check http status code: fixed the issue that If the user enters an address that not return 200 (404 or else), setup will also consider the downloading is successful.
2. always cleanup curl and close fp.
