### PR TITLE
UI: Device Settings Spacing

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -96,7 +96,7 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
 }
 
 DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
-  setSpacing(50);
+  setSpacing(7);
   addItem(new LabelControl(tr("Dongle ID"), getDongleId().value_or(tr("N/A"))));
   addItem(new LabelControl(tr("Serial"), params.get("HardwareSerial").c_str()));
 


### PR DESCRIPTION
This change crunches the Device settings space between each row so that the Reboot and Shut Off button are always visible (only true if the disable radar option is not shown though).