### PR TITLE
IsoTpParallelQuery: break earlier and add comment

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -137,11 +137,10 @@ class IsoTpParallelQuery:
             request_done[tx_addr] = True
             cloudlog.error(f"iso-tp query bad response: {tx_addr} - 0x{dat.hex()}")
 
-      # Break if all requests are done
+      # Break if all requests are done, we've timed out on all requests, or we've hit a max total timeout
       if all(request_done.values()):
         break
 
-      # Or if we've timed out on all requests
       cur_time = time.monotonic()
       if cur_time - max(response_timeouts.values()) > 0:
         for tx_addr in msgs:
@@ -149,7 +148,6 @@ class IsoTpParallelQuery:
             cloudlog.error(f"iso-tp query timeout after receiving response: {tx_addr}")
         break
 
-      # Or we've hit a max total timeout
       if cur_time - start_time > total_timeout:
         cloudlog.error("iso-tp query timeout while receiving data")
         break

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -100,9 +100,6 @@ class IsoTpParallelQuery:
     while True:
       self.rx()
 
-      if all(request_done.values()):
-        break
-
       for tx_addr, msg in msgs.items():
         try:
           dat, rx_in_progress = msg.recv()
@@ -140,6 +137,11 @@ class IsoTpParallelQuery:
             request_done[tx_addr] = True
             cloudlog.error(f"iso-tp query bad response: {tx_addr} - 0x{dat.hex()}")
 
+      # Break if all requests are done
+      if all(request_done.values()):
+        break
+
+      # Or if we've timed out on all requests
       cur_time = time.monotonic()
       if cur_time - max(response_timeouts.values()) > 0:
         for tx_addr in msgs:
@@ -147,6 +149,7 @@ class IsoTpParallelQuery:
             cloudlog.error(f"iso-tp query timeout after receiving response: {tx_addr}")
         break
 
+      # Or we've hit a max total timeout
       if cur_time - start_time > total_timeout:
         cloudlog.error("iso-tp query timeout while receiving data")
         break


### PR DESCRIPTION
Checks request done after updating request done, not between receiving msgs and updating request done

Saves some time if the current loop sets all requests done, we don't need to receive messages