### PR TITLE
cabana: set time column to fixed width

### DIFF
--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -170,11 +170,16 @@ std::deque<HistoryLogModel::Message> HistoryLogModel::fetchData(uint64_t from_ti
 // HeaderView
 
 QSize HeaderView::sectionSizeFromContents(int logicalIndex) const {
-  int default_size = qMax(100, rect().width() / model()->columnCount());
-  const QString text = model()->headerData(logicalIndex, this->orientation(), Qt::DisplayRole).toString();
-  const QRect rect = fontMetrics().boundingRect({0, 0, default_size, 2000}, defaultAlignment(), text);
-  QSize size = rect.size() + QSize{10, 6};
-  return {qMax(size.width(), default_size), size.height()};
+  static QSize time_col_size = fontMetrics().boundingRect({0, 0, 200, 200}, defaultAlignment(), "000000.000").size() + QSize(10, 6);
+  if (logicalIndex == 0) {
+    return time_col_size;
+  } else {
+    int default_size = qMax(100, (rect().width() - time_col_size.width()) / (model()->columnCount() - 1));
+    const QString text = model()->headerData(logicalIndex, this->orientation(), Qt::DisplayRole).toString();
+    const QRect rect = fontMetrics().boundingRect({0, 0, default_size, 2000}, defaultAlignment(), text);
+    QSize size = rect.size() + QSize{10, 6};
+    return QSize{qMax(size.width(), default_size), size.height()};
+  }
 }
 
 void HeaderView::paintSection(QPainter *painter, const QRect &rect, int logicalIndex) const {


### PR DESCRIPTION
Issue: the time column uses the same stretch mechanism as others, which will cause space waste, especially in hex mode: it use  the same width as data column. which makes data difficult to view, especially for 64bytes data:

![Screenshot from 2023-01-28 00-18-13](https://user-images.githubusercontent.com/27770/215141941-ed47103c-9f64-4b18-b3f9-8ceb9b1b85a2.png)
![Screenshot from 2023-01-28 00-17-33](https://user-images.githubusercontent.com/27770/215141966-9a41b8d2-6963-4948-9493-5a886a9dc78c.png)

Fix: set it to fixed width in `sectionSizeFromContents`:

![Screenshot from 2023-01-28 00-16-57](https://user-images.githubusercontent.com/27770/215141969-bf4f001b-ba2c-4e0e-bc00-27ed9e4ce4c0.png)
![Screenshot from 2023-01-28 00-16-01](https://user-images.githubusercontent.com/27770/215141976-48abdbea-5899-44a3-b760-cc0042bb0c49.png)
