### PR TITLE
Ford: use curvature without roll compensation

### DIFF
--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -1,4 +1,3 @@
-import math
 from cereal import car
 from common.numpy_fast import clip
 from opendbc.can.packer import CANPacker

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -46,10 +46,8 @@ class CarController:
     # send steering commands at 20Hz
     if (self.frame % CarControllerParams.STEER_STEP) == 0:
       if CC.latActive:
-        # apply limits to curvature
-        apply_curvature = -self.VM.calc_curvature(math.radians(actuators.steeringAngleDeg), CS.out.vEgo, 0.0)
-        apply_curvature = apply_std_steer_angle_limits(apply_curvature, self.apply_curvature_last, CS.out.vEgo, CarControllerParams)
-        # clip to signal range
+        # apply limits to curvature and clip to signal range
+        apply_curvature = apply_std_steer_angle_limits(actuators.curvature, self.apply_curvature_last, CS.out.vEgo, CarControllerParams)
         apply_curvature = clip(apply_curvature, -CarControllerParams.CURVATURE_MAX, CarControllerParams.CURVATURE_MAX)
       else:
         apply_curvature = 0.


### PR DESCRIPTION
Ford's EPS expects the curvature signal (`LatCtlCurv_No_Actl`) to be road curvature, not path curvature, which means that any roll or wheel compensations we do to the steering angle do not make sense if we convert back to curvature in the car controller. This uses the lag-compensated curvature straight from the plan.

Reduces undershooting on banked roads, and some oscillation going straight. Below is toggling on and off roll compensation on a heavily banked road.

![Screenshot from 2023-01-26 18-38-53 (1)](https://user-images.githubusercontent.com/25857203/215011704-58c89c5d-5dc2-45ba-8b36-f84904374e88.png)