### PR TITLE
replay: fix hang if started with a special segment and there is no INIT_DATA in events

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -28,7 +28,7 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
 
   if (!allow_list.empty()) {
     // the following events are needed for replay to work properly.
-    allow_list.insert(cereal::Event::Which::PANDA_STATE_D_E_P_R_E_C_A_T_E_D);
+    allow_list.insert(cereal::Event::Which::INIT_DATA);
     allow_list.insert(cereal::Event::Which::CAR_PARAMS);
   }
 

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -25,6 +25,13 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
       s.push_back(it.name);
     }
   }
+
+  if (!allow_list.empty()) {
+    // the following events are needed for replay to work properly.
+    allow_list.insert(cereal::Event::Which::PANDA_STATE_D_E_P_R_E_C_A_T_E_D);
+    allow_list.insert(cereal::Event::Which::CAR_PARAMS);
+  }
+
   qDebug() << "services " << s;
   qDebug() << "loading route " << route;
 


### PR DESCRIPTION
fix issue: https://github.com/commaai/openpilot/discussions/26091#discussioncomment-4791434

replay need read INIT_DATA to get the route's start ts (nano_since_boot).