### PR TITLE
controlsd: add tests around cruise speed

### DIFF
--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -8,7 +8,6 @@ from cereal import car
 from common.params import Params
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 
-
 ButtonEvent = car.CarState.ButtonEvent
 ButtonType = car.CarState.ButtonEvent.Type
 
@@ -26,7 +25,7 @@ def run_cruise_simulation(cruise, t_end=20.):
   )
   valid, output = man.evaluate()
   assert valid
-  return output[-1,3]
+  return output[-1, 3]
 
 
 class TestCruiseSpeed(unittest.TestCase):
@@ -46,7 +45,7 @@ class TestCruiseSpeed(unittest.TestCase):
 @parameterized_class(('pcm_cruise',), [(False,)])
 class TestVCruiseHelper(unittest.TestCase):
   def setUp(self):
-    self.CP = car.CarParams(pcmCruise=self.pcm_cruise)
+    self.CP = car.CarParams(pcmCruise=self.pcm_cruise)  # pylint: disable=E1101
     self.v_cruise_helper = VCruiseHelper(self.CP)
 
   def test_adjust_speed_in_standstill(self):
@@ -67,7 +66,7 @@ class TestVCruiseHelper(unittest.TestCase):
         should_equal = standstill or pressed
         self.assertEqual(should_equal, (initial_v_cruise == self.v_cruise_helper.v_cruise_kph))
 
-  def test_v_cruise_initialize(self):
+  def test_initialize_v_cruise(self):
     """
     Asserts allowed cruise speeds on enabling with SET
     """

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -48,7 +48,23 @@ class TestVCruiseHelper(unittest.TestCase):
     self.CP = car.CarParams(pcmCruise=self.pcm_cruise)  # pylint: disable=E1101
     self.v_cruise_helper = VCruiseHelper(self.CP)
 
-  def test_adjust_speed_in_standstill(self):
+  def test_adjust_speed(self):
+    """
+    Asserts speed changes on falling edges of buttons.
+    """
+
+    self.v_cruise_helper.initialize_v_cruise(car.CarState())
+
+    for btn in (ButtonType.accelCruise, ButtonType.decelCruise):
+      initial_v_cruise = self.v_cruise_helper.v_cruise_kph
+      for pressed in (True, False):
+        CS = car.CarState(cruiseState={"available": True})
+        CS.buttonEvents = [ButtonEvent(type=btn, pressed=pressed)]
+
+        self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False)
+        self.assertEqual(pressed, (initial_v_cruise == self.v_cruise_helper.v_cruise_kph))
+
+  def test_resume_in_standstill(self):
     """
     Asserts we don't increment set speed if user presses resume/accel to exit cruise standstill.
     """

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -3,7 +3,7 @@ import numpy as np
 from parameterized import parameterized_class
 import unittest
 
-from selfdrive.controls.lib.drive_helpers import VCruiseHelper, V_CRUISE_ENABLE_MIN
+from selfdrive.controls.lib.drive_helpers import VCruiseHelper, V_CRUISE_MAX, V_CRUISE_ENABLE_MIN
 from cereal import car
 from common.params import Params
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
@@ -68,10 +68,14 @@ class TestVCruiseHelper(unittest.TestCase):
         self.assertEqual(should_equal, (initial_v_cruise == self.v_cruise_helper.v_cruise_kph))
 
   def test_v_cruise_initialize(self):
