### PR TITLE
Subaru: add missing Impreza fw versions

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -114,12 +114,11 @@ FW_VERSIONS = {
     ],
     (Ecu.eps, 0x746, None): [
       b'\x7a\xc0\x0c\x00',
-      b'z\xc0\b\x00',
+      b'z\xc0\x08\x00',
       b'\x8a\xc0\x00\x00',
       b'z\xc0\x04\x00',
       b'z\xc0\x00\x00',
       b'\x8a\xc0\x10\x00',
-      b'z\xc0\x08\x00',
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00\x64\xb5\x1f\x40\x20\x0e',

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -119,6 +119,7 @@ FW_VERSIONS = {
       b'z\xc0\x04\x00',
       b'z\xc0\x00\x00',
       b'\x8a\xc0\x10\x00',
+      b'z\xc0\x08\x00',
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00\x64\xb5\x1f\x40\x20\x0e',
@@ -131,6 +132,10 @@ FW_VERSIONS = {
       b'\000\000e\002\037@ \024',
       b'\x00\x00d)\x00\x00\x00\x00',
       b'\x00\x00c\xf4\x00\x00\x00\x00',
+      b'\x00\x00d\xdc\x00\x00\x00\x00',
+    ],
+    (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00\xac\x02\x00',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xaa\x61\x66\x73\x07',

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -111,6 +111,7 @@ FW_VERSIONS = {
       b'z\x9c\x19\x80\x01',
       b'z\x94\x08\x90\x00',
       b'z\x84\x19\x90\x00',
+      b'\xf1\x00\xb2\x06\x04',
     ],
     (Ecu.eps, 0x746, None): [
       b'\x7a\xc0\x0c\x00',


### PR DESCRIPTION
In this route: `dc30ef2ad294a732|2022-04-04--16-29-51` @michaelhonan's esp fw version flipped from `b'\xa2 \x185\x00'` to `b'\xf1\x00\xb2\x06\x04'` and hasn't changed back since (checked every few routes up to current).