### PR TITLE
MapPanel: provide QObject::connect context

### DIFF
--- a/selfdrive/ui/qt/maps/map_panel.cc
+++ b/selfdrive/ui/qt/maps/map_panel.cc
@@ -14,21 +14,21 @@ MapPanel::MapPanel(const QMapboxGLSettings &mapboxSettings, QWidget *parent) : Q
 
   auto map = new MapWindow(mapboxSettings);
   QObject::connect(uiState(), &UIState::offroadTransition, map, &MapWindow::offroadTransition);
-  QObject::connect(device(), &Device::interactiveTimeout, [=]() {
+  QObject::connect(device(), &Device::interactiveTimeout, this, [=]() {
     content_stack->setCurrentIndex(0);
   });
-  QObject::connect(map, &MapWindow::requestVisible, [=](bool visible) {
+  QObject::connect(map, &MapWindow::requestVisible, this, [=](bool visible) {
     // when we show the map for a new route, signal HomeWindow to hide the sidebar
     if (visible) { emit mapPanelRequested(); }
     setVisible(visible);
   });
-  QObject::connect(map, &MapWindow::requestSettings, [=](bool settings) {
+  QObject::connect(map, &MapWindow::requestSettings, this, [=](bool settings) {
     content_stack->setCurrentIndex(settings ? 1 : 0);
   });
   content_stack->addWidget(map);
 
   auto settings = new MapSettings(true, parent);
-  QObject::connect(settings, &MapSettings::closeSettings, [=]() {
+  QObject::connect(settings, &MapSettings::closeSettings, this, [=]() {
     content_stack->setCurrentIndex(0);
   });
   content_stack->addWidget(settings);


### PR DESCRIPTION
Provide `this` (MapPanel) as context for connections

https://doc.qt.io/qt-5/qobject.html#connect-5
> The connection will automatically disconnect if the sender or the context is destroyed. However, you should take care that any objects used within the functor are still alive when the signal is emitted.

Fixes crash when signals are emitted after MapPanel has been deleted

Closes #29728