### PR TITLE
cars: log non-critical car faults

### DIFF
--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -199,7 +199,7 @@ class CarState(CarStateBase):
     else:
       if self.CP.openpilotLongitudinalControl:
         self.brake_error = cp.vl["STANDSTILL"]["BRAKE_ERROR_1"] or cp.vl["STANDSTILL"]["BRAKE_ERROR_2"]
-      ret.accFaultedNonCritical = cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"]
+      ret.adasFaulted = cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"]
     ret.espDisabled = cp.vl["VSA_STATUS"]["ESP_DISABLED"] != 0
 
     ret.wheelSpeeds = self.get_wheel_speeds(

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -196,9 +196,15 @@ class CarState(CarStateBase):
     if self.CP.carFingerprint in HONDA_BOSCH_RADARLESS:
       ret.accFaulted = bool(cp.vl["CRUISE_FAULT_STATUS"]["CRUISE_FAULT"])
     else:
+      # FIXME: On some cars, these two signals are always 1, this flag is masking a bug in release
+      # find and set the ACC faulted signals on more platforms
       if self.CP.openpilotLongitudinalControl:
         ret.accFaulted = bool(cp.vl["STANDSTILL"]["BRAKE_ERROR_1"] or cp.vl["STANDSTILL"]["BRAKE_ERROR_2"])
-      ret.carFaultedNonCritical = bool(cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"])
+
+        # Log non-critical stock ACC/LKAS faults if Nidec (camera)
+        if self.CP.carFingerprint not in HONDA_BOSCH:
+          ret.carFaultedNonCritical = bool(cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"])
+
     ret.espDisabled = cp.vl["VSA_STATUS"]["ESP_DISABLED"] != 0
 
     ret.wheelSpeeds = self.get_wheel_speeds(

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -196,8 +196,8 @@ class CarState(CarStateBase):
     if self.CP.carFingerprint in HONDA_BOSCH_RADARLESS:
       ret.accFaulted = bool(cp.vl["CRUISE_FAULT_STATUS"]["CRUISE_FAULT"])
     else:
-      # FIXME: On some cars, these two signals are always 1, this flag is masking a bug in release
-      # find and set the ACC faulted signals on more platforms
+      # On some cars, these two signals are always 1, this flag is masking a bug in release
+      # FIXME: find and set the ACC faulted signals on more platforms
       if self.CP.openpilotLongitudinalControl:
         ret.accFaulted = bool(cp.vl["STANDSTILL"]["BRAKE_ERROR_1"] or cp.vl["STANDSTILL"]["BRAKE_ERROR_2"])
 

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -196,8 +196,10 @@ class CarState(CarStateBase):
 
     if self.CP.carFingerprint in HONDA_BOSCH_RADARLESS:
       self.brake_error = cp.vl["CRUISE_FAULT_STATUS"]["CRUISE_FAULT"]
-    elif self.CP.openpilotLongitudinalControl:
-      self.brake_error = cp.vl["STANDSTILL"]["BRAKE_ERROR_1"] or cp.vl["STANDSTILL"]["BRAKE_ERROR_2"]
+    else:
+      if self.CP.openpilotLongitudinalControl:
+        self.brake_error = cp.vl["STANDSTILL"]["BRAKE_ERROR_1"] or cp.vl["STANDSTILL"]["BRAKE_ERROR_2"]
+      ret.accFaultedNonCritical = cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"]
     ret.espDisabled = cp.vl["VSA_STATUS"]["ESP_DISABLED"] != 0
 
     ret.wheelSpeeds = self.get_wheel_speeds(
@@ -332,12 +334,15 @@ class CarState(CarStateBase):
                   ("AEB_REQ_1", "BRAKE_COMMAND"),
                   ("FCW", "BRAKE_COMMAND"),
                   ("CHIME", "BRAKE_COMMAND"),
+                  ("LKAS_PROBLEM", "LKAS_HUD"),
                   ("FCM_OFF", "ACC_HUD"),
                   ("FCM_OFF_2", "ACC_HUD"),
                   ("FCM_PROBLEM", "ACC_HUD"),
+                  ("ACC_PROBLEM", "ACC_HUD"),
                   ("ICONS", "ACC_HUD")]
       checks += [
         ("ACC_HUD", 10),
+        ("LKAS_HUD", 10),
         ("BRAKE_COMMAND", 50),
       ]
 

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -201,9 +201,9 @@ class CarState(CarStateBase):
       if self.CP.openpilotLongitudinalControl:
         ret.accFaulted = bool(cp.vl["STANDSTILL"]["BRAKE_ERROR_1"] or cp.vl["STANDSTILL"]["BRAKE_ERROR_2"])
 
-        # Log non-critical stock ACC/LKAS faults if Nidec (camera)
-        if self.CP.carFingerprint not in HONDA_BOSCH:
-          ret.carFaultedNonCritical = bool(cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"])
+      # Log non-critical stock ACC/LKAS faults if Nidec (camera)
+      if self.CP.carFingerprint not in HONDA_BOSCH:
+        ret.carFaultedNonCritical = bool(cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"])
 
     ret.espDisabled = cp.vl["VSA_STATUS"]["ESP_DISABLED"] != 0
 

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -264,6 +264,8 @@ class CarInterfaceBase(ABC):
       events.add(EventName.parkBrake)
     if cs_out.accFaulted:
       events.add(EventName.accFaulted)
+    if cs_out.adasFaulted:
+      events.add(EventName.adasFaulted)
     if cs_out.steeringPressed:
       events.add(EventName.steerOverride)
 

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -264,8 +264,6 @@ class CarInterfaceBase(ABC):
       events.add(EventName.parkBrake)
     if cs_out.accFaulted:
       events.add(EventName.accFaulted)
-    if cs_out.adasFaulted:
-      events.add(EventName.adasFaulted)
     if cs_out.steeringPressed:
       events.add(EventName.steerOverride)
 


### PR DESCRIPTION
adds field to carstate and an event to log when some portion of the car's ADAS systems are faulted, but openpilot can still engage. for example, the camera on Nidec (and many others) wants to display a faulted signal but we block and send our own. this should only be used to log superficial faults, nothing that prevents any kind of control