### PR TITLE
modeld: use any available stream as main, if there's only one

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -440,6 +440,8 @@ class Controls:
         available_streams = VisionIpcClient.available_streams("camerad", block=False)
         if VisionStreamType.VISION_STREAM_ROAD not in available_streams:
           self.sm.ignore_alive.append('roadCameraState')
+        if VisionStreamType.VISION_STREAM_WIDE_ROAD not in available_streams:
+          self.sm.ignore_alive.append('wideRoadCameraState')
 
         if not self.read_only:
           self.CI.init(self.CP, self.can_sock, self.pm.sock['sendcan'])

--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -189,9 +189,11 @@ int main(int argc, char **argv) {
   LOGW("models loaded, modeld starting");
 
   bool main_wide_camera = false;
+  bool use_extra_client = true; // set to false to use single camera
   while (!do_exit) {
     auto streams = VisionIpcClient::getAvailableStreams("camerad", false);
     if (!streams.empty()) {
+      use_extra_client = streams.count(VISION_STREAM_WIDE_ROAD) > 0 && streams.count(VISION_STREAM_ROAD) > 0;
       main_wide_camera = streams.count(VISION_STREAM_ROAD) == 0;
       break;
     }
@@ -199,7 +201,7 @@ int main(int argc, char **argv) {
     util::sleep_for(100);
   }
 
-  bool use_extra_client = !main_wide_camera;  // set for single camera mode
+  LOGW("vision stream set up, main_wide_camera: %d, use_extra_client: %d", main_wide_camera, use_extra_client);
   VisionIpcClient vipc_client_main = VisionIpcClient("camerad", main_wide_camera ? VISION_STREAM_WIDE_ROAD : VISION_STREAM_ROAD, true, device_id, context);
   VisionIpcClient vipc_client_extra = VisionIpcClient("camerad", VISION_STREAM_WIDE_ROAD, false, device_id, context);
 

--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -201,9 +201,9 @@ int main(int argc, char **argv) {
     util::sleep_for(100);
   }
 
-  LOGW("vision stream set up, main_wide_camera: %d, use_extra_client: %d", main_wide_camera, use_extra_client);
   VisionIpcClient vipc_client_main = VisionIpcClient("camerad", main_wide_camera ? VISION_STREAM_WIDE_ROAD : VISION_STREAM_ROAD, true, device_id, context);
   VisionIpcClient vipc_client_extra = VisionIpcClient("camerad", VISION_STREAM_WIDE_ROAD, false, device_id, context);
+  LOGW("vision stream set up, main_wide_camera: %d, use_extra_client: %d", main_wide_camera, use_extra_client);
 
   while (!do_exit && !vipc_client_main.connect(false)) {
     util::sleep_for(100);


### PR DESCRIPTION
It's misleading to use stream of type VISION_STREAM_WIDE_ROAD for regular road camera streams if you want to use it with single camera. 
This enables modeld to run with single vision stream, regardless of its type. Related to #27640. 