### PR TITLE
sim: fix modeld crash #23666

### DIFF
--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -15,6 +15,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends\
     libx11-6 \
   && rm -rf /var/lib/apt/lists/*
 
+RUN git clone https://github.com/zeromq/libzmq.git /libzmq && \
+    cd /libzmq  && ./autogen.sh && \
+    ./configure && make && make install
+
 # Intel OpenCL driver
 ARG INTEL_DRIVER=l_opencl_p_18.1.0.015.tgz
 ARG INTEL_DRIVER_URL=http://registrationcenter-download.intel.com/akdlm/irc_nas/vcp/15532
@@ -62,6 +66,7 @@ COPY ./selfdrive $HOME/openpilot/selfdrive
 COPY ./tools $HOME/openpilot/tools
 
 RUN sed -i 's/\/tmp\/tools\/openpilot_env\.sh/\/openpilot\/tools\/openpilot_env\.sh/g' ~/.bashrc
+RUN echo "\nln -s -f /usr/local/lib/libzmq.so.5.2.5  /lib/x86_64-linux-gnu/libzmq.so.5" >> ~/.bashrc
 
 WORKDIR $HOME/openpilot
 RUN scons -j$(nproc)

--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -61,5 +61,7 @@ COPY ./panda $HOME/openpilot/panda
 COPY ./selfdrive $HOME/openpilot/selfdrive
 COPY ./tools $HOME/openpilot/tools
 
+RUN sed -i 's/\/tmp\/tools\/openpilot_env\.sh/\/openpilot\/tools\/openpilot_env\.sh/g' ~/.bashrc
+
 WORKDIR $HOME/openpilot
 RUN scons -j$(nproc)

--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -3,6 +3,11 @@ openpilot in simulator
 
 openpilot implements a [bridge](bridge.py) that allows it to run in the [CARLA simulator](https://carla.org/). 
 
+## Build Docker Image Locally
+```
+./build_container.sh
+```
+
 ## System Requirements
 
 openpilot doesn't have any extreme hardware requirements, however CARLA requires an NVIDIA graphics card and is very resource-intensive and may not run smoothly on your system. For this case, we have a low quality mode you can activate by running:

--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -6,8 +6,6 @@ cd $DIR
 # expose X to the container
 xhost +local:root
 
-docker pull ghcr.io/commaai/openpilot-sim:latest
-
 OPENPILOT_DIR="/openpilot"
 if ! [[ -z "$MOUNT_OPENPILOT" ]]
 then


### PR DESCRIPTION
**Description** [#23666](https://github.com/commaai/openpilot/issues/23666)
modeld will crash on startup in docker. I guess the reason is caused by libzmq. After installing the newest version of libzmq, modeld can work properly.
- same issue: https://github.com/zeromq/libzmq/issues/3313
