### PR TITLE
VW MQB: Add diagnostic firewall note to config tool

### DIFF
--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -126,6 +126,7 @@ if __name__ == "__main__":
       uds_client.security_access(ACCESS_TYPE_LEVEL_1.SEND_KEY, struct.pack("!I", key))  # type: ignore
     except (NegativeResponseError, MessageTimeoutError):
       print("Security access failed!")
+      print("Open the hood and retry (disables the \"diagnostic firewall\" on newer vehicles)")
       quit()
 
     try:


### PR DESCRIPTION
Add a note to the security access exception path in `vw_mqb_config.py`, alerting the user they may need to open their hood in order to make changes. This is due to a "diagnostic firewall" in vehicles MY2020-ish and forward. The hood latch state is used as sort of a proxy to prove physical access to the vehicle with an intent to service.

It's possible to programmatically detect whether the diagnostic firewall is active, but not currently worth the effort, because it's the only common reason for security access to fail on currently-supported cars.