### PR TITLE
Car docs: test no duplicate years

### DIFF
--- a/selfdrive/car/tests/test_docs.py
+++ b/selfdrive/car/tests/test_docs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from collections import defaultdict
 import re
 import unittest
 
@@ -12,58 +13,79 @@ class TestCarDocs(unittest.TestCase):
   def setUp(self):
     self.all_cars = get_all_car_info()
 
-  def test_generator(self):
-    generated_cars_md = generate_cars_md(self.all_cars, CARS_MD_TEMPLATE)
-    with open(CARS_MD_OUT, "r") as f:
-      current_cars_md = f.read()
+  # def test_generator(self):
+  #   generated_cars_md = generate_cars_md(self.all_cars, CARS_MD_TEMPLATE)
+  #   with open(CARS_MD_OUT, "r") as f:
+  #     current_cars_md = f.read()
+  #
+  #   self.assertEqual(generated_cars_md, current_cars_md,
+  #                    "Run selfdrive/car/docs.py to update the compatibility documentation")
 
-    self.assertEqual(generated_cars_md, current_cars_md,
-                     "Run selfdrive/car/docs.py to update the compatibility documentation")
-
-  def test_missing_car_info(self):
-    all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True).keys()
-    for platform in sorted(interfaces.keys()):
+  def test_duplicate_years(self):
+    all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True)
+    for platform, car_infos in all_car_info_platforms.items():
       with self.subTest(platform=platform):
-        self.assertTrue(platform in all_car_info_platforms, "Platform: {} doesn't exist in CarInfo".format(platform))
-
-  def test_naming_conventions(self):
-    # Asserts market-standard car naming conventions by brand
-    for car in self.all_cars:
-      with self.subTest(car=car):
-        tokens = car.model.lower().split(" ")
-        if car.car_name == "hyundai":
-          self.assertNotIn("phev", tokens, "Use `Plug-in Hybrid`")
-          self.assertNotIn("hev", tokens, "Use `Hybrid`")
-          if "plug-in hybrid" in car.model.lower():
-            self.assertIn("Plug-in Hybrid", car.model, "Use correct capitalization")
-          if car.make != "Kia":
-            self.assertNotIn("ev", tokens, "Use `Electric`")
-        elif car.car_name == "toyota":
-          if "rav4" in tokens:
-            self.assertIn("RAV4", car.model, "Use correct capitalization")
-
-  def test_torque_star(self):
-    # Asserts brand-specific assumptions around steering torque star
-    for car in self.all_cars:
-      with self.subTest(car=car):
-        # honda sanity check, it's the definition of a no torque star
-        if car.car_fingerprint in (HONDA.ACCORD, HONDA.CIVIC, HONDA.CRV, HONDA.ODYSSEY, HONDA.PILOT):
-          self.assertEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has full torque star")
-        elif car.car_name in ("toyota", "hyundai"):
-          self.assertNotEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has no torque star")
-
-  def test_year_format(self):
-    for car in self.all_cars:
-      with self.subTest(car=car):
-        self.assertIsNone(re.search(r"\d{4}-\d{4}", car.name), f"Format years correctly: {car.name}")
-
-  def test_harnesses(self):
-    for car in self.all_cars:
-      with self.subTest(car=car):
-        if car.name == "comma body":
+        if not isinstance(car_infos, list):
+          raise unittest.SkipTest("No need to check single CarInfo")
+        if platform != "LEXUS RX HYBRID 2017":
+          # continue
           raise unittest.SkipTest
+        model_to_years = defaultdict(list)
+        for car_info in car_infos:
+          model_key = (car_info.make, car_info.model)
+          for year in car_info.year_list:
 
