### PR TITLE
cabana: support displaying&editing overlapping signals in the binary view

### DIFF
--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -14,8 +14,8 @@ public:
   BinaryItemDelegate(QObject *parent);
   void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   void setSelectionColor(const QColor &color) { selection_color = color; }
-  bool isSameColor(const QModelIndex &index, int dx, int dy) const;
-  void drawBorder(QPainter* painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+  bool hasSignal(const QModelIndex &index, int dx, int dy, const cabana::Signal *sig) const;
+  void drawSignalCell(QPainter* painter, const QStyleOptionViewItem &option, const QModelIndex &index, const cabana::Signal *sig) const;
 
   QFont small_font, hex_font;
   QColor selection_color;
@@ -40,7 +40,7 @@ public:
   }
 
   struct Item {
-    QColor bg_color = QColor(102, 86, 169, 0);
+    QColor bg_color = QColor(102, 86, 169, 255);
     bool is_msb = false;
     bool is_lsb = false;
     QString val;


### PR DESCRIPTION

| before  | after |
| ------------- | ------------- |
| ![Screenshot from 2023-06-01 16-22-48](https://github.com/commaai/openpilot/assets/27770/324de671-f2fe-4fd3-a013-4f14d7fccc72)  | ![Screenshot from 2023-06-01 16-17-16](https://github.com/commaai/openpilot/assets/27770/4d0b025e-29d6-47ca-bab9-4636cf70d579)  |

[Kazam_screencast_00118.webm](https://github.com/commaai/openpilot/assets/27770/25c29252-9294-4a25-80d9-e15390c66f71)


this is also a prerequisite for multiplexed signals

