### PR TITLE
cruise speed tests: match controlsd initialization of cruise speed

### DIFF
--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -64,10 +64,9 @@ class TestVCruiseHelper(unittest.TestCase):
     Asserts speed changes on falling edges of buttons.
     """
 
-    for btn in (ButtonType.accelCruise, ButtonType.decelCruise):
-      self.reset_cruise_speed_state()
-      self.enable(V_CRUISE_ENABLE_MIN * CV.KPH_TO_MS)
+    self.enable(V_CRUISE_ENABLE_MIN * CV.KPH_TO_MS)
 
+    for btn in (ButtonType.accelCruise, ButtonType.decelCruise):
       for pressed in (True, False):
         CS = car.CarState(cruiseState={"available": True})
         CS.buttonEvents = [ButtonEvent(type=btn, pressed=pressed)]

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -5,6 +5,7 @@ import unittest
 
 from selfdrive.controls.lib.drive_helpers import VCruiseHelper, V_CRUISE_MAX, V_CRUISE_ENABLE_MIN
 from cereal import car
+from common.conversions import Conversions as CV
 from common.params import Params
 from selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 
@@ -47,40 +48,52 @@ class TestVCruiseHelper(unittest.TestCase):
   def setUp(self):
     self.CP = car.CarParams(pcmCruise=self.pcm_cruise)  # pylint: disable=E1101
     self.v_cruise_helper = VCruiseHelper(self.CP)
+    self.reset_cruise_speed_state()
+
+  def reset_cruise_speed_state(self):
+    # Two resets previous cruise speed
+    for _ in range(2):
+      self.v_cruise_helper.update_v_cruise(car.CarState(), enabled=False, is_metric=False)
+
+  def enable(self, v_ego, resume=False):
+    CS = car.CarState(vEgo=v_ego)
+    if resume:
+      CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=False)]
+    self.v_cruise_helper.initialize_v_cruise(CS)
 
   def test_adjust_speed(self):
     """
     Asserts speed changes on falling edges of buttons.
     """
 
-    self.v_cruise_helper.initialize_v_cruise(car.CarState())
-
     for btn in (ButtonType.accelCruise, ButtonType.decelCruise):
-      initial_v_cruise = self.v_cruise_helper.v_cruise_kph
+      self.reset_cruise_speed_state()
+      self.enable(V_CRUISE_ENABLE_MIN * CV.KPH_TO_MS)
+
       for pressed in (True, False):
         CS = car.CarState(cruiseState={"available": True})
         CS.buttonEvents = [ButtonEvent(type=btn, pressed=pressed)]
 
         self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False)
-        self.assertEqual(pressed, (initial_v_cruise == self.v_cruise_helper.v_cruise_kph))
+        self.assertEqual(pressed, self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last)
 
   def test_resume_in_standstill(self):
     """
     Asserts we don't increment set speed if user presses resume/accel to exit cruise standstill.
     """
 
-    self.v_cruise_helper.initialize_v_cruise(car.CarState())
-    initial_v_cruise = self.v_cruise_helper.v_cruise_kph
-
     for standstill in (True, False):
       for pressed in (True, False):
+        self.reset_cruise_speed_state()
+        self.enable(0)
+
         CS = car.CarState(cruiseState={"available": True, "standstill": standstill})
         CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=pressed)]
 
         self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False)
         # speed should only update if not at standstill and button falling edge
         should_equal = standstill or pressed
-        self.assertEqual(should_equal, (initial_v_cruise == self.v_cruise_helper.v_cruise_kph))
+        self.assertEqual(should_equal, self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last)
 
   def test_initialize_v_cruise(self):
     """
@@ -88,7 +101,10 @@ class TestVCruiseHelper(unittest.TestCase):
     """
 
     for v_ego in np.linspace(0, 100, 101):
-      self.v_cruise_helper.initialize_v_cruise(car.CarState(vEgo=float(v_ego)))
+      self.reset_cruise_speed_state()
+      self.assertFalse(self.v_cruise_helper.v_cruise_initialized)
+
+      self.enable(float(v_ego))
       self.assertTrue(V_CRUISE_ENABLE_MIN <= self.v_cruise_helper.v_cruise_kph <= V_CRUISE_MAX)
       self.assertTrue(self.v_cruise_helper.v_cruise_initialized)
 

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -55,11 +55,9 @@ class TestVCruiseHelper(unittest.TestCase):
     for _ in range(2):
       self.v_cruise_helper.update_v_cruise(car.CarState(), enabled=False, is_metric=False)
 
-  def enable(self, v_ego, resume=False):
-    CS = car.CarState(vEgo=v_ego)
-    if resume:
-      CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=False)]
-    self.v_cruise_helper.initialize_v_cruise(CS)
+  def enable(self, v_ego):
+    # Simulates user pressing set with a current speed
+    self.v_cruise_helper.initialize_v_cruise(car.CarState(vEgo=v_ego))
 
   def test_adjust_speed(self):
     """

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -79,15 +79,14 @@ class TestVCruiseHelper(unittest.TestCase):
     Asserts we don't increment set speed if user presses resume/accel to exit cruise standstill.
     """
 
+    self.enable(0)
+
     for standstill in (True, False):
       for pressed in (True, False):
-        self.reset_cruise_speed_state()
-        self.enable(0)
-
         CS = car.CarState(cruiseState={"available": True, "standstill": standstill})
         CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=pressed)]
-
         self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False)
+
         # speed should only update if not at standstill and button falling edge
         should_equal = standstill or pressed
         self.assertEqual(should_equal, self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last)

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -53,7 +53,7 @@ class TestVCruiseHelper(unittest.TestCase):
   def reset_cruise_speed_state(self):
     # Two resets previous cruise speed
     for _ in range(2):
-      self.v_cruise_helper.update_v_cruise(car.CarState(), enabled=False, is_metric=False)
+      self.v_cruise_helper.update_v_cruise(car.CarState(cruiseState={"available": False}), enabled=False, is_metric=False)
 
   def enable(self, v_ego):
     # Simulates user pressing set with a current speed


### PR DESCRIPTION
controlsd always calls update first, now we properly init `v_cruise_kph_last` (which isn't tested yet, no behavior change with this)