-        self.assertNotIn(car.harness, [None, Harness.none], f"Need to specify car harness: {car.name}")
+            self.assertNotIn(year, model_to_years[model_key], f"{car_info.name}: Duplicate model year")
+            model_to_years[model_key].append(year)
+          # model_to_years[(car_info.make, car_info.model)] |= set(car_info.year_list)
+          # print((car_info.make, car_info.model, car_info.years))
+        print(model_to_years)
+        # print(platform, car_infos)
+
+  # def test_missing_car_info(self):
+  #   all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True).keys()
+  #   for platform in sorted(interfaces.keys()):
+  #     with self.subTest(platform=platform):
+  #       self.assertTrue(platform in all_car_info_platforms, "Platform: {} doesn't exist in CarInfo".format(platform))
+  #
+  # def test_naming_conventions(self):
+  #   # Asserts market-standard car naming conventions by brand
+  #   for car in self.all_cars:
+  #     with self.subTest(car=car):
+  #       tokens = car.model.lower().split(" ")
+  #       if car.car_name == "hyundai":
+  #         self.assertNotIn("phev", tokens, "Use `Plug-in Hybrid`")
+  #         self.assertNotIn("hev", tokens, "Use `Hybrid`")
+  #         if "plug-in hybrid" in car.model.lower():
+  #           self.assertIn("Plug-in Hybrid", car.model, "Use correct capitalization")
+  #         if car.make != "Kia":
+  #           self.assertNotIn("ev", tokens, "Use `Electric`")
+  #       elif car.car_name == "toyota":
+  #         if "rav4" in tokens:
+  #           self.assertIn("RAV4", car.model, "Use correct capitalization")
+  #
+  # def test_torque_star(self):
+  #   # Asserts brand-specific assumptions around steering torque star
+  #   for car in self.all_cars:
+  #     with self.subTest(car=car):
+  #       # honda sanity check, it's the definition of a no torque star
+  #       if car.car_fingerprint in (HONDA.ACCORD, HONDA.CIVIC, HONDA.CRV, HONDA.ODYSSEY, HONDA.PILOT):
+  #         self.assertEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has full torque star")
+  #       elif car.car_name in ("toyota", "hyundai"):
+  #         self.assertNotEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has no torque star")
+  #
+  # def test_year_format(self):
+  #   for car in self.all_cars:
+  #     with self.subTest(car=car):
+  #       self.assertIsNone(re.search(r"\d{4}-\d{4}", car.name), f"Format years correctly: {car.name}")
+  #
+  # def test_harnesses(self):
+  #   for car in self.all_cars:
+  #     with self.subTest(car=car):
+  #       if car.name == "comma body":
+  #         raise unittest.SkipTest
+  #
+  #       self.assertNotIn(car.harness, [None, Harness.none], f"Need to specify car harness: {car.name}")
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/tests/test_docs.py
+++ b/selfdrive/car/tests/test_docs.py
@@ -22,13 +22,12 @@ class TestCarDocs(unittest.TestCase):
                      "Run selfdrive/car/docs.py to update the compatibility documentation")
 
   def test_duplicate_years(self):
-    model_to_years = defaultdict(list)
+    model_model_years = defaultdict(list)
     for car in self.all_cars:
       with self.subTest(car_info_name=car.name):
-        make_model = (car.make, car.model)
         for year in car.year_list:
-          self.assertNotIn(year, model_to_years[make_model], f"{car.name}: Duplicate model year")
-          model_to_years[make_model].append(year)
+          self.assertNotIn(year, model_model_years[(car.make, car.model)], f"{car.name}: Duplicate model year")
+          model_model_years[(car.make, car.model)].append(year)
 
   def test_missing_car_info(self):
     all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True).keys()

--- a/selfdrive/car/tests/test_docs.py
+++ b/selfdrive/car/tests/test_docs.py
@@ -25,9 +25,10 @@ class TestCarDocs(unittest.TestCase):
     model_model_years = defaultdict(list)
     for car in self.all_cars:
       with self.subTest(car_info_name=car.name):
+        make_model = (car.make, car.model)
         for year in car.year_list:
-          self.assertNotIn(year, model_model_years[(car.make, car.model)], f"{car.name}: Duplicate model year")
-          model_model_years[(car.make, car.model)].append(year)
+          self.assertNotIn(year, model_model_years[make_model], f"{car.name}: Duplicate model year")
+          model_model_years[make_model].append(year)
 
   def test_missing_car_info(self):
     all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True).keys()

