### PR TITLE
cabana: simplify conversions between QVariant and QVector<QColor>

### DIFF
--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -17,7 +17,7 @@ QVariant HistoryLogModel::data(const QModelIndex &index, int role) const {
     }
     return show_signals ? QString::number(m.sig_values[index.column() - 1]) : toHex(m.data);
   } else if (role == Qt::UserRole && index.column() == 1 && !show_signals) {
-    return ChangeTracker::toVariantList(m.colors);
+    return QVariant::fromValue(m.colors);
   }
   return {};
 }

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -121,17 +121,15 @@ QVariant MessageListModel::data(const QModelIndex &index, int role) const {
       case 4: return toHex(can_data.dat);
     }
   } else if (role == Qt::UserRole && index.column() == 4) {
-    QList<QVariant> colors;
-    colors.reserve(can_data.dat.size());
-    for (int i = 0; i < can_data.dat.size(); i++){
-      if (suppressed_bytes.contains({id, i})) {
-        colors.append(QColor(255, 255, 255, 0));
-      } else {
-        colors.append(i < can_data.colors.size() ? can_data.colors[i] : QColor(255, 255, 255, 0));
+    QVector<QColor> colors = can_data.colors;
+    if (!suppressed_bytes.empty()) {
+      for (int i = 0; i < colors.size(); i++) {
+        if (suppressed_bytes.contains({id, i})) {
+          colors[i] = QColor(255, 255, 255, 0);
+        }
       }
     }
-    return colors;
-
+    return QVariant::fromValue(colors);
   }
   return {};
 }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -66,13 +66,6 @@ void ChangeTracker::clear() {
   colors.clear();
 }
 
-QList<QVariant> ChangeTracker::toVariantList(const QVector<QColor> &colors) {
-  QList<QVariant> ret;
-  ret.reserve(colors.size());
-  for (auto &c : colors) ret.append(c);
-  return ret;
-}
-
 // MessageBytesDelegate
 
 MessageBytesDelegate::MessageBytesDelegate(QObject *parent) : QStyledItemDelegate(parent) {
@@ -89,12 +82,8 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     return;
   }
 
-  if ((option.state & QStyle::State_Selected) && (option.state & QStyle::State_Active)) {
-    painter->setPen(option.palette.color(QPalette::HighlightedText));
-  } else {
-    painter->setPen(option.palette.color(QPalette::Text));
-  }
-
+  auto color_role = option.state & QStyle::State_Selected ? QPalette::HighlightedText: QPalette::Text;
+  painter->setPen(option.palette.color(color_role));
   painter->setFont(fixed_font);
   QRect space = painter->boundingRect(opt.rect, opt.displayAlignment, " ");
   QRect pos = painter->boundingRect(opt.rect, opt.displayAlignment, "00");
@@ -103,15 +92,13 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   int m = space.width() / 2;
   const QMargins margins(m, m, m, m);
 
-  QList<QVariant> colors = index.data(Qt::UserRole).toList();
-  int i = 0;
-  for (auto &byte : byte_list) {
+  auto colors = index.data(Qt::UserRole).value<QVector<QColor>>();
+  for (int i = 0; i < byte_list.size(); ++i) {
     if (i < colors.size()) {
-      painter->fillRect(pos.marginsAdded(margins), colors[i].value<QColor>());
+      painter->fillRect(pos.marginsAdded(margins), colors[i]);
     }
-    painter->drawText(pos, opt.displayAlignment, byte);
+    painter->drawText(pos, opt.displayAlignment, byte_list[i]);
     pos.moveLeft(pos.right() + space.width());
-    i++;
   }
 }
 

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -14,7 +14,6 @@
 class ChangeTracker {
 public:
   void compute(const QByteArray &dat, double ts, uint32_t freq);
-  static QList<QVariant> toVariantList(const QVector<QColor> &colors);
   void clear();
 
   QVector<double> last_change_t;


### PR DESCRIPTION
use `QVariant::fromValue` and `QVariant::value` to simplify the conversions.
