### PR TITLE
mapsd: release MapRenderer on exit

### DIFF
--- a/selfdrive/navd/main.cc
+++ b/selfdrive/navd/main.cc
@@ -14,8 +14,6 @@ int main(int argc, char *argv[]) {
   std::signal(SIGINT, sigTermHandler);
   std::signal(SIGTERM, sigTermHandler);
 
-  MapRenderer * m = new MapRenderer(get_mapbox_settings());
-  assert(m);
-
+  MapRenderer m(get_mapbox_settings());
   return app.exec();
 }

--- a/selfdrive/navd/map_renderer.cc
+++ b/selfdrive/navd/map_renderer.cc
@@ -53,8 +53,7 @@ MapRenderer::MapRenderer(const QMapboxGLSettings &settings, bool online) : m_set
   ctx->makeCurrent(surface.get());
   assert(QOpenGLContext::currentContext() == ctx.get());
 
-  gl_functions.reset(ctx->functions());
-  gl_functions->initializeOpenGLFunctions();
+  ctx->functions()->initializeOpenGLFunctions();
 
   QOpenGLFramebufferObjectFormat fbo_format;
   fbo.reset(new QOpenGLFramebufferObject(WIDTH, HEIGHT, fbo_format));
@@ -67,7 +66,7 @@ MapRenderer::MapRenderer(const QMapboxGLSettings &settings, bool online) : m_set
 
   m_map->resize(fbo->size());
   m_map->setFramebufferObject(fbo->handle(), fbo->size());
-  gl_functions->glViewport(0, 0, WIDTH, HEIGHT);
+  ctx->functions()->glViewport(0, 0, WIDTH, HEIGHT);
 
   QObject::connect(m_map.data(), &QMapboxGL::mapChanged, [=](QMapboxGL::MapChange change) {
     // https://github.com/mapbox/mapbox-gl-native/blob/cf734a2fec960025350d8de0d01ad38aeae155a0/platform/qt/include/qmapboxgl.hpp#L116
@@ -157,9 +156,9 @@ bool MapRenderer::loaded() {
 
 void MapRenderer::update() {
   double start_t = millis_since_boot();
-  gl_functions->glClear(GL_COLOR_BUFFER_BIT);
+  ctx->functions()->glClear(GL_COLOR_BUFFER_BIT);
   m_map->render();
-  gl_functions->glFlush();
+  ctx->functions()->glFlush();
   double end_t = millis_since_boot();
 
   if ((vipc_server != nullptr) && loaded()) {

--- a/selfdrive/navd/map_renderer.h
+++ b/selfdrive/navd/map_renderer.h
@@ -28,7 +28,6 @@ public:
 private:
   std::unique_ptr<QOpenGLContext> ctx;
   std::unique_ptr<QOffscreenSurface> surface;
-  std::unique_ptr<QOpenGLFunctions> gl_functions;
   std::unique_ptr<QOpenGLFramebufferObject> fbo;
 
   std::unique_ptr<VisionIpcServer> vipc_server;


### PR DESCRIPTION
1. release MapRenderer on exit
2. fix segfault caused  by double free opengl functions:
```
corrupted size vs. prev_size in fastbins
Aborted (core dumped)
```

Related issue:  https://github.com/commaai/openpilot/issues/28919#issuecomment-1637460717

Not quite sure if it's directly related to  #28919, but this should be fixed anyway. 