### PR TITLE
fixed CarParams write in replay

### DIFF
--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -275,7 +275,9 @@ void Replay::startStream(const Segment *cur_segment) {
   it = std::find_if(events.begin(), events.end(), [](auto e) { return e->which == cereal::Event::Which::CAR_PARAMS; });
   if (it != events.end()) {
     car_fingerprint_ = (*it)->event.getCarParams().getCarFingerprint();
-    auto bytes = (*it)->bytes();
+    capnp::MallocMessageBuilder car_params_builder;
+    car_params_builder.setRoot((*it)->event.getCarParams());
+    auto bytes = capnp::messageToFlatArray(car_params_builder).asBytes();
     Params().put("CarParams", (const char *)bytes.begin(), bytes.size());
   } else {
     rWarning("failed to read CarParams from current segment");

--- a/selfdrive/ui/replay/replay.cc
+++ b/selfdrive/ui/replay/replay.cc
@@ -275,9 +275,10 @@ void Replay::startStream(const Segment *cur_segment) {
   it = std::find_if(events.begin(), events.end(), [](auto e) { return e->which == cereal::Event::Which::CAR_PARAMS; });
   if (it != events.end()) {
     car_fingerprint_ = (*it)->event.getCarParams().getCarFingerprint();
-    capnp::MallocMessageBuilder car_params_builder;
-    car_params_builder.setRoot((*it)->event.getCarParams());
-    auto bytes = capnp::messageToFlatArray(car_params_builder).asBytes();
+    capnp::MallocMessageBuilder builder;
+    builder.setRoot((*it)->event.getCarParams());
+    auto words = capnp::messageToFlatArray(builder);
+    auto bytes = words.asBytes();
     Params().put("CarParams", (const char *)bytes.begin(), bytes.size());
   } else {
     rWarning("failed to read CarParams from current segment");


### PR DESCRIPTION
**Description**

Solves the issue in #24327 where the write to CarParams was not readable by radard. The issue was caused by converting the Event object to a byte string rather than the underlying CarParams object, when radard expected CarParams. I created a MessageBuilder, copied the CarParams reader into it, and flattened it into a list of words. That was converted to bytes and sent to Params.

**Verification**

Before this fix, radard would crash on startup. I tested my change by checking for elements of CarParams once they were loaded by radard, and got sensible values.
