### PR TITLE
interfaces: test interface attributes

### DIFF
--- a/selfdrive/car/mock/values.py
+++ b/selfdrive/car/mock/values.py
@@ -10,5 +10,3 @@ class CAR:
 CAR_INFO: Dict[str, Optional[Union[CarInfo, List[CarInfo]]]] = {
   CAR.MOCK: None,
 }
-
-DBC: Dict[str, Dict[str, str]] = {}

--- a/selfdrive/car/mock/values.py
+++ b/selfdrive/car/mock/values.py
@@ -10,3 +10,5 @@ class CAR:
 CAR_INFO: Dict[str, Optional[Union[CarInfo, List[CarInfo]]]] = {
   CAR.MOCK: None,
 }
+
+DBC: Dict[str, Dict[str, str]] = {}

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -129,8 +129,15 @@ class TestCarInterfaces(unittest.TestCase):
     self.assertEqual(len(ret), 0)
 
     # If all attributes exist, should still equal num_brands
-    ret = get_interface_attr('CAR_INFO', ignore_none=True)
-    self.assertEqual(len(ret), num_brands)
+    # ret = [brand for brand, versions in get_interface_attr('FW_VERSIONS').items() if versions is]
+    ret = get_interface_attr('FW_VERSIONS')
+    none_brands = {b for b, v in ret.items() if v is not None}
+    self.assertGreater(len(none_brands), 0)
+
+    ret = get_interface_attr('FW_VERSIONS', ignore_none=True)
+
+    none_brands_in_ret = {b for b in none_brands if b in ret}
+    self.assertEqual(len(none_brands_in_ret), 0, f'Brands with None values in ignored None result: {none_brands_in_ret}')
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -116,7 +116,7 @@ class TestCarInterfaces(unittest.TestCase):
     self.assertGreaterEqual(num_brands, 13)
 
     # Should return value for all brands when not combining
-    for attr in ('DBC', 'FAKE', 'CAR'):
+    for attr in ('DBC', 'FAKE', 'CAR_INFO'):
       ret = get_interface_attr(attr)
       self.assertEqual(len(ret), num_brands)
 

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -111,7 +111,7 @@ class TestCarInterfaces(unittest.TestCase):
       radar_interface._update([radar_interface.trigger_msg])
 
   def test_interface_attrs(self):
-    """ Asserts basic behavior of interface attribute getter """
+    """Asserts basic behavior of interface attribute getter"""
     num_brands = len(get_interface_attr('CAR'))
     self.assertGreaterEqual(num_brands, 13)
 

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -115,10 +115,9 @@ class TestCarInterfaces(unittest.TestCase):
     num_brands = len(get_interface_attr('CAR'))
     self.assertGreaterEqual(num_brands, 13)
 
-    # Should return value for all brands when not combining
-    for attr in ('DBC', 'FAKE', 'CAR_INFO'):
-      ret = get_interface_attr(attr)
-      self.assertEqual(len(ret), num_brands)
+    # Should return value for all brands when not combining, even if attribute doesn't exist
+    ret = get_interface_attr('FAKE_ATTR')
+    self.assertEqual(len(ret), num_brands)
 
     # Make sure we can combine dicts
     ret = get_interface_attr('CAR_INFO', combine_brands=True)
@@ -135,7 +134,7 @@ class TestCarInterfaces(unittest.TestCase):
     ret = get_interface_attr('FINGERPRINTS', ignore_none=True)
     none_brands_in_ret = none_brands.intersection(ret)
     self.assertEqual(len(none_brands_in_ret), 0, f'Brands with None values in ignore_none=True result: ' +
-                                                 f'{none_brands_in_ret}')
+                     f'{none_brands_in_ret}')
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -41,74 +41,74 @@ def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
 
 class TestCarInterfaces(unittest.TestCase):
 
