### PR TITLE
translations: remove locations

### DIFF
--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -29,10 +29,7 @@ class TestTranslations(unittest.TestCase):
   def _read_translation_file(path, file):
     tr_file = os.path.join(path, f"{file}.ts")
     with open(tr_file, "r") as f:
-      # ignore locations when checking if translations are updated
-      lines = [line for line in f.read().splitlines() if
-               not line.strip().startswith(LOCATION_TAG)]
-      return "\n".join(lines)
+      return f.read()
 
   def test_missing_translation_files(self):
     for name, file in self.translation_files.items():
@@ -92,6 +89,13 @@ class TestTranslations(unittest.TestCase):
               self.assertNotIn(None, numerusform, "Ensure all plural translation forms are completed.")
               self.assertTrue(all([re.search("%[0-9]+", t) is None for t in numerusform]),
                               "Plural translations must use %n, not %1, %2, etc.: {}".format(numerusform))
+
+  def test_no_locations(self):
+    for name, file in self.translation_files.items():
+      with self.subTest(name=name, file=file):
+        for line in self._read_translation_file(TRANSLATIONS_DIR, file).splitlines():
+          self.assertFalse(line.strip().startswith(LOCATION_TAG),
+                           f"Line contains location tag: {line.strip()}, remove all line numbers.")
 
 
 if __name__ == "__main__":

--- a/selfdrive/ui/translations/main_en.ts
+++ b/selfdrive/ui/translations/main_en.ts
@@ -4,7 +4,6 @@
 <context>
     <name>InputDialog</name>
     <message numerus="yes">
-        <location filename="../qt/widgets/input.cc" line="+168"/>
         <source>Need at least %n character(s)!</source>
         <translation>
             <numerusform>Need at least %n character!</numerusform>
@@ -15,7 +14,6 @@
 <context>
     <name>QObject</name>
     <message numerus="yes">
-        <location filename="../qt/util.cc" line="+82"/>
         <source>%n minute(s) ago</source>
         <translation>
             <numerusform>%n minute ago</numerusform>
@@ -23,7 +21,6 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n hour(s) ago</source>
         <translation>
             <numerusform>%n hour ago</numerusform>
@@ -31,7 +28,6 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n day(s) ago</source>
         <translation>
             <numerusform>%n day ago</numerusform>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -4,17 +4,14 @@
 <context>
     <name>AbstractAlert</name>
     <message>
-        <location filename="../qt/widgets/offroad_alerts.cc" line="+25"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Snooze Update</source>
         <translation>更新の一時停止</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Reboot and Update</source>
         <translation>再起動してアップデート</translation>
     </message>
@@ -22,53 +19,42 @@
 <context>
     <name>AdvancedNetworking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+121"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Enable Tethering</source>
         <translation>ﾃｻﾞﾘﾝｸﾞを有効化</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Tethering Password</source>
         <translation>ﾃｻﾞﾘﾝｸﾞﾊﾟｽﾜｰﾄﾞ</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+27"/>
         <source>EDIT</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Enter new tethering password</source>
         <translation>新しいテザリングパスワードを入力</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>IP Address</source>
         <translation>IP アドレス</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable Roaming</source>
         <translation>ﾛｰﾐﾝｸﾞを有効化</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>APN Setting</source>
         <translation>APN 設定</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter APN</source>
         <translation>APN を入力</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>leave blank for automatic configuration</source>
         <translation>空白のままにして、自動設定にします</translation>
     </message>
@@ -76,13 +62,10 @@
 <context>
     <name>ConfirmationDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+221"/>
-        <location line="+5"/>
         <source>Ok</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -90,17 +73,14 @@
 <context>
     <name>DeclinePage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="+140"/>
         <source>You must accept the Terms and Conditions in order to use openpilot.</source>
         <translation>openpilot をご利用される前に、利用規約に同意する必要があります。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decline, uninstall %1</source>
         <translation>拒否して %1 をｱﾝｲﾝｽﾄｰﾙ</translation>
     </message>
@@ -108,152 +88,122 @@
 <context>
     <name>DevicePanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+151"/>
         <source>Dongle ID</source>
         <translation>ドングル番号 (Dongle ID)</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Serial</source>
         <translation>シリアル番号</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Driver Camera</source>
         <translation>車内カメラ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PREVIEW</source>
         <translation>見る</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)</source>
         <translation>車内カメラをプレビューして、ドライバー監視システムの視界を確認ができます。(車両の電源を切る必要があります)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reset Calibration</source>
         <translation>ｷｬﾘﾌﾞﾚｰｼｮﾝをﾘｾｯﾄ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>RESET</source>
         <translation>ﾘｾｯﾄ</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Are you sure you want to reset calibration?</source>
         <translation>ｷｬﾘﾌﾞﾚｰｼｮﾝをリセットしてもよろしいですか？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Review Training Guide</source>
         <translation>入門書を見る</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>REVIEW</source>
         <translation>見る</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Review the rules, features, and limitations of openpilot</source>
         <translation>openpilot の特徴を見る</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to review the training guide?</source>
         <translation>入門書を見てもよろしいですか？</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Regulatory</source>
         <translation>認証情報</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>VIEW</source>
         <translation>見る</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Change Language</source>
         <translation>言語を変更</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>CHANGE</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Select a language</source>
         <translation>言語を選択</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Power Off</source>
         <translation>電源を切る</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>openpilot requires the device to be mounted within 4° left or right and within 5° up or 8° down. openpilot is continuously calibrating, resetting is rarely required.</source>
         <translation>openpilot は、左または右の4°以内、上の5°または下の8°以内にデバイスを取付ける必要があります。キャリブレーションを引き続きます、リセットはほとんど必要ありません。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source> Your device is pointed %1° %2 and %3° %4.</source>
         <translation> このデバイスは%2の%1°、%4の%3°に向けます。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>down</source>
         <translation>下</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>up</source>
         <translation>上</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Are you sure you want to reboot?</source>
         <translation>再起動してもよろしいですか？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Reboot</source>
         <translation>openpilot をキャンセルして再起動ができます</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Are you sure you want to power off?</source>
         <translation>シャットダウンしてもよろしいですか？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Power Off</source>
         <translation>openpilot をキャンセルしてシャットダウンができます</translation>
     </message>
@@ -261,32 +211,26 @@
 <context>
     <name>DriveStats</name>
     <message>
-        <location filename="../qt/widgets/drive_stats.cc" line="+37"/>
         <source>Drives</source>
         <translation>運転履歴</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Hours</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>ALL TIME</source>
         <translation>累計</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>PAST WEEK</source>
         <translation>先週</translation>
     </message>
     <message>
-        <location filename="../qt/widgets/drive_stats.h" line="+15"/>
         <source>KM</source>
         <translation>km</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Miles</source>
         <translation>マイル</translation>
     </message>
@@ -294,7 +238,6 @@
 <context>
     <name>DriverViewScene</name>
     <message>
-        <location filename="../qt/offroad/driverview.cc" line="+55"/>
         <source>camera starting</source>
         <translation>ｶﾒﾗを起動しています</translation>
     </message>
@@ -302,12 +245,10 @@
 <context>
     <name>InputDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-155"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message numerus="yes">
-        <location line="+97"/>
         <source>Need at least %n character(s)!</source>
         <translation>
             <numerusform>%n文字以上でお願いします！</numerusform>
@@ -317,22 +258,18 @@
 <context>
     <name>Installer</name>
     <message>
-        <location filename="../installer/installer.cc" line="+56"/>
         <source>Installing...</source>
         <translation>インストールしています...</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>Receiving objects: </source>
         <translation>ｵﾌﾞｼﾞｪｸﾄをﾀﾞｳﾝﾛｰﾄﾞしています： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Resolving deltas: </source>
         <translation>デルタを解決しています： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Updating files: </source>
         <translation>ファイルを更新しています： </translation>
     </message>
@@ -340,27 +277,22 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
         <source>eta</source>
         <translation>予定到着時間</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>min</source>
         <translation>分</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>hr</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>km</source>
         <translation>ｷﾛﾒｰﾄﾙ</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>mi</source>
         <translation>ﾏｲﾙ</translation>
     </message>
@@ -368,22 +300,18 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
         <source> km</source>
         <translation> ｷﾛﾒｰﾄﾙ</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> m</source>
         <translation> ﾒｰﾄﾙ</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> mi</source>
         <translation> ﾏｲﾙ</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> ft</source>
         <translation> ﾌｨｰﾄ</translation>
     </message>
@@ -391,48 +319,40 @@
 <context>
     <name>MapPanel</name>
     <message>
-        <location filename="../qt/maps/map_settings.cc" line="+62"/>
         <source>Current Destination</source>
         <translation>現在の目的地</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>CLEAR</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Recent Destinations</source>
         <translation>最近の目的地</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Try the Navigation Beta</source>
         <translation>β版ﾅﾋﾞｹﾞｰｼｮﾝを試す</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Get turn-by-turn directions displayed and more with a comma
 prime subscription. Sign up now: https://connect.comma.ai</source>
         <translation>より詳細な案内情報を得ることができます。
 詳しくはこちら：https://connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>No home
 location set</source>
         <translation>自宅の住所はまだ
 設定されていません</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No work
 location set</source>
         <translation>職場の住所はまだ
 設定されていません</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>no recent destinations</source>
         <translation>最近の目的地履歴がありません</translation>
     </message>
@@ -440,12 +360,10 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
         <source>Map Loading</source>
         <translation>マップを読み込んでいます</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Waiting for GPS</source>
         <translation>GPS信号を探しています</translation>
     </message>
@@ -453,12 +371,10 @@ location set</source>
 <context>
     <name>MultiOptionDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+132"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -466,23 +382,18 @@ location set</source>
 <context>
     <name>Networking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="-135"/>
         <source>Advanced</source>
         <translation>詳細</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Enter password</source>
         <translation>パスワードを入力</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+10"/>
         <source>for &quot;%1&quot;</source>
         <translation>ﾈｯﾄﾜｰｸ名：%1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Wrong password</source>
         <translation>ﾊﾟｽﾜｰﾄﾞが間違っています</translation>
     </message>
@@ -490,30 +401,22 @@ location set</source>
 <context>
     <name>NvgWindow</name>
     <message>
-        <location filename="../qt/onroad.cc" line="+218"/>
         <source>km/h</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+3"/>
         <source>MAX</source>
         <translation>最高速度</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+3"/>
         <source>SPEED</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+3"/>
         <source>LIMIT</source>
         <translation>制限速度</translation>
     </message>
@@ -521,17 +424,14 @@ location set</source>
 <context>
     <name>OffroadHome</name>
     <message>
-        <location filename="../qt/home.cc" line="+114"/>
         <source>UPDATE</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source> ALERTS</source>
         <translation> 警告</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source> ALERT</source>
         <translation> 警告</translation>
     </message>
@@ -539,22 +439,18 @@ location set</source>
 <context>
     <name>PairingPopup</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+89"/>
         <source>Pair your device to your comma account</source>
         <translation>デバイスと comma アカウントを連携する</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Go to https://connect.comma.ai on your phone</source>
         <translation>モバイルデバイスで「connect.comma.ai」にアクセスして</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Click &quot;add new device&quot; and scan the QR code on the right</source>
         <translation>「新しいデバイスを追加」を押すと、右側のQRコードをスキャンしてください</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>「connect.comma.ai」をホーム画面に追加して、アプリのように使うことができます</translation>
     </message>
@@ -562,32 +458,26 @@ location set</source>
 <context>
     <name>PrimeAdWidget</name>
     <message>
-        <location line="+88"/>
         <source>Upgrade Now</source>
         <translation>今すぐｱｯﾌﾟｸﾞﾚｰﾄ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Become a comma prime member at connect.comma.ai</source>
         <translation>connect.comma.ai でﾌﾟﾗｲﾑ会員に登録できます</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>PRIME FEATURES:</source>
         <translation>特典：</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Remote access</source>
         <translation>リモートアクセス</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>1 year of storage</source>
         <translation>一年間の保存期間</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Developer perks</source>
         <translation>開発者向け特典</translation>
     </message>
@@ -595,22 +485,18 @@ location set</source>
 <context>
     <name>PrimeUserWidget</name>
     <message>
-        <location line="-78"/>
         <source>✓ SUBSCRIBED</source>
         <translation>✓ 入会しました</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>comma prime</source>
         <translation>comma prime</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>CONNECT.COMMA.AI</source>
         <translation>CONNECT.COMMA.AI</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>COMMA POINTS</source>
         <translation>COMMA POINTS</translation>
     </message>
@@ -618,41 +504,34 @@ location set</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../qt/text.cc" line="+36"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exit</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../qt/util.cc" line="+21"/>
         <source>dashcam</source>
         <translation>ﾄﾞﾗｲﾌﾞﾚｺｰﾀﾞｰ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>openpilot</source>
         <translation>openpilot</translation>
     </message>
     <message numerus="yes">
-        <location line="+61"/>
         <source>%n minute(s) ago</source>
         <translation>
             <numerusform>%n 分前</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n hour(s) ago</source>
         <translation>
             <numerusform>%n 時間前</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n day(s) ago</source>
         <translation>
             <numerusform>%n 日前</numerusform>
@@ -662,47 +541,38 @@ location set</source>
 <context>
     <name>Reset</name>
     <message>
-        <location filename="../qt/setup/reset.cc" line="+29"/>
         <source>Reset failed. Reboot to try again.</source>
         <translation>初期化に失敗しました。再起動後に再試行してください。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Are you sure you want to reset your device?</source>
         <translation>初期化してもよろしいですか？</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Resetting device...</source>
         <translation>デバイスが初期化されます...</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>System Reset</source>
         <translation>システムを初期化</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>System reset triggered. Press confirm to erase all content and settings. Press cancel to resume boot.</source>
         <translation>システムの初期化をリクエストしました。「確認」ボタンを押すとデバイスが初期化されます。「キャンセル」ボタンを押すと起動を続行します。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>「data」パーティションをマウントできません。「確認」ボタンを押すとデバイスが初期化されます。</translation>
     </message>
