### PR TITLE
controlsd: add curvature steering

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -34,7 +34,7 @@ class TestCarInterfaces(unittest.TestCase):
     self.assertGreater(car_params.mass, 1)
     self.assertGreater(car_params.steerRateCost, 1e-3)
 
-    if car_params.steerControlType != car.CarParams.SteerControlType.angle:
+    if car_params.steerControlType not in (car.CarParams.SteerControlType.angle, car.CarParams.SteerControlType.curvature):
       tuning = car_params.lateralTuning.which()
       if tuning == 'pid':
         self.assertTrue(len(car_params.lateralTuning.pid.kpV))

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -587,8 +587,9 @@ class Controls:
       actuators.steer, actuators.steeringAngleDeg, \
       actuators.curvature, actuators.curvatureRate, \
       actuators.pathAngle, actuators.pathDeviation, lac_log = self.LaC.update(CC.latActive, CS, self.VM, params,
-                                                                              self.last_actuators, lat_plan, self.desired_curvature,
-                                                                              self.desired_curvature_rate, self.sm['liveLocationKalman'])
+                                                                              self.last_actuators, lat_plan, self.sm['modelV2'],
+                                                                              self.desired_curvature, self.desired_curvature_rate,
+                                                                              self.sm['liveLocationKalman'])
     else:
       lac_log = log.ControlsState.LateralDebugState.new_message()
       if self.sm.rcv_frame['testJoystick'] > 0:

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -24,6 +24,7 @@ from selfdrive.controls.lib.latcontrol_indi import LatControlINDI
 from selfdrive.controls.lib.latcontrol_angle import LatControlAngle
 from selfdrive.controls.lib.latcontrol_torque import LatControlTorque
 from selfdrive.controls.lib.latcontrol_lqr import LatControlLQR
+from selfdrive.controls.lib.latcontrol_curvature import LatControlCurvature
 from selfdrive.controls.lib.events import Events, ET
 from selfdrive.controls.lib.alertmanager import AlertManager, set_offroad_alert
 from selfdrive.controls.lib.vehicle_model import VehicleModel
@@ -142,6 +143,8 @@ class Controls:
     self.LaC: LatControl
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       self.LaC = LatControlAngle(self.CP, self.CI)
+    elif self.CP.steerControlType == car.CarParams.SteerControlType.curvature:
+      self.LaC = LatControlCurvature(self.CP, self.CI)
     elif self.CP.lateralTuning.which() == 'pid':
       self.LaC = LatControlPID(self.CP, self.CI)
     elif self.CP.lateralTuning.which() == 'indi':
@@ -581,9 +584,11 @@ class Controls:
                                                                                        lat_plan.psis,
                                                                                        lat_plan.curvatures,
                                                                                        lat_plan.curvatureRates)
-      actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(CC.latActive, CS, self.VM, params,
-                                                                             self.last_actuators, self.desired_curvature,
-                                                                             self.desired_curvature_rate, self.sm['liveLocationKalman'])
+      actuators.steer, actuators.steeringAngleDeg, \
+      actuators.curvature, actuators.curvatureRate, \
+      actuators.pathAngle, actuators.pathDeviation, lac_log = self.LaC.update(CC.latActive, CS, self.VM, params,
+                                                                              self.last_actuators, lat_plan, self.desired_curvature,
+                                                                              self.desired_curvature_rate, self.sm['liveLocationKalman'])
     else:
       lac_log = log.ControlsState.LateralDebugState.new_message()
       if self.sm.rcv_frame['testJoystick'] > 0:
@@ -593,7 +598,9 @@ class Controls:
         if CC.latActive:
           steer = clip(self.sm['testJoystick'].axes[1], -1, 1)
           # max angle is 45 for angle-based cars
-          actuators.steer, actuators.steeringAngleDeg = steer, steer * 45.
+          steer_angle = steer * 45.
+          curvature = self.VM.calc_curvature(math.radians(steer_angle), CS.vEgo, params.roll)
+          actuators.steer, actuators.steeringAngleDeg, actuators.curvature = steer, steer_angle, curvature
 
         lac_log.active = self.active
         lac_log.steeringAngleDeg = CS.steeringAngleDeg
