### PR TITLE
cabana: only update the colors of newly fetched messages in historylog

### DIFF
--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -33,7 +33,6 @@ public:
   int columnCount(const QModelIndex &parent = QModelIndex()) const override {
     return display_signals_mode && !sigs.empty() ? sigs.size() + 1 : 2;
   }
-  void updateColors();
   void refresh();
 
 public slots:


### PR DESCRIPTION
Currently historylog will recalculate the color of all messages. this will make the performance worse as the message list grows.