### PR TITLE
HB: Fix ACC faulted with OP Long enabled

### DIFF
--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -115,7 +115,7 @@ def create_ui_commands(packer, CP, enabled, pcm_speed, hud, is_metric, idx, stoc
     }
 
     if CP.carFingerprint in HONDA_BOSCH:
-      acc_hud_values['ACC_ON'] = hud.car != 0
+      acc_hud_values['ACC_ON'] = enabled != 0
       acc_hud_values['FCM_OFF'] = 1
       acc_hud_values['FCM_OFF_2'] = 1
     else:


### PR DESCRIPTION
**Description**
Fixes issue: #24833, introduced in #24806.

Based on logic from pervious version from pull mentioned above, I used "enabled" to determine ACC_ON state.

**Verification**
No more error message from issue mentioned above. Tested with OP Long enabled in route below. Verified HUD displayed accurately depending on engaged state. Tested with OP Long disabled as well with no issues.

**Route**
f1055ddb93ff2d3b|2022-06-12--09-54-09--1

