### PR TITLE
Fix controls mismatch on button enable cars + test against panda safety

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -403,9 +403,9 @@ class CarInterface(CarInterfaceBase):
     for b in ret.buttonEvents:
 
       # do enable on both accel and decel buttons
-      if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
-        if not self.CP.pcmCruise:
-          events.add(EventName.buttonEnable)
+      if not self.CP.pcmCruise:
+        if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
+            events.add(EventName.buttonEnable)
 
       # do disable on button down
       if b.type == ButtonType.cancel and b.pressed:

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -50,9 +50,6 @@ class TestCarModel(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    #if cls.car_model != "HONDA ACCORD 2018":
-    #  raise unittest.SkipTest
-
     if cls.route is None:
       if cls.car_model in non_tested_cars:
         print(f"Skipping tests for {cls.car_model}: missing route")
@@ -63,11 +60,6 @@ class TestCarModel(unittest.TestCase):
     params.clear_all()
 
     for seg in (2, 1, 0):
-      #from tools.lib.route import Route
-      #from tools.lib.logreader import MultiLogIterator
-      #r = Route("97bbe58ea225ad1d|2022-03-08--12-54-42")
-      #lr = MultiLogIterator(r.log_paths()[3:4])
-
       try:
         lr = LogReader(get_url(cls.route, seg))
       except Exception:
@@ -97,9 +89,6 @@ class TestCarModel(unittest.TestCase):
     assert cls.CP
     assert cls.CP.carFingerprint == cls.car_model
 
-    if cls.CP.pcmCruise:
-      raise unittest.SkipTest
-
   def setUp(self):
     self.CI = self.CarInterface(self.CP, self.CarController, self.CarState)
     assert self.CI
@@ -107,7 +96,7 @@ class TestCarModel(unittest.TestCase):
     # TODO: check safetyModel is in release panda build
     self.safety = libpandasafety_py.libpandasafety
     set_status = self.safety.set_safety_hooks(self.CP.safetyConfigs[0].safetyModel.raw, self.CP.safetyConfigs[0].safetyParam)
-    self.assertEqual(0, set_status, f"failed to set safetyModel {self.CP.safetyConfigs[0].safetyModel}")
+    self.assertEqual(0, set_status, f"failed to set safetyModel {self.CP.safetyConfigs}")
     self.safety.init_tests()
 
   def test_car_params(self):
@@ -199,6 +188,9 @@ class TestCarModel(unittest.TestCase):
         to_send = package_can_msg(msg)
         self.safety.safety_rx_hook(to_send)
         self.CI.update(CC, (can_list_to_can_capnp([msg, ]), ))
+    self.safety.set_controls_allowed(0)
+
+    dat = defaultdict(list)
 
     controls_allowed_prev = False
     CS_prev = car.CarState.new_message()
@@ -240,27 +232,39 @@ class TestCarModel(unittest.TestCase):
         else:
           checks['controlsAllowed'] += not CS.cruiseState.enabled and self.safety.get_controls_allowed()
       else:
-        # TODO: make panda enter controls on the falling edge like openpilot on these cars
-        if self.CP.carName not in ("gm"):
-          # Check for enable events on rising edge of controls allowed
-          button_enable = any(evt.enable for evt in CS.events)
-          checks['controlsAllowed'] += button_enable != (self.safety.get_controls_allowed and not controls_allowed_prev)
-          if button_enable != (self.safety.get_controls_allowed and not controls_allowed_prev):
-            print(button_enable, (self.safety.get_controls_allowed and not controls_allowed_prev))
+        # Check for enable events on rising edge of controls allowed
+        button_enable = any(evt.enable for evt in CS.events)
+        mismatch = button_enable != (self.safety.get_controls_allowed() and not controls_allowed_prev)
+        checks['controlsAllowed'] += mismatch
+        controls_allowed_prev = self.safety.get_controls_allowed()
+        if button_enable and not mismatch:
+          self.safety.set_controls_allowed(False)
+
+        if button_enable != (self.safety.get_controls_allowed() and not controls_allowed_prev):
+          print(CS.events)
+          print(button_enable, self.safety.get_controls_allowed(), controls_allowed_prev)
+
+        dat['gas'].append(self.safety.get_gas_pressed_prev())
+        dat['brake'].append(self.safety.get_brake_pressed_prev())
+        dat['button enable'].append(int(button_enable)*0.7 - 0.2)
+        dat['controls allowed'].append(self.safety.get_controls_allowed())
 
       if self.CP.carName == "honda":
         checks['mainOn'] += CS.cruiseState.available != self.safety.get_acc_main_on()
 
       CS_prev = CS
-      controls_allowed_prev = self.safety.get_controls_allowed()
+
+    #if checks['controlsAllowed'] > 0:
+    #  import matplotlib.pyplot as plt
+    #  for k, v in dat.items():
+    #    plt.plot(v, label=k)
+    #  plt.legend()
+    #  plt.title(self.CP.carFingerprint)
+    #  plt.show()
 
     # TODO: add flag to toyota safety
     if self.CP.carFingerprint == TOYOTA.SIENNA and checks['brakePressed'] < 25:
       checks['brakePressed'] = 0
-
-    # Honda Nidec uses button enable in panda, but pcm enable in openpilot
-    if self.CP.carName == "honda" and self.CP.carFingerprint not in HONDA_BOSCH and checks['controlsAllowed'] < 25:
-      checks['controlsAllowed'] = 0
 
     failed_checks = {k: v for k, v in checks.items() if v > 0}
     self.assertFalse(len(failed_checks), f"panda safety doesn't agree with openpilot: {failed_checks}")

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -188,9 +188,9 @@ class TestCarModel(unittest.TestCase):
         to_send = package_can_msg(msg)
         self.safety.safety_rx_hook(to_send)
         self.CI.update(CC, (can_list_to_can_capnp([msg, ]), ))
-    self.safety.set_controls_allowed(0)
 
-    dat = defaultdict(list)
+    if not self.CP.pcmCruise:
+      self.safety.set_controls_allowed(0)
 
     controls_allowed_prev = False
     CS_prev = car.CarState.new_message()
@@ -240,27 +240,10 @@ class TestCarModel(unittest.TestCase):
         if button_enable and not mismatch:
           self.safety.set_controls_allowed(False)
 
-        if button_enable != (self.safety.get_controls_allowed() and not controls_allowed_prev):
-          print(CS.events)
-          print(button_enable, self.safety.get_controls_allowed(), controls_allowed_prev)
-
-        dat['gas'].append(self.safety.get_gas_pressed_prev())
-        dat['brake'].append(self.safety.get_brake_pressed_prev())
-        dat['button enable'].append(int(button_enable)*0.7 - 0.2)
-        dat['controls allowed'].append(self.safety.get_controls_allowed())
-
       if self.CP.carName == "honda":
         checks['mainOn'] += CS.cruiseState.available != self.safety.get_acc_main_on()
 
       CS_prev = CS
-
-    #if checks['controlsAllowed'] > 0:
-    #  import matplotlib.pyplot as plt
-    #  for k, v in dat.items():
-    #    plt.plot(v, label=k)
-    #  plt.legend()
-    #  plt.title(self.CP.carFingerprint)
-    #  plt.show()
 
     # TODO: add flag to toyota safety
     if self.CP.carFingerprint == TOYOTA.SIENNA and checks['brakePressed'] < 25:


### PR DESCRIPTION
resolves #22597

Fixes a controls mismatch on Honda Nidecs with pedals, Honda Bosch longitudinal, Hyundai longitudinal, and GM cars.