### PR TITLE
Toyota: check Lane Tracing Assist (LTA) EPS faults

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -12,7 +12,7 @@ from selfdrive.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, 
 
 SteerControlType = car.CarParams.SteerControlType
 
-# These definitions seem to be common across LKA (torque) and LTA (angle)
+# These steering fault definitions seem to be common across LKA (torque) and LTA (angle)
 # - high steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
 # - lka/lta msg drop out: goes to 9 then 11 for a combined total of 2 seconds, then 3.
 #     if using the other control command, goes directly to 3 after 1.5 seconds

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -99,8 +99,7 @@ class CarState(CarStateBase):
 
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       # 3 is a fault from the lta command message not being received by the EPS
-      # TODO: set actual codes. 1 is inactive, 5 is active
-      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] not in (1, 3, 5)
+      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 25)
       ret.steerFaultPermanent = ret.steerFaultPermanent or cp.vl["EPS_STATUS"]["LTA_STATE"] in (3,)
 
     if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
@@ -189,6 +188,7 @@ class CarState(CarStateBase):
       ("STEER_ANGLE_INITIALIZING", "STEER_TORQUE_SENSOR"),
       ("TURN_SIGNALS", "BLINKERS_STATE"),
       ("LKA_STATE", "EPS_STATUS"),
+      ("LTA_STATE", "EPS_STATUS"),
       ("AUTO_HIGH_BEAM", "LIGHT_STALK"),
     ]
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -10,6 +10,8 @@ from opendbc.can.parser import CANParser
 from selfdrive.car.interfaces import CarStateBase
 from selfdrive.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, NO_STOP_TIMER_CAR, TSS2_CAR, RADAR_ACC_CAR, EPS_SCALE, UNSUPPORTED_DSU_CAR
 
+SteerControlType = car.CarParams.SteerControlType
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):
@@ -97,7 +99,7 @@ class CarState(CarStateBase):
     # 3 is a fault from the lka command message not being received by the EPS
     ret.steerFaultPermanent = cp.vl["EPS_STATUS"]["LKA_STATE"] in (3, 17)
 
-    if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
+    if self.CP.steerControlType == SteerControlType.angle:
       # may also report 0 until the EPS calibrates the STEER_TORQUE_SENSOR angle
       # 3 is a fault from the lta command message not being received by the EPS
       ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 25)
@@ -189,9 +191,12 @@ class CarState(CarStateBase):
       ("STEER_ANGLE_INITIALIZING", "STEER_TORQUE_SENSOR"),
       ("TURN_SIGNALS", "BLINKERS_STATE"),
       ("LKA_STATE", "EPS_STATUS"),
-      ("LTA_STATE", "EPS_STATUS"),
       ("AUTO_HIGH_BEAM", "LIGHT_STALK"),
     ]
+
+    # Check LTA state if using LTA angle control
+    if CP.steerControlType == SteerControlType.angle:
+      signals.append(("LTA_STATE", "EPS_STATUS"))
 
     checks = [
       ("GEAR_PACKET", 1),

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -12,6 +12,13 @@ from selfdrive.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, 
 
 SteerControlType = car.CarParams.SteerControlType
 
+# These definitions seem to be common across LKA (torque) and LTA (angle)
+# - high steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
+# - lka/lta msg drop out: goes to 9 then 11 for a combined total of 2 seconds, then 3
+#   - if using the other control command, goes to 3 after 1.5 seconds
+# - initializing: LTA can report 0 as long as STEER_TORQUE_SENSOR->STEER_ANGLE_INITIALIZING is 1
+TEMP_STEER_FAULTS = (0, 9, 11, 21, 25)
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):
@@ -92,17 +99,13 @@ class CarState(CarStateBase):
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
 
     # Check EPS LKA/LTA fault status
-    # steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
-    # lka msg drop out: goes to 9 then 11 for a combined total of 2 seconds
-    ret.steerFaultTemporary = cp.vl["EPS_STATUS"]["LKA_STATE"] in (0, 9, 11, 21, 25)
-    # 17 is a fault from a prolonged high torque delta between cmd and user
-    # 3 is a fault from the lka command message not being received by the EPS
+    ret.steerFaultTemporary = cp.vl["EPS_STATUS"]["LKA_STATE"] in TEMP_STEER_FAULTS
+    # 3 is a fault from the lka command message not being received by the EPS (recoverable)
+    # 17 is a fault from a prolonged high torque delta between cmd and user (permanent)
     ret.steerFaultPermanent = cp.vl["EPS_STATUS"]["LKA_STATE"] in (3, 17)
 
     if self.CP.steerControlType == SteerControlType.angle:
-      # may also report 0 until the EPS calibrates the STEER_TORQUE_SENSOR angle
-      # 3 is a fault from the lta command message not being received by the EPS
-      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 11, 21, 25)
+      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in TEMP_STEER_FAULTS
       ret.steerFaultPermanent = ret.steerFaultPermanent or cp.vl["EPS_STATUS"]["LTA_STATE"] in (3,)
 
     if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -102,7 +102,7 @@ class CarState(CarStateBase):
     if self.CP.steerControlType == SteerControlType.angle:
       # may also report 0 until the EPS calibrates the STEER_TORQUE_SENSOR angle
       # 3 is a fault from the lta command message not being received by the EPS
