### PR TITLE
Params: nogil at the end

### DIFF
--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -14,7 +14,7 @@ cdef extern from "common/params.h":
     ALL
 
   cdef cppclass c_Params "Params":
-    c_Params(string) nogil except +
+    c_Params(string) except + nogil
     string get(string, bool) nogil
     bool getBool(string, bool) nogil
     int remove(string) nogil

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -14,7 +14,7 @@ cdef extern from "common/params.h":
     ALL
 
   cdef cppclass c_Params "Params":
-    c_Params(string) nogil except +
+    c_Params(string) except + nogil
     string get(string, bool) nogil
     bool getBool(string, bool) nogil
     int remove(string) nogil
@@ -104,8 +104,8 @@ cdef class Params:
   def all_keys(self):
     return self.p.allKeys()
 
-def put_nonblocking(key, val, d=""):
-  threading.Thread(target=lambda: Params(d).put(key, val)).start()
+  def put_nonblocking(self, key, val):
+    threading.Thread(target=lambda: self.put(key, val)).start()
 
-def put_bool_nonblocking(key, bool val, d=""):
-  threading.Thread(target=lambda: Params(d).put_bool(key, val)).start()
+  def put_bool_nonblocking(self, key, bool val):
+    threading.Thread(target=lambda: self.put_bool(key, val)).start()

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -14,7 +14,7 @@ cdef extern from "common/params.h":
     ALL
 
   cdef cppclass c_Params "Params":
-    c_Params(string) except + nogil
+    c_Params(string) nogil except +
     string get(string, bool) nogil
     bool getBool(string, bool) nogil
     int remove(string) nogil
@@ -104,8 +104,8 @@ cdef class Params:
   def all_keys(self):
     return self.p.allKeys()
 
-  def put_nonblocking(self, key, val):
-    threading.Thread(target=lambda: self.put(key, val)).start()
+def put_nonblocking(key, val, d=""):
+  threading.Thread(target=lambda: Params(d).put(key, val)).start()
 
-  def put_bool_nonblocking(self, key, bool val):
-    threading.Thread(target=lambda: self.put_bool(key, val)).start()
+def put_bool_nonblocking(key, bool val, d=""):
+  threading.Thread(target=lambda: Params(d).put_bool(key, val)).start()


### PR DESCRIPTION
nogil should always go at the end


```warning: common/params_pyx.pyx:17:35: The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.```