### PR TITLE
Toyota: query hybrid vehicle control computer ECU

### DIFF
--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -250,7 +250,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # These have been seen responding to UDS query
     (Ecu.hybrid, 0x712, None),  # Hybrid Control Assembly & Computer
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer 2
-    (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake
+    (Ecu.epb, 0x750, 0x2c),     # Electronic Parking Brake
     (Ecu.telematics, 0x750, 0xc7),
   ],
 )

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -259,6 +259,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # - EPS/EMPS (0x7a0, 0x7a1)
     # - SRS Airbag (0x780, 0x784)
     # These have been seen responding to UDS query
+    (Ecu.hybrid, 0x712, None),  # Hybrid Control Assembly & Module
+    (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Module 2
     (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake
     (Ecu.telematics, 0x750, 0xc7),
   ],

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -247,6 +247,19 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Ecu.engine: [CAR.CAMRY, CAR.COROLLA_TSS2, CAR.CHR, CAR.CHR_TSS2, CAR.LEXUS_IS, CAR.LEXUS_RC],
   },
   extra_ecus=[
+    # All known ECUs on a late-model Toyota vehicle not queried here:
+    # Responds to UDS:
+    # - Hybrid Control (0x7d2, 0x712)
+    # - Combination Meter (0x7c0)
+    # - HV Battery (0x713, 0x747)
+    # - Motor Generator (0x716, 0x724)
+    # Responds to KWP:
+    # - Air Conditioner (0x7c4),
+    # - Steering Angle Sensor (0x7b3),
+    # - ABS/VSC/TRAC (0x7b0),
+    # - EPS/EMPS (0x7A0, 0x7a1),
+    # - SRS Airbag (0x780, 0x784)
+    # These have been seen responding to UDS query
     (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake
     (Ecu.telematics, 0x750, 0xc7),
   ],

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -224,19 +224,19 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, TOYOTA_VERSION_REQUEST_KWP],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, TOYOTA_VERSION_RESPONSE_KWP],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics, Ecu.hybrid],
       bus=0,
     ),
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, StdQueries.OBD_VERSION_REQUEST],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, StdQueries.OBD_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.engine, Ecu.epb, Ecu.telematics],
+      whitelist_ecus=[Ecu.engine, Ecu.epb, Ecu.telematics, Ecu.hybrid],
       bus=0,
     ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.DEFAULT_DIAGNOSTIC_REQUEST, StdQueries.EXTENDED_DIAGNOSTIC_REQUEST, StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.DEFAULT_DIAGNOSTIC_RESPONSE, StdQueries.EXTENDED_DIAGNOSTIC_RESPONSE, StdQueries.UDS_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.engine, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics],
