### PR TITLE
cabana: transmit

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -64,6 +64,10 @@ double get_raw_value(const uint8_t *data, size_t data_size, const cabana::Signal
   return val * sig.factor + sig.offset;
 }
 
+void set_raw_value(const uint8_t *data, size_t data_size, const cabana::Signal &sig, double value) {
+
+}
+
 bool cabana::operator==(const cabana::Signal &l, const cabana::Signal &r) {
   return l.name == r.name && l.size == r.size &&
          l.start_bit == r.start_bit &&

--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -79,7 +79,7 @@ namespace cabana {
 
 // Helper functions
 double get_raw_value(const uint8_t *data, size_t data_size, const cabana::Signal &sig);
-void set_raw_value(const uint8_t *data, size_t data_size, const cabana::Signal &sig, double value);
+void set_raw_value(uint8_t *data, size_t data_size, const cabana::Signal &sig, double value);
 int bigEndianStartBitsIndex(int start_bit);
 int bigEndianBitIndex(int index);
 void updateSigSizeParamsFromRange(cabana::Signal &s, int start_bit, int size);

--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -56,6 +56,7 @@ namespace cabana {
     QString comment;
     ValueDescription val_desc;
     int precision = 0;
+    std::optional<double> tx_value;
     void updatePrecision();
     QString formatValue(double value) const;
   };
@@ -78,6 +79,7 @@ namespace cabana {
 
 // Helper functions
 double get_raw_value(const uint8_t *data, size_t data_size, const cabana::Signal &sig);
+void set_raw_value(const uint8_t *data, size_t data_size, const cabana::Signal &sig, double value);
 int bigEndianStartBitsIndex(int start_bit);
 int bigEndianBitIndex(int index);
 void updateSigSizeParamsFromRange(cabana::Signal &s, int start_bit, int size);

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -609,6 +609,25 @@ void SignalView::handleSignalUpdated(const cabana::Signal *sig) {
 }
 
 void SignalView::updateState(const QHash<MessageId, CanData> *msgs) {
+  if (transmit_enable) {
+    bool should_transmit = false;
+    // Transmit on RX
+    if ((transmit_rate == -1) && msgs->contains(model->msg_id)) {
+      should_transmit = true;
+    }
+
+    if (should_transmit) {
+      MessageId msg_id = model->msg_id;
+      auto msg = dbc()->msg(msg_id);
+
+      if (msg != nullptr) {
+        QByteArray data;
+        data.resize(msg->size);
+        can->transmit(msg_id, data);
+      }
+    }
+  }
+
   if (model->rowCount() == 0 || (msgs && !msgs->contains(model->msg_id))) return;
 
   const auto &last_msg = can->lastMessage(model->msg_id);

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -436,6 +436,12 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
 
   // WARNING: increasing the maximum range can result in severe performance degradation.
   // 30s is a reasonable value at present.
+
+  // TODO: add transmit settings here
+  // CheckBox -> Enable Transmit
+  // DropDown -> Rate. Single, On RX, 100 ms, 50 ms, 20 ms, 10ms, 1 ms
+  // Button -> Send now
+
   const int max_range = 30; // 30s
   settings.sparkline_range = std::clamp(settings.sparkline_range, 1, max_range);
   hl->addWidget(sparkline_label = new QLabel());

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -612,7 +612,7 @@ void SignalView::updateState(const QHash<MessageId, CanData> *msgs) {
   if (transmit_enable) {
     bool should_transmit = false;
     // Transmit on RX
-    if ((transmit_rate == -1) && msgs->contains(model->msg_id)) {
+    if ((transmit_rate == -1) && (msgs != nullptr) && msgs->contains(model->msg_id)) {
       should_transmit = true;
     }
 

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -619,10 +619,16 @@ void SignalView::updateState(const QHash<MessageId, CanData> *msgs) {
     if (should_transmit) {
       MessageId msg_id = model->msg_id;
       auto msg = dbc()->msg(msg_id);
+      auto last_msg = can->lastMessage(msg_id);
 
       if (msg != nullptr) {
         QByteArray data;
         data.resize(msg->size);
+
+        for (auto &sig : msg->sigs) {
+          double value = sig.tx_value.value_or(get_raw_value((uint8_t *)last_msg.dat.constData(), last_msg.dat.size(), sig));
+          set_raw_value((uint8_t *)data.constData(), data.size(), sig, value);
+        }
         can->transmit(msg_id, data);
       }
     }

--- a/tools/cabana/signalview.h
+++ b/tools/cabana/signalview.h
@@ -119,6 +119,7 @@ private:
   void setSparklineRange(int value);
   void handleSignalUpdated(const cabana::Signal *sig);
   void updateState(const QHash<MessageId, CanData> *msgs = nullptr);
+  void updateTransmitSettings();
 
   struct TreeView : public QTreeView {
     TreeView(QWidget *parent) : QTreeView(parent) {}
@@ -134,6 +135,12 @@ private:
   };
   int max_value_width = 0;
   TreeView *tree;
+
+  QCheckBox *transmit_enable_cb;
+  QComboBox *transmit_rate_cb;
+  bool transmit_enable;
+  int transmit_rate;
+
   QLabel *sparkline_label;
   QSlider *sparkline_range_slider;
   QLineEdit *filter_edit;

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -57,6 +57,8 @@ public:
   const std::vector<const CanEvent *> &allEvents() const { return all_events_; }
   const std::vector<const CanEvent *> &events(const MessageId &id) const { return events_.at(id); }
   virtual const std::vector<std::tuple<int, int, TimelineType>> getTimeline() { return {}; }
+  virtual bool canTransmit() const {return false; }
+  virtual void transmit(const MessageId &id, const QByteArray &dat) {};
 
 signals:
   void paused();

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -57,7 +57,7 @@ public:
   const std::vector<const CanEvent *> &allEvents() const { return all_events_; }
   const std::vector<const CanEvent *> &events(const MessageId &id) const { return events_.at(id); }
   virtual const std::vector<std::tuple<int, int, TimelineType>> getTimeline() { return {}; }
-  virtual bool canTransmit() const {return false; }
+  virtual bool hasTransmit() const {return false; }
   virtual void transmit(const MessageId &id, const QByteArray &dat) {};
 
 signals:

--- a/tools/cabana/streams/pandastream.cc
+++ b/tools/cabana/streams/pandastream.cc
@@ -86,6 +86,10 @@ void PandaStream::streamThread() {
   }
 }
 
+void PandaStream::transmit(const MessageId &id, const QByteArray &dat) {
+  qDebug() << "TX" << id.source << id.address << dat;
+}
+
 AbstractOpenStreamWidget *PandaStream::widget(AbstractStream **stream) {
   return new OpenPandaWidget(stream);
 }

--- a/tools/cabana/streams/pandastream.h
+++ b/tools/cabana/streams/pandastream.h
@@ -22,6 +22,8 @@ public:
   inline QString routeName() const override {
     return QString("Live Streaming From Panda %1").arg(config.serial);
   }
+  inline bool hasTransmit() const override { return true; }
+  void transmit(const MessageId &id, const QByteArray &dat) override;
 
 protected:
   void streamThread() override;

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -25,6 +25,10 @@ public:
   inline const std::vector<std::tuple<int, int, TimelineType>> getTimeline() override { return replay->getTimeline(); }
   static AbstractOpenStreamWidget *widget(AbstractStream **stream);
 
+  // TODO: remove this after testing
+  inline bool hasTransmit() const override { return true; }
+  virtual void transmit(const MessageId &id, const QByteArray &dat) {qDebug() << "transmit" << id.source << id.address << dat;};
+
 private:
   void mergeSegments();
   std::unique_ptr<Replay> replay = nullptr;


### PR DESCRIPTION
Useful for figuring out what certain dashbaord messages mean, or scaling of things like wheel speed by observing shown value in the car.

 - Transmit at a fixed rate, on button press, or on receive on that message (useful to override the state of a certain signal).
 - Allow overriding signals, otherwise the received value is copied to be transmitted.


Future work for separate PRs:
- Setting a "function" as TX value, such as a counter or checksum
- Flooding the bus with a msg of certain ID to block everything with a higher ID
- In binary view, show status of each bit. (e.g. copied from original msg, overriding but same as original, overriding but different than original).
- Set transmit value by editing binary view directly. E.g. click on bits to toggle them, or editing the byte value.
- Decouple transmit timing from FPS