### PR TITLE
boardd: fix scons warning "Two different environments were specified"

### DIFF
--- a/selfdrive/boardd/SConscript
+++ b/selfdrive/boardd/SConscript
@@ -8,4 +8,4 @@ env.Library('libcan_list_to_can_capnp', ['can_list_to_can_capnp.cc'])
 
 envCython.Program('boardd_api_impl.so', 'boardd_api_impl.pyx', LIBS=["can_list_to_can_capnp", 'capnp', 'kj'] + envCython["LIBS"])
 if GetOption('test'):
-  env.Program('tests/test_boardd_usbprotocol', ['tests/test_boardd_usbprotocol.cc', 'panda.cc', 'panda_comms.cc', 'spi.cc'], LIBS=libs)
+  env.Program('tests/test_boardd_usbprotocol', ['tests/test_boardd_usbprotocol.cc'], LIBS=[panda] + libs)


### PR DESCRIPTION
This warning appeared after https://github.com/commaai/openpilot/pull/27936

