### PR TITLE
Full French UI Localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ build/
 !**/.gitkeep
 
 poetry.toml
+Pipfile

--- a/selfdrive/ui/translations/languages.json
+++ b/selfdrive/ui/translations/languages.json
@@ -1,6 +1,7 @@
 {
   "English": "main_en",
   "Deutsch": "main_de",
+  "Français": "main_fr",
   "Português": "main_pt-BR",
   "中文（繁體）": "main_zh-CHT",
   "中文（简体）": "main_zh-CHS",

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -1,0 +1,1158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>AbstractAlert</name>
+    <message>
+        <source>Close</source>
+        <translation>Fermer</translation>
+    </message>
+    <message>
+        <source>Snooze Update</source>
+        <translation>Reporter la mise à jour</translation>
+    </message>
+    <message>
+        <source>Reboot and Update</source>
+        <translation>Redémarrer et mettre à jour</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedNetworking</name>
+    <message>
+        <source>Back</source>
+        <translation>Retour</translation>
+    </message>
+    <message>
+        <source>Enable Tethering</source>
+        <translation>Activer le partage de connexion</translation>
+    </message>
+    <message>
+        <source>Tethering Password</source>
+        <translation>Mot de passe du partage de connexion</translation>
+    </message>
+    <message>
+        <source>EDIT</source>
+        <translation>MODIFIER</translation>
+    </message>
+    <message>
+        <source>Enter new tethering password</source>
+        <translation>Entrez le nouveau mot de passe du partage de connexion</translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation>Adresse IP</translation>
+    </message>
+    <message>
+        <source>Enable Roaming</source>
+        <translation>Activer l&apos;itinérance</translation>
+    </message>
+    <message>
+        <source>APN Setting</source>
+        <translation>Paramètre APN</translation>
+    </message>
+    <message>
+        <source>Enter APN</source>
+        <translation>Entrer le nom du point d&apos;accès</translation>
+    </message>
+    <message>
+        <source>leave blank for automatic configuration</source>
+        <translation>laisser vide pour une configuration automatique</translation>
+    </message>
+    <message>
+        <source>Cellular Metered</source>
+        <translation>Connexion cellulaire limitée</translation>
+    </message>
+    <message>
+        <source>Prevent large data uploads when on a metered connection</source>
+        <translation>Éviter les transferts de données importants sur une connexion limitée</translation>
+    </message>
+</context>
+<context>
+    <name>AnnotatedCameraWidget</name>
+    <message>
+        <source>km/h</source>
+        <translation>km/h</translation>
+    </message>
+    <message>
+        <source>mph</source>
+        <translation>mi/h</translation>
+    </message>
+    <message>
+        <source>MAX</source>
+        <translation>MAX</translation>
+    </message>
+    <message>
+        <source>SPEED</source>
+        <translation>VITESSE</translation>
+    </message>
+    <message>
+        <source>LIMIT</source>
+        <translation>LIMITE</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmationDialog</name>
+    <message>
+        <source>Ok</source>
+        <translation>Ok</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>DeclinePage</name>
+    <message>
+        <source>You must accept the Terms and Conditions in order to use openpilot.</source>
+        <translation>Vous devez accepter les conditions générales pour utiliser openpilot.</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation>Retour</translation>
+    </message>
+    <message>
+        <source>Decline, uninstall %1</source>
+        <translation>Refuser, désinstaller %1</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePanel</name>
+    <message>
+        <source>Dongle ID</source>
+        <translation>Dongle ID</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation>N/A</translation>
+    </message>
+    <message>
+        <source>Serial</source>
+        <translation>N° de série</translation>
+    </message>
+    <message>
+        <source>Driver Camera</source>
+        <translation>Caméra conducteur</translation>
+    </message>
+    <message>
+        <source>PREVIEW</source>
+        <translation>APERÇU</translation>
+    </message>
+    <message>
+        <source>Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)</source>
+        <translation>Aperçu de la caméra orientée vers le conducteur pour assurer une bonne visibilité de la surveillance du conducteur. (véhicule doit être éteint)</translation>
+    </message>
+    <message>
+        <source>Reset Calibration</source>
+        <translation>Réinitialiser la calibration</translation>
+    </message>
+    <message>
+        <source>RESET</source>
+        <translation>RÉINITIALISER</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to reset calibration?</source>
+        <translation>Êtes-vous sûr de vouloir réinitialiser la calibration ?</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>Réinitialiser</translation>
+    </message>
+    <message>
+        <source>Review Training Guide</source>
+        <translation>Revoir le guide de formation</translation>
+    </message>
+    <message>
+        <source>REVIEW</source>
+        <translation>REVOIR</translation>
+    </message>
+    <message>
+        <source>Review the rules, features, and limitations of openpilot</source>
+        <translation>Revoir les règles, fonctionnalités et limitations d&apos;openpilot</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to review the training guide?</source>
+        <translation>Êtes-vous sûr de vouloir revoir le guide de formation ?</translation>
+    </message>
+    <message>
+        <source>Review</source>
+        <translation>Revoir</translation>
+    </message>
+    <message>
+        <source>Regulatory</source>
+        <translation>Réglementaire</translation>
+    </message>
+    <message>
+        <source>VIEW</source>
+        <translation>VOIR</translation>
+    </message>
+    <message>
+        <source>Change Language</source>
+        <translation>Changer de langue</translation>
+    </message>
+    <message>
+        <source>CHANGE</source>
+        <translation>CHANGER</translation>
+    </message>
+    <message>
+        <source>Select a language</source>
+        <translation>Choisir une langue</translation>
+    </message>
+    <message>
+        <source>Reboot</source>
+        <translation>Redémarrer</translation>
+    </message>
+    <message>
+        <source>Power Off</source>
+        <translation>Éteindre</translation>
+    </message>
+    <message>
+        <source>openpilot requires the device to be mounted within 4° left or right and within 5° up or 8° down. openpilot is continuously calibrating, resetting is rarely required.</source>
+        <translation>openpilot nécessite que l&apos;appareil soit monté à 4° à gauche ou à droite et à 5° vers le haut ou 8° vers le bas. openpilot se calibre en continu, la réinitialisation est rarement nécessaire.</translation>
+    </message>
+    <message>
+        <source> Your device is pointed %1° %2 and %3° %4.</source>
+        <translation> Votre appareil est orienté %1° %2 et %3° %4.</translation>
+    </message>
+    <message>
+        <source>down</source>
+        <translation>bas</translation>
+    </message>
+    <message>
+        <source>up</source>
+        <translation>haut</translation>
+    </message>
+    <message>
+        <source>left</source>
+        <translation>gauche</translation>
+    </message>
+    <message>
+        <source>right</source>
+        <translation>droite</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to reboot?</source>
+        <translation>Êtes-vous sûr de vouloir redémarrer ?</translation>
+    </message>
+    <message>
+        <source>Disengage to Reboot</source>
+        <translation>Désengager pour redémarrer</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to power off?</source>
+        <translation>Êtes-vous sûr de vouloir éteindre ?</translation>
+    </message>
+    <message>
+        <source>Disengage to Power Off</source>
+        <translation>Désengager pour éteindre</translation>
+    </message>
+</context>
+<context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>Trajets</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>Heures</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>DEPUIS TOUJOURS</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>CETTE SEMAINE</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>KM</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>Miles</translation>
+    </message>
+</context>
+<context>
+    <name>DriverViewScene</name>
+    <message>
+        <source>camera starting</source>
+        <translation>démarrage de la caméra</translation>
+    </message>
+</context>
+<context>
+    <name>ExperimentalModeButton</name>
+    <message>
+        <source>EXPERIMENTAL MODE ON</source>
+        <translation>MODE EXPÉRIMENTAL ACTIVÉ</translation>
+    </message>
+    <message>
+        <source>CHILL MODE ON</source>
+        <translation>MODE DÉTENTE ACTIVÉ</translation>
+    </message>
+</context>
+<context>
+    <name>InputDialog</name>
+    <message>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message numerus="yes">
+        <source>Need at least %n character(s)!</source>
+        <translation>
+            <numerusform>Besoin d&apos;au moins %n caractère !</numerusform>
+            <numerusform>Besoin d&apos;au moins %n caractères !</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>Installer</name>
+    <message>
+        <source>Installing...</source>
+        <translation>Installation...</translation>
+    </message>
+</context>
+<context>
+    <name>MapETA</name>
+    <message>
+        <source>eta</source>
+        <translation>eta</translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation>min</translation>
+    </message>
+    <message>
+        <source>hr</source>
+        <translation>h</translation>
+    </message>
+    <message>
+        <source>km</source>
+        <translation>km</translation>
+    </message>
+    <message>
+        <source>mi</source>
+        <translation>mi</translation>
+    </message>
+</context>
+<context>
+    <name>MapInstructions</name>
+    <message>
+        <source> km</source>
+        <translation> km</translation>
+    </message>
+    <message>
+        <source> m</source>
+        <translation> m</translation>
+    </message>
+    <message>
+        <source> mi</source>
+        <translation> mi</translation>
+    </message>
+    <message>
+        <source> ft</source>
+        <translation> ft</translation>
+    </message>
+</context>
+<context>
+    <name>MapPanel</name>
+    <message>
+        <source>Current Destination</source>
+        <translation>Destination actuelle</translation>
+    </message>
+    <message>
+        <source>CLEAR</source>
+        <translation>EFFACER</translation>
+    </message>
+    <message>
+        <source>Recent Destinations</source>
+        <translation>Destinations récentes</translation>
+    </message>
+    <message>
+        <source>Try the Navigation Beta</source>
+        <translation>Essayez la navigation beta</translation>
+    </message>
+    <message>
+        <source>Get turn-by-turn directions displayed and more with a comma
+prime subscription. Sign up now: https://connect.comma.ai</source>
+        <translation>Obtenez des instructions de navigation et plus encore avec un abonnement comma
+prime. Abonnez-vous maintenant : https://connect.comma.ai</translation>
+    </message>
+    <message>
+        <source>No home
+location set</source>
+        <translation>Aucun domicile défini</translation>
+    </message>
+    <message>
+        <source>No work
+location set</source>
+        <translation>Aucun lieu de travail défini</translation>
+    </message>
+    <message>
+        <source>no recent destinations</source>
+        <translation>pas de destinations récentes</translation>
+    </message>
+</context>
+<context>
+    <name>MapWindow</name>
+    <message>
+        <source>Map Loading</source>
+        <translation>Chargement de la carte</translation>
+    </message>
+    <message>
+        <source>Waiting for GPS</source>
+        <translation>En attente du GPS</translation>
+    </message>
+</context>
+<context>
+    <name>MultiOptionDialog</name>
+    <message>
+        <source>Select</source>
+        <translation>Sélectionner</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>Networking</name>
+    <message>
+        <source>Advanced</source>
+        <translation>Avancé</translation>
+    </message>
+    <message>
+        <source>Enter password</source>
+        <translation>Entrer le mot de passe</translation>
+    </message>
+    <message>
+        <source>for &quot;%1&quot;</source>
+        <translation>pour &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Wrong password</source>
+        <translation>Mot de passe incorrect</translation>
+    </message>
+</context>
+<context>
+    <name>OffroadHome</name>
+    <message>
+        <source>UPDATE</source>
+        <translation>MISE À JOUR</translation>
+    </message>
+    <message>
+        <source> ALERTS</source>
+        <translation> ALERTES</translation>
+    </message>
+    <message>
+        <source> ALERT</source>
+        <translation> ALERTE</translation>
+    </message>
+</context>
+<context>
+    <name>PairingPopup</name>
+    <message>
+        <source>Pair your device to your comma account</source>
+        <translation>Associez votre appareil à votre compte comma</translation>
+    </message>
+    <message>
+        <source>Go to https://connect.comma.ai on your phone</source>
+        <translation>Allez sur https://connect.comma.ai sur votre téléphone</translation>
+    </message>
+    <message>
+        <source>Click &quot;add new device&quot; and scan the QR code on the right</source>
+        <translation>Cliquez sur &quot;ajouter un nouvel appareil&quot; et scannez le code QR à droite</translation>
+    </message>
+    <message>
+        <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
+        <translation>Ajoutez connect.comma.ai à votre écran d&apos;accueil pour l&apos;utiliser comme une application</translation>
+    </message>
+</context>
+<context>
+    <name>ParamControl</name>
+    <message>
+        <source>Enable</source>
+        <translation>Activer</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>PrimeAdWidget</name>
+    <message>
+        <source>Upgrade Now</source>
+        <translation>Mettre à niveau maintenant</translation>
+    </message>
+    <message>
+        <source>Become a comma prime member at connect.comma.ai</source>
+        <translation>Devenez membre comma prime sur connect.comma.ai</translation>
+    </message>
+    <message>
+        <source>PRIME FEATURES:</source>
+        <translation>FONCTIONNALITÉS PRIME :</translation>
+    </message>
+    <message>
+        <source>Remote access</source>
+        <translation>Accès à distance</translation>
+    </message>
+    <message>
+        <source>1 year of storage</source>
+        <translation>1 an de stockage</translation>
+    </message>
+    <message>
+        <source>Developer perks</source>
+        <translation>Avantages pour les développeurs</translation>
+    </message>
+</context>
+<context>
+    <name>PrimeUserWidget</name>
+    <message>
+        <source>✓ SUBSCRIBED</source>
+        <translation>✓ ABONNÉ</translation>
+    </message>
+    <message>
+        <source>comma prime</source>
+        <translation>comma prime</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Reboot</source>
+        <translation>Redémarrer</translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <translation>Quitter</translation>
+    </message>
+    <message>
+        <source>dashcam</source>
+        <translation>dashcam</translation>
+    </message>
+    <message>
+        <source>openpilot</source>
+        <translation>openpilot</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation>
+            <numerusform>il y a %n minute</numerusform>
+            <numerusform>il y a %n minutes</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation>
+            <numerusform>il y a %n heure</numerusform>
+            <numerusform>il y a %n heures</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation>
+            <numerusform>il y a %n jour</numerusform>
+            <numerusform>il y a %n jours</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>Reset</name>
+    <message>
+        <source>Reset failed. Reboot to try again.</source>
+        <translation>Réinitialisation échouée. Redémarrez pour réessayer.</translation>
+    </message>
+    <message>
+        <source>Resetting device...
+This may take up to a minute.</source>
+        <translation>Réinitialisation de l&apos;appareil...
+Cela peut prendre jusqu&apos;à une minute.</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to reset your device?</source>
+        <translation>Êtes-vous sûr de vouloir réinitialiser votre appareil ?</translation>
+    </message>
+    <message>
+        <source>System Reset</source>
+        <translation>Réinitialisation du système</translation>
+    </message>
+    <message>
+        <source>Press confirm to erase all content and settings. Press cancel to resume boot.</source>
+        <translation>Appuyez sur confirmer pour effacer tout le contenu et les paramètres. Appuyez sur annuler pour reprendre le démarrage.</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <source>Reboot</source>
+        <translation>Redémarrer</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>Confirmer</translation>
+    </message>
+    <message>
+        <source>Unable to mount data partition. Partition may be corrupted. Press confirm to erase and reset your device.</source>
+        <translation>Impossible de monter la partition data. La partition peut être corrompue. Appuyez sur confirmer pour effacer et réinitialiser votre appareil.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>×</source>
+        <translation>×</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>Appareil</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation>Réseau</translation>
+    </message>
+    <message>
+        <source>Toggles</source>
+        <translation>Options</translation>
+    </message>
+    <message>
+        <source>Software</source>
+        <translation>Logiciel</translation>
+    </message>
+    <message>
+        <source>Navigation</source>
+        <translation>Navigation</translation>
+    </message>
+</context>
+<context>
+    <name>Setup</name>
+    <message>
+        <source>Something went wrong. Reboot the device.</source>
+        <translation>Un problème est survenu. Redémarrez l&apos;appareil.</translation>
+    </message>
+    <message>
+        <source>Ensure the entered URL is valid, and the device’s internet connection is good.</source>
+        <translation>Assurez-vous que l&apos;URL saisie est valide et que la connexion internet de l&apos;appareil est bonne.</translation>
+    </message>
+    <message>
+        <source>No custom software found at this URL.</source>
+        <translation>Aucun logiciel personnalisé trouvé à cette URL.</translation>
+    </message>
+    <message>
+        <source>WARNING: Low Voltage</source>
+        <translation>ATTENTION : Tension faible</translation>
+    </message>
+    <message>
+        <source>Power your device in a car with a harness or proceed at your own risk.</source>
+        <translation>Alimentez votre appareil dans une voiture avec un harness ou continuez à vos risques et périls.</translation>
+    </message>
+    <message>
+        <source>Power off</source>
+        <translation>Éteindre</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <source>Getting Started</source>
+        <translation>Commencer</translation>
+    </message>
+    <message>
+        <source>Before we get on the road, let’s finish installation and cover some details.</source>
+        <translation>Avant de prendre la route, terminons l&apos;installation et passons en revue quelques détails.</translation>
+    </message>
+    <message>
+        <source>Connect to Wi-Fi</source>
+        <translation>Se connecter au Wi-Fi</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation>Retour</translation>
+    </message>
+    <message>
+        <source>Enter URL</source>
+        <translation>Entrer l&apos;URL</translation>
+    </message>
+    <message>
+        <source>for Custom Software</source>
+        <translation>pour logiciel personnalisé</translation>
+    </message>
+    <message>
+        <source>Continue without Wi-Fi</source>
+        <translation>Continuer sans Wi-Fi</translation>
+    </message>
+    <message>
+        <source>Waiting for internet</source>
+        <translation>En attente d&apos;internet</translation>
+    </message>
+    <message>
+        <source>Downloading...</source>
+        <translation>Téléchargement...</translation>
+    </message>
+    <message>
+        <source>Download Failed</source>
+        <translation>Échec du téléchargement</translation>
+    </message>
+    <message>
+        <source>Reboot device</source>
+        <translation>Redémarrer l&apos;appareil</translation>
+    </message>
+    <message>
+        <source>Start over</source>
+        <translation>Recommencer</translation>
+    </message>
+</context>
+<context>
+    <name>SetupWidget</name>
+    <message>
+        <source>Finish Setup</source>
+        <translation>Terminer l&apos;installation</translation>
+    </message>
+    <message>
+        <source>Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer.</source>
+        <translation>Associez votre appareil avec comma connect (connect.comma.ai) et profitez de l&apos;offre comma prime.</translation>
+    </message>
+    <message>
+        <source>Pair device</source>
+        <translation>Associer l&apos;appareil</translation>
+    </message>
+</context>
+<context>
+    <name>Sidebar</name>
+    <message>
+        <source>CONNECT</source>
+        <translation>CONNECTER</translation>
+    </message>
+    <message>
+        <source>OFFLINE</source>
+        <translation>HORS LIGNE</translation>
+    </message>
+    <message>
+        <source>ONLINE</source>
+        <translation>EN LIGNE</translation>
+    </message>
+    <message>
+        <source>ERROR</source>
+        <translation>ERREUR</translation>
+    </message>
+    <message>
+        <source>TEMP</source>
+        <translation>TEMP</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation>HAUT</translation>
+    </message>
+    <message>
+        <source>GOOD</source>
+        <translation>BON</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>VEHICLE</source>
+        <translation>VÉHICULE</translation>
+    </message>
+    <message>
+        <source>NO</source>
+        <translation>NON</translation>
+    </message>
+    <message>
+        <source>PANDA</source>
+        <translation>PANDA</translation>
+    </message>
+    <message>
+        <source>GPS</source>
+        <translation>GPS</translation>
+    </message>
+    <message>
+        <source>SEARCH</source>
+        <translation>RECHERCHE</translation>
+    </message>
+    <message>
+        <source>--</source>
+        <translation>--</translation>
+    </message>
+    <message>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
+    </message>
+    <message>
+        <source>ETH</source>
+        <translation>ETH</translation>
+    </message>
+    <message>
+        <source>2G</source>
+        <translation>2G</translation>
+    </message>
+    <message>
+        <source>3G</source>
+        <translation>3G</translation>
+    </message>
+    <message>
+        <source>LTE</source>
+        <translation>LTE</translation>
+    </message>
+    <message>
+        <source>5G</source>
+        <translation>5G</translation>
+    </message>
+</context>
+<context>
+    <name>SoftwarePanel</name>
+    <message>
+        <source>Updates are only downloaded while the car is off.</source>
+        <translation>Les mises à jour sont téléchargées uniquement lorsque la voiture est éteinte.</translation>
+    </message>
+    <message>
+        <source>Current Version</source>
+        <translation>Version actuelle</translation>
+    </message>
+    <message>
+        <source>Download</source>
+        <translation>Télécharger</translation>
+    </message>
+    <message>
+        <source>CHECK</source>
+        <translation>VÉRIFIER</translation>
+    </message>
+    <message>
+        <source>Install Update</source>
+        <translation>Installer la mise à jour</translation>
+    </message>
+    <message>
+        <source>INSTALL</source>
+        <translation>INSTALLER</translation>
+    </message>
+    <message>
+        <source>Target Branch</source>
+        <translation>Branche cible</translation>
+    </message>
+    <message>
+        <source>SELECT</source>
+        <translation>SÉLECTIONNER</translation>
+    </message>
+    <message>
+        <source>Select a branch</source>
+        <translation>Sélectionner une branche</translation>
+    </message>
+    <message>
+        <source>Uninstall %1</source>
+        <translation>Désinstaller %1</translation>
+    </message>
+    <message>
+        <source>UNINSTALL</source>
+        <translation>DÉSINSTALLER</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to uninstall?</source>
+        <translation>Êtes-vous sûr de vouloir désinstaller ?</translation>
+    </message>
+    <message>
+        <source>Uninstall</source>
+        <translation>Désinstaller</translation>
+    </message>
+    <message>
+        <source>failed to check for update</source>
+        <translation>échec de la vérification de la mise à jour</translation>
+    </message>
+    <message>
+        <source>DOWNLOAD</source>
+        <translation>TÉLÉCHARGER</translation>
+    </message>
+    <message>
+        <source>update available</source>
+        <translation>mise à jour disponible</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>jamais</translation>
+    </message>
+    <message>
+        <source>up to date, last checked %1</source>
+        <translation>à jour, dernière vérification %1</translation>
+    </message>
+</context>
+<context>
+    <name>SshControl</name>
+    <message>
+        <source>SSH Keys</source>
+        <translation>Clés SSH</translation>
+    </message>
+    <message>
+        <source>Warning: This grants SSH access to all public keys in your GitHub settings. Never enter a GitHub username other than your own. A comma employee will NEVER ask you to add their GitHub username.</source>
+        <translation>Attention : Ceci accorde l&apos;accès SSH à toutes les clés publiques de vos paramètres GitHub. N&apos;entrez jamais un nom d&apos;utilisateur GitHub autre que le vôtre. Un employé de comma ne vous demandera JAMAIS d&apos;ajouter son nom d&apos;utilisateur GitHub.</translation>
+    </message>
+    <message>
+        <source>ADD</source>
+        <translation>AJOUTER</translation>
+    </message>
+    <message>
+        <source>Enter your GitHub username</source>
+        <translation>Entrez votre nom d&apos;utilisateur GitHub</translation>
+    </message>
+    <message>
+        <source>LOADING</source>
+        <translation>CHARGEMENT</translation>
+    </message>
+    <message>
+        <source>REMOVE</source>
+        <translation>SUPPRIMER</translation>
+    </message>
+    <message>
+        <source>Username &apos;%1&apos; has no keys on GitHub</source>
+        <translation>L&apos;utilisateur &apos;%1&apos; n&apos;a pas de clés sur GitHub</translation>
+    </message>
+    <message>
+        <source>Request timed out</source>
+        <translation>Délai de la demande dépassé</translation>
+    </message>
+    <message>
+        <source>Username &apos;%1&apos; doesn&apos;t exist on GitHub</source>
+        <translation>L&apos;utilisateur &apos;%1&apos; n&apos;existe pas sur GitHub</translation>
+    </message>
+</context>
+<context>
+    <name>SshToggle</name>
+    <message>
+        <source>Enable SSH</source>
+        <translation>Activer SSH</translation>
+    </message>
+</context>
+<context>
+    <name>TermsPage</name>
+    <message>
+        <source>Terms &amp; Conditions</source>
+        <translation>Termes &amp; Conditions</translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation>Refuser</translation>
+    </message>
+    <message>
+        <source>Scroll to accept</source>
+        <translation>Faire défiler pour accepter</translation>
+    </message>
+    <message>
+        <source>Agree</source>
+        <translation>Accepter</translation>
+    </message>
+</context>
+<context>
+    <name>TogglesPanel</name>
+    <message>
+        <source>Enable openpilot</source>
+        <translation>Activer openpilot</translation>
+    </message>
+    <message>
+        <source>Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off.</source>
+        <translation>Utilisez le système openpilot pour le régulateur de vitesse adaptatif et l&apos;assistance au maintien de voie. Votre attention est requise en permanence pour utiliser cette fonctionnalité. La modification de ce paramètre prend effet lorsque la voiture est éteinte.</translation>
+    </message>
+    <message>
+        <source>openpilot Longitudinal Control (Alpha)</source>
+        <translation>Contrôle longitudinal openpilot (Alpha)</translation>
+    </message>
+    <message>
+        <source>WARNING: openpilot longitudinal control is in alpha for this car and will disable Automatic Emergency Braking (AEB).</source>
+        <translation>ATTENTION : le contrôle longitudinal openpilot est en alpha pour cette voiture et désactivera le freinage d&apos;urgence automatique (AEB).</translation>
+    </message>
+    <message>
+        <source>On this car, openpilot defaults to the car&apos;s built-in ACC instead of openpilot&apos;s longitudinal control. Enable this to switch to openpilot longitudinal control. Enabling Experimental mode is recommended when enabling openpilot longitudinal control alpha.</source>
+        <translation>Sur cette voiture, openpilot utilise par défaut le régulateur de vitesse adaptatif intégré à la voiture plutôt que le contrôle longitudinal d&apos;openpilot. Activez ceci pour passer au contrôle longitudinal openpilot. Il est recommandé d&apos;activer le mode expérimental lors de l&apos;activation du contrôle longitudinal openpilot alpha.</translation>
+    </message>
+    <message>
+        <source>Experimental Mode</source>
+        <translation>Mode expérimental</translation>
+    </message>
+    <message>
+        <source>Disengage on Accelerator Pedal</source>
+        <translation>Désengager avec la pédale d&apos;accélérateur</translation>
+    </message>
+    <message>
+        <source>When enabled, pressing the accelerator pedal will disengage openpilot.</source>
+        <translation>Lorsqu&apos;il est activé, appuyer sur la pédale d&apos;accélérateur désengagera openpilot.</translation>
+    </message>
+    <message>
+        <source>Enable Lane Departure Warnings</source>
+        <translation>Activer les avertissements de sortie de voie</translation>
+    </message>
+    <message>
+        <source>Receive alerts to steer back into the lane when your vehicle drifts over a detected lane line without a turn signal activated while driving over 31 mph (50 km/h).</source>
+        <translation>Recevez des alertes pour revenir dans la voie lorsque votre véhicule dérive au-delà d&apos;une ligne de voie détectée sans clignotant activé en roulant à plus de 31 mph (50 km/h).</translation>
+    </message>
+    <message>
+        <source>Record and Upload Driver Camera</source>
+        <translation>Enregistrer et télécharger la caméra conducteur</translation>
+    </message>
+    <message>
+        <source>Upload data from the driver facing camera and help improve the driver monitoring algorithm.</source>
+        <translation>Publiez les données de la caméra orientée vers le conducteur et aidez à améliorer l&apos;algorithme de surveillance du conducteur.</translation>
+    </message>
+    <message>
+        <source>Use Metric System</source>
+        <translation>Utiliser le système métrique</translation>
+    </message>
+    <message>
+        <source>Display speed in km/h instead of mph.</source>
+        <translation>Afficher la vitesse en km/h au lieu de mph.</translation>
+    </message>
+    <message>
+        <source>Show ETA in 24h Format</source>
+        <translation>Afficher l&apos;heure d&apos;arrivée en format 24h</translation>
+    </message>
+    <message>
+        <source>Use 24h format instead of am/pm</source>
+        <translation>Utiliser le format 24h plutôt que am/pm</translation>
+    </message>
+    <message>
+        <source>Show Map on Left Side of UI</source>
+        <translation>Afficher la carte à gauche de l&apos;interface</translation>
+    </message>
+    <message>
+        <source>Show map on left side when in split screen view.</source>
+        <translation>Afficher la carte à gauche en mode écran scindé.</translation>
+    </message>
+    <message>
+        <source>Aggressive</source>
+        <translation>Aggressif</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <source>Relaxed</source>
+        <translation>Détendu</translation>
+    </message>
+    <message>
+        <source>Driving Personality</source>
+        <translation>Personnalité de conduite</translation>
+    </message>
+    <message>
+        <source>Standard is recommended. In aggressive mode, openpilot will follow lead cars closer and be more aggressive with the gas and brake. In relaxed mode openpilot will stay further away from lead cars.</source>
+        <translation>Le mode standard est recommandé. En mode agressif, openpilot suivra de plus près les voitures de tête et sera plus agressif avec l&apos;accélérateur et le frein. En mode détendu, openpilot restera plus éloigné des voitures de tête.</translation>
+    </message>
+    <message>
+        <source>openpilot defaults to driving in &lt;b&gt;chill mode&lt;/b&gt;. Experimental mode enables &lt;b&gt;alpha-level features&lt;/b&gt; that aren&apos;t ready for chill mode. Experimental features are listed below:</source>
+        <translation>Par défaut, openpilot conduit en &lt;b&gt;mode détente&lt;/b&gt;. Le mode expérimental permet d&apos;activer des &lt;b&gt;fonctionnalités alpha&lt;/b&gt; qui ne sont pas prêtes pour le mode détente. Les fonctionnalités expérimentales sont listées ci-dessous :</translation>
+    </message>
+    <message>
+        <source>🌮 End-to-End Longitudinal Control 🌮</source>
+        <translation>🌮 Contrôle longitudinal de bout en bout 🌮</translation>
+    </message>
+    <message>
+        <source>Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would, including stopping for red lights and stop signs. Since the driving model decides the speed to drive, the set speed will only act as an upper bound. This is an alpha quality feature; mistakes should be expected.</source>
+        <translation>Laissez le modèle de conduite contrôler l&apos;accélérateur et les freins. openpilot conduira comme il pense qu&apos;un humain le ferait, y compris s&apos;arrêter aux feux rouges et aux panneaux stop. Comme le modèle de conduite décide de la vitesse à adopter, la vitesse définie ne servira que de limite supérieure. Cette fonctionnalité est de qualité alpha ; des erreurs sont à prévoir.</translation>
+    </message>
+    <message>
+        <source>New Driving Visualization</source>
+        <translation>Nouvelle visualisation de la conduite</translation>
+    </message>
+    <message>
+        <source>The driving visualization will transition to the road-facing wide-angle camera at low speeds to better show some turns. The Experimental mode logo will also be shown in the top right corner.</source>
+        <translation>À faible vitesse, la visualisation de la conduite utilisera la caméra à grand angle orientée vers la route pour mieux montrer certains virages. Le logo du mode expérimental sera également affiché dans le coin supérieur droit.</translation>
+    </message>
+    <message>
+        <source>Experimental mode is currently unavailable on this car since the car&apos;s stock ACC is used for longitudinal control.</source>
+        <translation>Le mode expérimental est actuellement indisponible pour cette voiture car le régulateur de vitesse adaptatif d&apos;origine est utilisé pour le contrôle longitudinal.</translation>
+    </message>
+    <message>
+        <source>openpilot longitudinal control may come in a future update.</source>
+        <translation>Le contrôle longitudinal openpilot pourrait être disponible dans une future mise à jour.</translation>
+    </message>
+    <message>
+        <source>An alpha version of openpilot longitudinal control can be tested, along with Experimental mode, on non-release branches.</source>
+        <translation>Une version alpha du contrôle longitudinal openpilot peut être testée, avec le mode expérimental, sur des branches non publiées.</translation>
+    </message>
+    <message>
+        <source>Enable experimental longitudinal control to allow Experimental mode.</source>
+        <translation>Activez le contrôle longitudinal expérimental pour permettre le mode expérimental.</translation>
+    </message>
+</context>
+<context>
+    <name>Updater</name>
+    <message>
+        <source>Update Required</source>
+        <translation>Mise à jour requise</translation>
+    </message>
+    <message>
+        <source>An operating system update is required. Connect your device to Wi-Fi for the fastest update experience. The download size is approximately 1GB.</source>
+        <translation>Une mise à jour du système d&apos;exploitation est requise. Connectez votre appareil au Wi-Fi pour une mise à jour plus rapide. La taille du téléchargement est d&apos;environ 1 Go.</translation>
+    </message>
+    <message>
+        <source>Connect to Wi-Fi</source>
+        <translation>Se connecter au Wi-Fi</translation>
+    </message>
+    <message>
+        <source>Install</source>
+        <translation>Installer</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation>Retour</translation>
+    </message>
+    <message>
+        <source>Loading...</source>
+        <translation>Chargement...</translation>
+    </message>
+    <message>
+        <source>Reboot</source>
+        <translation>Redémarrer</translation>
+    </message>
+    <message>
+        <source>Update failed</source>
+        <translation>Échec de la mise à jour</translation>
+    </message>
+</context>
+<context>
+    <name>WiFiPromptWidget</name>
+    <message>
+        <source>Setup Wi-Fi</source>
+        <translation>Configurer le Wi-Fi</translation>
+    </message>
+    <message>
+        <source>Connect to Wi-Fi to upload driving data and help improve openpilot</source>
+        <translation>Connectez-vous au Wi-Fi pour publier les données de conduite et aider à améliorer openpilot</translation>
+    </message>
+    <message>
+        <source>Open Settings</source>
+        <translation>Ouvrir les paramètres</translation>
+    </message>
+    <message>
+        <source>Uploading training data</source>
+        <translation>Téléchargement des données d&apos;entraînement</translation>
+    </message>
+    <message>
+        <source>Your data is used to train driving models and help improve openpilot</source>
+        <translation>Vos données sont utilisées pour former des modèles de conduite et aider à améliorer openpilot</translation>
+    </message>
+</context>
+<context>
+    <name>WifiUI</name>
+    <message>
+        <source>Scanning for networks...</source>
+        <translation>Recherche de réseaux...</translation>
+    </message>
+    <message>
+        <source>CONNECTING...</source>
+        <translation>CONNEXION...</translation>
+    </message>
+    <message>
+        <source>FORGET</source>
+        <translation>OUBLIER</translation>
+    </message>
+    <message>
+        <source>Forget Wi-Fi Network &quot;%1&quot;?</source>
+        <translation>Oublier le réseau Wi-Fi &quot;%1&quot; ?</translation>
+    </message>
+    <message>
+        <source>Forget</source>
+        <translation>Oublier</translation>
+    </message>
+</context>
+</TS>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -117,6 +117,33 @@
     </message>
 </context>
 <context>
