### PR TITLE
Add nvme bootlog command only when device is TICI

### DIFF
--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -26,9 +26,12 @@ static kj::Array<capnp::word> build_boot_log() {
 
   // Gather output of commands
   std::vector<std::string> bootlog_commands = {
-    "[ -e /dev/nvme0 ] && nvme smart-log --output-format=json /dev/nvme0",
     "[ -x \"$(command -v journalctl)\" ] && journalctl",
   };
+
+  if (Hardware::TICI()) {
+    bootlog_commands.push_back("[ -e /dev/nvme0 ] && sudo nvme smart-log --output-format=json /dev/nvme0");
+  }
 
   auto commands = boot.initCommands().initEntries(bootlog_commands.size());
   for (int j = 0; j < bootlog_commands.size(); j++) {

--- a/selfdrive/loggerd/bootlog.cc
+++ b/selfdrive/loggerd/bootlog.cc
@@ -26,7 +26,7 @@ static kj::Array<capnp::word> build_boot_log() {
 
   // Gather output of commands
   std::vector<std::string> bootlog_commands = {
-    "[ -e /dev/nvme0 ] && sudo nvme smart-log --output-format=json /dev/nvme0",
+    "[ -e /dev/nvme0 ] && nvme smart-log --output-format=json /dev/nvme0",
     "[ -x \"$(command -v journalctl)\" ] && journalctl",
   };
 


### PR DESCRIPTION
This fixes issue:
- #25625 

**This works for the simulator, but not sure if removing ```sudo``` from the bootlog command is possible for the comma hardware, so needs validation.**