### PR TITLE
three: support WPA3 networks

### DIFF
--- a/selfdrive/ui/qt/offroad/networkmanager.h
+++ b/selfdrive/ui/qt/offroad/networkmanager.h
@@ -10,8 +10,10 @@ const int NM_802_11_AP_FLAGS_WPS = 0x00000002;
 // https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NM80211ApSecurityFlags
 const int NM_802_11_AP_SEC_PAIR_WEP40      = 0x00000001;
 const int NM_802_11_AP_SEC_PAIR_WEP104     = 0x00000002;
+const int NM_802_11_AP_SEC_PAIR_CCMP       = 0x00000008;
 const int NM_802_11_AP_SEC_GROUP_WEP40     = 0x00000010;
 const int NM_802_11_AP_SEC_GROUP_WEP104    = 0x00000020;
+const int NM_802_11_AP_SEC_GROUP_CCMP      = 0x00000080;
 const int NM_802_11_AP_SEC_KEY_MGMT_PSK    = 0x00000100;
 const int NM_802_11_AP_SEC_KEY_MGMT_802_1X = 0x00000200;
 

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -145,7 +145,7 @@ SecurityType WifiManager::getSecurityType(const QVariantMap &properties) {
   int wpa_props = wpaflag | rsnflag;
 
   // obtained by looking at flags of networks in the office as reported by an Android phone
-  const int supports_wpa = NM_802_11_AP_SEC_PAIR_WEP40 | NM_802_11_AP_SEC_PAIR_WEP104 | NM_802_11_AP_SEC_GROUP_WEP40 | NM_802_11_AP_SEC_GROUP_WEP104 | NM_802_11_AP_SEC_KEY_MGMT_PSK;
+  const int supports_wpa = NM_802_11_AP_SEC_PAIR_WEP40 | NM_802_11_AP_SEC_PAIR_WEP104 | NM_802_11_AP_SEC_PAIR_CCMP | NM_802_11_AP_SEC_GROUP_WEP40 | NM_802_11_AP_SEC_GROUP_WEP104 | NM_802_11_AP_SEC_GROUP_CCMP | NM_802_11_AP_SEC_KEY_MGMT_PSK;
 
   if ((sflag == NM_802_11_AP_FLAGS_NONE) || ((sflag & NM_802_11_AP_FLAGS_WPS) && !(wpa_props & supports_wpa))) {
     return SecurityType::OPEN;


### PR DESCRIPTION
Will test if it works tonight. My rsnflags: `1160`

Reference: https://developer-old.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NM80211ApSecurityFlags

Also supports `NM_802_11_AP_SEC_KEY_MGMT_SAE`, might want to add that.