### PR TITLE
cabana: clear zoom stack after reset zoom

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -145,6 +145,7 @@ void ChartsWidget::zoomIn(double min, double max) {
 
 void ChartsWidget::zoomReset() {
   setZoom(display_range.first, display_range.second);
+  zoom_stack.clear();
 }
 
 void ChartsWidget::zoomUndo() {


### PR DESCRIPTION
fixed the zoom stack not cleared after user resets zoom via toolbar button.

