### PR TITLE
Added ControlsTimer class with example usage in mazda+hyundai

### DIFF
--- a/common/realtime.py
+++ b/common/realtime.py
@@ -136,7 +136,7 @@ class DurationTimer:
     return False
 
 class ModelTimer(DurationTimer):
-  frame = 0 # type: int
+  frame = -1 # type: int
   objects = [] # type: List[DurationTimer]
   def __init__(self, duration=0) -> None:
     self.step = DT_MDL
@@ -159,7 +159,7 @@ class ModelTimer(DurationTimer):
     return ModelTimer.interval_obj(rate, cls.frame)
 
 class ControlsTimer(DurationTimer):
-  frame = 0
+  frame = -1
   objects = [] # type: List[DurationTimer]
   def __init__(self, duration=0) -> None:
     self.step = DT_CTRL
@@ -297,14 +297,13 @@ class TestTimers(unittest.TestCase):
     self.assertTrue(control_timer2.active())
     self.assertTrue(model_timer1.active())
     self.assertTrue(model_timer2.active())
-    for i in range(0, 2001):
-      if i != 0:
-        if i % 1 == 0:
-          # Increment control timers  to simulate 100Hz
-          ControlsTimer.tick()
-        if i % 5 == 0: 
-          # Increment model timers to simulate 20Hz
-          ModelTimer.tick()
+    for i in range(1, 2002):
+      if i % 1 == 0:
+        # Increment control timers  to simulate 100Hz
+        ControlsTimer.tick()
+      if i % 5 == 0: 
+        # Increment model timers to simulate 20Hz
+        ModelTimer.tick()
           
       # Test interval method for control timers
       if i % 200 == 0:  # 1-second interval (100Hz)

--- a/common/realtime.py
+++ b/common/realtime.py
@@ -131,7 +131,7 @@ class DurationTimer:
 
   @staticmethod
   def interval_obj(rate, frame) -> bool:
-    if frame % rate == 0: # Highlighting shows "frame" in white
+    if frame % rate == 0:
       return True
     return False
 

--- a/common/realtime.py
+++ b/common/realtime.py
@@ -94,3 +94,89 @@ class Ratekeeper:
     self._frame += 1
     self._remaining = remaining
     return lagged
+
+
+class DurationTimer:
+  def __init__(self, duration=0, step=DT_CTRL) -> None:
+    self.step = step
+    self.duration = duration
+    self.was_reset = False
+    self.timer = 0
+    self.min = float("-inf") # type: float
+    self.max = float("inf") # type: float
+
+  def tick_obj(self) -> None:
+    self.timer += self.step
+    # reset on overflow
+    self.reset() if (self.timer == (self.max or self.min)) else None
+
+  def reset(self) -> None:
+    """Resets this objects timer"""
+    self.timer = 0
+    self.was_reset = True
+
+  def active(self) -> bool:
+    """Returns true if time since last reset is less than duration"""
+    return bool(round(self.timer,2) < self.duration)
+
+  def adjust(self, duration) -> None:
+    """Adjusts the duration of the timer"""
+    self.duration = duration
+
+  def once_after_reset(self) -> bool: 
+    """Returns true only one time after calling reset()"""
+    ret = self.was_reset
+    self.was_reset = False
+    return ret
+
+  @staticmethod
+  def interval_obj(rate, frame) -> bool:
+    if frame % rate == 0: # Highlighting shows "frame" in white
+      return True
+    return False
+
+class ModelTimer(DurationTimer):
+  frame = 0 # type: int
+  objects = [] # type: List[DurationTimer]
+  def __init__(self, duration=0) -> None:
+    self.step = DT_MDL
+    super().__init__(duration, self.step)
+    self.__class__.objects.append(self)
+
+  @classmethod
+  def tick(cls) -> None:
+    cls.frame += 1
+    for obj in cls.objects:
+      ModelTimer.tick_obj(obj)
+
+  @classmethod
+  def reset_all(cls) -> None:
+    for obj in cls.objects:
+      obj.reset()
+
+  @classmethod
+  def interval(cls, rate) -> bool:
+    return ModelTimer.interval_obj(rate, cls.frame)
+
+class ControlsTimer(DurationTimer):
+  frame = 0
+  objects = [] # type: List[DurationTimer]
+  def __init__(self, duration=0) -> None:
+    self.step = DT_CTRL
+    super().__init__(duration=duration, step=self.step)
+    self.__class__.objects.append(self)
+
+  @classmethod
+  def tick(cls) -> None:
+    cls.frame += 1
+    for obj in cls.objects:
+      ControlsTimer.tick_obj(obj)
+
+  @classmethod
+  def reset_all(cls) -> None:
+    for obj in cls.objects:
+      obj.reset()
+
+  @classmethod
+  def interval(cls, rate) -> bool:
+    return ControlsTimer.interval_obj(rate, cls.frame)

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -1,11 +1,11 @@
 from cereal import car
 from common.conversions import Conversions as CV
 from common.numpy_fast import clip
