### PR TITLE
Cabana: fix segfault on exit

### DIFF
--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -102,7 +102,10 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   QObject::connect(tabbar, &QTabBar::tabCloseRequested, tabbar, &QTabBar::removeTab);
   QObject::connect(charts, &ChartsWidget::chartOpened, [this](const QString &id, const Signal *sig) { updateChartState(id, sig, true); });
   QObject::connect(charts, &ChartsWidget::chartClosed, [this](const QString &id, const Signal *sig) { updateChartState(id, sig, false); });
-  QObject::connect(undo_stack, &QUndoStack::indexChanged, [this]() { dbcMsgChanged(); });
+  QObject::connect(undo_stack, &QUndoStack::indexChanged, [this]() {
+    if (undo_stack->count() > 0)
+      dbcMsgChanged();
+  });
 }
 
 void DetailWidget::showTabBarContextMenu(const QPoint &pt) {


### PR DESCRIPTION
QUndoStack emit indexChanged(0) in destructor. most of the children of the detailview have been deleted at this time, which will cause a crash in `dbcMsgChanged`
 
https://codebrowser.dev/qt5/qtbase/src/widgets/util/qundostack.cpp.html#597