### PR TITLE
camerad: pixclk 88mhz but frame time the same

### DIFF
--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -74,7 +74,7 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 1618; // with HDR, slowest ss, 40ms
+const int EXPOSURE_TIME_MAX = 0x6f4; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -74,7 +74,7 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 0x6f4; // with HDR, slowest ss, 40ms
+const int EXPOSURE_TIME_MAX = 0x0855; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -74,7 +74,7 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 0x0C6F; // with HDR, slowest ss, 40ms
+const int EXPOSURE_TIME_MAX = 0x09FE; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -74,7 +74,7 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 0x0855; // with HDR, slowest ss, 40ms
+const int EXPOSURE_TIME_MAX = 0x0C6F; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {

--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -74,7 +74,7 @@ const int ANALOG_GAIN_REC_IDX = 0x6; // 0.8x
 const int ANALOG_GAIN_MAX_IDX = 0xD; // 4.0x
 
 const int EXPOSURE_TIME_MIN = 2; // with HDR, fastest ss
-const int EXPOSURE_TIME_MAX = 0x09FE; // with HDR, slowest ss, 40ms
+const int EXPOSURE_TIME_MAX = 0x0855; // with HDR, slowest ss, 40ms
 
 // ************** low level camera helpers ****************
 int do_cam_control(int fd, int op_code, void *handle, int size) {

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -52,7 +52,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   // input clock is 19.2 / 2 * 0x37 = 528 MHz
   // pixclk is 528 / 6 = 88 MHz
   // full roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*FRAME_LENGTH_LINES)) = 39.99 ms
-  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 22.85 ms
+  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 15.18 ms
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
   {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
@@ -72,7 +72,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x3402, 0x0788}, // X_OUTPUT_CONTROL
   {0x3404, 0x04B8}, // Y_OUTPUT_CONTROL
   {0x3064, 0x1982}, // SMIA_TEST
-  {0x30BA, 0x11F2}, // DIGITAL_CTRL
+  {0x30BA, 0x11F1}, // DIGITAL_CTRL
 
   // Enable external trigger and disable GPIO outputs
   {0x30CE, 0x0120}, // SLAVE_SH_SYNC_MODE | FRAME_START_MODE
@@ -80,8 +80,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x340C, 0x802},  // GPIO_HIDRV_EN | GPIO0_ISEL=2
 
   // Readout timing
-  {0x300C, 0x0672}, // LINE_LENGTH_PCK (valid for 3-exposure HDR)
-  {0x300A, 0x0855}, // FRAME_LENGTH_LINES
+  {0x300C, 0x0452}, // LINE_LENGTH_PCK (valid for 2-exposure HDR)
+  {0x300A, 0x0C6F}, // FRAME_LENGTH_LINES
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings
@@ -121,6 +121,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x100C, 0x0589}, // FINE_INTEGRATION_TIME2_MIN
   {0x100E, 0x07B1}, // FINE_INTEGRATION_TIME3_MIN
   {0x1010, 0x0139}, // FINE_INTEGRATION_TIME4_MIN
+
+  // TODO: do these have to be lower than LINE_LENGTH_PCK?
   {0x3014, 0x08CB}, // FINE_INTEGRATION_TIME_
   {0x321E, 0x0894}, // FINE_INTEGRATION_TIME2
 

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -123,8 +123,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x1010, 0x0139}, // FINE_INTEGRATION_TIME4_MIN
 
   // TODO: do these have to be lower than LINE_LENGTH_PCK?
-  {0x3014, 0x08CB}, // FINE_INTEGRATION_TIME_
-  {0x321E, 0x0894}, // FINE_INTEGRATION_TIME2
+  {0x3014, 0x0139}, // FINE_INTEGRATION_TIME_
+  {0x321E, 0x0361}, // FINE_INTEGRATION_TIME2
 
   {0x31D0, 0x0000}, // COMPANDING, no good in 10 bit?
   {0x33DA, 0x0000}, // COMPANDING

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -51,8 +51,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   // CLOCK Settings
   // input clock is 19.2 / 2 * 0x37 = 528 MHz
   // pixclk is 528 / 6 = 88 MHz
