### PR TITLE
camerad:  zero memory before returning from MemoryManager::alloc

### DIFF
--- a/system/camerad/cameras/camera_util.cc
+++ b/system/camerad/cameras/camera_util.cc
@@ -1,5 +1,7 @@
 #include "system/camerad/cameras/camera_util.h"
 
+#include <string.h>
+
 #include <cassert>
 
 #include <sys/ioctl.h>
@@ -111,6 +113,7 @@ void *MemoryManager::alloc(int size, uint32_t *handle) {
     size_lookup[ptr] = size;
   }
   lock.unlock();
+  memset(ptr, 0, size);
   return ptr;
 }
 


### PR DESCRIPTION
non-zeroed memory may result in unexpected behavior in the `camerad`.