### PR TITLE
manager: watchdog restart is non-blocking

### DIFF
--- a/selfdrive/manager/process.py
+++ b/selfdrive/manager/process.py
@@ -91,7 +91,7 @@ class ManagerProcess(ABC):
     pass
 
   def restart(self) -> None:
-    self.stop()
+    self.stop(block=False)
     self.start()
 
   def check_watchdog(self, started: bool) -> None:


### PR DESCRIPTION
If a watched process dies right as we want to go offroad, we can sit onroad while we wait for the process to be stopped, logging can errors that can extend across segments