### PR TITLE
scons: fix multithreaded builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -417,9 +417,6 @@ SConscript([
 
 SConscript(['third_party/SConscript'])
 
-SConscript(['common/kalman/SConscript'])
-SConscript(['common/transformations/SConscript'])
-
 SConscript(['selfdrive/boardd/SConscript'])
 SConscript(['selfdrive/controls/lib/lateral_mpc_lib/SConscript'])
 SConscript(['selfdrive/controls/lib/longitudinal_mpc_lib/SConscript'])

--- a/common/SConscript
+++ b/common/SConscript
@@ -32,5 +32,13 @@ if GetOption('extras'):
               ['tests/test_runner.cc', 'tests/test_util.cc', 'tests/test_swaglog.cc', 'tests/test_ratekeeper.cc'],
               LIBS=[_common, 'json11', 'zmq', 'pthread'])
 
-# Cython
-envCython.Program('params_pyx.so', 'params_pyx.pyx', LIBS=envCython['LIBS'] + [_common, 'zmq', 'json11'])
+# Cython bindings
+params_python = envCython.Program('params_pyx.so', 'params_pyx.pyx', LIBS=envCython['LIBS'] + [_common, 'zmq', 'json11'])
+
+SConscript(['kalman/SConscript'])
+SConscript(['transformations/SConscript'])
+
+Import('simple_kalman_python', 'transformations')
+common_python = [params_python, simple_kalman_python, transformations]
+
+Export('common_python')

--- a/common/SConscript
+++ b/common/SConscript
@@ -35,8 +35,10 @@ if GetOption('extras'):
 # Cython bindings
 params_python = envCython.Program('params_pyx.so', 'params_pyx.pyx', LIBS=envCython['LIBS'] + [_common, 'zmq', 'json11'])
 
-SConscript(['kalman/SConscript'])
-SConscript(['transformations/SConscript'])
+SConscript([
+  'kalman/SConscript',
+  'transformations/SConscript'  
+])
 
 Import('simple_kalman_python', 'transformations')
 common_python = [params_python, simple_kalman_python, transformations]

--- a/common/SConscript
+++ b/common/SConscript
@@ -40,7 +40,7 @@ SConscript([
   'transformations/SConscript'  
 ])
 
-Import('simple_kalman_python', 'transformations')
-common_python = [params_python, simple_kalman_python, transformations]
+Import('simple_kalman_python', 'transformations_python')
+common_python = [params_python, simple_kalman_python, transformations_python]
 
 Export('common_python')

--- a/common/kalman/SConscript
+++ b/common/kalman/SConscript
@@ -1,3 +1,5 @@
 Import('envCython')
 
-envCython.Program('simple_kalman_impl.so', 'simple_kalman_impl.pyx')
+simple_kalman_python = envCython.Program('simple_kalman_impl.so', 'simple_kalman_impl.pyx')
+
+Export('simple_kalman_python')

--- a/common/transformations/SConscript
+++ b/common/transformations/SConscript
@@ -1,6 +1,5 @@
 Import('env', 'envCython')
 
 transformations = env.Library('transformations', ['orientation.cc', 'coordinates.cc'])
-Export('transformations')
-
-envCython.Program('transformations.so', 'transformations.pyx')
+transformations_python = envCython.Program('transformations.so', 'transformations.pyx')
+Export('transformations', 'transformations_python')

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
@@ -1,4 +1,4 @@
-Import('env', 'envCython', 'arch', 'messaging_python')
+Import('env', 'envCython', 'arch', 'messaging_python', 'common_python')
 
 gen = "c_generated_code"
 
@@ -66,7 +66,7 @@ lenv.Clean(generated_files, Dir(gen))
 generated_long = lenv.Command(generated_files,
                               source_list,
                               f"cd {Dir('.').abspath} && python3 long_mpc.py")
-lenv.Depends(generated_long, messaging_python)
+lenv.Depends(generated_long, [messaging_python, common_python])
 
 lenv["CFLAGS"].append("-DACADOS_WITH_QPOASES")
 lenv["CXXFLAGS"].append("-DACADOS_WITH_QPOASES")


### PR DESCRIPTION
Error log:

```
clang++ -o selfdrive/locationd/models/live_kf.o -c -std=c++1z -DSWAGLOG="\"common/swaglog.h\"" -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -DSWAGLOG="\"common/swaglog.h\"" -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/mapbox-gl-native-qt/include -Ithird_party/qrcode -Ithird_party -Icereal -Iopendbc/can -Ithird_party/json11 selfdrive/locationd/models/live_kf.cc

cd /var/jenkins_home/workspace/openpilot_master/selfdrive/controls/lib/longitudinal_mpc_lib && python3 long_mpc.py

Traceback (most recent call last):

  File "/var/jenkins_home/workspace/openpilot_master/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py", line 10, in <module>

    from openpilot.selfdrive.car.interfaces import ACCEL_MIN

  File "/var/jenkins_home/workspace/openpilot_master/openpilot/selfdrive/car/interfaces.py", line 11, in <module>

    from openpilot.common.kalman.simple_kalman import KF1D, get_kalman_gain

  File "/var/jenkins_home/workspace/openpilot_master/openpilot/common/kalman/simple_kalman.py", line 1, in <module>

    from openpilot.common.kalman.simple_kalman_impl import KF1D as KF1D

ModuleNotFoundError: No module named 'openpilot.common.kalman.simple_kalman_impl'

```