### PR TITLE
cabana: improve the performance of updating TreeView in real-time.

### DIFF
--- a/tools/cabana/signaledit.h
+++ b/tools/cabana/signaledit.h
@@ -85,6 +85,7 @@ public:
   QValidator *name_validator, *double_validator;
   QFont small_font;
   const int color_label_width = 18;
+  mutable QHash<QString, int> width_cache;
 };
 
 class SignalView : public QFrame {


### PR DESCRIPTION
cache sizeHint can improve the performance of `SignalModel::updateState` by 10 to 20 times.
