### PR TITLE
sensorDataInvalid Alert: Check both conditions

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -378,7 +378,7 @@ class Controls:
       self.events.add(EventName.vehicleModelInvalid)
     if not self.sm['lateralPlan'].mpcSolutionValid:
       self.events.add(EventName.plannerError)
-    if not (self.sm['liveParameters'].sensorValid or self.sm['liveLocationKalman'].sensorsOK) and not NOSENSOR:
+    if not (self.sm['liveParameters'].sensorValid and self.sm['liveLocationKalman'].sensorsOK) and not NOSENSOR:
       if self.sm.frame > 5 / DT_CTRL:  # Give locationd some time to receive all the inputs
         self.events.add(EventName.sensorDataInvalid)
     if not self.sm['liveLocationKalman'].inputsOK and not NOSENSOR:


### PR DESCRIPTION
This check would have caught https://github.com/commaai/openpilot/issues/29812, ~2 secs before the vehicle invalid alert. This is conceptually the better way to catch such issues.
![image](https://github.com/commaai/openpilot/assets/1649262/0ac62241-e9ac-49ea-9124-769098af855a)

ToDo
- [ ] Check how many more counterfactual alerts
- [ ] TP/FP 