### PR TITLE
CanBusBase: fix offset calculation

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -186,8 +186,7 @@ class CanBusBase:
   def __init__(self, CP, fingerprint: Optional[Dict[int, Dict[int, int]]]) -> None:
     if CP is None:
       assert fingerprint is not None
-      num = math.ceil(max([k for k, v in fingerprint.items() if len(v)], default=1) / 4)
+      num = max([k for k, v in fingerprint.items() if len(v)], default=0) // 4 + 1
     else:
       num = len(CP.safetyConfigs)
-
     self.offset = 4 * (num - 1)

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -1,5 +1,4 @@
 # functions common among cars
-import math
 from collections import namedtuple
 from typing import Dict, Optional
 

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -189,4 +189,5 @@ class CanBusBase:
       num = math.ceil(max([k for k, v in fingerprint.items() if len(v)], default=1) / 4)
     else:
       num = len(CP.safetyConfigs)
+
     self.offset = 4 * (num - 1)


### PR DESCRIPTION
fixes crash in CanBusBase when there is only CAN traffic on bus 0 (no events in sentry, very unlikely to actually happen)

Added in: https://github.com/commaai/openpilot/pull/27903
Caught in: https://github.com/commaai/openpilot/pull/28931