### PR TITLE
CI: simulator disable pull to save local space

### DIFF
--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -64,7 +64,6 @@ jobs:
       run: eval "$BUILD_CL"
     - name: Build simulator image
       run: |
-        docker pull $DOCKER_REGISTRY/$IMAGE_NAME:latest
         DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_REGISTRY/$IMAGE_NAME:latest -t $DOCKER_REGISTRY/$IMAGE_NAME:latest -f tools/sim/Dockerfile.sim .
     - name: Push to container registry
       if: github.ref == 'refs/heads/master' && github.repository == 'commaai/openpilot'


### PR DESCRIPTION
After adding the scons-cache to the simulator, are starting to reach the local storage limit of github actions (only 14gb is guarenteed) so the sim building is failing occasionally: https://github.com/commaai/openpilot/actions/runs/5932532426/job/16087435248

Pulling the sim image would only rarely give us any cache (only if we don't change anything in openpilot, selfdrive, panda, and others). So there is not much point in wasting the extra ~2gb of space and time that it requires to pull the full simulator image