### PR TITLE
ui: stretch abstract control title

### DIFF
--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -38,7 +38,7 @@ AbstractControl::AbstractControl(const QString &title, const QString &desc, cons
   title_label = new QPushButton(title);
   title_label->setFixedHeight(120);
   title_label->setStyleSheet("font-size: 50px; font-weight: 400; text-align: left");
-  hlayout->addWidget(title_label);
+  hlayout->addWidget(title_label, 1);
 
   // value next to control button
   value = new ElidedLabel();


### PR DESCRIPTION
Stretches the title text touch area all the way to the next widget (so you can press across the full width to expand descriptions)