### PR TITLE
Toyota: add alternate hybrid control ECU

### DIFF
--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -259,8 +259,10 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # - Steering Angle Sensor (0x7b3)
     # - EPS/EMPS (0x7a0, 0x7a1)
 
-    # TODO: if these duplicate ECUs always exist together, remove one
+    # Hybrid control computer can be on one of two addresses
+    (Ecu.hybrid, 0x7e2, None),  # Hybrid Control Assembly & Computer
     (Ecu.hybrid, 0x7d2, None),  # Hybrid Control Assembly & Computer
+    # TODO: if these duplicate ECUs always exist together, remove one
     (Ecu.srs, 0x780, None),     # SRS Airbag
     (Ecu.srs, 0x784, None),     # SRS Airbag 2
     # Likely only exists on cars where EPB isn't standard (e.g. Camry, Avalon (/Hybrid))


### PR DESCRIPTION
Found when checking out https://github.com/commaai/openpilot/issues/28651, this user's LSS2 Lexus engine is on 0x7e0, and there's an rx response for 0x7e2 in the logs:

![image](https://github.com/commaai/openpilot/assets/25857203/5e1c1016-bfc5-4a09-a74d-fc02c38a30f5)

I also checked out this exact car in Techstream, and it tried to query 0x7e2 for this ECU, then gave up because I ran it on my Camry which has it on 0x7d2.

[J2545 Logger](https://code.google.com/archive/p/j2534-logger/) logs:

```python
6.299s >> PTWriteMsgs(1, 0x050E5AD4, 0x05C9BCF4, 1000)
  Msg[ 0] 6:ISO15765. 5 bytes. TxF=0x00000040
  TxFlags: 6:ISO15765_FRAME_PAD
  \__ 00 00 07 e2 3e  # here's the 0x7e2 query!
  sent 1 of 1 messages
  6.299s 0:STATUS_NOERROR
6.299s << PTReadMsgs(1, 0x05C9ACE0, 0x05C9ACD4, 1000)
  read 1 of 1 messages
  Msg[ 0] 0.133723s. 6:ISO15765. Actual data 0 of 4 bytes. RxS=0x00000009
  RxStatus: 0:TX_MSG_TYPE 3:TX_INDICATION
  \__ [00] [00] [07] [e2]
  6.318s 0:STATUS_NOERROR
6.318s << PTReadMsgs(1, 0x05C9ACE0, 0x05C9ACD4, 1000)
  read 0 of 1 messages
  7.328s 16:ERR_BUFFER_EMPTY
7.752s -- PTDisconnect(1)
  7.752s 0:STATUS_NOERROR
7.752s -- PTClose(1)
  7.980s 0:STATUS_NOERROR
```