### PR TITLE
Toyota: log EPS fault from LKA cmd message drop out

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -85,10 +85,12 @@ class CarState(CarStateBase):
     ret.steeringTorqueEps = cp.vl["STEER_TORQUE_SENSOR"]["STEER_TORQUE_EPS"] * self.eps_torque_scale
     # we could use the override bit from dbc, but it's triggered at too high torque values
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
-    # steer rate fault, goes to 21 or 25 for 1 frame, then 9 for ~2 seconds
-    ret.steerFaultTemporary = cp.vl["EPS_STATUS"]["LKA_STATE"] in (0, 9, 21, 25)
+    # steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
+    # lka msg drop out: goes to 9 then 11 for a combined total of 2 seconds
+    ret.steerFaultTemporary = cp.vl["EPS_STATUS"]["LKA_STATE"] in (0, 9, 11, 21, 25)
     # 17 is a fault from a prolonged high torque delta between cmd and user
-    ret.steerFaultPermanent = cp.vl["EPS_STATUS"]["LKA_STATE"] == 17
+    # 3 is a fault from the lka command message not being received by the EPS
+    ret.steerFaultPermanent = cp.vl["EPS_STATUS"]["LKA_STATE"] in (3, 17)
 
     if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
       ret.cruiseState.available = cp.vl["DSU_CRUISE"]["MAIN_ON"] != 0


### PR DESCRIPTION
The LKA_STATE code for the EPS failing to receive LKA msgs is 3, and on rising edge of the fault ***while engaged*** it goes to 9 for ~1.2 seconds, then 11 for 0.8 seconds, then rests at 3 (recoverable if EPS gets steering msgs again).

If openpilot were ever to stop sending LKA messages and the EPS status was at 3, openpilot would enable without any steering assist or warnings (not even from car).

f15e3c37c118e841|2022-12-02--23-47-57

![Screenshot from 2022-12-03 01-02-12](https://user-images.githubusercontent.com/25857203/205433147-7dc8646e-23cd-46e1-a8db-d654226e6133.png)