### PR TITLE
statsd: fix duplicate filename

### DIFF
--- a/selfdrive/statsd.py
+++ b/selfdrive/statsd.py
@@ -88,6 +88,7 @@ def main() -> NoReturn:
   # subscribe to deviceState for started state
   sm = SubMaster(['deviceState'])
 
+  idx = 0
   last_flush_time = time.monotonic()
   gauges = {}
   samples: Dict[str, List[float]] = defaultdict(list)
@@ -149,9 +150,10 @@ def main() -> NoReturn:
       # check that we aren't filling up the drive
       if len(os.listdir(STATS_DIR)) < STATS_DIR_FILE_LIMIT:
         if len(result) > 0:
-          stats_path = os.path.join(STATS_DIR, str(int(current_time.timestamp())))
+          stats_path = os.path.join(STATS_DIR, f"{current_time.timestamp():.0f}_{idx}")
           with atomic_write_in_dir(stats_path) as f:
             f.write(result)
+          idx += 1
       else:
         cloudlog.error("stats dir full")
 


### PR DESCRIPTION
If ignition is cycled within the same second, and athena didn't yet upload the stats an exception would be thrown trying to write to an existing file.

https://sentry.io/organizations/commaai/issues/3011938822/?project=77924&query=is%3Aunresolved+daemon%3Astatsd&statsPeriod=14d