### PR TITLE
GM: Lower LKA loopback CAN Error timing threshold to accommodate dropped packets

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -135,7 +135,7 @@ class CarState(CarStateBase):
     checks = [
       ("ASCMLKASteeringCmd", 10), # 10 Hz is the stock inactive rate (every 100ms). 
       #                             While active 50 Hz (every 20 ms) is normal
-      #                             EPS will tolerate around 200ms when actrive before faulting 
+      #                             EPS will tolerate around 200ms when active before faulting 
     ]
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, CanBus.LOOPBACK)

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -133,7 +133,9 @@ class CarState(CarStateBase):
     ]
 
     checks = [
-      ("ASCMLKASteeringCmd", 50),
+      ("ASCMLKASteeringCmd", 10), # 10 Hz is the stock inactive rate (every 100ms). 
+      #                             While active 50 Hz (every 20 ms) is normal
+      #                             EPS will tolerate around 200ms when actrive before faulting 
     ]
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, CanBus.LOOPBACK)


### PR DESCRIPTION
**Description**
On GM vehicles with the problematic EPS / PSCM, the module will occasionally fault if the Panda drops packets for over 100 ms. The stock LKA camera sends inactive frames every 100ms, switchign to a 20ms interval only when active.

This change to the timing requirement will accommodate stock behavior, and should reduce unnecessary CAN Error alerts.

**Verification**

This has been tested on a large range of vehicles in OPGM as well as the Silverado and GMC Sierra. This change alone will not fix all the EPS issues - forthcoming PRs will cover the specific problem conditions


