### PR TITLE
cabana: show min and max values in chart tooltip

### DIFF
--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -46,6 +46,8 @@ public:
     uint64_t last_value_mono_time = 0;
     QPointF track_pt{};
     SegmentTree segment_tree;
+    double min = 0;
+    double max = 0;
   };
 
 signals:


### PR DESCRIPTION
Useful for computing the correct scalars when comparing the values to a different source (e.g. a scantool).
![Screenshot 2023-03-30 at 13 48 04](https://user-images.githubusercontent.com/1314752/228826845-a10ac193-ee37-4044-b2af-4756a7c5f907.png)
