### PR TITLE
Update carla script to easier install docker and nvidia-docker

### DIFF
--- a/tools/sim/start_carla.sh
+++ b/tools/sim/start_carla.sh
@@ -2,8 +2,6 @@
 #echo "Your name is $1"
 # Requires nvidia docker - https://github.com/NVIDIA/nvidia-docker
 if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
-#  if [ "$INSTALL" == "1" ]; then
-#  echo "Nvidia docker is required. Do you want to install it now? (y/n)"# Re-run with "start_carla.sh 1" INSTALL=1 to automatically install."
   read -p "Nvidia docker is required. Do you want to install it now? (y/n)";
   if [ "${REPLY}" == "y" ]; then
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID)

--- a/tools/sim/start_carla.sh
+++ b/tools/sim/start_carla.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#echo "Your name is $1"
 # Requires nvidia docker - https://github.com/NVIDIA/nvidia-docker
 if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
   read -p "Nvidia docker is required. Do you want to install it now? (y/n)";

--- a/tools/sim/start_carla.sh
+++ b/tools/sim/start_carla.sh
@@ -9,7 +9,7 @@ if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
     sudo apt-get update && sudo apt-get install -y nvidia-docker2 # Also installs docker-ce and nvidia-container-toolkit
-    read -p "Just installed docker? Set permanent docker permission for usergroup. (Run 'sudo systemctl restart docker' afterwards and then rerun start_carla.sh) (y/n)"
+    read -p "Just installed docker? Set permanent docker permission for usergroup. Permissions are fully working after logging out. (Run 'sudo systemctl restart docker' afterwards and then rerun start_carla.sh) (y/n)"
     if [ "${REPLY}" == "y" ]; then
         # Adding docker to current usergroup
         sudo groupadd docker

--- a/tools/sim/start_carla.sh
+++ b/tools/sim/start_carla.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
-
+#echo "Your name is $1"
 # Requires nvidia docker - https://github.com/NVIDIA/nvidia-docker
 if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
-  if [ -z "$INSTALL" ]; then
-    echo "Nvidia docker is required. Re-run with INSTALL=1 to automatically install."
-    exit 0
-  else
+#  if [ "$INSTALL" == "1" ]; then
+#  echo "Nvidia docker is required. Do you want to install it now? (y/n)"# Re-run with "start_carla.sh 1" INSTALL=1 to automatically install."
+  read -p "Nvidia docker is required. Do you want to install it now? (y/n)";
+  if [ "${REPLY}" == "y" ]; then
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
     echo $distribution
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-    sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+    sudo apt-get update && sudo apt-get install -y nvidia-docker2 # Also installs docker-ce and nvidia-container-toolkit
+    read -p "Just installed docker? Set permanent docker permission for usergroup. (Run 'sudo systemctl restart docker' afterwards and then rerun start_carla.sh) (y/n)"
+    if [ "${REPLY}" == "y" ]; then
+        # Adding docker to current usergroup
+        sudo groupadd docker
+        sudo usermod -aG docker $USER
+        newgrp docker
+    fi
     sudo systemctl restart docker
+  else
+    exit
   fi
 fi
 

--- a/tools/sim/start_carla.sh
+++ b/tools/sim/start_carla.sh
@@ -9,13 +9,6 @@ if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
     curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
     curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
     sudo apt-get update && sudo apt-get install -y nvidia-docker2 # Also installs docker-ce and nvidia-container-toolkit
-    read -p "Just installed docker? Set permanent docker permission for usergroup. Permissions are fully working after logging out. (Run 'sudo systemctl restart docker' afterwards and then rerun start_carla.sh) (y/n)"
-    if [ "${REPLY}" == "y" ]; then
-        # Adding docker to current usergroup
-        sudo groupadd docker
-        sudo usermod -aG docker $USER
-        newgrp docker
-    fi
     sudo systemctl restart docker
   else
     exit 0

--- a/tools/sim/start_carla.sh
+++ b/tools/sim/start_carla.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Requires nvidia docker - https://github.com/NVIDIA/nvidia-docker
 if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
   read -p "Nvidia docker is required. Do you want to install it now? (y/n)";
@@ -17,7 +18,7 @@ if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
     fi
     sudo systemctl restart docker
   else
-    exit
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
I couldn't figure out how to use the old behaviour with Install=1

With this change typing "y" will install nvidia-docker2 with its dependencies nvidia-container-toolkit and docker-ce (previously didn't install docker-ce).

Verified branches manually