### PR TITLE
Longitudinal MPC: dont creep

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -34,7 +34,7 @@ X_EGO_COST = 0.
 V_EGO_COST = 0.
 A_EGO_COST = 0.
 J_EGO_COST = 5.0
-A_CHANGE_COST = .5
+A_CHANGE_COST = 200.
 DANGER_ZONE_COST = 100.
 CRASH_DISTANCE = .5
 LIMIT_COST = 1e6
@@ -136,7 +136,7 @@ def gen_long_mpc_solver():
            x_ego,
            v_ego,
            a_ego,
-           20*(a_ego - prev_a),
+           a_ego - prev_a,
            j_ego]
   ocp.model.cost_y_expr = vertcat(*costs)
   ocp.model.cost_y_expr_e = vertcat(*costs[:-1])

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -57,7 +57,13 @@ def get_stopped_equivalence_factor(v_lead):
   return (v_lead**2) / (2 * COMFORT_BRAKE)
 
 def get_safe_obstacle_distance(v_ego):
-  return (v_ego**2) / (2 * COMFORT_BRAKE) + T_FOLLOW * v_ego + STOP_DISTANCE
+  v_min = .5  # below this speed the follow distance does not decrease further
+  eps = 1e-3
+  # smooth_max(v_min, v_ego)
+  vego_smooth_max = (v_ego + v_min + np.sqrt(eps+ (v_ego-v_min)**2))/2
+  # NOTE: one could add  "-v_min * T_FOLLOW"
+  #       to achieve desired_follow_distance(0, 0) = STOP_DISTANCE
+  return (v_ego**2) / (2 * COMFORT_BRAKE) + T_FOLLOW * (vego_smooth_max) + STOP_DISTANCE
 
 def desired_follow_distance(v_ego, v_lead):
   return get_safe_obstacle_distance(v_ego) - get_stopped_equivalence_factor(v_lead)


### PR DESCRIPTION
I saw the creeping behavior in the first maneuver in `test_longitudinal.py`.
I addressed this in this PR by modifying `get_safe_obstacle_distance` for small speeds.
Below a certain speed, I chose `v_min = .5` the follow distance should not decrease further.
Otherwise openpilot brakes and then wants to get closer since the desired distance gets smaller.