-  # @parameterized.expand([(car,) for car in sorted(all_known_cars())])
-  # @settings(max_examples=5)
-  # @given(data=st.data())
-  # def test_car_interfaces(self, car_name, data):
-  #   CarInterface, CarController, CarState = interfaces[car_name]
-  #
-  #   args = get_fuzzy_car_interface_args(data.draw)
-  #
-  #   car_params = CarInterface.get_params(car_name, args['fingerprints'], args['car_fw'],
-  #                                        experimental_long=args['experimental_long'], docs=False)
-  #   car_interface = CarInterface(car_params, CarController, CarState)
-  #   assert car_params
-  #   assert car_interface
-  #
-  #   self.assertGreater(car_params.mass, 1)
-  #   self.assertGreater(car_params.wheelbase, 0)
-  #   # centerToFront is center of gravity to front wheels, assert a reasonable range
-  #   self.assertTrue(car_params.wheelbase * 0.3 < car_params.centerToFront < car_params.wheelbase * 0.7)
-  #   self.assertGreater(car_params.maxLateralAccel, 0)
-  #
-  #   # Longitudinal sanity checks
-  #   self.assertEqual(len(car_params.longitudinalTuning.kpV), len(car_params.longitudinalTuning.kpBP))
-  #   self.assertEqual(len(car_params.longitudinalTuning.kiV), len(car_params.longitudinalTuning.kiBP))
-  #   self.assertEqual(len(car_params.longitudinalTuning.deadzoneV), len(car_params.longitudinalTuning.deadzoneBP))
-  #
-  #   # Lateral sanity checks
-  #   if car_params.steerControlType != car.CarParams.SteerControlType.angle:
-  #     tune = car_params.lateralTuning
-  #     if tune.which() == 'pid':
-  #       self.assertTrue(not math.isnan(tune.pid.kf) and tune.pid.kf > 0)
-  #       self.assertTrue(len(tune.pid.kpV) > 0 and len(tune.pid.kpV) == len(tune.pid.kpBP))
-  #       self.assertTrue(len(tune.pid.kiV) > 0 and len(tune.pid.kiV) == len(tune.pid.kiBP))
-  #
-  #     elif tune.which() == 'torque':
-  #       self.assertTrue(not math.isnan(tune.torque.kf) and tune.torque.kf > 0)
-  #       self.assertTrue(not math.isnan(tune.torque.friction) and tune.torque.friction > 0)
-  #
-  #     elif tune.which() == 'indi':
-  #       self.assertTrue(len(tune.indi.outerLoopGainV))
-  #
-  #   cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
-  #   # Run car interface
-  #   now_nanos = 0
-  #   CC = car.CarControl.new_message(**cc_msg)
-  #   for _ in range(10):
-  #     car_interface.update(CC, [])
-  #     car_interface.apply(CC, now_nanos)
-  #     car_interface.apply(CC, now_nanos)
-  #     now_nanos += DT_CTRL * 1e9  # 10 ms
-  #
-  #   CC = car.CarControl.new_message(**cc_msg)
-  #   CC.enabled = True
-  #   for _ in range(10):
-  #     car_interface.update(CC, [])
-  #     car_interface.apply(CC, now_nanos)
-  #     car_interface.apply(CC, now_nanos)
-  #     now_nanos += DT_CTRL * 1e9  # 10ms
-  #
-  #   # Test radar interface
-  #   RadarInterface = importlib.import_module(f'selfdrive.car.{car_params.carName}.radar_interface').RadarInterface
-  #   radar_interface = RadarInterface(car_params)
-  #   assert radar_interface
-  #
-  #   # Run radar interface once
-  #   radar_interface.update([])
-  #   if not car_params.radarUnavailable and radar_interface.rcp is not None and \
-  #      hasattr(radar_interface, '_update') and hasattr(radar_interface, 'trigger_msg'):
-  #     radar_interface._update([radar_interface.trigger_msg])
+  @parameterized.expand([(car,) for car in sorted(all_known_cars())])
+  @settings(max_examples=5)
+  @given(data=st.data())
+  def test_car_interfaces(self, car_name, data):
+    CarInterface, CarController, CarState = interfaces[car_name]
+
+    args = get_fuzzy_car_interface_args(data.draw)
+
+    car_params = CarInterface.get_params(car_name, args['fingerprints'], args['car_fw'],
+                                         experimental_long=args['experimental_long'], docs=False)
+    car_interface = CarInterface(car_params, CarController, CarState)
+    assert car_params
+    assert car_interface
+
+    self.assertGreater(car_params.mass, 1)
+    self.assertGreater(car_params.wheelbase, 0)
+    # centerToFront is center of gravity to front wheels, assert a reasonable range
+    self.assertTrue(car_params.wheelbase * 0.3 < car_params.centerToFront < car_params.wheelbase * 0.7)
+    self.assertGreater(car_params.maxLateralAccel, 0)
+
+    # Longitudinal sanity checks
+    self.assertEqual(len(car_params.longitudinalTuning.kpV), len(car_params.longitudinalTuning.kpBP))
+    self.assertEqual(len(car_params.longitudinalTuning.kiV), len(car_params.longitudinalTuning.kiBP))
+    self.assertEqual(len(car_params.longitudinalTuning.deadzoneV), len(car_params.longitudinalTuning.deadzoneBP))
+
+    # Lateral sanity checks
+    if car_params.steerControlType != car.CarParams.SteerControlType.angle:
+      tune = car_params.lateralTuning
+      if tune.which() == 'pid':
+        self.assertTrue(not math.isnan(tune.pid.kf) and tune.pid.kf > 0)
+        self.assertTrue(len(tune.pid.kpV) > 0 and len(tune.pid.kpV) == len(tune.pid.kpBP))
+        self.assertTrue(len(tune.pid.kiV) > 0 and len(tune.pid.kiV) == len(tune.pid.kiBP))
+
+      elif tune.which() == 'torque':
+        self.assertTrue(not math.isnan(tune.torque.kf) and tune.torque.kf > 0)
+        self.assertTrue(not math.isnan(tune.torque.friction) and tune.torque.friction > 0)
+
+      elif tune.which() == 'indi':
+        self.assertTrue(len(tune.indi.outerLoopGainV))
+
+    cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
+    # Run car interface
+    now_nanos = 0
+    CC = car.CarControl.new_message(**cc_msg)
+    for _ in range(10):
+      car_interface.update(CC, [])
+      car_interface.apply(CC, now_nanos)
+      car_interface.apply(CC, now_nanos)
+      now_nanos += DT_CTRL * 1e9  # 10 ms
+
+    CC = car.CarControl.new_message(**cc_msg)
+    CC.enabled = True
+    for _ in range(10):
+      car_interface.update(CC, [])
+      car_interface.apply(CC, now_nanos)
+      car_interface.apply(CC, now_nanos)
+      now_nanos += DT_CTRL * 1e9  # 10ms
+
+    # Test radar interface
+    RadarInterface = importlib.import_module(f'selfdrive.car.{car_params.carName}.radar_interface').RadarInterface
+    radar_interface = RadarInterface(car_params)
+    assert radar_interface
+
+    # Run radar interface once
+    radar_interface.update([])
+    if not car_params.radarUnavailable and radar_interface.rcp is not None and \
+       hasattr(radar_interface, '_update') and hasattr(radar_interface, 'trigger_msg'):
+      radar_interface._update([radar_interface.trigger_msg])
 
   def test_interface_attrs(self):
     """ Asserts basic behavior of interface attribute getter """

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -115,21 +115,14 @@ class TestCarInterfaces(unittest.TestCase):
     num_brands = len(get_interface_attr('CAR'))
     self.assertGreaterEqual(num_brands, 13)
 
