### PR TITLE
cabana: add filter per column

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -44,7 +44,6 @@ MainWindow::MainWindow() : QMainWindow() {
   qRegisterMetaType<uint64_t>("uint64_t");
   qRegisterMetaType<SourceSet>("SourceSet");
   qRegisterMetaType<ReplyMsgType>("ReplyMsgType");
-
   installMessageHandler([this](ReplyMsgType type, const std::string msg) {
     // use queued connection to recv the log messages from replay.
     emit showMessage(QString::fromStdString(msg), 2000);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -44,6 +44,7 @@ MainWindow::MainWindow() : QMainWindow() {
   qRegisterMetaType<uint64_t>("uint64_t");
   qRegisterMetaType<SourceSet>("SourceSet");
   qRegisterMetaType<ReplyMsgType>("ReplyMsgType");
+
   installMessageHandler([this](ReplyMsgType type, const std::string msg) {
     // use queued connection to recv the log messages from replay.
     emit showMessage(QString::fromStdString(msg), 2000);

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -180,34 +180,34 @@ void MessageListModel::setFilterStrings(const QMap<int, QString> &filters) {
   fetchData();
 }
 
-void MessageListModel::sortMessages(QList<MessageId> &new_msgs) {
+void MessageListModel::sortMessages(Qt::SortOrder sort_order, int sort_column, QList<MessageId> &new_msgs) {
   // QList<MessageId> new_msgs = msgs;
   if (sort_column == Column::NAME) {
-    std::sort(new_msgs.begin(), new_msgs.end(), [this](auto &l, auto &r) {
+    std::sort(new_msgs.begin(), new_msgs.end(), [=](auto &l, auto &r) {
       auto ll = std::pair{msgName(l), l};
       auto rr = std::pair{msgName(r), r};
       return sort_order == Qt::AscendingOrder ? ll < rr : ll > rr;
     });
   } else if (sort_column == Column::SOURCE) {
-    std::sort(new_msgs.begin(), new_msgs.end(), [this](auto &l, auto &r) {
+    std::sort(new_msgs.begin(), new_msgs.end(), [=](auto &l, auto &r) {
       auto ll = std::pair{l.source, l};
       auto rr = std::pair{r.source, r};
       return sort_order == Qt::AscendingOrder ? ll < rr : ll > rr;
     });
   } else if (sort_column == Column::ADDRESS) {
-    std::sort(new_msgs.begin(), new_msgs.end(), [this](auto &l, auto &r) {
+    std::sort(new_msgs.begin(), new_msgs.end(), [=](auto &l, auto &r) {
       auto ll = std::pair{l.address, l};
       auto rr = std::pair{r.address, r};
       return sort_order == Qt::AscendingOrder ? ll < rr : ll > rr;
     });
   } else if (sort_column == Column::FREQ) {
-    std::sort(new_msgs.begin(), new_msgs.end(), [this](auto &l, auto &r) {
+    std::sort(new_msgs.begin(), new_msgs.end(), [=](auto &l, auto &r) {
       auto ll = std::pair{can->lastMessage(l).freq, l};
       auto rr = std::pair{can->lastMessage(r).freq, r};
       return sort_order == Qt::AscendingOrder ? ll < rr : ll > rr;
     });
   } else if (sort_column == Column::COUNT) {
-    std::sort(new_msgs.begin(), new_msgs.end(), [this](auto &l, auto &r) {
+    std::sort(new_msgs.begin(), new_msgs.end(), [=](auto &l, auto &r) {
       auto ll = std::pair{can->lastMessage(l).count, l};
       auto rr = std::pair{can->lastMessage(r).count, r};
       return sort_order == Qt::AscendingOrder ? ll < rr : ll > rr;
@@ -271,7 +271,7 @@ void MessageListModel::fetchData() {
       new_msgs.push_back(it.key());
     }
   }
-  sortMessages(new_msgs);
+  sortMessages(sort_order, sort_column, new_msgs);
 
   if (msgs != new_msgs) {
     beginResetModel();

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -191,11 +191,6 @@ QVariant MessageListModel::data(const QModelIndex &index, int role) const {
     }
     return QVariant::fromValue(colors);
   } else if (role == BytesRole && index.column() == Column::DATA) {
-    if (QSet<int>({1, 3, 6, 7}).contains(index.row())) {
-      QByteArray dat(64, 0);
-      memcpy(dat.data(), can_data.dat.data(), can_data.dat.size());
-      return dat;
-    }
     return can_data.dat;
   }
   return {};

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -27,9 +27,7 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
 
   // Must be called before setting any header parameters to avoid overriding
   restoreHeaderState(settings.message_header_state);
-
   view->header()->setSectionsMovable(true);
-  view->header()->setStretchLastSection(true);
 
   // Header context menu
   view->header()->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -56,7 +54,9 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
     settings.multiple_lines_bytes = (state == Qt::Checked);
     delegate->setMultipleLines(settings.multiple_lines_bytes);
     view->setUniformRowHeights(!settings.multiple_lines_bytes);
-    model->fetchData(); // Why?
+
+    // Reset model to force recalculation of the width of the bytes column
+    model->forceResetModel();
   });
   QObject::connect(can, &AbstractStream::msgsReceived, model, &MessageListModel::msgsReceived);
   QObject::connect(can, &AbstractStream::streamStarted, this, &MessagesWidget::reset);
@@ -336,6 +336,11 @@ void MessageListModel::reset() {
   filter_str.clear();
   msgs.clear();
   clearSuppress();
+  endResetModel();
+}
+
+void MessageListModel::forceResetModel() {
+  beginResetModel();
   endResetModel();
 }
 

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -23,10 +23,11 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
   view->setItemsExpandable(false);
   view->setIndentation(0);
   view->setRootIsDecorated(false);
+  view->setHeader(header);
+
   // Must be called before setting any header parameters to avoid overriding
   restoreHeaderState(settings.message_header_state);
 
-  view->setHeader(header);
   view->header()->setSectionsMovable(true);
   view->header()->setStretchLastSection(true);
 

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -261,7 +261,7 @@ bool MessageListModel::matchMessage(const MessageId &id, const CanData &data, QM
           bool data_match = false;
           data_match |= QString(data.dat.toHex()).contains(txt, cs);
 
-          QRegularExpression re(txt);
+          QRegularExpression re(txt, QRegularExpression::CaseInsensitiveOption | QRegularExpression::DotMatchesEverythingOption);
           if (re.isValid()) {
             data_match |= re.match(QString(data.dat.toHex())).hasMatch();
             data_match |= re.match(QString(data.dat.toHex(' '))).hasMatch();

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -99,9 +99,9 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
 }
 
 void MessagesWidget::selectMessage(const MessageId &msg_id) {
-  // if (int row = model->msgs.indexOf(msg_id); row != -1) {
-  //   view->selectionModel()->setCurrentIndex(model->index(row, 0), QItemSelectionModel::Rows | QItemSelectionModel::ClearAndSelect);
-  // }
+  if (int row = model->msgs.indexOf(msg_id); row != -1) {
+    view->selectionModel()->setCurrentIndex(model->index(row, 0), QItemSelectionModel::Rows | QItemSelectionModel::ClearAndSelect);
+  }
 }
 
 void MessagesWidget::updateSuppressedButtons() {

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -281,16 +281,8 @@ void MessageListModel::fetchData() {
 }
 
 void MessageListModel::msgsReceived(const QHash<MessageId, CanData> *new_msgs) {
-  // int prev_row_count = msgs.size();
   QList<MessageId> prev_msgs = msgs;
   fetchData();
-
-
-  for (int i = 0; i < msgs.size(); ++i) {
-    if (i >= prev_msgs.size() || msgs[i] != prev_msgs[i]) {
-      emit dataChanged(index(i, Column::NAME), index(i, Column::DATA), {Qt::DisplayRole});
-    }
-  }
 
   for (int i = 0; i < msgs.size(); ++i) {
     if (new_msgs->contains(msgs[i])) {

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -475,9 +475,7 @@ void MessageView::headerContextMenuEvent(const QPoint &pos) {
 MessageViewHeader::MessageViewHeader(QWidget *parent, MessageListModel *model) : model(model), QHeaderView(Qt::Horizontal, parent) {
   QObject::connect(this, &QHeaderView::sectionResized, this, &MessageViewHeader::handleSectionResized);
   QObject::connect(this, &QHeaderView::sectionMoved, this, &MessageViewHeader::handleSectionMoved);
-
-    // TODO: handle hiding columns
-    // TODO: handle horizontal scrolling
+  // TODO: handle horizontal scrolling
 }
 
 void MessageViewHeader::showEvent(QShowEvent *e) {
@@ -530,6 +528,7 @@ void MessageViewHeader::updateHeaderPositions() {
       int h = editors[i]->sizeHint().height();
       editors[i]->move(sectionViewportPosition(i), sz.height());
       editors[i]->resize(sectionSize(i), h);
+      editors[i]->setHidden(isSectionHidden(i));
     }
   }
 }

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -216,7 +216,7 @@ void MessageListModel::sortMessages(Qt::SortOrder sort_order, int sort_column, Q
 }
 
 static std::pair<unsigned int, unsigned int> parseRange(QString &filter, bool *ok = nullptr, int base = 10) {
-  // Parse out filter string into a range (e.g. "1-3" -> {1, 3}, "1-" -> {1, inf})
+  // Parse out filter string into a range (e.g. "1" -> {1, 1}, "1-3" -> {1, 3}, "1-" -> {1, inf})
   bool ok1 = true, ok2 = true;
   unsigned int parsed1 = std::numeric_limits<unsigned int>::min();
   unsigned int parsed2 = std::numeric_limits<unsigned int>::max();

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -58,7 +58,6 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
   main_layout->addLayout(suppress_layout);
 
   // signals/slots
-
   QObject::connect(header, &MessageViewHeader::filtersUpdated, model, &MessageListModel::setFilterStrings);
   QObject::connect(view->horizontalScrollBar(), &QScrollBar::valueChanged, header, &MessageViewHeader::updateHeaderPositions);
   QObject::connect(clear_filters, &QPushButton::clicked, header, &MessageViewHeader::clearFilters);

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -43,6 +43,8 @@ public:
 
 private:
   void sortMessages(QList<MessageId> &new_msgs);
+  static bool matchMessage(const MessageId &id, const CanData &data, QMap<int, QString> &filters);
+
   QMap<int, QString> filter_str;
   int sort_column = 0;
   Qt::SortOrder sort_order = Qt::AscendingOrder;

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -70,8 +70,6 @@ class MessageViewHeader : public QHeaderView {
 public:
   MessageViewHeader(QWidget *parent, MessageListModel *model);
   void showEvent(QShowEvent *e) override;
-  void handleSectionResized(int logicalIndex, int oldSize, int newSize);
-  void handleSectionMoved(int logicalIndex, int oldVisualIndex, int newVisualIndex);
   void updateHeaderPositions();
 
   void updateGeometries() override;

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -34,7 +34,7 @@ public:
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
   void setFilterStrings(const QMap<int, QString> &filters);
   void msgsReceived(const QHash<MessageId, CanData> *new_msgs = nullptr);
-  void sortMessages();
+  void fetchData();
   void suppress();
   void clearSuppress();
   void reset();
@@ -42,6 +42,7 @@ public:
   QSet<std::pair<MessageId, int>> suppressed_bytes;
 
 private:
+  void sortMessages(QList<MessageId> &new_msgs);
   QMap<int, QString> filter_str;
   int sort_column = 0;
   Qt::SortOrder sort_order = Qt::AscendingOrder;

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -32,7 +32,7 @@ public:
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return msgs.size(); }
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
-  void setFilterString(const QString &string);
+  void setFilterStrings(const QMap<int, QString> &filters);
   void msgsReceived(const QHash<MessageId, CanData> *new_msgs = nullptr);
   void sortMessages();
   void suppress();
@@ -42,7 +42,7 @@ public:
   QSet<std::pair<MessageId, int>> suppressed_bytes;
 
 private:
-  QString filter_str;
+  QMap<int, QString> filter_str;
   int sort_column = 0;
   Qt::SortOrder sort_order = Qt::AscendingOrder;
 };
@@ -72,7 +72,12 @@ public:
   void updateGeometries() override;
   QSize sizeHint() const override;
 
+signals:
+  void filtersUpdated(const QMap<int, QString> &filters);
+
 private:
+  void updateFilters();
+
   QMap<int, QLineEdit *> editors;
   QMap<int, QSet<QString>> values;
   MessageListModel *model;
@@ -96,7 +101,6 @@ protected:
   MessageView *view;
   MessageViewHeader *header;
   std::optional<MessageId> current_msg_id;
-  QLineEdit *filter;
   QCheckBox *multiple_lines_bytes;
   MessageListModel *model;
   QPushButton *suppress_add;

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -42,7 +42,7 @@ public:
   QSet<std::pair<MessageId, int>> suppressed_bytes;
 
 private:
-  void sortMessages(QList<MessageId> &new_msgs);
+  static void sortMessages(Qt::SortOrder sort_order, int sort_column, QList<MessageId> &new_msgs);
   static bool matchMessage(const MessageId &id, const CanData &data, QMap<int, QString> &filters);
 
   QMap<int, QString> filter_str;

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -4,6 +4,7 @@
 #include <QCheckBox>
 #include <QContextMenuEvent>
 #include <QHeaderView>
+#include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
 #include <QSet>
@@ -76,6 +77,9 @@ public:
   void updateGeometries() override;
   QSize sizeHint() const override;
 
+public slots:
+  void clearFilters();
+
 signals:
   void filtersUpdated(const QMap<int, QString> &filters);
 
@@ -98,6 +102,9 @@ public:
   void updateSuppressedButtons();
   void reset();
 
+public slots:
+  void dbcModified();
+
 signals:
   void msgSelectionChanged(const MessageId &message_id);
 
@@ -109,4 +116,5 @@ protected:
   MessageListModel *model;
   QPushButton *suppress_add;
   QPushButton *suppress_clear;
+  QLabel *num_msg_label;
 };

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -38,6 +38,7 @@ public:
   void suppress();
   void clearSuppress();
   void reset();
+  void forceResetModel();
   QList<MessageId> msgs;
   QSet<std::pair<MessageId, int>> suppressed_bytes;
 

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -16,9 +16,19 @@ class MessageListModel : public QAbstractTableModel {
 Q_OBJECT
 
 public:
+
+  enum Column {
+    NAME = 0,
+    SOURCE,
+    ADDRESS,
+    FREQ,
+    COUNT,
+    DATA,
+  };
+
   MessageListModel(QObject *parent) : QAbstractTableModel(parent) {}
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return 6; }
+  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return Column::DATA + 1; }
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return msgs.size(); }
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
@@ -48,6 +58,26 @@ public:
   void headerContextMenuEvent(const QPoint &pos);
 };
 
+class MessageViewHeader : public QHeaderView {
+  // https://stackoverflow.com/a/44346317
+
+  Q_OBJECT
+public:
+  MessageViewHeader(QWidget *parent, MessageListModel *model);
+  void showEvent(QShowEvent *e) override;
+  void handleSectionResized(int logicalIndex, int oldSize, int newSize);
+  void handleSectionMoved(int logicalIndex, int oldVisualIndex, int newVisualIndex);
+  void updateHeaderPositions();
+
+  void updateGeometries() override;
+  QSize sizeHint() const override;
+
+private:
+  QMap<int, QLineEdit *> editors;
+  QMap<int, QSet<QString>> values;
+  MessageListModel *model;
+};
+
 class MessagesWidget : public QWidget {
   Q_OBJECT
 
@@ -64,6 +94,7 @@ signals:
 
 protected:
   MessageView *view;
+  MessageViewHeader *header;
   std::optional<MessageId> current_msg_id;
   QLineEdit *filter;
   QCheckBox *multiple_lines_bytes;


### PR DESCRIPTION
![Screenshot 2023-05-04 at 10 33 22](https://user-images.githubusercontent.com/1314752/236152471-4dd8f59a-9cb9-47db-9e9e-a890df4a5b7d.png)
![Screenshot 2023-05-04 at 10 33 37](https://user-images.githubusercontent.com/1314752/236152467-9a4a7120-9e28-45bb-bc41-c9cb68cf2cd0.png)


- [x] Change top header to contain msg/signal count, clear all filters and multiple lines checkbox
- [x] Test behavior during horizontal scrolling
- [x] Test behavior with hidden columns
- [x] Add range/wildcard filtering for numbers (e.g. 100-200, 100-)
- [x] Add regex filter
- [x] Re-evaluate filters when new data comes in (needed for count, frequency and data)