### PR TITLE
Devcontainer: run setup as batman user

### DIFF
--- a/.devcontainer/container_post_create.sh
+++ b/.devcontainer/container_post_create.sh
@@ -18,3 +18,4 @@ fi
 # that were running as root and therefore had their caches written as root
 sudo chown -R $TARGET_USER: /tmp/scons_cache
 sudo chown -R $TARGET_USER: /tmp/comma_download_cache
+sudo chown -R $TARGET_USER: /home/batman/.comma

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
       "username": "batman"
     }
   },
-  "containerUser": "root",
+  "containerUser": "batman",
   "remoteUser": "batman",
   "customizations": {
     "vscode": {

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -105,3 +105,4 @@ jobs:
       run: |
         devcontainer exec --workspace-folder . scons -j$(nproc)
         devcontainer exec --workspace-folder . pip install pip-install-test
+        devcontainer exec --workspace-folder . touch /home/batman/.comma/auth.json


### PR DESCRIPTION
otherwise the volume mounts will be created as root and require the chown