### PR TITLE
FPv2: don't multiplex second panda

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -116,7 +116,8 @@ bool safety_setter_thread(std::vector<Panda *> pandas) {
   // initialize to ELM327 without OBD multiplexing for fingerprinting
   bool obd_multiplexing_enabled = false;
   for (int i = 0; i < pandas.size(); i++) {
-    pandas[i]->set_safety_model(cereal::CarParams::SafetyModel::ELM327, 1U);
+    const uint16_t safety_param = (i > 0) ? 1U : 0U;
+    pandas[i]->set_safety_model(cereal::CarParams::SafetyModel::ELM327, safety_param);
   }
 
   // openpilot can switch between multiplexing modes for different FW queries
@@ -127,8 +128,8 @@ bool safety_setter_thread(std::vector<Panda *> pandas) {
 
     bool obd_multiplexing_requested = p.getBool("ObdMultiplexingEnabled");
     if (obd_multiplexing_requested != obd_multiplexing_enabled) {
-      const uint16_t safety_param = obd_multiplexing_requested ? 0U : 1U;
       for (int i = 0; i < pandas.size(); i++) {
+        const uint16_t safety_param = (i > 0) ? 1U : (obd_multiplexing_requested ? 0U : 1U);
         pandas[i]->set_safety_model(cereal::CarParams::SafetyModel::ELM327, safety_param);
       }
       obd_multiplexing_enabled = obd_multiplexing_requested;

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -129,7 +129,7 @@ bool safety_setter_thread(std::vector<Panda *> pandas) {
     bool obd_multiplexing_requested = p.getBool("ObdMultiplexingEnabled");
     if (obd_multiplexing_requested != obd_multiplexing_enabled) {
       for (int i = 0; i < pandas.size(); i++) {
-        const uint16_t safety_param = (i > 0) ? 1U : (obd_multiplexing_requested ? 0U : 1U);
+        const uint16_t safety_param = (i > 0 || !obd_multiplexing_requested) ? 1U : 0U;
         pandas[i]->set_safety_model(cereal::CarParams::SafetyModel::ELM327, safety_param);
       }
       obd_multiplexing_enabled = obd_multiplexing_requested;

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -116,8 +116,7 @@ bool safety_setter_thread(std::vector<Panda *> pandas) {
   // initialize to ELM327 without OBD multiplexing for fingerprinting
   bool obd_multiplexing_enabled = false;
   for (int i = 0; i < pandas.size(); i++) {
-    const uint16_t safety_param = (i > 0) ? 1U : 0U;
-    pandas[i]->set_safety_model(cereal::CarParams::SafetyModel::ELM327, safety_param);
+    pandas[i]->set_safety_model(cereal::CarParams::SafetyModel::ELM327, 1U);
   }
 
   // openpilot can switch between multiplexing modes for different FW queries

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -367,7 +367,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.fwdCamera, Ecu.adas, Ecu.cornerRadar],
       bus=5,
-      obd_multiplexing=False,
     ),
   ],
   extra_ecus=[

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -367,6 +367,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.fwdCamera, Ecu.adas, Ecu.cornerRadar],
       bus=5,
+      obd_multiplexing=False,
     ),
   ],
   extra_ecus=[


### PR DESCRIPTION
Fixes bus 5 queries (second panda's bus 1) being multiplexed to nowhere from https://github.com/commaai/openpilot/pull/27656