### PR TITLE
cabana: Prevent dialog that load autosaved file from blocking replay->start()

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -373,7 +373,8 @@ void MainWindow::eventsMerged() {
     if (!dbc()->msgCount() && !car_fingerprint.isEmpty()) {
       auto dbc_name = fingerprint_to_dbc[car_fingerprint];
       if (dbc_name != QJsonValue::Undefined) {
-        loadDBCFromOpendbc(dbc_name.toString());
+        // Prevent dialog that load autosaved file from blocking replay->start().
+        QTimer::singleShot(0, [dbc_name, this]() { loadDBCFromOpendbc(dbc_name.toString()); });
       }
     }
   }


### PR DESCRIPTION
fixed issue:  https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6184481