### PR TITLE
controls: preEnabled doesn't consider noEntry

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -518,10 +518,7 @@ class Controls:
 
         # PRE ENABLING
         elif self.state == State.preEnabled:
-          if self.events.any(ET.NO_ENTRY):
-            self.state = State.disabled
-            self.current_alert_types.append(ET.NO_ENTRY)
-          elif not self.events.any(ET.PRE_ENABLE):
+          if not self.events.any(ET.PRE_ENABLE):
             self.state = State.enabled
           else:
             self.current_alert_types.append(ET.PRE_ENABLE)

--- a/selfdrive/controls/tests/test_state_machine.py
+++ b/selfdrive/controls/tests/test_state_machine.py
@@ -79,7 +79,7 @@ class TestStateMachine(unittest.TestCase):
     self.assertEqual(self.controlsd.state, State.disabled)
 
   def test_no_entry(self):
-    # disabled with enable events
+    # Make sure noEntry keeps us disabled
     for et in ENABLE_EVENT_TYPES:
       self.controlsd.events.add(make_event([ET.NO_ENTRY, et]))
       self.controlsd.state_transition(self.CS)
@@ -87,11 +87,11 @@ class TestStateMachine(unittest.TestCase):
       self.controlsd.events.clear()
 
   def test_no_entry_pre_enable(self):
-    # preEnabled with preEnabled event
+    # preEnabled with noEntry event
     self.controlsd.state = State.preEnabled
     self.controlsd.events.add(make_event([ET.NO_ENTRY, ET.PRE_ENABLE]))
     self.controlsd.state_transition(self.CS)
-    self.assertEqual(self.controlsd.state, State.disabled)
+    self.assertEqual(self.controlsd.state, State.preEnabled)
 
   def test_maintain_states(self):
     # Given current state's event type, we should maintain state


### PR DESCRIPTION
For pre-enabling on brake. Doesn't make sense to consider noEntries added after we've already preEnabled (which is a subset of enabled)