### PR TITLE
Chrysler: dynamic min steer speed for LKAS bit to avoid fault

### DIFF
--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -51,12 +51,15 @@ class CarController:
       lkas_control_bit = self.lkas_control_bit_prev
       if CS.out.vEgo > self.CP.minSteerSpeed:
         lkas_control_bit = True
-      elif self.CP.carFingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
-        if CS.out.vEgo < (self.CP.minSteerSpeed - 3.0):
-          lkas_control_bit = False
-      elif self.CP.carFingerprint in RAM_CARS:
-        if CS.out.vEgo < (self.CP.minSteerSpeed - 0.5):
-          lkas_control_bit = False
+      if CS.out.steerFaultTemporary or CS.out.steerFaultPermanent:
+        lkas_control_bit = False
+      # TODO: is it necessary to set the bit low if it's set above the min speed?
+      # elif self.CP.carFingerprint in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
+      #   if CS.out.vEgo < (self.CP.minSteerSpeed - 3.0):
+      #     lkas_control_bit = False
+      # elif self.CP.carFingerprint in RAM_CARS:
+      #   if CS.out.vEgo < (self.CP.minSteerSpeed - 0.5):
+      #     lkas_control_bit = False
 
       # EPS faults if LKAS re-enables too quickly
       lkas_control_bit = lkas_control_bit and (self.frame - self.last_lkas_falling_edge > 200)

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -81,7 +81,7 @@ class CarState(CarStateBase):
 
     if self.CP.carFingerprint in RAM_CARS:
       self.auto_high_beam = cp_cam.vl["DAS_6"]['AUTO_HIGH_BEAM_ON']  # Auto High Beam isn't Located in this message on chrysler or jeep currently located in 729 message
-      ret.steerFaultTemporary  = cp.vl["EPS_3"]["DASM_FAULT"] == 1
+      ret.steerFaultTemporary = cp.vl["EPS_3"]["DASM_FAULT"] == 1
     else:
       ret.steerFaultPermanent = cp.vl["EPS_2"]["LKAS_STATE"] == 4
 

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -58,11 +58,12 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 16.3
       ret.mass = 2493. + STD_CARGO_KG
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
-      ret.minSteerSpeed = 14.5
-      if car_fw is not None:
-        for fw in car_fw:
-          if fw.ecu == 'eps' and fw.fwVersion[:8] in (b"68312176", b"68273275"):
-            ret.minSteerSpeed = 10.0 * CV.KPH_TO_MS
+      ret.minSteerSpeed = 50.0 * CV.KPH_TO_MS
+      # if car_fw is not None:
+      #   for fw in car_fw:
+      #     if fw.ecu == 'eps' and fw.fwVersion[:8] in (b"68312176", b"68273275"):
+      #       # This firmware allows steering to 10 kph only once car has ever gone below 10 kph TODO: zero?
+      #       ret.minSteerSpeed = 10.0 * CV.KPH_TO_MS
 
     elif candidate == CAR.RAM_HD:
       ret.steerActuatorDelay = 0.2

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from cereal import car
+from common.conversions import Conversions as CV
 from panda import Panda
 from selfdrive.car import STD_CARGO_KG, scale_rot_inertia, scale_tire_stiffness, gen_empty_fingerprint, get_safety_config
 from selfdrive.car.chrysler.values import CAR, DBC, RAM_HD, RAM_DT
@@ -61,7 +62,7 @@ class CarInterface(CarInterfaceBase):
       if car_fw is not None:
         for fw in car_fw:
           if fw.ecu == 'eps' and fw.fwVersion[:8] in (b"68312176", b"68273275"):
-            ret.minSteerSpeed = 0.
+            ret.minSteerSpeed = 10.0 * CV.KPH_TO_MS
 
     elif candidate == CAR.RAM_HD:
       ret.steerActuatorDelay = 0.2

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -59,11 +59,11 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 2493. + STD_CARGO_KG
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
       ret.minSteerSpeed = 50.0 * CV.KPH_TO_MS
-      # if car_fw is not None:
-      #   for fw in car_fw:
-      #     if fw.ecu == 'eps' and fw.fwVersion[:8] in (b"68312176", b"68273275"):
-      #       # This firmware allows steering to 10 kph only once car has ever gone below 10 kph TODO: zero?
-      #       ret.minSteerSpeed = 10.0 * CV.KPH_TO_MS
+      if car_fw is not None:
+        for fw in car_fw:
+          if fw.ecu == 'eps' and fw.fwVersion[:8] in (b"68312176", b"68273275"):
+            # This firmware allows steering to 10 kph only once car has ever gone below 10 kph TODO: zero?
+            ret.minSteerSpeed = 10.0 * CV.KPH_TO_MS
 
     elif candidate == CAR.RAM_HD:
       ret.steerActuatorDelay = 0.2


### PR DESCRIPTION
Applicable for Ram 1500s with special EPS FW. When booted onroad, if the LKAS bit is set above 32 mph and the truck slows below that, a fault occurs.

What's safe to do:
- Above 32 mph, set and unset the LKAS bit as many times as we want
- Setting the LKAS bit under 32 mph, then keep it high forever

What will cause a fault:
- Setting the bit above 32 mph, then slowing below 32 mph with it high
- Unsetting the bit under 32 mph once it's been set under 32 mph

Therefore, we need a dynamic minimum steering speed. This handles the following cases:
- C3 boots up and truck is > 32 mph, user enables:
  - Truck falls below 32 mph
  - The truck stops steering at 32 mph
  - The user disables under 32 mph
  - LKAS bit rises, steering speed is now 6 mph for the rest of the drive
- C3 boots up and truck is > 32 mph, user does not enable:
  - Truck falls below 32 mph
  - LKAS bit rises, steering speed is now 6 mph for the rest of the drive
- C3 boots up and truck is < 32 mph:
  - LKAS bit rises, steering speed is now 6 mph for the rest of the drive