### PR TITLE
FPv2: fixed fingerprint overrides query result

### DIFF
--- a/scripts/launch_corolla.sh
+++ b/scripts/launch_corolla.sh
@@ -3,4 +3,5 @@
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 export FINGERPRINT="TOYOTA COROLLA TSS2 2019"
+export SKIP_FW_QUERY="1"
 $DIR/../launch_openpilot.sh

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -81,7 +81,7 @@ def fingerprint(logcan, sendcan):
   skip_fw_query = os.environ.get('SKIP_FW_QUERY', False)
   ecu_rx_addrs = set()
 
-  if not fixed_fingerprint and not skip_fw_query:
+  if not skip_fw_query:
     # Vin query only reliably works through OBDII
     bus = 1
 

--- a/selfdrive/test/profiling/profiler.py
+++ b/selfdrive/test/profiling/profiler.py
@@ -53,6 +53,7 @@ def profile(proc, func, car='toyota'):
   msgs = list(LogReader(rlog_url)) * int(os.getenv("LOOP", "1"))
 
   os.environ['FINGERPRINT'] = fingerprint
+  os.environ['SKIP_FW_QUERY'] = "1"
   os.environ['REPLAY'] = "1"
 
   def run(sm, pm, can_sock):

--- a/tools/sim/launch_openpilot.sh
+++ b/tools/sim/launch_openpilot.sh
@@ -3,6 +3,7 @@
 export PASSIVE="0"
 export NOBOARD="1"
 export SIMULATION="1"
+export SKIP_FW_QUERY="1"
 export FINGERPRINT="HONDA CIVIC 2016"
 
 export BLOCK="camerad,loggerd,encoderd"


### PR DESCRIPTION
This is often done by car porters, users with fingerprinting issues (most recently the new CAN-FD Hyundais), and users with missing versions, however it means that we don't get any useful information out of these users.

This makes us go through the normal fingerprinting flow if the `FINGERPRINT` environment variable is set, while still providing `SKIP_FW_QUERY` to skip queries if needed. This lets us gather data about these problems without users not being able to use openpilot.

We will now get from these users:
- VIN
- VIN ECU rx addr
- FW versions
- Logging issues around getting this data