### PR TITLE
cabana: switch theme on the fly

### DIFF
--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -37,8 +37,10 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   int icon_size = style()->pixelMetric(QStyle::PM_SmallIconSize);
   toolbar->setIconSize({icon_size, icon_size});
 
-  QAction *new_plot_btn = toolbar->addWidget(toolButton("file-plus", tr("New Chart")));
-  QAction *new_tab_btn = toolbar->addWidget(toolButton("window-stack", tr("New Tab")));
+  auto new_plot_btn = toolButton("file-plus", tr("New Chart"));
+  auto new_tab_btn = toolButton("window-stack", tr("New Tab"));
+  toolbar->addWidget(new_plot_btn);
+  toolbar->addWidget(new_tab_btn);
   toolbar->addWidget(title_label = new QLabel());
   title_label->setContentsMargins(0, 0, style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing), 0);
 
@@ -71,11 +73,10 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   redo_zoom_action = zoom_undo_stack->createRedoAction(this);
   redo_zoom_action->setIcon(utils::icon("arrow-clockwise"));
   toolbar->addAction(redo_zoom_action);
-  reset_zoom_action = toolbar->addWidget(toolButton("zoom-out", ""));
-  reset_zoom_action->setToolTip(tr("Reset zoom"));
-  qobject_cast<QToolButton*>(toolbar->widgetForAction(reset_zoom_action))->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+  reset_zoom_action = toolbar->addWidget(reset_zoom_btn = toolButton("zoom-out", tr("Reset Zoom")));
+  reset_zoom_btn->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
-  remove_all_btn = toolbar->addWidget(toolButton("x", tr("Remove all charts")));
+  remove_all_btn = toolbar->addAction(utils::icon("x"), tr("Remove all charts"));
   dock_btn = toolbar->addAction("");
   main_layout->addWidget(toolbar);
 
@@ -115,11 +116,11 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   QObject::connect(can, &AbstractStream::eventsMerged, this, &ChartsWidget::eventsMerged);
   QObject::connect(can, &AbstractStream::updated, this, &ChartsWidget::updateState);
   QObject::connect(range_slider, &QSlider::valueChanged, this, &ChartsWidget::setMaxChartRange);
-  QObject::connect(new_plot_btn, &QAction::triggered, this, &ChartsWidget::newChart);
+  QObject::connect(new_plot_btn, &QToolButton::clicked, this, &ChartsWidget::newChart);
   QObject::connect(remove_all_btn, &QAction::triggered, this, &ChartsWidget::removeAll);
-  QObject::connect(reset_zoom_action, &QAction::triggered, this, &ChartsWidget::zoomReset);
+  QObject::connect(reset_zoom_btn, &QToolButton::clicked, this, &ChartsWidget::zoomReset);
   QObject::connect(&settings, &Settings::changed, this, &ChartsWidget::settingChanged);
