### PR TITLE
ui/map_settings: fix next destination being cleared on offroad transition

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.h
+++ b/selfdrive/ui/qt/maps/map_settings.h
@@ -26,6 +26,7 @@ class NavigationRequest : public QObject {
 public:
   static NavigationRequest *instance();
   QJsonArray currentLocations() const { return locations; };
+  void updateNextDestination();
 
 signals:
   void locationsUpdated(const QJsonArray &locations);
@@ -37,6 +38,7 @@ private:
 
   Params params;
   QString prev_response;
+  QString offline_dest;
   QJsonArray locations;
 };
 


### PR DESCRIPTION
param `NavDestination` will be cleared on offroad transition.  This will cause the destinations set while offline to be cleared as well.