### PR TITLE
Calculate average desired curvature using planned distance instead of vego

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -614,7 +614,8 @@ class Controls:
       self.desired_curvature, self.desired_curvature_rate = get_lag_adjusted_curvature(self.CP, CS.vEgo,
                                                                                        lat_plan.psis,
                                                                                        lat_plan.curvatures,
-                                                                                       lat_plan.curvatureRates)
+                                                                                       lat_plan.curvatureRates,
+                                                                                       long_plan.distances)
       actuators.steer, actuators.steeringAngleDeg, lac_log = self.LaC.update(CC.latActive, CS, self.VM, lp,
                                                                              self.last_actuators, self.steer_limited, self.desired_curvature,
                                                                              self.desired_curvature_rate, self.sm['liveLocationKalman'])

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -17,6 +17,7 @@ V_CRUISE_INITIAL_EXPERIMENTAL_MODE = 105
 IMPERIAL_INCREMENT = 1.6  # should be CV.MPH_TO_KPH, but this causes rounding errors
 
 MIN_SPEED = 1.0
+MIN_DIST = 0.001
 CONTROL_N = 17
 CAR_ROTATION_RADIUS = 0.0
 
@@ -163,11 +164,12 @@ def rate_limit(new_value, last_value, dw_step, up_step):
   return clip(new_value, last_value + dw_step, last_value + up_step)
 
 
-def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates):
-  if len(psis) != CONTROL_N:
+def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, distances):
+  if len(psis) != CONTROL_N or len(distances) != CONTROL_N:
     psis = [0.0]*CONTROL_N
     curvatures = [0.0]*CONTROL_N
     curvature_rates = [0.0]*CONTROL_N
+    distances = [0.0]*CONTROL_N
   v_ego = max(MIN_SPEED, v_ego)
 
   # TODO this needs more thought, use .2s extra for now to estimate other delays
@@ -178,7 +180,11 @@ def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates):
   # psi to calculate a simple linearization of desired curvature
   current_curvature_desired = curvatures[0]
   psi = interp(delay, T_IDXS[:CONTROL_N], psis)
-  average_curvature_desired = psi / (v_ego * delay)
+  distance = interp(delay, T_IDXS[:CONTROL_N], distances)
+  distance = max(MIN_DIST, distance)
+
+  average_curvature_desired = psi / distance
+
   desired_curvature = 2 * average_curvature_desired - current_curvature_desired
 
   # This is the "desired rate of the setpoint" not an actual desired rate

--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -119,18 +119,25 @@ class LateralPlanner:
     else:
       self.solution_invalid_cnt = 0
 
-  def publish(self, sm, pm):
+  def publish(self, sm, pm, longitudinal_planner):
     plan_solution_valid = self.solution_invalid_cnt < 2
+    if len(longitudinal_planner.v_desired_trajectory) < CONTROL_N:
+      return
+
     plan_send = messaging.new_message('lateralPlan')
     plan_send.valid = sm.all_checks(service_list=['carState', 'controlsState', 'modelV2'])
+
+    velocities = np.maximum(0.01, np.array(longitudinal_planner.v_desired_trajectory[0:CONTROL_N]))
+    curvatures_rates = np.array(self.lat_mpc.x_sol[0:CONTROL_N, 3])
 
     lateralPlan = plan_send.lateralPlan
     lateralPlan.modelMonoTime = sm.logMonoTime['modelV2']
     lateralPlan.dPathPoints = self.y_pts.tolist()
     lateralPlan.psis = self.lat_mpc.x_sol[0:CONTROL_N, 2].tolist()
 
-    lateralPlan.curvatures = (self.lat_mpc.x_sol[0:CONTROL_N, 3]/self.v_ego).tolist()
-    lateralPlan.curvatureRates = [float(x/self.v_ego) for x in self.lat_mpc.u_sol[0:CONTROL_N - 1]] + [0.0]
+    lateralPlan.curvatures = (curvatures_rates/velocities).tolist()
+    x_mpc = self.lat_mpc.u_sol[0:CONTROL_N - 1]
+    lateralPlan.curvatureRates = [float(x_mpc[i]/velocities[i]) for i in range(0,len(x_mpc)) ] + [0.0]
 
     lateralPlan.mpcSolutionValid = bool(plan_solution_valid)
     lateralPlan.solverExecutionTime = self.lat_mpc.solve_time

