### PR TITLE
Hyundai longitudinal: reduce time from acceleration to deceleration

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -46,6 +46,7 @@ class CarController:
     self.steer_rate_limited = False
     self.last_resume_frame = 0
     self.accel = 0
+    self.enabled_frames = 0
 
   def update(self, CC, CS):
     actuators = CC.actuators
@@ -88,8 +89,16 @@ class CarController:
           self.last_resume_frame = self.frame
 
     if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
-      accel = actuators.accel
+      accel = 0  # actuators.accel
       jerk = 0
+      if CC.longActive:
+        self.enabled_frames += 1
+        if self.enabled_frames < 200:
+          accel = 1.5
+        else:
+          accel = -1.5
+      else:
+        self.enabled_frames = 0
 
       if CC.longActive:
         jerk = clip(2.0 * (accel - CS.out.aEgo), -12.7, 12.7)

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -109,7 +109,7 @@ def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_spe
   scc14_values = {
     "ComfortBandUpper": 0.0, # stock usually is 0 but sometimes uses higher values
     "ComfortBandLower": 0.0, # stock usually is 0 but sometimes uses higher values
-    "JerkUpperLimit": max(jerk, 1.0) if not stopping else 0, # stock usually is 1.0 but sometimes uses higher values
+    "JerkUpperLimit": max(jerk, 0.0) if not stopping else 0, # stock usually is 1.0 but sometimes uses higher values
     "JerkLowerLimit": max(-jerk, 1.0), # stock usually is 0.5 but sometimes uses higher values
     "ACCMode": 2 if enabled and gas_pressed else 1 if enabled else 4, # stock will always be 4 instead of 0 after first disengage
     "ObjGap": 2 if lead_visible else 0, # 5: >30, m, 4: 25-30 m, 3: 20-25 m, 2: < 20 m, 0: no lead

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -109,7 +109,8 @@ def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_spe
   scc14_values = {
     "ComfortBandUpper": 0.0, # stock usually is 0 but sometimes uses higher values
     "ComfortBandLower": 0.0, # stock usually is 0 but sometimes uses higher values
-    "JerkUpperLimit": max(jerk, 0.0) if not stopping else 0, # stock usually is 1.0 but sometimes uses higher values
+    # "JerkUpperLimit": max(jerk, 0.0) if not stopping else 0, # stock usually is 1.0 but sometimes uses higher values
+    "JerkUpperLimit": max(jerk, 1.0) if not stopping else 0, # stock usually is 1.0 but sometimes uses higher values
     "JerkLowerLimit": max(-jerk, 1.0), # stock usually is 0.5 but sometimes uses higher values
     "ACCMode": 2 if enabled and gas_pressed else 1 if enabled else 4, # stock will always be 4 instead of 0 after first disengage
     "ObjGap": 2 if lead_visible else 0, # 5: >30, m, 4: 25-30 m, 3: 20-25 m, 2: < 20 m, 0: no lead


### PR DESCRIPTION
Another PR split out from https://github.com/commaai/openpilot/pull/24053/files. This reduces the minimum positive jerk from 1 to 0, so when acceleration error is negative, we don't allow any pos jerk, hopefully for faster braking after accelerating