### PR TITLE
loggerd: add missing utility include

### DIFF
--- a/selfdrive/loggerd/loggerd.h
+++ b/selfdrive/loggerd/loggerd.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <utility>
 
 #include "cereal/messaging/messaging.h"
 #include "cereal/services.h"

--- a/selfdrive/loggerd/tests/test_logger.cc
+++ b/selfdrive/loggerd/tests/test_logger.cc
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <sstream>
 #include <thread>
+#include <utility>
 
 #include "catch2/catch.hpp"
 #include "cereal/messaging/messaging.h"


### PR DESCRIPTION
Fixes build with `clang version 14.0.6`.

```
selfdrive/loggerd/encoderd.cc:22:14: error: no member named 'exchange' in namespace 'std'; did you mean '__exchange'?
    if (std::exchange(s->camera_ready[cam_type], true) == false) {
        ~~~~~^~~~~~~~
             __exchange
```