### PR TITLE
radard: add missing accel data for vision-only leads

### DIFF
--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -130,7 +130,7 @@ class Cluster():
       "aLeadTau": float(self.aLeadTau)
     }
 
-  def get_RadarState_from_vision(self, lead_msg, lead_index, v_ego):
+  def get_RadarState_from_vision(self, lead_msg, v_ego):
     return {
       "dRel": float(lead_msg.x[0] - RADAR_TO_CAMERA),
       "yRel": float(-lead_msg.y[0]),

--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -146,7 +146,6 @@ class Cluster():
       "vRel": float(lead_msg.v[0] - v_ego),
       "vLead": float(lead_msg.v[0]),
       "vLeadK": float(lead_msg.v[0]),
-      "aLead": float(lead_msg.a[0]),
       "aLeadK": float(lead_msg.a[0]),
       "aLeadTau": _vision_lead_aTau[lead_index],
       "fcw": False,

--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -5,6 +5,9 @@ from common.kalman.simple_kalman import KF1D
 # Default lead acceleration decay set to 50% at 1s
 _LEAD_ACCEL_TAU = 1.5
 
+# Hack to maintain vision lead state
+_vision_lead_aTau = {0: _LEAD_ACCEL_TAU, 1: _LEAD_ACCEL_TAU}
+
 # radar tracks
 SPEED, ACCEL = 0, 1   # Kalman filter states enum
 
@@ -130,15 +133,22 @@ class Cluster():
       "aLeadTau": float(self.aLeadTau)
     }
 
-  def get_RadarState_from_vision(self, lead_msg, v_ego):
+  def get_RadarState_from_vision(self, lead_msg, lead_index, v_ego):
+    # Learn if constant acceleration
+    if abs(float(lead_msg.a[0])) < 0.5:
+      _vision_lead_aTau[lead_index] = _LEAD_ACCEL_TAU
+    else:
+      _vision_lead_aTau[lead_index] *= 0.9
+
     return {
       "dRel": float(lead_msg.x[0] - RADAR_TO_CAMERA),
       "yRel": float(-lead_msg.y[0]),
       "vRel": float(lead_msg.v[0] - v_ego),
       "vLead": float(lead_msg.v[0]),
       "vLeadK": float(lead_msg.v[0]),
-      "aLeadK": float(0),
-      "aLeadTau": _LEAD_ACCEL_TAU,
+      "aLead": float(lead_msg.a[0]),
+      "aLeadK": float(lead_msg.a[0]),
+      "aLeadTau": _vision_lead_aTau[lead_index],
       "fcw": False,
       "modelProb": float(lead_msg.prob),
       "radar": False,

--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -5,9 +5,6 @@ from common.kalman.simple_kalman import KF1D
 # Default lead acceleration decay set to 50% at 1s
 _LEAD_ACCEL_TAU = 1.5
 
-# Hack to maintain vision lead state
-_vision_lead_aTau = {0: _LEAD_ACCEL_TAU, 1: _LEAD_ACCEL_TAU}
-
 # radar tracks
 SPEED, ACCEL = 0, 1   # Kalman filter states enum
 
@@ -134,12 +131,6 @@ class Cluster():
     }
 
   def get_RadarState_from_vision(self, lead_msg, lead_index, v_ego):
-    # Learn if constant acceleration
-    if abs(float(lead_msg.a[0])) < 0.5:
-      _vision_lead_aTau[lead_index] = _LEAD_ACCEL_TAU
-    else:
-      _vision_lead_aTau[lead_index] *= 0.9
-
     return {
       "dRel": float(lead_msg.x[0] - RADAR_TO_CAMERA),
       "yRel": float(-lead_msg.y[0]),
@@ -147,7 +138,7 @@ class Cluster():
       "vLead": float(lead_msg.v[0]),
       "vLeadK": float(lead_msg.v[0]),
       "aLeadK": float(lead_msg.a[0]),
-      "aLeadTau": _vision_lead_aTau[lead_index],
+      "aLeadTau": 0.3,  # FIXME: make this a separate named constant
       "fcw": False,
       "modelProb": float(lead_msg.prob),
       "radar": False,

--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -130,7 +130,7 @@ class Cluster():
       "aLeadTau": float(self.aLeadTau)
     }
 
