### PR TITLE
third party: add -Wno-unqualified-std-cast-call to fix json11 build

### DIFF
--- a/third_party/SConscript
+++ b/third_party/SConscript
@@ -1,6 +1,6 @@
 Import('env')
 
-env.Library('json11', ['json11/json11.cpp'])
+env.Library('json11', ['json11/json11.cpp'], CCFLAGS=env['CCFLAGS'] + ['-Wno-unqualified-std-cast-call'])
 env.Append(CPPPATH=[Dir('json11')])
 
 env.Library('kaitai', ['kaitai/kaitaistream.cpp'], CPPDEFINES=['KS_STR_ENCODING_NONE'])


### PR DESCRIPTION


**Description** 

On Ubuntu 20.04, scons fails to build after a fresh openpilot install and running $ tools/ubuntu_setup.sh

<details>
<summary>Error</summary>

```
$ cd openpilot && pipenv shell
$ scons -u -j$(nproc) --no-cache
scons: Reading SConscript files ...
Git commit hash for gitversion.h: 04aeb30c
scons: done reading SConscript files.
scons: Building targets ...
clang++ -o third_party/json11/json11.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -Ithird_party/json11 third_party/json11/json11.cpp
clang++ -o cereal/messaging/messaging_pyx.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include cereal/messaging/messaging_pyx.cpp
clang++ -o cereal/visionipc/visionipc_pyx.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include cereal/visionipc/visionipc_pyx.cpp
clang++ -o common/clock.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include common/clock.cpp
clang++ -o common/kalman/simple_kalman_impl.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include common/kalman/simple_kalman_impl.cpp
clang++ -o common/params_pyx.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include common/params_pyx.cpp
clang++ -o common/transformations/transformations.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include common/transformations/transformations.cpp
clang++ -o opendbc/can/packer_pyx.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include opendbc/can/packer_pyx.cpp
clang++ -o opendbc/can/parser_pyx.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/curl/include -Ithird_party/libgralloc/include -Ithird_party/android_frameworks_native/include -Ithird_party/android_hardware_libhardware/include -Ithird_party/android_system_core/include -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -I/home/yuma/.pyenv/versions/3.8.10/include/python3.8 -I/home/yuma/.local/share/virtualenvs/openpilot_build-7Hm_3GI3/lib/python3.8/site-packages/numpy/core/include opendbc/can/parser_pyx.cpp
third_party/json11/json11.cpp:201:54: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit JsonString(string &&value)      : Value(move(value)) {}
                                                     ^
                                                     std::
third_party/json11/json11.cpp:209:58: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit JsonArray(Json::array &&value)      : Value(move(value)) {}
                                                         ^
                                                         std::
third_party/json11/json11.cpp:217:60: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit JsonObject(Json::object &&value)      : Value(move(value)) {}
                                                           ^
                                                           std::
third_party/json11/json11.cpp:259:72: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
Json::Json(string &&value)             : m_ptr(make_shared<JsonString>(move(value))) {}
                                                                       ^
                                                                       std::
third_party/json11/json11.cpp:262:71: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
Json::Json(Json::array &&values)       : m_ptr(make_shared<JsonArray>(move(values))) {}
                                                                      ^
                                                                      std::
third_party/json11/json11.cpp:264:72: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
Json::Json(Json::object &&values)      : m_ptr(make_shared<JsonObject>(move(values))) {}
                                                                       ^
                                                                       std::
third_party/json11/json11.cpp:358:21: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
        return fail(move(msg), Json());
                    ^
                    std::
third_party/json11/json11.cpp:154:46: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit Value(T &&value)      : m_value(move(value)) {}
                                             ^
                                             std::
third_party/json11/json11.cpp:201:48: note: in instantiation of member function 'json11::Value<json11::Json::STRING, std::basic_string<char>>::Value' requested here
    explicit JsonString(string &&value)      : Value(move(value)) {}
                                               ^
third_party/json11/json11.cpp:154:46: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit Value(T &&value)      : m_value(move(value)) {}
                                             ^
                                             std::
third_party/json11/json11.cpp:209:52: note: in instantiation of member function 'json11::Value<json11::Json::ARRAY, std::vector<json11::Json>>::Value' requested here
    explicit JsonArray(Json::array &&value)      : Value(move(value)) {}
                                                   ^
third_party/json11/json11.cpp:154:46: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit Value(T &&value)      : m_value(move(value)) {}
                                             ^
                                             std::
third_party/json11/json11.cpp:217:54: note: in instantiation of member function 'json11::Value<json11::Json::OBJECT, std::map<std::basic_string<char>, json11::Json>>::Value' requested here
    explicit JsonObject(Json::object &&value)      : Value(move(value)) {}
                                                     ^
third_party/json11/json11.cpp:154:46: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit Value(T &&value)      : m_value(move(value)) {}
                                             ^
                                             std::
third_party/json11/json11.cpp:222:18: note: in instantiation of member function 'json11::Value<json11::Json::NUL, json11::NullStruct>::Value' requested here
    JsonNull() : Value({}) {}
                 ^
arm-none-eabi-gcc -o panda/board/bootstub-pedal.o -c -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -T/home/yuma/work/openpilot_build/panda/board/stm32fx/stm32fx_flash.ld -std=gnu11 -mcpu=cortex-m3 -msoft-float -DSTM32F2 -DSTM32F205xx -O2 -DPEDAL -DALLOW_DEBUG -Ipanda/board/stm32fx/inc -Ipanda/board/stm32h7/inc -Ipanda -Ipanda/board panda/board/bootstub.c
arm-none-eabi-gcc -o panda/board/bootstub-pedal_usb.o -c -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -T/home/yuma/work/openpilot_build/panda/board/stm32fx/stm32fx_flash.ld -std=gnu11 -mcpu=cortex-m3 -msoft-float -DSTM32F2 -DSTM32F205xx -O2 -DPEDAL -DPEDAL_USB -DALLOW_DEBUG -Ipanda/board/stm32fx/inc -Ipanda/board/stm32h7/inc -Ipanda -Ipanda/board panda/board/bootstub.c
arm-none-eabi-gcc -o panda/board/main-panda.o -c -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -T/home/yuma/work/openpilot_build/panda/board/stm32fx/stm32fx_flash.ld -std=gnu11 -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Os -g -DPANDA -DALLOW_DEBUG -Ipanda/board/stm32fx/inc -Ipanda/board/stm32h7/inc -Ipanda -Ipanda/board panda/board/main.c
arm-none-eabi-gcc -o panda/board/main-panda_h7.o -c -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -T/home/yuma/work/openpilot_build/panda/board/stm32h7/stm32h7x5_flash.ld -std=gnu11 -mcpu=cortex-m7 -mhard-float -DSTM32H7 -DSTM32H725xx -mfpu=fpv5-d16 -fsingle-precision-constant -Os -g -DPANDA -DALLOW_DEBUG -Ipanda/board/stm32fx/inc -Ipanda/board/stm32h7/inc -Ipanda -Ipanda/board panda/board/main.c
11 errors generated.
arm-none-eabi-gcc -o panda/board/main-pedal.o -c -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -T/home/yuma/work/openpilot_build/panda/board/stm32fx/stm32fx_flash.ld -std=gnu11 -mcpu=cortex-m3 -msoft-float -DSTM32F2 -DSTM32F205xx -O2 -DPEDAL -DALLOW_DEBUG -Ipanda/board/stm32fx/inc -Ipanda/board/stm32h7/inc -Ipanda -Ipanda/board panda/board/pedal/main.c
arm-none-eabi-gcc -o panda/board/main-pedal_usb.o -c -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -T/home/yuma/work/openpilot_build/panda/board/stm32fx/stm32fx_flash.ld -std=gnu11 -mcpu=cortex-m3 -msoft-float -DSTM32F2 -DSTM32F205xx -O2 -DPEDAL -DPEDAL_USB -DALLOW_DEBUG -Ipanda/board/stm32fx/inc -Ipanda/board/stm32h7/inc -Ipanda -Ipanda/board panda/board/pedal/main.c
arm-none-eabi-gcc -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -T/home/yuma/work/openpilot_build/panda/board/stm32fx/stm32fx_flash.ld -std=gnu11 -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Os -g -DPANDA -DALLOW_DEBUG -o panda/board/obj/startup_panda.o -c panda/board/stm32fx/startup_stm32f413xx.s
scons: *** [third_party/json11/json11.o] Error 1
scons: building terminated because of errors.

```
</details>

An excerpt of the error is shown below.

```bash
third_party/json11/json11.cpp:209:58: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    explicit JsonArray(Json::array &&value)      : Value(move(value)) {}
                                                         ^
                                                         std::
```

This problem can be solved by adding std:: to all variables that are being warned, or by adding a compile option to hide the warning.

Since the former is a significant change, I addressed this issue by adding a compile option `-Wno-unqualified-std-cast-call`.


I think the error will occur depending on the version of clang++.
Here is my clang++ version.

```bash
$ clang++ --version
Ubuntu clang version 16.0.0-++20220905052907+91d8324366f4-1~exp1~20220905173003.370
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

**Verification**

After making the changes, we ran the build with scons and verified that the build was successful.

