### PR TITLE
ui/settings: fixed button overlap in sidebar.

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -343,7 +343,6 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
     QPushButton {
       font-size: 140px;
       padding-bottom: 20px;
-      font-weight: bold;
       border 1px grey solid;
       border-radius: 100px;
       background-color: #292929;
@@ -379,22 +378,18 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
   QObject::connect(map_panel, &MapPanel::closeSettings, this, &SettingsWindow::closeSettings);
 #endif
 
-  const int padding = panels.size() > 3 ? 25 : 35;
-
   nav_btns = new QButtonGroup(this);
   for (auto &[name, panel] : panels) {
     QPushButton *btn = new QPushButton(name);
     btn->setCheckable(true);
     btn->setChecked(nav_btns->buttons().size() == 0);
-    btn->setStyleSheet(QString(R"(
+    btn->setStyleSheet(R"(
       QPushButton {
         color: grey;
         border: none;
         background: none;
         font-size: 65px;
         font-weight: 500;
-        padding-top: %1px;
-        padding-bottom: %1px;
       }
       QPushButton:checked {
         color: white;
@@ -402,8 +397,8 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
       QPushButton:pressed {
         color: #ADADAD;
       }
-    )").arg(padding));
-
+    )");
+    btn->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     nav_btns->addButton(btn);
     sidebar_layout->addWidget(btn, 0, Qt::AlignRight);
 


### PR DESCRIPTION
issue: the device button is overlapped with the close button.  adding a red border in the stylesheet will make it clear to see this issue.

fixed this issue with the following changes:
1.remove hard-coded padding,use sizePolicy to stretch buttons
2.remove redundant(font-weight) style for the close button.


|  | before  | after |
| ------------- | ------------- | ------------- |
| with-border  | ![Screenshot from 2023-05-17 14-15-13](https://github.com/commaai/openpilot/assets/27770/e1dab4e2-bc43-4fd6-ac9e-a89f2caea43a) | ![Screenshot from 2023-05-17 14-42-42](https://github.com/commaai/openpilot/assets/27770/32f7d9ee-1143-4fa9-81f2-318e2c137841) |
| no-border  | ![Screenshot from 2023-05-17 14-33-38](https://github.com/commaai/openpilot/assets/27770/66079cc1-2235-40a6-b71d-01724db5a8c8)  | ![Screenshot from 2023-05-17 14-41-57](https://github.com/commaai/openpilot/assets/27770/33d5a68f-46df-4d99-994a-b550993ba020) |








