### PR TITLE
cabana: fix incorrect current ts in live stream mode

### DIFF
--- a/tools/cabana/streams/livestream.h
+++ b/tools/cabana/streams/livestream.h
@@ -32,7 +32,6 @@ protected:
   std::atomic<uint64_t> current_ts = 0;
   std::atomic<float> speed_ = 1;
   std::atomic<bool> pause_ = false;
-  uint64_t last_update_event_ts = 0;
   uint64_t last_update_ts = 0;
 
   const QString zmq_address;


### PR DESCRIPTION
- The current time is incorrectly set to the latest received can event time, not the current playing time when playing at slow speed(0.1x or 0.5x):

  [Kazam_screencast_00095.webm](https://user-images.githubusercontent.com/27770/224890380-7b19d1ff-0aee-4197-bc95-7aae8e8b67fe.webm)


- After fixed:

  [Kazam_screencast_00093.webm](https://user-images.githubusercontent.com/27770/224890479-3e24fee0-493c-491a-b992-8c5bc1ab63db.webm)
