### PR TITLE
process_replay: skip tests and exit gracefully on macOS

### DIFF
--- a/selfdrive/controls/tests/test_leads.py
+++ b/selfdrive/controls/tests/test_leads.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import platform
 import unittest
 
 import cereal.messaging as messaging
@@ -8,6 +9,7 @@ from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 
 
 class TestLeads(unittest.TestCase):
+  @unittest.skipIf(platform.system() == "Darwin", "replay_process is not supported on macOS")
   def test_radar_fault(self):
     # if there's no radar-related can traffic, radard should either not respond or respond with an error
     # this is tightly coupled with underlying car radar_interface implementation, but it's a good sanity check

--- a/selfdrive/controls/tests/test_leads.py
+++ b/selfdrive/controls/tests/test_leads.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-import platform
 import unittest
 
 import cereal.messaging as messaging
 
 from openpilot.selfdrive.test.process_replay import replay_process_with_name
+from openpilot.selfdrive.test.process_replay.support_utils import skip_if_process_replay_unsupported
 from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 
 
 class TestLeads(unittest.TestCase):
-  @unittest.skipIf(platform.system() == "Darwin", "replay_process is not supported on macOS")
+  @skip_if_process_replay_unsupported
   def test_radar_fault(self):
     # if there's no radar-related can traffic, radard should either not respond or respond with an error
     # this is tightly coupled with underlying car radar_interface implementation, but it's a good sanity check

--- a/selfdrive/debug/run_process_on_route.py
+++ b/selfdrive/debug/run_process_on_route.py
@@ -3,7 +3,7 @@
 import argparse
 
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, replay_process
-from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_unsupported
 from openpilot.tools.lib.logreader import MultiLogIterator
 from openpilot.tools.lib.route import Route
 from openpilot.tools.lib.helpers import save_log
@@ -15,7 +15,7 @@ if __name__ == "__main__":
   parser.add_argument("process", help="The process to run")
   args = parser.parse_args()
 
-  exit_if_process_replay_supported()
+  exit_if_process_replay_unsupported()
 
   cfg = [c for c in CONFIGS if c.proc_name == args.process][0]
 

--- a/selfdrive/debug/run_process_on_route.py
+++ b/selfdrive/debug/run_process_on_route.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
+import platform
+import sys
 
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, replay_process
 from openpilot.tools.lib.logreader import MultiLogIterator
@@ -13,6 +15,10 @@ if __name__ == "__main__":
   parser.add_argument("route", help="The route name to use")
   parser.add_argument("process", help="The process to run")
   args = parser.parse_args()
+
+  if platform.system() == "Darwin":
+    print(f"{sys.argv[0]} is not supported on macOS")
+    sys.exit(1)
 
   cfg = [c for c in CONFIGS if c.proc_name == args.process][0]
 

--- a/selfdrive/debug/run_process_on_route.py
+++ b/selfdrive/debug/run_process_on_route.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
-import platform
-import sys
 
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, replay_process
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
 from openpilot.tools.lib.logreader import MultiLogIterator
 from openpilot.tools.lib.route import Route
 from openpilot.tools.lib.helpers import save_log
@@ -16,9 +15,7 @@ if __name__ == "__main__":
   parser.add_argument("process", help="The process to run")
   args = parser.parse_args()
 
-  if platform.system() == "Darwin":
-    print(f"{sys.argv[0]} is not supported on macOS")
-    sys.exit(1)
+  exit_if_process_replay_supported()
 
   cfg = [c for c in CONFIGS if c.proc_name == args.process][0]
 

--- a/selfdrive/locationd/test/test_laikad.py
+++ b/selfdrive/locationd/test/test_laikad.py
@@ -20,6 +20,7 @@ from openpilot.selfdrive.test.openpilotci import get_url
 from openpilot.tools.lib.logreader import LogReader
 
 from openpilot.selfdrive.test.process_replay.process_replay import get_process_config, replay_process
+from openpilot.selfdrive.test.process_replay.support_utils import skip_if_process_replay_unsupported
 from openpilot.selfdrive.test.helpers import SKIP_ENV_VAR
 
 GPS_TIME_PREDICTION_ORBITS_RUSSIAN_SRC = GPSTime.from_datetime(datetime(2022, month=1, day=29, hour=12))
@@ -96,7 +97,7 @@ def get_measurement_mock(gpstime, sat_ephemeris):
 
 
 @unittest.skipIf(SKIP_ENV_VAR in os.environ, f"Laika test skipped since it's long and not currently used. Unset {SKIP_ENV_VAR} to run")
