### PR TITLE
laikad: Filter unwanted pseudoranges

### DIFF
--- a/selfdrive/locationd/laikad.py
+++ b/selfdrive/locationd/laikad.py
@@ -103,6 +103,9 @@ class Laikad:
           self.fetch_orbits(latest_msg_t + SECS_IN_MIN, block)
 
       new_meas = read_raw_ublox(report)
+      # Filter measurements with unexpected pseudoranges for GPS and GLONASS satellites
+      new_meas = [m for m in new_meas if 1e7 < m.observables['C1C'] < 3e7]
+
       processed_measurements = process_measurements(new_meas, self.astro_dog)
 
       est_pos = self.get_est_pos(t, processed_measurements)


### PR DESCRIPTION
Some satellites have a very incorrect pseudorange either negative or a very high number which isn't possible. And when using uncorrected measurements this could lead to a bad kalman filter state.

Filtering pseudoranges outside of the range [1e7,3e7] removes most measurements that cannot be corrected. From all the 1000 segments shown in this plot it would remove the top 1.5% and <0.0001 % of the lowest pseudoranges.
![image](https://user-images.githubusercontent.com/4709833/177585847-ad118855-7acb-459f-9841-957c84414adf.png)
