### PR TITLE
Subaru: cleanup and fix preglobal

### DIFF
--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -36,7 +36,7 @@ class CarController:
         apply_steer = 0
 
       if self.CP.carFingerprint in PREGLOBAL_CARS:
-        can_sends.append(subarucan.create_preglobal_steering_control(self.packer, apply_steer, CC.latActive))
+        can_sends.append(subarucan.create_preglobal_steering_control(self.packer, self.frame // self.p.STEER_STEP, apply_steer, CC.latActive))
       else:
         can_sends.append(subarucan.create_steering_control(self.packer, apply_steer, CC.latActive))
 

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -177,11 +177,6 @@ class CarState(CarStateBase):
     if CP.carFingerprint not in PREGLOBAL_CARS:
       if CP.carFingerprint not in GLOBAL_GEN2:
         messages += CarState.get_common_global_body_messages(CP)
-
-      messages += [
-        ("Dashlights", 10),
-        ("BodyInfo", 10),
-      ]
     else:
       messages += CarState.get_common_preglobal_body_messages()
 

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -4,7 +4,7 @@ from opendbc.can.can_define import CANDefine
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.subaru.values import DBC, CAR, GLOBAL_GEN2, PREGLOBAL_CARS, HYBRID_CARS, CanBus, SubaruFlags
+from openpilot.selfdrive.car.subaru.values import DBC, GLOBAL_GEN2, PREGLOBAL_CARS, HYBRID_CARS, CanBus, SubaruFlags
 from openpilot.selfdrive.car import CanSignalRateCalculator
 
 
@@ -24,7 +24,7 @@ class CarState(CarStateBase):
 
     ret.gasPressed = ret.gas > 1e-5
     if self.car_fingerprint in PREGLOBAL_CARS:
-      ret.brakePressed = cp.vl["Brake_Pedal"]["Brake_Pedal"] > 2
+      ret.brakePressed = cp.vl["Brake_Pedal"]["Brake_Pedal"] > 0
     else:
       cp_brakes = cp_body if self.car_fingerprint in GLOBAL_GEN2 else cp
       ret.brakePressed = cp_brakes.vl["Brake_Status"]["Brake"] == 1
@@ -145,6 +145,17 @@ class CarState(CarStateBase):
     return messages
 
   @staticmethod
+  def get_common_preglobal_body_messages():
+    messages = [
+      ("CruiseControl", 50),
+      ("Wheel_Speeds", 50),
+      ("Dash_State2", 1),
+      ("Dashlights", 10),
+    ]
+
+    return messages
+
+  @staticmethod
   def get_can_parser(CP):
     messages = [
       # sig_address, frequency
@@ -172,23 +183,7 @@ class CarState(CarStateBase):
         ("BodyInfo", 10),
       ]
     else:
-      messages += [
-        ("Wheel_Speeds", 50),
-        ("Dash_State2", 1),
-      ]
-
-      if CP.carFingerprint == CAR.FORESTER_PREGLOBAL:
-        messages += [
-          ("Dashlights", 20),
-          ("BodyInfo", 1),
-          ("CruiseControl", 50),
-        ]
-
-      if CP.carFingerprint in (CAR.LEGACY_PREGLOBAL, CAR.OUTBACK_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018):
-        messages += [
-          ("Dashlights", 10),
-          ("CruiseControl", 50),
-        ]
+      messages += CarState.get_common_preglobal_body_messages()
 
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, CanBus.main)
 

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -239,13 +239,14 @@ def create_es_infotainment(packer, es_infotainment_msg, visual_alert):
 
 # *** Subaru Pre-global ***
 
-def subaru_preglobal_checksum(packer, values, addr):
+def subaru_preglobal_checksum(packer, values, addr, checksum_byte=7):
   dat = packer.make_can_msg(addr, 0, values)[2]
-  return (sum(dat[:7])) % 256
+  return (sum(dat[:checksum_byte]) + sum(dat[checksum_byte+1:])) % 256
 
 
-def create_preglobal_steering_control(packer, apply_steer, steer_req):
+def create_preglobal_steering_control(packer, frame, apply_steer, steer_req):
   values = {
+    "COUNTER": frame % 0x08,
     "LKAS_Command": apply_steer,
     "LKAS_Active": steer_req,
   }


### PR DESCRIPTION
Preglobal (currently in dashcam mode) was broken on master:

- COUNTER has to be set in OP since we have to make the checksum in python
- brakepressed was mismatched from the panda safety
- added ability to specific the preglobal checksum byte, which is required for ES_Status and ES_Brake since the checksum is in a different place

Also some cleanup for subaru:
- carstate was also pretty messy and had lots of duplicates, cleaned that up
