### PR TITLE
cabana: add space between signal and msg name

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -485,7 +485,7 @@ void ChartView::updateTitle() {
   }
   for (auto &s : sigs) {
     auto decoration = s.series->isVisible() ? "none" : "line-through";
-    s.series->setName(QString("<span style=\"text-decoration:%1\"><b>%2</b><font color=\"gray\">%3 %4</font></span>").arg(decoration).arg(s.sig->name.c_str()).arg(msgName(s.msg_id)).arg(s.msg_id));
+    s.series->setName(QString("<span style=\"text-decoration:%1\"><b>%2</b> <font color=\"gray\">%3 %4</font></span>").arg(decoration, s.sig->name.c_str(), msgName(s.msg_id), s.msg_id));
   }
 }
 


### PR DESCRIPTION
This space can also change the tooltips from one line to two lines:
```
Signal
Msg

```
after:
![Screenshot from 2023-02-08 13-37-25](https://user-images.githubusercontent.com/27770/217444405-ca5ec238-8cc3-4076-98f9-c62c09f95de5.png)

before:
![Screenshot from 2023-02-08 13-39-04](https://user-images.githubusercontent.com/27770/217444400-c805c0c5-6721-42de-8c6f-790c20358e10.png)
