### PR TITLE
cabana: fix the timeline position of the newly created chart was always 0 when paused.

### DIFF
--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -264,6 +264,7 @@ void ChartsWidget::showChart(const MessageId &id, const cabana::Signal *sig, boo
   if (show && !chart) {
     chart = merge && currentCharts().size() > 0 ? currentCharts().front() : createChart();
     chart->addSignal(id, sig);
+    updateState();
   } else if (!show && chart) {
     chart->removeIf([&](auto &s) { return s.msg_id == id && s.sig == sig; });
   }


### PR DESCRIPTION
before:
![2023-05-02_14-38](https://user-images.githubusercontent.com/27770/235601396-4cdce7ab-01a6-416d-a91b-d156bb937ab8.png)
after:
![2023-05-02_15-07](https://user-images.githubusercontent.com/27770/235601901-848ecd54-856b-4f00-af98-d0a72fc8286c.png)
