### PR TITLE
cabana: Make the close button on TabBar look consistent and adaptable to different templates.

### DIFF
--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -65,13 +65,12 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   main_layout->addWidget(toolbar);
 
   // tabbar
-  tabbar = new QTabBar(this);
+  tabbar = new TabBar(this);
   tabbar->setAutoHide(true);
   tabbar->setExpanding(false);
   tabbar->setDrawBase(true);
   tabbar->setAcceptDrops(true);
   tabbar->setChangeCurrentOnDrag(true);
-  tabbar->setTabsClosable(true);
   tabbar->setUsesScrollButtons(true);
   main_layout->addWidget(tabbar);
 

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -3,7 +3,6 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QScrollArea>
-#include <QTabBar>
 #include <QTimer>
 #include <QUndoCommand>
 #include <QUndoStack>
@@ -95,7 +94,7 @@ private:
   ToolButton *remove_all_btn;
   QList<ChartView *> charts;
   std::unordered_map<int, QList<ChartView *>> tab_charts;
-  QTabBar *tabbar;
+  TabBar *tabbar;
   ChartsContainer *charts_container;
   QScrollArea *charts_scroll;
   uint32_t max_chart_range = 0;

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -13,8 +13,7 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   main_layout->setContentsMargins(0, 0, 0, 0);
 
   // tabbar
-  tabbar = new QTabBar(this);
-  tabbar->setTabsClosable(true);
+  tabbar = new TabBar(this);
   tabbar->setUsesScrollButtons(true);
   tabbar->setAutoHide(true);
   tabbar->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -41,7 +41,7 @@ private:
   QLabel *time_label, *warning_icon, *warning_label;
   ElidedLabel *name_label;
   QWidget *warning_widget;
-  QTabBar *tabbar;
+  TabBar *tabbar;
   QTabWidget *tab_widget;
   QToolButton *remove_btn;
   LogsWidget *history_log;

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -131,6 +131,29 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   painter->setPen(old_pen);
 }
 
+// TabBar
+
+int TabBar::addTab(const QString &text) {
+  int index = QTabBar::addTab(text);
+  QToolButton *btn = new ToolButton("x", tr("Close Tab"));
+  int width = style()->pixelMetric(QStyle::PM_TabCloseIndicatorWidth, nullptr, btn);
+  int height = style()->pixelMetric(QStyle::PM_TabCloseIndicatorHeight, nullptr, btn);
+  btn->setFixedSize({width, height});
+  setTabButton(index, QTabBar::RightSide, btn);
+  QObject::connect(btn, &QToolButton::clicked, this, &TabBar::closeTabClicked);
+  return index;
+}
+
+void TabBar::closeTabClicked() {
+  QObject *object = sender();
+  for (int i = 0; i < count(); ++i) {
+    if (tabButton(i, QTabBar::RightSide) == object) {
+      emit tabCloseRequested(i);
+      break;
+    }
+  }
+}
+
 QColor getColor(const cabana::Signal *sig) {
   float h = 19 * (float)sig->lsb / 64.0;
   h = fmod(h, 1.0);
@@ -191,7 +214,7 @@ void setTheme(int theme) {
       new_palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor("#777777"));
       new_palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor("#777777"));
       new_palette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));;
-      new_palette.setColor(QPalette::Light, QColor("#3c3f41"));
+      new_palette.setColor(QPalette::Light, QColor("#777777"));
       new_palette.setColor(QPalette::Dark, QColor("#353535"));
     } else {
       new_palette = style->standardPalette();

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -122,4 +122,15 @@ private:
   int theme;
 };
 
+class TabBar : public QTabBar {
+  Q_OBJECT
+
+public:
+  TabBar(QWidget *parent) : QTabBar(parent) {}
+  int addTab(const QString &text);
+
+private:
+  void closeTabClicked();
+};
+
 int num_decimals(double num);


### PR DESCRIPTION
The default close button has different appearances on different platforms. It also cannot adapt to changes in the palette. this makes it almost invisible in dark theme:
1. looks different:
    ![Screenshot from 2023-04-29 19-15-20](https://user-images.githubusercontent.com/27770/235300045-8f82843a-62cb-4442-bcef-d5a122bab74a.png)
    ![Screenshot from 2023-04-29 19-13-35](https://user-images.githubusercontent.com/27770/235300046-5376e931-391d-40cf-8218-e9c0fc760bf3.png)
    ![Screenshot from 2023-04-29 19-16-47](https://user-images.githubusercontent.com/27770/235300044-78f3453c-5688-4014-9398-51d675d2eb4d.png)
2. hard to see the close button in  dark template:
  ![Screenshot from 2023-04-29 19-17-02](https://user-images.githubusercontent.com/27770/235300041-124a4314-67a8-444e-86b7-914635ca3380.png)

After: looks consistent on different platforms and adaptable to light/dark template.
1.light theme:
  ![2023-04-29_19-03](https://user-images.githubusercontent.com/27770/235300048-2cf5b85d-51ae-49be-8b34-4bdb67d52e55.png)
2.dark theme:
  ![2023-04-29_19-00](https://user-images.githubusercontent.com/27770/235300051-3e13ba5a-1262-4b25-a479-f2ab2d603626.png)


