### PR TITLE
scons: rename QT_MOCHPREFIX to QT3_MOCHPREFIX

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -334,7 +334,7 @@ qt_flags = [
 qt_env['CXXFLAGS'] += qt_flags
 qt_env['LIBPATH'] += ['#selfdrive/ui']
 qt_env['LIBS'] = qt_libs
-qt_env['QT_MOCHPREFIX'] = cache_dir + '/moc_files/moc_'
+qt_env['QT3_MOCHPREFIX'] = cache_dir + '/moc_files/moc_'
 
 if GetOption("clazy"):
   checks = [

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -27,8 +27,8 @@ assets_src = "assets/assets.qrc"
 cabana_env.Command(assets, assets_src, f"rcc $SOURCES -o $TARGET")
 cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "assets/assets.o"]))
 
-prev_moc_path = cabana_env['QT_MOCHPREFIX']
-cabana_env['QT_MOCHPREFIX'] = os.path.dirname(prev_moc_path) + '/cabana/moc_'
+prev_moc_path = cabana_env['QT3_MOCHPREFIX']
+cabana_env['QT3_MOCHPREFIX'] = os.path.dirname(prev_moc_path) + '/cabana/moc_'
 cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
                                                'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
                                                'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',


### PR DESCRIPTION
`QT_MOCHPREFIX` was renamed to `QT3_MOCHPREFIX` after scons 4.5.0
https://github.com/SCons/scons/blob/e141cd3288ece58340a1a9e5d99a8c4f810366a9/SCons/Tool/qt3.xml#L391