### PR TITLE
ui/driverview: inherit from CameraWidget

### DIFF
--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -3,62 +3,33 @@
 #include <algorithm>
 #include <QPainter>
 
-#include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/util.h"
 
 const int FACE_IMG_SIZE = 130;
 
-DriverViewWindow::DriverViewWindow(QWidget* parent) : QWidget(parent) {
-  setAttribute(Qt::WA_OpaquePaintEvent);
-  layout = new QStackedLayout(this);
-  layout->setStackingMode(QStackedLayout::StackAll);
-
-  cameraView = new CameraWidget("camerad", VISION_STREAM_DRIVER, true, this);
-  layout->addWidget(cameraView);
-
-  scene = new DriverViewScene(this);
-  connect(cameraView, &CameraWidget::vipcThreadFrameReceived, scene, &DriverViewScene::frameUpdated);
-  layout->addWidget(scene);
-  layout->setCurrentWidget(scene);
-
-  QObject::connect(device(), &Device::interactiveTimeout, this, &DriverViewWindow::closeView);
-}
-
-void DriverViewWindow::closeView() {
-  if (isVisible()) {
-    cameraView->stopVipcThread();
-    emit done();
-  }
-}
-
-void DriverViewWindow::mouseReleaseEvent(QMouseEvent* e) {
-  closeView();
-}
-
-DriverViewScene::DriverViewScene(QWidget* parent) : QWidget(parent) {
+DriverViewWindow::DriverViewWindow(QWidget* parent) : CameraWidget("camerad", VISION_STREAM_DRIVER, true, parent) {
   face_img = loadPixmap("../assets/img_driver_face_static.png", {FACE_IMG_SIZE, FACE_IMG_SIZE});
+  QObject::connect(device(), &Device::interactiveTimeout, this, &DriverViewWindow::done);
+  QObject::connect(this, &CameraWidget::clicked, this, &DriverViewWindow::done);
 }
 
-void DriverViewScene::showEvent(QShowEvent* event) {
-  frame_updated = false;
+void DriverViewWindow::showEvent(QShowEvent* event) {
   params.putBool("IsDriverViewEnabled", true);
   device()->resetInteractiveTimeout(60);
+  CameraWidget::showEvent(event);
 }
 
-void DriverViewScene::hideEvent(QHideEvent* event) {
+void DriverViewWindow::hideEvent(QHideEvent* event) {
   params.putBool("IsDriverViewEnabled", false);
+  stopVipcThread();
 }
 
-void DriverViewScene::frameUpdated() {
-  frame_updated = true;
-  update();
-}
+void DriverViewWindow::paintGL() {
+  CameraWidget::paintGL();
 
-void DriverViewScene::paintEvent(QPaintEvent* event) {
   QPainter p(this);
-
   // startup msg
-  if (!frame_updated) {
+  if (frames.empty()) {
     p.setPen(Qt::white);
     p.setRenderHint(QPainter::TextAntialiasing);
     p.setFont(InterFont(100, QFont::Bold));
@@ -70,7 +41,7 @@ void DriverViewScene::paintEvent(QPaintEvent* event) {
   cereal::DriverStateV2::Reader driver_state = sm["driverStateV2"].getDriverStateV2();
   cereal::DriverStateV2::DriverData::Reader driver_data;
 
-  is_rhd = driver_state.getWheelOnRightProb() > 0.5;
+  bool is_rhd = driver_state.getWheelOnRightProb() > 0.5;
   driver_data = is_rhd ? driver_state.getRightDriverData() : driver_state.getLeftDriverData();
 
   bool face_detected = driver_data.getFaceProb() > 0.7;

--- a/selfdrive/ui/qt/offroad/driverview.h
+++ b/selfdrive/ui/qt/offroad/driverview.h
@@ -1,31 +1,8 @@
 #pragma once
 
-#include <QStackedLayout>
-
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 
-class DriverViewScene : public QWidget {
-  Q_OBJECT
-
-public:
-  explicit DriverViewScene(QWidget *parent);
-
-public slots:
-  void frameUpdated();
-
-protected:
-  void showEvent(QShowEvent *event) override;
-  void hideEvent(QHideEvent *event) override;
-  void paintEvent(QPaintEvent *event) override;
-
-private:
-  Params params;
-  QPixmap face_img;
-  bool is_rhd = false;
-  bool frame_updated = false;
-};
-
-class DriverViewWindow : public QWidget {
+class DriverViewWindow : public CameraWidget {
   Q_OBJECT
 
 public:
@@ -35,10 +12,10 @@ signals:
   void done();
 
 protected:
-  void mouseReleaseEvent(QMouseEvent* e) override;
-  void closeView();
+  void showEvent(QShowEvent *event) override;
+  void hideEvent(QHideEvent *event) override;
+  void paintGL() override;
 
-  CameraWidget *cameraView;
-  DriverViewScene *scene;
-  QStackedLayout *layout;
+  Params params;
+  QPixmap face_img;
 };

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>Kamera startet</translation>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>démarrage de la caméra</translation>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>ｶﾒﾗを起動しています</translation>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>카메라 시작중</translation>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>câmera iniciando</translation>

--- a/selfdrive/ui/translations/main_th.ts
+++ b/selfdrive/ui/translations/main_th.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>กำลังเปิดกล้อง</translation>

--- a/selfdrive/ui/translations/main_tr.ts
+++ b/selfdrive/ui/translations/main_tr.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>kamera başlatılıyor</translation>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>正在启动相机</translation>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -302,7 +302,7 @@
     </message>
 </context>
 <context>
-    <name>DriverViewScene</name>
+    <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>
         <translation>開啟相機中</translation>


### PR DESCRIPTION
The `DriverViewWindow` has basically remained unchanged since the conversion from `nanovg` to `QOpenglWidget` https://github.com/commaai/openpilot/pull/21063. it's quite outdated compared to the current ui code.