### PR TITLE
ui/onroad: equal margins on imperial

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -355,7 +355,7 @@ void AnnotatedCameraWidget::drawHud(QPainter &p) {
   int top_radius = 32;
   int bottom_radius = has_eu_speed_limit ? 100 : 32;
 
-  QRect set_speed_rect(QPoint(60 + (default_size.width() - set_speed_size.width()) / 2, 45), set_speed_size);
+  QRect set_speed_rect(QPoint((is_metric ? 60 : 45) + (default_size.width() - set_speed_size.width()) / 2, 45), set_speed_size);
   p.setPen(QPen(whiteColor(75), 6));
   p.setBrush(blackColor(166));
   drawRoundedRect(p, set_speed_rect, top_radius, top_radius, bottom_radius, bottom_radius);


### PR DESCRIPTION
This PR rectifies an inconsistency in OpenPilot's top/left margins of the set speed box between imperial and metric, ensuring equal dimensions across both.. unless this was intentional.

After:
<img width="1192" alt="Screenshot 2023-07-31 at 10 53 18 PM" src="https://github.com/commaai/openpilot/assets/1976269/e8c58815-f306-48fa-a89f-8280f95c3d8b">
<img width="1192" alt="Screenshot 2023-07-31 at 10 53 28 PM" src="https://github.com/commaai/openpilot/assets/1976269/9a8a6aa2-63ed-411f-8bca-cdafbf6afe52">


Before:
<img width="1192" alt="Screenshot 2023-07-31 at 10 54 15 PM" src="https://github.com/commaai/openpilot/assets/1976269/12d079ed-6e63-4fad-bec0-9d53c798e811">
<img width="1192" alt="Screenshot 2023-07-31 at 10 54 06 PM" src="https://github.com/commaai/openpilot/assets/1976269/4d47e67b-bcb8-42ec-9043-e82cf1ae4688">
