### PR TITLE
GM: resolve resume-related ACC faults

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -24,12 +24,12 @@ def create_button_event(cur_but: int, prev_but: int, buttons_dict: Dict[int, cap
   return be
 
 
-def create_button_enable_events(buttonEvents: capnp.lib.capnp._DynamicListBuilder, pcm_cruise: bool = False, resume_enabled: bool = True) -> List[int]:
+def create_button_enable_events(buttonEvents: capnp.lib.capnp._DynamicListBuilder, pcm_cruise: bool = False) -> List[int]:
   events = []
   for b in buttonEvents:
     # do enable on both accel and decel buttons
     if not pcm_cruise:
-      if (b.type == ButtonType.decelCruise or (b.type == ButtonType.accelCruise and resume_enabled)) and not b.pressed:
+      if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
         events.append(EventName.buttonEnable)
     # do disable on button down
     if b.type == ButtonType.cancel and b.pressed:

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -24,12 +24,12 @@ def create_button_event(cur_but: int, prev_but: int, buttons_dict: Dict[int, cap
   return be
 
 
-def create_button_enable_events(buttonEvents: capnp.lib.capnp._DynamicListBuilder, pcm_cruise: bool = False) -> List[int]:
+def create_button_enable_events(buttonEvents: capnp.lib.capnp._DynamicListBuilder, pcm_cruise: bool = False, resume_enabled: bool = True) -> List[int]:
   events = []
   for b in buttonEvents:
     # do enable on both accel and decel buttons
     if not pcm_cruise:
-      if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
+      if (b.type == ButtonType.decelCruise or (b.type == ButtonType.accelCruise and resume_enabled)) and not b.pressed:
         events.append(EventName.buttonEnable)
     # do disable on button down
     if b.type == ButtonType.cancel and b.pressed:

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -178,7 +178,7 @@ class CarInterface(CarInterfaceBase):
     if ret.vEgo < self.CP.minSteerSpeed:
       events.add(car.CarEvent.EventName.belowSteerSpeed)
 
-    # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
+    # The ECM will fault if resume triggers an enable while speed is unset
     if c.hudControl.setSpeed > 70:
       events.add(car.CarEvent.EventName.resumeBlocked)
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -161,9 +161,13 @@ class CarInterface(CarInterfaceBase):
     if self.CS.cruise_buttons != self.CS.prev_cruise_buttons and self.CS.prev_cruise_buttons != CruiseButtons.INIT:
       be = create_button_event(self.CS.cruise_buttons, self.CS.prev_cruise_buttons, BUTTONS_DICT, CruiseButtons.UNPRESS)
 
-      # Suppress resume button if we're resuming from stop so we don't adjust speed.
-      if be.type == ButtonType.accelCruise and (ret.cruiseState.enabled and ret.standstill):
-        be.type = ButtonType.unknown
+      if be.type == ButtonType.accelCruise:
+        # Suppress resume button if we're resuming from stop so we don't adjust speed.
+        if ret.cruiseState.enabled and ret.standstill:
+          be.type = ButtonType.unknown
+        # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
+        elif c.hudControl.setSpeed < 70:
+          be.type = ButtonType.unknown
 
       ret.buttonEvents = [be]
 
@@ -179,7 +183,9 @@ class CarInterface(CarInterfaceBase):
       events.add(car.CarEvent.EventName.belowSteerSpeed)
 
     # handle button presses
-    events.events.extend(create_button_enable_events(ret.buttonEvents, pcm_cruise=self.CP.pcmCruise))
+    # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
+    resume_enabled = c.hudControl.setSpeed < 70
+    events.events.extend(create_button_enable_events(ret.buttonEvents, pcm_cruise=self.CP.pcmCruise, resume_enabled=resume_enabled))
 
     ret.events = events.to_msg()
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -178,10 +178,12 @@ class CarInterface(CarInterfaceBase):
     if ret.vEgo < self.CP.minSteerSpeed:
       events.add(car.CarEvent.EventName.belowSteerSpeed)
 
-    # handle button presses
     # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
-    resume_enabled = c.hudControl.setSpeed < 70
-    events.events.extend(create_button_enable_events(ret.buttonEvents, pcm_cruise=self.CP.pcmCruise, resume_enabled=resume_enabled))
+    if c.hudControl.setSpeed >= 70:
+      events.add(car.CarEvent.EventName.resumeBlocked)
+
+    # handle button presses
+    events.events.extend(create_button_enable_events(ret.buttonEvents, pcm_cruise=self.CP.pcmCruise, resume_enabled=True))
 
     ret.events = events.to_msg()
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -183,7 +183,7 @@ class CarInterface(CarInterfaceBase):
       events.add(car.CarEvent.EventName.resumeBlocked)
 
     # handle button presses
-    events.events.extend(create_button_enable_events(ret.buttonEvents, pcm_cruise=self.CP.pcmCruise, resume_enabled=True))
+    events.events.extend(create_button_enable_events(ret.buttonEvents, pcm_cruise=self.CP.pcmCruise))
 
     ret.events = events.to_msg()
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -179,7 +179,7 @@ class CarInterface(CarInterfaceBase):
       events.add(car.CarEvent.EventName.belowSteerSpeed)
 
     # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
-    if c.hudControl.setSpeed >= 70:
+    if c.hudControl.setSpeed > 70:
       events.add(car.CarEvent.EventName.resumeBlocked)
 
     # handle button presses

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -179,7 +179,7 @@ class CarInterface(CarInterfaceBase):
       events.add(car.CarEvent.EventName.belowSteerSpeed)
 
     # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
-    if c.hudControl.setSpeed == 0:
+    if c.hudControl.setSpeed >= 70:
       events.add(car.CarEvent.EventName.resumeBlocked)
 
     # handle button presses

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -179,7 +179,7 @@ class CarInterface(CarInterfaceBase):
       events.add(car.CarEvent.EventName.belowSteerSpeed)
 
     # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
-    if c.hudControl.setSpeed >= 70:
+    if c.hudControl.setSpeed == 0:
       events.add(car.CarEvent.EventName.resumeBlocked)
 
     # handle button presses

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -179,7 +179,7 @@ class CarInterface(CarInterfaceBase):
       events.add(car.CarEvent.EventName.belowSteerSpeed)
 
     # The ECM will fault if resume triggers an enable while speed is unset
-    if c.hudControl.setSpeed > 70:
+    if c.hudControl.setSpeed > 70 and ButtonType.accelCruise in (be.type for be in ret.buttonEvents):
       events.add(car.CarEvent.EventName.resumeBlocked)
 
     # handle button presses

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -161,13 +161,9 @@ class CarInterface(CarInterfaceBase):
     if self.CS.cruise_buttons != self.CS.prev_cruise_buttons and self.CS.prev_cruise_buttons != CruiseButtons.INIT:
       be = create_button_event(self.CS.cruise_buttons, self.CS.prev_cruise_buttons, BUTTONS_DICT, CruiseButtons.UNPRESS)
 
-      if be.type == ButtonType.accelCruise:
-        # Suppress resume button if we're resuming from stop so we don't adjust speed.
-        if ret.cruiseState.enabled and ret.standstill:
-          be.type = ButtonType.unknown
-        # The ECM will fault if resume triggers an enable while speed is unset (unset is greater than 70 m/s)
-        elif c.hudControl.setSpeed < 70:
-          be.type = ButtonType.unknown
+      # Suppress resume button if we're resuming from stop so we don't adjust speed.
+      if be.type == ButtonType.accelCruise and (ret.cruiseState.enabled and ret.standstill):
+        be.type = ButtonType.unknown
 
       ret.buttonEvents = [be]
 

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -372,6 +372,10 @@ class CarInterface(CarInterfaceBase):
     # handle button presses
     events.events.extend(create_button_enable_events(ret.buttonEvents, self.CP.pcmCruise))
 
+    # The ECM will fault if resume triggers an enable while speed is unset
+    if c.hudControl.setSpeed > 70:
+      events.add(car.CarEvent.EventName.resumeBlocked)
+
     ret.events = events.to_msg()
 
     return ret

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -373,7 +373,7 @@ class CarInterface(CarInterfaceBase):
     events.events.extend(create_button_enable_events(ret.buttonEvents, self.CP.pcmCruise))
 
     # The ECM will fault if resume triggers an enable while speed is unset
-    if c.hudControl.setSpeed > 70:
+    if c.hudControl.setSpeed > 70 and ButtonType.accelCruise in (be.type for be in ret.buttonEvents):
       events.add(car.CarEvent.EventName.resumeBlocked)
 
     ret.events = events.to_msg()

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -372,10 +372,6 @@ class CarInterface(CarInterfaceBase):
     # handle button presses
     events.events.extend(create_button_enable_events(ret.buttonEvents, self.CP.pcmCruise))
 
-    # The ECM will fault if resume triggers an enable while speed is unset
-    if c.hudControl.setSpeed > 70 and ButtonType.accelCruise in (be.type for be in ret.buttonEvents):
-      events.add(car.CarEvent.EventName.resumeBlocked)
-
     ret.events = events.to_msg()
 
     return ret

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -16,7 +16,7 @@ from system.version import get_short_branch
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from selfdrive.car.car_helpers import get_car, get_startup_event, get_one_can
 from selfdrive.controls.lib.lane_planner import CAMERA_OFFSET
-from selfdrive.controls.lib.drive_helpers import update_v_cruise, initialize_v_cruise
+from selfdrive.controls.lib.drive_helpers import V_CRUISE_INITIAL, update_v_cruise, initialize_v_cruise
 from selfdrive.controls.lib.drive_helpers import get_lag_adjusted_curvature
 from selfdrive.controls.lib.latcontrol import LatControl
 from selfdrive.controls.lib.longcontrol import LongControl
@@ -162,8 +162,8 @@ class Controls:
     self.active = False
     self.can_rcv_error = False
     self.soft_disable_timer = 0
-    self.v_cruise_kph = 0
-    self.v_cruise_cluster_kph = 0
+    self.v_cruise_kph = V_CRUISE_INITIAL
+    self.v_cruise_cluster_kph = V_CRUISE_INITIAL
     self.v_cruise_kph_last = 0
     self.mismatch_counter = 0
     self.cruise_mismatch_counter = 0
@@ -452,19 +452,22 @@ class Controls:
 
     self.v_cruise_kph_last = self.v_cruise_kph
 
-    if CS.cruiseState.available:
-      # if stock cruise is completely disabled, then we can use our own set speed logic
-      if not self.CP.pcmCruise:
+    # if stock cruise is completely disabled, then we can use our own set speed logic
+    if not self.CP.pcmCruise:
+      if CS.cruiseState.available:
         self.v_cruise_kph = update_v_cruise(self.v_cruise_kph, CS.vEgo, CS.gasPressed, CS.buttonEvents,
                                             self.button_timers, self.enabled, self.is_metric)
         self.v_cruise_cluster_kph = self.v_cruise_kph
       else:
+        self.v_cruise_kph = V_CRUISE_INITIAL
+        self.v_cruise_cluster_kph = V_CRUISE_INITIAL
+    else:
+      if CS.cruiseState.available:
         self.v_cruise_kph = CS.cruiseState.speed * CV.MS_TO_KPH
         self.v_cruise_cluster_kph = CS.cruiseState.speedCluster * CV.MS_TO_KPH
-
-    else:
-      self.v_cruise_kph = 0
-      self.v_cruise_cluster_kph = 0
+      else:
+        self.v_cruise_kph = 0
+        self.v_cruise_cluster_kph = 0
 
     # decrement the soft disable timer at every step, as it's reset on
     # entrance in SOFT_DISABLING state

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -16,7 +16,7 @@ from system.version import get_short_branch
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from selfdrive.car.car_helpers import get_car, get_startup_event, get_one_can
 from selfdrive.controls.lib.lane_planner import CAMERA_OFFSET
-from selfdrive.controls.lib.drive_helpers import V_CRUISE_INITIAL, update_v_cruise, initialize_v_cruise
+from selfdrive.controls.lib.drive_helpers import update_v_cruise, initialize_v_cruise
 from selfdrive.controls.lib.drive_helpers import get_lag_adjusted_curvature
 from selfdrive.controls.lib.latcontrol import LatControl
 from selfdrive.controls.lib.longcontrol import LongControl
@@ -162,8 +162,8 @@ class Controls:
     self.active = False
     self.can_rcv_error = False
     self.soft_disable_timer = 0
-    self.v_cruise_kph = V_CRUISE_INITIAL
-    self.v_cruise_cluster_kph = V_CRUISE_INITIAL
+    self.v_cruise_kph = 0
+    self.v_cruise_cluster_kph = 0
     self.v_cruise_kph_last = 0
     self.mismatch_counter = 0
     self.cruise_mismatch_counter = 0
@@ -452,22 +452,19 @@ class Controls:
 
     self.v_cruise_kph_last = self.v_cruise_kph
 
-    # if stock cruise is completely disabled, then we can use our own set speed logic
-    if not self.CP.pcmCruise:
-      if CS.cruiseState.available:
+    if CS.cruiseState.available:
+      # if stock cruise is completely disabled, then we can use our own set speed logic
+      if not self.CP.pcmCruise:
         self.v_cruise_kph = update_v_cruise(self.v_cruise_kph, CS.vEgo, CS.gasPressed, CS.buttonEvents,
                                             self.button_timers, self.enabled, self.is_metric)
         self.v_cruise_cluster_kph = self.v_cruise_kph
       else:
-        self.v_cruise_kph = V_CRUISE_INITIAL
-        self.v_cruise_cluster_kph = V_CRUISE_INITIAL
-    else:
-      if CS.cruiseState.available:
         self.v_cruise_kph = CS.cruiseState.speed * CV.MS_TO_KPH
         self.v_cruise_cluster_kph = CS.cruiseState.speedCluster * CV.MS_TO_KPH
-      else:
-        self.v_cruise_kph = 0
-        self.v_cruise_cluster_kph = 0
+
+    else:
+      self.v_cruise_kph = 0
+      self.v_cruise_cluster_kph = 0
 
     # decrement the soft disable timer at every step, as it's reset on
     # entrance in SOFT_DISABLING state

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -16,7 +16,7 @@ from system.version import get_short_branch
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from selfdrive.car.car_helpers import get_car, get_startup_event, get_one_can
 from selfdrive.controls.lib.lane_planner import CAMERA_OFFSET
-from selfdrive.controls.lib.drive_helpers import update_v_cruise, initialize_v_cruise
+from selfdrive.controls.lib.drive_helpers import V_CRUISE_INITIAL, update_v_cruise, initialize_v_cruise
 from selfdrive.controls.lib.drive_helpers import get_lag_adjusted_curvature
 from selfdrive.controls.lib.latcontrol import LatControl
 from selfdrive.controls.lib.longcontrol import LongControl
@@ -162,8 +162,8 @@ class Controls:
     self.active = False
     self.can_rcv_error = False
     self.soft_disable_timer = 0
-    self.v_cruise_kph = 255
-    self.v_cruise_cluster_kph = 255
+    self.v_cruise_kph = V_CRUISE_INITIAL
+    self.v_cruise_cluster_kph = V_CRUISE_INITIAL
     self.v_cruise_kph_last = 0
     self.mismatch_counter = 0
     self.cruise_mismatch_counter = 0
@@ -454,9 +454,13 @@ class Controls:
 
     # if stock cruise is completely disabled, then we can use our own set speed logic
     if not self.CP.pcmCruise:
-      self.v_cruise_kph = update_v_cruise(self.v_cruise_kph, CS.vEgo, CS.gasPressed, CS.buttonEvents,
-                                          self.button_timers, self.enabled, self.is_metric)
-      self.v_cruise_cluster_kph = self.v_cruise_kph
+      if CS.cruiseState.available:
+        self.v_cruise_kph = update_v_cruise(self.v_cruise_kph, CS.vEgo, CS.gasPressed, CS.buttonEvents,
+                                            self.button_timers, self.enabled, self.is_metric)
+        self.v_cruise_cluster_kph = self.v_cruise_kph
+      else:
+        self.v_cruise_kph = V_CRUISE_INITIAL
+        self.v_cruise_cluster_kph = V_CRUISE_INITIAL
     else:
       if CS.cruiseState.available:
         self.v_cruise_kph = CS.cruiseState.speed * CV.MS_TO_KPH

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -458,7 +458,9 @@ class Controls:
         self.v_cruise_kph = update_v_cruise(self.v_cruise_kph, CS.vEgo, CS.gasPressed, CS.buttonEvents,
                                             self.button_timers, self.enabled, self.is_metric)
         self.v_cruise_cluster_kph = self.v_cruise_kph
-      else:
+      elif self.CP.carName == "gm":
+        # GM is the only car that requires a SET after losing main
+        # TODO: make the car interfaces handle button enable cruise speed
         self.v_cruise_kph = V_CRUISE_INITIAL
         self.v_cruise_cluster_kph = V_CRUISE_INITIAL
     else:

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -11,6 +11,7 @@ from selfdrive.modeld.constants import T_IDXS
 V_CRUISE_MAX = 145  # kph
 V_CRUISE_MIN = 8  # kph
 V_CRUISE_ENABLE_MIN = 40  # kph
+V_CRUISE_INITIAL = 255  # kph
 
 LAT_MPC_N = 16
 LON_MPC_N = 32

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -11,6 +11,7 @@ from selfdrive.modeld.constants import T_IDXS
 V_CRUISE_MAX = 145  # kph
 V_CRUISE_MIN = 8  # kph
 V_CRUISE_ENABLE_MIN = 40  # kph
+V_CRUISE_INITIAL = 255  # kph
 
 LAT_MPC_N = 16
 LON_MPC_N = 32
@@ -95,8 +96,8 @@ def update_v_cruise(v_cruise_kph, v_ego, gas_pressed, buttonEvents, button_timer
 
 def initialize_v_cruise(v_ego, buttonEvents, v_cruise_last):
   for b in buttonEvents:
-    # 0kph means we don't have a set speed
-    if b.type in (ButtonType.accelCruise, ButtonType.resumeCruise) and v_cruise_last != 0:
+    # 250kph or above probably means we never had a set speed
+    if b.type in (ButtonType.accelCruise, ButtonType.resumeCruise) and v_cruise_last < 250:
       return v_cruise_last
 
   return int(round(clip(v_ego * CV.MS_TO_KPH, V_CRUISE_ENABLE_MIN, V_CRUISE_MAX)))

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -11,7 +11,6 @@ from selfdrive.modeld.constants import T_IDXS
 V_CRUISE_MAX = 145  # kph
 V_CRUISE_MIN = 8  # kph
 V_CRUISE_ENABLE_MIN = 40  # kph
-V_CRUISE_INITIAL = 255  # kph
 
 LAT_MPC_N = 16
 LON_MPC_N = 32
@@ -96,8 +95,8 @@ def update_v_cruise(v_cruise_kph, v_ego, gas_pressed, buttonEvents, button_timer
 
 def initialize_v_cruise(v_ego, buttonEvents, v_cruise_last):
   for b in buttonEvents:
-    # 250kph or above probably means we never had a set speed
-    if b.type in (ButtonType.accelCruise, ButtonType.resumeCruise) and v_cruise_last < 250:
+    # 0kph means we don't have a set speed
+    if b.type in (ButtonType.accelCruise, ButtonType.resumeCruise) and v_cruise_last != 0:
       return v_cruise_last
 
   return int(round(clip(v_ego * CV.MS_TO_KPH, V_CRUISE_ENABLE_MIN, V_CRUISE_MAX)))

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -635,6 +635,10 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
     ET.NO_ENTRY: wrong_car_mode_alert,
   },
 
+  EventName.resumeBlocked: {
+    ET.NO_ENTRY: NoEntryAlert("Press Set to Engage"),
+  },
+
   EventName.wrongCruiseMode: {
     ET.USER_DISABLE: EngagementAlert(AudibleAlert.disengage),
     ET.NO_ENTRY: NoEntryAlert("Adaptive Cruise Disabled"),


### PR DESCRIPTION
Fixes: ACC faults with GM when you enable via resume button without first enabling with set button.

Behavior changes:
- On all non pcmCruise cars, pressing the main button to disable cruise will now reset the set speed in the openpilot UI just like pcmCruise cars (make sure). Think this is a good change to unify this behavior
- On GM, a `buttonEnable` event will not be created when you press resume to enable until you engage at least once with the set button