### PR TITLE
translation badges: fix chinese badges

### DIFF
--- a/selfdrive/ui/translations/languages.json
+++ b/selfdrive/ui/translations/languages.json
@@ -6,8 +6,8 @@
   "Türkçe": "main_tr",
   "العربية": "main_ar",
   "ไทย": "main_th",
-  "中文（繁體）": "main_zh-CHT",
-  "中文（简体）": "main_zh-CHS",
+  "中文 (繁體)": "main_zh-CHT",
+  "中文 (简体)": "main_zh-CHS",
   "한국어": "main_ko",
   "日本語": "main_ja"
 }


### PR DESCRIPTION
Chinese badge names were using the `）` character instead of `)` which added additional padding.

Before:
<img width="316" alt="Screenshot 2023-09-18 at 7 14 34 AM" src="https://github.com/commaai/openpilot/assets/1976269/b5678119-ffde-4465-b2b3-5aa5a866b80e">

After:
<img width="308" alt="Screenshot 2023-09-18 at 7 14 55 AM" src="https://github.com/commaai/openpilot/assets/1976269/2935a4c5-876b-4dec-8516-8109797a500b">
