### PR TITLE
cabana: fix occasional ellipsis on y axis ticks

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -521,8 +521,8 @@ void ChartView::updateAxisY() {
 
   if (min_y == std::numeric_limits<double>::max()) min_y = 0;
   if (max_y == std::numeric_limits<double>::lowest()) max_y = 0;
-  if (max_y == min_y) {
-    axis_y->setRange(min_y - 1, max_y + 1);
+  if (std::abs(max_y - min_y) < 1e-3) {
+    applyNiceNumbers(min_y - 1, max_y + 1);
   } else {
     double range = max_y - min_y;
     applyNiceNumbers(min_y - range * 0.05, max_y + range * 0.05);
@@ -539,6 +539,7 @@ void ChartView::applyNiceNumbers(qreal min, qreal max) {
   tick_count = int(max - min) + 1;
   axis_y->setRange(min * step, max * step);
   axis_y->setTickCount(tick_count);
+  axis_y->setLabelFormat("%.1f");
 }
 
 // nice numbers can be expressed as form of 1*10^n, 2* 10^n or 5*10^n


### PR DESCRIPTION
Sometimes there would be ellipsis shown on the y axis ticks. Forcing the label format to 1 digit, and also using `applyNiceNumbers` for constant signals fixes this.


Before:
![Screenshot 2023-01-29 at 12 54 20](https://user-images.githubusercontent.com/1314752/215325210-67a14881-fab6-4fc2-adab-8b57a676bc2f.png)

After:
![Screenshot 2023-01-29 at 13 08 08](https://user-images.githubusercontent.com/1314752/215325208-bf4998af-ea47-4659-85a9-6a77fe5d4b73.png)
