### PR TITLE
More conservative lead policy in e2e long mode

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -254,7 +254,7 @@ class LongitudinalMpc:
       constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST]
     elif self.mode == 'blended':
       cost_weights = [0., 0.2, 0.25, 1.0, 0.0, 1.0]
-      constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, 5.0]
+      constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, 200.0]
     elif self.mode == 'e2e':
       cost_weights = [0., 0.2, 0.25, 1., 0.0, .1]
       constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, 0.0]
@@ -366,6 +366,7 @@ class LongitudinalMpc:
 
     self.params[:,2] = np.min(x_obstacles, axis=1)
     self.params[:,3] = np.copy(self.prev_a)
+    self.params[:,4] = T_FOLLOW
 
     self.run()
     if (np.any(lead_xv_0[:,0] - self.x_sol[:,0] < CRASH_DISTANCE) and

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -91,7 +91,9 @@ def gen_long_model():
   a_max = SX.sym('a_max')
   x_obstacle = SX.sym('x_obstacle')
   prev_a = SX.sym('prev_a')
-  model.p = vertcat(a_min, a_max, x_obstacle, prev_a)
+  lead_t_follow = SX.sym('lead_t_follow')
+  lead_danger_factor = SX.sym('lead_danger_factor')
+  model.p = vertcat(a_min, a_max, x_obstacle, prev_a, lead_t_follow, lead_danger_factor)
 
   # dynamics model
   f_expl = vertcat(v_ego, a_ego, j_ego)
@@ -157,7 +159,7 @@ def gen_long_ocp():
 
   x0 = np.zeros(X_DIM)
   ocp.constraints.x0 = x0
-  ocp.parameter_values = np.array([-1.2, 1.2, 0.0, 0.0])
+  ocp.parameter_values = np.array([-1.2, 1.2, 0.0, 0.0, T_FOLLOW, LEAD_DANGER_FACTOR])
 
   # We put all constraint cost weights to 0 and only set them at runtime
   cost_weights = np.zeros(CONSTR_DIM)

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -254,7 +254,7 @@ class LongitudinalMpc:
       constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST]
     elif self.mode == 'blended':
       cost_weights = [0., 0.2, 0.25, 1.0, 0.0, 1.0]
-      constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, 200.0]
+      constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST]
     elif self.mode == 'e2e':
       cost_weights = [0., 0.2, 0.25, 1., 0.0, .1]
       constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, 0.0]

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -254,7 +254,7 @@ class LongitudinalMpc:
       constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST]
     elif self.mode == 'blended':
       cost_weights = [0., 0.2, 0.25, 1.0, 0.0, 1.0]
-      constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST]
+      constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, 50.0]
     elif self.mode == 'e2e':
       cost_weights = [0., 0.2, 0.25, 1., 0.0, .1]
       constraint_cost_weights = [LIMIT_COST, LIMIT_COST, LIMIT_COST, 0.0]

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -351,7 +351,8 @@ class LongitudinalMpc:
 
       x_and_cruise = np.column_stack([x, cruise_target])
       x = np.min(x_and_cruise, axis=1)
-      self.source = 'e2e'
+      
+      self.source = 'e2e' if x_and_cruise[0,0] < x_and_cruise[0,1] else 'cruise'
 
     else:
       raise NotImplementedError(f'Planner mode {self.mode} not recognized in planner update')
@@ -374,6 +375,17 @@ class LongitudinalMpc:
       self.crash_cnt += 1
     else:
       self.crash_cnt = 0
