### PR TITLE
Subaru: gen2 torque increase

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -21,7 +21,7 @@ class CarControllerParams:
     self.STEER_DRIVER_FACTOR = 1       # from dbc
 
     if CP.carFingerprint in GLOBAL_GEN2:
-      self.STEER_MAX = 1000
+      self.STEER_MAX = 1400
       self.STEER_DELTA_UP = 40
       self.STEER_DELTA_DOWN = 40
     elif CP.carFingerprint == CAR.IMPREZA_2020:


### PR DESCRIPTION
Here's a plot of 20,000 subaru segments:

![image](https://github.com/commaai/openpilot/assets/9648890/d7672e39-51af-4d56-aabe-d22264a51d08)

Green shades are the Legacy / Outback
Red shades are various other gen1 cars

I'm not seeing a significant difference between the two cars, even with some people who have manually increased the limits or were running before the torque was decreased. We also have stock ES routes that go up to 1400 on extreme turns before it gives up:

![image](https://github.com/commaai/openpilot/assets/9648890/1fc9147c-54a4-4201-90a4-3a7911fa0ff5)

I purpose we increase it to 1400, since we know eyesight will do that.

Panda PR: https://github.com/commaai/panda/pull/1530