### PR TITLE
Toyota: whitelist FW queries

### DIFF
--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -209,16 +209,19 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, TOYOTA_VERSION_REQUEST],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, TOYOTA_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps],
       bus=0,
     ),
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, StdQueries.OBD_VERSION_REQUEST],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, StdQueries.OBD_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.engine],
       bus=0,
     ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.DEFAULT_DIAGNOSTIC_REQUEST, StdQueries.EXTENDED_DIAGNOSTIC_REQUEST, StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.DEFAULT_DIAGNOSTIC_RESPONSE, StdQueries.EXTENDED_DIAGNOSTIC_RESPONSE, StdQueries.UDS_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.engine, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.abs, Ecu.eps],
       bus=0,
     ),
   ],


### PR DESCRIPTION
Checked 835 dongles and [these platforms](https://pastebin.com/kSTkE9Ne), no Toyota ECU ever responded successfully to two of our queries, that's efficient! However, for a given query, not all ECUs respond across the fleet, so we can whitelist to a superset of all the cars. Only the engine on 0x7e0 will ever respond to the OBD version request, for example.

|Query Data|Superset of responses from the fleet|
|---|---|
|[b'>', b'\t\x04']|{('engine', 2016, 0)}|
|[b'>\x00', b'\x10\x01', b'\x10\x03', b'"\xf1\x81']|{('fwdCamera', 1872, 109), ('engine', 1792, 0), ('abs', 1968, 0), ('abs', 2001, 0), ('eps', 1953, 0), ('fwdRadar', 1872, 15)}|
|[b'>', b'\x1a\x88\x01']|{('dsu', 1937, 0), ('fwdCamera', 1872, 109), ('abs', 1968, 0), ('eps', 1953, 0), ('fwdRadar', 1872, 15)}|