### PR TITLE
ui: fix networking crash

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -124,10 +124,10 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   connect(back, &QPushButton::clicked, [=]() { emit backPress(); });
   main_layout->addWidget(back, 0, Qt::AlignLeft);
 
-//  ListWidget *list = new ListWidget(this);
+  ListWidget *list = new ListWidget(this);
   // Enable tethering layout
   tetheringToggle = new ToggleControl(tr("Enable Tethering"), "", "", wifi->isTetheringEnabled());
-//  list->addItem(tetheringToggle);
+  list->addItem(tetheringToggle);
   QObject::connect(tetheringToggle, &ToggleControl::toggleFlipped, this, &AdvancedNetworking::toggleTethering);
 
   // Change tethering password
@@ -138,15 +138,15 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
       wifi->changeTetheringPassword(pass);
     }
   });
-//  list->addItem(editPasswordButton);
+  list->addItem(editPasswordButton);
 
   // IP address
   ipLabel = new LabelControl(tr("IP Address"), wifi->ipv4_address);
-//  list->addItem(ipLabel);
+  list->addItem(ipLabel);
 
   // SSH keys
-//  list->addItem(new SshToggle());
-//  list->addItem(new SshControl());
+  list->addItem(new SshToggle());
+  list->addItem(new SshControl());
 
   // Roaming toggle
   const bool roamingEnabled = params.getBool("GsmRoaming");
@@ -155,7 +155,7 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
     params.putBool("GsmRoaming", state);
     wifi->updateGsmSettings(state, QString::fromStdString(params.get("GsmApn")));
   });
-//  list->addItem(roamingToggle);
+  list->addItem(roamingToggle);
 
   // APN settings
   ButtonControl *editApnButton = new ButtonControl(tr("APN Setting"), tr("EDIT"));
@@ -171,12 +171,12 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
     }
     wifi->updateGsmSettings(roamingEnabled, apn);
   });
-//  list->addItem(editApnButton);
+  list->addItem(editApnButton);
 
   // Set initial config
   wifi->updateGsmSettings(roamingEnabled, QString::fromStdString(params.get("GsmApn")));
 
-//  main_layout->addWidget(new ScrollView(list, this));
+  main_layout->addWidget(new ScrollView(list, this));
   main_layout->addStretch(1);
 }
 

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -124,10 +124,10 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   connect(back, &QPushButton::clicked, [=]() { emit backPress(); });
   main_layout->addWidget(back, 0, Qt::AlignLeft);
 
-  ListWidget *list = new ListWidget(this);
+//  ListWidget *list = new ListWidget(this);
   // Enable tethering layout
   tetheringToggle = new ToggleControl(tr("Enable Tethering"), "", "", wifi->isTetheringEnabled());
-  list->addItem(tetheringToggle);
+//  list->addItem(tetheringToggle);
   QObject::connect(tetheringToggle, &ToggleControl::toggleFlipped, this, &AdvancedNetworking::toggleTethering);
 
   // Change tethering password
@@ -138,15 +138,15 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
       wifi->changeTetheringPassword(pass);
     }
   });
-  list->addItem(editPasswordButton);
+//  list->addItem(editPasswordButton);
 
   // IP address
   ipLabel = new LabelControl(tr("IP Address"), wifi->ipv4_address);
-  list->addItem(ipLabel);
+//  list->addItem(ipLabel);
 
   // SSH keys
-  list->addItem(new SshToggle());
-  list->addItem(new SshControl());
+//  list->addItem(new SshToggle());
+//  list->addItem(new SshControl());
 
   // Roaming toggle
   const bool roamingEnabled = params.getBool("GsmRoaming");
@@ -155,7 +155,7 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
     params.putBool("GsmRoaming", state);
     wifi->updateGsmSettings(state, QString::fromStdString(params.get("GsmApn")));
   });
-  list->addItem(roamingToggle);
+//  list->addItem(roamingToggle);
 
   // APN settings
   ButtonControl *editApnButton = new ButtonControl(tr("APN Setting"), tr("EDIT"));
@@ -171,12 +171,12 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
     }
     wifi->updateGsmSettings(roamingEnabled, apn);
   });
-  list->addItem(editApnButton);
+//  list->addItem(editApnButton);
 
   // Set initial config
   wifi->updateGsmSettings(roamingEnabled, QString::fromStdString(params.get("GsmApn")));
 
-  main_layout->addWidget(new ScrollView(list, this));
+//  main_layout->addWidget(new ScrollView(list, this));
   main_layout->addStretch(1);
 }
 
