### PR TITLE
feat: Optimize the order_nodes method

### DIFF
--- a/third_party/cluster/fastcluster_R_dm.cpp
+++ b/third_party/cluster/fastcluster_R_dm.cpp
@@ -22,45 +22,35 @@ void order_nodes(const int N, const int * const merge, const t_index * const nod
 
      Runtime: Θ(N)
   */
-  auto_array_ptr<pos_node> queue(N/2);
+  std::stack<std::pair<int, int>> queue;
+  queue.push({N-2, 0});
 
   int parent;
   int child;
-  t_index pos = 0;
+  t_index pos;
 
-  queue[0].pos = 0;
-  queue[0].node = N-2;
-  t_index idx = 1;
+  while (!queue.empty()) {
+      std::tie(parent, pos) = queue.top();
+      queue.pop();
 
-  do {
-    --idx;
-    pos = queue[idx].pos;
-    parent = queue[idx].node;
+      // First child
+      child = merge[parent];
+      if (child < 0) {
+          order[pos] = -child;
+          ++pos;
+      } else {
+          queue.push({child-1, pos});
+          pos += node_size[child-1];
+      }
 
-    // First child
-    child = merge[parent];
-    if (child<0) { // singleton node, write this into the 'order' array.
-      order[pos] = -child;
-      ++pos;
+      // Second child
+      child = merge[parent+N-1];
+      if (child < 0) {
+          order[pos] = -child;
+      } else {
+          queue.push({child-1, pos});
+      }
     }
-    else { /* compound node: put it on top of the queue and decompose it
-              in a later iteration. */
-      queue[idx].pos = pos;
-      queue[idx].node = child-1; // convert index-1 based to index-0 based
-      ++idx;
-      pos += node_size[child-1];
-    }
-    // Second child
-    child = merge[parent+N-1];
-    if (child<0) {
-      order[pos] = -child;
-    }
-    else {
-      queue[idx].pos = pos;
-      queue[idx].node = child-1;
-      ++idx;
-    }
-  } while (idx>0);
 }
 
 #define size_(r_) ( ((r_<N) ? 1 : node_size[r_-N]) )


### PR DESCRIPTION
## WHAT and HOW

- Replacing the auto_array_ptr with a stack of pairs of integers. This eliminates the need for dynamic memory allocation and indexing into the stack.

- I have also used C++11's std::tie function to unpack the pair and assign it to the variables parent and pos. This eliminates the need for a separate struct for holding the pair.

- I also use std::stack::empty() instead of idx > 0 to check if the stack is empty.

Bonus: I also changed the naming of the variables from camelCase to snake_case, which is more common in C++.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
