### PR TITLE
Ford: set radarOffCan

### DIFF
--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -18,6 +18,7 @@ class CarInterface(CarInterfaceBase):
     # These cars are dashcam only until the port is finished
     ret.dashcamOnly = True
 
+    ret.radarOffCan = True
     ret.steerControlType = car.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0


### PR DESCRIPTION
Fixes a crash in process replay which checks this field instead of checking if the DBC is not present