### PR TITLE
cabana: fill rows with Qt::BDiagPattern if messag size is incorrect

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -273,6 +273,10 @@ void BinaryViewModel::refresh() {
     row_count = can->lastMessage(msg_id).dat.size();
     items.resize(row_count * column_count);
   }
+  int valid_rows = std::min(can->lastMessage(msg_id).dat.size(), row_count);
+  for (int i = 0; i < valid_rows * column_count; ++i) {
+    items[i].valid = true;
+  }
   endResetModel();
   updateState();
 }
@@ -306,9 +310,6 @@ void BinaryViewModel::updateState() {
     }
     items[i * column_count + 8].val = toHex(binary[i]);
     items[i * column_count + 8].bg_color = last_msg.colors[i];
-  }
-  for (int i = binary.size() * column_count; i < items.size(); ++i) {
-    items[i].val = "-";
   }
 
   for (int i = 0; i < items.size(); ++i) {
@@ -376,6 +377,9 @@ void BinaryItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     }
   }
 
+  if (!item->valid) {
+    painter->fillRect(option.rect, QBrush(Qt::darkGray, Qt::BDiagPattern));
+  }
   painter->drawText(option.rect, Qt::AlignCenter, item->val);
   if (item->is_msb || item->is_lsb) {
     painter->setFont(small_font);

--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -42,8 +42,9 @@ public:
     QColor bg_color = QColor(102, 86, 169, 0);
     bool is_msb = false;
     bool is_lsb = false;
-    QString val = "-";
+    QString val;
     QList<const cabana::Signal *> sigs;
+    bool valid = false;
   };
   std::vector<Item> items;
 


### PR DESCRIPTION
message size is bigger than can data size:
![Screenshot from 2023-03-31 01-25-53](https://user-images.githubusercontent.com/27770/228920177-a39e6c5d-8bb9-4958-97b5-26fc1dc879d0.png)

message size is less than can data size:
![Screenshot from 2023-03-31 01-25-24](https://user-images.githubusercontent.com/27770/228920190-6d73119b-93a2-4746-af47-96b0c5b56a1e.png)
