### PR TITLE
GM: check radarOffCan in radar_interface

### DIFF
--- a/selfdrive/car/gm/radar_interface.py
+++ b/selfdrive/car/gm/radar_interface.py
@@ -3,7 +3,7 @@ import math
 from cereal import car
 from common.conversions import Conversions as CV
 from opendbc.can.parser import CANParser
-from selfdrive.car.gm.values import DBC, CAR, CanBus
+from selfdrive.car.gm.values import DBC, CanBus
 from selfdrive.car.interfaces import RadarInterfaceBase
 
 RADAR_HEADER_MSG = 1120
@@ -16,9 +16,6 @@ LAST_RADAR_MSG = RADAR_HEADER_MSG + NUM_SLOTS
 
 
 def create_radar_can_parser(car_fingerprint):
-  if car_fingerprint not in (CAR.VOLT, CAR.MALIBU, CAR.HOLDEN_ASTRA, CAR.ACADIA, CAR.CADILLAC_ATS, CAR.ESCALADE_ESV):
-    return None
-
   # C1A-ARS3-A by Continental
   radar_targets = list(range(SLOT_1_MSG, SLOT_1_MSG + NUM_SLOTS))
   signals = list(zip(['FLRRNumValidTargets',
@@ -34,11 +31,12 @@ def create_radar_can_parser(car_fingerprint):
 
   return CANParser(DBC[car_fingerprint]['radar'], signals, checks, CanBus.OBSTACLE)
 
+
 class RadarInterface(RadarInterfaceBase):
   def __init__(self, CP):
     super().__init__(CP)
 
-    self.rcp = create_radar_can_parser(CP.carFingerprint)
+    self.rcp = None if CP.radarOffCan else create_radar_can_parser(CP.carFingerprint)
 
     self.trigger_msg = LAST_RADAR_MSG
     self.updated_messages = set()


### PR DESCRIPTION
GM currently uses a hardcoded list of vehicle models to determine whether to use radar. This change brings the GM radar interface in line with other makes in using `CP.radarOffCan` to determine whether to create a radar CAN parser. (Compare Honda's `radar_interface.py` implementation.)