### PR TITLE
CI: use default caching action

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -79,8 +79,8 @@ jobs:
     - name: Build openpilot with all flags
       timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 12 || 30) }} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc) --extras && release/check-dirty.sh"
-    - name: Cleanup scons cache
-      timeout-minutes: 2
+    - name: Cleanup scons cache and rebuild
+      timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 2 || 30) }} # allow more time when we missed the scons cache
       run: |
           ${{ env.RUN }} "rm -rf /tmp/scons_cache/* && \
                           scons -j$(nproc) --cache-populate"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -47,7 +47,7 @@ jobs:
       timeout-minutes: 1
       run: release/check-submodules.sh
     - name: Build openpilot and run checks
-      timeout-minutes: 10
+      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30} # allow more time when we missed the scons cache
       run: |
         cd $STRIPPED_DIR
         ${{ env.RUN }} "CI=1 python selfdrive/manager/build.py"
@@ -77,7 +77,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot with all flags
-      timeout-minutes: 12
+      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && 12 || 30} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc) --extras && release/check-dirty.sh"
     - name: Cleanup scons cache
       timeout-minutes: 2
@@ -243,7 +243,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot
-      timeout-minutes: 10
+      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run unit tests
       timeout-minutes: 40

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -76,8 +76,6 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/workflows/setup
-      with:
-        save-cache: true
     - name: Build openpilot with all flags
       timeout-minutes: 12
       run: ${{ env.RUN }} "scons -j$(nproc) --extras && release/check-dirty.sh"
@@ -86,6 +84,12 @@ jobs:
       run: |
           ${{ env.RUN }} "rm -rf /tmp/scons_cache/* && \
                           scons -j$(nproc) --cache-populate"
+    - name: Save scons cache
+      uses: actions/cache/save@v3
+      if: github.ref == 'refs/heads/master'
+      with:
+        path: /tmp/scons_cache
+        key: scons-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
 
   build_mac:
     name: build macos

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -47,7 +47,7 @@ jobs:
       timeout-minutes: 1
       run: release/check-submodules.sh
     - name: Build openpilot and run checks
-      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30} # allow more time when we missed the scons cache
+      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30'} # allow more time when we missed the scons cache
       run: |
         cd $STRIPPED_DIR
         ${{ env.RUN }} "CI=1 python selfdrive/manager/build.py"
@@ -77,7 +77,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot with all flags
-      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && 12 || 30} # allow more time when we missed the scons cache
+      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && '12' || '30'} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc) --extras && release/check-dirty.sh"
     - name: Cleanup scons cache
       timeout-minutes: 2
@@ -243,7 +243,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot
-      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30} # allow more time when we missed the scons cache
+      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30'} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run unit tests
       timeout-minutes: 40

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -47,7 +47,7 @@ jobs:
       timeout-minutes: 1
       run: release/check-submodules.sh
     - name: Build openpilot and run checks
-      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30'} # allow more time when we missed the scons cache
+      timeout-minutes: ${fromJSON(((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30)} # allow more time when we missed the scons cache
       run: |
         cd $STRIPPED_DIR
         ${{ env.RUN }} "CI=1 python selfdrive/manager/build.py"
@@ -77,7 +77,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot with all flags
-      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && '12' || '30'} # allow more time when we missed the scons cache
+      timeout-minutes: ${fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && 12 || 30)} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc) --extras && release/check-dirty.sh"
     - name: Cleanup scons cache
       timeout-minutes: 2
@@ -243,7 +243,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot
-      timeout-minutes: ${(steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30'} # allow more time when we missed the scons cache
+      timeout-minutes: ${fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30)} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run unit tests
       timeout-minutes: 40

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -47,7 +47,7 @@ jobs:
       timeout-minutes: 1
       run: release/check-submodules.sh
     - name: Build openpilot and run checks
-      timeout-minutes: ${fromJSON(((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30)} # allow more time when we missed the scons cache
+      timeout-minutes: ${ fromJSON(((steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30')} # allow more time when we missed the scons cache
       run: |
         cd $STRIPPED_DIR
         ${{ env.RUN }} "CI=1 python selfdrive/manager/build.py"
@@ -77,7 +77,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot with all flags
-      timeout-minutes: ${fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && 12 || 30)} # allow more time when we missed the scons cache
+      timeout-minutes: ${ fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && '12' || '30') } # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc) --extras && release/check-dirty.sh"
     - name: Cleanup scons cache
       timeout-minutes: 2
@@ -243,7 +243,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot
-      timeout-minutes: ${fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30)} # allow more time when we missed the scons cache
+      timeout-minutes: ${ fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30') } # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run unit tests
       timeout-minutes: 40

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -47,7 +47,7 @@ jobs:
       timeout-minutes: 1
       run: release/check-submodules.sh
     - name: Build openpilot and run checks
-      timeout-minutes: ${ fromJSON(((steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30')} # allow more time when we missed the scons cache
+      timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30) }} # allow more time when we missed the scons cache
       run: |
         cd $STRIPPED_DIR
         ${{ env.RUN }} "CI=1 python selfdrive/manager/build.py"
@@ -77,7 +77,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot with all flags
-      timeout-minutes: ${ fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && '12' || '30') } # allow more time when we missed the scons cache
+      timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 12 || 30) }} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc) --extras && release/check-dirty.sh"
     - name: Cleanup scons cache
       timeout-minutes: 2
@@ -243,7 +243,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
     - name: Build openpilot
-      timeout-minutes: ${ fromJSON((steps.restore-scons-cache.outputs.cache-hit == 'true') && '10' || '30') } # allow more time when we missed the scons cache
+      timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30) }} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run unit tests
       timeout-minutes: 40

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -1,10 +1,5 @@
 name: 'openpilot env setup'
 
-inputs:
-  save-cache:
-    default: false
-    required: false
-
 runs:
   using: "composite"
   steps:
@@ -18,13 +13,8 @@ runs:
       run: echo "CACHE_COMMIT_DATE=$(git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d-%H:%M')" >> $GITHUB_ENV
     - shell: bash
       run: echo "$CACHE_COMMIT_DATE"
-    - shell: bash
-      run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
-      if: github.ref != 'refs/heads/master' || inputs.save-cache == 'false'
     - id: scons-cache
-      # TODO: change the version to the released version
-      # when https://github.com/actions/cache/pull/489 (or 571) is merged.
-      uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+      uses: actions/cache/restore@v3
       with:
         path: /tmp/scons_cache
         key: scons-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -13,7 +13,7 @@ runs:
       run: echo "CACHE_COMMIT_DATE=$(git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d-%H:%M')" >> $GITHUB_ENV
     - shell: bash
       run: echo "$CACHE_COMMIT_DATE"
-    - id: scons-cache
+    - id: restore-scons-cache
       uses: actions/cache/restore@v3
       with:
         path: /tmp/scons_cache


### PR DESCRIPTION
prerequisite of using buildjet's cache is to be on the latest version of actions/cache