### PR TITLE
IsoTpParallelQuery: support request callbacks

### DIFF
--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -3,7 +3,7 @@ import capnp
 import copy
 from dataclasses import dataclass, field
 import struct
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 
 import panda.python.uds as uds
 
@@ -53,8 +53,8 @@ class StdQueries:
 
 @dataclass
 class Request:
-  request: List[bytes]
-  response: List[bytes]
+  request: List[Union[bytes, Callable]]
+  response: List[Union[bytes, Callable]]
   whitelist_ecus: List[int] = field(default_factory=list)
   rx_offset: int = 0x8
   bus: int = 1

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -312,7 +312,7 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
               f.fwVersion = version
               f.address = tx_addr
               f.responseAddress = uds.get_rx_addr_for_tx_addr(tx_addr, r.rx_offset)
-              f.request = r.request
+              f.request = query.request
               f.brand = brand
               f.bus = r.bus
               f.logging = r.logging or (f.ecu, tx_addr, sub_addr) in config.extra_ecus

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -126,8 +126,9 @@ class IsoTpParallelQuery:
           if counter + 1 < len(self.request):
             # If request callback defined, replace it with its results
             if callable(self.request[counter + 1]):  # and self.response[counter + 1]:
-              self.request[counter + 1:] = self.request[counter + 1](dat[len(expected_response):])
-              self.response[counter + 1:] = self.response[counter + 1](dat[len(expected_response):])
+              response = dat[len(expected_response):]
+              self.request[counter + 1:] = self.request[counter + 1](response)
+              self.response[counter + 1:] = self.response[counter + 1](response)
 
             response_timeouts[tx_addr] = time.monotonic() + timeout
             msg.send(self.request[counter + 1])

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -124,14 +124,12 @@ class IsoTpParallelQuery:
 
         if response_valid:
           if counter + 1 < len(self.request):
-            response_timeouts[tx_addr] = time.monotonic() + timeout
-            next_request = self.request[counter + 1]
-            if callable(next_request):  # and self.response[counter + 1]:
-              new_requests = next_request(dat[len(expected_response):])
-              new_responses = self.response[counter + 1](dat[len(expected_response):])
-              self.request[counter + 1:] = new_requests
-              self.response[counter + 1:] = new_responses
+            # If request callback defined, replace it with its results
+            if callable(self.request[counter + 1]):  # and self.response[counter + 1]:
+              self.request[counter + 1:] = self.request[counter + 1](dat[len(expected_response):])
+              self.response[counter + 1:] = self.response[counter + 1](dat[len(expected_response):])
 
+            response_timeouts[tx_addr] = time.monotonic() + timeout
             msg.send(self.request[counter + 1])
             request_counter[tx_addr] += 1
           else:

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -125,7 +125,7 @@ class IsoTpParallelQuery:
         if response_valid:
           if counter + 1 < len(self.request):
             # If request callback defined, replace it with its results
-            if callable(self.request[counter + 1]):  # and self.response[counter + 1]:
+            if callable(self.request[counter + 1]):
               response = dat[len(expected_response):]
               self.request[counter + 1:] = self.request[counter + 1](response)
               self.response[counter + 1:] = self.response[counter + 1](response)

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -125,6 +125,13 @@ class IsoTpParallelQuery:
         if response_valid:
           if counter + 1 < len(self.request):
             response_timeouts[tx_addr] = time.monotonic() + timeout
+            next_request = self.request[counter + 1]
+            if callable(next_request):  # and self.response[counter + 1]:
+              new_requests = next_request(dat[len(expected_response):])
+              new_responses = self.response[counter + 1](dat[len(expected_response):])
+              self.request[counter + 1:] = new_requests
+              self.response[counter + 1:] = new_responses
+
             msg.send(self.request[counter + 1])
             request_counter[tx_addr] += 1
           else:

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -130,6 +130,8 @@ class IsoTpParallelQuery:
               self.request[counter + 1:] = self.request[counter + 1](response)
               self.response[counter + 1:] = self.response[counter + 1](response)
 
