### PR TITLE
cabana: fix the text of signal value being clipped

### DIFF
--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -82,6 +82,12 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   QStyleOptionViewItemV4 opt = option;
   initStyleOption(&opt, index);
 
+  auto byte_list = opt.text.split(" ");
+  if (byte_list.size() <= 1) {
+    QStyledItemDelegate::paint(painter, option, index);
+    return;
+  }
+
   if ((option.state & QStyle::State_Selected) && (option.state & QStyle::State_Active)) {
     painter->setPen(option.palette.color(QPalette::HighlightedText));
   } else {
@@ -98,7 +104,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 
   QList<QVariant> colors = index.data(Qt::UserRole).toList();
   int i = 0;
-  for (auto &byte : opt.text.split(" ")) {
+  for (auto &byte : byte_list) {
     if (i < colors.size()) {
       painter->fillRect(pos.marginsAdded(margins), colors[i].value<QColor>());
     }


### PR DESCRIPTION
before:
![Screenshot from 2023-02-10 15-20-12](https://user-images.githubusercontent.com/27770/218028047-1ffdcd73-8326-4f7a-bab6-d3136cbd863b.png)


after:
![Screenshot from 2023-02-10 15-20-54](https://user-images.githubusercontent.com/27770/218028041-37714834-644a-43bf-afc6-928a44717f92.png)
