### PR TITLE
locationd: add gps sanity check for quectel gps

### DIFF
--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -267,7 +267,7 @@ void Localizer::handle_gps(double current_time, const cereal::GpsLocationData::R
   bool gps_invalid_flag = (log.getFlags() % 2 == 0);
   bool gps_unreasonable = (Vector2d(log.getAccuracy(), log.getVerticalAccuracy()).norm() >= SANE_GPS_UNCERTAINTY);
   bool gps_accuracy_insane = ((log.getVerticalAccuracy() <= 0) || (log.getSpeedAccuracy() <= 0) || (log.getBearingAccuracyDeg() <= 0));
-  bool gps_accuracy_insane_quectel = (log.getAccuracy() == 0) && (log.getVerticalAccuracy() == 500);
+  bool gps_accuracy_insane_quectel = log.getVerticalAccuracy() >= 500;
   bool gps_lat_lng_alt_insane = ((std::abs(log.getLatitude()) > 90) || (std::abs(log.getLongitude()) > 180) || (std::abs(log.getAltitude()) > ALTITUDE_SANITY_CHECK));
   bool gps_vel_insane = (floatlist2vector(log.getVNED()).norm() > TRANS_SANITY_CHECK);
 

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -267,7 +267,7 @@ void Localizer::handle_gps(double current_time, const cereal::GpsLocationData::R
   bool gps_invalid_flag = (log.getFlags() % 2 == 0);
   bool gps_unreasonable = (Vector2d(log.getAccuracy(), log.getVerticalAccuracy()).norm() >= SANE_GPS_UNCERTAINTY);
   bool gps_accuracy_insane = ((log.getVerticalAccuracy() <= 0) || (log.getSpeedAccuracy() <= 0) || (log.getBearingAccuracyDeg() <= 0));
-  bool gps_accuracy_insane_quectel = log.getVerticalAccuracy() >= 500;
+  bool gps_accuracy_insane_quectel = log.getVerticalAccuracy() == 500;
   bool gps_lat_lng_alt_insane = ((std::abs(log.getLatitude()) > 90) || (std::abs(log.getLongitude()) > 180) || (std::abs(log.getAltitude()) > ALTITUDE_SANITY_CHECK));
   bool gps_vel_insane = (floatlist2vector(log.getVNED()).norm() > TRANS_SANITY_CHECK);
 

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -267,10 +267,11 @@ void Localizer::handle_gps(double current_time, const cereal::GpsLocationData::R
   bool gps_invalid_flag = (log.getFlags() % 2 == 0);
   bool gps_unreasonable = (Vector2d(log.getAccuracy(), log.getVerticalAccuracy()).norm() >= SANE_GPS_UNCERTAINTY);
   bool gps_accuracy_insane = ((log.getVerticalAccuracy() <= 0) || (log.getSpeedAccuracy() <= 0) || (log.getBearingAccuracyDeg() <= 0));
+  bool gps_accuracy_insane_quectel = (log.getAccuracy() == 0) && (log.getVerticalAccuracy() == 500);
   bool gps_lat_lng_alt_insane = ((std::abs(log.getLatitude()) > 90) || (std::abs(log.getLongitude()) > 180) || (std::abs(log.getAltitude()) > ALTITUDE_SANITY_CHECK));
   bool gps_vel_insane = (floatlist2vector(log.getVNED()).norm() > TRANS_SANITY_CHECK);
 
-  if (gps_invalid_flag || gps_unreasonable || gps_accuracy_insane || gps_lat_lng_alt_insane || gps_vel_insane) {
+  if (gps_invalid_flag || gps_unreasonable || gps_accuracy_insane || gps_lat_lng_alt_insane || gps_vel_insane || gps_accuracy_insane_quectel) {
     this->determine_gps_mode(current_time);
     return;
   }

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -272,7 +272,7 @@ void Localizer::handle_gps(double current_time, const cereal::GpsLocationData::R
 
   // quectel gps verticalAccuracy is clipped to 500
   bool gps_accuracy_insane_quectel = false;
-  if (!Params().getBool("UbloxAvailable", true)) {
+  if (!ublox_available) {
     gps_accuracy_insane_quectel = log.getVerticalAccuracy() == 500;
   }
 
@@ -502,8 +502,10 @@ void Localizer::determine_gps_mode(double current_time) {
 }
 
 int Localizer::locationd_thread() {
+
+  ublox_available = Params().getBool("UbloxAvailable", true);
   const char* gps_location_socket;
-  if (Params().getBool("UbloxAvailable", true)) {
+  if (ublox_available) {
     gps_location_socket = "gpsLocationExternal";
   } else {
     gps_location_socket = "gpsLocation";

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -504,8 +504,8 @@ void Localizer::determine_gps_mode(double current_time) {
 }
 
 int Localizer::locationd_thread() {
-
   ublox_available = Params().getBool("UbloxAvailable", true);
+
   const char* gps_location_socket;
   if (ublox_available) {
     gps_location_socket = "gpsLocationExternal";

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -277,6 +277,7 @@ void Localizer::handle_gps(double current_time, const cereal::GpsLocationData::R
   }
 
   if (gps_invalid_flag || gps_unreasonable || gps_accuracy_insane || gps_lat_lng_alt_insane || gps_vel_insane || gps_accuracy_insane_quectel) {
+    this->gps_valid = false;
     this->determine_gps_mode(current_time);
     return;
   }
@@ -284,6 +285,7 @@ void Localizer::handle_gps(double current_time, const cereal::GpsLocationData::R
   double sensor_time = current_time - sensor_time_offset;
 
   // Process message
+  this->gps_valid = true;
   this->gps_mode = true;
   Geodetic geodetic = { log.getLatitude(), log.getLongitude(), log.getAltitude() };
   this->converter = std::make_unique<LocalCoord>(geodetic);
@@ -482,7 +484,7 @@ kj::ArrayPtr<capnp::byte> Localizer::get_message_bytes(MessageBuilder& msg_build
 }
 
 bool Localizer::isGpsOK() {
-  return this->gps_mode;
+  return this->gps_valid;
 }
 
 void Localizer::determine_gps_mode(double current_time) {

--- a/selfdrive/locationd/locationd.h
+++ b/selfdrive/locationd/locationd.h
@@ -71,4 +71,5 @@ private:
   double reset_tracker = 0.0;
   bool device_fell = false;
   bool gps_mode = false;
+  bool ublox_available = true;
 };

--- a/selfdrive/locationd/locationd.h
+++ b/selfdrive/locationd/locationd.h
@@ -71,5 +71,6 @@ private:
   double reset_tracker = 0.0;
   bool device_fell = false;
   bool gps_mode = false;
+  bool gps_valid = false;
   bool ublox_available = true;
 };

--- a/selfdrive/locationd/locationd.h
+++ b/selfdrive/locationd/locationd.h
@@ -68,7 +68,6 @@ private:
   std::unique_ptr<LocalCoord> converter;
 
   int64_t unix_timestamp_millis = 0;
-  double last_gps_fix = 0;
   double reset_tracker = 0.0;
   bool device_fell = false;
   bool gps_mode = false;

--- a/selfdrive/test/process_replay/ref_commit
+++ b/selfdrive/test/process_replay/ref_commit
@@ -1,1 +1,1 @@
-01b24beff6855e8c4d2fb0efeeefafb46343e013
+6abe3ec1ee19710bdd89ce2882b9503d4aff8e7f


### PR DESCRIPTION
quectel gps verticalAccuracy is clipped to 500, and flags is always 1, so invalid values would pass, causing location
jumps

also the quectel gps returns values in a 1hz rate which causes gpsOK flickering due to the time limit of 1s,
as was seen in: `be13974ffe78aa72|2022-11-02--19-02-26--18`