### PR TITLE
Ford: disable radar parser

### DIFF
--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -51,7 +51,7 @@ class RADAR:
   DELPHI_MRR = 'FORD_CADS'
 
 
-DBC: Dict[str, Dict[str, str]] = defaultdict(lambda: dbc_dict("ford_lincoln_base_pt", RADAR.DELPHI_MRR))
+DBC: Dict[str, Dict[str, str]] = defaultdict(lambda: dbc_dict("ford_lincoln_base_pt", None))
 
 
 @dataclass


### PR DESCRIPTION
The radar parser caused many false positive FCWs.
