### PR TITLE
boardd.cc: change fault list size (new exti fault for panda deep sleep mode)

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -371,7 +371,7 @@ std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> 
 
     size_t j = 0;
     for (size_t f = size_t(cereal::PandaState::FaultType::RELAY_MALFUNCTION);
-        f <= size_t(cereal::PandaState::FaultType::INTERRUPT_RATE_TICK); f++) {
+        f <= size_t(cereal::PandaState::FaultType::INTERRUPT_RATE_EXTI); f++) {
       if (fault_bits.test(f)) {
         faults.set(j, cereal::PandaState::FaultType(f));
         j++;

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -338,7 +338,7 @@ void Panda::set_power_saving(bool power_saving) {
   usb_write(0xe7, power_saving, 0);
 }
 
-void Panda::set_deepsleep(void) {
+void Panda::enable_deepsleep(void) {
   usb_write(0xe7, 0, 0);
 }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -339,7 +339,7 @@ void Panda::set_power_saving(bool power_saving) {
 }
 
 void Panda::enable_deepsleep(void) {
-  usb_write(0xe7, 0, 0);
+  usb_write(0xfb, 0, 0);
 }
 
 void Panda::set_usb_power_mode(cereal::PeripheralState::UsbPowerMode power_mode) {

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -338,6 +338,10 @@ void Panda::set_power_saving(bool power_saving) {
   usb_write(0xe7, power_saving, 0);
 }
 
+void Panda::set_deepsleep(void) {
+  usb_write(0xe7, 0, 0);
+}
+
 void Panda::set_usb_power_mode(cereal::PeripheralState::UsbPowerMode power_mode) {
   usb_write(0xe6, (uint16_t)power_mode, 0);
 }

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -85,7 +85,7 @@ class Panda {
   std::optional<std::vector<uint8_t>> get_firmware_version();
   std::optional<std::string> get_serial();
   void set_power_saving(bool power_saving);
-  void enable_deepsleep(void);
+  void enable_deepsleep();
   void set_usb_power_mode(cereal::PeripheralState::UsbPowerMode power_mode);
   void send_heartbeat(bool engaged);
   void set_can_speed_kbps(uint16_t bus, uint16_t speed);

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -85,7 +85,7 @@ class Panda {
   std::optional<std::vector<uint8_t>> get_firmware_version();
   std::optional<std::string> get_serial();
   void set_power_saving(bool power_saving);
-  void set_deepsleep(void);
+  void enable_deepsleep(void);
   void set_usb_power_mode(cereal::PeripheralState::UsbPowerMode power_mode);
   void send_heartbeat(bool engaged);
   void set_can_speed_kbps(uint16_t bus, uint16_t speed);

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -85,6 +85,7 @@ class Panda {
   std::optional<std::vector<uint8_t>> get_firmware_version();
   std::optional<std::string> get_serial();
   void set_power_saving(bool power_saving);
+  void set_deepsleep(void);
   void set_usb_power_mode(cereal::PeripheralState::UsbPowerMode power_mode);
   void send_heartbeat(bool engaged);
   void set_can_speed_kbps(uint16_t bus, uint16_t speed);


### PR DESCRIPTION
needed for panda deepsleep mode

merge after cereal and panda bump (or with this PR)