### PR TITLE
cabana: hide/show columns using context menu

### DIFF
--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -2,8 +2,10 @@
 
 #include <QAbstractTableModel>
 #include <QCheckBox>
+#include <QContextMenuEvent>
 #include <QHeaderView>
 #include <QLineEdit>
+#include <QMenu>
 #include <QSet>
 #include <QTreeView>
 
@@ -43,6 +45,7 @@ public:
   void drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const override {}
   void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>()) override;
   void updateBytesSectionSize();
+  void headerContextMenuEvent(const QPoint &pos);
 };
 
 class MessagesWidget : public QWidget {


### PR DESCRIPTION
 - Order of context menu follows when rearranging columns
 - Hide/Show state already saved by `restoreHeaderState`
 - Column that was clicked on is made bold

![Screenshot 2023-04-26 at 10 50 27](https://user-images.githubusercontent.com/1314752/234522952-e0e05f8b-5baf-4feb-a894-fc965b837dd0.png)
