### PR TITLE
add poetry-dotenv-plugin

### DIFF
--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -60,6 +60,7 @@ if [ -d "./xx" ] || [ -n "$POETRY_VIRTUALENVS_CREATE" ]; then
   RUN=""
 else
   echo "PYTHONPATH=${PWD}" > .env
+  poetry self add poetry-dotenv-plugin@^0.1.0
   RUN="poetry run"
 fi
 


### PR DESCRIPTION
This is required for the `.env` to be loaded into the environment for `poetry run` and `poetry shell`
https://github.com/mpeteuil/poetry-dotenv-plugin

The package is installed to the system poetry environment, not configured as part of the openpilot pyproject.tom/poetry.lock
https://python-poetry.org/docs/cli/#self-add


```
$ echo $PYTHONPATH

$ poetry shell
Spawning shell within /home/incognitojam/.cache/pypoetry/virtualenvs/openpilot-YfXROSFh-py3.8
(openpilot-py3.8) $ echo $PYTHONPATH
/home/incognitojam/openpilot
```