### PR TITLE
boardd: keepTime after failing to get `ignition_opt`

### DIFF
--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -480,7 +480,7 @@ void panda_state_thread(std::vector<Panda *> pandas, bool spoofing_started) {
     auto ignition_opt = send_panda_states(&pm, pandas, spoofing_started);
 
     if (!ignition_opt) {
-      LOGW("Failed to get ignition_opt");
+      LOGE("Failed to get ignition_opt");
       rk.keepTime();
       continue;
     }

--- a/selfdrive/boardd/boardd.cc
+++ b/selfdrive/boardd/boardd.cc
@@ -480,6 +480,8 @@ void panda_state_thread(std::vector<Panda *> pandas, bool spoofing_started) {
     auto ignition_opt = send_panda_states(&pm, pandas, spoofing_started);
 
     if (!ignition_opt) {
+      LOGW("Failed to get ignition_opt");
+      rk.keepTime();
       continue;
     }
 


### PR DESCRIPTION
Think it's better to call `keepTime` after failing to get ignition_opt  than retrying immediately in loop.