### PR TITLE
Ford: shiftByWire ECU not used for fingerprinting

### DIFF
--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -101,6 +101,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.shiftByWire],
     ),
   ],
+  extra_ecus=[
+    (Ecu.shiftByWire, 0x732, None),
+  ],
 )
 
 FW_VERSIONS = {
@@ -122,10 +125,6 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7E0, None): [
       b'M1PA-14C204-GF\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'N1PA-14C204-AC\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-    ],
-    (Ecu.shiftByWire, 0x732, None): [
-      b'LX6P-14G395-AD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-      b'PZ1P-14G395-AB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
   CAR.ESCAPE_MK4: {
@@ -152,11 +151,6 @@ FW_VERSIONS = {
       b'MX6A-14C204-BEF\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'MX6A-14C204-BEJ\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'NX6A-14C204-BLE\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-    ],
-    (Ecu.shiftByWire, 0x732, None): [
-      b'LX6P-14G395-AB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-      b'LX6P-14G395-AD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-      b'PZ1P-14G395-AC\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
   CAR.EXPLORER_MK6: {
@@ -189,12 +183,6 @@ FW_VERSIONS = {
       b'MB5A-14C204-MD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'MB5A-14C204-RC\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'NB5A-14C204-HB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-    ],
-    (Ecu.shiftByWire, 0x732, None): [
-      b'L1MP-14C561-AB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-      b'L1MP-14G395-AD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-      b'L1MP-14G395-AE\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-      b'L1MP-14G395-JB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
   CAR.FOCUS_MK4: {
@@ -233,9 +221,6 @@ FW_VERSIONS = {
       b'NZ6A-14C204-PA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'NZ6A-14C204-ZA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'PZ6A-14C204-JC\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-    ],
-    (Ecu.shiftByWire, 0x732, None): [
-      b'NZ6P-14G395-AD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
 }


### PR DESCRIPTION
This ECU FW doesn't provide much new information to help determine the platform, but it is still useful to detect its presence to determine whether the car has an automatic transmission (i.e. not every car has this ECU). We can use the `extra_ecus` in `FwQueryConfig` for this. 