### PR TITLE
UI: move experimental toggle to right

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -2,6 +2,7 @@
 
 #include <QHBoxLayout>
 #include <QMouseEvent>
+#include <QStackedWidget>
 #include <QVBoxLayout>
 
 #include "selfdrive/ui/qt/offroad/experimental_mode.h"
@@ -136,8 +137,17 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
     home_layout->setContentsMargins(0, 0, 0, 0);
     home_layout->setSpacing(30);
 
-    // left: DriveStats
-    home_layout->addWidget(new DriveStats, 1);
+    // left: DriveStats, PrimeAdWidget
+    QStackedWidget *left_widget = new QStackedWidget(this);
+    left_widget->addWidget(new DriveStats);
+    left_widget->addWidget(new PrimeAdWidget);
+
+    left_widget->setCurrentIndex(uiState()->primeType() ? 0 : 1);
+    connect(uiState(), &UIState::primeTypeChanged, [=](int prime_type) {
+      left_widget->setCurrentIndex(prime_type ? 0 : 1);
+    });
+
+    home_layout->addWidget(left_widget, 1);
 
     // right: ExperimentalModeButton, SetupWidget
     QWidget* right_widget = new QWidget(this);

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -136,21 +136,23 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
     home_layout->setContentsMargins(0, 0, 0, 0);
     home_layout->setSpacing(30);
 
-    // left: ExperimentalModeButton, DriveStats
-    QWidget* left_widget = new QWidget(this);
-    QVBoxLayout* left_column = new QVBoxLayout(left_widget);
-    left_column->setContentsMargins(0, 0, 0, 0);
-    left_column->setSpacing(30);
+    // left: DriveStats
+    home_layout->addWidget(new DriveStats, 1);
+
+    // right: ExperimentalModeButton, SetupWidget
+    QWidget* right_widget = new QWidget(this);
+    QVBoxLayout* right_column = new QVBoxLayout(right_widget);
+    right_column->setContentsMargins(0, 0, 0, 0);
+    right_column->setSpacing(30);
 
     ExperimentalModeButton *experimental_mode = new ExperimentalModeButton(this);
     QObject::connect(experimental_mode, &ExperimentalModeButton::openSettings, this, &OffroadHome::openSettings);
-    left_column->addWidget(experimental_mode, 1);
-    left_column->addWidget(new DriveStats, 1);
+    right_column->addWidget(experimental_mode, 1);
 
-    home_layout->addWidget(left_widget, 1);
+    right_column->addWidget(new SetupWidget, 1);
 
-    // right: SetupWidget
-    home_layout->addWidget(new SetupWidget);
+    right_widget->setFixedWidth(750);
+    home_layout->addWidget(right_widget, 1);
   }
   center_layout->addWidget(home_widget);
 
@@ -170,7 +172,7 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
 
   setStyleSheet(R"(
     * {
-     color: white;
+      color: white;
     }
     OffroadHome {
       background-color: black;

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -195,8 +195,8 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
   QFrame* finishRegistration = new QFrame;
   finishRegistration->setObjectName("primeWidget");
   QVBoxLayout* finishRegistationLayout = new QVBoxLayout(finishRegistration);
-  finishRegistationLayout->setSpacing(40);
-  finishRegistationLayout->setContentsMargins(64, 64, 64, 64);
+  finishRegistationLayout->setSpacing(38);
+  finishRegistationLayout->setContentsMargins(64, 48, 64, 48);
 
   QLabel* registrationTitle = new QLabel(tr("Finish Setup"));
   registrationTitle->setStyleSheet("font-size: 75px; font-weight: bold;");
@@ -204,7 +204,7 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
 
   QLabel* registrationDescription = new QLabel(tr("Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer."));
   registrationDescription->setWordWrap(true);
-  registrationDescription->setStyleSheet("font-size: 55px; font-weight: light;");
+  registrationDescription->setStyleSheet("font-size: 50px; font-weight: light;");
   finishRegistationLayout->addWidget(registrationDescription);
 
   finishRegistationLayout->addStretch();

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -234,13 +234,14 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
   outer_layout->setContentsMargins(0, 0, 0, 0);
   outer_layout->addWidget(mainLayout);
 
-  primeAd = new PrimeAdWidget;
-  mainLayout->addWidget(primeAd);
-
   primeUser = new PrimeUserWidget;
   mainLayout->addWidget(primeUser);
 
-  mainLayout->setCurrentWidget(uiState()->primeType() ? (QWidget*)primeUser : (QWidget*)primeAd);
+  if (uiState()->primeType()) {
+    mainLayout->setCurrentWidget((QWidget*)primeUser);
+  } else {
+    mainLayout->setVisible(false);
+  }
 
   setFixedWidth(750);
   setStyleSheet(R"(
@@ -279,13 +280,15 @@ void SetupWidget::replyFinished(const QString &response, bool success) {
 
   if (!json["is_paired"].toBool()) {
     mainLayout->setCurrentIndex(0);
+    mainLayout->setVisible(true);
   } else {
     popup->reject();
 
     if (prime_type) {
       mainLayout->setCurrentWidget(primeUser);
+      mainLayout->setVisible(true);
     } else {
-      mainLayout->setCurrentWidget(primeAd);
+      mainLayout->setVisible(false);
     }
   }
 }

--- a/selfdrive/ui/qt/widgets/prime.h
+++ b/selfdrive/ui/qt/widgets/prime.h
@@ -72,7 +72,6 @@ public:
 private:
   PairingPopup *popup;
   QStackedWidget *mainLayout;
-  PrimeAdWidget *primeAd;
   PrimeUserWidget *primeUser;
 
 private slots:


### PR DESCRIPTION
- Move the experimental toggle button to the right column to make more space for https://github.com/commaai/openpilot/pull/27629
- Move prime ad to the left when no prime

||New|Old|
|-|-|-|
|Unpaired|<img height=175 src=https://github.com/commaai/openpilot/assets/4038174/0b524252-4db1-45e4-82ea-f818c3d69e58>|<img height=175 src=https://github.com/commaai/openpilot/assets/4038174/1f304398-4941-4588-afbe-eebfb86058fe>|
|No prime|<img height=175 src=https://github.com/commaai/openpilot/assets/4038174/7349629a-cc4a-42f5-a8bf-2bde22b65e18>|<img height=175 src=https://github.com/commaai/openpilot/assets/4038174/880273dc-dd3d-4d00-be1a-a4809ddbf54d>|
|Prime|<img height=175 src=https://github.com/commaai/openpilot/assets/4038174/fad6333d-2bb6-42d3-8118-52ca33810ed9>|<img height=175 src=https://github.com/commaai/openpilot/assets/4038174/d7063bb4-ce43-4749-a956-c179bd4afb17>|
