### PR TITLE
cabana: attach messageid to tabdata

### DIFF
--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -50,7 +50,6 @@ private:
   ElidedLabel *name_label;
   QWidget *warning_widget;
   QTabBar *tabbar;
-  QList<MessageId> tabbar_ids;
   QTabWidget *tab_widget;
   QAction *remove_msg_act;
   LogsWidget *history_log;


### PR DESCRIPTION
save messageid to tabdata, remove the variable 'message_ids' used to hold the ids. 
also fixed a issues after this change:  setMessage will be called twice on first click

