### PR TITLE
Cabana: Improve contrast when using dark themes

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -437,9 +437,11 @@ void BinaryItemDelegate::drawSignalCell(QPainter *painter, const QStyleOptionVie
   auto sig_color = getColor(sig);
   QColor color = sig_color;
   color.setAlpha(item->bg_color.alpha());
-  painter->fillRect(rc, Qt::white);
+  // Mixing the signal colour with the Base background color to fade it
+  painter->fillRect(rc, QApplication::palette().color(QPalette::Base));
   painter->fillRect(rc, color);
 
+  // Draw edges
   color = sig_color.darker(125);
   painter->setPen(QPen(color, 1));
   if (draw_left) painter->drawLine(rc.topLeft(), rc.bottomLeft());

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -213,9 +213,19 @@ void ChartView::updateTitle() {
   for (QLegendMarker *marker : chart()->legend()->markers()) {
     QObject::connect(marker, &QLegendMarker::clicked, this, &ChartView::handleMarkerClicked, Qt::UniqueConnection);
   }
+
+  // Use CSS to draw titles in the WindowText color
+  auto tmp = palette().color(QPalette::WindowText);
+  auto titleColorCss = tmp.name(QColor::HexArgb);
+  // Draw message details in similar color, but slightly fade it to the background
+  tmp.setAlpha(180);
+  auto msgColorCss = tmp.name(QColor::HexArgb);
+
   for (auto &s : sigs) {
     auto decoration = s.series->isVisible() ? "none" : "line-through";
-    s.series->setName(QString("<span style=\"text-decoration:%1\"><b>%2</b> <font color=\"gray\">%3 %4</font></span>").arg(decoration, s.sig->name, msgName(s.msg_id), s.msg_id.toString()));
+    s.series->setName(QString("<span style=\"text-decoration:%1; color:%2\"><b>%3</b> <font color=\"%4\">%5 %6</font></span>")
+                      .arg(decoration, titleColorCss, s.sig->name,
+                           msgColorCss, msgName(s.msg_id), s.msg_id.toString()));
   }
   split_chart_act->setEnabled(sigs.size() > 1);
   resetChartCache();

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -63,7 +63,10 @@ QVariant HistoryLogModel::headerData(int section, Qt::Orientation orientation, i
         return "Data";
       }
     } else if (role == Qt::BackgroundRole && section > 0 && show_signals) {
-      return QBrush(getColor(sigs[section - 1]));
+      // Alpha-blend the signal color with the background to ensure contrast
+      QColor sigColor = getColor(sigs[section - 1]);
+      sigColor.setAlpha(128);
+      return QBrush(sigColor);
     }
   }
   return {};

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -459,7 +459,10 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   tree->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
   tree->header()->setStretchLastSection(true);
   tree->setMinimumHeight(300);
-  tree->setStyleSheet("QSpinBox{background-color:white;border:none;} QLineEdit{background-color:white;}");
+
+  // Use a distinctive background for the whole row containing a QSpinBox or QLineEdit
+  QString nodeBgColor = palette().color(QPalette::AlternateBase).name(QColor::HexArgb);
+  tree->setStyleSheet(QString("QSpinBox{background-color:%1;border:none;} QLineEdit{background-color:%1;}").arg(nodeBgColor));
 
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
Change some hard-coded colors in the Cabana UI that didn't always contrast well when using different system color themes:

* Signal view text/value editor background
* Signal log view heading text
* Binaryview signal box color (when not selected or highlighted)
* Chart title & message text

Before (automatic system theme with dark colors)
![before_automatic_dark_theme](https://github.com/commaai/openpilot/assets/205573/5584cd8e-6f8e-46ea-ad1a-e6980a3f299b)

Before (manually configured dark theme)
![before_manual_darktheme](https://github.com/commaai/openpilot/assets/205573/43be16f1-868d-4831-9518-a400d3e89511)

After (automatic system theme with dark colors)
![after_automatic_dark](https://github.com/commaai/openpilot/assets/205573/a53307f3-b170-4e8d-963f-faa8a0e9f8b7)

After (manually configured dark theme)
![after_manual_darktheme](https://github.com/commaai/openpilot/assets/205573/0b8d951b-7cf6-4777-a126-843a03e5af0a)

I've only tested this on Linux, but I think it should produce either the same results on systems where the Base colour is White or improved contrast on other systems.