### PR TITLE
GM: add support for vehicles with manual parking brakes

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -64,7 +64,7 @@ class CarState(CarStateBase):
     ret.leftBlinker = pt_cp.vl["BCMTurnSignals"]["TurnSignals"] == 1
     ret.rightBlinker = pt_cp.vl["BCMTurnSignals"]["TurnSignals"] == 2
 
-    ret.parkingBrake = pt_cp.vl["EPBStatus"]["EPBClosed"] == 1
+    ret.parkingBrake = pt_cp.vl["VehicleIgnitionAlt"]["ParkBrake"] == 1
     ret.cruiseState.available = pt_cp.vl["ECMEngineStatus"]["CruiseMainOn"] != 0
     ret.espDisabled = pt_cp.vl["ESPStatus"]["TractionControlOn"] != 1
     ret.accFaulted = pt_cp.vl["AcceleratorPedal2"]["CruiseState"] == AccState.FAULTED
@@ -100,7 +100,7 @@ class CarState(CarStateBase):
       ("LKATorqueDelivered", "PSCMStatus"),
       ("LKATorqueDeliveredStatus", "PSCMStatus"),
       ("TractionControlOn", "ESPStatus"),
-      ("EPBClosed", "EPBStatus"),
+      ("ParkBrake", "VehicleIgnitionAlt"),
       ("CruiseMainOn", "ECMEngineStatus"),
     ]
 
@@ -110,7 +110,7 @@ class CarState(CarStateBase):
       ("PSCMStatus", 10),
       ("ESPStatus", 10),
       ("BCMDoorBeltStatus", 10),
-      ("EPBStatus", 20),
+      ("VehicleIgnitionAlt", 10),
       ("EBCMWheelSpdFront", 20),
       ("EBCMWheelSpdRear", 20),
       ("AcceleratorPedal2", 33),


### PR DESCRIPTION
**Description**

The message EPBStatus is only present in vehicles with an electronic parking brake - many truck still use manual parking brakes.

The newly discovered VehicleIgnitionAlt.ParkBrake signal appears to be present in all vehicles regardless of Electronic vs Manual parking brake 


**Verification**

Confirmed that the message is present in all fingerprints; tested on Suburban (Manual) and Bolt (EPB).

Actuating the parking brake doesn't appear to be part of the typical test route. I've done as much validation as I can reasonably accomplish.

@sshane has offered to help with signal regression testing