### PR TITLE
updated: only run offroad & disable automatic git garbage collection

### DIFF
--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -134,7 +134,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"LastPeripheralPandaType", PERSISTENT},
     {"LastPowerDropDetected", CLEAR_ON_MANAGER_START},
     {"LastSystemShutdown", CLEAR_ON_MANAGER_START},
-    {"LastUpdateException", PERSISTENT},
+    {"LastUpdateException", CLEAR_ON_MANAGER_START},
     {"LastUpdateTime", PERSISTENT},
     {"LiveParameters", PERSISTENT},
     {"NavDestination", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -130,7 +130,6 @@ def manager_thread() -> None:
 
   ensure_running(managed_processes.values(), started=False, not_run=ignore)
 
-  started_prev = False
   sm = messaging.SubMaster(['deviceState', 'carParams'], poll=['deviceState'])
   pm = messaging.PubMaster(['managerState'])
 
@@ -140,13 +139,6 @@ def manager_thread() -> None:
     started = sm['deviceState'].started
     driverview = params.get_bool("IsDriverViewEnabled")
     ensure_running(managed_processes.values(), started=started, driverview=driverview, notcar=sm['carParams'].notCar, not_run=ignore)
-
-    # trigger an update after going offroad
-    if started_prev and not started and 'updated' in managed_processes:
-      os.sync()
-      managed_processes['updated'].signal(signal.SIGHUP)
-
-    started_prev = started
 
     running = ' '.join("%s%s\u001b[0m" % ("\u001b[32m" if p.proc.is_alive() else "\u001b[31m", p.name)
                        for p in managed_processes.values() if p.proc)

--- a/selfdrive/manager/process_config.py
+++ b/selfdrive/manager/process_config.py
@@ -34,7 +34,7 @@ procs = [
   PythonProcess("thermald", "selfdrive.thermald.thermald", offroad=True),
   PythonProcess("timezoned", "selfdrive.timezoned", enabled=TICI, offroad=True),
   PythonProcess("tombstoned", "selfdrive.tombstoned", enabled=not PC, offroad=True),
-  PythonProcess("updated", "selfdrive.updated", enabled=not PC, offroad=True),
+  PythonProcess("updated", "selfdrive.updated", enabled=not PC, onroad=False, offroad=True),
   PythonProcess("uploader", "selfdrive.loggerd.uploader", offroad=True),
   PythonProcess("statsd", "selfdrive.statsd", offroad=True),
 

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -171,6 +171,7 @@ def setup_git_options(cwd: str) -> None:
     ("core.checkStat", "minimal"),
     ("protocol.version", "2"),
     ("gc.auto", "0"),
+    ("gc.autoDetach", "false"),
   ]
   for option, value in git_cfg:
     run(["git", "config", option, value], cwd)

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -383,6 +383,7 @@ def main() -> None:
   update_failed_count = 0
 
   # Set initial params for offroad alerts
+  # TODO: set once on startup from manager?
   set_params(False, 0, None)
 
   # Wait for IsOffroad to be set before our first update attempt
@@ -438,10 +439,11 @@ def main() -> None:
       exception = str(e)
       overlay_init.unlink(missing_ok=True)
 
-    try:
-      set_params(new_version, update_failed_count, exception)
-    except Exception:
-      cloudlog.exception("uncaught updated exception while setting params, shouldn't happen")
+    if not wait_helper.shutdown:
+      try:
+        set_params(new_version, update_failed_count, exception)
+      except Exception:
+        cloudlog.exception("uncaught updated exception while setting params, shouldn't happen")
 
     # TODO: replace this with a good backoff
     wait_helper.sleep(300)

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -380,11 +380,7 @@ def main() -> None:
 
   first_run = True
   last_fetch_time = 0.0
-  update_failed_count = 0
-
-  # Set initial params for offroad alerts
-  # TODO: set once on startup from manager?
-  set_params(False, 0, None)
+  update_failed_count = 0  # TODO: Load from param?
 
   # Wait for IsOffroad to be set before our first update attempt
   wait_helper = WaitTimeHelper(proc)

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -393,14 +393,6 @@ def main() -> None:
     update_now = wait_helper.ready_event.is_set()
     wait_helper.ready_event.clear()
 
-    # Don't run updater while onroad or if the time's wrong
-    time_wrong = datetime.datetime.utcnow().year < 2019
-    is_onroad = not params.get_bool("IsOffroad")
-    if is_onroad or time_wrong:
-      wait_helper.sleep(30)
-      cloudlog.info("not running updater, not offroad")
-      continue
-
     # Attempt an update
     exception = None
     new_version = False

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -257,7 +257,12 @@ def finalize_update() -> None:
 
   run(["git", "reset", "--hard"], FINALIZED)
   run(["git", "submodule", "foreach", "--recursive", "git", "reset"], FINALIZED)
+
+  cloudlog.info("Starting git gc")
+  t = time.monotonic()
   run(["git", "gc"], FINALIZED)
+  gc_dt = time.monotonic() - t
+  cloudlog.info(f"Done git gc, took {gc_dt:.3f} s")
 
   set_consistent_flag(True)
   cloudlog.info("done finalizing overlay")

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -170,6 +170,7 @@ def setup_git_options(cwd: str) -> None:
     ("core.trustctime", "false"),
     ("core.checkStat", "minimal"),
     ("protocol.version", "2"),
+    ("gc.auto", "0"),
   ]
   for option, value in git_cfg:
     run(["git", "config", option, value], cwd)
