### PR TITLE
cabana: faster history log with better stretch mode

### DIFF
--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -6,21 +6,22 @@
 #include "tools/cabana/dbcmanager.h"
 
 class HistoryLogModel : public QAbstractTableModel {
-Q_OBJECT
+  Q_OBJECT
 
 public:
   HistoryLogModel(QObject *parent) : QAbstractTableModel(parent) {}
   void setMessage(const QString &message_id);
   void updateState();
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return column_count; }
-  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return row_count; }
+  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return column_count; }
 
 private:
   QString msg_id;
   int row_count = 0;
-  int column_count = 0;
+  int column_count = 2;
+  const Msg *dbc_msg = nullptr;
 };
 
 class HistoryLog : public QWidget {
@@ -28,8 +29,8 @@ class HistoryLog : public QWidget {
 
 public:
   HistoryLog(QWidget *parent);
-  void setMessage(const QString &message_id);
-  void updateState();
+  void setMessage(const QString &message_id) { model->setMessage(message_id); }
+  void updateState() { model->updateState(); }
 
 private:
   QTableView *table;


### PR DESCRIPTION
move the 'time' column from vertical header to normal cell. the `headerDataChanged` will cause QAbstractView to reset  the layout and redraw the entire view (include the horizontalHeader).

https://github.com/commaai/openpilot/blob/00494a44f4fb8f9e18ce82e22bf40fbe6bc1a805/tools/cabana/historylog.cc#L72