### PR TITLE
IsoTpParallelQuery: log empty responses

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -115,7 +115,7 @@ class IsoTpParallelQuery:
           addrs_responded.add(tx_addr)
           response_timeouts[tx_addr] = time.monotonic() + timeout
 
-        if not dat:
+        if dat is not None:
           continue
 
         counter = request_counter[tx_addr]

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -120,7 +120,7 @@ class IsoTpParallelQuery:
 
         # Log unexpected empty responses
         if len(dat) == 0:
-          cloudlog.error(f"iso-tp query bad response: {tx_addr} - 0x{dat.hex()}")
+          cloudlog.error(f"iso-tp query empty response: {tx_addr}")
           continue
 
         counter = request_counter[tx_addr]

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -115,7 +115,12 @@ class IsoTpParallelQuery:
           addrs_responded.add(tx_addr)
           response_timeouts[tx_addr] = time.monotonic() + timeout
 
-        if dat is not None:
+        if dat is None:
+          continue
+
+        # Log unexpected empty responses
+        if len(dat) == 0:
+          cloudlog.error(f"iso-tp query bad response: {tx_addr} - 0x{dat.hex()}")
           continue
 
         counter = request_counter[tx_addr]

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -121,6 +121,7 @@ class IsoTpParallelQuery:
         # Log unexpected empty responses
         if len(dat) == 0:
           cloudlog.error(f"iso-tp query empty response: {tx_addr}")
+          request_done[tx_addr] = True
           continue
 
         counter = request_counter[tx_addr]


### PR DESCRIPTION
Added in https://github.com/commaai/one/pull/512/commits/255def1ea1750c6cf721a6fb6e2b1508318573e4, don't think it was intentional. If a query returns zero bytes, we should log it for investigation