### PR TITLE
cabana: add support for multiple DBC files

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -28,7 +28,7 @@ cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "asset
 
 prev_moc_path = cabana_env['QT_MOCHPREFIX']
 cabana_env['QT_MOCHPREFIX'] = os.path.dirname(prev_moc_path) + '/cabana/moc_'
-cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'chartswidget.cc', 'historylog.cc', 'videowidget.cc', 'signaledit.cc', 'dbc.cc', 'dbcmanager.cc',
+cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'chartswidget.cc', 'historylog.cc', 'videowidget.cc', 'signaledit.cc', 'dbc.cc', 'dbcfile.cc', 'dbcmanager.cc',
                                                'commands.cc', 'messageswidget.cc', 'route.cc', 'settings.cc', 'util.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('_cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 

--- a/tools/cabana/dbcfile.cc
+++ b/tools/cabana/dbcfile.cc
@@ -24,7 +24,7 @@ DBCFile::DBCFile(const QString &dbc_file_name, QObject *parent) : QObject(parent
     }
     open(file.readAll());
   } else {
-    // TODO: throw exception
+    throw std::runtime_error("Failed to open file.");
   }
 }
 
@@ -79,6 +79,8 @@ bool DBCFile::saveAs(const QString &new_filename) {
 bool DBCFile::autoSave() {
   if (!filename.isEmpty()) {
     return writeContents(filename + AUTO_SAVE_EXTENSION);
+  } else {
+    return false;
   }
 }
 

--- a/tools/cabana/dbcfile.cc
+++ b/tools/cabana/dbcfile.cc
@@ -73,16 +73,23 @@ cabana::Signal *DBCFile::addSignal(const MessageId &id, const cabana::Signal &si
   return nullptr;
 }
 
- cabana::Signal *DBCFile::removeSignal(const MessageId &id, const QString &sig_name) {
+cabana::Signal *DBCFile::getSignal(const MessageId &id, const QString &sig_name) {
+  if (auto m = const_cast<cabana::Msg *>(msg(id))) {
+    auto it = std::find_if(m->sigs.begin(), m->sigs.end(), [&](auto &s) { return s.name == sig_name; });
+    if (it != m->sigs.end()) {
+     return &(*it);
+    }
+  }
+  return nullptr;
+ }
+
+void DBCFile::removeSignal(const MessageId &id, const QString &sig_name) {
   if (auto m = const_cast<cabana::Msg *>(msg(id))) {
     auto it = std::find_if(m->sigs.begin(), m->sigs.end(), [&](auto &s) { return s.name == sig_name; });
     if (it != m->sigs.end()) {
       m->sigs.erase(it);
-      return &(*it); // TOOD: is this a use after free?
     }
   }
-
-  return nullptr;
 }
 
 void DBCFile::updateMsg(const MessageId &id, const QString &name, uint32_t size) {

--- a/tools/cabana/dbcfile.cc
+++ b/tools/cabana/dbcfile.cc
@@ -38,10 +38,10 @@ void DBCFile::open(const QString &content) {
   auto dbc = const_cast<DBC *>(dbc_parse_from_stream(name_.toStdString(), stream));
   msgs.clear();
   for (auto &msg : dbc->msgs) {
-      auto &m = msgs[msg.address];
-      m.name = msg.name.c_str();
-      m.size = msg.size;
-      for (auto &s : msg.sigs) {
+    auto &m = msgs[msg.address];
+    m.name = msg.name.c_str();
+    m.size = msg.size;
+    for (auto &s : msg.sigs) {
       m.sigs.push_back({});
       auto &sig = m.sigs.last();
       sig.name = s.name.c_str();
@@ -54,7 +54,7 @@ void DBCFile::open(const QString &content) {
       sig.offset = s.offset;
       sig.is_little_endian = s.is_little_endian;
       sig.updatePrecision();
-      }
+    }
   }
   parseExtraInfo(content);
 

--- a/tools/cabana/dbcfile.cc
+++ b/tools/cabana/dbcfile.cc
@@ -50,9 +50,6 @@ void DBCFile::open(const QString &name, const QString &content) {
   parseExtraInfo(content);
   name_ = name;
 
-  // TODO: deal with names
-  // emit DBCFileChanged();
-
   delete dbc;
 }
 

--- a/tools/cabana/dbcfile.cc
+++ b/tools/cabana/dbcfile.cc
@@ -1,0 +1,232 @@
+#include "tools/cabana/dbcfile.h"
+
+#include <QDebug>
+
+#include <QFile>
+#include <QRegularExpression>
+#include <QTextStream>
+#include <QVector>
+#include <limits>
+#include <sstream>
+
+
+DBCFile::DBCFile(const QString &dbc_file_name, QObject *parent) : QObject(parent) {
+  QString opendbc_file_path = QString("%1/%2.dbc").arg(OPENDBC_FILE_PATH, dbc_file_name);
+  QFile file(opendbc_file_path);
+  if (file.open(QIODevice::ReadOnly)) {
+    open(dbc_file_name, file.readAll());
+  } else {
+    // TODO: throw exception
+  }
+}
+
+DBCFile::DBCFile(const QString &name, const QString &content, QObject *parent) : QObject(parent) {
+  open(name, content);
+}
+
+void DBCFile::open(const QString &name, const QString &content) {
+  std::istringstream stream(content.toStdString());
+  auto dbc = const_cast<DBC *>(dbc_parse_from_stream(name.toStdString(), stream));
+  msgs.clear();
+  for (auto &msg : dbc->msgs) {
+      auto &m = msgs[msg.address];
+      m.name = msg.name.c_str();
+      m.size = msg.size;
+      for (auto &s : msg.sigs) {
+      m.sigs.push_back({});
+      auto &sig = m.sigs.last();
+      sig.name = s.name.c_str();
+      sig.start_bit = s.start_bit;
+      sig.msb = s.msb;
+      sig.lsb = s.lsb;
+      sig.size = s.size;
+      sig.is_signed = s.is_signed;
+      sig.factor = s.factor;
+      sig.offset = s.offset;
+      sig.is_little_endian = s.is_little_endian;
+      sig.updatePrecision();
+      }
+  }
+  parseExtraInfo(content);
+  name_ = name;
+
+  // TODO: deal with names
+  // emit DBCFileChanged();
+
+  delete dbc;
+}
+
+cabana::Signal *DBCFile::addSignal(const MessageId &id, const cabana::Signal &sig) {
+  if (auto m = const_cast<cabana::Msg *>(msg(id.address))) {
+    m->sigs.push_back(sig);
+    return &m->sigs.last();
+  }
+
+  return nullptr;
+}
+
+ cabana::Signal *DBCFile::updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig) {
+  if (auto m = const_cast<cabana::Msg *>(msg(id))) {
+    if (auto s = (cabana::Signal *)m->sig(sig_name)) {
+      *s = sig;
+      return s;
+    }
+  }
+
+  return nullptr;
+}
+
+ cabana::Signal *DBCFile::removeSignal(const MessageId &id, const QString &sig_name) {
+  if (auto m = const_cast<cabana::Msg *>(msg(id))) {
+    auto it = std::find_if(m->sigs.begin(), m->sigs.end(), [&](auto &s) { return s.name == sig_name; });
+    if (it != m->sigs.end()) {
+      m->sigs.erase(it);
+      return &(*it); // TOOD: is this a use after free?
+    }
+  }
+
+  return nullptr;
+}
+
+void DBCFile::updateMsg(const MessageId &id, const QString &name, uint32_t size) {
+  auto &m = msgs[id.address];
+  m.name = name;
+  m.size = size;
+}
+
+void DBCFile::removeMsg(const MessageId &id) {
+  msgs.erase(id.address);
+}
+
+std::map<uint32_t, cabana::Msg> DBCFile::getMessages() {
+  return msgs;
+}
+
+const cabana::Msg *DBCFile::msg(const MessageId &id) const {
+  return msg(id.address);
+}
+
+const cabana::Msg *DBCFile::msg(uint32_t address) const {
+  auto it = msgs.find(address);
+  return it != msgs.end() ? &it->second : nullptr;
+}
+
+const cabana::Msg* DBCFile::msg(const QString &name) {
+  for (auto &[_, msg] : msgs) {
+    if (msg.name == name) {
+      return &msg;
+    }
+  }
+
+  return nullptr;
+}
+
+
+QStringList DBCFile::signalNames() const {
+  // Used for autocompletion
+  QStringList ret;
+  for (auto const& [_, msg] : msgs) {
+    for (auto sig: msg.getSignals()) {
+      ret << sig->name;
+    }
+  }
+  ret.sort();
+  ret.removeDuplicates();
+  return ret;
+}
+
+int DBCFile::msgCount() const {
+  return msgs.size();
+}
+
+QString DBCFile::name() const {
+  return name_;
+}
+
+void DBCFile::parseExtraInfo(const QString &content) {
+  static QRegularExpression bo_regexp(R"(^BO_ (\w+) (\w+) *: (\w+) (\w+))");
+  static QRegularExpression sg_regexp(R"(^SG_ (\w+) : (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*))");
+  static QRegularExpression sgm_regexp(R"(^SG_ (\w+) (\w+) *: (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*))");
+  static QRegularExpression sg_comment_regexp(R"(^CM_ SG_ *(\w+) *(\w+) *\"(.*)\";)");
+  static QRegularExpression val_regexp(R"(VAL_ (\w+) (\w+) (.*);)");
+  auto get_sig = [this](uint32_t address, const QString &name) -> cabana::Signal * {
+    auto m = (cabana::Msg *)msg(address);
+    return m ? (cabana::Signal *)m->sig(name) : nullptr;
+  };
+
+  QTextStream stream((QString *)&content);
+  uint32_t address = 0;
+  while (!stream.atEnd()) {
+    QString line = stream.readLine().trimmed();
+    if (line.startsWith("BO_ ")) {
+      if (auto match = bo_regexp.match(line); match.hasMatch()) {
+        address = match.captured(1).toUInt();
+      }
+    } else if (line.startsWith("SG_ ")) {
+      int offset = 0;
+      auto match = sg_regexp.match(line);
+      if (!match.hasMatch()) {
+        match = sgm_regexp.match(line);
+        offset = 1;
+      }
+      if (match.hasMatch()) {
+        if (auto s = get_sig(address, match.captured(1))) {
+          s->min = match.captured(8 + offset);
+          s->max = match.captured(9 + offset);
+          s->unit = match.captured(10 + offset);
+        }
+      }
+    } else if (line.startsWith("VAL_ ")) {
+      if (auto match = val_regexp.match(line); match.hasMatch()) {
+        if (auto s = get_sig(match.captured(1).toUInt(), match.captured(2))) {
+          QStringList desc_list = match.captured(3).trimmed().split('"');
+          for (int i = 0; i < desc_list.size(); i += 2) {
+            auto val = desc_list[i].trimmed();
+            if (!val.isEmpty() && (i + 1) < desc_list.size()) {
+              auto desc = desc_list[i+1].trimmed();
+              s->val_desc.push_back({val, desc});
+            }
+          }
+        }
+      }
+    } else if (line.startsWith("CM_ SG_ ")) {
+      if (auto match = sg_comment_regexp.match(line); match.hasMatch()) {
+        if (auto s = get_sig(match.captured(1).toUInt(), match.captured(2))) {
+          s->comment = match.captured(3).trimmed();
+        }
+      }
+    }
+  }
+}
+
+QString DBCFile::generateDBC() {
+  QString dbc_string, signal_comment, val_desc;
+  for (auto &[address, m] : msgs) {
+    dbc_string += QString("BO_ %1 %2: %3 XXX\n").arg(address).arg(m.name).arg(m.size);
+    for (auto sig : m.getSignals()) {
+      dbc_string += QString(" SG_ %1 : %2|%3@%4%5 (%6,%7) [%8|%9] \"%10\" XXX\n")
+                        .arg(sig->name)
+                        .arg(sig->start_bit)
+                        .arg(sig->size)
+                        .arg(sig->is_little_endian ? '1' : '0')
+                        .arg(sig->is_signed ? '-' : '+')
+                        .arg(sig->factor, 0, 'g', std::numeric_limits<double>::digits10)
+                        .arg(sig->offset, 0, 'g', std::numeric_limits<double>::digits10)
+                        .arg(sig->min)
+                        .arg(sig->max)
+                        .arg(sig->unit);
+      if (!sig->comment.isEmpty()) {
+        signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);
+      }
+      if (!sig->val_desc.isEmpty()) {
+        QStringList text;
+        for (auto &[val, desc] : sig->val_desc) {
+          text << QString("%1 \"%2\"").arg(val, desc);
+        }
+        val_desc += QString("VAL_ %1 %2 %3;\n").arg(address).arg(sig->name).arg(text.join(" "));
+      }
+    }
+    dbc_string += "\n";
+  }
+  return dbc_string + signal_comment + val_desc;
+}

--- a/tools/cabana/dbcfile.cc
+++ b/tools/cabana/dbcfile.cc
@@ -77,8 +77,9 @@ bool DBCFile::saveAs(const QString &new_filename) {
 }
 
 bool DBCFile::autoSave() {
-  assert(!filename.isEmpty());
-  return writeContents(filename + AUTO_SAVE_EXTENSION);
+  if (!filename.isEmpty()) {
+    return writeContents(filename + AUTO_SAVE_EXTENSION);
+  }
 }
 
 void DBCFile::cleanupAutoSaveFile() {

--- a/tools/cabana/dbcfile.h
+++ b/tools/cabana/dbcfile.h
@@ -10,6 +10,9 @@
 
 #include "tools/cabana/dbc.h"
 
+const QString AUTO_SAVE_EXTENSION = ".tmp";
+
+
 class DBCFile : public QObject {
   Q_OBJECT
 
@@ -18,7 +21,13 @@ public:
   DBCFile(const QString &name, const QString &content, QObject *parent=nullptr);
   ~DBCFile() {}
 
-  void open(const QString &name, const QString &content);
+  void open(const QString &content);
+
+  bool save();
+  bool saveAs(const QString &new_filename);
+  bool autoSave();
+  bool writeContents(const QString &fn);
+  void cleanupAutoSaveFile();
   QString generateDBC();
 
   cabana::Signal *addSignal(const MessageId &id, const cabana::Signal &sig);
@@ -36,6 +45,8 @@ public:
   QStringList signalNames() const;
   int msgCount() const;
   QString name() const;
+
+  QString filename;
 
 private:
   void parseExtraInfo(const QString &content);

--- a/tools/cabana/dbcfile.h
+++ b/tools/cabana/dbcfile.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <map>
+#include <QList>
+#include <QMetaType>
+#include <QObject>
+#include <QString>
+#include <QSet>
+#include <QDebug>
+
+#include "tools/cabana/dbc.h"
+
+class DBCFile : public QObject {
+  Q_OBJECT
+
+public:
+  DBCFile(const QString &dbc_file_name, QObject *parent=nullptr);
+  DBCFile(const QString &name, const QString &content, QObject *parent=nullptr);
+  ~DBCFile() {}
+
+  void open(const QString &name, const QString &content);
+  QString generateDBC();
+
+  cabana::Signal *addSignal(const MessageId &id, const cabana::Signal &sig);
+  cabana::Signal *updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig);
+  cabana::Signal *removeSignal(const MessageId &id, const QString &sig_name);
+
+  void updateMsg(const MessageId &id, const QString &name, uint32_t size);
+  void removeMsg(const MessageId &id);
+
+  std::map<uint32_t, cabana::Msg> getMessages();
+  const cabana::Msg *msg(const MessageId &id) const;
+  const cabana::Msg *msg(uint32_t address) const;
+  const cabana::Msg* msg(const QString &name);
+  QStringList signalNames() const;
+  int msgCount() const;
+  QString name() const;
+
+private:
+  void parseExtraInfo(const QString &content);
+  std::map<uint32_t, cabana::Msg> msgs;
+  QString name_;
+};

--- a/tools/cabana/dbcfile.h
+++ b/tools/cabana/dbcfile.h
@@ -23,7 +23,8 @@ public:
 
   cabana::Signal *addSignal(const MessageId &id, const cabana::Signal &sig);
   cabana::Signal *updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig);
-  cabana::Signal *removeSignal(const MessageId &id, const QString &sig_name);
+  cabana::Signal *getSignal(const MessageId &id, const QString &sig_name);
+  void removeSignal(const MessageId &id, const QString &sig_name);
 
   void updateMsg(const MessageId &id, const QString &name, uint32_t size);
   void removeMsg(const MessageId &id);

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -45,7 +45,7 @@ QString DBCManager::generateDBC() {
 
 void DBCManager::addSignal(const MessageId &id, const cabana::Signal &sig) {
   DBCFile *dbc_file = findDBCFile(id);
-  assert(dbc_file != nullptr);
+  assert(dbc_file != nullptr); // Create new DBC?
   cabana::Signal *s = dbc_file->addSignal(id, sig);
 
   if (s != nullptr) {
@@ -58,7 +58,7 @@ void DBCManager::addSignal(const MessageId &id, const cabana::Signal &sig) {
 
 void DBCManager::updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig) {
   DBCFile *dbc_file = findDBCFile(id);
-  assert(dbc_file != nullptr);
+  assert(dbc_file != nullptr); // This should be impossible
   cabana::Signal *s = dbc_file->updateSignal(id, sig_name, sig);
 
   if (s != nullptr) {
@@ -68,7 +68,7 @@ void DBCManager::updateSignal(const MessageId &id, const QString &sig_name, cons
 
 void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
   DBCFile *dbc_file = findDBCFile(id);
-  assert(dbc_file != nullptr);
+  assert(dbc_file != nullptr); // This should be impossible
   cabana::Signal *s = dbc_file->removeSignal(id, sig_name);
 
   if (s != nullptr) {
@@ -78,7 +78,7 @@ void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
 
 void DBCManager::updateMsg(const MessageId &id, const QString &name, uint32_t size) {
   DBCFile *dbc_file = findDBCFile(id);
-  assert(dbc_file != nullptr);
+  assert(dbc_file != nullptr); // This should be impossible
   dbc_file->updateMsg(id, name, size);
 
   // This DBC applies to all active sources, emit for every source
@@ -89,7 +89,7 @@ void DBCManager::updateMsg(const MessageId &id, const QString &name, uint32_t si
 
 void DBCManager::removeMsg(const MessageId &id) {
   DBCFile *dbc_file = findDBCFile(id);
-  assert(dbc_file != nullptr);
+  assert(dbc_file != nullptr); // This should be impossible
   dbc_file->removeMsg(id);
 
   // This DBC applies to all active sources, emit for every source
@@ -102,7 +102,9 @@ std::map<MessageId, cabana::Msg> DBCManager::getMessages(uint8_t source) {
   std::map<MessageId, cabana::Msg> ret;
 
   DBCFile *dbc_file = findDBCFile({.source = source, .address = 0});
-  assert(dbc_file != nullptr);
+  if (dbc_file == nullptr) {
+    return ret;
+  }
 
   for (auto &[address, msg] : dbc_file->getMessages()) {
     MessageId id = {.source = source, .address = address};
@@ -113,13 +115,17 @@ std::map<MessageId, cabana::Msg> DBCManager::getMessages(uint8_t source) {
 
 const cabana::Msg *DBCManager::msg(const MessageId &id) const {
   DBCFile *dbc_file = findDBCFile(id);
-  assert(dbc_file != nullptr);
+  if (dbc_file == nullptr) {
+    return nullptr;
+  }
   return dbc_file->msg(id);
 }
 
 const cabana::Msg* DBCManager::msg(uint8_t source, const QString &name) {
   DBCFile *dbc_file = findDBCFile({.source = source, .address = 0});
-  assert(dbc_file != nullptr);
+  if (dbc_file == nullptr) {
+    return nullptr;
+  }
   return dbc_file->msg(name);
 }
 

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -84,10 +84,11 @@ void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
   assert(sources_dbc_file); // This should be impossible
   auto [_, dbc_file] = *sources_dbc_file;
 
-  cabana::Signal *s = dbc_file->removeSignal(id, sig_name);
+  cabana::Signal *s = dbc_file->getSignal(id, sig_name);
 
   if (s != nullptr) {
     emit signalRemoved(s);
+    dbc_file->removeSignal(id, sig_name);
   }
 }
 

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -10,10 +10,20 @@
 
 
 bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error) {
-  // Check if file is already open, and merge sources
-  for (auto &[ss, dbc_file] : dbc_files) {
+  for (int i = 0; i < dbc_files.size(); i++) {
+    auto &[ss, dbc_file] = dbc_files[i];
+
+    // Check if file is already open, and merge sources
     if (dbc_file->filename == dbc_file_name) {
       ss |= s;
+      emit DBCFileChanged();
+      return true;
+    }
+
+    // Check if there is already a file for this sourceset, then replace it
+    if (ss == s) {
+      delete dbc_file;
+      dbc_files[i] = {s, new DBCFile(dbc_file_name, this)};
       emit DBCFileChanged();
       return true;
     }

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -177,17 +177,20 @@ void DBCManager::updateSources(const SourceSet &s) {
   sources = s;
 }
 
-std::optional<std::pair<SourceSet, DBCFile*>> DBCManager::findDBCFile(const MessageId &id) const {
+std::optional<std::pair<SourceSet, DBCFile*>> DBCManager::findDBCFile(const uint8_t source) const {
   // Find DBC file that matches id.source, fall back to SOURCE_ALL if no specific DBC is found
 
   for (auto &[source_set, dbc_file] : dbc_files) {
-    if (source_set.contains(id.source)) return {{source_set, dbc_file}};
+    if (source_set.contains(source)) return {{source_set, dbc_file}};
   }
   for (auto &[source_set, dbc_file] : dbc_files) {
     if (source_set == SOURCE_ALL) return {{sources, dbc_file}};
   }
   return {};
+}
 
+std::optional<std::pair<SourceSet, DBCFile*>> DBCManager::findDBCFile(const MessageId &id) const {
+  return findDBCFile(id.source);
 }
 
 DBCManager *dbc() {

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -173,6 +173,10 @@ int DBCManager::msgCount() const {
   return ret;
 }
 
+int DBCManager::dbcCount() const {
+  return dbc_files.size();
+}
+
 void DBCManager::updateSources(const SourceSet &s) {
   sources = s;
 }

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -52,12 +52,6 @@ void DBCManager::closeAll() {
 }
 
 
-QString DBCManager::generateDBC() {
-  // TODO: move saving logic into DBCManager
-  return "";
-}
-
-
 void DBCManager::addSignal(const MessageId &id, const cabana::Signal &sig) {
   auto sources_dbc_file = findDBCFile(id);
   assert(sources_dbc_file); // Create new DBC?

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -61,11 +61,6 @@ void DBCManager::addSignal(const MessageId &id, const cabana::Signal &sig) {
   cabana::Signal *s = dbc_file->addSignal(id, sig);
 
   if (s != nullptr) {
-    // This DBC applies to all active sources, emit for every source
-    if (dbc_sources == SOURCE_ALL) {
-      dbc_sources = sources;
-    }
-
     for (uint8_t source : dbc_sources) {
       emit signalAdded({.source = source, .address = id.address}, s);
     }
@@ -103,11 +98,6 @@ void DBCManager::updateMsg(const MessageId &id, const QString &name, uint32_t si
 
   dbc_file->updateMsg(id, name, size);
 
-  // This DBC applies to all active sources, emit for every source
-  if (dbc_sources == SOURCE_ALL) {
-    dbc_sources = sources;
-  }
-
   for (uint8_t source : dbc_sources) {
     emit msgUpdated({.source = source, .address = id.address});
   }
@@ -119,12 +109,6 @@ void DBCManager::removeMsg(const MessageId &id) {
   auto [dbc_sources, dbc_file] = *sources_dbc_file;
 
   dbc_file->removeMsg(id);
-
-
-  // This DBC applies to all active sources, emit for every source
-  if (dbc_sources == SOURCE_ALL) {
-    dbc_sources = sources;
-  }
 
   for (uint8_t source : dbc_sources) {
     emit msgRemoved({.source = source, .address = id.address});
@@ -199,7 +183,7 @@ std::optional<std::pair<SourceSet, DBCFile*>> DBCManager::findDBCFile(const Mess
     if (source_set.contains(id.source)) return {{source_set, dbc_file}};
   }
   for (auto &[source_set, dbc_file] : dbc_files) {
-    if (source_set == SOURCE_ALL) return {{source_set, dbc_file}};
+    if (source_set == SOURCE_ALL) return {{sources, dbc_file}};
   }
   return {};
 

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -10,7 +10,14 @@
 
 
 bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error) {
-  // TODO: check if file is already open and merge sources
+  // Check if file is already open, and merge sources
+  for (auto &[ss, dbc_file] : dbc_files) {
+    if (dbc_file->filename == dbc_file_name) {
+      ss |= s;
+      emit DBCFileChanged();
+      return true;
+    }
+  }
 
   try {
     dbc_files.push_back({s, new DBCFile(dbc_file_name, this)});
@@ -24,8 +31,6 @@ bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error)
 }
 
 bool DBCManager::open(SourceSet s, const QString &name, const QString &content, QString *error) {
-  // TODO: check if file is already open and merge sources
-
   try {
     dbc_files.push_back({s, new DBCFile(name, content, this)});
   } catch (std::exception &e) {

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -1,5 +1,4 @@
 #include "tools/cabana/dbcmanager.h"
-#include <QDebug>
 
 #include <QFile>
 #include <QRegularExpression>
@@ -11,7 +10,7 @@
 
 bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error) {
   for (int i = 0; i < dbc_files.size(); i++) {
-    auto &[ss, dbc_file] = dbc_files[i];
+    auto [ss, dbc_file] = dbc_files[i];
 
     // Check if file is already open, and merge sources
     if (dbc_file->filename == dbc_file_name) {
@@ -22,10 +21,16 @@ bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error)
 
     // Check if there is already a file for this sourceset, then replace it
     if (ss == s) {
-      delete dbc_file;
-      dbc_files[i] = {s, new DBCFile(dbc_file_name, this)};
-      emit DBCFileChanged();
-      return true;
+      try {
+        dbc_files[i] = {s, new DBCFile(dbc_file_name, this)};
+        delete dbc_file;
+
+        emit DBCFileChanged();
+        return true;
+      } catch (std::exception &e) {
+        if (error) *error = e.what();
+        return false;
+      }
     }
   }
 

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -37,6 +37,16 @@ bool DBCManager::open(SourceSet s, const QString &name, const QString &content, 
   return true;
 }
 
+void DBCManager::closeAll() {
+  while (dbc_files.size()) {
+    DBCFile *dbc_file = dbc_files.back().second;
+    dbc_files.pop_back();
+    delete dbc_file;
+  }
+  emit DBCFileChanged();
+}
+
+
 QString DBCManager::generateDBC() {
   // TODO: move saving logic into DBCManager
   return "";

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -161,14 +161,13 @@ int DBCManager::msgCount() const {
   return ret;
 }
 
-void DBCManager::updateSources(const QSet<uint8_t> &s) {
+void DBCManager::updateSources(const SourceSet &s) {
   sources = s;
 }
 
 DBCFile *DBCManager::findDBCFile(const MessageId &id) const {
   // Find DBC file that matches id.source, fall back to SOURCE_ALL if no specific DBC is found
 
-  // TODO: match on lower 6 bits only to get sent/blocked busses automatically?
   for (auto &[source_set, dbc_file] : dbc_files) {
     if (source_set.contains(id.source)) return dbc_file;
   }

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -167,6 +167,8 @@ void DBCManager::updateSources(const QSet<uint8_t> &s) {
 
 DBCFile *DBCManager::findDBCFile(const MessageId &id) const {
   // Find DBC file that matches id.source, fall back to SOURCE_ALL if no specific DBC is found
+
+  // TODO: match on lower 6 bits only to get sent/blocked busses automatically?
   for (auto &[source_set, dbc_file] : dbc_files) {
     if (source_set.contains(id.source)) return dbc_file;
   }

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -8,43 +8,11 @@
 #include <limits>
 #include <sstream>
 
-bool DBCManager::open(const QString &dbc_file_name, QString *error) {
-  QString opendbc_file_path = QString("%1/%2.dbc").arg(OPENDBC_FILE_PATH, dbc_file_name);
-  QFile file(opendbc_file_path);
-  if (file.open(QIODevice::ReadOnly)) {
-    return open(dbc_file_name, file.readAll(), error);
-  }
-  return false;
-}
 
-bool DBCManager::open(const QString &name, const QString &content, QString *error) {
+bool DBCManager::open(const QString &dbc_file_name, QString *error) {
+  // TODO: get source set as argument
   try {
-    std::istringstream stream(content.toStdString());
-    auto dbc = const_cast<DBC *>(dbc_parse_from_stream(name.toStdString(), stream));
-    msgs.clear();
-    for (auto &msg : dbc->msgs) {
-      auto &m = msgs[msg.address];
-      m.name = msg.name.c_str();
-      m.size = msg.size;
-      for (auto &s : msg.sigs) {
-        m.sigs.push_back({});
-        auto &sig = m.sigs.last();
-        sig.name = s.name.c_str();
-        sig.start_bit = s.start_bit;
-        sig.msb = s.msb;
-        sig.lsb = s.lsb;
-        sig.size = s.size;
-        sig.is_signed = s.is_signed;
-        sig.factor = s.factor;
-        sig.offset = s.offset;
-        sig.is_little_endian = s.is_little_endian;
-        sig.updatePrecision();
-      }
-    }
-    parseExtraInfo(content);
-    name_ = name;
-    emit DBCFileChanged();
-    delete dbc;
+    dbc_files.reset(new DBCFile(dbc_file_name, this));
   } catch (std::exception &e) {
     if (error) *error = e.what();
     return false;
@@ -52,119 +20,32 @@ bool DBCManager::open(const QString &name, const QString &content, QString *erro
   return true;
 }
 
-void DBCManager::parseExtraInfo(const QString &content) {
-  static QRegularExpression bo_regexp(R"(^BO_ (\w+) (\w+) *: (\w+) (\w+))");
-  static QRegularExpression sg_regexp(R"(^SG_ (\w+) : (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*))");
-  static QRegularExpression sgm_regexp(R"(^SG_ (\w+) (\w+) *: (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*))");
-  static QRegularExpression sg_comment_regexp(R"(^CM_ SG_ *(\w+) *(\w+) *\"(.*)\";)");
-  static QRegularExpression val_regexp(R"(VAL_ (\w+) (\w+) (.*);)");
-  auto get_sig = [this](uint32_t address, const QString &name) -> cabana::Signal * {
-    auto m = (cabana::Msg *)msg(address);
-    return m ? (cabana::Signal *)m->sig(name) : nullptr;
-  };
-
-  QTextStream stream((QString *)&content);
-  uint32_t address = 0;
-  while (!stream.atEnd()) {
-    QString line = stream.readLine().trimmed();
-    if (line.startsWith("BO_ ")) {
-      if (auto match = bo_regexp.match(line); match.hasMatch()) {
-        address = match.captured(1).toUInt();
-      }
-    } else if (line.startsWith("SG_ ")) {
-      int offset = 0;
-      auto match = sg_regexp.match(line);
-      if (!match.hasMatch()) {
-        match = sgm_regexp.match(line);
-        offset = 1;
-      }
-      if (match.hasMatch()) {
-        if (auto s = get_sig(address, match.captured(1))) {
-          s->min = match.captured(8 + offset);
-          s->max = match.captured(9 + offset);
-          s->unit = match.captured(10 + offset);
-        }
-      }
-    } else if (line.startsWith("VAL_ ")) {
-      if (auto match = val_regexp.match(line); match.hasMatch()) {
-        if (auto s = get_sig(match.captured(1).toUInt(), match.captured(2))) {
-          QStringList desc_list = match.captured(3).trimmed().split('"');
-          for (int i = 0; i < desc_list.size(); i += 2) {
-            auto val = desc_list[i].trimmed();
-            if (!val.isEmpty() && (i + 1) < desc_list.size()) {
-              auto desc = desc_list[i+1].trimmed();
-              s->val_desc.push_back({val, desc});
-            }
-          }
-        }
-      }
-    } else if (line.startsWith("CM_ SG_ ")) {
-      if (auto match = sg_comment_regexp.match(line); match.hasMatch()) {
-        if (auto s = get_sig(match.captured(1).toUInt(), match.captured(2))) {
-          s->comment = match.captured(3).trimmed();
-        }
-      }
-    }
+bool DBCManager::open(const QString &name, const QString &content, QString *error) {
+  // TODO: get source set as argument
+  try {
+    dbc_files.reset(new DBCFile(name, content, this));
+  } catch (std::exception &e) {
+    if (error) *error = e.what();
+    return false;
   }
+  return true;
 }
 
 QString DBCManager::generateDBC() {
-  QString dbc_string, signal_comment, val_desc;
-  for (auto &[address, m] : msgs) {
-    dbc_string += QString("BO_ %1 %2: %3 XXX\n").arg(address).arg(m.name).arg(m.size);
-    for (auto sig : m.getSignals()) {
-      dbc_string += QString(" SG_ %1 : %2|%3@%4%5 (%6,%7) [%8|%9] \"%10\" XXX\n")
-                        .arg(sig->name)
-                        .arg(sig->start_bit)
-                        .arg(sig->size)
-                        .arg(sig->is_little_endian ? '1' : '0')
-                        .arg(sig->is_signed ? '-' : '+')
-                        .arg(sig->factor, 0, 'g', std::numeric_limits<double>::digits10)
-                        .arg(sig->offset, 0, 'g', std::numeric_limits<double>::digits10)
-                        .arg(sig->min)
-                        .arg(sig->max)
-                        .arg(sig->unit);
-      if (!sig->comment.isEmpty()) {
-        signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);
-      }
-      if (!sig->val_desc.isEmpty()) {
-        QStringList text;
-        for (auto &[val, desc] : sig->val_desc) {
-          text << QString("%1 \"%2\"").arg(val, desc);
-        }
-        val_desc += QString("VAL_ %1 %2 %3;\n").arg(address).arg(sig->name).arg(text.join(" "));
-      }
-    }
-    dbc_string += "\n";
-  }
-  return dbc_string + signal_comment + val_desc;
+  // TODO: move saving logic into DBCManager
+  DBCFile *dbc_file = dbc_files.get();
+  assert(dbc_file != nullptr);
+
+  return dbc_file->generateDBC();
 }
 
-void DBCManager::updateMsg(const MessageId &id, const QString &name, uint32_t size) {
-  auto &m = msgs[id.address];
-  m.name = name;
-  m.size = size;
-
-  // This DBC applies to all active sources, emit for every source
-  for (uint8_t source : sources) {
-    emit msgUpdated({.source = source, .address = id.address});
-  }
-}
-
-void DBCManager::removeMsg(const MessageId &id) {
-  msgs.erase(id.address);
-
-  // This DBC applies to all active sources, emit for every source
-  for (uint8_t source : sources) {
-    emit msgRemoved({.source = source, .address = id.address});
-  }
-}
 
 void DBCManager::addSignal(const MessageId &id, const cabana::Signal &sig) {
-  if (auto m = const_cast<cabana::Msg *>(msg(id.address))) {
-    m->sigs.push_back(sig);
-    auto s = &m->sigs.last();
+  DBCFile *dbc_file = findDBCFile(id);
+  assert(dbc_file != nullptr);
+  cabana::Signal *s = dbc_file->addSignal(id, sig);
 
+  if (s != nullptr) {
     // This DBC applies to all active sources, emit for every source
     for (uint8_t source : sources) {
       emit signalAdded({.source = source, .address = id.address}, s);
@@ -173,39 +54,110 @@ void DBCManager::addSignal(const MessageId &id, const cabana::Signal &sig) {
 }
 
 void DBCManager::updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig) {
-  if (auto m = const_cast<cabana::Msg *>(msg(id))) {
-    if (auto s = (cabana::Signal *)m->sig(sig_name)) {
-      *s = sig;
-      emit signalUpdated(s);
-    }
+  DBCFile *dbc_file = findDBCFile(id);
+  assert(dbc_file != nullptr);
+  cabana::Signal *s = dbc_file->updateSignal(id, sig_name, sig);
+
+  if (s != nullptr) {
+    emit signalUpdated(s);
   }
 }
 
 void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
-  if (auto m = const_cast<cabana::Msg *>(msg(id))) {
-    auto it = std::find_if(m->sigs.begin(), m->sigs.end(), [&](auto &s) { return s.name == sig_name; });
-    if (it != m->sigs.end()) {
-      emit signalRemoved(&(*it));
-      m->sigs.erase(it);
-    }
+  DBCFile *dbc_file = findDBCFile(id);
+  assert(dbc_file != nullptr);
+  cabana::Signal *s = dbc_file->removeSignal(id, sig_name);
+
+  if (s != nullptr) {
+    emit signalRemoved(s);
   }
 }
 
-QStringList DBCManager::signalNames() {
-  // Used for autocompletion
-  QStringList ret;
-  for (auto const& [_, msg] : msgs) {
-    for (auto sig: msg.getSignals()) {
-      ret << sig->name;
-    }
+void DBCManager::updateMsg(const MessageId &id, const QString &name, uint32_t size) {
+  DBCFile *dbc_file = findDBCFile(id);
+  assert(dbc_file != nullptr);
+  dbc_file->updateMsg(id, name, size);
+
+  // This DBC applies to all active sources, emit for every source
+  for (uint8_t source : sources) {
+    emit msgUpdated({.source = source, .address = id.address});
   }
+}
+
+void DBCManager::removeMsg(const MessageId &id) {
+  DBCFile *dbc_file = findDBCFile(id);
+  assert(dbc_file != nullptr);
+  dbc_file->removeMsg(id);
+
+  // This DBC applies to all active sources, emit for every source
+  for (uint8_t source : sources) {
+    emit msgRemoved({.source = source, .address = id.address});
+  }
+}
+
+std::map<MessageId, cabana::Msg> DBCManager::getMessages(uint8_t source) {
+  std::map<MessageId, cabana::Msg> ret;
+
+  DBCFile *dbc_file = findDBCFile({.source = source, .address = 0});
+  assert(dbc_file != nullptr);
+
+  for (auto &[address, msg] : dbc_file->getMessages()) {
+    MessageId id = {.source = source, .address = address};
+    ret[id] = msg;
+  }
+  return ret;
+}
+
+const cabana::Msg *DBCManager::msg(const MessageId &id) const {
+  DBCFile *dbc_file = findDBCFile(id);
+  assert(dbc_file != nullptr);
+  return dbc_file->msg(id);
+}
+
+const cabana::Msg* DBCManager::msg(uint8_t source, const QString &name) {
+  DBCFile *dbc_file = findDBCFile({.source = source, .address = 0});
+  assert(dbc_file != nullptr);
+  return dbc_file->msg(name);
+}
+
+QStringList DBCManager::signalNames() const {
+  QStringList ret;
+
+  // TODO: Loop over all dbc files
+  DBCFile *dbc_file = dbc_files.get();
+  assert(dbc_file != nullptr);
+  ret << dbc_file->signalNames();
+
   ret.sort();
   ret.removeDuplicates();
   return ret;
 }
 
+int DBCManager::msgCount() const {
+  int ret = 0;
+
+  // TODO: Loop over all dbc files
+  DBCFile *dbc_file = dbc_files.get();
+  assert(dbc_file != nullptr);
+  ret += dbc_file->msgCount();
+
+  return ret;
+}
+
+QString DBCManager::name() const {
+  // TODO: doesn't make sense with multiple DBC
+
+  DBCFile *dbc_file = dbc_files.get();
+  assert(dbc_file != nullptr);
+  return dbc_file->name();
+}
+
 void DBCManager::updateSources(const QSet<uint8_t> &s) {
   sources = s;
+}
+
+DBCFile *DBCManager::findDBCFile(const MessageId &id) const {
+  return dbc_files.get();
 }
 
 DBCManager *dbc() {

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -17,6 +17,8 @@ bool DBCManager::open(const QString &dbc_file_name, QString *error) {
     if (error) *error = e.what();
     return false;
   }
+
+  emit DBCFileChanged();
   return true;
 }
 
@@ -28,6 +30,8 @@ bool DBCManager::open(const QString &name, const QString &content, QString *erro
     if (error) *error = e.what();
     return false;
   }
+
+  emit DBCFileChanged();
   return true;
 }
 

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -22,6 +22,7 @@ public:
   ~DBCManager() {}
   bool open(SourceSet s, const QString &dbc_file_name, QString *error = nullptr);
   bool open(SourceSet s, const QString &name, const QString &content, QString *error = nullptr);
+  void closeAll();
   QString generateDBC();
 
   void addSignal(const MessageId &id, const cabana::Signal &sig);

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -41,11 +41,11 @@ public:
 
 private:
   DBCFile *findDBCFile(const MessageId &id) const;
-  QSet<uint8_t> sources;
+  SourceSet sources;
   QList<std::pair<SourceSet, DBCFile*>> dbc_files;
 
 public slots:
-  void updateSources(const QSet<uint8_t> &s);
+  void updateSources(const SourceSet &s);
 
 signals:
   void signalAdded(MessageId id, const cabana::Signal *sig);

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -40,7 +40,7 @@ public:
   int msgCount() const;
 
 private:
-  DBCFile *findDBCFile(const MessageId &id) const;
+  std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const MessageId &id) const;
   SourceSet sources;
   QList<std::pair<SourceSet, DBCFile*>> dbc_files;
 

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -39,8 +39,10 @@ public:
   QStringList signalNames() const;
   int msgCount() const;
 
-private:
+  std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const uint8_t source) const;
   std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const MessageId &id) const;
+
+private:
   SourceSet sources;
   QList<std::pair<SourceSet, DBCFile*>> dbc_files;
 

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -23,7 +23,6 @@ public:
   bool open(SourceSet s, const QString &dbc_file_name, QString *error = nullptr);
   bool open(SourceSet s, const QString &name, const QString &content, QString *error = nullptr);
   void closeAll();
-  QString generateDBC();
 
   void addSignal(const MessageId &id, const cabana::Signal &sig);
   void updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig);

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -43,9 +43,10 @@ public:
   std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const uint8_t source) const;
   std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const MessageId &id) const;
 
+  QList<std::pair<SourceSet, DBCFile*>> dbc_files;
+
 private:
   SourceSet sources;
-  QList<std::pair<SourceSet, DBCFile*>> dbc_files;
 
 public slots:
   void updateSources(const SourceSet &s);

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -9,6 +9,7 @@
 #include <QDebug>
 
 #include "tools/cabana/dbc.h"
+#include "tools/cabana/dbcfile.h"
 
 class DBCManager : public QObject {
   Q_OBJECT
@@ -19,33 +20,26 @@ public:
   bool open(const QString &dbc_file_name, QString *error = nullptr);
   bool open(const QString &name, const QString &content, QString *error = nullptr);
   QString generateDBC();
+
   void addSignal(const MessageId &id, const cabana::Signal &sig);
   void updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig);
   void removeSignal(const MessageId &id, const QString &sig_name);
-  inline int msgCount() const { return msgs.size(); }
 
-  inline QString name() const { return name_; }
   void updateMsg(const MessageId &id, const QString &name, uint32_t size);
   void removeMsg(const MessageId &id);
-  inline std::map<MessageId, cabana::Msg> getMessages(uint8_t source) {
-    std::map<MessageId, cabana::Msg> ret;
-    for (auto &[address, msg] : msgs) {
-      MessageId id = {.source = source, .address = address};
-      ret[id] = msg;
-    }
-    return ret;
-  }
-  inline const cabana::Msg *msg(const MessageId &id) const { return msg(id.address); }
-  inline const cabana::Msg* msg(uint8_t source, const QString &name) {
-    for (auto &[_, msg] : msgs) {
-      if (msg.name == name) {
-        return &msg;
-      }
-    }
 
-    return nullptr;
-  }
-  QStringList signalNames();
+  std::map<MessageId, cabana::Msg> getMessages(uint8_t source);
+  const cabana::Msg *msg(const MessageId &id) const;
+  const cabana::Msg* msg(uint8_t source, const QString &name);
+
+  QStringList signalNames() const;
+  int msgCount() const;
+  QString name() const;
+
+private:
+  DBCFile *findDBCFile(const MessageId &id) const;
+  QSet<uint8_t> sources;
+  std::unique_ptr<DBCFile> dbc_files; // TODO: Replace by list
 
 public slots:
   void updateSources(const QSet<uint8_t> &s);
@@ -57,17 +51,6 @@ signals:
   void msgUpdated(MessageId id);
   void msgRemoved(MessageId id);
   void DBCFileChanged();
-
-private:
-  void parseExtraInfo(const QString &content);
-  std::map<uint32_t, cabana::Msg> msgs;
-  QString name_;
-  QSet<uint8_t> sources;
-
-  inline const cabana::Msg *msg(uint32_t address) const {
-    auto it = msgs.find(address);
-    return it != msgs.end() ? &it->second : nullptr;
-  }
 };
 
 DBCManager *dbc();

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -38,6 +38,7 @@ public:
 
   QStringList signalNames() const;
   int msgCount() const;
+  int dbcCount() const;
 
   std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const uint8_t source) const;
   std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const MessageId &id) const;

--- a/tools/cabana/dbcmanager.h
+++ b/tools/cabana/dbcmanager.h
@@ -11,14 +11,17 @@
 #include "tools/cabana/dbc.h"
 #include "tools/cabana/dbcfile.h"
 
+typedef QSet<uint8_t> SourceSet;
+const SourceSet SOURCE_ALL = {};
+
 class DBCManager : public QObject {
   Q_OBJECT
 
 public:
   DBCManager(QObject *parent) {}
   ~DBCManager() {}
-  bool open(const QString &dbc_file_name, QString *error = nullptr);
-  bool open(const QString &name, const QString &content, QString *error = nullptr);
+  bool open(SourceSet s, const QString &dbc_file_name, QString *error = nullptr);
+  bool open(SourceSet s, const QString &name, const QString &content, QString *error = nullptr);
   QString generateDBC();
 
   void addSignal(const MessageId &id, const cabana::Signal &sig);
@@ -34,12 +37,11 @@ public:
 
   QStringList signalNames() const;
   int msgCount() const;
-  QString name() const;
 
 private:
   DBCFile *findDBCFile(const MessageId &id) const;
   QSet<uint8_t> sources;
-  std::unique_ptr<DBCFile> dbc_files; // TODO: Replace by list
+  QList<std::pair<SourceSet, DBCFile*>> dbc_files;
 
 public slots:
   void updateSources(const QSet<uint8_t> &s);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -414,6 +414,7 @@ void MainWindow::saveFile() {
       QString fn = QFileDialog::getSaveFileName(this, tr("Save File"), QDir::cleanPath(settings.last_dir + "/untitled.dbc"), tr("DBC (*.dbc)"));
       if (!fn.isEmpty()) {
         dbc_file->saveAs(fn);
+        updateRecentFiles(fn);
       }
     }
   }

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -256,6 +256,7 @@ void MainWindow::openRoute() {
 
 void MainWindow::newFile() {
   remindSaveChanges();
+  dbc()->closeAll();
   dbc()->open(SOURCE_ALL, "", "");
   updateLoadSaveMenus();
 }

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -112,9 +112,14 @@ void MainWindow::createActions() {
   file_menu->addAction(tr("Load DBC From Clipboard"), this, &MainWindow::loadDBCFromClipboard);
 
   file_menu->addSeparator();
-  file_menu->addAction(tr("Save DBC..."), this, &MainWindow::save)->setShortcuts(QKeySequence::Save);
-  file_menu->addAction(tr("Save DBC As..."), this, &MainWindow::saveAs)->setShortcuts(QKeySequence::SaveAs);
-  file_menu->addAction(tr("Copy DBC To Clipboard"), this, &MainWindow::saveDBCToClipboard);
+  save_dbc = file_menu->addAction(tr("Save DBC..."), this, &MainWindow::save);
+  save_dbc->setShortcuts(QKeySequence::Save);
+
+  save_dbc_as = file_menu->addAction(tr("Save DBC As..."), this, &MainWindow::saveAs);
+  save_dbc_as->setShortcuts(QKeySequence::SaveAs);
+
+  copy_dbc_to_clipboard = file_menu->addAction(tr("Copy DBC To Clipboard"), this, &MainWindow::saveDBCToClipboard);
+
   file_menu->addSeparator();
   file_menu->addAction(tr("Settings..."), this, &MainWindow::setOption)->setShortcuts(QKeySequence::Preferences);
 
@@ -421,6 +426,13 @@ void MainWindow::updateSources(const SourceSet &s) {
 }
 
 void MainWindow::updateLoadSaveMenus() {
+  if (dbc()->dbcCount() > 1) {
+    save_dbc->setText(tr("Save %1 DBCs...").arg(dbc()->dbcCount()));
+  } else {
+    save_dbc->setText(tr("Save DBC..."));
+  }
+  save_dbc_as->setEnabled(sources.size() == 1);
+
   open_dbc_for_source->setEnabled(sources.size() > 0);
 
   open_dbc_for_source->clear();

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -382,9 +382,6 @@ void MainWindow::loadDBCFromFingerprint() {
 
 void MainWindow::save() {
   saveFile();
-
-  // TODO: Check if we need to save as
-  // saveAs();
 }
 
 void MainWindow::autoSave() {
@@ -410,7 +407,6 @@ void MainWindow::saveFile() {
       dbc_file->save();
       updateRecentFiles(dbc_file->filename);
     } else {
-      // TODO: Show sources in prompt
       QString fn = QFileDialog::getSaveFileName(this, tr("Save File"), QDir::cleanPath(settings.last_dir + "/untitled.dbc"), tr("DBC (*.dbc)"));
       if (!fn.isEmpty()) {
         dbc_file->saveAs(fn);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -54,9 +54,13 @@ MainWindow::MainWindow() : QMainWindow() {
 
   main_win = this;
   qInstallMessageHandler(qLogMessageHandler);
-  QFile json_file("./car_fingerprint_to_dbc.json");
-  if (json_file.open(QIODevice::ReadOnly)) {
-    fingerprint_to_dbc = QJsonDocument::fromJson(json_file.readAll());
+
+  for (const QString &fn : {"./car_fingerprint_to_dbc.json", "./tools/cabana/car_fingerprint_to_dbc.json"}) {
+    QFile json_file(fn);
+    if (json_file.open(QIODevice::ReadOnly)) {
+      fingerprint_to_dbc = QJsonDocument::fromJson(json_file.readAll());
+      break;
+    }
   }
 
   setStyleSheet(QString(R"(QMainWindow::separator {

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -274,6 +274,7 @@ void MainWindow::loadFile(const QString &fn) {
     if (file.open(QIODevice::ReadOnly)) {
       auto dbc_name = QFileInfo(fn).baseName();
       QString error;
+      dbc()->closeAll();
       bool ret = dbc()->open(SOURCE_ALL, dbc_name, file.readAll(), &error);
       if (ret) {
         setCurrentFile(fn);
@@ -303,6 +304,8 @@ void MainWindow::openRecentFile() {
 
 void MainWindow::loadDBCFromOpendbc(const QString &name) {
   remindSaveChanges();
+
+  dbc()->closeAll();
   dbc()->open(SOURCE_ALL, name);
 }
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -231,7 +231,6 @@ void MainWindow::undoStackCleanChanged(bool clean) {
 
 void MainWindow::DBCFileChanged() {
   UndoStack::instance()->clear();
-  setWindowFilePath(QString("%1").arg(dbc()->name()));
 }
 
 void MainWindow::openRoute() {
@@ -247,7 +246,7 @@ void MainWindow::openRoute() {
 
 void MainWindow::newFile() {
   remindSaveChanges();
-  dbc()->open("untitled.dbc", "");
+  dbc()->open(SOURCE_ALL, "untitled.dbc", "");
 }
 
 void MainWindow::openFile() {
@@ -275,7 +274,7 @@ void MainWindow::loadFile(const QString &fn) {
     if (file.open(QIODevice::ReadOnly)) {
       auto dbc_name = QFileInfo(fn).baseName();
       QString error;
-      bool ret = dbc()->open(dbc_name, file.readAll(), &error);
+      bool ret = dbc()->open(SOURCE_ALL, dbc_name, file.readAll(), &error);
       if (ret) {
         setCurrentFile(fn);
         statusBar()->showMessage(tr("DBC File %1 loaded").arg(fn), 2000);
@@ -303,17 +302,15 @@ void MainWindow::openRecentFile() {
 }
 
 void MainWindow::loadDBCFromOpendbc(const QString &name) {
-  if (name != dbc()->name()) {
-    remindSaveChanges();
-    dbc()->open(name);
-  }
+  remindSaveChanges();
+  dbc()->open(SOURCE_ALL, name);
 }
 
 void MainWindow::loadDBCFromClipboard() {
   remindSaveChanges();
   QString dbc_str = QGuiApplication::clipboard()->text();
   QString error;
-  bool ret = dbc()->open("clipboard", dbc_str, &error);
+  bool ret = dbc()->open(SOURCE_ALL, "clipboard", dbc_str, &error);
   if (ret && dbc()->msgCount() > 0) {
     QMessageBox::information(this, tr("Load From Clipboard"), tr("DBC Successfully Loaded!"));
   } else {
@@ -327,7 +324,7 @@ void MainWindow::loadDBCFromClipboard() {
 
 void MainWindow::loadDBCFromFingerprint() {
   // Don't overwrite already loaded DBC
-  if (!dbc()->name().isEmpty()) {
+  if (dbc()->msgCount()) {
     return;
   }
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -465,7 +465,7 @@ void MainWindow::updateLoadSaveMenus() {
   open_dbc_for_source->clear();
 
   for (uint8_t source : sources_sorted) {
-    if (source >= 64) continue; // Sent and blocked busses are handled implicitly
+    if (source >= 64) continue; // Sent and blocked buses are handled implicitly
     QAction *action = new QAction(this);
 
     auto d = dbc()->findDBCFile(source);

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -83,6 +83,9 @@ protected:
   QAction *recent_files_acts[MAX_RECENT_FILES] = {};
   QMenu *open_recent_menu = nullptr;
   QMenu *open_dbc_for_source = nullptr;
+  QAction *save_dbc = nullptr;
+  QAction *save_dbc_as = nullptr;
+  QAction *copy_dbc_to_clipboard = nullptr;
   int prev_undostack_index = 0;
   int prev_undostack_count = 0;
   SourceSet sources;

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -14,8 +14,6 @@
 #include "tools/cabana/videowidget.h"
 #include "tools/cabana/tools/findsimilarbits.h"
 
-const QString AUTO_SAVE_EXTENSION = ".tmp";
-
 class MainWindow : public QMainWindow {
   Q_OBJECT
 
@@ -46,10 +44,10 @@ signals:
 
 protected:
   void remindSaveChanges();
-  void saveFile(const QString &fn);
+  void saveFile();
   void autoSave();
   void cleanupAutoSaveFile();
-  void setCurrentFile(const QString &fn);
+  void updateRecentFiles(const QString &fn);
   void updateRecentFileActions();
   void createActions();
   void createDockWindows();
@@ -78,7 +76,6 @@ protected:
   QLabel *status_label;
   QJsonDocument fingerprint_to_dbc;
   QSplitter *video_splitter;;
-  QString current_file = "";
   enum { MAX_RECENT_FILES = 15 };
   QAction *recent_files_acts[MAX_RECENT_FILES] = {};
   QMenu *open_recent_menu = nullptr;

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -23,7 +23,7 @@ public:
   MainWindow();
   void dockCharts(bool dock);
   void showStatusMessage(const QString &msg, int timeout = 0) { statusBar()->showMessage(msg, timeout); }
-  void loadFile(const QString &fn, SourceSet sources = SOURCE_ALL, bool close_all = true);
+  void loadFile(const QString &fn, SourceSet s = SOURCE_ALL, bool close_all = true);
 
 public slots:
   void openRoute();
@@ -65,6 +65,7 @@ protected:
   void onlineHelp();
   void toggleFullScreen();
   void updateStatus();
+  void updateLoadSaveMenus();
 
   VideoWidget *video_widget = nullptr;
   QDockWidget *video_dock;
@@ -84,6 +85,7 @@ protected:
   QMenu *open_dbc_for_source = nullptr;
   int prev_undostack_index = 0;
   int prev_undostack_count = 0;
+  SourceSet sources;
   friend class OnlineHelp;
 };
 

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -28,6 +28,7 @@ public slots:
   void openRoute();
   void newFile();
   void openFile();
+  void openFileForSource();
   void openRecentFile();
   void openOpendbcFile();
   void loadDBCFromOpendbc(const QString &name);
@@ -36,6 +37,7 @@ public slots:
   void save();
   void saveAs();
   void saveDBCToClipboard();
+  void updateSources(const QSet<uint8_t> &s);
 
 signals:
   void showMessage(const QString &msg, int timeout);
@@ -78,6 +80,7 @@ protected:
   enum { MAX_RECENT_FILES = 15 };
   QAction *recent_files_acts[MAX_RECENT_FILES] = {};
   QMenu *open_recent_menu = nullptr;
+  QMenu *open_dbc_for_source = nullptr;
   int prev_undostack_index = 0;
   int prev_undostack_count = 0;
   friend class OnlineHelp;

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -8,6 +8,7 @@
 #include <QStatusBar>
 
 #include "tools/cabana/chartswidget.h"
+#include "tools/cabana/dbcmanager.h"
 #include "tools/cabana/detailwidget.h"
 #include "tools/cabana/messageswidget.h"
 #include "tools/cabana/videowidget.h"
@@ -22,7 +23,7 @@ public:
   MainWindow();
   void dockCharts(bool dock);
   void showStatusMessage(const QString &msg, int timeout = 0) { statusBar()->showMessage(msg, timeout); }
-  void loadFile(const QString &fn);
+  void loadFile(const QString &fn, SourceSet sources = SOURCE_ALL, bool close_all = true);
 
 public slots:
   void openRoute();
@@ -37,7 +38,7 @@ public slots:
   void save();
   void saveAs();
   void saveDBCToClipboard();
-  void updateSources(const QSet<uint8_t> &s);
+  void updateSources(const SourceSet &s);
 
 signals:
   void showMessage(const QString &msg, int timeout);

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -64,11 +64,11 @@ signals:
   void updated();
   void msgsReceived(const QHash<MessageId, CanData> *);
   void received(QHash<MessageId, CanData> *);
-  void sourcesUpdated(const QSet<uint8_t> &s);
+  void sourcesUpdated(const SourceSet &s);
 
 public:
   QHash<MessageId, CanData> last_msgs;
-  QSet<uint8_t> sources;
+  SourceSet sources;
 
 protected:
   virtual void process(QHash<MessageId, CanData> *);

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -11,9 +11,9 @@ const std::string TEST_RLOG_URL = "https://commadata2.blob.core.windows.net/comm
 
 TEST_CASE("DBCManager::generateDBC") {
   DBCManager dbc_origin(nullptr);
-  dbc_origin.open("toyota_new_mc_pt_generated");
+  dbc_origin.open({0}, "toyota_new_mc_pt_generated");
   DBCManager dbc_from_generated(nullptr);
-  dbc_from_generated.open("", dbc_origin.generateDBC());
+  dbc_from_generated.open({0}, "", dbc_origin.generateDBC());
 
   REQUIRE(dbc_origin.msgCount() == dbc_from_generated.msgCount());
   auto msgs = dbc_origin.getMessages(0);
@@ -33,7 +33,7 @@ TEST_CASE("DBCManager::generateDBC") {
 
 TEST_CASE("Parse can messages") {
   DBCManager dbc(nullptr);
-  dbc.open("toyota_new_mc_pt_generated");
+  dbc.open({0}, "toyota_new_mc_pt_generated");
   CANParser can_parser(0, "toyota_new_mc_pt_generated", {}, {});
 
   LogReader log;

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -9,15 +9,14 @@
 // demo route, first segment
 const std::string TEST_RLOG_URL = "https://commadata2.blob.core.windows.net/commadata2/4cf7a6ad03080c90/2021-09-29--13-46-36/0/rlog.bz2";
 
-TEST_CASE("DBCManager::generateDBC") {
-  DBCManager dbc_origin(nullptr);
-  dbc_origin.open({0}, "toyota_new_mc_pt_generated");
-  DBCManager dbc_from_generated(nullptr);
-  dbc_from_generated.open({0}, "", dbc_origin.generateDBC());
+TEST_CASE("DBCFile::generateDBC") {
+  QString fn = QString("%1/%2.dbc").arg(OPENDBC_FILE_PATH, "toyota_new_mc_pt_generated");
+  DBCFile dbc_origin(fn);
+  DBCFile dbc_from_generated("", dbc_origin.generateDBC());
 
   REQUIRE(dbc_origin.msgCount() == dbc_from_generated.msgCount());
-  auto msgs = dbc_origin.getMessages(0);
-  auto new_msgs = dbc_from_generated.getMessages(0);
+  auto msgs = dbc_origin.getMessages();
+  auto new_msgs = dbc_from_generated.getMessages();
   for (auto &[id, m] : msgs) {
     auto &new_m = new_msgs.at(id);
     REQUIRE(m.name == new_m.name);

--- a/tools/cabana/tools/findsimilarbits.cc
+++ b/tools/cabana/tools/findsimilarbits.cc
@@ -20,7 +20,7 @@ FindSimilarBitsDlg::FindSimilarBitsDlg(QWidget *parent) : QDialog(parent, Qt::Wi
   QHBoxLayout *src_layout = new QHBoxLayout();
   src_bus_combo = new QComboBox(this);
   find_bus_combo = new QComboBox(this);
-  QSet<uint8_t> bus_set;
+  SourceSet bus_set;
   for (auto it = can->last_msgs.begin(); it != can->last_msgs.end(); ++it) {
     bus_set << it.key().source;
   }


### PR DESCRIPTION
Add option to open separate DBC file  for each bus. Still possible to open a DBC that applies to all busses.

Technically you should also be able to add multiple DBC files for the same bus (in cases where each node has it's own DBC), but will consider that out of scope for this PR.

Tried to keep the changes as minimal as possible, but it still got quite big.

Currently supported:
- Opening a .dbc file that applies to all busses
- Opening a .dbc file that applies to one ore more specific busses
- Having multiple .dbc files open at the same time
- Opening a file from opendbc that applies to all busses
- Opening a recent file that applies to all busses

Not (yet) supported, todo in separate PRs:
 - Save as with more than one file open
 - Save to clipboard with more than one file open
 - Creating a new DBC file for a specific bus only
 - Closing a DBC file
 - Opening a DBC from opendbc or recent files that applies to a specific bus (instead of all)
 - An advanced DBC manager dialog where you can do things like change bus assignments or load multiple DBC files for the same bus.
 - Add radar bus DBC to `loadDBCFromFingerprint` to load both files automatically.


![image](https://user-images.githubusercontent.com/1314752/227890755-15720cb6-9647-4df6-b882-98561acbff1e.png)

![image](https://user-images.githubusercontent.com/1314752/227890922-885bda12-00c5-4978-b88f-7f6a765084dc.png)
