### PR TITLE
VW PQ: Fix cruise fault detection, cleanup

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -222,10 +222,11 @@ class CarState(CarStateBase):
     # Update ACC radar status.
     self.acc_type = 0  # TODO: this is ACC "basic" with nonzero min speed, support FtS (1) later
     ret.cruiseState.available = bool(pt_cp.vl["Motor_5"]["GRA_Hauptschalter"])
-    ret.cruiseState.enabled = bool(pt_cp.vl["Motor_2"]["GRA_Status"])
+    ret.cruiseState.enabled = pt_cp.vl["Motor_2"]["GRA_Status"] in (1, 2)
     if self.CP.pcmCruise:
       ret.accFaulted = ext_cp.vl["ACC_GRA_Anziege"]["ACA_StaACC"] in (6, 7)
-    # TODO: update opendbc with PQ TSK state for OP long accFaulted
+    else:
+      ret.accFaulted = pt_cp.vl["Motor_2"]["GRA_Status"] == 3
 
     # Update ACC setpoint. When the setpoint reads as 255, the driver has not
     # yet established an ACC setpoint, so treat it as zero.
@@ -485,15 +486,15 @@ class MqbExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers
   fwd_radar_signals = [
     ("ACC_Wunschgeschw_02", "ACC_02"),           # ACC set speed
-    ("ACC_Typ", "ACC_06"),                       # Basic vs F2S vs SNG
+    ("ACC_Typ", "ACC_06"),                       # Basic vs FtS vs SnG
     ("AWV2_Freigabe", "ACC_10"),                 # FCW brake jerk release
     ("ANB_Teilbremsung_Freigabe", "ACC_10"),     # AEB partial braking release
     ("ANB_Zielbremsung_Freigabe", "ACC_10"),     # AEB target braking release
   ]
   fwd_radar_checks = [
-    ("ACC_06", 50),                                 # From J428 ACC radar control module
-    ("ACC_10", 50),                                 # From J428 ACC radar control module
-    ("ACC_02", 17),                                 # From J428 ACC radar control module
+    ("ACC_06", 50),                              # From J428 ACC radar control module
+    ("ACC_10", 50),                              # From J428 ACC radar control module
+    ("ACC_02", 17),                              # From J428 ACC radar control module
   ]
   bsm_radar_signals = [
     ("SWA_Infostufe_SWA_li", "SWA_01"),          # Blind spot object info, left
@@ -502,24 +503,24 @@ class MqbExtraSignals:
     ("SWA_Warnung_SWA_re", "SWA_01"),            # Blind spot object warning, right
   ]
   bsm_radar_checks = [
-    ("SWA_01", 20),                                 # From J1086 Lane Change Assist
+    ("SWA_01", 20),                              # From J1086 Lane Change Assist
   ]
 
 class PqExtraSignals:
   # Additional signal and message lists for optional or bus-portable controllers
   fwd_radar_signals = [
-    ("ACA_StaACC", "ACC_GRA_Anziege", 0),           # ACC drivetrain coordinator status
-    ("ACA_V_Wunsch", "ACC_GRA_Anziege", 0),         # ACC set speed
+    ("ACA_StaACC", "ACC_GRA_Anziege"),           # ACC drivetrain coordinator status
+    ("ACA_V_Wunsch", "ACC_GRA_Anziege"),         # ACC set speed
   ]
   fwd_radar_checks = [
-    ("ACC_GRA_Anziege", 25),                        # From J428 ACC radar control module
+    ("ACC_GRA_Anziege", 25),                     # From J428 ACC radar control module
   ]
   bsm_radar_signals = [
-    ("SWA_Infostufe_SWA_li", "SWA_1", 0),           # Blind spot object info, left
-    ("SWA_Warnung_SWA_li", "SWA_1", 0),             # Blind spot object warning, left
-    ("SWA_Infostufe_SWA_re", "SWA_1", 0),           # Blind spot object info, right
-    ("SWA_Warnung_SWA_re", "SWA_1", 0),             # Blind spot object warning, right
+    ("SWA_Infostufe_SWA_li", "SWA_1"),           # Blind spot object info, left
+    ("SWA_Warnung_SWA_li", "SWA_1"),             # Blind spot object warning, left
+    ("SWA_Infostufe_SWA_re", "SWA_1"),           # Blind spot object info, right
+    ("SWA_Warnung_SWA_re", "SWA_1"),             # Blind spot object warning, right
   ]
   bsm_radar_checks = [
-    ("SWA_1", 20),                                  # From J1086 Lane Change Assist
+    ("SWA_1", 20),                               # From J1086 Lane Change Assist
   ]


### PR DESCRIPTION
**Description**

Prep for PQ follow-to-stop support, with other minor cleanup.

* Correctly parse `Motor_2.GRA_Status` into its enabled/fault states. Panda was [already correct](https://github.com/commaai/panda/blob/e4c4253964a25ff980520b70ea9f50aede4a1db6/board/safety/safety_volkswagen_pq.h#L157).
* With the above fix, detect and surface drivetrain coordinator faults when using openpilot longitudinal.
* Cleanup some leftover CAN state default values that were deprecated a long time ago.
* Minor comment cleanup and whitespace realignment.

**Verification**

Examined a route where the drivetrain coordinator rejected basic ACC mode controls when it expected FtS mode.

**Route**

Route: `064d1816e448f8eb|2022-11-22--16-56-48`