### PR TITLE
GMC: Sierra 2020-21 support

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@ Version 0.8.16 (2022-08-26)
   * Brazilian Portuguese thanks to AlexandreSato!
 * Chevrolet Bolt EUV 2022-23 support thanks to JasonJShuler!
 * Chevrolet Silverado 2020-21 support thanks to JasonJShuler!
-* GMC Sierra 1500 2020-21 support
+* GMC Sierra 1500 2020-21 support thanks to JasonJShuler!
 * Hyundai Ioniq 5 2022 support thanks to sunnyhaibin!
 * Hyundai Kona Electric 2022 support thanks to sunnyhaibin!
 * Hyundai Tucson Hybrid 2022 support thanks to sunnyhaibin!

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@ Version 0.8.16 (2022-08-26)
   * Brazilian Portuguese thanks to AlexandreSato!
 * Chevrolet Bolt EUV 2022-23 support thanks to JasonJShuler!
 * Chevrolet Silverado 2020-21 support thanks to JasonJShuler!
+* GMC Sierra 1500 2020-21 support
 * Hyundai Ioniq 5 2022 support thanks to sunnyhaibin!
 * Hyundai Kona Electric 2022 support thanks to sunnyhaibin!
 * Hyundai Tucson Hybrid 2022 support thanks to sunnyhaibin!

--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -4,7 +4,7 @@
 
 A supported vehicle is one that just works when you install a comma device. Every car performs differently with openpilot, but all supported cars should provide a better experience than any stock system.
 
-# 204 Supported Cars
+# 205 Supported Cars
 
 |Make|Model|Supported Package|ACC|No ACC accel below|No ALC below|Steering Torque|Harness|
 |---|---|---|:---:|:---:|:---:|:---:|:---:|
@@ -32,6 +32,7 @@ A supported vehicle is one that just works when you install a comma device. Ever
 |Genesis|G80 2017-19|All|Stock|0 mph|0 mph|[![star](assets/icon-star-full.svg)](##)|Hyundai H|
 |Genesis|G90 2017-18|All|Stock|0 mph|0 mph|[![star](assets/icon-star-full.svg)](##)|Hyundai C|
 |GMC|Acadia 2018[<sup>1</sup>](#footnotes)|Adaptive Cruise Control|openpilot|0 mph|7 mph|[![star](assets/icon-star-full.svg)](##)|OBD-II|
+|GMC|Sierra 1500 2020-21|Driver Alert Package II|Stock|0 mph|7 mph|[![star](assets/icon-star-full.svg)](##)|GM|
 |Honda|Accord 2018-22|All|Stock|0 mph|3 mph|[![star](assets/icon-star-empty.svg)](##)|Honda Bosch A|
 |Honda|Accord Hybrid 2018-22|All|Stock|0 mph|3 mph|[![star](assets/icon-star-empty.svg)](##)|Honda Bosch A|
 |Honda|Civic 2016-18|Honda Sensing|openpilot|0 mph|12 mph|[![star](assets/icon-star-empty.svg)](##)|Honda Nidec|

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -85,7 +85,10 @@ CAR_INFO: Dict[str, Union[GMCarInfo, List[GMCarInfo]]] = {
   CAR.BUICK_REGAL: GMCarInfo("Buick Regal Essence 2018"),
   CAR.ESCALADE_ESV: GMCarInfo("Cadillac Escalade ESV 2016", "Adaptive Cruise Control (ACC) & LKAS"),
   CAR.BOLT_EUV: GMCarInfo("Chevrolet Bolt EUV 2022-23", "Premier or Premier Redline Trim without Super Cruise Package", video_link="https://youtu.be/xvwzGMUA210", footnotes=[], harness=Harness.gm),
-  CAR.SILVERADO: GMCarInfo("Chevrolet Silverado 1500 2020-21", "Safety Package II", footnotes=[], harness=Harness.gm),
+  CAR.SILVERADO: [
+    GMCarInfo("Chevrolet Silverado 1500 2020-21", "Safety Package II", footnotes=[], harness=Harness.gm),
+    GMCarInfo("GMC Sierra 1500 2020-21", "Adaptive Cruise Control", footnotes=[], harness=Harness.gm),
+  ],
 }
 
 

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -87,7 +87,7 @@ CAR_INFO: Dict[str, Union[GMCarInfo, List[GMCarInfo]]] = {
   CAR.BOLT_EUV: GMCarInfo("Chevrolet Bolt EUV 2022-23", "Premier or Premier Redline Trim without Super Cruise Package", video_link="https://youtu.be/xvwzGMUA210", footnotes=[], harness=Harness.gm),
   CAR.SILVERADO: [
     GMCarInfo("Chevrolet Silverado 1500 2020-21", "Safety Package II", footnotes=[], harness=Harness.gm),
-    GMCarInfo("GMC Sierra 1500 2020-21", "Adaptive Cruise Control", footnotes=[], harness=Harness.gm),
+    GMCarInfo("GMC Sierra 1500 2020-21", "Driver Alert Package II", footnotes=[], harness=Harness.gm),
   ],
 }
 


### PR DESCRIPTION
Tuning looks almost identical (2.0 m/s^2). Car fingerprints as a Silverado. ACC is available on SLT PREMIUM PLUS PACKAGE, AT4 CARBONPRO™ EDITION, and DENALI ULTIMATE PACKAGE trims with Driver Alert
Package II.