### PR TITLE
cabana: MacOS fixes

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -8,10 +8,11 @@ base_libs = [common, messaging, cereal, visionipc, transformations, 'zmq',
 
 if arch == "Darwin":
   base_frameworks.append('OpenCL')
+  base_frameworks.append('QtCharts')
 else:
   base_libs.append('OpenCL')
 
-qt_libs = ['qt_util', 'Qt5Charts'] + base_libs
+qt_libs = ['qt_util'] + base_libs
 cabana_libs = [widgets, cereal, messaging, visionipc, replay_lib, opendbc,'avutil', 'avcodec', 'avformat', 'bz2', 'curl', 'yuv'] + qt_libs
 cabana_env = qt_env.Clone()
 

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -6,7 +6,6 @@ base_frameworks = qt_env['FRAMEWORKS']
 base_libs = [common, messaging, cereal, visionipc, transformations, 'zmq',
              'capnp', 'kj', 'm', 'ssl', 'crypto', 'pthread'] + qt_env["LIBS"]
 
-
 if arch == "Darwin":
   base_frameworks.append('OpenCL')
   base_frameworks.append('QtCharts')

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -6,13 +6,16 @@ base_frameworks = qt_env['FRAMEWORKS']
 base_libs = [common, messaging, cereal, visionipc, transformations, 'zmq',
              'capnp', 'kj', 'm', 'ssl', 'crypto', 'pthread'] + qt_env["LIBS"]
 
+
 if arch == "Darwin":
   base_frameworks.append('OpenCL')
   base_frameworks.append('QtCharts')
 else:
   base_libs.append('OpenCL')
+  base_libs.append('Qt5Charts')
 
 qt_libs = ['qt_util'] + base_libs
+
 cabana_libs = [widgets, cereal, messaging, visionipc, replay_lib, opendbc,'avutil', 'avcodec', 'avformat', 'bz2', 'curl', 'yuv'] + qt_libs
 cabana_env = qt_env.Clone()
 

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -33,9 +33,11 @@ int main(int argc, char *argv[]) {
     replay_flags |= REPLAY_FLAG_QCAMERA;
   }
 
+  // TODO: Remove when OpenpilotPrefix supports ZMQ
 #ifndef __APPLE__
   OpenpilotPrefix op_prefix;
 #endif
+
   CANMessages p(&app);
   int ret = 0;
   if (p.loadRoute(route, cmd_parser.value("data_dir"), replay_flags)) {

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -33,7 +33,9 @@ int main(int argc, char *argv[]) {
     replay_flags |= REPLAY_FLAG_QCAMERA;
   }
 
+#ifndef __APPLE__
   OpenpilotPrefix op_prefix;
+#endif
   CANMessages p(&app);
   int ret = 0;
   if (p.loadRoute(route, cmd_parser.value("data_dir"), replay_flags)) {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -269,6 +269,8 @@ void ChartView::setPlotAreaLeftPosition(int pos) {
 void ChartView::addSeries(const QString &msg_id, const Signal *sig) {
   QLineSeries *series = new QLineSeries(this);
 
+  // TODO: Due to a bug in CameraWidget the camera frames
+  // are drawn instead of the graphs on MacOS. Re-enable OpenGL when fixed
 #ifndef __APPLE__
   series->setUseOpenGL(true);
 #endif

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -268,7 +268,10 @@ void ChartView::setPlotAreaLeftPosition(int pos) {
 
 void ChartView::addSeries(const QString &msg_id, const Signal *sig) {
   QLineSeries *series = new QLineSeries(this);
+
+#ifndef __APPLE__
   series->setUseOpenGL(true);
+#endif
   chart()->addSeries(series);
   series->attachAxis(axis_x);
   series->attachAxis(axis_y);


### PR DESCRIPTION
- `OpenpilotPrefix` is msgq specific, which isn't used on MacOS
- OpenGL needs to be disabled on the graphs or it will draw the video. There might be a more proper fix for this. https://github.com/commaai/openpilot/discussions/26091#discussioncomment-4634932
- `Qt5Charts` needs to be added as a framework instead of library

Still draft until I have a chance to test on Linux