### PR TITLE
CI: add option to build a scons cache docker image

### DIFF
--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -3,9 +3,8 @@ name: 'openpilot env setup'
 inputs:
   setup_docker_scons_cache:
     description: 'Whether or not to build the scons-cache docker image'
-    type: boolean
     required: false
-    default: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -31,7 +30,7 @@ runs:
     - id: setup-scons-cache-docker
       name: Sets up a docker image with scons cache that can by mounted as a buildkit cache mount
       shell: bash
-      if: ${{ inputs.setup_docker_scons_cache }}
+      if: ${{ inputs.setup_docker_scons_cache == 'true' }}
       run: |
         cp Dockerfile.scons_cache ~
         cd ~/scons_cache

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -1,5 +1,12 @@
 name: 'openpilot env setup'
 
+inputs:
+  setup_docker_scons_cache:
+    description: 'Whether or not to build the scons-cache docker image'
+    type: boolean
+    required: false
+    default: false
+
 runs:
   using: "composite"
   steps:
@@ -21,7 +28,13 @@ runs:
         restore-keys: |
           scons-${{ env.CACHE_COMMIT_DATE }}-
           scons-
-
+    - id: setup-scons-cache-docker
+      name: Sets up a docker image with scons cache that can by mounted as a buildkit cache mount
+      if: ${{ github.event.inputs.setup_docker_scons_cache }}
+      run: |
+        cp Dockerfile.scons_cache ~
+        cd ~/scons_cache
+        DOCKER_BUILDKIT=1 docker build -t scons-cache -f Dockerfile.scons_cache .
     # build our docker image
     - shell: bash
       run: eval ${{ env.BUILD }}

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -30,6 +30,7 @@ runs:
           scons-
     - id: setup-scons-cache-docker
       name: Sets up a docker image with scons cache that can by mounted as a buildkit cache mount
+      shell: bash
       if: ${{ github.event.inputs.setup_docker_scons_cache }}
       run: |
         cp Dockerfile.scons_cache ~

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -31,7 +31,7 @@ runs:
     - id: setup-scons-cache-docker
       name: Sets up a docker image with scons cache that can by mounted as a buildkit cache mount
       shell: bash
-      if: ${{ github.event.inputs.setup_docker_scons_cache }}
+      if: ${{ inputs.setup_docker_scons_cache }}
       run: |
         cp Dockerfile.scons_cache ~
         cd ~/scons_cache

--- a/Dockerfile.scons_cache
+++ b/Dockerfile.scons_cache
@@ -1,0 +1,3 @@
+FROM alpine:3
+
+COPY ./scons_cache /tmp/scons_cache


### PR DESCRIPTION
If we build a docker image that contains the scons cache, we can use --mount in buildkit to use this cache in other docker images, without it bloating the size of the image