### PR TITLE
sim: outputting frames in NV12 format

### DIFF
--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -103,15 +103,22 @@ class Camerad:
     img = np.reshape(img, (H, W, 4))
     img = img[:, :, [0, 1, 2]].copy()
 
-    # convert RGB frame to YUV
+    # TODO: use real_debayer.cl or dedicated rgb_to_nv12.cl program to convert from RGB to NV12 directly
+    # convert RGB frame to YUV I420
     rgb = np.reshape(img, (H, W * 3))
     rgb_cl = cl_array.to_device(self.queue, rgb)
     yuv_cl = cl_array.empty_like(rgb_cl)
     self.krnl(self.queue, (np.int32(self.Wdiv4), np.int32(self.Hdiv4)), None, rgb_cl.data, yuv_cl.data).wait()
     yuv = np.resize(yuv_cl.get(), rgb.size // 2)
-    eof = int(frame_id * 0.05 * 1e9)
 
-    self.vipc_server.send(yuv_type, yuv.data.tobytes(), frame_id, eof, eof)
+    # convert YUV I420 to NV12 frame
+    uv_offset = H * W
+    y = yuv[:uv_offset]
+    uv = yuv[uv_offset:].reshape(2, -1).ravel('F')
+    nv12 = np.hstack((y, uv))
+
+    eof = int(frame_id * 0.05 * 1e9)
+    self.vipc_server.send(yuv_type, nv12.data.tobytes(), frame_id, eof, eof)
 
     dat = messaging.new_message(pub_type)
     msg = {


### PR DESCRIPTION
Fix for:
- #25451 

Converting is done from YUV:I420 to YUV:NV12, using numpy. The conversion from I420 to NV12 is luckily done rather quickly. This addition will work fine for us, experimenting with openpilot using CARLA in colour again.

Although this works fine, the most optimal solution would be using a dedicated RGB to YUV:NV12 converted OpenCL program, I tried changing [rgb_to_yuv.cl](https://github.com/commaai/openpilot/blob/master/system/camerad/transforms/rgb_to_yuv.cl) to [real_debayer.cl](https://github.com/commaai/openpilot/blob/master/system/camerad/cameras/real_debayer.cl), but I am not able to compile the cl program. Also I am not sure if that will work.

So, although this fixes the issue, a nice extra would be:
- swapping to [real_debayer.cl](https://github.com/commaai/openpilot/blob/master/system/camerad/cameras/real_debayer.cll) or creating a dedicated rgb_to_nv12.cl program.