### PR TITLE
V4LEncoder: remove unused member variable buf_in

### DIFF
--- a/selfdrive/loggerd/encoder/v4l_encoder.h
+++ b/selfdrive/loggerd/encoder/v4l_encoder.h
@@ -28,7 +28,6 @@ private:
   static void dequeue_handler(V4LEncoder *e);
   std::thread dequeue_handler_thread;
 
-  VisionBuf buf_in[BUF_IN_COUNT];
   VisionBuf buf_out[BUF_OUT_COUNT];
   SafeQueue<unsigned int> free_buf_in;
 };


### PR DESCRIPTION
buf_in is unused  after [ea5b8cd](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)