### PR TITLE
cabana: enable Hi-DPI support on MacOS

### DIFF
--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -110,7 +110,7 @@ void sigTermHandler(int s) {
   qApp->quit();
 }
 
-void initApp(int argc, char *argv[]) {
+void initApp(int argc, char *argv[], bool disable_hidpi) {
   Hardware::set_display_power(true);
   Hardware::set_brightness(65);
 
@@ -118,13 +118,13 @@ void initApp(int argc, char *argv[]) {
   std::signal(SIGINT, sigTermHandler);
   std::signal(SIGTERM, sigTermHandler);
 
+  if (disable_hidpi) {
 #ifdef __APPLE__
-  {
     // Get the devicePixelRatio, and scale accordingly to maintain 1:1 rendering
     QApplication tmp(argc, argv);
     qputenv("QT_SCALE_FACTOR", QString::number(1.0 / tmp.devicePixelRatio() ).toLocal8Bit());
-  }
 #endif
+  }
 
   setQtSurfaceFormat();
 }

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -19,7 +19,7 @@ void clearLayout(QLayout* layout);
 void setQtSurfaceFormat();
 QString timeAgo(const QDateTime &date);
 void swagLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
-void initApp(int argc, char *argv[]);
+void initApp(int argc, char *argv[], bool disable_hidpi = true);
 QWidget* topWidget (QWidget* widget);
 QPixmap loadPixmap(const QString &fileName, const QSize &size = {}, Qt::AspectRatioMode aspectRatioMode = Qt::KeepAspectRatio);
 QPixmap bootstrapPixmap(const QString &id);

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -12,7 +12,7 @@
 int main(int argc, char *argv[]) {
   QCoreApplication::setApplicationName("Cabana");
   QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-  initApp(argc, argv);
+  initApp(argc, argv, false);
   QApplication app(argc, argv);
   app.setApplicationDisplayName("Cabana");
   app.setWindowIcon(QIcon(":cabana-icon.png"));


### PR DESCRIPTION
Hi-DPI support was disabled on MacOS to make the openpilot ui fit on a macbook screen by rendering at 0.5x scale. Disable this code path for cabana otherwise everything looks very small.

After this change the video is 2x too small, but that will be fixed in https://github.com/commaai/openpilot/pull/27941