### PR TITLE
Add nvme-cli as common requirement

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -66,7 +66,8 @@ function install_ubuntu_common_requirements() {
     libqt5x11extras5-dev \
     libreadline-dev \
     libdw1 \
-    valgrind
+    valgrind \
+    nvme-cli
 }
 
 # Install Ubuntu 22.04 LTS packages


### PR DESCRIPTION
Since ```nvme``` command is used in: [bootlog.cc](https://github.com/commaai/openpilot/blob/4bb399ba3c13953680522707bba662527fa771b7/selfdrive/loggerd/bootlog.cc#L29)