### PR TITLE
replay: fix missing events before INIT_DATA

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -321,13 +321,12 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
 void Replay::startStream(const Segment *cur_segment) {
   const auto &events = cur_segment->log->events;
 
-  // get route start time from initData
-  auto it = std::find_if(events.begin(), events.end(), [](auto e) { return e->which == cereal::Event::Which::INIT_DATA; });
-  route_start_ts_ = it != events.end() ? (*it)->mono_time : events[0]->mono_time;
-  cur_mono_time_ += route_start_ts_;
+  // each segment has an INIT_DATA
+  route_start_ts_ = events.front()->mono_time;
+  cur_mono_time_ += route_start_ts_ - 1;
 
   // write CarParams
-  it = std::find_if(events.begin(), events.end(), [](auto e) { return e->which == cereal::Event::Which::CAR_PARAMS; });
+  auto it = std::find_if(events.begin(), events.end(), [](auto e) { return e->which == cereal::Event::Which::CAR_PARAMS; });
   if (it != events.end()) {
     car_fingerprint_ = (*it)->event.getCarParams().getCarFingerprint();
     capnp::MallocMessageBuilder builder;


### PR DESCRIPTION
**Issue**: replay pushes event from the INIT_DATA. but  there may be events whose mono_time is earlier than INIT_DATA.
The actual ordering of events(sorted by logreader) in segments might look like this:

> seg 0:  `event1, event2, ...INIT_DATA`
> seg 1:  `INIT_DATA, event1, event2, ...`
> ...
> seg n:  `INIT_DATA, event1, event2, ...`

**Fix**: get route start time from first event in the segment. it's always less than or equal to INIT_DATA.