### PR TITLE
Ford: log stock AEB

### DIFF
--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -75,7 +75,7 @@ class CarState(CarStateBase):
 
     # safety
     ret.stockFcw = bool(cp_cam.vl["ACCDATA_3"]["FcwVisblWarn_B_Rq"])
-    ret.stockAeb = ret.stockFcw and ret.cruiseState.enabled
+    ret.stockAeb = bool(cp_cam.vl["ACCDATA_2"]["CmbbBrkDecel_B_Rq"])
 
     # button presses
     ret.leftBlinker = cp.vl["Steering_Data_FD1"]["TurnLghtSwtch_D_Stat"] == 1
@@ -217,6 +217,8 @@ class CarState(CarStateBase):
   def get_cam_can_parser(CP):
     signals = [
       # sig_name, sig_address
+      ("CmbbBrkDecel_B_Rq", "ACCDATA_2"),           # AEB actuation request bit
+
       ("HaDsply_No_Cs", "ACCDATA_3"),
       ("HaDsply_No_Cnt", "ACCDATA_3"),
       ("AccStopStat_D_Dsply", "ACCDATA_3"),         # ACC stopped status message
@@ -261,6 +263,7 @@ class CarState(CarStateBase):
 
     checks = [
       # sig_address, frequency
+      ("ACCDATA_2", 50),
       ("ACCDATA_3", 5),
       ("IPMA_Data", 1),
     ]


### PR DESCRIPTION
No instances of this in our fleet, but I reproduced two AEBs on our Bronco. No signals in `ACCDATA` changed during the AEB, except one: `CmbbEngTqMn_B_Rq`. This possibly tells the PCM to disengage the torque converter (or just lower the engine RPM) to stop faster. So this means all of the braking actuation request is done in `ACCDATA_2` except the lowering of the engine torque.

Route: 54827bf84c38b14f|2023-05-18--01-57-42

![image](https://github.com/commaai/openpilot/assets/25857203/4b0c0fd0-2942-4084-848a-d484d8f5033a)

All of the `ACCDATA_2` signals that change for an AEB event:

![image](https://github.com/commaai/openpilot/assets/25857203/4f9ec715-ed68-41cd-b7a7-596561cd3999)

Engine torque signal changing in `ACCDATA`:

![image](https://github.com/commaai/openpilot/assets/25857203/4c1e5297-d470-4574-a5c1-3a8a29129545)
