### PR TITLE
replay: fix seekTo issue

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -18,7 +18,7 @@ Replay::Replay(QString route, QStringList allow, QStringList block, QStringList 
   for (const auto &it : services) {
     uint16_t which = event_struct.getFieldByName(it.name).getProto().getDiscriminantValue();
     if ((which == cereal::Event::Which::UI_DEBUG || which == cereal::Event::Which::USER_FLAG) &&
-        !(flags & REPLAY_FLAG_ALL_SERVICES) && 
+        !(flags & REPLAY_FLAG_ALL_SERVICES) &&
         !allow.contains(it.name)) {
       continue;
     }

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -307,7 +307,8 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
     updateEvents([&]() {
       events_.swap(new_events_);
       segments_merged_ = segments_need_merge;
-      return true;
+      // Do not wake up the stream thread if the current segment has not been merged.
+      return isSegmentMerged(current_segment_) || (segments_.count(current_segment_) == 0);
     });
   }
 }

--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -147,7 +147,7 @@ TEST_CASE("Route") {
 // helper class for unit tests
 class TestReplay : public Replay {
  public:
-  TestReplay(const QString &route, uint8_t flags = REPLAY_FLAG_NO_FILE_CACHE) : Replay(route, {}, {}, {}, nullptr, flags) {}
+  TestReplay(const QString &route, uint32_t flags = REPLAY_FLAG_NO_FILE_CACHE | REPLAY_FLAG_NO_VIPC) : Replay(route, {}, {}, {}, nullptr, flags) {}
   void test_seek();
   void testSeekTo(int seek_to);
 };
@@ -191,7 +191,7 @@ void TestReplay::test_seek() {
   QEventLoop loop;
   std::thread thread = std::thread([&]() {
     for (int i = 0; i < 10; ++i) {
-      testSeekTo(util::random_int(0, 1 * 60));
+      testSeekTo(util::random_int(0, 2 * 60));
     }
     loop.quit();
   });


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/29398. 
fixes a long-standing bug: the stream thread may jumps to a wrong segment tafter seekto.
