### PR TITLE
thermald: consider pmic in component temp management

### DIFF
--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -244,7 +244,7 @@ def thermald_thread(end_event, hw_queue):
     current_filter.update(msg.deviceState.batteryCurrent / 1e6)
 
     max_comp_temp = temp_filter.update(
-      max(max(msg.deviceState.cpuTempC), msg.deviceState.memoryTempC, max(msg.deviceState.gpuTempC))
+      max(max(msg.deviceState.cpuTempC), msg.deviceState.memoryTempC, max(msg.deviceState.gpuTempC), max(msg.deviceState.pmicTempC))
     )
 
     if fan_controller is not None:


### PR DESCRIPTION
For an offroad C3 sitting in the sun, the PMIC temperature appears to be the highest sensed on the device, but it currently isn't considered for ThermalStatus changes. Add it to the list of monitored components, to give the device a better chance at staying offroad if it's too heat-soaked to startup without going into the red zone.

Doesn't resolve, but may help with #23144.

Route: `3cfdec54aa035f3f|2022-05-29--16-38-08`

<img width="496" alt="image" src="https://user-images.githubusercontent.com/46612682/171574785-93b1df7a-157b-4585-9ddc-1e7a9dd5d542.png">