### PR TITLE
Discrete controller (discrete PID, no FF, no integrator windup via recalculation/last_actuators)

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -42,6 +42,8 @@ class TestCarInterfaces(unittest.TestCase):
         self.assertTrue(car_params.lateralTuning.torque.kf > 0)
       elif tuning == 'indi':
         self.assertTrue(len(car_params.lateralTuning.indi.outerLoopGainV))
+      elif tuning == 'discrete':
+        self.assertTrue(car_params.lateralTuning.discrete)
 
     # Run car interface
     CC = car.CarControl.new_message()

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -119,6 +119,8 @@ class TestCarModel(unittest.TestCase):
         self.assertTrue(self.CP.lateralTuning.torque.kf > 0)
       elif tuning == 'indi':
         self.assertTrue(len(self.CP.lateralTuning.indi.outerLoopGainV))
+      elif tuning == 'discrete':
+        self.assertTrue(self.CP.lateralTuning.discrete)
       else:
         raise Exception("unkown tuning")
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -19,6 +19,7 @@ from selfdrive.controls.lib.drive_helpers import update_v_cruise, initialize_v_c
 from selfdrive.controls.lib.drive_helpers import get_lag_adjusted_curvature
 from selfdrive.controls.lib.longcontrol import LongControl
 from selfdrive.controls.lib.latcontrol_pid import LatControlPID
+from selfdrive.controls.lib.latcontrol_discrete import LatControlDiscrete
 from selfdrive.controls.lib.latcontrol_indi import LatControlINDI
 from selfdrive.controls.lib.latcontrol_angle import LatControlAngle
 from selfdrive.controls.lib.latcontrol_torque import LatControlTorque
@@ -146,6 +147,8 @@ class Controls:
       self.LaC = LatControlINDI(self.CP, self.CI)
     elif self.CP.lateralTuning.which() == 'torque':
       self.LaC = LatControlTorque(self.CP, self.CI)
+    elif self.CP.lateralTuning.which() == 'discrete':
+      self.LaC = LatControlDiscrete(self.CP, self.CI)
 
     self.initialized = False
     self.state = State.disabled
@@ -734,6 +737,8 @@ class Controls:
       controlsState.lateralControlState.torqueState = lac_log
     elif lat_tuning == 'indi':
       controlsState.lateralControlState.indiState = lac_log
+    elif lat_tuning == 'discrete':
+      controlsState.lateralControlState.discreteState = lac_log
 
     self.pm.send('controlsState', dat)
 

--- a/selfdrive/controls/lib/discrete.py
+++ b/selfdrive/controls/lib/discrete.py
@@ -4,8 +4,9 @@ import numpy.polynomial.polynomial as P
 class DiscreteController():
   def __init__(self, gains, rate=100):
     self.gains = np.array(gains)
-    Z = [[[1, 1], [2, -2]], [[1], [1]], [[2, -2], [1-2j, 1+2j]]] # Trapezoidal IPD (filter is in complex term)
-    T = [[[1, 0], [1    ]], [[1], [1]], [[1    ], [1   , .05j]]] # Trapezoidal IPD (filter is in complex term)
+    N = 20 # Filter coefficient. corner frequency in rad/s. 20 = ~3.18hz
+    Z = [[[1, 1], [2, -2]], [[1], [1]], [[2, -2], [1-2j, 1+2j]]] # Trapezoidal IPD
+    T = [[[1, 0], [1    ]], [[1], [1]], [[1    ], [1   , (1/N)*1j]]] # Trapezoidal IPD
     self.G = [[P.polymul(Z[i][j][::-1], P.polyval(1/rate, T[i][j][::-1]))[::-1].real.tolist() for j in range(len(Z[i]))] for i in range(len(Z))]
     self.update_controller()
     self.reset()

--- a/selfdrive/controls/lib/discrete.py
+++ b/selfdrive/controls/lib/discrete.py
@@ -1,0 +1,68 @@
+import numpy as np
+import numpy.polynomial.polynomial as P
+  
+class DiscreteController():
+  def __init__(self, gains, rate=100):
+    self.gains = np.array(gains)
+    Z = [[[1, 1], [2, -2]], [[1], [1]], [[2, -2], [1-2j, 1+2j]]] # Trapezoidal IPD (filter is in complex term)
+    T = [[[1, 0], [1    ]], [[1], [1]], [[1    ], [1   , .05j]]] # Trapezoidal IPD (filter is in complex term)
+    self.G = [[P.polymul(Z[i][j][::-1], P.polyval(1/rate, T[i][j][::-1]))[::-1].real.tolist() for j in range(len(Z[i]))] for i in range(len(Z))]
+    self.update_controller()
+    self.reset()
+
+  def reset(self):
+    self.e = np.zeros(len(self.ke))
+    self.u = np.zeros(len(self.ku))
+    self.d = np.zeros((len(self.c), len(self.u)))
+
+  def update(self, error, last_output):
+    #recalculate the last error from corrected u0
+    self.u[0] = last_output
+    self.e[0] += np.divide(np.sum(np.multiply(self.ku, self.u)) - np.sum(np.multiply(self.ke, self.e)), self.ke[0])
+    
+    #logging
+    for i in range(len(self.c)):
+      self.d[i][0] += np.divide(np.sum(np.multiply(self.c[i]/self.a[0], self.e)) - np.sum(np.multiply(self.ku, self.d[i])), self.ku[0])
+      self.d[i] = np.roll(self.d[i], 1)
+    
+    #next timestep
+    self.e = np.roll(self.e, 1)
+    self.u = np.roll(self.u, 1)
+
+    #calculate next step desired
+    self.e[0] = error
+    self.u[0] += np.divide(np.sum(np.multiply(self.ke, self.e)) - np.sum(np.multiply(self.ku, self.u)), self.ku[0])
+
+    return float(self.u[0])
+  
+  def update_gains(self):
+    b = [0]
+    for i in range(len(self.c)):
+      b = P.polyadd(b, self.gains[i]*self.c[i])
+    self.ke = np.array([i / self.a[0] for i in b])
+    self.b = b
+
+  def update_controller(self):
+    self.a = [1]
+    c = np.array(np.zeros(len(self.G)), dtype=object)
+    for g in self.G:
+      self.a = P.polymul(self.a[::-1], g[1][::-1])[::-1]
+    for i in range(len(self.G)):
+      c[i] = self.G[i][0]
+      for j in range(len(self.G)):
+        if i != j:
+          c[i] = P.polymul(c[i][::-1], self.G[j][1][::-1])[::-1]
+    maxlen = 0
+    for i in range(len(c)):
+      maxlen = maxlen if maxlen >= len(c[i]) else len(c[i])
+    self.c = np.ndarray((len(c), maxlen))
+    for i in range(len(c)):
+      self.c[i] = np.append(np.repeat([0], maxlen-len(c[i])), c[i])
+    self.ku = np.array([i / self.a[0] for i in self.a])
+    self.update_gains()
+    
+    if self.a[0] == 0 or len(self.a) < len(self.b):
+      raise ValueError("Controller is non-causal. Output depends on future value. e.g. Forward Euler PID")
+    if np.linalg.matrix_rank(self.c)<len(self.c):
+      raise ValueError("Controller gains are not linearly independant")
+    

