### PR TITLE
EKF paramsd tuning for convergence.

### DIFF
--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -63,10 +63,10 @@ class CarKalman(KalmanFilter):
     math.radians(0.02)**2,
     math.radians(0.25)**2,
 
-    .1**2, .01**2,
+    6**2, .03**2,
     math.radians(0.1)**2,
-    math.radians(0.1)**2,
-    math.radians(1)**2,
+    math.radians(12)**2,
+    math.radians(3)**2,
   ])
 
   P_initial = np.diag([

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -71,7 +71,7 @@ class CarKalman(KalmanFilter):
 
   P_initial = np.diag([
     (2 / 100)**2,
-    .01**2,
+    .1**2,
     math.radians(0.08)**2,
     math.radians(0.25)**2,
 

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -58,7 +58,7 @@ class CarKalman(KalmanFilter):
 
   # process noise
   Q = np.diag([
-    (.05 / 100)**2,
+    (.005 / 100)**2,
     .01**2,
     math.radians(0.02)**2,
     math.radians(0.25)**2,
@@ -68,15 +68,24 @@ class CarKalman(KalmanFilter):
     math.radians(0.1)**2,
     math.radians(1)**2,
   ])
-  P_initial = Q.copy()
+
+  P_initial = np.diag([
+    (2 / 100)**2,
+    .01**2,
+    math.radians(0.08)**2,
+    math.radians(0.25)**2,
+
+    .6**2, .03**2,
+    math.radians(.1)**2,
+    math.radians(1.2)**2,
+    math.radians(.3)**2,
+  ])
+  
 
   obs_noise: Dict[int, Any] = {
-    ObservationKind.STEER_ANGLE: np.atleast_2d(math.radians(0.05)**2),
+    ObservationKind.STEER_ANGLE: np.atleast_2d(math.radians(1.0)**2),
     ObservationKind.ANGLE_OFFSET_FAST: np.atleast_2d(math.radians(10.0)**2),
-    ObservationKind.ROAD_ROLL: np.atleast_2d(math.radians(1.0)**2),
-    ObservationKind.STEER_RATIO: np.atleast_2d(5.0**2),
-    ObservationKind.STIFFNESS: np.atleast_2d(0.5**2),
-    ObservationKind.ROAD_FRAME_X_SPEED: np.atleast_2d(0.1**2),
+    ObservationKind.ROAD_FRAME_X_SPEED: np.atleast_2d(0.5**2),
   }
 
   global_vars = [
@@ -153,8 +162,6 @@ class CarKalman(KalmanFilter):
       [sp.Matrix([u]), ObservationKind.ROAD_FRAME_X_SPEED, None],
       [sp.Matrix([sa]), ObservationKind.STEER_ANGLE, None],
       [sp.Matrix([angle_offset_fast]), ObservationKind.ANGLE_OFFSET_FAST, None],
-      [sp.Matrix([sR]), ObservationKind.STEER_RATIO, None],
-      [sp.Matrix([sf]), ObservationKind.STIFFNESS, None],
       [sp.Matrix([theta]), ObservationKind.ROAD_ROLL, None],
     ]
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -76,7 +76,8 @@ class ParamsLearner:
         self.kf.predict_and_observe(t, ObservationKind.ANGLE_OFFSET_FAST, np.array([[0]]))
     elif which == 'carState':
       speed, steering_angle = msg.vEgo, msg.steeringAngleDeg
-      in_linear_region = abs(steering_angle) < 3*self.steering_ratio
+      self.steering_pressed = msg.steeringPressed
+      in_linear_region = abs(steering_angle) < 3*self.steering_ratio and not self.steering_pressed
       self.active = speed > 5 and in_linear_region
 
       if self.active:

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -77,11 +77,10 @@ class ParamsLearner:
     elif which == 'carState':
       speed, steering_angle = msg.vEgo, msg.steeringAngleDeg
       in_linear_region = abs(steering_angle) < 3*self.steering_ratio
-      self.active = speed > 5
+      self.active = speed > 5 and in_linear_region
 
       if self.active:
-        if in_linear_region:
-          self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[math.radians(steering_angle)]]))
+        self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[math.radians(steering_angle)]]))
         self.kf.predict_and_observe(t, ObservationKind.ROAD_FRAME_X_SPEED, np.array([[speed]]))
 
 def main(sm=None, pm=None):


### PR DESCRIPTION
Currently the EKF/params learner isn't converging. STD's should not be increasing constantly. 
covariance Q values for steering angle, speed, and roll are very low implying that they do not differ from the model, however these three are not modeled at all and should have a much higher co-variance. 
I'm not an expert in tuning these but was able to get good results and stable STD's showing that the EKF was converging on it's own. 

I still need to get stock working but for some reason FPV2 is not working when I tried setting up a branch without all of the subaru changes. I may be stuck until .8.14 is released and mlp has a new branch with merge conflicts sorted. There were a ton of conflicts when I was trying to find out what I needed,  but I will try again to get a cleaner branch for some good before and after logs. 

The issue however is clear in the below comments in the code, both of which should be resolved. 

'# We observe the current stiffness and steer ratio (with a high observation noise) to bound
'# the respective estimate STD. Otherwise the STDs keep increasing, causing rapid changes in the
'# states in longer routes (especially straight stretches).

'# Reset time when stopped so uncertainty doesn't grow

I'm also assuming this would need to go through some extensive testing to make sure nothing breaks as well as to get better values than what I've found for Q/P. But by letting the model be more unsure about where the steering angle, speed, and roll should be after not getting observations the innovation is not creating large swings in the other values to counter the change in value when resuming observations of speed/roll/yaw/steering angle.