### PR TITLE
cabana: sort bus:id numerically instead of alphabetically

### DIFF
--- a/tools/cabana/canmessages.cc
+++ b/tools/cabana/canmessages.cc
@@ -64,6 +64,8 @@ bool CANMessages::eventFilter(const Event *event) {
       QString id = QString("%1:%2").arg(c.getSrc()).arg(c.getAddress(), 1, 16);
       CanData &data = (*new_msgs)[id];
       data.ts = current_sec;
+      data.src = c.getSrc();
+      data.address = c.getAddress();
       data.dat = QByteArray((char *)c.getDat().begin(), c.getDat().size());
       data.count = ++counters[id];
       if (double delta = (current_sec - counters_begin_sec); delta > 0) {

--- a/tools/cabana/canmessages.h
+++ b/tools/cabana/canmessages.h
@@ -11,6 +11,8 @@
 
 struct CanData {
   double ts = 0.;
+  uint32_t src = 0;
+  uint32_t address = 0;
   uint32_t count = 0;
   uint32_t freq = 0;
   QByteArray dat;

--- a/tools/cabana/canmessages.h
+++ b/tools/cabana/canmessages.h
@@ -11,7 +11,7 @@
 
 struct CanData {
   double ts = 0.;
-  uint32_t src = 0;
+  uint8_t src = 0;
   uint32_t address = 0;
   uint32_t count = 0;
   uint32_t freq = 0;

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -101,7 +101,9 @@ void MessageListModel::sortMessages() {
     });
   } else if (sort_column == 1) {
     std::sort(msgs.begin(), msgs.end(), [this](auto &l, auto &r) {
-      return sort_order == Qt::AscendingOrder ? l < r : l > r;
+      auto ll = std::tuple{can->lastMessage(l).src, can->lastMessage(l).address, l};
+      auto rr = std::tuple{can->lastMessage(r).src, can->lastMessage(r).address, r};
+      return sort_order == Qt::AscendingOrder ? ll < rr : ll > rr;
     });
   } else if (sort_column == 2) {
     std::sort(msgs.begin(), msgs.end(), [this](auto &l, auto &r) {


### PR DESCRIPTION
Before `0:4a` would be sorted after `0:3aa`