### PR TITLE
MacOS: homebrew arm-none-eabi-gcc works again

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -52,13 +52,8 @@ brew "zeromq"
 brew "protobuf"
 brew "protobuf-c"
 brew "swig"
+cask "gcc-arm-embedded"
 EOS
-
-# Install gcc-arm-embedded 10.3-2021.10. 11.x is broken on M1 Macs with Xcode 13.3~
-brew uninstall gcc-arm-embedded || true
-curl -L https://github.com/Homebrew/homebrew-cask/raw/d407663b8017a0a062c7fc0b929faf2e16abd1ff/Casks/gcc-arm-embedded.rb > /tmp/gcc-arm-embedded.rb
-brew install --cask /tmp/gcc-arm-embedded.rb
-rm /tmp/gcc-arm-embedded.rb
 
 echo "[ ] finished brew install t=$SECONDS"
 


### PR DESCRIPTION
Pinned version is no longer needed. Tested on latest MacOS (Ventura 13.1) and xcode (14.2). Needs https://github.com/commaai/panda/pull/1204 or the firmware won't boot, and https://github.com/commaai/body/pull/12 to fix body build.