### PR TITLE
replay: emit segmentsMerged before updateEvent

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -301,14 +301,14 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
       }
     }
 
+    if (stream_thread_) {
+      emit segmentsMerged();
+    }
     updateEvents([&]() {
       events_.swap(new_events_);
       segments_merged_ = segments_need_merge;
       return true;
     });
-    if (stream_thread_) {
-      emit segmentsMerged();
-    }
   }
 }
 


### PR DESCRIPTION
this PR fixed an issue where `emit segmentsMerged` after `updateEvent` may cause cabana to fail to update can events in time before the stream thread starts pushing events.

related to: https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6390464