### PR TITLE
Cabana: add test case for parsing can messages

### DIFF
--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -1,6 +1,12 @@
 
+#include "opendbc/can/common.h"
+#undef INFO
 #include "catch2/catch.hpp"
 #include "tools/cabana/dbcmanager.h"
+#include "tools/replay/logreader.h"
+
+// demo route, first segment
+const std::string TEST_RLOG_URL = "https://commadata2.blob.core.windows.net/commadata2/4cf7a6ad03080c90/2021-09-29--13-46-36/0/rlog.bz2";
 
 TEST_CASE("DBCManager::generateDBC") {
   DBCManager dbc_origin(nullptr);
@@ -18,5 +24,44 @@ TEST_CASE("DBCManager::generateDBC") {
     REQUIRE(m.sigs.size() == new_m.sigs.size());
     for (auto &[name, sig] : m.sigs)
       REQUIRE(sig == new_m.sigs[name]);
+  }
+}
+
+
+TEST_CASE("Parse can messages") {
+  DBCManager dbc(nullptr);
+  dbc.open("toyota_new_mc_pt_generated");
+  CANParser can_parser(0, "toyota_new_mc_pt_generated", {}, {});
+
+  LogReader log;
+  REQUIRE(log.load(TEST_RLOG_URL, nullptr, {}, true));
+  REQUIRE(log.events.size() > 0);
+  for (auto e : log.events) {
+    if (e->which == cereal::Event::Which::CAN) {
+      std::vector<SignalValue> values_1;
+      for (const auto &c : e->event.getCan()) {
+        const auto msg = dbc.msg(c.getAddress());
+        if (c.getSrc() == 0 && msg) {
+          for (auto &[name, sig] : msg->sigs) {
+            double val = get_raw_value((uint8_t *)c.getDat().begin(), c.getDat().size(), sig);
+            values_1.push_back({.address = c.getAddress(), .name = name.toStdString(), .value = val});
+          }
+        }
+      }
+      can_parser.UpdateCans(e->mono_time, e->event.getCan());
+      auto values_2 = can_parser.query_latest();
+      for (auto &v1 : values_1) {
+        bool found = false;
+        for (auto &v2 : values_2) {
+          if (v2.address == v1.address && v2.name == v1.name) {
+            auto it = std::find(v2.all_values.begin(), v2.all_values.end(), v1.value);
+            REQUIRE(it != v2.all_values.end());
+            found = true;
+            break;
+          }
+        }
+        REQUIRE(found);
+      }
+    }
   }
 }


### PR DESCRIPTION
Added test case to make sure the results is the same as opendbc/CANParser::UpdateCans.