+    <name>DestinationWidget</name>
+    <message>
+        <source>Home</source>
+        <translation>Domicile</translation>
+    </message>
+    <message>
+        <source>Work</source>
+        <translation>Travail</translation>
+    </message>
+    <message>
+        <source>No destination set</source>
+        <translation>Aucune destination définie</translation>
+    </message>
+    <message>
+        <source>home</source>
+        <translation>domicile</translation>
+    </message>
+    <message>
+        <source>work</source>
+        <translation>travail</translation>
+    </message>
+    <message>
+        <source>No %1 location set</source>
+        <translation>Aucun lieu %1 défini</translation>
+    </message>
+</context>
+<context>
     <name>DevicePanel</name>
     <message>
         <source>Dongle ID</source>
@@ -356,42 +383,14 @@
     </message>
 </context>
 <context>
-    <name>MapPanel</name>
+    <name>MapSettings</name>
     <message>
-        <source>Current Destination</source>
-        <translation>Destination actuelle</translation>
+        <source>NAVIGATION</source>
+        <translation>NAVIGATION</translation>
     </message>
     <message>
-        <source>CLEAR</source>
-        <translation>EFFACER</translation>
-    </message>
-    <message>
-        <source>Recent Destinations</source>
-        <translation>Destinations récentes</translation>
-    </message>
-    <message>
-        <source>Try the Navigation Beta</source>
-        <translation>Essayez la navigation beta</translation>
-    </message>
-    <message>
-        <source>Get turn-by-turn directions displayed and more with a comma
-prime subscription. Sign up now: https://connect.comma.ai</source>
-        <translation>Obtenez des instructions de navigation et plus encore avec un abonnement comma
-prime. Abonnez-vous maintenant : https://connect.comma.ai</translation>
-    </message>
-    <message>
-        <source>No home
-location set</source>
-        <translation>Aucun domicile défini</translation>
-    </message>
-    <message>
-        <source>No work
-location set</source>
-        <translation>Aucun lieu de travail défini</translation>
-    </message>
-    <message>
-        <source>no recent destinations</source>
-        <translation>pas de destinations récentes</translation>
+        <source>Manage at connect.comma.ai</source>
+        <translation>Gérer sur connect.comma.ai</translation>
     </message>
 </context>
 <context>
