### PR TITLE
missing optional include

### DIFF
--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <QtDBus>
 #include <QTimer>
 


### PR DESCRIPTION
In file included from ./selfdrive/ui/qt/offroad/networking.h:7:
./selfdrive/ui/qt/offroad/wifiManager.h:50:8: error: no template named 'optional' in namespace 'std'
  std::optional<QDBusPendingCall> activateWifiConnection(const QString &ssid);
  ~~~~~^
1 error generated.


master branch build wifimanager.h error

is missing optional
add 
 #include <optional> 
ubuntu base build no error