### PR TITLE
nav: speed limits using valhalla map matching

### DIFF
--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -24,7 +24,7 @@ REROUTE_DISTANCE = 25
 MANEUVER_TRANSITION_THRESHOLD = 10
 VALID_POS_STD = 50.0
 
-VALHALLA_HOST = "http://localhost:8002"
+VALHALLA_HOST = "http://valhalla1.openstreetmap.de/"
 
 
 class RouteEngine:

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -180,7 +180,7 @@ void NvgWindow::updateState(const UIState &s) {
   const SubMaster &sm = *(s.sm);
 
   const bool cs_alive = sm.alive("controlsState");
-  const bool nav_alive = sm.alive("navInstruction") && sm["navInstruction"].getValid();
+  const bool nav_alive = sm.alive("navInstruction");
 
   const auto cs = sm["controlsState"].getControlsState();
 
@@ -202,8 +202,8 @@ void NvgWindow::updateState(const UIState &s) {
   speed_limit *= (s.scene.is_metric ? MS_TO_KPH : MS_TO_MPH);
 
   setProperty("speedLimit", speed_limit);
-  setProperty("has_us_speed_limit", nav_alive && speed_limit_sign == cereal::NavInstruction::SpeedLimitSign::MUTCD);
-  setProperty("has_eu_speed_limit", nav_alive && speed_limit_sign == cereal::NavInstruction::SpeedLimitSign::VIENNA);
+  setProperty("has_us_speed_limit", nav_alive && speed_limit > 0 && speed_limit_sign == cereal::NavInstruction::SpeedLimitSign::MUTCD);
+  setProperty("has_eu_speed_limit", nav_alive && speed_limit > 0 && speed_limit_sign == cereal::NavInstruction::SpeedLimitSign::VIENNA);
 
   setProperty("is_cruise_set", cruise_set);
   setProperty("is_metric", s.scene.is_metric);


### PR DESCRIPTION
Seems to work ok-ish. The map snapping seems eager to pick exits over continuing on the highway leading to wrong or missing speed limits when passing exits.

The public server has strict rate limits, so this is not shippable without running our own valhalla server! https://gis-ops.com/global-open-valhalla-server-online/
> The server is available on https://valhalla1.openstreetmap.de/ and accepts requests on all endpoints except for /expansion, /height and /centroid. The whole infrastructure consists of one server to build an updated routing graph continuously, while another server hosts the service on 16 threads. One server to answer requests also means we have to put tight-ish restrictions on the public access to the service: each user has a limit of 1 request per second and the service has a total rate limit of 100 requests per second. We still hope that this initiative will serve as in easy entrypoint for interested users and foster Valhalla's contributor community.
