### PR TITLE
GM camera ACC: revert FCW logging

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -96,9 +96,7 @@ class CarState(CarStateBase):
     ret.cruiseState.standstill = pt_cp.vl["AcceleratorPedal2"]["CruiseState"] == AccState.STANDSTILL
     if self.CP.networkLocation == NetworkLocation.fwdCamera:
       ret.cruiseState.speed = cam_cp.vl["ASCMActiveCruiseControlStatus"]["ACCSpeedSetpoint"] * CV.KPH_TO_MS
-
       ret.stockAeb = cam_cp.vl["AEBCmd"]["AEBCmdActive"] != 0
-      ret.stockFcw = cam_cp.vl["ASCMActiveCruiseControlStatus"]["FCWAlert"] != 0
 
     return ret
 
@@ -110,7 +108,6 @@ class CarState(CarStateBase):
       signals += [
         ("AEBCmdActive", "AEBCmd"),
         ("RollingCounter", "ASCMLKASteeringCmd"),
-        ("FCWAlert", "ASCMActiveCruiseControlStatus"),
         ("ACCSpeedSetpoint", "ASCMActiveCruiseControlStatus"),
       ]
       checks += [


### PR DESCRIPTION
Camera uses FlexRay/gmlan to show FCW alerts unfortunately, this is always 0