### PR TITLE
test_models: don't skip test cases with multiple pytest jobs

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -39,7 +39,7 @@ for r in routes:
 test_cases: List[Tuple[str, Optional[CarTestRoute]]] = []
 for i, c in enumerate(sorted(all_known_cars())):
   if i % NUM_JOBS == JOB_ID:
-    test_cases.extend((c, r) for r in routes_by_car.get(c, (None, )))
+    test_cases.extend(sorted((c, r) for r in routes_by_car.get(c, (None, ))))
 
 SKIP_ENV_VAR = "SKIP_LONG_TESTS"
 

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -36,6 +36,7 @@ routes_by_car = defaultdict(set)
 for r in routes:
   routes_by_car[r.car_model].add(r)
 
+# We ensure all test cases are sorted for determinism with multiple jobs
 test_cases: List[Tuple[str, Optional[CarTestRoute]]] = []
 for i, c in enumerate(sorted(all_known_cars())):
   if i % NUM_JOBS == JOB_ID:

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -36,7 +36,6 @@ routes_by_car = defaultdict(set)
 for r in routes:
   routes_by_car[r.car_model].add(r)
 
-# We ensure all test cases are sorted for determinism with multiple jobs
 test_cases: List[Tuple[str, Optional[CarTestRoute]]] = []
 for i, c in enumerate(sorted(all_known_cars())):
   if i % NUM_JOBS == JOB_ID:


### PR DESCRIPTION
the ordering of the test case segments within the same platform is non-deterministic, so we were often not running on all segments if there were multiple segments for a platform.

For example, for EV6 with 3 routes, it could easily only run one segment three times, or one once and another twice, etc.

Before:

```python
================================================================================== short test summary info ==================================================================================
ERROR test_models.py::TestCarModel_99_KIA_EV6_2022::test_panda_safety_tx_cases - AssertionError: d545129f3ca90f28|2022-10-19--09-22-54
ERROR test_models.py::TestCarModel_100_KIA_EV6_2022::test_panda_safety_tx_cases - AssertionError: d545129f3ca90f28|2022-10-19--09-22-54
ERROR test_models.py::TestCarModel_101_KIA_EV6_2022::test_panda_safety_tx_cases - AssertionError: 9b25e8c1484a1b67|2023-04-13--10-41-45
============================================================================== 222 skipped, 3 errors in 11.87s ==============================================================================
batman@workstation-shane:~/openpilot/selfdrive/car/tests$ FILTER="KIA EV" pytest -n32 -s ./test_models.py
```

After:

```python
================================================================================== short test summary info ==================================================================================
ERROR test_models.py::TestCarModel_101_KIA_EV6_2022::test_panda_safety_tx_cases - AssertionError: d545129f3ca90f28|2022-10-19--09-22-54
ERROR test_models.py::TestCarModel_99_KIA_EV6_2022::test_panda_safety_tx_cases - AssertionError: 68d6a96e703c00c9|2022-09-10--16-09-39
ERROR test_models.py::TestCarModel_100_KIA_EV6_2022::test_panda_safety_tx_cases - AssertionError: 9b25e8c1484a1b67|2023-04-13--10-41-45
============================================================================== 222 skipped, 3 errors in 12.41s ==============================================================================
```

Not an issue for CI since we extend all routes for a platform right after the first sorted() call, ordering might be different, but all should get ran.