@@ -403,6 +402,10 @@ location set</source>
     <message>
         <source>Waiting for GPS</source>
         <translation>En attente du GPS</translation>
+    </message>
+    <message>
+        <source>Waiting for route</source>
+        <translation>En attente d&apos;un trajet</translation>
     </message>
 </context>
 <context>
@@ -433,6 +436,63 @@ location set</source>
     <message>
         <source>Wrong password</source>
         <translation>Mot de passe incorrect</translation>
+    </message>
+</context>
+<context>
+    <name>OffroadAlert</name>
+    <message>
+        <source>Device temperature too high. System cooling down before starting. Current internal component temperature: %1</source>
+        <translation>Température de l&apos;appareil trop élevée. Le système doit refroidir avant de démarrer. Température actuelle de l&apos;appareil : %1</translation>
+    </message>
+    <message>
+        <source>Immediately connect to the internet to check for updates. If you do not connect to the internet, openpilot won&apos;t engage in %1</source>
+        <translation>Connectez-vous immédiatement à internet pour vérifier les mises à jour. Si vous ne vous connectez pas à internet, openpilot ne s&apos;engagera pas dans %1</translation>
+    </message>
+    <message>
+        <source>Connect to internet to check for updates. openpilot won&apos;t automatically start until it connects to internet to check for updates.</source>
+        <translation>Connectez l&apos;appareil à internet pour vérifier les mises à jour. openpilot ne démarrera pas automatiquement tant qu&apos;il ne se connecte pas à internet pour vérifier les mises à jour.</translation>
+    </message>
+    <message>
+        <source>Unable to download updates
+%1</source>
+        <translation>Impossible de télécharger les mises à jour
+%1</translation>
+    </message>
+    <message>
+        <source>Invalid date and time settings, system won&apos;t start. Connect to internet to set time.</source>
+        <translation>Paramètres de date et d&apos;heure invalides, le système ne démarrera pas. Connectez l&apos;appareil à Internet pour régler l&apos;heure.</translation>
+    </message>
+    <message>
+        <source>Taking camera snapshots. System won&apos;t start until finished.</source>
+        <translation>Capture de clichés photo. Le système ne démarrera pas tant qu&apos;il n&apos;est pas terminé.</translation>
+    </message>
+    <message>
+        <source>An update to your device&apos;s operating system is downloading in the background. You will be prompted to update when it&apos;s ready to install.</source>
+        <translation>Une mise à jour du système d&apos;exploitation de votre appareil est en cours de téléchargement en arrière-plan. Vous serez invité à effectuer la mise à jour lorsqu&apos;elle sera prête à être installée.</translation>
+    </message>
+    <message>
+        <source>Device failed to register. It will not connect to or upload to comma.ai servers, and receives no support from comma.ai. If this is an official device, visit https://comma.ai/support.</source>
+        <translation>L&apos;appareil n&apos;a pas réussi à s&apos;enregistrer. Il ne se connectera pas aux serveurs de comma.ai, n&apos;enverra rien et ne recevra aucune assistance de comma.ai. S&apos;il s&apos;agit d&apos;un appareil officiel, visitez https://comma.ai/support.</translation>
+    </message>
+    <message>
+        <source>NVMe drive not mounted.</source>
+        <translation>Le disque NVMe n&apos;est pas monté.</translation>
+    </message>
+    <message>
+        <source>Unsupported NVMe drive detected. Device may draw significantly more power and overheat due to the unsupported NVMe.</source>
+        <translation>Disque NVMe non supporté détecté. L&apos;appareil peut consommer beaucoup plus d&apos;énergie et surchauffer en raison du NVMe non supporté.</translation>
+    </message>
+    <message>
+        <source>openpilot was unable to identify your car. Your car is either unsupported or its ECUs are not recognized. Please submit a pull request to add the firmware versions to the proper vehicle. Need help? Join discord.comma.ai.</source>
+        <translation>openpilot n&apos;a pas pu identifier votre voiture. Votre voiture n&apos;est pas supportée ou ses ECUs ne sont pas reconnues. Veuillez soumettre un pull request pour ajouter les versions de firmware au véhicule approprié. Besoin d&apos;aide ? Rejoignez discord.comma.ai.</translation>
+    </message>
+    <message>
+        <source>openpilot was unable to identify your car. Check integrity of cables and ensure all connections are secure, particularly that the comma power is fully inserted in the OBD-II port of the vehicle. Need help? Join discord.comma.ai.</source>
+        <translation>openpilot n&apos;a pas pu identifier votre voiture. Vérifiez l&apos;intégrité des câbles et assurez-vous que toutes les connexions sont correctes, en particulier l&apos;alimentation du comma est totalement insérée dans le port OBD-II du véhicule. Besoin d&apos;aide ? Rejoignez discord.comma.ai.</translation>
+    </message>
+    <message>
+        <source>openpilot detected a change in the device&apos;s mounting position. Ensure the device is fully seated in the mount and the mount is firmly secured to the windshield.</source>
+        <translation>openpilot a détecté un changement dans la position de montage de l&apos;appareil. Assurez-vous que l&apos;appareil est totalement inséré dans le support et que le support est fermement fixé au pare-brise.</translation>
     </message>
 </context>
 <context>
