### PR TITLE
CI: fix proc replay download cache permissions

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -301,6 +301,7 @@ jobs:
       timeout-minutes: 30
       run: |
         ${{ env.RUN }} "CI=1 coverage run selfdrive/test/process_replay/test_processes.py -j$(nproc) && \
+                        chmod -R 777 /tmp/comma_download_cache && \
                         coverage xml"
     - name: Print diff
       id: print-diff


### PR DESCRIPTION
Appears to have been an issue for awhile, but the replay logs only take 10 second to download anyway.

(random commit from May, same issue) https://github.com/commaai/openpilot/actions/runs/5101950826/job/13812264100#step:24:3