### PR TITLE
torqued: reset LiveTorqueParameters on calibration reset

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -193,6 +193,7 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   connect(resetCalibBtn, &ButtonControl::clicked, [&]() {
     if (ConfirmationDialog::confirm(tr("Are you sure you want to reset calibration?"), tr("Reset"), this)) {
       params.remove("CalibrationParams");
+      params.remove("LiveTorqueParameters")
     }
   });
   addItem(resetCalibBtn);


### PR DESCRIPTION
Reset `LiveTorqueParameters` when the user resets calibration.

Currently, when reset calibration is requested, only `CalibrationParams` is purged but not `LiveTorqueParameters`. This allows `torqued` to relearn the values as the bucket points are purged.