### PR TITLE
Subaru: add missing engine FW for 2019 Impreza

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -196,6 +196,7 @@ FW_VERSIONS = {
       b'\xaa!dt\a',
       b'\xc5!ar\a',
       b'\xbe!as\a',
+      b'\xc5!as\x07',
       b'\xc5!ds\a',
       b'\xc5!`s\a',
       b'\xaa!au\a',


### PR DESCRIPTION
Added 2019 Subaru Impreza ECU to enable vehicle recognition. Tested on fork of open pilot master on 11/4.

Validation done on successful drive with fork.

**Route**
Route: 78c45ff47fdd934b|2022-11-04--18-34-57