### PR TITLE
parmasd: update linear region

### DIFF
--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -85,9 +85,10 @@ class ParamsLearner:
 
     elif which == 'carState':
       self.steering_angle = msg.steeringAngleDeg
+      self.steering_pressed = msg.steeringPressed
       self.speed = msg.vEgo
 
-      in_linear_region = abs(self.steering_angle) < 3*self.steering_ratio
+      in_linear_region = abs(self.steering_angle) < 3*self.steering_ratio and not self.steering_pressed
       self.active = self.speed > 5 and in_linear_region
 
       if self.active:

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -29,7 +29,6 @@ class ParamsLearner:
     self.kf.filter.set_global("stiffness_rear", CP.tireStiffnessRear)
 
     self.active = False
-    self.lockout = True
 
     self.speed = 0.0
     self.roll = 0.0
@@ -89,9 +88,7 @@ class ParamsLearner:
       self.speed = msg.vEgo
 
       in_linear_region = abs(self.steering_angle) < 3*self.steering_ratio
-      self.active = self.speed > 5 and in_linear_region and not self.lockout
-      
-      self.lockout = not (self.active or abs(self.steering_angle) < 0.2*self.steering_ratio)
+      self.active = self.speed > 5 and in_linear_region
 
       if self.active:
         self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[math.radians(msg.steeringAngleDeg)]]))


### PR DESCRIPTION
noticed that the large changes to EKF states for params learner were occuring when releasing the wheel at large steering angles. 

I believe this is outside the "linear-region" so these are invalid readings causing issues with the learned values. 

I originally just changed the "if angle < 45deg ~~or not steerPressed~~*" to just check the angle and not enable at higher angles. 
however I still got large swings in values when the learner re-enabled returning to 3 or 4 deg. 

I added logic to lockout the learner until after the steering returns to center after being outside of the "linear region" 
I also updated it based on steering ratio (from car params) for the vehicle to be ~3deg of tire steering instead of 45deg of steering wheel. as that region differs based on vehicle. 

