### PR TITLE
CAN-FD HKG: query pt bus for fwdRadar

### DIFF
--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -138,6 +138,15 @@ REQUESTS: List[Request] = [
     [HYUNDAI_VERSION_REQUEST_MULTI],
     [HYUNDAI_VERSION_RESPONSE],
   ),
+  # CAN-FD Hyundai
+  # FIXME: querying fwdRadar on OBD bus can be spotty, query on pt bus instead
+  Request(
+    "hyundai",
+    [HYUNDAI_VERSION_REQUEST_LONG],
+    [HYUNDAI_VERSION_RESPONSE],
+    whitelist_ecus=[Ecu.fwdRadar],
+    bus=4,
+  ),
   # Honda
   Request(
     "honda",


### PR DESCRIPTION
When our EV6 fails to fingerprint (and other HKG CAN-FD cars like Ioniq 5 - `534e3360c3936247|2022-09-06--07-52-05`), it is always missing the `fwdRadar` ECU. When checking the can data, you can see that it skips an iso-tp frame on bus 1 near the end of the message, causing `IsoTpMessage` to throw away the response.

However, on bus 4/6, we aren't missing this CAN message from 0x7d8 (each block is a `can` service packet):

```python
rxaddr=2008, txaddr=0x7d0, bus=1, 72961027157, b'% 1.00 1'
rxaddr=2008, txaddr=0x7d0, bus=4, 72961027157, b'% 1.00 1'
rxaddr=2008, txaddr=0x7d0, bus=6, 72961027157, b'% 1.00 1'
rxaddr=2008, txaddr=0x7d0, bus=5, 72961027157, b'% 1.00 1'
rxaddr=2008, txaddr=0x7d0, bus=4, 72961027157, b'&.01 991'
rxaddr=2008, txaddr=0x7d0, bus=6, 72961027157, b'&.01 991'
rxaddr=2008, txaddr=0x7d0, bus=5, 72961027157, b'&.01 991'

rxaddr=2008, txaddr=0x7d0, bus=1, 72971549605, b'&.01 991'

rxaddr=2008, txaddr=0x7d0, bus=4, 72983373199, b"'10-CV00"
rxaddr=2008, txaddr=0x7d0, bus=6, 72983373199, b"'10-CV00"
rxaddr=2008, txaddr=0x7d0, bus=4, 72983373199, b'(0      '  # <-- should be next rxdata to complete FW version on bus 1
rxaddr=2008, txaddr=0x7d0, bus=6, 72983373199, b'(0      '
rxaddr=2008, txaddr=0x7d0, bus=5, 72983373199, b"'10-CV00"

rxaddr=2008, txaddr=0x7d0, bus=1, 72989958928, b"'10-CV00"
rxaddr=2008, txaddr=0x7d0, bus=4, 72989958928, b')   \xaa\xaa\xaa\xaa'
rxaddr=2008, txaddr=0x7d0, bus=6, 72989958928, b')   \xaa\xaa\xaa\xaa'
rxaddr=2008, txaddr=0x7d0, bus=5, 72989958928, b')   \xaa\xaa\xaa\xaa'

rxaddr=2008, txaddr=0x7d0, bus=1, 73000815751, b')   \xaa\xaa\xaa\xaa'  # but instead we skip it and go on to the next frame?
```