### PR TITLE
cabana: speed up exit

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -27,6 +27,11 @@ AbstractStream::AbstractStream(QObject *parent) : QObject(parent) {
     emit StreamNotifier::instance()->changingStream();
     delete can;
     can = this;
+    // TODO: add method stop() to class AbstractStream
+    QObject::connect(qApp, &QApplication::aboutToQuit, can, []() {
+      qDebug() << "stopping stream thread";
+      can->pause(true);
+    });
     emit StreamNotifier::instance()->streamStarted();
   });
 }

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -159,13 +159,13 @@ Slider::Slider(QWidget *parent) : thumbnail_label(parent), QSlider(Qt::Horizonta
       qlog_future = std::make_unique<QFuture<void>>(QtConcurrent::run(this, &Slider::parseQLog));
     }
   });
-}
-
-Slider::~Slider() {
-  abort_parse_qlog = true;
-  if (qlog_future) {
-    qlog_future->waitForFinished();
-  }
+  QObject::connect(qApp, &QApplication::aboutToQuit, [this]() {
+    abort_parse_qlog = true;
+    if (qlog_future && qlog_future->isRunning()) {
+      qDebug() << "stopping thumbnail thread";
+      qlog_future->waitForFinished();
+    }
+  });
 }
 
 AlertInfo Slider::alertInfo(double seconds) {

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -37,7 +37,6 @@ class Slider : public QSlider {
 
 public:
   Slider(QWidget *parent);
-  ~Slider();
   double currentSecond() const { return value() / factor; }
   void setCurrentSecond(double sec) { setValue(sec * factor); }
   void setTimeRange(double min, double max);


### PR DESCRIPTION
Stop stream, thumbnail thread before exiting so that the application can  quit the main event loop quickly
