### PR TITLE
CI: run build_mac twice, if setup script changed

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -112,10 +112,10 @@ jobs:
         run: |
           if [[ ${{ steps.filter.outputs.setup_scripts }} == true ]]; then
             # setup scripts have changed, run the build_mac job twice
-            echo "matrix='{\"iterations\": [0, 1]}'" >> "$GITHUB_OUTPUT"
+            echo "matrix={"iterations": [0, 1]}" >> "$GITHUB_OUTPUT"
           else
             # run it once
-            echo "matrix='{\"iterations\": [0]}'" >> "$GITHUB_OUTPUT"
+            echo "matrix={"iterations": [0]}" >> "$GITHUB_OUTPUT"
           fi
 
   build_mac:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -124,6 +124,8 @@ jobs:
     needs: build_mac_matrix
     strategy:
       matrix: ${{fromJson(needs.build_mac_matrix.outputs.matrix)}}
+      fail-fast: true
+      max-parallel: 1
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -112,10 +112,10 @@ jobs:
         run: |
           if [[ ${{ steps.filter.outputs.setup_scripts }} == true ]]; then
             # setup scripts have changed, run the build_mac job twice
-            echo 'matrix={"iterations": [0, 1]}' >> "$GITHUB_OUTPUT"
+            echo 'matrix={"iterations": ["build", "test_cache"]}' >> "$GITHUB_OUTPUT"
           else
             # run it once
-            echo 'matrix={"iterations": [0]}' >> "$GITHUB_OUTPUT"
+            echo 'matrix={"iterations": ["build"]}' >> "$GITHUB_OUTPUT"
           fi
 
   build_mac:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -112,10 +112,10 @@ jobs:
         run: |
           if [[ ${{ steps.filter.outputs.setup_scripts }} == true ]]; then
             # setup scripts have changed, run the build_mac job twice
-            echo "matrix={"iterations": [0, 1]}" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"iterations": [0, 1]}' >> "$GITHUB_OUTPUT"
           else
             # run it once
-            echo "matrix={"iterations": [0]}" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"iterations": [0]}' >> "$GITHUB_OUTPUT"
           fi
 
   build_mac:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -93,9 +93,34 @@ jobs:
         path: ~/scons_cache
         key: scons-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
 
+  build_mac_matrix:
+    name: setup macos build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set_matrix.outputs.matrix }} 
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          setup_scripts:
+            - tools/mac_setup.sh
+            - tools/install_python_dependencies.sh
+      - name: setup matrix
+        id: set_matrix
+        run: |
+          if [[ ${{ steps.filter.outputs.setup_scripts }} == true ]]; then
+            echo "matrix='{\"iterations\": [0, 1]}'" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix='{\"iterations\": [0]}'" >> "$GITHUB_OUTPUT"
+          fi
+
   build_mac:
     name: build macos
     runs-on: macos-latest
+    needs: build_mac_matrix
+    strategy:
+      matrix: ${{fromJson(needs.build_mac_matrix.outputs.matrix)}}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -103,15 +103,18 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
-          setup_scripts:
-            - tools/mac_setup.sh
-            - tools/install_python_dependencies.sh
+          filters: |
+            setup_scripts:
+              - tools/mac_setup.sh
+              - tools/install_python_dependencies.sh
       - name: setup matrix
         id: set_matrix
         run: |
           if [[ ${{ steps.filter.outputs.setup_scripts }} == true ]]; then
+            # setup scripts have changed, run the build_mac job twice
             echo "matrix='{\"iterations\": [0, 1]}'" >> "$GITHUB_OUTPUT"
           else
+            # run it once
             echo "matrix='{\"iterations\": [0]}'" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -107,7 +107,7 @@ jobs:
             setup_scripts:
               - tools/mac_setup.sh
               - tools/install_python_dependencies.sh
-      - name: setup matrix
+      - name: Setup matrix
         id: set_matrix
         run: |
           if [[ ${{ steps.filter.outputs.setup_scripts }} == true ]]; then

--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -31,6 +31,7 @@ EOF
   eval "$(pyenv virtualenv-init -)"
 fi
 
+
 export MAKEFLAGS="-j$(nproc)"
 
 PYENV_PYTHON_VERSION=$(cat $ROOT/.python-version)


### PR DESCRIPTION
This would run the build_mac job twice, to test a cache, if any of the setup scripts changed. 

This would prevent a situation like this: https://github.com/commaai/openpilot/pull/29456, where the first run succeeds, but the one after that, fails due to missing files in build cache.