### PR TITLE
api.cc: expose error type in requestDone signal

### DIFF
--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -117,7 +117,7 @@ void HttpRequest::requestFinished() {
   networkTimer->stop();
 
   if (reply->error() == QNetworkReply::NoError) {
-    emit requestDone(reply->readAll(), true);
+    emit requestDone(reply->readAll(), true, reply->error());
   } else {
     QString error;
     if (reply->error() == QNetworkReply::OperationCanceledError) {
@@ -130,7 +130,7 @@ void HttpRequest::requestFinished() {
       }
       error = reply->errorString();
     }
-    emit requestDone(error, false);
+    emit requestDone(error, false, reply->error());
   }
 
   reply->deleteLater();

--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -125,9 +125,6 @@ void HttpRequest::requestFinished() {
       nam()->clearConnectionCache();
       error = "Request timed out";
     } else {
-      if (reply->error() == QNetworkReply::ContentAccessDenied || reply->error() == QNetworkReply::AuthenticationRequiredError) {
-        qWarning() << ">>  Unauthorized. Authenticate with tools/lib/auth.py  <<";
-      }
       error = reply->errorString();
     }
     emit requestDone(error, false, reply->error());

--- a/selfdrive/ui/qt/api.h
+++ b/selfdrive/ui/qt/api.h
@@ -31,7 +31,7 @@ public:
   bool timeout() const;
 
 signals:
-  void requestDone(const QString &response, bool success);
+  void requestDone(const QString &response, bool success, QNetworkReply::NetworkError error);
 
 protected:
   QNetworkReply *reply = nullptr;

--- a/selfdrive/ui/qt/request_repeater.cc
+++ b/selfdrive/ui/qt/request_repeater.cc
@@ -15,7 +15,7 @@ RequestRepeater::RequestRepeater(QObject *parent, const QString &requestURL, con
   if (!cacheKey.isEmpty()) {
     prevResp = QString::fromStdString(params.get(cacheKey.toStdString()));
     if (!prevResp.isEmpty()) {
-      QTimer::singleShot(500, [=]() { emit requestDone(prevResp, true); });
+      QTimer::singleShot(500, [=]() { emit requestDone(prevResp, true, QNetworkReply::NoError); });
     }
     QObject::connect(this, &HttpRequest::requestDone, [=](const QString &resp, bool success) {
       if (success && resp != prevResp) {

--- a/selfdrive/ui/replay/route.cc
+++ b/selfdrive/ui/replay/route.cc
@@ -35,7 +35,11 @@ bool Route::load() {
 bool Route::loadFromServer() {
   QEventLoop loop;
   HttpRequest http(nullptr, !Hardware::PC());
-  QObject::connect(&http, &HttpRequest::requestDone, [&](const QString &json, bool success) {
+  QObject::connect(&http, &HttpRequest::requestDone, [&](const QString &json, bool success, QNetworkReply::NetworkError error) {
+    if (error == QNetworkReply::ContentAccessDenied || error == QNetworkReply::AuthenticationRequiredError) {
+      qWarning() << ">>  Unauthorized. Authenticate with tools/lib/auth.py  <<";
+    }
+
     loop.exit(success ? loadFromJson(json) : 0);
   });
   http.sendRequest("https://api.commadotai.com/v1/route/" + route_.str + "/files");


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
