### PR TITLE
Fingerprinting: gather CAN fingerprint first & add docs

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -91,7 +91,7 @@ def fingerprint(logcan, sendcan):
 
   # *** CAN fingerprinting ***
 
-  finger = gen_empty_fingerprint()
+  can_finger = gen_empty_fingerprint()
   candidate_cars = {i: all_legacy_fingerprint_cars() for i in [0, 1]}  # attempt fingerprint on both bus 0 and 1
   frame = 0
   max_fingerprint_frames = 100  # 1s
@@ -108,9 +108,9 @@ def fingerprint(logcan, sendcan):
       # The fingerprint dict is generated for all buses, this way the car interface
       # can use it to detect a (valid) multipanda setup and initialize accordingly
       if can.src < 128:
-        if can.src not in finger:
-          finger[can.src] = {}
-        finger[can.src][can.address] = len(can.dat)
+        if can.src not in can_finger:
+          can_finger[can.src] = {}
+        can_finger[can.src][can.address] = len(can.dat)
 
       for b in candidate_cars:
         # Ignore extended messages and VIN query response.
@@ -184,7 +184,7 @@ def fingerprint(logcan, sendcan):
 
   cloudlog.event("fingerprinted", car_fingerprint=car_fingerprint, source=source, fuzzy=not exact_match,
                  fw_count=len(car_fw), ecu_responses=list(ecu_rx_addrs), vin_rx_addr=vin_rx_addr, error=True)
-  return car_fingerprint, finger, vin, car_fw, source, exact_match
+  return car_fingerprint, can_finger, vin, car_fw, source, exact_match
 
 
 def get_car(logcan, sendcan):

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -113,8 +113,8 @@ def fingerprint(logcan, sendcan):
         finger[can.src][can.address] = len(can.dat)
 
       for b in candidate_cars:
-        # Ignore extended messages
-        if can.src == b and can.address < 0x800:
+        # Ignore extended messages and VIN query response.
+        if can.src == b and can.address < 0x800 and can.address not in (0x7df, 0x7e0, 0x7e8):
           candidate_cars[b] = eliminate_incompatible_cars(can, candidate_cars[b])
 
     # if we only have one car choice and the time since we got our first

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -94,7 +94,7 @@ def fingerprint(logcan, sendcan):
   finger = gen_empty_fingerprint()
   candidate_cars = {i: all_legacy_fingerprint_cars() for i in [0, 1]}  # attempt fingerprint on both bus 0 and 1
   frame = 0
-  frame_fingerprint = 100  # 1s
+  max_fingerprint_frames = 100  # 1s
   car_fingerprint = None
   done = False
 
@@ -120,12 +120,12 @@ def fingerprint(logcan, sendcan):
     # if we only have one car choice and the time since we got our first
     # message has elapsed, exit
     for b in candidate_cars:
-      if len(candidate_cars[b]) == 1 and frame > frame_fingerprint:
+      if len(candidate_cars[b]) == 1 and frame > max_fingerprint_frames:
         # fingerprint done
         car_fingerprint = candidate_cars[b][0]
 
     # bail if no cars left or we've been waiting for more than 2s
-    failed = (all(len(cc) == 0 for cc in candidate_cars.values()) and frame > frame_fingerprint) or frame > 200
+    failed = (all(len(cc) == 0 for cc in candidate_cars.values()) and frame > max_fingerprint_frames) or frame > 200
     succeeded = car_fingerprint is not None
     done = failed or succeeded
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -114,6 +114,7 @@ def fingerprint(logcan, sendcan):
 
       for b in candidate_cars:
         # Ignore extended messages and VIN query response.
+        # TODO: remove VIN query exception, CAN fingerprinting is done first
         if can.src == b and can.address < 0x800 and can.address not in (0x7df, 0x7e0, 0x7e8):
           candidate_cars[b] = eliminate_incompatible_cars(can, candidate_cars[b])
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -79,7 +79,7 @@ interfaces = load_interfaces(interface_names)
 def fingerprint(logcan, sendcan):
   """
   Fingerprints the vehicle using both CAN fingerprinting and FW fingerprinting. CAN fingerprint gathering is done first
-  to give enough time to the PubSocket to connect, however we attempt to fingerprint using the FW versions first.
+  to give enough time to the PubSocket to connect, however, a successful FW fingerprinting match overrides CAN fingerprinting.
 
   1. CAN fingerprinting:
     1. Creates dictionary of CAN addresses to lengths for CAN fingerprinting and feature detection (1-2s)

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -113,8 +113,8 @@ def fingerprint(logcan, sendcan):
         finger[can.src][can.address] = len(can.dat)
 
       for b in candidate_cars:
-        # Ignore extended messages and VIN query response.
-        if can.src == b and can.address < 0x800 and can.address not in (0x7df, 0x7e0, 0x7e8):
+        # Ignore extended messages
+        if can.src == b and can.address < 0x800:
           candidate_cars[b] = eliminate_incompatible_cars(can, candidate_cars[b])
 
     # if we only have one car choice and the time since we got our first

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -79,7 +79,7 @@ interfaces = load_interfaces(interface_names)
 def fingerprint(logcan, sendcan):
   """
   Fingerprints the vehicle using both CAN fingerprinting and FW fingerprinting. CAN fingerprint gathering is done first
-  to give enough time to the PubSocket to connect, however, a successful FW fingerprinting match overrides CAN fingerprinting.
+  to give enough time to the PubSocket to connect, however, a successful FW fingerprint match overrides CAN fingerprinting.
 
   1. CAN fingerprinting:
     1. Creates dictionary of CAN addresses to lengths for CAN fingerprinting and feature detection (1-2s)

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -78,7 +78,7 @@ interfaces = load_interfaces(interface_names)
 # **** for use live only ****
 def fingerprint(logcan, sendcan):
   """
-  Fingerprints the vehicle using both CAN fingerprinting and FW fingerprinting. CAN fingerprint gathering is done first
+  Fingerprints the car using both CAN fingerprinting and FW fingerprinting. CAN fingerprint gathering is done first
   to give enough time to the PubSocket to connect, however, a successful FW fingerprint match overrides CAN fingerprinting.
 
   1. CAN fingerprinting:

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -86,7 +86,7 @@ def fingerprint(logcan, sendcan):
   2. FW fingerprinting:
     1. Queries the car for the VIN
     2. Queries the car for present ECU addresses
-    3. Queries the car for ECU FW versions, ordered by most likely brand using present ECUs
+    3. Queries the car for ECU FW versions, ordered by most likely brands using present ECUs
   """
 
   # *** CAN fingerprinting ***


### PR DESCRIPTION
- Flipped CAN and FW fingerprinting so that the PubSocket is connected to boardd by the time we get to the VIN query (no missed first try or anything else we want to do with it)
- Added function docs explaining what the function does and in what order (including why we CAN fingerprint first)
- Cleaned up some variable names