### PR TITLE
hyundai-can long control improvements

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -173,9 +173,15 @@ class CarController:
               self.last_button_frame = self.frame
 
       if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
-        # TODO: unclear if this is needed
-        jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
-        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
+        # calculate jerk from plan, give a small offset for the upper limit for the cars ecu
+        lower_jerk = clip(abs(accel - self.accel_last) * 50, 0., 3.0)
+        upper_jerk = lower_jerk + 0.5
+
+        # When accelerating from very low speeds or stopped, allow more jerk to prevent a slow takeoff
+        if CS.out.vEgoRaw < 4. and accel > 0:
+            lower_jerk = max(0.5, lower_jerk)
+            upper_jerk = lower_jerk + 0.5
+        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, upper_jerk, lower_jerk, int(self.frame / 2),
                                                         hud_control.leadVisible, set_speed_in_units, stopping, CC.cruiseControl.override))
 
       # 20 Hz LFA MFA message

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -179,8 +179,8 @@ class CarController:
 
         # When accelerating from very low speeds or stopped, allow more jerk to prevent a slow takeoff
         if CS.out.vEgoRaw < 4. and accel > 0:
-            lower_jerk = max(0.5, lower_jerk)
-            upper_jerk = lower_jerk + 0.5
+          lower_jerk = max(0.5, lower_jerk)
+          upper_jerk = lower_jerk + 0.5
         can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, upper_jerk, lower_jerk, int(self.frame / 2),
                                                         hud_control.leadVisible, set_speed_in_units, stopping, CC.cruiseControl.override))
 

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -96,7 +96,7 @@ def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 
-def create_acc_commands(packer, enabled, accel, upper_jerk, idx, lead_visible, set_speed, stopping, long_override):
+def create_acc_commands(packer, enabled, accel, upper_jerk, lower_jerk, idx, lead_visible, set_speed, stopping, long_override):
   commands = []
 
   scc11_values = {
@@ -127,8 +127,8 @@ def create_acc_commands(packer, enabled, accel, upper_jerk, idx, lead_visible, s
   scc14_values = {
     "ComfortBandUpper": 0.0, # stock usually is 0 but sometimes uses higher values
     "ComfortBandLower": 0.0, # stock usually is 0 but sometimes uses higher values
-    "JerkUpperLimit": upper_jerk, # stock usually is 1.0 but sometimes uses higher values
-    "JerkLowerLimit": 5.0, # stock usually is 0.5 but sometimes uses higher values
+    "JerkUpperLimit": min(3.0, upper_jerk), # stock usually is 1.0 but sometimes uses higher values
+    "JerkLowerLimit": max(0.1, lower_jerk), # stock usually is 0.5 but sometimes uses higher values
     "ACCMode": 2 if enabled and long_override else 1 if enabled else 4, # stock will always be 4 instead of 0 after first disengage
     "ObjGap": 2 if lead_visible else 0, # 5: >30, m, 4: 25-30 m, 3: 20-25 m, 2: < 20 m, 0: no lead
   }

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -233,8 +233,12 @@ class CarInterface(CarInterfaceBase):
       ret.longitudinalTuning.kiV = [0.0]
       ret.experimentalLongitudinalAvailable = candidate in (HYBRID_CAR | EV_CAR) and candidate not in CANFD_RADAR_SCC_CAR
     else:
-      ret.longitudinalTuning.kpV = [0.5]
-      ret.longitudinalTuning.kiV = [0.0]
+      ret.longitudinalTuning.kpBP = [2.0, 7.0]
+      ret.longitudinalTuning.kpV = [0.4, 0.9]
+
+      ret.longitudinalTuning.kiBP = [2.0, 7.0]
+      ret.longitudinalTuning.kiV = [0.0, 0.19]
+
       ret.experimentalLongitudinalAvailable = candidate not in (LEGACY_SAFETY_MODE_CAR | CAMERA_SCC_CAR)
     ret.openpilotLongitudinalControl = experimental_long and ret.experimentalLongitudinalAvailable
     ret.pcmCruise = not ret.openpilotLongitudinalControl


### PR DESCRIPTION
**Description**
Calculate jerk from the acceleration plan and use as the lower limit value when sending accel commands to hyundai can vehicles.

Using small min values for the jerk increases the resolution of the acceleration that the car provides. This allows the car to better fit the acceleration to the plan by making smaller adjustments to the acceleration to maintain/hit the target acceleration.

However, with too small of values for either the min or max jerk the car responds to changes in acceleration very sluggishly. Thus when we are requesting rapid changes to acceleration we need larger jerk values.

To achieve a good balance of resolution to responsiveness we can determine what the jerk in the planned acceleration is between the last acc command and the current command and use that as the basis of the values we request from the car. This allows a dynamic resolution that matches the current demands of the plan.

**Verification**
I've been driving using this change for the last month or so and find the acceleration to be noticeably smoother. However, I'm marking as a draft for now as I'm not entirely confident in the behavior when stopping and accelerating from a stop. I believe it's similar or better in behavior at stopping speeds as the current method, but most of my driving does not have stop and go driving to fully test with. Some tuning may still be necessary at very low speeds.

I also suspect that using this method would improve the feel of acceleration on can-fd vehicles, but do not have one to test with so the change currently is only on the can controls.