### PR TITLE
UI: new laneless design

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -304,23 +304,11 @@ void NvgWindow::updateFrameMat(int w, int h) {
       .translate(-intrinsic_matrix.v[2], -intrinsic_matrix.v[5]);
 }
 
-void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
-  const UIScene &scene = s->scene;
+void NvgWindow::drawLaneLines(QPainter &painter, const UIScene &scene) {
   if (!scene.end_to_end) {
     // lanelines
     for (int i = 0; i < std::size(scene.lane_line_vertices); ++i) {
-      if (false)  {  // i == 1 || i == 2) {
-        // TODO: can we just use the projected vertices somehow?
-        const cereal::ModelDataV2::XYZTData::Reader &line = (*s->sm)["modelV2"].getModelV2().getLaneLines()[i];
-        const float default_pos = 1.4;  // when lane poly isn't available
-        const float lane_pos = line.getY().size() > 0 ? std::abs(line.getY()[5]) : default_pos;  // get redder when line is closer to car
-        float hue = 332.5 * lane_pos - 332.5;  // equivalent to {1.4, 1.0}: {133, 0} (green to red)
-        hue = fmin(133, fmax(0, hue)) / 360.;  // clip and normalize
-        painter.setBrush(QColor::fromHslF(hue, 0.73, 0.64, scene.lane_line_probs[i]));
-      } else {
-        painter.setBrush(QColor::fromRgbF(1.0, 1.0, 1.0, scene.lane_line_probs[i]));
-      }
-
+      painter.setBrush(QColor::fromRgbF(1.0, 1.0, 1.0, scene.lane_line_probs[i]));
       painter.drawPolygon(scene.lane_line_vertices[i].v, scene.lane_line_vertices[i].cnt);
     }
     // road edges
@@ -331,18 +319,8 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
   }
   // paint path
   QLinearGradient bg(0, height(), 0, height() / 4);
-  const cereal::ModelDataV2::XYZTData::Reader &pos = (*s->sm)["modelV2"].getModelV2().getPosition();
-  const float lat_pos = pos.getY().size() > 0 ? std::abs(pos.getY()[14] - pos.getY()[0]) : 0;  // 14 is 1.91406 (subtract initial pos to not consider offset)
-  float hue = lat_pos * -39.46 + 148;  // interp from {0, 4.5} -> {148, 0}
-//  hue = fmin(148, hue);
-  qDebug() << lat_pos << hue;
-  if ((*s->sm)["controlsState"].getControlsState().getEnabled()) {
-    bg.setColorAt(0, QColor::fromHslF(hue / 360., .94, .51, 225/255.));  // 148 is magic. 148 is spring green
-    bg.setColorAt(1, QColor::fromHslF(hue / 360., .73, .49, 0));
-  } else {
-    bg.setColorAt(0, scene.end_to_end ? redColor() : QColor(255, 255, 255));
-    bg.setColorAt(1, scene.end_to_end ? redColor(0) : QColor(255, 255, 255, 0));
-  }
+  bg.setColorAt(0, scene.end_to_end ? redColor() : whiteColor());
+  bg.setColorAt(1, scene.end_to_end ? redColor(0) : whiteColor(0));
   painter.setBrush(bg);
   painter.drawPolygon(scene.track_vertices.v, scene.track_vertices.cnt);
 }
