### PR TITLE
Codecov: ignore tests files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,5 @@ coverage:
         informational: true
     patch: off
 
+ignore:
+  - "**/test_*.py"


### PR DESCRIPTION
don't count the tests themselves as coverable

leads to confusing codecov changes: [ex: in this PR](https://app.codecov.io/gh/commaai/openpilot/pull/30189?src=pr&el=h1&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term=commaai)

(the same tests are skipped, but with pytest instead of unittest.SkipTest)