### PR TITLE
cabana: fix find similar bits

### DIFF
--- a/tools/cabana/tools/findsimilarbits.cc
+++ b/tools/cabana/tools/findsimilarbits.cc
@@ -126,7 +126,7 @@ QList<FindSimilarBitsDlg::mismatched_struct> FindSimilarBitsDlg::calcBits(uint8_
     if (auto cnt = msg_count[it.key()]; cnt > min_msgs_cnt) {
       auto &mismatched = it.value();
       for (int i = 0; i < mismatched.size(); ++i) {
-        if (uint32_t perc = (mismatched[i] / (double)cnt) * 100; perc < 50) {
+        if (float perc = (mismatched[i] / (double)cnt) * 100; perc < 50) {
           result.push_back({it.key(), (uint32_t)i / 8, (uint32_t)i % 8, mismatched[i], cnt, perc});
         }
       }

--- a/tools/cabana/tools/findsimilarbits.cc
+++ b/tools/cabana/tools/findsimilarbits.cc
@@ -74,15 +74,15 @@ void FindSimilarBitsDlg::find() {
   auto msg_mismatched = calcBits(bus_combo->currentText().toUInt(), selected_address, byte_idx_sb->value(), bit_idx_sb->value(), min_msgs->text().toInt());
   table->setRowCount(msg_mismatched.size());
   table->setColumnCount(6);
-  table->setHorizontalHeaderLabels({"address", "mismatches", "total msgs", "% mismatched", "byte idx", "bit idx"});
+  table->setHorizontalHeaderLabels({"address", "byte idx", "bit idx", "mismatches", "total", "perc%"});
   for (int i = 0; i < msg_mismatched.size(); ++i) {
     auto &m = msg_mismatched[i];
     table->setItem(i, 0, new QTableWidgetItem(QString("%1").arg(m.address, 1, 16)));
-    table->setItem(i, 3, new QTableWidgetItem(QString::number(m.mismatches)));
-    table->setItem(i, 4, new QTableWidgetItem(QString::number(m.total_msgs)));
-    table->setItem(i, 5, new QTableWidgetItem(QString::number(m.perc)));
     table->setItem(i, 1, new QTableWidgetItem(QString::number(m.byte_idx)));
     table->setItem(i, 2, new QTableWidgetItem(QString::number(m.bit_idx)));
+    table->setItem(i, 3, new QTableWidgetItem(QString::number(m.mismatches)));
+    table->setItem(i, 4, new QTableWidgetItem(QString::number(m.total)));
+    table->setItem(i, 5, new QTableWidgetItem(QString::number(m.perc)));
   }
   search_btn->setEnabled(true);
 }
@@ -127,11 +127,11 @@ QList<FindSimilarBitsDlg::mismatched_struct> FindSimilarBitsDlg::calcBits(uint8_
       auto &mismatched = it.value();
       for (int i = 0; i < mismatched.size(); ++i) {
         if (uint32_t perc = (mismatched[i] / (double)cnt) * 100; perc < 50) {
-          result.push_back({it.key(), mismatched[i], cnt, perc, (uint32_t)i / 8, (uint32_t)i % 8});
+          result.push_back({it.key(), (uint32_t)i / 8, (uint32_t)i % 8, mismatched[i], cnt, perc});
         }
       }
     }
   }
-  std::sort(result.begin(), result.end(), [](auto &l, auto &r) { return l.perc < r.perc; });
+  std::sort(result.begin(), result.end(), [](auto &l, auto &r) { return l.perc > r.perc; });
   return result;
 }

--- a/tools/cabana/tools/findsimilarbits.cc
+++ b/tools/cabana/tools/findsimilarbits.cc
@@ -74,15 +74,15 @@ void FindSimilarBitsDlg::find() {
   auto msg_mismatched = calcBits(bus_combo->currentText().toUInt(), selected_address, byte_idx_sb->value(), bit_idx_sb->value(), min_msgs->text().toInt());
   table->setRowCount(msg_mismatched.size());
   table->setColumnCount(6);
-  table->setHorizontalHeaderLabels({"address", "byte idx", "bit idx", "mismatches", "total", "perc%"});
+  table->setHorizontalHeaderLabels({"address", "mismatches", "total msgs", "% mismatched", "byte idx", "bit idx"});
   for (int i = 0; i < msg_mismatched.size(); ++i) {
     auto &m = msg_mismatched[i];
     table->setItem(i, 0, new QTableWidgetItem(QString("%1").arg(m.address, 1, 16)));
+    table->setItem(i, 3, new QTableWidgetItem(QString::number(m.mismatches)));
+    table->setItem(i, 4, new QTableWidgetItem(QString::number(m.total_msgs)));
+    table->setItem(i, 5, new QTableWidgetItem(QString::number(m.perc)));
     table->setItem(i, 1, new QTableWidgetItem(QString::number(m.byte_idx)));
     table->setItem(i, 2, new QTableWidgetItem(QString::number(m.bit_idx)));
-    table->setItem(i, 3, new QTableWidgetItem(QString::number(m.mismatches)));
-    table->setItem(i, 4, new QTableWidgetItem(QString::number(m.total)));
-    table->setItem(i, 5, new QTableWidgetItem(QString::number(m.perc)));
   }
   search_btn->setEnabled(true);
 }
@@ -127,11 +127,11 @@ QList<FindSimilarBitsDlg::mismatched_struct> FindSimilarBitsDlg::calcBits(uint8_
       auto &mismatched = it.value();
       for (int i = 0; i < mismatched.size(); ++i) {
         if (uint32_t perc = (mismatched[i] / (double)cnt) * 100; perc < 50) {
-          result.push_back({it.key(), (uint32_t)i / 8, (uint32_t)i % 8, mismatched[i], cnt, perc});
+          result.push_back({it.key(), mismatched[i], cnt, perc, (uint32_t)i / 8, (uint32_t)i % 8});
         }
       }
     }
   }
