### PR TITLE
CI: use GITHUB_ENV for env variables

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -193,7 +193,7 @@ jobs:
         submodules: true
     - name: Setup to push to repo
       run: |
-        export PUSH_IMAGE=true
+        echo "PUSH_IMAGE=true" >> "$GITHUB_ENV"
         $DOCKER_LOGIN
     - uses: ./.github/workflows/setup
       with:

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: Setup to push to repo
       if: github.ref == 'refs/heads/master' && github.repository == 'commaai/openpilot'
       run: |
-        export PUSH_IMAGE=true
+        echo "PUSH_IMAGE=true" >> "$GITHUB_ENV"
         $DOCKER_LOGIN
     - name: Build and push sim image
       run: |
@@ -82,7 +82,7 @@ jobs:
     - name: Setup to push to repo
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
       run: |
-        export PUSH_IMAGE=true
+        echo "PUSH_IMAGE=true" >> "$GITHUB_ENV"
         $DOCKER_LOGIN
     - name: Build and push docs image
       run: |

--- a/selfdrive/test/docker_build.sh
+++ b/selfdrive/test/docker_build.sh
@@ -35,7 +35,7 @@ DOCKER_BUILDKIT=1 docker build --cache-to type=inline --cache-from type=registry
 
 if [[ ! -z "$PUSH_IMAGE" ]];
 then
-    docker push $REMOTE_TAG
-    docker tag $REMOTE_TAG $REMOTE_SHA_TAG
-    docker push $REMOTE_SHA_TAG
+  docker push $REMOTE_TAG
+  docker tag $REMOTE_TAG $REMOTE_SHA_TAG
+  docker push $REMOTE_SHA_TAG
 fi


### PR DESCRIPTION
export doesn't work across steps, so we never will push the image