### PR TITLE
C++ FirstOrderFilter: add initialized flag

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -153,12 +153,18 @@ struct unique_fd {
 
 class FirstOrderFilter {
 public:
-  FirstOrderFilter(float x0, float ts, float dt) {
+  FirstOrderFilter(float x0, float ts, float dt, bool initialized = true) {
     k_ = (dt / ts) / (1.0 + dt / ts);
     x_ = x0;
+    initialized_ = initialized;
   }
   inline float update(float x) {
-    x_ = (1. - k_) * x_ + k_ * x;
+    if (initialized_) {
+      x_ = (1. - k_) * x_ + k_ * x;
+    } else {
+      initialized_ = true;
+      x_ = x;
+    }
     return x_;
   }
   inline void reset(float x) { x_ = x; }
@@ -166,6 +172,7 @@ public:
 
 private:
   float x_, k_;
+  bool initialized_;
 };
 
 template<typename T>


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/29601

matches python implementation exactly:

https://github.com/commaai/openpilot/blob/d54fa5c7f198af93474a73643b9363fc2a2043ba/common/filter_simple.py#L1-L18