### PR TITLE
Hyundai: fix cancel command occasionally not working

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -3,7 +3,8 @@ from common.realtime import DT_CTRL
 from common.numpy_fast import clip, interp
 from selfdrive.config import Conversions as CV
 from selfdrive.car import apply_std_steer_torque_limits
-from selfdrive.car.hyundai.hyundaican import create_lkas11, create_clu11, create_lfahda_mfc, create_acc_commands, create_acc_opt, create_frt_radar_opt
+from selfdrive.car.hyundai.hyundaican import create_lkas11, create_clu11, create_lfahda_mfc, create_acc_commands, \
+                                             create_acc_opt, create_frt_radar_opt, create_cancel_command
 from selfdrive.car.hyundai.values import Buttons, CarControllerParams, CAR
 from opendbc.can.packer import CANPacker
 
@@ -45,6 +46,8 @@ class CarController():
     self.steer_rate_limited = False
     self.last_resume_frame = 0
     self.accel = 0
+    self.cancel_frames = 0
+    self.prev_pcm_cancel = False
 
   def update(self, c, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert, hud_speed,
              left_lane, right_lane, left_lane_depart, right_lane_depart):
@@ -78,14 +81,23 @@ class CarController():
                                    left_lane_warning, right_lane_warning))
 
     if not CS.CP.openpilotLongitudinalControl:
+      if pcm_cancel_cmd and not self.prev_pcm_cancel:
+        self.cancel_frames = 0
       if pcm_cancel_cmd:
-        can_sends.append(create_clu11(self.packer, frame, CS.clu11, Buttons.CANCEL))
+        self.cancel_frames += 1
+        if frame % 10 == 0:
+          print('Sending cancel')
+          can_sends.extend([create_cancel_command(self.packer, CS.cgw1)] * 1)
       elif CS.out.cruiseState.standstill:
         # send resume at a max freq of 10Hz
         if (frame - self.last_resume_frame) * DT_CTRL > 0.1:
           # send 25 messages at a time to increases the likelihood of resume being accepted
           can_sends.extend([create_clu11(self.packer, frame, CS.clu11, Buttons.RES_ACCEL)] * 25)
           self.last_resume_frame = frame
+
+      if not pcm_cancel_cmd and self.prev_pcm_cancel:
+        print('Took {} send frames to cancel'.format(self.cancel_frames))
+      self.prev_pcm_cancel = pcm_cancel_cmd
 
     if frame % 2 == 0 and CS.CP.openpilotLongitudinalControl:
       lead_visible = False

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -46,8 +46,6 @@ class CarController():
     self.steer_rate_limited = False
     self.last_resume_frame = 0
     self.accel = 0
-    self.cancel_frames = 0
-    self.prev_pcm_cancel = False
 
   def update(self, c, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert, hud_speed,
              left_lane, right_lane, left_lane_depart, right_lane_depart):
@@ -81,23 +79,14 @@ class CarController():
                                    left_lane_warning, right_lane_warning))
 
     if not CS.CP.openpilotLongitudinalControl:
-      if pcm_cancel_cmd and not self.prev_pcm_cancel:
-        self.cancel_frames = 0
-      if pcm_cancel_cmd:
-        self.cancel_frames += 1
-        if frame % 10 == 0:
-          print('Sending cancel')
-          can_sends.extend([create_cancel_command(self.packer, CS.cgw1)] * 1)
+      if frame % 4 == 0:
+        can_sends.extend([create_cancel_command(self.packer, CS.cgw1)] * 10)
       elif CS.out.cruiseState.standstill:
         # send resume at a max freq of 10Hz
         if (frame - self.last_resume_frame) * DT_CTRL > 0.1:
           # send 25 messages at a time to increases the likelihood of resume being accepted
           can_sends.extend([create_clu11(self.packer, frame, CS.clu11, Buttons.RES_ACCEL)] * 25)
           self.last_resume_frame = frame
-
-      if not pcm_cancel_cmd and self.prev_pcm_cancel:
-        print('Took {} send frames to cancel'.format(self.cancel_frames))
-      self.prev_pcm_cancel = pcm_cancel_cmd
 
     if frame % 2 == 0 and CS.CP.openpilotLongitudinalControl:
       lead_visible = False

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -79,7 +79,7 @@ class CarController():
                                    left_lane_warning, right_lane_warning))
 
     if not CS.CP.openpilotLongitudinalControl:
-      if frame % 4 == 0:
+      if pcm_cancel_cmd and frame % 4 == 0:
         can_sends.extend([create_cancel_command(self.packer, CS.cgw1)] * 10)
       elif CS.out.cruiseState.standstill:
         # send resume at a max freq of 10Hz

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -109,6 +109,7 @@ class CarState(CarStateBase):
     # save the entire LKAS11 and CLU11
     self.lkas11 = copy.copy(cp_cam.vl["LKAS11"])
     self.clu11 = copy.copy(cp.vl["CLU11"])
