### PR TITLE
Allow Kona_EV to use Radar when in OP long.

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1198,7 +1198,7 @@ DBC = {
   CAR.KIA_SORENTO: dbc_dict('hyundai_kia_generic', None), # Has 0x5XX messages, but different format
   CAR.KIA_STINGER: dbc_dict('hyundai_kia_generic', None),
   CAR.KONA: dbc_dict('hyundai_kia_generic', None),
-  CAR.KONA_EV: dbc_dict('hyundai_kia_generic', None),
+  CAR.KONA_EV: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.KONA_HEV: dbc_dict('hyundai_kia_generic', None),
   CAR.SANTA_FE: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar'),
   CAR.SANTA_FE_2022: dbc_dict('hyundai_kia_generic', None),


### PR DESCRIPTION
Route ID:
9cd125880f4d91a4|2022-05-08--00-39-15

When using Vision Only OP long the car tends to try to crash into the car ahead at certain speeds. I just dont use OP long due to how much better the stock radar performs. after allot of looking though the PR requests and issues I saw issue #22241 and #23461 and figured i could try to get my radar working with OP long. 

Even though Kona_EV cant be moved from legacy safety tag yet. #24306 the car can use the radar points to help operate when manually enabling OP long. by adding 'hyundai_kia_mando_front_radar'

