### PR TITLE
Optima 2019: set LKAS icon correctly

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -15,6 +15,7 @@ def process_hud_alert(enabled, fingerprint, hud_control):
   sys_warning = (hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw))
 
   # initialize to no line visible
+  # TODO: this is not accurate for all cars
   sys_state = 1
   if hud_control.leftLaneVisible and hud_control.rightLaneVisible or sys_warning:  # HUD alert only display when LKAS status is active
     sys_state = 3 if enabled or sys_warning else 4

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -37,7 +37,7 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # Note: the warning is hidden while the blinkers are on
     values["CF_Lkas_SysWarning"] = 4 if sys_warning else 0
 
-  # Likely cars without the ability to show individual lane lines in the dash
+  # Likely cars lacking the ability to show individual lane lines in the dash
   elif car_fingerprint in (CAR.KIA_OPTIMA,):
     # SysWarning 4 = keep hands on wheel + beep
     values["CF_Lkas_SysWarning"] = 4 if sys_warning else 0

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -7,17 +7,6 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
                   lkas11, sys_warning, sys_state, enabled,
                   left_lane, right_lane,
                   left_lane_depart, right_lane_depart):
-  with open("/data/sysstate", "r") as f:
-    sys_state = int(f.read().strip() or 0)
-  with open("/data/active_mode", "r") as f:
-    active_mode = int(f.read().strip() or 0)
-  with open("/data/ldws_usm", "r") as f:
-    ldws_usm = int(f.read().strip() or 0)
-  with open("/data/fcw_usm", "r") as f:
-    fcw_usm = int(f.read().strip() or 0)
-  with open("/data/syswarn", "r") as f:
-    syswarn = int(f.read().strip() or 0)
-
   values = lkas11
   values["CF_Lkas_LdwsSysState"] = sys_state
   values["CF_Lkas_SysWarning"] = 3 if sys_warning else 0
@@ -31,8 +20,8 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
                          CAR.IONIQ_EV_2020, CAR.IONIQ_PHEV, CAR.KIA_SELTOS, CAR.ELANTRA_2021, CAR.GENESIS_G70_2020,
                          CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_EV, CAR.KONA_HEV, CAR.KONA_EV_2022,
                          CAR.SANTA_FE_2022, CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.SANTA_FE_PHEV_2022):
-    values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)  # active_mode
-    values["CF_Lkas_LdwsOpt_USM"] = 2  # ldws_usm
+    values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)
+    values["CF_Lkas_LdwsOpt_USM"] = 2
 
     # FcwOpt_USM 5 = Orange blinking car + lanes
     # FcwOpt_USM 4 = Orange car + lanes
@@ -40,13 +29,13 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # FcwOpt_USM 2 = Green car + lanes
     # FcwOpt_USM 1 = White car + lanes
     # FcwOpt_USM 0 = No car + lanes
-    values["CF_Lkas_FcwOpt_USM"] = 2 if enabled else 1  # fcw_usm
+    values["CF_Lkas_FcwOpt_USM"] = 2 if enabled else 1
 
     # SysWarning 4 = keep hands on wheel
     # SysWarning 5 = keep hands on wheel (red)
     # SysWarning 6 = keep hands on wheel (red) + beep
     # Note: the warning is hidden while the blinkers are on
-    values["CF_Lkas_SysWarning"] = 4 if sys_warning else 0  # syswarn
+    values["CF_Lkas_SysWarning"] = 4 if sys_warning else 0
 
   # Likely cars without the ability to show individual lane lines in the dash
   elif car_fingerprint in (CAR.KIA_OPTIMA,):

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -47,7 +47,7 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # SysState 3 = green car + lanes, green steering wheel
     # SysState 4 = green car + lanes
     values["CF_Lkas_LdwsSysState"] = 3 if enabled else 1
