### PR TITLE
sensord: move bmx accel,gyro to deep suspend on startup, deprecate bmx temp and light

### DIFF
--- a/selfdrive/sensord/sensors/bmx055_accel.cc
+++ b/selfdrive/sensord/sensors/bmx055_accel.cc
@@ -61,6 +61,15 @@ int BMX055_Accel::shutdown()  {
   return ret;
 }
 
+int BMX055_Accel::is_available() {
+  uint8_t buffer[1];
+  int ret = read_register(BMX055_ACCEL_I2C_REG_ID, buffer, 1);
+  if(ret < 0) {
+    return 0;
+  }
+  return 1;
+}
+
 bool BMX055_Accel::get_event(cereal::SensorEventData::Builder &event) {
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];

--- a/selfdrive/sensord/sensors/bmx055_accel.h
+++ b/selfdrive/sensord/sensors/bmx055_accel.h
@@ -38,4 +38,5 @@ public:
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
   int shutdown();
+  int is_available();
 };

--- a/selfdrive/sensord/sensors/bmx055_gyro.cc
+++ b/selfdrive/sensord/sensors/bmx055_gyro.cc
@@ -72,6 +72,15 @@ int BMX055_Gyro::shutdown()  {
   return ret;
 }
 
+int BMX055_Gyro::is_available() {
+  uint8_t buffer[1];
+  int ret = read_register(BMX055_GYRO_I2C_REG_ID, buffer, 1);
+  if(ret < 0) {
+    return 0;
+  }
+  return 1;
+}
+
 bool BMX055_Gyro::get_event(cereal::SensorEventData::Builder &event) {
   uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];

--- a/selfdrive/sensord/sensors/bmx055_gyro.h
+++ b/selfdrive/sensord/sensors/bmx055_gyro.h
@@ -38,4 +38,5 @@ public:
   int init();
   bool get_event(cereal::SensorEventData::Builder &event);
   int shutdown();
+  int is_available();
 };

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -5,7 +5,6 @@
 
 #include "common/swaglog.h"
 #include "common/timing.h"
-#include "common/util.h"
 
 #define DEG2RAD(x) ((x) * M_PI / 180.0)
 
