### PR TITLE
cabana: allow zooming to smaller ranges

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -713,7 +713,7 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
     if (rubber->width() <= 0) {
       // no rubber dragged, seek to mouse position
       can->seekTo(min);
-    } else if ((max_rounded - min_rounded) >= 0.5) {
+    } else if (rubber->width() > 10) {
       // zoom in if selected range is greater than 0.5s
       emit zoomIn(min_rounded, max_rounded);
     } else {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -714,7 +714,6 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
       // no rubber dragged, seek to mouse position
       can->seekTo(min);
     } else if (rubber->width() > 10) {
-      // zoom in if selected range is greater than 0.5s
       emit zoomIn(min_rounded, max_rounded);
     } else {
       update();


### PR DESCRIPTION
Use width of rubber instead of absolute time. Otherwise it's impossible to zoom beyond 0.5 seconds.