### PR TITLE
Hyundai: enforce ACC main state with controls allowed

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -134,7 +134,7 @@ class CarController:
         stopping = actuators.longControlState == LongCtrlState.stopping
         set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_MPH if CS.clu11["CF_Clu_SPEED_UNIT"] == 1 else CV.MS_TO_KPH)
         can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
-                                                        hud_control.leadVisible, set_speed_in_units, stopping, CS.out.gasPressed))
+                                                        hud_control.leadVisible, set_speed_in_units, stopping, CS.out.gasPressed, CS.main_mode))
         self.accel = accel
 
       # 20 Hz LFA MFA message

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -74,6 +74,7 @@ class CarState(CarStateBase):
       ret.cruiseState.available = cp.vl["TCS13"]["ACCEnable"] == 0
       ret.cruiseState.enabled = cp.vl["TCS13"]["ACC_REQ"] == 1
       ret.cruiseState.standstill = False
+      self.main_mode = cp.vl["EMS16"]["CRUISE_LAMP_M"] == 1
     else:
       ret.cruiseState.available = cp_cruise.vl["SCC11"]["MainMode_ACC"] == 1
       ret.cruiseState.enabled = cp_cruise.vl["SCC12"]["ACCMode"] != 0
@@ -304,7 +305,6 @@ class CarState(CarStateBase):
       ]
       checks += [
         ("EMS12", 100),
-        ("EMS16", 100),
       ]
 
     if CP.carFingerprint in FEATURES["use_cluster_gears"]:
@@ -319,6 +319,12 @@ class CarState(CarStateBase):
     else:
       signals.append(("CF_Lvr_Gear", "LVR12"))
       checks.append(("LVR12", 100))
+
+    if CP.openpilotLongitudinalControl:
+      signals.append(("CRUISE_LAMP_M", "EMS16"))
+
+    if CP.openpilotLongitudinalControl or CP.carFingerprint not in (HYBRID_CAR | EV_CAR):
+      checks.append(("EMS16", 100))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 0)
 

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -80,11 +80,11 @@ def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 
-def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_speed, stopping, gas_pressed):
+def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_speed, stopping, gas_pressed, main_mode):
   commands = []
 
   scc11_values = {
-    "MainMode_ACC": 1,
+    "MainMode_ACC": 1 if main_mode else 0,
     "TauGapSet": 4,
     "VSetDis": set_speed if enabled else 0,
     "AliveCounterACC": idx % 0x10,


### PR DESCRIPTION
Enforce ACC main state with stock/openpilot longitudinal control in openpilot and panda safety.

Stock ACC: `SCC11|MainMode_ACC`

openpilot ACC: `EMS16|CRUISE_LAMP_M`
- Available on all currently supported openpilot longitudinal HKG cars
- Sync with ACC MAIN button press
- Will be copied and sent with `SCC11|MainMode_ACC` to the car when ACC MAIN is pressed

**Requires**
- https://github.com/commaai/panda/pull/1054