### PR TITLE
VW: Long control message builder cleanup

### DIFF
--- a/selfdrive/car/volkswagen/mqbcan.py
+++ b/selfdrive/car/volkswagen/mqbcan.py
@@ -56,18 +56,18 @@ def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
   return acc_control_value(main_switch_on, acc_faulted, long_active)
 
 
-def create_acc_accel_control(packer, bus, acc_type, enabled, accel, acc_control, stopping, starting, esp_hold):
+def create_acc_accel_control(packer, bus, acc_type, long_active, accel, acc_control, stopping, starting, esp_hold):
   commands = []
 
   acc_06_values = {
     "ACC_Typ": acc_type,
     "ACC_Status_ACC": acc_control,
-    "ACC_StartStopp_Info": enabled,
-    "ACC_Sollbeschleunigung_02": accel if enabled else 3.01,
+    "ACC_StartStopp_Info": long_active,
+    "ACC_Sollbeschleunigung_02": accel if long_active else 3.01,
     "ACC_zul_Regelabw_unten": 0.2,  # TODO: dynamic adjustment of comfort-band
     "ACC_zul_Regelabw_oben": 0.2,  # TODO: dynamic adjustment of comfort-band
-    "ACC_neg_Sollbeschl_Grad_02": 4.0 if enabled else 0,  # TODO: dynamic adjustment of jerk limits
-    "ACC_pos_Sollbeschl_Grad_02": 4.0 if enabled else 0,  # TODO: dynamic adjustment of jerk limits
+    "ACC_neg_Sollbeschl_Grad_02": 4.0 if long_active else 0,  # TODO: dynamic adjustment of jerk limits
+    "ACC_pos_Sollbeschl_Grad_02": 4.0 if long_active else 0,  # TODO: dynamic adjustment of jerk limits
     "ACC_Anfahren": starting,
     "ACC_Anhalten": stopping,
   }
