### PR TITLE
canaba: display the opened dbc files in the window title bar.

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -474,7 +474,7 @@ void MainWindow::updateLoadSaveMenus() {
   open_dbc_for_source->setEnabled(sources.size() > 0);
   open_dbc_for_source->clear();
 
-  QStringList dbc_files;
+  std::map<QString, QStringList> dbc_files;
   for (uint8_t source : sources_sorted) {
     if (source >= 64) continue; // Sent and blocked buses are handled implicitly
     QAction *action = new QAction(this);
@@ -487,7 +487,7 @@ void MainWindow::updateLoadSaveMenus() {
       name = "untitled";
     }
 
-    dbc_files.push_back("[" % name % "]");
+    dbc_files[d->second->filename].push_back(QString::number(source));
     action->setText(tr("Bus %1 (current: %2)").arg(source).arg(name));
     action->setData(source);
 
@@ -495,8 +495,11 @@ void MainWindow::updateLoadSaveMenus() {
     open_dbc_for_source->addAction(action);
   }
 
-  dbc_files.removeDuplicates();
-  setWindowFilePath(dbc_files.join(" "));
+  QStringList title;
+  for (auto &[filename, sources] : dbc_files) {
+    title.push_back("[" % sources.join(",") + "]" + QFileInfo(filename).baseName());
+  }
+  setWindowFilePath(title.join(" | "));
 }
 
 void MainWindow::updateRecentFiles(const QString &fn) {

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -481,13 +481,14 @@ void MainWindow::updateLoadSaveMenus() {
 
     auto d = dbc()->findDBCFile(source);
     QString name = tr("no DBC");
-    if (d && !d->second->name().isEmpty()) {
-      name = tr("%1").arg(d->second->name());
-    } else if (d) {
-      name = "untitled";
+    if (d) {
+      if (!d->second->name().isEmpty()) {
+        name = tr("%1").arg(d->second->name());
+      } else {
+        name = "untitled";
+      }
+      dbc_files[d->second->filename].push_back(QString::number(source));
     }
-
-    dbc_files[d->second->filename].push_back(QString::number(source));
     action->setText(tr("Bus %1 (current: %2)").arg(source).arg(name));
     action->setData(source);
 
@@ -497,7 +498,8 @@ void MainWindow::updateLoadSaveMenus() {
 
   QStringList title;
   for (auto &[filename, sources] : dbc_files) {
-    title.push_back("[" % sources.join(",") + "]" + QFileInfo(filename).baseName());
+    QString bus = dbc_files.size() == 1 ? "all" : sources.join(",");
+    title.push_back("[" + bus + "]" + QFileInfo(filename).baseName());
   }
   setWindowFilePath(title.join(" | "));
 }

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -474,6 +474,7 @@ void MainWindow::updateLoadSaveMenus() {
   open_dbc_for_source->setEnabled(sources.size() > 0);
   open_dbc_for_source->clear();
 
+  QStringList dbc_files;
   for (uint8_t source : sources_sorted) {
     if (source >= 64) continue; // Sent and blocked buses are handled implicitly
     QAction *action = new QAction(this);
@@ -486,12 +487,16 @@ void MainWindow::updateLoadSaveMenus() {
       name = "untitled";
     }
 
+    dbc_files.push_back("[" % name % "]");
     action->setText(tr("Bus %1 (current: %2)").arg(source).arg(name));
     action->setData(source);
 
     QObject::connect(action, &QAction::triggered, this, &MainWindow::openFileForSource);
     open_dbc_for_source->addAction(action);
   }
+
+  dbc_files.removeDuplicates();
+  setWindowFilePath(dbc_files.join(" "));
 }
 
 void MainWindow::updateRecentFiles(const QString &fn) {


### PR DESCRIPTION
before:
![Screenshot from 2023-04-18 04-08-00](https://user-images.githubusercontent.com/27770/232598881-d19d4a8f-1e5e-4840-a9f1-6ccb63722763.png)

after: （the format is `[bus1, bus2]filename | [bus3, bus4]filename`)
![Screenshot from 2023-04-18 04-29-29](https://user-images.githubusercontent.com/27770/232603301-65f01a81-1aa5-42df-b518-793e9df8b372.png)

![Screenshot from 2023-04-18 04-55-40](https://user-images.githubusercontent.com/27770/232608805-d97bafa0-96e7-4818-bad8-390cd836ae7e.png)
