### PR TITLE
Fix spacing in MultiOptionDialog

### DIFF
--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -296,6 +296,8 @@ MultiOptionDialog::MultiOptionDialog(const QString &prompt_text, const QStringLi
     group->addButton(selectionLabel);
     listLayout->addWidget(selectionLabel);
   }
+  // add stretch to keep buttons spaced correctly
+  listLayout->addStretch(1);
 
   ScrollView *scroll_view = new ScrollView(listWidget, this);
   scroll_view->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);


### PR DESCRIPTION
Previous change only fixed stretch taking up huge amounts of space when starting the dialog not from the main UI. This fixes that as well as the buttons being spaced far apart when you just have 2 or 3 buttons