### PR TITLE
car interfaces: long running fuzzy test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,6 +160,7 @@ pipeline {
             sh "scons --clean && scons --no-cache --random -j42"
             sh "INTERNAL_SEG_CNT=500 INTERNAL_SEG_LIST=selfdrive/car/tests/test_models_segs.txt FILEREADER_CACHE=1 \
                 pytest -n42 --dist=loadscope selfdrive/car/tests/test_models.py"
+            sh "MAX_EXAMPLES=100 pytest -n42 selfdrive/car/tests/test_car_interfaces.py"
           }
 
           post {

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -51,8 +51,8 @@ class TestCarInterfaces(unittest.TestCase):
 
   # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
   #  many generated examples to overrun when max_examples > ~20, don't run it
-  @parameterized.expand([(car,) for car in sorted(all_known_cars()) if car.startswith('SUBARU CROSSTREK HYBRID') or car.startswith('TOYOTA')])
-  @settings(max_examples=50,
+  @parameterized.expand([(car,) for car in sorted(all_known_cars()) if car.startswith('SUBARU CROSSTREK HYBRID')])
+  @settings(max_examples=100,
             phases=(Phase.reuse, Phase.generate, Phase.shrink),
             # suppress_health_check=list(HealthCheck),
             )
@@ -67,7 +67,7 @@ class TestCarInterfaces(unittest.TestCase):
     car_interface = CarInterface(car_params, CarController, CarState)
     assert car_params
     assert car_interface
-    return
+    # return
 
     self.assertGreater(car_params.mass, 1)
     self.assertGreater(car_params.wheelbase, 0)

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -3,7 +3,7 @@ import os
 import math
 import unittest
 import hypothesis.strategies as st
-from hypothesis import given, settings, Phase, HealthCheck
+from hypothesis import Phase, given, settings
 import importlib
 from parameterized import parameterized
 

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -18,9 +18,7 @@ from openpilot.selfdrive.test.fuzzy_generation import DrawType, FuzzyGenerator
 
 ALL_ECUS = list({ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()})
 
-
 MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '5'))
-ALL_ECUS = list({ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()})
 
 
 def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
@@ -40,8 +38,6 @@ def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
 
   params: dict = draw(params_strategy)
   params['car_fw'] = [car.CarParams.CarFw(ecu=fw[0], address=fw[1], subAddress=fw[2] or 0) for fw in params['car_fw']]
-  print(params)
-  print()
   return params
 
 
@@ -53,11 +49,9 @@ class TestCarInterfaces(unittest.TestCase):
 
   # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
   #  many generated examples to overrun when max_examples > ~20, don't run it
-  @parameterized.expand([(car,) for car in sorted(all_known_cars()) if car.startswith('SUBARU CROSSTREK HYBRID')])
-  @settings(max_examples=100,
-            phases=(Phase.reuse, Phase.generate, Phase.shrink),
-            # suppress_health_check=list(HealthCheck),
-            )
+  @parameterized.expand([(car,) for car in sorted(all_known_cars())])
+  @settings(max_examples=MAX_EXAMPLES, deadline=500,
+            phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())
   def test_car_interfaces(self, car_name, data):
     CarInterface, CarController, CarState = interfaces[car_name]
@@ -69,7 +63,6 @@ class TestCarInterfaces(unittest.TestCase):
     car_interface = CarInterface(car_params, CarController, CarState)
     assert car_params
     assert car_interface
-    # return
 
     self.assertGreater(car_params.mass, 1)
     self.assertGreater(car_params.wheelbase, 0)

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -48,7 +48,7 @@ class TestCarInterfaces(unittest.TestCase):
     os.environ['NO_RADAR_SLEEP'] = '1'
 
   # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
-  #  many generated examples to overrun when max_examples > ~20, don't run it
+  #  many generated examples to overrun when max_examples > ~20, don't use it
   @parameterized.expand([(car,) for car in sorted(all_known_cars())])
   @settings(max_examples=MAX_EXAMPLES, deadline=500,
             phases=(Phase.reuse, Phase.generate, Phase.shrink))

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -3,7 +3,7 @@ import os
 import math
 import unittest
 import hypothesis.strategies as st
