### PR TITLE
longcontrol: enter stopping state if cruise standstill

### DIFF
--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -15,7 +15,7 @@ def long_control_state_trans(CP, active, long_control_state, v_ego, v_target,
   accelerating = v_target_1sec > v_target
   planned_stop = (v_target < CP.vEgoStopping and
                   v_target_1sec < CP.vEgoStopping and
-                  not accelerating)
+                  not accelerating) or cruise_standstill
   stay_stopped = (v_ego < CP.vEgoStopping and
                   (brake_pressed or cruise_standstill))
   stopping_condition = planned_stop or stay_stopped


### PR DESCRIPTION
cruiseState.standstill means that the car has entered its standstill state and does not respond to gas, so we should be commanding brake to stop in case we're on a hill

hit this in the bolt:

![image](https://github.com/commaai/openpilot/assets/25857203/a4d6848a-d593-402a-9290-ef3a39137009)