### PR TITLE
hyundai: consistent start from stop

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -133,6 +133,13 @@ class CarController:
         accel = clip(accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
 
         stopping = actuators.longControlState == LongCtrlState.stopping
+        starting_from_stop = actuators.longControlState == LongCtrlState.pid and accel > 0.01 and CS.brake_control_active and CS.out.standstill
+        if starting_from_stop:
+          # command big accel until brakes release to start quickly from a stop
+          # ESC seems to integrate accel command based on upper jerk limit
+          # and the longer you sit stopped the more accel you have to request to get going
+          accel = 2.0
+          jerk = -12.7
         set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_MPH if CS.clu11["CF_Clu_SPEED_UNIT"] == 1 else CV.MS_TO_KPH)
         can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
                                                         hud_control.leadVisible, set_speed_in_units, stopping, CS.out.gasPressed))

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -56,7 +56,7 @@ class CarState(CarStateBase):
     ret.vEgoRaw = (ret.wheelSpeeds.fl + ret.wheelSpeeds.fr + ret.wheelSpeeds.rl + ret.wheelSpeeds.rr) / 4.
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
 
-    ret.standstill = ret.vEgoRaw < 0.1
+    ret.standstill = cp.vl["TCS13"]["StandStill"] == 1
 
     ret.steeringAngleDeg = cp.vl["SAS11"]["SAS_Angle"]
     ret.steeringRateDeg = cp.vl["SAS11"]["SAS_Speed"]
@@ -127,6 +127,7 @@ class CarState(CarStateBase):
     self.clu11 = copy.copy(cp.vl["CLU11"])
     self.steer_state = cp.vl["MDPS12"]["CF_Mdps_ToiActive"]  # 0 NOT ACTIVE, 1 ACTIVE
     self.brake_error = cp.vl["TCS13"]["ACCEnable"] != 0  # 0 ACC CONTROL ENABLED, 1-3 ACC CONTROL DISABLED
+    self.brake_control_active = cp.vl["TCS13"]["DCEnable"] == 1
     self.prev_cruise_buttons = self.cruise_buttons[-1]
     self.cruise_buttons.extend(cp.vl_all["CLU11"]["CF_Clu_CruiseSwState"])
     self.main_buttons.extend(cp.vl_all["CLU11"]["CF_Clu_CruiseSwMain"])
@@ -229,6 +230,7 @@ class CarState(CarStateBase):
 
       ("ACCEnable", "TCS13"),
       ("ACC_REQ", "TCS13"),
+      ("DCEnable", "TCS13"),
       ("DriverBraking", "TCS13"),
       ("StandStill", "TCS13"),
       ("PBRAKE_ACT", "TCS13"),

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -102,11 +102,11 @@ def create_acc_commands(packer, enabled, accel, jerk, idx, lead_visible, set_spe
     "TauGapSet": 4,
     "VSetDis": set_speed if enabled else 0,
     "AliveCounterACC": idx % 0x10,
-    "ObjValid": 0,  # TODO: these two bits may allow for better longitudinal control
-    "ACC_ObjStatus": 0,
+    "ObjValid": 1, # close lead makes controls tighter
+    "ACC_ObjStatus": 1, # close lead makes controls tighter
     "ACC_ObjLatPos": 0,
     "ACC_ObjRelSpd": 0,
-    "ACC_ObjDist": 0,
+    "ACC_ObjDist": 1, # close lead makes controls tighter
   }
   commands.append(packer.make_can_msg("SCC11", 0, scc11_values))
 


### PR DESCRIPTION
there is still a lot of room for improvement (can probably be made twice as fast) but as a starting point this makes it consistent

further improvements:
* make vEgoStarting 0
* request more accel with higher upper jerk limit when planner wants higher jerk

here is an example running this branch after sitting stopped for a long time (the longer you sit stopped the worse the problem is)
![start-from-stop-1-zoomed-out](https://user-images.githubusercontent.com/4112046/188503973-708da806-2c10-42d8-9aa8-f5bb0ba4d12f.png)
![start-from-stop-1-zoomed-in](https://user-images.githubusercontent.com/4112046/188504002-f3f391d3-3786-439c-b809-e6fe49476e5c.png)

