### PR TITLE
panda: support uint32_t safety param

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -248,7 +248,7 @@ int Panda::usb_bulk_read(unsigned char endpoint, unsigned char* data, int length
 }
 
 void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, uint32_t safety_param) {
-  usb_write(0xfc, ((uint16_t)safety_model & ((1 << 16) - 1)), 0);
+  usb_write(0xdc, ((uint16_t)safety_model & ((1 << 16) - 1)), 0);
   usb_write(0xdc, safety_param & ((1 << 16) - 1), safety_param >> 16);  // split safety_param in half
 }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -248,7 +248,8 @@ int Panda::usb_bulk_read(unsigned char endpoint, unsigned char* data, int length
 }
 
 void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, uint32_t safety_param) {
-  usb_write(0xdc, (uint16_t)safety_model, safety_param);
+  usb_write(0xfc, (uint16_t)(safety_model & ((1 << 16) - 1)), 0);
+  usb_write(0xdc, safety_param & ((1 << 16) - 1), safety_param >> 16);  // split safety_param in half
 }
 
 void Panda::set_alternative_experience(uint16_t alternative_experience) {

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -248,7 +248,7 @@ int Panda::usb_bulk_read(unsigned char endpoint, unsigned char* data, int length
 }
 
 void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, uint32_t safety_param) {
-  usb_write(0xdc, ((uint16_t)safety_model & ((1 << 16) - 1)), 0);
+  usb_write(0xdc, (uint16_t)safety_model, 0);
   usb_write(0xdc, safety_param & ((1 << 16) - 1), safety_param >> 16);  // split safety_param in half
 }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -248,7 +248,7 @@ int Panda::usb_bulk_read(unsigned char endpoint, unsigned char* data, int length
 }
 
 void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, uint32_t safety_param) {
-  usb_write(0xfc, (uint16_t)(safety_model & ((1 << 16) - 1)), 0);
+  usb_write(0xfc, ((uint16_t)safety_model & ((1 << 16) - 1)), 0);
   usb_write(0xdc, safety_param & ((1 << 16) - 1), safety_param >> 16);  // split safety_param in half
 }
 


### PR DESCRIPTION
First send the safety mode, then the safety param split into two halves over two total USB packets. Tried to use wLength to use just one packet, but I got segmentation faults from the usb write as it describes the data size