### PR TITLE
HKG: improved Kona tuning

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -121,7 +121,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.indi.actuatorEffectivenessV = [2.3]
       ret.minSteerSpeed = 60 * CV.KPH_TO_MS
     elif candidate in (CAR.KONA, CAR.KONA_EV, CAR.KONA_HEV):
-      ret.lateralTuning.pid.kf = 0.00005
+      ret.lateralTuning.pid.kf = 0.00006
       ret.mass = {CAR.KONA_EV: 1685., CAR.KONA_HEV: 1425.}.get(candidate, 1275.) + STD_CARGO_KG
       ret.wheelbase = 2.7
       ret.steerRatio = 13.73 * 1.15  # Spec


### PR DESCRIPTION
 Adjusting the "kf" value of Hyundai KONA hybrid

Update Interface.py  

By adjusting the Interface.py kf value of Hyundai KONA hybrid 2020, it seems desirable to adjust the "kf" value from "0.00005" to "0.00006" for more stable steering wheel operation and improved stability in onroad..

Reference Test Route.

Dongl-ID : 0665dbbc79ef999e

results: 0665dbbc79ef999e|2022-03-21--14-30-57