### PR TITLE
cabana: refactor the cache for CAN events

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -260,7 +260,9 @@ void ChartView::updateSeries(const cabana::Signal *sig) {
       s.series->setColor(getColor(s.sig));
 
       const auto &msgs = can->events().at(s.msg_id);
-      auto first = std::upper_bound(msgs.cbegin(), msgs.cend(), CanEvent{.mono_time = s.last_value_mono_time});
+      auto first = std::upper_bound(msgs.cbegin(), msgs.cend(), s.last_value_mono_time, [](uint64_t ts, auto e) {
+        return ts < e->mono_time;
+      });
       int new_size = std::max<int>(s.vals.size() + std::distance(first, msgs.cend()), settings.max_cached_minutes * 60 * 100);
       if (s.vals.capacity() <= new_size) {
         s.vals.reserve(new_size * 2);
@@ -269,14 +271,15 @@ void ChartView::updateSeries(const cabana::Signal *sig) {
 
       const double route_start_time = can->routeStartTime();
       for (auto end = msgs.cend(); first != end; ++first) {
-        double value = get_raw_value(first->dat, first->size, *s.sig);
-        double ts = first->mono_time / 1e9 - route_start_time;  // seconds
+        const CanEvent *e = *first;
+        double value = get_raw_value(e->dat, e->size, *s.sig);
+        double ts = e->mono_time / 1e9 - route_start_time;  // seconds
         s.vals.append({ts, value});
         if (!s.step_vals.empty()) {
           s.step_vals.append({ts, s.step_vals.back().y()});
         }
         s.step_vals.append({ts, value});
-        s.last_value_mono_time = first->mono_time;
+        s.last_value_mono_time = e->mono_time;
       }
       if (!can->liveStreaming()) {
         s.segment_tree.build(s.vals);


### PR DESCRIPTION
Use a variable-length array to cache events in contiguous memory blocks.
```
struct CanEvent {
  uint64_t mono_time;
  uint8_t size;
  uint8_t dat[];
};
```

Compared to the previous non-contiguous fixed 64-bytes cache, it can automatically expand or shrink as needed, reducing resource waste (Non-CAN FD data can reduce the cache space by a factor of 8) , storing data in contiguous memory blocks can improve data access efficiency too.

This is also a prerequisite for implementing seeking and zooming in live stream mode.