-    values["CF_Lkas_LdwsOpt_USM"] = 2  # 2 shows LKAS icon
+    values["CF_Lkas_LdwsOpt_USM"] = 2  # non-2 changes above SysState definition
 
     # these have no effect
     values["CF_Lkas_LdwsActivemode"] = 0

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -19,7 +19,8 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
   if car_fingerprint in (CAR.SONATA, CAR.PALISADE, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_HEV_2021, CAR.SANTA_FE,
                          CAR.IONIQ_EV_2020, CAR.IONIQ_PHEV, CAR.KIA_SELTOS, CAR.ELANTRA_2021, CAR.GENESIS_G70_2020,
                          CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_EV, CAR.KONA_HEV, CAR.KONA_EV_2022,
-                         CAR.SANTA_FE_2022, CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.SANTA_FE_PHEV_2022):
+                         CAR.SANTA_FE_2022, CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.SANTA_FE_PHEV_2022,
+                         CAR.KIA_OPTIMA):
     values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)
     values["CF_Lkas_LdwsOpt_USM"] = 2
 
@@ -41,8 +42,6 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # This field is actually LdwsActivemode
     # Genesis and Optima fault when forwarding while engaged
     values["CF_Lkas_LdwsActivemode"] = 2
-  elif car_fingerprint == CAR.KIA_OPTIMA:
-    values["CF_Lkas_LdwsActivemode"] = 0
 
   dat = packer.make_can_msg("LKAS11", 0, values)[2]
 

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -7,6 +7,17 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
                   lkas11, sys_warning, sys_state, enabled,
                   left_lane, right_lane,
                   left_lane_depart, right_lane_depart):
+  with open("/data/sysstate", "r") as f:
+    sys_state = int(f.read().strip() or 0)
+  with open("/data/active_mode", "r") as f:
+    active_mode = int(f.read().strip() or 0)
+  with open("/data/ldws_usm", "r") as f:
+    ldws_usm = int(f.read().strip() or 0)
+  with open("/data/fcw_usm", "r") as f:
+    fcw_usm = int(f.read().strip() or 0)
+  with open("/data/syswarn", "r") as f:
+    syswarn = int(f.read().strip() or 0)
+
   values = lkas11
   values["CF_Lkas_LdwsSysState"] = sys_state
   values["CF_Lkas_SysWarning"] = 3 if sys_warning else 0
@@ -21,8 +32,8 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
                          CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_EV, CAR.KONA_HEV, CAR.KONA_EV_2022,
                          CAR.SANTA_FE_2022, CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.SANTA_FE_PHEV_2022,
                          CAR.KIA_OPTIMA):
-    values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)
-    values["CF_Lkas_LdwsOpt_USM"] = 2
+    values["CF_Lkas_LdwsActivemode"] = active_mode
+    values["CF_Lkas_LdwsOpt_USM"] = ldws_usm
 
     # FcwOpt_USM 5 = Orange blinking car + lanes
     # FcwOpt_USM 4 = Orange car + lanes
@@ -30,13 +41,13 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # FcwOpt_USM 2 = Green car + lanes
     # FcwOpt_USM 1 = White car + lanes
     # FcwOpt_USM 0 = No car + lanes
-    values["CF_Lkas_FcwOpt_USM"] = 2 if enabled else 1
+    values["CF_Lkas_FcwOpt_USM"] = fcw_usm
 
     # SysWarning 4 = keep hands on wheel
     # SysWarning 5 = keep hands on wheel (red)
     # SysWarning 6 = keep hands on wheel (red) + beep
     # Note: the warning is hidden while the blinkers are on
-    values["CF_Lkas_SysWarning"] = 4 if sys_warning else 0
+    values["CF_Lkas_SysWarning"] = syswarn
 
   elif car_fingerprint == CAR.HYUNDAI_GENESIS:
     # This field is actually LdwsActivemode

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -58,7 +58,7 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # SysState 3 = green car + lanes, green steering wheel
     # SysState 4 = green car + lanes
     values["CF_Lkas_LdwsSysState"] = 3 if enabled else 1
