### PR TITLE
GM: add permanent ACC fault signal

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -100,7 +100,8 @@ class CarState(CarStateBase):
     ret.parkingBrake = pt_cp.vl["VehicleIgnitionAlt"]["ParkBrake"] == 1
     ret.cruiseState.available = pt_cp.vl["ECMEngineStatus"]["CruiseMainOn"] != 0
     ret.espDisabled = pt_cp.vl["ESPStatus"]["TractionControlOn"] != 1
-    ret.accFaulted = pt_cp.vl["AcceleratorPedal2"]["CruiseState"] == AccState.FAULTED
+    ret.accFaulted = (pt_cp.vl["AcceleratorPedal2"]["CruiseState"] == AccState.FAULTED or
+                      pt_cp.vl["EBCMFrictionBrakeStatus"]["FrictionBrakeUnavailable"] == 1)
 
     ret.cruiseState.enabled = pt_cp.vl["AcceleratorPedal2"]["CruiseState"] != AccState.OFF
     ret.cruiseState.standstill = pt_cp.vl["AcceleratorPedal2"]["CruiseState"] == AccState.STANDSTILL
@@ -155,6 +156,7 @@ class CarState(CarStateBase):
       ("RLWheelSpd", "EBCMWheelSpdRear"),
       ("RRWheelSpd", "EBCMWheelSpdRear"),
       ("MovingBackward", "EBCMWheelSpdRear"),
+      ("FrictionBrakeUnavailable", "EBCMFrictionBrakeStatus"),
       ("PRNDL2", "ECMPRDNL2"),
       ("ManualMode", "ECMPRDNL2"),
       ("LKADriverAppldTrq", "PSCMStatus"),
@@ -180,6 +182,7 @@ class CarState(CarStateBase):
       ("VehicleIgnitionAlt", 10),
       ("EBCMWheelSpdFront", 20),
       ("EBCMWheelSpdRear", 20),
+      ("EBCMFrictionBrakeStatus", 20),
       ("AcceleratorPedal2", 33),
       ("ASCMSteeringButton", 33),
       ("ECMEngineStatus", 100),


### PR DESCRIPTION
Catches some permanent ACC faults that aren't represented in the current ACC fault signal (which is related to the ECM). I believe this new signal is from the EBCM, since only brakes are affected (ECM allows engagement fine). The stock camera blocks engagement in this state, so this is a good idea to check.

opendbc PR: https://github.com/commaai/opendbc/pull/782

```python
Last 90 days:
Loaded 5671 segments
Cars in mkv data:
CHEVROLET SILVERADO 1500 2020: 451 mkv segments
CADILLAC ATS Premium Performance 2018: 1 mkv segments
CHEVROLET BOLT EUV 2022: 2894 mkv segments
GMC ACADIA DENALI 2018: 104 mkv segments
CHEVROLET VOLT PREMIER 2017: 2221 mkv segments
```

No failed asserts with this mask:

```python
for r in results:
  segment, perm_faults, can_valids, ignitions, platform = r

  if can_valids.count(False) > 100:
    print('CAN not valid:', platform)
    continue
  
  if len(perm_faults) < 3000:
    continue
    
  if not all(ignitions):
    continue
    
  if segment in (
    "1092d371df987f78|2023-02-05--16-56-57--4",  # Silverado FP as Acadia
    "9e27a5ad608f9b5d|2023-01-26--18-21-39--5",  # Bolt EUV FP as Acadia
    "9e27a5ad608f9b5d|2023-01-26--18-21-39--2",  # Bolt EUV FP as Acadia
    "894c916ba5d876c1|2023-01-16--13-16-25--2",  # Bolt EUV FP as Volt
    "d1f7b11f0190e0bc|2022-11-20--16-09-09--8",  # Bolt EUV FP as Volt
    "9e27a5ad608f9b5d|2023-02-08--15-57-01--10", # Bolt EUV FP as Volt
    "a8632896bc8c451f|2023-02-04--14-37-00--10", # Bolt EUV, camera stops sending msgs
    "d36d20eb6a0ec201|2022-12-15--11-53-25--4",  # Bolt EUV, last segment
    "a8632896bc8c451f|2022-12-13--05-44-22--52", # Bolt EUV FP as Volt
    "9e27a5ad608f9b5d|2023-02-08--15-57-01--16", # Bolt EUV FP as Volt
    "3140e1c6195c880e|2022-11-15--01-16-31--6",  # Rose at the end of the segment, not sure
    "6e997623cb7cdaa6|2023-02-07--00-39-26--2",  # Don't remember what I was doing, but comma Bolt, lots of local diff
    "a8632896bc8c451f|2023-01-06--20-24-35--12", # Missing bus 2 traffic, existing ACC fault signal is also 1
    
    ):
    continue


  assert not any(perm_faults)
```