### PR TITLE
cabana: extend color palette, make chart colors match signal view

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -173,7 +173,6 @@ void BinaryViewModel::refresh() {
   if ((dbc_msg = dbc()->msg(msg_id))) {
     row_count = dbc_msg->size;
     items.resize(row_count * column_count);
-    int i = 0;
     for (auto sig : dbc_msg->getSignals()) {
       auto [start, end] = getSignalRange(sig);
       for (int j = start; j <= end; ++j) {
@@ -185,10 +184,9 @@ void BinaryViewModel::refresh() {
         }
         if (j == start) sig->is_little_endian ? items[idx].is_lsb = true : items[idx].is_msb = true;
         if (j == end) sig->is_little_endian ? items[idx].is_msb = true : items[idx].is_lsb = true;
-        items[idx].bg_color = getColor(i);
+        items[idx].bg_color = getColor(sig);
         items[idx].sigs.push_back(sig);
       }
-      ++i;
     }
   } else {
     row_count = can->lastMessage(msg_id).dat.size();

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -525,6 +525,7 @@ void ChartView::updateSeries(const Signal *sig, const std::vector<Event *> *even
         s.vals.clear();
         s.vals.reserve(settings.max_cached_minutes * 60 * 100);  // [n]seconds * 100hz
         s.last_value_mono_time = 0;
+        s.series->setColor(getColor(sig));
       }
 
       struct Chunk {

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -49,7 +49,7 @@ QVariant HistoryLogModel::headerData(int section, Qt::Orientation orientation, i
       }
       return show_signals ? QString::fromStdString(sigs[section - 1]->name).replace('_', ' ') : "Data";
     } else if (role == Qt::BackgroundRole && section > 0 && show_signals) {
-      return QBrush(QColor(getColor(section - 1)));
+      return QBrush(getColor(sigs[section - 1]));
     }
   }
   return {};

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -279,7 +279,7 @@ void SignalItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     }
 
     // color label
-    auto bg_color = QColor(getColor(item->row()));
+    auto bg_color = getColor(item->sig);
     QRect rc{option.rect.left() + 3, option.rect.top(), 22, option.rect.height()};
     painter->setPen(Qt::NoPen);
     painter->setBrush(item->highlight ? bg_color.darker(125) : bg_color);

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QFontDatabase>
 #include <QPainter>
+#include <QDebug>
 
 #include <limits>
 #include <cmath>
@@ -104,10 +105,10 @@ QColor getColor(const Signal *sig) {
   h = fmod(h, 1.0);
 
   size_t hash = qHash(QString::fromStdString(sig->name));
-  float v = 13 * (float)(hash & 0xff) / 255.0;
-  v = 0.75 + fmod(v, 0.25);
+  float s = 0.25 + 0.5 * (float)((hash >> 8) & 0xff) / 255.0;
+  float v = 0.75 + 0.25 * (float)((hash >> 16) & 0xff) / 255.0;
 
-  return QColor::fromHsvF(h, 0.5, v);
+  return QColor::fromHsvF(h, s, v);
 }
 
 NameValidator::NameValidator(QObject *parent) : QRegExpValidator(QRegExp("^(\\w+)"), parent) { }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -105,8 +105,8 @@ QColor getColor(const Signal *sig) {
   h = fmod(h, 1.0);
 
   size_t hash = qHash(QString::fromStdString(sig->name));
-  float s = 0.25 + 0.5 * (float)((hash >> 8) & 0xff) / 255.0;
-  float v = 0.75 + 0.25 * (float)((hash >> 16) & 0xff) / 255.0;
+  float s = 0.25 + 0.25 * (float)(hash & 0xff) / 255.0;
+  float v = 0.75 + 0.25 * (float)((hash >> 8) & 0xff) / 255.0;
 
   return QColor::fromHsvF(h, s, v);
 }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -4,6 +4,9 @@
 #include <QFontDatabase>
 #include <QPainter>
 
+#include <limits>
+#include <cmath>
+
 #include "selfdrive/ui/qt/util.h"
 
 static QColor blend(QColor a, QColor b) {
@@ -94,6 +97,17 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     pos.moveLeft(pos.right() + space.width());
     i++;
   }
+}
+
+QColor getColor(const Signal *sig) {
+  float h = 19 * (float)sig->lsb / 64.0;
+  h = fmod(h, 1.0);
+
+  size_t hash = qHash(QString::fromStdString(sig->name));
+  float v = 13 * (float)(hash & 0xff) / 255.0;
+  v = 0.75 + fmod(v, 0.25);
+
+  return QColor::fromHsvF(h, 0.5, v);
 }
 
 NameValidator::NameValidator(QObject *parent) : QRegExpValidator(QRegExp("^(\\w+)"), parent) { }

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -7,6 +7,8 @@
 #include <QStyledItemDelegate>
 #include <QVector>
 
+#include "opendbc/can/common_dbc.h"
+
 class ChangeTracker {
 public:
   void compute(const QByteArray &dat, double ts, uint32_t freq);
@@ -33,11 +35,7 @@ public:
 
 inline QString toHex(const QByteArray &dat) { return dat.toHex(' ').toUpper(); }
 inline char toHex(uint value) { return "0123456789ABCDEF"[value & 0xF]; }
-inline const QString &getColor(int i) {
-  // TODO: add more colors
-  static const QString SIGNAL_COLORS[] = {"#9FE2BF", "#40E0D0", "#6495ED", "#CCCCFF", "#FF7F50", "#FFBF00"};
-  return SIGNAL_COLORS[i % std::size(SIGNAL_COLORS)];
-}
+QColor getColor(const Signal *sig);
 
 class NameValidator : public QRegExpValidator {
   Q_OBJECT


### PR DESCRIPTION
Generate "random" but nice looking colors. I'm open to a different color generation function, but this seems to produce acceptable results and is deterministic based on signal properties.

![2023-02-08-123824_493x800_scrot](https://user-images.githubusercontent.com/1314752/217519608-15da604f-2226-4f5d-896b-cb2d00c126ff.png)
![2023-02-08-123804_814x715_scrot](https://user-images.githubusercontent.com/1314752/217519610-3803578e-4df6-4ff2-8f37-c068f7367a48.png)

