### PR TITLE
cabana: fix segfault in AbstractStream::mergeEvents when no can events in stream 

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -130,7 +130,7 @@ void AbstractStream::mergeEvents(std::vector<Event *>::const_iterator first, std
       e.insert(it, new_e.cbegin(), new_e.cend());
     }
   }
-  total_sec = (all_events_.back()->mono_time - all_events_.front()->mono_time) / 1e9;
+  total_sec = !all_events_.empty() ? ((all_events_.back()->mono_time - all_events_.front()->mono_time) / 1e9) : 0;
   emit eventsMerged();
 }
 


### PR DESCRIPTION
this is a new bug introduced by https://github.com/commaai/openpilot/pull/27994
it occurs when the route contains only qlog and there are no can events inside it. or the size of the `CanData` list in the CAN message is 0, after `Panda::can_receive` return true when no messages are received from panda. (this segfault may only happen at the moment when Cabana is just started.)

@adeebshihadeh : do we need to return false if (recv <= 0) in `Panda::can_receive`?
https://github.com/commaai/openpilot/blob/1016c3f97c9e710c75380249da29c89b0e7ca8e1/selfdrive/boardd/panda.cc#L248

Or check the size of raw_can_data in `can_recv_thread`, if it is 0, do not send the empty can message?
https://github.com/commaai/openpilot/blob/bda33a942f176f329c9a86e405b28593dfde05d6/selfdrive/boardd/boardd.cc#L257-L267