### PR TITLE
cabana: socketcan support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -282,7 +282,7 @@ Export('envCython')
 
 # Qt build environment
 qt_env = env.Clone()
-qt_modules = ["Widgets", "Gui", "Core", "Network", "Concurrent", "Multimedia", "Quick", "Qml", "QuickWidgets", "Location", "Positioning", "DBus", "Xml"]
+qt_modules = ["Widgets", "Gui", "Core", "Network", "Concurrent", "Multimedia", "Quick", "Qml", "QuickWidgets", "Location", "Positioning", "DBus", "Xml", "SerialBus"]
 
 qt_libs = []
 if arch == "Darwin":

--- a/SConstruct
+++ b/SConstruct
@@ -284,9 +284,6 @@ Export('envCython')
 qt_env = env.Clone()
 qt_modules = ["Widgets", "Gui", "Core", "Network", "Concurrent", "Multimedia", "Quick", "Qml", "QuickWidgets", "Location", "Positioning", "DBus", "Xml"]
 
-if arch != "larch64":
-  qt_modules += ["SerialBus"] # SocketCAN support
-
 qt_libs = []
 if arch == "Darwin":
   qt_env['QTDIR'] = f"{brew_prefix}/opt/qt@5"

--- a/SConstruct
+++ b/SConstruct
@@ -282,7 +282,10 @@ Export('envCython')
 
 # Qt build environment
 qt_env = env.Clone()
-qt_modules = ["Widgets", "Gui", "Core", "Network", "Concurrent", "Multimedia", "Quick", "Qml", "QuickWidgets", "Location", "Positioning", "DBus", "Xml", "SerialBus"]
+qt_modules = ["Widgets", "Gui", "Core", "Network", "Concurrent", "Multimedia", "Quick", "Qml", "QuickWidgets", "Location", "Positioning", "DBus", "Xml"]
+
+if arch != "larch64":
+  qt_modules += ["SerialBus"] # SocketCAN support
 
 qt_libs = []
 if arch == "Darwin":

--- a/tools/cabana/README.md
+++ b/tools/cabana/README.md
@@ -17,6 +17,7 @@ Options:
   --stream                       read can messages from live streaming
   --panda                        read can messages from panda
   --panda-serial <panda-serial>  read can messages from panda with given serial
+  --socketcan <socketcan>        read can messages from given SocketCAN device
   --zmq <zmq>                    the ip address on which to receive zmq
                                  messages
   --data_dir <data_dir>          local directory with routes

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -27,7 +27,7 @@ assets_src = "assets/assets.qrc"
 cabana_env.Command(assets, assets_src, f"rcc $SOURCES -o $TARGET")
 cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "assets/assets.o"]))
 
-cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
+cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/socketcanstream.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
                                                'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
                                                'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',
                                                'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'util.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -9,6 +9,7 @@ base_libs = [common, messaging, cereal, visionipc, transformations, 'zmq',
 if arch == "Darwin":
   base_frameworks.append('OpenCL')
   base_frameworks.append('QtCharts')
+  base_frameworks.append('QtSerialBus')
 else:
   base_libs.append('OpenCL')
   base_libs.append('Qt5Charts')

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -12,6 +12,7 @@ if arch == "Darwin":
 else:
   base_libs.append('OpenCL')
   base_libs.append('Qt5Charts')
+  base_libs.append('Qt5SerialBus')
 
 qt_libs = ['qt_util'] + base_libs
 

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -7,6 +7,7 @@
 #include "tools/cabana/streams/devicestream.h"
 #include "tools/cabana/streams/pandastream.h"
 #include "tools/cabana/streams/replaystream.h"
+#include "tools/cabana/streams/socketcanstream.h"
 
 int main(int argc, char *argv[]) {
   QCoreApplication::setApplicationName("Cabana");
@@ -28,6 +29,7 @@ int main(int argc, char *argv[]) {
   cmd_parser.addOption({"stream", "read can messages from live streaming"});
   cmd_parser.addOption({"panda", "read can messages from panda"});
   cmd_parser.addOption({"panda-serial", "read can messages from panda with given serial", "panda-serial"});
+  cmd_parser.addOption({"socketcan", "read can messages from given SocketCAN device", "socketcan"});
   cmd_parser.addOption({"zmq", "the ip address on which to receive zmq messages", "zmq"});
   cmd_parser.addOption({"data_dir", "local directory with routes", "data_dir"});
   cmd_parser.addOption({"no-vipc", "do not output video"});
@@ -50,6 +52,10 @@ int main(int argc, char *argv[]) {
       qWarning() << e.what();
       return 0;
     }
+  } else if (cmd_parser.isSet("socketcan")) {
+    SocketCanStreamConfig config = {};
+    config.device = cmd_parser.value("socketcan");
+    stream = new SocketCanStream(&app, config);
   } else {
     uint32_t replay_flags = REPLAY_FLAG_NONE;
     if (cmd_parser.isSet("ecam")) {

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -29,7 +29,9 @@ int main(int argc, char *argv[]) {
   cmd_parser.addOption({"stream", "read can messages from live streaming"});
   cmd_parser.addOption({"panda", "read can messages from panda"});
   cmd_parser.addOption({"panda-serial", "read can messages from panda with given serial", "panda-serial"});
-  cmd_parser.addOption({"socketcan", "read can messages from given SocketCAN device", "socketcan"});
+  if (SocketCanStream::available()) {
+    cmd_parser.addOption({"socketcan", "read can messages from given SocketCAN device", "socketcan"});
+  }
   cmd_parser.addOption({"zmq", "the ip address on which to receive zmq messages", "zmq"});
   cmd_parser.addOption({"data_dir", "local directory with routes", "data_dir"});
   cmd_parser.addOption({"no-vipc", "do not output video"});

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -34,6 +34,12 @@ struct CanEvent {
   uint8_t dat[];
 };
 
+struct BusConfig {
+  int can_speed_kbps = 500;
+  int data_speed_kbps = 2000;
+  bool can_fd = false;
+};
+
 class AbstractStream : public QObject {
   Q_OBJECT
 

--- a/tools/cabana/streams/pandastream.h
+++ b/tools/cabana/streams/pandastream.h
@@ -10,7 +10,6 @@
 const uint32_t speeds[] = {10U, 20U, 50U, 100U, 125U, 250U, 500U, 1000U};
 const uint32_t data_speeds[] = {10U, 20U, 50U, 100U, 125U, 250U, 500U, 1000U, 2000U, 5000U};
 
-
 struct PandaStreamConfig {
   QString serial = "";
   std::vector<BusConfig> bus_config;

--- a/tools/cabana/streams/pandastream.h
+++ b/tools/cabana/streams/pandastream.h
@@ -10,11 +10,6 @@
 const uint32_t speeds[] = {10U, 20U, 50U, 100U, 125U, 250U, 500U, 1000U};
 const uint32_t data_speeds[] = {10U, 20U, 50U, 100U, 125U, 250U, 500U, 1000U, 2000U, 5000U};
 
-struct BusConfig {
-  int can_speed_kbps = 500;
-  int data_speed_kbps = 2000;
-  bool can_fd = false;
-};
 
 struct PandaStreamConfig {
   QString serial = "";

--- a/tools/cabana/streams/socketcanstream.cc
+++ b/tools/cabana/streams/socketcanstream.cc
@@ -1,6 +1,10 @@
 #include "tools/cabana/streams/socketcanstream.h"
 
 SocketCanStream::SocketCanStream(QObject *parent, SocketCanStreamConfig config_) : config(config_), LiveStream(parent) {
+  if (!QCanBus::instance()->plugins().contains("socketcan")) {
+    throw std::runtime_error("SocketCAN plugin not available");
+  }
+
   qDebug() << "Connecting to SocketCAN device" << config.device;
   if (!connect()) {
     throw std::runtime_error("Failed to connect to SocketCAN device");
@@ -8,6 +12,21 @@ SocketCanStream::SocketCanStream(QObject *parent, SocketCanStreamConfig config_)
 }
 
 bool SocketCanStream::connect() {
+  // Connecting might generate some warnings about missing socketcan/libsocketcan libraries
+  // These are expected and can be ignored, we don't need the advanced features of libsocketcan
+  QString errorString;
+  device.reset(QCanBus::instance()->createDevice("socketcan", config.device, &errorString));
+
+  if (!device) {
+    qDebug() << "Failed to create SocketCAN device" << errorString;
+    return false;
+  }
+
+  if (!device->connectDevice()) {
+    qDebug() << "Failed to connect to device";
+    return false;
+  }
+
   return true;
 }
 
@@ -16,5 +35,25 @@ void SocketCanStream::streamThread() {
   while (!QThread::currentThread()->isInterruptionRequested()) {
     QThread::msleep(1);
 
+    auto frames = device->readAllFrames();
+    if (frames.size() == 0) continue;
+
+    MessageBuilder msg;
+    auto evt = msg.initEvent();
+    auto canData = evt.initCan(frames.size());
+
+
+    for (uint i = 0; i < frames.size(); i++) {
+      if (!frames[i].isValid()) continue;
+
+      canData[i].setAddress(frames[i].frameId());
+      canData[i].setSrc(0);
+
+      auto payload = frames[i].payload();
+      canData[i].setDat(kj::arrayPtr((uint8_t*)payload.data(), payload.size()));
+    }
+
+    auto bytes = msg.toBytes();
+    handleEvent((const char*)bytes.begin(), bytes.size());
   }
 }

--- a/tools/cabana/streams/socketcanstream.cc
+++ b/tools/cabana/streams/socketcanstream.cc
@@ -84,7 +84,7 @@ OpenSocketCanWidget::OpenSocketCanWidget(AbstractStream **stream) : AbstractOpen
   QPushButton *refresh = new QPushButton(tr("Refresh"));
   refresh->setFixedWidth(100);
   device_layout->addWidget(refresh);
-  form_layout->addRow(tr("Serial"), device_layout);
+  form_layout->addRow(tr("Device"), device_layout);
   main_layout->addLayout(form_layout);
 
   main_layout->addStretch(1);

--- a/tools/cabana/streams/socketcanstream.cc
+++ b/tools/cabana/streams/socketcanstream.cc
@@ -1,11 +1,12 @@
 #include "tools/cabana/streams/socketcanstream.h"
+#include "socketcanstream.h"
 
 #include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 
 SocketCanStream::SocketCanStream(QObject *parent, SocketCanStreamConfig config_) : config(config_), LiveStream(parent) {
-  if (!QCanBus::instance()->plugins().contains("socketcan")) {
+  if (!available()) {
     throw std::runtime_error("SocketCAN plugin not available");
   }
 
@@ -13,6 +14,10 @@ SocketCanStream::SocketCanStream(QObject *parent, SocketCanStreamConfig config_)
   if (!connect()) {
     throw std::runtime_error("Failed to connect to SocketCAN device");
   }
+}
+
+bool SocketCanStream::available() {
+  return QCanBus::instance()->plugins().contains("socketcan");
 }
 
 bool SocketCanStream::connect() {

--- a/tools/cabana/streams/socketcanstream.cc
+++ b/tools/cabana/streams/socketcanstream.cc
@@ -1,0 +1,20 @@
+#include "tools/cabana/streams/socketcanstream.h"
+
+SocketCanStream::SocketCanStream(QObject *parent, SocketCanStreamConfig config_) : config(config_), LiveStream(parent) {
+  qDebug() << "Connecting to SocketCAN device" << config.device;
+  if (!connect()) {
+    throw std::runtime_error("Failed to connect to SocketCAN device");
+  }
+}
+
+bool SocketCanStream::connect() {
+  return true;
+}
+
+void SocketCanStream::streamThread() {
+
+  while (!QThread::currentThread()->isInterruptionRequested()) {
+    QThread::msleep(1);
+
+  }
+}

--- a/tools/cabana/streams/socketcanstream.h
+++ b/tools/cabana/streams/socketcanstream.h
@@ -12,7 +12,6 @@
 
 struct SocketCanStreamConfig {
   QString device = ""; // TODO: support multiple devices/buses at once
-  std::vector<BusConfig> bus_config;
 };
 
 class SocketCanStream : public LiveStream {

--- a/tools/cabana/streams/socketcanstream.h
+++ b/tools/cabana/streams/socketcanstream.h
@@ -2,7 +2,11 @@
 
 #include <QtSerialBus/QCanBus>
 #include <QtSerialBus/QCanBusDevice>
-#include <QtSerialBus/QCanBusFrame>
+#include <QtSerialBus/QCanBusDeviceInfo>
+
+#include <QComboBox>
+#include <QFormLayout>
+#include <QVBoxLayout>
 
 #include "tools/cabana/streams/livestream.h"
 
@@ -15,6 +19,7 @@ class SocketCanStream : public LiveStream {
   Q_OBJECT
 public:
   SocketCanStream(QObject *parent, SocketCanStreamConfig config_ = {});
+  static AbstractOpenStreamWidget *widget(AbstractStream **stream);
 
   inline QString routeName() const override {
     return QString("Live Streaming From Socket CAN %1").arg(config.device);
@@ -26,4 +31,19 @@ protected:
 
   SocketCanStreamConfig config = {};
   std::unique_ptr<QCanBusDevice> device;
+};
+
+class OpenSocketCanWidget : public AbstractOpenStreamWidget {
+  Q_OBJECT
+
+public:
+  OpenSocketCanWidget(AbstractStream **stream);
+  bool open() override;
+  QString title() override { return tr("&SocketCAN"); }
+
+private:
+  void refreshDevices();
+
+  QComboBox *device_edit;
+  SocketCanStreamConfig config = {};
 };

--- a/tools/cabana/streams/socketcanstream.h
+++ b/tools/cabana/streams/socketcanstream.h
@@ -21,6 +21,8 @@ public:
   SocketCanStream(QObject *parent, SocketCanStreamConfig config_ = {});
   static AbstractOpenStreamWidget *widget(AbstractStream **stream);
 
+  static bool available();
+
   inline QString routeName() const override {
     return QString("Live Streaming From Socket CAN %1").arg(config.device);
   }

--- a/tools/cabana/streams/socketcanstream.h
+++ b/tools/cabana/streams/socketcanstream.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <QtSerialBus/QCanBus>
+#include <QtSerialBus/QCanBusDevice>
+#include <QtSerialBus/QCanBusFrame>
+
 #include "tools/cabana/streams/livestream.h"
 
 struct SocketCanStreamConfig {
-  QString device = "";
+  QString device = ""; // TODO: support multiple devices/buses at once
   std::vector<BusConfig> bus_config;
 };
 
@@ -21,4 +25,5 @@ protected:
   bool connect();
 
   SocketCanStreamConfig config = {};
+  std::unique_ptr<QCanBusDevice> device;
 };

--- a/tools/cabana/streams/socketcanstream.h
+++ b/tools/cabana/streams/socketcanstream.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "tools/cabana/streams/livestream.h"
+
+struct SocketCanStreamConfig {
+  QString device = "";
+  std::vector<BusConfig> bus_config;
+};
+
+class SocketCanStream : public LiveStream {
+  Q_OBJECT
+public:
+  SocketCanStream(QObject *parent, SocketCanStreamConfig config_ = {});
+
+  inline QString routeName() const override {
+    return QString("Live Streaming From Socket CAN %1").arg(config.device);
+  }
+
+protected:
+  void streamThread() override;
+  bool connect();
+
+  SocketCanStreamConfig config = {};
+};

--- a/tools/cabana/streamselector.cc
+++ b/tools/cabana/streamselector.cc
@@ -6,6 +6,7 @@
 #include <QLabel>
 #include <QPushButton>
 
+#include "streams/socketcanstream.h"
 #include "tools/cabana/streams/devicestream.h"
 #include "tools/cabana/streams/pandastream.h"
 #include "tools/cabana/streams/replaystream.h"
@@ -41,7 +42,9 @@ StreamSelector::StreamSelector(AbstractStream **stream, QWidget *parent) : QDial
 
   addStreamWidget(ReplayStream::widget(stream));
   addStreamWidget(PandaStream::widget(stream));
-  addStreamWidget(SocketCanStream::widget(stream));
+  if (SocketCanStream::available()) {
+    addStreamWidget(SocketCanStream::widget(stream));
+  }
   addStreamWidget(DeviceStream::widget(stream));
 
   QObject::connect(btn_box, &QDialogButtonBox::rejected, this, &QDialog::reject);

--- a/tools/cabana/streamselector.cc
+++ b/tools/cabana/streamselector.cc
@@ -9,6 +9,7 @@
 #include "tools/cabana/streams/devicestream.h"
 #include "tools/cabana/streams/pandastream.h"
 #include "tools/cabana/streams/replaystream.h"
+#include "tools/cabana/streams/socketcanstream.h"
 
 StreamSelector::StreamSelector(AbstractStream **stream, QWidget *parent) : QDialog(parent) {
   setWindowTitle(tr("Open stream"));
@@ -40,6 +41,7 @@ StreamSelector::StreamSelector(AbstractStream **stream, QWidget *parent) : QDial
 
   addStreamWidget(ReplayStream::widget(stream));
   addStreamWidget(PandaStream::widget(stream));
+  addStreamWidget(SocketCanStream::widget(stream));
   addStreamWidget(DeviceStream::widget(stream));
 
   QObject::connect(btn_box, &QDialogButtonBox::rejected, this, &QDialog::reject);

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -73,6 +73,7 @@ function install_ubuntu_common_requirements() {
     libqt5sql5-sqlite \
     libqt5svg5-dev \
     libqt5charts5-dev \
+    libqt5serialbus5-dev  \
     libqt5x11extras5-dev \
     libreadline-dev \
     libdw1 \


### PR DESCRIPTION
Test on a virtual socketcan device using.
```bash
sudo modprobe vcan
sudo ip link add dev vcan0 type vcan
sudo ip link set up vcan0
cangen vcan0 -g 1 -L 8 # Generate some fake data
```

Start cabana using `./cabana --socketcan vcan0` or use open stream dialog.


![2023-08-23-070822_613x280_scrot](https://github.com/commaai/openpilot/assets/1314752/ef9e0e47-9ad5-4305-929c-473844c1d32b)
