### PR TITLE
cabana: right align signal values & fixed text overflow

### DIFF
--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -338,6 +338,15 @@ void SignalItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     text = painter->fontMetrics().elidedText(text, Qt::ElideRight, text_rect.width());
     painter->drawText(text_rect, option.displayAlignment, text);
     painter->restore();
+  } else if (index.column() == 1 && item && item->type == SignalModel::Item::Sig) {
+    // draw signal value
+    if (option.state & QStyle::State_Selected) {
+      painter->fillRect(option.rect, option.palette.highlight());
+    }
+    painter->setPen((option.state & QStyle::State_Selected ? option.palette.highlightedText() : option.palette.text()).color());
+    QRect rc = option.rect.adjusted(0, 0, -70, 0);
+    auto text = painter->fontMetrics().elidedText(index.data(Qt::DisplayRole).toString(), Qt::ElideRight, rc.width());
+    painter->drawText(rc, Qt::AlignRight | Qt::AlignVCenter, text);
   } else {
     QStyledItemDelegate::paint(painter, option, index);
   }


### PR DESCRIPTION
![Screenshot from 2023-02-24 10-12-32](https://user-images.githubusercontent.com/27770/221076717-543b10aa-73e0-4eb4-bfee-54eee00feae8.png)

before:
![Screenshot from 2023-02-24 10-19-46](https://user-images.githubusercontent.com/27770/221076712-235c44df-3072-4e91-baa9-444d7d1f54e5.png)
![Screenshot from 2023-02-24 10-27-07](https://user-images.githubusercontent.com/27770/221077068-e6cc04a0-4838-412d-b8c9-59346a9ab3e2.png)
