### PR TITLE
ui/MainWindow: use switch in eventFilter

### DIFF
--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -79,11 +79,16 @@ void MainWindow::closeSettings() {
 }
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event) {
-  const static QSet<QEvent::Type> evts({QEvent::MouseButtonPress, QEvent::MouseMove,
-                                 QEvent::TouchBegin, QEvent::TouchUpdate, QEvent::TouchEnd});
-
-  if (evts.contains(event->type())) {
-    device.resetInteractiveTimout();
+  switch (event->type()) {
+    case QEvent::TouchBegin:
+    case QEvent::TouchUpdate:
+    case QEvent::TouchEnd:
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseMove:
+      device.resetInteractiveTimout();
+      break;
+    default:
+      break;
   }
   return false;
 }


### PR DESCRIPTION
Because we have installed this event filter for the entire app, it would be better to return as soon as possible.  https://stackoverflow.com/questions/6860525/c-what-is-faster-lookup-in-hashmap-or-switch-statement

Also, I think using a switch statement here may be more readable.