+    self.cgw1 = copy.copy(cp.vl["CGW1"])
     self.park_brake = cp.vl["TCS13"]["PBRAKE_ACT"] == 1
     self.steer_state = cp.vl["MDPS12"]["CF_Mdps_ToiActive"]  # 0 NOT ACTIVE, 1 ACTIVE
     self.brake_error = cp.vl["TCS13"]["ACCEnable"] != 0 # 0 ACC CONTROL ENABLED, 1-3 ACC CONTROL DISABLED
@@ -138,6 +139,43 @@ class CarState(CarStateBase):
       ("CF_Gway_TurnSigLh", "CGW1"),
       ("CF_Gway_TurnSigRh", "CGW1"),
       ("CF_Gway_ParkBrakeSw", "CGW1"),
+      ("CF_Gway_IGNSw", "CGW1"),
+      ("CF_Gway_RKECmd", "CGW1"),
+      ("CF_Gway_DrvKeyLockSw", "CGW1"),
+      ("CF_Gway_DrvKeyUnlockSw", "CGW1"),
+      ("CF_Gway_TrunkTgSw", "CGW1"),
+      ("CF_Gway_AstSeatBeltSw", "CGW1"),
+      ("CF_Gway_SMKOption", "CGW1"),
+      ("CF_Gway_HoodSw", "CGW1"),
+      ("CF_Gway_WiperIntT", "CGW1"),
+      ("CF_Gway_WiperIntSw", "CGW1"),
+      ("CF_Gway_WiperLowSw", "CGW1"),
+      ("CF_Gway_WiperHighSw", "CGW1"),
+      ("CF_Gway_WiperAutoSw", "CGW1"),
+      ("CF_Gway_RainSnsState", "CGW1"),
+      ("CF_Gway_HeadLampLow", "CGW1"),
+      ("CF_Gway_HeadLampHigh", "CGW1"),
+      ("CF_Gway_HazardSw", "CGW1"),
+      ("CF_Gway_DefoggerRly", "CGW1"),
+      ("CF_Gway_ALightStat", "CGW1"),
+      ("CF_Gway_LightSwState", "CGW1"),
+      ("CF_Gway_Frt_Fog_Act", "CGW1"),
+      ("CF_Gway_TSigRHSw", "CGW1"),
+      ("CF_Gway_TSigLHSw", "CGW1"),
+      ("CF_Gway_DriveTypeOption", "CGW1"),
+      ("CF_Gway_StarterRlyState", "CGW1"),
+      ("CF_Gway_PassiveAccessLock", "CGW1"),
+      ("CF_Gway_WiperMistSw", "CGW1"),
+      ("CF_Gway_PassiveAccessUnlock", "CGW1"),
+      ("CF_Gway_RrSunRoofOpenState", "CGW1"),
+      ("CF_Gway_PassingSW", "CGW1"),
+      ("CF_Gway_HBAControlMode", "CGW1"),
+      ("CF_Gway_HLpHighSw", "CGW1"),
+      ("CF_Gway_InhibitRMT", "CGW1"),
+      ("CF_Gway_RainSnsOption", "CGW1"),
+      ("C_SunRoofOpenState", "CGW1"),
+      ("CF_Gway_Ign1", "CGW1"),
+      ("CF_Gway_Ign2", "CGW1"),
 
       ("CYL_PRES", "ESP12"),
 

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -62,6 +62,11 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
   return packer.make_can_msg("LKAS11", 0, values)
 
 
+def create_cancel_command(packer, cgw1_values):
+  cgw1_values["CF_Gway_DrvDrSw"] = 1
+  return packer.make_can_msg("CGW1", 0, cgw1_values)
+
+
 def create_clu11(packer, frame, clu11, button):
   values = clu11
   values["CF_Clu_CruiseSwState"] = button


### PR DESCRIPTION
Resolves #23674

Old silent (but *UNSAFE*) branch moved here: https://github.com/sshane/openpilot/tree/hyundai-cancel-cmd-silent

This sends the driver door open bit at a frequency that can't perfectly align with the car's message, as the car reads at 10Hz and we can sometimes always send at the wrong time to not get our message accepted by the SCC module (but CLU reads all messages as the dash flickers?)

When only sending 1 message at 10Hz vs. 25Hz and 10 messages: https://user-images.githubusercontent.com/25857203/157397440-8b0eb4c6-8ad1-4587-83ff-1c354a7073d3.png