@@ -710,7 +580,6 @@ location set</source>
 <context>
     <name>RichTextDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-75"/>
         <source>Ok</source>
         <translation>OK</translation>
     </message>
@@ -718,33 +587,26 @@ location set</source>
 <context>
     <name>SettingsWindow</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+22"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Device</source>
         <translation>デバイス</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+39"/>
         <source>Network</source>
         <translation>ﾈｯﾄﾜｰｸ</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Toggles</source>
         <translation>切り替え</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Software</source>
         <translation>ｿﾌﾄｳｪｱ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Navigation</source>
         <translation>ﾅﾋﾞｹﾞｰｼｮﾝ</translation>
     </message>
@@ -752,105 +614,82 @@ location set</source>
 <context>
     <name>Setup</name>
     <message>
-        <location filename="../qt/setup/setup.cc" line="+73"/>
         <source>WARNING: Low Voltage</source>
         <translation>警告：低電圧</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Power your device in a car with a harness or proceed at your own risk.</source>
         <translation>自己責任でハーネスから電源を供給してください。</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Power off</source>
         <translation>電源を切る</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+83"/>
-        <location line="+86"/>
         <source>Continue</source>
         <translation>続ける</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Getting Started</source>
         <translation>はじめに</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Before we get on the road, let’s finish installation and cover some details.</source>
         <translation>その前に、インストールを完了し、いくつかの詳細を説明します。</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Connect to Wi-Fi</source>
         <translation>Wi-Fi に接続</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+98"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Continue without Wi-Fi</source>
         <translation>Wi-Fi に未接続で続行</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waiting for internet</source>
         <translation>インターネット接続を待機中</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Choose Software to Install</source>
         <translation>インストールするソフトウェアを選びます</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Dashcam</source>
         <translation>ﾄﾞﾗｲﾌﾞﾚｺｰﾀﾞｰ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Custom Software</source>
         <translation>カスタムソフトウェア</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Enter URL</source>
         <translation>URL を入力</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>for Custom Software</source>
         <translation>カスタムソフトウェア</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Downloading...</source>
         <translation>ダウンロード中...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Download Failed</source>
         <translation>ダウンロード失敗</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ensure the entered URL is valid, and the device’s internet connection is good.</source>
         <translation>入力された URL を確認し、デバイスがインターネットに接続されていることを確認してください。</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Reboot device</source>
         <translation>デバイスを再起動</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Start over</source>
         <translation>最初からやり直す</translation>
     </message>
@@ -858,17 +697,14 @@ location set</source>
 <context>
     <name>SetupWidget</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+82"/>
         <source>Finish Setup</source>
         <translation>セットアップ完了</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer.</source>
         <translation>デバイスを comma connect (connect.comma.ai)でペアリングし comma prime 特典を申請してください。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Pair device</source>
         <translation>デバイスをペアリング</translation>
     </message>
@@ -876,106 +712,82 @@ location set</source>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qt/sidebar.cc" line="+74"/>
-        <location line="+2"/>
         <source>CONNECT</source>
         <translation>接続</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>OFFLINE</source>
         <translation>オフライン</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+13"/>
         <source>ONLINE</source>
         <translation>オンライン</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>ERROR</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>TEMP</source>
         <translation>温度</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>HIGH</source>
         <translation>高温</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>GOOD</source>
         <translation>最適</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>VEHICLE</source>
         <translation>車両</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>NO</source>
         <translation>NO</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PANDA</source>
         <translation>PANDA</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SEARCH</source>
         <translation>検索</translation>
     </message>
     <message>
-        <location filename="../qt/sidebar.h" line="+36"/>
         <source>--</source>
         <translation>--</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wi-Fi</source>
         <translation>Wi-Fi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ETH</source>
         <translation>ETH</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2G</source>
         <translation>2G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>3G</source>
         <translation>3G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>LTE</source>
         <translation>LTE</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>5G</source>
         <translation>5G</translation>
     </message>
@@ -983,63 +795,50 @@ location set</source>
 <context>
     <name>SoftwarePanel</name>
     <message>
-        <location filename="../qt/offroad/software_settings.cc" line="+24"/>
         <source>Updates are only downloaded while the car is off.</source>
         <translation>車の電源がオフの間のみ、アップデートのダウンロードが行われます。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Current Version</source>
         <translation>現在のバージョン</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Download</source>
         <translation>ダウンロード</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Install Update</source>
         <translation>アップデート</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>INSTALL</source>
         <translation>インストール</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Target Branch</source>
         <translation>対象のブランチ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SELECT</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select a branch</source>
         <translation>ブランチを選択</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>UNINSTALL</source>
         <translation>アンインストール</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uninstall %1</source>
         <translation>%1をアンインストール</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to uninstall?</source>
         <translation>アンインストールしてもよろしいですか？</translation>
     </message>
     <message>
-        <location line="-47"/>
-        <location line="+3"/>
         <source>CHECK</source>
         <translation>確認</translation>
     </message>
@@ -1047,48 +846,38 @@ location set</source>
 <context>
     <name>SshControl</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.cc" line="+7"/>
         <source>SSH Keys</source>
         <translation>SSH 鍵</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.</source>
         <translation>警告: これは、GitHub の設定にあるすべての公開鍵への SSH アクセスを許可するものです。自分以外の GitHub のユーザー名を入力しないでください。コンマのスタッフが GitHub のユーザー名を追加するようお願いすることはありません。</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+24"/>
         <source>ADD</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Enter your GitHub username</source>
         <translation>GitHub のユーザー名を入力してください</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>LOADING</source>
         <translation>ローディング</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>REMOVE</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Username &apos;%1&apos; has no keys on GitHub</source>
         <translation>ユーザー名 “%1” は GitHub に鍵がありません</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Request timed out</source>
         <translation>リクエストタイムアウト</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username &apos;%1&apos; doesn&apos;t exist on GitHub</source>
         <translation>ユーザー名 &apos;%1&apos; は GitHub に存在しません</translation>
     </message>
@@ -1096,7 +885,6 @@ location set</source>
 <context>
     <name>SshToggle</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.h" line="+13"/>
         <source>Enable SSH</source>
         <translation>SSH を有効化</translation>
     </message>
@@ -1104,22 +892,18 @@ location set</source>
 <context>
     <name>TermsPage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="-75"/>
         <source>Terms &amp; Conditions</source>
         <translation>利用規約</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Decline</source>
         <translation>拒否</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Scroll to accept</source>
         <translation>スクロールして同意</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Agree</source>
         <translation>同意</translation>
     </message>
@@ -1127,102 +911,82 @@ location set</source>
 <context>
     <name>TogglesPanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="-303"/>
         <source>Enable openpilot</source>
         <translation>openpilot を有効化</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off.</source>
         <translation>アダプティブクルーズコントロールとレーンキーピングドライバーアシスト（openpilotシステム）。この機能を使用するには、常に注意が必要です。この設定を変更すると、車の電源が切れたときに有効になります。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Enable Lane Departure Warnings</source>
         <translation>車線逸脱警報機能を有効化</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receive alerts to steer back into the lane when your vehicle drifts over a detected lane line without a turn signal activated while driving over 31 mph (50 km/h).</source>
         <translation>時速31マイル（50km）を超えるスピードで走行中、ウインカーを作動させずに検出された車線ライン上に車両が触れた場合、車線に戻るアラートを受信します。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use Metric System</source>
         <translation>メートル法を有効化</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Display speed in km/h instead of mph.</source>
         <translation>速度は mph ではなく km/h で表示されます。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Record and Upload Driver Camera</source>
         <translation>車内カメラの録画とアップロード</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload data from the driver facing camera and help improve the driver monitoring algorithm.</source>
         <translation>車内カメラの映像をアップロードし、ドライバー監視システムのアルゴリズムの向上に役立てます。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>🌮 End-to-end longitudinal (extremely alpha) 🌮</source>
         <translation>🌮 エンドツーエンドのアクセル制御 (超アルファ版) 🌮</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Experimental openpilot longitudinal control</source>
         <translation>実験段階のopenpilotによるアクセル制御</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;b&gt;WARNING: openpilot longitudinal control is experimental for this car and will disable AEB.&lt;/b&gt;</source>
         <translation>&lt;b&gt;警告: openpilotによるアクセル制御は実験段階であり、AEBを無効化します。&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.</source>
         <translation>アクセルとブレーキの制御をopenpilotに任せます。openpilotが人間と同じように運転します。最初期の実験段階です。</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>openpilot longitudinal control is not currently available for this car.</source>
         <translation>openpilotによるアクセル制御は、この車では現在利用できません。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enable experimental longitudinal control to enable this.</source>
         <translation>ここ機能を使う為には、「実験段階のopenpilotによるアクセル制御」を先に有効化してください。</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Disengage On Accelerator Pedal</source>
         <translation>ｱｸｾﾙ踏むと openpilot をｷｬﾝｾﾙ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>When enabled, pressing the accelerator pedal will disengage openpilot.</source>
         <translation>有効な場合は、アクセルを踏むと openpilot をキャンセルします。</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Show ETA in 24h Format</source>
         <translation>24時間表示</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use 24h format instead of am/pm</source>
         <translation>AM/PM の代わりに24時間形式を使用します</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Map on Left Side of UI</source>
         <translation>ﾃﾞｨｽﾌﾟﾚｲの左側にﾏｯﾌﾟを表示</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show map on left side when in split screen view.</source>
         <translation>分割画面表示の場合、ディスプレイの左側にマップを表示します。</translation>
     </message>
@@ -1230,42 +994,34 @@ location set</source>
 <context>
     <name>Updater</name>
     <message>
-        <location filename="../qt/setup/updater.cc" line="+23"/>
         <source>Update Required</source>
         <translation>更新が必要です</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>An operating system update is required. Connect your device to Wi-Fi for the fastest update experience. The download size is approximately 1GB.</source>
         <translation>ｵﾍﾟﾚｰﾃｨﾝｸﾞｼｽﾃﾑのアップデートが必要です。Wi-Fi に接続することで、最速のアップデートを体験できます。ダウンロードサイズは約 1GB です。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Connect to Wi-Fi</source>
         <translation>Wi-Fi に接続</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Install</source>
         <translation>インストール</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Loading...</source>
         <translation>読み込み中...</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Update failed</source>
         <translation>更新失敗</translation>
     </message>
@@ -1273,22 +1029,18 @@ location set</source>
 <context>
     <name>WifiUI</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+113"/>
         <source>Scanning for networks...</source>
         <translation>ネットワークをスキャン中...</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>CONNECTING...</source>
         <translation>接続中...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>FORGET</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Forget Wi-Fi Network &quot;%1&quot;?</source>
         <translation>Wi-Fiﾈｯﾄﾜｰｸ%1を削除してもよろしいですか？</translation>
     </message>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -4,17 +4,14 @@
 <context>
     <name>AbstractAlert</name>
     <message>
-        <location filename="../qt/widgets/offroad_alerts.cc" line="+25"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Snooze Update</source>
         <translation>업데이트 일시중지</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Reboot and Update</source>
         <translation>업데이트 및 재부팅</translation>
     </message>
@@ -22,53 +19,42 @@
 <context>
     <name>AdvancedNetworking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+121"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Enable Tethering</source>
         <translation>테더링 사용</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Tethering Password</source>
         <translation>테더링 비밀번호</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+27"/>
         <source>EDIT</source>
         <translation>편집</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Enter new tethering password</source>
         <translation>새 테더링 비밀번호를 입력하세요</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>IP Address</source>
         <translation>IP 주소</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable Roaming</source>
         <translation>로밍 사용</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>APN Setting</source>
         <translation>APN 설정</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter APN</source>
         <translation>APN 입력</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>leave blank for automatic configuration</source>
         <translation>자동설정하려면 공백으로 두세요</translation>
     </message>
@@ -76,13 +62,10 @@
 <context>
     <name>ConfirmationDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+221"/>
-        <location line="+5"/>
         <source>Ok</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -90,17 +73,14 @@
 <context>
     <name>DeclinePage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="+140"/>
         <source>You must accept the Terms and Conditions in order to use openpilot.</source>
         <translation>openpilot을 사용하려면 이용약관에 동의해야 합니다.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decline, uninstall %1</source>
         <translation>거절, %1 제거</translation>
     </message>
@@ -108,152 +88,122 @@
 <context>
     <name>DevicePanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+151"/>
         <source>Dongle ID</source>
         <translation>Dongle ID</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Serial</source>
         <translation>Serial</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Driver Camera</source>
         <translation>운전자 카메라</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PREVIEW</source>
         <translation>미리보기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)</source>
         <translation>운전자 모니터링이 좋은 가시성을 갖도록 운전자를 향한 카메라를 미리 봅니다. (차량연결은 해제되어있어야 합니다)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reset Calibration</source>
         <translation>캘리브레이션</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>RESET</source>
         <translation>재설정</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Are you sure you want to reset calibration?</source>
         <translation>캘리브레이션을 재설정하시겠습니까?</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Review Training Guide</source>
         <translation>트레이닝 가이드</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>REVIEW</source>
         <translation>다시보기</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Review the rules, features, and limitations of openpilot</source>
         <translation>openpilot의 규칙, 기능 및 제한 다시보기</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to review the training guide?</source>
         <translation>트레이닝 가이드를 다시보시겠습니까?</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Regulatory</source>
         <translation>규제</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>VIEW</source>
         <translation>보기</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Change Language</source>
         <translation>언어 변경</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>CHANGE</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Select a language</source>
         <translation>언어를 선택하세요</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Reboot</source>
         <translation>재부팅</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Power Off</source>
         <translation>전원 종료</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>openpilot requires the device to be mounted within 4° left or right and within 5° up or 8° down. openpilot is continuously calibrating, resetting is rarely required.</source>
         <translation>openpilot은 좌우측은 4° 이내, 위쪽은 5° 아래쪽은 8° 이내로 장치를 설치해야 합니다. openpilot은 지속적으로 보정되므로 리셋은 거의 필요하지 않습니다.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source> Your device is pointed %1° %2 and %3° %4.</source>
         <translation> 사용자의 장치가 %1° %2 및 %3° %4 위치에 설치되어있습니다.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>down</source>
         <translation>아래로</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>up</source>
         <translation>위로</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>left</source>
         <translation>좌측으로</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>right</source>
         <translation>우측으로</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Are you sure you want to reboot?</source>
         <translation>재부팅 하시겠습니까?</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Reboot</source>
         <translation>재부팅 하려면 해제하세요</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Are you sure you want to power off?</source>
         <translation>전원을 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Power Off</source>
         <translation>전원을 종료하려면 해제하세요</translation>
     </message>
