### PR TITLE
WIP: Refactor body face UI to use grid system

### DIFF
--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -8,7 +8,7 @@
 
 FaceDotMatrix::FaceDotMatrix(QWidget* parent) : QWidget(parent) {
   QPalette pal = QPalette();
-  pal.setColor(QPalette::Window, Qt::black);
+  pal.setColor(QPalette::Window, Qt::yellow);
   setAutoFillBackground(true); 
   setPalette(pal);
   setAttribute(Qt::WA_TransparentForMouseEvents, true);
@@ -25,32 +25,36 @@ void FaceDotMatrix::paintEvent(QPaintEvent *e) {
 }
 
 Eye::Eye(QWidget* parent) : FaceDotMatrix(parent) {
+  dotWidth = 64;
+  dotMargin = 10;
+  dotsPerSpace = 4;
 }
 
 void Eye::paintEvent(QPaintEvent *e) {
   QPainter painter(this);
   QPen linepen(Qt::white);
   linepen.setCapStyle(Qt::RoundCap);
-  linepen.setWidth(56);
+  linepen.setWidth(dotWidth);
   painter.setRenderHint(QPainter::Antialiasing,true);
   painter.setPen(linepen);
-  painter.drawPoint(width()/2+100, height()/2+100);
+
+  int m = (dotWidth+dotMargin*2);
+  int spaceAvailible = width() / dotsPerSpace;
+
+  if (m > spaceAvailible)
+    m = spaceAvailible;
+
+  int startPosition = (width() / 2) - (dotsPerSpace/2)*m;
+  for (int i = 0; i<dotsPerSpace; i++) {
+    painter.drawPoint(startPosition + i*m + m/2, m);
+  }
 }
 
 Mouth::Mouth(QWidget* parent) : FaceDotMatrix(parent) {
 }
 
 void Mouth::paintEvent(QPaintEvent *e) {
-  printf("%d %d\n", height(), width());
-  QPainter painter(this);
-  QPen linepen(Qt::black);
-  linepen.setCapStyle(Qt::RoundCap);
-  linepen.setWidth(30);
-  painter.setRenderHint(QPainter::Antialiasing,true);
-  painter.setPen(linepen);
-  painter.drawPoint(0,0);
 }
-
 
 BodyWindow::BodyWindow(QWidget *parent) : QWidget(parent) {
   layout = new QGridLayout(this);
@@ -83,8 +87,6 @@ BodyWindow::BodyWindow(QWidget *parent) : QWidget(parent) {
   layout->addWidget(mouth,2,2);
   layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 2, 3);
   layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 2, 4);
-  
-  
 
   QObject::connect(uiState(), &UIState::uiUpdate, this, &BodyWindow::updateState);
 }

--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -14,41 +14,44 @@ FaceDotMatrix::FaceDotMatrix(QWidget* parent) : QWidget(parent) {
   setAttribute(Qt::WA_TransparentForMouseEvents, true);
 }
 
