### PR TITLE
ui/networking: pass network by value

### DIFF
--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -77,7 +77,7 @@ void Networking::refresh() {
   an->refresh();
 }
 
-void Networking::connectToNetwork(const Network &n) {
+void Networking::connectToNetwork(const Network n) {
   if (wifi->isKnownConnection(n.ssid)) {
     wifi->activateWifiConnection(n.ssid);
     wifiWidget->refresh();
@@ -310,7 +310,7 @@ WifiItem *WifiUI::getItem(int n) {
   auto item = n < wifi_items.size() ? wifi_items[n] : wifi_items.emplace_back(new WifiItem(tr("CONNECTING..."), tr("FORGET")));
   if (!item->parentWidget()) {
     QObject::connect(item, &WifiItem::connectToNetwork, this, &WifiUI::connectToNetwork);
-    QObject::connect(item, &WifiItem::forgotNetwork, [this](const Network &n) {
+    QObject::connect(item, &WifiItem::forgotNetwork, [this](const Network n) {
       if (ConfirmationDialog::confirm(tr("Forget Wi-Fi Network \"%1\"?").arg(QString::fromUtf8(n.ssid)), tr("Forget"), this))
         wifi->forgetConnection(n.ssid);
     });

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -12,8 +12,9 @@ public:
   void setItem(const Network& n, const QPixmap &icon, bool show_forget_btn, const QPixmap &strength);
 
 signals:
-  void connectToNetwork(const Network &n);
-  void forgotNetwork(const Network &n);
+  // Cannot pass Network by reference. it may change after the signal is sent.
+  void connectToNetwork(const Network n);
+  void forgotNetwork(const Network n);
 
 protected:
   ElidedLabel* ssidLabel;
@@ -43,7 +44,7 @@ private:
   std::vector<WifiItem*> wifi_items;
 
 signals:
-  void connectToNetwork(const Network &n);
+  void connectToNetwork(const Network n);
 
 public slots:
   void refresh();
@@ -91,6 +92,6 @@ public slots:
   void refresh();
 
 private slots:
-  void connectToNetwork(const Network &n);
+  void connectToNetwork(const Network n);
   void wrongPassword(const QString &ssid);
 };


### PR DESCRIPTION

Cannot pass Network by reference after #29037. it may change after a refresh.  this can cause the ssid to potentially change to another network's when the password/forget network dialog displayed. 