### PR TITLE
Ford: fix counter in LateralMotionControl2 message

### DIFF
--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -70,7 +70,7 @@ class CarController:
       if self.CP.carFingerprint in CANFD_CARS:
         # TODO: extended mode
         mode = 1 if CC.latActive else 0
-        counter = self.frame // CarControllerParams.STEER_STEP
+        counter = (self.frame // CarControllerParams.STEER_STEP) % 0xF
         can_sends.append(create_lat_ctl2_msg(self.packer, mode, 0., 0., -apply_curvature, 0., counter))
       else:
         can_sends.append(create_lat_ctl_msg(self.packer, CC.latActive, 0., 0., -apply_curvature, 0.))


### PR DESCRIPTION
This only affects the currently unsupported CAN FD platforms.