### PR TITLE
Hyundai: remove HYUNDAI_GENESIS from legacy steer max blacklist

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -35,7 +35,7 @@ class CarControllerParams:
 
     # To determine the limit for your car, find the maximum value that the stock LKAS will request.
     # If the max stock LKAS request is <384, add your car to this list.
-    elif CP.carFingerprint in (CAR.GENESIS_G80, CAR.GENESIS_G90, CAR.ELANTRA, CAR.HYUNDAI_GENESIS, CAR.IONIQ,
+    elif CP.carFingerprint in (CAR.GENESIS_G80, CAR.GENESIS_G90, CAR.ELANTRA, CAR.IONIQ,
                                CAR.IONIQ_EV_LTD, CAR.SANTA_FE_PHEV_2022, CAR.SONATA_LF, CAR.KIA_FORTE, CAR.KIA_NIRO_PHEV,
                                CAR.KIA_OPTIMA_H, CAR.KIA_SORENTO):
       self.STEER_MAX = 255


### PR DESCRIPTION
**Description** [](A description of the bug and the fix. Also link any relevant issues.
Tested removing HYUNDAI_GENESIS from legacy

**Verification** [](Explain how you tested this bug fix.)
Route with steering limit reached

**Route**
Route: [a route with the bug fix]
85eab094426c2649|2023-02-01--14-01-32--11
