### PR TITLE
CI: use buildjet for process replay

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -284,12 +284,14 @@ jobs:
 
   process_replay:
     name: process replay
-    runs-on: ubuntu-20.04
+    runs-on: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: ./.github/workflows/setup
+      with:
+        is_buildjet: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'true' || 'false' }}
     - name: Cache test routes
       id: dependency-cache
       uses: actions/cache@v3
@@ -355,7 +357,7 @@ jobs:
 
   test_cars:
     name: cars
-    runs-on: ubuntu-20.04
+    runs-on: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -365,6 +367,8 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/workflows/setup
+      with:
+        is_buildjet: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'true' || 'false' }}
     - name: Cache test routes
       id: dependency-cache
       uses: actions/cache@v3

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -357,7 +357,7 @@ jobs:
 
   test_cars:
     name: cars
-    runs-on: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
+    runs-on: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'buildjet-4vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -290,8 +290,6 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/workflows/setup
-      with:
-        is_buildjet: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'true' || 'false' }}
     - name: Cache test routes
       id: dependency-cache
       uses: actions/cache@v3
@@ -357,7 +355,7 @@ jobs:
 
   test_cars:
     name: cars
-    runs-on: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'buildjet-4vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -367,8 +365,6 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/workflows/setup
-      with:
-        is_buildjet: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'true' || 'false' }}
     - name: Cache test routes
       id: dependency-cache
       uses: actions/cache@v3

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -9,11 +9,6 @@ inputs:
     description: 'Whether or not to pull the git lfs'
     required: false
     default: 'true'
-  is_buildjet:
-    description: 'Whether or not this is a buildjet runner'
-    required: false
-    default: 'false'
-
 
 runs:
   using: "composite"
@@ -50,8 +45,8 @@ runs:
         find . -type f -executable -not -perm 755 -exec chmod 755 {} \;
         find . -type f -not -executable -not -perm 644 -exec chmod 644 {} \;
     - id: setup-buildx-action
-      if: ${{ inputs.is_buildjet == 'true' }}
-      name: Set up Docker Buildx
+      if: contains("${{runner.name}}", "buildjet")
+      name: Set up Docker Buildx on buildjet to ensure a consistent cache
       uses: docker/setup-buildx-action@v2
       with:
         driver: docker-container

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -45,7 +45,7 @@ runs:
         find . -type f -executable -not -perm 755 -exec chmod 755 {} \;
         find . -type f -not -executable -not -perm 644 -exec chmod 644 {} \;
     - id: setup-buildx-action
-      if: contains("${{runner.name}}", "buildjet")
+      if: contains(runner.name, 'buildjet')
       name: Set up Docker Buildx on buildjet to ensure a consistent cache
       uses: docker/setup-buildx-action@v2
       with:

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -9,6 +9,11 @@ inputs:
     description: 'Whether or not to pull the git lfs'
     required: false
     default: 'true'
+  is_buildjet:
+    description: 'Whether or not this is a buildjet runner'
+    required: false
+    default: 'false'
+
 
 runs:
   using: "composite"
@@ -44,6 +49,12 @@ runs:
       run: |
         find . -type f -executable -not -perm 755 -exec chmod 755 {} \;
         find . -type f -not -executable -not -perm 644 -exec chmod 644 {} \;
+    - id: setup-buildx-action
+      if: ${{ inputs.is_buildjet == 'true' }}
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver: docker-container
     # build our docker image
     - shell: bash
       run: eval ${{ env.BUILD }}

--- a/selfdrive/test/docker_build.sh
+++ b/selfdrive/test/docker_build.sh
@@ -31,7 +31,7 @@ REMOTE_SHA_TAG=$REMOTE_TAG:$COMMIT_SHA
 SCRIPT_DIR=$(dirname "$0")
 OPENPILOT_DIR=$SCRIPT_DIR/../../
 
-DOCKER_BUILDKIT=1 docker build --cache-to type=inline --cache-from type=registry,ref=$REMOTE_TAG -t $REMOTE_TAG -t $LOCAL_TAG -f $OPENPILOT_DIR/$DOCKER_FILE $OPENPILOT_DIR
+DOCKER_BUILDKIT=1 docker buildx build --load --cache-to type=inline --cache-from type=registry,ref=$REMOTE_TAG -t $REMOTE_TAG -t $LOCAL_TAG -f $OPENPILOT_DIR/$DOCKER_FILE $OPENPILOT_DIR
 
 if [[ ! -z "$PUSH_IMAGE" ]];
 then


### PR DESCRIPTION
- [ ] worth it?
- [ ] only move jobs over that are faster
- [x] do forks get charged to us? no
- [x] does fork CI just work? `runs-on` supports expressions, so we can just fallback to the normal GitHub runners
  - [ ] need a test that enforces this,  otherwise it'll break silently