### PR TITLE
Cabana: add signal value filters to the logs view

### DIFF
--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -32,30 +32,6 @@ bool CANMessages::loadRoute(const QString &route, const QString &data_dir, uint3
   return false;
 }
 
-QList<QPointF> CANMessages::findSignalValues(const QString &id, const Signal *signal, double value, FindFlags flag, int max_count) {
-  auto evts = events();
-  if (!evts) return {};
-
-  QList<QPointF> ret;
-  ret.reserve(max_count);
-  auto [bus, address] = DBCManager::parseId(id);
-  for (auto &evt : *evts) {
-    if (evt->which != cereal::Event::Which::CAN) continue;
-
-    for (const auto &c : evt->event.getCan()) {
-      if (bus == c.getSrc() && address == c.getAddress()) {
-        double val = get_raw_value((uint8_t *)c.getDat().begin(), c.getDat().size(), *signal);
-        if ((flag == EQ && val == value) || (flag == LT && val < value) || (flag == GT && val > value)) {
-          ret.push_back({(evt->mono_time / (double)1e9) - can->routeStartTime(), val});
-          if (ret.size() >= max_count)
-            return ret;
-        }
-      }
-    }
-  }
-  return ret;
-}
-
 void CANMessages::process(QHash<QString, CanData> *messages) {
   for (auto it = messages->begin(); it != messages->end(); ++it) {
     can_msgs[it.key()] = it.value();

--- a/tools/cabana/canmessages.h
+++ b/tools/cabana/canmessages.h
@@ -4,7 +4,6 @@
 
 #include <QColor>
 #include <QHash>
-#include <QList>
 
 #include "opendbc/can/common_dbc.h"
 #include "tools/cabana/settings.h"
@@ -21,12 +20,10 @@ class CANMessages : public QObject {
   Q_OBJECT
 
 public:
-  enum FindFlags{ EQ, LT, GT };
   CANMessages(QObject *parent);
   ~CANMessages();
   bool loadRoute(const QString &route, const QString &data_dir, uint32_t replay_flags = REPLAY_FLAG_NONE);
   void seekTo(double ts);
-  QList<QPointF> findSignalValues(const QString&id, const Signal* signal, double value, FindFlags flag, int max_count);
   bool eventFilter(const Event *event);
 
   inline QString routeName() const { return replay->route()->name(); }

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -86,7 +86,7 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   tab_widget = new QTabWidget(this);
   tab_widget->setTabPosition(QTabWidget::South);
   tab_widget->addTab(scroll, "&Msg");
-  history_log = new HistoryLog(this);
+  history_log = new LogsWidget(this);
   tab_widget->addTab(history_log, "&Logs");
   main_layout->addWidget(tab_widget);
 

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -53,7 +53,7 @@ private:
   QTabWidget *tab_widget;
   QToolBar *toolbar;
   QAction *remove_msg_act;
-  HistoryLog *history_log;
+  LogsWidget *history_log;
   BinaryView *binary_view;
   QScrollArea *scroll;
   ChartsWidget *charts;

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <deque>
+#include <QComboBox>
 #include <QHeaderView>
+#include <QLineEdit>
 #include <QTableView>
 
 #include "tools/cabana/canmessages.h"
@@ -19,6 +21,7 @@ public:
   HistoryLogModel(QObject *parent);
   void setMessage(const QString &message_id);
   void updateState();
+  void setFilter(int sig_idx, const QString &value, std::function<bool(double, double)> cmp);
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
   void fetchMore(const QModelIndex &parent) override;
@@ -29,13 +32,16 @@ public:
   struct Message {
     uint64_t mono_time = 0;
     QVector<double> sig_values;
-    QByteArray data;
+    QString data;
   };
 
   std::deque<Message> fetchData(uint64_t min_mono_time, uint64_t max_mono_time);
   QString msg_id;
   bool has_more_data = true;
   const int batch_size = 50;
+  int filter_sig_idx = -1;
+  double filter_value = 0;
+  std::function<bool(double, double)> filter_cmp = nullptr;
   std::deque<Message> messages;
   std::vector<const Signal*> sigs;
 };
@@ -43,11 +49,27 @@ public:
 class HistoryLog : public QTableView {
 public:
   HistoryLog(QWidget *parent);
-  void setMessage(const QString &message_id) { model->setMessage(message_id); }
+  int sizeHintForColumn(int column) const override { return -1; };
+};
+
+class LogsWidget : public QWidget {
+  Q_OBJECT
+
+public:
+  LogsWidget(QWidget *parent);
+  void setMessage(const QString &message_id);
   void updateState() { model->updateState(); }
 
+private slots:
+  void setFilter();
+
 private:
-  int sizeHintForColumn(int column) const override { return -1; };
   void showEvent(QShowEvent *event) override { model->setMessage(model->msg_id); };
+
+  HistoryLog *logs;
   HistoryLogModel *model;
+  QWidget *filter_container;
+  QComboBox *signals_cb, *comp_box;
+  QLineEdit *value_edit;
+  std::vector<const Signal*> sigs;
 };

--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QComboBox>
-#include <QDialog>
 #include <QLabel>
 #include <QLineEdit>
 #include <QSpinBox>
@@ -9,7 +8,6 @@
 #include <QToolButton>
 
 #include "selfdrive/ui/qt/widgets/controls.h"
-
 #include "tools/cabana/canmessages.h"
 #include "tools/cabana/dbcmanager.h"
 
@@ -58,9 +56,4 @@ protected:
   int form_idx = 0;
   QToolButton *plot_btn;
   QTimer *save_timer;
-};
-
-class SignalFindDlg : public QDialog {
-public:
-  SignalFindDlg(const QString &id, const Signal *signal, QWidget *parent);
 };


### PR DESCRIPTION
Remove "Find signal value" button and dialog from `DetailView`. add dynamic value filters to the logsView to filtering in all CAN events in real time:

[Kazam_screencast_00002.webm](https://user-images.githubusercontent.com/27770/207235947-d796783b-1be2-48b1-a969-c15c17ee94bc.webm)


