### PR TITLE
ui/map: fix destination sync issue after removing `NavDestination`

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -60,7 +60,7 @@ MapSettings::MapSettings(bool closeable, QWidget *parent) : QFrame(parent) {
   current_widget = new DestinationWidget(this);
   QObject::connect(current_widget, &DestinationWidget::actionClicked, [=]() {
     if (current_destination.empty()) return;
-    params.remove("NavDestination");
+    params.put("NavDestination", "");
     updateCurrentRoute();
   });
   frame->addWidget(current_widget);
@@ -298,6 +298,7 @@ NavigationRequest::NavigationRequest(QObject *parent) : QObject(parent) {
     }
     {
       auto param_watcher = new ParamWatcher(this);
+      param_watcher->addParam("NavDestination");
       QObject::connect(param_watcher, &ParamWatcher::paramChanged, this, &NavigationRequest::nextDestinationUpdated);
 
       // Destination set while offline
@@ -318,6 +319,7 @@ NavigationRequest::NavigationRequest(QObject *parent) : QObject(parent) {
 
         // athena can set destination at any time
         param_watcher->addParam("NavDestination");
+        emit nextDestinationUpdated();
       });
     }
   }

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -60,7 +60,7 @@ MapSettings::MapSettings(bool closeable, QWidget *parent) : QFrame(parent) {
   current_widget = new DestinationWidget(this);
   QObject::connect(current_widget, &DestinationWidget::actionClicked, [=]() {
     if (current_destination.empty()) return;
-    params.put("NavDestination", "");
+    params.remove("NavDestination");
     updateCurrentRoute();
   });
   frame->addWidget(current_widget);


### PR DESCRIPTION
1. always `emit nextDestinationUpdated()` after `addParam("NavDestination");`  to ensure that the current destination can be updated after param 'NavDestination' is recreated.
~2. set  `NavDestination` to empty instead of remove it  after user clicks "remove current destination" button.~


