### PR TITLE
HKG: add 2017 Genesis G90 Fingerprint

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1142,7 +1142,10 @@ FW_VERSIONS = {
     ],
   },
   CAR.GENESIS_G90: {
-    (Ecu.transmission, 0x7e1, None): [b'\xf1\x87VDGMD15866192DD3x\x88x\x89wuFvvfUf\x88vWwgwwwvfVgx\x87o\xff\xbc^\xf1\x81E14\x00\x00\x00\x00\x00\x00\x00\xf1\x00bcshcm49  E14\x00\x00\x00\x00\x00\x00\x00SHI0G50NB1tc5\xb7'],
+    (Ecu.transmission, 0x7e1, None): [
+      b'\xf1\x87VDGMD15352242DD3w\x87gxwvgv\x87wvw\x88wXwffVfffUfw\x88o\xff\x06J\xf1\x81E14\x00\x00\x00\x00\x00\x00\x00\xf1\x00bcshcm49  E14\x00\x00\x00\x00\x00\x00\x00SHI0G50NB1tc5\xb7',
+      b'\xf1\x87VDGMD15866192DD3x\x88x\x89wuFvvfUf\x88vWwgwwwvfVgx\x87o\xff\xbc^\xf1\x81E14\x00\x00\x00\x00\x00\x00\x00\xf1\x00bcshcm49  E14\x00\x00\x00\x00\x00\x00\x00SHI0G50NB1tc5\xb7',
+    ],
     (Ecu.fwdRadar, 0x7d0, None): [b'\xf1\x00HI__ SCC F-CUP      1.00 1.01 96400-D2100         '],
     (Ecu.fwdCamera, 0x7c4, None): [b'\xf1\x00HI  LKAS AT USA LHD 1.00 1.00 95895-D2020 160302'],
     (Ecu.engine, 0x7e0, None): [b'\xf1\x810000000000\x00'],


### PR DESCRIPTION
Fingerprinting 2017 Genesis G90.
dongle_id: `04d9e339e666093e`

PLEASE NOTE: Most recent drive was done on sunnyhaibin fork, not the main fork.

When compared to the existing `values.py`, only the transmission fw was different, thus updating only the transmission and leaving out the others.
![image](https://github.com/commaai/openpilot/assets/15177043/7de12222-c2a4-4678-8cd7-3c25607ea27b)

