### PR TITLE
macOS: disable camerad and sensord on Darwin

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -405,13 +405,17 @@ SConscript(['rednose/SConscript'])
 
 # Build system services
 SConscript([
-  'system/camerad/SConscript',
   'system/clocksd/SConscript',
   'system/proclogd/SConscript',
   'system/ubloxd/SConscript',
+  'system/loggerd/SConscript',
 ])
 if arch != "Darwin":
-  SConscript(['system/logcatd/SConscript'])
+  SConscript([
+    'system/camerad/SConscript',
+    'system/sensord/SConscript',
+    'system/logcatd/SConscript',
+  ])
 
 # Build openpilot
 
@@ -428,19 +432,13 @@ SConscript(['third_party/SConscript'])
 SConscript(['common/kalman/SConscript'])
 SConscript(['common/transformations/SConscript'])
 
-SConscript(['selfdrive/modeld/SConscript'])
-
+SConscript(['selfdrive/boardd/SConscript'])
 SConscript(['selfdrive/controls/lib/lateral_mpc_lib/SConscript'])
 SConscript(['selfdrive/controls/lib/longitudinal_mpc_lib/SConscript'])
-
-SConscript(['selfdrive/boardd/SConscript'])
-
-SConscript(['system/loggerd/SConscript'])
-
 SConscript(['selfdrive/locationd/SConscript'])
-SConscript(['system/sensord/SConscript'])
-SConscript(['selfdrive/ui/SConscript'])
 SConscript(['selfdrive/navd/SConscript'])
+SConscript(['selfdrive/modeld/SConscript'])
+SConscript(['selfdrive/ui/SConscript'])
 
 if (arch in ['x86_64', 'Darwin'] and Dir('#tools/cabana/').exists()) or GetOption('extras'):
   SConscript(['tools/replay/SConscript'])

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -52,6 +52,7 @@ brew "zeromq"
 brew "protobuf"
 brew "protobuf-c"
 brew "swig"
+brew "gcc@12"
 cask "gcc-arm-embedded"
 EOS
 


### PR DESCRIPTION
* disable camerad and sensord, these are not to be used on a PC anyway. 
* add gcc@12 as a homebrew dependency - required by panda

Along with panda PR(https://github.com/commaai/panda/pull/1409) this should fix setup/build issues on macOS.