### PR TITLE
hyundai: better longitudinal control

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -1,6 +1,6 @@
 from cereal import car
 from common.realtime import DT_CTRL
-from common.numpy_fast import clip, interp
+from common.numpy_fast import clip
 from common.conversions import Conversions as CV
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.hyundai.hyundaican import create_lkas11, create_clu11, create_lfahda_mfc, create_acc_commands, create_acc_opt, create_frt_radar_opt
@@ -88,20 +88,29 @@ class CarController:
           self.last_resume_frame = self.frame
 
     if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
-      lead_visible = False
+      pid_control = (actuators.longControlState == LongCtrlState.pid)
+      stopping = (actuators.longControlState == LongCtrlState.stopping)
       accel = actuators.accel if CC.longActive else 0
+      # TODO: aEgo lags when jerk is high, use smoothed ACCEL_REF_ACC instead?
+      accel_error = accel - CS.out.aEgo if CC.longActive else 0
 
-      jerk = clip(2.0 * (accel - CS.out.aEgo), -12.7, 12.7)
+      # TODO: jerk upper would probably be better from longitudinal planner desired jerk?
+      jerk_upper = clip(2.0 * accel_error, 0.0, 1.5) # zero when error is negative to keep decel control tight
+      jerk_lower = 12.7 # always max value to keep decel control tight
 
-      if accel < 0:
-        accel = interp(accel - CS.out.aEgo, [-1.0, -0.5], [2 * accel, accel])
+      if pid_control and CS.out.standstill and CS.brake_control_active and accel > 0.0:
+        # brake controller needs to wind up internallly until it reaches a threshhold where the brakes release
+        # larger values cause faster windup (too small and you never start moving)
+        # larger values get vehicle moving quicker but can cause sharp negative jerk transitioning back to plan
+        # larger values also cause more overshoot and therefore it takes longer to stop once moving
+        accel = 1.0
+        jerk_upper = 1.0
 
       accel = clip(accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
 
-      stopping = (actuators.longControlState == LongCtrlState.stopping)
       set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_MPH if CS.clu11["CF_Clu_SPEED_UNIT"] == 1 else CV.MS_TO_KPH)
-      can_sends.extend(create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2), lead_visible,
-                                           set_speed_in_units, stopping, CS.out.gasPressed))
+      can_sends.extend(create_acc_commands(self.packer, CC.enabled, accel, jerk_upper, jerk_lower, int(self.frame / 2),
+                                           hud_control.leadVisible, set_speed_in_units, stopping, CS.out.gasPressed))
       self.accel = accel
 
     # 20 Hz LFA MFA message

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -95,7 +95,7 @@ class CarController:
       accel_error = accel - CS.out.aEgo if CC.longActive else 0
 
       # TODO: jerk upper would probably be better from longitudinal planner desired jerk?
-      jerk_upper = clip(2.0 * accel_error, 0.0, 1.5) # zero when error is negative to keep decel control tight
+      jerk_upper = clip(2.0 * accel_error, 0.0, 2.0) # zero when error is negative to keep decel control tight
       jerk_lower = 12.7 # always max value to keep decel control tight
 
       if pid_control and CS.out.standstill and CS.brake_control_active and accel > 0.0:

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -114,6 +114,7 @@ class CarState(CarStateBase):
     self.brake_error = cp.vl["TCS13"]["ACCEnable"] != 0 # 0 ACC CONTROL ENABLED, 1-3 ACC CONTROL DISABLED
     self.prev_cruise_buttons = self.cruise_buttons
     self.cruise_buttons = cp.vl["CLU11"]["CF_Clu_CruiseSwState"]
+    self.brake_control_active = cp.vl["TCS13"]["DCEnable"] == 1
 
     return ret
 
@@ -155,6 +156,7 @@ class CarState(CarStateBase):
       ("CF_Clu_AliveCnt1", "CLU11"),
 
       ("ACCEnable", "TCS13"),
