### PR TITLE
ui/map: fix css error

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -35,7 +35,7 @@ MapWindow::MapWindow(const QMapboxGLSettings &settings) : m_settings(settings), 
   map_eta->setFixedHeight(120);
 
   error = new QLabel(this);
-  error->setStyleSheet(R"(color:white;padding:50px 11px;font-size: 90px; background-color:rgb(0, 0, 0, 150);)");
+  error->setStyleSheet(R"(color:white;padding:50px 11px;font-size: 90px; background-color:rgba(0, 0, 0, 150);)");
   error->setAlignment(Qt::AlignCenter);
 
   overlay_layout->addWidget(error);


### PR DESCRIPTION
fix css error message: 

> : QCssParser::parseColorValue: Specified color without alpha value but alpha given: 'rgb 0, 0, 0, 150'

![Screenshot from 2023-08-11 17-44-44](https://github.com/commaai/openpilot/assets/27770/06c5273b-3d3f-4a21-af7a-42c70c1da472)

