### PR TITLE
cabana: auto resizing the columns for signal view

### DIFF
--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -80,9 +80,11 @@ class SignalItemDelegate : public QStyledItemDelegate {
 public:
   SignalItemDelegate(QObject *parent);
   void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+  QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
   QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   QValidator *name_validator, *double_validator;
   QFont small_font;
+  const int color_label_width = 18;
 };
 
 class SignalView : public QWidget {


### PR DESCRIPTION
Fixed the Issue: The current resize mode causes the space between the columns is too large.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-02-18 14-11-08](https://user-images.githubusercontent.com/27770/219844506-041ebf1e-28d9-43a5-8000-da362e83ba52.png)  | ![Screenshot from 2023-02-18 14-20-55](https://user-images.githubusercontent.com/27770/219844760-b886ea30-23bb-496b-a7ac-c19009d3381d.png)  |



