### PR TITLE
rawgpsd: fix loading assistance data

### DIFF
--- a/system/sensord/rawgps/rawgpsd.py
+++ b/system/sensord/rawgps/rawgpsd.py
@@ -141,10 +141,17 @@ def download_and_inject_assistance():
 
     # inject into module
     try:
-      subprocess.check_call(f"mmcli -m any --timeout 30 --location-inject-assistance-data={assist_data_file}", shell=True)
+      cmd = f"mmcli -m any --timeout 30 --location-inject-assistance-data={assist_data_file}"
+      subprocess.check_output(cmd, stderr=subprocess.PIPE, shell=True)
       cloudlog.info("successfully loaded assistance data")
-    except subprocess.CalledProcessError:
-      cloudlog.exception("rawgps.mmcli_command_failed")
+    except subprocess.CalledProcessError as e:
+      cloudlog.event(
+        "rawgps.assistance_loading_failed",
+        error=True,
+        cmd=e.cmd,
+        output=e.output,
+        returncode=e.returncode
+      )
   finally:
     if os.path.exists(assist_data_file):
       os.remove(assist_data_file)

--- a/system/sensord/rawgps/rawgpsd.py
+++ b/system/sensord/rawgps/rawgpsd.py
@@ -7,7 +7,6 @@ import math
 import time
 import pycurl
 import subprocess
-import tempfile
 from datetime import datetime
 from typing import NoReturn
 from struct import unpack_from, calcsize, pack
@@ -136,7 +135,7 @@ def download_and_inject_assistance():
         c.setopt(pycurl.WRITEDATA, fp)
         c.perform()
         c.close()
-    except pycurl.error as e:
+    except pycurl.error:
       cloudlog.exception("Failed to download assistance file")
       return
 


### PR DESCRIPTION
This was always failing since `c` is closed too early. Needs a CI test.
```
Failed to download assistance file with error: cannot invoke getinfo() - no curl handle
Traceback (most recent call last):
  File "./rawgpsd.py", line 122, in download_and_inject_assistance
    bytes_n = c.getinfo(c.CONTENT_LENGTH_DOWNLOAD)
pycurl.error: cannot invoke getinfo() - no curl handle
```