### PR TITLE
cabana: make highlight fade time independent of playback speed

### DIFF
--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -13,7 +13,7 @@
 #include "tools/replay/replay.h"
 
 struct CanData {
-  void compute(const char *dat, const int size, double current_sec, uint32_t in_freq = 0);
+  void compute(const char *dat, const int size, double current_sec, double playback_speed, uint32_t in_freq = 0);
 
   double ts = 0.;
   uint32_t count = 0;
@@ -51,6 +51,7 @@ public:
   virtual VisionStreamType visionStreamType() const { return VISION_STREAM_ROAD; }
   virtual const Route *route() const { return nullptr; }
   virtual void setSpeed(float speed) {}
+  virtual double getSpeed() { return 1; }
   virtual bool isPaused() const { return false; }
   virtual void pause(bool pause) {}
   virtual const std::vector<Event*> *rawEvents() const { return nullptr; }

--- a/tools/cabana/streams/livestream.h
+++ b/tools/cabana/streams/livestream.h
@@ -11,6 +11,7 @@ public:
   inline double routeStartTime() const override { return start_ts / (double)1e9; }
   inline double currentSec() const override { return (current_ts - start_ts) / (double)1e9; }
   void setSpeed(float speed) override { speed_ = std::min<float>(1.0, speed); }
+  double getSpeed() override { return speed_; }
   bool isPaused() const override { return pause_; }
   void pause(bool pause) override;
 

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -21,6 +21,7 @@ public:
   inline QDateTime currentDateTime() const override { return replay->currentDateTime(); }
   inline const Route *route() const override { return replay->route(); }
   inline void setSpeed(float speed) override { replay->setSpeed(speed); }
+  inline float getSpeed() const { return replay->getSpeed(); }
   inline bool isPaused() const override { return replay->isPaused(); }
   void pause(bool pause) override;
   const std::vector<Event*> *rawEvents() const override { return replay->events(); }


### PR DESCRIPTION
At higher playback speed it's easy to miss single changes without this.