### PR TITLE
Subaru: fix forwarded signal name

### DIFF
--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -258,7 +258,7 @@ class CarState(CarStateBase):
         ("LKAS_State_Msg", "ES_DashStatus"),
         ("Signal2", "ES_DashStatus"),
         ("Cruise_Soft_Disable", "ES_DashStatus"),
-        ("EyeSight_Status_Msg", "ES_DashStatus"),
+        ("Cruise_Status_Msg", "ES_DashStatus"),
         ("Signal3", "ES_DashStatus"),
         ("Cruise_Distance", "ES_DashStatus"),
         ("Signal4", "ES_DashStatus"),


### PR DESCRIPTION
wrong name from https://github.com/commaai/openpilot/pull/25248, after https://github.com/commaai/openpilot/pull/27773 and https://github.com/commaai/openpilot/pull/28020 this would have thrown an exception