### PR TITLE
setup: replace software selection widget with input dialog

### DIFF
--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -170,7 +170,16 @@ QWidget * Setup::network_setup() {
   QPushButton *cont = new QPushButton();
   cont->setObjectName("navBtn");
   cont->setProperty("primary", true);
-  QObject::connect(cont, &QPushButton::clicked, this, &Setup::nextPage);
+  QObject::connect(cont, &QPushButton::clicked, [=]() {
+    QString url = InputDialog::getText(tr("Enter installer URL"), this, "");
+    if (url.isEmpty()) {
+      return;
+    }
+    setCurrentWidget(downloading_widget);
+    QTimer::singleShot(1000, this, [=]() {
+      download(url);
+    });
+  });
   blayout->addWidget(cont);
 
   // setup timer for testing internet connection
@@ -193,106 +202,6 @@ QWidget * Setup::network_setup() {
     }
   });
   timer->start(1000);
-
-  return widget;
-}
-
-QWidget * radio_button(QString title, QButtonGroup *group) {
-  QPushButton *btn = new QPushButton(title);
-  btn->setCheckable(true);
-  group->addButton(btn);
-  btn->setStyleSheet(R"(
-    QPushButton {
-      height: 230;
-      padding-left: 100px;
-      padding-right: 100px;
-      text-align: left;
-      font-size: 80px;
-      font-weight: 400;
-      border-radius: 10px;
-      background-color: #4F4F4F;
-    }
-    QPushButton:checked {
-      background-color: #465BEA;
-    }
-  )");
-
-  // checkmark icon
-  QPixmap pix(":/img_circled_check.svg");
-  btn->setIcon(pix);
-  btn->setIconSize(QSize(0, 0));
-  btn->setLayoutDirection(Qt::RightToLeft);
-  QObject::connect(btn, &QPushButton::toggled, [=](bool checked) {
-    btn->setIconSize(checked ? QSize(104, 104) : QSize(0, 0));
-  });
-  return btn;
-}
-
-QWidget * Setup::software_selection() {
-  QWidget *widget = new QWidget();
-  QVBoxLayout *main_layout = new QVBoxLayout(widget);
-  main_layout->setContentsMargins(55, 50, 55, 50);
-  main_layout->setSpacing(0);
-
-  // title
-  QLabel *title = new QLabel(tr("Choose Software to Install"));
-  title->setStyleSheet("font-size: 90px; font-weight: 500;");
-  main_layout->addWidget(title, 0, Qt::AlignLeft | Qt::AlignTop);
-
-  main_layout->addSpacing(50);
-
-  // dashcam + custom radio buttons
-  QButtonGroup *group = new QButtonGroup(widget);
-  group->setExclusive(true);
-
-  QWidget *dashcam = radio_button(tr("Dashcam"), group);
-  main_layout->addWidget(dashcam);
-
-  main_layout->addSpacing(30);
-
-  QWidget *custom = radio_button(tr("Custom Software"), group);
-  main_layout->addWidget(custom);
-
-  main_layout->addStretch();
-
-  // back + continue buttons
-  QHBoxLayout *blayout = new QHBoxLayout;
-  main_layout->addLayout(blayout);
-  blayout->setSpacing(50);
-
-  QPushButton *back = new QPushButton(tr("Back"));
-  back->setObjectName("navBtn");
-  QObject::connect(back, &QPushButton::clicked, this, &Setup::prevPage);
-  blayout->addWidget(back);
-
-  QPushButton *cont = new QPushButton(tr("Continue"));
-  cont->setObjectName("navBtn");
-  cont->setEnabled(false);
-  cont->setProperty("primary", true);
-  blayout->addWidget(cont);
-
-  QObject::connect(cont, &QPushButton::clicked, [=]() {
-    auto w = currentWidget();
-    QTimer::singleShot(0, [=]() {
-      setCurrentWidget(downloading_widget);
-    });
-    QString url = DASHCAM_URL;
-    if (group->checkedButton() != dashcam) {
-      url = InputDialog::getText(tr("Enter URL"), this, tr("for Custom Software"));
-    }
-    if (!url.isEmpty()) {
-      QTimer::singleShot(1000, this, [=]() {
-        download(url);
-      });
-    } else {
-      setCurrentWidget(w);
-    }
-  });
-
-  connect(group, QOverload<QAbstractButton *>::of(&QButtonGroup::buttonClicked), [=](QAbstractButton *btn) {
-    btn->setChecked(true);
-    cont->setEnabled(true);
-  });
 
   return widget;
 }
