### PR TITLE
cabana: add #include <QObject> in dbcfile.h

### DIFF
--- a/tools/cabana/dbc/dbcfile.h
+++ b/tools/cabana/dbc/dbcfile.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <QList>
+#include <QObject>
 #include <QString>
 
 #include "tools/cabana/dbc/dbc.h"


### PR DESCRIPTION
fix build error on some system, related issue: https://github.com/commaai/openpilot/issues/28197#issuecomment-1550698861