### PR TITLE
Remove void argument

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -338,7 +338,7 @@ void Panda::set_power_saving(bool power_saving) {
   usb_write(0xe7, power_saving, 0);
 }
 
-void Panda::enable_deepsleep(void) {
+void Panda::enable_deepsleep() {
   usb_write(0xfb, 0, 0);
 }
 


### PR DESCRIPTION
One seems to have remained from https://github.com/commaai/openpilot/pull/23911

Searching the codebase, seems like there are a few more simmilar examples, can remove them since they don't seem to do anything according to https://stackoverflow.com/questions/693788/is-it-better-to-use-c-void-arguments-void-foovoid-or-not-void-foo