### PR TITLE
ui/networking: bolding the connected network

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -347,7 +347,7 @@ void WifiItem::setItem(const Network &n, const QPixmap &status_icon, bool show_f
 
   ssidLabel->setText(n.ssid);
   ssidLabel->setEnabled(n.security_type != SecurityType::UNSUPPORTED);
-  ssidLabel->setFont(InterFont(55, network.connected == ConnectedType::DISCONNECTED ? QFont::Normal : QFont::Medium));
+  ssidLabel->setFont(InterFont(55, network.connected == ConnectedType::DISCONNECTED ? QFont::Normal : QFont::Bold));
 
   connecting->setVisible(n.connected == ConnectedType::CONNECTING);
   forgetBtn->setVisible(show_forget_btn);


### PR DESCRIPTION
Before
![Screenshot from 2023-08-14 13-55-12](https://github.com/commaai/openpilot/assets/27770/e03329c5-1f73-4416-80a0-02f8f8fc61e0)

After
![Screenshot from 2023-08-14 13-53-51](https://github.com/commaai/openpilot/assets/27770/7e6b3f9f-c2c6-41ed-b895-1f97efe82f70)
