### PR TITLE
loggerd: remove 'enable' from struct LogCameraInfo

### DIFF
--- a/selfdrive/loggerd/encoderd.cc
+++ b/selfdrive/loggerd/encoderd.cc
@@ -124,10 +124,8 @@ void encoderd_thread() {
 
   std::vector<std::thread> encoder_threads;
   for (const auto &cam : cameras_logged) {
-    if (cam.enable) {
-      encoder_threads.push_back(std::thread(encoder_thread, &s, cam));
-      s.max_waiting++;
-    }
+    encoder_threads.push_back(std::thread(encoder_thread, &s, cam));
+    s.max_waiting++;
   }
   for (auto &t : encoder_threads) t.join();
 }

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -204,10 +204,8 @@ void loggerd_thread() {
   // init encoders
   s.last_camera_seen_tms = millis_since_boot();
   for (const auto &cam : cameras_logged) {
-    if (cam.enable) {
-      s.max_waiting++;
-      if (cam.has_qcamera) { s.max_waiting++; }
-    }
+    s.max_waiting++;
+    if (cam.has_qcamera) { s.max_waiting++; }
   }
 
   uint64_t msg_count = 0, bytes_count = 0;

--- a/selfdrive/loggerd/loggerd.h
+++ b/selfdrive/loggerd/loggerd.h
@@ -50,7 +50,6 @@ struct LogCameraInfo {
   int bitrate;
   bool is_h265;
   bool has_qcamera;
-  bool enable;
   bool record;
 };
 
@@ -63,7 +62,6 @@ const LogCameraInfo cameras_logged[] = {
     .bitrate = MAIN_BITRATE,
     .is_h265 = true,
     .has_qcamera = true,
-    .enable = true,
     .record = true,
     .frame_width = 1928,
     .frame_height = 1208,
@@ -76,7 +74,6 @@ const LogCameraInfo cameras_logged[] = {
     .bitrate = DCAM_BITRATE,
     .is_h265 = true,
     .has_qcamera = false,
-    .enable = true,
     .record = Params().getBool("RecordFront"),
     .frame_width = 1928,
     .frame_height = 1208,
@@ -89,7 +86,6 @@ const LogCameraInfo cameras_logged[] = {
     .bitrate = MAIN_BITRATE,
     .is_h265 = true,
     .has_qcamera = false,
-    .enable = true,
     .record = true,
     .frame_width = 1928,
     .frame_height = 1208,
@@ -100,7 +96,6 @@ const LogCameraInfo qcam_info = {
   .fps = MAIN_FPS,
   .bitrate = 256000,
   .is_h265 = false,
-  .enable = true,
   .record = true,
   .frame_width = 526,
   .frame_height = 330,


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
