### PR TITLE
fix build without extras

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -1,6 +1,6 @@
 import os
 Import('env', 'qt_env', 'arch', 'common', 'messaging', 'visionipc',
-       'cereal', 'transformations', 'widgets', 'replay_lib', 'opendbc')
+       'cereal', 'transformations', 'widgets', 'opendbc')
 
 base_frameworks = qt_env['FRAMEWORKS']
 base_libs = [common, messaging, cereal, visionipc, transformations, 'zmq',
@@ -15,6 +15,7 @@ qt_libs = ['qt_util', 'Qt5Charts'] + base_libs
 if arch in ['x86_64', 'Darwin'] and GetOption('extras'):
   qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 
+  Import('replay_lib')
   # qt_env["LD_LIBRARY_PATH"] = [Dir(f"#opendbc/can").abspath]
   cabana_libs = [widgets, cereal, messaging, visionipc, replay_lib, opendbc,'avutil', 'avcodec', 'avformat', 'bz2', 'curl', 'yuv'] + qt_libs
   qt_env.Program('_cabana', ['cabana.cc', 'mainwin.cc', 'chartswidget.cc', 'videowidget.cc', 'parser.cc', 'messageswidget.cc', 'detailwidget.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)


### PR DESCRIPTION
I think #25946 may have broken build on device (jenkins failed) since the `cabana/SConscript` tried to import `replay_lib` unconditionally, which isn't exported by replay unless on a PC or otherwise choose to build extras