### PR TITLE
hyundai: fix FCA11 checksum and counter

### DIFF
--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -132,6 +132,8 @@ def create_acc_commands(packer, enabled, accel, upper_jerk, idx, lead_visible, s
   }
   commands.append(packer.make_can_msg("SCC14", 0, scc14_values))
 
+  # note that some vehicles most likely have an alternate checksum/counter definition
+  # https://github.com/commaai/opendbc/commit/9ddcdb22c4929baf310295e832668e6e7fcfa602
   fca11_values = {
     "CR_FCA_Alive": idx % 0xF,
     "PAINT1_Status": 1,

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -133,17 +133,13 @@ def create_acc_commands(packer, enabled, accel, upper_jerk, idx, lead_visible, s
   commands.append(packer.make_can_msg("SCC14", 0, scc14_values))
 
   fca11_values = {
-    # seems to count 2,1,0,3,2,1,0,3,2,1,0,3,2,1,0,repeat...
-    # (where first value is aligned to Supplemental_Counter == 0)
-    # test: [(idx % 0xF, -((idx % 0xF) + 2) % 4) for idx in range(0x14)]
-    "CR_FCA_Alive": ((-((idx % 0xF) + 2) % 4) << 2) + 1,
-    "Supplemental_Counter": idx % 0xF,
+    "CR_FCA_Alive": idx % 0xF,
     "PAINT1_Status": 1,
     "FCA_DrvSetStatus": 1,
     "FCA_Status": 1, # AEB disabled
   }
   fca11_dat = packer.make_can_msg("FCA11", 0, fca11_values)[2]
-  fca11_values["CR_FCA_ChkSum"] = 0x10 - sum(sum(divmod(i, 16)) for i in fca11_dat) % 0x10
+  fca11_values["CR_FCA_ChkSum"] = hyundai_checksum(fca11_dat[:7])
   commands.append(packer.make_can_msg("FCA11", 0, fca11_values))
 
   return commands


### PR DESCRIPTION
When using openpilot longitudinal control (at least for 2020 sonata/palisade) before these changes TCS13.CF_VSM_Avail == 3 which means there is an FCA error (preventing the possibility of openpilot using AEB)
![image](https://user-images.githubusercontent.com/4112046/177110444-d3e9d45d-f2d9-4ea0-9de2-c32e5a717ed1.png)

Looking at the firmware for my palisade I can see there is code for parsing both ways, so the other parsing is probably for some older vehicles or vehicles with a different ECU sending FCA11.  It seems like we would have to split the DBC to support both so I figure for now we should switch to what the 2020 sonata/palisade use.  And after these changes I am able to command AEB on my palisade.

Before merging:
- [x] test on sonata (thanks @sunnyhaibin)
- [x] decide if we should merge this only for specific platforms - some cars probably use a different message layout, but I believe they are broken on master now, too (@adeebshihadeh can you make this decision, adjust this PR accordingly and merge https://github.com/commaai/opendbc/pull/656?) - decided to leave old vehicles broken and add comment about it
