### PR TITLE
Ram 1500: more generic EPS steer to zero check

### DIFF
--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -58,9 +58,9 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 2493. + STD_CARGO_KG
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
       ret.minSteerSpeed = 14.5
-      for fw in car_fw:
-        if fw.ecu == 'eps' and fw.fwVersion.startswith((b"68312176", b"68273275")):
-          ret.minSteerSpeed = 0.
+      # Older EPS FW allow steer to zero
+      if any(fw.ecu == 'eps' and fw.fwVersion[:4] <= b"6831" for fw in car_fw):
+        ret.minSteerSpeed = 0.
 
     elif candidate == CAR.RAM_HD:
       ret.steerActuatorDelay = 0.2


### PR DESCRIPTION
@realfast what do you think about this? I'd like to make the check more generic to catch new cars without a specific revision of the FW. It looks like that there's a clear pattern with the FW versions. Older major revisions allow a lower min steering speed. Same with the Chrysler check above. We might be able to unify them in the future when we see more Ram FW.