### PR TITLE
Clean up timers on receipt of a non-0x78 UDS error

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -135,7 +135,7 @@ class IsoTpParallelQuery:
             if self.debug:
               cloudlog.warning(f"iso-tp query response pending: {tx_addr}")
           else:
-            response_timeouts.pop(tx_addr, None)
+            response_timeouts[tx_addr] = 0
             request_done[tx_addr] = True
             cloudlog.warning(f"iso-tp query bad response: {tx_addr} - 0x{dat.hex()}")
 

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -135,6 +135,7 @@ class IsoTpParallelQuery:
             if self.debug:
               cloudlog.warning(f"iso-tp query response pending: {tx_addr}")
           else:
+            response_timeouts.pop(tx_addr, None)
             request_done[tx_addr] = True
             cloudlog.warning(f"iso-tp query bad response: {tx_addr} - 0x{dat.hex()}")
 


### PR DESCRIPTION
**Description**

The end user complaint (simplified) was that openpilot master stays in "waiting for controls to start" for almost a minute at startup. The same car works correctly on openpilot 0.8.13.1.

With #24724, the UDS fingerprinting code now handles "request received - response pending" errors by extending timeouts to wait for a successful response. However, queries can still fail at this stage.

In the case of ~~a certain snowflake VW Polo engine ECU~~ some 1.0 and 1.4L engine ECUs on Polo, Golf, Jetta, and Passat GTE, we can get 0x7F2278 response pending quickly followed by 0x7F2231 request out of range. When this happened, the query was marked done but the timer wasn't cleaned up, which prevented the query loop from proceeding until the 10 second timer elapsed. This happened a few times to build up the larger total delay.

This fix makes sure failed queries are always completely terminated.

**Verification**

The end user reports this patch fixed his problem.

**Route**

Before: `0bbe367c98fa1538|2022-08-10--14-28-52`

After: `0bbe367c98fa1538|2022-08-12--00-11-15`
 `0bbe367c98fa1538|2022-08-12--00-06-36`
 `0bbe367c98fa1538|2022-08-11--23-56-30`