### PR TITLE
cabana: display warning if failed to write settings

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -606,7 +606,13 @@ void MainWindow::closeEvent(QCloseEvent *event) {
     settings.video_splitter_state = video_splitter->saveState();
   }
   settings.message_header_state = messages_widget->saveHeaderState();
-  settings.save();
+
+  auto status = settings.save();
+  if (status == QSettings::AccessError) {
+    QString error = tr("Failed to write settings to [%1]: access denied").arg(QDir::currentPath() + "/settings");
+    qDebug() << error;
+    QMessageBox::warning(this, tr("Failed to write settings"), error);
+  }
   QWidget::closeEvent(event);
 }
 

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -609,7 +609,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
   auto status = settings.save();
   if (status == QSettings::AccessError) {
-    QString error = tr("Failed to write settings to [%1]: access denied").arg(QDir::currentPath() + "/settings");
+    QString error = tr("Failed to write settings to [%1]: access denied").arg(Settings::filePath());
     qDebug() << error;
     QMessageBox::warning(this, tr("Failed to write settings"), error);
   }

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -6,7 +6,6 @@
 #include <QFileDialog>
 #include <QFormLayout>
 #include <QPushButton>
-#include <QSettings>
 #include <QStandardPaths>
 
 #include "tools/cabana/util.h"
@@ -35,6 +34,8 @@ void Settings::save() {
   s.setValue("log_path", log_path);
   s.setValue("drag_direction", drag_direction);
   s.setValue("suppress_defined_signals", suppress_defined_signals);
+  s.sync();
+  return s.status();
 }
 
 void Settings::load() {

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -12,7 +12,7 @@
 
 Settings settings;
 
-void Settings::save() {
+QSettings::Status Settings::save() {
   QSettings s(filePath(), QSettings::IniFormat);
   s.setValue("fps", fps);
   s.setValue("max_cached_minutes", max_cached_minutes);

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -7,6 +7,7 @@
 #include <QDialog>
 #include <QGroupBox>
 #include <QLineEdit>
+#include <QSettings>
 #include <QSpinBox>
 
 #define LIGHT_THEME 1
@@ -24,7 +25,7 @@ public:
   };
 
   Settings() {}
-  void save();
+  QSettings::Status save();
   void load();
   inline static QString filePath() { return QApplication::applicationDirPath() + "/settings"; }
 


### PR DESCRIPTION
my cabana has always reverted to default settings every time I start it up for the past week. Until I found it's a  permission issue.
think it's better to display a warning for QSettings::AccessError than silently skipping it.
