### PR TITLE
Swap `belowSteerSpeed` and `resumeRequired` alert priorities

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -282,7 +282,7 @@ class CarInterface(CarInterfaceBase):
       events.add(EventName.belowEngageSpeed)
     if ret.cruiseState.standstill and not self.CP.autoResumeSng:
       events.add(EventName.resumeRequired)
-    elif ret.vEgo < self.CP.minSteerSpeed:
+    if ret.vEgo < self.CP.minSteerSpeed:
       events.add(EventName.belowSteerSpeed)
 
     ret.events = events.to_msg()

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -280,9 +280,9 @@ class CarInterface(CarInterfaceBase):
     if below_min_enable_speed and not (ret.standstill and ret.brake >= 20 and
                                        self.CP.networkLocation == NetworkLocation.fwdCamera):
       events.add(EventName.belowEngageSpeed)
-    if ret.cruiseState.standstill:
+    if ret.cruiseState.standstill and not self.CP.autoResumeSng:
       events.add(EventName.resumeRequired)
-    if ret.vEgo < self.CP.minSteerSpeed:
+    elif ret.vEgo < self.CP.minSteerSpeed:
       events.add(EventName.belowSteerSpeed)
 
     ret.events = events.to_msg()

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -280,7 +280,7 @@ class CarInterface(CarInterfaceBase):
     if below_min_enable_speed and not (ret.standstill and ret.brake >= 20 and
                                        self.CP.networkLocation == NetworkLocation.fwdCamera):
       events.add(EventName.belowEngageSpeed)
-    if ret.cruiseState.standstill and not self.CP.autoResumeSng:
+    if ret.cruiseState.standstill:
       events.add(EventName.resumeRequired)
     if ret.vEgo < self.CP.minSteerSpeed:
       events.add(EventName.belowSteerSpeed)

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -954,37 +954,3 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
   },
 
 }
-
-
-if __name__ == '__main__':
-  # print all alerts by type and priority
-  from collections import defaultdict, OrderedDict
-  from pprint import pprint
-
-  event_names = EventName.__dict__
-  event_names = {k: v for k, v in event_names.items() if not k.startswith('_')}
-
-  alerts_by_type = defaultdict(lambda: defaultdict(list))
-
-  CP = car.CarParams.new_message()
-  CS = car.CarState.new_message()
-  sm = messaging.SubMaster(['deviceState', 'pandaStates', 'peripheralState', 'modelV2', 'liveCalibration',
-                                     'driverMonitoringState', 'longitudinalPlan', 'lateralPlan', 'liveLocationKalman',
-                                     'managerState', 'liveParameters', 'radarState', 'liveTorqueParameters', 'testJoystick'],
-                                    ignore_avg_freq=['radarState', 'testJoystick'])
-
-  for i, alerts in EVENTS.items():
-    for type, alert in alerts.items():
-      if isinstance(alert, Callable):
-        alert = alert(CP, CS, sm, False, 0.1)
-      priority = alert.priority
-      name = [k for k, v in event_names.items() if v == i][0]
-      alerts_by_type[type][priority].append(name)
-
-  for k, v in alerts_by_type.items():
-    alerts_by_type[k] = OrderedDict(v)
-    alerts_by_type[k] = {str(j): v for j, v in sorted(alerts_by_type[k].items(), key=lambda x: -x[0])}
-  alerts_by_type = OrderedDict(alerts_by_type)
-  alerts_by_type = sorted(alerts_by_type.items(), key=lambda x: x[0])
-
-  pprint(alerts_by_type)

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -976,8 +976,7 @@ if __name__ == '__main__':
   for i, alerts in EVENTS.items():
     for type, alert in alerts.items():
       if isinstance(alert, Callable):
-        # alert = alert(CP, CS, sm, False, 0.1)  # TODO
-        continue
+        alert = alert(CP, CS, sm, False, 0.1)
       priority = alert.priority
       name = [k for k, v in event_names.items() if v == i][0]
       alerts_by_type[type][priority].append(name)

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -966,9 +966,9 @@ if __name__ == '__main__':
 
   alerts_by_type = defaultdict(lambda: defaultdict(list))
 
