### PR TITLE
cabana: clear all cached values in chart after changing signal properties in live mode

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -259,10 +259,10 @@ void ChartView::updateSeriesPoints() {
   }
 }
 
-void ChartView::updateSeries(const cabana::Signal *sig) {
+void ChartView::updateSeries(const cabana::Signal *sig, bool clear) {
   for (auto &s : sigs) {
     if (!sig || s.sig == sig) {
-      if (!can->liveStreaming()) {
+      if (clear) {
         s.vals.clear();
         s.step_vals.clear();
         s.last_value_mono_time = 0;

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -27,7 +27,7 @@ public:
   ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent = nullptr);
   void addSignal(const MessageId &msg_id, const cabana::Signal *sig);
   bool hasSignal(const MessageId &msg_id, const cabana::Signal *sig) const;
-  void updateSeries(const cabana::Signal *sig = nullptr);
+  void updateSeries(const cabana::Signal *sig = nullptr, bool clear = true);
   void updatePlot(double cur, double min, double max);
   void setSeriesType(SeriesType type);
   void updatePlotArea(int left, bool force = false);

--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -149,8 +149,9 @@ void ChartsWidget::updateTabBar() {
 
 void ChartsWidget::eventsMerged() {
   QFutureSynchronizer<void> future_synchronizer;
+  bool clear = !can->liveStreaming();
   for (auto c : charts) {
-    future_synchronizer.addFuture(QtConcurrent::run(c, &ChartView::updateSeries, nullptr));
+    future_synchronizer.addFuture(QtConcurrent::run(c, &ChartView::updateSeries, nullptr, clear));
   }
 }
 


### PR DESCRIPTION
fixed the issue: https://github.com/commaai/openpilot/discussions/26091#discussioncomment-5829354
