### PR TITLE
VIN: make Ford exception more explicit

### DIFF
--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -29,7 +29,7 @@ def get_vin(logcan, sendcan, bus, timeout=0.1, retry=5, debug=False):
           if vin is not None:
             # Ford pads with null bytes
             if len(vin) == 24:
-              vin = vin.replace(b'\x00', b'')
+              vin = re.sub(b'\x00*$', b'', vin)
 
             # Honda Bosch response starts with a length, trim to correct length
             if vin.startswith(b'\x11'):

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -28,7 +28,8 @@ def get_vin(logcan, sendcan, bus, timeout=0.1, retry=5, debug=False):
           vin = results.get((addr, None))
           if vin is not None:
             # Ford pads with null bytes
-            vin = vin.replace(b'\x00', b'')
+            if len(vin) == 24:
+              vin = vin.replace(b'\x00', b'')
 
             # Honda Bosch response starts with a length, trim to correct length
             if vin.startswith(b'\x11'):


### PR DESCRIPTION
Only replaces from the right and not slices in case another brand returns 24 bytes in the future and it's a different format