### PR TITLE
Hide set speed when main is off

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -181,7 +181,7 @@ void OnroadHud::updateState(const UIState &s) {
   const auto cs = sm["controlsState"].getControlsState();
 
   float maxspeed = cs.getVCruise();
-  bool cruise_set = maxspeed > 0 && (int)maxspeed != SET_SPEED_NA && sm["controlsState"].getCarState().getCruiseState().getAvailable();
+  bool cruise_set = maxspeed > 0 && (int)maxspeed != SET_SPEED_NA && sm["carState"].getCarState().getCruiseState().getAvailable();
   if (cruise_set && !s.scene.is_metric) {
     maxspeed *= KM_TO_MILE;
   }

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -181,7 +181,7 @@ void OnroadHud::updateState(const UIState &s) {
   const auto cs = sm["controlsState"].getControlsState();
 
   float maxspeed = cs.getVCruise();
-  bool cruise_set = maxspeed > 0 && (int)maxspeed != SET_SPEED_NA;
+  bool cruise_set = maxspeed > 0 && (int)maxspeed != SET_SPEED_NA && sm["controlsState"].getCarState().getCruiseState().getAvailable();
   if (cruise_set && !s.scene.is_metric) {
     maxspeed *= KM_TO_MILE;
   }


### PR DESCRIPTION
Applies to all PCM cars, need to take a look at how the button cars do this.

The process replay difference looks like it's because the main button was turned off in the Toyota route and we now reset to 255 kph