### PR TITLE
Devcontainer: add special windows instructions

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -38,7 +38,7 @@ poetry shell
 scons -u -j$(nproc)
 ```
 
-## Dev Container on any Linux or macOS
+## Dev Container on any Linux, macOS, or Windows
 
 openpilot supports [Dev Containers](https://containers.dev/). Dev containers provide customizable and consistent development environment wrapped inside a container. This means you can develop in a designated environment matching our primary development target, regardless of your local setup.
 
@@ -47,6 +47,12 @@ Dev containers are supported in [multiple editors and IDEs](https://containers.d
 #### X11 forwarding on macOS
 
 GUI apps like `ui` or `cabana` can also run inside the container by leveraging X11 forwarding. To make use of it on macOS, additional configuration steps must be taken. Follow [these](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088) steps to setup X11 forwarding on macOS.
+
+#### Special Windows Instructions
+
+On Windows, you must clone openpilot into a container volume, otherwise the symlinks will be broken because Windows doesn't support them very well. Follow [these instructions](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) to get started after getting docker installed.
+
+With Windows 11, X11 forwarding should work out of the box.
 
 ## WSL on Windows
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -52,7 +52,7 @@ GUI apps like `ui` or `cabana` can also run inside the container by leveraging X
 
 On Windows, you must clone openpilot into a container volume, otherwise the symlinks will be broken because Windows doesn't support them very well. Follow [these instructions](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) to get started after getting docker installed.
 
-With Windows 11, X11 forwarding should work out of the box.
+With Windows 11 and recent Windows 10 updates, X11 forwarding should work out of the box.
 
 ## WSL on Windows
 


### PR DESCRIPTION
If you clone the repo into a container volume, everything seems to work as expected. If you try to open a local windows clone, all the symlinks are broken, which seems to just be an issue with windows and symlinks. With windows 11 and recent windows 10 updates, X11 forwarding also works out of the box, and cabana runs pretty well.