### PR TITLE
Trying to fix visiontest

### DIFF
--- a/selfdrive/modeld/visiontest.mk
+++ b/selfdrive/modeld/visiontest.mk
@@ -51,7 +51,7 @@ libvisiontest_inputs := visiontest.c \
                         transforms/transform.cc \
                         transforms/loadyuv.cc \
                         ../common/clutil.cc \
-                        $(BASEDIR)/selfdrive/common/util.c \
+                        $(BASEDIR)/selfdrive/common/util.cc \
                         $(CEREAL_OBJS)
 
 visiontest: libvisiontest.so

--- a/selfdrive/modeld/visiontest.py
+++ b/selfdrive/modeld/visiontest.py
@@ -6,13 +6,9 @@ from common.basedir import BASEDIR
 # Initialize visiontest. Ignore output.
 _visiond_dir = os.path.dirname(os.path.abspath(__file__))
 _libvisiontest = "libvisiontest.so"
-try:  # because this crashes sometimes when running pipeline
-  subprocess.check_output(["make", "-C", _visiond_dir, "-f",
-                           os.path.join(_visiond_dir, "visiontest.mk"),
-                           _libvisiontest])
-except Exception:
-  pass
-
+subprocess.check_output(["make", "-C", _visiond_dir, "-f",
+                         os.path.join(_visiond_dir, "visiontest.mk"),
+                         _libvisiontest])
 
 class VisionTest():
   """A version of the vision model that can be run on a desktop.


### PR DESCRIPTION
Wanted to use the visiontest to see if I can run the models locally. However couldn't get it working.

Did notice that visiontest.mk seems incorrect since util.c doesn't exist. There was a name change from util.c to util.cc a year ago https://github.com/commaai/openpilot/pull/19710 and this file could have been forgotten.

This change doesn't fix it for me yet. I currently get: `error: invalid argument '-std=gnu11' not allowed with 'C++'` Any tips are welcome.