### PR TITLE
cabana: reduce the padding in DetailsView

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -8,7 +8,7 @@
 
 // BinaryView
 
-const int CELL_HEIGHT = 35;
+const int CELL_HEIGHT = 30;
 
 BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   model = new BinaryViewModel(this);
@@ -156,7 +156,7 @@ void BinarySelectionModel::select(const QItemSelection &selection, QItemSelectio
 
 BinaryItemDelegate::BinaryItemDelegate(QObject *parent) : QStyledItemDelegate(parent) {
   // cache fonts and color
-  small_font.setPointSize(7);
+  small_font.setPointSize(6);
   bold_font.setBold(true);
   highlight_color = QApplication::style()->standardPalette().color(QPalette::Active, QPalette::Highlight);
 }

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -85,18 +85,17 @@ SignalEdit::SignalEdit(int index, const QString &msg_id, const Signal &sig, QWid
   // title bar
   QHBoxLayout *title_layout = new QHBoxLayout();
   icon = new QLabel(">");
-  icon->setFixedSize(15, 30);
   icon->setStyleSheet("font-weight:bold");
   title_layout->addWidget(icon);
   title = new ElidedLabel(this);
   title->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
   title->setText(QString("%1. %2").arg(index + 1).arg(sig_name));
   title->setStyleSheet(QString("font-weight:bold; color:%1").arg(getColor(index)));
-  title_layout->addWidget(title);
+  title_layout->addWidget(title, 1);
 
   QPushButton *plot_btn = new QPushButton("📈");
   plot_btn->setToolTip(tr("Show Plot"));
-  plot_btn->setFixedSize(30, 30);
+  plot_btn->setFixedSize(20, 20);
   QObject::connect(plot_btn, &QPushButton::clicked, this, &SignalEdit::showChart);
   title_layout->addWidget(plot_btn);
   main_layout->addLayout(title_layout);


### PR DESCRIPTION
reduce the padding,make it more compact.
before:
![Screenshot from 2022-10-18 11-07-42](https://user-images.githubusercontent.com/27770/196326492-5a885656-45e6-49a8-87b3-2eeeab121992.png)
after:
![Screenshot from 2022-10-18 11-08-02](https://user-images.githubusercontent.com/27770/196326496-594ed252-e717-4eea-b3e0-315656e29db8.png)
The padding of b is also reduced

 the cell padding in binaryview is also reduced.
