### PR TITLE
Devcontainer: improve CI tests and support using local built image

### DIFF
--- a/.devcontainer/host_setup.sh
+++ b/.devcontainer/host_setup.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # pull base image
-docker pull ghcr.io/commaai/openpilot-base:latest
+if [[ -z $USE_LOCAL_IMAGE ]]; then
+  docker pull ghcr.io/commaai/openpilot-base:latest
+fi
 
 # setup .host dir
 mkdir -p .devcontainer/.host

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -101,8 +101,8 @@ jobs:
     - name: Build dev container image
       run: devcontainer build --workspace-folder .
     - name: Run dev container
-      run: devcontainer up --workspace-folder .
+      run: devcontainer up --workspace-folder --mount type=volume,source=.ci_cache/scons_cache,target=/tmp/scons_cache .
     - name: Test environment
       run: |
-        devcontainer exec --workspace-folder . scons --dry-run
+        devcontainer exec --workspace-folder . scons -j$(nproc)
         devcontainer exec --workspace-folder . pip install pip-install-test

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -101,7 +101,10 @@ jobs:
     - name: Build dev container image
       run: devcontainer build --workspace-folder .
     - name: Run dev container
-      run: devcontainer up --workspace-folder . --mount type=volume,source=$GITHUB_WORKSPACE/.ci_cache/scons_cache,target=/tmp/scons_cache
+      run: |
+        mkdir -p /tmp/devcontainer_scons_cache/
+        cp -r $GITHUB_WORKSPACE/.ci_cache/scons_cache/* /tmp/devcontainer_scons_cache/
+        devcontainer up --workspace-folder . --mount type=volume,source=$GITHUB_WORKSPACE/.ci_cache/scons_cache,target=/tmp/scons_cache
     - name: Test environment
       run: |
         devcontainer exec --workspace-folder . scons -j$(nproc)

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -104,7 +104,7 @@ jobs:
       run: |
         mkdir -p /tmp/devcontainer_scons_cache/
         cp -r $GITHUB_WORKSPACE/.ci_cache/scons_cache/* /tmp/devcontainer_scons_cache/
-        devcontainer up --workspace-folder . --mount type=volume,source=$GITHUB_WORKSPACE/.ci_cache/scons_cache,target=/tmp/scons_cache
+        devcontainer up --workspace-folder .
     - name: Test environment
       run: |
         devcontainer exec --workspace-folder . scons -j$(nproc)

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -90,6 +90,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - uses: ./.github/workflows/setup-with-retry
+      with:
+        git_lfs: false
+    - name: Use local image for testing devcontainer with latest base image
+      run: |
+        echo "USE_LOCAL_IMAGE=true" >> "$GITHUB_ENV"
     - name: Setup Dev Container CLI
       run: npm install -g @devcontainers/cli
     - name: Build dev container image
@@ -97,4 +103,6 @@ jobs:
     - name: Run dev container
       run: devcontainer up --workspace-folder .
     - name: Test environment
-      run: devcontainer exec --workspace-folder . scons --dry-run
+      run: |
+        devcontainer exec --workspace-folder . scons --dry-run
+        devcontainer exec --workspace-folder . pip install pip-install-test

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -101,7 +101,7 @@ jobs:
     - name: Build dev container image
       run: devcontainer build --workspace-folder .
     - name: Run dev container
-      run: devcontainer up --workspace-folder --mount type=volume,source=.ci_cache/scons_cache,target=/tmp/scons_cache .
+      run: devcontainer up --workspace-folder . --mount type=volume,source=$GITHUB_WORKSPACE/.ci_cache/scons_cache,target=/tmp/scons_cache
     - name: Test environment
       run: |
         devcontainer exec --workspace-folder . scons -j$(nproc)


### PR DESCRIPTION
- run CI test on the locally built base image rather than the upstream one (useful in CI and local dev)
- ensure pip install works in the container by installing a mock package (relevant to switching to the batman user)