### PR TITLE
UI: reduce frame drops.

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -242,7 +242,6 @@ void CameraWidget::paintGL() {
   //   if (frames[frame_idx].first == draw_frame_id) break;
   // }
 
-  // Log duplicate/dropped frames
   VisionBuf *frame = frames.front().second;
   frames.pop_front();
 

--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -243,14 +243,8 @@ void CameraWidget::paintGL() {
   // }
 
   // Log duplicate/dropped frames
-  const auto current_frame = frames.front();
+  VisionBuf *frame = frames.front().second;
   frames.pop_front();
-  if (current_frame.first == prev_frame_id) {
-    qDebug() << "Drawing same frame twice" << current_frame.first;
-  }
-  prev_frame_id = current_frame.first;
-  VisionBuf *frame = current_frame.second;
-  assert(frame != nullptr);
 
   glViewport(0, 0, width(), height());
   glBindVertexArray(frame_vao);

--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -81,7 +81,6 @@ protected:
   std::mutex frame_lock;
   std::deque<std::pair<uint32_t, VisionBuf*>> frames;
   uint32_t draw_frame_id = 0;
-  uint32_t prev_frame_id = 0;
 
 protected slots:
   void vipcConnected(VisionIpcClient *vipc_client);


### PR DESCRIPTION
The drawing freq of UI is not stable compared with the vipc receive Freq. lot's of frames will be dropped If we only paint the last one.
use  `deque<> frames` as a buffer to sync between UI thread and vipc thread.  this can reduce many frame drops.
