### PR TITLE
nav: set icon anchor for destination pin

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -131,7 +131,7 @@ void MapWindow::initLayers() {
     m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
     m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
     m_map->setLayoutProperty("pinLayer", "symbol-sort-key", 0);
-    m_map->setLayoutProperty("pinLayer", "icon-anchor", "top");
+    m_map->setLayoutProperty("pinLayer", "icon-anchor", "bottom");
   }
   if (!m_map->layerExists("carPosLayer")) {
     qDebug() << "Initializing carPosLayer";

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -130,7 +130,7 @@ void MapWindow::initLayers() {
     m_map->setLayoutProperty("pinLayer", "icon-image", "default_marker");
     m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
     m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
-    m_map->setLayoutProperty("pinLayer", "symbol-sort-key", 0);
+    m_map->setLayoutProperty("pinLayer", "icon-anchor", "top");
   }
   if (!m_map->layerExists("carPosLayer")) {
     qDebug() << "Initializing carPosLayer";

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -130,6 +130,7 @@ void MapWindow::initLayers() {
     m_map->setLayoutProperty("pinLayer", "icon-image", "default_marker");
     m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
     m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
+    m_map->setLayoutProperty("pinLayer", "symbol-sort-key", 0);
     m_map->setLayoutProperty("pinLayer", "icon-anchor", "top");
   }
   if (!m_map->layerExists("carPosLayer")) {


### PR DESCRIPTION
Now that we're using a symbol layer for the pin icon (https://github.com/commaai/openpilot/pull/29050), we can set an anchoring mode: [Mapbox GL JS Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-symbol-icon-anchor).

Also fixes a slight stretching problem if you offset the pin up in an image.

| Master | PR [#29049](https://github.com/commaai/openpilot/pull/29049) | This PR |
| :---: | :---: | :---: |
| ![image](https://github.com/commaai/openpilot/assets/25857203/d8e1315a-0fbe-466c-8bbb-e8f62bcfa532) | ![image](https://github.com/commaai/openpilot/assets/25857203/9c1b2eb9-d2e8-4c3a-ad35-7da7b9ebeac2) | ![image](https://github.com/commaai/openpilot/assets/25857203/15886885-db2d-4fb2-8c32-391a61845bf1) |