### PR TITLE
cabana: dispaly CPU & memory usage on the status bar

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -73,7 +73,6 @@ MainWindow::MainWindow() : QMainWindow() {
   QObject::connect(messages_widget, &MessagesWidget::msgSelectionChanged, center_widget, &CenterWidget::setMessage);
   QObject::connect(charts_widget, &ChartsWidget::dock, this, &MainWindow::dockCharts);
   QObject::connect(can, &AbstractStream::streamStarted, this, &MainWindow::loadDBCFromFingerprint);
-  QObject::connect(can, &AbstractStream::eventsMerged, this, &MainWindow::updateStatus);
   QObject::connect(dbc(), &DBCManager::DBCFileChanged, this, &MainWindow::DBCFileChanged);
   QObject::connect(can, &AbstractStream::sourcesUpdated, dbc(), &DBCManager::updateSources);
   QObject::connect(can, &AbstractStream::sourcesUpdated, this, &MainWindow::updateSources);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -203,6 +203,9 @@ void MainWindow::createStatusBar() {
 
   statusBar()->addPermanentWidget(status_label = new QLabel(this));
   updateStatus();
+  QTimer *timer = new QTimer(this);
+  timer->callOnTimeout(this, &MainWindow::updateStatus);
+  timer->start(1000);
 }
 
 void MainWindow::createShortcuts() {
@@ -669,7 +672,15 @@ void MainWindow::updateDownloadProgress(uint64_t cur, uint64_t total, bool succe
 }
 
 void MainWindow::updateStatus() {
-  status_label->setText(tr("Cached Minutes:%1 FPS:%2").arg(settings.max_cached_minutes).arg(settings.fps));
+  QString text = tr("Cached Minutes: %1  FPS: %2").arg(settings.max_cached_minutes).arg(settings.fps);
+  auto [cpu_usage, mem] = cpuAndMemoryUsage();
+  if (cpu_usage > 0) {
+    text += QString("  CPU: %1%").arg(cpu_usage, 0, 'f', 1);
+  }
+  if (mem > 0) {
+    text += QString("  RES: %1").arg(formattedDataSize(mem).c_str());
+  }
+  status_label->setText(text);
 }
 
 void MainWindow::dockCharts(bool dock) {

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -230,7 +230,7 @@ int num_decimals(double num) {
 std::pair<double, uint64_t> cpuAndMemoryUsage() {
   static const double hertz = sysconf(_SC_CLK_TCK);
   static const size_t page_size = sysconf(_SC_PAGE_SIZE);
-  static double prev_cputime = 0;
+  static uint64_t prev_cputime = 0;
   static double prev_ts = 0;
 
   double cpu_usage = 0;
@@ -240,9 +240,9 @@ std::pair<double, uint64_t> cpuAndMemoryUsage() {
   if (stats.size() == 52) {
     const double current_ts = seconds_since_boot();
     res = stats[23].toULong() * page_size;
-    double cpu_time = (stats[13].toULong() + stats[14].toULong() + stats[15].toLong() + stats[16].toLong()) / hertz;
+    uint64_t cpu_time = stats[13].toULong() + stats[14].toULong() + stats[15].toLong() + stats[16].toLong();
     if (prev_ts > 0) {
-      cpu_usage = ((cpu_time - prev_cputime) / (current_ts - prev_ts)) * 100;
+      cpu_usage = (((cpu_time - prev_cputime) / hertz) / (current_ts - prev_ts)) * 100;
     }
     prev_cputime = cpu_time;
     prev_ts = current_ts;

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -123,3 +123,4 @@ private:
 };
 
 int num_decimals(double num);
+std::pair<double, uint64_t> cpuAndMemoryUsage();

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -127,8 +127,10 @@ std::string formattedDataSize(size_t size) {
     return std::to_string(size) + " B";
   } else if (size < 1024 * 1024) {
     return util::string_format("%.2f KB", (float)size / 1024);
-  } else {
+  } else if (size < 1024 * 1024 * 1024) {
     return util::string_format("%.2f MB", (float)size / (1024 * 1024));
+  } else {
+    return util::string_format("%.2f GB", (float)size / (1024 * 1024 * 1024));
   }
 }
 


### PR DESCRIPTION
Display Cabana's current CPU and memory usage in the status bar, makes it convenient for users to check the current resource utilization.
![2023-04-27_23-39](https://user-images.githubusercontent.com/27770/234930507-cf973c68-c0ed-421d-bc97-b833f4b3ce78.png)
