### PR TITLE
FwQueryConfig: use auxiliary field to add requests for first aux panda

### DIFF
--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -78,6 +78,6 @@ class FwQueryConfig:
   def __post_init__(self):
     for i in range(len(self.requests)):
       if self.requests[i].auxiliary:
-        new_r = copy.deepcopy(self.requests[i])
-        new_r.bus += 4
-        self.requests.append(new_r)
+        new_request = copy.deepcopy(self.requests[i])
+        new_request.bus += 4
+        self.requests.append(new_request)

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import capnp
+import copy
 from dataclasses import dataclass, field
 import struct
 from typing import Dict, List, Optional, Tuple
@@ -57,6 +58,8 @@ class Request:
   whitelist_ecus: List[int] = field(default_factory=list)
   rx_offset: int = 0x8
   bus: int = 1
+  # Whether this query should be run on the first auxiliary panda (CAN FD cars for example)
+  auxiliary: bool = False
   # FW responses from these queries will not be used for fingerprinting
   logging: bool = False
   # boardd toggles OBD multiplexing on/off as needed
@@ -71,3 +74,10 @@ class FwQueryConfig:
   non_essential_ecus: Dict[capnp.lib.capnp._EnumModule, List[str]] = field(default_factory=dict)
   # Ecus added for data collection, not to be fingerprinted on
   extra_ecus: List[Tuple[capnp.lib.capnp._EnumModule, int, Optional[int]]] = field(default_factory=list)
+
+  def __post_init__(self):
+    for i in range(len(self.requests)):
+      if self.requests[i].auxiliary:
+        new_r = copy.deepcopy(self.requests[i])
+        new_r.bus += 4
+        self.requests.append(new_r)

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -341,6 +341,28 @@ HYUNDAI_VERSION_REQUEST_MULTI = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]
   p16(0xf100)
 HYUNDAI_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40])
 
+# CAN-FD queries (from camera)
+canfd_fw_requests = [
+  Request(
+    [HYUNDAI_VERSION_REQUEST_LONG],
+    [HYUNDAI_VERSION_RESPONSE],
+    whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar],
+    bus=0,
+  ),
+  Request(
+    [HYUNDAI_VERSION_REQUEST_LONG],
+    [HYUNDAI_VERSION_RESPONSE],
+    whitelist_ecus=[Ecu.fwdCamera, Ecu.adas, Ecu.cornerRadar],
+    bus=1,
+    obd_multiplexing=False,
+  ),
+]
+
+for _, r in enumerate(canfd_fw_requests):
+  new_r = r.copy()
+  new_r.bus += 3
+  canfd_fw_requests.append(new_r)
+
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
     # TODO: minimize shared whitelists for CAN and cornerRadar for CAN-FD
@@ -354,21 +376,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_REQUEST_MULTI],
       [HYUNDAI_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.engine, Ecu.transmission, Ecu.eps, Ecu.abs, Ecu.fwdRadar],
-    ),
-    # CAN-FD queries (camera)
-    Request(
-      [HYUNDAI_VERSION_REQUEST_LONG],
-      [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar],
-      bus=4,
-    ),
-    Request(
-      [HYUNDAI_VERSION_REQUEST_LONG],
-      [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.adas, Ecu.cornerRadar],
-      bus=5,
-    ),
-  ],
+    )
+  ] + canfd_fw_requests + [r.bus for r in canfd_fw_requests],
   extra_ecus=[
     (Ecu.adas, 0x730, None),         # ADAS Driving ECU on HDA2 platforms
     (Ecu.cornerRadar, 0x7b7, None),
@@ -1542,6 +1551,9 @@ FW_VERSIONS = {
     ]
   },
   CAR.KIA_EV6: {
+    (Ecu.transmission, 0x7e1, None): [
+      b'gdg',
+    ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00CV1_ RDR -----      1.00 1.01 99110-CV000         ',
     ],

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -355,7 +355,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.engine, Ecu.transmission, Ecu.eps, Ecu.abs, Ecu.fwdRadar],
     ),
-
     # CAN-FD queries (from camera)
     # TODO: combine shared whitelists with CAN requests
     Request(
@@ -375,7 +374,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     ),
   ],
   extra_ecus=[
-    (Ecu.adas, 0x730, None),  # ADAS Driving ECU on HDA2 platforms
+    (Ecu.adas, 0x730, None),         # ADAS Driving ECU on HDA2 platforms
     (Ecu.cornerRadar, 0x7b7, None),
   ],
 )
@@ -1547,9 +1546,6 @@ FW_VERSIONS = {
     ]
   },
   CAR.KIA_EV6: {
-    (Ecu.transmission, 0x7e1, None): [
-      b'gdg',
-    ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00CV1_ RDR -----      1.00 1.01 99110-CV000         ',
     ],

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -341,28 +341,6 @@ HYUNDAI_VERSION_REQUEST_MULTI = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]
   p16(0xf100)
 HYUNDAI_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40])
 
