### PR TITLE
[PID] sanitize gains - cleanup

### DIFF
--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -33,27 +33,28 @@ class PIController():
     return interp(self.speed, self._k_i[0], self._k_i[1])
 
   def sanitize_gains(self, k_p, k_i, k_f):
+    if isinstance(k_p, Number):
+      k_p = [[0], [k_p]]
+    if not k_p[0]:
+      k_p[0] = [0.0]
+    if not k_p[1]:
+      k_p = [[0], [0]]
+
+    if isinstance(k_i, Number):
+      k_i = [[0], [k_i]]
+    if not k_i[0]:
+      k_i[0] = [0.0]
+    if not k_i[1]:
+      k_i = [[0], [0]]
+    
+    if not isinstance(k_f, Number):
+      k_f = 0
+    if not k_i[0]:
+      k_f = 0
+
     self._k_p = k_p  # proportional gain
     self._k_i = k_i  # integral gain
     self.k_f = k_f   # feedforward gain
-    if isinstance(self._k_p, Number):
-      self._k_p = [[0], [self._k_p]]
-    if not self._k_p[0]:
-      self._k_p[0] = [0.0]
-    if not self._k_p[1]:
-      self._k_p = [[0], [0]]
-
-    if isinstance(self._k_i, Number):
-      self._k_i = [[0], [self._k_i]]
-    if not self._k_i[0]:
-      self._k_i[0] = [0.0]
-    if not self._k_i[1]:
-      self._k_i = [[0], [0]]
-    
-    if not isinstance(self.k_f, Number):
-      self.k_f = 0
-    if not self._k_i[0]:
-      self.k_f = 0
 
   def reset(self):
     self.p = 0.0

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -14,13 +14,7 @@ def apply_deadzone(error, deadzone):
 
 class PIController():
   def __init__(self, k_p, k_i, k_f=1., pos_limit=None, neg_limit=None, rate=100):
-    self._k_p = k_p  # proportional gain
-    self._k_i = k_i  # integral gain
-    self.k_f = k_f   # feedforward gain
-    if isinstance(self._k_p, Number):
-      self._k_p = [[0], [self._k_p]]
-    if isinstance(self._k_i, Number):
-      self._k_i = [[0], [self._k_i]]
+    self.sanitize_gains(k_p, k_i, k_f)
 
     self.pos_limit = pos_limit
     self.neg_limit = neg_limit
@@ -37,6 +31,24 @@ class PIController():
   @property
   def k_i(self):
     return interp(self.speed, self._k_i[0], self._k_i[1])
+
+  def sanitize_gains(self, k_p, k_i, k_f):
+    self._k_p = k_p  # proportional gain
+    self._k_i = k_i  # integral gain
+    self.k_f = k_f   # feedforward gain
+    if isinstance(self._k_p, Number):
+      self._k_p = [[0], [self._k_p]]
+    if not self._k_p[0]:
+      self._k_p[0] = [0.0]
+    if not self._k_p[1]:
+      self._k_p = [[0], [0]]
+
+    if isinstance(self._k_i, Number):
+      self._k_i = [[0], [self._k_i]]
+    if not self._k_i[0]:
+      self._k_i[0] = [0.0]
+    if not self._k_i[1]:
+      self._k_i = [[0], [0]]
 
   def reset(self):
     self.p = 0.0

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -14,25 +14,6 @@ def apply_deadzone(error, deadzone):
 
 class PIController():
   def __init__(self, k_p, k_i, k_f=0., pos_limit=None, neg_limit=None, rate=100):
-    self.sanitize_gains(k_p, k_i, k_f)
-
-    self.pos_limit = pos_limit
-    self.neg_limit = neg_limit
-
-    self.i_unwind_rate = 0.3 / rate
-    self.i_rate = 1.0 / rate
-
-    self.reset()
-
-  @property
-  def k_p(self):
-    return interp(self.speed, self._k_p[0], self._k_p[1])
-
-  @property
-  def k_i(self):
-    return interp(self.speed, self._k_i[0], self._k_i[1])
-
-  def sanitize_gains(self, k_p, k_i, k_f):
     if isinstance(k_p, Number):
       k_p = [[0], [k_p]]
     if not k_p[0]:
@@ -55,6 +36,22 @@ class PIController():
     self._k_p = k_p  # proportional gain
     self._k_i = k_i  # integral gain
     self.k_f = k_f   # feedforward gain
+
+    self.pos_limit = pos_limit
+    self.neg_limit = neg_limit
+
+    self.i_unwind_rate = 0.3 / rate
+    self.i_rate = 1.0 / rate
+
+    self.reset()
+
+  @property
+  def k_p(self):
+    return interp(self.speed, self._k_p[0], self._k_p[1])
+
+  @property
+  def k_i(self):
+    return interp(self.speed, self._k_i[0], self._k_i[1])
 
   def reset(self):
     self.p = 0.0

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -13,7 +13,7 @@ def apply_deadzone(error, deadzone):
   return error
 
 class PIController():
-  def __init__(self, k_p, k_i, k_f=1., pos_limit=None, neg_limit=None, rate=100):
+  def __init__(self, k_p, k_i, k_f=0., pos_limit=None, neg_limit=None, rate=100):
     self.sanitize_gains(k_p, k_i, k_f)
 
     self.pos_limit = pos_limit
@@ -49,6 +49,11 @@ class PIController():
       self._k_i[0] = [0.0]
     if not self._k_i[1]:
       self._k_i = [[0], [0]]
+    
+    if not isinstance(self.k_f, Number):
+      self.k_f = 0
+    if not self._k_i[0]:
+      self.k_f = 0
 
   def reset(self):
     self.p = 0.0


### PR DESCRIPTION
ran into division by zero in numpy_fast.py in selfdrive:process-replay
it was empty lists from the capnp list builder being passed into the pid controller for the gains. 

for me it happened because I had a kd term and the toyota interface calls a tune list that invokes the lateraltuning.init() function clearing the values from cars/interfaces.py. 
Although I'm not sure what changed since I last updated that caused this since it looks like the toyota stuff was there on by branch before I updated. 

if you were to exclude BP's or V's for Ki / Kp from the interface for a vehicle it would crash here as well. 


I'm inclined to say "who cares" but I see some sanitation was getting added here for passing values in the wrong format already so I moved it to a dedicated function and added sanitation for missing BP's or excluded gains. 
