### PR TITLE
ButtonParamControl: minimum button width

### DIFF
--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -202,7 +202,7 @@ class ButtonParamControl : public AbstractControl {
   Q_OBJECT
 public:
   ButtonParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon,
-                     const std::vector<QString> &button_texts) : AbstractControl(title, desc, icon) {
+                     const std::vector<QString> &button_texts, const int minimum_button_width = 225) : AbstractControl(title, desc, icon) {
     const QString style = R"(
       QPushButton {
         border-radius: 50px;
@@ -230,7 +230,7 @@ public:
       button->setCheckable(true);
       button->setChecked(i == value);
       button->setStyleSheet(style);
-      button->setMinimumWidth(225);
+      button->setMinimumWidth(minimum_button_width);
       hlayout->addWidget(button);
       button_group->addButton(button, i);
     }

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -230,6 +230,7 @@ public:
       button->setCheckable(true);
       button->setChecked(i == value);
       button->setStyleSheet(style);
+      button->setMinimumWidth(225);
       hlayout->addWidget(button);
       button_group->addButton(button, i);
     }


### PR DESCRIPTION
For ease of clicking when text is small


| Before  | After |
| ------------- | ------------- |
|![image](https://github.com/commaai/openpilot/assets/25857203/98591b1e-5533-4768-ba59-105ae7d7a174)|![image](https://github.com/commaai/openpilot/assets/25857203/31cf6f42-a9fc-401f-8a21-f5cafc54f290)|
