### PR TITLE
Honda: raise pedal gas pressed threshold

### DIFF
--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -241,9 +241,10 @@ class CarState(CarStateBase):
 
     if self.CP.enableGasInterceptor:
       ret.gas = (cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS"] + cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS2"]) / 2.
+      ret.gasPressed = ret.gas > 3.
     else:
       ret.gas = cp.vl["POWERTRAIN_DATA"]["PEDAL_GAS"]
-    ret.gasPressed = ret.gas > 1e-5
+      ret.gasPressed = ret.gas > 1e-5
 
     ret.steeringTorque = cp.vl["STEER_STATUS"]["STEER_TORQUE_SENSOR"]
     ret.steeringTorqueEps = cp.vl["STEER_MOTOR_TORQUE"]["MOTOR_TORQUE"]

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -241,7 +241,7 @@ class CarState(CarStateBase):
 
     if self.CP.enableGasInterceptor:
       ret.gas = (cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS"] + cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS2"]) / 2.
-      ret.gasPressed = ret.gas > 3.
+      ret.gasPressed = ret.gas > 15
     else:
       ret.gas = cp.vl["POWERTRAIN_DATA"]["PEDAL_GAS"]
       ret.gasPressed = ret.gas > 1e-5


### PR DESCRIPTION
Resolves https://github.com/commaai/openpilot/issues/21998.

Some Honda users have noisy gas interceptors, while others not so much. Out of 13 total users with pedals from 173,956 segments, two users had much more noisy interceptor signals than the rest. Some segments from those two users: https://imgur.com/a/OvJFxDC. Some of the others: https://imgur.com/a/uxDX4vL

From the last 30 days of data, this is when the gas interceptor was reporting above zero while car gas was zero:

```
Stats by dongle id:
67cc68f0290328c2/HONDA ODYSSEY 2018 (350 samples): avg: 1.204, 99th percentile: 6.771, max: 8.198
211d3271a862c848/HONDA ODYSSEY 2018 (940 samples): avg: 1.952, 99th percentile: 10.197, max: 17.976
809adcfce1b6f495/HONDA ODYSSEY 2018 (3591 samples): avg: 2.842, 99th percentile: 7.753, max: 16.325
2205ba1364b32b3e/HONDA PILOT 2017 (4417 samples): avg: 1.507, 99th percentile: 8.431, max: 26.421
22786e510b775801/HONDA CIVIC 2016 (843 samples): avg: 1.352, 99th percentile: 11.527, max: 27.882
54fd8451b3974762/HONDA RIDGELINE 2017 (268 samples): avg: 1.911, 99th percentile: 11.011, max: 28.199
4d5e075821d0d877/HONDA CIVIC 2016 (35 samples): avg: 2.291, 99th percentile: 9.178, max: 9.912
981ec27a7a4ad541/HONDA RIDGELINE 2017 (1064 samples): avg: 2.413, 99th percentile: 12.078, max: 27.31
a3f025079c99dde7/HONDA CIVIC 2016 (7745 samples): avg: 1.161, 99th percentile: 6.519, max: 41.343
a993952413a92fe9/HONDA RIDGELINE 2017 (1245 samples): avg: 2.512, 99th percentile: 10.865, max: 14.611
b9a21c12423207c5/HONDA CIVIC 2016 (204 samples): avg: 0.965, 99th percentile: 5.525, max: 8.071
bf960626d90a2b97/ACURA RDX 2018 (41 samples): avg: 1.845, 99th percentile: 11.144, max: 13.531
cfb32f0fb91b173b/HONDA CIVIC 2016 (2078 samples): avg: 1.261, 99th percentile: 12.086, max: 24.516

Stats by platform:
HONDA ODYSSEY 2018 (4881 samples): avg: 2.553, 99th percentile: 7.893, max: 17.976
HONDA PILOT 2017 (4417 samples): avg: 1.507, 99th percentile: 8.431, max: 26.421
HONDA CIVIC 2016 (10905 samples): avg: 1.195, 99th percentile: 8.452, max: 41.343
HONDA RIDGELINE 2017 (2577 samples): avg: 2.408, 99th percentile: 11.022, max: 28.199
ACURA RDX 2018 (41 samples): avg: 1.845, 99th percentile: 11.144, max: 13.531
```

Running on last 180 days now