### PR TITLE
tools: add link to jungle repo

### DIFF
--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -61,7 +61,7 @@ cd selfdrive/ui && ./watch3
 
 ## Stream CAN messages to your device
 
-Replay CAN messages as they were recorded using a [panda jungle](https://comma.ai/shop/products/panda-jungle). The jungle has 6x OBD-C ports for connecting all your comma devices.
+Replay CAN messages as they were recorded using a [panda jungle](https://comma.ai/shop/products/panda-jungle). The jungle has 6x OBD-C ports for connecting all your comma devices. Check out the [jungle repo](https://github.com/commaai/panda_jungle) for more info.
 
 `can_replay.py` is a convenient script for when any CAN data will do.
 
@@ -72,5 +72,3 @@ MOCK=1 selfdrive/boardd/tests/boardd_old.py
 # In another terminal:
 selfdrive/ui/replay/replay <route-name>
 ```
-
-Note that you'll need to ensure that the proper [udev rules](https://github.com/commaai/panda_jungle#udev-rules) have been set up.

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -72,3 +72,5 @@ MOCK=1 selfdrive/boardd/tests/boardd_old.py
 # In another terminal:
 selfdrive/ui/replay/replay <route-name>
 ```
+
+Note that you'll need to ensure that the proper [udev rules](https://github.com/commaai/panda_jungle#udev-rules) have been set up.


### PR DESCRIPTION
When using a Panda Jungle for the first time, there is a helpful console message to clone the panda jungle repo, along with a suggested console command. Users may simply run the command and forego adding the udev rules while expecting the jungle to work. If the proper udev rules haven't been added, the script simply sits there and can confuse the user as it appears to be working, when it is not.