### PR TITLE
FPv2: log responses from data collection queries

### DIFF
--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -57,6 +57,8 @@ class Request:
   whitelist_ecus: List[int] = field(default_factory=list)
   rx_offset: int = 0x8
   bus: int = 1
+  # FW responses from these queries will not be used for fingerprinting
+  logging: bool = False
 
 
 @dataclass

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -233,18 +233,9 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
   parallel_addrs = []
   logging_addrs = []
   ecu_types = {}
-  # logging_addrs = defaultdict(list)
 
   for brand, brand_versions in versions.items():
-    # print(brand, brand_versions.keys())
-    # print(brand, brand_versions["debug"])
     for candidate, ecu in brand_versions.items():
-      # if brand not in logging_addrs:
-      #   logging_addrs[brand] = []
-      # if car == "debug":
-      #   logging_addrs.append() [brand].append(ecu)
-      #   # logging_addrs[brand].append(ecu)
-
       for ecu_type, addr, sub_addr in ecu.keys():
         a = (brand, addr, sub_addr)
         if a not in ecu_types:
@@ -261,14 +252,12 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
             addrs.append([a])
 
   addrs.insert(0, parallel_addrs)
-  print('logging', logging_addrs)
 
   # Get versions and build capnp list to put into CarParams
   car_fw = []
   requests = [(brand, r) for brand, r in REQUESTS if query_brand is None or brand == query_brand]
   for addr in tqdm(addrs, disable=not progress):
     for addr_chunk in chunks(addr):
-      # print(addr_chunk)
       for brand, r in requests:
         # Skip query if no panda available
         if r.bus > num_pandas * 4 - 1:

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -231,14 +231,27 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
   # ECUs using a subaddress need be queried one by one, the rest can be done in parallel
   addrs = []
   parallel_addrs = []
+  logging_addrs = []
   ecu_types = {}
+  # logging_addrs = defaultdict(list)
 
   for brand, brand_versions in versions.items():
-    for c in brand_versions.values():
-      for ecu_type, addr, sub_addr in c.keys():
+    # print(brand, brand_versions.keys())
+    # print(brand, brand_versions["debug"])
+    for candidate, ecu in brand_versions.items():
+      # if brand not in logging_addrs:
+      #   logging_addrs[brand] = []
+      # if car == "debug":
+      #   logging_addrs.append() [brand].append(ecu)
+      #   # logging_addrs[brand].append(ecu)
+
+      for ecu_type, addr, sub_addr in ecu.keys():
         a = (brand, addr, sub_addr)
         if a not in ecu_types:
           ecu_types[a] = ecu_type
+
+        if a not in logging_addrs and candidate == "debug":
+          logging_addrs.append(a)
 
         if sub_addr is None:
           if a not in parallel_addrs:
@@ -248,12 +261,14 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
             addrs.append([a])
 
   addrs.insert(0, parallel_addrs)
+  print('logging', logging_addrs)
 
   # Get versions and build capnp list to put into CarParams
   car_fw = []
   requests = [(brand, r) for brand, r in REQUESTS if query_brand is None or brand == query_brand]
   for addr in tqdm(addrs, disable=not progress):
     for addr_chunk in chunks(addr):
+      # print(addr_chunk)
       for brand, r in requests:
         # Skip query if no panda available
         if r.bus > num_pandas * 4 - 1:
@@ -268,14 +283,15 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
             for (tx_addr, sub_addr), version in query.get_data(timeout).items():
               f = car.CarParams.CarFw.new_message()
 
-              f.ecu = ecu_types.get((brand, tx_addr, sub_addr), Ecu.unknown)
+              ecu_key = (brand, tx_addr, sub_addr)
+              f.ecu = ecu_types.get(ecu_key, Ecu.unknown)
               f.fwVersion = version
               f.address = tx_addr
               f.responseAddress = uds.get_rx_addr_for_tx_addr(tx_addr, r.rx_offset)
               f.request = r.request
               f.brand = brand
               f.bus = r.bus
-              f.logging = r.logging
+              f.logging = r.logging or ecu_key in logging_addrs
 
               if sub_addr is not None:
                 f.subAddress = sub_addr

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -29,7 +29,7 @@ def chunks(l, n=128):
 def build_fw_dict(fw_versions, filter_brand=None):
   fw_versions_dict = defaultdict(set)
   for fw in fw_versions:
-    if filter_brand is None or fw.brand == filter_brand:
+    if (filter_brand is None or fw.brand == filter_brand) and not fw.logging:
       addr = fw.address
       sub_addr = fw.subAddress if fw.subAddress != 0 else None
       fw_versions_dict[(addr, sub_addr)].add(fw.fwVersion)

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -276,6 +276,7 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
               f.request = r.request
               f.brand = brand
               f.bus = r.bus
+              f.logging = r.logging
 
               if sub_addr is not None:
                 f.subAddress = sub_addr

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -29,13 +29,9 @@ def chunks(l, n=128):
 def build_fw_dict(fw_versions, filter_brand=None):
   fw_versions_dict = defaultdict(set)
   for fw in fw_versions:
-    if fw.logging:
-      continue
-    if filter_brand is not None and fw.brand != filter_brand:
-      continue
-    addr = fw.address
-    sub_addr = fw.subAddress if fw.subAddress != 0 else None
-    fw_versions_dict[(addr, sub_addr)].add(fw.fwVersion)
+    if (filter_brand is None or fw.brand == filter_brand) and not fw.logging:
+      sub_addr = fw.subAddress if fw.subAddress != 0 else None
+      fw_versions_dict[(fw.address, sub_addr)].add(fw.fwVersion)
   return dict(fw_versions_dict)
 
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -29,10 +29,13 @@ def chunks(l, n=128):
 def build_fw_dict(fw_versions, filter_brand=None):
   fw_versions_dict = defaultdict(set)
   for fw in fw_versions:
-    if (filter_brand is None or fw.brand == filter_brand) and not fw.logging:
-      addr = fw.address
-      sub_addr = fw.subAddress if fw.subAddress != 0 else None
-      fw_versions_dict[(addr, sub_addr)].add(fw.fwVersion)
+    if fw.logging:
+      continue
+    if filter_brand is not None and fw.brand != filter_brand:
+      continue
+    addr = fw.address
+    sub_addr = fw.subAddress if fw.subAddress != 0 else None
+    fw_versions_dict[(addr, sub_addr)].add(fw.fwVersion)
   return dict(fw_versions_dict)
 
 

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -171,12 +171,14 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HONDA_VERSION_REQUEST],
       [HONDA_VERSION_RESPONSE],
       bus=1,
+      logging=True
     ),
     # Query Nidec PT bus from camera for data collection
     Request(
       [StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.UDS_VERSION_RESPONSE],
       bus=0,
+      logging=True
     ),
   ],
   extra_ecus=[

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -184,7 +184,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
   extra_ecus=[
     # The only other ECU on PT bus accessible by camera on radarless Civic
     (Ecu.unknown, 0x18DAB3F1, None),
-    (Ecu.programmedFuelInjection, 0x18da10f1, None),
   ],
 )
 

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -184,6 +184,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   extra_ecus=[
     # The only other ECU on PT bus accessible by camera on radarless Civic
     (Ecu.unknown, 0x18DAB3F1, None),
+    (Ecu.programmedFuelInjection, 0x18da10f1, None),
   ],
 )
 


### PR DESCRIPTION
Marks responses to queries added for logging, so we don't fingerprint on them later. Fixes a bug where this Civic 2022 always fuzzy fingerprints due to data collection response replacing missing real response (not supported for some reason by the radar on this specific car): https://github.com/commaai/openpilot/pull/27126