### PR TITLE
process replay: don't upload if diff doesn't exist

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -246,7 +246,6 @@ jobs:
       run: |
         ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run replay
-      continue-on-error: true
       run: |
         (exit 1)
     - name: Print diff

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -259,6 +259,7 @@ jobs:
         name: process_replay_diff.txt
         path: selfdrive/test/process_replay/diff.txt
     - name: debug
+      if: always()
       run: |
         echo ${{ steps.print_diff.outcome }} || true
         echo "$steps.print_diff.outcome" || true

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -265,7 +265,7 @@ jobs:
         echo ${{ steps.print_diff.conclusion }}
         echo "steps.print_diff.conclusion"
     - name: Upload reference logs
-      if: ${{ steps.print_diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
+      if: ${{ github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }} && steps.print_diff.outcome == 'success'
       run: |
         ${{ env.RUN }} "CI=1 AZURE_TOKEN='$AZURE_TOKEN' python selfdrive/test/process_replay/test_processes.py -j$(nproc) --upload-only"
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -250,7 +250,7 @@ jobs:
       run: |
         (exit 1)
     - name: Print diff
-      id: print_diff
+      id: print-diff
       if: always()
       run: cat selfdrive/test/process_replay/diff.txt
     - uses: actions/upload-artifact@v2
@@ -259,15 +259,8 @@ jobs:
       with:
         name: process_replay_diff.txt
         path: selfdrive/test/process_replay/diff.txt
-    - name: debug
-      if: always()
-      run: |
-        echo ${{ steps.print_diff.outcome }} || true
-        echo "$steps.print_diff.outcome" || true
-        echo ${{ steps.print_diff.conclusion }} || true
-        echo "steps.print_diff.conclusion" || true
     - name: Upload reference logs
-      if: ${{ failure() && steps.print_diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
+      if: ${{ failure() && steps.print-diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
       run: |
         ${{ env.RUN }} "CI=1 AZURE_TOKEN='$AZURE_TOKEN' python selfdrive/test/process_replay/test_processes.py -j$(nproc) --upload-only"
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -251,7 +251,7 @@ jobs:
     - name: Print diff
       id: print-diff
       if: always()
-      run: cat selfdrive/test/process_replay/diff.txt
+      run: echo "successful"
     - uses: actions/upload-artifact@v2
       if: always()
       continue-on-error: true

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -252,7 +252,7 @@ jobs:
     - name: Print diff
       id: print_diff
       if: always()
-      run: echo "should be successful"
+      run: cat selfdrive/test/process_replay/diff.txt
     - uses: actions/upload-artifact@v2
       if: always()
       continue-on-error: true
@@ -267,7 +267,7 @@ jobs:
         echo ${{ steps.print_diff.conclusion }} || true
         echo "steps.print_diff.conclusion" || true
     - name: Upload reference logs
-      if: ${{ steps.print_diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
+      if: ${{ failure() && steps.print_diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
       run: |
         ${{ env.RUN }} "CI=1 AZURE_TOKEN='$AZURE_TOKEN' python selfdrive/test/process_replay/test_processes.py -j$(nproc) --upload-only"
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -246,6 +246,7 @@ jobs:
       run: |
         ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run replay
+      continue-on-error: true
       run: |
         (exit 1)
     - name: Print diff
@@ -266,7 +267,7 @@ jobs:
         echo ${{ steps.print_diff.conclusion }} || true
         echo "steps.print_diff.conclusion" || true
     - name: Upload reference logs
-      if: ${{ github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }} && steps.print_diff.outcome == 'success'
+      if: ${{ steps.print_diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
       run: |
         ${{ env.RUN }} "CI=1 AZURE_TOKEN='$AZURE_TOKEN' python selfdrive/test/process_replay/test_processes.py -j$(nproc) --upload-only"
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -247,11 +247,12 @@ jobs:
         ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run replay
       run: |
-        (exit 1)
+        ${{ env.RUN }} "CI=1 coverage run selfdrive/test/process_replay/test_processes.py -j$(nproc) && \
+                        coverage xml"
     - name: Print diff
       id: print-diff
       if: always()
-      run: echo "successful"
+      run: cat selfdrive/test/process_replay/diff.txt
     - uses: actions/upload-artifact@v2
       if: always()
       continue-on-error: true

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -260,10 +260,10 @@ jobs:
         path: selfdrive/test/process_replay/diff.txt
     - name: debug
       run: |
-        echo ${{ steps.print_diff.outcome }}
-        echo "$steps.print_diff.outcome"
-        echo ${{ steps.print_diff.conclusion }}
-        echo "steps.print_diff.conclusion"
+        echo ${{ steps.print_diff.outcome }} || true
+        echo "$steps.print_diff.outcome" || true
+        echo ${{ steps.print_diff.conclusion }} || true
+        echo "steps.print_diff.conclusion" || true
     - name: Upload reference logs
       if: ${{ github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }} && steps.print_diff.outcome == 'success'
       run: |

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -258,6 +258,12 @@ jobs:
       with:
         name: process_replay_diff.txt
         path: selfdrive/test/process_replay/diff.txt
+    - name: debug
+      run: |
+        echo ${{ steps.print_diff.outcome }}
+        echo "$steps.print_diff.outcome"
+        echo ${{ steps.print_diff.conclusion }}
+        echo "steps.print_diff.conclusion"
     - name: Upload reference logs
       if: ${{ steps.print_diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
       run: |

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -247,11 +247,10 @@ jobs:
         ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run replay
       run: |
-        ${{ env.RUN }} "CI=1 coverage run selfdrive/test/process_replay/test_processes.py -j$(nproc) && \
-                        coverage xml"
+        (exit 1)
     - name: Print diff
       if: always()
-      run: cat selfdrive/test/process_replay/diff.txt
+      run: echo "should be successful"
     - uses: actions/upload-artifact@v2
       if: always()
       continue-on-error: true

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -249,6 +249,7 @@ jobs:
       run: |
         (exit 1)
     - name: Print diff
+      id: print_diff
       if: always()
       run: echo "should be successful"
     - uses: actions/upload-artifact@v2
@@ -258,7 +259,7 @@ jobs:
         name: process_replay_diff.txt
         path: selfdrive/test/process_replay/diff.txt
     - name: Upload reference logs
-      if: ${{ failure() && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
+      if: ${{ steps.print_diff.outcome == 'success' && github.event_name == 'pull_request' && github.repository == 'commaai/openpilot' && env.AZURE_TOKEN != '' }}
       run: |
         ${{ env.RUN }} "CI=1 AZURE_TOKEN='$AZURE_TOKEN' python selfdrive/test/process_replay/test_processes.py -j$(nproc) --upload-only"
     - name: "Upload coverage to Codecov"


### PR DESCRIPTION
Likely process replay crashed instead of failed, and not all logs are available. No point in wasting container space uploading logs that won't be used