### PR TITLE
GM: Change from brake value threshold to Brake_Pressed signal

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -31,10 +31,11 @@ class CarState(CarStateBase):
     ret.standstill = ret.vEgoRaw < 0.01
 
     ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(pt_cp.vl["ECMPRDNL"]["PRNDL"], None))
-    ret.brake = pt_cp.vl["EBCMBrakePedalPosition"]["BrakePedalPosition"] / 0xd0
-    # Brake pedal's potentiometer returns near-zero reading even when pedal is not pressed.
-    if ret.brake < 10/0xd0:
-      ret.brake = 0.
+    ret.brakePressed = bool(pt_cp.vl["ECMEngineStatus"]["Brake_Pressed"])
+    ret.brake = 0.
+    
+    if ret.brakePressed:
+      ret.brake = pt_cp.vl["EBCMBrakePedalPosition"]["BrakePedalPosition"] / 0xd0
 
     ret.gas = pt_cp.vl["AcceleratorPedal2"]["AcceleratorPedal2"] / 254.
     ret.gasPressed = ret.gas > 1e-5
@@ -67,7 +68,6 @@ class CarState(CarStateBase):
     ret.espDisabled = pt_cp.vl["ESPStatus"]["TractionControlOn"] != 1
     self.pcm_acc_status = pt_cp.vl["AcceleratorPedal2"]["CruiseState"]
 
-    ret.brakePressed = ret.brake > 1e-5
     # Regen braking is braking
     if self.car_fingerprint == CAR.VOLT:
       ret.brakePressed = ret.brakePressed or bool(pt_cp.vl["EBCMRegenPaddle"]["RegenPaddle"])
@@ -106,6 +106,7 @@ class CarState(CarStateBase):
       ("TractionControlOn", "ESPStatus", 0),
       ("EPBClosed", "EPBStatus", 0),
       ("CruiseMainOn", "ECMEngineStatus", 0),
+      ("Brake_Pressed", "ECMEngineStatus", 0),
     ]
 
     checks = [


### PR DESCRIPTION
**Description** [] The Suburban (and Silverado) were encountering random disengages while operating with Stock ACC.
![random disengage](https://user-images.githubusercontent.com/29778397/150917712-96c845b6-63a4-4233-9711-f08a1f8f9ebe.png)


Logs indicated a Pedal pressed event. It was discovered that the brake position value when unpressed fluctuates normally between 6 and 9 (after scaling) but occasionally hits 10. Openpilot's threshold is >10 - meaning anything over 9 was seen as a press. The 10 was erroneously interpreted as a brake press. Since we know the value likes to reach 10, I bumped the threshold to 12 (So a max value of 11 means zero).

In this screenshot from Cabana, you can see the LKAS disabling immediately after a brake position value of 10:

![suburban_high_brake_float](https://user-images.githubusercontent.com/29778397/150917048-9c5d317f-770d-4a88-a02f-cdc281f35fc4.png)

Whereas here is the brake tap to disengage, followed by actual application of the brake while taking an exit:
![BrakePosition-tap](https://user-images.githubusercontent.com/29778397/150917344-04692404-1a04-49ca-98b8-84efeebdbc2a.png)




**Verification** [] After applying this (and the corresponding panda change) vehicle was driven 3 hours without any spurious pedal press events.
![none_of_those_disengages](https://user-images.githubusercontent.com/29778397/150918393-4972cd81-4997-4931-8cd2-df08d934a9fe.png)
![no_unexpected_disengages](https://user-images.githubusercontent.com/29778397/150918401-24673b24-03db-4ee9-83b2-2e1cf099b8bd.png)

NOTE: This fix also requires the same adjustment be made panda side - here is the associated PR: https://github.com/commaai/panda/pull/837