+      ("DCEnable", "TCS13"),
       ("ACC_REQ", "TCS13"),
       ("DriverBraking", "TCS13"),
       ("StandStill", "TCS13"),

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -78,7 +78,7 @@ def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 
-def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_speed, stopping, gas_pressed):
+def create_acc_commands(packer, enabled, accel, jerk_upper, jerk_lower, idx, lead_visible, set_speed, stopping, gas_pressed):
   commands = []
 
   scc11_values = {
@@ -86,19 +86,19 @@ def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_spe
     "TauGapSet": 4,
     "VSetDis": set_speed if enabled else 0,
     "AliveCounterACC": idx % 0x10,
-    "ObjValid": 1 if lead_visible else 0,
-    "ACC_ObjStatus": 1 if lead_visible else 0,
+    "ObjValid": 1, # close lead makes controls tighter
+    "ACC_ObjStatus": 1, # close lead makes controls tighter
     "ACC_ObjLatPos": 0,
     "ACC_ObjRelSpd": 0,
-    "ACC_ObjDist": 0,
+    "ACC_ObjDist": 1, # close lead makes controls tighter
   }
   commands.append(packer.make_can_msg("SCC11", 0, scc11_values))
 
   scc12_values = {
     "ACCMode": 2 if enabled and gas_pressed else 1 if enabled else 0,
     "StopReq": 1 if enabled and stopping else 0,
-    "aReqRaw": accel if enabled else 0,
-    "aReqValue": accel if enabled else 0, # stock ramps up and down respecting jerk limit until it reaches aReqRaw
+    "aReqRaw": accel if enabled and not stopping else 0,
+    "aReqValue": accel if enabled and not stopping else 0, # stock ramps up and down respecting jerk limit until it reaches aReqRaw
     "CR_VSM_Alive": idx % 0xF,
   }
   scc12_dat = packer.make_can_msg("SCC12", 0, scc12_values)[2]
@@ -109,8 +109,8 @@ def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_spe
   scc14_values = {
     "ComfortBandUpper": 0.0, # stock usually is 0 but sometimes uses higher values
     "ComfortBandLower": 0.0, # stock usually is 0 but sometimes uses higher values
-    "JerkUpperLimit": max(jerk, 1.0) if (enabled and not stopping) else 0, # stock usually is 1.0 but sometimes uses higher values
-    "JerkLowerLimit": max(-jerk, 1.0) if enabled else 0, # stock usually is 0.5 but sometimes uses higher values
+    "JerkUpperLimit": jerk_upper if enabled else 0, # stock usually is 1.0 but sometimes uses higher values
+    "JerkLowerLimit": jerk_lower if enabled else 0, # stock usually is 0.5 but sometimes uses higher values
     "ACCMode": 2 if enabled and gas_pressed else 1 if enabled else 4, # stock will always be 4 instead of 0 after first disengage
     "ObjGap": 2 if lead_visible else 0, # 5: >30, m, 4: 25-30 m, 3: 20-25 m, 2: < 20 m, 0: no lead
   }

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -39,14 +39,14 @@ class CarInterface(CarInterfaceBase):
     ret.steerLimitTimer = 0.4
     tire_stiffness_factor = 1.
 
-    ret.stoppingControl = True
-    ret.vEgoStopping = 1.0
+    ret.vEgoStarting = 0.1
+    ret.vEgoStopping = 0.1
 
     ret.longitudinalTuning.kpV = [0.1]
     ret.longitudinalTuning.kiV = [0.0]
     ret.stopAccel = 0.0
 
-    ret.longitudinalActuatorDelayUpperBound = 1.0 # s
+    ret.longitudinalActuatorDelayUpperBound = 0.5 # s
 
     if candidate in (CAR.SANTA_FE, CAR.SANTA_FE_2022, CAR.SANTA_FE_HEV_2022, CAR.SANTA_FE_PHEV_2022):
       ret.lateralTuning.pid.kf = 0.00005


### PR DESCRIPTION
The following changes improve starting from a stop and make brake control more consistent and lag less:
* when stopped and you want to start moving, make a large accel request until the brakes release
* always tell the vehicle there is a lead 1 meter away

Both of these seem to be required for a consistent, quick start start from stop.  It still takes around a second, but I think it is as fast as stock and no one will complain (any slow movement after you start rolling is the planners fault).

Always telling the vehicle there is a lead 1 meter away seems to make braking way more responsive.  So much that it seems like the lag is only about 0.5 seconds (or less) normally now and we no longer need to add double the error where accel is negative.

This has only been tested on a 2020 palisade and the request values used to get you started when stopped may need to be adjusted for different vehicles (but hopefully not).  I set these values kind of conservative for now because if you set them higher the vehicle does start faster, but it will always go all the way to the requested value and this can cause a harsh jerk when the transition happens back to the plan accel (if it is still small and positive).

I also noticed that sometimes the plan can take a while to reach `vEgoStarting` which caused further delay starting from a stop, so lowering it makes starting from a stop faster and more consistent.  Perhaps we want to do this for other manufacturers, too.