### PR TITLE
timezoned: set headers

### DIFF
--- a/system/timezoned.py
+++ b/system/timezoned.py
@@ -11,7 +11,9 @@ from timezonefinder import TimezoneFinder
 from openpilot.common.params import Params
 from openpilot.system.hardware import AGNOS
 from openpilot.system.swaglog import cloudlog
+from openpilot.system.version import get_version
 
+REQUEST_HEADERS = headers = {'User-Agent': "openpilot-" + get_version()}
 
 def set_timezone(valid_timezones, timezone):
   if timezone not in valid_timezones:
@@ -58,7 +60,7 @@ def main() -> NoReturn:
     if location is None:
       cloudlog.debug("Setting timezone based on IP lookup")
       try:
-        r = requests.get("https://ipapi.co/timezone", timeout=10)
+        r = requests.get("https://ipapi.co/timezone", headers=REQUEST_HEADERS, timeout=10)
         if r.status_code == 200:
           set_timezone(valid_timezones, r.text)
         else:

--- a/system/timezoned.py
+++ b/system/timezoned.py
@@ -13,7 +13,7 @@ from openpilot.system.hardware import AGNOS
 from openpilot.system.swaglog import cloudlog
 from openpilot.system.version import get_version
 
-REQUEST_HEADERS = headers = {'User-Agent': "openpilot-" + get_version()}
+REQUEST_HEADERS = {'User-Agent': "openpilot-" + get_version()}
 
 def set_timezone(valid_timezones, timezone):
   if timezone not in valid_timezones:

--- a/system/timezoned.py
+++ b/system/timezoned.py
@@ -15,6 +15,7 @@ from openpilot.system.version import get_version
 
 REQUEST_HEADERS = {'User-Agent': "openpilot-" + get_version()}
 
+
 def set_timezone(valid_timezones, timezone):
   if timezone not in valid_timezones:
     cloudlog.error(f"Timezone not supported {timezone}")

--- a/system/timezoned.py
+++ b/system/timezoned.py
@@ -20,7 +20,7 @@ def set_timezone(valid_timezones, timezone):
     cloudlog.error(f"Timezone not supported {timezone}")
     return
 
-  cloudlog.debug(f"Setting timezone to {timezone}")
+  cloudlog.info(f"Setting timezone to {timezone}")
   try:
     if AGNOS:
       tzpath = os.path.join("/usr/share/zoneinfo/", timezone)


### PR DESCRIPTION
Issue: for new devices, if API responds with 429 / Too Many Requests, timezoned waits an hour to retry, leaving all routes until then with incorrect local times (it uses the UTC time).

Found 3 cases of time jumping backward just looking at the last 9 dongles to first fingerprint.

User-Agent matters to the timezone API. This is running on a prime device over LTE:


https://github.com/commaai/openpilot/assets/25857203/ac9509de-125b-4edf-82ed-584d04d09f9e