### PR TITLE
Fix camera error description

### DIFF
--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -732,13 +732,13 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
                                        creation_delay=30.),
   },
 
-  EventName.driverCameraError: {
-    ET.PERMANENT: NormalPermanentAlert("Camera CRC Error - Road Fisheye",
+  EventName.wideRoadCameraError: {
+    ET.PERMANENT: NormalPermanentAlert("Camera CRC Error - WideRoad (Fisheye)",
                                        duration=1.,
                                        creation_delay=30.),
   },
 
-  EventName.wideRoadCameraError: {
+  EventName.driverCameraError: {
     ET.PERMANENT: NormalPermanentAlert("Camera CRC Error - Driver",
                                        duration=1.,
                                        creation_delay=30.),

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -733,7 +733,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
   },
 
   EventName.wideRoadCameraError: {
-    ET.PERMANENT: NormalPermanentAlert("Camera CRC Error - WideRoad (Fisheye)",
+    ET.PERMANENT: NormalPermanentAlert("Camera CRC Error - Road Fisheye",
                                        duration=1.,
                                        creation_delay=30.),
   },


### PR DESCRIPTION
Camera error description was changed incorrectly in #24156 possibly due to the order of road, driver, wideroad.
*At least the eventname doesn't match the error description in the code. I haven't verified it in any way yet.

Changed the order to road, wideroad, driver and so fixed the description.

Should the messages have the detailed description of which camera it is? Since this was removed in https://github.com/commaai/openpilot/pull/22943 and then added back in #24156 
