### PR TITLE
SCons: respect cache read only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 .tags
 .ipynb_checkpoints
 .idea
+.moc_files
 .overlay_init
 .overlay_consistent
 .sconsign.dblite

--- a/SConstruct
+++ b/SConstruct
@@ -337,7 +337,7 @@ qt_env['LIBS'] = qt_libs
 
 # Have to respect cache-readonly
 if GetOption('cache_readonly'):
-  qt_env['QT3_MOCHPREFIX'] = './moc_files/moc_'
+  qt_env['QT3_MOCHPREFIX'] = '#.moc_files/moc_'
 else:
   qt_env['QT3_MOCHPREFIX'] = cache_dir + '/moc_files/moc_'
 

--- a/SConstruct
+++ b/SConstruct
@@ -334,7 +334,12 @@ qt_flags = [
 qt_env['CXXFLAGS'] += qt_flags
 qt_env['LIBPATH'] += ['#selfdrive/ui']
 qt_env['LIBS'] = qt_libs
-qt_env['QT3_MOCHPREFIX'] = cache_dir + '/moc_files/moc_'
+
+# Have to respect cache-readonly
+if GetOption('cache_readonly'):
+  qt_env['QT3_MOCHPREFIX'] = './moc_files/moc_'
+else:
+  qt_env['QT3_MOCHPREFIX'] = cache_dir + '/moc_files/moc_'
 
 if GetOption("clazy"):
   checks = [

--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -337,7 +338,13 @@ qt_env['LIBS'] = qt_libs
 
 # Have to respect cache-readonly
 if GetOption('cache_readonly'):
-  qt_env['QT3_MOCHPREFIX'] = '#.moc_files/moc_'
+  local_moc_files_dir = Dir("#.moc_files").abspath
+  cache_moc_files_dir = cache_dir + "/moc_files"
+  if os.path.exists(local_moc_files_dir):
+    shutil.rmtree(local_moc_files_dir)
+  if os.path.exists(cache_moc_files_dir):
+    shutil.copytree(cache_moc_files_dir, local_moc_files_dir)
+  qt_env['QT3_MOCHPREFIX'] = local_moc_files_dir + "/moc_"
 else:
   qt_env['QT3_MOCHPREFIX'] = cache_dir + '/moc_files/moc_'
 


### PR DESCRIPTION
currently the moc_files don't respect the cache-readonly param to scons, since building will write to this directory if it doesn't already exist.
This PR will make it so if we have cache-readonly set, we put the cache folder in the local directory so it doesn't make any permanent changes to the cache

required for: https://github.com/commaai/openpilot/pull/29436
because the --mount from buildkit is readonly