### PR TITLE
nav: hide settings on map request visible

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -58,7 +58,7 @@ MapWindow::MapWindow(const QMapboxGLSettings &settings) : m_settings(settings), 
     }
   )");
   QObject::connect(settings_btn, &QPushButton::clicked, [=]() {
-    emit openSettings();
+    emit requestSettings(true);
   });
 
   overlay_layout->addWidget(map_instructions);
@@ -157,6 +157,7 @@ void MapWindow::updateState(const UIState &s) {
       emit requestVisible(true); // Show map on destination set/change
       allow_open = false;
     }
+    emit requestSettings(false);
   }
 
   if (m_map.isNull()) {

--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -122,5 +122,5 @@ public slots:
 
 signals:
   void requestVisible(bool visible);
-  void openSettings();
+  void requestSettings(bool settings);
 };

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -30,4 +30,7 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
     content_stack->setCurrentIndex(0);
   });
   content_stack->addWidget(settings);
+
+  // default to settings open
+  content_stack->setCurrentIndex(1);
 }

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -20,8 +20,8 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
     if (visible) { emit mapPanelRequested(); }
     setVisible(visible);
   });
-  QObject::connect(map, &MapWindow::openSettings, [=]() {
-    content_stack->setCurrentIndex(1);
+  QObject::connect(map, &MapWindow::requestSettings, [=](bool settings) {
+    content_stack->setCurrentIndex(settings ? 1 : 0);
   });
   content_stack->addWidget(map);
 

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -15,8 +15,8 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
   auto map = new MapWindow(mapboxSettings);
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
+    // show the map for a new route and signal HomeWindow to hide the sidebar
     content_stack->setCurrentIndex(0);
-    // when we show the map for a new route, signal HomeWindow to hide the sidebar
     if (visible) { emit mapPanelRequested(); }
     setVisible(visible);
   });

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -30,7 +30,4 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
     content_stack->setCurrentIndex(0);
   });
   content_stack->addWidget(settings);
-
-  // default to settings open
-  content_stack->setCurrentIndex(1);
 }

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -15,6 +15,7 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
   auto map = new MapWindow(mapboxSettings);
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
+    content_stack->setCurrentIndex(0);
     // when we show the map for a new route, signal HomeWindow to hide the sidebar
     if (visible) { emit mapPanelRequested(); }
     setVisible(visible);

--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -15,8 +15,7 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
   auto map = new MapWindow(mapboxSettings);
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
   QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
-    // show the map for a new route and signal HomeWindow to hide the sidebar
-    content_stack->setCurrentIndex(0);
+    // when we show the map for a new route, signal HomeWindow to hide the sidebar
     if (visible) { emit mapPanelRequested(); }
     setVisible(visible);
   });


### PR DESCRIPTION
Close map settings when route is set from connect (on no route -> route transition).

Doesn't close settings if route was already set due to [`allow_open` issue](https://github.com/commaai/openpilot/issues/27710#issuecomment-1486163933).