### PR TITLE
cabana: use a monotonic buffer to allocate CanEvent

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -137,7 +137,7 @@ void AbstractStream::mergeEvents(std::vector<Event *>::const_iterator first, std
   static std::unordered_map<MessageId, std::deque<const CanEvent *>> new_events_map;
   static  std::vector<const CanEvent *> new_events;
   new_events_map.clear();
-  neew_events.clear();
+  new_events.clear();
 
   for (auto it = first; it != last; ++it) {
     if ((*it)->which == cereal::Event::Which::CAN) {
@@ -161,16 +161,13 @@ void AbstractStream::mergeEvents(std::vector<Event *>::const_iterator first, std
     return l->mono_time < r->mono_time;
   };
 
-  bool append = new_events.front()->mono_time > lastest_event_ts;
   for (auto &[id, new_e] : new_events_map) {
     auto &e = events_[id];
-    auto pos = append ? e.end()
-                      : std::upper_bound(e.cbegin(), e.cend(), new_e.front(), compare);
+    auto pos = std::upper_bound(e.cbegin(), e.cend(), new_e.front(), compare);
     e.insert(pos, new_e.cbegin(), new_e.cend());
   }
 
-  auto pos = append ? all_events_.end()
-                    : std::upper_bound(all_events_.begin(), all_events_.end(), new_events.front(), compare);
+  auto pos = std::upper_bound(all_events_.begin(), all_events_.end(), new_events.front(), compare);
   all_events_.insert(pos, new_events.cbegin(), new_events.cend());
 
   lastest_event_ts = all_events_.back()->mono_time;

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -5,6 +5,8 @@
 
 #include <QTimer>
 
+static const int EVENT_NEXT_BUFFER_SIZE = 6 * 1024 * 1024;  // 6MB
+
 AbstractStream *can = nullptr;
 
 StreamNotifier *StreamNotifier::instance() {
@@ -15,7 +17,7 @@ StreamNotifier *StreamNotifier::instance() {
 AbstractStream::AbstractStream(QObject *parent) : QObject(parent) {
   assert(parent != nullptr);
   new_msgs = std::make_unique<QHash<MessageId, CanData>>();
-  event_buffer = std::make_unique<MonotonicBuffer>(50000 * (sizeof(CanEvent) + sizeof(uint8_t) * 8));
+  event_buffer = std::make_unique<MonotonicBuffer>(EVENT_NEXT_BUFFER_SIZE);
 
   QObject::connect(this, &AbstractStream::seekedTo, this, &AbstractStream::updateLastMsgsTo);
   QObject::connect(&settings, &Settings::changed, this, &AbstractStream::updateMasks);

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -134,9 +134,10 @@ void AbstractStream::updateLastMsgsTo(double sec) {
 }
 
 void AbstractStream::mergeEvents(std::vector<Event *>::const_iterator first, std::vector<Event *>::const_iterator last) {
-  std::unordered_map<MessageId, std::deque<const CanEvent *>> new_events_map;
-  std::vector<const CanEvent *> new_events;
-  new_events.reserve(std::distance(first, last));
+  static std::unordered_map<MessageId, std::deque<const CanEvent *>> new_events_map;
+  static  std::vector<const CanEvent *> new_events;
+  new_events_map.clear();
+  neew_events.clear();
 
   for (auto it = first; it != last; ++it) {
     if ((*it)->which == cereal::Event::Which::CAN) {

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -167,7 +167,7 @@ void AbstractStream::mergeEvents(std::vector<Event *>::const_iterator first, std
     e.insert(pos, new_e.cbegin(), new_e.cend());
   }
 
-  auto pos = std::upper_bound(all_events_.begin(), all_events_.end(), new_events.front(), compare);
+  auto pos = std::upper_bound(all_events_.cbegin(), all_events_.cend(), new_events.front(), compare);
   all_events_.insert(pos, new_events.cbegin(), new_events.cend());
 
   lastest_event_ts = all_events_.back()->mono_time;

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -163,12 +163,12 @@ void AbstractStream::mergeEvents(std::vector<Event *>::const_iterator first, std
 
   for (auto &[id, new_e] : new_events_map) {
     auto &e = events_[id];
-    auto pos = std::upper_bound(e.cbegin(), e.cend(), new_e.front(), compare);
-    e.insert(pos, new_e.cbegin(), new_e.cend());
+    auto insert_pos = std::upper_bound(e.cbegin(), e.cend(), new_e.front(), compare);
+    e.insert(insert_pos, new_e.cbegin(), new_e.cend());
   }
 
-  auto pos = std::upper_bound(all_events_.cbegin(), all_events_.cend(), new_events.front(), compare);
-  all_events_.insert(pos, new_events.cbegin(), new_events.cend());
+  auto insert_pos = std::upper_bound(all_events_.cbegin(), all_events_.cend(), new_events.front(), compare);
+  all_events_.insert(insert_pos, new_events.cbegin(), new_events.cend());
 
   lastest_event_ts = all_events_.back()->mono_time;
   emit eventsMerged();

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -101,7 +101,7 @@ protected:
   QHash<MessageId, CanData> all_msgs;
   std::unordered_map<MessageId, std::vector<const CanEvent *>> events_;
   std::vector<const CanEvent *> all_events_;
-  std::deque<std::unique_ptr<char[]>> memory_blocks;
+  std::unique_ptr<MonotonicBuffer> event_buffer;
   std::mutex mutex;
   std::unordered_map<MessageId, std::vector<uint8_t>> masks;
 };

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <deque>
 #include <vector>
 #include <utility>
 
@@ -151,6 +152,21 @@ public slots:
 private:
   inline static int sig_fd[2] = {};
   QSocketNotifier *sn;
+};
+
+class MonotonicBuffer {
+public:
+  MonotonicBuffer(size_t initial_size) : next_buffer_size(initial_size) {}
+  ~MonotonicBuffer();
+  void *allocate(size_t bytes, size_t alignment = 16ul);
+  void deallocate(void *p) {}
+
+private:
+  void *current_buf = nullptr;
+  size_t next_buffer_size = 0;
+  size_t available = 0;
+  std::deque<void *> buffers;
+  static constexpr float growth_factor = 1.5;
 };
 
 int num_decimals(double num);


### PR DESCRIPTION
Use a custom monotonic buffer to allocate CanEvent, and align all events by 16 bytes. this can improves overall performance, especially when running in live streaming mode.
