### PR TITLE
VW MQB: Engage at standstill with OP longitudinal

### DIFF
--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -230,7 +230,7 @@ class CarInterface(CarInterfaceBase):
       events.add(EventName.belowSteerSpeed)
 
     if self.CS.CP.openpilotLongitudinalControl:
-      if ret.vEgo < self.CP.minEnableSpeed + 2.:
+      if ret.vEgo < self.CP.minEnableSpeed + 0.5:
         events.add(EventName.belowEngageSpeed)
       if c.enabled and ret.vEgo < self.CP.minEnableSpeed:
         events.add(EventName.speedTooLow)

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -230,7 +230,7 @@ class CarInterface(CarInterfaceBase):
       events.add(EventName.belowSteerSpeed)
 
     if self.CS.CP.openpilotLongitudinalControl:
-      if self.CP.minEnableSpeed > 0 and ret.vEgo < self.CP.minEnableSpeed + 2.0:
+      if ret.vEgo < self.CP.minEnableSpeed + 0.5:
         events.add(EventName.belowEngageSpeed)
       if c.enabled and ret.vEgo < self.CP.minEnableSpeed:
         events.add(EventName.speedTooLow)

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -230,7 +230,7 @@ class CarInterface(CarInterfaceBase):
       events.add(EventName.belowSteerSpeed)
 
     if self.CS.CP.openpilotLongitudinalControl:
-      if ret.vEgo < self.CP.minEnableSpeed + 0.5:
+      if self.CP.minEnableSpeed > 0 and ret.vEgo < self.CP.minEnableSpeed + 2.0:
         events.add(EventName.belowEngageSpeed)
       if c.enabled and ret.vEgo < self.CP.minEnableSpeed:
         events.add(EventName.speedTooLow)


### PR DESCRIPTION
**Description**

Fix a bug with VW belowEngageSpeed/speedTooLow that prevented engaging at standstill.

**Verification**

Successfully tested several engages from standstill with brake pressed, with and without leads and stoplights.

Tested only for SnG cars. May or may not work on FtS cars, but those need more support code anyway.

**Route**

Route: `3cfdec54aa035f3f|2022-11-30--23-25-39`