### PR TITLE
process_replay: improved support for drained pubs

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -77,9 +77,9 @@ class ReplayContext:
   def wait_for_recv_called(self):
     messaging.wait_for_one_event(self.all_recv_called_events)
 
-  def wait_for_next_recv(self, end_of_cycle):
+  def wait_for_next_recv(self, trigger_empty_recv):
     index = messaging.wait_for_one_event(self.all_recv_called_events)
-    if self.drained_pub is not None and end_of_cycle:
+    if self.drained_pub is not None and trigger_empty_recv:
       self.all_recv_called_events[index].clear()
       self.all_recv_ready_events[index].set()
       self.all_recv_called_events[index].wait()
@@ -417,12 +417,17 @@ def _replay_single_process(cfg, lr, fingerprint):
                 for s in sockets.values():
                   messaging.recv_one_or_none(s)
 
+              # empty recv on drained pub indicates the end of messages, only do that if there're any
+              trigger_empty_recv = False
+              if cfg.drained_pub:
+                trigger_empty_recv = next((True for m in msg_queue if m.which() == cfg.drained_pub), False)
+
               for m in msg_queue:
                 pm.send(m.which(), m.as_builder())
               msg_queue = []
 
               rc.unlock_sockets()
-              rc.wait_for_next_recv(True)
+              rc.wait_for_next_recv(trigger_empty_recv)
 
               for s in resp_sockets:
                 ms = messaging.drain_sock(sockets[s])  


### PR DESCRIPTION
…ueue

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
