### PR TITLE
Toyota: fix learning bad offsets for some models

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -58,7 +58,7 @@ class CarState(CarStateBase):
     torque_sensor_angle_deg = cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
 
     # Wait until an update has been seen to avoid learning an incorrect offset
-    if abs(torque_sensor_angle_deg) > 1e-3 and not bool(cp.vl["STEER_TORQUE_SENSOR"]["INITIALIZING"]):
+    if abs(torque_sensor_angle_deg) > 1e-3 and not bool(cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE_INITIALIZING"]):
       self.accurate_steer_angle_seen = True
 
     if self.accurate_steer_angle_seen:
@@ -150,7 +150,7 @@ class CarState(CarStateBase):
       ("STEER_TORQUE_DRIVER", "STEER_TORQUE_SENSOR"),
       ("STEER_TORQUE_EPS", "STEER_TORQUE_SENSOR"),
       ("STEER_ANGLE", "STEER_TORQUE_SENSOR"),
-      ("INITIALIZING", "STEER_TORQUE_SENSOR"),
+      ("STEER_ANGLE_INITIALIZING", "STEER_TORQUE_SENSOR"),
       ("TURN_SIGNALS", "BLINKERS_STATE"),
       ("LKA_STATE", "EPS_STATUS"),
       ("AUTO_HIGH_BEAM", "LIGHT_STALK"),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -20,7 +20,6 @@ class CarState(CarStateBase):
     # the signal is zeroed to where the steering angle starts.
     # However, on some cars this signal is absolute and requires no offset
     self.accurate_steer_angle_seen = False
-    self.prev_accurate_steer_angle = 0.0
     self.angle_offset = FirstOrderFilter(None, 60.0, DT_CTRL, initialized=False)
 
     self.low_speed_lockout = False
@@ -59,9 +58,8 @@ class CarState(CarStateBase):
     torque_sensor_angle_deg = cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
 
     # Wait until an update has been seen to avoid learning an incorrect offset
-    if abs(torque_sensor_angle_deg - self.prev_accurate_steer_angle) > 1e-3:
+    if not cp.vl["STEER_TORQUE_SENSOR"]["INITIALIZING"]:
       self.accurate_steer_angle_seen = True
-    self.prev_accurate_steer_angle = torque_sensor_angle_deg
 
     if self.accurate_steer_angle_seen:
       # Offset seems to be invalid for large steering angles
@@ -152,6 +150,7 @@ class CarState(CarStateBase):
       ("STEER_TORQUE_DRIVER", "STEER_TORQUE_SENSOR"),
       ("STEER_TORQUE_EPS", "STEER_TORQUE_SENSOR"),
       ("STEER_ANGLE", "STEER_TORQUE_SENSOR"),
+      ("INITIALIZING", "STEER_TORQUE_SENSOR"),
       ("TURN_SIGNALS", "BLINKERS_STATE"),
       ("LKA_STATE", "EPS_STATUS"),
       ("AUTO_HIGH_BEAM", "LIGHT_STALK"),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -58,7 +58,7 @@ class CarState(CarStateBase):
     torque_sensor_angle_deg = cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
 
     # Wait until an update has been seen to avoid learning an incorrect offset
-    if not cp.vl["STEER_TORQUE_SENSOR"]["INITIALIZING"]:
+    if not bool(cp.vl["STEER_TORQUE_SENSOR"]["INITIALIZING"]):
       self.accurate_steer_angle_seen = True
 
     if self.accurate_steer_angle_seen:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -58,7 +58,7 @@ class CarState(CarStateBase):
     torque_sensor_angle_deg = cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
 
     # Wait until an update has been seen to avoid learning an incorrect offset
-    if not bool(cp.vl["STEER_TORQUE_SENSOR"]["INITIALIZING"]):
+    if abs(torque_sensor_angle_deg) > 1e-3 and not bool(cp.vl["STEER_TORQUE_SENSOR"]["INITIALIZING"]):
       self.accurate_steer_angle_seen = True
 
     if self.accurate_steer_angle_seen:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -16,9 +16,9 @@ class CarState(CarStateBase):
     self.shifter_values = can_define.dv["GEAR_PACKET"]["GEAR"]
     self.eps_torque_scale = EPS_SCALE[CP.carFingerprint] / 100.
 
-    # On most cars with cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
-    # the signal is zeroed to where the steering angle starts.
-    # However, on some cars this signal is absolute and requires no offset
+    # On cars with cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
+    # the signal is zeroed to where the steering angle is at start.
+    # Need to apply an offset as soon as the steering angle measurements are both received
     self.accurate_steer_angle_seen = False
     self.angle_offset = FirstOrderFilter(None, 60.0, DT_CTRL, initialized=False)
 
@@ -57,7 +57,7 @@ class CarState(CarStateBase):
     ret.steeringAngleDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_ANGLE"] + cp.vl["STEER_ANGLE_SENSOR"]["STEER_FRACTION"]
     torque_sensor_angle_deg = cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
 
-    # Wait until an update has been seen to avoid learning an incorrect offset
+    # On some cars, the angle measurement is non-zero while initializing
     if abs(torque_sensor_angle_deg) > 1e-3 and not bool(cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE_INITIALIZING"]):
       self.accurate_steer_angle_seen = True
 


### PR DESCRIPTION
On most TSS2 cars, the angle measurement in `STEER_TORQUE_SENSOR` is zero when initializing, however for some TSS2.5 cars (at least the 2022 Camry Hybrid), the signal is non-zero until it's ready, so wait for the `INITIALIZING` bit to fall before reading from it.

An example of a bad initial offset: https://imgur.com/a/jCA71Dq

The desired angle was offset using the liveParameters angle offset, so this is why we generally never noticed this while driving, however there should have been some minor hugging for a bit: https://imgur.com/a/JymjExk

Checked 50,000 Toyota segments, the only time `INITIALIZING` is 1 is at the very start of the route (and angle is still zero) or at the very end when the driver is about to shut off their vehicle (but the way the logic is, we never stop reading from the new sensor once we start). Plots: https://imgur.com/a/dH6exmi