### PR TITLE
map_helpers: pass parameters by const reference

### DIFF
--- a/selfdrive/ui/qt/maps/map_helpers.cc
+++ b/selfdrive/ui/qt/maps/map_helpers.cc
@@ -56,7 +56,7 @@ QMapbox::CoordinatesCollections model_to_collection(
   return collections;
 }
 
-QMapbox::CoordinatesCollections coordinate_to_collection(QMapbox::Coordinate c) {
+QMapbox::CoordinatesCollections coordinate_to_collection(const QMapbox::Coordinate &c) {
   QMapbox::Coordinates coordinates;
   coordinates.push_back(c);
 
@@ -85,7 +85,7 @@ QMapbox::CoordinatesCollections capnp_coordinate_list_to_collection(const capnp:
 
 }
 
-QMapbox::CoordinatesCollections coordinate_list_to_collection(QList<QGeoCoordinate> coordinate_list) {
+QMapbox::CoordinatesCollections coordinate_list_to_collection(const QList<QGeoCoordinate> &coordinate_list) {
   QMapbox::Coordinates coordinates;
 
   for (auto &c : coordinate_list) {
@@ -143,7 +143,7 @@ QList<QGeoCoordinate> polyline_to_coordinate_list(const QString &polylineString)
   return path;
 }
 
-std::optional<QMapbox::Coordinate> coordinate_from_param(std::string param) {
+std::optional<QMapbox::Coordinate> coordinate_from_param(const std::string &param) {
   QString json_str = QString::fromStdString(Params().get(param));
   if (json_str.isEmpty()) return {};
 

--- a/selfdrive/ui/qt/maps/map_helpers.h
+++ b/selfdrive/ui/qt/maps/map_helpers.h
@@ -21,10 +21,10 @@ QMapbox::CoordinatesCollections model_to_collection(
   const cereal::LiveLocationKalman::Measurement::Reader &calibratedOrientationECEF,
   const cereal::LiveLocationKalman::Measurement::Reader &positionECEF,
   const cereal::ModelDataV2::XYZTData::Reader &line);
-QMapbox::CoordinatesCollections coordinate_to_collection(QMapbox::Coordinate c);
+QMapbox::CoordinatesCollections coordinate_to_collection(const QMapbox::Coordinate &c);
 QMapbox::CoordinatesCollections capnp_coordinate_list_to_collection(const capnp::List<cereal::NavRoute::Coordinate>::Reader &coordinate_list);
-QMapbox::CoordinatesCollections coordinate_list_to_collection(QList<QGeoCoordinate> coordinate_list);
+QMapbox::CoordinatesCollections coordinate_list_to_collection(const QList<QGeoCoordinate> &coordinate_list);
 QList<QGeoCoordinate> polyline_to_coordinate_list(const QString &polylineString);
 
-std::optional<QMapbox::Coordinate> coordinate_from_param(std::string param);
+std::optional<QMapbox::Coordinate> coordinate_from_param(const std::string &param);
 double angle_difference(double angle1, double angle2);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
