### PR TITLE
inc sensord cpu usage in onroad test

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -29,7 +29,7 @@ PROCS = {
   "selfdrive.controls.plannerd": 11.7,
   "./_ui": 19.2,
   "selfdrive.locationd.paramsd": 9.0,
-  "./_sensord": 6.17,
+  "./_sensord": 12.0,
   "selfdrive.controls.radard": 4.5,
   "./_modeld": 4.48,
   "./boardd": 3.63,


### PR DESCRIPTION
Changing sensord to interrupts increased its cpu usage.
Measuring with `top` shows the following increases:
```
lsm, no bmx:
~9% ->  ~(12-13)%

lsm c variant, no bmx:
~12% ->  ~17-18%

lsm, with bmx
~17% -> 21%
```
```
using the test_onroad.py script:
 6.22 ->  9.43%
other values on the CI device have been: 11.2%, 11.9%, 14.13%

so the 12% has been chosen
```