### PR TITLE
GM: remove unused CANParser flag

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -216,4 +216,4 @@ class CarState(CarStateBase):
       ("ASCMLKASteeringCmd", 0),
     ]
 
-    return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, CanBus.LOOPBACK, enforce_checks=False)
+    return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, CanBus.LOOPBACK)


### PR DESCRIPTION
prep for https://github.com/commaai/opendbc/pull/828

this only allows the checks list to be empty. the freqs start at 0 if not defined, but we define to 0, so setting the flag doesn't do anything:

https://github.com/commaai/opendbc/blob/7d23b4c01b177fc3d8386f4e8eb3a565619be87b/can/parser_pyx.pyx#L98-L99