-# CAN-FD queries (from camera)
-canfd_fw_requests = [
-  Request(
-    [HYUNDAI_VERSION_REQUEST_LONG],
-    [HYUNDAI_VERSION_RESPONSE],
-    whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar],
-    bus=0,
-  ),
-  Request(
-    [HYUNDAI_VERSION_REQUEST_LONG],
-    [HYUNDAI_VERSION_RESPONSE],
-    whitelist_ecus=[Ecu.fwdCamera, Ecu.adas, Ecu.cornerRadar],
-    bus=1,
-    obd_multiplexing=False,
-  ),
-]
-
-for _, r in enumerate(canfd_fw_requests):
-  new_r = r.copy()
-  new_r.bus += 3
-  canfd_fw_requests.append(new_r)
-
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
     # TODO: minimize shared whitelists for CAN and cornerRadar for CAN-FD
@@ -376,10 +354,28 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_REQUEST_MULTI],
       [HYUNDAI_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.engine, Ecu.transmission, Ecu.eps, Ecu.abs, Ecu.fwdRadar],
-    )
-  ] + canfd_fw_requests + [r.bus for r in canfd_fw_requests],
+    ),
+
+    # CAN-FD queries (from camera)
+    # TODO: combine shared whitelists with CAN requests
+    Request(
+      [HYUNDAI_VERSION_REQUEST_LONG],
+      [HYUNDAI_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar],
+      bus=0,
+      auxiliary=True,
+    ),
+    Request(
+      [HYUNDAI_VERSION_REQUEST_LONG],
+      [HYUNDAI_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.adas, Ecu.cornerRadar],
+      bus=1,
+      auxiliary=True,
+      obd_multiplexing=False,
+    ),
+  ],
   extra_ecus=[
-    (Ecu.adas, 0x730, None),         # ADAS Driving ECU on HDA2 platforms
+    (Ecu.adas, 0x730, None),  # ADAS Driving ECU on HDA2 platforms
     (Ecu.cornerRadar, 0x7b7, None),
   ],
 )

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -364,6 +364,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac],
       bus=0,
       auxiliary=True,
+      obd_multiplexing=False,
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -355,6 +355,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.engine, Ecu.transmission, Ecu.eps, Ecu.abs, Ecu.fwdRadar],
     ),
+
     # CAN-FD queries (from camera)
     # TODO: combine shared whitelists with CAN requests
     Request(

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -22,20 +22,20 @@ class TestFwFingerprint(unittest.TestCase):
     self.assertEqual(len(candidates), 1, f"got more than one candidate: {candidates}")
     self.assertEqual(candidates[0], expected)
 
-  # @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
-  # def test_fw_fingerprint(self, brand, car_model, ecus):
-  #   CP = car.CarParams.new_message()
-  #   for _ in range(200):
-  #     fw = []
-  #     for ecu, fw_versions in ecus.items():
-  #       if not len(fw_versions):
-  #         raise unittest.SkipTest("Car model has no FW versions")
-  #       ecu_name, addr, sub_addr = ecu
-  #       fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
-  #                  "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
-  #     CP.carFw = fw
-  #     _, matches = match_fw_to_car(CP.carFw)
-  #     self.assertFingerprints(matches, car_model)
+  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  def test_fw_fingerprint(self, brand, car_model, ecus):
+    CP = car.CarParams.new_message()
+    for _ in range(200):
+      fw = []
+      for ecu, fw_versions in ecus.items():
+        if not len(fw_versions):
+          raise unittest.SkipTest("Car model has no FW versions")
+        ecu_name, addr, sub_addr = ecu
+        fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
+                   "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
+      CP.carFw = fw
+      _, matches = match_fw_to_car(CP.carFw)
+      self.assertFingerprints(matches, car_model)
 
   def test_no_duplicate_fw_versions(self):
     for car_model, ecus in FW_VERSIONS.items():

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -22,20 +22,20 @@ class TestFwFingerprint(unittest.TestCase):
     self.assertEqual(len(candidates), 1, f"got more than one candidate: {candidates}")
     self.assertEqual(candidates[0], expected)
 
-  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
-  def test_fw_fingerprint(self, brand, car_model, ecus):
-    CP = car.CarParams.new_message()
-    for _ in range(200):
-      fw = []
-      for ecu, fw_versions in ecus.items():
-        if not len(fw_versions):
-          raise unittest.SkipTest("Car model has no FW versions")
-        ecu_name, addr, sub_addr = ecu
-        fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
-                   "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
-      CP.carFw = fw
-      _, matches = match_fw_to_car(CP.carFw)
-      self.assertFingerprints(matches, car_model)
+  # @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  # def test_fw_fingerprint(self, brand, car_model, ecus):
+  #   CP = car.CarParams.new_message()
+  #   for _ in range(200):
+  #     fw = []
+  #     for ecu, fw_versions in ecus.items():
+  #       if not len(fw_versions):
+  #         raise unittest.SkipTest("Car model has no FW versions")
+  #       ecu_name, addr, sub_addr = ecu
+  #       fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
+  #                  "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
+  #     CP.carFw = fw
+  #     _, matches = match_fw_to_car(CP.carFw)
+  #     self.assertFingerprints(matches, car_model)
 
   def test_no_duplicate_fw_versions(self):
     for car_model, ecus in FW_VERSIONS.items():


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
