### PR TITLE
ui/map: initialize speed filter with current speed

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -18,7 +18,7 @@ const float MAX_PITCH = 50;
 const float MIN_PITCH = 0;
 const float MAP_SCALE = 2;
 
-MapWindow::MapWindow(const QMapboxGLSettings &settings) : m_settings(settings), velocity_filter(0, 10, 0.05) {
+MapWindow::MapWindow(const QMapboxGLSettings &settings) : m_settings(settings), velocity_filter(0, 10, 0.05, false) {
   QObject::connect(uiState(), &UIState::uiUpdate, this, &MapWindow::updateState);
 
   map_overlay = new QWidget (this);


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/29601

fixes map always starting from 0 m/s zoom level when you get a fix while driving

Old:

https://github.com/commaai/openpilot/assets/25857203/e4e79693-041a-4232-8e27-274c38117b8b

New:


https://github.com/commaai/openpilot/assets/25857203/aefee966-a11f-4940-b272-f16a07f892c1