### PR TITLE
cabana: preserve msg transmitter & signal receiver when saving DBC

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -165,7 +165,7 @@ bool cabana::Signal::operator==(const cabana::Signal &other) const {
          is_signed == other.is_signed && is_little_endian == other.is_little_endian &&
          factor == other.factor && offset == other.offset &&
          min == other.min && max == other.max && comment == other.comment && unit == other.unit && val_desc == other.val_desc &&
-         multiplex_value == other.multiplex_value && type == other.type;
+         multiplex_value == other.multiplex_value && type == other.type && receiver_name == other.receiver_name;
 }
 
 // helper functions

--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -73,6 +73,7 @@ public:
   double min, max;
   QString unit;
   QString comment;
+  QString receiver_name;
   ValueDescription val_desc;
   int precision = 0;
   QColor color;
@@ -101,6 +102,7 @@ public:
   QString name;
   uint32_t size;
   QString comment;
+  QString transmitter;
   std::vector<cabana::Signal *> sigs;
 
   std::vector<uint8_t> mask;

--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -117,6 +117,7 @@ void DBCFile::parse(const QString &content) {
       current_msg->address = address;
       current_msg->name = match.captured(2);
       current_msg->size = match.captured(3).toULong();
+      current_msg->transmitter = match.captured(4).trimmed();
     } else if (line.startsWith("SG_ ")) {
       int offset = 0;
       auto match = sg_regexp.match(line);
@@ -150,6 +151,7 @@ void DBCFile::parse(const QString &content) {
       s.min = match.captured(8 + offset).toDouble();
       s.max = match.captured(9 + offset).toDouble();
       s.unit = match.captured(10 + offset);
+      s.receiver_name = match.captured(11 + offset).trimmed();
 
       current_msg->sigs.push_back(new cabana::Signal(s));
     } else if (line.startsWith("VAL_ ")) {
@@ -196,7 +198,7 @@ void DBCFile::parse(const QString &content) {
 QString DBCFile::generateDBC() {
   QString dbc_string, signal_comment, message_comment, val_desc;
   for (const auto &[address, m] : msgs) {
-    dbc_string += QString("BO_ %1 %2: %3 XXX\n").arg(address).arg(m.name).arg(m.size);
+    dbc_string += QString("BO_ %1 %2: %3 %4\n").arg(address).arg(m.name).arg(m.size).arg(m.transmitter.isEmpty() ? "XXX" : m.transmitter);
     if (!m.comment.isEmpty()) {
       message_comment += QString("CM_ BO_ %1 \"%2\";\n").arg(address).arg(m.comment);
     }
@@ -207,7 +209,7 @@ QString DBCFile::generateDBC() {
       } else if (sig->type == cabana::Signal::Type::Multiplexed) {
         multiplexer_indicator = QString("m%1 ").arg(sig->multiplex_value);
       }
-      dbc_string += QString(" SG_ %1 %2: %3|%4@%5%6 (%7,%8) [%9|%10] \"%11\" XXX\n")
+      dbc_string += QString(" SG_ %1 %2: %3|%4@%5%6 (%7,%8) [%9|%10] \"%11\" %12\n")
                         .arg(sig->name)
                         .arg(multiplexer_indicator)
                         .arg(sig->start_bit)
@@ -218,7 +220,8 @@ QString DBCFile::generateDBC() {
                         .arg(doubleToString(sig->offset))
                         .arg(doubleToString(sig->min))
                         .arg(doubleToString(sig->max))
-                        .arg(sig->unit);
+                        .arg(sig->unit)
+                        .arg(sig->receiver_name.isEmpty() ? "XXX" : sig->receiver_name);
       if (!sig->comment.isEmpty()) {
         signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);
       }

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -72,13 +72,13 @@ TEST_CASE("Parse can messages") {
 
 TEST_CASE("Parse dbc") {
   QString content = R"(
-BO_ 160 message_1: 8 XXX
+BO_ 160 message_1: 8 EON
   SG_ signal_1 : 0|12@1+ (1,0) [0|4095] "unit"  XXX
   SG_ signal_2 : 12|1@1+ (1.0,0.0) [0.0|1] ""  XXX
 
 BO_ 162 message_1: 8 XXX
-  SG_ signal_1 M : 0|12@1+ (1,0) [0|4095] "unit"  XXX
-  SG_ signal_2 M4 : 12|1@1+ (1.0,0.0) [0.0|1] ""  XXX
+  SG_ signal_1 M : 0|12@1+ (1,0) [0|4095] "unit" XXX
+  SG_ signal_2 M4 : 12|1@1+ (1.0,0.0) [0.0|1] "" XXX
 
 VAL_ 160 signal_1 0 "disabled" 1.2 "initializing" 2 "fault";
 
@@ -96,6 +96,7 @@ CM_ SG_ 160 signal_2 "multiple line comment
   REQUIRE(msg->size == 8);
   REQUIRE(msg->comment == "message comment");
   REQUIRE(msg->sigs.size() == 2);
+  REQUIRE(msg->transmitter == "EON");
   REQUIRE(file.msg("message_1") != nullptr);
 
   auto sig_1 = msg->sigs[0];
@@ -106,6 +107,7 @@ CM_ SG_ 160 signal_2 "multiple line comment
   REQUIRE(sig_1->max == 4095);
   REQUIRE(sig_1->unit == "unit");
   REQUIRE(sig_1->comment == "signal comment");
+  REQUIRE(sig_1->receiver_name == "XXX");
   REQUIRE(sig_1->val_desc.size() == 3);
   REQUIRE(sig_1->val_desc[0] == std::pair<double, QString>{0, "disabled"});
   REQUIRE(sig_1->val_desc[1] == std::pair<double, QString>{1.2, "initializing"});
@@ -123,4 +125,5 @@ CM_ SG_ 160 signal_2 "multiple line comment
   REQUIRE(msg->sigs[1]->multiplex_value == 4);
   REQUIRE(msg->sigs[1]->start_bit == 12);
   REQUIRE(msg->sigs[1]->size == 1);
+  REQUIRE(msg->sigs[1]->receiver_name == "XXX");
 }


### PR DESCRIPTION
![2023-07-07_01-16](https://github.com/commaai/openpilot/assets/27770/9f6342e9-777e-4e04-bb24-570ed2b45e40)

related issue: https://github.com/commaai/opendbc/pull/877#discussion_r1253902824