### PR TITLE
Docker: split openpilot-base into two stages

### DIFF
--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -33,6 +33,7 @@ COPY tools/install_python_dependencies.sh /tmp/tools/
 RUN cd /tmp && \
     tools/install_python_dependencies.sh && \
     rm -rf /tmp/* && \
-    rm -rf /root/.cache
+    rm -rf /root/.cache && \
+    pip uninstall -y poetry
 
 RUN sudo git config --global --add safe.directory /tmp/openpilot

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -12,22 +12,28 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ENV POETRY_VIRTUALENVS_CREATE=false
-ENV PYENV_VERSION=3.11.4
-ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
-
-COPY pyproject.toml poetry.lock .python-version /tmp/
-COPY tools/ubuntu_setup.sh tools/install_ubuntu_dependencies.sh tools/install_python_dependencies.sh /tmp/tools/
+COPY tools/install_ubuntu_dependencies.sh /tmp/tools/
 RUN cd /tmp && \
-    tools/ubuntu_setup.sh && \
+    tools/install_ubuntu_dependencies.sh && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
     rm -rf /root/.cache && \
-    pip uninstall -y poetry && \
     # remove unused architectures from gcc for panda
     cd /usr/lib/gcc/arm-none-eabi/9.2.1 && \
     rm -rf arm/ && \
     rm -rf thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
+
+ENV POETRY_VIRTUALENVS_CREATE=false
+ENV PYENV_VERSION=3.11.4
+ENV PYENV_ROOT="/home/${USERNAME}/.pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+
+COPY pyproject.toml poetry.lock .python-version /tmp/
+COPY tools/install_python_dependencies.sh /tmp/tools/
+
+RUN cd /tmp && \
+    tools/install_python_dependencies.sh && \
+    rm -rf /tmp/* && \
+    rm -rf /home/${USERNAME}/.cache
 
 RUN sudo git config --global --add safe.directory /tmp/openpilot

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -23,6 +23,16 @@ RUN cd /tmp && \
     rm -rf arm/ && \
     rm -rf thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
 
+ARG USERNAME=batman
+ARG UID=1000
+ARG GID=1000
+
+RUN groupadd -g "${GID}" ${USERNAME} \
+    && useradd --create-home --no-log-init -u "${UID}" -g "${GID}" ${USERNAME} \
+    && usermod -aG sudo ${USERNAME}
+
+USER ${USERNAME}
+
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV PYENV_VERSION=3.11.4
 ENV PYENV_ROOT="/home/${USERNAME}/.pyenv"

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -17,25 +17,14 @@ RUN cd /tmp && \
     tools/install_ubuntu_dependencies.sh && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
-    rm -rf /root/.cache && \
     # remove unused architectures from gcc for panda
     cd /usr/lib/gcc/arm-none-eabi/9.2.1 && \
     rm -rf arm/ && \
     rm -rf thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
 
-ARG USERNAME=batman
-ARG UID=1000
-ARG GID=1000
-
-RUN groupadd -g "${GID}" ${USERNAME} \
-    && useradd --create-home --no-log-init -u "${UID}" -g "${GID}" ${USERNAME} \
-    && usermod -aG sudo ${USERNAME}
-
-USER ${USERNAME}
-
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV PYENV_VERSION=3.11.4
-ENV PYENV_ROOT="/home/${USERNAME}/.pyenv"
+ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
 
 COPY pyproject.toml poetry.lock .python-version /tmp/
@@ -44,6 +33,6 @@ COPY tools/install_python_dependencies.sh /tmp/tools/
 RUN cd /tmp && \
     tools/install_python_dependencies.sh && \
     rm -rf /tmp/* && \
-    rm -rf /home/${USERNAME}/.cache
+    rm -rf /root/.cache
 
 RUN sudo git config --global --add safe.directory /tmp/openpilot


### PR DESCRIPTION
this will allow us to cache the ubuntu dependencies even if we change something in pypoetry, reducing build times

also will allow us to insert a "user" step, to run as non-root