### PR TITLE
FPv2: log all responses

### DIFF
--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -465,13 +465,15 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
           if addrs:
             query = IsoTpParallelQuery(sendcan, logcan, r.bus, addrs, r.request, r.response, r.rx_offset, debug=debug)
 
-            for (addr, _), version in query.get_data(timeout).items():  # TODO: use new response address (_)
+            for (addr, rx_addr), version in query.get_data(timeout).items():
               f = car.CarParams.CarFw.new_message()
 
               f.ecu = ecu_types[(r.brand, addr[0], addr[1])]
               f.fwVersion = version
               f.address = addr[0]
-              f.responseAddress = uds.get_rx_addr_for_tx_addr(addr[0], r.rx_offset)
+              f.responseAddress = rx_addr
+              print(f'calc rx addr: {uds.get_rx_addr_for_tx_addr(addr[0], r.rx_offset)}, actual rx addr: {rx_addr}')
+              assert uds.get_rx_addr_for_tx_addr(addr[0], r.rx_offset) == rx_addr
               f.request = r.request
               f.brand = r.brand
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -464,7 +464,6 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
 
           if addrs:
             query = IsoTpParallelQuery(sendcan, logcan, r.bus, addrs, r.request, r.response, r.rx_offset, debug=debug)
-
             for (addr, rx_addr), version in query.get_data(timeout).items():
               f = car.CarParams.CarFw.new_message()
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -476,6 +476,7 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
               assert uds.get_rx_addr_for_tx_addr(addr[0], r.rx_offset) == rx_addr
               f.request = r.request
               f.brand = r.brand
+              f.bus = r.bus
 
               if addr[1] is not None:
                 f.subAddress = addr[1]
@@ -531,7 +532,7 @@ if __name__ == "__main__":
   padding = max([len(fw.brand) for fw in fw_vers] or [0])
   for version in fw_vers:
     subaddr = None if version.subAddress == 0 else hex(version.subAddress)
-    print(f"  Brand: {version.brand:{padding}} - (Ecu.{version.ecu}, {hex(version.address)}, {subaddr}): [{version.fwVersion}]")
+    print(f"  Brand: {version.brand:{padding}}, bus: {version.bus} - (Ecu.{version.ecu}, {hex(version.address)}, {subaddr}): [{version.fwVersion}]")
   print("}")
 
   print()

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -472,8 +472,6 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
               f.fwVersion = version
               f.address = addr[0]
               f.responseAddress = rx_addr
-              print(f'calc rx addr: {uds.get_rx_addr_for_tx_addr(addr[0], r.rx_offset)}, actual rx addr: {rx_addr}')
-              assert uds.get_rx_addr_for_tx_addr(addr[0], r.rx_offset) == rx_addr
               f.request = r.request
               f.brand = r.brand
               f.bus = r.bus

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
           padding = max([len(fw.brand or UNKNOWN_BRAND) for fw in car_fw])
           for version in sorted(car_fw, key=lambda fw: fw.brand):
             subaddr = None if version.subAddress == 0 else hex(version.subAddress)
-            print(f"  Brand: {version.brand or UNKNOWN_BRAND:{padding}} - (Ecu.{version.ecu}, {hex(version.address)}, {subaddr}): [{version.fwVersion}],")
+            print(f"  Brand: {version.brand or UNKNOWN_BRAND:{padding}}, bus: {version.bus} - (Ecu.{version.ecu}, {hex(version.address)}, {subaddr}): [{version.fwVersion}],")
 
           print("Mismatches")
           found = False


### PR DESCRIPTION
Previous PRs removed ordering problem between brands but requests within brands still overrode previous responses.

Now we simply append to a list instead of updating a dictionary to never throw away a valid response. Recent change to fingerprint on all versions for an `(addr, subaddr)` key (https://github.com/commaai/openpilot/pull/25204) means this is the only change required, and doesn't affect fingerprinting whatsoever.

Future idea: use the Ecu whitelisting to make sure we only get the response per ecu from the request that gives the most unique data (from looking at a lot of routes with this logging)

TLDR:
- Appends all responses to a list, not update a dict (don't throw anything away)
- Log bus for each version in the CarFw struct (might use same request on multiple buses)
- Fingerprinting on all ECU responses was added in https://github.com/commaai/openpilot/pull/25204, so these changes work out of the box