### PR TITLE
params: catch signals with sigtimedwait in blocking read 

### DIFF
--- a/common/SConscript
+++ b/common/SConscript
@@ -29,7 +29,7 @@ Export('_common', '_gpucommon')
 
 if GetOption('extras'):
   env.Program('tests/test_common',
-              ['tests/test_runner.cc', 'tests/test_util.cc', 'tests/test_swaglog.cc', 'tests/test_ratekeeper.cc'],
+              ['tests/test_runner.cc', 'tests/test_params.cc', 'tests/test_util.cc', 'tests/test_swaglog.cc', 'tests/test_ratekeeper.cc'],
               LIBS=[_common, 'json11', 'zmq', 'pthread'])
 
 # Cython

--- a/common/params.cc
+++ b/common/params.cc
@@ -13,11 +13,6 @@
 
 namespace {
 
-volatile sig_atomic_t params_do_exit = 0;
-void params_sig_handler(int signal) {
-  params_do_exit = 1;
-}
-
 int fsync_dir(const std::string &path) {
   int result = -1;
   int fd = HANDLE_EINTR(open(path.c_str(), O_RDONLY, 0755));
@@ -283,20 +278,18 @@ std::string Params::get(const std::string &key, bool block) {
     return util::read_file(getParamPath(key));
   } else {
     // blocking read until successful
-    params_do_exit = 0;
-    void (*prev_handler_sigint)(int) = std::signal(SIGINT, params_sig_handler);
-    void (*prev_handler_sigterm)(int) = std::signal(SIGTERM, params_sig_handler);
-
+    sigset_t sigset;
+    sigfillset(&sigset);
     std::string value;
-    while (!params_do_exit) {
-      if (value = util::read_file(getParamPath(key)); !value.empty()) {
-        break;
-      }
-      util::sleep_for(100);  // 0.1 s
+    while (true) {
+      if (value = util::read_file(getParamPath(key)); !value.empty()) break;
+
+      siginfo_t info = {};
+      timespec req = {.tv_nsec = (long)(100 * 1e6)};
+      sigtimedwait(&sigset, &info, &req);
+      if (info.si_signo == SIGINT || info.si_signo == SIGTERM) break;
     }
 
-    std::signal(SIGINT, prev_handler_sigint);
-    std::signal(SIGTERM, prev_handler_sigterm);
     return value;
   }
 }

--- a/common/params.cc
+++ b/common/params.cc
@@ -282,7 +282,8 @@ std::string Params::get(const std::string &key, bool block) {
     sigfillset(&sigset);
     std::string value;
     while (true) {
-      if (value = util::read_file(getParamPath(key)); !value.empty()) break;
+      std::string value = util::read_file(getParamPath(key));
+      if (!value.empty()) break;
 
       siginfo_t info = {};
       timespec req = {.tv_nsec = (long)(100 * 1e6)};

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -59,13 +59,7 @@ cdef class Params:
       val = self.p.get(k, block)
 
     if val == b"":
-      if block:
-        # If we got no value while running in blocked mode
-        # it means we got an interrupt while waiting
-        raise KeyboardInterrupt
-      else:
-        return None
-
+      return None
     return val if encoding is None else val.decode(encoding)
 
   def get_bool(self, key, bool block=False):

--- a/common/tests/test_params.cc
+++ b/common/tests/test_params.cc
@@ -1,0 +1,53 @@
+#include <signal.h>      /* Definition of SIG* constants */
+#include <sys/syscall.h> /* Definition of SYS_* constants */
+#include <unistd.h>
+
+#include <future>
+
+#include "catch2/catch.hpp"
+#include "common/params.h"
+#include "common/timing.h"
+#include "common/util.h"
+
+
+std::atomic<int> signal_caught = 0;
+
+void signal_handle(int s) {
+  signal_caught = s;
+}
+
+TEST_CASE("params_blocking_read") {
+  bool send_sigint = GENERATE(true, false);
+  char tmp_path[] = "/tmp/test_Params_XXXXXX";
+  const std::string param_path = mkdtemp(tmp_path);
+  pthread_t thread_id = pthread_self();
+
+  // install signal handle
+  signal_caught = 0;
+  std::signal(SIGINT, signal_handle);
+
+  // write param in thread
+  double write_after = 200;
+  std::future<void> future = std::async(std::launch::async, [=]() {
+    util::sleep_for(write_after);
+    if (send_sigint) {
+      pthread_kill(thread_id, SIGINT);
+    }
+    Params params(param_path);
+    params.put("CarParams", "1");
+  });
+
+  // blocking read
+  double begin_ts = millis_since_boot();
+  Params params(param_path);
+  auto value = params.get("CarParams", true);
+  if (send_sigint) {
+    REQUIRE(signal_caught == SIGINT);
+    REQUIRE(value.empty());
+  } else {
+    REQUIRE(signal_caught == 0);
+    REQUIRE(value == "1");
+  }
+  double end_ts = millis_since_boot();
+  REQUIRE((end_ts - begin_ts) > write_after);
+}


### PR DESCRIPTION
catch signals with std::signal and restore it to the origin one before return is not safe.
the previous handler cannot receive the signals during block read, and If two blocking reads occur at the same time, it may set prev_handler_sigint to params_sig_handler, which will cause the original handler to be lost and never be called.

- [x] catch signals with sigtimedwiat
- [ ] test case