+
+    # Check if it got within lead comfort range
+    # TODO This should be done cleaner
+    if self.mode == 'blended':
+      if any((lead_0_obstacle - get_safe_obstacle_distance(self.x_sol[:,1], T_FOLLOW))- self.x_sol[:,0] < 0.0):
+        self.source = 'lead0'
+      if any((lead_1_obstacle - get_safe_obstacle_distance(self.x_sol[:,1], T_FOLLOW))- self.x_sol[:,0] < 0.0) and \
+         (lead_1_obstacle[0] - lead_0_obstacle[0]):
+        self.source = 'lead1'
+
+      
 
   def update_with_xva(self, x, v, a):
     self.params[:,0] = -10.

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -45,7 +45,7 @@ def limit_accel_in_turns(v_ego, angle_steers, a_target, CP):
   return [a_target[0], min(a_target[1], a_x_allowed)]
 
 
-class Planner:
+class LongitudinalPlanner:
   def __init__(self, CP, init_v=0.0, init_a=0.0):
     self.CP = CP
     params = Params()

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -126,7 +126,8 @@ class LongitudinalPlanner:
     self.j_desired_trajectory = np.interp(T_IDXS[:CONTROL_N], T_IDXS_MPC[:-1], self.mpc.j_solution)
 
     # TODO counter is only needed because radar is glitchy, remove once radar is gone
-    self.fcw = self.mpc.crash_cnt > 5
+    # TODO write fcw in e2e_long mode
+    self.fcw = self.mpc.mode == 'acc' and self.mpc.crash_cnt > 5
     if self.fcw:
       cloudlog.info("FCW triggered")
 

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -126,8 +126,7 @@ class Planner:
     self.j_desired_trajectory = np.interp(T_IDXS[:CONTROL_N], T_IDXS_MPC[:-1], self.mpc.j_solution)
 
     # TODO counter is only needed because radar is glitchy, remove once radar is gone
-    # TODO write fcw in e2e_long mode
-    self.fcw = self.mpc.mode == 'acc' and self.mpc.crash_cnt > 5
+    self.fcw = self.mpc.crash_cnt > 5
     if self.fcw:
       cloudlog.info("FCW triggered")
 

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -3,7 +3,7 @@ from cereal import car
 from common.params import Params
 from common.realtime import Priority, config_realtime_process
 from system.swaglog import cloudlog
-from selfdrive.controls.lib.longitudinal_planner import Planner
+from selfdrive.controls.lib.longitudinal_planner import LongitudinalPlanner
 from selfdrive.controls.lib.lateral_planner import LateralPlanner
 import cereal.messaging as messaging
 
@@ -16,7 +16,7 @@ def plannerd_thread(sm=None, pm=None):
   CP = car.CarParams.from_bytes(params.get("CarParams", block=True))
   cloudlog.info("plannerd got CarParams: %s", CP.carName)
 
-  longitudinal_planner = Planner(CP)
+  longitudinal_planner = LongitudinalPlanner(CP)
   lateral_planner = LateralPlanner(CP)
 
   if sm is None:

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -6,11 +6,11 @@ from common.params import Params
 
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 
-def run_cruise_simulation(cruise, t_end=100., e2e=False):
+def run_cruise_simulation(cruise, t_end=20.):
   man = Maneuver(
     '',
     duration=t_end,
-    initial_speed=float(0.),
+    initial_speed=max(cruise - 1., 0.0),
     lead_relevancy=True,
     initial_distance_lead=100,
     cruise_values=[cruise],

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 
-def run_cruise_simulation(cruise, t_end=100.):
+def run_cruise_simulation(cruise, t_end=100., e2e=False):
   man = Maneuver(
     '',
     duration=t_end,
@@ -13,6 +13,7 @@ def run_cruise_simulation(cruise, t_end=100.):
     cruise_values=[cruise],
     prob_lead_values=[0.0],
     breakpoints=[0.],
+    e2e=False,
   )
   valid, output = man.evaluate()
   assert valid
@@ -21,12 +22,13 @@ def run_cruise_simulation(cruise, t_end=100.):
 
 class TestCruiseSpeed(unittest.TestCase):
   def test_cruise_speed(self):
-    for speed in np.arange(5, 40, 5):
-      print(f'Testing {speed} m/s')
-      cruise_speed = float(speed)
+    for e2e in [False, True]:
+      for speed in np.arange(5, 40, 5):
+        print(f'Testing {speed} m/s')
+        cruise_speed = float(speed)
 
-      simulation_steady_state = run_cruise_simulation(cruise_speed)
-      self.assertAlmostEqual(simulation_steady_state, cruise_speed, delta=.01, msg=f'Did not reach {speed} m/s')
+        simulation_steady_state = run_cruise_simulation(cruise_speed, e2e=e2e)
+        self.assertAlmostEqual(simulation_steady_state, cruise_speed, delta=.01, msg=f'Did not reach {speed} m/s')
 
 
 if __name__ == "__main__":

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 import unittest
 import numpy as np
+from common.params import Params
+
+
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 
 def run_cruise_simulation(cruise, t_end=100., e2e=False):
@@ -13,7 +16,6 @@ def run_cruise_simulation(cruise, t_end=100., e2e=False):
     cruise_values=[cruise],
     prob_lead_values=[0.0],
     breakpoints=[0.],
-    e2e=False,
   )
   valid, output = man.evaluate()
   assert valid
