### PR TITLE
Replay: handle deprecated event

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -365,37 +365,41 @@ void Replay::handleDeprecatedEvent(const Event *evt) {
     for (auto old_evt : evt->event.getSensorEventsDEPRECATED()) {
       auto old_which = old_evt.which();
       void (cereal::Event::Builder::*setSensorData)(cereal::SensorEventData::Reader) = nullptr;
+      cereal::Event::Which new_which;
 
       switch (old_which) {
         case cereal::SensorEventData::ACCELERATION:
           setSensorData = &cereal::Event::Builder::setAccelerometer;
+          new_which = cereal::Event::ACCELEROMETER;
           break;
         case cereal::SensorEventData::GYRO:
         case cereal::SensorEventData::GYRO_UNCALIBRATED:
           setSensorData = &cereal::Event::Builder::setGyroscope;
+          new_which = cereal::Event::GYROSCOPE;
           break;
         case cereal::SensorEventData::LIGHT:
         case cereal::SensorEventData::PROXIMITY:
           setSensorData = &cereal::Event::Builder::setLightSensor;
+          new_which = cereal::Event::LIGHT_SENSOR;
           break;
         case cereal::SensorEventData::MAGNETIC:
         case cereal::SensorEventData::MAGNETIC_UNCALIBRATED:
           setSensorData = &cereal::Event::Builder::setMagnetometer;
+          new_which = cereal::Event::MAGNETOMETER;
           break;
         case cereal::SensorEventData::TEMPERATURE:
           setSensorData = &cereal::Event::Builder::setTemperatureSensor;
+          new_which = cereal::Event::TEMPERATURE_SENSOR;
           break;
         default:
           break;
       }
 
-      if (setSensorData) {
+      if (setSensorData && sockets_[new_which] != nullptr) {
         MessageBuilder msg;
         auto new_evt = msg.initEvent();
         (new_evt.*setSensorData)(old_evt);
-        if (sockets_[new_evt.which()] != nullptr) {
-          publish_frame(new_evt.which(), msg);
-        }
+        publish_frame(new_which, msg);
       }
     }
   }

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -365,6 +365,7 @@ void Replay::handleDeprecatedEvent(const Event *evt) {
     for (auto old_evt : evt->event.getSensorEventsDEPRECATED()) {
       auto old_which = old_evt.which();
       void (cereal::Event::Builder::*setSensorData)(cereal::SensorEventData::Reader) = nullptr;
+
       switch (old_which) {
         case cereal::SensorEventData::ACCELERATION:
           setSensorData = &cereal::Event::Builder::setAccelerometer;

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -78,6 +78,7 @@ protected:
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);
   void buildTimeline();
+  void handleDeprecatedEvent(const Event *evt);
   inline bool isSegmentMerged(int n) {
     return std::find(segments_merged_.begin(), segments_merged_.end(), n) != segments_merged_.end();
   }


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
