### PR TITLE
Hyundai Sonata: lateral torque custom ff

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -97,9 +97,16 @@ class CarInterfaceBase(ABC):
     # Proportional to realigning tire momentum: lateral acceleration.
     # TODO: something with lateralPlan.curvatureRates
     return desired_angle * (v_ego**2)
+  
+  @staticmethod
+  def get_steer_feedforward_torque_default(desired_lateral_accel, v_ego):
+    return desired_lateral_accel
 
   def get_steer_feedforward_function(self):
     return self.get_steer_feedforward_default
+  
+  def get_steer_feedforward_torque_function(self):
+    return self.get_steer_feedforward_torque_default
 
   # returns a set of default params to avoid repetition in car specific params
   @staticmethod

--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -27,7 +27,7 @@ class LatControlTorque(LatControl):
     super().__init__(CP, CI)
     self.pid = PIDController(CP.lateralTuning.torque.kp, CP.lateralTuning.torque.ki,
                              k_f=CP.lateralTuning.torque.kf, pos_limit=self.steer_max, neg_limit=-self.steer_max)
-    self.get_steer_feedforward = CI.get_steer_feedforward_function()
+    self.get_steer_feedforward = CI.get_steer_feedforward_torque_function()
     self.use_steering_angle = CP.lateralTuning.torque.useSteeringAngle
     self.friction = CP.lateralTuning.torque.friction
     self.kf = CP.lateralTuning.torque.kf
@@ -62,7 +62,7 @@ class LatControlTorque(LatControl):
       error = setpoint - measurement
       pid_log.error = error
 
-      ff = desired_lateral_accel - params.roll * ACCELERATION_DUE_TO_GRAVITY
+      ff = self.get_steer_feedforward(desired_lateral_accel - params.roll * ACCELERATION_DUE_TO_GRAVITY, CS.vEgo)
       # convert friction into lateral accel units for feedforward
       friction_compensation = interp(apply_deadzone(error, lateral_accel_deadzone), [-FRICTION_THRESHOLD, FRICTION_THRESHOLD], [-self.friction, self.friction])
       ff += friction_compensation / self.kf


### PR DESCRIPTION
Same as [custom torque for Chevy Volt](https://github.com/commaai/openpilot/pull/25358), but for Sonata. 

Unlike the Volt, this is still a linear feedforward w.r.t. lateral acceleration, but it includes a speed dependence to resolve low-speed issues. The effect is to increase low-speed feedforward, based on the data that indicate the amount of steering torque necessary to hold a given lateral acceleration at a given speed. The speed-dependence is significant. More so for [Palisade](https://github.com/commaai/openpilot/pull/25512).

This cuts feedforward error in half compared to linear feedforward, using the params.yaml max lat acceleration value to determine kf (0.35) for the comparison:
```MAE old 0.4226, new 0.1952
STD old 0.3828, new 0.2319
```

Fit from around 5.2 hours of driving data: 1.1 million samples filtered down to 1657 points with constant curvature rate, no saturation, and no driver torque.
```
describe(steer_offsets) = DescribeResult(nobs=1114146, minmax=(-4.021855354309082, 5.805548191070557), mean=-0.04294795383310292, variance=0.4337575485851953, skewness=0.5776027928213927, kurtosis=5.4416345277293825)
Samples: 659493

Regularized samples: 1657

speed: DescribeResult(nobs=1657, minmax=(3.8551877475920175, 34.86912155151367), mean=18.47563591727422, variance=37.38501038503589, skewness=-0.15137777709401073, kurtosis=-0.24800719124959114)
angle: DescribeResult(nobs=1657, minmax=(-3.3460993669537373, 4.258131831871131), mean=0.016330547001693167, variance=0.8556872533901201, skewness=0.14323546604620502, kurtosis=0.9803802511551987)
steer: DescribeResult(nobs=1657, minmax=(-3.596901416509924, 3.983225806759249), mean=0.2110790710868405, variance=0.6545499240843514, skewness=-0.09025266441000007, kurtosis=1.7571489967239113)

lat_accel 0.00-0.20:438, lat_accel 0.21-0.41:271, lat_accel 0.43-0.63:215, lat_accel 0.64-0.84:159, lat_accel 0.86-1.06:121
lat_accel 1.07-1.27:107, lat_accel 1.29-1.49:97, lat_accel 1.50-1.70:57, lat_accel 1.71-1.91:37, lat_accel 1.93-2.13:25
lat_accel 2.14-2.34:16, lat_accel 2.36-2.56:16, lat_accel 2.57-2.77:7, lat_accel 2.79-2.99:7, lat_accel 3.00-3.20:4

mph 08-13:38, mph 13-18:66, mph 18-23:89, mph 23-28:94, mph 28-33:127
mph 33-38:191, mph 38-43:267, mph 43-48:212, mph 48-53:304, mph 53-58:71
mph 58-63:128, mph 63-68:39, mph 68-73:16, mph 73-78:8, mph 78-83:7
mph 83-88:0, mph 88-93:0, 
```
![mph](https://user-images.githubusercontent.com/7284371/185804435-8c016bda-1d13-4669-8be7-90ce6614e6b1.gif)


~~Waiting on testers before taking out of draft.~~
Working with tester. Others please do not test until I update.