### PR TITLE
longitudinal MPC: set qp_tol to 1e-2

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -181,6 +181,7 @@ def gen_long_mpc_solver():
   # More iterations take too much time and less lead to inaccurate convergence in
   # some situations. Ideally we would run just 1 iteration to ensure fixed runtime.
   ocp.solver_options.qp_solver_iter_max = 10
+  ocp.solver_options.qp_tol = 1e-2
 
   # set prediction horizon
   ocp.solver_options.tf = Tf

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -55,6 +55,7 @@ class Planner:
     self.v_desired_trajectory = np.zeros(CONTROL_N)
     self.a_desired_trajectory = np.zeros(CONTROL_N)
     self.j_desired_trajectory = np.zeros(CONTROL_N)
+    self.solverExecutionTime = 0.0
 
   def update(self, sm):
     v_ego = sm['carState'].vEgo

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -216,8 +216,9 @@ class TestOnroad(unittest.TestCase):
       ts = [getattr(getattr(m, s), "solverExecutionTime") for m in self.lr if m.which() == s]
       self.assertLess(min(ts), instant_max, f"high '{s}' execution time: {min(ts)}")
       self.assertLess(np.mean(ts), avg_max, f"high avg '{s}' execution time: {np.mean(ts)}")
-      result += f"'{s}' execution time: {min(ts)}\n"
-      result += f"'{s}' avg execution time: {np.mean(ts)}\n"
+      result += f"'{s}' execution time: min  {min(ts):.5f}s\n"
+      result += f"'{s}' execution time: max  {max(ts):.5f}s\n"
+      result += f"'{s}' execution time: mean {np.mean(ts):.5f}s\n"
     result += "------------------------------------------------\n"
     print(result)
 
@@ -237,8 +238,8 @@ class TestOnroad(unittest.TestCase):
       ts = [getattr(getattr(m, s), "modelExecutionTime") for m in self.lr if m.which() == s]
       self.assertLess(min(ts), instant_max, f"high '{s}' execution time: {min(ts)}")
       self.assertLess(np.mean(ts), avg_max, f"high avg '{s}' execution time: {np.mean(ts)}")
-      result += f"'{s}' execution time: {min(ts)}\n"
-      result += f"'{s}' avg execution time: {np.mean(ts)}\n"
+      result += f"'{s}' execution time: min  {min(ts):.5f}s\n"
+      result += f"'{s}' execution time: mean {np.mean(ts):.5f}s\n"
     result += "------------------------------------------------\n"
     print(result)
 


### PR DESCRIPTION
HPIPM always does the full 10 QP iterations right now.

This seems quite unnecessary and is probably even makes the initialization for the next QP solver call worse.
It definitely reduces the CPU load:

The following timings are obtained from the scenarios in `selfdrive/test/process_replay/test_processes.py --whitelist-procs plannerd`

```
SUMMARY longitudinal MPC timing variant WIP
time total:	 mean 0.323 ms, 99% quantile: 0.388 ms, 99.9% quantile: 0.564 ms, max 3.410 ms
time qp:	 mean 0.236 ms, 99% quantile: 0.283 ms, 99.9% quantile: 0.426 ms, max 3.320 ms
time lin:	 mean 0.044 ms, 99% quantile: 0.059 ms, 99.9% quantile: 0.078 ms, max 0.098 ms
time sim:	 mean 0.014 ms, 99% quantile: 0.019 ms, 99.9% quantile: 0.026 ms, max 0.031 ms
evaluated 13820 calls to longitudinal MPC.
QP iter: mean: 10.0, median: 10.0, 99% quantile: 10.0, max: 10.0

SUMMARY longitudinal MPC timing variant tol1e-2
time total:	 mean 0.192 ms, 99% quantile: 0.249 ms, 99.9% quantile: 0.311 ms, max 3.310 ms
time qp:	 mean 0.107 ms, 99% quantile: 0.162 ms, 99.9% quantile: 0.217 ms, max 3.220 ms
time lin:	 mean 0.044 ms, 99% quantile: 0.054 ms, 99.9% quantile: 0.076 ms, max 2.610 ms
time sim:	 mean 0.014 ms, 99% quantile: 0.017 ms, 99.9% quantile: 0.025 ms, max 2.510 ms
evaluated 13820 calls to longitudinal MPC.
QP iter: mean: 3.2062228654124456, median: 3.0, 99% quantile: 6.0, max: 10.0
```


Batch test output:
```
Speed: comparing maximum speed diffs over segment
decent: < 2m/s: 1542/1542 aka 100.00%
good:   < 1m/s: 1542/1542 aka 100.00%
best: (<.5m/s): 1542/1542 aka 100.00%

Acceleration: maximum acceleration diffs over segment
decent: < 1m/s^2: 1542/1542 aka 100.00%
good: (<.5m/s^2): 1542/1542 aka 100.00%
best  (<.2m/s^2): 1542/1542 aka 100.00%

0 segments disagree by more than 1.0/s^2:
mean(abs(max_speed_diffs)): 0.004 m/s
mean(abs(max_accel_diffs)): 0.004 m/s^2
```

Jenkins Comma 3 output https://jenkins.comma.life/blue/organizations/jenkins/openpilot/detail/longMPC_qptol1e-2/2/pipeline/56/
```
-----------------  MPC Timing ------------------
'longitudinalPlan' execution time: min  0.00047s
'longitudinalPlan' execution time: max  0.00111s
'longitudinalPlan' execution time: mean 0.00063s
```