### PR TITLE
ratekeeper.h: add missing <cstdint> include

### DIFF
--- a/common/ratekeeper.h
+++ b/common/ratekeeper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 class RateKeeper {


### PR DESCRIPTION
To fix compilation with clang 15