### PR TITLE
athena: stricter socket timeout when onroad

### DIFF
--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -771,7 +771,7 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
       onroad = onroad_prev
 
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 30000 if onroad else 60000)  # ms
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 25000 if onroad else 55000)  # ms
 
 
 def backoff(retries: int) -> int:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -770,7 +770,7 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
     if onroad != onroad_prev:
       onroad_prev = onroad
 
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 16000 if onroad else 55000)
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 16000 if onroad else 0)
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -770,8 +770,8 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
     if onroad != onroad_prev:
       onroad_prev = onroad
 
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 20000 if onroad else 55000)
-      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 10 if onroad else 30)
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 16000 if onroad else 55000)
+      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
 

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -787,8 +787,8 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
     print(f"TCP_KEEPCNT: {sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT)}")
     print(f"TCP_USER_TIMEOUT: {sock.getsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT)}")
 
-    for level, optname, value in WS_SOCKET_OPTS:
-      sock.setsockopt(level, optname, value)
+    # for level, optname, value in WS_SOCKET_OPTS:
+    #   sock.setsockopt(level, optname, value)
 
 
 def backoff(retries: int) -> int:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -771,6 +771,7 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
       onroad_prev = onroad
 
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
+      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
       sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 30000 if onroad else 55000)  # ms
 
 

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -765,7 +765,7 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
   onroad_prev = None
   sock = ws.sock
 
-  while not end_event.wait(5):
+  while True:
     onroad = params.get_bool("IsOnroad")
     if onroad != onroad_prev:
       onroad_prev = onroad
@@ -773,6 +773,9 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
       sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 20000 if onroad else 55000)  # ms
+
+    if end_event.wait(5):
+      break
 
 
 def backoff(retries: int) -> int:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -143,10 +143,9 @@ class UploadQueueCache:
 
 def handle_long_poll(ws: WebSocket, exit_event: Optional[threading.Event]) -> None:
   end_event = threading.Event()
-  ready_event = threading.Event()
 
   threads = [
-    threading.Thread(target=ws_manage, args=(ws, end_event, ready_event), name='ws_manage'),
+    threading.Thread(target=ws_manage, args=(ws, end_event), name='ws_manage'),
     threading.Thread(target=ws_recv, args=(ws, end_event), name='ws_recv'),
     threading.Thread(target=ws_send, args=(ws, end_event), name='ws_send'),
     threading.Thread(target=upload_handler, args=(end_event,), name='upload_handler'),
@@ -156,9 +155,6 @@ def handle_long_poll(ws: WebSocket, exit_event: Optional[threading.Event]) -> No
     threading.Thread(target=jsonrpc_handler, args=(end_event,), name=f'worker_{x}')
     for x in range(HANDLER_THREADS)
   ]
-
-  if not ready_event.wait(5):
-    cloudlog.warning("athena.ws_manage.timeout")
 
   for thread in threads:
     thread.start()
@@ -764,7 +760,7 @@ def ws_send(ws: WebSocket, end_event: threading.Event) -> None:
       end_event.set()
 
 
-def ws_manage(ws: WebSocket, end_event: threading.Event, ready_event: threading.Event) -> None:
+def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
   params = Params()
   onroad_prev = None
   sock = ws.sock
@@ -774,10 +770,9 @@ def ws_manage(ws: WebSocket, end_event: threading.Event, ready_event: threading.
     if onroad != onroad_prev:
       onroad_prev = onroad
 
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 20000 if onroad else 55000)  # ms
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 20000 if onroad else 55000)  # ms
-      ready_event.set()
 
     if end_event.wait(5):
       break

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -159,8 +159,7 @@ def handle_long_poll(ws: WebSocket, exit_event: Optional[threading.Event]) -> No
   for thread in threads:
     thread.start()
   try:
-    while not end_event.is_set():
-      time.sleep(0.1)
+    while not end_event.wait(0.1):
       if exit_event is not None and exit_event.is_set():
         end_event.set()
   except (KeyboardInterrupt, SystemExit):

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -772,7 +772,7 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
 
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 30000 if onroad else 55000)  # ms
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 20000 if onroad else 55000)  # ms
 
 
 def backoff(retries: int) -> int:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -762,7 +762,7 @@ def ws_send(ws: WebSocket, end_event: threading.Event) -> None:
 
 def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
   params = Params()
