### PR TITLE
cabana: significantly reduce CPU usage by caching chart to pixmap

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -385,11 +385,6 @@ ChartView::ChartView(QWidget *parent) : tip_label(this), QChartView(nullptr, par
   chart->legend()->setShowToolTips(true);
   chart->setMargins({0, 0, 0, 0});
 
-  background = new QGraphicsRectItem(chart);
-  background->setBrush(QApplication::palette().color(QPalette::Base));
-  background->setPen(Qt::NoPen);
-  background->setZValue(chart->zValue() - 1);
-
   setChart(chart);
 
   createToolButtons();
@@ -520,15 +515,14 @@ void ChartView::resizeEvent(QResizeEvent *event) {
   manage_btn_proxy->setPos(x, top);
   chart()->legend()->setGeometry({move_icon->sceneBoundingRect().topRight(), manage_btn_proxy->sceneBoundingRect().bottomLeft()});
   if (align_to > 0) {
-    updatePlotArea(align_to);
+    updatePlotArea(align_to, true);
   }
   QChartView::resizeEvent(event);
 }
 
-void ChartView::updatePlotArea(int left_pos) {
-  if (align_to != left_pos || rect() != background->rect()) {
+void ChartView::updatePlotArea(int left_pos, bool force) {
+  if (align_to != left_pos || force) {
     align_to = left_pos;
-    background->setRect(rect());
 
     qreal left, top, right, bottom;
     chart()->layout()->getContentsMargins(&left, &top, &right, &bottom);
@@ -873,6 +867,7 @@ void ChartView::paintEvent(QPaintEvent *event) {
       const qreal dpr = viewport()->devicePixelRatioF();
       chart_pixmap = QPixmap(viewport()->size() * dpr);
       chart_pixmap.setDevicePixelRatio(dpr);
+      chart_pixmap.fill(Qt::white);
       QPainter p(&chart_pixmap);
       p.setRenderHints(QPainter::Antialiasing);
       scene()->setSceneRect(viewport()->rect());

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -867,7 +867,7 @@ void ChartView::paintEvent(QPaintEvent *event) {
       const qreal dpr = viewport()->devicePixelRatioF();
       chart_pixmap = QPixmap(viewport()->size() * dpr);
       chart_pixmap.setDevicePixelRatio(dpr);
-      chart_pixmap.fill(Qt::white);
+      chart_pixmap.fill(palette().color(QPalette::Base));
       QPainter p(&chart_pixmap);
       p.setRenderHints(QPainter::Antialiasing);
       scene()->setSceneRect(viewport()->rect());

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -88,6 +88,8 @@ private:
   QSize sizeHint() const override { return {CHART_MIN_WIDTH, settings.chart_height}; }
   void updateAxisY();
   void updateTitle();
+  void resetChartCache();
+  void paintEvent(QPaintEvent *event) override;
   void drawForeground(QPainter *painter, const QRectF &rect) override;
   std::tuple<double, double, int> getNiceAxisNumbers(qreal min, qreal max, int tick_count);
   qreal niceNumber(qreal x, bool ceiling);
@@ -111,6 +113,7 @@ private:
   SeriesType series_type = SeriesType::Line;
   bool is_scrubbing = false;
   bool resume_after_scrub = false;
+  QPixmap chart_pixmap;
   friend class ChartsWidget;
  };
 

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -42,7 +42,7 @@ public:
   void updateSeries(const cabana::Signal *sig = nullptr);
   void updatePlot(double cur, double min, double max);
   void setSeriesType(SeriesType type);
-  void updatePlotArea(int left);
+  void updatePlotArea(int left, bool force = false);
   void showTip(double sec);
   void hideTip();
 
@@ -105,7 +105,6 @@ private:
   QGraphicsPixmapItem *move_icon;
   QGraphicsProxyWidget *close_btn_proxy;
   QGraphicsProxyWidget *manage_btn_proxy;
-  QGraphicsRectItem *background;
   ValueTipLabel tip_label;
   QList<SigItem> sigs;
   double cur_sec = 0;


### PR DESCRIPTION
override `QChartView::paintEvent` to improve the pool real-time performance of `QtChart` by caching chart to pixmap.
The default implementation (https://codebrowser.dev/qt5/qtbase/src/widgets/graphicsview/qgraphicsview.cpp.html#_ZN13QGraphicsView10paintEventEP11QPaintEvent) redraws all items in graphics scene every time, which can lead to very high CPU usage on updating.

The test results after refactor: （settings.fps = 10）:
-  One chart:
  opengl enabled: save ~6% of a core
  opengl disabled: save ~12% of a core 
- Four charts:
  opengl enabled: save ~22% of a core
  opengl disabled: save ~50% of a core 







