### PR TITLE
sensord: move sensors in lowest power mode on exit/kill

### DIFF
--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -27,6 +27,8 @@ int BMX055_Accel::init() {
   if (ret < 0) {
     goto fail;
   }
+  // bmx055 accel has a 1.3ms wakeup time from deep suspend mode
+  util::sleep_for(10);
 
   // High bandwidth
   // ret = set_register(BMX055_ACCEL_I2C_REG_HBW, BMX055_ACCEL_HBW_ENABLE);

--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -53,9 +53,7 @@ fail:
 
 int BMX055_Accel::shutdown()  {
   // enter deep suspend mode (lowest power mode)
-
-  int ret = 0;
-  ret = set_register(BMX055_ACCEL_I2C_REG_PMU, BMX055_ACCEL_DEEP_SUSPEND);
+  int ret = set_register(BMX055_ACCEL_I2C_REG_PMU, BMX055_ACCEL_DEEP_SUSPEND);
   if (ret < 0) {
     LOGE("Could not move BMX055 ACCEL in deep suspend mode!")
   }

--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -23,6 +23,11 @@ int BMX055_Accel::init() {
     goto fail;
   }
 
+  ret = set_register(BMX055_ACCEL_I2C_REG_PMU, BMX055_ACCEL_NORMAL_MODE);
+  if (ret < 0) {
+    goto fail;
+  }
+
   // High bandwidth
   // ret = set_register(BMX055_ACCEL_I2C_REG_HBW, BMX055_ACCEL_HBW_ENABLE);
   // if (ret < 0) {
@@ -40,6 +45,18 @@ int BMX055_Accel::init() {
   }
 
 fail:
+  return ret;
+}
+
+int BMX055_Accel::shutdown()  {
+  // enter deep suspend mode (lowest power mode)
+
+  int ret = 0;
+  ret = set_register(BMX055_ACCEL_I2C_REG_PMU, BMX055_ACCEL_DEEP_SUSPEND);
+  if (ret < 0) {
+    LOGE("Could not move BMX055 ACCEL in deep suspend mode!")
+  }
+
   return ret;
 }
 

--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -4,6 +4,7 @@
 
 #include "common/swaglog.h"
 #include "common/timing.h"
+#include "common/util.h"
 
 BMX055_Accel::BMX055_Accel(I2CBus *bus) : I2CSensor(bus) {}
 

--- a/selfdrive/sensord/sensors/bmx055_accel.h
+++ b/selfdrive/sensord/sensors/bmx055_accel.h
@@ -10,6 +10,7 @@
 #define BMX055_ACCEL_I2C_REG_X_LSB  0x02
 #define BMX055_ACCEL_I2C_REG_TEMP   0x08
 #define BMX055_ACCEL_I2C_REG_BW     0x10
+#define BMX055_ACCEL_I2C_REG_PMU    0x11
 #define BMX055_ACCEL_I2C_REG_HBW    0x13
 #define BMX055_ACCEL_I2C_REG_FIFO   0x3F
 
@@ -18,6 +19,8 @@
 
 #define BMX055_ACCEL_HBW_ENABLE       0b10000000
 #define BMX055_ACCEL_HBW_DISABLE      0b00000000
+#define BMX055_ACCEL_DEEP_SUSPEND     0b00100000
+#define BMX055_ACCEL_NORMAL_MODE      0b00000000
 
 #define BMX055_ACCEL_BW_7_81HZ  0b01000
 #define BMX055_ACCEL_BW_15_63HZ 0b01001
@@ -34,5 +37,5 @@ public:
   BMX055_Accel(I2CBus *bus);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
-  int shutdown() { return 0; }
+  int shutdown();
 };

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -64,9 +64,7 @@ fail:
 
 int BMX055_Gyro::shutdown()  {
   // enter deep suspend mode (lowest power mode)
-
-  int ret = 0;
-  ret = set_register(BMX055_GYRO_I2C_REG_LPM1, BMX055_GYRO_DEEP_SUSPEND);
+  int ret = set_register(BMX055_GYRO_I2C_REG_LPM1, BMX055_GYRO_DEEP_SUSPEND);
   if (ret < 0) {
     LOGE("Could not move BMX055 GYRO in deep suspend mode!")
   }

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -26,6 +26,11 @@ int BMX055_Gyro::init() {
     goto fail;
   }
 
+  ret = set_register(BMX055_GYRO_I2C_REG_LPM1, BMX055_GYRO_NORMAL_MODE);
+  if (ret < 0) {
+    goto fail;
+  }
+
   // High bandwidth
   // ret = set_register(BMX055_GYRO_I2C_REG_HBW, BMX055_GYRO_HBW_ENABLE);
   // if (ret < 0) {
@@ -51,6 +56,18 @@ int BMX055_Gyro::init() {
   }
 
 fail:
+  return ret;
+}
+
+int BMX055_Gyro::shutdown()  {
+  // enter deep suspend mode (lowest power mode)
+
+  int ret = 0;
+  ret = set_register(BMX055_GYRO_I2C_REG_LPM1, BMX055_GYRO_DEEP_SUSPEND);
+  if (ret < 0) {
+    LOGE("Could not move BMX055 GYRO in deep suspend mode!")
+  }
+
   return ret;
 }
 

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -31,7 +31,7 @@ int BMX055_Gyro::init() {
   if (ret < 0) {
     goto fail;
   }
-  // bmx055 has a 30ms wakeup time from deep suspend mode
+  // bmx055 gyro has a 30ms wakeup time from deep suspend mode
   util::sleep_for(50);
 
   // High bandwidth

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "common/swaglog.h"
+#include "common/util.h"
 
 #define DEG2RAD(x) ((x) * M_PI / 180.0)
 
@@ -30,6 +31,8 @@ int BMX055_Gyro::init() {
   if (ret < 0) {
     goto fail;
   }
+  // bmx055 has a 30ms wakeup time from deep suspend mode
+  util::sleep_for(50);
 
   // High bandwidth
   // ret = set_register(BMX055_GYRO_I2C_REG_HBW, BMX055_GYRO_HBW_ENABLE);

--- a/selfdrive/sensord/sensors/bmx055_gyro.h
+++ b/selfdrive/sensord/sensors/bmx055_gyro.h
@@ -10,6 +10,7 @@
 #define BMX055_GYRO_I2C_REG_RATE_X_LSB 0x02
 #define BMX055_GYRO_I2C_REG_RANGE      0x0F
 #define BMX055_GYRO_I2C_REG_BW         0x10
+#define BMX055_GYRO_I2C_REG_LPM1       0x11
 #define BMX055_GYRO_I2C_REG_HBW        0x13
 #define BMX055_GYRO_I2C_REG_FIFO       0x3F
 
@@ -18,6 +19,8 @@
 
 #define BMX055_GYRO_HBW_ENABLE       0b10000000
 #define BMX055_GYRO_HBW_DISABLE      0b00000000
+#define BMX055_GYRO_DEEP_SUSPEND     0b00100000
+#define BMX055_GYRO_NORMAL_MODE      0b00000000
 
 #define BMX055_GYRO_RANGE_2000      0b000
 #define BMX055_GYRO_RANGE_1000      0b001
@@ -34,5 +37,5 @@ public:
   BMX055_Gyro(I2CBus *bus);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
-  int shutdown() { return 0; }
+  int shutdown();
 };

--- a/selfdrive/sensord/sensors/bmx055_magn.cc
+++ b/selfdrive/sensord/sensors/bmx055_magn.cc
@@ -155,6 +155,18 @@ int BMX055_Magn::init() {
   return ret;
 }
 
+int BMX055_Magn::shutdown() {
+  int ret = 0;
+
+  // move to suspend mode
+  ret = set_register(BMX055_MAGN_I2C_REG_PWR_0, 0);
+  if (ret < 0) {
+    LOGE("Could not move BMX055 MAGN in suspend mode!")
+  }
+
+  return ret;
+}
+
 bool BMX055_Magn::perform_self_test() {
   uint8_t buffer[8];
   int16_t x, y;

--- a/selfdrive/sensord/sensors/bmx055_magn.cc
+++ b/selfdrive/sensord/sensors/bmx055_magn.cc
@@ -156,10 +156,8 @@ int BMX055_Magn::init() {
 }
 
 int BMX055_Magn::shutdown() {
-  int ret = 0;
-
   // move to suspend mode
-  ret = set_register(BMX055_MAGN_I2C_REG_PWR_0, 0);
+  int ret = set_register(BMX055_MAGN_I2C_REG_PWR_0, 0);
   if (ret < 0) {
     LOGE("Could not move BMX055 MAGN in suspend mode!")
   }

--- a/selfdrive/sensord/sensors/bmx055_magn.h
+++ b/selfdrive/sensord/sensors/bmx055_magn.h
@@ -60,5 +60,5 @@ public:
   BMX055_Magn(I2CBus *bus);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
-  int shutdown() { return 0; }
+  int shutdown();
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.cc
@@ -71,12 +71,25 @@ int LSM6DS3_Accel::shutdown() {
   value &= ~(LSM6DS3_ACCEL_INT1_DRDY_XL);
   ret = set_register(LSM6DS3_ACCEL_I2C_REG_INT1_CTRL, value);
   if (ret < 0) {
+    LOGE("Could not disable lsm6ds3 acceleration interrupt!")
     goto fail;
   }
-  return ret;
+
+  // enable power-down mode
+  value = 0;
+  ret = read_register(LSM6DS3_ACCEL_I2C_REG_CTRL1_XL, &value, 1);
+  if (ret < 0) {
+    goto fail;
+  }
+
+  value &= 0x0F;
+  ret = set_register(LSM6DS3_ACCEL_I2C_REG_CTRL1_XL, value);
+  if (ret < 0) {
+    LOGE("Could not power-down lsm6ds3 acceleration!")
+    goto fail;
+  }
 
 fail:
-  LOGE("Could not disable lsm6ds3 acceleration interrupt!")
   return ret;
 }
 

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.cc
@@ -85,7 +85,7 @@ int LSM6DS3_Accel::shutdown() {
   value &= 0x0F;
   ret = set_register(LSM6DS3_ACCEL_I2C_REG_CTRL1_XL, value);
   if (ret < 0) {
-    LOGE("Could not power-down lsm6ds3 acceleration!")
+    LOGE("Could not power-down lsm6ds3 accelerometer!")
     goto fail;
   }
 

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -74,12 +74,25 @@ int LSM6DS3_Gyro::shutdown() {
   value &= ~(LSM6DS3_GYRO_INT1_DRDY_G);
   ret = set_register(LSM6DS3_GYRO_I2C_REG_INT1_CTRL, value);
   if (ret < 0) {
+    LOGE("Could not disable lsm6ds3 gyroscope interrupt!")
     goto fail;
   }
-  return ret;
+
+  // enable power-down mode
+  value = 0;
+  ret = read_register(LSM6DS3_GYRO_I2C_REG_CTRL2_G, &value, 1);
+  if (ret < 0) {
+    goto fail;
+  }
+
+  value &= 0x0F;
+  ret = set_register(LSM6DS3_GYRO_I2C_REG_CTRL2_G, value);
+  if (ret < 0) {
+    LOGE("Could not power-down lsm6ds3 gyroscope!")
+    goto fail;
+  }
 
 fail:
-  LOGE("Could not disable lsm6ds3 gyroscope interrupt!")
   return ret;
 }
 

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -5,7 +5,6 @@
 
 #include "common/swaglog.h"
 #include "common/timing.h"
-#include "common/util.h"
 
 #define DEG2RAD(x) ((x) * M_PI / 180.0)
 
@@ -47,9 +46,6 @@ int LSM6DS3_Gyro::init() {
   if (ret < 0) {
     goto fail;
   }
-
-  // give gyro time to wake up from power down mode
-  util::sleep_for(50);
 
   // enable data ready interrupt for gyro on INT1
   // (without resetting existing interrupts)

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -5,6 +5,7 @@
 
 #include "common/swaglog.h"
 #include "common/timing.h"
+#include "common/util.h"
 
 #define DEG2RAD(x) ((x) * M_PI / 180.0)
 
@@ -46,6 +47,9 @@ int LSM6DS3_Gyro::init() {
   if (ret < 0) {
     goto fail;
   }
+
+  // give gyro time to wake up from power down mode
+  util::sleep_for(50);
 
   // enable data ready interrupt for gyro on INT1
   // (without resetting existing interrupts)

--- a/selfdrive/sensord/sensors/mmc5603nj_magn.cc
+++ b/selfdrive/sensord/sensors/mmc5603nj_magn.cc
@@ -51,6 +51,34 @@ fail:
   return ret;
 }
 
+int MMC5603NJ_Magn::shutdown() {
+  int ret = 0;
+
+  // disable auto reset of measurements
+  uint8_t value = 0;
+  ret = read_register(MMC5603NJ_I2C_REG_INTERNAL_0, &value, 1);
+  if (ret < 0) {
+    goto fail;
+  }
+
+  value &= ~(MMC5603NJ_CMM_FREQ_EN | MMC5603NJ_AUTO_SR_EN);
+  ret = set_register(MMC5603NJ_I2C_REG_INTERNAL_0, value);
+  if (ret < 0) {
+    goto fail;
+  }
+
+  // set ODR to 0 to leave continuous mode
+  ret = set_register(MMC5603NJ_I2C_REG_ODR, 0);
+  if (ret < 0) {
+    goto fail;
+  }
+  return ret;
+
+fail:
+  LOGE("Could not disable mmc5603nj auto set reset")
+  return ret;
+}
+
 bool MMC5603NJ_Magn::get_event(cereal::SensorEventData::Builder &event) {
 
   uint64_t start_time = nanos_since_boot();

--- a/selfdrive/sensord/sensors/mmc5603nj_magn.h
+++ b/selfdrive/sensord/sensors/mmc5603nj_magn.h
@@ -26,5 +26,5 @@ public:
   MMC5603NJ_Magn(I2CBus *bus);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
-  int shutdown() { return 0; }
+  int shutdown();
 };

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -207,8 +207,8 @@ int sensor_loop() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10) - (end - begin));
   }
 
-  for (int i = 0; i < sensors.size(); i++) {
-    sensors[i]->shutdown();
+  for (Sensor *sensor :  sensors) {
+    sensor->shutdown();
   }
 
   lsm_interrupt_thread.join();

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -28,6 +28,10 @@
 ExitHandler do_exit;
 std::mutex pm_mutex;
 
+// filter first values (0.5sec) as those may contain inaccuracies
+uint64_t init_ts = 0;
+constexpr uint64_t init_delay = 500*1e6;
+
 void interrupt_loop(int fd, std::vector<Sensor *>& sensors, PubMaster& pm) {
   struct pollfd fd_list[1] = {0};
   fd_list[0].fd = fd;
@@ -86,6 +90,10 @@ void interrupt_loop(int fd, std::vector<Sensor *>& sensors, PubMaster& pm) {
     auto events = msg.initEvent().initSensorEvents(collected_events.size());
     for (int i = 0; i < collected_events.size(); ++i) {
       events.adoptWithCaveats(i, kj::mv(collected_events[i]));
+    }
+
+    if (ts - init_ts < init_delay) {
+      continue;
     }
 
     std::lock_guard<std::mutex> lock(pm_mutex);
@@ -167,6 +175,7 @@ int sensor_loop() {
   }
 
   PubMaster pm({"sensorEvents"});
+  init_ts = nanos_since_boot();
 
   // thread for reading events via interrupts
   std::vector<Sensor *> lsm_interrupt_sensors = {&lsm6ds3_accel, &lsm6ds3_gyro};
@@ -183,6 +192,10 @@ int sensor_loop() {
     for (int i = 0; i < num_events; i++) {
       auto event = sensor_events[i];
       sensors[i]->get_event(event);
+    }
+
+    if (nanos_since_boot() - init_ts < init_delay) {
+      continue;
     }
 
     {

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -194,6 +194,10 @@ int sensor_loop() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10) - (end - begin));
   }
 
+  for (int i = 0; i < sensors.size(); i++) {
+    sensors[i]->shutdown();
+  }
+
   lsm_interrupt_thread.join();
   delete i2c_bus_imu;
   return 0;


### PR DESCRIPTION
Move all sensors in its lowest possible power state on sensord exit/kill.
Its hard to measure a difference but in average a draw about 2mA less an consume about 100mW less.