### PR TITLE
Cabana: Reimplement HistoryLog::sizeHintForColumn to improve performance

### DIFF
--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -1,7 +1,6 @@
 #include "tools/cabana/historylog.h"
 
 #include <QFontDatabase>
-#include <QVBoxLayout>
 
 // HistoryLogModel
 
@@ -88,4 +87,9 @@ HistoryLog::HistoryLog(QWidget *parent) : QTableView(parent) {
   setFrameShape(QFrame::NoFrame);
   setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
   setStyleSheet("QTableView::item { border:0px; padding-left:5px; padding-right:5px; }");
+}
+
+int HistoryLog::sizeHintForColumn(int column) const {
+  // sizeHintForColumn is only called for column 0 (ResizeToContents)
+  return itemDelegate()->sizeHint(viewOptions(), model->index(0, 0)).width() + 1; // +1 for grid
 }

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -9,7 +9,7 @@
 class HeaderView : public QHeaderView {
 public:
   HeaderView(Qt::Orientation orientation, QWidget *parent = nullptr) : QHeaderView(orientation, parent) {}
-  QSize sectionSizeFromContents(int logicalIndex) const;
+  QSize sectionSizeFromContents(int logicalIndex) const override;
 };
 
 class HistoryLogModel : public QAbstractTableModel {
@@ -40,5 +40,6 @@ public:
   void setMessage(const QString &message_id) { model->setMessage(message_id); }
   void updateState() { model->updateState(); }
 private:
+  int sizeHintForColumn(int column) const override;
   HistoryLogModel *model;
 };


### PR DESCRIPTION
`sizeHintForColumn` is called for time column every time when the log about to change. the default implement iterate over the entire rows which can be very slow.
the new implementation only calc the width of the first row (time column), no matter how many rows there are.