### PR TITLE
CHEVROLET SILVERADO 1500 2020: More accurate Silverado 1500 Weight

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -218,7 +218,7 @@ class CarInterface(CarInterfaceBase):
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
     elif candidate == CAR.SILVERADO:
-      ret.mass = 2200. + STD_CARGO_KG
+      ret.mass = 2450. + STD_CARGO_KG
       ret.wheelbase = 3.75
       ret.steerRatio = 16.3
       ret.centerToFront = ret.wheelbase * 0.5


### PR DESCRIPTION
**Description**
Silverado Weight in interface.py under GM is a bit low 2200 is below something even from the brochure info
![259527987-9f68b136-280e-4a3d-b3ae-62b140eb3955](https://github.com/commaai/openpilot/assets/607941/5c31a6cc-27fe-40fc-a68f-59bff6664784)

**Verification** 
Sampled vehicles actually running OpenPilot are weighted as follows:
2495
2509
2521
2539


nuwandavek suggested a lower than sampled number and from documents as a baseline