### PR TITLE
ui/map_eta: adjust font size to avoid text overflow

### DIFF
--- a/selfdrive/ui/qt/maps/map_eta.cc
+++ b/selfdrive/ui/qt/maps/map_eta.cc
@@ -4,6 +4,7 @@
 #include <QPainter>
 
 #include "selfdrive/ui/qt/maps/map_helpers.h"
+#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/ui.h"
 
 const float MANEUVER_TRANSITION_THRESHOLD = 10;
@@ -12,16 +13,23 @@ MapETA::MapETA(QWidget *parent) : QWidget(parent) {
   setVisible(false);
   setAttribute(Qt::WA_TranslucentBackground);
   eta_doc.setUndoRedoEnabled(false);
-  eta_doc.setDefaultStyleSheet("body {font-family:Inter;font-size:70px;color:white;} b{font-weight:600;} td{padding:0 3px;}");
+  eta_doc.setDefaultFont(InterFont(font_size));
+  eta_doc.setDefaultStyleSheet("body {color:white;} b{font-weight:600;} td{padding:0 3px;}");
 }
 
 void MapETA::paintEvent(QPaintEvent *event) {
   if (!eta_doc.isEmpty()) {
+    QSizeF txt_size = eta_doc.size();
+    while (txt_size.width() >= (width() - UI_BORDER_SIZE * 3)) {
+      font_size -= 5;
+      eta_doc.setDefaultFont(InterFont(font_size));
+      txt_size = eta_doc.size();
+    }
+
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
     p.setPen(Qt::NoPen);
     p.setBrush(QColor(0, 0, 0, 150));
-    QSizeF txt_size = eta_doc.size();
     p.drawRoundedRect((width() - txt_size.width()) / 2 - UI_BORDER_SIZE, 0, txt_size.width() + UI_BORDER_SIZE * 2, height() + 25, 25, 25);
     p.translate((width() - txt_size.width()) / 2, (height() - txt_size.height()) / 2);
     eta_doc.drawContents(&p);

--- a/selfdrive/ui/qt/maps/map_eta.cc
+++ b/selfdrive/ui/qt/maps/map_eta.cc
@@ -19,17 +19,11 @@ MapETA::MapETA(QWidget *parent) : QWidget(parent) {
 
 void MapETA::paintEvent(QPaintEvent *event) {
   if (!eta_doc.isEmpty()) {
-    QSizeF txt_size = eta_doc.size();
-    while (txt_size.width() >= (width() - UI_BORDER_SIZE * 3)) {
-      font_size -= 5;
-      eta_doc.setDefaultFont(InterFont(font_size));
-      txt_size = eta_doc.size();
-    }
-
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
     p.setPen(Qt::NoPen);
     p.setBrush(QColor(0, 0, 0, 150));
+    QSizeF txt_size = adjustSize();
     p.drawRoundedRect((width() - txt_size.width()) / 2 - UI_BORDER_SIZE, 0, txt_size.width() + UI_BORDER_SIZE * 2, height() + 25, 25, 25);
     p.translate((width() - txt_size.width()) / 2, (height() - txt_size.height()) / 2);
     eta_doc.drawContents(&p);
@@ -61,4 +55,14 @@ void MapETA::updateETA(float s, float s_typical, float d) {
 
   setVisible(d >= MANEUVER_TRANSITION_THRESHOLD);
   update();
+}
+
+QSizeF MapETA::adjustSize() {
+  QSizeF size = eta_doc.size();
+  while (size.width() >= (width() - UI_BORDER_SIZE * 3)) {
+    font_size -= 5;
+    eta_doc.setDefaultFont(InterFont(font_size));
+    size = eta_doc.size();
+  }
+  return size;
 }

--- a/selfdrive/ui/qt/maps/map_eta.h
+++ b/selfdrive/ui/qt/maps/map_eta.h
@@ -18,6 +18,7 @@ private:
   void showEvent(QShowEvent *event) override { format_24h = param.getBool("NavSettingTime24h"); }
 
   bool format_24h = false;
+  int font_size = 70;
   QTextDocument eta_doc;
   Params param;
 };

--- a/selfdrive/ui/qt/maps/map_eta.h
+++ b/selfdrive/ui/qt/maps/map_eta.h
@@ -15,6 +15,7 @@ public:
 
 private:
   void paintEvent(QPaintEvent *event) override;
+  QSizeF adjustSize();
   void showEvent(QShowEvent *event) override { format_24h = param.getBool("NavSettingTime24h"); }
 
   bool format_24h = false;


### PR DESCRIPTION
before:
![Screenshot from 2023-08-12 21-49-42](https://github.com/commaai/openpilot/assets/27770/71d098d5-e795-4f08-ad8c-dbcc619991b4)
after
![Screenshot from 2023-08-12 22-06-53](https://github.com/commaai/openpilot/assets/27770/7d93662a-129c-4cf3-ab39-e707e5d4f61b)

