### PR TITLE
cabana: bug fixes

### DIFF
--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -289,6 +289,7 @@ void ChartsWidget::splitChart(ChartView *src_chart) {
     }
     src_chart->updateAxisY();
     src_chart->updateTitle();
+    QTimer::singleShot(0, src_chart, &ChartView::resetChartCache);
   }
 }
 

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -30,7 +30,7 @@ struct CanData {
   std::vector<std::array<uint32_t, 8>> bit_change_counts;
   std::vector<int> last_delta;
   std::vector<int> same_delta_counter;
-  double last_freq_update_ts = seconds_since_boot();
+  double last_freq_update_ts = 0;
 };
 
 struct CanEvent {


### PR DESCRIPTION
1. fix frequency always shows `-` after zooming to a small time range
2. fix chart legend alignment issue after splitting the chart:
![2023-09-14_03-01](https://github.com/commaai/openpilot/assets/27770/0da5ff12-6083-4626-a9f3-c812da4c10af)
