### PR TITLE
ecu addrs: add warning when skipping remote frame

### DIFF
--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -56,6 +56,7 @@ def get_ecu_addrs(logcan: messaging.SubSocket, sendcan: messaging.PubSocket, que
       for packet in can_packets:
         for msg in packet.can:
           if not len(msg.dat):
+            cloudlog.warning("ECU addr scan: skipping empty remote frame")
             continue
 
           subaddr = None if (msg.address, None, msg.src) in responses else msg.dat[0]


### PR DESCRIPTION
not too concerned with having this in the qlog, so a warning is fine