### PR TITLE
Remove sudo from bootlog cmd, nvme-cli common requirement

### DIFF
--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -26,7 +26,7 @@ static kj::Array<capnp::word> build_boot_log() {
 
   // Gather output of commands
   std::vector<std::string> bootlog_commands = {
-    "[ -e /dev/nvme0 ] && sudo nvme smart-log --output-format=json /dev/nvme0",
+    "[ -e /dev/nvme0 ] && nvme smart-log --output-format=json /dev/nvme0",
     "[ -x \"$(command -v journalctl)\" ] && journalctl",
   };
 

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -66,7 +66,8 @@ function install_ubuntu_common_requirements() {
     libqt5x11extras5-dev \
     libreadline-dev \
     libdw1 \
-    valgrind
+    valgrind \
+    nvme-cli
 }
 
 # Install Ubuntu 22.04 LTS packages


### PR DESCRIPTION
This fixes issue:
- #25625 

and adds nvme-cli to common requirements, since the command ```nvme``` is used.

**This works for the simulator, but not sure if removing ```sudo``` from the bootlog command is possible for the comma hardware, so needs validation.**