### PR TITLE
Ram Long/S0/CruiseFix

### DIFF
--- a/common/colors.py
+++ b/common/colors.py
@@ -1,0 +1,41 @@
+class Colors:
+  def __init__(self):
+    self.HEADER = '\033[95m'
+    self.OKBLUE = '\033[94m'
+    self.CBLUE = '\33[44m'
+    self.BOLD = '\033[1m'
+    self.CITALIC = '\33[3m'
+    self.OKGREEN = '\033[92m'
+    self.CWHITE = '\33[37m'
+    self.ENDC = '\033[0m' + self.CWHITE
+    self.UNDERLINE = '\033[4m'
+    self.PINK = '\33[38;5;207m'
+    self.PRETTY_YELLOW = self.BASE(220)
+
+    self.RED = '\033[91m'
+    self.PURPLE_BG = '\33[45m'
+    self.YELLOW = '\033[93m'
+    self.BLUE_GREEN = self.BASE(85)
+
+    self.FAIL = self.RED
+    self.INFO = self.PURPLE_BG
+    self.SUCCESS = self.OKGREEN
+    self.PROMPT = self.YELLOW
+    self.DBLUE = '\033[36m'
+    self.CYAN = self.BASE(39)
+    self.WARNING = '\033[33m'
+
+  def BASE(self, col):  # seems to support more Colors
+    return '\33[38;5;{}m'.format(col)
+
+  def BASEBG(self, col):  # seems to support more Colors
+    return '\33[48;5;{}m'.format(col)
+
+COLORS = Colors()
+
+def opParams_warning(msg):
+  print('{}opParams WARNING: {}{}'.format(COLORS.WARNING, msg, COLORS.ENDC))
+
+
+def opParams_error(msg):
+  print('{}opParams ERROR: {}{}'.format(COLORS.FAIL, msg, COLORS.ENDC))

--- a/common/numpy_fast.py
+++ b/common/numpy_fast.py
@@ -1,15 +1,21 @@
+import sys
+
+def int_rnd(x):
+  return int(round(x))
+
 def clip(x, lo, hi):
   return max(lo, min(hi, x))
 
 def interp(x, xp, fp):
   N = len(xp)
+  T = len(fp)
 
   def get_interp(xv):
     hi = 0
     while hi < N and xv > xp[hi]:
       hi += 1
     low = hi - 1
