### PR TITLE
cabana: add a test case for dbc parsing

### DIFF
--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -212,7 +212,7 @@ void DBCFile::parseExtraInfo(const QString &content) {
   uint32_t address = 0;
   while (!stream.atEnd()) {
     ++line_num;
-    line = stream.readLine();
+    line = stream.readLine().trimmed();
     if (line.startsWith("BO_ ")) {
       auto match = bo_regexp.match(line);
       dbc_assert(match.hasMatch());

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -69,3 +69,44 @@ TEST_CASE("Parse can messages") {
     }
   }
 }
+
+TEST_CASE("Parse dbc") {
+  QString content = R"(
+BO_ 160 message_1: 8 XXX
+  SG_ signal_1 : 0|12@1+ (1,0) [0|4095] "unit"  XXX
+  SG_ signal_2 : 12|1@1+ (1.0,0.0) [0.0|1] ""  XXX
+
+VAL_ 160 signal_1 0 "disabled" 1.2 "initializing" 2 "fault";
+
+CM_ BO_ 160 "message comment";
+CM_ SG_ 160 signal_1 "signal comment";
+CM_ SG_ 160 signal_2 "multiple line comment
+1
+2
+";)";
+
+  DBCFile file("", content);
+  auto msg = file.msg(160);
+  REQUIRE(msg != nullptr);
+  REQUIRE(msg->name == "message_1");
+  REQUIRE(msg->size == 8);
+  REQUIRE(msg->comment == "message comment");
+  REQUIRE(msg->sigs.size() == 2);
+  REQUIRE(file.msg("message_1") != nullptr);
+
+  auto &sig_1 = msg->sigs[0];
+  REQUIRE(sig_1.name == "signal_1");
+  REQUIRE(sig_1.start_bit == 0);
+  REQUIRE(sig_1.size == 12);
+  REQUIRE(sig_1.min == 0);
+  REQUIRE(sig_1.max == 4095);
+  REQUIRE(sig_1.unit == "unit");
+  REQUIRE(sig_1.comment == "signal comment");
+  REQUIRE(sig_1.val_desc.size() == 3);
+  REQUIRE(sig_1.val_desc[0] == std::pair<double, QString>{0, "disabled"});
+  REQUIRE(sig_1.val_desc[1] == std::pair<double, QString>{1.2, "initializing"});
+  REQUIRE(sig_1.val_desc[2] == std::pair<double, QString>{2, "fault"});
+
+  auto &sig_2 = msg->sigs[1];
+  REQUIRE(sig_2.comment == "multiple line comment\n1\n2");
+}


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