@@ -388,7 +366,7 @@ void NvgWindow::paintGL() {
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
 
-    drawLaneLines(painter, s);
+    drawLaneLines(painter, s->scene);
 
     if (s->scene.longitudinal_control) {
       auto leads = (*s->sm)["modelV2"].getModelV2().getLeadsV3();

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -384,10 +384,7 @@ void NvgWindow::paintGL() {
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
 
-    double cur_t = millis_since_boot();
     drawLaneLines(painter, s);
-    double elapsed = millis_since_boot() - cur_t;
-    qDebug() << "Took" << elapsed << "ms to draw";
 
     if (s->scene.longitudinal_control) {
       auto leads = (*s->sm)["modelV2"].getModelV2().getLeadsV3();

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -332,8 +332,8 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
     curve_hue = int(curve_hue * 100 + 0.5) / 100;
 
     bg.setColorAt(0.0 / 1.5, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
-    bg.setColorAt(0.45 / 1.5, QColor::fromHslF(112 / 360., 1.0, 0.68, 0.8));
-    bg.setColorAt(0.7 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.6));
+    bg.setColorAt(0.55 / 1.5, QColor::fromHslF(112 / 360., 1.0, 0.68, 0.8));
+    bg.setColorAt(0.9 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.6));
     bg.setColorAt(1.0, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.0));
   } else {
     bg.setColorAt(0, whiteColor());

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -311,26 +311,28 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
     painter.setBrush(QColor::fromRgbF(1.0, 1.0, 1.0, scene.lane_line_probs[i]));
     painter.drawPolygon(scene.lane_line_vertices[i].v, scene.lane_line_vertices[i].cnt);
   }
+
   // road edges
   for (int i = 0; i < std::size(scene.road_edge_vertices); ++i) {
     painter.setBrush(QColor::fromRgbF(1.0, 0, 0, std::clamp<float>(1.0 - scene.road_edge_stds[i], 0.0, 1.0)));
     painter.drawPolygon(scene.road_edge_vertices[i].v, scene.road_edge_vertices[i].cnt);
   }
+
   // paint path
   QLinearGradient bg(0, height(), 0, height() / 2);
   if (scene.end_to_end) {
     const auto &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
     float orientation_future = 0;
-    if (orientation.getZ().size() > 0) {
+    if (orientation.getZ().size() > 16) {
       orientation_future = std::abs(orientation.getZ()[16]);  // 2.5 seconds
     }
     // straight: 101, in turns: 70
-    float curve_hue = fmax(70, 101 - (orientation_future * 310)) / 360.;
+    const float curve_hue = fmax(70, 101 - (orientation_future * 310));
 
     bg.setColorAt(0.0, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
     bg.setColorAt(0.35, QColor::fromHslF(148 / 360., 1.0, 0.5, 0.9));
-    bg.setColorAt(0.9, QColor::fromHslF(curve_hue, 1.0, 0.65, 0.8));
-    bg.setColorAt(1.0, QColor::fromHslF(curve_hue, 1.0, 0.65, 0.4));
+    bg.setColorAt(0.9, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.8));
+    bg.setColorAt(1.0, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.4));
   } else {
     bg.setColorAt(0, whiteColor());
     bg.setColorAt(1, whiteColor(0));

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -304,11 +304,23 @@ void NvgWindow::updateFrameMat(int w, int h) {
       .translate(-intrinsic_matrix.v[2], -intrinsic_matrix.v[5]);
 }
 
-void NvgWindow::drawLaneLines(QPainter &painter, const UIScene &scene) {
+void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
+  const UIScene &scene = s->scene;
   if (!scene.end_to_end) {
     // lanelines
     for (int i = 0; i < std::size(scene.lane_line_vertices); ++i) {
-      painter.setBrush(QColor::fromRgbF(1.0, 1.0, 1.0, scene.lane_line_probs[i]));
+      if (false)  {  // i == 1 || i == 2) {
+        // TODO: can we just use the projected vertices somehow?
+        const cereal::ModelDataV2::XYZTData::Reader &line = (*s->sm)["modelV2"].getModelV2().getLaneLines()[i];
+        const float default_pos = 1.4;  // when lane poly isn't available
+        const float lane_pos = line.getY().size() > 0 ? std::abs(line.getY()[5]) : default_pos;  // get redder when line is closer to car
+        float hue = 332.5 * lane_pos - 332.5;  // equivalent to {1.4, 1.0}: {133, 0} (green to red)
+        hue = fmin(133, fmax(0, hue)) / 360.;  // clip and normalize
+        painter.setBrush(QColor::fromHslF(hue, 0.73, 0.64, scene.lane_line_probs[i]));
+      } else {
+        painter.setBrush(QColor::fromRgbF(1.0, 1.0, 1.0, scene.lane_line_probs[i]));
+      }
+
       painter.drawPolygon(scene.lane_line_vertices[i].v, scene.lane_line_vertices[i].cnt);
     }
     // road edges
@@ -319,8 +331,18 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIScene &scene) {
   }
   // paint path
   QLinearGradient bg(0, height(), 0, height() / 4);
-  bg.setColorAt(0, scene.end_to_end ? redColor() : whiteColor());
-  bg.setColorAt(1, scene.end_to_end ? redColor(0) : whiteColor(0));
+  const cereal::ModelDataV2::XYZTData::Reader &pos = (*s->sm)["modelV2"].getModelV2().getPosition();
+  const float lat_pos = pos.getY().size() > 0 ? std::abs(pos.getY()[14] - pos.getY()[0]) : 0;  // 14 is 1.91406 (subtract initial pos to not consider offset)
+  float hue = lat_pos * -39.46 + 148;  // interp from {0, 4.5} -> {148, 0}
+//  hue = fmin(148, hue);
+  qDebug() << lat_pos << hue;
+  if ((*s->sm)["controlsState"].getControlsState().getEnabled()) {
+    bg.setColorAt(0, QColor::fromHslF(hue / 360., .94, .51, 225/255.));  // 148 is magic. 148 is spring green
+    bg.setColorAt(1, QColor::fromHslF(hue / 360., .73, .49, 0));
+  } else {
+    bg.setColorAt(0, scene.end_to_end ? redColor() : QColor(255, 255, 255));
+    bg.setColorAt(1, scene.end_to_end ? redColor(0) : QColor(255, 255, 255, 0));
+  }
   painter.setBrush(bg);
   painter.drawPolygon(scene.track_vertices.v, scene.track_vertices.cnt);
 }
@@ -366,7 +388,7 @@ void NvgWindow::paintGL() {
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
 
-    drawLaneLines(painter, s->scene);
+    drawLaneLines(painter, s);
 
     if (s->scene.longitudinal_control) {
       auto leads = (*s->sm)["modelV2"].getModelV2().getLeadsV3();

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -327,7 +327,6 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
     // straight: 101, in turns: 70
     float curve_hue = fmax(70, 101 - (orientation_future * 310)) / 360.;
 
-    // compensate so gradient ends near middle
     bg.setColorAt(0.0, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
     bg.setColorAt(0.35, QColor::fromHslF(148 / 360., 1.0, 0.5, 0.9));
     bg.setColorAt(0.9, QColor::fromHslF(curve_hue, 1.0, 0.65, 0.8));

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -308,7 +308,7 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
   const UIScene &scene = s->scene;
   // lanelines
   for (int i = 0; i < std::size(scene.lane_line_vertices); ++i) {
-    painter.setBrush(QColor::fromRgbF(1.0, 1.0, 1.0, scene.lane_line_probs[i]));
+    painter.setBrush(QColor::fromRgbF(1.0, 1.0, 1.0, std::clamp<float>(scene.lane_line_probs[i], 0.0, 0.7)));
     painter.drawPolygon(scene.lane_line_vertices[i].v, scene.lane_line_vertices[i].cnt);
   }
 
@@ -319,7 +319,7 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
   }
 
   // paint path
-  QLinearGradient bg(0, height(), 0, height() / 2);
+  QLinearGradient bg(0, height(), 0, height() / 4);
   if (scene.end_to_end) {
     const auto &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
     float orientation_future = 0;
@@ -329,10 +329,11 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
     // straight: 101, in turns: 70
     const float curve_hue = fmax(70, 101 - (orientation_future * 310));
 
-    bg.setColorAt(0.0, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
-    bg.setColorAt(0.35, QColor::fromHslF(148 / 360., 1.0, 0.5, 0.9));
-    bg.setColorAt(0.9, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.8));
-    bg.setColorAt(1.0, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.4));
+    bg.setColorAt(0.0 / 1.5, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
+    bg.setColorAt(0.45 / 1.5, QColor::fromHslF(101 / 360., 1.0, 0.68, 0.8));
+    bg.setColorAt(0.7 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.6));
+//    bg.setColorAt(1 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.4));
+    bg.setColorAt(1.0, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.0));
   } else {
     bg.setColorAt(0, whiteColor());
     bg.setColorAt(1, whiteColor(0));

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -327,10 +327,10 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
       orientation_future = std::abs(orientation.getZ()[16]);  // 2.5 seconds
     }
     // straight: 101, in turns: 70
-    const float curve_hue = fmax(70, 101 - (orientation_future * 310));
+    const float curve_hue = fmax(70, 112 - (orientation_future * 310));
 
     bg.setColorAt(0.0 / 1.5, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
-    bg.setColorAt(0.45 / 1.5, QColor::fromHslF(101 / 360., 1.0, 0.68, 0.8));
+    bg.setColorAt(0.45 / 1.5, QColor::fromHslF(112 / 360., 1.0, 0.68, 0.8));
     bg.setColorAt(0.7 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.6));
 //    bg.setColorAt(1 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.4));
     bg.setColorAt(1.0, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.0));

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -327,12 +327,11 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
       orientation_future = std::abs(orientation.getZ()[16]);  // 2.5 seconds
     }
     // straight: 101, in turns: 70