-void FaceDotMatrix::paintEvent(QPaintEvent *e) {
+void FaceDotMatrix::paintEvent(QPaintEvent *e) {}
+
+void FaceDotMatrix::paintMatrix(int a[4][4]) {
   QPainter painter(this);
   QPen linepen(Qt::white);
   linepen.setCapStyle(Qt::RoundCap);
-  linepen.setWidth(30);
+  linepen.setWidth(dotSize);
   painter.setRenderHint(QPainter::Antialiasing,true);
   painter.setPen(linepen);
-  painter.drawPoint(width()/2, height()/2);
+
+  int m = (dotSize+dotMargin*2);
+  int startPosition = (width() / 2) - (dotsPerSpace/2)*m;
+  for (int i = 0; i<dotsPerSpace; i++) {
+    linepen.setColor(Qt::white);
+    painter.drawPoint(startPosition + i*m + m/2, m/2);
+  }
 }
 
 Eye::Eye(QWidget* parent) : FaceDotMatrix(parent) {
-  dotWidth = 64;
+  dotSize = 64;
   dotMargin = 10;
   dotsPerSpace = 4;
 }
 
 void Eye::paintEvent(QPaintEvent *e) {
-  QPainter painter(this);
-  QPen linepen(Qt::white);
-  linepen.setCapStyle(Qt::RoundCap);
-  linepen.setWidth(dotWidth);
-  painter.setRenderHint(QPainter::Antialiasing,true);
-  painter.setPen(linepen);
-
-  int m = (dotWidth+dotMargin*2);
-  int spaceAvailible = width() / dotsPerSpace;
-
-  if (m > spaceAvailible)
-    m = spaceAvailible;
-
-  int startPosition = (width() / 2) - (dotsPerSpace/2)*m;
-  for (int i = 0; i<dotsPerSpace; i++) {
-    painter.drawPoint(startPosition + i*m + m/2, m);
-  }
+  int a[4][4] = {
+    0,1,1,0,
+    1,1,1,1,
+    1,1,1,1,
+    0,1,1,0
+  };
+  paintMatrix(a);
 }
+
+void Eye::updateState(const UIState &s) {
+  update();
+}
+
 
 Mouth::Mouth(QWidget* parent) : FaceDotMatrix(parent) {
 }
@@ -89,6 +92,8 @@ BodyWindow::BodyWindow(QWidget *parent) : QWidget(parent) {
   layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 2, 4);
 
   QObject::connect(uiState(), &UIState::uiUpdate, this, &BodyWindow::updateState);
+  QObject::connect(uiState(), &UIState::uiUpdate, leftEye, &Eye::updateState);
+  QObject::connect(uiState(), &UIState::uiUpdate, rightEye, &Eye::updateState);
 }
 
 void BodyWindow::updateState(const UIState &s) {

--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -25,17 +25,19 @@ void FaceDotMatrix::paintMatrix(int a[4][4]) {
   painter.setPen(linepen);
 
   int m = (dotSize+dotMargin*2);
-  int startPosition = (width() / 2) - (dotsPerSpace/2)*m;
-  for (int i = 0; i<dotsPerSpace; i++) {
-    linepen.setColor(Qt::white);
-    painter.drawPoint(startPosition + i*m + m/2, m/2);
+  int xOffset = (width()/2) - 2*m;
+  int yOffset = (height()/2) - 2*m;
+
+  for (int i = 0; i<4; i++) {
+    painter.drawPoint(xOffset + i*m + m/2, yOffset + i*m + m/2);
   }
+
+  
 }
 
 Eye::Eye(QWidget* parent) : FaceDotMatrix(parent) {
   dotSize = 64;
   dotMargin = 10;
-  dotsPerSpace = 4;
 }
 
 void Eye::paintEvent(QPaintEvent *e) {

--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -5,33 +5,88 @@
 
 #include "selfdrive/ui/qt/body.h"
 
-BodyWindow::BodyWindow(QWidget *parent) : QWidget(parent) {
-  layout = new QGridLayout(this);
-  layout->setMargin(0);
-  layout->setSpacing(0);
 
-  //setAttribute(Qt::WA_TransparentForMouseEvents, true);
-
-  battery = new QLabel();
-  battery->setStyleSheet("QLabel { font-size: 200px; }");
-  battery->setAlignment(Qt::AlignTop | Qt::AlignRight);
-
-  layout->addWidget(battery,0,2);
-  //layout->addWidget(rightEye,0,2);
-  //layout->addWidget(leftEye,0,2);
-  //layout->addWidget(mouth,0,2);
-
-  QObject::connect(uiState(), &UIState::uiUpdate, this, &BodyWindow::updateState);
+FaceDotMatrix::FaceDotMatrix(QWidget* parent) : QWidget(parent) {
+  QPalette pal = QPalette();
+  pal.setColor(QPalette::Window, Qt::black);
+  setAutoFillBackground(true); 
+  setPalette(pal);
+  setAttribute(Qt::WA_TransparentForMouseEvents, true);
 }
 
-void BodyWindow::paintEvent(QPaintEvent *e) {
+void FaceDotMatrix::paintEvent(QPaintEvent *e) {
   QPainter painter(this);
-  QPen linepen(Qt::red);
+  QPen linepen(Qt::white);
   linepen.setCapStyle(Qt::RoundCap);
   linepen.setWidth(30);
   painter.setRenderHint(QPainter::Antialiasing,true);
   painter.setPen(linepen);
-  painter.drawPoint(200,200);
+  painter.drawPoint(width()/2, height()/2);
+}
+
+Eye::Eye(QWidget* parent) : FaceDotMatrix(parent) {
+}
+
+void Eye::paintEvent(QPaintEvent *e) {
+  QPainter painter(this);
+  QPen linepen(Qt::white);
+  linepen.setCapStyle(Qt::RoundCap);
+  linepen.setWidth(56);
+  painter.setRenderHint(QPainter::Antialiasing,true);
+  painter.setPen(linepen);
+  painter.drawPoint(width()/2+100, height()/2+100);
+}
+
+Mouth::Mouth(QWidget* parent) : FaceDotMatrix(parent) {
+}
+
+void Mouth::paintEvent(QPaintEvent *e) {
+  printf("%d %d\n", height(), width());
+  QPainter painter(this);
+  QPen linepen(Qt::black);
+  linepen.setCapStyle(Qt::RoundCap);
+  linepen.setWidth(30);
+  painter.setRenderHint(QPainter::Antialiasing,true);
+  painter.setPen(linepen);
+  painter.drawPoint(0,0);
+}
+
+
+BodyWindow::BodyWindow(QWidget *parent) : QWidget(parent) {
+  layout = new QGridLayout(this);
+
+  QPalette pal = QPalette();
+  pal.setColor(QPalette::Window, Qt::black);
+  setAutoFillBackground(true); 
+  setPalette(pal);
+
+  setAttribute(Qt::WA_TransparentForMouseEvents, true);
+
+  leftEye = new Eye(this);
+  rightEye = new Eye(this);
+  mouth = new Mouth(this);
+
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 0, 0);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 0, 1);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 0, 2);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 0, 3);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 0, 4);
+  
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 1, 0);
+  layout->addWidget(leftEye,1,1);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 1, 2);
+  layout->addWidget(rightEye,1,3);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 1, 4);
+
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 2, 0);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 2, 1);
+  layout->addWidget(mouth,2,2);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 2, 3);
+  layout->addItem(new QSpacerItem(1,1,QSizePolicy::Expanding,QSizePolicy::Expanding), 2, 4);
+  
+  
+
+  QObject::connect(uiState(), &UIState::uiUpdate, this, &BodyWindow::updateState);
 }
 
 void BodyWindow::updateState(const UIState &s) {
@@ -39,23 +94,8 @@ void BodyWindow::updateState(const UIState &s) {
     return;
   }
 
-  const SubMaster &sm = *(s.sm);
+  // const SubMaster &sm = *(s.sm);
 
   // TODO: use carState.standstill when that's fixed
   //const bool standstill = std::abs(sm["carState"].getCarState().getVEgo()) < 0.01;
-
-  battery->setText(generateBatteryText(sm["carState"].getCarState().getFuelGauge()));
-}
-
-QString BodyWindow::generateBatteryText(float fuelGauge) {
-  int batteryOkDots = round(5*fuelGauge);
-  int batteryDotsRemain = 5 - batteryOkDots;
-  QString batteryDotsText = "<font color=\"white\">";
-  for (int i=0; i<batteryOkDots; i++)
-    batteryDotsText+="·";
-  batteryDotsText+="</font><font color=\"grey\">";
-  for (int i=0; i<batteryDotsRemain; i++)
-    batteryDotsText+="·";
-  batteryDotsText+="</font>";
-  return batteryDotsText;
 }

