### PR TITLE
Subaru: Use Cruise_Status for set speed instead of dashstatus

### DIFF
--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -56,7 +56,11 @@ class CarState(CarStateBase):
     cp_cruise = cp_body if self.car_fingerprint in GLOBAL_GEN2 else cp
     ret.cruiseState.enabled = cp_cruise.vl["CruiseControl"]["Cruise_Activated"] != 0
     ret.cruiseState.available = cp_cruise.vl["CruiseControl"]["Cruise_On"] != 0
-    ret.cruiseState.speed = cp_cruise.vl["Cruise_Status"]["Cruise_Set_Speed"] * CV.KPH_TO_MS
+
+    if self.car_fingerprint in PREGLOBAL_CARS:
+      ret.cruiseState.speed = cp_cam.vl["ES_DashStatus"]["Cruise_Set_Speed"] * CV.KPH_TO_MS
+    else:
+      ret.cruiseState.speed = cp_cruise.vl["Cruise_Status"]["Cruise_Set_Speed"] * CV.KPH_TO_MS
 
     if (self.car_fingerprint in PREGLOBAL_CARS and cp.vl["Dash_State2"]["UNITS"] == 1) or \
        (self.car_fingerprint not in PREGLOBAL_CARS and cp.vl["Dashlights"]["UNITS"] == 1):
@@ -134,7 +138,7 @@ class CarState(CarStateBase):
       ("Cruise_Throttle", "ES_Distance"),
       ("Signal2", "ES_Distance"),
       ("Car_Follow", "ES_Distance"),
-      ("Signal3", "ES_Distance"),
+      ("Low_Speed_Follow", "ES_Distance"),
       ("Cruise_Soft_Disable", "ES_Distance"),
       ("Signal7", "ES_Distance"),
       ("Cruise_Brake_Active", "ES_Distance"),

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -56,7 +56,7 @@ class CarState(CarStateBase):
     cp_cruise = cp_body if self.car_fingerprint in GLOBAL_GEN2 else cp
     ret.cruiseState.enabled = cp_cruise.vl["CruiseControl"]["Cruise_Activated"] != 0
     ret.cruiseState.available = cp_cruise.vl["CruiseControl"]["Cruise_On"] != 0
-    ret.cruiseState.speed = cp_cam.vl["ES_DashStatus"]["Cruise_Set_Speed"] * CV.KPH_TO_MS
+    ret.cruiseState.speed = cp_cam.vl["Cruise_Status"]["Cruise_Set_Speed"] * CV.KPH_TO_MS
 
     if (self.car_fingerprint in PREGLOBAL_CARS and cp.vl["Dash_State2"]["UNITS"] == 1) or \
        (self.car_fingerprint not in PREGLOBAL_CARS and cp.vl["Dashlights"]["UNITS"] == 1):

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -56,7 +56,7 @@ class CarState(CarStateBase):
     cp_cruise = cp_body if self.car_fingerprint in GLOBAL_GEN2 else cp
     ret.cruiseState.enabled = cp_cruise.vl["CruiseControl"]["Cruise_Activated"] != 0
     ret.cruiseState.available = cp_cruise.vl["CruiseControl"]["Cruise_On"] != 0
-    ret.cruiseState.speed = cp_cam.vl["Cruise_Status"]["Cruise_Set_Speed"] * CV.KPH_TO_MS
+    ret.cruiseState.speed = cp_cruise.vl["Cruise_Status"]["Cruise_Set_Speed"] * CV.KPH_TO_MS
 
     if (self.car_fingerprint in PREGLOBAL_CARS and cp.vl["Dash_State2"]["UNITS"] == 1) or \
        (self.car_fingerprint not in PREGLOBAL_CARS and cp.vl["Dashlights"]["UNITS"] == 1):
@@ -96,6 +96,7 @@ class CarState(CarStateBase):
     signals = [
       ("Cruise_On", "CruiseControl"),
       ("Cruise_Activated", "CruiseControl"),
+      ("Cruise_Set_Speed", "Cruise_Status"),
       ("FL", "Wheel_Speeds"),
       ("FR", "Wheel_Speeds"),
       ("RL", "Wheel_Speeds"),
@@ -104,6 +105,7 @@ class CarState(CarStateBase):
     ]
     checks = [
       ("CruiseControl", 20),
+      ("Cruise_Status", 20),
       ("Wheel_Speeds", 50),
       ("Brake_Status", 50),
     ]

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -25,7 +25,7 @@ def create_es_distance(packer, es_distance_msg, bus, pcm_cancel_cmd):
     "Cruise_Throttle",
     "Signal2",
     "Car_Follow",
-    "Signal3",
+    "Low_Speed_Follow",
     "Cruise_Soft_Disable",
     "Signal7",
     "Cruise_Brake_Active",


### PR DESCRIPTION
**Description**
DashStatus isn't available when ES is disabled. I found the same set speed signal in Cruise_Status, at least for global.

**Verification**
Been using this change on my long PR without issues.

https://github.com/commaai/opendbc/pull/859