### PR TITLE
cabana: improve video splitter

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -124,13 +124,20 @@ void MainWindow::createDockWindows() {
 
   video_splitter = new QSplitter(Qt::Vertical,this);
 
+  // splitter between video and charts
+  video_splitter = new QSplitter(Qt::Vertical, this);
   if (!can->liveStreaming()) {
     video_widget = new VideoWidget(this);
     video_splitter->addWidget(video_widget);
     QObject::connect(charts_widget, &ChartsWidget::rangeChanged, video_widget, &VideoWidget::rangeChanged);
   }
   video_splitter->addWidget(charts_container);
+  video_splitter->setStretchFactor(1, 1);
   video_splitter->restoreState(settings.video_splitter_state);
+  if (!can->liveStreaming() && video_splitter->sizes()[0] == 0) {
+    // display video at minimum size.
+    video_splitter->setSizes({1, 1});
+  }
 
   video_dock = new QDockWidget(can->routeName(), this);
   video_dock->setObjectName(tr("VideoPanel"));
@@ -284,7 +291,9 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
   settings.geometry = saveGeometry();
   settings.window_state = saveState();
-  settings.video_splitter_state = video_splitter->saveState();
+  if (!can->liveStreaming()) {
+    settings.video_splitter_state = video_splitter->saveState();
+  }
   settings.save();
   QWidget::closeEvent(event);
 }


### PR DESCRIPTION
1.don't save state in live stream mode. otherwise the video will disappear in next replay mode.
2.make sure video is visible after startup