### PR TITLE
Joystick inactive handoff to controller for injection + Angle mode / axes swap flags

### DIFF
--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -128,6 +128,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"IsTakingSnapshot", CLEAR_ON_MANAGER_START},
     {"IsUpdateAvailable", CLEAR_ON_MANAGER_START},
     {"JoystickDebugMode", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},
+    {"JoystickAngleMode", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},
     {"LastAthenaPingTime", CLEAR_ON_MANAGER_START},
     {"LastGPSPosition", PERSISTENT},
     {"LastManagerExitReason", CLEAR_ON_MANAGER_START},

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -498,7 +498,7 @@ class Controls:
 
     # Steering PID loop and lateral MPC
     lat_active = self.active and not CS.steerFaultTemporary and not CS.steerFaultPermanent and CS.vEgo > self.CP.minSteerSpeed
-    if self.joystick_angle_mode:
+    if self.joystick_angle_mode and not self.CP.lateralTuning.which() == 'indi':
         desired_curvature = -self.VM.calc_curvature(clip(self.sm['testJoystick'].axes[1], -1, 1)*45, CS.vEgo, params.roll)
         desired_curvature_rate = 0
     else:

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -498,7 +498,7 @@ class Controls:
 
     # Steering PID loop and lateral MPC
     lat_active = self.active and not CS.steerFaultTemporary and not CS.steerFaultPermanent and CS.vEgo > self.CP.minSteerSpeed
-    if self.joystick_angle_mode and not self.CP.lateralTuning.which() == 'indi':
+    if self.joystick_angle_mode and self.sm.rcv_frame['testJoystick'] > 0 and not self.CP.lateralTuning.which() == 'indi':
         desired_curvature = -self.VM.calc_curvature(clip(self.sm['testJoystick'].axes[1], -1, 1)*45, CS.vEgo, params.roll)
         desired_curvature_rate = 0
     else:
@@ -510,6 +510,7 @@ class Controls:
                                                                              desired_curvature, desired_curvature_rate)
     if self.joystick_mode and not self.joystick_angle_mode:
       lac_log = log.ControlsState.LateralDebugState.new_message()
+      lac_log.saturated = False
       if self.sm.rcv_frame['testJoystick'] > 0 and self.active:
         if self.sm['testJoystick'].axes[0] != 0:
           actuators.accel = 4.0*clip(self.sm['testJoystick'].axes[0], -1, 1)
@@ -517,6 +518,7 @@ class Controls:
           steer = clip(self.sm['testJoystick'].axes[1], -1, 1)
           # max angle is 45 for angle-based cars
           actuators.steer, actuators.steeringAngleDeg = steer, steer * 45.
+          lac_log.saturated = abs(steer) >= 0.9
 
         lac_log.active = True
         lac_log.steeringAngleDeg = CS.steeringAngleDeg

--- a/tools/joystick/README.md
+++ b/tools/joystick/README.md
@@ -22,6 +22,8 @@ The available buttons and axes will print showing their key mappings. In general
 ### Joystick on your comma three
 
 Plug the joystick into your comma three aux USB-C port. Then, SSH into the device and start `joystickd.py`.
+to swap axes run with --swap_axes
+to control angle run with --angle_mode
 
 ### Joystick on your laptop
 
@@ -32,6 +34,8 @@ In order to use a joystick over the network, we need to run joystickd locally fr
    ```shell
    # on your comma device
    echo -n "1" > /data/params/d/JoystickDebugMode
+   #for controlling angle instead of torque
+   echo -n "1" > /data/params/d/JoystickAngleMode
    ```
 3. Run bridge with your laptop's IP address. This republishes the `testJoystick` packets sent from your laptop so that openpilot can receive them:
    ```shell
@@ -43,6 +47,8 @@ In order to use a joystick over the network, we need to run joystickd locally fr
    # on your laptop
    export ZMQ=1
    tools/joystick/joystickd.py
+   # to swap axes:
+   tools/joystick/joystickd.py --swap_axes
    ```
 
 ---

--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -91,6 +91,7 @@ if __name__ == '__main__':
 
   if args.angle_mode:
     Params().put_bool('JoystickAngleMode', True)
+    print('INDI control requires a desired angle and angle rate. Angle Mode will not be used on INDI')
 
   print()
   if args.keyboard:


### PR DESCRIPTION
changed the logic of the Joystick debug mode to fallback to the long/lat controller when joystick inputs are at 0

This would allow for the injection test joystick behavior pinned in tuning. ~"hands resting on lap like using OP"

I also added and angle mode to allow the joystick to request a steering angle from the controller instead of overriding the torque. 

last I added a swap axes option to switch the gas/steer. It seems the ps5 controller defaults to lateral being up/down on one of the sticks. 