@@ -747,6 +754,8 @@ class Controls:
       controlsState.lateralControlState.debugState = lac_log
     elif self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       controlsState.lateralControlState.angleState = lac_log
+    elif self.CP.steerControlType == car.CarParams.SteerControlType.curvature:
+      controlsState.lateralControlState.curvatureState = lac_log
     elif lat_tuning == 'pid':
       controlsState.lateralControlState.pidState = lac_log
     elif lat_tuning == 'torque':

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -16,7 +16,7 @@ class LatControl(ABC):
     self.steer_max = 1.0
 
   @abstractmethod
-  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, model_v2, desired_curvature, desired_curvature_rate, llk):
     pass
 
   def reset(self):

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -16,7 +16,7 @@ class LatControl(ABC):
     self.steer_max = 1.0
 
   @abstractmethod
-  def update(self, active, CS, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
     pass
 
   def reset(self):

--- a/selfdrive/controls/lib/latcontrol_angle.py
+++ b/selfdrive/controls/lib/latcontrol_angle.py
@@ -7,7 +7,7 @@ STEER_ANGLE_SATURATION_THRESHOLD = 2.5  # Degrees
 
 
 class LatControlAngle(LatControl):
-  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, model_v2, desired_curvature, desired_curvature_rate, llk):
     angle_log = log.ControlsState.LateralAngleState.new_message()
 
     if CS.vEgo < MIN_STEER_SPEED or not active:

--- a/selfdrive/controls/lib/latcontrol_angle.py
+++ b/selfdrive/controls/lib/latcontrol_angle.py
@@ -7,7 +7,7 @@ STEER_ANGLE_SATURATION_THRESHOLD = 2.5  # Degrees
 
 
 class LatControlAngle(LatControl):
-  def update(self, active, CS, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
     angle_log = log.ControlsState.LateralAngleState.new_message()
 
     if CS.vEgo < MIN_STEER_SPEED or not active:
@@ -22,4 +22,4 @@ class LatControlAngle(LatControl):
     angle_log.saturated = self._check_saturation(angle_control_saturated, CS)
     angle_log.steeringAngleDeg = float(CS.steeringAngleDeg)
     angle_log.steeringAngleDesiredDeg = angle_steers_des
-    return 0, float(angle_steers_des), angle_log
+    return 0, float(angle_steers_des), 0, 0, 0, 0, angle_log

--- a/selfdrive/controls/lib/latcontrol_curvature.py
+++ b/selfdrive/controls/lib/latcontrol_curvature.py
@@ -24,7 +24,7 @@ class LatControlCurvature(LatControl):
 
       # "road/lane curvature" is different from the immediate manoeuvre/path curvature
       # later curvature values are probably closer to this "road curvature" value
-      curvature = -curvatures[6]
+      curvature = -curvatures[16]
       path_deviation = -path_points[0] if len(path_points) > 0 else 0
 
       # calculate the angle of the path (t = approx 1s)

--- a/selfdrive/controls/lib/latcontrol_curvature.py
+++ b/selfdrive/controls/lib/latcontrol_curvature.py
@@ -5,7 +5,7 @@ from selfdrive.controls.lib.latcontrol import LatControl, MIN_STEER_SPEED
 
 
 class LatControlCurvature(LatControl):
-  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, model_v2, desired_curvature, desired_curvature_rate, llk):
     curvature_log = log.ControlsState.LateralCurvatureState.new_message()
 
     if CS.vEgo < MIN_STEER_SPEED or not active:

