### PR TITLE
cabana/MessageViewHeader:  fixed header position issue

### DIFF
--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -491,22 +491,6 @@ MessageViewHeader::MessageViewHeader(QWidget *parent, MessageListModel *model) :
   QObject::connect(this, &QHeaderView::sectionMoved, this, &MessageViewHeader::updateHeaderPositions);
 }
 
-void MessageViewHeader::showEvent(QShowEvent *e) {
-
-  for (int i = 0; i < count(); i++) {
-    if (!editors[i]) {
-      QString column_name = model->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
-      editors[i] = new QLineEdit(this);
-      editors[i]->setClearButtonEnabled(true);
-      editors[i]->setPlaceholderText(tr("Filter %1").arg(column_name));
-
-      QObject::connect(editors[i], &QLineEdit::textChanged, this, &MessageViewHeader::updateFilters);
-    }
-    editors[i]->show();
-  }
-  QHeaderView::showEvent(e);
-}
-
 void MessageViewHeader::updateFilters() {
   QMap<int, QString> filters;
   for (int i = 0; i < count(); i++) {
@@ -539,11 +523,18 @@ void MessageViewHeader::updateHeaderPositions() {
 }
 
 void MessageViewHeader::updateGeometries() {
-  if (editors[0]) {
-    setViewportMargins(0, 0, 0, editors[0]->sizeHint().height());
-  } else {
-    setViewportMargins(0, 0, 0, 0);
+  for (int i = 0; i < count(); i++) {
+    if (!editors[i]) {
+      QString column_name = model->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
+      editors[i] = new QLineEdit(this);
+      editors[i]->setClearButtonEnabled(true);
+      editors[i]->setPlaceholderText(tr("Filter %1").arg(column_name));
+
+      QObject::connect(editors[i], &QLineEdit::textChanged, this, &MessageViewHeader::updateFilters);
+    }
   }
+  setViewportMargins(0, 0, 0, editors[0] ? editors[0]->sizeHint().height() : 0);
+
   QHeaderView::updateGeometries();
   updateHeaderPositions();
 }

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -70,7 +70,6 @@ class MessageViewHeader : public QHeaderView {
   Q_OBJECT
 public:
   MessageViewHeader(QWidget *parent, MessageListModel *model);
-  void showEvent(QShowEvent *e) override;
   void updateHeaderPositions();
 
   void updateGeometries() override;


### PR DESCRIPTION
issue: All QLineEdit have been stacked together if there are no messages on startup.(When the messagewidget is displayed for the first time)

| Before  | After |
| ------------- | ------------- |
| ![2023-05-25_16-24](https://github.com/commaai/openpilot/assets/27770/be539fb6-ead4-4e83-977a-b88bcc31bc35)  | ![Screenshot 2023-05-25 16:09:49](https://github.com/commaai/openpilot/assets/27770/135fd5dd-bc8e-4a31-9e42-8b2a8eaa0dee)  |




