### PR TITLE
tizi: affine IRQ by action instead of number

### DIFF
--- a/common/gpio.py
+++ b/common/gpio.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import glob
+from typing import Optional, List
 
 def gpio_init(pin: int, output: bool) -> None:
   try:
@@ -23,3 +24,13 @@ def gpio_read(pin: int) -> Optional[bool]:
     print(f"Failed to set gpio {pin} value: {e}")
 
   return val
+
+def get_irq_for_action(action: str) -> List[int]:
+  ret = []
+  for fn in glob.glob('/sys/kernel/irq/*/actions'):
+    with open(fn) as f:
+      actions = f.read().strip().split(',')
+      if action in actions:
+        irq = int(fn.split('/')[-2])
+        ret.append(irq)
+  return ret

--- a/selfdrive/debug/profiling/watch-irqs.sh
+++ b/selfdrive/debug/profiling/watch-irqs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+set -e
+
+RUBYOPT="-W0" irqtop -d1 -R

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -67,7 +67,7 @@ def sudo_write(val, path):
 def affine_irq(val, action):
   irq = get_irq_for_action(action)
   if len(irq) == 0:
-    print(f"No IRQs not found for '{action}'")
+    print(f"No IRQs found for '{action}'")
     return
   for i in irq:
     sudo_write(str(val), f"/proc/irq/{i}/smp_affinity_list")
@@ -438,13 +438,19 @@ class Tici(HardwareBase):
       sudo_write(gov, f'/sys/devices/system/cpu/cpufreq/policy{n}/scaling_governor')
 
     # *** IRQ config ***
+
+    # GPU
     affine_irq(5, "kgsl-3d0")
-    affine_irq(4, "spi_geni")        # SPI goes on boardd core
-    affine_irq(4, "xhci-hcd:usb1")   # xhci-hcd:usb1 goes on the boardd core
-    affine_irq(4, "xhci-hcd:usb3")   # xhci-hcd:usb3 goes on the boardd core
+
+    # boardd core
+    affine_irq(4, "spi_geni")        # SPI
+    affine_irq(4, "xhci-hcd:usb1")   # internal panda USB
+    affine_irq(4, "xhci-hcd:usb3")   # aux panda USB (or potentially anything else on USB)
+
+    # camerad core
     camera_irqs = ("cci", "cpas_camnoc", "cpas-cdm", "csid", "ife", "csid", "csid-lite", "ife-lite")
     for n in camera_irqs:
-      affine_irq(5, n)  # camerad core
+      affine_irq(5, n)
 
   def get_gpu_usage_percent(self):
     try:

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from pathlib import Path
 
 from cereal import log
-from common.gpio import gpio_set, gpio_init
+from common.gpio import gpio_set, gpio_init, get_irq_for_action
 from system.hardware.base import HardwareBase, ThermalConfig
 from system.hardware.tici import iwlist
 from system.hardware.tici.pins import GPIO
@@ -63,8 +63,16 @@ MM_MODEM_ACCESS_TECHNOLOGY_LTE = 1 << 14
 def sudo_write(val, path):
   os.system(f"sudo su -c 'echo {val} > {path}'")
 
-def affine_irq(val, irq):
-  sudo_write(str(val), f"/proc/irq/{irq}/smp_affinity_list")
+#def affine_irq(val, irq):
+#  sudo_write(str(val), f"/proc/irq/{irq}/smp_affinity_list")
+
+def affine_irq(val, action):
+  irq = get_irq_for_action(action)
+  if len(irq) == 0:
+    print(f"No IRQs not found for '{action}'")
+    return
+  for i in irq:
+    sudo_write(str(val), f"/proc/irq/{i}/smp_affinity_list")
 
 
 class Tici(HardwareBase):
@@ -432,12 +440,14 @@ class Tici(HardwareBase):
       sudo_write(gov, f'/sys/devices/system/cpu/cpufreq/policy{n}/scaling_governor')
 
     # *** IRQ config ***
