### PR TITLE
GM camera ACC: display speed on cluster

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -52,7 +52,8 @@ class CarState(CarStateBase):
 
     # Cluster speed is likely on low speed GMLAN for ASCM cars
     if self.CP.networkLocation == NetworkLocation.fwdCamera:
-      ret.vEgoCluster = pt_cp.vl["SPEED_RELATED"]["ClusterSpeed"]
+      # TODO: make sure units are always kph
+      ret.vEgoCluster = pt_cp.vl["SPEED_RELATED"]["ClusterSpeed"] * CV.KPH_TO_MS
 
     if pt_cp.vl["ECMPRDNL2"]["ManualMode"] == 1:
       ret.gearShifter = self.parse_gear_shifter("T")

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -50,6 +50,10 @@ class CarState(CarStateBase):
     # sample rear wheel speeds, standstill=True if ECM allows engagement with brake
     ret.standstill = ret.wheelSpeeds.rl <= STANDSTILL_THRESHOLD and ret.wheelSpeeds.rr <= STANDSTILL_THRESHOLD
 
+    # Cluster speed is likely on low speed GMLAN for ASCM cars
+    if self.CP.networkLocation == NetworkLocation.fwdCamera:
+      ret.vEgoCluster = pt_cp.vl["SPEED_RELATED"]["ClusterSpeed"]
+
     if pt_cp.vl["ECMPRDNL2"]["ManualMode"] == 1:
       ret.gearShifter = self.parse_gear_shifter("T")
     else:
@@ -184,13 +188,14 @@ class CarState(CarStateBase):
       ("ECMAcceleratorPos", 80),
     ]
 
-    # Used to read back last counter sent to PT by camera
     if CP.networkLocation == NetworkLocation.fwdCamera:
       signals += [
+        ("ClusterSpeed", "SPEED_RELATED"),
         ("RollingCounter", "ASCMLKASteeringCmd"),
       ]
       checks += [
-        ("ASCMLKASteeringCmd", 0),
+        ("SPEED_RELATED", 10),
+        ("ASCMLKASteeringCmd", 0),  # Used to read back last counter sent to PT by camera
       ]
 
     if CP.transmissionType == TransmissionType.direct:

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -23,6 +23,9 @@ class CarState(CarStateBase):
     self.cam_lka_steering_cmd_counter = 0
     self.buttons_counter = 0
 
+    self.cluster_speed_hyst_gap = CV.KPH_TO_MS / 2.
+    self.cluster_min_speed = CV.KPH_TO_MS / 2.
+
   def update(self, pt_cp, cam_cp, loopback_cp):
     ret = car.CarState.new_message()
 
@@ -50,10 +53,12 @@ class CarState(CarStateBase):
     # sample rear wheel speeds, standstill=True if ECM allows engagement with brake
     ret.standstill = ret.wheelSpeeds.rl <= STANDSTILL_THRESHOLD and ret.wheelSpeeds.rr <= STANDSTILL_THRESHOLD
 
-    # Cluster speed is likely on low speed GMLAN for ASCM cars
-    if self.CP.networkLocation == NetworkLocation.fwdCamera:
-      # TODO: make sure units are always kph
-      ret.vEgoCluster = pt_cp.vl["SPEED_RELATED"]["ClusterSpeed"] * CV.KPH_TO_MS
+    ret.vEgoCluster = ret.vEgo * 1.005
+
+    # # Cluster speed is likely on low speed GMLAN for ASCM cars
+    # if self.CP.networkLocation == NetworkLocation.fwdCamera:
+    #   # TODO: make sure units are always kph
+    #   ret.vEgoCluster = pt_cp.vl["SPEED_RELATED"]["ClusterSpeed"] * CV.KPH_TO_MS
 
     if pt_cp.vl["ECMPRDNL2"]["ManualMode"] == 1:
       ret.gearShifter = self.parse_gear_shifter("T")


### PR DESCRIPTION
Message appears to exist on some ASCM cars, but is all zeros, except the first byte at `0xc8`. Quickly checked and didn't see any other similar message for the Volt.

opendbc PR: https://github.com/commaai/opendbc/pull/780

TODO:
- [ ] Check units
- [ ] Check it exists on all camera ACC cars