### PR TITLE
[paramsd] Add a hysteresis band for valid checks where applicable

### DIFF
--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -16,10 +16,11 @@ from system.swaglog import cloudlog
 MAX_ANGLE_OFFSET_DELTA = 20 * DT_MDL  # Max 20 deg/s
 ROLL_MAX_DELTA = math.radians(20.0) * DT_MDL  # 20deg in 1 second is well within curvature limits
 ROLL_MIN, ROLL_MAX = math.radians(-10), math.radians(10)
+ROLL_LOWERED_MAX = math.radians(8)
 ROLL_STD_MAX = math.radians(1.5)
 LATERAL_ACC_SENSOR_THRESHOLD = 4.0
-AVG_OFFSET_MAX = 10.0
-AVG_OFFSET_LOWERED_MAX = 8.0
+OFFSET_MAX = 10.0
+OFFSET_LOWERED_MAX = 8.0
 
 
 class ParamsLearner:
@@ -104,7 +105,7 @@ class ParamsLearner:
       self.kf.filter.reset_rewind()
 
 
-def check_valid_with_hysteresis(current_valid: bool, val: float, threshold: float = AVG_OFFSET_MAX, lowered_threshold: float = AVG_OFFSET_LOWERED_MAX):
+def check_valid_with_hysteresis(current_valid: bool, val: float, threshold: float = OFFSET_MAX, lowered_threshold: float = OFFSET_LOWERED_MAX):
   if current_valid:
     current_valid = abs(val) < threshold
   else:
@@ -195,7 +196,7 @@ def main(sm=None, pm=None):
       sensors_valid = bool(abs(learner.speed * (x[States.YAW_RATE] + learner.yaw_rate)) < LATERAL_ACC_SENSOR_THRESHOLD)
       avg_offset_valid = check_valid_with_hysteresis(avg_offset_valid, angle_offset_average)
       total_offset_valid = check_valid_with_hysteresis(total_offset_valid, angle_offset)
-      roll_valid = check_valid_with_hysteresis(roll_valid, roll)
+      roll_valid = check_valid_with_hysteresis(roll_valid, roll, threshold=ROLL_MAX, lowered_threshold=ROLL_LOWERED_MAX)
 
       msg = messaging.new_message('liveParameters')
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -105,7 +105,7 @@ class ParamsLearner:
       self.kf.filter.reset_rewind()
 
 
-def check_valid_with_hysteresis(current_valid: bool, val: float, threshold: float = OFFSET_MAX, lowered_threshold: float = OFFSET_LOWERED_MAX):
+def check_valid_with_hysteresis(current_valid: bool, val: float, threshold: float, lowered_threshold: float):
   if current_valid:
     current_valid = abs(val) < threshold
   else:
@@ -194,8 +194,8 @@ def main(sm=None, pm=None):
       roll_std = float(P[States.ROAD_ROLL])
       # Account for the opposite signs of the yaw rates
       sensors_valid = bool(abs(learner.speed * (x[States.YAW_RATE] + learner.yaw_rate)) < LATERAL_ACC_SENSOR_THRESHOLD)
-      avg_offset_valid = check_valid_with_hysteresis(avg_offset_valid, angle_offset_average)
-      total_offset_valid = check_valid_with_hysteresis(total_offset_valid, angle_offset)
+      avg_offset_valid = check_valid_with_hysteresis(avg_offset_valid, angle_offset_average, threshold=OFFSET_MAX, lowered_threshold=OFFSET_LOWERED_MAX)
+      total_offset_valid = check_valid_with_hysteresis(total_offset_valid, angle_offset, threshold=OFFSET_MAX, lowered_threshold=OFFSET_LOWERED_MAX)
       roll_valid = check_valid_with_hysteresis(roll_valid, roll, threshold=ROLL_MAX, lowered_threshold=ROLL_LOWERED_MAX)
 
       msg = messaging.new_message('liveParameters')

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -141,10 +141,8 @@ def main(sm=None, pm=None):
   # Check if starting values are sane
   if params is not None:
     try:
-      angle_offset_sane = abs(params.get('angleOffsetAverageDeg')) < 10.0
       steer_ratio_sane = min_sr <= params['steerRatio'] <= max_sr
-      params_sane = angle_offset_sane and steer_ratio_sane
-      if not params_sane:
+      if not steer_ratio_sane:
         cloudlog.info(f"Invalid starting values found {params}")
         params = None
     except Exception as e:

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -194,9 +194,9 @@ def main(sm=None, pm=None):
       roll_std = float(P[States.ROAD_ROLL])
       # Account for the opposite signs of the yaw rates
       sensors_valid = bool(abs(learner.speed * (x[States.YAW_RATE] + learner.yaw_rate)) < LATERAL_ACC_SENSOR_THRESHOLD)
-      avg_offset_valid = check_valid_with_hysteresis(avg_offset_valid, angle_offset_average, threshold=OFFSET_MAX, lowered_threshold=OFFSET_LOWERED_MAX)
-      total_offset_valid = check_valid_with_hysteresis(total_offset_valid, angle_offset, threshold=OFFSET_MAX, lowered_threshold=OFFSET_LOWERED_MAX)
-      roll_valid = check_valid_with_hysteresis(roll_valid, roll, threshold=ROLL_MAX, lowered_threshold=ROLL_LOWERED_MAX)
+      avg_offset_valid = check_valid_with_hysteresis(avg_offset_valid, angle_offset_average, OFFSET_MAX, OFFSET_LOWERED_MAX)
+      total_offset_valid = check_valid_with_hysteresis(total_offset_valid, angle_offset, OFFSET_MAX, OFFSET_LOWERED_MAX)
+      roll_valid = check_valid_with_hysteresis(roll_valid, roll, ROLL_MAX, ROLL_LOWERED_MAX)
 
       msg = messaging.new_message('liveParameters')
 


### PR DESCRIPTION
Paramsd `valid` flag can toggle, causing repeated alerts, which can be annoying. A hysteresis band allows prevents this. This PR adds hysteresis to `slow_offset`, `total_offset`, and `roll`

---
ToDo:
- [x] Check which conditions are tripping
- [x] Check how many alerts would reduce with the change
- [ ] ~~Add cool-down time?~~