### PR TITLE
cabana: fix background refresh issue

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -48,7 +48,6 @@ MainWindow::MainWindow() : QWidget() {
 }
 
 void MainWindow::dockCharts(bool dock) {
-  charts_widget->setUpdatesEnabled(false);
   if (dock && floating_window) {
     floating_window->removeEventFilter(charts_widget);
     r_layout->addWidget(charts_widget);
@@ -62,7 +61,6 @@ void MainWindow::dockCharts(bool dock) {
     floating_window->setMinimumSize(QGuiApplication::primaryScreen()->size() / 2);
     floating_window->showMaximized();
   }
-  charts_widget->setUpdatesEnabled(true);
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {


### PR DESCRIPTION
the background of the chartswidget was not refreshed after undocking charts:
![Screenshot from 2022-10-18 18-23-20](https://user-images.githubusercontent.com/27770/196406692-5453a8cc-a938-419d-92af-d917a22dae1d.png)

after fix:
![Screenshot from 2022-10-18 18-24-21](https://user-images.githubusercontent.com/27770/196406745-248e8e98-634c-468e-99c9-05aa920a3eab.png)


