### PR TITLE
Hyundai: Sonata FW version to enable radar tracks

### DIFF
--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -32,6 +32,9 @@ SUPPORTED_FW_VERSIONS = {
   b"DN8_ SCC FHCUP      1.00 1.00 99110-L0000\x19\x08)\x15T    ": ConfigValues(
     default_config=b"\x00\x00\x00\x01\x00\x00",
     tracks_enabled=b"\x00\x00\x00\x01\x00\x01"),
+  b"DN8_ SCC F-CUP      1.00 1.00 99110-L0000\x19\x08)\x15T    ": ConfigValues(
+    default_config=b"\x00\x00\x00\x01\x00\x00",
+    tracks_enabled=b"\x00\x00\x00\x01\x00\x01"),
   # 2021 SONATA HYBRID
   b"DNhe SCC FHCUP      1.00 1.02 99110-L5000 \x01#\x15#    ": ConfigValues(
     default_config=b"\x00\x00\x00\x01\x00\x00",


### PR DESCRIPTION
User was able to enable radar tracks on the 2020 Hyundai Sonata with the radar FW version added to the script.

Route: `4f3e4f2f6d94e940|2023-02-25--09-33-11`

Thanks to community 2020 Hyundai Sonata owner goodchoom.