### PR TITLE
Hyundai longitudinal: set jerk limits to max

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -104,22 +104,18 @@ class CarController:
             self.last_button_frame = self.frame
 
       if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
-        accel = actuators.accel
-        jerk = 0
+        self.accel = actuators.accel
 
-        if CC.longActive:
-          jerk = clip(2.0 * (accel - CS.out.aEgo), -12.7, 12.7)
-          if accel < 0:
-            accel = interp(accel - CS.out.aEgo, [-1.0, -0.5], [2 * accel, accel])
+        if CC.longActive and self.accel < 0:
+          self.accel = interp(self.accel - CS.out.aEgo, [-1.0, -0.5], [2 * self.accel, self.accel])
 
-        accel = clip(accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
+        self.accel = clip(self.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
 
         lead_visible = False
         stopping = actuators.longControlState == LongCtrlState.stopping
         set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_MPH if CS.clu11["CF_Clu_SPEED_UNIT"] == 1 else CV.MS_TO_KPH)
-        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2), lead_visible,
-                                             set_speed_in_units, stopping, CS.out.gasPressed))
-        self.accel = accel
+        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, self.accel, int(self.frame / 2),
+                                                        lead_visible, set_speed_in_units, stopping, CS.out.gasPressed))
 
       # 20 Hz LFA MFA message
       if self.frame % 5 == 0 and self.car_fingerprint in (CAR.SONATA, CAR.PALISADE, CAR.IONIQ, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_HEV_2021,

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -3,6 +3,7 @@ from selfdrive.car.hyundai.values import CAR, CHECKSUM
 
 hyundai_checksum = crcmod.mkCrcFun(0x11D, initCrc=0xFD, rev=False, xorOut=0xdf)
 
+
 def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
                   lkas11, sys_warning, sys_state, enabled,
                   left_lane, right_lane,
@@ -78,7 +79,8 @@ def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 
-def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_speed, stopping, gas_pressed):
+
+def create_acc_commands(packer, enabled, accel, idx, lead_visible, set_speed, stopping, gas_pressed):
   commands = []
 
   scc11_values = {
@@ -107,12 +109,12 @@ def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_spe
   commands.append(packer.make_can_msg("SCC12", 0, scc12_values))
 
   scc14_values = {
-    "ComfortBandUpper": 0.0, # stock usually is 0 but sometimes uses higher values
-    "ComfortBandLower": 0.0, # stock usually is 0 but sometimes uses higher values
-    "JerkUpperLimit": max(jerk, 1.0) if not stopping else 0, # stock usually is 1.0 but sometimes uses higher values
-    "JerkLowerLimit": max(-jerk, 1.0), # stock usually is 0.5 but sometimes uses higher values
-    "ACCMode": 2 if enabled and gas_pressed else 1 if enabled else 4, # stock will always be 4 instead of 0 after first disengage
-    "ObjGap": 2 if lead_visible else 0, # 5: >30, m, 4: 25-30 m, 3: 20-25 m, 2: < 20 m, 0: no lead
+    "ComfortBandUpper": 0.0,  # stock usually is 0 but sometimes uses higher values
+    "ComfortBandLower": 0.0,  # stock usually is 0 but sometimes uses higher values
+    "JerkUpperLimit": 12.7 if not stopping and enabled else 0,  # max jerk limits, aReq should control jerk
+    "JerkLowerLimit": 12.7 if enabled else 0,
+    "ACCMode": 2 if enabled and gas_pressed else 1 if enabled else 4,  # stock will always be 4 instead of 0 after first disengage
+    "ObjGap": 2 if lead_visible else 0,  # 5: >30, m, 4: 25-30 m, 3: 20-25 m, 2: < 20 m, 0: no lead
   }
   commands.append(packer.make_can_msg("SCC14", 0, scc14_values))
 
@@ -132,6 +134,7 @@ def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_spe
 
   return commands
 
+
 def create_acc_opt(packer):
   commands = []
 
@@ -149,6 +152,7 @@ def create_acc_opt(packer):
   commands.append(packer.make_can_msg("FCA12", 0, fca12_values))
 
   return commands
+
 
 def create_frt_radar_opt(packer):
   frt_radar11_values = {


### PR DESCRIPTION
From my testing on a 2020 Sonata, changing the jerk limits to the maximum value had little effect in both transitioning from 2.0 m/s/s to -3.0 m/s/s instantly, and continually ramping up to 2.0 m/s/s then ramping down to -3.0 m/s/s.

However I think this makes sense conceptually to allow maximum jerk possible, the car should always follow the acceleration request, which with no lag, is already jerk limited from the planner (not including the controller).

Car's jerk request vs our jerk request: https://imgur.com/a/JPSO02U. Will post more results and get testers before merging.