### PR TITLE
Lock SR within EKF with bool in carParams

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -77,6 +77,8 @@ class CarInterfaceBase(ABC):
     ret.steerControlType = car.CarParams.SteerControlType.torque
     ret.minSteerSpeed = 0.
     ret.wheelSpeedFactor = 1.0
+    
+    ret.learnSR = True
 
     ret.pcmCruise = True     # openpilot's state is tied to the PCM's cruise state on most cars
     ret.minEnableSpeed = -1. # enable is done by stock ACC, so ignore this

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -78,7 +78,7 @@ class CarInterfaceBase(ABC):
     ret.minSteerSpeed = 0.
     ret.wheelSpeedFactor = 1.0
     
-    ret.learnSR = True
+    ret.lockSR = False
 
     ret.pcmCruise = True     # openpilot's state is tied to the PCM's cruise state on most cars
     ret.minEnableSpeed = -1. # enable is done by stock ACC, so ignore this

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -86,6 +86,8 @@ class CarKalman(KalmanFilter):
     'center_to_rear',
     'stiffness_front',
     'stiffness_rear',
+    'steer_ratio',
+    'learnSR',
   ]
 
   @staticmethod
@@ -98,7 +100,7 @@ class CarKalman(KalmanFilter):
 
     # globals
     global_vars = [sp.Symbol(name) for name in CarKalman.global_vars]
-    m, j, aF, aR, cF_orig, cR_orig = global_vars
+    m, j, aF, aR, cF_orig, cR_orig, sR, learnSR = global_vars
 
     # make functions and jacobians with sympy
     # state variables
@@ -114,7 +116,7 @@ class CarKalman(KalmanFilter):
     theta = state[States.ROAD_ROLL, :][0, 0]
     sa = state[States.STEER_ANGLE, :][0, 0]
 
-    sR = state[States.STEER_RATIO, :][0, 0]
+    sR = sR*(1.-learnSR) + learnSR*state[States.STEER_RATIO, :][0, 0]
     u, v = state[States.VELOCITY, :]
     r = state[States.YAW_RATE, :][0, 0]
 

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -87,7 +87,7 @@ class CarKalman(KalmanFilter):
     'stiffness_front',
     'stiffness_rear',
     'steer_ratio',
-    'learnSR',
+    'learn_sr',
   ]
 
   @staticmethod

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -29,6 +29,8 @@ class ParamsLearner:
     self.kf.filter.set_global("center_to_rear", CP.wheelbase - CP.centerToFront)
     self.kf.filter.set_global("stiffness_front", CP.tireStiffnessFront)
     self.kf.filter.set_global("stiffness_rear", CP.tireStiffnessRear)
+    self.kf.filter.set_global("steer_ratio", CP.steerRatio)
+    self.kf.filter.set_global("learn_sr", 1. if CP.learnSR else 0.)
 
     self.active = False
 
@@ -117,7 +119,10 @@ def main(sm=None, pm=None):
   CP = car.CarParams.from_bytes(params_reader.get("CarParams", block=True))
   cloudlog.info("paramsd got CarParams")
 
-  min_sr, max_sr = 0.5 * CP.steerRatio, 2.0 * CP.steerRatio
+  min_sr, max_sr = CP.steerRatio, CP.steerRatio
+  if CP.learnSR:
+    min_sr /= 2
+    max_sr *= 2
 
   params = params_reader.get("LiveParameters")
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -30,7 +30,7 @@ class ParamsLearner:
     self.kf.filter.set_global("stiffness_front", CP.tireStiffnessFront)
     self.kf.filter.set_global("stiffness_rear", CP.tireStiffnessRear)
     self.kf.filter.set_global("steer_ratio", CP.steerRatio)
-    self.kf.filter.set_global("learn_sr", 1. if CP.learnSR else 0.)
+    self.kf.filter.set_global("learn_sr", 0. if CP.lockSR else 1.)
 
     self.active = False
 
@@ -120,7 +120,7 @@ def main(sm=None, pm=None):
   cloudlog.info("paramsd got CarParams")
 
   min_sr, max_sr = CP.steerRatio, CP.steerRatio
-  if CP.learnSR:
+  if not CP.lockSR:
     min_sr /= 2
     max_sr *= 2
 


### PR DESCRIPTION
SR causes a lot of headaches and personally was never accurate on my vehicle. 
Steering was jerky and cut hard corners very badly or oversteered to the curb. 

Just overriding the value causes it's own issues. namely stiffness factor is not learned effectively. but it's done in  forks because it still performs better in some cases. 

After setting my steering ratio to the stock value Stiffness Factor was re-learned to ~0.665 
I used this value in my interface.py to scale the front/rear stiffness and now have the improved accuracy steering in straights and curves without breaking the learner, so now it can learn stiffness and any others from the dynamic model while locking the SR. 