### PR TITLE
cabana: use raw signal value to match value descriptions

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -131,8 +131,9 @@ void cabana::Signal::update() {
 
 QString cabana::Signal::formatValue(double value) const {
   // Show enum string
+  int64_t raw_value = (value - offset) / factor;
   for (const auto &[val, desc] : val_desc) {
-    if (std::abs(value - val) < 1e-6) {
+    if (std::abs(raw_value - val) < 1e-6) {
       return desc;
     }
   }


### PR DESCRIPTION
the value in value description is a signal raw value transferred on the bus.  we should use raw value to match it.

fixed the issue: https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6179534

