### PR TITLE
Soundd: Give each alert a volume

### DIFF
--- a/selfdrive/ui/soundd/sound.cc
+++ b/selfdrive/ui/soundd/sound.cc
@@ -15,12 +15,13 @@
 Sound::Sound(QObject *parent) : sm({"controlsState", "microphone"}) {
   qInfo() << "default audio device: " << QAudioDeviceInfo::defaultOutputDevice().deviceName();
 
-  for (auto &[alert, fn, loops] : sound_list) {
+  for (auto &[alert, fn, loops, volume] : sound_list) {
     QSoundEffect *s = new QSoundEffect(this);
     QObject::connect(s, &QSoundEffect::statusChanged, [=]() {
       assert(s->status() != QSoundEffect::Error);
     });
     s->setSource(QUrl::fromLocalFile("../../assets/sounds/" + fn));
+    s->setVolume(volume);
     sounds[alert] = {s, loops};
   }
 

--- a/selfdrive/ui/soundd/sound.h
+++ b/selfdrive/ui/soundd/sound.h
@@ -9,18 +9,21 @@
 #include "system/hardware/hw.h"
 #include "selfdrive/ui/ui.h"
 
-const std::tuple<AudibleAlert, QString, int> sound_list[] = {
+const float MAX_VOLUME = 1.0;
+
+
+const std::tuple<AudibleAlert, QString, int, float> sound_list[] = {
   // AudibleAlert, file name, loop count
-  {AudibleAlert::ENGAGE, "engage.wav", 0},
-  {AudibleAlert::DISENGAGE, "disengage.wav", 0},
-  {AudibleAlert::REFUSE, "refuse.wav", 0},
+  {AudibleAlert::ENGAGE, "engage.wav", 0, MAX_VOLUME},
+  {AudibleAlert::DISENGAGE, "disengage.wav", 0, MAX_VOLUME},
+  {AudibleAlert::REFUSE, "refuse.wav", 0, MAX_VOLUME},
 
-  {AudibleAlert::PROMPT, "prompt.wav", 0},
-  {AudibleAlert::PROMPT_REPEAT, "prompt.wav", QSoundEffect::Infinite},
-  {AudibleAlert::PROMPT_DISTRACTED, "prompt_distracted.wav", QSoundEffect::Infinite},
+  {AudibleAlert::PROMPT, "prompt.wav", 0, MAX_VOLUME},
+  {AudibleAlert::PROMPT_REPEAT, "prompt.wav", QSoundEffect::Infinite, MAX_VOLUME},
+  {AudibleAlert::PROMPT_DISTRACTED, "prompt_distracted.wav", QSoundEffect::Infinite, MAX_VOLUME},
 
-  {AudibleAlert::WARNING_SOFT, "warning_soft.wav", QSoundEffect::Infinite},
-  {AudibleAlert::WARNING_IMMEDIATE, "warning_immediate.wav", QSoundEffect::Infinite},
+  {AudibleAlert::WARNING_SOFT, "warning_soft.wav", QSoundEffect::Infinite, MAX_VOLUME},
+  {AudibleAlert::WARNING_IMMEDIATE, "warning_immediate.wav", QSoundEffect::Infinite, MAX_VOLUME},
 };
 
 class Sound : public QObject {

--- a/selfdrive/ui/soundd/sound.h
+++ b/selfdrive/ui/soundd/sound.h
@@ -9,8 +9,8 @@
 #include "system/hardware/hw.h"
 #include "selfdrive/ui/ui.h"
 
-const float MAX_VOLUME = 1.0;
 
+const float MAX_VOLUME = 1.0;
 
 const std::tuple<AudibleAlert, QString, int, float> sound_list[] = {
   // AudibleAlert, file name, loop count

--- a/selfdrive/ui/tests/test_sound.cc
+++ b/selfdrive/ui/tests/test_sound.cc
@@ -31,7 +31,7 @@ void controls_thread(int loop_cnt) {
 
   const int DT_CTRL = 10;  // ms
   for (int i = 0; i < loop_cnt; ++i) {
-    for (auto &[alert, fn, loops] : sound_list) {
+    for (auto &[alert, fn, loops, volume] : sound_list) {
       printf("testing %s\n", qPrintable(fn));
       for (int j = 0; j < 1000 / DT_CTRL; ++j) {
         MessageBuilder msg;


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
