### PR TITLE
Lateral Planner: Set a minimum heading cost for lateral planner

### DIFF
--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -34,6 +34,7 @@ class MPC_COST_LAT:
   PATH = 1.0
   HEADING = 1.0
   STEER_RATE = 1.0
+  LANELESS_HEADING_MIN = 0.15
 
 
 def rate_limit(new_value, last_value, dw_step, up_step):

--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -64,7 +64,7 @@ class LateralPlanner:
       d_path_xyz = self.path_xyz
       path_cost = np.clip(abs(self.path_xyz[0, 1] / self.path_xyz_stds[0, 1]), 0.5, 1.5) * MPC_COST_LAT.PATH
       # Heading cost is useful at low speed, otherwise end of plan can be off-heading
-      heading_cost = interp(v_ego, [5.0, 10.0], [MPC_COST_LAT.HEADING, 0.0])
+      heading_cost = interp(v_ego, [5.0, 10.0], [MPC_COST_LAT.HEADING, MPC_COST_LAT.LANELESS_HEADING_MIN])
       self.lat_mpc.set_weights(path_cost, heading_cost, self.steer_rate_cost)
 
     y_pts = np.interp(v_ego * self.t_idxs[:LAT_MPC_N + 1], np.linalg.norm(d_path_xyz, axis=1), d_path_xyz[:, 1])


### PR DESCRIPTION
Set a minimum `heading_cost` in the lateral planner where `use_lanelines == False`. This should help reduce pingpoing significantly without harming performance.

![image](https://user-images.githubusercontent.com/1649262/163096289-1474ab74-5e62-45c6-89ab-171beaea53b6.png)

*ToDo*
- Run lateral report and compare. 