### PR TITLE
GM: disallow engage shortly after pressing brake

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -20,7 +20,7 @@ class CarState(CarStateBase):
     self.loopback_lka_steering_cmd_updated = False
     self.camera_lka_steering_cmd_counter = 0
     self.buttons_counter = 0
-    self.prev_brake_pressed = 0
+    self.prev_brake_pressed = False
 
   def update(self, pt_cp, cam_cp, loopback_cp):
     ret = car.CarState.new_message()


### PR DESCRIPTION
Just got sent a segment where the ECM will fault if you try to engage on the frame brakePressed falls: https://connect.comma.ai/fe80a4e1cedec853/1674777037139/1674777042711

- [ ] Reproduce how long exactly it takes to not fault with our current signal
- [ ] Decide if we should make this generic?
- [ ] Panda