### PR TITLE
Laikad: Cache orbit and nav data

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -127,6 +127,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"IsTakingSnapshot", CLEAR_ON_MANAGER_START},
     {"IsUpdateAvailable", CLEAR_ON_MANAGER_START},
     {"JoystickDebugMode", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},
+    {"LaikadEphemeris", PERSISTENT},
     {"LastAthenaPingTime", CLEAR_ON_MANAGER_START},
     {"LastGPSPosition", PERSISTENT},
     {"LastManagerExitReason", CLEAR_ON_MANAGER_START},

--- a/selfdrive/locationd/laikad.py
+++ b/selfdrive/locationd/laikad.py
@@ -30,7 +30,6 @@ class Laikad:
     self.gnss_kf = GNSSKalman(GENERATED_DIR)
     self.orbit_p: Optional[Process] = None
     self.orbit_q = Queue()
-    self.params = Params()
     self.load_cache()
     self.last_save_t = None
     self.last_fetch_orbits_t = None

--- a/selfdrive/locationd/laikad.py
+++ b/selfdrive/locationd/laikad.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import time
-from multiprocessing import Process, Queue
+from concurrent.futures import Future, ProcessPoolExecutor
 from typing import List, Optional
 
 import numpy as np
@@ -10,7 +10,7 @@ from numpy.linalg import linalg
 
 from cereal import log, messaging
 from laika import AstroDog
-from laika.constants import SECS_IN_MIN
+from laika.constants import SECS_IN_HR, SECS_IN_MIN
 from laika.ephemeris import EphemerisType, convert_ublox_ephem
 from laika.gps_time import GPSTime
 from laika.helpers import ConstellationId
@@ -29,8 +29,9 @@ class Laikad:
   def __init__(self, valid_const=("GPS", "GLONASS"), auto_update=False, valid_ephem_types=(EphemerisType.ULTRA_RAPID_ORBIT, EphemerisType.NAV)):
     self.astro_dog = AstroDog(valid_const=valid_const, auto_update=auto_update, valid_ephem_types=valid_ephem_types)
     self.gnss_kf = GNSSKalman(GENERATED_DIR)
-    self.orbit_p: Optional[Process] = None
-    self.orbit_q = Queue()
+    self.orbit_fetch_executor = ProcessPoolExecutor()
+    self.orbit_fetch_future: Optional[Future] = None
+    self.last_fetch_orbits_t = None
 
   def process_ublox_msg(self, ublox_msg, ublox_mono_time: int, block=False):
     if ublox_msg.which == 'measurementReport':
@@ -82,7 +83,7 @@ class Laikad:
       return dat
     elif ublox_msg.which == 'ephemeris':
       ephem = convert_ublox_ephem(ublox_msg.ephemeris)
-      self.astro_dog.add_ephems([ephem], self.astro_dog.nav)
+      self.astro_dog.add_navs([ephem])
     # elif ublox_msg.which == 'ionoData':
     # todo add this. Needed to better correct messages offline. First fix ublox_msg.cc to sent them.
 
@@ -100,7 +101,7 @@ class Laikad:
         cloudlog.error("Gnss kalman std too far")
 
       if len(pos_fix) == 0:
-        cloudlog.error("Position fix not available when resetting kalman filter")
+        cloudlog.warning("Position fix not available when resetting kalman filter")
         return
       post_est = pos_fix[0][:3].tolist()
       self.init_gnss_localizer(post_est)
@@ -124,36 +125,33 @@ class Laikad:
 
     self.gnss_kf.init_state(x_initial, covs_diag=p_initial_diag)
 
-  def get_orbit_data(self, t: GPSTime, queue):
-    cloudlog.info(f"Start to download/parse orbits for time {t.as_datetime()}")
-    start_time = time.monotonic()
-    try:
-      self.astro_dog.get_orbit_data(t, only_predictions=True)
-    except RuntimeError as e:
-      cloudlog.info(f"No orbit data found. {e}")
-      return
-    cloudlog.info(f"Done parsing orbits. Took {time.monotonic() - start_time:.2f}s")
-    if queue is not None:
-      queue.put((self.astro_dog.orbits, self.astro_dog.orbit_fetched_times))
-
   def fetch_orbits(self, t: GPSTime, block):
