### PR TITLE
Devcontainer: move chown to start script

### DIFF
--- a/.devcontainer/container_post_create.sh
+++ b/.devcontainer/container_post_create.sh
@@ -13,8 +13,3 @@ if [ -n "\$DISPLAY" ]; then
 fi
 EOF
 fi
-
-# These lines are temporary, to remain backwards compatible with old devcontainers
-# that were running as root and therefore had their caches written as root
-sudo chown -R $TARGET_USER: /tmp/scons_cache
-sudo chown -R $TARGET_USER: /tmp/comma_download_cache

--- a/.devcontainer/container_post_start.sh
+++ b/.devcontainer/container_post_start.sh
@@ -5,3 +5,10 @@ SUBMODULE_DIRS=$(git config --file .gitmodules --get-regexp path | awk '{ print 
 for DIR in $SUBMODULE_DIRS; do 
   git config --global --add safe.directory "$PWD/$DIR"
 done
+
+TARGET_USER=batman
+
+# These lines are temporary, to remain backwards compatible with old devcontainers
+# that were running as root and therefore had their caches written as root
+sudo chown -R $TARGET_USER: /tmp/scons_cache
+sudo chown -R $TARGET_USER: /tmp/comma_download_cache


### PR DESCRIPTION
the chown step needs to be done in the start script, because the volumes aren't mounted until that step