### PR TITLE
cabana: set series color in createSeries

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -365,7 +365,7 @@ ChartView::ChartView(QWidget *parent) : QChartView(nullptr, parent) {
 }
 
 void ChartView::addSeries(const QString &msg_id, const Signal *sig) {
-  QXYSeries *series = createSeries(series_type);
+  QXYSeries *series = createSeries(series_type, getColor(sig));
   chart()->addSeries(series);
   series->attachAxis(axis_x);
   series->attachAxis(axis_y);
@@ -519,7 +519,6 @@ void ChartView::updateSeries(const Signal *sig, const std::vector<Event *> *even
         s.vals.clear();
         s.vals.reserve(settings.max_cached_minutes * 60 * 100);  // [n]seconds * 100hz
         s.last_value_mono_time = 0;
-        s.series->setColor(getColor(s.sig));
       }
 
       struct Chunk {
@@ -777,13 +776,14 @@ void ChartView::drawForeground(QPainter *painter, const QRectF &rect) {
   }
 }
 
-QXYSeries *ChartView::createSeries(QAbstractSeries::SeriesType type) {
+QXYSeries *ChartView::createSeries(QAbstractSeries::SeriesType type, QColor color) {
   QXYSeries *series = nullptr;
   if (type == QAbstractSeries::SeriesTypeLine) {
     series = new QLineSeries(this);
   } else {
     series = new QScatterSeries(this);
   }
+  series->setColor(color);
     // TODO: Due to a bug in CameraWidget the camera frames
     // are drawn instead of the graphs on MacOS. Re-enable OpenGL when fixed
 #ifndef __APPLE__
@@ -802,7 +802,7 @@ void ChartView::setSeriesType(QAbstractSeries::SeriesType type) {
       s.series->deleteLater();
     }
     for (auto &s : sigs) {
-      auto series = createSeries(series_type);
+      auto series = createSeries(series_type, getColor(s.sig));
       chart()->addSeries(series);
       series->attachAxis(axis_x);
       series->attachAxis(axis_y);

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -520,6 +520,7 @@ void ChartView::updateSeries(const Signal *sig, const std::vector<Event *> *even
         s.vals.reserve(settings.max_cached_minutes * 60 * 100);  // [n]seconds * 100hz
         s.last_value_mono_time = 0;
       }
+      s.series->setColor(getColor(s.sig));
 
       struct Chunk {
         std::vector<Event *>::const_iterator first, second;

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -76,7 +76,7 @@ private:
   void drawForeground(QPainter *painter, const QRectF &rect) override;
   std::tuple<double, double, int> getNiceAxisNumbers(qreal min, qreal max, int tick_count);
   qreal niceNumber(qreal x, bool ceiling);
-  QXYSeries *createSeries(QAbstractSeries::SeriesType type);
+  QXYSeries *createSeries(QAbstractSeries::SeriesType type, QColor color);
   void updateSeriesPoints();
 
   int y_label_width = 0;


### PR DESCRIPTION
Fixed the issue that the  series color will be reset to default color after switching type:

[Kazam_screencast_00016.webm](https://user-images.githubusercontent.com/27770/217867690-88a9eca8-d490-4a5b-ae5a-37b76dd03ca5.webm)

after:

[Kazam_screencast_00014.webm](https://user-images.githubusercontent.com/27770/217868168-7565082c-7ce6-4b2c-aee3-5fa730a5561d.webm)
