### PR TITLE
cabana: add setting to choose preferred drag direction for new signals

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -239,7 +239,19 @@ std::tuple<int, int, bool> BinaryView::getSelection(QModelIndex index) {
   if (index.column() == 8) {
     index = model->index(index.row(), 7);
   }
-  bool is_lb = (resize_sig && resize_sig->is_little_endian) || (!resize_sig && index < anchor_index);
+  bool is_lb = true;
+  if (resize_sig) {
+    is_lb = resize_sig->is_little_endian;
+  } else if (settings.drag_direction == Settings::DragDirection::MsbFirst) {
+    is_lb = index < anchor_index;
+  } else if (settings.drag_direction == Settings::DragDirection::LsbFirst) {
+    is_lb = !(index < anchor_index);
+  } else if (settings.drag_direction == Settings::DragDirection::AlwaysLE) {
+    is_lb = true;
+  } else if (settings.drag_direction == Settings::DragDirection::AlwaysBE) {
+    is_lb = false;
+  }
+
   int cur_bit_idx = get_bit_index(index, is_lb);
   int anchor_bit_idx = get_bit_index(anchor_index, is_lb);
   auto [start_bit, end_bit] = std::minmax(cur_bit_idx, anchor_bit_idx);

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -37,6 +37,7 @@ void Settings::save() {
   s.setValue("multiple_lines_bytes", multiple_lines_bytes);
   s.setValue("log_livestream", log_livestream);
   s.setValue("log_path", log_path);
+  s.setValue("drag_direction", drag_direction);
 }
 
 void Settings::load() {
@@ -59,6 +60,7 @@ void Settings::load() {
   multiple_lines_bytes = s.value("multiple_lines_bytes", true).toBool();
   log_livestream = s.value("log_livestream", true).toBool();
   log_path = s.value("log_path").toString();
+  drag_direction = (Settings::DragDirection)s.value("drag_direction", 0).toInt();
   if (log_path.isEmpty()) {
     log_path = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/cabana_live_stream/";
   }
@@ -91,6 +93,14 @@ SettingsDlg::SettingsDlg(QWidget *parent) : QDialog(parent) {
   form_layout->addRow(tr("Max Cached Minutes"), cached_minutes);
   main_layout->addWidget(groupbox);
 
+  groupbox = new QGroupBox("New Signal Settings");
+  form_layout = new QFormLayout(groupbox);
+  drag_direction = new QComboBox(this);
+  drag_direction->addItems({tr("MSB First"), tr("LSB First"), tr("Always Little Endian"), tr("Always Big Endian")});
+  drag_direction->setCurrentIndex(settings.drag_direction);
+  form_layout->addRow(tr("Drag Direction"), drag_direction);
+  main_layout->addWidget(groupbox);
+
   groupbox = new QGroupBox("Chart");
   form_layout = new QFormLayout(groupbox);
   chart_series_type = new QComboBox(this);
@@ -113,6 +123,7 @@ SettingsDlg::SettingsDlg(QWidget *parent) : QDialog(parent) {
   auto browse_btn = new QPushButton(tr("B&rowse..."));
   path_layout->addWidget(browse_btn);
   main_layout->addWidget(log_livestream);
+
 
   auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Apply);
   main_layout->addWidget(buttonBox);
@@ -151,6 +162,7 @@ void SettingsDlg::save() {
   settings.chart_height = chart_height->value();
   settings.log_livestream = log_livestream->isChecked();
   settings.log_path = log_path->text();
+  settings.drag_direction = (Settings::DragDirection)drag_direction->currentIndex();
   settings.save();
   emit settings.changed();
 }

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -15,6 +15,13 @@ class Settings : public QObject {
   Q_OBJECT
 
 public:
+  enum DragDirection {
+    MsbFirst,
+    LsbFirst,
+    AlwaysLE,
+    AlwaysBE,
+  };
+
   Settings();
   void save();
   void load();
@@ -37,6 +44,7 @@ public:
   QByteArray window_state;
   QStringList recent_files;
   QByteArray message_header_state;
+  DragDirection drag_direction;
 
 signals:
   void changed();
@@ -55,6 +63,7 @@ public:
   QComboBox *theme;
   QGroupBox *log_livestream;
   QLineEdit *log_path;
+  QComboBox *drag_direction;
 };
 
 extern Settings settings;


### PR DESCRIPTION
Got user feedback that default drag direction felt backwards to them, so made it possible to always start at the LSB. Also added option to always create BE/LE signals, since on most cars all signals are the same endianness.

Default setting is the same as current behavior.

![2023-04-17-124030_322x447_scrot](https://user-images.githubusercontent.com/1314752/232461596-6c2304c7-3eab-4533-8640-7e3f13405506.png)
