### PR TITLE
loggerd: fix length of ArrayPtr in handle_encoder_msg

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -55,7 +55,7 @@ int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct 
   int bytes_count = 0;
 
   // extract the message
-  capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize()));
+  capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize() / sizeof(capnp::word)));
   auto event = cmsg.getRoot<cereal::Event>();
   auto edata = (name == "driverEncodeData") ? event.getDriverEncodeData() :
     ((name == "wideRoadEncodeData") ? event.getWideRoadEncodeData() :


### PR DESCRIPTION
**Description** 
I was just reading the code for loggerd.cc and it appears that the ArrayPtr created from the received cereal message has the wrong size. It should be in 64bit capnp-words, not bytes.

**Verification** 
I don't own a Comma 3, but I'm using cereal and some of this code in my own robotics project and I was getting crashes.

