### PR TITLE
cabana: small improvements to SignalView

### DIFF
--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -42,7 +42,7 @@ public:
   bool saveSignal(const Signal *origin_s, Signal &s);
   void resizeSignal(const Signal *sig, int start_bit, int size);
   void removeSignal(const Signal *sig);
-  inline Item *getItem(const QModelIndex &index) const { return index.isValid() ? (Item *)index.internalPointer() : root.get(); }
+  Item *getItem(const QModelIndex &index) const;
   int signalRow(const Signal *sig) const;
   void showExtraInfo(const QModelIndex &index);
 


### PR DESCRIPTION
1. do not `emit dataChanged` if no changes.
2. add checks in `rowCount()`, `index()`,`parent()` to prevent potential crashes if index is invalid.