### PR TITLE
fix LFS error when pushing on forks

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,4 +1,4 @@
 [lfs]
 	url = https://gitlab.com/commaai/openpilot-lfs.git/info/lfs
-	pushurl = ssh://git@gitlab.com/commaai/openpilot-lfs.git
+	pushurl = git@github.com:commaai/openpilot.git
 	locksverify = false

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,4 +1,4 @@
 [lfs]
 	url = https://gitlab.com/commaai/openpilot-lfs.git/info/lfs
-	pushurl = git@github.com:commaai/openpilot.git
+	pushurl = 
 	locksverify = false

--- a/scripts/push-lfs.sh
+++ b/scripts/push-lfs.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
-echo "WARNING: this is a script for internal use only."
+printf "WARNING: this is a script for internal use only.\n\n"
 
+printf "pushing to GitLab\n"
 git lfs push --all ssh://git@gitlab.com/commaai/openpilot-lfs.git
+
+printf "\npushing to GitHub\n"
+git lfs push --all git@github.com:commaai/openpilot.git

--- a/scripts/push-lfs.sh
+++ b/scripts/push-lfs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+echo "WARNING: this is a script for internal use only."
+
+git lfs push --all ssh://git@gitlab.com/commaai/openpilot-lfs.git


### PR DESCRIPTION
resolves #29288

Note that this doesn't generally make LFS work on forks. This simply fixes an error if a fork maintainer tries to push a rebase where there were upstream changes to LFS files. 

- [ ] `git push` works on forks with an LFS diff
- [x] CI fails if an object is missing from GitLab LFS