### PR TITLE
uploader: ensure requests.put gets file like object

### DIFF
--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import bz2
+import io
 import json
 import os
 import random
@@ -153,10 +154,11 @@ class Uploader():
         self.last_resp = FakeResponse()
       else:
         with open(fn, "rb") as f:
-          data = f.read()
-
           if key.endswith('.bz2') and not fn.endswith('.bz2'):
-            data = bz2.compress(data)
+            data = bz2.compress(f.read())
+            data = io.BytesIO(data)
+          else:
+            data = f
 
           self.last_resp = requests.put(url, data=data, headers=headers, timeout=10)
     except Exception as e:


### PR DESCRIPTION
Requests handles bytes differently from file like objects internally. Without the bytesIO the whole file seems to be uploaded in one chunk, causing the timeout to be hit for a 2MB qcam over 512kbit.

https://github.com/psf/requests/blob/main/requests/models.py#L518