### PR TITLE
translation badges: add arabic exception

### DIFF
--- a/selfdrive/ui/translations/create_badges.py
+++ b/selfdrive/ui/translations/create_badges.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     color = "green" if percent_finished == 100 else "orange" if percent_finished > 90 else "red"
 
     # Download badge
-    badge_label = f"LANGUAGE {name}"
+    badge_label = f"LANGUAGE {name}" if (name != "العربية") else f"LANGUAGE Arabic"
     badge_message = f"{percent_finished}% complete"
     if unfinished_translations != 0:
       badge_message += f" ({unfinished_translations} unfinished)"


### PR DESCRIPTION
Arabic badges are currently [not supported](https://github.com/badges/shields/issues/4140) and results in the following
<img width="268" alt="Screenshot 2023-09-18 at 6 52 52 AM" src="https://github.com/commaai/openpilot/assets/1976269/4bd77a67-cf24-432a-b8fb-3c6c710ee8c6">
This fix swaps the word `العربية` to `Arabic` until a fix is made upstream.
