### PR TITLE
fix crash if there is no git repository

### DIFF
--- a/selfdrive/version.py
+++ b/selfdrive/version.py
@@ -55,11 +55,15 @@ def get_origin(default: Optional[str] = None) -> Optional[str]:
 
 @cache
 def get_normalized_origin(default: Optional[str] = None) -> Optional[str]:
-  return get_origin('')\
-          .replace("git@", "", 1)\
-          .replace(".git", "", 1)\
-          .replace("https://", "", 1)\
-          .replace(":", "/", 1)
+  origin = get_origin()
+
+  if origin is None:
+    return default
+
+  return origin.replace("git@", "", 1) \
+               .replace(".git", "", 1) \
+               .replace("https://", "", 1) \
+               .replace(":", "/", 1)
 
 
 @cache

--- a/selfdrive/version.py
+++ b/selfdrive/version.py
@@ -55,7 +55,7 @@ def get_origin(default: Optional[str] = None) -> Optional[str]:
 
 @cache
 def get_normalized_origin(default: Optional[str] = None) -> Optional[str]:
-  return get_origin()\
+  return get_origin('')\
           .replace("git@", "", 1)\
           .replace(".git", "", 1)\
           .replace("https://", "", 1)\


### PR DESCRIPTION

**Description**
The function `get_origin` in `selfdrive/version.py` will return None if there is no git repository. It will cause `statsd` crash when running simulatior in docker. 

- error message of executing `./start_openpilot_docekr.sh`
```
Process statsd:                                                                                                                                               
Traceback (most recent call last):                                             
  File "/root/.pyenv/versions/3.8.10/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()                                                                                                                                                
  File "/root/.pyenv/versions/3.8.10/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)                                                                                                                 
  File "/openpilot/selfdrive/manager/process.py", line 42, in launcher                                                                                        
    getattr(mod, 'main')()                                                                                                                                    
  File "/openpilot/selfdrive/statsd.py", line 69, in main   
    'origin': get_normalized_origin(),                                                                                                                        
  File "/openpilot/selfdrive/version.py", line 59, in get_normalized_origin                                                                                   
    return get_origin()\                
AttributeError: 'NoneType' object has no attribute 'replace' 
```
