### PR TITLE
Simulator: fix metadrive tick frequency

### DIFF
--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -32,7 +32,7 @@ class SimulatorBridge(ABC):
     set_params_enabled()
     self.params = Params()
 
-    self.rk = Ratekeeper(100)
+    self.rk = Ratekeeper(100, None)
 
     msg = messaging.new_message('liveCalibration')
     msg.liveCalibration.validBlocks = 20
@@ -89,8 +89,6 @@ class SimulatorBridge(ABC):
     self.simulated_car_thread = threading.Thread(target=rk_loop, args=(functools.partial(self.simulated_car.update, self.simulator_state),
                                                                         100, self._exit_event))
     self.simulated_car_thread.start()
-
-    rk = Ratekeeper(100, print_delay_threshold=None)
 
     # Simulation tends to be slow in the initial steps. This prevents lagging later
     for _ in range(20):
@@ -162,4 +160,4 @@ class SimulatorBridge(ABC):
 
       self.started = True
 
-      rk.keep_time()
+      self.rk.keep_time()


### PR DESCRIPTION
metadrive was running at too high of a frequency since there were two ratekeeper instances in the bridge

also noticed that the model doesn't seem to update after the first frame in the simulator with the Optimus Prime model (if you revert that model, it works)