### PR TITLE
UI: only show cell settings on non-prime connection

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -116,6 +116,9 @@ MapPanel::MapPanel(QWidget* parent) : QWidget(parent) {
   stack->addWidget(main_widget);
   stack->addWidget(no_prime_widget);
   stack->setCurrentIndex(uiState()->prime_type ? 0 : 1);
+  connect(uiState(), &UIState::primeTypeChanged, [=](int prime_type) {
+    stack->setCurrentIndex(prime_type ? 0 : 1);
+  });
 
   QVBoxLayout *wrapper = new QVBoxLayout(this);
   wrapper->addWidget(stack);
@@ -194,7 +197,6 @@ void MapPanel::parseResponse(const QString &response, bool success) {
 }
 
 void MapPanel::refresh() {
-  stack->setCurrentIndex(uiState()->prime_type ? 0 : 1);
   if (cur_destinations == prev_destinations) return;
 
   QJsonDocument doc = QJsonDocument::fromJson(cur_destinations.trimmed().toUtf8());

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -115,7 +115,6 @@ MapPanel::MapPanel(QWidget* parent) : QWidget(parent) {
 
   stack->addWidget(main_widget);
   stack->addWidget(no_prime_widget);
-  stack->setCurrentIndex(uiState()->prime_type ? 0 : 1);
   connect(uiState(), &UIState::primeTypeChanged, [=](int prime_type) {
     stack->setCurrentIndex(prime_type ? 0 : 1);
   });

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -38,11 +38,11 @@ public:
   explicit AdvancedNetworking(QWidget* parent = 0, WifiManager* wifi = 0);
 
 private:
-  ToggleControl* tetheringToggle;
   LabelControl* ipLabel;
-  ToggleControl *roamingToggle;
-  ButtonControl *editApnButton;
-  ToggleControl *meteredToggle;
+  ToggleControl* tetheringToggle;
+  ToggleControl* roamingToggle;
+  ButtonControl* editApnButton;
+  ToggleControl* meteredToggle;
   WifiManager* wifi = nullptr;
   Params params;
 

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -38,8 +38,11 @@ public:
   explicit AdvancedNetworking(QWidget* parent = 0, WifiManager* wifi = 0);
 
 private:
-  LabelControl* ipLabel;
   ToggleControl* tetheringToggle;
+  LabelControl* ipLabel;
+  ToggleControl *roamingToggle;
+  ButtonControl *editApnButton;
+  ToggleControl *meteredToggle;
   WifiManager* wifi = nullptr;
   Params params;
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -415,16 +415,16 @@ void WifiManager::addTetheringConnection() {
 }
 
 void WifiManager::tetheringActivated(QDBusPendingCallWatcher *call) {
-    int prime_type = uiState()->prime_type;
-    int ipv4_forward = (prime_type == PrimeType::NONE || prime_type == PrimeType::LITE);
+  int prime_type = uiState()->prime_type;
+  int ipv4_forward = (prime_type == PrimeType::NONE || prime_type == PrimeType::LITE);
 
-    if (!ipv4_forward) {
-      QTimer::singleShot(5000, this, [=] {
-        qWarning() << "net.ipv4.ip_forward = 0";
-        std::system("sudo sysctl net.ipv4.ip_forward=0");
-      });
-    }
-    call->deleteLater();
+  if (!ipv4_forward) {
+    QTimer::singleShot(5000, this, [=] {
+      qWarning() << "net.ipv4.ip_forward = 0";
+      std::system("sudo sysctl net.ipv4.ip_forward=0");
+    });
+  }
+  call->deleteLater();
 }
 
 void WifiManager::setTetheringEnabled(bool enabled) {

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -312,11 +312,7 @@ void SetupWidget::replyFinished(const QString &response, bool success) {
 
   QJsonObject json = doc.object();
   int prime_type = json["prime_type"].toInt();
-
-  if (uiState()->prime_type != prime_type) {
-    uiState()->prime_type = prime_type;
-    Params().put("PrimeType", std::to_string(prime_type));
-  }
+  uiState()->prime_type = prime_type;
 
   if (!json["is_paired"].toBool()) {
     mainLayout->setCurrentIndex(0);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -201,6 +201,13 @@ void UIState::updateStatus() {
     started_prev = scene.started;
     emit offroadTransition(!scene.started);
   }
+
+  // Handle prime type change
+  if (prime_type != prime_type_prev) {
+    prime_type_prev = prime_type;
+    emit primeTypeChanged(prime_type);
+    Params().put("PrimeType", std::to_string(prime_type));
+  }
 }
 
 UIState::UIState(QObject *parent) : QObject(parent) {
@@ -212,7 +219,7 @@ UIState::UIState(QObject *parent) : QObject(parent) {
 
   Params params;
   wide_camera = params.getBool("WideCameraOnly");
-  prime_type = std::atoi(params.get("PrimeType").c_str());
+  prime_type = prime_type_prev = std::atoi(params.get("PrimeType").c_str());
   language = QString::fromStdString(params.get("LanguageSetting"));
 
   // update timer

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -219,7 +219,7 @@ UIState::UIState(QObject *parent) : QObject(parent) {
 
   Params params;
   wide_camera = params.getBool("WideCameraOnly");
-  prime_type = prime_type_prev = std::atoi(params.get("PrimeType").c_str());
+  prime_type = std::atoi(params.get("PrimeType").c_str());
   language = QString::fromStdString(params.get("LanguageSetting"));
 
   // update timer

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -126,7 +126,7 @@ public:
   UIScene scene = {};
 
   bool awake;
-  int prime_type = 0;
+  int prime_type;
   QString language;
 
   QTransform car_space_transform;
@@ -135,6 +135,7 @@ public:
 signals:
   void uiUpdate(const UIState &s);
   void offroadTransition(bool offroad);
+  void primeTypeChanged(int prime_type);
 
 private slots:
   void update();
@@ -142,6 +143,7 @@ private slots:
 private:
   QTimer *timer;
   bool started_prev = false;
+  int prime_type_prev;
 };
 
 UIState *uiState();

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -143,7 +143,7 @@ private slots:
 private:
   QTimer *timer;
   bool started_prev = false;
-  int prime_type_prev = 0;
+  int prime_type_prev = -1;
 };
 
 UIState *uiState();

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -143,7 +143,7 @@ private slots:
 private:
   QTimer *timer;
   bool started_prev = false;
-  int prime_type_prev;
+  int prime_type_prev = 0;
 };
 
 UIState *uiState();


### PR DESCRIPTION
- [x] merge #25902
- [x] refactor `UIState` to emit signal on prime type change
- [x] hide gsm toggles in `AdvancedNetworking` on `UIState#primeTypeChanged`
- [x] also fixed map settings not being visible after upgrading to prime