### PR TITLE
Document WSL bug workaround

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -42,6 +42,15 @@ Neither openpilot nor any of the tools are developed or tested on Windows, but t
 
 Follow [these instructions](https://docs.microsoft.com/en-us/windows/wsl/install) to setup the WSL and install the `Ubuntu-20.04` distribution. Once your Ubuntu WSL environment is setup, follow the Linux setup instructions to finish setting up your environment. See [these instructions](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps) for running GUI apps.
 
+---
+**NOTE**
+
+If you are running WSL and any GUIs are failing (segfaulting or other strange issues) even after following the steps above, you may need to enable software rendering with `LIBGL_ALWAYS_SOFTWARE=1`
+
+Example command: `LIBGL_ALWAYS_SOFTWARE=1 selfdrive/ui/ui`
+
+---
+
 ## CTF
 Learn about the openpilot ecosystem and tools by playing our [CTF](/tools/CTF.md).
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -42,14 +42,7 @@ Neither openpilot nor any of the tools are developed or tested on Windows, but t
 
 Follow [these instructions](https://docs.microsoft.com/en-us/windows/wsl/install) to setup the WSL and install the `Ubuntu-20.04` distribution. Once your Ubuntu WSL environment is setup, follow the Linux setup instructions to finish setting up your environment. See [these instructions](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps) for running GUI apps.
 
----
-**NOTE**
-
-If you are running WSL and any GUIs are failing (segfaulting or other strange issues) even after following the steps above, you may need to enable software rendering with `LIBGL_ALWAYS_SOFTWARE=1`
-
-Example command: `LIBGL_ALWAYS_SOFTWARE=1 selfdrive/ui/ui`
-
----
+**NOTE**: If you are running WSL and any GUIs are failing (segfaulting or other strange issues) even after following the steps above, you may need to enable software rendering with `LIBGL_ALWAYS_SOFTWARE=1`, e.g. `LIBGL_ALWAYS_SOFTWARE=1 selfdrive/ui/ui`.
 
 ## CTF
 Learn about the openpilot ecosystem and tools by playing our [CTF](/tools/CTF.md).


### PR DESCRIPTION
WSL developers may run into an issue while running GUIs, where GUIs will segfault or crash due to hardware rendering issues.

Use LIBGL_ALWAYS_SOFTWARE=1 if you see segfaults or other strange GUI failures even after setting up a fresh WSL.

History: https://github.com/commaai/openpilot/discussions/26091#discussioncomment-4258846 .

Followed @adeebshihadeh advice to put this in README and not UI wrapper from (https://github.com/commaai/openpilot/pull/28691)