### PR TITLE
cabana: draw message bytes at the same width

### DIFF
--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -65,11 +65,6 @@ MessageBytesDelegate::MessageBytesDelegate(QObject *parent) : QStyledItemDelegat
 }
 
 void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {
-  QList<QVariant> colors = index.data(Qt::UserRole).toList();
-  if (colors.empty()) {
-    QStyledItemDelegate::paint(painter, option, index);
-    return;
-  }
   QStyleOptionViewItemV4 opt = option;
   initStyleOption(&opt, index);
 
@@ -87,6 +82,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   int m = space.width() / 2;
   const QMargins margins(m, m, m, m);
 
+  QList<QVariant> colors = index.data(Qt::UserRole).toList();
   int i = 0;
   for (auto &byte : opt.text.split(" ")) {
     if (i < colors.size()) {


### PR DESCRIPTION
Draw message bytes at the same width even when there is no color data

before:

![Screenshot from 2023-01-30 20-39-52](https://user-images.githubusercontent.com/27770/215480819-2cdd66f9-1a47-4f17-8234-9398b7049ed5.png)

after:

![Screenshot from 2023-01-30 20-42-28](https://user-images.githubusercontent.com/27770/215480814-ac1afd30-f81b-4155-a4a3-0428c6c1f157.png)
