### PR TITLE
test_models: fix Nidec routes that start enabled

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -231,7 +231,7 @@ class TestCarModelBase(unittest.TestCase):
         ret = self.safety.safety_rx_hook(to_send)
         self.assertEqual(1, ret, f"safety rx failed ({ret=}): {to_send}")
 
-      # Skip first frame so that CS_prev is properly initialized
+      # Skip first frame so CS_prev is properly initialized
       if idx == 0:
         CS_prev = CS
         # Button may be left pressed in warm up period

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -234,6 +234,11 @@ class TestCarModelBase(unittest.TestCase):
         ret = self.safety.safety_rx_hook(to_send)
         self.assertEqual(1, ret, f"safety rx failed ({ret=}): {to_send}")
 
+      # Skip testing while CS_prev is blank CarState
+      if idx == 0:
+        CS_prev = CS
+        continue
+
       # TODO: check rest of panda's carstate (steering, ACC main on, etc.)
 
       checks['gasPressed'] += CS.gasPressed != self.safety.get_gas_pressed_prev()

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -219,9 +219,6 @@ class TestCarModelBase(unittest.TestCase):
         to_send = package_can_msg(msg)
         self.safety.safety_rx_hook(to_send)
 
-    if not self.CP.pcmCruise:
-      self.safety.set_controls_allowed(0)
-
     controls_allowed_prev = False
     CS_prev = None
     checks = defaultdict(lambda: 0)
@@ -237,6 +234,8 @@ class TestCarModelBase(unittest.TestCase):
       # Skip first frame so that CS_prev is properly initialized
       if CS_prev is None:
         CS_prev = CS
+        if not self.CP.pcmCruise:
+          self.safety.set_controls_allowed(0)
         continue
 
       # TODO: check rest of panda's carstate (steering, ACC main on, etc.)

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -220,7 +220,7 @@ class TestCarModelBase(unittest.TestCase):
         self.safety.safety_rx_hook(to_send)
 
     controls_allowed_prev = False
-    CS_prev = None
+    CS_prev = car.CarState.new_message()
     checks = defaultdict(lambda: 0)
     for idx, can in enumerate(self.can_msgs):
       CS = self.CI.update(CC, (can.as_builder().to_bytes(), ))

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -222,7 +222,7 @@ class TestCarModelBase(unittest.TestCase):
     controls_allowed_prev = False
     CS_prev = None
     checks = defaultdict(lambda: 0)
-    for can in self.can_msgs:
+    for idx, can in enumerate(self.can_msgs):
       CS = self.CI.update(CC, (can.as_builder().to_bytes(), ))
       for msg in can_capnp_to_can_list(can.can, src_filter=range(64)):
         msg = list(msg)
@@ -232,8 +232,9 @@ class TestCarModelBase(unittest.TestCase):
         self.assertEqual(1, ret, f"safety rx failed ({ret=}): {to_send}")
 
       # Skip first frame so that CS_prev is properly initialized
-      if CS_prev is None:
+      if idx == 0:
         CS_prev = CS
+        # Button may be left pressed in warm up period
         if not self.CP.pcmCruise:
           self.safety.set_controls_allowed(0)
         continue

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -223,7 +223,7 @@ class TestCarModelBase(unittest.TestCase):
       self.safety.set_controls_allowed(0)
 
     controls_allowed_prev = False
-    CS_prev = car.CarState.new_message()
+    CS_prev = None
     checks = defaultdict(lambda: 0)
     for can in self.can_msgs:
       CS = self.CI.update(CC, (can.as_builder().to_bytes(), ))
@@ -234,8 +234,8 @@ class TestCarModelBase(unittest.TestCase):
         ret = self.safety.safety_rx_hook(to_send)
         self.assertEqual(1, ret, f"safety rx failed ({ret=}): {to_send}")
 
-      # Skip testing while CS_prev is blank CarState
-      if idx == 0:
+      # Skip first frame so that CS_prev is properly initialized
+      if CS_prev is None:
         CS_prev = CS
         continue
 


### PR DESCRIPTION
On the first iteration, the line below would be True, even if we started enabled. Wait one frame to start testing until CS_prev is initialized

```if CS.cruiseState.enabled and not CS_prev.cruiseState.enabled:```