@@ -22,12 +24,14 @@ def run_cruise_simulation(cruise, t_end=100., e2e=False):
 
 class TestCruiseSpeed(unittest.TestCase):
   def test_cruise_speed(self):
+    params = Params()
     for e2e in [False, True]:
+      params.put_bool("EndToEndLong", e2e)
       for speed in np.arange(5, 40, 5):
         print(f'Testing {speed} m/s')
         cruise_speed = float(speed)
 
-        simulation_steady_state = run_cruise_simulation(cruise_speed, e2e=e2e)
+        simulation_steady_state = run_cruise_simulation(cruise_speed)
         self.assertAlmostEqual(simulation_steady_state, cruise_speed, delta=.01, msg=f'Did not reach {speed} m/s')
 
 

--- a/selfdrive/controls/tests/test_following_distance.py
+++ b/selfdrive/controls/tests/test_following_distance.py
@@ -5,7 +5,7 @@ import numpy as np
 from selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import desired_follow_distance
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 
-def run_following_distance_simulation(v_lead, t_end=100.0):
+def run_following_distance_simulation(v_lead, t_end=100.0, e2e=False):
   man = Maneuver(
     '',
     duration=t_end,
@@ -14,6 +14,7 @@ def run_following_distance_simulation(v_lead, t_end=100.0):
     initial_distance_lead=100,
     speed_lead_values=[v_lead],
     breakpoints=[0.],
+    e2e=e2e
   )
   valid, output = man.evaluate()
   assert valid
@@ -22,14 +23,15 @@ def run_following_distance_simulation(v_lead, t_end=100.0):
 
 class TestFollowingDistance(unittest.TestCase):
   def test_following_distance(self):
-    for speed in np.arange(0, 40, 5):
-      print(f'Testing {speed} m/s')
-      v_lead = float(speed)
+    for e2e in [False, True]:
+      for speed in np.arange(0, 40, 5):
+        print(f'Testing {speed} m/s')
+        v_lead = float(speed)
 
-      simulation_steady_state = run_following_distance_simulation(v_lead)
-      correct_steady_state = desired_follow_distance(v_lead, v_lead)
+        simulation_steady_state = run_following_distance_simulation(v_lead, e2e=e2e)
+        correct_steady_state = desired_follow_distance(v_lead, v_lead)
 
-      self.assertAlmostEqual(simulation_steady_state, correct_steady_state, delta=(correct_steady_state*.1 + .5))
+        self.assertAlmostEqual(simulation_steady_state, correct_steady_state, delta=(correct_steady_state*.1 + .5))
 
 
 if __name__ == "__main__":

--- a/selfdrive/controls/tests/test_following_distance.py
+++ b/selfdrive/controls/tests/test_following_distance.py
@@ -33,8 +33,8 @@ class TestFollowingDistance(unittest.TestCase):
         v_lead = float(speed)
         simulation_steady_state = run_following_distance_simulation(v_lead)
         correct_steady_state = desired_follow_distance(v_lead, v_lead)
