### PR TITLE
ui/NavManager: parse location timestamp from API

### DIFF
--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -15,6 +15,11 @@ static bool locationEqual(const QJsonValue &v1, const QJsonValue &v2) {
   return v1["latitude"] == v2["latitude"] && v1["longitude"] == v2["longitude"];
 }
 
+static qint64 convertTimestampToEpoch(const QString &timestamp) {
+  QDateTime dt = QDateTime::fromString(timestamp, Qt::ISODate);
+  return dt.isValid() ? dt.toSecsSinceEpoch() : 0;
+}
+
 MapSettings::MapSettings(bool closeable, QWidget *parent) : QFrame(parent) {
   setContentsMargins(0, 0, 0, 0);
   setAttribute(Qt::WA_NoMousePropagation);
@@ -322,7 +327,8 @@ void NavManager::parseLocationsResponse(const QString &response, bool success) {
   auto remote_locations = doc.array();
   for (QJsonValueRef loc : remote_locations) {
     auto obj = loc.toObject();
-    obj.insert("time", getLastActivity(obj));
+    auto newTime = convertTimestampToEpoch(obj["modified"].toString());
+    obj.insert("time", qMax(newTime, getLastActivity(obj)));
     loc = obj;
   }
 

--- a/selfdrive/ui/qt/maps/map_settings.cc
+++ b/selfdrive/ui/qt/maps/map_settings.cc
@@ -327,8 +327,8 @@ void NavManager::parseLocationsResponse(const QString &response, bool success) {
   auto remote_locations = doc.array();
   for (QJsonValueRef loc : remote_locations) {
     auto obj = loc.toObject();
-    auto newTime = convertTimestampToEpoch(obj["modified"].toString());
-    obj.insert("time", qMax(newTime, getLastActivity(obj)));
+    auto serverTime = convertTimestampToEpoch(obj["modified"].toString());
+    obj.insert("time", qMax(serverTime, getLastActivity(obj)));
     loc = obj;
   }
 


### PR DESCRIPTION
The API now includes "modified" timestamps for saved locations. This is the time the location was "last modified", and is useful for determining when the device navigated to a "recent" location.

https://api.comma.ai/#retrieve-saved-locations

Parse and combine this timestamp with the local "last activity" time to improve location sorting.

Related: #29079
Closes: #29074

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
