### PR TITLE
cabana: fix gaps in step line between chunks

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -549,7 +549,12 @@ void ChartView::updateSeries(const Signal *sig, const std::vector<Event *> *even
       });
       for (auto &c : chunks) {
         s.vals.append(c.vals);
-        s.step_vals.append(c.step_vals);
+        if (!c.step_vals.empty()) {
+          if (!s.step_vals.empty()) {
+            s.step_vals.append({c.step_vals.first().x(), s.step_vals.back().y()});
+          }
+          s.step_vals.append(c.step_vals);
+        }
       }
       if (events->size()) {
         s.last_value_mono_time = events->back()->mono_time;


### PR DESCRIPTION
before:
![2023-02-24_22-12](https://user-images.githubusercontent.com/27770/221202619-00248e64-3e26-4dec-8197-003b453db40f.png)

after:

![2023-02-24_22-21](https://user-images.githubusercontent.com/27770/221202579-ee2f0899-06d5-4d6b-9dc8-fb8240912426.png)
