### PR TITLE
Toyota: fill stockFcw on all cars except those with their DSU unplugged

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -100,7 +100,7 @@ class CarState(CarStateBase):
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
 
     if not self.CP.enableDsu:
-      ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
+      ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
     # these cars are identified by an ACC_TYPE value of 2.

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -96,9 +96,10 @@ class CarState(CarStateBase):
 
     if self.CP.carFingerprint in RADAR_ACC_CAR:
       self.acc_type = cp.vl["ACC_CONTROL"]["ACC_TYPE"]
-      ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
     elif self.CP.carFingerprint in TSS2_CAR:
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
+
+    if not self.CP.enableDsu:
       ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -209,7 +209,7 @@ class CarState(CarStateBase):
       ]
       checks.append(("BSM", 1))
 
-    if CP.carFingerprint in RADAR_ACC_CAR or CP.enableDsu:
+    if CP.carFingerprint in RADAR_ACC_CAR or not CP.enableDsu:
       signals += [
         ("ACC_TYPE", "ACC_CONTROL"),
         ("FCW", "ACC_HUD"),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -94,12 +94,13 @@ class CarState(CarStateBase):
       ret.cruiseState.available = cp.vl["PCM_CRUISE_2"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["PCM_CRUISE_2"]["SET_SPEED"] * CV.KPH_TO_MS
 
-    if self.CP.carFingerprint in TSS2_CAR:
-      self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
-      ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
-    elif self.CP.carFingerprint in RADAR_ACC_CAR or (not self.CP.enableDsu and self.CP.carFingerprint not in TSS2_CAR):
+    if self.CP.carFingerprint in RADAR_ACC_CAR or (not self.CP.enableDsu and self.CP.carFingerprint not in TSS2_CAR):
       self.acc_type = cp.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
+    elif self.CP.carFingerprint in TSS2_CAR:
+      self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
+      ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
+
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
     # these cars are identified by an ACC_TYPE value of 2.

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -97,7 +97,7 @@ class CarState(CarStateBase):
     if self.CP.carFingerprint in TSS2_CAR:
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
-    elif self.CP.carFingerprint in RADAR_ACC_CAR or (not self.CP.enableDsu and not self.CP.carFingerprint in TSS2_CAR):
+    elif self.CP.carFingerprint in RADAR_ACC_CAR or (not self.CP.enableDsu and self.CP.carFingerprint not in TSS2_CAR):
       self.acc_type = cp.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -209,7 +209,7 @@ class CarState(CarStateBase):
       ]
       checks.append(("BSM", 1))
 
-    if CP.carFingerprint in RADAR_ACC_CAR or not CP.enableDsu:
+    if CP.carFingerprint in RADAR_ACC_CAR or (not CP.enableDsu and CP.carFingerprint not in TSS2_CAR):
       signals += [
         ("ACC_TYPE", "ACC_CONTROL"),
         ("FCW", "ACC_HUD"),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -94,13 +94,12 @@ class CarState(CarStateBase):
       ret.cruiseState.available = cp.vl["PCM_CRUISE_2"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["PCM_CRUISE_2"]["SET_SPEED"] * CV.KPH_TO_MS
 
-    if self.CP.carFingerprint in RADAR_ACC_CAR or (not self.CP.enableDsu and self.CP.carFingerprint not in TSS2_CAR):
+    if self.CP.carFingerprint in RADAR_ACC_CAR:
       self.acc_type = cp.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
-    elif self.CP.carFingerprint in TSS2_CAR:
+    elif not self.CP.enableDsu:
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
-
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
     # these cars are identified by an ACC_TYPE value of 2.
@@ -210,7 +209,7 @@ class CarState(CarStateBase):
       ]
       checks.append(("BSM", 1))
 
-    if CP.carFingerprint in RADAR_ACC_CAR or (not CP.enableDsu and CP.carFingerprint not in TSS2_CAR):
+    if CP.carFingerprint in RADAR_ACC_CAR:
       signals += [
         ("ACC_TYPE", "ACC_CONTROL"),
         ("FCW", "ACC_HUD"),
@@ -235,7 +234,7 @@ class CarState(CarStateBase):
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
     ]
 
-    if CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR):
+    if not CP.enableDsu and CP.carFingerprint not in RADAR_ACC_CAR:
       signals += [
         ("ACC_TYPE", "ACC_CONTROL"),
         ("FCW", "ACC_HUD"),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -234,7 +234,7 @@ class CarState(CarStateBase):
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
     ]
 
-    if CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR):
+    if not CP.enableDsu or CP.carFingerprint in RADAR_ACC_CAR:
       signals += [
         ("ACC_TYPE", "ACC_CONTROL"),
         ("FCW", "ACC_HUD"),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -96,11 +96,10 @@ class CarState(CarStateBase):
 
     if self.CP.carFingerprint in RADAR_ACC_CAR:
       self.acc_type = cp.vl["ACC_CONTROL"]["ACC_TYPE"]
-    elif self.CP.carFingerprint in TSS2_CAR:
-      self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
-
-    if not self.CP.enableDsu:
       ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
+    elif not self.CP.enableDsu:
+      self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
+      ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
     # these cars are identified by an ACC_TYPE value of 2.

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -94,12 +94,12 @@ class CarState(CarStateBase):
       ret.cruiseState.available = cp.vl["PCM_CRUISE_2"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["PCM_CRUISE_2"]["SET_SPEED"] * CV.KPH_TO_MS
 
-    if self.CP.carFingerprint in RADAR_ACC_CAR:
-      self.acc_type = cp.vl["ACC_CONTROL"]["ACC_TYPE"]
-      ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
-    elif not self.CP.enableDsu:
+    if self.CP.carFingerprint in TSS2_CAR:
       self.acc_type = cp_cam.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp_cam.vl["ACC_HUD"]["FCW"])
+    elif self.CP.carFingerprint in RADAR_ACC_CAR or (not self.CP.enableDsu and not self.CP.carFingerprint in TSS2_CAR):
+      self.acc_type = cp.vl["ACC_CONTROL"]["ACC_TYPE"]
+      ret.stockFcw = bool(cp.vl["ACC_HUD"]["FCW"])
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
     # these cars are identified by an ACC_TYPE value of 2.
@@ -209,7 +209,7 @@ class CarState(CarStateBase):
       ]
       checks.append(("BSM", 1))
 
-    if CP.carFingerprint in RADAR_ACC_CAR:
+    if CP.carFingerprint in RADAR_ACC_CAR or CP.enableDsu:
       signals += [
         ("ACC_TYPE", "ACC_CONTROL"),
         ("FCW", "ACC_HUD"),
@@ -234,7 +234,7 @@ class CarState(CarStateBase):
       ("PRE_COLLISION", 0), # TODO: figure out why freq is inconsistent
     ]
 
-    if not CP.enableDsu or CP.carFingerprint in RADAR_ACC_CAR:
+    if CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR):
       signals += [
         ("ACC_TYPE", "ACC_CONTROL"),
         ("FCW", "ACC_HUD"),


### PR DESCRIPTION
Don't know why this was limited to TSS 2.0 cars in the first place, the system only send `create_fcw_command` when a vehicle is not a `NO_DSU_CAR` and DSU is not seen on the CAN Network. 