### PR TITLE
Car docs: update CAN-FD footnote

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -233,7 +233,7 @@ A supported vehicle is one that just works when you install a comma three. All s
 <sup>2</sup>By default, this car will use the stock Adaptive Cruise Control (ACC) for longitudinal control. If the Driver Support Unit (DSU) is disconnected, openpilot ACC will replace stock ACC. <b><i>NOTE: disconnecting the DSU disables Automatic Emergency Braking (AEB).</i></b> <br />
 <sup>3</sup>Requires a <a href="https://github.com/commaai/openpilot/wiki/GM#hardware">community built ASCM harness</a>. <b><i>NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).</i></b> <br />
 <sup>4</sup>2019 Honda Civic 1.6L Diesel Sedan does not have ALC below 12mph. <br />
-<sup>5</sup>Requires a <a href="https://comma.ai/shop/panda" target="_blank">red panda</a> and additional <a href="https://comma.ai/shop/harness-box" target="_blank">harness box</a>. Also requires a USB-A to USB-C OTG dongle, USB-A to USB-A cable, and a USB-C to USB-C 3.1 Gen 2 cable. <br />
+<sup>5</sup>Requires a <a href="https://comma.ai/shop/panda" target="_blank">red panda</a> and additional <a href="https://comma.ai/shop/harness-box" target="_blank">harness box</a>. Also requires an extra <a href="https://comma.ai/shop/obd-c-cable" target="_blank">OBD-C cable</a>, USB-A to USB-A cable, and a USB-A to USB-C OTG dongle. <br />
 <sup>6</sup>openpilot operates above 28mph for Camry 4CYL L, 4CYL LE and 4CYL SE which don't have Full-Speed Range Dynamic Radar Cruise Control. <br />
 <sup>7</sup>Not including the China market Kamiq, which is based on the (currently) unsupported PQ34 platform. <br />
 <sup>8</sup>Refers only to the MQB-based European B8 Passat, not the NMS Passat in the USA/China/Mideast markets. <br />

--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -233,7 +233,7 @@ A supported vehicle is one that just works when you install a comma three. All s
 <sup>2</sup>By default, this car will use the stock Adaptive Cruise Control (ACC) for longitudinal control. If the Driver Support Unit (DSU) is disconnected, openpilot ACC will replace stock ACC. <b><i>NOTE: disconnecting the DSU disables Automatic Emergency Braking (AEB).</i></b> <br />
 <sup>3</sup>Requires a <a href="https://github.com/commaai/openpilot/wiki/GM#hardware">community built ASCM harness</a>. <b><i>NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).</i></b> <br />
 <sup>4</sup>2019 Honda Civic 1.6L Diesel Sedan does not have ALC below 12mph. <br />
-<sup>5</sup>Requires a <a href="https://comma.ai/shop/panda" target="_blank">red panda</a> and additional <a href="https://comma.ai/shop/harness-box" target="_blank">harness box</a>. Also requires an extra <a href="https://comma.ai/shop/obd-c-cable" target="_blank">OBD-C cable</a>, USB-A to USB-A cable, and a USB-A to USB-C OTG dongle. <br />
+<sup>5</sup>Requires a <a href="https://comma.ai/shop/panda" target="_blank">red panda</a>, additional <a href="https://comma.ai/shop/harness-box" target="_blank">harness box</a>, additional <a href="https://comma.ai/shop/obd-c-cable" target="_blank">OBD-C cable</a>, USB-A to USB-A cable, and a USB-A to USB-C OTG dongle. <br />
 <sup>6</sup>openpilot operates above 28mph for Camry 4CYL L, 4CYL LE and 4CYL SE which don't have Full-Speed Range Dynamic Radar Cruise Control. <br />
 <sup>7</sup>Not including the China market Kamiq, which is based on the (currently) unsupported PQ34 platform. <br />
 <sup>8</sup>Refers only to the MQB-based European B8 Passat, not the NMS Passat in the USA/China/Mideast markets. <br />

