### PR TITLE
cpplint: add filter `build/include_alpha`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
         - --linelength=240
         # https://google.github.io/styleguide/cppguide.html
         # relevant rules are whitelisted, see all options with: cpplint --filter=
-        - --filter=-build,-legal,-readability,-runtime,-whitespace,+build/include_subdir,+build/forward_decl,+build/include_what_you_use,+build/deprecated,+whitespace/comma,+whitespace/line_length,+whitespace/empty_if_body,+whitespace/empty_loop_body,+whitespace/empty_conditional_body,+whitespace/forcolon,+whitespace/parens,+whitespace/semicolon,+whitespace/tab,+readability/braces
+        - --filter=-build,-legal,-readability,-runtime,-whitespace,+build/include_alpha,+build/include_subdir,+build/forward_decl,+build/include_what_you_use,+build/deprecated,+whitespace/comma,+whitespace/line_length,+whitespace/empty_if_body,+whitespace/empty_loop_body,+whitespace/empty_conditional_body,+whitespace/forcolon,+whitespace/parens,+whitespace/semicolon,+whitespace/tab,+readability/braces
 -   repo: local
     hooks:
     -   id: test_translations

--- a/common/clutil.cc
+++ b/common/clutil.cc
@@ -4,8 +4,8 @@
 #include <iostream>
 #include <memory>
 
-#include "common/util.h"
 #include "common/swaglog.h"
