### PR TITLE
ui/map_settings: remove repaint 

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -218,7 +218,6 @@ void MapSettings::refresh() {
   }
 
   destinations_layout->addStretch();
-  repaint();
 }
 
 void MapSettings::navigateTo(const QJsonObject &place) {


### PR DESCRIPTION
not sure if it's related to https://github.com/commaai/openpilot/issues/27682 

https://github.com/qt/qt/blob/0a2f2382541424726168804be2c90b91381608c6/src/gui/painting/qbackingstore.cpp#L381-L387

but there doesn't seem to be any need to call repaint here