### PR TITLE
Updated Carla to version 0.9.14

### DIFF
--- a/tools/sim/start_carla.sh
+++ b/tools/sim/start_carla.sh
@@ -15,7 +15,7 @@ if ! $(apt list --installed | grep -q nvidia-container-toolkit); then
   fi
 fi
 
-docker pull carlasim/carla:0.9.13
+docker pull carlasim/carla:0.9.14
 
 EXTRA_ARGS="-it"
 if [[ "$DETACH" ]]; then
@@ -30,5 +30,5 @@ docker run \
   --net=host \
   -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
   $EXTRA_ARGS \
-  carlasim/carla:0.9.13 \
+  carlasim/carla:0.9.14 \
   /bin/bash ./CarlaUE4.sh -opengl -nosound -RenderOffScreen -benchmark -fps=20 -quality-level=Low


### PR DESCRIPTION
### Bugfix:

**Description** 
When following [the tools readme](https://github.com/commaai/openpilot/blob/master/tools/README.md) and then [the sim readme](https://github.com/commaai/openpilot/blob/master/tools/sim/README.md), one ends up with the error described in this issue: #29173 (`Restarting bridge. Error: rpc::rpc_error during call in function get_sensor_token`)
The bridge will not start with this error, and just keeps spamming. This Pull Request fixes this issue.

This issue seems to be originating from the switch to Python 3.11 about two weeks ago. In #28843 the Python carla package was updated to be this specific one:
https://github.com/commaai/openpilot/blob/21802265bec5ede0eaf4093ba0cd2c4c5be3b1af/pyproject.toml#L68

This package seems to be there, because there is no carla python package for python 3.11.
The package is for the carla version 0.9.14, but the file `tools/sim/start_carla.sh` specifies 0.9.13.
Simply bumping this version up to 0.9.14 fixes the error mentioned in #29173.
Note: the warning remains, but can safely be ignored versions match after this PR is merged.

**Verification**
I tested to run the simulation two ways:
1. by starting the carla docker (`tools/sim/start_carla.sh`) and then the openpilot docker (`tools/sim/start_openpilot_docker.sh`)
2. by starting the carla docker (`tools/sim/start_carla.sh`) and then openpilot (`tools/sim/launch_openpilot.sh`) followed by the bridge (`tools/sim/bridge.py`).

Both methods executed successfully.


_This is my first contribution, I hope everything is okay. Please don't hesitate to mention anything I can do better next time. Have a lovely day!_