### PR TITLE
cabana: properly handle unix signals

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -15,6 +15,8 @@ int main(int argc, char *argv[]) {
   QApplication app(argc, argv);
   app.setApplicationDisplayName("Cabana");
   app.setWindowIcon(QIcon(":cabana-icon.png"));
+
+  UnixSignalHandler signalHandler;
   utils::setTheme(settings.theme);
 
   QCommandLineParser cmd_parser;

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -1,7 +1,11 @@
 #include "tools/cabana/util.h"
 
 #include <array>
+#include <csignal>
+#include <sys/socket.h>
+#include <unistd.h>
 
+#include <QDebug>
 #include <QColor>
 #include <QFontDatabase>
 #include <QLocale>
@@ -144,6 +148,40 @@ void TabBar::closeTabClicked() {
     }
   }
 }
+
+// UnixSignalHandler
+
+UnixSignalHandler::UnixSignalHandler(QObject *parent) : QObject(nullptr) {
+  if (::socketpair(AF_UNIX, SOCK_STREAM, 0, sig_fd)) {
+    qFatal("Couldn't create TERM socketpair");
+  }
+
+  sn = new QSocketNotifier(sig_fd[1], QSocketNotifier::Read, this);
+  connect(sn, SIGNAL(activated(QSocketDescriptor)), this, SLOT(handleSigTerm()));
+  std::signal(SIGINT, signalHandler);
+  std::signal(SIGTERM, UnixSignalHandler::signalHandler);
+}
+
+UnixSignalHandler::~UnixSignalHandler() {
+  ::close(sig_fd[0]);
+  ::close(sig_fd[1]);
+}
+
+void UnixSignalHandler::signalHandler(int s) {
+  ::write(sig_fd[0], &s, sizeof(s));
+}
+
+void UnixSignalHandler::handleSigTerm() {
+  sn->setEnabled(false);
+  int tmp;
+  ::read(sig_fd[1], &tmp, sizeof(tmp));
+
+  printf("\nexiting...\n");
+  qApp->closeAllWindows();
+  qApp->exit();
+}
+
+// NameValidator
 
 NameValidator::NameValidator(QObject *parent) : QRegExpValidator(QRegExp("^(\\w+)"), parent) {}
 

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -8,6 +8,7 @@
 #include <QDoubleValidator>
 #include <QFont>
 #include <QRegExpValidator>
+#include <QSocketNotifier>
 #include <QStringBuilder>
 #include <QStyledItemDelegate>
 #include <QToolButton>
@@ -133,6 +134,22 @@ public:
 
 private:
   void closeTabClicked();
+};
+
+class UnixSignalHandler : public QObject {
+  Q_OBJECT
+
+public:
+  UnixSignalHandler(QObject *parent = nullptr);
+  ~UnixSignalHandler();
+  static void signalHandler(int s);
+
+public slots:
+  void handleSigTerm();
+
+private:
+  inline static int sig_fd[2] = {};
+  QSocketNotifier *sn;
 };
 
 int num_decimals(double num);


### PR DESCRIPTION
handle unix signals with QSocketNotifier:  https://doc.qt.io/qt-5/unix-signals.html

this pr fixed issue of states & settings are not saved when cabana exits. (https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6246769)