### PR TITLE
Cabana: fix wrong hardcoded column index

### DIFF
--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -224,7 +224,7 @@ void MessageListModel::updateState(bool sort) {
           changePersistentIndex(idx, index(std::distance(msgs.begin(), it), idx.column()));
       }
     }
-    emit dataChanged(index(0, 0), index(msgs.size() - 1, 3), {Qt::DisplayRole});
+    emit dataChanged(index(0, 0), index(msgs.size() - 1, columnCount() - 1), {Qt::DisplayRole});
   }
 }
 


### PR DESCRIPTION
remove wrong hardcoded column index. the correct index is `4 (columnCount() - 1)`