### PR TITLE
present ecus: handle Chrysler abs

### DIFF
--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -22,10 +22,11 @@ def make_tester_present_msg(addr, bus, subaddr=None):
 
 
 def is_tester_present_response(msg: capnp.lib.capnp._DynamicStructReader, subaddr: Optional[int] = None) -> bool:
-  # ISO-TP messages are always padded to 8 bytes
+  # ISO-TP messages are always padded to 8 bytes, except for Chrysler abs
   # tester present response is always a single frame
   dat_offset = 1 if subaddr is not None else 0
-  if len(msg.dat) == 8 and 1 <= msg.dat[dat_offset] <= 7:
+  chrysler_abs_ecu = msg.address == 0x747 - 0x280
+  if (len(msg.dat) == 8 or chrysler_abs_ecu) and 1 <= msg.dat[dat_offset] <= 7:
     # success response
     if msg.dat[dat_offset + 1] == (SERVICE_TYPE.TESTER_PRESENT + 0x40):
       return True

--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -25,7 +25,7 @@ def is_tester_present_response(msg: capnp.lib.capnp._DynamicStructReader, subadd
   # ISO-TP messages are always padded to 8 bytes, except for Chrysler abs
   # tester present response is always a single frame
   dat_offset = 1 if subaddr is not None else 0
-  chrysler_abs_ecu = msg.address == 0x747 - 0x280
+  chrysler_abs_ecu = msg.address == (0x747 - 0x280) and len(msg.dat) == 3
   if (len(msg.dat) == 8 or chrysler_abs_ecu) and 1 <= msg.dat[dat_offset] <= 7:
     # success response
     if msg.dat[dat_offset + 1] == (SERVICE_TYPE.TESTER_PRESENT + 0x40):


### PR DESCRIPTION
It seems like on the `CHRYSLER PACIFICA 2018` and `CHRYSLER PACIFICA 2020`, this ECU responds with a non standard ISO-TP CAN frame of only 3 bytes. I checked 300k rlogs we have for the last 90 days, and this ECU and platform are the only ones to ever send back non-eight-byte messages. It also reverts back to 8 bytes for the FW query.

`1223` is the ABS response address:

```python
47542224824 rxaddr=1863, bus=2, 420.96 ms, 0x023e000000000000, b'\x02>\x00\x00\x00\x00\x00\x00', len(can.dat)=8
47542224824 rxaddr=1863, bus=128, 420.96 ms, 0x023e000000000000, b'\x02>\x00\x00\x00\x00\x00\x00', len(can.dat)=8
47542224824 rxaddr=1223, bus=2, 420.96 ms, 0x027e00, b'\x02~\x00', len(can.dat)=3
47542224824 rxaddr=1223, bus=0, 420.96 ms, 0x027e00, b'\x02~\x00', len(can.dat)=3
47542224824 rxaddr=1223, bus=1, 420.96 ms, 0x027e00, b'\x02~\x00', len(can.dat)=3
47861919355 rxaddr=1863, bus=2, 740.66 ms, 0x0322f13200000000, b'\x03"\xf12\x00\x00\x00\x00', len(can.dat)=8
47861919355 rxaddr=1863, bus=128, 740.66 ms, 0x0322f13200000000, b'\x03"\xf12\x00\x00\x00\x00', len(can.dat)=8
47861919355 rxaddr=1223, bus=0, 740.66 ms, 0x100d62f132363835, b'\x10\rb\xf12685', len(can.dat)=8
47861919355 rxaddr=1223, bus=2, 740.66 ms, 0x100d62f132363835, b'\x10\rb\xf12685', len(can.dat)=8
47861919355 rxaddr=1223, bus=1, 740.66 ms, 0x100d62f132363835, b'\x10\rb\xf12685', len(can.dat)=8
```