### PR TITLE
CAR.IONIQ_5 update for Ecu.fwdRadar values

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1621,6 +1621,7 @@ FW_VERSIONS = {
   CAR.IONIQ_5: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NE1_ RDR -----      1.00 1.00 99110-GI000         ',
+      b'\xf1\x8799110GI000\xf1\x00NE1_ RDR -----      1.00 1.00 99110-GI000         ',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NE1 MFC  AT USA LHD 1.00 1.02 99211-GI010 211206',


### PR DESCRIPTION
missing firmware version for car. Including in here. From dongle id 5608f42aaece1463. Confirmed working on fork installed to comma 3
