### PR TITLE
adding support for macos x64 acados

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,14 +61,22 @@ if arch == "aarch64" and TICI:
 
 USE_WEBCAM = os.getenv("USE_WEBCAM") is not None
 
+lib_path = ""
+tera_path = ""
+if arch == "Darwin" and real_arch == "i386":
+  lib_path = [Dir(f"#third_party/acados/x86_64/lib").abspath]
+  tera_path = Dir("#").abspath + f"/third_party/acados/x86_64/t_renderer"
+else:
+  lib_path = [Dir(f"#third_party/acados/{arch}/lib").abspath]
+  tera_path = Dir("#").abspath + f"/third_party/acados/{arch}/t_renderer"
+
 lenv = {
   "PATH": os.environ['PATH'],
-  "LD_LIBRARY_PATH": [Dir(f"#third_party/acados/{arch}/lib").abspath],
+  "LD_LIBRARY_PATH": lib_path,
   "PYTHONPATH": Dir("#").abspath + ":" + Dir("#pyextra/").abspath,
-
   "ACADOS_SOURCE_DIR": Dir("#third_party/acados/include/acados").abspath,
   "ACADOS_PYTHON_INTERFACE_PATH": Dir("#pyextra/acados_template").abspath,
-  "TERA_PATH": Dir("#").abspath + f"/third_party/acados/{arch}/t_renderer",
+  "TERA_PATH": tera_path
 }
 
 rpath = lenv["LD_LIBRARY_PATH"].copy()
@@ -118,7 +126,6 @@ else:
         "/System/Library/Frameworks/OpenGL.framework/Libraries",
       ]
     else:
-      print('test')
       libpath = [
         f"#third_party/libyuv/{yuv_dir}/lib",
         f"{brew_prefix}/lib",

--- a/SConstruct
+++ b/SConstruct
@@ -107,15 +107,27 @@ else:
   if arch == "Darwin":
     brew_prefix = subprocess.check_output(['brew', '--prefix'], encoding='utf8').strip()
     yuv_dir = "mac" if real_arch != "arm64" else "mac_arm64"
-    libpath = [
-      f"#third_party/libyuv/{yuv_dir}/lib",
-      f"{brew_prefix}/lib",
-      f"{brew_prefix}/Library",
-      f"{brew_prefix}/opt/openssl/lib",
-      f"{brew_prefix}/Cellar",
-      f"#third_party/acados/{arch}/lib",
-      "/System/Library/Frameworks/OpenGL.framework/Libraries",
-    ]
+    if real_arch == "arm64":
+      libpath = [
+        f"#third_party/libyuv/{yuv_dir}/lib",
+        f"{brew_prefix}/lib",
+        f"{brew_prefix}/Library",
+        f"{brew_prefix}/opt/openssl/lib",
+        f"{brew_prefix}/Cellar",
+        f"#third_party/acados/{arch}/lib",
+        "/System/Library/Frameworks/OpenGL.framework/Libraries",
+      ]
+    else:
+      print('test')
+      libpath = [
+        f"#third_party/libyuv/{yuv_dir}/lib",
+        f"{brew_prefix}/lib",
+        f"{brew_prefix}/Library",
+        f"{brew_prefix}/opt/openssl/lib",
+        f"{brew_prefix}/Cellar",
+        f"#third_party/acados/x86_64/lib",
+        "/System/Library/Frameworks/OpenGL.framework/Libraries",
+      ]
     cflags += ["-DGL_SILENCE_DEPRECATION"]
     cxxflags += ["-DGL_SILENCE_DEPRECATION"]
     cpppath += [


### PR DESCRIPTION
**Description**
macOS with i386 cpu couldn't build acados as it was looking for the Darwin files which is arm arch. Made new check for i386 cpu to use x64 directory.

**Verification** 
Built on macos with intel cpu

