### PR TITLE
cabana: fix Incorrect Y-Axis Scale

### DIFF
--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -37,6 +37,7 @@ private:
   void addData(const CanData &can_data, const Signal &sig);
   void updateSeries();
   void rangeChanged(qreal min, qreal max);
+  void updateAxisY();
 
   QString id;
   QString sig_name;


### PR DESCRIPTION
the min_y and max_y are not set correctly in the zoomed range.