### PR TITLE
camerad: disable registers/stats

### DIFF
--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -59,6 +59,7 @@ typedef struct CameraInfo {
   int bayer_flip;
   bool hdr;
   uint32_t frame_offset = 0;
+  uint32_t isp_offset = 0;
   uint32_t extra_height = 0;
   int registers_offset = -1;
   int stats_offset = -1;

--- a/selfdrive/camerad/cameras/camera_common.h
+++ b/selfdrive/camerad/cameras/camera_common.h
@@ -48,6 +48,7 @@ const bool env_disable_wide_road = getenv("DISABLE_WIDE_ROAD") != NULL;
 const bool env_disable_driver = getenv("DISABLE_DRIVER") != NULL;
 const bool env_debug_frames = getenv("DEBUG_FRAMES") != NULL;
 const bool env_log_raw_frames = getenv("LOG_RAW_FRAMES") != NULL;
+const bool env_enable_stats = getenv("ENABLE_STATS") != NULL;
 
 typedef void (*release_cb)(void *cookie, int buf_idx);
 

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -31,8 +31,8 @@ const size_t FRAME_WIDTH = 1928;
 const size_t FRAME_HEIGHT = 1208;
 const size_t FRAME_STRIDE = 2896;  // for 12 bit output. 1928 * 12 / 8 + 4 (alignment)
 
-// const size_t AR0231_REGISTERS_HEIGHT = 2;
-// const size_t AR0231_STATS_HEIGHT = 2;
+const size_t AR0231_REGISTERS_HEIGHT = 2;
+const size_t AR0231_STATS_HEIGHT = 2;
 
 const int MIPI_SETTLE_CNT = 33;  // Calculated by camera_freqs.py
 
@@ -41,6 +41,11 @@ CameraInfo cameras_supported[CAMERA_ID_MAX] = {
     .frame_width = FRAME_WIDTH,
     .frame_height = FRAME_HEIGHT,
     .frame_stride = FRAME_STRIDE,
+    .extra_height = env_enable_stats ? (uint32_t)(AR0231_REGISTERS_HEIGHT + AR0231_STATS_HEIGHT) : 0,
+
+    .registers_offset = env_enable_stats ? 0 : -1,
+    .frame_offset = env_enable_stats ? (uint32_t)AR0231_REGISTERS_HEIGHT : 0,
+    .stats_offset = env_enable_stats ? (int)(AR0231_REGISTERS_HEIGHT + FRAME_HEIGHT) : -1,
 
     .bayer = true,
     .bayer_flip = 1,

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -41,11 +41,13 @@ CameraInfo cameras_supported[CAMERA_ID_MAX] = {
     .frame_width = FRAME_WIDTH,
     .frame_height = FRAME_HEIGHT,
     .frame_stride = FRAME_STRIDE,
-    .extra_height = env_enable_stats ? (uint32_t)(AR0231_REGISTERS_HEIGHT + AR0231_STATS_HEIGHT) : 0,
+    .extra_height = AR0231_REGISTERS_HEIGHT + AR0231_STATS_HEIGHT,
 
-    .registers_offset = env_enable_stats ? 0 : -1,
-    .frame_offset = env_enable_stats ? (uint32_t)AR0231_REGISTERS_HEIGHT : 0,
+    .isp_offset = env_enable_stats ? 0 : (uint32_t)AR0231_REGISTERS_HEIGHT, // Add padding if registers are disabled
+    .frame_offset = AR0231_REGISTERS_HEIGHT,
+
     .stats_offset = env_enable_stats ? (int)(AR0231_REGISTERS_HEIGHT + FRAME_HEIGHT) : -1,
+    .registers_offset = env_enable_stats ? 0 : -1,
 
     .bayer = true,
     .bayer_flip = 1,
@@ -517,6 +519,7 @@ void CameraState::config_isp(int io_mem_handle, int fence, int request_id, int b
 
   if (io_mem_handle != 0) {
     io_cfg[0].mem_handle[0] = io_mem_handle;
+    io_cfg[0].offsets[0] = ci.frame_stride * ci.isp_offset;
 		io_cfg[0].planes[0] = (struct cam_plane_cfg){
 		 .width = ci.frame_width,
 		 .height = ci.frame_height + ci.extra_height,

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -67,7 +67,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x30A6, 0x0001}, // Y_ODD_INC_
   {0x3402, 0x0788}, // X_OUTPUT_CONTROL
   {0x3404, 0x04B8}, // Y_OUTPUT_CONTROL
-  {0x3064, 0x1982}, // SMIA_TEST
+  {0x3064, 0x1802}, // SMIA_TEST
   {0x30BA, 0x11F2}, // DIGITAL_CTRL
 
   // Enable external trigger and disable GPIO outputs


### PR DESCRIPTION
both registers and stats are causing framedrops. Reverting until we figure out how to fix.

out of founds read in debayer kernel must be fixed before merging!