### PR TITLE
loggerd: refactor RemoteEncoder from struct to class

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -136,9 +136,9 @@ uint32_t RemoteEncoder::writePacket(cereal::Event::Reader event) {
 uint32_t RemoteEncoder::write(cereal::Event::Reader event) {
   const auto edata = (event.*getEncodeData)();
   const auto idx = edata.getIdx();
-  const auto flags = idx.getFlags();
+  const bool is_key_frame = idx.getFlags() & V4L2_BUF_FLAG_KEYFRAME;
   if (!recording) {
-    if (flags & V4L2_BUF_FLAG_KEYFRAME) {
+    if (is_key_frame) {
       // only create on iframe
       if (dropped_frames) {
         // this should only happen for the first segment, maybe
@@ -162,7 +162,7 @@ uint32_t RemoteEncoder::write(cereal::Event::Reader event) {
 
   if (writer) {
     auto data = edata.getData();
-    writer->write((uint8_t *)data.begin(), data.size(), idx.getTimestampEof() / 1000, false, flags & V4L2_BUF_FLAG_KEYFRAME);
+    writer->write((uint8_t *)data.begin(), data.size(), idx.getTimestampEof() / 1000, false, is_key_frame);
   }
 
   // put it in log stream as the idx packet

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -43,7 +43,7 @@ void rotate_if_needed(LoggerdState *s) {
 class RemoteEncoder {
  public:
   RemoteEncoder(LoggerdState *s, const std::string &name);
-  ~RemoteEncoder(){};
+  ~RemoteEncoder() {};
   uint32_t handlePacket(Message *raw_msg);
 
  protected:
@@ -84,7 +84,7 @@ RemoteEncoder::RemoteEncoder(LoggerdState *s, const std::string &name) : s(s), n
 
 uint32_t RemoteEncoder::handlePacket(Message *raw_msg) {
   std::unique_ptr<Message> msg(raw_msg);
-  capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize()));
+  capnp::FlatArrayMessageReader cmsg({(capnp::word *)msg->getData(), msg->getSize()});
   const auto event = cmsg.getRoot<cereal::Event>();
   const int32_t segment_num = (event.*getEncodeData)().getIdx().getSegmentNum();
 
@@ -124,7 +124,7 @@ uint32_t RemoteEncoder::writePacket(cereal::Event::Reader event) {
   uint32_t bytes_count = 0;
   if (!q.empty()) {
     for (Message *msg : q) {
-      capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize()));
+      capnp::FlatArrayMessageReader cmsg({(capnp::word *)msg->getData(), msg->getSize()});
       bytes_count += write(cmsg.getRoot<cereal::Event>());
       delete msg;
     }

--- a/selfdrive/loggerd/loggerd.h
+++ b/selfdrive/loggerd/loggerd.h
@@ -1,28 +1,18 @@
 #pragma once
 
-#include <unistd.h>
-
 #include <atomic>
 #include <cassert>
-#include <cerrno>
-#include <condition_variable>
-#include <mutex>
 #include <string>
-#include <thread>
 #include <unordered_map>
 
 #include "cereal/messaging/messaging.h"
 #include "cereal/services.h"
-#include "cereal/visionipc/visionipc.h"
 #include "cereal/visionipc/visionipc_client.h"
-#include "system/camerad/cameras/camera_common.h"
 #include "common/params.h"
 #include "common/swaglog.h"
 #include "common/timing.h"
 #include "common/util.h"
-#include "system/hardware/hw.h"
 
-#include "selfdrive/loggerd/encoder/encoder.h"
 #include "selfdrive/loggerd/logger.h"
 #ifdef QCOM2
 #include "selfdrive/loggerd/encoder/v4l_encoder.h"


### PR DESCRIPTION
The original code is brilliant but it's not easy to understand and maintain. so I'm trying to refactor `RemoteEncoder` from struct to class, with the following main changes:

1. split `handle_encoder_msg` into small functions.
2. remove recursive call to `handle_encoder_msg`.
3. use function pointers to make code more concise.
4. make it easy to move VideoWriter  to threads in the future.(or write video in encoderd)