-    values["CF_Lkas_LdwsOpt_USM"] = 1  # needs to be non-zero to show LKAS icon
+    values["CF_Lkas_LdwsOpt_USM"] = 2  # 2 shows LKAS icon
 
     # these have no effect
     values["CF_Lkas_LdwsActivemode"] = 0

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -30,10 +30,9 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
   if car_fingerprint in (CAR.SONATA, CAR.PALISADE, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_HEV_2021, CAR.SANTA_FE,
                          CAR.IONIQ_EV_2020, CAR.IONIQ_PHEV, CAR.KIA_SELTOS, CAR.ELANTRA_2021, CAR.GENESIS_G70_2020,
                          CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_EV, CAR.KONA_HEV, CAR.KONA_EV_2022,
-                         CAR.SANTA_FE_2022, CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.SANTA_FE_PHEV_2022,
-                         CAR.KIA_OPTIMA):
-    values["CF_Lkas_LdwsActivemode"] = active_mode
-    values["CF_Lkas_LdwsOpt_USM"] = ldws_usm
+                         CAR.SANTA_FE_2022, CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.SANTA_FE_PHEV_2022):
+    values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)  # active_mode
+    values["CF_Lkas_LdwsOpt_USM"] = 2  # ldws_usm
 
     # FcwOpt_USM 5 = Orange blinking car + lanes
     # FcwOpt_USM 4 = Orange car + lanes
@@ -41,13 +40,29 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # FcwOpt_USM 2 = Green car + lanes
     # FcwOpt_USM 1 = White car + lanes
     # FcwOpt_USM 0 = No car + lanes
-    values["CF_Lkas_FcwOpt_USM"] = fcw_usm
+    values["CF_Lkas_FcwOpt_USM"] = 2 if enabled else 0  # fcw_usm
 
     # SysWarning 4 = keep hands on wheel
     # SysWarning 5 = keep hands on wheel (red)
     # SysWarning 6 = keep hands on wheel (red) + beep
     # Note: the warning is hidden while the blinkers are on
-    values["CF_Lkas_SysWarning"] = syswarn
+    values["CF_Lkas_SysWarning"] = 4 if sys_warning else 0  # syswarn
+
+  # Likely cars without the ability to show individual lane lines in the dash
+  elif car_fingerprint in (CAR.KIA_OPTIMA,):
+    # SysWarning 4 = keep hands on wheel + beep
+    values["CF_Lkas_SysWarning"] = 4 if sys_warning else 0
+
+    # SysState 0 = no icons
+    # SysState 1-2 = white car + lanes
+    # SysState 3 = green car + lanes, green steering wheel
+    # SysState 4 = green car + lanes
+    values["CF_Lkas_LdwsSysState"] = 3 if enabled else 1
+    values["CF_Lkas_LdwsOpt_USM"] = 1  # needs to be non-zero to show LKAS icon
+
+    # these have no effect
+    values["CF_Lkas_LdwsActivemode"] = 0
+    values["CF_Lkas_FcwOpt_USM"] = 0
 
   elif car_fingerprint == CAR.HYUNDAI_GENESIS:
     # This field is actually LdwsActivemode

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -40,7 +40,7 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
     # FcwOpt_USM 2 = Green car + lanes
     # FcwOpt_USM 1 = White car + lanes
     # FcwOpt_USM 0 = No car + lanes
-    values["CF_Lkas_FcwOpt_USM"] = 2 if enabled else 0  # fcw_usm
+    values["CF_Lkas_FcwOpt_USM"] = 2 if enabled else 1  # fcw_usm
 
     # SysWarning 4 = keep hands on wheel
     # SysWarning 5 = keep hands on wheel (red)


### PR DESCRIPTION
I think we assume the cars to have the ability to show individual lane lines, which we do through `CF_Lkas_LdwsSysState` (as well as for showing alerts? this doesn't seem right), however on the Optima, a sys state of 4 for disabled is to show the lines (but Optima chooses green for the color).

Another difference is the `CF_Lkas_SysWarning` signal, it only does anything with `4`, but it's audible, not silent.

Another difference is `CF_Lkas_LdwsOpt_USM` which doesn't seem to do anything, besides if you set it to 0, `CF_Lkas_LdwsSysState` won't work to show any LKAS icon at all.

Another difference is `CF_Lkas_LdwsActivemode` and `CF_Lkas_FcwOpt_USM` don't seem to do anything.