### PR TITLE
logging: change event_name arg

### DIFF
--- a/common/logging_extra.py
+++ b/common/logging_extra.py
@@ -153,9 +153,9 @@ class SwagLogger(logging.Logger):
   def bind_global(self, **kwargs):
     self.global_ctx.update(kwargs)
 
-  def event(self, event_name, *args, **kwargs):
+  def event(self, event, *args, **kwargs):
     evt = NiceOrderedDict()
-    evt['event'] = event_name
+    evt['event'] = event
     if args:
       evt['args'] = args
     evt.update(kwargs)


### PR DESCRIPTION
This doesn't change anything in practice, but makes it harder to write a bug where a kwarg with the name `event` would overwrite the event name, since now Python will raise a syntax error.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
