### PR TITLE
Revert "ui/network: don't refresh on connect (#29651)"

### DIFF
--- a/selfdrive/ui/qt/offroad/wifiManager.cc
+++ b/selfdrive/ui/qt/offroad/wifiManager.cc
@@ -166,7 +166,7 @@ SecurityType WifiManager::getSecurityType(const QVariantMap &properties) {
 }
 
 void WifiManager::connect(const Network &n, const QString &password, const QString &username) {
-  setCurrentSsid(n.ssid);
+  setCurrentConnecting(n.ssid);
   forgetConnection(n.ssid);  // Clear all connections that may already exist to the network we are connecting
   Connection connection;
   connection["connection"]["type"] = "802-11-wireless";
@@ -231,13 +231,11 @@ void WifiManager::forgetConnection(const QString &ssid) {
   }
 }
 
-void WifiManager::setCurrentSsid(const QString &connecting_ssid, const QString &connected_ssid) {
-  // Allows the network connected statuses to be updated between AP refreshes
+void WifiManager::setCurrentConnecting(const QString &ssid) {
+  connecting_to_network = ssid;
   for (auto &network : seenNetworks) {
-    network.connected = (network.ssid == connecting_ssid) ? ConnectedType::CONNECTING :
-                        ((network.ssid == connected_ssid) ? ConnectedType::CONNECTED : ConnectedType::DISCONNECTED);
+    network.connected = (network.ssid == ssid) ? ConnectedType::CONNECTING : ConnectedType::DISCONNECTED;
   }
-  connecting_to_network = connecting_ssid;
   emit refreshSignal();
 }
 
@@ -271,8 +269,8 @@ void WifiManager::stateChange(unsigned int new_state, unsigned int previous_stat
     forgetConnection(connecting_to_network);
     emit wrongPassword(connecting_to_network);
   } else if (new_state == NM_DEVICE_STATE_ACTIVATED) {
-    ipv4_address = getIp4Address();
-    setCurrentSsid("", connecting_to_network);
+    connecting_to_network = "";
+    refreshNetworks();
   }
 }
 
@@ -329,7 +327,7 @@ void WifiManager::initConnections() {
 std::optional<QDBusPendingCall> WifiManager::activateWifiConnection(const QString &ssid) {
   const QDBusObjectPath &path = getConnectionPath(ssid);
   if (!path.path().isEmpty()) {
-    setCurrentSsid(ssid);
+    setCurrentConnecting(ssid);
     return asyncCall(NM_DBUS_PATH, NM_DBUS_INTERFACE, "ActivateConnection", QVariant::fromValue(path), QVariant::fromValue(QDBusObjectPath(adapter)), QVariant::fromValue(QDBusObjectPath("/")));
   }
   return std::nullopt;

--- a/selfdrive/ui/qt/offroad/wifiManager.h
+++ b/selfdrive/ui/qt/offroad/wifiManager.h
@@ -85,7 +85,7 @@ private:
   void refreshNetworks();
   void activateModemConnection(const QDBusObjectPath &path);
   void addTetheringConnection();
-  void setCurrentSsid(const QString &connecting_ssid, const QString &connected_ssid = "");
+  void setCurrentConnecting(const QString &ssid);
 
 signals:
   void wrongPassword(const QString &ssid);


### PR DESCRIPTION
Introduced some bugs, best to revert.

This reverts commit 6ea564b33ec6066bea1cc9829ce7c3078fdd735d.

Revert "ui/network: refresh IP address on connect"

This reverts commit 46c32613fccd22e356c0b3092b61132ce264ae49.
