### PR TITLE
casync: reuse requests session in RemoteChunkReader

### DIFF
--- a/system/hardware/tici/casync.py
+++ b/system/hardware/tici/casync.py
@@ -55,6 +55,7 @@ class RemoteChunkReader(ChunkReader):
   def __init__(self, url: str) -> None:
     super().__init__()
     self.url = url
+    self.session = requests.Session()
 
   def read(self, chunk: Chunk) -> bytes:
     sha_hex = chunk.sha.hex()
@@ -62,7 +63,7 @@ class RemoteChunkReader(ChunkReader):
 
     for i in range(CHUNK_DOWNLOAD_RETRIES):
       try:
-        resp = requests.get(url, timeout=CHUNK_DOWNLOAD_TIMEOUT)
+        resp = self.session.get(url, timeout=CHUNK_DOWNLOAD_TIMEOUT)
         break
       except Exception:
         if i == CHUNK_DOWNLOAD_RETRIES - 1:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