-      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 21, 25)
+      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 11, 21, 25)
       ret.steerFaultPermanent = ret.steerFaultPermanent or cp.vl["EPS_STATUS"]["LTA_STATE"] in (3,)
 
     if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -88,12 +88,20 @@ class CarState(CarStateBase):
     ret.steeringTorqueEps = cp.vl["STEER_TORQUE_SENSOR"]["STEER_TORQUE_EPS"] * self.eps_torque_scale
     # we could use the override bit from dbc, but it's triggered at too high torque values
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
+
+    # Check EPS LKA/LTA fault status
     # steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
     # lka msg drop out: goes to 9 then 11 for a combined total of 2 seconds
     ret.steerFaultTemporary = cp.vl["EPS_STATUS"]["LKA_STATE"] in (0, 9, 11, 21, 25)
     # 17 is a fault from a prolonged high torque delta between cmd and user
     # 3 is a fault from the lka command message not being received by the EPS
     ret.steerFaultPermanent = cp.vl["EPS_STATUS"]["LKA_STATE"] in (3, 17)
+
+    if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
+      # 3 is a fault from the lta command message not being received by the EPS
+      # TODO: set actual codes. 1 is inactive, 5 is active
+      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] not in (1, 3, 5)
+      ret.steerFaultPermanent = ret.steerFaultPermanent or cp.vl["EPS_STATUS"]["LTA_STATE"] in (3,)
 
     if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
       # TODO: find the bit likely in DSU_CRUISE that describes an ACC fault. one may also exist in CLUTCH

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -14,9 +14,10 @@ SteerControlType = car.CarParams.SteerControlType
 
 # These definitions seem to be common across LKA (torque) and LTA (angle)
 # - high steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
-# - lka/lta msg drop out: goes to 9 then 11 for a combined total of 2 seconds, then 3
-#   - if using the other control command, goes to 3 after 1.5 seconds
-# - initializing: LTA can report 0 as long as STEER_TORQUE_SENSOR->STEER_ANGLE_INITIALIZING is 1
+# - lka/lta msg drop out: goes to 9 then 11 for a combined total of 2 seconds, then 3.
+#     if using the other control command, goes to 3 after 1.5 seconds
+# - initializing: LTA can report 0 as long as STEER_TORQUE_SENSOR->STEER_ANGLE_INITIALIZING is 1,
+#     and is a catch-all for LKA
 TEMP_STEER_FAULTS = (0, 9, 11, 21, 25)
 
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -102,7 +102,7 @@ class CarState(CarStateBase):
     if self.CP.steerControlType == SteerControlType.angle:
       # may also report 0 until the EPS calibrates the STEER_TORQUE_SENSOR angle
       # 3 is a fault from the lta command message not being received by the EPS
-      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 25)
+      ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 21, 25)
       ret.steerFaultPermanent = ret.steerFaultPermanent or cp.vl["EPS_STATUS"]["LTA_STATE"] in (3,)
 
     if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -98,6 +98,7 @@ class CarState(CarStateBase):
     ret.steerFaultPermanent = cp.vl["EPS_STATUS"]["LKA_STATE"] in (3, 17)
 
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
+      # may also report 0 until the EPS calibrates the STEER_TORQUE_SENSOR angle
       # 3 is a fault from the lta command message not being received by the EPS
       ret.steerFaultTemporary = ret.steerFaultTemporary or cp.vl["EPS_STATUS"]["LTA_STATE"] in (0, 9, 25)
       ret.steerFaultPermanent = ret.steerFaultPermanent or cp.vl["EPS_STATUS"]["LTA_STATE"] in (3,)

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -15,7 +15,7 @@ SteerControlType = car.CarParams.SteerControlType
 # These definitions seem to be common across LKA (torque) and LTA (angle)
 # - high steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
 # - lka/lta msg drop out: goes to 9 then 11 for a combined total of 2 seconds, then 3.
-#     if using the other control command, goes to 3 after 1.5 seconds
+#     if using the other control command, goes directly to 3 after 1.5 seconds
 # - initializing: LTA can report 0 as long as STEER_TORQUE_SENSOR->STEER_ANGLE_INITIALIZING is 1,
 #     and is a catch-all for LKA
 TEMP_STEER_FAULTS = (0, 9, 11, 21, 25)

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -12,7 +12,7 @@ from selfdrive.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, 
 
 SteerControlType = car.CarParams.SteerControlType
 
-# These steering fault definitions seem to be common across LKA (torque) and LTA (angle)
+# These steering fault definitions seem to be common across LKA (torque) and LTA (angle):
 # - high steer rate fault: goes to 21 or 25 for 1 frame, then 9 for 2 seconds
 # - lka/lta msg drop out: goes to 9 then 11 for a combined total of 2 seconds, then 3.
 #     if using the other control command, goes directly to 3 after 1.5 seconds

--- a/selfdrive/car/toyota/tests/test_toyota.py
+++ b/selfdrive/car/toyota/tests/test_toyota.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 import unittest
 
-from selfdrive.car.toyota.values import TSS2_CAR, ANGLE_CONTROL_CAR
+from selfdrive.car.toyota.values import DBC, TSS2_CAR, ANGLE_CONTROL_CAR
 
 
 class TestToyotaInterfaces(unittest.TestCase):
   def test_angle_car_set(self):
     self.assertTrue(len(ANGLE_CONTROL_CAR - TSS2_CAR) == 0)
+
+  def test_tss2_dbc(self):
+    # We make some assumptions about TSS2 platforms,
+    # like looking up certain signals only in this DBC
+    for car, dbc in DBC.items():
+      if car in TSS2_CAR:
+        self.assertEqual(dbc["pt"], "toyota_nodsu_pt_generated")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Splitting from https://github.com/commaai/openpilot/pull/26722

If using LKA, no change (don't check LTA, probably fine but don't want to make a big change in this PR).

If using LTA, it checks both LKA and LTA for faults.