### PR TITLE
HKG CAN-FD: query camera on both buses

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -306,7 +306,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdRadar],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar],
       bus=4,
     ),
     Request(


### PR DESCRIPTION
fwdCamera is only on bus 4 on HDA1, only bus 5 on HDA2