Plot:
![desired_follow_distance](https://user-images.githubusercontent.com/31900285/155362214-6cf35b93-790e-420c-bd6e-c3d9f9c009c6.png)

Output of `test_longitudinal.py`
Before this PR:
```
13.00 sec   129.45 m    0.15 m/s   -0.19 m/s2   lead_rel:   6.30 m   -0.15 m/s
13.20 sec   129.48 m    0.12 m/s   -0.16 m/s2   lead_rel:   6.27 m   -0.12 m/s
13.40 sec   129.50 m    0.09 m/s   -0.13 m/s2   lead_rel:   6.25 m   -0.09 m/s
13.60 sec   129.51 m    0.06 m/s   -0.11 m/s2   lead_rel:   6.24 m   -0.06 m/s
13.80 sec   129.52 m    0.04 m/s   -0.08 m/s2   lead_rel:   6.23 m   -0.04 m/s
14.00 sec   129.53 m    0.03 m/s   -0.06 m/s2   lead_rel:   6.22 m   -0.03 m/s
14.20 sec   129.53 m    0.02 m/s   -0.05 m/s2   lead_rel:   6.22 m   -0.02 m/s
14.40 sec   129.54 m    0.01 m/s   -0.03 m/s2   lead_rel:   6.21 m   -0.01 m/s
14.60 sec   129.54 m    0.01 m/s   -0.02 m/s2   lead_rel:   6.21 m   -0.01 m/s
14.80 sec   129.54 m    0.00 m/s   -0.01 m/s2   lead_rel:   6.21 m   -0.00 m/s
15.00 sec   129.54 m    0.00 m/s   -0.01 m/s2   lead_rel:   6.21 m   -0.00 m/s
15.20 sec   129.54 m    0.00 m/s    0.00 m/s2   lead_rel:   6.21 m    0.00 m/s
15.40 sec   129.54 m    0.00 m/s    0.00 m/s2   lead_rel:   6.21 m   -0.00 m/s
15.60 sec   129.54 m    0.00 m/s    0.01 m/s2   lead_rel:   6.21 m   -0.00 m/s
15.80 sec   129.54 m    0.00 m/s    0.01 m/s2   lead_rel:   6.21 m   -0.00 m/s
16.00 sec   129.54 m    0.00 m/s    0.01 m/s2   lead_rel:   6.21 m   -0.00 m/s
16.20 sec   129.54 m    0.01 m/s    0.01 m/s2   lead_rel:   6.21 m   -0.01 m/s
16.40 sec   129.54 m    0.01 m/s    0.01 m/s2   lead_rel:   6.21 m   -0.01 m/s
16.60 sec   129.54 m    0.01 m/s    0.01 m/s2   lead_rel:   6.21 m   -0.01 m/s
16.80 sec   129.55 m    0.01 m/s    0.01 m/s2   lead_rel:   6.20 m   -0.01 m/s
17.00 sec   129.55 m    0.02 m/s    0.01 m/s2   lead_rel:   6.20 m   -0.02 m/s
17.20 sec   129.55 m    0.02 m/s    0.01 m/s2   lead_rel:   6.20 m   -0.02 m/s
17.40 sec   129.56 m    0.02 m/s    0.01 m/s2   lead_rel:   6.19 m   -0.02 m/s
17.60 sec   129.56 m    0.02 m/s    0.01 m/s2   lead_rel:   6.19 m   -0.02 m/s
17.80 sec   129.57 m    0.02 m/s    0.01 m/s2   lead_rel:   6.18 m   -0.02 m/s
18.00 sec   129.57 m    0.03 m/s    0.01 m/s2   lead_rel:   6.18 m   -0.03 m/s
18.20 sec   129.58 m    0.03 m/s    0.01 m/s2   lead_rel:   6.17 m   -0.03 m/s
18.40 sec   129.58 m    0.03 m/s    0.01 m/s2   lead_rel:   6.17 m   -0.03 m/s
18.60 sec   129.59 m    0.03 m/s    0.01 m/s2   lead_rel:   6.16 m   -0.03 m/s
18.80 sec   129.59 m    0.03 m/s    0.01 m/s2   lead_rel:   6.16 m   -0.03 m/s
19.00 sec   129.60 m    0.03 m/s    0.00 m/s2   lead_rel:   6.15 m   -0.03 m/s
19.20 sec   129.61 m    0.03 m/s    0.00 m/s2   lead_rel:   6.14 m   -0.03 m/s
19.40 sec   129.61 m    0.04 m/s    0.00 m/s2   lead_rel:   6.14 m   -0.04 m/s
19.60 sec   129.62 m    0.04 m/s    0.00 m/s2   lead_rel:   6.13 m   -0.04 m/s
19.80 sec   129.63 m    0.04 m/s    0.00 m/s2   lead_rel:   6.12 m   -0.04 m/s
```

After this PR:
```
13.00 sec   129.06 m    0.11 m/s   -0.17 m/s2   lead_rel:   6.69 m   -0.11 m/s
13.20 sec   129.08 m    0.08 m/s   -0.14 m/s2   lead_rel:   6.67 m   -0.08 m/s
13.40 sec   129.09 m    0.06 m/s   -0.11 m/s2   lead_rel:   6.66 m   -0.06 m/s
13.60 sec   129.10 m    0.04 m/s   -0.08 m/s2   lead_rel:   6.65 m   -0.04 m/s
13.80 sec   129.11 m    0.02 m/s   -0.06 m/s2   lead_rel:   6.64 m   -0.02 m/s
14.00 sec   129.11 m    0.01 m/s   -0.04 m/s2   lead_rel:   6.64 m   -0.01 m/s
14.20 sec   129.11 m    0.01 m/s   -0.03 m/s2   lead_rel:   6.64 m   -0.01 m/s
14.40 sec   129.11 m    0.00 m/s   -0.02 m/s2   lead_rel:   6.64 m   -0.00 m/s
14.60 sec   129.11 m    0.00 m/s   -0.01 m/s2   lead_rel:   6.64 m   -0.00 m/s
14.80 sec   129.11 m    0.00 m/s   -0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
15.00 sec   129.11 m    0.00 m/s   -0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
15.20 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
15.40 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
15.60 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
15.80 sec   129.11 m    0.00 m/s   -0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
16.00 sec   129.11 m    0.00 m/s   -0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
16.20 sec   129.11 m    0.00 m/s   -0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
16.40 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
16.60 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
16.80 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
17.00 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
17.20 sec   129.11 m    0.00 m/s   -0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
17.40 sec   129.11 m    0.00 m/s   -0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
17.60 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
17.80 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
18.00 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
18.20 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
18.40 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
18.60 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
18.80 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
19.00 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
19.20 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
19.40 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
19.60 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
19.80 sec   129.11 m    0.00 m/s    0.00 m/s2   lead_rel:   6.64 m   -0.00 m/s
```