### PR TITLE
cabana: fix shadowed variable in abstractstream.cc

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -69,15 +69,15 @@ void AbstractStream::updateLastMsgsTo(double sec) {
   last_msgs.clear();
 
   uint64_t last_ts = (sec + routeStartTime()) * 1e9;
-  for (auto &[id, e] : events_) {
-    auto it = std::lower_bound(e.crbegin(), e.crend(), last_ts, [](auto e, uint64_t ts) {
+  for (auto &[id, ev] : events_) {
+    auto it = std::lower_bound(ev.crbegin(), ev.crend(), last_ts, [](auto e, uint64_t ts) {
       return e->mono_time > ts;
     });
-    if (it != e.crend()) {
+    if (it != ev.crend()) {
       double ts = (*it)->mono_time / 1e9 - routeStartTime();
       auto &m = all_msgs[id];
       m.compute((const char *)(*it)->dat, (*it)->size, ts, getSpeed());
-      m.count = std::distance(it, e.crend());
+      m.count = std::distance(it, ev.crend());
       m.freq = m.count / std::max(1.0, ts);
     }
   }


### PR DESCRIPTION
I don't mind making these PRs, but maybe we should set up some CI with a more recent clang than the one from ubuntu 20.04 to catch this. It happens to me on MacOS and on arch linux with latest clang. Maybe we can catch it too with an Ubuntu 22.04 build?