### PR TITLE
Qcom localizer: erratic clocks have an erratic error rate too

### DIFF
--- a/selfdrive/locationd/models/loc_kf.py
+++ b/selfdrive/locationd/models/loc_kf.py
@@ -334,12 +334,13 @@ class LocKalman():
 
 
     # process noise
-    clock_error_drift = 100.0 if erratic_clock else 0.1
+    q_clock_error = 100.0 if erratic_clock else 0.1
+    q_clock_error_rate = 10 if erratic_clock else 0.0
     self.Q = np.diag([0.03**2, 0.03**2, 0.03**2,
                       0.0**2, 0.0**2, 0.0**2,
                       0.0**2, 0.0**2, 0.0**2,
                       0.1**2, 0.1**2, 0.1**2,
-                      (clock_error_drift)**2, (0)**2,
+                      (q_clock_error)**2, (q_clock_error_rate)**2,
                       (0.005 / 100)**2, (0.005 / 100)**2, (0.005 / 100)**2,
                       (0.02 / 100)**2,
                       3**2, 3**2, 3**2,


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
