### PR TITLE
VW MQB: Cleanup, add FW for 2022 Volkswagen Taos

### DIFF
--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -469,16 +469,16 @@ FW_VERSIONS = {
   },
   CAR.POLO_MK6: {
     (Ecu.engine, 0x7e0, None): [
-        b'\xf1\x8704C906025H \xf1\x895177',
+      b'\xf1\x8704C906025H \xf1\x895177',
     ],
     (Ecu.transmission, 0x7e1, None): [
-        b'\xf1\x870CW300050D \xf1\x891908',
+      b'\xf1\x870CW300050D \xf1\x891908',
     ],
     (Ecu.srs, 0x715, None): [
       b'\xf1\x872Q0959655AJ\xf1\x890250\xf1\x82\x1248130411110416--04040404784811152H14',
     ],
     (Ecu.eps, 0x712, None): [
-        b'\xf1\x872Q1909144M \xf1\x896041',
+      b'\xf1\x872Q1909144M \xf1\x896041',
     ],
     (Ecu.fwdRadar, 0x757, None): [
       b'\xf1\x872Q0907572R \xf1\x890372',
@@ -486,19 +486,19 @@ FW_VERSIONS = {
   },
   CAR.TAOS_MK1: {
     (Ecu.engine, 0x7e0, None): [
-        b'\xf1\x8705E906013E \xf1\x891624',
+      b'\xf1\x8705E906013E \xf1\x891624',
     ],
     (Ecu.transmission, 0x7e1, None): [
-        b'\xf1\x8709S927158BL\xf1\x893791',
-    ],
-    (Ecu.fwdRadar, 0x757, None): [
-        b'\xf1\x872Q0907572T \xf1\x890383',
-    ],
-    (Ecu.eps, 0x712, None): [
-        b'\xf1\x875QM909144C \xf1\x891082\xf1\x82\x0521060605A1',
+      b'\xf1\x8709S927158BL\xf1\x893791',
     ],
     (Ecu.srs, 0x715, None): [
       b'\xf1\x875Q0959655CB\xf1\x890421\xf1\x82\x1311111111333500314646021450149333613100',
+    ],
+    (Ecu.eps, 0x712, None): [
+      b'\xf1\x875QM909144C \xf1\x891082\xf1\x82\x0521060605A1',
+    ],
+    (Ecu.fwdRadar, 0x757, None): [
+      b'\xf1\x872Q0907572T \xf1\x890383',
     ],
   },
   CAR.TCROSS_MK1: {

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -486,15 +486,19 @@ FW_VERSIONS = {
   },
   CAR.TAOS_MK1: {
     (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x8704E906027NJ\xf1\x891445',
       b'\xf1\x8705E906013E \xf1\x891624',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x8709S927158BL\xf1\x893791',
+      b'\xf1\x8709S927158FF\xf1\x893876',
     ],
     (Ecu.srs, 0x715, None): [
       b'\xf1\x875Q0959655CB\xf1\x890421\xf1\x82\x1311111111333500314646021450149333613100',
+      b'\xf1\x875Q0959655CE\xf1\x890421\xf1\x82\x1311110011333300314240021350139333613100',
     ],
     (Ecu.eps, 0x712, None): [
+      b'\xf1\x875QM909144C \xf1\x891082\xf1\x82\x0521060405A1',
       b'\xf1\x875QM909144C \xf1\x891082\xf1\x82\x0521060605A1',
     ],
     (Ecu.fwdRadar, 0x757, None): [


### PR DESCRIPTION
Fix some indentation and ordering irregularity for Polo and Taos. Add more firmware for the 2022 Volkswagen Taos.

**Dongle ID:** `f4664a55c6771e2b`

Thanks to community Taos owner MadMaxBR!