### PR TITLE
ui: reset nav status on offroad transition

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -357,6 +357,7 @@ void MapWindow::pinchTriggered(QPinchGesture *gesture) {
 void MapWindow::offroadTransition(bool offroad) {
   if (offroad) {
     clearRoute();
+    uiState()->scene.navigate_on_openpilot = false;
   } else {
     auto dest = coordinate_from_param("NavDestination");
     emit requestVisible(dest.has_value());

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -233,6 +233,7 @@ void UIState::updateStatus() {
       scene.started_frame = sm->frame;
     }
     started_prev = scene.started;
+    uiState()->scene.navigate_on_openpilot = false;
     emit offroadTransition(!scene.started);
   }
 }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -233,7 +233,6 @@ void UIState::updateStatus() {
       scene.started_frame = sm->frame;
     }
     started_prev = scene.started;
-    uiState()->scene.navigate_on_openpilot = false;
     emit offroadTransition(!scene.started);
   }
 }


### PR DESCRIPTION
Related: https://github.com/commaai/openpilot/pull/28867

Resets nav status on offroad transition.

Fixes a bug where UI enforces map when: using nav last route, shut off car, turn on car with modeld not running