### PR TITLE
navd: handle maxspeed being none

### DIFF
--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -145,7 +145,7 @@ class RouteEngine:
             # Last step does not have maxspeed
             if (maxspeed_idx < len(maxspeeds)):
               maxspeed = maxspeeds[maxspeed_idx]
-              if ('unknown' not in maxspeed) and maxspeed['speed']:
+              if ('unknown' not in maxspeed) and ('none' not in maxspeed):
                 coord.annotations['maxspeed'] = maxspeed_to_ms(maxspeed)
 
             coords.append(coord)

--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -143,8 +143,10 @@ class RouteEngine:
             coord = Coordinate.from_mapbox_tuple(c)
 
             # Last step does not have maxspeed
-            if (maxspeed_idx < len(maxspeeds)) and ('unknown' not in maxspeeds[maxspeed_idx]):
-              coord.annotations['maxspeed'] = maxspeed_to_ms(maxspeeds[maxspeed_idx])
+            if (maxspeed_idx < len(maxspeeds)):
+              maxspeed = maxspeeds[maxspeed_idx]
+              if ('unknown' not in maxspeed) and maxspeed['speed']:
+                coord.annotations['maxspeed'] = maxspeed_to_ms(maxspeed)
 
             coords.append(coord)
             maxspeed_idx += 1


### PR DESCRIPTION
Can happen on the autobahn according to the docs:
> speed: The maximum speed limit between the coordinates of a segment. The value can be either the legal speed limit or an advisory speed limit where posted, or none if the speed limit is unlimited (for instance, a German Autobahn).


TODO: actually verify this