### PR TITLE
ui: stop vipc thread before the DriverViewWindow is hidden

### DIFF
--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -22,6 +22,7 @@ DriverViewWindow::DriverViewWindow(QWidget* parent) : QWidget(parent) {
 }
 
 void DriverViewWindow::mouseReleaseEvent(QMouseEvent* e) {
+  cameraView->stopVipcThread();
   emit done();
 }
 
@@ -35,7 +36,6 @@ void DriverViewScene::showEvent(QShowEvent* event) {
 }
 
 void DriverViewScene::hideEvent(QHideEvent* event) {
-  // TODO: stop vipc thread ?
   params.putBool("IsDriverViewEnabled", false);
 }
 

--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -35,6 +35,7 @@ public:
   void setFrameId(int frame_id) { draw_frame_id = frame_id; }
   void setStreamType(VisionStreamType type) { requested_stream_type = type; }
   VisionStreamType getStreamType() { return active_stream_type; }
+  void stopVipcThread();
 
 signals:
   void clicked();
@@ -51,7 +52,6 @@ protected:
   void updateCalibration(const mat3 &calib);
   void vipcThread();
   void clearFrames();
-  void stopVipcThread();
 
   bool zoomed_view;
   GLuint frame_vao, frame_vbo, frame_ibo;


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
