### PR TITLE
Honda FPv2: log extra UDS identifier

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -160,11 +160,15 @@ HONDA_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
+    # Currently used to fingerprint
     Request(
       [StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.UDS_VERSION_RESPONSE],
       bus=1,
     ),
+
+    # Data collection requests:
+    # Log extra identifiers for current ECUs
     Request(
       [HONDA_VERSION_REQUEST],
       [HONDA_VERSION_RESPONSE],

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -151,12 +151,10 @@ CAR_INFO: Dict[str, Optional[Union[HondaCarInfo, List[HondaCarInfo]]]] = {
   CAR.HONDA_E: HondaCarInfo("Honda e 2020", "All", min_steer_speed=3. * CV.MPH_TO_MS),
 }
 
-
 HONDA_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
   p16(0xF112)
 HONDA_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
   p16(0xF112)
-
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -152,9 +152,10 @@ CAR_INFO: Dict[str, Optional[Union[HondaCarInfo, List[HondaCarInfo]]]] = {
 }
 
 HONDA_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
+  p16(0xF181) + \
   p16(0xF112)
 HONDA_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
-  p16(0xF112)
+  p16(0xF181)
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -4,9 +4,10 @@ from typing import Dict, List, Optional, Union
 
 from cereal import car
 from common.conversions import Conversions as CV
+from panda.python import uds
 from selfdrive.car import dbc_dict
 from selfdrive.car.docs_definitions import CarFootnote, CarInfo, Column, Harness
-from selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
+from selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16
 
 Ecu = car.CarParams.Ecu
 VisualAlert = car.CarControl.HUDControl.VisualAlert
@@ -150,11 +151,23 @@ CAR_INFO: Dict[str, Optional[Union[HondaCarInfo, List[HondaCarInfo]]]] = {
   CAR.HONDA_E: HondaCarInfo("Honda e 2020", "All", min_steer_speed=3. * CV.MPH_TO_MS),
 }
 
+
+HONDA_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
+  p16(0xF112)
+HONDA_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
+  p16(0xF112)
+
+
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
     Request(
       [StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.UDS_VERSION_RESPONSE],
+      bus=1,
+    ),
+    Request(
+      [HONDA_VERSION_REQUEST],
+      [HONDA_VERSION_RESPONSE],
       bus=1,
     ),
     # Query Nidec PT bus from camera for data collection

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -152,10 +152,9 @@ CAR_INFO: Dict[str, Optional[Union[HondaCarInfo, List[HondaCarInfo]]]] = {
 }
 
 HONDA_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
-  p16(0xF181) + \
   p16(0xF112)
 HONDA_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
-  p16(0xF181)
+  p16(0xF112)
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[


### PR DESCRIPTION
This seems to be the most common identifier, available on all ECUs (seen by the camera) for:

- Honda Civic 2016
- Honda Accord 2019, 2020
- Honda Civic Radarless (except for an unknown ECU)

Short writeup:

Identifier 0xF112 seems to be available for every ECU, and it has extra data that the current 0xF181 does not have. A 2019 and 2020 Accord have identical 0xF181 versions, but 0xF112 is different.

Going to add a new query for it to see if this will help us distinguish cars, since the Accord and Accord Hybrid share radar and camera FW versions. We would have no way to distinguish them right now if we didn't have OBD.

Something interesting I noticed was that the model year _could_ be encoded in the 0xF112 version for _some cars_.

- 2020 Accord all ECUs 0xF112: `b'\x0e745020022608C7\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'` (5th, 6th idx bytes are 20)
- 2019 Accord all ECUs 0xF112: `b'\x0e11201901121307\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'` (5th, 6th idx bytes are 19)

But this encoding was not obvious on Nidec Civic or radarless Civic. More data will help.