### PR TITLE
cabana: fix message view performance issues after #27901

### DIFF
--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -26,6 +26,7 @@ public:
   BinaryViewModel(QObject *parent) : QAbstractTableModel(parent) {}
   void refresh();
   void updateState();
+  void updateItem(int row, int col, const QString &val, const QColor &color);
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const { return {}; }
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return row_count; }

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -286,3 +286,9 @@ void MessageView::drawRow(QPainter *painter, const QStyleOptionViewItem &option,
   painter->setPen(old_pen);
   painter->resetTransform();
 }
+
+void MessageView::dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles) {
+   // Bypass the slow call to QTreeView::dataChanged.
+   // QTreeView::dataChanged will invalidate the height cache and that's what we don't need in MessageView.
+   QAbstractItemView::dataChanged(topLeft, bottomRight, roles);
+}

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -25,14 +25,16 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
   view = new MessageView(this);
   model = new MessageListModel(this);
   auto delegate = new MessageBytesDelegate(view, settings.multiple_lines_bytes);
-  view->setItemDelegateForColumn(5, delegate);
+  view->setItemDelegate(delegate);
   view->setModel(model);
   view->setSortingEnabled(true);
   view->sortByColumn(0, Qt::AscendingOrder);
+  view->setAllColumnsShowFocus(true);
+  view->setEditTriggers(QAbstractItemView::NoEditTriggers);
   view->setItemsExpandable(false);
   view->setIndentation(0);
   view->setRootIsDecorated(false);
-  view->header()->setStretchLastSection(true);
+  view->header()->setSectionsMovable(false);
   main_layout->addWidget(view);
 
   // suppress
@@ -48,6 +50,7 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
   QObject::connect(multiple_lines_bytes, &QCheckBox::stateChanged, [=](int state) {
     settings.multiple_lines_bytes = (state == Qt::Checked);
     delegate->setMultipleLines(settings.multiple_lines_bytes);
+    view->setUniformRowHeights(!settings.multiple_lines_bytes);
     model->sortMessages();
   });
   QObject::connect(can, &AbstractStream::msgsReceived, model, &MessageListModel::msgsReceived);
@@ -148,7 +151,7 @@ QVariant MessageListModel::data(const QModelIndex &index, int role) const {
       }
     }
     return QVariant::fromValue(colors);
-  } else if (role == BytesRole) {
+  } else if (role == BytesRole && index.column() == 5) {
     return can_data.dat;
   }
   return {};
@@ -268,9 +271,9 @@ void MessageListModel::reset() {
 
 void MessageView::drawRow(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {
   QTreeView::drawRow(painter, option, index);
-  painter->save();
   const int gridHint = style()->styleHint(QStyle::SH_Table_GridLineColor, &option, this);
   const QColor gridColor = QColor::fromRgba(static_cast<QRgb>(gridHint));
+  QPen old_pen = painter->pen();
   painter->setPen(gridColor);
   painter->drawLine(option.rect.left(), option.rect.bottom(), option.rect.right(), option.rect.bottom());
 
@@ -280,5 +283,6 @@ void MessageView::drawRow(QPainter *painter, const QStyleOptionViewItem &option,
     painter->translate(header()->sectionSize(i), 0);
     painter->drawLine(0, y, 0, y + option.rect.height());
   }
-  painter->restore();
+  painter->setPen(old_pen);
+  painter->resetTransform();
 }

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -40,6 +40,7 @@ class MessageView : public QTreeView {
 public:
   MessageView(QWidget *parent) : QTreeView(parent) {}
   void drawRow(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+  void drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const override {}
 };
 
 class MessagesWidget : public QWidget {

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -41,6 +41,7 @@ public:
   MessageView(QWidget *parent) : QTreeView(parent) {}
   void drawRow(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   void drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const override {}
+  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>()) override;
 };
 
 class MessagesWidget : public QWidget {

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -30,7 +30,7 @@ void Settings::save() {
   s.setValue("geometry", geometry);
   s.setValue("video_splitter_state", video_splitter_state);
   s.setValue("recent_files", recent_files);
-  s.setValue("msg_header_state", message_header_state);
+  s.setValue("message_header_state_v2", message_header_state);
   s.setValue("chart_series_type", chart_series_type);
   s.setValue("theme", theme);
   s.setValue("sparkline_range", sparkline_range);
@@ -52,7 +52,7 @@ void Settings::load() {
   geometry = s.value("geometry").toByteArray();
   video_splitter_state = s.value("video_splitter_state").toByteArray();
   recent_files = s.value("recent_files").toStringList();
-  message_header_state = s.value("msg_header_state").toByteArray();
+  message_header_state = s.value("message_header_state_v2").toByteArray();
   chart_series_type = s.value("chart_series_type", 0).toInt();
   theme = s.value("theme", 0).toInt();
   sparkline_range = s.value("sparkline_range", 15).toInt();

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -30,7 +30,7 @@ void Settings::save() {
   s.setValue("geometry", geometry);
   s.setValue("video_splitter_state", video_splitter_state);
   s.setValue("recent_files", recent_files);
-  s.setValue("message_header_state", message_header_state);
+  s.setValue("msg_header_state", message_header_state);
   s.setValue("chart_series_type", chart_series_type);
   s.setValue("theme", theme);
   s.setValue("sparkline_range", sparkline_range);
@@ -52,7 +52,7 @@ void Settings::load() {
   geometry = s.value("geometry").toByteArray();
   video_splitter_state = s.value("video_splitter_state").toByteArray();
   recent_files = s.value("recent_files").toStringList();
-  message_header_state = s.value("message_header_state").toByteArray();
+  message_header_state = s.value("msg_header_state").toByteArray();
   chart_series_type = s.value("chart_series_type", 0).toInt();
   theme = s.value("theme", 0).toInt();
   sparkline_range = s.value("sparkline_range", 15).toInt();


### PR DESCRIPTION
Issues:
1. the CPU usage **increased by 20%** after #27901.  
2. The new messagelist is not compatible with the state saved by the previous settings.

fixed:
1. Optimize the sizehint() and paint() , the cpu usage has been reduced by about 20%, basically the same as the previous version.
2. rename setting key from 'message_header_state' to 'msg_header_state' to avoid the issues with incompatible settings file.

[updated]
merged another performance related pr: remove copies in BinaryViewModel::UpdateState
