### PR TITLE
Hyundai: remove bad esp fingerprint

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1146,9 +1146,6 @@ FW_VERSIONS = {
       b'\xf1\000DNhe SCC F-CUP      1.00 1.02 99110-L5000         ',
       b'\xf1\x8799110L5000\xf1\000DNhe SCC F-CUP      1.00 1.02 99110-L5000         ',
     ],
-    (Ecu.esp, 0x7b0, None): [
-      b'\xf1\x87\x00\x00\x00\x00\x00\x00\x00\x00\xf1\x81\x00\x00\x00\x00\x00\x00\x00\x00',
-    ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x8756310-L5500\xf1\x00DN8 MDPS C 1.00 1.02 56310-L5500 4DNHC102',
       b'\xf1\x8756310-L5450\xf1\x00DN8 MDPS C 1.00 1.02 56310-L5450 4DNHC102',


### PR DESCRIPTION
This was added in: https://github.com/commaai/openpilot/pull/23988, but it's probably just a broken FW query from another brand that's adding it (user is still on old branch so can't check response request). Its address is the esp on Subarus, so it was probably just copied making that assumption

Car still fingerprints fully with this removed