### PR TITLE
FPv2: only set multiplexing when needed

### DIFF
--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -280,7 +280,8 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
           continue
 
         # Toggle OBD multiplexing for each request
-        set_obd_multiplexing(params, r.obd_multiplexing)
+        if r.bus % 4 == 1:
+          set_obd_multiplexing(params, r.obd_multiplexing)
 
         try:
           addrs = [(a, s) for (b, a, s) in addr_chunk if b in (brand, 'any') and

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -369,7 +369,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac],
       bus=0,
       auxiliary=True,
-      obd_multiplexing=False,
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
@@ -387,7 +386,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.parking],
       bus=0,
       auxiliary=True,
-      obd_multiplexing=False,
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_ALT],


### PR DESCRIPTION
For example, if a brand starts by querying ECUs on bus 1 without OBD multiplexing, then the next request called to query on bus 0, the OBD multiplexing mode does not matter, so do not change it (until a query is done on bus 1)

Takes 0.1s to switch OBD multiplexing modes, since the blocking `get` loop in params is ran at 10Hz