--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -8,7 +8,7 @@
 
 FaceDotMatrix::FaceDotMatrix(QWidget* parent) : QWidget(parent) {
   QPalette pal = QPalette();
-  pal.setColor(QPalette::Window, Qt::yellow);
+  pal.setColor(QPalette::Window, Qt::black);
   setAutoFillBackground(true); 
   setPalette(pal);
   setAttribute(Qt::WA_TransparentForMouseEvents, true);
@@ -16,7 +16,7 @@ FaceDotMatrix::FaceDotMatrix(QWidget* parent) : QWidget(parent) {
 
 void FaceDotMatrix::paintEvent(QPaintEvent *e) {}
 
-void FaceDotMatrix::paintMatrix(int a[4][4]) {
+void FaceDotMatrix::paintMatrix(float a[4][4]) {
   QPainter painter(this);
   QPen linepen(Qt::white);
   linepen.setCapStyle(Qt::RoundCap);
@@ -28,10 +28,19 @@ void FaceDotMatrix::paintMatrix(int a[4][4]) {
   int xOffset = (width()/2) - 2*m;
   int yOffset = (height()/2) - 2*m;
 
-  for (int i = 0; i<4; i++) {
-    painter.drawPoint(xOffset + i*m + m/2, yOffset + i*m + m/2);
+  float lastPenStrength = 0; // to save calls to change color.
+  for (int j = 0; j<4; j++) {
+    for (int i = 0; i<4; i++) {
+      float p = a[i][j];
+      if (p == 0) continue;
+      if (p != lastPenStrength) {
+        linepen.setColor(QColor(255*p,255*p,255*p));
+        painter.setPen(linepen);
+        lastPenStrength = p;
+      }
+      painter.drawPoint(xOffset + i*m + m/2, yOffset + j*m + m/2);
+    }
   }
-
   
 }
 
@@ -41,9 +50,9 @@ Eye::Eye(QWidget* parent) : FaceDotMatrix(parent) {
 }
 
 void Eye::paintEvent(QPaintEvent *e) {
-  int a[4][4] = {
+  float a[4][4] = {
     0,1,1,0,
-    1,1,1,1,
+    1,0.2,0.5,1,
     1,1,1,1,
     0,1,1,0
   };

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -11,6 +11,9 @@ class FaceDotMatrix : public QWidget {
 
 public:
   FaceDotMatrix(QWidget* parent = 0);
+  int dotMargin;
+  int dotWidth;
+  int dotsPerSpace;
 
 protected:
   virtual void paintEvent(QPaintEvent *event);

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -6,6 +6,37 @@
 
 #include "selfdrive/ui/ui.h"
 
+class FaceDotMatrix : public QWidget {
+  Q_OBJECT
+
+public:
+  FaceDotMatrix(QWidget* parent = 0);
+
+protected:
+  virtual void paintEvent(QPaintEvent *event);
+};
+
+
+class Eye : public FaceDotMatrix {
+  Q_OBJECT
+
+public:
+  Eye(QWidget* parent = 0);
+
+protected:
+  void paintEvent(QPaintEvent *event);
+};
+
+class Mouth : public FaceDotMatrix {
+  Q_OBJECT
+
+public:
+  Mouth(QWidget* parent = 0);
+
+protected:
+  void paintEvent(QPaintEvent *event);
+};
+
 class BodyWindow : public QWidget {
   Q_OBJECT
 
@@ -14,14 +45,9 @@ public:
 
 private:
   QGridLayout *layout;
-  QLabel *battery;
-
-  int batteryDots;
-
-  QString generateBatteryText(float fuelGauge);
-
-protected:
-  void paintEvent(QPaintEvent *event);
+  Eye *leftEye;
+  Eye *rightEye;
+  Mouth *mouth;
 
 private slots:
   void updateState(const UIState &s);

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -13,7 +13,6 @@ public:
   FaceDotMatrix(QWidget* parent = 0);
   int dotMargin;
   int dotSize;
-  int dotsPerSpace;
 
 protected:
   void paintMatrix(int a[4][4]);

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -12,10 +12,11 @@ class FaceDotMatrix : public QWidget {
 public:
   FaceDotMatrix(QWidget* parent = 0);
   int dotMargin;
-  int dotWidth;
+  int dotSize;
   int dotsPerSpace;
 
 protected:
+  void paintMatrix(int a[4][4]);
   virtual void paintEvent(QPaintEvent *event);
 };
 
@@ -25,6 +26,10 @@ class Eye : public FaceDotMatrix {
 
 public:
   Eye(QWidget* parent = 0);
+  bool isOpen;
+  
+public slots:
+  void updateState(const UIState &s);
 
 protected:
   void paintEvent(QPaintEvent *event);

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -1,18 +1,27 @@
 #pragma once
 
-#include <QMovie>
+#include <QGridLayout>
 #include <QLabel>
+#include <QPainter>
 
 #include "selfdrive/ui/ui.h"
 
-class BodyWindow : public QLabel {
+class BodyWindow : public QWidget {
   Q_OBJECT
 
 public:
   BodyWindow(QWidget* parent = 0);
 
 private:
-  QMovie *awake, *sleep;
+  QGridLayout *layout;
+  QLabel *battery;
+
+  int batteryDots;
+
+  QString generateBatteryText(float fuelGauge);
+
+protected:
+  void paintEvent(QPaintEvent *event);
 
 private slots:
   void updateState(const UIState &s);

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -15,7 +15,7 @@ public:
   int dotSize;
 
 protected:
-  void paintMatrix(int a[4][4]);
+  void paintMatrix(float a[4][4]);
   virtual void paintEvent(QPaintEvent *event);
 };
 


### PR DESCRIPTION
Partially replaces https://github.com/commaai/openpilot/pull/24383

> Nice, I was going to do this soon! Here's the design we have (ignore the arrow). The whole body UI is on a grid system, but I started with GIFs for the face at first for simplicity. Let's break this up into two PR's:
> 
> * implementing the grid system in the UI (with both faces)
> * adding the battery indicator from this design
> 
> ![image](https://user-images.githubusercontent.com/8762862/166123481-3ae592bc-b553-4829-8b4f-914798ec4dc9.png)

This PR attempts to port the current body UI into a grid per some kind of architecture like so (accidentally drew less columns and thus the battery is in the wrong spot but you get the idea of how im thinking about it):

![grid_face](https://user-images.githubusercontent.com/175305/166170702-985b28be-fb1e-458c-8b6e-9e8bf2193ba8.png)

this PR wont include the battery, it's just there in the drawing, i will make another PR for the battery (currently i have code for it using center dots and it looks almost perfect, but probably better to use qpainter or graphicsscene). I dont know which to use for drawing but i think because it's so simple, i should use qpainter.