### PR TITLE
Change camera readout to 25ms

### DIFF
--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -64,7 +64,7 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 1780; // with HDR, slowest ss, 40ms
+const int EXPOSURE_TIME_MAX = 2018; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -64,7 +64,7 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 1618; // with HDR, slowest ss, 40ms
+const int EXPOSURE_TIME_MAX = 1780; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {
@@ -746,6 +746,8 @@ void CameraState::camera_open() {
     csiphy_info->lane_cnt = 0x4;
     csiphy_info->secure_mode = 0x0;
     csiphy_info->settle_time = MIPI_SETTLE_CNT * 200000000ULL;
+
+    // TODO: This is wrong, but doesn't seem to matter
     csiphy_info->data_rate = 48000000;  // Calculated by camera_freqs.py
 
     int ret_ = device_config(csiphy_fd, session_handle, csiphy_dev_handle, cam_packet_handle);

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1051,8 +1051,8 @@ void CameraState::set_camera_exposure(float grey_frac) {
   // Processing a frame takes right about 50ms, so we need to wait a few ms
   // so we don't send i2c commands around the frame start.
   int ms = (nanos_since_boot() - buf.cur_frame_data.timestamp_sof) / 1000000;
-  if (ms < 60) {
-    util::sleep_for(60 - ms);
+  if (ms < 80) {
+    util::sleep_for(80 - ms);
   }
   // LOGE("ae - camera %d, cur_t %.5f, sof %.5f, dt %.5f", camera_num, 1e-9 * nanos_since_boot(), 1e-9 * buf.cur_frame_data.timestamp_sof, 1e-9 * (nanos_since_boot() - buf.cur_frame_data.timestamp_sof));
 

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -1051,8 +1051,8 @@ void CameraState::set_camera_exposure(float grey_frac) {
   // Processing a frame takes right about 50ms, so we need to wait a few ms
   // so we don't send i2c commands around the frame start.
   int ms = (nanos_since_boot() - buf.cur_frame_data.timestamp_sof) / 1000000;
-  if (ms < 80) {
-    util::sleep_for(80 - ms);
+  if (ms < 60) {
+    util::sleep_for(60 - ms);
   }
   // LOGE("ae - camera %d, cur_t %.5f, sof %.5f, dt %.5f", camera_num, 1e-9 * nanos_since_boot(), 1e-9 * buf.cur_frame_data.timestamp_sof, 1e-9 * (nanos_since_boot() - buf.cur_frame_data.timestamp_sof));
 

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -64,7 +64,11 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 2018; // with HDR, slowest ss, 40ms
+
+// In Trigger Shutter Sync mode the course integration time
+// must not be equal or greater than FRAME_LENGTH_LINES
+// In HDR mode, the sum of all exposure must be less than FRAME_LENGTH_LINES
+const int EXPOSURE_TIME_MAX = 1257; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -48,13 +48,16 @@ struct i2c_random_wr_payload init_array_imx390[] = {
 struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x301A, 0x0018}, // RESET_REGISTER
 
-  // CLOCK Settings
-  {0x302A, 0x0006}, // VT_PIX_CLK_DIV
-  {0x302C, 0x0001}, // VT_SYS_CLK_DIV
-  {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
-  {0x3030, 0x0032}, // PLL_MULTIPLIER
-  {0x3036, 0x000C}, // OP_WORD_CLK_DIV
-  {0x3038, 0x0001}, // OP_SYS_CLK_DIV
+  // CLOCK Settings 
+  // Target System Frequency: 88 MHz
+  // Input Clock Frequency: 19.200 MHz
+  // Output data rate (per lane): 58.667 MHz
+  {0x302A, 0x0008}, // VT_PIX_CLK_DIV = 8
+  {0x302C, 0x0001}, // VT_SYS_CLK_DIV = 1
+  {0x302E, 0x0003}, // PRE_PLL_CLK_DIV = 3
+  {0x3030, 0x006E}, // PLL_MULTIPLIER = 110
+  {0x3036, 0x000C}, // OP_PIX_CLK_DIV = 12
+  {0x3038, 0x0001}, // OP_SYS_CLK_DIV = 1
 
   // FORMAT
   {0x3040, 0xC000}, // READ_MODE
@@ -77,7 +80,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
 
   // Readout timing
   {0x300C, 0x07B9}, // LINE_LENGTH_PCK
-  {0x300A, 0x0652}, // FRAME_LENGTH_LINES
+  {0x300A, 0x05CB}, // FRAME_LENGTH_LINES
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -79,8 +79,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x340C, 0x802},  // GPIO_HIDRV_EN | GPIO0_ISEL=2
 
   // Readout timing
-  {0x300C, 0x07B9}, // LINE_LENGTH_PCK
-  {0x300A, 0x05CB}, // FRAME_LENGTH_LINES
+  {0x300A, 0x04E9}, // FRAME_LENGTH_LINES = 1257
+  {0x300C, 0x06D0}, // LINE_LENGTH_PCK = 1744
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings
@@ -94,8 +94,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x3348, 0x0111}, // MIPI_F2_VDT_VC
   {0x334C, 0x0211}, // MIPI_F3_VDT_VC
   {0x3350, 0x0311}, // MIPI_F4_VDT_VC
-  {0x31B0, 0x0053}, // FRAME_PREAMBLE
-  {0x31B2, 0x003B}, // LINE_PREAMBLE
+  {0x31B0, 0x0052}, // FRAME_PREAMBLE
+  {0x31B2, 0x0039}, // LINE_PREAMBLE
   {0x301A, 0x001C}, // RESET_REGISTER
 
   // Noise Corrections
@@ -112,14 +112,20 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x3082, 0x0004}, // OPERATION_MODE_CTRL
   {0x3238, 0x0444}, // EXPOSURE_RATIO
 
-  {0x1008, 0x0361}, // FINE_INTEGRATION_TIME_MIN
-  {0x100C, 0x0589}, // FINE_INTEGRATION_TIME2_MIN
-  {0x100E, 0x07B1}, // FINE_INTEGRATION_TIME3_MIN
-  {0x1010, 0x0139}, // FINE_INTEGRATION_TIME4_MIN
-  {0x3014, 0x08CB}, // FINE_INTEGRATION_TIME_
-  {0x321E, 0x08CB}, // FINE_INTEGRATION_TIME2
-  {0x321E, 0x08CB}, // FINE_INTEGRATION_TIME3
-  {0x321E, 0x0894}, // FINE_INTEGRATION_TIME4
+  {0x1008, 0x0361}, // FINE_INTEGRATION_TIME_MIN = 865
+  {0x100C, 0x0589}, // FINE_INTEGRATION_TIME2_MIN = 1417
+  {0x100E, 0x07B1}, // FINE_INTEGRATION_TIME3_MIN = 1969
+  {0x1010, 0x0139}, // FINE_INTEGRATION_TIME4_MIN = 313
+  {0x3012, 0x07E2}, // COARSE_INTEGRATION_TIME = 2018
+  {0x3014, 0x07E2}, // FINE_INTEGRATION_TIME = 2018
+  // {0x321E, 0x07E2}, // FINE_INTEGRATION_TIME2 = 2018
+  // {0x3222, 0x07E2}, // FINE_INTEGRATION_TIME3 = 2018
+  // {0x3226, 0x07AB}, // FINE_INTEGRATION_TIME4 = 1963
+
+  // Looks like the last fine integration time 
+  // that's actually used needs to be FINE_INTEGRATION_TIME4
+  // Bug in register wizard in case you don't use 4 exposures?
+  {0x321E, 0x07AB}, // FINE_INTEGRATION_TIME2 = 1963
 
   {0x31D0, 0x0000}, // COMPANDING, no good in 10 bit?
   {0x33DA, 0x0000}, // COMPANDING


### PR DESCRIPTION
This PR is on hold until we are ready to merge full HDR support. 

The current trigger mode limits the integration time to `FRAME_LENGTH_LINES`. To to increase the roll speed we are forced to lower max exposure time. This can be fixed by changing to a different trigger mode, but that will cause `timestamp_sof` to go out of sync between cameras. Once we have full HDR and can use the same exposure on all cameras so this is not an issue anymore.

Changes clock from 80Mhz to 88Mhz. Need to check effect on GPS.