### PR TITLE
Ford: parse VIN correctly

### DIFF
--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -28,6 +28,9 @@ def get_vin(logcan, sendcan, bus, timeout=0.1, retry=5, debug=False):
           if vin.startswith(b'\x11'):
             vin = vin[1:18]
 
+          # Ford returns 24 bytes padded with nulls, trim to correct length
+          vin = vin[0:17]
+
           return addr[0], rx_addr, vin.decode()
         print(f"vin query retry ({i+1}) ...")
       except Exception:


### PR DESCRIPTION
Ford ECUs respond to the UDS VIN request with 24 bytes (padded with nulls). This was causing a "Malformed VIN" error in the logs.

Example Route: `86d00e12925f4df7|2022-06-25--12-18-27` (car params in useradmin just shows VIN: 0)

Example from parsing some recordings of UDS traffic:
```
0x7df  ReadDataByIdentifier.Request(didlist=['VIN'])
0x7e8  ReadDataByIdentifier.PositiveResponse(raw=\x57\x46\x30\x4e\x58\x58\x47\x43\x48\x4e\x4a\x52\x36\x39\x37\x31\x32\x00\x00\x00\x00\x00\x00\x00, utf8="WF0NXXGCHNJR69712       ")
```