### PR TITLE
setup: set download timeout

### DIFF
--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -53,6 +53,7 @@ void Setup::download(QString url) {
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_USERAGENT, (USER_AGENT + version).c_str());
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
 
   int ret = curl_easy_perform(curl);
   long res_status = 0;


### PR DESCRIPTION
installer binary is approx 200KB, 30 seconds should be more than enough time to download, even on mobile data

https://curl.se/libcurl/c/CURLOPT_TIMEOUT.html