### PR TITLE
cabana: some improvements to messages view

### DIFF
--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -132,12 +132,20 @@ QVariant MessageListModel::data(const QModelIndex &index, int role) const {
   const auto &id = msgs[index.row()];
   auto &can_data = can->lastMessage(id);
 
+  auto getFreq = [](const CanData &d) -> QString {
+    if (d.freq > 0 && (can->currentSec() - d.ts) < (5.0 / d.freq)) {
+      return d.freq >= 1 ? QString::number(std::nearbyint(d.freq)) : QString::number(d.freq, 'f', 2);
+    } else {
+      return "--";
+    }
+  };
+
   if (role == Qt::DisplayRole) {
     switch (index.column()) {
       case 0: return msgName(id);
       case 1: return id.source;
       case 2: return QString::number(id.address, 16);;
-      case 3: return can_data.freq;
+      case 3: return getFreq(can_data);
       case 4: return can_data.count;
       case 5: return toHex(can_data.dat);
     }

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -144,7 +144,7 @@ QVariant MessageListModel::data(const QModelIndex &index, int role) const {
     switch (index.column()) {
       case 0: return msgName(id);
       case 1: return id.source;
-      case 2: return QString::number(id.address, 16);;
+      case 2: return QString::number(id.address, 16);
       case 3: return getFreq(can_data);
       case 4: return can_data.count;
       case 5: return toHex(can_data.dat);

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -17,7 +17,7 @@ struct CanData {
 
   double ts = 0.;
   uint32_t count = 0;
-  uint32_t freq = 0;
+  double freq = 0;
   QByteArray dat;
   QVector<QColor> colors;
   QVector<double> last_change_t;

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include <QAbstractItemView>
 #include <QApplication>
 #include <QByteArray>
 #include <QDateTime>
@@ -66,6 +67,7 @@ public:
   MessageBytesDelegate(QObject *parent, bool multiple_lines = false);
   void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+  bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
   void setMultipleLines(bool v);
 
 private:


### PR DESCRIPTION
1. use double type for freq to improve precision.
2. display dash if message have not been updated for a while.
3. display as float number if freq < 1 (0 is displayed before)
  ![2023-04-17_04-35](https://user-images.githubusercontent.com/27770/232340996-43b7d58f-0936-46fe-af4b-e4bc977b28d3.png)
4. display active colors more clearly in highlighted state. 

|   | normal | highlighted |
| ------------- | ------------- | ------------- |
| before | ![Screenshot from 2023-04-17 19-38-56](https://user-images.githubusercontent.com/27770/232474445-6104a24c-f232-4ee2-849a-1cc098332f90.png)  | ![Screenshot from 2023-04-17 19-39-07](https://user-images.githubusercontent.com/27770/232475170-51721088-2fc4-4ce2-b297-6ebfa9bd3a92.png) |
| After | ![Screenshot from 2023-04-17 19-40-36](https://user-images.githubusercontent.com/27770/232474436-41ad015a-d212-4d30-968f-34f0db6a9417.png) | ![2023-04-17_19-41](https://user-images.githubusercontent.com/27770/232474423-93b785bf-cf97-44c7-83e0-b1fb7152fbcb.png) |

5. show tooltip for tuncated message name:
![2023-04-17_21-13](https://user-images.githubusercontent.com/27770/232497593-be42bcf5-9306-4215-9295-8cf158f94c74.png)
