### PR TITLE
cabana: improve UI & fix bugs

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -32,7 +32,6 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
   verticalHeader()->setDefaultSectionSize(CELL_HEIGHT);
   horizontalHeader()->hide();
-  setFrameShape(QFrame::NoFrame);
   setShowGrid(false);
   setMouseTracking(true);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -114,8 +113,8 @@ void BinaryView::addShortcuts() {
 }
 
 QSize BinaryView::minimumSizeHint() const {
-  return {(horizontalHeader()->minimumSectionSize() + 1) * 9 + VERTICAL_HEADER_WIDTH,
-          CELL_HEIGHT * std::min(model->rowCount(), 10)};
+  return {(horizontalHeader()->minimumSectionSize() + 1) * 9 + VERTICAL_HEADER_WIDTH + 2,
+          CELL_HEIGHT * std::min(model->rowCount(), 10) + 2};
 }
 
 void BinaryView::highlight(const Signal *sig) {

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -256,19 +256,19 @@ void BinaryViewModel::refresh() {
   if (auto dbc_msg = dbc()->msg(*msg_id)) {
     row_count = dbc_msg->size;
     items.resize(row_count * column_count);
-    for (auto &sig : dbc_msg->sigs) {
-      auto [start, end] = getSignalRange(&sig);
+    for (auto sig : dbc_msg->getSignals()) {
+      auto [start, end] = getSignalRange(sig);
       for (int j = start; j <= end; ++j) {
-        int bit_index = sig.is_little_endian ? bigEndianBitIndex(j) : j;
+        int bit_index = sig->is_little_endian ? bigEndianBitIndex(j) : j;
         int idx = column_count * (bit_index / 8) + bit_index % 8;
         if (idx >= items.size()) {
-          qWarning() << "signal " << sig.name << "out of bounds.start_bit:" << sig.start_bit << "size:" << sig.size;
+          qWarning() << "signal " << sig->name << "out of bounds.start_bit:" << sig->start_bit << "size:" << sig->size;
           break;
         }
-        if (j == start) sig.is_little_endian ? items[idx].is_lsb = true : items[idx].is_msb = true;
-        if (j == end) sig.is_little_endian ? items[idx].is_msb = true : items[idx].is_lsb = true;
-        items[idx].bg_color = getColor(&sig);
-        items[idx].sigs.push_back(&sig);
+        if (j == start) sig->is_little_endian ? items[idx].is_lsb = true : items[idx].is_msb = true;
+        if (j == end) sig->is_little_endian ? items[idx].is_msb = true : items[idx].is_lsb = true;
+        items[idx].bg_color = getColor(sig);
+        items[idx].sigs.push_back(sig);
       }
     }
   } else {

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -107,7 +107,7 @@ void BinaryView::addShortcuts() {
   QObject::connect(shortcut_plot_c, &QShortcut::activated, shortcut_plot, &QShortcut::activated);
   QObject::connect(shortcut_plot, &QShortcut::activated, [=]{
     if (hovered_sig != nullptr) {
-      emit showChart(*model->msg_id, hovered_sig, true, false);
+      emit showChart(model->msg_id, hovered_sig, true, false);
     }
   });
 }
@@ -218,8 +218,6 @@ void BinaryView::setMessage(const MessageId &message_id) {
 }
 
 void BinaryView::refresh() {
-  if (!model->msg_id) return;
-
   clearSelection();
   anchor_index = QModelIndex();
   resize_sig = nullptr;
@@ -253,7 +251,7 @@ std::tuple<int, int, bool> BinaryView::getSelection(QModelIndex index) {
 void BinaryViewModel::refresh() {
   beginResetModel();
   items.clear();
-  if (auto dbc_msg = dbc()->msg(*msg_id)) {
+  if (auto dbc_msg = dbc()->msg(msg_id)) {
     row_count = dbc_msg->size;
     items.resize(row_count * column_count);
     for (auto sig : dbc_msg->getSignals()) {
@@ -272,7 +270,7 @@ void BinaryViewModel::refresh() {
       }
     }
   } else {
-    row_count = can->lastMessage(*msg_id).dat.size();
+    row_count = can->lastMessage(msg_id).dat.size();
     items.resize(row_count * column_count);
   }
   endResetModel();
@@ -281,7 +279,7 @@ void BinaryViewModel::refresh() {
 
 void BinaryViewModel::updateState() {
   auto prev_items = items;
-  const auto &last_msg = can->lastMessage(*msg_id);
+  const auto &last_msg = can->lastMessage(msg_id);
   const auto &binary = last_msg.dat;
 
   // data size may changed.

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -126,6 +126,16 @@ void BinaryView::highlight(const Signal *sig) {
         emit model->dataChanged(index, index, {Qt::DisplayRole});
       }
     }
+
+    if (sig && underMouse()) {
+      QString tooltip = tr(R"(%1<br /><span style="color:gray;font-size:small">
+        Size:%2 LE:%3 SGD:%4</span>
+      )").arg(sig->name).arg(sig->size).arg(sig->is_little_endian ? "Y" : "N").arg(sig->is_signed ? "Y" : "N");
+      QToolTip::showText(QCursor::pos(), tooltip, this, rect());
+    } else {
+      QToolTip::showText(QCursor::pos(), "", this, rect());
+    }
+
     hovered_sig = sig;
     emit signalHovered(hovered_sig);
   }
@@ -168,7 +178,6 @@ void BinaryView::highlightPosition(const QPoint &pos) {
     auto item = (BinaryViewModel::Item *)index.internalPointer();
     const Signal *sig = item->sigs.isEmpty() ? nullptr : item->sigs.back();
     highlight(sig);
-    QToolTip::showText(pos, sig ? sig->name : "", this, rect());
   }
 }
 

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -43,7 +43,7 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   setWhatsThis(R"(
     <b>Binary View</b><br/>
     <!-- TODO: add descprition here -->
-    Shortcuts:<br />
+    <span style="color:gray">Shortcuts</span><br />
     Delete Signal:
       <span style="background-color:lightGray;color:gray">&nbsp;x&nbsp;</span>,
       <span style="background-color:lightGray;color:gray">&nbsp;Backspace&nbsp;</span>,
@@ -53,7 +53,7 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
     Open chart:
       <span style="background-color:lightGray;color:gray">&nbsp;c&nbsp;</span>,
       <span style="background-color:lightGray;color:gray">&nbsp;p&nbsp;</span>,
-      <span style="background-color:lightGray;color:gray">&nbsp;g&nbsp;</span><br />
+      <span style="background-color:lightGray;color:gray">&nbsp;g&nbsp;</span>
   )");
 }
 

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -45,15 +45,15 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
     <!-- TODO: add descprition here -->
     Shortcuts:<br />
     Delete Signal:
-      <span style="background-color:lightGray;color:gray"> x </span>,
-      <span style="background-color:lightGray;color:gray"> Backspace </span>,
-      <span style="background-color:lightGray;color:gray"> Delete</span><br />
-    Change endianness: <span style="background-color:lightGray;color:gray"> e </span><br />
-    Change singedness: <span style="background-color:lightGray;color:gray"> s </span><br />
+      <span style="background-color:lightGray;color:gray">&nbsp;x&nbsp;</span>,
+      <span style="background-color:lightGray;color:gray">&nbsp;Backspace&nbsp;</span>,
+      <span style="background-color:lightGray;color:gray">&nbsp;Delete&nbsp;</span><br />
+    Change endianness: <span style="background-color:lightGray;color:gray">&nbsp;e&nbsp; </span><br />
+    Change singedness: <span style="background-color:lightGray;color:gray">&nbsp;s&nbsp;</span><br />
     Open chart:
-      <span style="background-color:lightGray;color:gray"> c </span>,
-      <span style="background-color:lightGray;color:gray"> p </span>,
-      <span style="background-color:lightGray;color:gray"> g </span><br />
+      <span style="background-color:lightGray;color:gray">&nbsp;c&nbsp;</span>,
+      <span style="background-color:lightGray;color:gray">&nbsp;p&nbsp;</span>,
+      <span style="background-color:lightGray;color:gray">&nbsp;g&nbsp;</span><br />
   )");
 }
 

--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include <QApplication>
 #include <QList>
 #include <QSet>
@@ -50,7 +48,7 @@ public:
   };
   std::vector<Item> items;
 
-  std::optional<MessageId> msg_id;
+  MessageId msg_id;
   int row_count = 0;
   const int column_count = 9;
 };

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -891,10 +891,10 @@ void SeriesSelector::updateAvailableList(int index) {
   available_list->clear();
   MessageId msg_id = msgs_combo->itemData(index).value<MessageId>();
   auto selected_items = seletedItems();
-  for (auto &s : dbc()->msg(msg_id)->sigs) {
-    bool is_selected = std::any_of(selected_items.begin(), selected_items.end(), [=, sig=&s](auto it) { return it->msg_id == msg_id && it->sig == sig; });
+  for (auto s : dbc()->msg(msg_id)->getSignals()) {
+    bool is_selected = std::any_of(selected_items.begin(), selected_items.end(), [=, sig=s](auto it) { return it->msg_id == msg_id && it->sig == sig; });
     if (!is_selected) {
-      addItemToList(available_list, msg_id, &s);
+      addItemToList(available_list, msg_id, s);
     }
   }
 }

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -18,8 +18,10 @@
 const int MAX_COLUMN_COUNT = 4;
 // ChartsWidget
 
-ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
+ChartsWidget::ChartsWidget(QWidget *parent) : QFrame(parent) {
+  setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
   QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
 
   // toolbar
   QToolBar *toolbar = new QToolBar(tr("Charts"), this);
@@ -43,6 +45,7 @@ ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
 
   range_lb_action = toolbar->addWidget(range_lb = new QLabel(this));
   range_slider = new QSlider(Qt::Horizontal, this);
+  range_slider->setMaximumWidth(200);
   range_slider->setToolTip(tr("Set the chart range"));
   range_slider->setRange(1, settings.max_cached_minutes * 60);
   range_slider->setSingleStep(1);
@@ -67,6 +70,7 @@ ChartsWidget::ChartsWidget(QWidget *parent) : QWidget(parent) {
   charts_main_layout->addStretch(0);
 
   QScrollArea *charts_scroll = new QScrollArea(this);
+  charts_scroll->setFrameStyle(QFrame::NoFrame);
   charts_scroll->setWidgetResizable(true);
   charts_scroll->setWidget(charts_container);
   charts_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -438,12 +438,12 @@ void ChartView::manageSeries() {
 }
 
 void ChartView::resizeEvent(QResizeEvent *event) {
-  QChartView::resizeEvent(event);
   updatePlotArea(align_to);
   int x = event->size().width() - close_btn_proxy->size().width() - 11;
   close_btn_proxy->setPos(x, 8);
   manage_btn_proxy->setPos(x - manage_btn_proxy->size().width() - 5, 8);
   move_icon->setPos(11, 8);
+  QChartView::resizeEvent(event);
 }
 
 void ChartView::updatePlotArea(int left) {
@@ -452,7 +452,7 @@ void ChartView::updatePlotArea(int left) {
     align_to = left;
     background->setRect(r);
     chart()->legend()->setGeometry(QRect(r.left(), r.top(), r.width(), 45));
-    chart()->setPlotArea(QRect(align_to, r.top() + 45, r.width() - align_to - 22, r.height() - 80));
+    chart()->setPlotArea(QRect(align_to, r.top() + 45, r.width() - align_to - 36, r.height() - 80));
     chart()->layout()->invalidate();
   }
 }
@@ -574,7 +574,7 @@ void ChartView::updateAxisY() {
 
     QFontMetrics fm(axis_y->labelsFont());
     int n = qMax(int(-qFloor(std::log10((max_y - min_y) / (tick_count - 1)))), 0) + 1;
-    y_label_width = qMax(fm.width(QString::number(min_y, 'f', n)), fm.width(QString::number(max_y, 'f', n))) + 20;  // left margin 20
+    y_label_width = qMax(fm.width(QString::number(min_y, 'f', n)), fm.width(QString::number(max_y, 'f', n))) + 15;  // left margin 15
     emit axisYLabelWidthChanged(y_label_width);
   }
 }

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -11,7 +11,6 @@
 #include <QRubberBand>
 #include <QPushButton>
 #include <QToolBar>
-#include <QToolButton>
 #include <QToolTip>
 #include <QtConcurrent>
 
@@ -333,18 +332,12 @@ ChartView::ChartView(QWidget *parent) : QChartView(nullptr, parent) {
   move_icon = new QGraphicsPixmapItem(utils::icon("grip-horizontal"), chart);
   move_icon->setToolTip(tr("Drag and drop to combine charts"));
 
-  QToolButton *remove_btn = new QToolButton();
-  remove_btn->setIcon(utils::icon("x"));
-  remove_btn->setAutoRaise(true);
-  remove_btn->setToolTip(tr("Remove Chart"));
+  QToolButton *remove_btn = toolButton("x", tr("Remove Chart"));
   close_btn_proxy = new QGraphicsProxyWidget(chart);
   close_btn_proxy->setWidget(remove_btn);
   close_btn_proxy->setZValue(chart->zValue() + 11);
 
-  QToolButton *manage_btn = new QToolButton();
-  manage_btn->setToolButtonStyle(Qt::ToolButtonIconOnly);
-  manage_btn->setIcon(utils::icon("list"));
-  manage_btn->setAutoRaise(true);
+  QToolButton *manage_btn = toolButton("list", "");
   QMenu *menu = new QMenu(this);
   line_series_action = menu->addAction(tr("Line"), [this]() { setSeriesType(QAbstractSeries::SeriesTypeLine); });
   line_series_action->setCheckable(true);

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -92,7 +92,7 @@ private:
   friend class ChartsWidget;
  };
 
-class ChartsWidget : public QWidget {
+class ChartsWidget : public QFrame {
   Q_OBJECT
 
 public:

--- a/tools/cabana/commands.cc
+++ b/tools/cabana/commands.cc
@@ -36,8 +36,8 @@ RemoveMsgCommand::RemoveMsgCommand(const MessageId &id, QUndoCommand *parent) : 
 void RemoveMsgCommand::undo() {
   if (!message.name.isEmpty()) {
     dbc()->updateMsg(id, message.name, message.size);
-    for (auto &s : message.sigs)
-      dbc()->addSignal(id, s);
+    for (auto s : message.getSignals())
+      dbc()->addSignal(id, *s);
   }
 }
 

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -10,10 +10,6 @@
 
 namespace dbcmanager {
 
-void sortSignalsByAddress(QList<Signal> &sigs) {
-  std::sort(sigs.begin(), sigs.end(), [](auto &a, auto &b) { return a.start_bit < b.start_bit; });
-}
-
 bool DBCManager::open(const QString &dbc_file_name, QString *error) {
   QString opendbc_file_path = QString("%1/%2.dbc").arg(OPENDBC_FILE_PATH, dbc_file_name);
   QFile file(opendbc_file_path);
@@ -83,27 +79,27 @@ QString DBCManager::generateDBC() {
   QString dbc_string, signal_comment, val_desc;
   for (auto &[address, m] : msgs) {
     dbc_string += QString("BO_ %1 %2: %3 XXX\n").arg(address).arg(m.name).arg(m.size);
-    for (auto &sig : m.sigs) {
+    for (auto sig : m.getSignals()) {
       dbc_string += QString(" SG_ %1 : %2|%3@%4%5 (%6,%7) [%8|%9] \"%10\" XXX\n")
-                        .arg(sig.name)
-                        .arg(sig.start_bit)
-                        .arg(sig.size)
-                        .arg(sig.is_little_endian ? '1' : '0')
-                        .arg(sig.is_signed ? '-' : '+')
-                        .arg(sig.factor, 0, 'g', std::numeric_limits<double>::digits10)
-                        .arg(sig.offset, 0, 'g', std::numeric_limits<double>::digits10)
-                        .arg(sig.min)
-                        .arg(sig.max)
-                        .arg(sig.unit);
-      if (!sig.comment.isEmpty()) {
-        signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig.name).arg(sig.comment);
+                        .arg(sig->name)
+                        .arg(sig->start_bit)
+                        .arg(sig->size)
+                        .arg(sig->is_little_endian ? '1' : '0')
+                        .arg(sig->is_signed ? '-' : '+')
+                        .arg(sig->factor, 0, 'g', std::numeric_limits<double>::digits10)
+                        .arg(sig->offset, 0, 'g', std::numeric_limits<double>::digits10)
+                        .arg(sig->min)
+                        .arg(sig->max)
+                        .arg(sig->unit);
+      if (!sig->comment.isEmpty()) {
+        signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);
       }
-      if (!sig.val_desc.isEmpty()) {
+      if (!sig->val_desc.isEmpty()) {
         QString text;
-        for (auto &[val, desc] : sig.val_desc) {
+        for (auto &[val, desc] : sig->val_desc) {
           text += QString("%1 \"%2\"").arg(val, desc);
         }
-        val_desc += QString("VAL_ %1 %2 %3;\n").arg(address).arg(sig.name).arg(text);
+        val_desc += QString("VAL_ %1 %2 %3;\n").arg(address).arg(sig->name).arg(text);
       }
     }
     dbc_string += "\n";
@@ -127,7 +123,6 @@ void DBCManager::addSignal(const MessageId &id, const Signal &sig) {
   if (auto m = const_cast<Msg *>(msg(id.address))) {
     m->sigs.push_back(sig);
     auto s = &m->sigs.last();
-    sortSignalsByAddress(m->sigs);
     emit signalAdded(id.address, s);
   }
 }
@@ -136,7 +131,6 @@ void DBCManager::updateSignal(const MessageId &id, const QString &sig_name, cons
   if (auto m = const_cast<Msg *>(msg(id))) {
     if (auto s = (Signal *)m->sig(sig_name)) {
       *s = sig;
-      sortSignalsByAddress(m->sigs);
       emit signalUpdated(s);
     }
   }
@@ -155,6 +149,16 @@ void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
 DBCManager *dbc() {
   static DBCManager dbc_manager(nullptr);
   return &dbc_manager;
+}
+
+// Msg
+
+std::vector<const Signal*> Msg::getSignals() const {
+  std::vector<const Signal*> ret;
+  ret.reserve(sigs.size());
+  for (auto &sig : sigs) ret.push_back(&sig);
+  std::sort(ret.begin(), ret.end(), [](auto l, auto r) { return l->start_bit < r->start_bit; });
+  return ret;
 }
 
 // helper functions
@@ -246,7 +250,6 @@ bool dbcmanager::DBCManager::open(const QString &name, const QString &content, Q
         sig.offset = s.offset;
         sig.is_little_endian = s.is_little_endian;
       }
-      sortSignalsByAddress(m.sigs);
     }
     parseExtraInfo(content);
     name_ = name;

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -95,11 +95,11 @@ QString DBCManager::generateDBC() {
         signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);
       }
       if (!sig->val_desc.isEmpty()) {
-        QString text;
+        QStringList text;
         for (auto &[val, desc] : sig->val_desc) {
-          text += QString("%1 \"%2\"").arg(val, desc);
+          text << QString("%1 \"%2\"").arg(val, desc);
         }
-        val_desc += QString("VAL_ %1 %2 %3;\n").arg(address).arg(sig->name).arg(text);
+        val_desc += QString("VAL_ %1 %2 %3;\n").arg(address).arg(sig->name).arg(text.join(" "));
       }
     }
     dbc_string += "\n";

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -50,12 +50,16 @@ struct Signal {
 struct Msg {
   QString name;
   uint32_t size;
-  QList<Signal> sigs;
 
+  std::vector<const Signal*> getSignals() const;
   const Signal *sig(const QString &sig_name) const {
     auto it = std::find_if(sigs.begin(), sigs.end(), [&](auto &s) { return s.name == sig_name; });
     return it != sigs.end() ? &(*it) : nullptr;
   }
+
+private:
+  QList<Signal> sigs;
+  friend class DBCManager;
 };
 
 class DBCManager : public QObject {

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -72,7 +72,7 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   QObject::connect(binary_view, &BinaryView::resizeSignal, signal_view->model, &SignalModel::resizeSignal);
   QObject::connect(binary_view, &BinaryView::addSignal, signal_view->model, &SignalModel::addSignal);
   QObject::connect(binary_view, &BinaryView::signalHovered, signal_view, &SignalView::signalHovered);
-  QObject::connect(binary_view, &BinaryView::signalClicked, signal_view, &SignalView::expandSignal);
+  QObject::connect(binary_view, &BinaryView::signalClicked, [this](const Signal *s) { signal_view->selectSignal(s, true); });
   QObject::connect(binary_view, &BinaryView::editSignal, signal_view->model, &SignalModel::saveSignal);
   QObject::connect(binary_view, &BinaryView::removeSignal, signal_view->model, &SignalModel::removeSignal);
   QObject::connect(binary_view, &BinaryView::showChart, charts, &ChartsWidget::showChart);

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -111,15 +111,17 @@ void DetailWidget::showTabBarContextMenu(const QPoint &pt) {
 
 void DetailWidget::removeAll() {
   msg_id = std::nullopt;
+  stacked_layout->setCurrentIndex(0);
   tabbar->blockSignals(true);
   while (tabbar->count() > 0) {
     tabbar->removeTab(0);
   }
   tabbar->blockSignals(false);
-  stacked_layout->setCurrentIndex(0);
 }
 
 void DetailWidget::setMessage(const MessageId &message_id) {
+  if (message_id == msg_id) return;
+
   msg_id = message_id;
 
   tabbar->blockSignals(true);

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -143,7 +143,6 @@ void DetailWidget::setMessage(const MessageId &message_id) {
 
   stacked_layout->setCurrentIndex(1);
   refresh();
-  splitter->setSizes({1, 2});
 
   setUpdatesEnabled(true);
 }

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -25,13 +25,13 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   // message title
   QToolBar *toolbar = new QToolBar(this);
   toolbar->setIconSize({16, 16});
-  toolbar->addWidget(new QLabel("time:"));
   time_label = new QLabel(this);
-  time_label->setStyleSheet("font-weight:bold");
+  time_label->setToolTip(tr("Current time"));
+  time_label->setStyleSheet("QLabel{font-weight:bold;}");
   toolbar->addWidget(time_label);
   name_label = new ElidedLabel(this);
   name_label->setContentsMargins(5, 0, 5, 0);
-  name_label->setStyleSheet("font-weight:bold;");
+  name_label->setStyleSheet("QLabel{font-weight:bold;}");
   name_label->setAlignment(Qt::AlignCenter);
   name_label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
   toolbar->addWidget(name_label);
@@ -59,6 +59,7 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   splitter->setStretchFactor(1, 1);
 
   tab_widget = new QTabWidget(this);
+  tab_widget->setStyleSheet("QTabWidget::pane {border: none; margin-bottom: -2px;}");
   tab_widget->setTabPosition(QTabWidget::South);
   tab_widget->addTab(splitter, utils::icon("file-earmark-ruled"), "&Msg");
   tab_widget->addTab(history_log = new LogsWidget(this), utils::icon("stopwatch"), "&Logs");

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -2,7 +2,6 @@
 
 #include <QDialogButtonBox>
 #include <QSplitter>
-#include <QStackedLayout>
 #include <QTabWidget>
 #include <QToolBar>
 
@@ -24,11 +23,6 @@ public:
   QSpinBox *size_spin;
 };
 
-class WelcomeWidget : public QWidget {
-public:
-  WelcomeWidget(QWidget *parent);
-};
-
 class DetailWidget : public QWidget {
   Q_OBJECT
 
@@ -36,7 +30,6 @@ public:
   DetailWidget(ChartsWidget *charts, QWidget *parent);
   void setMessage(const MessageId &message_id);
   void refresh();
-  void removeAll();
   QSize minimumSizeHint() const override { return binary_view->minimumSizeHint(); }
 
 private:
@@ -45,7 +38,7 @@ private:
   void removeMsg();
   void updateState(const QHash<MessageId, CanData> * msgs = nullptr);
 
-  std::optional<MessageId> msg_id;
+  MessageId msg_id;
   QLabel *time_label, *warning_icon, *warning_label;
   ElidedLabel *name_label;
   QWidget *warning_widget;
@@ -57,5 +50,18 @@ private:
   SignalView *signal_view;
   ChartsWidget *charts;
   QSplitter *splitter;
-  QStackedLayout *stacked_layout;
+};
+
+class CenterWidget : public QWidget {
+  Q_OBJECT
+public:
+  CenterWidget(ChartsWidget* charts, QWidget *parent);
+  void setMessage(const MessageId &msg_id);
+  void clear();
+
+private:
+  QWidget *createWelcomeWidget();
+  DetailWidget *detail_widget = nullptr;
+  QWidget *welcome_widget = nullptr;
+  ChartsWidget *charts;
 };

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -3,7 +3,6 @@
 #include <QDialogButtonBox>
 #include <QSplitter>
 #include <QTabWidget>
-#include <QToolBar>
 
 #include "selfdrive/ui/qt/widgets/controls.h"
 #include "tools/cabana/binaryview.h"
@@ -44,7 +43,7 @@ private:
   QWidget *warning_widget;
   QTabBar *tabbar;
   QTabWidget *tab_widget;
-  QAction *remove_msg_act;
+  QToolButton *remove_btn;
   LogsWidget *history_log;
   BinaryView *binary_view;
   SignalView *signal_view;

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -189,7 +189,8 @@ void HeaderView::paintSection(QPainter *painter, const QRect &rect, int logicalI
 
 // LogsWidget
 
-LogsWidget::LogsWidget(QWidget *parent) : QWidget(parent) {
+LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
+  setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
   main_layout->setSpacing(0);
@@ -219,8 +220,7 @@ LogsWidget::LogsWidget(QWidget *parent) : QWidget(parent) {
   main_layout->addWidget(toolbar);
   QFrame *line = new QFrame(this);
   line->setFrameStyle(QFrame::HLine | QFrame::Sunken);
-  main_layout->addWidget(line);;
-
+  main_layout->addWidget(line);
   main_layout->addWidget(logs = new QTableView(this));
   logs->setModel(model = new HistoryLogModel(this));
   logs->setItemDelegateForColumn(1, new MessageBytesDelegate(this));

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -210,7 +210,8 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   h->addStretch(0);
   h->addWidget(dynamic_mode = new QCheckBox(tr("Dynamic")), 0, Qt::AlignRight);
 
-  display_type_cb->addItems({"Signal Value", "Hex Value"});
+  display_type_cb->addItems({"Signal", "Hex"});
+  display_type_cb->setToolTip(tr("Dispaly signal value or raw hex value"));
   comp_box->addItems({">", "=", "!=", "<"});
   value_edit->setClearButtonEnabled(true);
   value_edit->setValidator(new QDoubleValidator(-500000, 500000, 6, this));

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -27,7 +27,7 @@ void HistoryLogModel::setMessage(const MessageId &message_id) {
   msg_id = message_id;
 }
 
-void HistoryLogModel::refresh() {
+void HistoryLogModel::refresh(bool fetch_message) {
   beginResetModel();
   sigs.clear();
   if (auto dbc_msg = dbc()->msg(*msg_id)) {
@@ -37,7 +37,9 @@ void HistoryLogModel::refresh() {
   has_more_data = true;
   messages.clear();
   hex_colors.clear();
-  updateState();
+  if (fetch_message) {
+    updateState();
+  }
   endResetModel();
 }
 
@@ -251,7 +253,7 @@ void LogsWidget::refresh() {
   if (!model->msg_id) return;
 
   model->setFilter(0, "", nullptr);
-  model->refresh();
+  model->refresh(isVisible());
   bool has_signal = model->sigs.size();
   if (has_signal) {
     signals_cb->clear();
@@ -276,4 +278,16 @@ void LogsWidget::setFilter() {
   }
   model->setFilter(signals_cb->currentIndex(), value_edit->text(), cmp);
   model->refresh();
+}
+
+void LogsWidget::updateState() {
+  if (isVisible() && dynamic_mode->isChecked()) {
+    model->updateState();
+  }
+}
+
+void LogsWidget::showEvent(QShowEvent *event) {
+  if (dynamic_mode->isChecked() || model->canFetchMore({}) && model->rowCount() == 0) {
+    model->refresh();
+  }
 }

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -211,7 +211,7 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   h->addWidget(dynamic_mode = new QCheckBox(tr("Dynamic")), 0, Qt::AlignRight);
 
   display_type_cb->addItems({"Signal", "Hex"});
-  display_type_cb->setToolTip(tr("Dispaly signal value or raw hex value"));
+  display_type_cb->setToolTip(tr("Display signal value or raw hex value"));
   comp_box->addItems({">", "=", "!=", "<"});
   value_edit->setClearButtonEnabled(true);
   value_edit->setValidator(new QDoubleValidator(-500000, 500000, 6, this));

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -9,6 +9,8 @@
 
 #include "tools/cabana/dbcmanager.h"
 #include "tools/cabana/streams/abstractstream.h"
+#include "tools/cabana/util.h"
+
 using namespace dbcmanager;
 
 class HeaderView : public QHeaderView {
@@ -88,4 +90,5 @@ private:
   QComboBox *signals_cb, *comp_box, *display_type_cb;
   QLineEdit *value_edit;
   QWidget *filters_widget;
+  MessageBytesDelegate *delegate;
 };

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -36,7 +36,7 @@ public:
   int columnCount(const QModelIndex &parent = QModelIndex()) const override {
     return display_signals_mode && !sigs.empty() ? sigs.size() + 1 : 2;
   }
-  void refresh();
+  void refresh(bool fetch_message = true);
 
 public slots:
   void setDisplayType(int type);
@@ -75,8 +75,8 @@ class LogsWidget : public QFrame {
 public:
   LogsWidget(QWidget *parent);
   void setMessage(const MessageId &message_id);
-  void updateState() {if (dynamic_mode->isChecked()) model->updateState(); }
-  void showEvent(QShowEvent *event) override { if (dynamic_mode->isChecked()) model->refresh(); }
+  void updateState();
+  void showEvent(QShowEvent *event) override;
 
 private slots:
   void setFilter();

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -69,7 +69,7 @@ public:
   bool display_signals_mode = true;
 };
 
-class LogsWidget : public QWidget {
+class LogsWidget : public QFrame {
   Q_OBJECT
 
 public:

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <deque>
-#include <optional>
-
 #include <QCheckBox>
 #include <QComboBox>
 #include <QHeaderView>
@@ -55,7 +53,7 @@ public:
   std::deque<HistoryLogModel::Message> fetchData(InputIt first, InputIt last, uint64_t min_time);
   std::deque<Message> fetchData(uint64_t from_time, uint64_t min_time = 0);
 
-  std::optional<MessageId> msg_id;
+  MessageId msg_id;
   ChangeTracker hex_colors;
   bool has_more_data = true;
   const int batch_size = 50;

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -64,7 +64,7 @@ public:
   uint64_t last_fetch_time = 0;
   std::function<bool(double, double)> filter_cmp = nullptr;
   std::deque<Message> messages;
-  QList<Signal> sigs;
+  std::vector<const Signal *> sigs;
   bool dynamic_mode = true;
   bool display_signals_mode = true;
 };

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -27,8 +27,8 @@ void qLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const
 
 MainWindow::MainWindow() : QMainWindow() {
   createDockWindows();
-  detail_widget = new DetailWidget(charts_widget, this);
-  setCentralWidget(detail_widget);
+  center_widget = new CenterWidget(charts_widget, this);
+  setCentralWidget(center_widget);
   createActions();
   createStatusBar();
   createShortcuts();
@@ -60,7 +60,7 @@ MainWindow::MainWindow() : QMainWindow() {
 
   QObject::connect(this, &MainWindow::showMessage, statusBar(), &QStatusBar::showMessage);
   QObject::connect(this, &MainWindow::updateProgressBar, this, &MainWindow::updateDownloadProgress);
-  QObject::connect(messages_widget, &MessagesWidget::msgSelectionChanged, detail_widget, &DetailWidget::setMessage);
+  QObject::connect(messages_widget, &MessagesWidget::msgSelectionChanged, center_widget, &CenterWidget::setMessage);
   QObject::connect(charts_widget, &ChartsWidget::dock, this, &MainWindow::dockCharts);
   QObject::connect(can, &AbstractStream::streamStarted, this, &MainWindow::loadDBCFromFingerprint);
   QObject::connect(dbc(), &DBCManager::DBCFileChanged, this, &MainWindow::DBCFileChanged);
@@ -198,7 +198,7 @@ void MainWindow::DBCFileChanged() {
 void MainWindow::openRoute() {
   OpenRouteDialog dlg(this);
   if (dlg.exec()) {
-    detail_widget->removeAll();
+    center_widget->clear();
     charts_widget->removeAll();
     statusBar()->showMessage(tr("Route %1 loaded").arg(can->routeName()), 2000);
   } else if (dlg.failedToLoad()) {

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -174,7 +174,7 @@ void MainWindow::createStatusBar() {
   progress_bar = new QProgressBar();
   progress_bar->setRange(0, 100);
   progress_bar->setTextVisible(true);
-  progress_bar->setFixedSize({230, 16});
+  progress_bar->setFixedSize({300, 16});
   progress_bar->setVisible(false);
   statusBar()->addWidget(new QLabel(tr("For Help,Press F1")));
   statusBar()->addPermanentWidget(progress_bar);

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -59,7 +59,7 @@ protected:
   VideoWidget *video_widget = nullptr;
   QDockWidget *video_dock;
   MessagesWidget *messages_widget;
-  DetailWidget *detail_widget;
+  CenterWidget *center_widget;
   ChartsWidget *charts_widget;
   QWidget *floating_window = nullptr;
   QVBoxLayout *charts_layout;

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -70,10 +70,10 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
   setWhatsThis(tr(R"(
     <b>Message View</b><br/>
     <!-- TODO: add descprition here -->
-    Byte color: <br />
+    <span style="color:gray">Byte color</span><br />
     <span style="color:gray;">■ </span> constant changing<br />
     <span style="color:blue;">■ </span> increasing<br />
-    <span style="color:red;">■ </span> decreasing <br />
+    <span style="color:red;">■ </span> decreasing
   )"));
 }
 

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -9,6 +9,7 @@
 
 MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0 ,0, 0, 0);
 
   // message filter
   filter = new QLineEdit(this);

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -13,6 +13,8 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
 
   // message filter
   filter = new QLineEdit(this);
+  QRegularExpression re("\\S+");
+  filter->setValidator(new QRegularExpressionValidator(re, this));
   filter->setClearButtonEnabled(true);
   filter->setPlaceholderText(tr("filter messages"));
   main_layout->addWidget(filter);

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -94,9 +94,9 @@ void MessagesWidget::updateSuppressedButtons() {
 }
 
 void MessagesWidget::reset() {
+  current_msg_id = std::nullopt;
   model->reset();
   filter->clear();
-  current_msg_id = std::nullopt;
   updateSuppressedButtons();
 }
 

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -1,9 +1,6 @@
 #include "tools/cabana/messageswidget.h"
 
-#include <QApplication>
-#include <QFontDatabase>
 #include <QHBoxLayout>
-#include <QPainter>
 #include <QPushButton>
 #include <QVBoxLayout>
 
@@ -94,9 +91,9 @@ void MessagesWidget::updateSuppressedButtons() {
 }
 
 void MessagesWidget::reset() {
-  current_msg_id = std::nullopt;
   model->reset();
   filter->clear();
+  current_msg_id = std::nullopt;
   updateSuppressedButtons();
 }
 

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -141,8 +141,8 @@ void MessageListModel::setFilterString(const QString &string) {
     if (id.toString().contains(txt, cs) || msgName(id).contains(txt, cs)) return true;
     // Search by signal name
     if (const auto msg = dbc()->msg(id)) {
-      for (auto &signal : msg->sigs) {
-        if (signal.name.contains(txt, cs)) return true;
+      for (auto s : msg->getSignals()) {
+        if (s->name.contains(txt, cs)) return true;
       }
     }
     return false;

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include <QAbstractTableModel>
 #include <QHeaderView>
 #include <QLineEdit>

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -6,7 +6,6 @@
 #include <QHeaderView>
 #include <QLineEdit>
 #include <QSet>
-#include <QStyledItemDelegate>
 #include <QTableView>
 
 #include "tools/cabana/dbcmanager.h"

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -353,6 +353,8 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   QHBoxLayout *hl = new QHBoxLayout(title_bar);
   hl->addWidget(signal_count_lb = new QLabel());
   filter_edit = new QLineEdit(this);
+  QRegularExpression re("\\S+");
+  filter_edit->setValidator(new QRegularExpressionValidator(re, this));
   filter_edit->setClearButtonEnabled(true);
   filter_edit->setPlaceholderText(tr("filter signals by name"));
   hl->addWidget(filter_edit);

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -345,7 +345,8 @@ QWidget *SignalItemDelegate::createEditor(QWidget *parent, const QStyleOptionVie
 
 // SignalView
 
-SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), QWidget(parent) {
+SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), QFrame(parent) {
+  setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
   // title bar
   QWidget *title_bar = new QWidget(this);
   title_bar->setAutoFillBackground(true);

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -58,7 +58,7 @@ void SignalModel::refresh() {
 }
 
 void SignalModel::updateState(const QHash<MessageId, CanData> *msgs) {
-  if (!msgs || (msgs->contains(msg_id))) {
+  if (!msgs || msgs->contains(msg_id)) {
     auto &dat = can->lastMessage(msg_id).dat;
     int row = 0;
     for (auto item : root->children) {

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -48,9 +48,9 @@ void SignalModel::refresh() {
   beginResetModel();
   root.reset(new SignalModel::Item);
   if (auto msg = dbc()->msg(msg_id)) {
-    for (auto &s : msg->sigs) {
-      if (filter_str.isEmpty() || s.name.contains(filter_str, Qt::CaseInsensitive)) {
-        insertItem(root.get(), root->children.size(), &s);
+    for (auto s : msg->getSignals()) {
+      if (filter_str.isEmpty() || s->name.contains(filter_str, Qt::CaseInsensitive)) {
+        insertItem(root.get(), root->children.size(), s);
       }
     }
   }

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -458,7 +458,7 @@ void SignalView::expandSignal(const Signal *sig) {
     bool expand = !tree->isExpanded(idx);
     tree->setExpanded(idx, expand);
     tree->scrollTo(idx, QAbstractItemView::PositionAtTop);
-    if (expand) tree->setCurrentIndex(idx);
+    tree->setCurrentIndex(idx);
   }
 }
 

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -129,11 +129,11 @@ QVariant SignalModel::data(const QModelIndex &index, int role) const {
           case Item::Min: return item->sig->min;
           case Item::Max: return item->sig->max;
           case Item::Desc: {
-            QString val_desc;
+            QStringList val_desc;
             for (auto &[val, desc] : item->sig->val_desc) {
-              val_desc += QString("%1 \"%2\"").arg(val, desc);
+              val_desc << QString("%1 \"%2\"").arg(val, desc);
             }
-            return val_desc;
+            return val_desc.join(" ");
           }
           default: break;
         }

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -280,11 +280,19 @@ void SignalModel::handleSignalRemoved(const Signal *sig) {
 
 // SignalItemDelegate
 
-SignalItemDelegate::SignalItemDelegate(QObject *parent) {
+SignalItemDelegate::SignalItemDelegate(QObject *parent) : QStyledItemDelegate(parent) {
   name_validator = new NameValidator(this);
   double_validator = new QDoubleValidator(this);
   double_validator->setLocale(QLocale::C);  // Match locale of QString::toDouble() instead of system
   small_font.setPointSize(8);
+}
+
+QSize SignalItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const {
+  QSize size = QStyledItemDelegate::sizeHint(option, index);
+  if (!index.parent().isValid() && index.column() == 0) {
+    size.rwidth() = std::min(((QWidget*)parent())->size().width() / 2, size.width() + color_label_width + 8);
+  }
+  return size;
 }
 
 void SignalItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {
@@ -298,7 +306,7 @@ void SignalItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
 
     // color label
     auto bg_color = getColor(item->sig);
-    QRect rc{option.rect.left(), option.rect.top(), 18, option.rect.height()};
+    QRect rc{option.rect.left(), option.rect.top(), color_label_width, option.rect.height()};
     painter->setPen(Qt::NoPen);
     painter->setBrush(item->highlight ? bg_color.darker(125) : bg_color);
     painter->drawRoundedRect(rc.adjusted(0, 2, 0, -2), 3, 3);
@@ -356,7 +364,7 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   QRegularExpression re("\\S+");
   filter_edit->setValidator(new QRegularExpressionValidator(re, this));
   filter_edit->setClearButtonEnabled(true);
-  filter_edit->setPlaceholderText(tr("filter signals by name"));
+  filter_edit->setPlaceholderText(tr("filter signals"));
   hl->addWidget(filter_edit);
   hl->addStretch(1);
   auto collapse_btn = new QToolButton();
@@ -374,7 +382,8 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   tree->setHeaderHidden(true);
   tree->setMouseTracking(true);
   tree->setExpandsOnDoubleClick(false);
-  tree->header()->setSectionResizeMode(QHeaderView::Stretch);
+  tree->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+  tree->header()->setStretchLastSection(true);
   tree->setMinimumHeight(300);
   tree->setStyleSheet("QSpinBox{background-color:white;border:none;} QLineEdit{background-color:white;}");
 

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -392,7 +392,7 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   QObject::connect(model, &QAbstractItemModel::modelReset, this, &SignalView::rowsChanged);
   QObject::connect(model, &QAbstractItemModel::rowsInserted, this, &SignalView::rowsChanged);
   QObject::connect(model, &QAbstractItemModel::rowsRemoved, this, &SignalView::rowsChanged);
-  QObject::connect(dbc(), &DBCManager::signalAdded, [this](uint32_t address, const Signal *sig) { expandSignal(sig); });
+  QObject::connect(dbc(), &DBCManager::signalAdded, [this](uint32_t address, const Signal *sig) { selectSignal(sig); });
 
   setWhatsThis(tr(R"(
     <b>Signal view</b><br />
@@ -452,11 +452,12 @@ void SignalView::rowClicked(const QModelIndex &index) {
   }
 }
 
-void SignalView::expandSignal(const Signal *sig) {
+void SignalView::selectSignal(const Signal *sig, bool expand) {
   if (int row = model->signalRow(sig); row != -1) {
     auto idx = model->index(row, 0);
-    bool expand = !tree->isExpanded(idx);
-    tree->setExpanded(idx, expand);
+    if (expand) {
+      tree->setExpanded(idx, !tree->isExpanded(idx));
+    }
     tree->scrollTo(idx, QAbstractItemView::PositionAtTop);
     tree->setCurrentIndex(idx);
   }

--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -80,9 +80,11 @@ class SignalItemDelegate : public QStyledItemDelegate {
 public:
   SignalItemDelegate(QObject *parent);
   void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+  QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
   QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   QValidator *name_validator, *double_validator;
   QFont small_font;
+  const int color_label_width = 18;
 };
 
 class SignalView : public QFrame {

--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -85,7 +85,7 @@ public:
   QFont small_font;
 };
 
-class SignalView : public QWidget {
+class SignalView : public QFrame {
   Q_OBJECT
 
 public:

--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -93,7 +93,7 @@ public:
   void setMessage(const MessageId &id);
   void signalHovered(const Signal *sig);
   void updateChartState();
-  void expandSignal(const Signal *sig);
+  void selectSignal(const Signal *sig, bool expand = false);
   void rowClicked(const QModelIndex &index);
   SignalModel *model = nullptr;
 

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -31,10 +31,12 @@ bool AbstractStream::updateEvent(const Event *event) {
       data.dat = QByteArray((char *)c.getDat().begin(), c.getDat().size());
       data.count = ++counters[id];
       data.freq = data.count / std::max(1.0, current_sec);
-      change_trackers[id].compute(data.dat, data.ts, data.freq);
-      data.colors = change_trackers[id].colors;
-      data.last_change_t = change_trackers[id].last_change_t;
-      data.bit_change_counts = change_trackers[id].bit_change_counts;
+
+      auto &tracker = change_trackers[id];
+      tracker.compute(data.dat, data.ts, data.freq);
+      data.colors = tracker.colors;
+      data.last_change_t = tracker.last_change_t;
+      data.bit_change_counts = tracker.bit_change_counts;
     }
 
     double ts = millis_since_boot();

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -23,9 +23,11 @@ TEST_CASE("DBCManager::generateDBC") {
     auto &new_m = new_msgs.at(address);
     REQUIRE(m.name == new_m.name);
     REQUIRE(m.size == new_m.size);
-    REQUIRE(m.sigs.size() == new_m.sigs.size());
-    for (int i = 0; i < m.sigs.size(); ++i) {
-      REQUIRE(m.sigs[i] == new_m.sigs[i]);
+    REQUIRE(m.getSignals().size() == new_m.getSignals().size());
+    auto sigs = m.getSignals();
+    auto new_sigs = new_m.getSignals();
+    for (int i = 0; i < sigs.size(); ++i) {
+      REQUIRE(*sigs[i] == *new_sigs[i]);
     }
   }
 }
@@ -44,9 +46,9 @@ TEST_CASE("Parse can messages") {
       for (const auto &c : e->event.getCan()) {
         const auto msg = dbc.msg(c.getAddress());
         if (c.getSrc() == 0 && msg) {
-          for (auto &sig : msg->sigs) {
-            double val = get_raw_value((uint8_t *)c.getDat().begin(), c.getDat().size(), sig);
-            values_1[{c.getAddress(), sig.name}].push_back(val);
+          for (auto sig : msg->getSignals()) {
+            double val = get_raw_value((uint8_t *)c.getDat().begin(), c.getDat().size(), *sig);
+            values_1[{c.getAddress(), sig->name}].push_back(val);
           }
         }
       }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QFontDatabase>
 #include <QPainter>
+#include <QPixmapCache>
 #include <QDebug>
 
 #include <limits>
@@ -124,11 +125,16 @@ namespace utils {
 QPixmap icon(const QString &id) {
   static bool dark_theme = QApplication::style()->standardPalette().color(QPalette::WindowText).value() >
                            QApplication::style()->standardPalette().color(QPalette::Background).value();
-  QPixmap pm = bootstrapPixmap(id);
-  if (dark_theme) {
-    QPainter p(&pm);
-    p.setCompositionMode(QPainter::CompositionMode_SourceIn);
-    p.fillRect(pm.rect(), Qt::lightGray);
+  QPixmap pm;
+  QString key = "bootstrap_" % id % (dark_theme ? "1" : "0");
+  if (!QPixmapCache::find(key, &pm)) {
+    pm = bootstrapPixmap(id);
+    if (dark_theme) {
+      QPainter p(&pm);
+      p.setCompositionMode(QPainter::CompositionMode_SourceIn);
+      p.fillRect(pm.rect(), Qt::lightGray);
+    }
+    QPixmapCache::insert(key, pm);
   }
   return pm;
 }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -86,7 +86,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   auto colors = index.data(Qt::UserRole).value<QVector<QColor>>();
   auto byte_list = index.data(Qt::DisplayRole).toString().split(" ");
   for (int i = 0; i < byte_list.size(); ++i) {
-    if (i < colors.size()) {
+    if (i < colors.size() && colors[i].alpha() > 0) {
       painter->fillRect(pos.marginsAdded(margins), colors[i]);
     }
     painter->drawText(pos, Qt::AlignCenter, byte_list[i]);

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -74,32 +74,23 @@ MessageBytesDelegate::MessageBytesDelegate(QObject *parent) : QStyledItemDelegat
 }
 
 void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {
-  QStyleOptionViewItemV4 opt = option;
-  initStyleOption(&opt, index);
-
-  auto byte_list = opt.text.split(" ");
-  if (byte_list.size() <= 1) {
-    QStyledItemDelegate::paint(painter, option, index);
-    return;
-  }
-
   auto color_role = option.state & QStyle::State_Selected ? QPalette::HighlightedText: QPalette::Text;
   painter->setPen(option.palette.color(color_role));
   painter->setFont(fixed_font);
-  QRect space = painter->boundingRect(opt.rect, opt.displayAlignment, " ");
-  QRect pos = painter->boundingRect(opt.rect, opt.displayAlignment, "00").adjusted(0, 0, 2, 0);
-  pos.moveLeft(pos.x() + space.width());
-
-  int m = space.width() / 2;
+  int space = painter->boundingRect(option.rect, option.displayAlignment, " ").width();
+  QRect pos = painter->boundingRect(option.rect, option.displayAlignment, "00").adjusted(0, 0, 2, 0);
+  pos.moveLeft(pos.x() + space);
+  int m = space / 2;
   const QMargins margins(m, m, m, m);
 
   auto colors = index.data(Qt::UserRole).value<QVector<QColor>>();
+  auto byte_list = index.data(Qt::DisplayRole).toString().split(" ");
   for (int i = 0; i < byte_list.size(); ++i) {
     if (i < colors.size()) {
       painter->fillRect(pos.marginsAdded(margins), colors[i]);
     }
     painter->drawText(pos, Qt::AlignCenter, byte_list[i]);
-    pos.moveLeft(pos.right() + space.width());
+    pos.moveLeft(pos.right() + space);
   }
 }
 

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -130,3 +130,11 @@ QPixmap icon(const QString &id) {
   return pm;
 }
 }  // namespace utils
+
+QToolButton *toolButton(const QString &icon, const QString &tooltip) {
+  auto btn = new QToolButton();
+  btn->setIcon(utils::icon(icon));
+  btn->setToolTip(tooltip);
+  btn->setAutoRaise(true);
+  return btn;
+};

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -86,7 +86,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   painter->setPen(option.palette.color(color_role));
   painter->setFont(fixed_font);
   QRect space = painter->boundingRect(opt.rect, opt.displayAlignment, " ");
-  QRect pos = painter->boundingRect(opt.rect, opt.displayAlignment, "00");
+  QRect pos = painter->boundingRect(opt.rect, opt.displayAlignment, "00").adjusted(0, 0, 2, 0);
   pos.moveLeft(pos.x() + space.width());
 
   int m = space.width() / 2;
@@ -97,7 +97,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     if (i < colors.size()) {
       painter->fillRect(pos.marginsAdded(margins), colors[i]);
     }
-    painter->drawText(pos, opt.displayAlignment, byte_list[i]);
+    painter->drawText(pos, Qt::AlignCenter, byte_list[i]);
     pos.moveLeft(pos.right() + space.width());
   }
 }

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -8,6 +8,7 @@
 #include <QRegExpValidator>
 #include <QStringBuilder>
 #include <QStyledItemDelegate>
+#include <QToolButton>
 #include <QVector>
 
 #include "tools/cabana/dbcmanager.h"
@@ -53,3 +54,5 @@ public:
 namespace utils {
 QPixmap icon(const QString &id);
 }
+
+QToolButton *toolButton(const QString &icon, const QString &tooltip);

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -6,6 +6,7 @@
 #include <QColor>
 #include <QFont>
 #include <QRegExpValidator>
+#include <QStringBuilder>
 #include <QStyledItemDelegate>
 #include <QVector>
 

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -28,9 +28,9 @@ inline QString formatTime(int seconds) {
 
 VideoWidget::VideoWidget(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
   QFrame *frame = new QFrame(this);
-  frame->setFrameShape(QFrame::StyledPanel);
-  frame->setFrameShadow(QFrame::Sunken);
+  frame->setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
   main_layout->addWidget(frame);
 
   QVBoxLayout *frame_layout = new QVBoxLayout(frame);


### PR DESCRIPTION
Merged many small changes and bug fixes in this one.

UI:
1. Improve looks and consistency of splitters, makes it easier to use.
2. Add border to binary view.
3. All panels have the same height.
4. reduce space between panels.
5. Larger download progress bar to make sure download text will not be truncated.
6. Remove "time:" label.
7. Set the max width for range slider so that it doesn't get too wide.
8. keep detailview's splitter sizes after msg changed
9. no leading spaces allowed in msg and signal filters.
10. reduce charts flickers while resizing.
11. display size, LE, signed in tooltip for signal
12. don't fetch history logs if invisible
13. faster setMessage
14. msg_id is always valid now, remove all std::optional in details widgets. 
15. cache icons in QPixmapCache
16. other small improvements...

![2023-02-18_17-48](https://user-images.githubusercontent.com/27770/219853923-ca8ef5a6-3d6f-4b9f-bca9-3d57201b0641.png) 

Before:
![2023-02-18_17-50](https://user-images.githubusercontent.com/27770/219853916-e09c4487-9220-4327-98a9-8a4408cddf95.png)

DBCManager:
1. make sigs a private member.
2. fixed the bug that the element address not changing after sorting.
3. add space between value description



