### PR TITLE
Ford: implement curvature steering control

### DIFF
--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -18,9 +18,8 @@ class CarInterface(CarInterfaceBase):
     #ret.safetyConfigs = [get_safety_config(car.CarParams.SafetyModel.ford)]
     ret.dashcamOnly = True
 
-    # Angle-based steering
-    # TODO: use curvature control when ready
-    ret.steerControlType = car.CarParams.SteerControlType.angle
+    # curvature steering
+    ret.steerControlType = car.CarParams.SteerControlType.curvature
     ret.steerActuatorDelay = 0.1
     ret.steerLimitTimer = 1.0
 

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -35,7 +35,7 @@ class TestCarInterfaces(unittest.TestCase):
     self.assertGreater(car_params.mass, 1)
     self.assertGreater(car_params.steerRateCost, 1e-3)
 
-    if car_params.steerControlType != car.CarParams.SteerControlType.angle:
+    if car_params.steerControlType not in (car.CarParams.SteerControlType.angle, car.CarParams.SteerControlType.curvature):
       tuning = car_params.lateralTuning.which()
       if tuning == 'pid':
         self.assertTrue(len(car_params.lateralTuning.pid.kpV))

--- a/selfdrive/controls/lib/latcontrol_angle.py
+++ b/selfdrive/controls/lib/latcontrol_angle.py
@@ -22,4 +22,4 @@ class LatControlAngle(LatControl):
     angle_log.saturated = self._check_saturation(angle_control_saturated, CS)
     angle_log.steeringAngleDeg = float(CS.steeringAngleDeg)
     angle_log.steeringAngleDesiredDeg = angle_steers_des
-    return 0, float(angle_steers_des), angle_log
+    return 0, float(angle_steers_des), 0, 0, angle_log

--- a/selfdrive/controls/lib/latcontrol_curvature.py
+++ b/selfdrive/controls/lib/latcontrol_curvature.py
@@ -1,0 +1,32 @@
+import math
+from cereal import log
+from selfdrive.controls.lib.latcontrol import LatControl, MIN_STEER_SPEED
+
+
+class LatControlCurvature(LatControl):
+  def update(self, active, CS, VM, params, last_actuators, desired_curvature, desired_curvature_rate, llk):
+    curvature_log = log.ControlsState.LateralCurvatureState.new_message()
+
+    steer_angle_without_offset = math.radians(CS.steeringAngleDeg - params.angleOffsetDeg)
+    curvature = -VM.calc_curvature(steer_angle_without_offset, CS.vEgo, params.roll)
+
+    curvature_log.steeringAngleDeg = float(CS.steeringAngleDeg)
+    curvature_log.curvature = float(curvature)
+
+    if CS.vEgo < MIN_STEER_SPEED or not active:
+      curvature_log.active = False
+      desired_curvature = 0
+      desired_curvature_rate = 0
+      angle_steers_des = 0
+    else:
+      curvature_log.active = True
+      angle_steers_des = math.degrees(VM.get_steer_from_curvature(-desired_curvature, CS.vEgo, params.roll))
+      angle_steers_des += params.angleOffsetDeg
+
+    # TODO: calculate saturated, like latcontrol_angle
+    curvature_log.saturated = False
+    curvature_log.curvature = curvature
+    curvature_log.desiredCurvature = float(desired_curvature)
+    curvature_log.desiredCurvatureRate = float(desired_curvature_rate)
+    curvature_log.steeringAngleDesiredDeg = angle_steers_des
+    return 0, 0, desired_curvature, desired_curvature_rate, curvature_log

--- a/selfdrive/controls/lib/latcontrol_indi.py
+++ b/selfdrive/controls/lib/latcontrol_indi.py
@@ -117,4 +117,4 @@ class LatControlINDI(LatControl):
       indi_log.output = float(output_steer)
       indi_log.saturated = self._check_saturation(self.steer_max - abs(output_steer) < 1e-3, CS)
 
-    return float(output_steer), float(steers_des), indi_log
+    return float(output_steer), float(steers_des), 0, 0, indi_log

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -45,4 +45,4 @@ class LatControlPID(LatControl):
       pid_log.output = output_steer
       pid_log.saturated = self._check_saturation(self.steer_max - abs(output_steer) < 1e-3, CS)
 
-    return output_steer, angle_steers_des, pid_log
+    return output_steer, angle_steers_des, 0, 0, pid_log

--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -92,4 +92,4 @@ class LatControlTorque(LatControl):
       pid_log.desiredLateralAccel = desired_lateral_accel
 
     # TODO left is positive in this convention
-    return -output_torque, 0.0, pid_log
+    return -output_torque, 0, 0, 0, pid_log


### PR DESCRIPTION
This adds support for the Ford "curvature based" steering control.

In the stock system, the IPMA (MobileEye chip) produces information about the car in the lane (lane curvature, angle of the car to the desired path, offset from the desired path). The PSCM processes this information (presumably along with other data, such as the vehicle speed or roll rate) to calculate a steering angle.

To use this control method for openpilot we can calculate curvature, path deviation and path angle from the model and lateral planner outputs. So far I have found that `model_v2.position.y` is most promising for `pathOffset`, as is `model_v2.orientation.z[0]` for `pathAngle`. The `curvature` signal is trickier since it is calculated from the path the model wants to take, but this includes any corrective action which is already accounted for in the `pathOffset` and `pathAngle`. In the stock system, curvature is more "constant" from the shape of the road or lane, and is not affected by the car's orientation or offset.

The LCA command has signals for "ramp rate" and "precision" which I have set to "fast" and "comfortable" - this might need some more experimentation. Currently there is no rate limitting implemented other than clipping the values to the signal ranges from the DBC.

Demo route: `86d00e12925f4df7|2022-06-10--17-44-23` (this was using my `ford-devel-c3` branch, not this PR)
PlotJuggler layout: TODO (useful for comparing curvature controls state to stock signals)

See also:
- https://github.com/commaai/cereal/pull/303
- https://github.com/commaai/panda/pull/966