### PR TITLE
testing closet: dont compress rlogs

### DIFF
--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -267,8 +267,8 @@ def uploader_fn(exit_event):
     name, key, fn = d
 
     # qlogs and bootlogs need to be compressed before uploading
-    if key.endswith(('qlog', 'rlog')) or (key.startswith('boot/') and not key.endswith('.bz2')):
-      key += ".bz2"
+    #if key.endswith(('qlog', 'rlog')) or (key.startswith('boot/') and not key.endswith('.bz2')):
+      #key += ".bz2"
 
     success = uploader.upload(name, key, fn, sm['deviceState'].networkType.raw, sm['deviceState'].networkMetered)
     if success:


### PR DESCRIPTION
Comment out lines marking qlogs/rlogs for compression.
Saves 13+2s in upload process.