### PR TITLE
installer: only build openpilot and openpilot_internal

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -79,14 +79,9 @@ if GetOption('extras'):
   senv['LINKFLAGS'].append('-Wl,-strip-debug')
 
   release = "release3"
-  dashcam = "dashcam3"
   installers = [
     ("openpilot", release),
-    ("openpilot_test", f"{release}-staging"),
-    ("openpilot_nightly", "master-ci"),
-    ("openpilot_internal", "master"),
-    ("dashcam", dashcam),
-    ("dashcam_test", f"{dashcam}-staging"),
+    ("openpilot_internal", release),
   ]
 
   cont = {}


### PR DESCRIPTION
Rest will be handled server side by inserting the right branch name