-    for attr in ('DBC', 'CAR_INFO'):
-      ret = get_interface_attr('DBC', ignore_none=True)
-      self.assertEqual(len(ret), num_brands)
-
-
-    dbc = get_interface_attr('CAR')
-    dbc = get_interface_attr('FW_VERSIONS')
-
     # Should return value for all brands when not combining
     for attr in ('DBC', 'FAKE', 'CAR'):
       ret = get_interface_attr(attr)
-      self.assertGreaterEqual(len(ret), 13)
+      self.assertEqual(len(ret), num_brands)
 
+    # Every brand must implement CAR
     ret = get_interface_attr('CAR', ignore_none=True)
-    self.assertEqual(len(ret), 13)
+    self.assertGreaterEqual(len(ret), num_brands)
 
     for attr in ('DBC', 'FAKE', 'CAR'):
       ret = get_interface_attr(attr, ignore_none=True)

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -120,8 +120,8 @@ class TestCarInterfaces(unittest.TestCase):
     self.assertEqual(len(ret), num_brands)
 
     # Make sure we can combine dicts
-    ret = get_interface_attr('CAR_INFO', combine_brands=True)
-    self.assertGreaterEqual(len(ret), 200)
+    ret = get_interface_attr('DBC', combine_brands=True)
+    self.assertGreaterEqual(len(ret), 170)
 
     # We don't support combining non-dicts
     ret = get_interface_attr('CAR', combine_brands=True)

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -112,11 +112,33 @@ class TestCarInterfaces(unittest.TestCase):
 
   def test_interface_attrs(self):
     """ Asserts basic behavior of interface attribute getter """