-    if t not in self.astro_dog.orbit_fetched_times:
-      if block:
-        self.get_orbit_data(t, None)
-        return
-      if self.orbit_p is None:
-        self.orbit_p = Process(target=self.get_orbit_data, args=(t, self.orbit_q))
-        self.orbit_p.start()
-      if not self.orbit_q.empty():
-        ret = self.orbit_q.get()
+    if t not in self.astro_dog.orbit_fetched_times and (self.last_fetch_orbits_t is None or t - self.last_fetch_orbits_t > SECS_IN_HR):
+      astro_dog_vars = self.astro_dog.valid_const, self.astro_dog.auto_update, self.astro_dog.valid_ephem_types
+      if self.orbit_fetch_future is None:
+        self.orbit_fetch_future = self.orbit_fetch_executor.submit(get_orbit_data, t, *astro_dog_vars)
+        if block:
+          self.orbit_fetch_future.result()
+      if self.orbit_fetch_future.done():
+        ret = self.orbit_fetch_future.result()
         if ret:
           self.astro_dog.orbits, self.astro_dog.orbit_fetched_times = ret
-          self.orbit_p.join()
-          self.orbit_p = None
+        self.orbit_fetch_future = None
+        self.last_fetch_orbits_t = t
 
-  def __del__(self):
-    if self.orbit_p is not None:
-      self.orbit_p.kill()
+
+def get_orbit_data(t: GPSTime, valid_const, auto_update, valid_ephem_types):
+  astro_dog = AstroDog(valid_const=valid_const, auto_update=auto_update, valid_ephem_types=valid_ephem_types)
+  cloudlog.info(f"Start to download/parse orbits for time {t.as_datetime()}")
+  start_time = time.monotonic()
+  data = None
+  try:
+    astro_dog.get_orbit_data(t, only_predictions=True)
+    data = (astro_dog.orbits, astro_dog.orbit_fetched_times)
+  except RuntimeError as e:
+    cloudlog.info(f"No orbit data found. {e}")
+  cloudlog.info(f"Done parsing orbits. Took {time.monotonic() - start_time:.2f}s")
+  return data
 
 
 def create_measurement_msg(meas: GNSSMeasurement):

--- a/selfdrive/locationd/laikad.py
+++ b/selfdrive/locationd/laikad.py
@@ -150,7 +150,7 @@ def get_orbit_data(t: GPSTime, valid_const, auto_update, valid_ephem_types):
     data = (astro_dog.orbits, astro_dog.orbit_fetched_times)
   except RuntimeError as e:
     cloudlog.info(f"No orbit data found. {e}")
-  cloudlog.info(f"Done parsing orbits. Took {time.monotonic() - start_time:.2f}s")
+  cloudlog.info(f"Done parsing orbits. Took {time.monotonic() - start_time:.1f}s")
   return data
 
 

--- a/selfdrive/locationd/laikad.py
+++ b/selfdrive/locationd/laikad.py
@@ -53,8 +53,7 @@ class Laikad:
       report = ublox_msg.measurementReport
       if report.gpsWeek > 0:
         latest_msg_t = GPSTime(report.gpsWeek, report.rcvTow)
-        if self.last_fetch_orbits_t is None or latest_msg_t - self.last_fetch_orbits_t> SECS_IN_HR:
-          self.fetch_orbits(latest_msg_t + SECS_IN_MIN, block)
+        self.fetch_orbits(latest_msg_t + SECS_IN_MIN, block)
       new_meas = read_raw_ublox(report)
 
       measurements = process_measurements(new_meas, self.astro_dog)
@@ -141,9 +140,9 @@ class Laikad:
       queue.put(queue_data)
 
   def fetch_orbits(self, t: GPSTime, block):
-    if t not in self.astro_dog.orbit_fetched_times:
+    if t not in self.astro_dog.orbit_fetched_times and (self.last_fetch_orbits_t is None or t - self.last_fetch_orbits_t > SECS_IN_HR):
       if block:
-        # For testing purposes
+        # Blocking used for testing purposes
         self.get_orbit_data(t, None)
         return
       if self.orbit_p is None:

--- a/selfdrive/locationd/laikad.py
+++ b/selfdrive/locationd/laikad.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import json
 import time
 from concurrent.futures import Future, ProcessPoolExecutor
 from typing import List, Optional
@@ -12,7 +13,7 @@ from cereal import log, messaging
 from common.params import Params, put_nonblocking
 from laika import AstroDog
 from laika.constants import SECS_IN_HR, SECS_IN_MIN
-from laika.ephemeris import EphemerisType, convert_ublox_ephem
+from laika.ephemeris import Ephemeris, EphemerisType, convert_ublox_ephem
 from laika.gps_time import GPSTime
 from laika.helpers import ConstellationId
 from laika.raw_gnss import GNSSMeasurement, calc_pos_fix, correct_measurements, process_measurements, read_raw_ublox
