### PR TITLE
uploader: compress qcamera.ts files with gzip

### DIFF
--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import bz2
+import gzip
 import io
 import json
 import os
@@ -156,6 +157,9 @@ class Uploader():
         with open(fn, "rb") as f:
           if key.endswith('.bz2') and not fn.endswith('.bz2'):
             data = bz2.compress(f.read())
+            data = io.BytesIO(data)
+          elif key.endswith('.gz') and not fn.endswith('.gz'):
+            data = gzip.compress(f.read())
             data = io.BytesIO(data)
           else:
             data = f

--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -272,6 +272,10 @@ def uploader_fn(exit_event):
     if key.endswith(('qlog', 'rlog')) or (key.startswith('boot/') and not key.endswith('.bz2')):
       key += ".bz2"
 
+    # qcamera.ts files should be compressed with gzip before uploading
+    if key.endswith("qcamera.ts"):
+      key += ".gz"
+
     success = uploader.upload(name, key, fn, sm['deviceState'].networkType.raw, sm['deviceState'].networkMetered)
     if success:
       backoff = 0.1


### PR DESCRIPTION
Due to suboptimal encoding, the qcamera.ts files contain lots of "empty space" (ranges of 0xFF bytes). We can compress the files using qzip to reduce their size from 2.2mb to about 1.9-2.0mb per segment.

(upload qcamera.ts to https://binvis.io/#/view/local?curve=scan)