### PR TITLE
Hyundai: Add missing safety param to separate CAN-FD cruise button messages

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -299,6 +299,7 @@ class CarInterface(CarInterfaceBase):
         # non-HDA2
         if 0x1cf not in fingerprint[4]:
           ret.flags |= HyundaiFlags.CANFD_ALT_BUTTONS.value
+          ret.safetyConfigs[1].safetyParam |= Panda.FLAG_HYUNDAI_CANFD_ALT_BUTTONS
     else:
       ret.enableBsm = 0x58b in fingerprint[0]
 


### PR DESCRIPTION
Somehow we missed the `FLAG_HYUNDAI_CANFD_ALT_BUTTONS` flag to separate `0x1cf` and `0x1aa` in panda safety in the Tucson Hybrid PR, and caused some non-HDA or HDA1 CAN-FD cars to not properly perform RX checks in panda safety.
- https://github.com/commaai/openpilot/pull/25276