--- a/selfdrive/car/tests/test_docs.py
+++ b/selfdrive/car/tests/test_docs.py
@@ -22,13 +22,13 @@ class TestCarDocs(unittest.TestCase):
                      "Run selfdrive/car/docs.py to update the compatibility documentation")
 
   def test_duplicate_years(self):
-    model_model_years = defaultdict(list)
+    make_model_years = defaultdict(list)
     for car in self.all_cars:
       with self.subTest(car_info_name=car.name):
         make_model = (car.make, car.model)
         for year in car.year_list:
-          self.assertNotIn(year, model_model_years[make_model], f"{car.name}: Duplicate model year")
-          model_model_years[make_model].append(year)
+          self.assertNotIn(year, make_model_years[make_model], f"{car.name}: Duplicate model year")
+          make_model_years[make_model].append(year)
 
   def test_missing_car_info(self):
     all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True).keys()

--- a/selfdrive/car/tests/test_docs.py
+++ b/selfdrive/car/tests/test_docs.py
@@ -13,79 +13,67 @@ class TestCarDocs(unittest.TestCase):
   def setUp(self):
     self.all_cars = get_all_car_info()
 
-  # def test_generator(self):
-  #   generated_cars_md = generate_cars_md(self.all_cars, CARS_MD_TEMPLATE)
-  #   with open(CARS_MD_OUT, "r") as f:
-  #     current_cars_md = f.read()
-  #
-  #   self.assertEqual(generated_cars_md, current_cars_md,
-  #                    "Run selfdrive/car/docs.py to update the compatibility documentation")
+  def test_generator(self):
+    generated_cars_md = generate_cars_md(self.all_cars, CARS_MD_TEMPLATE)
+    with open(CARS_MD_OUT, "r") as f:
+      current_cars_md = f.read()
+
+    self.assertEqual(generated_cars_md, current_cars_md,
+                     "Run selfdrive/car/docs.py to update the compatibility documentation")
 
   def test_duplicate_years(self):
-    all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True)
-    for platform, car_infos in all_car_info_platforms.items():
+    model_to_years = defaultdict(list)
+    for car in self.all_cars:
+      with self.subTest(car_info_name=car.name):
+        make_model = (car.make, car.model)
+        for year in car.year_list:
+          self.assertNotIn(year, model_to_years[make_model], f"{car.name}: Duplicate model year")
+          model_to_years[make_model].append(year)
+
+  def test_missing_car_info(self):
+    all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True).keys()
+    for platform in sorted(interfaces.keys()):
       with self.subTest(platform=platform):
-        if not isinstance(car_infos, list):
-          raise unittest.SkipTest("No need to check single CarInfo")
-        if platform != "LEXUS RX HYBRID 2017":
-          # continue
+        self.assertTrue(platform in all_car_info_platforms, "Platform: {} doesn't exist in CarInfo".format(platform))
+
+  def test_naming_conventions(self):
+    # Asserts market-standard car naming conventions by brand
+    for car in self.all_cars:
+      with self.subTest(car=car):
+        tokens = car.model.lower().split(" ")
+        if car.car_name == "hyundai":
+          self.assertNotIn("phev", tokens, "Use `Plug-in Hybrid`")
+          self.assertNotIn("hev", tokens, "Use `Hybrid`")
+          if "plug-in hybrid" in car.model.lower():
+            self.assertIn("Plug-in Hybrid", car.model, "Use correct capitalization")
+          if car.make != "Kia":
+            self.assertNotIn("ev", tokens, "Use `Electric`")
+        elif car.car_name == "toyota":
+          if "rav4" in tokens:
+            self.assertIn("RAV4", car.model, "Use correct capitalization")
+
+  def test_torque_star(self):
+    # Asserts brand-specific assumptions around steering torque star
+    for car in self.all_cars:
+      with self.subTest(car=car):
+        # honda sanity check, it's the definition of a no torque star
+        if car.car_fingerprint in (HONDA.ACCORD, HONDA.CIVIC, HONDA.CRV, HONDA.ODYSSEY, HONDA.PILOT):
+          self.assertEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has full torque star")
+        elif car.car_name in ("toyota", "hyundai"):
+          self.assertNotEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has no torque star")
+
+  def test_year_format(self):
+    for car in self.all_cars:
+      with self.subTest(car=car):
+        self.assertIsNone(re.search(r"\d{4}-\d{4}", car.name), f"Format years correctly: {car.name}")
+
+  def test_harnesses(self):
+    for car in self.all_cars:
+      with self.subTest(car=car):
+        if car.name == "comma body":
           raise unittest.SkipTest
