### PR TITLE
update_requirements: fix opendbc pre-commit hook installation

### DIFF
--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -75,9 +75,8 @@ if [ "$(uname)" != "Darwin" ]; then
   echo "pre-commit hooks install..."
   shopt -s nullglob
   for f in .pre-commit-config.yaml */.pre-commit-config.yaml; do
-    cd $DIR/$(dirname $f)
-    if [ -e ".git" ]; then
-      $RUN pre-commit install
+    if [ -e "$DIR/$(dirname $f)/.git" ]; then
+      $RUN pre-commit install -c "$f"
     fi
   done
 fi


### PR DESCRIPTION
When doing a fresh close/install using `tools/ubuntu_setup.sh`, `update_requirements.sh` script fails at pre-commit hook installation step (at https://github.com/commaai/openpilot/blob/master/update_requirements.sh#L80) with: 
```
pre-commit hooks install...
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at /openpilot/.git/modules/body/hooks/pre-commit
pre-commit installed at /openpilot/.git/modules/cereal/hooks/pre-commit
pre-commit installed at /openpilot/.git/modules/laika_repo/hooks/pre-commit
Creating virtualenv opendbc-Q-_TInKi-py3.11 in /root/.cache/pypoetry/virtualenvs
Command not found: pre-commit
```
It's caused by poetry switching venv to opendbc venv, which does not have pre-commit installed.

Since hooks are installed in root git repository anyway, poetry can be just forced to use openpilot env, by running the command from openpillot root dir.