### PR TITLE
ui: toggle confirmation and dialog redesign

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -69,7 +69,7 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
       tr("🌮 End-to-end longitudinal (extremely alpha) 🌮"),
       "Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.",
       "../assets/offroad/icon_road.png",
-      true,
+      false,
     },
     {
       "ExperimentalLongitudinalEnabled",

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -189,7 +189,7 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
     auto regulatoryBtn = new ButtonControl(tr("Regulatory"), tr("VIEW"), "");
     connect(regulatoryBtn, &ButtonControl::clicked, [=]() {
       const std::string txt = util::read_file("../assets/offroad/fcc.html");
-      RichTextDialog::alert(QString::fromStdString(txt), this);
+      ConfirmationDialog::rich(QString::fromStdString(txt), this);
     });
     addItem(regulatoryBtn);
   }

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -27,49 +27,56 @@
 #include "selfdrive/ui/qt/widgets/input.h"
 
 TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
-  // param, title, desc, icon
-  std::vector<std::tuple<QString, QString, QString, QString>> toggle_defs{
+  // param, title, desc, icon, confirm
+  std::vector<std::tuple<QString, QString, QString, QString, bool>> toggle_defs{
     {
       "OpenpilotEnabledToggle",
       tr("Enable openpilot"),
       tr("Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off."),
       "../assets/offroad/icon_openpilot.png",
+      false,
     },
     {
       "IsLdwEnabled",
       tr("Enable Lane Departure Warnings"),
       tr("Receive alerts to steer back into the lane when your vehicle drifts over a detected lane line without a turn signal activated while driving over 31 mph (50 km/h)."),
       "../assets/offroad/icon_warning.png",
+      false,
     },
     {
       "IsMetric",
       tr("Use Metric System"),
       tr("Display speed in km/h instead of mph."),
       "../assets/offroad/icon_metric.png",
+      false,
     },
     {
       "RecordFront",
       tr("Record and Upload Driver Camera"),
       tr("Upload data from the driver facing camera and help improve the driver monitoring algorithm."),
       "../assets/offroad/icon_monitoring.png",
+      false,
     },
     {
       "DisengageOnAccelerator",
       tr("Disengage On Accelerator Pedal"),
       tr("When enabled, pressing the accelerator pedal will disengage openpilot."),
       "../assets/offroad/icon_disengage_on_accelerator.svg",
+      false,
     },
     {
       "EndToEndLong",
       tr("🌮 End-to-end longitudinal (extremely alpha) 🌮"),
-      "",
+      "Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.",
       "../assets/offroad/icon_road.png",
+      true,
     },
     {
       "ExperimentalLongitudinalEnabled",
       tr("Experimental openpilot longitudinal control"),
       tr("<b>WARNING: openpilot longitudinal control is experimental for this car and will disable AEB.</b>"),
       "../assets/offroad/icon_speed_limit.png",
+      true,
     },
 #ifdef ENABLE_MAPS
     {
@@ -77,19 +84,20 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
       tr("Show ETA in 24h Format"),
       tr("Use 24h format instead of am/pm"),
       "../assets/offroad/icon_metric.png",
+      false,
     },
     {
       "NavSettingLeftSide",
       tr("Show Map on Left Side of UI"),
       tr("Show map on left side when in split screen view."),
       "../assets/offroad/icon_road.png",
+      false,
     },
 #endif
-
   };
 
-  for (auto &[param, title, desc, icon] : toggle_defs) {
-    auto toggle = new ParamControl(param, title, desc, icon, this);
+  for (auto &[param, title, desc, icon, confirm] : toggle_defs) {
+    auto toggle = new ParamControl(param, title, desc, icon, confirm, this);
 
     bool locked = params.getBool((param + "Lock").toStdString());
     toggle->setEnabled(!locked);

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -67,7 +67,7 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
     {
       "EndToEndLong",
       tr("🌮 End-to-end longitudinal (extremely alpha) 🌮"),
-      "Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would. Super experimental.",
+      "",
       "../assets/offroad/icon_road.png",
       false,
     },

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -143,8 +143,7 @@ public:
     key = param.toStdString();
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
       QString content("<body><h2>" + title + "</h2>"
-                      "<p>" + getDescription() + "</p><br/>"
-                      "<p><strong>" + tr("Are you sure you want to enable this toggle?") + "</strong></p></body>");
+                      "<p>" + getDescription() + "</p></body>");
       if (!confirm || !state || RichTextDialog::confirm(content, this)) {
         params.putBool(key, state);
       } else {

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -142,8 +142,8 @@ public:
   ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, const bool confirm, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
     key = param.toStdString();
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
-      QString content("<body><br/><h2>" + title + "</h2><br/>"
-                      "<p>" + getDescription() + "</p></body>");
+      QString content("<body><h2>" + title + "</h2><br><br>"
+                      "<p style=\"text-align: center; margin: 0 128px;\">" + getDescription() + "</p></body>");
       ConfirmationDialog dialog(content, tr("Ok"), tr("Cancel"), true, this);
       if (!confirm || !state || dialog.exec()) {
         params.putBool(key, state);

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -142,8 +142,7 @@ public:
   ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, const bool confirm, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
     key = param.toStdString();
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
-      QString content("<body><br/><br/><br/>"
-                      "<h2>" + title + "</h2><br/>"
+      QString content("<body><br/><h2>" + title + "</h2><br/>"
                       "<p>" + getDescription() + "</p></body>");
       ConfirmationDialog dialog(content, tr("Ok"), tr("Cancel"), true, this);
       if (!confirm || !state || dialog.exec()) {

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -144,7 +144,8 @@ public:
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
       QString content("<body><h2>" + title + "</h2>"
                       "<p>" + getDescription() + "</p></body>");
-      if (!confirm || !state || RichTextDialog::confirm(content, this)) {
+      ConfirmationDialog dialog(content, tr("Ok"), tr("Cancel"), true, this);
+      if (!confirm || !state || dialog.exec()) {
         params.putBool(key, state);
       } else {
         toggle.togglePosition();

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -137,7 +137,7 @@ class ParamControl : public ToggleControl {
 public:
   ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, const bool confirm, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
     key = param.toStdString();
-    QString content("<body><h2>" + title + "</h2><p>" + desc + "</p><br/><p><strong>" + tr("Are you sure?") + "</strong></p></body>");
+    QString content("<body><h2>" + title + "</h2><p>" + desc + "</p><br/><p><strong>" + tr("Are you sure you want to enable this toggle?") + "</strong></p></body>");
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
       if (!confirm || !state || RichTextDialog::confirm(content, this)) {
         params.putBool(key, state);

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -50,6 +50,10 @@ public:
     value->setText(val);
   }
 
+  const QString getDescription() {
+    return description->text();
+  }
+
 public slots:
   void showDescription() {
     description->setVisible(true);
@@ -137,8 +141,10 @@ class ParamControl : public ToggleControl {
 public:
   ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, const bool confirm, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
     key = param.toStdString();
-    QString content("<body><h2>" + title + "</h2><p>" + desc + "</p><br/><p><strong>" + tr("Are you sure you want to enable this toggle?") + "</strong></p></body>");
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
+      QString content("<body><h2>" + title + "</h2>"
+                      "<p>" + getDescription() + "</p><br/>"
+                      "<p><strong>" + tr("Are you sure you want to enable this toggle?") + "</strong></p></body>");
       if (!confirm || !state || RichTextDialog::confirm(content, this)) {
         params.putBool(key, state);
       } else {

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -7,6 +7,7 @@
 #include <QPushButton>
 
 #include "common/params.h"
+#include "selfdrive/ui/qt/widgets/input.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
 
 QFrame *horizontal_line(QWidget *parent = nullptr);
@@ -134,10 +135,15 @@ class ParamControl : public ToggleControl {
   Q_OBJECT
 
 public:
-  ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
+  ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, const bool confirm, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
     key = param.toStdString();
+    QString content("<body><h2>" + title + "</h2><p>" + desc + "</p><br/><p><strong>" + tr("Are you sure?") + "</strong></p></body>");
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
-      params.putBool(key, state);
+      if (!confirm || !state || RichTextDialog::confirm(content, this)) {
+        params.putBool(key, state);
+      } else {
+        toggle.togglePosition();
+      }
     });
   }
 

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -142,7 +142,8 @@ public:
   ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, const bool confirm, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
     key = param.toStdString();
     QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
-      QString content("<body><h2>" + title + "</h2>"
+      QString content("<body><br/><br/><br/>"
+                      "<h2>" + title + "</h2><br/>"
                       "<p>" + getDescription() + "</p></body>");
       ConfirmationDialog dialog(content, tr("Ok"), tr("Cancel"), true, this);
       if (!confirm || !state || dialog.exec()) {

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -230,7 +230,7 @@ bool ConfirmationDialog::confirm(const QString &prompt_text, QWidget *parent) {
 
 // RichTextDialog
 
-RichTextDialog::RichTextDialog(const QString &prompt_text, const QString &btn_text,
+RichTextDialog::RichTextDialog(const QString &prompt_text, const QString &confirm_text, const QString &cancel_text,
                                QWidget *parent) : QDialogBase(parent) {
   QFrame *container = new QFrame(this);
   container->setStyleSheet("QFrame { background-color: #1B1B1B; }");
@@ -244,10 +244,22 @@ RichTextDialog::RichTextDialog(const QString &prompt_text, const QString &btn_te
   prompt->setStyleSheet("font-size: 42px; font-weight: light; color: #C9C9C9; margin: 45px;");
   main_layout->addWidget(new ScrollView(prompt, this), 1, Qt::AlignTop);
 
-  // confirm button
-  QPushButton* confirm_btn = new QPushButton(btn_text);
-  main_layout->addWidget(confirm_btn);
-  QObject::connect(confirm_btn, &QPushButton::clicked, this, &QDialog::accept);
+  // cancel + confirm buttons
+  QHBoxLayout *btn_layout = new QHBoxLayout();
+  btn_layout->setSpacing(30);
+  main_layout->addLayout(btn_layout);
+
+  if (cancel_text.length()) {
+    QPushButton* cancel_btn = new QPushButton(cancel_text);
+    btn_layout->addWidget(cancel_btn);
+    QObject::connect(cancel_btn, &QPushButton::clicked, this, &QDialog::reject);
+  }
+
+  if (confirm_text.length()) {
+    QPushButton* confirm_btn = new QPushButton(confirm_text);
+    btn_layout->addWidget(confirm_btn);
+    QObject::connect(confirm_btn, &QPushButton::clicked, this, &QDialog::accept);
+  }
 
   QVBoxLayout *outer_layout = new QVBoxLayout(this);
   outer_layout->setContentsMargins(100, 100, 100, 100);
@@ -255,7 +267,12 @@ RichTextDialog::RichTextDialog(const QString &prompt_text, const QString &btn_te
 }
 
 bool RichTextDialog::alert(const QString &prompt_text, QWidget *parent) {
-  auto d = RichTextDialog(prompt_text, tr("Ok"), parent);
+  auto d = RichTextDialog(prompt_text, tr("Ok"), "", parent);
+  return d.exec();
+}
+
+bool RichTextDialog::confirm(const QString &prompt_text, QWidget *parent) {
+  auto d = RichTextDialog(prompt_text, tr("Ok"), tr("Cancel"), parent);
   return d.exec();
 }
 

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -192,8 +192,8 @@ ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString
   QLabel *prompt = new QLabel(prompt_text, this);
   prompt->setWordWrap(true);
   prompt->setAlignment(rich ? Qt::AlignLeft : Qt::AlignHCenter);
-  prompt->setStyleSheet(rich ? "font-size: 42px; font-weight: light;" : "font-size: 70px; font-weight: bold;");
-  main_layout->addWidget(new ScrollView(prompt, this), 1, Qt::AlignTop);
+  prompt->setStyleSheet((rich ? "font-size: 42px; font-weight: light;" : "font-size: 70px; font-weight: bold;") + QString(" margin: 45px;"));
+  main_layout->addWidget(rich ? (QWidget*)new ScrollView(prompt, this) : (QWidget*)prompt, 1, Qt::AlignTop);
 
   // cancel + confirm buttons
   QHBoxLayout *btn_layout = new QHBoxLayout();
@@ -213,7 +213,7 @@ ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString
   }
 
   QVBoxLayout *outer_layout = new QVBoxLayout(this);
-  int margin = rich ? 100 : 190;
+  int margin = rich ? 100 : 200;
   outer_layout->setContentsMargins(margin, margin, margin, margin);
   outer_layout->addWidget(container);
 }

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -183,17 +183,17 @@ void InputDialog::setMinLength(int length) {
 // ConfirmationDialog
 
 ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString &confirm_text, const QString &cancel_text,
-                                       QWidget *parent) : QDialogBase(parent) {
+                                       const bool rich, QWidget *parent) : QDialogBase(parent) {
   QFrame *container = new QFrame(this);
-  container->setStyleSheet("QFrame { border-radius: 0; background-color: #ECECEC; }");
+  container->setStyleSheet("QFrame { background-color: #1B1B1B; }");
   QVBoxLayout *main_layout = new QVBoxLayout(container);
-  main_layout->setContentsMargins(32, 120, 32, 32);
+  main_layout->setContentsMargins(32, rich ? 32 : 120, 32, 32);
 
   QLabel *prompt = new QLabel(prompt_text, this);
   prompt->setWordWrap(true);
-  prompt->setAlignment(Qt::AlignHCenter);
-  prompt->setStyleSheet("font-size: 70px; font-weight: bold; color: black;");
-  main_layout->addWidget(prompt, 1, Qt::AlignTop | Qt::AlignHCenter);
+  prompt->setAlignment(rich ? Qt::AlignLeft : Qt::AlignHCenter);
+  prompt->setStyleSheet(rich ? "font-size: 42px; font-weight: light;" : "font-size: 70px; font-weight: bold;");
+  main_layout->addWidget(new ScrollView(prompt, this), 1, Qt::AlignTop);
 
   // cancel + confirm buttons
   QHBoxLayout *btn_layout = new QHBoxLayout();
@@ -213,66 +213,23 @@ ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString
   }
 
   QVBoxLayout *outer_layout = new QVBoxLayout(this);
-  outer_layout->setContentsMargins(210, 170, 210, 170);
+  int margin = rich ? 100 : 190;
+  outer_layout->setContentsMargins(margin, margin, margin, margin);
   outer_layout->addWidget(container);
 }
 
 bool ConfirmationDialog::alert(const QString &prompt_text, QWidget *parent) {
-  ConfirmationDialog d = ConfirmationDialog(prompt_text, tr("Ok"), "", parent);
+  ConfirmationDialog d = ConfirmationDialog(prompt_text, tr("Ok"), "", false, parent);
   return d.exec();
 }
 
 bool ConfirmationDialog::confirm(const QString &prompt_text, QWidget *parent) {
-  ConfirmationDialog d = ConfirmationDialog(prompt_text, tr("Ok"), tr("Cancel"), parent);
+  ConfirmationDialog d = ConfirmationDialog(prompt_text, tr("Ok"), tr("Cancel"), false, parent);
   return d.exec();
 }
 
-
-// RichTextDialog
-
-RichTextDialog::RichTextDialog(const QString &prompt_text, const QString &confirm_text, const QString &cancel_text,
-                               QWidget *parent) : QDialogBase(parent) {
-  QFrame *container = new QFrame(this);
-  container->setStyleSheet("QFrame { background-color: #1B1B1B; }");
-  QVBoxLayout *main_layout = new QVBoxLayout(container);
-  main_layout->setContentsMargins(32, 32, 32, 32);
-
-  QLabel *prompt = new QLabel(prompt_text, this);
-  prompt->setWordWrap(true);
-  prompt->setAlignment(Qt::AlignLeft);
-  prompt->setTextFormat(Qt::RichText);
-  prompt->setStyleSheet("font-size: 42px; font-weight: light; color: #C9C9C9; margin: 45px;");
-  main_layout->addWidget(new ScrollView(prompt, this), 1, Qt::AlignTop);
-
-  // cancel + confirm buttons
-  QHBoxLayout *btn_layout = new QHBoxLayout();
-  btn_layout->setSpacing(30);
-  main_layout->addLayout(btn_layout);
-
-  if (cancel_text.length()) {
-    QPushButton* cancel_btn = new QPushButton(cancel_text);
-    btn_layout->addWidget(cancel_btn);
-    QObject::connect(cancel_btn, &QPushButton::clicked, this, &QDialog::reject);
-  }
-
-  if (confirm_text.length()) {
-    QPushButton* confirm_btn = new QPushButton(confirm_text);
-    btn_layout->addWidget(confirm_btn);
-    QObject::connect(confirm_btn, &QPushButton::clicked, this, &QDialog::accept);
-  }
-
-  QVBoxLayout *outer_layout = new QVBoxLayout(this);
-  outer_layout->setContentsMargins(100, 100, 100, 100);
-  outer_layout->addWidget(container);
-}
-
-bool RichTextDialog::alert(const QString &prompt_text, QWidget *parent) {
-  auto d = RichTextDialog(prompt_text, tr("Ok"), "", parent);
-  return d.exec();
-}
-
-bool RichTextDialog::confirm(const QString &prompt_text, QWidget *parent) {
-  auto d = RichTextDialog(prompt_text, tr("Ok"), tr("Cancel"), parent);
+bool ConfirmationDialog::rich(const QString &prompt_text, QWidget *parent) {
+  ConfirmationDialog d = ConfirmationDialog(prompt_text, tr("Ok"), "", true, parent);
   return d.exec();
 }
 

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -185,7 +185,7 @@ void InputDialog::setMinLength(int length) {
 ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString &confirm_text, const QString &cancel_text,
                                        const bool rich, QWidget *parent) : QDialogBase(parent) {
   QFrame *container = new QFrame(this);
-  container->setStyleSheet("QFrame { background-color: #1B1B1B; }");
+  container->setStyleSheet("QFrame { background-color: #1B1B1B; color: #C9C9C9; }");
   QVBoxLayout *main_layout = new QVBoxLayout(container);
   main_layout->setContentsMargins(32, rich ? 32 : 120, 32, 32);
 

--- a/selfdrive/ui/qt/widgets/input.h
+++ b/selfdrive/ui/qt/widgets/input.h
@@ -65,8 +65,10 @@ class RichTextDialog : public QDialogBase {
   Q_OBJECT
 
 public:
-  explicit RichTextDialog(const QString &prompt_text, const QString &btn_text, QWidget* parent);
+  explicit RichTextDialog(const QString &prompt_text, const QString &confirm_text,
+                          const QString &cancel_text, QWidget* parent);
   static bool alert(const QString &prompt_text, QWidget *parent);
+  static bool confirm(const QString &prompt_text, QWidget *parent);
 };
 
 class MultiOptionDialog : public QDialogBase {

--- a/selfdrive/ui/qt/widgets/input.h
+++ b/selfdrive/ui/qt/widgets/input.h
@@ -55,20 +55,10 @@ class ConfirmationDialog : public QDialogBase {
 
 public:
   explicit ConfirmationDialog(const QString &prompt_text, const QString &confirm_text,
-                              const QString &cancel_text, QWidget* parent);
+                              const QString &cancel_text, const bool rich, QWidget* parent);
   static bool alert(const QString &prompt_text, QWidget *parent);
   static bool confirm(const QString &prompt_text, QWidget *parent);
-};
-
-// larger ConfirmationDialog for rich text
-class RichTextDialog : public QDialogBase {
-  Q_OBJECT
-
-public:
-  explicit RichTextDialog(const QString &prompt_text, const QString &confirm_text,
-                          const QString &cancel_text, QWidget* parent);
-  static bool alert(const QString &prompt_text, QWidget *parent);
-  static bool confirm(const QString &prompt_text, QWidget *parent);
+  static bool rich(const QString &prompt_text, QWidget *parent);
 };
 
 class MultiOptionDialog : public QDialogBase {

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -464,6 +464,13 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -590,6 +597,10 @@ location set</source>
     <message>
         <source>Ok</source>
         <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -464,6 +464,17 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Ok</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -583,17 +594,6 @@ location set</source>
     <message>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>「data」パーティションをマウントできません。「確認」ボタンを押すとデバイスが初期化されます。</translation>
-    </message>
-</context>
-<context>
-    <name>RichTextDialog</name>
-    <message>
-        <source>Ok</source>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">キャンセル</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -464,13 +464,6 @@ location set</source>
     </message>
 </context>
 <context>
-    <name>ParamControl</name>
-    <message>
-        <source>Are you sure you want to enable this toggle?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -466,7 +466,7 @@ location set</source>
 <context>
     <name>ParamControl</name>
     <message>
-        <source>Are you sure?</source>
+        <source>Are you sure you want to enable this toggle?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -464,6 +464,17 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Ok</source>
+        <translation type="unfinished">확인</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -583,17 +594,6 @@ location set</source>
     <message>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>데이터 파티션을 마운트할 수 없습니다. 확인 버튼을 눌러 장치를 리셋합니다.</translation>
-    </message>
-</context>
-<context>
-    <name>RichTextDialog</name>
-    <message>
-        <source>Ok</source>
-        <translation>확인</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">취소</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -464,13 +464,6 @@ location set</source>
     </message>
 </context>
 <context>
-    <name>ParamControl</name>
-    <message>
-        <source>Are you sure you want to enable this toggle?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -466,7 +466,7 @@ location set</source>
 <context>
     <name>ParamControl</name>
     <message>
-        <source>Are you sure?</source>
+        <source>Are you sure you want to enable this toggle?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -464,6 +464,13 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -590,6 +597,10 @@ location set</source>
     <message>
         <source>Ok</source>
         <translation>확인</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -465,13 +465,6 @@ trabalho definido</translation>
     </message>
 </context>
 <context>
-    <name>ParamControl</name>
-    <message>
-        <source>Are you sure you want to enable this toggle?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -465,6 +465,17 @@ trabalho definido</translation>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Ok</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -587,17 +598,6 @@ trabalho definido</translation>
     <message>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>Não foi possível montar a partição de dados. Pressione confirmar para resetar seu dispositivo.</translation>
-    </message>
-</context>
-<context>
-    <name>RichTextDialog</name>
-    <message>
-        <source>Ok</source>
-        <translation>Ok</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">Cancelar</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -467,7 +467,7 @@ trabalho definido</translation>
 <context>
     <name>ParamControl</name>
     <message>
-        <source>Are you sure?</source>
+        <source>Are you sure you want to enable this toggle?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -465,6 +465,13 @@ trabalho definido</translation>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -594,6 +601,10 @@ trabalho definido</translation>
     <message>
         <source>Ok</source>
         <translation>Ok</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -462,13 +462,6 @@ location set</source>
     </message>
 </context>
 <context>
-    <name>ParamControl</name>
-    <message>
-        <source>Are you sure you want to enable this toggle?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -462,6 +462,13 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -588,6 +595,10 @@ location set</source>
     <message>
         <source>Ok</source>
         <translation>好的</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -462,6 +462,17 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Ok</source>
+        <translation type="unfinished">好的</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -581,17 +592,6 @@ location set</source>
     <message>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>无法挂载数据分区。 确认以重置您的设备。</translation>
-    </message>
-</context>
-<context>
-    <name>RichTextDialog</name>
-    <message>
-        <source>Ok</source>
-        <translation>好的</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -464,7 +464,7 @@ location set</source>
 <context>
     <name>ParamControl</name>
     <message>
-        <source>Are you sure?</source>
+        <source>Are you sure you want to enable this toggle?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -464,13 +464,6 @@ location set</source>
     </message>
 </context>
 <context>
-    <name>ParamControl</name>
-    <message>
-        <source>Are you sure you want to enable this toggle?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -466,7 +466,7 @@ location set</source>
 <context>
     <name>ParamControl</name>
     <message>
-        <source>Are you sure?</source>
+        <source>Are you sure you want to enable this toggle?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -464,6 +464,13 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -590,6 +597,10 @@ location set</source>
     <message>
         <source>Ok</source>
         <translation>確定</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -464,6 +464,17 @@ location set</source>
     </message>
 </context>
 <context>
+    <name>ParamControl</name>
+    <message>
+        <source>Ok</source>
+        <translation type="unfinished">確定</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
     <name>PrimeAdWidget</name>
     <message>
         <source>Upgrade Now</source>
@@ -583,17 +594,6 @@ location set</source>
     <message>
         <source>Unable to mount data partition. Press confirm to reset your device.</source>
         <translation>無法掛載數據分區。請按確認重置您的設備。</translation>
-    </message>
-</context>
-<context>
-    <name>RichTextDialog</name>
-    <message>
-        <source>Ok</source>
-        <translation>確定</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Show confirmation dialog for toggling experimental long:
![Screenshot from 2022-11-03 17-30-03](https://user-images.githubusercontent.com/4038174/199865696-18e97d8f-744e-4011-a1fe-ea658a0dfb71.png)


- The param isn't written until the user confirms, and the toggle is switched back if they cancel
- Also updates the ConfirmationDialog style (no more white dialogs)

Other dialogs:
|Dialog|New|Old|
|---|---|---|
|Training guide|![Screenshot from 2022-11-02 17-43-46](https://user-images.githubusercontent.com/4038174/199628126-1ab76be2-dea0-477b-94ba-2aaa72dca35b.png)|![Screenshot from 2022-11-02 17-26-52](https://user-images.githubusercontent.com/4038174/199626603-5b6d9769-cd19-4ec7-a3ca-c6dc9e323ac7.png)|
|Reset calibration|![Screenshot from 2022-11-02 17-43-43](https://user-images.githubusercontent.com/4038174/199628134-bfe35836-f0cf-4419-994a-e918fa4e1f48.png)|![Screenshot from 2022-11-02 17-27-29](https://user-images.githubusercontent.com/4038174/199626652-58cd7006-b469-4e3b-9d9d-880b06450f17.png)|
|Reboot|![Screenshot from 2022-11-02 17-46-04](https://user-images.githubusercontent.com/4038174/199628318-e66523e8-03e8-4990-a464-3f251d5f1ef1.png)|![Screenshot from 2022-11-02 17-46-11](https://user-images.githubusercontent.com/4038174/199628324-ba85a1a7-01e3-4141-a364-6d51e7a6bae8.png)|
|SSH Key|![Screenshot from 2022-11-02 17-47-30](https://user-images.githubusercontent.com/4038174/199628441-6eb42b6c-8928-4acb-be38-989766cb79a2.png)|![Screenshot from 2022-11-02 17-47-15](https://user-images.githubusercontent.com/4038174/199628437-8b1c3649-0a7b-405b-a1e2-911d6128cc56.png)|
|Regulatory (no change)|![Screenshot from 2022-11-02 17-32-07](https://user-images.githubusercontent.com/4038174/199627026-5bb81923-1591-4ef2-b6a8-01d511e9e4c9.png)||
|Branch switcher (no change)|![Screenshot from 2022-11-03 18-41-42](https://user-images.githubusercontent.com/4038174/199867010-8dcd17c4-f7db-458c-bdc5-36dcf315b234.png)||
