### PR TITLE
test_car_model: allow route or segment name

### DIFF
--- a/selfdrive/debug/test_car_model.py
+++ b/selfdrive/debug/test_car_model.py
@@ -22,7 +22,7 @@ def create_test_models_suite(routes: List[Tuple[str, CarTestRoute]], ci=False) -
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Test any route against common issues with a new car port. " +
                                                "Uses selfdrive/car/tests/test_models.py")
-  parser.add_argument("route_or_segment_name", help="Specify route to run tests on")
+  parser.add_argument("route", help="Specify route to run tests on")
   parser.add_argument("--car", help="Specify car model for test route")
   parser.add_argument("--ci", action="store_true", help="Attempt to get logs using openpilotci, need to specify car")
   args = parser.parse_args()
@@ -30,9 +30,9 @@ if __name__ == "__main__":
     parser.print_help()
     sys.exit()
 
-  route_or_segment_name = SegmentName(args.route_or_segment_name.strip(), allow_route_name=True)
+  route_or_segment_name = SegmentName(args.route.strip(), allow_route_name=True)
   segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
-  test_route = CarTestRoute(route_or_segment_name.route_name, args.car, segment=segment_num)
+  test_route = CarTestRoute(route_or_segment_name.route_name.canonical_name, args.car, segment=segment_num)
   test_suite = create_test_models_suite([(args.car, test_route)], ci=args.ci)
 
   unittest.TextTestRunner().run(test_suite)

--- a/selfdrive/debug/test_car_model.py
+++ b/selfdrive/debug/test_car_model.py
@@ -22,7 +22,7 @@ def create_test_models_suite(routes: List[Tuple[str, CarTestRoute]], ci=False) -
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Test any route against common issues with a new car port. " +
                                                "Uses selfdrive/car/tests/test_models.py")
-  parser.add_argument("route", help="Specify route to run tests on")
+  parser.add_argument("route_or_segment_name", help="Specify route to run tests on")
   parser.add_argument("--car", help="Specify car model for test route")
   parser.add_argument("--ci", action="store_true", help="Attempt to get logs using openpilotci, need to specify car")
   args = parser.parse_args()
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     parser.print_help()
     sys.exit()
 
-  route_or_segment_name = SegmentName(args.route.strip(), allow_route_name=True)
+  route_or_segment_name = SegmentName(args.route_or_segment_name.strip(), allow_route_name=True)
   segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
   test_route = CarTestRoute(route_or_segment_name.route_name.canonical_name, args.car, segment=segment_num)
   test_suite = create_test_models_suite([(args.car, test_route)], ci=args.ci)

--- a/selfdrive/debug/test_car_model.py
+++ b/selfdrive/debug/test_car_model.py
@@ -6,6 +6,7 @@ import unittest
 
 from selfdrive.car.tests.routes import CarTestRoute
 from selfdrive.car.tests.test_models import TestCarModel
+from tools.lib.route import SegmentName
 
 
 def create_test_models_suite(routes: List[Tuple[str, CarTestRoute]], ci=False) -> unittest.TestSuite:
@@ -21,16 +22,17 @@ def create_test_models_suite(routes: List[Tuple[str, CarTestRoute]], ci=False) -
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Test any route against common issues with a new car port. " +
                                                "Uses selfdrive/car/tests/test_models.py")
-  parser.add_argument("route", help="Specify route to run tests on")
+  parser.add_argument("route_or_segment_name", help="Specify route to run tests on")
   parser.add_argument("--car", help="Specify car model for test route")
-  parser.add_argument("--segment", type=int, nargs="?", help="Specify segment of route to test")
   parser.add_argument("--ci", action="store_true", help="Attempt to get logs using openpilotci, need to specify car")
   args = parser.parse_args()
   if len(sys.argv) == 1:
     parser.print_help()
     sys.exit()
 
-  test_route = CarTestRoute(args.route, args.car, segment=args.segment)
+  route_or_segment_name = SegmentName(args.route.strip(), allow_route_name=True)
+  segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
+  test_route = CarTestRoute(route_or_segment_name.route_name, args.car, segment=segment_num)
   test_suite = create_test_models_suite([(args.car, test_route)], ci=args.ci)
 
   unittest.TextTestRunner().run(test_suite)

--- a/selfdrive/debug/test_car_model.py
+++ b/selfdrive/debug/test_car_model.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     parser.print_help()
     sys.exit()
 
-  route_or_segment_name = SegmentName(args.route.strip(), allow_route_name=True)
+  route_or_segment_name = SegmentName(args.route_or_segment_name.strip(), allow_route_name=True)
   segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
   test_route = CarTestRoute(route_or_segment_name.route_name, args.car, segment=segment_num)
   test_suite = create_test_models_suite([(args.car, test_route)], ci=args.ci)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