-  std::sort(result.begin(), result.end(), [](auto &l, auto &r) { return l.perc > r.perc; });
+  std::sort(result.begin(), result.end(), [](auto &l, auto &r) { return l.perc < r.perc; });
   return result;
 }

--- a/tools/cabana/tools/findsimilarbits.cc
+++ b/tools/cabana/tools/findsimilarbits.cc
@@ -74,7 +74,7 @@ void FindSimilarBitsDlg::find() {
   auto msg_mismatched = calcBits(bus_combo->currentText().toUInt(), selected_address, byte_idx_sb->value(), bit_idx_sb->value(), min_msgs->text().toInt());
   table->setRowCount(msg_mismatched.size());
   table->setColumnCount(6);
-  table->setHorizontalHeaderLabels({"address", "byte idx", "bit idx", "mismatches", "total", "perc%"});
+  table->setHorizontalHeaderLabels({"address", "byte idx", "bit idx", "mismatches", "total msgs", "% mismatched"});
   for (int i = 0; i < msg_mismatched.size(); ++i) {
     auto &m = msg_mismatched[i];
     table->setItem(i, 0, new QTableWidgetItem(QString("%1").arg(m.address, 1, 16)));
@@ -132,6 +132,6 @@ QList<FindSimilarBitsDlg::mismatched_struct> FindSimilarBitsDlg::calcBits(uint8_
       }
     }
   }
-  std::sort(result.begin(), result.end(), [](auto &l, auto &r) { return l.perc > r.perc; });
+  std::sort(result.begin(), result.end(), [](auto &l, auto &r) { return l.perc < r.perc; });
   return result;
 }

--- a/tools/cabana/tools/findsimilarbits.h
+++ b/tools/cabana/tools/findsimilarbits.h
@@ -12,7 +12,8 @@ public:
 
 private:
   struct mismatched_struct {
-    uint32_t address, byte_idx, bit_idx, mismatches, total, perc;
+    uint32_t address, byte_idx, bit_idx, mismatches, total;
+    float perc;
   };
   QList<mismatched_struct> calcBits(uint8_t bus, uint32_t selected_address, int byte_idx, int bit_idx, int min_msgs_cnt);
   void find();

--- a/tools/cabana/tools/findsimilarbits.h
+++ b/tools/cabana/tools/findsimilarbits.h
@@ -12,7 +12,7 @@ public:
 
 private:
   struct mismatched_struct {
-    uint32_t address, mismatches, total_msgs, perc, byte_idx, bit_idx;
+    uint32_t address, byte_idx, bit_idx, mismatches, total, perc;
   };
   QList<mismatched_struct> calcBits(uint8_t bus, uint32_t selected_address, int byte_idx, int bit_idx, int min_msgs_cnt);
   void find();

--- a/tools/cabana/tools/findsimilarbits.h
+++ b/tools/cabana/tools/findsimilarbits.h
@@ -12,7 +12,7 @@ public:
 
 private:
   struct mismatched_struct {
-    uint32_t address, byte_idx, bit_idx, mismatches, total, perc;
+    uint32_t address, mismatches, total_msgs, perc, byte_idx, bit_idx;
   };
   QList<mismatched_struct> calcBits(uint8_t bus, uint32_t selected_address, int byte_idx, int bit_idx, int min_msgs_cnt);
   void find();

--- a/tools/cabana/tools/findsimilarbits.h
+++ b/tools/cabana/tools/findsimilarbits.h
@@ -3,6 +3,7 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QLineEdit>
+#include <QSpinBox>
 #include <QTableWidget>
 
 class FindSimilarBitsDlg : public QDialog {
@@ -13,11 +14,12 @@ private:
   struct mismatched_struct {
     uint32_t address, byte_idx, bit_idx, mismatches, total, perc;
   };
-  QList<mismatched_struct> calcBits(uint8_t bus, int bit_to_find, int min_msgs_cnt);
+  QList<mismatched_struct> calcBits(uint8_t bus, uint32_t selected_address, int byte_idx, int bit_idx, int min_msgs_cnt);
   void find();
 
   QTableWidget *table;
-  QComboBox *bus_combo, *bit_combo;
+  QComboBox *bus_combo, *msg_cb;
+  QSpinBox *byte_idx_sb, *bit_idx_sb;
   QPushButton *search_btn;
   QLineEdit *min_msgs;
 };


### PR DESCRIPTION
dynamic get `bit_to_find` from selected message bit:

>  if (address == selected_address && dat.size() > byte_idx) {
            bit_to_find = ((dat[byte_idx] >> (7 - bit_idx)) & 1) != 0;
          }

![2023-01-11_17-04](https://user-images.githubusercontent.com/27770/211763712-8da1914e-9513-4550-a659-303b9db86056.png)


@sshane Is it right to do like this? any comments?