### PR TITLE
ui/map_instructions: center lanes

### DIFF
--- a/selfdrive/ui/qt/maps/map_instructions.cc
+++ b/selfdrive/ui/qt/maps/map_instructions.cc
@@ -33,11 +33,7 @@ MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
   main_layout->addLayout(top_layout);
   main_layout->addLayout(lane_layout = new QHBoxLayout);
   lane_layout->setAlignment(Qt::AlignHCenter);
-  qDebug() << "spacing" << lane_layout->spacing();
   lane_layout->setSpacing(10);
-  qDebug() << "spacing" << lane_layout->spacing();
-//  lane_layout->addStretch(0);
-//  lane_layout->addStretch(0);
 
   setStyleSheet("color:white");
   QPalette pal = palette();
@@ -132,7 +128,6 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
 
     QLabel *label = (i < lane_labels.size()) ? lane_labels[i] : lane_labels.emplace_back(new QLabel);
     if (!label->parentWidget()) {
-//      lane_layout->insertWidget(lane_layout->count() - 1, label);
       lane_layout->addWidget(label);
     }
     label->setPixmap(pixmap_cache[fn]);

--- a/selfdrive/ui/qt/maps/map_instructions.cc
+++ b/selfdrive/ui/qt/maps/map_instructions.cc
@@ -10,27 +10,30 @@ const QString ICON_SUFFIX = ".png";
 
 MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
   is_rhd = Params().getBool("IsRhdDetected");
-  QHBoxLayout *main_layout = new QHBoxLayout(this);
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(11, UI_BORDER_SIZE, 11, 11);
-  main_layout->addWidget(icon_01 = new QLabel, 0, Qt::AlignTop);
 
-  QWidget *right_container = new QWidget(this);
-  right_container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-  QVBoxLayout *layout = new QVBoxLayout(right_container);
+  QHBoxLayout *top_layout = new QHBoxLayout;
+  top_layout->addWidget(icon_01 = new QLabel, 0, Qt::AlignTop);
 
-  layout->addWidget(distance = new QLabel);
+  QVBoxLayout *right_layout = new QVBoxLayout;
+  right_layout->addWidget(distance = new QLabel);
   distance->setStyleSheet(R"(font-size: 90px;)");
 
-  layout->addWidget(primary = new QLabel);
+  right_layout->addWidget(primary = new QLabel);
   primary->setStyleSheet(R"(font-size: 60px;)");
   primary->setWordWrap(true);
 
-  layout->addWidget(secondary = new QLabel);
+  right_layout->addWidget(secondary = new QLabel);
   secondary->setStyleSheet(R"(font-size: 50px;)");
   secondary->setWordWrap(true);
 
-  layout->addLayout(lane_layout = new QHBoxLayout);
-  main_layout->addWidget(right_container);
+  top_layout->addLayout(right_layout);
+
+  main_layout->addLayout(top_layout);
+  main_layout->addLayout(lane_layout = new QHBoxLayout);
+  lane_layout->addStretch(0);
+  lane_layout->addStretch(0);
 
   setStyleSheet("color:white");
   QPalette pal = palette();
@@ -125,7 +128,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
 
     QLabel *label = (i < lane_labels.size()) ? lane_labels[i] : lane_labels.emplace_back(new QLabel);
     if (!label->parentWidget()) {
-      lane_layout->addWidget(label);
+      lane_layout->insertWidget(lane_layout->count() - 1, label);
     }
     label->setPixmap(pixmap_cache[fn]);
     label->setVisible(true);

--- a/selfdrive/ui/qt/maps/map_instructions.cc
+++ b/selfdrive/ui/qt/maps/map_instructions.cc
@@ -32,8 +32,12 @@ MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
 
   main_layout->addLayout(top_layout);
   main_layout->addLayout(lane_layout = new QHBoxLayout);
-  lane_layout->addStretch(0);
-  lane_layout->addStretch(0);
+  lane_layout->setAlignment(Qt::AlignHCenter);
+  qDebug() << "spacing" << lane_layout->spacing();
+  lane_layout->setSpacing(10);
+  qDebug() << "spacing" << lane_layout->spacing();
+//  lane_layout->addStretch(0);
+//  lane_layout->addStretch(0);
 
   setStyleSheet("color:white");
   QPalette pal = palette();
@@ -128,7 +132,8 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
 
     QLabel *label = (i < lane_labels.size()) ? lane_labels[i] : lane_labels.emplace_back(new QLabel);
     if (!label->parentWidget()) {
-      lane_layout->insertWidget(lane_layout->count() - 1, label);
+//      lane_layout->insertWidget(lane_layout->count() - 1, label);
+      lane_layout->addWidget(label);
     }
     label->setPixmap(pixmap_cache[fn]);
     label->setVisible(true);


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2023-08-18 22:17:02](https://github.com/commaai/openpilot/assets/27770/26c734ef-d2f0-4a26-9c8f-02de72308ede)  | ![Screenshot 2023-08-18 22:17:58](https://github.com/commaai/openpilot/assets/27770/26da0f05-93da-4fd4-96e3-42bcf9bfca86)  |
| ![Screenshot 2023-08-18 22:15:57](https://github.com/commaai/openpilot/assets/27770/59ee9c40-add4-47cd-8921-31c612b846bd)  | ![Screenshot 2023-08-18 22:14:20](https://github.com/commaai/openpilot/assets/27770/04ac04bf-4df0-4485-a28e-b3ad6aa3d4ab)  |
| ![Screenshot 2023-08-18 22:16:32](https://github.com/commaai/openpilot/assets/27770/01d8a250-e990-4f7f-a164-27362e697a6b)  | ![Screenshot 2023-08-18 22:20:05](https://github.com/commaai/openpilot/assets/27770/fc85e465-fe62-44e7-913d-3a00e7ebbfe2)  |

Center lanes like google map & mapbox

google map:
![Screenshot from 2023-08-18 22-30-44](https://github.com/commaai/openpilot/assets/27770/3ce819b2-ae82-4424-84d2-a2f5e27a025b)

mapbox (https://docs.mapbox.com/android/navigation/guides/ui-components/maneuver/):
![Screenshot from 2023-08-18 22-29-47](https://github.com/commaai/openpilot/assets/27770/bd06f5f7-b16b-4858-988a-7774b73f81f1)


