### PR TITLE
cabana: fix  'QObject::connect: No such signal' warning in UnixSignalHandler

### DIFF
--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -157,7 +157,7 @@ UnixSignalHandler::UnixSignalHandler(QObject *parent) : QObject(nullptr) {
   }
 
   sn = new QSocketNotifier(sig_fd[1], QSocketNotifier::Read, this);
-  connect(sn, SIGNAL(activated(QSocketDescriptor)), this, SLOT(handleSigTerm()));
+  connect(sn, &QSocketNotifier::activated, this, &UnixSignalHandler::handleSigTerm);
   std::signal(SIGINT, signalHandler);
   std::signal(SIGTERM, UnixSignalHandler::signalHandler);
 }


### PR DESCRIPTION
fixed the warning of `QObject::connect: No such signal QSocketNotifier::activated(QSocketDescriptor)` if Qt version is less than 5.15


