### PR TITLE
ui/MapSettings: refactor `NavigationRequest` to `NavManager`

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -158,6 +158,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"LongitudinalPersonality", PERSISTENT},
     {"NavDestination", CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION},
     {"NavDestinationWaypoints", CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION},
+    {"NavPastDestinations", PERSISTENT},
     {"NavSettingLeftSide", PERSISTENT},
     {"NavSettingTime24h", PERSISTENT},
     {"NavdRender", PERSISTENT},

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -58,11 +58,8 @@ MapSettings::MapSettings(bool closeable, QWidget *parent) : QFrame(parent) {
   frame->addSpacing(32);
 
   current_widget = new DestinationWidget(this);
-  QObject::connect(current_widget, &DestinationWidget::actionClicked, [=]() {
-    if (current_destination.empty()) return;
-    params.remove("NavDestination");
-    updateCurrentRoute();
-  });
+  QObject::connect(current_widget, &DestinationWidget::actionClicked,
+                   []() { NavManager::instance()->setCurrentDestination({}); });
   frame->addWidget(current_widget);
   frame->addSpacing(32);
 
@@ -81,11 +78,7 @@ MapSettings::MapSettings(bool closeable, QWidget *parent) : QFrame(parent) {
   frame->addWidget(destinations_scroller);
 
   setStyleSheet("MapSettings { background-color: #333333; }");
-
-  QObject::connect(NavigationRequest::instance(), &NavigationRequest::locationsUpdated, this, &MapSettings::updateLocations);
-  QObject::connect(NavigationRequest::instance(), &NavigationRequest::nextDestinationUpdated, this, &MapSettings::updateCurrentRoute);
-
-  current_locations = NavigationRequest::instance()->currentLocations();
+  QObject::connect(NavManager::instance(), &NavManager::updated, this, &MapSettings::refresh);
 }
 
 void MapSettings::mousePressEvent(QMouseEvent *ev) {
@@ -94,32 +87,12 @@ void MapSettings::mousePressEvent(QMouseEvent *ev) {
 }
 
 void MapSettings::showEvent(QShowEvent *event) {
-  updateCurrentRoute();
-}
-
-void MapSettings::updateCurrentRoute() {
-  auto dest = QString::fromStdString(params.get("NavDestination"));
-  if (dest.size()) {
-    QJsonDocument doc = QJsonDocument::fromJson(dest.trimmed().toUtf8());
-    if (doc.isNull()) {
-      qWarning() << "JSON Parse failed on NavDestination" << dest;
-      return;
-    }
-    current_destination = doc.object();
-    current_widget->set(current_destination, true);
-  } else {
-    current_destination = {};
-    current_widget->unset("", true);
-  }
-  if (isVisible()) refresh();
-}
-
-void MapSettings::updateLocations(const QJsonArray &locations) {
-  current_locations = locations;
   refresh();
 }
 
 void MapSettings::refresh() {
+  if (!isVisible()) return;
+
   setUpdatesEnabled(false);
 
   auto get_w = [this](int i) {
@@ -131,11 +104,17 @@ void MapSettings::refresh() {
     return w;
   };
 
+  const auto current_dest = NavManager::instance()->currentDestination();
+  if (!current_dest.isEmpty()) {
+    current_widget->set(current_dest, true);
+  } else {
+    current_widget->unset("", true);
+  }
   home_widget->unset(NAV_FAVORITE_LABEL_HOME);
   work_widget->unset(NAV_FAVORITE_LABEL_WORK);
 
   int n = 0;
-  for (auto location : current_locations) {
+  for (auto location : NavManager::instance()->currentLocations()) {
     DestinationWidget *w = nullptr;
     auto dest = location.toObject();
     if (dest["save_type"].toString() == NAV_TYPE_FAVORITE) {
@@ -145,7 +124,7 @@ void MapSettings::refresh() {
     }
     w = w ? w : get_w(n++);
     w->set(dest, false);
-    w->setVisible(dest != current_destination);
+    w->setVisible(dest != current_dest);
   }
   for (; n < widgets.size(); ++n) widgets[n]->setVisible(false);
 
@@ -153,9 +132,7 @@ void MapSettings::refresh() {
 }
 
 void MapSettings::navigateTo(const QJsonObject &place) {
-  QJsonDocument doc(place);
-  params.put("NavDestination", doc.toJson().toStdString());
-  updateCurrentRoute();
+  NavManager::instance()->setCurrentDestination(place);
   emit closeSettings();
 }
 
@@ -281,24 +258,26 @@ void DestinationWidget::unset(const QString &label, bool current) {
   setVisible(true);
 }
 
-// singleton NavigationRequest
+// singleton NavManager
 
-NavigationRequest *NavigationRequest::instance() {
-  static NavigationRequest *request = new NavigationRequest(qApp);
+NavManager *NavManager::instance() {
+  static NavManager *request = new NavManager(qApp);
   return request;
 }
 
-NavigationRequest::NavigationRequest(QObject *parent) : QObject(parent) {
+NavManager::NavManager(QObject *parent) : QObject(parent) {
+  locations = QJsonDocument::fromJson(params.get("NavPastDestinations").c_str()).array();
+  current_dest = QJsonDocument::fromJson(params.get("NavDestination").c_str()).object();
   if (auto dongle_id = getDongleId()) {
     {
       // Fetch favorite and recent locations
       QString url = CommaApi::BASE_URL + "/v1/navigation/" + *dongle_id + "/locations";
       RequestRepeater *repeater = new RequestRepeater(this, url, "ApiCache_NavDestinations", 30, true);
-      QObject::connect(repeater, &RequestRepeater::requestDone, this, &NavigationRequest::parseLocationsResponse);
+      QObject::connect(repeater, &RequestRepeater::requestDone, this, &NavManager::parseLocationsResponse);
     }
     {
       auto param_watcher = new ParamWatcher(this);
-      QObject::connect(param_watcher, &ParamWatcher::paramChanged, this, &NavigationRequest::nextDestinationUpdated);
+      QObject::connect(param_watcher, &ParamWatcher::paramChanged, this, &NavManager::updated);
 
       // Destination set while offline
       QString url = CommaApi::BASE_URL + "/v1/navigation/" + *dongle_id + "/next";
@@ -318,6 +297,8 @@ NavigationRequest::NavigationRequest(QObject *parent) : QObject(parent) {
 
         // athena can set destination at any time
         param_watcher->addParam("NavDestination");
+        current_dest = QJsonDocument::fromJson(params.get("NavDestination").c_str()).object();
+        emit updated();
       });
     }
   }
@@ -325,7 +306,7 @@ NavigationRequest::NavigationRequest(QObject *parent) : QObject(parent) {
 
 static void swap(QJsonValueRef v1, QJsonValueRef v2) { std::swap(v1, v2); }
 
-void NavigationRequest::parseLocationsResponse(const QString &response, bool success) {
+void NavManager::parseLocationsResponse(const QString &response, bool success) {
   if (!success || response == prev_response) return;
 
   prev_response = response;
@@ -343,5 +324,19 @@ void NavigationRequest::parseLocationsResponse(const QString &response, bool suc
     return has_favorite && (std::tuple(a["save_type"].toString(), a["place_name"].toString()) <
                             std::tuple(b["save_type"].toString(), b["place_name"].toString()));
   });
-  emit locationsUpdated(locations);
+  write_param_future = std::async(std::launch::async, [destinations = QJsonArray(locations)]() {
+    Params().put("NavPastDestinations", QJsonDocument(destinations).toJson().toStdString());
+  });
+
+  emit updated();
+}
+
+void NavManager::setCurrentDestination(const QJsonObject &loc) {
+  current_dest = loc;
+  if (!current_dest.isEmpty()) {
+    params.put("NavDestination", QJsonDocument(current_dest).toJson().toStdString());
+  } else {
+    params.remove("NavDestination");
+  }
+  emit updated();
 }

--- a/selfdrive/ui/qt/maps/map_settings.h
+++ b/selfdrive/ui/qt/maps/map_settings.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <future>
+
 #include <QFrame>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -20,43 +22,40 @@ const QString NAV_FAVORITE_LABEL_WORK = "work";
 
 class DestinationWidget;
 
-class NavigationRequest : public QObject {
+class NavManager : public QObject {
   Q_OBJECT
 
 public:
-  static NavigationRequest *instance();
+  static NavManager *instance();
   QJsonArray currentLocations() const { return locations; };
+  QJsonObject currentDestination() const { return current_dest; }
+  void setCurrentDestination(const QJsonObject &loc);
 
 signals:
-  void locationsUpdated(const QJsonArray &locations);
-  void nextDestinationUpdated();
+  void updated();
 
 private:
-  NavigationRequest(QObject *parent);
+  NavManager(QObject *parent);
   void parseLocationsResponse(const QString &response, bool success);
 
   Params params;
   QString prev_response;
   QJsonArray locations;
+  QJsonObject current_dest;
+  std::future<void> write_param_future;
 };
 
 class MapSettings : public QFrame {
   Q_OBJECT
 public:
   explicit MapSettings(bool closeable = false, QWidget *parent = nullptr);
-
   void navigateTo(const QJsonObject &place);
-  void updateLocations(const QJsonArray &locations);
-  void updateCurrentRoute();
 
 private:
   void mousePressEvent(QMouseEvent *ev) override;
   void showEvent(QShowEvent *event) override;
   void refresh();
 
-  Params params;
-  QJsonArray current_locations;
-  QJsonObject current_destination;
   QVBoxLayout *destinations_layout;
   DestinationWidget *current_widget;
   DestinationWidget *home_widget;

--- a/selfdrive/ui/qt/maps/map_settings.h
+++ b/selfdrive/ui/qt/maps/map_settings.h
@@ -37,6 +37,9 @@ signals:
 private:
   NavManager(QObject *parent);
   void parseLocationsResponse(const QString &response, bool success);
+  QJsonObject getNavDestination() {
+    return QJsonDocument::fromJson(params.get("NavDestination").c_str()).object();
+  }
 
   Params params;
   QString prev_response;
@@ -82,7 +85,7 @@ private:
     QPixmap home, work, favorite, recent, directions;
   };
 
-  static NavIcons icons() {
+  static NavIcons &icons() {
     static NavIcons nav_icons {
       loadPixmap("../assets/navigation/icon_home.svg", {48, 48}),
       loadPixmap("../assets/navigation/icon_work.svg", {48, 48}),


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/29079

1. refactor `NavigationRequest` to `NavManager`.  Move all params read/write operations into `NavManager`. `MapSettings` is only responsible for UI stuffs. this also reduce some IO operations.
2. clear current destination on offroad transition.
3.  fix destination sync issue after removing NavDestination