@@ -261,32 +211,26 @@
 <context>
     <name>DriveStats</name>
     <message>
-        <location filename="../qt/widgets/drive_stats.cc" line="+37"/>
         <source>Drives</source>
         <translation>주행</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Hours</source>
         <translation>시간</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>ALL TIME</source>
         <translation>전체</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>PAST WEEK</source>
         <translation>지난주</translation>
     </message>
     <message>
-        <location filename="../qt/widgets/drive_stats.h" line="+15"/>
         <source>KM</source>
         <translation>Km</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Miles</source>
         <translation>Miles</translation>
     </message>
@@ -294,7 +238,6 @@
 <context>
     <name>DriverViewScene</name>
     <message>
-        <location filename="../qt/offroad/driverview.cc" line="+55"/>
         <source>camera starting</source>
         <translation>카메라 시작중</translation>
     </message>
@@ -302,12 +245,10 @@
 <context>
     <name>InputDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-155"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message numerus="yes">
-        <location line="+97"/>
         <source>Need at least %n character(s)!</source>
         <translation>
             <numerusform>최소 %n 자가 필요합니다!</numerusform>
@@ -317,22 +258,18 @@
 <context>
     <name>Installer</name>
     <message>
-        <location filename="../installer/installer.cc" line="+56"/>
         <source>Installing...</source>
         <translation>설치중...</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>Receiving objects: </source>
         <translation>수신중： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Resolving deltas: </source>
         <translation>델타병합： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Updating files: </source>
         <translation>파일갱신： </translation>
     </message>
@@ -340,27 +277,22 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
         <source>eta</source>
         <translation>도착</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>min</source>
         <translation>분</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>hr</source>
         <translation>시간</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>mi</source>
         <translation>mi</translation>
     </message>
@@ -368,22 +300,18 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> mi</source>
         <translation> mi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> ft</source>
         <translation> ft</translation>
     </message>
@@ -391,48 +319,40 @@
 <context>
     <name>MapPanel</name>
     <message>
-        <location filename="../qt/maps/map_settings.cc" line="+62"/>
         <source>Current Destination</source>
         <translation>현재 목적지</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>CLEAR</source>
         <translation>삭제</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Recent Destinations</source>
         <translation>최근 목적지</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Try the Navigation Beta</source>
         <translation>네비게이션(베타)를 사용해보세요</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Get turn-by-turn directions displayed and more with a comma
 prime subscription. Sign up now: https://connect.comma.ai</source>
         <translation>자세한 경로안내를 원하시면 comma prime을 구독하세요.
 등록：https://connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>No home
 location set</source>
         <translation>집
 설정되지않음</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No work
 location set</source>
         <translation>회사
 설정되지않음</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>no recent destinations</source>
         <translation>최근 목적지 없음</translation>
     </message>
@@ -440,12 +360,10 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
         <source>Map Loading</source>
         <translation>지도 로딩</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Waiting for GPS</source>
         <translation>GPS를 기다리는 중</translation>
     </message>
@@ -453,12 +371,10 @@ location set</source>
 <context>
     <name>MultiOptionDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+132"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -466,23 +382,18 @@ location set</source>
 <context>
     <name>Networking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="-135"/>
         <source>Advanced</source>
         <translation>고급 설정</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Enter password</source>
         <translation>비밀번호를 입력하세요</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+10"/>
         <source>for &quot;%1&quot;</source>
         <translation>&quot;%1&quot;에 접속하려면 인증이 필요합니다</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Wrong password</source>
         <translation>비밀번호가 틀렸습니다</translation>
     </message>
@@ -490,30 +401,22 @@ location set</source>
 <context>
     <name>NvgWindow</name>
     <message>
-        <location filename="../qt/onroad.cc" line="+218"/>
         <source>km/h</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+3"/>
         <source>MAX</source>
         <translation>MAX</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+3"/>
         <source>SPEED</source>
         <translation>SPEED</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+3"/>
         <source>LIMIT</source>
         <translation>LIMIT</translation>
     </message>
@@ -521,17 +424,14 @@ location set</source>
 <context>
     <name>OffroadHome</name>
     <message>
-        <location filename="../qt/home.cc" line="+114"/>
         <source>UPDATE</source>
         <translation>업데이트</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source> ALERTS</source>
         <translation> 알림</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source> ALERT</source>
         <translation> 알림</translation>
     </message>
@@ -539,22 +439,18 @@ location set</source>
 <context>
     <name>PairingPopup</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+89"/>
         <source>Pair your device to your comma account</source>
         <translation>장치를 콤마 계정과 페어링합니다</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Go to https://connect.comma.ai on your phone</source>
         <translation>https://connect.comma.ai에 접속하세요</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Click &quot;add new device&quot; and scan the QR code on the right</source>
         <translation>&quot;새 장치 추가&quot;를 클릭하고 오른쪽 QR 코드를 검색합니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>connect.comma.ai을 앱처럼 사용하려면 홈 화면에 바로가기를 만드십시오</translation>
     </message>
@@ -562,32 +458,26 @@ location set</source>
 <context>
     <name>PrimeAdWidget</name>
     <message>
-        <location line="+88"/>
         <source>Upgrade Now</source>
         <translation>지금 업그레이드</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Become a comma prime member at connect.comma.ai</source>
         <translation>connect.comma.ai에서 comma prime에 가입합니다</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>PRIME FEATURES:</source>
         <translation>PRIME 기능：</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Remote access</source>
         <translation>원격 접속</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>1 year of storage</source>
         <translation>1년간 저장</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Developer perks</source>
         <translation>개발자 혜택</translation>
     </message>
@@ -595,22 +485,18 @@ location set</source>
 <context>
     <name>PrimeUserWidget</name>
     <message>
-        <location line="-78"/>
         <source>✓ SUBSCRIBED</source>
         <translation>✓ 구독함</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>comma prime</source>
         <translation>comma prime</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>CONNECT.COMMA.AI</source>
         <translation>CONNECT.COMMA.AI</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>COMMA POINTS</source>
         <translation>COMMA POINTS</translation>
     </message>
@@ -618,41 +504,34 @@ location set</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../qt/text.cc" line="+36"/>
         <source>Reboot</source>
         <translation>재부팅</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../qt/util.cc" line="+21"/>
         <source>dashcam</source>
         <translation>dashcam</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>openpilot</source>
         <translation>openpilot</translation>
     </message>
     <message numerus="yes">
-        <location line="+61"/>
         <source>%n minute(s) ago</source>
         <translation>
             <numerusform>%n 분전</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n hour(s) ago</source>
         <translation>
             <numerusform>%n 시간전</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n day(s) ago</source>
         <translation>
             <numerusform>%n 일전</numerusform>
@@ -662,47 +541,38 @@ location set</source>
 <context>
     <name>Reset</name>
     <message>
-        <location filename="../qt/setup/reset.cc" line="+29"/>
         <source>Reset failed. Reboot to try again.</source>
         <translation>초기화 실패. 재부팅후 다시 시도하세요.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Are you sure you want to reset your device?</source>
         <translation>장치를 초기화 하시겠습니까?</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Resetting device...</source>
         <translation>장치 초기화중...</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>System Reset</source>
         <translation>장치 초기화</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>System reset triggered. Press confirm to erase all content and settings. Press cancel to resume boot.</source>
         <translation>장치를 초기화 합니다. 확인버튼을 누르면 모든 내용과 설정이 초기화됩니다. 부팅을 재개하려면 취소를 누르세요.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reboot</source>
         <translation>재부팅</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Confirm</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>데이터 파티션을 마운트할 수 없습니다. 확인 버튼을 눌러 장치를 리셋합니다.</translation>
     </message>
@@ -710,7 +580,6 @@ location set</source>
 <context>
     <name>RichTextDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-75"/>
         <source>Ok</source>
         <translation>확인</translation>
     </message>
@@ -718,33 +587,26 @@ location set</source>
 <context>
     <name>SettingsWindow</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+22"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Device</source>
         <translation>장치</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+39"/>
         <source>Network</source>
         <translation>네트워크</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Toggles</source>
         <translation>토글</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Software</source>
         <translation>소프트웨어</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Navigation</source>
         <translation>네비게이션</translation>
     </message>
@@ -752,105 +614,82 @@ location set</source>
 <context>
     <name>Setup</name>
     <message>
-        <location filename="../qt/setup/setup.cc" line="+73"/>
         <source>WARNING: Low Voltage</source>
         <translation>경고: 전압이 낮습니다</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Power your device in a car with a harness or proceed at your own risk.</source>
         <translation>하네스 보드에 차량의 전원을 연결하세요.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Power off</source>
         <translation>전원 종료</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+83"/>
-        <location line="+86"/>
         <source>Continue</source>
         <translation>계속</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Getting Started</source>
         <translation>설정 시작</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Before we get on the road, let’s finish installation and cover some details.</source>
         <translation>출발하기 전에 설정을 완료하고 몇 가지 세부 사항을 살펴보겠습니다.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Connect to Wi-Fi</source>
         <translation>wifi 연결</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+98"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Continue without Wi-Fi</source>
         <translation>wifi 연결없이 계속하기</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waiting for internet</source>
         <translation>네트워크 접속을 기다립니다</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Choose Software to Install</source>
         <translation>설치할 소프트웨어를 선택하세요</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Dashcam</source>
         <translation>Dashcam</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Custom Software</source>
         <translation>Custom Software</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Enter URL</source>
         <translation>URL 입력</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>for Custom Software</source>
         <translation>for Custom Software</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Downloading...</source>
         <translation>다운로드중...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Download Failed</source>
         <translation>다운로드 실패</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ensure the entered URL is valid, and the device’s internet connection is good.</source>
         <translation>입력된 URL이 유효하고 장치의 네트워크 연결이 잘 되어 있는지 확인하세요.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Reboot device</source>
         <translation>재부팅</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Start over</source>
         <translation>다시 시작</translation>
     </message>
@@ -858,17 +697,14 @@ location set</source>
 <context>
     <name>SetupWidget</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+82"/>
         <source>Finish Setup</source>
         <translation>설정 완료</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer.</source>
         <translation>장치를 (connect.comma.ai)에서 페어링하고 comma prime 오퍼를 청구합니다.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Pair device</source>
         <translation>장치 페어링</translation>
     </message>
@@ -876,106 +712,82 @@ location set</source>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qt/sidebar.cc" line="+74"/>
-        <location line="+2"/>
         <source>CONNECT</source>
         <translation>연결</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>OFFLINE</source>
         <translation>오프라인</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+13"/>
         <source>ONLINE</source>
         <translation>온라인</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>ERROR</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>TEMP</source>
         <translation>온도</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>HIGH</source>
         <translation>높음</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>GOOD</source>
         <translation>좋음</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>OK</source>
         <translation>경고</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>VEHICLE</source>
         <translation>차량</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>NO</source>
         <translation>NO</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PANDA</source>
         <translation>PANDA</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SEARCH</source>
         <translation>검색중</translation>
     </message>
     <message>
-        <location filename="../qt/sidebar.h" line="+36"/>
         <source>--</source>
         <translation>--</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wi-Fi</source>
         <translation>Wi-Fi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ETH</source>
         <translation>이더넷</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2G</source>
         <translation>2G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>3G</source>
         <translation>3G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>LTE</source>
         <translation>LTE</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>5G</source>
         <translation>5G</translation>
     </message>
@@ -983,63 +795,50 @@ location set</source>
 <context>
     <name>SoftwarePanel</name>
     <message>
-        <location filename="../qt/offroad/software_settings.cc" line="+24"/>
         <source>Updates are only downloaded while the car is off.</source>
         <translation>업데이트는 차량 연결이 해제되어 있는 동안에만 다운로드됩니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Current Version</source>
         <translation>현재 버전</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Download</source>
         <translation>다운로드</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Install Update</source>
         <translation>업데이트 설치</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>INSTALL</source>
         <translation>설치</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Target Branch</source>
         <translation>대상 브랜치</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SELECT</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select a branch</source>
         <translation>브랜치 선택</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>UNINSTALL</source>
         <translation>제거</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uninstall %1</source>
         <translation>%1 제거</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to uninstall?</source>
         <translation>제거하시겠습니까?</translation>
     </message>
     <message>
-        <location line="-47"/>
-        <location line="+3"/>
         <source>CHECK</source>
         <translation>확인</translation>
     </message>