+    num_brands = len(get_interface_attr('CAR'))
+    self.assertGreaterEqual(num_brands, 13)
+
+    for attr in ('DBC', 'CAR_INFO'):
+      ret = get_interface_attr('DBC', ignore_none=True)
+      self.assertEqual(len(ret), num_brands)
+
+
+    dbc = get_interface_attr('CAR')
+    dbc = get_interface_attr('FW_VERSIONS')
+
     # Should return value for all brands when not combining
     for attr in ('DBC', 'FAKE', 'CAR'):
       ret = get_interface_attr(attr)
       self.assertGreaterEqual(len(ret), 13)
 
+    ret = get_interface_attr('CAR', ignore_none=True)
+    self.assertEqual(len(ret), 13)
+
+    for attr in ('DBC', 'FAKE', 'CAR'):
+      ret = get_interface_attr(attr, ignore_none=True)
+      self.assertGreaterEqual(len(ret), 13)
+
+    ret = get_interface_attr('FW_VERSIONS')
+    self.assertTrue(all(len(i) for i in ret.values()))
+
+#'FW_VERSIONS', 'FINGERPRINTS', 'CAR_INFO'
     ret = get_interface_attr('DBC', combine_brands=True)
     self.assertGreaterEqual(len(ret), 170)
     ret = get_interface_attr('FAKE', combine_brands=True)
@@ -126,7 +148,7 @@ class TestCarInterfaces(unittest.TestCase):
     ret = get_interface_attr('CAR', combine_brands=True)
     self.assertGreaterEqual(len(ret), 0)
 
-    ret = get_interface_attr('FW_VERSIONS', combine_brands=True, file='fingerprints')
+    ret = get_interface_attr('FW_VERSIONS', combine_brands=True)
     self.assertGreaterEqual(len(ret), 190)
 
 

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -11,6 +11,7 @@ from common.realtime import DT_CTRL
 from selfdrive.car import gen_empty_fingerprint
 from selfdrive.car.car_helpers import interfaces
 from selfdrive.car.fingerprints import all_known_cars
+from selfdrive.car.interfaces import get_interface_attr
 from selfdrive.test.fuzzy_generation import DrawType, FuzzyGenerator
 
 
@@ -40,74 +41,94 @@ def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
 
 class TestCarInterfaces(unittest.TestCase):
 
