### PR TITLE
Hyundai: temporarily remove Tucson FW that requires different tuning

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1562,7 +1562,6 @@ FW_VERSIONS = {
   CAR.TUCSON_4TH_GEN: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9240 14T',
-      b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-CW010 14X',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NX4__               1.01 1.00 99110-N9100         ',


### PR DESCRIPTION
The other FW version behaves just like the rest of the CAN-FD Hyundai models, but this one requires different tuning. See commaai/opendbc#1115