### PR TITLE
ui: singleton Device instance

### DIFF
--- a/selfdrive/ui/qt/request_repeater.cc
+++ b/selfdrive/ui/qt/request_repeater.cc
@@ -5,7 +5,7 @@ RequestRepeater::RequestRepeater(QObject *parent, const QString &requestURL, con
   timer = new QTimer(this);
   timer->setTimerType(Qt::VeryCoarseTimer);
   QObject::connect(timer, &QTimer::timeout, [=]() {
-    if ((!uiState()->scene.started || while_onroad) && uiState()->awake && !active()) {
+    if ((!uiState()->scene.started || while_onroad) && device()->isAwake() && !active()) {
       sendRequest(requestURL);
     }
   });

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -38,7 +38,7 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
       closeSettings();
     }
   });
-  QObject::connect(&device, &Device::interactiveTimeout, [=]() {
+  QObject::connect(device(), &Device::interactiveTimeout, [=]() {
     if (main_layout->currentWidget() == settingsWindow) {
       closeSettings();
     }
@@ -92,7 +92,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event) {
     case QEvent::MouseMove: {
       // ignore events when device is awakened by resetInteractiveTimeout
       ignore = !uiState()->awake;
-      device.resetInteractiveTimeout();
+      device()->resetInteractiveTimeout();
       break;
     }
     default:

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -91,7 +91,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event) {
     case QEvent::MouseButtonPress:
     case QEvent::MouseMove: {
       // ignore events when device is awakened by resetInteractiveTimeout
-      ignore = !uiState()->awake;
+      ignore = !device()->isAwake();
       device()->resetInteractiveTimeout();
       break;
     }

--- a/selfdrive/ui/qt/window.h
+++ b/selfdrive/ui/qt/window.h
@@ -18,8 +18,6 @@ private:
   void openSettings(int index = 0, const QString &param = "");
   void closeSettings();
 
-  Device device;
-
   QStackedLayout *main_layout;
   HomeWindow *homeWindow;
   SettingsWindow *settingsWindow;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -347,3 +347,8 @@ UIState *uiState() {
   static UIState ui_state;
   return &ui_state;
 }
+
+Device *device() {
+  static Device _device;
+  return &_device;
+}

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -283,9 +283,6 @@ Device::Device(QObject *parent) : brightness_filter(BACKLIGHT_OFFROAD, BACKLIGHT
 void Device::update(const UIState &s) {
   updateBrightness(s);
   updateWakefulness(s);
-
-  // TODO: remove from UIState and use signals
-  uiState()->awake = awake;
 }
 
 void Device::setAwake(bool on) {

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -210,6 +210,8 @@ public slots:
   void update(const UIState &s);
 };
 
+Device *device();
+
 void ui_update_params(UIState *s);
 int get_path_length_idx(const cereal::XYZTData::Reader &line, const float path_height);
 void update_model(UIState *s,

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -161,7 +161,6 @@ public:
   UIStatus status;
   UIScene scene = {};
 
-  bool awake;
   QString language;
 
   QTransform car_space_transform;
@@ -188,6 +187,7 @@ class Device : public QObject {
 
 public:
   Device(QObject *parent = 0);
+  bool isAwake() { return awake; }
 
 private:
   bool awake = false;


### PR DESCRIPTION
so we can use `interactiveTimeout` signal anywhere (https://github.com/commaai/openpilot/pull/28904) and https://github.com/commaai/openpilot/pull/28907. removes copy of `awake` in UIState, can access `device()->isAwake()` instead