### PR TITLE
Eliminate toyota close radar glitches causing no resume

### DIFF
--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -151,7 +151,8 @@ class Cluster():
 
   def potential_low_speed_lead(self, v_ego):
     # stop for stuff in front of you and low speed, even without model confirmation
-    return abs(self.yRel) < 1.0 and (v_ego < v_ego_stationary) and self.dRel < 25
+    # Radar points closer than 0.75, are almost always glitches on toyota radars
+    return abs(self.yRel) < 1.0 and (v_ego < v_ego_stationary) and (0.75 < self.dRel < 25)
 
   def is_potential_fcw(self, model_prob):
     return model_prob > .9


### PR DESCRIPTION
Verified ~10 cases where a lead is detected below 0.75m without model confirmation in 270k segments. All were false positives on toyota radar.
