### PR TITLE
macOS: install gcc@13 to match panda requirements

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -49,7 +49,7 @@ brew "pyenv"
 brew "pyenv-virtualenv"
 brew "qt@5"
 brew "zeromq"
-brew "gcc@12"
+brew "gcc@13"
 cask "gcc-arm-embedded"
 brew "portaudio"
 EOS


### PR DESCRIPTION
Fixes https://github.com/commaai/openpilot/issues/29823 - Use gcc@13 as per https://github.com/commaai/panda/commit/a48678f625cbb5b58b804b9b0418e7fd186c52e6