### PR TITLE
cabana: add --dbc command line argument

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -24,6 +24,7 @@ int main(int argc, char *argv[]) {
   cmd_parser.addOption({"zmq", "the ip address on which to receive zmq messages", "zmq"});
   cmd_parser.addOption({"data_dir", "local directory with routes", "data_dir"});
   cmd_parser.addOption({"no-vipc", "do not output video"});
+  cmd_parser.addOption({"dbc", "dbc file to open", "dbc"});
   cmd_parser.process(app);
   const QStringList args = cmd_parser.positionalArguments();
   if (args.empty() && !cmd_parser.isSet("demo") && !cmd_parser.isSet("stream")) {
@@ -57,6 +58,12 @@ int main(int argc, char *argv[]) {
   }
 
   MainWindow w;
+
+  // Load DBC
+  if (cmd_parser.isSet("dbc")) {
+    w.loadFile(cmd_parser.value("dbc"));
+  }
+
   w.show();
   return app.exec();
 }

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -243,6 +243,11 @@ void MainWindow::loadDBCFromClipboard() {
 }
 
 void MainWindow::loadDBCFromFingerprint() {
+  // Don't overwrite already loaded DBC
+  if (!dbc()->name().isEmpty()) {
+    return;
+  }
+
   remindSaveChanges();
   auto fingerprint = can->carFingerprint();
   video_dock->setWindowTitle(tr("ROUTE: %1  FINGERPINT: %2").arg(can->routeName()).arg(fingerprint.isEmpty() ? tr("Unknown Car") : fingerprint));

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -20,6 +20,7 @@ public:
   MainWindow();
   void dockCharts(bool dock);
   void showStatusMessage(const QString &msg, int timeout = 0) { statusBar()->showMessage(msg, timeout); }
+  void loadFile(const QString &fn);
 
 public slots:
   void newFile();
@@ -40,7 +41,6 @@ signals:
 protected:
   void remindSaveChanges();
   void saveFile(const QString &fn);
-  void loadFile(const QString &fn);
   void setCurrentFile(const QString &fn);
   void updateRecentFileActions();
   void createActions();


### PR DESCRIPTION
Useful during development to quickly start cabana in a ready to go state.