### PR TITLE
ignore temp translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ selfdrive/mapd/default_speeds_by_region.json
 system/proclogd/proclogd
 selfdrive/ui/_ui
 selfdrive/ui/translations/alerts_generated.h
+selfdrive/ui/translations/tmp
 selfdrive/test/longitudinal_maneuvers/out
 selfdrive/car/tests/cars_dump
 system/camerad/camerad


### PR DESCRIPTION
if you force cancel the precommit in the middle of the translations step these aren't gitignored