### PR TITLE
[controlsd] Revert Rav4 TSS2 to PID control

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -119,7 +119,6 @@ class CarInterface(CarInterfaceBase):
       # See https://github.com/commaai/openpilot/pull/21429#issuecomment-873652891
       for fw in car_fw:
         if fw.ecu == "eps" and (fw.fwVersion.startswith(b'\x02') or fw.fwVersion in [b'8965B42181\x00\x00\x00\x00\x00\x00']):
-          ret.lateralTuning.init('pid')
           ret.lateralTuning.pid.kpV = [0.15]
           ret.lateralTuning.pid.kiV = [0.05]
           ret.lateralTuning.pid.kf = 0.00004

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -110,6 +110,20 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 14.3
       tire_stiffness_factor = 0.7933
       ret.mass = 3585. * CV.LB_TO_KG + STD_CARGO_KG  # Average between ICE and Hybrid
+      ret.lateralTuning.init('pid')
+      ret.lateralTuning.pid.kpV = [0.6]
+      ret.lateralTuning.pid.kiV = [0.1]
+      ret.lateralTuning.pid.kf = 0.00007818594
+
+      # 2019+ RAV4 TSS2 uses two different steering racks and specific tuning seems to be necessary.
+      # See https://github.com/commaai/openpilot/pull/21429#issuecomment-873652891
+      for fw in car_fw:
+        if fw.ecu == "eps" and (fw.fwVersion.startswith(b'\x02') or fw.fwVersion in [b'8965B42181\x00\x00\x00\x00\x00\x00']):
+          ret.lateralTuning.init('pid')
+          ret.lateralTuning.pid.kpV = [0.15]
+          ret.lateralTuning.pid.kiV = [0.05]
+          ret.lateralTuning.pid.kf = 0.00004
+          break
 
     elif candidate in (CAR.COROLLA_TSS2, CAR.COROLLAH_TSS2):
       stop_and_go = True


### PR DESCRIPTION
Torque control on Rav4 TSS2 has some issues (the multiple eps versions already needed separate PID tunes). I have identified some of the issues, but it might still be a regression if not fully fixed. Reverting back to the old PID tunes for now, will continue working on the issues in a branch.