### PR TITLE
sensord: build message without orphans

### DIFF
--- a/selfdrive/sensord/sensors/lsm6ds3_accel.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.cc
@@ -80,17 +80,14 @@ fail:
   return ret;
 }
 
+bool LSM6DS3_Accel::trigged() {
+  // INT1 shared with gyro, check STATUS_REG who triggered
+  uint8_t status_reg = 0;
+  read_register(LSM6DS3_ACCEL_I2C_REG_STAT_REG, &status_reg, sizeof(status_reg));
+  return (status_reg & LSM6DS3_ACCEL_DRDY_XLDA) != 0;
+}
+
 bool LSM6DS3_Accel::get_event(cereal::SensorEventData::Builder &event) {
-
-  if (has_interrupt_enabled()) {
-    // INT1 shared with gyro, check STATUS_REG who triggered
-    uint8_t status_reg = 0;
-    read_register(LSM6DS3_ACCEL_I2C_REG_STAT_REG, &status_reg, sizeof(status_reg));
-    if ((status_reg & LSM6DS3_ACCEL_DRDY_XLDA) == 0) {
-      return false;
-    }
-  }
-
   uint8_t buffer[6];
   int len = read_register(LSM6DS3_ACCEL_I2C_REG_OUTX_L_XL, buffer, sizeof(buffer));
   assert(len == sizeof(buffer));

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.cc
@@ -80,7 +80,7 @@ fail:
   return ret;
 }
 
-bool LSM6DS3_Accel::trigged() {
+bool LSM6DS3_Accel::triggered() {
   // INT1 shared with gyro, check STATUS_REG who triggered
   uint8_t status_reg = 0;
   read_register(LSM6DS3_ACCEL_I2C_REG_STAT_REG, &status_reg, sizeof(status_reg));

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.h
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.h
@@ -29,5 +29,6 @@ public:
   LSM6DS3_Accel(I2CBus *bus, int gpio_nr = 0, bool shared_gpio = false);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
+  bool trigged() override;
   int shutdown();
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_accel.h
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.h
@@ -29,6 +29,6 @@ public:
   LSM6DS3_Accel(I2CBus *bus, int gpio_nr = 0, bool shared_gpio = false);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
-  bool trigged() override;
+  bool triggered() override;
   int shutdown();
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -83,7 +83,7 @@ fail:
   return ret;
 }
 
-bool LSM6DS3_Gyro::trigged() {
+bool LSM6DS3_Gyro::triggered() {
   // INT1 shared with accel, check STATUS_REG who triggered
   uint8_t status_reg = 0;
   read_register(LSM6DS3_GYRO_I2C_REG_STAT_REG, &status_reg, sizeof(status_reg));

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -83,17 +83,14 @@ fail:
   return ret;
 }
 
+bool LSM6DS3_Gyro::trigged() {
+  // INT1 shared with accel, check STATUS_REG who triggered
+  uint8_t status_reg = 0;
+  read_register(LSM6DS3_GYRO_I2C_REG_STAT_REG, &status_reg, sizeof(status_reg));
+  return (status_reg & LSM6DS3_GYRO_DRDY_GDA) != 0;
+}
+
 bool LSM6DS3_Gyro::get_event(cereal::SensorEventData::Builder &event) {
-
-  if (has_interrupt_enabled()) {
-    // INT1 shared with accel, check STATUS_REG who triggered
-    uint8_t status_reg = 0;
-    read_register(LSM6DS3_GYRO_I2C_REG_STAT_REG, &status_reg, sizeof(status_reg));
-    if ((status_reg & LSM6DS3_GYRO_DRDY_GDA) == 0) {
-      return false;
-    }
-  }
-
   uint8_t buffer[6];
   int len = read_register(LSM6DS3_GYRO_I2C_REG_OUTX_L_G, buffer, sizeof(buffer));
   assert(len == sizeof(buffer));

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.h
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.h
@@ -29,6 +29,6 @@ public:
   LSM6DS3_Gyro(I2CBus *bus, int gpio_nr = 0, bool shared_gpio = false);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
-  bool trigged() override;
+  bool triggered() override;
   int shutdown();
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.h
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.h
@@ -29,5 +29,6 @@ public:
   LSM6DS3_Gyro(I2CBus *bus, int gpio_nr = 0, bool shared_gpio = false);
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
+  bool trigged() override;
   int shutdown();
 };

--- a/selfdrive/sensord/sensors/sensor.h
+++ b/selfdrive/sensord/sensors/sensor.h
@@ -9,6 +9,6 @@ public:
   virtual int init() = 0;
   virtual bool get_event(cereal::SensorEventData::Builder &event) = 0;
   virtual bool has_interrupt_enabled() = 0;
-  virtual bool trigged() { return false; };
+  virtual bool triggered() { return false; };
   virtual int shutdown() = 0;
 };

--- a/selfdrive/sensord/sensors/sensor.h
+++ b/selfdrive/sensord/sensors/sensor.h
@@ -9,5 +9,6 @@ public:
   virtual int init() = 0;
   virtual bool get_event(cereal::SensorEventData::Builder &event) = 0;
   virtual bool has_interrupt_enabled() = 0;
+  virtual bool trigged() { return false; };
   virtual int shutdown() = 0;
 };

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -74,7 +74,7 @@ void interrupt_loop(int fd, std::vector<Sensor *>& sensors, PubMaster& pm) {
 
     std::vector<Sensor *> s;
     for (auto sensor : sensors) {
-      if (sensor->trigged()) s.push_back(sensor);
+      if (sensor->triggered()) s.push_back(sensor);
     }
     if (s.empty()) continue;
 

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -28,12 +28,12 @@
 ExitHandler do_exit;
 std::mutex pm_mutex;
 
-void publish_events(PubMaster &pm, const std::vector<Sensor *> &s, std::optional<int64_t> ts = {}) {
+void publish_events(PubMaster &pm, const std::vector<Sensor *> &sensors, std::optional<int64_t> ts = {}) {
   MessageBuilder msg;
-  auto sensor_events = msg.initEvent().initSensorEvents(s.size());
-  for (int i = 0; i < s.size(); i++) {
+  auto sensor_events = msg.initEvent().initSensorEvents(sensors.size());
+  for (int i = 0; i < sensors.size(); i++) {
     auto event = sensor_events[i];
-    s[i]->get_event(event);
+    sensors[i]->get_event(event);
     if (ts) {
       event.setTimestamp(*ts);
     }


### PR DESCRIPTION
the orphan is slower and more complicated than calling `initSensorEvents` directly, and it will leave memory holes in the serialized message. the only way to remove these extra spaces is to copy the message to a new MessageBuilder, since only the reachable objects will be copied.