### PR TITLE
nav: better reroute backoff policy

### DIFF
--- a/selfdrive/ui/navd/route_engine.cc
+++ b/selfdrive/ui/navd/route_engine.cc
@@ -294,7 +294,7 @@ void RouteEngine::recomputeRoute() {
 
   if (recompute_countdown == 0 && should_recompute) {
     recompute_countdown = std::pow(2, recompute_backoff);
-    recompute_backoff = std::min(7, recompute_backoff + 1);
+    recompute_backoff = std::min(6, recompute_backoff + 1);
     calculateRoute(*new_destination);
   } else {
     recompute_countdown = std::max(0, recompute_countdown - 1);

--- a/selfdrive/ui/navd/route_engine.cc
+++ b/selfdrive/ui/navd/route_engine.cc
@@ -221,7 +221,7 @@ void RouteEngine::routeUpdate() {
         if (next_segment.isValid()) {
           segment = next_segment;
 
-          recompute_backoff = std::max(0, recompute_backoff - 1);
+          recompute_backoff = 0;
           recompute_countdown = 0;
         } else {
           qWarning() << "Destination reached";


### PR DESCRIPTION
Lowers max backoff and completely resets once successfully completing a segment. I think this should mostly, or even entirely, fix my issues with the current backoff policy while still being robust to lots of reroute requests if not driving on the route at all.