### PR TITLE
Tools: add auto fingerprinting tool

### DIFF
--- a/selfdrive/debug/auto_fingerprint.py
+++ b/selfdrive/debug/auto_fingerprint.py
@@ -38,8 +38,6 @@ def format_fw_versions(brand, fw_versions):
   return ret
 
 def write_fw_versions(brand, fw_versions):
-  new_fw_versions = format_fw_versions(brand, ALL_FW_VERSIONS[brand])
-  
   filename = f"selfdrive/car/{brand}/values.py"
   with open(filename, "r") as f:
     values_py = f.read()
@@ -53,7 +51,7 @@ def write_fw_versions(brand, fw_versions):
     end_str = "}\n}\n"
     end = values_py.index(end_str)
 
-  new_values_py = values_py[0:start] + new_fw_versions + "\n" + values_py[end+len(end_str):]
+  new_values_py = values_py[0:start] + format_fw_versions(brand, fw_versions) + "\n" + values_py[end+len(end_str):]
   
   with open(filename, "w") as f:
     f.write(new_values_py)
@@ -113,4 +111,4 @@ if __name__ == "__main__":
         fw_versions.add(fw.fwVersion)
         ALL_FW_VERSIONS[brand][platform][key] = list(fw_versions)
 
-  write_fw_versions(brand, fw_versions)
+  write_fw_versions(brand, ALL_FW_VERSIONS[brand])

--- a/selfdrive/debug/auto_fingerprint.py
+++ b/selfdrive/debug/auto_fingerprint.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
-import re
 from cereal import car
-import codecs
 
-from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, replay_process
 from openpilot.tools.lib.logreader import MultiLogIterator
 from openpilot.tools.lib.route import Route
-from pyvin import VIN
-from selfdrive.car.fw_versions import build_fw_dict, match_fw_to_car
+from selfdrive.car.fw_versions import match_fw_to_car
 from selfdrive.car.interfaces import get_interface_attr
 
 
@@ -75,12 +71,6 @@ if __name__ == "__main__":
       carVin = msg.carParams.carVin
       break
   
-  if carVin is not None and carVin != '00000000000000000':
-    vehicle = VIN(carVin)
-    print("VIN: ", carVin, vehicle.Make, vehicle.Model, vehicle.ModelYear)
-  else:
-    print("No VIN found...")
-
   if args.platform is None: # attempt to auto-determine platform with other fuzzy fingerprints
     _, possible_platforms = match_fw_to_car(carFw)
 

--- a/selfdrive/debug/auto_fingerprint.py
+++ b/selfdrive/debug/auto_fingerprint.py
@@ -25,7 +25,7 @@ def format_fw_versions(brand, fw_versions):
     for key in fw_versions[platform]:
         (ecu, addr, subAddr) = key
         ret += f"    (Ecu.{ECU_LOOKUP[ecu]}, {hex(addr)}, {None if subAddr == 0 else subAddr}): [\n"
-        for version in fw_versions[platform][key]:
+        for version in sorted(fw_versions[platform][key]):
           ret += f"      {version},\n"
         ret += "    ],\n"
     ret += "  },\n"

