### PR TITLE
IsoTpParallelQuery: process all functional responses

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -16,19 +16,20 @@ class IsoTpParallelQuery:
     self.request = request
     self.response = response
     self.debug = debug
+    self.functional_addr = functional_addr
     self.response_pending_timeout = response_pending_timeout
 
-    if functional_addr:
+    if self.functional_addr:
       assert all([a in FUNCTIONAL_ADDRS for a in addrs]), "Non-functional addresses in addrs"
-      self.msg_addrs = {}
+      real_addrs = []
       if 0x7DF in addrs:
-        self.msg_addrs[(0x7DF, None)] = [get_rx_addr_for_tx_addr(0x7E0 + i) for i in range(8)]
+        real_addrs.extend([(0x7E0 + i, None) for i in range(8)])
       if 0x18DB33F1 in addrs:
-        self.msg_addrs[(0x18DB33F1, None)] = [get_rx_addr_for_tx_addr(0x18DA00F1 + (i << 8)) for i in range(256)]
+        real_addrs.extend([(0x18DA00F1 + (i << 8), None) for i in range(256)])
     else:
       real_addrs = [a if isinstance(a, tuple) else (a, None) for a in addrs]
-      self.msg_addrs = {tx_addr: [get_rx_addr_for_tx_addr(tx_addr[0], rx_offset=response_offset)] for tx_addr in real_addrs}
 
+    self.msg_addrs = {tx_addr: get_rx_addr_for_tx_addr(tx_addr[0], rx_offset=response_offset) for tx_addr in real_addrs}
     self.msg_buffer = defaultdict(list)
 
   def rx(self):
@@ -75,23 +76,29 @@ class IsoTpParallelQuery:
     msgs = {}
     request_counter = {}
     request_done = {}
-    for tx_addr, rx_addrs in self.msg_addrs.items():
-      # some tx addrs can have multiple rx addrs (functional query)
-      for rx_addr in rx_addrs:
-        sub_addr = tx_addr[1]
+    for tx_addr, rx_addr in self.msg_addrs.items():
+      # rx_addr not set when using functional tx addr
+      id_addr = rx_addr or tx_addr[0]
+      sub_addr = tx_addr[1]
 
-        can_client = CanClient(self._can_tx, partial(self._can_rx, rx_addr, sub_addr=sub_addr), tx_addr[0], rx_addr,
-                               self.bus, sub_addr=sub_addr, debug=self.debug)
+      can_client = CanClient(self._can_tx, partial(self._can_rx, id_addr, sub_addr=sub_addr), tx_addr[0], rx_addr,
+                             self.bus, sub_addr=sub_addr, debug=self.debug)
 
-        max_len = 8 if sub_addr is None else 7
+      max_len = 8 if sub_addr is None else 7
 
-        msg = IsoTpMessage(can_client, timeout=0, max_len=max_len, debug=self.debug)
+      msg = IsoTpMessage(can_client, timeout=0, max_len=max_len, debug=self.debug)
+      msgs[tx_addr] = msg
+      request_counter[tx_addr] = 0
+      request_done[tx_addr] = False
 
+    if self.functional_addr:
+      # send first query to 0x7DF
+      can_client = CanClient(self._can_tx, partial(self._can_rx, 0x7DF), 0x7DF, None, self.bus, debug=self.debug)
+      msg = IsoTpMessage(can_client, timeout=0, debug=self.debug)
+      msg.send(self.request[0])
+    else:
+      for msg in msgs.values():
         msg.send(self.request[0])
-
-        msgs[tx_addr] = msg
-        request_counter[tx_addr] = 0
-        request_done[tx_addr] = False
 
     results = {}
     start_time = time.monotonic()

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -20,8 +20,8 @@ class IsoTpParallelQuery:
     self.functional_addr = functional_addr
     self.response_pending_timeout = response_pending_timeout
 
-    # After first query to functional addrs, we communicate on physical addresses
     if self.functional_addr:
