### PR TITLE
IsoTpParallelQuery: extend timeout for every frame type

### DIFF
--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -104,14 +104,14 @@ class IsoTpParallelQuery:
 
       for tx_addr, msg in msgs.items():
         try:
-          dat, rx_in_progress = msg.recv()
+          dat, updated = msg.recv()
         except Exception:
           cloudlog.exception(f"Error processing UDS response: {tx_addr}")
           request_done[tx_addr] = True
           continue
 
-        # Extend timeout for each consecutive ISO-TP frame to avoid timing out on long responses
-        if rx_in_progress:
+        # Extend timeout for each valid ISO-TP frame to avoid timing out on long responses
+        if updated:
           addrs_responded.add(tx_addr)
           response_timeouts[tx_addr] = time.monotonic() + timeout
 


### PR DESCRIPTION
Not just consecutive. Does this by adding more checks to IsoTpMessage in panda so we throw an exception on broadcast addrs instead of timing out. A Toyota ECU was also seen taking a long time to respond with a first consecutive frame, so this reduces accidental time outs.

openpilot PR this partially reverts, allowed due to the added panda iso-tp checks: https://github.com/commaai/openpilot/pull/27762

panda PRs:

https://github.com/commaai/panda/pull/1487
https://github.com/commaai/panda/pull/1610