### PR TITLE
regen: send wideRoadCameraState

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -15,7 +15,6 @@ from cereal.services import service_list
 from common.params import Params
 from common.timeout import Timeout
 from panda.python import ALTERNATIVE_EXPERIENCE
-from selfdrive.car.fingerprints import FW_VERSIONS
 from selfdrive.car.car_helpers import get_car, interfaces
 from selfdrive.test.process_replay.helpers import OpenpilotPrefix
 from selfdrive.manager.process import PythonProcess

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -372,7 +372,7 @@ def setup_env(simulation=False, CP=None):
     if CP.alternativeExperience == ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS:
       params.put_bool("DisengageOnAccelerator", False)
 
-    if CP.fingerprintSource == "fw" and CP.carFingerprint in FW_VERSIONS:
+    if CP.fingerprintSource == "fw":
       params.put("CarParamsCache", CP.as_builder().to_bytes())
     else:
       os.environ['SKIP_FW_QUERY'] = "1"

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -156,7 +156,7 @@ def replay_cameras(lr, frs, disable_tqdm=False):
   # init vipc server and cameras
   p = []
   vs = VisionIpcServer("camerad")
-  for s, dt, size, stream, use_extra_client in cameras:
+  for (s, dt, size, stream, use_extra_client) in cameras:
     fr = frs.get(s, None)
 
     frames = None

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -14,7 +14,7 @@ from cereal.services import service_list
 from cereal.visionipc import VisionIpcServer, VisionStreamType
 from common.params import Params
 from common.realtime import Ratekeeper, DT_MDL, DT_DMON, sec_since_boot
-from common.transformations.camera import eon_f_frame_size, eon_d_frame_size, tici_f_frame_size, tici_e_frame_size, tici_d_frame_size
+from common.transformations.camera import eon_f_frame_size, eon_d_frame_size, tici_f_frame_size, tici_d_frame_size
 from selfdrive.manager.process import ensure_running
 from selfdrive.manager.process_config import managed_processes
 from selfdrive.test.process_replay.process_replay import FAKEDATA, setup_env, check_enabled

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -14,7 +14,7 @@ from cereal.services import service_list
 from cereal.visionipc import VisionIpcServer, VisionStreamType
 from common.params import Params
 from common.realtime import Ratekeeper, DT_MDL, DT_DMON, sec_since_boot
-from common.transformations.camera import eon_f_frame_size, eon_d_frame_size, tici_f_frame_size, tici_d_frame_size
+from common.transformations.camera import eon_f_frame_size, eon_d_frame_size, tici_f_frame_size, tici_e_frame_size, tici_d_frame_size
 from selfdrive.manager.process import ensure_running
 from selfdrive.manager.process_config import managed_processes
 from selfdrive.test.process_replay.process_replay import FAKEDATA, setup_env, check_enabled
@@ -118,15 +118,17 @@ def replay_service(s, msgs):
 
 def replay_cameras(lr, frs, disable_tqdm=False):
   eon_cameras = [
-    ("roadCameraState", DT_MDL, eon_f_frame_size, VisionStreamType.VISION_STREAM_ROAD, True),
-    ("driverCameraState", DT_DMON, eon_d_frame_size, VisionStreamType.VISION_STREAM_DRIVER, False),
+    ("roadCameraState", DT_MDL, eon_f_frame_size, VisionStreamType.VISION_STREAM_ROAD),
+    ("wideRoadCameraState", DT_DMON, eon_f_frame_size, VisionStreamType.VISION_STREAM_WIDE_ROAD),
+    ("driverCameraState", DT_DMON, eon_d_frame_size, VisionStreamType.VISION_STREAM_DRIVER),
   ]
   tici_cameras = [
-    ("roadCameraState", DT_MDL, tici_f_frame_size, VisionStreamType.VISION_STREAM_ROAD, True),
-    ("driverCameraState", DT_MDL, tici_d_frame_size, VisionStreamType.VISION_STREAM_DRIVER, False),
+    ("roadCameraState", DT_MDL, tici_f_frame_size, VisionStreamType.VISION_STREAM_ROAD),
+    ("wideRoadCameraState", DT_MDL, tici_e_frame_size, VisionStreamType.VISION_STREAM_WIDE_ROAD),
+    ("driverCameraState", DT_MDL, tici_d_frame_size, VisionStreamType.VISION_STREAM_DRIVER),
   ]
 
-  def replay_camera(s, stream, dt, vipc_server, frames, size, use_extra_client):
+  def replay_camera(s, stream, dt, vipc_server, frames, size):
     pm = messaging.PubMaster([s, ])
     rk = Ratekeeper(1 / dt, print_delay_threshold=None)
 
