### PR TITLE
GM Port: Add Auto-resume support

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -109,7 +109,7 @@ class CarController:
 
     else:
       # Stock longitudinal, integrated at camera
-      if (self.frame - self.last_button_frame) * DT_CTRL > 0.04:
+      if (self.frame - self.last_button_frame) * DT_CTRL > 0.2:
         if CC.cruiseControl.cancel:
           self.last_button_frame = self.frame
           # CS.buttons_counter = (CS.buttons_counter + 1) % 4
@@ -118,7 +118,7 @@ class CarController:
     # Resume allowed for ASCM and CAM, OP and Stock long
     # TODO: @sshane: cruiseControl.resume logic may need review for stock long
     # TODO: Spamming repeatedly faster than 100ms can cause fault (cruise main off)
-    if (self.frame - self.last_button_frame) * DT_CTRL > 0.04:
+    if (self.frame - self.last_button_frame) * DT_CTRL > 0.2:
       if CC.cruiseControl.resume:
         self.last_button_frame = self.frame
         # CS.buttons_counter = (CS.buttons_counter + 1) % 4

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -112,8 +112,18 @@ class CarController:
       if (self.frame - self.last_button_frame) * DT_CTRL > 0.04:
         if CC.cruiseControl.cancel:
           self.last_button_frame = self.frame
-          can_sends.append(gmcan.create_buttons(self.packer_pt, CanBus.CAMERA, CS.buttons_counter, CruiseButtons.CANCEL))
+          # CS.buttons_counter = (CS.buttons_counter + 1) % 4
+          can_sends.append(gmcan.create_buttons(self.packer_pt, CanBus.CAMERA, (CS.buttons_counter + 1) % 4, CruiseButtons.CANCEL))
 
+    # Resume allowed for ASCM and CAM, OP and Stock long
+    # TODO: @sshane: cruiseControl.resume logic may need review for stock long
+    # TODO: Spamming repeatedly faster than 100ms can cause fault (cruise main off)
+    if (self.frame - self.last_button_frame) * DT_CTRL > 0.04:
+      if CC.cruiseControl.resume:
+        self.last_button_frame = self.frame
+        # CS.buttons_counter = (CS.buttons_counter + 1) % 4
+        can_sends.append(gmcan.create_buttons(self.packer_pt, CanBus.POWERTRAIN, (CS.buttons_counter + 1) % 4, CruiseButtons.RES_ACCEL))
+    
     # Show green icon when LKA torque is applied, and
     # alarming orange icon when approaching torque limit.
     # If not sent again, LKA icon disappears in about 5 seconds.


### PR DESCRIPTION
**Description**
Updated GM carcontroller.py to send the ACC resume button on the PT bus when CC.cruiseControl.resume is true.
Updated the rolling counter logic to increment the RC - without incrementing we were sending the same RC value the car had just sent, and this would probably cause our message to be rejected.

Depends on Panda PR: https://github.com/commaai/panda/pull/1039

TODO: controlsd code that sets cruiseControl.resume may need review to ensure it works correctly with the stock long as well as OP long.

**Verification**
TBD - will need @sshane and / or community assistance to test