### PR TITLE
sensord: fix concurrency issues

### DIFF
--- a/common/i2c.cc
+++ b/common/i2c.cc
@@ -37,7 +37,7 @@ I2CBus::~I2CBus() {
 
 int I2CBus::read_register(uint8_t device_address, uint register_address, uint8_t *buffer, uint8_t len) {
   int ret = 0;
-
+  std::lock_guard lk(mutex);
   ret = HANDLE_EINTR(ioctl(i2c_fd, I2C_SLAVE, device_address));
   if(ret < 0) { goto fail; }
 
@@ -50,7 +50,7 @@ fail:
 
 int I2CBus::set_register(uint8_t device_address, uint register_address, uint8_t data) {
   int ret = 0;
-
+  std::lock_guard lk(mutex);
   ret = HANDLE_EINTR(ioctl(i2c_fd, I2C_SLAVE, device_address));
   if(ret < 0) { goto fail; }
 

--- a/common/i2c.h
+++ b/common/i2c.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-
+#include <mutex>
 #include <sys/types.h>
 
 class I2CBus {
@@ -9,6 +9,7 @@ class I2CBus {
     int i2c_fd;
 
   public:
+    std::mutex mutex;
     I2CBus(uint8_t bus_id);
     ~I2CBus();
 


### PR DESCRIPTION
get_event is accessed by multiple threads,  which will lead to concurrency issues.