-    # TODO: test with different speeds and buttons
-    self.v_cruise_helper.initialize_v_cruise(car.CarState())
-    self.assertTrue(self.v_cruise_helper.v_cruise_initialized)
-    self.assertEqual(V_CRUISE_ENABLE_MIN, self.v_cruise_helper.v_cruise_kph)
+    """
+    Asserts allowed cruise speeds on enabling with SET
+    """
+
+    for v_ego in np.linspace(0, 100, 101):
+      self.v_cruise_helper.initialize_v_cruise(car.CarState(vEgo=float(v_ego)))
+      self.assertTrue(V_CRUISE_ENABLE_MIN <= self.v_cruise_helper.v_cruise_kph <= V_CRUISE_MAX)
+      self.assertTrue(self.v_cruise_helper.v_cruise_initialized)
 
 
 if __name__ == "__main__":

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -49,12 +49,12 @@ class TestVCruiseHelper(unittest.TestCase):
     self.v_cruise_helper = VCruiseHelper(self.CP)
 
   def test_v_cruise_initialized_pcm(self):
-    if not self.CP.pcmCruise:
-      raise unittest.SkipTest
-
     for cruise_available in [False, True, False]:
       CS = car.CarState(cruiseState={"available": cruise_available, "speed": 10.})
-      self.v_cruise_helper.update_v_cruise(CS, False, False)
+      if not self.CP.pcmCruise:
+        CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=False)]
+
+      self.v_cruise_helper.update_v_cruise(CS, True, False)
       self.assertEqual(cruise_available, self.v_cruise_helper.v_cruise_initialized)
 
 

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
-import unittest
 import numpy as np
+from parameterized import parameterized_class
+import unittest
+
+from selfdrive.controls.lib.drive_helpers import VCruiseHelper
+from cereal import car
 from common.params import Params
-
-
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
+
+
+ButtonEvent = car.CarState.ButtonEvent
+ButtonType = car.CarState.ButtonEvent.Type
+
 
 def run_cruise_simulation(cruise, t_end=20.):
   man = Maneuver(
@@ -22,17 +29,33 @@ def run_cruise_simulation(cruise, t_end=20.):
   return output[-1,3]
 
 
-class TestCruiseSpeed(unittest.TestCase):
-  def test_cruise_speed(self):
-    params = Params()
-    for e2e in [False, True]:
-      params.put_bool("ExperimentalMode", e2e)
-      for speed in np.arange(5, 40, 5):
-        print(f'Testing {speed} m/s')
-        cruise_speed = float(speed)
+# class TestCruiseSpeed(unittest.TestCase):
+#   def test_cruise_speed(self):
+#     params = Params()
+#     for e2e in [False, True]:
+#       params.put_bool("ExperimentalMode", e2e)
+#       for speed in np.arange(5, 40, 5):
+#         print(f'Testing {speed} m/s')
+#         cruise_speed = float(speed)
+#
+#         simulation_steady_state = run_cruise_simulation(cruise_speed)
+#         self.assertAlmostEqual(simulation_steady_state, cruise_speed, delta=.01, msg=f'Did not reach {speed} m/s')
 
-        simulation_steady_state = run_cruise_simulation(cruise_speed)
-        self.assertAlmostEqual(simulation_steady_state, cruise_speed, delta=.01, msg=f'Did not reach {speed} m/s')
+
+@parameterized_class(('pcm_cruise',), [(True,), (False,)])
+class TestVCruiseHelper(unittest.TestCase):
+  def setUp(self):
+    self.CP = car.CarParams(pcmCruise=self.pcm_cruise)
+    self.v_cruise_helper = VCruiseHelper(self.CP)
+
+  def test_v_cruise_initialized_pcm(self):
+    if not self.CP.pcmCruise:
+      raise unittest.SkipTest
+
+    for cruise_available in [False, True, False]:
+      CS = car.CarState(cruiseState={"available": cruise_available, "speed": 10.})
+      self.v_cruise_helper.update_v_cruise(CS, False, False)
+      self.assertEqual(cruise_available, self.v_cruise_helper.v_cruise_initialized)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds tests for:
- Speed adjusts on falling edge of buttons
- Cruise standstill exception added recently (https://github.com/commaai/openpilot/pull/25470)
- Enforcing limits on speed when enabling with SET

Only not pcmCruise tests for now as that mode is the most fragile, will make more complete in future PRs.