### PR TITLE
Metadrive: no preloading models

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -112,7 +112,8 @@ class MetaDriveBridge(SimulatorBridge):
         ]
       ),
       decision_repeat=1,
-      physics_world_step_size=self.TICKS_PER_FRAME/100
+      physics_world_step_size=self.TICKS_PER_FRAME/100,
+      preload_models=False
     )
 
     return MetaDriveWorld(config)


### PR DESCRIPTION
disable preloading saves  ~20 seconds on startup because it load a bunch of models that we aren't actually using anywhere