-  def get_RadarState_from_vision(self, lead_msg, v_ego):
+  def get_RadarState_from_vision(self, lead_msg, lead_index, v_ego):
     return {
       "dRel": float(lead_msg.x[0] - RADAR_TO_CAMERA),
       "yRel": float(-lead_msg.y[0]),

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -64,7 +64,7 @@ def match_vision_to_cluster(v_ego, lead, clusters):
     return None
 
 
-def get_lead(v_ego, ready, clusters, lead_msg, low_speed_override=True):
+def get_lead(v_ego, ready, clusters, lead_msg, lead_index, low_speed_override=True):
   # Determine leads, this is where the essential logic happens
   if len(clusters) > 0 and ready and lead_msg.prob > .5:
     cluster = match_vision_to_cluster(v_ego, lead_msg, clusters)
@@ -75,7 +75,7 @@ def get_lead(v_ego, ready, clusters, lead_msg, low_speed_override=True):
   if cluster is not None:
     lead_dict = cluster.get_RadarState(lead_msg.prob)
   elif (cluster is None) and ready and (lead_msg.prob > .5):
-    lead_dict = Cluster().get_RadarState_from_vision(lead_msg, v_ego)
+    lead_dict = Cluster().get_RadarState_from_vision(lead_msg, lead_index, v_ego)
 
   if low_speed_override:
     low_speed_clusters = [c for c in clusters if c.potential_low_speed_lead(v_ego)]
@@ -171,8 +171,8 @@ class RadarD():
 
     leads_v3 = sm['modelV2'].leadsV3
     if len(leads_v3) > 1:
-      radarState.leadOne = get_lead(self.v_ego, self.ready, clusters, leads_v3[0], low_speed_override=True)
-      radarState.leadTwo = get_lead(self.v_ego, self.ready, clusters, leads_v3[1], low_speed_override=False)
+      radarState.leadOne = get_lead(self.v_ego, self.ready, clusters, leads_v3[0], 0, low_speed_override=True)
+      radarState.leadTwo = get_lead(self.v_ego, self.ready, clusters, leads_v3[1], 1, low_speed_override=False)
     return dat
 
 

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -64,7 +64,7 @@ def match_vision_to_cluster(v_ego, lead, clusters):
     return None
 
 
-def get_lead(v_ego, ready, clusters, lead_msg, lead_index, low_speed_override=True):
+def get_lead(v_ego, ready, clusters, lead_msg, low_speed_override=True):
   # Determine leads, this is where the essential logic happens
   if len(clusters) > 0 and ready and lead_msg.prob > .5:
     cluster = match_vision_to_cluster(v_ego, lead_msg, clusters)
@@ -75,7 +75,7 @@ def get_lead(v_ego, ready, clusters, lead_msg, lead_index, low_speed_override=Tr
   if cluster is not None:
     lead_dict = cluster.get_RadarState(lead_msg.prob)
   elif (cluster is None) and ready and (lead_msg.prob > .5):
-    lead_dict = Cluster().get_RadarState_from_vision(lead_msg, lead_index, v_ego)
+    lead_dict = Cluster().get_RadarState_from_vision(lead_msg, v_ego)
 
   if low_speed_override:
     low_speed_clusters = [c for c in clusters if c.potential_low_speed_lead(v_ego)]
@@ -171,8 +171,8 @@ class RadarD():
 
     leads_v3 = sm['modelV2'].leadsV3
     if len(leads_v3) > 1:
-      radarState.leadOne = get_lead(self.v_ego, self.ready, clusters, leads_v3[0], 0, low_speed_override=True)
-      radarState.leadTwo = get_lead(self.v_ego, self.ready, clusters, leads_v3[1], 1, low_speed_override=False)
+      radarState.leadOne = get_lead(self.v_ego, self.ready, clusters, leads_v3[0], low_speed_override=True)
+      radarState.leadTwo = get_lead(self.v_ego, self.ready, clusters, leads_v3[1], low_speed_override=False)
     return dat
 
 


### PR DESCRIPTION
**Description**

For vision-only leads, neither the lead car accel value nor its corresponding Tau factor currently propagate to the radarState leads used by the longitudinal MPC. The vision-only accel data isn't the best, but seems a lot better than nothing.

The absence may help explain why VOACC has trouble promptly reacting to a steady-state lead car that begins to slow down.  IIRC there's also supposed to be some pull-forward effect when departing from a stop in traffic, populating aLeadK may help keep up with traffic if I understood correctly.

**Verification**

Anecdotally I think VOACC (non-E2E policy) drives better with this change. To test it more rigorously, I cheesed up a script to plot the existing longitudinal CI test Maneuvers [with and without aLeadK](https://github.com/commaai/openpilot/blob/a48ec655ac4983145bc93c712ecabac75b886e11/selfdrive/test/longitudinal_maneuvers/plant.py#L88) to simulate the MPC behavior with a VOACC lead.

In this current-state VOACC simulation, with a steady state 20m/s lead decelerating at 1m/s (quite tame), we can just barely make the stop, ending up too close. For a similar lead decelerating at 2m/s (moderate), we close to a collision and an MPC crash. I didn't bother with the 3m/s test. The simulation doesn't apply the aTau factor, but that's also added in this PR and should make the "good" stops better.

-----

**steady state following a car at 20m/s, then lead decel to 0mph at 1m/s^2 -- aLeadK reported**

Baseline, good stop.

![maneuver-2-alead-enabled](https://user-images.githubusercontent.com/46612682/204448073-2aa95dc8-cda2-4e09-89ea-87cf38722cc2.png)

-----

**steady state following a car at 20m/s, then lead decel to 0mph at 1m/s^2 -- aLeadK set to zero**

Uncomfortably close stop.

![maneuver-2-alead-disabled](https://user-images.githubusercontent.com/46612682/204448148-fb39ff0a-b5ab-40c3-88bc-fb127384f3b8.png)

-----

**steady state following a car at 20m/s, then lead decel to 0mph at 2m/s^2 -- aLeadK reported**

Baseline, good stop.

![maneuver-3-alead-enabled](https://user-images.githubusercontent.com/46612682/204448262-22fa9c70-c374-40f2-abca-0bbd29e0a231.png)

-----

**steady state following a car at 20m/s, then lead decel to 0mph at 2m/s^2 -- aLeadK set to zero**

Collision, MPC crash.

![maneuver-3-alead-disabled](https://user-images.githubusercontent.com/46612682/204448291-421d1177-4eb0-4c39-b601-9feeb223d4de.png)
