### PR TITLE
Add timeout argument to test_processes

### DIFF
--- a/selfdrive/test/process_replay/README.md
+++ b/selfdrive/test/process_replay/README.md
@@ -5,7 +5,6 @@ Process replay is a regression test designed to identify any changes in the outp
 If the test fails, make sure that you didn't unintentionally change anything. If there are intentional changes, the reference logs will be updated.
 
 Use `test_processes.py` to run the test locally.
-Use `--longer-timeout` to increase the timeout of expected messages to 30 seconds when needed.
 
 Currently the following processes are tested:
 
@@ -15,6 +14,23 @@ Currently the following processes are tested:
 * calibrationd
 * ubloxd
 
+### Usage test_processes.py
+```
+Usage: test_processes.py [-h] [--whitelist-procs PROCS] [--whitelist-cars CARS] [--blacklist-procs PROCS]
+                         [--blacklist-cars CARS] [--ignore-fields FIELDS] [--ignore-msgs MSGS] [--timeout TIMEOUT]
+
+Regression test to identify changes in a process's output
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --whitelist-procs PROCS               Whitelist given processes from the test (e.g. controlsd)
+  --whitelist-cars WHITELIST_CARS       Whitelist given cars from the test (e.g. HONDA)
+  --blacklist-procs BLACKLIST_PROCS     Blacklist given processes from the test (e.g. controlsd)
+  --blacklist-cars BLACKLIST_CARS       Blacklist given cars from the test (e.g. HONDA)
+  --ignore-fields IGNORE_FIELDS         Extra fields or msgs to ignore (e.g. carState.events)
+  --ignore-msgs IGNORE_MSGS             Msgs to ignore (e.g. carEvents)
+  --timeout TIMEOUT                     Set timeout of incoming messages
+```
 ## Forks
 
 openpilot forks can use this test with their own reference logs

--- a/selfdrive/test/process_replay/README.md
+++ b/selfdrive/test/process_replay/README.md
@@ -1,10 +1,11 @@
-# process replay
+# Process replay
 
 Process replay is a regression test designed to identify any changes in the output of a process. This test replays a segment through individual processes and compares the output to a known good replay. Each make is represented in the test with a segment.
 
 If the test fails, make sure that you didn't unintentionally change anything. If there are intentional changes, the reference logs will be updated.
 
 Use `test_processes.py` to run the test locally.
+Use `--longer-timeout` to increase the timeout of expected messages to 30 seconds when needed.
 
 Currently the following processes are tested:
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -335,14 +335,16 @@ CONFIGS = [
 ]
 
 
-def replay_process(cfg, lr, fingerprint=None):
-  if "--longer-timeout" in sys.argv:
+def replay_process(cfg, lr, fingerprint=None, override_timeout=None):
+  if override_timeout is not None:
     global timeout
-    timeout = 30
+    timeout = override_timeout
+
   if cfg.fake_pubsubmaster:
     return python_replay_process(cfg, lr, fingerprint)
   else:
     return cpp_replay_process(cfg, lr, fingerprint)
+
 
 def setup_env(simulation=False):
   params = Params()

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -64,7 +64,7 @@ def test_process(cfg, lr, cmp_log_fn, ignore_fields=None, ignore_msgs=None, time
   cmp_log_path = cmp_log_fn if os.path.exists(cmp_log_fn) else BASE_URL + os.path.basename(cmp_log_fn)
   cmp_log_msgs = list(LogReader(cmp_log_path))
 
-  log_msgs = replay_process(cfg, lr, override_timeout=timeout)
+  log_msgs = replay_process(cfg, lr, timeout=timeout)
 
   # check to make sure openpilot is engaged in the route
   if cfg.proc_name == "controlsd":


### PR DESCRIPTION
Add --timeout TIMEOUT_SEC argument to test_processes to increase the expected messages timeout.
Useful when testing laikad messages since currently it takes just a bit more than 15 seconds to load in new data.

Also updated the readme by adding the usages of test_processes