### PR TITLE
UI: reduce margin around software version

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -102,11 +102,11 @@ void HomeWindow::mouseDoubleClickEvent(QMouseEvent* e) {
 
 OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
   QVBoxLayout* main_layout = new QVBoxLayout(this);
-  main_layout->setContentsMargins(40, 40, 40, 45);
+  main_layout->setContentsMargins(40, 40, 40, 40);
 
   // top header
   QHBoxLayout* header_layout = new QHBoxLayout();
-  header_layout->setContentsMargins(15, 15, 15, 0);
+  header_layout->setContentsMargins(0, 0, 0, 0);
   header_layout->setSpacing(16);
 
   update_notif = new QPushButton(tr("UPDATE"));


### PR DESCRIPTION
As spotted by @deanlee https://github.com/commaai/openpilot/pull/28269#issuecomment-1560495007, there is unnecessary margin between the software version label and the top of the screen. I've also updated the bottom margin to match the other sides.

||New|Old|
|-|-|-|
|Unpaired|<img height=160 src=https://github.com/commaai/openpilot/assets/4038174/94d4ffbf-9085-46a8-9e5a-888ce17b4beb>|<img height=160 src=https://github.com/commaai/openpilot/assets/4038174/bccb7640-ec93-4a16-85f3-ecf32a100a26>|
|No prime|<img height=160 src=https://github.com/commaai/openpilot/assets/4038174/c794471c-4dcb-445c-8fb6-ba6482764efd>|<img height=160 src=https://github.com/commaai/openpilot/assets/4038174/b6882aa0-d06f-48e1-8a17-e39ee96da8c8>|
|Prime|<img height=160 src=https://github.com/commaai/openpilot/assets/4038174/9c96a8c8-0612-4dac-bd7f-a368d5f96ba0>|<img height=160 src=https://github.com/commaai/openpilot/assets/4038174/e88843a7-c196-42ef-a571-c70478927e16>|