-  QObject::connect(new_tab_btn, &QAction::triggered, this, &ChartsWidget::newTab);
+  QObject::connect(new_tab_btn, &QToolButton::clicked, this, &ChartsWidget::newTab);
   QObject::connect(tabbar, &QTabBar::tabCloseRequested, this, &ChartsWidget::removeTab);
   QObject::connect(tabbar, &QTabBar::currentChanged, [this](int index) {
     if (index != -1) updateLayout(true);
@@ -229,7 +230,7 @@ void ChartsWidget::updateToolBar() {
   undo_zoom_action->setVisible(is_zoomed);
   redo_zoom_action->setVisible(is_zoomed);
   reset_zoom_action->setVisible(is_zoomed);
-  reset_zoom_action->setText(is_zoomed ? tr("%1-%2").arg(zoomed_range.first, 0, 'f', 1).arg(zoomed_range.second, 0, 'f', 1) : "");
+  reset_zoom_btn->setText(is_zoomed ? tr("%1-%2").arg(zoomed_range.first, 0, 'f', 1).arg(zoomed_range.second, 0, 'f', 1) : "");
   remove_all_btn->setEnabled(!charts.isEmpty());
   dock_btn->setIcon(utils::icon(docking ? "arrow-up-right-square" : "arrow-down-left-square"));
   dock_btn->setToolTip(docking ? tr("Undock charts") : tr("Dock charts"));

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -512,6 +512,7 @@ void ChartView::createToolButtons() {
   QToolButton *manage_btn = new ToolButton("list", "");
   manage_btn->setMenu(menu);
   manage_btn->setPopupMode(QToolButton::InstantPopup);
+  manage_btn->setStyleSheet("QToolButton::menu-indicator { image: none; }");
   manage_btn_proxy = new QGraphicsProxyWidget(chart());
   manage_btn_proxy->setWidget(manage_btn);
   manage_btn_proxy->setZValue(chart()->zValue() + 11);

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -37,8 +37,8 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   int icon_size = style()->pixelMetric(QStyle::PM_SmallIconSize);
   toolbar->setIconSize({icon_size, icon_size});
 
-  auto new_plot_btn = toolButton("file-plus", tr("New Chart"));
-  auto new_tab_btn = toolButton("window-stack", tr("New Tab"));
+  auto new_plot_btn = new ToolButton("file-plus", tr("New Chart"));
+  auto new_tab_btn = new ToolButton("window-stack", tr("New Tab"));
   toolbar->addWidget(new_plot_btn);
   toolbar->addWidget(new_tab_btn);
   toolbar->addWidget(title_label = new QLabel());
@@ -73,7 +73,7 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   redo_zoom_action = zoom_undo_stack->createRedoAction(this);
   redo_zoom_action->setIcon(utils::icon("arrow-clockwise"));
   toolbar->addAction(redo_zoom_action);
-  reset_zoom_action = toolbar->addWidget(reset_zoom_btn = toolButton("zoom-out", tr("Reset Zoom")));
+  reset_zoom_action = toolbar->addWidget(reset_zoom_btn = new ToolButton("zoom-out", tr("Reset Zoom")));
   reset_zoom_btn->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
   remove_all_btn = toolbar->addAction(utils::icon("x"), tr("Remove all charts"));
@@ -492,7 +492,7 @@ void ChartView::createToolButtons() {
   move_icon = new QGraphicsPixmapItem(utils::icon("grip-horizontal"), chart());
   move_icon->setToolTip(tr("Drag and drop to move chart"));
 
-  QToolButton *remove_btn = toolButton("x", tr("Remove Chart"));
+  QToolButton *remove_btn = new ToolButton("x", tr("Remove Chart"));
   close_btn_proxy = new QGraphicsProxyWidget(chart());
   close_btn_proxy->setWidget(remove_btn);
   close_btn_proxy->setZValue(chart()->zValue() + 11);
@@ -512,7 +512,7 @@ void ChartView::createToolButtons() {
   menu->addSeparator();
   menu->addAction(tr("Manage series"), this, &ChartView::manageSeries);
 
-  QToolButton *manage_btn = toolButton("list", "");
+  QToolButton *manage_btn = new ToolButton("list", "");
   manage_btn->setMenu(menu);
   manage_btn->setPopupMode(QToolButton::InstantPopup);
   manage_btn_proxy = new QGraphicsProxyWidget(chart());

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -240,7 +240,7 @@ void ChartsWidget::settingChanged() {
   if (std::exchange(current_theme, settings.theme) != current_theme) {
     undo_zoom_action->setIcon(utils::icon("arrow-counterclockwise"));
     redo_zoom_action->setIcon(utils::icon("arrow-clockwise"));
-    auto theme = settings.theme == 2 ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight;
+    auto theme = settings.theme == DARK_THEME ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight;
     for (auto c : charts) {
       c->setTheme(theme);
     }
@@ -477,7 +477,7 @@ ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *par
   // TODO: enable zoomIn/seekTo in live streaming mode.
   setRubberBand(can->liveStreaming() ? QChartView::NoRubberBand : QChartView::HorizontalRubberBand);
   setMouseTracking(true);
-  setTheme(settings.theme == 2 ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight);
+  setTheme(settings.theme == DARK_THEME ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight);
 
   QObject::connect(axis_y, &QValueAxis::rangeChanged, [this]() { resetChartCache(); });
   QObject::connect(axis_y, &QAbstractAxis::titleTextChanged, [this]() { resetChartCache(); });
@@ -1271,7 +1271,7 @@ ValueTipLabel::ValueTipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt:
   setForegroundRole(QPalette::ToolTipText);
   setBackgroundRole(QPalette::ToolTipBase);
   auto palette = QToolTip::palette();
-  if (settings.theme != 2) {
+  if (settings.theme != DARK_THEME) {
     palette.setColor(QPalette::ToolTipBase, QApplication::palette().color(QPalette::Base));
     palette.setColor(QPalette::ToolTipText, QRgb(0x404044)); // same color as chart label brush
   }

--- a/tools/cabana/chartswidget.cc
+++ b/tools/cabana/chartswidget.cc
@@ -1270,7 +1270,12 @@ QList<SeriesSelector::ListItem *> SeriesSelector::seletedItems() {
 ValueTipLabel::ValueTipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::FramelessWindowHint) {
   setForegroundRole(QPalette::ToolTipText);
   setBackgroundRole(QPalette::ToolTipBase);
-  setPalette(QToolTip::palette());
+  auto palette = QToolTip::palette();
+  if (settings.theme != 2) {
+    palette.setColor(QPalette::ToolTipBase, QApplication::palette().color(QPalette::Base));
+    palette.setColor(QPalette::ToolTipText, QRgb(0x404044)); // same color as chart label brush
+  }
+  setPalette(palette);
   ensurePolished();
   setMargin(1 + style()->pixelMetric(QStyle::PM_ToolTipLabelFrameWidth, nullptr, this));
   setAttribute(Qt::WA_ShowWithoutActivating);

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -190,15 +190,15 @@ private:
   QAction *range_lb_action;
   QAction *range_slider_action;
   bool docking = true;
-  QAction *dock_btn;
+  ToolButton *dock_btn;
 
   QAction *undo_zoom_action;
   QAction *redo_zoom_action;
   QAction *reset_zoom_action;
-  QToolButton *reset_zoom_btn;
+  ToolButton *reset_zoom_btn;
   QUndoStack *zoom_undo_stack;
 
-  QAction *remove_all_btn;
+  ToolButton *remove_all_btn;
   QList<ChartView *> charts;
   std::unordered_map<int, QList<ChartView *>> tab_charts;
   QTabBar *tabbar;

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -195,6 +195,7 @@ private:
   QAction *undo_zoom_action;
   QAction *redo_zoom_action;
   QAction *reset_zoom_action;
+  QToolButton *reset_zoom_btn;
   QUndoStack *zoom_undo_stack;
 
   QAction *remove_all_btn;

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -94,6 +94,7 @@ private:
   void updateAxisY();
   void updateTitle();
   void resetChartCache();
+  void setTheme(QChart::ChartTheme theme);
   void paintEvent(QPaintEvent *event) override;
   void drawForeground(QPainter *painter, const QRectF &rect) override;
   void drawBackground(QPainter *painter, const QRectF &rect) override;

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -63,8 +63,6 @@ public:
   };
 
 signals:
-  void seriesRemoved(const MessageId &id, const cabana::Signal *sig);
-  void seriesAdded(const MessageId &id, const cabana::Signal *sig);
   void zoomIn(double min, double max);
   void zoomUndo();
   void remove();

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -212,6 +212,7 @@ private:
   int auto_scroll_count = 0;
   QTimer auto_scroll_timer;
   QTimer align_timer;
+  int current_theme = 0;
   friend class ZoomCommand;
   friend class ChartView;
   friend class ChartsContainer;

--- a/tools/cabana/chartswidget.h
+++ b/tools/cabana/chartswidget.h
@@ -63,11 +63,7 @@ public:
   };
 
 signals:
-  void zoomIn(double min, double max);
-  void zoomUndo();
-  void remove();
   void axisYLabelWidthChanged(int w);
-  void hovered(double sec);
 
 private slots:
   void signalUpdated(const cabana::Signal *sig);
@@ -166,7 +162,6 @@ private:
   void removeChart(ChartView *chart);
   void eventsMerged();
   void updateState();
-  void zoomIn(double min, double max);
   void zoomReset();
   void startAutoScroll();
   void stopAutoScroll();

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -32,9 +32,9 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   name_label->setAlignment(Qt::AlignCenter);
   name_label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
   title_layout->addWidget(name_label);
-  auto edit_btn = toolButton("pencil", tr("Edit Message"));
+  auto edit_btn = new ToolButton("pencil", tr("Edit Message"));
   title_layout->addWidget(edit_btn);
-  remove_btn = toolButton("x-lg", tr("Remove Message"));
+  remove_btn = new ToolButton("x-lg", tr("Remove Message"));
   title_layout->addWidget(remove_btn);
   main_layout->addLayout(title_layout);
 

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -22,7 +22,7 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
 
   // message title
   QHBoxLayout *title_layout = new QHBoxLayout();
-  title_layout->setContentsMargins(0, 6, 0, 0);
+  title_layout->setContentsMargins(3, 6, 3, 0);
   time_label = new QLabel(this);
   time_label->setToolTip(tr("Current time"));
   time_label->setStyleSheet("QLabel{font-weight:bold;}");

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -186,6 +186,7 @@ void HeaderView::paintSection(QPainter *painter, const QRect &rect, int logicalI
     painter->fillRect(rect, bg_role.value<QBrush>());
   }
   QString text = model()->headerData(logicalIndex, Qt::Horizontal, Qt::DisplayRole).toString();
+  painter->setPen(palette().color(settings.theme == 2 ? QPalette::BrightText : QPalette::Text));
   painter->drawText(rect.adjusted(5, 3, -5, -3), defaultAlignment(), text.replace(QChar('_'), ' '));
 }
 

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -186,7 +186,7 @@ void HeaderView::paintSection(QPainter *painter, const QRect &rect, int logicalI
     painter->fillRect(rect, bg_role.value<QBrush>());
   }
   QString text = model()->headerData(logicalIndex, Qt::Horizontal, Qt::DisplayRole).toString();
-  painter->setPen(palette().color(settings.theme == 2 ? QPalette::BrightText : QPalette::Text));
+  painter->setPen(palette().color(settings.theme == DARK_THEME ? QPalette::BrightText : QPalette::Text));
   painter->drawText(rect.adjusted(5, 3, -5, -3), defaultAlignment(), text.replace(QChar('_'), ' '));
 }
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -541,7 +541,6 @@ void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool succe
 
 void MainWindow::updateStatus() {
   status_label->setText(tr("Cached Minutes:%1 FPS:%2").arg(settings.max_cached_minutes).arg(settings.fps));
-  utils::setTheme(settings.theme);
 }
 
 void MainWindow::dockCharts(bool dock) {

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -1,5 +1,6 @@
 #include "tools/cabana/settings.h"
 
+#include <QAbstractButton>
 #include <QDialogButtonBox>
 #include <QDir>
 #include <QFormLayout>
@@ -85,12 +86,21 @@ SettingsDlg::SettingsDlg(QWidget *parent) : QDialog(parent) {
   chart_height->setValue(settings.chart_height);
   form_layout->addRow(tr("Chart Height"), chart_height);
 
-  auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+  auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Apply);
   form_layout->addRow(buttonBox);
 
   setFixedWidth(360);
-  connect(buttonBox, &QDialogButtonBox::accepted, this, &SettingsDlg::save);
-  connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(buttonBox, &QDialogButtonBox::clicked, [=](QAbstractButton *button) {
+    auto role = buttonBox->buttonRole(button);
+    if (role == QDialogButtonBox::AcceptRole) {
+      save();
+      accept();
+    } else if (role == QDialogButtonBox::ApplyRole) {
+      save();
+    } else if (role == QDialogButtonBox::RejectRole) {
+      reject();
+    }
+  });
 }
 
 void SettingsDlg::save() {
@@ -100,6 +110,5 @@ void SettingsDlg::save() {
   settings.chart_series_type = chart_series_type->currentIndex();
   settings.chart_height = chart_height->value();
   settings.save();
-  accept();
   emit settings.changed();
 }

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -6,7 +6,8 @@
 #include <QFormLayout>
 #include <QSettings>
 
-// Settings
+#include "tools/cabana/util.h"
+
 Settings settings;
 
 Settings::Settings() {
@@ -105,7 +106,10 @@ SettingsDlg::SettingsDlg(QWidget *parent) : QDialog(parent) {
 
 void SettingsDlg::save() {
   settings.fps = fps->value();
-  settings.theme = theme->currentIndex();
+  if (std::exchange(settings.theme, theme->currentIndex()) != settings.theme) {
+    // set theme before emit changed
+    utils::setTheme(settings.theme);
+  }
   settings.max_cached_minutes = cached_minutes->value();
   settings.chart_series_type = chart_series_type->currentIndex();
   settings.chart_height = chart_height->value();

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -7,6 +7,7 @@
 
 #define LIGHT_THEME 1
 #define DARK_THEME 2
+
 class Settings : public QObject {
   Q_OBJECT
 

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -5,6 +5,8 @@
 #include <QDialog>
 #include <QSpinBox>
 
+#define LIGHT_THEME 1
+#define DARK_THEME 2
 class Settings : public QObject {
   Q_OBJECT
 

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -525,7 +525,7 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   sparkline_range_slider->setValue(settings.sparkline_range);
   sparkline_range_slider->setToolTip(tr("Sparkline time range"));
 
-  auto collapse_btn = toolButton("dash-square", tr("Collapse All"));
+  auto collapse_btn = new ToolButton("dash-square", tr("Collapse All"));
   collapse_btn->setIconSize({12, 12});
   hl->addWidget(collapse_btn);
 
@@ -582,8 +582,8 @@ void SignalView::rowsChanged() {
       h->setContentsMargins(0, v_margin, -h_margin, v_margin);
       h->setSpacing(style()->pixelMetric(QStyle::PM_ToolBarItemSpacing));
 
-      auto remove_btn = toolButton("x", tr("Remove signal"));
-      auto plot_btn = toolButton("graph-up", "");
+      auto remove_btn = new ToolButton("x", tr("Remove signal"));
+      auto plot_btn = new ToolButton("graph-up", "");
       plot_btn->setCheckable(true);
       h->addWidget(plot_btn);
       h->addWidget(remove_btn);

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -14,6 +14,7 @@ static QColor blend(QColor a, QColor b) {
 }
 
 void ChangeTracker::compute(const QByteArray &dat, double ts, uint32_t freq) {
+  // TODO: light color on dark theme
   if (prev_dat.size() != dat.size()) {
     colors.resize(dat.size());
     last_change_t.resize(dat.size());

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -201,15 +201,6 @@ void setTheme(int theme) {
 
 }  // namespace utils
 
-QToolButton *toolButton(const QString &icon, const QString &tooltip) {
-  auto btn = new ThemeAwareToolButton(icon);
-  btn->setToolTip(tooltip);
-  btn->setAutoRaise(true);
-  const int metric = qApp->style()->pixelMetric(QStyle::PM_SmallIconSize);
-  btn->setIconSize({metric, metric});
-  return btn;
-};
-
 QString toHex(uint8_t byte) {
   static std::array<QString, 256> hex = []() {
     std::array<QString, 256> ret;

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -168,31 +168,33 @@ void setTheme(int theme) {
   static int prev_theme = 0;
   if (theme != prev_theme) {
     prev_theme = theme;
+    QPalette new_palette;
     if (theme == 2) {
-      QPalette darkPalette;
       // "Darcula" like dark theme
-      darkPalette.setColor(QPalette::Window, QColor("#353535"));
-      darkPalette.setColor(QPalette::WindowText, QColor("#bbbbbb"));
-      darkPalette.setColor(QPalette::Base, QColor("#3c3f41"));
-      darkPalette.setColor(QPalette::AlternateBase, QColor("#3c3f41"));
-      darkPalette.setColor(QPalette::ToolTipBase, QColor("#3c3f41"));
-      darkPalette.setColor(QPalette::ToolTipText, QColor("#bbb"));
-      darkPalette.setColor(QPalette::Text, QColor("#bbbbbb"));
-      darkPalette.setColor(QPalette::Button, QColor("#3c3f41"));
-      darkPalette.setColor(QPalette::ButtonText, QColor("#bbbbbb"));
-      darkPalette.setColor(QPalette::Highlight, QColor("#2f65ca"));
-      darkPalette.setColor(QPalette::HighlightedText, QColor("#bbbbbb"));
-      darkPalette.setColor(QPalette::BrightText, QColor("#f0f0f0"));
-      darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor("#777777"));
-      darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, QColor("#777777"));
-      darkPalette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));;
-      qApp->setPalette(darkPalette);
+      new_palette.setColor(QPalette::Window, QColor("#353535"));
+      new_palette.setColor(QPalette::WindowText, QColor("#bbbbbb"));
+      new_palette.setColor(QPalette::Base, QColor("#3c3f41"));
+      new_palette.setColor(QPalette::AlternateBase, QColor("#3c3f41"));
+      new_palette.setColor(QPalette::ToolTipBase, QColor("#3c3f41"));
+      new_palette.setColor(QPalette::ToolTipText, QColor("#bbb"));
+      new_palette.setColor(QPalette::Text, QColor("#bbbbbb"));
+      new_palette.setColor(QPalette::Button, QColor("#3c3f41"));
+      new_palette.setColor(QPalette::ButtonText, QColor("#bbbbbb"));
+      new_palette.setColor(QPalette::Highlight, QColor("#2f65ca"));
+      new_palette.setColor(QPalette::HighlightedText, QColor("#bbbbbb"));
+      new_palette.setColor(QPalette::BrightText, QColor("#f0f0f0"));
+      new_palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor("#777777"));
+      new_palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor("#777777"));
+      new_palette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));;
+      new_palette.setColor(QPalette::Light, QColor("#3c3f41"));
+      new_palette.setColor(QPalette::Dark, QColor("#353535"));
     } else {
-      qApp->setPalette(style->standardPalette());
+      new_palette = style->standardPalette();
     }
+    qApp->setPalette(new_palette);
     style->polish(qApp);
     for (auto w : QApplication::allWidgets()) {
-      w->setPalette(qApp->palette());
+      w->setPalette(new_palette);
     }
   }
 }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -153,7 +153,7 @@ QPixmap icon(const QString &id) {
     if (dark_theme) {
       QPainter p(&pm);
       p.setCompositionMode(QPainter::CompositionMode_SourceIn);
-      p.fillRect(pm.rect(), Qt::white);
+      p.fillRect(pm.rect(), QColor(187, 187, 187));
     }
     QPixmapCache::insert(key, pm);
   }
@@ -171,14 +171,14 @@ void setTheme(int theme) {
       // modify palette to dark
       QPalette darkPalette;
       darkPalette.setColor(QPalette::Window, QColor(53, 53, 53));
-      darkPalette.setColor(QPalette::WindowText, Qt::white);
+      darkPalette.setColor(QPalette::WindowText, QColor(187, 187, 187));
       darkPalette.setColor(QPalette::Base, QColor(25, 25, 25));
       darkPalette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
-      darkPalette.setColor(QPalette::ToolTipBase, Qt::white);
+      darkPalette.setColor(QPalette::ToolTipBase, QColor(187, 187, 187));
       darkPalette.setColor(QPalette::ToolTipText, QColor(41, 41, 41));
-      darkPalette.setColor(QPalette::Text, Qt::white);
+      darkPalette.setColor(QPalette::Text, QColor(187, 187, 187));
       darkPalette.setColor(QPalette::Button, QColor(53, 53, 53));
-      darkPalette.setColor(QPalette::ButtonText, Qt::white);
+      darkPalette.setColor(QPalette::ButtonText, QColor(187, 187, 187));
       darkPalette.setColor(QPalette::BrightText, Qt::red);
       darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
       darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -153,7 +153,7 @@ QPixmap icon(const QString &id) {
     if (dark_theme) {
       QPainter p(&pm);
       p.setCompositionMode(QPainter::CompositionMode_SourceIn);
-      p.fillRect(pm.rect(), QColor(187, 187, 187));
+      p.fillRect(pm.rect(), QColor("#bbbbbb"));
     }
     QPixmapCache::insert(key, pm);
   }
@@ -168,25 +168,23 @@ void setTheme(int theme) {
   if (theme != prev_theme) {
     prev_theme = theme;
     if (theme == 2) {
-      // modify palette to dark
       QPalette darkPalette;
-      darkPalette.setColor(QPalette::Window, QColor(53, 53, 53));
-      darkPalette.setColor(QPalette::WindowText, QColor(187, 187, 187));
-      darkPalette.setColor(QPalette::Base, QColor(25, 25, 25));
-      darkPalette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
-      darkPalette.setColor(QPalette::ToolTipBase, QColor(187, 187, 187));
-      darkPalette.setColor(QPalette::ToolTipText, QColor(41, 41, 41));
-      darkPalette.setColor(QPalette::Text, QColor(187, 187, 187));
-      darkPalette.setColor(QPalette::Button, QColor(53, 53, 53));
-      darkPalette.setColor(QPalette::ButtonText, QColor(187, 187, 187));
-      darkPalette.setColor(QPalette::BrightText, Qt::red);
-      darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
-      darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
-      darkPalette.setColor(QPalette::HighlightedText, Qt::black);
-      darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::darkGray);
-      darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, Qt::darkGray);
-      darkPalette.setColor(QPalette::Disabled, QPalette::Text, Qt::darkGray);
-      darkPalette.setColor(QPalette::Disabled, QPalette::Light, QColor(53, 53, 53));
+      // "Darcula" like dark theme
+      darkPalette.setColor(QPalette::Window, QColor("#353535"));
+      darkPalette.setColor(QPalette::WindowText, QColor("#bbbbbb"));
+      darkPalette.setColor(QPalette::Base, QColor("#3c3f41"));
+      darkPalette.setColor(QPalette::AlternateBase, QColor("#3c3f41"));
+      darkPalette.setColor(QPalette::ToolTipBase, QColor("#3c3f41"));
+      darkPalette.setColor(QPalette::ToolTipText, QColor("#bbb"));
+      darkPalette.setColor(QPalette::Text, QColor("#bbbbbb"));
+      darkPalette.setColor(QPalette::Button, QColor("#3c3f41"));
+      darkPalette.setColor(QPalette::ButtonText, QColor("#bbbbbb"));
+      darkPalette.setColor(QPalette::Highlight, QColor("#2f65ca"));
+      darkPalette.setColor(QPalette::HighlightedText, QColor("#bbbbbb"));
+      darkPalette.setColor(QPalette::BrightText, QColor("#f0f0f0"));
+      darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor("#777777"));
+      darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, QColor("#777777"));
+      darkPalette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));;
       qApp->setPalette(darkPalette);
     } else {
       qApp->setPalette(style->standardPalette());

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -21,7 +21,7 @@ void ChangeTracker::compute(const QByteArray &dat, double ts, uint32_t freq) {
     std::fill(colors.begin(), colors.end(), QColor(0, 0, 0, 0));
     std::fill(last_change_t.begin(), last_change_t.end(), ts);
   } else {
-    int factor = settings.theme == 2 ? 135 : 0;
+    int factor = settings.theme == DARK_THEME ? 135 : 0;
     QColor cyan = QColor(0, 187, 255, start_alpha).lighter(factor);
     QColor red = QColor(255, 0, 0, start_alpha).lighter(factor);
     QColor greyish_blue = QColor(102, 86, 169, start_alpha / 2).lighter(factor);
@@ -146,7 +146,7 @@ QValidator::State NameValidator::validate(QString &input, int &pos) const {
 
 namespace utils {
 QPixmap icon(const QString &id) {
-  bool dark_theme = settings.theme == 2;
+  bool dark_theme = settings.theme == DARK_THEME;
   QPixmap pm;
   QString key = "bootstrap_" % id % (dark_theme ? "1" : "0");
   if (!QPixmapCache::find(key, &pm)) {
@@ -169,7 +169,7 @@ void setTheme(int theme) {
   if (theme != prev_theme) {
     prev_theme = theme;
     QPalette new_palette;
-    if (theme == 2) {
+    if (theme == DARK_THEME) {
       // "Darcula" like dark theme
       new_palette.setColor(QPalette::Window, QColor("#353535"));
       new_palette.setColor(QPalette::WindowText, QColor("#bbbbbb"));

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -8,7 +8,6 @@
 #include <limits>
 
 #include "selfdrive/ui/qt/util.h"
-#include "tools/cabana/settings.h"
 
 static QColor blend(QColor a, QColor b) {
   return QColor((a.red() + b.red()) / 2, (a.green() + b.green()) / 2, (a.blue() + b.blue()) / 2, (a.alpha() + b.alpha()) / 2);
@@ -184,19 +183,25 @@ void setTheme(int theme) {
       darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
       darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
       darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+      darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::darkGray);
+      darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, Qt::darkGray);
+      darkPalette.setColor(QPalette::Disabled, QPalette::Text, Qt::darkGray);
+      darkPalette.setColor(QPalette::Disabled, QPalette::Light, QColor(53, 53, 53));
       qApp->setPalette(darkPalette);
     } else {
       qApp->setPalette(style->standardPalette());
     }
     style->polish(qApp);
+    for (auto w : QApplication::allWidgets()) {
+      w->setPalette(qApp->palette());
+    }
   }
 }
 
 }  // namespace utils
 
 QToolButton *toolButton(const QString &icon, const QString &tooltip) {
-  auto btn = new QToolButton();
-  btn->setIcon(utils::icon(icon));
+  auto btn = new ThemeAwareToolButton(icon);
   btn->setToolTip(tooltip);
   btn->setAutoRaise(true);
   const int metric = qApp->style()->pixelMetric(QStyle::PM_SmallIconSize);

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cmath>
 
+#include <QApplication>
 #include <QByteArray>
 #include <QDateTime>
 #include <QColor>
@@ -105,12 +106,16 @@ inline QString formatSeconds(int seconds) {
 }
 }
 
-class ThemeAwareToolButton : public QToolButton {
+class ToolButton : public QToolButton {
   Q_OBJECT
 public:
-  ThemeAwareToolButton(const QString &icon, QWidget *parent = nullptr) : QToolButton(parent) {
+  ToolButton(const QString &icon, const QString &tooltip = {}, QWidget *parent = nullptr) : QToolButton(parent) {
     setIcon(icon);
-    connect(&settings, &Settings::changed, this, &ThemeAwareToolButton::updateIcon);
+    setToolTip(tooltip);
+    setAutoRaise(true);
+    const int metric = QApplication::style()->pixelMetric(QStyle::PM_SmallIconSize);
+    setIconSize({metric, metric});
+    connect(&settings, &Settings::changed, this, &ToolButton::updateIcon);
   }
   void setIcon(const QString &icon) {
     icon_str = icon;
@@ -122,5 +127,4 @@ private:
   QString icon_str;
 };
 
-QToolButton *toolButton(const QString &icon, const QString &tooltip);
 int num_decimals(double num);

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -115,6 +115,7 @@ public:
     setAutoRaise(true);
     const int metric = QApplication::style()->pixelMetric(QStyle::PM_SmallIconSize);
     setIconSize({metric, metric});
+    theme = settings.theme;
     connect(&settings, &Settings::changed, this, &ToolButton::updateIcon);
   }
   void setIcon(const QString &icon) {
@@ -123,8 +124,9 @@ public:
   }
 
 private:
-  void updateIcon() { setIcon(icon_str); }
+  void updateIcon() { if (std::exchange(theme, settings.theme) != theme) setIcon(icon_str); }
   QString icon_str;
+  int theme;
 };
 
 int num_decimals(double num);

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -14,6 +14,7 @@
 #include <QVector>
 
 #include "tools/cabana/dbc/dbc.h"
+#include "tools/cabana/settings.h"
 
 class ChangeTracker {
 public:
@@ -103,6 +104,23 @@ inline QString formatSeconds(int seconds) {
   return QDateTime::fromTime_t(seconds).toString(seconds > 60 * 60 ? "hh:mm:ss" : "mm:ss");
 }
 }
+
+class ThemeAwareToolButton : public QToolButton {
+  Q_OBJECT
+public:
+  ThemeAwareToolButton(const QString &icon, QWidget *parent = nullptr) : QToolButton(parent) {
+    setIcon(icon);
+    connect(&settings, &Settings::changed, this, &ThemeAwareToolButton::updateIcon);
+  }
+  void setIcon(const QString &icon) {
+    icon_str = icon;
+    QToolButton::setIcon(utils::icon(icon_str));
+  }
+
+private:
+  void updateIcon() { setIcon(icon_str); }
+  QString icon_str;
+};
 
 QToolButton *toolButton(const QString &icon, const QString &tooltip);
 int num_decimals(double num);

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -304,7 +304,7 @@ void InfoLabel::showAlert(const AlertInfo &alert) {
 
 void InfoLabel::paintEvent(QPaintEvent *event) {
   QPainter p(this);
-  p.setPen(QPen(Qt::white, 2));
+  p.setPen(QPen(palette().color(QPalette::BrightText), 2));
   if (!pixmap.isNull()) {
     p.drawPixmap(0, 0, pixmap);
     p.drawRect(rect());

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -63,6 +63,7 @@ VideoWidget::VideoWidget(QWidget *parent) : QFrame(parent) {
   QObject::connect(play_btn, &QPushButton::clicked, []() { can->pause(!can->isPaused()); });
   QObject::connect(can, &AbstractStream::paused, this, &VideoWidget::updatePlayBtnState);
   QObject::connect(can, &AbstractStream::resume, this, &VideoWidget::updatePlayBtnState);
+  QObject::connect(&settings, &Settings::changed, this, &VideoWidget::updatePlayBtnState);
   updatePlayBtnState();
 
   setWhatsThis(tr(R"(

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -323,9 +323,11 @@ void InfoLabel::paintEvent(QPaintEvent *event) {
       text += "\n" + alert_info.text2;
     }
 
-    QFont font;
-    font.setPixelSize(!pixmap.isNull() ? 11 : QFont().pixelSize());
-    p.setFont(font);
+    if (!pixmap.isNull()) {
+      QFont font;
+      font.setPixelSize(11);
+      p.setFont(font);
+    }
     QRect text_rect = rect().adjusted(2, 2, -2, -2);
     QRect r = p.fontMetrics().boundingRect(text_rect, Qt::AlignTop | Qt::AlignHCenter | Qt::TextWordWrap, text);
     p.fillRect(text_rect.left(), r.top(), text_rect.width(), r.height(), color);


### PR DESCRIPTION
1. add `Apply` button to settings dialog:
![2023-04-09_18-33](https://user-images.githubusercontent.com/27770/230767798-5bbdf506-c76a-493b-baea-abe00fbdc452.png)
2. new Darcula like dark theme:
![2023-04-10_01-52](https://user-images.githubusercontent.com/27770/230788609-024fe645-f8bc-4203-925c-cb3dee78bbca.png)
3. lighter byte activity colors in dark theme:

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-04-10 03-17-48](https://user-images.githubusercontent.com/27770/230792299-99563dc0-b176-4424-92ef-e6f7849334cb.png) | ![Screenshot from 2023-04-10 03-02-13](https://user-images.githubusercontent.com/27770/230792301-8ee19e02-61ce-4086-a60b-c8ebd159f4f4.png)  |

4. modify the QtChart::DarkTheme to make it consistent with our light/dark theme.
5. switch theme on the fly (the dark theme in this video is old, it's not the new Darcula like theme):

[Kazam_screencast_00042.webm](https://user-images.githubusercontent.com/27770/230768816-8158cb5a-3468-4f8c-af0a-9258b266d201.webm)

