### PR TITLE
cabana: fix crash when switching dbc file

### DIFF
--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -405,16 +405,15 @@ void ChartsWidget::removeAll() {
     tabbar->removeTab(1);
   }
   tab_charts.clear();
-  zoomReset();
 
   if (!charts.isEmpty()) {
     for (auto c : charts) {
       delete c;
     }
     charts.clear();
-    updateToolBar();
     emit seriesChanged();
   }
+  zoomReset();
 }
 
 void ChartsWidget::alignCharts() {


### PR DESCRIPTION
`Resetzoom` should be called after all charts have been deleted.Otherwise it may access pointers to signals that are no longer valid.