### PR TITLE
ui: fix disappearing path in wide cam mode

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -380,13 +380,15 @@ void AnnotatedCameraWidget::drawHud(QPainter &p) {
   SubMaster &sm = *(s->sm);
   // TODO: handle controls unresponsive
   auto CC = sm["carControl"].getCarControl();
+  auto CS = sm["carState"].getCarState();
+
   int base_status = sm["controlsState"].getControlsState().getEnabled() ? STATUS_ENGAGED : STATUS_DISENGAGED;
-  int lat_status = (CC.getEnabled() && !CC.getLatActive()) ? STATUS_OVERRIDE : base_status;
+  int lat_status = (CC.getEnabled() && (!CC.getLatActive() || CS.getSteeringPressed())) ? STATUS_OVERRIDE : base_status;
+  int long_status = (CC.getEnabled() && !CC.getLongActive()) ? STATUS_OVERRIDE : base_status;
+
   drawIcon(p, rect().right() - radius / 2 - bdr_s * 2, radius / 2 + int(bdr_s * 1.5),
            steer_img, bg_colors[lat_status], 1.0);
-
-  int long_status = (CC.getEnabled() && !CC.getLongActive()) ? STATUS_OVERRIDE : base_status;
-  drawIcon(p, rect().right() - radius / 2 - bdr_s * 2, radius*2 + int(bdr_s * 1.5),
+  drawIcon(p, rect().right() - radius / 2 - bdr_s * 2, radius * 2 + int(bdr_s * 1.5),
            longitudinal_img, bg_colors[long_status], 1.0);
 
   // dm icon

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -469,6 +469,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
   }
 
   // paint path
+  qDebug() << std::size(scene.track_vertices);
   QLinearGradient bg(0, height(), 0, height() / 4);
   float start_hue, end_hue;
   if (scene.end_to_end_long) {
@@ -580,6 +581,7 @@ void AnnotatedCameraWidget::paintGL() {
     // TODO: also detect when ecam vision stream isn't available
     // for replay of old routes, never go to widecam
     wide_cam_requested = wide_cam_requested && s->scene.calibration_wide_valid;
+//    qDebug() << wide_cam_requested;
     CameraWidget::setStreamType(wide_cam_requested ? VISION_STREAM_WIDE_ROAD : VISION_STREAM_ROAD);
 
     s->scene.wide_cam = CameraWidget::getStreamType() == VISION_STREAM_WIDE_ROAD;
@@ -596,6 +598,8 @@ void AnnotatedCameraWidget::paintGL() {
   QPainter painter(this);
   painter.setRenderHint(QPainter::Antialiasing);
   painter.setPen(Qt::NoPen);
+
+//  qDebug() << s->worldObjectsVisible();
 
   if (s->worldObjectsVisible()) {
     if (sm.rcv_frame("modelV2") > s->scene.started_frame) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -376,20 +376,22 @@ void AnnotatedCameraWidget::drawHud(QPainter &p) {
   drawText(p, rect().center().x(), 290, speedUnit, 200);
 
   // lateral + longitudinal control icons
-  UIState *s = uiState();
-  SubMaster &sm = *(s->sm);
   // TODO: handle controls unresponsive
-  auto CC = sm["carControl"].getCarControl();
-  auto CS = sm["carState"].getCarState();
+  if (engageable) {
+    UIState *s = uiState();
+    SubMaster &sm = *(s->sm);
+    auto CC = sm["carControl"].getCarControl();
+    auto CS = sm["carState"].getCarState();
 
-  int base_status = sm["controlsState"].getControlsState().getEnabled() ? STATUS_ENGAGED : STATUS_DISENGAGED;
-  int lat_status = (CC.getEnabled() && (!CC.getLatActive() || CS.getSteeringPressed())) ? STATUS_OVERRIDE : base_status;
-  int long_status = (CC.getEnabled() && !CC.getLongActive()) ? STATUS_OVERRIDE : base_status;
+    int base_status = sm["controlsState"].getControlsState().getEnabled() ? STATUS_ENGAGED : STATUS_DISENGAGED;
+    int lat_status = (CC.getEnabled() && (!CC.getLatActive() || CS.getSteeringPressed())) ? STATUS_OVERRIDE : base_status;
+    int long_status = (CC.getEnabled() && !CC.getLongActive()) ? STATUS_OVERRIDE : base_status;
 
-  drawIcon(p, rect().right() - radius / 2 - bdr_s * 2, radius / 2 + int(bdr_s * 1.5),
-           steer_img, bg_colors[lat_status], 1.0);
-  drawIcon(p, rect().right() - radius / 2 - bdr_s * 2, radius * 2 + int(bdr_s * 1.5),
-           longitudinal_img, bg_colors[long_status], 1.0);
+    drawIcon(p, rect().right() - radius / 2 - bdr_s * 2, radius / 2 + int(bdr_s * 1.5),
+             steer_img, bg_colors[lat_status], 1.0);
+    drawIcon(p, rect().right() - radius / 2 - bdr_s * 2, radius * 2 + int(bdr_s * 1.5),
+             longitudinal_img, bg_colors[long_status], 1.0);
+  }
 
   // dm icon
   if (!hideDM) {

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -50,7 +50,8 @@ private:
   void drawIcon(QPainter &p, int x, int y, QPixmap &img, QBrush bg, float opacity);
   void drawText(QPainter &p, int x, int y, const QString &text, int alpha = 255);
 
-  QPixmap engage_img;
+  QPixmap steer_img;
+  QPixmap longitudinal_img;
   QPixmap dm_img;
   const int radius = 192;
   const int img_size = (radius / 2) * 1.5;

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -151,11 +151,17 @@ QWidget* topWidget (QWidget* widget) {
 }
 
 QPixmap loadPixmap(const QString &fileName, const QSize &size, Qt::AspectRatioMode aspectRatioMode) {
-  if (size.isEmpty()) {
-    return QPixmap(fileName);
+  QPixmap p;
+  if (fileName.endsWith(".svg")) {
+    p = QIcon(fileName).pixmap(size);
   } else {
-    return QPixmap(fileName).scaled(size, aspectRatioMode, Qt::SmoothTransformation);
+    p = QPixmap(fileName);
   }
+
+  if (!size.isEmpty()) {
+    p = p.scaled(size, aspectRatioMode, Qt::SmoothTransformation);
+  }
+  return p;
 }
 
 QRect getTextRect(QPainter &p, int flags, const QString &text) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -212,7 +212,7 @@ void UIState::updateStatus() {
 
 UIState::UIState(QObject *parent) : QObject(parent) {
   sm = std::make_unique<SubMaster, const std::initializer_list<const char *>>({
-    "modelV2", "controlsState", "liveCalibration", "radarState", "deviceState", "roadCameraState",
+    "modelV2", "carControl", "controlsState", "liveCalibration", "radarState", "deviceState", "roadCameraState",
     "pandaStates", "carParams", "driverMonitoringState", "carState", "liveLocationKalman",
     "wideRoadCameraState", "managerState", "navInstruction", "navRoute", "gnssMeasurements",
   });

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -179,13 +179,10 @@ void UIState::updateStatus() {
   if (scene.started && sm->updated("controlsState")) {
     auto controls_state = (*sm)["controlsState"].getControlsState();
     auto alert_status = controls_state.getAlertStatus();
-    auto state = controls_state.getState();
     if (alert_status == cereal::ControlsState::AlertStatus::USER_PROMPT) {
       status = STATUS_WARNING;
     } else if (alert_status == cereal::ControlsState::AlertStatus::CRITICAL) {
       status = STATUS_ALERT;
-    } else if (state == cereal::ControlsState::OpenpilotState::PRE_ENABLED || state == cereal::ControlsState::OpenpilotState::OVERRIDING) {
-      status = STATUS_OVERRIDE;
     } else {
       status = controls_state.getEnabled() ? STATUS_ENGAGED : STATUS_DISENGAGED;
     }


### PR DESCRIPTION
The function that converts the 3D xyz points into xy screen coords has a check to make sure all points fall within the screen boundaries + some margin (so that there's no gaps on the bottom or top).

https://github.com/commaai/openpilot/blob/9a8c7f2453bcb917eb428704c1733f28e5d42d11/selfdrive/ui/ui.cc#L21-L36

In narrow mode, this filters out points that are behind the camera (model predicts x positions upwards of -2 meters sometimes) as the screen coordinates are really high. However, in wide cam mode, these coords are not so high, causing the first few polygon xy points to be above the screen.

Then since `allow_invert=False` with the path, we skip most (if not all) points, as the points will of course all be below the top of the screen.

https://github.com/commaai/openpilot/blob/9a8c7f2453bcb917eb428704c1733f28e5d42d11/selfdrive/ui/ui.cc#L61-L75

Now we clip the incoming model x to under the camera. In wide cam mode, xyz points aren't within the screen boundaries + margin until around 1.3 m, and narrow is even further.