### PR TITLE
test_models: add skip flags

### DIFF
--- a/selfdrive/car/tests/routes.py
+++ b/selfdrive/car/tests/routes.py
@@ -38,7 +38,7 @@ class CarTestRoute(NamedTuple):
   route: str
   car_model: Optional[str]
   segment: Optional[int] = None
-  skip_flags: SkipFlags = 0
+  skip_flags: SkipFlags = SkipFlags(0)
 
 
 routes = [

--- a/selfdrive/car/tests/routes.py
+++ b/selfdrive/car/tests/routes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from enum import IntFlag
 from typing import NamedTuple, Optional
 
 from openpilot.selfdrive.car.chrysler.values import CAR as CHRYSLER
@@ -29,10 +30,15 @@ non_tested_cars = [
 ]
 
 
+class SkipFlags(IntFlag):
+  RELAY_MALFUNCTION = 1
+
+
 class CarTestRoute(NamedTuple):
   route: str
   car_model: Optional[str]
   segment: Optional[int] = None
+  skip_flags: SkipFlags = 0
 
 
 routes = [
@@ -279,7 +285,10 @@ routes = [
   # Segments that test specific issues
   # Controls mismatch due to interceptor threshold
   CarTestRoute("cfb32f0fb91b173b|2022-04-06--14-54-45", HONDA.CIVIC, segment=21),
-  CarTestRoute("5a8762b91fc70467|2022-04-14--21-26-20", TOYOTA.RAV4, segment=2),
+  # Smart-DSU starts publishing ACC_CONTROL, skip relay malfunction check
+  CarTestRoute("5a8762b91fc70467|2022-04-14--21-26-20", TOYOTA.RAV4, segment=2,
+               skip_flags=SkipFlags.RELAY_MALFUNCTION),
+
   # Controls mismatch due to standstill threshold
   CarTestRoute("bec2dcfde6a64235|2022-04-08--14-21-32", HONDA.CRV_HYBRID, segment=22),
 ]

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -16,7 +16,7 @@ from openpilot.selfdrive.car.car_helpers import FRAME_FINGERPRINT, interfaces
 from openpilot.selfdrive.car.gm.values import CAR as GM
 from openpilot.selfdrive.car.honda.values import CAR as HONDA, HONDA_BOSCH
 from openpilot.selfdrive.car.hyundai.values import CAR as HYUNDAI
-from openpilot.selfdrive.car.tests.routes import non_tested_cars, routes, CarTestRoute
+from openpilot.selfdrive.car.tests.routes import non_tested_cars, routes, CarTestRoute, SkipFlags
 from openpilot.selfdrive.controls.controlsd import Controls
 from openpilot.selfdrive.test.openpilotci import get_url
 from openpilot.tools.lib.logreader import LogReader
@@ -65,7 +65,6 @@ def get_test_cases() -> List[Tuple[str, Optional[CarTestRoute]]]:
       test_cases.append((platform, CarTestRoute(segment_name.route_name.canonical_name, platform,
                                                 segment=segment_name.segment_num)))
   return test_cases
-
 
 
 class TestCarModelBase(unittest.TestCase):
@@ -258,7 +257,8 @@ class TestCarModelBase(unittest.TestCase):
 
           # No need to check relay malfunction on disabled routes (relay closed),
           # or before fingerprinting is done (1s of tolerance to exit silent mode)
-          if self.openpilot_enabled and t / 1e4 > (self.elm_frame + 100):
+          if (self.openpilot_enabled and t / 1e4 > (self.elm_frame + 100) and
+            not self.test_route.skip_flags & SkipFlags.RELAY_MALFUNCTION):
             self.assertFalse(self.safety.get_relay_malfunction())
           else:
             self.safety.set_relay_malfunction(False)


### PR DESCRIPTION
Pre-req for https://github.com/commaai/openpilot/pull/29094

The RAV4 segment tests a gas interceptor mismatch in panda safety, and so in the route the SDSU started publishing ACC_CONTROL as it thought openpilot had died (since we were blocking msgs in the route). And so the relay malfunction is expected in this case.