+      whitelist_ecus=[Ecu.engine, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics, Ecu.hybrid],
       bus=0,
     ),
   ],

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -248,6 +248,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   },
   extra_ecus=[
     # These have been seen responding to UDS query
+    # TODO: if these hybrid ECUs always exist together, remove one
     (Ecu.hybrid, 0x712, None),  # Hybrid Control Assembly & Computer
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer 2
     (Ecu.epb, 0x750, 0x2c),     # Electronic Parking Brake

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -247,20 +247,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Ecu.engine: [CAR.CAMRY, CAR.COROLLA_TSS2, CAR.CHR, CAR.CHR_TSS2, CAR.LEXUS_IS, CAR.LEXUS_RC],
   },
   extra_ecus=[
-    # All known ECUs on a late-model Toyota vehicle not queried here:
-    # Responds to UDS:
-    # - Hybrid Control (0x7d2, 0x712)
-    # - Combination Meter (0x7c0)
-    # - HV Battery (0x713, 0x747)
-    # - Motor Generator (0x716, 0x724)
-    # Responds to KWP:
-    # - Air Conditioner (0x7c4)
-    # - Steering Angle Sensor (0x7b3)
-    # - EPS/EMPS (0x7a0, 0x7a1)
-    # - SRS Airbag (0x780, 0x784)
     # These have been seen responding to UDS query
-    (Ecu.hybrid, 0x712, None),  # Hybrid Control Assembly & Module
-    (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Module 2
+    (Ecu.hybrid, 0x712, None),  # Hybrid Control Assembly & Computer
+    (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer 2
     (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake
     (Ecu.telematics, 0x750, 0xc7),
   ],

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -254,10 +254,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # - HV Battery (0x713, 0x747)
     # - Motor Generator (0x716, 0x724)
     # Responds to KWP:
-    # - Air Conditioner (0x7c4),
-    # - Steering Angle Sensor (0x7b3),
-    # - ABS/VSC/TRAC (0x7b0),
-    # - EPS/EMPS (0x7A0, 0x7a1),
+    # - Air Conditioner (0x7c4)
+    # - Steering Angle Sensor (0x7b3)
+    # - EPS/EMPS (0x7A0, 0x7a1)
     # - SRS Airbag (0x780, 0x784)
     # These have been seen responding to UDS query
     (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -256,7 +256,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # Responds to KWP:
     # - Air Conditioner (0x7c4)
     # - Steering Angle Sensor (0x7b3)
-    # - EPS/EMPS (0x7A0, 0x7a1)
+    # - EPS/EMPS (0x7a0, 0x7a1)
     # - SRS Airbag (0x780, 0x784)
     # These have been seen responding to UDS query
     (Ecu.epb, 0x750, 0x2c),  # Electronic Parking Brake


### PR DESCRIPTION
This is in reference to a 2022 Camry Hybrid LE

these names come from toyota's diagnostic software. looking up closest parts yields the following results:

- 0x712/0x7d2 Hybrid Control: First part number is computer assembly, hybrid vehicle control. Second part number is computer, hybrid vehicle control. This likely controls and manages overall hybrid operation like distribution of power.

  [All parts of this category for this vehicle.](https://autoparts.toyota.com/search?search_query=8998&driveline=FWD%202.5L%204-Cyl.%20Gas/Electric%20Hybrid%20ECVT&grade=LE%20Hybrid%204Dr.%20Sedan&series_name=CAMRY%20HYBRID&model_year=2022&model_year_code=2022:2559)

  First part number likely computer assembly: https://toyota.oempartsonline.com/oem-parts/toyota-drive-motor-battery-pack-control-module-8998006080?c=bD03Jm49U2VhcmNoIFJlc3VsdHM%3D or https://toyota.oempartsonline.com/oem-parts/toyota-drive-motor-battery-pack-control-module-8998006010

  Second part number likely computer: https://toyota.oempartsonline.com/oem-parts/toyota-computer-hybrid-veh-8998133130

  My FW version is `b'\x02899830621000\x00\x00\x00\x00899853313000\x00\x00\x00\x00'`
- 0x713/0x747 HV Battery: This is the Drive Motor Battery Pack Control Module. Likely manages stuff like health and SOC, when to allow charging from regen, etc.

  [All parts of this category for this vehicle.](https://autoparts.toyota.com/search?search_query=8989&driveline=FWD%202.5L%204-Cyl.%20Gas/Electric%20Hybrid%20ECVT&grade=LE%20Hybrid%204Dr.%20Sedan&series_name=CAMRY%20HYBRID&model_year=2022&model_year_code=2022:2559)

  First part number likely computer assembly: https://toyota.oempartsonline.com/oem-parts/toyota-drive-motor-battery-pack-control-module-8989033012

  Second part number likley battery voltage sensor: https://toyota.oempartsonline.com/oem-parts/toyota-sensor-8989233040

  My FW version is `b'\x028989F3301200\x00\x00\x00\x008989G3301100\x00\x00\x00\x00'`
- 0x716/0x724 Motor Generator (MG2/MG2): Some parts sites call this "Computer Assy, Electric Vehicle Control," or "Computer Assembly Elect." Some parts sites say this fits a 2002 RAV4 EV https://www.oemgenuineparts.com/oem-parts/toyota-computer-assembly-elect-8988042023. Likely simpler in operation, applies torque to the wheels based on input power from the hybrid control computer (first ECU above).

  No results for `89880` on Toyota's site. Likely not too useful as it's less understandable how it's shared at this point.

  My FW version is `b'\x02898844202311\x00\x00\x00\x00898844201301\x00\x00\x00\x00'`