### PR TITLE
soundd: set volume on changes

### DIFF
--- a/selfdrive/ui/soundd/sound.cc
+++ b/selfdrive/ui/soundd/sound.cc
@@ -36,7 +36,10 @@ void Sound::update() {
   if (sm.updated("microphone")) {
     float volume = util::map_val(sm["microphone"].getMicrophone().getFilteredSoundPressureWeightedDb(), 30.f, 60.f, 0.f, 1.f);
     volume = QAudio::convertVolume(volume, QAudio::LogarithmicVolumeScale, QAudio::LinearVolumeScale);
-    Hardware::set_volume(volume);
+    // set volume on changes
+    if (std::exchange(current_volume, std::nearbyint(volume * 10)) != current_volume) {
+      Hardware::set_volume(volume);
+    }
   }
 
   setAlert(Alert::get(sm, 0));

--- a/selfdrive/ui/soundd/sound.cc
+++ b/selfdrive/ui/soundd/sound.cc
@@ -5,7 +5,6 @@
 #include <QAudio>
 #include <QAudioDeviceInfo>
 #include <QDebug>
-#include <QtConcurrent>
 
 #include "cereal/messaging/messaging.h"
 #include "common/util.h"
@@ -34,12 +33,12 @@ void Sound::update() {
   sm.update(0);
 
   // scale volume using ambient noise level
-  if (sm.updated("microphone") && !future.isRunning()) {
+  if (sm.updated("microphone")) {
     float volume = util::map_val(sm["microphone"].getMicrophone().getFilteredSoundPressureWeightedDb(), 30.f, 60.f, 0.f, 1.f);
     volume = QAudio::convertVolume(volume, QAudio::LogarithmicVolumeScale, QAudio::LinearVolumeScale);
     // set volume on changes
     if (std::exchange(current_volume, std::nearbyint(volume * 10)) != current_volume) {
-      future = QtConcurrent::run(Hardware::set_volume, volume);
+      Hardware::set_volume(volume);
     }
   }
 

--- a/selfdrive/ui/soundd/sound.cc
+++ b/selfdrive/ui/soundd/sound.cc
@@ -5,6 +5,7 @@
 #include <QAudio>
 #include <QAudioDeviceInfo>
 #include <QDebug>
+#include <QtConcurrent>
 
 #include "cereal/messaging/messaging.h"
 #include "common/util.h"
@@ -33,12 +34,12 @@ void Sound::update() {
   sm.update(0);
 
   // scale volume using ambient noise level
-  if (sm.updated("microphone")) {
+  if (sm.updated("microphone") && !future.isRunning()) {
     float volume = util::map_val(sm["microphone"].getMicrophone().getFilteredSoundPressureWeightedDb(), 30.f, 60.f, 0.f, 1.f);
     volume = QAudio::convertVolume(volume, QAudio::LogarithmicVolumeScale, QAudio::LinearVolumeScale);
     // set volume on changes
     if (std::exchange(current_volume, std::nearbyint(volume * 10)) != current_volume) {
-      Hardware::set_volume(volume);
+      future = QtConcurrent::run(Hardware::set_volume, volume);
     }
   }
 

--- a/selfdrive/ui/soundd/sound.h
+++ b/selfdrive/ui/soundd/sound.h
@@ -30,4 +30,5 @@ protected:
   SubMaster sm;
   Alert current_alert = {};
   QMap<AudibleAlert, QPair<QSoundEffect *, int>> sounds;
+  int current_volume = -1;
 };

--- a/selfdrive/ui/soundd/sound.h
+++ b/selfdrive/ui/soundd/sound.h
@@ -1,4 +1,3 @@
-#include <QFuture>
 #include <QMap>
 #include <QSoundEffect>
 #include <QString>
@@ -30,7 +29,6 @@ protected:
 
   SubMaster sm;
   Alert current_alert = {};
-  int current_volume = -1;
-  QFuture<void> future;
   QMap<AudibleAlert, QPair<QSoundEffect *, int>> sounds;
+  int current_volume = -1;
 };

--- a/selfdrive/ui/soundd/sound.h
+++ b/selfdrive/ui/soundd/sound.h
@@ -1,3 +1,4 @@
+#include <QFuture>
 #include <QMap>
 #include <QSoundEffect>
 #include <QString>
@@ -29,6 +30,7 @@ protected:
 
   SubMaster sm;
   Alert current_alert = {};
-  QMap<AudibleAlert, QPair<QSoundEffect *, int>> sounds;
   int current_volume = -1;
+  QFuture<void> future;
+  QMap<AudibleAlert, QPair<QSoundEffect *, int>> sounds;
 };


### PR DESCRIPTION
~async~ set volumn on changes. (same as async set_brightnes in ui.cc)
resolve https://github.com/commaai/openpilot/issues/28992  （not tested on the device at the moment, but it should be solved.）

`hardware::set_volume `invokes expensive system calls.  blocking call it at 10hz can impact performance, And it may cause `soundd` to be unable to run stably at 20hz, and in the worst case, may cause some alerts to be lost.