### PR TITLE
CI: reduce unittest timeout

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -271,7 +271,7 @@ jobs:
       timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30) }} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run unit tests
-      timeout-minutes: 40
+      timeout-minutes: 15
       run: |
         ${{ env.RUN }} "export SKIP_LONG_TESTS=1 && \
                         $PYTEST -n auto --dist=loadscope --timeout 30 -o cpp_files=test_* && \


### PR DESCRIPTION
we don't need 40 minutes for the unit tests anymore, it just wastes time when it hangs