-  @parameterized.expand([(car,) for car in sorted(all_known_cars())])
-  @settings(max_examples=5)
-  @given(data=st.data())
-  def test_car_interfaces(self, car_name, data):
-    CarInterface, CarController, CarState = interfaces[car_name]
+  # @parameterized.expand([(car,) for car in sorted(all_known_cars())])
+  # @settings(max_examples=5)
+  # @given(data=st.data())
+  # def test_car_interfaces(self, car_name, data):
+  #   CarInterface, CarController, CarState = interfaces[car_name]
+  #
+  #   args = get_fuzzy_car_interface_args(data.draw)
+  #
+  #   car_params = CarInterface.get_params(car_name, args['fingerprints'], args['car_fw'],
+  #                                        experimental_long=args['experimental_long'], docs=False)
+  #   car_interface = CarInterface(car_params, CarController, CarState)
+  #   assert car_params
+  #   assert car_interface
+  #
+  #   self.assertGreater(car_params.mass, 1)
+  #   self.assertGreater(car_params.wheelbase, 0)
+  #   # centerToFront is center of gravity to front wheels, assert a reasonable range
+  #   self.assertTrue(car_params.wheelbase * 0.3 < car_params.centerToFront < car_params.wheelbase * 0.7)
+  #   self.assertGreater(car_params.maxLateralAccel, 0)
+  #
+  #   # Longitudinal sanity checks
+  #   self.assertEqual(len(car_params.longitudinalTuning.kpV), len(car_params.longitudinalTuning.kpBP))
+  #   self.assertEqual(len(car_params.longitudinalTuning.kiV), len(car_params.longitudinalTuning.kiBP))
+  #   self.assertEqual(len(car_params.longitudinalTuning.deadzoneV), len(car_params.longitudinalTuning.deadzoneBP))
+  #
+  #   # Lateral sanity checks
+  #   if car_params.steerControlType != car.CarParams.SteerControlType.angle:
+  #     tune = car_params.lateralTuning
+  #     if tune.which() == 'pid':
+  #       self.assertTrue(not math.isnan(tune.pid.kf) and tune.pid.kf > 0)
+  #       self.assertTrue(len(tune.pid.kpV) > 0 and len(tune.pid.kpV) == len(tune.pid.kpBP))
+  #       self.assertTrue(len(tune.pid.kiV) > 0 and len(tune.pid.kiV) == len(tune.pid.kiBP))
+  #
+  #     elif tune.which() == 'torque':
+  #       self.assertTrue(not math.isnan(tune.torque.kf) and tune.torque.kf > 0)
+  #       self.assertTrue(not math.isnan(tune.torque.friction) and tune.torque.friction > 0)
+  #
+  #     elif tune.which() == 'indi':
+  #       self.assertTrue(len(tune.indi.outerLoopGainV))
+  #
+  #   cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
+  #   # Run car interface
+  #   now_nanos = 0
+  #   CC = car.CarControl.new_message(**cc_msg)
+  #   for _ in range(10):
+  #     car_interface.update(CC, [])
+  #     car_interface.apply(CC, now_nanos)
+  #     car_interface.apply(CC, now_nanos)
+  #     now_nanos += DT_CTRL * 1e9  # 10 ms
+  #
+  #   CC = car.CarControl.new_message(**cc_msg)
+  #   CC.enabled = True
+  #   for _ in range(10):
+  #     car_interface.update(CC, [])
+  #     car_interface.apply(CC, now_nanos)
+  #     car_interface.apply(CC, now_nanos)
+  #     now_nanos += DT_CTRL * 1e9  # 10ms
+  #
+  #   # Test radar interface
+  #   RadarInterface = importlib.import_module(f'selfdrive.car.{car_params.carName}.radar_interface').RadarInterface
+  #   radar_interface = RadarInterface(car_params)
+  #   assert radar_interface
+  #
+  #   # Run radar interface once
+  #   radar_interface.update([])
+  #   if not car_params.radarUnavailable and radar_interface.rcp is not None and \
+  #      hasattr(radar_interface, '_update') and hasattr(radar_interface, 'trigger_msg'):
+  #     radar_interface._update([radar_interface.trigger_msg])
 
-    args = get_fuzzy_car_interface_args(data.draw)
+  def test_interface_attrs(self):
+    """ Asserts basic behavior of interface attribute getter """
+    # Should return value for all brands when not combining
+    for attr in ('DBC', 'FAKE', 'CAR'):
+      ret = get_interface_attr(attr)
+      self.assertGreaterEqual(len(ret), 13)
 
-    car_params = CarInterface.get_params(car_name, args['fingerprints'], args['car_fw'],
-                                         experimental_long=args['experimental_long'], docs=False)
-    car_interface = CarInterface(car_params, CarController, CarState)
-    assert car_params
-    assert car_interface
+    ret = get_interface_attr('DBC', combine_brands=True)
+    self.assertGreaterEqual(len(ret), 170)
+    ret = get_interface_attr('FAKE', combine_brands=True)
+    self.assertGreaterEqual(len(ret), 0)
 
-    self.assertGreater(car_params.mass, 1)
-    self.assertGreater(car_params.wheelbase, 0)
-    # centerToFront is center of gravity to front wheels, assert a reasonable range
-    self.assertTrue(car_params.wheelbase * 0.3 < car_params.centerToFront < car_params.wheelbase * 0.7)
-    self.assertGreater(car_params.maxLateralAccel, 0)
+    # We don't support combining non lists/dicts
+    ret = get_interface_attr('CAR', combine_brands=True)
+    self.assertGreaterEqual(len(ret), 0)
 
