### PR TITLE
Increase Minimum Offroad Battery Voltage

### DIFF
--- a/selfdrive/thermald/power_monitoring.py
+++ b/selfdrive/thermald/power_monitoring.py
@@ -9,14 +9,14 @@ from selfdrive.statsd import statlog
 
 CAR_VOLTAGE_LOW_PASS_K = 0.091 # LPF gain for 5s tau (dt/tau / (dt/tau + 1))
 
-# A C2 uses about 1W while idling, and 30h seens like a good shutoff for most cars
+# A C3 uses about 3.7W while idling, and 10h seens like a good shutoff for most cars
 # While driving, a battery charges completely in about 30-60 minutes
 CAR_BATTERY_CAPACITY_uWh = 30e6
 CAR_CHARGING_RATE_W = 45
 
-VBATT_PAUSE_CHARGING = 11.0           # Lower limit on the LPF car battery voltage
+VBATT_PAUSE_CHARGING = 12.0           # Lower limit on the LPF car battery voltage
 VBATT_INSTANT_PAUSE_CHARGING = 7.0    # Lower limit on the instant car battery voltage measurements to avoid triggering on instant power loss
-MAX_TIME_OFFROAD_S = 30*3600
+MAX_TIME_OFFROAD_S = 10*3600
 MIN_ON_TIME_S = 3600
 
 class PowerMonitoring:

--- a/selfdrive/thermald/power_monitoring.py
+++ b/selfdrive/thermald/power_monitoring.py
@@ -121,4 +121,5 @@ class PowerMonitoring:
     should_shutdown &= in_car
     should_shutdown |= self.params.get_bool("ForcePowerDown")
     should_shutdown &= started_seen or (now > MIN_ON_TIME_S)
+    should_shutdown &= self.params.get_bool("IsOffroad")
     return should_shutdown

--- a/selfdrive/thermald/power_monitoring.py
+++ b/selfdrive/thermald/power_monitoring.py
@@ -121,5 +121,4 @@ class PowerMonitoring:
     should_shutdown &= in_car
     should_shutdown |= self.params.get_bool("ForcePowerDown")
     should_shutdown &= started_seen or (now > MIN_ON_TIME_S)
-    should_shutdown &= self.params.get_bool("IsOffroad")
     return should_shutdown

--- a/selfdrive/thermald/power_monitoring.py
+++ b/selfdrive/thermald/power_monitoring.py
@@ -9,14 +9,13 @@ from selfdrive.statsd import statlog
 
 CAR_VOLTAGE_LOW_PASS_K = 0.091 # LPF gain for 5s tau (dt/tau / (dt/tau + 1))
 
-# A C3 uses about 3.7W while idling, and 10h seens like a good shutoff for most cars
 # While driving, a battery charges completely in about 30-60 minutes
 CAR_BATTERY_CAPACITY_uWh = 30e6
 CAR_CHARGING_RATE_W = 45
 
-VBATT_PAUSE_CHARGING = 12.0           # Lower limit on the LPF car battery voltage
+VBATT_PAUSE_CHARGING = 11.8           # Lower limit on the LPF car battery voltage
 VBATT_INSTANT_PAUSE_CHARGING = 7.0    # Lower limit on the instant car battery voltage measurements to avoid triggering on instant power loss
-MAX_TIME_OFFROAD_S = 10*3600
+MAX_TIME_OFFROAD_S = 30*3600
 MIN_ON_TIME_S = 3600
 
 class PowerMonitoring:

--- a/selfdrive/thermald/power_monitoring.py
+++ b/selfdrive/thermald/power_monitoring.py
@@ -7,7 +7,7 @@ from system.hardware import HARDWARE
 from system.swaglog import cloudlog
 from selfdrive.statsd import statlog
 
-CAR_VOLTAGE_LOW_PASS_K = 0.091 # LPF gain for 5s tau (dt/tau / (dt/tau + 1))
+CAR_VOLTAGE_LOW_PASS_K = 0.011 # LPF gain for 45s tau (dt/tau / (dt/tau + 1))
 
 # While driving, a battery charges completely in about 30-60 minutes
 CAR_BATTERY_CAPACITY_uWh = 30e6


### PR DESCRIPTION
This PR supercedes https://github.com/commaai/openpilot/pull/26640

Updated minimum offroad battery voltage and increased lowpass filter to a value of Tau = 45s.

Most vehicles make use of lead acid batteries which during normal use shouldn't ever decrease below ~12V (different sources give a range of 11.9-12.2V). Increasing this limit will prevent premature battery failure by preventing excessive sulfation of the cells and by extension prematurely reduce the remaining life of the car battery.

Offroad Battery Voltage Distribution (Last 7 Days):
![image-1](https://user-images.githubusercontent.com/51210836/205119078-78a8c0ca-cae4-4b75-a842-0cfd79a18283.png)

![image](https://user-images.githubusercontent.com/51210836/204896525-9ecc7e01-ddf4-4381-a4d3-a145676243d5.png)
![image](https://user-images.githubusercontent.com/51210836/204894976-b65acac2-bd43-4351-8ab3-71645b55e89f.png)