### PR TITLE
HKG: Add fingerprint for US Kia Sorento Hybrid 2023

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1930,6 +1930,7 @@ FW_VERSIONS = {
   CAR.KIA_SORENTO_HEV_4TH_GEN: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00MQ4HMFC  AT KOR LHD 1.00 1.12 99210-P2000 230331',
+      b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.11 99210-P2000 211217',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00MQhe SCC FHCUP      1.00 1.07 99110-P4000         ',


### PR DESCRIPTION
Added US specific fwdCamera ECU fingerprint for the Kia Sorento Hybrid 2023

Dongle ID: `94bfe1d4acdfb5c0`