@@ -499,12 +559,16 @@ location set</source>
         <translation>Accès à distance</translation>
     </message>
     <message>
-        <source>1 year of storage</source>
-        <translation>1 an de stockage</translation>
+        <source>24/7 LTE connectivity</source>
+        <translation>Connexion LTE 24/7</translation>
     </message>
     <message>
-        <source>Developer perks</source>
-        <translation>Avantages pour les développeurs</translation>
+        <source>1 year of drive storage</source>
+        <translation>1 an de stockage de trajets</translation>
+    </message>
+    <message>
+        <source>Turn-by-turn navigation</source>
+        <translation>Navigation étape par étape</translation>
     </message>
 </context>
 <context>
@@ -620,10 +684,6 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
     <message>
         <source>Software</source>
         <translation>Logiciel</translation>
-    </message>
-    <message>
-        <source>Navigation</source>
-        <translation>Navigation</translation>
     </message>
 </context>
 <context>
@@ -1042,20 +1102,12 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation>Par défaut, openpilot conduit en &lt;b&gt;mode détente&lt;/b&gt;. Le mode expérimental permet d&apos;activer des &lt;b&gt;fonctionnalités alpha&lt;/b&gt; qui ne sont pas prêtes pour le mode détente. Les fonctionnalités expérimentales sont listées ci-dessous :</translation>
     </message>
     <message>
