### PR TITLE
Cabana: align the charts properly

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -2,6 +2,7 @@
 
 #include <QGraphicsLayout>
 #include <QRubberBand>
+#include <QTimer>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
 
@@ -183,7 +184,6 @@ ChartView::ChartView(const QString &id, const Signal *sig, QWidget *parent)
   font.setBold(true);
   chart->setTitleFont(font);
   chart->setMargins({0, 0, 0, 0});
-  chart->layout()->setContentsMargins(0, 0, 0, 0);
 
   track_line = new QGraphicsLineItem(chart);
   track_line->setPen(QPen(Qt::gray, 1, Qt::DashLine));
@@ -202,12 +202,30 @@ ChartView::ChartView(const QString &id, const Signal *sig, QWidget *parent)
     rubber->setPalette(pal);
   }
 
+  QTimer *timer = new QTimer(this);
+  timer->setInterval(100);
+  timer->setSingleShot(true);
+  timer->callOnTimeout(this, &ChartView::adjustChartMargins);
+
   QObject::connect(can, &CANMessages::updated, this, &ChartView::updateState);
   QObject::connect(can, &CANMessages::rangeChanged, this, &ChartView::rangeChanged);
   QObject::connect(can, &CANMessages::eventsMerged, this, &ChartView::updateSeries);
   QObject::connect(dynamic_cast<QValueAxis *>(chart->axisX()), &QValueAxis::rangeChanged, can, &CANMessages::setRange);
+  QObject::connect(chart, &QChart::plotAreaChanged, [=](const QRectF &plotArea) {
+    // use a singleshot timer to avoid recursion call.
+    timer->start();
+  });
 
   updateSeries();
+}
+
+void ChartView::adjustChartMargins() {
+  // TODO: Remove hardcoded aligned_pos
+  const int aligned_pos = 60;
+  if (chart()->plotArea().left() != aligned_pos) {
+    const float left_margin = chart()->margins().left() + aligned_pos - chart()->plotArea().left();
+    chart()->setMargins(QMargins(left_margin, 0, 0, 0));
+  }
 }
 
 void ChartWidget::setHeight(int height) {

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -27,6 +27,7 @@ private:
   void mouseMoveEvent(QMouseEvent *ev) override;
   void enterEvent(QEvent *event) override;
   void leaveEvent(QEvent *event) override;
+  void adjustChartMargins();
 
   void rangeChanged(qreal min, qreal max);
   void updateAxisY();


### PR DESCRIPTION
@jyoung8607 : charts with different length y labels has been aligned.

![aligned](https://user-images.githubusercontent.com/27770/196279431-d9f34fda-067b-48d0-8a4f-5a0f6d81df1f.png)
