### PR TITLE
nav ui: restore speed-adaptive map zoom level

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -194,8 +194,7 @@ void MapWindow::updateState(const UIState &s) {
 
   if (zoom_counter == 0) {
     m_map->setZoom(util::map_val<float>(velocity_filter.x(), 0, 30, MAX_ZOOM, MIN_ZOOM));
-    zoom_counter = -1;
-  } else if (zoom_counter > 0) {
+  } else {
     zoom_counter--;
   }
 

--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -100,7 +100,7 @@ private:
   // Panning
   QPointF m_lastPos;
   int pan_counter = 0;
-  int zoom_counter = -1;
+  int zoom_counter = 0;
 
   // Position
   std::optional<QMapbox::Coordinate> last_position;


### PR DESCRIPTION
Speed-adaptive map zoom has been mostly broken since #25784. The map does a one time zoom to an appropriate level for your speed at the moment you engage navigation, or after the timer expires on a pan or pinch action, but then remains stuck at that same zoom level no matter how your speed changes.

@deanlee was this an expensive operation? Is it okay to put back at 20Hz? Before proposing a full revert, I tried a version that called setZoom() at 1Hz and the visual effect was unpleasant compared to full rate.