### PR TITLE
cabana/cameraview: Scale the glViewPort by devicePixelRatio()

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -114,6 +114,18 @@ CameraWidget::~CameraWidget() {
   doneCurrent();
 }
 
+// Qt uses device-independent pixels, depending on platform this may be
+// different to what OpenGL uses
+int CameraWidget::glWidth()
+{
+    return width() * devicePixelRatio();
+}
+
+int CameraWidget::glHeight()
+{
+  return height() * devicePixelRatio();
+}
+
 void CameraWidget::initializeGL() {
   initializeOpenGLFunctions();
 
@@ -188,7 +200,7 @@ void CameraWidget::availableStreamsUpdated(std::set<VisionStreamType> streams) {
 }
 
 void CameraWidget::updateFrameMat() {
-  int w = width(), h = height();
+  int w = glWidth(), h = glHeight();
 
   if (zoomed_view) {
     if (active_stream_type == VISION_STREAM_DRIVER) {
@@ -266,7 +278,7 @@ void CameraWidget::paintGL() {
 
   updateFrameMat();
 
-  glViewport(0, 0, width(), height());
+  glViewport(0, 0, glWidth(), glHeight());
   glBindVertexArray(frame_vao);
   glUseProgram(program->programId());
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -116,8 +116,7 @@ CameraWidget::~CameraWidget() {
 
 // Qt uses device-independent pixels, depending on platform this may be
 // different to what OpenGL uses
-int CameraWidget::glWidth()
-{
+int CameraWidget::glWidth() {
     return width() * devicePixelRatio();
 }
 

--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -120,8 +120,7 @@ int CameraWidget::glWidth() {
     return width() * devicePixelRatio();
 }
 
-int CameraWidget::glHeight()
-{
+int CameraWidget::glHeight() {
   return height() * devicePixelRatio();
 }
 

--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -54,6 +54,9 @@ protected:
   void vipcThread();
   void clearFrames();
 
+  int glWidth();
+  int glHeight();
+
   bool zoomed_view;
   GLuint frame_vao, frame_vbo, frame_ibo;
   GLuint textures[2];


### PR DESCRIPTION
Fix for an issue I ran into using Cabana on a "hidpi" Linux system with Wayland+Plasma (Qt 5.15.9) where [devicePixelRatio() != 1.0](https://doc.qt.io/qt-5/qwindow.html#devicePixelRatio) and the video doesn't take up the full widget area.

Screenshot of the demo route showing the issue:

![image](https://user-images.githubusercontent.com/205573/232624508-858f75d2-d4ca-41c0-8321-0d7dc2e33bf5.png)

On the recommended Ubuntu 20.04 install I wasn't able to reproduce. It seems devicePixelRatio() is equal to 1.0 there even with scaling at 200% or 300%. It might be different if "Fractional Scaling" is enabled in GNOME (I couldn't make that option work in my test WM for some reason.)

I was going to enable this just for Linux, but it appears to also be recommended for Retina macOS:

> [However, in OpenGL pixels are always device pixels. For example, geometry passed to glViewport() needs to be scaled by devicePixelRatio().](https://doc.qt.io/qt-5/scalability.html#high-dpi-scaling-on-macos-and-io)

So I've turned it on unconditionally, with the assumption that on many systems `devicePixelRatio() == 1.0` so it won't change anything. I don't have a Mac or WSL system to verify if this either fixes or creates any issues there, though.

Thanks for developing Cabana and the comma.ai ecosystem, I really like this tool!