### PR TITLE
UI: improved disengage on gas toggle description

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -68,7 +68,7 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
     {
       "DisengageOnAccelerator",
       "Disengage On Accelerator Pedal",
-      "When enabled, openpilot will disengage when the accelerator pedal is depressed.",
+      "When enabled, pressing the accelerator pedal will disengage openpilot.",
       "../assets/offroad/icon_disengage_on_accelerator.svg",
     },
 #ifdef ENABLE_MAPS

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -68,7 +68,7 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
     {
       "DisengageOnAccelerator",
       "Disengage On Accelerator Pedal",
-      "When enabled, openpilot will disengage when the accelerator pedal is pressed.",
+      "When enabled, openpilot will disengage when the accelerator pedal is depressed.",
       "../assets/offroad/icon_disengage_on_accelerator.svg",
     },
 #ifdef ENABLE_MAPS


### PR DESCRIPTION
Should be depressed as standard in automotive industry.

Pressed implies state change from down -> up, depressed means the state is down
