### PR TITLE
CI: speed up FW unit tests

### DIFF
--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -116,6 +116,7 @@ def match_fw_to_car_exact(live_fw_versions, filter_brand=None, log=True) -> Set[
   for candidate, fws in candidates.items():
     brand = MODEL_TO_BRAND[candidate]
     if not is_brand(brand, filter_brand):
+      invalid.add(candidate)
       continue
 
     config = FW_QUERY_CONFIGS[brand]

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -163,7 +163,7 @@ def match_fw_to_car(fw_versions, allow_exact=True, allow_fuzzy=True, log=True):
       # If specified and no matches so far, fall back to brand's fuzzy fingerprinting function
       config = FW_QUERY_CONFIGS[brand]
       if not exact_match and not len(matches) and config.match_fw_to_car_fuzzy is not None:
-        matches |= config.match_fw_to_car_fuzzy(fw_versions_dict, brand)
+        matches |= config.match_fw_to_car_fuzzy(fw_versions_dict)
 
     if len(matches):
       return exact_match, matches

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -46,52 +46,52 @@ class TestFwFingerprint(unittest.TestCase):
       _, matches = match_fw_to_car(CP.carFw, allow_fuzzy=False)
       self.assertFingerprints(matches, car_model)
 
-  # @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
-  # def test_custom_fuzzy_match(self, brand, car_model, ecus):
-  #   # Assert brand-specific fuzzy fingerprinting function doesn't disagree with standard fuzzy function
-  #   config = FW_QUERY_CONFIGS[brand]
-  #   if config.match_fw_to_car_fuzzy is None:
-  #     raise unittest.SkipTest("Brand does not implement custom fuzzy fingerprinting function")
-  #
-  #   CP = car.CarParams.new_message()
-  #   for _ in range(5):
-  #     fw = []
-  #     for ecu, fw_versions in ecus.items():
-  #       ecu_name, addr, sub_addr = ecu
-  #       fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
-  #                  "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
-  #     CP.carFw = fw
-  #     _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
-  #     brand_matches = config.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw))
-  #
-  #     # If both have matches, they must agree
-  #     if len(matches) == 1 and len(brand_matches) == 1:
-  #       self.assertEqual(matches, brand_matches)
+  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  def test_custom_fuzzy_match(self, brand, car_model, ecus):
+    # Assert brand-specific fuzzy fingerprinting function doesn't disagree with standard fuzzy function
+    config = FW_QUERY_CONFIGS[brand]
+    if config.match_fw_to_car_fuzzy is None:
+      raise unittest.SkipTest("Brand does not implement custom fuzzy fingerprinting function")
 
-  # @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
-  # def test_fuzzy_match_ecu_count(self, brand, car_model, ecus):
-  #   # Asserts that fuzzy matching does not count matching FW, but ECU address keys
-  #   valid_ecus = [e for e in ecus if e[0] not in FUZZY_EXCLUDE_ECUS]
-  #   if not len(valid_ecus):
-  #     raise unittest.SkipTest("Car model has no compatible ECUs for fuzzy matching")
-  #
-  #   fw = []
-  #   for ecu in valid_ecus:
-  #     ecu_name, addr, sub_addr = ecu
-  #     for _ in range(5):
-  #       # Add multiple FW versions to simulate ECU returning to multiple queries in a brand
-  #       fw.append({"ecu": ecu_name, "fwVersion": random.choice(ecus[ecu]), 'brand': brand,
-  #                  "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
-  #     CP = car.CarParams.new_message(carFw=fw)
-  #     _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
-  #
-  #     # Assert no match if there are not enough unique ECUs
-  #     unique_ecus = {(f['address'], f['subAddress']) for f in fw}
-  #     if len(unique_ecus) < 2:
-  #       self.assertEqual(len(matches), 0, car_model)
-  #     # There won't always be a match due to shared FW, but if there is it should be correct
-  #     elif len(matches):
-  #       self.assertFingerprints(matches, car_model)
+    CP = car.CarParams.new_message()
+    for _ in range(5):
+      fw = []
+      for ecu, fw_versions in ecus.items():
+        ecu_name, addr, sub_addr = ecu
+        fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
+                   "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
+      CP.carFw = fw
+      _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
+      brand_matches = config.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw))
+
+      # If both have matches, they must agree
+      if len(matches) == 1 and len(brand_matches) == 1:
+        self.assertEqual(matches, brand_matches)
+
+  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  def test_fuzzy_match_ecu_count(self, brand, car_model, ecus):
+    # Asserts that fuzzy matching does not count matching FW, but ECU address keys
+    valid_ecus = [e for e in ecus if e[0] not in FUZZY_EXCLUDE_ECUS]
+    if not len(valid_ecus):
+      raise unittest.SkipTest("Car model has no compatible ECUs for fuzzy matching")
+
+    fw = []
+    for ecu in valid_ecus:
+      ecu_name, addr, sub_addr = ecu
+      for _ in range(5):
+        # Add multiple FW versions to simulate ECU returning to multiple queries in a brand
+        fw.append({"ecu": ecu_name, "fwVersion": random.choice(ecus[ecu]), 'brand': brand,
+                   "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
+      CP = car.CarParams.new_message(carFw=fw)
+      _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
+
+      # Assert no match if there are not enough unique ECUs
+      unique_ecus = {(f['address'], f['subAddress']) for f in fw}
+      if len(unique_ecus) < 2:
+        self.assertEqual(len(matches), 0, car_model)
+      # There won't always be a match due to shared FW, but if there is it should be correct
+      elif len(matches):
+        self.assertFingerprints(matches, car_model)
 
   def test_fw_version_lists(self):
     for car_model, ecus in FW_VERSIONS.items():
@@ -168,95 +168,95 @@ class TestFwFingerprint(unittest.TestCase):
           self.assertEqual(len(request_obj.request), len(request_obj.response))
 
 
-# class TestFwFingerprintTiming(unittest.TestCase):
-#   N: int = 5
-#   TOL: float = 0.1
-#
-#   @staticmethod
-#   def _run_thread(thread: threading.Thread) -> float:
-#     params = Params()
-#     params.put_bool("ObdMultiplexingEnabled", True)
-#     thread.start()
-#     t = time.perf_counter()
-#     while thread.is_alive():
-#       time.sleep(0.02)
-#       if not params.get_bool("ObdMultiplexingChanged"):
-#         params.put_bool("ObdMultiplexingChanged", True)
-#     return time.perf_counter() - t
-#
-#   def _benchmark_brand(self, brand, num_pandas):
-#     fake_socket = FakeSocket()
-#     brand_time = 0
-#     for _ in range(self.N):
-#       thread = threading.Thread(target=get_fw_versions, args=(fake_socket, fake_socket, brand),
-#                                 kwargs=dict(num_pandas=num_pandas))
-#       brand_time += self._run_thread(thread)
-#
-#     return round(brand_time / self.N, 2)
-#
-#   def _assert_timing(self, avg_time, ref_time):
-#     self.assertLess(avg_time, ref_time + self.TOL)
-#     self.assertGreater(avg_time, ref_time - self.TOL, "Performance seems to have improved, update test refs.")
-#
-#   def test_startup_timing(self):
-#     # Tests worse-case VIN query time and typical present ECU query time
-#     vin_ref_time = 1.0
-#     present_ecu_ref_time = 0.8
-#
-#     fake_socket = FakeSocket()
-#     present_ecu_time = 0.0
-#     for _ in range(self.N):
-#       thread = threading.Thread(target=get_present_ecus, args=(fake_socket, fake_socket),
-#                                 kwargs=dict(num_pandas=2))
-#       present_ecu_time += self._run_thread(thread)
-#     self._assert_timing(present_ecu_time / self.N, present_ecu_ref_time)
-#     print(f'get_present_ecus, query time={present_ecu_time / self.N} seconds')
-#
-#     vin_time = 0.0
-#     for _ in range(self.N):
-#       thread = threading.Thread(target=get_vin, args=(fake_socket, fake_socket, 1))
-#       vin_time += self._run_thread(thread)
-#     self._assert_timing(vin_time / self.N, vin_ref_time)
-#     print(f'get_vin, query time={vin_time / self.N} seconds')
-#
-#   def test_fw_query_timing(self):
-#     total_ref_time = 6.1
-#     brand_ref_times = {
-#       1: {
-#         'body': 0.1,
-#         'chrysler': 0.3,
-#         'ford': 0.2,
-#         'honda': 0.5,
-#         'hyundai': 0.7,
-#         'mazda': 0.2,
-#         'nissan': 0.3,
-#         'subaru': 0.2,
-#         'tesla': 0.2,
-#         'toyota': 1.6,
-#         'volkswagen': 0.2,
-#       },
-#       2: {
-#         'ford': 0.4,
-#         'hyundai': 1.1,
-#       }
-#     }
-#
-#     total_time = 0
-#     for num_pandas in (1, 2):
-#       for brand, config in FW_QUERY_CONFIGS.items():
-#         with self.subTest(brand=brand, num_pandas=num_pandas):
-#           multi_panda_requests = [r for r in config.requests if r.bus > 3]
-#           if not len(multi_panda_requests) and num_pandas > 1:
-#             raise unittest.SkipTest("No multi-panda FW queries")
-#
-#           avg_time = self._benchmark_brand(brand, num_pandas)
-#           total_time += avg_time
-#           self._assert_timing(avg_time, brand_ref_times[num_pandas][brand])
-#           print(f'{brand=}, {num_pandas=}, {len(config.requests)=}, avg FW query time={avg_time} seconds')
-#
-#     with self.subTest(brand='all_brands'):
-#       self._assert_timing(total_time, total_ref_time)
-#       print(f'all brands, total FW query time={total_time} seconds')
+class TestFwFingerprintTiming(unittest.TestCase):
+  N: int = 5
+  TOL: float = 0.1
+
+  @staticmethod
+  def _run_thread(thread: threading.Thread) -> float:
+    params = Params()
+    params.put_bool("ObdMultiplexingEnabled", True)
+    thread.start()
+    t = time.perf_counter()
+    while thread.is_alive():
+      time.sleep(0.02)
+      if not params.get_bool("ObdMultiplexingChanged"):
+        params.put_bool("ObdMultiplexingChanged", True)
+    return time.perf_counter() - t
+
+  def _benchmark_brand(self, brand, num_pandas):
+    fake_socket = FakeSocket()
+    brand_time = 0
+    for _ in range(self.N):
+      thread = threading.Thread(target=get_fw_versions, args=(fake_socket, fake_socket, brand),
+                                kwargs=dict(num_pandas=num_pandas))
+      brand_time += self._run_thread(thread)
+
+    return round(brand_time / self.N, 2)
+
+  def _assert_timing(self, avg_time, ref_time):
+    self.assertLess(avg_time, ref_time + self.TOL)
+    self.assertGreater(avg_time, ref_time - self.TOL, "Performance seems to have improved, update test refs.")
+
+  def test_startup_timing(self):
+    # Tests worse-case VIN query time and typical present ECU query time
+    vin_ref_time = 1.0
+    present_ecu_ref_time = 0.8
+
+    fake_socket = FakeSocket()
+    present_ecu_time = 0.0
+    for _ in range(self.N):
+      thread = threading.Thread(target=get_present_ecus, args=(fake_socket, fake_socket),
+                                kwargs=dict(num_pandas=2))
+      present_ecu_time += self._run_thread(thread)
+    self._assert_timing(present_ecu_time / self.N, present_ecu_ref_time)
+    print(f'get_present_ecus, query time={present_ecu_time / self.N} seconds')
+
+    vin_time = 0.0
+    for _ in range(self.N):
+      thread = threading.Thread(target=get_vin, args=(fake_socket, fake_socket, 1))
+      vin_time += self._run_thread(thread)
+    self._assert_timing(vin_time / self.N, vin_ref_time)
+    print(f'get_vin, query time={vin_time / self.N} seconds')
+
+  def test_fw_query_timing(self):
+    total_ref_time = 6.1
+    brand_ref_times = {
+      1: {
+        'body': 0.1,
+        'chrysler': 0.3,
+        'ford': 0.2,
+        'honda': 0.5,
+        'hyundai': 0.7,
+        'mazda': 0.2,
+        'nissan': 0.3,
+        'subaru': 0.2,
+        'tesla': 0.2,
+        'toyota': 1.6,
+        'volkswagen': 0.2,
+      },
+      2: {
+        'ford': 0.4,
+        'hyundai': 1.1,
+      }
+    }
+
+    total_time = 0
+    for num_pandas in (1, 2):
+      for brand, config in FW_QUERY_CONFIGS.items():
+        with self.subTest(brand=brand, num_pandas=num_pandas):
+          multi_panda_requests = [r for r in config.requests if r.bus > 3]
+          if not len(multi_panda_requests) and num_pandas > 1:
+            raise unittest.SkipTest("No multi-panda FW queries")
+
+          avg_time = self._benchmark_brand(brand, num_pandas)
+          total_time += avg_time
+          self._assert_timing(avg_time, brand_ref_times[num_pandas][brand])
+          print(f'{brand=}, {num_pandas=}, {len(config.requests)=}, avg FW query time={avg_time} seconds')
+
+    with self.subTest(brand='all_brands'):
+      self._assert_timing(total_time, total_ref_time)
+      print(f'all brands, total FW query time={total_time} seconds')
 
 
 if __name__ == "__main__":

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -46,52 +46,52 @@ class TestFwFingerprint(unittest.TestCase):
       _, matches = match_fw_to_car(CP.carFw, allow_fuzzy=False)
       self.assertFingerprints(matches, car_model)
 
-  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
-  def test_custom_fuzzy_match(self, brand, car_model, ecus):
-    # Assert brand-specific fuzzy fingerprinting function doesn't disagree with standard fuzzy function
-    config = FW_QUERY_CONFIGS[brand]
-    if config.match_fw_to_car_fuzzy is None:
-      raise unittest.SkipTest("Brand does not implement custom fuzzy fingerprinting function")
+  # @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  # def test_custom_fuzzy_match(self, brand, car_model, ecus):
+  #   # Assert brand-specific fuzzy fingerprinting function doesn't disagree with standard fuzzy function
+  #   config = FW_QUERY_CONFIGS[brand]
+  #   if config.match_fw_to_car_fuzzy is None:
+  #     raise unittest.SkipTest("Brand does not implement custom fuzzy fingerprinting function")
+  #
+  #   CP = car.CarParams.new_message()
+  #   for _ in range(5):
+  #     fw = []
+  #     for ecu, fw_versions in ecus.items():
+  #       ecu_name, addr, sub_addr = ecu
+  #       fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
+  #                  "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
+  #     CP.carFw = fw
+  #     _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
+  #     brand_matches = config.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw))
+  #
+  #     # If both have matches, they must agree
+  #     if len(matches) == 1 and len(brand_matches) == 1:
+  #       self.assertEqual(matches, brand_matches)
 
-    CP = car.CarParams.new_message()
-    for _ in range(5):
-      fw = []
-      for ecu, fw_versions in ecus.items():
-        ecu_name, addr, sub_addr = ecu
-        fw.append({"ecu": ecu_name, "fwVersion": random.choice(fw_versions), 'brand': brand,
-                   "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
-      CP.carFw = fw
-      _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
-      brand_matches = config.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw))
-
-      # If both have matches, they must agree
-      if len(matches) == 1 and len(brand_matches) == 1:
-        self.assertEqual(matches, brand_matches)
-
-  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
-  def test_fuzzy_match_ecu_count(self, brand, car_model, ecus):
-    # Asserts that fuzzy matching does not count matching FW, but ECU address keys
-    valid_ecus = [e for e in ecus if e[0] not in FUZZY_EXCLUDE_ECUS]
-    if not len(valid_ecus):
-      raise unittest.SkipTest("Car model has no compatible ECUs for fuzzy matching")
-
-    fw = []
-    for ecu in valid_ecus:
-      ecu_name, addr, sub_addr = ecu
-      for _ in range(5):
-        # Add multiple FW versions to simulate ECU returning to multiple queries in a brand
-        fw.append({"ecu": ecu_name, "fwVersion": random.choice(ecus[ecu]), 'brand': brand,
-                   "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
-      CP = car.CarParams.new_message(carFw=fw)
-      _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
-
-      # Assert no match if there are not enough unique ECUs
-      unique_ecus = {(f['address'], f['subAddress']) for f in fw}
-      if len(unique_ecus) < 2:
-        self.assertEqual(len(matches), 0, car_model)
-      # There won't always be a match due to shared FW, but if there is it should be correct
-      elif len(matches):
-        self.assertFingerprints(matches, car_model)
+  # @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  # def test_fuzzy_match_ecu_count(self, brand, car_model, ecus):
+  #   # Asserts that fuzzy matching does not count matching FW, but ECU address keys
+  #   valid_ecus = [e for e in ecus if e[0] not in FUZZY_EXCLUDE_ECUS]
+  #   if not len(valid_ecus):
+  #     raise unittest.SkipTest("Car model has no compatible ECUs for fuzzy matching")
+  #
+  #   fw = []
+  #   for ecu in valid_ecus:
+  #     ecu_name, addr, sub_addr = ecu
+  #     for _ in range(5):
+  #       # Add multiple FW versions to simulate ECU returning to multiple queries in a brand
+  #       fw.append({"ecu": ecu_name, "fwVersion": random.choice(ecus[ecu]), 'brand': brand,
+  #                  "address": addr, "subAddress": 0 if sub_addr is None else sub_addr})
+  #     CP = car.CarParams.new_message(carFw=fw)
+  #     _, matches = match_fw_to_car(CP.carFw, allow_exact=False, log=False)
+  #
+  #     # Assert no match if there are not enough unique ECUs
+  #     unique_ecus = {(f['address'], f['subAddress']) for f in fw}
+  #     if len(unique_ecus) < 2:
+  #       self.assertEqual(len(matches), 0, car_model)
+  #     # There won't always be a match due to shared FW, but if there is it should be correct
+  #     elif len(matches):
+  #       self.assertFingerprints(matches, car_model)
 
   def test_fw_version_lists(self):
     for car_model, ecus in FW_VERSIONS.items():
@@ -168,95 +168,95 @@ class TestFwFingerprint(unittest.TestCase):
           self.assertEqual(len(request_obj.request), len(request_obj.response))
 
 
-class TestFwFingerprintTiming(unittest.TestCase):
-  N: int = 5
-  TOL: float = 0.1
-
-  @staticmethod
-  def _run_thread(thread: threading.Thread) -> float:
-    params = Params()
-    params.put_bool("ObdMultiplexingEnabled", True)
-    thread.start()
-    t = time.perf_counter()
-    while thread.is_alive():
-      time.sleep(0.02)
-      if not params.get_bool("ObdMultiplexingChanged"):
-        params.put_bool("ObdMultiplexingChanged", True)
-    return time.perf_counter() - t
-
-  def _benchmark_brand(self, brand, num_pandas):
-    fake_socket = FakeSocket()
-    brand_time = 0
-    for _ in range(self.N):
-      thread = threading.Thread(target=get_fw_versions, args=(fake_socket, fake_socket, brand),
-                                kwargs=dict(num_pandas=num_pandas))
-      brand_time += self._run_thread(thread)
-
-    return round(brand_time / self.N, 2)
-
-  def _assert_timing(self, avg_time, ref_time):
-    self.assertLess(avg_time, ref_time + self.TOL)
-    self.assertGreater(avg_time, ref_time - self.TOL, "Performance seems to have improved, update test refs.")
-
-  def test_startup_timing(self):
-    # Tests worse-case VIN query time and typical present ECU query time
-    vin_ref_time = 1.0
-    present_ecu_ref_time = 0.8
-
-    fake_socket = FakeSocket()
-    present_ecu_time = 0.0
-    for _ in range(self.N):
-      thread = threading.Thread(target=get_present_ecus, args=(fake_socket, fake_socket),
-                                kwargs=dict(num_pandas=2))
-      present_ecu_time += self._run_thread(thread)
-    self._assert_timing(present_ecu_time / self.N, present_ecu_ref_time)
-    print(f'get_present_ecus, query time={present_ecu_time / self.N} seconds')
-
-    vin_time = 0.0
-    for _ in range(self.N):
-      thread = threading.Thread(target=get_vin, args=(fake_socket, fake_socket, 1))
-      vin_time += self._run_thread(thread)
-    self._assert_timing(vin_time / self.N, vin_ref_time)
-    print(f'get_vin, query time={vin_time / self.N} seconds')
-
-  def test_fw_query_timing(self):
-    total_ref_time = 6.1
-    brand_ref_times = {
-      1: {
-        'body': 0.1,
-        'chrysler': 0.3,
-        'ford': 0.2,
-        'honda': 0.5,
-        'hyundai': 0.7,
-        'mazda': 0.2,
-        'nissan': 0.3,
-        'subaru': 0.2,
-        'tesla': 0.2,
-        'toyota': 1.6,
-        'volkswagen': 0.2,
-      },
-      2: {
-        'ford': 0.4,
-        'hyundai': 1.1,
-      }
-    }
-
-    total_time = 0
-    for num_pandas in (1, 2):
-      for brand, config in FW_QUERY_CONFIGS.items():
-        with self.subTest(brand=brand, num_pandas=num_pandas):
-          multi_panda_requests = [r for r in config.requests if r.bus > 3]
-          if not len(multi_panda_requests) and num_pandas > 1:
-            raise unittest.SkipTest("No multi-panda FW queries")
-
-          avg_time = self._benchmark_brand(brand, num_pandas)
-          total_time += avg_time
-          self._assert_timing(avg_time, brand_ref_times[num_pandas][brand])
-          print(f'{brand=}, {num_pandas=}, {len(config.requests)=}, avg FW query time={avg_time} seconds')
-
-    with self.subTest(brand='all_brands'):
-      self._assert_timing(total_time, total_ref_time)
-      print(f'all brands, total FW query time={total_time} seconds')
+# class TestFwFingerprintTiming(unittest.TestCase):
+#   N: int = 5
+#   TOL: float = 0.1
+#
+#   @staticmethod
+#   def _run_thread(thread: threading.Thread) -> float:
+#     params = Params()
+#     params.put_bool("ObdMultiplexingEnabled", True)
+#     thread.start()
+#     t = time.perf_counter()
+#     while thread.is_alive():
+#       time.sleep(0.02)
+#       if not params.get_bool("ObdMultiplexingChanged"):
+#         params.put_bool("ObdMultiplexingChanged", True)
+#     return time.perf_counter() - t
+#
+#   def _benchmark_brand(self, brand, num_pandas):
+#     fake_socket = FakeSocket()
+#     brand_time = 0
+#     for _ in range(self.N):
+#       thread = threading.Thread(target=get_fw_versions, args=(fake_socket, fake_socket, brand),
+#                                 kwargs=dict(num_pandas=num_pandas))
+#       brand_time += self._run_thread(thread)
+#
+#     return round(brand_time / self.N, 2)
+#
+#   def _assert_timing(self, avg_time, ref_time):
+#     self.assertLess(avg_time, ref_time + self.TOL)
+#     self.assertGreater(avg_time, ref_time - self.TOL, "Performance seems to have improved, update test refs.")
+#
+#   def test_startup_timing(self):
+#     # Tests worse-case VIN query time and typical present ECU query time
+#     vin_ref_time = 1.0
+#     present_ecu_ref_time = 0.8
+#
+#     fake_socket = FakeSocket()
+#     present_ecu_time = 0.0
+#     for _ in range(self.N):
+#       thread = threading.Thread(target=get_present_ecus, args=(fake_socket, fake_socket),
+#                                 kwargs=dict(num_pandas=2))
+#       present_ecu_time += self._run_thread(thread)
+#     self._assert_timing(present_ecu_time / self.N, present_ecu_ref_time)
+#     print(f'get_present_ecus, query time={present_ecu_time / self.N} seconds')
+#
+#     vin_time = 0.0
+#     for _ in range(self.N):
+#       thread = threading.Thread(target=get_vin, args=(fake_socket, fake_socket, 1))
+#       vin_time += self._run_thread(thread)
+#     self._assert_timing(vin_time / self.N, vin_ref_time)
+#     print(f'get_vin, query time={vin_time / self.N} seconds')
+#
+#   def test_fw_query_timing(self):
+#     total_ref_time = 6.1
+#     brand_ref_times = {
+#       1: {
+#         'body': 0.1,
+#         'chrysler': 0.3,
+#         'ford': 0.2,
+#         'honda': 0.5,
+#         'hyundai': 0.7,
+#         'mazda': 0.2,
+#         'nissan': 0.3,
+#         'subaru': 0.2,
+#         'tesla': 0.2,
+#         'toyota': 1.6,
+#         'volkswagen': 0.2,
+#       },
+#       2: {
+#         'ford': 0.4,
+#         'hyundai': 1.1,
+#       }
+#     }
+#
+#     total_time = 0
+#     for num_pandas in (1, 2):
+#       for brand, config in FW_QUERY_CONFIGS.items():
+#         with self.subTest(brand=brand, num_pandas=num_pandas):
+#           multi_panda_requests = [r for r in config.requests if r.bus > 3]
+#           if not len(multi_panda_requests) and num_pandas > 1:
+#             raise unittest.SkipTest("No multi-panda FW queries")
+#
+#           avg_time = self._benchmark_brand(brand, num_pandas)
+#           total_time += avg_time
+#           self._assert_timing(avg_time, brand_ref_times[num_pandas][brand])
+#           print(f'{brand=}, {num_pandas=}, {len(config.requests)=}, avg FW query time={avg_time} seconds')
+#
+#     with self.subTest(brand='all_brands'):
+#       self._assert_timing(total_time, total_ref_time)
+#       print(f'all brands, total FW query time={total_time} seconds')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Takes half the time of the unit tests! 155s -> 30s on local PC, 517s -> 318s in CI

Only look at the DB FW for the current brand we're fingerprinting

Currently we try to fingerprint on every candidate, when only FW from toyota is passed in, for example. This should never happen, and was partially verified in https://github.com/commaai/openpilot/pull/29233

edit: hmm, not getting nearly as much speed up in CI than local, think I'll just make this a car-focused clean up