### PR TITLE
regen: send vipc_client_extra frames

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -347,6 +347,7 @@ def setup_env(simulation=False):
   params.put_bool("OpenpilotEnabledToggle", True)
   params.put_bool("Passive", False)
   params.put_bool("DisengageOnAccelerator", True)
+  params.put_bool("EnableWideCamera", False)
 
   os.environ["NO_RADAR_SLEEP"] = "1"
   os.environ["REPLAY"] = "1"

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from dataclasses import make_dataclass
 import os
 import time
 import multiprocessing
@@ -114,59 +113,59 @@ def replay_service(s, msgs):
 
 
 def replay_cameras(lr, frs):
-  Camera = make_dataclass("Camera", ["dt", "frame_size", "stream_type", "use_extra_client"])
-  cameras = {  # default TICI cameras
-    "roadCameraState": Camera(DT_MDL, tici_f_frame_size, VisionStreamType.VISION_STREAM_ROAD, True),
-    "driverCameraState": Camera(DT_MDL, tici_d_frame_size, VisionStreamType.VISION_STREAM_DRIVER, False),
-  }
+  eon_cameras = [
+    ("roadCameraState", DT_MDL, eon_f_frame_size, VisionStreamType.VISION_STREAM_ROAD, True),
+    ("driverCameraState", DT_DMON, eon_d_frame_size, VisionStreamType.VISION_STREAM_DRIVER, False),
+  ]
+  tici_cameras = [
+    ("roadCameraState", DT_MDL, tici_f_frame_size, VisionStreamType.VISION_STREAM_ROAD, True),
+    ("driverCameraState", DT_MDL, tici_d_frame_size, VisionStreamType.VISION_STREAM_DRIVER, False),
+  ]
 
-  def replay_camera(stream, camera, vipc_server, frames):
-    pm = messaging.PubMaster([stream, ])
-    rk = Ratekeeper(1 / camera.dt, print_delay_threshold=None)
+  def replay_camera(s, stream, dt, vipc_server, frames, size, use_extra_client):
+    pm = messaging.PubMaster([s, ])
+    rk = Ratekeeper(1 / dt, print_delay_threshold=None)
 
-    img = b"\x00" * int(camera.size[0] * camera.size[1] * 3 / 2)
+    img = b"\x00" * int(size[0] * size[1] * 3 / 2)
     while True:
       if frames is not None:
         img = frames[rk.frame % len(frames)]
 
       rk.keep_time()
 
-      m = messaging.new_message(stream)
-      msg = getattr(m, stream)
+      m = messaging.new_message(s)
+      msg = getattr(m, s)
       msg.frameId = rk.frame
       msg.timestampSof = m.logMonoTime
       msg.timestampEof = m.logMonoTime
-      pm.send(stream, m)
+      pm.send(s, m)
 
       vipc_server.send(stream, img, msg.frameId, msg.timestampSof, msg.timestampEof)
-      if camera.use_extra_client:
+      if use_extra_client:
         vipc_server.send(VisionStreamType.VISION_STREAM_WIDE_ROAD, img, msg.frameId, msg.timestampSof, msg.timestampEof)
 
   init_data = [m for m in lr if m.which() == 'initData'][0]
-  if init_data.initData.deviceType != 'tici':
-    cameras["roadCameraState"].size = eon_f_frame_size
-    cameras["driverCameraState"].size = eon_d_frame_size
-    cameras["driverCameraState"].dt = DT_DMON
+  cameras = tici_cameras if (init_data.initData.deviceType == 'tici') else eon_cameras
 
   # init vipc server and cameras
   p = []
   vs = VisionIpcServer("camerad")
-  for stream, camera in cameras.items():
-    fr = frs.get(stream, None)
+  for (s, dt, size, stream, use_extra_client) in cameras:
+    fr = frs.get(s, None)
 
     frames = None
     if fr is not None:
-      print(f"Decompressing frames {stream}")
+      print(f"Decompressing frames {s}")
       frames = []
       for i in tqdm(range(fr.frame_count)):
         img = fr.get(i, pix_fmt='yuv420p')[0]
         frames.append(img.flatten().tobytes())
 
-    vs.create_buffers(camera.stream_type, 40, False, camera.size[0], camera.size[1])
-    if camera.use_extra_client:
-      vs.create_buffers(VisionStreamType.VISION_STREAM_WIDE_ROAD, 40, False, camera.size[0], camera.size[1])
+    vs.create_buffers(stream, 40, False, size[0], size[1])
+    if use_extra_client:
+      vs.create_buffers(VisionStreamType.VISION_STREAM_WIDE_ROAD, 40, False, size[0], size[1])
     p.append(multiprocessing.Process(target=replay_camera,
-                                     args=(stream, camera, vs, frames)))
+                                     args=(s, stream, dt, vs, frames, size, use_extra_client)))
 
   # hack to make UI work
   vs.create_buffers(VisionStreamType.VISION_STREAM_RGB_ROAD, 4, True, eon_f_frame_size[0], eon_f_frame_size[1])

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from collections import namedtuple
 from dataclasses import make_dataclass
 import os
 import time


### PR DESCRIPTION
Issue: constantly get `selfdrive/modeld/modeld.cc: vipc_client_extra no frame` when trying to run regen.

modeld now relies on vipc_client_extra all the time, not just when not using `EnableWideCamera` (broke in https://github.com/commaai/openpilot/pull/24263)

This duplicates the frame like modeld used to do when not TICI