### PR TITLE
URLFile: don't cache non-existent file's lengths

### DIFF
--- a/tools/lib/tests/test_caching.py
+++ b/tools/lib/tests/test_caching.py
@@ -63,7 +63,7 @@ class TestFileDownload(unittest.TestCase):
     self.compare_loads(large_file_url)
 
   @parameterized.expand([(True, ), (False, )])
-  def test_exists_file(self, cache_enabled):
+  def test_recover_from_missing_file(self, cache_enabled):
     os.environ["FILEREADER_CACHE"] = "1" if cache_enabled else "0"
 
     exists_file = "http://localhost:5001/test.png"

--- a/tools/lib/tests/test_caching.py
+++ b/tools/lib/tests/test_caching.py
@@ -1,10 +1,53 @@
 #!/usr/bin/env python3
+import http.server
 import os
+from parameterized import parameterized
+import threading
 import unittest
 from openpilot.tools.lib.url_file import URLFile
 
 
+class MockRequestHandler(http.server.BaseHTTPRequestHandler):
+  FILE_EXISTS = True
+
+  def _handle_request(self, send_content):
+    if self.FILE_EXISTS:
+      self.send_response(200)
+      self.send_header("Content-Length", 4)
+    else:
+      self.send_response(404)
+    self.end_headers()
+
+    if self.FILE_EXISTS and send_content:
+      self.wfile.write(b'1234')
+
+  def do_GET(self):
+    self._handle_request(True)
+
+  def do_HEAD(self):
+    self._handle_request(False)
+
+
+class MockServer(threading.Thread):
+  def run(self):
+    self.server = http.server.HTTPServer(("127.0.0.1", 5001), MockRequestHandler)
+    self.server.serve_forever()
+
+  def stop(self):
+    self.server.shutdown()
+
+
 class TestFileDownload(unittest.TestCase):
+  server: MockServer
+
+  @classmethod
+  def setUpClass(cls):
+    cls.server = MockServer()
+    cls.server.start()
+
+  @classmethod
+  def tearDownClass(cls) -> None:
+    cls.server.stop()
 
   def compare_loads(self, url, start=0, length=None):
     """Compares range between cached and non cached version"""
@@ -58,6 +101,22 @@ class TestFileDownload(unittest.TestCase):
 
     self.compare_loads(large_file_url, length - 100, 100)
     self.compare_loads(large_file_url)
+
+  @parameterized.expand([(True, ), (False, )])
+  def test_exists_file(self, cache_enabled):
+    os.environ["FILEREADER_CACHE"] = "1" if cache_enabled else "0"
+
+    exists_file = "http://localhost:5001/test.png"
+
+    MockRequestHandler.FILE_EXISTS = False
+    file_not_exists = URLFile(exists_file)
+    length = file_not_exists.get_length()
+    self.assertEqual(length, -1)
+
+    MockRequestHandler.FILE_EXISTS = True
+    file_exists = URLFile(exists_file)
+    length = file_exists.get_length()
+    self.assertEqual(length, 4)
 
 
 if __name__ == "__main__":

--- a/tools/lib/tests/test_caching.py
+++ b/tools/lib/tests/test_caching.py
@@ -66,7 +66,7 @@ class TestFileDownload(unittest.TestCase):
   def test_recover_from_missing_file(self, cache_enabled):
     os.environ["FILEREADER_CACHE"] = "1" if cache_enabled else "0"
 
-    exists_file = "http://localhost:5001/test.png"
+    file_url = "http://localhost:5001/test.png"
 
     file_exists = False
 
@@ -78,13 +78,11 @@ class TestFileDownload(unittest.TestCase):
     patch_length = mock.patch.object(URLFile, "get_length_online", get_length_online_mock)
     patch_length.start()
     try:
-      file_not_exists = URLFile(exists_file)
-      length = file_not_exists.get_length()
+      length = URLFile(file_url).get_length()
       self.assertEqual(length, -1)
 
       file_exists = True
-      file_exists = URLFile(exists_file)
-      length = file_exists.get_length()
+      length = URLFile(file_url).get_length()
       self.assertEqual(length, 4)
     finally:
       patch_length.stop()

--- a/tools/lib/tests/test_caching.py
+++ b/tools/lib/tests/test_caching.py
@@ -2,9 +2,12 @@
 import os
 import unittest
 
-from openpilot.tools.lib.url_file import URLFile
+from pathlib import Path
 from parameterized import parameterized
 from unittest import mock
+
+from openpilot.system.hardware.hw import Paths
+from openpilot.tools.lib.url_file import URLFile
 
 
 class TestFileDownload(unittest.TestCase):
@@ -85,6 +88,9 @@ class TestFileDownload(unittest.TestCase):
       length = URLFile(file_url).get_length()
       self.assertEqual(length, 4)
     finally:
+      tempfile_length = Path(Paths.download_cache_root()) / "ba2119904385654cb0105a2da174875f8e7648db175f202ecae6d6428b0e838f_length"
+      if tempfile_length.exists():
+        tempfile_length.unlink()
       patch_length.stop()
 
 

--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -73,7 +73,7 @@ class URLFile:
           return self._length
 
     self._length = self.get_length_online()
-    if not self._force_download:
+    if not self._force_download and self._length != -1:
       with atomic_write_in_dir(file_length_path, mode="w") as file_length:
         file_length.write(str(self._length))
     return self._length


### PR DESCRIPTION
resolves: https://github.com/commaai/openpilot/issues/29919

allows for recovery if the file become available again later