### PR TITLE
Cabana: move dbc related code from MessagesWidget to MainWin

### DIFF
--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <QComboBox>
+#include <QDialog>
+#include <QJsonDocument>
 #include <QProgressBar>
 #include <QSplitter>
 #include <QStatusBar>
+#include <QTextEdit>
 
 #include "tools/cabana/chartswidget.h"
 #include "tools/cabana/detailwidget.h"
@@ -16,6 +20,12 @@ public:
   MainWindow();
   void dockCharts(bool dock);
   void showStatusMessage(const QString &msg, int timeout = 0) { status_bar->showMessage(msg, timeout); }
+
+public slots:
+  void loadDBCFromName(const QString &name);
+  void loadDBCFromFingerprint();
+  void loadDBCFromPaste();
+  void saveDBC();
 
 signals:
   void showMessage(const QString &msg, int timeout);
@@ -35,4 +45,25 @@ protected:
   QVBoxLayout *r_layout;
   QProgressBar *progress_bar;
   QStatusBar *status_bar;
+  QJsonDocument fingerprint_to_dbc;
+  QComboBox *dbc_combo;
+};
+
+
+class LoadDBCDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  LoadDBCDialog(QWidget *parent);
+  QTextEdit *dbc_edit;
+};
+
+class SaveDBCDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  SaveDBCDialog(QWidget *parent);
+  void copytoClipboard();
+  void saveAs();
+  QTextEdit *dbc_edit;
 };

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -1,32 +1,9 @@
 #pragma once
 
 #include <QAbstractTableModel>
-#include <QComboBox>
-#include <QDialog>
-#include <QJsonDocument>
 #include <QTableView>
-#include <QTextEdit>
 
 #include "tools/cabana/canmessages.h"
-
-class LoadDBCDialog : public QDialog {
-  Q_OBJECT
-
-public:
-  LoadDBCDialog(QWidget *parent);
-  QTextEdit *dbc_edit;
-};
-
-class SaveDBCDialog : public QDialog {
-  Q_OBJECT
-
-public:
-  SaveDBCDialog(QWidget *parent);
-  void copytoClipboard();
-  void saveAs();
-  QTextEdit *dbc_edit;
-};
-
 class MessageListModel : public QAbstractTableModel {
 Q_OBJECT
 
@@ -58,18 +35,10 @@ class MessagesWidget : public QWidget {
 public:
   MessagesWidget(QWidget *parent);
 
-public slots:
-  void loadDBCFromName(const QString &name);
-  void loadDBCFromFingerprint();
-  void loadDBCFromPaste();
-  void saveDBC();
-
 signals:
   void msgSelectionChanged(const QString &message_id);
 
 protected:
   QTableView *table_widget;
-  QComboBox *dbc_combo;
   MessageListModel *model;
-  QJsonDocument fingerprint_to_dbc;
 };


### PR DESCRIPTION
MessagesWidget should only be responsible for displaying the message table. 
Move dbc related code (load, save, paste) to MainWin, We can also easily add these functions to the mainwin menu in the future.

