### PR TITLE
CI: remove redundant env variables in 'openpilot env setup'

### DIFF
--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -1,13 +1,5 @@
 name: 'openpilot env setup'
 
-env:
-  BASE_IMAGE: openpilot-base
-  DOCKER_REGISTRY: ghcr.io/commaai
-  BUILD: |
-      docker pull $(grep -iohP '(?<=^from)\s+\S+' Dockerfile.openpilot_base) || true
-      docker pull $DOCKER_REGISTRY/$BASE_IMAGE:latest || true
-      docker build --cache-from $DOCKER_REGISTRY/$BASE_IMAGE:latest -t $DOCKER_REGISTRY/$BASE_IMAGE:latest -t $BASE_IMAGE:latest -f Dockerfile.openpilot_base .
-
 inputs:
   save-cache:
     default: false
@@ -42,4 +34,4 @@ runs:
 
     # build our docker image
     - shell: bash
-      run: eval "$BUILD"
+      run: eval ${{ env.BUILD }}


### PR DESCRIPTION
**Description**
Having env variables in [action.yaml](https://github.com/commaai/openpilot/blob/aea1a0d5e684daf7682703174233390b0cf79c83/.github/workflows/setup/action.yaml#L3-L9) is redundant. You can just use ```run: eval ${{ env.BUILD }}```. That way, BUILD env variable is in one place and is not repeated.

**Verification**
Tested it on my fork, and there it works. The tests on the pull request will verify.