### PR TITLE
sensord: setTimeStamp for all sensors

### DIFF
--- a/selfdrive/sensord/sensors/lsm6ds3_accel.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_accel.cc
@@ -104,6 +104,7 @@ bool LSM6DS3_Accel::get_event(cereal::SensorEventData::Builder &event) {
     }
   }
 
+  uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
   int len = read_register(LSM6DS3_ACCEL_I2C_REG_OUTX_L_XL, buffer, sizeof(buffer));
   assert(len == sizeof(buffer));
@@ -117,6 +118,7 @@ bool LSM6DS3_Accel::get_event(cereal::SensorEventData::Builder &event) {
   event.setVersion(1);
   event.setSensor(SENSOR_ACCELEROMETER);
   event.setType(SENSOR_TYPE_ACCELEROMETER);
+  event.setTimestamp(start_time);
 
   float xyz[] = {y, -x, z};
   auto svec = event.initAcceleration();

--- a/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
+++ b/selfdrive/sensord/sensors/lsm6ds3_gyro.cc
@@ -107,6 +107,7 @@ bool LSM6DS3_Gyro::get_event(cereal::SensorEventData::Builder &event) {
     }
   }
 
+  uint64_t start_time = nanos_since_boot();
   uint8_t buffer[6];
   int len = read_register(LSM6DS3_GYRO_I2C_REG_OUTX_L_G, buffer, sizeof(buffer));
   assert(len == sizeof(buffer));
@@ -120,6 +121,7 @@ bool LSM6DS3_Gyro::get_event(cereal::SensorEventData::Builder &event) {
   event.setVersion(2);
   event.setSensor(SENSOR_GYRO_UNCALIBRATED);
   event.setType(SENSOR_TYPE_GYROSCOPE_UNCALIBRATED);
+  event.setTimestamp(start_time);
 
   float xyz[] = {y, -x, z};
   auto svec = event.initGyroUncalibrated();


### PR DESCRIPTION
It's not clear to me why setTimeStamp is not called for all sensors.
but I'm worried that something like the following logic will go wrong if timestamp is not set:

https://github.com/commaai/openpilot/blob/7ef55f3820e02f9c445822b7fa288a29a6cd3177/selfdrive/locationd/locationd.cc#L204



