### PR TITLE
ui/map:  singleton navigation requests

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -1,5 +1,6 @@
 #include "map_settings.h"
 
+#include <QApplication>
 #include <QDebug>
 #include <vector>
 
@@ -84,38 +85,8 @@ MapSettings::MapSettings(bool closeable, QWidget *parent)
 
   setStyleSheet("MapSettings { background-color: #333333; }");
 
-  if (auto dongle_id = getDongleId()) {
-    // Fetch favorite and recent locations
-    {
-      QString url = CommaApi::BASE_URL + "/v1/navigation/" + *dongle_id + "/locations";
-      RequestRepeater* repeater = new RequestRepeater(this, url, "ApiCache_NavDestinations", 30, true);
-      QObject::connect(repeater, &RequestRepeater::requestDone, this, &MapSettings::parseResponse);
-    }
-
-    // Destination set while offline
-    {
-      QString url = CommaApi::BASE_URL + "/v1/navigation/" + *dongle_id + "/next";
-      RequestRepeater* repeater = new RequestRepeater(this, url, "", 10, true);
-      HttpRequest* deleter = new HttpRequest(this);
-
-      QObject::connect(repeater, &RequestRepeater::requestDone, [=](const QString &resp, bool success) {
-        if (success && resp != "null") {
-          if (params.get("NavDestination").empty()) {
-            qWarning() << "Setting NavDestination from /next" << resp;
-            params.put("NavDestination", resp.toStdString());
-          } else {
-            qWarning() << "Got location from /next, but NavDestination already set";
-          }
-
-          // Send DELETE to clear destination server side
-          deleter->sendRequest(url, HttpRequest::Method::DELETE);
-        }
-
-        // Update UI (athena can set destination at any time)
-        updateCurrentRoute();
-      });
-    }
-  }
+  QObject::connect(NavigationRequest::instance(), &NavigationRequest::locationsUpdated, this, &MapSettings::parseResponse);
+  QObject::connect(NavigationRequest::instance(), &NavigationRequest::nextDestinationUpdated, this, &MapSettings::updateCurrentRoute);
 }
 
 void MapSettings::mousePressEvent(QMouseEvent *ev) {
@@ -346,4 +317,44 @@ void DestinationWidget::unset(const QString &label, bool current) {
   action->setVisible(false);
 
   setStyleSheet(styleSheet());
+}
+
+// singleton NavigationRequest
+
+NavigationRequest *NavigationRequest::instance() {
+  static NavigationRequest *request = new NavigationRequest(qApp);
+  return request;
+}
+
+NavigationRequest::NavigationRequest(QObject *parent) : QObject(parent) {
+  if (auto dongle_id = getDongleId()) {
+    {
+      // Fetch favorite and recent locations
+      QString url = CommaApi::BASE_URL + "/v1/navigation/" + *dongle_id + "/locations";
+      RequestRepeater *repeater = new RequestRepeater(this, url, "ApiCache_NavDestinations", 30, true);
+      QObject::connect(repeater, &RequestRepeater::requestDone, this, &NavigationRequest::locationsUpdated);
+    }
+
+    {
+      // Destination set while offline
+      QString url = CommaApi::BASE_URL + "/v1/navigation/" + *dongle_id + "/next";
+      HttpRequest *deleter = new HttpRequest(this);
+      RequestRepeater *repeater = new RequestRepeater(this, url, "", 10, true);
+      QObject::connect(repeater, &RequestRepeater::requestDone, [=](const QString &resp, bool success) {
+        if (success && resp != "null") {
+          if (params.get("NavDestination").empty()) {
+            qWarning() << "Setting NavDestination from /next" << resp;
+            params.put("NavDestination", resp.toStdString());
+          } else {
+            qWarning() << "Got location from /next, but NavDestination already set";
+          }
+          // Send DELETE to clear destination server side
+          deleter->sendRequest(url, HttpRequest::Method::DELETE);
+        }
+
+        // Update UI (athena can set destination at any time)
+        emit nextDestinationUpdated(resp, success);
+      });
+    }
+  }
 }

--- a/selfdrive/ui/qt/maps/map_settings.h
+++ b/selfdrive/ui/qt/maps/map_settings.h
@@ -27,7 +27,6 @@ class NavigationRequest : public QObject {
   Q_OBJECT
 
 public:
-  NavigationRequest(QObject *parent);
   static NavigationRequest *instance();
 
 signals:
@@ -35,6 +34,8 @@ signals:
   void nextDestinationUpdated(const QString &response, bool success);
 
 private:
+  NavigationRequest(QObject *parent);
+
   Params params;
 };
 

--- a/selfdrive/ui/qt/maps/map_settings.h
+++ b/selfdrive/ui/qt/maps/map_settings.h
@@ -23,6 +23,21 @@ const QString NAV_FAVORITE_LABEL_WORK = "work";
 class NavDestination;
 class DestinationWidget;
 
+class NavigationRequest : public QObject {
+  Q_OBJECT
+
+public:
+  NavigationRequest(QObject *parent);
+  static NavigationRequest *instance();
+
+signals:
+  void locationsUpdated(const QString &response, bool success);
+  void nextDestinationUpdated(const QString &response, bool success);
+
+private:
+  Params params;
+};
+
 class MapSettings : public QFrame {
   Q_OBJECT
 public:


### PR DESCRIPTION
There are multiple instances of `MapSettings` in home and map, each with its own `RequestRepeater` to query from commaapi for navigation requests.  these duplicate requests result in wasted bandwidth and resources, and may potentially lead to synchronization issues.