### PR TITLE
ui: fix ElidedLabel mouse event propagation

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -244,11 +244,9 @@ DestinationWidget::DestinationWidget(QWidget *parent) : QPushButton(parent) {
   inner_frame->setSpacing(0);
   {
     title = new ElidedLabel(this);
-    title->setAttribute(Qt::WA_TransparentForMouseEvents);
     inner_frame->addWidget(title);
 
     subtitle = new ElidedLabel(this);
-    subtitle->setAttribute(Qt::WA_TransparentForMouseEvents);
     subtitle->setObjectName("subtitle");
     inner_frame->addWidget(subtitle);
   }
@@ -317,7 +315,6 @@ void DestinationWidget::set(NavDestination *destination, bool current) {
   subtitle->setVisible(true);
 
   // TODO: use pixmap
-  action->setAttribute(Qt::WA_TransparentForMouseEvents, !current);
   action->setText(current ? "×" : "→");
   action->setVisible(true);
 

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -81,7 +81,7 @@ void OnroadWindow::mousePressEvent(QMouseEvent* e) {
     map->setVisible(!sidebarVisible && !map->isVisible());
   }
 #endif
-  // propagation event to parent(HomeWindow)
+  // propagate event to parent(HomeWindow)
   QWidget::mousePressEvent(e);
 }
 

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -81,7 +81,7 @@ void OnroadWindow::mousePressEvent(QMouseEvent* e) {
     map->setVisible(!sidebarVisible && !map->isVisible());
   }
 #endif
-  // propagate event to parent(HomeWindow)
+  // propagate event to parent (HomeWindow)
   QWidget::mousePressEvent(e);
 }
 

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -28,7 +28,7 @@ protected:
     if (rect().contains(event->pos())) {
       emit clicked();
     }
-    QLabel::mouseReleaseEvent(event);  // propagate event to parent
+    event->ignore();  // propagate event to parent
   }
   QString lastText_, elidedText_;
 };

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -28,6 +28,7 @@ protected:
     if (rect().contains(event->pos())) {
       emit clicked();
     }
+    QWidget::mouseReleaseEvent(event);  // propagate event to parent
   }
   QString lastText_, elidedText_;
 };

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -28,7 +28,7 @@ protected:
     if (rect().contains(event->pos())) {
       emit clicked();
     }
-    QWidget::mouseReleaseEvent(event);  // propagate event to parent
+    QLabel::mouseReleaseEvent(event);  // propagate event to parent
   }
   QString lastText_, elidedText_;
 };

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -28,7 +28,7 @@ protected:
     if (rect().contains(event->pos())) {
       emit clicked();
     }
-    event->ignore();  // propagate event to parent
+    QLabel::mouseReleaseEvent(event);  // propagate event to parent
   }
   QString lastText_, elidedText_;
 };


### PR DESCRIPTION
`clicked` is only used here:

https://github.com/commaai/openpilot/blob/e63e2dde18b9ae2925d1a38c527dccfd0c99d4c5/selfdrive/ui/qt/offroad/networking.cc#L304-L306

and ElidedLabel is only used in BoxLayouts like the one in networking:

or QFrame, like in controls.h:

https://github.com/commaai/openpilot/blob/e63e2dde18b9ae2925d1a38c527dccfd0c99d4c5/selfdrive/ui/qt/widgets/controls.h#L67-L77

and so those receiving extra mouse release events shouldn't affect anything (no double taps or anything like that)