-  onroad_prev = False
+  onroad_prev = None
   sock = ws.sock
 
   while not end_event.wait(5):

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -770,8 +770,9 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
     if onroad != onroad_prev:
       onroad_prev = onroad
 
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 20000 if onroad else 55000)  # ms
-      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 20000 if onroad else 55000)
+      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 10 if onroad else 30)
+      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
 
     if end_event.wait(5):

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -771,7 +771,7 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
       onroad_prev = onroad
 
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
-      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 25000 if onroad else 55000)  # ms
+      sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 30000 if onroad else 55000)  # ms
 
 
 def backoff(retries: int) -> int:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -43,7 +43,7 @@ from system.swaglog import SWAGLOG_DIR, cloudlog
 from system.version import get_commit, get_origin, get_short_branch, get_version
 
 
-# missing in pysocket
+# mypy does not see socket.TCP_USER_TIMEOUT
 TCP_USER_TIMEOUT = 18
 
 ATHENA_HOST = os.getenv('ATHENA_HOST', 'wss://athena.comma.ai')

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -768,7 +768,7 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
   while not end_event.wait(5):
     onroad = params.get_bool("IsOnroad")
     if onroad != onroad_prev:
-      onroad = onroad_prev
+      onroad_prev = onroad
 
       sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5 if onroad else 30)      # s
       sock.setsockopt(socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 25000 if onroad else 55000)  # ms

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -107,7 +107,7 @@ class TestAthenadPing(unittest.TestCase):
   @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     self._set_onroad(True)
-    self.assertTimeout(30)  # expect approx 25s
+    self.assertTimeout(100)  # expect approx 25s
 
 
 if __name__ == "__main__":

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -27,7 +27,6 @@ class TestAthenadPing(unittest.TestCase):
   exit_event: threading.Event
 
   _create_connection: Callable
-  mock_create_connection: MagicMock
 
   def _get_ping_time(self) -> Optional[str]:
     return cast(Optional[str], self.params.get("LastAthenaPingTime", encoding="utf-8"))
@@ -46,8 +45,7 @@ class TestAthenadPing(unittest.TestCase):
     cls.params = Params()
     cls.dongle_id = cls.params.get("DongleId", encoding="utf-8")
     cls._create_connection = athenad.create_connection
-    cls.mock_create_connection = MagicMock(wraps=cls._create_connection)
-    athenad.create_connection = cls.mock_create_connection
+    athenad.create_connection = MagicMock(wraps=cls._create_connection)
 
   @classmethod
   def tearDownClass(cls) -> None:
@@ -61,7 +59,7 @@ class TestAthenadPing(unittest.TestCase):
     self.exit_event = threading.Event()
     self.athenad = threading.Thread(target=athenad.main, args=(self.exit_event,))
 
-    self.mock_create_connection.reset_mock()
+    athenad.create_connection.reset_mock()
 
   def tearDown(self) -> None:
     if self.athenad.is_alive():

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -107,7 +107,7 @@ class TestAthenadPing(unittest.TestCase):
   @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     self._set_onroad(True)
-    self.assertTimeout(40)  # expect approx 35s
+    self.assertTimeout(30)  # expect approx 25s
 
 
 if __name__ == "__main__":

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -107,7 +107,7 @@ class TestAthenadPing(unittest.TestCase):
   @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     self._set_onroad(True)
-    self.assertTimeout(40)  # expect 25-35s
+    self.assertTimeout(30)  # expect 20-30s
 
 
 if __name__ == "__main__":

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -3,8 +3,10 @@ import subprocess
 import threading
 import time
 import unittest
-from typing import Callable, cast, Optional
+from typing import Callable, cast, List, Optional, Tuple
 from unittest.mock import MagicMock
+
+from websocket import WebSocket
 
 from common.params import Params
 from common.timeout import Timeout
@@ -17,6 +19,14 @@ def wifi_radio(on: bool) -> None:
     return
   print(f"wifi {'on' if on else 'off'}")
   subprocess.run(["nmcli", "radio", "wifi", "on" if on else "off"], check=True)
