### PR TITLE
CI: use local scons cache instead of building a separate image

### DIFF
--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -1,10 +1,6 @@
 name: 'openpilot env setup'
 
 inputs:
-  setup_docker_scons_cache:
-    description: 'Whether or not to build the scons-cache docker image'
-    required: false
-    default: 'false'
   git_lfs:
     description: 'Whether or not to pull the git lfs'
     required: false
@@ -47,11 +43,3 @@ runs:
     # build our docker image
     - shell: bash
       run: eval ${{ env.BUILD }}
-    - id: setup-scons-cache-docker
-      name: Sets up a docker image with scons cache that can by mounted as a buildkit cache mount
-      shell: bash
-      if: ${{ inputs.setup_docker_scons_cache == 'true' }}
-      run: |
-        cp selfdrive/test/Dockerfile.scons_cache $GITHUB_WORKSPACE/.ci_cache
-        cd $GITHUB_WORKSPACE/.ci_cache
-        DOCKER_BUILDKIT=1 docker build -t scons-cache -f Dockerfile.scons_cache .

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -53,8 +53,6 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/workflows/setup
-      with:
-        setup_docker_scons_cache: true
     - name: Build base cl image
       run: eval "$BUILD_CL"
     - name: Setup to push to repo
@@ -76,7 +74,6 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup
       with:
-        setup_docker_scons_cache: true
         git_lfs: false
     - name: Setup to push to repo
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'

--- a/SConstruct
+++ b/SConstruct
@@ -11,7 +11,6 @@ SCons.Warnings.warningAsException(True)
 
 TICI = os.path.isfile('/TICI')
 AGNOS = TICI
-CI_SIM = os.environ.get("CI_SIM", None) != None
 
 Decider('MD5-timestamp')
 
@@ -236,7 +235,7 @@ if GetOption('compile_db'):
   env.CompilationDatabase('compile_commands.json')
 
 # Setup cache dir
-cache_dir = '/data/scons_cache' if AGNOS else '/tmp/scons_cache' if not CI_SIM else '.ci_cache/scons_cache'
+cache_dir = '/data/scons_cache' if AGNOS else '/tmp/scons_cache'
 CacheDir(cache_dir)
 Clean(["."], cache_dir)
 

--- a/SConstruct
+++ b/SConstruct
@@ -11,6 +11,7 @@ SCons.Warnings.warningAsException(True)
 
 TICI = os.path.isfile('/TICI')
 AGNOS = TICI
+CI_SIM = os.environ.get("CI_SIM", None) != None
 
 Decider('MD5-timestamp')
 
@@ -235,7 +236,7 @@ if GetOption('compile_db'):
   env.CompilationDatabase('compile_commands.json')
 
 # Setup cache dir
-cache_dir = '/data/scons_cache' if AGNOS else '/tmp/scons_cache'
+cache_dir = '/data/scons_cache' if AGNOS else '/tmp/scons_cache' if not CI_SIM else '.ci_cache/scons_cache'
 CacheDir(cache_dir)
 Clean(["."], cache_dir)
 

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -1,5 +1,3 @@
-FROM scons-cache as scons-cache
-
 FROM ghcr.io/commaai/openpilot-base:latest
 
 ENV PYTHONUNBUFFERED 1

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -38,5 +38,5 @@ WORKDIR ${OPENPILOT_PATH}/docs
 RUN make html
 
 FROM nginx:1.21
-COPY --from=1 /home/batman/openpilot/build/docs/html /usr/share/nginx/html
+COPY --from=0 /home/batman/openpilot/build/docs/html /usr/share/nginx/html
 COPY ./docs/docker/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -31,7 +31,7 @@ COPY ./selfdrive ${OPENPILOT_PATH}/selfdrive
 COPY ./system ${OPENPILOT_PATH}/system
 COPY ./*.md ${OPENPILOT_PATH}/
 
-RUN --mount=type=bind,from=scons-cache,source=/tmp/scons_cache,target=/tmp/scons_cache,rw scons -j$(nproc)
+RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j$(nproc)
 
 RUN apt update && apt install doxygen -y
 COPY ./docs ${OPENPILOT_PATH}/docs

--- a/selfdrive/test/Dockerfile.scons_cache
+++ b/selfdrive/test/Dockerfile.scons_cache
@@ -1,3 +1,0 @@
-FROM alpine:3
-
-COPY ./scons_cache /tmp/scons_cache

--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -1,5 +1,3 @@
-FROM scons-cache as scons-cache
-
 FROM ghcr.io/commaai/openpilot-base-cl:latest
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -29,6 +29,6 @@ COPY ./system $HOME/openpilot/system
 COPY ./tools $HOME/openpilot/tools
 
 WORKDIR $HOME/openpilot
-RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j12
+RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j$(nproc)
 
 RUN python -c "from openpilot.selfdrive.test.helpers import set_params_enabled; set_params_enabled()"

--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -29,6 +29,6 @@ COPY ./system $HOME/openpilot/system
 COPY ./tools $HOME/openpilot/tools
 
 WORKDIR $HOME/openpilot
-RUN --mount=type=bind,from=scons-cache,source=/tmp/scons_cache,target=/tmp/scons_cache,rw scons -j12
+RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j12
 
 RUN python -c "from openpilot.selfdrive.test.helpers import set_params_enabled; set_params_enabled()"


### PR DESCRIPTION
since we moved the scons cache to a local directory, we can just mount it directly instead of making a separate image, which is slightly faster