### PR TITLE
GM:  scale up set speed because dbc will factor it down

### DIFF
--- a/selfdrive/car/gm/gmcan.py
+++ b/selfdrive/car/gm/gmcan.py
@@ -63,7 +63,7 @@ def create_friction_brake_command(packer, bus, apply_brake, idx, near_stop, at_f
   return packer.make_can_msg("EBCMFrictionBrakeCmd", bus, values)
 
 def create_acc_dashboard_command(packer, bus, acc_engaged, target_speed_kph, lead_car_in_sight, fcw):
-  target_speed = min(target_speed_kph, 255)
+  target_speed = min(target_speed_kph, 255) * 16
 
   values = {
     "ACCAlwaysOne" : 1,


### PR DESCRIPTION
GM powertrain DBC was [recently changed](https://github.com/commaai/openpilot/commit/f341df006a002a47034787673893f930caa81b53) by @sshane  to include scaling that was previously being done in `carstate.py` for the ACC set speed. 

There was also a line in `gmcan.py` that _appeared_ to be doing the same thing, but it wasn't due to bit magic. Driving on master today to test an unrelated change, I noticed the dash set speed was 1/16th the actual set speed. 

This is odd, because I [tested the dbc scaling and this problem wasn't present](https://github.com/commaai/openpilot/pull/25422). Regardless, this change fixes it.

Tested with [equivalent change](https://github.com/opgm/openpilot/commit/6a3941bb13a9a22dc95b3ea2f4bf2008325daba8) on this route [c11fcb510a549332|2022-08-15--12-18-54--0](https://cabana.comma.ai/?route=c11fcb510a549332%7C2022-08-15--12-18-54&exp=1692125252&sig=vULFUCX7J%2BMBGLrLSZQcKulrKmEySICCJGVkf10hSZ8%3D&max=17&url=https%3A%2F%2Fchffrprivate.azureedge.net%2Fchffrprivate3%2Fv2%2Fc11fcb510a549332%2F7f8dbff9f37c147d626083d4725fb753_2022-08-15--12-18-54)