### PR TITLE
qt/util.c: clearLayout, support QFormLayout

### DIFF
--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -59,7 +59,8 @@ void configFont(QPainter &p, const QString &family, int size, const QString &sty
 }
 
 void clearLayout(QLayout* layout) {
-  while (QLayoutItem* item = layout->takeAt(0)) {
+  while (layout->count() > 0) {
+    QLayoutItem* item = layout->takeAt(0);
     if (QWidget* widget = item->widget()) {
       widget->deleteLater();
     }


### PR DESCRIPTION
Low priority. Fixes warning `QFormLayout::takeAt: Invalid index 0` when the layout is already empty.