### PR TITLE
cabana: support choosing color for signal

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -31,7 +31,7 @@ cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "asset
 
 cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/socketcanstream.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
                                                'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
-                                               'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',
+                                               'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc', 'common/colordlg.cc',
                                                'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'util.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -20,6 +20,7 @@
 #include <QWindow>
 
 #include "tools/cabana/chart/chartswidget.h"
+#include "tools/cabana/common/colordlg.h"
 
 // ChartAxisElement's padding is 4 (https://codebrowser.dev/qt5/qtcharts/src/charts/axis/chartaxiselement_p.h.html)
 const int AXIS_X_TOP_MARGIN = 4;
@@ -79,6 +80,7 @@ void ChartView::createToolButtons() {
   }
   menu->addSeparator();
   menu->addAction(tr("Manage Signals"), this, &ChartView::manageSignals);
+  menu->addAction(tr("Choose Colors"), this, &ChartView::chooseColorForSignals);
   split_chart_act = menu->addAction(tr("Split Chart"), [this]() { charts_widget->splitChart(this); });
 
   QToolButton *manage_btn = new ToolButton("list", "");
@@ -175,6 +177,14 @@ void ChartView::manageSignals() {
       return std::none_of(items.cbegin(), items.cend(), [&](auto &it) { return s.msg_id == it->msg_id && s.sig == it->sig; });
     });
   }
