### PR TITLE
cabana: set the COMMA_CACHE environment variable

### DIFF
--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -8,10 +8,13 @@
 
 ReplayStream::ReplayStream(QObject *parent) : AbstractStream(parent) {
   unsetenv("ZMQ");
+  setenv("COMMA_CACHE", "/tmp/cabana_download_cache", 1);
+
   // TODO: Remove when OpenpilotPrefix supports ZMQ
 #ifndef __APPLE__
   op_prefix = std::make_unique<OpenpilotPrefix>();
 #endif
+
   QObject::connect(&settings, &Settings::changed, [this]() {
     if (replay) replay->setSegmentCacheLimit(settings.max_cached_minutes);
   });

--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -8,7 +8,7 @@
 
 ReplayStream::ReplayStream(QObject *parent) : AbstractStream(parent) {
   unsetenv("ZMQ");
-  setenv("COMMA_CACHE", "/tmp/cabana_download_cache", 1);
+  setenv("COMMA_CACHE", "/tmp/comma_download_cache", 1);
 
   // TODO: Remove when OpenpilotPrefix supports ZMQ
 #ifndef __APPLE__


### PR DESCRIPTION
related discussions : https://github.com/commaai/openpilot/pull/29818#issuecomment-1712196683

[update]
add function `setDownloadCachePath` to replay 