### PR TITLE
deleter: improve performance

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -4,6 +4,7 @@ import shutil
 import threading
 from typing import List
 
+from common.params import Params
 from system.swaglog import cloudlog
 from system.loggerd.config import ROOT, get_available_bytes, get_available_percent
 from system.loggerd.uploader import listdir_by_creation
@@ -54,6 +55,10 @@ def deleter_thread(exit_event):
     if out_of_percent or out_of_bytes:
       if not dirs:
         dirs = listdir_by_creation(ROOT)
+        # Skip the last segment if onroad
+        if Params().get("IsOnroad"):
+          dirs = dirs[:-1]
+
         preserved_dirs = get_preserved_segments(dirs)
         dirs.sort(key=lambda d: (d in DELETE_LAST, d in preserved_dirs))
 


### PR DESCRIPTION
`listdir_by_creation`&`get_preserved_segments` is very resource consuming if there are a lot of segments on disk.
calling these two functions every time before deleting a directory will impact performance,  especially when `deleter` needs to delete old files continuously after `loggerd` is started when the disk is full.

This pr cache the sorted segments to variable `dirs`. only repopulate it after it becomes empty.


