### PR TITLE
cabana: support editing dbc files without a stream

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -63,9 +63,7 @@ int main(int argc, char *argv[]) {
 
     if (route.isEmpty()) {
       StreamSelector dlg(&stream);
-      if (!dlg.exec()) {
-        return 0;
-      }
+      dlg.exec();
       dbc_file = dlg.dbcFile();
     } else {
       auto replay_stream = new ReplayStream(&app);
@@ -77,11 +75,13 @@ int main(int argc, char *argv[]) {
   }
 
   MainWindow w;
+  if (!stream) {
+    stream = new DummyStream(&app);
+  }
+  stream->start();
   if (!dbc_file.isEmpty()) {
     w.loadFile(dbc_file);
   }
-  assert(stream != nullptr);
-  stream->start();
   w.show();
   return app.exec();
 }

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -1,12 +1,5 @@
 #include "tools/cabana/dbc/dbcmanager.h"
-
-#include <QFile>
-#include <QRegularExpression>
-#include <QTextStream>
-#include <QVector>
-#include <limits>
-#include <sstream>
-
+#include <algorithm>
 
 bool DBCManager::open(SourceSet s, const QString &dbc_file_name, QString *error) {
   for (int i = 0; i < dbc_files.size(); i++) {
@@ -280,13 +273,7 @@ int DBCManager::dbcCount() const {
 }
 
 int DBCManager::nonEmptyDBCCount() const {
-  int cnt = 0;
-  for (auto &[_, dbc_file] : dbc_files) {
-    if (!dbc_file->isEmpty()) {
-      cnt++;
-    }
-  }
-  return cnt;
+  return std::count_if(dbc_files.cbegin(), dbc_files.cend(), [](auto &f) { return !f.second->isEmpty(); });
 }
 
 void DBCManager::updateSources(const SourceSet &s) {

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -8,7 +8,6 @@
 #include <QObject>
 #include <QString>
 #include <QSet>
-#include <QDebug>
 
 #include "tools/cabana/dbc/dbc.h"
 #include "tools/cabana/dbc/dbcfile.h"

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -77,6 +77,8 @@ MainWindow::MainWindow() : QMainWindow() {
 void MainWindow::createActions() {
   QMenu *file_menu = menuBar()->addMenu(tr("&File"));
   file_menu->addAction(tr("Open Stream..."), this, &MainWindow::openStream);
+  close_stream_act = file_menu->addAction(tr("Close stream"), this, &MainWindow::closeStream);
+  close_stream_act->setEnabled(false);
   file_menu->addSeparator();
 
   file_menu->addAction(tr("New DBC File"), [this]() { newFile(); })->setShortcuts(QKeySequence::New);
@@ -246,6 +248,15 @@ void MainWindow::openStream() {
   }
 }
 
+void MainWindow::closeStream() {
+  AbstractStream *stream = new DummyStream(this);
+  stream->start();
+  if (dbc()->nonEmptyDBCCount() > 0) {
+    emit dbc()->DBCFileChanged();
+  }
+  statusBar()->showMessage(tr("stream closed"));
+}
+
 void MainWindow::newFile(SourceSet s) {
   closeFile(s);
   dbc()->open(s, "", "");
@@ -318,6 +329,7 @@ void MainWindow::changingStream() {
 }
 
 void MainWindow::streamStarted() {
+  close_stream_act->setEnabled(dynamic_cast<DummyStream *>(can) == nullptr);
   createDockWidgets();
 
   video_dock->setWindowTitle(can->routeName());
@@ -462,6 +474,7 @@ void MainWindow::updateLoadSaveMenus() {
   std::sort(sources_sorted.begin(), sources_sorted.end());
 
   manage_dbcs_menu->clear();
+  manage_dbcs_menu->setEnabled(dynamic_cast<DummyStream *>(can) == nullptr);
 
   for (uint8_t source : sources_sorted) {
     if (source >= 64) continue; // Sent and blocked buses are handled implicitly

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -178,6 +178,7 @@ void MainWindow::createDockWidgets() {
   video_splitter->addWidget(charts_container);
   video_splitter->setStretchFactor(1, 1);
   video_splitter->restoreState(settings.video_splitter_state);
+  video_splitter->handle(1)->setEnabled(!can->liveStreaming());
   video_dock->setWidget(video_splitter);
   QObject::connect(charts_widget, &ChartsWidget::dock, this, &MainWindow::dockCharts);
 }

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -6,7 +6,6 @@
 #include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
-#include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QResizeEvent>
@@ -136,7 +135,7 @@ void MainWindow::createActions() {
   commands_act->setDefaultWidget(new QUndoView(UndoStack::instance()));
   commands_menu->addAction(commands_act);
 
-  QMenu *tools_menu = menuBar()->addMenu(tr("&Tools"));
+  tools_menu = menuBar()->addMenu(tr("&Tools"));
   tools_menu->addAction(tr("Find &Similar Bits"), this, &MainWindow::findSimilarBits);
   tools_menu->addAction(tr("&Find Signal"), this, &MainWindow::findSignal);
 
@@ -329,7 +328,9 @@ void MainWindow::changingStream() {
 }
 
 void MainWindow::streamStarted() {
-  close_stream_act->setEnabled(dynamic_cast<DummyStream *>(can) == nullptr);
+  bool has_stream = dynamic_cast<DummyStream *>(can) == nullptr;
+  close_stream_act->setEnabled(has_stream);
+  tools_menu->setEnabled(has_stream);
   createDockWidgets();
 
   video_dock->setWindowTitle(can->routeName());

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -3,6 +3,7 @@
 #include <QDockWidget>
 #include <QJsonDocument>
 #include <QMainWindow>
+#include <QMenu>
 #include <QProgressBar>
 #include <QSplitter>
 #include <QStatusBar>
@@ -89,6 +90,7 @@ protected:
   QAction *recent_files_acts[MAX_RECENT_FILES] = {};
   QMenu *open_recent_menu = nullptr;
   QMenu *manage_dbcs_menu = nullptr;
+  QMenu *tools_menu = nullptr;
   QAction *close_stream_act = nullptr;
   QAction *save_dbc = nullptr;
   QAction *save_dbc_as = nullptr;

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -26,6 +26,7 @@ public:
 
 public slots:
   void openStream();
+  void closeStream();
   void changingStream();
   void streamStarted();
 
@@ -88,6 +89,7 @@ protected:
   QAction *recent_files_acts[MAX_RECENT_FILES] = {};
   QMenu *open_recent_menu = nullptr;
   QMenu *manage_dbcs_menu = nullptr;
+  QAction *close_stream_act = nullptr;
   QAction *save_dbc = nullptr;
   QAction *save_dbc_as = nullptr;
   QAction *copy_dbc_to_clipboard = nullptr;

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -243,100 +243,54 @@ void MessageListModel::sortMessages(std::vector<MessageId> &new_msgs) {
   }
 }
 
-static std::pair<unsigned int, unsigned int> parseRange(const QString &filter, bool *ok = nullptr, int base = 10) {
+static bool parseRange(const QString &filter, uint32_t value, int base = 10) {
   // Parse out filter string into a range (e.g. "1" -> {1, 1}, "1-3" -> {1, 3}, "1-" -> {1, inf})
-  bool ok1 = true, ok2 = true;
-  unsigned int parsed1 = std::numeric_limits<unsigned int>::min();
-  unsigned int parsed2 = std::numeric_limits<unsigned int>::max();
-
+  unsigned int min = std::numeric_limits<unsigned int>::min();
+  unsigned int max = std::numeric_limits<unsigned int>::max();
   auto s = filter.split('-');
-  if (s.size() == 1) {
-    parsed1 = s[0].toUInt(ok, base);
-    return {parsed1, parsed1};
-  } else if (s.size() == 2) {
-    if (!s[0].isEmpty()) parsed1 = s[0].toUInt(&ok1, base);
-    if (!s[1].isEmpty()) parsed2 = s[1].toUInt(&ok2, base);
-
-    *ok = ok1 & ok2;
-    return {parsed1, parsed2};
-  } else {
-    *ok = false;
-    return {0, 0};
-  }
+  bool ok = s.size() <= 2;
+  if (ok && !s[0].isEmpty()) min = s[0].toUInt(&ok, base);
+  if (ok && s.size() == 2 && !s[1].isEmpty()) max = s[1].toUInt(&ok, base);
+  return ok && value >= min && value <= max;
 }
 
 bool MessageListModel::matchMessage(const MessageId &id, const CanData &data, const QMap<int, QString> &filters) {
   bool match = true;
-  bool convert_ok;
-
   for (auto it = filters.cbegin(); it != filters.cend() && match; ++it) {
     const QString &txt = it.value();
     QRegularExpression re(txt, QRegularExpression::CaseInsensitiveOption | QRegularExpression::DotMatchesEverythingOption);
-
     switch (it.key()) {
-      case Column::NAME:
-        {
-          bool name_match = re.match(msgName(id)).hasMatch();
-
-          // Message signals
-          if (const auto msg = dbc()->msg(id)) {
-            for (auto s : msg->getSignals()) {
-              if (re.match(s->name).hasMatch()) {
-                name_match = true;
-                break;
-              }
-            }
-          }
-          if (!name_match) match = false;
-        }
+      case Column::NAME: {
+        const auto msg = dbc()->msg(id);
+        match = re.match(msg ? msg->name : UNTITLED).hasMatch();
+        match |= msg && std::any_of(msg->sigs.cbegin(), msg->sigs.cend(), [&re](const auto &s) { return re.match(s.name).hasMatch(); });
         break;
+      }
       case Column::SOURCE:
-        {
-          auto source = parseRange(txt, &convert_ok);
-          bool source_match = convert_ok && (id.source >= source.first && id.source <= source.second);
-          if (!source_match) match = false;
-        }
+        match = parseRange(txt, id.source);
         break;
-      case Column::ADDRESS:
-        {
-          bool address_re_match = re.match(QString::number(id.address, 16)).hasMatch();
-
-          auto address = parseRange(txt, &convert_ok, 16);
-          bool address_match = convert_ok && (id.address >= address.first && id.address <= address.second);
-
-          if (!address_re_match && !address_match) match = false;
-        }
+      case Column::ADDRESS: {
+        match = re.match(QString::number(id.address, 16)).hasMatch();
+        match |= parseRange(txt, id.address, 16);
         break;
+      }
       case Column::FREQ:
-        {
-          // TODO: Hide stale messages?
-          auto freq = parseRange(txt, &convert_ok);
-          bool freq_match = convert_ok && (data.freq >= freq.first && data.freq <= freq.second);
-          if (!freq_match) match = false;
-        }
+        // TODO: Hide stale messages?
+        match = parseRange(txt, data.freq);
         break;
       case Column::COUNT:
-        {
-          auto count = parseRange(txt, &convert_ok);
-          bool count_match = convert_ok && (data.count >= count.first && data.count <= count.second);
-          if (!count_match) match = false;
-        }
+        match = parseRange(txt, data.count);
         break;
-      case Column::DATA:
-        {
-          bool data_match = false;
-          data_match |= QString(data.dat.toHex()).contains(txt, Qt::CaseInsensitive);
-          data_match |= re.match(QString(data.dat.toHex())).hasMatch();
-          data_match |= re.match(QString(data.dat.toHex(' '))).hasMatch();
-
-          if (!data_match) match = false;
-        }
+      case Column::DATA: {
+        match = QString(data.dat.toHex()).contains(txt, Qt::CaseInsensitive);
+        match |= re.match(QString(data.dat.toHex())).hasMatch();
+        match |= re.match(QString(data.dat.toHex(' '))).hasMatch();
         break;
+      }
     }
   }
   return match;
 }
-
 
 void MessageListModel::fetchData() {
   std::vector<MessageId> new_msgs;

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -100,6 +100,15 @@ protected:
   AbstractStream **stream = nullptr;
 };
 
+class DummyStream : public AbstractStream {
+  Q_OBJECT
+public:
+  DummyStream(QObject *parent) : AbstractStream(parent) {}
+  QString routeName() const override { return tr("No Stream"); }
+  void start() override { emit streamStarted(); }
+  double currentSec() const override { return 0; }
+};
+
 class StreamNotifier : public QObject {
   Q_OBJECT
 public:

--- a/tools/cabana/tools/findsimilarbits.cc
+++ b/tools/cabana/tools/findsimilarbits.cc
@@ -20,12 +20,8 @@ FindSimilarBitsDlg::FindSimilarBitsDlg(QWidget *parent) : QDialog(parent, Qt::Wi
   QHBoxLayout *src_layout = new QHBoxLayout();
   src_bus_combo = new QComboBox(this);
   find_bus_combo = new QComboBox(this);
-  SourceSet bus_set;
-  for (auto it = can->last_msgs.begin(); it != can->last_msgs.end(); ++it) {
-    bus_set << it.key().source;
-  }
   for (auto cb : {src_bus_combo, find_bus_combo}) {
-    for (uint8_t bus : bus_set) {
+    for (uint8_t bus : can->sources) {
       cb->addItem(QString::number(bus), bus);
     }
     cb->model()->sort(0);


### PR DESCRIPTION
1. Support launching Cabana without connecting to a stream (Click 'cancel' button in the open stream dialog). cabana will function as a DBC file editor in this case:
 
![Screenshot from 2023-05-25 17-01-45](https://github.com/commaai/openpilot/assets/27770/e4e65e82-4b39-4739-b017-b82c472dc478)

2. add "Close Stream" to file menu. you can open/close a stream at any time. Cabana will switch to edit mode after closing the stream:

![2023-05-25_17-02](https://github.com/commaai/openpilot/assets/27770/98c03ade-916c-4614-8e50-c6351eec6d09)

video:

[Kazam_screencast_00117.webm](https://github.com/commaai/openpilot/assets/27770/208572c8-0c39-4fe5-bddd-c32fe5674919)

3. improve & cleanup `MessageListModel::matchMessage`
