### PR TITLE
replay: only keep one init_data in merged events

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -269,8 +269,12 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
     new_events_->reserve(new_events_size);
     for (int n : segments_need_merge) {
       const auto &e = segments_[n]->log->events;
-      auto middle = new_events_->insert(new_events_->end(), e.begin(), e.end());
-      std::inplace_merge(new_events_->begin(), middle, new_events_->end(), Event::lessThan());
+      if (e.size() > 0) {
+        auto insert_from = e.begin();
+        if (new_events_->size() > 0 && (*insert_from)->which == cereal::Event::Which::INIT_DATA) ++insert_from;
+        auto middle = new_events_->insert(new_events_->end(), insert_from, e.end());
+        std::inplace_merge(new_events_->begin(), middle, new_events_->end(), Event::lessThan());
+      }
     }
 
     updateEvents([&]() {


### PR DESCRIPTION
the `INIT_DATA` in each segment makes the std::inplace_merge shifting all events to the right. this can make the inplace sorting very slow.

the inplace_merge is 4x~5x faster after this PR.

 