### PR TITLE
cabana: make video resizable

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -16,7 +16,6 @@
 
 ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
-  main_layout->setContentsMargins(0, 0, 0, 0);
 
   // toolbar
   QToolBar *toolbar = new QToolBar(tr("Charts"), this);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -116,19 +116,23 @@ void MainWindow::createDockWindows() {
   addDockWidget(Qt::LeftDockWidgetArea, dock);
 
   // right panel
-  QWidget *right_container = new QWidget(this);
-  r_layout = new QVBoxLayout(right_container);
   charts_widget = new ChartsWidget(this);
+  QWidget *charts_container = new QWidget(this);
+  charts_layout = new QVBoxLayout(charts_container);
+  charts_layout->setContentsMargins(0, 0, 0, 0);
+  charts_layout->addWidget(charts_widget);
+
   video_widget = new VideoWidget(this);
-  r_layout->addWidget(video_widget, 0, Qt::AlignTop);
-  r_layout->addWidget(charts_widget, 1);
-  r_layout->addStretch(0);
+  video_splitter = new QSplitter(Qt::Vertical,this);
+  video_splitter->addWidget(video_widget);
+  video_splitter->addWidget(charts_container);
+  video_splitter->restoreState(settings.video_splitter_state);
 
   video_dock = new QDockWidget(can->routeName(), this);
   video_dock->setObjectName(tr("VideoPanel"));
   video_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
   video_dock->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
-  video_dock->setWidget(right_container);
+  video_dock->setWidget(video_splitter);
   addDockWidget(Qt::RightDockWidgetArea, video_dock);
 }
 
@@ -239,7 +243,7 @@ void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool succe
 void MainWindow::dockCharts(bool dock) {
   if (dock && floating_window) {
     floating_window->removeEventFilter(charts_widget);
-    r_layout->insertWidget(2, charts_widget, 1);
+    charts_layout->insertWidget(0, charts_widget, 1);
     floating_window->deleteLater();
     floating_window = nullptr;
   } else if (!dock && !floating_window) {
@@ -270,6 +274,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
   settings.geometry = saveGeometry();
   settings.window_state = saveState();
+  settings.video_splitter_state = video_splitter->saveState();
   settings.save();
   QWidget::closeEvent(event);
 }

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -5,6 +5,7 @@
 #include <QJsonDocument>
 #include <QMainWindow>
 #include <QProgressBar>
+#include <QSplitter>
 #include <QStatusBar>
 
 #include "tools/cabana/chartswidget.h"
@@ -51,8 +52,9 @@ protected:
   DetailWidget *detail_widget;
   ChartsWidget *charts_widget;
   QWidget *floating_window = nullptr;
-  QVBoxLayout *r_layout;
+  QVBoxLayout *charts_layout;
   QProgressBar *progress_bar;
   QJsonDocument fingerprint_to_dbc;
   QComboBox *dbc_combo;
+  QSplitter *video_splitter;;
 };

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -21,6 +21,7 @@ void Settings::save() {
   s.setValue("last_dir", last_dir);
   s.setValue("window_state", window_state);
   s.setValue("geometry", geometry);
+  s.setValue("video_splitter_state", video_splitter_state);
 }
 
 void Settings::load() {
@@ -32,6 +33,7 @@ void Settings::load() {
   last_dir = s.value("last_dir", QDir::homePath()).toString();
   window_state = s.value("window_state").toByteArray();
   geometry = s.value("geometry").toByteArray();
+  video_splitter_state = s.value("video_splitter_state").toByteArray();
 }
 
 // SettingsDlg

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -18,7 +18,9 @@ public:
   int chart_height = 200;
   int max_chart_x_range = 3 * 60; // 3 minutes
   QString last_dir;
-  QByteArray window_state, geometry;
+  QByteArray geometry;
+  QByteArray video_splitter_state;
+  QByteArray window_state;
 
 signals:
   void changed();

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -17,20 +17,16 @@ inline QString formatTime(int seconds) {
   return QDateTime::fromTime_t(seconds).toString(seconds > 60 * 60 ? "hh:mm:ss" : "mm:ss");
 }
 
-VideoWidget::VideoWidget(QWidget *parent) : QFrame(parent) {
-  setFrameShape(QFrame::StyledPanel);
-  setFrameShadow(QFrame::Sunken);
-  QHBoxLayout *containter_layout = new QHBoxLayout(this);
-  QVBoxLayout *main_layout = new QVBoxLayout();
-  main_layout->setContentsMargins(0, 0, 0, 0);
+VideoWidget::VideoWidget(QWidget *parent) : QWidget(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  QFrame *frame = new QFrame(this);
+  frame->setFrameShape(QFrame::StyledPanel);
+  frame->setFrameShadow(QFrame::Sunken);
+  main_layout->addWidget(frame);
 
-  containter_layout->addStretch(1);
-  containter_layout->addLayout(main_layout);
-  containter_layout->addStretch(1);
-
-  cam_widget = new CameraWidget("camerad", can->visionStreamType(), false, this);
-  cam_widget->setFixedSize(parent->width(), parent->width() / 1.596);
-  main_layout->addWidget(cam_widget);
+  QVBoxLayout *frame_layout = new QVBoxLayout(frame);
+  cam_widget = new CameraWidget("camerad", can->visionStreamType(), false);
+  frame_layout->addWidget(cam_widget);
 
   // slider controls
   QHBoxLayout *slider_layout = new QHBoxLayout();
@@ -43,7 +39,7 @@ VideoWidget::VideoWidget(QWidget *parent) : QFrame(parent) {
 
   end_time_label = new QLabel(this);
   slider_layout->addWidget(end_time_label);
-  main_layout->addLayout(slider_layout);
+  frame_layout->addLayout(slider_layout);
 
   // btn controls
   QHBoxLayout *control_layout = new QHBoxLayout();
@@ -61,7 +57,11 @@ VideoWidget::VideoWidget(QWidget *parent) : QFrame(parent) {
     group->addButton(btn);
     if (speed == 1.0) btn->setChecked(true);
   }
-  main_layout->addLayout(control_layout);
+  frame_layout->addLayout(control_layout);
+
+  cam_widget->setMinimumHeight(100);
+  cam_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
 
   QObject::connect(slider, &QSlider::sliderReleased, [this]() { can->seekTo(slider->value() / 1000.0); });
   QObject::connect(slider, &QSlider::valueChanged, [=](int value) { time_label->setText(formatTime(value / 1000)); });

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -35,7 +35,7 @@ private:
   QSize thumbnail_size = {};
 };
 
-class VideoWidget : public QFrame {
+class VideoWidget : public QWidget {
   Q_OBJECT
 
 public:


### PR DESCRIPTION
make video&right panel resizable. drag to topmost to hide the video.
the splitter state will be restored on next startup

[Kazam_screencast_00052.webm](https://user-images.githubusercontent.com/27770/213267236-ca402365-509e-446e-b453-cbb145eba658.webm)
