### PR TITLE
sim: role_name attribute used by ScenarioRunner for CARLA

### DIFF
--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -304,6 +304,7 @@ class CarlaBridge:
     world_map = world.get_map()
 
     vehicle_bp = blueprint_library.filter('vehicle.tesla.*')[1]
+    vehicle_bp.set_attribute('role_name', 'hero')
     spawn_points = world_map.get_spawn_points()
     assert len(spawn_points) > self._args.num_selected_spawn_point, f'''No spawn point {self._args.num_selected_spawn_point}, try a value between 0 and
       {len(spawn_points)} for this town.'''


### PR DESCRIPTION
* Added role_name attribute to sim that is used by ScenarioRunner for the CARLA simulator.