### PR TITLE
ui/map: Hide error box if no errors 

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -173,10 +173,13 @@ void MapWindow::updateState(const UIState &s) {
     return;
   }
 
-  loaded_once = loaded_once || m_map->isFullyLoaded();
   if (!loaded_once) {
-    map_instructions->showError(tr("Map Loading"));
-    return;
+    if ((loaded_once = m_map->isFullyLoaded()) == true) {
+      map_instructions->noError();
+    } else {
+      map_instructions->showError(tr("Map Loading"));
+      return;
+    }
   }
 
   initLayers();
@@ -455,7 +458,11 @@ void MapInstructions::showError(QString error_text) {
 }
 
 void MapInstructions::noError() {
-  error = false;
+  if (error) {
+    error = false;
+    distance->setText("");
+    hide();
+  }
 }
 
 void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruction) {

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -340,7 +340,7 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
+        <location filename="../qt/maps/map.cc" line="+628"/>
         <source>eta</source>
         <translation>予定到着時間</translation>
     </message>
@@ -368,7 +368,7 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
+        <location line="-241"/>
         <source> km</source>
         <translation> ｷﾛﾒｰﾄﾙ</translation>
     </message>
@@ -440,12 +440,12 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
+        <location filename="../qt/maps/map.cc" line="-258"/>
         <source>Map Loading</source>
         <translation>マップを読み込んでいます</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+18"/>
         <source>Waiting for GPS</source>
         <translation>GPS信号を探しています</translation>
     </message>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -340,7 +340,7 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
+        <location filename="../qt/maps/map.cc" line="+628"/>
         <source>eta</source>
         <translation>도착</translation>
     </message>
@@ -368,7 +368,7 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
+        <location line="-241"/>
         <source> km</source>
         <translation> km</translation>
     </message>
@@ -440,12 +440,12 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
+        <location filename="../qt/maps/map.cc" line="-258"/>
         <source>Map Loading</source>
         <translation>지도 로딩</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+18"/>
         <source>Waiting for GPS</source>
         <translation>GPS를 기다리는 중</translation>
     </message>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -341,7 +341,7 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
+        <location filename="../qt/maps/map.cc" line="+628"/>
         <source>eta</source>
         <translation>eta</translation>
     </message>
@@ -369,7 +369,7 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
+        <location line="-241"/>
         <source> km</source>
         <translation> km</translation>
     </message>
@@ -441,12 +441,12 @@ trabalho definido</translation>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
+        <location filename="../qt/maps/map.cc" line="-258"/>
         <source>Map Loading</source>
         <translation>Carregando Mapa</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+18"/>
         <source>Waiting for GPS</source>
         <translation>Esperando por GPS</translation>
     </message>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -340,7 +340,7 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
+        <location filename="../qt/maps/map.cc" line="+628"/>
         <source>eta</source>
         <translation>埃塔</translation>
     </message>
@@ -368,7 +368,7 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
+        <location line="-241"/>
         <source> km</source>
         <translation> km</translation>
     </message>
@@ -438,12 +438,12 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
+        <location filename="../qt/maps/map.cc" line="-258"/>
         <source>Map Loading</source>
         <translation>地图加载中</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+18"/>
         <source>Waiting for GPS</source>
         <translation>等待 GPS</translation>
     </message>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -340,7 +340,7 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
+        <location filename="../qt/maps/map.cc" line="+628"/>
         <source>eta</source>
         <translation>抵達</translation>
     </message>
@@ -368,7 +368,7 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
+        <location line="-241"/>
         <source> km</source>
         <translation> km</translation>
     </message>
@@ -440,12 +440,12 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
+        <location filename="../qt/maps/map.cc" line="-258"/>
         <source>Map Loading</source>
         <translation>地圖加載中</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+18"/>
         <source>Waiting for GPS</source>
         <translation>等待 GPS</translation>
     </message>


### PR DESCRIPTION
the "Map Loading" error or the  "Waiting for GPS" error will always be displayed on the screen if updateDistance is not called due to invalid navInstruction.You can run replay --demo to see this issue in the ui.