@@ -1047,48 +846,38 @@ location set</source>
 <context>
     <name>SshControl</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.cc" line="+7"/>
         <source>SSH Keys</source>
         <translation>SSH 키</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.</source>
         <translation>경고: 허용으로 설정하면 GitHub 설정의 모든 공용 키에 대한 SSH 액세스 권한이 부여됩니다. GitHub 사용자 ID 이외에는 입력하지 마십시오. comma에서는 GitHub ID를 추가하라는 요청을 하지 않습니다.</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+24"/>
         <source>ADD</source>
         <translation>추가</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Enter your GitHub username</source>
         <translation>GitHub 사용자 ID</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>LOADING</source>
         <translation>로딩</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>REMOVE</source>
         <translation>제거</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Username &apos;%1&apos; has no keys on GitHub</source>
         <translation>&apos;%1&apos;의 키가 GitHub에 없습니다</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Request timed out</source>
         <translation>요청 시간 초과</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username &apos;%1&apos; doesn&apos;t exist on GitHub</source>
         <translation>&apos;%1&apos;은 GitHub에 없습니다</translation>
     </message>
@@ -1096,7 +885,6 @@ location set</source>
 <context>
     <name>SshToggle</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.h" line="+13"/>
         <source>Enable SSH</source>
         <translation>SSH 사용</translation>
     </message>
@@ -1104,22 +892,18 @@ location set</source>
 <context>
     <name>TermsPage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="-75"/>
         <source>Terms &amp; Conditions</source>
         <translation>약관</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Decline</source>
         <translation>거절</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Scroll to accept</source>
         <translation>허용하려면 아래로 스크롤하세요</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Agree</source>
         <translation>동의</translation>
     </message>
@@ -1127,102 +911,82 @@ location set</source>
 <context>
     <name>TogglesPanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="-303"/>
         <source>Enable openpilot</source>
         <translation>openpilot 사용</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off.</source>
         <translation>어댑티브 크루즈 컨트롤 및 차선 유지 운전자 보조를 위해 openpilot 시스템을 사용하십시오. 이 기능을 사용하려면 항상 주의를 기울여야 합니다. 설정변경은 장치 재부팅후 적용됩니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Enable Lane Departure Warnings</source>
         <translation>차선 이탈 경고 사용</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receive alerts to steer back into the lane when your vehicle drifts over a detected lane line without a turn signal activated while driving over 31 mph (50 km/h).</source>
         <translation>차량이 50km/h(31mph) 이상의 속도로 주행하는 동안 방향지시등 없이 감지된 차선 위를 주행할 경우 차선이탈 경고를 표시합니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use Metric System</source>
         <translation>미터법 사용</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Display speed in km/h instead of mph.</source>
         <translation>mph 대신 km/h로 속도를 표시합니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Record and Upload Driver Camera</source>
         <translation>운전자 카메라 녹화 및 업로드</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload data from the driver facing camera and help improve the driver monitoring algorithm.</source>
         <translation>운전자 카메라에서 데이터를 업로드하고 운전자 모니터링 알고리즘을 개선합니다.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>🌮 End-to-end longitudinal (extremely alpha) 🌮</source>
         <translation>🌮 e2e 롱컨트롤 사용 (매우 실험적) 🌮 </translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Experimental openpilot longitudinal control</source>
         <translation>openpilot 롱컨트롤 (실험적)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;b&gt;WARNING: openpilot longitudinal control is experimental for this car and will disable AEB.&lt;/b&gt;</source>
         <translation>&lt;b&gt;경고: openpilot 롱컨트롤은 실험적인 기능으로 차량의 AEB를 비활성화합니다.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.</source>
         <translation>주행모델이 가속과 감속을 제어하도록 하면 openpilot은 운전자가 생각하는것처럼 운전합니다. (매우 실험적)</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>openpilot longitudinal control is not currently available for this car.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enable experimental longitudinal control to enable this.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Disengage On Accelerator Pedal</source>
         <translation>가속페달 조작시 해제</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>When enabled, pressing the accelerator pedal will disengage openpilot.</source>
         <translation>활성화된 경우 가속 페달을 누르면 openpilot이 해제됩니다.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Show ETA in 24h Format</source>
         <translation>24시간 형식으로 도착예정시간 표시</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use 24h format instead of am/pm</source>
         <translation>오전/오후 대신 24시간 형식 사용</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Map on Left Side of UI</source>
         <translation>UI 왼쪽에 지도 표시</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show map on left side when in split screen view.</source>
         <translation>분할 화면 보기에서 지도를 왼쪽에 표시합니다.</translation>
     </message>
@@ -1230,42 +994,34 @@ location set</source>
 <context>
     <name>Updater</name>
     <message>
-        <location filename="../qt/setup/updater.cc" line="+23"/>
         <source>Update Required</source>
         <translation>업데이트 필요</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>An operating system update is required. Connect your device to Wi-Fi for the fastest update experience. The download size is approximately 1GB.</source>
         <translation>OS 업데이트가 필요합니다. 장치를 wifi에 연결하면 가장 빠른 업데이트 경험을 제공합니다. 다운로드 크기는 약 1GB입니다.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Connect to Wi-Fi</source>
         <translation>wifi 연결</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Install</source>
         <translation>설치</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Loading...</source>
         <translation>로딩중...</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reboot</source>
         <translation>재부팅</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Update failed</source>
         <translation>업데이트 실패</translation>
     </message>
@@ -1273,22 +1029,18 @@ location set</source>
 <context>
     <name>WifiUI</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+113"/>
         <source>Scanning for networks...</source>
         <translation>네트워크 검색 중...</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>CONNECTING...</source>
         <translation>연결중...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>FORGET</source>
         <translation>저장안함</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Forget Wi-Fi Network &quot;%1&quot;?</source>
         <translation>wifi 네트워크 저장안함 &quot;%1&quot;?</translation>
     </message>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -4,17 +4,14 @@
 <context>
     <name>AbstractAlert</name>
     <message>
-        <location filename="../qt/widgets/offroad_alerts.cc" line="+25"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Snooze Update</source>
         <translation>Adiar Atualização</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Reboot and Update</source>
         <translation>Reiniciar e Atualizar</translation>
     </message>
@@ -22,53 +19,42 @@
 <context>
     <name>AdvancedNetworking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+121"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Enable Tethering</source>
         <translation>Ativar Tether</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Tethering Password</source>
         <translation>Senha Tethering</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+27"/>
         <source>EDIT</source>
         <translation>EDITAR</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Enter new tethering password</source>
         <translation>Insira nova senha tethering</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>IP Address</source>
         <translation>Endereço IP</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable Roaming</source>
         <translation>Ativar Roaming</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>APN Setting</source>
         <translation>APN Config</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter APN</source>
         <translation>Insira APN</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>leave blank for automatic configuration</source>
         <translation>deixe em branco para configuração automática</translation>
     </message>
@@ -76,13 +62,10 @@
 <context>
     <name>ConfirmationDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+221"/>
-        <location line="+5"/>
         <source>Ok</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -90,17 +73,14 @@
 <context>
     <name>DeclinePage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="+140"/>
         <source>You must accept the Terms and Conditions in order to use openpilot.</source>
         <translation>Você precisa aceitar os Termos e Condições para utilizar openpilot.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decline, uninstall %1</source>
         <translation>Rejeitar, desintalar %1</translation>
     </message>
@@ -108,152 +88,122 @@
 <context>
     <name>DevicePanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+151"/>
         <source>Dongle ID</source>
         <translation>Dongle ID</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Serial</source>
         <translation>Serial</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Driver Camera</source>
         <translation>Câmera voltada para o Motorista</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PREVIEW</source>
         <translation>PREVISUAL</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)</source>
         <translation>Pré-visualizar a câmera voltada para o motorista para garantir que monitor tem uma boa visibilidade (veículo precisa estar desligado)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reset Calibration</source>
         <translation>Resetar Calibragem</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>RESET</source>
         <translation>RESET</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Are you sure you want to reset calibration?</source>
         <translation>Tem certeza que quer resetar a calibragem?</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Review Training Guide</source>
         <translation>Revisar Guia de Treinamento</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>REVIEW</source>
         <translation>REVISAR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Review the rules, features, and limitations of openpilot</source>
         <translation>Revisar regras, aprimoramentos e limitações do openpilot</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to review the training guide?</source>
         <translation>Tem certeza que quer rever o treinamento?</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Regulatory</source>
         <translation>Regulatório</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>VIEW</source>
         <translation>VER</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Change Language</source>
         <translation>Alterar Idioma</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>CHANGE</source>
         <translation>ALTERAR</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Select a language</source>
         <translation>Selecione o Idioma</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>openpilot requires the device to be mounted within 4° left or right and within 5° up or 8° down. openpilot is continuously calibrating, resetting is rarely required.</source>
         <translation>o openpilot requer que o dispositivo seja montado dentro de 4° esquerda ou direita e dentro de 5° para cima ou 8° para baixo. o openpilot está continuamente calibrando, resetar raramente é necessário.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source> Your device is pointed %1° %2 and %3° %4.</source>
         <translation> Seu dispositivo está montado %1° %2 e %3° %4.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>down</source>
         <translation>baixo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>up</source>
         <translation>cima</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>left</source>
         <translation>esquerda</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>right</source>
         <translation>direita</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Are you sure you want to reboot?</source>
         <translation>Tem certeza que quer reiniciar?</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Reboot</source>
         <translation>Desacione para Reiniciar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Are you sure you want to power off?</source>
         <translation>Tem certeza que quer desligar?</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Power Off</source>
         <translation>Desacione para Desligar</translation>
     </message>
@@ -261,32 +211,26 @@
 <context>
     <name>DriveStats</name>
     <message>
-        <location filename="../qt/widgets/drive_stats.cc" line="+37"/>
         <source>Drives</source>
         <translation>Dirigidas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Hours</source>
         <translation>Horas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>ALL TIME</source>
         <translation>TOTAL</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>PAST WEEK</source>
         <translation>SEMANA PASSADA</translation>
     </message>
     <message>
-        <location filename="../qt/widgets/drive_stats.h" line="+15"/>
         <source>KM</source>
         <translation>KM</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Miles</source>
         <translation>Milhas</translation>
     </message>
@@ -294,7 +238,6 @@
 <context>
     <name>DriverViewScene</name>
     <message>
-        <location filename="../qt/offroad/driverview.cc" line="+55"/>
         <source>camera starting</source>
         <translation>câmera iniciando</translation>
     </message>
@@ -302,12 +245,10 @@
 <context>
     <name>InputDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-155"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message numerus="yes">
-        <location line="+97"/>
         <source>Need at least %n character(s)!</source>
         <translation>
             <numerusform>Necessita no mínimo %n caractere!</numerusform>
@@ -318,22 +259,18 @@
 <context>
     <name>Installer</name>
     <message>
-        <location filename="../installer/installer.cc" line="+56"/>
         <source>Installing...</source>
         <translation>Instalando...</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>Receiving objects: </source>
         <translation>Recebendo objetos: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Resolving deltas: </source>
         <translation>Resolvendo deltas: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Updating files: </source>
         <translation>Atualizando arquivos: </translation>
     </message>
@@ -341,27 +278,22 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
         <source>eta</source>
         <translation>eta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>min</source>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>hr</source>
         <translation>hr</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>mi</source>
         <translation>mi</translation>
     </message>
@@ -369,22 +301,18 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> mi</source>
         <translation> milha</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> ft</source>
         <translation> pés</translation>
     </message>
@@ -392,48 +320,40 @@
 <context>
     <name>MapPanel</name>
     <message>
-        <location filename="../qt/maps/map_settings.cc" line="+62"/>
         <source>Current Destination</source>
         <translation>Destino Atual</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>CLEAR</source>
         <translation>LIMPAR</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Recent Destinations</source>
         <translation>Destinos Recentes</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Try the Navigation Beta</source>
         <translation>Experimente a Navegação Beta</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Get turn-by-turn directions displayed and more with a comma
 prime subscription. Sign up now: https://connect.comma.ai</source>
         <translation>Obtenha instruções passo a passo exibidas e muito mais com 
 uma assinatura prime Inscreva-se agora:  https://connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>No home
 location set</source>
         <translation>Sem local
 residência definido</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No work
 location set</source>
         <translation>Sem local de
 trabalho definido</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>no recent destinations</source>
         <translation>sem destinos recentes</translation>
     </message>
@@ -441,12 +361,10 @@ trabalho definido</translation>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
         <source>Map Loading</source>
         <translation>Carregando Mapa</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Waiting for GPS</source>
         <translation>Esperando por GPS</translation>
     </message>
@@ -454,12 +372,10 @@ trabalho definido</translation>
 <context>
     <name>MultiOptionDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+132"/>
         <source>Select</source>
         <translation>Selecione</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -467,23 +383,18 @@ trabalho definido</translation>
 <context>
     <name>Networking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="-135"/>
         <source>Advanced</source>
         <translation>Avançado</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Enter password</source>
         <translation>Insira a senha</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+10"/>
         <source>for &quot;%1&quot;</source>
         <translation>para &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Wrong password</source>
         <translation>Senha incorreta</translation>
     </message>
@@ -491,30 +402,22 @@ trabalho definido</translation>
 <context>
     <name>NvgWindow</name>
     <message>
-        <location filename="../qt/onroad.cc" line="+218"/>
         <source>km/h</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+3"/>
         <source>MAX</source>
         <translation>LIMITE</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+3"/>
         <source>SPEED</source>
         <translation>MAX</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+3"/>
         <source>LIMIT</source>
         <translation>VELO</translation>
     </message>
@@ -522,17 +425,14 @@ trabalho definido</translation>
 <context>
     <name>OffroadHome</name>
     <message>
-        <location filename="../qt/home.cc" line="+114"/>
         <source>UPDATE</source>
         <translation>ATUALIZAÇÃO</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source> ALERTS</source>
         <translation> ALERTAS</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source> ALERT</source>
         <translation> ALERTA</translation>
     </message>
