### PR TITLE
sim: add docker kill to openpilot docker

### DIFF
--- a/tools/sim/start_openpilot_docker.sh
+++ b/tools/sim/start_openpilot_docker.sh
@@ -20,6 +20,7 @@ else
   EXTRA_ARGS="${EXTRA_ARGS} -it"
 fi
 
+docker kill openpilot_client || true
 docker run --net=host\
   --name openpilot_client \
   --rm \


### PR DESCRIPTION
minor bug fix when running openpilot docker for the second time

