### PR TITLE
Wrong format type in console UI print statement

### DIFF
--- a/selfdrive/ui/replay/consoleui.cc
+++ b/selfdrive/ui/replay/consoleui.cc
@@ -241,7 +241,7 @@ void ConsoleUI::updateProgressBar(uint64_t cur, uint64_t total, bool success) {
 
 void ConsoleUI::updateSummary() {
   const auto &route = replay->route();
-  mvwprintw(w[Win::Stats], 0, 0, "Route: %s, %d segments", qPrintable(route->name()), route->segments().size());
+  mvwprintw(w[Win::Stats], 0, 0, "Route: %s, %lu segments", qPrintable(route->name()), route->segments().size());
   mvwprintw(w[Win::Stats], 1, 0, "Car Fingerprint: %s", replay->carFingerprint().c_str());
   wrefresh(w[Win::Stats]);
 }


### PR DESCRIPTION
```
selfdrive/ui/replay/consoleui.cc:244:87: error: format specifies type 'int' but the argument has type 'std::map<int, SegmentFile>::size_type' (aka 'unsigned long') [-Werror,-Wformat]
  mvwprintw(w[Win::Stats], 0, 0, "Route: %s, %d segments", qPrintable(route->name()), route->segments().size());
                                             ~~                                       ^~~~~~~~~~~~~~~~~~~~~~~~
                                             %lu
```