### PR TITLE
Chrysler: whitelist FPv2 queries

### DIFF
--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -208,7 +208,7 @@ REQUESTS: List[Request] = [
     "chrysler",
     [CHRYSLER_VERSION_REQUEST],
     [CHRYSLER_VERSION_RESPONSE],
-    whitelist_ecus=[Ecu.eps, Ecu.srs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.combinationMeter],
+    whitelist_ecus=[Ecu.eps, Ecu.srs, Ecu.gateway, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.combinationMeter],
     rx_offset=CHRYSLER_RX_OFFSET,
   ),
   Request(

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -208,7 +208,7 @@ REQUESTS: List[Request] = [
     "chrysler",
     [CHRYSLER_VERSION_REQUEST],
     [CHRYSLER_VERSION_RESPONSE],
-    whitelist_ecus=[Ecu.eps, Ecu.srs, Ecu.gateway, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.combinationMeter],
+    whitelist_ecus=[Ecu.esp, Ecu.eps, Ecu.srs, Ecu.gateway, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.combinationMeter],
     rx_offset=CHRYSLER_RX_OFFSET,
   ),
   Request(

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -208,12 +208,14 @@ REQUESTS: List[Request] = [
     "chrysler",
     [CHRYSLER_VERSION_REQUEST],
     [CHRYSLER_VERSION_RESPONSE],
+    whitelist_ecus=[Ecu.eps, Ecu.srs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.combinationMeter],
     rx_offset=CHRYSLER_RX_OFFSET,
   ),
   Request(
     "chrysler",
     [CHRYSLER_VERSION_REQUEST],
     [CHRYSLER_VERSION_RESPONSE],
+    whitelist_ecus=[Ecu.engine, Ecu.transmission],
   ),
   # Ford
   Request(


### PR DESCRIPTION
Slightly speeds up querying as we don't need to time out on ECUs that will never respond. Will also make it easy to add the second engine query

```
ecu: fwdCamera, rx offsets: {-640}
ecu: combinationMeter, rx offsets: {-640}
ecu: eps, rx offsets: {-640}
ecu: srs, rx offsets: {-640}
ecu: esp, rx offsets: {-640}
ecu: transmission, rx offsets: {8}
ecu: engine, rx offsets: {8}
ecu: fwdRadar, rx offsets: {-640}

checked 72 dongles, segments: 6208, platform segments: {'CHRYSLER PACIFICA HYBRID 2017': 198, 'CHRYSLER PACIFICA 2018': 555, 'CHRYSLER PACIFICA HYBRID 2019': 1820, 'JEEP GRAND CHEROKEE V6 2018': 1186, 'JEEP GRAND CHEROKEE 2019': 316, 'CHRYSLER PACIFICA HYBRID 2018': 1303, 'RAM 1500 5TH GEN': 450, 'CHRYSLER PACIFICA 2020': 380}
```