### PR TITLE
cabana: support undo/redo zoom

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -120,14 +120,9 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), QFrame(parent) 
 }
 
 void ChartsWidget::eventsMerged() {
-  {
-    QFutureSynchronizer<void> future_synchronizer;
-    for (auto c : charts) {
-      future_synchronizer.addFuture(QtConcurrent::run(c, &ChartView::updateSeries, nullptr));
-    }
-  }
-  if (can->isPaused()) {
-    updateState();
+  QFutureSynchronizer<void> future_synchronizer;
+  for (auto c : charts) {
+    future_synchronizer.addFuture(QtConcurrent::run(c, &ChartView::updateSeries, nullptr));
   }
 }
 

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -213,7 +213,7 @@ ChartView *ChartsWidget::findChart(const MessageId &id, const cabana::Signal *si
 }
 
 ChartView *ChartsWidget::createChart() {
-  auto chart = new ChartView(this);
+  auto chart = new ChartView(is_zoomed ? zoomed_range : display_range, this);
   chart->setFixedHeight(settings.chart_height);
   chart->setMinimumWidth(CHART_MIN_WIDTH);
   chart->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
@@ -235,7 +235,6 @@ void ChartsWidget::showChart(const MessageId &id, const cabana::Signal *sig, boo
   if (show && !chart) {
     chart = merge && charts.size() > 0 ? charts.back() : createChart();
     chart->addSeries(id, sig);
-    updateState();
   } else if (!show && chart) {
     chart->removeIf([&](auto &s) { return s.msg_id == id && s.sig == sig; });
   }
@@ -362,7 +361,7 @@ bool ChartsWidget::event(QEvent *event) {
 
 // ChartView
 
-ChartView::ChartView(QWidget *parent) : tip_label(this), QChartView(nullptr, parent) {
+ChartView::ChartView(const std::pair<double, double> &x_range, QWidget *parent) : tip_label(this), QChartView(nullptr, parent) {
   series_type = (SeriesType)settings.chart_series_type;
   QChart *chart = new QChart();
   chart->setBackgroundVisible(false);
@@ -374,6 +373,7 @@ ChartView::ChartView(QWidget *parent) : tip_label(this), QChartView(nullptr, par
   chart->legend()->setShowToolTips(true);
   chart->setMargins({0, 0, 0, 0});
 
+  axis_x->setRange(x_range.first, x_range.second);
   setChart(chart);
 
   createToolButtons();

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -227,6 +227,7 @@ ChartView *ChartsWidget::createChart() {
   QObject::connect(chart, &ChartView::hovered, this, &ChartsWidget::showValueTip);
   charts.push_back(chart);
   updateLayout();
+  updateToolBar();
   return chart;
 }
 
@@ -238,7 +239,6 @@ void ChartsWidget::showChart(const MessageId &id, const cabana::Signal *sig, boo
   } else if (!show && chart) {
     chart->removeIf([&](auto &s) { return s.msg_id == id && s.sig == sig; });
   }
-  updateToolBar();
 }
 
 void ChartsWidget::setColumnCount(int n) {

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -292,8 +292,8 @@ void ChartsWidget::removeChart(ChartView *chart) {
   charts.removeOne(chart);
   chart->deleteLater();
   updateToolBar();
-  alignCharts();
   updateLayout();
+  alignCharts();
   emit seriesChanged();
 }
 

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -37,7 +37,7 @@ class ChartView : public QChartView {
   Q_OBJECT
 
 public:
-  ChartView(QWidget *parent = nullptr);
+  ChartView(const std::pair<double, double> &x_range, QWidget *parent = nullptr);
   void addSeries(const MessageId &msg_id, const cabana::Signal *sig);
   bool hasSeries(const MessageId &msg_id, const cabana::Signal *sig) const;
   void updateSeries(const cabana::Signal *sig = nullptr);

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -5,8 +5,9 @@
 #include <QListWidget>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsProxyWidget>
-#include <QStack>
 #include <QTimer>
+#include <QUndoCommand>
+#include <QUndoStack>
 #include <QtCharts/QChartView>
 #include <QtCharts/QLegendMarker>
 #include <QtCharts/QLineSeries>
@@ -129,6 +130,7 @@ public:
 public slots:
   void setColumnCount(int n);
   void removeAll();
+  void setZoom(double min, double max);
 
 signals:
   void dock(bool floating);
@@ -146,8 +148,6 @@ private:
   void updateState();
   void zoomIn(double min, double max);
   void zoomReset();
-  void zoomUndo();
-  void setZoom(double min, double max);
   void updateToolBar();
   void setMaxChartRange(int value);
   void updateLayout();
@@ -163,8 +163,12 @@ private:
   QAction *range_slider_action;
   bool docking = true;
   QAction *dock_btn;
+
   QAction *undo_zoom_action;
+  QAction *redo_zoom_action;
   QAction *reset_zoom_action;
+  QUndoStack *zoom_undo_stack;
+
   QAction *remove_all_btn;
   QGridLayout *charts_layout;
   QList<ChartView *> charts;
@@ -174,11 +178,23 @@ private:
   bool is_zoomed = false;
   std::pair<double, double> display_range;
   std::pair<double, double> zoomed_range;
-  QStack<QPair<double, double>> zoom_stack;
   QAction *columns_action;
   int column_count = 1;
   int current_column_count = 0;
   QTimer align_timer;
+  friend class ZoomCommand;
+};
+
+class ZoomCommand : public QUndoCommand {
+public:
+  ZoomCommand(ChartsWidget *charts, std::pair<double, double> range) : charts(charts), range(range), QUndoCommand() {
+    prev_range = charts->is_zoomed ? charts->zoomed_range : charts->display_range;
+    setText(QObject::tr("Zoom to %1-%2").arg(range.first, 0, 'f', 1).arg(range.second, 0, 'f', 1));
+  }
+  void undo() override { charts->setZoom(prev_range.first, prev_range.second); }
+  void redo() override { charts->setZoom(range.first, range.second); }
+  ChartsWidget *charts;
+  std::pair<double, double> prev_range, range;
 };
 
 class SeriesSelector : public QDialog {


### PR DESCRIPTION
Currently only undo is supported. use `QUndoStack` to support undo/redo to complete the zoom functions:

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-04-04 14-47-59](https://user-images.githubusercontent.com/27770/229710515-46ed1971-0f92-4d54-ab91-e8bae45a0484.png)  | ![Screenshot from 2023-04-04 14-44-58](https://user-images.githubusercontent.com/27770/229710100-7cf20b4e-9813-4b5e-813a-e5338b045ebb.png)  |
