### PR TITLE
camerad: remove exp_lock, setting exposure parameters in `set_camera_exposure`.

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -161,10 +161,7 @@ void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &fr
   framed.setLensErr(frame_data.lens_err);
   framed.setLensTruePos(frame_data.lens_true_pos);
   framed.setProcessingTime(frame_data.processing_time);
-
-  const float ev = c->cur_ev[frame_data.frame_id % 3];
-  const float perc = util::map_val(ev, c->min_ev, c->max_ev, 0.0f, 100.0f);
-  framed.setExposureValPercent(perc);
+  framed.setExposureValPercent(frame_data.exposure_val_percent);
 
   if (c->camera_id == CAMERA_ID_AR0231) {
     framed.setSensor(cereal::FrameData::ImageSensor::AR0231);

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -65,6 +65,7 @@ typedef struct FrameMetadata {
   float gain;
   float measured_grey_fraction;
   float target_grey_fraction;
+  float exposure_val_percent;
 
   // Focus
   unsigned int lens_pos;

--- a/system/camerad/cameras/camera_qcom2.h
+++ b/system/camerad/cameras/camera_qcom2.h
@@ -20,13 +20,10 @@ public:
   CameraInfo ci;
   bool enabled;
 
-  std::mutex exp_lock;
-
   int exposure_time;
   bool dc_gain_enabled;
   int dc_gain_weight;
   int gain_idx;
-  float analog_gain_frac;
 
   int exposure_time_min;
   int exposure_time_max;
@@ -51,7 +48,6 @@ public:
   int new_exp_g;
   int new_exp_t;
 
-  float measured_grey_fraction;
   float target_grey_fraction;
   float target_grey_factor;
 


### PR DESCRIPTION
Setting the exposure parameters in `CameraState::handle_camera_event` will complicate the code, an can cause the exposure parameters to differ from the actual exposure parameters of the current frame.


