### PR TITLE
macOS: re-order CI caching jobs

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -142,6 +142,13 @@ jobs:
         source tools/openpilot_env.sh
         rm -rf /tmp/scons_cache/*
         poetry run scons -j$(nproc) --cache-populate
+    - name: Save scons cache
+      id: scons-save-cache
+      uses: actions/cache/save@v3
+      if: github.ref == 'refs/heads/master'
+      with:
+        path: /tmp/scons_cache
+        key: macos_scons-${{ github.sha }}
     - name: Pre Cache - Remove pre-existing Homebrew packages
       if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: |
@@ -155,13 +162,6 @@ jobs:
         # .fseventsd directory causes permission errors in dep caching step
         # its used by the system to observe changes within the directory - toolchain works without it, just remove it
         sudo rm -rf /Applications/ArmGNUToolchain/*/*/.fseventsd
-    - name: Save scons cache
-      id: scons-save-cache
-      uses: actions/cache/save@v3
-      if: github.ref == 'refs/heads/master'
-      with:
-        path: /tmp/scons_cache
-        key: macos_scons-${{ github.sha }}
 
   docker_push:
     name: docker push


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