-        <source>🌮 End-to-End Longitudinal Control 🌮</source>
-        <translation>🌮 Contrôle longitudinal de bout en bout 🌮</translation>
-    </message>
-    <message>
         <source>Let the driving model control the gas and brakes. openpilot will drive as it thinks a human would, including stopping for red lights and stop signs. Since the driving model decides the speed to drive, the set speed will only act as an upper bound. This is an alpha quality feature; mistakes should be expected.</source>
         <translation>Laissez le modèle de conduite contrôler l&apos;accélérateur et les freins. openpilot conduira comme il pense qu&apos;un humain le ferait, y compris s&apos;arrêter aux feux rouges et aux panneaux stop. Comme le modèle de conduite décide de la vitesse à adopter, la vitesse définie ne servira que de limite supérieure. Cette fonctionnalité est de qualité alpha ; des erreurs sont à prévoir.</translation>
     </message>
     <message>
         <source>New Driving Visualization</source>
         <translation>Nouvelle visualisation de la conduite</translation>
-    </message>
-    <message>
-        <source>The driving visualization will transition to the road-facing wide-angle camera at low speeds to better show some turns. The Experimental mode logo will also be shown in the top right corner.</source>
-        <translation>À faible vitesse, la visualisation de la conduite utilisera la caméra à grand angle orientée vers la route pour mieux montrer certains virages. Le logo du mode expérimental sera également affiché dans le coin supérieur droit.</translation>
     </message>
     <message>
         <source>Experimental mode is currently unavailable on this car since the car&apos;s stock ACC is used for longitudinal control.</source>
