### PR TITLE
replay: fix segfault caused by pointer usage after freeing

### DIFF
--- a/tools/replay/logreader.cc
+++ b/tools/replay/logreader.cc
@@ -74,8 +74,8 @@ bool LogReader::parse(const std::set<cereal::Event::Which> &allow, std::atomic<b
       Event *evt = new Event(words);
 #endif
       if (!allow.empty() && allow.find(evt->which) == allow.end()) {
-        delete evt;
         words = kj::arrayPtr(evt->reader.getEnd(), words.end());
+        delete evt;
         continue;
       }
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->
**Description** [](A description of the bug and the fix. Also link any relevant issues.)
In `replay/logreader.cc`, there is a usage after free bug, which caused cabana segfault loading certain routes on certain platforms (e.g. macOS). More descriptions of the issue can be found at https://github.com/commaai/openpilot/issues/28778

**Verification** [](Explain how you tested this bug fix.)
Loading the mentioned route won't segfault after the fix on macOS.