### PR TITLE
Hyundai: Enable radar tracks for Santa Fe 2019

### DIFF
--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -52,6 +52,10 @@ SUPPORTED_FW_VERSIONS = {
   b'IK__ SCC F-CUP      1.00 1.02 96400-G9100\x18\x07\x06\x17\x12    ': ConfigValues(
     default_config=b"\x00\x00\x00\x01\x00\x00",
     tracks_enabled=b"\x00\x00\x00\x01\x00\x01"),
+  # 2019 SANTA FE
+  b"TM__ SCC F-CUP      1.00 1.00 99110-S1210\x19\x01%\x168    ": ConfigValues(
+    default_config=b"\x00\x00\x00\x01\x00\x00",
+    tracks_enabled=b"\x00\x00\x00\x01\x00\x01"),
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
User was able to enable radar tracks on the 2019 Hyundai Santa Fe with the radar FW version added to the script.

Route: `092ef1cc055c6354|2023-01-29--14-58-08`

Thanks to community 2019 Hyundai Santa Fe owner @evdoks.