### PR TITLE
Update radar_interface.py

### DIFF
--- a/selfdrive/car/honda/radar_interface.py
+++ b/selfdrive/car/honda/radar_interface.py
@@ -3,86 +3,86 @@ from cereal import car
 from opendbc.can.parser import CANParser
 from selfdrive.car.interfaces import RadarInterfaceBase
 from selfdrive.car.honda.values import DBC
-
+from collections import deque
 
 def _create_nidec_can_parser(car_fingerprint):
-  radar_messages = [0x400] + list(range(0x430, 0x43A)) + list(range(0x440, 0x446))
-  signals = list(zip(['RADAR_STATE'] +
+    radar_messages = [0x400] + list(range(0x430, 0x43A)) + list(range(0x440, 0x446))
+    signals = list(zip(['RADAR_STATE'] +
                      ['LONG_DIST'] * 16 + ['NEW_TRACK'] * 16 + ['LAT_DIST'] * 16 +
                      ['REL_SPEED'] * 16,
                      [0x400] + radar_messages[1:] * 4))
-  checks = [(s[1], 20) for s in signals]
-  return CANParser(DBC[car_fingerprint]['radar'], signals, checks, 1)
+    checks = [(s[1], 20) for s in signals]
+    return CANParser(DBC[car_fingerprint]['radar'], signals, checks, 1)
 
 
 class RadarInterface(RadarInterfaceBase):
-  def __init__(self, CP):
-    super().__init__(CP)
-    self.track_id = 0
-    self.radar_fault = False
-    self.radar_wrong_config = False
-    self.radar_off_can = CP.radarOffCan
-    self.radar_ts = CP.radarTimeStep
+    def __init__(self, CP):
+        super().__init__(CP)
+        self.track_id = 0
+        self.radar_fault = False
+        self.radar_wrong_config = False
+        self.radar_off_can = CP.radarOffCan
+        self.radar_ts = CP.radarTimeStep
+        self.delay = int(round(0.1 / CP.radarTimeStep))   # 0.1s delay of radar
+        self.rcp = None
+        self.can_strings = deque(maxlen=self.delay)
+        if not self.radar_off_can:
+            self.rcp = _create_nidec_can_parser(CP.carFingerprint)
+            self.trigger_msg = 0x445
+            self.updated_messages = set()
 
-    self.delay = int(round(0.1 / CP.radarTimeStep))   # 0.1s delay of radar
+    def update(self, can_strings):
+        if self.radar_off_can:
+            return super().update(None)
+        self.can_strings.extend(can_strings)
+        if len(self.can_strings) < self.delay:
+            return None
 
-    # Nidec
-    if self.radar_off_can:
-      self.rcp = None
-    else:
-      self.rcp = _create_nidec_can_parser(CP.carFingerprint)
-    self.trigger_msg = 0x445
-    self.updated_messages = set()
+        vls = self.rcp.update_strings(self.can_strings)
+        self.updated_messages.update(vls)
 
-  def update(self, can_strings):
-    # in Bosch radar and we are only steering for now, so sleep 0.05s to keep
-    # radard at 20Hz and return no points
-    if self.radar_off_can:
-      return super().update(None)
+        if self.trigger_msg not in self.updated_messages:
+            return None
 
-    vls = self.rcp.update_strings(can_strings)
-    self.updated_messages.update(vls)
+        rr = self._update(self.updated_messages)
+        self.updated_messages.clear()
+        self.can_strings.clear()
+        return rr
 
-    if self.trigger_msg not in self.updated_messages:
-      return None
+    def _update(self, updated_messages):
+        ret = car.RadarData.new_message()
 
-    rr = self._update(self.updated_messages)
-    self.updated_messages.clear()
-    return rr
+        for ii in sorted(updated_messages):
+            cpt = self.rcp.vl.get(ii, None)
+            if cpt is None:
+                continue
+            if isinstance(cpt, dict) and cpt.get('RADAR_STATE', None) is not None:
+                # check for radar faults
+                self.radar_fault = cpt['RADAR_STATE'] != 0x79
+                self.radar_wrong_config = cpt['RADAR_STATE'] == 0x69
+            elif cpt.get('LONG_DIST', None) is not None and cpt['LONG_DIST'] < 255:
+                if ii not in self.pts or cpt['NEW_TRACK']:
+                    self.pts[ii] = car.RadarData.RadarPoint.new_message()
+                    self.pts[ii].trackId = self.track_id
+                    self.track_id += 1
+                self.pts[ii].dRel = cpt['LONG_DIST']  # from front of car
+                self.pts[ii].yRel = -cpt['LAT_DIST']  # in car frame's y axis, left is positive
+                self.pts[ii].vRel = cpt['REL_SPEED']
+                self.pts[ii].aRel = float('nan')
+                self.pts[ii].measured = True
+            elif ii in self.pts:
+                self.pts.pop(ii)
 
-  def _update(self, updated_messages):
-    ret = car.RadarData.new_message()
+        errors = []
+        if not self.rcp.can_valid:
+            errors.append("canError")
+        if self.radar_fault:
+            errors.append("fault")
+        if self.radar_wrong_config:
+            errors.append("wrongConfig")
+        ret.errors = errors
+        return ret
 
-    for ii in sorted(updated_messages):
-      cpt = self.rcp.vl[ii]
-      if ii == 0x400:
-        # check for radar faults
-        self.radar_fault = cpt['RADAR_STATE'] != 0x79
-        self.radar_wrong_config = cpt['RADAR_STATE'] == 0x69
-      elif cpt['LONG_DIST'] < 255:
-        if ii not in self.pts or cpt['NEW_TRACK']:
-          self.pts[ii] = car.RadarData.RadarPoint.new_message()
-          self.pts[ii].trackId = self.track_id
-          self.track_id += 1
-        self.pts[ii].dRel = cpt['LONG_DIST']  # from front of car
-        self.pts[ii].yRel = -cpt['LAT_DIST']  # in car frame's y axis, left is positive
-        self.pts[ii].vRel = cpt['REL_SPEED']
-        self.pts[ii].aRel = float('nan')
-        self.pts[ii].yvRel = float('nan')
-        self.pts[ii].measured = True
-      else:
-        if ii in self.pts:
-          del self.pts[ii]
 
-    errors = []
-    if not self.rcp.can_valid:
-      errors.append("canError")
-    if self.radar_fault:
-      errors.append("fault")
-    if self.radar_wrong_config:
-      errors.append("wrongConfig")
-    ret.errors = errors
 
-    ret.points = list(self.pts.values())
 
-    return ret


### PR DESCRIPTION
You can use the collections.deque class to store the can_strings instead of a list. This can provide better performance when inserting and removing elements from the beginning of the list.

You can use the isinstance function to check the type of variable instead of using the __class__ attribute.

You can use the CP.carFingerprint variable instead of hardcoding the car fingerprint in the _create_nidec_can_parser() function.

You can use the dict.get() method to safely retrieve a value from a dictionary without raising an exception.

You can use the dict.pop() method to remove an item from a dictionary and return its value, instead of using the del statement.

You can use the dict.setdefault() method to set the default value of a key if it does not exist in the dictionary, instead of using the if statement to check if the key exists.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
