### PR TITLE
body: add fuelGaugePercentage to body carState

### DIFF
--- a/selfdrive/car/body/carstate.py
+++ b/selfdrive/car/body/carstate.py
@@ -20,6 +20,8 @@ class CarState(CarStateBase):
     ret.steerFaultPermanent = any([cp.vl['VAR_VALUES']['MOTOR_ERR_L'], cp.vl['VAR_VALUES']['MOTOR_ERR_R'],
                                    cp.vl['VAR_VALUES']['FAULT']])
 
+    ret.fuelGaugePercentage = cp.vl["BODY_DATA"]["BATT_PERCENTAGE"] / 100;
+
     # irrelevant for non-car
     ret.gearShifter = car.CarState.GearShifter.drive
     ret.cruiseState.enabled = True


### PR DESCRIPTION
Depends on https://github.com/commaai/cereal/pull/291

Partial replacement for https://github.com/commaai/openpilot/pull/24383

To explain why I am dividing by 100 in the change:

In cereal, https://github.com/commaai/cereal/pull/291 introduces a generic
fuelGaugePercentage field and defines it as a Float32 per the discussion
in an effort to make this field generic and capable of handling more
precise reporting.

The Comma body, however, is reporting battery percentage as an integer from
zero to one hundred, so this change is dividing by 100 to get the number
into that range. Is this appropriate?

It also does not perform any error checking to know if it's okay to
do this as I'm making the assumption that it's safe. Is this indeed a safe
assumption?

**Verification** I tested this on my comma body using code from https://github.com/commaai/openpilot/pull/24383 which renders a battery level on the display (the code, of course, has to then multiply by 100 to show it as a string percentage). But it does not crash and works fine. I don't like the fact that I'm doing / 100 and then * 100 but it's probably worth it for maintaining the generic-ness of the new carState field. Or maybe the body will report more precise values in the future and then half of the math would be removed. I think like im complaining about an extra couple grains of sand on a beach right now though!