### PR TITLE
CARLA: Remove GPU requirement for openpilot docker

### DIFF
--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -19,7 +19,6 @@ docker run --net=host\
   --name openpilot_client \
   --rm \
   -it \
-  --gpus all \
   --device=/dev/dri:/dev/dri \
   --device=/dev/input:/dev/input \
   -v /tmp/.X11-unix:/tmp/.X11-unix \


### PR DESCRIPTION
no GPU is needed for running openpilot. This pull request solves this error message when starting openpilot docker.

```
$./start_openpilot_docker.sh 
non-network local connections being added to access control list
latest: Pulling from commaai/openpilot-sim
Digest: sha256:bb016007c940d0b3c6cba526cbd81f0fec0caf06c735451b8c286fbe925fa7a1
Status: Image is up to date for ghcr.io/commaai/openpilot-sim:latest
ghcr.io/commaai/openpilot-sim:latest
docker: Error response from daemon: failed to create shim: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: nvidia-container-cli: initialization error: nvml error: driver not loaded: unknown.
```
