### PR TITLE
cabana: do not try to save empty wildcard DBC

### DIFF
--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -186,12 +186,29 @@ QStringList DBCFile::signalNames() const {
   return ret;
 }
 
+int DBCFile::signalCount(const MessageId &id) const {
+  if (msgs.count(id.address) == 0) return 0;
+  return msgs.at(id.address).sigs.size();
+}
+
+int DBCFile::signalCount() const {
+  int total = 0;
+  for (auto const& [_, msg] : msgs) {
+    total += msg.sigs.size();
+  }
+  return total;
+}
+
 int DBCFile::msgCount() const {
   return msgs.size();
 }
 
 QString DBCFile::name() const {
   return name_;
+}
+
+bool DBCFile::isEmpty() const {
+  return (signalCount() == 0) && name().isEmpty();
 }
 
 void DBCFile::parseExtraInfo(const QString &content) {

--- a/tools/cabana/dbc/dbcfile.h
+++ b/tools/cabana/dbc/dbcfile.h
@@ -43,8 +43,11 @@ public:
   const cabana::Msg *msg(uint32_t address) const;
   const cabana::Msg* msg(const QString &name);
   QStringList signalNames() const;
+  int signalCount(const MessageId &id) const;
+  int signalCount() const;
   int msgCount() const;
   QString name() const;
+  bool isEmpty() const;
 
   QString filename;
 

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -216,7 +216,7 @@ int DBCManager::dbcCount() const {
 
 int DBCManager::nonEmptyDBCCount() const {
   int cnt = 0;
-  for (auto [_, dbc_file] : dbc_files) {
+  for (auto &[_, dbc_file] : dbc_files) {
     if (!dbc_file->isEmpty()) {
       cnt++;
     }

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -180,6 +180,26 @@ QStringList DBCManager::signalNames() const {
   return ret;
 }
 
+int DBCManager::signalCount(const MessageId &id) const {
+  auto sources_dbc_file = findDBCFile(id);
+  if (!sources_dbc_file) {
+    return 0;
+  }
+
+  auto [_, dbc_file] = *sources_dbc_file;
+  return dbc_file->signalCount(id);
+}
+
+int DBCManager::signalCount() const {
+  int ret = 0;
+
+  for (auto &[_, dbc_file] : dbc_files) {
+    ret += dbc_file->signalCount();
+  }
+
+  return ret;
+}
+
 int DBCManager::msgCount() const {
   int ret = 0;
 
@@ -192,6 +212,16 @@ int DBCManager::msgCount() const {
 
 int DBCManager::dbcCount() const {
   return dbc_files.size();
+}
+
+int DBCManager::nonEmptyDBCCount() const {
+  int cnt = 0;
+  for (auto [_, dbc_file] : dbc_files) {
+    if (!dbc_file->isEmpty()) {
+      cnt++;
+    }
+  }
+  return cnt;
 }
 
 void DBCManager::updateSources(const SourceSet &s) {

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -38,8 +38,11 @@ public:
   const cabana::Msg* msg(uint8_t source, const QString &name);
 
   QStringList signalNames() const;
+  int signalCount(const MessageId &id) const;
+  int signalCount() const;
   int msgCount() const;
   int dbcCount() const;
+  int nonEmptyDBCCount() const;
 
   std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const uint8_t source) const;
   std::optional<std::pair<SourceSet, DBCFile*>> findDBCFile(const MessageId &id) const;


### PR DESCRIPTION
After loading a dbc for a specific bus, it would also try to save the empty "wildcard" dbc even if it has no signals. Treat DBC files that have no filename and no signals as non-existent.

Also add some useful helper functions. Will use those in another PR too where I'm moving the new signal name generation into dbcmanager/dbcfile.