### PR TITLE
interceptor: set to 0 value when inactive

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -154,6 +154,8 @@ def create_gas_interceptor_command(packer, gas_amount, idx):
   values = {
     "ENABLE": enable,
     "COUNTER_PEDAL": idx & 0xF,
+    "GAS_COMMAND": 0.0,
+    "GAS_COMMAND2": 0.0,
   }
 
   if enable:

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -154,8 +154,8 @@ def create_gas_interceptor_command(packer, gas_amount, idx):
   values = {
     "ENABLE": enable,
     "COUNTER_PEDAL": idx & 0xF,
-    "GAS_COMMAND": 0.0,
-    "GAS_COMMAND2": 0.0,
+    "GAS_COMMAND": 0,
+    "GAS_COMMAND2": 0,
   }
 
   if enable:


### PR DESCRIPTION
instead of 0 bytes, which is different. for: https://github.com/commaai/panda/pull/1509, pre-req of https://github.com/commaai/opendbc/pull/884