### PR TITLE
cabana: replace space by underscore when editing signal name

### DIFF
--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -288,7 +288,7 @@ EditMessageDialog::EditMessageDialog(const QString &msg_id, const QString &title
   form_layout->addRow("ID", new QLabel(msg_id));
 
   name_edit = new QLineEdit(title, this);
-  name_edit->setValidator(new QRegExpValidator(QRegExp("^(\\w+)"), name_edit));
+  name_edit->setValidator(new NameValidator(name_edit));
   form_layout->addRow(tr("Name"), name_edit);
 
   size_spin = new QSpinBox(this);

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -17,7 +17,7 @@ SignalForm::SignalForm(QWidget *parent) : QWidget(parent) {
   main_layout->addLayout(form_layout);
 
   name = new QLineEdit();
-  name->setValidator(new QRegExpValidator(QRegExp("^(\\w+)"), name));
+  name->setValidator(new NameValidator(name));
   form_layout->addRow(tr("Name"), name);
 
   QHBoxLayout *hl = new QHBoxLayout(this);

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -97,3 +97,10 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     i++;
   }
 }
+
+NameValidator::NameValidator(QObject *parent) : QRegExpValidator(QRegExp("^(\\w+)"), parent) { }
+
+QValidator::State NameValidator::validate(QString &input, int &pos) const {
+  input.replace(' ', '_');
+  return QRegExpValidator::validate(input, pos);
+}

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -3,6 +3,7 @@
 #include <QByteArray>
 #include <QColor>
 #include <QFont>
+#include <QRegExpValidator>
 #include <QStyledItemDelegate>
 #include <QVector>
 
@@ -36,3 +37,11 @@ inline const QString &getColor(int i) {
   static const QString SIGNAL_COLORS[] = {"#9FE2BF", "#40E0D0", "#6495ED", "#CCCCFF", "#FF7F50", "#FFBF00"};
   return SIGNAL_COLORS[i % std::size(SIGNAL_COLORS)];
 }
+
+class NameValidator : public QRegExpValidator {
+  Q_OBJECT
+
+public:
+  NameValidator(QObject *parent=nullptr);
+  QValidator::State validate(QString &input, int &pos) const override;
+};


### PR DESCRIPTION
Abstract regexvalidator into a common class. Little user friendly function to automatically replaces spaces by underscores