### PR TITLE
Prefix messages for process replay

### DIFF
--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -30,8 +30,6 @@ def manager_init() -> None:
   # update system time from panda
   set_time(cloudlog)
 
-  os.environ['OPENPILOIT_PREFIX'] = "MANAGER"
-
   # save boot log
   subprocess.call("./bootlog", cwd=os.path.join(BASEDIR, "selfdrive/loggerd"))
 

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -30,6 +30,8 @@ def manager_init() -> None:
   # update system time from panda
   set_time(cloudlog)
 
+  os.environ['OPENPILOIT_PREFIX'] = "MANAGER"
+
   # save boot log
   subprocess.call("./bootlog", cwd=os.path.join(BASEDIR, "selfdrive/loggerd"))
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -5,7 +5,6 @@ import sys
 import threading
 import time
 import signal
-import uuid
 from collections import namedtuple
 
 import capnp
@@ -339,7 +338,6 @@ CONFIGS = [
 
 
 def replay_process(cfg, lr, fingerprint=None):
-  os.environ['OPENPILOIT_PREFIX'] = str(uuid.uuid4())
   if cfg.fake_pubsubmaster:
     return python_replay_process(cfg, lr, fingerprint)
   else:

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 import signal
+import uuid
 from collections import namedtuple
 
 import capnp
@@ -338,6 +339,7 @@ CONFIGS = [
 
 
 def replay_process(cfg, lr, fingerprint=None):
+  os.environ['OPENPILOIT_PREFIX'] = str(uuid.uuid4())
   if cfg.fake_pubsubmaster:
     return python_replay_process(cfg, lr, fingerprint)
   else:


### PR DESCRIPTION
Add a prefixing ID in the file structure path to messages
Tested by:
* running test_processes
* running on device
* running latency logger on produced logs 

Uses Cereal from PR: https://github.com/commaai/cereal/pull/299