### PR TITLE
regen: initialize once

### DIFF
--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -201,14 +201,14 @@ def regen_segment(lr, frs=None, outdir=FAKEDATA, disable_tqdm=False):
   params = Params()
   os.environ["LOG_ROOT"] = outdir
 
-  for msg in lr:
-    if msg.which() == 'carParams':
-      setup_env(CP=msg.carParams)
-    elif msg.which() == 'liveCalibration':
-      params.put("CalibrationParams", msg.as_builder().to_bytes())
+  # Get and setup initial state
+  CP = [m for m in lr if m.which() == 'carParams'][0].carParams
+  liveCalibration = [m for m in lr if m.which() == 'liveCalibration'][0]
+
+  setup_env(CP=CP)
+  params.put("CalibrationParams", liveCalibration.as_builder().to_bytes())
 
   vs, cam_procs = replay_cameras(lr, frs, disable_tqdm=disable_tqdm)
-
   fake_daemons = {
     'sensord': [
       multiprocessing.Process(target=replay_sensor_events, args=('sensorEvents', lr)),


### PR DESCRIPTION
This was setting up environment and writing params every respective message. This also uses the first message, not last.