### PR TITLE
CI: remove old docs base image push

### DIFF
--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -92,5 +92,4 @@ jobs:
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
       run: |
         $DOCKER_LOGIN
-        docker push $DOCKER_REGISTRY/openpilot-docs-base:latest
         docker push $DOCKER_REGISTRY/openpilot-docs:latest


### PR DESCRIPTION
openpilot-docs-base was removed because it's not required anymore with the scons-cache mount, but the push was not removed at the end of the docs step, which caused this error:

https://github.com/commaai/openpilot/actions/runs/5931970157/job/16084917516