### PR TITLE
get_present_ecus: check available pandas

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -99,7 +99,7 @@ def fingerprint(logcan, sendcan, num_pandas):
     else:
       cloudlog.warning("Getting VIN & FW versions")
       vin_rx_addr, vin = get_vin(logcan, sendcan, bus)
-      ecu_rx_addrs = get_present_ecus(logcan, sendcan)
+      ecu_rx_addrs = get_present_ecus(logcan, sendcan, num_pandas=num_pandas)
       car_fw = get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs, num_pandas=num_pandas)
       cached = False
 

--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -87,5 +87,5 @@ if __name__ == "__main__":
   for addr, subaddr, bus in ecu_addrs:
     msg = f"  0x{hex(addr)}"
     if subaddr is not None:
-      msg += f" (sub-address: 0x{hex(subaddr)})"
+      msg += f" (sub-address: {hex(subaddr)})"
     print(msg)

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -146,12 +146,16 @@ def match_fw_to_car(fw_versions, allow_exact=True, allow_fuzzy=True):
   return True, set()
 
 
-def get_present_ecus(logcan, sendcan):
+def get_present_ecus(logcan, sendcan, num_pandas=1):
   queries = list()
   parallel_queries = list()
   responses = set()
 
   for brand, r in REQUESTS:
+    # Skip query if no panda available
+    if r.bus > num_pandas * 4 - 1:
+      continue
+
     for brand_versions in VERSIONS[brand].values():
       for ecu_type, addr, sub_addr in brand_versions:
         # Only query ecus in whitelist if whitelist is not empty

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -146,7 +146,7 @@ def match_fw_to_car(fw_versions, allow_exact=True, allow_fuzzy=True):
   return True, set()
 
 
-def get_present_ecus(logcan, sendcan, num_pandas=1):
+def get_present_ecus(logcan, sendcan, num_pandas=1) -> Set[Tuple[int, Optional[int], int]]:
   queries = list()
   parallel_queries = list()
   responses = set()
@@ -175,7 +175,7 @@ def get_present_ecus(logcan, sendcan, num_pandas=1):
 
   queries.insert(0, parallel_queries)
 
-  ecu_responses: Set[Tuple[int, Optional[int], int]] = set()
+  ecu_responses = set()
   for query in queries:
     ecu_responses.update(get_ecu_addrs(logcan, sendcan, set(query), responses, timeout=0.1))
   return ecu_responses


### PR DESCRIPTION
Does the same thing `get_fw_versions` does, but for the tester present queries to find the available ECUs. Might save a few ms.

https://github.com/commaai/openpilot/blob/0ee53532be30c740a77f20c39b672f7b0ebb755b/selfdrive/car/fw_versions.py#L255-L257