### PR TITLE
Refactor bridge.py

### DIFF
--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -58,3 +58,43 @@ All inputs:
 
 The following resources contain more details and troubleshooting tips.
 * [CARLA on the openpilot wiki](https://github.com/commaai/openpilot/wiki/CARLA)
+
+
+* [Carla python aPI](https://carla.readthedocs.io/en/latest/python_api/#carlavehiclecontrol)
+
+```
+throttle (float)
+A scalar value to control the vehicle throttle [0.0, 1.0]. Default is 0.0.
+brake (float)
+A scalar value to control the vehicle brake [0.0, 1.0]. Default is 0.0. 
+steer (float)
+A scalar value to control the vehicle steering [-1.0, 1.0]. Default is 0.0.
+```
+* [car.capnp](https://github.com/commaai/cereal/blob/master/car.capnp#L334)
+
+```
+                  ┌──────────────────┐
+                  │ OpenPilot/Manual │
+                  └──────┬───────────┘
+(Throttle, Brake, Steer) │
+                         │
+                         │
+  ┌──────┐               │  TBS_scale_clamp()
+  │      │               │
+  │ ┌────▼────┐       ┌──▼──┐
+  │ │old(prev)│       │ new │
+  │ └────┬────┘       └──┬──┘
+  │      │               │
+  │      └──────────────►│  TBS_rate_limit()
+  │                      │
+  │                   ┌──▼──┐
+  └───────────────────┤ out │
+                      └──┬──┘
+                         │  vehicle.apply_control
+                         │
+                  ┌──────▼───────┐
+                  │    CARLA     │
+                  └──────────────┘
+
+new, old and out are objects of type TBS (TrottleBrakeSteer)
+```

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -109,7 +109,7 @@ def TBS_rate_limit(old, new, mode):
     Blimit = 1
     Slimit = 0.0002
   else:  # manual
-    # Make mnual loosing loss throttle gradually
+    # Make manual losing throttle gradually
     if new.throttle == 0:
       Tlimit = 0.001
     else:

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -55,12 +55,14 @@ class VehicleState:
 
 class TrottleBrakeSteer:
   def __init__(self, throttle=0, brake=0, steer=0):
-    self.reset(throttle=0, brake=0, steer=0)
-
-  def reset(self, throttle=0, brake=0, steer=0):
     self.throttle = throttle
     self.brake = brake
     self.steer = steer
+
+  def reset(self):
+    self.throttle = 0
+    self.brake = 0
+    self.steer = 0
 
   def __repr__(self):
     return "[T:%.4f B:%.4f S:%.4f]" % (self.throttle, self.brake, self.steer)

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -55,6 +55,9 @@ class VehicleState:
 
 class TrottleBrakeSteer:
   def __init__(self, throttle=0, brake=0, steer=0):
+    self.reset(throttle=0, brake=0, steer=0)
+
+  def reset(self, throttle=0, brake=0, steer=0):
     self.throttle = throttle
     self.brake = brake
     self.steer = steer
@@ -455,7 +458,7 @@ class CarlaBridge:
       # 3. Send current carstate to op via can
 
       cruise_button = 0
-      manual.__init__()
+      manual.reset()
       # --------------Step 1-------------------------------
       if not q.empty():
         message = q.get()


### PR DESCRIPTION
**Description** 
Hard-coded values and adjustments are scattered in the bridge.py which makes understanding the logic very difficult.
Here are some examples:

- `throttle_manual_multiplier = 0.7 `
- `brake_manual_multiplier = 0.7`
- `steer_manual_multiplier = 45 * STEER_RATIO`
- `throttle_op = clip(sm['carControl'].actuators.accel / 1.6, 0.0, 1.0)`
- `brake_op = clip(-sm['carControl'].actuators.accel / 4.0, 0.0, 1.0)`
- `vc.throttle = throttle_out / 0.6`


I merged parallel variables `throttle_X`,  `brake_X ` and `steer_X` into a `TrottleBrakeSteer` class, and these variables are refactored:
  
`throttle_manual, brake_manual, steer_manual` :arrow_right:  `manual` object
`throttle_out,  brake_out, steer_out` :arrow_right: `out` object
`old_throttle, old_brake, old_steer` :arrow_right: `old` object

I moved all CARLA simulator  and manual driving adjustments to two separate functions `TBS_rate_limit` and `TBS_scale_clamp`.
(TBS~TrottleBrakeSteer) and as the result, I got rid of these variables:
- `REPEAT_COUNTER`
- `STEER_RATIO`
- `max_steer_angle`
- `throttle_ease_out_counter`
- `steer_manual_multiplier`
- `throttle_manual_multiplier`
- `brake_manual_multiplier`
- `steer_carla`


The goal is to make integration of other simulators and environments easier in the future by isolating CARLA specific calibrations.

**Verification**

The autopilot and manual driving is tested.
