### PR TITLE
Hyundai Kona Hybrid 2020: use torque controller

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -131,7 +131,7 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 13.42  # Spec
       tire_stiffness_factor = 0.385
       if candidate == CAR.KONA_HEV:
-        set_torque_tune(ret.lateralTuning, 3.6, 0.01)
+        set_torque_tune(ret.lateralTuning, 4.0, 0.01)
       else:
         ret.lateralTuning.pid.kf = 0.00005
         ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -126,13 +126,16 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.indi.actuatorEffectivenessV = [2.3]
       ret.minSteerSpeed = 60 * CV.KPH_TO_MS
     elif candidate in (CAR.KONA, CAR.KONA_EV, CAR.KONA_HEV):
-      ret.lateralTuning.pid.kf = 0.00005
       ret.mass = {CAR.KONA_EV: 1685., CAR.KONA_HEV: 1425.}.get(candidate, 1275.) + STD_CARGO_KG
       ret.wheelbase = 2.6
       ret.steerRatio = 13.42  # Spec
       tire_stiffness_factor = 0.385
-      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
+      if candidate == CAR.KONA_HEV:
+        set_torque_tune(ret.lateralTuning, 3.6, 0.01)
+      else:
+        ret.lateralTuning.pid.kf = 0.00005
+        ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
+        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.05]]
     elif candidate in (CAR.IONIQ, CAR.IONIQ_EV_LTD, CAR.IONIQ_EV_2020, CAR.IONIQ_PHEV, CAR.IONIQ_HEV_2022):
       ret.lateralTuning.pid.kf = 0.00006
       ret.mass = 1490. + STD_CARGO_KG  # weight per hyundai site https://www.hyundaiusa.com/ioniq-electric/specifications.aspx


### PR DESCRIPTION
User claims the car took this curve on its own with no overriding: https://connect.comma.ai/9a3aa85e86f9c3fc/1654135225953/1654135287942 

Looked at this segment manually and it was able to hit 3.9 m/s/s at 15 m/s:
![Screenshot from 2022-06-02 00-16-15](https://user-images.githubusercontent.com/25857203/171574928-a0eb3ebb-ec5f-48bb-903f-0b0a4160ac0f.png)

Another route at 3.6 m/s/s, still overshooting (max torque too low): https://connect.comma.ai/9a3aa85e86f9c3fc/1654157401617/1654157440571

Seems like this thing can take turns: https://imgur.com/a/XXDiXSZ (possibly 4.0 m/s/s is still too low, from the fit)