### PR TITLE
ubuntu_setup.sh detect base ubuntu version for variant distros

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -108,7 +108,11 @@ if [ -f "/etc/os-release" ]; then
       if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         exit 1
       fi
-      install_ubuntu_focal_requirements
+      if [ "$UBUNTU_CODENAME" = "jammy" ]; then
+        install_ubuntu_jammy_requirements
+      else
+        install_ubuntu_focal_requirements
+      fi
   esac
 else
   echo "No /etc/os-release in the system"


### PR DESCRIPTION
**Description**
ubuntu_setup.sh allows the user to attempt execution on non-supported distributions / versions, however it always ran the focal (20.04) version in that case. For distributions that are based on Ubuntu (such as Linux Mint), the UBUNTU_CODENAME value in os_release contains the Ubuntu codename on which the distribution is based.

This PR updates the script to check the UBUNTU_CODENAME after a user agrees to try install in a non-supported distro, and if it is based on Ubuntu's Jammy Jellyfish (22.04), it runs the jammy installer; otherwise it defaults to the focal installer.

This increases the chances of a successful install on the new derivatives based on jammy, such as Linux Mint 21.

**Verification**
The UBUNTU_CODENAME value is present in Ubuntu itself as well as derivative distributions since at least 20.04, and it contains the version of Ubuntu on which the distro is derived. I've tested the script on Mint 21 (it works great!). The script behaves as it did prior to this change if UBUNTU_VERSION isn't "jammy"