### PR TITLE
Sensord skip init values, first 500ms

### DIFF
--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -177,6 +177,7 @@ int sensor_loop() {
   }
 
   PubMaster pm({"sensorEvents"});
+  init_ts = nanos_since_boot();
 
   // thread for reading events via interrupts
   std::vector<Sensor *> lsm_interrupt_sensors = {&lsm6ds3_accel, &lsm6ds3_gyro};

--- a/selfdrive/sensord/tests/test_sensord.py
+++ b/selfdrive/sensord/tests/test_sensord.py
@@ -158,6 +158,11 @@ class TestSensord(unittest.TestCase):
     data_list.sort()
     tdiffs = np.diff(data_list)
 
+    # with the skip of first 500ms measurements it happens that one value
+    # before the skip is received, this high diffs are filtered as they ruin
+    # the standard dev calculation
+    tdiffs = list(filter(lambda d: d <= 500*10**6, tdiffs))
+
     high_delay_diffs = set(filter(lambda d: d >= 10.1*10**6, tdiffs))
     assert len(high_delay_diffs) < 10, f"Too many high delay packages: {high_delay_diffs}"
 


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/22888
by filtering the initial measurements