### PR TITLE
ui/networking: call isTetheringEnabled out of the loop

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -286,6 +286,7 @@ void WifiUI::refresh() {
   scanningLabel->setVisible(is_empty);
   if (is_empty) return;
 
+  const bool is_tethering_enabled = wifi->isTetheringEnabled();
   QList<Network> sortedNetworks = wifi->seenNetworks.values();
   std::sort(sortedNetworks.begin(), sortedNetworks.end(), compare_by_strength);
 
@@ -313,7 +314,7 @@ void WifiUI::refresh() {
     }
 
     // Forget button
-    if (wifi->isKnownConnection(network.ssid) && !wifi->isTetheringEnabled()) {
+    if (wifi->isKnownConnection(network.ssid) && !is_tethering_enabled) {
       QPushButton *forgetBtn = new QPushButton(tr("FORGET"));
       forgetBtn->setObjectName("forgetBtn");
       QObject::connect(forgetBtn, &QPushButton::clicked, [=]() {


### PR DESCRIPTION
isTetheringEnabled will initiate a dbus call. there is no need to call it in loop.