### PR TITLE
Lateral control: interpolate actuator delay

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -497,12 +497,12 @@ class Controls:
 
       # Steering PID loop and lateral MPC
       lat_active = self.active and not CS.steerWarning and not CS.steerError and CS.vEgo > self.CP.minSteerSpeed
-      lat_rcv_frames = self.sm.frame - self.sm.rcv_frame['longitudinalPlan']
+      t_since_plan = (self.sm.frame - self.sm.rcv_frame['lateralPlan']) * DT_CTRL
       desired_curvature, desired_curvature_rate = get_lag_adjusted_curvature(self.CP, CS.vEgo,
                                                                              lat_plan.psis,
                                                                              lat_plan.curvatures,
                                                                              lat_plan.curvatureRates,
-                                                                             lat_rcv_frames)
+                                                                             t_since_plan)
       actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(lat_active, CS, self.CP, self.VM, params, self.last_actuators,
                                                                              desired_curvature, desired_curvature_rate)
     else:

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -497,10 +497,12 @@ class Controls:
 
       # Steering PID loop and lateral MPC
       lat_active = self.active and not CS.steerWarning and not CS.steerError and CS.vEgo > self.CP.minSteerSpeed
+      lat_rcv_frames = self.sm.frame - self.sm.rcv_frame['longitudinalPlan']
       desired_curvature, desired_curvature_rate = get_lag_adjusted_curvature(self.CP, CS.vEgo,
                                                                              lat_plan.psis,
                                                                              lat_plan.curvatures,
-                                                                             lat_plan.curvatureRates)
+                                                                             lat_plan.curvatureRates,
+                                                                             lat_rcv_frames)
       actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(lat_active, CS, self.CP, self.VM, params, self.last_actuators,
                                                                              desired_curvature, desired_curvature_rate)
     else:

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -94,6 +94,7 @@ def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, t_s
   delay = CP.steerActuatorDelay + .2
   if len(psis) == CONTROL_N:
     psi = interp(delay + t_since_plan, T_IDXS[:CONTROL_N], psis)
+    psi -= interp(t_since_plan, T_IDXS[:CONTROL_N], psis)
     current_curvature = interp(t_since_plan, T_IDXS[:CONTROL_N], curvatures)
     desired_curvature_rate = interp(t_since_plan, T_IDXS[:CONTROL_N], curvature_rates)
   else:

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -1,7 +1,7 @@
 import math
 from cereal import car
 from common.numpy_fast import clip, interp
-from common.realtime import DT_MDL, DT_CTRL
+from common.realtime import DT_MDL
 from selfdrive.config import Conversions as CV
 from selfdrive.modeld.constants import T_IDXS
 
@@ -89,14 +89,14 @@ def initialize_v_cruise(v_ego, buttonEvents, v_cruise_last):
   return int(round(clip(v_ego * CV.MS_TO_KPH, V_CRUISE_ENABLE_MIN, V_CRUISE_MAX)))
 
 
-def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, rcv_frames):
+def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, t_since_plan):
   if len(psis) != CONTROL_N:
     psis = [0.0 for _ in range(CONTROL_N)]
     curvatures = [0.0 for _ in range(CONTROL_N)]
     curvature_rates = [0.0 for _ in range(CONTROL_N)]
 
   # TODO this needs more thought, use .2s extra for now to estimate other delays
-  delay = CP.steerActuatorDelay + (rcv_frames * DT_CTRL) + .2
+  delay = CP.steerActuatorDelay + t_since_plan + .2
   current_curvature = curvatures[0]
   psi = interp(delay, T_IDXS[:CONTROL_N], psis)
   desired_curvature_rate = curvature_rates[0]

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -1,7 +1,7 @@
 import math
 from cereal import car
 from common.numpy_fast import clip, interp
-from common.realtime import DT_MDL
+from common.realtime import DT_MDL, DT_CTRL
 from selfdrive.config import Conversions as CV
 from selfdrive.modeld.constants import T_IDXS
 
@@ -89,14 +89,14 @@ def initialize_v_cruise(v_ego, buttonEvents, v_cruise_last):
   return int(round(clip(v_ego * CV.MS_TO_KPH, V_CRUISE_ENABLE_MIN, V_CRUISE_MAX)))
 
 
