### PR TITLE
cabana: align y axis correctly

### DIFF
--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -26,6 +26,8 @@ public:
   void updateSeries(const Signal *sig = nullptr);
   void setEventsRange(const std::pair<double, double> &range);
   void setDisplayRange(double min, double max);
+  void setPlotAreaLeftPosition(int pos);
+  qreal getYAsixLabelWidth() const;
 
   struct SigItem {
     QString msg_id;
@@ -44,6 +46,7 @@ signals:
   void zoomIn(double min, double max);
   void zoomReset();
   void remove();
+  void axisYUpdated();
 
 private slots:
   void msgRemoved(uint32_t address);
@@ -58,7 +61,6 @@ private:
   void mouseMoveEvent(QMouseEvent *ev) override;
   void leaveEvent(QEvent *event) override;
   void resizeEvent(QResizeEvent *event) override;
-  void adjustChartMargins();
   void updateAxisY();
   void updateTitle();
   void updateFromSettings();
@@ -89,6 +91,7 @@ signals:
   void seriesChanged();
 
 private:
+  void alignCharts();
   void removeChart(ChartView *chart);
   void eventsMerged();
   void updateState();


### PR DESCRIPTION
align plots by finding the longest y-axis label. remove hard coded `aligned_pos`, 

![2022-12-25_15-41](https://user-images.githubusercontent.com/27770/209461269-5524dbce-cacc-44c5-999a-ca1e2fbd9665.png)
