### PR TITLE
replay: fixed incorrect totalSeconds when there are invalid segments in route

### DIFF
--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -68,7 +68,7 @@ public:
   inline QDateTime currentDateTime() const { return route_->datetime().addSecs(currentSeconds()); }
   inline uint64_t routeStartTime() const { return route_start_ts_; }
   inline int toSeconds(uint64_t mono_time) const { return (mono_time - route_start_ts_) / 1e9; }
-  inline int totalSeconds() const { return segments_.size() * 60; }
+  inline int totalSeconds() const { return (!segments_.empty()) ? (segments_.rbegin()->first + 1) * 60 : 0; }
   inline void setSpeed(float speed) { speed_ = speed; }
   inline float getSpeed() const { return speed_; }
   inline const std::vector<Event *> *events() const { return events_.get(); }


### PR DESCRIPTION
Related cabana issue: https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6045018

This bug will also cause the replay's consoleUI to be unable to display the indicator line for the current time on the progress bar:

![2023-06-03_19-55](https://github.com/commaai/openpilot/assets/27770/603d2b72-4c84-4422-a10c-2e112deac6e6)
