### PR TITLE
FPv2: fingerprint on all FW combinations

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -8,7 +8,7 @@ from system.version import is_comma_remote, is_tested_branch
 from selfdrive.car.interfaces import get_interface_attr
 from selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 from selfdrive.car.vin import get_vin, VIN_UNKNOWN
-from selfdrive.car.fw_versions import get_fw_versions_ordered, match_fw_to_car, get_present_ecus
+from selfdrive.car.fw_versions import get_fw_versions, match_fw_to_car, get_present_ecus
 from system.swaglog import cloudlog
 import cereal.messaging as messaging
 from selfdrive.car import gen_empty_fingerprint
@@ -99,7 +99,7 @@ def fingerprint(logcan, sendcan):
       cloudlog.warning("Getting VIN & FW versions")
       _, vin_rx_addr, vin = get_vin(logcan, sendcan, bus)
       ecu_rx_addrs = get_present_ecus(logcan, sendcan)
-      car_fw = get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs)
+      car_fw = get_fw_versions(logcan, sendcan)
 
     exact_fw_match, fw_candidates = match_fw_to_car(car_fw)
   else:

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -8,7 +8,7 @@ from system.version import is_comma_remote, is_tested_branch
 from selfdrive.car.interfaces import get_interface_attr
 from selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 from selfdrive.car.vin import get_vin, VIN_UNKNOWN
-from selfdrive.car.fw_versions import get_fw_versions, match_fw_to_car, get_present_ecus
+from selfdrive.car.fw_versions import get_fw_versions_ordered, match_fw_to_car, get_present_ecus
 from system.swaglog import cloudlog
 import cereal.messaging as messaging
 from selfdrive.car import gen_empty_fingerprint
@@ -99,7 +99,7 @@ def fingerprint(logcan, sendcan):
       cloudlog.warning("Getting VIN & FW versions")
       _, vin_rx_addr, vin = get_vin(logcan, sendcan, bus)
       ecu_rx_addrs = get_present_ecus(logcan, sendcan)
-      car_fw = get_fw_versions(logcan, sendcan)
+      car_fw = get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs)
 
     exact_fw_match, fw_candidates = match_fw_to_car(car_fw)
   else:

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -336,8 +336,7 @@ def match_fw_to_car(fw_versions, allow_fuzzy=True):
     exact_matches.append((False, match_fw_to_car_fuzzy))
 
   for exact_match, match_func in exact_matches:
-    # TODO: For each brand, attempt to fingerprint using FW returned from its queries
-    # Until erroneous FW versions are removed, try to fingerprint on all possible combinations
+    # TODO: For each brand, attempt to fingerprint using only FW returned from its queries
     matches = set()
     fw_versions_dict = build_fw_dict(fw_versions, filter_brand=None)
     matches |= match_func(fw_versions_dict)

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import itertools
 import struct
 import traceback
 from collections import defaultdict
@@ -22,11 +21,6 @@ ESSENTIAL_ECUS = [Ecu.engine, Ecu.eps, Ecu.esp, Ecu.fwdRadar, Ecu.fwdCamera, Ecu
 
 def p16(val):
   return struct.pack("!H", val)
-
-
-def all_subsets(iterable):
-  s = list(iterable)
-  return itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s) + 1))
 
 
 TESTER_PRESENT_REQUEST = bytes([uds.SERVICE_TYPE.TESTER_PRESENT, 0x0])
@@ -418,12 +412,8 @@ def get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs, timeout=0.1, debug=Fa
 
     # TODO: Until erroneous FW versions are removed, try to fingerprint on all possible combinations so far
     exact_match, matches = match_fw_to_car(all_car_fw, allow_fuzzy=False)
-    if exact_match and len(matches) == 1:
+    if len(matches) == 1:
       break
-    all_fw_versions_dict = build_fw_dict(all_car_fw)
-    for fw_versions_subset in all_subsets(all_fw_versions_dict.items()):
-      if len(match_fw_to_car_exact(dict(fw_versions_subset))) == 1:
-        break
 
   return all_car_fw
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -228,7 +228,7 @@ def chunks(l, n=128):
 
 
 def build_fw_dict(fw_versions, filter_brand=None):
-  """Returns all fw versions for an address (from different requests or brands if filter not specified)"""
+  """Returns all FW versions for an address"""
 
   fw_versions_dict = defaultdict(set)
   for fw in fw_versions:

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -411,7 +411,7 @@ def get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs, timeout=0.1, debug=Fa
     all_car_fw.extend(car_fw)
 
     # TODO: Until erroneous FW versions are removed, try to fingerprint on all possible combinations so far
-    exact_match, matches = match_fw_to_car(all_car_fw, allow_fuzzy=False)
+    _, matches = match_fw_to_car(all_car_fw, allow_fuzzy=False)
     if len(matches) == 1:
       break
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -228,8 +228,6 @@ def chunks(l, n=128):
 
 
 def build_fw_dict(fw_versions, filter_brand=None):
-  """Returns all FW versions for an address"""
-
   fw_versions_dict = defaultdict(set)
   for fw in fw_versions:
     if filter_brand is None or fw.brand == filter_brand:

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -89,24 +89,9 @@ if __name__ == "__main__":
             print("not in supported cars")
             break
 
-          # Older routes only have carFw from their brand
-          old_route = not any([len(fw.brand) for fw in car_fw])
-          brands = SUPPORTED_BRANDS if not old_route else [None]
-
-          # Exact match
-          exact_matches, fuzzy_matches = [], []
-          for brand in brands:
-            fw_versions_dict = build_fw_dict(car_fw, filter_brand=brand)
-            exact_matches = match_fw_to_car_exact(fw_versions_dict)
-            if len(exact_matches) == 1:
-              break
-
-          # Fuzzy match
-          for brand in brands:
-            fw_versions_dict = build_fw_dict(car_fw, filter_brand=brand)
-            fuzzy_matches = match_fw_to_car_fuzzy(fw_versions_dict)
-            if len(fuzzy_matches) == 1:
-              break
+          fw_versions_dict = build_fw_dict(car_fw)
+          exact_matches = match_fw_to_car_exact(fw_versions_dict)
+          fuzzy_matches = match_fw_to_car_fuzzy(fw_versions_dict)
 
           if (len(exact_matches) == 1) and (list(exact_matches)[0] == live_fingerprint):
             good_exact += 1


### PR DESCRIPTION
Will run this on a lot of routes to ensure we don't change fingerprinting outcomes, but should be good to go

- Tries to fingerprint on all FW versions returned, still ordering and breaking when an exact match is achieved (except on all FW versions, not just by brand)
- `build_fw_dict` now returns a dictionary where values are a set of all the fwVersions returned for that `(addr, sub_addr)` key (could be from different brand requests if not filtered)
- `match_fw_to_car_fuzzy` and `match_fw_to_car_exact` now try to fingerprint using any of the FW responses for the `(addr, sub_addr)` key