### PR TITLE
cabana: fix drawing sparkline at half width on hi-dpi screen

### DIFF
--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -389,7 +389,7 @@ void SignalItemDelegate::drawSparkline(QPainter *painter, const QStyleOptionView
 
     int h_margin = option.widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin);
     int v_margin = std::max(option.widget->style()->pixelMetric(QStyle::PM_FocusFrameVMargin) + 2, 4);
-    const double xscale = (option.rect.width() - 175.0 * option.widget->devicePixelRatioF() - h_margin * 2) / settings.sparkline_range;
+    const double xscale = (option.rect.width() - 175.0 - h_margin * 2) / settings.sparkline_range;
     const double yscale = (option.rect.height() - v_margin * 2) / (max - min);
     const int left = option.rect.left();
     const int top = option.rect.top() + v_margin;


### PR DESCRIPTION
See https://github.com/commaai/openpilot/discussions/26091#discussioncomment-5477772

@deanlee why did you add this `* option.widget->devicePixelRatioF()`? I think there are some openGL functions that are not pixel ratio aware, but doesn't seem necessary here.