### PR TITLE
cabana: display active colors more clearly in highlighted state.

### DIFF
--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -89,24 +89,29 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   int h_margin = option.widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin);
   if (option.state & QStyle::State_Selected) {
     painter->fillRect(option.rect, option.palette.highlight());
-    painter->setPen(option.palette.color(QPalette::HighlightedText));
-  } else {
-    painter->setPen(option.palette.color(QPalette::Text));
   }
 
   const QPoint pt{option.rect.left() + h_margin, option.rect.top() + v_margin};
   QFont old_font = painter->font();
+  QPen old_pen = painter->pen();
   painter->setFont(fixed_font);
   for (int i = 0; i < byte_list.size(); ++i) {
     int row = !multiple_lines ? 0 : i / 8;
     int column = !multiple_lines ? i : i % 8;
     QRect r = QRect({pt.x() + column * byte_size.width(), pt.y() + row * byte_size.height()}, byte_size);
     if (i < colors.size() && colors[i].alpha() > 0) {
+      if (option.state & QStyle::State_Selected) {
+        painter->setPen(option.palette.color(QPalette::Text));
+        painter->fillRect(r, option.palette.color(QPalette::Window));
+      }
       painter->fillRect(r, colors[i]);
+    } else if (option.state & QStyle::State_Selected) {
+      painter->setPen(option.palette.color(QPalette::HighlightedText));
     }
     painter->drawText(r, Qt::AlignCenter, toHex(byte_list[i]));
   }
   painter->setFont(old_font);
+  painter->setPen(old_pen);
 }
 
 QColor getColor(const cabana::Signal *sig) {


### PR DESCRIPTION
|   | normal | highlighted |
| ------------- | ------------- | ------------- |
| before | ![Screenshot from 2023-04-17 19-38-56](https://user-images.githubusercontent.com/27770/232474445-6104a24c-f232-4ee2-849a-1cc098332f90.png)  | ![Screenshot from 2023-04-17 19-39-07](https://user-images.githubusercontent.com/27770/232475170-51721088-2fc4-4ce2-b297-6ebfa9bd3a92.png) |
| After | ![Screenshot from 2023-04-17 19-40-36](https://user-images.githubusercontent.com/27770/232474436-41ad015a-d212-4d30-968f-34f0db6a9417.png) | ![2023-04-17_19-41](https://user-images.githubusercontent.com/27770/232474423-93b785bf-cf97-44c7-83e0-b1fb7152fbcb.png) |

