### PR TITLE
onnx_runner: force determinism 

### DIFF
--- a/selfdrive/modeld/runners/onnx_runner.py
+++ b/selfdrive/modeld/runners/onnx_runner.py
@@ -32,11 +32,12 @@ def run_loop(m, tf8_input=False):
   ishapes = [[1]+ii.shape[1:] for ii in m.get_inputs()]
   keys = [x.name for x in m.get_inputs()]
   itypes = [ORT_TYPES_TO_NP_TYPES[x.type] for x in m.get_inputs()]
-  print("onnx model inputs", keys, ishapes, itypes)
+
   # run once to initialize CUDA provider
   if "CUDAExecutionProvider" in m.get_providers():
     m.run(None, dict(zip(keys, [np.zeros(shp, dtype=itp) for shp, itp in zip(ishapes, itypes)])))
 
+  print("ready to run onnx model", keys, ishapes, file=sys.stderr)
   while 1:
     inputs = []
     for k, shp, itp in zip(keys, ishapes, itypes):

--- a/selfdrive/modeld/runners/onnx_runner.py
+++ b/selfdrive/modeld/runners/onnx_runner.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import numpy as np
+from typing import Tuple, Dict, Union, Any
 
 os.environ["OMP_NUM_THREADS"] = "4"
 os.environ["OMP_WAIT_POLICY"] = "PASSIVE"
@@ -55,6 +56,8 @@ if __name__ == "__main__":
   print("Onnx available providers: ", ort.get_available_providers(), file=sys.stderr)
   options = ort.SessionOptions()
   options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+
+  provider: Union[str, Tuple[str, Dict[Any, Any]]]
   if 'OpenVINOExecutionProvider' in ort.get_available_providers() and 'ONNXCPU' not in os.environ:
     provider = 'OpenVINOExecutionProvider'
   elif 'CUDAExecutionProvider' in ort.get_available_providers() and 'ONNXCPU' not in os.environ:

--- a/selfdrive/modeld/runners/onnx_runner.py
+++ b/selfdrive/modeld/runners/onnx_runner.py
@@ -37,7 +37,6 @@ def run_loop(m, tf8_input=False):
   if "CUDAExecutionProvider" in m.get_providers():
     m.run(None, dict(zip(keys, [np.zeros(shp, dtype=itp) for shp, itp in zip(ishapes, itypes)])))
 
-  print("ready to run onnx model", keys, ishapes, file=sys.stderr)
   while 1:
     inputs = []
     for k, shp, itp in zip(keys, ishapes, itypes):

--- a/selfdrive/modeld/runners/onnx_runner.py
+++ b/selfdrive/modeld/runners/onnx_runner.py
@@ -32,7 +32,7 @@ def run_loop(m, tf8_input=False):
   ishapes = [[1]+ii.shape[1:] for ii in m.get_inputs()]
   keys = [x.name for x in m.get_inputs()]
   itypes = [ORT_TYPES_TO_NP_TYPES[x.type] for x in m.get_inputs()]
-
+  print("onnx model inputs", keys, ishapes, itypes)
   # run once to initialize CUDA provider
   if "CUDAExecutionProvider" in m.get_providers():
     m.run(None, dict(zip(keys, [np.zeros(shp, dtype=itp) for shp, itp in zip(ishapes, itypes)])))
@@ -59,10 +59,9 @@ if __name__ == "__main__":
     provider = 'OpenVINOExecutionProvider'
   elif 'CUDAExecutionProvider' in ort.get_available_providers() and 'ONNXCPU' not in os.environ:
     options.intra_op_num_threads = 2
-    provider = 'CUDAExecutionProvider'
+    provider = ('CUDAExecutionProvider', {'cudnn_conv_algo_search': 'DEFAULT'})
   else:
     options.intra_op_num_threads = 2
-    options.inter_op_num_threads = 8
     options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
     options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
     provider = 'CPUExecutionProvider'


### PR DESCRIPTION
Force execution determinism on CUDAExecutionProvider. Remove `inter_op_num_threads` setting, since it does not make sense in ORT_SEQUENTIAL mode