### PR TITLE
loggerd: copy&clear re.q before recursive calling handle_encoder_msg

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -84,10 +84,11 @@ int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct 
       re.marked_ready_to_rotate = false;
       // we are in this segment now, process any queued messages before this one
       if (!re.q.empty()) {
-        for (auto &qmsg: re.q) {
+        auto q = re.q;
+        re.q.clear();
+        for (auto &qmsg: q) {
           bytes_count += handle_encoder_msg(s, qmsg, name, re);
         }
-        re.q.clear();
       }
     }
 


### PR DESCRIPTION
Fix potential memory leaks and undefined behavior.
 
`handle_encoder_msg` may modify the `re.q` by pushing  message to it again in rare case. this will cause memory leaks and undefined behavior to iterate over the re.q(size changed in loop)

