### PR TITLE
cabana: cacnel signal highlighting on leaveEvent

### DIFF
--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -449,3 +449,8 @@ void SignalView::signalHovered(const Signal *sig) {
     }
   }
 }
+
+void SignalView::leaveEvent(QEvent *event) {
+  emit highlight(nullptr);
+  QWidget::leaveEvent(event);
+}

--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -89,6 +89,7 @@ signals:
 
 private:
   void rowsChanged();
+  void leaveEvent(QEvent *event);
 
   QString msg_id;
   QTreeView *tree;


### PR DESCRIPTION
fixed the issue that signal stays highlighted after mouse leaved the signal view.