### PR TITLE
Add missing FW versions for 2019 Honda Passport

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -1167,6 +1167,7 @@ FW_VERSIONS = {
     (Ecu.programmedFuelInjection, 0x18da10f1, None): [
       b'37805-RLV-B220\x00\x00',
       b'37805-RLV-B210\x00\x00',
+      b'37805-RLV-L160\x00\x00',
     ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-TGS-A230\x00\x00',
@@ -1177,6 +1178,7 @@ FW_VERSIONS = {
     ],
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-TG7-A040\x00\x00',
+      b'38897-TG7-A030\x00\x00',
     ],
     (Ecu.srs, 0x18da53f1, None): [
       b'77959-TGS-A010\x00\x00',
@@ -1186,10 +1188,12 @@ FW_VERSIONS = {
     ],
     (Ecu.transmission, 0x18da1ef1, None): [
       b'28101-5EZ-A600\x00\x00',
+      b'28101-5EZ-A430\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TGS-AT20\x00\x00',
       b'78109-TGS-AX20\x00\x00',
+      b'78109-TGS-AJ20\x00\x00',
     ],
     (Ecu.vsa, 0x18da28f1, None): [
       b'57114-TGS-A530\x00\x00',


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)
Honda passport 2019 
added
{'address': 416944369, 'ecu': 'programmedFuelInjection', 'fwVersion': b'37805-RLV-L160\x00\x00', 'subAddress': 0}, 
{'address': 417001457, 'ecu': 'gateway', 'fwVersion': b'38897-TG7-A030\x00\x00', 'subAddress': 0},
{'address': 416947953, 'ecu': 'transmission', 'fwVersion': b'28101-5EZ-A430\x00\x00', 'subAddress': 0},
{'address': 416964849, 'ecu': 'combinationMeter', 'fwVersion': b'78109-TGS-AJ20\x00\x00', 'subAddress': 0}

**Verification** [](Explain how you tested the refactor for regressions.)

-->