+      # Add standard physical tx addresses to prepare to communicate after initial functional address query
       real_addrs = []
       for a in FUNCTIONAL_ADDRS:
         if a in self.addrs:

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -21,7 +21,7 @@ class IsoTpParallelQuery:
     self.response_pending_timeout = response_pending_timeout
 
     if self.functional_addr:
-      # Add standard physical tx addresses to prepare to communicate after initial functional address query
+      # Add standard physical addresses to tx on after initial functional address query
       real_addrs = []
       for a in FUNCTIONAL_ADDRS:
         if a in self.addrs:
@@ -90,7 +90,7 @@ class IsoTpParallelQuery:
       request_done[tx_addr] = False
 
     if self.functional_addr:
-      # send first query to functional addresses, subsequent queries on physical addresses
+      # Send first query to functional addresses, subsequent queries on physical addresses that respond
       for a in FUNCTIONAL_ADDRS:
         if a in self.addrs:
           can_client = CanClient(self._can_tx, partial(self._can_rx, a), a, None, self.bus, debug=self.debug)

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -20,12 +20,13 @@ class IsoTpParallelQuery:
     self.functional_addr = functional_addr
     self.response_pending_timeout = response_pending_timeout
 
+    # After first query to functional addrs, we communicate on physical addresses
     if self.functional_addr:
-      assert all([a in FUNCTIONAL_ADDRS for a in self.addrs]), "Non-functional addresses in addrs"
       real_addrs = []
       for a in FUNCTIONAL_ADDRS:
         if a in self.addrs:
           real_addrs.extend(FUNCTIONAL_ADDRS[a])
+
     else:
       real_addrs = [a if isinstance(a, tuple) else (a, None) for a in self.addrs]
 
@@ -90,9 +91,9 @@ class IsoTpParallelQuery:
 
     if self.functional_addr:
       # send first query to functional addresses, subsequent queries on physical addresses
-      for functional_addr in [0x7DF, 0x18DB33F1]:
-        if functional_addr in self.addrs:
-          can_client = CanClient(self._can_tx, partial(self._can_rx, functional_addr), functional_addr, None, self.bus, debug=self.debug)
+      for a in FUNCTIONAL_ADDRS:
+        if a in self.addrs:
+          can_client = CanClient(self._can_tx, partial(self._can_rx, a), a, None, self.bus, debug=self.debug)
           msg = IsoTpMessage(can_client, timeout=0, debug=self.debug)
           msg.send(self.request[0])
 

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -20,15 +20,15 @@ class IsoTpParallelQuery:
 
     if functional_addr:
       assert all([a in FUNCTIONAL_ADDRS for a in addrs]), "Non-functional addresses in addrs"
-      real_addrs = []
+      self.msg_addrs = {}
       if 0x7DF in addrs:
-        real_addrs.extend([(0x7E0 + i, None) for i in range(8)])
+        self.msg_addrs[(0x7DF, None)] = [get_rx_addr_for_tx_addr(0x7E0 + i) for i in range(8)]
       if 0x18DB33F1 in addrs:
-        real_addrs.extend([(0x18DA00F1 + (i << 8), None) for i in range(256)])
+        self.msg_addrs[(0x18DB33F1, None)] = [get_rx_addr_for_tx_addr(0x18DA00F1 + (i << 8)) for i in range(256)]
     else:
       real_addrs = [a if isinstance(a, tuple) else (a, None) for a in addrs]
+      self.msg_addrs = {tx_addr: [get_rx_addr_for_tx_addr(tx_addr[0], rx_offset=response_offset)] for tx_addr in real_addrs}
 
-    self.msg_addrs = {tx_addr: get_rx_addr_for_tx_addr(tx_addr[0], rx_offset=response_offset) for tx_addr in real_addrs}
     self.msg_buffer = defaultdict(list)
 
   def rx(self):
@@ -75,22 +75,23 @@ class IsoTpParallelQuery:
     msgs = {}
     request_counter = {}
     request_done = {}