-  // full roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*FRAME_LENGTH_LINES)) = 39.98 ms
-  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 27.1 ms
+  // full roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*FRAME_LENGTH_LINES)) = 39.99 ms
+  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 22.85 ms
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
   {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
@@ -80,8 +80,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x340C, 0x802},  // GPIO_HIDRV_EN | GPIO0_ISEL=2
 
   // Readout timing
-  {0x300C, 0x07B9}, // LINE_LENGTH_PCK
-  {0x300A, 0x06F4}, // FRAME_LENGTH_LINES
+  {0x300C, 0x0672}, // LINE_LENGTH_PCK (valid for 3-exposure HDR)
+  {0x300A, 0x0855}, // FRAME_LENGTH_LINES
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -52,7 +52,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   // input clock is 19.2 / 2 * 0x37 = 528 MHz
   // pixclk is 528 / 6 = 88 MHz
   // full roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*FRAME_LENGTH_LINES)) = 39.99 ms
-  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 15.18 ms
+  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 18.89 ms
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
   {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
@@ -80,8 +80,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x340C, 0x802},  // GPIO_HIDRV_EN | GPIO0_ISEL=2
 
   // Readout timing
-  {0x300C, 0x0452}, // LINE_LENGTH_PCK (valid for 2-exposure HDR)
-  {0x300A, 0x0C6F}, // FRAME_LENGTH_LINES
+  {0x300C, 0x0560}, // LINE_LENGTH_PCK (1376 clks is the minimum allowed by the wizard)
+  {0x300A, 0x09FE}, // FRAME_LENGTH_LINES
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings
@@ -123,8 +123,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x1010, 0x0139}, // FINE_INTEGRATION_TIME4_MIN
 
   // TODO: do these have to be lower than LINE_LENGTH_PCK?
-  {0x3014, 0x0139}, // FINE_INTEGRATION_TIME_
-  {0x321E, 0x0361}, // FINE_INTEGRATION_TIME2
+  {0x3014, 0x0574}, // FINE_INTEGRATION_TIME_
+  {0x321E, 0x0589}, // FINE_INTEGRATION_TIME2
 
   {0x31D0, 0x0000}, // COMPANDING, no good in 10 bit?
   {0x33DA, 0x0000}, // COMPANDING

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -52,7 +52,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   // input clock is 19.2 / 2 * 0x37 = 528 MHz
   // pixclk is 528 / 6 = 88 MHz
   // full roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*FRAME_LENGTH_LINES)) = 39.99 ms
-  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 18.89 ms
+  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 22.85 ms
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
   {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
@@ -72,7 +72,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x3402, 0x0788}, // X_OUTPUT_CONTROL
   {0x3404, 0x04B8}, // Y_OUTPUT_CONTROL
   {0x3064, 0x1982}, // SMIA_TEST
-  {0x30BA, 0x11F1}, // DIGITAL_CTRL
+  {0x30BA, 0x11F2}, // DIGITAL_CTRL
 
   // Enable external trigger and disable GPIO outputs
   {0x30CE, 0x0120}, // SLAVE_SH_SYNC_MODE | FRAME_START_MODE
@@ -80,8 +80,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x340C, 0x802},  // GPIO_HIDRV_EN | GPIO0_ISEL=2
 
   // Readout timing
-  {0x300C, 0x0560}, // LINE_LENGTH_PCK (1376 clks is the minimum allowed by the wizard)
-  {0x300A, 0x09FE}, // FRAME_LENGTH_LINES
+  {0x300C, 0x0672}, // LINE_LENGTH_PCK (valid for 3-exposure HDR)
+  {0x300A, 0x0855}, // FRAME_LENGTH_LINES
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings
@@ -123,8 +123,8 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x1010, 0x0139}, // FINE_INTEGRATION_TIME4_MIN
 
   // TODO: do these have to be lower than LINE_LENGTH_PCK?