-@unittest.skipIf(platform.system() == "Darwin", "replay_process is not supported on macOS")
+@skip_if_process_replay_unsupported
 class TestLaikad(unittest.TestCase):
 
   @classmethod

--- a/selfdrive/locationd/test/test_laikad.py
+++ b/selfdrive/locationd/test/test_laikad.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import platform
 import time
 import unittest
 from cereal import log
@@ -95,6 +96,7 @@ def get_measurement_mock(gpstime, sat_ephemeris):
 
 
 @unittest.skipIf(SKIP_ENV_VAR in os.environ, f"Laika test skipped since it's long and not currently used. Unset {SKIP_ENV_VAR} to run")
+@unittest.skipIf(platform.system() == "Darwin", "replay_process is not supported on macOS")
 class TestLaikad(unittest.TestCase):
 
   @classmethod

--- a/selfdrive/locationd/test/test_laikad.py
+++ b/selfdrive/locationd/test/test_laikad.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import os
-import platform
 import time
 import unittest
 from cereal import log

--- a/selfdrive/test/process_replay/model_replay.py
+++ b/selfdrive/test/process_replay/model_replay.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import platform
 import sys
 import time
 from collections import defaultdict
@@ -143,6 +144,10 @@ def model_replay(lr, frs):
 
 
 if __name__ == "__main__":
+  if platform.system() == "Darwin":
+    print(f"{sys.argv[0]} is not supported on macOS")
+    sys.exit(1)
+
   update = "--update" in sys.argv
   replay_dir = os.path.dirname(os.path.abspath(__file__))
   ref_commit_fn = os.path.join(replay_dir, "model_replay_ref_commit")

--- a/selfdrive/test/process_replay/model_replay.py
+++ b/selfdrive/test/process_replay/model_replay.py
@@ -14,7 +14,7 @@ from openpilot.selfdrive.test.openpilotci import BASE_URL, get_url
 from openpilot.selfdrive.test.process_replay.compare_logs import compare_logs
 from openpilot.selfdrive.test.process_replay.test_processes import format_diff
 from openpilot.selfdrive.test.process_replay.process_replay import get_process_config, replay_process
-from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_unsupported
 from openpilot.system.version import get_commit
 from openpilot.tools.lib.framereader import FrameReader
 from openpilot.tools.lib.logreader import LogReader
@@ -144,7 +144,7 @@ def model_replay(lr, frs):
 
 
 if __name__ == "__main__":
-  exit_if_process_replay_supported()
+  exit_if_process_replay_unsupported()
 
   update = "--update" in sys.argv
   replay_dir = os.path.dirname(os.path.abspath(__file__))

--- a/selfdrive/test/process_replay/model_replay.py
+++ b/selfdrive/test/process_replay/model_replay.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import os
-import platform
 import sys
 import time
 from collections import defaultdict
@@ -15,6 +14,7 @@ from openpilot.selfdrive.test.openpilotci import BASE_URL, get_url
 from openpilot.selfdrive.test.process_replay.compare_logs import compare_logs
 from openpilot.selfdrive.test.process_replay.test_processes import format_diff
 from openpilot.selfdrive.test.process_replay.process_replay import get_process_config, replay_process
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
 from openpilot.system.version import get_commit
 from openpilot.tools.lib.framereader import FrameReader
 from openpilot.tools.lib.logreader import LogReader
@@ -144,9 +144,7 @@ def model_replay(lr, frs):
 
 
 if __name__ == "__main__":
-  if platform.system() == "Darwin":
-    print(f"{sys.argv[0]} is not supported on macOS")
-    sys.exit(1)
+  exit_if_process_replay_supported()
 
   update = "--update" in sys.argv
   replay_dir = os.path.dirname(os.path.abspath(__file__))

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-import os
 import argparse
+import os
+import platform
+import sys
 import time
 import capnp
 
@@ -108,6 +110,10 @@ if __name__ == "__main__":
   parser.add_argument("route", type=str, help="The source route")
   parser.add_argument("seg", type=int, help="Segment in source route")
   args = parser.parse_args()
+
+  if platform.system() == "Darwin":
+    print(f"{sys.argv[0]} is not supported on macOS")
+    sys.exit(1)
 
   blacklist_set = set(args.blacklist_procs)
   daemons = [p for p in args.whitelist_procs if p not in blacklist_set]

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -10,6 +10,7 @@ from typing import Union, Iterable, Optional, List, Any, Dict, Tuple
 
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, FAKEDATA, replay_process, get_process_config, \
                                                         check_openpilot_enabled, get_custom_params_from_lr
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
 from openpilot.selfdrive.test.update_ci_routes import upload_route
 from openpilot.tools.lib.route import Route
 from openpilot.tools.lib.framereader import FrameReader
