### PR TITLE
[PID] sanitize gains

### DIFF
--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -19,8 +19,12 @@ class PIController():
     self.k_f = k_f   # feedforward gain
     if isinstance(self._k_p, Number):
       self._k_p = [[0], [self._k_p]]
+    if not self._k_p[1]:
+      self._k_p = [[0], [0]]
     if isinstance(self._k_i, Number):
       self._k_i = [[0], [self._k_i]]
+    if not self._k_i[1]:
+      self._k_i = [[0], [0]]
 
     self.pos_limit = pos_limit
     self.neg_limit = neg_limit

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -14,6 +14,17 @@ def apply_deadzone(error, deadzone):
 
 class PIController():
   def __init__(self, k_p, k_i, k_f=1., pos_limit=None, neg_limit=None, rate=100):
+    self.sanitize_gains(k_p, k_i, k_f)
+
+    self.pos_limit = pos_limit
+    self.neg_limit = neg_limit
+
+    self.i_unwind_rate = 0.3 / rate
+    self.i_rate = 1.0 / rate
+
+    self.reset()
+
+  def sanitize_gains(self, k_p, k_i, k_f):
     self._k_p = k_p  # proportional gain
     self._k_i = k_i  # integral gain
     self.k_f = k_f   # feedforward gain
@@ -25,14 +36,6 @@ class PIController():
       self._k_i = [[0], [self._k_i]]
     if not self._k_i[1]:
       self._k_i = [[0], [0]]
-
-    self.pos_limit = pos_limit
-    self.neg_limit = neg_limit
-
-    self.i_unwind_rate = 0.3 / rate
-    self.i_rate = 1.0 / rate
-
-    self.reset()
 
   @property
   def k_p(self):

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -41,7 +41,10 @@ class PIController():
       self._k_i = [[0.], self._k_i[1]]
     if not self._k_i[1]:
       self._k_i = [[0], [0]]
-
+      
+    if not isinstance(self.k_f, Number):
+      self.k_f = 0
+      
   @property
   def k_p(self):
     return interp(self.speed, self._k_p[0], self._k_p[1])

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -30,10 +30,15 @@ class PIController():
     self.k_f = k_f   # feedforward gain
     if isinstance(self._k_p, Number):
       self._k_p = [[0], [self._k_p]]
+    if not self._k_p[0]:
+      self._k_p = [[0.], self._k_p[1]]
     if not self._k_p[1]:
       self._k_p = [[0], [0]]
+
     if isinstance(self._k_i, Number):
       self._k_i = [[0], [self._k_i]]
+    if not self._k_i[0]:
+      self._k_i = [[0.], self._k_i[1]]
     if not self._k_i[1]:
       self._k_i = [[0], [0]]
 


### PR DESCRIPTION
ran into division by zero in numpy_fast.py in selfdrive:process-replay
it was empty lists from the capnp list builder being passed into the pid controller for the gains.

for me it happened because I had a kd term and the toyota interface calls a tune list that invokes the lateraltuning.init() function clearing the values from cars/interfaces.py.
Although I'm not sure what changed since I last updated that caused this since it looks like the toyota stuff was there on by branch before I updated.

if you were to exclude BP's or V's for Ki / Kp from the interface for a vehicle it would crash here as well.

I'm inclined to say "who cares" but I see some sanitation was getting added here for passing values in the wrong format already so I moved it to a dedicated function and added sanitation for missing BP's or excluded gains.