### PR TITLE
Params: better error logging on constructor

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -64,7 +64,7 @@ bool create_params_path(const std::string &param_path, const std::string &key_pa
 std::string ensure_params_path(const std::string &prefix, const std::string &path = {}) {
   std::string params_path = path.empty() ? Path::params() : path;
   if (!create_params_path(params_path, params_path + prefix)) {
-    throw std::runtime_error(util::string_format("Failed to ensure params path, errno=%d", errno));
+    throw std::runtime_error(util::string_format("Failed to ensure params path, errno=%d, path=%s", errno, params_path.c_str()));
   }
   return params_path;
 }

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -14,7 +14,7 @@ cdef extern from "common/params.h":
     ALL
 
   cdef cppclass c_Params "Params":
-    c_Params(string) nogil
+    c_Params(string) nogil except +
     string get(string, bool) nogil
     bool getBool(string, bool) nogil
     int remove(string) nogil

--- a/common/prefix.py
+++ b/common/prefix.py
@@ -22,7 +22,7 @@ class OpenpilotPrefix:
     os.makedirs(Paths.log_root(), exist_ok=True)
     os.makedirs(Paths.download_cache_root(), exist_ok=True)
     os.makedirs(Paths.comma_home(), exist_ok=True)
-  
+
     return self
 
   def __exit__(self, exc_type, exc_obj, exc_tb):

--- a/common/prefix.py
+++ b/common/prefix.py
@@ -20,8 +20,6 @@ class OpenpilotPrefix:
     except FileExistsError:
       pass
     os.makedirs(Paths.log_root(), exist_ok=True)
-    os.makedirs(Paths.download_cache_root(), exist_ok=True)
-    os.makedirs(Paths.comma_home(), exist_ok=True)
 
     return self
 

--- a/common/prefix.py
+++ b/common/prefix.py
@@ -20,7 +20,9 @@ class OpenpilotPrefix:
     except FileExistsError:
       pass
     os.makedirs(Paths.log_root(), exist_ok=True)
-
+    os.makedirs(Paths.download_cache_root(), exist_ok=True)
+    os.makedirs(Paths.comma_home(), exist_ok=True)
+  
     return self
 
   def __exit__(self, exc_type, exc_obj, exc_tb):


### PR DESCRIPTION
Seems like the recent CI unittest failures are something with the nonblocking params write. Unclear what the exact cause is, but this will at least allow us to see the errors. Currently if you get an exception in the C params implementation, it causes a fatal python error that seems to totally break pytest and causes the timeout

Before this change: fatal python error on runtime error: 
https://github.com/commaai/openpilot/actions/runs/6216166456/job/16869754995#step:5:80

After: doesn't crash pytest and cause a timeout anymore, just shows a failed test:
https://github.com/jnewb1/openpilot/actions/runs/6210296847/job/16860422338#step:5:161