### PR TITLE
VW PQ: Fix exception with openpilot longitudinal

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -12,6 +12,7 @@ class CarState(CarStateBase):
     super().__init__(CP)
     self.CCP = CarControllerParams(CP)
     self.button_states = {button.event_type: False for button in self.CCP.BUTTONS}
+    self.esp_hold_confirmation = False
 
   def create_button_events(self, pt_cp, buttons):
     button_events = []
@@ -220,7 +221,6 @@ class CarState(CarStateBase):
     self.acc_type = 0  # TODO: this is ACC "basic" with nonzero min speed, support FtS (1) later
     ret.cruiseState.available = bool(pt_cp.vl["Motor_5"]["GRA_Hauptschalter"])
     ret.cruiseState.enabled = bool(pt_cp.vl["Motor_2"]["GRA_Status"])
-    self.esp_hold_confirmation = False
     if self.CP.pcmCruise:
       ret.accFaulted = ext_cp.vl["ACC_GRA_Anziege"]["ACA_StaACC"] in (6, 7)
     # TODO: update opendbc with PQ TSK state for OP long accFaulted

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -220,6 +220,7 @@ class CarState(CarStateBase):
     self.acc_type = 0  # TODO: this is ACC "basic" with nonzero min speed, support FtS (1) later
     ret.cruiseState.available = bool(pt_cp.vl["Motor_5"]["GRA_Hauptschalter"])
     ret.cruiseState.enabled = bool(pt_cp.vl["Motor_2"]["GRA_Status"])
+    self.esp_hold_confirmation = False
     if self.CP.pcmCruise:
       ret.accFaulted = ext_cp.vl["ACC_GRA_Anziege"]["ACA_StaACC"] in (6, 7)
     # TODO: update opendbc with PQ TSK state for OP long accFaulted


### PR DESCRIPTION
**Description**

Fix a bug that crept in with MQB longitudinal, a missing state value that only applies to SnG cars, none of which are PQ.

**Verification**

Tested offline / in replay, controlsd no longer dies.

**Route**

N/A

**Additional context**

```
(openpilot-py3.8) jyoung@DESKTOP-6JPRDTA:~/openpilot$ FINGERPRINT="VOLKSWAGEN PASSAT NMS" selfdrive/controls/controlsd.py
Waiting for CAN messages...
Getting VIN & FW versions
vin query retry (1) ...
vin query retry (1) ...
vin query retry (2) ...
vin query retry (2) ...
vin query retry (3) ...
vin query retry (3) ...
vin query retry (4) ...
vin query retry (4) ...
vin query retry (5) ...
vin query retry (5) ...
VIN 00000000000000000
{"event": "fingerprinted", "car_fingerprint": "VOLKSWAGEN PASSAT NMS", "source": 2, "fuzzy": false, "cached": false, "fw_count": 0, "ecu_responses": [], "vin_rx_addr": 0, "error": true}
{"event": "commIssue", "error": true, "invalid": [], "not_alive": ["liveTorqueParameters"], "not_freq_ok": [], "can_rcv_timeout": false}
Traceback (most recent call last):
  File "selfdrive/controls/controlsd.py", line 897, in <module>
    main()
  File "selfdrive/controls/controlsd.py", line 893, in main
    controls.controlsd_thread()
  File "selfdrive/controls/controlsd.py", line 887, in controlsd_thread
    self.step()
  File "selfdrive/controls/controlsd.py", line 879, in step
    self.publish_logs(CS, start_time, CC, lac_log)
  File "selfdrive/controls/controlsd.py", line 761, in publish_logs
    self.last_actuators, can_sends = self.CI.apply(CC)
  File "/home/jyoung/openpilot/selfdrive/car/volkswagen/interface.py", line 250, in apply
    return self.CC.update(c, self.CS, self.ext_bus)
  File "/home/jyoung/openpilot/selfdrive/car/volkswagen/carcontroller.py", line 79, in update
    acc_control, stopping, starting, CS.esp_hold_confirmation))
AttributeError: 'CarState' object has no attribute 'esp_hold_confirmation'
```
