### PR TITLE
Toyota LTA: show alert when steering angle sensor is initializing

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -8,6 +8,7 @@ from selfdrive.car import STD_CARGO_KG, scale_tire_stiffness, get_safety_config
 from selfdrive.car.interfaces import CarInterfaceBase
 
 EventName = car.CarEvent.EventName
+SteerControlType = car.CarParams.SteerControlType
 
 
 class CarInterface(CarInterfaceBase):
@@ -27,7 +28,7 @@ class CarInterface(CarInterfaceBase):
 
     if candidate in ANGLE_CONTROL_CAR:
       ret.dashcamOnly = True
-      ret.steerControlType = car.CarParams.SteerControlType.angle
+      ret.steerControlType = SteerControlType.angle
       ret.safetyConfigs[0].safetyParam |= Panda.FLAG_TOYOTA_LTA
     else:
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
@@ -258,6 +259,11 @@ class CarInterface(CarInterfaceBase):
 
     # events
     events = self.create_common_events(ret)
+
+    # Lane Tracing Assist control is unavailable (EPS_STATUS->LTA_STATE=0) until
+    # the more accurate angle signal is ready
+    if self.CP.steerControlType == SteerControlType.angle and not self.CS.accurate_steer_angle_seen:
+      events.add(EventName.vehicleSensorsInvalid)
 
     if self.CP.openpilotLongitudinalControl:
       if ret.cruiseState.standstill and not ret.brakePressed and not self.CP.enableGasInterceptor:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -261,7 +261,7 @@ class CarInterface(CarInterfaceBase):
     events = self.create_common_events(ret)
 
     # Lane Tracing Assist control is unavailable (EPS_STATUS->LTA_STATE=0) until
-    # the more accurate angle signal sensor is initialized
+    # the more accurate angle sensor signal is initialized
     if self.CP.steerControlType == SteerControlType.angle and not self.CS.accurate_steer_angle_seen:
       events.add(EventName.vehicleSensorsInvalid)
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -261,7 +261,7 @@ class CarInterface(CarInterfaceBase):
     events = self.create_common_events(ret)
 
     # Lane Tracing Assist control is unavailable (EPS_STATUS->LTA_STATE=0) until
-    # the more accurate angle signal is ready
+    # the more accurate angle signal is initialized
     if self.CP.steerControlType == SteerControlType.angle and not self.CS.accurate_steer_angle_seen:
       events.add(EventName.vehicleSensorsInvalid)
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -261,7 +261,7 @@ class CarInterface(CarInterfaceBase):
     events = self.create_common_events(ret)
 
     # Lane Tracing Assist control is unavailable (EPS_STATUS->LTA_STATE=0) until
-    # the more accurate angle signal is initialized
+    # the more accurate angle signal sensor is initialized
     if self.CP.steerControlType == SteerControlType.angle and not self.CS.accurate_steer_angle_seen:
       events.add(EventName.vehicleSensorsInvalid)
 


### PR DESCRIPTION
Add lockout condition found in https://github.com/commaai/openpilot/pull/28711 for LTA. Basically, if we're trying to command with LTA and `STEER_TORQUE_SENSOR->STEER_ANGLE_INITIALIZING`=1, `EPS_STATUS->LTA_STATE` will be 0 (not available). Show an alert instead of a fault as this is expected.

Should check data to ensure this captures every case where LTA_STATE is 0