### PR TITLE
Cabana: double click the title bar to move binview to a separate column

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -20,7 +20,7 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   setItemDelegate(delegate);
   horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
   horizontalHeader()->hide();
-  verticalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setMouseTracking(true);
   setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
@@ -28,7 +28,7 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
 
 QSize BinaryView::sizeHint() const {
   QSize sz = QTableView::sizeHint();
-  return {sz.width(), model->rowCount() <= 8 ? ((CELL_HEIGHT + 1) * model->rowCount() + 1) : sz.height()};
+  return {sz.width(), model->rowCount() <= 8 ? ((CELL_HEIGHT + 1) * model->rowCount() + 2) : sz.height()};
 }
 
 void BinaryView::highlight(const Signal *sig) {
@@ -110,7 +110,6 @@ void BinaryView::leaveEvent(QEvent *event) {
 void BinaryView::setMessage(const QString &message_id) {
   msg_id = message_id;
   model->setMessage(message_id);
-  resizeRowsToContents();
   clearSelection();
   updateState();
   updateGeometry();

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -11,6 +11,8 @@
 
 // BinaryView
 
+const int CELL_HEIGHT = 30;
+
 BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   model = new BinaryViewModel(this);
   setModel(model);

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -26,7 +26,7 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
 
 QSize BinaryView::sizeHint() const {
   QSize sz = QTableView::sizeHint();
-  return {sz.width(), model->rowCount() <= 8 ? ((CELL_HEIGHT + 1) * model->rowCount() + 2) : sz.height()};
+  return {sz.width(), model->rowCount() <= 8 ? ((CELL_HEIGHT + 1) * model->rowCount() + 1) : sz.height()};
 }
 
 void BinaryView::highlight(const Signal *sig) {
@@ -244,9 +244,8 @@ BinaryItemDelegate::BinaryItemDelegate(QObject *parent) : QStyledItemDelegate(pa
 }
 
 QSize BinaryItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const {
-  // QSize sz = QStyledItemDelegate::sizeHint(option, index);
-  // return {sz.width(), CELL_HEIGHT};
-  return {CELL_HEIGHT, CELL_HEIGHT};
+  QSize sz = QStyledItemDelegate::sizeHint(option, index);
+  return {sz.width(), CELL_HEIGHT};
 }
 
 void BinaryItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -20,13 +20,13 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   setItemDelegate(delegate);
   horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
   horizontalHeader()->hide();
-  verticalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  // verticalHeader()->setSectionResizeMode(QHeaderView::Stretch);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setMouseTracking(true);
 
-  QObject::connect(model, &QAbstractItemModel::modelReset, [this]() {
-    setFixedHeight((CELL_HEIGHT + 1) * std::min(model->rowCount(), 8) + 2);
-  });
+  // QObject::connect(model, &QAbstractItemModel::modelReset, [this]() {
+  //   // setFixedHeight((CELL_HEIGHT + 1) * std::min(model->rowCount(), 8) + 2);
+  // });
 }
 
 void BinaryView::highlight(const Signal *sig) {
@@ -157,7 +157,7 @@ void BinaryViewModel::setMessage(const QString &message_id) {
 
   dbc_msg = dbc()->msg(msg_id);
   if (dbc_msg) {
-    row_count = dbc_msg->size;
+    row_count = 64;//dbc_msg->size;
     items.resize(row_count * column_count);
     for (int i = 0; i < dbc_msg->sigs.size(); ++i) {
       const auto &sig = dbc_msg->sigs[i];

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -11,8 +11,6 @@
 
 // BinaryView
 
-const int CELL_HEIGHT = 30;
-
 BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   model = new BinaryViewModel(this);
   setModel(model);
@@ -20,13 +18,15 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   setItemDelegate(delegate);
   horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
   horizontalHeader()->hide();
-  // verticalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  verticalHeader()->setSectionResizeMode(QHeaderView::Stretch);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setMouseTracking(true);
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+}
 
-  // QObject::connect(model, &QAbstractItemModel::modelReset, [this]() {
-  //   // setFixedHeight((CELL_HEIGHT + 1) * std::min(model->rowCount(), 8) + 2);
-  // });
+QSize BinaryView::sizeHint() const {
+  QSize sz = QTableView::sizeHint();
+  return {sz.width(), model->rowCount() <= 8 ? ((CELL_HEIGHT + 1) * model->rowCount() + 2) : sz.height()};
 }
 
 void BinaryView::highlight(const Signal *sig) {
@@ -111,6 +111,7 @@ void BinaryView::setMessage(const QString &message_id) {
   resizeRowsToContents();
   clearSelection();
   updateState();
+  updateGeometry();
 }
 
 void BinaryView::updateState() {
@@ -157,7 +158,7 @@ void BinaryViewModel::setMessage(const QString &message_id) {
 
   dbc_msg = dbc()->msg(msg_id);
   if (dbc_msg) {
-    row_count = 64;//dbc_msg->size;
+    row_count = dbc_msg->size;
     items.resize(row_count * column_count);
     for (int i = 0; i < dbc_msg->sigs.size(); ++i) {
       const auto &sig = dbc_msg->sigs[i];
@@ -243,8 +244,9 @@ BinaryItemDelegate::BinaryItemDelegate(QObject *parent) : QStyledItemDelegate(pa
 }
 
 QSize BinaryItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const {
-  QSize sz = QStyledItemDelegate::sizeHint(option, index);
-  return {sz.width(), CELL_HEIGHT};
+  // QSize sz = QStyledItemDelegate::sizeHint(option, index);
+  // return {sz.width(), CELL_HEIGHT};
+  return {CELL_HEIGHT, CELL_HEIGHT};
 }
 
 void BinaryItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {

--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <QDebug>
 #include <QList>
 #include <QSet>
 #include <QStyledItemDelegate>
 #include <QTableView>
 
 #include "tools/cabana/dbcmanager.h"
-
-const int CELL_HEIGHT = 30;
 
 class BinaryItemDelegate : public QStyledItemDelegate {
   Q_OBJECT

--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <QDebug>
 #include <QList>
 #include <QSet>
 #include <QStyledItemDelegate>
 #include <QTableView>
 
 #include "tools/cabana/dbcmanager.h"
+
+const int CELL_HEIGHT = 30;
 
 class BinaryItemDelegate : public QStyledItemDelegate {
   Q_OBJECT
@@ -61,6 +64,7 @@ public:
   void highlight(const Signal *sig);
   const Signal *hoveredSignal() const { return hovered_sig; }
   QSet<const Signal*> getOverlappingSignals() const;
+  QSize sizeHint() const override;
 
 signals:
   void signalHovered(const Signal *sig);

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -20,6 +20,7 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   main_layout->addLayout(right_column);
 
   binary_view_container = new QWidget(this);
+  binary_view_container->setMinimumWidth(500);
   binary_view_container->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
   QVBoxLayout *bin_layout = new QVBoxLayout(binary_view_container);
   bin_layout->setContentsMargins(0, 0, 0, 0);

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -38,14 +38,17 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   tabbar->setContextMenuPolicy(Qt::CustomContextMenu);
   bin_layout->addWidget(tabbar);
 
-  title_frame = new TitleFrame(this);
-  title_frame->setToolTip(tr("Double click to move to mew column"));
+  TitleFrame *title_frame = new TitleFrame(this);
   title_frame->setFrameShape(QFrame::StyledPanel);
   title_frame->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   QVBoxLayout *frame_layout = new QVBoxLayout(title_frame);
 
   // message title
   QHBoxLayout *title_layout = new QHBoxLayout();
+  split_btn = new QPushButton("⬅", this);
+  split_btn->setFixedSize(20, 20);
+  split_btn->setToolTip(tr("Split to two columns"));
+  title_layout->addWidget(split_btn);
   title_layout->addWidget(new QLabel("time:"));
   time_label = new QLabel(this);
   time_label->setStyleSheet("font-weight:bold");
@@ -92,6 +95,7 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   history_log = new HistoryLog(this);
   right_column->addWidget(history_log);
 
+  QObject::connect(split_btn, &QPushButton::clicked, this, &DetailWidget::moveBinaryView);
   QObject::connect(title_frame, &TitleFrame::doubleClicked, this, &DetailWidget::moveBinaryView);
   QObject::connect(edit_btn, &QPushButton::clicked, this, &DetailWidget::editMsg);
   QObject::connect(binary_view, &BinaryView::resizeSignal, this, &DetailWidget::resizeSignal);
@@ -202,12 +206,12 @@ void DetailWidget::moveBinaryView() {
   if (binview_in_left_col) {
     right_column->insertWidget(0, binary_view_container);
     emit binaryViewMoved(true);
-    title_frame->setToolTip(tr("Double click to move to mew column"));
   } else {
     tow_columns_layout->insertWidget(0, binary_view_container);
     emit binaryViewMoved(false);
-    title_frame->setToolTip(tr("Double click To move back to the origin column"));
   }
+  split_btn->setText(binview_in_left_col ? "⬅" : "➡");
+  split_btn->setToolTip(binview_in_left_col ? tr("Split to two columns") : tr("Move back"));
   binary_view->updateGeometry();
   binview_in_left_col = !binview_in_left_col;
 }

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -35,7 +35,8 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   bin_layout->addWidget(tabbar);
 
   // message title
-  TitleFrame *title_frame = new TitleFrame(this);
+  title_frame = new TitleFrame(this);
+  title_frame->setToolTip(tr("Double click to move to mew column"));
   QVBoxLayout *frame_layout = new QVBoxLayout(title_frame);
   title_frame->setFrameShape(QFrame::StyledPanel);
   QHBoxLayout *title_layout = new QHBoxLayout();
@@ -196,9 +197,11 @@ void DetailWidget::moveBinaryView() {
   if (tow_columns_layout->itemAtPosition(0, 0)) {
     right_column->insertWidget(0, binary_view_container);
     emit binaryViewMoved(true);
+    title_frame->setToolTip(tr("Double click to move to mew column"));
   } else {
     tow_columns_layout->addWidget(binary_view_container, 0, 0);
     emit binaryViewMoved(false);
+    title_frame->setToolTip(tr("Double click To move back to the origin column"));
   }
 }
 

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -168,8 +168,10 @@ void DetailWidget::updateState() {
 void DetailWidget::moveBinaryView() {
   if (tow_columns_layout->itemAtPosition(0, 0)) {
     right_column->insertWidget(0, binary_view_container);
+    emit moveBinaryView1(false);
   } else {
     tow_columns_layout->addWidget(binary_view_container, 0, 0);
+    emit moveBinaryView1(true);
   }
 }
 

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -16,15 +16,18 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
   main_layout->setSpacing(0);
-  tow_columns_layout = new QGridLayout();
+
+  tow_columns_layout = new QHBoxLayout();
+  tow_columns_layout->setSpacing(11);
   main_layout->addLayout(tow_columns_layout);
 
   right_column = new QVBoxLayout();
-  tow_columns_layout->addLayout(right_column, 0, 1);
+  tow_columns_layout->addLayout(right_column);
 
   binary_view_container = new QWidget(this);
   QVBoxLayout *bin_layout = new QVBoxLayout(binary_view_container);
   bin_layout->setContentsMargins(0, 0, 0, 0);
+  bin_layout->setSpacing(0);
   // tabbar
   tabbar = new QTabBar(this);
   tabbar->setTabsClosable(true);
@@ -34,11 +37,14 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   tabbar->setContextMenuPolicy(Qt::CustomContextMenu);
   bin_layout->addWidget(tabbar);
 
-  // message title
   title_frame = new TitleFrame(this);
   title_frame->setToolTip(tr("Double click to move to mew column"));
-  QVBoxLayout *frame_layout = new QVBoxLayout(title_frame);
   title_frame->setFrameShape(QFrame::StyledPanel);
+  title_frame->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+  QVBoxLayout *frame_layout = new QVBoxLayout(title_frame);
+  // frame_layout->setContentsMargins(0 , 0, 0, 0);
+
+  // message title
   QHBoxLayout *title_layout = new QHBoxLayout();
   title_layout->addWidget(new QLabel("time:"));
   time_label = new QLabel(this);
@@ -68,7 +74,7 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
 
   // binary view
   binary_view = new BinaryView(this);
-  bin_layout->addWidget(binary_view);  //, 1, Qt::AlignTop);
+  bin_layout->addWidget(binary_view);
   right_column->addWidget(binary_view_container);
 
   // signals
@@ -123,7 +129,6 @@ void DetailWidget::showTabBarContextMenu(const QPoint &pt) {
 void DetailWidget::setMessage(const QString &message_id) {
   if (message_id.isEmpty()) return;
 
-  qWarning() << "setmessage" << message_id;
   int index = -1;
   for (int i = 0; i < tabbar->count(); ++i) {
     if (tabbar->tabText(i) == message_id) {
@@ -194,15 +199,18 @@ void DetailWidget::updateState() {
 }
 
 void DetailWidget::moveBinaryView() {
-  if (tow_columns_layout->itemAtPosition(0, 0)) {
+  if (binview_in_left_col) {
     right_column->insertWidget(0, binary_view_container);
     emit binaryViewMoved(true);
     title_frame->setToolTip(tr("Double click to move to mew column"));
   } else {
-    tow_columns_layout->addWidget(binary_view_container, 0, 0);
+    tow_columns_layout->insertWidget(0, binary_view_container);
     emit binaryViewMoved(false);
     title_frame->setToolTip(tr("Double click To move back to the origin column"));
   }
+  binary_view->resizeRowsToContents();
+  binary_view->updateGeometry();
+  binview_in_left_col = !binview_in_left_col;
 }
 
 void DetailWidget::showForm() {

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -18,11 +18,11 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   tow_columns_layout = new QGridLayout();
   main_layout->addLayout(tow_columns_layout);
 
-  QVBoxLayout *right_column = new QVBoxLayout();
+  right_column = new QVBoxLayout();
   tow_columns_layout->addLayout(right_column, 0, 1);
 
   binary_view_container = new QWidget(this);
-  QVBoxLayout *bin_layout= new QVBoxLayout(binary_view_container);
+  QVBoxLayout *bin_layout = new QVBoxLayout(binary_view_container);
   bin_layout->setContentsMargins(0, 0, 0, 0);
   // tabbar
   tabbar = new QTabBar(this);
@@ -33,7 +33,7 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   bin_layout->addWidget(tabbar);
 
   // message title
-  QFrame *title_frame = new QFrame();
+  TitleFrame *title_frame = new TitleFrame(this);
   QVBoxLayout *frame_layout = new QVBoxLayout(title_frame);
   title_frame->setFrameShape(QFrame::StyledPanel);
   QHBoxLayout *title_layout = new QHBoxLayout();
@@ -65,7 +65,7 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
 
   // binary view
   binary_view = new BinaryView(this);
-  bin_layout->addWidget(binary_view);//, 1, Qt::AlignTop);
+  bin_layout->addWidget(binary_view);  //, 1, Qt::AlignTop);
   right_column->addWidget(binary_view_container);
 
   // signals
@@ -83,6 +83,7 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   history_log = new HistoryLog(this);
   right_column->addWidget(history_log);
 
+  QObject::connect(title_frame, &TitleFrame::doubleClicked, this, &DetailWidget::moveBinaryView);
   QObject::connect(edit_btn, &QPushButton::clicked, this, &DetailWidget::editMsg);
   QObject::connect(binary_view, &BinaryView::resizeSignal, this, &DetailWidget::resizeSignal);
   QObject::connect(binary_view, &BinaryView::addSignal, this, &DetailWidget::addSignal);
@@ -162,6 +163,14 @@ void DetailWidget::updateState() {
 
   binary_view->updateState();
   history_log->updateState();
+}
+
+void DetailWidget::moveBinaryView() {
+  if (tow_columns_layout->itemAtPosition(0, 0)) {
+    right_column->insertWidget(0, binary_view_container);
+  } else {
+    tow_columns_layout->addWidget(binary_view_container, 0, 0);
+  }
 }
 
 void DetailWidget::showForm() {

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -25,6 +25,7 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   tow_columns_layout->addLayout(right_column);
 
   binary_view_container = new QWidget(this);
+  binary_view_container->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
   QVBoxLayout *bin_layout = new QVBoxLayout(binary_view_container);
   bin_layout->setContentsMargins(0, 0, 0, 0);
   bin_layout->setSpacing(0);
@@ -207,7 +208,6 @@ void DetailWidget::moveBinaryView() {
     emit binaryViewMoved(false);
     title_frame->setToolTip(tr("Double click To move back to the origin column"));
   }
-  binary_view->resizeRowsToContents();
   binary_view->updateGeometry();
   binview_in_left_col = !binview_in_left_col;
 }

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -42,7 +42,6 @@ DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
   title_frame->setFrameShape(QFrame::StyledPanel);
   title_frame->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   QVBoxLayout *frame_layout = new QVBoxLayout(title_frame);
-  // frame_layout->setContentsMargins(0 , 0, 0, 0);
 
   // message title
   QHBoxLayout *title_layout = new QHBoxLayout();

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -13,16 +13,11 @@
 // DetailWidget
 
 DetailWidget::DetailWidget(QWidget *parent) : QWidget(parent) {
-  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout = new QHBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
-  main_layout->setSpacing(0);
-
-  tow_columns_layout = new QHBoxLayout();
-  tow_columns_layout->setSpacing(11);
-  main_layout->addLayout(tow_columns_layout);
 
   right_column = new QVBoxLayout();
-  tow_columns_layout->addLayout(right_column);
+  main_layout->addLayout(right_column);
 
   binary_view_container = new QWidget(this);
   binary_view_container->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
@@ -207,7 +202,7 @@ void DetailWidget::moveBinaryView() {
     right_column->insertWidget(0, binary_view_container);
     emit binaryViewMoved(true);
   } else {
-    tow_columns_layout->insertWidget(0, binary_view_container);
+    main_layout->insertWidget(0, binary_view_container);
     emit binaryViewMoved(false);
   }
   split_btn->setText(binview_in_left_col ? "⬅" : "➡");

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -168,10 +168,10 @@ void DetailWidget::updateState() {
 void DetailWidget::moveBinaryView() {
   if (tow_columns_layout->itemAtPosition(0, 0)) {
     right_column->insertWidget(0, binary_view_container);
-    emit moveBinaryView1(false);
+    emit binaryViewMoved(true);
   } else {
     tow_columns_layout->addWidget(binary_view_container, 0, 0);
-    emit moveBinaryView1(true);
+    emit binaryViewMoved(false);
   }
 }
 

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QGridLayout>
 #include <QScrollArea>
 #include <QTabBar>
 #include <QVBoxLayout>

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -50,6 +50,7 @@ public:
 signals:
   void showChart(const QString &msg_id, const Signal *sig);
   void removeChart(const Signal *sig);
+  void moveBinaryView1(bool out);
 
 private:
   void addSignal(int start_bit, int to);

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -50,7 +50,7 @@ public:
 signals:
   void showChart(const QString &msg_id, const Signal *sig);
   void removeChart(const Signal *sig);
-  void moveBinaryView1(bool out);
+  void binaryViewMoved(bool in);
 
 private:
   void addSignal(int start_bit, int to);

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -69,8 +69,9 @@ private:
   QPushButton *edit_btn;
   QWidget *signals_container;
   QTabBar *tabbar;
-  QGridLayout *tow_columns_layout;
+  QHBoxLayout *tow_columns_layout;
   QVBoxLayout *right_column;
+  bool binview_in_left_col = false;
   QWidget *binary_view_container;
   TitleFrame *title_frame;
   HistoryLog *history_log;

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -72,6 +72,7 @@ private:
   QGridLayout *tow_columns_layout;
   QVBoxLayout *right_column;
   QWidget *binary_view_container;
+  TitleFrame *title_frame;
   HistoryLog *history_log;
   BinaryView *binary_view;
   ScrollArea *scroll;

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QGridLayout>
 #include <QScrollArea>
 #include <QTabBar>
 
@@ -39,6 +40,7 @@ signals:
   void removeChart(const Signal *sig);
 
 private:
+  void showTabBarContextMenu(const QPoint &pt);
   void addSignal(int start_bit, int to);
   void resizeSignal(const Signal *sig, int from, int to);
   void saveSignal(const Signal *sig, const Signal &new_sig);
@@ -53,7 +55,8 @@ private:
   QPushButton *edit_btn;
   QWidget *signals_container;
   QTabBar *tabbar;
-  QStringList messages;
+  QGridLayout *tow_columns_layout;
+  QWidget *binary_view_container;
   HistoryLog *history_log;
   BinaryView *binary_view;
   ScrollArea *scroll;

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -68,7 +68,7 @@ private:
   QPushButton *edit_btn;
   QWidget *signals_container;
   QTabBar *tabbar;
-  QHBoxLayout *tow_columns_layout;
+  QHBoxLayout *main_layout;
   QVBoxLayout *right_column;
   bool binview_in_left_col = false;
   QWidget *binary_view_container;

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -10,11 +10,9 @@
 
 class TitleFrame : public QFrame {
   Q_OBJECT
-
 public:
   TitleFrame(QWidget *parent) : QFrame(parent) {}
   void mouseDoubleClickEvent(QMouseEvent *e) { emit doubleClicked(); }
-
 signals:
   void doubleClicked();
 };

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -3,10 +3,22 @@
 #include <QGridLayout>
 #include <QScrollArea>
 #include <QTabBar>
+#include <QVBoxLayout>
 
 #include "tools/cabana/binaryview.h"
 #include "tools/cabana/historylog.h"
 #include "tools/cabana/signaledit.h"
+
+class TitleFrame : public QFrame {
+  Q_OBJECT
+
+public:
+  TitleFrame(QWidget *parent) : QFrame(parent) {}
+  void mouseDoubleClickEvent(QMouseEvent *e) { emit doubleClicked(); }
+
+signals:
+  void doubleClicked();
+};
 
 class EditMessageDialog : public QDialog {
   Q_OBJECT
@@ -47,6 +59,7 @@ private:
   void editMsg();
   void showForm();
   void updateState();
+  void moveBinaryView();
 
   QString msg_id;
   QLabel *name_label, *time_label, *warning_label;
@@ -56,6 +69,7 @@ private:
   QTabBar *tabbar;
   QStringList messages;
   QGridLayout *tow_columns_layout;
+  QVBoxLayout *right_column;
   QWidget *binary_view_container;
   HistoryLog *history_log;
   BinaryView *binary_view;

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -40,7 +40,6 @@ signals:
   void removeChart(const Signal *sig);
 
 private:
-  void showTabBarContextMenu(const QPoint &pt);
   void addSignal(int start_bit, int to);
   void resizeSignal(const Signal *sig, int from, int to);
   void saveSignal(const Signal *sig, const Signal &new_sig);
@@ -55,6 +54,7 @@ private:
   QPushButton *edit_btn;
   QWidget *signals_container;
   QTabBar *tabbar;
+  QStringList messages;
   QGridLayout *tow_columns_layout;
   QWidget *binary_view_container;
   HistoryLog *history_log;

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -72,7 +72,7 @@ private:
   QVBoxLayout *right_column;
   bool binview_in_left_col = false;
   QWidget *binary_view_container;
-  TitleFrame *title_frame;
+  QPushButton *split_btn;
   HistoryLog *history_log;
   BinaryView *binary_view;
   ScrollArea *scroll;

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -3,7 +3,6 @@
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QScreen>
-#include <QSplitter>
 #include <QVBoxLayout>
 
 #include "tools/replay/util.h"
@@ -22,8 +21,10 @@ MainWindow::MainWindow() : QWidget() {
   h_layout->setContentsMargins(0, 0, 0, 0);
   main_layout->addLayout(h_layout);
 
-  QSplitter *splitter = new QSplitter(Qt::Horizontal, this);
+  splitter = new QSplitter(Qt::Horizontal, this);
   splitter->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+  splitter->setStretchFactor(0, 0);
+  splitter->setStretchFactor(1, 1);
   messages_widget = new MessagesWidget(this);
   splitter->addWidget(messages_widget);
 
@@ -84,6 +85,7 @@ MainWindow::MainWindow() : QWidget() {
   QObject::connect(this, &MainWindow::updateProgressBar, this, &MainWindow::updateDownloadProgress);
   QObject::connect(messages_widget, &MessagesWidget::msgSelectionChanged, detail_widget, &DetailWidget::setMessage);
   QObject::connect(detail_widget, &DetailWidget::showChart, charts_widget, &ChartsWidget::addChart);
+  QObject::connect(detail_widget, &DetailWidget::moveBinaryView1, this, &MainWindow::showLeftPanel);
   QObject::connect(charts_widget, &ChartsWidget::dock, this, &MainWindow::dockCharts);
   QObject::connect(charts_widget, &ChartsWidget::rangeChanged, video_widget, &VideoWidget::rangeChanged);
   QObject::connect(settings_btn, &QPushButton::clicked, this, &MainWindow::setOption);
@@ -103,6 +105,15 @@ void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool succe
   }
 }
 
+void MainWindow::showLeftPanel(bool show) {
+  // show ? splitter->setSizes(100, 500) : 
+  // qWarning() << "here";
+  if (show) {
+    splitter->setSizes({0, 500});
+  } else {
+    splitter->setSizes({100, 500});
+  }
+}
 
 void MainWindow::dockCharts(bool dock) {
   if (dock && floating_window) {

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -9,7 +9,7 @@
 
 static MainWindow *main_win = nullptr;
 void qLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-  if (main_win) main_win->showStatusMessage(msg);
+  if (main_win) emit main_win->showMessage(msg, 300);
 }
 
 MainWindow::MainWindow() : QWidget() {
@@ -23,8 +23,6 @@ MainWindow::MainWindow() : QWidget() {
 
   splitter = new QSplitter(Qt::Horizontal, this);
   splitter->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
-  splitter->setStretchFactor(0, 0);
-  splitter->setStretchFactor(1, 1);
   messages_widget = new MessagesWidget(this);
   splitter->addWidget(messages_widget);
 
@@ -75,13 +73,13 @@ MainWindow::MainWindow() : QWidget() {
   qRegisterMetaType<ReplyMsgType>("ReplyMsgType");
   installMessageHandler([this](ReplyMsgType type, const std::string msg) {
     // use queued connection to recv the log messages from replay.
-    emit logMessageFromReplay(QString::fromStdString(msg), 3000);
+    emit showMessage(QString::fromStdString(msg), 3000);
   });
   installDownloadProgressHandler([this](uint64_t cur, uint64_t total, bool success) {
     emit updateProgressBar(cur, total, success);
   });
 
-  QObject::connect(this, &MainWindow::logMessageFromReplay, status_bar, &QStatusBar::showMessage);
+  QObject::connect(this, &MainWindow::showMessage, status_bar, &QStatusBar::showMessage);
   QObject::connect(this, &MainWindow::updateProgressBar, this, &MainWindow::updateDownloadProgress);
   QObject::connect(messages_widget, &MessagesWidget::msgSelectionChanged, detail_widget, &DetailWidget::setMessage);
   QObject::connect(detail_widget, &DetailWidget::showChart, charts_widget, &ChartsWidget::addChart);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -85,14 +85,14 @@ MainWindow::MainWindow() : QWidget() {
   QObject::connect(this, &MainWindow::updateProgressBar, this, &MainWindow::updateDownloadProgress);
   QObject::connect(messages_widget, &MessagesWidget::msgSelectionChanged, detail_widget, &DetailWidget::setMessage);
   QObject::connect(detail_widget, &DetailWidget::showChart, charts_widget, &ChartsWidget::addChart);
-  QObject::connect(detail_widget, &DetailWidget::moveBinaryView1, this, &MainWindow::showLeftPanel);
+  QObject::connect(detail_widget, &DetailWidget::binaryViewMoved, [this](bool in) { splitter->setSizes({in ? 100 : 0, 500}); });
   QObject::connect(charts_widget, &ChartsWidget::dock, this, &MainWindow::dockCharts);
   QObject::connect(charts_widget, &ChartsWidget::rangeChanged, video_widget, &VideoWidget::rangeChanged);
   QObject::connect(settings_btn, &QPushButton::clicked, this, &MainWindow::setOption);
   QObject::connect(can, &CANMessages::eventsMerged, [=]() { fingerprint_label->setText(can->carFingerprint() ); });
 
   main_win = this;
-  // qInstallMessageHandler(qLogMessageHandler);
+  qInstallMessageHandler(qLogMessageHandler);
 }
 
 void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool success) {
@@ -102,16 +102,6 @@ void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool succe
     progress_bar->show();
   } else {
     progress_bar->hide();
-  }
-}
-
-void MainWindow::showLeftPanel(bool show) {
-  // show ? splitter->setSizes(100, 500) : 
-  // qWarning() << "here";
-  if (show) {
-    splitter->setSizes({0, 500});
-  } else {
-    splitter->setSizes({100, 500});
   }
 }
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -22,10 +22,7 @@ MainWindow::MainWindow() : QWidget() {
   main_layout->addLayout(h_layout);
 
   splitter = new QSplitter(Qt::Horizontal, this);
-  splitter->setStretchFactor(0, 0);
-  // splitter->setStretchFactor(1, 1);
   splitter->setHandleWidth(11);
-  splitter->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
   messages_widget = new MessagesWidget(this);
   splitter->addWidget(messages_widget);
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -22,6 +22,8 @@ MainWindow::MainWindow() : QWidget() {
   main_layout->addLayout(h_layout);
 
   splitter = new QSplitter(Qt::Horizontal, this);
+  splitter->setStretchFactor(0, 0);
+  // splitter->setStretchFactor(1, 1);
   splitter->setHandleWidth(11);
   splitter->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
   messages_widget = new MessagesWidget(this);
@@ -30,7 +32,6 @@ MainWindow::MainWindow() : QWidget() {
   detail_widget = new DetailWidget(this);
   splitter->addWidget(detail_widget);
 
-  splitter->setSizes({100, 500});
   h_layout->addWidget(splitter);
 
   // right widgets

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -22,6 +22,7 @@ MainWindow::MainWindow() : QWidget() {
   main_layout->addLayout(h_layout);
 
   splitter = new QSplitter(Qt::Horizontal, this);
+  splitter->setHandleWidth(11);
   splitter->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
   messages_widget = new MessagesWidget(this);
   splitter->addWidget(messages_widget);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -9,7 +9,7 @@
 
 static MainWindow *main_win = nullptr;
 void qLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-  if (main_win) emit main_win->showMessage(msg, 300);
+  if (main_win) emit main_win->showMessage(msg, 0);
 }
 
 MainWindow::MainWindow() : QWidget() {

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -90,7 +90,7 @@ MainWindow::MainWindow() : QWidget() {
   QObject::connect(can, &CANMessages::eventsMerged, [=]() { fingerprint_label->setText(can->carFingerprint() ); });
 
   main_win = this;
-  qInstallMessageHandler(qLogMessageHandler);
+  // qInstallMessageHandler(qLogMessageHandler);
 }
 
 void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool success) {

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -18,7 +18,7 @@ public:
   void showStatusMessage(const QString &msg, int timeout = 0) { status_bar->showMessage(msg, timeout); }
 
 signals:
-  void logMessageFromReplay(const QString &msg, int timeout);
+  void showMessage(const QString &msg, int timeout);
   void updateProgressBar(uint64_t cur, uint64_t total, bool success);
 
 protected:

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -25,7 +25,6 @@ protected:
   void closeEvent(QCloseEvent *event) override;
   void updateDownloadProgress(uint64_t cur, uint64_t total, bool success);
   void setOption();
-  void showLeftPanel(bool show);
 
   VideoWidget *video_widget;
   MessagesWidget *messages_widget;

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QProgressBar>
+#include <QSplitter>
 #include <QStatusBar>
 
 #include "tools/cabana/chartswidget.h"
@@ -24,11 +25,13 @@ protected:
   void closeEvent(QCloseEvent *event) override;
   void updateDownloadProgress(uint64_t cur, uint64_t total, bool success);
   void setOption();
+  void showLeftPanel(bool show);
 
   VideoWidget *video_widget;
   MessagesWidget *messages_widget;
   DetailWidget *detail_widget;
   ChartsWidget *charts_widget;
+  QSplitter *splitter;
   QWidget *floating_window = nullptr;
   QVBoxLayout *r_layout;
   QProgressBar *progress_bar;


### PR DESCRIPTION
click the left ⬅ button, or double click the title bar to split binview to a separate standalone column.
click again to move it back to the top of detail view.

![Screenshot from 2022-10-29 18-11-45](https://user-images.githubusercontent.com/27770/198825854-fe012714-f194-44e8-8bf8-09882c372eb7.png)

[Kazam_screencast_00011.webm](https://user-images.githubusercontent.com/27770/198814415-c4996ae8-c80c-4bfc-8b14-c47e5c17938a.webm)
