### PR TITLE
cabana: fix PandaStream crash if no panda found

### DIFF
--- a/tools/cabana/streams/devicestream.cc
+++ b/tools/cabana/streams/devicestream.cc
@@ -1,6 +1,7 @@
 #include "tools/cabana/streams/devicestream.h"
 
 DeviceStream::DeviceStream(QObject *parent, QString address) : zmq_address(address), LiveStream(parent) {
+  startStreamThread();
 }
 
 void DeviceStream::streamThread() {

--- a/tools/cabana/streams/livestream.cc
+++ b/tools/cabana/streams/livestream.cc
@@ -8,10 +8,15 @@ LiveStream::LiveStream(QObject *parent) : AbstractStream(parent, true) {
     util::create_directories(path, 0755);
     fs.reset(new std::ofstream(path + "/rlog" , std::ios::binary | std::ios::out));
   }
-
   stream_thread = new QThread(this);
   QObject::connect(stream_thread, &QThread::started, [=]() { streamThread(); });
   QObject::connect(stream_thread, &QThread::finished, stream_thread, &QThread::deleteLater);
+}
+
+void LiveStream::startStreamThread() {
+  // delay the start of the thread to avoid calling startStreamThread
+  // in the constructor when other classes' slots have not been connected to
+  // the signals of the livestream.
   QTimer::singleShot(0, [this]() { stream_thread->start(); });
 }
 

--- a/tools/cabana/streams/livestream.h
+++ b/tools/cabana/streams/livestream.h
@@ -13,6 +13,7 @@ public:
   void setSpeed(float speed) override { speed_ = std::min<float>(1.0, speed); }
   bool isPaused() const override { return pause_; }
   void pause(bool pause) override;
+  void startStreamThread();
 
 protected:
   virtual void handleEvent(Event *evt);

--- a/tools/cabana/streams/pandastream.cc
+++ b/tools/cabana/streams/pandastream.cc
@@ -13,6 +13,7 @@ PandaStream::PandaStream(QObject *parent, PandaStreamConfig config_) : config(co
   if (!connect()) {
     throw std::runtime_error("Failed to connect to panda");
   }
+  startStreamThread();
 }
 
 bool PandaStream::connect() {


### PR DESCRIPTION
issue: the stream thread started before panda connected.  If pandaStream fails to connect or no panda found, the stream thread will crash immediately.

fixed: start stream thread after panda connected