### PR TITLE
Remove Kia Sorento from LEGACY_SAFETY_MODE_CAR

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1939,8 +1939,8 @@ EV_CAR = {CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.KONA_EV, CAR.KIA_NIRO_EV, CAR
 
 # these cars require a special panda safety mode due to missing counters and checksums in the messages
 LEGACY_SAFETY_MODE_CAR = {CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV,
-                          CAR.KIA_SORENTO, CAR.SONATA_LF, CAR.KIA_OPTIMA_G4, CAR.KIA_OPTIMA_G4_FL, CAR.VELOSTER,
-                          CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022}
+                          CAR.SONATA_LF, CAR.KIA_OPTIMA_G4, CAR.KIA_OPTIMA_G4_FL, CAR.VELOSTER, CAR.GENESIS_G70, CAR.GENESIS_G80,
+                          CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022}
 
 # these cars have not been verified to work with longitudinal yet - radar disable, sending correct messages, etc
 UNSUPPORTED_LONGITUDINAL_CAR = LEGACY_SAFETY_MODE_CAR | {CAR.KIA_NIRO_PHEV}

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1943,7 +1943,7 @@ LEGACY_SAFETY_MODE_CAR = {CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_L
                           CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022}
 
 # these cars have not been verified to work with longitudinal yet - radar disable, sending correct messages, etc
-UNSUPPORTED_LONGITUDINAL_CAR = LEGACY_SAFETY_MODE_CAR | {CAR.KIA_NIRO_PHEV}
+UNSUPPORTED_LONGITUDINAL_CAR = LEGACY_SAFETY_MODE_CAR | {CAR.KIA_NIRO_PHEV, CAR.KIA_SORENTO}
 
 # If 0x500 is present on bus 1 it probably has a Mando radar outputting radar points.
 # If no points are outputted by default it might be possible to turn it on using  selfdrive/debug/hyundai_enable_radar_points.py

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1939,8 +1939,8 @@ EV_CAR = {CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.KONA_EV, CAR.KIA_NIRO_EV, CAR
 
 # these cars require a special panda safety mode due to missing counters and checksums in the messages
 LEGACY_SAFETY_MODE_CAR = {CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV,
-                          CAR.SONATA_LF, CAR.KIA_OPTIMA_G4, CAR.KIA_OPTIMA_G4_FL, CAR.VELOSTER, CAR.GENESIS_G70, CAR.GENESIS_G80,
-                          CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022}
+                          CAR.SONATA_LF, CAR.KIA_OPTIMA_G4, CAR.KIA_OPTIMA_G4_FL, CAR.VELOSTER,
+                          CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022}
 
 # these cars have not been verified to work with longitudinal yet - radar disable, sending correct messages, etc
 UNSUPPORTED_LONGITUDINAL_CAR = LEGACY_SAFETY_MODE_CAR | {CAR.KIA_NIRO_PHEV}


### PR DESCRIPTION
# Description

After seeing @sshane's Discord [message](https://discord.com/channels/469524606043160576/524611978208215070/1142340953412223067) and [open PR](https://github.com/commaai/openpilot/pull/29473) regarding disallowing longitudinal in Openpilot while still checking the counters and checksums for cars that have historically been in `LEGACY_SAFETY_MODE_CAR`.

I ran his branch (`hkg-remove-from-legacy`) in my 2019 Kia Sorento.

# Verification


I verified the following cases with alpha longitudinal enabled/disabled:

### Alpha long disabled ❌ 
**Route:** `88da9d94a8980684|2023-08-19--23-47-41--0`
> No issues observed while removed from `LEGACY_SAFETY_MODE_CAR`.

### Alpha long enabled ✅
**Route:** `88da9d94a8980684|2023-08-19--23-52-14--0`
> `Harness Relay Malfunction` error and repeated errors in cluster, but I expected this because `disable_radar` doesn't work for my car at the moment. 