### PR TITLE
cabana: fix segfault when switching DBC files.

### DIFF
--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -402,7 +402,7 @@ void ChartsWidget::removeAll() {
 
   if (!charts.isEmpty()) {
     for (auto c : charts) {
-      c->deleteLater();
+      delete c;
     }
     charts.clear();
     updateToolBar();

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -528,7 +528,7 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   QObject::connect(tree, &QTreeView::entered, [this](const QModelIndex &index) { emit highlight(model->getItem(index)->sig); });
   QObject::connect(model, &QAbstractItemModel::modelReset, this, &SignalView::rowsChanged);
   QObject::connect(model, &QAbstractItemModel::rowsRemoved, this, &SignalView::rowsChanged);
-  QObject::connect(dbc(), &DBCManager::signalAdded, [this](MessageId id, const cabana::Signal *sig) { selectSignal(sig); });
+  QObject::connect(dbc(), &DBCManager::signalAdded, this, &SignalView::handleSignalAdded);
   QObject::connect(dbc(), &DBCManager::signalUpdated, this, &SignalView::handleSignalUpdated);
   QObject::connect(tree->verticalScrollBar(), &QScrollBar::valueChanged, [this]() { updateState(); });
   QObject::connect(tree->verticalScrollBar(), &QScrollBar::rangeChanged, [this]() { updateState(); });
@@ -630,6 +630,12 @@ void SignalView::setSparklineRange(int value) {
   settings.sparkline_range = value;
   updateToolBar();
   updateState();
+}
+
+void SignalView::handleSignalAdded(MessageId id, const cabana::Signal *sig) {
+  if (id.address == model->msg_id.address) {
+    selectSignal(sig);
+  }
 }
 
 void SignalView::handleSignalUpdated(const cabana::Signal *sig) {

--- a/tools/cabana/signalview.h
+++ b/tools/cabana/signalview.h
@@ -116,6 +116,7 @@ private:
   void resizeEvent(QResizeEvent* event) override;
   void updateToolBar();
   void setSparklineRange(int value);
+  void handleSignalAdded(MessageId id, const cabana::Signal *sig);
   void handleSignalUpdated(const cabana::Signal *sig);
   void updateState(const QHash<MessageId, CanData> *msgs = nullptr);
 


### PR DESCRIPTION
1. fix `SignalView` segfault when adding signal after switching DBCs. 
this bug is caused by the connected lambda function not being disconnected after the `SignalView` is deleted.
2. fix 'ChartView' segfault when switching DBCs. 
 Delete the chart immediately after switching DBCs instead of deleteLater, to avoid the chart continuing to execute the updaeState with invalid signal pointer when the load autosaved file dialog is displayed(blocked).

related issue:  https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6201049: 

> I also got a segfault when switching DBCs one time, not reproducible yet