### PR TITLE
cabana: use monospaced font for hex in BinaryView

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -1,6 +1,7 @@
 #include "tools/cabana/binaryview.h"
 
 #include <QApplication>
+#include <QFontDatabase>
 #include <QHeaderView>
 #include <QPainter>
 
@@ -157,7 +158,8 @@ void BinarySelectionModel::select(const QItemSelection &selection, QItemSelectio
 BinaryItemDelegate::BinaryItemDelegate(QObject *parent) : QStyledItemDelegate(parent) {
   // cache fonts and color
   small_font.setPointSize(6);
-  bold_font.setBold(true);
+  hex_font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+  hex_font.setBold(true);
   highlight_color = QApplication::style()->standardPalette().color(QPalette::Active, QPalette::Highlight);
 }
 
@@ -172,7 +174,7 @@ void BinaryItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
   // TODO: highlight signal cells on mouse over
   painter->fillRect(option.rect, option.state & QStyle::State_Selected ? highlight_color : item->bg_color);
   if (index.column() == 8) {
-    painter->setFont(bold_font);
+    painter->setFont(hex_font);
   }
   painter->drawText(option.rect, Qt::AlignCenter, item->val);
   if (item->is_msb || item->is_lsb) {

--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -14,7 +14,7 @@ public:
   QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
-  QFont small_font, bold_font;
+  QFont small_font, hex_font;
   QColor highlight_color;
 };
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
