### PR TITLE
Ford: fix CAN FD fingerprinting

### DIFF
--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -109,12 +109,21 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.shiftByWire],
       bus=0,
     ),
+    # CAN FD queries. F150 does not respond to queries on powertrain bus (0) yet,
+    # so that query is just for logging and debugging purposes
+    Request(
+      [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
+      [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.engine, Ecu.shiftByWire],
+      auxiliary=True,
+    ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.engine, Ecu.shiftByWire],
       bus=0,
       auxiliary=True,
+      logging=True,
     ),
   ],
   extra_ecus=[

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -109,8 +109,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.shiftByWire],
       bus=0,
     ),
+
     # CAN FD queries. F150 does not respond to queries on powertrain bus (0) yet,
-    # so that query is just for logging and debugging purposes
+    # so that query below is just for logging and debugging purposes
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -100,7 +100,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
     # CAN and CAN FD queries are combined. For CAN FD, bus 0 (4) queries do not respond and so
     # are purely for debugging/logging purposes at the moment.
-    # TODO: properly handle auxiliary queries to separate queries and add back whitelists
+    # TODO: properly handle auxiliary requests to separate queries and add back whitelists
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -98,33 +98,21 @@ CAR_INFO: Dict[str, Union[CarInfo, List[CarInfo]]] = {
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
+    # CAN and CAN FD queries are combined. For CAN FD, bus 0 (4) queries do not respond and so
+    # are purely for debugging/logging purposes at the moment.
+    # TODO: properly handle auxiliary queries to separate queries and add back whitelists
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.engine],
-    ),
-    Request(
-      [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
-      [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.shiftByWire],
-      bus=0,
-    ),
-
-    # CAN FD queries. F150 does not respond to queries on powertrain bus (0) yet,
-    # so that query below is just for logging and debugging purposes
-    Request(
-      [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
-      [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.engine, Ecu.shiftByWire],
+      # whitelist_ecus=[Ecu.engine],
       auxiliary=True,
     ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.engine, Ecu.shiftByWire],
+      # whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.shiftByWire],
       bus=0,
       auxiliary=True,
-      logging=True,
     ),
   ],
   extra_ecus=[

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -98,8 +98,8 @@ CAR_INFO: Dict[str, Union[CarInfo, List[CarInfo]]] = {
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
-    # CAN and CAN FD queries are combined. For CAN FD, bus 0 (4) queries do not respond and so
-    # are purely for debugging/logging purposes at the moment.
+    # CAN and CAN FD queries are combined.
+    # FIXME: For CAN FD, ECUs respond with frames larger than 8 bytes on the powertrain bus
     # TODO: properly handle auxiliary requests to separate queries and add back whitelists
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -80,7 +80,7 @@ class FwQueryConfig:
 
   def __post_init__(self):
     for i in range(len(self.requests)):
-      if self.requests[i].auxiliary:# and self.requests[i].bus != 1:
+      if self.requests[i].auxiliary:
         new_request = copy.deepcopy(self.requests[i])
         new_request.bus += 4
         self.requests.append(new_request)

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -80,7 +80,7 @@ class FwQueryConfig:
 
   def __post_init__(self):
     for i in range(len(self.requests)):
-      if self.requests[i].auxiliary:
+      if self.requests[i].auxiliary:# and self.requests[i].bus != 1:
         new_request = copy.deepcopy(self.requests[i])
         new_request.bus += 4
         self.requests.append(new_request)

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -236,7 +236,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'volkswagen': 0.2,
       },
       2: {
-        'ford': 0.4,
+        'ford': 0.5,
         'hyundai': 1.1,
       }
     }

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -220,12 +220,12 @@ class TestFwFingerprintTiming(unittest.TestCase):
     print(f'get_vin, query time={vin_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = 6.7
+    total_ref_time = 6.6
     brand_ref_times = {
       1: {
         'body': 0.1,
         'chrysler': 0.3,
-        'ford': 0.3,
+        'ford': 0.2,
         'honda': 0.5,
         'hyundai': 0.7,
         'mazda': 0.2,
@@ -236,7 +236,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'volkswagen': 0.2,
       },
       2: {
-        'ford': 0.5,
+        'ford': 0.4,
         'hyundai': 1.1,
       }
     }


### PR DESCRIPTION
CAN FD cars use up to 64 bytes in their iso-tp responses when not using the OBD port, so we need to query with the OBD port for now