--- a/selfdrive/debug/auto_fingerprint.py
+++ b/selfdrive/debug/auto_fingerprint.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from cereal import car
+import codecs
+
+from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, replay_process
+from openpilot.tools.lib.logreader import MultiLogIterator
+from openpilot.tools.lib.route import Route
+from pyvin import VIN
+from selfdrive.car.fw_versions import build_fw_dict, match_fw_to_car
+from selfdrive.car.interfaces import get_interface_attr
+
+
+ALL_FW_VERSIONS = get_interface_attr("FW_VERSIONS")
+ALL_CARS = get_interface_attr("CAR")
+
+PYTHON_CAR_NAME_TO_PLATFORM = {brand: {m: v for v, m in vars(ALL_CARS[brand]).items() if not (v.startswith('_')  or callable(m))} for brand in ALL_CARS}
+ECU_LOOKUP = {m: v for v, m in vars(car.CarParams.Ecu).items() if not (v.startswith('_')  or callable(m) or v.startswith("schema"))}
+REVERSE_ECU_LOOKUP = {v: k for k, v in ECU_LOOKUP.items()}
+
+def format_fw_versions(brand, fw_versions):
+  ret = ""
+
+  ret += "FW_VERSIONS = {\n"
+  for platform in fw_versions:
+    ret += f"  CAR.{PYTHON_CAR_NAME_TO_PLATFORM[brand][platform]}: {{\n"
+    for key in fw_versions[platform]:
+        (ecu, addr, subAddr) = key
+        ret += f"    (Ecu.{ECU_LOOKUP[ecu]}, {hex(addr)}, {None if subAddr == 0 else subAddr}): [\n"
+        for version in fw_versions[platform][key]:
+          ret += f"      {version},\n"
+        ret += "    ],\n"
+    ret += "  },\n"
+  ret += "}"
+
+  return ret
+
+def write_fw_versions(brand, fw_versions):
+  new_fw_versions = format_fw_versions(brand, ALL_FW_VERSIONS[brand])
+  
+  filename = f"selfdrive/car/{brand}/values.py"
+  with open(filename, "r") as f:
+    values_py = f.read()
+
+  start = values_py.index("FW_VERSIONS = {")
+
+  end_str = "},\n}\n"
+  try:
+    end = values_py.index(end_str)
+  except:
+    end_str = "}\n}\n"
+    end = values_py.index(end_str)
+
+  new_values_py = values_py[0:start] + new_fw_versions + "\n" + values_py[end+len(end_str):]
+  
+  with open(filename, "w") as f:
+    f.write(new_values_py)
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Auto fingerprint from a route")
+  parser.add_argument("route", help="The route name to use")
+  parser.add_argument("platform", help="The platform, or leave empty to auto-determine using fuzzy", default=None, nargs='?')
+  args = parser.parse_args()
+
+  route = Route(args.route)
+  lr = MultiLogIterator(route.qlog_paths())
+
+  carFw = None
+  carVin = None
+
+  for msg in lr:
+    if msg.which() == "carParams":
+      carFw = msg.carParams.carFw
+      carVin = msg.carParams.carVin
+      break
+  
+  if carVin is not None and carVin != '00000000000000000':
+    vehicle = VIN(carVin)
+    print("VIN: ", carVin, vehicle.Make, vehicle.Model, vehicle.ModelYear)
+  else:
+    print("No VIN found...")
+
+  if args.platform is None: # attempt to auto-determine platform with other fuzzy fingerprints
+    _, possible_platforms = match_fw_to_car(carFw)
+
+    if len(possible_platforms) != 1:
+      raise Exception(f"Unable to auto-determine platform, possible platforms: {possible_platforms}")
+    
+    platform = list(possible_platforms)[0]
+  else:
+    platform = args.platform
+
+  print("Adding fingerprint for: ", platform)
+
+  all_cars_by_brand = get_interface_attr("CAR_INFO")
+  brand = None
+  for b in all_cars_by_brand:
+    if platform in all_cars_by_brand[b]:
+      brand = b
+  
+  for fw in carFw:
+    if fw.brand == brand:
+      ecu = REVERSE_ECU_LOOKUP[fw.ecu]
+      addr = fw.address
+      subAddr = None if fw.subAddress == 0 else fw.subAddress
+      key = (ecu, addr, subAddr)
+
+      if key in ALL_FW_VERSIONS[brand][platform]:
+        fw_versions = set(ALL_FW_VERSIONS[brand][platform][key])
+        fw_versions.add(fw.fwVersion)
+        ALL_FW_VERSIONS[brand][platform][key] = list(fw_versions)
+
+  write_fw_versions(brand, fw_versions)


### PR DESCRIPTION
enter a route and platform (or no platform if the platform can be determined automatically with fuzzy fingerprinting), and it will auto place firmware versions to the correct spot

TODO:

- [ ] preserve comments next to existing fw versions?
- [ ] run the formatting script on existing fingerprints to normalize them

my thought was this could be run in a CI job, if someone requested it in an issue or PR, and it could automatically create a PR

```!fingerprint '8ae405c83e79aec8|2023-09-03--17-00-45' 'SUBARU IMPREZA SPORT 2020'```