### PR TITLE
Cabana: miscellaneous fixes

### DIFF
--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -79,7 +79,7 @@ bool CANMessages::eventFilter(const Event *event) {
     }
 
     double current_sec = replay->currentSeconds();
-    if (counters_begin_sec == 0 || counters_begin_sec > current_sec) {
+    if (counters_begin_sec == 0 || counters_begin_sec >= current_sec) {
       counters.clear();
       counters_begin_sec = current_sec;
     }

--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -44,7 +44,7 @@ QList<QPointF> CANMessages::findSignalValues(const QString &id, const Signal *si
   for (auto &evt : *evts) {
     if (evt->which != cereal::Event::Which::CAN) continue;
 
-    for (auto c : evt->event.getCan()) {
+    for (const auto &c : evt->event.getCan()) {
       if (bus == c.getSrc() && address == c.getAddress()) {
         double val = get_raw_value((uint8_t *)c.getDat().begin(), c.getDat().size(), *signal);
         if ((flag == EQ && val == value) || (flag == LT && val < value) || (flag == GT && val > value)) {

--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -120,7 +120,7 @@ const std::deque<CanData> CANMessages::messages(const QString &id) {
 }
 
 void CANMessages::seekTo(double ts) {
-  replay->seekTo(ts, false);
+  replay->seekTo(std::max(0, ts), false);
   counters_begin_sec = 0;
 }
 

--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -65,6 +65,7 @@ void CANMessages::process(QHash<QString, CanData> *messages) {
   emit updated();
   emit msgsReceived(messages);
   delete messages;
+  processing = false;
 }
 
 bool CANMessages::eventFilter(const Event *event) {
@@ -105,7 +106,9 @@ bool CANMessages::eventFilter(const Event *event) {
     }
 
     double ts = millis_since_boot();
-    if ((ts - prev_update_ts) > (1000.0 / settings.fps)) {
+    if ((ts - prev_update_ts) > (1000.0 / settings.fps) && !processing) {
+      // delay posting CAN message if UI thread is busy
+      processing = true;
       prev_update_ts = ts;
       // use pointer to avoid data copy in queued connection.
       emit received(new_msgs.release());

--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -120,7 +120,7 @@ const std::deque<CanData> CANMessages::messages(const QString &id) {
 }
 
 void CANMessages::seekTo(double ts) {
-  replay->seekTo(std::max(0, ts), false);
+  replay->seekTo(std::max(double(0), ts), false);
   counters_begin_sec = 0;
 }
 

--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -78,7 +78,7 @@ bool CANMessages::eventFilter(const Event *event) {
     }
 
     double current_sec = replay->currentSeconds();
-    if (counters_begin_sec == 0) {
+    if (counters_begin_sec == 0 || counters_begin_sec > current_sec) {
       counters.clear();
       counters_begin_sec = current_sec;
     }

--- a/tools/cabana/canmessages.h
+++ b/tools/cabana/canmessages.h
@@ -63,6 +63,7 @@ protected:
   Replay *replay = nullptr;
   std::mutex lock;
   std::atomic<double> counters_begin_sec = 0;
+  std::atomic<bool> processing = false;
   QHash<QString, uint32_t> counters;
   QHash<QString, std::deque<CanData>> received_msgs;
 };

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -293,7 +293,7 @@ void ChartView::updateSeries(const std::pair<double, double> range) {
   double end_ns = (route_start_time + range.second) * 1e9;
   for (auto it = begin; it != events->end() && (*it)->mono_time <= end_ns; ++it) {
     if ((*it)->which == cereal::Event::Which::CAN) {
-      for (auto c : (*it)->event.getCan()) {
+      for (const auto &c : (*it)->event.getCan()) {
         if (bus == c.getSrc() && address == c.getAddress()) {
           auto dat = c.getDat();
           double value = get_raw_value((uint8_t *)dat.begin(), dat.size(), *signal);

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -192,6 +192,8 @@ ChartView::ChartView(const QString &id, const Signal *sig, QWidget *parent)
   chart->createDefaultAxes();
   chart->legend()->hide();
   chart->layout()->setContentsMargins(0, 0, 0, 0);
+  // top margin for title
+  chart->setMargins({0, 11, 0, 0});
 
   line_marker = new QGraphicsLineItem(chart);
   line_marker->setZValue(chart->zValue() + 10);
@@ -265,6 +267,7 @@ void ChartView::adjustChartMargins() {
   if (chart()->plotArea().left() != aligned_pos) {
     const float left_margin = chart()->margins().left() + aligned_pos - chart()->plotArea().left();
     chart()->setMargins(QMargins(left_margin, 11, 0, 0));
+    updateLineMarker(can->currentSec());
   }
 }
 

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -266,6 +266,7 @@ EditMessageDialog::EditMessageDialog(const QString &msg_id, const QString &title
   form_layout->addRow("ID", new QLabel(msg_id));
 
   name_edit = new QLineEdit(title, this);
+  name_edit->setValidator(new QRegExpValidator(QRegExp("^(\\w+)"), name_edit));
   form_layout->addRow(tr("Name"), name_edit);
 
   size_spin = new QSpinBox(this);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -1,5 +1,6 @@
 #include "tools/cabana/mainwin.h"
 
+#include <iostream>
 #include <QApplication>
 #include <QClipboard>
 #include <QCompleter>
@@ -20,6 +21,7 @@
 
 static MainWindow *main_win = nullptr;
 void qLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+  if (type == QtDebugMsg) std::cout << msg.toStdString() << std::endl;
   if (main_win) emit main_win->showMessage(msg, 0);
 }
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -194,6 +194,7 @@ void MainWindow::saveDBCToFile() {
     QFile file(file_name);
     if (file.open(QIODevice::WriteOnly))
       file.write(dbc()->generateDBC().toUtf8());
+      detail_widget->undo_stack->clear();
   }
 }
 

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -16,6 +16,7 @@ SignalForm::SignalForm(QWidget *parent) : QWidget(parent) {
   QFormLayout *form_layout = new QFormLayout(this);
 
   name = new QLineEdit();
+  name->setValidator(new QRegExpValidator(QRegExp("^(\\w+)"), name));
   form_layout->addRow(tr("Name"), name);
 
   size = new QSpinBox();

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -37,7 +37,7 @@ VideoWidget::VideoWidget(QWidget *parent) : QWidget(parent) {
   // btn controls
   QHBoxLayout *control_layout = new QHBoxLayout();
   play_btn = new QPushButton("⏸");
-  play_btn->setStyleSheet("font-weight:bold");
+  play_btn->setStyleSheet("font-weight:bold; height:16px");
   control_layout->addWidget(play_btn);
 
   QButtonGroup *group = new QButtonGroup(this);


### PR DESCRIPTION
1. delay posting CAN message to qt event queue if UI thread is busy.
2. update line marker position after adjust margins. ( the line marker position is incorrect if open chart when replay is paused)
3. make sure seek_to >= 0s
4. fix incorrect freq after auto loop restart when the replay reach the end.
5. fix different height of play/pause button.
6. clear undo stack after saving.
7. no space allowed in signal and msg name.

 
