### PR TITLE
GM: don't consider soft disabling as ACC fault

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -17,7 +17,7 @@ class CarState(CarStateBase):
     self.shifter_values = can_define.dv["ECMPRDNL2"]["PRNDL2"]
     self.lka_steering_cmd_counter = 0
     self.buttons_counter = 0
-    self.frames_acc_faulted = 0
+    self.acc_faulted_frames = 0
 
   def update(self, pt_cp, cam_cp, loopback_cp):
     ret = car.CarState.new_message()
@@ -80,13 +80,13 @@ class CarState(CarStateBase):
     ret.espDisabled = pt_cp.vl["ESPStatus"]["TractionControlOn"] != 1
 
     if pt_cp.vl["AcceleratorPedal2"]["CruiseState"] == AccState.FAULTED:
-      self.frames_acc_faulted += 1
+      self.acc_faulted_frames += 1
     else:
       # GM uses the FAULTED state in AcceleratorPedal2->CruiseState for genuine ACC faults
       # as well as soft disables with full longitudinal actuation (tries to brake to a stop).
       # Set accFaulted if FAULTED less than 10 frames (immediate disable)
-      ret.accFaulted = 0 < self.frames_acc_faulted <= 10
-      self.frames_acc_faulted = 0
+      ret.accFaulted = 0 < self.acc_faulted_frames <= 10
+      self.acc_faulted_frames = 0
 
     ret.cruiseState.enabled = pt_cp.vl["AcceleratorPedal2"]["CruiseState"] != AccState.OFF
     ret.cruiseState.standstill = pt_cp.vl["AcceleratorPedal2"]["CruiseState"] == AccState.STANDSTILL

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -84,7 +84,7 @@ class CarState(CarStateBase):
     else:
       # GM uses the FAULTED state in AcceleratorPedal2->CruiseState for genuine ACC faults
       # as well as soft disables with full longitudinal actuation (tries to brake to a stop).
-      # Set accFaulted if FAULTED less than 10 frames (immediate disable)
+      # Set accFaulted if state is FAULTED less than 10 frames (immediate disable)
       ret.accFaulted = 0 < self.acc_faulted_frames <= 10
       self.acc_faulted_frames = 0
 


### PR DESCRIPTION
***In dashcam mode,*** if stock ACC is braking for a car and the user presses the cancel button (taps or holds), ACC stays engaged for up to 2.8 seconds (observed) and a warning sound and lights are played (FCW severity) while the car tries to bring you to a stop before it disengages.

The entire time, the cruise state is "faulted," however we usually take faulted to mean we caused an issue with the car. In this instance though, faulted is a state where the car is soft disabling and continuing longitudinal actuation as normal.