### PR TITLE
cababa: display '--' in chart tooltip if no min max values

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -820,8 +820,10 @@ void ChartView::showTip(double sec) {
         x = std::max(x, chart()->mapToPosition(*it).x());
       }
       QString name = sigs.size() > 1 ? s.sig->name + ": " : "";
-      text_list << QString("<span style=\"color:%1;\">■ </span>%2<b>%3</b> (%4 - %5)")
-                       .arg(s.series->color().name(), name, value, QString::number(s.min), QString::number(s.max));
+      QString min = s.min == std::numeric_limits<double>::max() ? "--" : QString::number(s.min);
+      QString max = s.max == std::numeric_limits<double>::lowest() ? "--" : QString::number(s.max);
+      text_list << QString("<span style=\"color:%1;\">■ </span>%2<b>%3</b> (%4, %5)")
+                       .arg(s.series->color().name(), name, value, min, max);
     }
   }
   QPointF tooltip_pt(x, chart()->plotArea().top());


### PR DESCRIPTION
fixed the buggy display of min-max values:

| Before  | After |
| ------------- | ------------- |
| ![2023-04-04_13-20](https://user-images.githubusercontent.com/27770/229694291-c3d15e61-6e6d-4976-9afb-4c4d692809ea.png) | ![2023-04-04_13-17](https://user-images.githubusercontent.com/27770/229694324-24eec386-22a0-4450-af6a-0d4d5ffd96f3.png) |


