### PR TITLE
ui/sidebar: Fix the inconsistent padding in different languages.

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -391,7 +391,7 @@ void AnnotatedCameraWidget::drawHud(QPainter &p) {
 }
 
 void AnnotatedCameraWidget::drawText(QPainter &p, int x, int y, const QString &text, int alpha) {
-  QRect real_rect = getTextRect(p, 0, text);
+  QRect real_rect = p.fontMetrics().boundingRect(text);
   real_rect.moveCenter({x, y - real_rect.height() / 2});
 
   p.setPen(QColor(0xff, 0xff, 0xff, alpha));

--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -21,15 +21,7 @@ void Sidebar::drawMetric(QPainter &p, const QPair<QString, QString> &label, QCol
 
   p.setPen(QColor(0xff, 0xff, 0xff));
   configFont(p, "Inter", 35, "SemiBold");
-
-  QRect label_rect = getTextRect(p, Qt::AlignCenter, label.first);
-  label_rect.setWidth(218);
-  label_rect.moveLeft(rect.left() + 22);
-  label_rect.moveTop(rect.top() + 19);
-  p.drawText(label_rect, Qt::AlignCenter, label.first);
-
-  label_rect.moveTop(rect.top() + 65);
-  p.drawText(label_rect, Qt::AlignCenter, label.second);
+  p.drawText(rect.adjusted(22, 0, 0, 0), Qt::AlignCenter, label.first + "\n" + label.second);
 }
 
 Sidebar::Sidebar(QWidget *parent) : QFrame(parent), onroad(false), flag_pressed(false), settings_pressed(false) {

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -162,12 +162,6 @@ QPixmap loadPixmap(const QString &fileName, const QSize &size, Qt::AspectRatioMo
   }
 }
 
-QRect getTextRect(QPainter &p, int flags, const QString &text) {
-  QFontMetrics fm(p.font());
-  QRect init_rect = fm.boundingRect(text);
-  return fm.boundingRect(init_rect, flags, text);
-}
-
 void drawRoundedRect(QPainter &painter, const QRectF &rect, qreal xRadiusTop, qreal yRadiusTop, qreal xRadiusBottom, qreal yRadiusBottom){
   qreal w_2 = rect.width() / 2;
   qreal h_2 = rect.height() / 2;

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -25,6 +25,5 @@ QWidget* topWidget (QWidget* widget);
 QPixmap loadPixmap(const QString &fileName, const QSize &size = {}, Qt::AspectRatioMode aspectRatioMode = Qt::KeepAspectRatio);
 QPixmap bootstrapPixmap(const QString &id);
 
-QRect getTextRect(QPainter &p, int flags, const QString &text);
 void drawRoundedRect(QPainter &painter, const QRectF &rect, qreal xRadiusTop, qreal yRadiusTop, qreal xRadiusBottom, qreal yRadiusBottom);
 QColor interpColor(float xv, std::vector<float> xp, std::vector<QColor> fp);


### PR DESCRIPTION
1. remove hardcoded positions. make padding and spacing consistent across languages.

Taking Korean as an example, the hardcoded positioning has resulted in inconsistent padding on the top and bottom:

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2023-06-30 01:44:52](https://github.com/commaai/openpilot/assets/27770/35a15fad-f828-4dfb-a453-49639c4ead6b)  | ![Screenshot 2023-06-30 01:42:34](https://github.com/commaai/openpilot/assets/27770/3c12b21d-dd01-4623-95cf-a1b8472e0c8b)  |

all languages:

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2023-06-30 01:43:22](https://github.com/commaai/openpilot/assets/27770/ac6f0a56-1230-40f8-8f31-31eed8c03324)  | ![Screenshot 2023-06-30 01:40:37](https://github.com/commaai/openpilot/assets/27770/f67c36a1-3705-4743-818e-da5ea32a36ff)  |
| ![Screenshot 2023-06-30 01:43:35](https://github.com/commaai/openpilot/assets/27770/eb877a0b-2ac8-407d-ae35-1de7eccca1d2)  | ![Screenshot 2023-06-30 01:41:05](https://github.com/commaai/openpilot/assets/27770/93f67ecc-fbb9-47aa-a787-3eda66f93bc1)  |
| ![Screenshot 2023-06-30 01:43:51](https://github.com/commaai/openpilot/assets/27770/7d3cb29b-bb03-428c-8809-91b8920c1633)  | ![Screenshot 2023-06-30 01:41:19](https://github.com/commaai/openpilot/assets/27770/03fb40cf-5682-4e74-9e9f-abe61ac9e527)  |
| ![Screenshot 2023-06-30 01:44:04](https://github.com/commaai/openpilot/assets/27770/cff90c7a-46c8-4b7d-a6d5-7fe448b86b53)  | ![Screenshot 2023-06-30 01:41:37](https://github.com/commaai/openpilot/assets/27770/7b497f2b-7586-43db-ad02-774e517052b9)  |
| ![Screenshot 2023-06-30 01:44:18](https://github.com/commaai/openpilot/assets/27770/6311d52c-baf9-4b59-ad32-edce5a1e2f20)  | ![Screenshot 2023-06-30 01:41:57](https://github.com/commaai/openpilot/assets/27770/c45f2666-d04b-4c1d-b2b4-3127e2675b79)  |
| ![Screenshot 2023-06-30 01:44:32](https://github.com/commaai/openpilot/assets/27770/395a6735-3517-4d4f-b322-a6a34db740c1)  | ![Screenshot 2023-06-30 01:42:17](https://github.com/commaai/openpilot/assets/27770/e2924e42-3bc1-4fa0-ae83-353b026f1411)  |
| ![Screenshot 2023-06-30 01:44:52](https://github.com/commaai/openpilot/assets/27770/35a15fad-f828-4dfb-a453-49639c4ead6b)  | ![Screenshot 2023-06-30 01:42:34](https://github.com/commaai/openpilot/assets/27770/3c12b21d-dd01-4623-95cf-a1b8472e0c8b)  |

2. remove function `getTextRect` from util. there is no need to call `boundingRect` twice, the second call will only adjust the left and right spacing, and the returned height will not change.
