### PR TITLE
ci: don't trigger on pull request sync event

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -4,6 +4,7 @@ on:
     branches-ignore:
       - 'testing-closet*'
   pull_request:
+    types: [opened, reopened]
 
 env:
   BASE_IMAGE: openpilot-base

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -2,6 +2,7 @@ name: tools
 on:
   push:
   pull_request:
+    types: [opened, reopened]
 
 env:
   BASE_IMAGE: openpilot-base


### PR DESCRIPTION
By default the `pull_request` trigger causes the workflows to run whenever a PR is `opened`, `reopened` or `synchronized` (a commit is pushed), but since we have the `push` trigger it causes the workflows to run twice for every push to a branch with an active PR.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request