### PR TITLE
cabana: saving & restoring columns widths

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -29,11 +29,13 @@ MainWindow::MainWindow() : QMainWindow() {
   createStatusBar();
   createShortcuts();
 
+  // restore states
   restoreGeometry(settings.geometry);
   if (isMaximized()) {
     setGeometry(QApplication::desktop()->availableGeometry(this));
   }
   restoreState(settings.window_state);
+  messages_widget->restoreHeaderState(settings.message_header_state);
 
   qRegisterMetaType<uint64_t>("uint64_t");
   qRegisterMetaType<ReplyMsgType>("ReplyMsgType");
@@ -287,11 +289,13 @@ void MainWindow::closeEvent(QCloseEvent *event) {
   if (floating_window)
     floating_window->deleteLater();
 
+  // save states
   settings.geometry = saveGeometry();
   settings.window_state = saveState();
   if (!can->liveStreaming()) {
     settings.video_splitter_state = video_splitter->saveState();
   }
+  settings.message_header_state = messages_widget->saveHeaderState();
   settings.save();
   QWidget::closeEvent(event);
 }

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -1,7 +1,6 @@
 #include "tools/cabana/messageswidget.h"
 
 #include <QFontDatabase>
-#include <QHeaderView>
 #include <QLineEdit>
 #include <QVBoxLayout>
 #include <QPainter>

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QAbstractTableModel>
+#include <QHeaderView>
 #include <QTableView>
 #include <QStyledItemDelegate>
 
@@ -33,6 +34,8 @@ class MessagesWidget : public QWidget {
 public:
   MessagesWidget(QWidget *parent);
   void selectMessage(const QString &message_id);
+  QByteArray saveHeaderState() const { return table_widget->horizontalHeader()->saveState(); }
+  bool restoreHeaderState(const QByteArray &state) const { return table_widget->horizontalHeader()->restoreState(state); }
 
 signals:
   void msgSelectionChanged(const QString &message_id);

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -23,6 +23,7 @@ void Settings::save() {
   s.setValue("window_state", window_state);
   s.setValue("geometry", geometry);
   s.setValue("video_splitter_state", video_splitter_state);
+  s.setValue("message_header_state", message_header_state);
 }
 
 void Settings::load() {
@@ -36,6 +37,7 @@ void Settings::load() {
   window_state = s.value("window_state").toByteArray();
   geometry = s.value("geometry").toByteArray();
   video_splitter_state = s.value("video_splitter_state").toByteArray();
+  message_header_state = s.value("message_header_state").toByteArray();
 }
 
 // SettingsDlg

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -22,6 +22,7 @@ public:
   QByteArray geometry;
   QByteArray video_splitter_state;
   QByteArray window_state;
+  QByteArray message_header_state;
 
 signals:
   void changed();


### PR DESCRIPTION
save/restore messagelist's columns widths.
![Screenshot from 2023-01-25 15-54-30](https://user-images.githubusercontent.com/27770/214509198-826621b2-1776-4b6f-b18d-badf5814fa48.png)
