### PR TITLE
fix(cabana): include #qvariant

### DIFF
--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <QList>
 #include <QString>
+#include <QVariant>
 
 struct MessageId {
   uint8_t source;


### PR DESCRIPTION
Building with Qt5 requires this header for the file to compile. 
See https://github.com/commaai/openpilot/pull/27352#issuecomment-1435941500