### PR TITLE
cabana: fix segfault on screen changed

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -44,9 +44,9 @@ ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *par
   setTheme(settings.theme == DARK_THEME ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight);
   signal_value_font.setPointSize(9);
 
-  QObject::connect(axis_y, &QValueAxis::rangeChanged, [this]() { resetChartCache(); });
-  QObject::connect(axis_y, &QAbstractAxis::titleTextChanged, [this]() { resetChartCache(); });
-  QObject::connect(window()->windowHandle(), &QWindow::screenChanged, [this]() { resetChartCache(); });
+  QObject::connect(axis_y, &QValueAxis::rangeChanged, this, &ChartView::resetChartCache);
+  QObject::connect(axis_y, &QAbstractAxis::titleTextChanged, this, &ChartView::resetChartCache);
+  QObject::connect(window()->windowHandle(), &QWindow::screenChanged, this, &ChartView::resetChartCache);
 
   QObject::connect(dbc(), &DBCManager::signalRemoved, this, &ChartView::signalRemoved);
   QObject::connect(dbc(), &DBCManager::signalUpdated, this, &ChartView::signalUpdated);


### PR DESCRIPTION
related issue: https://github.com/commaai/openpilot/discussions/26091#discussioncomment-5944361

The `screenChanged` signal should not be connected to a lambda function. otherwise, after the chart is deleted, this connection still exists and the lambda function will be called on screen changed with an invalid `this` pointer, causing a segmentation fault.
