### PR TITLE
UI: preserve recent destinations sort order

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -182,8 +182,8 @@ void MapSettings::refresh() {
   // TODO: should we build a new layout and swap it in?
   clearLayout(destinations_layout);
 
-  // Sort: HOME, WORK, and then descending-alphabetical FAVORITES, RECENTS
-  std::sort(destinations.begin(), destinations.end(), [](const auto &a, const auto &b) {
+  // Sort: HOME, WORK, and then most recent (as returned by API) FAVORITES, RECENTS
+  std::stable_sort(destinations.begin(), destinations.end(), [](const auto &a, const auto &b) {
     if (a->isFavorite() && b->isFavorite()) {
       if (a->label() == NAV_FAVORITE_LABEL_HOME) return true;
       else if (b->label() == NAV_FAVORITE_LABEL_HOME) return false;
@@ -193,7 +193,7 @@ void MapSettings::refresh() {
     }
     else if (a->isFavorite()) return true;
     else if (b->isFavorite()) return false;
-    return a->name() < b->name();
+    return false;
   });
 
   for (auto &destination : destinations) {

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -189,7 +189,7 @@ void MapSettings::refresh() {
       else if (b->label() == NAV_FAVORITE_LABEL_HOME) return false;
       else if (a->label() == NAV_FAVORITE_LABEL_WORK) return true;
       else if (b->label() == NAV_FAVORITE_LABEL_WORK) return false;
-      else if (a->label() != b->label()) return a->label() < b->label();
+      else return a->name() < b->name();
     }
     else if (a->isFavorite()) return true;
     else if (b->isFavorite()) return false;

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -182,7 +182,7 @@ void MapSettings::refresh() {
   // TODO: should we build a new layout and swap it in?
   clearLayout(destinations_layout);
 
-  // Sort: HOME, WORK, and then most recent (as returned by API) FAVORITES, RECENTS
+  // Sort: HOME, WORK, alphabetical FAVORITES, and then most recent (as returned by API)
   std::stable_sort(destinations.begin(), destinations.end(), [](const auto &a, const auto &b) {
     if (a->isFavorite() && b->isFavorite()) {
       if (a->label() == NAV_FAVORITE_LABEL_HOME) return true;


### PR DESCRIPTION
- **preserve sort order of recent destinations**
The API returns these in order of "modification", which is when they were last navigated
- **sort favourites by name** (except home/work)
Their modification date is only set when created or their type is changed (between home/work/favourite), not when they are navigated to, so instead sort them by name