### PR TITLE
fix UI segfault when starting onroad and receiving radarState before modelV2

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -129,7 +129,7 @@ static void update_state(UIState *s) {
     if (sm.updated("modelV2")) {
       update_model(s, sm["modelV2"].getModelV2());
     }
-    if (sm.updated("radarState") && sm.rcv_frame("modelV2") >= s->scene.started_frame) {
+    if (sm.updated("radarState") && sm.rcv_frame("modelV2") > s->scene.started_frame) {
       update_leads(s, sm["radarState"].getRadarState(), sm["modelV2"].getModelV2().getPosition());
     }
   }


### PR DESCRIPTION
Reproducible when starting ui with replay already running. Might also trigger on device if ui is restarted by the watchdog, but don't see any in sentry.