### PR TITLE
Replay: add option -c to set segment cache size

### DIFF
--- a/tools/replay/main.cc
+++ b/tools/replay/main.cc
@@ -23,6 +23,7 @@ int main(int argc, char *argv[]) {
   parser.addPositionalArgument("route", "the drive to replay. find your drives at connect.comma.ai");
   parser.addOption({{"a", "allow"}, "whitelist of services to send", "allow"});
   parser.addOption({{"b", "block"}, "blacklist of services to send", "block"});
+  parser.addOption({{"c", "cache"}, "cache <n> segments in memory. default is 5", "n"});
   parser.addOption({{"s", "start"}, "start from <seconds>", "seconds"});
   parser.addOption({"demo", "use a demo route instead of providing your own"});
   parser.addOption({"data_dir", "local directory with routes", "data_dir"});
@@ -47,6 +48,9 @@ int main(int argc, char *argv[]) {
     }
   }
   Replay *replay = new Replay(route, allow, block, nullptr, replay_flags, parser.value("data_dir"), &app);
+  if (!parser.value("c").isEmpty()) {
+    replay->setSegmentCacheLimit(parser.value("c").toInt());
+  }
   if (!replay->load()) {
     return 0;
   }


### PR DESCRIPTION
usage:
`replay --demo -c=25`
`replay --demo -c 25`