### PR TITLE
Pin GitHub Actions 📌

### DIFF
--- a/.github/workflows/badges.yaml
+++ b/.github/workflows/badges.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'commaai/openpilot'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup

--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -25,7 +25,7 @@ jobs:
       IMAGE_NAME: openpilot-prebuilt
     steps:
     - name: Wait for green check mark
-      uses: lewagon/wait-on-check-action@e2558238c09778af25867eb5de5a3ce4bbae3dcd
+      uses: lewagon/wait-on-check-action@v1.1.2
       with:
         ref: master
         wait-interval: 30

--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -25,13 +25,13 @@ jobs:
       IMAGE_NAME: openpilot-prebuilt
     steps:
     - name: Wait for green check mark
-      uses: lewagon/wait-on-check-action@v1.1.2
+      uses: lewagon/wait-on-check-action@e2558238c09778af25867eb5de5a3ce4bbae3dcd # pin@v1.1.2
       with:
         ref: master
         wait-interval: 30
         running-workflow-name: 'build prebuilt'
         check-regexp: ^((?!.*(build master-ci).*).)*$
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - name: Build Docker image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         wait-interval: 30
         running-workflow-name: 'build master-ci'
         check-regexp: ^((?!.*(build prebuilt).*).)*$
-    - uses: actions/checkout@v3actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'commaai/openpilot'
     steps:
     - name: Wait for green check mark
-      uses: lewagon/wait-on-check-action@e2558238c09778af25867eb5de5a3ce4bbae3dcd
+      uses: lewagon/wait-on-check-action@v1.1.2
       with:
         ref: master
         wait-interval: 30

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,13 +12,13 @@ jobs:
     if: github.repository == 'commaai/openpilot'
     steps:
     - name: Wait for green check mark
-      uses: lewagon/wait-on-check-action@v1.1.2
+      uses: lewagon/wait-on-check-action@e2558238c09778af25867eb5de5a3ce4bbae3dcd # pin@v1.1.2
       with:
         ref: master
         wait-interval: 30
         running-workflow-name: 'build master-ci'
         check-regexp: ^((?!.*(build prebuilt).*).)*$
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -34,7 +34,7 @@ jobs:
     env:
       STRIPPED_DIR: /tmp/releasepilot
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         fetch-depth: 0
         submodules: true
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -85,7 +85,7 @@ jobs:
   #  runs-on: macos-latest
   #  timeout-minutes: 60
   #  steps:
-  #  - uses: actions/checkout@v3
+  #  - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
   #    with:
   #      submodules: true
   #  - name: Determine pre-existing Homebrew packages
@@ -144,7 +144,7 @@ jobs:
     env:
       IMAGE_NAME: openpilotwebcamci
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -167,7 +167,7 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
     needs: static_analysis # hack to ensure slow tests run first since this and static_analysis are fast
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - name: Build Docker image
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - name: Build Docker image
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -315,7 +315,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -344,7 +344,7 @@ jobs:
       matrix:
         job: [0, 1, 2, 3, 4]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 50
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - name: Build docker container
@@ -391,7 +391,7 @@ jobs:
     timeout-minutes: 50
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
         with:
           submodules: true
           ref: ${{ github.event.pull_request.base.ref }}
