### PR TITLE
Ford: use CADS radar interface

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -499,6 +499,7 @@ opendbc/gm_global_a_powertrain_generated.dbc
 opendbc/gm_global_a_object.dbc
 opendbc/gm_global_a_chassis.dbc
 
+opendbc/FORD_CADS.dbc
 opendbc/ford_lincoln_base_pt.dbc
 
 opendbc/honda_accord_2018_can_generated.dbc

--- a/release/files_common
+++ b/release/files_common
@@ -500,6 +500,7 @@ opendbc/gm_global_a_object.dbc
 opendbc/gm_global_a_chassis.dbc
 
 opendbc/FORD_CADS.dbc
+opendbc/ford_fusion_2018_adas.dbc
 opendbc/ford_lincoln_base_pt.dbc
 
 opendbc/honda_accord_2018_can_generated.dbc

--- a/selfdrive/car/ford/radar_interface.py
+++ b/selfdrive/car/ford/radar_interface.py
@@ -5,30 +5,39 @@ from opendbc.can.parser import CANParser
 from selfdrive.car.ford.values import CANBUS, DBC
 from selfdrive.car.interfaces import RadarInterfaceBase
 
-RADAR_MSGS = list(range(0x120, 0x12F))
+RADAR_MSGS = list(range(0x120, 0x15F + 1))  # 64 points
+LAST_MSG = max(RADAR_MSGS)
+NUM_MSGS = len(RADAR_MSGS)
 
 
-def _create_radar_can_parser(car_fingerprint):
-  if DBC[car_fingerprint]['radar'] is None:
+def _create_radar_can_parser(CP):
+  if DBC[CP.carFingerprint]['radar'] is None:
     return None
 
-  msg_n = len(RADAR_MSGS)
-  signals = list(zip(['CAN_DET_RANGE'] * msg_n + ['CAN_DET_AZIMUTH'] * msg_n + ['CAN_DET_RANGE_RATE'] * msg_n + ['CAN_DET_VALID_LEVEL'] * msg_n,
-                     RADAR_MSGS * 4,
-                     [0] * msg_n + [0] * msg_n + [0] * msg_n + [0] * msg_n))
-  checks = list(zip(RADAR_MSGS, [20]*msg_n))
+  signals = []
+  checks = []
 
-  return CANParser(DBC[car_fingerprint]['radar'], signals, checks, CANBUS.radar)
+  for ii in range(1, NUM_MSGS + 1):
+    msg = f"MRR_Detection_{ii:03d}"
+    signals += [
+      (f"CAN_DET_VALID_LEVEL_{ii:02d}", msg),
+      (f"CAN_DET_RANGE_{ii:02d}", msg),
+      (f"CAN_DET_AZIMUTH_{ii:02d}", msg),
+      (f"CAN_DET_RANGE_RATE_{ii:02d}", msg),
+      (f"CAN_DET_AMPLITUDE_{ii:02d}", msg),
+    ]
+    checks += [(msg, 20)]
+
+  return CANParser(DBC[CP.carFingerprint]['radar'], signals, checks, CANBUS.radar)
 
 class RadarInterface(RadarInterfaceBase):
   def __init__(self, CP):
     super().__init__(CP)
-    self.validCnt = {key: 0 for key in RADAR_MSGS}
+    self.updated_messages = set()
+    self.trigger_msg = LAST_MSG
     self.track_id = 0
 
-    self.rcp = _create_radar_can_parser(CP.carFingerprint)
-    self.trigger_msg = 0x12E
-    self.updated_messages = set()
+    self.rcp = _create_radar_can_parser(CP)
 
   def update(self, can_strings):
     if self.rcp is None:
@@ -40,32 +49,48 @@ class RadarInterface(RadarInterfaceBase):
     if self.trigger_msg not in self.updated_messages:
       return None
 
+    rr = self._update(self.updated_messages)
+    self.updated_messages.clear()
+
+    return rr
+
+  def _update(self, updated_messages):
     ret = car.RadarData.new_message()
+    if self.rcp is None:
+      return ret
+
     errors = []
+
     if not self.rcp.can_valid:
-      errors.append('canError')
+      errors.append("canError")
     ret.errors = errors
 
