### PR TITLE
Added curvature controls to joystick mode

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -629,9 +629,8 @@ class Controls:
 
         if CC.latActive:
           steer = clip(self.sm['testJoystick'].axes[1], -1, 1)
-          # max angle is 45 for angle-based cars
-          actuators.steer, actuators.steeringAngleDeg = steer, steer * 45.
-          actuators.curvature = steer * -0.02
+          # max angle is 45 for angle-based cars, max curvature is 0.02
+          actuators.steer, actuators.steeringAngleDeg, actuators.curvature = steer, steer * 45., steer * -0.02
 
         lac_log.active = self.active
         lac_log.steeringAngleDeg = CS.steeringAngleDeg

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -631,6 +631,7 @@ class Controls:
           steer = clip(self.sm['testJoystick'].axes[1], -1, 1)
           # max angle is 45 for angle-based cars
           actuators.steer, actuators.steeringAngleDeg = steer, steer * 45.
+          actuators.curvature = steer * -0.02
 
         lac_log.active = self.active
         lac_log.steeringAngleDeg = CS.steeringAngleDeg


### PR DESCRIPTION
**Description**: Joystick Mode would not operate curvature controlled vehicles.

**Verification**: I went to an empty parking lot and enabled joystick mode. I enabled OpenPilot and pushed corresponding A/D commands on the keyboard. 

I verified that "A" turned the vehicle to the left and "D" turned the vehicle to the right.

I used the Ford max curvature (0.02) as a baseline.
