### PR TITLE
ui: cleanup controls

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -73,7 +73,6 @@ MapSettings::MapSettings(bool closeable, QWidget *parent)
   });
   frame->addWidget(current_widget);
   frame->addSpacing(32);
-  frame->addWidget(horizontal_line());
 
   QWidget *destinations_container = new QWidget(this);
   destinations_layout = new QVBoxLayout(destinations_container);

--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -3,18 +3,6 @@
 #include <QPainter>
 #include <QStyleOption>
 
-QFrame *horizontal_line(QWidget *parent) {
-  QFrame *line = new QFrame(parent);
-  line->setFrameShape(QFrame::StyledPanel);
-  line->setStyleSheet(R"(
-    border-width: 1px;
-    border-bottom-style: solid;
-    border-color: gray;
-  )");
-  line->setFixedHeight(2);
-  return line;
-}
-
 AbstractControl::AbstractControl(const QString &title, const QString &desc, const QString &icon, QWidget *parent) : QFrame(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setMargin(0);

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -11,8 +11,6 @@
 #include "selfdrive/ui/qt/widgets/input.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
 
-QFrame *horizontal_line(QWidget *parent = nullptr);
-
 class ElidedLabel : public QLabel {
   Q_OBJECT
 
@@ -287,14 +285,4 @@ private:
   }
   QVBoxLayout outer_layout;
   QVBoxLayout inner_layout;
-};
-
-// convenience class for wrapping layouts
-class LayoutWidget : public QWidget {
-  Q_OBJECT
-
-public:
-  LayoutWidget(QLayout *l, QWidget *parent = nullptr) : QWidget(parent) {
-    setLayout(l);
-  }
 };

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -286,3 +286,13 @@ private:
   QVBoxLayout outer_layout;
   QVBoxLayout inner_layout;
 };
+
+// convenience class for wrapping layouts
+class LayoutWidget : public QWidget {
+  Q_OBJECT
+
+public:
+  LayoutWidget(QLayout *l, QWidget *parent = nullptr) : QWidget(parent) {
+    setLayout(l);
+  }
+};


### PR DESCRIPTION
1. remove `class LayoutWidget` . it's not used after https://github.com/commaai/openpilot/issues/28476
2. remove `horizontal_line`.  this control will not have any visible effect under the current stylesheet:
 

| Begin  | After |
| ------------- | ------------- |
| ![Screenshot 2023-07-05 12:31:42](https://github.com/commaai/openpilot/assets/27770/5f6ec98e-f53b-4efa-922b-47623cdd50af)  | ![Screenshot 2023-07-05 12:32:31](https://github.com/commaai/openpilot/assets/27770/48fa5cf7-617f-4bc3-bd87-e2e1d7144a82)  |



