### PR TITLE
Subaru: remove A/C fw version

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -122,9 +122,6 @@ FW_VERSIONS = {
       b'\x00\x00c\xf4\x00\x00\x00\x00',
       b'\x00\x00d\xdc\x00\x00\x00\x00',
     ],
-    (Ecu.fwdCamera, 0x7c4, None): [
-      b'\xf1\x00\xac\x02\x00',
-    ],
     (Ecu.engine, 0x7e0, None): [
       b'\xaa\x61\x66\x73\x07',
       b'\xbeacr\a',

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -12,6 +12,7 @@ Ecu = car.CarParams.Ecu
 
 ECU_NAME = {v: k for k, v in Ecu.schema.enumerants.items()}
 
+
 class TestFwFingerprint(unittest.TestCase):
   def assertFingerprints(self, candidates, expected):
     candidates = list(candidates)
@@ -41,6 +42,19 @@ class TestFwFingerprint(unittest.TestCase):
           passed = False
 
     self.assertTrue(passed, "Duplicate FW versions found")
+
+  def test_blacklisted_ecus(self):
+    passed = True
+    blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
+    for car_model, ecus in FW_VERSIONS.items():
+      if car_model.startswith("SUBARU"):
+        for ecu in ecus.keys():
+          if ecu[1] in blacklisted_addrs:
+            print(f'{car_model}: Blacklisted ecu: ({ECU_NAME[ecu[0]]}, {hex(ecu[1])})')
+            passed = False
+
+    self.assertTrue(passed, "Blacklisted FW versions found ")
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -4,6 +4,7 @@ import unittest
 from parameterized import parameterized
 
 from cereal import car
+from selfdrive.car.car_helpers import interfaces
 from selfdrive.car.fingerprints import FW_VERSIONS
 from selfdrive.car.fw_versions import match_fw_to_car
 
@@ -47,7 +48,9 @@ class TestFwFingerprint(unittest.TestCase):
     passed = True
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
     for car_model, ecus in FW_VERSIONS.items():
-      if car_model.startswith("SUBARU"):
+      CarInterface, _, _ = interfaces[car_model]
+      CP = CarInterface.get_params(car_model)
+      if CP.carName == 'subaru':
         for ecu in ecus.keys():
           if ecu[1] in blacklisted_addrs:
             print(f'{car_model}: Blacklisted ecu: ({ECU_NAME[ecu[0]]}, {hex(ecu[1])})')

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -48,15 +48,14 @@ class TestFwFingerprint(unittest.TestCase):
     passed = True
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
     for car_model, ecus in FW_VERSIONS.items():
-      CarInterface, _, _ = interfaces[car_model]
-      CP = CarInterface.get_params(car_model)
+      CP = interfaces[car_model][0].get_params(car_model)
       if CP.carName == 'subaru':
         for ecu in ecus.keys():
           if ecu[1] in blacklisted_addrs:
-            print(f'{car_model}: Blacklisted ecu: ({ECU_NAME[ecu[0]]}, {hex(ecu[1])})')
+            print(f'{car_model}: Blacklisted ecu: (Ecu.{ECU_NAME[ecu[0]]}, {hex(ecu[1])})')
             passed = False
 
-    self.assertTrue(passed, "Blacklisted FW versions found ")
+    self.assertTrue(passed, "Blacklisted FW versions found")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR removes Subaru A/C ECU (0x7c4) fw version added with 3ff14adbd67cb003506e735a1608e44b5f6b275d

0x7c4 is Hyundai fwdCamera ECU address (https://github.com/commaai/openpilot/blob/master/selfdrive/car/hyundai/values.py#L235) which is why it also shows up in subaru carFw as second fwdCamera entry. There similar case with fwdRadar entry (0x7d0). Both entries should be ignored when adding Subaru FW values.

Here is a modified fw_versions.py scan (0xf197) which shows ecu descriptions for 2018 Crosstrek

```
Found ECU descriptions
{
  (Ecu.unknown, 0x7d0, None): [b'\xf1\x00\x00\x00\x02']
  (Ecu.unknown, 0x7e0, None): [b'2.0 DOHC                        ']
  (Ecu.unknown, 0x7c4, None): [b'Air Condition System            ']
  (Ecu.unknown, 0x7e1, None): [b'CVT                             ']
  (Ecu.unknown, 0x746, None): [b'Power Steering System           ']
  (Ecu.unknown, 0x787, None): [b'EyeSight System                 ']
  (Ecu.unknown, 0x7b0, None): [b'VDC/Parking Brake System        ']
  (Ecu.unknown, 0x780, None): [b'Airbag System\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f']
  (Ecu.unknown, 0x735, None): [b'Keyless Entry System            ']
  (Ecu.unknown, 0x747, None): [b'Automatic Headlight Leveling    ']
  (Ecu.unknown, 0x753, None): [b'Tire pressure monitor           ']
  (Ecu.unknown, 0x752, None): [b'\xf1\x00 \x80\x86']
  (Ecu.unknown, 0x783, None): [b'METER                           ']
  (Ecu.unknown, 0x7d5, None): [b'\xf1\x000\x00\x00']
  (Ecu.unknown, 0x7f1, None): [b'Airbag System\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f']
  (Ecu.unknown, 0x750, 0xec): [b'\xf1\x00\x00\x00\x00']
}
```
https://github.com/martinl/openpilot/wiki/Subaru-Fingerprinting-v2
