### PR TITLE
ui/map: Velocity filter fix

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -152,8 +152,12 @@ struct unique_fd {
 class FirstOrderFilter {
 public:
   FirstOrderFilter(float x0, float ts, float dt) {
-    k_ = (dt / ts) / (1.0 + dt / ts);
     x_ = x0;
+    dt_ = dt;
+    updateAlpha(ts);
+  }
+  inline void updateAlpha(float ts) {
+    k_ = (dt_ / ts) / (1.0 + dt_ / ts);
   }
   inline float update(float x) {
     x_ = (1. - k_) * x_ + k_ * x;
@@ -163,7 +167,7 @@ public:
   inline float x(){ return x_; }
 
 private:
-  float x_, k_;
+  float x_, k_, dt_;
 };
 
 template<typename T>

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -151,6 +151,7 @@ void MapWindow::updateState(const UIState &s) {
     if (locationd_valid) {
       last_position = QMapbox::Coordinate(locationd_pos.getValue()[0], locationd_pos.getValue()[1]);
       last_bearing = RAD2DEG(locationd_orientation.getValue()[2]);
+      velocity_filter.updateAlpha(locationd_velocity.getValue()[0]/3);
       velocity_filter.update(locationd_velocity.getValue()[0]);
     }
   }

--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -151,7 +151,7 @@ void MapWindow::updateState(const UIState &s) {
     if (locationd_valid) {
       last_position = QMapbox::Coordinate(locationd_pos.getValue()[0], locationd_pos.getValue()[1]);
       last_bearing = RAD2DEG(locationd_orientation.getValue()[2]);
-      velocity_filter.updateAlpha(locationd_velocity.getValue()[0]/3);
+      velocity_filter.updateAlpha(abs(locationd_velocity.getValue()[0])/3);
       velocity_filter.update(locationd_velocity.getValue()[0]);
     }
   }


### PR DESCRIPTION
When the vehicle comes to a stop, the map continues to zoom in due to the velocity filter alpha being too high. This fixes the behavior by dynamically adjusting the alpha based on the current speed. This may need to be adjusted based on aesthetic preference. I divide the speed by 3 here `velocity_filter.updateAlpha(locationd_velocity.getValue()[0]/3);` to keep the alpha similar to the init value at at high speed.
