### PR TITLE
pin sensord and lsm interrupt to core 1, for better timing

### DIFF
--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -218,5 +218,11 @@ int sensor_loop() {
 
 int main(int argc, char *argv[]) {
   setpriority(PRIO_PROCESS, 0, -18);
+
+  cpu_set_t mask;
+  CPU_ZERO(&mask);
+  CPU_SET(1, &mask);
+  sched_setaffinity(0, sizeof(mask), &mask);
+
   return sensor_loop();
 }

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -174,7 +174,9 @@ int sensor_loop() {
     return -1;
   }
 
-  // pin interrupt to core 1
+  // increase interrupt quality by pinning interrupt and process to core 1
+  setpriority(PRIO_PROCESS, 0, -18);
+  util::set_core_affinity({1});
   std::system("sudo su -c 'echo 1 > /proc/irq/336/smp_affinity_list'");
 
   PubMaster pm({"sensorEvents"});
@@ -220,7 +222,5 @@ int sensor_loop() {
 }
 
 int main(int argc, char *argv[]) {
-  setpriority(PRIO_PROCESS, 0, -18);
-  util::set_core_affinity({1});
-  return sensor_loop();
+ return sensor_loop();
 }

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -175,7 +175,7 @@ int sensor_loop() {
   }
 
   // pin interrupt to core 1
-  system("sudo su -c 'echo 1 > /proc/irq/336/smp_affinity_list'");
+  std::system("sudo su -c 'echo 1 > /proc/irq/336/smp_affinity_list'");
 
   PubMaster pm({"sensorEvents"});
   init_ts = nanos_since_boot();

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -222,5 +222,5 @@ int sensor_loop() {
 }
 
 int main(int argc, char *argv[]) {
- return sensor_loop();
+  return sensor_loop();
 }

--- a/selfdrive/sensord/sensors_qcom2.cc
+++ b/selfdrive/sensord/sensors_qcom2.cc
@@ -174,6 +174,9 @@ int sensor_loop() {
     return -1;
   }
 
+  // pin interrupt to core 1
+  system("sudo su -c 'echo 1 > /proc/irq/336/smp_affinity_list'");
+
   PubMaster pm({"sensorEvents"});
   init_ts = nanos_since_boot();
 
@@ -207,7 +210,7 @@ int sensor_loop() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10) - (end - begin));
   }
 
-  for (Sensor *sensor :  sensors) {
+  for (Sensor *sensor : sensors) {
     sensor->shutdown();
   }
 
@@ -218,11 +221,6 @@ int sensor_loop() {
 
 int main(int argc, char *argv[]) {
   setpriority(PRIO_PROCESS, 0, -18);
-
-  cpu_set_t mask;
-  CPU_ZERO(&mask);
-  CPU_SET(1, &mask);
-  sched_setaffinity(0, sizeof(mask), &mask);
-
+  util::set_core_affinity({1});
   return sensor_loop();
 }

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -440,7 +440,6 @@ class Tici(HardwareBase):
     affine_irq(1, 7)    # msm_drm
     affine_irq(1, 250)  # msm_vidc
     affine_irq(1, 8)    # i2c_geni (sensord)
-    affine_irq(1, 336)    # lsm gpio (sensord)
     sudo_write("f", "/proc/irq/default_smp_affinity")
 
     # *** GPU config ***

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -440,6 +440,7 @@ class Tici(HardwareBase):
     affine_irq(1, 7)    # msm_drm
     affine_irq(1, 250)  # msm_vidc
     affine_irq(1, 8)    # i2c_geni (sensord)
+    affine_irq(1, 336)    # lsm gpio (sensord)
     sudo_write("f", "/proc/irq/default_smp_affinity")
 
     # *** GPU config ***


### PR DESCRIPTION
Pin sensord and lsm gpio interrupt to core1, this gives better timings, the high outlier values  basically vanished (only saw one in 150k samples)

before: (this image is slightly cropped, otherwise the outliers ruin the comparison)
![hist_nopin_interrupts_26k_accel](https://user-images.githubusercontent.com/14962620/191659417-dbc99ffa-1107-4d4f-afa5-f4cae31160cd.png)

after:
![hist_pin_interrupts_26k_accel_3](https://user-images.githubusercontent.com/14962620/191659449-e085722a-65ea-4200-a2b4-4f615bda3a66.png)

same result obtained from the lsm gyro. as can be seen the values are very consistent in three piles, all within 150us)