-    for ii in sorted(self.updated_messages):
-      cpt = self.rcp.vl[ii]
+    for ii in range(1, NUM_MSGS + 1):
+      msg = self.rcp.vl[f"MRR_Detection_{ii:03d}"]
+
+      if ii not in self.pts:
+        self.pts[ii] = car.RadarData.RadarPoint.new_message()
+        self.pts[ii].trackId = self.track_id
+        self.track_id += 1
 
       # radar point only valid if valid signal asserted
-      if cpt['CAN_DET_VALID_LEVEL'] > 0:
-        if ii not in self.pts:
-          self.pts[ii] = car.RadarData.RadarPoint.new_message()
-          self.pts[ii].trackId = self.track_id
-          self.track_id += 1
-        self.pts[ii].dRel = cpt['CAN_DET_RANGE']  # from front of car
-        # self.pts[ii].yRel = cpt['CAN_DET_RANGE'] * -cpt['CAN_DET_AZIMUTH']   # in car frame's y axis, left is positive
-        self.pts[ii].yRel = sin(-cpt['CAN_DET_AZIMUTH']) * cpt['CAN_DET_RANGE']
-        self.pts[ii].vRel = cpt['CAN_DET_RANGE_RATE']
-        self.pts[ii].aRel = float('nan')
+      valid = msg[f"CAN_DET_VALID_LEVEL_{ii:02d}"] > 0
+      if valid:
+        rel_distance = msg[f"CAN_DET_RANGE_{ii:02d}"]  # m
+        azimuth = msg[f"CAN_DET_AZIMUTH_{ii:02d}"]  # rad
+
+        self.pts[ii].dRel = rel_distance  # m from front of car
+        self.pts[ii].yRel = sin(-azimuth) * rel_distance  # in car frame's y axis, left is positive
+        self.pts[ii].vRel = msg[f"CAN_DET_RANGE_RATE_{ii:02d}"]  # m/s relative velocity
+
+        # use aRel for debugging AMPLITUDE (reflection size)
+        self.pts[ii].aRel = msg[f"CAN_DET_AMPLITUDE_{ii:02d}"]  # dBsm
+
         self.pts[ii].yvRel = float('nan')
         self.pts[ii].measured = True
+
       else:
-        if ii in self.pts:
-          del self.pts[ii]
+        del self.pts[ii]
 
     ret.points = list(self.pts.values())
-    self.updated_messages.clear()
     return ret

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -24,6 +24,11 @@ class CarControllerParams:
   STEER_RATE_LIMIT_DOWN = AngleRateLimit(speed_points=[0., 5., 15.], max_angle_diff_points=[5., 3.5, 0.4])
 
 
+class RADAR:
+  FUSION = 'ford_fusion_2018_adas'
+  CADS = 'FORD_CADS'
+
+
 class CANBUS:
   main = 0
   radar = 1
@@ -80,6 +85,6 @@ FW_VERSIONS = {
 
 
 DBC = {
-  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', 'FORD_CADS'),
-  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', 'FORD_CADS'),
+  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', RADAR.CADS),
+  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', RADAR.CADS),
 }

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -80,6 +80,6 @@ FW_VERSIONS = {
 
 
 DBC = {
-  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', None),
-  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', None),
+  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', 'FORD_CADS'),
+  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', 'FORD_CADS'),
 }

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -25,8 +25,8 @@ class CarControllerParams:
 
 
 class RADAR:
-  FUSION = 'ford_fusion_2018_adas'
-  CADS = 'FORD_CADS'
+  DELPHI_ESR = 'ford_fusion_2018_adas'
+  DELPHI_MRR = 'FORD_CADS'
 
 
 class CANBUS:
@@ -85,6 +85,6 @@ FW_VERSIONS = {
 
 
 DBC = {
-  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', RADAR.CADS),
-  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', RADAR.CADS),
+  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', RADAR.DELPHI_MRR),
+  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', RADAR.DELPHI_MRR),
 }


### PR DESCRIPTION
The Focus Mk4 (and I presume Escape too) seems to use the CADS radar instead of whatever radar was used in the Fusion. I just looked at the messages in cabana and verified that the message IDs for the the Fusion radar weren't there, and that these ones were.

Thanks very much to @ReFil who wrote this :smile: I'm going to test this out today