### PR TITLE
Hyundai: enable radar tracks for 2019 Santa Fe

### DIFF
--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -59,6 +59,9 @@ SUPPORTED_FW_VERSIONS = {
   b"TM__ SCC F-CUP      1.00 1.00 99110-S1210\x19\x01%\x168    ": ConfigValues(
     default_config=b"\x00\x00\x00\x01\x00\x00",
     tracks_enabled=b"\x00\x00\x00\x01\x00\x01"),
+  b"TM__ SCC F-CUP      1.00 1.02 99110-S2000\x18\x07\x08\x18W    ": ConfigValues(
+    default_config=b"\x00\x00\x00\x01\x00\x00",
+    tracks_enabled=b"\x00\x00\x00\x01\x00\x01"),
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description:** Adding a second Radar FW for the 2019 Hyundai Santa Fe to the hyundai_enable_radar_points.py script

**Verification:** Viewed route in cabana to verify radar tracks are working. 

**Route:** 9ebc35731309da40|2023-06-21--16-30-20--0