### PR TITLE
Cabana: execute generate_dbc_json.py after building

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -26,4 +26,4 @@ if GetOption('test'):
 
 def generate_dbc_json(target, source, env):
   env.Execute('tools/cabana/generate_dbc_json.py --out tools/cabana/car_fingerprint_to_dbc.json')
-cabana_env.Command('generate_dbc_json', [], generate_dbc_json )
+cabana_env.Command('generate_dbc_json', [], generate_dbc_json)

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -17,10 +17,13 @@ cabana_env = qt_env.Clone()
 
 prev_moc_path = cabana_env['QT_MOCHPREFIX']
 cabana_env['QT_MOCHPREFIX'] = os.path.dirname(prev_moc_path) + '/cabana/moc_'
-cabana_env.Execute('./generate_dbc_json.py --out car_fingerprint_to_dbc.json')
 cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'binaryview.cc', 'chartswidget.cc', 'historylog.cc', 'videowidget.cc', 'signaledit.cc', 'dbcmanager.cc',
                             'canmessages.cc', 'commands.cc', 'messageswidget.cc', 'settings.cc', 'detailwidget.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('_cabana', ['cabana.cc', cabana_lib], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 
 if GetOption('test'):
   cabana_env.Program('tests/_test_cabana', ['tests/test_runner.cc', 'tests/test_cabana.cc', cabana_lib], LIBS=[cabana_libs])
+
+def generate_dbc_json(target, source, env):
+  env.Execute('tools/cabana/generate_dbc_json.py --out tools/cabana/car_fingerprint_to_dbc.json')
+cabana_env.Command('generate_dbc_json', [], generate_dbc_json )


### PR DESCRIPTION
 fix the dependency error:

> ./generate_dbc_json.py --out car_fingerprint_to_dbc.json
> Traceback (most recent call last):
>   File "./generate_dbc_json.py", line 5, in <module>
>     from selfdrive.car.car_helpers import get_interface_attr
>   File "/home/batman/openpilot/selfdrive/car/car_helpers.py", line 5, in <module>
>     from common.params import Params
>   File "/home/batman/openpilot/common/params.py", line 1, in <module>
>     from common.params_pyx import Params, ParamKeyType, UnknownKeyName, put_nonblocking, put_bool_nonblocking # pylint: disable=no-name-in-module, import-error
> ModuleNotFoundError: No module named 'common.params_pyx'
> scons: *** Error 1