### PR TITLE
Toyota LTA: lower angle rate limits

### DIFF
--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -24,11 +24,11 @@ class CarControllerParams:
 
   # Lane Tracing Assist (LTA) control limits
   # Assuming a steering ratio of 13.7:
-  # Limit to ~2.5 m/s^3 up (9 deg/s), ~3.6 m/s^3 down (13 deg/s) at 75 mph
-  # Worst case, the low speed limits will allow 4.9 m/s^3 up and down (18 deg/s) at 75 mph,
+  # Limit to ~2.0 m/s^3 up (7.5 deg/s), ~3.0 m/s^3 down (11 deg/s) at 75 mph
+  # Worst case, the low speed limits will allow ~4.0 m/s^3 up and down (15 deg/s) at 75 mph,
   # however the EPS has its own internal limits at all speeds which are less than that
-  ANGLE_RATE_LIMIT_UP = AngleRateLimit(speed_bp=[5, 25], angle_v=[0.36, 0.18])
-  ANGLE_RATE_LIMIT_DOWN = AngleRateLimit(speed_bp=[5, 25], angle_v=[0.36, 0.26])
+  ANGLE_RATE_LIMIT_UP = AngleRateLimit(speed_bp=[5, 25], angle_v=[0.3, 0.15])
+  ANGLE_RATE_LIMIT_DOWN = AngleRateLimit(speed_bp=[5, 25], angle_v=[0.3, 0.22])
 
   def __init__(self, CP):
     if CP.lateralTuning.which == 'torque':

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -24,11 +24,11 @@ class CarControllerParams:
 
   # Lane Tracing Assist (LTA) control limits
   # Assuming a steering ratio of 13.7:
-  # Limit to ~2.0 m/s^3 up (7.5 deg/s), ~3.0 m/s^3 down (11 deg/s) at 75 mph
-  # Worst case, the low speed limits will allow ~4.0 m/s^3 up and down (15 deg/s) at 75 mph,
+  # Limit to ~2.0 m/s^3 up (7.5 deg/s), ~3.5 m/s^3 down (13 deg/s) at 75 mph
+  # Worst case, the low speed limits will allow ~4.0 m/s^3 up (15 deg/s) and ~4.9 m/s^3 down (18 deg/s) at 75 mph,
   # however the EPS has its own internal limits at all speeds which are less than that
   ANGLE_RATE_LIMIT_UP = AngleRateLimit(speed_bp=[5, 25], angle_v=[0.3, 0.15])
-  ANGLE_RATE_LIMIT_DOWN = AngleRateLimit(speed_bp=[5, 25], angle_v=[0.3, 0.22])
+  ANGLE_RATE_LIMIT_DOWN = AngleRateLimit(speed_bp=[5, 25], angle_v=[0.36, 0.26])
 
   def __init__(self, CP):
     if CP.lateralTuning.which == 'torque':


### PR DESCRIPTION
lower limits, follow up to https://github.com/commaai/openpilot/pull/28735

matches Ford safety more closely with up/down jerks. plus the EPS on a TSS 2.5 vehicle limits jerk to 2.0 m/s^2 up so it doesn't make sense to try to request more.

injection test to find max jerk by the EPS with no limits:

![image](https://github.com/commaai/openpilot/assets/25857203/f5887a96-6fd3-4585-9c19-e79e524d511a)

297b4b460f361603|2023-07-06--22-11-36