### PR TITLE
sim: fix gps message

### DIFF
--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -179,7 +179,7 @@ def gps_callback(gps, vehicle_state):
   ]
 
   dat.gpsLocationExternal = {
-    "timestamp": int(time.time() * 1000),
+    "unixTimestampMillis": int(time.time() * 1000),
     "flags": 1,  # valid fix
     "accuracy": 1.0,
     "verticalAccuracy": 1.0,


### PR DESCRIPTION
bug introduced in https://github.com/commaai/cereal/pull/341 when the `timestamp` field was renamed