### PR TITLE
test_models: remove carState test from panda tests

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -237,7 +237,6 @@ class TestCarModelBase(unittest.TestCase):
       # TODO: check rest of panda's carstate (steering, ACC main on, etc.)
 
       checks['gasPressed'] += CS.gasPressed != self.safety.get_gas_pressed_prev()
-      checks['cruiseState'] += CS.cruiseState.enabled and not CS.cruiseState.available
       if self.CP.carName not in ("hyundai", "volkswagen", "body"):
         # TODO: fix standstill mismatches for other makes
         checks['standstill'] += CS.standstill == self.safety.get_vehicle_moving()


### PR DESCRIPTION
This wasn't the correct place for it, and it's actually expected in certain scenarios. For example this Prius which presses the main button while engaged at a stop, ACC stays engaged to keep applying the brakes until user intervention: https://connect.comma.ai/748cc5e00e00d2f8/1661007658151/1661007719828