### PR TITLE
pre-commit: use non-deprecated lock file check command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,10 +80,9 @@ repos:
     rev: '1.6.0'
     hooks:
     -   id: poetry-check
-    -   id: poetry-lock
         name: validate poetry lock
         args:
-        - --check
+        - --lock
 -   repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.26.3
     hooks:


### PR DESCRIPTION
Uses `check --lock` instead of `lock --check` with this hook https://github.com/python-poetry/poetry/blob/515a763fd54e45d94c887645eda904871666c69c/.pre-commit-hooks.yaml#L1-L7

PR that deprecated old command: https://github.com/python-poetry/poetry/pull/8015/files

```
Usage:
  lock [options]

Options:
      --no-update            Do not update locked versions, only refresh lock file.
      --check                Check that the poetry.lock file corresponds to the current version of pyproject.toml. (Deprecated) Use poetry check --lock instead.
```

Warning in CI: 
```
poetry lock --check is deprecated, use `poetry check --lock` instead.
```