### PR TITLE
Cabana: fix segment fault in  QApplication::notify(QObject*, QEvent*) ()

### DIFF
--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 #include <QTimer>
 
+#include "selfdrive/ui/qt/util.h"
 #include "tools/cabana/canmessages.h"
 #include "tools/cabana/dbcmanager.h"
 
@@ -106,7 +107,7 @@ void DetailWidget::dbcMsgChanged() {
   if (msg_id.isEmpty()) return;
 
   warning_widget->hide();
-  qDeleteAll(signals_container->findChildren<SignalEdit *>());
+  clearLayout(signals_container->layout());
   QString msg_name = tr("untitled");
   if (auto msg = dbc()->msg(msg_id)) {
     for (int i = 0; i < msg->sigs.size(); ++i) {


### PR DESCRIPTION
`qDeleteAll` delete widgets using the C++ delete operator (not the obj->deleteLater()). if an event was posted to widgets that was deleted before returning to the event loop. `QApplication::notify(QObject*, QEvent*) () `will segmentation fault.  
