### PR TITLE
cabana: do not round time when seeking from chartswidget

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -588,14 +588,21 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton && rubber && rubber->isVisible()) {
     rubber->hide();
     QRectF rect = rubber->geometry().normalized();
-    double min = std::floor(chart()->mapToValue(rect.topLeft()).x() * 10.0) / 10.0;
-    double max = std::floor(chart()->mapToValue(rect.bottomRight()).x() * 10.0) / 10.0;
+    double min = chart()->mapToValue(rect.topLeft()).x();
+    double max = chart()->mapToValue(rect.bottomRight()).x();
+
+    // Prevent zooming/seeking past the end of the route
+    min = std::clamp(min, can->routeStartTime(), can->routeStartTime() + can->totalSeconds());
+    max = std::clamp(max, can->routeStartTime(), can->routeStartTime() + can->totalSeconds());
+
+    double min_rounded = std::floor(min * 10.0) / 10.0;
+    double max_rounded = std::floor(max * 10.0) / 10.0;
     if (rubber->width() <= 0) {
       // no rubber dragged, seek to mouse position
-      can->seekTo(chart()->mapToValue(rect.topLeft()).x());
-    } else if ((max - min) >= 0.5) {
+      can->seekTo(min);
+    } else if ((max_rounded - min_rounded) >= 0.5) {
       // zoom in if selected range is greater than 0.5s
-      emit zoomIn(min, max);
+      emit zoomIn(min_rounded, max_rounded);
     }
     event->accept();
   } else if (!can->liveStreaming() && event->button() == Qt::RightButton) {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -592,7 +592,7 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
     double max = std::floor(chart()->mapToValue(rect.bottomRight()).x() * 10.0) / 10.0;
     if (rubber->width() <= 0) {
       // no rubber dragged, seek to mouse position
-      can->seekTo(min);
+      can->seekTo(chart()->mapToValue(rect.topLeft()).x());
     } else if ((max - min) >= 0.5) {
       // zoom in if selected range is greater than 0.5s
       emit zoomIn(min, max);


### PR DESCRIPTION
Rounding the time makes it seek to a different place then was clicked. Obvious when seeking when very zoomed in.

Also prevent zooming past the end of the route, as that causes a segfault when the start and end of the rubberband are both past the end.