### PR TITLE
cabana: get icon size from QStyle::PM_SmallIconSize

### DIFF
--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -170,6 +170,8 @@ QToolButton *toolButton(const QString &icon, const QString &tooltip) {
   btn->setIcon(utils::icon(icon));
   btn->setToolTip(tooltip);
   btn->setAutoRaise(true);
+  const int metric = qApp->style()->pixelMetric(QStyle::PM_SmallIconSize);
+  btn->setIconSize({metric, metric});
   return btn;
 };
 


### PR DESCRIPTION
The current icon size is equal to the size of bootstrap icons. this can cause icons to appear too large on some devices.