### PR TITLE
Ford F150 - Pitch Tolerance Increase

### DIFF
--- a/selfdrive/locationd/calibrationd.py
+++ b/selfdrive/locationd/calibrationd.py
@@ -34,7 +34,7 @@ RPY_INIT = np.array([0.0,0.0,0.0])
 WIDE_FROM_DEVICE_EULER_INIT = np.array([0.0, 0.0, 0.0])
 
 # These values are needed to accommodate biggest modelframe
-PITCH_LIMITS = np.array([-0.09074112085129739, 0.14907572052989657])
+PITCH_LIMITS = np.array([-0.09074112085129739, 0.14907572052989657]) * 2
 YAW_LIMITS = np.array([-0.06912048084718224, 0.06912048084718235])
 DEBUG = os.getenv("DEBUG") is not None
 


### PR DESCRIPTION
**Description**
Ford F150 has a steep windshield and default tolerance levels provided invalid calibrations.

**Verification**
Increased calibration values (temporarily) while working on CAN-FD platform.

**Route**
Route: `b9a91fc95c5ba5c7|2023-02-05--14-49-24`