### PR TITLE
VW MQB: Early EPS faults are temporary

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -42,10 +42,10 @@ class CarState(CarStateBase):
     ret.yawRate = pt_cp.vl["ESP_02"]["ESP_Gierrate"] * (1, -1)[int(pt_cp.vl["ESP_02"]["ESP_VZ_Gierrate"])] * CV.DEG_TO_RAD
 
     # Verify EPS readiness to accept steering commands
-    # To handle cars without factory Lane Assist, treat FAULT like INITIALIZING for three seconds after startup
+    # For cars without Lane Assist, treat FAULT like INITIALIZING for worst likely controls init and EPS recovery time
     hca_status = self.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
-    ret.steerFaultPermanent = hca_status == "DISABLED" or (hca_status == "FAULT" and self.frame >= 300)
-    ret.steerFaultTemporary = hca_status in ("INITIALIZING", "REJECTED") or (hca_status == "FAULT" and self.frame < 300)
+    ret.steerFaultPermanent = hca_status == "DISABLED" or (hca_status == "FAULT" and self.frame >= 600)
+    ret.steerFaultTemporary = hca_status in ("INITIALIZING", "REJECTED") or (hca_status == "FAULT" and self.frame < 600)
 
     # Update gas, brakes, and gearshift.
     ret.gas = pt_cp.vl["Motor_20"]["MO_Fahrpedalrohwert_01"] / 100.0

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -42,6 +42,7 @@ class CarState(CarStateBase):
     ret.yawRate = pt_cp.vl["ESP_02"]["ESP_Gierrate"] * (1, -1)[int(pt_cp.vl["ESP_02"]["ESP_VZ_Gierrate"])] * CV.DEG_TO_RAD
 
     # Verify EPS readiness to accept steering commands
+    # To handle cars without factory Lane Assist, treat FAULT like INITIALIZING for three seconds after startup
     hca_status = self.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
     ret.steerFaultPermanent = hca_status == "DISABLED" or (hca_status == "FAULT" and self.frame >= 300)
     ret.steerFaultTemporary = hca_status in ("INITIALIZING", "REJECTED") or (hca_status == "FAULT" and self.frame < 300)


### PR DESCRIPTION
Improve startup behavior for cars without factory Lane Assist.

When openpilot can start up relatively late after the rest of the car, on a car doesn't have factory Lane Assist, nothing is there to send the expected HCA_01 message, and we initially see the EPS in a FAULT state. It recovers quickly when openpilot starts sending, but the openpilot UI briefly shows an unnecessary and disconcerting fault message to the driver.

For the first three seconds after controls start, handle FAULT the same as INITIALIZING, which we legitimately see for a moment if openpilot starts up fast on cars with Lane Assist. This keeps us from showing the driver superfluous UI alerts in most cases, while still letting us alert the driver that we can't steer yet in cases like late startup/reboot with stock ACC already engaged.