### PR TITLE
ui/map: interactive counter fix

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -193,12 +193,12 @@ void MapWindow::updateState(const UIState &s) {
     m_map->updateSource("carPosSource", carPosSource);
   }
 
-  if (interaction_counter != 0){
-    interaction_counter--;
-  } else {
+  if (interaction_counter == 0) {
     if (last_position) m_map->setCoordinate(*last_position);
     if (last_bearing) m_map->setBearing(*last_bearing);
     m_map->setZoom(util::map_val<float>(velocity_filter.x(), 0, 30, MAX_ZOOM, MIN_ZOOM));
+  } else {
+    interaction_counter--;
   }
 
   if (sm.updated("navInstruction")) {

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -10,7 +10,7 @@
 #include "selfdrive/ui/ui.h"
 
 
-const int PAN_TIMEOUT = 100;
+const int INTERACTION_TIMEOUT = 100;
 
 const float MAX_ZOOM = 17;
 const float MIN_ZOOM = 14;
@@ -193,17 +193,12 @@ void MapWindow::updateState(const UIState &s) {
     m_map->updateSource("carPosSource", carPosSource);
   }
 
-  if (pan_counter == 0) {
+  if (interaction_counter != 0){
+    interaction_counter--;
+  } else {
     if (last_position) m_map->setCoordinate(*last_position);
     if (last_bearing) m_map->setBearing(*last_bearing);
-  } else {
-    pan_counter--;
-  }
-
-  if (zoom_counter == 0) {
     m_map->setZoom(util::map_val<float>(velocity_filter.x(), 0, 30, MAX_ZOOM, MIN_ZOOM));
-  } else {
-    zoom_counter--;
   }
 
   if (sm.updated("navInstruction")) {
@@ -307,15 +302,14 @@ void MapWindow::mouseDoubleClickEvent(QMouseEvent *ev) {
   m_map->setZoom(util::map_val<float>(velocity_filter.x(), 0, 30, MAX_ZOOM, MIN_ZOOM));
   update();
 
-  pan_counter = 0;
-  zoom_counter = 0;
+  interaction_counter = 0;
 }
 
 void MapWindow::mouseMoveEvent(QMouseEvent *ev) {
   QPointF delta = ev->localPos() - m_lastPos;
 
   if (!delta.isNull()) {
-    pan_counter = PAN_TIMEOUT;
+    interaction_counter = INTERACTION_TIMEOUT;
     m_map->moveBy(delta / MAP_SCALE);
     update();
   }
@@ -337,7 +331,7 @@ void MapWindow::wheelEvent(QWheelEvent *ev) {
   m_map->scaleBy(1 + factor, ev->pos() / MAP_SCALE);
   update();
 
-  zoom_counter = PAN_TIMEOUT;
+  interaction_counter = INTERACTION_TIMEOUT;
   ev->accept();
 }
 
@@ -362,7 +356,7 @@ void MapWindow::pinchTriggered(QPinchGesture *gesture) {
     // TODO: figure out why gesture centerPoint doesn't work
     m_map->scaleBy(gesture->scaleFactor(), {width() / 2.0 / MAP_SCALE, height() / 2.0 / MAP_SCALE});
     update();
-    zoom_counter = PAN_TIMEOUT;
+    interaction_counter = INTERACTION_TIMEOUT;
   }
 }
 

--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -53,8 +53,7 @@ private:
 
   // Panning
   QPointF m_lastPos;
-  int pan_counter = 0;
-  int zoom_counter = 0;
+  int interaction_counter = 0;
 
   // Position
   std::optional<QMapbox::Coordinate> last_valid_nav_dest;


### PR DESCRIPTION
When the user zooms out to pan a long distance, the zoom counter will cause the view to zoom back in even if the user is still panning around. The same thing occurs for zooming without panning, the center will reset to the last_position. This PR fixes that behavior by combining the counters into a single interaction_counter.

fix https://github.com/commaai/openpilot/issues/28816