### PR TITLE
Replace numpy.linalg.solve with numpy.linalg.lstsq in vehicle model

### DIFF
--- a/selfdrive/controls/lib/vehicle_model.py
+++ b/selfdrive/controls/lib/vehicle_model.py
@@ -221,7 +221,7 @@ def dyn_ss_sol(sa: float, u: float, roll: float, VM: VehicleModel) -> np.ndarray
   """
   A, B = create_dyn_state_matrices(u, VM)
   inp = np.array([[sa], [roll]])
-  return -solve(A, B) @ inp  # type: ignore
+  return -np.linalg.lstsq(A, B, rcond=None)[0] @ inp
 
 
 def calc_slip_factor(VM: VehicleModel) -> float:


### PR DESCRIPTION
#Descriptions:

This PR replaces the numpy.linalg.solve function with the more efficient and numerically stable numpy.linalg.lstsq function in the dyn_ss_sol function. This change improves performance and stability, especially when dealing with ill-conditioned matrices.

#Changes:

Updated the dyn_ss_sol function in vehicle_model.py to use numpy.linalg.lstsq instead of numpy.linalg.solve.
Benefits:

#Improved efficiency: 

numpy.linalg.lstsq is faster than numpy.linalg.solve in many cases.

#Increased numerical stability: 

numpy.linalg.lstsq is better suited for handling ill-conditioned matrices, which can lead to more accurate and stable results.

#Testing:

Note that I do not have comma device to test on until next week