### PR TITLE
replay: show absolute time

### DIFF
--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -50,14 +50,6 @@ void add_str(WINDOW *w, const char *str, Color color = Color::Default, bool bold
   if (color != Color::Default) wattroff(w, COLOR_PAIR(color));
 }
 
-std::string format_seconds(int s) {
-  int total_minutes = s / 60;
-  int seconds = s % 60;
-  int hours = total_minutes / 60;
-  int minutes = total_minutes % 60;
-  return util::string_format("%02d:%02d:%02d", hours, minutes, seconds);
-}
-
 }  // namespace
 
 ConsoleUI::ConsoleUI(Replay *replay, QObject *parent) : replay(replay), sm({"carState", "liveParameters"}), QObject(parent) {
@@ -177,8 +169,8 @@ void ConsoleUI::updateStatus() {
   }
   auto [status_str, status_color] = status_text[status];
   write_item(0, 0, "STATUS:    ", status_str, "      ", false, status_color);
-  std::string suffix = " / " + format_seconds(replay->totalSeconds());
-  write_item(0, 25, "TIME:  ", format_seconds(replay->currentSeconds()), suffix, true);
+  std::string current_segment = " - " + std::to_string((int)(replay->currentSeconds() / 60));
+  write_item(0, 25, "TIME:  ", replay->currentDateTime().toString("ddd MMMM dd hh:mm:ss").toStdString(), current_segment, true);
 
   auto p = sm["liveParameters"].getLiveParameters();
   write_item(1, 0, "STIFFNESS: ", util::string_format("%.2f %%", p.getStiffnessFactor() * 100), "  ");

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -64,6 +64,7 @@ public:
   inline void removeFlag(REPLAY_FLAGS flag) { flags_ &= ~flag; }
   inline const Route* route() const { return route_.get(); }
   inline double currentSeconds() const { return double(cur_mono_time_ - route_start_ts_) / 1e9; }
+  inline QDateTime currentDateTime() const { return route_->datetime().addSecs(currentSeconds()); }
   inline uint64_t routeStartTime() const { return route_start_ts_; }
   inline int toSeconds(uint64_t mono_time) const { return (mono_time - route_start_ts_) / 1e9; }
   inline int totalSeconds() const { return segments_.size() * 60; }

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -31,6 +31,7 @@ bool Route::load() {
     rInfo("invalid route format");
     return false;
   }
+  date_time_ = QDateTime::fromString(route_.timestamp, "yyyy-MM-dd--HH-mm-ss");
   return data_dir_.isEmpty() ? loadFromServer() : loadFromLocal();
 }
 

--- a/tools/replay/route.h
+++ b/tools/replay/route.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDateTime>
 #include <QFutureSynchronizer>
 
 #include "tools/replay/framereader.h"
@@ -27,6 +28,7 @@ public:
   Route(const QString &route, const QString &data_dir = {});
   bool load();
   inline const QString &name() const { return route_.str; }
+  inline const QDateTime datetime() const { return date_time_; }
   inline const QString &dir() const { return data_dir_; }
   inline const RouteIdentifier &identifier() const { return route_; }
   inline const std::map<int, SegmentFile> &segments() const { return segments_; }
@@ -41,6 +43,7 @@ protected:
   RouteIdentifier route_ = {};
   QString data_dir_;
   std::map<int, SegmentFile> segments_;
+  QDateTime date_time_;
 };
 
 class Segment : public QObject {


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/25385
![2023-01-03_17-52](https://user-images.githubusercontent.com/27770/210334581-d3cef473-eebd-4db9-baed-76aa8456ca4f.png)

@adeebshihadeh does this ok? [date time] - [current segemnt]