### PR TITLE
GM: fix possible steering message counter duplication

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -62,8 +62,8 @@ class CarController:
       if not self.sent_lka_steering_cmd or out_of_sync:
         steer_step = self.params.STEER_STEP
 
-    if CS.loopback_lka_steering_cmd_updated:
-      self.lka_steering_cmd_counter += 1
+    if CS.loopback_lka_steering_cmd_msgs != 0:
+      self.lka_steering_cmd_counter += CS.loopback_lka_steering_cmd_msgs
       self.sent_lka_steering_cmd = True
 
     # Avoid GM EPS faults when transmitting messages too close together: skip this transmit if we

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -17,7 +17,7 @@ class CarState(CarStateBase):
     super().__init__(CP)
     can_define = CANDefine(DBC[CP.carFingerprint]["pt"])
     self.shifter_values = can_define.dv["ECMPRDNL2"]["PRNDL2"]
-    self.loopback_lka_steering_cmd_updated = False
+    self.loopback_lka_steering_cmd_msgs = 0
     self.loopback_lka_steering_cmd_ts_nanos = 0
     self.pt_lka_steering_cmd_counter = 0
     self.cam_lka_steering_cmd_counter = 0
@@ -33,7 +33,7 @@ class CarState(CarStateBase):
     self.moving_backward = pt_cp.vl["EBCMWheelSpdRear"]["MovingBackward"] != 0
 
     # Variables used for avoiding LKAS faults
-    self.loopback_lka_steering_cmd_updated = len(loopback_cp.vl_all["ASCMLKASteeringCmd"]["RollingCounter"]) > 0
+    self.loopback_lka_steering_cmd_msgs = len(loopback_cp.vl_all["ASCMLKASteeringCmd"]["RollingCounter"])
     self.loopback_lka_steering_cmd_ts_nanos = loopback_cp.ts_nanos["ASCMLKASteeringCmd"]["RollingCounter"]
     if self.CP.networkLocation == NetworkLocation.fwdCamera:
       self.pt_lka_steering_cmd_counter = pt_cp.vl["ASCMLKASteeringCmd"]["RollingCounter"]


### PR DESCRIPTION
After thinking this out, this doesn't make sense. We already handle this pretty well. If OP were to lag so much that we didn't get a readback frame in three 10 ms frames and send a duplicate counter, then all of a sudden get *two* 128 confirmations, the car would see:

0 -> 0 (OP GETS READBACKS) -> 2

And on master, we'd handle this to the best of our ability by only incrementing once (we still would send a duplicate frame, thinking the steering message got blocked somehow):

0 -> 0 (OP GETS READBACKS) -> 1