### PR TITLE
Hyundai: Show LFA and HDA icons for all CAN-FD HKG

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -78,7 +78,7 @@ class CarController:
         can_sends.append(hyundaicanfd.create_cam_0x2a4(self.packer, CS.cam_0x2a4))
 
       # LFA and HDA icons
-      if self.frame % 2 == 0 and not (self.CP.flags & HyundaiFlags.CANFD_HDA2):
+      if self.frame % 2 == 0:
         can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, CC.enabled))
 
       # button presses


### PR DESCRIPTION
Currently the LFA and HDA icons only show on non HDA2 CAN-FD HKG when openpilot is engaged. This allows all variant of HDA CAN-FD to show the icons when engaged.

**openpilot disengaged:**
- LFA: off
- HDA: off

**openpilot engaged:**
- LFA: green
- HDA: green

![image](https://user-images.githubusercontent.com/47793918/184517276-64efdfe7-8443-4b1f-8725-c075ff57cf20.png)