@@ -540,22 +440,18 @@ trabalho definido</translation>
 <context>
     <name>PairingPopup</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+89"/>
         <source>Pair your device to your comma account</source>
         <translation>Pareie seu dispositivo à sua conta comma</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Go to https://connect.comma.ai on your phone</source>
         <translation>navegue até https://connect.comma.ai no seu telefone</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Click &quot;add new device&quot; and scan the QR code on the right</source>
         <translation>Clique &quot;add new device&quot; e escaneie o QR code a seguir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>Salve connect.comma.ai como sua página inicial para utilizar como um app</translation>
     </message>
@@ -563,32 +459,26 @@ trabalho definido</translation>
 <context>
     <name>PrimeAdWidget</name>
     <message>
-        <location line="+88"/>
         <source>Upgrade Now</source>
         <translation>Atualizar Agora</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Become a comma prime member at connect.comma.ai</source>
         <translation>Torne-se um membro comma prime em connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>PRIME FEATURES:</source>
         <translation>APRIMORAMENTOS PRIME:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Remote access</source>
         <translation>Acesso remoto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>1 year of storage</source>
         <translation>1 ano de armazenamento</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Developer perks</source>
         <translation>Benefícios para desenvolvedor</translation>
     </message>
@@ -596,22 +486,18 @@ trabalho definido</translation>
 <context>
     <name>PrimeUserWidget</name>
     <message>
-        <location line="-78"/>
         <source>✓ SUBSCRIBED</source>
         <translation>✓ INSCRITO</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>comma prime</source>
         <translation>comma prime</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>CONNECT.COMMA.AI</source>
         <translation>CONNECT.COMMA.AI</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>COMMA POINTS</source>
         <translation>PONTOS COMMA</translation>
     </message>
@@ -619,27 +505,22 @@ trabalho definido</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../qt/text.cc" line="+36"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exit</source>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../qt/util.cc" line="+21"/>
         <source>dashcam</source>
         <translation>dashcam</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>openpilot</source>
         <translation>openpilot</translation>
     </message>
     <message numerus="yes">
-        <location line="+61"/>
         <source>%n minute(s) ago</source>
         <translation>
             <numerusform>há %n minuto</numerusform>
@@ -647,7 +528,6 @@ trabalho definido</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n hour(s) ago</source>
         <translation>
             <numerusform>há %n hora</numerusform>
@@ -655,7 +535,6 @@ trabalho definido</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n day(s) ago</source>
         <translation>
             <numerusform>há %n dia</numerusform>
@@ -666,47 +545,38 @@ trabalho definido</translation>
 <context>
     <name>Reset</name>
     <message>
-        <location filename="../qt/setup/reset.cc" line="+29"/>
         <source>Reset failed. Reboot to try again.</source>
         <translation>Reset falhou. Reinicie para tentar novamente.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Are you sure you want to reset your device?</source>
         <translation>Tem certeza que quer resetar seu dispositivo?</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Resetting device...</source>
         <translation>Resetando dispositivo...</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>System Reset</source>
         <translation>Resetar Sistema</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>System reset triggered. Press confirm to erase all content and settings. Press cancel to resume boot.</source>
         <translation>Solicitado reset do sistema. Confirme para apagar todo conteúdo e configurações. Aperte cancelar para continuar boot.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>Não foi possível montar a partição de dados. Pressione confirmar para resetar seu dispositivo.</translation>
     </message>
@@ -714,7 +584,6 @@ trabalho definido</translation>
 <context>
     <name>RichTextDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-75"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -722,33 +591,26 @@ trabalho definido</translation>
 <context>
     <name>SettingsWindow</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+22"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+39"/>
         <source>Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Toggles</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Software</source>
         <translation>Software</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Navigation</source>
         <translation>Navegação</translation>
     </message>
@@ -756,105 +618,82 @@ trabalho definido</translation>
 <context>
     <name>Setup</name>
     <message>
-        <location filename="../qt/setup/setup.cc" line="+73"/>
         <source>WARNING: Low Voltage</source>
         <translation>ALERTA: Baixa Voltagem</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Power your device in a car with a harness or proceed at your own risk.</source>
         <translation>Ligue seu dispositivo em um carro com um chicote ou prossiga por sua conta e risco.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Power off</source>
         <translation>Desligar</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+83"/>
-        <location line="+86"/>
         <source>Continue</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Getting Started</source>
         <translation>Começando</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Before we get on the road, let’s finish installation and cover some details.</source>
         <translation>Antes de pegarmos a estrada, vamos terminar a instalação e cobrir alguns detalhes.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Connect to Wi-Fi</source>
         <translation>Conectar ao Wi-Fi</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+98"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Continue without Wi-Fi</source>
         <translation>Continuar sem Wi-Fi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waiting for internet</source>
         <translation>Esperando pela internet</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Choose Software to Install</source>
         <translation>Escolher Software para Instalar</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Dashcam</source>
         <translation>Dashcam</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Custom Software</source>
         <translation>Sofware Customizado</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Enter URL</source>
         <translation>Preencher URL</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>for Custom Software</source>
         <translation>para o Software Customizado</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Downloading...</source>
         <translation>Baixando...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Download Failed</source>
         <translation>Download Falhou</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ensure the entered URL is valid, and the device’s internet connection is good.</source>
         <translation>Garanta que a URL inserida é valida, e uma boa conexão à internet.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Reboot device</source>
         <translation>Reiniciar Dispositivo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Start over</source>
         <translation>Inicializar</translation>
     </message>
@@ -862,17 +701,14 @@ trabalho definido</translation>
 <context>
     <name>SetupWidget</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+82"/>
         <source>Finish Setup</source>
         <translation>Concluir</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer.</source>
         <translation>Pareie seu dispositivo com comma connect (connect.comma.ai) e reivindique sua oferta de comma prime.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Pair device</source>
         <translation>Parear dispositivo</translation>
     </message>
@@ -880,106 +716,82 @@ trabalho definido</translation>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qt/sidebar.cc" line="+74"/>
-        <location line="+2"/>
         <source>CONNECT</source>
         <translation>CONEXÃO</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>OFFLINE</source>
         <translation>OFFLINE</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+13"/>
         <source>ONLINE</source>
         <translation>ONLINE</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>ERROR</source>
         <translation>ERRO</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>TEMP</source>
         <translation>TEMP</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>HIGH</source>
         <translation>ALTA</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>GOOD</source>
         <translation>BOA</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>VEHICLE</source>
         <translation>VEÍCULO</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>NO</source>
         <translation>SEM</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PANDA</source>
         <translation>PANDA</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SEARCH</source>
         <translation>PROCURA</translation>
     </message>
     <message>
-        <location filename="../qt/sidebar.h" line="+36"/>
         <source>--</source>
         <translation>--</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wi-Fi</source>
         <translation>Wi-Fi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ETH</source>
         <translation>ETH</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2G</source>
         <translation>2G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>3G</source>
         <translation>3G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>LTE</source>
         <translation>LTE</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>5G</source>
         <translation>5G</translation>
     </message>
@@ -987,63 +799,50 @@ trabalho definido</translation>
 <context>
     <name>SoftwarePanel</name>
     <message>
-        <location filename="../qt/offroad/software_settings.cc" line="+24"/>
         <source>Updates are only downloaded while the car is off.</source>
         <translation>Atualizações baixadas durante o motor desligado.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Current Version</source>
         <translation>Versao Atual</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Install Update</source>
         <translation>Instalar Atualização</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>INSTALL</source>
         <translation>INSTALAR</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Target Branch</source>
         <translation>Alterar Branch</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SELECT</source>
         <translation>SELECIONE</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select a branch</source>
         <translation>Selecione uma branch</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>UNINSTALL</source>
         <translation>DESINSTAL</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uninstall %1</source>
         <translation>Desintalar o %1</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to uninstall?</source>
         <translation>Tem certeza que quer desinstalar?</translation>
     </message>
     <message>
-        <location line="-47"/>
-        <location line="+3"/>
         <source>CHECK</source>
         <translation>VERIFICAR</translation>
     </message>
@@ -1051,48 +850,38 @@ trabalho definido</translation>
 <context>
     <name>SshControl</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.cc" line="+7"/>
         <source>SSH Keys</source>
         <translation>Chave SSH</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.</source>
         <translation>Aviso: isso concede acesso SSH a todas as chaves públicas nas configurações do GitHub. Nunca insira um nome de usuário do GitHub que não seja o seu. Um funcionário da comma NUNCA pedirá que você adicione seu nome de usuário do GitHub.</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+24"/>
         <source>ADD</source>
         <translation>ADICIONAR</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Enter your GitHub username</source>
         <translation>Insira seu nome de usuário do GitHub</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>LOADING</source>
         <translation>CARREGANDO</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>REMOVE</source>
         <translation>REMOVER</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Username &apos;%1&apos; has no keys on GitHub</source>
         <translation>Usuário &quot;%1” não possui chaves no GitHub</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Request timed out</source>
         <translation>A solicitação expirou</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username &apos;%1&apos; doesn&apos;t exist on GitHub</source>
         <translation>Usuário &apos;%1&apos; não existe no GitHub</translation>
     </message>
@@ -1100,7 +889,6 @@ trabalho definido</translation>
 <context>
     <name>SshToggle</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.h" line="+13"/>
         <source>Enable SSH</source>
         <translation>Habilitar SSH</translation>
     </message>
@@ -1108,22 +896,18 @@ trabalho definido</translation>
 <context>
     <name>TermsPage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="-75"/>
         <source>Terms &amp; Conditions</source>
         <translation>Termos &amp; Condições</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Decline</source>
         <translation>Declinar</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Scroll to accept</source>
         <translation>Role a tela para aceitar</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Agree</source>
         <translation>Concordo</translation>
     </message>
@@ -1131,102 +915,82 @@ trabalho definido</translation>
 <context>
     <name>TogglesPanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="-303"/>
         <source>Enable openpilot</source>
         <translation>Ativar openpilot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off.</source>
         <translation>Use o sistema openpilot para controle de cruzeiro adaptativo e assistência ao motorista de manutenção de faixa. Sua atenção é necessária o tempo todo para usar esse recurso. A alteração desta configuração tem efeito quando o carro é desligado.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Enable Lane Departure Warnings</source>
         <translation>Ativar Avisos de Saída de Faixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receive alerts to steer back into the lane when your vehicle drifts over a detected lane line without a turn signal activated while driving over 31 mph (50 km/h).</source>
         <translation>Receba alertas para voltar para a pista se o seu veículo sair da faixa e a seta não tiver sido acionada previamente quando em velocidades superiores a 50 km/h.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use Metric System</source>
         <translation>Usar Sistema Métrico</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Display speed in km/h instead of mph.</source>
         <translation>Exibir velocidade em km/h invés de mph.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Record and Upload Driver Camera</source>
         <translation>Gravar e Upload Câmera Motorista</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload data from the driver facing camera and help improve the driver monitoring algorithm.</source>
         <translation>Upload dados da câmera voltada para o motorista e ajude a melhorar o algoritmo de monitoramentor.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>🌮 End-to-end longitudinal (extremely alpha) 🌮</source>
         <translation>🌮 End-to-end longitudinal (experimental) 🌮</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Experimental openpilot longitudinal control</source>
         <translation>Controle longitudinal experimental openpilot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;b&gt;WARNING: openpilot longitudinal control is experimental for this car and will disable AEB.&lt;/b&gt;</source>
         <translation>&lt;b&gt;AVISO: o controle longitudinal openpilot é experimental para este carro e irá desabilitar AEB.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.</source>
         <translation>Deixe o modelo controlar o acelerador e os freios. openpilot irá conduzir como pensa que um humano faria. Super experimental.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>openpilot longitudinal control is not currently available for this car.</source>
         <translation>controle longitudinal openpilot não está disponível para este carro.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enable experimental longitudinal control to enable this.</source>
         <translation>Habilite o controle longitudinal experimental para habilitar isso.</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Disengage On Accelerator Pedal</source>
         <translation>Desacionar Com Pedal Do Acelerador</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>When enabled, pressing the accelerator pedal will disengage openpilot.</source>
         <translation>Quando ativado, pressionar o pedal do acelerador desacionará o openpilot.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Show ETA in 24h Format</source>
         <translation>Mostrar ETA em formato 24h</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use 24h format instead of am/pm</source>
         <translation>Use o formato 24h em vez de am/pm</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Map on Left Side of UI</source>
         <translation>Exibir Mapa no Lado Esquerdo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show map on left side when in split screen view.</source>
         <translation>Exibir mapa do lado esquerdo quando a tela for dividida.</translation>
     </message>
@@ -1234,42 +998,34 @@ trabalho definido</translation>
 <context>
     <name>Updater</name>
     <message>
-        <location filename="../qt/setup/updater.cc" line="+23"/>
         <source>Update Required</source>
         <translation>Atualização Necessária</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>An operating system update is required. Connect your device to Wi-Fi for the fastest update experience. The download size is approximately 1GB.</source>
         <translation>Uma atualização do sistema operacional é necessária. Conecte seu dispositivo ao Wi-Fi para a experiência de atualização mais rápida. O tamanho do download é de aproximadamente 1GB.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Connect to Wi-Fi</source>
         <translation>Conecte-se ao Wi-Fi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Loading...</source>
         <translation>Carregando...</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Update failed</source>
         <translation>Falha na atualização</translation>
     </message>
@@ -1277,22 +1033,18 @@ trabalho definido</translation>
 <context>
     <name>WifiUI</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+113"/>
         <source>Scanning for networks...</source>
         <translation>Procurando redes...</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>CONNECTING...</source>
         <translation>CONECTANDO...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>FORGET</source>
         <translation>ESQUECER</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Forget Wi-Fi Network &quot;%1&quot;?</source>
         <translation>Esquecer Rede Wi-Fi &quot;%1&quot;?</translation>
     </message>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -4,17 +4,14 @@
 <context>
     <name>AbstractAlert</name>
     <message>
-        <location filename="../qt/widgets/offroad_alerts.cc" line="+25"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Snooze Update</source>
         <translation>暂停更新</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Reboot and Update</source>
         <translation>重启并更新</translation>
     </message>
