### PR TITLE
cabana: support dragging chart between tabs

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -81,6 +81,8 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   QHBoxLayout *tab_layout = new QHBoxLayout();
   tab_layout->addWidget(tabbar = new QTabBar(this));
   tabbar->setAutoHide(true);
+  tabbar->setAcceptDrops(true);
+  tabbar->setChangeCurrentOnDrag(true);
   tabbar->setTabsClosable(true);
   tabbar->setUsesScrollButtons(true);
   tab_layout->addStretch(0);
@@ -1264,7 +1266,9 @@ void ChartsContainer::dropEvent(QDropEvent *event) {
     auto w = getDropBefore(event->pos());
     auto chart = qobject_cast<ChartView *>(event->source());
     if (w != chart) {
-      charts_widget->currentCharts().removeOne(chart);
+      for (auto &[_, list] : charts_widget->tab_charts) {
+        list.removeOne(chart);
+      }
       int to = w ? charts_widget->currentCharts().indexOf(w) : charts_widget->currentCharts().size();
       charts_widget->currentCharts().insert(to, chart);
       charts_widget->updateLayout(true);


### PR DESCRIPTION
video (drag `ACCEL_Z` from `tab 1` to `tab 2`, and insert it after `TURN_SIGNALS`):

[Kazam_screencast_00032.webm](https://user-images.githubusercontent.com/27770/230684423-36311125-022e-4ffd-a40f-9882f7ec3acb.webm)
