### PR TITLE
when fingerprinting fails use last successful fw fingerprint for VIN

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -134,6 +134,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"LastSystemShutdown", CLEAR_ON_MANAGER_START},
     {"LastUpdateException", CLEAR_ON_MANAGER_START},
     {"LastUpdateTime", PERSISTENT},
+    {"LastVinFingerprint", PERSISTENT},
     {"LiveParameters", PERSISTENT},
     {"NavDestination", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},
     {"NavSettingTime24h", PERSISTENT},

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -170,7 +170,7 @@ def fingerprint(logcan, sendcan):
   if not car_fingerprint:
     # use last successful fingerprint for VIN if no match was found
     try:
-      last_vin_fingerprint = json.loads(Params().get("LastVinFingerprint"))
+      last_vin_fingerprint = json.loads(Params().get("LastVinFingerprint") or b"")
     except json.decoder.JSONDecodeError:
       last_vin_fingerprint = dict()
     if vin in last_vin_fingerprint:


### PR DESCRIPTION
idea to better handle people taking their car in for service and openpilot doesn't work when they leave to due to updates applied to their vehicle

example: https://github.com/commaai/openpilot/issues/24444

when we process qlogs we should automatically open PRs to add missing fw versions if the fingerprint was not an exact match

needs tests and probably more logging if this is something we actually want to do