### PR TITLE
ui: tap experimental mode icon to toggle

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -177,7 +177,7 @@ void OnroadAlerts::paintEvent(QPaintEvent *event) {
 
 ExperimentalButton::ExperimentalButton(QWidget *parent) : QPushButton(parent) {
   setVisible(false);
-  setFixedSize(diameter, diameter);
+  setFixedSize(btn_size, btn_size);
   setCheckable(true);
 
   params = Params();
@@ -209,15 +209,15 @@ void ExperimentalButton::paintEvent(QPaintEvent *event) {
   QPainter p(this);
   p.setRenderHint(QPainter::Antialiasing);
 
-  QPoint center(radius, radius);
+  QPoint center(btn_size / 2, btn_size / 2);
   QPixmap img = isChecked() ? experimental_img : engage_img;
 
   p.setOpacity(1.0);
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(0, 0, 0, 166));
-  p.drawEllipse(center, radius, radius);
+  p.drawEllipse(center, btn_size / 2, btn_size / 2);
   p.setOpacity(isDown() ? 0.8 : 1.0);
-  p.drawPixmap((width() - img_size) / 2, (height() - img_size) / 2, img);
+  p.drawPixmap((btn_size - img_size) / 2, (btn_size - img_size) / 2, img);
 }
 
 
@@ -437,7 +437,7 @@ void AnnotatedCameraWidget::drawHud(QPainter &p) {
 
   // dm icon
   if (!hideDM) {
-    int dm_icon_x = rightHandDM ? rect().right() - radius - (bdr_s * 2) : radius + (bdr_s * 2);
+    int dm_icon_x = rightHandDM ? rect().right() - btn_size / 2 - (bdr_s * 2) : btn_size / 2 + (bdr_s * 2);
     drawIcon(p, dm_icon_x, rect().bottom() - footer_h / 2,
              dm_img, blackColor(70), dmActive ? 1.0 : 0.2);
   }
@@ -460,7 +460,7 @@ void AnnotatedCameraWidget::drawIcon(QPainter &p, int x, int y, QPixmap &img, QB
   p.setOpacity(1.0);  // bg dictates opacity of ellipse
   p.setPen(Qt::NoPen);
   p.setBrush(bg);
-  p.drawEllipse(x - radius, y - radius, diameter, diameter);
+  p.drawEllipse(x - btn_size / 2, y - btn_size / 2, btn_size, btn_size);
   p.setOpacity(opacity);
   p.drawPixmap(x - img.size().width() / 2, y - img.size().height() / 2, img);
 }

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -9,10 +9,8 @@
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 
 
-const int img_size = 144;
-const int diameter = (img_size * 4) / 3;
-const int radius = diameter / 2;
-
+const int btn_size = 192;
+const int img_size = (btn_size / 4) * 3;
 
 
 // ***** onroad widgets *****
@@ -38,15 +36,12 @@ public:
   explicit ExperimentalButton(QWidget *parent = 0);
   void updateState(const UIState &s);
 
-  void setBackgroundColor(const QColor &color) { bg = color; }
-
 private:
   void paintEvent(QPaintEvent *event) override;
 
   Params params;
   QPixmap engage_img;
   QPixmap experimental_img;
-  QColor bg;
 };
 
 // container window for the NVG UI

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -9,7 +9,10 @@
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 
 
-const int radius = 192;
+const int img_size = 144;
+const int diameter = (img_size * 4) / 3;
+const int radius = diameter / 2;
+
 
 
 // ***** onroad widgets *****
@@ -30,11 +33,12 @@ private:
 
 class ExperimentalButton : public QPushButton {
   Q_OBJECT
-  Q_PROPERTY(bool engageable MEMBER engageable);
 
 public:
   explicit ExperimentalButton(QWidget *parent = 0);
   void updateState(const UIState &s);
+
+  void setBackgroundColor(const QColor &color) { bg = color; }
 
 private:
   void paintEvent(QPaintEvent *event) override;
@@ -42,8 +46,7 @@ private:
   Params params;
   QPixmap engage_img;
   QPixmap experimental_img;
-
-  bool engageable = false;
+  QColor bg;
 };
 
 // container window for the NVG UI

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -37,6 +37,7 @@ class AnnotatedCameraWidget : public CameraWidget {
   Q_PROPERTY(bool is_metric MEMBER is_metric);
 
   Q_PROPERTY(bool engageable MEMBER engageable);
+  Q_PROPERTY(bool experimental_mode_available MEMBER experimental_mode_available);
   Q_PROPERTY(bool dmActive MEMBER dmActive);
   Q_PROPERTY(bool hideDM MEMBER hideDM);
   Q_PROPERTY(bool rightHandDM MEMBER rightHandDM);
@@ -47,6 +48,8 @@ public:
   void updateState(const UIState &s);
 
 private:
+  void mousePressEvent(QMouseEvent* e) override;
+
   void drawIcon(QPainter &p, int x, int y, QPixmap &img, QBrush bg, float opacity);
   void drawText(QPainter &p, int x, int y, const QString &text, int alpha = 255);
 
@@ -62,6 +65,7 @@ private:
   bool is_cruise_set = false;
   bool is_metric = false;
   bool engageable = false;
+  bool experimental_mode_available = false;
   bool dmActive = false;
   bool hideDM = false;
   bool rightHandDM = false;
@@ -70,6 +74,7 @@ private:
   bool v_ego_cluster_seen = false;
   int status = STATUS_DISENGAGED;
   std::unique_ptr<PubMaster> pm;
+  Params params;
 
   int skip_frame_count = 0;
   bool wide_cam_requested = false;

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <QPushButton>
 #include <QStackedLayout>
 #include <QWidget>
 
 #include "common/util.h"
-#include "selfdrive/ui/qt/widgets/cameraview.h"
 #include "selfdrive/ui/ui.h"
+#include "selfdrive/ui/qt/widgets/cameraview.h"
+
+
+const int radius = 192;
 
 
 // ***** onroad widgets *****
@@ -24,6 +28,24 @@ private:
   Alert alert = {};
 };
 
+class ExperimentalButton : public QPushButton {
+  Q_OBJECT
+  Q_PROPERTY(bool engageable MEMBER engageable);
+
+public:
+  explicit ExperimentalButton(QWidget *parent = 0);
+  void updateState(const UIState &s);
+
+private:
+  void paintEvent(QPaintEvent *event) override;
+
+  Params params;
+  QPixmap engage_img;
+  QPixmap experimental_img;
+
+  bool engageable = false;
+};
+
 // container window for the NVG UI
 class AnnotatedCameraWidget : public CameraWidget {
   Q_OBJECT
@@ -36,8 +58,6 @@ class AnnotatedCameraWidget : public CameraWidget {
   Q_PROPERTY(bool has_us_speed_limit MEMBER has_us_speed_limit);
   Q_PROPERTY(bool is_metric MEMBER is_metric);
 
-  Q_PROPERTY(bool engageable MEMBER engageable);
-  Q_PROPERTY(bool experimental_mode_available MEMBER experimental_mode_available);
   Q_PROPERTY(bool dmActive MEMBER dmActive);
   Q_PROPERTY(bool hideDM MEMBER hideDM);
   Q_PROPERTY(bool rightHandDM MEMBER rightHandDM);
@@ -48,24 +68,17 @@ public:
   void updateState(const UIState &s);
 
 private:
-  void mousePressEvent(QMouseEvent* e) override;
-
   void drawIcon(QPainter &p, int x, int y, QPixmap &img, QBrush bg, float opacity);
   void drawText(QPainter &p, int x, int y, const QString &text, int alpha = 255);
 
-  QPixmap engage_img;
-  QPixmap experimental_img;
+  ExperimentalButton *experimental_btn;
   QPixmap dm_img;
-  const int radius = 192;
-  const int img_size = (radius / 2) * 1.5;
   float speed;
   QString speedUnit;
   float setSpeed;
   float speedLimit;
   bool is_cruise_set = false;
   bool is_metric = false;
-  bool engageable = false;
-  bool experimental_mode_available = false;
   bool dmActive = false;
   bool hideDM = false;
   bool rightHandDM = false;
@@ -74,7 +87,6 @@ private:
   bool v_ego_cluster_seen = false;
   int status = STATUS_DISENGAGED;
   std::unique_ptr<PubMaster> pm;
-  Params params;
 
   int skip_frame_count = 0;
   bool wide_cam_requested = false;

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -104,7 +104,7 @@ typedef struct UIScene {
   QPointF lead_vertices[2];
 
   float light_sensor;
-  bool started, ignition, is_metric, map_on_left, longitudinal_control;
+  bool started, ignition, is_metric, map_on_left, longitudinal_control, experimental_mode_available;
   uint64_t started_frame;
 } UIScene;
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -104,7 +104,7 @@ typedef struct UIScene {
   QPointF lead_vertices[2];
 
   float light_sensor;
-  bool started, ignition, is_metric, map_on_left, longitudinal_control, experimental_mode_available;
+  bool started, ignition, is_metric, map_on_left, longitudinal_control;
   uint64_t started_frame;
 } UIScene;
 


### PR DESCRIPTION
After experimental mode has been enabled for the first time (confirmed), it can be toggled by tapping the engage-ability/experimental mode icon in the upper right.

Closes #27002