### PR TITLE
MacOS: build fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -232,6 +232,7 @@ env = Environment(
 
 if arch == "Darwin":
   env['RPATHPREFIX'] = "-rpath "
+  env.PrependENVPath('PATH', '/opt/homebrew/opt/llvm/bin:/opt/homebrew/bin')
 
 if GetOption('compile_db'):
   env.CompilationDatabase('compile_commands.json')
@@ -399,12 +400,14 @@ SConscript(['rednose/SConscript'])
 
 # Build system services
 SConscript([
-  'system/camerad/SConscript',
   'system/clocksd/SConscript',
   'system/proclogd/SConscript',
 ])
 if arch != "Darwin":
-  SConscript(['system/logcatd/SConscript'])
+  SConscript([
+    'system/camerad/SConscript',
+    'system/logcatd/SConscript',
+  ])
 
 # Build openpilot
 
@@ -431,7 +434,8 @@ SConscript(['selfdrive/boardd/SConscript'])
 SConscript(['selfdrive/loggerd/SConscript'])
 
 SConscript(['selfdrive/locationd/SConscript'])
-SConscript(['selfdrive/sensord/SConscript'])
+if arch != "Darwin":
+  SConscript(['selfdrive/sensord/SConscript'])
 SConscript(['selfdrive/ui/SConscript'])
 SConscript(['selfdrive/navd/SConscript'])
 

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -53,11 +53,16 @@ brew "protobuf"
 brew "protobuf-c"
 brew "swig"
 cask "gcc-arm-embedded"
+brew "gcc@12"
 EOS
 
 echo "[ ] finished brew install t=$SECONDS"
 
 BREW_PREFIX=$(brew --prefix)
+
+# set up gcc-12 for panda tests
+ln -s ${BREW_PREFIX}/bin/gcc-12 ${BREW_PREFIX}/bin/gcc
+ln -s ${BREW_PREFIX}/bin/g++-12 ${BREW_PREFIX}/bin/g++
 
 # archive backend tools for pip dependencies
 export LDFLAGS="$LDFLAGS -L${BREW_PREFIX}/opt/zlib/lib"


### PR DESCRIPTION
This PR changes following for macOS build
- use clang and gcc-12 from homebrew to build openpilot
- disable camerad and sensord build
- add gcc@12 for building panda tests

Testing:
scons -i succeeds without compilation errors on M1 macOS Ventura