### PR TITLE
make debayer faster

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -38,10 +38,10 @@ public:
              "-cl-fast-relaxed-math -cl-denorms-are-zero "
              "-DFRAME_WIDTH=%d -DFRAME_HEIGHT=%d -DFRAME_STRIDE=%d -DFRAME_OFFSET=%d "
              "-DRGB_WIDTH=%d -DRGB_HEIGHT=%d -DRGB_STRIDE=%d "
-             "-DBAYER_FLIP=%d -DHDR=%d -DCAM_NUM=%d",
+             "-DBAYER_FLIP=%d -DHDR=%d -DCAM_NUM=%d%s",
              ci->frame_width, ci->frame_height, ci->frame_stride, ci->frame_offset,
              b->rgb_width, b->rgb_height, b->rgb_stride,
-             ci->bayer_flip, ci->hdr, s->camera_num);
+             ci->bayer_flip, ci->hdr, s->camera_num, s->camera_num==1 ? " -DVIGNETTING" : "");
     const char *cl_file = "cameras/real_debayer.cl";
     cl_program prg_debayer = cl_program_from_file(context, device_id, cl_file, args);
     krnl_ = CL_CHECK_ERR(clCreateKernel(prg_debayer, "debayer10", &err));

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -51,6 +51,7 @@ public:
   void queue(cl_command_queue q, cl_mem cam_buf_cl, cl_mem buf_cl, int width, int height, float gain, float black_level, cl_event *debayer_event) {
     CL_CHECK(clSetKernelArg(krnl_, 0, sizeof(cl_mem), &cam_buf_cl));
     CL_CHECK(clSetKernelArg(krnl_, 1, sizeof(cl_mem), &buf_cl));
+    CL_CHECK(clSetKernelArg(krnl_, 2, sizeof(float), &black_level));
 
     const size_t globalWorkSize[] = {size_t(width / 2), size_t(height / 2)};
     const int debayer_local_worksize = 16;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -54,10 +54,8 @@ public:
 
     const size_t globalWorkSize[] = {size_t(width / 2), size_t(height / 2)};
     const int debayer_local_worksize = 16;
-    constexpr int localMemSize = (debayer_local_worksize * 2 + 2) * (debayer_local_worksize * 2 + 2) * 2;
+    CL_CHECK(clSetKernelArg(krnl_, 2, sizeof(float), &black_level));
     const size_t localWorkSize[] = {debayer_local_worksize, debayer_local_worksize};
-    CL_CHECK(clSetKernelArg(krnl_, 2, localMemSize, 0));
-    CL_CHECK(clSetKernelArg(krnl_, 3, sizeof(float), &black_level));
     CL_CHECK(clEnqueueNDRangeKernel(q, krnl_, 2, NULL, globalWorkSize, localWorkSize, 0, 0, debayer_event));
   }
 
@@ -165,7 +163,7 @@ bool CameraBuf::acquire() {
   }
 
   clWaitForEvents(1, &event);
-  printf("debayer %f\n", (millis_since_boot() - start_time));
+  //printf("debayer %f\n", (millis_since_boot() - start_time));
   CL_CHECK(clReleaseEvent(event));
 
   cur_frame_data.processing_time = (millis_since_boot() - start_time) / 1000.0;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -54,7 +54,6 @@ public:
 
     const size_t globalWorkSize[] = {size_t(width / 2), size_t(height / 2)};
     const int debayer_local_worksize = 16;
-    CL_CHECK(clSetKernelArg(krnl_, 2, sizeof(float), &black_level));
     const size_t localWorkSize[] = {debayer_local_worksize, debayer_local_worksize};
     CL_CHECK(clEnqueueNDRangeKernel(q, krnl_, 2, NULL, globalWorkSize, localWorkSize, 0, 0, debayer_event));
   }
@@ -163,7 +162,7 @@ bool CameraBuf::acquire() {
   }
 
   clWaitForEvents(1, &event);
-  //printf("debayer %f\n", (millis_since_boot() - start_time));
+  printf("debayer %f\n", (millis_since_boot() - start_time));
   CL_CHECK(clReleaseEvent(event));
 
   cur_frame_data.processing_time = (millis_since_boot() - start_time) / 1000.0;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -165,6 +165,7 @@ bool CameraBuf::acquire() {
   }
 
   clWaitForEvents(1, &event);
+  printf("debayer %f\n", (millis_since_boot() - start_time));
   CL_CHECK(clReleaseEvent(event));
 
   cur_frame_data.processing_time = (millis_since_boot() - start_time) / 1000.0;