@@ -111,9 +112,7 @@ if __name__ == "__main__":
   parser.add_argument("seg", type=int, help="Segment in source route")
   args = parser.parse_args()
 
-  if platform.system() == "Darwin":
-    print(f"{sys.argv[0]} is not supported on macOS")
-    sys.exit(1)
+  exit_if_process_replay_supported()
 
   blacklist_set = set(args.blacklist_procs)
   daemons = [p for p in args.whitelist_procs if p not in blacklist_set]

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -10,7 +10,7 @@ from typing import Union, Iterable, Optional, List, Any, Dict, Tuple
 
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, FAKEDATA, replay_process, get_process_config, \
                                                         check_openpilot_enabled, get_custom_params_from_lr
-from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_unsupported
 from openpilot.selfdrive.test.update_ci_routes import upload_route
 from openpilot.tools.lib.route import Route
 from openpilot.tools.lib.framereader import FrameReader
@@ -112,7 +112,7 @@ if __name__ == "__main__":
   parser.add_argument("seg", type=int, help="Segment in source route")
   args = parser.parse_args()
 
-  exit_if_process_replay_supported()
+  exit_if_process_replay_unsupported()
 
   blacklist_set = set(args.blacklist_procs)
   daemons = [p for p in args.whitelist_procs if p not in blacklist_set]

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import os
-import platform
-import sys
 import time
 import capnp
 

--- a/selfdrive/test/process_replay/support_utils.py
+++ b/selfdrive/test/process_replay/support_utils.py
@@ -4,13 +4,13 @@ import sys
 import unittest
 
 
-def skipIfProcessReplayUnsupported(func):
+def skip_if_process_replay_unsupported(func):
   if platform.system() == "Darwin":
     return unittest.skip("process_replay is not supported on macOS")(func)
   
   return func
 
-def exit_if_process_replay_supported():
+def exit_if_process_replay_unsupported():
   if platform.system() == "Darwin":
     print(f"{sys.argv[0]} is not supported on macOS")
     sys.exit(1)

--- a/selfdrive/test/process_replay/support_utils.py
+++ b/selfdrive/test/process_replay/support_utils.py
@@ -1,0 +1,16 @@
+
+import platform
+import sys
+import unittest
+
+
+def skipIfProcessReplayUnsupported(func):
+  if platform.system() == "Darwin":
+    return unittest.skip("process_replay is not supported on macOS")(func)
+  
+  return func
+
+def exit_if_process_replay_supported():
+  if platform.system() == "Darwin":
+    print(f"{sys.argv[0]} is not supported on macOS")
+    sys.exit(1)

--- a/selfdrive/test/process_replay/support_utils.py
+++ b/selfdrive/test/process_replay/support_utils.py
@@ -1,4 +1,3 @@
-
 import platform
 import sys
 import unittest
@@ -7,7 +6,6 @@ import unittest
 def skip_if_process_replay_unsupported(func):
   if platform.system() == "Darwin":
     return unittest.skip("process_replay is not supported on macOS")(func)
-  
   return func
 
 def exit_if_process_replay_unsupported():

--- a/selfdrive/test/process_replay/test_fuzzy.py
+++ b/selfdrive/test/process_replay/test_fuzzy.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import copy
-import platform
 import unittest
 
 from hypothesis import given, HealthCheck, Phase, settings
@@ -10,15 +9,16 @@ from parameterized import parameterized
 from cereal import log
 from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.test.fuzzy_generation import FuzzyGenerator
-import openpilot.selfdrive.test.process_replay.process_replay as pr
+from openpilot.selfdrive.test.process_replay import replay_process, CONFIGS
+from openpilot.selfdrive.test.process_replay.support_utils import skip_if_process_replay_unsupported
 
 # These processes currently fail because of unrealistic data breaking assumptions
 # that openpilot makes causing error with NaN, inf, int size, array indexing ...
 # TODO: Make each one testable
 NOT_TESTED = ['controlsd', 'plannerd', 'calibrationd', 'dmonitoringd', 'paramsd', 'laikad', 'dmonitoringmodeld', 'modeld']
-TEST_CASES = [(cfg.proc_name, copy.deepcopy(cfg)) for cfg in pr.CONFIGS if cfg.proc_name not in NOT_TESTED]
+TEST_CASES = [(cfg.proc_name, copy.deepcopy(cfg)) for cfg in CONFIGS if cfg.proc_name not in NOT_TESTED]
 
-@unittest.skipIf(platform.system() == "Darwin", "replay_process is not supported on macOS")
+@skip_if_process_replay_unsupported
 class TestFuzzProcesses(unittest.TestCase):
 
   @parameterized.expand(TEST_CASES)
