### PR TITLE
dmonitoringmodeld: initialize model first

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -84,7 +84,6 @@ private:
 };
 
 std::unordered_map<std::string, uint32_t> keys = {
-    {"DmModelInitialized", CLEAR_ON_ONROAD_TRANSITION},
     {"AccessToken", CLEAR_ON_MANAGER_START | DONT_LOG},
     {"ApiCache_Device", PERSISTENT},
     {"ApiCache_DriveStats", PERSISTENT},
@@ -108,6 +107,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"DisablePowerDown", PERSISTENT},
     {"DisableUpdates", PERSISTENT},
     {"DisengageOnAccelerator", PERSISTENT},
+    {"DmModelInitialized", CLEAR_ON_ONROAD_TRANSITION},
     {"DongleId", PERSISTENT},
     {"DoReboot", CLEAR_ON_MANAGER_START},
     {"DoShutdown", CLEAR_ON_MANAGER_START},

--- a/common/params.cc
+++ b/common/params.cc
@@ -84,6 +84,7 @@ private:
 };
 
 std::unordered_map<std::string, uint32_t> keys = {
+    {"DmModelInitialized", CLEAR_ON_ONROAD_TRANSITION},
     {"AccessToken", CLEAR_ON_MANAGER_START | DONT_LOG},
     {"ApiCache_Device", PERSISTENT},
     {"ApiCache_DriveStats", PERSISTENT},

--- a/selfdrive/modeld/dmonitoringmodeld.cc
+++ b/selfdrive/modeld/dmonitoringmodeld.cc
@@ -5,8 +5,8 @@
 #include <cstdlib>
 
 #include "cereal/visionipc/visionipc_client.h"
-#include "common/swaglog.h"
 #include "common/params.h"
+#include "common/swaglog.h"
 #include "common/util.h"
 #include "selfdrive/modeld/models/dmonitoring.h"
 

--- a/selfdrive/modeld/dmonitoringmodeld.cc
+++ b/selfdrive/modeld/dmonitoringmodeld.cc
@@ -6,6 +6,7 @@
 
 #include "cereal/visionipc/visionipc_client.h"
 #include "common/swaglog.h"
+#include "common/params.h"
 #include "common/util.h"
 #include "selfdrive/modeld/models/dmonitoring.h"
 
@@ -48,6 +49,8 @@ int main(int argc, char **argv) {
   // init the models
   DMonitoringModelState model;
   dmonitoring_init(&model);
+
+  Params().putBool("DmModelInitialized", true);
 
   LOGW("connecting to driver stream");
   VisionIpcClient vipc_client = VisionIpcClient("camerad", VISION_STREAM_DRIVER, true);

--- a/selfdrive/modeld/navmodeld.cc
+++ b/selfdrive/modeld/navmodeld.cc
@@ -45,7 +45,9 @@ int main(int argc, char **argv) {
   // there exists a race condition when two processes try to create a
   // SNPE model runner at the same time, wait for dmonitoringmodeld to finish
   LOGW("waiting for dmonitoringmodeld to initialize");
-  Params().getBool("DmModelInitialized", true);
+  if (!Params().getBool("DmModelInitialized", true)) {
+    return 0;
+  }
 
   // init the models
   NavModelState model;

--- a/selfdrive/modeld/navmodeld.cc
+++ b/selfdrive/modeld/navmodeld.cc
@@ -42,9 +42,8 @@ void run_model(NavModelState &model, VisionIpcClient &vipc_client) {
 int main(int argc, char **argv) {
   setpriority(PRIO_PROCESS, 0, -15);
 
-  LOGW("navmodeld waiting for dmonitoringmodeld to initialize");
+  LOGW("waiting for dmonitoringmodeld to initialize");
   Params().getBool("DmModelInitialized", true);
-  LOGW("navmodeld initializing model");
 
   // init the models
   NavModelState model;

--- a/selfdrive/modeld/navmodeld.cc
+++ b/selfdrive/modeld/navmodeld.cc
@@ -5,8 +5,8 @@
 #include <cstdlib>
 
 #include "cereal/visionipc/visionipc_client.h"
-#include "common/swaglog.h"
 #include "common/params.h"
+#include "common/swaglog.h"
 #include "common/util.h"
 #include "selfdrive/modeld/models/nav.h"
 

--- a/selfdrive/modeld/navmodeld.cc
+++ b/selfdrive/modeld/navmodeld.cc
@@ -6,6 +6,7 @@
 
 #include "cereal/visionipc/visionipc_client.h"
 #include "common/swaglog.h"
+#include "common/params.h"
 #include "common/util.h"
 #include "selfdrive/modeld/models/nav.h"
 
@@ -40,6 +41,10 @@ void run_model(NavModelState &model, VisionIpcClient &vipc_client) {
 
 int main(int argc, char **argv) {
   setpriority(PRIO_PROCESS, 0, -15);
+
+  LOGW("navmodeld waiting for dmonitoringmodeld to initialize");
+  Params().getBool("DmModelInitialized", true);
+  LOGW("navmodeld initializing model");
 
   // init the models
   NavModelState model;

--- a/selfdrive/modeld/navmodeld.cc
+++ b/selfdrive/modeld/navmodeld.cc
@@ -42,6 +42,8 @@ void run_model(NavModelState &model, VisionIpcClient &vipc_client) {
 int main(int argc, char **argv) {
   setpriority(PRIO_PROCESS, 0, -15);
 
+  // there exists a race condition when two processes try to create a
+  // SNPE model runner at the same time, wait for dmonitoringmodeld to finish
   LOGW("waiting for dmonitoringmodeld to initialize");
   Params().getBool("DmModelInitialized", true);
 

--- a/selfdrive/test/process_replay/model_replay.py
+++ b/selfdrive/test/process_replay/model_replay.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import Any
 
 import cereal.messaging as messaging
+from common.params import Params
 from common.spinner import Spinner
 from system.hardware import PC
 from selfdrive.manager.process_config import managed_processes
@@ -62,6 +63,7 @@ def nav_model_replay(lr):
   try:
     assert "MAPBOX_TOKEN" in os.environ
     os.environ['MAP_RENDER_TEST_MODE'] = '1'
+    Params().put_bool('DmModelInitialized', True)
     managed_processes['mapsd'].start()
     managed_processes['navmodeld'].start()
 


### PR DESCRIPTION
Prevents two processes from initializing and building their models at the same (ie. dmonitoringmodeld and navmodeld)