### PR TITLE
Tesla non-zero stopAccel

### DIFF
--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -23,7 +23,6 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.kpV = [0]
     ret.longitudinalTuning.kiBP = [0]
     ret.longitudinalTuning.kiV = [0]
-    ret.stopAccel = 0.0
     ret.longitudinalActuatorDelayUpperBound = 0.5 # s
     ret.radarTimeStep = (1.0 / 8) # 8Hz
 


### PR DESCRIPTION
This might fix an issue where the car can continue creeping forward very slowly when the commanded (negative) acceleration is below the quantization level of the CAN message (so it gets rounded up to 0).