-    # Longitudinal sanity checks
-    self.assertEqual(len(car_params.longitudinalTuning.kpV), len(car_params.longitudinalTuning.kpBP))
-    self.assertEqual(len(car_params.longitudinalTuning.kiV), len(car_params.longitudinalTuning.kiBP))
-    self.assertEqual(len(car_params.longitudinalTuning.deadzoneV), len(car_params.longitudinalTuning.deadzoneBP))
+    ret = get_interface_attr('FW_VERSIONS', combine_brands=True, file='fingerprints')
+    self.assertGreaterEqual(len(ret), 190)
 
-    # Lateral sanity checks
-    if car_params.steerControlType != car.CarParams.SteerControlType.angle:
-      tune = car_params.lateralTuning
-      if tune.which() == 'pid':
-        self.assertTrue(not math.isnan(tune.pid.kf) and tune.pid.kf > 0)
-        self.assertTrue(len(tune.pid.kpV) > 0 and len(tune.pid.kpV) == len(tune.pid.kpBP))
-        self.assertTrue(len(tune.pid.kiV) > 0 and len(tune.pid.kiV) == len(tune.pid.kiBP))
-
-      elif tune.which() == 'torque':
-        self.assertTrue(not math.isnan(tune.torque.kf) and tune.torque.kf > 0)
-        self.assertTrue(not math.isnan(tune.torque.friction) and tune.torque.friction > 0)
-
-      elif tune.which() == 'indi':
-        self.assertTrue(len(tune.indi.outerLoopGainV))
-
-    cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
-    # Run car interface
-    now_nanos = 0
-    CC = car.CarControl.new_message(**cc_msg)
-    for _ in range(10):
-      car_interface.update(CC, [])
-      car_interface.apply(CC, now_nanos)
-      car_interface.apply(CC, now_nanos)
-      now_nanos += DT_CTRL * 1e9  # 10 ms
-
-    CC = car.CarControl.new_message(**cc_msg)
-    CC.enabled = True
-    for _ in range(10):
-      car_interface.update(CC, [])
-      car_interface.apply(CC, now_nanos)
-      car_interface.apply(CC, now_nanos)
-      now_nanos += DT_CTRL * 1e9  # 10ms
-
-    # Test radar interface
-    RadarInterface = importlib.import_module(f'selfdrive.car.{car_params.carName}.radar_interface').RadarInterface
-    radar_interface = RadarInterface(car_params)
-    assert radar_interface
-
-    # Run radar interface once
-    radar_interface.update([])
-    if not car_params.radarUnavailable and radar_interface.rcp is not None and \
-       hasattr(radar_interface, '_update') and hasattr(radar_interface, 'trigger_msg'):
-      radar_interface._update([radar_interface.trigger_msg])
 
 if __name__ == "__main__":
   unittest.main()

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -129,7 +129,7 @@ class TestCarInterfaces(unittest.TestCase):
 
     # If brand has None value, it shouldn't return when ignore_none=True is specified
     none_brands = {b for b, v in get_interface_attr('FINGERPRINTS').items() if v is None}
-    self.assertGreater(len(none_brands), 0)
+    self.assertGreaterEqual(len(none_brands), 1)
 
     ret = get_interface_attr('FINGERPRINTS', ignore_none=True)
     none_brands_in_ret = none_brands.intersection(ret)

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -133,8 +133,7 @@ class TestCarInterfaces(unittest.TestCase):
 
     ret = get_interface_attr('FINGERPRINTS', ignore_none=True)
     none_brands_in_ret = none_brands.intersection(ret)
-    self.assertEqual(len(none_brands_in_ret), 0, f'Brands with None values in ignore_none=True result: ' +
-                     f'{none_brands_in_ret}')
+    self.assertEqual(len(none_brands_in_ret), 0, f'Brands with None values in ignore_none=True result: {none_brands_in_ret}')
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -128,16 +128,14 @@ class TestCarInterfaces(unittest.TestCase):
     ret = get_interface_attr('CAR', combine_brands=True)
     self.assertEqual(len(ret), 0)
 
