### PR TITLE
Ford: log ACC faults

### DIFF
--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -48,6 +48,7 @@ class CarState(CarStateBase):
     ret.cruiseState.available = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (3, 4, 5)
     ret.cruiseState.nonAdaptive = cp.vl["Cluster_Info1_FD1"]["AccEnbl_B_RqDrv"] == 0
     ret.cruiseState.standstill = cp.vl["EngBrakeData"]["AccStopMde_D_Rq"] == 3
+    ret.accFaulted = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (2, 3)
 
     # gear
     if self.CP.transmissionType == TransmissionType.automatic:

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -48,7 +48,7 @@ class CarState(CarStateBase):
     ret.cruiseState.available = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (3, 4, 5)
     ret.cruiseState.nonAdaptive = cp.vl["Cluster_Info1_FD1"]["AccEnbl_B_RqDrv"] == 0
     ret.cruiseState.standstill = cp.vl["EngBrakeData"]["AccStopMde_D_Rq"] == 3
-    ret.accFaulted = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (2, 3)
+    ret.accFaulted = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (1, 2)
 
     # gear
     if self.CP.transmissionType == TransmissionType.automatic:


### PR DESCRIPTION
The signal definition in the DBC states: `VAL_TABLE_ CcStat_D_Actl 7 "Undefined_2" 6 "Undefined_1" 5 "Active" 4 "Active_Que_Assist" 3 "Standby" 2 "Standby_Denied" 1 "Denied" 0 "Off";`

- When the PCM stops receiving the `ACCDATA_X` messages and it is in the `Off` state (`not cruiseState.available`), this signal goes to `Denied` indicating that you cannot enter `Standby` state.
- When the PCM stops receiving the `ACCDATA_X` messages and it is in the `Standby` state, the signal goes to `Standby_Denied`, indicating that it was previously in `Standby`, but now will not let you engage. When you press the main button, it falls to `Denied` and does not let you enter any state higher than this.

Relevant logs:
- 54827bf84c38b14f|2023-05-04--13-29-29
- 54827bf84c38b14f|2023-05-04--13-25-44
- 54827bf84c38b14f|2023-05-04--13-22-46
- 54827bf84c38b14f|2023-05-04--13-29-29