### PR TITLE
carla sim: fix missing camera

### DIFF
--- a/tools/sim/tmux_script.sh
+++ b/tools/sim/tmux_script.sh
@@ -2,5 +2,5 @@
 tmux new -d -s carla-sim
 tmux send-keys "./launch_openpilot.sh" ENTER
 tmux neww
-tmux send-keys "./bridge.py $*" ENTER
+tmux send-keys "./bridge.py --high_quality --dual_camera $*" ENTER
 tmux a -t carla-sim


### PR DESCRIPTION
Passing ` --high_quality --dual_camera` to `bridge.py` solved the camera issue for me. 

![image](https://user-images.githubusercontent.com/1111940/207360569-59c6bb0e-1077-4cb8-a1ac-c3319cea144c.png)

Closes:
#26503 #26595
