### PR TITLE
ui/map: fix ETA widget text spacing

### DIFF
--- a/selfdrive/ui/qt/maps/map_eta.cc
+++ b/selfdrive/ui/qt/maps/map_eta.cc
@@ -48,7 +48,7 @@ void MapETA::updateETA(float s, float s_typical, float d) {
                              uiState()->scene.is_metric ? tr("km") : tr("mi")};
 
   eta_doc.setHtml(QString(R"(<body><table><tr><td><b>%1</b></td><td>%2</td>
-                             <td style="padding-left:40px;color:%3;"><b>%4</b></td><td style="padding-right:40px;">%5</td>
+                             <td style="padding-left:40px;color:%3;"><b>%4</b></td><td style="padding-right:40px;color:%3;">%5</td>
                              <td><b>%6</b></td><td>%7</td></tr></body>)")
                       .arg(eta[0], eta[1], color, remaining[0], remaining[1], distance[0], distance[1]));
 

--- a/selfdrive/ui/qt/maps/map_eta.cc
+++ b/selfdrive/ui/qt/maps/map_eta.cc
@@ -11,7 +11,7 @@ MapETA::MapETA(QWidget *parent) : QWidget(parent) {
   setVisible(false);
   setAttribute(Qt::WA_TranslucentBackground);
   eta_doc.setUndoRedoEnabled(false);
-  eta_doc.setDefaultStyleSheet("body {font-family:Inter;font-size:60px;color:white;} b{font-size:70px;font-weight:600}");
+  eta_doc.setDefaultStyleSheet("body {font-family:Inter;font-size:70px;color:white;} b{font-weight:600;} td{padding:0 3px;}");
 }
 
 void MapETA::paintEvent(QPaintEvent *event) {
@@ -47,7 +47,9 @@ void MapETA::updateETA(float s, float s_typical, float d) {
   auto distance = std::array{QString::number(num, 'f', num < 100 ? 1 : 0),
                              uiState()->scene.is_metric ? tr("km") : tr("mi")};
 
-  eta_doc.setHtml(QString(R"(<body><b>%1</b>%2 <span style="color:%3"><b>%4</b>%5</span> <b>%6</b>%7</body>)")
+  eta_doc.setHtml(QString(R"(<body><table><tr><td><b>%1</b></td><td>%2</td>
+                             <td style="padding-left:40px;color:%3;"><b>%4</b></td><td style="padding-right:40px;">%5</td>
+                             <td><b>%6</b></td><td>%7</td></tr></body>)")
                       .arg(eta[0], eta[1], color, remaining[0], remaining[1], distance[0], distance[1]));
 
   setVisible(d >= MANEUVER_TRANSITION_THRESHOLD);


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/29062 . make the spacing between text  same as the original version before refactor: (`font-size` 70px, `cell-spacing`:3px, `eta` padding-left:40px, padding-right 40px)

after:
![Screenshot from 2023-07-21 05-26-32](https://github.com/commaai/openpilot/assets/27770/c8753597-4dd5-4cd0-80b0-c442cec86031)

