### PR TITLE
IsoTpParallelQuery: skip finished requests

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -103,6 +103,9 @@ class IsoTpParallelQuery:
       self.rx()
 
       for tx_addr, msg in msgs.items():
+        if request_done[tx_addr]:
+          continue
+
         try:
           dat, rx_in_progress = msg.recv()
         except Exception:


### PR DESCRIPTION
no need to rx or tx to these addresses once done

pre-reqs:
- [ ] https://github.com/commaai/panda/pull/1487
- [ ] rx_in_progress -> any rx
- [ ] ensure exceptions from isotpmessages mark addr as done, and can't extend timeouts any more, even if we still get msgs