### PR TITLE
cabana: supports multiple dbc files, either globally or for a specified bus.

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
 
   // Load DBC
   if (!dbc_file.isEmpty()) {
-    w.loadFile(dbc_file);
+    w.loadFile({dbc_file});
   }
 
   w.show();

--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <map>
 #include <QList>
-#include <QMetaType>
-#include <QObject>
 #include <QString>
 
 #include "opendbc/can/common_dbc.h"

--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -7,7 +7,6 @@
 #include <limits>
 #include <sstream>
 
-
 DBCFile::DBCFile(const QString &dbc_file_name, QObject *parent) : QObject(parent) {
   QFile file(dbc_file_name);
   if (file.open(QIODevice::ReadOnly)) {
@@ -164,10 +163,8 @@ const cabana::Msg* DBCFile::msg(const QString &name) {
       return &msg;
     }
   }
-
   return nullptr;
 }
-
 
 QStringList DBCFile::signalNames() const {
   // Used for autocompletion

--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -1,12 +1,9 @@
 #include "tools/cabana/dbc/dbcfile.h"
 
-#include <QDebug>
-
 #include <QFile>
 #include <QFileInfo>
 #include <QRegularExpression>
 #include <QTextStream>
-#include <QVector>
 #include <limits>
 #include <sstream>
 
@@ -116,7 +113,6 @@ cabana::Signal *DBCFile::addSignal(const MessageId &id, const cabana::Signal &si
       return s;
     }
   }
-
   return nullptr;
 }
 
