### PR TITLE
Honda Bosch Longitudinal: use clipped actuators.accel for gasbrake lookup

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -206,7 +206,7 @@ class CarController:
 
         if self.CP.carFingerprint in HONDA_BOSCH:
           self.accel = clip(accel, self.params.BOSCH_ACCEL_MIN, self.params.BOSCH_ACCEL_MAX)
-          self.gas = interp(accel, self.params.BOSCH_GAS_LOOKUP_BP, self.params.BOSCH_GAS_LOOKUP_V)
+          self.gas = interp(self.accel, self.params.BOSCH_GAS_LOOKUP_BP, self.params.BOSCH_GAS_LOOKUP_V)
 
           stopping = actuators.longControlState == LongCtrlState.stopping
           can_sends.extend(hondacan.create_acc_commands(self.packer, CC.enabled, CC.longActive, self.accel, self.gas,


### PR DESCRIPTION
**Description** Found this while refactoring gasbrake to account for pitch. Changes process replay for one segment. If this is the intended behavior, I'll add a comment in the refactor.

**Verification** a priori