-    # If all attributes exist, should still equal num_brands
-    # ret = [brand for brand, versions in get_interface_attr('FW_VERSIONS').items() if versions is]
-    ret = get_interface_attr('FW_VERSIONS')
-    none_brands = {b for b, v in ret.items() if v is not None}
+    # If brand has None value, it shouldn't return when ignore_none=True is specified
+    none_brands = {b for b, v in get_interface_attr('FINGERPRINTS').items() if v is None}
     self.assertGreater(len(none_brands), 0)
 
-    ret = get_interface_attr('FW_VERSIONS', ignore_none=True)
-
-    none_brands_in_ret = {b for b in none_brands if b in ret}
-    self.assertEqual(len(none_brands_in_ret), 0, f'Brands with None values in ignored None result: {none_brands_in_ret}')
+    ret = get_interface_attr('FINGERPRINTS', ignore_none=True)
+    none_brands_in_ret = none_brands.intersection(ret)
+    self.assertEqual(len(none_brands_in_ret), 0, f'Brands with None values in ignore_none=True result: ' +
+                                                 f'{none_brands_in_ret}')
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -124,16 +124,13 @@ class TestCarInterfaces(unittest.TestCase):
     ret = get_interface_attr('CAR_INFO', combine_brands=True)
     self.assertGreaterEqual(len(ret), 200)
 
-    # If all attributes exist, should still equal num_brands
-    ret = get_interface_attr('CAR_INFO', ignore_none=True)
-    self.assertEqual(len(ret), num_brands)
-
     # We don't support combining non-dicts
     ret = get_interface_attr('CAR', combine_brands=True)
     self.assertEqual(len(ret), 0)
 
-    # ret = get_interface_attr('FW_VERSIONS', combine_brands=True)
-    # self.assertGreaterEqual(len(ret), 190)
+    # If all attributes exist, should still equal num_brands
+    ret = get_interface_attr('CAR_INFO', ignore_none=True)
+    self.assertEqual(len(ret), num_brands)
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -120,29 +120,20 @@ class TestCarInterfaces(unittest.TestCase):
       ret = get_interface_attr(attr)
       self.assertEqual(len(ret), num_brands)
 
-    # Every brand must implement CAR
-    ret = get_interface_attr('CAR', ignore_none=True)
-    self.assertGreaterEqual(len(ret), num_brands)
+    # Make sure we can combine dicts
+    ret = get_interface_attr('CAR_INFO', combine_brands=True)
+    self.assertGreaterEqual(len(ret), 200)
 
-    for attr in ('DBC', 'FAKE', 'CAR'):
-      ret = get_interface_attr(attr, ignore_none=True)
-      self.assertGreaterEqual(len(ret), 13)
+    # If all attributes exist, should still equal num_brands
+    ret = get_interface_attr('CAR_INFO', ignore_none=True)
+    self.assertEqual(len(ret), num_brands)
 
-    ret = get_interface_attr('FW_VERSIONS')
-    self.assertTrue(all(len(i) for i in ret.values()))
-
-#'FW_VERSIONS', 'FINGERPRINTS', 'CAR_INFO'
-    ret = get_interface_attr('DBC', combine_brands=True)
-    self.assertGreaterEqual(len(ret), 170)
-    ret = get_interface_attr('FAKE', combine_brands=True)
-    self.assertGreaterEqual(len(ret), 0)
-
-    # We don't support combining non lists/dicts
+    # We don't support combining non-dicts
     ret = get_interface_attr('CAR', combine_brands=True)
-    self.assertGreaterEqual(len(ret), 0)
+    self.assertEqual(len(ret), 0)
 
-    ret = get_interface_attr('FW_VERSIONS', combine_brands=True)
-    self.assertGreaterEqual(len(ret), 190)
+    # ret = get_interface_attr('FW_VERSIONS', combine_brands=True)
+    # self.assertGreaterEqual(len(ret), 190)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
looks like the first run for some tests exceeded the deadline threshold. it normally takes 70ms, first run took 280ms, so I don't want to just bump the max time to something like 300ms for a one off failure (first we've seen). leaving as is

same as https://github.com/commaai/openpilot/pull/29297