### PR TITLE
Add missing FW, 2021 Honda Passport Elite

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -1118,12 +1118,14 @@ FW_VERSIONS = {
   CAR.PASSPORT: {
     (Ecu.programmedFuelInjection, 0x18da10f1, None): [
       b'37805-RLV-B220\x00\x00',
+      b'37805-RLV-B210\x00\x00',
     ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-TGS-A230\x00\x00',
     ],
     (Ecu.fwdRadar, 0x18dab0f1, None): [
       b'36161-TGS-A030\x00\x00',
+      b'36161-TGS-A130\x00\x00',
     ],
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-TG7-A040\x00\x00',
@@ -1139,6 +1141,7 @@ FW_VERSIONS = {
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TGS-AT20\x00\x00',
+      b'78109-TGS-AX20\x00\x00',
     ],
     (Ecu.vsa, 0x18da28f1, None): [
       b'57114-TGS-A530\x00\x00',


### PR DESCRIPTION
Values from route: e600788942a02f83|2022-04-18--20-41-48