### PR TITLE
FW query timing test: fix refs

### DIFF
--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -197,7 +197,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
                                 kwargs=dict(num_pandas=num_pandas))
       brand_time += self._run_thread(thread)
 
-    return round(brand_time / self.N, 2)
+    return brand_time / self.N
 
   def _assert_timing(self, avg_time, ref_time):
     self.assertLess(avg_time, ref_time + self.TOL)
@@ -256,10 +256,12 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
           avg_time = self._benchmark_brand(brand, num_pandas)
           total_time += avg_time
+          avg_time = round(avg_time, 2)
           self._assert_timing(avg_time, brand_ref_times[num_pandas][brand])
           print(f'{brand=}, {num_pandas=}, {len(config.requests)=}, avg FW query time={avg_time} seconds')
 
     with self.subTest(brand='all_brands'):
+      total_time = round(total_time, 2)
       self._assert_timing(total_time, total_ref_time)
       print(f'all brands, total FW query time={total_time} seconds')
 

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -225,14 +225,14 @@ class TestFwFingerprintTiming(unittest.TestCase):
     print(f'get_vin, query time={vin_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = 6.1
+    total_ref_time = 6.08
     brand_ref_times = {
       1: {
-        'body': 0.1,
+        'body': 0.11,
         'chrysler': 0.3,
         'ford': 0.2,
-        'honda': 0.5,
-        'hyundai': 0.7,
+        'honda': 0.52,
+        'hyundai': 0.73,
         'mazda': 0.2,
         'nissan': 0.4,
         'subaru': 0.2,
@@ -242,7 +242,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
       },
       2: {
         'ford': 0.3,
-        'hyundai': 1.1,
+        'hyundai': 1.12,
       }
     }
 

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -225,14 +225,14 @@ class TestFwFingerprintTiming(unittest.TestCase):
     print(f'get_vin, query time={vin_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = 6.08
+    total_ref_time = 6.07
     brand_ref_times = {
       1: {
         'body': 0.11,
         'chrysler': 0.3,
         'ford': 0.2,
         'honda': 0.52,
-        'hyundai': 0.73,
+        'hyundai': 0.72,
         'mazda': 0.2,
         'nissan': 0.4,
         'subaru': 0.2,


### PR DESCRIPTION
I incorrectly assumed that changing OBD multiplexing took exactly 0.1s like the queries, but it takes more like 0.12s (seen in the test), so I made the refs match more closely what it was printing.