### PR TITLE
Cabana: fix mouse freezes / hangs

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -402,10 +402,13 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
       // zoom in if selected range is greater than 0.5s
       emit zoomIn(min, max);
     }
+    event->accept();
   } else if (event->button() == Qt::RightButton) {
     emit zoomReset();
+    event->accept();
+  } else {
+    QGraphicsView::mouseReleaseEvent(event);
   }
-  event->accept();
 }
 
 void ChartView::mouseMoveEvent(QMouseEvent *ev) {


### PR DESCRIPTION
bass class QGraphicsView::mouseReleaseEvent should be called in else statement.  otherwise the subsequent mouse event may not be sent to the event queue.