@@ -400,7 +400,7 @@ jobs:
         run: |
           ${{ env.RUN }} "scons -j$(nproc) && python selfdrive/debug/dump_car_info.py --path /tmp/openpilot_cache/base_car_info"
           sudo chown -R $USER:$USER ${{ github.workspace }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
         with:
           submodules: true
       - name: Save car docs diff

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -96,7 +96,7 @@ jobs:
   #      echo 'EOF' >> $GITHUB_ENV
   #  - name: Cache dependencies
   #    id: dependency-cache
-  #    uses: actions/cache@v2
+  #    uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # pin@v2
   #    with:
   #      path: |
   #        ~/.pyenv
@@ -252,7 +252,7 @@ jobs:
                         ./system/camerad/test/ae_gray_test && \
                         coverage xml"
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
 
   process_replay:
     name: process replay
@@ -265,7 +265,7 @@ jobs:
     - uses: ./.github/workflows/setup
     - name: Cache test routes
       id: dependency-cache
-      uses: actions/cache@v3
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3
       with:
         path: /tmp/comma_download_cache
         key: proc-replay-${{ hashFiles('.github/workflows/selfdrive_tests.yaml', 'selfdrive/test/process_replay/ref_commit') }}
@@ -277,7 +277,7 @@ jobs:
     - name: Print diff
       if: always()
       run: cat selfdrive/test/process_replay/diff.txt
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
       if: always()
       continue-on-error: true
       with:
@@ -289,7 +289,7 @@ jobs:
         ${{ env.RUN }} "scons -j$(nproc) && \
                         CI=1 AZURE_TOKEN='$AZURE_TOKEN' python selfdrive/test/process_replay/test_processes.py -j$(nproc) --upload-only"
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
 
   model_replay_onnx:
     name: model replay onnx
@@ -327,8 +327,8 @@ jobs:
                         coverage run ./test_longitudinal.py && \
                         coverage xml"
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
-    - uses: actions/upload-artifact@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+    - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
       if: always()
       continue-on-error: true
       with:
@@ -350,7 +350,7 @@ jobs:
     - uses: ./.github/workflows/setup
     - name: Cache test routes
       id: dependency-cache
-      uses: actions/cache@v3.0.8
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3.0.8
       with:
         path: /tmp/comma_download_cache
         key: car_models-${{ hashFiles('selfdrive/car/tests/test_models.py', 'selfdrive/car/tests/routes.py') }}-${{ matrix.job }}
@@ -364,7 +364,7 @@ jobs:
         NUM_JOBS: 5
         JOB_ID: ${{ matrix.job }}
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
 
   docs:
     name: build docs
@@ -412,14 +412,14 @@ jobs:
           echo "::set-output name=diff::$output"
       - name: Find comment
         if: ${{ env.AZURE_TOKEN != '' }}
-        uses: peter-evans/find-comment@v2.0.0
+        uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d # pin@v2.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: This PR makes changes to
       - name: Update comment
         if: ${{ steps.save_diff.outputs.diff != '' && env.AZURE_TOKEN != '' }}
-        uses: peter-evans/create-or-update-comment@v2.0.0
+        uses: peter-evans/create-or-update-comment@c9fcb64660bc90ec1cc535646af190c992007c32 # pin@v2.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -427,7 +427,7 @@ jobs:
           edit-mode: replace
       - name: Delete comment
         if: ${{ steps.fc.outputs.comment-id != '' && steps.save_diff.outputs.diff == '' && env.AZURE_TOKEN != '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # pin@v6
         with:
           script: |
             github.rest.issues.deleteComment({

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -350,7 +350,7 @@ jobs:
     - uses: ./.github/workflows/setup
     - name: Cache test routes
       id: dependency-cache
-      uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+      uses: actions/cache@v3.0.8
       with:
         path: /tmp/comma_download_cache
         key: car_models-${{ hashFiles('selfdrive/car/tests/test_models.py', 'selfdrive/car/tests/routes.py') }}-${{ matrix.job }}
@@ -412,14 +412,14 @@ jobs:
           echo "::set-output name=diff::$output"
       - name: Find comment
         if: ${{ env.AZURE_TOKEN != '' }}
-        uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d
+        uses: peter-evans/find-comment@v2.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: This PR makes changes to
       - name: Update comment
         if: ${{ steps.save_diff.outputs.diff != '' && env.AZURE_TOKEN != '' }}
-        uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
+        uses: peter-evans/create-or-update-comment@v2.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - name: Build Docker image
@@ -47,7 +47,7 @@ jobs:
       IMAGE_NAME: openpilot-sim
     if: github.repository == 'commaai/openpilot'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       with:
         submodules: true
     - name: Pull LFS


### PR DESCRIPTION
# Pin GitHub Actions 📌

This pull request pins all GitHub Actions to an exact SHA. The reasoning for this is to prevent supply chain security attacks in 3rd party Action dependencies

## Learn More 📚 

You can learn more about Actions security hardening at the following links:

- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
- https://github.com/mheap/pin-github-action

---

Let me know if you have any questions and hopefully this PR helps to lock down all 3rd party Action dependencies 🔒 