### PR TITLE
replay: fix incorrect format string in seekTo 

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -193,7 +193,7 @@ std::optional<uint64_t> Replay::find(FindFlag flag) {
 
 void Replay::pause(bool pause) {
   updateEvents([=]() {
-    rWarning("%s at %d s", pause ? "paused..." : "resuming", currentSeconds());
+    rWarning("%s at %.2f s", pause ? "paused..." : "resuming", currentSeconds());
     paused_ = pause;
     return true;
   });


### PR DESCRIPTION
fix incorrect format string:
![2023-03-10_01-01](https://user-images.githubusercontent.com/27770/224101008-853c2b77-b7d3-4120-a7ef-6eda7cec491b.png)

after:

![Screenshot from 2023-03-10 01-01-57](https://user-images.githubusercontent.com/27770/224100976-be9dd5d5-f0cc-4dfa-9aaf-d7462c1771b3.png)