### PR TITLE
PlotJuggler: better support Cabana links

### DIFF
--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -12,8 +12,6 @@ import argparse
 
 from common.basedir import BASEDIR
 from selfdrive.test.process_replay.compare_logs import save_log
-from tools.lib.api import CommaApi
-from tools.lib.auth_config import get_token
 from tools.lib.robust_logreader import RobustLogReader
 from tools.lib.route import Route, SegmentName
 from urllib.parse import urlparse, parse_qs

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -79,7 +79,7 @@ def juggle_route(route_or_segment_name, segment_count, qlog, can, layout, dbc=No
     query = parse_qs(urlparse(route_or_segment_name).query)
     route_or_segment_name = query["route"][0]
 
-  if route_or_segment_name[:7] in ("http://", "https://") or os.path.isfile(route_or_segment_name):
+  if route_or_segment_name.startswith(("http://", "https://")) or os.path.isfile(route_or_segment_name):
     logs = [route_or_segment_name]
   else:
     route_or_segment_name = SegmentName(route_or_segment_name, allow_route_name=True)

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -79,9 +79,9 @@ def juggle_route(route_or_segment_name, segment_count, qlog, can, layout, dbc=No
   segment_start = 0
   if 'cabana' in route_or_segment_name:
     query = parse_qs(urlparse(route_or_segment_name).query)
-    api = CommaApi(get_token())
-    logs = api.get(f'v1/route/{query["route"][0]}/log_urls?sig={query["sig"][0]}&exp={query["exp"][0]}')
-  elif route_or_segment_name.startswith("http://") or route_or_segment_name.startswith("https://") or os.path.isfile(route_or_segment_name):
+    route_or_segment_name = query["route"][0]
+
+  if route_or_segment_name[:7] in ("http://", "https://") or os.path.isfile(route_or_segment_name):
     logs = [route_or_segment_name]
   else:
     route_or_segment_name = SegmentName(route_or_segment_name, allow_route_name=True)


### PR DESCRIPTION
Currently if you click "Copy Share Link" and try to use PJ, you get authentication errors which aren't solved by authenticating (due to the sig field). This also fixes not detecting routes without logs, where it previously just loaded up an empty PJ screen without asking to load qlogs. And you now can copy the Cabana link directly from your address bar