-def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates):
+def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, rcv_frames):
   if len(psis) != CONTROL_N:
-    psis = [0.0 for i in range(CONTROL_N)]
-    curvatures = [0.0 for i in range(CONTROL_N)]
-    curvature_rates = [0.0 for i in range(CONTROL_N)]
+    psis = [0.0 for _ in range(CONTROL_N)]
+    curvatures = [0.0 for _ in range(CONTROL_N)]
+    curvature_rates = [0.0 for _ in range(CONTROL_N)]
 
   # TODO this needs more thought, use .2s extra for now to estimate other delays
-  delay = CP.steerActuatorDelay + .2
+  delay = CP.steerActuatorDelay + (rcv_frames * DT_CTRL) + .2
   current_curvature = curvatures[0]
   psi = interp(delay, T_IDXS[:CONTROL_N], psis)
   desired_curvature_rate = curvature_rates[0]
@@ -109,9 +109,9 @@ def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates):
 
   max_curvature_rate = interp(v_ego, MAX_CURVATURE_RATE_SPEEDS, MAX_CURVATURE_RATES)
   safe_desired_curvature_rate = clip(desired_curvature_rate,
-                                          -max_curvature_rate,
-                                          max_curvature_rate)
+                                     -max_curvature_rate,
+                                     max_curvature_rate)
   safe_desired_curvature = clip(desired_curvature,
-                                     current_curvature - max_curvature_rate * DT_MDL,
-                                     current_curvature + max_curvature_rate * DT_MDL)
+                                current_curvature - max_curvature_rate * DT_MDL,
+                                current_curvature + max_curvature_rate * DT_MDL)
   return safe_desired_curvature, safe_desired_curvature_rate

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -96,10 +96,10 @@ def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, t_s
     curvature_rates = [0.0 for _ in range(CONTROL_N)]
 
   # TODO this needs more thought, use .2s extra for now to estimate other delays
-  delay = CP.steerActuatorDelay + t_since_plan + .2
-  current_curvature = curvatures[0]
-  psi = interp(delay, T_IDXS[:CONTROL_N], psis)
-  desired_curvature_rate = curvature_rates[0]
+  delay = CP.steerActuatorDelay + .2
+  current_curvature = interp(t_since_plan, T_IDXS[:CONTROL_N], curvatures)
+  psi = interp(delay + t_since_plan, T_IDXS[:CONTROL_N], psis)
+  desired_curvature_rate = interp(t_since_plan, T_IDXS[:CONTROL_N], curvature_rates)
 
   # MPC can plan to turn the wheel and turn back before t_delay. This means
   # in high delay cases some corrections never even get commanded. So just use

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -90,16 +90,16 @@ def initialize_v_cruise(v_ego, buttonEvents, v_cruise_last):
 
 
 def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, t_since_plan):
-  if len(psis) != CONTROL_N:
-    psis = [0.0 for _ in range(CONTROL_N)]
-    curvatures = [0.0 for _ in range(CONTROL_N)]
-    curvature_rates = [0.0 for _ in range(CONTROL_N)]
-
   # TODO this needs more thought, use .2s extra for now to estimate other delays
   delay = CP.steerActuatorDelay + .2
-  current_curvature = interp(t_since_plan, T_IDXS[:CONTROL_N], curvatures)
-  psi = interp(delay + t_since_plan, T_IDXS[:CONTROL_N], psis)
-  desired_curvature_rate = interp(t_since_plan, T_IDXS[:CONTROL_N], curvature_rates)
+  if len(psis) == CONTROL_N:
+    psi = interp(delay + t_since_plan, T_IDXS[:CONTROL_N], psis)
+    current_curvature = interp(t_since_plan, T_IDXS[:CONTROL_N], curvatures)
+    desired_curvature_rate = interp(t_since_plan, T_IDXS[:CONTROL_N], curvature_rates)
+  else:
+    psi = 0.0
+    current_curvature = 0.0
+    desired_curvature_rate = 0.0
 
   # MPC can plan to turn the wheel and turn back before t_delay. This means
   # in high delay cases some corrections never even get commanded. So just use


### PR DESCRIPTION
Interpolate the 20hz value we control on to 100hz. Not yet done, as we shouldn't get lat_plan data by the 0th index anymore