### PR TITLE
Ford: block stock ACC warnings on OP long

### DIFF
--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -187,9 +187,11 @@ def create_acc_ui_msg(packer, CP, main_on: bool, enabled: bool, standstill: bool
   if CP.openpilotLongitudinalControl:
     values.update({
       "AccStopStat_D_Dsply": 2 if standstill else 0,              # Stopping status text
+      "AccMsgTxt_D2_Rq": 0,                                       # ACC text
       "AccTGap_B_Dsply": 0,                                       # Show time gap control UI
       "AccFllwMde_B_Dsply": 1 if hud_control.leadVisible else 0,  # Lead indicator
       "AccStopMde_B_Dsply": 1 if standstill else 0,
+      "AccWarn_D_Dsply": 0,                                       # ACC warning
       "AccTGap_D_Dsply": 4,                                       # Fixed time gap in UI
     })
 


### PR DESCRIPTION
Override additional signals which the stock system uses to show messages such as "ACC unavailable", "Speed too low" and cancellation sounds.
![image](https://github.com/commaai/openpilot/assets/4038174/229d781e-9d43-4890-a236-7330feab0f65)

