### PR TITLE
e2e path 2.0

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -467,7 +467,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       acceleration_future = acceleration.getX()[10];  // 1.0 second
     }
     start_hue = 210;
-    end_hue = fmax(fmin(195 - (accel_filter.update(acceleration_future) * 100), 360), 90);
+    end_hue = fmax(fmin(195 - (accel_filter.update(acceleration_future) * 80), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -466,8 +466,8 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     if (acceleration.getZ().size() > 10) {
       acceleration_future = acceleration.getX()[10];  // 1.0 second
     }
-    start_hue = 210;
-    end_hue = fmax(fmin(195 - (accel_filter.update(acceleration_future) * 75), 360), 90);
+    start_hue = 215;
+    end_hue = fmax(fmin(200 - (accel_filter.update(acceleration_future) * 100), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -467,7 +467,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       acceleration_future = acceleration.getX()[10];  // 1.0 second
     }
     start_hue = 210;
-    end_hue = fmax(fmin(195 - (accel_filter.update(acceleration_future) * 80), 360), 90);
+    end_hue = fmax(fmin(195 - (accel_filter.update(acceleration_future) * 75), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -467,7 +467,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       acceleration_future = acceleration.getX()[10];  // 1.0 second
     }
     start_hue = 210;
-    end_hue = fmax(fmin(195 - (acceleration_future * 65), 360), 90);
+    end_hue = fmax(fmin(195 - (acceleration_future * 75), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -458,11 +458,8 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
   }
 
   // paint path
-
-  // max y of scene.track_vertices
   int max_y = std::max_element(scene.track_vertices.begin(), scene.track_vertices.end(),
                                [](const QPointF &a, const QPointF &b) { return a.y() > b.y(); })->y();
-
   QLinearGradient bg(0, height(), 0, max_y);
   float start_hue, end_hue;
   if (true) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -466,8 +466,8 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     if (acceleration.getZ().size() > 16) {
       acceleration_future = acceleration.getX()[16];  // 2.5 seconds
     }
-    start_hue = 208;
-    end_hue = fmax(fmin(start_hue - (acceleration_future * 55), 290), 122);
+    start_hue = 220;
+    end_hue = fmax(fmin(start_hue - (acceleration_future * 57), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -462,7 +462,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
                                [](const QPointF &a, const QPointF &b) { return a.y() > b.y(); })->y();
   QLinearGradient bg(0, height(), 0, max_y);
   float start_hue, end_hue;
-  if (true) {
+  if (scene.end_to_end_long) {
     const auto &acceleration = (*s->sm)["modelV2"].getModelV2().getAcceleration();
     float acceleration_future = 0;
     if (acceleration.getZ().size() > 16) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -458,7 +458,12 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
   }
 
   // paint path
-  QLinearGradient bg(0, height(), 0, scene.track_vertices[16].y());
+
+  // max y of scene.track_vertices
+  int max_y = std::max_element(scene.track_vertices.begin(), scene.track_vertices.end(),
+                               [](const QPointF &a, const QPointF &b) { return a.y() > b.y(); })->y();
+
+  QLinearGradient bg(0, height(), 0, max_y);
   float start_hue, end_hue;
   if (true) {
     const auto &acceleration = (*s->sm)["modelV2"].getModelV2().getAcceleration();
@@ -467,13 +472,13 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       acceleration_future = acceleration.getX()[16];  // 2.5 seconds
     }
     start_hue = 208;
-    end_hue = fmax(fmin(start_hue - (acceleration_future * 56), 330), 122);
+    end_hue = fmax(fmin(start_hue - (acceleration_future * 40), 290), 122);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
     bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.65, 0.5, 0.4));
-    bg.setColorAt(0.95, QColor::fromHslF(end_hue / 360., 0.65, 0.5, 0.35));
+    bg.setColorAt(0.98, QColor::fromHslF(end_hue / 360., 0.65, 0.5, 0.35));
     bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 0.65, 0.5, 0.0));
   } else {
     const auto &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
@@ -489,7 +494,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
     bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.94, 0.51, 0.4));
-    bg.setColorAt(0.95, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.35));
+    bg.setColorAt(0.98, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.35));
     bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.0));
   }
 

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -466,15 +466,15 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     if (acceleration.getZ().size() > 16) {
       acceleration_future = acceleration.getX()[16];  // 2.5 seconds
     }
-    start_hue = 225;
-    end_hue = fmax(fmin(start_hue - (acceleration_future * 65), 360), 90);
+    start_hue = 210;
+    end_hue = fmax(fmin(195 - (acceleration_future * 65), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
-    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 1.0, 0.6, 0.4));
-    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 1.0, 0.7, 0.35));
-    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 1.0, 0.7, 0.0));
+    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.94, 0.51, 0.6));
+    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.45));
+    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.0));
   } else {
     const auto &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
     float orientation_future = 0;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -458,9 +458,9 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
   }
 
   // paint path
