### PR TITLE
Toyota: remove longitudinal deadzone

### DIFF
--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -31,16 +31,12 @@ class LatTunes(Enum):
 def set_long_tune(tune, name):
   # Improved longitudinal tune
   if name == LongTunes.TSS2 or name == LongTunes.PEDAL:
-    tune.deadzoneBP = [0., 8.05]
-    tune.deadzoneV = [.0, .14]
     tune.kpBP = [0., 5., 20.]
     tune.kpV = [1.3, 1.0, 0.7]
     tune.kiBP = [0., 5., 12., 20., 27.]
     tune.kiV = [.35, .23, .20, .17, .1]
   # Default longitudinal tune
   elif name == LongTunes.TSS:
-    tune.deadzoneBP = [0., 9.]
-    tune.deadzoneV = [0., .15]
     tune.kpBP = [0., 5., 35.]
     tune.kiBP = [0., 35.]
     tune.kpV = [3.6, 2.4, 1.5]


### PR DESCRIPTION
Difference between the tunes is super small, and I can't imagine this helps in any situations. If anything we don't want deadzone, as response can be laggy sometimes