### PR TITLE
VW MQB: EPS configuration tool

### DIFF
--- a/selfdrive/debug/README.md
+++ b/selfdrive/debug/README.md
@@ -43,7 +43,9 @@ Lane Assist that want to use openpilot integrated at the CAN gateway (J533).
 
 This script is mean to run directly on a vehicle-installed comma two or comma
 three, with the openpilot/tmux processes stopped. It should also work on a
-separate PC with a USB-attached comma panda.
+separate PC with a USB-attached comma panda. Vehicle ignition must be on,
+recommend engine not be running. Must turn ignition off and on again for any
+changes to take effect.
 
 ```
 usage: vw_mqb_config.py [-h] [--debug] {disable,show,enable}

--- a/selfdrive/debug/README.md
+++ b/selfdrive/debug/README.md
@@ -34,3 +34,25 @@ optional arguments:
   --addr ADDR
   --values VALUES  values to monitor (instead of entire event)
 ```
+
+## [vw_mqb_config.py](vw_mqb_config.py)
+
+Shows Volkswagen EPS software and coding info, and enables or disables Heading
+Control Assist (Lane Assist). Useful for enabling HCA on cars without factory
+Lane Assist that want to use openpilot integrated at the CAN gateway (J533).
+
+This script is mean to run directly on a vehicle-installed comma two or comma
+three, with the openpilot/tmux processes stopped. It should also work on a
+separate PC with a USB-attached comma panda.
+
+```
+usage: vw_mqb_config.py [-h] [--debug] {disable,show,enable}
+
+positional arguments:
+  {disable,show,enable}
+                        show or modify current EPS HCA config
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               enable ISO-TP/UDS stack debugging output
+  ```

--- a/selfdrive/debug/README.md
+++ b/selfdrive/debug/README.md
@@ -41,7 +41,7 @@ Shows Volkswagen EPS software and coding info, and enables or disables Heading
 Control Assist (Lane Assist). Useful for enabling HCA on cars without factory
 Lane Assist that want to use openpilot integrated at the CAN gateway (J533).
 
-This script is mean to run directly on a vehicle-installed comma two or comma
+This script is meant to run directly on a vehicle-installed comma two or comma
 three, with the openpilot/tmux processes stopped. It should also work on a
 separate PC with a USB-attached comma panda. Vehicle ignition must be on,
 recommend engine not be running. Must turn ignition off and on again for any

--- a/selfdrive/debug/README.md
+++ b/selfdrive/debug/README.md
@@ -37,24 +37,23 @@ optional arguments:
 
 ## [vw_mqb_config.py](vw_mqb_config.py)
 
