### PR TITLE
CARLA: fix setting camera EOF

### DIFF
--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -39,6 +39,7 @@ STEER_RATIO = 15.
 pm = messaging.PubMaster(['roadCameraState', 'sensorEvents', 'can', "gpsLocationExternal"])
 sm = messaging.SubMaster(['carControl', 'controlsState'])
 
+startTime = time.time()
 
 class VehicleState:
   def __init__(self):
@@ -94,7 +95,7 @@ class Camerad:
     yuv_cl = cl_array.empty_like(rgb_cl)
     self.krnl(self.queue, (np.int32(self.Wdiv4), np.int32(self.Hdiv4)), None, rgb_cl.data, yuv_cl.data).wait()
     yuv = np.resize(yuv_cl.get(), np.int32(rgb.size / 2))
-    eof = self.frame_id * 0.05
+    eof = int((time.time() - startTime) * 1000000000)
 
     # TODO: remove RGB send once the last RGB vipc subscriber is removed
     self.vipc_server.send(VisionStreamType.VISION_STREAM_RGB_ROAD, img.tobytes(), self.frame_id, eof, eof)

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -95,7 +95,7 @@ class Camerad:
     yuv_cl = cl_array.empty_like(rgb_cl)
     self.krnl(self.queue, (np.int32(self.Wdiv4), np.int32(self.Hdiv4)), None, rgb_cl.data, yuv_cl.data).wait()
     yuv = np.resize(yuv_cl.get(), np.int32(rgb.size / 2))
-    eof = int((time.time() - startTime) * 1000000000)
+    eof = int(self.frame_id * 0.05 * 1e9)
 
     # TODO: remove RGB send once the last RGB vipc subscriber is removed
     self.vipc_server.send(VisionStreamType.VISION_STREAM_RGB_ROAD, img.tobytes(), self.frame_id, eof, eof)

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -39,7 +39,6 @@ STEER_RATIO = 15.
 pm = messaging.PubMaster(['roadCameraState', 'sensorEvents', 'can', "gpsLocationExternal"])
 sm = messaging.SubMaster(['carControl', 'controlsState'])
 
-startTime = time.time()
 
 class VehicleState:
   def __init__(self):


### PR DESCRIPTION
**Description** [issue #23985](https://github.com/commaai/openpilot/issues/23985)

The scalars of the timestamp are different in real-world and simulation, which causes an infinite loop in modeld.

In `selfdrive/modeld/modeld.cc`, it keeps receiving data until the timestamp of the meta_main is 25000000 more than the timestamp of the meta_extra. However, the timestamp value is much smaller than 25000000 in simulation. So the loop below will cause modeld to hang. I guess the timestamp unit here is nanosecond. But the unit in `bridge.py` is second.
 ```c++
    while (get_ts(meta_main) < get_ts(meta_extra) + 25000000ULL) {
      buf_main = vipc_client_main.recv(&meta_main);
      if (buf_main == nullptr)  break;
    }
```

The timestamp is assigned in `tools/sim/bridge.py`.  I think one way to fix this issue is to multiply `eof` by a constant value.
```python
    # convert RGB frame to YUV
    rgb = np.reshape(img, (H, W * 3))
    rgb_cl = cl_array.to_device(self.queue, rgb)
    yuv_cl = cl_array.empty_like(rgb_cl)
    self.krnl(self.queue, (np.int32(self.Wdiv4), np.int32(self.Hdiv4)), None, rgb_cl.data, yuv_cl.data).wait()
    yuv = np.resize(yuv_cl.get(), np.int32(rgb.size / 2))
    eof = self.frame_id * 0.05

    # TODO: remove RGB send once the last RGB vipc subscriber is removed
    self.vipc_server.send(VisionStreamType.VISION_STREAM_RGB_BACK, img.tobytes(), self.frame_id, eof, eof)
    self.vipc_server.send(VisionStreamType.VISION_STREAM_ROAD, yuv.data.tobytes(), self.frame_id, eof, eof)

    dat = messaging.new_message('roadCameraState')
    dat.roadCameraState = {
      "frameId": image.frame,
      "transform": [1.0, 0.0, 0.0,
                    0.0, 1.0, 0.0,
                    0.0, 0.0, 1.0]
    }
    pm.send('roadCameraState', dat)
    self.frame_id += 1
```

After modifying the value of `eof`, Openpilot can accelerate again. I am not sure whether this fix will cause other problems. Let me know if there is a better way to fix this issue. 
```python
    eof = int((time.time() - startTime) * 1000000000)
```