### PR TITLE
Body UI: Show battery percentage in bottom-right corner

### DIFF
--- a/selfdrive/car/body/carstate.py
+++ b/selfdrive/car/body/carstate.py
@@ -25,6 +25,8 @@ class CarState(CarStateBase):
     ret.cruiseState.enabled = True
     ret.cruiseState.available = True
 
+    ret.batteryPercent = cp.vl["BODY_DATA"]["BATT_PERCENTAGE"]
+
     return ret
 
   @staticmethod

--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -1,20 +1,35 @@
-#include "selfdrive/ui/qt/body.h"
-
 #include <cmath>
 
-BodyWindow::BodyWindow(QWidget *parent) : QLabel(parent) {
+#include <QVBoxLayout>
+
+#include "selfdrive/ui/qt/body.h"
+
+BodyWindow::BodyWindow(QWidget *parent) : QWidget(parent) {
+  layout = new QVBoxLayout(this);
+  layout->setMargin(0);
+  layout->setSpacing(0);
+
+  face = new QLabel();
+
   awake = new QMovie("../assets/body/awake.gif");
   awake->setCacheMode(QMovie::CacheAll);
   sleep = new QMovie("../assets/body/sleep.gif");
   sleep->setCacheMode(QMovie::CacheAll);
 
+  face->setAlignment(Qt::AlignCenter);
+  face->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+
+  battery = new QLabel();
+  battery->setStyleSheet("QLabel { font-size: 54px; }");
+  battery->setAlignment(Qt::AlignBottom | Qt::AlignRight);
+  battery->adjustSize();
+
   QPalette p(Qt::black);
-  setPalette(p);
-  setAutoFillBackground(true);
+  face->setPalette(p);
+  face->setAutoFillBackground(true);
 
-  setAlignment(Qt::AlignCenter);
-
-  setAttribute(Qt::WA_TransparentForMouseEvents, true);
+  layout->addWidget(face);
+  layout->addWidget(battery);
 
   QObject::connect(uiState(), &UIState::uiUpdate, this, &BodyWindow::updateState);
 }
@@ -28,9 +43,12 @@ void BodyWindow::updateState(const UIState &s) {
 
   // TODO: use carState.standstill when that's fixed
   const bool standstill = std::abs(sm["carState"].getCarState().getVEgo()) < 0.01;
+
+  battery->setText("<font color=\"red\">🔋</font> <font color=\"white\">"+QString::number(sm["carState"].getCarState().getBatteryPercent())+"%</font>");
+
   QMovie *m = standstill ? sleep : awake;
-  if (m != movie()) {
-    setMovie(m);
-    movie()->start();
+  if (m != face->movie()) {
+    face->setMovie(m);
+    face->movie()->start();
   }
 }

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -1,18 +1,22 @@
 #pragma once
 
+#include <QVBoxLayout>
 #include <QMovie>
 #include <QLabel>
 
 #include "selfdrive/ui/ui.h"
 
-class BodyWindow : public QLabel {
+class BodyWindow : public QWidget {
   Q_OBJECT
 
 public:
   BodyWindow(QWidget* parent = 0);
 
 private:
+  QVBoxLayout *layout;
+  QLabel *face;
   QMovie *awake, *sleep;
+  QLabel *battery;
 
 private slots:
   void updateState(const UIState &s);


### PR DESCRIPTION
Added battery percentage to the carState which required https://github.com/commaai/cereal/pull/290 

I did not retarget the cereal git submodule in this PR.

I did however implement a battery monitor as per the attached image.


![IMG_1449](https://user-images.githubusercontent.com/175305/166123936-336b14c7-3bea-4dfa-99de-1aa165c0bfd5.png)

