### PR TITLE
ui/map: update mapbox style

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -269,7 +269,7 @@ void MapWindow::initializeGL() {
 
   m_map->setMargins({0, 350, 0, 50});
   m_map->setPitch(MIN_PITCH);
-  m_map->setStyleUrl("mapbox://styles/commaai/clj7g5vrp007b01qzb5ro0i4j");
+  m_map->setStyleUrl("mapbox://styles/commaai/clkqztk0f00ou01qyhsa5bzpj");
 
   QObject::connect(m_map.data(), &QMapboxGL::mapChanged, [=](QMapboxGL::MapChange change) {
     // set global animation duration to 0 ms so visibility changes are instant


### PR DESCRIPTION
- Pedestrian and railroad crossing icons now shown (toggle was combined with one-way roads).
- Map data updates

TODO: test on device

|New|<img height=500 src=https://github.com/commaai/openpilot/assets/4038174/e162bab2-f3ad-451c-a163-f94e121ec63d>|
|---|---|
|Old|<img height=500 src=https://github.com/commaai/openpilot/assets/4038174/557ad251-1af3-4e8f-b3c3-788220cab159>|


