### PR TITLE
ui: fix alert disappear when no controlState is received in a frame.

### DIFF
--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -49,38 +49,38 @@ struct Alert {
 
   static Alert get(const SubMaster &sm, uint64_t started_frame) {
     const cereal::ControlsState::Reader &cs = sm["controlsState"].getControlsState();
-    if (sm.updated("controlsState")) {
-      return {cs.getAlertText1().cStr(), cs.getAlertText2().cStr(),
-              cs.getAlertType().cStr(), cs.getAlertSize(),
-              cs.getAlertStatus(),
-              cs.getAlertSound()};
-    } else if ((sm.frame - started_frame) > 5 * UI_FREQ) {
+    Alert alert = {cs.getAlertText1().cStr(), cs.getAlertText2().cStr(),
+                   cs.getAlertType().cStr(), cs.getAlertSize(),
+                   cs.getAlertStatus(),
+                   cs.getAlertSound()};
+
+    if (!sm.updated("controlsState") && (sm.frame - started_frame) > 5 * UI_FREQ) {
       const int CONTROLS_TIMEOUT = 5;
       const int controls_missing = (nanos_since_boot() - sm.rcv_time("controlsState")) / 1e9;
 
       // Handle controls timeout
       if (sm.rcv_frame("controlsState") < started_frame) {
         // car is started, but controlsState hasn't been seen at all
-        return {"openpilot Unavailable", "Waiting for controls to start",
-                "controlsWaiting", cereal::ControlsState::AlertSize::MID,
-                cereal::ControlsState::AlertStatus::NORMAL,
-                AudibleAlert::NONE};
+        alert = {"openpilot Unavailable", "Waiting for controls to start",
+                 "controlsWaiting", cereal::ControlsState::AlertSize::MID,
+                 cereal::ControlsState::AlertStatus::NORMAL,
+                 AudibleAlert::NONE};
       } else if (controls_missing > CONTROLS_TIMEOUT && !Hardware::PC()) {
         // car is started, but controls is lagging or died
         if (cs.getEnabled() && (controls_missing - CONTROLS_TIMEOUT) < 10) {
-          return {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
-                  "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
-                  cereal::ControlsState::AlertStatus::CRITICAL,
-                  AudibleAlert::WARNING_IMMEDIATE};
+          alert = {"TAKE CONTROL IMMEDIATELY", "Controls Unresponsive",
+                   "controlsUnresponsive", cereal::ControlsState::AlertSize::FULL,
+                   cereal::ControlsState::AlertStatus::CRITICAL,
+                   AudibleAlert::WARNING_IMMEDIATE};
         } else {
-          return {"Controls Unresponsive", "Reboot Device",
-                  "controlsUnresponsivePermanent", cereal::ControlsState::AlertSize::MID,
-                  cereal::ControlsState::AlertStatus::NORMAL,
-                  AudibleAlert::NONE};
+          alert = {"Controls Unresponsive", "Reboot Device",
+                   "controlsUnresponsivePermanent", cereal::ControlsState::AlertSize::MID,
+                   cereal::ControlsState::AlertStatus::NORMAL,
+                   AudibleAlert::NONE};
         }
       }
     }
-    return {};
+    return alert;
   }
 };
 


### PR DESCRIPTION
issue: alert disappers when no controlState is received in a frame:

[Kazam_screencast_00122.webm](https://github.com/commaai/openpilot/assets/27770/6eb87e88-e920-4edb-8171-1788fbd88390)

@adeebshihadeh , I used a qlog to test it. It should fix the https://github.com/commaai/openpilot/issues/28810  as well.