### PR TITLE
navd: check duration_typical before using

### DIFF
--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -226,7 +226,11 @@ class RouteEngine:
     remaining = 1.0 - along_geometry / max(step['distance'], 1)
     total_distance = step['distance'] * remaining
     total_time = step['duration'] * remaining
-    total_time_typical = step['duration_typical'] * remaining
+
+    if step['duration_typical'] is None:
+      total_time_typical = total_time
+    else:
+      total_time_typical = step['duration_typical'] * remaining
 
     # Add up totals for future steps
     for i in range(self.step_idx + 1, len(self.route)):


### PR DESCRIPTION
fix (happend twice this year)
```
Traceback (most recent call last):
  File "/data/openpilot/selfdrive/manager/process.py", line 43, in launcher
    getattr(mod, 'main')()
  File "/data/openpilot/selfdrive/navd/navd.py", line 329, in main
    route_engine.update()
  File "/data/openpilot/selfdrive/navd/navd.py", line 78, in update
    self.send_instruction()
  File "/data/openpilot/selfdrive/navd/navd.py", line 229, in send_instruction
    total_time_typical = step['duration_typical'] * remaining
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```
this seems not always be available at navigation start
it should give the time of the route under typical conditions and we use it set the ETA color, so setting it to the
total_time seems like a reasonable fallback