### PR TITLE
interfaces: remove unnecessary brake pedal check

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -156,8 +156,7 @@ class CarInterfaceBase(ABC):
       events.add(EventName.steerUnavailable)
 
     # Disable on rising edge of gas or brake. Also disable on brake when speed > 0.
-    if (cs_out.gasPressed and not self.CS.out.gasPressed) or \
-       (cs_out.brakePressed and (not self.CS.out.brakePressed or not cs_out.standstill)):
+    if (cs_out.gasPressed and not self.CS.out.gasPressed) or (cs_out.brakePressed and not cs_out.standstill):
       events.add(EventName.pedalPressed)
 
     # we engage when pcm is active (rising edge)

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -81,12 +81,12 @@ class CarInterfaceBase(ABC):
     ret.minSteerSpeed = 0.
     ret.wheelSpeedFactor = 1.0
 
-    ret.pcmCruise = True     # openpilot's state is tied to the PCM's cruise state on most cars
-    ret.minEnableSpeed = -1. # enable is done by stock ACC, so ignore this
+    ret.pcmCruise = True  # openpilot's state is tied to the PCM's cruise state on most cars
+    ret.minEnableSpeed = -1.  # enable is done by stock ACC, so ignore this
     ret.steerRatioRear = 0.  # no rear steering, at least on the listed cars aboveA
     ret.openpilotLongitudinalControl = False
     ret.stopAccel = -2.0
-    ret.stoppingDecelRate = 0.8 # brake_travel/s while trying to stop
+    ret.stoppingDecelRate = 0.8  # brake_travel/s while trying to stop
     ret.vEgoStopping = 0.5
     ret.vEgoStarting = 0.5  # needs to be >= vEgoStopping to avoid state transition oscillation
     ret.stoppingControl = True

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -140,7 +140,6 @@ class CarInterfaceBase(ABC):
     if cs_out.brakeHoldActive and self.CP.openpilotLongitudinalControl:
       events.add(EventName.brakeHold)
 
-
     # Handle permanent and temporary steering faults
     self.steering_unpressed = 0 if cs_out.steeringPressed else self.steering_unpressed + 1
     if cs_out.steerWarning:


### PR DESCRIPTION
We only add `pedalPressed` on rising edge of gas so that we can engage when gas is previously pressed (gasPressed and pedalPressed are both added for one frame, then only gasPressed), but we can always just check brake pressed.