### PR TITLE
HKG: EV6 - improved LAT_ACCEL_FACTOR and FRICTION values 

### DIFF
--- a/selfdrive/car/torque_data/override.yaml
+++ b/selfdrive/car/torque_data/override.yaml
@@ -21,7 +21,7 @@ FORD FOCUS 4TH GEN: [.nan, 1.5, .nan]
 COMMA BODY: [.nan, 1000, .nan]
 
 # Totally new cars
-KIA EV6 2022: [3.5, 3.0, 0.0]
+KIA EV6 2022: [3.0, 3.0, 0.05]
 RAM 1500 5TH GEN: [2.0, 2.0, 0.0]
 RAM HD 5TH GEN: [1.4, 1.4, 0.0]
 SUBARU OUTBACK 6TH GEN: [2.3, 2.3, 0.11]


### PR DESCRIPTION
**Description**

This PR improves understeering in the 2022 Kia EV6. This is done simply by cherry-picking a commit from https://github.com/commaai/openpilot/pull/25801, per my comment: https://github.com/commaai/openpilot/pull/25801#issuecomment-1279170301.

**Verification**

@hoomoose and I have found that in both of our EV6s, these torque values perform significantly better. Without them, stock OP can only maintain centering on straightaways.

**Route**

without: 859ffc6fd4e4168c|2022-10-13--17-49-56
with: 859ffc6fd4e4168c|2022-10-07--20-13-11
