### PR TITLE
aarch64: disable carla and onnxruntime-gpu on non-x64 hosts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ libusb1 = "^3.0.0"
 nose = "^1.3.7"
 numpy = "^1.23.0"
 onnx = "^1.12.0"
-onnxruntime-gpu = { version = "^1.11.1", platform = "linux" }
+onnxruntime-gpu = { version = "^1.11.1", platform = "linux", markers = "platform_machine == 'x86_64'" }
 pillow = "^9.2.0"
 poetry = "==1.2.2"
 protobuf = "==3.20.1"
@@ -66,7 +66,7 @@ sconscontrib = {git = "https://github.com/SCons/scons-contrib.git"}
 av = "^9.2.0"
 azure-storage-blob = "~2.1"
 breathe = "^4.34.0"
-carla = { version = "==0.9.13", platform = "linux" }
+carla = { version = "==0.9.13", platform = "linux", markers = "platform_machine == 'x86_64'" }
 control = "^0.9.2"
 coverage = "^6.4.1"
 dictdiffer = "^0.9.0"


### PR DESCRIPTION
these packages are not available on aarch64. with this at least the setup script succeeds. openpilot will not build on aarch64 ubuntu yet, but this is the first step.