### PR TITLE
Discover Qt paths using qmake

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -298,12 +298,14 @@ if arch == "Darwin":
   qt_env["FRAMEWORKS"] += [f"Qt{m}" for m in qt_modules] + ["OpenGL"]
   qt_env.AppendENVPath('PATH', os.path.join(qt_env['QTDIR'], "bin"))
 else:
-  qt_env['QTDIR'] = "/usr"
+  qt_query = os.popen('qmake -query').read()
+  qt_query = {kv[0]: kv[1] for kv in [line.split(':') for line in qt_query.split('\n')] if len(kv) == 2}
+
+  qt_env['QTDIR'] = qt_query['QT_INSTALL_PREFIX']
   qt_dirs = [
-    f"/usr/include/{real_arch}-linux-gnu/qt5",
-    f"/usr/include/{real_arch}-linux-gnu/qt5/QtGui/5.12.8/QtGui",
+    f"{qt_query['QT_INSTALL_HEADERS']}",
   ]
-  qt_dirs += [f"/usr/include/{real_arch}-linux-gnu/qt5/Qt{m}" for m in qt_modules]
+  qt_dirs += [f"{qt_query['QT_INSTALL_HEADERS']}/Qt{m}" for m in qt_modules]
 
   qt_libs = [f"Qt5{m}" for m in qt_modules]
   if arch == "larch64":

--- a/SConstruct
+++ b/SConstruct
@@ -304,6 +304,7 @@ else:
   qt_env['QTDIR'] = qt_query['QT_INSTALL_PREFIX']
   qt_dirs = [
     f"{qt_query['QT_INSTALL_HEADERS']}",
+    f"{qt_query['QT_INSTALL_HEADERS']}/QtGui/5.12.8/QtGui",
   ]
   qt_dirs += [f"{qt_query['QT_INSTALL_HEADERS']}/Qt{m}" for m in qt_modules]
 

--- a/SConstruct
+++ b/SConstruct
@@ -298,15 +298,15 @@ if arch == "Darwin":
   qt_env["FRAMEWORKS"] += [f"Qt{m}" for m in qt_modules] + ["OpenGL"]
   qt_env.AppendENVPath('PATH', os.path.join(qt_env['QTDIR'], "bin"))
 else:
-  qt_query = os.popen('qmake -query').read()
-  qt_query = {kv[0]: kv[1] for kv in [line.split(':') for line in qt_query.split('\n')] if len(kv) == 2}
-
-  qt_env['QTDIR'] = qt_query['QT_INSTALL_PREFIX']
+  qt_install_prefix = subprocess.check_output(['qmake', '-query', 'QT_INSTALL_PREFIX'], encoding='utf8').strip()
+  qt_install_headers = subprocess.check_output(['qmake', '-query', 'QT_INSTALL_HEADERS'], encoding='utf8').strip()
+  
+  qt_env['QTDIR'] = qt_install_prefix
   qt_dirs = [
-    f"{qt_query['QT_INSTALL_HEADERS']}",
-    f"{qt_query['QT_INSTALL_HEADERS']}/QtGui/5.12.8/QtGui",
+    f"{qt_install_headers}",
+    f"{qt_install_headers}/QtGui/5.12.8/QtGui",
   ]
-  qt_dirs += [f"{qt_query['QT_INSTALL_HEADERS']}/Qt{m}" for m in qt_modules]
+  qt_dirs += [f"{qt_install_headers}/Qt{m}" for m in qt_modules]
 
   qt_libs = [f"Qt5{m}" for m in qt_modules]
   if arch == "larch64":


### PR DESCRIPTION
Only change needed to the Sconstruct to build on arch linux. Feel free to close if you don't want to support non ubuntu OSes.

Unfortunately homebrew doesn't put qmake on the path. If you're willing to add that to `mac_setup.sh` you can also clean up the mac part.

Tested on device.

Example `qmake -query` output:
```
comma@tici:/data/openpilot$ qmake -query
QT_SYSROOT:
QT_INSTALL_PREFIX:/usr
QT_INSTALL_ARCHDATA:/usr/lib/aarch64-linux-gnu/qt5
QT_INSTALL_DATA:/usr/share/qt5
QT_INSTALL_DOCS:/usr/share/qt5/doc
QT_INSTALL_HEADERS:/usr/include/aarch64-linux-gnu/qt5
QT_INSTALL_LIBS:/usr/lib/aarch64-linux-gnu
QT_INSTALL_LIBEXECS:/usr/lib/aarch64-linux-gnu/qt5/libexec
QT_INSTALL_BINS:/usr/lib/qt5/bin
QT_INSTALL_TESTS:/usr/tests
QT_INSTALL_PLUGINS:/usr/lib/aarch64-linux-gnu/qt5/plugins
QT_INSTALL_IMPORTS:/usr/lib/aarch64-linux-gnu/qt5/imports
QT_INSTALL_QML:/usr/lib/aarch64-linux-gnu/qt5/qml
QT_INSTALL_TRANSLATIONS:/usr/share/qt5/translations
QT_INSTALL_CONFIGURATION:/etc/xdg
QT_INSTALL_EXAMPLES:/usr/lib/aarch64-linux-gnu/qt5/examples
QT_INSTALL_DEMOS:/usr/lib/aarch64-linux-gnu/qt5/examples
QT_HOST_PREFIX:/usr
QT_HOST_DATA:/usr/lib/aarch64-linux-gnu/qt5
QT_HOST_BINS:/usr/lib/qt5/bin
QT_HOST_LIBS:/usr/lib/aarch64-linux-gnu
QMAKE_SPEC:linux-g++
QMAKE_XSPEC:linux-g++
QMAKE_VERSION:3.1
QT_VERSION:5.12.8
```