### PR TITLE
AGNOS 5

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@ Version 0.8.15 (2022-XX-XX)
   * Much smoother control, consistent across the speed range
   * Effective feedforward that uses road roll
   * Simplified tuning, all car-specific parameters can be derived from data
+* AGNOS 5
 
 Version 0.8.14 (2022-06-01)
 ========================

--- a/launch_env.sh
+++ b/launch_env.sh
@@ -7,7 +7,7 @@ export OPENBLAS_NUM_THREADS=1
 export VECLIB_MAXIMUM_THREADS=1
 
 if [ -z "$AGNOS_VERSION" ]; then
-  export AGNOS_VERSION="4"
+  export AGNOS_VERSION="5"
 fi
 
 if [ -z "$PASSIVE" ]; then

--- a/selfdrive/hardware/tici/agnos.json
+++ b/selfdrive/hardware/tici/agnos.json
@@ -1,9 +1,9 @@
 [
   {
     "name": "boot",
-    "url": "https://commadist.azureedge.net/agnosupdate/boot-0a86272196cb54607f8ba082f412fed4607baaf6ce3eb8dc8e950b4a1d763954.img.xz",
-    "hash": "0a86272196cb54607f8ba082f412fed4607baaf6ce3eb8dc8e950b4a1d763954",
-    "hash_raw": "0a86272196cb54607f8ba082f412fed4607baaf6ce3eb8dc8e950b4a1d763954",
+    "url": "https://commadist.azureedge.net/agnosupdate-staging/boot-e92fd5e29276c1272146af455f30d5a79075256112bff91e193ad0905777be1d.img.xz",
+    "hash": "e92fd5e29276c1272146af455f30d5a79075256112bff91e193ad0905777be1d",
+    "hash_raw": "e92fd5e29276c1272146af455f30d5a79075256112bff91e193ad0905777be1d",
     "size": 14776320,
     "sparse": false,
     "full_check": true,
@@ -11,7 +11,7 @@
   },
   {
     "name": "abl",
-    "url": "https://commadist.azureedge.net/agnosupdate/abl-ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate-staging/abl-ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82.img.xz",
     "hash": "ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82",
     "hash_raw": "ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82",
     "size": 274432,
@@ -21,7 +21,7 @@
   },
   {
     "name": "xbl",
-    "url": "https://commadist.azureedge.net/agnosupdate/xbl-2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate-staging/xbl-2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35.img.xz",
     "hash": "2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35",
     "hash_raw": "2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35",
     "size": 3670016,
@@ -31,7 +31,7 @@
   },
   {
     "name": "xbl_config",
-    "url": "https://commadist.azureedge.net/agnosupdate/xbl_config-3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate-staging/xbl_config-3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad.img.xz",
     "hash": "3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad",
     "hash_raw": "3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad",
     "size": 364544,
@@ -41,9 +41,9 @@
   },
   {
     "name": "system",
-    "url": "https://commadist.azureedge.net/agnosupdate/system-9b0b534ed0c35c25850dbb73d3f052611f2e2c9db32410edc25d75fbcfc6c15e.img.xz",
-    "hash": "b1f622f00037bbdb28c0a6016c0e42fa7f87e99591ff2417c757a67ff559b526",
-    "hash_raw": "9b0b534ed0c35c25850dbb73d3f052611f2e2c9db32410edc25d75fbcfc6c15e",
+    "url": "https://commadist.azureedge.net/agnosupdate-staging/system-2995bf503f100fcca5516cca05b5f309156cc77b95ab1e87cdc0246f32176a52.img.xz",
+    "hash": "cb0c2e8a9cfa6777657ecd5c9664e72c57f1195778a4a7d36478cd7159a9eac1",
+    "hash_raw": "2995bf503f100fcca5516cca05b5f309156cc77b95ab1e87cdc0246f32176a52",
     "size": 10737418240,
     "sparse": true,
     "full_check": false,

--- a/selfdrive/hardware/tici/agnos.json
+++ b/selfdrive/hardware/tici/agnos.json
@@ -1,17 +1,17 @@
 [
   {
     "name": "boot",
-    "url": "https://commadist.azureedge.net/agnosupdate-staging/boot-e92fd5e29276c1272146af455f30d5a79075256112bff91e193ad0905777be1d.img.xz",
-    "hash": "e92fd5e29276c1272146af455f30d5a79075256112bff91e193ad0905777be1d",
-    "hash_raw": "e92fd5e29276c1272146af455f30d5a79075256112bff91e193ad0905777be1d",
-    "size": 14776320,
+    "url": "https://commadist.azureedge.net/agnosupdate/boot-bb71f49294150c4233b89e2a10768a5a3de003203ecd02e3f845821b35cd409f.img.xz",
+    "hash": "bb71f49294150c4233b89e2a10768a5a3de003203ecd02e3f845821b35cd409f",
+    "hash_raw": "bb71f49294150c4233b89e2a10768a5a3de003203ecd02e3f845821b35cd409f",
+    "size": 14780416,
     "sparse": false,
     "full_check": true,
     "has_ab": true
   },
   {
     "name": "abl",
-    "url": "https://commadist.azureedge.net/agnosupdate-staging/abl-ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate/abl-ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82.img.xz",
     "hash": "ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82",
     "hash_raw": "ab4068f005ed9cb7fbca55c6d658880df1abfb1a4e6afb64f3fc5e64dac6fc82",
     "size": 274432,
@@ -21,7 +21,7 @@
   },
   {
     "name": "xbl",
-    "url": "https://commadist.azureedge.net/agnosupdate-staging/xbl-2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate/xbl-2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35.img.xz",
     "hash": "2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35",
     "hash_raw": "2b1b67aa918cd127f2b0b4ed0a372f3a93676cf9d270bd3e56329516efdc5a35",
     "size": 3670016,
@@ -31,7 +31,7 @@
   },
   {
     "name": "xbl_config",
-    "url": "https://commadist.azureedge.net/agnosupdate-staging/xbl_config-3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate/xbl_config-3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad.img.xz",
     "hash": "3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad",
     "hash_raw": "3aa926394b4cec464300bfc0e7ab77d50889b38041138c60cd84c397930b38ad",
     "size": 364544,
@@ -41,9 +41,9 @@
   },
   {
     "name": "system",
-    "url": "https://commadist.azureedge.net/agnosupdate-staging/system-2995bf503f100fcca5516cca05b5f309156cc77b95ab1e87cdc0246f32176a52.img.xz",
-    "hash": "cb0c2e8a9cfa6777657ecd5c9664e72c57f1195778a4a7d36478cd7159a9eac1",
-    "hash_raw": "2995bf503f100fcca5516cca05b5f309156cc77b95ab1e87cdc0246f32176a52",
+    "url": "https://commadist.azureedge.net/agnosupdate/system-8aa796767e3af57fd24e4d54280944187b8fcc04c8748f5c20fef2700be10161.img.xz",
+    "hash": "b51b8247f2b926edc3a2b8242bbab52a484ae72559a3b4a55e961bf6b8d47223",
+    "hash_raw": "8aa796767e3af57fd24e4d54280944187b8fcc04c8748f5c20fef2700be10161",
     "size": 10737418240,
     "sparse": true,
     "full_check": false,


### PR DESCRIPTION
* VSCode remote support
* updated ModemManager + libqmi
* NetworkManager connections for both prime types 
* block incoming cell connections
* new python packages: onnx, pyopencl, PyQt, pytest

## release checklist

- [x] CPU usage
- [x] shutdown
- [x] bootkick on ignition
- [x] wifi
- [x] modem
- [x] image size
- [x] sounds
- [x] python/shims works
- [x] clean openpilot build
- [x] factory reset
  - [x] user-prompted reset
  - [x] corrupt userdata
- [x] color calibration
- [x] clean setup