### PR TITLE
cabana: fix core dump when failed to connect to panda

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -42,7 +42,12 @@ int main(int argc, char *argv[]) {
     if (cmd_parser.isSet("panda-serial")) {
       config.serial = cmd_parser.value("panda-serial");
     }
-    stream = new PandaStream(&app, config);
+    try {
+      stream = new PandaStream(&app, config);
+    } catch (std::exception &e) {
+      qWarning() << e.what();
+      return 0;
+    }
   } else {
     uint32_t replay_flags = REPLAY_FLAG_NONE;
     if (cmd_parser.isSet("ecam")) {


### PR DESCRIPTION
![2023-06-14_01-18](https://github.com/commaai/openpilot/assets/27770/7138992f-c968-44ca-b8d2-bb516a1f7f82)
