### PR TITLE
cabana: reduce the number of ticks on the Y-axis

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -331,7 +331,7 @@ void ChartView::updateAxisY() {
   }
 
   double delta = std::abs(max - min) < 1e-3 ? 1 : (max - min) * 0.05;
-  auto [min_y, max_y, tick_count] = getNiceAxisNumbers(min - delta, max + delta, axis_y->tickCount());
+  auto [min_y, max_y, tick_count] = getNiceAxisNumbers(min - delta, max + delta, 3);
   if (min_y != axis_y->min() || max_y != axis_y->max() || y_label_width == 0) {
     axis_y->setRange(min_y, max_y);
     axis_y->setTickCount(tick_count);


### PR DESCRIPTION
reduce the `tickCout` of Y-axis to avoid the labels are elided due to insufficient height caused by too many ticks.

before
![Screenshot from 2023-04-19 12-53-27](https://user-images.githubusercontent.com/27770/232971539-e88f850b-087d-4470-bd72-da232d527a71.png)
after
![Screenshot from 2023-04-19 12-56-37](https://user-images.githubusercontent.com/27770/232971530-d9b1d30a-4ae6-45e2-98e0-56bdd125d404.png)

