### PR TITLE
cabana:  fixed incorrect comparison 

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -124,7 +124,9 @@ void AbstractStream::mergeEvents(std::vector<Event *>::const_iterator first, std
     parseEvents(new_events, first, last);
     for (auto &[id, new_e] : new_events) {
       auto &e = events_[id];
-      auto it = std::upper_bound(e.cbegin(), e.cend(), new_e.front());
+      auto it = std::upper_bound(e.cbegin(), e.cend(), new_e.front(), [](const CanEvent *l, const CanEvent *r) {
+        return l->mono_time < r->mono_time;
+      });
       e.insert(it, new_e.cbegin(), new_e.cend());
     }
   }


### PR DESCRIPTION
Fix the error of using default comparison to comparing pointers instead of comparing the pointed mono_time .

this bug will occur when launching Cabana from a specified segment.  it results in incorrect event sorting.

for example, start cabana from the segment 5:

`./cabana "4cf7a6ad03080c90|2021-09-29--13-46-36--5"`
![2023-04-23_23-49](https://user-images.githubusercontent.com/27770/233850189-d5e74dce-6dd7-4307-9603-cb9274ebfb25.png)

