### PR TITLE
ui/settings: Don't apply styles to more elements than needed.

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -345,10 +345,6 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
   QVBoxLayout *sidebar_layout = new QVBoxLayout(sidebar_widget);
   sidebar_layout->setMargin(0);
   panel_widget = new QStackedWidget();
-  panel_widget->setStyleSheet(R"(
-    border-radius: 30px;
-    background-color: #292929;
-  )");
 
   // close button
   QPushButton *close_btn = new QPushButton(tr("×"));
@@ -436,6 +432,10 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
     }
     SettingsWindow {
       background-color: black;
+    }
+    QStackedWidget, ScrollView {
+      background-color: #292929;
+      border-radius: 30px;
     }
   )");
 }

--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -23,7 +23,7 @@ AbstractControl::AbstractControl(const QString &title, const QString &desc, cons
   // title
   title_label = new QPushButton(title);
   title_label->setFixedHeight(120);
-  title_label->setStyleSheet("font-size: 50px; font-weight: 400; text-align: left");
+  title_label->setStyleSheet("font-size: 50px; font-weight: 400; text-align: left; border: none;");
   hlayout->addWidget(title_label, 1);
 
   // value next to control button


### PR DESCRIPTION
Don't apply border-raduis, backgound-color to all child items.
| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-08-18 17-02-47](https://github.com/commaai/openpilot/assets/27770/b945cb55-a6c7-4d62-a39e-4d4021a0695b)  | ![Screenshot from 2023-08-18 17-08-46](https://github.com/commaai/openpilot/assets/27770/d463bb76-01a7-4d2f-b81d-a3fca684d636)  |
| ![Screenshot from 2023-08-18 17-02-27](https://github.com/commaai/openpilot/assets/27770/123ca870-7e91-4060-ad9d-5bdff016a7cd)  | ![Screenshot from 2023-08-18 17-08-37](https://github.com/commaai/openpilot/assets/27770/1eee3f82-85db-4f25-b74c-b70541b9527a)  |
| ![Screenshot from 2023-08-18 17-02-01](https://github.com/commaai/openpilot/assets/27770/bca6d10f-3f87-4db5-aac6-bbe8015c0a91)  | ![Screenshot from 2023-08-18 17-08-28](https://github.com/commaai/openpilot/assets/27770/dd1e5711-f932-4138-9559-981f54535341)  |






