### PR TITLE
ui: cleanup setMainWindow

### DIFF
--- a/selfdrive/ui/qt/qt_window.cc
+++ b/selfdrive/ui/qt/qt_window.cc
@@ -11,6 +11,7 @@ void setMainWindow(QWidget *w) {
   } else {
     w->setFixedSize(DEVICE_SCREEN_SIZE * scale);
   }
+  w->show();
 
 #ifdef QCOM2
   QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
@@ -22,8 +23,6 @@ void setMainWindow(QWidget *w) {
   // ensure we have a valid eglDisplay, otherwise the ui will silently fail
   void *egl = native->nativeResourceForWindow("egldisplay", w->windowHandle());
   assert(egl != nullptr);
-#else
-  w->show();
 #endif
 }
 

--- a/selfdrive/ui/qt/qt_window.cc
+++ b/selfdrive/ui/qt/qt_window.cc
@@ -1,17 +1,16 @@
 #include "selfdrive/ui/qt/qt_window.h"
 
 void setMainWindow(QWidget *w) {
+  const float scale = util::getenv("SCALE", 1.0f);
   const QSize sz = QGuiApplication::primaryScreen()->size();
-  if (Hardware::PC() && sz.width() <= 1920 && sz.height() <= 1080 && getenv("SCALE") == nullptr) {
+
+  if (Hardware::PC() && scale == 1.0 && !(sz - DEVICE_SCREEN_SIZE).isValid()) {
     w->setMinimumSize(QSize(640, 480)); // allow resize smaller than fullscreen
-    w->setMaximumSize(QSize(2160, 1080));
+    w->setMaximumSize(DEVICE_SCREEN_SIZE);
     w->resize(sz);
   } else {
-    const float scale = util::getenv("SCALE", 1.0f);
-    const bool wide = (sz.width() >= WIDE_WIDTH) ^ (getenv("INVERT_WIDTH") != NULL);
-    w->setFixedSize(QSize(wide ? WIDE_WIDTH : 1920, 1080) * scale);
+    w->setFixedSize(DEVICE_SCREEN_SIZE * scale);
   }
-  w->show();
 
 #ifdef QCOM2
   QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
@@ -23,6 +22,8 @@ void setMainWindow(QWidget *w) {
   // ensure we have a valid eglDisplay, otherwise the ui will silently fail
   void *egl = native->nativeResourceForWindow("egldisplay", w->windowHandle());
   assert(egl != nullptr);
+#else
+  w->show();
 #endif
 }
 

--- a/selfdrive/ui/qt/qt_window.h
+++ b/selfdrive/ui/qt/qt_window.h
@@ -15,7 +15,6 @@
 #include "system/hardware/hw.h"
 
 const QString ASSET_PATH = ":/";
-
-const int WIDE_WIDTH = 2160;
+const QSize DEVICE_SCREEN_SIZE = {2160, 1080};
 
 void setMainWindow(QWidget *w);


### PR DESCRIPTION
Use only wide_width (DEVICE_SCREEN_SIZE ). 1920 is the width of c2, there is no need to use it anymore.