-from hypothesis import given, settings
+from hypothesis import given, settings, Phase, HealthCheck
 import importlib
 from parameterized import parameterized
 
@@ -12,8 +12,13 @@ from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car import gen_empty_fingerprint
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.car.fingerprints import all_known_cars
+from openpilot.selfdrive.car.fw_versions import FW_VERSIONS
 from openpilot.selfdrive.car.interfaces import get_interface_attr
 from openpilot.selfdrive.test.fuzzy_generation import DrawType, FuzzyGenerator
+
+
+MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '5'))
+ALL_ECUS = list({ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()})
 
 
 def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
@@ -22,12 +27,8 @@ def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
                                                                      st.integers(min_value=0, max_value=64)) for key in
                                                 gen_empty_fingerprint()})
 
-  # just the most important fields
-  car_fw_strategy = st.lists(st.fixed_dictionaries({
-    'ecu': st.sampled_from(list(car.CarParams.Ecu.schema.enumerants.keys())),
-    # TODO: only use reasonable addrs for the paired ecu and brand/platform
-    'address': st.integers(min_value=0, max_value=0x800),
-  }))
+  # only pick from possible ecus to reduce search space
+  car_fw_strategy = st.lists(st.sampled_from(ALL_ECUS))
 
   params_strategy = st.fixed_dictionaries({
     'fingerprints': fingerprint_strategy,
@@ -36,7 +37,9 @@ def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
   })
 
   params: dict = draw(params_strategy)
-  params['car_fw'] = [car.CarParams.CarFw(**fw) for fw in params['car_fw']]
+  params['car_fw'] = [car.CarParams.CarFw(ecu=fw[0], address=fw[1], subAddress=fw[2] or 0) for fw in params['car_fw']]
+  print(params)
+  print()
   return params
 
 
@@ -46,8 +49,13 @@ class TestCarInterfaces(unittest.TestCase):
   def setUpClass(cls):
     os.environ['NO_RADAR_SLEEP'] = '1'
 
-  @parameterized.expand([(car,) for car in sorted(all_known_cars())])
-  @settings(max_examples=5)
+  # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
+  #  many generated examples to overrun when max_examples > ~20, don't run it
+  @parameterized.expand([(car,) for car in sorted(all_known_cars()) if car.startswith('SUBARU CROSSTREK HYBRID') or car.startswith('TOYOTA')])
+  @settings(max_examples=50,
+            phases=(Phase.reuse, Phase.generate, Phase.shrink),
+            # suppress_health_check=list(HealthCheck),
+            )
   @given(data=st.data())
   def test_car_interfaces(self, car_name, data):
     CarInterface, CarController, CarState = interfaces[car_name]
@@ -59,6 +67,7 @@ class TestCarInterfaces(unittest.TestCase):
     car_interface = CarInterface(car_params, CarController, CarState)
     assert car_params
     assert car_interface
+    return
 
     self.assertGreater(car_params.mass, 1)
     self.assertGreater(car_params.wheelbase, 0)


### PR DESCRIPTION
5 examples aren't nearly enough to catch anything deeper than surface level...however it somehow caught the Subaru bug newly introduced for the dashcammed Subaru hybrids, just once. We got lucky, can't reproduce it with 5 examples offline: https://github.com/commaai/openpilot/actions/runs/5961022763/job/16169445552 (Subaru PR is https://github.com/commaai/openpilot/pull/25378)

I also disabled the `target` phase as for some reason it overran most examples, and the examples that didn't overflow the buffer it gave you were very small lists and dicts. It also could take up to 2x longer with this phase with high max examples because of the overran examples. Not sure example what is going on here, but the [docs say to disable it if you want to run on more diverse, uniform data](https://hypothesis.readthedocs.io/en/latest/details.html#targeted-example-generation), so should be fine to disable for now. `Phase.target` also didn't seem to massively improve detection of the Subaru bug.

