### PR TITLE
cabana:  use a segment tree to solve range queries in O(log n) time complexity

### DIFF
--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -46,6 +46,7 @@ public:
     QVector<QPointF> step_vals;
     uint64_t last_value_mono_time = 0;
     QPointF track_pt{};
+    SegmentTree segment_tree;
   };
 
 signals:

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -67,6 +67,40 @@ void ChangeTracker::clear() {
   colors.clear();
 }
 
+
+// SegmentTree
+
+void SegmentTree::build(const QVector<QPointF> &arr) {
+  size = arr.size();
+  tree.resize(4 * size);  // size of the tree is 4 times the size of the array
+  if (size > 0) {
+    build_tree(arr, 1, 0, size - 1);
+  }
+}
+
+void SegmentTree::build_tree(const QVector<QPointF> &arr, int n, int left, int right) {
+  if (left == right) {
+    const double y = arr[left].y();
+    tree[n] = {y, y};
+  } else {
+    const int mid = (left + right) >> 1;
+    build_tree(arr, 2 * n, left, mid);
+    build_tree(arr, 2 * n + 1, mid + 1, right);
+    tree[n] = {std::min(tree[2 * n].first, tree[2 * n + 1].first), std::max(tree[2 * n].second, tree[2 * n + 1].second)};
+  }
+}
+
+std::pair<double, double> SegmentTree::get_minmax(int n, int left, int right, int range_left, int range_right) const {
+  if (range_left > right || range_right < left)
+    return {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest()};
+  if (range_left <= left && range_right >= right)
+    return tree[n];
+  int mid = (left + right) >> 1;
+  auto l = get_minmax(2 * n, left, mid, range_left, range_right);
+  auto r = get_minmax(2 * n + 1, mid + 1, right, range_left, range_right);
+  return {std::min(l.first, r.first), std::max(l.second, r.second)};
+}
+
 // MessageBytesDelegate
 
 MessageBytesDelegate::MessageBytesDelegate(QObject *parent) : QStyledItemDelegate(parent) {

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -35,6 +35,19 @@ enum {
   BytesRole = Qt::UserRole + 2
 };
 
+class SegmentTree {
+public:
+  SegmentTree() = default;
+  void build(const QVector<QPointF> &arr);
+  inline std::pair<double, double> minmax(int left, int right) const { return get_minmax(1, 0, size - 1, left, right); }
+
+private:
+  std::pair<double, double> get_minmax(int n, int left, int right, int range_left, int range_right) const;
+  void build_tree(const QVector<QPointF> &arr, int n, int left, int right);
+  std::vector<std::pair<double ,double>> tree;
+  int size = 0;
+};
+
 class MessageBytesDelegate : public QStyledItemDelegate {
   Q_OBJECT
 public:


### PR DESCRIPTION
issue: 
function `updateAxisY`(O(N)) is heavily  called in ui thread,  this could lead to lagging when there are multiple charts with a large number of events. 

resolve: 
using a segment tree to improve the performance of range query for min and max values.

[Kazam_screencast_00088.webm](https://user-images.githubusercontent.com/27770/222913871-fcb97d0f-9dcb-46b0-b392-a1923c935a38.webm)
