### PR TITLE
FW Request: return addrs

### DIFF
--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -9,7 +9,7 @@ from selfdrive.car import make_can_msg
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from system.swaglog import cloudlog
 
-EcuAddrBusType = Tuple[int, Optional[int], int]
+EcuAddrBusType = Tuple[int, Optional[int], int]  # (addr, sub_addr, bus)
 
 
 def make_tester_present_msg(addr, bus, subaddr=None):

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -66,14 +66,7 @@ class Request:
   obd_multiplexing: bool = True
 
   # Auto-filled by FwQueryConfig
-  # ecus: Set[Tuple[int, Optional[int]]] = field(default_factory=set)
-  query_ecus: Set[Tuple[int, Optional[int]]] = field(default_factory=set)
-
   extra_ecus: List[Tuple[capnp.lib.capnp._EnumModule, int, Optional[int]]] = None
-
-  # def get_ecus(self, parallel_query: bool):
-  #     return [(addr, sub_addr) for addr, sub_addr in self.query_ecus if
-  #             (sub_addr is None) == parallel_query]
 
   def get_addrs(self, VERSIONS):
     addrs = set()
@@ -87,10 +80,6 @@ class Request:
           else:
             addrs.add(a)
 
-    # if extra_ecus:
-    #   for ecu_type, addr, sub_addr in self.extra_ecus:
-    #     if len(self.whitelist_ecus) == 0 or ecu_type in self.whitelist_ecus:
-    #       ecus.add((addr, sub_addr))
     return addrs, parallel_addrs
 
 
@@ -111,26 +100,3 @@ class FwQueryConfig:
         new_request = copy.deepcopy(request)
         new_request.bus += 4
         self.requests.append(new_request)
-
-  def init(self, VERSIONS):
-    # for versions in VERSIONS.values():
-    #   for ecu_type, addr, sub_addr in versions:
-    #     for r in self.requests:
-    #       if len(r.whitelist_ecus) == 0 or ecu_type in r.whitelist_ecus:
-    #         r.query_ecus.add((addr, sub_addr))
-
-    for r in self.requests:
-      for versions in VERSIONS.values():
-        for ecu_type, addr, sub_addr in list(versions) + self.extra_ecus:
-          if len(r.whitelist_ecus) == 0 or ecu_type in r.whitelist_ecus:
-            r.query_ecus.add((addr, sub_addr))
-
-      # for
-      # brand_addrs[brand] |= {(addr, sub_addr) for _, addr, sub_addr in FW_QUERY_CONFIGS[brand].extra_ecus}
-            # # Build set of queries
-            # if sub_addr is None:
-            #   if a not in parallel_queries[r.obd_multiplexing]:
-            #     parallel_queries[r.obd_multiplexing].append(a)
-            # else:  # subaddresses must be queried one by one
-            #   if [a] not in queries[r.obd_multiplexing]:
-            #     queries[r.obd_multiplexing].append([a])

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -75,18 +75,23 @@ class Request:
   #     return [(addr, sub_addr) for addr, sub_addr in self.query_ecus if
   #             (sub_addr is None) == parallel_query]
 
-  def get_addrs(self, VERSIONS, extra_ecus: bool = True):
-    ecus = set()
+  def get_addrs(self, VERSIONS):
+    addrs = set()
+    parallel_addrs = set()
     for versions in VERSIONS.values():
-      for ecu_type, addr, sub_addr in versions:
+      for ecu_type, addr, sub_addr in list(versions) + self.extra_ecus:
         if len(self.whitelist_ecus) == 0 or ecu_type in self.whitelist_ecus:
-          ecus.add((addr, sub_addr))
+          a = (addr, sub_addr)
+          if sub_addr is None:
+            parallel_addrs.add(a)
+          else:
+            addrs.add(a)
 
-    if extra_ecus:
-      for ecu_type, addr, sub_addr in self.extra_ecus:
-        if len(self.whitelist_ecus) == 0 or ecu_type in self.whitelist_ecus:
-          ecus.add((addr, sub_addr))
-    return ecus
+    # if extra_ecus:
+    #   for ecu_type, addr, sub_addr in self.extra_ecus:
+    #     if len(self.whitelist_ecus) == 0 or ecu_type in self.whitelist_ecus:
+    #       ecus.add((addr, sub_addr))
+    return addrs, parallel_addrs
 
 
 @dataclass

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -80,7 +80,7 @@ class Request:
           else:
             addrs.add(a)
 
-    return addrs, parallel_addrs
+    return parallel_addrs, addrs
 
 
 @dataclass

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -74,10 +74,10 @@ class Request:
           a = (addr, sub_addr)
           if sub_addr is None:
             parallel_addrs.add(a)
