### PR TITLE
Cabana: fix "show plot" button state sync issue

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -152,12 +152,12 @@ void ChartsWidget::showChart(const QString &id, const Signal *sig, bool show, bo
       QObject::connect(chart, &ChartView::remove, [=]() { removeChart(chart); });
       QObject::connect(chart, &ChartView::zoomIn, this, &ChartsWidget::zoomIn);
       QObject::connect(chart, &ChartView::zoomReset, this, &ChartsWidget::zoomReset);
-      QObject::connect(chart, &ChartView::seriesRemoved, this, &ChartsWidget::chartClosed);
+      QObject::connect(chart, &ChartView::seriesRemoved, this, &ChartsWidget::seriesChanged);
+      QObject::connect(chart, &ChartView::seriesAdded, this, &ChartsWidget::seriesChanged);
       charts_layout->insertWidget(0, chart);
       charts.push_back(chart);
     }
     chart->addSeries(id, sig);
-    emit chartOpened(id, sig);
   } else if (ChartView *chart = findChart(id, sig)) {
     chart->removeSeries(id, sig);
   }
@@ -169,11 +169,16 @@ void ChartsWidget::removeChart(ChartView *chart) {
   charts.removeOne(chart);
   chart->deleteLater();
   updateToolBar();
+  emit seriesChanged();
 }
 
 void ChartsWidget::removeAll() {
-  for (auto c : charts.toVector())
-    removeChart(c);
+  for (auto c : charts) {
+    c->deleteLater();
+  }
+  charts.clear();
+  updateToolBar();
+  emit seriesChanged();
 }
 
 bool ChartsWidget::eventFilter(QObject *obj, QEvent *event) {
@@ -227,11 +232,6 @@ ChartView::ChartView(QWidget *parent) : QChartView(nullptr, parent) {
   QObject::connect(manage_btn, &QToolButton::clicked, this, &ChartView::manageSeries);
 }
 
-ChartView::~ChartView() {
-  for (auto &s : sigs)
-    emit seriesRemoved(s.msg_id, s.sig);
-}
-
 void ChartView::addSeries(const QString &msg_id, const Signal *sig) {
   QLineSeries *series = new QLineSeries(this);
   series->setUseOpenGL(true);
@@ -243,6 +243,7 @@ void ChartView::addSeries(const QString &msg_id, const Signal *sig) {
   updateTitle();
   updateSeries(sig);
   updateAxisY();
+  emit seriesAdded(msg_id, sig);
 }
 
 void ChartView::removeSeries(const QString &msg_id, const Signal *sig) {
@@ -259,9 +260,10 @@ bool ChartView::hasSeries(const QString &msg_id, const Signal *sig) const {
 QList<ChartView::SigItem>::iterator ChartView::removeSeries(const QList<ChartView::SigItem>::iterator &it) {
   chart()->removeSeries(it->series);
   it->series->deleteLater();
-  emit seriesRemoved(it->msg_id, it->sig);
-
+  QString msg_id = it->msg_id;
+  const Signal *sig = it->sig;
   auto ret = sigs.erase(it);
+  emit seriesRemoved(msg_id, sig);
   if (!sigs.isEmpty()) {
     updateAxisY();
   } else {

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -20,7 +20,6 @@ class ChartView : public QChartView {
 
 public:
   ChartView(QWidget *parent = nullptr);
-  ~ChartView();
   void addSeries(const QString &msg_id, const Signal *sig);
   void removeSeries(const QString &msg_id, const Signal *sig);
   bool hasSeries(const QString &msg_id, const Signal *sig) const;
@@ -41,6 +40,7 @@ public:
 
 signals:
   void seriesRemoved(const QString &id, const Signal *sig);
+  void seriesAdded(const QString &id, const Signal *sig);
   void zoomIn(double min, double max);
   void zoomReset();
   void remove();
@@ -81,16 +81,15 @@ class ChartsWidget : public QWidget {
 public:
   ChartsWidget(QWidget *parent = nullptr);
   void showChart(const QString &id, const Signal *sig, bool show, bool merge);
-  void removeChart(ChartView *chart);
-  inline bool isChartOpened(const QString &id, const Signal *sig) { return findChart(id, sig) != nullptr; }
+  inline bool hasSignal(const QString &id, const Signal *sig) { return findChart(id, sig) != nullptr; }
 
 signals:
   void dock(bool floating);
   void rangeChanged(double min, double max, bool is_zommed);
-  void chartOpened(const QString &id, const Signal *sig);
-  void chartClosed(const QString &id, const Signal *sig);
+  void seriesChanged();
 
 private:
+  void removeChart(ChartView *chart);
   void eventsMerged();
   void updateState();
   void updateDisplayRange();

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -107,8 +107,7 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
     }
   });
   QObject::connect(tabbar, &QTabBar::tabCloseRequested, tabbar, &QTabBar::removeTab);
-  QObject::connect(charts, &ChartsWidget::chartOpened, [this](const QString &id, const Signal *sig) { updateChartState(id, sig, true); });
-  QObject::connect(charts, &ChartsWidget::chartClosed, [this](const QString &id, const Signal *sig) { updateChartState(id, sig, false); });
+  QObject::connect(charts, &ChartsWidget::seriesChanged, this, &DetailWidget::updateChartState);
   QObject::connect(undo_stack, &QUndoStack::indexChanged, [this]() {
     if (undo_stack->count() > 0)
       dbcMsgChanged();
@@ -169,7 +168,7 @@ void DetailWidget::dbcMsgChanged(int show_form_idx) {
         signal_list.push_back(form);
       }
       form->setSignal(msg_id, sig);
-      form->setChartOpened(charts->isChartOpened(msg_id, sig));
+      form->setChartOpened(charts->hasSignal(msg_id, sig));
       ++i;
     }
     if (msg->size != can->lastMessage(msg_id).dat.size())
@@ -212,9 +211,9 @@ void DetailWidget::showForm(const Signal *sig) {
   setUpdatesEnabled(true);
 }
 
-void DetailWidget::updateChartState(const QString &id, const Signal *sig, bool opened) {
+void DetailWidget::updateChartState() {
   for (auto f : signal_list)
-    if (f->msg_id == id && f->sig == sig) f->setChartOpened(opened);
+    f->setChartOpened(charts->hasSignal(f->msg_id, f->sig));
 }
 
 void DetailWidget::editMsg() {
@@ -334,4 +333,3 @@ WelcomeWidget::WelcomeWidget(QWidget *parent) : QWidget(parent) {
 
   setStyleSheet("QLabel{color:darkGray;}");
 }
-

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -35,7 +35,7 @@ public:
 
 private:
   void showForm(const Signal *sig);
-  void updateChartState(const QString &id, const Signal *sig, bool opened);
+  void updateChartState();
   void showTabBarContextMenu(const QPoint &pt);
   void addSignal(int start_bit, int size, bool little_endian);
   void resizeSignal(const Signal *sig, int from, int to);


### PR DESCRIPTION
Fixed the "show plot" button cannot sync state with charts after user manages the series through the `SeriesSelector` dialog :

![Screenshot from 2022-12-12 23-44-03](https://user-images.githubusercontent.com/27770/207089039-25dd0b4b-9f3a-4cfd-9aa5-059e8332b80f.png)
