### PR TITLE
ci: only run one instance of each workflow

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -1,9 +1,14 @@
 name: selfdrive
+
 on:
   push:
     branches-ignore:
       - 'testing-closet*'
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 env:
   BASE_IMAGE: openpilot-base

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -1,7 +1,12 @@
 name: tools
+
 on:
   push:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 env:
   BASE_IMAGE: openpilot-base


### PR DESCRIPTION
When a new commit is pushed to a branch, the old workflows will be cancelled. This shouldn't prevent the push and synchronise events from running at the same time.