### PR TITLE
Tucson Hybrid 4th gen: add missing fwdRadar

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1369,6 +1369,9 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9240 14Q',
     ],
+    (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00NX4__               1.00 1.00 99110-N9100         ',
+    ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00NX4 MDPS C 1.00 1.01 56300-P0100 2228',
     ],


### PR DESCRIPTION
Added fwdRadar recovered from CAN logs: https://github.com/commaai/openpilot/pull/25276

This always skipped heavily on the OBD port, so that's why it was never gathered. Should be merged after move to camera fingerprinting