### PR TITLE
Enable Process Replay to Work with Logs Stored in LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.dlc filter=lfs diff=lfs merge=lfs -text
 *.onnx filter=lfs diff=lfs merge=lfs -text
+selfdrive/test/process_replay/fakedata|*.bz2 filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -277,6 +277,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+        lfs: true
     - name: Cache dependencies
       id: dependency-cache
       uses: actions/cache@v2

--- a/selfdrive/test/.gitignore
+++ b/selfdrive/test/.gitignore
@@ -6,4 +6,5 @@ process_replay/model_diff.txt
 valgrind_logs.txt
 
 *.bz2
+!process_replay/fakedata|*.bz2
 *.hevc


### PR DESCRIPTION
**Description**
Forks are not able to use the process_replay test.  The instructions [here](https://github.com/commaai/openpilot/tree/master/selfdrive/test/process_replay) are incomplete and various configurations need to be changed.

**Changes**
- Add `lfs: true` to the checkout action so that lfs files are downloaded.
- Add the replay log files to `.gitattributes` so the logs get uploaded to lfs
- Exclude the log files from `.gitignore` so they show up as changes to be staged

**Remaining Issue**
I have no idea how I can modify `/.lfsconfig` so that it works for forks and for comma.  For us github users, deleting the file makes everything work.  Similarly, I can change the `url` and `pushurl` in the file to github urls and it works.  But I can't figure out a design that would work across both forks and comma.  Any ideas would be appreciated.  ~If comma has a means of setting the contents of `.lfsconfig` for comma employees as part of its installation tooling, that might help.  I think we can remove `.lfsconfig` from the repo and ignore it.~  Nope that doesn't work, I thought the lfs pointer might contain the url, but no it doesn't.

- Also, if we can get this to work, I can update the README with some additional instructions to help fork maintainers.

**Verification**
I was able to get things to work using my own replay logs on this [testing branch](https://github.com/krkeegan/openpilot/tree/test-lfs).

**Notes**
I am competent with git, but LFS is a whole new thing for me, so I may be making some bad assumptions here.