### PR TITLE
Ford: handle metric cruise speed

### DIFF
--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -60,9 +60,8 @@ class CarState(CarStateBase):
       ret.steerFaultTemporary |= cp.vl["Lane_Assist_Data3_FD1"]["LatCtlSte_D_Stat"] not in (1, 2, 3)
 
     # cruise state
-    # TODO: find cruise speed units signal
-    cruise_speed_kph = False
-    ret.cruiseState.speed = cp.vl["EngBrakeData"]["Veh_V_DsplyCcSet"] * (CV.KPH_TO_MS if cruise_speed_kph else CV.MPH_TO_MS)
+    cruise_speed_metric = cp.vl["Cluster_Info1_FD1"]["MetricActv_B_Actl"] == 1
+    ret.cruiseState.speed = cp.vl["EngBrakeData"]["Veh_V_DsplyCcSet"] * (CV.KPH_TO_MS if cruise_speed_metric else CV.MPH_TO_MS)
     ret.cruiseState.enabled = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (4, 5)
     ret.cruiseState.available = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (3, 4, 5)
     ret.cruiseState.nonAdaptive = cp.vl["Cluster_Info1_FD1"]["AccEnbl_B_RqDrv"] == 0

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -60,7 +60,9 @@ class CarState(CarStateBase):
       ret.steerFaultTemporary |= cp.vl["Lane_Assist_Data3_FD1"]["LatCtlSte_D_Stat"] not in (1, 2, 3)
 
     # cruise state
-    ret.cruiseState.speed = cp.vl["EngBrakeData"]["Veh_V_DsplyCcSet"] * CV.MPH_TO_MS
+    # TODO: find cruise speed units signal
+    cruise_speed_kph = False
+    ret.cruiseState.speed = cp.vl["EngBrakeData"]["Veh_V_DsplyCcSet"] * (CV.KPH_TO_MS if cruise_speed_kph else CV.MPH_TO_MS)
     ret.cruiseState.enabled = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (4, 5)
     ret.cruiseState.available = cp.vl["EngBrakeData"]["CcStat_D_Actl"] in (3, 4, 5)
     ret.cruiseState.nonAdaptive = cp.vl["Cluster_Info1_FD1"]["AccEnbl_B_RqDrv"] == 0


### PR DESCRIPTION
We are treating the unitless cruise speed signal as a value in `mph`, even when the cluster is set to metric. We should determine the correct units from another signal.

**DBC Signal analysis**
|Signal|Description|Signal value|Comment|
|-|-|-|-|
|`EngBrakeData.Veh_V_DsplyCcSet`|Unitless set speed|
|`IPMA_Data2.IsaVLimUnit_D_Rq`|Camera reported kph/mph unit for `IsaVLim_D_Rq` (Intelligent Speed Assistance)|Bronco Sport: `Mph`<br/>Kuga: not present|
|`IPMA_Data2.IaccVLimUnit_D_Rq`|Camera reported kph/mph unit for `IaccVLim_D_Rq` (Intelligent Adaptive Cruise Control)|Bronco Sport: `Null`<br/>Kuga: not present|Not clear whether this unit will always match the cluster setting or if the unit is for the local speed limit.|
|`Mc_Send_Signals_2_FD1.Mc_VehUntTrpCoUsrSel_St`|Trip computer metric/imperial setting|Bronco Sport: not present<br/>Kuga: not present|
|`Cluster_Info1_FD1.MetricActv_B_Actl`||Bronco Sport: `Inactive`<br/>Kuga: `Inactive`|Not sure why Kuga does not report `Active` for this signal. May not be cluster speed related.|

Ford Kuga (kph): `32a35015aa4d5598|2023-08-20--18-22-54--21`
Ford Bronco Sport (mph): `1e79b0494c46cabf|2023-08-21--15-58-38--4`

TODO: test changing cluster setting and find different bits

Closes #29494