### PR TITLE
cabana: custom slider to indicate the status of engaged/disengaged/alerts

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -99,7 +99,6 @@ void VideoWidget::updateState() {
 }
 
 // Slider
-// TODO: show timeline bar like what replay did.
 Slider::Slider(QWidget *parent) : QSlider(Qt::Horizontal, parent) {
   fetch_timeline_timer = new QTimer(this);
   fetch_timeline_timer->setInterval(2000);

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -4,6 +4,7 @@
 #include <QDateTime>
 #include <QHBoxLayout>
 #include <QMouseEvent>
+#include <QPainter>
 #include <QPushButton>
 #include <QVBoxLayout>
 
@@ -100,6 +101,51 @@ void VideoWidget::updateState() {
 // Slider
 // TODO: show timeline bar like what replay did.
 Slider::Slider(QWidget *parent) : QSlider(Qt::Horizontal, parent) {
+  fetch_timeline_timer = new QTimer(this);
+  fetch_timeline_timer->setInterval(2000);
+  fetch_timeline_timer->callOnTimeout([this]() {
+    timeline = parser->replay->getTimeline();
+  });
+  fetch_timeline_timer->start();
+}
+
+void Slider::paintEvent(QPaintEvent *ev) {
+  auto getPaintRange = [this](double begin, double end) -> std::pair<double, double> {
+    double total_sec = maximum() - minimum();
+    int start_pos = ((std::max((double)minimum(), (double)begin) - minimum()) / total_sec) * width();
+    int end_pos = ((std::min((double)maximum(), (double)end) - minimum()) / total_sec) * width();
+    return {start_pos, end_pos};
+  };
+
+  QPainter p(this);
+  const int v_margin = 2;
+  p.fillRect(rect().adjusted(0, v_margin, 0, -v_margin), QColor(0, 0, 128));
+
+  for (auto [begin, end, type] : timeline) {
+    if (begin > maximum() || end < minimum()) continue;
+
+    if (type == TimelineType::Engaged) {
+      auto [start_pos, end_pos] = getPaintRange(begin, end);
+      p.fillRect(QRect(start_pos, v_margin, end_pos - start_pos, height() - v_margin * 2), QColor(0, 135, 0));
+    }
+  }
+  for (auto [begin, end, type] : timeline) {
+    if (type == TimelineType::Engaged || begin > maximum() || end < minimum()) continue;
+
+    auto [start_pos, end_pos] = getPaintRange(begin, end);
+    if (type == TimelineType::UserFlag) {
+      p.fillRect(QRect(start_pos, height() - v_margin - 3, end_pos - start_pos, 3), Qt::white);
+    } else {
+      QColor color(Qt::green);
+      if (type != TimelineType::AlertInfo)
+        color = type == TimelineType::AlertWarning ? Qt::yellow : Qt::red;
+
+      p.fillRect(QRect(start_pos, height() - v_margin - 3, end_pos - start_pos, 3), color);
+    }
+  }
+  p.setPen(QPen(Qt::black, 2));
+  qreal x = width() * ((value() - minimum()) / double(maximum() - minimum()));
+  p.drawLine(QPointF{x, 0.}, QPointF{x, (qreal)height()});
 }
 
 void Slider::mousePressEvent(QMouseEvent *e) {

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -6,6 +6,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPushButton>
+#include <QTimer>
 #include <QVBoxLayout>
 
 #include "tools/cabana/parser.h"
@@ -100,12 +101,10 @@ void VideoWidget::updateState() {
 
 // Slider
 Slider::Slider(QWidget *parent) : QSlider(Qt::Horizontal, parent) {
-  fetch_timeline_timer = new QTimer(this);
-  fetch_timeline_timer->setInterval(2000);
-  fetch_timeline_timer->callOnTimeout([this]() {
-    timeline = parser->replay->getTimeline();
-  });
-  fetch_timeline_timer->start();
+  QTimer *timer = new QTimer(this);
+  timer->setInterval(2000);
+  timer->callOnTimeout([this]() { timeline = parser->replay->getTimeline(); });
+  timer->start();
 }
 
 void Slider::paintEvent(QPaintEvent *ev) {

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -2,7 +2,6 @@
 
 #include <QLabel>
 #include <QSlider>
-#include <QTimer>
 #include <QWidget>
 
 #include "selfdrive/ui/qt/widgets/cameraview.h"
@@ -20,7 +19,6 @@ signals:
 
 private:
    void paintEvent(QPaintEvent *ev) override;
-   QTimer *fetch_timeline_timer;
    std::vector<std::tuple<int, int, TimelineType>> timeline;
 };
 

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -2,9 +2,11 @@
 
 #include <QLabel>
 #include <QSlider>
+#include <QTimer>
 #include <QWidget>
 
 #include "selfdrive/ui/qt/widgets/cameraview.h"
+#include "tools/replay/replay.h"
 
 class Slider : public QSlider {
   Q_OBJECT
@@ -15,6 +17,11 @@ public:
 
 signals:
   void setPosition(int value);
+
+private:
+   void paintEvent(QPaintEvent *ev) override;
+   QTimer *fetch_timeline_timer;
+   std::vector<std::tuple<int, int, TimelineType>> timeline;
 };
 
 class VideoWidget : public QWidget {


### PR DESCRIPTION
![timelinebar](https://user-images.githubusercontent.com/27770/194519360-2cd6b099-e57a-4c76-8403-5dcd0aadb9e8.png)

the color blocks are not good-looking, we can draw it better later.