### PR TITLE
longcontrol: ignore cruise standstill if interceptor

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -10,6 +10,7 @@ LongCtrlState = car.CarControl.Actuators.LongControlState
 
 def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
                              v_target_1sec, brake_pressed, cruise_standstill):
+  # Ignore cruise standstill if car has a gas interceptor since we can always exit
   cruise_standstill = cruise_standstill and CP.enableGasInterceptor
   accelerating = v_target_1sec > v_target
   planned_stop = (v_target < CP.vEgoStopping and

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -10,12 +10,13 @@ LongCtrlState = car.CarControl.Actuators.LongControlState
 
 def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
                              v_target_1sec, brake_pressed, cruise_standstill):
+  cruise_standstill = cruise_standstill and CP.enableGasInterceptor
   accelerating = v_target_1sec > v_target
   planned_stop = (v_target < CP.vEgoStopping and
                   v_target_1sec < CP.vEgoStopping and
                   not accelerating)
   stay_stopped = (v_ego < CP.vEgoStopping and
-               (brake_pressed or cruise_standstill))
+                  (brake_pressed or cruise_standstill))
   stopping_condition = planned_stop or stay_stopped
 
   starting_condition = (v_target_1sec > CP.vEgoStarting and

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -10,7 +10,7 @@ LongCtrlState = car.CarControl.Actuators.LongControlState
 
 def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
                              v_target_1sec, brake_pressed, cruise_standstill):
-  # Ignore cruise standstill if car has a gas interceptor since we can always exit standstill
+  # Ignore cruise standstill if car has a gas interceptor
   cruise_standstill = cruise_standstill and CP.enableGasInterceptor
   accelerating = v_target_1sec > v_target
   planned_stop = (v_target < CP.vEgoStopping and

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -10,7 +10,7 @@ LongCtrlState = car.CarControl.Actuators.LongControlState
 
 def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
                              v_target_1sec, brake_pressed, cruise_standstill):
-  # Ignore cruise standstill if car has a gas interceptor since we can always exit
+  # Ignore cruise standstill if car has a gas interceptor since we can always exit standstill
   cruise_standstill = cruise_standstill and CP.enableGasInterceptor
   accelerating = v_target_1sec > v_target
   planned_stop = (v_target < CP.vEgoStopping and

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -11,7 +11,7 @@ LongCtrlState = car.CarControl.Actuators.LongControlState
 def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
                              v_target_1sec, brake_pressed, cruise_standstill):
   # Ignore cruise standstill if car has a gas interceptor
-  cruise_standstill = cruise_standstill and CP.enableGasInterceptor
+  cruise_standstill = cruise_standstill and not CP.enableGasInterceptor
   accelerating = v_target_1sec > v_target
   planned_stop = (v_target < CP.vEgoStopping and
                   v_target_1sec < CP.vEgoStopping and


### PR DESCRIPTION
Makes more sense to check this generically in longcontrol, rather than not logging standstill in the car interfaces