### PR TITLE
Toyota: add alternate transmission address

### DIFF
--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -264,7 +264,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer
     (Ecu.srs, 0x780, None),     # SRS Airbag
     (Ecu.srs, 0x784, None),     # SRS Airbag 2
-    # Likely only exists on cars where EPB isn't standard
+    # Likely only exists on cars where EPB isn't standard (eg. Camry)
     (Ecu.epb, 0x750, 0x2c),     # Electronic Parking Brake
     (Ecu.gateway, 0x750, 0x5f),
     (Ecu.telematics, 0x750, 0xc7),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -268,7 +268,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.gateway, 0x750, 0x5f),
     (Ecu.telematics, 0x750, 0xc7),
     (Ecu.transmission, 0x701, None),
-    # A few platforms have a tester present response on this address
+    # A few platforms have a tester present response on this address, add to log
     (Ecu.transmission, 0x7e1, None),
     (Ecu.combinationMeter, 0x7c0, None),
   ],

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -264,7 +264,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer
     (Ecu.srs, 0x780, None),     # SRS Airbag
     (Ecu.srs, 0x784, None),     # SRS Airbag 2
-    # Likely only exists on cars where EPB isn't standard (EPB is usually combined with ABS)
+    # Likely only exists on cars where EPB isn't standard
     (Ecu.epb, 0x750, 0x2c),     # Electronic Parking Brake
     (Ecu.gateway, 0x750, 0x5f),
     (Ecu.telematics, 0x750, 0xc7),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -264,11 +264,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer
     (Ecu.srs, 0x780, None),     # SRS Airbag
     (Ecu.srs, 0x784, None),     # SRS Airbag 2
-    # Likely only exists on cars where EPB isn't standard (eg. Camry)
     (Ecu.epb, 0x750, 0x2c),     # Electronic Parking Brake
     (Ecu.gateway, 0x750, 0x5f),
     (Ecu.telematics, 0x750, 0xc7),
-    # Transmission is combined with engine on some platforms
     (Ecu.transmission, 0x701, None),
     # A few platforms have a tester present response on this address
     (Ecu.transmission, 0x7e1, None),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -260,6 +260,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # - EPS/EMPS (0x7a0, 0x7a1)
 
     # TODO: if these duplicate ECUs always exist together, remove one
+    # On some cars, EPB is controlled by the ABS module
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer
     (Ecu.srs, 0x780, None),     # SRS Airbag
     (Ecu.srs, 0x784, None),     # SRS Airbag 2

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -260,7 +260,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # - EPS/EMPS (0x7a0, 0x7a1)
 
     # TODO: if these duplicate ECUs always exist together, remove one
-    # On some cars, EPB is controlled by the ABS module
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer
     (Ecu.srs, 0x780, None),     # SRS Airbag
     (Ecu.srs, 0x784, None),     # SRS Airbag 2

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -268,6 +268,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.gateway, 0x750, 0x5f),
     (Ecu.telematics, 0x750, 0xc7),
     (Ecu.transmission, 0x701, None),
+    # A few cars have a tester present response on this address
+    (Ecu.transmission, 0x7e1, None),
     (Ecu.combinationMeter, 0x7c0, None),
   ],
 )

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -264,6 +264,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer
     (Ecu.srs, 0x780, None),     # SRS Airbag
     (Ecu.srs, 0x784, None),     # SRS Airbag 2
+    # Likely only exists on cars where EPB isn't standard (EPB is usually combined with ABS)
     (Ecu.epb, 0x750, 0x2c),     # Electronic Parking Brake
     (Ecu.gateway, 0x750, 0x5f),
     (Ecu.telematics, 0x750, 0xc7),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -267,8 +267,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.epb, 0x750, 0x2c),     # Electronic Parking Brake
     (Ecu.gateway, 0x750, 0x5f),
     (Ecu.telematics, 0x750, 0xc7),
+    # Transmission is combined with engine on some platforms
     (Ecu.transmission, 0x701, None),
-    # A few cars have a tester present response on this address
+    # A few platforms have a tester present response on this address
     (Ecu.transmission, 0x7e1, None),
     (Ecu.combinationMeter, 0x7c0, None),
   ],


### PR DESCRIPTION
Not sub-addressed, so it's free to add.

These routes in last year have a tester present pos/neg response (no FW yet):

```python
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-11-22--15-35-00--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-02--09-48-26--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-14--16-59-07--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-18--11-53-06--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-22--10-47-41--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-08--13-20-21--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-06-19--22-17-35--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-02--10-10-19--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-01--15-29-50--0
TOYOTA AVALON 2016 815d9fb3c93b55eb|2023-06-20--14-02-43--0
TOYOTA AVALON 2016 9bb8992d98301fa5|2023-06-05--14-59-21--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-04-10--12-57-26--0
TOYOTA AVALON 2016 9fcc6441e5de31c9|2023-04-30--07-52-04--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-26--09-32-13--0
TOYOTA AVALON 2016 815d9fb3c93b55eb|2023-01-02--10-42-21--0
TOYOTA AVALON 2016 815d9fb3c93b55eb|2022-11-30--09-18-47--0
TOYOTA AVALON 2016 815d9fb3c93b55eb|2023-04-13--09-52-12--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-05--07-48-19--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-02--10-32-36--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-03-02--03-12-11--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-11-23--17-56-45--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-15--07-57-25--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-11-25--15-04-03--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-02--10-45-13--0
TOYOTA AVALON 2016 815d9fb3c93b55eb|2023-06-19--13-32-29--0
TOYOTA AVALON 2016 9fcc6441e5de31c9|2023-04-29--21-58-48--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-15--22-06-23--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-02-14--20-40-52--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-12--08-17-26--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-06-17--20-39-32--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-04-25--11-29-28--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-04-05--20-56-58--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-26--20-51-21--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-03-05--20-43-51--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-24--14-57-39--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-09--12-13-08--0
TOYOTA AVALON 2016 fe56ef3e908ceadc|2023-04-17--09-37-42--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-04-07--08-50-43--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-03-23--19-33-29--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-17--17-52-27--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-12--14-47-25--0
TOYOTA AVALON 2016 fe56ef3e908ceadc|2023-04-13--17-09-59--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-04-22--18-27-23--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-02--09-56-03--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-06-21--12-20-07--0
TOYOTA AVALON 2016 815d9fb3c93b55eb|2023-05-23--12-25-51--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-02--16-39-06--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-11-20--11-33-49--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-03-13--19-36-14--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-01--11-13-04--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-01--16-05-51--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-02--08-07-16--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-03-17--08-33-40--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-29--12-29-42--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-04--08-07-55--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-01--13-02-24--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-02-12--20-50-09--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-14--07-44-52--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-03-04--21-40-25--0
LEXUS IS 2018 3776c9b10eb2ab37|2023-03-02--07-40-41--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-06--10-13-00--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-03-05--14-27-15--0
TOYOTA AVALON 2016 9fcc6441e5de31c9|2023-05-10--20-22-53--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2022-12-26--17-25-54--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-04-04--11-00-16--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-02-13--08-10-44--0
TOYOTA AVALON 2016 f4b656c4aaf63360|2023-01-16--17-52-31--0
```