### PR TITLE
Subaru: longitudinal incorrect "inactive" rpm

### DIFF
--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -56,7 +56,7 @@ class CarController:
       cruise_brake = clip(apply_brake, CarControllerParams.BRAKE_MIN, CarControllerParams.BRAKE_MAX)
     else:
       cruise_throttle = CarControllerParams.THROTTLE_INACTIVE
-      cruise_rpm = CarControllerParams.RPM_INACTIVE
+      cruise_rpm = CarControllerParams.RPM_MIN
       cruise_brake = CarControllerParams.BRAKE_MIN
 
     # *** alerts and pcm cancel ***

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -41,13 +41,14 @@ class CarControllerParams:
   RPM_MIN = 0
   RPM_MAX = 2400
 
-  RPM_INACTIVE = 600             # a good base rpm for zero acceleration
+  RPM_INACTIVE = 0
+  RPM_BASE = 600             # a good base rpm for zero acceleration
 
   THROTTLE_LOOKUP_BP = [0, 1]
   THROTTLE_LOOKUP_V = [THROTTLE_INACTIVE, THROTTLE_MAX]
 
   RPM_LOOKUP_BP = [0, 1]
-  RPM_LOOKUP_V = [RPM_INACTIVE, RPM_MAX]
+  RPM_LOOKUP_V = [RPM_BASE, RPM_MAX]
 
   BRAKE_LOOKUP_BP = [-1, 0]
   BRAKE_LOOKUP_V = [BRAKE_MAX, BRAKE_MIN]

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -41,14 +41,13 @@ class CarControllerParams:
   RPM_MIN = 0
   RPM_MAX = 2400
 
-  RPM_INACTIVE = 0
-  RPM_BASE = 600             # a good base rpm for zero acceleration
+  RPM_INACTIVE = 600             # a good base rpm for zero acceleration
 
   THROTTLE_LOOKUP_BP = [0, 1]
   THROTTLE_LOOKUP_V = [THROTTLE_INACTIVE, THROTTLE_MAX]
 
   RPM_LOOKUP_BP = [0, 1]
-  RPM_LOOKUP_V = [RPM_BASE, RPM_MAX]
+  RPM_LOOKUP_V = [RPM_INACTIVE, RPM_MAX]
 
   BRAKE_LOOKUP_BP = [-1, 0]
   BRAKE_LOOKUP_V = [BRAKE_MAX, BRAKE_MIN]


### PR DESCRIPTION
the "inactive" rpm should be zero, not 600 which is just a good base RPM for zero acceleration. caused transmission fault here: https://github.com/commaai/openpilot/issues/29487

Resolves: https://github.com/commaai/openpilot/issues/29487