### PR TITLE
UI: consider border when setting map width

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -95,7 +95,7 @@ void OnroadWindow::offroadTransition(bool offroad) {
 
       QObject::connect(uiState(), &UIState::offroadTransition, m, &MapWindow::offroadTransition);
 
-      m->setFixedWidth(topWidget(this)->width() / 2);
+      m->setFixedWidth(topWidget(this)->width() / 2 - bdr_s);
       split->insertWidget(0, m);
 
       // Make map visible after adding to split


### PR DESCRIPTION
This makes the map 30px less wide, but the camera view and map panel now have the same width

**Before**
![Screenshot from 2023-06-10 18-32-01](https://github.com/commaai/openpilot/assets/4038174/8d63ea02-4225-493f-8d5b-b2720e1a47c7)

**After**
![Screenshot from 2023-06-10 18-32-03](https://github.com/commaai/openpilot/assets/4038174/aa35c840-f187-4992-ba05-25d25bdd8f9e)