-    return fp[-1] if hi == N and xv > xp[low] else (
+    return fp[-1] if hi >= T or low >= T or (hi >= N and xv >= xp[low]) or (N < T and xv == xp[-1]) else (
       fp[0] if hi == 0 else
       (xv - xp[low]) * (fp[hi] - fp[low]) / (xp[hi] - xp[low]) + fp[low])
 
@@ -17,3 +23,46 @@ def interp(x, xp, fp):
 
 def mean(x):
   return sum(x) / len(x)
+
+def incremental_avg(cur_avg, new_val, new_size):
+  return cur_avg + ((new_val - cur_avg) / new_size)
+
+def find_nearest_index(x, y):
+  '''
+  Finds nearest index of x based on the value(s) of y.
+  '''
+  def get_nearest(yv):
+    dist = sys.maxsize
+    i = 0
+    xi = 0
+
+    for xv in x:
+      d = abs(abs(xv) - abs(yv))
+      # print(f'd({d}) = xv({xv}) - yv({yv})')
+      if d <= dist:
+        dist = d
+        i = xi
+      xi += 1
+
+    return i
+
+  idxs = [get_nearest(yv) for yv in y] if hasattr(y, '__iter__') else get_nearest(y)
+
+  # if hasattr(y, '__iter__'):
+  #   for yv in y:
+  #     idxs.append(get_nearest(yv))
+  # else:
+  #   idxs.append(get_nearest(y))
+
+  return idxs
+
+def is_multi_iter(x):
+  multi_iter = False
+
+  if hasattr(x, '__iter__'):
+    for i in x:
+      if hasattr(i, '__iter__'):
+        multi_iter = True
+        break
+
+  return multi_iter

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+import os
+import json
+import math
+import time
+from common.numpy_fast import find_nearest_index, interp, is_multi_iter
+from common.colors import opParams_error as error
+from common.colors import opParams_warning as warning
+from selfdrive.hardware import PC
+
+try:
+  from common.realtime import sec_since_boot
+except ImportError:
+  sec_since_boot = time.time
+  warning("Using python time.time() instead of faster sec_since_boot")
+
+travis = True if PC else False  # replace with travis_checker if you use travis or GitHub Actions
+
+
+def parse_param_modifiers(src, value):
+  if src:
+    if ParamModifierKeys.ABS in src:
+      return parse_param_modifiers(src.replace(ParamModifierKeys.ABS, ''), abs(value))
+    elif ParamModifierKeys.DEGREES in src:
+      return parse_param_modifiers(src.replace(ParamModifierKeys.DEGREES, ''), math.degrees(value))
+    elif ParamModifierKeys.RADIANS in src:
+      return parse_param_modifiers(src.replace(ParamModifierKeys.RADIANS, ''), math.radians(value))
+  else:
+    return value
+
+def eval_breakpoint_source(sources, CS, controls_state):
+  '''
+  Maps a breakpoint source array to actual values
+  '''
+
+  def eval_source(src):
+    if BreakPointSourceKeys.VEGO in src:
+      return parse_param_modifiers(src.replace(BreakPointSourceKeys.VEGO, ''), CS.vEgo)
+    elif BreakPointSourceKeys.AEGO in src:
+      return parse_param_modifiers(src.replace(BreakPointSourceKeys.AEGO, ''), CS.aEgo)
+    elif BreakPointSourceKeys.DESIRED_STEER in src:
+      return parse_param_modifiers(src.replace(BreakPointSourceKeys.DESIRED_STEER, ''), controls_state.desiredSteerDeg)
+    else:
+      raise ValueError(f'Unknown value option: {src}')
+
+  return [eval_source(source) for source in sources]
+
+def interp_multi_bp(x, bp, v):
+  def correct_multi_bp(idx):
+    if not is_multi_iter(bp[idx]):
+      bp[idx] = [bp[idx], bp[idx]]
+
+      if len(bp) <= 1:
+        bp.insert(0, bp[idx][0])
+
+  is_bp_multi_iter = is_multi_iter(bp)
+  is_v_multi_iter = is_multi_iter(v)
+
+  if not is_bp_multi_iter:
+    bp = [bp, bp]
+
+  # correct_multi_bp(0)
+  correct_multi_bp(-1)
+
+  if not is_v_multi_iter:
+    v = [v, v]
+
+  l_x = len(x)
+  l_bp = len(bp)
+  l_v = len(v)
+
+  # print(f'bp: {bp}')
+  if l_v <= 1:
+    v = [v[-1], v[-1]]
+
+  if l_bp < l_x or not hasattr(bp[0], '__iter__') or len(bp[0]) <= 1:
+    # return interp(x[0], bp[0][0], v[0])
+    # idx = range(len(x)) if is_multi_iter(x) else 0
+    # idx = [0] if is_multi_iter(x) else 0
+    idx = 0
+  else:
+    idx = find_nearest_index(bp[0], x[0])
+
+  # print(f'indexes: {idx}')
+
+  if hasattr(idx, '__iter__'):
+    return [interp(x[-1], bp[-1][-1], v[min(l_v - 1, i)]) for i in set(idx)]
+  else:
+    return interp(x[-1], bp[-1][-1], v[min(l_v - 1, idx)])
+
+  # return [interp(x[-1], bp[-1][i], v[i]) for i in set(idx)] if hasattr(idx, '__iter__') else interp(x[-1], bp[-1][idx], v[idx])
+  # return interp(x[1], bp[1][idx], v[idx])
+
+class BreakPointSourceKeys:
+  VEGO = 'vego'
+  AEGO = 'aego'
+  DESIRED_STEER = 'desired_steer'
+
+class ParamModifierKeys:
+  ABS = '_abs'
+  DEGREES = '_deg'
+  RADIANS = '_rad'
+
+class ValueTypes:
+  number = [float, int]
+  none_or_number = [type(None), float, int]
+  list_of_numbers = [list, float, int]
+
+class Param:
+  def __init__(self, default, allowed_types, description=None, live=False, hidden=False, depends_on=None):
+    self.default = default
+    if not isinstance(allowed_types, list):
+      allowed_types = [allowed_types]
+    self.allowed_types = allowed_types
+    self.description = description
+    self.hidden = hidden
+    self.live = live
+    self.depends_on = depends_on
+    self.children = []
+    self._create_attrs()
+
+  def is_valid(self, value):
+    if not self.has_allowed_types:
+      return True
+    if self.is_list and isinstance(value, list):
+      for v in value:
+        if type(v) not in self.allowed_types:
+          return False
+      return True
+    else:
+      return type(value) in self.allowed_types or value in self.allowed_types
+
+  def _create_attrs(self):  # Create attributes and check Param is valid
+    self.has_allowed_types = isinstance(self.allowed_types, list) and len(self.allowed_types) > 0
+    self.has_description = self.description is not None
+    self.is_list = list in self.allowed_types
+    self.is_bool = bool in self.allowed_types
+    if self.has_allowed_types:
+      assert type(self.default) in self.allowed_types or self.default in self.allowed_types, 'Default value type must be in specified allowed_types!'
+
+      if self.is_list and self.default:
+        for v in self.default:
+          assert type(v) in self.allowed_types, 'Default value type must be in specified allowed_types!'
+
+
+class opParams:
+  def __init__(self):
+    """
+      To add your own parameter to opParams in your fork, simply add a new entry in self.fork_params, instancing a new Param class with at minimum a default value.
+      The allowed_types and description args are not required but highly recommended to help users edit their parameters with opEdit safely.
+        - The description value will be shown to users when they use opEdit to change the value of the parameter.
+        - The allowed_types arg is used to restrict what kinds of values can be entered with opEdit so that users can't crash openpilot with unintended behavior.
+              (setting a param intended to be a number with a boolean, or viceversa for example)
+          Limiting the range of floats or integers is still recommended when `.get`ting the parameter.
+          When a None value is allowed, use `type(None)` instead of None, as opEdit checks the type against the values in the arg with `isinstance()`.
+        - Finally, the live arg tells both opParams and opEdit that it's a live parameter that will change. Therefore, you must place the `op_params.get()` call in the update function so that it can update.
+
+      Here's an example of a good fork_param entry:
+      self.fork_params = {'camera_offset': Param(default=0.06, allowed_types=VT.number)}  # VT.number allows both floats and ints
+    """
+  
+    VT = ValueTypes()
+    self.fork_params = {
+                        # LAT_KP_BP: Param([0., 25.,], [list, float, int], live=True),
+                        # LAT_KP_V: Param([0.12, 0.12], [list, float, int], live=True),
+                        # LAT_KI_BP: Param([0.,25.], [list, float, int], live=True),
+                        # LAT_KI_V: Param([0., 0.0001], [list, float, int], live=True),
+                        # LAT_KD_BP: Param([0.,25.], [list, float, int], live=True),
+                        # LAT_KD_V: Param([0., 0.001], [list, float, int], live=True),
+                        # LAT_KF: Param(6e-6, VT.number, live=True),
+                        # MAX_LAT_ACCEL: Param(1.2, VT.number, live=True),
+                        # FRICTION: Param(0.05, VT.number, live=True),
+                        ACCEL_FACTOR: Param(1.5, VT.number, live=True),
+                        DECEL_FACTOR: Param(1.5, VT.number, live=True),
+                        # STEER_ACT_DELAY: Param(0.1, VT.number, live=True),
+                        # STEER_RATE_COST: Param(0.5, VT.number, live=True),
+                        # DEVICE_OFFSET: Param(0.0, VT.number, live=True),
+                        
+                        #SHOW_RATE_PARAMS: Param(False, [bool], live=True),
+                        #ENABLE_RATE_PARAMS: Param(False, [bool], live=True, depends_on=SHOW_RATE_PARAMS),
+                        #STOCK_DELTA_UP_DOWN: Param(6, VT.number, live=True ,depends_on=SHOW_RATE_PARAMS),
+                        #STOCK_DELTA_UP: Param(25, VT.number, live=True ,depends_on=SHOW_RATE_PARAMS),
+                        #STOCK_DELTA_DOWN: Param(50, VT.number, live=True ,depends_on=SHOW_RATE_PARAMS),
+                        #STOCK_STEER_MAX: Param(363, VT.number, live=True ,depends_on=SHOW_RATE_PARAMS),
+}
+
+    self._params_file = '/data/op_params.json'
+    self._backup_file = '/data/op_params_corrupt.json'
+    self._last_read_time = sec_since_boot()
+    self.read_frequency = 2.5  # max frequency to read with self.get(...) (sec)
+    self._to_delete = ['lane_hug_direction', 'lane_hug_angle_offset', 'prius_use_lqr']  # a list of params you want to delete (unused)
+    self._last_mod_time = 0.0
+    self._run_init()  # restores, reads, and updates params
+
+  def _run_init(self):  # does first time initializing of default params
+    # Two required parameters for opEdit
+    self.fork_params['username'] = Param(None, [type(None), str, bool], 'Your identifier provided with any crash logs sent to Sentry.\nHelps the developer reach out to you if anything goes wrong')
+    self.fork_params['op_edit_live_mode'] = Param(False, bool, 'This parameter controls which mode opEdit starts in', hidden=False)
+    self.params = self._get_all_params(default=True)  # in case file is corrupted
+
+    for k, p in self.fork_params.items():
+      d = p.depends_on
+      while d:
+        fp = self.fork_params[d]
+        fp.children.append(k)
+        d = fp.depends_on
+
+    if travis:
+      return
+
+    to_write = False
+    if os.path.isfile(self._params_file):
+      if self._read():
+        to_write = self._add_default_params()  # if new default data has been added
+        to_write |= self._delete_old()  # or if old params have been deleted
+      else:  # backup and re-create params file
+        error("Can't read op_params.json file, backing up to /data/op_params_corrupt.json and re-creating file!")
+        to_write = True
+        if os.path.isfile(self._backup_file):
+          os.remove(self._backup_file)
+        os.rename(self._params_file, self._backup_file)
+    else:
+      to_write = True  # user's first time running a fork with op_params, write default params
+
+    if to_write:
+      if self._write():
+        os.chmod(self._params_file, 0o764)
+
+  def get(self, key=None, force_live=False):  # any params you try to get MUST be in fork_params
+    if PC:
+      assert isinstance(self, opParams), f'Self is type: {type(self).__name__}, expected opParams'
+
+    param_info = self.param_info(key)
+    self._update_params(param_info, force_live)
+
+    if key is None:
+      return self._get_all_params()
+
+    self._check_key_exists(key, 'get')
+    value = self.params[key]
+    if param_info.is_valid(value):  # always valid if no allowed types, otherwise checks to make sure
+      return value  # all good, returning user's value
+
+    warning('User\'s value type is not valid! Returning default')  # somehow... it should always be valid
+    return param_info.default  # return default value because user's value of key is not in allowed_types to avoid crashing openpilot
+
+  def put(self, key, value):
+    self._check_key_exists(key, 'put')
+    if not self.param_info(key).is_valid(value):
+      raise Exception('opParams: Tried to put a value of invalid type!')
+    self.params.update({key: value})
+    self._write()
+
+  def delete(self, key):  # todo: might be obsolete. remove?
+    if key in self.params:
+      del self.params[key]
+      self._write()
+
+  def param_info(self, key):
+    if key in self.fork_params:
+      return self.fork_params[key]
+    return Param(None, type(None))
+
+  def _check_key_exists(self, key, met):
+    if key not in self.fork_params or key not in self.params:
+      raise Exception('opParams: Tried to {} an unknown parameter! Key not in fork_params: {}'.format(met, key))
+
+  def _add_default_params(self):
+    added = False
+    for key, param in self.fork_params.items():
+      if key not in self.params:
+        self.params[key] = param.default
+        added = True
+      elif not param.is_valid(self.params[key]):
+        warning('Value type of user\'s {} param not in allowed types, replacing with default!'.format(key))
+        self.params[key] = param.default
+        added = True
+    return added
+
+  def _delete_old(self):
+    deleted = False
+    for param in self._to_delete:
+      if param in self.params:
+        del self.params[param]
+        deleted = True
+    return deleted
+
+  def _get_all_params(self, default=False, return_hidden=False):
+    if default:
+      return {k: p.default for k, p in self.fork_params.items()}
+    return {k: self.params[k] for k, p in self.fork_params.items() if k in self.params and (not p.hidden or return_hidden)}
+
+  def _update_params(self, param_info, force_live):
+    if force_live or param_info.live:  # if is a live param, we want to get updates while openpilot is running
+      if not travis and sec_since_boot() - self._last_read_time >= self.read_frequency:  # make sure we aren't reading file too often
+        if self._read():
+          self._last_read_time = sec_since_boot()
+
+  def _read(self):
+    if os.path.isfile(self._params_file):
+      try:
+        mod_time = os.path.getmtime(self._params_file)
+        if mod_time > self._last_mod_time:
+          with open(self._params_file, "r") as f:
+            self.params = json.loads(f.read())
+          self._last_mod_time = mod_time
+          return True
+        else:
+          return False
+      except Exception as e:
+        print("Unable to read file: " + str(e))
+        return False
+    else:
+      return False
+
+  def _write(self):
+    if not travis or os.path.isdir("/data/"):
+      try:
+        with open(self._params_file, "w") as f:
+          f.write(json.dumps(self.params, indent=2))  # can further speed it up by remove indentation but makes file hard to read
+        return True
+      except Exception as e:
+        print("Unable to write file: " + str(e))
+        return False
+
+SHOW_INDI_PARAMS = 'show_indi_params'
+ENABLE_INDI_BREAKPOINTS = 'enable_indi_breakpoints'
+
+# LAT_KP_BP = 'lat_kp_bp'
+# LAT_KP_V = 'lat_kp_v'
+# LAT_KI_BP = 'lat_ki_bp'
+# LAT_KI_V = 'lat_ki_v'
+# LAT_KD_BP = 'lat_kd_bp'
+# LAT_KD_V = 'lat_kd_v'
+# LAT_KF = 'lat_kf'
+# MAX_LAT_ACCEL = 'max_lat_accel'
+# FRICTION = 'friction'
+ACCEL_FACTOR = 'accel_factor'
+DECEL_FACTOR = 'decel_factor'
+
+#SHOW_RATE_PARAMS = 'show_rate_params'
+#ENABLE_RATE_PARAMS = 'enable_rate_params'
+#STOCK_DELTA_UP_DOWN = 'stock_delta_up_down'
+# STOCK_DELTA_UP = 'stock_delta_up'
+# STOCK_DELTA_DOWN = 'stock_delta_down'
+# STOCK_STEER_MAX = 'stock_steer_max'
+# STEER_ACT_DELAY = 'steer_act_delay'
+# STEER_RATIO = 'steer ratio'
+# STEER_RATE_COST = 'steer_rate_cost'
+# DEVICE_OFFSET = 'device_offset'

--- a/op_edit.py
+++ b/op_edit.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+import time
+import ast
+import difflib
+
+from common.op_params import opParams
+from common.colors import COLORS
+from collections import OrderedDict
+
+
+class opEdit:  # use by running `python /data/openpilot/op_edit.py`
+  def __init__(self):
+    self.op_params = opParams()
+    self.params = None
+    self.sleep_time = 0.75
+    self.live_tuning = self.op_params.get('op_edit_live_mode')
+    self.username = self.op_params.get('username')
+    self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),
+                        bool: {False: COLORS.RED, True: COLORS.OKGREEN},
+                        type(None): COLORS.BASE(177),
+                        str: COLORS.BASE(77)}
+
+    self.last_choice = None
+
+    self.run_init()
+
+  def run_init(self):
+    if self.username is None:
+      self.success('\nWelcome to the opParams command line editor!', sleep_time=0)
+      self.prompt('Parameter \'username\' is missing! Would you like to add your Discord username for easier crash debugging?')
+
+      username_choice = self.input_with_options(['Y', 'n', 'don\'t ask again'], default='n')[0]
+      if username_choice == 0:
+        self.prompt('Please enter your Discord username so the developers can reach out if a crash occurs:')
+        username = ''
+        while username == '':
+          username = input('>> ').strip()
+        self.success('Thanks! Saved your Discord username\n'
+                     'Edit the \'username\' parameter at any time to update', sleep_time=3.0)
+        self.op_params.put('username', username)
+        self.username = username
+      elif username_choice == 2:
+        self.op_params.put('username', False)
+        self.info('Got it, bringing you into opEdit\n'
+                  'Edit the \'username\' parameter at any time to update', sleep_time=3.0)
+    else:
+      self.success('\nWelcome to the opParams command line editor, {}!'.format(self.username), sleep_time=0)
+
+    self.run_loop()
+
+  def run_loop(self):
+    while True:
+      if not self.live_tuning:
+        self.info('Here are your parameters:', end='\n', sleep_time=0)
+      else:
+        self.info('Here are your live parameters:', sleep_time=0)
+        self.info('(changes take effect within {} seconds)'.format(self.op_params.read_frequency), end='\n', sleep_time=0)
+      self.params = self.op_params.get(force_live=True)
+      if self.live_tuning:  # only display live tunable params
+        self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
+
+      self.params = OrderedDict(sorted(self.params.items(), key=self.sort_params))
+
+      values_list = []
+      for k, v in self.params.items():
+        if len(str(v)) < 30 or len(str(v)) <= len('{} ... {}'.format(str(v)[:30], str(v)[-15:])):
+          v_color = ''
+          if type(v) in self.type_colors:
+            v_color = self.type_colors[type(v)]
+            if isinstance(v, bool):
+              v_color = v_color[v]
+          v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
+        else:
+          v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
+        values_list.append(v)
+
+      live = [COLORS.INFO + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+
+      to_print = []
+      blue_gradient = [33, 39, 45, 51, 87]
+      last_key = ''
+      last_info = None
+      shown_dots = False
+      for idx, param in enumerate(self.params):
+        info = self.op_params.param_info(param)
+        indent = self.get_sort_key(param).count(',')
+        line = ''
+        if not info.depends_on or param in last_info.children and \
+          self.op_params.get(last_key) and self.op_params.get(info.depends_on):
+          line = '{}. {}: {}  {}'.format(idx + 1, param, values_list[idx], live[idx])
+          line = indent * '.' + line
+        elif not shown_dots and last_info and param in last_info.children:
+          line = '...'
+          shown_dots = True
+        if line:
+          if idx == self.last_choice and self.last_choice is not None:
+            line = COLORS.OKGREEN + line
+          else:
+            _color = blue_gradient[min(round(idx / len(self.params) * len(blue_gradient)), len(blue_gradient) - 1)]
+            line = COLORS.BASE(_color) + line
+          if last_info and len(last_info.children) and indent == 0:
+            line = '\n' + line
+            shown_dots = False
+          to_print.append(line)
+
+        if indent == 0:
+          last_key = param
+          last_info = info
+
+
+      extras = {'a': ('Add new parameter', COLORS.OKGREEN),
+                'd': ('Delete parameter', COLORS.FAIL),
+                'l': ('Toggle live tuning', COLORS.WARNING),
+                'e': ('Exit opEdit', COLORS.PINK)}
+
+      to_print += ['---'] + ['{}. {}'.format(ext_col + e, ext_txt + COLORS.ENDC) for e, (ext_txt, ext_col) in extras.items()]
+      print('\n'.join(to_print))
+      self.prompt('\nChoose a parameter to edit (by index or name):')
+
+      choice = input('>> ').strip().lower()
+      parsed, choice = self.parse_choice(choice, len(self.params) + len(extras))
+      if parsed == 'continue':
+        continue
+      elif parsed == 'add':
+        self.add_parameter()
+      elif parsed == 'change':
+        self.last_choice = choice
+        self.change_parameter(choice)
+      elif parsed == 'delete':
+        self.delete_parameter()
+      elif parsed == 'live':
+        self.last_choice = None
+        self.live_tuning = not self.live_tuning
+        self.op_params.put('op_edit_live_mode', self.live_tuning)  # for next opEdit startup
+      elif parsed == 'exit':
+        return
+
+  def parse_choice(self, choice, opt_len):
+    if choice.isdigit():
+      choice = int(choice)
+      choice -= 1
+      if choice not in range(opt_len):  # number of options to choose from
+        self.error('Not in range!')
+        return 'continue', choice
+      return 'change', choice
+
+    if choice in ['a', 'add']:  # add new parameter
+      return 'add', choice
+    elif choice in ['d', 'delete', 'del']:  # delete parameter
+      return 'delete', choice
+    elif choice in ['l', 'live']:  # live tuning mode
+      return 'live', choice
+    elif choice in ['exit', 'e', '']:
+      self.error('Exiting opEdit!', sleep_time=0)
+      return 'exit', choice
+    else:  # find most similar param to user's input
+      param_sims = [(idx, self.str_sim(choice, param.lower())) for idx, param in enumerate(self.params)]
+      param_sims = [param for param in param_sims if param[1] > 0.5]
+      if len(param_sims) > 0:
+        chosen_param = sorted(param_sims, key=lambda param: param[1], reverse=True)[0]
+        return 'change', chosen_param[0]  # return idx
+
+    self.error('Invalid choice!')
+    return 'continue', choice
+
+  def str_sim(self, a, b):
+    return difflib.SequenceMatcher(a=a, b=b).ratio()
+
+  def change_parameter(self, choice):
+    while True:
+      chosen_key = list(self.params)[choice]
+      param_info = self.op_params.param_info(chosen_key)
+
+      old_value = self.params[chosen_key]
+      self.info('Chosen parameter: {}'.format(chosen_key), sleep_time=0)
+
+      to_print = []
+      if param_info.has_description:
+        to_print.append(COLORS.OKGREEN + '>>  Description: {}'.format(param_info.description.replace('\n', '\n  > ')) + COLORS.ENDC)
+      if param_info.has_allowed_types:
+        to_print.append(COLORS.RED + '>>  Allowed types: {}'.format(', '.join([at.__name__ if isinstance(at, type) else str(at) for at in param_info.allowed_types])) + COLORS.ENDC)
+      if param_info.live:
+        live_msg = '>>  This parameter supports live tuning!'
+        if not self.live_tuning:
+          live_msg += ' Updates should take effect within {} seconds'.format(self.op_params.read_frequency)
+        to_print.append(COLORS.YELLOW + live_msg + COLORS.ENDC)
+
+      if to_print:
+        print('\n{}\n'.format('\n'.join(to_print)))
+
+      if param_info.is_list:
+        self.change_param_list(old_value, param_info, chosen_key)  # TODO: need to merge the code in this function with the below to reduce redundant code
+        return
+
+      self.info('Current value: {} (type: {})'.format(old_value, type(old_value).__name__), sleep_time=0)
+
+      while True:
+        if param_info.live:
+          self.prompt('\nEnter your new value or [Enter] to exit:')
+        else:
+          self.prompt('\nEnter your new value:')
+        new_value = input('>> ').strip()
+        if new_value == '':
+          self.info('Exiting this parameter...', 0.5)
+          return
+
+        new_value = self.str_eval(new_value)
+
+        if param_info.is_bool and type(new_value) is int:
+          new_value = bool(new_value)
+
+        if not param_info.is_valid(new_value):
+          self.error('The type of data you entered ({}) is not allowed with this parameter!'.format(type(new_value).__name__))
+          continue
+
+        if param_info.live:  # stay in live tuning interface
+          self.op_params.put(chosen_key, new_value)
+          self.success('Saved {} with value: {}! (type: {})'.format(chosen_key, new_value, type(new_value).__name__))
+        else:  # else ask to save and break
+          print('\nOld value: {} (type: {})'.format(old_value, type(old_value).__name__))
+          print('New value: {} (type: {})'.format(new_value, type(new_value).__name__))
+          self.prompt('\nDo you want to save this?')
+          if self.input_with_options(['Y', 'n'], 'n')[0] == 0:
+            self.op_params.put(chosen_key, new_value)
+            self.success('Saved!')
+          else:
+            self.info('Not saved!', sleep_time=0)
+          return
+
+  def change_param_list(self, old_value, param_info, chosen_key, parent_list=None, parent_idx=None):
+    while True:
+      self.info('Current value: {} (type: {})'.format(old_value, type(old_value).__name__), sleep_time=0)
+      self.prompt('\nEnter index to edit (0 to {}), or -i to remove index, or +value to append value:'.format(len(old_value) - 1 if old_value else 0))
+
+      append_val = False
+      remove_idx = False
+      choice_idx = input('>> ')
+
+      if choice_idx == '':
+        self.info('Exiting this parameter...', 0.5)
+        return
+
+      if isinstance(choice_idx, str):
+        if choice_idx[0] == '-':
+          remove_idx = True
+        if choice_idx[0] == '+':
+          append_val = True
+
+      if append_val or remove_idx:
+        choice_idx = choice_idx[1::]
+
+      choice_idx = self.str_eval(choice_idx)
+      is_list = isinstance(choice_idx, list)
+
+      if not append_val and not (is_list or (isinstance(choice_idx, int) and choice_idx in range(len(old_value)))):
+        self.error('Must be an integar within list range!')
+        continue
+
+      while True:
+        if append_val or remove_idx or is_list:
+          new_value = choice_idx
+        else:
+          if isinstance(old_value[choice_idx], list):
+            self.change_param_list(old_value[choice_idx], param_info, chosen_key, parent_list=old_value, parent_idx=choice_idx)
+            break
+
+          self.info('Chosen index: {}'.format(choice_idx), sleep_time=0)
+          self.info('Value: {} (type: {})'.format(old_value[choice_idx], type(old_value[choice_idx]).__name__), sleep_time=0)
+          self.prompt('\nEnter your new value:')
+          new_value = input('>> ').strip()
+          new_value = self.str_eval(new_value)
+
+        if new_value == '':
+          self.info('Exiting this list item...', 0.5)
+          break
+
+        if not param_info.is_valid(new_value):
+          self.error('The type of data you entered ({}) is not allowed with this parameter!'.format(type(new_value).__name__))
+          break
+
+        if append_val:
+          old_value.append(new_value)
+        elif remove_idx:
+          del old_value[choice_idx]
+        elif is_list:
+          old_value = new_value
+        else:
+          old_value[choice_idx] = new_value
+
+        if parent_list and parent_idx is not None:
+          parent_list[parent_idx] = old_value
+
+        save_value = parent_list if parent_list else old_value
+        self.op_params.put(chosen_key, save_value)
+        self.success('Saved {} with value: {}! (type: {})'.format(chosen_key, save_value, type(save_value).__name__), end='\n')
+        break
+
+  def cyan(self, msg, end=''):
+    msg = self.str_color(msg, style='cyan')
+    # print(msg, flush=True, end='\n' + end)
+    return msg
+
+  def prompt(self, msg, end=''):
+    msg = self.str_color(msg, style='prompt')
+    print(msg, flush=True, end='\n' + end)
+
+  def info(self, msg, sleep_time=None, end=''):
+    if sleep_time is None:
+      sleep_time = self.sleep_time
+    msg = self.str_color(msg, style='info')
+
+    print(msg, flush=True, end='\n' + end)
+    time.sleep(sleep_time)
+
+  def error(self, msg, sleep_time=None, end='', surround=True):
+    if sleep_time is None:
+      sleep_time = self.sleep_time
+    msg = self.str_color(msg, style='fail', surround=surround)
+
+    print(msg, flush=True, end='\n' + end)
+    time.sleep(sleep_time)
+
+  def success(self, msg, sleep_time=None, end=''):
+    if sleep_time is None:
+      sleep_time = self.sleep_time
+    msg = self.str_color(msg, style='success')
+
+    print(msg, flush=True, end='\n' + end)
+    time.sleep(sleep_time)
+
+  def str_color(self, msg, style, surround=False):
+    if style == 'success':
+      style = COLORS.SUCCESS
+    elif style == 'fail':
+      style = COLORS.FAIL
+    elif style == 'prompt':
+      style = COLORS.PROMPT
+    elif style == 'info':
+      style = COLORS.INFO
+    elif style == 'cyan':
+      style = COLORS.CYAN
+
+    if surround:
+      msg = '{}--------\n{}\n{}--------{}'.format(style, msg, COLORS.ENDC + style, COLORS.ENDC)
+    else:
+      msg = '{}{}{}'.format(style, msg, COLORS.ENDC)
+
+    return msg
+
+  def input_with_options(self, options, default=None):
+    """
+    Takes in a list of options and asks user to make a choice.
+    The most similar option list index is returned along with the similarity percentage from 0 to 1
+    """
+    user_input = input('[{}]: '.format('/'.join(options))).lower().strip()
+    if not user_input:
+      return default, 0.0
+    sims = [self.str_sim(i.lower().strip(), user_input) for i in options]
+    argmax = sims.index(max(sims))
+    return argmax, sims[argmax]
+
+  def str_eval(self, dat):
+    dat = dat.strip()
+    try:
+      dat = ast.literal_eval(dat)
+    except: # noqa E722 pylint: disable=bare-except
+      if dat.lower() == 'none':
+        dat = None
+      elif dat.lower() in ['false', 'f']:
+        dat = False
+      elif dat.lower() in ['true', 't']:  # else, assume string
+        dat = True
+    return dat
+
+  def delete_parameter(self):
+    while True:
+      self.prompt('Enter the name of the parameter to delete:')
+      key = self.str_eval(input('>> '))
+
+      if key == '':
+        return
+      if not isinstance(key, str):
+        self.error('Input must be a string!')
+        continue
+      if key not in self.params:
+        self.error("Parameter doesn't exist!")
+        continue
+
+      value = self.params.get(key)
+      print('Parameter name: {}'.format(key))
+      print('Parameter value: {} (type: {})'.format(value, type(value).__name__))
+      self.prompt('Do you want to delete this?')
+
+      if self.input_with_options(['Y', 'n'], default='n')[0] == 0:
+        self.op_params.delete(key)
+        self.success('Deleted!')
+      else:
+        self.info('Not deleted!')
+      return
+
+  def add_parameter(self):
+    while True:
+      self.prompt('Type the name of your new parameter:')
+      key = self.str_eval(input('>> '))
+
+      if key == '':
+        return
+      if not isinstance(key, str):
+        self.error('Input must be a string!')
+        continue
+
+      self.prompt("Enter the data you'd like to save with this parameter:")
+      value = input('>> ').strip()
+      value = self.str_eval(value)
+
+      print('Parameter name: {}'.format(key))
+      print('Parameter value: {} (type: {})'.format(value, type(value).__name__))
+      self.prompt('Do you want to save this?')
+
+      if self.input_with_options(['Y', 'n'], default='n')[0] == 0:
+        self.op_params.put(key, value)
+        self.success('Saved!')
+      else:
+        self.info('Not saved!')
+      return
+
+  def sort_params(self, kv):
+    return self.get_sort_key(kv[0])
+
+  def get_sort_key(self, k):
+    p = self.op_params.param_info(k)
+
+    if not p.depends_on:
+      return f'{1 if not len(p.children) else 0}{k}'
+    else:
+      s = ''
+      while p.depends_on:
+        s = f'{p.depends_on},{s}'
+        p = self.op_params.param_info(p.depends_on)
+      return f'{0}{s}{k}'
+
+opEdit()

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -1,12 +1,21 @@
 from opendbc.can.packer import CANPacker
 from common.realtime import DT_CTRL
 from selfdrive.car import apply_toyota_steer_torque_limits
-from selfdrive.car.chrysler.chryslercan import create_lkas_hud, create_lkas_command, create_cruise_buttons
-from selfdrive.car.chrysler.values import CAR, RAM_CARS, CarControllerParams
+from selfdrive.car.chrysler.chryslercan import create_lkas_hud, create_lkas_command, create_cruise_buttons, acc_command
+from selfdrive.car.chrysler.values import CAR, RAM_CARS, RAM_DT, RAM_HD, CarControllerParams
+from cereal import car
+from common.conversions import Conversions as CV
+from common.numpy_fast import clip
+from common.op_params import opParams, ACCEL_FACTOR, DECEL_FACTOR
 
+GearShifter = car.CarState.GearShifter
+
+# braking
+BRAKE_CHANGE = 0.06
+ACCEL_MIN = -3.5
 
 class CarController:
-  def __init__(self, dbc_name, CP, VM):
+  def __init__(self, dbc_name, CP, VM, OP=None):
     self.CP = CP
     self.apply_steer_last = 0
     self.frame = 0
@@ -19,24 +28,38 @@ class CarController:
     self.packer = CANPacker(dbc_name)
     self.params = CarControllerParams(CP)
 
+    # long
+    self.last_brake = None
+    self.vehicleMass = CP.mass
+    self.max_gear = None
+    self.last_torque = 0
+    self.spoofspeed = 0
+
+    if OP is None:
+      OP = opParams()
+    self.op_params = OP
+    self.factor = self.op_params.get(ACCEL_FACTOR)
+
+
   def update(self, CC, CS):
     can_sends = []
 
     lkas_active = CC.latActive and self.lkas_control_bit_prev
 
     # cruise buttons
-    if (self.frame - self.last_button_frame)*DT_CTRL > 0.05:
+    if (CS.button_counter != self.last_button_frame):
       das_bus = 2 if self.CP.carFingerprint in RAM_CARS else 0
+      self.last_button_frame = CS.button_counter
+      if self.CP.carFingerprint in RAM_CARS:
+        can_sends.append(create_cruise_buttons(self.packer, CS.button_counter, das_bus, CS.cruise_buttons, cancel=CC.cruiseControl.cancel, resume=CC.cruiseControl.resume))
 
-      # ACC cancellation
-      if CC.cruiseControl.cancel:
-        self.last_button_frame = self.frame
-        can_sends.append(create_cruise_buttons(self.packer, CS.button_counter + 1, das_bus, cancel=True))
+       # ACC cancellation
+      elif CC.cruiseControl.cancel:
+        can_sends.append(create_cruise_buttons(self.packer, CS.button_counter+1, das_bus, CS.cruise_buttons, cancel=True))
 
       # ACC resume from standstill
       elif CC.cruiseControl.resume:
-        self.last_button_frame = self.frame
-        can_sends.append(create_cruise_buttons(self.packer, CS.button_counter + 1, das_bus, resume=True))
+        can_sends.append(create_cruise_buttons(self.packer, CS.button_counter+1, das_bus, CS.cruise_buttons, resume=True))
 
     # HUD alerts
     if self.frame % 25 == 0:
@@ -49,17 +72,22 @@ class CarController:
 
       # TODO: can we make this more sane? why is it different for all the cars?
       lkas_control_bit = self.lkas_control_bit_prev
-      if CS.out.vEgo > self.CP.minSteerSpeed:
+      if self.CP.carFingerprint in RAM_DT:
+        if CS.out.vEgo >= self.CP.minEnableSpeed:
+          lkas_control_bit = True
+        if (self.CP.minEnableSpeed >= 14.5)  and (CS.out.gearShifter != GearShifter.drive) :
+          lkas_control_bit = False
+      elif CS.out.vEgo > self.CP.minSteerSpeed:
         lkas_control_bit = True
       elif self.CP.carFingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
         if CS.out.vEgo < (self.CP.minSteerSpeed - 3.0):
           lkas_control_bit = False
-      elif self.CP.carFingerprint in RAM_CARS:
+      elif self.CP.carFingerprint in RAM_HD:
         if CS.out.vEgo < (self.CP.minSteerSpeed - 0.5):
           lkas_control_bit = False
 
       # EPS faults if LKAS re-enables too quickly
-      lkas_control_bit = lkas_control_bit and (self.frame - self.last_lkas_falling_edge > 200)
+      lkas_control_bit = lkas_control_bit and (self.frame - self.last_lkas_falling_edge > 200) and not CS.out.steerFaultTemporary and not CS.out.steerFaultPermanent
 
       if not lkas_control_bit and self.lkas_control_bit_prev:
         self.last_lkas_falling_edge = self.frame
@@ -74,9 +102,73 @@ class CarController:
 
       can_sends.append(create_lkas_command(self.packer, self.CP, int(apply_steer), lkas_control_bit))
 
+      #LONG
+      das_3_counter = CS.das_3['COUNTER']
+      max_gear = 0
+
+      if not CC.enabled:
+        self.last_brake = None
+      
+      max_gear = 8
+      if CC.actuators.accel <= 0:
+        accel_req = False
+        decel_req = False
+        torque = None
+        decel = self.acc_brake(CC.actuators.accel)
+        max_gear = 6
+        delta_accel = 0
+        self.last_torque = CS.engineTorque
+      else:
+        self.last_brake = None
+        accel_req = True
+        decel_req = False
+        delta_accel = CC.actuators.accel - CS.out.aEgo
+        
+        # adding a factor to the velocity. 1.0 multiplied by the delta_accel assumes that we are telling the formula we want to be x m/s faster than we currently
+        # are 1 second from now. I add the ability to modify this in real time to dial it in better. 
+        # For example if comma is requesting 2.0m/s2 acceleration and we use a 1.0 multiplier, then we are saying in 1 second we want to be traveling 2.0m/s faster. 
+        # if we put a 1.5 multiplier then it becomes 3.0 m/s faster 1 second from now. 
+        if delta_accel < 0: 
+          velocity = clip((self.op_params.get(DECEL_FACTOR) * abs(delta_accel)),  -3.5, 2.0)
+        else:
+          velocity = clip((self.op_params.get(ACCEL_FACTOR) * abs(delta_accel)),  -3.5, 2.0)
+
+        torque = (self.vehicleMass * delta_accel * velocity)  / (.105 *  CS.engineRpm)
+        if CS.engineTorque < 0 and torque > 0:
+          torque +=200 #A truck will idle between 100-200nm So, If torque is very negative we need to get back to positive quickly. 
+        else:
+          torque += CS.engineTorque
+
+        decel = None
+
+      self.last_torque = torque
+
+      can_sends.append(acc_command(self.packer, das_3_counter, CC.enabled,
+                                   accel_req,
+                                   torque,
+                                   max_gear,
+                                   decel_req,
+                                   decel,
+                                   CS.das_3))
+
     self.frame += 1
 
     new_actuators = CC.actuators.copy()
     new_actuators.steer = self.apply_steer_last / self.params.STEER_MAX
 
     return new_actuators, can_sends
+
+  def acc_brake(self, aTarget):
+    brake_target = max(ACCEL_MIN, round(aTarget, 2))
+    if self.last_brake is None:
+      self.last_brake = min(0., brake_target / 2)
+    else:
+      tBrake = brake_target
+      lBrake = self.last_brake
+      if tBrake < lBrake:
+        diff = min(BRAKE_CHANGE, (lBrake - tBrake) / 2)
+        self.last_brake = max(lBrake - diff, tBrake)
+      elif tBrake - lBrake > 0.01:  # don't let up unless it's a big enough jump
+        diff = min(BRAKE_CHANGE, (tBrake - lBrake) / 2)
+        self.last_brake = min(lBrake + diff, tBrake)
+    return self.last_brake

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -15,6 +15,12 @@ class CarState(CarStateBase):
     self.auto_high_beam = 0
     self.button_counter = 0
     self.lkas_car_model = -1
+    self.lkasdisabled = 0
+    self.lkasbuttonprev = 0
+
+    self.engineRpm = None
+    self.torqMin = None
+    self.torqMax = None
 
     if CP.carFingerprint in RAM_CARS:
       self.shifter_values = can_define.dv["Transmission_Status"]["Gear_State"]
@@ -78,6 +84,15 @@ class CarState(CarStateBase):
     ret.cruiseState.nonAdaptive = cp_cruise.vl["DAS_4"]["ACC_STATE"] in (1, 2)  # 1 NormalCCOn and 2 NormalCCSet
     ret.cruiseState.standstill = cp_cruise.vl["DAS_3"]["ACC_STANDSTILL"] == 1
     ret.accFaulted = cp_cruise.vl["DAS_3"]["ACC_FAULTED"] != 0
+    self.das_3 = cp_cruise.vl['DAS_3']
+    self.torqMin = cp_cruise.vl["DAS_3"]["ENGINE_TORQUE_REQUEST"]
+    self.maxgear = cp_cruise.vl["DAS_3"]["GR_MAX_REQ"]
+
+
+    
+    self.torqMax = cp.vl["ECM_TRQ"]["ENGINE_TORQ_MAX"]
+    self.engineRpm = cp.vl["ECM_1"]["ENGINE_RPM"]
+    self.engineTorque = cp.vl["ECM_1"]["ENGINE_TORQUE"]
 
     if self.CP.carFingerprint in RAM_CARS:
       self.auto_high_beam = cp_cam.vl["DAS_6"]['AUTO_HIGH_BEAM_ON']  # Auto High Beam isn't Located in this message on chrysler or jeep currently located in 729 message
@@ -92,7 +107,7 @@ class CarState(CarStateBase):
 
     self.lkas_car_model = cp_cam.vl["DAS_6"]["CAR_MODEL"]
     self.button_counter = cp.vl["CRUISE_BUTTONS"]["COUNTER"]
-
+    self.cruise_buttons = cp.vl["CRUISE_BUTTONS"]
     return ret
 
   @staticmethod
@@ -105,6 +120,21 @@ class CarState(CarStateBase):
       ("COUNTER", "DAS_3"),
       ("ACC_SET_SPEED_KPH", "DAS_4"),
       ("ACC_STATE", "DAS_4"),
+
+      ("ACC_GO", "DAS_3", 0),
+      ("ENGINE_TORQUE_REQUEST", "DAS_3", 0),
+      ("ENGINE_TORQUE_REQUEST_MAX", "DAS_3", 0),
+      ("ACC_DECEL", "DAS_3", 0),
+      ("ACC_DECEL_REQ", "DAS_3", 0),
+      ("ACC_AVAILABLE", "DAS_3", 0),
+      ("DISABLE_FUEL_SHUTOFF", "DAS_3", 0),
+      ("GR_MAX_REQ", "DAS_3", 0),
+      ("STS", "DAS_3", 0),
+      ("COLLISION_BRK_PREP", "DAS_3", 0),
+      ("ACC_BRK_PREP", "DAS_3", 0),
+      ("DISPLAY_REQ", "DAS_3", 0),
+      ("COUNTER", "DAS_3", 0),
+      ("CHECKSUM", "DAS_3", 0),
     ]
     checks = [
       ("DAS_3", 50),
@@ -136,7 +166,20 @@ class CarState(CarStateBase):
       ("COLUMN_TORQUE", "EPS_2"),
       ("EPS_TORQUE_MOTOR", "EPS_2"),
       ("LKAS_STATE", "EPS_2"),
+      ("ACC_Cancel", "CRUISE_BUTTONS"),
+      ("ACC_Distance_Dec", "CRUISE_BUTTONS"),
+      ("ACC_Accel", "CRUISE_BUTTONS"),
+      ("ACC_Decel", "CRUISE_BUTTONS"),
+      ("ACC_Resume", "CRUISE_BUTTONS"),
+      ("Cruise_OnOff", "CRUISE_BUTTONS"),
+      ("ACC_OnOff", "CRUISE_BUTTONS"),
+      ("ACC_Distance_Inc", "CRUISE_BUTTONS"),
       ("COUNTER", "CRUISE_BUTTONS"),
+
+      ("ENGINE_RPM", "ECM_1", 0),
+      ("ENGINE_TORQUE", "ECM_1", 0),
+      ("ENGINE_TORQ_MIN", "ECM_TRQ", 0),
+      ("ENGINE_TORQ_MAX", "ECM_TRQ", 0),
     ]
 
     checks = [
@@ -150,6 +193,8 @@ class CarState(CarStateBase):
       ("STEERING_LEVERS", 10),
       ("ORC_1", 2),
       ("BCM_1", 1),
+      ("ECM_1", 50),
+      ("ECM_TRQ", 50),
     ]
 
     if CP.enableBsm:
@@ -164,11 +209,15 @@ class CarState(CarStateBase):
         ("DASM_FAULT", "EPS_3"),
         ("Vehicle_Speed", "ESP_8"),
         ("Gear_State", "Transmission_Status"),
+        ("LKAS_Button", "Center_Stack_1"),
+        ("LKAS_Button", "Center_Stack_2"),
       ]
       checks += [
         ("ESP_8", 50),
         ("EPS_3", 50),
         ("Transmission_Status", 50),
+        ("Center_Stack_1", 1),
+        ("Center_Stack_2", 1),
       ]
     else:
       signals += [


### PR DESCRIPTION
@adeebshihadeh suggested I submit this as a dirty PR. 

Included is an initial step towards long control for Ram trucks which should roll over to all Chryslers. Chryslers use m/s2 for deceleration, but torque for acceleration. I have left live tuning in to allow quick adjustments while we work towards something acceptable. 

A steer to 0 fix for all Ram DT trucks. If a truck does not allow true steer to 0, we can turn the control bit on over 32mph and leave it on. The only drawback is we have to turn the bit off if the truck ever shifts out of drive. 

The last fix includes eliminating the cruise resume/cancel spamming for Rams. I block the messages to the DASM from the cruise buttons and send them with car controller instead. 
