### PR TITLE
cabana: fix text overlapping in sparkline

### DIFF
--- a/tools/cabana/signalview.h
+++ b/tools/cabana/signalview.h
@@ -59,7 +59,9 @@ private:
   MessageId msg_id;
   QString filter_str;
   std::unique_ptr<Item> root;
+  int value_width = 0;
   friend class SignalView;
+  friend class SignalItemDelegate;
 };
 
 class ValueDescriptionDlg : public QDialog {
@@ -84,10 +86,10 @@ public:
   QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
   QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
-  void drawSparkline(QPainter *painter, const QRect &rect, const QModelIndex &index) const;
+  void drawSparkline(QPainter *painter, const QRect &rect, const QStyleOptionViewItem &option, const QModelIndex &index) const;
   void 	updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   QValidator *name_validator, *double_validator;
-  QFont small_font;
+  QFont label_font, minmax_font;
   const int color_label_width = 18;
   mutable QHash<QString, int> width_cache;
 };


### PR DESCRIPTION
1. fix text overlapping for min/max values.
2. highlight min/max values on selected.

| Before  | After |
| ------------- | ------------- |
| ![2023-04-04_17-22](https://user-images.githubusercontent.com/27770/229748533-f0274cd3-c993-4d26-a889-13cd27cda359.png)  | ![2023-04-04_17-18](https://user-images.githubusercontent.com/27770/229748545-3e6059f2-ccd0-40bb-bc19-12c8d714b2aa.png)  |
| ![2023-04-04_17-23](https://user-images.githubusercontent.com/27770/229748523-6a1dd6be-494a-423e-8983-9ffc1bdb1739.png)  | ![2023-04-04_17-19](https://user-images.githubusercontent.com/27770/229748540-9834b6c8-a8e0-46ea-8b08-867a0b605494.png)  |