-          else:
+          else:  # subaddresses must be queried one by one
             addrs.add(a)
 
-    return parallel_addrs, addrs
+    return [parallel_addrs, *[{a} for a in addrs]]
 
 
 @dataclass

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -65,14 +65,11 @@ class Request:
   # boardd toggles OBD multiplexing on/off as needed
   obd_multiplexing: bool = True
 
-  # Auto-filled by FwQueryConfig
-  extra_ecus: List[Tuple[capnp.lib.capnp._EnumModule, int, Optional[int]]] = None
-
-  def get_addrs(self, VERSIONS):
+  def get_addrs(self, VERSIONS, extra_ecus):
     addrs = set()
     parallel_addrs = set()
     for versions in VERSIONS.values():
-      for ecu_type, addr, sub_addr in list(versions) + self.extra_ecus:
+      for ecu_type, addr, sub_addr in list(versions) + extra_ecus:
         if len(self.whitelist_ecus) == 0 or ecu_type in self.whitelist_ecus:
           a = (addr, sub_addr)
           if sub_addr is None:
@@ -94,9 +91,7 @@ class FwQueryConfig:
 
   def __post_init__(self):
     for i in range(len(self.requests)):
-      request = self.requests[i]
-      request.extra_ecus = [a for a in self.extra_ecus if a[0] in request.whitelist_ecus]
-      if request.auxiliary:
-        new_request = copy.deepcopy(request)
+      if self.requests[i].auxiliary:
+        new_request = copy.deepcopy(self.requests[i])
         new_request.bus += 4
         self.requests.append(new_request)

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -247,7 +247,6 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
   # ECUs using a subaddress need be queried one by one, the rest can be done in parallel
   addrs = []
   parallel_addrs = []
-  logging_addrs = []
   ecu_types = {}
 
   for brand, brand_versions in versions.items():
@@ -256,9 +255,6 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
         a = (brand, addr, sub_addr)
         if a not in ecu_types:
           ecu_types[a] = ecu_type
-
-        if a not in logging_addrs and candidate == "debug":
-          logging_addrs.append(a)
 
         if sub_addr is None:
           if a not in parallel_addrs:
@@ -300,7 +296,7 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
               f.request = r.request
               f.brand = brand
               f.bus = r.bus
-              f.logging = r.logging or ecu_key in logging_addrs
+              f.logging = r.logging or (f.ecu, tx_addr, sub_addr) in r.extra_ecus
               f.obdMultiplexing = r.obd_multiplexing
 
               if sub_addr is not None:

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -36,14 +36,6 @@ def build_fw_dict(fw_versions, filter_brand=None):
   return dict(fw_versions_dict)
 
 
-# def get_brand_addrs():
-#   brand_addrs = defaultdict(set)
-#   for brand, cars in VERSIONS.items():
-#     for fw in cars.values():
-#       brand_addrs[brand] |= {(addr, sub_addr) for _, addr, sub_addr in fw.keys()}
-#   return brand_addrs
-
-
 def get_brand_addrs():
   brand_addrs = defaultdict(set)
   for config, brand, r in REQUESTS:

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -36,11 +36,18 @@ def build_fw_dict(fw_versions, filter_brand=None):
   return dict(fw_versions_dict)
 
 
+# def get_brand_addrs():
+#   brand_addrs = defaultdict(set)
+#   for brand, cars in VERSIONS.items():
+#     for fw in cars.values():
+#       brand_addrs[brand] |= {(addr, sub_addr) for _, addr, sub_addr in fw.keys()}
+#   return brand_addrs
+
+
 def get_brand_addrs():
   brand_addrs = defaultdict(set)
-  for brand, cars in VERSIONS.items():
-    for fw in cars.values():
-      brand_addrs[brand] |= {(addr, sub_addr) for _, addr, sub_addr in fw.keys()}
+  for config, brand, r in REQUESTS:
+    brand_addrs[brand] |= set.union(*r.get_addrs(VERSIONS[brand], []))
   return brand_addrs
 
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -157,7 +157,6 @@ def get_present_ecus(logcan, sendcan, num_pandas=1) -> Set[EcuAddrBusType]:
     if r.bus > num_pandas * 4 - 1:
       continue
 
-    # parallel_addrs, addrs = r.get_addrs(VERSIONS[brand], [])
     addrs = set.union(*r.get_addrs(VERSIONS[brand], []))
 
     for addr, sub_addr in addrs:
