### PR TITLE
cabana: fix crash in BinaryView::refresh

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -143,8 +143,8 @@ void BinaryView::refresh() {
   anchor_index = QModelIndex();
   resize_sig = nullptr;
   hovered_sig = nullptr;
-  highlightPosition(QCursor::pos());
   model->refresh();
+  highlightPosition(QCursor::pos());
 }
 
 QSet<const Signal *> BinaryView::getOverlappingSignals() const {


### PR DESCRIPTION
`highlightPosition` should be called after `model->refresh`. Otherwise `item->sig` may be invalid, which will cause a crash:

`    Message: Process 2346578 (_cabana) of user 1000 dumped core.
                
                Stack trace of thread 2346578:
                #0  0x00000000004785af _ZN10BinaryView17highlightPositionERK6QPoint (/media/home/deanlee/openpilot/tools/cabana/_cabana + 0x785af)
                
                Stack trace of thread 2346610:
                #0  0x00007f3d78ef623f n/a (n/a + 0x0)
`