### PR TITLE
cars: explicitly add counter/checksum messages

### DIFF
--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -486,6 +486,8 @@ class CarState(CarStateBase):
 
     if not (CP.flags & HyundaiFlags.CANFD_CAMERA_SCC.value) and not CP.openpilotLongitudinalControl:
       signals += [
+        ("COUNTER", "SCC_CONTROL"),
+        ("CHECKSUM", "SCC_CONTROL"),
         ("ACCMode", "SCC_CONTROL"),
         ("VSetDis", "SCC_CONTROL"),
         ("CRUISE_STANDSTILL", "SCC_CONTROL"),
@@ -528,6 +530,7 @@ class CarState(CarStateBase):
     elif CP.flags & HyundaiFlags.CANFD_CAMERA_SCC:
       signals += [
         ("COUNTER", "SCC_CONTROL"),
+        ("CHECKSUM", "SCC_CONTROL"),
         ("NEW_SIGNAL_1", "SCC_CONTROL"),
         ("MainMode_ACC", "SCC_CONTROL"),
         ("ACCMode", "SCC_CONTROL"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -110,6 +110,7 @@ class CarState(CarStateBase):
   def get_global_es_distance_signals():
     signals = [
       ("COUNTER", "ES_Distance"),
+      ("CHECKSUM", "ES_Distance"),
       ("Signal1", "ES_Distance"),
       ("Cruise_Fault", "ES_Distance"),
       ("Cruise_Throttle", "ES_Distance"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -308,6 +308,8 @@ class CarState(CarStateBase):
 
       if CP.flags & SubaruFlags.SEND_INFOTAINMENT:
         signals += [
+          ("COUNTER", "INFOTAINMENT_STATUS"),
+          ("CHECKSUM", "INFOTAINMENT_STATUS"),
           ("LKAS_State_Infotainment", "INFOTAINMENT_STATUS"),
           ("LKAS_Blue_Lines", "INFOTAINMENT_STATUS"),
           ("Signal1", "INFOTAINMENT_STATUS"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -240,6 +240,7 @@ class CarState(CarStateBase):
         ("Cruise_Fault", "ES_Distance"),
         ("Signal5", "ES_Distance"),
         ("COUNTER", "ES_Distance"),
+        ("CHECKSUM", "ES_Distance"),
         ("Signal6", "ES_Distance"),
         ("Cruise_Button", "ES_Distance"),
         ("Signal7", "ES_Distance"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -279,6 +279,7 @@ class CarState(CarStateBase):
         ("Cruise_State", "ES_DashStatus"),
 
         ("COUNTER", "ES_LKAS_State"),
+        ("CHECKSUM", "ES_LKAS_State"),
         ("LKAS_Alert_Msg", "ES_LKAS_State"),
         ("Signal1", "ES_LKAS_State"),
         ("LKAS_ACTIVE", "ES_LKAS_State"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -252,6 +252,7 @@ class CarState(CarStateBase):
     else:
       signals = [
         ("COUNTER", "ES_DashStatus"),
+        ("CHECKSUM", "ES_DashStatus"),
         ("PCB_Off", "ES_DashStatus"),
         ("LDW_Off", "ES_DashStatus"),
         ("Signal1", "ES_DashStatus"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -240,7 +240,6 @@ class CarState(CarStateBase):
         ("Cruise_Fault", "ES_Distance"),
         ("Signal5", "ES_Distance"),
         ("COUNTER", "ES_Distance"),
-        ("CHECKSUM", "ES_Distance"),
         ("Signal6", "ES_Distance"),
         ("Cruise_Button", "ES_Distance"),
         ("Signal7", "ES_Distance"),


### PR DESCRIPTION
part of https://github.com/commaai/openpilot/pull/28336

CAN Parser automatically tracks COUNTER and CHECKSUM named signals, but only if the DBC name is in dbc.cc, this just makes it explicit for all cars