### PR TITLE
Power Monitoring test: fix exceptions

### DIFF
--- a/selfdrive/thermald/tests/test_power_monitoring.py
+++ b/selfdrive/thermald/tests/test_power_monitoring.py
@@ -119,7 +119,7 @@ class TestPowerMonitoring(unittest.TestCase):
   @parameterized.expand(ALL_PANDA_TYPES)
   def test_max_time_offroad(self, hw_type):
     MOCKED_MAX_OFFROAD_TIME = 3600
-    POWER_DRAW = 4
+    POWER_DRAW = 0 # To stop shutting down for other reasons
     with pm_patch("MAX_TIME_OFFROAD_S", MOCKED_MAX_OFFROAD_TIME, constant=True), pm_patch("HARDWARE.get_current_power_draw", POWER_DRAW):
       pm = PowerMonitoring()
       pm.car_battery_capacity_uWh = CAR_BATTERY_CAPACITY_uWh

--- a/selfdrive/thermald/tests/test_power_monitoring.py
+++ b/selfdrive/thermald/tests/test_power_monitoring.py
@@ -119,7 +119,8 @@ class TestPowerMonitoring(unittest.TestCase):
   @parameterized.expand(ALL_PANDA_TYPES)
   def test_max_time_offroad(self, hw_type):
     MOCKED_MAX_OFFROAD_TIME = 3600
-    with pm_patch("MAX_TIME_OFFROAD_S", MOCKED_MAX_OFFROAD_TIME, constant=True), pm_patch("HARDWARE.get_current_power_draw", None):
+    POWER_DRAW = 4
+    with pm_patch("MAX_TIME_OFFROAD_S", MOCKED_MAX_OFFROAD_TIME, constant=True), pm_patch("HARDWARE.get_current_power_draw", POWER_DRAW):
       pm = PowerMonitoring()
       pm.car_battery_capacity_uWh = CAR_BATTERY_CAPACITY_uWh
       start_time = ssb


### PR DESCRIPTION
This was causing a high rate of printed exceptions in the unit test job in CI (NoneType * int). Looks all other functions had this patch changed from None except this case, and 0 should be equivalent to None here.

Relevant PR: https://github.com/commaai/openpilot/pull/24055