### PR TITLE
Toyota: don't send UI on Prius V

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -126,7 +126,7 @@ class CarController:
       # forcing the pcm to disengage causes a bad fault sound so play a good sound instead
       send_ui = True
 
-    if self.frame % 100 == 0 or send_ui:
+    if self.frame % 100 == 0 or send_ui and self.CP.carFingerprint != CAR.PRIUS_V:
       can_sends.append(create_ui_command(self.packer, steer_alert, pcm_cancel_cmd, hud_control.leftLaneVisible,
                                          hud_control.rightLaneVisible, hud_control.leftLaneDepart,
                                          hud_control.rightLaneDepart, CC.enabled))

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -126,7 +126,7 @@ class CarController:
       # forcing the pcm to disengage causes a bad fault sound so play a good sound instead
       send_ui = True
 
-    if self.frame % 100 == 0 or send_ui and self.CP.carFingerprint != CAR.PRIUS_V:
+    if (self.frame % 100 == 0 or send_ui) and (self.CP.carFingerprint != CAR.PRIUS_V):
       can_sends.append(create_ui_command(self.packer, steer_alert, pcm_cancel_cmd, hud_control.leftLaneVisible,
                                          hud_control.rightLaneVisible, hud_control.leftLaneDepart,
                                          hud_control.rightLaneDepart, CC.enabled))


### PR DESCRIPTION
`LKAS_HUD` seems to exist on a different address on the Prius V, found this out when asking a user about experiences with my fork, they confirmed that my "keep LKAS" hack (which relied on panda passing this address through when not engaged) doesn't work on their car, this is also confirmed by the cars tests ran in #24782.

openpilot probably shouldn't send this in case it is used for something else.