-  int max_y = std::max_element(scene.track_vertices.begin(), scene.track_vertices.end(),
+  int min_y = std::max_element(scene.track_vertices.begin(), scene.track_vertices.end(),
                                [](const QPointF &a, const QPointF &b) { return a.y() > b.y(); })->y();
-  QLinearGradient bg(0, height(), 0, max_y);
+  QLinearGradient bg(0, height(), 0, min_y);
   float start_hue, end_hue;
   if (scene.end_to_end_long) {
     const auto &acceleration = (*s->sm)["modelV2"].getModelV2().getAcceleration();

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -463,8 +463,8 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
   if (scene.end_to_end_long) {
     const auto &acceleration = (*s->sm)["modelV2"].getModelV2().getAcceleration();
     float acceleration_future = 0;
-    if (acceleration.getZ().size() > 16) {
-      acceleration_future = acceleration.getX()[16];  // 2.5 seconds
+    if (acceleration.getZ().size() > 10) {
+      acceleration_future = acceleration.getX()[10];  // 1.0 second
     }
     start_hue = 210;
     end_hue = fmax(fmin(195 - (acceleration_future * 65), 360), 90);

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -458,9 +458,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
   }
 
   // paint path
-  int min_y = std::max_element(scene.track_vertices.begin(), scene.track_vertices.end(),
-                               [](const QPointF &a, const QPointF &b) { return a.y() > b.y(); })->y();
-  QLinearGradient bg(0, height(), 0, min_y);
+  QLinearGradient bg(0, height(), 0, height() / 4);
   float start_hue, end_hue;
   if (scene.end_to_end_long) {
     const auto &acceleration = (*s->sm)["modelV2"].getModelV2().getAcceleration();
@@ -469,14 +467,14 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       acceleration_future = acceleration.getX()[16];  // 2.5 seconds
     }
     start_hue = 208;
-    end_hue = fmax(fmin(start_hue - (acceleration_future * 40), 290), 122);
+    end_hue = fmax(fmin(start_hue - (acceleration_future * 55), 290), 122);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
-    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.65, 0.5, 0.4));
-    bg.setColorAt(0.98, QColor::fromHslF(end_hue / 360., 0.65, 0.5, 0.35));
-    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 0.65, 0.5, 0.0));
+    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.65, 0.6, 0.4));
+    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 0.65, 0.6, 0.35));
+    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 0.65, 0.6, 0.0));
   } else {
     const auto &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
     float orientation_future = 0;
@@ -491,7 +489,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
     bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.94, 0.51, 0.4));
-    bg.setColorAt(0.98, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.35));
+    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.35));
     bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.0));
   }
 

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -170,7 +170,7 @@ void OnroadAlerts::paintEvent(QPaintEvent *event) {
 }
 
 
-AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget* parent) : fps_filter(UI_FREQ, 3, 1. / UI_FREQ), CameraWidget("camerad", type, true, parent) {
+AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget* parent) : fps_filter(UI_FREQ, 3, 1. / UI_FREQ), accel_filter(UI_FREQ, .2, 1. / UI_FREQ), CameraWidget("camerad", type, true, parent) {
   pm = std::make_unique<PubMaster, const std::initializer_list<const char *>>({"uiDebug"});
 
   engage_img = loadPixmap("../assets/img_chffr_wheel.png", {img_size, img_size});
@@ -467,7 +467,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       acceleration_future = acceleration.getX()[10];  // 1.0 second
     }
     start_hue = 210;
-    end_hue = fmax(fmin(195 - (acceleration_future * 75), 360), 90);
+    end_hue = fmax(fmin(195 - (accel_filter.update(acceleration_future) * 100), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -467,7 +467,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       acceleration_future = acceleration.getX()[16];  // 2.5 seconds
     }
     start_hue = 225;
-    end_hue = fmax(fmin(start_hue - (acceleration_future * 62), 360), 90);
+    end_hue = fmax(fmin(start_hue - (acceleration_future * 65), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -489,7 +489,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
     bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.94, 0.51, 0.4));
-    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.35));
+    bg.setColorAt(0.95, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.35));
     bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.0));
   }
 

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -458,24 +458,23 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
   }
 
   // paint path
-  QLinearGradient bg(0, height(), 0, height() / 4);
+  QLinearGradient bg(0, height(), 0, scene.track_vertices[16].y());
   float start_hue, end_hue;
