### PR TITLE
unused variables removal

### DIFF
--- a/selfdrive/modeld/navmodeld.cc
+++ b/selfdrive/modeld/navmodeld.cc
@@ -16,8 +16,8 @@ void run_model(NavModelState &model, VisionIpcClient &vipc_client) {
   SubMaster sm({"navInstruction"});
   PubMaster pm({"navModel"});
 
-  double last_ts = 0;
-  uint32_t last_frame_id = 0;
+  //double last_ts = 0;
+  //uint32_t last_frame_id = 0;
   VisionIpcBufExtra extra = {};
 
   while (!do_exit) {
@@ -34,8 +34,8 @@ void run_model(NavModelState &model, VisionIpcClient &vipc_client) {
     navmodel_publish(pm, extra, *model_res, (t2 - t1) / 1000.0, sm["navInstruction"].getValid());
 
     //printf("navmodel process: %.2fms, from last %.2fms\n", t2 - t1, t1 - last_ts);
-    last_ts = t1;
-    last_frame_id = extra.frame_id;
+    //last_ts = t1;
+    //last_frame_id = extra.frame_id;
   }
 }
 


### PR DESCRIPTION
Fix errors when compiling on a PC:
```
selfdrive/modeld/navmodeld.cc:19:10: warning: variable 'last_ts' set but not used [-Wunused-but-set-variable]
  double last_ts = 0;
         ^
selfdrive/modeld/navmodeld.cc:20:12: warning: variable 'last_frame_id' set but not used [-Wunused-but-set-variable]
  uint32_t last_frame_id = 0;

2 warnings generated.
scons: building terminated because of errors.
```