### PR TITLE
tici: don't throttle the encoder

### DIFF
--- a/selfdrive/hardware/tici/hardware.py
+++ b/selfdrive/hardware/tici/hardware.py
@@ -468,6 +468,10 @@ class Tici(HardwareBase):
     sudo_write("performance", "/sys/class/devfreq/soc:qcom,memlat-cpu0/governor")
     sudo_write("performance", "/sys/class/devfreq/soc:qcom,memlat-cpu4/governor")
 
+    # *** VIDC (encoder) config ***
+    sudo_write("N", "/sys/kernel/debug/msm_vidc/clock_scaling")
+    sudo_write("Y", "/sys/kernel/debug/msm_vidc/disable_thermal_mitigation")
+
   def configure_modem(self):
     sim_id = self.get_sim_info().get('sim_id', '')
 


### PR DESCRIPTION
This halves the latency of the encoder and doesn't seem to draw more power.

The thermal mitigation I don't think is ever triggered reading the kernel (it will just kill the encoder), and it only affects "turbo mode", but no reason to have it. Decisions like not running the encoder shouldn't be in the kernel.