-Shows Volkswagen EPS software and coding info, and enables or disables Heading
-Control Assist (Lane Assist). Useful for enabling HCA on cars without factory
-Lane Assist that want to use openpilot integrated at the CAN gateway (J533).
-
-This script is meant to run directly on a vehicle-installed comma two or comma
-three, with the openpilot/tmux processes stopped. It should also work on a
-separate PC with a USB-attached comma panda. Vehicle ignition must be on,
-recommend engine not be running. Must turn ignition off and on again for any
-changes to take effect.
-
 ```
-usage: vw_mqb_config.py [-h] [--debug] {disable,show,enable}
+usage: vw_mqb_config.py [-h] [--debug] {enable,show,disable}
+
+Shows Volkswagen EPS software and coding info, and enables or disables Heading Control
+Assist (Lane Assist). Useful for enabling HCA on cars without factory Lane Assist that want
+to use openpilot integrated at the CAN gateway (J533).
 
 positional arguments:
-  {disable,show,enable}
+  {enable,show,disable}
                         show or modify current EPS HCA config
 
 optional arguments:
   -h, --help            show this help message and exit
   --debug               enable ISO-TP/UDS stack debugging output
-  ```
+
+This tool is meant to run directly on a vehicle-installed comma two or comma three, with
+the openpilot/tmux processes stopped. It should also work on a separate PC with a USB-
+attached comma panda. Vehicle ignition must be on. Recommend engine not be running when
+making changes. Must turn ignition off and on again for any changes to take effect.
+```

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -21,7 +21,14 @@ MQB_EPS_CAN_ADDR = 0x712
 RX_OFFSET = 0x6a
 
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser()
+  desc_text =   "Shows Volkswagen EPS software and coding info, and enables or disables Heading Control Assist " + \
+                "(Lane Assist). Useful for enabling HCA on cars without factory Lane Assist that want to use " + \
+                "openpilot integrated at the CAN gateway (J533)."
+  epilog_text = "This tool is meant to run directly on a vehicle-installed comma two or comma three, with the " + \
+                "openpilot/tmux processes stopped. It should also work on a separate PC with a USB-attached comma " + \
+                "panda. Vehicle ignition must be on. Recommend engine not be running when making changes. Must " + \
+                "turn ignition off and on again for any changes to take effect."
+  parser = argparse.ArgumentParser(description=desc_text, epilog=epilog_text)
   parser.add_argument("--debug", action="store_true", help="enable ISO-TP/UDS stack debugging output")
   parser.add_argument("action", choices={"show", "enable", "disable"}, help="show or modify current EPS HCA config")
   args = parser.parse_args()

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -17,6 +17,9 @@ class ACCESS_TYPE_LEVEL_1(IntEnum):
   REQUEST_SEED = ACCESS_TYPE.REQUEST_SEED + 2
   SEND_KEY = ACCESS_TYPE.SEND_KEY + 2
 
+MQB_EPS_CAN_ADDR = 0x712
+RX_OFFSET = 0x6a
+
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument("--debug", action="store_true", help="enable ISO-TP/UDS stack debugging output")
@@ -26,7 +29,7 @@ if __name__ == "__main__":
   panda = Panda()
   panda.set_safety_mode(Panda.SAFETY_ELM327)
   bus = 1 if panda.has_obd() else 0
-  uds_client = UdsClient(panda, 0x712, 0x77c, bus, timeout=0.2, debug=args.debug)
+  uds_client = UdsClient(panda, MQB_EPS_CAN_ADDR, MQB_EPS_CAN_ADDR + RX_OFFSET, bus, timeout=0.2, debug=args.debug)
 
   try:
     uds_client.diagnostic_session_control(SESSION_TYPE.EXTENDED_DIAGNOSTIC)

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     current_coding = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.CODING)  # type: ignore
     coding_text = current_coding.hex()
 
-    print("\nDiagnostic data from EPS controller\n")
+    print("\nEPS diagnostic data\n")
     print(f"   Part No HW:   {hw_pn}")
     print(f"   Part No SW:   {sw_pn}")
     print(f"   SW Version:   {sw_ver}")
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     param_index_char_curve = params[5:7]
     param_version_char_values = params[7:9]
     param_version_memory_map = params[9:11]
-    print("\nEPS parameterization data\n")
+    print("\nEPS parameterization (per-vehicle calibration) data\n")
     print(f"   Version of system parameters:     {param_version_system_params}")
     print(f"   Vehicle type:                     {param_vehicle_type}")
     print(f"   Index of characteristic curve:    {param_index_char_curve}")

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -2,8 +2,20 @@
 
 import argparse
 import struct
+from enum import IntEnum
 from panda import Panda
-from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
+from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE,\
+  DATA_IDENTIFIER_TYPE, ACCESS_TYPE
+
+# TODO: extend UDS library to allow custom/vendor-defined data identifiers without ignoring type checks
+class VOLKSWAGEN_DATA_IDENTIFIER_TYPE(IntEnum):
+  CODING = 0x0600
+  ODX_FILE_VERSION = 0xF182
+
+# TODO: extend UDS library security_access() to take an access level offset per ISO 14229-1:2020 10.4 and remove this
+class ACCESS_TYPE_LEVEL_1(IntEnum):
+  REQUEST_SEED = ACCESS_TYPE.REQUEST_SEED + 2
+  SEND_KEY = ACCESS_TYPE.SEND_KEY + 2
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
@@ -29,8 +41,8 @@ if __name__ == "__main__":
     sw_ver = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER).decode("utf-8")
     component = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.SYSTEM_NAME_OR_ENGINE_TYPE).decode("utf-8")
     odx_file = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.ODX_FILE).decode("utf-8")
-    odx_ver = uds_client.read_data_by_identifier(0xF1A2).decode("utf-8")  # type: ignore
-    current_coding = uds_client.read_data_by_identifier(0x0600)  # type: ignore
+    odx_ver = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.ODX_FILE_VERSION).decode("utf-8")  # type: ignore
+    current_coding = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.CODING)  # type: ignore
     coding_text = current_coding.hex()
 
     print("\nDiagnostic data from EPS controller\n")
@@ -74,9 +86,9 @@ if __name__ == "__main__":
     new_coding = new_byte_0.to_bytes(1, "little") + current_coding[1:]
 
     try:
-      seed = uds_client.security_access(0x3)  # type: ignore
+      seed = uds_client.security_access(ACCESS_TYPE_LEVEL_1.REQUEST_SEED)  # type: ignore
       key = struct.unpack("!I", seed)[0] + 28183  # yeah, it's like that
-      uds_client.security_access(0x4, struct.pack("!I", key))  # type: ignore
+      uds_client.security_access(ACCESS_TYPE_LEVEL_1.SEND_KEY, struct.pack("!I", key))  # type: ignore
     except (NegativeResponseError, MessageTimeoutError):
       print("Security access failed!")
       quit()
@@ -93,14 +105,14 @@ if __name__ == "__main__":
       uds_client.write_data_by_identifier(DATA_IDENTIFIER_TYPE.PROGRAMMING_DATE, prog_date)
       tester_num = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.CALIBRATION_REPAIR_SHOP_CODE_OR_CALIBRATION_EQUIPMENT_SERIAL_NUMBER)
       uds_client.write_data_by_identifier(DATA_IDENTIFIER_TYPE.REPAIR_SHOP_CODE_OR_TESTER_SERIAL_NUMBER, tester_num)
-      uds_client.write_data_by_identifier(0x0600, new_coding)  # type: ignore
+      uds_client.write_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.CODING, new_coding)  # type: ignore
     except (NegativeResponseError, MessageTimeoutError):
       print("Writing new configuration failed!")
       quit()
 
     try:
       # Read back result just to make 100% sure everything worked
-      current_coding_text = uds_client.read_data_by_identifier(0x0600).hex()  # type: ignore
+      current_coding_text = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.CODING).hex()  # type: ignore
       print(f"   New coding:   {current_coding_text}")
     except (NegativeResponseError, MessageTimeoutError):
       print("Reading back updated coding failed!")

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
   if odx_file == "EV_SteerAssisMQB\x00":
     coding_variant = "ZF"
     current_coding_array = struct.unpack("!4B", current_coding)
-    hca_enabled = (current_coding_array[0] & 1 << 4 != 0)
+    hca_enabled = (current_coding_array[0] & (1 << 4) != 0)
     hca_text = ("DISABLED", "ENABLED")[hca_enabled]
     print(f"   Lane Assist:  {hca_text}")
   else:

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -54,14 +54,26 @@ if __name__ == "__main__":
     odx_ver = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.ODX_FILE_VERSION).decode("utf-8")  # type: ignore
     current_coding = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.CODING)  # type: ignore
     coding_text = current_coding.hex()
+    params = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.APPLICATION_DATA_IDENTIFICATION).decode("utf-8")
+    param_version_system_params = params[0:2]
+    param_vehicle_type = params[2:4]
+    param_index_char_curve = params[4:6]
+    param_version_char_values = params[6:8]
+    param_version_memory_map = params[8:10]
 
     print("\nDiagnostic data from EPS controller\n")
     print(f"   Part No HW:   {hw_pn}")
     print(f"   Part No SW:   {sw_pn}")
-    print(f"   SW version:   {sw_ver}")
+    print(f"   SW Version:   {sw_ver}")
     print(f"   Component:    {component}")
     print(f"   Coding:       {coding_text}")
     print(f"   ASAM Dataset: {odx_file} version {odx_ver}")
+    print("\nEPS parameterization data\n")
+    print(f"   Version of system parameters:     {param_version_system_params}")
+    print(f"   Vehicle type:                     {param_vehicle_type}")
+    print(f"   Index of characteristic curve:    {param_index_char_curve}")
+    print(f"   Version of characteristic values: {param_version_char_values}")
+    print(f"   Version of memory map:            {param_version_memory_map}")
   except NegativeResponseError:
     print("Error fetching data from EPS")
     quit()

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import argparse
+import struct
+from panda import Panda
+from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--debug", action="store_true", help="enable ISO-TP/UDS stack debugging output")
+  parser.add_argument("action", choices={"show", "enable", "disable"}, help="show or modify current EPS HCA config")
+  args = parser.parse_args()
+
+  panda = Panda()
+  panda.set_safety_mode(Panda.SAFETY_ELM327)
+  bus = 1 if panda.has_obd() else 0
+  uds_client = UdsClient(panda, 0x712, 0x77c, bus, timeout=0.2, debug=args.debug)
+
+  try:
+    uds_client.diagnostic_session_control(SESSION_TYPE.EXTENDED_DIAGNOSTIC)
+  except MessageTimeoutError:
+    print("Timeout opening session with EPS")
+    quit()
+
+  odx_file, current_coding = None, None
+  try:
+    hw_pn = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER).decode("utf-8")
+    sw_pn = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_SPARE_PART_NUMBER).decode("utf-8")
+    sw_ver = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER).decode("utf-8")
+    component = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.SYSTEM_NAME_OR_ENGINE_TYPE).decode("utf-8")
+    odx_file = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.ODX_FILE).decode("utf-8")
+    odx_ver = uds_client.read_data_by_identifier(0xF1A2).decode("utf-8")  # type: ignore
+    current_coding = uds_client.read_data_by_identifier(0x0600)  # type: ignore
+    coding_text = current_coding.hex()
+
+    print("\nDiagnostic data from EPS controller\n")
+    print(f"   Part No HW:   {hw_pn}")
+    print(f"   Part No SW:   {sw_pn}")
+    print(f"   SW version:   {sw_ver}")
+    print(f"   Component:    {component}")
+    print(f"   Coding:       {coding_text}")
+    print(f"   ASAM Dataset: {odx_file} version {odx_ver}")
+  except NegativeResponseError:
+    print("Error fetching data from EPS")
+    quit()
+  except MessageTimeoutError:
+    print("Timeout fetching data from EPS")
+    quit()
+
+  coding_variant, current_coding_array = None, None
+  # EV_SteerAssisMQB covers the majority of MQB racks (EPS_MQB_ZFLS)
+  # APA racks (MQB_PP_APA) have a different coding layout, which should
+  # be easy to support once we identify the specific config bit
+  if odx_file == "EV_SteerAssisMQB\x00":
+    coding_variant = "ZF"
+    current_coding_array = struct.unpack("!4B", current_coding)
+    hca_enabled = (current_coding_array[0] & 1 << 4 != 0)
+    hca_text = ("DISABLED", "ENABLED")[hca_enabled]
+    print(f"   Lane Assist:  {hca_text}")
+  else:
+    print("Configuration changes not yet supported on this EPS!")
+    quit()
+
+  if args.action in ["enable", "disable"]:
+    print("\nAttempting configuration update")
+
+    assert(coding_variant == "ZF")  # revisit when we have the APA rack coding bit
+    # ZF EPS config coding length can be anywhere from 1 to 4 bytes, but the
+    # bit we care about is always in the same place in the first byte
+    if args.action == "enable":
+      new_byte_0 = current_coding_array[0] | 1 << 4
+    else:
+      new_byte_0 = current_coding_array[0] & ~(1 << 4)
+    new_coding = new_byte_0.to_bytes(1, "little") + current_coding[1:]
+
+    try:
+      seed = uds_client.security_access(0x3)  # type: ignore
+      key = struct.unpack("!I", seed)[0] + 28183  # yeah, it's like that
+      uds_client.security_access(0x4, struct.pack("!I", key))  # type: ignore
+    except (NegativeResponseError, MessageTimeoutError):
+      print("Security access failed!")
+      quit()
+
+    try:
+      # Programming date and tester number must be written before making
+      # a change, or write to 0x0600 will fail with request sequence error
+      # Encoding on tester is unclear, it contains the workshop code in the
+      # last two bytes, but not the VZ/importer or tester serial number
+      # Can't seem to read it back, but we can read the calibration tester,
+      # so fib a little and say that same tester did the programming
+      # TODO: encode the actual current date
+      prog_date = b'\x22\x02\x08'
+      uds_client.write_data_by_identifier(DATA_IDENTIFIER_TYPE.PROGRAMMING_DATE, prog_date)
+      tester_num = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.CALIBRATION_REPAIR_SHOP_CODE_OR_CALIBRATION_EQUIPMENT_SERIAL_NUMBER)
+      uds_client.write_data_by_identifier(DATA_IDENTIFIER_TYPE.REPAIR_SHOP_CODE_OR_TESTER_SERIAL_NUMBER, tester_num)
+      uds_client.write_data_by_identifier(0x0600, new_coding)  # type: ignore
+    except (NegativeResponseError, MessageTimeoutError):
+      print("Writing new configuration failed!")
+      quit()
+
+    try:
+      # Read back result just to make 100% sure everything worked
+      current_coding_text = uds_client.read_data_by_identifier(0x0600).hex()  # type: ignore
+      print(f"   New coding:   {current_coding_text}")
+    except (NegativeResponseError, MessageTimeoutError):
+      print("Reading back updated coding failed!")
+      quit()
+    print("EPS configuration successfully updated")

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -10,7 +10,6 @@ from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseErr
 # TODO: extend UDS library to allow custom/vendor-defined data identifiers without ignoring type checks
 class VOLKSWAGEN_DATA_IDENTIFIER_TYPE(IntEnum):
   CODING = 0x0600
-  ODX_FILE_VERSION = 0xF182
 
 # TODO: extend UDS library security_access() to take an access level offset per ISO 14229-1:2020 10.4 and remove this
 class ACCESS_TYPE_LEVEL_1(IntEnum):
@@ -51,7 +50,6 @@ if __name__ == "__main__":
     sw_ver = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER).decode("utf-8")
     component = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.SYSTEM_NAME_OR_ENGINE_TYPE).decode("utf-8")
     odx_file = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.ODX_FILE).decode("utf-8")
-    odx_ver = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.ODX_FILE_VERSION).decode("utf-8")  # type: ignore
     current_coding = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.CODING)  # type: ignore
     coding_text = current_coding.hex()
 
@@ -61,7 +59,7 @@ if __name__ == "__main__":
     print(f"   SW Version:   {sw_ver}")
     print(f"   Component:    {component}")
     print(f"   Coding:       {coding_text}")
-    print(f"   ASAM Dataset: {odx_file} version {odx_ver}")
+    print(f"   ASAM Dataset: {odx_file}")
   except NegativeResponseError:
     print("Error fetching data from EPS")
     quit()

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
 
     try:
       # Programming date and tester number must be written before making
-      # a change, or write to 0x0600 will fail with request sequence error
+      # a change, or write to CODING will fail with request sequence error
       # Encoding on tester is unclear, it contains the workshop code in the
       # last two bytes, but not the VZ/importer or tester serial number
       # Can't seem to read it back, but we can read the calibration tester,

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # ZF EPS config coding length can be anywhere from 1 to 4 bytes, but the
     # bit we care about is always in the same place in the first byte
     if args.action == "enable":
-      new_byte_0 = current_coding_array[0] | 1 << 4
+      new_byte_0 = current_coding_array[0] | (1 << 4)
     else:
       new_byte_0 = current_coding_array[0] & ~(1 << 4)
     new_coding = new_byte_0.to_bytes(1, "little") + current_coding[1:]

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -54,12 +54,6 @@ if __name__ == "__main__":
     odx_ver = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.ODX_FILE_VERSION).decode("utf-8")  # type: ignore
     current_coding = uds_client.read_data_by_identifier(VOLKSWAGEN_DATA_IDENTIFIER_TYPE.CODING)  # type: ignore
     coding_text = current_coding.hex()
-    params = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.APPLICATION_DATA_IDENTIFICATION).decode("utf-8")
-    param_version_system_params = params[0:2]
-    param_vehicle_type = params[2:4]
-    param_index_char_curve = params[4:6]
-    param_version_char_values = params[6:8]
-    param_version_memory_map = params[8:10]
 
     print("\nDiagnostic data from EPS controller\n")
     print(f"   Part No HW:   {hw_pn}")
@@ -68,12 +62,6 @@ if __name__ == "__main__":
     print(f"   Component:    {component}")
     print(f"   Coding:       {coding_text}")
     print(f"   ASAM Dataset: {odx_file} version {odx_ver}")
-    print("\nEPS parameterization data\n")
-    print(f"   Version of system parameters:     {param_version_system_params}")
-    print(f"   Vehicle type:                     {param_vehicle_type}")
-    print(f"   Index of characteristic curve:    {param_index_char_curve}")
-    print(f"   Version of characteristic values: {param_version_char_values}")
-    print(f"   Version of memory map:            {param_version_memory_map}")
   except NegativeResponseError:
     print("Error fetching data from EPS")
     quit()
@@ -93,6 +81,23 @@ if __name__ == "__main__":
     print(f"   Lane Assist:  {hca_text}")
   else:
     print("Configuration changes not yet supported on this EPS!")
+    quit()
+
+  try:
+    params = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.APPLICATION_DATA_IDENTIFICATION).decode("utf-8")
+    param_version_system_params = params[1:3]
+    param_vehicle_type = params[3:5]
+    param_index_char_curve = params[5:7]
+    param_version_char_values = params[7:9]
+    param_version_memory_map = params[9:11]
+    print("\nEPS parameterization data\n")
+    print(f"   Version of system parameters:     {param_version_system_params}")
+    print(f"   Vehicle type:                     {param_vehicle_type}")
+    print(f"   Index of characteristic curve:    {param_index_char_curve}")
+    print(f"   Version of characteristic values: {param_version_char_values}")
+    print(f"   Version of memory map:            {param_version_memory_map}")
+  except (NegativeResponseError, MessageTimeoutError):
+    print("Error fetching parameterization data from EPS!")
     quit()
 
   if args.action in ["enable", "disable"]:


### PR DESCRIPTION
Carried over from commaai/panda#848.

This is a simple tool to enable/disable HCA (Lane Assist) support in the Volkswagen MQB EPS. This is mainly useful if it's not already enabled from the factory, for those folks installing openpilot without factory Lane Assist using J533 harnesses.

This will work for the majority of MQB EPS racks. There is only one other major variant I'm aware of, and it should be trivial to add when we identify the proper bit to set. The tool will detect EPS models it doesn't support and refuse to configure them.

I plan to do more cleanup and feature work on this, but checking in what I have so I can work on other more urgent stuff.

**Short term TODO:**
* Support APA steering racks (just need to talk to someone with VCDS/OBDEleven and an APA rack)
* Handle programming date more correctly (cross manipulation of bit/byte/string data in Python is enraging)
* Add security access level to the UDS library (multiplier for access_type), then clean up my security_access code

**Long term TODO:**
* Extend this to support enabling/disabling Lane Assist messaging in the instrument cluster (lane lines, status, etc)
* Extend this to support tweaking the number of comfort blinks in the BCM (default to 3, nice for OP to use 5 or so)

These same tasks can eventually be done for VW PQ if we bring in Willem's new [TP2.0 and KWP2000 libraries](https://github.com/pd0wm/pq-flasher).

**Tool output, shows HCA disabled:**
```
comma@tici:/data/openpilot/panda/examples$ ./vw_mqb_config.py show
opening device 23001f001951393037323631 0xddcc
connected

