### PR TITLE
sim: write params to enable in Dockerfile

### DIFF
--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -63,3 +63,5 @@ COPY ./tools $HOME/openpilot/tools
 
 WORKDIR $HOME/openpilot
 RUN scons -j$(nproc)
+
+RUN python -c "from selfdrive.test.helpers import set_params_enabled; set_params_enabled()"


### PR DESCRIPTION
The params are written in bridge, but aren't picked up if manager is started first.