+#include "common/util.h"
 
 namespace {  // helper functions
 

--- a/common/gpio.cc
+++ b/common/gpio.cc
@@ -18,14 +18,14 @@ int gpiochip_get_ro_value_fd(const char* consumer_label, int gpiochiop_id, int p
 #else
 
 #include <fcntl.h>
+#include <linux/gpio.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include <cstring>
-#include <linux/gpio.h>
-#include <sys/ioctl.h>
 
-#include "common/util.h"
 #include "common/swaglog.h"
+#include "common/util.h"
 
 int gpio_init(int pin_nr, bool output) {
   char pin_dir_path[50];

--- a/common/i2c.cc
+++ b/common/i2c.cc
@@ -16,8 +16,8 @@
 #ifdef QCOM2
 // TODO: decide if we want to install libi2c-dev everywhere
 extern "C" {
-  #include <linux/i2c-dev.h>
   #include <i2c/smbus.h>
+  #include <linux/i2c-dev.h>
 }
 
 I2CBus::I2CBus(uint8_t bus_id) {

--- a/common/tests/test_swaglog.cc
+++ b/common/tests/test_swaglog.cc
@@ -1,13 +1,13 @@
 #include <zmq.h>
+
 #include <iostream>
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
-
-#include "third_party/json11/json11.hpp"
 #include "common/swaglog.h"
 #include "common/util.h"
 #include "common/version.h"
 #include "system/hardware/hw.h"
+#include "third_party/json11/json11.hpp"
 
 const char *SWAGLOG_ADDR = "ipc:///tmp/logmessage";
 std::string daemon_name = "testy";

--- a/common/transformations/coordinates.cc
+++ b/common/transformations/coordinates.cc
@@ -2,9 +2,9 @@
 
 #include "common/transformations/coordinates.hpp"
 
-#include <iostream>
 #include <cmath>
 #include <eigen3/Eigen/Dense>
+#include <iostream>
 
 double a = 6378137; // lgtm [cpp/short-global-name]
 double b = 6356752.3142; // lgtm [cpp/short-global-name]

--- a/common/transformations/orientation.cc
+++ b/common/transformations/orientation.cc
@@ -1,10 +1,11 @@
 #define _USE_MATH_DEFINES
 
-#include <iostream>
+#include "common/transformations/orientation.hpp"
+
 #include <cmath>
 #include <eigen3/Eigen/Dense>
+#include <iostream>
 
-#include "common/transformations/orientation.hpp"
 #include "common/transformations/coordinates.hpp"
 
 Eigen::Quaterniond ensure_unique(Eigen::Quaterniond quat){

--- a/common/util.cc
+++ b/common/util.cc
@@ -1,14 +1,13 @@
 #include "common/util.h"
 
-#include <sys/ioctl.h>
-#include <sys/stat.h>
-#include <sys/resource.h>
 #include <dirent.h>
+#include <sys/ioctl.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
 
 #include <cassert>
 #include <cerrno>
 #include <cstring>
-#include <dirent.h>
 #include <fstream>
 #include <iomanip>
 #include <random>

--- a/common/watchdog.cc
+++ b/common/watchdog.cc
@@ -1,6 +1,7 @@
+#include "common/watchdog.h"
+
 #include <string>
 
-#include "common/watchdog.h"
 #include "common/util.h"
 
 const std::string watchdog_fn_prefix = "/dev/shm/wd_";  // + <pid>

--- a/scripts/dump_pll.c
+++ b/scripts/dump_pll.c
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include <fcntl.h>
+#include <stdio.h>
 #include <sys/mman.h>
 
 void hexdump(uint32_t *d, int l) {

--- a/scripts/waste.c
+++ b/scripts/waste.c
@@ -2,15 +2,16 @@
 // gcc -O2 waste.c -lpthread -owaste -DMEM
 
 #define _GNU_SOURCE
-#include <stdio.h>
-#include <math.h>
-#include <sched.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <pthread.h>
 #include <arm_neon.h>
+#include <math.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/sysinfo.h>
+#include <unistd.h>
+
 #include "../common/timing.h"
 
 int get_nprocs(void);

--- a/selfdrive/boardd/main.cc
+++ b/selfdrive/boardd/main.cc
@@ -1,8 +1,8 @@
 #include <cassert>
 
-#include "selfdrive/boardd/boardd.h"
 #include "common/swaglog.h"
 #include "common/util.h"
+#include "selfdrive/boardd/boardd.h"
 #include "system/hardware/hw.h"
 
 int main(int argc, char *argv[]) {

--- a/selfdrive/boardd/panda.h
+++ b/selfdrive/boardd/panda.h
@@ -11,8 +11,8 @@
 
 #include "cereal/gen/cpp/car.capnp.h"
 #include "cereal/gen/cpp/log.capnp.h"
-#include "panda/board/health.h"
 #include "panda/board/can_definitions.h"
+#include "panda/board/health.h"
 #include "selfdrive/boardd/panda_comms.h"
 
 #define USB_TX_SOFT_LIMIT   (0x100U)

--- a/selfdrive/boardd/spi.cc
+++ b/selfdrive/boardd/spi.cc
@@ -1,7 +1,7 @@
 #ifndef __APPLE__
+#include <linux/spi/spidev.h>
 #include <sys/file.h>
 #include <sys/ioctl.h>
-#include <linux/spi/spidev.h>
 
 #include <cassert>
 #include <cmath>
@@ -9,12 +9,11 @@
 #include <iomanip>
 #include <sstream>
 
-#include "common/util.h"
-#include "common/timing.h"
 #include "common/swaglog.h"
+#include "common/timing.h"
+#include "common/util.h"
 #include "panda/board/comms_definitions.h"
 #include "selfdrive/boardd/panda_comms.h"
-
 
 #define SPI_SYNC 0x5AU
 #define SPI_HACK 0x79U

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -1,7 +1,7 @@
 #include "selfdrive/locationd/locationd.h"
 
-#include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/time.h>
 
 #include <algorithm>
 #include <cmath>

--- a/selfdrive/locationd/locationd.h
+++ b/selfdrive/locationd/locationd.h
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <eigen3/Eigen/Dense>
 #include <deque>
+#include <eigen3/Eigen/Dense>
 #include <fstream>
-#include <memory>
 #include <map>
+#include <memory>
 #include <string>
 
 #include "cereal/messaging/messaging.h"
-#include "common/transformations/coordinates.hpp"
-#include "common/transformations/orientation.hpp"
 #include "common/params.h"
 #include "common/swaglog.h"
 #include "common/timing.h"
+#include "common/transformations/coordinates.hpp"
+#include "common/transformations/orientation.hpp"
 #include "common/util.h"
-
 #include "system/sensord/sensors/constants.h"
 #define VISION_DECIMATION 2
 #define SENSOR_DECIMATION 10

--- a/selfdrive/locationd/models/live_kf.h
+++ b/selfdrive/locationd/models/live_kf.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <string>
 #include <cmath>
-#include <memory>
-#include <unordered_map>
-#include <vector>
-
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "generated/live_kf_constants.h"
 #include "rednose/helpers/ekf_sym.h"

--- a/selfdrive/modeld/dmonitoringmodeld.cc
+++ b/selfdrive/modeld/dmonitoringmodeld.cc
@@ -1,5 +1,5 @@
-#include <sys/resource.h>
 #include <limits.h>
+#include <sys/resource.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/selfdrive/modeld/modeld.cc
+++ b/selfdrive/modeld/modeld.cc
@@ -1,22 +1,19 @@
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <mutex>
-#include <cmath>
-
 #include <eigen3/Eigen/Dense>
+#include <mutex>
 
 #include "cereal/messaging/messaging.h"
-#include "common/transformations/orientation.hpp"
-
 #include "cereal/visionipc/visionipc_client.h"
 #include "common/clutil.h"
 #include "common/params.h"
 #include "common/swaglog.h"
+#include "common/transformations/orientation.hpp"
 #include "common/util.h"
-#include "system/hardware/hw.h"
 #include "selfdrive/modeld/models/driving.h"
 #include "selfdrive/modeld/models/nav.h"
-
+#include "system/hardware/hw.h"
 
 ExitHandler do_exit;
 

--- a/selfdrive/modeld/models/commonmodel.h
+++ b/selfdrive/modeld/models/commonmodel.h
@@ -12,8 +12,8 @@
 #include <CL/cl.h>
 #endif
 
-#include "common/mat.h"
 #include "cereal/messaging/messaging.h"
+#include "common/mat.h"
 #include "selfdrive/modeld/transforms/loadyuv.h"
 #include "selfdrive/modeld/transforms/transform.h"
 

--- a/selfdrive/modeld/models/driving.cc
+++ b/selfdrive/modeld/models/driving.cc
@@ -5,14 +5,12 @@
 
 #include <cassert>
 #include <cstring>
-
 #include <eigen3/Eigen/Dense>
 
 #include "common/clutil.h"
 #include "common/params.h"
-#include "common/timing.h"
 #include "common/swaglog.h"
-
+#include "common/timing.h"
 
 // #define DUMP_YUV
 

--- a/selfdrive/modeld/models/nav.h
+++ b/selfdrive/modeld/models/nav.h
@@ -2,8 +2,8 @@
 
 #include "cereal/messaging/messaging.h"
 #include "cereal/visionipc/visionipc_client.h"
-#include "common/util.h"
 #include "common/modeldata.h"
+#include "common/util.h"
 #include "selfdrive/modeld/models/commonmodel.h"
 #include "selfdrive/modeld/runners/run.h"
 

--- a/selfdrive/modeld/navmodeld.cc
+++ b/selfdrive/modeld/navmodeld.cc
@@ -1,5 +1,5 @@
-#include <sys/resource.h>
 #include <limits.h>
+#include <sys/resource.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/selfdrive/modeld/runners/runmodel.h
+++ b/selfdrive/modeld/runners/runmodel.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <cassert>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include <cassert>
 
 #include "common/clutil.h"
 #include "common/swaglog.h"

--- a/selfdrive/modeld/runners/snpemodel.cc
+++ b/selfdrive/modeld/runners/snpemodel.cc
@@ -8,8 +8,8 @@
 #include <utility>
 #include <vector>
 
-#include "common/util.h"
 #include "common/timing.h"
+#include "common/util.h"
 
 void PrintErrorStringAndExit() {
   std::cerr << zdl::DlSystem::getLastErrorString() << std::endl;

--- a/selfdrive/modeld/tests/snpe_benchmark/benchmark.cc
+++ b/selfdrive/modeld/tests/snpe_benchmark/benchmark.cc
@@ -1,12 +1,12 @@
-#include <SNPE/SNPE.hpp>
-#include <SNPE/SNPEBuilder.hpp>
-#include <SNPE/SNPEFactory.hpp>
 #include <DlContainer/IDlContainer.hpp>
 #include <DlSystem/DlError.hpp>
 #include <DlSystem/ITensor.hpp>
 #include <DlSystem/ITensorFactory.hpp>
-#include <iostream>
+#include <SNPE/SNPE.hpp>
+#include <SNPE/SNPEBuilder.hpp>
+#include <SNPE/SNPEFactory.hpp>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 
 using namespace std;

--- a/selfdrive/modeld/thneed/serialize.cc
+++ b/selfdrive/modeld/thneed/serialize.cc
@@ -1,10 +1,10 @@
 #include <cassert>
 #include <set>
 
-#include "third_party/json11/json11.hpp"
-#include "common/util.h"
 #include "common/clutil.h"
+#include "common/util.h"
 #include "selfdrive/modeld/thneed/thneed.h"
+#include "third_party/json11/json11.hpp"
 using namespace json11;
 
 extern map<cl_program, string> g_program_source;

--- a/selfdrive/navd/main.cc
+++ b/selfdrive/navd/main.cc
@@ -1,12 +1,12 @@
-#include <csignal>
 #include <sys/resource.h>
 
 #include <QApplication>
 #include <QDebug>
+#include <csignal>
 
-#include "selfdrive/ui/qt/util.h"
-#include "selfdrive/ui/qt/maps/map_helpers.h"
 #include "selfdrive/navd/map_renderer.h"
+#include "selfdrive/ui/qt/maps/map_helpers.h"
+#include "selfdrive/ui/qt/util.h"
 #include "system/hardware/hw.h"
 
 int main(int argc, char *argv[]) {

--- a/selfdrive/navd/map_renderer.cc
+++ b/selfdrive/navd/map_renderer.cc
@@ -1,13 +1,13 @@
 #include "selfdrive/navd/map_renderer.h"
 
-#include <cmath>
-#include <string>
 #include <QApplication>
 #include <QBuffer>
+#include <cmath>
+#include <string>
 
-#include "common/util.h"
-#include "common/timing.h"
 #include "common/swaglog.h"
+#include "common/timing.h"
+#include "common/util.h"
 #include "selfdrive/ui/qt/maps/map_helpers.h"
 
 const float DEFAULT_ZOOM = 13.5; // Don't go below 13 or features will start to disappear

--- a/selfdrive/navd/map_renderer.h
+++ b/selfdrive/navd/map_renderer.h
@@ -1,19 +1,17 @@
 #pragma once
 
+#include <QGeoCoordinate>
+#include <QMapboxGL>
+#include <QOffscreenSurface>
+#include <QOpenGLBuffer>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLFunctions>
+#include <QTimer>
 #include <memory>
 
-#include <QOpenGLContext>
-#include <QMapboxGL>
-#include <QTimer>
-#include <QGeoCoordinate>
-#include <QOpenGLBuffer>
-#include <QOffscreenSurface>
-#include <QOpenGLFunctions>
-#include <QOpenGLFramebufferObject>
-
-#include "cereal/visionipc/visionipc_server.h"
 #include "cereal/messaging/messaging.h"
-
+#include "cereal/visionipc/visionipc_server.h"
 
 class MapRenderer : public QObject {
   Q_OBJECT

--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -1,19 +1,19 @@
+#include "selfdrive/ui/installer/installer.h"
+
 #include <time.h>
 #include <unistd.h>
-
-#include <cstdlib>
-#include <fstream>
-#include <map>
-#include <string>
 
 #include <QDebug>
 #include <QDir>
 #include <QTimer>
 #include <QVBoxLayout>
+#include <cstdlib>
+#include <fstream>
+#include <map>
+#include <string>
 
-#include "selfdrive/ui/installer/installer.h"
-#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/qt_window.h"
+#include "selfdrive/ui/qt/util.h"
 
 std::string get_str(std::string const s) {
   std::string::size_type pos = s.find('?');

--- a/selfdrive/ui/main.cc
+++ b/selfdrive/ui/main.cc
@@ -3,10 +3,10 @@
 #include <QApplication>
 #include <QTranslator>
 
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/window.h"
+#include "system/hardware/hw.h"
 
 int main(int argc, char *argv[]) {
   setpriority(PRIO_PROCESS, 0, -20);

--- a/selfdrive/ui/mui.cc
+++ b/selfdrive/ui/mui.cc
@@ -1,11 +1,11 @@
 #include <QApplication>
-#include <QtWidgets>
-#include <QTimer>
 #include <QGraphicsScene>
+#include <QTimer>
+#include <QtWidgets>
 
 #include "cereal/messaging/messaging.h"
-#include "selfdrive/ui/ui.h"
 #include "selfdrive/ui/qt/qt_window.h"
+#include "selfdrive/ui/ui.h"
 
 class StatusBar : public QGraphicsRectItem {
   private:

--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -11,13 +11,12 @@
 #include <QFile>
 #include <QJsonDocument>
 #include <QNetworkRequest>
-
 #include <string>
 
 #include "common/params.h"
 #include "common/util.h"
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/util.h"
+#include "system/hardware/hw.h"
 
 namespace CommaApi {
 

--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -1,10 +1,9 @@
 #include "selfdrive/ui/qt/body.h"
 
-#include <cmath>
-#include <algorithm>
-
 #include <QPainter>
 #include <QStackedLayout>
+#include <algorithm>
+#include <cmath>
 
 #include "common/params.h"
 #include "common/timing.h"

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QMovie>
 #include <QLabel>
+#include <QMovie>
 #include <QPushButton>
 
 #include "common/util.h"

--- a/selfdrive/ui/qt/home.h
+++ b/selfdrive/ui/qt/home.h
@@ -8,8 +8,8 @@
 #include <QWidget>
 
 #include "common/params.h"
-#include "selfdrive/ui/qt/offroad/driverview.h"
 #include "selfdrive/ui/qt/body.h"
+#include "selfdrive/ui/qt/offroad/driverview.h"
 #include "selfdrive/ui/qt/onroad.h"
 #include "selfdrive/ui/qt/sidebar.h"
 #include "selfdrive/ui/qt/widgets/controls.h"

--- a/selfdrive/ui/qt/maps/map.h
+++ b/selfdrive/ui/qt/maps/map.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include <QGeoCoordinate>
 #include <QGestureEvent>
 #include <QLabel>
@@ -15,13 +13,14 @@
 #include <QString>
 #include <QVBoxLayout>
 #include <QWheelEvent>
+#include <optional>
 
 #include "cereal/messaging/messaging.h"
 #include "common/params.h"
 #include "common/util.h"
-#include "selfdrive/ui/ui.h"
 #include "selfdrive/ui/qt/maps/map_eta.h"
 #include "selfdrive/ui/qt/maps/map_instructions.h"
+#include "selfdrive/ui/ui.h"
 
 class MapWindow : public QOpenGLWidget {
   Q_OBJECT

--- a/selfdrive/ui/qt/maps/map_helpers.cc
+++ b/selfdrive/ui/qt/maps/map_helpers.cc
@@ -1,15 +1,14 @@
 #include "selfdrive/ui/qt/maps/map_helpers.h"
 
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <algorithm>
 #include <string>
 #include <utility>
 
-#include <QJsonDocument>
-#include <QJsonObject>
-
 #include "common/params.h"
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/api.h"
+#include "system/hardware/hw.h"
 
 QString get_mapbox_token() {
   // Valid for 4 weeks since we can't swap tokens on the fly

--- a/selfdrive/ui/qt/maps/map_helpers.h
+++ b/selfdrive/ui/qt/maps/map_helpers.h
@@ -1,16 +1,16 @@
 #pragma once
 
+#include <QGeoCoordinate>
+#include <QMapboxGL>
 #include <optional>
 #include <string>
 #include <utility>
-#include <eigen3/Eigen/Dense>
-#include <QMapboxGL>
-#include <QGeoCoordinate>
 
-#include "common/util.h"
+#include <eigen3/Eigen/Dense>
+#include "cereal/messaging/messaging.h"
 #include "common/transformations/coordinates.hpp"
 #include "common/transformations/orientation.hpp"
-#include "cereal/messaging/messaging.h"
+#include "common/util.h"
 
 const QString MAPBOX_TOKEN = util::getenv("MAPBOX_TOKEN").c_str();
 const QString MAPS_HOST = util::getenv("MAPS_HOST", MAPBOX_TOKEN.isEmpty() ? "https://maps.comma.ai" : "https://api.mapbox.com").c_str();

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -1,17 +1,15 @@
 #include "selfdrive/ui/qt/offroad/networking.h"
 
-#include <algorithm>
-
 #include <QHBoxLayout>
 #include <QScrollBar>
 #include <QStyle>
+#include <algorithm>
 
-#include "selfdrive/ui/ui.h"
 #include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
-
+#include "selfdrive/ui/ui.h"
 
 // Networking functions
 

--- a/selfdrive/ui/qt/offroad/onboarding.cc
+++ b/selfdrive/ui/qt/offroad/onboarding.cc
@@ -1,16 +1,15 @@
 #include "selfdrive/ui/qt/offroad/onboarding.h"
 
-#include <string>
-
 #include <QLabel>
 #include <QPainter>
 #include <QQmlContext>
 #include <QQuickWidget>
 #include <QTransform>
 #include <QVBoxLayout>
+#include <string>
 
-#include "common/util.h"
 #include "common/params.h"
+#include "common/util.h"
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/input.h"
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -1,28 +1,25 @@
 #include "selfdrive/ui/qt/offroad/settings.h"
 
+#include <QDebug>
 #include <cassert>
 #include <cmath>
 #include <string>
 #include <tuple>
 #include <vector>
 
-#include <QDebug>
-
-#include "selfdrive/ui/qt/offroad/networking.h"
-
 #include "common/params.h"
-#include "common/watchdog.h"
 #include "common/util.h"
-#include "system/hardware/hw.h"
+#include "common/watchdog.h"
+#include "selfdrive/ui/qt/offroad/networking.h"
+#include "selfdrive/ui/qt/qt_window.h"
+#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
 #include "selfdrive/ui/qt/widgets/input.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
 #include "selfdrive/ui/ui.h"
-#include "selfdrive/ui/qt/util.h"
-#include "selfdrive/ui/qt/qt_window.h"
-#include "selfdrive/ui/qt/widgets/input.h"
+#include "system/hardware/hw.h"
 
 TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
   // param, title, desc, icon

--- a/selfdrive/ui/qt/offroad/software_settings.cc
+++ b/selfdrive/ui/qt/offroad/software_settings.cc
@@ -1,20 +1,17 @@
-#include "selfdrive/ui/qt/offroad/settings.h"
-
+#include <QDebug>
+#include <QLabel>
 #include <cassert>
 #include <cmath>
 #include <string>
 
-#include <QDebug>
-#include <QLabel>
-
 #include "common/params.h"
 #include "common/util.h"
-#include "selfdrive/ui/ui.h"
+#include "selfdrive/ui/qt/offroad/settings.h"
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
 #include "selfdrive/ui/qt/widgets/input.h"
+#include "selfdrive/ui/ui.h"
 #include "system/hardware/hw.h"
-
 
 void SoftwarePanel::checkForUpdates() {
   std::system("pkill -SIGUSR1 -f selfdrive.updated");

--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -1,11 +1,10 @@
 #include "selfdrive/ui/qt/offroad/wifiManager.h"
 
-#include "selfdrive/ui/ui.h"
-#include "selfdrive/ui/qt/widgets/prime.h"
-
 #include "common/params.h"
 #include "common/swaglog.h"
 #include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/qt/widgets/prime.h"
+#include "selfdrive/ui/ui.h"
 
 bool compare_by_strength(const Network &a, const Network &b) {
   return std::tuple(a.connected, strengthLevel(a.strength), b.ssid) >

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -1,15 +1,13 @@
 #pragma once
 
-#include <memory>
-
 #include <QPushButton>
 #include <QStackedLayout>
 #include <QWidget>
+#include <memory>
 
 #include "common/util.h"
-#include "selfdrive/ui/ui.h"
 #include "selfdrive/ui/qt/widgets/cameraview.h"
-
+#include "selfdrive/ui/ui.h"
 
 const int btn_size = 192;
 const int img_size = (btn_size / 4) * 3;

--- a/selfdrive/ui/qt/qt_window.h
+++ b/selfdrive/ui/qt/qt_window.h
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <string>
-
 #include <QApplication>
 #include <QScreen>
 #include <QWidget>
+#include <string>
 
 #ifdef QCOM2
 #include <qpa/qplatformnativeinterface.h>
-#include <wayland-client-protocol.h>
 #include <QPlatformSurfaceEvent>
+#include <wayland-client-protocol.h>
 #endif
 
 #include "system/hardware/hw.h"

--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -1,23 +1,22 @@
 #include "selfdrive/ui/qt/setup/setup.h"
 
-#include <cstdio>
-#include <cstdlib>
-#include <sstream>
+#include <curl/curl.h>
 
 #include <QApplication>
 #include <QLabel>
 #include <QVBoxLayout>
 
-#include <curl/curl.h>
-
+#include <cstdio>
+#include <cstdlib>
+#include <sstream>
 #include <string>
 
 #include "common/util.h"
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/api.h"
-#include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/offroad/networking.h"
+#include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/widgets/input.h"
+#include "system/hardware/hw.h"
 
 const std::string USER_AGENT = "AGNOSSetup-";
 const QString DASHCAM_URL = "https://dashcam.comma.ai";

--- a/selfdrive/ui/qt/setup/updater.cc
+++ b/selfdrive/ui/qt/setup/updater.cc
@@ -1,12 +1,13 @@
+#include "selfdrive/ui/qt/setup/updater.h"
+
 #include <QDebug>
 #include <QTimer>
 #include <QVBoxLayout>
 
-#include "system/hardware/hw.h"
-#include "selfdrive/ui/qt/util.h"
-#include "selfdrive/ui/qt/qt_window.h"
-#include "selfdrive/ui/qt/setup/updater.h"
 #include "selfdrive/ui/qt/offroad/networking.h"
+#include "selfdrive/ui/qt/qt_window.h"
+#include "selfdrive/ui/qt/util.h"
+#include "system/hardware/hw.h"
 
 Updater::Updater(const QString &updater_path, const QString &manifest_path, QWidget *parent)
   : updater(updater_path), manifest(manifest_path), QStackedWidget(parent) {

--- a/selfdrive/ui/qt/setup/updater.h
+++ b/selfdrive/ui/qt/setup/updater.h
@@ -2,8 +2,8 @@
 
 #include <QLabel>
 #include <QProcess>
-#include <QPushButton>
 #include <QProgressBar>
+#include <QPushButton>
 #include <QStackedWidget>
 #include <QWidget>
 

--- a/selfdrive/ui/qt/spinner.cc
+++ b/selfdrive/ui/qt/spinner.cc
@@ -1,19 +1,18 @@
 #include "selfdrive/ui/qt/spinner.h"
 
-#include <algorithm>
-#include <cstdio>
-#include <iostream>
-#include <string>
-
 #include <QApplication>
 #include <QGridLayout>
 #include <QPainter>
 #include <QString>
 #include <QTransform>
+#include <algorithm>
+#include <cstdio>
+#include <iostream>
+#include <string>
 
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/util.h"
+#include "system/hardware/hw.h"
 
 TrackWidget::TrackWidget(QWidget *parent) : QWidget(parent) {
   setAttribute(Qt::WA_OpaquePaintEvent);

--- a/selfdrive/ui/qt/text.cc
+++ b/selfdrive/ui/qt/text.cc
@@ -5,10 +5,10 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-#include "system/hardware/hw.h"
-#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/qt_window.h"
+#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
+#include "system/hardware/hw.h"
 
 int main(int argc, char *argv[]) {
   initApp(argc, argv);

--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <QOpenGLFunctions>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLWidget>
+#include <QThread>
 #include <deque>
 #include <map>
 #include <memory>
@@ -8,23 +12,18 @@
 #include <string>
 #include <utility>
 
-#include <QOpenGLFunctions>
-#include <QOpenGLShaderProgram>
-#include <QOpenGLWidget>
-#include <QThread>
-
 #ifdef QCOM2
 #define EGL_EGLEXT_PROTOTYPES
 #define EGL_NO_X11
 #define GL_TEXTURE_EXTERNAL_OES 0x8D65
+#include <drm/drm_fourcc.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#include <drm/drm_fourcc.h>
 #endif
 
 #include "cereal/visionipc/visionipc_client.h"
-#include "system/camerad/cameras/camera_common.h"
 #include "selfdrive/ui/ui.h"
+#include "system/camerad/cameras/camera_common.h"
 
 const int FRAME_BUFFER_SIZE = 5;
 static_assert(FRAME_BUFFER_SIZE <= YUV_BUFFER_COUNT);

--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -1,13 +1,12 @@
 #include "selfdrive/ui/qt/widgets/input.h"
 
-#include <QPushButton>
 #include <QButtonGroup>
+#include <QPushButton>
 
-#include "system/hardware/hw.h"
-#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/qt_window.h"
+#include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
-
+#include "system/hardware/hw.h"
 
 QDialogBase::QDialogBase(QWidget *parent) : QDialog(parent) {
   Q_ASSERT(parent != nullptr);

--- a/selfdrive/ui/qt/widgets/offroad_alerts.cc
+++ b/selfdrive/ui/qt/widgets/offroad_alerts.cc
@@ -1,17 +1,16 @@
 #include "selfdrive/ui/qt/widgets/offroad_alerts.h"
 
-#include <algorithm>
-#include <string>
-#include <vector>
-#include <utility>
-
 #include <QHBoxLayout>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/util.h"
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
+#include "system/hardware/hw.h"
 
 AbstractAlert::AbstractAlert(bool hasRebootBtn, QWidget *parent) : QFrame(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -8,12 +8,11 @@
 #include <QStackedWidget>
 #include <QTimer>
 #include <QVBoxLayout>
-
 #include <QrCode.hpp>
 
+#include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/request_repeater.h"
 #include "selfdrive/ui/qt/util.h"
-#include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/widgets/wifi.h"
 
 using qrcodegen::QrCode;

--- a/selfdrive/ui/qt/widgets/ssh_keys.h
+++ b/selfdrive/ui/qt/widgets/ssh_keys.h
@@ -2,8 +2,8 @@
 
 #include <QPushButton>
 
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
+#include "system/hardware/hw.h"
 
 // SSH enable toggle
 class SshToggle : public ToggleControl {

--- a/selfdrive/ui/soundd/sound.h
+++ b/selfdrive/ui/soundd/sound.h
@@ -6,8 +6,8 @@
 #include <QSoundEffect>
 #include <QString>
 
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/ui.h"
+#include "system/hardware/hw.h"
 
 const std::tuple<AudibleAlert, QString, int> sound_list[] = {
   // AudibleAlert, file name, loop count

--- a/selfdrive/ui/tests/playsound.cc
+++ b/selfdrive/ui/tests/playsound.cc
@@ -1,7 +1,7 @@
 #include <QApplication>
+#include <QDebug>
 #include <QSoundEffect>
 #include <QTimer>
-#include <QDebug>
 
 int main(int argc, char **argv) {
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -1,14 +1,13 @@
 #include "selfdrive/ui/ui.h"
 
+#include <QtConcurrent>
 #include <algorithm>
 #include <cassert>
 #include <cmath>
 
-#include <QtConcurrent>
-
-#include "common/transformations/orientation.hpp"
 #include "common/params.h"
 #include "common/swaglog.h"
+#include "common/transformations/orientation.hpp"
 #include "common/util.h"
 #include "common/watchdog.h"
 #include "system/hardware/hw.h"

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -1,16 +1,15 @@
 #pragma once
 
-#include <map>
-#include <memory>
-#include <string>
-#include <optional>
-
-#include <QObject>
-#include <QTimer>
 #include <QColor>
 #include <QFuture>
+#include <QObject>
 #include <QPolygonF>
+#include <QTimer>
 #include <QTransform>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
 
 #include "cereal/messaging/messaging.h"
 #include "common/modeldata.h"

--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -1,25 +1,23 @@
 #include "system/camerad/cameras/camera_common.h"
 
+#include <jpeglib.h>
 #include <unistd.h>
 
 #include <cassert>
-#include <cstdio>
 #include <chrono>
+#include <cstdio>
 #include <string>
 #include <thread>
 
-#include "third_party/libyuv/include/libyuv.h"
-#include <jpeglib.h>
-
-#include "system/camerad/imgproc/utils.h"
 #include "common/clutil.h"
 #include "common/modeldata.h"
 #include "common/swaglog.h"
 #include "common/util.h"
-#include "system/hardware/hw.h"
-#include "third_party/linux/include/msm_media_info.h"
-
 #include "system/camerad/cameras/camera_qcom2.h"
+#include "system/camerad/imgproc/utils.h"
+#include "system/hardware/hw.h"
+#include "third_party/libyuv/include/libyuv.h"
+#include "third_party/linux/include/msm_media_info.h"
 #ifdef QCOM2
 #include "CL/cl_ext_qcom.h"
 #endif

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -16,13 +16,13 @@
 #include <string>
 #include <vector>
 
+#include "common/swaglog.h"
 #include "media/cam_defs.h"
 #include "media/cam_isp.h"
 #include "media/cam_isp_ife.h"
 #include "media/cam_sensor.h"
 #include "media/cam_sensor_cmn_header.h"
 #include "media/cam_sync.h"
-#include "common/swaglog.h"
 #include "system/camerad/cameras/sensor2_i2c.h"
 
 // For debugging:

--- a/system/camerad/cameras/camera_qcom2.h
+++ b/system/camerad/cameras/camera_qcom2.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <media/cam_req_mgr.h>
+
 #include <cstdint>
 #include <map>
 #include <utility>
 
-#include <media/cam_req_mgr.h>
-
-#include "system/camerad/cameras/camera_common.h"
-#include "system/camerad/cameras/camera_util.h"
 #include "common/params.h"
 #include "common/util.h"
+#include "system/camerad/cameras/camera_common.h"
+#include "system/camerad/cameras/camera_util.h"
 
 #define FRAME_BUF_COUNT 4
 #define ANALOG_GAIN_MAX_CNT 55

--- a/system/camerad/imgproc/utils.cc
+++ b/system/camerad/imgproc/utils.cc
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdio>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 
 const int16_t lapl_conv_krnl[9] = {0, 1, 0,

--- a/system/hardware/hw.h
+++ b/system/hardware/hw.h
@@ -2,8 +2,8 @@
 
 #include <string>
 
-#include "system/hardware/base.h"
 #include "common/util.h"
+#include "system/hardware/base.h"
 
 #if QCOM2
 #include "system/hardware/tici/hardware.h"

--- a/system/loggerd/encoder/v4l_encoder.cc
+++ b/system/loggerd/encoder/v4l_encoder.cc
@@ -1,12 +1,13 @@
+#include "system/loggerd/encoder/v4l_encoder.h"
+
+#include <poll.h>
+#include <sys/ioctl.h>
+
 #include <cassert>
 #include <string>
-#include <sys/ioctl.h>
-#include <poll.h>
 
-#include "system/loggerd/encoder/v4l_encoder.h"
-#include "common/util.h"
 #include "common/timing.h"
-
+#include "common/util.h"
 #include "third_party/libyuv/include/libyuv.h"
 #include "third_party/linux/include/msm_media_info.h"
 

--- a/system/loggerd/logger.cc
+++ b/system/loggerd/logger.cc
@@ -1,8 +1,8 @@
 #include "system/loggerd/logger.h"
 
+#include <ftw.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <ftw.h>
 
 #include <cassert>
 #include <cerrno>

--- a/system/loggerd/logger.h
+++ b/system/loggerd/logger.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <capnp/serialize.h>
+#include <kj/array.h>
 #include <pthread.h>
 
 #include <cassert>
@@ -8,12 +10,9 @@
 #include <memory>
 #include <string>
 
-#include <capnp/serialize.h>
-#include <kj/array.h>
-
 #include "cereal/messaging/messaging.h"
-#include "common/util.h"
 #include "common/swaglog.h"
+#include "common/util.h"
 #include "system/hardware/hw.h"
 
 const std::string LOG_ROOT = Path::log_root();

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -5,12 +5,11 @@
 #include "cereal/messaging/messaging.h"
 #include "cereal/services.h"
 #include "cereal/visionipc/visionipc_client.h"
-#include "system/camerad/cameras/camera_common.h"
-#include "system/hardware/hw.h"
 #include "common/params.h"
 #include "common/swaglog.h"
 #include "common/util.h"
-
+#include "system/camerad/cameras/camera_common.h"
+#include "system/hardware/hw.h"
 #include "system/loggerd/logger.h"
 
 constexpr int MAIN_FPS = 20;

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -1,7 +1,8 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#include "system/loggerd/video_writer.h"
+
 #include <cassert>
 
-#include "system/loggerd/video_writer.h"
 #include "common/swaglog.h"
 #include "common/util.h"
 

--- a/system/sensord/sensors/bmx055_temp.cc
+++ b/system/sensord/sensors/bmx055_temp.cc
@@ -2,9 +2,9 @@
 
 #include <cassert>
 
-#include "system/sensord/sensors/bmx055_accel.h"
 #include "common/swaglog.h"
 #include "common/timing.h"
+#include "system/sensord/sensors/bmx055_accel.h"
 
 BMX055_Temp::BMX055_Temp(I2CBus *bus) : I2CSensor(bus) {}
 

--- a/system/sensord/sensors/i2c_sensor.h
+++ b/system/sensord/sensors/i2c_sensor.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <cstdint>
 #include <unistd.h>
+
+#include <cstdint>
 #include <vector>
+
 #include "cereal/gen/cpp/log.capnp.h"
-
-#include "common/i2c.h"
 #include "common/gpio.h"
-
+#include "common/i2c.h"
 #include "common/swaglog.h"
 #include "system/sensord/sensors/constants.h"
 #include "system/sensord/sensors/sensor.h"

--- a/system/sensord/sensors_qcom2.cc
+++ b/system/sensord/sensors_qcom2.cc
@@ -1,14 +1,14 @@
+#include <linux/gpio.h>
+#include <poll.h>
 #include <sys/resource.h>
 
 #include <chrono>
+#include <map>
 #include <thread>
 #include <vector>
-#include <map>
-#include <poll.h>
-#include <linux/gpio.h>
 
-#include "cereal/services.h"
 #include "cereal/messaging/messaging.h"
+#include "cereal/services.h"
 #include "common/i2c.h"
 #include "common/ratekeeper.h"
 #include "common/swaglog.h"

--- a/system/ubloxd/tests/test_glonass_kaitai.cc
+++ b/system/ubloxd/tests/test_glonass_kaitai.cc
@@ -1,9 +1,9 @@
-#include <iostream>
-#include <vector>
 #include <bitset>
 #include <cassert>
 #include <cstdlib>
 #include <ctime>
+#include <iostream>
+#include <vector>
 
 #include "catch2/catch.hpp"
 #include "system/ubloxd/generated/glonass.h"

--- a/system/ubloxd/ublox_msg.h
+++ b/system/ubloxd/ublox_msg.h
@@ -10,8 +10,8 @@
 
 #include "cereal/messaging/messaging.h"
 #include "common/util.h"
-#include "system/ubloxd/generated/gps.h"
 #include "system/ubloxd/generated/glonass.h"
+#include "system/ubloxd/generated/gps.h"
 #include "system/ubloxd/generated/ubx.h"
 
 using namespace std::string_literals;

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -3,11 +3,11 @@
 
 #include "selfdrive/ui/qt/util.h"
 #include "tools/cabana/mainwin.h"
-#include "tools/cabana/streamselector.h"
 #include "tools/cabana/streams/devicestream.h"
 #include "tools/cabana/streams/pandastream.h"
 #include "tools/cabana/streams/replaystream.h"
 #include "tools/cabana/streams/socketcanstream.h"
+#include "tools/cabana/streamselector.h"
 
 int main(int argc, char *argv[]) {
   QCoreApplication::setApplicationName("Cabana");

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <memory>
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -12,8 +12,8 @@
 #include "tools/cabana/dbc/dbcmanager.h"
 #include "tools/cabana/detailwidget.h"
 #include "tools/cabana/messageswidget.h"
-#include "tools/cabana/videowidget.h"
 #include "tools/cabana/tools/findsimilarbits.h"
+#include "tools/cabana/videowidget.h"
 
 class MainWindow : public QMainWindow {
   Q_OBJECT

--- a/tools/cabana/streams/pandastream.h
+++ b/tools/cabana/streams/pandastream.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <memory>
-#include <vector>
-
 #include <QComboBox>
 #include <QFormLayout>
 #include <QVBoxLayout>
+#include <memory>
+#include <vector>
 
-#include "tools/cabana/streams/livestream.h"
 #include "selfdrive/boardd/panda.h"
+#include "tools/cabana/streams/livestream.h"
 
 const uint32_t speeds[] = {10U, 20U, 50U, 100U, 125U, 250U, 500U, 1000U};
 const uint32_t data_speeds[] = {10U, 20U, 50U, 100U, 125U, 250U, 500U, 1000U, 2000U, 5000U};

--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -1,8 +1,8 @@
 #include "tools/cabana/streams/replaystream.h"
 
-#include <QLabel>
 #include <QFileDialog>
 #include <QGridLayout>
+#include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -2,9 +2,9 @@
 #include "opendbc/can/common.h"
 #undef INFO
 #include "catch2/catch.hpp"
-#include "tools/replay/logreader.h"
 #include "tools/cabana/dbc/dbcmanager.h"
 #include "tools/cabana/streams/abstractstream.h"
+#include "tools/replay/logreader.h"
 
 // demo route, first segment
 const std::string TEST_RLOG_URL = "https://commadata2.blob.core.windows.net/commadata2/a2a0ccea32023010/2023-07-27--13-01-19/0/rlog.bz2";

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <cmath>
-#include <vector>
-#include <utility>
-
 #include <QApplication>
 #include <QByteArray>
 #include <QDateTime>
@@ -15,6 +11,9 @@
 #include <QStyledItemDelegate>
 #include <QToolButton>
 #include <QVector>
+#include <cmath>
+#include <utility>
+#include <vector>
 
 #include "tools/cabana/dbc/dbc.h"
 #include "tools/cabana/settings.h"

--- a/tools/lib/vidindex/bitstream.c
+++ b/tools/lib/vidindex/bitstream.c
@@ -1,7 +1,7 @@
 #include "./bitstream.h"
 
-#include <stdbool.h>
 #include <assert.h>
+#include <stdbool.h>
 
 static const uint32_t BS_MASKS[33] = {
     0,           0x1L,        0x3L,       0x7L,       0xFL,       0x1FL,

--- a/tools/lib/vidindex/vidindex.c
+++ b/tools/lib/vidindex/vidindex.c
@@ -1,13 +1,12 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
-#include <assert.h>
-
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "./bitstream.h"
 

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QThread>
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -7,10 +8,8 @@
 #include <set>
 #include <string>
 #include <tuple>
-#include <vector>
 #include <utility>
-
-#include <QThread>
+#include <vector>
 
 #include "tools/replay/camera.h"
 #include "tools/replay/route.h"

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -4,9 +4,9 @@
 #include <curl/curl.h>
 #include <openssl/sha.h>
 
-#include <cstring>
 #include <cassert>
 #include <cmath>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
I use the following style to format(resort) the includes (vscode):
![2023-08-24_23-42](https://github.com/commaai/openpilot/assets/27770/a1da1415-e001-4186-8d80-7e63e3c5e27b)

The reduced number of lines is due to the c++ formatter removing redundant blank lines.