@@ -84,9 +84,9 @@ def create_acc_accel_control(packer, bus, acc_type, enabled, accel, acc_control,
 
   acc_07_values = {
     "ACC_Anhalteweg": 0.75 if stopping else 20.46,  # Distance to stop (stopping coordinator handles terminal roll-out)
-    "ACC_Freilauf_Info": 2 if enabled else 0,
+    "ACC_Freilauf_Info": 2 if long_active else 0,
     "ACC_Folgebeschl": 3.02,  # Not using secondary controller accel unless and until we understand its impact
-    "ACC_Sollbeschleunigung_02": accel if enabled else 3.01,
+    "ACC_Sollbeschleunigung_02": accel if long_active else 3.01,
     "ACC_Anforderung_HMS": acc_hold_type,
     "ACC_Anfahren": starting,
     "ACC_Anhalten": stopping,

--- a/selfdrive/car/volkswagen/mqbcan.py
+++ b/selfdrive/car/volkswagen/mqbcan.py
@@ -56,18 +56,18 @@ def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
   return acc_control_value(main_switch_on, acc_faulted, long_active)
 
 
-def create_acc_accel_control(packer, bus, acc_type, long_active, accel, acc_control, stopping, starting, esp_hold):
+def create_acc_accel_control(packer, bus, acc_type, long_enabled, accel, acc_control, stopping, starting, esp_hold):
   commands = []
 
   acc_06_values = {
     "ACC_Typ": acc_type,
     "ACC_Status_ACC": acc_control,
-    "ACC_StartStopp_Info": long_active,
-    "ACC_Sollbeschleunigung_02": accel if long_active else 3.01,
+    "ACC_StartStopp_Info": long_enabled,
+    "ACC_Sollbeschleunigung_02": accel if long_enabled else 3.01,
     "ACC_zul_Regelabw_unten": 0.2,  # TODO: dynamic adjustment of comfort-band
     "ACC_zul_Regelabw_oben": 0.2,  # TODO: dynamic adjustment of comfort-band
-    "ACC_neg_Sollbeschl_Grad_02": 4.0 if long_active else 0,  # TODO: dynamic adjustment of jerk limits
-    "ACC_pos_Sollbeschl_Grad_02": 4.0 if long_active else 0,  # TODO: dynamic adjustment of jerk limits
+    "ACC_neg_Sollbeschl_Grad_02": 4.0 if long_enabled else 0,  # TODO: dynamic adjustment of jerk limits
+    "ACC_pos_Sollbeschl_Grad_02": 4.0 if long_enabled else 0,  # TODO: dynamic adjustment of jerk limits
     "ACC_Anfahren": starting,
     "ACC_Anhalten": stopping,
   }
@@ -84,9 +84,9 @@ def create_acc_accel_control(packer, bus, acc_type, long_active, accel, acc_cont
 
   acc_07_values = {
     "ACC_Anhalteweg": 0.75 if stopping else 20.46,  # Distance to stop (stopping coordinator handles terminal roll-out)
-    "ACC_Freilauf_Info": 2 if long_active else 0,
+    "ACC_Freilauf_Info": 2 if long_enabled else 0,
     "ACC_Folgebeschl": 3.02,  # Not using secondary controller accel unless and until we understand its impact
-    "ACC_Sollbeschleunigung_02": accel if long_active else 3.01,
+    "ACC_Sollbeschleunigung_02": accel if long_enabled else 3.01,
     "ACC_Anforderung_HMS": acc_hold_type,
     "ACC_Anfahren": starting,
     "ACC_Anhalten": stopping,

--- a/selfdrive/car/volkswagen/mqbcan.py
+++ b/selfdrive/car/volkswagen/mqbcan.py
@@ -56,18 +56,18 @@ def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
   return acc_control_value(main_switch_on, acc_faulted, long_active)
 
 
-def create_acc_accel_control(packer, bus, acc_type, long_enabled, accel, acc_control, stopping, starting, esp_hold):
+def create_acc_accel_control(packer, bus, acc_type, acc_enabled, accel, acc_control, stopping, starting, esp_hold):
   commands = []
 
   acc_06_values = {
     "ACC_Typ": acc_type,
     "ACC_Status_ACC": acc_control,
-    "ACC_StartStopp_Info": long_enabled,
-    "ACC_Sollbeschleunigung_02": accel if long_enabled else 3.01,
+    "ACC_StartStopp_Info": acc_enabled,
+    "ACC_Sollbeschleunigung_02": accel if acc_enabled else 3.01,
     "ACC_zul_Regelabw_unten": 0.2,  # TODO: dynamic adjustment of comfort-band
     "ACC_zul_Regelabw_oben": 0.2,  # TODO: dynamic adjustment of comfort-band
-    "ACC_neg_Sollbeschl_Grad_02": 4.0 if long_enabled else 0,  # TODO: dynamic adjustment of jerk limits
-    "ACC_pos_Sollbeschl_Grad_02": 4.0 if long_enabled else 0,  # TODO: dynamic adjustment of jerk limits
+    "ACC_neg_Sollbeschl_Grad_02": 4.0 if acc_enabled else 0,  # TODO: dynamic adjustment of jerk limits
+    "ACC_pos_Sollbeschl_Grad_02": 4.0 if acc_enabled else 0,  # TODO: dynamic adjustment of jerk limits
     "ACC_Anfahren": starting,
     "ACC_Anhalten": stopping,
   }
@@ -84,9 +84,9 @@ def create_acc_accel_control(packer, bus, acc_type, long_enabled, accel, acc_con
 
   acc_07_values = {
     "ACC_Anhalteweg": 0.75 if stopping else 20.46,  # Distance to stop (stopping coordinator handles terminal roll-out)
-    "ACC_Freilauf_Info": 2 if long_enabled else 0,
+    "ACC_Freilauf_Info": 2 if acc_enabled else 0,
     "ACC_Folgebeschl": 3.02,  # Not using secondary controller accel unless and until we understand its impact
-    "ACC_Sollbeschleunigung_02": accel if long_enabled else 3.01,
+    "ACC_Sollbeschleunigung_02": accel if acc_enabled else 3.01,
     "ACC_Anforderung_HMS": acc_hold_type,
     "ACC_Anfahren": starting,
     "ACC_Anhalten": stopping,

--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -59,7 +59,7 @@ def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
   return hud_status
 
 
-def create_acc_accel_control(packer, bus, acc_type, long_active, accel, acc_control, stopping, starting, esp_hold):
+def create_acc_accel_control(packer, bus, acc_type, long_enabled, accel, acc_control, stopping, starting, esp_hold):
   commands = []
 
   values = {
@@ -67,9 +67,9 @@ def create_acc_accel_control(packer, bus, acc_type, long_active, accel, acc_cont
     "ACS_StSt_Info": acc_control != 1,
     "ACS_Typ_ACC": acc_type,
     "ACS_Anhaltewunsch": acc_type == 1 and stopping,
-    "ACS_Sollbeschl": accel if long_active else 3.01,
-    "ACS_zul_Regelabw": 0.2 if long_active else 1.27,
-    "ACS_max_AendGrad": 3.0 if long_active else 5.08,
+    "ACS_Sollbeschl": accel if long_enabled else 3.01,
+    "ACS_zul_Regelabw": 0.2 if long_enabled else 1.27,
+    "ACS_max_AendGrad": 3.0 if long_enabled else 5.08,
   }
 
   commands.append(packer.make_can_msg("ACC_System", bus, values))

--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -59,7 +59,7 @@ def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
   return hud_status
 
 
-def create_acc_accel_control(packer, bus, acc_type, enabled, accel, acc_control, stopping, starting, esp_hold):
+def create_acc_accel_control(packer, bus, acc_type, long_active, accel, acc_control, stopping, starting, esp_hold):
   commands = []
 
   values = {
@@ -67,9 +67,9 @@ def create_acc_accel_control(packer, bus, acc_type, enabled, accel, acc_control,
     "ACS_StSt_Info": acc_control != 1,
     "ACS_Typ_ACC": acc_type,
     "ACS_Anhaltewunsch": acc_type == 1 and stopping,
-    "ACS_Sollbeschl": accel if acc_control == 1 else 3.01,
-    "ACS_zul_Regelabw": 0.2 if acc_control == 1 else 1.27,
-    "ACS_max_AendGrad": 3.0 if acc_control == 1 else 5.08,
+    "ACS_Sollbeschl": accel if long_active else 3.01,
+    "ACS_zul_Regelabw": 0.2 if long_active else 1.27,
+    "ACS_max_AendGrad": 3.0 if long_active else 5.08,
   }
 
   commands.append(packer.make_can_msg("ACC_System", bus, values))

--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -59,7 +59,7 @@ def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
   return hud_status
 
 
-def create_acc_accel_control(packer, bus, acc_type, long_enabled, accel, acc_control, stopping, starting, esp_hold):
+def create_acc_accel_control(packer, bus, acc_type, acc_enabled, accel, acc_control, stopping, starting, esp_hold):
   commands = []
 
   values = {
@@ -67,9 +67,9 @@ def create_acc_accel_control(packer, bus, acc_type, long_enabled, accel, acc_con
     "ACS_StSt_Info": acc_control != 1,
     "ACS_Typ_ACC": acc_type,
     "ACS_Anhaltewunsch": acc_type == 1 and stopping,
-    "ACS_Sollbeschl": accel if long_enabled else 3.01,
-    "ACS_zul_Regelabw": 0.2 if long_enabled else 1.27,
-    "ACS_max_AendGrad": 3.0 if long_enabled else 5.08,
+    "ACS_Sollbeschl": accel if acc_enabled else 3.01,
+    "ACS_zul_Regelabw": 0.2 if acc_enabled else 1.27,
+    "ACS_max_AendGrad": 3.0 if acc_enabled else 5.08,
   }
 
   commands.append(packer.make_can_msg("ACC_System", bus, values))


### PR DESCRIPTION
Cleanup only, null-effect change. Prepares for two more bugfix PRs.

The `enabled` parameter was confusingly named given other usage in controls. Change to `acc_enabled` and simplify some other expressions. This parameter does happen to equal `CC.longActive` today, but the upcoming bugfixes will add nuance.