### PR TITLE
Tall vehicles: calibrate vlead from model error

### DIFF
--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -132,12 +132,10 @@ class Cluster():
 
   def get_RadarState_from_vision(self, lead_msg, v_ego, vision_v_ego):
     # Learn vision model velocity error to correct vlead
+    corrected_v_lead = lead_msg.v[0]
     if v_ego > 0 and vision_v_ego > 0:
       vision_velocity_factor = v_ego / vision_v_ego
       corrected_v_lead = lead_msg.v[0] * vision_velocity_factor
-      #if no v_ego or vision_v_ego set, fallback to uncalibrated values
-    else: 
-      corrected_v_lead = lead_msg.v[0]
     return {
       "dRel": float(lead_msg.x[0] - RADAR_TO_CAMERA),
       "yRel": float(-lead_msg.y[0]),

--- a/selfdrive/controls/lib/radar_helpers.py
+++ b/selfdrive/controls/lib/radar_helpers.py
@@ -130,14 +130,21 @@ class Cluster():
       "aLeadTau": float(self.aLeadTau)
     }
 
-  def get_RadarState_from_vision(self, lead_msg, v_ego):
+  def get_RadarState_from_vision(self, lead_msg, v_ego, vision_v_ego):
+    # Learn vision model velocity error to correct vlead
+    if v_ego > 0 and vision_v_ego > 0:
+      vision_velocity_factor = v_ego / vision_v_ego
+      corrected_v_lead = lead_msg.v[0] * vision_velocity_factor
+      #if no v_ego or vision_v_ego set, fallback to uncalibrated values
+    else: 
+      corrected_v_lead = lead_msg.v[0]
     return {
       "dRel": float(lead_msg.x[0] - RADAR_TO_CAMERA),
       "yRel": float(-lead_msg.y[0]),
-      "vRel": float(lead_msg.v[0] - v_ego),
-      "vLead": float(lead_msg.v[0]),
-      "vLeadK": float(lead_msg.v[0]),
-      "aLeadK": float(0),
+      "vRel": float(corrected_v_lead - v_ego),
+      "vLead": float(corrected_v_lead),
+      "vLeadK": float(corrected_v_lead),
+      "aLeadK": float(lead_msg.a[0]),
       "aLeadTau": _LEAD_ACCEL_TAU,
       "fcw": False,
       "modelProb": float(lead_msg.prob),

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -172,11 +172,10 @@ class RadarD():
 
     leads_v3 = sm['modelV2'].leadsV3
     if len(leads_v3) > 1:
+      vision_v_ego = self.v_ego
       #check vision based ego from model
       if len(sm['modelV2'].temporalPose.trans):
         vision_v_ego = sm['modelV2'].temporalPose.trans[0]
-      else: #if no vision ego available, use wheel speed
-        vision_v_ego = self.v_ego
       radarState.leadOne = get_lead(self.v_ego, self.ready, clusters, leads_v3[0], vision_v_ego, low_speed_override=True)
       radarState.leadTwo = get_lead(self.v_ego, self.ready, clusters, leads_v3[1], vision_v_ego, low_speed_override=False)
     return dat


### PR DESCRIPTION
**Description**

When using vision only longitudinal control from OpenPilot (more prominent on taller vehicles), it estimates the world objects moving too slow overall including itself [#26799](https://github.com/commaai/openpilot/discussions/26799). This is verified from speed reported from the model is off from wheel speed, we used this info to calibrate e2e before, now we can use this concept to calibrate vlead and lead acceleration too. 

**Verification**

I have been driving a few days with another proof of concept branch and has been working really well on my GMC Sierra 1500 AT4 (2 inch taller than regular 1500's)

**Route**
Route: https://connect.comma.ai/fe80a4e1cedec853/1673461336764/1673461574279

As shown in the route, it maintained the distance with little to no overshooting or undershooting, also experience a cut-in that was handled perfectly with OP VOACC, I have driven a few hundred kms with this implemented so far