### PR TITLE
Cabana: fix segfault in dragging zoom

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -398,8 +398,8 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton && rubber && rubber->isVisible()) {
     rubber->hide();
     QRectF rect = rubber->geometry().normalized();
-    double min = chart()->mapToValue(rect.topLeft()).x();
-    double max = chart()->mapToValue(rect.bottomRight()).x();
+    double min = std::floor(chart()->mapToValue(rect.topLeft()).x() * 10.0) / 10.0;
+    double max = std::floor(chart()->mapToValue(rect.bottomRight()).x() * 10.0) / 10.0;
     if (rubber->width() <= 0) {
       // no rubber dragged, seek to mouse position
       can->seekTo(min);


### PR DESCRIPTION
The precision of double may causes `replay::seekTo` to be called recursively (`can->currentSec() < zoomed_range.first` is alaways true after zooming), resulting in segfault:
https://github.com/commaai/openpilot/blob/a19b5b91d2bcc0cd405599193828b9e9e187c52e/tools/cabana/chartswidget.cc#L98-L100

