### PR TITLE
IsoTpParallelQuery: log all timeouts

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -120,7 +120,6 @@ class IsoTpParallelQuery:
 
         counter = request_counter[tx_addr]
         expected_response = self.response[counter]
-        # response_valid = dat[:len(expected_response)] == expected_response
         response_valid = dat.startswith(expected_response)
 
         if response_valid:

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -80,7 +80,6 @@ class IsoTpParallelQuery:
     msgs = {}
     request_counter = {}
     request_done = {}
-    addrs_responded = set()  # track addresses that have ever sent a valid iso-tp frame for timeout logging
     for tx_addr, rx_addr in self.msg_addrs.items():
       msgs[tx_addr] = self._create_isotp_msg(*tx_addr, rx_addr)
       request_counter[tx_addr] = 0
@@ -97,6 +96,7 @@ class IsoTpParallelQuery:
 
     results = {}
     start_time = time.monotonic()
+    addrs_responded = set()  # track addresses that have ever sent a valid iso-tp frame for timeout logging
     response_timeouts = {tx_addr: start_time + timeout for tx_addr in self.msg_addrs}
     while True:
       self.rx()
@@ -111,8 +111,8 @@ class IsoTpParallelQuery:
 
         # Extend timeout for each consecutive ISO-TP frame to avoid timing out on long responses
         if rx_in_progress:
-          response_timeouts[tx_addr] = time.monotonic() + timeout
           addrs_responded.add(tx_addr)
+          response_timeouts[tx_addr] = time.monotonic() + timeout
 
         if not dat:
           continue

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -80,6 +80,7 @@ class IsoTpParallelQuery:
     msgs = {}
     request_counter = {}
     request_done = {}
+    addrs_responded = set()  # track addresses that have ever sent a valid iso-tp frame for timeout logging
     for tx_addr, rx_addr in self.msg_addrs.items():
       msgs[tx_addr] = self._create_isotp_msg(*tx_addr, rx_addr)
       request_counter[tx_addr] = 0
@@ -97,7 +98,6 @@ class IsoTpParallelQuery:
     results = {}
     start_time = time.monotonic()
     response_timeouts = {tx_addr: start_time + timeout for tx_addr in self.msg_addrs}
-    addrs_responded = set()
     while True:
       self.rx()
 

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -90,8 +90,7 @@ class IsoTpParallelQuery:
       for addr in self.functional_addrs:
         self._create_isotp_msg(addr, None, -1).send(self.request[0])
 
-    # Send first frame (single or first) to all addresses and receive asynchronously in the loop below.
-    # If querying functional addrs, only set up physical IsoTpMessages to send consecutive frames
+    # If querying functional addrs, set up physical IsoTpMessages to send consecutive frames
     for msg in msgs.values():
       msg.send(self.request[0], setup_only=len(self.functional_addrs) > 0)
 
@@ -120,7 +119,7 @@ class IsoTpParallelQuery:
 
         counter = request_counter[tx_addr]
         expected_response = self.response[counter]
-        response_valid = dat.startswith(expected_response)
+        response_valid = dat[:len(expected_response)] == expected_response
 
         if response_valid:
           if counter + 1 < len(self.request):

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -90,13 +90,15 @@ class IsoTpParallelQuery:
       for addr in self.functional_addrs:
         self._create_isotp_msg(addr, None, -1).send(self.request[0])
 
-    # If querying functional addrs, set up physical IsoTpMessages to send consecutive frames
+    # Send first frame (single or first) to all addresses and receive asynchronously in the loop below.
+    # If querying functional addrs, only set up physical IsoTpMessages to send consecutive frames
     for msg in msgs.values():
       msg.send(self.request[0], setup_only=len(self.functional_addrs) > 0)
 
     results = {}
     start_time = time.monotonic()
     response_timeouts = {tx_addr: start_time + timeout for tx_addr in self.msg_addrs}
+    addrs_ever_responded = set()
     while True:
       self.rx()
 
@@ -111,13 +113,15 @@ class IsoTpParallelQuery:
         # Extend timeout for each consecutive ISO-TP frame to avoid timing out on long responses
         if rx_in_progress:
           response_timeouts[tx_addr] = time.monotonic() + timeout
+          addrs_ever_responded.add(tx_addr)
 
         if not dat:
           continue
 
         counter = request_counter[tx_addr]
         expected_response = self.response[counter]
-        response_valid = dat[:len(expected_response)] == expected_response
+        # response_valid = dat[:len(expected_response)] == expected_response
+        response_valid = dat.startswith(expected_response)
 
         if response_valid:
           if counter + 1 < len(self.request):
@@ -140,8 +144,14 @@ class IsoTpParallelQuery:
       cur_time = time.monotonic()
       for tx_addr in response_timeouts:
         if cur_time - response_timeouts[tx_addr] > 0:
-          if request_counter[tx_addr] > 0 and not request_done[tx_addr]:
-            cloudlog.error(f"iso-tp query timeout after receiving response: {tx_addr}")
+          if not request_done[tx_addr]:
+            # Log appropriate error message based on whether we received a partial response
+            if request_counter[tx_addr] > 0:
+              cloudlog.error(f"iso-tp query timeout after receiving partial response: {tx_addr}")
+            elif tx_addr in addrs_ever_responded:
+              cloudlog.error(f"iso-tp query timeout while receiving response: {tx_addr}")
+            else:
+              cloudlog.error(f"iso-tp query timeout with no response: {tx_addr}")
           request_done[tx_addr] = True
 
       # Break if all requests are done (finished or timed out)

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -145,7 +145,6 @@ class IsoTpParallelQuery:
       for tx_addr in response_timeouts:
         if cur_time - response_timeouts[tx_addr] > 0:
           if not request_done[tx_addr]:
-            # Log appropriate error message based on whether we received a partial response
             if request_counter[tx_addr] > 0:
               cloudlog.error(f"iso-tp query timeout after receiving partial response: {tx_addr}")
             elif tx_addr in addrs_ever_responded:

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -97,7 +97,7 @@ class IsoTpParallelQuery:
     results = {}
     start_time = time.monotonic()
     response_timeouts = {tx_addr: start_time + timeout for tx_addr in self.msg_addrs}
-    addrs_ever_responded = set()
+    addrs_responded = set()
     while True:
       self.rx()
 
@@ -112,7 +112,7 @@ class IsoTpParallelQuery:
         # Extend timeout for each consecutive ISO-TP frame to avoid timing out on long responses
         if rx_in_progress:
           response_timeouts[tx_addr] = time.monotonic() + timeout
-          addrs_ever_responded.add(tx_addr)
+          addrs_responded.add(tx_addr)
 
         if not dat:
           continue
@@ -145,7 +145,7 @@ class IsoTpParallelQuery:
           if not request_done[tx_addr]:
             if request_counter[tx_addr] > 0:
               cloudlog.error(f"iso-tp query timeout after receiving partial response: {tx_addr}")
-            elif tx_addr in addrs_ever_responded:
+            elif tx_addr in addrs_responded:
               cloudlog.error(f"iso-tp query timeout while receiving response: {tx_addr}")
             else:
               cloudlog.error(f"iso-tp query timeout with no response: {tx_addr}")


### PR DESCRIPTION
Currently, we will only log timeouts on queries with more than 1 request (not bytes, or frames, actual tx and rx cycle). So hyundai with one request will never have any timeouts logged