### PR TITLE
common/util: move function `random_int` to util

### DIFF
--- a/common/util.cc
+++ b/common/util.cc
@@ -213,6 +213,13 @@ std::string hexdump(const uint8_t* in, const size_t size) {
   return ss.str();
 }
 
+int random_int(int min, int max) {
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<std::mt19937::result_type> dist(min, max);
+  return dist(rng);
+}
+
 std::string random_string(std::string::size_type length) {
   const std::string chrs = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   std::mt19937 rg{std::random_device{}()};

--- a/common/util.h
+++ b/common/util.h
@@ -75,8 +75,11 @@ int getenv(const char* key, int default_val);
 float getenv(const char* key, float default_val);
 
 std::string hexdump(const uint8_t* in, const size_t size);
-std::string random_string(std::string::size_type length);
 std::string dir_name(std::string const& path);
+
+// ***** random helpers *****
+int random_int(int min, int max);
+std::string random_string(std::string::size_type length);
 
 // **** file fhelpers *****
 std::string read_file(const std::string& fn);

--- a/selfdrive/boardd/tests/test_boardd_usbprotocol.cc
+++ b/selfdrive/boardd/tests/test_boardd_usbprotocol.cc
@@ -1,17 +1,10 @@
 #define CATCH_CONFIG_MAIN
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
-#include <random>
 
 #include "catch2/catch.hpp"
 #include "cereal/messaging/messaging.h"
+#include "common/util.h"
 #include "selfdrive/boardd/panda.h"
-
-int random_int(int min, int max) {
-  std::random_device dev;
-  std::mt19937 rng(dev());
-  std::uniform_int_distribution<std::mt19937::result_type> dist(min, max);
-  return dist(rng);
-}
 
 struct PandaTest : public Panda {
   PandaTest(uint32_t bus_offset, int can_list_size, cereal::PandaState::PandaType hw_type);
@@ -44,10 +37,10 @@ PandaTest::PandaTest(uint32_t bus_offset_, int can_list_size, cereal::PandaState
   auto can_list = msg.initEvent().initSendcan(can_list_size);
   for (uint8_t i = 0; i < can_list_size; ++i) {
     auto can = can_list[i];
-    uint32_t id = random_int(0, std::size(dlc_to_len) - 1);
+    uint32_t id = util::random_int(0, std::size(dlc_to_len) - 1);
     const std::string &dat = test_data[dlc_to_len[id]];
     can.setAddress(i);
-    can.setSrc(random_int(0, 3) + bus_offset);
+    can.setSrc(util::random_int(0, 3) + bus_offset);
     can.setDat(kj::ArrayPtr((uint8_t *)dat.data(), dat.size()));
     total_pakets_size += sizeof(can_header) + dat.size();
   }

--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -43,13 +43,6 @@ TEST_CASE("httpMultiPartDownload") {
   REQUIRE(sha256(content) == TEST_RLOG_CHECKSUM);
 }
 
-int random_int(int min, int max) {
-  std::random_device dev;
-  std::mt19937 rng(dev());
-  std::uniform_int_distribution<std::mt19937::result_type> dist(min, max);
-  return dist(rng);
-}
-
 TEST_CASE("FileReader") {
   auto enable_local_cache = GENERATE(true, false);
   std::string cache_file = cacheFilePath(TEST_RLOG_URL);
@@ -198,7 +191,7 @@ void TestReplay::test_seek() {
   QEventLoop loop;
   std::thread thread = std::thread([&]() {
     for (int i = 0; i < 10; ++i) {
-      testSeekTo(random_int(0, 1 * 60));
+      testSeekTo(util::random_int(0, 1 * 60));
     }
     loop.quit();
   });


### PR DESCRIPTION
move duplicated function `random_int` to util.   https://github.com/commaai/openpilot/pull/29374 also needs it.