### PR TITLE
thermald: fix panda dropout when we miss a pandaStates

### DIFF
--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -220,7 +220,7 @@ def thermald_thread(end_event, hw_queue):
         if TICI:
           fan_controller = TiciFanController()
 
-    elif (sec_since_boot() - sm.rcv_time['pandaStates']/1e9) > DISCONNECT_TIMEOUT:
+    elif (sec_since_boot() - sm.rcv_time['pandaStates']) > DISCONNECT_TIMEOUT:
       if onroad_conditions["ignition"]:
         onroad_conditions["ignition"] = False
         cloudlog.error("panda timed out onroad")


### PR DESCRIPTION
Contrary to the cpp implementation, rcv_time in Python's SubMaster is seconds, so if thermald ever lags and we miss a pandaStates packet, it thinks it's been down for more than 5 seconds. Will do the sec -> nanosec change of SubMaster in another PR as this is pretty important to get in, I think I've seen it on a few of our cars too (unsure)

This was found by a user's 2022 Civic C3 taking quite a while to either write parameters or set the power save mode in thermald, and we go on and offroad 3 times in a row. Example route: 5130484aa8069bad|2022-06-14--20-01-30--0