### PR TITLE
Toyota: correct weight for the Prius V

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -46,7 +46,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.78
       ret.steerRatio = 17.4
       tire_stiffness_factor = 0.5533
-      ret.mass = 3340. * CV.LB_TO_KG + STD_CARGO_KG 
+      ret.mass = 3340. * CV.LB_TO_KG + STD_CARGO_KG
       set_lat_tune(ret.lateralTuning, LatTunes.TORQUE, MAX_LAT_ACCEL=1.8, FRICTION=0.06)
 
     elif candidate in (CAR.RAV4, CAR.RAV4H):

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -46,7 +46,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.78
       ret.steerRatio = 17.4
       tire_stiffness_factor = 0.5533
-      ret.mass = 4387. * CV.LB_TO_KG + STD_CARGO_KG
+      ret.mass = 3340. * CV.LB_TO_KG + STD_CARGO_KG  # from Toyota eBrochures 
       set_lat_tune(ret.lateralTuning, LatTunes.TORQUE, MAX_LAT_ACCEL=1.8, FRICTION=0.06)
 
     elif candidate in (CAR.RAV4, CAR.RAV4H):

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -46,7 +46,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.78
       ret.steerRatio = 17.4
       tire_stiffness_factor = 0.5533
-      ret.mass = 3340. * CV.LB_TO_KG + STD_CARGO_KG  # from Toyota eBrochures 
+      ret.mass = 3340. * CV.LB_TO_KG + STD_CARGO_KG 
       set_lat_tune(ret.lateralTuning, LatTunes.TORQUE, MAX_LAT_ACCEL=1.8, FRICTION=0.06)
 
     elif candidate in (CAR.RAV4, CAR.RAV4H):


### PR DESCRIPTION
Prius V's weight is incorrect in `interface.py`, correct weight updated from https://www.toyotacertified.com/content/dam/tcuv/sections/brochures/en/prius-v/2017_priusv_ebrochure.pdf