-from common.realtime import DT_CTRL
 from opendbc.can.packer import CANPacker
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.hyundai import hyundaicanfd, hyundaican
 from selfdrive.car.hyundai.values import HyundaiFlags, Buttons, CarControllerParams, CANFD_CAR, CAR
+from common.realtime import ControlsTimer as Timer
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 LongCtrlState = car.CarControl.Actuators.LongControlState
@@ -47,12 +47,12 @@ class CarController:
     self.params = CarControllerParams(CP)
     self.packer = CANPacker(dbc_name)
     self.angle_limit_counter = 0
-    self.frame = 0
+    self.resume_timer = Timer(0.1)
+    self.btn_press_timer = Timer(0.25)
 
     self.accel_last = 0
     self.apply_steer_last = 0
     self.car_fingerprint = CP.carFingerprint
-    self.last_button_frame = 0
 
   def update(self, CC, CS):
     actuators = CC.actuators
@@ -81,7 +81,7 @@ class CarController:
     # *** common hyundai stuff ***
 
     # tester present - w/ no response (keeps relevant ECU disabled)
-    if self.frame % 100 == 0 and not (self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC.value) and self.CP.openpilotLongitudinalControl:
+    if Timer.interval(100) and not (self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC.value) and self.CP.openpilotLongitudinalControl:
       # for longitudinal control, either radar or ADAS driving ECU
       addr, bus = 0x7d0, 0
       if self.CP.flags & HyundaiFlags.CANFD_HDA2.value:
@@ -115,36 +115,36 @@ class CarController:
       can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, CC.enabled, lat_active, apply_steer))
 
       # disable LFA on HDA2
-      if self.frame % 5 == 0 and hda2:
+      if Timer.interval(5) and hda2:
         can_sends.append(hyundaicanfd.create_cam_0x2a4(self.packer, CS.cam_0x2a4))
 
       # LFA and HDA icons
-      if self.frame % 5 == 0 and (not hda2 or hda2_long):
+      if Timer.interval(5) and (not hda2 or hda2_long):
         can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CP, CC.enabled))
 
       # blinkers
       if hda2 and self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
-        can_sends.extend(hyundaicanfd.create_spas_messages(self.packer, self.frame, CC.leftBlinker, CC.rightBlinker))
+        can_sends.extend(hyundaicanfd.create_spas_messages(self.packer, CC.leftBlinker, CC.rightBlinker))
 
       if self.CP.openpilotLongitudinalControl:
         if hda2:
-          can_sends.extend(hyundaicanfd.create_adrv_messages(self.packer, self.frame))
-        if self.frame % 2 == 0:
+          can_sends.extend(hyundaicanfd.create_adrv_messages(self.packer))
+        if Timer.interval(2):
           can_sends.append(hyundaicanfd.create_acc_control(self.packer, self.CP, CC.enabled, self.accel_last, accel, stopping, CC.cruiseControl.override,
                                                            set_speed_in_units))
           self.accel_last = accel
       else:
         # button presses
-        if (self.frame - self.last_button_frame) * DT_CTRL > 0.25:
+        if not self.btn_press_timer.active():
           # cruise cancel
           if CC.cruiseControl.cancel:
             if self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:
               can_sends.append(hyundaicanfd.create_acc_cancel(self.packer, self.CP, CS.cruise_info))
-              self.last_button_frame = self.frame
+              self.btn_press_timer.reset()
             else:
               for _ in range(20):
                 can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, CS.buttons_counter+1, Buttons.CANCEL))
-              self.last_button_frame = self.frame
+              self.btn_press_timer.reset()
 
           # cruise standstill resume
           elif CC.cruiseControl.resume:
@@ -154,42 +154,42 @@ class CarController:
             else:
               for _ in range(20):
                 can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, CS.buttons_counter+1, Buttons.RES_ACCEL))
