### PR TITLE
Add FPv2: 2022 Subaru Outback Wilderness

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -461,6 +461,7 @@ FW_VERSIONS = {
       b'\xa1  \x08\x02',
       b'\xa1 \x06\x02',
       b'\xa1  \x08\x00',
+      b'\xa1 "\t\x00',
     ],
     (Ecu.eps, 0x746, None): [
       b'\x9b\xc0\x10\x00',
@@ -482,6 +483,7 @@ FW_VERSIONS = {
       b'\xe2"`p\x07',
       b'\xf1\x82\xe2,\xa0@\x07',
       b'\xbc"`q\x07',
+      b'\xe3,\xa0@\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xa5\xfe\xf7@\x00',


### PR DESCRIPTION
**Description** Add missing fw values for 2022 Subaru Outback Wilderness

**Route**
Route: 7e051e2bb863d0b6|2022-11-17--17-45-50--49