-
-        self.assertAlmostEqual(simulation_steady_state, correct_steady_state, delta=(correct_steady_state*.1 + .5))
+        err_ratio = 0.2 if e2e else 0.1
+        self.assertAlmostEqual(simulation_steady_state, correct_steady_state, delta=(err_ratio * correct_steady_state + .5))
 
 
 if __name__ == "__main__":

--- a/selfdrive/controls/tests/test_following_distance.py
+++ b/selfdrive/controls/tests/test_following_distance.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import unittest
 import numpy as np
+from common.params import Params
+
 
 from selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import desired_follow_distance
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
@@ -23,12 +25,13 @@ def run_following_distance_simulation(v_lead, t_end=100.0, e2e=False):
 
 class TestFollowingDistance(unittest.TestCase):
   def test_following_distance(self):
+    params = Params()
     for e2e in [False, True]:
+      params.put_bool("EndToEndLong", e2e)
       for speed in np.arange(0, 40, 5):
         print(f'Testing {speed} m/s')
         v_lead = float(speed)
-
-        simulation_steady_state = run_following_distance_simulation(v_lead, e2e=e2e)
+        simulation_steady_state = run_following_distance_simulation(v_lead)
         correct_steady_state = desired_follow_distance(v_lead, v_lead)
 
         self.assertAlmostEqual(simulation_steady_state, correct_steady_state, delta=(correct_steady_state*.1 + .5))

--- a/selfdrive/test/longitudinal_maneuvers/maneuver.py
+++ b/selfdrive/test/longitudinal_maneuvers/maneuver.py
@@ -17,6 +17,7 @@ class Maneuver():
     self.only_lead2 = kwargs.get("only_lead2", False)
     self.only_radar = kwargs.get("only_radar", False)
     self.ensure_start = kwargs.get("ensure_start", False)
+    self.e2e = kwargs.get("e2e", False)
 
     self.duration = duration
     self.title = title
@@ -27,7 +28,8 @@ class Maneuver():
       speed=self.speed,
       distance_lead=self.distance_lead,
       only_lead2=self.only_lead2,
-      only_radar=self.only_radar
+      only_radar=self.only_radar,
+      e2e=self.e2e,
     )
 
     valid = True

--- a/selfdrive/test/longitudinal_maneuvers/maneuver.py
+++ b/selfdrive/test/longitudinal_maneuvers/maneuver.py
@@ -17,7 +17,6 @@ class Maneuver():
     self.only_lead2 = kwargs.get("only_lead2", False)
     self.only_radar = kwargs.get("only_radar", False)
     self.ensure_start = kwargs.get("ensure_start", False)
-    self.e2e = kwargs.get("e2e", False)
 
     self.duration = duration
     self.title = title
@@ -29,7 +28,6 @@ class Maneuver():
       distance_lead=self.distance_lead,
       only_lead2=self.only_lead2,
       only_radar=self.only_radar,
-      e2e=self.e2e,
     )
 
     valid = True

--- a/selfdrive/test/longitudinal_maneuvers/maneuver.py
+++ b/selfdrive/test/longitudinal_maneuvers/maneuver.py
@@ -54,7 +54,7 @@ class Maneuver():
         valid = False
 
       if self.ensure_start and log['v_rel'] > 0 and log['speeds'][-1] <= 0.1:
-        print('Planner not starting!')
+        print('LongitudinalPlanner not starting!')
         valid = False
 
     print("maneuver end", valid)

--- a/selfdrive/test/longitudinal_maneuvers/plant.py
+++ b/selfdrive/test/longitudinal_maneuvers/plant.py
@@ -90,11 +90,14 @@ class Plant():
       radar.radarState.leadOne = lead
     radar.radarState.leadTwo = lead
 
