### PR TITLE
ui brightness: fix exposure scale factor

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -163,7 +163,8 @@ static void update_state(UIState *s) {
     scene.longitudinal_control = sm["carParams"].getCarParams().getOpenpilotLongitudinalControl();
   }
   if (sm.updated("wideRoadCameraState")) {
-    scene.light_sensor = 100.0f - sm["wideRoadCameraState"].getWideRoadCameraState().getExposureValPercent();
+    float scale = (sm["wideRoadCameraState"].getWideRoadCameraState().getSensor() == cereal::FrameData::ImageSensor::AR0321) ? 6.0f : 1.0f;
+    scene.light_sensor = std::max(100.0f - scale * sm["wideRoadCameraState"].getWideRoadCameraState().getExposureValPercent(), 0.0f);
   }
   scene.started = sm["deviceState"].getDeviceState().getStarted() && scene.ignition;
 }


### PR DESCRIPTION
Screen looked brighter than usual at night. I think the scale factor of 6x got lost in this refactor: https://github.com/commaai/openpilot/pull/25915/files#diff-b4c3a1489c8e0ba7f36583bd4088a422537e9098c4e82b102b22d57e72c03aceL185. 

This scale factor accounts for that fact that even in very dark scenes the exposure will never reach 100%, and depends on the sensor. Left the scale factor for the OX03C10 at 1. Not sure if you want the scale factor in ui or camerad.