### PR TITLE
CI: prepare for pytest by adding marker and avoiding duplicated tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ --ignore=laika_repo/ -Werror --strict-config --strict-markers"
+addopts = "--ignore=openpilot/ --ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ --ignore=laika_repo/ -Werror --strict-config --strict-markers"
 python_files = "test_*.py"
 #timeout = "30"  # you get this long by default
+markers = [
+  "parallel: mark tests as parallelizable (tests with no global state, so can be run in parallel)"
+]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
- need to ignore openpilot, or we get duplicated tests since its symlinked
- added marker for tests that we can run in parallel (opt in parallelization)