### PR TITLE
proclogd: fix wrong type for rss 

### DIFF
--- a/system/proclogd/proclog.cc
+++ b/system/proclogd/proclog.cc
@@ -95,7 +95,7 @@ std::optional<ProcStat> procStat(std::string stat) {
       .num_threads = stol(v[StatPos::num_threads - 1]),
       .starttime = stoull(v[StatPos::starttime - 1]),
       .vms = stoul(v[StatPos::vsize - 1]),
-      .rss = stoul(v[StatPos::rss - 1]),
+      .rss = stol(v[StatPos::rss - 1]),
       .processor = stoi(v[StatPos::processor - 1]),
     };
     return p;

--- a/system/proclogd/proclog.h
+++ b/system/proclogd/proclog.h
@@ -20,8 +20,8 @@ struct ProcCache {
 struct ProcStat {
   int pid, ppid, processor;
   char state;
-  long cutime, cstime, priority, nice, num_threads;
-  unsigned long utime, stime, vms, rss;
+  long cutime, cstime, priority, nice, num_threads, rss;
+  unsigned long utime, stime, vms;
   unsigned long long starttime;
   std::string name;
 };


### PR DESCRIPTION
rss should be long:

https://man7.org/linux/man-pages/man5/proc.5.html:
> (24) rss  %ld