### PR TITLE
Subaru: show alert for when stock ACC disengages

### DIFF
--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -231,6 +231,7 @@ class CarState(CarStateBase):
         ("Distance_Swap", "ES_Distance"),
         ("Standstill", "ES_Distance"),
         ("Signal3", "ES_Distance"),
+        ("Cruise_Soft_Disable", "ES_Distance"),
         ("Close_Distance", "ES_Distance"),
         ("Signal4", "ES_Distance"),
         ("Standstill_2", "ES_Distance"),

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -108,7 +108,12 @@ class CarInterface(CarInterfaceBase):
 
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_body)
 
-    ret.events = self.create_common_events(ret).to_msg()
+    events = self.create_common_events(ret)
+    # EyeSight soft disable (e.g. bad lighting or weather)
+    if self.CS.es_distance_msg["Cruise_Soft_Disable"] != 0:
+      events.add(car.CarEvent.EventName.cruiseDisabled)
+
+    ret.events = events.to_msg()
 
     return ret
 


### PR DESCRIPTION
As discussed earlier, we don't want to continue using the `cruiseDisabled` event in its current form (immediate disable without no entry), so I'll think about how we want to do this.

Todos:
- [ ] The car is in a no entry state, add button presses and show alert (make `cruiseDisabled` a `noEntry`)
- [ ] What happens if `carState.cruiseState.enabled` falls before the soft disable signal, or we see it that way? Do we not alert? Need to see how that works.

<img width="322" alt="Screenshot_53" src="https://user-images.githubusercontent.com/25857203/226796258-3e9b117a-e429-461e-85c3-19d1c3564067.png">