### PR TITLE
fix model.cc for x86 replay and webcam

### DIFF
--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -171,8 +171,8 @@ int main(int argc, char **argv) {
     assert(ret == 0);
   }
 
-  bool main_wide_camera = Params().getBool("EnableWideCamera");
-  bool use_extra_client = !main_wide_camera;  // set for single camera mode
+  bool main_wide_camera = Hardware::TICI() && Params().getBool("EnableWideCamera");
+  bool use_extra_client = main_wide_camera;  // set for single camera mode
 
   // cl init
   cl_device_id device_id = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT);


### PR DESCRIPTION
`Hardware::TICI() && Params().getBool("EnableWideCamera");` is used elsewhere in the codebase, removing such breaks x86/webcam, replay (debug/uiview.py), which also breaks comma CTF challenge.

The sign for `bool use_extra_client` was incorrect as well. `selfdrive/modeld/modeld.cc: vipc_client_extra no frame` is spammed with `!main_wide_camera` bool and the lane line/path is not drawn

Updated PR cc @pd0wm 

Now working as expected with this PR
![image](https://user-images.githubusercontent.com/7257172/166820287-d8153f57-ca1f-4bd6-aede-46aae549b974.png)
![image](https://user-images.githubusercontent.com/7257172/166822037-4385a3f1-6cf5-4999-8969-5687a1ccb30e.png)

