### PR TITLE
VW MNB: Add EPS config script support

### DIFF
--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -70,8 +70,8 @@ if __name__ == "__main__":
   coding_variant, current_coding_array, coding_byte, coding_bit = None, None, 0, 0
   coding_length = len(current_coding)
 
-  # EV_SteerAssisMQB covers the majority of MQB racks (EPS_MQB_ZFLS)
-  if odx_file == "EV_SteerAssisMQB\x00":
+  # EV_SteerAssisMQB/MNB cover the majority of MQB racks (EPS_MQB_ZFLS)
+  if odx_file in ("EV_SteerAssisMQB\x00", "EV_SteerAssisMNB\x00"):
     coding_variant = "ZF"
     coding_byte = 0
     coding_bit = 4
@@ -111,7 +111,7 @@ if __name__ == "__main__":
   if args.action in ["enable", "disable"]:
     print("\nAttempting configuration update")
 
-    assert(coding_variant in ("ZF", "APA")) 
+    assert(coding_variant in ("ZF", "APA"))
     # ZF EPS config coding length can be anywhere from 1 to 4 bytes, but the
     # bit we care about is always in the same place in the first byte
     if args.action == "enable":


### PR DESCRIPTION
**Description**

Add support for configuring the MNB platform EPS rack, used by the Volkswagen Crafter family of light commercial trucks.

**Verification**

```
comma@tici:/data/openpilot/selfdrive/debug$ ./vw_mqb_config.py show
opening device 2d003b001951393330393936 0xddcc
connected

EPS diagnostic data

   Part No HW:   2N0909143C
   Part No SW:   2N0909143E
   SW Version:   7021
   Component:    EPS_MQB_ZFLS
   Coding:       0107
   ASAM Dataset: EV_SteerAssisMNB
   Lane Assist:  DISABLED

EPS parameterization (per-vehicle calibration) data

   Version of system parameters:     16
   Vehicle type:                     3A
   Index of characteristic curve:    Z3
   Version of characteristic values: 06
   Version of memory map:            A2
```

```
comma@tici:/data/openpilot/selfdrive/debug$ ./vw_mqb_config.py enable
opening device 2d003b001951393330393936 0xddcc
connected

EPS diagnostic data

   Part No HW:   2N0909143C
   Part No SW:   2N0909143E
   SW Version:   7021
   Component:    EPS_MQB_ZFLS
   Coding:       0107
   ASAM Dataset: EV_SteerAssisMNB
   Lane Assist:  DISABLED

EPS parameterization (per-vehicle calibration) data

   Version of system parameters:     16
   Vehicle type:                     3A
   Index of characteristic curve:    Z3
   Version of characteristic values: 06
   Version of memory map:            A2

Attempting configuration update
   New coding:   1107
EPS configuration successfully updated
```

```
comma@tici:/data/openpilot/selfdrive/debug$ ./vw_mqb_config.py show
opening device 2d003b001951393330393936 0xddcc
connected

EPS diagnostic data

   Part No HW:   2N0909143C
   Part No SW:   2N0909143E
   SW Version:   7021
   Component:    EPS_MQB_ZFLS
   Coding:       1107
   ASAM Dataset: EV_SteerAssisMNB
   Lane Assist:  ENABLED

EPS parameterization (per-vehicle calibration) data

   Version of system parameters:     16
   Vehicle type:                     3A
   Index of characteristic curve:    Z3
   Version of characteristic values: 06
   Version of memory map:            A2
```