@@ -28,7 +28,7 @@ class TestFuzzProcesses(unittest.TestCase):
     msgs = FuzzyGenerator.get_random_event_msg(data.draw, events=cfg.pubs, real_floats=True)
     lr = [log.Event.new_message(**m).as_reader() for m in msgs]
     cfg.timeout = 5
-    pr.replay_process(cfg, lr, fingerprint=TOYOTA.COROLLA_TSS2, disable_progress=True)
+    replay_process(cfg, lr, fingerprint=TOYOTA.COROLLA_TSS2, disable_progress=True)
 
 if __name__ == "__main__":
   unittest.main()

--- a/selfdrive/test/process_replay/test_fuzzy.py
+++ b/selfdrive/test/process_replay/test_fuzzy.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 import copy
+import platform
+import unittest
+
 from hypothesis import given, HealthCheck, Phase, settings
 import hypothesis.strategies as st
 from parameterized import parameterized
-import unittest
 
 from cereal import log
 from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
@@ -16,6 +18,7 @@ import openpilot.selfdrive.test.process_replay.process_replay as pr
 NOT_TESTED = ['controlsd', 'plannerd', 'calibrationd', 'dmonitoringd', 'paramsd', 'laikad', 'dmonitoringmodeld', 'modeld']
 TEST_CASES = [(cfg.proc_name, copy.deepcopy(cfg)) for cfg in pr.CONFIGS if cfg.proc_name not in NOT_TESTED]
 
+@unittest.skipIf(platform.system() == "Darwin", "replay_process is not supported on macOS")
 class TestFuzzProcesses(unittest.TestCase):
 
   @parameterized.expand(TEST_CASES)

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -2,6 +2,7 @@
 import argparse
 import concurrent.futures
 import os
+import platform
 import sys
 from collections import defaultdict
 from tqdm import tqdm
@@ -180,6 +181,10 @@ if __name__ == "__main__":
   parser.add_argument("-j", "--jobs", type=int, default=max(cpu_count - 2, 1),
                       help="Max amount of parallel jobs")
   args = parser.parse_args()
+
+  if platform.system() == "Darwin":
+    print(f"{sys.argv[0]} is not supported on macOS")
+    sys.exit(1)
 
   tested_procs = set(args.whitelist_procs) - set(args.blacklist_procs)
   tested_cars = set(args.whitelist_cars) - set(args.blacklist_cars)

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -2,7 +2,6 @@
 import argparse
 import concurrent.futures
 import os
-import platform
 import sys
 from collections import defaultdict
 from tqdm import tqdm
@@ -12,6 +11,7 @@ from openpilot.selfdrive.car.car_helpers import interface_names
 from openpilot.selfdrive.test.openpilotci import get_url, upload_file
 from openpilot.selfdrive.test.process_replay.compare_logs import compare_logs
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, PROC_REPLAY_DIR, FAKEDATA, check_openpilot_enabled, replay_process
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
 from openpilot.system.version import get_commit
 from openpilot.tools.lib.filereader import FileReader
 from openpilot.tools.lib.logreader import LogReader
@@ -182,9 +182,7 @@ if __name__ == "__main__":
                       help="Max amount of parallel jobs")
   args = parser.parse_args()
 
-  if platform.system() == "Darwin":
-    print(f"{sys.argv[0]} is not supported on macOS")
-    sys.exit(1)
+  exit_if_process_replay_supported()
 
   tested_procs = set(args.whitelist_procs) - set(args.blacklist_procs)
   tested_cars = set(args.whitelist_cars) - set(args.blacklist_cars)

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -11,7 +11,7 @@ from openpilot.selfdrive.car.car_helpers import interface_names
 from openpilot.selfdrive.test.openpilotci import get_url, upload_file
 from openpilot.selfdrive.test.process_replay.compare_logs import compare_logs
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, PROC_REPLAY_DIR, FAKEDATA, check_openpilot_enabled, replay_process
-from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_supported
+from openpilot.selfdrive.test.process_replay.support_utils import exit_if_process_replay_unsupported
 from openpilot.system.version import get_commit
 from openpilot.tools.lib.filereader import FileReader
 from openpilot.tools.lib.logreader import LogReader
@@ -182,7 +182,7 @@ if __name__ == "__main__":
                       help="Max amount of parallel jobs")
   args = parser.parse_args()
 
-  exit_if_process_replay_supported()
+  exit_if_process_replay_unsupported()
 
   tested_procs = set(args.whitelist_procs) - set(args.blacklist_procs)
   tested_cars = set(args.whitelist_cars) - set(args.blacklist_cars)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