@@ -170,14 +169,6 @@ def get_present_ecus(logcan, sendcan, num_pandas=1) -> Set[EcuAddrBusType]:
       # Build set of expected responses to filter
       response_addr = uds.get_rx_addr_for_tx_addr(addr, r.rx_offset)
       responses.add((response_addr, sub_addr, r.bus))
-
-    # queries[r.obd_multiplexing] |= {(addr, sub_addr, r.bus) for addr, sub_addr in addrs}
-    # parallel_queries[r.obd_multiplexing] |= {(addr, sub_addr, r.bus) for addr, sub_addr in parallel_addrs}
-
-    # for addr, sub_addr in addrs:
-    #   # Build set of expected responses to filter
-    #   response_addr = uds.get_rx_addr_for_tx_addr(addr, r.rx_offset)
-    #   responses.add((response_addr, sub_addr, r.bus))
 
   ecu_responses = set()
   for obd_multiplexing in [True, False]:

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -148,8 +148,8 @@ def match_fw_to_car(fw_versions, allow_exact=True, allow_fuzzy=True):
 def get_present_ecus(logcan, sendcan, num_pandas=1) -> Set[EcuAddrBusType]:
   params = Params()
   # queries are split by OBD multiplexing mode
-  queries: Dict[bool, Set[EcuAddrBusType]] = {True: set(), False: set()}
-  parallel_queries: Dict[bool, Set[EcuAddrBusType]] = {True: set(), False: set()}
+  queries: Dict[bool, Set[EcuAddrBusType]] = defaultdict(set)
+  parallel_queries: Dict[bool, Set[EcuAddrBusType]] = defaultdict(set)
   responses = set()
 
   for _, brand, r in REQUESTS:

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -19,7 +19,7 @@ FW_QUERY_CONFIGS = get_interface_attr('FW_QUERY_CONFIG', ignore_none=True)
 VERSIONS = get_interface_attr('FW_VERSIONS', ignore_none=True)
 
 MODEL_TO_BRAND = {c: b for b, e in VERSIONS.items() for c in e}
-REQUESTS = [(brand, r) for brand, config in FW_QUERY_CONFIGS.items() for r in config.requests]
+REQUESTS = [(config, brand, r) for brand, config in FW_QUERY_CONFIGS.items() for r in config.requests]
 
 
 def chunks(l, n=128):
@@ -153,7 +153,7 @@ def get_present_ecus(logcan, sendcan, num_pandas=1) -> Set[EcuAddrBusType]:
   parallel_queries: Dict[bool, List[EcuAddrBusType]] = {True: [], False: []}
   responses = set()
 
-  for brand, r in REQUESTS:
+  for _, brand, r in REQUESTS:
     # Skip query if no panda available
     if r.bus > num_pandas * 4 - 1:
       continue
@@ -190,9 +190,9 @@ def get_brand_ecu_matches(ecu_rx_addrs):
   """Returns dictionary of brands and matches with ECUs in their FW versions"""
 
   brand_addrs = get_brand_addrs()
-  brand_matches = {brand: set() for brand, _ in REQUESTS}
+  brand_matches = {brand: set() for _, brand, _ in REQUESTS}
 
-  brand_rx_offsets = set((brand, r.rx_offset) for brand, r in REQUESTS)
+  brand_rx_offsets = set((brand, r.rx_offset) for _, brand, r in REQUESTS)
   for addr, sub_addr, _ in ecu_rx_addrs:
     # Since we can't know what request an ecu responded to, add matches for all possible rx offsets
     for brand, rx_offset in brand_rx_offsets:
@@ -235,8 +235,8 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
 
   # Get versions and build capnp list to put into CarParams
   car_fw = []
-  requests = [(brand, r) for brand, r in REQUESTS if query_brand is None or brand == query_brand]
-  for brand, r in requests:
+  requests = [(config, brand, r) for config, brand, r in REQUESTS if query_brand is None or brand == query_brand]
+  for config, brand, r in requests:
     if query_brand is not None and brand != query_brand:
       continue
 
@@ -248,7 +248,7 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
     if r.bus % 4 == 1:
       set_obd_multiplexing(params, r.obd_multiplexing)
 
-    for addrs in r.get_addrs(versions[brand]):
+    for addrs in r.get_addrs(versions[brand], config.extra_ecus):
       if not len(addrs):
         continue
 


### PR DESCRIPTION
Not sure if I like how big the diff is, it was supposed to make things simpler, but it turned into a *change*.

This gives me ideas of putting the FW versions inside the config though, then we can set up info we use later in the `__post_init__` function, removing duplicate code everywhere. Think: `config.ecu_types[(addr, sub_addr)]`, `config.get_addrs(extra_ecus=False, obd_multiplexing=True)`, etc.


Might close and re-open with that unification