@@ -24,30 +25,39 @@ from system.swaglog import cloudlog
 
 MAX_TIME_GAP = 10
 EPHEMERIS_CACHE = 'LaikadEphemeris'
+CACHE_VERSION = 0.1
 
 
 class Laikad:
-  def __init__(self, valid_const=("GPS", "GLONASS"), auto_update=False, valid_ephem_types=(EphemerisType.ULTRA_RAPID_ORBIT, EphemerisType.NAV)):
+  def __init__(self, valid_const=("GPS", "GLONASS"), auto_update=False, valid_ephem_types=(EphemerisType.ULTRA_RAPID_ORBIT, EphemerisType.NAV),
+               save_ephemeris=False):
     self.astro_dog = AstroDog(valid_const=valid_const, auto_update=auto_update, valid_ephem_types=valid_ephem_types, clear_old_ephemeris=True)
     self.gnss_kf = GNSSKalman(GENERATED_DIR)
     self.orbit_fetch_executor = ProcessPoolExecutor()
     self.orbit_fetch_future: Optional[Future] = None
     self.last_fetch_orbits_t = None
+    self.last_cached_t = None
+    self.save_ephemeris = save_ephemeris
     self.load_cache()
-    self.last_save_t = None
 
   def load_cache(self):
-    params = Params()
-    if params.check_key(EPHEMERIS_CACHE) and False:  # todo fix get params
-      ephemeris = params.get('LaikadEphemeris', block=True)
+    cache = Params().get('LaikadEphemeris')
+    if not cache:
+      return
+    try:
+      cache = json.loads(cache, object_hook=deserialize_hook)
+      self.astro_dog.add_orbits(cache['orbits'])
+      self.astro_dog.add_navs(cache['nav'])
+      self.last_fetch_orbits_t = cache['last_fetch_orbits_t']
+    except json.decoder.JSONDecodeError:
+      cloudlog.exception("Error parsing cache")
 
-      self.astro_dog.add_orbits(ephemeris['orbits'])
-      self.astro_dog.add_navs(ephemeris['nav'])
-
-  def cache_ephemeris(self, t):
-    if self.last_save_t is None or t - self.last_save_t > 30 * SECS_IN_MIN:
-      put_nonblocking('LaikadEphemeris', {'orbits': self.astro_dog.orbits, 'nav': self.astro_dog.nav})
-      self.last_save_t = t
+  def cache_ephemeris(self, t: GPSTime):
+    if self.save_ephemeris and (self.last_cached_t is None or t - self.last_cached_t > SECS_IN_MIN):
+      put_nonblocking('LaikadEphemeris', json.dumps(
+        {'version': CACHE_VERSION, 'last_fetch_orbits_t': self.last_fetch_orbits_t, 'orbits': self.astro_dog.orbits, 'nav': self.astro_dog.nav},
+        cls=CacheSerializer))
+      self.last_cached_t = t
 
   def process_ublox_msg(self, ublox_msg, ublox_mono_time: int, block=False):
     if ublox_msg.which == 'measurementReport':
@@ -99,8 +109,8 @@ class Laikad:
       return dat
     elif ublox_msg.which == 'ephemeris':
       ephem = convert_ublox_ephem(ublox_msg.ephemeris)
-      self.astro_dog.add_navs([ephem])
-      self.cache_ephemeris(ephem.epoch)
+      self.astro_dog.add_navs({ephem.prn: [ephem]})
+      self.cache_ephemeris(t=ephem.epoch)
     # elif ublox_msg.which == 'ionoData':
     # todo add this. Needed to better correct messages offline. First fix ublox_msg.cc to sent them.
 
@@ -118,7 +128,7 @@ class Laikad:
         cloudlog.error("Gnss kalman std too far")
 
       if len(pos_fix) == 0:
-        cloudlog.warning("Position fix not available when resetting kalman filter")
+        cloudlog.info("Position fix not available when resetting kalman filter")
         return
       post_est = pos_fix[0][:3].tolist()
       self.init_gnss_localizer(post_est)
@@ -153,7 +163,7 @@ class Laikad:
         ret = self.orbit_fetch_future.result()
         if ret:
           self.astro_dog.orbits, self.astro_dog.orbit_fetched_times = ret
-          self.cache_ephemeris(t)
+          self.cache_ephemeris(t=t)
         self.orbit_fetch_future = None
         self.last_fetch_orbits_t = t
 
