### PR TITLE
ui/map: cache navigation images at startup

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -421,17 +421,20 @@ void MapInstructions::buildPixmapCache() {
   for (QString fn : dir.entryList({"*" + ICON_SUFFIX}, QDir::Files)) {
     QPixmap pm(dir.filePath(fn));
     QString key = fn.left(fn.size() - ICON_SUFFIX.length());
+    pm = pm.scaledToWidth(200, Qt::SmoothTransformation);
+
+    // Maneuver icons
+    pixmap_cache[key] = pm;
+    // lane direction icons
     if (key.contains("turn_")) {
-      pixmap_cache[key] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-    } else {
-      pm = pm.scaledToWidth(200, Qt::SmoothTransformation);
-      pixmap_cache[key] = pm;
-      // for rhd, reflect direction and then flip
-      if (key.contains("_left")) {
-        pixmap_cache["rhd_" + key.replace("_left", "_right")] = pm.transformed(QTransform().scale(-1, 1));
-      } else if (key.contains("_right")) {
-        pixmap_cache["rhd_" + key.replace("_right", "_left")] = pm.transformed(QTransform().scale(-1, 1));
-      }
+      pixmap_cache["lane_" + key] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    }
+
+    // for rhd, reflect direction and then flip
+    if (key.contains("_left")) {
+      pixmap_cache["rhd_" + key.replace("_left", "_right")] = pm.transformed(QTransform().scale(-1, 1));
+    } else if (key.contains("_right")) {
+      pixmap_cache["rhd_" + key.replace("_right", "_left")] = pm.transformed(QTransform().scale(-1, 1));
     }
   }
 }
@@ -489,7 +492,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     }
 
     // TODO: Make more images based on active direction and combined directions
-    QString fn = "direction_";
+    QString fn = "lane_direction_";
     if (left) {
       fn += "turn_left";
     } else if (right) {

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -3,6 +3,7 @@
 #include <eigen3/Eigen/Dense>
 
 #include <QDebug>
+#include <QDir>
 
 #include "common/transformations/coordinates.hpp"
 #include "selfdrive/ui/qt/maps/map_helpers.h"
@@ -411,6 +412,27 @@ MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
   pal.setColor(QPalette::Background, QColor(0, 0, 0, 150));
   setAutoFillBackground(true);
   setPalette(pal);
+
+  buildPixmapCache();
+}
+
+void MapInstructions::buildPixmapCache() {
+  QDir dir("../assets/navigation");
+  for (QString fn : dir.entryList({"*.png"}, QDir::Files)) {
+    QPixmap pm(dir.filePath(fn));
+    if (fn.contains("turn_")) {
+      pixmap_cache[fn] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    } else {
+      pm = pm.scaledToWidth(200, Qt::SmoothTransformation);
+      pixmap_cache[fn] = pm;
+      // for rhd, reflect direction and then flip
+      if (fn.contains("_left")) {
+        pixmap_cache["rhd_" + fn.replace("_left", "_right")] = pm.transformed(QTransform().scale(-1, 1));
+      } else if (fn.contains("_right")) {
+        pixmap_cache["rhd_" + fn.replace("_right", "_left")] = pm.transformed(QTransform().scale(-1, 1));
+      }
+    }
+  }
 }
 
 QString MapInstructions::getDistance(float d) {
@@ -441,27 +463,14 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
   QString type = QString::fromStdString(instruction.getManeuverType());
   QString modifier = QString::fromStdString(instruction.getManeuverModifier());
   if (!type.isEmpty()) {
-    QString fn = "../assets/navigation/direction_" + type;
+    QString fn = "direction_" + type;
     if (!modifier.isEmpty()) {
       fn += "_" + modifier;
     }
     fn += ICON_SUFFIX;
     fn = fn.replace(' ', '_');
-
-    // for rhd, reflect direction and then flip
-    if (is_rhd) {
-      if (fn.contains("left")) {
-        fn.replace("left", "right");
-      } else if (fn.contains("right")) {
-        fn.replace("right", "left");
-      }
-    }
-
-    QPixmap pix(fn);
-    if (is_rhd) {
-      pix = pix.transformed(QTransform().scale(-1, 1));
-    }
-    icon_01->setPixmap(pix.scaledToWidth(200, Qt::SmoothTransformation));
+    bool rhd  = is_rhd && fn.contains("_left") || fn.contains("_right");
+    icon_01->setPixmap(pixmap_cache[!rhd ? fn : "rhd_" + fn]);
     icon_01->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
     icon_01->setVisible(true);
   }
@@ -480,7 +489,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     }
 
     // TODO: Make more images based on active direction and combined directions