Here's what hypothesis uses for its 5 examples for the Crosstrek Hybrid most of the time:

```python
{'fingerprints': {0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {0: 0}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
```

20 examples is much more diverse, but you need closer to 100 to have it start iterating through random single addresses to catch the Subaru bug:

```python
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {0: 0}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {}, 2: {0: 0}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {0: 0}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {0: 0}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}, 'car_fw': [], 'experimental_long': False}
{'fingerprints': {0: {112: 16}, 1: {1048: 48, 715: 64, 1591: 17, 527: 11, 607: 35, 795: 14, 1865: 0, 967: 63}, 2: {183: 13, 1001: 16, 1400: 0, 848: 64, 808: 58, 672: 63, 1452: 56, 1002: 38}, 3: {1170: 51, 834: 8}, 4: {1897: 3, 340: 33, 1335: 31, 2003: 28, 499: 30, 1410: 64}, 5: {2032: 19, 1712: 59, 0: 44, 455: 45, 1919: 14, 1827: 25, 700: 46, 754: 8, 953: 39, 1327: 2, 133: 16, 1560: 64, 396: 40, 1989: 36, 1628: 38, 857: 57}, 6: {719: 31}, 7: {2048: 44}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = eps, address = 1953, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 1798, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = combinationMeter, address = 416964849, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': False}
{'fingerprints': {0: {1997: 9, 1874: 64, 213: 8, 2048: 58, 1221: 63, 474: 33, 775: 63}, 1: {731: 45, 1352: 7, 1198: 44, 31: 33, 1814: 45, 1685: 20, 348: 62, 1: 40, 1196: 18, 942: 1}, 2: {}, 3: {1422: 6, 1902: 4, 679: 46}, 4: {2048: 14, 474: 10, 858: 19}, 5: {1575: 23, 1636: 18, 617: 23}, 6: {1567: 24}, 7: {104: 36}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = transmission, address = 416947953, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = electricBrakeBooster, address = 1613, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = hybrid, address = 2002, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdRadar, address = 1649, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdRadar, address = 1872, subAddress = 15, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = electricBrakeBooster, address = 416951281, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1840, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = engine, address = 1954, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdRadar, address = 1649, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1953, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = unknown, address = 416955121, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdRadar, address = 2000, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {539: 64, 1677: 31, 851: 17}, 2: {}, 3: {205: 63, 1608: 19, 1998: 58, 195: 4, 2048: 54, 540: 61, 2028: 52}, 4: {1118: 16, 1695: 12, 1010: 31, 441: 0, 1832: 38, 146: 28, 1630: 58, 317: 20, 1393: 20, 123: 18, 1634: 15, 1844: 47, 236: 64, 44: 19, 1693: 14, 1926: 12}, 5: {869: 54, 5: 31, 1663: 30, 1442: 48, 1471: 38}, 6: {300: 19}, 7: {1375: 44}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = gateway, address = 417001457, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = srs, address = 1813, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = abs, address = 1968, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 416986609, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1882, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = abs, address = 1856, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 416952561, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1889, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 1799, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdRadar, address = 1872, subAddress = 15, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': True}
{'fingerprints': {0: {}, 1: {370: 28, 494: 55, 1548: 2, 2003: 25}, 2: {}, 3: {1969: 12}, 4: {}, 5: {2033: 44}, 6: {46: 40, 974: 22, 5: 38, 647: 54, 569: 41}, 7: {1241: 2, 1769: 40, 1870: 43, 30: 62, 793: 23}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = electricBrakeBooster, address = 416951281, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1862, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = engine, address = 2016, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = combinationMeter, address = 416964849, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = shiftByWire, address = 416943089, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 1872, subAddress = 109, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = engine, address = 1792, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = programmedFuelInjection, address = 416944369, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': False}
{'fingerprints': {0: {2031: 59, 109: 43, 192: 50, 461: 36}, 1: {}, 2: {}, 3: {1531: 24, 0: 58, 1448: 25, 754: 22}, 4: {1457: 18, 1833: 51, 118: 1, 801: 13, 1931: 31}, 5: {1835: 27, 1202: 16, 471: 30, 1198: 26, 1851: 38, 1863: 1, 1093: 14, 893: 18, 15: 48, 929: 23, 1468: 33, 1675: 54, 0: 63, 281: 33, 1841: 34, 586: 63}, 6: {}, 7: {}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = transmission, address = 1955, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = shiftByWire, address = 416943089, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = engine, address = 2016, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': True}
{'fingerprints': {0: {}, 1: {}, 2: {933: 31, 2035: 36, 1811: 26, 979: 11, 1189: 15}, 3: {1771: 22, 1709: 55}, 4: {426: 52}, 5: {816: 62, 864: 18, 465: 7}, 6: {1019: 44, 124: 13, 203: 15}, 7: {1732: 20, 1286: 55, 90: 18}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = dsu, address = 1937, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1882, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 416986609, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = engine, address = 1792, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1858, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': False}
{'fingerprints': {0: {}, 1: {1740: 23, 86: 57, 939: 46, 772: 18, 721: 35}, 2: {0: 54, 1052: 5}, 3: {797: 46, 314: 48, 1961: 51, 440: 51, 21: 50, 605: 19, 2047: 21, 1765: 56}, 4: {1586: 58, 1104: 42, 303: 60}, 5: {26: 46, 826: 24, 1284: 42, 1533: 21}, 6: {2017: 36, 254: 14, 450: 44}, 7: {133: 15, 0: 32}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = eps, address = 1862, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 416952561, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = combinationMeter, address = 1859, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1858, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1889, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 416986609, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': False}
{'fingerprints': {0: {1480: 33, 33: 25, 1013: 24, 2048: 56, 1047: 43, 156: 26, 626: 33, 1816: 6, 1105: 54}, 1: {957: 49}, 2: {646: 31, 637: 25, 707: 21, 961: 5}, 3: {417: 51, 1999: 4, 68: 61, 1416: 1, 165: 55}, 4: {}, 5: {378: 26, 0: 12, 676: 45, 1748: 26, 201: 30, 1293: 16, 947: 26}, 6: {1011: 22}, 7: {}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 416986609, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = transmission, address = 1955, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = transmission, address = 416947953, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1862, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = srs, address = 1860, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 1862, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = electricBrakeBooster, address = 416951281, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdRadar, address = 416985329, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = unknown, address = 416955121, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = unknown, address = 416955121, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = eps, address = 416952561, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = engine, address = 1824, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = gateway, address = 417001457, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = unknown, address = 416955121, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = srs, address = 416961521, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 1988, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': True}
{'fingerprints': {0: {}, 1: {}, 2: {1740: 18, 1299: 30, 436: 21, 911: 4, 1998: 60, 1068: 31, 1: 19, 1770: 40, 790: 53, 708: 22, 2013: 54, 1399: 50, 1719: 44, 841: 23, 1733: 1, 1620: 60, 649: 36, 882: 45}, 3: {546: 31, 1891: 54, 1025: 46, 2048: 38, 899: 42}, 4: {849: 36, 734: 64, 856: 58, 372: 35, 264: 19, 175: 15, 686: 9, 1635: 37, 298: 9, 1484: 20, 2048: 11, 1603: 25, 830: 26, 224: 10}, 5: {}, 6: {143: 59, 404: 22, 1072: 30}, 7: {835: 7, 1652: 2}}, 'car_fw': [<car.capnp:CarParams.CarFw builder (ecu = fwdCamera, address = 1872, subAddress = 109, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>, <car.capnp:CarParams.CarFw builder (ecu = gateway, address = 416993521, subAddress = 0, responseAddress = 0, bus = 0, logging = false, obdMultiplexing = false)>], 'experimental_long': False}
```