### PR TITLE
interfaces: block enabling on not pcmCruise cars

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -303,7 +303,7 @@ class CarInterface(CarInterfaceBase):
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons
     # Main button also can trigger an engagement on these cars
-    allow_enable = any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
+    allow_enable = not self.CP.pcmCruise or any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
     events = self.create_common_events(ret, pcm_enable=self.CP.pcmCruise, allow_enable=allow_enable)
 
     if self.CS.brake_error:

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -292,7 +292,7 @@ class CarInterface(CarInterfaceBase):
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)
 
-    if self.CS.CP.openpilotLongitudinalControl and self.CS.cruise_buttons[-1] != self.CS.prev_cruise_buttons:
+    if self.CP.openpilotLongitudinalControl and self.CS.cruise_buttons[-1] != self.CS.prev_cruise_buttons:
       buttonEvents = [create_button_event(self.CS.cruise_buttons[-1], self.CS.prev_cruise_buttons, BUTTONS_DICT)]
       # Handle CF_Clu_CruiseSwState changing buttons mid-press
       if self.CS.cruise_buttons[-1] != 0 and self.CS.prev_cruise_buttons != 0:
@@ -303,8 +303,8 @@ class CarInterface(CarInterfaceBase):
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons
     # Main button also can trigger an engagement on these cars
-    allow_enable = any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
-    events = self.create_common_events(ret, pcm_enable=self.CS.CP.pcmCruise, allow_enable=allow_enable)
+    allow_enable = not self.CP.pcmCruise or any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
+    events = self.create_common_events(ret, pcm_enable=self.CP.pcmCruise, allow_enable=allow_enable)
 
     if self.CS.brake_error:
       events.add(EventName.brakeUnavailable)

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -303,7 +303,7 @@ class CarInterface(CarInterfaceBase):
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons
     # Main button also can trigger an engagement on these cars
-    allow_enable = not self.CP.pcmCruise or any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
+    allow_enable = any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
     events = self.create_common_events(ret, pcm_enable=self.CP.pcmCruise, allow_enable=allow_enable)
 
     if self.CS.brake_error:

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -259,8 +259,9 @@ class CarInterfaceBase(ABC):
     if cs_out.steerFaultPermanent:
       events.add(EventName.steerUnavailable)
 
-    # Handle button presses and enable with PCM cruise state
-    # enabling can optionally be blocked by the car interface
+    # if pcmCruise, enable or disable on PCM cruise state, or cancel button
+    # if not pcmCruise, enable or disable using the interface's defined buttons
+    # the car interface can optionally block either method of enabling
     for b in cs_out.buttonEvents:
       # Enable OP long on falling edge of enable buttons (defaults to accelCruise and decelCruise, overridable per-port)
       if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed) and allow_enable:
@@ -269,7 +270,6 @@ class CarInterfaceBase(ABC):
       if b.type == ButtonType.cancel and b.pressed:
         events.add(EventName.buttonCancel)
 
-    # we engage when pcm is active (rising edge)
     if pcm_enable:
       if cs_out.cruiseState.enabled and not self.CS.out.cruiseState.enabled and allow_enable:
         events.add(EventName.pcmEnable)

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -259,7 +259,7 @@ class CarInterfaceBase(ABC):
     if cs_out.steerFaultPermanent:
       events.add(EventName.steerUnavailable)
 
-    # Handle button presses and PCM cruise state
+    # Handle button presses and enable with PCM cruise state
     # enabling can optionally be blocked by the car interface
     for b in cs_out.buttonEvents:
       # Enable OP long on falling edge of enable buttons (defaults to accelCruise and decelCruise, overridable per-port)

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -261,15 +261,15 @@ class CarInterfaceBase(ABC):
 
     # if pcmCruise, enable or disable on PCM cruise state, or cancel button
     # if not pcmCruise, enable or disable using the interface's defined buttons
-    # the car interface can optionally block either method of enabling
     for b in cs_out.buttonEvents:
       # Enable OP long on falling edge of enable buttons (defaults to accelCruise and decelCruise, overridable per-port)
-      if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed) and allow_enable:
+      if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed):
         events.add(EventName.buttonEnable)
       # Disable on rising edge of cancel for both stock and OP long
       if b.type == ButtonType.cancel and b.pressed:
         events.add(EventName.buttonCancel)
 
+    # enabling can optionally be blocked by the car interface
     if pcm_enable:
       if cs_out.cruiseState.enabled and not self.CS.out.cruiseState.enabled and allow_enable:
         events.add(EventName.pcmEnable)

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -261,15 +261,15 @@ class CarInterfaceBase(ABC):
 
     # if pcmCruise, enable or disable on PCM cruise state, or cancel button
     # if not pcmCruise, enable or disable using the interface's defined buttons
+    # the car interface can optionally block either method of enabling
     for b in cs_out.buttonEvents:
       # Enable OP long on falling edge of enable buttons (defaults to accelCruise and decelCruise, overridable per-port)
-      if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed):
+      if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed) and allow_enable:
         events.add(EventName.buttonEnable)
       # Disable on rising edge of cancel for both stock and OP long
       if b.type == ButtonType.cancel and b.pressed:
         events.add(EventName.buttonCancel)
 
-    # enabling can optionally be blocked by the car interface
     if pcm_enable:
       if cs_out.cruiseState.enabled and not self.CS.out.cruiseState.enabled and allow_enable:
         events.add(EventName.pcmEnable)


### PR DESCRIPTION
allow_enable should really be used for both pcm and not pcmCruise, no reason we don't want to block not pcmCruise for any reason

unified the enabling by putting the two and only methods of enabling at the bottom