### PR TITLE
Cabana: fix marker z-index

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -247,10 +247,13 @@ ChartView::ChartView(const QString &id, const Signal *sig, QWidget *parent)
   chart->layout()->setContentsMargins(0, 0, 0, 0);
 
   track_line = new QGraphicsLineItem(chart);
+  track_line->setZValue(chart->zValue() + 10);
   track_line->setPen(QPen(Qt::gray, 1, Qt::DashLine));
   value_text = new QGraphicsSimpleTextItem(chart);
+  value_text->setZValue(chart->zValue() + 10);
   value_text->setBrush(Qt::gray);
   line_marker = new QGraphicsLineItem(chart);
+  line_marker->setZValue(chart->zValue() + 10);
   line_marker->setPen(QPen(Qt::black, 2));
 
   setChart(chart);


### PR DESCRIPTION
Fixed z-index issue:

![Screenshot from 2022-10-27 10-35-47](https://user-images.githubusercontent.com/27770/198177491-b40301ad-cb8b-4f72-8b2d-4c5e8d2cbecf.png)

after fixed:

![Screenshot from 2022-10-27 10-33-38](https://user-images.githubusercontent.com/27770/198177499-1a62a03c-7ac6-440c-b797-e1dfb19eb562.png)
