### PR TITLE
setup: add serial to request headers

### DIFF
--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -31,7 +31,7 @@ void Setup::download(QString url) {
   auto version = util::read_file("/VERSION");
 
   struct curl_slist *list = NULL;
-  list = curl_slist_append(list, ("X-comma-dongle-id: " + getDongleId().value_or("")).c_str());
+  list = curl_slist_append(list, ("X-openpilot-dongle-id: " + getDongleId().value_or("")).c_str());
 
   char tmpfile[] = "/tmp/installer_XXXXXX";
   FILE *fp = fdopen(mkstemp(tmpfile), "w");

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -14,7 +14,6 @@
 #include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/api.h"
 #include "selfdrive/ui/qt/qt_window.h"
-#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/offroad/networking.h"
 #include "selfdrive/ui/qt/widgets/input.h"
 
@@ -31,7 +30,7 @@ void Setup::download(QString url) {
   auto version = util::read_file("/VERSION");
 
   struct curl_slist *list = NULL;
-  list = curl_slist_append(list, ("X-openpilot-dongle-id: " + getDongleId().value_or("")).toStdString().c_str());
+  list = curl_slist_append(list, ("X-openpilot-serial: " + Hardware::get_serial()).c_str());
 
   char tmpfile[] = "/tmp/installer_XXXXXX";
   FILE *fp = fdopen(mkstemp(tmpfile), "w");

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -31,7 +31,7 @@ void Setup::download(QString url) {
   auto version = util::read_file("/VERSION");
 
   struct curl_slist *list = NULL;
-  list = curl_slist_append(list, ("X-openpilot-dongle-id: " + getDongleId().value_or("")).c_str());
+  list = curl_slist_append(list, ("X-openpilot-dongle-id: " + getDongleId().value_or("")).toStdString().c_str());
 
   char tmpfile[] = "/tmp/installer_XXXXXX";
   FILE *fp = fdopen(mkstemp(tmpfile), "w");

--- a/system/hardware/base.h
+++ b/system/hardware/base.h
@@ -16,6 +16,8 @@ public:
   static int get_voltage() { return 0; };
   static int get_current() { return 0; };
 
+  static std::string get_serial() { return "cccccc"; }
+
   static void reboot() {}
   static void poweroff() {}
   static void set_brightness(int percent) {}

--- a/system/hardware/tici/hardware.h
+++ b/system/hardware/tici/hardware.h
@@ -7,19 +7,6 @@
 #include "common/util.h"
 #include "system/hardware/base.h"
 
-std::string get_device_serial() {
-  std::ifstream stream("/proc/cmdline");
-  std::string cmdline;
-  std::getline(stream, cmdline);
-
-  auto start = cmdline.find("serialno=");
-  if (start != std::string::npos) {
-    auto end = cmdline.find(" ", start + 9);
-    return cmdline.substr(start + 9, end - start - 9);
-  }
-  return "cccccc";
-}
-
 class HardwareTici : public HardwareNone {
 public:
   static constexpr float MAX_VOLUME = 0.9;
@@ -35,7 +22,20 @@ public:
   static int get_current() { return std::atoi(util::read_file("/sys/class/hwmon/hwmon1/curr1_input").c_str()); };
 
   static std::string get_serial() {
-    static std::string serial = get_device_serial();
+    static std::string serial("");
+    if (serial.empty()) {
+      std::ifstream stream("/proc/cmdline");
+      std::string cmdline;
+      std::getline(stream, cmdline);
+
+      auto start = cmdline.find("serialno=");
+      if (start == std::string::npos) {
+        serial = "cccccc";
+      } else {
+        auto end = cmdline.find(" ", start + 9);
+        serial = cmdline.substr(start + 9, end - start - 9);
+      }
+    }
     return serial;
   }
 

--- a/system/hardware/tici/hardware.h
+++ b/system/hardware/tici/hardware.h
@@ -21,6 +21,18 @@ public:
   static int get_voltage() { return std::atoi(util::read_file("/sys/class/hwmon/hwmon1/in1_input").c_str()); };
   static int get_current() { return std::atoi(util::read_file("/sys/class/hwmon/hwmon1/curr1_input").c_str()); };
 
+  static std::string get_serial() {
+    std::ifstream stream("/proc/cmdline");
+    std::string cmdline;
+    std::getline(stream, cmdline)
+
+    auto start = cmdline.find("serialno=");
+    if (start != std::string::npos) {
+      auto end = cmdline.find(" ", start + 9);
+      return cmdline.substr(start + 9, end - start - 9);
+    }
+    return "cccccc";
+  }
 
   static void reboot() { std::system("sudo reboot"); };
   static void poweroff() { std::system("sudo poweroff"); };

--- a/system/hardware/tici/hardware.h
+++ b/system/hardware/tici/hardware.h
@@ -7,6 +7,19 @@
 #include "common/util.h"
 #include "system/hardware/base.h"
 
+std::string get_device_serial() {
+  std::ifstream stream("/proc/cmdline");
+  std::string cmdline;
+  std::getline(stream, cmdline);
+
+  auto start = cmdline.find("serialno=");
+  if (start != std::string::npos) {
+    auto end = cmdline.find(" ", start + 9);
+    return cmdline.substr(start + 9, end - start - 9);
+  }
+  return "cccccc";
+}
+
 class HardwareTici : public HardwareNone {
 public:
   static constexpr float MAX_VOLUME = 0.9;
@@ -22,16 +35,8 @@ public:
   static int get_current() { return std::atoi(util::read_file("/sys/class/hwmon/hwmon1/curr1_input").c_str()); };
 
   static std::string get_serial() {
-    std::ifstream stream("/proc/cmdline");
-    std::string cmdline;
-    std::getline(stream, cmdline);
-
-    auto start = cmdline.find("serialno=");
-    if (start != std::string::npos) {
-      auto end = cmdline.find(" ", start + 9);
-      return cmdline.substr(start + 9, end - start - 9);
-    }
-    return "cccccc";
+    static std::string serial = get_device_serial();
+    return serial;
   }
 
   static void reboot() { std::system("sudo reboot"); };

--- a/system/hardware/tici/hardware.h
+++ b/system/hardware/tici/hardware.h
@@ -24,7 +24,7 @@ public:
   static std::string get_serial() {
     std::ifstream stream("/proc/cmdline");
     std::string cmdline;
-    std::getline(stream, cmdline)
+    std::getline(stream, cmdline);
 
     auto start = cmdline.find("serialno=");
     if (start != std::string::npos) {


### PR DESCRIPTION
```
* Connected to nightly.comma.ai (20.188.93.37) port 80 (#0)
> GET / HTTP/1.1
Host: nightly.comma.ai
User-Agent: AGNOSSetup-
Accept: */*
X-openpilot-serial: cccccc
...
```