### PR TITLE
hypothesis: fix too slow health check

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1578,13 +1578,13 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.46.7"
+version = "6.47.5"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "hypothesis-6.46.7-py3-none-any.whl", hash = "sha256:2696cdb9005946bf1d2b215cc91d3fc01625e3342eb8743ddd04b667b2f1882b"},
-    {file = "hypothesis-6.46.7.tar.gz", hash = "sha256:967009fa561b3a3f8363a73d71923357271c37dc7fa27b30c2d21a1b6092b240"},
+    {file = "hypothesis-6.47.5-py3-none-any.whl", hash = "sha256:87049b781ee11ec1c7948565b889ab02e428a1e32d427ab4de8fdb3649242d06"},
+    {file = "hypothesis-6.47.5.tar.gz", hash = "sha256:e0c1e253fc97e7ecdb9e2bbff2cf815d8739e0d1d3d093d67c3af5bb6a7211b0"},
 ]
 
 [package.dependencies]
@@ -5106,4 +5106,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "80bd9226bb8fc61c75fe8047c55ba2da3919bc8d9b32a8154ec0a40f9fe2a18e"
+content-hash = "f159e93b7b57c4fad45a063d96ef97b01697fc811a51f968c7757b05808cee1c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ carla = { url = "https://github.com/commaai/carla/releases/download/3.11.4/carla
 coverage = "*"
 dictdiffer = "*"
 ft4222 = "*"
-hypothesis = "*"
+hypothesis = "~6.47"
 inputs = "*"
 lru-dict = "*"
 markdown-it-py = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ carla = { url = "https://github.com/commaai/carla/releases/download/3.11.4/carla
 coverage = "*"
 dictdiffer = "*"
 ft4222 = "*"
-hypothesis = "==6.46.7"
+hypothesis = "*"
 inputs = "*"
 lru-dict = "*"
 markdown-it-py = "*"


### PR DESCRIPTION
Pinned in https://github.com/commaai/openpilot/pull/24852. Version is from May 2022, time we upgrade.

Also fixes a slowness health check bug in jenkins CI when the machine is under load from other tests. Generation hangs or is generally slow and the check trips on a few cases.

Ran locally with 500 pytest jobs and 6.47.1 is the first version that doesn't fail the check.

---

Related discussion in hypothesis repo about similar issue in CI: https://github.com/HypothesisWorks/hypothesis/issues/2195#issuecomment-557451955