### PR TITLE
Ford: disable radar for now

### DIFF
--- a/selfdrive/car/ford/radar_interface.py
+++ b/selfdrive/car/ford/radar_interface.py
@@ -9,6 +9,9 @@ RADAR_MSGS = list(range(0x500, 0x540))
 
 
 def _create_radar_can_parser(car_fingerprint):
+  if DBC[car_fingerprint]['radar'] is None:
+    return None
+
   msg_n = len(RADAR_MSGS)
   signals = list(zip(['X_Rel'] * msg_n + ['Angle'] * msg_n + ['V_Rel'] * msg_n,
                      RADAR_MSGS * 3))
@@ -27,6 +30,9 @@ class RadarInterface(RadarInterfaceBase):
     self.updated_messages = set()
 
   def update(self, can_strings):
+    if self.rcp is None:
+      return super().update(None)
+
     vls = self.rcp.update_strings(can_strings)
     self.updated_messages.update(vls)
 

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -79,6 +79,6 @@ FW_VERSIONS = {
 
 
 DBC = {
-  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', 'ford_fusion_2018_adas'),
-  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', 'ford_fusion_2018_adas'),
+  CAR.ESCAPE_MK4: dbc_dict('ford_lincoln_base_pt', None),
+  CAR.FOCUS_MK4: dbc_dict('ford_lincoln_base_pt', None),
 }


### PR DESCRIPTION
The newer Ford vehicles require a different radar parser so I'd like to disable this for now.