### PR TITLE
Honda Bosch: fix undefined signal in can packing

### DIFF
--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -137,7 +137,6 @@ def create_ui_commands(packer, CP, pcm_speed, hud, is_metric, idx, stock_hud):
 
   lkas_hud_values = {
     'SET_ME_X41': 0x41,
-    'SET_ME_X48': 0x48,
     'STEERING_REQUIRED': hud.steer_required,
     'SOLID_LANES': hud.lanes,
     'BEEP': 0,


### PR DESCRIPTION
**Description** : Resolves the `undefined signal SET_ME_X48` terminal error for Honda Bosch vehicles with the extended LKAS_HUD CAN IDs. The signal is defined later for all other cars.

**Verification** : Discord user RedAcid and route replay.
**Car** : 2020 Honda Civic Hatchback
