### PR TITLE
seldrive: use common sig handler

### DIFF
--- a/selfdrive/navd/main.cc
+++ b/selfdrive/navd/main.cc
@@ -7,22 +7,12 @@
 #include "selfdrive/navd/map_renderer.h"
 #include "system/hardware/hw.h"
 
-
-
-void sigHandler(int s) {
-  qInfo() << "Shutting down";
-  std::signal(s, SIG_DFL);
-
-  qApp->quit();
-}
-
-
 int main(int argc, char *argv[]) {
   qInstallMessageHandler(swagLogMessageHandler);
 
   QApplication app(argc, argv);
-  std::signal(SIGINT, sigHandler);
-  std::signal(SIGTERM, sigHandler);
+  std::signal(SIGINT, sigTermHandler);
+  std::signal(SIGTERM, sigTermHandler);
 
   MapRenderer * m = new MapRenderer(get_mapbox_settings());
   assert(m);

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -17,6 +17,7 @@ QMap<QString, QString> getSupportedLanguages();
 void configFont(QPainter &p, const QString &family, int size, const QString &style);
 void clearLayout(QLayout* layout);
 void setQtSurfaceFormat();
+void sigTermHandler(int s);
 QString timeAgo(const QDateTime &date);
 void swagLogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
 void initApp(int argc, char *argv[], bool disable_hidpi = true);

--- a/selfdrive/ui/soundd/main.cc
+++ b/selfdrive/ui/soundd/main.cc
@@ -5,17 +5,15 @@
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/soundd/sound.h"
 
-void sigHandler(int s) {
-  qApp->quit();
-}
-
 int main(int argc, char **argv) {
   qInstallMessageHandler(swagLogMessageHandler);
   setpriority(PRIO_PROCESS, 0, -20);
 
+  // setup signal handlers to exit gracefully
+  std::signal(SIGINT, sigTermHandler);
+  std::signal(SIGTERM, sigTermHandler);
+  
   QApplication a(argc, argv);
-  std::signal(SIGINT, sigHandler);
-  std::signal(SIGTERM, sigHandler);
 
   Sound sound;
   return a.exec();

--- a/selfdrive/ui/soundd/main.cc
+++ b/selfdrive/ui/soundd/main.cc
@@ -9,11 +9,9 @@ int main(int argc, char **argv) {
   qInstallMessageHandler(swagLogMessageHandler);
   setpriority(PRIO_PROCESS, 0, -20);
 
-  // setup signal handlers to exit gracefully
+  QApplication a(argc, argv);
   std::signal(SIGINT, sigTermHandler);
   std::signal(SIGTERM, sigTermHandler);
-  
-  QApplication a(argc, argv);
 
   Sound sound;
   return a.exec();


### PR DESCRIPTION
It appears sometimes soundd hits this timeout here when `Ctrl+C`ing manager, but I haven't been able to reliably reproduce yet to debug. This is now just a clean up until the next PR

https://github.com/commaai/openpilot/blob/758a9d7c24e4736dd94cfbab127ab1414b3423a0/selfdrive/manager/process.py#L132-L149