@@ -1070,8 +1122,24 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation>Une version alpha du contrôle longitudinal openpilot peut être testée, avec le mode expérimental, sur des branches non publiées.</translation>
     </message>
     <message>
-        <source>Enable experimental longitudinal control to allow Experimental mode.</source>
-        <translation>Activez le contrôle longitudinal expérimental pour permettre le mode expérimental.</translation>
+        <source>End-to-End Longitudinal Control</source>
+        <translation>Contrôle longitudinal de bout en bout</translation>
+    </message>
+    <message>
+        <source>Navigate on openpilot</source>
+        <translation>Navigation avec openpilot</translation>
+    </message>
+    <message>
+        <source>When navigation has a destination, openpilot will input the map information into the model. This provides useful context for the model and allows openpilot to keep left or right appropriately at forks/exits. Lane change behavior is unchanged and still activated by the driver. This is an alpha quality feature; mistakes should be expected, particularly around exits and forks. These mistakes can include unintended laneline crossings, late exit taking, driving towards dividing barriers in the gore areas, etc.</source>
+        <translation>Lorsque la navigation dispose d&apos;une destination, openpilot entrera les informations de la carte dans le modèle. Cela fournit un contexte utile pour le modèle et permet à openpilot de se diriger à gauche ou à droite de manière appropriée aux bifurcations/sorties. Le comportement relatif au changement de voie reste inchangé et doit toujours être activé par le conducteur. Il s&apos;agit d&apos;une fonctionnalité alpha ; il faut s&apos;attendre à des erreurs, en particulier aux abords des sorties et des bifurcations. Ces erreurs peuvent inclure des franchissements involontaires de passages piétons, des prises de sortie tardives, la conduite vers des zones de séparation de type zebras, etc.</translation>
+    </message>
+    <message>
+        <source>The driving visualization will transition to the road-facing wide-angle camera at low speeds to better show some turns. The Experimental mode logo will also be shown in the top right corner. When a navigation destination is set and the driving model is using it as input, the driving path on the map will turn green.</source>
+        <translation>La visualisation de la conduite passera sur la caméra grand angle dirigée vers la route à faible vitesse afin de mieux montrer certains virages. Le logo du mode expérimental s&apos;affichera également dans le coin supérieur droit. Lorsqu&apos;une destination de navigation est définie et que le modèle de conduite l&apos;utilise comme entrée, la trajectoire de conduite sur la carte deviendra verte.</translation>
+    </message>
+    <message>
+        <source>Enable the openpilot longitudinal control (alpha) toggle to allow Experimental mode.</source>
+        <translation>Activer le contrôle longitudinal d&apos;openpilot (en alpha) pour autoriser le mode expérimental.</translation>
     </message>
 </context>
 <context>
