### PR TITLE
Documented TSS2 LTA steering mode signals

### DIFF
--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -15,15 +15,22 @@ def create_lta_steer_command(packer, steer, steer_req, raw_cnt):
 
   values = {
     "COUNTER": raw_cnt + 128,
-    "SETME_X1": 1,
-    "SETME_X3": 3,
-    "PERCENTAGE": 100,
-    "SETME_X64": 0x64,
-    "ANGLE": 0,  # Rate limit? Lower values seeem to work better, but needs more testing
-    "STEER_ANGLE_CMD": steer,
-    "STEER_REQUEST": steer_req,
-    "STEER_REQUEST_2": steer_req,
-    "BIT": 0,
+    "SETME_X1": 1, # usually 1, but doesn't do anything if sent (TSS2)
+    "SETME_X3": 3, # usually 3 on TSS2, 1 on TSS2.5 with sometimes 3, but doesn't do anything if sent (TSS2)
+    "PERCENTAGE": 100, # LTA driver override percentage (0-100), very close to steeringPressed in OP, doesn't do anything
+    "SETME_X64": 0x64, # ramps to 0 smoothly then back on falling edge of STEER_REQUEST if BIT isn't 1
+                       # sending anything less than 100 (0x64) will prevent steering, and sadly,
+                       # it likely isn't a torque scaling command, I tried setting it to different values
+                       # maybe if you start at 100 and send smaller values, it will scale the torque down
+    "ANGLE": 0,  # angle of car relative to lane center on LTA camera, doesn't do anything
+    "STEER_ANGLE_CMD": steer, # desired angle, OEM steers up to 95 degrees, can steer up to 150~ degrees but
+                              # torque will bottom out
+    "STEER_REQUEST": steer_req, # enable bit for steering, 1 to steer, 0 to not. If we don't alternate 0 every second,
+                                # the car will cut steering on override for 5 seconds (TSS2)
+    "STEER_REQUEST_2": steer_req, # same as above
+    "BIT": 0, # doesn't seem to do anything, but I pulse it because I'm too lazy to see exactly what it does
+              # originally thought it was a EPS reset bit, but it's not. See coorelation between this and
+              # STEER_REQUEST above in PlotJuggler.
   }
   return packer.make_can_msg("STEERING_LTA", 0, values)
 


### PR DESCRIPTION
Spent a bunch of time this last weekend with @sshane figuring out what these signals do.

LTA steering feels very nice and has a 95 degree steering limit stock, but I was able to get even higher angles with OP. Torque bottoms out at some point.

You can try it out here:
https://github.com/zorrobyte/openpilot/tree/zp-lta

![image](https://user-images.githubusercontent.com/7257172/155418745-7120e18c-ceaa-4a3c-8c96-cb4c17d348ae.png)

![image](https://user-images.githubusercontent.com/7257172/155418780-3b0046e9-ec3d-4ec3-83a6-6618ef2d41a7.png)

I'm cleaning up my branch and may attempt a PR at some point. Getting away from torque control and the tuning that comes along with it is incredibly nice. We can also use a steerRateCost of 0.1, which makes OP very responsive. Differences between laneless and laneful are apparent with angle based controls!

Dashcam LTA route:
4aa5d874f367adbc|2022-02-20--22-59-18

“Stock” LTA OP
4aa5d874f367adbc|2022-02-21--18-22-18

"Broken" OP LTA route (would not steer):
4aa5d874f367adbc|2022-02-21--18-37-54

Dashcam with disablements (LTA OEM steer overrides)
4aa5d874f367adbc|2022-02-22--14-47-21

Dadcam mode TSS2.5 stock
f15e3c37c118e841|2022-02-18--13-58-56