### PR TITLE
cabana: fix parts of chart widget not being redrawn

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -528,7 +528,7 @@ void ChartView::updatePlot(double cur, double min, double max) {
     updateAxisY();
     updateSeriesPoints();
   }
-  update();
+  scene()->invalidate({}, QGraphicsScene::ForegroundLayer);
 }
 
 void ChartView::updateSeriesPoints() {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -717,7 +717,7 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
       // zoom in if selected range is greater than 0.5s
       emit zoomIn(min_rounded, max_rounded);
     } else {
-      update();
+      scene()->invalidate({}, QGraphicsScene::ForegroundLayer);
     }
     event->accept();
   } else if (!can->liveStreaming() && event->button() == Qt::RightButton) {
@@ -775,7 +775,7 @@ void ChartView::mouseMoveEvent(QMouseEvent *ev) {
     text_list.push_front(QString::number(chart()->mapToValue({x, 0}).x(), 'f', 3));
     QPointF tooltip_pt(x + 12, plot_area.top() - 20);
     QToolTip::showText(mapToGlobal(tooltip_pt.toPoint()), text_list.join("<br />"), this, plot_area.toRect());
-    update();
+    scene()->invalidate({}, QGraphicsScene::ForegroundLayer);
   } else {
     QToolTip::hideText();
   }
@@ -788,7 +788,7 @@ void ChartView::mouseMoveEvent(QMouseEvent *ev) {
     if (rubber_rect != rubber->geometry()) {
       rubber->setGeometry(rubber_rect);
     }
-    update();
+    scene()->invalidate({}, QGraphicsScene::ForegroundLayer);
   }
 }
 


### PR DESCRIPTION
Was changed in https://github.com/commaai/openpilot/pull/27727/files but has some side effects.

![Screenshot 2023-03-30 at 09 37 57](https://user-images.githubusercontent.com/1314752/228764835-6a015edc-4ce1-4e38-8a28-5acbe58f349e.png)
(value marker is also not at correct mouse position)