### PR TITLE
devcontainer: force 256 color support in shell

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
   "containerEnv": {
     "DISPLAY": "${localEnv:DISPLAY}",
     "PYTHONPATH": "${containerWorkspaceFolder}",
+    "TERM": "xterm-256color",
     "force_color_prompt": "1"
   },
   "runArgs": [


### PR DESCRIPTION
docker by default sets TERM to `xterm` which is lacking proper color support. almost every modern terminal supports this, and vscode is also hard-coding this for its integrated terminal (https://github.com/microsoft/vscode/commit/7fca8ee82da20a0130af6dbe9999f5c073b2d8c7#diff-d901fd40c1ebeef4eb74b6108ee8971b9678704ec4b7c4aad0843e8d64cdbc46)