### PR TITLE
cabana: cleanup `MessageViewHeader` & `MessageBytesDelegate`

### DIFF
--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -28,7 +28,7 @@ MessagesWidget::MessagesWidget(QWidget *parent) : QWidget(parent) {
   // message table
   view = new MessageView(this);
   model = new MessageListModel(this);
-  header = new MessageViewHeader(this, model);
+  header = new MessageViewHeader(this);
   auto delegate = new MessageBytesDelegate(view, settings.multiple_lines_bytes);
 
   view->setItemDelegate(delegate);
@@ -446,7 +446,7 @@ void MessageView::headerContextMenuEvent(const QPoint &pos) {
   menu->popup(header()->mapToGlobal(pos));
 }
 
-MessageViewHeader::MessageViewHeader(QWidget *parent, MessageListModel *model) : model(model), QHeaderView(Qt::Horizontal, parent) {
+MessageViewHeader::MessageViewHeader(QWidget *parent) : QHeaderView(Qt::Horizontal, parent) {
   QObject::connect(this, &QHeaderView::sectionResized, this, &MessageViewHeader::updateHeaderPositions);
   QObject::connect(this, &QHeaderView::sectionMoved, this, &MessageViewHeader::updateHeaderPositions);
 }
@@ -485,7 +485,7 @@ void MessageViewHeader::updateHeaderPositions() {
 void MessageViewHeader::updateGeometries() {
   for (int i = 0; i < count(); i++) {
     if (!editors[i]) {
-      QString column_name = model->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
+      QString column_name = model()->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
       editors[i] = new QLineEdit(this);
       editors[i]->setClearButtonEnabled(true);
       editors[i]->setPlaceholderText(tr("Filter %1").arg(column_name));

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -69,7 +69,7 @@ class MessageViewHeader : public QHeaderView {
 
   Q_OBJECT
 public:
-  MessageViewHeader(QWidget *parent, MessageListModel *model);
+  MessageViewHeader(QWidget *parent);
   void updateHeaderPositions();
 
   void updateGeometries() override;
@@ -85,8 +85,6 @@ private:
   void updateFilters();
 
   QMap<int, QLineEdit *> editors;
-  QMap<int, QSet<QString>> values;
-  MessageListModel *model;
 };
 
 class MessagesWidget : public QWidget {

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -275,7 +275,7 @@ QSize SignalItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QMo
   int width = option.widget->size().width() / 2;
   if (index.column() == 0) {
     int spacing = option.widget->style()->pixelMetric(QStyle::PM_TreeViewIndentation) + color_label_width + 8;
-    auto text = index.data(Qt::DisplayRole).toString();;
+    auto text = index.data(Qt::DisplayRole).toString();
     auto item = (SignalModel::Item *)index.internalPointer();
     if (item->type == SignalModel::Item::Sig && item->sig->type != cabana::Signal::Type::Normal) {
       text += item->sig->type == cabana::Signal::Type::Multiplexor ? QString(" M ") : QString(" m%1 ").arg(item->sig->multiplex_value);

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -54,12 +54,6 @@ MessageBytesDelegate::MessageBytesDelegate(QObject *parent, bool multiple_lines)
   byte_size = QFontMetrics(fixed_font).size(Qt::TextSingleLine, "00 ") + QSize(0, 2);
 }
 
-void MessageBytesDelegate::setMultipleLines(bool v) {
-  if (std::exchange(multiple_lines, v) != multiple_lines) {
-    std::fill_n(size_cache, std::size(size_cache), QSize{});
-  }
-}
-
 int MessageBytesDelegate::widthForBytes(int n) const {
   int h_margin = QApplication::style()->pixelMetric(QStyle::PM_FocusFrameHMargin) + 1;
   return n * byte_size.width() + h_margin * 2;
@@ -73,19 +67,8 @@ QSize MessageBytesDelegate::sizeHint(const QStyleOptionViewItem &option, const Q
   }
   int n = data.toByteArray().size();
   assert(n >= 0 && n <= 64);
-
-  QSize size = size_cache[n];
-  if (size.isEmpty()) {
-    if (!multiple_lines) {
-      size.setWidth(widthForBytes(n));
-      size.setHeight(byte_size.height() + 2 * v_margin);
-    } else {
-      size.setWidth(widthForBytes(8));
-      size.setHeight(byte_size.height() * std::max(1, n / 8) + 2 * v_margin);
-    }
-    size_cache[n] = size;
-  }
-  return size;
+  return !multiple_lines ? QSize{widthForBytes(n), byte_size.height() + 2 * v_margin}
+                         : QSize{widthForBytes(8), byte_size.height() * std::max(1, n / 8) + 2 * v_margin};
 }
 
 void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -221,7 +221,7 @@ void setTheme(int theme) {
       new_palette.setColor(QPalette::BrightText, QColor("#f0f0f0"));
       new_palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor("#777777"));
       new_palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor("#777777"));
-      new_palette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));;
+      new_palette.setColor(QPalette::Disabled, QPalette::Text, QColor("#777777"));
       new_palette.setColor(QPalette::Light, QColor("#777777"));
       new_palette.setColor(QPalette::Dark, QColor("#353535"));
     } else {

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -67,15 +67,14 @@ public:
   MessageBytesDelegate(QObject *parent, bool multiple_lines = false);
   void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
   QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-  void setMultipleLines(bool v);
-  int widthForBytes(int n) const;
   bool multipleLines() const { return multiple_lines; }
+  void setMultipleLines(bool v) { multiple_lines = v; }
+  int widthForBytes(int n) const;
 
 private:
   QFont fixed_font;
   QSize byte_size = {};
   bool multiple_lines = false;
-  mutable QSize size_cache[65] = {};
 };
 
 inline QString toHex(const QByteArray &dat) { return dat.toHex(' ').toUpper(); }


### PR DESCRIPTION
MessageViewHeader: :
1. remove unused variable `values`
2. remove unnecessary variable `model`

MessageBytesDelegate:
remove unnecessary `size_cache`.  the sizeHint is fast enough without caching.