### PR TITLE
Replay: fix SEGFAULT in buildTimeline if segments are not continuous.

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -123,9 +123,9 @@ void Replay::buildTimeline() {
   uint64_t alert_begin = 0;
   TimelineType alert_type = TimelineType::None;
 
-  for (int i = 0; i < segments_.size() && !exit_; ++i) {
+  for (auto it = segments_.cbegin(); it != segments_.cend() && !exit_; ++it) {
     LogReader log;
-    if (!log.load(route_->at(i).qlog.toStdString(), &exit_,
+    if (!log.load(route_->at(it->first).qlog.toStdString(), &exit_,
                   {cereal::Event::Which::CONTROLS_STATE, cereal::Event::Which::USER_FLAG},
                   !hasFlag(REPLAY_FLAG_NO_FILE_CACHE), 0, 3)) continue;
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
