### PR TITLE
replay: Include cstdarg from util

### DIFF
--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -4,6 +4,7 @@
 #include <curl/curl.h>
 #include <openssl/sha.h>
 
+#include <cstdarg>
 #include <cstring>
 #include <cassert>
 #include <cmath>


### PR DESCRIPTION
Fix compilation error "use of undeclared identifier" for functions va_start & va_end.

Not sure how this suddenly became an issue here (Arch Linux system, clang 16.0.6) and wasn't one previously or otherwise. I am guessing probably a toolchain update means that this is no longer being recursively included...?

In any case, I think "include what you need" supports including cstdarg for these.

Thanks!
