### PR TITLE
replay: fixed the status is always "loading" if there is no carState in events

### DIFF
--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -165,7 +165,10 @@ void ConsoleUI::updateStatus() {
   sm.update(0);
 
   if (status != Status::Paused) {
-    status = (sm.updated("carState") || sm.updated("liveParameters")) ? Status::Playing : Status::Waiting;
+    auto events = replay->events();
+    uint64_t current_mono_time = replay->routeStartTime() + replay->currentSeconds() * 1e9;
+    bool playing = !events->empty() && events->back()->mono_time > current_mono_time;
+    status = playing ? Status::Playing : Status::Waiting;
   }
   auto [status_str, status_color] = status_text[status];
   write_item(0, 0, "STATUS:    ", status_str, "      ", false, status_color);


### PR DESCRIPTION
related issue  https://github.com/commaai/openpilot/pull/27107#issuecomment-1451028048 :

![2023-03-02_19-38](https://user-images.githubusercontent.com/27770/222418315-cd59d244-863c-43e8-9e88-97c3dff8b349.png)

