### PR TITLE
Tests: loggerd reduce iterations

### DIFF
--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -154,35 +154,34 @@ class TestLoggerd(unittest.TestCase):
       vipc_server.create_buffers_with_sizes(stream_type, 40, False, *(frame_spec))
     vipc_server.start_listener()
 
-    for _ in range(5):
-      num_segs = random.randint(2, 5)
-      length = random.randint(1, 3)
-      os.environ["LOGGERD_SEGMENT_LENGTH"] = str(length)
-      managed_processes["loggerd"].start()
-      managed_processes["encoderd"].start()
-      time.sleep(1)
+    num_segs = random.randint(2, 5)
+    length = random.randint(1, 3)
+    os.environ["LOGGERD_SEGMENT_LENGTH"] = str(length)
+    managed_processes["loggerd"].start()
+    managed_processes["encoderd"].start()
+    time.sleep(1)
 
-      fps = 20.0
-      for n in range(1, int(num_segs*length*fps)+1):
-        for stream_type, frame_spec, state in streams:
-          dat = np.empty(frame_spec[2], dtype=np.uint8)
-          vipc_server.send(stream_type, dat[:].flatten().tobytes(), n, n/fps, n/fps)
+    fps = 20.0
+    for n in range(1, int(num_segs*length*fps)+1):
+      for stream_type, frame_spec, state in streams:
+        dat = np.empty(frame_spec[2], dtype=np.uint8)
+        vipc_server.send(stream_type, dat[:].flatten().tobytes(), n, n/fps, n/fps)
 
-          camera_state = messaging.new_message(state)
-          frame = getattr(camera_state, state)
-          frame.frameId = n
-          pm.send(state, camera_state)
-        time.sleep(1.0/fps)
+        camera_state = messaging.new_message(state)
+        frame = getattr(camera_state, state)
+        frame.frameId = n
+        pm.send(state, camera_state)
+      time.sleep(1.0/fps)
 
-      managed_processes["loggerd"].stop()
-      managed_processes["encoderd"].stop()
+    managed_processes["loggerd"].stop()
+    managed_processes["encoderd"].stop()
 
-      route_path = str(self._get_latest_log_dir()).rsplit("--", 1)[0]
-      for n in range(num_segs):
-        p = Path(f"{route_path}--{n}")
-        logged = {f.name for f in p.iterdir() if f.is_file()}
-        diff = logged ^ expected_files
-        self.assertEqual(len(diff), 0, f"didn't get all expected files. run={_} seg={n} {route_path=}, {diff=}\n{logged=} {expected_files=}")
+    route_path = str(self._get_latest_log_dir()).rsplit("--", 1)[0]
+    for n in range(num_segs):
+      p = Path(f"{route_path}--{n}")
+      logged = {f.name for f in p.iterdir() if f.is_file()}
+      diff = logged ^ expected_files
+      self.assertEqual(len(diff), 0, f"didn't get all expected files. run={_} seg={n} {route_path=}, {diff=}\n{logged=} {expected_files=}")
 
   def test_bootlog(self):
     # generate bootlog with fake launch log

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -163,6 +163,7 @@ class TestLoggerd(unittest.TestCase):
 
     fps = 20.0
     for n in range(1, int(num_segs*length*fps)+1):
+      time_start = time.monotonic()
       for stream_type, frame_spec, state in streams:
         dat = np.empty(frame_spec[2], dtype=np.uint8)
         vipc_server.send(stream_type, dat[:].flatten().tobytes(), n, n/fps, n/fps)
@@ -171,7 +172,7 @@ class TestLoggerd(unittest.TestCase):
         frame = getattr(camera_state, state)
         frame.frameId = n
         pm.send(state, camera_state)
-      time.sleep(1.0/fps)
+      time.sleep((1.0/fps) - (time.monotonic() - time_start))
 
     managed_processes["loggerd"].stop()
     managed_processes["encoderd"].stop()

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -172,7 +172,7 @@ class TestLoggerd(unittest.TestCase):
         frame = getattr(camera_state, state)
         frame.frameId = n
         pm.send(state, camera_state)
-      time.sleep((1.0/fps) - (time.monotonic() - time_start))
+      time.sleep(max((1.0/fps) - (time.monotonic() - time_start), 0))
 
     managed_processes["loggerd"].stop()
     managed_processes["encoderd"].stop()


### PR DESCRIPTION
remove the 5x test of test_rotation, seems unnecessary and this test was taking 1 minute on CI
also decreased the sleep time by including the time that we spend sending the bytes
down to ~5-10 seconds locally