### PR TITLE
boardd: retry on bad SPI RX data len

### DIFF
--- a/selfdrive/boardd/spi.cc
+++ b/selfdrive/boardd/spi.cc
@@ -316,7 +316,10 @@ int PandaSpiHandle::spi_transfer(uint8_t endpoint, uint8_t *tx_data, uint16_t tx
     goto transfer_fail;
   }
   rx_data_len = *(uint16_t *)(rx_buf+1);
-  assert(rx_data_len < SPI_BUF_SIZE);
+  if (rx_data_len >= SPI_BUF_SIZE) {
+    LOGE("SPI: RX data len larger than buf size %d", rx_data_len);
+    goto transfer_fail;
+  }
 
   // Read data
   transfer.len = rx_data_len + 1;


### PR DESCRIPTION
This assert started getting hit after adding a timeout in the SPI driver: https://github.com/commaai/panda/pull/1223. boardd lags more than the SPI driver's timeout and ends up with the predefined under-run values (`0xcdcd`) for the RX data len. Bad RX data lengths less than `SPI_BUF_SIZE` will be caught after receiving the data while verifying the checksum.