### PR TITLE
FPv2 timing unit test: halve runs

### DIFF
--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -207,7 +207,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
           if not len(multi_panda_requests) and num_pandas > 1:
             raise unittest.SkipTest("No multi-panda FW queries")
 
-          avg_time = self._benchmark(brand, num_pandas, 10)
+          avg_time = self._benchmark(brand, num_pandas, 5)
           total_time += avg_time
           self._assert_timing(avg_time, brand_ref_times[num_pandas][brand], tol)
           print(f'{brand=}, {num_pandas=}, {len(config.requests)=}, avg FW query time={avg_time} seconds')


### PR DESCRIPTION
47 seconds -> 23 seconds, doesn't affect results much on my PC

This test still is taking the majority of the time (4-5 mins in CI for the file!). 200 tries probably isn't required...

https://github.com/commaai/openpilot/blob/fcc268b8be70e72654252e5424840ca37ad04196/selfdrive/car/tests/test_fw_fingerprint.py#L35-L46