@@ -255,6 +256,7 @@ def finalize_update() -> None:
 
   run(["git", "reset", "--hard"], FINALIZED)
   run(["git", "submodule", "foreach", "--recursive", "git", "reset"], FINALIZED)
+  run(["git", "gc"], FINALIZED)
 
   set_consistent_flag(True)
   cloudlog.info("done finalizing overlay")

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -260,9 +260,11 @@ def finalize_update() -> None:
 
   cloudlog.info("Starting git gc")
   t = time.monotonic()
-  run(["git", "gc"], FINALIZED)
-  gc_dt = time.monotonic() - t
-  cloudlog.info(f"Done git gc, took {gc_dt:.3f} s")
+  try:
+    run(["git", "gc"], FINALIZED)
+    cloudlog.info(f"Done git gc, took {time.monotonic() - t:.3f} s")
+  except subprocess.CalledProcessError:
+    cloudlog.exception(f"Failed git gc, took {time.monotonic() - t:.3f} s")
 
   set_consistent_flag(True)
   cloudlog.info("done finalizing overlay")

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -262,7 +262,7 @@ def finalize_update(wait_helper: WaitTimeHelper) -> None:
   t = time.monotonic()
   try:
     run(["git", "gc"], FINALIZED)
-    cloudlog.info(f"Done git gc, took {time.monotonic() - t:.3f} s")
+    cloudlog.event("Done git gc", duration=time.monotonic() - t)
   except subprocess.CalledProcessError:
     cloudlog.exception(f"Failed git gc, took {time.monotonic() - t:.3f} s")
 

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -242,7 +242,7 @@ def init_overlay() -> None:
   cloudlog.info(f"git diff output:\n{git_diff}")
 
 
-def finalize_update() -> None:
+def finalize_update(wait_helper: WaitTimeHelper) -> None:
   """Take the current OverlayFS merged view and finalize a copy outside of
   OverlayFS, ready to be swapped-in at BASEDIR. Copy using shutil.copytree"""
 
@@ -266,8 +266,11 @@ def finalize_update() -> None:
   except subprocess.CalledProcessError:
     cloudlog.exception(f"Failed git gc, took {time.monotonic() - t:.3f} s")
 
-  set_consistent_flag(True)
-  cloudlog.info("done finalizing overlay")
+  if wait_helper.shutdown:
+    cloudlog.info("got interrupted finalizing overlay")
+  else:
+    set_consistent_flag(True)
+    cloudlog.info("done finalizing overlay")
 
 
 def handle_agnos_update(wait_helper: WaitTimeHelper) -> None:
@@ -338,7 +341,7 @@ def fetch_update(wait_helper: WaitTimeHelper) -> bool:
         handle_agnos_update(wait_helper)
 
     # Create the finalized, ready-to-swap update
-    finalize_update()
+    finalize_update(wait_helper)
     cloudlog.info("openpilot update successful!")
   else:
     cloudlog.info("nothing new from git at this time")


### PR DESCRIPTION
@adeebshihadeh any thoughts? If we combine this with killing updated when going onroad it should fix https://github.com/commaai/openpilot/issues/23879. We can also run an aggressive `gc`, but not sure if we want to change that behavior.

(disabled jenkins for now to not change the config permanently on those devices in case we don't merge it)