### PR TITLE
test_models: speed up test

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -214,10 +214,10 @@ class TestCarModelBase(unittest.TestCase):
 
     # warm up pass, as initial states may be different
     for can in self.can_msgs[:300]:
+      self.CI.update(CC, (can.as_builder().to_bytes(), ))
       for msg in can_capnp_to_can_list(can.can, src_filter=range(64)):
         to_send = package_can_msg(msg)
         self.safety.safety_rx_hook(to_send)
-        self.CI.update(CC, (can_list_to_can_capnp([msg, ]), ))
 
     if not self.CP.pcmCruise:
       self.safety.set_controls_allowed(0)

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -9,7 +9,7 @@ from parameterized import parameterized_class
 
 from cereal import log, car
 from common.realtime import DT_CTRL
-from selfdrive.boardd.boardd import can_capnp_to_can_list, can_list_to_can_capnp
+from selfdrive.boardd.boardd import can_capnp_to_can_list
 from selfdrive.car.fingerprints import all_known_cars
 from selfdrive.car.car_helpers import interfaces
 from selfdrive.car.gm.values import CAR as GM


### PR DESCRIPTION
Speeds up 214 runs through this function from 73 seconds to 61 seconds. With a baseline of ~30 seconds to do the setUp and tearDown, this now takes about 70% of the previous time taken for just this function

- 214 function runs (`FILEREADER_CACHE=1`, `-j50`)
  - Before: 73s
  - After: 61ss
  - Baseline (only setUpClass, setUp, tearDown): 30s
  - Speedup: ~27%
- 691 function runs (`FILEREADER_CACHE=1`, `-j50`)
  - Before: 190s
  - After: 153s
  - Baseline (only setUpClass, setUp, tearDown): 70s
  - Speedup: ~30%