### PR TITLE
cabana: extend max chart range to 30 minutes

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -45,7 +45,7 @@ ChartsWidget::ChartsWidget(QWidget *parent) : QFrame(parent) {
   toolbar->addWidget(stretch_label);
 
   range_lb_action = toolbar->addWidget(range_lb = new QLabel(this));
-  range_slider = new QSlider(Qt::Horizontal, this);
+  range_slider = new LogSlider(1000, Qt::Horizontal, this);
   range_slider->setMaximumWidth(200);
   range_slider->setToolTip(tr("Set the chart range"));
   range_slider->setRange(1, settings.max_cached_minutes * 60);
@@ -163,7 +163,7 @@ void ChartsWidget::updateState() {
 }
 
 void ChartsWidget::setMaxChartRange(int value) {
-  max_chart_range = settings.chart_range = value;
+  max_chart_range = settings.chart_range = range_slider->value();
   updateToolBar();
   updateState();
 }

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -138,7 +138,7 @@ private:
 
   QLabel *title_label;
   QLabel *range_lb;
-  QSlider *range_slider;
+  LogSlider *range_slider;
   QAction *range_lb_action;
   QAction *range_slider_action;
   bool docking = true;

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -32,7 +32,7 @@ void Settings::save() {
 void Settings::load() {
   QSettings s("settings", QSettings::IniFormat);
   fps = s.value("fps", 10).toInt();
-  max_cached_minutes = s.value("max_cached_minutes", 5).toInt();
+  max_cached_minutes = s.value("max_cached_minutes", 30).toInt();
   chart_height = s.value("chart_height", 200).toInt();
   chart_range = s.value("chart_range", 3 * 60).toInt();
   chart_column_count = s.value("chart_column_count", 1).toInt();

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -14,7 +14,7 @@ public:
   void load();
 
   int fps = 10;
-  int max_cached_minutes = 5;
+  int max_cached_minutes = 30;
   int chart_height = 200;
   int chart_column_count = 1;
   int chart_range = 3 * 60; // e minutes

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 
 #include <QByteArray>
 #include <QColor>
@@ -29,6 +30,23 @@ private:
   const float fade_time = 2.0;
   QByteArray prev_dat;
 };
+
+class LogSlider : public QSlider {
+  Q_OBJECT
+
+public:
+  LogSlider(double factor, Qt::Orientation orientation, QWidget *parent = nullptr) : factor(factor), QSlider(orientation, parent) {};
+
+  void setRange(double min, double max) { QSlider::setRange(logScale(min), logScale(max)); }
+  int value() const { return invLogScale(QSlider::value()); }
+  void setValue(int value) { QSlider::setValue(logScale(value)); }
+
+private:
+  double factor;
+  int logScale(int value) const { return factor * std::log10(value); }
+  int invLogScale(int value) const { return std::pow(10, value / factor); }
+};
+
 
 enum {
   ColorsRole = Qt::UserRole + 1,


### PR DESCRIPTION
Change range slider to a log scale, otherwise selecting smaller ranges is almost impossible.