### PR TITLE
NavInstruction: add valid field

### DIFF
--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -207,9 +207,11 @@ class RouteEngine:
 
   def send_instruction(self):
     msg = messaging.new_message('navInstruction')
+    msg.valid = self.sm.all_checks()
+    msg.navInstruction.valid = True
 
     if self.step_idx is None:
-      msg.valid = False
+      msg.navInstruction.valid = False
       self.pm.send('navInstruction', msg)
       return
 

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -210,8 +210,8 @@ void MapWindow::updateState(const UIState &s) {
   }
 
   if (sm.updated("navInstruction")) {
-    if (sm.valid("navInstruction")) {
-      auto i = sm["navInstruction"].getNavInstruction();
+    auto i = sm["navInstruction"].getNavInstruction();
+    if (i.getValid()) {
       emit ETAChanged(i.getTimeRemaining(), i.getTimeRemainingTypical(), i.getDistanceRemaining());
 
       if (locationd_valid || laikad_valid) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -188,7 +188,7 @@ void AnnotatedCameraWidget::updateState(const UIState &s) {
   const SubMaster &sm = *(s.sm);
 
   const bool cs_alive = sm.alive("controlsState");
-  const bool nav_alive = sm.alive("navInstruction") && sm["navInstruction"].getValid();
+  const bool nav_alive = sm.alive("navInstruction") && sm["navInstruction"].getNavInstruction().getValid();
 
   const auto cs = sm["controlsState"].getControlsState();
 


### PR DESCRIPTION
Fixes bug where you can't engage without a nav route, or if you lose internet when `navInstruction` is added to controlsd

cereal: https://github.com/commaai/cereal/pull/399