### PR TITLE
ui/map_instructions: set margin-top to UI_BORDER_SIZE

### DIFF
--- a/selfdrive/ui/qt/maps/map_instructions.cc
+++ b/selfdrive/ui/qt/maps/map_instructions.cc
@@ -10,7 +10,7 @@ const QString ICON_SUFFIX = ".png";
 MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
   is_rhd = Params().getBool("IsRhdDetected");
   QHBoxLayout *main_layout = new QHBoxLayout(this);
-  main_layout->setContentsMargins(11, 50, 11, 11);
+  main_layout->setContentsMargins(11, UI_BORDER_SIZE, 11, 11);
   main_layout->addWidget(icon_01 = new QLabel, 0, Qt::AlignTop);
 
   QWidget *right_container = new QWidget(this);


### PR DESCRIPTION
current margin(50) is too big. use the same margin(UI_BORDER_SIZE) as `AnnotatedCameraWidget` and `MapETA`
| Before  | After |
| ------------- | ------------- |
| ![2023-08-14_17-52](https://github.com/commaai/openpilot/assets/27770/ac15ea95-110e-42a4-bbac-55247587fcf7)  | ![2023-08-14_17-51](https://github.com/commaai/openpilot/assets/27770/d4f24ee4-f422-4f26-947d-92c469a8fedf)  |

