### PR TITLE
cabana: improve drag&drop

### DIFF
--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -97,7 +97,7 @@ private:
   void paintEvent(QPaintEvent *event) override;
   void drawForeground(QPainter *painter, const QRectF &rect) override;
   void drawBackground(QPainter *painter, const QRectF &rect) override;
-  void drawDropIndicator(bool draw) { can_drop = draw; viewport()->update(); }
+  void drawDropIndicator(bool draw) { if (std::exchange(can_drop, draw) != can_drop) viewport()->update(); }
   std::tuple<double, double, int> getNiceAxisNumbers(qreal min, qreal max, int tick_count);
   qreal niceNumber(qreal x, bool ceiling);
   QXYSeries *createSeries(SeriesType type, QColor color);
@@ -133,7 +133,7 @@ public:
   void dragLeaveEvent(QDragLeaveEvent *event) override { drawDropIndicator({}); }
   void drawDropIndicator(const QPoint &pt) { drop_indictor_pos = pt; update(); }
   void paintEvent(QPaintEvent *ev) override;
-  ChartView *getDropBefore(const QPoint &pos) const;
+  ChartView *getDropAfter(const QPoint &pos) const;
 
   QGridLayout *charts_layout;
   ChartsWidget *charts_widget;


### PR DESCRIPTION
1. smaller drag image with  drop shadow effect & beautiful insert(drop) indicator:

![2023-04-09_01-14](https://user-images.githubusercontent.com/27770/230734329-ca851b2c-74c3-4d6d-9dd4-d3d756e7411c.png)

before:
![2023-04-09_01-12](https://user-images.githubusercontent.com/27770/230734240-d9217b49-ea36-41b4-a3f7-2394589e5c6c.png)

2. add support to insert(drop) chart at the top&bottom:

[Kazam_screencast_00038.webm](https://user-images.githubusercontent.com/27770/230712414-d373ba52-6212-4e58-90ed-59d3b56e5059.webm)

3.add bottom line to tabbar:
![2023-04-08_17-40](https://user-images.githubusercontent.com/27770/230714605-a24041c1-00e3-42f3-9889-2be2c8dbb492.png)
4.easy to drag&drop with better hotspot.
5.fix flickers while resizing chart panel