-    for tx_addr, rx_addr in self.msg_addrs.items():
-      # rx_addr not set when using functional tx addr
-      id_addr = rx_addr or tx_addr[0]
-      sub_addr = tx_addr[1]
+    for tx_addr, rx_addrs in self.msg_addrs.items():
+      # some tx addrs can have multiple rx addrs (functional query)
+      for rx_addr in rx_addrs:
+        sub_addr = tx_addr[1]
 
-      can_client = CanClient(self._can_tx, partial(self._can_rx, id_addr, sub_addr=sub_addr), tx_addr[0], rx_addr,
-                             self.bus, sub_addr=sub_addr, debug=self.debug)
+        can_client = CanClient(self._can_tx, partial(self._can_rx, rx_addr, sub_addr=sub_addr), tx_addr[0], rx_addr,
+                               self.bus, sub_addr=sub_addr, debug=self.debug)
 
-      max_len = 8 if sub_addr is None else 7
+        max_len = 8 if sub_addr is None else 7
 
-      msg = IsoTpMessage(can_client, timeout=0, max_len=max_len, debug=self.debug)
-      msg.send(self.request[0])
+        msg = IsoTpMessage(can_client, timeout=0, max_len=max_len, debug=self.debug)
 
-      msgs[tx_addr] = msg
-      request_counter[tx_addr] = 0
-      request_done[tx_addr] = False
+        msg.send(self.request[0])
+
+        msgs[tx_addr] = msg
+        request_counter[tx_addr] = 0
+        request_done[tx_addr] = False
 
     results = {}
     start_time = time.monotonic()

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -93,6 +93,7 @@ class IsoTpParallelQuery:
 
     if self.functional_addr:
       # send first query to 0x7DF
+      # TODO: support both functional addresses
       can_client = CanClient(self._can_tx, partial(self._can_rx, 0x7DF), 0x7DF, None, self.bus, debug=self.debug)
       msg = IsoTpMessage(can_client, timeout=0, debug=self.debug)
       msg.send(self.request[0])

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -23,10 +23,9 @@ class IsoTpParallelQuery:
     if self.functional_addr:
       assert all([a in FUNCTIONAL_ADDRS for a in self.addrs]), "Non-functional addresses in addrs"
       real_addrs = []
-      if 0x7DF in self.addrs:
-        real_addrs.extend([(0x7E0 + i, None) for i in range(8)])
-      if 0x18DB33F1 in self.addrs:
-        real_addrs.extend([(0x18DA00F1 + (i << 8), None) for i in range(256)])
+      for a in FUNCTIONAL_ADDRS:
+        if a in self.addrs:
+          real_addrs.extend(FUNCTIONAL_ADDRS[a])
     else:
       real_addrs = [a if isinstance(a, tuple) else (a, None) for a in self.addrs]
 

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -93,7 +93,7 @@ class IsoTpParallelQuery:
       # Send first query to functional addresses, subsequent queries on physical addresses that respond
       for a in FUNCTIONAL_ADDRS:
         if a in self.addrs:
-          can_client = CanClient(self._can_tx, partial(self._can_rx, a), a, None, self.bus, debug=self.debug)
+          can_client = CanClient(self._can_tx, partial(self._can_rx, a), a, -1, self.bus, debug=self.debug)
           msg = IsoTpMessage(can_client, timeout=0, debug=self.debug)
           msg.send(self.request[0])
 


### PR DESCRIPTION
Re-do of https://github.com/commaai/openpilot/pull/25930 as that PR queried physical addresses, not the functional address. This PR correctly sends the first request to the functional addresses, then hands off communication to each individual server/physical address, as you're supposed to do.

This PR aims to query in the following fashion:
- We send first query to 0x7DF (or the 11-bit functional address).
- We listen for first frame responses on range 0x7E0 to 0x7E7
- We then send flow control continue to any physical address that respond (0x7E0 for example). No more messages are sent to 0x7DF