### PR TITLE
is_tester_present: don't assert length 8

### DIFF
--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -22,15 +22,15 @@ def make_tester_present_msg(addr, bus, subaddr=None):
 
 
 def is_tester_present_response(msg: capnp.lib.capnp._DynamicStructReader, subaddr: Optional[int] = None) -> bool:
-  # ISO-TP messages are always padded to 8 bytes
   # tester present response is always a single frame
   dat_offset = 1 if subaddr is not None else 0
-  if len(msg.dat) == 8 and 1 <= msg.dat[dat_offset] <= 7:
+  if 1 <= msg.dat[dat_offset] <= 7:
     # success response
-    if msg.dat[dat_offset + 1] == (SERVICE_TYPE.TESTER_PRESENT + 0x40):
+    if len(msg.dat) > dat_offset + 1 and msg.dat[dat_offset + 1] == (SERVICE_TYPE.TESTER_PRESENT + 0x40):
       return True
     # error response
-    if msg.dat[dat_offset + 1] == 0x7F and msg.dat[dat_offset + 2] == SERVICE_TYPE.TESTER_PRESENT:
+    if len(msg.dat) > dat_offset + 2 and msg.dat[dat_offset + 1] == 0x7F and \
+      msg.dat[dat_offset + 2] == SERVICE_TYPE.TESTER_PRESENT:
       return True
   return False
 


### PR DESCRIPTION
CAN frame data optimization may be performed on single frames, flow control, and last consecutive frames.

- [ ] clean up and integrate with panda uds library fixes (also asserts the same thing)

a case this would fix: https://github.com/commaai/openpilot/pull/27760