### PR TITLE
Nissan: add counter signal to forwarded message

### DIFF
--- a/selfdrive/car/nissan/carstate.py
+++ b/selfdrive/car/nissan/carstate.py
@@ -171,6 +171,7 @@ class CarState(CarStateBase):
         ("USER_BRAKE_PRESSED", "CRUISE_THROTTLE"),
         ("NEW_SIGNAL_2", "CRUISE_THROTTLE"),
         ("GAS_PRESSED_INVERTED", "CRUISE_THROTTLE"),
+        ("COUNTER", "CRUISE_THROTTLE"),
         ("unsure1", "CRUISE_THROTTLE"),
         ("unsure2", "CRUISE_THROTTLE"),
         ("unsure3", "CRUISE_THROTTLE"),


### PR DESCRIPTION
I was not aware that dbc.cc only adds the counter type to signals where we explicitly say to track them for that dbc