### PR TITLE
ui: combine OnroadHud into NvgWindow

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -26,7 +26,7 @@ PROCS = {
   "./camerad": 26.0,
   "./locationd": 9.1,
   "selfdrive.controls.plannerd": 11.7,
-  "./_ui": 18.4,
+  "./_ui": 21.0,
   "selfdrive.locationd.paramsd": 9.0,
   "./_sensord": 6.17,
   "selfdrive.controls.radard": 4.5,

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -18,18 +18,13 @@ OnroadWindow::OnroadWindow(QWidget *parent) : QWidget(parent) {
   stacked_layout->setStackingMode(QStackedLayout::StackAll);
   main_layout->addLayout(stacked_layout);
 
-  QStackedLayout *road_view_layout = new QStackedLayout;
-  road_view_layout->setStackingMode(QStackedLayout::StackAll);
   nvg = new NvgWindow(VISION_STREAM_ROAD, this);
-  road_view_layout->addWidget(nvg);
-  // hud = new OnroadHud(this);
-  // road_view_layout->addWidget(hud);
 
   QWidget * split_wrapper = new QWidget;
   split = new QHBoxLayout(split_wrapper);
   split->setContentsMargins(0, 0, 0, 0);
   split->setSpacing(0);
-  split->addLayout(road_view_layout);
+  split->addWidget(nvg);
 
   stacked_layout->addWidget(split_wrapper);
 
@@ -202,6 +197,8 @@ void NvgWindow::updateState(const UIState &s) {
 }
 
 void NvgWindow::drawHud(QPainter &p) {
+  p.save();
+
   // Header gradient
   QLinearGradient bg(0, header_h - (header_h / 2.5), 0, header_h);
   bg.setColorAt(0, QColor::fromRgbF(0, 0, 0, 0.45));
@@ -242,6 +239,7 @@ void NvgWindow::drawHud(QPainter &p) {
     drawIcon(p, radius / 2 + (bdr_s * 2), rect().bottom() - footer_h / 2,
              dm_img, QColor(0, 0, 0, 70), dmActive ? 1.0 : 0.2);
   }
+  p.restore();
 }
 
 void NvgWindow::drawText(QPainter &p, int x, int y, const QString &text, int alpha) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -372,6 +372,8 @@ void NvgWindow::paintGL() {
   painter.setRenderHint(QPainter::Antialiasing);
   painter.setPen(Qt::NoPen);
 
+  drawHud(painter);
+
   UIState *s = uiState();
   if (s->worldObjectsVisible()) {
 
@@ -387,8 +389,6 @@ void NvgWindow::paintGL() {
       }
     }
   }
-
-  drawHud(painter);
 
   double cur_draw_t = millis_since_boot();
   double dt = cur_draw_t - prev_draw_t;

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -9,44 +9,6 @@
 
 
 // ***** onroad widgets *****
-
-class OnroadHud : public QWidget {
-  Q_OBJECT
-  Q_PROPERTY(QString speed MEMBER speed NOTIFY valueChanged);
-  Q_PROPERTY(QString speedUnit MEMBER speedUnit NOTIFY valueChanged);
-  Q_PROPERTY(QString maxSpeed MEMBER maxSpeed NOTIFY valueChanged);
-  Q_PROPERTY(bool is_cruise_set MEMBER is_cruise_set NOTIFY valueChanged);
-  Q_PROPERTY(bool engageable MEMBER engageable NOTIFY valueChanged);
-  Q_PROPERTY(bool dmActive MEMBER dmActive NOTIFY valueChanged);
-  Q_PROPERTY(bool hideDM MEMBER hideDM NOTIFY valueChanged);
-  Q_PROPERTY(int status MEMBER status NOTIFY valueChanged);
-
-public:
-  explicit OnroadHud(QWidget *parent);
-  void updateState(const UIState &s);
-
-private:
-  void drawIcon(QPainter &p, int x, int y, QPixmap &img, QBrush bg, float opacity);
-  void drawText(QPainter &p, int x, int y, const QString &text, int alpha = 255);
-  void paintEvent(QPaintEvent *event) override;
-
-  QPixmap engage_img;
-  QPixmap dm_img;
-  const int radius = 192;
-  const int img_size = (radius / 2) * 1.5;
-  QString speed;
-  QString speedUnit;
-  QString maxSpeed;
-  bool is_cruise_set = false;
-  bool engageable = false;
-  bool dmActive = false;
-  bool hideDM = false;
-  int status = STATUS_DISENGAGED;
-
-signals:
-  void valueChanged();
-};
-
 class OnroadAlerts : public QWidget {
   Q_OBJECT
 
@@ -65,9 +27,35 @@ private:
 // container window for the NVG UI
 class NvgWindow : public CameraViewWidget {
   Q_OBJECT
+  Q_PROPERTY(QString speed MEMBER speed);
+  Q_PROPERTY(QString speedUnit MEMBER speedUnit);
+  Q_PROPERTY(QString maxSpeed MEMBER maxSpeed);
+  Q_PROPERTY(bool is_cruise_set MEMBER is_cruise_set);
+  Q_PROPERTY(bool engageable MEMBER engageable);
+  Q_PROPERTY(bool dmActive MEMBER dmActive);
+  Q_PROPERTY(bool hideDM MEMBER hideDM);
+  Q_PROPERTY(int status MEMBER status);
 
 public:
   explicit NvgWindow(VisionStreamType type, QWidget* parent = 0);
+  void updateState(const UIState &s);
+
+private:
+  void drawIcon(QPainter &p, int x, int y, QPixmap &img, QBrush bg, float opacity);
+  void drawText(QPainter &p, int x, int y, const QString &text, int alpha = 255);
+
+  QPixmap engage_img;
+  QPixmap dm_img;
+  const int radius = 192;
+  const int img_size = (radius / 2) * 1.5;
+  QString speed;
+  QString speedUnit;
+  QString maxSpeed;
+  bool is_cruise_set = false;
+  bool engageable = false;
+  bool dmActive = false;
+  bool hideDM = false;
+  int status = STATUS_DISENGAGED;
 
 protected:
   void paintGL() override;
@@ -76,6 +64,7 @@ protected:
   void updateFrameMat(int w, int h) override;
   void drawLaneLines(QPainter &painter, const UIState *s);
   void drawLead(QPainter &painter, const cereal::ModelDataV2::LeadDataV3::Reader &lead_data, const QPointF &vd);
+  void drawHud(QPainter &p);
   inline QColor redColor(int alpha = 255) { return QColor(201, 34, 49, alpha); }
   inline QColor whiteColor(int alpha = 255) { return QColor(255, 255, 255, alpha); }
 
@@ -94,7 +83,7 @@ public:
 private:
   void paintEvent(QPaintEvent *event);
   void mousePressEvent(QMouseEvent* e) override;
-  OnroadHud *hud;
+  // OnroadHud *hud;
   OnroadAlerts *alerts;
   NvgWindow *nvg;
   QColor bg = bg_colors[STATUS_DISENGAGED];

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -83,7 +83,6 @@ public:
 private:
   void paintEvent(QPaintEvent *event);
   void mousePressEvent(QMouseEvent* e) override;
-  // OnroadHud *hud;
   OnroadAlerts *alerts;
   NvgWindow *nvg;
   QColor bg = bg_colors[STATUS_DISENGAGED];

--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -253,7 +253,6 @@ void CameraViewWidget::vipcConnected(VisionIpcClient *vipc_client) {
   stream_width = vipc_client->buffers[0].width;
   stream_height = vipc_client->buffers[0].height;
 
-  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
   for (int i = 0; i < 3; ++i) {
     glBindTexture(GL_TEXTURE_2D, textures[i]);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);


### PR DESCRIPTION
drawing OnroadHUD is very expensive and is therefore only done when values are actually changed. However this causes lots of inconsistency in drawing the camera feed. This dependency on the data also makes it hard to benchmark ui performance. Therefore I suggest moving it back into NvgWindow and drawing it every frame (on the GPU).


This might also reduce our uptick in ui restarts. I think those happen when asking weston to draw too many frames in short succession. Combining the separate draw of hud and camera into one should reduce the load on weston.