### PR TITLE
cabana: fix merging sources for already open DBC file

### DIFF
--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -14,7 +14,8 @@ bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error)
 
     // Check if file is already open, and merge sources
     if (dbc_file->filename == dbc_file_name) {
-      ss |= s;
+      dbc_files[i] = {ss | s, dbc_file};
+
       emit DBCFileChanged();
       return true;
     }

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <map>
+#include <optional>
+
 #include <QList>
 #include <QMetaType>
 #include <QObject>


### PR DESCRIPTION
`ss` used to be a reference, but changed that while cleaning up the PR for review.

This fixes opening an already open DBC file for a different bus.