### PR TITLE
re-add x86/webcam checking for wide cam

### DIFF
--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -171,8 +171,8 @@ int main(int argc, char **argv) {
     assert(ret == 0);
   }
 
-  bool main_wide_camera = Params().getBool("EnableWideCamera");
-  bool use_extra_client = !main_wide_camera;  // set for single camera mode
+  bool main_wide_camera = Hardware::TICI() && Params().getBool("EnableWideCamera");
+  bool use_extra_client = main_wide_camera;  // set for single camera mode
 
   // cl init
   cl_device_id device_id = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT);


### PR DESCRIPTION
`main_wide_camera` bool convention is `Hardware::TICI() && Params().getBool("EnableWideCamera");` elsewhere in the code and tici checks are still important for comma zero/x86/webcam

![image](https://user-images.githubusercontent.com/7257172/166687969-a91f4abe-086e-4589-89ed-659cc599eb4e.png)


Also, the condition is reversed:
`!main_wide_camera; == selfdrive/modeld/modeld.cc: connected extra cam with buffer size: 0 (0 x 0)` if not TICI or EnableWideCamera = True