### PR TITLE
cabana: sort events based on priority

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -20,7 +20,7 @@ static const QColor timeline_colors[] = {
 };
 
 
-bool sortTimelineBasedOnEventPriority(std::tuple<int, int, TimelineType> left, std::tuple<int, int, TimelineType> right){
+bool sortTimelineBasedOnEventPriority(const std::tuple<int, int, TimelineType> &left, const std::tuple<int, int, TimelineType> &right){
   const static std::map<TimelineType, int> timelinePriority = {
     {  TimelineType::None, 0 },
     {  TimelineType::Engaged, 10 },
@@ -142,16 +142,9 @@ void VideoWidget::updatePlayBtnState() {
 // Slider
 Slider::Slider(QWidget *parent) : timer(this), thumbnail_label(this), QSlider(Qt::Horizontal, parent) {
   timer.callOnTimeout([this]() {
-    auto unsortedTimeline = can->getTimeline();
+    auto timeline = can->getTimeline();
+    std::sort(timeline.begin(), timeline.end(), sortTimelineBasedOnEventPriority);
 
-    std::vector<std::tuple<int, int, TimelineType>> sortedTimeline;
-
-    std::copy(unsortedTimeline.begin(), unsortedTimeline.end(), std::back_inserter(sortedTimeline));
-
-    std::sort(sortedTimeline.begin(), sortedTimeline.end(), sortTimelineBasedOnEventPriority);
-
-    timeline = sortedTimeline;
-    
     update();
   });
   setMouseTracking(true);

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -183,13 +183,33 @@ void Slider::sliderChange(QAbstractSlider::SliderChange change) {
   }
 }
 
+bool sortTimelineBasedOnEventPriority(std::tuple<int, int, TimelineType> left, std::tuple<int, int, TimelineType> right){
+  std::map<TimelineType, int> timelinePriority = {
+    {  TimelineType::None, 0 },
+    {  TimelineType::Engaged, 10 },
+    {  TimelineType::AlertInfo, 20 },
+    {  TimelineType::AlertWarning, 30 },
+    {  TimelineType::AlertCritical, 40 },
+    {  TimelineType::UserFlag, 35 }
+  };
+
+  return timelinePriority[std::get<2>(left)] < timelinePriority[std::get<2>(right)];
+}
+
 void Slider::paintEvent(QPaintEvent *ev) {
   QPainter p(this);
   QRect r = rect().adjusted(0, 4, 0, -4);
   p.fillRect(r, timeline_colors[(int)TimelineType::None]);
   double min = minimum() / 1000.0;
   double max = maximum() / 1000.0;
-  for (auto [begin, end, type] : timeline) {
+
+  std::vector<std::tuple<int, int, TimelineType>> sortedTimeline;
+
+  std::copy(timeline.begin(), timeline.end(), std::back_inserter(sortedTimeline));
+
+  std::sort(sortedTimeline.begin(), sortedTimeline.end(), sortTimelineBasedOnEventPriority);
+
+  for (auto [begin, end, type] : sortedTimeline) {
     if (begin > max || end < min)
       continue;
     r.setLeft(((std::max(min, (double)begin) - min) / (max - min)) * width());

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -142,7 +142,7 @@ void VideoWidget::updatePlayBtnState() {
 // Slider
 Slider::Slider(QWidget *parent) : timer(this), thumbnail_label(this), QSlider(Qt::Horizontal, parent) {
   timer.callOnTimeout([this]() {
-    auto timeline = can->getTimeline();
+    timeline = can->getTimeline();
     std::sort(timeline.begin(), timeline.end(), sortTimelineBasedOnEventPriority);
 
     update();


### PR DESCRIPTION
**Description**

Sorts events on the cabana timeline based on some order that I thought made sense. This allows things like user flags to actually appear on the timeline (because they will be painted last).

![image](https://user-images.githubusercontent.com/9648890/230089523-a9d12b4c-d343-406b-abea-795a0c149c61.png)

