### PR TITLE
Cabana: add move constructor to struct CanData

### DIFF
--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -157,3 +157,19 @@ void CANMessages::resetRange() {
 void CANMessages::settingChanged() {
   replay->setSegmentCacheLimit(settings.cached_segment_limit);
 }
+
+// CanData
+
+CanData &CanData::operator=(const CanData &other) {
+  ts = other.ts;
+  bus_time = other.bus_time;
+  dat = other.dat;
+  return *this;
+}
+
+CanData &CanData::operator=(CanData &&other) {
+  ts = other.ts;
+  bus_time = other.bus_time;
+  dat = std::move(other.dat);
+  return *this;
+}

--- a/tools/cabana/canmessages.h
+++ b/tools/cabana/canmessages.h
@@ -16,6 +16,12 @@ struct CanData {
   double ts;
   uint16_t bus_time;
   QByteArray dat;
+
+  CanData() = default;
+  CanData(const CanData &other) { *this = other; }
+  CanData(CanData &&other) { *this = std::move(other); }
+  CanData &operator=(const CanData &other);
+  CanData &operator=(CanData &&other);
 };
 
 class CANMessages : public QObject {


### PR DESCRIPTION
we already used `std::move` & `std::make_move_iterator` to avoid `std::deque` copy between threads. add move constructor to `struct CanData` can save a bunch of memory alloc & copy for byte array