### PR TITLE
CI: ignore most of repo when building docker images

### DIFF
--- a/Dockerfile.openpilot_base.dockerignore
+++ b/Dockerfile.openpilot_base.dockerignore
@@ -1,6 +1,7 @@
 # ignore all files
 *
 
+# except for a few scripts we need to build from
 !/pyproject.toml
 !/poetry.lock
 !/.python-version

--- a/Dockerfile.openpilot_base.dockerignore
+++ b/Dockerfile.openpilot_base.dockerignore
@@ -1,0 +1,9 @@
+# ignore all files
+*
+
+!/pyproject.toml
+!/poetry.lock
+!/.python-version
+
+!/tools/ubuntu_setup.sh
+!/tools/install_python_dependencies.sh

--- a/Dockerfile.openpilot_base_cl.dockerignore
+++ b/Dockerfile.openpilot_base_cl.dockerignore
@@ -1,0 +1,2 @@
+# ignore all files
+*


### PR DESCRIPTION
Docker has to copy most of the repo into the docker context atm, but these two dockerfiles only use a few scripts. Should speed up the build and also might prevent cache misses on buildjet