### PR TITLE
GM: inactive gas/regen safety

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -67,7 +67,7 @@ class CarController:
       # Gas/regen, brakes, and UI commands - all at 25Hz
       if self.frame % 4 == 0:
         if not CC.longActive:
-          # ASCM sends max regen, camera ACC sends slightly different value
+          # ASCM sends max regen when not enabled
           self.apply_gas = self.params.INACTIVE_REGEN
           self.apply_brake = 0
         else:

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -67,8 +67,8 @@ class CarController:
       # Gas/regen, brakes, and UI commands - all at 25Hz
       if self.frame % 4 == 0:
         if not CC.longActive:
-          # Stock ECU sends max regen when not enabled
-          self.apply_gas = self.params.MAX_ACC_REGEN
+          # ASCM sends max regen, camera ACC sends slightly different value
+          self.apply_gas = self.params.INACTIVE_REGEN
           self.apply_brake = 0
         else:
           if self.CP.carFingerprint in EV_CAR:

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -30,6 +30,7 @@ class CarControllerParams:
   ZERO_GAS = 2048  # Coasting
   MAX_BRAKE = 400  # ~ -4.0 m/s^2 with regen
   MAX_ACC_REGEN = 1404  # Max ACC regen is slightly less than max paddle regen
+  INACTIVE_REGEN = 1404
 
   # Allow small margin below -3.5 m/s^2 from ISO 15622:2018 since we
   # perform the closed loop control, and might need some


### PR DESCRIPTION
A minor pre-req for camera ACC OP long + adds safety around max regen

ASCM sends max regen, but camera ACC doesn't