### PR TITLE
Ford: cleanup long control and send stopping signal

### DIFF
--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -97,7 +97,7 @@ def create_lat_ctl2_msg(packer, mode: int, path_offset: float, path_angle: float
   return packer.make_can_msg("LateralMotionControl2", CANBUS.main, values)
 
 
-def create_acc_msg(packer, long_active: bool, gas: float, accel: float, precharge_brake: bool, decel: bool):
+def create_acc_msg(packer, long_active: bool, gas: float, accel: float, decel: bool, stopping: bool):
   """
   Creates a CAN message for the Ford ACC Command.
 
@@ -111,8 +111,10 @@ def create_acc_msg(packer, long_active: bool, gas: float, accel: float, precharg
     "AccBrkTot_A_Rq": accel,                          # Brake total accel request: [-20|11.9449] m/s^2
     "Cmbb_B_Enbl": 1 if long_active else 0,           # Enabled: 0=No, 1=Yes
     "AccPrpl_A_Rq": gas,                              # Acceleration request: [-5|5.23] m/s^2
-    "AccBrkPrchg_B_Rq": 1 if precharge_brake else 0,  # Pre-charge brake request: 0=No, 1=Yes
+    "AccResumEnbl_B_Rq": 1 if long_active else 0,
+    "AccBrkPrchg_B_Rq": 1 if decel else 0,            # Pre-charge brake request: 0=No, 1=Yes
     "AccBrkDecel_B_Rq": 1 if decel else 0,            # Deceleration request: 0=Inactive, 1=Active
+    "AccStopStat_B_Rq": 1 if stopping else 0,
   }
   return packer.make_can_msg("ACCDATA", CANBUS.main, values)
 


### PR DESCRIPTION
This code is still behind the longitudinal control flag.

Use long control state to decide whether to command stopping. This allows the PCM to correctly enter standstill state and prevents the "bounce" seen previously after coming to a stop.