--- a/selfdrive/controls/lib/latcontrol_curvature.py
+++ b/selfdrive/controls/lib/latcontrol_curvature.py
@@ -1,0 +1,38 @@
+import math
+
+from cereal import log
+from selfdrive.controls.lib.latcontrol import LatControl, MIN_STEER_SPEED
+
+
+class LatControlCurvature(LatControl):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
+    curvature_log = log.ControlsState.LateralCurvatureState.new_message()
+
+    if CS.vEgo < MIN_STEER_SPEED or not active:
+      curvature_log.active = False
+      curvature = -VM.calc_curvature(math.radians(CS.steeringAngleDeg), CS.vEgo, params.roll)
+      curvature_rate = 0
+      path_angle = 0
+      path_deviation = 0
+    else:
+      curvature_log.active = True
+
+      curvatures = lat_plan.curvatures
+      path_points = lat_plan.dPathPoints
+
+      # "road/lane curvature" is different from the immediate manoeuvre/path curvature
+      # later curvature values are probably closer to this "road curvature" value
+      curvature = -curvatures[6]
+      path_deviation = -path_points[0] if len(path_points) > 0 else 0
+
+      # TODO
+      curvature_rate = 0
+      path_angle = 0
+
+    # TODO: calculate saturated, like latcontrol_angle
+    curvature_log.saturated = False
+    curvature_log.curvature = curvature
+    curvature_log.curvatureRate = curvature_rate
+    curvature_log.pathAngle = path_angle
+    curvature_log.pathDeviation = path_deviation
+    return 0, 0, curvature, curvature_rate, path_angle, path_deviation, curvature_log

--- a/selfdrive/controls/lib/latcontrol_curvature.py
+++ b/selfdrive/controls/lib/latcontrol_curvature.py
@@ -10,24 +10,28 @@ class LatControlCurvature(LatControl):
 
     if CS.vEgo < MIN_STEER_SPEED or not active:
       curvature_log.active = False
-      curvature = -VM.calc_curvature(math.radians(CS.steeringAngleDeg), CS.vEgo, params.roll)
-      curvature_rate = 0
-      path_angle = 0
-      path_deviation = 0
+      curvature = 0.0
+      curvature_rate = 0.0
+      path_angle = 0.0
+      path_deviation = 0.0
     else:
       curvature_log.active = True
 
       curvatures = lat_plan.curvatures
       path_points = lat_plan.dPathPoints
 
+      position = model_v2.position
+
       # "road/lane curvature" is different from the immediate manoeuvre/path curvature
       # later curvature values are probably closer to this "road curvature" value
       curvature = -curvatures[6]
       path_deviation = -path_points[0] if len(path_points) > 0 else 0
 
+      # calculate the angle of the path (t = approx 1s)
+      path_angle = math.atan(-position.y[10] / position.x[10])
+
       # TODO
       curvature_rate = 0
-      path_angle = 0
 
     # TODO: calculate saturated, like latcontrol_angle
     curvature_log.saturated = False

--- a/selfdrive/controls/lib/latcontrol_indi.py
+++ b/selfdrive/controls/lib/latcontrol_indi.py
@@ -63,7 +63,7 @@ class LatControlINDI(LatControl):
     self.steer_filter.x = 0.
     self.speed = 0.
 
-  def update(self, active, CS, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
     self.speed = CS.vEgo
     # Update Kalman filter
     y = np.array([[math.radians(CS.steeringAngleDeg)], [math.radians(CS.steeringRateDeg)]])
@@ -116,4 +116,4 @@ class LatControlINDI(LatControl):
       indi_log.output = float(output_steer)
       indi_log.saturated = self._check_saturation(self.steer_max - abs(output_steer) < 1e-3, CS)
 
-    return float(output_steer), float(steers_des), indi_log
+    return float(output_steer), float(steers_des), 0, 0, 0, 0, indi_log

--- a/selfdrive/controls/lib/latcontrol_indi.py
+++ b/selfdrive/controls/lib/latcontrol_indi.py
@@ -63,7 +63,7 @@ class LatControlINDI(LatControl):
     self.steer_filter.x = 0.
     self.speed = 0.
 
-  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, model_v2, desired_curvature, desired_curvature_rate, llk):
     self.speed = CS.vEgo
     # Update Kalman filter
     y = np.array([[math.radians(CS.steeringAngleDeg)], [math.radians(CS.steeringRateDeg)]])

