### PR TITLE
cabana: add button to skip to the end of stream

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -35,13 +35,24 @@ VideoWidget::VideoWidget(QWidget *parent) : QFrame(parent) {
   }
 
   // btn controls
+  QButtonGroup *group = new QButtonGroup(this);
+  group->setExclusive(true);
+
   QHBoxLayout *control_layout = new QHBoxLayout();
   play_btn = new QPushButton();
   play_btn->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
   control_layout->addWidget(play_btn);
+  if (can->liveStreaming()) {
+    control_layout->addWidget(skip_to_end_btn = new QPushButton(utils::icon("skip-end-fill"), {}));
+    skip_to_end_btn->setToolTip(tr("Skip to the end"));
+    QObject::connect(skip_to_end_btn, &QPushButton::clicked, [group]() {
+      // set speed to 1.0
+      group->buttons()[2]->click();
+      can->pause(false);
+      can->seekTo(can->totalSeconds() + 1);
+    });
+  }
 
-  QButtonGroup *group = new QButtonGroup(this);
-  group->setExclusive(true);
   for (float speed : {0.1, 0.5, 1., 2.}) {
     QPushButton *btn = new QPushButton(QString("%1x").arg(speed), this);
     btn->setCheckable(true);
@@ -121,7 +132,10 @@ void VideoWidget::setMaximumTime(double sec) {
 }
 
 void VideoWidget::updateTimeRange(double min, double max, bool is_zoomed) {
-  if (can->liveStreaming()) return;
+  if (can->liveStreaming()) {
+    skip_to_end_btn->setEnabled(!is_zoomed);
+    return;
+  }
 
   if (!is_zoomed) {
     min = 0;

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -81,6 +81,7 @@ protected:
   QLabel *end_time_label;
   QLabel *time_label;
   QPushButton *play_btn;
+  QPushButton *skip_to_end_btn = nullptr;
   InfoLabel *alert_label;
   Slider *slider;
 };


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/discussions/26091#discussioncomment-6975129

add skip-to-end button to skip to the end of stream:

![2023-09-17_12-57](https://github.com/commaai/openpilot/assets/27770/13d9bd49-46c4-42bc-bef0-102d6393d29b)

videos:

[Kazam_screencast_00125.webm](https://github.com/commaai/openpilot/assets/27770/0fdf84fe-4209-4103-9e98-87563b287854)

[Kazam_screencast_00127.webm](https://github.com/commaai/openpilot/assets/27770/9aeb579b-6ba1-4264-93e5-df8ebc5d2b6d)