@@ -1124,12 +1192,12 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation>Ouvrir les paramètres</translation>
     </message>
     <message>
-        <source>Uploading training data</source>
-        <translation>Téléchargement des données d&apos;entraînement</translation>
+        <source>Ready to upload</source>
+        <translation>Prêt à uploader</translation>
     </message>
     <message>
-        <source>Your data is used to train driving models and help improve openpilot</source>
-        <translation>Vos données sont utilisées pour former des modèles de conduite et aider à améliorer openpilot</translation>
+        <source>Training data will be pulled periodically while your device is on Wi-Fi</source>
+        <translation>Les données d&apos;entraînement seront envoyées périodiquement lorsque votre appareil est connecté au réseau Wi-Fi</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Hi,

After a failed attempt, I finally translated the Openpilot UI into French to improve accessibility for French-speaking users. The translation covers all UI elements to ensure a fully localized user experience. I've also incorporated @maxime-desroches and @nworb-cire 's comments and completed the missing translations since then.

### Verification

I've thoroughly tested the translated software by running it in the test scripts and cross-checking all translated texts with their English counterparts. No issues with character encoding or text overflow in the UI were found. Furthermore, I'm a native French-speaking and regular user of openpilot, so I can confirm the appropriateness of the translations. However, to err is human, so you're welcome to correct any mistakes.

### Additional remarks

During my translation and testing, I noticed that some interface elements were not localized, such as the guide, certain messages in the "software" section like "checking," "downloading," "finalizing update," as well as all messages that appear during driving like "Experimental Branch," "Reverse Gear," etc.

K.