### PR TITLE
Silverado Stopping Threshold and stopAccel

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -224,6 +224,9 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 16.3
       ret.centerToFront = ret.wheelbase * 0.5
       ret.tireStiffnessFactor = 1.0
+      ret.stopAccel = -0.25
+      ret.vEgoStopping = 0.1
+      ret.vEgoStarting = 0.1
       # On the Bolt, the ECM and camera independently check that you are either above 5 kph or at a stop
       # with foot on brake to allow engagement, but this platform only has that check in the camera.
       # TODO: check if this is split by EV/ICE with more platforms in the future


### PR DESCRIPTION
Smooth stopping, not abrupt stopping like before. Closer to stock and more comfortable for Silverado and Sierra 1500

**Description** []
Stock Openpilot has a very harsh stopping force when it approach 0 speeds

**Verification** []
This stopping value has been physically tested and feels very smooth and stops reliably in multiple scenarios, this was only possible with farmville model with consistent stopping behind the lead car, both coming to a stop and also stopping behind a completely stopped lead. Rest of the long control tuning can be more refined, good enough for now. I would love some assistance in long tuning as it overshoots a lot, not sure if it is upper or lower bound delay issue causing this

**Route**
Route: to be provided
