### PR TITLE
cabana: improve dbc parsing

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -40,7 +40,7 @@ void cabana::Signal::updatePrecision() {
 QString cabana::Signal::formatValue(double value) const {
   // Show enum string
   for (auto &[val, desc] : val_desc) {
-    if (std::abs(value - val.toInt()) < 1e-6) {
+    if (std::abs(value - val) < 1e-6) {
       return desc;
     }
   }

--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -42,7 +42,7 @@ struct std::hash<MessageId> {
   std::size_t operator()(const MessageId &k) const noexcept { return qHash(k); }
 };
 
-typedef QList<std::pair<QString, QString>> ValueDescription;
+typedef QList<std::pair<double, QString>> ValueDescription;
 
 namespace cabana {
   struct Signal {

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -224,7 +224,7 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   display_type_cb->setToolTip(tr("Display signal value or raw hex value"));
   comp_box->addItems({">", "=", "!=", "<"});
   value_edit->setClearButtonEnabled(true);
-  value_edit->setValidator(new QDoubleValidator(-500000, 500000, 6, this));
+  value_edit->setValidator(new DoubleValidator(this));
   dynamic_mode->setChecked(true);
   dynamic_mode->setEnabled(!can->liveStreaming());
 

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -133,7 +133,7 @@ QVariant SignalModel::data(const QModelIndex &index, int role) const {
           case Item::Desc: {
             QStringList val_desc;
             for (auto &[val, desc] : item->sig->val_desc) {
-              val_desc << QString("%1 \"%2\"").arg(val, desc);
+              val_desc << QString("%1 \"%2\"").arg(val).arg(desc);
             }
             return val_desc.join(" ");
           }
@@ -284,11 +284,7 @@ void SignalModel::handleSignalRemoved(const cabana::Signal *sig) {
 
 SignalItemDelegate::SignalItemDelegate(QObject *parent) : QStyledItemDelegate(parent) {
   name_validator = new NameValidator(this);
-
-  QLocale locale(QLocale::C);
-  locale.setNumberOptions(QLocale::RejectGroupSeparator);
-  double_validator = new QDoubleValidator(this);
-  double_validator->setLocale(locale);  // Match locale of QString::toDouble() instead of system
+  double_validator = new DoubleValidator(this);
 
   label_font.setPointSize(8);
   minmax_font.setPixelSize(10);
@@ -666,7 +662,7 @@ ValueDescriptionDlg::ValueDescriptionDlg(const ValueDescription &descriptions, Q
 
   int row = 0;
   for (auto &[val, desc] : descriptions) {
-    table->setItem(row, 0, new QTableWidgetItem(val));
+    table->setItem(row, 0, new QTableWidgetItem(QString::number(val)));
     table->setItem(row, 1, new QTableWidgetItem(desc));
     ++row;
   }
@@ -696,7 +692,7 @@ void ValueDescriptionDlg::save() {
     QString val = table->item(i, 0)->text().trimmed();
     QString desc = table->item(i, 1)->text().trimmed();
     if (!val.isEmpty() && !desc.isEmpty()) {
-      val_desc.push_back({val, desc});
+      val_desc.push_back({val.toDouble(), desc});
     }
   }
   QDialog::accept();
@@ -706,7 +702,7 @@ QWidget *ValueDescriptionDlg::Delegate::createEditor(QWidget *parent, const QSty
   QLineEdit *edit = new QLineEdit(parent);
   edit->setFrame(false);
   if (index.column() == 0) {
-    edit->setValidator(new QIntValidator(edit));
+    edit->setValidator(new DoubleValidator(parent));
   }
   return edit;
 }

--- a/tools/cabana/tools/findsignal.cc
+++ b/tools/cabana/tools/findsignal.cc
@@ -1,6 +1,5 @@
 #include "tools/cabana/tools/findsignal.h"
 
-#include <QDoubleValidator>
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QHeaderView>
@@ -138,8 +137,7 @@ FindSignalDlg::FindSignalDlg(QWidget *parent) : QDialog(parent, Qt::WindowFlags(
   undo_btn->setEnabled(false);
   reset_btn->setEnabled(false);
 
-  auto double_validator = new QDoubleValidator(this);
-  double_validator->setLocale(QLocale::C);
+  auto double_validator = new DoubleValidator(this);
   for (auto edit : {value1, value2, factor_edit, offset_edit, first_time_edit, last_time_edit}) {
     edit->setValidator(double_validator);
   }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -2,6 +2,7 @@
 
 #include <QFontDatabase>
 #include <QHelpEvent>
+#include <QLocale>
 #include <QPainter>
 #include <QPixmapCache>
 #include <QToolTip>
@@ -159,6 +160,13 @@ NameValidator::NameValidator(QObject *parent) : QRegExpValidator(QRegExp("^(\\w+
 QValidator::State NameValidator::validate(QString &input, int &pos) const {
   input.replace(' ', '_');
   return QRegExpValidator::validate(input, pos);
+}
+
+DoubleValidator::DoubleValidator(QObject *parent) : QDoubleValidator(parent) {
+  // Match locale of QString::toDouble() instead of system
+  QLocale locale(QLocale::C);
+  locale.setNumberOptions(QLocale::RejectGroupSeparator);
+  setLocale(locale);
 }
 
 namespace utils {

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -6,6 +6,7 @@
 #include <QApplication>
 #include <QByteArray>
 #include <QDateTime>
+#include <QDoubleValidator>
 #include <QColor>
 #include <QFont>
 #include <QRegExpValidator>
@@ -84,10 +85,15 @@ QColor getColor(const cabana::Signal *sig);
 
 class NameValidator : public QRegExpValidator {
   Q_OBJECT
-
 public:
   NameValidator(QObject *parent=nullptr);
   QValidator::State validate(QString &input, int &pos) const override;
+};
+
+class DoubleValidator : public QDoubleValidator {
+  Q_OBJECT
+public:
+  DoubleValidator(QObject *parent = nullptr);
 };
 
 namespace utils {


### PR DESCRIPTION
1. throw exception on error instead of silently skipping:
  ![Screenshot from 2023-05-28 01-39-59](https://github.com/commaai/openpilot/assets/27770/1ea1b897-dc2e-4bae-a486-9ce63e955995)
2. use c local for all double validator
3. Improve val_regexp to parse value descriptions without semicolon endings.
4. use `std::pair<double, QString>` for value description instead of `std::pair<QString, QString>`:
  ![Screenshot from 2023-05-28 02-57-40](https://github.com/commaai/openpilot/assets/27770/28131314-d3b7-4025-9cd2-354b90a25ddd)
