### PR TITLE
Chrysler: add ACC fault signal

### DIFF
--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -48,8 +48,8 @@ class CarState(CarStateBase):
     ret.steeringRateDeg = cp.vl["STEERING"]["STEERING_RATE"]
     ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(cp.vl["GEAR"]["PRNDL"], None))
 
-    ret.cruiseState.enabled = cp.vl["ACC_2"]["ACC_STATUS_2"] == 7  # ACC is green
-    ret.cruiseState.available = cp.vl["ACC_2"]["ACC_STATUS_2"] != 1  # ACC is white
+    ret.cruiseState.enabled = cp.vl["ACC_2"]["ACC_STATUS_2"] == 7  # ACC is green.
+    ret.cruiseState.available = ret.cruiseState.enabled  # FIXME: for now same as enabled
     ret.cruiseState.speed = cp.vl["DASHBOARD"]["ACC_SPEED_CONFIG_KPH"] * CV.KPH_TO_MS
     # CRUISE_STATE is a three bit msg, 0 is off, 1 and 2 are Non-ACC mode, 3 and 4 are ACC mode, find if there are other states too
     ret.cruiseState.nonAdaptive = cp.vl["DASHBOARD"]["CRUISE_STATE"] in (1, 2)

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -94,6 +94,7 @@ class CarState(CarStateBase):
       ("STEERING_RATE", "STEERING"),
       ("TURN_SIGNALS", "STEERING_LEVERS"),
       ("ACC_STATUS_2", "ACC_2"),
+      ("ACC_FAULTED", "ACC_2"),
       ("HIGH_BEAM_FLASH", "STEERING_LEVERS"),
       ("ACC_SPEED_CONFIG_KPH", "DASHBOARD"),
       ("CRUISE_STATE", "DASHBOARD"),

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -49,7 +49,7 @@ class CarState(CarStateBase):
     ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(cp.vl["GEAR"]["PRNDL"], None))
 
     ret.cruiseState.enabled = cp.vl["ACC_2"]["ACC_STATUS_2"] == 7  # ACC is green
-    ret.cruiseState.available = cp.vl["ACC_2"]["ACC_STATUS_2"] == 3  # ACC is white
+    ret.cruiseState.available = cp.vl["ACC_2"]["ACC_STATUS_2"] != 1  # ACC is white
     ret.cruiseState.speed = cp.vl["DASHBOARD"]["ACC_SPEED_CONFIG_KPH"] * CV.KPH_TO_MS
     # CRUISE_STATE is a three bit msg, 0 is off, 1 and 2 are Non-ACC mode, 3 and 4 are ACC mode, find if there are other states too
     ret.cruiseState.nonAdaptive = cp.vl["DASHBOARD"]["CRUISE_STATE"] in (1, 2)

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -53,6 +53,7 @@ class CarState(CarStateBase):
     ret.cruiseState.speed = cp.vl["DASHBOARD"]["ACC_SPEED_CONFIG_KPH"] * CV.KPH_TO_MS
     # CRUISE_STATE is a three bit msg, 0 is off, 1 and 2 are Non-ACC mode, 3 and 4 are ACC mode, find if there are other states too
     ret.cruiseState.nonAdaptive = cp.vl["DASHBOARD"]["CRUISE_STATE"] in (1, 2)
+    ret.accFaulted = cp.vl["ACC_2"]["ACC_FAULTED"] == 1
 
     ret.steeringTorque = cp.vl["EPS_STATUS"]["TORQUE_DRIVER"]
     ret.steeringTorqueEps = cp.vl["EPS_STATUS"]["TORQUE_MOTOR"]
@@ -69,7 +70,6 @@ class CarState(CarStateBase):
     self.lkas_counter = cp_cam.vl["LKAS_COMMAND"]["COUNTER"]
     self.lkas_car_model = cp_cam.vl["LKAS_HUD"]["CAR_MODEL"]
     self.lkas_status_ok = cp_cam.vl["LKAS_HEARTBIT"]["LKAS_STATUS_OK"]
-    self.acc_faulted = cp.vl["ACC_2"]["ACC_FAULTED"] == 1
 
     return ret
 

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -48,8 +48,8 @@ class CarState(CarStateBase):
     ret.steeringRateDeg = cp.vl["STEERING"]["STEERING_RATE"]
     ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(cp.vl["GEAR"]["PRNDL"], None))
 
-    ret.cruiseState.enabled = cp.vl["ACC_2"]["ACC_STATUS_2"] == 7  # ACC is green.
-    ret.cruiseState.available = ret.cruiseState.enabled  # FIXME: for now same as enabled
+    ret.cruiseState.enabled = cp.vl["ACC_2"]["ACC_STATUS_2"] == 7  # ACC is green
+    ret.cruiseState.available = cp.vl["ACC_2"]["ACC_STATUS_2"] == 3  # ACC is white
     ret.cruiseState.speed = cp.vl["DASHBOARD"]["ACC_SPEED_CONFIG_KPH"] * CV.KPH_TO_MS
     # CRUISE_STATE is a three bit msg, 0 is off, 1 and 2 are Non-ACC mode, 3 and 4 are ACC mode, find if there are other states too
     ret.cruiseState.nonAdaptive = cp.vl["DASHBOARD"]["CRUISE_STATE"] in (1, 2)
