### PR TITLE
cabana:  remove the margins of the legend item

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -305,6 +305,7 @@ ChartView::ChartView(QWidget *parent) : QChartView(nullptr, parent) {
   axis_y = new QValueAxis(this);
   chart->addAxis(axis_x, Qt::AlignBottom);
   chart->addAxis(axis_y, Qt::AlignLeft);
+  chart->legend()->layout()->setContentsMargins(0, 0, 40, 0);
   chart->legend()->setShowToolTips(true);
   chart->layout()->setContentsMargins(0, 0, 0, 0);
   chart->setMargins({20, 11, 11, 11});


### PR DESCRIPTION
Removed the unnecessary margins to make the legend at the same height with the buttons. and the plot area can also become a bit  larger.

before:
![Screenshot from 2023-01-30 22-02-15](https://user-images.githubusercontent.com/27770/215500859-15fca6d2-d07f-4964-b785-dad1d51cf7f0.png)
after:
![Screenshot from 2023-01-30 22-07-17](https://user-images.githubusercontent.com/27770/215500866-a476f2d7-ecaa-4ab1-882e-063a3cc249be.png)
