### PR TITLE
V4LEncoder: set  bytesused to buf->len

### DIFF
--- a/selfdrive/loggerd/encoder/v4l_encoder.cc
+++ b/selfdrive/loggerd/encoder/v4l_encoder.cc
@@ -37,11 +37,11 @@ static void dequeue_buffer(int fd, v4l2_buf_type buf_type, unsigned int *index=N
   assert(v4l_buf.m.planes[0].data_offset == 0);
 }
 
-static void queue_buffer(int fd, v4l2_buf_type buf_type, unsigned int index, VisionBuf *buf, struct timeval timestamp={0}, unsigned int bytesused=0) {
+static void queue_buffer(int fd, v4l2_buf_type buf_type, unsigned int index, VisionBuf *buf, struct timeval timestamp={}) {
   v4l2_plane plane = {
     .length = (unsigned int)buf->len,
     .m = { .userptr = (unsigned long)buf->addr, },
-    .bytesused = bytesused,
+    .bytesused = (uint32_t)buf->len,
     .reserved = {(unsigned int)buf->fd}
   };
 
@@ -51,7 +51,6 @@ static void queue_buffer(int fd, v4l2_buf_type buf_type, unsigned int index, Vis
     .memory = V4L2_MEMORY_USERPTR,
     .m = { .planes = &plane, },
     .length = 1,
-    .bytesused = 0,
     .flags = V4L2_BUF_FLAG_TIMESTAMP_COPY,
     .timestamp = timestamp
   };


### PR DESCRIPTION
should not set `bytesused=0` for output buffer. This will cause `vb2_warn_zero_bytesused` to output a warning message, and set `bytesused` to `plan.length` in `vb2_fill_vb2_v4l2_buffer`: https://github.com/torvalds/linux/blob/master/drivers/media/common/videobuf2/videobuf2-v4l2.c#L257

related to issue: https://github.com/commaai/openpilot/issues/24928