### PR TITLE
EV6: switch blinker signal

### DIFF
--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -192,8 +192,8 @@ class CarState(CarStateBase):
     ret.steeringPressed = abs(ret.steeringTorque) > self.params.STEER_THRESHOLD
     ret.steerFaultTemporary = cp.vl["MDPS"]["LKA_FAULT"] != 0
 
-    ret.leftBlinker, ret.rightBlinker = self.update_blinker_from_lamp(50, cp.vl["BLINKERS"]["LEFT_LAMP"],
-                                                                      cp.vl["BLINKERS"]["RIGHT_LAMP"])
+    ret.leftBlinker, ret.rightBlinker = self.update_blinker_from_lamp(200, cp.vl["BLINKER_STALKS"]["LEFT_BLINKER"],
+                                                                      cp.vl["BLINKER_STALKS"]["RIGHT_BLINKER"])
     if self.CP.enableBsm:
       ret.leftBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["FL_INDICATOR"] != 0
       ret.rightBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["FR_INDICATOR"] != 0
@@ -442,8 +442,8 @@ class CarState(CarStateBase):
 
       ("DISTANCE_UNIT", "CLUSTER_INFO"),
 
-      ("LEFT_LAMP", "BLINKERS"),
-      ("RIGHT_LAMP", "BLINKERS"),
+      ("LEFT_BLINKER", "BLINKER_STALKS"),
+      ("RIGHT_BLINKER", "BLINKER_STALKS"),
 
       ("DRIVER_DOOR_OPEN", "DOORS_SEATBELTS"),
       ("DRIVER_SEATBELT_LATCHED", "DOORS_SEATBELTS"),
@@ -460,7 +460,7 @@ class CarState(CarStateBase):
       ("TCS", 50),
       (cruise_btn_msg, 50),
       ("CLUSTER_INFO", 4),
-      ("BLINKERS", 4),
+      ("BLINKER_STALKS", 1),
       ("DOORS_SEATBELTS", 4),
     ]
 


### PR DESCRIPTION
The lamp signal previously used naturally includes openpilot-commanded blinkers. In the future, we'll probably want to split blinker user command from the lamp state in carState.