### PR TITLE
sensord: Avoid extra copies on sensor init

### DIFF
--- a/system/sensord/sensors_qcom2.cc
+++ b/system/sensord/sensors_qcom2.cc
@@ -118,18 +118,18 @@ int sensor_loop(I2CBus *i2c_bus_imu) {
 
   // Sensor init
   std::vector<std::pair<Sensor *, bool>> sensors_init; // Sensor, required
-  sensors_init.push_back({&bmx055_accel, false});
-  sensors_init.push_back({&bmx055_gyro, false});
-  sensors_init.push_back({&bmx055_magn, false});
-  sensors_init.push_back({&bmx055_temp, false});
+  sensors_init.emplace_back(&bmx055_accel, false);
+  sensors_init.emplace_back(&bmx055_gyro, false);
+  sensors_init.emplace_back(&bmx055_magn, false);
+  sensors_init.emplace_back(&bmx055_temp, false);
 
-  sensors_init.push_back({&lsm6ds3_accel, true});
-  sensors_init.push_back({&lsm6ds3_gyro, true});
-  sensors_init.push_back({&lsm6ds3_temp, true});
+  sensors_init.emplace_back(&lsm6ds3_accel, true);
+  sensors_init.emplace_back(&lsm6ds3_gyro, true);
+  sensors_init.emplace_back(&lsm6ds3_temp, true);
 
-  sensors_init.push_back({&mmc5603nj_magn, false});
+  sensors_init.emplace_back(&mmc5603nj_magn, false);
 
-  sensors_init.push_back({&light, true});
+  sensors_init.emplace_back(&light, true);
 
   bool has_magnetometer = false;
 


### PR DESCRIPTION
## Description:

Use emplace_back instead of push_back on sensor init.

This avoids an extra copy by constructing the std::pair in place.

If it were a primitive both would optimize to the same instructions, but std::pair makes it very unlikely to be optimized.

See https://godbolt.org/z/dheqYj611

## Verification:

Currently, I don't have the hardware to test the changes myself.