### PR TITLE
params: log `prefix` on fail

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -64,7 +64,9 @@ bool create_params_path(const std::string &param_path, const std::string &key_pa
 std::string ensure_params_path(const std::string &prefix, const std::string &path = {}) {
   std::string params_path = path.empty() ? Path::params() : path;
   if (!create_params_path(params_path, params_path + prefix)) {
-    throw std::runtime_error(util::string_format("Failed to ensure params path, errno=%d, path=%s", errno, params_path.c_str()));
+    throw std::runtime_error(util::string_format(
+        "Failed to ensure params path, errno=%d, path=%s, param_prefix=%s",
+        errno, params_path.c_str(), prefix.c_str()));
   }
   return params_path;
 }


### PR DESCRIPTION
 CI unittest failure at `ensure_params_path`  https://github.com/commaai/openpilot/actions/runs/6231677026/job/16913564833?pr=29971
`RuntimeError: Failed to ensure params path, errno=2, path=/root/.commaa8e5c6e388b1460/params`

One possibility is that a directory component in `key_path` does not exist (Or another process is calling rename at the same time.)
https://github.com/commaai/openpilot/blob/d0a31515a0ab5a91a949cd6f9ef3e05ef093925f/common/params.cc#L56

 Logging prefix can better locate where the problem is.