### PR TITLE
Fix mypy path error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
         entry: mypy
         language: system
         types: [python]
+        args: ['--explicit-package-bases']
         exclude: '^(third_party/)|(cereal/)|(opendbc/)|(panda/)|(laika/)|(laika_repo/)|(rednose/)|(rednose_repo/)|(tinygrad/)|(tinygrad_repo/)|(xx/)'
 -   repo: https://github.com/PyCQA/flake8
     rev: 6.0.0


### PR DESCRIPTION
Error 
```
selfdrive/manager/__init__.py: error: Source file found twice under different module names: "xx.openpilot.selfdrive.manager" and "selfdrive.manager"
Found 1 error in 1 file (errors prevented further checking)
```
This fixes it, by resolving path to the nearest parent directory, till it hits the current directory.
https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-paths-to-modules