### PR TITLE
manager: clear onroad/offroad transition params on start

### DIFF
--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -35,6 +35,7 @@ def manager_init() -> None:
   params = Params()
   params.clear_all(ParamKeyType.CLEAR_ON_MANAGER_START)
   params.clear_all(ParamKeyType.CLEAR_ON_ONROAD_TRANSITION)
+  params.clear_all(ParamKeyType.CLEAR_ON_OFFROAD_TRANSITION)
 
   default_params: List[Tuple[str, Union[str, bytes]]] = [
     ("CompletedTrainingVersion", "0"),

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -34,6 +34,7 @@ def manager_init() -> None:
 
   params = Params()
   params.clear_all(ParamKeyType.CLEAR_ON_MANAGER_START)
+  params.clear_all(ParamKeyType.CLEAR_ON_ONROAD_TRANSITION)
 
   default_params: List[Tuple[str, Union[str, bytes]]] = [
     ("CompletedTrainingVersion", "0"),


### PR DESCRIPTION
All params cleared on the onroad/offroad transition also are marked to clear on manager start.