### PR TITLE
cabana: show bus in own column

### DIFF
--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -16,7 +16,7 @@ Q_OBJECT
 public:
   MessageListModel(QObject *parent) : QAbstractTableModel(parent) {}
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return 5; }
+  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return 6; }
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return msgs.size(); }
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;


### PR DESCRIPTION
- Show bus in own column, now allows proper sorting by id.
- Set default width for first 4 columns (name, bus, id, freq)

![Screenshot 2023-02-23 at 12 06 56](https://user-images.githubusercontent.com/1314752/220889443-9e9e6748-cafd-49b4-a552-84c3a51ac969.png)
