### PR TITLE
Ford: detect reverse gear for manual transmissions

### DIFF
--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -55,8 +55,10 @@ class CarState(CarStateBase):
       ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(gear, None))
     elif self.CP.transmissionType == TransmissionType.manual:
       ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
-      # TODO: find reverse light signal
-      ret.gearShifter = GearShifter.drive
+      if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
+        ret.gearShifter = GearShifter.reverse
+      else:
+        ret.gearShifter = GearShifter.drive
 
     # safety
     ret.stockFcw = bool(cp_cam.vl["ACCDATA_3"]["FcwVisblWarn_B_Rq"])
@@ -148,9 +150,11 @@ class CarState(CarStateBase):
     elif CP.transmissionType == TransmissionType.manual:
       signals += [
         ("CluPdlPos_Pc_Meas", "Engine_Clutch_Data"),         # PCM clutch (pct)
+        ("RvrseLghtOn_B_Stat", "BCM_Lamp_Stat_FD1"),         # BCM reverse light
       ]
       checks += [
         ("Engine_Clutch_Data", 33),
+        ("BCM_Lamp_Stat_FD1", 1),
       ]
 
     if CP.enableBsm:


### PR DESCRIPTION
Inspired by @jyoung8607 (see [VW PR comments](https://github.com/commaai/openpilot/pull/20253/files#diff-764ad21a0896c363e716542267de410369ae44231abb4dbc8e1dddd81009074cR54) and further discussion on [clutch pressed events](https://github.com/commaai/openpilot/pull/24024#issuecomment-1078629374)) I found the reverse light signal from the BCM for detecting "reverse gear" in manual transmissions