### PR TITLE
common/tests: combine multiple test binaries into one

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -268,9 +268,7 @@ jobs:
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         ./selfdrive/ui/tests/test_translations.py && \
-                        ./common/tests/test_util && \
-                        ./common/tests/test_ratekeeper && \
-                        ./common/tests/test_swaglog && \
+                        ./common/tests/test_common && \
                         ./selfdrive/boardd/tests/test_boardd_usbprotocol && \
                         ./system/loggerd/tests/test_logger &&\
                         ./system/proclogd/tests/test_proclog && \

--- a/common/SConscript
+++ b/common/SConscript
@@ -28,9 +28,9 @@ _gpucommon = fxn('gpucommon', files)
 Export('_common', '_gpucommon')
 
 if GetOption('extras'):
-  env.Program('tests/test_util', ['tests/test_util.cc'], LIBS=[_common])
-  env.Program('tests/test_swaglog', ['tests/test_swaglog.cc'], LIBS=[_common, 'json11', 'zmq', 'pthread'])
-  env.Program('tests/test_ratekeeper', ['tests/test_ratekeeper.cc'], LIBS=[_common, 'json11', 'zmq', 'pthread'])
+  env.Program('tests/test_common',
+              ['tests/test_runner.cc', 'tests/test_util.cc', 'tests/test_swaglog.cc', 'tests/test_ratekeeper.cc'],
+              LIBS=[_common, 'json11', 'zmq', 'pthread'])
 
 # Cython
 envCython.Program('params_pyx.so', 'params_pyx.pyx', LIBS=envCython['LIBS'] + [_common, 'zmq', 'json11'])

--- a/common/tests/.gitignore
+++ b/common/tests/.gitignore
@@ -1,3 +1,1 @@
-test_ratekeeper
-test_util
-test_swaglog
+test_common

--- a/common/tests/test_ratekeeper.cc
+++ b/common/tests/test_ratekeeper.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 #include "common/ratekeeper.h"
 #include "common/timing.h"

--- a/common/tests/test_runner.cc
+++ b/common/tests/test_runner.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"

--- a/common/tests/test_swaglog.cc
+++ b/common/tests/test_swaglog.cc
@@ -1,13 +1,13 @@
 #include <zmq.h>
-#include <iostream>
-#define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
 
-#include "third_party/json11/json11.hpp"
+#include <iostream>
+
+#include "catch2/catch.hpp"
 #include "common/swaglog.h"
 #include "common/util.h"
 #include "common/version.h"
 #include "system/hardware/hw.h"
+#include "third_party/json11/json11.hpp"
 
 const char *SWAGLOG_ADDR = "ipc:///tmp/logmessage";
 std::string daemon_name = "testy";

--- a/common/tests/test_util.cc
+++ b/common/tests/test_util.cc
@@ -5,10 +5,10 @@
 
 #include <algorithm>
 #include <climits>
+#include <fstream>
 #include <random>
 #include <string>
 
-#define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 #include "common/util.h"
 


### PR DESCRIPTION
combine `test_util,``test_ratekeeper`,`test_swalog` into `test_common`. to reduce link&run time 