### PR TITLE
docs: ssh.comma.ai

### DIFF
--- a/tools/ssh/README.md
+++ b/tools/ssh/README.md
@@ -22,3 +22,52 @@ The public keys are only fetched from your GitHub account once. In order to upda
 The `id_rsa` key in this directory only works while your device is in the setup state with no software installed. After installation, that default key will be removed.
 
 See the [community wiki](https://github.com/commaai/openpilot/wiki/SSH) for more detailed instructions and information.
+
+# Connecting to ssh.comma.ai
+SSH into your comma device from anywhere with `ssh.comma.ai`.
+
+## Setup
+
+With software version 0.6.1 or newer, enter your GitHub username on your device under Developer Settings. Your GitHub authorized public keys will become your authorized SSH keys for `ssh.comma.ai`. You can add any additional keys in `/system/comma/home/.ssh/authorized_keys.persist`.
+
+Requires [comma SIM with comma prime](https://comma.ai/shop) activated with comma connect, available on iOS and Android. comma two and EON ship with a pre-inserted comma SIM.
+
+## Recommended .ssh/config
+
+With the below ssh configuration, you can type `ssh comma-{dongleid}` to connect to your device through `ssh.comma.ai`. For example, `ssh comma-ffffffffffffffff`.
+
+```
+Host comma-*
+  Port 22
+  User comma
+  IdentityFile ~/.ssh/my_github_key
+  ProxyCommand ssh %h@ssh.comma.ai -W %h:%p
+Host ssh.comma.ai
+  Hostname ssh.comma.ai
+  Port 22
+  IdentityFile ~/.ssh/my_github_key
+```
+
+## One-off connection
+
+```
+ssh -i ~/.ssh/my_github_key -o ProxyCommand="ssh -i ~/.ssh/my_github_key -W %h:%p -p %p %h@ssh.comma.ai" comma@ffffffffffffffff
+```
+(Replace `ffffffffffffffff` with your dongle_id)
+
+## ssh.comma.ai host key fingerprint
+
+```
+Host key fingerprint is SHA256:X22GOmfjGb9J04IA2+egtdaJ7vW9Fbtmpz9/x8/W1X4
++---[RSA 4096]----+
+|                 |
+|                 |
+|        .        |
+|         +   o   |
+|        S = + +..|
+|         + @ = .=|
+|        . B @ ++=|
+|         o * B XE|
+|         .o o OB/|
++----[SHA256]-----+
+```


### PR DESCRIPTION
[ssh.comma.ai](https://ssh.comma.ai) is going to change to a redirect to [docs.comma.ai](https://docs.comma.ai)