-    QString fn = "../assets/navigation/direction_";
+    QString fn = "direction_";
     if (left) {
       fn += "turn_left";
     } else if (right) {
@@ -497,7 +506,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     if (!label->parentWidget()) {
       lane_layout->addWidget(label);
     }
-    label->setPixmap(loadPixmap(fn + ICON_SUFFIX, {125, 125}, Qt::IgnoreAspectRatio));
+    label->setPixmap(pixmap_cache[fn + ICON_SUFFIX]);
     label->setVisible(true);
   }
 

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -20,6 +20,8 @@ const float MAX_PITCH = 50;
 const float MIN_PITCH = 0;
 const float MAP_SCALE = 2;
 
+const QString ICON_SUFFIX = ".png";
+
 MapWindow::MapWindow(const QMapboxGLSettings &settings) : m_settings(settings), velocity_filter(0, 10, 0.05) {
   QObject::connect(uiState(), &UIState::uiUpdate, this, &MapWindow::updateState);
 
@@ -416,9 +418,9 @@ MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
 
 void MapInstructions::buildPixmapCache() {
   QDir dir("../assets/navigation");
-  for (QString fn : dir.entryList({"*.png"}, QDir::Files)) {
+  for (QString fn : dir.entryList({"*" + ICON_SUFFIX}, QDir::Files)) {
     QPixmap pm(dir.filePath(fn));
-    QString key = fn.chopped(strlen(".png"));
+    QString key = fn.chopped(ICON_SUFFIX.length());
     if (key.contains("turn_")) {
       pixmap_cache[key] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     } else {

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -469,7 +469,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     }
     fn += ICON_SUFFIX;
     fn = fn.replace(' ', '_');
-    bool rhd  = is_rhd && fn.contains("_left") || fn.contains("_right");
+    bool rhd = is_rhd && fn.contains("_left") || fn.contains("_right");
     icon_01->setPixmap(pixmap_cache[!rhd ? fn : "rhd_" + fn]);
     icon_01->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
     icon_01->setVisible(true);

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -418,17 +418,17 @@ void MapInstructions::buildPixmapCache() {
   QDir dir("../assets/navigation");
   for (QString fn : dir.entryList({"*.png"}, QDir::Files)) {
     QPixmap pm(dir.filePath(fn));
-    fn.chop(strlen(".png"));
-    if (fn.contains("turn_")) {
-      pixmap_cache[fn] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    QString key = fn.chopped(strlen(".png"));
+    if (key.contains("turn_")) {
+      pixmap_cache[key] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     } else {
       pm = pm.scaledToWidth(200, Qt::SmoothTransformation);
-      pixmap_cache[fn] = pm;
+      pixmap_cache[key] = pm;
       // for rhd, reflect direction and then flip
-      if (fn.contains("_left")) {
-        pixmap_cache["rhd_" + fn.replace("_left", "_right")] = pm.transformed(QTransform().scale(-1, 1));
-      } else if (fn.contains("_right")) {
-        pixmap_cache["rhd_" + fn.replace("_right", "_left")] = pm.transformed(QTransform().scale(-1, 1));
+      if (key.contains("_left")) {
+        pixmap_cache["rhd_" + key.replace("_left", "_right")] = pm.transformed(QTransform().scale(-1, 1));
+      } else if (key.contains("_right")) {
+        pixmap_cache["rhd_" + key.replace("_right", "_left")] = pm.transformed(QTransform().scale(-1, 1));
       }
     }
   }

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -20,8 +20,6 @@ const float MAX_PITCH = 50;
 const float MIN_PITCH = 0;
 const float MAP_SCALE = 2;
 
-const QString ICON_SUFFIX = ".png";
-
 MapWindow::MapWindow(const QMapboxGLSettings &settings) : m_settings(settings), velocity_filter(0, 10, 0.05) {
   QObject::connect(uiState(), &UIState::uiUpdate, this, &MapWindow::updateState);
 
@@ -420,6 +418,7 @@ void MapInstructions::buildPixmapCache() {
   QDir dir("../assets/navigation");
   for (QString fn : dir.entryList({"*.png"}, QDir::Files)) {
     QPixmap pm(dir.filePath(fn));
+    fn.chop(strlen(".png"));
     if (fn.contains("turn_")) {
       pixmap_cache[fn] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     } else {
@@ -467,7 +466,6 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     if (!modifier.isEmpty()) {
       fn += "_" + modifier;
     }
-    fn += ICON_SUFFIX;
     fn = fn.replace(' ', '_');
     bool rhd = is_rhd && (fn.contains("_left") || fn.contains("_right"));
     icon_01->setPixmap(pixmap_cache[!rhd ? fn : "rhd_" + fn]);
@@ -506,7 +504,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     if (!label->parentWidget()) {
       lane_layout->addWidget(label);
     }
-    label->setPixmap(pixmap_cache[fn + ICON_SUFFIX]);
+    label->setPixmap(pixmap_cache[fn]);
     label->setVisible(true);
   }
 

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -469,7 +469,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     }
     fn += ICON_SUFFIX;
     fn = fn.replace(' ', '_');
-    bool rhd = is_rhd && fn.contains("_left") || fn.contains("_right");
+    bool rhd = is_rhd && (fn.contains("_left") || fn.contains("_right"));
     icon_01->setPixmap(pixmap_cache[!rhd ? fn : "rhd_" + fn]);
     icon_01->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
     icon_01->setVisible(true);

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -420,7 +420,7 @@ void MapInstructions::buildPixmapCache() {
   QDir dir("../assets/navigation");
   for (QString fn : dir.entryList({"*" + ICON_SUFFIX}, QDir::Files)) {
     QPixmap pm(dir.filePath(fn));
-    QString key = fn.chopped(ICON_SUFFIX.length());
+    QString key = fn.left(fn.size() - ICON_SUFFIX.length());
     if (key.contains("turn_")) {
       pixmap_cache[key] = pm.scaled({125, 125}, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     } else {

--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -34,8 +34,8 @@ private:
   QLabel *icon_01;
   QHBoxLayout *lane_layout;
   bool is_rhd = false;
-  QHash<QString, QPixmap> pixmap_cache;
   std::vector<QLabel *> lane_labels;
+  QHash<QString, QPixmap> pixmap_cache;
 
 public:
   MapInstructions(QWidget * parent=nullptr);

--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -4,6 +4,7 @@
 
 #include <QGeoCoordinate>
 #include <QGestureEvent>
+#include <QHash>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMap>
@@ -33,10 +34,12 @@ private:
   QLabel *icon_01;
   QHBoxLayout *lane_layout;
   bool is_rhd = false;
+  QHash<QString, QPixmap> pixmap_cache;
   std::vector<QLabel *> lane_labels;
 
 public:
   MapInstructions(QWidget * parent=nullptr);
+  void buildPixmapCache();
   QString getDistance(float d);
   void updateInstructions(cereal::NavInstruction::Reader instruction);
 };


### PR DESCRIPTION
Cache images to avoid reloading, scaling, and flipping (rhd) images with each refresh.it can also prevents Qlable from redrawing the pixmap when its content has not changed.