### PR TITLE
Snpemodel: Clean up after #23772

### DIFF
--- a/selfdrive/modeld/runners/snpemodel.cc
+++ b/selfdrive/modeld/runners/snpemodel.cc
@@ -159,14 +159,8 @@ void SNPEModel::execute(float *net_input_buf, int buf_size) {
       float *outputs_golden = (float *)malloc(output_size*sizeof(float));
       memcpy(outputs_golden, output, output_size*sizeof(float));
       memset(output, 0, output_size*sizeof(float));
-
-      for (int i = 0; i < 5; i++) {
-        memset(recurrent, 0, recurrent_size*sizeof(float));
-        uint64_t start_time = nanos_since_boot();
-        thneed->execute(inputs, output);
-        uint64_t elapsed_time = nanos_since_boot() - start_time;
-        printf("ran model in %.2f ms\n", float(elapsed_time)/1e6);
-      }
+      memset(recurrent, 0, recurrent_size*sizeof(float));
+      thneed->execute(inputs, output);
 
       if (memcmp(output, outputs_golden, output_size*sizeof(float)) == 0) {
         printf("thneed selftest passed\n");


### PR DESCRIPTION
After #23772 it appears the time testing to get a baseline of speed for the thneed optimizer was left behind when merged into master branch. I am not sure if this was done with intent or not. Please feel free to close this merge request if this is meant to stay like this. I did try asking in discord first, but no one responded.