### PR TITLE
don't build cabana unless extras

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -434,9 +434,10 @@ SConscript(['selfdrive/navd/SConscript'])
 if arch in ['x86_64', 'Darwin'] or GetOption('extras'):
   SConscript(['tools/replay/SConscript'])
 
-  opendbc = abspath([File('opendbc/can/libdbc.so')])
-  Export('opendbc')
-  SConscript(['tools/cabana/SConscript'])
+  if arch in ['x86_64', 'Darwin'] and GetOption('extras'):
+    opendbc = abspath([File('opendbc/can/libdbc.so')])
+    Export('opendbc')
+    SConscript(['tools/cabana/SConscript'])
 
 if GetOption('test'):
   SConscript('panda/tests/safety/SConscript')


### PR DESCRIPTION
this caused CI to fail for xx since qt libs aren't installed in CI docker