### PR TITLE
enable saving learned steering stiffness only reset on extreme drops in stiffnessFactor.

### DIFF
--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -153,7 +153,8 @@ def main(sm=None, pm=None):
 
   # When driving in wet conditions the stiffness can go down, and then be too low on the next drive
   # Without a way to detect this we have to reset the stiffness every drive
-  params['stiffnessFactor'] = 1.0
+  if params['stiffnessFactor'] < 0.90:
+    params['stiffnessFactor'] = 0.95
   learner = ParamsLearner(CP, params['steerRatio'], params['stiffnessFactor'], math.radians(params['angleOffsetAverageDeg']))
   angle_offset_average = params['angleOffsetAverageDeg']
   angle_offset = angle_offset_average


### PR DESCRIPTION
currently the steering stiffness factor is discarded on every drive to avoid using a value that's extremely low due to rain on a previous drive. 

This change puts a lower limit on how much it can be learned down before the value is reset and allows the stiffness factor to be saved / learned higher.

EKF value should reset when it was previously learned significantly low but possibly not back to one. 
EKF value should not be reset when it was learned "up" 

I do not have the data to back up 
"reset to 0.95 when lower than  0.90" 
but there should be some allowance for learning the tire stiffness down without resetting. 
otherwise this can be if params[sf] < 1.0: params[sf] = 1.0
