### PR TITLE
Cabana: fix right panel layout after undocking charts

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -73,6 +73,7 @@ MainWindow::MainWindow() : QMainWindow() {
   video_widget = new VideoWidget(this);
   r_layout->addWidget(video_widget, 0, Qt::AlignTop);
   r_layout->addWidget(charts_widget, 1);
+  r_layout->addStretch(0);
   main_layout->addWidget(right_container);
 
   setCentralWidget(central_widget);
@@ -217,7 +218,7 @@ void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool succe
 void MainWindow::dockCharts(bool dock) {
   if (dock && floating_window) {
     floating_window->removeEventFilter(charts_widget);
-    r_layout->addWidget(charts_widget, 1);
+    r_layout->insertWidget(2, charts_widget, 1);
     floating_window->deleteLater();
     floating_window = nullptr;
   } else if (!dock && !floating_window) {

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -223,6 +223,7 @@ void MainWindow::dockCharts(bool dock) {
     floating_window = nullptr;
   } else if (!dock && !floating_window) {
     floating_window = new QWidget(nullptr);
+    floating_window->setWindowTitle("Charts - Cabana");
     floating_window->setLayout(new QVBoxLayout());
     floating_window->layout()->addWidget(charts_widget);
     floating_window->installEventFilter(charts_widget);


### PR DESCRIPTION
![Screenshot from 2022-11-15 13-01-29](https://user-images.githubusercontent.com/27770/201830746-8c2903e5-d549-45bb-a846-63c71e2c9cb4.png)
