### PR TITLE
cabana: fix overlap in byte highlighting

### DIFF
--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -85,7 +85,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   pos.moveLeft(pos.x() + space.width());
 
   int m = space.width() / 2;
-  const QMargins margins(m + 1, m, m, m);
+  const QMargins margins(m, m, m, m);
 
   int i = 0;
   for (auto &byte : opt.text.split(" ")) {


### PR DESCRIPTION
Before:
![Screenshot 2023-01-29 at 09 56 10](https://user-images.githubusercontent.com/1314752/215315932-2078b689-87ef-4a45-9e48-87b872085f79.png)

After:
![Screenshot 2023-01-29 at 09 56 38](https://user-images.githubusercontent.com/1314752/215315937-d2ea353c-0568-413d-9b3a-db6ca21b308a.png)