+
+
+def mock_ws_manage(sockopts: List[Tuple[int, int, int]]):
+  def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
+    for level, optname, value in sockopts:
+      ws.sock.setsockopt(level, optname, value)
+    end_event.wait()
+  return ws_manage
 
 
 class TestAthenadPing(unittest.TestCase):

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -107,7 +107,7 @@ class TestAthenadPing(unittest.TestCase):
   @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     self._set_onroad(True)
-    self.assertTimeout(100)  # expect approx 25s
+    self.assertTimeout(30)  # expect approx 25s
 
 
 if __name__ == "__main__":

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -104,12 +104,12 @@ class TestAthenadPing(unittest.TestCase):
   @unittest.skipIf(not TICI, "only run on desk")
   def test_offroad(self) -> None:
     self._set_onroad(False)
-    self.assertTimeout(180)
+    self.assertTimeout(100)  # expect approx 90s
 
   @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     self._set_onroad(True)
-    self.assertTimeout(120)
+    self.assertTimeout(45)  # expect approx 35s
 
 
 if __name__ == "__main__":

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -103,7 +103,7 @@ class TestAthenadPing(unittest.TestCase):
 
   @unittest.skipIf(not TICI, "only run on desk")
   def test_offroad(self) -> None:
-    self._set_onroad(True)
+    self._set_onroad(False)
     self.assertTimeout(180)
 
   @unittest.skipIf(not TICI, "only run on desk")

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -119,29 +119,30 @@ class TestAthenadPing(unittest.TestCase):
       print("ping received")
 
   @unittest.skipIf(not TICI, "only run on desk")
-  def test_timeout(self) -> None:
-    with self.subTest("default sockopts"):
-      self.assertTimeout(120)
+  def test_default_sockopts(self) -> None:
+    self.assertTimeout(120)
 
-    with self.subTest("set sockopts"):
-      self.mock_ws_manage.side_effect = custom_ws_manage([
-        # (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-        # (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30),
-        # (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
-        # (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
-        (socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 60000),
-      ])
-      self.assertTimeout(120)
+  @unittest.skipIf(not TICI, "only run on desk")
+  def test_correct_sockopts(self) -> None:
+    self.mock_ws_manage.side_effect = custom_ws_manage([
+      # (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+      # (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30),
+      # (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
+      # (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
+      (socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 60000),
+    ])
+    self.assertTimeout(120)
 
-    with self.subTest("strict sockopts"):
-      self.mock_ws_manage.side_effect = custom_ws_manage([
-        # (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-        (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5),
-        # (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
-        # (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
-        (socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 35000),
-      ])
-      self.assertTimeout(120)
+  @unittest.skipIf(not TICI, "only run on desk")
+  def test_new_sockopts(self) -> None:
+    self.mock_ws_manage.side_effect = custom_ws_manage([
+      # (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+      (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 5),
+      # (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
+      # (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
+      (socket.IPPROTO_TCP, TCP_USER_TIMEOUT, 35000),
+    ])
+    self.assertTimeout(120)
 
 
 if __name__ == "__main__":

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -107,7 +107,7 @@ class TestAthenadPing(unittest.TestCase):
   @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     self._set_onroad(True)
-    self.assertTimeout(30)  # expect approx 25s
+    self.assertTimeout(40)  # expect 25-35s
 
 
 if __name__ == "__main__":

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -74,11 +74,11 @@ class TestAthenadPing(unittest.TestCase):
     wifi_radio(True)
     self._clear_ping_time()
 
-    self.exit_event = threading.Event()
-    self.athenad = threading.Thread(target=athenad.main, args=(self.exit_event,))
-
     self.mock_create_connection.reset_mock()
     self.mock_ws_manage.reset_mock()
+
+    self.exit_event = threading.Event()
+    self.athenad = threading.Thread(target=athenad.main, args=(self.exit_event,))
 
   def tearDown(self) -> None:
     if self.athenad.is_alive():

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -107,7 +107,7 @@ class TestAthenadPing(unittest.TestCase):
   @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     self._set_onroad(True)
-    self.assertTimeout(45)  # expect approx 35s
+    self.assertTimeout(40)  # expect approx 35s
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
continuation of #26141, with tests #28864

When onroad, the time to socket timeout after a network change is reduced to ~25s. The config used for offroad is the same as the current defaults.