### PR TITLE
cabana: use double for minimum value & maximum value

### DIFF
--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -51,7 +51,8 @@ namespace cabana {
     bool is_signed;
     double factor, offset;
     bool is_little_endian;
-    QString min, max, unit;
+    double min, max;
+    QString unit;
     QString comment;
     ValueDescription val_desc;
     int precision = 0;

--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -217,8 +217,8 @@ void DBCFile::parseExtraInfo(const QString &content) {
       }
       if (match.hasMatch()) {
         if (auto s = get_sig(address, match.captured(1))) {
-          s->min = match.captured(8 + offset);
-          s->max = match.captured(9 + offset);
+          s->min = match.captured(8 + offset).toDouble();
+          s->max = match.captured(9 + offset).toDouble();
           s->unit = match.captured(10 + offset);
         }
       }
@@ -258,8 +258,8 @@ QString DBCFile::generateDBC() {
                         .arg(sig->is_signed ? '-' : '+')
                         .arg(doubleToString(sig->factor))
                         .arg(doubleToString(sig->offset))
-                        .arg(sig->min)
-                        .arg(sig->max)
+                        .arg(doubleToString(sig->min))
+                        .arg(doubleToString(sig->max))
                         .arg(sig->unit);
       if (!sig->comment.isEmpty()) {
         signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -128,8 +128,8 @@ QVariant SignalModel::data(const QModelIndex &index, int role) const {
           case Item::Factor: return doubleToString(item->sig->factor);
           case Item::Unit: return item->sig->unit;
           case Item::Comment: return item->sig->comment;
-          case Item::Min: return item->sig->min;
-          case Item::Max: return item->sig->max;
+          case Item::Min: return doubleToString(item->sig->min);
+          case Item::Max: return doubleToString(item->sig->max);
           case Item::Desc: {
             QStringList val_desc;
             for (auto &[val, desc] : item->sig->val_desc) {
@@ -166,8 +166,8 @@ bool SignalModel::setData(const QModelIndex &index, const QVariant &value, int r
     case Item::Factor: s.factor = value.toDouble(); break;
     case Item::Unit: s.unit = value.toString(); break;
     case Item::Comment: s.comment = value.toString(); break;
-    case Item::Min: s.min = value.toString(); break;
-    case Item::Max: s.max = value.toString(); break;
+    case Item::Min: s.min = value.toDouble(); break;
+    case Item::Max: s.max = value.toDouble(); break;
     case Item::Desc: s.val_desc = value.value<ValueDescription>(); break;
     default: return false;
   }
@@ -230,7 +230,7 @@ void SignalModel::addSignal(int start_bit, int size, bool little_endian) {
     msg = dbc()->msg(msg_id);
   }
 
-  cabana::Signal sig = {.name = dbc()->newSignalName(msg_id), .is_little_endian = little_endian, .factor = 1, .min = "0", .max = QString::number(std::pow(2, size) - 1)};
+  cabana::Signal sig = {.name = dbc()->newSignalName(msg_id), .is_little_endian = little_endian, .factor = 1, .min = 0, .max = std::pow(2, size) - 1};
   updateSigSizeParamsFromRange(sig, start_bit, size);
   UndoStack::push(new AddSigCommand(msg_id, sig));
 }


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
