### PR TITLE
ui.py: support strided buffer

### DIFF
--- a/tools/replay/ui.py
+++ b/tools/replay/ui.py
@@ -116,9 +116,9 @@ def ui_thread(addr):
     if yuv_img_raw is None or not yuv_img_raw.data.any():
       continue
 
-    imgff = np.frombuffer(yuv_img_raw.data, dtype=np.uint8).reshape((vipc_client.height * 3 // 2, vipc_client.width))
+    imgff = np.frombuffer(yuv_img_raw.data, dtype=np.uint8).reshape((len(yuv_img_raw.data) // vipc_client.stride, vipc_client.stride))
     num_px = vipc_client.width * vipc_client.height
-    bgr = cv2.cvtColor(imgff, cv2.COLOR_YUV2RGB_NV12)
+    bgr = cv2.cvtColor(imgff[:vipc_client.height * 3 // 2, :vipc_client.width], cv2.COLOR_YUV2RGB_NV12)
 
     zoom_matrix = _BB_TO_FULL_FRAME[num_px]
     cv2.warpAffine(bgr, zoom_matrix[:2], (img.shape[1], img.shape[0]), dst=img, flags=cv2.WARP_INVERSE_MAP)


### PR DESCRIPTION
this PR fixed the crash after 3c94d953ab9fcaf8ee2371af3f269ae46d3563c6

```
    imgff = np.frombuffer(yuv_img_raw.data, dtype=np.uint8).reshape((vipc_client.height * 3 // 2, vipc_client.width))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: cannot reshape array of size 4804608 into shape (1812,1928)
```
