### PR TITLE
cabana: small improvements to charts

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -165,9 +165,9 @@ void ChartsWidget::setMaxChartRange(int value) {
 }
 
 void ChartsWidget::updateToolBar() {
-  if (docking) setColumnCount(0);
-  columns_lb_action->setVisible(!docking);
-  columns_cb_action->setVisible(!docking);
+  bool show_column_cb = rect().width() > CHART_MIN_WIDTH * 2;
+  columns_lb_action->setVisible(show_column_cb);
+  columns_cb_action->setVisible(show_column_cb);
 
   range_lb->setText(QString(" %1:%2 ").arg(max_chart_range / 60, 2, 10, QLatin1Char('0')).arg(max_chart_range % 60, 2, 10, QLatin1Char('0')));
   title_label->setText(tr("Charts: %1").arg(charts.size()));
@@ -223,12 +223,6 @@ void ChartsWidget::showChart(const QString &id, const Signal *sig, bool show, bo
 
 void ChartsWidget::setColumnCount(int n) {
   n = std::clamp(n + 1, 1, columns_cb->count());
-
-  // Update combobox if not called from combobox signal
-  if (columns_cb->currentIndex() != n - 1) {
-    columns_cb->setCurrentIndex(n - 1);
-  }
-
   if (column_count != n) {
     column_count = settings.chart_column_count = n;
     updateLayout();
@@ -238,7 +232,7 @@ void ChartsWidget::setColumnCount(int n) {
 void ChartsWidget::updateLayout() {
   int n = column_count;
   for (; n > 1; --n) {
-    if ((n * (CHART_MIN_WIDTH + charts_layout->spacing())) < rect().width()) break;
+    if ((n * CHART_MIN_WIDTH) < rect().width()) break;
   }
   for (int i = 0; i < charts.size(); ++i) {
     charts_layout->addWidget(charts[charts.size() - i - 1], i / n, i % n);
@@ -248,6 +242,7 @@ void ChartsWidget::updateLayout() {
 void ChartsWidget::resizeEvent(QResizeEvent *event) {
   QWidget::resizeEvent(event);
   updateLayout();
+  updateToolBar();
 }
 
 void ChartsWidget::newChart() {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -246,7 +246,6 @@ void ChartsWidget::updateLayout() {
 void ChartsWidget::resizeEvent(QResizeEvent *event) {
   QWidget::resizeEvent(event);
   updateLayout();
-  updateToolBar();
 }
 
 void ChartsWidget::newChart() {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -54,10 +54,13 @@ ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
   main_layout->addWidget(toolbar);
 
   // charts
+  charts_layout = new QGridLayout();
+  charts_layout->setSpacing(10);
+
   QWidget *charts_container = new QWidget(this);
   QVBoxLayout *charts_main_layout = new QVBoxLayout(charts_container);
   charts_main_layout->setContentsMargins(0, 0, 0, 0);
-  charts_main_layout->addLayout(charts_layout = new QGridLayout);
+  charts_main_layout->addLayout(charts_layout);
   charts_main_layout->addStretch(0);
 
   QScrollArea *charts_scroll = new QScrollArea(this);
@@ -165,7 +168,7 @@ void ChartsWidget::setMaxChartRange(int value) {
 }
 
 void ChartsWidget::updateToolBar() {
-  bool show_column_cb = rect().width() > CHART_MIN_WIDTH * 2;
+  bool show_column_cb = rect().width() > (CHART_MIN_WIDTH + charts_layout->spacing()) * 2;
   columns_lb_action->setVisible(show_column_cb);
   columns_cb_action->setVisible(show_column_cb);
 
@@ -232,7 +235,7 @@ void ChartsWidget::setColumnCount(int n) {
 void ChartsWidget::updateLayout() {
   int n = column_count;
   for (; n > 1; --n) {
-    if ((n * CHART_MIN_WIDTH) < rect().width()) break;
+    if ((n * (CHART_MIN_WIDTH + charts_layout->spacing())) < rect().width()) break;
   }
   for (int i = 0; i < charts.size(); ++i) {
     charts_layout->addWidget(charts[charts.size() - i - 1], i / n, i % n);

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -168,10 +168,6 @@ void ChartsWidget::setMaxChartRange(int value) {
 }
 
 void ChartsWidget::updateToolBar() {
-  bool show_column_cb = rect().width() > (CHART_MIN_WIDTH + charts_layout->spacing()) * 2;
-  columns_lb_action->setVisible(show_column_cb);
-  columns_cb_action->setVisible(show_column_cb);
-
   range_lb->setText(QString(" %1:%2 ").arg(max_chart_range / 60, 2, 10, QLatin1Char('0')).arg(max_chart_range % 60, 2, 10, QLatin1Char('0')));
   title_label->setText(tr("Charts: %1").arg(charts.size()));
   dock_btn->setIcon(bootstrapPixmap(docking ? "arrow-up-right" : "arrow-down-left"));
@@ -235,8 +231,13 @@ void ChartsWidget::setColumnCount(int n) {
 void ChartsWidget::updateLayout() {
   int n = column_count;
   for (; n > 1; --n) {
-    if ((n * (CHART_MIN_WIDTH + charts_layout->spacing())) < rect().width()) break;
+    if ((n * CHART_MIN_WIDTH + (n - 1) * charts_layout->spacing()) < charts_layout->geometry().width()) break;
   }
+
+  bool show_column_cb = n > 1;
+  columns_lb_action->setVisible(show_column_cb);
+  columns_cb_action->setVisible(show_column_cb);
+
   for (int i = 0; i < charts.size(); ++i) {
     charts_layout->addWidget(charts[charts.size() - i - 1], i / n, i % n);
   }

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -116,7 +116,6 @@ private:
   ChartView *findChart(const QString &id, const Signal *sig);
 
   QLabel *title_label;
-  QLabel *zoom_range_lb;
   QLabel *range_lb;
   QSlider *range_slider;
   bool docking = true;
@@ -131,6 +130,8 @@ private:
   std::pair<double, double> display_range;
   std::pair<double, double> zoomed_range;
   bool use_dark_theme = false;
+  QAction *columns_lb_action;
+  QAction *columns_cb_action;
   QComboBox *columns_cb;
   int column_count = 1;
   const int CHART_MIN_WIDTH = 300;


### PR DESCRIPTION
Small changes. Mostly improves the layout when working on laptops where horizontal space is at a premium.

- Replace zoom out icon by magnifying glass - instead of counterclockwise arrow. Noticed the previous icon wasn't intuitive for new users.
- Remove label for current zoom window. This should be obvious from the video slider or the charts x axis. This label takes up quite a bit of space that pushes the zoom out button into the qtoolbar extension which makes it hard to find.
- Only show column count when there is space for more than one column. This also helps with not pushing the zoom out button into an extension.
- Fix computation of number of columns to properly account for layout size and spacing, preventing part of the plot to fall off.

![Screenshot 2023-01-29 at 10 40 33](https://user-images.githubusercontent.com/1314752/215318226-b5ec2d16-ae5f-4974-ab05-be29bb92e39d.png)
![Screenshot 2023-01-29 at 10 40 50](https://user-images.githubusercontent.com/1314752/215318224-b2d1f644-e500-4e93-bad0-b741c692d464.png)
