### PR TITLE
events: add clutchPressed event

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -117,7 +117,9 @@ class CarInterfaceBase(ABC):
       events.add(EventName.doorOpen)
     if cs_out.seatbeltUnlatched:
       events.add(EventName.seatbeltNotLatched)
-    if cs_out.gearShifter != GearShifter.drive and (extra_gears is None or
+    if cs_out.clutchPressed:
+      events.add(EventName.clutchPressed)
+    elif cs_out.gearShifter != GearShifter.drive and (extra_gears is None or
        cs_out.gearShifter not in extra_gears):
       events.add(EventName.wrongGear)
     if cs_out.gearShifter == GearShifter.reverse:

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -493,6 +493,14 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
       Priority.LOW, VisualAlert.steerRequired, AudibleAlert.promptRepeat, 1.),
   },
 
+  EventName.clutchPressed: {
+    ET.WARNING: Alert(
+      "Clutch Pressed",
+      "",
+      AlertStatus.userPrompt, AlertSize.small,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, .2),
+  },
+
   # Thrown when the fan is driven at >50% but is not rotating
   EventName.fanMalfunction: {
     ET.PERMANENT: NormalPermanentAlert("Fan Malfunction", "Contact Support"),


### PR DESCRIPTION
Currently when you press the clutch in a manual transmission car, openpilot shows an alert for "wrong gear" and beeps a lot. Making this alert silent (or not showing it at all?) when the clutch is pressed and you are changing gear would be chill :smile: 

Note: Cruise control doesn't disengage while changing gear in the stock system

EDIT: I might only be facing this issue due to my car port - maybe other manufacturers "gear signal" doesn't immediately change when the clutch is pressed? Ford's seems to..