### PR TITLE
replay: use QCoreApplication

### DIFF
--- a/selfdrive/ui/replay/main.cc
+++ b/selfdrive/ui/replay/main.cc
@@ -7,7 +7,7 @@
 const QString DEMO_ROUTE = "4cf7a6ad03080c90|2021-09-29--13-46-36";
 
 int main(int argc, char *argv[]) {
-  QApplication app(argc, argv);
+  QCoreApplication app(argc, argv);
 
   const std::tuple<QString, REPLAY_FLAGS, QString> flags[] = {
       {"dcam", REPLAY_FLAG_DCAM, "load driver camera"},


### PR DESCRIPTION
Prevents from showing a dock entry on MacOS when running replay