### PR TITLE
Fix gcc-arm-embedded for m1 mac

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -54,7 +54,7 @@ brew "protobuf-c"
 brew "swig"
 EOS
 
-# Install an older gcc-arm-embedded for M1 Mac Silicon support with Xcode 13.3~
+# Install gcc-arm-embedded 10.3-2021.10. 11.x is broken on M1 Macs with Xcode 13.3~
 brew uninstall gcc-arm-embedded || true
 curl -L https://github.com/Homebrew/homebrew-cask/raw/d407663b8017a0a062c7fc0b929faf2e16abd1ff/Casks/gcc-arm-embedded.rb > /tmp/gcc-arm-embedded.rb
 brew install --cask /tmp/gcc-arm-embedded.rb

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -56,9 +56,9 @@ EOS
 
 # Install an older gcc-arm-embedded for M1 Mac Silicon support with Xcode 13.3~
 brew uninstall gcc-arm-embedded || true
-curl -L https://github.com/Homebrew/homebrew-cask/raw/d407663b8017a0a062c7fc0b929faf2e16abd1ff/Casks/gcc-arm-embedded.rb > gcc-arm-embedded.rb
-brew install --cask gcc-arm-embedded.rb
-rm gcc-arm-embedded.rb
+curl -L https://github.com/Homebrew/homebrew-cask/raw/d407663b8017a0a062c7fc0b929faf2e16abd1ff/Casks/gcc-arm-embedded.rb > /tmp/gcc-arm-embedded.rb
+brew install --cask /tmp/gcc-arm-embedded.rb
+rm /tmp/gcc-arm-embedded.rb
 
 echo "[ ] finished brew install t=$SECONDS"
 

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -52,8 +52,13 @@ brew "zeromq"
 brew "protobuf"
 brew "protobuf-c"
 brew "swig"
-cask "gcc-arm-embedded"
 EOS
+
+# Install an older gcc-arm-embedded for M1 Mac Silicon support with Xcode 13.3~
+brew uninstall gcc-arm-embedded || true
+curl -L https://github.com/Homebrew/homebrew-cask/raw/d407663b8017a0a062c7fc0b929faf2e16abd1ff/Casks/gcc-arm-embedded.rb > gcc-arm-embedded.rb
+brew install --cask gcc-arm-embedded.rb
+rm gcc-arm-embedded.rb
 
 echo "[ ] finished brew install t=$SECONDS"
 


### PR DESCRIPTION
Panda compile fails with M1 Mac running later Xcode:
https://github.com/commaai/openpilot/issues/24029

Using an older version of gcc-arm-embedded resolves the issue until they can fix it:https://discord.com/channels/469524606043160576/954493346250887168/974324203983626260

@pd0wm mentioned just adding it to the Mac script:
https://discord.com/channels/469524606043160576/954493346250887168/974326978549284934

Note that this still needs fixed:
https://github.com/commaai/openpilot/issues/23830