### PR TITLE
cabana: fix hang on scrubbing in zommed chart

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -723,10 +723,12 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
 void ChartView::mouseMoveEvent(QMouseEvent *ev) {
   // Scrubbing
   if (is_scrubbing && QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
-    double t = chart()->mapToValue({(double)ev->x(), (double)ev->y()}).x();
-    // Prevent seeking past the end of the route
-    t = std::clamp(t, 0., can->totalSeconds());
-    can->seekTo(t);
+    if (chart()->plotArea().contains(ev->pos())) {
+      double t = chart()->mapToValue(ev->pos()).x();
+      // Prevent seeking past the end of the route
+      t = std::clamp(t, 0., can->totalSeconds());
+      can->seekTo(t);
+    }
     return;
   }
 

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -1,5 +1,5 @@
 #include "tools/cabana/streams/abstractstream.h"
-
+#include <QTimer>
 #include <QtConcurrent>
 
 AbstractStream *can = nullptr;
@@ -115,6 +115,8 @@ void AbstractStream::updateLastMsgsTo(double sec) {
       m.value().freq = m.value().count / std::max(1.0, m.value().ts);
     }
   }
-  emit updated();
-  emit msgsReceived(&can_msgs);
+  QTimer::singleShot(0, [this]() {
+    emit updated();
+    emit msgsReceived(&can_msgs);
+  });
 }


### PR DESCRIPTION
fixed: Seekto will be called recursively If scrub goes out of the zoomed range.