### PR TITLE
util.cc: remove duplidate #include

### DIFF
--- a/common/util.cc
+++ b/common/util.cc
@@ -3,7 +3,6 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
-#include <dirent.h>
 
 #include <cassert>
 #include <cerrno>


### PR DESCRIPTION
there are two `#include <dirent.h>` in util.cc