### PR TITLE
Honda: add missing programmedFuelInjection, shiftByWire, and transmis…

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -1333,6 +1333,15 @@ FW_VERSIONS = {
     ],
   },
   CAR.RIDGELINE: {
+    (Ecu.programmedFuelInjection, 0x18da10f1, None): [
+      b'37805-5MJ-CA20\x00\x00',
+    ],
+    (Ecu.shiftByWire, 0x18da0bf1, None): [
+      b'54008-TG7-A530\x00\x00',
+    ],
+    (Ecu.transmission, 0x18da1ef1, None): [
+      b'28101-5MK-A000\x00\x00',
+    ],
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-T6Z-A020\x00\x00',
       b'39990-T6Z-A030\x00\x00',


### PR DESCRIPTION
Honda: add missing programmedFuelInjection, shiftByWire, and transmission FW for 2023 Honda Ridgeline

programmedFuelInjection, 0x18da10f1, b'37805-5MJ-CA20\x00\x00'
shiftByWire, 0x18da0bf1, b'54008-TG7-A530\x00\x00'
transmission, 0x18da1ef1, b'28101-5MK-A000\x00\x00'

Route: 49eb8c6a69caa049|2023-10-04--19-18-23--0