### PR TITLE
modeld: fix bash scripts

### DIFF
--- a/selfdrive/modeld/dmonitoringmodeld
+++ b/selfdrive/modeld/dmonitoringmodeld
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR

--- a/selfdrive/modeld/modeld
+++ b/selfdrive/modeld/modeld
@@ -1,7 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd "$DIR/../../"
 
-export LD_PRELOAD="$DIR/libthneed.so"
+if [ -f "$DIR/libthneed.so" ]; then
+  export LD_PRELOAD="$DIR/libthneed.so"
+fi
+
 exec "$DIR/modeld.py"

--- a/selfdrive/modeld/navmodeld
+++ b/selfdrive/modeld/navmodeld
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR


### PR DESCRIPTION
Fix `./modeld: 3: Bad substitution`.
Fix: `ERROR: ld.so: object '/tmp/openpilot/selfdrive/modeld/libthneed.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.` when thneed is not built