### PR TITLE
Toyota: log ACC faulted

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -123,6 +123,7 @@ class CarState(CarStateBase):
     ret.cruiseState.standstill = self.pcm_acc_status == 7
     ret.cruiseState.enabled = bool(cp.vl["PCM_CRUISE"]["CRUISE_ACTIVE"])
     ret.cruiseState.nonAdaptive = cp.vl["PCM_CRUISE"]["CRUISE_STATE"] in (1, 2, 3, 4, 5, 6)
+    ret.accFaulted = cp.vl["PCM_CRUISE_SM"]["ACC_FAULTED"] != 0
 
     ret.genericToggle = bool(cp.vl["LIGHT_STALK"]["AUTO_HIGH_BEAM"])
     ret.espDisabled = cp.vl["ESP_CONTROL"]["TC_DISABLED"] != 0
@@ -162,6 +163,7 @@ class CarState(CarStateBase):
       ("CRUISE_STATE", "PCM_CRUISE"),
       ("GAS_RELEASED", "PCM_CRUISE"),
       ("UI_SET_SPEED", "PCM_CRUISE_SM"),
+      ("ACC_FAULTED", "PCM_CRUISE_SM"),
       ("STEER_TORQUE_DRIVER", "STEER_TORQUE_SENSOR"),
       ("STEER_TORQUE_EPS", "STEER_TORQUE_SENSOR"),
       ("STEER_ANGLE", "STEER_TORQUE_SENSOR"),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -93,8 +93,7 @@ class CarState(CarStateBase):
     ret.steerFaultPermanent = cp.vl["EPS_STATUS"]["LKA_STATE"] in (3, 17)
 
     if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
-      # TODO: find the bit likely in DSU_CRUISE that describes an ACC fault.
-      # if none available, use signal in slower PCM_CRUISE_SM msg
+      # TODO: find the bit likely in DSU_CRUISE that describes an ACC fault. one may also exist in CLUTCH
       ret.cruiseState.available = cp.vl["DSU_CRUISE"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["DSU_CRUISE"]["SET_SPEED"] * CV.KPH_TO_MS
       cluster_set_speed = cp.vl["PCM_CRUISE_ALT"]["UI_SET_SPEED"]


### PR DESCRIPTION
Currently, openpilot is oblivious to any ACC faults on Toyota. If one occurs while engaged, we treat it as a user-disengage which isn't right. Ran on the fleet, this catches at least 14 segments. Here's a few examples:

- Brake pressed timing mismatch between OP and panda, panda blocks ACC msgs: ![Screenshot from 2022-12-03 02-38-28](https://user-images.githubusercontent.com/25857203/205436787-50e2daac-7d04-47a5-b883-8d35eab78cb9.png) 
- We started dropping msgs from the car, as well as our msgs failed to go out on the bus:
![Screenshot from 2022-12-03 02-58-57](https://user-images.githubusercontent.com/25857203/205437497-b8257aa1-a432-4116-a9d9-bb20aedbf6f8.png)
- C3 rebooted onroad, when it came back up, ACC fault: 1a7cdd18eaddea28|2022-10-15--17-12-45--0, 6244c0eb1696231c|2022-11-25--09-59-40--0, 3d2b038d1276f564|2022-11-23--17-11-56--0