-    const float curve_hue = fmax(70, 112 - (orientation_future * 310));
+    const float curve_hue = fmax(70, 112 - (orientation_future * 420));
 
     bg.setColorAt(0.0 / 1.5, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
     bg.setColorAt(0.45 / 1.5, QColor::fromHslF(112 / 360., 1.0, 0.68, 0.8));
     bg.setColorAt(0.7 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.6));
-//    bg.setColorAt(1 / 1.5, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.4));
     bg.setColorAt(1.0, QColor::fromHslF(curve_hue / 360., 1.0, 0.65, 0.0));
   } else {
     bg.setColorAt(0, whiteColor());

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -382,7 +382,10 @@ void NvgWindow::paintGL() {
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
 
+    double cur_t = millis_since_boot();
     drawLaneLines(painter, s);
+    double elapsed = millis_since_boot() - cur_t;
+    qDebug() << "Took" << elapsed << "ms to draw";
 
     if (s->scene.longitudinal_control) {
       auto leads = (*s->sm)["modelV2"].getModelV2().getLeadsV3();

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -318,7 +318,6 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
     painter.drawPolygon(scene.road_edge_vertices[i].v, scene.road_edge_vertices[i].cnt);
   }
 
-  double cur_t = millis_since_boot();
   // paint path
   QLinearGradient bg(0, height(), 0, height() / 4);
   if (scene.end_to_end) {
@@ -342,8 +341,6 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
   }
   painter.setBrush(bg);
   painter.drawPolygon(scene.track_vertices.v, scene.track_vertices.cnt);
-  double elapsed = millis_since_boot() - cur_t;
-  qDebug() << "Took" << elapsed << "ms to draw";
 }
 
 void NvgWindow::drawLead(QPainter &painter, const cereal::ModelDataV2::LeadDataV3::Reader &lead_data, const QPointF &vd) {
@@ -387,7 +384,10 @@ void NvgWindow::paintGL() {
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
 
+    double cur_t = millis_since_boot();
     drawLaneLines(painter, s);
+    double elapsed = millis_since_boot() - cur_t;
+    qDebug() << "Took" << elapsed << "ms to draw";
 
     if (s->scene.longitudinal_control) {
       auto leads = (*s->sm)["modelV2"].getModelV2().getLeadsV3();

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -319,30 +319,15 @@ void NvgWindow::drawLaneLines(QPainter &painter, const UIState *s) {
     }
   }
   // paint path
-//  float end_path_y = scene.track_vertices.v[scene.track_vertices.cnt / 2].y();
   QLinearGradient bg(0, height(), 0, height() / 4);
-//  qDebug() << scene.track_vertices.cnt;
-//  qDebug() << scene.track_vertices.v[scene.track_vertices.cnt / 2] << height();
   const cereal::ModelDataV2::XYZTData::Reader &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
-  const cereal::ModelDataV2::XYZTData::Reader &rate = (*s->sm)["modelV2"].getModelV2().getOrientationRate();
-  float orientation_rate = rate.getZ().size() > 0 ? std::abs(rate.getZ()[0]) : 0;
-  float orientation_future = orientation.getZ().size() > 0 ? std::abs(orientation.getZ()[16]) : 0;
-  orientation_rate = fmin(orientation_rate * (1 / 0.05), 1);
-//  orientation_future = fmin(orientation_future * (1 / 0.1), 1);
-//  qDebug() << orientation_future << orientation_rate;
-  // path in turn colors
-//  bg.setColorAt(0, QColor::fromHslF(148 / 360., 1, 50 / 100., 1));
-//  bg.setColorAt(0.25, QColor::fromHslF(101 / 360., 1, 65 / 100., 0.8));
-//  bg.setColorAt(.5, QColor::fromHslF(54 / 360., 1, 65 / 100., 0.4));
-//  bg.setColorAt(1, QColor::fromHslF(54 / 360., 1, 65 / 100., 0));
+  float orientation_future = orientation.getZ().size() > 0 ? std::abs(orientation.getZ()[16]) : 0;  // 2.5 seconds
+  float path_end_hue = fmax(70, 101 - (orientation_future * 310)) / 360;  // straight: 101, in turns: 70
 
-  float path_end_hue = fmax(70, 101 - (orientation_future * 310)) / 360;  // straight: 101, in turns (yellow): 54
-  qDebug() << path_end_hue * 360;
-
-  bg.setColorAt(0, QColor(0, 255, 119, 255));
-  bg.setColorAt(.35 / 1.5, QColor(0, 255, 119, 0.9*255.));
-  bg.setColorAt(.9 / 1.5, QColor::fromHslF(path_end_hue, 1., .65, .8));
-  bg.setColorAt(1. / 1.5, QColor::fromHslF(path_end_hue, 1., .65, .4));
+  bg.setColorAt(0.0, QColor::fromHslF(148 / 360., 1.0, 0.5, 1.0));
+  bg.setColorAt(0.35 / 1.5, QColor::fromHslF(148 / 360., 1.0, 0.5, 0.9));
+  bg.setColorAt(0.9 / 1.5, QColor::fromHslF(path_end_hue, 1.0, 0.65, 0.8));
+  bg.setColorAt(1.0 / 1.5, QColor::fromHslF(path_end_hue, 1.0, 0.65, 0.4));
   painter.setBrush(bg);
   painter.drawPolygon(scene.track_vertices.v, scene.track_vertices.cnt);
 }

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -74,7 +74,7 @@ protected:
   void initializeGL() override;
   void showEvent(QShowEvent *event) override;
   void updateFrameMat(int w, int h) override;
-  void drawLaneLines(QPainter &painter, const UIScene &scene);
+  void drawLaneLines(QPainter &painter, const UIState *s);
   void drawLead(QPainter &painter, const cereal::ModelDataV2::LeadDataV3::Reader &lead_data, const QPointF &vd);
   inline QColor redColor(int alpha = 255) { return QColor(201, 34, 49, alpha); }
   inline QColor whiteColor(int alpha = 255) { return QColor(255, 255, 255, alpha); }

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -74,7 +74,7 @@ protected:
   void initializeGL() override;
   void showEvent(QShowEvent *event) override;
   void updateFrameMat(int w, int h) override;
-  void drawLaneLines(QPainter &painter, const UIState *s);
+  void drawLaneLines(QPainter &painter, const UIScene &scene);
   void drawLead(QPainter &painter, const cereal::ModelDataV2::LeadDataV3::Reader &lead_data, const QPointF &vd);
   inline QColor redColor(int alpha = 255) { return QColor(201, 34, 49, alpha); }
   inline QColor whiteColor(int alpha = 255) { return QColor(255, 255, 255, alpha); }

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -57,13 +57,15 @@ struct Alert {
       } else if (controls_missing > CONTROLS_TIMEOUT) {
         // car is started, but controls is lagging or died
         if (cs.getEnabled() && (controls_missing - CONTROLS_TIMEOUT) < 10) {
-          return {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
-                  "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
-                  AudibleAlert::WARNING_IMMEDIATE};
+          return {};
+//          {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
+//                  "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
+//                  AudibleAlert::WARNING_IMMEDIATE};
         } else {
-          return {"Controls Unresponsive", "Reboot Device",
-                  "controlsUnresponsivePermanent", cereal::ControlsState::AlertSize::MID,
-                  AudibleAlert::NONE};
+          return {};
+//           {"Controls Unresponsive", "Reboot Device",
+//                  "controlsUnresponsivePermanent", cereal::ControlsState::AlertSize::MID,
+//                  AudibleAlert::NONE};
         }
       }
     }

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -57,15 +57,13 @@ struct Alert {
       } else if (controls_missing > CONTROLS_TIMEOUT) {
         // car is started, but controls is lagging or died
         if (cs.getEnabled() && (controls_missing - CONTROLS_TIMEOUT) < 10) {
-          return {};
-//          {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
-//                  "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
-//                  AudibleAlert::WARNING_IMMEDIATE};
+          return {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
+                  "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
+                  AudibleAlert::WARNING_IMMEDIATE};
         } else {
-          return {};
-//           {"Controls Unresponsive", "Reboot Device",
-//                  "controlsUnresponsivePermanent", cereal::ControlsState::AlertSize::MID,
-//                  AudibleAlert::NONE};
+          return {"Controls Unresponsive", "Reboot Device",
+                  "controlsUnresponsivePermanent", cereal::ControlsState::AlertSize::MID,
+                  AudibleAlert::NONE};
         }
       }
     }


### PR DESCRIPTION
Courtesy of @jozef-simo!

Timings: https://imgur.com/a/FjWL18l

Conclusion: Full function time is near identical to previous red path and lane lines (~1ms).

For just drawing the new path, without rounding the float hue it's very inconsistent and ranges from 0.2 ms to 1 ms, with rounding to 2 decimal places it's very consistently near 0.2 ms.