### PR TITLE
casync: manifest compare script

### DIFF
--- a/system/hardware/tici/tests/compare_casync_manifest.py
+++ b/system/hardware/tici/tests/compare_casync_manifest.py
@@ -59,16 +59,16 @@ if __name__ == "__main__":
       sources['remote_uncompressed'].append(chunk.length)
       sources['remote_compressed'].append(chunk_sizes[chunk.sha])
 
-  print("Update statistics (excluding zeros):")
-  print(f"  Total (uncompressed) {sum(sources['seed'] + sources['remote_uncompressed']) / 1000 / 1000:.2f} MB n = {len(to)}")
-  print(f"  Total (compressed download) {sum(chunk_sizes.values()) / 1000 / 1000:.2f} MB n = {len(to)}")
-
-  print("Seed:")
-  print(f"  Seed (uncompressed) {sum(sources['seed']) / 1000 / 1000:.2f} MB n = {len(sources['seed'])}")
-
-  print("Remote:")
+  print()
+  print("Update statistics (excluding zeros)")
+  print()
+  print("Download only with no seed:")
+  print(f"  Remote (uncompressed)\t\t{sum(sources['seed'] + sources['remote_uncompressed']) / 1000 / 1000:.2f} MB\tn = {len(to)}")
+  print(f"  Remote (compressed download)\t{sum(chunk_sizes.values()) / 1000 / 1000:.2f} MB\tn = {len(to)}")
+  print()
+  print("Upgrade with seed partition:")
+  print(f"  Seed   (uncompressed)\t\t{sum(sources['seed']) / 1000 / 1000:.2f} MB\t\t\t\tn = {len(sources['seed'])}")
   sz, n = sum(sources['remote_uncompressed']), len(sources['remote_uncompressed'])
-  print(f"  Remote (uncompressed) {sz / 1000 / 1000:.2f} MB (avg {sz / 1000 / 1000 / n:4f} MB) n = {n}")
-
+  print(f"  Remote (uncompressed)\t\t{sz / 1000 / 1000:.2f} MB\t(avg {sz / 1000 / 1000 / n:4f} MB)\tn = {n}")
   sz, n = sum(sources['remote_compressed']), len(sources['remote_compressed'])
-  print(f"  Remote (compressed download) {sz / 1000 / 1000:.2f} MB (avg {sz / 1000 / 1000 / n:4f} MB) n = {n}")
+  print(f"  Remote (compressed download)\t{sz / 1000 / 1000:.2f} MB\t(avg {sz / 1000 / 1000 / n:4f} MB)\tn = {n}")

--- a/system/hardware/tici/tests/compare_casync_manifest.py
+++ b/system/hardware/tici/tests/compare_casync_manifest.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+import multiprocessing
+import os
+from typing import Dict, List
+
+import requests
+from tqdm import tqdm
+
+import system.hardware.tici.casync as casync
+
+
+def get_chunk_download_size(chunk):
+  sha = chunk.sha.hex()
+  path = os.path.join(remote_url, sha[:4], sha + ".cacnk")
+  if os.path.isfile(path):
+    return os.path.getsize(path)
+  else:
+    r = requests.head(path)
+    r.raise_for_status()
+    return int(r.headers['content-length'])
+
+
+if __name__ == "__main__":
+
+  parser = argparse.ArgumentParser(description='Compute overlap between two casync manifests')
+  parser.add_argument('frm')
+  parser.add_argument('to')
+  args = parser.parse_args()
+
+  frm = casync.parse_caibx(args.frm)
+  to = casync.parse_caibx(args.to)
+  remote_url = args.to.replace('.caibx', '')
+
+  most_common = collections.Counter(t.sha for t in to).most_common(1)[0][0]
+
+  frm_dict = casync.build_chunk_dict(frm)
+
+  # Get content-length for each chunk
+  with multiprocessing.Pool() as pool:
+    szs = list(tqdm(pool.imap(get_chunk_download_size, to), total=len(to)))
+  chunk_sizes = {t.sha: sz for (t, sz) in zip(to, szs)}
+
+  sources: Dict[str, List[int]] = {
+    'seed': [],
+    'remote_uncompressed': [],
+    'remote_compressed': [],
+  }
+
+  for chunk in to:
+    # Assume most common chunk is the zero chunk
+    if chunk.sha == most_common:
+      continue
+
+    if chunk.sha in frm_dict:
+      sources['seed'].append(chunk.length)
+    else:
+      sources['remote_uncompressed'].append(chunk.length)
+      sources['remote_compressed'].append(chunk_sizes[chunk.sha])
+
+  print("Update statistics (exluding zeros):")
+  print(f"  Total (uncompressed) {sum(sources['seed'] + sources['remote_uncompressed']) / 1000 / 1000:.2f} MB n = {len(to)}")
+  print(f"  Total (compressed download) {sum(chunk_sizes.values()) / 1000 / 1000:.2f} MB n = {len(to)}")
+
+  print("Seed:")
+  print(f"  Seed (uncompressed) {sum(sources['seed']) / 1000 / 1000:.2f} MB n = {len(sources['seed'])}")
+
+  print("Remote:")
+  sz, n = sum(sources['remote_uncompressed']), len(sources['remote_uncompressed'])
+  print(f"  Remote (uncompressed) {sz / 1000 / 1000:.2f} MB (avg {sz / 1000 / 1000 / n:4f} MB) n = {n}")
+
+  sz, n = sum(sources['remote_compressed']), len(sources['remote_compressed'])
+  print(f"  Remote (compressed download) {sz / 1000 / 1000:.2f} MB (avg {sz / 1000 / 1000 / n:4f} MB) n = {n}")

