### PR TITLE
cabana: sets the line width with floating point precision.

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -843,7 +843,7 @@ QXYSeries *ChartView::createSeries(SeriesType type, QColor color) {
   series->setUseOpenGL(true);
   // Qt doesn't properly apply device pixel ratio in OpenGL mode
   QPen pen = series->pen();
-  pen.setWidth(2.0 * qApp->devicePixelRatio());
+  pen.setWidthF(2.0 * devicePixelRatioF());
   series->setPen(pen);
 #endif
   chart()->addSeries(series);


### PR DESCRIPTION
make sure the precision is the same as glLineWidth(/*float pen width*/) https://codebrowser.dev/qt5/qtcharts/src/charts/xychart/glxyseriesdata.cpp.html#64