### PR TITLE
casync unittests

### DIFF
--- a/system/hardware/tici/casync.py
+++ b/system/hardware/tici/casync.py
@@ -61,19 +61,24 @@ class RemoteChunkReader(ChunkReader):
     sha_hex = chunk.sha.hex()
     url = os.path.join(self.url, sha_hex[:4], sha_hex + ".cacnk")
 
-    for i in range(CHUNK_DOWNLOAD_RETRIES):
-      try:
-        resp = self.session.get(url, timeout=CHUNK_DOWNLOAD_TIMEOUT)
-        break
-      except Exception:
-        if i == CHUNK_DOWNLOAD_RETRIES - 1:
-          raise
-        time.sleep(CHUNK_DOWNLOAD_TIMEOUT)
+    if os.path.isfile(url):
+      with open(url, 'rb') as f:
+        contents = f.read()
+    else:
+      for i in range(CHUNK_DOWNLOAD_RETRIES):
+        try:
+          resp = self.session.get(url, timeout=CHUNK_DOWNLOAD_TIMEOUT)
+          break
+        except Exception:
+          if i == CHUNK_DOWNLOAD_RETRIES - 1:
+            raise
+          time.sleep(CHUNK_DOWNLOAD_TIMEOUT)
 
-    resp.raise_for_status()
+      resp.raise_for_status()
+      contents = resp.content
 
     decompressor = lzma.LZMADecompressor(format=lzma.FORMAT_AUTO)
-    return decompressor.decompress(resp.content)
+    return decompressor.decompress(contents)
 
 
 def parse_caibx(caibx_path: str) -> List[Chunk]:

--- a/system/hardware/tici/casync.py
+++ b/system/hardware/tici/casync.py
@@ -147,7 +147,8 @@ def extract(target: List[Chunk],
             progress: Optional[Callable[[int], None]] = None):
   stats: Dict[str, int] = defaultdict(int)
 
-  with open(out_path, 'wb') as out:
+  mode = 'rb+' if os.path.exists(out_path) else 'wb'
+  with open(out_path, mode) as out:
     for cur_chunk in target:
 
       # Find source for desired chunk

--- a/system/hardware/tici/casync.py
+++ b/system/hardware/tici/casync.py
@@ -40,9 +40,11 @@ class ChunkReader(ABC):
 class FileChunkReader(ChunkReader):
   """Reads chunks from a local file"""
   def __init__(self, fn: str) -> None:
-
     super().__init__()
     self.f = open(fn, 'rb')
+
+  def __del__(self):
+    self.f.close()
 
   def read(self, chunk: Chunk) -> bytes:
     self.f.seek(chunk.offset)
@@ -125,6 +127,7 @@ def parse_caibx(caibx_path: str) -> List[Chunk]:
     chunks.append(Chunk(sha, offset, length))
     offset = new_offset
 
+  caibx.close()
   return chunks
 
 

--- a/system/hardware/tici/tests/test_casync.py
+++ b/system/hardware/tici/tests/test_casync.py
@@ -60,6 +60,7 @@ class TestCasync(unittest.TestCase):
 
   def test_simple_extract(self):
     target = casync.parse_caibx(self.manifest_fn)
