### PR TITLE
Toyota LTA: set actuator delay

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -31,6 +31,7 @@ class CarInterface(CarInterfaceBase):
       ret.steerControlType = SteerControlType.angle
       ret.safetyConfigs[0].safetyParam |= Panda.FLAG_TOYOTA_LTA
 
+      # LTA control can be more delayed and winds up more often
       ret.steerActuatorDelay = 0.25
       ret.steerLimitTimer = 0.8
     else:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -30,11 +30,15 @@ class CarInterface(CarInterfaceBase):
       ret.dashcamOnly = True
       ret.steerControlType = SteerControlType.angle
       ret.safetyConfigs[0].safetyParam |= Panda.FLAG_TOYOTA_LTA
+
+      ret.steerActuatorDelay = 0.25
+      ret.steerLimitTimer = 0.8
     else:
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
-    ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
-    ret.steerLimitTimer = 0.4
+      ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
+      ret.steerLimitTimer = 0.4
+
     ret.stoppingControl = False  # Toyota starts braking more when it thinks you want to stop
 
     stop_and_go = False


### PR DESCRIPTION
Split from https://github.com/commaai/openpilot/pull/28710

Seems to be much higher with lack of PI controller, this value had minimal run-away oscillations unlike earlier in testing.

With torque limited to ~1500, control here in this tough situation was pretty good: https://connect.comma.ai/297b4b460f361603/1687858059933/1687858107380

![image](https://github.com/commaai/openpilot/assets/25857203/46f42d21-1adb-4be3-865c-50ab664ec1a1)

That was future desired accel, this is current desired accel:

![image](https://github.com/commaai/openpilot/assets/25857203/cfb50568-dd67-4648-b217-90201ff958ee)
