### PR TITLE
Added unofficial support for Ubuntu 22.10 in ubuntu_setup.sh

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -108,7 +108,10 @@ if [ -f "/etc/os-release" ]; then
   source /etc/os-release
   case "$VERSION_CODENAME" in
     "jammy")
-      install_ubuntu_jammy_requirements
+      install_ubuntu_jammy_kinetic_requirements
+      ;;
+    "kinetic")
+      install_ubuntu_jammy_kinetic_requirements
       ;;
     "focal")
       install_ubuntu_focal_requirements
@@ -120,7 +123,7 @@ if [ -f "/etc/os-release" ]; then
       if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         exit 1
       fi
-      if [ "$UBUNTU_CODENAME" = "jammy" ] || ["$UBUNTU_CODENAME" = "kinetic"]; then
+      if [ "$UBUNTU_CODENAME" = "jammy" ] || [ "$UBUNTU_CODENAME" = "kinetic" ]; then
         install_ubuntu_jammy_kinetic_requirements
       else
         install_ubuntu_focal_requirements

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -111,7 +111,7 @@ if [ -f "/etc/os-release" ]; then
       install_ubuntu_lts_latest_requirements
       ;;
     "kinetic")
-      install_ubuntu_jammy_kinetic_requirements
+      install_ubuntu_lts_latest_requirements
       ;;
     "focal")
       install_ubuntu_focal_requirements

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -81,8 +81,8 @@ function install_ubuntu_common_requirements() {
     valgrind
 }
 
-# Install Ubuntu 22.04 LTS packages
-function install_ubuntu_jammy_requirements() {
+# Install Ubuntu 22.04 LTS and Ubuntu 22.10 packages
+function install_ubuntu_jammy_kinetic_requirements() {
   install_ubuntu_common_requirements
 
   $SUDO apt-get install -y --no-install-recommends \
@@ -120,8 +120,8 @@ if [ -f "/etc/os-release" ]; then
       if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         exit 1
       fi
-      if [ "$UBUNTU_CODENAME" = "jammy" ]; then
-        install_ubuntu_jammy_requirements
+      if [ "$UBUNTU_CODENAME" = "jammy" ] || ["$UBUNTU_CODENAME" = "kinetic"]; then
+        install_ubuntu_jammy_kinetic_requirements
       else
         install_ubuntu_focal_requirements
       fi

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -124,7 +124,7 @@ if [ -f "/etc/os-release" ]; then
         exit 1
       fi
       if [ "$UBUNTU_CODENAME" = "jammy" ] || [ "$UBUNTU_CODENAME" = "kinetic" ]; then
-        install_ubuntu_jammy_kinetic_requirements
+        install_ubuntu_lts_latest_requirements
       else
         install_ubuntu_focal_requirements
       fi

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -81,8 +81,8 @@ function install_ubuntu_common_requirements() {
     valgrind
 }
 
-# Install Ubuntu 22.04 LTS and Ubuntu 22.10 packages
-function install_ubuntu_jammy_kinetic_requirements() {
+# Install Ubuntu 22.04 LTS packages
+function install_ubuntu_lts_latest_requirements() {
   install_ubuntu_common_requirements
 
   $SUDO apt-get install -y --no-install-recommends \

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -108,7 +108,7 @@ if [ -f "/etc/os-release" ]; then
   source /etc/os-release
   case "$VERSION_CODENAME" in
     "jammy")
-      install_ubuntu_jammy_kinetic_requirements
+      install_ubuntu_lts_latest_requirements
       ;;
     "kinetic")
       install_ubuntu_jammy_kinetic_requirements


### PR DESCRIPTION
**Description**
This change adds unofficial support for Ubuntu 22.10 Kinetic Kudu by adding an extra conditional to check and see if $VERSION_CODENAME in /etc/os-release is equal to "kinetic". If this fails, this change also checks to see if $UBUNTU_CODENAME is equal to "kinetic". 

The packages that are installed if the running OS is Ubuntu 22.10 are the same packages that are installed if the running OS is Ubuntu 22.04 LTS, hence a new function was not required (I just renamed the old function).

**Verification**
I am currently running Ubuntu 22.10 on my device and would get errors when running ubuntu_setup.sh due to an install candidate not being found for the following packages:
```
libavresample-dev \
qt5-default \
python-dev
```
this indicated to me that the script was running under the impression that I was using Ubuntu 20.04 LTS and attempting to install the packages required for that OS.

After making the changes, the install completes fully with no errors!

