### PR TITLE
cabana: DoubleValidator fix locale

### DIFF
--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -12,6 +12,8 @@
 
 SignalForm::SignalForm(QWidget *parent) : QWidget(parent) {
   auto double_validator = new QDoubleValidator(this);
+  double_validator->setLocale(QLocale::C); // Match locale of QString::toDouble() instead of system
+
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   QFormLayout *form_layout = new QFormLayout();
   main_layout->addLayout(form_layout);


### PR DESCRIPTION
If system locale uses "," for decimal separator it's accepted by the validator but rejected by QString::toDouble. If you use "." it get's rejected by the validator.