### PR TITLE
GM longitudinal pitch compensation

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -104,6 +104,9 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kiV = [0.]
       ret.lateralTuning.pid.kf = 1.  # get_steer_feedforward_volt()
       ret.steerActuatorDelay = 0.2
+      
+      ret.longitudinalActuatorDelayLowerBound = 0.41
+      ret.longitudinalActuatorDelayUpperBound = 0.41
 
     elif candidate == CAR.MALIBU:
       ret.mass = 1496. + STD_CARGO_KG

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -39,6 +39,7 @@ class States():
   YAW_RATE = _slice(1)  # [rad/s]
   STEER_ANGLE = _slice(1)  # [rad]
   ROAD_ROLL = _slice(1)  # [rad]
+  ROAD_PITCH = _slice(1)  # [rad]
 
 
 class CarKalman(KalmanFilter):
@@ -51,6 +52,7 @@ class CarKalman(KalmanFilter):
     0.0,
 
     10.0, 0.0,
+    0.0,
     0.0,
     0.0,
     0.0
@@ -67,6 +69,7 @@ class CarKalman(KalmanFilter):
     math.radians(0.1)**2,
     math.radians(0.1)**2,
     math.radians(1)**2,
+    math.radians(1)**2,
   ])
   P_initial = Q.copy()
 
@@ -74,6 +77,7 @@ class CarKalman(KalmanFilter):
     ObservationKind.STEER_ANGLE: np.atleast_2d(math.radians(0.05)**2),
     ObservationKind.ANGLE_OFFSET_FAST: np.atleast_2d(math.radians(10.0)**2),
     ObservationKind.ROAD_ROLL: np.atleast_2d(math.radians(1.0)**2),
+    ObservationKind.ROAD_PITCH: np.atleast_2d(math.radians(1.0)**2),
     ObservationKind.STEER_RATIO: np.atleast_2d(5.0**2),
     ObservationKind.STIFFNESS: np.atleast_2d(0.5**2),
     ObservationKind.ROAD_FRAME_X_SPEED: np.atleast_2d(0.1**2),
@@ -112,6 +116,7 @@ class CarKalman(KalmanFilter):
     angle_offset = state[States.ANGLE_OFFSET, :][0, 0]
     angle_offset_fast = state[States.ANGLE_OFFSET_FAST, :][0, 0]
     theta = state[States.ROAD_ROLL, :][0, 0]
+    phi = state[States.ROAD_PITCH, :][0, 0]
     sa = state[States.STEER_ANGLE, :][0, 0]
 
     sR = state[States.STEER_RATIO, :][0, 0]
@@ -156,6 +161,7 @@ class CarKalman(KalmanFilter):
       [sp.Matrix([sR]), ObservationKind.STEER_RATIO, None],
       [sp.Matrix([sf]), ObservationKind.STIFFNESS, None],
       [sp.Matrix([theta]), ObservationKind.ROAD_ROLL, None],
+      [sp.Matrix([phi]), ObservationKind.ROAD_PITCH, None],
     ]
 
     gen_code(generated_dir, name, f_sym, dt, state_sym, obs_eqs, dim_state, dim_state, global_vars=global_vars)

--- a/selfdrive/locationd/models/constants.py
+++ b/selfdrive/locationd/models/constants.py
@@ -40,6 +40,7 @@ class ObservationKind:
   STEER_RATIO = 29  # [-]
   ROAD_FRAME_X_SPEED = 30  # (x) [m/s]
   ROAD_ROLL = 31  # [rad]
+  ROAD_PITCH = 36  # [rad]
 
   names = [
     'Unknown',
@@ -79,6 +80,7 @@ class ObservationKind:
     'NO accel',
     'ORB features wide camera',
     'ECEF_VEL',
+    'Road Pitch',
   ]
 
   @classmethod

--- a/selfdrive/locationd/models/constants.py
+++ b/selfdrive/locationd/models/constants.py
@@ -81,6 +81,7 @@ class ObservationKind:
     'ORB features wide camera',
     'ECEF_VEL',
     'Road Pitch',
+    'Road Future Pitch',
   ]
 
   @classmethod


### PR DESCRIPTION
_Part of PR stack, but I don't know how to submit a PR to commaai/openpilot that's comparing two branches in the opgm repo, so the layers of the PR stack will include the commits from the previous._

