### PR TITLE
Build 22.04 without errors

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -55,7 +55,6 @@ function install_ubuntu_common_requirements() {
     ocl-icd-libopencl1 \
     ocl-icd-opencl-dev \
     clinfo \
-    python-dev \
     qml-module-qtquick2 \
     qtmultimedia5-dev \
     qtlocation5-dev \
@@ -68,7 +67,7 @@ function install_ubuntu_common_requirements() {
     valgrind
 }
 
-# Install Ubuntu 21.10 packages
+# Install Ubuntu 22.04 lts packages
 function install_ubuntu_latest_requirements() {
   install_ubuntu_common_requirements
 
@@ -76,7 +75,20 @@ function install_ubuntu_latest_requirements() {
     qtbase5-dev \
     qtchooser \
     qt5-qmake \
-    qtbase5-dev-tools
+    qtbase5-dev-tools \
+    python3-dev
+}
+
+# Install Ubuntu 21.10 packages
+function install_ubuntu_21.10_requirements() {
+  install_ubuntu_common_requirements
+
+  sudo apt-get install -y --no-install-recommends \
+    qtbase5-dev \
+    qtchooser \
+    qt5-qmake \
+    qtbase5-dev-tools\
+    python-dev
 }
 
 # Install Ubuntu 20.04 packages
@@ -85,15 +97,19 @@ function install_ubuntu_lts_requirements() {
 
   sudo apt-get install -y --no-install-recommends \
     libavresample-dev \
-    qt5-default
+    qt5-default \
+    python-dev
 }
 
 # Detect OS using /etc/os-release file
 if [ -f "/etc/os-release" ]; then
   source /etc/os-release
   case "$ID $VERSION_ID" in
-    "ubuntu 21.10")
+    "ubuntu 22.04")
       install_ubuntu_latest_requirements
+      ;;
+    "ubuntu 21.10")
+      install_ubuntu_21.10_requirements
       ;;
     "ubuntu 20.04")
       install_ubuntu_lts_requirements


### PR DESCRIPTION
- Removed python-dev from install_ubuntu_common_requirements() and added it to version specific install requirements
- Added case "ubuntu 22.04"
- Added install_ubuntu_21.10_requirements()
- Modified install_ubuntu_latest_requirements() to include python3-dev instead of python-dev