+    # Simulate model predicting slightly faster speed
+    # this is to ensure lead policy is effective when model
+    # does not predict slowdown in e2e mode
     position = log.ModelDataV2.XYZTData.new_message()
-    position.x = [float(x) for x in (self.speed + 1.0) * np.array(T_IDXS)]
+    position.x = [float(x) for x in (self.speed + 0.5) * np.array(T_IDXS)]
     model.modelV2.position = position
     velocity = log.ModelDataV2.XYZTData.new_message()
-    velocity.x = [float(x) for x in (self.speed + 1.0) * np.ones_like(T_IDXS)]
+    velocity.x = [float(x) for x in (self.speed + 0.5) * np.ones_like(T_IDXS)]
     model.modelV2.velocity = velocity
     acceleration = log.ModelDataV2.XYZTData.new_message()
     acceleration.x = [float(x) for x in np.zeros_like(T_IDXS)]

--- a/selfdrive/test/longitudinal_maneuvers/plant.py
+++ b/selfdrive/test/longitudinal_maneuvers/plant.py
@@ -7,7 +7,7 @@ import cereal.messaging as messaging
 from common.realtime import Ratekeeper, DT_MDL
 from selfdrive.controls.lib.longcontrol import LongCtrlState
 from selfdrive.modeld.constants import T_IDXS
-from selfdrive.controls.lib.longitudinal_planner import Planner
+from selfdrive.controls.lib.longitudinal_planner import LongitudinalPlanner
 
 
 class Plant():
@@ -45,7 +45,7 @@ class Plant():
     from selfdrive.car.honda.values import CAR
     from selfdrive.car.honda.interface import CarInterface
 
-    self.planner = Planner(CarInterface.get_params(CAR.CIVIC), init_v=self.speed)
+    self.planner = LongitudinalPlanner(CarInterface.get_params(CAR.CIVIC), init_v=self.speed)
 
   def current_time(self):
     return float(self.rk.frame) / self.rate

--- a/selfdrive/test/longitudinal_maneuvers/plant.py
+++ b/selfdrive/test/longitudinal_maneuvers/plant.py
@@ -14,7 +14,7 @@ class Plant():
   messaging_initialized = False
 
   def __init__(self, lead_relevancy=False, speed=0.0, distance_lead=2.0,
-               only_lead2=False, only_radar=False, e2e=False):
+               only_lead2=False, only_radar=False):
     self.rate = 1. / DT_MDL
 
     if not Plant.messaging_initialized:
@@ -44,10 +44,6 @@ class Plant():
 
     from selfdrive.car.honda.values import CAR
     from selfdrive.car.honda.interface import CarInterface
-    from common.params import Params
-
-    params = Params()
-    params.put_bool("EndToEndLong", e2e)
 
     self.planner = Planner(CarInterface.get_params(CAR.CIVIC), init_v=self.speed)
 

--- a/selfdrive/test/longitudinal_maneuvers/test_longitudinal.py
+++ b/selfdrive/test/longitudinal_maneuvers/test_longitudinal.py
@@ -140,16 +140,23 @@ class LongitudinalControl(unittest.TestCase):
 
 def run_maneuver_worker(k):
   def run(self):
+    params = Params()
+
     man = maneuvers[k]
-    print(man.title)
+    params.put_bool("EndToEndLong", True)
+    print(man.title, ' in e2e mode')
+    valid, _ = man.evaluate()
+    self.assertTrue(valid, msg=man.title)
+    params.put_bool("EndToEndLong", False)
+    print(man.title, ' in acc mode')
     valid, _ = man.evaluate()
     self.assertTrue(valid, msg=man.title)
   return run
 
-
 for k in range(len(maneuvers)):
   setattr(LongitudinalControl, f"test_longitudinal_maneuvers_{k+1}",
           run_maneuver_worker(k))
+
 
 if __name__ == "__main__":
   unittest.main(failfast=True)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
