### PR TITLE
Hyundai Tucson 2023 fingerpint

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1637,6 +1637,7 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9210 14G',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9240 14T',
+      b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-CW010 14X',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NX4__               1.00 1.00 99110-N9100         ',


### PR DESCRIPTION
Fingerprint for Hyundai Tucson 2023 

fwdCamera fwVersion added for fingerprint

dongle_id - bf1a6b0ba293c37b
route - bf1a6b0ba293c37b|2023-04-08--23-17-48