### PR TITLE
cabana: missing includes

### DIFF
--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -2,6 +2,8 @@
 
 #include <map>
 #include <QList>
+#include <QMetaType>
+#include <QObject>
 #include <QString>
 
 struct MessageId {


### PR DESCRIPTION
Building cabana on archlinux results in two errors

## missing QMetaType include
```
tools/cabana/streams/replaystream.cc                                                    In file included from tools/cabana/streams/replaystream.cc:1:                           
In file included from ./tools/cabana/streams/replaystream.h:3:                          
In file included from ./tools/cabana/streams/abstractstream.h:8:                        
./tools/cabana/dbcmanager.h:33:1: error: unknown type name 'Q_DECLARE_METATYPE'         Q_DECLARE_METATYPE(MessageId);                                                          
^                                                                                       
./tools/cabana/dbcmanager.h:61:27: error: expected class name                           
class DBCManager : public QObject {                                                     
                          ^                                                             
./tools/cabana/dbcmanager.h:62:3: error: unknown type name 'Q_OBJECT'                   
  Q_OBJECT           
  
```

## missing QObject include
```
  ./tools/cabana/dbcmanager.h:62:27: error: base class has incomplete type
class DBCManager : public QObject {

/usr/include/qt/QtCore/qobjectdefs_impl.h:52:7: note: forward declaration of 'QObject' 
class QObject;
```