### PR TITLE
cabana: Hack for WSL2 QDockWidget floating bug

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -1,4 +1,13 @@
 import os
+
+def is_running_on_wsl():
+  try:
+    with open('/proc/version', 'r') as f:
+      contents = f.read()
+    return 'WSL2' in contents
+  except FileNotFoundError:
+    return False
+
 Import('env', 'qt_env', 'arch', 'common', 'messaging', 'visionipc', 'replay_lib',
        'cereal', 'transformations', 'widgets')
 
@@ -20,6 +29,8 @@ cabana_env["LIBPATH"] += ['../../opendbc/can']
 cabana_libs = [widgets, cereal, messaging, visionipc, replay_lib, 'libdbc_static', 'avutil', 'avcodec', 'avformat', 'bz2', 'curl', 'yuv'] + qt_libs
 opendbc_path = '-DOPENDBC_FILE_PATH=\'"%s"\'' % (cabana_env.Dir("../../opendbc").abspath)
 cabana_env['CXXFLAGS'] += [opendbc_path]
+if is_running_on_wsl():
+  cabana_env.Append(CXXFLAGS=['-DWSL2'])
 
 # build assets
 assets = "assets/assets.cc"

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -193,6 +193,27 @@ void MainWindow::createDockWindows() {
   video_dock->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
   video_dock->setWidget(video_splitter);
   addDockWidget(Qt::RightDockWidgetArea, video_dock);
+
+#ifdef WSL2
+  dock->setFeatures(QDockWidget::DockWidgetMovable);
+  video_dock->setFeatures(QDockWidget::DockWidgetMovable);
+  QObject::connect(dock, &QDockWidget::topLevelChanged, this, &MainWindow::onDockWidgetTopLevelChanged);
+  QObject::connect(video_dock, &QDockWidget::topLevelChanged, this, &MainWindow::onDockWidgetTopLevelChanged);
+#endif
+}
+
+// This is a workaround for a bug in WSL2
+void MainWindow::onDockWidgetTopLevelChanged(bool topLevel) {
+  QDockWidget *dockWidget = qobject_cast<QDockWidget *>(sender());
+  if (dockWidget) {
+    if (topLevel) {
+      // the floating button breaks mouse tracking when docked so I remove it when docked and add it back when floating
+      dockWidget->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable); 
+      dockWidget->setTitleBarWidget(nullptr); // this fixes the mouse tracking issue when floating
+    } else {
+      dockWidget->setFeatures(QDockWidget::DockWidgetMovable);
+    }
+  }
 }
 
 void MainWindow::createStatusBar() {

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -64,6 +64,7 @@ protected:
   void toggleFullScreen();
   void updateStatus();
   void updateLoadSaveMenus();
+  void onDockWidgetTopLevelChanged(bool topLevel);
 
   VideoWidget *video_widget = nullptr;
   QDockWidget *video_dock;


### PR DESCRIPTION
This is a bug fix/workaround for an undocumented QT bug when using QDockWidget where floating widgets do not respond to mouse QEvents. 

https://github.com/commaai/openpilot/discussions/26091#discussioncomment-5563395

Note that this will remove the undock button but still allows the user to drag the QDockWidget title bar to undock. Once the widget is floating the dock button is shown. This is done because pressing the floatButton will lead to the behavior of the widget not responding to any QEvents.