### PR TITLE
cabana: add mutex around new_msgs

### DIFF
--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 
 #include <QColor>
 #include <QHash>
@@ -64,6 +65,7 @@ protected:
   bool is_live_streaming = false;
   std::atomic<bool> processing = false;
   QHash<MessageId, uint32_t> counters;
+  std::mutex new_msgs_lock;
   std::unique_ptr<QHash<MessageId, CanData>> new_msgs;
   QHash<MessageId, ChangeTracker> change_trackers;
 };


### PR DESCRIPTION
After https://github.com/commaai/openpilot/pull/27149 I'm seeing random crashes while seeking. It's obvious when zooming in to a small region so it has to loop around constantly.

I can't reproduce it with the replaystream in openpilot, but it's easy to hit with my own stream implementation. Which is basically just sleeping, and calling `updateEvent` in a loop. Adding locks fixed it.

@deanlee any thoughts why this could be? Do I need to add locks to my own stream implementation instead?

My stream implementation:
```c++
void VSBStream::seekTo(double ts) {
  it = std::lower_bound(can_events.begin(), can_events.end(), ts * 1e9, [](auto &e, uint64_t x) { return e->mono_time < x; });
  if (it == can_events.end()) it = can_events.begin();
  emit seekedTo((*it)->mono_time / 1e9);
}

void VSBStream::streamThread() {
  uint64_t last_run = nanos_since_boot();
  emit streamStarted();

  while (!QThread::currentThread()->isInterruptionRequested()) {
      QThread::msleep(1);
      uint64_t t = nanos_since_boot();

      if (isPaused()) {
        last_run = t;
        continue;
      }

      // Loop over events that need to be sent out since last iteration of this loop
      auto end_t = (*it)->mono_time + (t - last_run) * speed;
      for (; it != can_events.end() && (*it)->mono_time <= end_t; ++it) {
        updateEvent(*it);
      }

      // Loop around
      if (it == can_events.end()) {
        it = can_events.begin();
      }

      last_run = t;
  }
}
```