+          # If callback updated requests, check length again
+          if counter + 1 < len(self.request):
             response_timeouts[tx_addr] = time.monotonic() + timeout
             msg.send(self.request[counter + 1])
             request_counter[tx_addr] += 1

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -226,7 +226,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
     print(f'get_vin, query time={vin_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = 6.1
+    total_ref_time = 6.7
     brand_ref_times = {
       1: {
         'body': 0.1,
@@ -238,7 +238,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'nissan': 0.9,
         'subaru': 0.1,
         'tesla': 0.2,
-        'toyota': 1.6,
+        'toyota': 2.2,
         'volkswagen': 0.2,
       },
       2: {

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -169,6 +169,7 @@ class TestFwFingerprint(unittest.TestCase):
           self.assertEqual(len(request_obj.request), len(request_obj.response))
           for idx, (request, response) in enumerate(zip(request_obj.request, request_obj.response)):
             self.assertEqual(type(request), type(response))
+            # Last item can be non-bytes (callable)
             if idx < len(request_obj.request) - 1:
               self.assertTrue(isinstance(request, bytes))
 

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -120,6 +120,17 @@ class TestFwFingerprint(unittest.TestCase):
         with self.subTest(car_model=car_model):
           self.assertFalse(len(bad_ecus), f'{car_model}: Fingerprints contain ECUs added for data collection: {bad_ecus}')
 
+  def test_fw_query_config_requests(self):
+    # Asserts equal length request and response lists, types match between request and response pairs,
+    # and if a callable exists, it must be at the end
+    for brand, config in FW_QUERY_CONFIGS.items():
+      for request_obj in config.requests:
+        self.assertEqual(len(request_obj.request), len(request_obj.response))
+        for idx, (request, response) in enumerate(zip(request_obj.request, request_obj.response)):
+          self.assertEqual(type(request), type(response))
+          if idx < len(request_obj.request) - 1:
+            self.assertTrue(isinstance(request, bytes))
+
   def test_blacklisted_ecus(self):
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
     for car_model, ecus in FW_VERSIONS.items():

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -124,12 +124,13 @@ class TestFwFingerprint(unittest.TestCase):
     # Asserts equal length request and response lists, types match between request and response pairs,
     # and if a callable exists, it must be at the end
     for brand, config in FW_QUERY_CONFIGS.items():
-      for request_obj in config.requests:
-        self.assertEqual(len(request_obj.request), len(request_obj.response))
-        for idx, (request, response) in enumerate(zip(request_obj.request, request_obj.response)):
-          self.assertEqual(type(request), type(response))
-          if idx < len(request_obj.request) - 1:
-            self.assertTrue(isinstance(request, bytes))
+      with self.subTest(brand=brand):
+        for request_obj in config.requests:
+          self.assertEqual(len(request_obj.request), len(request_obj.response))
+          for idx, (request, response) in enumerate(zip(request_obj.request, request_obj.response)):
+            self.assertEqual(type(request), type(response))
+            if idx < len(request_obj.request) - 1:
+              self.assertTrue(isinstance(request, bytes))
 
   def test_blacklisted_ecus(self):
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -120,18 +120,6 @@ class TestFwFingerprint(unittest.TestCase):
         with self.subTest(car_model=car_model):
           self.assertFalse(len(bad_ecus), f'{car_model}: Fingerprints contain ECUs added for data collection: {bad_ecus}')
 
-  def test_fw_query_config_requests(self):
-    # Asserts equal length request and response lists, types match between request and response pairs,
-    # and if a callable exists, it must be at the end
-    for brand, config in FW_QUERY_CONFIGS.items():
-      with self.subTest(brand=brand):
-        for request_obj in config.requests:
-          self.assertEqual(len(request_obj.request), len(request_obj.response))
-          for idx, (request, response) in enumerate(zip(request_obj.request, request_obj.response)):
-            self.assertEqual(type(request), type(response))
-            if idx < len(request_obj.request) - 1:
-              self.assertTrue(isinstance(request, bytes))
-
   def test_blacklisted_ecus(self):
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
     for car_model, ecus in FW_VERSIONS.items():
@@ -173,11 +161,16 @@ class TestFwFingerprint(unittest.TestCase):
                          f'{brand.title()}: ECUs not in any FW query whitelists: {ecu_strings}')
 
   def test_fw_requests(self):
-    # Asserts equal length request and response lists
+    # Asserts equal length request and response lists, types match between request and response pairs,
+    # and if a callable exists it must be at the end
     for brand, config in FW_QUERY_CONFIGS.items():
       with self.subTest(brand=brand):
         for request_obj in config.requests:
           self.assertEqual(len(request_obj.request), len(request_obj.response))
+          for idx, (request, response) in enumerate(zip(request_obj.request, request_obj.response)):
+            self.assertEqual(type(request), type(response))
+            if idx < len(request_obj.request) - 1:
+              self.assertTrue(isinstance(request, bytes))
 
 
 class TestFwFingerprintTiming(unittest.TestCase):

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -254,6 +254,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics,
                       Ecu.hybrid, Ecu.srs, Ecu.combinationMeter, Ecu.transmission, Ecu.gateway, Ecu.hvac],
       bus=0,
+      logging=True,
     ),
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, StdQueries.OBD_VERSION_REQUEST],

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -229,12 +229,32 @@ STATIC_DSU_MSGS = [
 TOYOTA_VERSION_REQUEST_KWP = b'\x1a\x88\x01'
 TOYOTA_VERSION_RESPONSE_KWP = b'\x5a\x88\x01'
 
+
+def get_toyota_version_requests_kwp(responses: List[bytes]) -> List[bytes]:
+  prev_response = responses[1]  # tester present, supported ids, ...
+  supported_data_ids = [bytes([b]) for b in prev_response]
+  return [b'\x1a\x88' + b for b in supported_data_ids]
+
+
+def get_toyota_version_responses_kwp(responses: List[bytes]) -> List[bytes]:
+  prev_response = responses[1]  # tester present, supported ids, ...
+  supported_data_ids = [bytes([b]) for b in prev_response]
+  return [b'\x5a\x88' + b for b in supported_data_ids]
+
+
 FW_QUERY_CONFIG = FwQueryConfig(
   # TODO: look at data to whitelist new ECUs effectively
   requests=[
     Request(
       [StdQueries.SHORT_TESTER_PRESENT_REQUEST, TOYOTA_VERSION_REQUEST_KWP],
       [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, TOYOTA_VERSION_RESPONSE_KWP],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics,
+                      Ecu.hybrid, Ecu.srs, Ecu.combinationMeter, Ecu.transmission, Ecu.gateway, Ecu.hvac],
+      bus=0,
+    ),
+    Request(
+      [StdQueries.SHORT_TESTER_PRESENT_REQUEST, get_toyota_version_requests_kwp],
+      [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, get_toyota_version_responses_kwp],
       whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics,
                       Ecu.hybrid, Ecu.srs, Ecu.combinationMeter, Ecu.transmission, Ecu.gateway, Ecu.hvac],
       bus=0,

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -223,11 +223,14 @@ STATIC_DSU_MSGS = [
   (0x4CB, (CAR.PRIUS, CAR.RAV4H, CAR.LEXUS_RXH, CAR.LEXUS_NXH, CAR.LEXUS_NX, CAR.RAV4, CAR.COROLLA, CAR.HIGHLANDERH, CAR.HIGHLANDER, CAR.AVALON, CAR.SIENNA, CAR.LEXUS_CTH, CAR.LEXUS_ES, CAR.LEXUS_ESH, CAR.LEXUS_RX, CAR.PRIUS_V), 0, 100, b'\x0c\x00\x00\x00\x00\x00\x00\x00'),
 ]
 
+TOYOTA_VERSION_REQUEST_KWP = b'\x1a\x88\x01'
+TOYOTA_VERSION_RESPONSE_KWP = b'\x5a\x88\x01'
+
 # Some ECUs that use KWP2000 have their FW versions on non-standard data identifiers.
 # Toyota diagnostic software first gets the supported data ids, then queries them one by one.
 # For example, sends: 0x1a8800, receives: 0x1a8800010203, queries: 0x1a8801, 0x1a8802, 0x1a8803
-TOYOTA_VERSION_REQUEST_KWP = b'\x1a\x88\x01'
-TOYOTA_VERSION_RESPONSE_KWP = b'\x5a\x88\x01'
+TOYOTA_VERSION_REQUEST_PROBE_KWP = b'\x1a\x88\x00'
+TOYOTA_VERSION_RESPONSE_PROBE_KWP = b'\x5a\x88\x00'
 
 
 def get_toyota_version_requests_kwp(prev_response: bytes) -> List[bytes]:
@@ -249,8 +252,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
       bus=0,
     ),
     Request(
-      [StdQueries.SHORT_TESTER_PRESENT_REQUEST, b'\x1a\x88\x00', get_toyota_version_requests_kwp],
-      [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, b'\x5a\x88\x00', get_toyota_version_responses_kwp],
+      [StdQueries.SHORT_TESTER_PRESENT_REQUEST, TOYOTA_VERSION_REQUEST_PROBE_KWP, get_toyota_version_requests_kwp],
+      [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, TOYOTA_VERSION_RESPONSE_PROBE_KWP, get_toyota_version_responses_kwp],
       whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics,
                       Ecu.hybrid, Ecu.srs, Ecu.combinationMeter, Ecu.transmission, Ecu.gateway, Ecu.hvac],
       bus=0,

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -223,12 +223,12 @@ STATIC_DSU_MSGS = [
   (0x4CB, (CAR.PRIUS, CAR.RAV4H, CAR.LEXUS_RXH, CAR.LEXUS_NXH, CAR.LEXUS_NX, CAR.RAV4, CAR.COROLLA, CAR.HIGHLANDERH, CAR.HIGHLANDER, CAR.AVALON, CAR.SIENNA, CAR.LEXUS_CTH, CAR.LEXUS_ES, CAR.LEXUS_ESH, CAR.LEXUS_RX, CAR.PRIUS_V), 0, 100, b'\x0c\x00\x00\x00\x00\x00\x00\x00'),
 ]
 
-TOYOTA_VERSION_REQUEST_KWP = b'\x1a\x88\x01'
-TOYOTA_VERSION_RESPONSE_KWP = b'\x5a\x88\x01'
-
 # Some ECUs that use KWP2000 have their FW versions on non-standard data identifiers.
 # Toyota diagnostic software first gets the supported data ids, then queries them one by one.
 # For example, sends: 0x1a8800, receives: 0x1a8800010203, queries: 0x1a8801, 0x1a8802, 0x1a8803
+TOYOTA_VERSION_REQUEST_KWP = b'\x1a\x88\x01'
+TOYOTA_VERSION_RESPONSE_KWP = b'\x5a\x88\x01'
+
 TOYOTA_VERSION_REQUEST_PROBE_KWP = b'\x1a\x88\x00'
 TOYOTA_VERSION_RESPONSE_PROBE_KWP = b'\x5a\x88\x00'
 

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -230,16 +230,12 @@ TOYOTA_VERSION_REQUEST_KWP = b'\x1a\x88\x01'
 TOYOTA_VERSION_RESPONSE_KWP = b'\x5a\x88\x01'
 
 
-def get_toyota_version_requests_kwp(responses: List[bytes]) -> List[bytes]:
-  prev_response = responses[1]  # tester present, supported ids, ...
-  supported_data_ids = [bytes([b]) for b in prev_response]
-  return [b'\x1a\x88' + b for b in supported_data_ids]
+def get_toyota_version_requests_kwp(prev_response: bytes) -> List[bytes]:
+  return [b'\x1a\x88' + bytes([b]) for b in prev_response]
 
 
-def get_toyota_version_responses_kwp(responses: List[bytes]) -> List[bytes]:
-  prev_response = responses[1]  # tester present, supported ids, ...
-  supported_data_ids = [bytes([b]) for b in prev_response]
-  return [b'\x5a\x88' + b for b in supported_data_ids]
+def get_toyota_version_responses_kwp(prev_response: bytes) -> List[bytes]:
+  return [b'\x5a\x88' + bytes([b]) for b in prev_response]
 
 
 FW_QUERY_CONFIG = FwQueryConfig(
@@ -253,8 +249,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
       bus=0,
     ),
     Request(
-      [StdQueries.SHORT_TESTER_PRESENT_REQUEST, get_toyota_version_requests_kwp],
-      [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, get_toyota_version_responses_kwp],
+      [StdQueries.SHORT_TESTER_PRESENT_REQUEST, b'\x1a\x88\x00', get_toyota_version_requests_kwp],
+      [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, b'\x5a\x88\x00', get_toyota_version_responses_kwp],
       whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.dsu, Ecu.abs, Ecu.eps, Ecu.epb, Ecu.telematics,
                       Ecu.hybrid, Ecu.srs, Ecu.combinationMeter, Ecu.transmission, Ecu.gateway, Ecu.hvac],
       bus=0,


### PR DESCRIPTION
Configs can define requests with callbacks that take in the last response and output a list of new requests

edit: it works!

not replacing current query, since for some ECUs we will get more frames of info back (`\x01\x02` are the supported ids for fwdCamera) and thus exact matching won't work. can remove old query after data gathering