### PR TITLE
Ford: change LatCtlPrecision_D_Rq to comfortable

### DIFF
--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -76,8 +76,8 @@ def create_lat_ctl_msg(packer, CAN: CanBus, lat_active: bool, path_offset: float
                                                 #       3=InterventionRight, 4-7=NotUsed [0|7]
     "LatCtlRampType_D_Rq": 0,                   # Ramp speed: 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
                                                 #             Makes no difference with curvature control
-    "LatCtlPrecision_D_Rq": 1,                  # Precision: 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
-                                                #            The stock system always uses comfortable
+    "LatCtlPrecision_D_Rq": 0,                  # Precision: 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
+                                                # We have not observed the stock system using precise
     "LatCtlPathOffst_L_Actl": path_offset,      # Path offset [-5.12|5.11] meter
     "LatCtlPath_An_Actl": path_angle,           # Path angle [-0.5|0.5235] radians
     "LatCtlCurv_NoRate_Actl": curvature_rate,   # Curvature rate [-0.001024|0.00102375] 1/meter^2
@@ -101,7 +101,8 @@ def create_lat_ctl2_msg(packer, CAN: CanBus, mode: int, path_offset: float, path
     "LatCtl_D2_Rq": mode,                       # Mode: 0=None, 1=PathFollowingLimitedMode, 2=PathFollowingExtendedMode,
                                                 #       3=SafeRampOut, 4-7=NotUsed [0|7]
     "LatCtlRampType_D_Rq": 0,                   # 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
-    "LatCtlPrecision_D_Rq": 1,                  # 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
+    "LatCtlPrecision_D_Rq": 0,                  # 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
+                                                # We have not observed the stock system using precise
     "LatCtlPathOffst_L_Actl": path_offset,      # [-5.12|5.11] meter
     "LatCtlPath_An_Actl": path_angle,           # [-0.5|0.5235] radians
     "LatCtlCurv_No_Actl": curvature,            # [-0.02|0.02094] 1/meter


### PR DESCRIPTION
- Lane changes feel smoother (almost hard to tell whether you have triggered the lane change)
- Reduced steering wheel oscillation (still occurs after bumps in the road, but recovers)

I did not notice any large oscillations after driving for 6 hours on the motorway. Previously, I saw it more than once in 1hr at high speeds. Resolves https://github.com/commaai/opendbc/issues/1121