### PR TITLE
Toyota FPv2: log telematics ECU

### DIFF
--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -157,7 +157,7 @@ class TestFwFingerprint(unittest.TestCase):
 
         ecu_strings = ", ".join([f'Ecu.{ECU_NAME[ecu]}' for ecu in ecus_not_whitelisted])
         self.assertFalse(len(whitelisted_ecus) and len(ecus_not_whitelisted),
-                         f'{brand.title()}: FW query whitelist missing ecus: {ecu_strings}')
+                         f'{brand.title()}: ECUs not in any FW query whitelists: {ecu_strings}')
 
 
 class TestFwFingerprintTiming(unittest.TestCase):
@@ -186,7 +186,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   def test_fw_query_timing(self):
     tol = 0.1
-    total_ref_time = 5.5
+    total_ref_time = 5.8
     brand_ref_times = {
       1: {
         'body': 0.1,
@@ -198,7 +198,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'nissan': 0.9,
         'subaru': 0.1,
         'tesla': 0.2,
-        'toyota': 1.0,
+        'toyota': 1.3,
         'volkswagen': 0.2,
       },
       2: {

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -224,19 +224,19 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, TOYOTA_VERSION_REQUEST_KWP],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, TOYOTA_VERSION_RESPONSE_KWP],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics],
       bus=0,
     ),
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, StdQueries.OBD_VERSION_REQUEST],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, StdQueries.OBD_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.engine, Ecu.epb],
+      whitelist_ecus=[Ecu.engine, Ecu.epb, Ecu.telematics],
       bus=0,
     ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.DEFAULT_DIAGNOSTIC_REQUEST, StdQueries.EXTENDED_DIAGNOSTIC_REQUEST, StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.DEFAULT_DIAGNOSTIC_RESPONSE, StdQueries.EXTENDED_DIAGNOSTIC_RESPONSE, StdQueries.UDS_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.engine, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.abs, Ecu.eps, Ecu.epb],
+      whitelist_ecus=[Ecu.engine, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics],
       bus=0,
     ),
   ],

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -246,7 +246,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Ecu.engine: [CAR.CAMRY, CAR.COROLLA_TSS2, CAR.CHR, CAR.CHR_TSS2, CAR.LEXUS_IS, CAR.LEXUS_RC],
   },
   extra_ecus=[
-    (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake
+    (Ecu.telematics, 0x750, 0xc7),
   ],
 )
 

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -244,7 +244,10 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Ecu.abs: [CAR.RAV4, CAR.COROLLA, CAR.HIGHLANDER, CAR.SIENNA, CAR.LEXUS_IS],
     # On some models, the engine can show on two different addresses
     Ecu.engine: [CAR.CAMRY, CAR.COROLLA_TSS2, CAR.CHR, CAR.CHR_TSS2, CAR.LEXUS_IS, CAR.LEXUS_RC],
-  }
+  },
+  extra_ecus=[
+    (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake
+  ],
 )
 
 FW_VERSIONS = {


### PR DESCRIPTION
```python
*** Results for address 0xC7 ***

0xF100 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC_DATA_IDENTIFIER: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x84\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF181 APPLICATION_SOFTWARE_IDENTIFICATION: b'\x01N010ii464644\x00\x00\x00\x00'
0xF186 ACTIVE_DIAGNOSTIC_SESSION: b'\x03'
0xF18C ECU_SERIAL_NUMBER: b'8674106092355985233885113'
0xF190 VIN: b'REDACTED' (has it)
```

![image](https://github.com/commaai/openpilot/assets/25857203/9a418850-c9cd-413a-b204-88735b78655e)
