### PR TITLE
loggerd: rotate if segment length is >20% longer than expected

### DIFF
--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -31,10 +31,10 @@ void rotate_if_needed(LoggerdState *s) {
   bool timed_out = false;
   double tms = millis_since_boot();
   double seg_length_secs = (tms - s->last_rotate_tms) / 1000.;
-  if (seg_length_secs > SEGMENT_LENGTH) {
+  if ((seg_length_secs > SEGMENT_LENGTH) && !LOGGERD_TEST) {
     if ((tms - s->last_camera_seen_tms) > NO_CAMERA_PATIENCE) {
       timed_out = true;
-      LOGE("no camera packet seen. auto rotating");
+      LOGE("no camera packets seen. auto rotating");
     } else if (seg_length_secs > SEGMENT_LENGTH*1.2) {
       timed_out = true;
       LOGE("segment too long. auto rotating");

--- a/selfdrive/loggerd/loggerd.cc
+++ b/selfdrive/loggerd/loggerd.cc
@@ -32,6 +32,7 @@ void rotate_if_needed(LoggerdState *s) {
   double tms = millis_since_boot();
   double seg_length_secs = (tms - s->last_rotate_tms) / 1000.;
   if ((seg_length_secs > SEGMENT_LENGTH) && !LOGGERD_TEST) {
+    // TODO: might be nice to put these reasons in the sentinel
     if ((tms - s->last_camera_seen_tms) > NO_CAMERA_PATIENCE) {
       timed_out = true;
       LOGE("no camera packets seen. auto rotating");


### PR DESCRIPTION
closes #26579

The old logic only caught cases where all the cameras dropped out. This adds a more generic check to the rotation time out logic based on the segment length. It should catch more cases like a single camera dropping out, wrong camera frequencies, etc.