### PR TITLE
cabana: show signal values with consistent number of digits

### DIFF
--- a/tools/cabana/dbc.cc
+++ b/tools/cabana/dbc.cc
@@ -1,4 +1,5 @@
 #include "tools/cabana/dbc.h"
+#include "tools/cabana/util.h"
 
 uint qHash(const MessageId &item) {
   return qHash(item.source) ^ qHash(item.address);
@@ -10,6 +11,10 @@ std::vector<const cabana::Signal*> cabana::Msg::getSignals() const {
   for (auto &sig : sigs) ret.push_back(&sig);
   std::sort(ret.begin(), ret.end(), [](auto l, auto r) { return l->start_bit < r->start_bit; });
   return ret;
+}
+
+void cabana::Signal::updatePrecision() {
+  precision = std::max(num_decimals(factor), num_decimals(offset));
 }
 
 // helper functions

--- a/tools/cabana/dbc.h
+++ b/tools/cabana/dbc.h
@@ -51,6 +51,8 @@ namespace cabana {
     QString min, max, unit;
     QString comment;
     ValueDescription val_desc;
+    int precision = 0;
+    void updatePrecision();
   };
 
   struct Msg {

--- a/tools/cabana/dbcmanager.cc
+++ b/tools/cabana/dbcmanager.cc
@@ -38,6 +38,7 @@ bool DBCManager::open(const QString &name, const QString &content, QString *erro
         sig.factor = s.factor;
         sig.offset = s.offset;
         sig.is_little_endian = s.is_little_endian;
+        sig.updatePrecision();
       }
     }
     parseExtraInfo(content);

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -14,11 +14,14 @@ QVariant HistoryLogModel::data(const QModelIndex &index, int role) const {
     if (index.column() == 0) {
       return QString::number((m.mono_time / (double)1e9) - can->routeStartTime(), 'f', 2);
     }
-    return show_signals ? QString::number(m.sig_values[index.column() - 1]) : toHex(m.data);
+    int i = index.column() - 1;
+    return show_signals ? QString::number(m.sig_values[i], 'f', sigs[i]->precision) : toHex(m.data);
   } else if (role == ColorsRole) {
     return QVariant::fromValue(m.colors);
   } else if (role == BytesRole) {
     return m.data;
+  } else if (role == Qt::TextAlignmentRole) {
+    return Qt::AlignRight;
   }
   return {};
 }
@@ -235,7 +238,7 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   delegate = new MessageBytesDelegate(this);
   logs->setItemDelegateForColumn(1, new MessageBytesDelegate(this));
   logs->setHorizontalHeader(new HeaderView(Qt::Horizontal, this));
-  logs->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | (Qt::Alignment)Qt::TextWordWrap);
+  logs->horizontalHeader()->setDefaultAlignment(Qt::AlignRight | (Qt::Alignment)Qt::TextWordWrap);
   logs->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
   logs->verticalHeader()->setVisible(false);
   logs->setFrameShape(QFrame::NoFrame);

--- a/tools/cabana/signaledit.cc
+++ b/tools/cabana/signaledit.cc
@@ -62,7 +62,7 @@ void SignalModel::updateState(const QHash<MessageId, CanData> *msgs) {
     auto &dat = can->lastMessage(msg_id).dat;
     int row = 0;
     for (auto item : root->children) {
-      QString value = QString::number(get_raw_value((uint8_t *)dat.begin(), dat.size(), *item->sig));
+      QString value = QString::number(get_raw_value((uint8_t *)dat.begin(), dat.size(), *item->sig), 'f', item->sig->precision);
       if (!item->sig->unit.isEmpty()){
         value += " " + item->sig->unit;
       }
@@ -184,6 +184,7 @@ bool SignalModel::setData(const QModelIndex &index, const QVariant &value, int r
     case Item::Desc: s.val_desc = value.value<ValueDescription>(); break;
     default: return false;
   }
+  s.updatePrecision();
   bool ret = saveSignal(item->sig, s);
   emit dataChanged(index, index, {Qt::DisplayRole, Qt::EditRole, Qt::CheckStateRole});
   return ret;

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -184,3 +184,13 @@ QString toHex(uint8_t byte) {
   }();
   return hex[byte];
 }
+
+int num_decimals(double num) {
+   const QString string = QString::number(num);
+   const QStringList split = string.split('.');
+   if (split.size() == 1) {
+     return 0;
+   } else {
+     return split[1].size();
+   }
+ }

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -91,3 +91,4 @@ QPixmap icon(const QString &id);
 }
 
 QToolButton *toolButton(const QString &icon, const QString &tooltip);
+int num_decimals(double num);


### PR DESCRIPTION
Show consistent number of decimal places in signal and history view to prevent numbers moving around. Make historyview align right.

Merge after https://github.com/commaai/openpilot/pull/27552 to prevent conflicts.

Before:
![Screenshot 2023-03-10 at 11 39 03](https://user-images.githubusercontent.com/1314752/224295755-d9018d4d-599e-435a-b2f8-8814f1b535bf.png)

After:
![Screenshot 2023-03-10 at 11 37 45](https://user-images.githubusercontent.com/1314752/224295842-63841317-aa0f-4241-8465-4a8c1c54c626.png)

Before:
![Screenshot 2023-03-10 at 11 39 22](https://user-images.githubusercontent.com/1314752/224295607-32e531c0-8613-4bc3-8316-aaa46d4a0593.png)
After:
![Screenshot 2023-03-10 at 11 37 34](https://user-images.githubusercontent.com/1314752/224295621-d2a1a270-a9f9-4c09-8b61-831ddedfe9e2.png)
