### PR TITLE
Cabana: setSectionResizeMode to QHeaderView::Fixed

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -23,6 +23,7 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   setItemDelegate(delegate);
   horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
   verticalHeader()->setSectionsClickable(false);
+  verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
   horizontalHeader()->hide();
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);


### PR DESCRIPTION
Set the section resize mode to fixed to prevent user resize the section:

[Kazam_screencast_00038.webm](https://user-images.githubusercontent.com/27770/205032010-164447c7-b306-4abd-9e8a-f20319151690.webm)