+}
+
+void ChartView::chooseColorForSignals() {
+  SignalColorDlg dlg(this);
+  for (auto &s : sigs) {
+    dlg.addSignal(s.msg_id, s.sig);
+  }
+  dlg.exec();
 }
 
 void ChartView::resizeEvent(QResizeEvent *event) {

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -57,6 +57,7 @@ signals:
 private slots:
   void signalUpdated(const cabana::Signal *sig);
   void manageSignals();
+  void chooseColorForSignals();
   void handleMarkerClicked();
   void msgUpdated(MessageId id);
   void msgRemoved(MessageId id) { removeIf([=](auto &s) { return s.msg_id.address == id.address && !dbc()->msg(id); }); }

--- a/tools/cabana/common/colordlg.cc
+++ b/tools/cabana/common/colordlg.cc
@@ -1,0 +1,62 @@
+#include "tools/cabana/common/colordlg.h"
+
+#include <QDebug>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QVBoxLayout>
+
+#include "tools/cabana/dbc/dbcmanager.h"
+
+SignalColorDlg::SignalColorDlg(QWidget *parent) : QDialog(parent) {
+  setWindowTitle(tr("Choose color for signal"));
+  QHBoxLayout *hl = new QHBoxLayout;
+  hl->addWidget(signal_list = new QListWidget(this));
+  signal_list->setSelectionMode(QAbstractItemView::SingleSelection);
+
+  color_picker = new QColorDialog(this);
+  color_picker->setOption(QColorDialog::NoButtons);
+  color_picker->setWindowFlags(Qt::Widget);
+  hl->addWidget(color_picker);
+
+  auto button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->addLayout(hl);
+  main_layout->addWidget(button_box);
+
+  QObject::connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  QObject::connect(button_box, &QDialogButtonBox::accepted, [this]() {
+    for (int i = 0; i < signal_list->count(); ++i) {
+      auto item = static_cast<ListItem *>(signal_list->item(i));
+      dbc()->updateSignalColor(item->msg_id, item->sig->name, item->color);
+    }
+    accept();
+  });
+
+  QObject::connect(color_picker, &QColorDialog::currentColorChanged, [this](const QColor &color) {
+    if (auto current = static_cast<ListItem *>(signal_list->currentItem())) {
+      current->color = color;
+      QString text = QString("<span style=\"color:%0;\">■ </span> %1").arg(current->color.name(), current->sig->name);
+      static_cast<QLabel *>(signal_list->itemWidget(current))->setText(text);
+    }
+  });
+
+  QObject::connect(signal_list, &QListWidget::currentItemChanged, [this](QListWidgetItem *current, QListWidgetItem *) {
+    color_picker->setCurrentColor(static_cast<ListItem *>(current)->color);
+  });
+}
+
+void SignalColorDlg::addSignal(const MessageId &msg_id, const cabana::Signal *sig) {
+  QString text = QString("<span style=\"color:%0;\">■ </span> %1").arg(sig->color.name(), sig->name);
+  QLabel *label = new QLabel(text);
+  label->setContentsMargins(5, 0, 5, 0);
+
+  auto new_item = new ListItem(msg_id, sig, signal_list);
+  new_item->setSizeHint(label->sizeHint());
+
+  signal_list->setItemWidget(new_item, label);
+  if (!signal_list->currentItem()) {
+    signal_list->setCurrentItem(new_item);
+  }
+}

--- a/tools/cabana/common/colordlg.cc
+++ b/tools/cabana/common/colordlg.cc
@@ -2,21 +2,13 @@
 
 #include <QDialogButtonBox>
 #include <QHBoxLayout>
-#include <QLabel>
 #include <QVBoxLayout>
-
-#include "tools/cabana/dbc/dbcmanager.h"
-
-static QString item_text(const QString &name, const QColor &color) {
-  return QString("<span style=\"color:%0;\">■ </span> %1").arg(color.name(), name);
-}
 
 SignalColorDlg::SignalColorDlg(QWidget *parent) : QDialog(parent) {
   setWindowTitle(tr("Choose color for signal"));
   QHBoxLayout *hl = new QHBoxLayout;
-  hl->addWidget(signal_list = new QListWidget(this));
-  signal_list->setSelectionMode(QAbstractItemView::SingleSelection);
-
+  hl->addWidget(list = new QListWidget(this));
+  list->setContentsMargins(9, 9, 9, 9);
   hl->addWidget(color_picker = new QColorDialog(this));
   color_picker->setOption(QColorDialog::NoButtons);
   color_picker->setWindowFlags(Qt::Widget);
@@ -26,33 +18,25 @@ SignalColorDlg::SignalColorDlg(QWidget *parent) : QDialog(parent) {
   main_layout->addLayout(hl);
   main_layout->addWidget(button_box);
 
-  QObject::connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  QObject::connect(button_box, &QDialogButtonBox::accepted, [this]() {
-    for (int i = 0; i < signal_list->count(); ++i) {
-      auto item = static_cast<ListItem *>(signal_list->item(i));
-      dbc()->updateSignalColor(item->msg_id, item->sig->name, item->color);
+  connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(button_box, &QDialogButtonBox::accepted, [this]() {
+    for (int i = 0; i < list->count(); ++i) {
+      auto item = static_cast<Item *>(list->item(i));
+      dbc()->updateSignalColor(item->msg_id, item->text(), item->color);
     }
     accept();
   });
-  QObject::connect(color_picker, &QColorDialog::currentColorChanged, [this](const QColor &color) {
-    if (auto current = static_cast<ListItem *>(signal_list->currentItem())) {
-      current->color = color;
-      static_cast<QLabel *>(signal_list->itemWidget(current))->setText(item_text(current->sig->name, current->color));
+  connect(color_picker, &QColorDialog::currentColorChanged, [this](const QColor &color) {
+    if (auto current = static_cast<Item *>(list->currentItem())) {
+      current->setColor(color);
     }
   });
-  QObject::connect(signal_list, &QListWidget::currentItemChanged, [this](QListWidgetItem *current, QListWidgetItem *) {
-    color_picker->setCurrentColor(static_cast<ListItem *>(current)->color);
+  connect(list, &QListWidget::currentItemChanged, [this](QListWidgetItem *current, QListWidgetItem *) {
+    color_picker->setCurrentColor(static_cast<Item *>(current)->color);
   });
 }
 
 void SignalColorDlg::addSignal(const MessageId &msg_id, const cabana::Signal *sig) {
-  QLabel *label = new QLabel(item_text(sig->name, sig->color));
-  label->setContentsMargins(5, 0, 5, 0);
-
-  auto new_item = new ListItem(msg_id, sig, signal_list);
-  new_item->setSizeHint(label->sizeHint());
-  signal_list->setItemWidget(new_item, label);
-  if (!signal_list->currentItem()) {
-    signal_list->setCurrentItem(new_item);
-  }
+  auto new_item = new Item(msg_id, sig, list);
+  if (!list->currentItem()) list->setCurrentItem(new_item);
 }

--- a/tools/cabana/common/colordlg.cc
+++ b/tools/cabana/common/colordlg.cc
@@ -8,9 +8,8 @@ SignalColorDlg::SignalColorDlg(QWidget *parent) : QDialog(parent) {
   setWindowTitle(tr("Choose color for signal"));
   QHBoxLayout *hl = new QHBoxLayout;
   hl->addWidget(list = new QListWidget(this));
-  list->setContentsMargins(9, 9, 9, 9);
   hl->addWidget(color_picker = new QColorDialog(this));
-  color_picker->setOption(QColorDialog::NoButtons);
+  color_picker->setOptions(QColorDialog::NoButtons | QColorDialog::DontUseNativeDialog);
   color_picker->setWindowFlags(Qt::Widget);
 
   auto button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);

--- a/tools/cabana/common/colordlg.h
+++ b/tools/cabana/common/colordlg.h
@@ -2,9 +2,8 @@
 
 #include <QColorDialog>
 #include <QListWidget>
-#include <QListWidgetItem>
 
-#include "tools/cabana/dbc/dbc.h"
+#include "tools/cabana/dbc/dbcmanager.h"
 
 class SignalColorDlg : public QDialog {
 public:
@@ -12,14 +11,19 @@ public:
   void addSignal(const MessageId &msg_id, const cabana::Signal *sig);
 
 private:
-  struct ListItem : public QListWidgetItem {
-    ListItem(const MessageId &id, const cabana::Signal *s, QListWidget *parent)
-        : msg_id(id), sig(s), color(s->color), QListWidgetItem(parent) {}
+  struct Item : public QListWidgetItem {
+    Item(const MessageId &id, const cabana::Signal *s, QListWidget *parent)
+        : msg_id(id), QListWidgetItem(s->name, parent) { setColor(s->color); }
+    void setColor(const QColor &c) {
+      color = c;
+      QPixmap pm(12, 12);
+      pm.fill(color);
+      setIcon(pm);
+    }
     MessageId msg_id;
-    const cabana::Signal *sig;
     QColor color;
   };
 
-  QListWidget *signal_list;
+  QListWidget *list;
   QColorDialog *color_picker;
 };

--- a/tools/cabana/common/colordlg.h
+++ b/tools/cabana/common/colordlg.h
@@ -1,15 +1,12 @@
 #pragma once
 
 #include <QColorDialog>
-#include <QDialog>
 #include <QListWidget>
 #include <QListWidgetItem>
 
 #include "tools/cabana/dbc/dbc.h"
 
 class SignalColorDlg : public QDialog {
-  Q_OBJECT
-
 public:
   explicit SignalColorDlg(QWidget *parent);
   void addSignal(const MessageId &msg_id, const cabana::Signal *sig);

--- a/tools/cabana/common/colordlg.h
+++ b/tools/cabana/common/colordlg.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QColorDialog>
+#include <QDialog>
+#include <QListWidget>
+#include <QListWidgetItem>
+
+#include "tools/cabana/dbc/dbc.h"
+
+class SignalColorDlg : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit SignalColorDlg(QWidget *parent);
+  void addSignal(const MessageId &msg_id, const cabana::Signal *sig);
+
+private:
+  struct ListItem : public QListWidgetItem {
+    ListItem(const MessageId &id, const cabana::Signal *s, QListWidget *parent)
+        : msg_id(id), sig(s), color(s->color), QListWidgetItem(parent) {}
+    MessageId msg_id;
+    const cabana::Signal *sig;
+    QColor color;
+  };
+
+  QListWidget *signal_list;
+  QColorDialog *color_picker;
+};

--- a/tools/cabana/dbc/dbcmanager.cc
+++ b/tools/cabana/dbc/dbcmanager.cc
@@ -72,6 +72,15 @@ void DBCManager::updateSignal(const MessageId &id, const QString &sig_name, cons
   }
 }
 
+void DBCManager::updateSignalColor(const MessageId &id, const QString &sig_name, const QColor &color) {
+   if (auto m = msg(id)) {
+    if (auto s = m->sig(sig_name)) {
+      s->color = color;
+      emit signalUpdated(s);
+    }
+   }
+}
+
 void DBCManager::removeSignal(const MessageId &id, const QString &sig_name) {
   if (auto m = msg(id)) {
     if (auto s = m->sig(sig_name)) {

--- a/tools/cabana/dbc/dbcmanager.h
+++ b/tools/cabana/dbc/dbcmanager.h
@@ -26,6 +26,7 @@ public:
 
   void addSignal(const MessageId &id, const cabana::Signal &sig);
   void updateSignal(const MessageId &id, const QString &sig_name, const cabana::Signal &sig);
+  void updateSignalColor(const MessageId &id, const QString &sig_name, const QColor &color);
   void removeSignal(const MessageId &id, const QString &sig_name);
 
   void updateMsg(const MessageId &id, const QString &name, uint32_t size, const QString &comment);

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -458,10 +458,8 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   sparkline_range_slider->setValue(settings.sparkline_range);
   sparkline_range_slider->setToolTip(tr("Sparkline time range"));
 
-  auto choose_color_btn = new ToolButton("palette", tr("Choose color for signal"));
+  hl->addWidget(choose_color_btn = new ToolButton("palette", tr("Choose color for signal")));
   choose_color_btn->setIconSize({12, 12});
-  hl->addWidget(choose_color_btn);
-
   auto collapse_btn = new ToolButton("dash-square", tr("Collapse All"));
   collapse_btn->setIconSize({12, 12});
   hl->addWidget(collapse_btn);
@@ -595,6 +593,7 @@ void SignalView::signalHovered(const cabana::Signal *sig) {
 void SignalView::updateToolBar() {
   signal_count_lb->setText(tr("Signals: %1").arg(model->rowCount()));
   sparkline_label->setText(utils::formatSeconds(settings.sparkline_range));
+  choose_color_btn->setEnabled(model->rowCount() > 0);
 }
 
 void SignalView::setSparklineRange(int value) {

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -15,6 +15,7 @@
 #include <QVBoxLayout>
 
 #include "tools/cabana/commands.h"
+#include "tools/cabana/common/colordlg.h"
 
 // SignalModel
 
@@ -457,6 +458,10 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
   sparkline_range_slider->setValue(settings.sparkline_range);
   sparkline_range_slider->setToolTip(tr("Sparkline time range"));
 
+  auto choose_color_btn = new ToolButton("palette", tr("Choose color for signal"));
+  choose_color_btn->setIconSize({12, 12});
+  hl->addWidget(choose_color_btn);
+
   auto collapse_btn = new ToolButton("dash-square", tr("Collapse All"));
   collapse_btn->setIconSize({12, 12});
   hl->addWidget(collapse_btn);
@@ -487,6 +492,7 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
 
   QObject::connect(filter_edit, &QLineEdit::textEdited, model, &SignalModel::setFilter);
   QObject::connect(sparkline_range_slider, &QSlider::valueChanged, this, &SignalView::setSparklineRange);
+  QObject::connect(choose_color_btn, &QPushButton::clicked, this, &SignalView::chooseColorForSignals);
   QObject::connect(collapse_btn, &QPushButton::clicked, tree, &QTreeView::collapseAll);
   QObject::connect(tree, &QAbstractItemView::clicked, this, &SignalView::rowClicked);
   QObject::connect(tree, &QTreeView::viewportEntered, [this]() { emit highlight(nullptr); });
@@ -653,6 +659,14 @@ void SignalView::updateState(const QHash<MessageId, CanData> *msgs) {
   for (int i = 0; i < model->rowCount(); ++i) {
     emit model->dataChanged(model->index(i, 1), model->index(i, 1), {Qt::DisplayRole});
   }
+}
+
+void SignalView::chooseColorForSignals() {
+  SignalColorDlg dlg(this);
+  for (auto item : model->root->children) {
+    dlg.addSignal(model->msg_id, item->sig);
+  }
+  dlg.exec();
 }
 
 void SignalView::resizeEvent(QResizeEvent* event) {

--- a/tools/cabana/signalview.h
+++ b/tools/cabana/signalview.h
@@ -143,6 +143,7 @@ private:
   QLineEdit *filter_edit;
   ChartsWidget *charts;
   QLabel *signal_count_lb;
+  ToolButton *choose_color_btn;
   SignalItemDelegate *delegate;
   friend SignalItemDelegate;
 };

--- a/tools/cabana/signalview.h
+++ b/tools/cabana/signalview.h
@@ -117,6 +117,7 @@ private:
   void setSparklineRange(int value);
   void handleSignalAdded(MessageId id, const cabana::Signal *sig);
   void handleSignalUpdated(const cabana::Signal *sig);
+  void chooseColorForSignals();
   void updateState(const QHash<MessageId, CanData> *msgs = nullptr);
 
   struct TreeView : public QTreeView {


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6860946

1. choose color dialog:
![Screenshot 2023-09-07 19:32:41](https://github.com/commaai/openpilot/assets/27770/196e1688-51c8-48c3-9c39-6ae00abde32d)

2. chat view. click `Choose colors` to choose color for signals in chart
![2023-09-07_19-35](https://github.com/commaai/openpilot/assets/27770/7333b439-86a8-4c04-9d63-4d0668b05f22)
3.signal view. click palette button to choose color for signals in message:
![2023-09-07_19-34](https://github.com/commaai/openpilot/assets/27770/df3d34d2-06a7-4cb1-b96a-4396ad45db2a)