@@ -22,53 +19,42 @@
 <context>
     <name>AdvancedNetworking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+121"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Enable Tethering</source>
         <translation>启用WiFi热点</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Tethering Password</source>
         <translation>WiFi热点密码</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+27"/>
         <source>EDIT</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Enter new tethering password</source>
         <translation>输入新的WiFi热点密码</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>IP Address</source>
         <translation>IP地址</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable Roaming</source>
         <translation>启用数据漫游</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>APN Setting</source>
         <translation>APN设置</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter APN</source>
         <translation>输入APN</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>leave blank for automatic configuration</source>
         <translation>留空以自动配置</translation>
     </message>
@@ -76,13 +62,10 @@
 <context>
     <name>ConfirmationDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+221"/>
-        <location line="+5"/>
         <source>Ok</source>
         <translation>好的</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -90,17 +73,14 @@
 <context>
     <name>DeclinePage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="+140"/>
         <source>You must accept the Terms and Conditions in order to use openpilot.</source>
         <translation>您必须接受条款和条件以使用openpilot。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decline, uninstall %1</source>
         <translation>拒绝并卸载%1</translation>
     </message>
@@ -108,152 +88,122 @@
 <context>
     <name>DevicePanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+151"/>
         <source>Dongle ID</source>
         <translation>设备ID（Dongle ID）</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Serial</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Driver Camera</source>
         <translation>驾驶员摄像头</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PREVIEW</source>
         <translation>预览</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)</source>
         <translation>打开并预览驾驶员摄像头，以确保驾驶员监控具有良好视野。仅熄火时可用。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reset Calibration</source>
         <translation>重置设备校准</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>RESET</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Are you sure you want to reset calibration?</source>
         <translation>您确定要重置设备校准吗？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Review Training Guide</source>
         <translation>新手指南</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>REVIEW</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Review the rules, features, and limitations of openpilot</source>
         <translation>查看openpilot的使用规则，以及其功能和限制。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to review the training guide?</source>
         <translation>您确定要查看新手指南吗？</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Regulatory</source>
         <translation>监管信息</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>VIEW</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Change Language</source>
         <translation>切换语言</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>CHANGE</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Select a language</source>
         <translation>选择语言</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Reboot</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Power Off</source>
         <translation>关机</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>openpilot requires the device to be mounted within 4° left or right and within 5° up or 8° down. openpilot is continuously calibrating, resetting is rarely required.</source>
         <translation>openpilot要求设备安装的偏航角在左4°和右4°之间，俯仰角在上5°和下8°之间。一般来说，openpilot会持续更新校准，很少需要重置。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source> Your device is pointed %1° %2 and %3° %4.</source>
         <translation>您的设备校准为%1° %2、%3° %4。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>down</source>
         <translation>朝下</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>up</source>
         <translation>朝上</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>left</source>
         <translation>朝左</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>right</source>
         <translation>朝右</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Are you sure you want to reboot?</source>
         <translation>您确定要重新启动吗？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Reboot</source>
         <translation>取消openpilot以重新启动</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Are you sure you want to power off?</source>
         <translation>您确定要关机吗？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Power Off</source>
         <translation>取消openpilot以关机</translation>
     </message>
@@ -261,32 +211,26 @@
 <context>
     <name>DriveStats</name>
     <message>
-        <location filename="../qt/widgets/drive_stats.cc" line="+37"/>
         <source>Drives</source>
         <translation>旅程数</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Hours</source>
         <translation>小时</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>ALL TIME</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>PAST WEEK</source>
         <translation>过去一周</translation>
     </message>
     <message>
-        <location filename="../qt/widgets/drive_stats.h" line="+15"/>
         <source>KM</source>
         <translation>公里</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Miles</source>
         <translation>英里</translation>
     </message>
@@ -294,7 +238,6 @@
 <context>
     <name>DriverViewScene</name>
     <message>
-        <location filename="../qt/offroad/driverview.cc" line="+55"/>
         <source>camera starting</source>
         <translation>正在启动相机</translation>
     </message>
@@ -302,12 +245,10 @@
 <context>
     <name>InputDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-155"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message numerus="yes">
-        <location line="+97"/>
         <source>Need at least %n character(s)!</source>
         <translation>
             <numerusform>至少需要 %n 个字符！</numerusform>
@@ -317,22 +258,18 @@
 <context>
     <name>Installer</name>
     <message>
-        <location filename="../installer/installer.cc" line="+56"/>
         <source>Installing...</source>
         <translation>正在安装……</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>Receiving objects: </source>
         <translation>正在接收： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Resolving deltas: </source>
         <translation>正在处理： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Updating files: </source>
         <translation>正在更新文件： </translation>
     </message>
@@ -340,27 +277,22 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
         <source>eta</source>
         <translation>埃塔</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>min</source>
         <translation>分钟</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>hr</source>
         <translation>小时</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>mi</source>
         <translation>mi</translation>
     </message>
@@ -368,22 +300,18 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> mi</source>
         <translation> mi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> ft</source>
         <translation> ft</translation>
     </message>
@@ -391,46 +319,38 @@
 <context>
     <name>MapPanel</name>
     <message>
-        <location filename="../qt/maps/map_settings.cc" line="+62"/>
         <source>Current Destination</source>
         <translation>当前目的地</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>CLEAR</source>
         <translation>清空</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Recent Destinations</source>
         <translation>最近目的地</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Try the Navigation Beta</source>
         <translation>试用导航测试版</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Get turn-by-turn directions displayed and more with a comma
 prime subscription. Sign up now: https://connect.comma.ai</source>
         <translation>订阅comma prime以获取导航。 
 立即注册：https://connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>No home
 location set</source>
         <translation>家：未设定</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No work
 location set</source>
         <translation>工作：未设定</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>no recent destinations</source>
         <translation>无最近目的地</translation>
     </message>
@@ -438,12 +358,10 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
         <source>Map Loading</source>
         <translation>地图加载中</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Waiting for GPS</source>
         <translation>等待 GPS</translation>
     </message>
@@ -451,12 +369,10 @@ location set</source>
 <context>
     <name>MultiOptionDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+132"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -464,23 +380,18 @@ location set</source>
 <context>
     <name>Networking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="-135"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Enter password</source>
         <translation>输入密码</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+10"/>
         <source>for &quot;%1&quot;</source>
         <translation>网络名称：&quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Wrong password</source>
         <translation>密码错误</translation>
     </message>
@@ -488,30 +399,22 @@ location set</source>
 <context>
     <name>NvgWindow</name>
     <message>
-        <location filename="../qt/onroad.cc" line="+218"/>
         <source>km/h</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+3"/>
         <source>MAX</source>
         <translation>最高定速</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+3"/>
         <source>SPEED</source>
         <translation>SPEED</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+3"/>
         <source>LIMIT</source>
         <translation>LIMIT</translation>
     </message>
@@ -519,17 +422,14 @@ location set</source>
 <context>
     <name>OffroadHome</name>
     <message>
-        <location filename="../qt/home.cc" line="+114"/>
         <source>UPDATE</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source> ALERTS</source>
         <translation> 警报</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source> ALERT</source>
         <translation> 警报</translation>
     </message>
@@ -537,22 +437,18 @@ location set</source>
 <context>
     <name>PairingPopup</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+89"/>
         <source>Pair your device to your comma account</source>
         <translation>将您的设备与comma账号配对</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Go to https://connect.comma.ai on your phone</source>
         <translation>在手机上访问 https://connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Click &quot;add new device&quot; and scan the QR code on the right</source>
         <translation>点击“添加新设备”，扫描右侧二维码</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>将 connect.comma.ai 收藏到您的主屏幕，以便像应用程序一样使用它</translation>
     </message>
@@ -560,32 +456,26 @@ location set</source>
 <context>
     <name>PrimeAdWidget</name>
     <message>
-        <location line="+88"/>
         <source>Upgrade Now</source>
         <translation>现在升级</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Become a comma prime member at connect.comma.ai</source>
         <translation>打开connect.comma.ai以注册comma prime会员</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>PRIME FEATURES:</source>
         <translation>comma prime特权：</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Remote access</source>
         <translation>远程访问</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>1 year of storage</source>
         <translation>1年数据存储</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Developer perks</source>
         <translation>开发者福利</translation>
     </message>
@@ -593,22 +483,18 @@ location set</source>
 <context>
     <name>PrimeUserWidget</name>
     <message>
-        <location line="-78"/>
         <source>✓ SUBSCRIBED</source>
         <translation>✓ 已订阅</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>comma prime</source>
         <translation>comma prime</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>CONNECT.COMMA.AI</source>
         <translation>CONNECT.COMMA.AI</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>COMMA POINTS</source>
         <translation>COMMA POINTS点数</translation>
     </message>
@@ -616,41 +502,34 @@ location set</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../qt/text.cc" line="+36"/>
         <source>Reboot</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../qt/util.cc" line="+21"/>
         <source>dashcam</source>
         <translation>行车记录仪</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>openpilot</source>
         <translation>openpilot</translation>
     </message>
     <message numerus="yes">
-        <location line="+61"/>
         <source>%n minute(s) ago</source>
         <translation>
             <numerusform>%n 分钟前</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n hour(s) ago</source>
         <translation>
             <numerusform>%n 小时前</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n day(s) ago</source>
         <translation>
             <numerusform>%n 天前</numerusform>
@@ -660,47 +539,38 @@ location set</source>
 <context>
     <name>Reset</name>
     <message>
-        <location filename="../qt/setup/reset.cc" line="+29"/>
         <source>Reset failed. Reboot to try again.</source>
         <translation>重置失败。 重新启动以重试。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Are you sure you want to reset your device?</source>
         <translation>您确定要重置您的设备吗？</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Resetting device...</source>
         <translation>正在重置设备……</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>System Reset</source>
         <translation>恢复出厂设置</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>System reset triggered. Press confirm to erase all content and settings. Press cancel to resume boot.</source>
         <translation>已触发系统重置：确认以删除所有内容和设置。取消以正常启动设备。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reboot</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>无法挂载数据分区。 确认以重置您的设备。</translation>
     </message>
@@ -708,7 +578,6 @@ location set</source>
 <context>
     <name>RichTextDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-75"/>
         <source>Ok</source>
         <translation>好的</translation>
     </message>
@@ -716,33 +585,26 @@ location set</source>
 <context>
     <name>SettingsWindow</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+22"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+39"/>
         <source>Network</source>
         <translation>网络</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Toggles</source>
         <translation>设定</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Software</source>
         <translation>软件</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Navigation</source>
         <translation>导航</translation>
     </message>
@@ -750,105 +612,82 @@ location set</source>
 <context>
     <name>Setup</name>
     <message>
-        <location filename="../qt/setup/setup.cc" line="+73"/>
         <source>WARNING: Low Voltage</source>
         <translation>警告：低电压</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Power your device in a car with a harness or proceed at your own risk.</source>
         <translation>请使用car harness线束为您的设备供电，或自行承担风险。</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Power off</source>
         <translation>关机</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+83"/>
-        <location line="+86"/>
         <source>Continue</source>
         <translation>继续</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Getting Started</source>
         <translation>开始设置</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Before we get on the road, let’s finish installation and cover some details.</source>
         <translation>开始旅程之前，让我们完成安装并介绍一些细节。</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Connect to Wi-Fi</source>
         <translation>连接到WiFi</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+98"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Continue without Wi-Fi</source>
         <translation>不连接WiFi并继续</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waiting for internet</source>
         <translation>等待网络连接</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Choose Software to Install</source>
         <translation>选择要安装的软件</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Dashcam</source>
         <translation>Dashcam（行车记录仪）</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Custom Software</source>
         <translation>自定义软件</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Enter URL</source>
         <translation>输入网址</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>for Custom Software</source>
         <translation>以下载自定义软件</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Downloading...</source>
         <translation>正在下载……</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Download Failed</source>
         <translation>下载失败</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ensure the entered URL is valid, and the device’s internet connection is good.</source>
         <translation>请确保互联网连接良好且输入的URL有效。</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Reboot device</source>
         <translation>重启设备</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Start over</source>
         <translation>重来</translation>
     </message>
@@ -856,17 +695,14 @@ location set</source>
 <context>
     <name>SetupWidget</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+82"/>
         <source>Finish Setup</source>
         <translation>完成设置</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer.</source>
         <translation>将您的设备与comma connect （connect.comma.ai）配对并领取您的comma prime优惠。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Pair device</source>
         <translation>配对设备</translation>
     </message>
@@ -874,106 +710,82 @@ location set</source>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qt/sidebar.cc" line="+74"/>
-        <location line="+2"/>
         <source>CONNECT</source>
         <translation>CONNECT</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>OFFLINE</source>
         <translation>离线</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+13"/>
         <source>ONLINE</source>
         <translation>在线</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>ERROR</source>
         <translation>连接出错</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>TEMP</source>
         <translation>设备温度</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>HIGH</source>
         <translation>过热</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>GOOD</source>
         <translation>良好</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>OK</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>VEHICLE</source>
         <translation>车辆连接</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>NO</source>
         <translation>无</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PANDA</source>
         <translation>PANDA</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SEARCH</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../qt/sidebar.h" line="+36"/>
         <source>--</source>
         <translation>--</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wi-Fi</source>
         <translation>Wi-Fi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ETH</source>
         <translation>以太网</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2G</source>
         <translation>2G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>3G</source>
         <translation>3G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>LTE</source>
         <translation>LTE</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>5G</source>
         <translation>5G</translation>
     </message>
@@ -981,63 +793,50 @@ location set</source>
 <context>
     <name>SoftwarePanel</name>
     <message>
