### PR TITLE
Metadrive: fix reset

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -50,6 +50,7 @@ class MetaDriveWorld(World):
       self.vc[1] = 0
 
     self.controls_send.send([*self.vc, self.should_reset])
+    self.should_reset = False
 
   def read_sensors(self, state: SimulatorState):
     while self.state_recv.poll(0):

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -38,7 +38,7 @@ class MetaDriveWorld(World):
     self.should_reset = False
 
   def apply_controls(self, steer_angle, throttle_out, brake_out):
-    if (time.monotonic() - self.reset_time) > 5:
+    if (time.monotonic() - self.reset_time) > 2:
       self.vc[0] = steer_angle
 
       if throttle_out:


### PR DESCRIPTION
broke reset when I moved it to another process. Also decrease reset time to 2 seconds