### PR TITLE
Tools: allow using plotjuggler on local data

### DIFF
--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -3,6 +3,7 @@ import re
 from urllib.parse import urlparse
 from collections import defaultdict
 from itertools import chain
+from typing import Optional
 
 from tools.lib.auth_config import get_token
 from tools.lib.api import CommaApi
@@ -196,7 +197,11 @@ class SegmentName:
   # TODO: add constructor that takes dongle_id, time_str, segment_num and then create instances
   # of this class instead of manually constructing a segment name (use canonical_name prop instead)
   def __init__(self, name_str: str, allow_route_name=False):
-    self._name_str = name_str
+    data_dir_path_separator_index = name_str.rsplit("|", 1)[0].rfind("/")
+    use_data_dir = (data_dir_path_separator_index != -1) and ("|" in name_str)
+    self._name_str = name_str[data_dir_path_separator_index + 1:] if use_data_dir else name_str
+    self._data_dir = name_str[:data_dir_path_separator_index] if use_data_dir else None
+
     seg_num_delim = "--" if self._name_str.count("--") == 2 else "/"
     name_parts = self._name_str.rsplit(seg_num_delim, 1)
     if allow_route_name and len(name_parts) == 1:
@@ -219,5 +224,8 @@ class SegmentName:
 
   @property
   def route_name(self) -> RouteName: return self._route_name
+
+  @property
+  def data_dir(self) -> Optional[str]: return self._data_dir
 
   def __str__(self) -> str: return self._canonical_name

--- a/tools/lib/tests/test_route_library.py
+++ b/tools/lib/tests/test_route_library.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import unittest
+from collections import namedtuple
+
+from tools.lib.route import SegmentName
+
+class TestRouteLibrary(unittest.TestCase):
+  def test_segment_name_formats(self):
+    Case = namedtuple('Case', ['input', 'expected_route', 'expected_segment_num', 'expected_data_dir'])
+
+    cases = [ Case("4cf7a6ad03080c90|2021-09-29--13-46-36", "4cf7a6ad03080c90|2021-09-29--13-46-36", -1, None),
+              Case("4cf7a6ad03080c90/2021-09-29--13-46-36--1", "4cf7a6ad03080c90|2021-09-29--13-46-36", 1, None),
+              Case("4cf7a6ad03080c90|2021-09-29--13-46-36/2", "4cf7a6ad03080c90|2021-09-29--13-46-36", 2, None),
+              Case("4cf7a6ad03080c90/2021-09-29--13-46-36/3", "4cf7a6ad03080c90|2021-09-29--13-46-36", 3, None),
+              Case("/data/media/0/realdata/4cf7a6ad03080c90|2021-09-29--13-46-36", "4cf7a6ad03080c90|2021-09-29--13-46-36", -1, "/data/media/0/realdata"),
+              Case("/data/media/0/realdata/4cf7a6ad03080c90|2021-09-29--13-46-36--1", "4cf7a6ad03080c90|2021-09-29--13-46-36", 1, "/data/media/0/realdata"),
+              Case("/data/media/0/realdata/4cf7a6ad03080c90|2021-09-29--13-46-36/2", "4cf7a6ad03080c90|2021-09-29--13-46-36", 2, "/data/media/0/realdata") ]
+
+    def _validate(case):
+      route_or_segment_name = case.input
+
+      s = SegmentName(route_or_segment_name, allow_route_name=True)
+
+      self.assertEqual(str(s.route_name), case.expected_route)
+      self.assertEqual(s.segment_num, case.expected_segment_num)
+      self.assertEqual(s.data_dir, case.expected_data_dir)
+
+    for case in cases:
+      _validate(case)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -88,7 +88,7 @@ def juggle_route(route_or_segment_name, segment_count, qlog, can, layout, dbc=No
     if route_or_segment_name.segment_num != -1 and segment_count is None:
       segment_count = 1
 
-    r = Route(route_or_segment_name.route_name.canonical_name)
+    r = Route(route_or_segment_name.route_name.canonical_name, route_or_segment_name.data_dir)
     logs = r.qlog_paths() if qlog else r.log_paths()
 
   segment_end = segment_start + segment_count if segment_count else None


### PR DESCRIPTION
https://github.com/commaai/openpilot/pull/24008

example of setting up device data in expected format  
```bash
# on device
cd /data/media/0/realdata; for f in $(ls | grep "^2022"); do echo mv $f "ffffffffffffffff|$f"; done
# after copying to pc or mounting to pc
./tools/plotjuggler/juggle.py '/home/ntegan/data/ffffffffffffffff|2022-04-20--16-20-00'
```

example of putting data back in default format
```bash
cd /data/media/0/realdata; for f in $(ls | grep -E 'f{16}\|'); do echo mv $f $(sed -E 's/^f{16}\|(.*)/\1/g' <<<$f); done
```

example of zero padding segment nums for clean rlog/hevc concattenating
```bash
# this moves a segment like "2022-05-17--15-27-45--9" to "2022-05-17--15-27-45--009"
cd /data/media/0/realdata; for f in $(ls | grep '^2022'); do a=($(sed -E 's/^(.*--.*--)(.*)/\1 \2/g' <<<$f)); echo mv $f "${a[0]}$(printf "%03d" ${a[1]})"; done
```

example of reverting zero padding segment nums
```bash
# this moves a segment like "2022-05-17--15-27-45--009" to "2022-05-17--15-27-45--9"
cd /data/media/0/realdata; for f in $(ls | grep '^2022'); do a=($(sed -E 's/^(.*--.*--)(.*)/\1 \2/g' <<<$f));  echo mv $f "${a[0]}$(sed -E 's/^[0]*(.*)/\1/g' <<<${a[1]})"; done
```

NOTE:
* doesn't support "/" dongle/time delimiter when using data dir, e.g. "/home/Downloads/4cf7a6ad03080c90/2021-09-29--13-46-36/3"