--- a/selfdrive/camerad/cameras/camera_common.cc
+++ b/selfdrive/camerad/cameras/camera_common.cc
@@ -51,7 +51,6 @@ public:
   void queue(cl_command_queue q, cl_mem cam_buf_cl, cl_mem buf_cl, int width, int height, float gain, float black_level, cl_event *debayer_event) {
     CL_CHECK(clSetKernelArg(krnl_, 0, sizeof(cl_mem), &cam_buf_cl));
     CL_CHECK(clSetKernelArg(krnl_, 1, sizeof(cl_mem), &buf_cl));
-    CL_CHECK(clSetKernelArg(krnl_, 2, sizeof(float), &black_level));
 
     const size_t globalWorkSize[] = {size_t(width / 2), size_t(height / 2)};
     const int debayer_local_worksize = 16;

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -83,72 +83,36 @@ inline half get_k(half a, half b, half c, half d) {
 
 __kernel void debayer10(const __global uchar * in,
                         __global uchar * out,
-                        __local half * cached,
                         float black_level
                        )
 {
   const int gid_x = get_global_id(0);
   const int gid_y = get_global_id(1);
 
-  const int lid_x = get_local_id(0);
-  const int lid_y = get_local_id(1);
-
-  const int localRowLen = mad24(get_local_size(0), 2, 2); // 2 padding
-  const int localColLen = mad24(get_local_size(1), 2, 2);
-
-  const int x_global = mul24(gid_x, 2);
-  const int y_global = mul24(gid_y, 2);
-
-  const int x_local = mad24(lid_x, 2, 1);
-  const int y_local = mad24(lid_y, 2, 1);
-
-  const int x_global_mod = (gid_x == 0 || gid_x == get_global_size(0) - 1) ? -1: 1;
-  const int y_global_mod = (gid_y == 0 || gid_y == get_global_size(1) - 1) ? -1: 1;
-
-  int localColOffset = 0;
-  int globalColOffset;
-
-  cached[mad24(y_local + 0, localRowLen, x_local + 0)] = val_from_10(in, x_global + 0, y_global + 0, black_level);
-  cached[mad24(y_local + 0, localRowLen, x_local + 1)] = val_from_10(in, x_global + 1, y_global + 0, black_level);
-  cached[mad24(y_local + 1, localRowLen, x_local + 0)] = val_from_10(in, x_global + 0, y_global + 1, black_level);
-  cached[mad24(y_local + 1, localRowLen, x_local + 1)] = val_from_10(in, x_global + 1, y_global + 1, black_level);
-
-  if (lid_x == 0) {  // left edge
-    localColOffset = -1;
-    globalColOffset = -x_global_mod;
-    cached[mad24(y_local + 0, localRowLen, x_local - 1)] = val_from_10(in, x_global - x_global_mod, y_global + 0, black_level);
-    cached[mad24(y_local + 1, localRowLen, x_local - 1)] = val_from_10(in, x_global - x_global_mod, y_global + 1, black_level);
-  } else if (lid_x == get_local_size(0) - 1) {  // right edge
-    localColOffset = 2;
-    globalColOffset = x_global_mod + 1;
-    cached[mad24(y_local + 0, localRowLen, x_local + 2)] = val_from_10(in, x_global + x_global_mod + 1, y_global + 0, black_level);
-    cached[mad24(y_local + 1, localRowLen, x_local + 2)] = val_from_10(in, x_global + x_global_mod + 1, y_global + 1, black_level);
-  }
-
-  if (lid_y == 0) {  // top row
-    cached[mad24(y_local - 1, localRowLen, x_local + 0)] = val_from_10(in, x_global + 0, y_global - y_global_mod, black_level);
-    cached[mad24(y_local - 1, localRowLen, x_local + 1)] = val_from_10(in, x_global + 1, y_global - y_global_mod, black_level);
-    if (localColOffset != 0) {  // cache corners
-      cached[mad24(y_local - 1, localRowLen, x_local + localColOffset)] = val_from_10(in, x_global + globalColOffset, y_global - y_global_mod, black_level);
-    }
-  } else if (lid_y == get_local_size(1) - 1) {  // bottom row
-    cached[mad24(y_local + 2, localRowLen, x_local + 0)] = val_from_10(in, x_global + 0, y_global + y_global_mod + 1, black_level);
-    cached[mad24(y_local + 2, localRowLen, x_local + 1)] = val_from_10(in, x_global + 1, y_global + y_global_mod + 1, black_level);
-    if (localColOffset != 0) {  // cache corners
-      cached[mad24(y_local + 2, localRowLen, x_local + localColOffset)] = val_from_10(in, x_global + globalColOffset, y_global + y_global_mod + 1, black_level);
-    }
-  }
-
-  // sync
-  barrier(CLK_LOCAL_MEM_FENCE);
-
   half3 rgb;
   uchar3 rgb_out[4];
 
-  const half4 va = vload4(0, cached + mad24(lid_y * 2 + 0, localRowLen, lid_x * 2));
-  const half4 vb = vload4(0, cached + mad24(lid_y * 2 + 1, localRowLen, lid_x * 2));
-  const half4 vc = vload4(0, cached + mad24(lid_y * 2 + 2, localRowLen, lid_x * 2));
-  const half4 vd = vload4(0, cached + mad24(lid_y * 2 + 3, localRowLen, lid_x * 2));
+  half4 va, vb, vc, vd;
+
+  va.s0 = val_from_10(in, gid_x*2-1, gid_y*2-1, black_level);
+  va.s1 = val_from_10(in, gid_x*2+0, gid_y*2-1, black_level);
+  va.s2 = val_from_10(in, gid_x*2+1, gid_y*2-1, black_level);
+  va.s3 = val_from_10(in, gid_x*2+2, gid_y*2-1, black_level);
+
+  vb.s0 = val_from_10(in, gid_x*2-1, gid_y*2+0, black_level);
+  vb.s1 = val_from_10(in, gid_x*2+0, gid_y*2+0, black_level); // G(R)
+  vb.s2 = val_from_10(in, gid_x*2+1, gid_y*2+0, black_level); // R
+  vb.s3 = val_from_10(in, gid_x*2+2, gid_y*2+0, black_level);
+
+  vc.s0 = val_from_10(in, gid_x*2-1, gid_y*2+1, black_level);
+  vc.s1 = val_from_10(in, gid_x*2+0, gid_y*2+1, black_level); // B
+  vc.s2 = val_from_10(in, gid_x*2+1, gid_y*2+1, black_level); // G(B)
+  vc.s3 = val_from_10(in, gid_x*2+2, gid_y*2+1, black_level);
+
+  vd.s0 = val_from_10(in, gid_x*2-1, gid_y*2+2, black_level);
+  vd.s1 = val_from_10(in, gid_x*2+0, gid_y*2+2, black_level);
+  vd.s2 = val_from_10(in, gid_x*2+1, gid_y*2+2, black_level);
+  vd.s3 = val_from_10(in, gid_x*2+2, gid_y*2+2, black_level);
 
   // a simplified version of https://opensignalprocessingjournal.com/contents/volumes/V6/TOSIGPJ-6-1/TOSIGPJ-6-1.pdf
   const half k01 = get_k(va.s0, vb.s1, va.s2, vb.s1);

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -54,7 +54,10 @@ inline half val_from_12(const uchar * source, int gx, int gy) {
   uint major = (uint)source[start + offset] << 4;
   uint minor = (source[start + 2] >> (4 * offset)) & 0xf;
   half pv = ((half)(major + minor));
+  return pv;
+}
 
+inline half4 correct(half4 pv, int gx, int gy) {
   // normalize
   pv = max((half)0.0, pv - 168) / (4096.0 - 168);
 
@@ -110,6 +113,11 @@ __kernel void debayer10(const __global uchar * in, __global uchar * out)
   vd.s1 = val_from_12(in, gid_x2+0, gid_y2p2);
   vd.s2 = val_from_12(in, gid_x2+1, gid_y2p2);
   vd.s3 = val_from_12(in, gid_x2p2, gid_y2p2);
+
+  va = correct(va, gid_x2, gid_y2);
+  vb = correct(vb, gid_x2, gid_y2);
+  vc = correct(vc, gid_x2, gid_y2);
+  vd = correct(vd, gid_x2, gid_y2);
 
   // a simplified version of https://opensignalprocessingjournal.com/contents/volumes/V6/TOSIGPJ-6-1/TOSIGPJ-6-1.pdf
   const half k01 = get_k(va.s0, vb.s1, va.s2, vb.s1);

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -84,25 +84,32 @@ __kernel void debayer10(const __global uchar * in, __global uchar * out)
   // this is a 4x4 "conv"
   half4 va, vb, vc, vd;
 
-  va.s0 = val_from_12(in, gid_x*2-1, gid_y*2-1);
-  va.s1 = val_from_12(in, gid_x*2+0, gid_y*2-1);
-  va.s2 = val_from_12(in, gid_x*2+1, gid_y*2-1);
-  va.s3 = val_from_12(in, gid_x*2+2, gid_y*2-1);
+  const int gid_x2 = gid_x*2;
+  const int gid_x2m1 = gid_x == 0 ? gid_x2+1 : gid_x2-1;
+  const int gid_x2p2 = gid_x == (RGB_WIDTH-2) ? gid_x2+0 : gid_x2+2;
+  const int gid_y2 = gid_y*2;
+  const int gid_y2m1 = gid_y == 0 ? gid_y2+1 : gid_y2-1;
+  const int gid_y2p2 = gid_y == (RGB_HEIGHT-2) ? gid_y2+0 : gid_y2+2;
 
-  vb.s0 = val_from_12(in, gid_x*2-1, gid_y*2+0);
-  vb.s1 = val_from_12(in, gid_x*2+0, gid_y*2+0); // G(R)
-  vb.s2 = val_from_12(in, gid_x*2+1, gid_y*2+0); // R
-  vb.s3 = val_from_12(in, gid_x*2+2, gid_y*2+0);
+  va.s0 = val_from_12(in, gid_x2m1, gid_y2m1);
+  va.s1 = val_from_12(in, gid_x2+0, gid_y2m1);
+  va.s2 = val_from_12(in, gid_x2+1, gid_y2m1);
+  va.s3 = val_from_12(in, gid_x2p2, gid_y2m1);
 
-  vc.s0 = val_from_12(in, gid_x*2-1, gid_y*2+1);
-  vc.s1 = val_from_12(in, gid_x*2+0, gid_y*2+1); // B
-  vc.s2 = val_from_12(in, gid_x*2+1, gid_y*2+1); // G(B)
-  vc.s3 = val_from_12(in, gid_x*2+2, gid_y*2+1);
+  vb.s0 = val_from_12(in, gid_x2m1, gid_y*2+0);
+  vb.s1 = val_from_12(in, gid_x2+0, gid_y*2+0); // G(R)
+  vb.s2 = val_from_12(in, gid_x2+1, gid_y*2+0); // R
+  vb.s3 = val_from_12(in, gid_x2p2, gid_y*2+0);
 
-  vd.s0 = val_from_12(in, gid_x*2-1, gid_y*2+2);
-  vd.s1 = val_from_12(in, gid_x*2+0, gid_y*2+2);
-  vd.s2 = val_from_12(in, gid_x*2+1, gid_y*2+2);
-  vd.s3 = val_from_12(in, gid_x*2+2, gid_y*2+2);
+  vc.s0 = val_from_12(in, gid_x2m1, gid_y*2+1);
+  vc.s1 = val_from_12(in, gid_x2+0, gid_y*2+1); // B
+  vc.s2 = val_from_12(in, gid_x2+1, gid_y*2+1); // G(B)
+  vc.s3 = val_from_12(in, gid_x2p2, gid_y*2+1);
+
+  vd.s0 = val_from_12(in, gid_x2m1, gid_y2p2);
+  vd.s1 = val_from_12(in, gid_x2+0, gid_y2p2);
+  vd.s2 = val_from_12(in, gid_x2+1, gid_y2p2);
+  vd.s3 = val_from_12(in, gid_x2p2, gid_y2p2);
 
   // a simplified version of https://opensignalprocessingjournal.com/contents/volumes/V6/TOSIGPJ-6-1/TOSIGPJ-6-1.pdf
   const half k01 = get_k(va.s0, vb.s1, va.s2, vb.s1);

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -1,12 +1,3 @@
-#ifdef HALF_AS_FLOAT
-#define half float
-#define half2 float2
-#define half3 float3
-#define half4 float4
-#else
-#pragma OPENCL EXTENSION cl_khr_fp16 : enable
-#endif
-
 #define UV_WIDTH RGB_WIDTH / 2
 #define UV_HEIGHT RGB_HEIGHT / 2
 #define U_OFFSET RGB_WIDTH * RGB_HEIGHT
@@ -17,17 +8,17 @@
 #define RGB_TO_V(r, g, b) ((mul24(r, 56) - mul24(g, 47) - mul24(b, 9) + 0x8080) >> 8)
 #define AVERAGE(x, y, z, w) ((convert_ushort(x) + convert_ushort(y) + convert_ushort(z) + convert_ushort(w) + 1) >> 1)
 
-inline half3 color_correct(half3 rgb) {
+float3 color_correct(float3 rgb) {
   // color correction
-  half3 x = (half)rgb.x * (half3)(1.82717181, -0.31231438, 0.07307673);
-  x += (half)rgb.y * (half3)(-0.5743977, 1.36858544, -0.53183455);
-  x += (half)rgb.z * (half3)(-0.25277411, -0.05627105, 1.45875782);
+  float3 x = rgb.x * (1.82717181, -0.31231438, 0.07307673);
+  x += rgb.y * (-0.5743977, 1.36858544, -0.53183455);
+  x += rgb.z * (-0.25277411, -0.05627105, 1.45875782);
 
   // tone mapping params
-  const half gamma_k = 0.75;
-  const half gamma_b = 0.125;
-  const half mp = 0.01; // ideally midpoint should be adaptive
-  const half rk = 9 - 100*mp;
+  const float gamma_k = 0.75;
+  const float gamma_b = 0.125;
+  const float mp = 0.01; // ideally midpoint should be adaptive
+  const float rk = 9 - 100*mp;
 
   // poly approximation for s curve
   return (x > mp) ?
@@ -35,31 +26,30 @@ inline half3 color_correct(half3 rgb) {
     ((rk * (x-mp) * (gamma_k*mp+gamma_b) * (1+1/(rk*mp)) / (1-rk*(x-mp))) + gamma_k*mp + gamma_b);
 }
 
-inline half get_vignetting_s(float r) {
+float get_vignetting_s(float r) {
   if (r < 62500) {
-    return (half)(1.0f + 0.0000008f*r);
+    return (1.0f + 0.0000008f*r);
   } else if (r < 490000) {
-    return (half)(0.9625f + 0.0000014f*r);
+    return (0.9625f + 0.0000014f*r);
   } else if (r < 1102500) {
-    return (half)(1.26434f + 0.0000000000016f*r*r);
+    return (1.26434f + 0.0000000000016f*r*r);
   } else {
-    return (half)(0.53503625f + 0.0000000000022f*r*r);
+    return (0.53503625f + 0.0000000000022f*r*r);
   }
 }
 
-inline half val_from_12(const uchar * source, int gx, int gy) {
+float val_from_12(const uchar * source, int gx, int gy) {
   // parse 12bit
   int start = gy * FRAME_STRIDE + (3 * (gx / 2)) + (FRAME_STRIDE * FRAME_OFFSET);
   int offset = gx % 2;
   uint major = (uint)source[start + offset] << 4;
   uint minor = (source[start + 2] >> (4 * offset)) & 0xf;
-  half pv = ((half)(major + minor));
-  return pv;
+  return (float)(major + minor);
 }
 
-inline half4 correct(half4 pv, int gx, int gy) {
+float4 precolor_correct(float4 pv, int gx, int gy) {
   // normalize
-  pv = max((half)0.0, pv - 168) / (4096.0 - 168);
+  pv = max(0.0, pv - 168) / (4096.0 - 168);
 
   // correct vignetting
   #if CAM_NUM == 1
@@ -68,11 +58,11 @@ inline half4 correct(half4 pv, int gx, int gy) {
     pv *= get_vignetting_s(gx*gx + gy*gy);
   #endif
 
-  pv = clamp(pv, (half)0.0, (half)1.0);
+  pv = clamp(pv, 0.0, 1.0);
   return pv;
 }
 
-inline half get_k(half a, half b, half c, half d) {
+float get_k(float a, float b, float c, float d) {
   return 2.0 - (fabs(a - b) + fabs(c - d));
 }
 
@@ -81,11 +71,11 @@ __kernel void debayer10(const __global uchar * in, __global uchar * out)
   const int gid_x = get_global_id(0);
   const int gid_y = get_global_id(1);
 
-  half3 rgb;
+  float3 rgb;
   uchar3 rgb_out[4];
 
   // this is a 4x4 "conv"
-  half4 va, vb, vc, vd;
+  float4 va, vb, vc, vd;
 
   const int gid_x2 = gid_x*2;
   const int gid_x2m1 = gid_x == 0 ? gid_x2+1 : gid_x2-1;
@@ -114,43 +104,43 @@ __kernel void debayer10(const __global uchar * in, __global uchar * out)
   vd.s2 = val_from_12(in, gid_x2+1, gid_y2p2);
   vd.s3 = val_from_12(in, gid_x2p2, gid_y2p2);
 
-  va = correct(va, gid_x2, gid_y2);
-  vb = correct(vb, gid_x2, gid_y2);
-  vc = correct(vc, gid_x2, gid_y2);
-  vd = correct(vd, gid_x2, gid_y2);
+  va = precolor_correct(va, gid_x2, gid_y2);
+  vb = precolor_correct(vb, gid_x2, gid_y2);
+  vc = precolor_correct(vc, gid_x2, gid_y2);
+  vd = precolor_correct(vd, gid_x2, gid_y2);
 
   // a simplified version of https://opensignalprocessingjournal.com/contents/volumes/V6/TOSIGPJ-6-1/TOSIGPJ-6-1.pdf
-  const half k01 = get_k(va.s0, vb.s1, va.s2, vb.s1);
-  const half k02 = get_k(va.s2, vb.s1, vc.s2, vb.s1);
-  const half k03 = get_k(vc.s0, vb.s1, vc.s2, vb.s1);
-  const half k04 = get_k(va.s0, vb.s1, vc.s0, vb.s1);
+  const float k01 = get_k(va.s0, vb.s1, va.s2, vb.s1);
+  const float k02 = get_k(va.s2, vb.s1, vc.s2, vb.s1);
+  const float k03 = get_k(vc.s0, vb.s1, vc.s2, vb.s1);
+  const float k04 = get_k(va.s0, vb.s1, vc.s0, vb.s1);
   rgb.x = (k02*vb.s2+k04*vb.s0)/(k02+k04); // R_G1
   rgb.y = vb.s1; // G1(R)
   rgb.z = (k01*va.s1+k03*vc.s1)/(k01+k03); // B_G1
   rgb_out[0] = convert_uchar3_sat(color_correct(clamp(rgb, 0.0, 1.0)) * 255.0);
 
-  const half k11 = get_k(va.s1, vc.s1, va.s3, vc.s3);
-  const half k12 = get_k(va.s2, vb.s1, vb.s3, vc.s2);
-  const half k13 = get_k(va.s1, va.s3, vc.s1, vc.s3);
-  const half k14 = get_k(va.s2, vb.s3, vc.s2, vb.s1);
+  const float k11 = get_k(va.s1, vc.s1, va.s3, vc.s3);
+  const float k12 = get_k(va.s2, vb.s1, vb.s3, vc.s2);
+  const float k13 = get_k(va.s1, va.s3, vc.s1, vc.s3);
+  const float k14 = get_k(va.s2, vb.s3, vc.s2, vb.s1);
   rgb.x = vb.s2; // R
   rgb.y = (k11*(va.s2+vc.s2)*0.5+k13*(vb.s3+vb.s1)*0.5)/(k11+k13); // G_R
   rgb.z = (k12*(va.s3+vc.s1)*0.5+k14*(va.s1+vc.s3)*0.5)/(k12+k14); // B_R
   rgb_out[1] = convert_uchar3_sat(color_correct(clamp(rgb, 0.0, 1.0)) * 255.0);
 
-  const half k21 = get_k(vb.s0, vd.s0, vb.s2, vd.s2);
-  const half k22 = get_k(vb.s1, vc.s0, vc.s2, vd.s1);
-  const half k23 = get_k(vb.s0, vb.s2, vd.s0, vd.s2);
-  const half k24 = get_k(vb.s1, vc.s2, vd.s1, vc.s0);
+  const float k21 = get_k(vb.s0, vd.s0, vb.s2, vd.s2);
+  const float k22 = get_k(vb.s1, vc.s0, vc.s2, vd.s1);
+  const float k23 = get_k(vb.s0, vb.s2, vd.s0, vd.s2);
+  const float k24 = get_k(vb.s1, vc.s2, vd.s1, vc.s0);
   rgb.x = (k22*(vb.s2+vd.s0)*0.5+k24*(vb.s0+vd.s2)*0.5)/(k22+k24); // R_B
   rgb.y = (k21*(vb.s1+vd.s1)*0.5+k23*(vc.s2+vc.s0)*0.5)/(k21+k23); // G_B
   rgb.z = vc.s1; // B
   rgb_out[2] = convert_uchar3_sat(color_correct(clamp(rgb, 0.0, 1.0)) * 255.0);
 
-  const half k31 = get_k(vb.s1, vc.s2, vb.s3, vc.s2);
-  const half k32 = get_k(vb.s3, vc.s2, vd.s3, vc.s2);
-  const half k33 = get_k(vd.s1, vc.s2, vd.s3, vc.s2);
-  const half k34 = get_k(vb.s1, vc.s2, vd.s1, vc.s2);
+  const float k31 = get_k(vb.s1, vc.s2, vb.s3, vc.s2);
+  const float k32 = get_k(vb.s3, vc.s2, vd.s3, vc.s2);
+  const float k33 = get_k(vd.s1, vc.s2, vd.s3, vc.s2);
+  const float k34 = get_k(vb.s1, vc.s2, vd.s1, vc.s2);
   rgb.x = (k31*vb.s2+k33*vd.s2)/(k31+k33); // R_G2
   rgb.y = vc.s2; // G2(B)
   rgb.z = (k32*vc.s3+k34*vc.s1)/(k32+k34); // B_G2

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -87,6 +87,18 @@ __kernel void debayer10(const __global uchar * in, __global uchar * out)
   float4 vc = val4_from_12(dat[2], gain);
   float4 vd = val4_from_12(dat[3], gain);
 
+  if (gid_x == 0) {
+    va.s0 = va.s2;
+    vb.s0 = vb.s2;
+    vc.s0 = vc.s2;
+    vd.s0 = vd.s2;
+  } else if (gid_x == RGB_WIDTH/2 - 1) {
+    va.s3 = va.s1;
+    vb.s3 = vb.s1;
+    vc.s3 = vc.s1;
+    vd.s3 = vd.s1;
+  }
+
   // a simplified version of https://opensignalprocessingjournal.com/contents/volumes/V6/TOSIGPJ-6-1/TOSIGPJ-6-1.pdf
   const float k01 = get_k(va.s0, vb.s1, va.s2, vb.s1);
   const float k02 = get_k(va.s2, vb.s1, vc.s2, vb.s1);

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -83,6 +83,7 @@ inline half get_k(half a, half b, half c, half d) {
 
 __kernel void debayer10(const __global uchar * in,
                         __global uchar * out,
+                        __local half * cached,
                         float black_level
                        )
 {

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -52,14 +52,13 @@ float4 precolor_correct(ushort4 pvs, int gx, int gy) {
   float4 pv = max(0.0, convert_float4(pvs) - 168.0) / (4096.0 - 168.0);
 
   // correct vignetting
-  #if CAM_NUM == 1
+  #if VIGNETTING
     gx = (gx - RGB_WIDTH/2);
     gy = (gy - RGB_HEIGHT/2);
     pv *= get_vignetting_s(gx*gx + gy*gy);
   #endif
 
-  pv = clamp(pv, 0.0, 1.0);
-  return pv;
+  return clamp(pv, 0.0, 1.0);
 }
 
 float get_k(float a, float b, float c, float d) {

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -57,21 +57,20 @@ __kernel void debayer10(const __global uchar * in, __global uchar * out)
   const int gid_x = get_global_id(0);
   const int gid_y = get_global_id(1);
 
+  const int y_top_mod = (gid_y == 0) ? 2: 0;
+  const int y_bot_mod = (gid_y == (RGB_HEIGHT/2 - 1)) ? 1: 3;
+
   float3 rgb;
   uchar3 rgb_out[4];
 
-  int start = 2 * gid_y * FRAME_STRIDE + (3 * gid_x) + (FRAME_STRIDE * FRAME_OFFSET);
-
-  // deal with x/y offset
-  // TODO: this is wrong at the edges
-  start = max(0, start-FRAME_STRIDE-2);
+  int start = (2 * gid_y - 1) * FRAME_STRIDE + (3 * gid_x - 2) + (FRAME_STRIDE * FRAME_OFFSET);
 
   // read in 8x4 chars
   uchar8 dat[4];
-  dat[0] = vload8(0, in + start + FRAME_STRIDE*0);
+  dat[0] = vload8(0, in + start + FRAME_STRIDE*y_top_mod);
   dat[1] = vload8(0, in + start + FRAME_STRIDE*1);
   dat[2] = vload8(0, in + start + FRAME_STRIDE*2);
-  dat[3] = vload8(0, in + start + FRAME_STRIDE*3);
+  dat[3] = vload8(0, in + start + FRAME_STRIDE*y_bot_mod);
 
   // correct vignetting
   #if VIGNETTING

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -38,13 +38,13 @@ float get_vignetting_s(float r) {
   }
 }
 
-float4 precolor_correct_12(uchar8 pvs, float scale, float bias) {
+float4 precolor_correct_12(uchar8 pvs, float scale) {
   uint4 parsed = (uint4)(((uint)pvs.s0<<4) + (pvs.s1>>4),  // is from the previous 10 bit
                          ((uint)pvs.s2<<4) + (pvs.s4&0xF),
                          ((uint)pvs.s3<<4) + (pvs.s4>>4),
                          ((uint)pvs.s5<<4) + (pvs.s7&0xF));
   // normalize and scale
-  float4 pv = (convert_float4(parsed) - bias) / (4096.0 - bias);
+  float4 pv = (convert_float4(parsed) - 168.0) / (4096.0 - 168.0);
   return clamp(pv*scale, 0.0, 1.0);
 }
 
@@ -52,7 +52,7 @@ float get_k(float a, float b, float c, float d) {
   return 2.0 - (fabs(a - b) + fabs(c - d));
 }
 
-__kernel void debayer10(const __global uchar * in, __global uchar * out, float black_level)
+__kernel void debayer10(const __global uchar * in, __global uchar * out)
 {
   const int gid_x = get_global_id(0);
   const int gid_y = get_global_id(1);
@@ -81,11 +81,10 @@ __kernel void debayer10(const __global uchar * in, __global uchar * out, float b
   #endif
 
   float4 va, vb, vc, vd;
-  const float bias = black_level * 4.;
-  va = precolor_correct_12(vac, scale, bias);
-  vb = precolor_correct_12(vbc, scale, bias);
-  vc = precolor_correct_12(vcc, scale, bias);
-  vd = precolor_correct_12(vdc, scale, bias);
+  va = precolor_correct_12(vac, scale);
+  vb = precolor_correct_12(vbc, scale);
+  vc = precolor_correct_12(vcc, scale);
+  vd = precolor_correct_12(vdc, scale);
 
   // a simplified version of https://opensignalprocessingjournal.com/contents/volumes/V6/TOSIGPJ-6-1/TOSIGPJ-6-1.pdf
   const float k01 = get_k(va.s0, vb.s1, va.s2, vb.s1);

--- a/selfdrive/camerad/cameras/real_debayer.cl
+++ b/selfdrive/camerad/cameras/real_debayer.cl
@@ -10,9 +10,9 @@
 
 float3 color_correct(float3 rgb) {
   // color correction
-  float3 x = rgb.x * (1.82717181, -0.31231438, 0.07307673);
-  x += rgb.y * (-0.5743977, 1.36858544, -0.53183455);
-  x += rgb.z * (-0.25277411, -0.05627105, 1.45875782);
+  float3 x = rgb.x * (float3)(1.82717181, -0.31231438, 0.07307673);
+  x += rgb.y * (float3)(-0.5743977, 1.36858544, -0.53183455);
+  x += rgb.z * (float3)(-0.25277411, -0.05627105, 1.45875782);
 
   // tone mapping params
   const float gamma_k = 0.75;

--- a/selfdrive/hardware/tici/test_power_draw.py
+++ b/selfdrive/hardware/tici/test_power_draw.py
@@ -19,7 +19,7 @@ class Proc:
   warmup: float = 3.
 
 PROCS = [
-  Proc('camerad', 2.17),
+  Proc('camerad', 2.02),
   Proc('modeld', 0.95),
   Proc('dmonitoringmodeld', 0.25),
   Proc('encoderd', 0.42),

--- a/selfdrive/test/process_replay/test_debayer.py
+++ b/selfdrive/test/process_replay/test_debayer.py
@@ -80,8 +80,7 @@ def debayer_frame(ctx, debayer_prg, data, rgb=False):
   yuv_g = cl.Buffer(ctx, cl.mem_flags.WRITE_ONLY, FRAME_WIDTH * FRAME_HEIGHT + UV_SIZE * 2)
 
   local_worksize = (20, 20) if TICI else (4, 4)
-  local_mem = cl.LocalMemory(3528 if TICI else 400)
-  ev1 = debayer_prg.debayer10(q, (UV_WIDTH, UV_HEIGHT), local_worksize, cam_g, yuv_g, local_mem, np.float32(42))
+  ev1 = debayer_prg.debayer10(q, (UV_WIDTH, UV_HEIGHT), local_worksize, cam_g, yuv_g)
   cl.enqueue_copy(q, yuv_buff, yuv_g, wait_for=[ev1]).wait()
   cl.enqueue_barrier(q)
 


### PR DESCRIPTION
20ms -> 7.7ms

Edges are wrong, not really sure what desired behavior is here (but tell me what you want if you can't make it fast, use math, not control flow). And vignetting is slightly less precise, one value for the 2x2.

Also saves 120mW, 2.17W -> 2.05W on my device.

Three general OpenCL rules:
* Unless you are doing something very strange or need to accumulate, local caching is a bad idea. The GPU built-in cache does a very good job for normal image reads.
* Memory accesses are slow and should be used very sparingly. Half of the speedup is from using vload8 instead of byte accesses.
* The compiler is smart, it's LLVM. "const", "inline", unrolling loops won't speed things up.

Assuming 20 FLOPS per RGB pixel, this is now getting 57 GFLOPS. Getting more likely requires image inputs instead of pointers, then it uses a different way of accessing memory. But this makes more sense for intermediate stuff like what's in SNPE, where the exact byte locations matter less. 
```
1000/7.7*3*(1920*1280*20*3)
```