### PR TITLE
Translations badges: concatenate into one badge

### DIFF
--- a/selfdrive/ui/translations/README.md
+++ b/selfdrive/ui/translations/README.md
@@ -1,11 +1,6 @@
 # Multilanguage
 
-[![language](https://raw.githubusercontent.com/commaai/openpilot/badges/translation_badge_main_en.svg)](https://github.com/commaai/openpilot/blob/master/selfdrive/ui/translations/main_en.ts)
-[![language](https://raw.githubusercontent.com/commaai/openpilot/badges/translation_badge_main_pt.svg)](https://github.com/commaai/openpilot/blob/master/selfdrive/ui/translations/main_pt.ts)
-[![language](https://raw.githubusercontent.com/commaai/openpilot/badges/translation_badge_main_zh-CHT.svg)](https://github.com/commaai/openpilot/blob/master/selfdrive/ui/translations/main_zh-CHT.ts)
-[![language](https://raw.githubusercontent.com/commaai/openpilot/badges/translation_badge_main_zh-CHS.svg)](https://github.com/commaai/openpilot/blob/master/selfdrive/ui/translations/main_zh-CHS.ts)
-[![language](https://raw.githubusercontent.com/commaai/openpilot/badges/translation_badge_main_ko.svg)](https://github.com/commaai/openpilot/blob/master/selfdrive/ui/translations/main_ko.ts)
-[![language](https://raw.githubusercontent.com/commaai/openpilot/badges/translation_badge_main_ja.svg)](https://github.com/commaai/openpilot/blob/master/selfdrive/ui/translations/main_ja.ts)
+[![languages](https://raw.githubusercontent.com/commaai/openpilot/badges/translation_badge.svg)](#)
 
 ## Contributing
 

--- a/selfdrive/ui/translations/create_badges.py
+++ b/selfdrive/ui/translations/create_badges.py
@@ -8,14 +8,13 @@ from selfdrive.ui.update_translations import LANGUAGES_FILE, TRANSLATIONS_DIR
 
 TRANSLATION_TAG = "<translation"
 UNFINISHED_TRANSLATION_TAG = "<translation type=\"unfinished\""
-BADGE_HEIGHT = 20
-BADGE_OFFSET = 8
+BADGE_HEIGHT = 20 + 8
 
 if __name__ == "__main__":
   with open(LANGUAGES_FILE, "r") as f:
     translation_files = json.load(f)
 
-  global_svg = [f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="{len(translation_files) * (BADGE_HEIGHT + BADGE_OFFSET)}">']
+  badge_svg = [f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="{len(translation_files) * BADGE_HEIGHT}">']
   for idx, (name, file) in enumerate(translation_files.items()):
     with open(os.path.join(TRANSLATIONS_DIR, f"{file}.ts"), "r") as tr_f:
       tr_file = tr_f.read()
@@ -35,16 +34,16 @@ if __name__ == "__main__":
     assert r.status_code == 200, "Error downloading badge"
     content_svg = r.content.decode("utf-8")
 
-    # need to make tag ids in each badge unique
+    # make tag ids in each badge unique
     for tag in ("r", "s"):
       content_svg = content_svg.replace(f'id="{tag}"', f'id="{tag}{idx}"')
       content_svg = content_svg.replace(f'"url(#{tag})"', f'"url(#{tag}{idx})"')
 
-    global_svg.append('<g transform="translate(0, {})">'.format(idx * (BADGE_HEIGHT + BADGE_OFFSET)))
-    global_svg.append(content_svg)
-    global_svg.append("</g>")
+    badge_svg.append('<g transform="translate(0, {})">'.format(idx * BADGE_HEIGHT))
+    badge_svg.append(content_svg)
+    badge_svg.append("</g>")
 
-  global_svg.append("</svg>")
+  badge_svg.append("</svg>")
 
   with open(os.path.join(BASEDIR, "translation_badge.svg"), "w") as badge_f:
-    badge_f.write("\n".join(global_svg))
+    badge_f.write("\n".join(badge_svg))

--- a/selfdrive/ui/translations/create_badges.py
+++ b/selfdrive/ui/translations/create_badges.py
@@ -8,19 +8,17 @@ from selfdrive.ui.update_translations import LANGUAGES_FILE, TRANSLATIONS_DIR
 
 TRANSLATION_TAG = "<translation"
 UNFINISHED_TRANSLATION_TAG = "<translation type=\"unfinished\""
-TRANSLATION_BADGE = "translation_badge_{}.svg"
-TRANSLATION_LINK = "https://github.com/commaai/openpilot/blob/master/selfdrive/ui/translations/{}"
+BADGE_HEIGHT = 20
+BADGE_OFFSET = 8
 
 if __name__ == "__main__":
   with open(LANGUAGES_FILE, "r") as f:
     translation_files = json.load(f)
 
-  print("Copy into selfdrive/ui/translations/README.md:\n")
-  for name, file in translation_files.items():
+  global_svg = [f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="{len(translation_files) * (BADGE_HEIGHT + BADGE_OFFSET)}">']
+  for idx, (name, file) in enumerate(translation_files.items()):
     with open(os.path.join(TRANSLATIONS_DIR, f"{file}.ts"), "r") as tr_f:
       tr_file = tr_f.read()
-
-    print(f"[![language](https://raw.githubusercontent.com/commaai/openpilot/badges/{TRANSLATION_BADGE.format(file)})]({TRANSLATION_LINK.format(file)}.ts)")
 
     total_translations = 0
     unfinished_translations = 0
@@ -35,6 +33,18 @@ if __name__ == "__main__":
 
     r = requests.get(f"https://img.shields.io/badge/LANGUAGE {name}-{percent_finished}%25 complete-{color}")
     assert r.status_code == 200, "Error downloading badge"
+    content_svg = r.content.decode("utf-8")
 
-    with open(os.path.join(BASEDIR, TRANSLATION_BADGE.format(file)), "wb") as badge_f:
-      badge_f.write(r.content)
+    # need to make tag ids in each badge unique
+    for tag in ("r", "s"):
+      content_svg = content_svg.replace(f'id="{tag}"', f'id="{tag}{idx}"')
+      content_svg = content_svg.replace(f'"url(#{tag})"', f'"url(#{tag}{idx})"')
+
+    global_svg.append('<g transform="translate(0, {})">'.format(idx * (BADGE_HEIGHT + BADGE_OFFSET)))
+    global_svg.append(content_svg)
+    global_svg.append("</g>")
+
+  global_svg.append("</svg>")
+
+  with open(os.path.join(BASEDIR, "translation_badge.svg"), "w") as badge_f:
+    badge_f.write("\n".join(global_svg))

--- a/selfdrive/ui/translations/create_badges.py
+++ b/selfdrive/ui/translations/create_badges.py
@@ -39,9 +39,7 @@ if __name__ == "__main__":
       content_svg = content_svg.replace(f'id="{tag}"', f'id="{tag}{idx}"')
       content_svg = content_svg.replace(f'"url(#{tag})"', f'"url(#{tag}{idx})"')
 
-    badge_svg.append('<g transform="translate(0, {})">'.format(idx * BADGE_HEIGHT))
-    badge_svg.append(content_svg)
-    badge_svg.append("</g>")
+    badge_svg.extend([f'<g transform="translate(0, {idx * BADGE_HEIGHT})">', content_svg, "</g>"])
 
   badge_svg.append("</svg>")
 


### PR DESCRIPTION
No more manually editing README when new language is added/removed

One downsize is we lose linking to each language file from the badges, but trying to see if we can use a tag in svg