### PR TITLE
car intrfaces: no test deadline

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -50,7 +50,7 @@ class TestCarInterfaces(unittest.TestCase):
   # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
   #  many generated examples to overrun when max_examples > ~20, don't use it
   @parameterized.expand([(car,) for car in sorted(all_known_cars())])
-  @settings(max_examples=MAX_EXAMPLES, deadline=500,
+  @settings(max_examples=MAX_EXAMPLES, deadline=None,
             phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())
   def test_car_interfaces(self, car_name, data):


### PR DESCRIPTION
The deadline relies on a testing environment with stable resources, but the jenkins machine (or GH CI) might be running other tasks which can slow down our test and trip this check. We don't expect certain inputs to cause higher times, especially from carcontroller, so ignore.

Max seen so far is about 1100 ms under load (usually < 100ms), a deadline that high would only catch issues when the machine is under heavy load