### PR TITLE
cabana: support splitting chart

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -331,10 +331,16 @@ void ChartView::updateAxisY() {
     axis_y->setRange(min_y, max_y);
     axis_y->setTickCount(tick_count);
 
-    int title_spacing = unit.isEmpty() ? 0 : QFontMetrics(axis_y->titleFont()).size(Qt::TextSingleLine, unit).height();
-    QFontMetrics fm(axis_y->labelsFont());
     int n = qMax(int(-qFloor(std::log10((max_y - min_y) / (tick_count - 1)))), 0) + 1;
-    y_label_width = title_spacing + qMax(fm.width(QString::number(min_y, 'f', n)), fm.width(QString::number(max_y, 'f', n))) + 15;
+    int max_label_width = 0;
+    QFontMetrics fm(axis_y->labelsFont());
+    for (int i = 0; i < tick_count; i++) {
+      qreal value = min_y + (i * (max_y - min_y) / (tick_count - 1));
+      max_label_width = std::max(max_label_width, fm.width(QString::number(value, 'f', n)));
+    }
+
+    int title_spacing = unit.isEmpty() ? 0 : QFontMetrics(axis_y->titleFont()).size(Qt::TextSingleLine, unit).height();
+    y_label_width = title_spacing + max_label_width + 15;
     axis_y->setLabelFormat(QString("%.%1f").arg(n));
     emit axisYLabelWidthChanged(y_label_width);
   }

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -5,9 +5,11 @@
 #include <QDrag>
 #include <QGraphicsLayout>
 #include <QGraphicsDropShadowEffect>
+#include <QGraphicsOpacityEffect>
 #include <QMenu>
 #include <QMimeData>
 #include <QOpenGLWidget>
+#include <QPropertyAnimation>
 #include <QRubberBand>
 #include <QtMath>
 
@@ -569,6 +571,7 @@ void ChartView::dropEvent(QDropEvent *event) {
       sigs.append(source_chart->sigs);
       updateAxisY();
       updateTitle();
+      startAnimation();
 
       source_chart->sigs.clear();
       charts_widget->removeChart(source_chart);
@@ -581,6 +584,17 @@ void ChartView::dropEvent(QDropEvent *event) {
 void ChartView::resetChartCache() {
   chart_pixmap = QPixmap();
   viewport()->update();
+}
+
+void ChartView::startAnimation() {
+  QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+  viewport()->setGraphicsEffect(eff);
+  QPropertyAnimation *a = new QPropertyAnimation(eff, "opacity");
+  a->setDuration(250);
+  a->setStartValue(0.3);
+  a->setEndValue(1);
+  a->setEasingCurve(QEasingCurve::InBack);
+  a->start(QPropertyAnimation::DeleteWhenStopped);
 }
 
 void ChartView::paintEvent(QPaintEvent *event) {

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -25,8 +25,8 @@ class ChartView : public QChartView {
 
 public:
   ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent = nullptr);
-  void addSeries(const MessageId &msg_id, const cabana::Signal *sig);
-  bool hasSeries(const MessageId &msg_id, const cabana::Signal *sig) const;
+  void addSignal(const MessageId &msg_id, const cabana::Signal *sig);
+  bool hasSignal(const MessageId &msg_id, const cabana::Signal *sig) const;
   void updateSeries(const cabana::Signal *sig = nullptr);
   void updatePlot(double cur, double min, double max);
   void setSeriesType(SeriesType type);
@@ -52,7 +52,7 @@ signals:
 
 private slots:
   void signalUpdated(const cabana::Signal *sig);
-  void manageSeries();
+  void manageSignals();
   void handleMarkerClicked();
   void msgUpdated(MessageId id);
   void msgRemoved(MessageId id) { removeIf([=](auto &s) { return s.msg_id == id; }); }
@@ -60,6 +60,7 @@ private slots:
 
 private:
   void createToolButtons();
+  void addSeries(QXYSeries *series);
   void mousePressEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *ev) override;
@@ -89,6 +90,7 @@ private:
   int align_to = 0;
   QValueAxis *axis_x;
   QValueAxis *axis_y;
+  QAction *split_chart_act;
   QGraphicsPixmapItem *move_icon;
   QGraphicsProxyWidget *close_btn_proxy;
   QGraphicsProxyWidget *manage_btn_proxy;

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -33,6 +33,7 @@ public:
   void updatePlotArea(int left, bool force = false);
   void showTip(double sec);
   void hideTip();
+  void startAnimation();
 
   struct SigItem {
     MessageId msg_id;

--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -476,6 +476,7 @@ void ChartsContainer::dropEvent(QDropEvent *event) {
       charts_widget->currentCharts().insert(to, chart);
       charts_widget->updateLayout(true);
       event->acceptProposedAction();
+      chart->startAnimation();
     }
     drawDropIndicator({});
   }

--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -235,7 +235,7 @@ void ChartsWidget::settingChanged() {
 
 ChartView *ChartsWidget::findChart(const MessageId &id, const cabana::Signal *sig) {
   for (auto c : charts)
-    if (c->hasSeries(id, sig)) return c;
+    if (c->hasSignal(id, sig)) return c;
   return nullptr;
 }
 
@@ -256,9 +256,25 @@ void ChartsWidget::showChart(const MessageId &id, const cabana::Signal *sig, boo
   ChartView *chart = findChart(id, sig);
   if (show && !chart) {
     chart = merge && currentCharts().size() > 0 ? currentCharts().front() : createChart();
-    chart->addSeries(id, sig);
+    chart->addSignal(id, sig);
   } else if (!show && chart) {
     chart->removeIf([&](auto &s) { return s.msg_id == id && s.sig == sig; });
+  }
+}
+
+void ChartsWidget::splitChart(ChartView *src_chart) {
+  if (src_chart->sigs.size() > 1) {
+    for (auto it = src_chart->sigs.begin() + 1; it != src_chart->sigs.end(); /**/) {
+      auto c = createChart();
+      src_chart->chart()->removeSeries(it->series);
+      c->addSeries(it->series);
+      c->sigs.push_back(*it);
+      c->updateAxisY();
+      c->updateTitle();
+      it = src_chart->sigs.erase(it);
+    }
+    src_chart->updateAxisY();
+    src_chart->updateTitle();
   }
 }
 
@@ -346,7 +362,7 @@ void ChartsWidget::newChart() {
     if (!items.isEmpty()) {
       auto c = createChart();
       for (auto it : items) {
-        c->addSeries(it->msg_id, it->sig);
+        c->addSignal(it->msg_id, it->sig);
       }
     }
   }

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -58,6 +58,7 @@ private:
   void newChart();
   ChartView *createChart();
   void removeChart(ChartView *chart);
+  void splitChart(ChartView *chart);
   void eventsMerged();
   void updateState();
   void zoomReset();


### PR DESCRIPTION
1. added a menu item to split merged charts:

      [Kazam_screencast_00046.webm](https://user-images.githubusercontent.com/27770/231552940-8f3bf80c-f3c4-4ceb-a065-d46b60894aa6.webm)

2. fixed a multiple threads issue in `ChartView::updateSeries`
3. fixed elided axis-y label issue
4. fade in chart after drop.