### PR TITLE
Multilang: more translation sanity checks

### DIFF
--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -87,9 +87,16 @@ class TestTranslations(unittest.TestCase):
               if translation.get("type") == "unfinished":
                 continue
 
-              self.assertNotIn(None, numerusform, "Ensure all plural translation forms are completed.")
-              self.assertTrue(all(re.search("%[0-9]+", t) is None for t in numerusform),
-                              "Plural translations must use %n, not %1, %2, etc.: {}".format(numerusform))
+              for nf in numerusform:
+                self.assertIsNotNone(nf, "Ensure all plural translation forms are completed.")
+                self.assertIn("%n", nf, "Ensure numerus argument (%n) exists in translation.")
+                self.assertIsNone(re.search("%[0-9]+", nf), "Plural translations must use %n, not %1, %2, etc.: {}".format(numerusform))
+            else:
+              translation = message.find("translation")
+              if translation.get("type") == "unfinished":
+                continue
+              self.assertTrue(translation.text is not None and len(translation.text.strip()), translation.text)
+              # print(message.find("translation").text)
 
   def test_no_locations(self):
     for name, file in self.translation_files.items():

--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -67,11 +67,14 @@ class TestTranslations(unittest.TestCase):
         self.assertTrue("<translation type=\"vanished\">" not in cur_translations,
                         f"{file} ({name}) translation file has obsolete translations. Run selfdrive/ui/update_translations.py --vanish to remove them")
 
-  def test_plural_translations(self):
+  def test_finished_translations(self):
     """
-      Tests:
-      - that any numerus (plural) translations marked "finished" have all plural forms non-empty
+      Tests ran on each translation marked "finished"
+      Plural:
+      - that any numerus (plural) translations have all plural forms non-empty
       - that the correct format specifier is used (%n)
+      Non-plural:
+      - that translation is not empty
     """
     for name, file in self.translation_files.items():
       with self.subTest(name=name, file=file):
@@ -79,24 +82,23 @@ class TestTranslations(unittest.TestCase):
 
         for context in tr_xml.getroot():
           for message in context.iterfind("message"):
+            translation = message.find("translation")
+            source_text = message.find("source").text
+
+            # Do not test unfinished translations
+            if translation.get("type") == "unfinished":
+              continue
+
             if message.get("numerus") == "yes":
-              translation = message.find("translation")
               numerusform = [t.text for t in translation.findall("numerusform")]
 
-              # Do not assert finished translations
-              if translation.get("type") == "unfinished":
-                continue
-
               for nf in numerusform:
-                self.assertIsNotNone(nf, "Ensure all plural translation forms are completed.")
+                self.assertIsNotNone(nf, f"Ensure all plural translation forms are completed: {source_text}")
                 self.assertIn("%n", nf, "Ensure numerus argument (%n) exists in translation.")
                 self.assertIsNone(re.search("%[0-9]+", nf), "Plural translations must use %n, not %1, %2, etc.: {}".format(numerusform))
+
             else:
-              translation = message.find("translation")
-              if translation.get("type") == "unfinished":
-                continue
-              self.assertTrue(translation.text is not None and len(translation.text.strip()), translation.text)
-              # print(message.find("translation").text)
+              self.assertIsNotNone(translation.text, f"Ensure translation is completed: {source_text}")
 
   def test_no_locations(self):
     for name, file in self.translation_files.items():

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -836,27 +836,27 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Wi-Fi</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ETH</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>2G</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>3G</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>LTE</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>5G</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Catches missing %n (typo) in https://github.com/commaai/openpilot/pull/25765, and missing Traditional Chinese translations