### PR TITLE
selfdrive/car: reusable CanBus helper

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -1,10 +1,13 @@
 # functions common among cars
-import capnp
+import math
 from collections import namedtuple
+from typing import Dict, Optional
+
+import capnp
 
 from cereal import car
 from common.numpy_fast import clip, interp
-from typing import Dict
+
 
 # kg of standard extra cargo to count for drive, gas, etc...
 STD_CARGO_KG = 136.
@@ -175,3 +178,15 @@ def get_safety_config(safety_model, safety_param = None):
   if safety_param is not None:
     ret.safetyParam = safety_param
   return ret
+
+
+class CanBusBase:
+  offset: int
+
+  def __init__(self, CP, fingerprint: Optional[Dict[int, Dict[int, int]]]) -> None:
+    if CP is None:
+      assert fingerprint is not None
+      num = math.ceil(max([k for k, v in fingerprint.items() if len(v)], default=1) / 4)
+    else:
+      num = len(CP.safetyConfigs)
+    self.offset = 4 * (num - 1)

--- a/selfdrive/car/hyundai/hyundaicanfd.py
+++ b/selfdrive/car/hyundai/hyundaicanfd.py
@@ -1,17 +1,15 @@
-import math
-
 from common.numpy_fast import clip
+from selfdrive.car import CanBusBase
 from selfdrive.car.hyundai.values import HyundaiFlags
 
 
-class CanBus:
-  def __init__(self, CP, hda2=None, fingerprint=None):
-    if CP is None:
-      assert None not in (hda2, fingerprint)
-      num = math.ceil(max([k for k, v in fingerprint.items() if len(v)], default=1) / 4)
-    else:
+class CanBus(CanBusBase):
+  def __init__(self, CP, hda2=None, fingerprint=None) -> None:
+    super().__init__(CP, fingerprint)
+
+    if hda2 is None:
+      assert CP is not None
       hda2 = CP.flags & HyundaiFlags.CANFD_HDA2.value
-      num = len(CP.safetyConfigs)
 
     # On the CAN-FD platforms, the LKAS camera is on both A-CAN and E-CAN. HDA2 cars
     # have a different harness than the HDA1 and non-HDA variants in order to split
@@ -20,10 +18,9 @@ class CanBus:
     if hda2:
       self._a, self._e = 0, 1
 
-    offset = 4*(num - 1)
-    self._a += offset
-    self._e += offset
-    self._cam = 2 + offset
+    self._a += self.offset
+    self._e += self.offset
+    self._cam = 2 + self.offset
 
   @property
   def ECAN(self):

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -311,7 +311,7 @@ class CarInterface(CarInterfaceBase):
 
     # for blinkers
     if CP.flags & HyundaiFlags.ENABLE_BLINKERS:
-      disable_ecu(logcan, sendcan, bus=CanBus(CP.ECAN), addr=0x7B1, com_cont_req=b'\x28\x83\x01')
+      disable_ecu(logcan, sendcan, bus=CanBus(CP).ECAN, addr=0x7B1, com_cont_req=b'\x28\x83\x01')
 
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)


### PR DESCRIPTION
Move the offset calculation logic to a separate class so that it can be re-used by other brands. Also fixes a bug with blinkers (which probably aren't enabled anywhere at the moment).