### PR TITLE
map ui: Fixed ETA text alignment issue in CJK

### DIFF
--- a/selfdrive/ui/qt/maps/map_eta.cc
+++ b/selfdrive/ui/qt/maps/map_eta.cc
@@ -47,7 +47,7 @@ void MapETA::updateETA(float s, float s_typical, float d) {
   auto distance = std::array{QString::number(num, 'f', num < 100 ? 1 : 0),
                              uiState()->scene.is_metric ? tr("km") : tr("mi")};
 
-  eta_doc.setHtml(QString(R"(<body><table><tr><td><b>%1</b></td><td>%2</td>
+  eta_doc.setHtml(QString(R"(<body><table><tr style="vertical-align:bottom;"><td><b>%1</b></td><td>%2</td>
                              <td style="padding-left:40px;color:%3;"><b>%4</b></td><td style="padding-right:40px;color:%3;">%5</td>
                              <td><b>%6</b></td><td>%7</td></tr></body>)")
                       .arg(eta[0], eta[1], color, remaining[0], remaining[1], distance[0], distance[1]));


### PR DESCRIPTION
ETA section text seems out of alignment when text is translated into CJK.

English:
![old_eng](https://github.com/commaai/openpilot/assets/16603033/b7ae9df4-5d70-473a-82ac-b05ef5a13a20)
CHT:
![old_cht](https://github.com/commaai/openpilot/assets/16603033/94cdb8ea-babd-4ae8-8703-cf65876600d0)
Japanese:
![old_jp](https://github.com/commaai/openpilot/assets/16603033/726d96ba-fe59-45c7-8433-0a8983bc8f21)
Korean:
![old_kr](https://github.com/commaai/openpilot/assets/16603033/693f4e82-8c15-4aaf-93f0-087dfe4479e7)

--------

Adding vertical-align: bottom fixed the issue a little (not perfect, but good enough for OCD):
English:
![new_eng](https://github.com/commaai/openpilot/assets/16603033/ea7cdde6-7f8c-4e40-b849-bef6a65d9b14)
CHT:
![new_cht](https://github.com/commaai/openpilot/assets/16603033/6f30d8c7-d5ba-45a2-aa86-f69dc8390ccb)
Japanese:
![new_jp](https://github.com/commaai/openpilot/assets/16603033/60b0dd47-012e-4da6-a5bd-131ac2ce81f8)
Korean:
![new_kr](https://github.com/commaai/openpilot/assets/16603033/37385265-cfae-409c-9206-5becc28db811)