### PR TITLE
snapshot: fix rgb overflow

### DIFF
--- a/system/camerad/snapshot/snapshot.py
+++ b/system/camerad/snapshot/snapshot.py
@@ -39,7 +39,7 @@ def yuv_to_rgb(y, u, v):
     [0.00000, -0.39465, 2.03211],
     [1.13983, -0.58060, 0.00000],
   ])
-  rgb = np.dot(yuv, m)
+  rgb = np.dot(yuv, m).clip(0, 255)
   return rgb.astype(np.uint8)
 
 


### PR DESCRIPTION
Clamp rgb values before casting to uint8 to avoid overflow

Before : ![before](https://user-images.githubusercontent.com/27537531/175764177-32a72f46-884d-42f8-8bf3-fdba6b2b27cf.png)
After : ![after](https://user-images.githubusercontent.com/27537531/175764174-341f5adc-0db9-4f27-bde7-85697fdf4aab.png)
