### PR TITLE
ui: set global map transition duration

### DIFF
--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -66,6 +66,7 @@ class RouteEngine:
     self.sm.update(0)
 
     if self.sm.updated["managerState"]:
+      self.send_route()
       ui_pid = [p.pid for p in self.sm["managerState"].processes if p.name == "ui" and p.running]
       if ui_pid:
         if self.ui_pid and self.ui_pid != ui_pid[0]:
@@ -115,7 +116,7 @@ class RouteEngine:
 
     if self.recompute_countdown == 0 and should_recompute:
       self.recompute_countdown = 2**self.recompute_backoff
-      self.recompute_backoff = min(6, self.recompute_backoff + 1)
+      self.recompute_backoff = 0  # min(6, self.recompute_backoff + 1)
       self.calculate_route(new_destination)
       self.reroute_counter = 0
     else:

--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -66,7 +66,6 @@ class RouteEngine:
     self.sm.update(0)
 
     if self.sm.updated["managerState"]:
-      self.send_route()
       ui_pid = [p.pid for p in self.sm["managerState"].processes if p.name == "ui" and p.running]
       if ui_pid:
         if self.ui_pid and self.ui_pid != ui_pid[0]:
@@ -116,7 +115,7 @@ class RouteEngine:
 
     if self.recompute_countdown == 0 and should_recompute:
       self.recompute_countdown = 2**self.recompute_backoff
