### PR TITLE
cabana: fix coredump caused by getColor in updateSeries

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -525,7 +525,7 @@ void ChartView::updateSeries(const Signal *sig, const std::vector<Event *> *even
         s.vals.clear();
         s.vals.reserve(settings.max_cached_minutes * 60 * 100);  // [n]seconds * 100hz
         s.last_value_mono_time = 0;
-        s.series->setColor(getColor(sig));
+        s.series->setColor(getColor(s.sig));
       }
 
       struct Chunk {


### PR DESCRIPTION
fixed coredump:

> Core was generated by `./_cabana --demo'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  getColor (sig=0x0) at tools/cabana/util.cc:104
104	  float h = 19 * (float)sig->lsb / 64.0;
[Current thread is 1 (Thread 0x7fef25ab2700 (LWP 101071))]