Diagnostic data from EPS controller

   Part No HW:   3Q0909144L 
   Part No SW:   3Q0909144L 
   SW version:   5081
   Component:    EPS_MQB_ZFLS 
   Coding:       811f0000
   ASAM Dataset: EV_SteerAssisMQB version 015157
   Lane Assist:  DISABLED
```

**Tool output, changing coding to enable HCA:**
```
comma@tici:/data/openpilot/panda/examples$ ./vw_mqb_config.py enable
opening device 23001f001951393037323631 0xddcc
connected

Diagnostic data from EPS controller

   Part No HW:   3Q0909144L 
   Part No SW:   3Q0909144L 
   SW version:   5081
   Component:    EPS_MQB_ZFLS 
   Coding:       811f0000
   ASAM Dataset: EV_SteerAssisMQB version 015157
   Lane Assist:  DISABLED

Attempting configuration update
   New coding:   911f0000
EPS configuration successfully updated
```

**Tool output, shows HCA now enabled:**
```
comma@tici:/data/openpilot/panda/examples$ ./vw_mqb_config.py show
opening device 23001f001951393037323631 0xddcc
connected

Diagnostic data from EPS controller

   Part No HW:   3Q0909144L 
   Part No SW:   3Q0909144L 
   SW version:   5081
   Component:    EPS_MQB_ZFLS 
   Coding:       911f0000
   ASAM Dataset: EV_SteerAssisMQB version 015157
   Lane Assist:  ENABLED
```
