### PR TITLE
reduce updated data usage

### DIFF
--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -163,9 +163,13 @@ def setup_git_options(cwd: str) -> None:
 
   # We are using copytree to copy the directory, which also changes
   # inode numbers. Ignore those changes too.
+
+  # Set protocol to the new version (default after git 2.26) to reduce data
+  # usage on git fetch --dry-run from about 400KB to 18KB.
   git_cfg = [
     ("core.trustctime", "false"),
     ("core.checkStat", "minimal"),
+    ("protocol.version", "2"),
   ]
   for option, value in git_cfg:
     run(["git", "config", option, value], cwd)
@@ -411,7 +415,7 @@ def main() -> None:
   wait_helper.sleep(30)
 
   # Run the update loop
-  #  * every 1m, do a lightweight internet/update check
+  #  * every 5m, do a lightweight internet/update check
   #  * every 10m, do a full git fetch
   while not wait_helper.shutdown:
     update_now = wait_helper.ready_event.is_set()
@@ -464,7 +468,7 @@ def main() -> None:
     except Exception:
       cloudlog.exception("uncaught updated exception while setting params, shouldn't happen")
 
-    wait_helper.sleep(60)
+    wait_helper.sleep(300)
 
   dismount_overlay()
 

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -468,6 +468,7 @@ def main() -> None:
     except Exception:
       cloudlog.exception("uncaught updated exception while setting params, shouldn't happen")
 
+    # TODO: replace this with a good backoff
     wait_helper.sleep(300)
 
   dismount_overlay()


### PR DESCRIPTION
 - Set protocol version 2, this changes the `git fetch --dry-run` from 400KB to 18KB. See https://github.blog/2020-03-22-highlights-from-git-2-26/ for some more information
 - Reduce check frequency from once every 1 minute to once every 5 minutes

These two changes combined should reduce the theoretical data usage from 17GB to just 156MB per month for a device with 24/7 uptime.

TODO:
- [x]  Test on C2