### PR TITLE
PC: build with --test by default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,11 +6,14 @@ import sysconfig
 import platform
 import numpy as np
 
+from selfdrive.hardware import PC
+
 TICI = os.path.isfile('/TICI')
 Decider('MD5-timestamp')
 
 AddOption('--test',
           action='store_true',
+          default=PC,
           help='build test files')
 
 AddOption('--extras',

--- a/SConstruct
+++ b/SConstruct
@@ -6,9 +6,9 @@ import sysconfig
 import platform
 import numpy as np
 
-from selfdrive.hardware import PC
-
+EON = os.path.isfile('/EON')
 TICI = os.path.isfile('/TICI')
+PC = not (EON or TICI)
 Decider('MD5-timestamp')
 
 AddOption('--test',

--- a/selfdrive/camerad/SConscript
+++ b/selfdrive/camerad/SConscript
@@ -20,7 +20,7 @@ else:
   else:
     libs += ['avutil', 'avcodec', 'avformat', 'bz2', 'ssl', 'curl', 'crypto']
     # TODO: import replay_lib from root SConstruct
-    cameras = ['cameras/camera_replay.cc', 
+    cameras = ['cameras/camera_replay.cc',
       env.Object('camera-util', '#/selfdrive/ui/replay/util.cc'),
       env.Object('camera-framereader', '#/selfdrive/ui/replay/framereader.cc'),
       env.Object('camera-filereader', '#/selfdrive/ui/replay/filereader.cc')]


### PR DESCRIPTION
This builds with --test by default on PC. Useful for if you don't know about this flag and changed panda safety and am running something like `test_models.py`

Time to build all on 32 cores:

before: 83.7986 seconds
after:    86.5663 seconds