### PR TITLE
cabana: Add menu item that resets the window layout

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -32,6 +32,9 @@ MainWindow::MainWindow() : QMainWindow() {
   createStatusBar();
   createShortcuts();
 
+  // save default window state to allow resetting it
+  default_state = saveState();
+
   // restore states
   restoreGeometry(settings.geometry);
   if (isMaximized()) {
@@ -134,6 +137,10 @@ void MainWindow::createActions() {
   QWidgetAction *commands_act = new QWidgetAction(this);
   commands_act->setDefaultWidget(new QUndoView(UndoStack::instance()));
   commands_menu->addAction(commands_act);
+
+  edit_menu->addSeparator();
+  edit_menu->addAction(tr("Reset Window Layout"),
+                       [this]() { restoreState(default_state); });
 
   tools_menu = menuBar()->addMenu(tr("&Tools"));
   tools_menu->addAction(tr("Find &Similar Bits"), this, &MainWindow::findSimilarBits);

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -98,6 +98,7 @@ protected:
   QString car_fingerprint;
   int prev_undostack_index = 0;
   int prev_undostack_count = 0;
+  QByteArray default_state;
   friend class OnlineHelp;
 };
 


### PR DESCRIPTION
This is useful if you've broken out a docked column  and then closed the broken out window, for example.

The workaround is to find and delete the settings file, but this is a little easier. :)