### PR TITLE
Updater: Reboot instead of shutdown to install new branch

### DIFF
--- a/selfdrive/ui/qt/offroad/software_settings.cc
+++ b/selfdrive/ui/qt/offroad/software_settings.cc
@@ -45,7 +45,7 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
   installBtn = new ButtonControl(tr("Install Update"), tr("INSTALL"));
   connect(installBtn, &ButtonControl::clicked, [=]() {
     installBtn->setEnabled(false);
-    params.putBool("DoShutdown", true);
+    params.putBool("DoReboot", true);
   });
   addItem(installBtn);
 


### PR DESCRIPTION
Once the new branch is downloaded, pressing `INSTALL` would shut down the device. It may make more sense to reboot instead.