# Description

Adds longitudinal pitch compensation to be used in cars that use gas/brake control, where the command specifies an amount of acceleration force rather than an amount of acceleration relative to the road. The implementation is contained in car controller, as a type of passive long feedforward, transparent to the controller. 

To allow this to account for longitudinal actuator delay to allow for smoothing of the pitch signal, future model pitch is used to create a smoothed, predictive pitch.

Though not shown here, another benefit of this improvement is that if more than `ACCEL_MAX` acceleration is required to maintain speed up a steep hill, stock will not be able to maintain speed. With this improvement that is no longer the case.

`actuators.accelPitchCompensated` is used to determine the gas command, which specifies an acceleration force. The brake command on gm specifies acceleration relative to the ground, so the `actuators.accel` value is the correct value for friction brakes, even when going downhill. 
To support this assertion, see that gas command does not match up with aEgo:
![image](https://user-images.githubusercontent.com/7284371/185264371-24be94b2-6519-41dc-b401-fa3d5ea3ae09.png)
While brake command does match with aEgo
![image](https://user-images.githubusercontent.com/7284371/185264438-c5abff1b-5ece-4255-aea1-2f3cd4f5d787.png)
I also verified this extensively (though not with proper documentation) when developing "one pedal mode" in my openpilot fork, which involved artificially sending a constant brake command and observing the car's braking behavior. I found that the same brake command produces far more braking force on a decline, and far less (or none) on an incline.

However, when openpilot requests negative acceleration in order to stop behind a lead _when going uphill_, it would engage the friction brakes sooner (at the same time it would now, without this improvement), despite the negative gravitational acceleration, and resulting in more braking than in necessary, since it's being assisted by gravity.
So you'd like for openpilot to postpone friction brake use when decelerating uphill, but it can become a problem when stopping, as the pitch-compensated acceleration may remain positive even though openpilot would like to stop, resulting in late stopping behind leads.
The solution is to smoothly switch to non-pitch-compensated acceleration for determining brakes at low speed.
I've been using this method on my fork for about a month and it keeps the efficiency and brake-avoidance benefits of pitch-compensation without introducing possible problems when stopping behind leads.

(Any issues caused by the gas and brake signals having different physical meanings will also be minimized by [using the correct gas/brake threshold acceleration value](https://github.com/commaai/openpilot/pull/25453))

**This should also be used on other makes that specify acceleration force with gas or brake commands**

# Verification

The result is a complete elimination of long error due to pitch changes. In the following image the plots on the left are without pitch compensation, and on the right with pitch compensation. 

![Screen Shot 2022-08-17 at 3 16 49 PM](https://user-images.githubusercontent.com/7284371/185260603-91326ad7-0227-4c03-92c9-1dcd731b0e52.png)


See that as I climb up the stepped hill (pitch changing between 0 and ~12% grade), the pitchFutureLone (right side, second plot from top, orange line) predicts the liveParams pitch by ~0.4s, which is the value set for longitudinalActuatorDelayLowerBound (and upper bound), so it's predicting by the correct amount.

While there are large deviations between target and actual acceleration (fourth plot from top, left side) without pitch compensation, the pitch-induced error is completely removed on the right (error stays within ±0.05m/s^2 vs ±0.25m/s^2).
Also the with pitch compensation speed stays within 0±0.1m/s^2 compared to ±0.4m/s^2 (top plot). 

Here's another image showing data where I descend down the same stepped hill. Again, with pitch compensation, the speed and acceleration oscillations due to changing pitch are completely removed.

![Screen Shot 2022-08-17 at 3 12 35 PM](https://user-images.githubusercontent.com/7284371/185260625-57befcbb-1b73-46ed-98c3-32ea2c6ff5b6.png)



This PR includes three other PRs to 1) [add liveParams pitch](https://github.com/commaai/openpilot/pull/25466), 2) [add liveParams future predicted pitch based on long actuator delay](https://github.com/commaai/openpilot/pull/25467), and 3) to [add calculation of pitch-compensated acceleration, saved to actuators.accelPitchCompensated](https://github.com/commaai/openpilot/pull/25468).

Route: c11fcb510a549332|2022-08-17--13-58-51--0