### PR TITLE
replay: add support for reading from plain logs

### DIFF
--- a/tools/replay/logreader.cc
+++ b/tools/replay/logreader.cc
@@ -47,19 +47,12 @@ LogReader::~LogReader() {
 }
 
 bool LogReader::load(const std::string &url, std::atomic<bool> *abort, bool local_cache, int chunk_size, int retries) {
-  FileReader f(local_cache, chunk_size, retries);
-  raw_ = f.read(url, abort);
+  raw_ = FileReader(local_cache, chunk_size, retries).read(url, abort);
   if (raw_.empty()) return false;
 
-  bool is_bz2 = url.find(".bz2") != std::string::npos;
-  if (is_bz2) {
+  if (url.find(".bz2") != std::string::npos) {
     raw_ = decompressBZ2(raw_, abort);
-    if (raw_.empty()) {
-      if (!(abort && *abort)) {
-        rWarning("failed to decompress log");
-      }
-      return false;
-    }
+    if (raw_.empty()) return false;
   }
   return parse(abort);
 }

--- a/tools/replay/logreader.h
+++ b/tools/replay/logreader.h
@@ -51,7 +51,7 @@ public:
   LogReader(size_t memory_pool_block_size = DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE);
   ~LogReader();
   bool load(const std::string &url, std::atomic<bool> *abort = nullptr, bool local_cache = false, int chunk_size = -1, int retries = 0);
-  bool load(const std::byte *data, size_t size, std::atomic<bool> *abort = nullptr);
+  bool load(const std::byte *data, size_t size, std::atomic<bool> *abort = nullptr, bool is_bz2 = true);
 
   std::vector<Event*> events;
 

--- a/tools/replay/logreader.h
+++ b/tools/replay/logreader.h
@@ -51,11 +51,11 @@ public:
   LogReader(size_t memory_pool_block_size = DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE);
   ~LogReader();
   bool load(const std::string &url, std::atomic<bool> *abort = nullptr, bool local_cache = false, int chunk_size = -1, int retries = 0);
-  bool load(const std::byte *data, size_t size, std::atomic<bool> *abort = nullptr, bool is_bz2 = true);
-
+  bool load(const std::byte *data, size_t size, std::atomic<bool> *abort = nullptr);
   std::vector<Event*> events;
 
 private:
+  bool parse(std::atomic<bool> *abort);
   std::string raw_;
 #ifdef HAS_MEMORY_RESOURCE
   std::pmr::monotonic_buffer_resource *mbr_ = nullptr;

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -82,9 +82,9 @@ void Route::addFileToSegment(int n, const QString &file) {
   const int pos = name.lastIndexOf("--");
   name = pos != -1 ? name.mid(pos + 2) : name;
 
-  if (name == "rlog.bz2") {
+  if (name == "rlog.bz2" || name == "rlog") {
     segments_[n].rlog = file;
-  } else if (name == "qlog.bz2") {
+  } else if (name == "qlog.bz2" || name == "qlog") {
     segments_[n].qlog = file;
   } else if (name == "fcamera.hevc") {
     segments_[n].road_cam = file;

--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -71,6 +71,7 @@ TEST_CASE("LogReader") {
     FileReader reader(true);
     std::string corrupt_content = reader.read(TEST_RLOG_URL);
     corrupt_content.resize(corrupt_content.length() / 2);
+    corrupt_content = decompressBZ2(corrupt_content);
     LogReader log;
     REQUIRE(log.load((std::byte *)corrupt_content.data(), corrupt_content.size()));
     REQUIRE(log.events.size() > 0);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
