### PR TITLE
updated: sync submodules

### DIFF
--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -365,6 +365,7 @@ class Updater:
       ["git", "checkout", "--force", "--no-recurse-submodules", "-B", branch, "FETCH_HEAD"],
       ["git", "reset", "--hard"],
       ["git", "clean", "-xdff"],
+      ["git", "submodule", "sync"],
       ["git", "submodule", "init"],
       ["git", "submodule", "update"],
     ]


### PR DESCRIPTION
We should run `git submodule sync` since we occasionally change the remotes in `.gitmodules`. This might be why there have been issues since tinygrad moved from geohot to commaai