### PR TITLE
cabana: use the same double precision as the dbc file

### DIFF
--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <QList>
 #include <QMetaType>
 #include <QString>
@@ -85,3 +86,5 @@ int bigEndianBitIndex(int index);
 void updateSigSizeParamsFromRange(cabana::Signal &s, int start_bit, int size);
 std::pair<int, int> getSignalRange(const cabana::Signal *s);
 inline std::vector<std::string> allDBCNames() { return get_dbc_names(); }
+inline QString doubleToString(double value) { return QString::number(value, 'g', std::numeric_limits<double>::digits10); }
+

--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -4,7 +4,6 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 #include <QTextStream>
-#include <limits>
 #include <numeric>
 #include <sstream>
 
@@ -257,8 +256,8 @@ QString DBCFile::generateDBC() {
                         .arg(sig->size)
                         .arg(sig->is_little_endian ? '1' : '0')
                         .arg(sig->is_signed ? '-' : '+')
-                        .arg(sig->factor, 0, 'g', std::numeric_limits<double>::digits10)
-                        .arg(sig->offset, 0, 'g', std::numeric_limits<double>::digits10)
+                        .arg(doubleToString(sig->factor))
+                        .arg(doubleToString(sig->offset))
                         .arg(sig->min)
                         .arg(sig->max)
                         .arg(sig->unit);

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -124,8 +124,8 @@ QVariant SignalModel::data(const QModelIndex &index, int role) const {
           case Item::Sig: return item->sig_val;
           case Item::Name: return item->sig->name;
           case Item::Size: return item->sig->size;
-          case Item::Offset: return QString::number(item->sig->offset, 'f', 6);
-          case Item::Factor: return QString::number(item->sig->factor, 'f', 6);
+          case Item::Offset: return doubleToString(item->sig->offset);
+          case Item::Factor: return doubleToString(item->sig->factor);
           case Item::Unit: return item->sig->unit;
           case Item::Comment: return item->sig->comment;
           case Item::Min: return item->sig->min;


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| ![2023-05-20_03-02](https://github.com/commaai/openpilot/assets/27770/ed4e752d-812c-4315-9b50-fdfd0d9fe70c)  | ![Screenshot from 2023-05-20 03-01-32](https://github.com/commaai/openpilot/assets/27770/8c0a0085-59ec-48db-8d60-6600a2613be7)  |




