### PR TITLE
cabana: improve display of frequence

### DIFF
--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -132,12 +132,20 @@ QVariant MessageListModel::data(const QModelIndex &index, int role) const {
   const auto &id = msgs[index.row()];
   auto &can_data = can->lastMessage(id);
 
+  auto getFreq = [](const CanData &d) -> QString {
+    if (d.freq > 0 && (can->currentSec() - d.ts) < (5.0 / d.freq)) {
+      return d.freq >= 1 ? QString::number(std::nearbyint(d.freq)) : QString::number(d.freq, 'f', 2);
+    } else {
+      return "--";
+    }
+  };
+
   if (role == Qt::DisplayRole) {
     switch (index.column()) {
       case 0: return msgName(id);
       case 1: return id.source;
       case 2: return QString::number(id.address, 16);;
-      case 3: return can_data.freq;
+      case 3: return getFreq(can_data);
       case 4: return can_data.count;
       case 5: return toHex(can_data.dat);
     }

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -17,7 +17,7 @@ struct CanData {
 
   double ts = 0.;
   uint32_t count = 0;
-  uint32_t freq = 0;
+  double freq = 0;
   QByteArray dat;
   QVector<QColor> colors;
   QVector<double> last_change_t;


### PR DESCRIPTION
1. use double type for freq to improve precision.
2. display dash if message have not been updated for a while.
3. display as float number if freq < 1 (0 is displayed before)

![2023-04-17_04-35](https://user-images.githubusercontent.com/27770/232340996-43b7d58f-0936-46fe-af4b-e4bc977b28d3.png)
