### PR TITLE
URLFile: raise exception if remote URL doesn't exist when using cache

### DIFF
--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -121,7 +121,7 @@ class URLFile:
         end = self.get_length() - 1
       else:
         end = min(self._pos + ll, self.get_length()) - 1
-      assert end > 0, "No data from {}".format(self._url)
+      assert end > 0, f"Remote file is empty or doesn't exist: {self._url}"
       if self._pos >= end:
         return b""
       headers.append(f"Range: bytes={self._pos}-{end}")

--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -87,6 +87,7 @@ class URLFile:
 
     file_begin = self._pos
     file_end = self._pos + ll if ll is not None else self.get_length()
+    assert file_end != -1, f"Remote file is empty or doesn't exist: {self._url}"
     #  We have to align with chunks we store. Position is the begginiing of the latest chunk that starts before or at our file
     position = (file_begin // CHUNK_SIZE) * CHUNK_SIZE
     response = b""
@@ -121,7 +122,6 @@ class URLFile:
         end = self.get_length() - 1
       else:
         end = min(self._pos + ll, self.get_length()) - 1
-      assert end > 0, f"Remote file is empty or doesn't exist: {self._url}"
       if self._pos >= end:
         return b""
       headers.append(f"Range: bytes={self._pos}-{end}")

--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -121,6 +121,7 @@ class URLFile:
         end = self.get_length() - 1
       else:
         end = min(self._pos + ll, self.get_length()) - 1
+      assert end > 0, "No data from {}".format(self._url)
       if self._pos >= end:
         return b""
       headers.append(f"Range: bytes={self._pos}-{end}")


### PR DESCRIPTION
Right now the behavior is assymetrical when you try to use `URLFile` on a link that doesn't exist when you turn on and off `FILEREADER_CACHE`.


Reproduce with:
```python
import os
from tools.lib.url_file import URLFile
os.environ["FILEREADER_CACHE"] = "1"
url_f = URLFile("https://commadataci.blob.core.windows.net/can_be_anything")
print(url_f.read())
```

No cache:
```python
Exception: Error 400 ['Connection: keep-alive'] (https://commadataci.blob.core.windows.net/can_be_anything): b'\xef\xbb\xbf<?xml version="1.0" encoding="utf-8"?><Error><Code>OutOfRangeInput</Code><Message>One of the request inputs is out of range.\nRequestId:08bb607c-601e-015c-402f-60318c000000\nTime:2022-05-05T03:25:38.9140945Z</Message></Error>'
```

With cache:

```python
b''
```