### PR TITLE
cabana: fixed the freq column for high-freq messages may be incorrectly displayed as a --.

### DIFF
--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -133,7 +133,7 @@ QVariant MessageListModel::data(const QModelIndex &index, int role) const {
   auto &can_data = can->lastMessage(id);
 
   auto getFreq = [](const CanData &d) -> QString {
-    if (d.freq > 0 && (can->currentSec() - d.ts) < (5.0 / d.freq)) {
+    if (d.freq > 0 && (can->currentSec() - d.ts - 1.0 / settings.fps) < (5.0 / d.freq)) {
       return d.freq >= 1 ? QString::number(std::nearbyint(d.freq)) : QString::number(d.freq, 'f', 2);
     } else {
       return "--";


### PR DESCRIPTION
for example, the freq of SDSU(900hz) maybe dispalyed as --:

![Screenshot from 2023-04-18 05-11-36](https://user-images.githubusercontent.com/27770/232611993-3798814a-3ddf-44f4-b353-4cc023b69a3e.png)

the update frequency of Cabana itself should also be considered in calculation.