### PR TITLE
hyundai: fix ioniq5/6 sorting

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -121,6 +121,11 @@ class CarInterface(CarInterfaceBase):
       ret.tireStiffnessFactor = 0.385
       if candidate in (CAR.IONIQ, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV_2019):
         ret.minSteerSpeed = 32 * CV.MPH_TO_MS
+    elif candidate in (CAR.IONIQ_5, CAR.IONIQ_6):
+      ret.mass = 1948
+      ret.wheelbase = 2.97
+      ret.steerRatio = 14.26
+      ret.tireStiffnessFactor = 0.65
     elif candidate == CAR.VELOSTER:
       ret.mass = 2917. * CV.LB_TO_KG
       ret.wheelbase = 2.80
@@ -196,11 +201,6 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 2055
       ret.wheelbase = 2.9
       ret.steerRatio = 16.
-      ret.tireStiffnessFactor = 0.65
-    elif candidate in (CAR.IONIQ_5, CAR.IONIQ_6):
-      ret.mass = 1948
-      ret.wheelbase = 2.97
-      ret.steerRatio = 14.26
       ret.tireStiffnessFactor = 0.65
     elif candidate == CAR.KIA_SPORTAGE_HYBRID_5TH_GEN:
       ret.mass = 1767.  # SX Prestige trim support only


### PR DESCRIPTION
why ioniq 5 and 6 under the kia section I don't know but it's fixed now