@@ -271,7 +271,8 @@ void WifiUI::refresh() {
   // add networks
   ListWidget *list = new ListWidget(this);
   for (Network &network : sortedNetworks) {
-    QHBoxLayout *hlayout = new QHBoxLayout;
+    QWidget *wrapper = new QWidget;
+    QHBoxLayout *hlayout = new QHBoxLayout(wrapper);
     hlayout->setContentsMargins(44, 0, 73, 0);
     hlayout->setSpacing(50);
 
@@ -325,7 +326,7 @@ void WifiUI::refresh() {
     strength->setPixmap(strengths[std::clamp((int)round(network.strength / 33.), 0, 3)]);
     hlayout->addWidget(strength, 0, Qt::AlignRight);
 
-    list->addItem(hlayout);
+    list->addItem(wrapper);
   }
   main_layout->addWidget(list);
   main_layout->addStretch(1);

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -207,7 +207,8 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   });
 
   // power buttons
-  QHBoxLayout *power_layout = new QHBoxLayout();
+  QWidget *power_widget = new QWidget;
+  QHBoxLayout *power_layout = new QHBoxLayout(power_widget);
   power_layout->setSpacing(30);
 
   QPushButton *reboot_btn = new QPushButton(tr("Reboot"));
@@ -230,7 +231,7 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
     #poweroff_btn { height: 120px; border-radius: 15px; background-color: #E22C2C; }
     #poweroff_btn:pressed { background-color: #FF2424; }
   )");
-  addItem(power_layout);
+  addItem(power_widget);
 }
 
 void DevicePanel::updateCalibDescription() {

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -5,6 +5,7 @@
 #include <QLabel>
 #include <QPainter>
 #include <QPushButton>
+#include <QDebug>
 
 #include "common/params.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
@@ -156,7 +157,6 @@ class ListWidget : public QWidget {
     outer_layout.addStretch();
   }
   inline void addItem(QWidget *w) { inner_layout.addWidget(w); }
-  inline void addItem(QLayout *layout) { inner_layout.addLayout(layout); }
   inline void setSpacing(int spacing) { inner_layout.setSpacing(spacing); }
 
 private:
@@ -165,10 +165,20 @@ private:
     p.setPen(Qt::gray);
     for (int i = 0; i < inner_layout.count() - 1; ++i) {
       QWidget *widget = inner_layout.itemAt(i)->widget();
+      qDebug() << "i" << i;
+      qDebug() << "widget";
+      qDebug() << widget;
+      qDebug() << "geometry";
+      qDebug() << inner_layout.itemAt(i)->geometry();
+//      qDebug() << "isVisible";
+      qDebug() << "name";
+//      qDebug() << widget->objectName();
+//      qDebug() << widget->isVisible();
       if (widget->isVisible()) {
         QRect r = inner_layout.itemAt(i)->geometry();
         int bottom = r.bottom() + inner_layout.spacing() / 2;
         p.drawLine(r.left() + 40, bottom, r.right() - 40, bottom);
+        qDebug() << "draw line from" << r.left() + 40 << bottom << r.right() - 40 << bottom;
       }
     }
   }

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -5,7 +5,6 @@
 #include <QLabel>
 #include <QPainter>
 #include <QPushButton>
-#include <QDebug>
 
 #include "common/params.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
@@ -165,20 +164,10 @@ private:
     p.setPen(Qt::gray);
     for (int i = 0; i < inner_layout.count() - 1; ++i) {
       QWidget *widget = inner_layout.itemAt(i)->widget();
-      qDebug() << "i" << i;
-      qDebug() << "widget";
-      qDebug() << widget;
-      qDebug() << "geometry";
-      qDebug() << inner_layout.itemAt(i)->geometry();
-//      qDebug() << "isVisible";
-      qDebug() << "name";
-//      qDebug() << widget->objectName();
-//      qDebug() << widget->isVisible();
       if (widget->isVisible()) {
         QRect r = inner_layout.itemAt(i)->geometry();
         int bottom = r.bottom() + inner_layout.spacing() / 2;
         p.drawLine(r.left() + 40, bottom, r.right() - 40, bottom);
-        qDebug() << "draw line from" << r.left() + 40 << bottom << r.right() - 40 << bottom;
       }
     }
   }


### PR DESCRIPTION
This code introduced in https://github.com/commaai/openpilot/pull/25698 assumes all items of a `ListWidget` will be only widgets, however in two places (networking and power layout) we add layouts. So when getting the widgets from the inner layout items (`->widget()`) we get null `QWidget` objects causing segfaults when trying to call anything on them.