### PR TITLE
Subaru gen2: limit jerk by reducing steer delta

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -22,8 +22,8 @@ class CarControllerParams:
 
     if CP.carFingerprint in GLOBAL_GEN2:
       self.STEER_MAX = 1000
-      self.STEER_DELTA_UP = 40
-      self.STEER_DELTA_DOWN = 40
+      self.STEER_DELTA_UP = 25
+      self.STEER_DELTA_DOWN = 35
     elif CP.carFingerprint == CAR.IMPREZA_2020:
       self.STEER_MAX = 1439
     else:

--- a/selfdrive/car/tests/test_lateral_limits.py
+++ b/selfdrive/car/tests/test_lateral_limits.py
@@ -10,7 +10,6 @@ from common.realtime import DT_CTRL
 from selfdrive.car.car_helpers import interfaces
 from selfdrive.car.fingerprints import all_known_cars
 from selfdrive.car.interfaces import get_torque_params
-from selfdrive.car.subaru.values import CAR as SUBARU
 
 CAR_MODELS = all_known_cars()
 
@@ -22,12 +21,6 @@ MAX_LAT_JERK_UP_TOLERANCE = 0.5  # m/s^3
 
 # jerk is measured over half a second
 JERK_MEAS_T = 0.5
-
-# TODO: put these cars within limits
-ABOVE_LIMITS_CARS = [
-  SUBARU.LEGACY,
-  SUBARU.OUTBACK,
-]
 
 car_model_jerks: DefaultDict[str, Dict[str, float]] = defaultdict(dict)
 
@@ -49,9 +42,6 @@ class TestLateralLimits(unittest.TestCase):
       raise unittest.SkipTest
 
     if CP.notCar:
-      raise unittest.SkipTest
-
-    if CP.carFingerprint in ABOVE_LIMITS_CARS:
       raise unittest.SkipTest
 
     CarControllerParams = importlib.import_module(f'selfdrive.car.{CP.carName}.values').CarControllerParams


### PR DESCRIPTION
We currently limit gen2 cars to about half of gen1, but the delta is not half, which causes the jerk to be too high.

We might want to redo the lateral acceleration tests with the outback after the steering alignment was fixed, because it probably isn't actually that extreme:
https://github.com/commaai/openpilot/pull/29097

Should also limit panda to the same