### PR TITLE
Subaru: always show LKAS active

### DIFF
--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -56,11 +56,8 @@ def create_es_lkas(packer, es_lkas_msg, enabled, visual_alert, left_line, right_
     elif right_lane_depart:
       values["LKAS_Alert"] = 11 # Right lane departure dash alert
 
-  if enabled:
-    values["LKAS_ACTIVE"] = 1 # Show LKAS lane lines
-    values["LKAS_Dash_State"] = 2 # Green enabled indicator
-  else:
-    values["LKAS_Dash_State"] = 0 # LKAS Not enabled
+  values["LKAS_ACTIVE"] = 1 # Show LKAS lane lines
+  values["LKAS_Dash_State"] = 2 if enabled else 0 # Green enabled indicator
 
   values["LKAS_Left_Line_Visible"] = int(left_line)
   values["LKAS_Right_Line_Visible"] = int(right_line)


### PR DESCRIPTION
EyeSight always sets this to 1 from what I've seen (even when LKAS is toggled off), so we end up not changing anything.

This PR always shows the LKAS/ACC UI and the lines (lines visible is another signal), like other cars. (changes no behavior, just makes it clear it's always set to 1)

| | Previous Behavior | New Behavior |
| ------------- | ------------- | ------------- |
| Disabled  | Use EyeSight, always 1  | Set to 1 | 
| Enabled  | Set to 1  | Set to 1 |

Showing this when not enabled: https://user-images.githubusercontent.com/25857203/232626681-20e534a9-bbb6-4a78-8b98-edbfd8e768b9.jpg

Instead of this: https://user-images.githubusercontent.com/25857203/232626646-68616b4f-0765-4815-a566-9a45673ba3d2.jpg

And this when active: https://user-images.githubusercontent.com/25857203/232626773-3dabafe0-22c5-4da3-96c9-889f7449a146.jpg