### PR TITLE
joystick: revert max axes value to 255

### DIFF
--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -41,7 +41,7 @@ class Joystick:
   def __init__(self):
     # TODO: find a way to get this from API, perhaps "inputs" doesn't support it
     self.min_axis_value = {'ABS_Y': 0., 'ABS_RZ': 0.}
-    self.max_axis_value = {'ABS_Y': 1023., 'ABS_RZ': 255.}
+    self.max_axis_value = {'ABS_Y': 255., 'ABS_RZ': 255.}
     self.cancel_button = 'BTN_TRIGGER'
     self.axes_values = {'ABS_Y': 0., 'ABS_RZ': 0.}  # gb, steer
     self.axes_order = ['ABS_Y', 'ABS_RZ']


### PR DESCRIPTION
It's technically possible to get the max value from evdev (run `evtest`), but inputs does not support this yet. 255 seems to be the most common minimum max value, so use that. Then you need to calibrate on any other joystick by moving through the whole range first. Fixes joysticks with ranges under 1023