### PR TITLE
Replay: fix possible segfault on exit

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -51,9 +51,9 @@ void Replay::stop() {
     stream_thread_->wait();
     stream_thread_ = nullptr;
   }
-  segments_.clear();
   camera_server_.reset(nullptr);
   timeline_future.waitForFinished();
+  segments_.clear();
   rInfo("shutdown: done");
 }
 


### PR DESCRIPTION
it may cause segfault if stop camera server after clearing segments:
```
 Stack trace of thread 3265702:
  #0  0x000000000046acc4 _ZN9VisionBuf12set_frame_idEm (/media/home/deanlee/openpilot/tools/cabana/_cabana + 0x6acc4)
  #1  0x0000000000474f57 _ZN12CameraServer12cameraThreadERNS_6CameraE (/media/home/deanlee/openpilot/tools/cabana/_cabana + 0x74f57)
  #2  0x00007fbb5c89bde4 n/a (n/a + 0x0)
```
