### PR TITLE
IsoTpParallelQuery: remove spammy log

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -148,8 +148,7 @@ class IsoTpParallelQuery:
               cloudlog.error(f"iso-tp query timeout after receiving partial response: {tx_addr}")
             elif tx_addr in addrs_responded:
               cloudlog.error(f"iso-tp query timeout while receiving response: {tx_addr}")
-            else:
-              cloudlog.error(f"iso-tp query timeout with no response: {tx_addr}")
+            # timeout with no response
           request_done[tx_addr] = True
 
       # Break if all requests are done (finished or timed out)

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -148,7 +148,8 @@ class IsoTpParallelQuery:
               cloudlog.error(f"iso-tp query timeout after receiving partial response: {tx_addr}")
             elif tx_addr in addrs_responded:
               cloudlog.error(f"iso-tp query timeout while receiving response: {tx_addr}")
-            # timeout with no response
+            else:
+              cloudlog.warning(f"iso-tp query timeout with no response: {tx_addr}")
           request_done[tx_addr] = True
 
       # Break if all requests are done (finished or timed out)

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -148,8 +148,9 @@ class IsoTpParallelQuery:
               cloudlog.error(f"iso-tp query timeout after receiving partial response: {tx_addr}")
             elif tx_addr in addrs_responded:
               cloudlog.error(f"iso-tp query timeout while receiving response: {tx_addr}")
-            else:
-              cloudlog.warning(f"iso-tp query timeout with no response: {tx_addr}")
+            # TODO: handle functional addresses
+            # else:
+            #   cloudlog.error(f"iso-tp query timeout with no response: {tx_addr}")
           request_done[tx_addr] = True
 
       # Break if all requests are done (finished or timed out)


### PR DESCRIPTION
I originally only wanted to add the timeout while receiving response, so this wasn't needed. Making it a warning