### PR TITLE
VW: A little less signal pass-through

### DIFF
--- a/selfdrive/car/volkswagen/mqbcan.py
+++ b/selfdrive/car/volkswagen/mqbcan.py
@@ -34,12 +34,6 @@ def create_lka_hud_control(packer, bus, ldw_stock_values, enabled, steering_pres
 def create_acc_buttons_control(packer, bus, gra_stock_values, cancel=False, resume=False):
   values = {s: gra_stock_values[s] for s in [
     "GRA_Hauptschalter",           # ACC button, on/off
-    "GRA_Abbrechen",               # ACC button, cancel
-    "GRA_Tip_Setzen",              # ACC button, set
-    "GRA_Tip_Hoch",                # ACC button, increase or accel
-    "GRA_Tip_Runter",              # ACC button, decrease or decel
-    "GRA_Tip_Wiederaufnahme",      # ACC button, resume
-    "GRA_Verstellung_Zeitluecke",  # ACC button, time gap adj
     "GRA_Typ_Hauptschalter",       # ACC main button type
     "GRA_Codierung",               # ACC button configuration/coding
     "GRA_Tip_Stufe_2",             # unknown related to stalk type

--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -36,14 +36,6 @@ def create_acc_buttons_control(packer, bus, gra_stock_values, cancel=False, resu
     "GRA_Hauptschalt",      # ACC button, on/off
     "GRA_Typ_Hauptschalt",  # ACC button, momentary vs latching
     "GRA_Kodierinfo",       # ACC button, configuration
-    "GRA_Abbrechen",        # ACC button, cancel
-    "GRA_Neu_Setzen",       # ACC button, set
-    "GRA_Up_lang",          # ACC button, increase or accel, long press
-    "GRA_Down_lang",        # ACC button, decrease or decel, long press
-    "GRA_Up_kurz",          # ACC button, increase or accel, short press
-    "GRA_Down_kurz",        # ACC button, decrease or decel, short press
-    "GRA_Recall",           # ACC button, resume
-    "GRA_Zeitluecke",       # ACC button, time gap adj
     "GRA_Sender",           # ACC button, CAN message originator
   ]}
 


### PR DESCRIPTION
After some thought and DM discussion with @sshane, have realized we don't need to pass through any of the live button press states. Cancel and resume state were overridden anyway, merging other driver button presses with Cancel spam is wrong, and I'm not sure it ever made sense to try to merge other driver button presses with Resume spam. The remaining signals describe some physical properties and logical state of the installed ACC button/stalk for that particular car, and we do have to match the car for our spam to be accepted.