--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -233,7 +233,7 @@ A supported vehicle is one that just works when you install a comma three. All s
 <sup>2</sup>By default, this car will use the stock Adaptive Cruise Control (ACC) for longitudinal control. If the Driver Support Unit (DSU) is disconnected, openpilot ACC will replace stock ACC. <b><i>NOTE: disconnecting the DSU disables Automatic Emergency Braking (AEB).</i></b> <br />
 <sup>3</sup>Requires a <a href="https://github.com/commaai/openpilot/wiki/GM#hardware">community built ASCM harness</a>. <b><i>NOTE: disconnecting the ASCM disables Automatic Emergency Braking (AEB).</i></b> <br />
 <sup>4</sup>2019 Honda Civic 1.6L Diesel Sedan does not have ALC below 12mph. <br />
-<sup>5</sup>Requires a <a href="https://comma.ai/shop/panda" target="_blank">red panda</a> and additional <a href="https://comma.ai/shop/harness-box" target="_blank">harness box</a>. Also requires a USB-A to USB-C adapter and USB-A to USB-A cable. <br />
+<sup>5</sup>Requires a <a href="https://comma.ai/shop/panda" target="_blank">red panda</a> and additional <a href="https://comma.ai/shop/harness-box" target="_blank">harness box</a>. Also requires a USB-A to USB-C OTG dongle, USB-A to USB-A cable, and a USB-C to USB-C 3.1 Gen 2 cable. <br />
 <sup>6</sup>openpilot operates above 28mph for Camry 4CYL L, 4CYL LE and 4CYL SE which don't have Full-Speed Range Dynamic Radar Cruise Control. <br />
 <sup>7</sup>Not including the China market Kamiq, which is based on the (currently) unsupported PQ34 platform. <br />
 <sup>8</sup>Refers only to the MQB-based European B8 Passat, not the NMS Passat in the USA/China/Mideast markets. <br />

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -120,7 +120,7 @@ class CAR:
 class Footnote(Enum):
   CANFD = CarFootnote(
     "Requires a <a href=\"https://comma.ai/shop/panda\" target=\"_blank\">red panda</a> and additional <a href=\"https://comma.ai/shop/harness-box\" target=\"_blank\">harness box</a>. " +
-    "Also requires a USB-A to USB-C OTG dongle, USB-A to USB-A cable, and a USB-C to USB-C 3.1 Gen 2 cable.",
+    "Also requires an extra <a href=\"https://comma.ai/shop/obd-c-cable\" target=\"_blank\">OBD-C cable</a>, USB-A to USB-A cable, and a USB-A to USB-C OTG dongle.",
     Column.MODEL, shop_footnote=True)
 
 

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -120,7 +120,7 @@ class CAR:
 class Footnote(Enum):
   CANFD = CarFootnote(
     "Requires a <a href=\"https://comma.ai/shop/panda\" target=\"_blank\">red panda</a> and additional <a href=\"https://comma.ai/shop/harness-box\" target=\"_blank\">harness box</a>. " +
-    "Also requires a USB-A to USB-C adapter and USB-A to USB-A cable.",
+    "Also requires a USB-A to USB-C OTG dongle, USB-A to USB-A cable, and a USB-C to USB-C 3.1 Gen 2 cable.",
     Column.MODEL, shop_footnote=True)
 
 

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -119,8 +119,8 @@ class CAR:
 
 class Footnote(Enum):
   CANFD = CarFootnote(
-    "Requires a <a href=\"https://comma.ai/shop/panda\" target=\"_blank\">red panda</a> and additional <a href=\"https://comma.ai/shop/harness-box\" target=\"_blank\">harness box</a>. " +
-    "Also requires an extra <a href=\"https://comma.ai/shop/obd-c-cable\" target=\"_blank\">OBD-C cable</a>, USB-A to USB-A cable, and a USB-A to USB-C OTG dongle.",
+    "Requires a <a href=\"https://comma.ai/shop/panda\" target=\"_blank\">red panda</a>, additional <a href=\"https://comma.ai/shop/harness-box\" target=\"_blank\">harness box</a>, " +
+    "additional <a href=\"https://comma.ai/shop/obd-c-cable\" target=\"_blank\">OBD-C cable</a>, USB-A to USB-A cable, and a USB-A to USB-C OTG dongle.",
     Column.MODEL, shop_footnote=True)
 
 


### PR DESCRIPTION
You actually need another 3.1 Gen 2 cable (at least 10 Gbps), and the adapter has to specifically be OTG