--- a/selfdrive/controls/lib/latcontrol_discrete.py
+++ b/selfdrive/controls/lib/latcontrol_discrete.py
@@ -12,7 +12,7 @@ def linearize_error(error, speed):
 class LatControlDiscrete(LatControl):
   def __init__(self, CP, CI):
     super().__init__(CP, CI)
-    gains = [g for g in CP.lateralTuning.discrete.gains]
+    gains = [CP.lateralTuning.discrete.ki, CP.lateralTuning.discrete.kp, CP.lateralTuning.discrete.kd]
     self.discrete = DiscreteController(gains, rate=(1 / DT_CTRL))
 
   def reset(self):

--- a/selfdrive/controls/lib/latcontrol_discrete.py
+++ b/selfdrive/controls/lib/latcontrol_discrete.py
@@ -1,0 +1,43 @@
+import math
+
+from selfdrive.controls.lib.latcontrol import LatControl, MIN_STEER_SPEED
+from selfdrive.controls.lib.discrete import DiscreteController
+from common.numpy_fast import clip
+from common.realtime import DT_CTRL
+from cereal import log
+
+def linearize_error(error, speed):
+  return error * (1 + 1*((speed/40)**2))
+
+class LatControlDiscrete(LatControl):
+  def __init__(self, CP, CI):
+    super().__init__(CP, CI)
+    gains = [g for g in CP.lateralTuning.discrete.gains]
+    self.discrete = DiscreteController(gains, rate=(1 / DT_CTRL))
+
+  def reset(self):
+    super().reset()
+    self.discrete.reset()
+
+  def update(self, active, CS, CP, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+    angle_steers_des = math.degrees(VM.get_steer_from_curvature(-desired_curvature, CS.vEgo, params.roll))
+    angle_steers = CS.steeringAngleDeg-params.angleOffsetAverageDeg
+    error = linearize_error(angle_steers_des - angle_steers, CS.vEgo)
+    
+    discrete_log = log.ControlsState.LateralDiscreteState.new_message()
+    discrete_log.steeringAngleDesiredDeg = angle_steers_des
+    discrete_log.steeringAngleDeg = float(angle_steers)
+    discrete_log.angleError = error
+    
+    if CS.vEgo < MIN_STEER_SPEED or not active:
+      self.discrete.reset()
+      output_steer = 0.0
+    else:
+      output_steer = self.discrete.update(error, last_actuators.steer)
+      output_steer = clip(output_steer, -self.steer_max, self.steer_max)
+
+      discrete_log.active = True
+      discrete_log.output = float(self.discrete.u[1])
+      discrete_log.saturated = self._check_saturation(self.steer_max - abs(output_steer) < 1e-3, CS)
+      discrete_log.gains = [float(g*u[1]) for g, u in zip(self.discrete.gains, self.discrete.d)]
+    return output_steer, angle_steers_des, discrete_log


### PR DESCRIPTION
Uses last actuators to limit the integrator a bit better than https://github.com/commaai/openpilot/pull/23414 without needing any additional value changes / tuning. 
linearizes the error by speed to perform gain scheduling so only a single value is needed for P,I,D
Does not rely on or benefit from the use of FF. Integrator can handle what FF is used for currently and rate limits on the actuators make FF not useful since FF is intended to speed up the controllers reaction to a setpoint change. 
integrator(s) do not wind up they are recalculated based on the last_actuators. My current tuning I = ~1.5x P

Entire PID controller is actually defined in 3 lines. 
    N = 20 # Filter coefficient. corner frequency in rad/s. 20 = ~3.18hz
    Z = [[[1, 1], [2, -2]], [[1], [1]], [[2, -2], [1-2j, 1+2j]]] # Trapezoidal IPD
    T = [[[1, 0], [1    ]], [[1], [1]], [[1    ], [1   , (1/N)*1j]]] # Trapezoidal IPD

This would be PI only by changing those lines:
    Z = [[[1, 1], [2, -2]], [[1], [1]]] # Trapezoidal IP
    T = [[[1, 0], [1     ]], [[1], [1]]] # Trapezoidal IP
    
Useful on it's own as an upgraded PID controller for Lat but also could be a better controller for use in the new torque control to eliminate the badly behaved integrator in the stock system.