-  if (scene.end_to_end_long) {
+  if (true) {
     const auto &acceleration = (*s->sm)["modelV2"].getModelV2().getAcceleration();
     float acceleration_future = 0;
     if (acceleration.getZ().size() > 16) {
       acceleration_future = acceleration.getX()[16];  // 2.5 seconds
     }
-    start_hue = 60;
-    // speed up: 120, slow down: 0
-    end_hue = fmax(fmin(start_hue + acceleration_future * 30, 120), 0);
+    start_hue = 208;
+    end_hue = fmax(fmin(start_hue - (acceleration_future * 56), 330), 122);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
-    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.97, 0.56, 0.4));
-    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.35));
-    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 1.0, 0.68, 0.0));
+    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.65, 0.5, 0.4));
+    bg.setColorAt(0.95, QColor::fromHslF(end_hue / 360., 0.65, 0.5, 0.35));
+    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 0.65, 0.5, 0.0));
   } else {
     const auto &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
     float orientation_future = 0;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -466,15 +466,15 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     if (acceleration.getZ().size() > 16) {
       acceleration_future = acceleration.getX()[16];  // 2.5 seconds
     }
-    start_hue = 220;
-    end_hue = fmax(fmin(start_hue - (acceleration_future * 57), 360), 90);
+    start_hue = 225;
+    end_hue = fmax(fmin(start_hue - (acceleration_future * 62), 360), 90);
 
     // FIXME: painter.drawPolygon can be slow if hue is not rounded
     end_hue = int(end_hue * 100 + 0.5) / 100;
 
-    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 0.65, 0.6, 0.4));
-    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 0.65, 0.6, 0.35));
-    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 0.65, 0.6, 0.0));
+    bg.setColorAt(0.0, QColor::fromHslF(start_hue / 360., 1.0, 0.6, 0.4));
+    bg.setColorAt(0.5, QColor::fromHslF(end_hue / 360., 1.0, 0.7, 0.35));
+    bg.setColorAt(1.0, QColor::fromHslF(end_hue / 360., 1.0, 0.7, 0.0));
   } else {
     const auto &orientation = (*s->sm)["modelV2"].getModelV2().getOrientation();
     float orientation_future = 0;

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -87,6 +87,7 @@ protected:
 
   double prev_draw_t = 0;
   FirstOrderFilter fps_filter;
+  FirstOrderFilter accel_filter;
 };
 
 // container for all onroad widgets


### PR DESCRIPTION
green = fast
blue = same
red = slow

The gradient starts at the bottom of the screen and ends 3/4 the way up. This is probably why the opacity never seemed to work.

![Screenshot from 2022-11-02 13-27-05](https://user-images.githubusercontent.com/4038174/199596715-0dae1318-240d-4b3c-83de-679f3b168a7a.png)
![Screenshot from 2022-11-02 13-33-34](https://user-images.githubusercontent.com/4038174/199597082-050a88b7-29df-43e9-8b56-4198210c1d8e.png)
![Screenshot from 2022-11-02 13-33-44](https://user-images.githubusercontent.com/4038174/199597107-52f328f8-4358-4433-8eae-d1192e6cc3ff.png)
![Screenshot from 2022-11-02 13-34-19](https://user-images.githubusercontent.com/4038174/199597114-f51cc63d-feee-4f1b-aea6-6f2940f15ca1.png)
![Screenshot from 2022-11-02 13-35-38](https://user-images.githubusercontent.com/4038174/199597320-da3d4df3-2fe0-47b0-8d11-ab85a0e39603.png)
![Screenshot from 2022-11-02 13-36-44](https://user-images.githubusercontent.com/4038174/199597542-72051cd6-6762-46dc-8e83-f7558152e517.png)
![Screenshot from 2022-11-02 13-37-26](https://user-images.githubusercontent.com/4038174/199597650-48759577-e677-4b13-9d32-828820e5171c.png)
![Screenshot from 2022-11-02 13-37-48](https://user-images.githubusercontent.com/4038174/199597710-e087fc7d-e87e-4374-b79b-28346821fd1d.png)
![Screenshot from 2022-11-02 13-38-15](https://user-images.githubusercontent.com/4038174/199597785-80438cd0-b21c-40ed-9cbf-04b27bbbe3f7.png)
![Screenshot from 2022-11-02 13-38-44](https://user-images.githubusercontent.com/4038174/199597868-2da1019b-0c51-4751-a323-63bf346778c9.png)
![Screenshot from 2022-11-02 13-54-02](https://user-images.githubusercontent.com/4038174/199600536-286d0f79-b79e-4b77-b899-c086a2995ff5.png)
![Screenshot from 2022-11-02 13-53-27](https://user-images.githubusercontent.com/4038174/199600538-fe69846b-47a1-4c6c-bc0a-345f0cde6b28.png)
![Screenshot from 2022-11-02 13-54-30](https://user-images.githubusercontent.com/4038174/199600603-5da579b7-7a03-44ce-9257-1a2cad013bc5.png)
![Screenshot from 2022-11-02 13-54-54](https://user-images.githubusercontent.com/4038174/199600676-8b038b25-4cb2-470f-be8f-e2443bc865ed.png)
![Screenshot from 2022-11-02 13-57-17](https://user-images.githubusercontent.com/4038174/199601047-bbaf4892-5a1d-44a7-b89b-2386effc5bcf.png)
![Screenshot from 2022-11-02 13-58-13](https://user-images.githubusercontent.com/4038174/199601201-a76e8ddb-6d1e-4988-b68d-e6bb67f4b267.png)
