### PR TITLE
cabana: set border color for scatter series

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -764,6 +764,7 @@ QXYSeries *ChartView::createSeries(SeriesType type, QColor color) {
     chart()->legend()->setMarkerShape(QLegend::MarkerShapeFromSeries);
   } else {
     series = new QScatterSeries(this);
+    static_cast<QScatterSeries*>(series)->setBorderColor(color);
     chart()->legend()->setMarkerShape(QLegend::MarkerShapeCircle);
   }
   series->setColor(color);


### PR DESCRIPTION
resolve: scatter series can be hard to see in light mode without opengl( https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6722164), thanks to @nworb-cire for the bug report.

the default border color is white when series is drawn without opengl. set border color to the color of the signal to fix this issue.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-08-16 00-49-16](https://github.com/commaai/openpilot/assets/27770/6af1e168-8416-4f2d-9f70-84b18812dab9)  | ![Screenshot from 2023-08-16 00-48-11](https://github.com/commaai/openpilot/assets/27770/74212f79-d125-439a-a080-2ba4819b6e76)  |
| ![Screenshot from 2023-08-16 00-38-53](https://github.com/commaai/openpilot/assets/27770/ed220e3d-72af-426d-a7bd-a3b316ccaf27) | ![Screenshot from 2023-08-16 00-41-53](https://github.com/commaai/openpilot/assets/27770/2a044b96-8a5a-47af-8214-ce57dfe8142f) |








