### PR TITLE
fix regen: specify frame timestamps for modeld

### DIFF
--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -80,9 +80,10 @@ void run_model(ModelState &model, VisionIpcClient &vipc_client_main, VisionIpcCl
 
   while (!do_exit) {
     // Keep receiving frames until we are at least 1 frame ahead of previous extra frame
-    while (get_ts(meta_main) < get_ts(meta_extra) + 25000000ULL) {
+    bool behind_extra = get_ts(meta_main) < (get_ts(meta_extra) + 25000000ULL);
+    while (behind_extra || !use_extra_client) {
       buf_main = vipc_client_main.recv(&meta_main);
-      if (buf_main == nullptr)  break;
+      if (buf_main == nullptr || !use_extra_client) break;
     }
 
     if (buf_main == nullptr) {

--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -80,10 +80,9 @@ void run_model(ModelState &model, VisionIpcClient &vipc_client_main, VisionIpcCl
 
   while (!do_exit) {
     // Keep receiving frames until we are at least 1 frame ahead of previous extra frame
-    bool behind_extra = get_ts(meta_main) < (get_ts(meta_extra) + 25000000ULL);
-    while (behind_extra || !use_extra_client) {
+    while (get_ts(meta_main) < get_ts(meta_extra) + 25000000ULL) {
       buf_main = vipc_client_main.recv(&meta_main);
-      if (buf_main == nullptr || !use_extra_client) break;
+      if (buf_main == nullptr)  break;
     }
 
     if (buf_main == nullptr) {

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -134,6 +134,8 @@ def replay_cameras(lr, frs):
       m = messaging.new_message(s)
       msg = getattr(m, s)
       msg.frameId = rk.frame
+      msg.timestampSof = m.logMonoTime
+      msg.timestampEof = m.logMonoTime
       pm.send(s, m)
 
       vipc_server.send(stream, img, msg.frameId, msg.timestampSof, msg.timestampEof)


### PR DESCRIPTION
With the change from PR https://github.com/commaai/openpilot/pull/23901, modeld looks at the frame timestamps instead of frame ids, but regen wasn't migrated along with that, so modeld was just seeing zeros and skipping all frames. Now we just set them to the current `logMonoTime`