### PR TITLE
Toyota: log when AEB is disabled unexpectedly

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -250,6 +250,8 @@ class CarInterfaceBase(ABC):
       events.add(EventName.wrongCarMode)
     if cs_out.espDisabled:
       events.add(EventName.espDisabled)
+    if cs_out.aebDisabled:
+      events.add(EventName.aebDisabled)
     if cs_out.stockFcw:
       events.add(EventName.stockFcw)
     if cs_out.stockAeb:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -118,6 +118,7 @@ class CarState(CarStateBase):
       if not (self.CP.flags & ToyotaFlags.SMART_DSU.value):
         self.acc_type = cp_acc.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp_acc.vl["ACC_HUD"]["FCW"])
+      ret.aebDisabled = cp_acc.vl["ACC_HUD"]["PCS_INDICATOR"] != 0
 
     # some TSS2 cars have low speed lockout permanently set, so ignore on those cars
     # these cars are identified by an ACC_TYPE value of 2.
@@ -244,6 +245,7 @@ class CarState(CarStateBase):
           ("ACC_CONTROL", 33),
         ]
       signals += [
+        ("PCS_INDICATOR", "ACC_HUD"),
         ("FCW", "ACC_HUD"),
       ]
       checks += [
@@ -283,6 +285,7 @@ class CarState(CarStateBase):
         ("PRECOLLISION_ACTIVE", "PRE_COLLISION"),
         ("FORCE", "PRE_COLLISION"),
         ("ACC_TYPE", "ACC_CONTROL"),
+        ("PCS_INDICATOR", "ACC_HUD"),
         ("FCW", "ACC_HUD"),
       ]
       checks += [

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -724,7 +724,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
     ET.SOFT_DISABLE: soft_disable_alert("Calibration Incomplete"),
     ET.NO_ENTRY: NoEntryAlert("Calibration in Progress"),
   },
-  
+
   EventName.calibrationRecalibrating: {
     ET.PERMANENT: calibration_incomplete_alert,
     ET.SOFT_DISABLE: soft_disable_alert("Device Remount Detected: Recalibrating"),
@@ -744,6 +744,11 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
   EventName.espDisabled: {
     ET.SOFT_DISABLE: soft_disable_alert("Electronic Stability Control Disabled"),
     ET.NO_ENTRY: NoEntryAlert("Electronic Stability Control Disabled"),
+  },
+
+  EventName.aebDisabled: {
+    ET.SOFT_DISABLE: soft_disable_alert("Automatic Emergency Braking System Disabled"),
+    ET.NO_ENTRY: NoEntryAlert("Automatic Emergency Braking System Disabled"),
   },
 
   EventName.lowBattery: {


### PR DESCRIPTION
We can label this specific case as an ACC fault, but the PCM isn't actually faulted here, and neither is the camera. It's just telling the car that it won't actuate PSC/AEB. There's a few different reasons it will lock out too: radar alignment, camera visibility poor, over temperature, etc. This catches all of those as well as the user disabling AEB (do we want that though?)