### PR TITLE
Cabana: use QLineEdit for double value

### DIFF
--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -1,6 +1,7 @@
 #include "tools/cabana/signaledit.h"
 
 #include <QDialogButtonBox>
+#include <QDoubleValidator>
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QMessageBox>
@@ -36,13 +37,16 @@ SignalForm::SignalForm(const Signal &sig, QWidget *parent) : QWidget(parent) {
   sign->setCurrentIndex(sig.is_signed ? 0 : 1);
   form_layout->addRow(tr("sign"), sign);
 
-  factor = new QDoubleSpinBox();
-  factor->setDecimals(3);
-  factor->setValue(sig.factor);
+  auto double_validator = new QDoubleValidator(this);
+
+  factor = new QLineEdit();
+  factor->setValidator(double_validator);
+  factor->setText(QString::number(sig.factor));
   form_layout->addRow(tr("Factor"), factor);
 
-  offset = new QSpinBox();
-  offset->setValue(sig.offset);
+  offset = new QLineEdit();
+  offset->setValidator(double_validator);
+  offset->setText(QString::number(sig.offset));
   form_layout->addRow(tr("Offset"), offset);
 
   // TODO: parse the following parameters in opendbc
@@ -50,11 +54,11 @@ SignalForm::SignalForm(const Signal &sig, QWidget *parent) : QWidget(parent) {
   form_layout->addRow(tr("Unit"), unit);
   comment = new QLineEdit();
   form_layout->addRow(tr("Comment"), comment);
-  min_val = new QDoubleSpinBox();
-  factor->setDecimals(3);
+  min_val = new QLineEdit();
+  min_val->setValidator(double_validator);
   form_layout->addRow(tr("Minimum value"), min_val);
-  max_val = new QDoubleSpinBox();
-  factor->setDecimals(3);
+  max_val = new QLineEdit();
+  max_val->setValidator(double_validator);
   form_layout->addRow(tr("Maximum value"), max_val);
   val_desc = new QLineEdit();
   form_layout->addRow(tr("Value descriptions"), val_desc);

--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -16,9 +16,8 @@ class SignalForm : public QWidget {
 public:
   SignalForm(const Signal &sig, QWidget *parent);
 
-  QLineEdit *name, *unit, *comment, *val_desc;
-  QSpinBox *size, *offset;
-  QDoubleSpinBox *factor, *min_val, *max_val;
+  QLineEdit *name, *unit, *comment, *val_desc, *offset, *factor, *min_val, *max_val;
+  QSpinBox *size;
   QComboBox *sign, *endianness;
 };
 


### PR DESCRIPTION
spinBox can't handle double value correctly (factor,offset) :
![Screenshot from 2022-10-26 22-30-35](https://user-images.githubusercontent.com/27770/198054345-7f55d8a3-9f45-4855-a892-e003cf001d60.png)

replaced with QLineEdit:
![Screenshot from 2022-10-26 22-28-42](https://user-images.githubusercontent.com/27770/198054390-afb18e31-4e43-4fa3-b932-0bfe0012af26.png)
