### PR TITLE
Carla simulator: fix UI crashing

### DIFF
--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -211,7 +211,10 @@ def fake_driver_monitoring(exit_event: threading.Event):
   while not exit_event.is_set():
     # dmonitoringmodeld output
     dat = messaging.new_message('driverStateV2')
+    dat.driverStateV2.leftDriverData.faceOrientation = [0., 0., 0.]
     dat.driverStateV2.leftDriverData.faceProb = 1.0
+    dat.driverStateV2.rightDriverData.faceOrientation = [0., 0., 0.]
+    dat.driverStateV2.rightDriverData.faceProb = 1.0
     pm.send('driverStateV2', dat)
 
     # dmonitoringd output


### PR DESCRIPTION
When running simulator by running `./launch_openpilot.sh` and `./bridge.py --dual-camera` (still investigating why that's needed, I don't get any image without the flag) the UI segfaults without the faceOrientation parameters. Git bisect and a debugging helped find out that the issue was caused by https://github.com/commaai/openpilot/pull/27070/files#diff-b4c3a1489c8e0ba7f36583bd4088a422537e9098c4e82b102b22d57e72c03aceR117

Not sure why other users seem to have more success running the sim though, I get UI crashes on both PCs at home on current master... so if somebody has any time to test if this only fixes UI on simulator on my PC that would be great.