### PR TITLE
controlsd: no speed increment if enabled on button rising edge

### DIFF
--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -80,17 +80,18 @@ class TestVCruiseHelper(unittest.TestCase):
     ensure we don't adjust speed if enabled changes mid-press.
     """
 
-    initial_v_cruise = self.v_cruise_helper.v_cruise_kph
-
     # NOTE: enabled is always one frame behind the result from button press in controlsd
     for enabled, pressed in ((False, False),
                              (False, True),
                              (True, False)):
       CS = car.CarState(cruiseState={"available": True})
-      CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=pressed)]
-
+      CS.buttonEvents = [ButtonEvent(type=ButtonType.decelCruise, pressed=pressed)]
       self.v_cruise_helper.update_v_cruise(CS, enabled=enabled, is_metric=False)
-      self.assertEqual(initial_v_cruise, self.v_cruise_helper.v_cruise_kph)
+      if pressed:
+        self.enable(V_CRUISE_ENABLE_MIN * CV.KPH_TO_MS)
+
+      # Expected diff on enabling. Speed should not change on falling edge of pressed
+      self.assertEqual(not pressed, self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last)
 
   def test_resume_in_standstill(self):
     """

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -47,13 +47,12 @@ class TestVCruiseHelper(unittest.TestCase):
   def setUp(self):
     self.CP = car.CarParams(pcmCruise=self.pcm_cruise)  # pylint: disable=E1101
     self.v_cruise_helper = VCruiseHelper(self.CP)
+    self.v_cruise_helper.initialize_v_cruise(car.CarState())
 
   def test_adjust_speed(self):
     """
     Asserts speed changes on falling edges of buttons.
     """
-
-    self.v_cruise_helper.initialize_v_cruise(car.CarState())
 
     for btn in (ButtonType.accelCruise, ButtonType.decelCruise):
       initial_v_cruise = self.v_cruise_helper.v_cruise_kph
@@ -64,12 +63,29 @@ class TestVCruiseHelper(unittest.TestCase):
         self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False)
         self.assertEqual(pressed, (initial_v_cruise == self.v_cruise_helper.v_cruise_kph))
 
+  def test_rising_edge_enable(self):
+    """
+    Some car interfaces may enable on rising edge of a button,
+    ensure we don't adjust speed if enabled changes mid-press.
+    """
+
+    initial_v_cruise = self.v_cruise_helper.v_cruise_kph
+
+    # NOTE: enabled is always one frame behind the result from button press in controlsd
+    for enabled, pressed in ((False, False),
+                             (False, True),
+                             (True, False)):
+      CS = car.CarState(cruiseState={"available": True})
+      CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=pressed)]
+
+      self.v_cruise_helper.update_v_cruise(CS, enabled=enabled, is_metric=False)
+      self.assertEqual(initial_v_cruise, self.v_cruise_helper.v_cruise_kph)
+
   def test_resume_in_standstill(self):
     """
     Asserts we don't increment set speed if user presses resume/accel to exit cruise standstill.
     """
 
-    self.v_cruise_helper.initialize_v_cruise(car.CarState())
     initial_v_cruise = self.v_cruise_helper.v_cruise_kph
 
     for standstill in (True, False):
@@ -84,7 +100,7 @@ class TestVCruiseHelper(unittest.TestCase):
 
   def test_initialize_v_cruise(self):
     """
-    Asserts allowed cruise speeds on enabling with SET
+    Asserts allowed cruise speeds on enabling with SET.
     """
 
     for v_ego in np.linspace(0, 100, 101):


### PR DESCRIPTION
Not utilized by any port atm, but good to support this if any do. Behavior shouldn't change for any other cases per the tests

Splits out some diff from https://github.com/commaai/openpilot/pull/26442 that isn't 100% specific to GM