### PR TITLE
GM: match ECM standstill check

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -39,7 +39,7 @@ class CarState(CarStateBase):
     )
     ret.vEgoRaw = mean([ret.wheelSpeeds.fl, ret.wheelSpeeds.fr, ret.wheelSpeeds.rl, ret.wheelSpeeds.rr])
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
-    ret.standstill = ret.vEgoRaw < 0.01
+    ret.standstill = (pt_cp["ECMVehicleSpeed"]["VehicleSpeed"] + pt_cp["ECMVehicleSpeed"]["VehicleSpeedLeft"]) != 0
 
     if pt_cp.vl["ECMPRDNL2"]["ManualMode"] == 1:
       ret.gearShifter = self.parse_gear_shifter("T")
@@ -121,6 +121,8 @@ class CarState(CarStateBase):
     signals = [
       # sig_name, sig_address
       ("BrakePedalPos", "ECMAcceleratorPos"),
+      ("VehicleSpeed", "ECMVehicleSpeed"),
+      ("VehicleSpeedLeft", "ECMVehicleSpeed"),
       ("FrontLeftDoor", "BCMDoorBeltStatus"),
       ("FrontRightDoor", "BCMDoorBeltStatus"),
       ("RearLeftDoor", "BCMDoorBeltStatus"),
@@ -162,6 +164,7 @@ class CarState(CarStateBase):
       ("ECMEngineStatus", 100),
       ("PSCMSteeringAngle", 100),
       ("ECMAcceleratorPos", 80),
+      ("ECMVehicleSpeed", 80),
     ]
 
     if CP.transmissionType == TransmissionType.direct:

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -234,7 +234,7 @@ class TestCarModelBase(unittest.TestCase):
 
       checks['gasPressed'] += CS.gasPressed != self.safety.get_gas_pressed_prev()
       checks['cruiseState'] += CS.cruiseState.enabled and not CS.cruiseState.available
-      if self.CP.carName not in ("hyundai", "volkswagen", "gm", "body"):
+      if self.CP.carName not in ("hyundai", "volkswagen", "body"):
         # TODO: fix standstill mismatches for other makes
         checks['standstill'] += CS.standstill == self.safety.get_vehicle_moving()
 


### PR DESCRIPTION
Useful for avoiding faults both for OP long and without. As well as allowing engagement where the ECM allows it (sometimes up to 0.5 m/s, but as far as ECM and camera are concerned, we're at a standstill).

Also matches panda standstill now.

- [ ] Should check to make sure this isn't noisy at all on ASCM cars