### PR TITLE
MapPanel: refresh only when visible and destination changes

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -156,6 +156,7 @@ MapPanel::MapPanel(QWidget* parent) : QWidget(parent) {
 
 void MapPanel::showEvent(QShowEvent *event) {
   updateCurrentRoute();
+  refresh();
 }
 
 void MapPanel::clear() {
@@ -184,18 +185,25 @@ void MapPanel::updateCurrentRoute() {
 }
 
 void MapPanel::parseResponse(const QString &response, bool success) {
-  stack->setCurrentIndex((uiState()->prime_type || success) ? 0 : 1);
+  if (!success) return;
 
-  if (!success) {
-    return;
+  cur_destinations = response;
+  if (isVisible()) {
+    refresh();
   }
+}
 
-  QJsonDocument doc = QJsonDocument::fromJson(response.trimmed().toUtf8());
+void MapPanel::refresh() {
+  stack->setCurrentIndex(uiState()->prime_type ? 0 : 1);
+  if (cur_destinations == prev_destinations) return;
+
+  QJsonDocument doc = QJsonDocument::fromJson(cur_destinations.trimmed().toUtf8());
   if (doc.isNull()) {
     qDebug() << "JSON Parse failed on navigation locations";
     return;
   }
 
+  prev_destinations = cur_destinations;
   clear();
 
   bool has_recents = false;

--- a/selfdrive/ui/qt/maps/map_settings.h
+++ b/selfdrive/ui/qt/maps/map_settings.h
@@ -23,8 +23,10 @@ public:
 
 private:
   void showEvent(QShowEvent *event) override;
+  void refresh();
 
   Params params;
+  QString prev_destinations, cur_destinations;
   QStackedWidget *stack;
   QPushButton *home_button, *work_button;
   QLabel *home_address, *work_address;


### PR DESCRIPTION
The `MapPanel` is constantly rebuilding the recent list while onroad, even if it is invisible

