### PR TITLE
cabana: improve the welcome page

### DIFF
--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -232,9 +232,14 @@ WelcomeWidget::WelcomeWidget(QWidget *parent) : QWidget(parent) {
     return hlayout;
   };
 
+  auto lb = new QLabel(tr("<-Select a message to to view details"));
+  lb->setAlignment(Qt::AlignHCenter);
+  main_layout->addWidget(lb);
   main_layout->addLayout(newShortcutRow("Pause", "Space"));
   main_layout->addLayout(newShortcutRow("Help", "Alt + H"));
   main_layout->addStretch(0);
 
   setStyleSheet("QLabel{color:darkGray;}");
+  setBackgroundRole(QPalette::Base);
+  setAutoFillBackground(true);
 }


### PR DESCRIPTION
1. changed the background to the QPalette::Base, to makes the left and right borders more obvious.
2. add a label "<-Select a message to to view details"

![Screenshot from 2023-02-08 20-50-24](https://user-images.githubusercontent.com/27770/217534954-e0e7b5ca-16df-4b98-ac0c-ecff88dd627a.png)

before:
![image](https://user-images.githubusercontent.com/27770/217535053-18eca3ff-81bd-4750-b924-6158d8021956.png)
