### PR TITLE
ui: rename QDialogBase to DialogBase

### DIFF
--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -9,7 +9,7 @@
 #include "selfdrive/ui/qt/widgets/scrollview.h"
 
 
-QDialogBase::QDialogBase(QWidget *parent) : QDialog(parent) {
+DialogBase::DialogBase(QWidget *parent) : QDialog(parent) {
   Q_ASSERT(parent != nullptr);
   parent->installEventFilter(this);
 
@@ -19,7 +19,7 @@ QDialogBase::QDialogBase(QWidget *parent) : QDialog(parent) {
       color: white;
       font-family: Inter;
     }
-    QDialogBase {
+    DialogBase {
       background-color: black;
     }
     QPushButton {
@@ -36,19 +36,19 @@ QDialogBase::QDialogBase(QWidget *parent) : QDialog(parent) {
   )");
 }
 
-bool QDialogBase::eventFilter(QObject *o, QEvent *e) {
+bool DialogBase::eventFilter(QObject *o, QEvent *e) {
   if (o == parent() && e->type() == QEvent::Hide) {
     reject();
   }
   return QDialog::eventFilter(o, e);
 }
 
-int QDialogBase::exec() {
+int DialogBase::exec() {
   setMainWindow(this);
   return QDialog::exec();
 }
 
-InputDialog::InputDialog(const QString &title, QWidget *parent, const QString &subtitle, bool secret) : QDialogBase(parent) {
+InputDialog::InputDialog(const QString &title, QWidget *parent, const QString &subtitle, bool secret) : DialogBase(parent) {
   main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(50, 55, 50, 50);
   main_layout->setSpacing(0);
@@ -188,7 +188,7 @@ void InputDialog::setMinLength(int length) {
 // ConfirmationDialog
 
 ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString &confirm_text, const QString &cancel_text,
-                                       const bool rich, QWidget *parent) : QDialogBase(parent) {
+                                       const bool rich, QWidget *parent) : DialogBase(parent) {
   QFrame *container = new QFrame(this);
   container->setStyleSheet(R"(
     QFrame { background-color: #1B1B1B; color: #C9C9C9; }
@@ -245,7 +245,7 @@ bool ConfirmationDialog::rich(const QString &prompt_text, QWidget *parent) {
 
 // MultiOptionDialog
 
-MultiOptionDialog::MultiOptionDialog(const QString &prompt_text, const QStringList &l, const QString &current, QWidget *parent) : QDialogBase(parent) {
+MultiOptionDialog::MultiOptionDialog(const QString &prompt_text, const QStringList &l, const QString &current, QWidget *parent) : DialogBase(parent) {
   QFrame *container = new QFrame(this);
   container->setStyleSheet(R"(
     QFrame { background-color: #1B1B1B; }

--- a/selfdrive/ui/qt/widgets/input.h
+++ b/selfdrive/ui/qt/widgets/input.h
@@ -10,18 +10,18 @@
 #include "selfdrive/ui/qt/widgets/keyboard.h"
 
 
-class QDialogBase : public QDialog {
+class DialogBase : public QDialog {
   Q_OBJECT
 
 protected:
-  QDialogBase(QWidget *parent);
+  DialogBase(QWidget *parent);
   bool eventFilter(QObject *o, QEvent *e) override;
 
 public slots:
   int exec() override;
 };
 
-class InputDialog : public QDialogBase {
+class InputDialog : public DialogBase {
   Q_OBJECT
 
 public:
@@ -50,7 +50,7 @@ signals:
   void emitText(const QString &text);
 };
 
-class ConfirmationDialog : public QDialogBase {
+class ConfirmationDialog : public DialogBase {
   Q_OBJECT
 
 public:
@@ -61,7 +61,7 @@ public:
   static bool rich(const QString &prompt_text, QWidget *parent);
 };
 
-class MultiOptionDialog : public QDialogBase {
+class MultiOptionDialog : public DialogBase {
   Q_OBJECT
 
 public:

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -68,7 +68,7 @@ void PairingQRWidget::paintEvent(QPaintEvent *e) {
 }
 
 
-PairingPopup::PairingPopup(QWidget *parent) : QDialogBase(parent) {
+PairingPopup::PairingPopup(QWidget *parent) : DialogBase(parent) {
   QHBoxLayout *hlayout = new QHBoxLayout(this);
   hlayout->setContentsMargins(0, 0, 0, 0);
   hlayout->setSpacing(0);

--- a/selfdrive/ui/qt/widgets/prime.h
+++ b/selfdrive/ui/qt/widgets/prime.h
@@ -28,7 +28,7 @@ private slots:
 
 
 // pairing popup widget
-class PairingPopup : public QDialogBase {
+class PairingPopup : public DialogBase {
   Q_OBJECT
 
 public:


### PR DESCRIPTION
QDialogBase can easily be mistaken for a class in QT.