### PR TITLE
[Qcom GPS] BearingAccuracyDeg should not be 0 when inaccurate

### DIFF
--- a/system/sensord/rawgps/rawgpsd.py
+++ b/system/sensord/rawgps/rawgpsd.py
@@ -358,7 +358,7 @@ def main() -> NoReturn:
       gps.source = log.GpsLocationData.SensorSource.qcomdiag
       gps.vNED = vNED
       gps.verticalAccuracy = report["q_FltVdop"]
-      gps.bearingAccuracyDeg = report["q_FltHeadingUncRad"] * 180/math.pi
+      gps.bearingAccuracyDeg = report["q_FltHeadingUncRad"] * 180/math.pi if (report["q_FltHeadingUncRad"] != 0) else 180
       gps.speedAccuracy = math.sqrt(sum([x**2 for x in vNEDsigma]))
       # quectel gps verticalAccuracy is clipped to 500, set invalid if so
       gps.flags = 1 if gps.verticalAccuracy != 500 else 0


### PR DESCRIPTION
Current default `bearingDegAccuracy` is 0 when inaccurate. (https://github.com/commaai/openpilot/issues/28832) This is incorrect, it should be 180 deg.
![image](https://github.com/commaai/openpilot/assets/1649262/3bf21aaf-b2ee-4780-9eb0-b60e853102db)

To Do
- [x] ~Check if it is actually zero in some cases~ It is not
- [x] ~Accuracy and verticalAccuracy and SpeedAccuracy can also be 0 at the beginning. Handle them too?~ They are not zero, they are some non-zero noisy values, which is handled in `locationd`. Accuracy is always 0, but that is also handled.