### PR TITLE
networking: fix metered setting

### DIFF
--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -368,7 +368,7 @@ void WifiManager::updateGsmSettings(bool roaming, QString apn, bool metered) {
       changes = true;
     }
 
-    int meteredInt = metered ? NM_METERED_NO : NM_METERED_UNKNOWN;
+    int meteredInt = metered ? NM_METERED_UNKNOWN : NM_METERED_NO;
     if (settings.value("connection").value("metered").toInt() != meteredInt) {
       qWarning() << "Changing connection.metered to" << meteredInt;
       settings["connection"]["metered"] = meteredInt;


### PR DESCRIPTION
- When the metered toggle is enabled (default) set the `connection.metered` setting to `NM_METERED_UNKNOWN` (allow network manager to decide?)
- When the toggle is disabled, set to `NM_METERED_NO`

Bug introduced in #25902