### PR TITLE
UI: fix DM icon margins

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -556,8 +556,9 @@ void AnnotatedCameraWidget::drawDriverState(QPainter &painter, const UIState *s)
   painter.save();
 
   // base icon
-  int x = rightHandDM ? rect().right() -  (btn_size - 24) / 2 - (bdr_s * 2) : (btn_size - 24) / 2 + (bdr_s * 2);
-  int y = rect().bottom() - footer_h / 2;
+  int offset = bdr_s + btn_size / 2;
+  int x = rightHandDM ? width() - offset : offset;
+  int y = height() - offset;
   float opacity = dmActive ? 0.65 : 0.2;
   drawIcon(painter, x, y, dm_img, blackColor(70), opacity);
 


### PR DESCRIPTION
Use consistent margin `bdr_s` for for all three icons

|New|<img height=300 src=https://github.com/commaai/openpilot/assets/4038174/07ec6f70-77ae-410e-a5b8-24a9db1c53f7>|
|-|-|
|Old|<img height=300 src=https://github.com/commaai/openpilot/assets/4038174/555fff9c-a2dd-4a1b-a0c0-e294eb2a332f>|
