### PR TITLE
GM: use vehicle brake-pressed threshold to fix Cruise Fault

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -32,10 +32,8 @@ class CarState(CarStateBase):
     ret.standstill = ret.vEgoRaw < 0.01
     ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(pt_cp.vl["ECMPRDNL"]["PRNDL"], None))
 
-    # Brake pedal's potentiometer returns near-zero reading even when pedal is not pressed.
-    ret.brake = pt_cp.vl["EBCMBrakePedalPosition"]["BrakePedalPosition"] / 0xd0
-    ret.brakePressed = pt_cp.vl["EBCMBrakePedalPosition"]["BrakePedalPosition"] >= 10
-
+    ret.brake = pt_cp.vl["ECMAcceleratorPos"]["BrakePedalPos"] / 0xd0
+    ret.brakePressed = pt_cp.vl["ECMAcceleratorPos"]["BrakePedalPos"] >= 8
     # Regen braking is braking
     if self.CP.transmissionType == TransmissionType.direct:
       ret.brakePressed = ret.brakePressed or pt_cp.vl["EBCMRegenPaddle"]["RegenPaddle"] != 0
@@ -80,7 +78,7 @@ class CarState(CarStateBase):
   def get_can_parser(CP):
     signals = [
       # sig_name, sig_address
-      ("BrakePedalPosition", "EBCMBrakePedalPosition"),
+      ("BrakePedalPos", "ECMAcceleratorPos"),
       ("FrontLeftDoor", "BCMDoorBeltStatus"),
       ("FrontRightDoor", "BCMDoorBeltStatus"),
       ("RearLeftDoor", "BCMDoorBeltStatus"),
@@ -119,7 +117,7 @@ class CarState(CarStateBase):
       ("ASCMSteeringButton", 33),
       ("ECMEngineStatus", 100),
       ("PSCMSteeringAngle", 100),
-      ("EBCMBrakePedalPosition", 100),
+      ("ECMAcceleratorPos", 100),
     ]
 
     if CP.transmissionType == TransmissionType.direct:


### PR DESCRIPTION
**Description**

Observed GM vehicle Cruise Fault, or always unable to engage. https://github.com/commaai/openpilot/issues/24223
[Previous debugging](https://github.com/commaai/openpilot/wiki/GM#troubleshooting-open-pilots-cruise-fault-warning-on-volt-brake-pedal-positioning) related this behavior to a sticky brake pedal position on the GM Volt. There is a service bulletin and replacement part.
PlotJuggler shows that when brake position >= 8, in 0.5 seconds ACC will fault. When the value sticks high, then pulling up on the brake pedal will allow engaging, and dropping the brake pedal will cause a cruise fault.

**Verification**

With this change, vehicle correctly disengages when slowly and lightly increasing brake pedal pressure, hovering near this 8-count transition.