### PR TITLE
updated: fix brief notification of update for same version

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -171,7 +171,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"Timezone", PERSISTENT},
     {"TrainingVersion", PERSISTENT},
     {"UbloxAvailable", PERSISTENT},
-    {"UpdateAvailable", CLEAR_ON_MANAGER_START},
+    {"UpdateAvailable", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_ON},
     {"UpdateFailedCount", CLEAR_ON_MANAGER_START},
     {"UpdaterState", CLEAR_ON_MANAGER_START},
     {"UpdaterFetchAvailable", CLEAR_ON_MANAGER_START},

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -423,6 +423,9 @@ def main() -> None:
   wait_helper = WaitTimeHelper()
   wait_helper.only_check_for_update = True
 
+  # invalidate old finalized update
+  set_consistent_flag(False)
+
   # Run the update loop
   while True:
     wait_helper.ready_event.clear()


### PR DESCRIPTION
happens on the first `set_params` when updated starts up with an existing, finalized update. the update exists, but the commit/branch mismatch check doesn't work properly since the branches haven't been fetched yet

closes #26854