### PR TITLE
cabana: draw borders around signals

### DIFF
--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -13,6 +13,7 @@ public:
   BinaryItemDelegate(QObject *parent);
   void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   void setSelectionColor(const QColor &color) { selection_color = color; }
+  bool isSameColor(const QModelIndex &index, int dx, int dy) const;
 
   QFont small_font, hex_font;
   QColor selection_color;


### PR DESCRIPTION
After adding bit level highlighting it was a bit harder to see where the signal edges where. This should make things more clear. Had to move LSB/MSB indicators up slightly to make everything fit.

![Screenshot 2023-02-10 at 10 34 24](https://user-images.githubusercontent.com/1314752/218056548-0699e4e6-52f0-43c8-bb05-511001199352.png)

As you can see if the shape is concave very small gaps appear at the two inside corners. If you want I can add a bunch more code to handle this case, or we leave it like this.
![Screenshot 2023-02-10 at 10 34 47](https://user-images.githubusercontent.com/1314752/218056542-39f080d3-7450-4326-8d0c-88de8562524d.png)


Before:
![Screenshot 2023-02-10 at 10 40 13](https://user-images.githubusercontent.com/1314752/218057894-1afbe7fd-82be-4ebd-8e64-43f47f3f392d.png)