### PR TITLE
cabana: improve charts toolbar

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -36,14 +36,13 @@ ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
   stretch_label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
   toolbar->addWidget(stretch_label);
 
-  toolbar->addWidget(new QLabel(tr("Range:")));
-  toolbar->addWidget(range_lb = new QLabel(this));
+  range_lb_action = toolbar->addWidget(range_lb = new QLabel(this));
   range_slider = new QSlider(Qt::Horizontal, this);
   range_slider->setToolTip(tr("Set the chart range"));
   range_slider->setRange(1, settings.max_cached_minutes * 60);
   range_slider->setSingleStep(1);
   range_slider->setPageStep(60);  // 1 min
-  toolbar->addWidget(range_slider);
+  range_slider_action = toolbar->addWidget(range_slider);
 
   reset_zoom_btn = toolbar->addAction(utils::icon("zoom-out"), "");
   reset_zoom_btn->setToolTip(tr("Reset zoom (drag on chart to zoom X-Axis)"));
@@ -160,12 +159,14 @@ void ChartsWidget::setMaxChartRange(int value) {
 }
 
 void ChartsWidget::updateToolBar() {
-  range_lb->setText(QString(" %1:%2 ").arg(max_chart_range / 60, 2, 10, QLatin1Char('0')).arg(max_chart_range % 60, 2, 10, QLatin1Char('0')));
   title_label->setText(tr("Charts: %1").arg(charts.size()));
-  dock_btn->setIcon(utils::icon(docking ? "arrow-up-right" : "arrow-down-left"));
-  dock_btn->setToolTip(docking ? tr("Undock charts") : tr("Dock charts"));
+  range_lb->setText(QString("Range: %1:%2 ").arg(max_chart_range / 60, 2, 10, QLatin1Char('0')).arg(max_chart_range % 60, 2, 10, QLatin1Char('0')));
+  reset_zoom_btn->setVisible(is_zoomed);
+  range_lb_action->setVisible(!is_zoomed);
+  range_slider_action->setVisible(!is_zoomed);
   remove_all_btn->setEnabled(!charts.isEmpty());
-  reset_zoom_btn->setEnabled(is_zoomed);
+  dock_btn->setIcon(utils::icon(docking ? "arrow-up-right-square" : "arrow-down-left-square"));
+  dock_btn->setToolTip(docking ? tr("Undock charts") : tr("Dock charts"));
 }
 
 void ChartsWidget::settingChanged() {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -22,6 +22,7 @@ ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
   // toolbar
   QToolBar *toolbar = new QToolBar(tr("Charts"), this);
   toolbar->setIconSize({16, 16});
+  toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
   QAction *new_plot_btn = toolbar->addAction(utils::icon("file-plus"), "");
   new_plot_btn->setToolTip(tr("New Plot"));
@@ -45,7 +46,7 @@ ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
   range_slider_action = toolbar->addWidget(range_slider);
 
   reset_zoom_btn = toolbar->addAction(utils::icon("zoom-out"), "");
-  reset_zoom_btn->setToolTip(tr("Reset zoom (drag on chart to zoom X-Axis)"));
+  reset_zoom_btn->setToolTip(tr("Reset zoom"));
   remove_all_btn = toolbar->addAction(utils::icon("x"), "");
   remove_all_btn->setToolTip(tr("Remove all charts"));
   dock_btn = toolbar->addAction("");
@@ -161,9 +162,10 @@ void ChartsWidget::setMaxChartRange(int value) {
 void ChartsWidget::updateToolBar() {
   title_label->setText(tr("Charts: %1").arg(charts.size()));
   range_lb->setText(QString("Range: %1:%2 ").arg(max_chart_range / 60, 2, 10, QLatin1Char('0')).arg(max_chart_range % 60, 2, 10, QLatin1Char('0')));
-  reset_zoom_btn->setVisible(is_zoomed);
   range_lb_action->setVisible(!is_zoomed);
   range_slider_action->setVisible(!is_zoomed);
+  reset_zoom_btn->setVisible(is_zoomed);
+  reset_zoom_btn->setText(is_zoomed ? tr("Zoomin: %1-%2").arg(zoomed_range.first, 0, 'f', 2).arg(zoomed_range.second, 0, 'f', 2) : "");
   remove_all_btn->setEnabled(!charts.isEmpty());
   dock_btn->setIcon(utils::icon(docking ? "arrow-up-right-square" : "arrow-down-left-square"));
   dock_btn->setToolTip(docking ? tr("Undock charts") : tr("Dock charts"));

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -129,6 +129,8 @@ private:
   QLabel *title_label;
   QLabel *range_lb;
   QSlider *range_slider;
+  QAction *range_lb_action;
+  QAction *range_slider_action;
   bool docking = true;
   QAction *dock_btn;
   QAction *reset_zoom_btn;


### PR DESCRIPTION
**Issue:** It is confusing whether the chart is in zoom state or not, they look alike:

zoomed:
![Screenshot from 2023-02-07 00-27-43](https://user-images.githubusercontent.com/27770/217027999-27e463ff-3471-4b59-9007-a41ac2117673.png)
un-zoomed:
![Screenshot from 2023-02-07 00-27-32](https://user-images.githubusercontent.com/27770/217028013-213e83a7-bc8e-49b6-98fe-ba01eea10adb.png)

And when in the zoomed state, dragging the slider will not have any effect. It can also be confusing.

**Fixed:** hide range slider when in zoomed state, show reset zoom button only when in zoomed state:

zoomed:
![Screenshot from 2023-02-07 10-49-51](https://user-images.githubusercontent.com/27770/217135562-94b554be-abc0-42f7-b2ea-4c98d969d3e4.png)
un-zoomed:

![Screenshot from 2023-02-07 10-49-37](https://user-images.githubusercontent.com/27770/217135568-d1d7102b-a366-4afe-b1f1-ee76d7081c35.png)