### PR TITLE
cabana: fix updating tabbar_ids on "Close Other Tabs"

### DIFF
--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -103,10 +103,14 @@ void DetailWidget::showTabBarContextMenu(const QPoint &pt) {
     QMenu menu(this);
     menu.addAction(tr("Close Other Tabs"));
     if (menu.exec(tabbar->mapToGlobal(pt))) {
+      tabbar_ids.move(index, 0);
       tabbar->moveTab(index, 0);
       tabbar->setCurrentIndex(0);
-      while (tabbar->count() > 1)
+      while (tabbar->count() > 1) {
+        tabbar_ids.removeAt(1);
         tabbar->removeTab(1);
+      }
+      assert(tabbar_ids.size() == tabbar->count());
     }
   }
 }


### PR DESCRIPTION
Missed keeping the tab bar in sync with the ids on the "close other tabs" action. Would be great if you could attach extra data to the tabbar like on comboboxes...