### PR TITLE
Revert "Subaru: always show LKAS active (#27945)"

### DIFF
--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -97,8 +97,11 @@ def create_es_lkas_state(packer, es_lkas_state_msg, enabled, visual_alert, left_
     elif right_lane_depart:
       values["LKAS_Alert"] = 11  # Right lane departure dash alert
 
-  values["LKAS_ACTIVE"] = 1  # Show LKAS lane lines
-  values["LKAS_Dash_State"] = 2 if enabled else 0  # Green enabled indicator
+  if enabled:
+    values["LKAS_ACTIVE"] = 1  # Show LKAS lane lines
+    values["LKAS_Dash_State"] = 2  # Green enabled indicator
+  else:
+    values["LKAS_Dash_State"] = 0  # LKAS Not enabled
 
   values["LKAS_Left_Line_Visible"] = int(left_line)
   values["LKAS_Right_Line_Visible"] = int(right_line)


### PR DESCRIPTION
This reverts commit 8f1e67f6259c436aff500f6bdff9067d4ca79eb1.

This isn't shown on older gen Subarus, leads to confusion

Reminder to always check data, even for small changes!