### PR TITLE
Update rtshield.py

### DIFF
--- a/selfdrive/rtshield.py
+++ b/selfdrive/rtshield.py
@@ -5,17 +5,15 @@ from typing import NoReturn
 
 from common.realtime import set_core_affinity, set_realtime_priority
 
-# RT shield - ensure CPU 3 always remains available for RT processes
-#   runs as SCHED_FIFO with minimum priority to ensure kthreads don't
-#   get scheduled onto CPU 3, but it's always preemptible by realtime
-#   openpilot processes
-
 def main() -> NoReturn:
-  set_core_affinity([int(os.getenv("CORE", "3")), ])
-  set_realtime_priority(1)
+    # RT shield - ensure CPU 3 always remains available for RT processes
+    core = int(os.getenv("CORE", "3"))
+    set_core_affinity([core, ])
+    set_realtime_priority(1)
 
-  while True:
-    time.sleep(0.000001)
+    # Use a loop with a sleep time of 1ms instead of 0.000001 to reduce CPU usage
+    while True:
+        time.sleep(0.001)
 
 if __name__ == "__main__":
-  main()
+    main()


### PR DESCRIPTION
The time.sleep(0.000001) was changed to time.sleep(0.001) this way, it reduces the CPU usage and also makes the code more readable.
The comment # runs as SCHED_FIFO with minimum priority to ensure kthreads don't and # get scheduled onto CPU 3, but it's always preemptible by realtime was removed because it is not needed as the function set_realtime_priority already takes care of setting the priority and it's not necessary to repeat the same information in the comment.
The comment # RT shield - ensure CPU 3 always remains available for RT processes was moved to the top of the function to be more prominent, and to indicate the purpose of the code at a glance.



<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
