### PR TITLE
CI: fix sim/docs scons cache invalidation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ AddOption('--pc-thneed',
 AddOption('--minimal',
           action='store_false',
           dest='extras',
-          default=os.path.islink(Dir('#laika/').abspath) or os.path.exists(Dir('#laika/').abspath),
+          default=os.path.exists(Dir('#laika/').abspath),
           help='the minimum build to run openpilot. no tests, tools, etc.')
 
 ## Architecture name breakdown (arch)

--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ AddOption('--pc-thneed',
 AddOption('--minimal',
           action='store_false',
           dest='extras',
-          default=os.path.exists(Dir('#laika/').abspath),
+          default=os.path.islink(Dir('#laika/').abspath),
           help='the minimum build to run openpilot. no tests, tools, etc.')
 
 ## Architecture name breakdown (arch)

--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ AddOption('--pc-thneed',
 AddOption('--minimal',
           action='store_false',
           dest='extras',
-          default=os.path.islink(Dir('#laika/').abspath),
+          default=os.path.islink(Dir('#laika/').abspath) or os.path.exists(Dir('#laika/').abspath),
           help='the minimum build to run openpilot. no tests, tools, etc.')
 
 ## Architecture name breakdown (arch)

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/commaai/openpilot-base:latest
 
 ENV PYTHONUNBUFFERED 1
 
-ENV OPENPILOT_PATH /home/batman/openpilot/
+ENV OPENPILOT_PATH /tmp/openpilot
 ENV PYTHONPATH ${OPENPILOT_PATH}:${PYTHONPATH}
 ENV POETRY_VIRUALENVS_CREATE false
 
@@ -29,7 +29,7 @@ COPY ./selfdrive ${OPENPILOT_PATH}/selfdrive
 COPY ./system ${OPENPILOT_PATH}/system
 COPY ./*.md ${OPENPILOT_PATH}/
 
-RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j$(nproc)
+RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j$(nproc) --cache-readonly
 
 RUN apt update && apt install doxygen -y
 COPY ./docs ${OPENPILOT_PATH}/docs

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -38,5 +38,5 @@ WORKDIR ${OPENPILOT_PATH}/docs
 RUN make html
 
 FROM nginx:1.21
-COPY --from=0 /home/batman/openpilot/build/docs/html /usr/share/nginx/html
+COPY --from=0 /tmp/openpilot/build/docs/html /usr/share/nginx/html
 COPY ./docs/docker/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -15,8 +15,8 @@ COPY ./openpilot ${OPENPILOT_PATH}/openpilot
 COPY ./body ${OPENPILOT_PATH}/body
 COPY ./third_party ${OPENPILOT_PATH}/third_party
 COPY ./site_scons ${OPENPILOT_PATH}/site_scons
-COPY ./laika ${OPENPILOT_PATH}/laika
 COPY ./laika_repo ${OPENPILOT_PATH}/laika_repo
+RUN ln -s ${OPENPILOT_PATH}/laika_repo ${OPENPILOT_PATH}/laika
 COPY ./rednose ${OPENPILOT_PATH}/rednose
 COPY ./rednose_repo ${OPENPILOT_PATH}/rednose_repo
 COPY ./tools ${OPENPILOT_PATH}/tools

--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -9,26 +9,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN cd $HOME && \
     curl -O https://raw.githubusercontent.com/commaai/eon-neos-builder/master/devices/eon/home/.tmux.conf
 
-ENV PYTHONPATH $HOME/openpilot:${PYTHONPATH}
-RUN mkdir -p $HOME/openpilot
+ENV OPENPILOT_PATH /tmp/openpilot
+ENV PYTHONPATH ${OPENPILOT_PATH}:${PYTHONPATH}
 
-COPY SConstruct $HOME/openpilot/
+RUN mkdir -p ${OPENPILOT_PATH}
+WORKDIR ${OPENPILOT_PATH}
 
-COPY ./openpilot $HOME/openpilot/openpilot
-COPY ./body $HOME/openpilot/body
-COPY ./third_party $HOME/openpilot/third_party
-COPY ./site_scons $HOME/openpilot/site_scons
-COPY ./rednose $HOME/openpilot/rednose
-COPY ./laika $HOME/openpilot/laika
-COPY ./common $HOME/openpilot/common
-COPY ./opendbc $HOME/openpilot/opendbc
-COPY ./cereal $HOME/openpilot/cereal
-COPY ./panda $HOME/openpilot/panda
-COPY ./selfdrive $HOME/openpilot/selfdrive
-COPY ./system $HOME/openpilot/system
-COPY ./tools $HOME/openpilot/tools
+COPY SConstruct ${OPENPILOT_PATH}
 
-WORKDIR $HOME/openpilot
-RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j$(nproc)
+COPY ./openpilot ${OPENPILOT_PATH}/openpilot
+COPY ./body ${OPENPILOT_PATH}/body
+COPY ./third_party ${OPENPILOT_PATH}/third_party
+COPY ./site_scons ${OPENPILOT_PATH}/site_scons
+COPY ./rednose ${OPENPILOT_PATH}/rednose
+COPY ./laika ${OPENPILOT_PATH}/laika
+COPY ./common ${OPENPILOT_PATH}/common
+COPY ./opendbc ${OPENPILOT_PATH}/opendbc
+COPY ./cereal ${OPENPILOT_PATH}/cereal
+COPY ./panda ${OPENPILOT_PATH}/panda
+COPY ./selfdrive ${OPENPILOT_PATH}/selfdrive
+COPY ./system ${OPENPILOT_PATH}/system
+COPY ./tools ${OPENPILOT_PATH}/tools
+
+RUN --mount=type=bind,source=.ci_cache/scons_cache,target=/tmp/scons_cache,rw scons -j$(nproc) --cache-readonly
 
 RUN python -c "from openpilot.selfdrive.test.helpers import set_params_enabled; set_params_enabled()"

--- a/tools/sim/Dockerfile.sim
+++ b/tools/sim/Dockerfile.sim
@@ -22,7 +22,8 @@ COPY ./body ${OPENPILOT_PATH}/body
 COPY ./third_party ${OPENPILOT_PATH}/third_party
 COPY ./site_scons ${OPENPILOT_PATH}/site_scons
 COPY ./rednose ${OPENPILOT_PATH}/rednose
-COPY ./laika ${OPENPILOT_PATH}/laika
+COPY ./laika_repo ${OPENPILOT_PATH}/laika_repo
+RUN ln -s ${OPENPILOT_PATH}/laika_repo ${OPENPILOT_PATH}/laika
 COPY ./common ${OPENPILOT_PATH}/common
 COPY ./opendbc ${OPENPILOT_PATH}/opendbc
 COPY ./cereal ${OPENPILOT_PATH}/cereal


### PR DESCRIPTION
turns out to have been a combination of a few issues:

body/panda cache:
linkerscript uses absolute path, rather than local path, so since docs and sim were in /home/batman/openpilot and /openpilot rather than /tmp/openpilot, this caused a cache invalidation
```
  linkerscript_fn = File(project["LINKER_SCRIPT"]).srcnode().abspath

  ...

    "-fno-builtin",
    f"-T{linkerscript_fn}",
    "-std=gnu11",
 ```

QT cache:
- minimal build was set with islink, and we are copying in the files not linking
- since we are in minimal build, tools/replay/sconscript isn't run, meaning 
   ```
   qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
   ```
   wasn't run, which sets the global qt context, so all the qt files weren't cached because the command was different


all cache is used now, and down to 3-4 and 5-6 minutes