### PR TITLE
camerad: adjust CL priority on comma three

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -22,6 +22,7 @@
 #include "CL/cl_ext_qcom.h"
 #include "selfdrive/camerad/cameras/camera_qcom.h"
 #elif QCOM2
+#include "CL/cl_ext_qcom.h"
 #include "selfdrive/camerad/cameras/camera_qcom2.h"
 #elif WEBCAM
 #include "selfdrive/camerad/cameras/camera_webcam.h"
@@ -427,8 +428,7 @@ void common_process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) 
 
 void camerad_thread() {
   cl_device_id device_id = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT);
-   // TODO: do this for QCOM2 too
-#if defined(QCOM)
+#if defined(QCOM) || defined(QCOM2)
   const cl_context_properties props[] = {CL_CONTEXT_PRIORITY_HINT_QCOM, CL_PRIORITY_HINT_HIGH_QCOM, 0};
   cl_context context = CL_CHECK_ERR(clCreateContext(props, 1, &device_id, NULL, NULL, &err));
 #else


### PR DESCRIPTION
camerad was the same priority as weston. now modeld > camerad > weston + ui.
```
id: 1 type: ANY priority: 8 process: weston (4059) tid: 4059
id: 2 type: ANY priority: 8 process: weston (4059) tid: 4059
id: 3 type: ANY priority: 4 process: camerad (78037) tid: 78037
id: 4 type: ANY priority: 1 process: _modeld (78457) tid: 78457
id: 5 type: ANY priority: 1 process: _modeld (78457) tid: 78457
```