### PR TITLE
regen: add arg for migrating sensorEvents with old timestamps

### DIFF
--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -214,6 +214,7 @@ def migrate_sensorEvents(lr):
 
       m = messaging.new_message(sensor_service)
       m.valid = True
+      m.logMonoTime = msg.logMonoTime
 
       m_dat = getattr(m, sensor_service)
       m_dat.version = evt.version

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -190,7 +190,7 @@ def migrate_carparams(lr):
   return all_msgs
 
 
-def migrate_sensorEvents(lr):
+def migrate_sensorEvents(lr, old_logtime=False):
   all_msgs = []
   for msg in lr:
     if msg.which() != 'sensorEventsDEPRECATED':
@@ -214,7 +214,8 @@ def migrate_sensorEvents(lr):
 
       m = messaging.new_message(sensor_service)
       m.valid = True
-      m.logMonoTime = msg.logMonoTime
+      if old_logtime:
+        m.logMonoTime = msg.logMonoTime
 
       m_dat = getattr(m, sensor_service)
       m_dat.version = evt.version


### PR DESCRIPTION
@gast04 Was there a reason not to add the same log time while migrating events? I cannot reproduce `locationd` on old data if the timings are not right.