### PR TITLE
test_loggerd: fix test_rotation

### DIFF
--- a/selfdrive/loggerd/tests/test_loggerd.py
+++ b/selfdrive/loggerd/tests/test_loggerd.py
@@ -131,6 +131,7 @@ class TestLoggerd(unittest.TestCase):
       os.environ["LOGGERD_SEGMENT_LENGTH"] = str(length)
       managed_processes["loggerd"].start()
       managed_processes["encoderd"].start()
+      sm = messaging.SubMaster({'roadEncodeData'})
 
       fps = 20.0
       for n in range(1, int(num_segs*length*fps)+1):
@@ -143,6 +144,11 @@ class TestLoggerd(unittest.TestCase):
           frame.frameId = n
           pm.send(state, camera_state)
         time.sleep(1.0/fps)
+
+      while (True) :
+        sm.update(100)
+        if not sm.updated['roadEncodeData']:
+          break
 
       managed_processes["loggerd"].stop()
       managed_processes["encoderd"].stop()


### PR DESCRIPTION
the `FfmpegEncoder`  makes encoderd  very slow in processing frames. wait for loggerd to finish publishing before stopping it. otherwise the following errors often occur:

` Traceback (most recent call last):
  File "/tmp/openpilot/selfdrive/loggerd/tests/test_loggerd.py", line 154, in test_rotation
    logged = {f.name for f in p.iterdir() if f.is_file()}
  File "/tmp/openpilot/selfdrive/loggerd/tests/test_loggerd.py", line 154, in <setcomp>
    logged = {f.name for f in p.iterdir() if f.is_file()}
  File "/root/.pyenv/versions/3.8.10/lib/python3.8/pathlib.py", line 1122, in iterdir
    for name in self._accessor.listdir(self):
FileNotFoundError: [Errno 2] No such file or directory: '/root/.comma/media/0/realdata/2022-09-25--11-09-06--1'`