### PR TITLE
cabana: improve timeline

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -484,7 +484,7 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
     if (rubber->width() <= 0) {
       // no rubber dragged, seek to mouse position
       can->seekTo(min);
-    } else if (rubber->width() > 10) {
+    } else if (rubber->width() > 10 && (max - min) > 0.01) { // Minimum range is 10 milliseconds.
       charts_widget->zoom_undo_stack->push(new ZoomCommand(charts_widget, {min, max}));
     } else {
       viewport()->update();

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -190,7 +190,7 @@ void MainWindow::createDockWidgets() {
   video_splitter = new QSplitter(Qt::Vertical, this);
   video_widget = new VideoWidget(this);
   video_splitter->addWidget(video_widget);
-  QObject::connect(charts_widget, &ChartsWidget::rangeChanged, video_widget, &VideoWidget::rangeChanged);
+  QObject::connect(charts_widget, &ChartsWidget::rangeChanged, video_widget, &VideoWidget::updateTimeRange);
 
   video_splitter->addWidget(charts_container);
   video_splitter->setStretchFactor(1, 1);

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -57,7 +57,7 @@ public:
   virtual void pause(bool pause) {}
   const std::vector<const CanEvent *> &allEvents() const { return all_events_; }
   const std::vector<const CanEvent *> &events(const MessageId &id) const;
-  virtual const std::vector<std::tuple<int, int, TimelineType>> getTimeline() { return {}; }
+  virtual const std::vector<std::tuple<double, double, TimelineType>> getTimeline() { return {}; }
 
 signals:
   void paused();

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -23,7 +23,7 @@ public:
   inline float getSpeed() const { return replay->getSpeed(); }
   inline bool isPaused() const override { return replay->isPaused(); }
   void pause(bool pause) override;
-  inline const std::vector<std::tuple<int, int, TimelineType>> getTimeline() override { return replay->getTimeline(); }
+  inline const std::vector<std::tuple<double, double, TimelineType>> getTimeline() override { return replay->getTimeline(); }
   static AbstractOpenStreamWidget *widget(AbstractStream **stream);
 
 private:

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -34,6 +34,11 @@ class Slider : public QSlider {
 public:
   Slider(QWidget *parent);
   ~Slider();
+  double currentSecond() const { return value() / factor; }
+  void setCurrentSecond(double sec) { setValue(sec * factor); }
+  void setTimeRange(double min, double max);
+  AlertInfo alertInfo(double sec);
+  QPixmap thumbnail(double sec);
 
 signals:
   void updateMaximumTime(double);
@@ -42,20 +47,17 @@ private:
   void mousePressEvent(QMouseEvent *e) override;
   void mouseMoveEvent(QMouseEvent *e) override;
   bool event(QEvent *event) override;
-  void sliderChange(QAbstractSlider::SliderChange change) override;
   void paintEvent(QPaintEvent *ev) override;
   void parseQLog();
 
-  double max_sec = 0;
-  int slider_x = -1;
-  std::vector<std::tuple<int, int, TimelineType>> timeline;
+  const double factor = 1000.0;
+  std::vector<std::tuple<double, double, TimelineType>> timeline;
   std::mutex thumbnail_lock;
   std::atomic<bool> abort_parse_qlog = false;
   QMap<uint64_t, QPixmap> thumbnails;
   std::map<uint64_t, AlertInfo> alerts;
   std::unique_ptr<QFuture<void>> qlog_future;
   InfoLabel thumbnail_label;
-  friend class VideoWidget;
 };
 
 class VideoWidget : public QFrame {
@@ -63,7 +65,7 @@ class VideoWidget : public QFrame {
 
 public:
   VideoWidget(QWidget *parnet = nullptr);
-  void rangeChanged(double min, double max, bool is_zommed);
+  void updateTimeRange(double min, double max, bool is_zommed);
   void setMaximumTime(double sec);
 
 protected:

--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -259,8 +259,8 @@ void ConsoleUI::updateTimeline() {
 
   const int total_sec = replay->totalSeconds();
   for (auto [begin, end, type] : replay->getTimeline()) {
-    int start_pos = ((double)begin / total_sec) * width;
-    int end_pos = ((double)end / total_sec) * width;
+    int start_pos = (begin / total_sec) * width;
+    int end_pos = (end / total_sec) * width;
     if (type == TimelineType::Engaged) {
       mvwchgat(win, 1, start_pos, end_pos - start_pos + 1, A_COLOR, Color::Engaged, NULL);
       mvwchgat(win, 2, start_pos, end_pos - start_pos + 1, A_COLOR, Color::Engaged, NULL);

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -67,14 +67,14 @@ public:
   inline double currentSeconds() const { return double(cur_mono_time_ - route_start_ts_) / 1e9; }
   inline QDateTime currentDateTime() const { return route_->datetime().addSecs(currentSeconds()); }
   inline uint64_t routeStartTime() const { return route_start_ts_; }
-  inline int toSeconds(uint64_t mono_time) const { return (mono_time - route_start_ts_) / 1e9; }
+  inline double toSeconds(uint64_t mono_time) const { return (mono_time - route_start_ts_) / 1e9; }
   inline int totalSeconds() const { return (!segments_.empty()) ? (segments_.rbegin()->first + 1) * 60 : 0; }
   inline void setSpeed(float speed) { speed_ = speed; }
   inline float getSpeed() const { return speed_; }
   inline const std::vector<Event *> *events() const { return events_.get(); }
   inline const std::map<int, std::unique_ptr<Segment>> &segments() const { return segments_; };
   inline const std::string &carFingerprint() const { return car_fingerprint_; }
-  inline const std::vector<std::tuple<int, int, TimelineType>> getTimeline() {
+  inline const std::vector<std::tuple<double, double, TimelineType>> getTimeline() {
     std::lock_guard lk(timeline_lock);
     return timeline;
   }
@@ -131,7 +131,7 @@ protected:
 
   std::mutex timeline_lock;
   QFuture<void> timeline_future;
-  std::vector<std::tuple<int, int, TimelineType>> timeline;
+  std::vector<std::tuple<double, double, TimelineType>> timeline;
   std::set<cereal::Event::Which> allow_list;
   std::string car_fingerprint_;
   float speed_ = 1.0;


### PR DESCRIPTION
1. Use double instead of int to improve timeline precision.
2. The time range for zooming cannot be less than 10ms.
3. Synchronize the time of the `AlertInfo` pop-up with the time of the corresponding can frame.
4. Clean up the code, for example, by replacing the hard-coded factor with a const variable
