### PR TITLE
missing include

### DIFF
--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QLayoutItem>
 #include <QStyleOption>
+#include <QPainterPath>
 
 #include "common/params.h"
 #include "common/swaglog.h"


### PR DESCRIPTION
ubuntu 21.10 build test...error

selfdrive/ui/qt/util.cc:166:16: error: variable has incomplete type 'QPainterPath'
  QPainterPath path;
               ^
/usr/include/x86_64-linux-gnu/qt5/QtGui/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
class QPainterPath;
      ^
1 error generated.


util.cc add build ok.
```
#include <QPainterPath>
```