### PR TITLE
cabana: recalc y-axis label width after unit change

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -591,10 +591,13 @@ void ChartView::updateAxisY() {
       if (it->y() > max) max = it->y();
     }
   }
-  axis_y->setTitleText(unit);
-
   if (min == std::numeric_limits<double>::max()) min = 0;
   if (max == std::numeric_limits<double>::lowest()) max = 0;
+
+  if (axis_y->titleText() != unit) {
+    axis_y->setTitleText(unit);
+    y_label_width = 0;// recalc width
+  }
 
   double delta = std::abs(max - min) < 1e-3 ? 1 : (max - min) * 0.05;
   auto [min_y, max_y, tick_count] = getNiceAxisNumbers(min - delta, max + delta, axis_y->tickCount());


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
|![Screenshot from 2023-03-01 13-40-42](https://user-images.githubusercontent.com/27770/222054929-20adbe39-971e-4fae-823e-5881aa1bfeb5.png) |![Screenshot from 2023-03-01 13-41-39](https://user-images.githubusercontent.com/27770/222054920-e08eb109-25b4-48f2-b06b-df0a0631b704.png)  |