-              self.last_button_frame = self.frame
+              self.btn_press_timer.reset()
     else:
-      can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.car_fingerprint, apply_steer, lat_active,
+      can_sends.append(hyundaican.create_lkas11(self.packer, self.car_fingerprint, apply_steer, lat_active,
                                                 torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
                                                 hud_control.leftLaneVisible, hud_control.rightLaneVisible,
                                                 left_lane_warning, right_lane_warning))
 
       if not self.CP.openpilotLongitudinalControl:
         if CC.cruiseControl.cancel:
-          can_sends.append(hyundaican.create_clu11(self.packer, self.frame, CS.clu11, Buttons.CANCEL, self.CP.carFingerprint))
+          can_sends.append(hyundaican.create_clu11(self.packer, CS.clu11, Buttons.CANCEL, self.CP.carFingerprint))
         elif CC.cruiseControl.resume:
           # send resume at a max freq of 10Hz
-          if (self.frame - self.last_button_frame) * DT_CTRL > 0.1:
+          if not self.resume_timer.active():
             # send 25 messages at a time to increases the likelihood of resume being accepted
-            can_sends.extend([hyundaican.create_clu11(self.packer, self.frame, CS.clu11, Buttons.RES_ACCEL, self.CP.carFingerprint)] * 25)
-            self.last_button_frame = self.frame
+            can_sends.extend([hyundaican.create_clu11(self.packer, CS.clu11, Buttons.RES_ACCEL, self.CP.carFingerprint)] * 25)
+            self.resume_timer.reset()
 
-      if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
+      if Timer.interval(2) and self.CP.openpilotLongitudinalControl:
         # TODO: unclear if this is needed
         jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
-        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
+        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(Timer.frame / 2),
                                                         hud_control.leadVisible, set_speed_in_units, stopping, CC.cruiseControl.override))
 
       # 20 Hz LFA MFA message
