### PR TITLE
HKG: Add FW Versions for Kia Carnival 2024

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1951,6 +1951,7 @@ FW_VERSIONS = {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00KA4_ SCC FHCUP      1.00 1.03 99110-R0000         ',
       b'\xf1\x00KA4c SCC FHCUP      1.00 1.01 99110-I4000         ',
+      b'\xf1\x00KA4_ SCC FHCUP      1.00 1.00 99110-R0100         ',
     ],
   },
   CAR.KIA_SORENTO_HEV_4TH_GEN: {


### PR DESCRIPTION
Add firmware versions for the 2024 Kia Carnival.

Dongle ID: `95b0e793a90573c0`

Thanks to the community 2024 Kia Carnival owner Tes1a8.