### PR TITLE
cabana: set legend marker shape by the series type

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -781,8 +781,10 @@ QXYSeries *ChartView::createSeries(QAbstractSeries::SeriesType type, QColor colo
   QXYSeries *series = nullptr;
   if (type == QAbstractSeries::SeriesTypeLine) {
     series = new QLineSeries(this);
+    chart()->legend()->setMarkerShape(QLegend::MarkerShapeRectangle);
   } else {
     series = new QScatterSeries(this);
+    chart()->legend()->setMarkerShape(QLegend::MarkerShapeCircle);
   }
   series->setColor(color);
     // TODO: Due to a bug in CameraWidget the camera frames


### PR DESCRIPTION
The marker shape is determined by the series type:

![2023-02-11_04-01](https://user-images.githubusercontent.com/27770/218186732-0e6fcc6b-1f45-438b-a048-2846fd666719.png)
