### PR TITLE
athenad: unpreserve segment after uploading raw files

### DIFF
--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -264,6 +264,7 @@ def upload_handler(end_event: threading.Event) -> None:
           cloudlog.event("athena.upload_handler.retry", status_code=response.status_code, fn=fn, sz=sz, network_type=network_type, metered=metered)
           retry_upload(tid, end_event)
         else:
+          # TODO: unpreserve file
           cloudlog.event("athena.upload_handler.success", fn=fn, sz=sz, network_type=network_type, metered=metered)
 
         UploadQueueCache.cache(upload_queue)

--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -163,7 +163,6 @@ class TestAthenadMethods(unittest.TestCase):
     segment = '2023-04-05--12-34-56--0'
     filenames = ['qlog', 'qcamera.ts', 'rlog', 'fcamera.hevc', 'ecamera.hevc', 'dcamera.hevc']
     files = [f'{segment}/{f}' for f in filenames]
-
     for file in files:
       self._create_file(file, preserve=True)
 
@@ -171,10 +170,12 @@ class TestAthenadMethods(unittest.TestCase):
       item = athenad.UploadItem(path=file, url=f"{host}/{file}", headers={}, created_at=int(time.time()*1000), id=n)
       resp = athenad._do_upload(item)
       self.assertEqual(resp.status_code, 201)
+
+      # segment remains preserved until all files are uploaded
       if n + 1 != len(files):
         self.assertTrue(has_preserve_xattr(segment))
 
-    # check folder no longer preserved
+    # check segment is no longer preserved
     self.assertFalse(has_preserve_xattr(segment))
 
   @with_http_server


### PR DESCRIPTION
After all files have been uploaded, we can unpreserve the segment to free up space on the device.
https://github.com/commaai/openpilot/pull/28814#discussion_r1268434714