### PR TITLE
joystick: use long controller

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -16,7 +16,7 @@ from system.version import is_tested_branch, get_short_branch
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from selfdrive.car.car_helpers import get_car, get_startup_event, get_one_can
 from selfdrive.controls.lib.lateral_planner import CAMERA_OFFSET
-from selfdrive.controls.lib.drive_helpers import V_CRUISE_INITIAL, update_v_cruise, initialize_v_cruise, get_lag_adjusted_curvature, CONTROL_N
+from selfdrive.controls.lib.drive_helpers import CONTROL_N, V_CRUISE_INITIAL, update_v_cruise, initialize_v_cruise, get_lag_adjusted_curvature
 from selfdrive.controls.lib.latcontrol import LatControl
 from selfdrive.controls.lib.longcontrol import LongControl
 from selfdrive.controls.lib.latcontrol_pid import LatControlPID

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -619,9 +619,8 @@ class Controls:
     # accel PID loop
     if self.joystick_mode:
       joystick_accel = 4.0 * clip(self.sm['testJoystick'].axes[0], -1, 1) if self.sm.rcv_frame['testJoystick'] > 0 else 0.0
-      long_plan = log.LongitudinalPlan()
-      long_plan.accels = [joystick_accel] * CONTROL_N
-      long_plan.speeds = interpolate_mpc_to_traj(LongitudinalMpc.extrapolate_lead(0, CS.vEgo, joystick_accel, 0).T[1])
+      long_plan = log.LongitudinalPlan(accels=[joystick_accel] * CONTROL_N,
+                                       speeds=interpolate_mpc_to_traj(LongitudinalMpc.extrapolate_lead(0, CS.vEgo, joystick_accel, 0).T[1]))
     else:
       long_plan = self.sm['longitudinalPlan']
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -621,11 +621,12 @@ class Controls:
       joystick_accel = 4.0 * clip(self.sm['testJoystick'].axes[0], -1, 1) if self.sm.rcv_frame['testJoystick'] > 0 else 0.0
       long_plan = log.LongitudinalPlan(accels=[joystick_accel] * CONTROL_N,
                                        speeds=interpolate_mpc_to_traj(LongitudinalMpc.extrapolate_lead(0, CS.vEgo, joystick_accel, 0).T[1]))
+      t_since_plan = 0
     else:
       long_plan = self.sm['longitudinalPlan']
+      t_since_plan = (self.sm.frame - self.sm.rcv_frame['longitudinalPlan']) * DT_CTRL
 
     pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, self.v_cruise_kph * CV.KPH_TO_MS)
-    t_since_plan = (self.sm.frame - self.sm.rcv_frame['longitudinalPlan']) * DT_CTRL
     actuators.accel = self.LoC.update(CC.longActive, CS, long_plan, pid_accel_limits, t_since_plan)
 
     if not self.joystick_mode:


### PR DESCRIPTION
Puts more longcontrol behavior in the loop, such as PID gains, long control states like stopping/starting, prevent_overshoot

Bolt with joystick before this is smooth as we can modulate the accel smoothly, however the PID gains make it much more unstable which we should hit with joystick mode