### PR TITLE
joystickd: add controller mapping

### DIFF
--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -38,13 +38,20 @@ class Keyboard:
 
 
 class Joystick:
-  def __init__(self):
+  def __init__(self, gamepad=False):
     # TODO: find a way to get this from API, perhaps "inputs" doesn't support it
-    self.min_axis_value = {'ABS_Y': 0., 'ABS_RX': 0.}
-    self.max_axis_value = {'ABS_Y': 255., 'ABS_RX': 255.}
-    self.cancel_button = 'BTN_NORTH'  # (BTN_NORTH=X, ABS_RZ=Right Trigger)
-    self.axes_values = {'ABS_Y': 0., 'ABS_RX': 0.}  # gb, steer
-    self.axes_order = ['ABS_Y', 'ABS_RX']
+    if gamepad:
+      self.cancel_button = 'BTN_NORTH'  # (BTN_NORTH=X, ABS_RZ=Right Trigger)
+      accel_axis = 'ABS_Y'
+      steer_axis = 'ABS_RX'
+    else:
+      self.cancel_button = 'BTN_TRIGGER'
+      accel_axis = 'ABS_Y'
+      steer_axis = 'ABS_RZ'
+    self.min_axis_value = {accel_axis: 0., steer_axis: 0.}
+    self.max_axis_value = {accel_axis: 255., steer_axis: 255.}
+    self.axes_values = {accel_axis: 0., steer_axis: 0.}
+    self.axes_order = [accel_axis, steer_axis]
     self.cancel = False
 
   def update(self):

--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -87,9 +87,8 @@ def send_thread(joystick):
       requests.get("http://"+os.environ["WEB"]+":5000/control/%f/%f" % tuple([joystick.axes_values[a] for a in joystick.axes_order][::-1]), timeout=None)
     rk.keep_time()
 
-def joystick_thread(use_keyboard):
+def joystick_thread(joystick):
   Params().put_bool('JoystickDebugMode', True)
-  joystick = Keyboard() if use_keyboard else Joystick()
   threading.Thread(target=send_thread, args=(joystick,), daemon=True).start()
   while True:
     joystick.update()
@@ -99,6 +98,7 @@ if __name__ == '__main__':
                                                'openpilot must be offroad before starting joysticked.',
                                    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('--keyboard', action='store_true', help='Use your keyboard instead of a joystick')
+  parser.add_argument('--gamepad', action='store_true', help='Use gamepad configuration instead of joystick')
   args = parser.parse_args()
 
   if not Params().get_bool("IsOffroad") and "ZMQ" not in os.environ and "WEB" not in os.environ:
@@ -115,4 +115,5 @@ if __name__ == '__main__':
   else:
     print('Using joystick, make sure to run cereal/messaging/bridge on your device if running over the network!')
 
-  joystick_thread(args.keyboard)
+  joystick = Keyboard() if args.keyboard else Joystick(args.gamepad)
+  joystick_thread(joystick)

--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -42,7 +42,7 @@ class Joystick:
     # TODO: find a way to get this from API, perhaps "inputs" doesn't support it
     self.min_axis_value = {'ABS_Y': 0., 'ABS_RX': 0.}
     self.max_axis_value = {'ABS_Y': 255., 'ABS_RX': 255.}
-    self.cancel_button = 'BTN_NORTH' #(BTN_NORTH=X, ABS_RZ=Right Trigger)
+    self.cancel_button = 'BTN_NORTH'  # (BTN_NORTH=X, ABS_RZ=Right Trigger)
     self.axes_values = {'ABS_Y': 0., 'ABS_RX': 0.}  # gb, steer
     self.axes_order = ['ABS_Y', 'ABS_RX']
     self.cancel = False

--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -40,11 +40,11 @@ class Keyboard:
 class Joystick:
   def __init__(self):
     # TODO: find a way to get this from API, perhaps "inputs" doesn't support it
-    self.min_axis_value = {'ABS_Y': 0., 'ABS_RZ': 0.}
-    self.max_axis_value = {'ABS_Y': 255., 'ABS_RZ': 255.}
-    self.cancel_button = 'BTN_TRIGGER'
-    self.axes_values = {'ABS_Y': 0., 'ABS_RZ': 0.}  # gb, steer
-    self.axes_order = ['ABS_Y', 'ABS_RZ']
+    self.min_axis_value = {'ABS_Y': 0., 'ABS_RX': 0.}
+    self.max_axis_value = {'ABS_Y': 255., 'ABS_RX': 255.}
+    self.cancel_button = 'BTN_NORTH' #(BTN_NORTH=X, ABS_RZ=Right Trigger)
+    self.axes_values = {'ABS_Y': 0., 'ABS_RX': 0.}  # gb, steer
+    self.axes_order = ['ABS_Y', 'ABS_RX']
     self.cancel = False
 
   def update(self):


### PR DESCRIPTION
Current config maps steering to right trigger (ABS_RZ) when using a default xinput controller: https://inputs.readthedocs.io/en/latest/user/hardwaresupport.html

This results in default full left steering angle (1) requiring right trigger to return to centre (0) or right (-1).

It appears the intended mapping for steering is right thumbstick (ABS_RX).

Cancel button is also non-existent on default xinput controller. May be X button (BTN_NORTH) or Right Trigger (ABS_RZ).

Tested on Xbox One Controller via USB Cable, Logitech F710 and GameSir T4 Pro.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
