### PR TITLE
ecu addrs: check msg length

### DIFF
--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -55,6 +55,9 @@ def get_ecu_addrs(logcan: messaging.SubSocket, sendcan: messaging.PubSocket, que
       can_packets = messaging.drain_sock(logcan, wait_for_one=True)
       for packet in can_packets:
         for msg in packet.can:
+          if not len(msg.dat):
+            continue
+
           subaddr = None if (msg.address, None, msg.src) in responses else msg.dat[0]
           if (msg.address, subaddr, msg.src) in responses and is_tester_present_response(msg, subaddr):
             if debug:


### PR DESCRIPTION
Looks like this was hit once while testing on a branch, good to catch though. Needed for https://github.com/commaai/openpilot/pull/27697 to not regress fingerprinting if a remote frame happens to be on the bus