@@ -211,11 +221,31 @@ def get_bearing_from_gnss(ecef_pos, ecef_vel, vel_std):
   return float(np.rad2deg(bearing)), float(bearing_std)
 
 
+class CacheSerializer(json.JSONEncoder):
+
+  def default(self, o):
+    if isinstance(o, Ephemeris):
+      return o.to_json()
+    if isinstance(o, GPSTime):
+      return o.__dict__
+    if isinstance(o, np.ndarray):
+      return o.tolist()
+    return json.JSONEncoder.default(self, o)
+
+
+def deserialize_hook(dct):
+  if 'eph_type' in dct:
+    return Ephemeris.from_json(dct)
+  if 'week' in dct:
+    return GPSTime(dct['week'], dct['tow'])
+  return dct
+
+
 def main():
   sm = messaging.SubMaster(['ubloxGnss'])
   pm = messaging.PubMaster(['gnssMeasurements'])
 
-  laikad = Laikad()
+  laikad = Laikad(save_ephemeris=True)
   while True:
     sm.update()
 

--- a/selfdrive/locationd/test/test_laikad.py
+++ b/selfdrive/locationd/test/test_laikad.py
@@ -37,8 +37,10 @@ class TestLaikad(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    Params().delete('LaikadEphemeris')
     cls.logs = get_log(range(1))
+
+  def setUp(self):
+    Params().delete('LaikadEphemeris')
 
   def test_create_msg_without_errors(self):
     gpstime = GPSTime.from_datetime(datetime.now())

--- a/selfdrive/locationd/test/test_laikad.py
+++ b/selfdrive/locationd/test/test_laikad.py
@@ -10,7 +10,7 @@ from laika.ephemeris import EphemerisType
 from laika.gps_time import GPSTime
 from laika.helpers import ConstellationId, TimeRangeHolder
 from laika.raw_gnss import GNSSMeasurement, read_raw_ublox
-from selfdrive.locationd.laikad import Laikad, create_measurement_msg
+from selfdrive.locationd.laikad import EPHEMERIS_CACHE, Laikad, create_measurement_msg
 from selfdrive.test.openpilotci import get_url
 from tools.lib.logreader import LogReader
 
@@ -40,7 +40,7 @@ class TestLaikad(unittest.TestCase):
     cls.logs = get_log(range(1))
 
   def setUp(self):
-    Params().delete('LaikadEphemeris')
+    Params().delete(EPHEMERIS_CACHE)
 
   def test_create_msg_without_errors(self):
     gpstime = GPSTime.from_datetime(datetime.now())
@@ -121,7 +121,7 @@ class TestLaikad(unittest.TestCase):
 
     def wait_for_cache():
       max_time = 2
-      while Params().get('LaikadEphemeris') is None:
+      while Params().get(EPHEMERIS_CACHE) is None:
         time.sleep(0.1)
         max_time -= 0.1
         if max_time == 0:
@@ -129,7 +129,7 @@ class TestLaikad(unittest.TestCase):
     # Test cache with no ephemeris
     laikad.cache_ephemeris(t=GPSTime(0, 0))
     wait_for_cache()
-    Params().delete('LaikadEphemeris')
+    Params().delete(EPHEMERIS_CACHE)
 
     laikad.astro_dog.get_navs(first_gps_time)
     laikad.fetch_orbits(first_gps_time, block=True)

--- a/selfdrive/locationd/test/test_laikad.py
+++ b/selfdrive/locationd/test/test_laikad.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import time
 import unittest
 from datetime import datetime
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+from common.params import Params
 from laika.ephemeris import EphemerisType
 from laika.gps_time import GPSTime
-from laika.helpers import ConstellationId
+from laika.helpers import ConstellationId, TimeRangeHolder
 from laika.raw_gnss import GNSSMeasurement, read_raw_ublox
 from selfdrive.locationd.laikad import Laikad, create_measurement_msg
 from selfdrive.test.openpilotci import get_url
@@ -20,12 +22,14 @@ def get_log(segs=range(0)):
   return [m for m in logs if m.which() == 'ubloxGnss']
 
 
-def verify_messages(lr, laikad):
+def verify_messages(lr, laikad, return_one_success=False):
   good_msgs = []
   for m in lr:
     msg = laikad.process_ublox_msg(m.ubloxGnss, m.logMonoTime, block=True)
     if msg is not None and len(msg.gnssMeasurements.correctedMeasurements) > 0:
       good_msgs.append(msg)
+      if return_one_success:
+        return msg
   return good_msgs
 
 
@@ -33,6 +37,7 @@ class TestLaikad(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
+    Params().delete('LaikadEphemeris')
     cls.logs = get_log(range(1))
 
   def test_create_msg_without_errors(self):
@@ -81,8 +86,7 @@ class TestLaikad(unittest.TestCase):
     first_gps_time = self.get_first_gps_time()
     # Pretend process has loaded the orbits on startup by using the time of the first gps message.
     laikad.fetch_orbits(first_gps_time, block=True)
-    self.assertEqual(29, len(laikad.astro_dog.orbits.values()))
-    self.assertGreater(min([len(v) for v in laikad.astro_dog.orbits.values()]), 0)
+    self.dict_has_values(laikad.astro_dog.orbits)
 
   @unittest.skip("Use to debug live data")
   def test_laika_get_orbits_now(self):
@@ -108,6 +112,54 @@ class TestLaikad(unittest.TestCase):
     self.assertTrue(has_orbits)
     self.assertGreater(len(laikad.astro_dog.orbit_fetched_times._ranges), 0)
     self.assertEqual(None, laikad.orbit_fetch_future)
+
+  def test_cache(self):
+    laikad = Laikad(auto_update=True, save_ephemeris=True)
+    first_gps_time = self.get_first_gps_time()
+
+    def wait_for_cache():
+      max_time = 2
+      while Params().get('LaikadEphemeris') is None:
+        time.sleep(0.1)
+        max_time -= 0.1
+        if max_time == 0:
+          self.fail("Cache has not been written after 2 seconds")
+    # Test cache with no ephemeris
+    laikad.cache_ephemeris(t=GPSTime(0, 0))
+    wait_for_cache()
+    Params().delete('LaikadEphemeris')
+
+    laikad.astro_dog.get_navs(first_gps_time)
+    laikad.fetch_orbits(first_gps_time, block=True)
+
+    # Wait for cache to save
+    wait_for_cache()
+
+    # Check both nav and orbits separate
+    laikad = Laikad(auto_update=False, valid_ephem_types=EphemerisType.NAV)
+    # Verify orbits and nav are loaded from cache
+    self.dict_has_values(laikad.astro_dog.orbits)
+    self.dict_has_values(laikad.astro_dog.nav)
+    # Verify cache is working for only nav by running a segment
+    msg = verify_messages(self.logs, laikad, return_one_success=True)
+    self.assertIsNotNone(msg)
+
+    with patch('selfdrive.locationd.laikad.get_orbit_data', return_value=None) as mock_method:
+      # Verify no try to download orbit data since the cache has recently been saved
+      laikad.astro_dog.orbit_fetched_times = TimeRangeHolder()
+      laikad.fetch_orbits(first_gps_time, block=False)
+      mock_method.assert_not_called()
+
+      # Verify cache is working for only orbits by running a segment
+      laikad = Laikad(auto_update=False, valid_ephem_types=EphemerisType.ULTRA_RAPID_ORBIT)
+      msg = verify_messages(self.logs, laikad, return_one_success=True)
+      self.assertIsNotNone(msg)
+      # Verify orbit data is not downloaded
+      mock_method.assert_not_called()
+
+  def dict_has_values(self, dct):
+    self.assertGreater(len(dct), 0)
+    self.assertGreater(min([len(v) for v in dct.values()]), 0)
 
 
 if __name__ == "__main__":

--- a/selfdrive/locationd/test/test_laikad.py
+++ b/selfdrive/locationd/test/test_laikad.py
@@ -145,7 +145,7 @@ class TestLaikad(unittest.TestCase):
     self.assertIsNotNone(msg)
 
     with patch('selfdrive.locationd.laikad.get_orbit_data', return_value=None) as mock_method:
-      # Verify no try to download orbit data since the cache has recently been saved
+      # Verify no orbit downloads even if orbit fetch times is reset since the cache has recently been saved and we don't want to download high frequently
       laikad.astro_dog.orbit_fetched_times = TimeRangeHolder()
       laikad.fetch_orbits(first_gps_time, block=False)
       mock_method.assert_not_called()


### PR DESCRIPTION
Using Params to save orbits and nav from astro dog.
The cache file is measured to be ~ 3.6MB using sys.getsizeof(json_cache) and will be updated every minute with mostly new nav data. 
Only if no orbits are valid anymore, they will be downloaded and cached. And the orbit prediction file contain at max 24 hours of future ephemeris, but because of the delay from the source in processing these files when downloaded they are valid for around 12-18 hours.

Old ephemeris data is overwritten when new data is added: https://github.com/commaai/laika/pull/91 - Merged