### PR TITLE
v4l_encoder: improve `dequeue_buffer`

### DIFF
--- a/system/loggerd/encoder/v4l_encoder.cc
+++ b/system/loggerd/encoder/v4l_encoder.cc
@@ -27,7 +27,8 @@ static void checked_ioctl(int fd, unsigned long request, void *argp) {
   }
 }
 
-static bool dequeue_buffer(int fd, v4l2_buf_type buf_type, unsigned int *index=NULL, unsigned int *bytesused=NULL, unsigned int *flags=NULL, struct timeval *timestamp=NULL) {
+static bool dequeue_buffer(int fd, v4l2_buf_type buf_type, unsigned int *index = NULL, unsigned int *bytesused = NULL,
+                           unsigned int *flags = NULL, struct timeval *timestamp = NULL) {
   struct v4l2_buffer v4l_buf;
   memset(&v4l_buf, 0, sizeof(v4l_buf));
   // WARNING: do not change this to something smaller than VIDEO_MAX_PLANES

--- a/system/loggerd/encoder/v4l_encoder.cc
+++ b/system/loggerd/encoder/v4l_encoder.cc
@@ -38,7 +38,7 @@ static bool dequeue_buffer(int fd, v4l2_buf_type buf_type, unsigned int *index=N
   v4l_buf.memory = V4L2_MEMORY_USERPTR;
   v4l_buf.m.planes = planes;
   v4l_buf.length = 1;
-  int ret = HANDLE_EINTR(ioctl(fd, VIDIOC_DQBUF, &v4l_buf));
+  int ret = util::safe_ioctl(fd, VIDIOC_DQBUF, &v4l_buf);
   if (ret != 0) {
     if (errno == EAGAIN) {
       // EAGAIN if we're just out of buffers to dequeue.


### PR DESCRIPTION
Improve `dequeue_buffer`'s error handling by referring to the v4l-related code in webtrc and chromium.