### PR TITLE
cabana: align signal value vcenter

### DIFF
--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -21,7 +21,7 @@ QVariant HistoryLogModel::data(const QModelIndex &index, int role) const {
   } else if (role == BytesRole) {
     return m.data;
   } else if (role == Qt::TextAlignmentRole) {
-    return Qt::AlignRight;
+    return (uint32_t)(Qt::AlignRight | Qt::AlignVCenter);
   }
   return {};
 }


### PR DESCRIPTION
change alignment from  `AlignRight` to `AlignRight | AlignVCenter`
| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-03-24 21-55-13](https://user-images.githubusercontent.com/27770/227540381-310672cc-2c06-46cc-9936-8a129485c12e.png)  | ![Screenshot from 2023-03-24 21-53-22](https://user-images.githubusercontent.com/27770/227540441-a5b709ea-f3cc-4a51-888c-760c43847f08.png)
  |