--- a/selfdrive/controls/lib/latcontrol_lqr.py
+++ b/selfdrive/controls/lib/latcontrol_lqr.py
@@ -81,4 +81,4 @@ class LatControlLQR(LatControl):
     lqr_log.output = output_steer
     lqr_log.lqrOutput = lqr_output
     lqr_log.saturated = self._check_saturation(self.steer_max - abs(output_steer) < 1e-3, CS)
-    return output_steer, desired_angle, lqr_log
+    return output_steer, desired_angle, 0, 0, 0, 0, lqr_log

--- a/selfdrive/controls/lib/latcontrol_lqr.py
+++ b/selfdrive/controls/lib/latcontrol_lqr.py
@@ -30,7 +30,7 @@ class LatControlLQR(LatControl):
     super().reset()
     self.i_lqr = 0.0
 
-  def update(self, active, CS, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, model_v2, desired_curvature, desired_curvature_rate, llk):
     lqr_log = log.ControlsState.LateralLQRState.new_message()
 
     torque_scale = (0.45 + CS.vEgo / 60.0)**2  # Scale actuator model with speed

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -17,7 +17,7 @@ class LatControlPID(LatControl):
     super().reset()
     self.pid.reset()
 
-  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, model_v2, desired_curvature, desired_curvature_rate, llk):
     pid_log = log.ControlsState.LateralPIDState.new_message()
     pid_log.steeringAngleDeg = float(CS.steeringAngleDeg)
     pid_log.steeringRateDeg = float(CS.steeringRateDeg)

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -17,7 +17,7 @@ class LatControlPID(LatControl):
     super().reset()
     self.pid.reset()
 
-  def update(self, active, CS, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, desired_curvature, desired_curvature_rate, llk):
     pid_log = log.ControlsState.LateralPIDState.new_message()
     pid_log.steeringAngleDeg = float(CS.steeringAngleDeg)
     pid_log.steeringRateDeg = float(CS.steeringRateDeg)
@@ -45,4 +45,4 @@ class LatControlPID(LatControl):
       pid_log.output = output_steer
       pid_log.saturated = self._check_saturation(self.steer_max - abs(output_steer) < 1e-3, CS)
 
-    return output_steer, angle_steers_des, pid_log
+    return output_steer, angle_steers_des, 0, 0, 0, 0, pid_log

--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -36,7 +36,7 @@ class LatControlTorque(LatControl):
     super().reset()
     self.pid.reset()
 
-  def update(self, active, CS, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+  def update(self, active, CS, VM, params, last_actuators, lat_plan, model_v2, desired_curvature, desired_curvature_rate, llk):
     pid_log = log.ControlsState.LateralTorqueState.new_message()
 
     if CS.vEgo < MIN_STEER_SPEED or not active:


### PR DESCRIPTION
The Ford power steering control module (PSCM) has a unique controls method.

The CAN message sent from the LKAS camera that we use to actuate the steering, `LateralMotionControl`, has four important signals: curvature, curvature rate, path offset and path angle. The PSCM integrates this information about the path ahead (presumably along with other information about the vehicle such as speed and orientation) to determine the correct steering angle, and then moves towards it according to some parameters (ramp speed and precision, which are additional signals in the message).

![LateralMotionControl message](https://user-images.githubusercontent.com/4038174/163493632-a50c2ee5-3934-45ac-864c-dc5ebd8d69e3.png)

Sending only curvature and path offset, and zero values for curvature rate and path angle, is enough information to drive. The PSCM knows the curvature of the path and our current offset from it and is able to correct for it.

Ideally though we should be able to pull all four actuators from the model or the lateral plan. Path offset is easy to get from the plan in `dPathPoints`, and I visually verified that it resembled the stock system's values well enough using PlotJuggler (in the image below the sign is flipped).

![image](https://user-images.githubusercontent.com/4038174/163493961-64e48d34-aef9-45c2-8af6-b55381834241.png)

**Related PRs**
- https://github.com/commaai/cereal/pull/303