### PR TITLE
casync: handle hash failure

### DIFF
--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -186,7 +186,7 @@ def extract_casync_image(target_slot_number: int, partition: dict, cloudlog):
 
   sources: List[Tuple[str, casync.ChunkReader, casync.ChunkDict]] = []
 
-  # First source is the current partition. Index file for current version is provided in the manifest
+  # First source is the current partition.
   try:
     raw_hash = get_raw_hash(seed_path, partition['size'])
     caibx_url = f"{CAIBX_URL}{partition['name']}-{raw_hash}.caibx"

--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -196,8 +196,8 @@ def extract_casync_image(target_slot_number: int, partition: dict, cloudlog):
       sources += [('seed', casync.FileChunkReader(seed_path), casync.build_chunk_dict(casync.parse_caibx(caibx_url)))]
     except requests.RequestException:
       cloudlog.error(f"casync failed to load {caibx_url}")
-  except IOError:
-    cloudlog.error("Failed to hash seed partition")
+  except Exception:
+    cloudlog.excption("Failed to hash seed partition")
 
   # Second source is the target partition, this allows for resuming
   sources += [('target', casync.FileChunkReader(path), casync.build_chunk_dict(target))]

--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -187,13 +187,17 @@ def extract_casync_image(target_slot_number: int, partition: dict, cloudlog):
   sources: List[Tuple[str, casync.ChunkReader, casync.ChunkDict]] = []
 
   # First source is the current partition. Index file for current version is provided in the manifest
-  raw_hash = get_raw_hash(seed_path, partition['size'])
-  caibx_url = f"{CAIBX_URL}{partition['name']}-{raw_hash}.caibx"
   try:
-    cloudlog.info(f"casync fetching {caibx_url}")
-    sources += [('seed', casync.FileChunkReader(seed_path), casync.build_chunk_dict(casync.parse_caibx(caibx_url)))]
-  except requests.RequestException:
-    cloudlog.error(f"casync failed to load {caibx_url}")
+    raw_hash = get_raw_hash(seed_path, partition['size'])
+    caibx_url = f"{CAIBX_URL}{partition['name']}-{raw_hash}.caibx"
+
+    try:
+      cloudlog.info(f"casync fetching {caibx_url}")
+      sources += [('seed', casync.FileChunkReader(seed_path), casync.build_chunk_dict(casync.parse_caibx(caibx_url)))]
+    except requests.RequestException:
+      cloudlog.error(f"casync failed to load {caibx_url}")
+  except IOError:
+    cloudlog.error("Failed to hash seed partition")
 
   # Second source is the target partition, this allows for resuming
   sources += [('target', casync.FileChunkReader(path), casync.build_chunk_dict(target))]

--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -197,7 +197,7 @@ def extract_casync_image(target_slot_number: int, partition: dict, cloudlog):
     except requests.RequestException:
       cloudlog.error(f"casync failed to load {caibx_url}")
   except Exception:
-    cloudlog.exception("Failed to hash seed partition")
+    cloudlog.exception("casync failed to hash seed partition")
 
   # Second source is the target partition, this allows for resuming
   sources += [('target', casync.FileChunkReader(path), casync.build_chunk_dict(target))]

--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -197,7 +197,7 @@ def extract_casync_image(target_slot_number: int, partition: dict, cloudlog):
     except requests.RequestException:
       cloudlog.error(f"casync failed to load {caibx_url}")
   except Exception:
-    cloudlog.excption("Failed to hash seed partition")
+    cloudlog.exception("Failed to hash seed partition")
 
   # Second source is the target partition, this allows for resuming
   sources += [('target', casync.FileChunkReader(path), casync.build_chunk_dict(target))]


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
