### PR TITLE
athena: stricter socket timeout when device awake

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -124,6 +124,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"HasAcceptedTerms", PERSISTENT},
     {"IMEI", PERSISTENT},
     {"InstallDate", PERSISTENT},
+    {"IsDeviceAwake", CLEAR_ON_MANAGER_START},
     {"IsDriverViewEnabled", CLEAR_ON_MANAGER_START},
     {"IsEngaged", PERSISTENT},
     {"IsLdwEnabled", PERSISTENT},

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -104,6 +104,7 @@ def handle_long_poll(ws):
   threads = [
     threading.Thread(target=ws_recv, args=(ws, end_event), name='ws_recv'),
     threading.Thread(target=ws_send, args=(ws, end_event), name='ws_send'),
+    threading.Thread(target=ws_manage, args=(ws, end_event), name='ws_manage'),
     threading.Thread(target=upload_handler, args=(end_event,), name='upload_handler'),
     threading.Thread(target=log_handler, args=(end_event,), name='log_handler'),
     threading.Thread(target=stat_handler, args=(end_event,), name='stat_handler'),
@@ -702,6 +703,29 @@ def ws_send(ws, end_event):
     except Exception:
       cloudlog.exception("athenad.ws_send.exception")
       end_event.set()
+
+
+def ws_manage(ws, end_event):
+  # params = Params()
+  # awake_prev = False
+
+  while not end_event.is_set():
+    # awake = params.get_bool("IsDeviceAwake")
+    # if awake != awake_prev:
+
+    # missing in pysocket
+    TCP_USER_TIMEOUT = 18
+
+    sock: socket.socket = ws.sock
+    print("SO_KEEPALIVE:", sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE))
+    print("TCP_KEEPIDLE:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE))
+    print("TCP_KEEPINTVL:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL))
+    print("TCP_KEEPCNT:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT))
+    print("TCP_USER_TIMEOUT:", sock.getsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT))
+    print()
+    # awake_prev = awake
+
+    time.sleep(2)
 
 
 def backoff(retries):

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -710,8 +710,8 @@ def ws_send(ws, end_event):
 
 
 def ws_manage(ws, end_event):
-  params = Params()
-  awake_prev = False
+  # params = Params()
+  # awake_prev = False
 
   while not end_event.is_set():
     # Default socket options:
@@ -722,15 +722,21 @@ def ws_manage(ws, end_event):
     # TCP_USER_TIMEOUT: 0
     sock: socket.socket = ws.sock
 
-    awake = params.get_bool("IsDeviceAwake")
-    if awake != awake_prev:
-      awake_prev = awake
+    print(f"SO_KEEPALIVE: {sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)}")
+    print(f"TCP_KEEPIDLE: {sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE)}")
+    print(f"TCP_KEEPINTVL: {sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL)}")
+    print(f"TCP_KEEPCNT: {sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT)}")
+    print(f"TCP_USER_TIMEOUT: {sock.getsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT)}")
 
-      keepidle = 5 if awake else 30  # seconds
-      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, keepidle)
+    # awake = params.get_bool("IsDeviceAwake")
+    # if awake != awake_prev:
+    #   awake_prev = awake
 
-      user_timeout = 40*1000 if awake else 60*1000  # milliseconds
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, user_timeout)
+    #   keepidle = 5 if awake else 30  # seconds
+    #   sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, keepidle)
+
+    #   user_timeout = 40*1000 if awake else 60*1000  # milliseconds
+    #   sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, user_timeout)
 
     time.sleep(2)
 

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -39,6 +39,10 @@ from selfdrive.statsd import STATS_DIR
 from system.swaglog import SWAGLOG_DIR, cloudlog
 from system.version import get_commit, get_origin, get_short_branch, get_version
 
+
+# missing in pysocket
+TCP_USER_TIMEOUT = 18
+
 ATHENA_HOST = os.getenv('ATHENA_HOST', 'wss://athena.comma.ai')
 HANDLER_THREADS = int(os.getenv('HANDLER_THREADS', "4"))
 LOCAL_PORT_WHITELIST = {8022}
@@ -710,26 +714,23 @@ def ws_manage(ws, end_event):
   awake_prev = False
 
   while not end_event.is_set():
-    # missing in pysocket
-    TCP_USER_TIMEOUT = 18
-
+    # Default socket options:
+    # SO_KEEPALIVE: 1
+    # TCP_KEEPIDLE: 30
+    # TCP_KEEPINTVL: 10
+    # TCP_KEEPCNT: 3
+    # TCP_USER_TIMEOUT: 0
     sock: socket.socket = ws.sock
 
     awake = params.get_bool("IsDeviceAwake")
     if awake != awake_prev:
       awake_prev = awake
 
-      keepidle = 10 if awake else 30
+      keepidle = 5 if awake else 30  # seconds
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, keepidle)
-      print(f"setting TCP_KEEPIDLE to {keepidle}")
-      print()
 
-    print("SO_KEEPALIVE:", sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE))
-    print("TCP_KEEPIDLE:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE))
-    print("TCP_KEEPINTVL:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL))
-    print("TCP_KEEPCNT:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT))
-    print("TCP_USER_TIMEOUT:", sock.getsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT))
-    print()
+      user_timeout = 40*1000 if awake else 60*1000  # milliseconds
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, user_timeout)
 
     time.sleep(2)
 

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -706,24 +706,30 @@ def ws_send(ws, end_event):
 
 
 def ws_manage(ws, end_event):
-  # params = Params()
-  # awake_prev = False
+  params = Params()
+  awake_prev = False
 
   while not end_event.is_set():
-    # awake = params.get_bool("IsDeviceAwake")
-    # if awake != awake_prev:
-
     # missing in pysocket
     TCP_USER_TIMEOUT = 18
 
     sock: socket.socket = ws.sock
+
+    awake = params.get_bool("IsDeviceAwake")
+    if awake != awake_prev:
+      awake_prev = awake
+
+      keepidle = 10 if awake else 30
+      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, keepidle)
+      print(f"setting TCP_KEEPIDLE to {keepidle}")
+      print()
+
     print("SO_KEEPALIVE:", sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE))
     print("TCP_KEEPIDLE:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE))
     print("TCP_KEEPINTVL:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL))
     print("TCP_KEEPCNT:", sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT))
     print("TCP_USER_TIMEOUT:", sock.getsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT))
     print()
-    # awake_prev = awake
 
     time.sleep(2)
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -260,6 +260,7 @@ void Device::setAwake(bool on) {
     Hardware::set_display_power(awake);
     LOGD("setting display power %d", awake);
     emit displayPowerChanged(awake);
+    Params().putBool("IsDeviceAwake", awake);
   }
 }
 


### PR DESCRIPTION
when device is awake, reduce the `TCP_KEEPIDLE` delay. also set a `TCP_USER_TIMEOUT` according to recommendation in https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/

```
# current websocket sockopts
SO_KEEPALIVE: 1
TCP_KEEPIDLE: 30     # change to 5 seconds when awake?
TCP_KEEPINTVL: 10
TCP_KEEPCNT: 3
TCP_USER_TIMEOUT: 0  # set to TCP_KEEPIDLE + TCP_KEEPINTVL * TCP_KEEPCNT?
```

https://man7.org/linux/man-pages/man7/tcp.7.html#:~:text=TCP_KEEPIDLE