### PR TITLE
Cabana: move settings to seperate files

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -1,3 +1,4 @@
+import os
 Import('env', 'qt_env', 'arch', 'common', 'messaging', 'visionipc', 'replay_lib',
        'cereal', 'transformations', 'widgets', 'opendbc')
 
@@ -12,6 +13,10 @@ else:
 
 qt_libs = ['qt_util', 'Qt5Charts'] + base_libs
 cabana_libs = [widgets, cereal, messaging, visionipc, replay_lib, opendbc,'avutil', 'avcodec', 'avformat', 'bz2', 'curl', 'yuv'] + qt_libs
-qt_env.Execute('./generate_dbc_json.py --out car_fingerprint_to_dbc.json')
-qt_env.Program('_cabana', ['cabana.cc', 'mainwin.cc', 'binaryview.cc', 'chartswidget.cc', 'historylog.cc', 'videowidget.cc', 'signaledit.cc', 'dbcmanager.cc',
-                            'canmessages.cc', 'messageswidget.cc', 'detailwidget.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
+cabana_env = qt_env.Clone()
+
+prev_moc_path = cabana_env['QT_MOCHPREFIX']
+cabana_env['QT_MOCHPREFIX'] = os.path.dirname(prev_moc_path) + '/cabana/moc_'
+cabana_env.Execute('./generate_dbc_json.py --out car_fingerprint_to_dbc.json')
+cabana_env.Program('_cabana', ['cabana.cc', 'mainwin.cc', 'binaryview.cc', 'chartswidget.cc', 'historylog.cc', 'videowidget.cc', 'signaledit.cc', 'dbcmanager.cc',
+                            'canmessages.cc', 'messageswidget.cc', 'settings.cc', 'detailwidget.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)

--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -7,7 +7,6 @@
 
 Q_DECLARE_METATYPE(std::vector<CanData>);
 
-Settings settings;
 CANMessages *can = nullptr;
 
 CANMessages::CANMessages(QObject *parent) : QObject(parent) {
@@ -158,27 +157,4 @@ void CANMessages::resetRange() {
 
 void CANMessages::settingChanged() {
   replay->setSegmentCacheLimit(settings.cached_segment_limit);
-}
-
-// Settings
-
-Settings::Settings() {
-  load();
-}
-
-void Settings::save() {
-  QSettings s("settings", QSettings::IniFormat);
-  s.setValue("fps", fps);
-  s.setValue("log_size", can_msg_log_size);
-  s.setValue("cached_segment", cached_segment_limit);
-  s.setValue("chart_height", chart_height);
-  emit changed();
-}
-
-void Settings::load() {
-  QSettings s("settings", QSettings::IniFormat);
-  fps = s.value("fps", 10).toInt();
-  can_msg_log_size = s.value("log_size", 100).toInt();
-  cached_segment_limit = s.value("cached_segment", 3).toInt();
-  chart_height = s.value("chart_height", 200).toInt();
 }

--- a/tools/cabana/canmessages.h
+++ b/tools/cabana/canmessages.h
@@ -9,24 +9,8 @@
 #include <QList>
 
 #include "opendbc/can/common_dbc.h"
+#include "tools/cabana/settings.h"
 #include "tools/replay/replay.h"
-
-class Settings : public QObject {
-  Q_OBJECT
-
-public:
-  Settings();
-  void save();
-  void load();
-
-  int fps = 10;
-  int can_msg_log_size = 100;
-  int cached_segment_limit = 3;
-  int chart_height = 200;
-
-signals:
-  void changed();
-};
 
 struct CanData {
   double ts;
@@ -112,4 +96,4 @@ inline QColor hoverColor(const QColor &color) {
 
 // A global pointer referring to the unique CANMessages object
 extern CANMessages *can;
-extern Settings settings;
+

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -1,9 +1,7 @@
 #include "tools/cabana/mainwin.h"
 
 #include <QApplication>
-#include <QDialogButtonBox>
 #include <QHBoxLayout>
-#include <QFormLayout>
 #include <QScreen>
 #include <QSplitter>
 #include <QVBoxLayout>
@@ -81,54 +79,4 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 void MainWindow::setOption() {
   SettingsDlg dlg(this);
   dlg.exec();
-}
-
-// SettingsDlg
-
-SettingsDlg::SettingsDlg(QWidget *parent) : QDialog(parent) {
-  setWindowTitle(tr("Settings"));
-  QVBoxLayout *main_layout = new QVBoxLayout(this);
-  QFormLayout *form_layout = new QFormLayout();
-
-  fps = new QSpinBox(this);
-  fps->setRange(10, 100);
-  fps->setSingleStep(10);
-  fps->setValue(settings.fps);
-  form_layout->addRow("FPS", fps);
-
-  log_size = new QSpinBox(this);
-  log_size->setRange(50, 500);
-  log_size->setSingleStep(10);
-  log_size->setValue(settings.can_msg_log_size);
-  form_layout->addRow(tr("Log size"), log_size);
-
-  cached_segment = new QSpinBox(this);
-  cached_segment->setRange(3, 60);
-  cached_segment->setSingleStep(1);
-  cached_segment->setValue(settings.cached_segment_limit);
-  form_layout->addRow(tr("Cached segments limit"), cached_segment);
-
-  chart_height = new QSpinBox(this);
-  chart_height->setRange(100, 500);
-  chart_height->setSingleStep(10);
-  chart_height->setValue(settings.chart_height);
-  form_layout->addRow(tr("Chart height"), chart_height);
-
-  main_layout->addLayout(form_layout);
-
-  auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-  main_layout->addWidget(buttonBox);
-
-  setFixedWidth(360);
-  connect(buttonBox, &QDialogButtonBox::accepted, this, &SettingsDlg::save);
-  connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-}
-
-void SettingsDlg::save() {
-  settings.fps = fps->value();
-  settings.can_msg_log_size = log_size->value();
-  settings.cached_segment_limit = cached_segment->value();
-  settings.chart_height = chart_height->value();
-  settings.save();
-  accept();
 }

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -23,15 +23,3 @@ protected:
   QWidget *floating_window = nullptr;
   QVBoxLayout *r_layout;
 };
-
-class SettingsDlg : public QDialog {
-  Q_OBJECT
-
-public:
-  SettingsDlg(QWidget *parent);
-  void save();
-  QSpinBox *fps;
-  QSpinBox *log_size ;
-  QSpinBox *cached_segment;
-  QSpinBox *chart_height;
-};

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -1,0 +1,79 @@
+#include "tools/cabana/settings.h"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QSettings>
+
+// Settings
+Settings settings;
+
+Settings::Settings() {
+  load();
+}
+
+void Settings::save() {
+  QSettings s("settings", QSettings::IniFormat);
+  s.setValue("fps", fps);
+  s.setValue("log_size", can_msg_log_size);
+  s.setValue("cached_segment", cached_segment_limit);
+  s.setValue("chart_height", chart_height);
+  emit changed();
+}
+
+void Settings::load() {
+  QSettings s("settings", QSettings::IniFormat);
+  fps = s.value("fps", 10).toInt();
+  can_msg_log_size = s.value("log_size", 100).toInt();
+  cached_segment_limit = s.value("cached_segment", 3).toInt();
+  chart_height = s.value("chart_height", 200).toInt();
+}
+
+// SettingsDlg
+
+SettingsDlg::SettingsDlg(QWidget *parent) : QDialog(parent) {
+  setWindowTitle(tr("Settings"));
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  QFormLayout *form_layout = new QFormLayout();
+
+  fps = new QSpinBox(this);
+  fps->setRange(10, 100);
+  fps->setSingleStep(10);
+  fps->setValue(settings.fps);
+  form_layout->addRow("FPS", fps);
+
+  log_size = new QSpinBox(this);
+  log_size->setRange(50, 500);
+  log_size->setSingleStep(10);
+  log_size->setValue(settings.can_msg_log_size);
+  form_layout->addRow(tr("Log size"), log_size);
+
+  cached_segment = new QSpinBox(this);
+  cached_segment->setRange(3, 60);
+  cached_segment->setSingleStep(1);
+  cached_segment->setValue(settings.cached_segment_limit);
+  form_layout->addRow(tr("Cached segments limit"), cached_segment);
+
+  chart_height = new QSpinBox(this);
+  chart_height->setRange(100, 500);
+  chart_height->setSingleStep(10);
+  chart_height->setValue(settings.chart_height);
+  form_layout->addRow(tr("Chart height"), chart_height);
+
+  main_layout->addLayout(form_layout);
+
+  auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+  main_layout->addWidget(buttonBox);
+
+  setFixedWidth(360);
+  connect(buttonBox, &QDialogButtonBox::accepted, this, &SettingsDlg::save);
+  connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+void SettingsDlg::save() {
+  settings.fps = fps->value();
+  settings.can_msg_log_size = log_size->value();
+  settings.cached_segment_limit = cached_segment->value();
+  settings.chart_height = chart_height->value();
+  settings.save();
+  accept();
+}

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QDialog>
+#include <QSpinBox>
+
+class Settings : public QObject {
+  Q_OBJECT
+
+public:
+  Settings();
+  void save();
+  void load();
+
+  int fps = 10;
+  int can_msg_log_size = 100;
+  int cached_segment_limit = 3;
+  int chart_height = 200;
+
+signals:
+  void changed();
+};
+
+class SettingsDlg : public QDialog {
+  Q_OBJECT
+
+public:
+  SettingsDlg(QWidget *parent);
+  void save();
+  QSpinBox *fps;
+  QSpinBox *log_size ;
+  QSpinBox *cached_segment;
+  QSpinBox *chart_height;
+};
+
+extern Settings settings;


### PR DESCRIPTION
move settings related code from canmessage.xx and mainwin.xx to seperate files

Modified moc_path for cabana, since there is already a file with the same name in ui/qt/offroad/settings. 