### PR TITLE
modeld: don't attempt to connect extra vipc client if its not available

### DIFF
--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -111,7 +111,7 @@ def main():
 
   while not vipc_client_main.connect(False):
     time.sleep(0.1)
-  while not vipc_client_extra.connect(False):
+  while use_extra_client and not vipc_client_extra.connect(False):
     time.sleep(0.1)
 
   cloudlog.warning(f"connected main cam with buffer size: {vipc_client_main.buffer_len} ({vipc_client_main.width} x {vipc_client_main.height})")


### PR DESCRIPTION
This removes VisionIpc warnings about requesting non-existing buffer

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
