### PR TITLE
common_fault_avoidance: take a bool

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -132,7 +132,7 @@ def apply_std_steer_angle_limits(apply_angle, apply_angle_last, v_ego, LIMITS):
   return clip(apply_angle, apply_angle_last - angle_rate_lim, apply_angle_last + angle_rate_lim)
 
 
-def common_fault_avoidance(measured_value: float, max_value: float, request: bool, above_limit_frames: int,
+def common_fault_avoidance(fault_condition: bool, request: bool, above_limit_frames: int,
                            max_above_limit_frames: int, max_mismatching_frames: int = 1):
   """
   Several cars have the ability to work around their EPS limits by cutting the
@@ -140,7 +140,7 @@ def common_fault_avoidance(measured_value: float, max_value: float, request: boo
   """
 
   # Count up to max_above_limit_frames, at which point we need to cut the request for above_limit_frames to avoid a fault
-  if request and abs(measured_value) >= max_value:
+  if request and fault_condition:
     above_limit_frames += 1
   else:
     above_limit_frames = 0

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -65,7 +65,7 @@ class CarController:
     apply_steer = apply_driver_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, self.params)
 
     # >90 degree steering fault prevention
-    self.angle_limit_counter, apply_steer_req = common_fault_avoidance(CS.out.steeringAngleDeg, MAX_ANGLE, CC.latActive,
+    self.angle_limit_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringAngleDeg) >= MAX_ANGLE, CC.latActive,
                                                                        self.angle_limit_counter, MAX_ANGLE_FRAMES,
                                                                        MAX_ANGLE_CONSECUTIVE_FRAMES)
 

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -57,7 +57,7 @@ class CarController:
     apply_steer = apply_meas_steer_torque_limits(new_steer, self.last_steer, CS.out.steeringTorqueEps, self.params)
 
     # >100 degree/sec steering fault prevention
-    self.steer_rate_counter, apply_steer_req = common_fault_avoidance(CS.out.steeringRateDeg, MAX_STEER_RATE, CC.latActive,
+    self.steer_rate_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringRateDeg) >= MAX_STEER_RATE, CC.latActive,
                                                                       self.steer_rate_counter, MAX_STEER_RATE_FRAMES)
 
     if not CC.latActive:


### PR DESCRIPTION
Similar to:

https://github.com/commaai/openpilot/blob/22cf5421d625aaf578efcf572404a4d096c269b8/selfdrive/controls/lib/latcontrol.py#L26-L32

Instead of taking a value and max value which is restrictive, we can reduce args by calculating the fault condition in the carcontrollers. Might make it easier to ship for Subaru as well, since it might not explicitly be a max angle rate