-        <location filename="../qt/offroad/software_settings.cc" line="+24"/>
         <source>Updates are only downloaded while the car is off.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Current Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Install Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>INSTALL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Target Branch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select a branch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>UNINSTALL</source>
         <translation>卸载</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uninstall %1</source>
         <translation>卸载 %1</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to uninstall?</source>
         <translation>您确定要卸载吗？</translation>
     </message>
     <message>
-        <location line="-47"/>
-        <location line="+3"/>
         <source>CHECK</source>
         <translation>查看</translation>
     </message>
@@ -1045,48 +844,38 @@ location set</source>
 <context>
     <name>SshControl</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.cc" line="+7"/>
         <source>SSH Keys</source>
         <translation>SSH密钥</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.</source>
         <translation>警告：这将授予SSH访问权限给您GitHub设置中的所有公钥。切勿输入您自己以外的GitHub用户名。comma员工永远不会要求您添加他们的GitHub用户名。</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+24"/>
         <source>ADD</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Enter your GitHub username</source>
         <translation>输入您的GitHub用户名</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>LOADING</source>
         <translation>正在加载</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>REMOVE</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Username &apos;%1&apos; has no keys on GitHub</source>
         <translation>用户名“%1”在GitHub上没有密钥</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Request timed out</source>
         <translation>请求超时</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username &apos;%1&apos; doesn&apos;t exist on GitHub</source>
         <translation>GitHub上不存在用户名“%1”</translation>
     </message>
@@ -1094,7 +883,6 @@ location set</source>
 <context>
     <name>SshToggle</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.h" line="+13"/>
         <source>Enable SSH</source>
         <translation>启用SSH</translation>
     </message>
@@ -1102,22 +890,18 @@ location set</source>
 <context>
     <name>TermsPage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="-75"/>
         <source>Terms &amp; Conditions</source>
         <translation>条款和条件</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Decline</source>
         <translation>拒绝</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Scroll to accept</source>
         <translation>滑动以接受</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Agree</source>
         <translation>同意</translation>
     </message>
@@ -1125,102 +909,82 @@ location set</source>
 <context>
     <name>TogglesPanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="-303"/>
         <source>Enable openpilot</source>
         <translation>启用openpilot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off.</source>
         <translation>使用openpilot进行自适应巡航和车道保持辅助。使用此功能时您必须时刻保持注意力。该设置的更改在熄火时生效。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Enable Lane Departure Warnings</source>
         <translation>启用车道偏离警告</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receive alerts to steer back into the lane when your vehicle drifts over a detected lane line without a turn signal activated while driving over 31 mph (50 km/h).</source>
         <translation>车速超过31mph（50km/h）时，若检测到车辆越过车道线且未打转向灯，系统将发出警告以提醒您返回车道。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use Metric System</source>
         <translation>使用公制单位</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Display speed in km/h instead of mph.</source>
         <translation>显示车速时，以km/h代替mph。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Record and Upload Driver Camera</source>
         <translation>录制并上传驾驶员摄像头</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload data from the driver facing camera and help improve the driver monitoring algorithm.</source>
         <translation>上传驾驶员摄像头的数据，帮助改进驾驶员监控算法。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>🌮 End-to-end longitudinal (extremely alpha) 🌮</source>
         <translation>🌮 端对端纵向控制（实验性功能） 🌮</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Experimental openpilot longitudinal control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;b&gt;WARNING: openpilot longitudinal control is experimental for this car and will disable AEB.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.</source>
         <translation>让驾驶模型直接控制油门和刹车，openpilot将会模仿人类司机的驾驶方式。该功能仍非常实验性。</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>openpilot longitudinal control is not currently available for this car.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enable experimental longitudinal control to enable this.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Disengage On Accelerator Pedal</source>
         <translation>踩油门时取消控制</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>When enabled, pressing the accelerator pedal will disengage openpilot.</source>
         <translation>启用后，踩下油门踏板将取消openpilot。</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Show ETA in 24h Format</source>
         <translation>以24小时格式显示预计到达时间</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use 24h format instead of am/pm</source>
         <translation>使用24小时制代替am/pm</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Map on Left Side of UI</source>
         <translation>在介面左侧显示地图</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show map on left side when in split screen view.</source>
         <translation>在分屏模式中，将地图置于屏幕左侧。</translation>
     </message>
@@ -1228,42 +992,34 @@ location set</source>
 <context>
     <name>Updater</name>
     <message>
-        <location filename="../qt/setup/updater.cc" line="+23"/>
         <source>Update Required</source>
         <translation>需要更新</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>An operating system update is required. Connect your device to Wi-Fi for the fastest update experience. The download size is approximately 1GB.</source>
         <translation>操作系统需要更新。请将您的设备连接到WiFi以获取更快的更新体验。下载大小约为1GB。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Connect to Wi-Fi</source>
         <translation>连接到WiFi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Install</source>
         <translation>安装</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Loading...</source>
         <translation>正在加载……</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reboot</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Update failed</source>
         <translation>更新失败</translation>
     </message>
@@ -1271,22 +1027,18 @@ location set</source>
 <context>
     <name>WifiUI</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+113"/>
         <source>Scanning for networks...</source>
         <translation>正在扫描网络……</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>CONNECTING...</source>
         <translation>正在连接……</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>FORGET</source>
         <translation>忘记</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Forget Wi-Fi Network &quot;%1&quot;?</source>
         <translation>忘记WiFi网络 &quot;%1&quot;?</translation>
     </message>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -4,17 +4,14 @@
 <context>
     <name>AbstractAlert</name>
     <message>
-        <location filename="../qt/widgets/offroad_alerts.cc" line="+25"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Snooze Update</source>
         <translation>暫停更新</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Reboot and Update</source>
         <translation>重啟並更新</translation>
     </message>
@@ -22,53 +19,42 @@
 <context>
     <name>AdvancedNetworking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+121"/>
         <source>Back</source>
         <translation>回上頁</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Enable Tethering</source>
         <translation>啟用網路分享</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Tethering Password</source>
         <translation>網路分享密碼</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+27"/>
         <source>EDIT</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Enter new tethering password</source>
         <translation>輸入新的網路分享密碼</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>IP Address</source>
         <translation>IP 地址</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable Roaming</source>
         <translation>啟用漫遊</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>APN Setting</source>
         <translation>APN 設置</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter APN</source>
         <translation>輸入 APN</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>leave blank for automatic configuration</source>
         <translation>留空白將自動配置</translation>
     </message>
@@ -76,13 +62,10 @@
 <context>
     <name>ConfirmationDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+221"/>
-        <location line="+5"/>
         <source>Ok</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -90,17 +73,14 @@
 <context>
     <name>DeclinePage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="+140"/>
         <source>You must accept the Terms and Conditions in order to use openpilot.</source>
         <translation>您必須先接受條款和條件才能使用 openpilot。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Back</source>
         <translation>回上頁</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decline, uninstall %1</source>
         <translation>拒絕並卸載 %1</translation>
     </message>
@@ -108,152 +88,122 @@
 <context>
     <name>DevicePanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+151"/>
         <source>Dongle ID</source>
         <translation>Dongle ID</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N/A</source>
         <translation>無法使用</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Serial</source>
         <translation>序號</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Driver Camera</source>
         <translation>駕駛員攝像頭</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PREVIEW</source>
         <translation>預覽</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)</source>
         <translation>預覽駕駛員監控鏡頭畫面，以確保其具有良好視野。（僅在熄火時可用）</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reset Calibration</source>
         <translation>重置校準</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>RESET</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Are you sure you want to reset calibration?</source>
         <translation>您確定要重置校準嗎？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Review Training Guide</source>
         <translation>觀看使用教學</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>REVIEW</source>
         <translation>觀看</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Review the rules, features, and limitations of openpilot</source>
         <translation>觀看 openpilot 的使用規則、功能和限制</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to review the training guide?</source>
         <translation>您確定要觀看使用教學嗎？</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Regulatory</source>
         <translation>法規/監管</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>VIEW</source>
         <translation>觀看</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Change Language</source>
         <translation>更改語言</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>CHANGE</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Select a language</source>
         <translation>選擇語言</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Power Off</source>
         <translation>關機</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>openpilot requires the device to be mounted within 4° left or right and within 5° up or 8° down. openpilot is continuously calibrating, resetting is rarely required.</source>
         <translation>openpilot 需要將裝置固定在左右偏差 4° 以內，朝上偏差 5° 以内或朝下偏差 8° 以内。鏡頭在後台會持續自動校準，很少有需要重置的情况。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source> Your device is pointed %1° %2 and %3° %4.</source>
         <translation> 你的設備目前朝%2 %1° 以及朝%4 %3° 。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>down</source>
         <translation>下</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>up</source>
         <translation>上</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Are you sure you want to reboot?</source>
         <translation>您確定要重新啟動嗎？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Reboot</source>
         <translation>請先取消控車才能重新啟動</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Are you sure you want to power off?</source>
         <translation>您確定您要關機嗎？</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Disengage to Power Off</source>
         <translation>請先取消控車才能關機</translation>
     </message>
@@ -261,32 +211,26 @@
 <context>
     <name>DriveStats</name>
     <message>
-        <location filename="../qt/widgets/drive_stats.cc" line="+37"/>
         <source>Drives</source>
         <translation>旅程</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Hours</source>
         <translation>小時</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>ALL TIME</source>
         <translation>總共</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>PAST WEEK</source>
         <translation>上周</translation>
     </message>
     <message>
-        <location filename="../qt/widgets/drive_stats.h" line="+15"/>
         <source>KM</source>
         <translation>公里</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Miles</source>
         <translation>英里</translation>
     </message>
@@ -294,7 +238,6 @@
 <context>
     <name>DriverViewScene</name>
     <message>
-        <location filename="../qt/offroad/driverview.cc" line="+55"/>
         <source>camera starting</source>
         <translation>開啟相機中</translation>
     </message>
@@ -302,12 +245,10 @@
 <context>
     <name>InputDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-155"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message numerus="yes">
-        <location line="+97"/>
         <source>Need at least %n character(s)!</source>
         <translation>
             <numerusform>需要至少 %n 個字元！</numerusform>
@@ -317,22 +258,18 @@
 <context>
     <name>Installer</name>
     <message>
-        <location filename="../installer/installer.cc" line="+56"/>
         <source>Installing...</source>
         <translation>安裝中…</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>Receiving objects: </source>
         <translation>接收對象： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Resolving deltas: </source>
         <translation>分析差異： </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Updating files: </source>
         <translation>更新檔案： </translation>
     </message>
@@ -340,27 +277,22 @@
 <context>
     <name>MapETA</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="+621"/>
         <source>eta</source>
         <translation>抵達</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>min</source>
         <translation>分鐘</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>hr</source>
         <translation>小時</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>mi</source>
         <translation>mi</translation>
     </message>
@@ -368,22 +300,18 @@
 <context>
     <name>MapInstructions</name>
     <message>
-        <location line="-237"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> mi</source>
         <translation> mi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source> ft</source>
         <translation> ft</translation>
     </message>
@@ -391,48 +319,40 @@
 <context>
     <name>MapPanel</name>
     <message>
-        <location filename="../qt/maps/map_settings.cc" line="+62"/>
         <source>Current Destination</source>
         <translation>當前目的地</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>CLEAR</source>
         <translation>清除</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Recent Destinations</source>
         <translation>最近目的地</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Try the Navigation Beta</source>
         <translation>試用導航功能</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Get turn-by-turn directions displayed and more with a comma
 prime subscription. Sign up now: https://connect.comma.ai</source>
         <translation>成為 comma 高級會員來使用導航功能
 立即註冊：https://connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>No home
 location set</source>
         <translation>未設定
 住家位置</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No work
 location set</source>
         <translation>未設定
 工作位置</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>no recent destinations</source>
         <translation>沒有最近的導航記錄</translation>
     </message>
@@ -440,12 +360,10 @@ location set</source>
 <context>
     <name>MapWindow</name>
     <message>
-        <location filename="../qt/maps/map.cc" line="-257"/>
         <source>Map Loading</source>
         <translation>地圖加載中</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Waiting for GPS</source>
         <translation>等待 GPS</translation>
     </message>
@@ -453,12 +371,10 @@ location set</source>
 <context>
     <name>MultiOptionDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="+132"/>
         <source>Select</source>
         <translation>選擇</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -466,23 +382,18 @@ location set</source>
 <context>
     <name>Networking</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="-135"/>
         <source>Advanced</source>
         <translation>進階</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Enter password</source>
         <translation>輸入密碼</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+10"/>
         <source>for &quot;%1&quot;</source>
         <translation>給 &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Wrong password</source>
         <translation>密碼錯誤</translation>
     </message>
@@ -490,30 +401,22 @@ location set</source>
 <context>
     <name>NvgWindow</name>
     <message>
-        <location filename="../qt/onroad.cc" line="+218"/>
         <source>km/h</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+3"/>
         <source>MAX</source>
         <translation>最高</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+3"/>
         <source>SPEED</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+3"/>
         <source>LIMIT</source>
         <translation>速限</translation>
     </message>
@@ -521,17 +424,14 @@ location set</source>
 <context>
     <name>OffroadHome</name>
     <message>
-        <location filename="../qt/home.cc" line="+114"/>
         <source>UPDATE</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source> ALERTS</source>
         <translation> 提醒</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source> ALERT</source>
         <translation> 提醒</translation>
     </message>
@@ -539,22 +439,18 @@ location set</source>
 <context>
     <name>PairingPopup</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+89"/>
         <source>Pair your device to your comma account</source>
         <translation>將設備與您的 comma 帳號配對</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Go to https://connect.comma.ai on your phone</source>
         <translation>用手機連至 https://connect.comma.ai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Click &quot;add new device&quot; and scan the QR code on the right</source>
         <translation>點選 &quot;add new device&quot; 後掃描右邊的二維碼</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>將 connect.comma.ai 加入您的主屏幕，以便像手機 App 一樣使用它</translation>
     </message>
