### PR TITLE
Toyota: merge Lexus ESH params into similar vehicles

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -132,20 +132,12 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 3060. * CV.LB_TO_KG + STD_CARGO_KG
       set_lat_tune(ret.lateralTuning, LatTunes.PID_D)
 
-    elif candidate in (CAR.LEXUS_ES_TSS2, CAR.LEXUS_ESH_TSS2):
+    elif candidate in (CAR.LEXUS_ES_TSS2, CAR.LEXUS_ESH_TSS2, CAR.LEXUS_ESH):
       stop_and_go = True
       ret.wheelbase = 2.8702
       ret.steerRatio = 16.0  # not optimized
       tire_stiffness_factor = 0.444  # not optimized yet
-      ret.mass = 3704. * CV.LB_TO_KG + STD_CARGO_KG
-      set_lat_tune(ret.lateralTuning, LatTunes.PID_D)
-
-    elif candidate == CAR.LEXUS_ESH:
-      stop_and_go = True
-      ret.wheelbase = 2.8190
-      ret.steerRatio = 16.06
-      tire_stiffness_factor = 0.444  # not optimized yet
-      ret.mass = 3682. * CV.LB_TO_KG + STD_CARGO_KG
+      ret.mass = 3690. * CV.LB_TO_KG + STD_CARGO_KG  # mean between min and max
       set_lat_tune(ret.lateralTuning, LatTunes.PID_D)
 
     elif candidate == CAR.SIENNA:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -137,7 +137,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.8702
       ret.steerRatio = 16.0  # not optimized
       tire_stiffness_factor = 0.444  # not optimized yet
-      ret.mass = 3690. * CV.LB_TO_KG + STD_CARGO_KG  # mean between min and max
+      ret.mass = 3677. * CV.LB_TO_KG + STD_CARGO_KG  # mean between min and max
       set_lat_tune(ret.lateralTuning, LatTunes.PID_D)
 
     elif candidate == CAR.SIENNA:


### PR DESCRIPTION
One part of many for #23644.

Used min and max of all cars' variants (LEXUS ES 2019 has its own min max which I used the min from).

Mass is now max of a ~27 kg away from any of the true values.