### PR TITLE
Simulator: remove opencl dependence

### DIFF
--- a/tools/sim/lib/camerad.py
+++ b/tools/sim/lib/camerad.py
@@ -9,11 +9,11 @@ from openpilot.tools.sim.lib.common import W, H
 
 # Modified from: https://github.com/opencv/opencv/issues/22514#issuecomment-1369457841
 def rgb2nv12(rgb):
-    yuv = cv2.cvtColor(rgb, cv2.COLOR_BGR2YUV_I420)
-    uv_row_cnt = yuv.shape[0] // 3
-    uv_plane = np.transpose(yuv[uv_row_cnt * 2:].reshape(2, -1), [1, 0])
-    yuv[uv_row_cnt * 2:] = uv_plane.reshape(uv_row_cnt, -1)
-    return yuv
+  yuv = cv2.cvtColor(rgb, cv2.COLOR_BGR2YUV_I420)
+  uv_row_cnt = yuv.shape[0] // 3
+  uv_plane = np.transpose(yuv[uv_row_cnt * 2:].reshape(2, -1), [1, 0])
+  yuv[uv_row_cnt * 2:] = uv_plane.reshape(uv_row_cnt, -1)
+  return yuv
 
 
 class Camerad:

--- a/tools/sim/lib/camerad.py
+++ b/tools/sim/lib/camerad.py
@@ -8,7 +8,7 @@ from openpilot.tools.sim.lib.common import W, H
 
 
 # Modified from: https://github.com/opencv/opencv/issues/22514#issuecomment-1369457841
-def rgb2nv12(rgb: np.ndarray) -> np.ndarray:
+def rgb2nv12(rgb):
     yuv = cv2.cvtColor(rgb, cv2.COLOR_BGR2YUV_I420)
     uv_row_cnt = yuv.shape[0] // 3
     uv_plane = np.transpose(yuv[uv_row_cnt * 2:].reshape(2, -1), [1, 0])

--- a/tools/sim/lib/camerad.py
+++ b/tools/sim/lib/camerad.py
@@ -1,13 +1,20 @@
+import cv2
 import numpy as np
-import os
-import pyopencl as cl
-import pyopencl.array as cl_array
 
 from cereal.visionipc import VisionIpcServer, VisionStreamType
 from cereal import messaging
 
-from openpilot.common.basedir import BASEDIR
 from openpilot.tools.sim.lib.common import W, H
+
+
+# Modified from: https://github.com/opencv/opencv/issues/22514#issuecomment-1369457841
+def rgb2nv12(rgb: np.ndarray) -> np.ndarray:
+    yuv = cv2.cvtColor(rgb, cv2.COLOR_BGR2YUV_I420)
+    uv_row_cnt = yuv.shape[0] // 3
+    uv_plane = np.transpose(yuv[uv_row_cnt * 2:].reshape(2, -1), [1, 0])
+    yuv[uv_row_cnt * 2:] = uv_plane.reshape(uv_row_cnt, -1)
+    return yuv
+
 
 class Camerad:
   """Simulates the camerad daemon"""
@@ -24,18 +31,6 @@ class Camerad:
 
     self.vipc_server.start_listener()
 
-    # set up for pyopencl rgb to yuv conversion
-    self.ctx = cl.create_some_context()
-    self.queue = cl.CommandQueue(self.ctx)
-    cl_arg = f" -DHEIGHT={H} -DWIDTH={W} -DRGB_STRIDE={W * 3} -DUV_WIDTH={W // 2} -DUV_HEIGHT={H // 2} -DRGB_SIZE={W * H} -DCL_DEBUG "
-
-    kernel_fn = os.path.join(BASEDIR, "tools/sim/rgb_to_nv12.cl")
-    with open(kernel_fn) as f:
-      prg = cl.Program(self.ctx, f.read()).build(cl_arg)
-      self.krnl = prg.rgb_to_nv12
-    self.Wdiv4 = W // 4 if (W % 4 == 0) else (W + (4 - W % 4)) // 4
-    self.Hdiv4 = H // 4 if (H % 4 == 0) else (H + (4 - H % 4)) // 4
-
   def cam_send_yuv_road(self, yuv):
     self._send_yuv(yuv, self.frame_road_id, 'roadCameraState', VisionStreamType.VISION_STREAM_ROAD)
     self.frame_road_id += 1
@@ -49,11 +44,7 @@ class Camerad:
     assert rgb.shape == (H, W, 3), f"{rgb.shape}"
     assert rgb.dtype == np.uint8
 
-    rgb_cl = cl_array.to_device(self.queue, rgb)
-    yuv_cl = cl_array.empty_like(rgb_cl)
-    self.krnl(self.queue, (self.Wdiv4, self.Hdiv4), None, rgb_cl.data, yuv_cl.data).wait()
-    yuv = np.resize(yuv_cl.get(), rgb.size // 2)
-    return yuv.data.tobytes()
+    return rgb2nv12(rgb).tobytes()
 
   def _send_yuv(self, yuv, frame_id, pub_type, yuv_type):
     eof = int(frame_id * 0.05 * 1e9)


### PR DESCRIPTION
using opencv is only slightly slower, and will be much more compatible across platforms. This also works in the devcontainer (although modeld doesn't work because it also depends on CL)

https://gist.github.com/jnewb1/65f58ff25e9457f8ebb7581f0a31a716