@@ -145,8 +147,6 @@ def replay_cameras(lr, frs, disable_tqdm=False):
       pm.send(s, m)
 
       vipc_server.send(stream, img, msg.frameId, msg.timestampSof, msg.timestampEof)
-      if use_extra_client:
-        vipc_server.send(VisionStreamType.VISION_STREAM_WIDE_ROAD, img, msg.frameId, msg.timestampSof, msg.timestampEof)
 
   init_data = [m for m in lr if m.which() == 'initData'][0]
   cameras = tici_cameras if (init_data.initData.deviceType == 'tici') else eon_cameras
@@ -154,7 +154,7 @@ def replay_cameras(lr, frs, disable_tqdm=False):
   # init vipc server and cameras
   p = []
   vs = VisionIpcServer("camerad")
-  for (s, dt, size, stream, use_extra_client) in cameras:
+  for s, dt, size, stream in cameras:
     fr = frs.get(s, None)
 
     frames = None
@@ -166,10 +166,8 @@ def replay_cameras(lr, frs, disable_tqdm=False):
         frames.append(img.flatten().tobytes())
 
     vs.create_buffers(stream, 40, False, size[0], size[1])
-    if use_extra_client:
-      vs.create_buffers(VisionStreamType.VISION_STREAM_WIDE_ROAD, 40, False, size[0], size[1])
     p.append(multiprocessing.Process(target=replay_camera,
-                                     args=(s, stream, dt, vs, frames, size, use_extra_client)))
+                                     args=(s, stream, dt, vs, frames, size)))
 
   vs.start_listener()
   return vs, p
@@ -220,7 +218,7 @@ def regen_segment(lr, frs=None, outdir=FAKEDATA, disable_tqdm=False):
     # start procs up
     ignore = list(fake_daemons.keys()) + ['ui', 'manage_athenad', 'uploader', 'soundd']
     ensure_running(managed_processes.values(), started=True, params=Params(), CP=car.CarParams(), not_run=ignore)
-    for procs in fake_daemons.values():
+    for name, procs in fake_daemons.items():
       for p in procs:
         p.start()
 

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -218,7 +218,7 @@ def regen_segment(lr, frs=None, outdir=FAKEDATA, disable_tqdm=False):
     # start procs up
     ignore = list(fake_daemons.keys()) + ['ui', 'manage_athenad', 'uploader', 'soundd']
     ensure_running(managed_processes.values(), started=True, params=Params(), CP=car.CarParams(), not_run=ignore)
-    for name, procs in fake_daemons.items():
+    for procs in fake_daemons.values():
       for p in procs:
         p.start()
 

--- a/selfdrive/test/process_replay/regen_all.py
+++ b/selfdrive/test/process_replay/regen_all.py
@@ -11,12 +11,12 @@ from selfdrive.test.process_replay.test_processes import FAKEDATA, original_segm
 from tools.lib.route import SegmentName
 
 
-def regen_job(segment, disable_tqdm):
+def regen_job(segment, upload, disable_tqdm):
   with OpenpilotPrefix():
     sn = SegmentName(segment[1])
     fake_dongle_id = 'regen' + ''.join(random.choice('0123456789ABCDEF') for _ in range(11))
     try:
-      relr = regen_and_save(sn.route_name.canonical_name, sn.segment_num, upload=True, use_route_meta=False, outdir=os.path.join(FAKEDATA, fake_dongle_id), disable_tqdm=disable_tqdm)
+      relr = regen_and_save(sn.route_name.canonical_name, sn.segment_num, upload=upload, use_route_meta=False, outdir=os.path.join(FAKEDATA, fake_dongle_id), disable_tqdm=disable_tqdm)
       relr = '|'.join(relr.split('/')[-2:])
       return f'  ("{segment[0]}", "{relr}"), '
     except Exception as e:
@@ -26,12 +26,13 @@ def regen_job(segment, disable_tqdm):
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Generate new segments from old ones")
   parser.add_argument("-j", "--jobs", type=int, default=1)
+  parser.add_argument("--no-upload", action="store_true")
   args = parser.parse_args()
 
   with concurrent.futures.ProcessPoolExecutor(max_workers=args.jobs) as pool:
-    p = list(pool.map(regen_job, segments, [args.jobs > 1] * args.jobs))
+    p = pool.map(regen_job, segments, [not args.no_upload] * len(segments), [args.jobs > 1] * len(segments))
     msg = "Copy these new segments into test_processes.py:"
-    for seg in tqdm(p, desc="Generating segments"):
+    for seg in tqdm(p, desc="Generating segments", total=len(segments)):
       msg += "\n" + str(seg)
     print()
     print()


### PR DESCRIPTION
Fixes no routes regenerating

This isn't perfect, modeld complains of frames out of sync (it takes 10-20 ms to start the first camera process)

Changed to still send in one process, fixes out of sync issue (mostly)