@@ -69,6 +69,7 @@ class CarState(CarStateBase):
     self.lkas_counter = cp_cam.vl["LKAS_COMMAND"]["COUNTER"]
     self.lkas_car_model = cp_cam.vl["LKAS_HUD"]["CAR_MODEL"]
     self.lkas_status_ok = cp_cam.vl["LKAS_HEARTBIT"]["LKAS_STATUS_OK"]
+    self.acc_faulted = cp.vl["ACC_2"]["ACC_FAULTED"] == 1
 
     return ret
 

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -53,7 +53,7 @@ class CarState(CarStateBase):
     ret.cruiseState.speed = cp.vl["DASHBOARD"]["ACC_SPEED_CONFIG_KPH"] * CV.KPH_TO_MS
     # CRUISE_STATE is a three bit msg, 0 is off, 1 and 2 are Non-ACC mode, 3 and 4 are ACC mode, find if there are other states too
     ret.cruiseState.nonAdaptive = cp.vl["DASHBOARD"]["CRUISE_STATE"] in (1, 2)
-    ret.accFaulted = cp.vl["ACC_2"]["ACC_FAULTED"] == 1
+    ret.accFaulted = cp.vl["ACC_2"]["ACC_FAULTED"] != 0
 
     ret.steeringTorque = cp.vl["EPS_STATUS"]["TORQUE_DRIVER"]
     ret.steeringTorqueEps = cp.vl["EPS_STATUS"]["TORQUE_MOTOR"]

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -4,6 +4,8 @@ from selfdrive.car.chrysler.values import CAR
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint, get_safety_config
 from selfdrive.car.interfaces import CarInterfaceBase
 
+EventName = car.CarEvent.EventName
+
 
 class CarInterface(CarInterfaceBase):
   @staticmethod
@@ -56,7 +58,9 @@ class CarInterface(CarInterfaceBase):
     events = self.create_common_events(ret, extra_gears=[car.CarState.GearShifter.low])
 
     if ret.vEgo < self.CP.minSteerSpeed:
-      events.add(car.CarEvent.EventName.belowSteerSpeed)
+      events.add(EventName.belowSteerSpeed)
+    if self.CS.acc_faulted:
+      events.add(EventName.accFaulted)
 
     ret.events = events.to_msg()
 

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -4,8 +4,6 @@ from selfdrive.car.chrysler.values import CAR
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint, get_safety_config
 from selfdrive.car.interfaces import CarInterfaceBase
 
-EventName = car.CarEvent.EventName
-
 
 class CarInterface(CarInterfaceBase):
   @staticmethod
@@ -58,9 +56,7 @@ class CarInterface(CarInterfaceBase):
     events = self.create_common_events(ret, extra_gears=[car.CarState.GearShifter.low])
 
     if ret.vEgo < self.CP.minSteerSpeed:
-      events.add(EventName.belowSteerSpeed)
-    if self.CS.acc_faulted:
-      events.add(EventName.accFaulted)
+      events.add(car.CarEvent.EventName.belowSteerSpeed)
 
     ret.events = events.to_msg()
 


### PR DESCRIPTION
Fills the CS.cruiseState.available signal, and add events for ACC faults

Car always starts with `ACC_STATUS_2` at 1, then goes to 3 when ACC is available (white icon). And when a fault occurs, `ACC_STATUS_2` goes to 1 for the rest of the drive, with `ACC_FAULTED` rising.

Seems to be a pretty rare occurrence:
```python
Total routes: 5020, with fault: 34
Total disengagements: 5557, causing fault: 25
```

One notable exception is the `JEEP GRAND CHEROKEE V6 2018`, where in each segment where `ACC_FAULTED` rose after gas disengagement, it recovered after 10 frames and the users were able to re-engage later in the drive. With all other cars the fault was permanent and the bit stayed high

Here's the breakdown per car for faults (all 20 Jeep faults recovered except 1):

```python
CHRYSLER PACIFICA HYBRID 2019: 884 disengagements, causing fault: 10
CHRYSLER PACIFICA HYBRID 2018: 858 disengagements, causing fault: 0
CHRYSLER PACIFICA 2018: 694 disengagements, causing fault: 0
JEEP GRAND CHEROKEE V6 2018: 783 disengagements, causing fault: 19
JEEP GRAND CHEROKEE 2019: 267 disengagements, causing fault: 1
CHRYSLER PACIFICA HYBRID 2017: 1867 disengagements, causing fault: 0
CHRYSLER PACIFICA 2020: 204 disengagements, causing fault: 1
```

Some plots: https://imgur.com/a/k8LpyPR