### PR TITLE
fix micd input device

### DIFF
--- a/system/micd.py
+++ b/system/micd.py
@@ -85,10 +85,7 @@ class Mic:
       self.measurements = self.measurements[FFT_SAMPLES:]
 
   def micd_thread(self, device=None):
-    if device is None:
-      device = "sysdefault"
-
-    with sd.InputStream(device=device, channels=1, samplerate=SAMPLE_RATE, callback=self.callback) as stream:
+    with sd.InputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback) as stream:
       cloudlog.info(f"micd stream started: {stream.samplerate=} {stream.channels=} {stream.dtype=} {stream.device=}")
       while True:
         self.update()

--- a/system/micd.py
+++ b/system/micd.py
@@ -84,7 +84,7 @@ class Mic:
 
       self.measurements = self.measurements[FFT_SAMPLES:]
 
-  def micd_thread(self, device=None):
+  def micd_thread(self):
     with sd.InputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback) as stream:
       cloudlog.info(f"micd stream started: {stream.samplerate=} {stream.channels=} {stream.dtype=} {stream.device=}")
       while True:

--- a/system/micd.py
+++ b/system/micd.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import sounddevice as sd
 import numpy as np
 
 from cereal import messaging
@@ -85,6 +84,9 @@ class Mic:
       self.measurements = self.measurements[FFT_SAMPLES:]
 
   def micd_thread(self):
+    # sounddevice must be imported after forking processes
+    import sounddevice as sd  # pylint: disable=import-outside-toplevel
+
     with sd.InputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback) as stream:
       cloudlog.info(f"micd stream started: {stream.samplerate=} {stream.channels=} {stream.dtype=} {stream.device=}")
       while True:


### PR DESCRIPTION
closes #26935

- removed "sysdefault" and got a different error
- seems related: https://github.com/spatialaudio/python-sounddevice/issues/147
- removing import from top level seems to fix