### PR TITLE
Cabana: Fix >1 hour route time displaying

### DIFF
--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -97,7 +97,7 @@ namespace utils {
 QPixmap icon(const QString &id);
 void setTheme(int theme);
 inline QString formatSeconds(int seconds) {
-  return QDateTime::fromTime_t(seconds).toString(seconds > 60 * 60 ? "hh:mm:ss" : "mm:ss");
+  return QDateTime::fromSecsSinceEpoch(seconds, Qt::UTC).toString(seconds > 60 * 60 ? "hh:mm:ss" : "mm:ss");
 }
 }
 


### PR DESCRIPTION
For routes >1 hour, time is displayed incorrectly, since QT uses the timezone. If you instead specify UTC, it works correctly.
 
Example: c2585539cc5ebcb3|2023-07-29--07-37-37
Before:
![image](https://github.com/commaai/openpilot/assets/9648890/d7a81900-d28a-470a-9685-a6ba45f1927d)

After:
![image](https://github.com/commaai/openpilot/assets/9648890/286211cb-65c4-49bc-af71-a184ba02eda9)
