### PR TITLE
GM: add longitudinal delay to Escalade

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -208,6 +208,7 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 17.3
       ret.centerToFront = ret.wheelbase * 0.5
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
+      ret.longitudinalActuatorDelayUpperBound = 0.5  # large delay to initially start braking
 
     elif candidate == CAR.ESCALADE_ESV:
       ret.minEnableSpeed = -1.  # engage speed is decided by pcm

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -207,8 +207,8 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.95  # 116 inches in meters
       ret.steerRatio = 17.3
       ret.centerToFront = ret.wheelbase * 0.5
-      CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
       ret.longitudinalActuatorDelayUpperBound = 0.5  # large delay to initially start braking
+      CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
     elif candidate == CAR.ESCALADE_ESV:
       ret.minEnableSpeed = -1.  # engage speed is decided by pcm


### PR DESCRIPTION
Looked at data from Escalade 2017 user, dongle: ef8f2185104d862e 