### PR TITLE
update linear region for paramsd

### DIFF
--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -36,6 +36,7 @@ class ParamsLearner:
     self.roll = 0.0
     self.steering_pressed = False
     self.steering_angle = 0.0
+    self.steering_ratio = CP.steerRatio
 
     self.valid = True
 
@@ -89,7 +90,7 @@ class ParamsLearner:
       self.steering_pressed = msg.steeringPressed
       self.speed = msg.vEgo
 
-      in_linear_region = abs(self.steering_angle) < 45 or not self.steering_pressed
+      in_linear_region = abs(self.steering_angle) < 5*self.steering_ratio and not self.steering_pressed
       self.active = self.speed > 5 and in_linear_region
 
       if self.active:

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -90,7 +90,7 @@ class ParamsLearner:
       self.steering_pressed = msg.steeringPressed
       self.speed = msg.vEgo
 
-      in_linear_region = abs(self.steering_angle) < 5*self.steering_ratio
+      in_linear_region = abs(self.steering_angle) < 4*self.steering_ratio
       self.active = self.speed > 5 and in_linear_region
 
       if self.active:

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -90,7 +90,7 @@ class ParamsLearner:
       self.steering_pressed = msg.steeringPressed
       self.speed = msg.vEgo
 
-      in_linear_region = abs(self.steering_angle) < 5*self.steering_ratio and not self.steering_pressed
+      in_linear_region = abs(self.steering_angle) < 5*self.steering_ratio
       self.active = self.speed > 5 and in_linear_region
 
       if self.active:


### PR DESCRIPTION
It looks like this logic is supposed to lock out the EKF at extreme steering angles. however it observes when the steeringPressed message drops momentarily regardless of steering angle.  

I noted the EKF observing data while the steering wheel was at 250deg which immediately caused relatively massive swings in values and that this occurred frequently in manual turning maneuvers.
this adjustment is currently bounded by observing the estimated states but these are still invalid observations at these high steering angles. 

Removed the limit on steer pressed to preserve the behavior of in_linear_region within the ~45deg steer limit. 
EKF observations should still be accurate 
also scaled this  linear_region by steer ratio to limit the learner to about 4 deg of wheel steer instead of varying between vehicles. 
