### PR TITLE
cabana: fix new chart button placement on Windows

### DIFF
--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -351,7 +351,7 @@ bool SignalItemDelegate::helpEvent(QHelpEvent *event, QAbstractItemView *view, c
 void SignalItemDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const {
   auto item = (SignalModel::Item *)index.internalPointer();
   if (editor && item->type == SignalModel::Item::Sig && index.column() == 1) {
-    QRect geom = option.widget->style()->subElementRect(QStyle::SE_ItemViewItemText, &option);
+    QRect geom = option.rect;
     geom.setLeft(geom.right() - editor->sizeHint().width());
     editor->setGeometry(geom);
     return;


### PR DESCRIPTION
See https://github.com/commaai/openpilot/pull/27769 for more discussion. `option.widget->style()->subElementRect(QStyle::SE_ItemViewItemText, &option)` has zero width on windows.

This fixes it, and has no visual difference on MacOS.

![](https://user-images.githubusercontent.com/1314752/230403078-2709fef0-d5d4-4aab-abdc-1e3a0f09a483.png)
