### PR TITLE
Hyundai CAN FD: query hvac with alt request

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -385,14 +385,14 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_ALT],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.parkingAdas],
+      whitelist_ecus=[Ecu.parkingAdas, Ecu.hvac],
       bus=0,
       auxiliary=True,
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_ALT],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.parkingAdas],
+      whitelist_ecus=[Ecu.parkingAdas, Ecu.hvac],
       bus=1,
       auxiliary=True,
       obd_multiplexing=False,


### PR DESCRIPTION
Some cars' hvac respond negatively to `HYUNDAI_VERSION_REQUEST_LONG` :(

It's one Tucson and one Tucson Hybrid so far, but other Tucsons support this request...

bf1a6b0ba293c37b|2023-04-12--08-42-15 (`0x7f2212`)
and 85b586119c6a9213 (unknown response, but missing)

Try to query with the alt request used for parkingAdas until we can find one of these users in Discord to run a FW dump