### PR TITLE
Cabana: Fix unable to display charts for same signals from different buses.

### DIFF
--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -50,7 +50,7 @@ public:
   void setHeight(int height);
 
 signals:
-  void remove();
+  void remove(const QString &msg_id, const Signal *sig);
 
 public:
   QString id;
@@ -65,7 +65,7 @@ class ChartsWidget : public QWidget {
 public:
   ChartsWidget(QWidget *parent = nullptr);
   void addChart(const QString &id, const Signal *sig);
-  void removeChart(const Signal *sig);
+  void removeChart(const QString &id, const Signal *sig);
 
 signals:
   void dock(bool floating);
@@ -73,7 +73,7 @@ signals:
 private:
   void updateState();
   void updateTitleBar();
-  void removeAll();
+  void removeAll(const Signal *sig = nullptr);
   bool eventFilter(QObject *obj, QEvent *event);
 
   QWidget *title_bar;
@@ -84,5 +84,5 @@ private:
   QPushButton *reset_zoom_btn;
   QPushButton *remove_all_btn;
   QVBoxLayout *charts_layout;
-  QHash<const Signal *, ChartWidget *> charts;
+  QList<ChartWidget *> charts;
 };


### PR DESCRIPTION
changed chart's container from `QHash` to `QList`.   Signals come from different buses and it's name may be changed by signal edit. it's a mistake to using QHash here
