### PR TITLE
longitudinal MPC: set qp_tol to 1e-1

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -181,6 +181,7 @@ def gen_long_mpc_solver():
   # More iterations take too much time and less lead to inaccurate convergence in
   # some situations. Ideally we would run just 1 iteration to ensure fixed runtime.
   ocp.solver_options.qp_solver_iter_max = 10
+  ocp.solver_options.qp_tol = 1e-1
 
   # set prediction horizon
   ocp.solver_options.tf = Tf

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -55,6 +55,7 @@ class Planner:
     self.v_desired_trajectory = np.zeros(CONTROL_N)
     self.a_desired_trajectory = np.zeros(CONTROL_N)
     self.j_desired_trajectory = np.zeros(CONTROL_N)
+    self.solverExecutionTime = 0.0
 
   def update(self, sm):
     v_ego = sm['carState'].vEgo

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -216,8 +216,9 @@ class TestOnroad(unittest.TestCase):
       ts = [getattr(getattr(m, s), "solverExecutionTime") for m in self.lr if m.which() == s]
       self.assertLess(min(ts), instant_max, f"high '{s}' execution time: {min(ts)}")
       self.assertLess(np.mean(ts), avg_max, f"high avg '{s}' execution time: {np.mean(ts)}")
-      result += f"'{s}' execution time: {min(ts)}\n"
-      result += f"'{s}' avg execution time: {np.mean(ts)}\n"
+      result += f"'{s}' execution time: min  {min(ts):.5f}s\n"
+      result += f"'{s}' execution time: max  {max(ts):.5f}s\n"
+      result += f"'{s}' execution time: mean {np.mean(ts):.5f}s\n"
     result += "------------------------------------------------\n"
     print(result)
 
@@ -237,8 +238,8 @@ class TestOnroad(unittest.TestCase):
       ts = [getattr(getattr(m, s), "modelExecutionTime") for m in self.lr if m.which() == s]
       self.assertLess(min(ts), instant_max, f"high '{s}' execution time: {min(ts)}")
       self.assertLess(np.mean(ts), avg_max, f"high avg '{s}' execution time: {np.mean(ts)}")
-      result += f"'{s}' execution time: {min(ts)}\n"
-      result += f"'{s}' avg execution time: {np.mean(ts)}\n"
+      result += f"'{s}' execution time: min  {min(ts):.5f}s\n"
+      result += f"'{s}' execution time: mean {np.mean(ts):.5f}s\n"
     result += "------------------------------------------------\n"
     print(result)
 


### PR DESCRIPTION
I am not sure how much deviation is ok with respect to the current reference commit.

Either this PR or https://github.com/commaai/openpilot/pull/23861
Or something with another value should be merged IMO.


The following timings are obtained from the scenarios in `selfdrive/test/process_replay/test_processes.py --whitelist-procs plannerd`
```
SUMMARY longitudinal MPC timing variant tol1e-1
time total:	 mean 0.183 ms, 99% quantile: 0.250 ms, 99.9% quantile: 0.301 ms, max 0.731 ms
time qp:	 mean 0.096 ms, 99% quantile: 0.164 ms, 99.9% quantile: 0.203 ms, max 0.249 ms
time lin:	 mean 0.045 ms, 99% quantile: 0.057 ms, 99.9% quantile: 0.076 ms, max 0.607 ms
time sim:	 mean 0.014 ms, 99% quantile: 0.017 ms, 99.9% quantile: 0.026 ms, max 0.033 ms
evaluated 13820 calls to longitudinal MPC.
```

batch test output
```
Speed: comparing maximum speed diffs over segment
decent: < 2m/s: 1542/1542 aka 100.00%
good:   < 1m/s: 1542/1542 aka 100.00%
best: (<.5m/s): 1542/1542 aka 100.00%

Acceleration: maximum acceleration diffs over segment
decent: < 1m/s^2: 1542/1542 aka 100.00%
good: (<.5m/s^2): 1542/1542 aka 100.00%
best  (<.2m/s^2): 1542/1542 aka 100.00%

0 segments disagree by more than 1.0/s^2:
mean(abs(max_speed_diffs)): 0.017 m/s
mean(abs(max_accel_diffs)): 0.015 m/s^2
```

Jenkins Comma 3 build output (https://jenkins.comma.life/blue/organizations/jenkins/openpilot/detail/longMPC_qptol1e-1/1/pipeline/56)

```
-----------------  MPC Timing ------------------
'longitudinalPlan' execution time: min  0.00043s
'longitudinalPlan' execution time: max  0.00100s
'longitudinalPlan' execution time: mean 0.00060s
------------------------------------------------
```

