### PR TITLE
updater: checkout fails after fetching branch

### DIFF
--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -374,8 +374,8 @@ class Updater:
 
     cloudlog.info("git reset in progress")
     cmds = [
-      ["git", "checkout", "--force", "--no-recurse-submodules", "FETCH_HEAD", "-B", branch],
-      ["git", "reset", "--hard", f"origin/{branch}"],
+      ["git", "checkout", "--force", "--no-recurse-submodules", "-B", branch, "FETCH_HEAD"],
+      ["git", "reset", "--hard"],
       ["git", "clean", "-xdf"],
       ["git", "submodule", "init"],
       ["git", "submodule", "update"],

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -374,7 +374,7 @@ class Updater:
 
     cloudlog.info("git reset in progress")
     cmds = [
-      ["git", "checkout", "--force", "--no-recurse-submodules", branch],
+      ["git", "checkout", "--force", "--no-recurse-submodules", "FETCH_HEAD", "-B", branch],
       ["git", "reset", "--hard", f"origin/{branch}"],
       ["git", "clean", "-xdf"],
       ["git", "submodule", "init"],


### PR DESCRIPTION
When git fetch-ing a single branch it looks like FETCH_HEAD gets updated to point to the remote commit.

updater output:
```
[216.914855] updated.py:454 - : git fetch success: From https://github.com/commaai/openpilot
 * branch            metered-override -> FETCH_HEAD
```

but it doesn't create a branch locally, and git checkout doesn't recognise the branch name so we get this error
```
[216.931833] updated.py:454 - : git reset in progress
[216.959513] updated.py:457 - : {'event': 'update process failed', 'cmd': ['git', 'checkout', '--force', '--no-recurse-submodules', 'metered-override'], 'output': "error: pathspec 'metered-override' did not match any file(s) known to git\n", 'returncode': 1}
```

Instead checkout a new branch from FETCH_HEAD as the start point, like this:
```
git checkout --force --no-recurse-submodules FETCH_HEAD -B BRANCH_NAME
```

https://stackoverflow.com/a/70441995


EDIT: The next command throws an error too - I suspect you could remove the `origin/BRANCH`?
```
[875.504190] updated.py:454 - : git reset in progress
[875.825317] updated.py:457 - : {'event': 'update process failed', 'cmd': ['git', 'reset', '--hard', 'origin/metered-override'], 'output': "fatal: ambiguous argument 'origin/metered-override': unknown revision or path not in the working tree.\nUse '--' to separate paths from revisions, like this:\n'git <command> [<revision>...] -- [<file>...]'\n", 'returncode': 128}
```