### PR TITLE
CI: docs speedup by caching first stage

### DIFF
--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -108,7 +108,7 @@ jobs:
         file: docs/docker/Dockerfile
         push: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
         pull: true
-        tags: $DOCKER_REGISTRY/openpilot-docs-base:latest
+        tags: $DOCKER_REGISTRY/openpilot-docs:latest
         cache-to:
           - type=inline
         cache-from:

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -79,38 +79,13 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    -
-      name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-    -
-      name: Login to GHCR
-      uses: docker/login-action@v2
-      with:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    -
-      name: Build base docker image
-      uses: docker/build-push-action@v4
-      with:
-        file: docs/docker/Dockerfile
-        push: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
-        pull: true
-        tags: $DOCKER_REGISTRY/openpilot-docs-base:latest
-        cache-to:
-          - type=inline
-        cache-from:
-          - $DOCKER_REGISTRY/openpilot-docs-base:latest
-        target: openpilot-docs-base
-    -
-      name: Build docs docker image
-      uses: docker/build-push-action@v4
-      with:
-        file: docs/docker/Dockerfile
-        push: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
-        pull: true
-        tags: $DOCKER_REGISTRY/openpilot-docs:latest
-        cache-to:
-          - type=inline
-        cache-from:
-          - $DOCKER_REGISTRY/openpilot-docs-base:latest
-          - $DOCKER_REGISTRY/openpilot-docs:latest
+    - name: Build docker container
+      run: |
+        DOCKER_BUILDKIT=1 docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_REGISTRY/openpilot-docs-base:latest -t $DOCKER_REGISTRY/openpilot-docs-base:latest -f docs/docker/Dockerfile --target openpilot-docs-base .
+        DOCKER_BUILDKIT=1 docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_REGISTRY/openpilot-docs-base:latest --cache-from $DOCKER_REGISTRY/openpilot-docs:latest -t $DOCKER_REGISTRY/openpilot-docs:latest -f docs/docker/Dockerfile .
+    - name: Push docker container
+      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
+      run: |
+        $DOCKER_LOGIN
+        docker push $DOCKER_REGISTRY/openpilot-docs-base:latest
+        docker push $DOCKER_REGISTRY/openpilot-docs:latest

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -79,11 +79,38 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Build docker container
-      run: |
-        DOCKER_BUILDKIT=1 docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_REGISTRY/openpilot-docs:latest -t $DOCKER_REGISTRY/openpilot-docs:latest -f docs/docker/Dockerfile .
-    - name: Push docker container
-      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
-      run: |
-        $DOCKER_LOGIN
-        docker push $DOCKER_REGISTRY/openpilot-docs:latest
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    -
+      name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    -
+      name: Build base docker image
+      uses: docker/build-push-action@v4
+      with:
+        file: docs/docker/Dockerfile
+        push: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
+        pull: true
+        tags: $DOCKER_REGISTRY/openpilot-docs-base:latest
+        cache-to:
+          - type=inline
+        cache-from:
+          - $DOCKER_REGISTRY/openpilot-docs-base:latest
+        target: openpilot-docs-base
+    -
+      name: Build docs docker image
+      uses: docker/build-push-action@v4
+      with:
+        file: docs/docker/Dockerfile
+        push: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
+        pull: true
+        tags: $DOCKER_REGISTRY/openpilot-docs-base:latest
+        cache-to:
+          - type=inline
+        cache-from:
+          - $DOCKER_REGISTRY/openpilot-docs-base:latest
+          - $DOCKER_REGISTRY/openpilot-docs:latest

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/commaai/openpilot-base:latest
+FROM ghcr.io/commaai/openpilot-base:latest as openpilot-docs-base
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
the docs image is a multistage build meaning we weren't using any of the first stage as cache. @adeebshihadeh what do you think about using the docker/build-push-action@v4 for all the docker builds?