-  {0x3014, 0x0361}, // FINE_INTEGRATION_TIME_
-  {0x321E, 0x0589}, // FINE_INTEGRATION_TIME2
+  {0x3014, 0x08CB}, // FINE_INTEGRATION_TIME_
+  {0x321E, 0x0894}, // FINE_INTEGRATION_TIME2
 
   {0x31D0, 0x0000}, // COMPANDING, no good in 10 bit?
   {0x33DA, 0x0000}, // COMPANDING

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -49,11 +49,15 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x301A, 0x0018}, // RESET_REGISTER
 
   // CLOCK Settings
+  // input clock is 19.2 / 2 * 0x37 = 528 MHz
+  // pixclk is 528 / 6 = 88 MHz
+  // full roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*FRAME_LENGTH_LINES)) = 39.98 ms
+  // img  roll time is 1000/(PIXCLK/(LINE_LENGTH_PCK*Y_OUTPUT_CONTROL))   = 27.1 ms
   {0x302A, 0x0006}, // VT_PIX_CLK_DIV
   {0x302C, 0x0001}, // VT_SYS_CLK_DIV
   {0x302E, 0x0002}, // PRE_PLL_CLK_DIV
-  {0x3030, 0x0032}, // PLL_MULTIPLIER
-  {0x3036, 0x000C}, // OP_WORD_CLK_DIV
+  {0x3030, 0x0037}, // PLL_MULTIPLIER
+  {0x3036, 0x000C}, // OP_PIX_CLK_DIV
   {0x3038, 0x0001}, // OP_SYS_CLK_DIV
 
   // FORMAT
@@ -77,7 +81,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
 
   // Readout timing
   {0x300C, 0x07B9}, // LINE_LENGTH_PCK
-  {0x300A, 0x0652}, // FRAME_LENGTH_LINES
+  {0x300A, 0x06F4}, // FRAME_LENGTH_LINES
   {0x3042, 0x0000}, // EXTRA_DELAY
 
   // Readout Settings

--- a/selfdrive/camerad/cameras/sensor2_i2c.h
+++ b/selfdrive/camerad/cameras/sensor2_i2c.h
@@ -123,7 +123,7 @@ struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x1010, 0x0139}, // FINE_INTEGRATION_TIME4_MIN
 
   // TODO: do these have to be lower than LINE_LENGTH_PCK?
-  {0x3014, 0x0574}, // FINE_INTEGRATION_TIME_
+  {0x3014, 0x0361}, // FINE_INTEGRATION_TIME_
   {0x321E, 0x0589}, // FINE_INTEGRATION_TIME2
 
   {0x31D0, 0x0000}, // COMPANDING, no good in 10 bit?

--- a/selfdrive/hardware/tici/test_power_draw.py
+++ b/selfdrive/hardware/tici/test_power_draw.py
@@ -19,7 +19,7 @@ class Proc:
   warmup: float = 3.
 
 PROCS = [
-  Proc('camerad', 2.02),
+  Proc('camerad', 2.25),
   Proc('modeld', 0.95),
   Proc('dmonitoringmodeld', 0.25),
   Proc('encoderd', 0.42),


### PR DESCRIPTION
@pd0wm Check this.

It increases PIXCLK to maximum 88 MHz, but it keeps the frame time the same by increasing FRAME_LENGTH_LINES proportionally. Do you see the problematic exposure with this?

With this, we get image roll times of 27.1 ms, close to the minimum for the sensor.

Update: I'm way wrong about the minimum. LINE_LENGTH_PCK can somehow be less than X_OUTPUT_CONTROL.  Here it is at 22.8ms, and seems fine.

Btw, the sof to eof time seems very real, it's the actual image roll time, which makes sense. It starts on first pixel, and it's done when it receives the right number of rows.