@@ -147,24 +143,6 @@ void DBCFile::updateMsg(const MessageId &id, const QString &name, uint32_t size)
 
 void DBCFile::removeMsg(const MessageId &id) {
   msgs.erase(id.address);
-}
-
-QString DBCFile::newMsgName(const MessageId &id) {
-  return QString("NEW_MSG_") + QString::number(id.address, 16).toUpper();
-}
-
-QString DBCFile::newSignalName(const MessageId &id) {
-  auto m = msg(id);
-  assert(m != nullptr);
-
-  QString name;
-
-  for (int i = 1; /**/; ++i) {
-    name = QString("NEW_SIGNAL_%1").arg(i);
-    if (m->sig(name) == nullptr) break;
-  }
-
-  return name;
 }
 
 std::map<uint32_t, cabana::Msg> DBCFile::getMessages() {

--- a/tools/cabana/dbc/dbcfile.h
+++ b/tools/cabana/dbc/dbcfile.h
@@ -1,12 +1,7 @@
 #pragma once
 
 #include <map>
-#include <QList>
-#include <QMetaType>
-#include <QObject>
 #include <QString>
-#include <QSet>
-#include <QDebug>
 
 #include "tools/cabana/dbc/dbc.h"
 
@@ -37,9 +32,6 @@ public:
 
   void updateMsg(const MessageId &id, const QString &name, uint32_t size);
   void removeMsg(const MessageId &id);
-
-  QString newMsgName(const MessageId &id);
-  QString newSignalName(const MessageId &id);
 
   std::map<uint32_t, cabana::Msg> getMessages();
   const cabana::Msg *msg(const MessageId &id) const;

--- a/tools/cabana/dbc/dbcfile.h
+++ b/tools/cabana/dbc/dbcfile.h
@@ -7,7 +7,6 @@
 
 const QString AUTO_SAVE_EXTENSION = ".tmp";
 
-
 class DBCFile : public QObject {
   Q_OBJECT
 

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -45,8 +45,11 @@ void DBCManager::closeAll() {
 
 void DBCManager::removeSourcesFromFile(DBCFile *file, const SourceSet &source) {
   for (auto &[s, files] : dbc_files) {
-    if ((source.empty() || source.contains(s)) && !files.empty()) {
-      files.erase(std::find_if(files.begin(), files.end(), [=](auto &f) { return f.get() == file; }));
+    if ((source.empty() || source.contains(s))) {
+      auto it = std::find_if(files.begin(), files.end(), [=](auto &f) { return f.get() == file; });
+      if (it != files.end()) {
+        files.erase(it);
+      }
     }
   }
   emit DBCFileChanged();

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -21,7 +21,7 @@ bool DBCManager::open(const SourceSet &source, const QString &dbc_file_name, QSt
 bool DBCManager::open(const SourceSet &source, const QString &name, const QString &content, QString *error) {
   try {
     auto file = std::make_shared<DBCFile>(name, content, this);
-    for (auto s : souce) {
+    for (auto s : source) {
       dbc_files[s].emplace_back(file);
     }
     emit DBCFileChanged();
@@ -68,6 +68,7 @@ void DBCManager::updateSignal(const MessageId &id, const QString &sig_name, cons
   for (auto &f : findDBCFile(id.source)) {
     if (auto s = f->updateSignal(id, sig_name, sig)) {
       emit signalUpdated(s);
+      break;
     }
   }
 }
@@ -77,6 +78,7 @@ void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
     if (auto s = f->getSignal(id, sig_name)) {
       f->removeSignal(id, sig_name);
       emit signalRemoved(s);
+      break;
     }
   }
 }
@@ -88,6 +90,7 @@ void DBCManager::updateMsg(const MessageId &id, const QString &name, uint32_t si
     if (auto m = f->msg(id)) {
       f->updateMsg(id, name, size);
       updated = true;
+      break;
     }
   }
 
@@ -99,7 +102,10 @@ void DBCManager::updateMsg(const MessageId &id, const QString &name, uint32_t si
 
 void DBCManager::removeMsg(const MessageId &id) {
   for (auto &f : findDBCFile(id.source)) {
-    f->removeMsg(id);
+    if (auto m = f->msg(id)) {
+      f->removeMsg(id);
+      break;
+    }
   }
   emit msgRemoved(id);
 }

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -2,13 +2,13 @@
 
 #include <numeric>
 
-bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error) {
+bool DBCManager::open(const SourceSet &source, const QString &dbc_file_name, QString *error) {
   try {
     auto all = allDBCFiles();
     auto exist_file = std::find_if(all.begin(), all.end(), [&fn = dbc_file_name](auto &f) { return f->filename == fn; });
     auto file = exist_file != all.end() ? *exist_file : std::make_shared<DBCFile>(dbc_file_name, this);
-    for (auto source : s) {
-      dbc_files[source].emplace_back(file);
+    for (auto s : source) {
+      dbc_files[s].emplace_back(file);
     }
     emit DBCFileChanged();
     return true;
@@ -18,11 +18,11 @@ bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error)
   }
 }
 
-bool DBCManager::open(SourceSet s, const QString &name, const QString &content, QString *error) {
+bool DBCManager::open(const SourceSet &source, const QString &name, const QString &content, QString *error) {
   try {
     auto file = std::make_shared<DBCFile>(name, content, this);
-    for (auto source : s) {
-      dbc_files[source].emplace_back(file);
+    for (auto s : souce) {
+      dbc_files[s].emplace_back(file);
     }
     emit DBCFileChanged();
     return true;
@@ -32,9 +32,9 @@ bool DBCManager::open(SourceSet s, const QString &name, const QString &content, 
   }
 }
 
-void DBCManager::close(SourceSet s) {
-  for (auto source : s) {
-    dbc_files.erase(source);
+void DBCManager::close(const SourceSet &source) {
+  for (auto s : source) {
+    dbc_files.erase(s);
   }
   emit DBCFileChanged();
 }

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -72,11 +72,10 @@ void DBCManager::updateSignal(const MessageId &id, const QString &sig_name, cons
 }
 
 void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
-  for (auto &f : findDBCFiles(id.source)) {
+  if (auto f = findDBCFile(id)) {
     if (auto s = f->getSignal(id, sig_name)) {
       f->removeSignal(id, sig_name);
       emit signalRemoved(s);
-      break;
     }
   }
 }

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -20,9 +20,9 @@ class DBCManager : public QObject {
 public:
   DBCManager(QObject *parent) {}
   ~DBCManager() {}
-  bool open(SourceSet s, const QString &dbc_file_name, QString *error = nullptr);
-  bool open(SourceSet s, const QString &name, const QString &content, QString *error = nullptr);
-  void close(SourceSet s);
+  bool open(const SourceSet &source, const QString &dbc_file_name, QString *error = nullptr);
+  bool open(const SourceSet &source, const QString &name, const QString &content, QString *error = nullptr);
+  void close(const SourceSet &source);
   void closeAll();
   inline void close(DBCFile *file) { removeSourcesFromFile(file, {}); }
   void removeSourcesFromFile(DBCFile *file, const SourceSet &s);

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -25,7 +25,7 @@ public:
   void close(const SourceSet &source);
   void closeAll();
   inline void close(DBCFile *file) { removeSourcesFromFile(file, {}); }
-  void removeSourcesFromFile(DBCFile *file, const SourceSet &s);
+  void removeSourcesFromFile(DBCFile *file, const SourceSet &source);
 
   void addSignal(const MessageId &id, const cabana::Signal &sig);
   void updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig);

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -49,9 +49,10 @@ public:
   SourceSet sources(DBCFile *file) const;
 
   const std::set<std::shared_ptr<DBCFile>> allDBCFiles() const;
-  const std::vector<std::shared_ptr<DBCFile>> &findDBCFile(const uint8_t source) const;
+  const std::vector<std::shared_ptr<DBCFile>> &findDBCFiles(const uint8_t source) const;
+  DBCFile *findDBCFile(const MessageId &id) const;
 
-signals:
+ signals:
   void signalAdded(MessageId id, const cabana::Signal *sig);
   void signalRemoved(const cabana::Signal *sig);
   void signalUpdated(const cabana::Signal *sig);

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -260,7 +260,6 @@ void MainWindow::newFile() {
   remindSaveChanges();
   dbc()->closeAll();
   dbc()->open(SOURCE_ALL, "", "");
-  updateLoadSaveMenus();
 }
 
 void MainWindow::openFile() {
@@ -312,7 +311,6 @@ void MainWindow::loadFile(const QStringList &fn, SourceSet s, bool close_all) {
 
   statusBar()->showMessage(tr("DBC File %1 loaded").arg(fn.join(",")), 2000);
   updateRecentFiles(fn[0]);
-  updateLoadSaveMenus();
 }
 
 void MainWindow::openOpendbcFile() {
@@ -336,8 +334,6 @@ void MainWindow::loadDBCFromOpendbc(const QString &name) {
 
   dbc()->closeAll();
   dbc()->open(SOURCE_ALL, opendbc_file_path);
-
-  updateLoadSaveMenus();
 }
 
 void MainWindow::loadFromClipboard(SourceSet s, bool close_all) {
@@ -458,7 +454,6 @@ void MainWindow::saveFileAs(DBCFile *dbc_file) {
   if (!fn.isEmpty()) {
     dbc_file->saveAs(fn);
     updateRecentFiles(fn);
-    updateLoadSaveMenus();
   }
 }
 
@@ -466,7 +461,6 @@ void MainWindow::removeBusFromFile(DBCFile *dbc_file, uint8_t source) {
   assert(dbc_file != nullptr);
   SourceSet ss = {source, uint8_t(source + 128), uint8_t(source + 192)};
   dbc()->removeSourcesFromFile(dbc_file, ss);
-  updateLoadSaveMenus();
 }
 
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -494,7 +494,6 @@ void MainWindow::updateLoadSaveMenus() {
   save_dbc->setEnabled(cnt > 0);
   save_dbc->setText(cnt > 1 ? tr("Save %1 DBCs...").arg(dbc()->dbcCount()) : tr("Save DBC..."));
   save_dbc_as->setEnabled(cnt == 1);
-
   // TODO: Support clipboard for multiple files
   copy_dbc_to_clipboard->setEnabled(cnt == 1);
 
@@ -514,7 +513,7 @@ void MainWindow::updateLoadSaveMenus() {
 
     // Show sub-menu for each dbc for this source.
     QStringList bus_menu_fns;
-    for (auto &file : dbc()->findDBCFile(source)) {
+    for (auto &file : dbc()->findDBCFiles(source)) {
       auto f = file.get();
       QString fn = f->filename.isEmpty() ? "untitled" : QFileInfo(f->filename).baseName();
       bus_menu->addSeparator();
@@ -524,7 +523,6 @@ void MainWindow::updateLoadSaveMenus() {
       bus_menu->addAction(tr("Copy to Clipboard..."), [=]() { saveFileToClipboard(f); });
       bus_menu->addAction(tr("Remove from this bus..."), [=]() { removeBusFromFile(f, source); });
       bus_menu->addAction(tr("Remove from all buses..."), [=]() { closeFile(f); });
-
       bus_menu_fns << fn;
     }
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -433,12 +433,7 @@ void MainWindow::saveFile(DBCFile *dbc_file) {
     dbc_file->save();
     updateRecentFiles(dbc_file->filename);
   } else if (!dbc_file->isEmpty()) {
-    SourceSet s = dbc()->sources(dbc_file);
-    QString fn = QFileDialog::getSaveFileName(this, tr("Save File (bus: %1)").arg(toString(s)), QDir::cleanPath(settings.last_dir + "/untitled.dbc"), tr("DBC (*.dbc)"));
-    if (!fn.isEmpty()) {
-      dbc_file->saveAs(fn);
-      updateRecentFiles(fn);
-    }
+    saveFileAs(dbc_file);
   }
 
   UndoStack::instance()->setClean();

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -6,6 +6,7 @@
 #include <QProgressBar>
 #include <QSplitter>
 #include <QStatusBar>
+#include <QStringList>
 
 #include "tools/cabana/chart/chartswidget.h"
 #include "tools/cabana/dbc/dbcmanager.h"
@@ -21,7 +22,7 @@ public:
   MainWindow();
   void dockCharts(bool dock);
   void showStatusMessage(const QString &msg, int timeout = 0) { statusBar()->showMessage(msg, timeout); }
-  void loadFile(const QString &fn, SourceSet s = SOURCE_ALL, bool close_all = true);
+  void loadFile(const QStringList &fn, SourceSet s = SOURCE_ALL, bool close_all = true);
 
 public slots:
   void openRoute();


### PR DESCRIPTION
Currently, Cabana only supports one global DBC file and can only specify one DBC file for a bus.

This PR adds support for multiple DBC files, and updates Messages and Signals in different files upon saving.

1. open multiple dbc files globally:
    ![2023-05-04_05-22](https://user-images.githubusercontent.com/27770/236053445-eb7f8185-4d07-44cc-bda8-b520ad671a1c.png)
    ![2023-05-04_05-24](https://user-images.githubusercontent.com/27770/236053439-64d175ba-cef7-4dd5-a4f9-873eb78a3bd6.png)
2. open multiple dbc files for a bus:
 ![2023-05-04_05-25](https://user-images.githubusercontent.com/27770/236053427-c1a729bb-503b-41c1-b240-07c63b145c40.png)
