### PR TITLE
Don't build OpenCV tests in webcam docker image

### DIFF
--- a/tools/webcam/Dockerfile
+++ b/tools/webcam/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mv opencv-${OPENCV_VERSION} OpenCV && \
     cd OpenCV && mkdir build && cd build && \
     cmake -DWITH_OPENGL=ON -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON \
-          -DWITH_XINE=ON -DENABLE_PRECOMPILED_HEADERS=OFF .. && \
+          -DWITH_XINE=ON -DENABLE_PRECOMPILED_HEADERS=OFF -DBUILD_TESTS=OFF \
+          -DBUILD_PERF_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_opencv_apps=OFF .. && \
     make -j8 && \
     make install && \
     ldconfig && \


### PR DESCRIPTION
Building opencv tests and apps are [on by default](https://docs.opencv.org/4.x/db/d05/tutorial_config_reference.html#tutorial_config_reference_general_tests), but I'm not sure they are needed.

This saves about 30 minutes when building the webcam docker image!