### PR TITLE
cabana: show dots when zoomed far into a signal

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -469,6 +469,16 @@ void ChartView::updatePlot(double cur, double min, double max) {
     axis_x->setRange(min, max);
     updateAxisY();
   }
+
+  // Show points when zoomed in enough
+  for (auto &s : sigs) {
+    auto begin = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->min(), [](auto &p, double x) { return p.x() < x; });
+    auto end = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->max(), [](auto &p, double x) { return p.x() < x; });
+
+    int pixels_per_point = width() / (end - begin);
+    s.series->setPointsVisible(pixels_per_point > 20);
+  }
+
   scene()->invalidate({}, QGraphicsScene::ForegroundLayer);
 }
 

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -475,7 +475,9 @@ void ChartView::updatePlot(double cur, double min, double max) {
     auto begin = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->min(), [](auto &p, double x) { return p.x() < x; });
     auto end = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->max(), [](auto &p, double x) { return p.x() < x; });
 
-    int pixels_per_point = width() / (end - begin);
+    int num_points = std::max<int>(end - begin, 1);
+    int pixels_per_point = width() / num_points;
+
     s.series->setPointsVisible(pixels_per_point > 20);
   }
 


### PR DESCRIPTION
Makes it more clear that values are interpolated when comparing low frequency signals to high frequency ones. Dots appear when there is more than 20 pixels of space between samples.

![Screenshot 2023-01-29 at 15 45 18](https://user-images.githubusercontent.com/1314752/215334174-4ef58926-add7-47c2-b453-5080ded44b2a.png)
