### PR TITLE
docs: fix Table of Contents link to "in a car" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Table of Contents
 =======================
 
 * [What is openpilot?](#what-is-openpilot)
-* [Running on a dedicated device in a car](#running-on-a-dedicated-device-in-a-car)
+* [Running in a car](#running-on-a-dedicated-device-in-a-car)
 * [Running on PC](#running-on-pc)
 * [Community and Contributing](#community-and-contributing)
 * [User Data and comma Account](#user-data-and-comma-account)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Table of Contents
 =======================
 
 * [What is openpilot?](#what-is-openpilot)
-* [Running in a car](#running-in-a-car)
+* [Running on a dedicated device in a car](#running-on-a-dedicated-device-in-a-car)
 * [Running on PC](#running-on-pc)
 * [Community and Contributing](#community-and-contributing)
 * [User Data and comma Account](#user-data-and-comma-account)


### PR DESCRIPTION
**Description**
The README.md heading for "Running in a car" changed to "Running on a dedicated device in a car" so the Table of Contents link no longer worked.
This PR updates the link and text in the table.

**Verification**
Clicked on the link in my forked README.md