### PR TITLE
Ford: fix gear parsing

### DIFF
--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from cereal import car
 from common.conversions import Conversions as CV
 from opendbc.can.can_define import CANDefine
@@ -51,8 +49,8 @@ class CarState(CarStateBase):
 
     # gear
     if self.CP.transmissionType == TransmissionType.automatic:
-      gear = int(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnGear_D_RqDrv"])
-      ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(gear, None))
+      gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnGear_D_RqDrv"], None)
+      ret.gearShifter = self.parse_gear_shifter(gear)
     elif self.CP.transmissionType == TransmissionType.manual:
       ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
       if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
@@ -84,14 +82,6 @@ class CarState(CarStateBase):
     self.lkas_status_stock_values = cp_cam.vl["IPMA_Data"]
 
     return ret
-
-  @staticmethod
-  def parse_gear_shifter(gear: str) -> car.CarState.GearShifter:
-    d: Dict[str, car.CarState.GearShifter] = {
-        'PARK': GearShifter.park, 'REVERSE': GearShifter.reverse, 'NEUTRAL': GearShifter.neutral,
-        'MANUAL': GearShifter.manumatic, 'DRIVE': GearShifter.drive,
-    }
-    return d.get(gear, GearShifter.unknown)
 
   @staticmethod
   def get_can_parser(CP):

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -88,8 +88,8 @@ class CarState(CarStateBase):
   @staticmethod
   def parse_gear_shifter(gear: str) -> car.CarState.GearShifter:
     d: Dict[str, car.CarState.GearShifter] = {
-        'Park': GearShifter.park, 'Reverse': GearShifter.reverse, 'Neutral': GearShifter.neutral,
-        'Manual': GearShifter.manumatic, 'Drive': GearShifter.drive,
+        'PARK': GearShifter.park, 'REVERSE': GearShifter.reverse, 'NEUTRAL': GearShifter.neutral,
+        'MANUAL': GearShifter.manumatic, 'DRIVE': GearShifter.drive,
     }
     return d.get(gear, GearShifter.unknown)
 

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -2,7 +2,7 @@
 from cereal import car
 from common.conversions import Conversions as CV
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint
-from selfdrive.car.ford.values import TransmissionType, CAR
+from selfdrive.car.ford.values import CAR, TransmissionType, GearShifter
 from selfdrive.car.interfaces import CarInterfaceBase
 
 
@@ -70,7 +70,7 @@ class CarInterface(CarInterfaceBase):
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)
 
-    events = self.create_common_events(ret)
+    events = self.create_common_events(ret, extra_gears=[GearShifter.manumatic])
     ret.events = events.to_msg()
 
     return ret

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -7,6 +7,7 @@ from selfdrive.car.docs_definitions import CarInfo
 
 Ecu = car.CarParams.Ecu
 TransmissionType = car.CarParams.TransmissionType
+GearShifter = car.CarState.GearShifter
 
 AngleRateLimit = namedtuple('AngleRateLimit', ['speed_points', 'max_angle_diff_points'])
 

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -319,6 +319,9 @@ class CarStateBase(ABC):
 
   @staticmethod
   def parse_gear_shifter(gear: Optional[str]) -> car.CarState.GearShifter:
+    if gear is None:
+      return GearShifter.unknown
+    
     d: Dict[str, car.CarState.GearShifter] = {
         'P': GearShifter.park, 'PARK': GearShifter.park,
         'R': GearShifter.reverse, 'REVERSE': GearShifter.reverse,
@@ -330,7 +333,7 @@ class CarStateBase(ABC):
         'L': GearShifter.low, 'LOW': GearShifter.low,
         'B': GearShifter.brake, 'BRAKE': GearShifter.brake,
     }
-    return d.get(gear.upper(), GearShifter.unknown) if gear is not None else GearShifter.unknown
+    return d.get(gear.upper(), GearShifter.unknown)
 
   @staticmethod
   def get_cam_can_parser(CP):

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -320,11 +320,17 @@ class CarStateBase(ABC):
   @staticmethod
   def parse_gear_shifter(gear: str) -> car.CarState.GearShifter:
     d: Dict[str, car.CarState.GearShifter] = {
-        'P': GearShifter.park, 'R': GearShifter.reverse, 'N': GearShifter.neutral,
-        'E': GearShifter.eco, 'T': GearShifter.manumatic, 'D': GearShifter.drive,
-        'S': GearShifter.sport, 'L': GearShifter.low, 'B': GearShifter.brake
+        'P': GearShifter.park, 'PARK': GearShifter.park,
+        'R': GearShifter.reverse, 'REVERSE': GearShifter.reverse,
+        'N': GearShifter.neutral, 'NEUTRAL': GearShifter.neutral,
+        'E': GearShifter.eco, 'ECO': GearShifter.eco,
+        'T': GearShifter.manumatic, 'MANUAL': GearShifter.manumatic,
+        'D': GearShifter.drive, 'DRIVE': GearShifter.drive,
+        'S': GearShifter.sport, 'SPORT': GearShifter.sport,
+        'L': GearShifter.low, 'LOW': GearShifter.low,
+        'B': GearShifter.brake, 'BRAKE': GearShifter.brake,
     }
-    return d.get(gear, GearShifter.unknown)
+    return d.get(gear.upper(), GearShifter.unknown)
 
   @staticmethod
   def get_cam_can_parser(CP):

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -2,7 +2,7 @@ import yaml
 import os
 import time
 from abc import abstractmethod, ABC
-from typing import Any, Dict, Tuple, List
+from typing import Any, Dict, Optional, Tuple, List
 
 from cereal import car
 from common.basedir import BASEDIR
@@ -318,7 +318,7 @@ class CarStateBase(ABC):
     return bool(left_blinker_stalk or self.left_blinker_cnt > 0), bool(right_blinker_stalk or self.right_blinker_cnt > 0)
 
   @staticmethod
-  def parse_gear_shifter(gear: str) -> car.CarState.GearShifter:
+  def parse_gear_shifter(gear: Optional[str]) -> car.CarState.GearShifter:
     d: Dict[str, car.CarState.GearShifter] = {
         'P': GearShifter.park, 'PARK': GearShifter.park,
         'R': GearShifter.reverse, 'REVERSE': GearShifter.reverse,
@@ -330,7 +330,7 @@ class CarStateBase(ABC):
         'L': GearShifter.low, 'LOW': GearShifter.low,
         'B': GearShifter.brake, 'BRAKE': GearShifter.brake,
     }
-    return d.get(gear.upper(), GearShifter.unknown)
+    return d.get(gear.upper(), GearShifter.unknown) if gear is not None else GearShifter.unknown
 
   @staticmethod
   def get_cam_can_parser(CP):


### PR DESCRIPTION
`CANDefine` converts all of the signal defined values to uppercase/snake case, so our map from signal to gears should use uppercase too.

Also added Manumatic as an extra drive gear for Ford.