### PR TITLE
Honda: HR-V 2023 radarless support

### DIFF
--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -103,7 +103,7 @@ def get_can_signals(CP, gearbox_msg, main_on_sig_msg):
     else:
       checks.append(("CRUISE_PARAMS", 50))
 
-  if CP.carFingerprint in (CAR.ACCORD, CAR.ACCORDH, CAR.CIVIC_BOSCH, CAR.CIVIC_BOSCH_DIESEL, CAR.CRV_HYBRID, CAR.INSIGHT, CAR.ACURA_RDX_3G, CAR.HONDA_E, CAR.CIVIC_2022):
+  if CP.carFingerprint in (CAR.ACCORD, CAR.ACCORDH, CAR.CIVIC_BOSCH, CAR.CIVIC_BOSCH_DIESEL, CAR.CRV_HYBRID, CAR.INSIGHT, CAR.ACURA_RDX_3G, CAR.HONDA_E, CAR.CIVIC_2022, CAR.HRV_2023):
     signals.append(("DRIVERS_DOOR_OPEN", "SCM_FEEDBACK"))
   elif CP.carFingerprint in (CAR.ODYSSEY_CHN, CAR.FREED, CAR.HRV):
     signals.append(("DRIVERS_DOOR_OPEN", "SCM_BUTTONS"))
@@ -176,7 +176,7 @@ class CarState(CarStateBase):
     # panda checks if the signal is non-zero
     ret.standstill = cp.vl["ENGINE_DATA"]["XMISSION_SPEED"] < 1e-5
     # TODO: find a common signal across all cars
-    if self.CP.carFingerprint in (CAR.ACCORD, CAR.ACCORDH, CAR.CIVIC_BOSCH, CAR.CIVIC_BOSCH_DIESEL, CAR.CRV_HYBRID, CAR.INSIGHT, CAR.ACURA_RDX_3G, CAR.HONDA_E, CAR.CIVIC_2022):
+    if self.CP.carFingerprint in (CAR.ACCORD, CAR.ACCORDH, CAR.CIVIC_BOSCH, CAR.CIVIC_BOSCH_DIESEL, CAR.CRV_HYBRID, CAR.INSIGHT, CAR.ACURA_RDX_3G, CAR.HONDA_E, CAR.CIVIC_2022, CAR.HRV_2023):
       ret.doorOpen = bool(cp.vl["SCM_FEEDBACK"]["DRIVERS_DOOR_OPEN"])
     elif self.CP.carFingerprint in (CAR.ODYSSEY_CHN, CAR.FREED, CAR.HRV):
       ret.doorOpen = bool(cp.vl["SCM_BUTTONS"]["DRIVERS_DOOR_OPEN"])

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -267,7 +267,7 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.82
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.18]] # TODO: can probably use some tuning
 
-     elif candidate in (CAR.HRV_2023):
+     elif candidate == CAR.HRV_2023:
       ret.mass = 1305. + STD_CARGO_KG
       ret.wheelbase = 2.61
       ret.centerToFront = ret.wheelbase * 0.52

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -267,6 +267,16 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.82
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.18]] # TODO: can probably use some tuning
 
+     elif candidate in (CAR.HRV_2023):
+      ret.mass = 1305. + STD_CARGO_KG
+      ret.wheelbase = 2.61
+      ret.centerToFront = ret.wheelbase * 0.41
+	  #the remaining parameters were copied from Civic 2022
+      ret.steerRatio = 15.38
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
+      tire_stiffness_factor = 1.
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.8], [0.24]]
+      
     else:
       raise ValueError(f"unsupported car {candidate}")
 

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -270,12 +270,11 @@ class CarInterface(CarInterfaceBase):
      elif candidate in (CAR.HRV_2023):
       ret.mass = 1305. + STD_CARGO_KG
       ret.wheelbase = 2.61
-      ret.centerToFront = ret.wheelbase * 0.41
-	  #the remaining parameters were copied from Civic 2022
+      ret.centerToFront = ret.wheelbase * 0.52
       ret.steerRatio = 15.38
-      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 2560], [0, 2560]]  # TODO: determine if there is a dead zone at the top end
       tire_stiffness_factor = 1.
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.8], [0.24]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[1.1], [0.33]]
       
     else:
       raise ValueError(f"unsupported car {candidate}")

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -267,7 +267,7 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.82
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.18]] # TODO: can probably use some tuning
 
-     elif candidate == CAR.HRV_2023:
+    elif candidate == CAR.HRV_2023:
       ret.mass = 1305. + STD_CARGO_KG
       ret.wheelbase = 2.61
       ret.centerToFront = ret.wheelbase * 0.52

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -95,6 +95,7 @@ class CAR:
   RIDGELINE = "HONDA RIDGELINE 2017"
   INSIGHT = "HONDA INSIGHT 2019"
   HONDA_E = "HONDA E 2020"
+  HRV_2023 = "HONDA HRV 2023 NON US"
 
 
 class Footnote(Enum):
