### PR TITLE
process replay: print correct ref path

### DIFF
--- a/selfdrive/test/process_replay/model_replay.py
+++ b/selfdrive/test/process_replay/model_replay.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
       # TODO this tolerence is absurdly large
       tolerance = 5e-1 if PC else None
       results: Any = {TEST_ROUTE: {}}
-      log_paths: Any = {TEST_ROUTE: {'ref': BASE_URL + log_fn, 'new': log_fn}}
+      log_paths: Any = {TEST_ROUTE: {"models": {'ref': BASE_URL + log_fn, 'new': log_fn}}}
       results[TEST_ROUTE]["models"] = compare_logs(cmp_log, log_msgs, tolerance=tolerance, ignore_fields=ignore)
       diff1, diff2, failed = format_diff(results, log_paths, ref_commit)
 

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -117,7 +117,7 @@ def format_diff(results, log_paths, ref_commit):
     for proc, diff in list(result.items()):
       # long diff
       diff2 += f"*** process: {proc} ***\n"
-      diff2 += f"\tref: {log_paths[segment][proc]['ref']}\n\n"
+      diff2 += f"\tref: {log_paths[segment][proc]['ref']}\n"
       diff2 += f"\tnew: {log_paths[segment][proc]['new']}\n\n"
 
       # short diff

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -117,7 +117,6 @@ def format_diff(results, log_paths, ref_commit):
     for proc, diff in list(result.items()):
       # long diff
       diff2 += f"*** process: {proc} ***\n"
-      print(segment, proc)
       diff2 += f"\tref: {log_paths[segment][proc]['ref']}\n\n"
       diff2 += f"\tnew: {log_paths[segment][proc]['new']}\n\n"
 

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -117,19 +117,20 @@ def format_diff(results, log_paths, ref_commit):
     for proc, diff in list(result.items()):
       # long diff
       diff2 += f"*** process: {proc} ***\n"
-      diff2 += f"\tref: {log_paths[segment]['ref']}\n\n"
-      diff2 += f"\tnew: {log_paths[segment]['new']}\n\n"
+      print(segment, proc)
+      diff2 += f"\tref: {log_paths[segment][proc]['ref']}\n\n"
+      diff2 += f"\tnew: {log_paths[segment][proc]['new']}\n\n"
 
       # short diff
       diff1 += f"    {proc}\n"
       if isinstance(diff, str):
-        diff1 += f"        ref: {log_paths[segment]['ref']}\n"
-        diff1 += f"        new: {log_paths[segment]['new']}\n\n"
+        diff1 += f"        ref: {log_paths[segment][proc]['ref']}\n"
+        diff1 += f"        new: {log_paths[segment][proc]['new']}\n\n"
         diff1 += f"        {diff}\n"
         failed = True
       elif len(diff):
-        diff1 += f"        ref: {log_paths[segment]['ref']}\n"
-        diff1 += f"        new: {log_paths[segment]['new']}\n\n"
+        diff1 += f"        ref: {log_paths[segment][proc]['ref']}\n"
+        diff1 += f"        new: {log_paths[segment][proc]['new']}\n\n"
 
         cnt: Dict[str, int] = {}
         for d in diff:
@@ -196,8 +197,7 @@ if __name__ == "__main__":
     untested = (set(interface_names) - set(excluded_interfaces)) - {c.lower() for c in tested_cars}
     assert len(untested) == 0, f"Cars missing routes: {str(untested)}"
 
-
-  log_paths: DefaultDict[str, Dict[str, str]] = defaultdict(dict)
+  log_paths: DefaultDict[str, Dict[str, Dict[str, str]]] = defaultdict(lambda: defaultdict(dict))
   with concurrent.futures.ProcessPoolExecutor(max_workers=args.jobs) as pool:
     if not args.upload_only:
       download_segments = [seg for car, seg in segments if car in tested_cars]
@@ -225,8 +225,8 @@ if __name__ == "__main__":
         dat = None if args.upload_only else log_data[segment]
         pool_args.append((segment, cfg, args, cur_log_fn, ref_log_path, dat))
 
-        log_paths[segment]['ref'] = ref_log_path
-        log_paths[segment]['new'] = cur_log_fn
+        log_paths[segment][cfg.proc_name + cfg.subtest_name]['ref'] = ref_log_path
+        log_paths[segment][cfg.proc_name + cfg.subtest_name]['new'] = cur_log_fn
 
     results: Any = defaultdict(dict)
     p2 = pool.map(run_test_process, pool_args)


### PR DESCRIPTION
Fixes prints added in https://github.com/commaai/openpilot/pull/25251 always printing the last process