### PR TITLE
longcontrol: enter stopping state immediately

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -32,6 +32,8 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
   else:
     if long_control_state == LongCtrlState.off:
       long_control_state = LongCtrlState.pid
+      if stopping_condition:
+        long_control_state = LongCtrlState.stopping
 
     elif long_control_state == LongCtrlState.pid:
       if stopping_condition:

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -30,12 +30,8 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
     long_control_state = LongCtrlState.off
 
   else:
-    if long_control_state == LongCtrlState.off:
+    if long_control_state in (LongCtrlState.off, LongCtrlState.pid):
       long_control_state = LongCtrlState.pid
-      if stopping_condition:
-        long_control_state = LongCtrlState.stopping
-
-    elif long_control_state == LongCtrlState.pid:
       if stopping_condition:
         long_control_state = LongCtrlState.stopping
 


### PR DESCRIPTION
Possibly fixes a bug with GMs where we command accel for one frame on engaging at a stop when openpilot wants to go.

![Screenshot from 2023-01-04 21-27-37](https://user-images.githubusercontent.com/25857203/210708102-02542121-626c-4da6-aca1-b94c68aa1ffc.png)