### PR TITLE
map: fix repeated call to m_map->setZoom

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -204,7 +204,8 @@ void MapWindow::updateState(const UIState &s) {
 
   if (zoom_counter == 0) {
     m_map->setZoom(util::map_val<float>(velocity_filter.x(), 0, 30, MAX_ZOOM, MIN_ZOOM));
-  } else {
+    zoom_counter = -1;
+  } else if (zoom_counter > 0) {
     zoom_counter--;
   }
 

--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -98,7 +98,7 @@ private:
   // Panning
   QPointF m_lastPos;
   int pan_counter = 0;
-  int zoom_counter = 0;
+  int zoom_counter = -1;
 
   // Position
   std::optional<QMapbox::Coordinate> last_position;


### PR DESCRIPTION
`m_map->setZoom` is called an infinite number of times. because  zoom_counter is 0 as long as the user doesn't touch the screen