### PR TITLE
VW PQ: Miscellaneous longitudinal bug fixes

### DIFF
--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -85,8 +85,8 @@ def create_acc_hud_control(packer, bus, acc_hud_status, set_speed, lead_distance
     "ACA_V_Wunsch": set_speed,
     "ACA_gemZeitl": lead_distance,
     "ACA_PrioDisp": 3,
-    # TODO: ACA_ID_StaACC, ACA_AnzDisplay, ACA_kmh_mph, ACA_Aend_Zeitluecke
-    # kmh_mph handling probably needed to resolve rounding errors in displayed setpoint
+    # TODO: restore dynamic pop-to-foreground/highlight behavior with ACA_PrioDisp and ACA_AnzDisplay
+    # TODO: ACA_kmh_mph handling probably needed to resolve rounding errors in displayed setpoint
   }
 
   return packer.make_can_msg("ACC_GRA_Anzeige", bus, values)

--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -64,9 +64,10 @@ def create_acc_accel_control(packer, bus, acc_type, acc_enabled, accel, acc_cont
 
   values = {
     "ACS_Sta_ADR": acc_control,
-    "ACS_StSt_Info": acc_control != 1,
+    "ACS_StSt_Info": acc_enabled,
     "ACS_Typ_ACC": acc_type,
     "ACS_Anhaltewunsch": acc_type == 1 and stopping,
+    "ACS_FreigSollB": acc_enabled,
     "ACS_Sollbeschl": accel if acc_enabled else 3.01,
     "ACS_zul_Regelabw": 0.2 if acc_enabled else 1.27,
     "ACS_max_AendGrad": 3.0 if acc_enabled else 5.08,
@@ -83,8 +84,8 @@ def create_acc_hud_control(packer, bus, acc_hud_status, set_speed, lead_distance
     "ACA_Zeitluecke": 2,
     "ACA_V_Wunsch": set_speed,
     "ACA_gemZeitl": lead_distance,
-    # TODO: ACA_ID_StaACC, ACA_AnzDisplay, ACA_kmh_mph, ACA_PrioDisp, ACA_Aend_Zeitluecke
-    # display/display-prio handling probably needed to stop confusing the instrument cluster
+    "ACA_PrioDisp": 3,
+    # TODO: ACA_ID_StaACC, ACA_AnzDisplay, ACA_kmh_mph, ACA_Aend_Zeitluecke
     # kmh_mph handling probably needed to resolve rounding errors in displayed setpoint
   }
 


### PR DESCRIPTION
**Description**

Fix three separate issues with openpilot longitudinal control on VW PQ:

1) Fix the instrument cluster getting "stuck" displaying the ACC screen with lead car indicator. With the fixes from commaai/opendbc#792 we can now correctly set the lower display priority.

2) Fix the engine auto start-stop inhibit signal. It was inverted.

3) Set the accel request valid field when enabled. Not sure how we got away without this in the past, for example on the 2018 NMS Passat I tested last year, but some older ECUs are ignoring accel requests without it.

**Verification**

The fixes have all been road-tested on an older NMS (USA) Passat and a European VW Sharan.

**Route**

Route: `e12eb71c201af95a|2023-04-05--07-26-02`

**Additional Info**

The combination of `ACA_PrioDisp` and `ACA_AnzDisplay` are supposed to be used to temporarily pop the ACC page to the foreground and increase brightness when activity happens: engagement, follow distance adjustment, or a lead car comes into range. Eventually we should emulate that stock behavior. However, openpilot doesn't allow adjustment of the follow distance, and its lead car data is so low-value right now (presence only, no distance, noisy/not debounced) that it's not yet worth implementing. The driver can still switch to the ACC data screen manually if they want to see it.