### PR TITLE
cabana: improve precision of timeline

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -25,7 +25,8 @@
 const int AXIS_X_TOP_MARGIN = 4;
 static inline bool xLessThan(const QPointF &p, float x) { return p.x() < x; }
 
-ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent) : charts_widget(parent), tip_label(this), QChartView(nullptr, parent) {
+ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent)
+    : charts_widget(parent), tip_label(this), QChartView(nullptr, parent) {
   series_type = (SeriesType)settings.chart_series_type;
   QChart *chart = new QChart();
   chart->setBackgroundVisible(false);
@@ -668,6 +669,7 @@ void ChartView::drawBackground(QPainter *painter, const QRectF &rect) {
 
 void ChartView::drawForeground(QPainter *painter, const QRectF &rect) {
   drawTimeline(painter);
+  drawSignalValue(painter);
   // draw track points
   painter->setPen(Qt::NoPen);
   qreal track_line_x = -1;
@@ -715,23 +717,24 @@ void ChartView::drawForeground(QPainter *painter, const QRectF &rect) {
 
 void ChartView::drawTimeline(QPainter *painter) {
   const auto plot_area = chart()->plotArea();
-  // draw line
+  // draw vertical time line
   qreal x = std::clamp(chart()->mapToPosition(QPointF{cur_sec, 0}).x(), plot_area.left(), plot_area.right());
   painter->setPen(QPen(chart()->titleBrush().color(), 2));
   painter->drawLine(QPointF{x, plot_area.top()}, QPointF{x, plot_area.bottom() + 1});
 
-  // draw current time
+  // draw current time under the axis-x
   QString time_str = QString::number(cur_sec, 'f', 2);
   QSize time_str_size = QFontMetrics(axis_x->labelsFont()).size(Qt::TextSingleLine, time_str) + QSize(8, 2);
-  QRect time_str_rect(QPoint(x - time_str_size.width() / 2, plot_area.bottom() + AXIS_X_TOP_MARGIN), time_str_size);
+  QRectF time_str_rect(QPointF(x - time_str_size.width() / 2.0, plot_area.bottom() + AXIS_X_TOP_MARGIN), time_str_size);
   QPainterPath path;
   path.addRoundedRect(time_str_rect, 3, 3);
   painter->fillPath(path, settings.theme == DARK_THEME ? Qt::darkGray : Qt::gray);
   painter->setPen(palette().color(QPalette::BrightText));
   painter->setFont(axis_x->labelsFont());
   painter->drawText(time_str_rect, Qt::AlignCenter, time_str);
+}
 
-  // draw signal value
+void ChartView::drawSignalValue(QPainter *painter) {
   auto item_group = qgraphicsitem_cast<QGraphicsItemGroup *>(chart()->legend()->childItems()[0]);
   assert(item_group != nullptr);
   auto legend_markers = item_group->childItems();

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -83,6 +83,7 @@ private:
   void drawForeground(QPainter *painter, const QRectF &rect) override;
   void drawBackground(QPainter *painter, const QRectF &rect) override;
   void drawDropIndicator(bool draw) { if (std::exchange(can_drop, draw) != can_drop) viewport()->update(); }
+  void drawSignalValue(QPainter *painter);
   void drawTimeline(QPainter *painter);
   std::tuple<double, double, int> getNiceAxisNumbers(qreal min, qreal max, int tick_count);
   qreal niceNumber(qreal x, bool ceiling);


### PR DESCRIPTION
Currently the vertical line and time text use different precision (QPoint vs QPointF). This results in the movement of the time string not being synchronized with the line  (always lagging behind the timeline.):

![2023-09-11_18-34](https://github.com/commaai/openpilot/assets/27770/03dcf638-726f-43e6-8957-673d1453d049)

before fix:

[Kazam_screencast_00087.webm](https://github.com/commaai/openpilot/assets/27770/a1e589e5-32b5-4597-9b48-c9330a9e16a2)

after fix:

[Kazam_screencast_00115.webm](https://github.com/commaai/openpilot/assets/27770/4f0c49e8-a64e-4bd2-a80a-1cad3a7bdf0c)

