### PR TITLE
cabana: add keyboard shortcuts to binary view

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -62,9 +62,13 @@ void BinaryView::addShortcuts() {
   QShortcut *shortcut_endian = new QShortcut(QKeySequence(Qt::Key_E), this);
   QObject::connect(shortcut_endian, &QShortcut::activated, [=]{
     if (hovered_sig != nullptr) {
+      const Signal *hovered_sig_prev = hovered_sig;
       Signal s = *hovered_sig;
       s.is_little_endian = !s.is_little_endian;
       emit editSignal(hovered_sig, s);
+
+      hovered_sig = nullptr;
+      highlight(hovered_sig_prev);
     }
   });
 
@@ -72,9 +76,13 @@ void BinaryView::addShortcuts() {
   QShortcut *shortcut_sign = new QShortcut(QKeySequence(Qt::Key_S), this);
   QObject::connect(shortcut_sign, &QShortcut::activated, [=]{
     if (hovered_sig != nullptr) {
+      const Signal *hovered_sig_prev = hovered_sig;
       Signal s = *hovered_sig;
       s.is_signed = !s.is_signed;
       emit editSignal(hovered_sig, s);
+
+      hovered_sig = nullptr;
+      highlight(hovered_sig_prev);
     }
   });
 

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -91,7 +91,6 @@ void BinaryView::addShortcuts() {
   });
 }
 
-
 QSize BinaryView::minimumSizeHint() const {
   return {(horizontalHeader()->minimumSectionSize() + 1) * 9 + VERTICAL_HEADER_WIDTH,
           CELL_HEIGHT * std::min(model->rowCount(), 10)};

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -58,7 +58,7 @@ void BinaryView::addShortcuts() {
     }
   });
 
-  // Change endianess (e)
+  // Change endianness (e)
   QShortcut *shortcut_endian = new QShortcut(QKeySequence(Qt::Key_E), this);
   QObject::connect(shortcut_endian, &QShortcut::activated, [=]{
     if (hovered_sig != nullptr) {

--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -68,8 +68,12 @@ signals:
   void signalHovered(const Signal *sig);
   void addSignal(int start_bit, int size, bool little_endian);
   void resizeSignal(const Signal *sig, int from, int size);
+  void removeSignal(const Signal *sig);
+  void editSignal(const Signal *origin_s, Signal &s);
+  void showChart(const QString &name, const Signal *sig, bool show, bool merge);
 
 private:
+  void addShortcuts();
   void refresh();
   std::tuple<int, int, bool> getSelection(QModelIndex index);
   void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -74,6 +74,9 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   QObject::connect(binary_view, &BinaryView::addSignal, signal_view->model, &SignalModel::addSignal);
   QObject::connect(binary_view, &BinaryView::signalHovered, signal_view, &SignalView::signalHovered);
   QObject::connect(binary_view, &BinaryView::signalClicked, signal_view, &SignalView::expandSignal);
+  QObject::connect(binary_view, &BinaryView::editSignal, signal_view->model, &SignalModel::saveSignal);
+  QObject::connect(binary_view, &BinaryView::removeSignal, signal_view->model, &SignalModel::removeSignal);
+  QObject::connect(binary_view, &BinaryView::showChart, charts, &ChartsWidget::showChart);
   QObject::connect(signal_view, &SignalView::showChart, charts, &ChartsWidget::showChart);
   QObject::connect(signal_view, &SignalView::highlight, binary_view, &BinaryView::highlight);
   QObject::connect(tab_widget, &QTabWidget::currentChanged, [this]() { updateState(); });


### PR DESCRIPTION
- Delete signal: x, backspace, delete
- Toggle endianness: e
- Toggle signedness: s
- Open chart: c, p, g (Chart, Plot, Graph)

Any thoughts on how to explain this to the user?