### PR TITLE
cabana: display current time & values in chart

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -18,6 +18,8 @@
 
 #include "tools/cabana/chart/chartswidget.h"
 
+// ChartAxisElement's padding is 4 (https://codebrowser.dev/qt5/qtcharts/src/charts/axis/chartaxiselement_p.h.html)
+const int AXIS_X_TOP_MARGIN = 4;
 static inline bool xLessThan(const QPointF &p, float x) { return p.x() < x; }
 
 ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent) : charts_widget(parent), tip_label(this), QChartView(nullptr, parent) {
@@ -686,8 +688,7 @@ void ChartView::drawForeground(QPainter *painter, const QRectF &rect) {
     auto rubber_rect = rubber->geometry().normalized();
     for (const auto &pt : {rubber_rect.bottomLeft(), rubber_rect.bottomRight()}) {
       QString sec = QString::number(chart()->mapToValue(pt).x(), 'f', 1);
-      // ChartAxisElement's padding is 4 (https://codebrowser.dev/qt5/qtcharts/src/charts/axis/chartaxiselement_p.h.html)
-      auto r = painter->fontMetrics().boundingRect(sec).adjusted(-6, -4, 6, 4);
+      auto r = painter->fontMetrics().boundingRect(sec).adjusted(-6, -AXIS_X_TOP_MARGIN, 6, AXIS_X_TOP_MARGIN);
       pt == rubber_rect.bottomLeft() ? r.moveTopRight(pt + QPoint{0, 2}) : r.moveTopLeft(pt + QPoint{0, 2});
       painter->fillRect(r, Qt::gray);
       painter->drawText(r, Qt::AlignCenter, sec);
@@ -700,12 +701,12 @@ void ChartView::drawTimeline(QPainter *painter) {
   // draw line
   qreal x = std::clamp(chart()->mapToPosition(QPointF{cur_sec, 0}).x(), plot_area.left(), plot_area.right());
   painter->setPen(QPen(chart()->titleBrush().color(), 2));
-  painter->drawLine(QPointF{x, plot_area.top()}, QPointF{x, plot_area.bottom()});
+  painter->drawLine(QPointF{x, plot_area.top()}, QPointF{x, plot_area.bottom() + 2});
 
   // draw current time
   QString time_str = QString::number(cur_sec, 'f', 2);
   QSize time_str_size = QFontMetrics(axis_x->labelsFont()).size(Qt::TextSingleLine, time_str) + QSize(8, 2);
-  QRect time_str_rect(QPoint(x - time_str_size.width() / 2, plot_area.bottom() + 3), time_str_size);
+  QRect time_str_rect(QPoint(x - time_str_size.width() / 2, plot_area.bottom() + AXIS_X_TOP_MARGIN), time_str_size);
   QPainterPath path;
   path.addRoundedRect(time_str_rect, 3, 3);
   painter->fillPath(path, Qt::darkGray);

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -701,7 +701,7 @@ void ChartView::drawTimeline(QPainter *painter) {
   // draw line
   qreal x = std::clamp(chart()->mapToPosition(QPointF{cur_sec, 0}).x(), plot_area.left(), plot_area.right());
   painter->setPen(QPen(chart()->titleBrush().color(), 2));
-  painter->drawLine(QPointF{x, plot_area.top()}, QPointF{x, plot_area.bottom() + 2});
+  painter->drawLine(QPointF{x, plot_area.top()}, QPointF{x, plot_area.bottom() + 1});
 
   // draw current time
   QString time_str = QString::number(cur_sec, 'f', 2);
@@ -732,7 +732,7 @@ void ChartView::drawTimeline(QPainter *painter) {
       }
     }
     QRectF marker_rect = legend_markers[i++]->sceneBoundingRect();
-    QRectF value_rect(marker_rect.bottomLeft(), marker_rect.size());
+    QRectF value_rect(marker_rect.bottomLeft() - QPoint(0, 1), marker_rect.size());
     QString elided_val = painter->fontMetrics().elidedText(value, Qt::ElideRight, value_rect.width());
     painter->drawText(value_rect, Qt::AlignHCenter | Qt::AlignTop, elided_val);
   }

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -710,7 +710,7 @@ void ChartView::drawTimeline(QPainter *painter) {
   QPainterPath path;
   path.addRoundedRect(time_str_rect, 3, 3);
   painter->fillPath(path, Qt::darkGray);
-  painter->setPen(QPen(Qt::white));
+  painter->setPen(palette().color(QPalette::BrightText));
   painter->setFont(axis_x->labelsFont());
   painter->drawText(time_str_rect, Qt::AlignCenter, time_str);
 

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -687,7 +687,7 @@ void ChartView::drawForeground(QPainter *painter, const QRectF &rect) {
     painter->setPen(Qt::white);
     auto rubber_rect = rubber->geometry().normalized();
     for (const auto &pt : {rubber_rect.bottomLeft(), rubber_rect.bottomRight()}) {
-      QString sec = QString::number(chart()->mapToValue(pt).x(), 'f', 1);
+      QString sec = QString::number(chart()->mapToValue(pt).x(), 'f', 2);
       auto r = painter->fontMetrics().boundingRect(sec).adjusted(-6, -AXIS_X_TOP_MARGIN, 6, AXIS_X_TOP_MARGIN);
       pt == rubber_rect.bottomLeft() ? r.moveTopRight(pt + QPoint{0, 2}) : r.moveTopLeft(pt + QPoint{0, 2});
       painter->fillRect(r, Qt::gray);
@@ -709,7 +709,7 @@ void ChartView::drawTimeline(QPainter *painter) {
   QRect time_str_rect(QPoint(x - time_str_size.width() / 2, plot_area.bottom() + AXIS_X_TOP_MARGIN), time_str_size);
   QPainterPath path;
   path.addRoundedRect(time_str_rect, 3, 3);
-  painter->fillPath(path, Qt::darkGray);
+  painter->fillPath(path, settings.theme == DARK_THEME ? Qt::darkGray : Qt::gray);
   painter->setPen(palette().color(QPalette::BrightText));
   painter->setFont(axis_x->labelsFont());
   painter->drawText(time_str_rect, Qt::AlignCenter, time_str);

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -80,6 +80,7 @@ private:
   void drawForeground(QPainter *painter, const QRectF &rect) override;
   void drawBackground(QPainter *painter, const QRectF &rect) override;
   void drawDropIndicator(bool draw) { if (std::exchange(can_drop, draw) != can_drop) viewport()->update(); }
+  void drawTimeline(QPainter *painter);
   std::tuple<double, double, int> getNiceAxisNumbers(qreal min, qreal max, int tick_count);
   qreal niceNumber(qreal x, bool ceiling);
   QXYSeries *createSeries(SeriesType type, QColor color);
@@ -104,6 +105,7 @@ private:
   QPixmap chart_pixmap;
   bool can_drop = false;
   double tooltip_x = -1;
+  QFont signal_value_font;
   ChartsWidget *charts_widget;
   friend class ChartsWidget;
 };

--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -60,7 +60,7 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   reset_zoom_action = toolbar->addWidget(reset_zoom_btn = new ToolButton("zoom-out", tr("Reset Zoom")));
   reset_zoom_btn->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
-  toolbar->addWidget(remove_all_btn = new ToolButton("x", tr("Remove all charts")));
+  toolbar->addWidget(remove_all_btn = new ToolButton("x-square", tr("Remove all charts")));
   toolbar->addWidget(dock_btn = new ToolButton(""));
   main_layout->addWidget(toolbar);
 

--- a/tools/cabana/chart/tiplabel.cc
+++ b/tools/cabana/chart/tiplabel.cc
@@ -9,6 +9,9 @@
 TipLabel::TipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::FramelessWindowHint) {
   setForegroundRole(QPalette::ToolTipText);
   setBackgroundRole(QPalette::ToolTipBase);
+  QFont font;
+  font.setPointSize(9);
+  setFont(font);
   auto palette = QToolTip::palette();
   if (settings.theme != DARK_THEME) {
     palette.setColor(QPalette::ToolTipBase, QApplication::palette().color(QPalette::Base));

--- a/tools/cabana/chart/tiplabel.cc
+++ b/tools/cabana/chart/tiplabel.cc
@@ -10,7 +10,7 @@ TipLabel::TipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::Frameless
   setForegroundRole(QPalette::ToolTipText);
   setBackgroundRole(QPalette::ToolTipBase);
   QFont font;
-  font.setPointSize(9);
+  font.setPointSize(8.34563465);
   setFont(font);
   auto palette = QToolTip::palette();
   if (settings.theme != DARK_THEME) {

--- a/tools/cabana/chart/tiplabel.cc
+++ b/tools/cabana/chart/tiplabel.cc
@@ -10,7 +10,7 @@ TipLabel::TipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::Frameless
   setForegroundRole(QPalette::ToolTipText);
   setBackgroundRole(QPalette::ToolTipBase);
   QFont font;
-  font.setPointSize(8.34563465);
+  font.setPointSizeF(8.34563465);
   setFont(font);
   auto palette = QToolTip::palette();
   if (settings.theme != DARK_THEME) {

--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -17,6 +17,22 @@ void cabana::Signal::updatePrecision() {
   precision = std::max(num_decimals(factor), num_decimals(offset));
 }
 
+QString cabana::Signal::formatValue(double value) const {
+  // Show enum string
+  for (auto &[val, desc] : val_desc) {
+    if (std::abs(value - val.toInt()) < 1e-6) {
+      return desc;
+    }
+  }
+
+  QString val_str = QString::number(value, 'f', precision);
+  // Show unit
+  if (!unit.isEmpty()) {
+    val_str += " " + unit;
+  }
+  return val_str;
+}
+
 // helper functions
 
 static QVector<int> BIG_ENDIAN_START_BITS = []() {

--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -26,7 +26,6 @@ QString cabana::Signal::formatValue(double value) const {
   }
 
   QString val_str = QString::number(value, 'f', precision);
-  // Show unit
   if (!unit.isEmpty()) {
     val_str += " " + unit;
   }

--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -57,6 +57,7 @@ namespace cabana {
     ValueDescription val_desc;
     int precision = 0;
     void updatePrecision();
+    QString formatValue(double value) const;
   };
 
   struct Msg {

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -595,17 +595,7 @@ void SignalView::updateState(const QHash<MessageId, CanData> *msgs) {
   const auto &last_msg = can->lastMessage(model->msg_id);
   for (auto item : model->root->children) {
     double value = get_raw_value((uint8_t *)last_msg.dat.constData(), last_msg.dat.size(), *item->sig);
-    item->sig_val = QString::number(value, 'f', item->sig->precision);
-    // Show unit
-    if (!item->sig->unit.isEmpty()) {
-      item->sig_val += " " + item->sig->unit;
-    }
-    // Show enum string
-    for (auto &[val, desc] : item->sig->val_desc) {
-      if (std::abs(value - val.toInt()) < 1e-6) {
-        item->sig_val = desc;
-      }
-    }
+    item->sig_val = item->sig->formatValue(value);
     max_value_width = std::max(max_value_width, fontMetrics().width(item->sig_val));
   }
 

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -191,7 +191,7 @@ void setTheme(int theme) {
       new_palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor("#777777"));
       new_palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor("#777777"));
       new_palette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));;
-      new_palette.setColor(QPalette::Light, QColor("#777777"));
+      new_palette.setColor(QPalette::Light, QColor("#3c3f41"));
       new_palette.setColor(QPalette::Dark, QColor("#353535"));
     } else {
       new_palette = style->standardPalette();

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -191,7 +191,7 @@ void setTheme(int theme) {
       new_palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor("#777777"));
       new_palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor("#777777"));
       new_palette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));;
-      new_palette.setColor(QPalette::Light, QColor("#3c3f41"));
+      new_palette.setColor(QPalette::Light, QColor("#777777"));
       new_palette.setColor(QPalette::Dark, QColor("#353535"));
     } else {
       new_palette = style->standardPalette();


### PR DESCRIPTION
Currently, there is no way to know the current value of the signal in chart except by moving the mouse near the current value to display a ToolTip:
![Screenshot from 2023-04-28 00-57-12](https://user-images.githubusercontent.com/27770/234935385-9375d972-209a-493e-8bcf-2566e9b98c04.png)

This PR adds the feature of displaying the current signal value below the legend mark and showing the current time on the x-axis.
![2023-04-27_16-22](https://user-images.githubusercontent.com/27770/234804430-bf20777a-80d5-4322-8f2b-17f999c316f5.png)

dark theme:
![2023-04-27_16-19](https://user-images.githubusercontent.com/27770/234804451-d0c726ea-e0b6-4fba-bccc-1b69b83040cf.png)
