### PR TITLE
cabana: dispaly alert info in thumbnail&video player

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -3,6 +3,7 @@
 #include <QButtonGroup>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QStackedLayout>
 #include <QStyleOptionSlider>
 #include <QVBoxLayout>
 #include <QtConcurrent>
@@ -19,7 +20,6 @@ static const QColor timeline_colors[] = {
   [(int)TimelineType::AlertCritical] = QColor(199, 0, 57),
 };
 
-
 bool sortTimelineBasedOnEventPriority(const std::tuple<int, int, TimelineType> &left, const std::tuple<int, int, TimelineType> &right){
   const static std::map<TimelineType, int> timelinePriority = {
     {  TimelineType::None, 0 },
@@ -29,7 +29,6 @@ bool sortTimelineBasedOnEventPriority(const std::tuple<int, int, TimelineType> &
     {  TimelineType::AlertCritical, 40 },
     {  TimelineType::UserFlag, 35 }
   };
-
   return timelinePriority.at(std::get<2>(left)) < timelinePriority.at(std::get<2>(right));
 }
 
@@ -92,10 +91,14 @@ QWidget *VideoWidget::createCameraWidget() {
   QWidget *w = new QWidget(this);
   QVBoxLayout *l = new QVBoxLayout(w);
   l->setContentsMargins(0, 0, 0, 0);
-  cam_widget = new CameraWidget("camerad", can->visionStreamType(), false);
+
+  QStackedLayout *stacked = new QStackedLayout();
+  stacked->setStackingMode(QStackedLayout::StackAll);
+  stacked->addWidget(cam_widget = new CameraWidget("camerad", can->visionStreamType(), false));
   cam_widget->setMinimumHeight(MIN_VIDEO_HEIGHT);
   cam_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
-  l->addWidget(cam_widget);
+  stacked->addWidget(alert_label = new InfoLabel(this));
+  l->addLayout(stacked);
 
   // slider controls
   slider_layout = new QHBoxLayout();
@@ -130,8 +133,17 @@ void VideoWidget::rangeChanged(double min, double max, bool is_zoomed) {
 }
 
 void VideoWidget::updateState() {
-  if (!slider->isSliderDown())
+  if (!slider->isSliderDown()) {
     slider->setValue(can->currentSec() * 1000);
+  }
+  std::lock_guard lk(slider->thumbnail_lock);
+  uint64_t mono_time = (can->currentSec() + can->routeStartTime()) * 1e9;
+  auto it = slider->alerts.lower_bound(mono_time);
+  if (it != slider->alerts.end() && (it->first - mono_time) < 1e9) {
+    alert_label->showAlert(it->second);
+  } else {
+    alert_label->showAlert({});
+  }
 }
 
 void VideoWidget::updatePlayBtnState() {
@@ -144,7 +156,6 @@ Slider::Slider(QWidget *parent) : timer(this), thumbnail_label(this), QSlider(Qt
   timer.callOnTimeout([this]() {
     timeline = can->getTimeline();
     std::sort(timeline.begin(), timeline.end(), sortTimelineBasedOnEventPriority);
-
     update();
   });
   setMouseTracking(true);
@@ -169,28 +180,23 @@ void Slider::streamStarted() {
 void Slider::loadThumbnails() {
   const auto &segments = can->route()->segments();
   for (auto it = segments.rbegin(); it != segments.rend() && !abort_load_thumbnail; ++it) {
+    LogReader log;
     std::string qlog = it->second.qlog.toStdString();
-    if (!qlog.empty()) {
-      LogReader log;
-      if (log.load(qlog, &abort_load_thumbnail, {cereal::Event::Which::THUMBNAIL, cereal::Event::Which::CONTROLS_STATE}, true, 0, 3)) {
-        for (auto ev = log.events.cbegin(); ev != log.events.cend() && !abort_load_thumbnail; ++ev) {
-          if ((*ev)->which == cereal::Event::Which::THUMBNAIL) {
-            auto thumb = (*ev)->event.getThumbnail();
-            auto data = thumb.getThumbnail();
-            if (QPixmap pm; pm.loadFromData(data.begin(), data.size(), "jpeg")) {
-              pm = pm.scaledToHeight(MIN_VIDEO_HEIGHT - THUMBNAIL_MARGIN * 2, Qt::SmoothTransformation);
-              std::lock_guard lk(thumbnail_lock);
-              thumbnails[thumb.getTimestampEof()] = pm;
-            }
-          } else if ((*ev)->which == cereal::Event::Which::CONTROLS_STATE) {
-            auto cs = (*ev)->event.getControlsState();
-            if (cs.getAlertType().size() > 0 && cs.getAlertText1().size() > 0) {
-              std::lock_guard lk(thumbnail_lock);
-              auto &alert = alerts[(*ev)->mono_time];
-              alert.status = cs.getAlertStatus();
-              alert.text1 = cs.getAlertText1().cStr();
-              alert.text2 = cs.getAlertText2().cStr();
-            }
+    if (!qlog.empty() && log.load(qlog, &abort_load_thumbnail, {cereal::Event::Which::THUMBNAIL, cereal::Event::Which::CONTROLS_STATE}, true, 0, 3)) {
+      for (auto ev = log.events.cbegin(); ev != log.events.cend() && !abort_load_thumbnail; ++ev) {
+        if ((*ev)->which == cereal::Event::Which::THUMBNAIL) {
+          auto thumb = (*ev)->event.getThumbnail();
+          auto data = thumb.getThumbnail();
+          if (QPixmap pm; pm.loadFromData(data.begin(), data.size(), "jpeg")) {
+            pm = pm.scaledToHeight(MIN_VIDEO_HEIGHT - THUMBNAIL_MARGIN * 2, Qt::SmoothTransformation);
+            std::lock_guard lk(thumbnail_lock);
+            thumbnails[thumb.getTimestampEof()] = pm;
+          }
+        } else if ((*ev)->which == cereal::Event::Which::CONTROLS_STATE) {
+          auto cs = (*ev)->event.getControlsState();
+          if (cs.getAlertType().size() > 0 && cs.getAlertText1().size() > 0) {
+            std::lock_guard lk(thumbnail_lock);
+            alerts.emplace((*ev)->mono_time, AlertInfo{cs.getAlertStatus(), cs.getAlertText1().cStr(), cs.getAlertText2().cStr()});
           }
         }
       }
@@ -268,14 +274,14 @@ void Slider::leaveEvent(QEvent *event) {
   QSlider::leaveEvent(event);
 }
 
-// ThumbnailLabel
+// InfoLabel
 
-ThumbnailLabel::ThumbnailLabel(QWidget *parent) : QWidget(parent, Qt::Tool | Qt::FramelessWindowHint) {
+InfoLabel::InfoLabel(QWidget *parent) : QWidget(parent, Qt::Tool | Qt::FramelessWindowHint) {
   setAttribute(Qt::WA_ShowWithoutActivating);
   setVisible(false);
 }
 
-void ThumbnailLabel::showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm, const AlertInfo &alert) {
+void InfoLabel::showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm, const AlertInfo &alert) {
   pixmap = pm;
   second = sec;
   alert_info = alert;
@@ -286,12 +292,23 @@ void ThumbnailLabel::showPixmap(const QPoint &pt, const QString &sec, const QPix
   }
 }
 
-void ThumbnailLabel::paintEvent(QPaintEvent *event) {
+void InfoLabel::showAlert(const AlertInfo &alert) {
+  alert_info = alert;
+  pixmap = {};
+  setVisible(!alert_info.text1.isEmpty());
+  if (isVisible()) {
+    update();
+  }
+}
+
+void InfoLabel::paintEvent(QPaintEvent *event) {
   QPainter p(this);
-  p.drawPixmap(0, 0, pixmap);
   p.setPen(QPen(Qt::white, 2));
-  p.drawRect(rect());
-  p.drawText(rect().adjusted(0, 0, 0, -THUMBNAIL_MARGIN), second, Qt::AlignHCenter | Qt::AlignBottom);
+  if (!pixmap.isNull()) {
+    p.drawPixmap(0, 0, pixmap);
+    p.drawRect(rect());
+    p.drawText(rect().adjusted(0, 0, 0, -THUMBNAIL_MARGIN), second, Qt::AlignHCenter | Qt::AlignBottom);
+  }
   if (alert_info.text1.size() > 0) {
     QColor color = timeline_colors[(int)TimelineType::AlertInfo];
     if (alert_info.status == cereal::ControlsState::AlertStatus::USER_PROMPT) {
@@ -300,14 +317,13 @@ void ThumbnailLabel::paintEvent(QPaintEvent *event) {
       color = timeline_colors[(int)TimelineType::AlertCritical];
     }
     color.setAlphaF(0.5);
-
     QString text = alert_info.text1;
     if (!alert_info.text2.isEmpty()) {
       text += "\n" + alert_info.text2;
     }
 
     QFont font;
-    font.setPixelSize(11);
+    font.setPixelSize(!pixmap.isNull() ? 11 : QFont().pixelSize());
     p.setFont(font);
     QRect text_rect = rect().adjusted(2, 2, -2, -2);
     QRect r = p.fontMetrics().boundingRect(text_rect, Qt::AlignTop | Qt::AlignHCenter | Qt::TextWordWrap, text);

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -13,13 +13,20 @@
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 #include "tools/cabana/streams/abstractstream.h"
 
+struct AlertInfo {
+  cereal::ControlsState::AlertStatus status;
+  QString text1;
+  QString text2;
+};
+
 class ThumbnailLabel : public QWidget {
 public:
   ThumbnailLabel(QWidget *parent);
-  void showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm);
+  void showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm, const AlertInfo &alert);
   void paintEvent(QPaintEvent *event) override;
   QPixmap pixmap;
   QString second;
+  AlertInfo alert_info;
 };
 
 class Slider : public QSlider {
@@ -43,6 +50,7 @@ private:
   std::mutex thumbnail_lock;
   std::atomic<bool> abort_load_thumbnail = false;
   QMap<uint64_t, QPixmap> thumbnails;
+  std::map<uint64_t, AlertInfo> alerts;
   QFuture<void> thumnail_future;
   ThumbnailLabel thumbnail_label;
   QTimer timer;

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -19,10 +19,11 @@ struct AlertInfo {
   QString text2;
 };
 
-class ThumbnailLabel : public QWidget {
+class InfoLabel : public QWidget {
 public:
-  ThumbnailLabel(QWidget *parent);
+  InfoLabel(QWidget *parent);
   void showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm, const AlertInfo &alert);
+  void showAlert(const AlertInfo &alert);
   void paintEvent(QPaintEvent *event) override;
   QPixmap pixmap;
   QString second;
@@ -52,8 +53,9 @@ private:
   QMap<uint64_t, QPixmap> thumbnails;
   std::map<uint64_t, AlertInfo> alerts;
   QFuture<void> thumnail_future;
-  ThumbnailLabel thumbnail_label;
+  InfoLabel thumbnail_label;
   QTimer timer;
+  friend class VideoWidget;
 };
 
 class VideoWidget : public QFrame {
@@ -73,5 +75,6 @@ protected:
   QLabel *time_label;
   QHBoxLayout *slider_layout;
   QPushButton *play_btn;
+  InfoLabel *alert_label;
   Slider *slider;
 };


### PR DESCRIPTION
1. display alert info in thumbnail. (thanks to https://github.com/commaai/openpilot/pull/27809. the color blocks of alert events can be displayed correctly on the slider after it.)
![2023-04-08_05-39](https://user-images.githubusercontent.com/27770/230682422-a8da2e5a-c389-4dac-a61e-a0837b81eed7.png)
![2023-04-08_05-40](https://user-images.githubusercontent.com/27770/230682417-ea60bb2f-561b-4dd6-beef-b0eecb9a0282.png)
![2023-04-08_05-41](https://user-images.githubusercontent.com/27770/230682403-c91d578d-ad24-4aac-9c97-5f202ab414a5.png)
![2023-04-08_05-40_1](https://user-images.githubusercontent.com/27770/230682410-89f8ccd7-b667-41aa-8d6d-c86ff02e7a5b.png)

2. display alert info while playing video:

![Screenshot from 2023-04-08 21-34-54](https://user-images.githubusercontent.com/27770/230724060-7aa21e46-577e-4069-8d3d-4a97709bc830.png)
![Screenshot from 2023-04-08 20-58-09](https://user-images.githubusercontent.com/27770/230722480-cc71cff9-888e-4354-a6c8-80a92729ffab.png)
