### PR TITLE
FPv2 tests: consider extra ECUs in brand ECUs

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -315,8 +315,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     ),
   ],
   extra_ecus=[
-    (Ecu.adas, 0x730, None),         # ADAS Driving ECU on HDA2 platforms
-    (Ecu.cornerRadar, 0x7B7, None),
+    (Ecu.adas, 0x730, None),  # ADAS Driving ECU on HDA2 platforms
   ],
 )
 

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -315,7 +315,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
     ),
   ],
   extra_ecus=[
-    (Ecu.adas, 0x730, None),  # ADAS Driving ECU on HDA2 platforms
+    (Ecu.adas, 0x730, None),         # ADAS Driving ECU on HDA2 platforms
+    (Ecu.cornerRadar, 0x7B7, None),
   ],
 )
 

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -45,7 +45,7 @@ class TestFwFingerprint(unittest.TestCase):
             self.assertFalse(len(duplicates), f"{car_model}: Duplicate FW versions: Ecu.{ECU_NAME[ecu[0]]}, {duplicates}")
 
   def test_data_collection_ecus(self):
-    # Assert no ECUs in extra_ecus are in the fingerprinting database
+    # Asserts no extra ECUs are in the fingerprinting database
     for brand, config in FW_QUERY_CONFIGS.items():
       for car_model, ecus in VERSIONS[brand].items():
         bad_ecus = set(ecus).intersection(config.extra_ecus)

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -80,10 +80,11 @@ class TestFwFingerprint(unittest.TestCase):
   def test_fw_request_ecu_whitelist(self):
     for brand, config in FW_QUERY_CONFIGS.items():
       with self.subTest(brand=brand):
-        whitelisted_ecus = set([ecu for r in config.requests for ecu in r.whitelist_ecus])
-        brand_ecus = set([fw[0] for car_fw in VERSIONS[brand].values() for fw in car_fw])
+        whitelisted_ecus = {ecu for r in config.requests for ecu in r.whitelist_ecus}
+        brand_ecus = {fw[0] for car_fw in VERSIONS[brand].values() for fw in car_fw}
+        brand_ecus |= {ecu[0] for ecu in config.extra_ecus}
 
-        # each ecu in brand's fw versions needs to be whitelisted at least once
+        # each ecu in brand's fw versions + extra ecus needs to be whitelisted at least once
         ecus_not_whitelisted = brand_ecus - whitelisted_ecus
 
         ecu_strings = ", ".join([f'Ecu.{ECU_NAME[ecu]}' for ecu in ecus_not_whitelisted])

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -45,6 +45,7 @@ class TestFwFingerprint(unittest.TestCase):
             self.assertFalse(len(duplicates), f"{car_model}: Duplicate FW versions: Ecu.{ECU_NAME[ecu[0]]}, {duplicates}")
 
   def test_data_collection_ecus(self):
+    # Assert no ECUs in extra_ecus are in the fingerprinting database
     for brand, config in FW_QUERY_CONFIGS.items():
       for car_model, ecus in VERSIONS[brand].items():
         bad_ecus = set(ecus).intersection(config.extra_ecus)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
