### PR TITLE
cabana: use QStaticText to boost rending performance

### DIFF
--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -19,6 +19,8 @@ public:
   void drawSignalCell(QPainter* painter, const QStyleOptionViewItem &option, const QModelIndex &index, const cabana::Signal *sig) const;
 
   QFont small_font, hex_font;
+  std::array<QStaticText, 256> hex_text_table;
+  std::array<QStaticText, 2> bin_text_table;
 };
 
 class BinaryViewModel : public QAbstractTableModel {
@@ -26,7 +28,7 @@ public:
   BinaryViewModel(QObject *parent) : QAbstractTableModel(parent) {}
   void refresh();
   void updateState();
-  void updateItem(int row, int col, const QString &val, const QColor &color);
+  void updateItem(int row, int col, uint8_t val, const QColor &color);
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return row_count; }
@@ -42,7 +44,7 @@ public:
     QColor bg_color = QColor(102, 86, 169, 255);
     bool is_msb = false;
     bool is_lsb = false;
-    QString val;
+    uint8_t val;
     QList<const cabana::Signal *> sigs;
     bool valid = false;
   };

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -1,7 +1,6 @@
 #include "tools/cabana/util.h"
 
 #include <algorithm>
-#include <array>
 #include <csignal>
 #include <limits>
 #include <memory>
@@ -56,6 +55,10 @@ std::pair<double, double> SegmentTree::get_minmax(int n, int left, int right, in
 MessageBytesDelegate::MessageBytesDelegate(QObject *parent, bool multiple_lines) : multiple_lines(multiple_lines), QStyledItemDelegate(parent) {
   fixed_font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
   byte_size = QFontMetrics(fixed_font).size(Qt::TextSingleLine, "00 ") + QSize(0, 2);
+  for (int i = 0; i < 256; ++i) {
+    hex_text_table[i].setText(QStringLiteral("%1").arg(i, 2, 16, QLatin1Char('0')).toUpper());
+    hex_text_table[i].prepare({}, fixed_font);
+  }
 }
 
 int MessageBytesDelegate::widthForBytes(int n) const {
@@ -107,7 +110,7 @@ void MessageBytesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     } else if (option.state & QStyle::State_Selected) {
       painter->setPen(option.palette.color(QPalette::HighlightedText));
     }
-    painter->drawText(r, Qt::AlignCenter, toHex(byte_list[i]));
+    utils::drawStaticText(painter, r, hex_text_table[(uint8_t)(byte_list[i])]);
   }
   painter->setFont(old_font);
   painter->setPen(old_pen);

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cmath>
 #include <deque>
 #include <vector>
@@ -10,8 +11,10 @@
 #include <QDateTime>
 #include <QDoubleValidator>
 #include <QFont>
+#include <QPainter>
 #include <QRegExpValidator>
 #include <QSocketNotifier>
+#include <QStaticText>
 #include <QStringBuilder>
 #include <QStyledItemDelegate>
 #include <QToolButton>
@@ -75,6 +78,7 @@ public:
   int widthForBytes(int n) const;
 
 private:
+  std::array<QStaticText, 256> hex_text_table;
   QFont fixed_font;
   QSize byte_size = {};
   bool multiple_lines = false;
@@ -101,6 +105,10 @@ QPixmap icon(const QString &id);
 void setTheme(int theme);
 inline QString formatSeconds(int seconds) {
   return QDateTime::fromSecsSinceEpoch(seconds, Qt::UTC).toString(seconds > 60 * 60 ? "hh:mm:ss" : "mm:ss");
+}
+inline void drawStaticText(QPainter *p, const QRect &r, const QStaticText &text) {
+  auto size = (r.size() - text.size()) / 2;
+  p->drawStaticText(r.left() + size.width(), r.top() + size.height(), text);
 }
 }
 


### PR DESCRIPTION
use QStaticText to draw hex column & binary view:

![Screenshot from 2023-09-14 01-36-16](https://github.com/commaai/openpilot/assets/27770/6e3bace9-8578-40fa-9a0c-3c3798ccfe95)
![Screenshot from 2023-09-14 01-36-31](https://github.com/commaai/openpilot/assets/27770/8ee83f42-62b7-4995-b680-fe2da3a6835b)

