### PR TITLE
panda.cc: fix possible heap overflow on wrong checksum

### DIFF
--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -236,6 +236,9 @@ void Panda::can_send(capnp::List<cereal::CanData>::Reader can_data_list) {
 }
 
 bool Panda::can_receive(std::vector<can_frame>& out_vec) {
+  // Check if enough space left in buffer to store RECV_SIZE data
+  assert(receive_buffer_size + RECV_SIZE < sizeof(receive_buffer));
+
   int recv = handle->bulk_read(0x81, &receive_buffer[receive_buffer_size], RECV_SIZE);
   if (!comms_healthy()) {
     return false;
@@ -278,6 +281,7 @@ bool Panda::unpack_can_buffer(uint8_t *data, uint32_t &size, std::vector<can_fra
 
     if (calculate_checksum(&data[pos], sizeof(can_header) + data_len) != 0) {
       LOGE("Panda CAN checksum failed");
+      size = 0;
       return false;
     }
 

--- a/selfdrive/boardd/panda.cc
+++ b/selfdrive/boardd/panda.cc
@@ -237,7 +237,7 @@ void Panda::can_send(capnp::List<cereal::CanData>::Reader can_data_list) {
 
 bool Panda::can_receive(std::vector<can_frame>& out_vec) {
   // Check if enough space left in buffer to store RECV_SIZE data
-  assert(receive_buffer_size + RECV_SIZE < sizeof(receive_buffer));
+  assert(receive_buffer_size + RECV_SIZE <= sizeof(receive_buffer));
 
   int recv = handle->bulk_read(0x81, &receive_buffer[receive_buffer_size], RECV_SIZE);
   if (!comms_healthy()) {


### PR DESCRIPTION
When the checksum computation fails `size`/`receive_buffer_size` is not decremented. If I understand the code correctly this broken message would stay in the buffer while all newly received data starts overflowing `receive_buffer`.

Setting `size = 0` is not guaranteed to get back in sync with the packets. So maybe you want to implement a better recovery mechanism.

(untested on device)