### PR TITLE
ui: remove lupdate warnings: "Qualifying with unknown namespace"

### DIFF
--- a/selfdrive/ui/update_translations.py
+++ b/selfdrive/ui/update_translations.py
@@ -19,7 +19,7 @@ def update_translations(vanish=False, plural_only=None, translations_dir=TRANSLA
 
   for file in translation_files.values():
     tr_file = os.path.join(translations_dir, f"{file}.ts")
-    args = f"lupdate -locations none -recursive {UI_DIR} -ts {tr_file}"
+    args = f"lupdate -locations none -recursive {UI_DIR} -ts {tr_file} -I {BASEDIR}"
     if vanish:
       args += " -no-obsolete"
     if file in plural_only:


### PR DESCRIPTION
This change removes multiple "Qualifying with unknown namespace/class" warnings in `update_translations.py`
> ....
/openpilot/selfdrive/ui/qt/offroad/experimental_mode.cc:75: Qualifying with unknown namespace/class ::ExperimentalModeButton
/openpilot/selfdrive/ui/qt/offroad/networking.cc:32: Qualifying with unknown namespace/class ::Networking
/openpilot/selfdrive/ui/qt/offroad/networking.cc:89: Qualifying with unknown namespace/class ::Networking
/openpilot/selfdrive/ui/qt/offroad/networking.cc:99: Qualifying with unknown namespace/class ::Networking
/openpilot/selfdrive/ui/qt/offroad/networking.cc:123: Qualifying with unknown namespace/class ::AdvancedNetworking
...