### PR TITLE
FW fingerprinting updates

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -166,7 +166,7 @@ def fingerprint(logcan, sendcan):
     source = car.CarParams.FingerprintSource.fixed
 
   cloudlog.event("fingerprinted", car_fingerprint=car_fingerprint, source=source, fuzzy=not exact_match,
-                 fw_count=len(car_fw), ecu_rx_addrs=list(ecu_rx_addrs), error=True)
+                 fw_count=len(car_fw), ecu_responses=list(ecu_rx_addrs), error=True)
   return car_fingerprint, finger, vin, car_fw, source, exact_match
 
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -79,7 +79,7 @@ interfaces = load_interfaces(interface_names)
 def fingerprint(logcan, sendcan):
   fixed_fingerprint = os.environ.get('FINGERPRINT', "")
   skip_fw_query = os.environ.get('SKIP_FW_QUERY', False)
-  ecu_responses = set()
+  ecu_rx_addrs = set()
 
   if not fixed_fingerprint and not skip_fw_query:
     # Vin query only reliably works thorugh OBDII
@@ -98,7 +98,7 @@ def fingerprint(logcan, sendcan):
     else:
       cloudlog.warning("Getting VIN & FW versions")
       _, vin = get_vin(logcan, sendcan, bus)
-      ecu_responses = get_present_ecus(logcan, sendcan)
+      ecu_rx_addrs = get_present_ecus(logcan, sendcan)
       car_fw = get_fw_versions(logcan, sendcan)
 
     exact_fw_match, fw_candidates = match_fw_to_car(car_fw)
@@ -166,7 +166,7 @@ def fingerprint(logcan, sendcan):
     source = car.CarParams.FingerprintSource.fixed
 
   cloudlog.event("fingerprinted", car_fingerprint=car_fingerprint, source=source, fuzzy=not exact_match,
-                 fw_count=len(car_fw), ecu_responses=list(ecu_responses), error=True)
+                 fw_count=len(car_fw), ecu_rx_addrs=list(ecu_rx_addrs), error=True)
   return car_fingerprint, finger, vin, car_fw, source, exact_match
 
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -166,7 +166,7 @@ def fingerprint(logcan, sendcan):
     source = car.CarParams.FingerprintSource.fixed
 
   cloudlog.event("fingerprinted", car_fingerprint=car_fingerprint, source=source, fuzzy=not exact_match,
-                 fw_count=len(car_fw), ecu_responses=ecu_responses, error=True)
+                 fw_count=len(car_fw), ecu_responses=list(ecu_responses), error=True)
   return car_fingerprint, finger, vin, car_fw, source, exact_match
 
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -371,7 +371,7 @@ def get_fw_versions(logcan, sendcan, extra=None, timeout=0.1, debug=False, progr
   addrs.insert(0, parallel_addrs)
 
   fw_versions = {}
-  for addr in tqdm(addrs, disable=not progress):
+  for i, addr in enumerate(tqdm(addrs, disable=not progress)):
     for addr_chunk in chunks(addr):
       for r in REQUESTS:
         try:
@@ -380,7 +380,8 @@ def get_fw_versions(logcan, sendcan, extra=None, timeout=0.1, debug=False, progr
 
           if addrs:
             query = IsoTpParallelQuery(sendcan, logcan, r.bus, addrs, r.request, r.response, r.rx_offset, debug=debug)
-            fw_versions.update({(r.brand, addr): (version, r) for addr, version in query.get_data(timeout).items()})
+            t = 2 * timeout if i == 0 else timeout
+            fw_versions.update({(r.brand, addr): (version, r) for addr, version in query.get_data(t).items()})
         except Exception:
           cloudlog.warning(f"FW query exception: {traceback.format_exc()}")
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -448,9 +448,10 @@ if __name__ == "__main__":
   print()
   print("Found FW versions")
   print("{")
+  padding = max([len(fw.brand) for fw in fw_vers])
   for version in fw_vers:
     subaddr = None if version.subAddress == 0 else hex(version.subAddress)
-    print(f"  (Ecu.{version.ecu}, {hex(version.address)}, {subaddr}): [{version.fwVersion}]")
+    print(f"  Brand: {version.brand:{padding}} - (Ecu.{version.ecu}, {hex(version.address)}, {subaddr}): [{version.fwVersion}]")
   print("}")
 
   print()


### PR DESCRIPTION
- Fuzzy fingerprinting can only ever return 0 or 1 matches, however exact matching can return any number of matches. Previous behavior was to throw out matches if `len(matches) > 1`, but was changed to just use the first exact match. This changes `match_fw_to_car()` back to original behavior for exact matching.
- Update ecu_responses name and fix json parsing
- Print brand with ecu when running fw_versions.py