### PR TITLE
cabana: dynamically switch between OpenGL

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -471,32 +471,32 @@ void ChartView::updatePlot(double cur, double min, double max) {
   if (min != axis_x->min() || max != axis_x->max()) {
     axis_x->setRange(min, max);
     updateAxisY();
-  }
 
-  // Show points when zoomed in enough
-  for (auto &s : sigs) {
-    auto begin = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->min(), [](auto &p, double x) { return p.x() < x; });
-    auto end = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->max(), [](auto &p, double x) { return p.x() < x; });
+    // Show points when zoomed in enough
+    for (auto &s : sigs) {
+      auto begin = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->min(), [](auto &p, double x) { return p.x() < x; });
+      auto end = std::lower_bound(s.vals.begin(), s.vals.end(), axis_x->max(), [](auto &p, double x) { return p.x() < x; });
 
-    int num_points = std::max<int>(end - begin, 1);
-    int pixels_per_point = width() / num_points;
+      int num_points = std::max<int>(end - begin, 1);
+      int pixels_per_point = width() / num_points;
 
-    s.series->setPointsVisible(pixels_per_point > 20);
+      s.series->setPointsVisible(pixels_per_point > 20);
 
-    // TODO: On MacOS QChartWidget doesn't work with the OpenGL settings that CameraWidget needs.
+      // TODO: On MacOS QChartWidget doesn't work with the OpenGL settings that CameraWidget needs.
 #ifndef __APPLE
-    // OpenGL mode lacks certain features (such as showing points), only use when drawing many points
-    bool use_opengl = pixels_per_point < 1;
-    s.series->setUseOpenGL(use_opengl);
+      // OpenGL mode lacks certain features (such as showing points), only use when drawing many points
+      bool use_opengl = pixels_per_point < 1;
+      s.series->setUseOpenGL(use_opengl);
 
-    // Qt doesn't properly apply device pixel ratio in OpenGL mode
-    QApplication* application = static_cast<QApplication *>(QApplication::instance());
-    float scale = use_opengl ? application->devicePixelRatio() : 1.0;
+      // Qt doesn't properly apply device pixel ratio in OpenGL mode
+      QApplication* application = static_cast<QApplication *>(QApplication::instance());
+      float scale = use_opengl ? application->devicePixelRatio() : 1.0;
 
-    QPen pen = s.series->pen();
-    pen.setWidth(2.0 * scale);
-    s.series->setPen(pen);
+      QPen pen = s.series->pen();
+      pen.setWidth(2.0 * scale);
+      s.series->setPen(pen);
 #endif
+    }
   }
 
   scene()->invalidate({}, QGraphicsScene::ForegroundLayer);

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -358,11 +358,6 @@ void ChartView::setPlotAreaLeftPosition(int pos) {
 void ChartView::addSeries(const QString &msg_id, const Signal *sig) {
   QLineSeries *series = new QLineSeries(this);
 
-  // TODO: Due to a bug in CameraWidget the camera frames
-  // are drawn instead of the graphs on MacOS. Re-enable OpenGL when fixed
-#ifndef __APPLE__
-  series->setUseOpenGL(true);
-#endif
   chart()->addSeries(series);
   series->attachAxis(axis_x);
   series->attachAxis(axis_y);
@@ -487,6 +482,20 @@ void ChartView::updatePlot(double cur, double min, double max) {
     int pixels_per_point = width() / num_points;
 
     s.series->setPointsVisible(pixels_per_point > 20);
+
+#ifndef __APPLE
+    // OpenGL mode lacks certain features (such as showing points), only use when drawing many points
+    bool use_opengl = pixels_per_point < 1;
+    s.series->setUseOpenGL(use_opengl);
+
+    // Qt doesn't properly apply device pixel ratio in OpenGL mode
+    QApplication* application = static_cast<QApplication *>(QApplication::instance());
+    float scale = use_opengl ? application->devicePixelRatio() : 1.0;
+
+    QPen pen = s.series->pen();
+    pen.setWidth(2.0 * scale);
+    s.series->setPen(pen);
+#endif
   }
 
   scene()->invalidate({}, QGraphicsScene::ForegroundLayer);

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -483,6 +483,7 @@ void ChartView::updatePlot(double cur, double min, double max) {
 
     s.series->setPointsVisible(pixels_per_point > 20);
 
+    // TODO: On MacOS QChartWidget doesn't work with the OpenGL settings that CameraWidget needs.
 #ifndef __APPLE
     // OpenGL mode lacks certain features (such as showing points), only use when drawing many points
     bool use_opengl = pixels_per_point < 1;


### PR DESCRIPTION
Continuation of https://github.com/commaai/openpilot/pull/27145

Actually, it looks like this whole points feature doesn't work if you have OpenGL enabled.

https://doc.qt.io/qt-6.2/qabstractseries.html#useOpenGL-prop

> The OpenGL acceleration of series drawing is meant for use cases that need fast drawing of large numbers of points. It is optimized for efficiency, and therefore the series using it lack support for many features available to non-accelerated series:
> 
>  - Pen styles, marker shapes and light markers are ignored for accelerated series. Only solid lines and plain scatter dots are supported. The scatter dots may be circular or rectangular, depending on the underlying graphics hardware and drivers.

Switching dynamically between OpenGL enabled/disabled seems to work decent, as long as you multiply the pen width by the device pixel ratio when OpenGL is enabled.

@deanlee any thoughts?