@@ -47,9 +46,6 @@ int LSM6DS3_Gyro::init() {
   if (ret < 0) {
     goto fail;
   }
-
-  // give gyro time to wake up from power down mode
-  util::sleep_for(50);
 
   // enable data ready interrupt for gyro on INT1
   // (without resetting existing interrupts)

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -5,6 +5,7 @@
 
 #include "common/swaglog.h"
 #include "common/timing.h"
+#include "common/util.h"
 
 #define DEG2RAD(x) ((x) * M_PI / 180.0)
 
@@ -46,6 +47,9 @@ int LSM6DS3_Gyro::init() {
   if (ret < 0) {
     goto fail;
   }
+
+  // give gyro time to wake up from power down mode
+  util::sleep_for(50);
 
   // enable data ready interrupt for gyro on INT1
   // (without resetting existing interrupts)

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -117,9 +117,12 @@ int sensor_loop() {
 
   // bmx accel and gyro data is not used anymore
   BMX055_Accel bmx055_accel(i2c_bus_imu);
+  if (bmx055_accel.is_available())
+    bmx055_accel.shutdown();
+
   BMX055_Gyro bmx055_gyro(i2c_bus_imu);
-  bmx055_accel.shutdown();
-  bmx055_gyro.shutdown();
+  if (bmx055_accel.is_available())
+    bmx055_gyro.shutdown();
 
   BMX055_Magn bmx055_magn(i2c_bus_imu);
   BMX055_Temp bmx055_temp(i2c_bus_imu);

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -16,7 +16,6 @@
 #include "selfdrive/sensord/sensors/bmx055_magn.h"
 #include "selfdrive/sensord/sensors/bmx055_temp.h"
 #include "selfdrive/sensord/sensors/constants.h"
-#include "selfdrive/sensord/sensors/light_sensor.h"
 #include "selfdrive/sensord/sensors/lsm6ds3_accel.h"
 #include "selfdrive/sensord/sensors/lsm6ds3_gyro.h"
 #include "selfdrive/sensord/sensors/lsm6ds3_temp.h"
@@ -131,7 +130,8 @@ int sensor_loop() {
 
   MMC5603NJ_Magn mmc5603nj_magn(i2c_bus_imu);
 
-  LightSensor light("/sys/class/i2c-adapter/i2c-2/2-0038/iio:device1/in_intensity_both_raw");
+  // light sensor has been deprecated
+  // LightSensor light("/sys/class/i2c-adapter/i2c-2/2-0038/iio:device1/in_intensity_both_raw");
 
   // Sensor init
   std::vector<std::pair<Sensor *, bool>> sensors_init; // Sensor, required
@@ -143,8 +143,6 @@ int sensor_loop() {
   sensors_init.push_back({&lsm6ds3_temp, true});
 
   sensors_init.push_back({&mmc5603nj_magn, false});
-
-  sensors_init.push_back({&light, true});
 
   bool has_magnetometer = false;
 

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -118,8 +118,8 @@ int sensor_loop() {
   // bmx accel and gyro data is not used anymore
   BMX055_Accel bmx055_accel(i2c_bus_imu);
   BMX055_Gyro bmx055_gyro(i2c_bus_imu);
-  bmx055_accel->shutdown();
-  bmx055_gyro->shutdown();
+  bmx055_accel.shutdown();
+  bmx055_gyro.shutdown();
 
   BMX055_Magn bmx055_magn(i2c_bus_imu);
   BMX055_Temp bmx055_temp(i2c_bus_imu);

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -116,8 +116,12 @@ int sensor_loop() {
     return -1;
   }
 
+  // bmx accel and gyro data is not used anymore
   BMX055_Accel bmx055_accel(i2c_bus_imu);
   BMX055_Gyro bmx055_gyro(i2c_bus_imu);
+  bmx055_accel->shutdown();
+  bmx055_gyro->shutdown();
+
   BMX055_Magn bmx055_magn(i2c_bus_imu);
   BMX055_Temp bmx055_temp(i2c_bus_imu);
 
@@ -131,8 +135,6 @@ int sensor_loop() {
 
   // Sensor init
   std::vector<std::pair<Sensor *, bool>> sensors_init; // Sensor, required
-  sensors_init.push_back({&bmx055_accel, false});
-  sensors_init.push_back({&bmx055_gyro, false});
   sensors_init.push_back({&bmx055_magn, false});
   sensors_init.push_back({&bmx055_temp, false});
 

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -139,7 +139,6 @@ int sensor_loop() {
   // Sensor init
   std::vector<std::pair<Sensor *, bool>> sensors_init; // Sensor, required
   sensors_init.push_back({&bmx055_magn, false});
-  sensors_init.push_back({&bmx055_temp, false});
 
   sensors_init.push_back({&lsm6ds3_accel, true});
   sensors_init.push_back({&lsm6ds3_gyro, true});

--- a/selfdrive/sensord/tests/test_sensord.py
+++ b/selfdrive/sensord/tests/test_sensord.py
@@ -12,48 +12,34 @@ from selfdrive.manager.process_config import managed_processes
 
 SENSOR_CONFIGURATIONS = (
   {
-    ('bmx055', 'acceleration'),
-    ('bmx055', 'gyroUncalibrated'),
     ('bmx055', 'magneticUncalibrated'),
-    ('bmx055', 'temperature'),
     ('lsm6ds3', 'acceleration'),
     ('lsm6ds3', 'gyroUncalibrated'),
     ('lsm6ds3', 'temperature'),
-    ('rpr0521', 'light'),
   },
   {
     ('lsm6ds3', 'acceleration'),
     ('lsm6ds3', 'gyroUncalibrated'),
     ('lsm6ds3', 'temperature'),
     ('mmc5603nj', 'magneticUncalibrated'),
-    ('rpr0521', 'light'),
   },
   {
-    ('bmx055', 'acceleration'),
-    ('bmx055', 'gyroUncalibrated'),
     ('bmx055', 'magneticUncalibrated'),
-    ('bmx055', 'temperature'),
     ('lsm6ds3trc', 'acceleration'),
     ('lsm6ds3trc', 'gyroUncalibrated'),
     ('lsm6ds3trc', 'temperature'),
-    ('rpr0521', 'light'),
   },
   {
     ('lsm6ds3trc', 'acceleration'),
     ('lsm6ds3trc', 'gyroUncalibrated'),
     ('lsm6ds3trc', 'temperature'),
     ('mmc5603nj', 'magneticUncalibrated'),
-    ('rpr0521', 'light'),
   },
 )
 
 Sensor = log.SensorEventData.SensorSource
 SensorConfig = namedtuple('SensorConfig', ['type', 'sanity_min', 'sanity_max'])
 ALL_SENSORS = {
-  Sensor.rpr0521: {
-    SensorConfig("light", 0, 150),
-  },
-
   Sensor.lsm6ds3: {
     SensorConfig("acceleration", 5, 15),
     SensorConfig("gyroUncalibrated", 0, .2),
@@ -67,10 +53,7 @@ ALL_SENSORS = {
   },
 
   Sensor.bmx055: {
-    SensorConfig("acceleration", 5, 15),
-    SensorConfig("gyroUncalibrated", 0, .2),
     SensorConfig("magneticUncalibrated", 0, 300),
-    SensorConfig("temperature", 0, 60),
   },
 
   Sensor.mmc5603nj: {


### PR DESCRIPTION
bmx sensor data is not used anymore, and will not be used in the future, therfore the bmx gyro and accel is moved into a low power state on startup, the light sensor is discontinued. And also the bmx tempererature will not be used anymore
