### PR TITLE
test_models: fix runaway memory growth for long running tests

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -109,6 +109,13 @@ class TestCarModelBase(unittest.TestCase):
     assert cls.CP
     assert cls.CP.carFingerprint == cls.car_model
 
+  @classmethod
+  def tearDownClass(cls):
+    del cls.can_msgs
+
+  # def tearDown(self):
+  #   del self.safety
+
   def setUp(self):
     self.CI = self.CarInterface(self.CP, self.CarController, self.CarState)
     assert self.CI

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -113,9 +113,6 @@ class TestCarModelBase(unittest.TestCase):
   def tearDownClass(cls):
     del cls.can_msgs
 
-  # def tearDown(self):
-  #   del self.safety
-
   def setUp(self):
     self.CI = self.CarInterface(self.CP, self.CarController, self.CarState)
     assert self.CI


### PR DESCRIPTION
Because we don't delete can_msgs, when running on a lot of test cases, the memory usage can easily continue growing up to hundreds of GBs. Now it caps out at around 15GB when running 32 jobs on ~1000 routes (PC idle baseline is ~10GB).

with `pytest -n32 test_models.py` and 8-10GB idle baseline:

- master: 
  - 30GB
- PR:
  - 13GB