### PR TITLE
CI: disable buildjet on PR's from forks

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -277,8 +277,8 @@ jobs:
 
   process_replay:
     name: process replay
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'commaai/openpilot' && github.event.pull_request.head.repo.full_name == 'commaai/openpilot') ||
-                 (github.event_name != 'pull_request' && github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
+    runs-on: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'commaai/openpilot' && github.event.pull_request.head.repo.full_name == 'commaai/openpilot') ||
+                  (github.event_name != 'pull_request' && github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -277,7 +277,8 @@ jobs:
 
   process_replay:
     name: process replay
-    runs-on: ${{ ((github.event.pull_request.head.repo.full_name == 'commaai/openpilot') || (github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'commaai/openpilot' && github.event.pull_request.head.repo.full_name == 'commaai/openpilot') ||
+                 (github.event_name != 'pull_request' && github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -73,7 +73,7 @@ jobs:
         arch: ${{ fromJson(
            ((github.repository == 'commaai/openpilot') &&
               ((github.event_name != 'pull_request') || 
-               (github.event.pull_request.base.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
+               (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
     runs-on: ${{ (matrix.arch == 'aarch64') && 'buildjet-2vcpu-ubuntu-2204-arm' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3
@@ -282,7 +282,7 @@ jobs:
     name: process replay
     runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
                    ((github.event_name != 'pull_request') || 
-                    (github.event.pull_request.base.repo.full_name == 'commaai/openpilot'))) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
+                    (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -71,8 +71,9 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(
-          ((github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'commaai/openpilot' && github.event.pull_request.head.repo.full_name == 'commaai/openpilot') ||
-           (github.event_name != 'pull_request' && github.repository == 'commaai/openpilot')) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
+           ((github.repository == 'commaai/openpilot') &&
+              ((github.event_name != 'pull_request') || 
+               (github.event.pull_request.base.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
     runs-on: ${{ (matrix.arch == 'aarch64') && 'buildjet-2vcpu-ubuntu-2204-arm' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3
@@ -279,8 +280,9 @@ jobs:
 
   process_replay:
     name: process replay
-    runs-on: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'commaai/openpilot' && github.event.pull_request.head.repo.full_name == 'commaai/openpilot') ||
-                  (github.event_name != 'pull_request' && github.repository == 'commaai/openpilot')) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
+    runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
+                   ((github.event_name != 'pull_request') || 
+                    (github.event.pull_request.base.repo.full_name == 'commaai/openpilot'))) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -70,7 +70,9 @@ jobs:
   build:
     strategy:
       matrix:
-        arch: ${{ fromJson( (github.repository == 'commaai/openpilot') && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
+        arch: ${{ fromJson(
+          ((github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'commaai/openpilot' && github.event.pull_request.head.repo.full_name == 'commaai/openpilot') ||
+           (github.event_name != 'pull_request' && github.repository == 'commaai/openpilot')) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
     runs-on: ${{ (matrix.arch == 'aarch64') && 'buildjet-2vcpu-ubuntu-2204-arm' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- only when within main repo
- if not a PR (example: push to master), always run on buildjet
- otherwise, only run on buildjet if the PR originates from main repo