### PR TITLE
ui/map: hide settings with showing map

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -189,10 +189,10 @@ void MapWindow::updateState(const UIState &s) {
 
     // Only open the map on setting destination the first time
     if (allow_open) {
+      emit requestSettings(false);
       emit requestVisible(true); // Show map on destination set/change
       allow_open = false;
     }
-    emit requestSettings(false);
   }
 
   loaded_once = loaded_once || (m_map && m_map->isFullyLoaded());


### PR DESCRIPTION
for consistent behavior. we don't show the map every time it re-routes, so shouldn't hide the settings every time it re-routes. though after https://github.com/commaai/openpilot/pull/28904 this isn't a big issue