### PR TITLE
FPv2: add comment about nuance of fuzzy fingerprinting

### DIFF
--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -91,6 +91,8 @@ def match_fw_to_car_fuzzy(fw_versions_dict, log=True, exclude=None):
         elif candidate != candidates[0]:
           return set()
 
+  # Note that it is possible to match to a candidate without all its ECUs being present
+  # if there are enough matches. FIXME: parameterize this or require all ECUs to exist like exact matching
   if len(matched_ecus) >= 2:
     if log:
       cloudlog.error(f"Fingerprinted {candidate} using fuzzy match. {len(matched_ecus)} matching ECUs")


### PR DESCRIPTION
This was not very obvious when working on this. Note that we have specific logic to invalidate candidates if FW versions for ECUs do not exist on the car when exact matching, but not fuzzy matching (like if the car has LKAS but not SCC and thus no radar).

One existing case would be if ABS and engine matched a platform, but no radar or camera existed, there would be a false positive.

There may be legitimate cases where we want this, but we should make it an explicit option in the config, or similar