### PR TITLE
MacOS: build fixes

### DIFF
--- a/common/SConscript
+++ b/common/SConscript
@@ -10,10 +10,12 @@ common_libs = [
   'statlog.cc',
   'swaglog.cc',
   'util.cc',
-  'gpio.cc',
   'i2c.cc',
   'watchdog.cc',
 ]
+
+if arch != "Darwin":
+  common_libs.append('gpio.cc')
 
 _common = fxn('common', common_libs, LIBS="json11")
 

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <bitset>
 #include <cassert>

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -14,7 +14,9 @@ Panda::Panda(std::string serial, uint32_t bus_offset) : bus_offset(bus_offset) {
   try {
     handle = std::make_unique<PandaUsbHandle>(serial);
   } catch (std::exception &e) {
+#ifndef __APPLE__
     handle = std::make_unique<PandaSpiHandle>(serial);
+#endif
   }
 
   hw_type = get_hw_type();
@@ -46,11 +48,13 @@ std::string Panda::hw_serial() {
 std::vector<std::string> Panda::list() {
   std::vector<std::string> serials = PandaUsbHandle::list();
 
+#ifndef __APPLE__
   for (auto s : PandaSpiHandle::list()) {
     if (std::find(serials.begin(), serials.end(), s) == serials.end()) {
       serials.push_back(s);
     }
   }
+#endif
 
   return serials;
 }

--- a/selfdrive/boardd/panda_comms.h
+++ b/selfdrive/boardd/panda_comms.h
@@ -5,7 +5,9 @@
 #include <cstdint>
 #include <vector>
 
+#ifndef __APPLE__
 #include <linux/spi/spidev.h>
+#endif
 
 #include <libusb-1.0/libusb.h>
 
@@ -52,6 +54,7 @@ private:
   void handle_usb_issue(int err, const char func[]);
 };
 
+#ifndef __APPLE__
 class PandaSpiHandle : public PandaCommsHandle {
 public:
   PandaSpiHandle(std::string serial);
@@ -75,3 +78,4 @@ private:
   int spi_transfer(uint8_t endpoint, uint8_t *tx_data, uint16_t tx_len, uint8_t *rx_data, uint16_t max_rx_len);
   int spi_transfer_retry(uint8_t endpoint, uint8_t *tx_data, uint16_t tx_len, uint8_t *rx_data, uint16_t max_rx_len);
 };
+#endif

--- a/selfdrive/boardd/spi.cc
+++ b/selfdrive/boardd/spi.cc
@@ -1,3 +1,4 @@
+#ifndef __APPLE__
 #include <sys/file.h>
 #include <sys/ioctl.h>
 #include <linux/spi/spidev.h>
@@ -339,3 +340,4 @@ int PandaSpiHandle::spi_transfer(uint8_t endpoint, uint8_t *tx_data, uint16_t tx
 transfer_fail:
   return ret;
 }
+#endif

--- a/selfdrive/loggerd/SConscript
+++ b/selfdrive/loggerd/SConscript
@@ -13,6 +13,8 @@ if arch == "Darwin":
   # fix OpenCL
   del libs[libs.index('OpenCL')]
   env['FRAMEWORKS'] = ['OpenCL']
+  # exclude v4l
+  del src[src.index('encoder/v4l_encoder.cc')]
 
 logger_lib = env.Library('logger', src)
 libs.insert(0, logger_lib)

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -24,6 +24,9 @@ cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/livestream
                                                'commands.cc', 'messageswidget.cc', 'settings.cc', 'util.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('_cabana', ['cabana.cc', cabana_lib, asset_obj], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 
+if arch == "Darwin":
+  cabana_env.Execute('install_name_tool -change opendbc/can/libdbc.dylib @loader_path/../../opendbc/can/libdbc.dylib ./_cabana')
+
 if GetOption('test'):
   cabana_env.Program('tests/_test_cabana', ['tests/test_runner.cc', 'tests/test_cabana.cc', cabana_lib], LIBS=[cabana_libs])
 


### PR DESCRIPTION
Some suggested build fixes for macOS:
 - exclude common/gpio.cc
 - exclude spi for boardd
 - exclude v4l for loggerd
 - update libdbc.dylib relative path for cabana

I tested some car porting tools (fw fingerprinting test, plotjuggler, cabana) and they are usable now on macOS 13.1