### PR TITLE
IsoTpParallelQuery: log response pending

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -134,8 +134,7 @@ class IsoTpParallelQuery:
           error_code = dat[2] if len(dat) > 2 else -1
           if error_code == 0x78:
             response_timeouts[tx_addr] = time.monotonic() + self.response_pending_timeout
-            if self.debug:
-              cloudlog.warning(f"iso-tp query response pending: {tx_addr}")
+            cloudlog.error(f"iso-tp query response pending: {tx_addr}")
           else:
             response_timeouts[tx_addr] = 0
             request_done[tx_addr] = True


### PR DESCRIPTION
We can extend the timeout by 10 seconds and not log anything at all, this now logs to the qlogs