--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -67,7 +67,7 @@ class LateralPlanner:
       self.plan_yaw = np.array(md.orientation.z)
       self.plan_yaw_rate = np.array(md.orientationRate.z)
       self.velocity_xyz = np.column_stack([md.velocity.x, md.velocity.y, md.velocity.z])
-      car_speed = np.linalg.norm(self.velocity_xyz, axis=1) - get_speed_error(md, v_ego_car)
+      car_speed = np.array(md.velocity.x) - get_speed_error(md, v_ego_car)
       self.v_plan = np.clip(car_speed, MIN_SPEED, np.inf)
       self.v_ego = self.v_plan[0]
 

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -229,6 +229,7 @@ class LongitudinalMpc:
     # self.solver = AcadosOcpSolverCython(MODEL_NAME, ACADOS_SOLVER_TYPE, N)
     self.solver.reset()
     # self.solver.options_set('print_level', 2)
+    self.x_solution = np.zeros(N+1)
     self.v_solution = np.zeros(N+1)
     self.a_solution = np.zeros(N+1)
     self.prev_a = np.array(self.a_solution)
@@ -434,6 +435,7 @@ class LongitudinalMpc:
     for i in range(N):
       self.u_sol[i] = self.solver.get(i, 'u')
 
+    self.x_solution = self.x_sol[:,0]
     self.v_solution = self.x_sol[:,1]
     self.a_solution = self.x_sol[:,2]
     self.j_solution = self.u_sol[:,0]

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -51,10 +51,10 @@ def plannerd_thread(sm=None, pm=None):
     sm.update()
 
     if sm.updated['modelV2']:
-      lateral_planner.update(sm)
-      lateral_planner.publish(sm, pm)
       longitudinal_planner.update(sm)
       longitudinal_planner.publish(sm, pm)
+      lateral_planner.update(sm)
+      lateral_planner.publish(sm, pm, longitudinal_planner)
       publish_ui_plan(sm, pm, lateral_planner, longitudinal_planner)
 
 def main(sm=None, pm=None):


### PR DESCRIPTION
### The problem:
The psis used when calculating the average desired curvature in get_lag_adjusted_curvature appear to be the psi based on the planned acceleration. In get_lag_adjusted_curvature we try to remove the distance from the psi to get the curvature. To determine the distance the function takes the current velocity times the lag. However, when the model is planning on having a positive or negative acceleration in the curve there will be a difference in distance the model plans on traveling vs the distance that would be traveled at the current velocity. This results in poor planner performance in the curve because the planner is using a falsely high or low curvature depending on negative or positive acceleration in the model.

### Solution:
This change gets a simple average of the first planned velocity and the velocity interpolated at the lag time to then use in the distance calculation. This results in more accurate curve planning by the planner.

### Graphs:
**Without change:**
![Screenshot 2023-05-05 at 7 51 32 PM](https://user-images.githubusercontent.com/9106735/236588361-9ce63e8e-e113-4d1c-86d6-4310cc987979.png)
Notice how the planner curvature (green second row) flattens out at the apex of the curve whenever we begin accelerating.

**With change:**
![Screenshot 2023-05-05 at 7 22 41 PM](https://user-images.githubusercontent.com/9106735/236588478-af3a561d-2e3b-4064-b6b1-3cd7924c457c.png)
In this screenshot note how much smoother the planner curvature lowers and rises. Also note that this was even hitting the curve 10 mph faster than in the previous graph without the change, which traditionally would have caused poorer performance.

### Personal Observation:
Control throughout curves feels noticeably smoother and more planted. Fewer odd jerks of the steering wheel. Seems not to cut the corner as bad either.