### PR TITLE
Toyota: remove extra ECUs from OBD query

### DIFF
--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -186,7 +186,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   def test_fw_query_timing(self):
     tol = 0.1
-    total_ref_time = 5.8
+    total_ref_time = 5.6
     brand_ref_times = {
       1: {
         'body': 0.1,
@@ -198,7 +198,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'nissan': 0.9,
         'subaru': 0.1,
         'tesla': 0.2,
-        'toyota': 1.3,
+        'toyota': 1.1,
         'volkswagen': 0.2,
       },
       2: {

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -230,7 +230,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, StdQueries.OBD_VERSION_REQUEST],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, StdQueries.OBD_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.engine, Ecu.epb, Ecu.telematics],
+      whitelist_ecus=[Ecu.engine],
       bus=0,
     ),
     Request(

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -219,7 +219,7 @@ TOYOTA_VERSION_REQUEST_KWP = b'\x1a\x88\x01'
 TOYOTA_VERSION_RESPONSE_KWP = b'\x5a\x88\x01'
 
 FW_QUERY_CONFIG = FwQueryConfig(
-  # TODO: look at data to whitelist epb effectively
+  # TODO: look at data to whitelist extra_ecus effectively
   requests=[
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, TOYOTA_VERSION_REQUEST_KWP],


### PR DESCRIPTION
Pretty sure only engine uses this, but want to get a few routes before we do this

For recent PRs merged: https://github.com/commaai/openpilot/pull/28613, https://github.com/commaai/openpilot/pull/28612, https://github.com/commaai/openpilot/pull/28628, and https://github.com/commaai/openpilot/pull/28633