-        model_to_years = defaultdict(list)
-        for car_info in car_infos:
-          model_key = (car_info.make, car_info.model)
-          for year in car_info.year_list:
 
-            self.assertNotIn(year, model_to_years[model_key], f"{car_info.name}: Duplicate model year")
-            model_to_years[model_key].append(year)
-          # model_to_years[(car_info.make, car_info.model)] |= set(car_info.year_list)
-          # print((car_info.make, car_info.model, car_info.years))
-        print(model_to_years)
-        # print(platform, car_infos)
-
-  # def test_missing_car_info(self):
-  #   all_car_info_platforms = get_interface_attr("CAR_INFO", combine_brands=True).keys()
-  #   for platform in sorted(interfaces.keys()):
-  #     with self.subTest(platform=platform):
-  #       self.assertTrue(platform in all_car_info_platforms, "Platform: {} doesn't exist in CarInfo".format(platform))
-  #
-  # def test_naming_conventions(self):
-  #   # Asserts market-standard car naming conventions by brand
-  #   for car in self.all_cars:
-  #     with self.subTest(car=car):
-  #       tokens = car.model.lower().split(" ")
-  #       if car.car_name == "hyundai":
-  #         self.assertNotIn("phev", tokens, "Use `Plug-in Hybrid`")
-  #         self.assertNotIn("hev", tokens, "Use `Hybrid`")
-  #         if "plug-in hybrid" in car.model.lower():
-  #           self.assertIn("Plug-in Hybrid", car.model, "Use correct capitalization")
-  #         if car.make != "Kia":
-  #           self.assertNotIn("ev", tokens, "Use `Electric`")
-  #       elif car.car_name == "toyota":
-  #         if "rav4" in tokens:
-  #           self.assertIn("RAV4", car.model, "Use correct capitalization")
-  #
-  # def test_torque_star(self):
-  #   # Asserts brand-specific assumptions around steering torque star
-  #   for car in self.all_cars:
-  #     with self.subTest(car=car):
-  #       # honda sanity check, it's the definition of a no torque star
-  #       if car.car_fingerprint in (HONDA.ACCORD, HONDA.CIVIC, HONDA.CRV, HONDA.ODYSSEY, HONDA.PILOT):
-  #         self.assertEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has full torque star")
-  #       elif car.car_name in ("toyota", "hyundai"):
-  #         self.assertNotEqual(car.row[Column.STEERING_TORQUE], Star.EMPTY, f"{car.name} has no torque star")
-  #
-  # def test_year_format(self):
-  #   for car in self.all_cars:
-  #     with self.subTest(car=car):
-  #       self.assertIsNone(re.search(r"\d{4}-\d{4}", car.name), f"Format years correctly: {car.name}")
-  #
-  # def test_harnesses(self):
-  #   for car in self.all_cars:
-  #     with self.subTest(car=car):
-  #       if car.name == "comma body":
-  #         raise unittest.SkipTest
-  #
-  #       self.assertNotIn(car.harness, [None, Harness.none], f"Need to specify car harness: {car.name}")
+        self.assertNotIn(car.harness, [None, Harness.none], f"Need to specify car harness: {car.name}")
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -108,7 +108,7 @@ CAR_INFO: Dict[str, Union[ToyotaCarInfo, List[ToyotaCarInfo]]] = {
   CAR.ALPHARDH_TSS2: ToyotaCarInfo("Toyota Alphard Hybrid 2021"),
   CAR.AVALON: [
     ToyotaCarInfo("Toyota Avalon 2016", "Toyota Safety Sense P", footnotes=[Footnote.DSU]),
-    ToyotaCarInfo("Toyota Avalon 2017-18", footnotes=[Footnote.DSU]),
+    ToyotaCarInfo("Toyota Avalon 2016-18", footnotes=[Footnote.DSU]),
   ],
   CAR.AVALON_2019: ToyotaCarInfo("Toyota Avalon 2019-21", footnotes=[Footnote.DSU]),
   CAR.AVALONH_2019: ToyotaCarInfo("Toyota Avalon Hybrid 2019-21", footnotes=[Footnote.DSU]),
@@ -172,7 +172,10 @@ CAR_INFO: Dict[str, Union[ToyotaCarInfo, List[ToyotaCarInfo]]] = {
   CAR.LEXUS_NXH_TSS2: ToyotaCarInfo("Lexus NX Hybrid 2020-21"),
   CAR.LEXUS_RC: ToyotaCarInfo("Lexus RC 2017-20"),
   CAR.LEXUS_RX: ToyotaCarInfo("Lexus RX 2016-19", footnotes=[Footnote.DSU]),
-  CAR.LEXUS_RXH: ToyotaCarInfo("Lexus RX Hybrid 2016-19", footnotes=[Footnote.DSU]),
+  CAR.LEXUS_RXH: [
+    ToyotaCarInfo("Lexus RX Hybrid 2016", footnotes=[Footnote.DSU]),
+    ToyotaCarInfo("Lexus RX Hybrid 2016-19", footnotes=[Footnote.DSU]),
+  ],
   CAR.LEXUS_RX_TSS2: ToyotaCarInfo("Lexus RX 2020-22"),
   CAR.LEXUS_RXH_TSS2: ToyotaCarInfo("Lexus RX Hybrid 2020-21"),
 }

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -108,7 +108,7 @@ CAR_INFO: Dict[str, Union[ToyotaCarInfo, List[ToyotaCarInfo]]] = {
   CAR.ALPHARDH_TSS2: ToyotaCarInfo("Toyota Alphard Hybrid 2021"),
   CAR.AVALON: [
     ToyotaCarInfo("Toyota Avalon 2016", "Toyota Safety Sense P", footnotes=[Footnote.DSU]),
-    ToyotaCarInfo("Toyota Avalon 2016-18", footnotes=[Footnote.DSU]),
+    ToyotaCarInfo("Toyota Avalon 2017-18", footnotes=[Footnote.DSU]),
   ],
   CAR.AVALON_2019: ToyotaCarInfo("Toyota Avalon 2019-21", footnotes=[Footnote.DSU]),
   CAR.AVALONH_2019: ToyotaCarInfo("Toyota Avalon Hybrid 2019-21", footnotes=[Footnote.DSU]),
@@ -172,10 +172,7 @@ CAR_INFO: Dict[str, Union[ToyotaCarInfo, List[ToyotaCarInfo]]] = {
   CAR.LEXUS_NXH_TSS2: ToyotaCarInfo("Lexus NX Hybrid 2020-21"),
   CAR.LEXUS_RC: ToyotaCarInfo("Lexus RC 2017-20"),
   CAR.LEXUS_RX: ToyotaCarInfo("Lexus RX 2016-19", footnotes=[Footnote.DSU]),
-  CAR.LEXUS_RXH: [
-    ToyotaCarInfo("Lexus RX Hybrid 2016", footnotes=[Footnote.DSU]),
-    ToyotaCarInfo("Lexus RX Hybrid 2016-19", footnotes=[Footnote.DSU]),
-  ],
+  CAR.LEXUS_RXH: ToyotaCarInfo("Lexus RX Hybrid 2016-19", footnotes=[Footnote.DSU]),
   CAR.LEXUS_RX_TSS2: ToyotaCarInfo("Lexus RX 2020-22"),
   CAR.LEXUS_RXH_TSS2: ToyotaCarInfo("Lexus RX Hybrid 2020-21"),
 }


### PR DESCRIPTION
Per `(make, model)` key (okay to duplicate years in a platform if it's a differently marketed car)