### PR TITLE
Nissan: use raw speed to calculate angle limits

### DIFF
--- a/selfdrive/car/nissan/carcontroller.py
+++ b/selfdrive/car/nissan/carcontroller.py
@@ -30,7 +30,7 @@ class CarController:
 
     if CC.latActive:
       # windup slower
-      apply_angle = apply_std_steer_angle_limits(actuators.steeringAngleDeg, self.apply_angle_last, CS.out.vEgo, CarControllerParams)
+      apply_angle = apply_std_steer_angle_limits(actuators.steeringAngleDeg, self.apply_angle_last, CS.out.vEgoRaw, CarControllerParams)
 
       # Max torque from driver before EPS will give up and not apply torque
       if not bool(CS.out.steeringPressed):


### PR DESCRIPTION
Uses a speed much closer to what panda reads. So we can start to lower the speed threshold after https://github.com/commaai/panda/pull/1391. Next mismatch is Tesla using a different speed signal.