### PR TITLE
Move Qt moc files to scons cache directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -327,6 +327,7 @@ qt_flags = [
 qt_env['CXXFLAGS'] += qt_flags
 qt_env['LIBPATH'] += ['#selfdrive/ui']
 qt_env['LIBS'] = qt_libs
+qt_env['QT_MOCHPREFIX'] = cache_dir + '/moc_files/moc_'
 
 if GetOption("clazy"):
   checks = [


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/26093

The disadvantage of set QT_MOCHPREFIX in the root is cannot have files with the same name. currently their filenames are all unique.so I only set QT_MOCHPREFIX here once.

To ensure that there is no problem with the same name, we need to set QT_MOCHPREFIX in the sub-sconstruct to a different directory.

@adeebshihadeh what do you think ? Do we need to set the moc directories separately ?
