### PR TITLE
camerad: remove exp_lock, setting exposure parameters in set_camera_exposure

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -156,10 +156,7 @@ void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &fr
   framed.setMeasuredGreyFraction(frame_data.measured_grey_fraction);
   framed.setTargetGreyFraction(frame_data.target_grey_fraction);
   framed.setProcessingTime(frame_data.processing_time);
-
-  const float ev = c->cur_ev[frame_data.frame_id % 3];
-  const float perc = util::map_val(ev, c->min_ev, c->max_ev, 0.0f, 100.0f);
-  framed.setExposureValPercent(perc);
+  framed.setExposureValPercent(frame_data.exposure_val_percent);
 
   if (c->camera_id == CAMERA_ID_AR0231) {
     framed.setSensor(cereal::FrameData::ImageSensor::AR0231);

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -64,6 +64,7 @@ typedef struct FrameMetadata {
   float gain;
   float measured_grey_fraction;
   float target_grey_fraction;
+  float exposure_val_percent;
 
   float processing_time;
 } FrameMetadata;

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -1217,9 +1217,6 @@ static void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) 
 
 void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
   const CameraBuf *b = &c->buf;
-  const auto [x, y, w, h] = (c == &s->wide_road_cam) ? std::tuple(96, 250, 1734, 524) : std::tuple(96, 160, 1734, 986);
-  const int skip = 2;
-  c->set_camera_exposure(set_exposure_target(b, x, x + w, skip, y, y + h, skip));
 
   MessageBuilder msg;
   auto framed = c == &s->road_cam ? msg.initEvent().initRoadCameraState() : msg.initEvent().initWideRoadCameraState();
@@ -1234,6 +1231,10 @@ void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
   }
 
   s->pm->send(c == &s->road_cam ? "roadCameraState" : "wideRoadCameraState", msg);
+
+  const auto [x, y, w, h] = (c == &s->wide_road_cam) ? std::tuple(96, 250, 1734, 524) : std::tuple(96, 160, 1734, 986);
+  const int skip = 2;
+  c->set_camera_exposure(set_exposure_target(b, x, x + w, skip, y, y + h, skip));
 }
 
 void cameras_run(MultiCameraState *s) {

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -1008,13 +1008,6 @@ void CameraState::handle_camera_event(void *evdat) {
     auto &meta_data = buf.camera_bufs_metadata[buf_idx];
     meta_data.frame_id = main_id - idx_offset;
     meta_data.timestamp_sof = timestamp;
-    exp_lock.lock();
-    meta_data.gain = analog_gain_frac * (1 + dc_gain_weight * (dc_gain_factor-1) / dc_gain_max_weight);
-    meta_data.high_conversion_gain = dc_gain_enabled;
-    meta_data.integ_lines = exposure_time;
-    meta_data.measured_grey_fraction = measured_grey_fraction;
-    meta_data.target_grey_fraction = target_grey_fraction;
-    exp_lock.unlock();
 
     // dispatch
     enqueue_req_multi(real_id + FRAME_BUF_COUNT, 1, 1);
@@ -1128,12 +1121,9 @@ void CameraState::set_camera_exposure(float grey_frac) {
     }
   }
 
-  exp_lock.lock();
-
-  measured_grey_fraction = grey_frac;
   target_grey_fraction = target_grey;
 
-  analog_gain_frac = sensor_analog_gains[new_exp_g];
+  float analog_gain_frac = sensor_analog_gains[new_exp_g];
   gain_idx = new_exp_g;
   exposure_time = new_exp_t;
   dc_gain_enabled = enable_dc_gain;
@@ -1141,7 +1131,12 @@ void CameraState::set_camera_exposure(float grey_frac) {
   float gain = analog_gain_frac * (1 + dc_gain_weight * (dc_gain_factor-1) / dc_gain_max_weight);
   cur_ev[buf.cur_frame_data.frame_id % 3] = exposure_time * gain;
 
-  exp_lock.unlock();
+  buf.cur_frame_data.gain = gain;
+  buf.cur_frame_data.high_conversion_gain = dc_gain_enabled;
+  buf.cur_frame_data.integ_lines = exposure_time;
+  buf.cur_frame_data.measured_grey_fraction = grey_frac;
+  buf.cur_frame_data.target_grey_fraction = target_grey_fraction;
+  buf.cur_frame_data.exposure_val_percent = util::map_val(exposure_time * gain, min_ev, max_ev, 0.0f, 100.0f);
 
   // Processing a frame takes right about 50ms, so we need to wait a few ms
   // so we don't send i2c commands around the frame start.
@@ -1222,6 +1217,9 @@ static void process_driver_camera(MultiCameraState *s, CameraState *c, int cnt) 
 
 void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
   const CameraBuf *b = &c->buf;
+  const auto [x, y, w, h] = (c == &s->wide_road_cam) ? std::tuple(96, 250, 1734, 524) : std::tuple(96, 160, 1734, 986);
+  const int skip = 2;
+  c->set_camera_exposure(set_exposure_target(b, x, x + w, skip, y, y + h, skip));
 
   MessageBuilder msg;
   auto framed = c == &s->road_cam ? msg.initEvent().initRoadCameraState() : msg.initEvent().initWideRoadCameraState();
@@ -1236,10 +1234,6 @@ void process_road_camera(MultiCameraState *s, CameraState *c, int cnt) {
   }
 
   s->pm->send(c == &s->road_cam ? "roadCameraState" : "wideRoadCameraState", msg);
-
-  const auto [x, y, w, h] = (c == &s->wide_road_cam) ? std::tuple(96, 250, 1734, 524) : std::tuple(96, 160, 1734, 986);
-  const int skip = 2;
-  c->set_camera_exposure(set_exposure_target(b, x, x + w, skip, y, y + h, skip));
 }
 
 void cameras_run(MultiCameraState *s) {

--- a/system/camerad/cameras/camera_qcom2.h
+++ b/system/camerad/cameras/camera_qcom2.h
@@ -20,13 +20,10 @@ public:
   CameraInfo ci;
   bool enabled;
 
-  std::mutex exp_lock;
-
   int exposure_time;
   bool dc_gain_enabled;
   int dc_gain_weight;
   int gain_idx;
-  float analog_gain_frac;
 
   int exposure_time_min;
   int exposure_time_max;
@@ -51,7 +48,6 @@ public:
   int new_exp_g;
   int new_exp_t;
 
-  float measured_grey_fraction;
   float target_grey_fraction;
   float target_grey_factor;
 


### PR DESCRIPTION
we don't need this lock any more.