### PR TITLE
Add ip and port arguments to /tools/sim/bridge.py

### DIFF
--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -39,7 +39,7 @@ Options:
   --high_quality        Set simulator to higher quality (requires good GPU)
   --town TOWN           Select map to drive in
   --spawn_point NUM     Number of the spawn point to start in
-  --ip IP_ADDRESS       IP address of Carla client (127.0.0.1 as default)
+  --host HOST           Host address of Carla client (127.0.0.1 as default)
   --port PORT           Port of Carla client (2000 as default)
 ```
 

--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -39,6 +39,8 @@ Options:
   --high_quality        Set simulator to higher quality (requires good GPU)
   --town TOWN           Select map to drive in
   --spawn_point NUM     Number of the spawn point to start in
+  --ip                  Set IP address of Carla server (127.0.0.1 as default)
+  --port                Set port of Carla server (2000 as default)
 ```
 
 To engage openpilot press 1 a few times while focused on bridge.py to increase the cruise speed.

--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -39,8 +39,8 @@ Options:
   --high_quality        Set simulator to higher quality (requires good GPU)
   --town TOWN           Select map to drive in
   --spawn_point NUM     Number of the spawn point to start in
-  --ip                  Set IP address of Carla server (127.0.0.1 as default)
-  --port                Set port of Carla server (2000 as default)
+  --ip                  Set IP address of Carla client (127.0.0.1 as default)
+  --port                Set port of Carla client (2000 as default)
 ```
 
 To engage openpilot press 1 a few times while focused on bridge.py to increase the cruise speed.

--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -39,8 +39,8 @@ Options:
   --high_quality        Set simulator to higher quality (requires good GPU)
   --town TOWN           Select map to drive in
   --spawn_point NUM     Number of the spawn point to start in
-  --ip                  Set IP address of Carla client (127.0.0.1 as default)
-  --port                Set port of Carla client (2000 as default)
+  --ip IP_ADDRESS       IP address of Carla client (127.0.0.1 as default)
+  --port PORT           Port of Carla client (2000 as default)
 ```
 
 To engage openpilot press 1 a few times while focused on bridge.py to increase the cruise speed.

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -39,6 +39,8 @@ def parse_args(add_args=None):
   parser.add_argument('--dual_camera', action='store_true')
   parser.add_argument('--town', type=str, default='Town04_Opt')
   parser.add_argument('--spawn_point', dest='num_selected_spawn_point', type=int, default=16)
+  parser.add_argument('--ip', dest='ip', type=str, default = '127.0.0.1')
+  parser.add_argument('--port', dest='port', type=int, default = 2000)
 
   return parser.parse_args(add_args)
 
@@ -233,8 +235,8 @@ def can_function_runner(vs: VehicleState, exit_event: threading.Event):
     i += 1
 
 
-def connect_carla_client():
-  client = carla.Client("127.0.0.1", 2000)
+def connect_carla_client(IP, PORT):
+  client = carla.Client(IP, PORT)
   client.set_timeout(5)
   return client
 
@@ -291,7 +293,7 @@ class CarlaBridge:
       self.close()
 
   def _run(self, q: Queue):
-    client = connect_carla_client()
+    client = connect_carla_client(self._args.ip, self._args.port)
     world = client.load_world(self._args.town)
 
     settings = world.get_settings()

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -39,8 +39,8 @@ def parse_args(add_args=None):
   parser.add_argument('--dual_camera', action='store_true')
   parser.add_argument('--town', type=str, default='Town04_Opt')
   parser.add_argument('--spawn_point', dest='num_selected_spawn_point', type=int, default=16)
-  parser.add_argument('--ip', dest='ip', type=str, default = '127.0.0.1')
-  parser.add_argument('--port', dest='port', type=int, default = 2000)
+  parser.add_argument('--host', dest='host', type=str, default='127.0.0.1')
+  parser.add_argument('--port', dest='port', type=int, default=2000)
 
   return parser.parse_args(add_args)
 
@@ -235,8 +235,8 @@ def can_function_runner(vs: VehicleState, exit_event: threading.Event):
     i += 1
 
 
-def connect_carla_client(IP, PORT):
-  client = carla.Client(IP, PORT)
+def connect_carla_client(host: str, port: int):
+  client = carla.Client(host, port)
   client.set_timeout(5)
   return client
 
@@ -293,7 +293,7 @@ class CarlaBridge:
       self.close()
 
   def _run(self, q: Queue):
-    client = connect_carla_client(self._args.ip, self._args.port)
+    client = connect_carla_client(self._args.host, self._args.port)
     world = client.load_world(self._args.town)
 
     settings = world.get_settings()


### PR DESCRIPTION
Since Carla requires too many resources, running the Carla client on a PC with a high performance video card while working on openpilot on a laptops is a better configuration.

Currently, bridge.py in the latest docker images assigns only a local IP address as 127.0.0.1 in function connect_carla_client(). Therefore, each time after executing /tools/sim/start_openpilot_docker.sh, users have to manually modify the very function in file bridge.py.

To make it easier to set the ip address and port number of the Carla client, I added the ip and port arguments to bridge.py. Also, I have updated the descriptions of the new arguments in README.md.

