### PR TITLE
GM camera ACC: cancel after delay

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -20,6 +20,7 @@ class CarController:
     self.apply_brake = 0
     self.frame = 0
     self.last_button_frame = 0
+    self.cancel_counter = 0
 
     self.lka_steering_cmd_counter = 0
     self.sent_lka_steering_cmd = False
@@ -111,9 +112,12 @@ class CarController:
         can_sends += gmcan.create_adas_keepalive(CanBus.POWERTRAIN)
 
     else:
+      self.cancel_counter = self.cancel_counter + 1 if CC.cruiseControl.cancel else 0
+
       # Stock longitudinal, integrated at camera
       if (self.frame - self.last_button_frame) * DT_CTRL > 0.04:
-        if CC.cruiseControl.cancel:
+        # TODO: find the max time the ECM allows before it faults using OP long (camera will always cancel before it faults)
+        if self.cancel_counter > 50:
           self.last_button_frame = self.frame
           can_sends.append(gmcan.create_buttons(self.packer_pt, CanBus.CAMERA, CS.buttons_counter, CruiseButtons.CANCEL))
 

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -112,6 +112,8 @@ class CarController:
         can_sends += gmcan.create_adas_keepalive(CanBus.POWERTRAIN)
 
     else:
+      # While car is braking, cancel button causes ECM to enter a soft disable state with a fault status.
+      # A delayed cancellation allows camera to cancel and avoids a fault when user depresses brake
       self.cancel_counter = self.cancel_counter + 1 if CC.cruiseControl.cancel else 0
 
       # Stock longitudinal, integrated at camera

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -55,12 +55,7 @@ class CarState(CarStateBase):
     # To avoid a cruise fault we need to match the ECM's brake pressed signal and threshold
     # https://static.nhtsa.gov/odi/tsbs/2017/MC-10137629-9999.pdf
     ret.brake = pt_cp.vl["ECMAcceleratorPos"]["BrakePedalPos"]
-    if self.CP.networkLocation != NetworkLocation.fwdCamera:
-      ret.brakePressed = ret.brake >= 8
-    else:
-      # While car is braking, cancel button causes ECM to enter a soft disable state with a fault status.
-      # Match ECM threshold at a standstill to allow the camera to cancel earlier
-      ret.brakePressed = ret.brake >= 20
+    ret.brakePressed = ret.brake >= 8
 
     # Regen braking is braking
     if self.CP.transmissionType == TransmissionType.direct:


### PR DESCRIPTION
- [x] Find the max time the ECM allows before it faults using OP long (camera will always cancel before it faults)

Reverts https://github.com/commaai/openpilot/pull/26081

The camera (and likely ECM) has a set delay from pressing brake above its threshold to cancelling cruise, so if the user rapidly depresses brake, the threshold can rise well above ours and we start to cancel, causing a FCW and (fake) cruise fault. Raising the brake threshold was not the correct choice here, as it will constantly fault when using OP long.

![Screenshot from 2022-10-20 22-51-08](https://user-images.githubusercontent.com/25857203/197270948-733f2386-6cf3-4d7e-b83c-3c3a6c46dc01.png)
![Screenshot from 2022-10-20 22-55-07](https://user-images.githubusercontent.com/25857203/197270953-c7dcf66a-4d54-449f-87ea-69dccebf674b.png)
