### PR TITLE
Cabana: get double precision from std::numeric_limits

### DIFF
--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -1,5 +1,6 @@
 #include "tools/cabana/dbcmanager.h"
 
+#include <limits>
 #include <sstream>
 #include <QVector>
 
@@ -41,8 +42,8 @@ QString DBCManager::generateDBC() {
                         .arg(sig.size)
                         .arg(sig.is_little_endian ? '1' : '0')
                         .arg(sig.is_signed ? '-' : '+')
-                        .arg(sig.factor, 0, 'g', 20)
-                        .arg(sig.offset);
+                        .arg(sig.factor, 0, 'g', std::numeric_limits<double>::digits10)
+                        .arg(sig.offset, 0, 'g', std::numeric_limits<double>::digits10);
     }
     dbc_string += "\n";
   }


### PR DESCRIPTION
make sure the precision is the same as the std::stod in openDBC: https://github.com/commaai/opendbc/blob/b3dc569994fd10e4de04afd650980c51ddfce5e1/can/dbc.cc#L152-L153:

      sig.factor = std::stod(match[offset + 6].str());
      sig.offset = std::stod(match[offset + 7].str());

The output is now the same as sig.factor and the original dbc file:
>  SG_ GAS_COMMAND2 : 23|16@0+ (0.159375,-151.111) [0|0] "" XXX