+
     sources = [('remote', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
     stats = casync.extract(target, sources, self.target_fn)
 
@@ -69,11 +70,12 @@ class TestCasync(unittest.TestCase):
     self.assertEqual(stats['remote'], len(self.contents))
 
   def test_seed(self):
+    target = casync.parse_caibx(self.manifest_fn)
+
     # Populate seed with half of the target contents
     with open(self.seed_fn, 'wb') as seed_f:
       seed_f.write(self.contents[:len(self.contents) // 2])
 
-    target = casync.parse_caibx(self.manifest_fn)
     sources = [('seed', casync.FileChunkReader(self.seed_fn), casync.build_chunk_dict(target))]
     sources += [('remote', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
     stats = casync.extract(target, sources, self.target_fn)
@@ -88,12 +90,11 @@ class TestCasync(unittest.TestCase):
   def test_lo_already_done(self):
     """Test that an already flashed target doesn't download any chunks"""
     target = casync.parse_caibx(self.manifest_fn)
-    sources = []
 
     with open(self.target_lo, 'wb') as f:
       f.write(self.contents)
 
-    sources += [('target', casync.FileChunkReader(self.target_lo), casync.build_chunk_dict(target))]
+    sources = [('target', casync.FileChunkReader(self.target_lo), casync.build_chunk_dict(target))]
     sources += [('remote', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
 
     stats = casync.extract(target, sources, self.target_lo)
@@ -107,9 +108,8 @@ class TestCasync(unittest.TestCase):
   def test_lo_chunk_reuse(self):
     """Test that chunks that are reused are only downloaded once"""
     target = casync.parse_caibx(self.manifest_fn)
-    sources = []
 
-    sources += [('target', casync.FileChunkReader(self.target_lo), casync.build_chunk_dict(target))]
+    sources = [('target', casync.FileChunkReader(self.target_lo), casync.build_chunk_dict(target))]
     sources += [('remote', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
 
     stats = casync.extract(target, sources, self.target_lo)

--- a/system/hardware/tici/tests/test_casync.py
+++ b/system/hardware/tici/tests/test_casync.py
@@ -6,6 +6,9 @@ import subprocess
 
 import system.hardware.tici.casync as casync
 
+# dd if=/dev/zero of=/tmp/img.raw bs=1M count=2
+# sudo losetup -f /tmp/img.raw
+# losetup -a | grep img.raw
 LOOPBACK = os.environ.get('LOOPBACK', None)
 
 

--- a/system/hardware/tici/tests/test_casync.py
+++ b/system/hardware/tici/tests/test_casync.py
@@ -6,12 +6,13 @@ import subprocess
 
 import system.hardware.tici.casync as casync
 
+LOOPBACK = os.environ.get('LOOPBACK', None)
+
 
 class TestCasync(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     cls.tmpdir = tempfile.TemporaryDirectory()
-    print(cls.tmpdir.name)
 
     # Build example contents
     contents = []
@@ -30,15 +31,47 @@ class TestCasync(unittest.TestCase):
     cls.store_fn = os.path.join(cls.tmpdir.name, 'store')
     subprocess.check_output(["casync", "make", "--compression=xz", "--store", cls.store_fn, cls.manifest_fn, cls.orig_fn])
 
+  def setUp(self):
+    if LOOPBACK is not None:
+      self.target_lo = LOOPBACK
+      with open(self.target_lo, 'wb') as f:
+        f.write(b"0" * len(self.contents))
+
+    self.target_fn = os.path.join(self.tmpdir.name, next(tempfile._get_candidate_names()))
+
+  def tearDown(self):
+    try:
+      os.unlink(self.target_fn)
+    except FileNotFoundError:
+      pass
+
   def test_simple_extract(self):
     target = casync.parse_caibx(self.manifest_fn)
-    sources = [('store', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
+    sources = [('remote', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
+    stats = casync.extract(target, sources, self.target_fn)
 
-    with tempfile.NamedTemporaryFile() as target_fn:
-      stats = casync.extract(target, sources, target_fn.name)
-      self.assertEqual(target_fn.read(), self.contents)
+    with open(self.target_fn, 'rb') as target_f:
+      self.assertEqual(target_f.read(), self.contents)
 
-    self.assertEqual(stats['store'], len(self.contents))
+    self.assertEqual(stats['remote'], len(self.contents))
+
+  @unittest.skipUnless(LOOPBACK, "requires loopback device")
+  def test_lo_already_done(self):
+    target = casync.parse_caibx(self.manifest_fn)
+    sources = []
+
+    with open(self.target_lo, 'wb') as f:
+      f.write(self.contents)
+
+    sources += [('target', casync.FileChunkReader(self.target_lo), casync.build_chunk_dict(target))]
+    sources += [('remote', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
+
+    stats = casync.extract(target, sources, self.target_lo)
+
+    with open(self.target_lo, 'rb') as f:
+      self.assertEqual(f.read(len(self.contents)), self.contents)
+
+    self.assertEqual(stats['target'], len(self.contents))
 
 
 if __name__ == "__main__":

--- a/system/hardware/tici/tests/test_casync.py
+++ b/system/hardware/tici/tests/test_casync.py
@@ -13,12 +13,14 @@ class TestCasync(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     cls.tmpdir = tempfile.TemporaryDirectory()
+    print(cls.tmpdir.name)
 
     # Build example contents
-    contents = []
-    for _ in range(128):
-      contents += [i for i in range(256)]
-    contents += [0] * 1024
+    chunk_a = [i % 256 for i in range(1024)] * 512
+    chunk_b = [(256 - i) % 256 for i in range(1024)] * 512
+    zeroes = [0] * (1024 * 128)
+    contents = chunk_a + chunk_b + zeroes + chunk_a
+
     cls.contents = bytes(contents)
 
     # Write to file
@@ -30,6 +32,12 @@ class TestCasync(unittest.TestCase):
     cls.manifest_fn = os.path.join(cls.tmpdir.name, 'orig.caibx')
     cls.store_fn = os.path.join(cls.tmpdir.name, 'store')
     subprocess.check_output(["casync", "make", "--compression=xz", "--store", cls.store_fn, cls.manifest_fn, cls.orig_fn])
+
+    target = casync.parse_caibx(cls.manifest_fn)
+    hashes = [c.sha.hex() for c in target]
+
+    # Ensure we have chunk reuse
+    assert len(hashes) > len(set(hashes))
 
   def setUp(self):
     if LOOPBACK is not None:
@@ -57,6 +65,7 @@ class TestCasync(unittest.TestCase):
 
   @unittest.skipUnless(LOOPBACK, "requires loopback device")
   def test_lo_already_done(self):
+    """Test that an already flashed target doesn't download any chunks"""
     target = casync.parse_caibx(self.manifest_fn)
     sources = []
 
@@ -72,6 +81,22 @@ class TestCasync(unittest.TestCase):
       self.assertEqual(f.read(len(self.contents)), self.contents)
 
     self.assertEqual(stats['target'], len(self.contents))
+
+  @unittest.skipUnless(LOOPBACK, "requires loopback device")
+  def test_lo_chunk_reuse(self):
+    """Test that chunks that are reused are only downloaded once"""
+    target = casync.parse_caibx(self.manifest_fn)
+    sources = []
+
+    sources += [('target', casync.FileChunkReader(self.target_lo), casync.build_chunk_dict(target))]
+    sources += [('remote', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
+
+    stats = casync.extract(target, sources, self.target_lo)
+
+    with open(self.target_lo, 'rb') as f:
+      self.assertEqual(f.read(len(self.contents)), self.contents)
+
+    self.assertLess(stats['remote'], len(self.contents))
 
 
 if __name__ == "__main__":

--- a/system/hardware/tici/tests/test_casync.py
+++ b/system/hardware/tici/tests/test_casync.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import os
+import unittest
+import tempfile
+import subprocess
+
+import system.hardware.tici.casync as casync
+
+
+class TestCasync(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.tmpdir = tempfile.TemporaryDirectory()
+    print(cls.tmpdir.name)
+
+    # Build example contents
+    contents = []
+    for _ in range(128):
+      contents += [i for i in range(256)]
+    contents += [0] * 1024
+    cls.contents = bytes(contents)
+
+    # Write to file
+    cls.orig_fn = os.path.join(cls.tmpdir.name, 'orig.bin')
+    with open(cls.orig_fn, 'wb') as f:
+      f.write(cls.contents)
+
+    # Create casync files
+    cls.manifest_fn = os.path.join(cls.tmpdir.name, 'orig.caibx')
+    cls.store_fn = os.path.join(cls.tmpdir.name, 'store')
+    subprocess.check_output(["casync", "make", "--compression=xz", "--store", cls.store_fn, cls.manifest_fn, cls.orig_fn])
+
+  def test_simple_extract(self):
+    target = casync.parse_caibx(self.manifest_fn)
+    sources = [('store', casync.RemoteChunkReader(self.store_fn), casync.build_chunk_dict(target))]
+
+    with tempfile.NamedTemporaryFile() as target_fn:
+      stats = casync.extract(target, sources, target_fn.name)
+      self.assertEqual(target_fn.read(), self.contents)
+
+    self.assertEqual(stats['store'], len(self.contents))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -14,6 +14,7 @@ function install_ubuntu_common_requirements() {
     autoconf \
     build-essential \
     ca-certificates \
+    casync \
     clang \
     cmake \
     make \


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