-  CP = None
-  CS = None
-  sm = None
+  CP = car.CarParams.new_message()
+  CS = car.CarState.new_message()
+  sm = messaging.SubMaster(['carState', 'carParams'])
 
   for i, alerts in EVENTS.items():
     for type, alert in alerts.items():

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -968,7 +968,10 @@ if __name__ == '__main__':
 
   CP = car.CarParams.new_message()
   CS = car.CarState.new_message()
-  sm = messaging.SubMaster(['carState', 'carParams'])
+  sm = messaging.SubMaster(['deviceState', 'pandaStates', 'peripheralState', 'modelV2', 'liveCalibration',
+                                     'driverMonitoringState', 'longitudinalPlan', 'lateralPlan', 'liveLocationKalman',
+                                     'managerState', 'liveParameters', 'radarState', 'liveTorqueParameters', 'testJoystick'],
+                                    ignore_avg_freq=['radarState', 'testJoystick'])
 
   for i, alerts in EVENTS.items():
     for type, alert in alerts.items():

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -238,7 +238,7 @@ def below_steer_speed_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.S
     f"Steer Unavailable Below {get_display_speed(CP.minSteerSpeed, metric)}",
     "",
     AlertStatus.userPrompt, AlertSize.small,
-    Priority.MID, VisualAlert.steerRequired, AudibleAlert.prompt, 0.4)
+    Priority.LOW, VisualAlert.steerRequired, AudibleAlert.prompt, 0.4)
 
 
 def calibration_incomplete_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int) -> Alert:
@@ -505,7 +505,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
       "Press Resume to Exit Standstill",
       "",
       AlertStatus.userPrompt, AlertSize.small,
-      Priority.LOW, VisualAlert.none, AudibleAlert.none, .2),
+      Priority.MID, VisualAlert.none, AudibleAlert.none, .2),
   },
 
   EventName.belowSteerSpeed: {
@@ -724,7 +724,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
     ET.SOFT_DISABLE: soft_disable_alert("Calibration Incomplete"),
     ET.NO_ENTRY: NoEntryAlert("Calibration in Progress"),
   },
-  
+
   EventName.calibrationRecalibrating: {
     ET.PERMANENT: calibration_incomplete_alert,
     ET.SOFT_DISABLE: soft_disable_alert("Device Remount Detected: Recalibrating"),

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -954,3 +954,35 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
   },
 
 }
+
+
+if __name__ == '__main__':
+  # print all alerts by type and priority
+  from collections import defaultdict, OrderedDict
+  from pprint import pprint
+
+  event_names = EventName.__dict__
+  event_names = {k: v for k, v in event_names.items() if not k.startswith('_')}
+
+  alerts_by_type = defaultdict(lambda: defaultdict(list))
+
+  CP = None
+  CS = None
+  sm = None
+
+  for i, alerts in EVENTS.items():
+    for type, alert in alerts.items():
+      if isinstance(alert, Callable):
+        # alert = alert(CP, CS, sm, False, 0.1)  # TODO
+        continue
+      priority = alert.priority
+      name = [k for k, v in event_names.items() if v == i][0]
+      alerts_by_type[type][priority].append(name)
+
+  for k, v in alerts_by_type.items():
+    alerts_by_type[k] = OrderedDict(v)
+    alerts_by_type[k] = {str(j): v for j, v in sorted(alerts_by_type[k].items(), key=lambda x: -x[0])}
+  alerts_by_type = OrderedDict(alerts_by_type)
+  alerts_by_type = sorted(alerts_by_type.items(), key=lambda x: x[0])
+
+  pprint(alerts_by_type)


### PR DESCRIPTION
Should fix https://github.com/commaai/openpilot/issues/28361.

I also added the SnG criterion for sending the resume message so that we don't have to remember to add that if/when we get SnG implemented on GM.