@@ -149,6 +150,7 @@ CAR_INFO: Dict[str, Optional[Union[HondaCarInfo, List[HondaCarInfo]]]] = {
   CAR.RIDGELINE: HondaCarInfo("Honda Ridgeline 2017-22", min_steer_speed=12. * CV.MPH_TO_MS),
   CAR.INSIGHT: HondaCarInfo("Honda Insight 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS),
   CAR.HONDA_E: HondaCarInfo("Honda e 2020", "All", min_steer_speed=3. * CV.MPH_TO_MS),
+  CAR.HRV_2023: HondaCarInfo("Honda HRV 2023 Non US","All"),
 }
 
 HONDA_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
@@ -1492,6 +1494,32 @@ FW_VERSIONS = {
       b'37805-64D-P510\x00\x00',
     ],
   },
+CAR.HRV_2023: {
+    (Ecu.eps, 0x18DA30F1, None): [
+      b'39990-3M0-G110\x00\x00',
+    ],
+    (Ecu.gateway, 0x18DAEFF1, None): [
+      b'38897-3M0-M110\x00\x00',
+    ],
+    (Ecu.srs, 0x18DA53F1, None): [
+      b'77959-3M0-K840\x00\x00',
+    ],
+    (Ecu.combinationMeter, 0x18DA60F1, None): [
+      b'78109-3M0-M310\x00\x00',
+    ],
+    (Ecu.fwdRadar, 0x18DAB0F1, None): [
+      b'8S102-3M6-P030\x00\x00',
+    ],
+    (Ecu.vsa, 0x18DA28F1, None): [
+      b'57114-3M6-M010\x00\x00',
+    ],
+    (Ecu.transmission, 0x18DA1EF1, None): [
+      b'28101-6JC-M310\x00\x00',
+    ],
+    (Ecu.programmedFuelInjection, 0x18DA10F1, None): [
+      b'37805-6HZ-M630\x00\x00',
+    ],
+  },
 }
 
 DBC = {
@@ -1517,6 +1545,7 @@ DBC = {
   CAR.INSIGHT: dbc_dict('honda_insight_ex_2019_can_generated', None),
   CAR.HONDA_E: dbc_dict('acura_rdx_2020_can_generated', None),
   CAR.CIVIC_2022: dbc_dict('honda_civic_ex_2022_can_generated', None),
+  CAR.HRV_2023: dbc_dict('honda_hrv_2023_can_generated', None),
 }
 
 STEER_THRESHOLD = {
@@ -1531,4 +1560,4 @@ HONDA_NIDEC_ALT_SCM_MESSAGES = {CAR.ACURA_ILX, CAR.ACURA_RDX, CAR.CRV, CAR.CRV_E
 HONDA_BOSCH = {CAR.ACCORD, CAR.ACCORDH, CAR.CIVIC_BOSCH, CAR.CIVIC_BOSCH_DIESEL, CAR.CRV_5G,
                CAR.CRV_HYBRID, CAR.INSIGHT, CAR.ACURA_RDX_3G, CAR.HONDA_E, CAR.CIVIC_2022}
 HONDA_BOSCH_ALT_BRAKE_SIGNAL = {CAR.ACCORD, CAR.CRV_5G, CAR.ACURA_RDX_3G}
-HONDA_BOSCH_RADARLESS = {CAR.CIVIC_2022}
+HONDA_BOSCH_RADARLESS = {CAR.CIVIC_2022,CAR.HRV_2023}

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -183,9 +183,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ],
   extra_ecus=[
     # The only other ECU on PT bus accessible by camera on radarless Civic
-    (Ecu.unknown, 0x18DAB3F1, None):[
-      b'36162-T50-E020\x00\x00',
-    ],
+    (Ecu.unknown, 0x18DAB3F1, None)=
   ],
 )
 

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -183,7 +183,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ],
   extra_ecus=[
     # The only other ECU on PT bus accessible by camera on radarless Civic
-    (Ecu.unknown, 0x18DAB3F1, None)=
+    (Ecu.unknown, 0x18DAB3F1, None),
   ],
 )
 
@@ -1518,6 +1518,9 @@ CAR.HRV_2023: {
     ],
     (Ecu.programmedFuelInjection, 0x18DA10F1, None): [
       b'37805-6HZ-M630\x00\x00',
+    ],
+    (Ecu.unknown, 0x18DAB3F1, None):[
+      b'36162-T50-E020\x00\x00',
     ],
   },
 }

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -1545,7 +1545,7 @@ DBC = {
   CAR.INSIGHT: dbc_dict('honda_insight_ex_2019_can_generated', None),
   CAR.HONDA_E: dbc_dict('acura_rdx_2020_can_generated', None),
   CAR.CIVIC_2022: dbc_dict('honda_civic_ex_2022_can_generated', None),
-  CAR.HRV_2023: dbc_dict('honda_hrv_2023_can_generated', None),
+  CAR.HRV_2023: dbc_dict('honda_civic_ex_2022_can_generated', None),
 }
 
 STEER_THRESHOLD = {

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -183,7 +183,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ],
   extra_ecus=[
     # The only other ECU on PT bus accessible by camera on radarless Civic
-    (Ecu.unknown, 0x18DAB3F1, None),
+    (Ecu.unknown, 0x18DAB3F1, None):[
+      b'36162-T50-E020\x00\x00',
+    ],
   ],
 )
 


### PR DESCRIPTION
**Description** Adds Brazilian HRV/Vezel 2023Model
**Verification** Fingerprint
**Route**
Test Route: 147613502316e718|2023-02-14--19-59-09


<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system: