### PR TITLE
add g++-12 dependancy for Ubuntu 22.04

### DIFF
--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -86,6 +86,7 @@ function install_ubuntu_lts_latest_requirements() {
   install_ubuntu_common_requirements
 
   $SUDO apt-get install -y --no-install-recommends \
+    g++-12 \
     qtbase5-dev \
     qtchooser \
     qt5-qmake \


### PR DESCRIPTION
scons -u -j8 gave clang++ not finding iostream and others. 

Similar error found online:
https://askubuntu.com/questions/1449769/clang-cannot-find-iostream

solution at the bottom of the page worked. installed g++-12 and built fine after that.

