### PR TITLE
Hyundai: Add FW Versions for Tucson 2023

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1473,6 +1473,7 @@ FW_VERSIONS = {
   CAR.TUCSON_4TH_GEN: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9240 14T',
+      b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-CW010 14X',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NX4__               1.01 1.00 99110-N9100         ',


### PR DESCRIPTION
Add firmware for the 2023 Hyundai Tucson.

Route ID: `3b6975a40910dc1c|2023-01-06--03-01-50`

Thanks to community 2023 Hyundai Tucson owner `Andrew Preble#1920` (Discord).