### PR TITLE
Ruff: Disallow implicit string concat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,3 +209,4 @@ exclude = [
   "tinygrad_repo",
   "third_party",
 ]
+flake8-implicit-str-concat.allow-multiline=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,8 +197,8 @@ build-backend = "poetry.core.masonry.api"
 
 # https://beta.ruff.rs/docs/configuration/#using-pyprojecttoml
 [tool.ruff]
-select = ["E", "F", "W"]
-ignore = ["W292", "E741", "E402"]
+select = ["E", "F", "W", "ISC"]
+ignore = ["W292", "E741", "E402", "ISC003"]
 line-length = 160
 target-version="py311"
 exclude = [


### PR DESCRIPTION
flake8-implicit-str-concat.allow-multiline=false disabled implicit concat across multiple lines.

However, ISC003 disables explicit string concat
```
    "Experimental openpilot longitudinal control is available behind a toggle; " +
    "the toggle is only available in non-release branches such as `devel` or `master-ci`. ",
```

in favor of implicit with parens
```
 ("Experimental openpilot longitudinal control is available behind a toggle; "
    "the toggle is only available in non-release branches such as `devel` or `master-ci`. ")
```

So I disabled ISC003, unless we like the parens better?