### PR TITLE
Use LTA steering mode for TSS2 cars (and possibly TSS2.5 security cars)

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -48,13 +48,6 @@ class CarController():
     apply_steer = apply_toyota_steer_torque_limits(new_steer, self.last_steer, CS.out.steeringTorqueEps, CarControllerParams)
     self.steer_rate_limited = new_steer != apply_steer
 
-    # Cut steering while we're in a known fault state (2s)
-    if not active or CS.steer_state in (9, 25):
-      apply_steer = 0
-      apply_steer_req = 0
-    else:
-      apply_steer_req = 1
-
     # TODO: probably can delete this. CS.pcm_acc_status uses a different signal
     # than CS.cruiseState.enabled. confirm they're not meaningfully different
     if not enabled and CS.pcm_acc_status:
@@ -72,20 +65,29 @@ class CarController():
 
     can_sends = []
 
-    #*** control msgs ***
-    #print("steer {0} {1} {2} {3}".format(apply_steer, min_lim, max_lim, CS.steer_torque_motor)
-
-    # toyota can trace shows this message at 42Hz, with counter adding alternatively 1 and 2;
-    # sending it at 100Hz seem to allow a higher rate limit, as the rate limit seems imposed
-    # on consecutive messages
-    can_sends.append(create_steer_command(self.packer, apply_steer, apply_steer_req, frame))
-    if frame % 2 == 0 and CS.CP.carFingerprint in TSS2_CAR:
-      can_sends.append(create_lta_steer_command(self.packer, 0, 0, frame // 2))
-
-    # LTA mode. Set ret.steerControlType = car.CarParams.SteerControlType.angle and whitelist 0x191 in the panda
-    # if frame % 2 == 0:
-    #   can_sends.append(create_steer_command(self.packer, 0, 0, frame // 2))
-    #   can_sends.append(create_lta_steer_command(self.packer, actuators.steeringAngleDeg, apply_steer_req, frame // 2))
+    if CS.CP.steerControlType == car.CarParams.SteerControlType.angle:
+      can_sends.append(create_steer_command(self.packer, 0, 0, frame))
+      # On TSS2 cars, the LTA and STEER_TORQUE_SENSOR messages use relative steering angle signals that start
+      # at 0 degrees, so we need to offset the commanded angle as well.
+      # Also need to pulse steer_req to prevent 5 second steering lockout in some cases
+      steer_req = active and (frame % 100 != 0)
+      percentage = interp(abs(CS.out.steeringTorque), [50, 100], [100, 0])
+      commanded_angle = interp(percentage, [-10, 100], [CS.out.steeringAngleDeg + CS.out.steeringAngleOffsetDeg, 
+                    actuators.steeringAngleDeg + CS.out.steeringAngleOffsetDeg])
+      can_sends.append(create_lta_steer_command(self.packer, commanded_angle, steer_req, frame))
+    else:
+      # Cut steering while we're in a known fault state (2s)
+      if not active or CS.steer_state in (9, 25):
+        apply_steer = 0
+        apply_steer_req = 0
+      else:
+        apply_steer_req = 1
+      # toyota can trace shows this message at 42Hz, with counter adding alternatively 1 and 2;
+      # sending it at 100Hz seem to allow a higher rate limit, as the rate limit seems imposed
+      # on consecutive messages
+      can_sends.append(create_steer_command(self.packer, apply_steer, apply_steer_req, frame))
+      if frame % 2 == 0 and CS.CP.carFingerprint in TSS2_CAR:
+        can_sends.append(create_lta_steer_command(self.packer, 0, 0, frame // 2))
 
     # we can spam can to cancel the system even if we are using lat only control
     if (frame % 3 == 0 and CS.CP.openpilotLongitudinalControl) or pcm_cancel_cmd:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -198,6 +198,11 @@ class CarInterface(CarInterfaceBase):
     ret.steerRateCost = 1.
     ret.centerToFront = ret.wheelbase * 0.44
 
+    if(candidate in TSS2_CAR):
+      ret.steerRateCost = 0.1
+      ret.steerActuatorDelay = 0.25
+      ret.steerControlType = car.CarParams.SteerControlType.angle
+
     # TODO: get actual value, for now starting with reasonable value for
     # civic and scaling by mass and wheelbase
     ret.rotationalInertia = scale_rot_inertia(ret.mass, ret.wheelbase)

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -10,20 +10,20 @@ def create_steer_command(packer, steer, steer_req, raw_cnt):
   return packer.make_can_msg("STEERING_LKA", 0, values)
 
 
-def create_lta_steer_command(packer, steer, steer_req, raw_cnt):
+def create_lta_steer_command(packer, commanded_angle, steer_req, frame):
   """Creates a CAN message for the Toyota LTA Steer Command."""
 
   values = {
-    "COUNTER": raw_cnt + 128,
+    "COUNTER": frame,
     "SETME_X1": 1,
     "SETME_X3": 3,
     "PERCENTAGE": 100,
     "SETME_X64": 0x64,
-    "ANGLE": 0,  # Rate limit? Lower values seeem to work better, but needs more testing
-    "STEER_ANGLE_CMD": steer,
+    "ANGLE": 0,
+    "STEER_ANGLE_CMD": commanded_angle,
     "STEER_REQUEST": steer_req,
     "STEER_REQUEST_2": steer_req,
-    "BIT": 0,
+    "BIT": steer_req, # TODO: figure out of this needs to be pulsed 0 every second
   }
   return packer.make_can_msg("STEERING_LTA", 0, values)
 


### PR DESCRIPTION
Toyota has a system called Lane Trace Assist on TSS2.0+ cars, which is their version of L2 Lane Keeping. As such, they have provided us LTA signals in which we can send angles for the car to steer to.

Angle based control prevents us from having to compute and tune PID/LQR/INDI controls, which not only reduces lag, but also enhances the lateral control on these cars. We also take advantage of the EPS motor tuning Toyota has provided for us.

This is a draft PR so that I may collect feedback and clean up the code, panda changes are also required to allow sending the LTA messages. @pd0wm was experimenting with the LTA messages previously.

I have been working with @sshane on this over the weekend and was inspired by branch:
https://github.com/commaai/openpilot/tree/toyota-lta

LTA controls are much smoother than LKA controls and also seemingly have a higher angle limit:
![image](https://user-images.githubusercontent.com/7257172/155427030-6fe8a467-e56d-4cde-a80b-1121c9ace380.png)

Did someone say 🌮 🔔 ?

![image](https://user-images.githubusercontent.com/7257172/155427081-96b76ce4-bd1e-43a0-95ce-0cd097fc71ed.png)

Lastly, I do not believe that Toyota security cars have the security bit on LTA. If so, this will be the controls method used to upstream these cars (and for OP to work at all). I call dibs on the bounty ;)
https://discord.com/channels/469524606043160576/905950538816978974/945496092152303617
https://discord.com/channels/469524606043160576/905950538816978974/945787996278521926