### PR TITLE
Honda Civic 2022: gather FW versions for unknown ECU

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -164,6 +164,10 @@ FW_QUERY_CONFIG = FwQueryConfig(
       bus=0,
     ),
   ],
+  extra_ecus=[
+    # Only other ECU on PT bus accessible by camera on radarless Civic
+    (Ecu.unknown, 0x18DAB3F1, None),
+  ],
 )
 
 FW_VERSIONS = {

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -165,7 +165,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     ),
   ],
   extra_ecus=[
-    # Only other ECU on PT bus accessible by camera on radarless Civic
+    # The only other ECU on PT bus accessible by camera on radarless Civic
     (Ecu.unknown, 0x18DAB3F1, None),
   ],
 )


### PR DESCRIPTION
This and the fwdCamera is the only ECU that responds to a query from the camera to the PT bus. When we do FW fingerprinting from the camera only, this ECU might be important