### PR TITLE
Add --dbc argument to plotjuggler

### DIFF
--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -12,8 +12,7 @@ Once you've cloned and are in openpilot, this command will download PlotJuggler 
 
 ```
 $ ./juggle.py -h
-usage: juggle.py [-h] [--demo] [--qlog] [--can] [--stream] [--layout [LAYOUT]] [--install]
-                 [route_or_segment_name] [segment_count]
+usage: juggle.py [-h] [--demo] [--qlog] [--can] [--stream] [--layout [LAYOUT]] [--install] [--dbc DBC] [route_or_segment_name] [segment_count]
 
 A helper to run PlotJuggler on openpilot routes
 
@@ -23,13 +22,15 @@ positional arguments:
   segment_count         The number of segments to plot (default: None)
 
 optional arguments:
-  -h, --help         show this help message and exit
-  --demo             Use the demo route instead of providing one (default: False)
-  --qlog             Use qlogs (default: False)
-  --can              Parse CAN data (default: False)
-  --stream           Start PlotJuggler in streaming mode (default: False)
-  --layout [LAYOUT]  Run PlotJuggler with a pre-defined layout (default: None)
-  --install          Install or update PlotJuggler + plugins (default: False)
+  -h, --help            show this help message and exit
+  --demo                Use the demo route instead of providing one (default: False)
+  --qlog                Use qlogs (default: False)
+  --can                 Parse CAN data (default: False)
+  --stream              Start PlotJuggler in streaming mode (default: False)
+  --layout [LAYOUT]     Run PlotJuggler with a pre-defined layout (default: None)
+  --install             Install or update PlotJuggler + plugins (default: False)
+  --dbc DBC             Set the DBC name to load for parsing CAN data. If not set, the DBC will be
+                        automatically inferred from the logs. (default: None)
 ```
 
 Examples using route name:

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
   parser.add_argument("--stream", action="store_true", help="Start PlotJuggler in streaming mode")
   parser.add_argument("--layout", nargs='?', help="Run PlotJuggler with a pre-defined layout")
   parser.add_argument("--install", action="store_true", help="Install or update PlotJuggler + plugins")
-  parser.add_argument("--dbc", help="Set the DBC name to load for parsing CAN data")
+  parser.add_argument("--dbc", help="Set the DBC name to load for parsing CAN data. If not set, the DBC will be automatically inferred from the logs.")
   parser.add_argument("route_or_segment_name", nargs='?', help="The route or segment name to plot (cabana share URL accepted)")
   parser.add_argument("segment_count", type=int, nargs='?', help="The number of segments to plot")
 

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -75,7 +75,7 @@ def start_juggler(fn=None, dbc=None, layout=None):
   subprocess.call(cmd, shell=True, env=env, cwd=juggle_dir)
 
 
-def juggle_route(route_or_segment_name, segment_count, qlog, can, layout):
+def juggle_route(route_or_segment_name, segment_count, qlog, can, layout, dbc=None):
   segment_start = 0
   if 'cabana' in route_or_segment_name:
     query = parse_qs(urlparse(route_or_segment_name).query)
@@ -113,14 +113,14 @@ def juggle_route(route_or_segment_name, segment_count, qlog, can, layout):
     all_data = [d for d in all_data if d.which() not in ['can', 'sendcan']]
 
   # Infer DBC name from logs
-  dbc = None
-  for cp in [m for m in all_data if m.which() == 'carParams']:
-    try:
-      DBC = __import__(f"selfdrive.car.{cp.carParams.carName}.values", fromlist=['DBC']).DBC
-      dbc = DBC[cp.carParams.carFingerprint]['pt']
-    except Exception:
-      pass
-    break
+  if dbc is None:
+    for cp in [m for m in all_data if m.which() == 'carParams']:
+      try:
+        DBC = __import__(f"selfdrive.car.{cp.carParams.carName}.values", fromlist=['DBC']).DBC
+        dbc = DBC[cp.carParams.carFingerprint]['pt']
+      except Exception:
+        pass
+      break
 
   with tempfile.NamedTemporaryFile(suffix='.rlog', dir=juggle_dir) as tmp:
     save_log(tmp.name, all_data, compress=False)
@@ -138,6 +138,7 @@ if __name__ == "__main__":
   parser.add_argument("--stream", action="store_true", help="Start PlotJuggler in streaming mode")
   parser.add_argument("--layout", nargs='?', help="Run PlotJuggler with a pre-defined layout")
   parser.add_argument("--install", action="store_true", help="Install or update PlotJuggler + plugins")
+  parser.add_argument("--dbc", help="Set the DBC name to load for parsing CAN data")
   parser.add_argument("route_or_segment_name", nargs='?', help="The route or segment name to plot (cabana share URL accepted)")
   parser.add_argument("segment_count", type=int, nargs='?', help="The number of segments to plot")
 
@@ -158,4 +159,4 @@ if __name__ == "__main__":
     start_juggler(layout=args.layout)
   else:
     route_or_segment_name = DEMO_ROUTE if args.demo else args.route_or_segment_name.strip()
-    juggle_route(route_or_segment_name, args.segment_count, args.qlog, args.can, args.layout)
+    juggle_route(route_or_segment_name, args.segment_count, args.qlog, args.can, args.layout, args.dbc)


### PR DESCRIPTION
It would be nice if you could also parse in a DBC file which isn't in opendbc, but this requires more changes since they are currently built at plotjuggler build time, and not loaded dynamically.