### PR TITLE
CI: remove warning messages

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -198,7 +198,7 @@ jobs:
         $DOCKER_LOGIN
     - uses: ./.github/workflows/setup-with-retry
       with:
-        git-lfs: false
+        git_lfs: false
         docker_hub_pat: ${{ secrets.DOCKER_HUB_PAT }}
     - name: Build and push CL Docker image
       if: matrix.arch == 'x86_64'
@@ -309,7 +309,7 @@ jobs:
       id: print-diff
       if: always()
       run: cat selfdrive/test/process_replay/diff.txt
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: always()
       continue-on-error: true
       with:


### PR DESCRIPTION
- git-lfs should be git_lfs (was pulling LFS when it doesn't need to, since it defaults to true)
- update to artifacts v3

![image](https://github.com/commaai/openpilot/assets/9648890/de6ff5a4-3f1b-4895-a47c-073e625ddcc1)