### PR TITLE
Subaru: Add missing Forester 2021 engine fw

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -240,6 +240,7 @@ FW_VERSIONS = {
       b'\xcb\"`@\a',
       b'\xcb\"`p\a',
       b'\xf1\x00\xa2\x10\n',
+      b'\xcf"`p\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\032\xf6B0\000',


### PR DESCRIPTION
**Description** Add missing engine fw version for Forester 2021 from following route

**Route**
Route: 7db92cafc6d7cd6b|2022-07-31--20-13-23
