### PR TITLE
Cabana: set fix height for statusbar

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -23,6 +23,7 @@ MainWindow::MainWindow() : QWidget() {
   main_layout->addLayout(h_layout);
 
   QSplitter *splitter = new QSplitter(Qt::Horizontal, this);
+  splitter->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
   messages_widget = new MessagesWidget(this);
   splitter->addWidget(messages_widget);
 
@@ -58,6 +59,7 @@ MainWindow::MainWindow() : QWidget() {
 
   // status bar
   status_bar = new QStatusBar(this);
+  status_bar->setFixedHeight(20);
   status_bar->setContentsMargins(0, 0, 0, 0);
   status_bar->setSizeGripEnabled(true);
   progress_bar = new QProgressBar();


### PR DESCRIPTION
Fixed the issue that the statusbar make use of extra space when chartview is undocked:

![Screenshot from 2022-10-27 23-30-31](https://user-images.githubusercontent.com/27770/198333299-3607edd7-3df1-4b02-80a1-0aa74add7838.png)


