### PR TITLE
sensor2_i2c.h: remove unused B context

### DIFF
--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -58,19 +58,13 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
 
   // FORMAT
   {0x3040, 0xC000}, // READ_MODE
-  {0x3004, 0x0000}, // X_ADDR_START_ (A)
-  {0x308A, 0x0000}, // X_ADDR_START_ (B)
-  {0x3008, 0x0787}, // X_ADDR_END_ (A)
-  {0x308E, 0x0787}, // X_ADDR_END_ (B)
-  {0x3002, 0x0000}, // Y_ADDR_START_ (A)
-  {0x308C, 0x0000}, // Y_ADDR_START_ (B)
-  {0x3006, 0x04B7}, // Y_ADDR_END_ (A)
-  {0x3090, 0x04B7}, // Y_ADDR_END_ (B)
+  {0x3004, 0x0000}, // X_ADDR_START_
+  {0x3008, 0x0787}, // X_ADDR_END_
+  {0x3002, 0x0000}, // Y_ADDR_START_
+  {0x3006, 0x04B7}, // Y_ADDR_END_
   {0x3032, 0x0000}, // SCALING_MODE
-  {0x30A2, 0x0001}, // X_ODD_INC_ (A)
-  {0x30AE, 0x0001}, // X_ODD_INC_ (B)
-  {0x30A6, 0x0001}, // Y_ODD_INC_ (A)
-  {0x30A8, 0x0001}, // Y_ODD_INC_ (B)
+  {0x30A2, 0x0001}, // X_ODD_INC_
+  {0x30A6, 0x0001}, // Y_ODD_INC_
   {0x3402, 0x0F10}, // X_OUTPUT_CONTROL
   {0x3404, 0x0970}, // Y_OUTPUT_CONTROL
   {0x3064, 0x1802}, // SMIA_TEST
@@ -82,10 +76,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x340C, 0x802}, // 2 // 0000 0000 0010
 
   // Readout timing
-  {0x300C, 0x07B9}, // LINE_LENGTH_PCK (A)
-  {0x303E, 0x07B9}, // LINE_LENGTH_PCK (B)
-  {0x300A, 0x07E7}, // FRAME_LENGTH_LINES (A)
-  {0x30AA, 0x07E7}, // FRAME_LENGTH_LINES (B)
+  {0x300C, 0x07B9}, // LINE_LENGTH_PCK
+  {0x300A, 0x07E7}, // FRAME_LENGTH_LINES
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings
@@ -114,18 +106,10 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x31E0, 0x0003},
 
   // HDR Settings
-  {0x3082, 0x0004}, // OPERATION_MODE_CTRL (A)
-  {0x3084, 0x0004}, // OPERATION_MODE_CTRL (B)
-
-  {0x3238, 0x0004}, // EXPOSURE_RATIO (A)
-  {0x323A, 0x0004}, // EXPOSURE_RATIO (B)
-
-  {0x3014, 0x098E}, // FINE_INTEGRATION_TIME_ (A)
-  {0x3018, 0x098E}, // FINE_INTEGRATION_TIME_ (B)
-
-  {0x321E, 0x098E}, // FINE_INTEGRATION_TIME2 (A)
-  {0x3220, 0x098E}, // FINE_INTEGRATION_TIME2 (B)
-
+  {0x3082, 0x0004}, // OPERATION_MODE_CTRL
+  {0x3238, 0x0004}, // EXPOSURE_RATIO
+  {0x3014, 0x098E}, // FINE_INTEGRATION_TIME_
+  {0x321E, 0x098E}, // FINE_INTEGRATION_TIME2
   {0x31D0, 0x0000}, // COMPANDING, no good in 10 bit?
   {0x33DA, 0x0000}, // COMPANDING
   {0x318E, 0x0200}, // PRE_HDR_GAIN_EN
@@ -143,26 +127,19 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
 
    // Initial Gains
   {0x3022, 0x0001}, // GROUPED_PARAMETER_HOLD_
-  {0x3366, 0xFF77}, // ANALOG_GAIN (1x) (A)
-  {0x3368, 0xFF77}, // ANALOG_GAIN (1x) (B)
+  {0x3366, 0xFF77}, // ANALOG_GAIN (1x)
 
   {0x3060, 0x3333}, // ANALOG_COLOR_GAIN
 
-  {0x3362, 0x0000}, // DC GAIN (A & B)
+  {0x3362, 0x0000}, // DC GAIN
 
-  {0x305A, 0x00F8}, // red gain (A)
-  {0x3058, 0x0122}, // blue gain (A)
-  {0x3056, 0x009A}, // g1 gain (A)
-  {0x305C, 0x009A}, // g2 gain (A)
-
-  {0x30C0, 0x00F8}, // red gain (B)
-  {0x30BE, 0x0122}, // blue gain (B)
-  {0x30BC, 0x009A}, // g1 gain (B)
-  {0x30C2, 0x009A}, // g2 gain (B)
+  {0x305A, 0x00F8}, // red gain
+  {0x3058, 0x0122}, // blue gain
+  {0x3056, 0x009A}, // g1 gain
+  {0x305C, 0x009A}, // g2 gain
 
   {0x3022, 0x0000}, // GROUPED_PARAMETER_HOLD_
 
   // Initial Integration Time
-  {0x3012, 0x0005}, // (A)
-  {0x3016, 0x0005}, // (B)
+  {0x3012, 0x0005},
 };


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
