### PR TITLE
encoder/VideoWriter: remove unnecessary call to `avcodec_close`

### DIFF
--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -1,6 +1,5 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <cassert>
-#include <cstdlib>
 
 #include "system/loggerd/video_writer.h"
 #include "common/swaglog.h"
@@ -8,7 +7,6 @@
 
 VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec)
   : remuxing(remuxing) {
-  raw = codec == cereal::EncodeIndex::Type::BIG_BOX_LOSSLESS;
   vid_path = util::string_format("%s/%s", path, filename);
   lock_path = util::string_format("%s/%s.lock", path, filename);
 
@@ -18,6 +16,7 @@ VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, 
 
   LOGD("encoder_open %s remuxing:%d", this->vid_path.c_str(), this->remuxing);
   if (this->remuxing) {
+    bool raw = (codec == cereal::EncodeIndex::Type::BIG_BOX_LOSSLESS);
     avformat_alloc_output_context2(&this->ofmt_ctx, NULL, raw ? "matroska" : NULL, this->vid_path.c_str());
     assert(this->ofmt_ctx);
 
@@ -98,7 +97,6 @@ void VideoWriter::write(uint8_t *data, int len, long long timestamp, bool codecc
 
 VideoWriter::~VideoWriter() {
   if (this->remuxing) {
-    if (this->raw) { avcodec_close(this->codec_ctx); }
     int err = av_write_trailer(this->ofmt_ctx);
     if (err != 0) LOGE("av_write_trailer failed %d", err);
     avcodec_free_context(&this->codec_ctx);

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -16,11 +16,10 @@ public:
   ~VideoWriter();
 private:
   std::string vid_path, lock_path;
-
   FILE *of = nullptr;
 
   AVCodecContext *codec_ctx;
   AVFormatContext *ofmt_ctx;
   AVStream *out_stream;
-  bool remuxing, raw;
+  bool remuxing;
 };


### PR DESCRIPTION
there is no need to call `avcodec_close` before `avcodec_free_context`.`avcodec_free_context` will call `avcodec_close` internally to close the opened codec (if any).

https://ffmpeg.org/doxygen/trunk/libavcodec_2options_8c_source.html#l00175
https://ffmpeg.org/doxygen/trunk/avcodec_8c_source.html#l00425