### PR TITLE
Update lat_control at CAN send rate. 

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -44,6 +44,12 @@ class CarInterfaceBase(ABC):
     if CarController is not None:
       self.CC = CarController(self.cp.dbc_name, CP, self.VM)
 
+  def get_steer_step(self):
+    return 1
+
+  def get_frame(self):
+    return self.frame
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     return ACCEL_MIN, ACCEL_MAX

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -15,6 +15,9 @@ class CarController():
     self.p = CarControllerParams(CP)
     self.packer = CANPacker(DBC[CP.carFingerprint]['pt'])
 
+  def get_steer_step(self):
+    return self.p.STEER_STEP
+
   def update(self, c, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert, left_line, right_line, left_lane_depart, right_lane_depart):
 
     can_sends = []

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -106,6 +106,9 @@ class CarInterface(CarInterfaceBase):
 
     return ret
 
+  def get_steer_step(self):
+    return self.CC.get_steer_step()
+
   # returns a car.CarState
   def update(self, c, can_strings):
     self.cp.update_strings(can_strings)

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -3,6 +3,7 @@ import math
 from selfdrive.controls.lib.pid import PIController
 from selfdrive.controls.lib.drive_helpers import get_steer_max
 from selfdrive.controls.lib.latcontrol import LatControl, MIN_STEER_SPEED
+from common.realtime import DT_CTRL
 from cereal import log
 
 
@@ -11,7 +12,8 @@ class LatControlPID(LatControl):
     super().__init__(CP, CI)
     self.pid = PIController((CP.lateralTuning.pid.kpBP, CP.lateralTuning.pid.kpV),
                             (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
-                            k_f=CP.lateralTuning.pid.kf, pos_limit=1.0, neg_limit=-1.0)
+                            k_f=CP.lateralTuning.pid.kf, pos_limit=1.0, neg_limit=-1.0,
+                            rate=(1 / (DT_CTRL*CI.get_steer_step())))
     self.get_steer_feedforward = CI.get_steer_feedforward_function()
 
   def reset(self):


### PR DESCRIPTION
PR is to update the lateral controller at the same rate as the commands are sent. Technically speaking it improves stability but usually this is only a significant impact at  higher frequencies. 

However, I believe this would be important for something like autotune planned. 
With autotune needing to measure the error and adjust gains based on the last control signals and errors, it would seem important to only update the controller at the same rate as the commands are sent to ensure everything is as ideally synced as possible. 
it would also be important to s

draft because only subaru interface.py has a change for the cars put in and I'm not a fan of how the logging conditionals look in controlsd.py. hopefully there's a cleaner way to log at a different rate than the control loop or just repeat the last log.  