### PR TITLE
Tests: speedup replay test

### DIFF
--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -126,7 +126,6 @@ std::string download_demo_route() {
       std::string log_path = util::string_format("%s/%s--%d/", data_dir.c_str(), route_name.c_str(), i);
       util::create_directories(log_path, 0755);
       REQUIRE(download_to_file(remote_route.at(i).rlog.toStdString(), log_path + "rlog.bz2"));
-      REQUIRE(download_to_file(remote_route.at(i).road_cam.toStdString(), log_path + "fcamera.hevc"));
       REQUIRE(download_to_file(remote_route.at(i).driver_cam.toStdString(), log_path + "dcamera.hevc"));
       REQUIRE(download_to_file(remote_route.at(i).wide_road_cam.toStdString(), log_path + "ecamera.hevc"));
       REQUIRE(download_to_file(remote_route.at(i).qcamera.toStdString(), log_path + "qcamera.ts"));
@@ -137,27 +136,26 @@ std::string download_demo_route() {
 }
 
 
-TEST_CASE("Route") {
+TEST_CASE("Local route") {
   std::string data_dir = download_demo_route();
 
-  SECTION("Local route") {
-    auto flags = GENERATE(REPLAY_FLAG_DCAM | REPLAY_FLAG_ECAM, REPLAY_FLAG_QCAMERA);
-    Route route(DEMO_ROUTE, QString::fromStdString(data_dir));
-    REQUIRE(route.load());
-    REQUIRE(route.segments().size() == 2);
-    for (int i = 0; i < route.segments().size(); ++i) {
-      read_segment(i, route.at(i), flags);
-    }
-  };
-  SECTION("Remote route") {
-    auto flags = GENERATE(REPLAY_FLAG_DCAM | REPLAY_FLAG_ECAM, REPLAY_FLAG_QCAMERA);
-    Route route(DEMO_ROUTE);
-    REQUIRE(route.load());
-    REQUIRE(route.segments().size() == 13);
-    for (int i = 0; i < 2; ++i) {
-      read_segment(i, route.at(i), flags);
-    }
-  };
+  auto flags = GENERATE(REPLAY_FLAG_DCAM | REPLAY_FLAG_ECAM, REPLAY_FLAG_QCAMERA);
+  Route route(DEMO_ROUTE, QString::fromStdString(data_dir));
+  REQUIRE(route.load());
+  REQUIRE(route.segments().size() == 2);
+  for (int i = 0; i < route.segments().size(); ++i) {
+    read_segment(i, route.at(i), flags);
+  }
+}
+
+TEST_CASE("Remote route") {
+  auto flags = GENERATE(REPLAY_FLAG_DCAM | REPLAY_FLAG_ECAM, REPLAY_FLAG_QCAMERA);
+  Route route(DEMO_ROUTE);
+  REQUIRE(route.load());
+  REQUIRE(route.segments().size() == 13);
+  for (int i = 0; i < 2; ++i) {
+    read_segment(i, route.at(i), flags);
+  }
 }
 
 // helper class for unit tests


### PR DESCRIPTION
fcam isn't used by this test
split into two tests to more easily see which part is taking the bulk of the time