### PR TITLE
navd: fix scons warning ""Two different environments were specified"

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -238,6 +238,7 @@ if GetOption('compile_db'):
 cache_dir = '/data/scons_cache' if AGNOS else '/tmp/scons_cache'
 CacheDir(cache_dir)
 Clean(["."], cache_dir)
+Export('cache_dir')
 
 node_interval = 5
 node_count = 0

--- a/selfdrive/navd/SConscript
+++ b/selfdrive/navd/SConscript
@@ -1,4 +1,4 @@
-Import('qt_env', 'arch', 'common', 'messaging', 'visionipc', 'cereal', 'transformations')
+Import('qt_env', 'arch', 'cache_dir', 'common', 'messaging', 'visionipc', 'cereal', 'transformations')
 
 base_libs = [common, messaging, cereal, visionipc, transformations, 'zmq',
              'capnp', 'kj', 'm', 'OpenCL', 'ssl', 'crypto', 'pthread'] + qt_env["LIBS"]
@@ -18,4 +18,6 @@ if arch in ['larch64', 'x86_64']:
   nav_src = ["main.cc", "map_renderer.cc"]
   qt_env.Program("map_renderer", nav_src, LIBS=qt_libs + ['common', 'json11'])
 
-  qt_env.SharedLibrary("map_renderer", ["map_renderer.cc"], LIBS=qt_libs + ['common', 'messaging'])
+  shared_env = qt_env.Clone()
+  shared_env['QT_MOCHPREFIX'] = cache_dir + '/moc_files/moc_shared_'
+  shared_env.SharedLibrary("map_renderer", ['map_renderer.cc'], LIBS=qt_libs + ['common', 'messaging'])


### PR DESCRIPTION
fixed scons warning:

`scons: warning: Two different environments were specified for target /tmp/scons_cache/moc_files/moc_map_renderer.cc,`
