### PR TITLE
cabana: optimize chart update

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -325,7 +325,6 @@ void ChartView::updateLineMarker(double current_sec) {
           chart()->plotArea().width() * (current_sec - axis_x->min()) / (axis_x->max() - axis_x->min());
   if (int(line_marker->line().x1()) != x) {
     line_marker->setLine(x, 0, x, height());
-    chart()->update();
   }
 }
 
@@ -410,6 +409,7 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
   } else {
     QGraphicsView::mouseReleaseEvent(event);
   }
+  setViewportUpdateMode(QGraphicsView::MinimalViewportUpdate);
 }
 
 void ChartView::mouseMoveEvent(QMouseEvent *ev) {
@@ -436,6 +436,8 @@ void ChartView::mouseMoveEvent(QMouseEvent *ev) {
     track_line->setVisible(value != vals.end());
     value_text->setVisible(value != vals.end());
     track_ellipse->setVisible(value != vals.end());
+  } else {
+    setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
   }
   QChartView::mouseMoveEvent(ev);
 }


### PR DESCRIPTION
the chart->update() is used to erase the line marker's background when the rubber band is visible. (chart::paint will repaint the line series, this consumes a lot of cpu time).

it's extremely slow compared  to set viewportUpdateMode to FullViewportUpdate  and let qchartview update the viewport when the rubber band is visible, and switch back to MinimalViewportUpdate after mouse released:
https://codebrowser.dev/qt5/qtbase/src/widgets/graphicsview/qgraphicsview.cpp.html#777
>     // Update new rubberband
>     if (viewportUpdateMode != QGraphicsView::NoViewportUpdate) {
>         if (viewportUpdateMode != QGraphicsView::FullViewportUpdate)
>             q->viewport()->update(rubberBandRegion(q->viewport(), rubberBandRect));
>         else
>             updateAll();
>     }
> 
