### PR TITLE
ui: fix possible memory leak in EGL

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -59,7 +59,11 @@ protected:
 
 #ifdef QCOM2
   EGLDisplay egl_display;
-  std::map<int, EGLImageKHR> egl_images;
+  struct {
+    EGLImageKHR handle;
+    int fd;
+  } EGLState;
+  std::map<int, EGLState> egl_images;
 #endif
 
   std::string stream_name;


### PR DESCRIPTION
The EGL implementation no longer take ownership of the fd.https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import.txt:

>     3. Does ownership of the file descriptor pass to the EGL library?

    ANSWER: No, EGL does not take ownership of the file descriptors. It is the
    responsibility of the application to close the file descriptors on success
    and failure.
