### PR TITLE
Canaba: remove unused metatype in canmessage

### DIFF
--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -5,8 +5,6 @@
 
 #include "tools/cabana/dbcmanager.h"
 
-Q_DECLARE_METATYPE(std::vector<CanData>);
-
 CANMessages *can = nullptr;
 
 CANMessages::CANMessages(QObject *parent) : QObject(parent) {

--- a/tools/cabana/canmessages.h
+++ b/tools/cabana/canmessages.h
@@ -96,4 +96,3 @@ inline QColor hoverColor(const QColor &color) {
 
 // A global pointer referring to the unique CANMessages object
 extern CANMessages *can;
-


### PR DESCRIPTION
We currently pass pointer instead of copy vector to the qt queued connection, this meta type is not needed anymore.

