### PR TITLE
ui/OffroadHome: cleanup layout and style sheet

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -2,7 +2,6 @@
 
 #include <QHBoxLayout>
 #include <QMouseEvent>
-#include <QStackedWidget>
 #include <QVBoxLayout>
 
 #include "selfdrive/ui/qt/offroad/experimental_mode.h"
@@ -142,44 +141,43 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
   center_layout = new QStackedLayout();
 
   QWidget *home_widget = new QWidget(this);
+  home_widget->setObjectName("home_widget");
   {
     QHBoxLayout *home_layout = new QHBoxLayout(home_widget);
     home_layout->setContentsMargins(0, 0, 0, 0);
     home_layout->setSpacing(30);
 
     // left: MapSettings/PrimeAdWidget
-    QStackedWidget *left_widget = new QStackedWidget(this);
+    QStackedLayout *left_columm = new QStackedLayout();
 #ifdef ENABLE_MAPS
-    left_widget->addWidget(new MapSettings);
+    left_columm->addWidget(new MapSettings);
 #else
-    left_widget->addWidget(new DriveStats);
+    left_columm->addWidget(new DriveStats);
 #endif
-    left_widget->addWidget(new PrimeAdWidget);
-    left_widget->setStyleSheet("border-radius: 10px;");
+    left_columm->addWidget(new PrimeAdWidget);
 
-    left_widget->setCurrentIndex(uiState()->primeType() ? 0 : 1);
+    left_columm->setCurrentIndex(uiState()->primeType() ? 0 : 1);
     connect(uiState(), &UIState::primeTypeChanged, [=](int prime_type) {
-      left_widget->setCurrentIndex(prime_type ? 0 : 1);
+      left_columm->setCurrentIndex(prime_type ? 0 : 1);
     });
 
-    home_layout->addWidget(left_widget, 1);
+    home_layout->addLayout(left_columm);
 
     // right: ExperimentalModeButton, SetupWidget
-    QWidget* right_widget = new QWidget(this);
-    QVBoxLayout* right_column = new QVBoxLayout(right_widget);
+    QVBoxLayout* right_column = new QVBoxLayout();
     right_column->setContentsMargins(0, 0, 0, 0);
-    right_widget->setFixedWidth(750);
     right_column->setSpacing(30);
 
     ExperimentalModeButton *experimental_mode = new ExperimentalModeButton(this);
+    experimental_mode->setFixedWidth(750);
     QObject::connect(experimental_mode, &ExperimentalModeButton::openSettings, this, &OffroadHome::openSettings);
-    right_column->addWidget(experimental_mode, 1);
+    right_column->addWidget(experimental_mode);
 
     SetupWidget *setup_widget = new SetupWidget;
     QObject::connect(setup_widget, &SetupWidget::openSettings, this, &OffroadHome::openSettings);
     right_column->addWidget(setup_widget, 1);
 
-    home_layout->addWidget(right_widget, 1);
+    home_layout->addLayout(right_column);
   }
   center_layout->addWidget(home_widget);
 
@@ -212,6 +210,10 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
     }
     OffroadHome > QLabel {
       font-size: 55px;
+    }
+    #home_widget > QWidget {
+      border-radius: 10px;
+      background-color: #333333;
     }
   )");
 }

--- a/selfdrive/ui/qt/widgets/drive_stats.cc
+++ b/selfdrive/ui/qt/widgets/drive_stats.cc
@@ -52,11 +52,6 @@ DriveStats::DriveStats(QWidget* parent) : QFrame(parent) {
   }
 
   setStyleSheet(R"(
-    DriveStats {
-      background-color: #333333;
-      border-radius: 10px;
-    }
-
     QLabel[type="title"] { font-size: 51px; font-weight: 500; }
     QLabel[type="number"] { font-size: 78px; font-weight: 500; }
     QLabel[type="unit"] { font-size: 51px; font-weight: 300; color: #A0A0A0; }

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -172,13 +172,6 @@ PrimeAdWidget::PrimeAdWidget(QWidget* parent) : QFrame(parent) {
     l->setStyleSheet("font-size: 50px; margin-bottom: 15px;");
     main_layout->addWidget(l, 0, Qt::AlignBottom);
   }
-
-  setStyleSheet(R"(
-    PrimeAdWidget {
-      border-radius: 10px;
-      background-color: #333333;
-    }
-  )");
 }
 
 
@@ -246,13 +239,6 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
 
   primeUser->setVisible(uiState()->primeType());
   mainLayout->setCurrentIndex(1);
-
-  setStyleSheet(R"(
-    #primeWidget {
-      border-radius: 10px;
-      background-color: #333333;
-    }
-  )");
 
   // Retain size while hidden
   QSizePolicy sp_retain = sizePolicy();

--- a/selfdrive/ui/qt/widgets/wifi.cc
+++ b/selfdrive/ui/qt/widgets/wifi.cc
@@ -80,14 +80,6 @@ WiFiPromptWidget::WiFiPromptWidget(QWidget *parent) : QFrame(parent) {
     uploading_layout->addWidget(desc);
   }
   stack->addWidget(uploading);
-
-  setStyleSheet(R"(
-    WiFiPromptWidget {
-      background-color: #333333;
-      border-radius: 10px;
-    }
-  )");
-
   QObject::connect(uiState(), &UIState::uiUpdate, this, &WiFiPromptWidget::updateState);
 }
 


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2023-08-19 03:56:03](https://github.com/commaai/openpilot/assets/27770/7fce1f3c-9155-4f0b-94ff-8515eb74c5d5)  | ![Screenshot 2023-08-19 03:56:54](https://github.com/commaai/openpilot/assets/27770/8a58d6bf-a510-42ce-bdb0-fc11908f69ef)  |

1. Remove unnecessary widget containers to reduce overhead.
2. cleanup style sheet, use same border-radius & background-color for all children.
3. fixed a stretch issue:
![2023-08-19_03-52](https://github.com/commaai/openpilot/assets/27770/0bd297f8-4723-48c3-91f4-93b005071f0f)

