### PR TITLE
Cabana: fix segfault on exit

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -10,7 +10,7 @@
 
 static MainWindow *main_win = nullptr;
 void qLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-  main_win->showStatusMessage(msg);
+  if (main_win) main_win->showStatusMessage(msg);
 }
 
 MainWindow::MainWindow() : QWidget() {
@@ -118,6 +118,7 @@ void MainWindow::dockCharts(bool dock) {
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
+  main_win = nullptr;
   if (floating_window)
     floating_window->deleteLater();
   QWidget::closeEvent(event);


### PR DESCRIPTION
this bug was introduced by https://github.com/commaai/openpilot/pull/26187.  If the main window is null or there is still qt log after closing it will cause a crash