### PR TITLE
Remove unused MPC_COST_LONG class

### DIFF
--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -37,13 +37,6 @@ class MPC_COST_LAT:
   STEER_RATE = 1.0
 
 
-class MPC_COST_LONG:
-  TTC = 5.0
-  DISTANCE = 0.1
-  ACCELERATION = 10.0
-  JERK = 20.0
-
-
 def rate_limit(new_value, last_value, dw_step, up_step):
   return clip(new_value, last_value + dw_step, last_value + up_step)
 


### PR DESCRIPTION
I noticed MPC_COST_LONG is not used anywhere in the code so I guess it can be removed