-      if self.frame % 5 == 0 and self.car_fingerprint in (CAR.SONATA, CAR.PALISADE, CAR.IONIQ, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_HEV_2021,
+      if Timer.interval(5) and self.car_fingerprint in (CAR.SONATA, CAR.PALISADE, CAR.IONIQ, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_HEV_2021,
                                                           CAR.IONIQ_EV_2020, CAR.IONIQ_PHEV, CAR.KIA_CEED, CAR.KIA_SELTOS, CAR.KONA_EV, CAR.KONA_EV_2022,
                                                           CAR.ELANTRA_2021, CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_HEV, CAR.SANTA_FE_2022,
                                                           CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.GENESIS_G70_2020, CAR.SANTA_FE_PHEV_2022, CAR.KIA_STINGER_2022):
         can_sends.append(hyundaican.create_lfahda_mfc(self.packer, CC.enabled))
 
       # 5 Hz ACC options
-      if self.frame % 20 == 0 and self.CP.openpilotLongitudinalControl:
+      if Timer.interval(20) and self.CP.openpilotLongitudinalControl:
         can_sends.extend(hyundaican.create_acc_opt(self.packer))
 
       # 2 Hz front radar options
-      if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
+      if Timer.interval(50) and self.CP.openpilotLongitudinalControl:
         can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
 
     new_actuators = actuators.copy()
@@ -197,5 +197,4 @@ class CarController:
     new_actuators.steerOutputCan = apply_steer
     new_actuators.accel = accel
 
-    self.frame += 1
     return new_actuators, can_sends

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -1,9 +1,10 @@
 import crcmod
 from selfdrive.car.hyundai.values import CAR, CHECKSUM, CAMERA_SCC_CAR
+from common.realtime import ControlsTimer as Timer
 
 hyundai_checksum = crcmod.mkCrcFun(0x11D, initCrc=0xFD, rev=False, xorOut=0xdf)
 
-def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
+def create_lkas11(packer, car_fingerprint, apply_steer, steer_req,
                   torque_fault, lkas11, sys_warning, sys_state, enabled,
                   left_lane, right_lane,
                   left_lane_depart, right_lane_depart):
@@ -15,7 +16,7 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
   values["CR_Lkas_StrToqReq"] = apply_steer
   values["CF_Lkas_ActToi"] = steer_req
   values["CF_Lkas_ToiFlt"] = torque_fault  # seems to allow actuation on CR_Lkas_StrToqReq
-  values["CF_Lkas_MsgCount"] = frame % 0x10
+  values["CF_Lkas_MsgCount"] = Timer.frame % 0x10
 
   if car_fingerprint in (CAR.SONATA, CAR.PALISADE, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_HEV_2021, CAR.SANTA_FE,
                          CAR.IONIQ_EV_2020, CAR.IONIQ_PHEV, CAR.KIA_SELTOS, CAR.ELANTRA_2021, CAR.GENESIS_G70_2020,
@@ -78,10 +79,10 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
   return packer.make_can_msg("LKAS11", 0, values)
 
 
-def create_clu11(packer, frame, clu11, button, car_fingerprint):
+def create_clu11(packer, clu11, button, car_fingerprint):
   values = clu11
   values["CF_Clu_CruiseSwState"] = button
-  values["CF_Clu_AliveCnt1"] = frame % 0x10
+  values["CF_Clu_AliveCnt1"] = Timer.frame % 0x10
   # send buttons to camera on camera-scc based cars
   bus = 2 if car_fingerprint in CAMERA_SCC_CAR else 0
   return packer.make_can_msg("CLU11", bus, values)

--- a/selfdrive/car/hyundai/hyundaicanfd.py
+++ b/selfdrive/car/hyundai/hyundaicanfd.py
@@ -1,5 +1,6 @@
 from common.numpy_fast import clip
 from selfdrive.car.hyundai.values import HyundaiFlags
+from common.realtime import ControlsTimer as Timer
 
 def get_e_can_bus(CP):
   # On the CAN-FD platforms, the LKAS camera is on both A-CAN and E-CAN. HDA2 cars
@@ -97,7 +98,7 @@ def create_acc_control(packer, CP, enabled, accel_last, accel, stopping, gas_ove
   return packer.make_can_msg("SCC_CONTROL", get_e_can_bus(CP), values)
 
 
-def create_spas_messages(packer, frame, left_blink, right_blink):
+def create_spas_messages(packer, left_blink, right_blink):
   ret = []
 
   values = {
@@ -117,7 +118,7 @@ def create_spas_messages(packer, frame, left_blink, right_blink):
   return ret
 
 
-def create_adrv_messages(packer, frame):
+def create_adrv_messages(packer):
   # messages needed to car happy after disabling
   # the ADAS Driving ECU to do longitudinal control
 
@@ -127,7 +128,7 @@ def create_adrv_messages(packer, frame):
   }
   ret.append(packer.make_can_msg("ADRV_0x51", 4, values))
 
-  if frame % 2 == 0:
+  if Timer.interval(2):
     values = {
       'AEB_SETTING': 0x1,  # show AEB disabled icon
       'SET_ME_2': 0x2,
@@ -137,7 +138,7 @@ def create_adrv_messages(packer, frame):
     }
     ret.append(packer.make_can_msg("ADRV_0x160", 5, values))
 
-  if frame % 5 == 0:
+  if Timer.interval(5):
     values = {
       'SET_ME_1C': 0x1c,
       'SET_ME_FF': 0xff,
@@ -152,13 +153,13 @@ def create_adrv_messages(packer, frame):
     }
     ret.append(packer.make_can_msg("ADRV_0x200", 5, values))
 
-  if frame % 20 == 0:
+  if Timer.interval(20):
     values = {
       'SET_ME_15': 0x15,
     }
     ret.append(packer.make_can_msg("ADRV_0x345", 5, values))
 
-  if frame % 100 == 0:
+  if Timer.interval(100):
     values = {
       'SET_ME_22': 0x22,
       'SET_ME_41': 0x41,

--- a/selfdrive/car/mazda/carcontroller.py
+++ b/selfdrive/car/mazda/carcontroller.py
@@ -3,6 +3,7 @@ from opendbc.can.packer import CANPacker
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.mazda import mazdacan
 from selfdrive.car.mazda.values import CarControllerParams, Buttons
+from common.realtime import ControlsTimer as Timer
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 
@@ -13,7 +14,7 @@ class CarController:
     self.apply_steer_last = 0
     self.packer = CANPacker(dbc_name)
     self.brake_counter = 0
-    self.frame = 0
+    self.brake_timer = Timer(0.07)
 
   def update(self, CC, CS):
     can_sends = []
@@ -32,13 +33,13 @@ class CarController:
       # will disable the crz 'main on'. crz ctrl msg runs at 50hz. 70ms allows us to
       # read 3 messages and most likely sync state before we attempt cancel.
       self.brake_counter = self.brake_counter + 1
-      if self.frame % 10 == 0 and not (CS.out.brakePressed and self.brake_counter < 7):
+      if Timer.interval(10) and not (CS.out.brakePressed and self.brake_timer.active()):
         # Cancel Stock ACC if it's enabled while OP is disengaged
         # Send at a rate of 10hz until we sync with stock ACC state
         can_sends.append(mazdacan.create_button_cmd(self.packer, self.CP.carFingerprint, CS.crz_btns_counter, Buttons.CANCEL))
     else:
-      self.brake_counter = 0
-      if CC.cruiseControl.resume and self.frame % 5 == 0:
+      self.brake_timer.reset()
+      if CC.cruiseControl.resume and Timer.interval(5):
         # Mazda Stop and Go requires a RES button (or gas) press if the car stops more than 3 seconds
         # Send Resume button when planner wants car to move
         can_sends.append(mazdacan.create_button_cmd(self.packer, self.CP.carFingerprint, CS.crz_btns_counter, Buttons.RESUME))
@@ -46,7 +47,7 @@ class CarController:
     self.apply_steer_last = apply_steer
 
     # send HUD alerts
-    if self.frame % 50 == 0:
+    if Timer.interval(50):
       ldw = CC.hudControl.visualAlert == VisualAlert.ldw
       steer_required = CC.hudControl.visualAlert == VisualAlert.steerRequired
       # TODO: find a way to silence audible warnings so we can add more hud alerts
@@ -55,11 +56,10 @@ class CarController:
 
     # send steering command
     can_sends.append(mazdacan.create_steering_control(self.packer, self.CP.carFingerprint,
-                                                      self.frame, apply_steer, CS.cam_lkas))
+                                                      apply_steer, CS.cam_lkas))
 
     new_actuators = CC.actuators.copy()
     new_actuators.steer = apply_steer / CarControllerParams.STEER_MAX
     new_actuators.steerOutputCan = apply_steer
 
-    self.frame += 1
     return new_actuators, can_sends

--- a/selfdrive/car/mazda/mazdacan.py
+++ b/selfdrive/car/mazda/mazdacan.py
@@ -1,9 +1,10 @@
 import copy
 
 from selfdrive.car.mazda.values import GEN1, Buttons
+from common.realtime import ControlsTimer as Timer
 
 
-def create_steering_control(packer, car_fingerprint, frame, apply_steer, lkas):
+def create_steering_control(packer, car_fingerprint, apply_steer, lkas):
 
   tmp = apply_steer + 2048
 
@@ -28,7 +29,7 @@ def create_steering_control(packer, car_fingerprint, frame, apply_steer, lkas):
   amd = (amd >> 4) | (( amd & 0xF) << 4)
   alo = (tmp & 0x3) << 2
 
-  ctr = frame % 16
+  ctr = Timer.frame % 16
   # bytes:     [    1  ] [ 2 ] [             3               ]  [           4         ]
   csum = 249 - ctr - hi - lo - (lnv << 3) - er1 - (ldw << 7) - ( er2 << 4) - (b1 << 5)
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -5,7 +5,7 @@ from typing import SupportsFloat
 
 from cereal import car, log
 from common.numpy_fast import clip
-from common.realtime import sec_since_boot, config_realtime_process, Priority, Ratekeeper, DT_CTRL
+from common.realtime import sec_since_boot, config_realtime_process, Priority, Ratekeeper, DT_CTRL, ControlsTimer
 from common.profiler import Profiler
 from common.params import Params, put_nonblocking
 import cereal.messaging as messaging
@@ -725,6 +725,7 @@ class Controls:
     if not self.read_only and self.initialized:
       # send car controls over can
       self.last_actuators, can_sends = self.CI.apply(CC)
+      ControlsTimer.tick()
       self.pm.send('sendcan', can_list_to_can_capnp(can_sends, msgtype='sendcan', valid=CS.canValid))
       CC.actuatorsOutput = self.last_actuators
       if self.CP.steerControlType == car.CarParams.SteerControlType.angle:


### PR DESCRIPTION
Increase the readability of DT_CTRL based duration timers in carports. Also, remove redundant self.frame+=1 in every carcontroller. See examples for Mazda and Hyundai.