### PR TITLE
Simulator: fix port issues in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,3 +9,5 @@ RUN pip install ipython jupyter jupyterlab
 RUN cd $HOME && \
     curl -O https://raw.githubusercontent.com/commaai/agnos-builder/master/userspace/home/.tmux.conf && \
     curl -O https://github.com/commaai/agnos-builder/blob/master/userspace/home/.vimrc
+
+ENV CARLA_HOST="172.17.0.1"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,4 +10,4 @@ RUN cd $HOME && \
     curl -O https://raw.githubusercontent.com/commaai/agnos-builder/master/userspace/home/.tmux.conf && \
     curl -O https://github.com/commaai/agnos-builder/blob/master/userspace/home/.vimrc
 
-ENV CARLA_HOST="172.17.0.1"
+ENV CARLA_HOST="host.docker.internal"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
     "--volume=${localEnv:HOME}/.comma:/root/.comma",
     "--volume=/tmp/comma_download_cache:/tmp/comma_download_cache",
     "--volume=/tmp/devcontainer_scons_cache:/tmp/scons_cache",
-    "--shm-size=1G"
+    "--shm-size=1G",
+    "--add-host=host.docker.internal:host-gateway" // required to use host.docker.internal on linux
   ],
   "customizations": {
     "vscode": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     -   id: check-ast
         exclude: '^(third_party)/'
     -   id: check-json
+        exclude: '.devcontainer/devcontainer.json' # this supports JSON with comments
     -   id: check-toml
     -   id: check-xml
     -   id: check-yaml

--- a/tools/sim/run_bridge.py
+++ b/tools/sim/run_bridge.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import os
 
 from typing import Any
 from multiprocessing import Queue
@@ -18,7 +19,7 @@ def parse_args(add_args=None):
   # Carla specific
   parser.add_argument('--town', type=str, default='Town04_Opt')
   parser.add_argument('--spawn_point', dest='num_selected_spawn_point', type=int, default=16)
-  parser.add_argument('--host', dest='host', type=str, default='127.0.0.1')
+  parser.add_argument('--host', dest='host', type=str, default=os.environ.get("CARLA_HOST", '127.0.0.1'))
   parser.add_argument('--port', dest='port', type=int, default=2000)
 
   return parser.parse_args(add_args)


### PR DESCRIPTION
need to connect to the docker host rather than localhost (which is the devcontainer)

still doesn't work in the devcontainer because it doesn't have opencl, but I will fix that separately

resolves: https://github.com/commaai/openpilot/issues/29760