### PR TITLE
nav: improve no route alert text

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -205,7 +205,7 @@ void MapWindow::updateState(const UIState &s) {
   if (!locationd_valid) {
     setError(tr("Waiting for GPS"));
   } else if (routing_problem) {
-    setError(tr("Waiting for internet"));
+    setError(tr("Waiting for route"));
   } else {
     setError("");
   }
@@ -237,6 +237,7 @@ void MapWindow::updateState(const UIState &s) {
     // an invalid navInstruction packet with a nav destination is only possible if:
     // - API exception/no internet
     // - route response is empty
+    //   + the period of time after where navd is waiting for recompute backoff
     auto dest = coordinate_from_param("NavDestination");
     routing_problem = !sm.valid("navInstruction") && dest.has_value();
 

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -237,17 +237,12 @@ void MapWindow::updateState(const UIState &s) {
     // an invalid navInstruction packet with a nav destination is only possible if:
     // - API exception/no internet
     // - route response is empty
-
-    //this kind of works, but we need an additional check somewhere to monitor the param
-//    auto dest = coordinate_from_param("NavDestination");
-//    routing_problem = !sm.valid("navInstruction") && dest.has_value();
+    auto dest = coordinate_from_param("NavDestination");
+    routing_problem = !sm.valid("navInstruction") && dest.has_value();
 
     if (sm.valid("navInstruction")) {
       auto i = sm["navInstruction"].getNavInstruction();
       map_eta->updateETA(i.getTimeRemaining(), i.getTimeRemainingTypical(), i.getDistanceRemaining());
-
-//      auto dest = coordinate_from_param("NavDestination");
-      routing_problem = false;
 
       if (locationd_valid) {
         m_map->setPitch(MAX_PITCH); // TODO: smooth pitching based on maneuver distance
@@ -265,11 +260,6 @@ void MapWindow::updateState(const UIState &s) {
   if (sm.rcv_frame("navRoute") != route_rcv_frame) {
     qWarning() << "Updating navLayer with new route";
     auto route = sm["navRoute"].getNavRoute();
-    auto dest = coordinate_from_param("NavDestination");
-    if (route.getCoordinates().size() == 0 && dest.has_value()) {
-      routing_problem = true;
-    }
-
     auto route_points = capnp_coordinate_list_to_collection(route.getCoordinates());
     QMapbox::Feature feature(QMapbox::Feature::LineStringType, route_points, {}, {});
     QVariantMap navSource;

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -237,12 +237,17 @@ void MapWindow::updateState(const UIState &s) {
     // an invalid navInstruction packet with a nav destination is only possible if:
     // - API exception/no internet
     // - route response is empty
-    auto dest = coordinate_from_param("NavDestination");
-    routing_problem = !sm.valid("navInstruction") && dest.has_value();
+
+    //this kind of works, but we need an additional check somewhere to monitor the param
+//    auto dest = coordinate_from_param("NavDestination");
+//    routing_problem = !sm.valid("navInstruction") && dest.has_value();
 
     if (sm.valid("navInstruction")) {
       auto i = sm["navInstruction"].getNavInstruction();
       map_eta->updateETA(i.getTimeRemaining(), i.getTimeRemainingTypical(), i.getDistanceRemaining());
+
+//      auto dest = coordinate_from_param("NavDestination");
+      routing_problem = false;
 
       if (locationd_valid) {
         m_map->setPitch(MAX_PITCH); // TODO: smooth pitching based on maneuver distance
@@ -260,6 +265,11 @@ void MapWindow::updateState(const UIState &s) {
   if (sm.rcv_frame("navRoute") != route_rcv_frame) {
     qWarning() << "Updating navLayer with new route";
     auto route = sm["navRoute"].getNavRoute();
+    auto dest = coordinate_from_param("NavDestination");
+    if (route.getCoordinates().size() == 0 && dest.has_value()) {
+      routing_problem = true;
+    }
+
     auto route_points = capnp_coordinate_list_to_collection(route.getCoordinates());
     QMapbox::Feature feature(QMapbox::Feature::LineStringType, route_points, {}, {});
     QVariantMap navSource;

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -237,7 +237,7 @@ void MapWindow::updateState(const UIState &s) {
     // an invalid navInstruction packet with a nav destination is only possible if:
     // - API exception/no internet
     // - route response is empty
-    //   + the period of time after where navd is waiting for recompute backoff
+    // - any time navd is waiting for recompute_countdown
     auto dest = coordinate_from_param("NavDestination");
     routing_problem = !sm.valid("navInstruction") && dest.has_value();
 

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -404,8 +404,8 @@
         <translation>Warten auf GPS</translation>
     </message>
     <message>
-        <source>Waiting for internet</source>
-        <translation type="unfinished">Auf Internet warten</translation>
+        <source>Waiting for route</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -403,8 +403,8 @@
         <translation>GPS信号を探しています</translation>
     </message>
     <message>
-        <source>Waiting for internet</source>
-        <translation type="unfinished">インターネット接続を待機中</translation>
+        <source>Waiting for route</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -403,8 +403,8 @@
         <translation>GPS 수신중</translation>
     </message>
     <message>
-        <source>Waiting for internet</source>
-        <translation type="unfinished">인터넷 대기중</translation>
+        <source>Waiting for route</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -404,8 +404,8 @@
         <translation>Esperando por GPS</translation>
     </message>
     <message>
-        <source>Waiting for internet</source>
-        <translation type="unfinished">Esperando pela internet</translation>
+        <source>Waiting for route</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -403,8 +403,8 @@
         <translation>等待 GPS</translation>
     </message>
     <message>
-        <source>Waiting for internet</source>
-        <translation type="unfinished">等待网络连接</translation>
+        <source>Waiting for route</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -403,8 +403,8 @@
         <translation>等待 GPS</translation>
     </message>
     <message>
-        <source>Waiting for internet</source>
-        <translation type="unfinished">連接至網路中</translation>
+        <source>Waiting for route</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
"internet" being the catch-all was wrong, this condition is true any time we're expecting a valid route and nav instruciton but there aren't any.

Could be no internet, an API error, or (what I didn't consider:) exceeding re-computes and navd is in the cooldown phase (from setting a destination and clearing it too many times, but that's less of a problem after https://github.com/commaai/openpilot/pull/29067).

This is fundamentally different from re-routing while using nav. We never clear the route if the re-route was successful, so navd needs to broadcast something for that (future feature!).