### PR TITLE
IsoTpParallelQuery: set separation time

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -69,7 +69,7 @@ class IsoTpParallelQuery:
 
     max_len = 8 if sub_addr is None else 7
     # uses iso-tp frame separation time of 10 ms
-    # TODO: use single_frame_mode so ECU can send as fast as it wants,
+    # TODO: use single_frame_mode so ECUs can send as fast as they want,
     # as well as reduces chances we process messages from previous query
     return IsoTpMessage(can_client, timeout=0, separation_time=0.01, debug=self.debug, max_len=max_len)
 

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -69,6 +69,8 @@ class IsoTpParallelQuery:
 
     max_len = 8 if sub_addr is None else 7
     # uses iso-tp frame separation time of 10 ms
+    # TODO: use single_frame_mode so ECU can send as fast as it wants,
+    # as well as reduces chances we process messages from previous query
     return IsoTpMessage(can_client, timeout=0, separation_time=0.01, debug=self.debug, max_len=max_len)
 
   def get_data(self, timeout, total_timeout=60.):

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -70,7 +70,7 @@ class IsoTpParallelQuery:
     max_len = 8 if sub_addr is None else 7
     # uses iso-tp frame separation time of 10 ms
     # TODO: use single_frame_mode so ECUs can send as fast as they want,
-    # as well as reduces chances we process messages from previous query
+    # as well as reduces chances we process messages from previous queries
     return IsoTpMessage(can_client, timeout=0, separation_time=0.01, debug=self.debug, max_len=max_len)
 
   def get_data(self, timeout, total_timeout=60.):

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -68,7 +68,8 @@ class IsoTpParallelQuery:
                            self.bus, sub_addr=sub_addr, debug=self.debug)
 
     max_len = 8 if sub_addr is None else 7
-    return IsoTpMessage(can_client, timeout=0, max_len=max_len, debug=self.debug)
+    # uses iso-tp frame separation time of 10 ms
+    return IsoTpMessage(can_client, timeout=0, separation_time=0.01, debug=self.debug, max_len=max_len)
 
   def get_data(self, timeout, total_timeout=60.):
     self._drain_rx()


### PR DESCRIPTION
Moves hidden away 10 ms STmin setting into openpilot as a parameter for IsoTpMessage