### PR TITLE
devcontainer: expose zmq ports for bridging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,9 @@
     "--volume=/tmp/comma_download_cache:/tmp/comma_download_cache",
     "--volume=/tmp/devcontainer_scons_cache:/tmp/scons_cache",
     "--shm-size=1G",
-    "--add-host=host.docker.internal:host-gateway" // required to use host.docker.internal on linux
+    "--add-host=host.docker.internal:host-gateway", // required to use host.docker.internal on linux
+    "--publish=0.0.0.0:8001-8021:8001-8021", // required for ZMQ
+    "--publish=0.0.0.0:8023-8079:8023-8079"
   ],
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,7 @@
     "--volume=/tmp/devcontainer_scons_cache:/tmp/scons_cache",
     "--shm-size=1G",
     "--add-host=host.docker.internal:host-gateway", // required to use host.docker.internal on linux
-    "--publish=0.0.0.0:8001-8021:8001-8021", // required for ZMQ
-    "--publish=0.0.0.0:8023-8079:8023-8079"
+    "--publish=0.0.0.0:8070-8079:8070-8079"  // body ZMQ services
   ],
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
