### PR TITLE
V4LEncoder: use std::vector to bind the VisionIpcBufExtra to index

### DIFF
--- a/selfdrive/loggerd/encoder/encoder.cc
+++ b/selfdrive/loggerd/encoder/encoder.cc
@@ -11,7 +11,7 @@ void VideoEncoder::publisher_init() {
   pm.reset(new PubMaster({service_name}));
 }
 
-void VideoEncoder::publisher_publish(VideoEncoder *e, int segment_num, uint32_t idx, VisionIpcBufExtra &extra,
+void VideoEncoder::publisher_publish(VideoEncoder *e, int segment_num, uint32_t idx, const VisionIpcBufExtra &extra,
                                      unsigned int flags, kj::ArrayPtr<capnp::byte> header, kj::ArrayPtr<capnp::byte> dat) {
   // broadcast packet
   MessageBuilder msg;

--- a/selfdrive/loggerd/encoder/encoder.h
+++ b/selfdrive/loggerd/encoder/encoder.h
@@ -24,7 +24,7 @@ public:
   virtual void encoder_close() = 0;
 
   void publisher_init();
-  static void publisher_publish(VideoEncoder *e, int segment_num, uint32_t idx, VisionIpcBufExtra &extra, unsigned int flags, kj::ArrayPtr<capnp::byte> header, kj::ArrayPtr<capnp::byte> dat);
+  static void publisher_publish(VideoEncoder *e, int segment_num, uint32_t idx, const VisionIpcBufExtra &extra, unsigned int flags, kj::ArrayPtr<capnp::byte> header, kj::ArrayPtr<capnp::byte> dat);
 
   void writer_open(const char* path) {
     if (this->write) write_handler_thread = std::thread(VideoEncoder::write_handler, this, path);

--- a/selfdrive/loggerd/encoder/v4l_encoder.h
+++ b/selfdrive/loggerd/encoder/v4l_encoder.h
@@ -23,7 +23,7 @@ private:
   int segment_num = -1;
   int counter = 0;
 
-  SafeQueue<VisionIpcBufExtra> extras;
+  std::vector<VisionIpcBufExtra> extras;
 
   static void dequeue_handler(V4LEncoder *e);
   std::thread dequeue_handler_thread;


### PR DESCRIPTION
I think it's more safe and readable than pop from a SafeQueue.

`std::vector extras` is thread safe  if there is no access from different threads to the same element. 