-      self.recompute_backoff = 0  # min(6, self.recompute_backoff + 1)
+      self.recompute_backoff = min(6, self.recompute_backoff + 1)
       self.calculate_route(new_destination)
       self.reroute_counter = 0
     else:

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -126,44 +126,11 @@ void MapWindow::initLayers() {
     QVariantMap transition;
     transition["duration"] = 0;  // ms
     m_map->setPaintProperty("pinLayer", "icon-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "icon-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "text-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "text-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "raster-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "raster-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "background-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "background-opacity-transition", transition);
-
-    m_map->setLayoutProperty("pinLayer", "fill-opacity-transition", transition);
-
-    m_map->setLayoutProperty("pinLayer", "line-opacity-transition", transition);
-
-    m_map->setLayoutProperty("pinLayer", "icon-opacity-transition", transition);
-
-    m_map->setLayoutProperty("pinLayer", "text-opacity-transition", transition);
-
-    m_map->setLayoutProperty("pinLayer", "raster-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "circle-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "circle-stroke-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "fill-extrusion-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "heatmap-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "sky-opacity-transition", transition);
-
-    m_map->setPaintProperty("pinLayer", "raster-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "circle-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "circle-stroke-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "fill-extrusion-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "heatmap-opacity-transition", transition);
-    m_map->setPaintProperty("pinLayer", "sky-opacity-transition", transition);
-
-    m_map->setPaintProperty("pinLayer", "raster-fade-duration", 0);
-    m_map->setLayoutProperty("pinLayer", "raster-fade-duration", 0);
-//    m_map->setLayoutProperty("pinLayer", "icon-pitch-alignment", "viewport");
     m_map->setLayoutProperty("pinLayer", "icon-image", "default_marker");
-//    m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
-//    m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
-//    m_map->setLayoutProperty("pinLayer", "symbol-sort-key", 0);
-//    m_map->setLayoutProperty("pinLayer", "icon-anchor", "bottom");
+    m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
+    m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
+    m_map->setLayoutProperty("pinLayer", "symbol-sort-key", 0);
+    m_map->setLayoutProperty("pinLayer", "icon-anchor", "bottom");
   }
   if (!m_map->layerExists("carPosLayer")) {
     qDebug() << "Initializing carPosLayer";

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -16,7 +16,7 @@ const float MANEUVER_TRANSITION_THRESHOLD = 10;
 
 const float MAX_ZOOM = 17;
 const float MIN_ZOOM = 14;
-const float MAX_PITCH = 50;
+//const float MAX_PITCH = 50;
 const float MIN_PITCH = 0;
 const float MAP_SCALE = 2;
 
@@ -126,12 +126,44 @@ void MapWindow::initLayers() {
     QVariantMap transition;
     transition["duration"] = 0;  // ms
     m_map->setPaintProperty("pinLayer", "icon-opacity-transition", transition);
-    m_map->setLayoutProperty("pinLayer", "icon-pitch-alignment", "viewport");
+    m_map->setLayoutProperty("pinLayer", "icon-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "text-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "text-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "raster-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "raster-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "background-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "background-opacity-transition", transition);
+
+    m_map->setLayoutProperty("pinLayer", "fill-opacity-transition", transition);
+
+    m_map->setLayoutProperty("pinLayer", "line-opacity-transition", transition);
+
+    m_map->setLayoutProperty("pinLayer", "icon-opacity-transition", transition);
+
+    m_map->setLayoutProperty("pinLayer", "text-opacity-transition", transition);
+
+    m_map->setLayoutProperty("pinLayer", "raster-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "circle-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "circle-stroke-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "fill-extrusion-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "heatmap-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "sky-opacity-transition", transition);
+
+    m_map->setPaintProperty("pinLayer", "raster-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "circle-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "circle-stroke-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "fill-extrusion-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "heatmap-opacity-transition", transition);
+    m_map->setPaintProperty("pinLayer", "sky-opacity-transition", transition);
+
+    m_map->setPaintProperty("pinLayer", "raster-fade-duration", 0);
+    m_map->setLayoutProperty("pinLayer", "raster-fade-duration", 0);
+//    m_map->setLayoutProperty("pinLayer", "icon-pitch-alignment", "viewport");
     m_map->setLayoutProperty("pinLayer", "icon-image", "default_marker");
-    m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
-    m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
-    m_map->setLayoutProperty("pinLayer", "symbol-sort-key", 0);
-    m_map->setLayoutProperty("pinLayer", "icon-anchor", "bottom");
+//    m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
+//    m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
+//    m_map->setLayoutProperty("pinLayer", "symbol-sort-key", 0);
+//    m_map->setLayoutProperty("pinLayer", "icon-anchor", "bottom");
   }
   if (!m_map->layerExists("carPosLayer")) {
     qDebug() << "Initializing carPosLayer";
@@ -254,7 +286,7 @@ void MapWindow::updateState(const UIState &s) {
       map_eta->updateETA(i.getTimeRemaining(), i.getTimeRemainingTypical(), i.getDistanceRemaining());
 
       if (locationd_valid) {
-        m_map->setPitch(MAX_PITCH); // TODO: smooth pitching based on maneuver distance
+//        m_map->setPitch(MAX_PITCH); // TODO: smooth pitching based on maneuver distance
         map_instructions->updateInstructions(i);
       }
     } else {
@@ -265,6 +297,21 @@ void MapWindow::updateState(const UIState &s) {
       settings_btn->setIcon(map_eta->isVisible() ? settings_icon : directions_icon);
     }
   }
+
+//  auto nav_dest = coordinate_from_param("NavDestination");
+//  if (nav_dest.has_value()) {
+//    auto point = coordinate_to_collection(*nav_dest);
+//    QMapbox::Feature feature(QMapbox::Feature::PointType, point, {}, {});
+//    QVariantMap pinSource;
+//    pinSource["type"] = "geojson";
+//    pinSource["data"] = QVariant::fromValue<QMapbox::Feature>(feature);
+//    m_map->updateSource("pinSource", pinSource);
+//    m_map->setPaintProperty("pinLayer", "visibility", "visible");
+////    m_map->setPaintProperty("pinLayer", "icon-opacity", 1);
+//    qDebug() << "setting vis: true";
+//  } else {
+//    m_map->setPaintProperty("pinLayer", "visibility", "none");
+//  }
 
   if (sm.rcv_frame("navRoute") != route_rcv_frame) {
     qWarning() << "Updating navLayer with new route";
@@ -304,12 +351,21 @@ void MapWindow::initializeGL() {
     m_map->setCoordinateZoom(QMapbox::Coordinate(64.31990695292795, -149.79038934046247), MIN_ZOOM);
   }
 
+  qDebug() << fixed << qSetRealNumberPrecision(20);
   m_map->setMargins({0, 350, 0, 50});
   m_map->setPitch(MIN_PITCH);
   m_map->setStyleUrl("mapbox://styles/commaai/clj7g5vrp007b01qzb5ro0i4j");
+//  m_map->setTransitionOptions(0, 0);
 
   QObject::connect(m_map.data(), &QMapboxGL::mapChanged, [=](QMapboxGL::MapChange change) {
+    if (change == QMapboxGL::MapChange::MapChangeDidFinishLoadingStyle) {
+      double ts = millis_since_boot();
+      qDebug() << fixed << qSetRealNumberPrecision(20) << "WARNINGWARNING: style finished loading" << ts;
+      m_map->setTransitionOptions(0, 0);
+    }
     if (change == QMapboxGL::MapChange::MapChangeDidFinishLoadingMap) {
+      double ts = millis_since_boot();
+      qDebug() << fixed << qSetRealNumberPrecision(20) << "WARNINGWARNING: MAP finished loading" << ts;
       loaded_once = true;
     }
   });
@@ -415,7 +471,8 @@ void MapWindow::offroadTransition(bool offroad) {
 }
 
 void MapWindow::updateDestinationMarker() {
-  m_map->setPaintProperty("pinLayer", "icon-opacity", 0);
+//  m_map->setPaintProperty("pinLayer", "icon-opacity", 0);
+//  m_map->setPaintProperty("pinLayer", "visibility", "none");
 
   auto nav_dest = coordinate_from_param("NavDestination");
   if (nav_dest.has_value()) {
@@ -425,7 +482,11 @@ void MapWindow::updateDestinationMarker() {
     pinSource["type"] = "geojson";
     pinSource["data"] = QVariant::fromValue<QMapbox::Feature>(feature);
     m_map->updateSource("pinSource", pinSource);
-    m_map->setPaintProperty("pinLayer", "icon-opacity", 1);
+    m_map->setPaintProperty("pinLayer", "visibility", "visible");
+//    m_map->setPaintProperty("pinLayer", "icon-opacity", 1);
+    qDebug() << "setting vis: true";
+  } else {
+    m_map->setPaintProperty("pinLayer", "visibility", "none");
   }
 }
 

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -121,11 +121,6 @@ void MapWindow::initLayers() {
     pin["type"] = "symbol";
     pin["source"] = "pinSource";
     m_map->addLayer(pin);
-
-    // FIXME: solve, workaround to remove animation on visibility property
-    QVariantMap transition;
-    transition["duration"] = 0;  // ms
-    m_map->setPaintProperty("pinLayer", "icon-opacity-transition", transition);
     m_map->setLayoutProperty("pinLayer", "icon-pitch-alignment", "viewport");
     m_map->setLayoutProperty("pinLayer", "icon-image", "default_marker");
     m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -307,17 +307,12 @@ void MapWindow::initializeGL() {
   m_map->setMargins({0, 350, 0, 50});
   m_map->setPitch(MIN_PITCH);
   m_map->setStyleUrl("mapbox://styles/commaai/clj7g5vrp007b01qzb5ro0i4j");
-//  m_map->setTransitionOptions(0, 0);
 
   QObject::connect(m_map.data(), &QMapboxGL::mapChanged, [=](QMapboxGL::MapChange change) {
     if (change == QMapboxGL::MapChange::MapChangeDidFinishLoadingStyle) {
-      double ts = millis_since_boot();
-      qDebug() << fixed << qSetRealNumberPrecision(20) << "WARNINGWARNING: style finished loading" << ts;
       m_map->setTransitionOptions(0, 0);
     }
     if (change == QMapboxGL::MapChange::MapChangeDidFinishLoadingMap) {
-      double ts = millis_since_boot();
-      qDebug() << fixed << qSetRealNumberPrecision(20) << "WARNINGWARNING: MAP finished loading" << ts;
       loaded_once = true;
     }
   });
@@ -423,8 +418,7 @@ void MapWindow::offroadTransition(bool offroad) {
 }
 
 void MapWindow::updateDestinationMarker() {
-//  m_map->setPaintProperty("pinLayer", "icon-opacity", 0);
-//  m_map->setPaintProperty("pinLayer", "visibility", "none");
+  m_map->setPaintProperty("pinLayer", "visibility", "none");
 
   auto nav_dest = coordinate_from_param("NavDestination");
   if (nav_dest.has_value()) {
@@ -435,10 +429,6 @@ void MapWindow::updateDestinationMarker() {
     pinSource["data"] = QVariant::fromValue<QMapbox::Feature>(feature);
     m_map->updateSource("pinSource", pinSource);
     m_map->setPaintProperty("pinLayer", "visibility", "visible");
-//    m_map->setPaintProperty("pinLayer", "icon-opacity", 1);
-    qDebug() << "setting vis: true";
-  } else {
-    m_map->setPaintProperty("pinLayer", "visibility", "none");
   }
 }
 

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -126,6 +126,7 @@ void MapWindow::initLayers() {
     QVariantMap transition;
     transition["duration"] = 0;  // ms
     m_map->setPaintProperty("pinLayer", "icon-opacity-transition", transition);
+    m_map->setLayoutProperty("pinLayer", "icon-pitch-alignment", "viewport");
     m_map->setLayoutProperty("pinLayer", "icon-image", "default_marker");
     m_map->setLayoutProperty("pinLayer", "icon-ignore-placement", true);
     m_map->setLayoutProperty("pinLayer", "icon-allow-overlap", true);
@@ -265,21 +266,6 @@ void MapWindow::updateState(const UIState &s) {
     }
   }
 
-//  auto nav_dest = coordinate_from_param("NavDestination");
-//  if (nav_dest.has_value()) {
-//    auto point = coordinate_to_collection(*nav_dest);
-//    QMapbox::Feature feature(QMapbox::Feature::PointType, point, {}, {});
-//    QVariantMap pinSource;
-//    pinSource["type"] = "geojson";
-//    pinSource["data"] = QVariant::fromValue<QMapbox::Feature>(feature);
-//    m_map->updateSource("pinSource", pinSource);
-//    m_map->setPaintProperty("pinLayer", "visibility", "visible");
-////    m_map->setPaintProperty("pinLayer", "icon-opacity", 1);
-//    qDebug() << "setting vis: true";
-//  } else {
-//    m_map->setPaintProperty("pinLayer", "visibility", "none");
-//  }
-
   if (sm.rcv_frame("navRoute") != route_rcv_frame) {
     qWarning() << "Updating navLayer with new route";
     auto route = sm["navRoute"].getNavRoute();
@@ -318,7 +304,6 @@ void MapWindow::initializeGL() {
     m_map->setCoordinateZoom(QMapbox::Coordinate(64.31990695292795, -149.79038934046247), MIN_ZOOM);
   }
 
-  qDebug() << fixed << qSetRealNumberPrecision(20);
   m_map->setMargins({0, 350, 0, 50});
   m_map->setPitch(MIN_PITCH);
   m_map->setStyleUrl("mapbox://styles/commaai/clj7g5vrp007b01qzb5ro0i4j");

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -16,7 +16,7 @@ const float MANEUVER_TRANSITION_THRESHOLD = 10;
 
 const float MAX_ZOOM = 17;
 const float MIN_ZOOM = 14;
-//const float MAX_PITCH = 50;
+const float MAX_PITCH = 50;
 const float MIN_PITCH = 0;
 const float MAP_SCALE = 2;
 
@@ -249,7 +249,7 @@ void MapWindow::updateState(const UIState &s) {
       map_eta->updateETA(i.getTimeRemaining(), i.getTimeRemainingTypical(), i.getDistanceRemaining());
 
       if (locationd_valid) {
-//        m_map->setPitch(MAX_PITCH); // TODO: smooth pitching based on maneuver distance
+        m_map->setPitch(MAX_PITCH); // TODO: smooth pitching based on maneuver distance
         map_instructions->updateInstructions(i);
       }
     } else {
@@ -304,6 +304,7 @@ void MapWindow::initializeGL() {
   m_map->setStyleUrl("mapbox://styles/commaai/clj7g5vrp007b01qzb5ro0i4j");
 
   QObject::connect(m_map.data(), &QMapboxGL::mapChanged, [=](QMapboxGL::MapChange change) {
+    // set global animation duration to 0 ms so visibility changes are instant
     if (change == QMapboxGL::MapChange::MapChangeDidFinishLoadingStyle) {
       m_map->setTransitionOptions(0, 0);
     }


### PR DESCRIPTION
Allows us to use `visibility` property for symbol layers which fixes a bug where destination pin icon would appear at old position for a frame on showing new destination. Related: https://github.com/commaai/openpilot/pull/29050

Need to set the transition options *after* the style is created/parsed, as it resets the options to defaults on parse here:

https://github.com/mapbox/mapbox-gl-native/blob/f9b8ddb804246a1b40cb4056b50761b32f901434/src/mbgl/style/style_impl.cpp#L103

According to https://github.com/mapbox/mapbox-gl-js/pull/6702 and https://github.com/mapbox/mapbox-gl-js/issues/6519#issuecomment-390001993, this affects all symbol layers and there's no way to parameterize it for now (not that we need to yet), so this sets it to an instant fade when the style has loaded.

Style load can happen a couple hundred ms earlier than map load, so we should set as early as we can. And we can still override the global duration as-needed per layer for property transitions, like our path.

<sub>yes, none of the transition properties worked 😢</sub>