### PR TITLE
Toyota: fix intermittent fault sound when disengaging

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -125,7 +125,7 @@ class CarController:
       send_ui = True
       self.alert_active = not self.alert_active
     elif self.frame - self.pcm_cancel_frame < 10:
-      # forcing the pcm to disengage causes a bad fault sound so mask with silent alert
+      # forcing the pcm to disengage causes a bad fault sound so mask with a silent alert
       send_ui = True
 
     # send additional 5 messages after disengage with silent alert, then 5 with no alert to quickly hide alert

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -16,7 +16,7 @@ class CarController:
     self.CP = CP
     self.torque_rate_limits = CarControllerParams(self.CP)
     self.frame = 0
-    self.pcm_cancel_frame = -100
+    self.pcm_cancel_frame = float('-inf')
     self.last_steer = 0
     self.alert_active = False
     self.last_standstill = False

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -66,12 +66,12 @@ def create_fcw_command(packer, fcw):
   return packer.make_can_msg("ACC_HUD", 0, values)
 
 
-def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_depart, right_lane_depart, enabled):
+def create_ui_command(packer, lda_hold_wheel, left_line, right_line, left_lane_depart, right_lane_depart, enabled):
   values = {
-    "LDA_ALERT": steer or chime,
+    "LDA_ALERT": 1 if lda_hold_wheel else 0,  # 1 is a large text "HOLD WHEEL" alert, 2 is longer text
     "RIGHT_LINE": 3 if right_lane_depart else 1 if right_line else 2,
     "LEFT_LINE": 3 if left_lane_depart else 1 if left_line else 2,
-    "BARRIERS" : 1 if enabled else 0,
+    "BARRIERS": 1 if enabled else 0,
 
     # static signals
     "SET_ME_X02": 2,

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -68,7 +68,7 @@ def create_fcw_command(packer, fcw):
 
 def create_ui_command(packer, lda_hold_wheel, left_line, right_line, left_lane_depart, right_lane_depart, enabled):
   values = {
-    "LDA_ALERT": 1 if lda_hold_wheel else 0,  # 1 is a large text "HOLD WHEEL" alert, 2 is longer text
+    "LDA_ALERT": 1 if lda_hold_wheel else 0,
     "RIGHT_LINE": 3 if right_lane_depart else 1 if right_line else 2,
     "LEFT_LINE": 3 if left_lane_depart else 1 if left_line else 2,
     "BARRIERS": 1 if enabled else 0,

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -68,8 +68,7 @@ def create_fcw_command(packer, fcw):
 
 def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_depart, right_lane_depart, enabled):
   values = {
-    "TWO_BEEPS": chime,
-    "LDA_ALERT": steer,
+    "LDA_ALERT": steer or chime,
     "RIGHT_LINE": 3 if right_lane_depart else 1 if right_line else 2,
     "LEFT_LINE": 3 if left_lane_depart else 1 if left_line else 2,
     "BARRIERS" : 1 if enabled else 0,
@@ -77,6 +76,7 @@ def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_dep
     # static signals
     "SET_ME_X02": 2,
     "SET_ME_X01": 1,
+    "TWO_BEEPS": 0,
     "LKAS_STATUS": 1,
     "REPEATED_BEEPS": 0,
     "LANE_SWAY_FLD": 7,


### PR DESCRIPTION
This was caused by us happening to disengage when `self.frame % 100` is slightly less than 99, so we'd clear out the `TWO_BEEPS` alert too quickly 

Also hides the visual alert quicker when https://github.com/commaai/openpilot/pull/25361 is merged