### PR TITLE
EKF paramsd sign cleanup

### DIFF
--- a/selfdrive/controls/lib/vehicle_model.py
+++ b/selfdrive/controls/lib/vehicle_model.py
@@ -201,7 +201,7 @@ def create_dyn_state_matrices(u: float, VM: VehicleModel) -> Tuple[np.ndarray, n
   B[1, 0] = (VM.cF * VM.aF - VM.chi * VM.cR * VM.aR) / VM.j / VM.sR
 
   # Roll input
-  B[0, 1] = -ACCELERATION_DUE_TO_GRAVITY
+  B[0, 1] = ACCELERATION_DUE_TO_GRAVITY
 
   return A, B
 

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -133,7 +133,7 @@ class CarKalman(KalmanFilter):
     C[1, 0] = 0
 
     x = sp.Matrix([v, r])  # lateral velocity, yaw rate
-    x_dot = A * x + B * (sa - angle_offset - angle_offset_fast) - C * theta
+    x_dot = A * x + B * (sa - angle_offset - angle_offset_fast) + C * theta
 
     dt = sp.Symbol('dt')
     state_dot = sp.Matrix(np.zeros((dim_state, 1)))

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -133,7 +133,7 @@ class CarKalman(KalmanFilter):
     C[1, 0] = 0
 
     x = sp.Matrix([v, r])  # lateral velocity, yaw rate
-    x_dot = A * x + B * (sa - angle_offset - angle_offset_fast) + C * theta
+    x_dot = A * x + B * (sa + angle_offset + angle_offset_fast) + C * theta
 
     dt = sp.Symbol('dt')
     state_dot = sp.Matrix(np.zeros((dim_state, 1)))

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -65,7 +65,7 @@ class ParamsLearner:
           if yaw_rate_valid:
             self.kf.predict_and_observe(t,
                                         ObservationKind.ROAD_FRAME_YAW_RATE,
-                                        np.array([[-yaw_rate]]),
+                                        np.array([[yaw_rate]]),
                                         np.array([np.atleast_2d(yaw_rate_std**2)]))
 
           self.kf.predict_and_observe(t,
@@ -83,7 +83,7 @@ class ParamsLearner:
         self.kf.predict_and_observe(t, ObservationKind.STEER_RATIO, np.array([[steer_ratio]]))
 
     elif which == 'carState':
-      self.steering_angle = msg.steeringAngleDeg
+      self.steering_angle = -msg.steeringAngleDeg
       self.steering_pressed = msg.steeringPressed
       self.speed = msg.vEgo
 
@@ -91,7 +91,7 @@ class ParamsLearner:
       self.active = self.speed > 5 and in_linear_region
 
       if self.active:
-        self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[math.radians(msg.steeringAngleDeg)]]))
+        self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[math.radians(self.steering_angle)]]))
         self.kf.predict_and_observe(t, ObservationKind.ROAD_FRAME_X_SPEED, np.array([[self.speed]]))
 
     if not self.active:


### PR DESCRIPTION
This is probably noted already but the signs are backwards from convention in paramsd. 

currently yaw_rate and steering angle are observed opposite of convention and roll is opposite of convention in the model.

This "corrects" the signs and keeps angle offset the same sign. This should align with the main localizer + NED convention. 

Behavior is already correct and not modified here. The params learner is just in it's own mirror universe right now. 
I.e. curently,
locationd: NED
paramsd: NWD
VM dyn_matrices: NEU?