@@ -562,32 +458,26 @@ location set</source>
 <context>
     <name>PrimeAdWidget</name>
     <message>
-        <location line="+88"/>
         <source>Upgrade Now</source>
         <translation>馬上升級</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Become a comma prime member at connect.comma.ai</source>
         <translation>成為 connect.comma.ai 的高級會員</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>PRIME FEATURES:</source>
         <translation>高級會員特點：</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Remote access</source>
         <translation>遠程訪問</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>1 year of storage</source>
         <translation>一年的雲端行車記錄</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Developer perks</source>
         <translation>開發者福利</translation>
     </message>
@@ -595,22 +485,18 @@ location set</source>
 <context>
     <name>PrimeUserWidget</name>
     <message>
-        <location line="-78"/>
         <source>✓ SUBSCRIBED</source>
         <translation>✓ 已訂閱</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>comma prime</source>
         <translation>comma 高級會員</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>CONNECT.COMMA.AI</source>
         <translation>CONNECT.COMMA.AI</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>COMMA POINTS</source>
         <translation>COMMA 積分</translation>
     </message>
@@ -618,41 +504,34 @@ location set</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../qt/text.cc" line="+36"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exit</source>
         <translation>離開</translation>
     </message>
     <message>
-        <location filename="../qt/util.cc" line="+21"/>
         <source>dashcam</source>
         <translation>行車記錄器</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>openpilot</source>
         <translation>openpilot</translation>
     </message>
     <message numerus="yes">
-        <location line="+61"/>
         <source>%n minute(s) ago</source>
         <translation>
             <numerusform>%n 分鐘前</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n hour(s) ago</source>
         <translation>
             <numerusform>%n 小時前</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+3"/>
         <source>%n day(s) ago</source>
         <translation>
             <numerusform>%n 天前</numerusform>
@@ -662,47 +541,38 @@ location set</source>
 <context>
     <name>Reset</name>
     <message>
-        <location filename="../qt/setup/reset.cc" line="+29"/>
         <source>Reset failed. Reboot to try again.</source>
         <translation>重置失敗。請重新啟動後再試。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Are you sure you want to reset your device?</source>
         <translation>您確定要重置你的設備嗎？</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Resetting device...</source>
         <translation>重置設備中…</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>System Reset</source>
         <translation>系統重置</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>System reset triggered. Press confirm to erase all content and settings. Press cancel to resume boot.</source>
         <translation>系統重置已觸發。請按確認刪除所有內容和設置。按取消恢復啟動。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>無法掛載數據分區。請按確認重置您的設備。</translation>
     </message>
@@ -710,7 +580,6 @@ location set</source>
 <context>
     <name>RichTextDialog</name>
     <message>
-        <location filename="../qt/widgets/input.cc" line="-75"/>
         <source>Ok</source>
         <translation>確定</translation>
     </message>
@@ -718,33 +587,26 @@ location set</source>
 <context>
     <name>SettingsWindow</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="+22"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Device</source>
         <translation>設備</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+39"/>
         <source>Network</source>
         <translation>網路</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Toggles</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Software</source>
         <translation>軟體</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Navigation</source>
         <translation>導航</translation>
     </message>
@@ -752,105 +614,82 @@ location set</source>
 <context>
     <name>Setup</name>
     <message>
-        <location filename="../qt/setup/setup.cc" line="+73"/>
         <source>WARNING: Low Voltage</source>
         <translation>警告：電壓過低</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Power your device in a car with a harness or proceed at your own risk.</source>
         <translation>請使用車上 harness 提供的電源，若繼續的話您需要自擔風險。</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Power off</source>
         <translation>關機</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+83"/>
-        <location line="+86"/>
         <source>Continue</source>
         <translation>繼續</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Getting Started</source>
         <translation>入門</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Before we get on the road, let’s finish installation and cover some details.</source>
         <translation>在我們上路之前，讓我們完成安裝並介紹一些細節。</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Connect to Wi-Fi</source>
         <translation>連接到無線網絡</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+98"/>
         <source>Back</source>
         <translation>回上頁</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Continue without Wi-Fi</source>
         <translation>在沒有 Wi-Fi 的情況下繼續</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waiting for internet</source>
         <translation>連接至網路中</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Choose Software to Install</source>
         <translation>選擇要安裝的軟體</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Dashcam</source>
         <translation>行車記錄器</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Custom Software</source>
         <translation>定制的軟體</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Enter URL</source>
         <translation>輸入網址</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>for Custom Software</source>
         <translation>定制的軟體</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Downloading...</source>
         <translation>下載中…</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Download Failed</source>
         <translation>下載失敗</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ensure the entered URL is valid, and the device’s internet connection is good.</source>
         <translation>請確定您輸入的是有效的安裝網址，並且確定設備的網路連線狀態良好。</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Reboot device</source>
         <translation>重新啟動</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Start over</source>
         <translation>重新開始</translation>
     </message>
@@ -858,17 +697,14 @@ location set</source>
 <context>
     <name>SetupWidget</name>
     <message>
-        <location filename="../qt/widgets/prime.cc" line="+82"/>
         <source>Finish Setup</source>
         <translation>完成設置</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer.</source>
         <translation>將您的設備與 comma connect (connect.comma.ai) 配對並領取您的 comma 高級會員優惠。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Pair device</source>
         <translation>配對設備</translation>
     </message>
@@ -876,106 +712,82 @@ location set</source>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qt/sidebar.cc" line="+74"/>
-        <location line="+2"/>
         <source>CONNECT</source>
         <translation>雲端服務</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>OFFLINE</source>
         <translation>已離線</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+13"/>
         <source>ONLINE</source>
         <translation>已連線</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>ERROR</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>TEMP</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>HIGH</source>
         <translation>偏高</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>GOOD</source>
         <translation>正常</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>OK</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>VEHICLE</source>
         <translation>車輛通訊</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>NO</source>
         <translation>未連線</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PANDA</source>
         <translation>車輛通訊</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SEARCH</source>
         <translation>車輛通訊</translation>
     </message>
     <message>
-        <location filename="../qt/sidebar.h" line="+36"/>
         <source>--</source>
         <translation>--</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wi-Fi</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ETH</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2G</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>3G</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>LTE</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>5G</source>
         <translation></translation>
     </message>
@@ -983,63 +795,50 @@ location set</source>
 <context>
     <name>SoftwarePanel</name>
     <message>
-        <location filename="../qt/offroad/software_settings.cc" line="+24"/>
         <source>Updates are only downloaded while the car is off.</source>
         <translation>系統更新只會在熄火時下載。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Current Version</source>
         <translation>當前版本</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Download</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Install Update</source>
         <translation>安裝更新</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>INSTALL</source>
         <translation>安裝</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Target Branch</source>
         <translation>目標分支</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>SELECT</source>
         <translation>選取</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select a branch</source>
         <translation>選取一個分支</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>UNINSTALL</source>
         <translation>卸載</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uninstall %1</source>
         <translation>卸載 %1</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Are you sure you want to uninstall?</source>
         <translation>您確定您要卸載嗎？</translation>
     </message>
     <message>
-        <location line="-47"/>
-        <location line="+3"/>
         <source>CHECK</source>
         <translation>檢查</translation>
     </message>
@@ -1047,48 +846,38 @@ location set</source>
 <context>
     <name>SshControl</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.cc" line="+7"/>
         <source>SSH Keys</source>
         <translation>SSH 密鑰</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.</source>
         <translation>警告：這將授權給 GitHub 帳號中所有公鑰 SSH 訪問權限。切勿輸入非您自己的 GitHub 用戶名。comma 員工「永遠不會」要求您添加他們的 GitHub 用戶名。</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+24"/>
         <source>ADD</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Enter your GitHub username</source>
         <translation>請輸入您 GitHub 的用戶名</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>LOADING</source>
         <translation>載入中</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>REMOVE</source>
         <translation>移除</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Username &apos;%1&apos; has no keys on GitHub</source>
         <translation>GitHub 用戶 &apos;%1&apos; 沒有設定任何密鑰</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Request timed out</source>
         <translation>請求超時</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username &apos;%1&apos; doesn&apos;t exist on GitHub</source>
         <translation>GitHub 用戶 &apos;%1&apos; 不存在</translation>
     </message>
@@ -1096,7 +885,6 @@ location set</source>
 <context>
     <name>SshToggle</name>
     <message>
-        <location filename="../qt/widgets/ssh_keys.h" line="+13"/>
         <source>Enable SSH</source>
         <translation>啟用 SSH 服務</translation>
     </message>
@@ -1104,22 +892,18 @@ location set</source>
 <context>
     <name>TermsPage</name>
     <message>
-        <location filename="../qt/offroad/onboarding.cc" line="-75"/>
         <source>Terms &amp; Conditions</source>
         <translation>條款和條件</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Decline</source>
         <translation>拒絕</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Scroll to accept</source>
         <translation>滑動至頁尾接受條款</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Agree</source>
         <translation>接受</translation>
     </message>
@@ -1127,102 +911,82 @@ location set</source>
 <context>
     <name>TogglesPanel</name>
     <message>
-        <location filename="../qt/offroad/settings.cc" line="-303"/>
         <source>Enable openpilot</source>
         <translation>啟用 openpilot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off.</source>
         <translation>使用 openpilot 的主動式巡航和車道保持功能，開啟後您需要持續集中注意力，設定變更在重新啟動車輛後生效。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Enable Lane Departure Warnings</source>
         <translation>啟用車道偏離警告</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receive alerts to steer back into the lane when your vehicle drifts over a detected lane line without a turn signal activated while driving over 31 mph (50 km/h).</source>
         <translation>車速在時速 50 公里 (31 英里) 以上且未打方向燈的情況下，如果偵測到車輛駛出目前車道線時，發出車道偏離警告。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use Metric System</source>
         <translation>使用公制單位</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Display speed in km/h instead of mph.</source>
         <translation>啟用後，速度單位顯示將從 mp/h 改為 km/h。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Record and Upload Driver Camera</source>
         <translation>記錄並上傳駕駛監控影像</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload data from the driver facing camera and help improve the driver monitoring algorithm.</source>
         <translation>上傳駕駛監控的錄像來協助我們提升駕駛監控的準確率。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>🌮 End-to-end longitudinal (extremely alpha) 🌮</source>
         <translation>🌮 端對端縱向控制（實驗性功能） 🌮</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Experimental openpilot longitudinal control</source>
         <translation>使用 openpilot 縱向控制（實驗）</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;b&gt;WARNING: openpilot longitudinal control is experimental for this car and will disable AEB.&lt;/b&gt;</source>
         <translation>&lt;b&gt;注意：這台車的 openpilot 縱向控制仍然是實驗中的功能，開啟這功能將會關閉自動緊急煞車 (AEB)。&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.</source>
         <translation>讓駕駛模型直接控製油門和剎車，openpilot將會模仿人類司機的駕駛方式。該功能仍非常實驗性。</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>openpilot longitudinal control is not currently available for this car.</source>
         <translation>openpilot 縱向控制目前不適用於這輛車。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enable experimental longitudinal control to enable this.</source>
         <translation>打開縱向控制（實驗）以啟用此功能。</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Disengage On Accelerator Pedal</source>
         <translation>油門取消控車</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>When enabled, pressing the accelerator pedal will disengage openpilot.</source>
         <translation>啟用後，踩踏油門將會取消 openpilot 控制。</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Show ETA in 24h Format</source>
         <translation>預計到達時間單位改用 24 小時制</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use 24h format instead of am/pm</source>
         <translation>使用 24 小時制。(預設值為 12 小時制)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Map on Left Side of UI</source>
         <translation>將地圖顯示在畫面的左側</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show map on left side when in split screen view.</source>
         <translation>進入分割畫面後，地圖將會顯示在畫面的左側。</translation>
     </message>
@@ -1230,42 +994,34 @@ location set</source>
 <context>
     <name>Updater</name>
     <message>
-        <location filename="../qt/setup/updater.cc" line="+23"/>
         <source>Update Required</source>
         <translation>系統更新</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>An operating system update is required. Connect your device to Wi-Fi for the fastest update experience. The download size is approximately 1GB.</source>
         <translation>設備的操作系統需要更新。請將您的設備連接到 Wi-Fi 以獲得最快的更新體驗。下載大小約為 1GB。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Connect to Wi-Fi</source>
         <translation>連接到無線網絡</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Install</source>
         <translation>安裝</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Back</source>
         <translation>回上頁</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Loading...</source>
         <translation>載入中…</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Update failed</source>
         <translation>更新失敗</translation>
     </message>
@@ -1273,22 +1029,18 @@ location set</source>
 <context>
     <name>WifiUI</name>
     <message>
-        <location filename="../qt/offroad/networking.cc" line="+113"/>
         <source>Scanning for networks...</source>
         <translation>掃描無線網路中...</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>CONNECTING...</source>
         <translation>連線中...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>FORGET</source>
         <translation>清除</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Forget Wi-Fi Network &quot;%1&quot;?</source>
         <translation>清除 Wi-Fi 網路 &quot;%1&quot;?</translation>
     </message>

--- a/selfdrive/ui/update_translations.py
+++ b/selfdrive/ui/update_translations.py
@@ -19,7 +19,7 @@ def update_translations(vanish=False, plural_only=None, translations_dir=TRANSLA
 
   for file in translation_files.values():
     tr_file = os.path.join(translations_dir, f"{file}.ts")
-    args = f"lupdate -locations relative -recursive {UI_DIR} -ts {tr_file}"
+    args = f"lupdate -locations none -recursive {UI_DIR} -ts {tr_file}"
     if vanish:
       args += " -no-obsolete"
     if file in plural_only:


### PR DESCRIPTION
in this or another pr: script to launch linguist with a temporary file with line numbers, then when done remove all the location tag lines