### PR TITLE
Add CarInfo for Elantra GT and i30

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -110,7 +110,10 @@ CAR_INFO: Dict[str, Optional[Union[HyundaiCarInfo, List[HyundaiCarInfo]]]] = {
   CAR.ELANTRA: HyundaiCarInfo("Hyundai Elantra 2017-19", min_enable_speed=19 * CV.MPH_TO_MS, harness=Harness.hyundai_b),
   CAR.ELANTRA_2021: HyundaiCarInfo("Hyundai Elantra 2021-22", video_link="https://youtu.be/_EdYQtV52-c", harness=Harness.hyundai_k),
   CAR.ELANTRA_HEV_2021: HyundaiCarInfo("Hyundai Elantra Hybrid 2021-22", video_link="https://youtu.be/_EdYQtV52-c", harness=Harness.hyundai_k),
-  CAR.ELANTRA_GT_I30: None,  # dashcamOnly and same platform as CAR.ELANTRA
+  CAR.ELANTRA_GT_I30: [
+    HyundaiCarInfo("Hyundai Elantra GT 2017-19", harness=Harness.hyundai_e),
+    HyundaiCarInfo("Hyundai i30 2019", harness=Harness.hyundai_e),
+  ],
   CAR.HYUNDAI_GENESIS: HyundaiCarInfo("Hyundai Genesis 2015-16", min_enable_speed=19 * CV.MPH_TO_MS, harness=Harness.hyundai_j),  # TODO: check 2015 packages
   CAR.IONIQ: HyundaiCarInfo("Hyundai Ioniq Hybrid 2017-19", harness=Harness.hyundai_c),
   CAR.IONIQ_HEV_2022: HyundaiCarInfo("Hyundai Ioniq Hybrid 2020-22", harness=Harness.hyundai_h),  # TODO: confirm 2020-21 harness


### PR DESCRIPTION
Adds car info from https://github.com/commaai/openpilot/pull/970/files. i30 is the [over-seas name](https://en.wikipedia.org/wiki/Hyundai_Elantra#Elantra_GT)

2018 GT has `Smart Cruise Control with stop/start`: https://cdn.dealereprocess.org/cdn/brochures/hyundai/2018-elantragt.pdf

Only 2019 i30 has SCC: https://www.inghamdriven.nz/hyundai/wp-content/uploads/sites/16/2021/01/i30-Brochure-May-2019.pdf https://www.coupers.co.uk/pdfs/brochure/i30.pdf