@@ -372,7 +281,6 @@ Setup::Setup(QWidget *parent) : QStackedWidget(parent) {
 
   addWidget(getting_started());
   addWidget(network_setup());
-  addWidget(software_selection());
 
   downloading_widget = downloading();
   addWidget(downloading_widget);

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -171,14 +171,18 @@ QWidget * Setup::network_setup() {
   cont->setObjectName("navBtn");
   cont->setProperty("primary", true);
   QObject::connect(cont, &QPushButton::clicked, [=]() {
-    QString url = InputDialog::getText(tr("Enter installer URL"), this, "");
-    if (url.isEmpty()) {
-      return;
-    }
-    setCurrentWidget(downloading_widget);
-    QTimer::singleShot(1000, this, [=]() {
-      download(url);
+    auto w = currentWidget();
+    QTimer::singleShot(0, [=]() {
+      setCurrentWidget(downloading_widget);
     });
+    QString url = InputDialog::getText(tr("Enter URL"), this, tr("for Custom Software"));
+    if (!url.isEmpty()) {
+      QTimer::singleShot(1000, this, [=]() {
+        download(url);
+      });
+    } else {
+      setCurrentWidget(w);
+    }
   });
   blayout->addWidget(cont);
 

--- a/selfdrive/ui/qt/setup/setup.h
+++ b/selfdrive/ui/qt/setup/setup.h
@@ -14,7 +14,6 @@ private:
   QWidget *low_voltage();
   QWidget *getting_started();
   QWidget *network_setup();
-  QWidget *software_selection();
   QWidget *downloading();
   QWidget *download_failed();
 

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -675,6 +675,14 @@ location set</source>
         <translation>Auf Internet warten</translation>
     </message>
     <message>
+        <source>Enter URL</source>
+        <translation>URL eingeben</translation>
+    </message>
+    <message>
+        <source>for Custom Software</source>
+        <translation>für spezifische Software</translation>
+    </message>
+    <message>
         <source>Downloading...</source>
         <translation>Herunterladen...</translation>
     </message>
@@ -693,10 +701,6 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>Von neuem beginnen</translation>
-    </message>
-    <message>
-        <source>Enter installer URL</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -675,26 +675,6 @@ location set</source>
         <translation>Auf Internet warten</translation>
     </message>
     <message>
-        <source>Choose Software to Install</source>
-        <translation>Software zum installieren auswählen</translation>
-    </message>
-    <message>
-        <source>Dashcam</source>
-        <translation>Dashcam</translation>
-    </message>
-    <message>
-        <source>Custom Software</source>
-        <translation>Spezifische Software</translation>
-    </message>
-    <message>
-        <source>Enter URL</source>
-        <translation>URL eingeben</translation>
-    </message>
-    <message>
-        <source>for Custom Software</source>
-        <translation>für spezifische Software</translation>
-    </message>
-    <message>
         <source>Downloading...</source>
         <translation>Herunterladen...</translation>
     </message>
@@ -713,6 +693,10 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>Von neuem beginnen</translation>
+    </message>
+    <message>
+        <source>Enter installer URL</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -673,6 +673,14 @@ location set</source>
         <translation>インターネット接続を待機中</translation>
     </message>
     <message>
+        <source>Enter URL</source>
+        <translation>URL を入力</translation>
+    </message>
+    <message>
+        <source>for Custom Software</source>
+        <translation>カスタムソフトウェア</translation>
+    </message>
+    <message>
         <source>Downloading...</source>
         <translation>ダウンロード中...</translation>
     </message>
@@ -691,10 +699,6 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>最初からやり直す</translation>
-    </message>
-    <message>
-        <source>Enter installer URL</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -673,26 +673,6 @@ location set</source>
         <translation>インターネット接続を待機中</translation>
     </message>
     <message>
-        <source>Choose Software to Install</source>
-        <translation>インストールするソフトウェアを選択してください</translation>
-    </message>
-    <message>
-        <source>Dashcam</source>
-        <translation>ﾄﾞﾗｲﾌﾞﾚｺｰﾀﾞｰ</translation>
-    </message>
-    <message>
-        <source>Custom Software</source>
-        <translation>カスタムソフトウェア</translation>
-    </message>
-    <message>
-        <source>Enter URL</source>
-        <translation>URL を入力</translation>
-    </message>
-    <message>
-        <source>for Custom Software</source>
-        <translation>カスタムソフトウェア</translation>
-    </message>
-    <message>
         <source>Downloading...</source>
         <translation>ダウンロード中...</translation>
     </message>
@@ -711,6 +691,10 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>最初からやり直す</translation>
+    </message>
+    <message>
+        <source>Enter installer URL</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -673,6 +673,14 @@ location set</source>
         <translation>네트워크 접속을 기다립니다</translation>
     </message>
     <message>
+        <source>Enter URL</source>
+        <translation>URL 입력</translation>
+    </message>
+    <message>
+        <source>for Custom Software</source>
+        <translation>for Custom Software</translation>
+    </message>
+    <message>
         <source>Downloading...</source>
         <translation>다운로드중...</translation>
     </message>
@@ -691,10 +699,6 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>다시 시작</translation>
-    </message>
-    <message>
-        <source>Enter installer URL</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -673,26 +673,6 @@ location set</source>
         <translation>네트워크 접속을 기다립니다</translation>
     </message>
     <message>
-        <source>Choose Software to Install</source>
-        <translation>설치할 소프트웨어를 선택하세요</translation>
-    </message>
-    <message>
-        <source>Dashcam</source>
-        <translation>Dashcam</translation>
-    </message>
-    <message>
-        <source>Custom Software</source>
-        <translation>Custom Software</translation>
-    </message>
-    <message>
-        <source>Enter URL</source>
-        <translation>URL 입력</translation>
-    </message>
-    <message>
-        <source>for Custom Software</source>
-        <translation>for Custom Software</translation>
-    </message>
-    <message>
         <source>Downloading...</source>
         <translation>다운로드중...</translation>
     </message>
@@ -711,6 +691,10 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>다시 시작</translation>
+    </message>
+    <message>
+        <source>Enter installer URL</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -677,6 +677,14 @@ trabalho definido</translation>
         <translation>Esperando pela internet</translation>
     </message>
     <message>
+        <source>Enter URL</source>
+        <translation>Preencher URL</translation>
+    </message>
+    <message>
+        <source>for Custom Software</source>
+        <translation>para o Software Customizado</translation>
+    </message>
+    <message>
         <source>Downloading...</source>
         <translation>Baixando...</translation>
     </message>
@@ -695,10 +703,6 @@ trabalho definido</translation>
     <message>
         <source>Start over</source>
         <translation>Inicializar</translation>
-    </message>
-    <message>
-        <source>Enter installer URL</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -677,26 +677,6 @@ trabalho definido</translation>
         <translation>Esperando pela internet</translation>
     </message>
     <message>
-        <source>Choose Software to Install</source>
-        <translation>Escolher Software para Instalar</translation>
-    </message>
-    <message>
-        <source>Dashcam</source>
-        <translation>Dashcam</translation>
-    </message>
-    <message>
-        <source>Custom Software</source>
-        <translation>Sofware Customizado</translation>
-    </message>
-    <message>
-        <source>Enter URL</source>
-        <translation>Preencher URL</translation>
-    </message>
-    <message>
-        <source>for Custom Software</source>
-        <translation>para o Software Customizado</translation>
-    </message>
-    <message>
         <source>Downloading...</source>
         <translation>Baixando...</translation>
     </message>
@@ -715,6 +695,10 @@ trabalho definido</translation>
     <message>
         <source>Start over</source>
         <translation>Inicializar</translation>
+    </message>
+    <message>
+        <source>Enter installer URL</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -671,6 +671,14 @@ location set</source>
         <translation>等待网络连接</translation>
     </message>
     <message>
+        <source>Enter URL</source>
+        <translation>输入网址</translation>
+    </message>
+    <message>
+        <source>for Custom Software</source>
+        <translation>以下载自定义软件</translation>
+    </message>
+    <message>
         <source>Downloading...</source>
         <translation>正在下载……</translation>
     </message>
@@ -689,10 +697,6 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>重来</translation>
-    </message>
-    <message>
-        <source>Enter installer URL</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -671,26 +671,6 @@ location set</source>
         <translation>等待网络连接</translation>
     </message>
     <message>
-        <source>Choose Software to Install</source>
-        <translation>选择要安装的软件</translation>
-    </message>
-    <message>
-        <source>Dashcam</source>
-        <translation>Dashcam（行车记录仪）</translation>
-    </message>
-    <message>
-        <source>Custom Software</source>
-        <translation>自定义软件</translation>
-    </message>
-    <message>
-        <source>Enter URL</source>
-        <translation>输入网址</translation>
-    </message>
-    <message>
-        <source>for Custom Software</source>
-        <translation>以下载自定义软件</translation>
-    </message>
-    <message>
         <source>Downloading...</source>
         <translation>正在下载……</translation>
     </message>
@@ -709,6 +689,10 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>重来</translation>
+    </message>
+    <message>
+        <source>Enter installer URL</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -673,6 +673,14 @@ location set</source>
         <translation>連接至網路中</translation>
     </message>
     <message>
+        <source>Enter URL</source>
+        <translation>輸入網址</translation>
+    </message>
+    <message>
+        <source>for Custom Software</source>
+        <translation>定制的軟體</translation>
+    </message>
+    <message>
         <source>Downloading...</source>
         <translation>下載中…</translation>
     </message>
@@ -691,10 +699,6 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>重新開始</translation>
-    </message>
-    <message>
-        <source>Enter installer URL</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -673,26 +673,6 @@ location set</source>
         <translation>連接至網路中</translation>
     </message>
     <message>
-        <source>Choose Software to Install</source>
-        <translation>選擇要安裝的軟體</translation>
-    </message>
-    <message>
-        <source>Dashcam</source>
-        <translation>行車記錄器</translation>
-    </message>
-    <message>
-        <source>Custom Software</source>
-        <translation>定制的軟體</translation>
-    </message>
-    <message>
-        <source>Enter URL</source>
-        <translation>輸入網址</translation>
-    </message>
-    <message>
-        <source>for Custom Software</source>
-        <translation>定制的軟體</translation>
-    </message>
-    <message>
         <source>Downloading...</source>
         <translation>下載中…</translation>
     </message>
@@ -711,6 +691,10 @@ location set</source>
     <message>
         <source>Start over</source>
         <translation>重新開始</translation>
+    </message>
+    <message>
+        <source>Enter installer URL</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
remove the "Choose Software to Install" screen and jump straight to inputting an installer URL after confirming wi-fi network.

|New|Old|
|-|-|
|Removed|![Choose Software to Install (custom)](https://user-images.githubusercontent.com/4038174/217147756-f0ef1714-fc98-42df-8ec7-dc0539a315d0.png)|



closes https://github.com/commaai/agnos-builder/issues/105