### PR TITLE
cabana: fixed the issue of parsing multiplexed signals

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -111,6 +111,9 @@ void cabana::Msg::update() {
   for (auto sig : sigs) {
     sig->multiplexor = sig->type == cabana::Signal::Type::Multiplexed ? multiplexor : nullptr;
     if (!sig->multiplexor) {
+      if (sig->type == cabana::Signal::Type::Multiplexed) {
+        sig->type = cabana::Signal::Type::Normal;
+      }
       sig->multiplex_value = 0;
     }
   }

--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -136,7 +136,6 @@ void DBCFile::parse(const QString &content) {
           dbc_assert(++multiplexor_cnt < 2, "Multiple multiplexor");
           s.type = cabana::Signal::Type::Multiplexor;
         } else {
-          dbc_assert(multiplexor_cnt == 1, "No multiplexor");
           s.type = cabana::Signal::Type::Multiplexed;
           s.multiplex_value = indicator.mid(1).toInt();
         }


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6246756

Fixed the issue of not being able to parse the messages wit 'M' under 'm', for example:

> SG_ CONF_TCU **m**1 : 0|6@1+ (1.0,0.0) [0.0|63.0] ""  _4WD,ACU,BCM,CLU,DATC,EPB,ESC,IBOX,LCA,SMK
> SG_ CAN_VERS **m**0 : 0|6@1+ (1.0,0.0) [0.0|7.7] ""  _4WD,ABS,ESC,IBOX
> SG_ TQ_STND **m**3 : 0|6@1+ (10.0,0.0) [0.0|630.0] "Nm"  _4WD,DATC,ECS,EPB,ESC,FATC,IBOX
> SG_ OBD_FRF_ACK **m**2 : 0|6@1+ (1.0,0.0) [0.0|63.0] ""  _4WD,ESC,IBOX
> SG_ MUL_CODE **M** : 6|2@1+ (1.0,0.0) [0.0|3.0] ""  _4WD,ABS,ACU,BCM,CLU,DATC,ECS,EPB,ESC,IBOX,LCA,SMK,TCU
> 

before:

![image](https://github.com/commaai/openpilot/assets/27770/5fc5c414-6d20-4e91-93f0-3d90f10f51d5)

after:

![Screenshot from 2023-06-24 02-39-48](https://github.com/commaai/openpilot/assets/27770/6ccf5ce7-e1e2-4380-b1d8-1fafe6e20876)
