### PR TITLE
cabana: improve layout

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -11,6 +11,7 @@
 // BinaryView
 
 const int CELL_HEIGHT = 36;
+const int VERTICAL_HEADER_WIDTH = 30;
 
 inline int get_bit_index(const QModelIndex &index, bool little_endian) {
   return index.row() * 8 + (little_endian ? 7 - index.column() : index.column());
@@ -31,6 +32,10 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   setMouseTracking(true);
   setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
   setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+}
+
+QSize BinaryView::minimumSizeHint() const {
+  return {horizontalHeader()->minimumSectionSize() * 9 + VERTICAL_HEADER_WIDTH + 2, 0};
 }
 
 void BinaryView::highlight(const Signal *sig) {
@@ -215,7 +220,7 @@ QVariant BinaryViewModel::headerData(int section, Qt::Orientation orientation, i
   if (orientation == Qt::Vertical) {
     switch (role) {
       case Qt::DisplayRole: return section;
-      case Qt::SizeHintRole: return QSize(30, 0);
+      case Qt::SizeHintRole: return QSize(VERTICAL_HEADER_WIDTH, 0);
       case Qt::TextAlignmentRole: return Qt::AlignCenter;
     }
   }

--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -60,6 +60,7 @@ public:
   void highlight(const Signal *sig);
   QSet<const Signal*> getOverlappingSignals() const;
   inline void updateState() { model->updateState(); }
+  QSize minimumSizeHint() const override;
 
 signals:
   void signalClicked(const Signal *sig);

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -16,7 +16,6 @@
 
 DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(charts), QWidget(parent) {
   undo_stack = new QUndoStack(this);
-  setMinimumWidth(500);
   QWidget *main_widget = new QWidget(this);
   QVBoxLayout *main_layout = new QVBoxLayout(main_widget);
   main_layout->setContentsMargins(0, 0, 0, 0);

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -31,6 +31,7 @@ public:
   DetailWidget(ChartsWidget *charts, QWidget *parent);
   void setMessage(const QString &message_id);
   void dbcMsgChanged(int show_form_idx = -1);
+  QSize minimumSizeHint() const override { return binary_view->minimumSizeHint(); }
   QUndoStack *undo_stack = nullptr;
 
 private:

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -24,7 +24,6 @@ void qLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const
 MainWindow::MainWindow() : QMainWindow() {
   createDockWindows();
   detail_widget = new DetailWidget(charts_widget, this);
-  detail_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
   setCentralWidget(detail_widget);
   createActions();
   createStatusBar();


### PR DESCRIPTION
remove hardcoded width for detailWidget. make sure the hex column in binaryview will not be hidden.

![Screenshot from 2023-01-22 16-27-10](https://user-images.githubusercontent.com/27770/213907006-b47bd836-d8bc-43ae-a974-26f07f9bac95.png)

before:

![Screenshot from 2023-01-22 16-27-55](https://user-images.githubusercontent.com/27770/213907002-821002e0-b37a-4c4a-b681-51d922ffa5bd.png)

