### PR TITLE
cabana/findSignalDlg: support filter messages by bus/address/time.

### DIFF
--- a/tools/cabana/tools/findsignal.h
+++ b/tools/cabana/tools/findsignal.h
@@ -14,6 +14,7 @@ public:
     MessageId id = {};
     uint64_t mono_time = 0;
     cabana::Signal sig = {};
+    double value = 0.;
     QStringList values;
   };
 
@@ -21,7 +22,7 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override { return 3; }
-  int rowCount(const QModelIndex &parent = QModelIndex()) const override { return std::min(filtered_signals.size(), 200); }
+  int rowCount(const QModelIndex &parent = QModelIndex()) const override { return std::min(filtered_signals.size(), 300); }
   void search(std::function<bool(double)> cmp);
   void reset();
   void undo();
@@ -29,6 +30,7 @@ public:
   QList<SearchSignal> filtered_signals;
   QList<SearchSignal> initial_signals;
   QList<QList<SearchSignal>> histories;
+  uint64_t last_time = std::numeric_limits<uint64_t>::max();
 };
 
 class FindSignalDlg : public QDialog {
@@ -46,11 +48,12 @@ private:
   void customMenuRequested(const QPoint &pos);
 
   QLineEdit *value1, *value2, *factor_edit, *offset_edit;
+  QLineEdit *bus_edit, *address_edit, *first_time_edit, *last_time_edit;
   QComboBox *compare_cb;
   QSpinBox *min_size, *max_size;
   QCheckBox *litter_endian, *is_signed;
   QPushButton *search_btn, *reset_btn, *undo_btn;
-  QGroupBox *properties_group;
+  QGroupBox *properties_group, *message_group;
   QTableView *view;
   QLabel *to_label, *stats_label;
   FindSignalModel *model;


### PR DESCRIPTION
add capability to filter messages by bus and address, as well as a time range.

![2023-05-14_22-41](https://github.com/commaai/openpilot/assets/27770/1b58b036-55be-4a06-82ec-698e23b9633d)
