### PR TITLE
VW PQ: Use correct brake signal

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -170,7 +170,7 @@ class CarState(CarStateBase):
     ret.gas = pt_cp.vl["Motor_3"]["Fahrpedal_Rohsignal"] / 100.0
     ret.gasPressed = ret.gas > 0
     ret.brake = pt_cp.vl["Bremse_5"]["Bremsdruck"] / 250.0  # FIXME: this is pressure in Bar, not sure what OP expects
-    ret.brakePressed = bool(pt_cp.vl["Motor_2"]["Bremstestschalter"])
+    ret.brakePressed = bool(pt_cp.vl["Motor_2"]["Bremslichtschalter"])
     ret.parkingBrake = bool(pt_cp.vl["Kombi_1"]["Bremsinfo"])
 
     # Update gear and/or clutch position data.


### PR DESCRIPTION
**Description**

For VW PQ, openpilot and Panda safety are using two different signals to detect driver brake pressed. This is in-and-of-itself a bug; they should be using the same signal. Panda is using the most correct signal, the "brake light switch" vs the "brake test switch" (the primary vs redundant/error-checking mechanical switches at the brake pedal itself). Sync openpilot to that.

Because these signals show the state of two independent mechanical switches, we cannot depend on them to switch together at the time scales required for openpilot and Panda safety response. In the long term, for additional safety, it would probably make sense for openpilot/Panda to disengage on the OR of both signals, but that is a matter for another PR for both VW PQ and VW MQB.

**Verification**

The problem was discovered while troubleshooting a Controls Mismatch on a vehicle with unusually high divergence between the two signals. Panda correctly exited controls when the brake light switch signal went high, but openpilot remained engaged because the brake test switch signal didn't go high as well. Using the same signal is the correct solution.

Thanks to VW Sharan owner Ken Peng for the trouble report.

![Screenshot from 2022-10-03 13-15-26](https://user-images.githubusercontent.com/46612682/193649421-0aef81b8-b842-4af3-a531-61b74ce92028.png)

**Route**
Route: `064d1816e448f8eb|2022-09-29--07-53-07`