--- a/system/hardware/tici/tests/compare_casync_manifest.py
+++ b/system/hardware/tici/tests/compare_casync_manifest.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
       sources['remote_uncompressed'].append(chunk.length)
       sources['remote_compressed'].append(chunk_sizes[chunk.sha])
 
-  print("Update statistics (exluding zeros):")
+  print("Update statistics (excluding zeros):")
   print(f"  Total (uncompressed) {sum(sources['seed'] + sources['remote_uncompressed']) / 1000 / 1000:.2f} MB n = {len(to)}")
   print(f"  Total (compressed download) {sum(chunk_sizes.values()) / 1000 / 1000:.2f} MB n = {len(to)}")
 


### PR DESCRIPTION
AGNOS 5.1 -> 5.2 stats

Larger chunks mean more efficient download when no seed, but worse performance when seed is available. For reference the .xz compressed sparse image is 651MB.

64k:
```
Download only with no seed:
  Remote (uncompressed)		3500.67 MB	n = 74027
  Remote (compressed download)	853.81 MB	n = 74027

Upgrade with seed partition:
  Seed   (uncompressed)		2264.36 MB				n = 33335
  Remote (uncompressed)		1236.31 MB	(avg 0.094476 MB)	n = 13086
  Remote (compressed download)	266.12 MB	(avg 0.020336 MB)	n = 13086
```

128k:
```
Download only with no seed:
  Remote (uncompressed)		3508.01 MB	n = 35894
  Remote (compressed download)	818.85 MB	n = 35894

Upgrade with seed partition:
  Seed   (uncompressed)		2072.70 MB				n = 14637
  Remote (uncompressed)		1435.31 MB	(avg 0.192195 MB)	n = 7468
  Remote (compressed download)	295.62 MB	(avg 0.039585 MB)	n = 7468
```

256k:
```
Download only with no seed:
  Remote (uncompressed)		3520.07 MB	n = 17850
  Remote (compressed download)	790.50 MB	n = 17850

Upgrade with seed partition:
  Seed   (uncompressed)		1882.29 MB				n = 6709
  Remote (uncompressed)		1637.78 MB	(avg 0.384636 MB)	n = 4258
  Remote (compressed download)	328.80 MB	(avg 0.077219 MB)	n = 4258

```

512k:
```
Download only with no seed:
  Remote (uncompressed)		3550.48 MB	n = 8686
  Remote (compressed download)	761.26 MB	n = 8686

Upgrade with seed partition:
  Seed   (uncompressed)		1643.73 MB				n = 2880
  Remote (uncompressed)		1906.75 MB	(avg 0.801492 MB)	n = 2379
  Remote (compressed download)	366.46 MB	(avg 0.154040 MB)	n = 2379

```

1MB:
```
Download only with no seed:
  Remote (uncompressed)		3594.52 MB	n = 4274
  Remote (compressed download)	737.06 MB	n = 4274

Upgrade with seed partition:
  Seed   (uncompressed)		1344.65 MB				n = 1200
  Remote (uncompressed)		2249.86 MB	(avg 1.641039 MB)	n = 1371
  Remote (compressed download)	415.86 MB	(avg 0.303324 MB)	n = 1371
```