### PR TITLE
cabana: fix bg color issue for inactive item

### DIFF
--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -331,7 +331,7 @@ void SignalItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
   if (item && item->type == SignalModel::Item::Sig) {
     painter->setRenderHint(QPainter::Antialiasing);
     if (option.state & QStyle::State_Selected) {
-      painter->fillRect(option.rect, option.palette.highlight());
+      painter->fillRect(option.rect, option.palette.brush(QPalette::Normal, QPalette::Highlight));
     }
 
     int h_margin = option.widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin) + 1;

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -96,7 +96,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
   int v_margin = option.widget->style()->pixelMetric(QStyle::PM_FocusFrameVMargin);
   int h_margin = option.widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin);
   if (option.state & QStyle::State_Selected) {
-    painter->fillRect(option.rect, option.palette.highlight());
+    painter->fillRect(option.rect, option.palette.brush(QPalette::Normal, QPalette::Highlight));
   }
 
   const QPoint pt{option.rect.left() + h_margin, option.rect.top() + v_margin};


### PR DESCRIPTION
issue:  `option.palette.highlight()`  will changed to  inactive color group(`QPalette::Inactive`) after lose focus.  this results in wrong background color for inactive item on some platforms (for example, linux mint):

![Screenshot from 2023-06-09 13-19-26](https://github.com/commaai/openpilot/assets/27770/bb0f914b-c300-40ef-bbb2-9e65b94d700b)
![Screenshot from 2023-06-09 13-18-19](https://github.com/commaai/openpilot/assets/27770/3e704337-8736-4d9c-acfc-30e64ee44763)

fixed: Always use the normal color group (`QPalette::Normal`) to draw the background color of the selected item:

![Screenshot from 2023-06-09 14-12-12](https://github.com/commaai/openpilot/assets/27770/5a013c18-eb72-4ed0-bd7a-6c3b39fde437)
![Screenshot from 2023-06-09 14-11-56](https://github.com/commaai/openpilot/assets/27770/2be5057e-3070-4111-a383-728fa9ba3545)

