### PR TITLE
Use the cluster speed when limiting speed

### DIFF
--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -95,8 +95,11 @@ class LongitudinalPlanner:
     self.mpc.mode = 'blended' if sm['controlsState'].experimentalMode else 'acc'
 
     v_ego = sm['carState'].vEgo
+    v_ego_raw = sm['carState'].vEgoRaw
+    v_ego_cluster = sm['carState'].vEgoCluster
+    v_ego_diff = v_ego_raw - v_ego_cluster if v_ego_cluster > 0 else 0
     v_cruise_kph = min(sm['controlsState'].vCruise, V_CRUISE_MAX)
-    v_cruise = v_cruise_kph * CV.KPH_TO_MS
+    v_cruise = v_cruise_kph * CV.KPH_TO_MS + v_ego_diff
 
     long_control_off = sm['controlsState'].longControlState == LongCtrlState.off
     force_slow_decel = sm['controlsState'].forceDecel


### PR DESCRIPTION
The Problem:

Openpilot displays the current speed based off of the speed that is shown in the car's cluster. This is done to prevent a disparity between the car and the information that openpilot is giving, that disparity can lead to less confidence from the user that openpilot is correct. However, the internal openpilot speed is used to limit speed. This leads to openpilot sometimes showing a speed above the set max speed which reduces user confidence that openpilot is correctly limiting based off of the users' max speed setting.

The Solution:
By calculating the difference between the cluster speed and vEgo we can determine the maximum speed that will result in the cluster speed matching the speed the user has set.