### PR TITLE
FW Query: test no pointless OBD queries on aux panda

### DIFF
--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -108,7 +108,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
       # whitelist_ecus=[Ecu.engine],
-      auxiliary=True,
     ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -241,7 +241,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'volkswagen': 0.2,
       },
       2: {
-        'ford': 0.4,
+        'ford': 0.3,
         'hyundai': 1.1,
       }
     }

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -168,6 +168,10 @@ class TestFwFingerprint(unittest.TestCase):
         for request_obj in config.requests:
           self.assertEqual(len(request_obj.request), len(request_obj.response))
 
+          # No request on the OBD port (bus 1, multiplexed) should be run in an aux panda
+          self.assertFalse(request_obj.auxiliary and request_obj.bus == 1 and request_obj.obd_multiplexing,
+                           f"{brand.title()}: OBD multiplexed request is marked auxiliary: {request_obj}")
+
 
 class TestFwFingerprintTiming(unittest.TestCase):
   N: int = 5

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -168,7 +168,7 @@ class TestFwFingerprint(unittest.TestCase):
         for request_obj in config.requests:
           self.assertEqual(len(request_obj.request), len(request_obj.response))
 
-          # No request on the OBD port (bus 1, multiplexed) should be run in an aux panda
+          # No request on the OBD port (bus 1, multiplexed) should be run on an aux panda
           self.assertFalse(request_obj.auxiliary and request_obj.bus == 1 and request_obj.obd_multiplexing,
                            f"{brand.title()}: OBD multiplexed request is marked auxiliary: {request_obj}")
 


### PR DESCRIPTION
You can see with a red panda on Ford we query bus 5 with multiplexing, but that can core is not connected to anything besides the radar bus when not multiplexed. Nothing will ever be returned.

5 % 4 == 1, so:

```python
        # Toggle OBD multiplexing for each request
        if r.bus % 4 == 1:
          set_obd_multiplexing(params, r.obd_multiplexing)
```

we now have a test to catch this.

Before:

```python
[Request(request=[b'>\x00', b'"\xf1\x88'], response=[b'~\x00', b'b\xf1\x88'], whitelist_ecus=[], rx_offset=8, bus=1, auxiliary=True, logging=False, obd_multiplexing=True),
 Request(request=[b'>\x00', b'"\xf1\x88'], response=[b'~\x00', b'b\xf1\x88'], whitelist_ecus=[], rx_offset=8, bus=0, auxiliary=True, logging=False, obd_multiplexing=True),
 Request(request=[b'>\x00', b'"\xf1\x88'], response=[b'~\x00', b'b\xf1\x88'], whitelist_ecus=[], rx_offset=8, bus=5, auxiliary=True, logging=False, obd_multiplexing=True),
 Request(request=[b'>\x00', b'"\xf1\x88'], response=[b'~\x00', b'b\xf1\x88'], whitelist_ecus=[], rx_offset=8, bus=4, auxiliary=True, logging=False, obd_multiplexing=True)]
```

After:

```python
[Request(request=[b'>\x00', b'"\xf1\x88'], response=[b'~\x00', b'b\xf1\x88'], whitelist_ecus=[], rx_offset=8, bus=1, auxiliary=False, logging=False, obd_multiplexing=True),
 Request(request=[b'>\x00', b'"\xf1\x88'], response=[b'~\x00', b'b\xf1\x88'], whitelist_ecus=[], rx_offset=8, bus=0, auxiliary=True, logging=False, obd_multiplexing=True),
 Request(request=[b'>\x00', b'"\xf1\x88'], response=[b'~\x00', b'b\xf1\x88'], whitelist_ecus=[], rx_offset=8, bus=4, auxiliary=True, logging=False, obd_multiplexing=True)]
```