-    affine_irq(5, 565)   # kgsl-3d0
-    affine_irq(4, 126)   # SPI goes on boardd core
-    affine_irq(4, 740)   # xhci-hcd:usb1 goes on the boardd core
-    affine_irq(4, 1069)  # xhci-hcd:usb3 goes on the boardd core
-    for irq in range(237, 246):
-      affine_irq(5, irq) # camerad
+    affine_irq(5, "kgsl-3d0")
+    affine_irq(4, "spi_geni")        # SPI goes on boardd core
+    affine_irq(4, "xhci-hcd:usb1")   # xhci-hcd:usb1 goes on the boardd core
+    affine_irq(4, "xhci-hcd:usb3")   # xhci-hcd:usb3 goes on the boardd core
+    # TODO: some of these have multiple irqs
+    camera_irqs = ("cci", "cpas_camnoc", "cpas-cdm", "csid", "ife", "csid", "csid-lite", "ife-lite")
+    #for irq in range(237, 246):
+    #  affine_irq(5, irq) # camerad
 
   def get_gpu_usage_percent(self):
     try:
@@ -461,9 +471,11 @@ class Tici(HardwareBase):
     # *** IRQ config ***
 
     # move these off the default core
-    affine_irq(1, 7)    # msm_drm
-    affine_irq(1, 250)  # msm_vidc
-    affine_irq(1, 8)    # i2c_geni (sensord)
+    affine_irq(1, "msm_drm")
+    affine_irq(1, "msm_vidc")
+    affine_irq(1, "i2c_geni")
+
+    # mask off big cluster from default affinity
     sudo_write("f", "/proc/irq/default_smp_affinity")
 
     # *** GPU config ***

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -63,8 +63,6 @@ MM_MODEM_ACCESS_TECHNOLOGY_LTE = 1 << 14
 def sudo_write(val, path):
   os.system(f"sudo su -c 'echo {val} > {path}'")
 
-#def affine_irq(val, irq):
-#  sudo_write(str(val), f"/proc/irq/{irq}/smp_affinity_list")
 
 def affine_irq(val, action):
   irq = get_irq_for_action(action)
@@ -444,10 +442,9 @@ class Tici(HardwareBase):
     affine_irq(4, "spi_geni")        # SPI goes on boardd core
     affine_irq(4, "xhci-hcd:usb1")   # xhci-hcd:usb1 goes on the boardd core
     affine_irq(4, "xhci-hcd:usb3")   # xhci-hcd:usb3 goes on the boardd core
-    # TODO: some of these have multiple irqs
     camera_irqs = ("cci", "cpas_camnoc", "cpas-cdm", "csid", "ife", "csid", "csid-lite", "ife-lite")
-    #for irq in range(237, 246):
-    #  affine_irq(5, irq) # camerad
+    for n in camera_irqs:
+      affine_irq(5, n)  # camerad core
 
   def get_gpu_usage_percent(self):
     try:

--- a/system/sensord/tests/test_sensord.py
+++ b/system/sensord/tests/test_sensord.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import os
-import glob
 import time
 import unittest
 import numpy as np
@@ -8,6 +7,7 @@ from collections import namedtuple, defaultdict
 
 import cereal.messaging as messaging
 from cereal import log
+from common.gpio import get_irq_for_action
 from system.hardware import TICI
 from selfdrive.manager.process_config import managed_processes
 
@@ -113,13 +113,7 @@ class TestSensord(unittest.TestCase):
       cls.events = read_sensor_events(cls.sample_secs)
 
       # determine sensord's irq
-      cls.sensord_irq = None
-      for fn in glob.glob('/sys/kernel/irq/*/actions'):
-        with open(fn) as f:
-          if "sensord" in f.read():
-            cls.sensord_irq = int(fn.split('/')[-2])
-            break
-      assert cls.sensord_irq is not None
+      cls.sensord_irq = get_irq_for_action("sensord")[0]
     finally:
       # teardown won't run if this doesn't succeed
       managed_processes["sensord"].stop()


### PR DESCRIPTION
These numbers can change, presumably due to device tree differences and updates, so use the real names.