### PR TITLE
controls: write recalibrating offroad alert once

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -178,6 +178,7 @@ class Controls:
     self.desired_curvature_rate = 0.0
     self.experimental_mode = False
     self.v_cruise_helper = VCruiseHelper(self.CP)
+    self.recalibrating_seen = False
 
     # TODO: no longer necessary, aside from process replay
     self.sm['liveParameters'].valid = True
@@ -286,8 +287,9 @@ class Controls:
       if cal_status == log.LiveCalibrationData.Status.uncalibrated:
         self.events.add(EventName.calibrationIncomplete)
       elif cal_status == log.LiveCalibrationData.Status.recalibrating:
-        if self.params.get("Offroad_Recalibration") is None:
+        if not self.recalibrating_seen:
           set_offroad_alert("Offroad_Recalibration", True)
+        self.recalibrating_seen = True
         self.events.add(EventName.calibrationRecalibrating)
       else:
         self.events.add(EventName.calibrationInvalid)

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -286,7 +286,8 @@ class Controls:
       if cal_status == log.LiveCalibrationData.Status.uncalibrated:
         self.events.add(EventName.calibrationIncomplete)
       elif cal_status == log.LiveCalibrationData.Status.recalibrating:
-        set_offroad_alert("Offroad_Recalibration", True)
+        if self.params.get("Offroad_Recalibration") is None:
+          set_offroad_alert("Offroad_Recalibration", True)
         self.events.add(EventName.calibrationRecalibrating)
       else:
         self.events.add(EventName.calibrationInvalid)


### PR DESCRIPTION
thermald has a nice function to only write if the status has changed, but it relies on a global variable in the file:

https://github.com/commaai/openpilot/blob/f678ff0f2282d9374a13fa9513f5f8f43f5dac11/selfdrive/thermald/thermald.py#L89-L93

we can also make `set_offroad_alert` check the file existence, but it doesn't really work for `extra_text` which we don't care about in this specific case (this is the only place we call `set_offroad_alert` in a high-rate loop)

lags quite heavily and shows controlsdLagging alert instead of recalibrating while softDisabling:

![image](https://github.com/commaai/openpilot/assets/25857203/5afb5d49-b516-4f0a-8460-e542dd7625e4)

https://connect.comma.ai/f15e3c37c118e841/1685088456190/1685088556786