### PR TITLE
camerad: remove deprecated focus parameters from FrameMetadata

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -157,9 +157,6 @@ void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &fr
   framed.setHighConversionGain(frame_data.high_conversion_gain);
   framed.setMeasuredGreyFraction(frame_data.measured_grey_fraction);
   framed.setTargetGreyFraction(frame_data.target_grey_fraction);
-  framed.setLensPos(frame_data.lens_pos);
-  framed.setLensErr(frame_data.lens_err);
-  framed.setLensTruePos(frame_data.lens_true_pos);
   framed.setProcessingTime(frame_data.processing_time);
 
   const float ev = c->cur_ev[frame_data.frame_id % 3];

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -66,11 +66,6 @@ typedef struct FrameMetadata {
   float measured_grey_fraction;
   float target_grey_fraction;
 
-  // Focus
-  unsigned int lens_pos;
-  float lens_err;
-  float lens_true_pos;
-
   float processing_time;
 } FrameMetadata;
 


### PR DESCRIPTION
related cereal pr: https://github.com/commaai/cereal/pull/423