### PR TITLE
Cabana: redirect qt logs to status bar

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -8,7 +8,15 @@
 
 #include "tools/replay/util.h"
 
+static MainWindow *main_win = nullptr;
+void qLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+  main_win->showStatusMessage(msg);
+}
+
 MainWindow::MainWindow() : QWidget() {
+  main_win = this;
+  qInstallMessageHandler(qLogMessageHandler);
+
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(11, 11, 11, 5);
   main_layout->setSpacing(0);

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -14,6 +14,7 @@ class MainWindow : public QWidget {
 public:
   MainWindow();
   void dockCharts(bool dock);
+  void showStatusMessage(const QString &msg, int timeout = 0) { status_bar->showMessage(msg, timeout); }
 
 signals:
   void logMessageFromReplay(const QString &msg, int timeout);


### PR DESCRIPTION
![Screenshot from 2022-10-21 16-23-36](https://user-images.githubusercontent.com/27770/197150152-73915539-314f-46b6-8105-5d62c8f7daab.png)
