### PR TITLE
disable_ecu: log retries as errors

### DIFF
--- a/selfdrive/car/disable_ecu.py
+++ b/selfdrive/car/disable_ecu.py
@@ -31,7 +31,7 @@ def disable_ecu(logcan, sendcan, bus=0, addr=0x7d0, com_cont_req=b'\x28\x83\x01'
     except Exception:
       cloudlog.exception("ecu disable exception")
 
-    print(f"ecu disable retry ({i+1}) ...")
+    cloudlog.error(f"ecu disable retry ({i + 1}) ...")
   cloudlog.warning("ecu disable failed")
   return False
 

--- a/selfdrive/car/disable_ecu.py
+++ b/selfdrive/car/disable_ecu.py
@@ -32,7 +32,7 @@ def disable_ecu(logcan, sendcan, bus=0, addr=0x7d0, com_cont_req=b'\x28\x83\x01'
       cloudlog.exception("ecu disable exception")
 
     cloudlog.error(f"ecu disable retry ({i + 1}) ...")
-  cloudlog.warning("ecu disable failed")
+  cloudlog.error("ecu disable failed")
   return False
 
 


### PR DESCRIPTION
follows what VIN does, so we can easily spot when this goes wrong in the qlogs