### PR TITLE
params: catch signals with sigtimedwait in blocking read

### DIFF
--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -57,15 +57,6 @@ cdef class Params:
     cdef string val
     with nogil:
       val = self.p.get(k, block)
-
-    if val == b"":
-      if block:
-        # If we got no value while running in blocked mode
-        # it means we got an interrupt while waiting
-        raise KeyboardInterrupt
-      else:
-        return None
-
     return val if encoding is None else val.decode(encoding)
 
   def get_bool(self, key):


### PR DESCRIPTION
catch signals with std::signal and restore it to the origin one before return is not safe. 
the previous handler cannot receive the signals during block read, and If two blocking reads occur at the same time, it may cause prev_handler_sigint point to params_sig_handler, which will cause the original handler to be lost and never be called.
