### PR TITLE
cabana: fix QCompleter leak

### DIFF
--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -395,7 +395,7 @@ QWidget *SignalItemDelegate::createEditor(QWidget *parent, const QStyleOptionVie
     else e->setValidator(double_validator);
 
     if (item->type == SignalModel::Item::Name) {
-      QCompleter *completer = new QCompleter(dbc()->signalNames());
+      QCompleter *completer = new QCompleter(dbc()->signalNames(), e);
       completer->setCaseSensitivity(Qt::CaseInsensitive);
       completer->setFilterMode(Qt::MatchContains);
       e->setCompleter(completer);


### PR DESCRIPTION
Issue: `QLineEdit::setCompleter` (https://codebrowser.dev/qt5/qtbase/src/widgets/widgets/qlineedit.cpp.html#645) will not take ownership of the completer. 

Fix : set parent to QLineEdit to delete the completer when line edit is deleted. 