### PR TITLE
ui: don't hide sidebar twice

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -34,7 +34,7 @@ HomeWindow::HomeWindow(QWidget* parent) : QWidget(parent) {
   slayout->addWidget(home);
 
   onroad = new OnroadWindow(this);
-  QObject::connect(onroad, &OnroadWindow::mapWindowShown, this, [=] { sidebar->hide(); });
+  QObject::connect(onroad, &OnroadWindow::mapPanelShown, this, [=] { sidebar->hide(); });
   slayout->addWidget(onroad);
 
   body = new BodyWindow(this);

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -34,7 +34,7 @@ HomeWindow::HomeWindow(QWidget* parent) : QWidget(parent) {
   slayout->addWidget(home);
 
   onroad = new OnroadWindow(this);
-  QObject::connect(onroad, &OnroadWindow::mapPanelShown, this, [=] { sidebar->hide(); });
+  QObject::connect(onroad, &OnroadWindow::mapPanelRequested, this, [=] { sidebar->hide(); });
   slayout->addWidget(onroad);
 
   body = new BodyWindow(this);

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -14,8 +14,8 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
 
   auto map = new MapWindow(mapboxSettings);
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
-//  QObject::connect(map, &MapWindow::requestVisible, this, &MapPanel::requestVisible);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
+    // when we show the map for a new route, signal HomeWindow to hide the sidebar
     if (visible) { emit mapWindowShown(); }
     setVisible(visible);
   });

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -14,7 +14,9 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
 
   auto map = new MapWindow(mapboxSettings);
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
+  QObject::connect(map, &MapWindow::requestVisible, this, &MapPanel::requestVisible);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
+//    emit
     setVisible(visible);
   });
   QObject::connect(map, &MapWindow::openSettings, [=]() {

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -14,9 +14,9 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
 
   auto map = new MapWindow(mapboxSettings);
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
-  QObject::connect(map, &MapWindow::requestVisible, this, &MapPanel::requestVisible);
+//  QObject::connect(map, &MapWindow::requestVisible, this, &MapPanel::requestVisible);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
-//    emit
+    if (visible) { emit mapWindowShown(); }
     setVisible(visible);
   });
   QObject::connect(map, &MapWindow::openSettings, [=]() {

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -16,7 +16,7 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
     // when we show the map for a new route, signal HomeWindow to hide the sidebar
-    if (visible) { emit mapPanelShown(); }
+    if (visible) { emit mapPanelRequested(); }
     setVisible(visible);
   });
   QObject::connect(map, &MapWindow::openSettings, [=]() {

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -16,7 +16,7 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
     // when we show the map for a new route, signal HomeWindow to hide the sidebar
-    if (visible) { emit mapWindowShown(); }
+    if (visible) { emit mapPanelShown(); }
     setVisible(visible);
   });
   QObject::connect(map, &MapWindow::openSettings, [=]() {

--- a/selfdrive/ui/qt/maps/map_panel.h
+++ b/selfdrive/ui/qt/maps/map_panel.h
@@ -12,9 +12,6 @@ public:
 
   bool isShowingMap() const;
 
-//private:
-//  void showEvent(QShowEvent *event) { emit mapWindowShown(); };
-
 signals:
   void mapWindowShown();
 

--- a/selfdrive/ui/qt/maps/map_panel.h
+++ b/selfdrive/ui/qt/maps/map_panel.h
@@ -16,6 +16,7 @@ private:
   void showEvent(QShowEvent *event) { emit mapWindowShown(); };
 
 signals:
+  void requestVisible(bool visible);
   void mapWindowShown();
 
 private:

--- a/selfdrive/ui/qt/maps/map_panel.h
+++ b/selfdrive/ui/qt/maps/map_panel.h
@@ -12,11 +12,10 @@ public:
 
   bool isShowingMap() const;
 
-private:
-  void showEvent(QShowEvent *event) { emit mapWindowShown(); };
+//private:
+//  void showEvent(QShowEvent *event) { emit mapWindowShown(); };
 
 signals:
-  void requestVisible(bool visible);
   void mapWindowShown();
 
 private:

--- a/selfdrive/ui/qt/maps/map_panel.h
+++ b/selfdrive/ui/qt/maps/map_panel.h
@@ -13,7 +13,7 @@ public:
   bool isShowingMap() const;
 
 signals:
-  void mapWindowShown();
+  void mapPanelShown();
 
 private:
   QStackedLayout *content_stack;

--- a/selfdrive/ui/qt/maps/map_panel.h
+++ b/selfdrive/ui/qt/maps/map_panel.h
@@ -13,7 +13,7 @@ public:
   bool isShowingMap() const;
 
 signals:
-  void mapPanelShown();
+  void mapPanelRequested();
 
 private:
   QStackedLayout *content_stack;

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -92,7 +92,7 @@ void OnroadWindow::offroadTransition(bool offroad) {
       auto m = new MapPanel(get_mapbox_settings());
       map = m;
 
-      QObject::connect(m, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
+      QObject::connect(m, &MapPanel::mapPanelShown, this, &OnroadWindow::mapPanelShown);
 
       m->setFixedWidth(topWidget(this)->width() / 2 - UI_BORDER_SIZE);
       split->insertWidget(0, m);

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -92,7 +92,7 @@ void OnroadWindow::offroadTransition(bool offroad) {
       auto m = new MapPanel(get_mapbox_settings());
       map = m;
 
-      QObject::connect(m, &MapPanel::mapPanelShown, this, &OnroadWindow::mapPanelShown);
+      QObject::connect(m, &MapPanel::mapPanelRequested, this, &OnroadWindow::mapPanelRequested);
 
       m->setFixedWidth(topWidget(this)->width() / 2 - UI_BORDER_SIZE);
       split->insertWidget(0, m);

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -93,13 +93,13 @@ void OnroadWindow::offroadTransition(bool offroad) {
       map = m;
 
 //      QObject::connect(m->map, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
-//      QObject::connect(m, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
-      QObject::connect(m, &MapPanel::requestVisible, [=](bool visible) {
-        if (visible) {
-          emit mapWindowShown();
-        }
-        m->setVisible(visible);
-      });
+      QObject::connect(m, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
+//      QObject::connect(m, &MapPanel::requestVisible, [=](bool visible) {
+//        if (visible) {
+//          emit mapWindowShown();
+//        }
+//        m->setVisible(visible);
+//      });
 
       m->setFixedWidth(topWidget(this)->width() / 2 - UI_BORDER_SIZE);
       split->insertWidget(0, m);

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -92,7 +92,14 @@ void OnroadWindow::offroadTransition(bool offroad) {
       auto m = new MapPanel(get_mapbox_settings());
       map = m;
 
-      QObject::connect(m, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
+//      QObject::connect(m->map, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
+//      QObject::connect(m, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
+      QObject::connect(m, &MapPanel::requestVisible, [=](bool visible) {
+        if (visible) {
+          emit mapWindowShown();
+        }
+        m->setVisible(visible);
+      });
 
       m->setFixedWidth(topWidget(this)->width() / 2 - UI_BORDER_SIZE);
       split->insertWidget(0, m);

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -92,14 +92,7 @@ void OnroadWindow::offroadTransition(bool offroad) {
       auto m = new MapPanel(get_mapbox_settings());
       map = m;
 
-//      QObject::connect(m->map, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
       QObject::connect(m, &MapPanel::mapWindowShown, this, &OnroadWindow::mapWindowShown);
-//      QObject::connect(m, &MapPanel::requestVisible, [=](bool visible) {
-//        if (visible) {
-//          emit mapWindowShown();
-//        }
-//        m->setVisible(visible);
-//      });
 
       m->setFixedWidth(topWidget(this)->width() / 2 - UI_BORDER_SIZE);
       split->insertWidget(0, m);

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -119,7 +119,7 @@ public:
   bool isMapVisible() const { return map && map->isVisible(); }
 
 signals:
-  void mapWindowShown();
+  void mapPanelShown();
 
 private:
   void paintEvent(QPaintEvent *event);

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -119,7 +119,7 @@ public:
   bool isMapVisible() const { return map && map->isVisible(); }
 
 signals:
-  void mapPanelShown();
+  void mapPanelRequested();
 
 private:
   void paintEvent(QPaintEvent *event);


### PR DESCRIPTION
previously would hide sidebar twice when tapping screen (one from show event of map, one from mouse event in home.cc). now the signal `mapPanelRequested` is only emitted when it requests itself to be shown, which doesn't require a function override

related: https://github.com/commaai/openpilot/pull/28490