### PR TITLE
cabana/chart: fix rubber band precision issue

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -474,7 +474,7 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
   auto rubber = findChild<QRubberBand *>();
   if (event->button() == Qt::LeftButton && rubber && rubber->isVisible()) {
     rubber->hide();
-    QRectF rect = rubber->geometry().normalized();
+    auto rect = rubber->geometry().normalized();
     double min = chart()->mapToValue(rect.topLeft()).x();
     double max = chart()->mapToValue(rect.bottomRight()).x();
 
@@ -698,7 +698,10 @@ void ChartView::drawForeground(QPainter *painter, const QRectF &rect) {
     }
   }
 
-  // paint zoom range
+  drawRubberBandTimeRange(painter);
+}
+
+void ChartView::drawRubberBandTimeRange(QPainter *painter) {
   auto rubber = findChild<QRubberBand *>();
   if (rubber && rubber->isVisible() && rubber->width() > 1) {
     painter->setPen(Qt::white);

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -84,6 +84,7 @@ private:
   void drawBackground(QPainter *painter, const QRectF &rect) override;
   void drawDropIndicator(bool draw) { if (std::exchange(can_drop, draw) != can_drop) viewport()->update(); }
   void drawTimeline(QPainter *painter);
+  void drawRubberBandTimeRange(QPainter *painter);
   std::tuple<double, double, int> getNiceAxisNumbers(qreal min, qreal max, int tick_count);
   qreal niceNumber(qreal x, bool ceiling);
   QXYSeries *createSeries(SeriesType type, QColor color);

--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -219,7 +219,7 @@ void ChartsWidget::updateToolBar() {
   undo_zoom_action->setVisible(is_zoomed);
   redo_zoom_action->setVisible(is_zoomed);
   reset_zoom_action->setVisible(is_zoomed);
-  reset_zoom_btn->setText(is_zoomed ? tr("%1-%2").arg(zoomed_range.first, 0, 'f', 1).arg(zoomed_range.second, 0, 'f', 1) : "");
+  reset_zoom_btn->setText(is_zoomed ? tr("%1-%2").arg(zoomed_range.first, 0, 'f', 2).arg(zoomed_range.second, 0, 'f', 2) : "");
   remove_all_btn->setEnabled(!charts.isEmpty());
   dock_btn->setIcon(docking ? "arrow-up-right-square" : "arrow-down-left-square");
   dock_btn->setToolTip(docking ? tr("Undock charts") : tr("Dock charts"));

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -120,7 +120,7 @@ class ZoomCommand : public QUndoCommand {
 public:
   ZoomCommand(ChartsWidget *charts, std::pair<double, double> range) : charts(charts), range(range), QUndoCommand() {
     prev_range = charts->is_zoomed ? charts->zoomed_range : charts->display_range;
-    setText(QObject::tr("Zoom to %1-%2").arg(range.first, 0, 'f', 1).arg(range.second, 0, 'f', 1));
+    setText(QObject::tr("Zoom to %1-%2").arg(range.first, 0, 'f', 2).arg(range.second, 0, 'f', 2));
   }
   void undo() override { charts->setZoom(prev_range.first, prev_range.second); }
   void redo() override { charts->setZoom(range.first, range.second); }


### PR DESCRIPTION
Fixed time range selected by the rubber band does not match the actual time range.
take the following screenshot as an example, the rubber band selects a time range of `337.06-400.44`, but after releasing the mouse, the actual time range becomes `337.1-402.9` :

![2023-09-12_12-26](https://github.com/commaai/openpilot/assets/27770/0e51598e-6a91-4eb8-9a94-2e3c78b1d1dc)

![2023-09-12_12-26_1](https://github.com/commaai/openpilot/assets/27770/bae9eb76-2850-4594-9968-481b54cf3435)


