### PR TITLE
Multilang: check format arguments are consistent

### DIFF
--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -11,6 +11,7 @@ from selfdrive.ui.update_translations import TRANSLATIONS_DIR, LANGUAGES_FILE, u
 TMP_TRANSLATIONS_DIR = os.path.join(TRANSLATIONS_DIR, "tmp")
 UNFINISHED_TRANSLATION_TAG = "<translation type=\"unfinished\""  # non-empty translations can be marked unfinished
 LOCATION_TAG = "<location "
+FORMAT_ARG = re.compile("%[0-9]+")
 
 
 class TestTranslations(unittest.TestCase):
@@ -96,13 +97,13 @@ class TestTranslations(unittest.TestCase):
               for nf in numerusform:
                 self.assertIsNotNone(nf, f"Ensure all plural translation forms are completed: {source_text}")
                 self.assertIn("%n", nf, "Ensure numerus argument (%n) exists in translation.")
-                self.assertIsNone(re.search("%[0-9]+", nf), "Plural translations must use %n, not %1, %2, etc.: {}".format(numerusform))
+                self.assertIsNone(FORMAT_ARG.search(nf), "Plural translations must use %n, not %1, %2, etc.: {}".format(numerusform))
 
             else:
               self.assertIsNotNone(translation.text, f"Ensure translation is completed: {source_text}")
 
-              source_args = re.findall("%[0-9]+", source_text)
-              translation_args = re.findall("%[0-9]+", translation.text)
+              source_args = FORMAT_ARG.findall(source_text)
+              translation_args = FORMAT_ARG.findall(translation.text)
               self.assertEqual(sorted(source_args), sorted(translation_args),
                                f"Ensure format arguments are consistent: `{source_text}` vs. `{translation.text}`")
 

--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -75,6 +75,7 @@ class TestTranslations(unittest.TestCase):
       - that the correct format specifier is used (%n)
       Non-plural:
       - that translation is not empty
+      - that translation format arguments are consistent
     """
     for name, file in self.translation_files.items():
       with self.subTest(name=name, file=file):
@@ -99,6 +100,11 @@ class TestTranslations(unittest.TestCase):
 
             else:
               self.assertIsNotNone(translation.text, f"Ensure translation is completed: {source_text}")
+
+              source_args = re.findall("%[0-9]+", source_text)
+              translation_args = re.findall("%[0-9]+", translation.text)
+              self.assertEqual(sorted(source_args), sorted(translation_args),
+                               f"Ensure format arguments are consistent: `{source_text}` vs. `{translation.text}`")
 
   def test_no_locations(self):
     for name, file in self.translation_files.items():


### PR DESCRIPTION
catches another issue in https://github.com/commaai/openpilot/pull/25765