### PR TITLE
cabana dbc: Sort signals by name if start bits are equal

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -9,7 +9,13 @@ std::vector<const cabana::Signal*> cabana::Msg::getSignals() const {
   std::vector<const Signal*> ret;
   ret.reserve(sigs.size());
   for (auto &sig : sigs) ret.push_back(&sig);
-  std::sort(ret.begin(), ret.end(), [](auto l, auto r) { return l->start_bit < r->start_bit; });
+  std::sort(ret.begin(), ret.end(), [](auto l, auto r) {
+    if (l->start_bit != r->start_bit) {
+      return l->start_bit < r->start_bit;
+    }
+    // For VECTOR__INDEPENDENT_SIG_MSG, many signals have same start bit
+    return l->name < r->name;
+  });
   return ret;
 }
 


### PR DESCRIPTION
This is particularly significant for VECTOR__INDEPENDENT_SIG_MSG where a lot of the signals share the same start bit.

Without this change, the order is undefined for most of these signals and results in a lot of unnecessary churn in the DBC file contents between saves.
