### PR TITLE
Check for implicit None returns in selfdrive/car/

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Any
 
 from cereal import car
 from openpilot.common.numpy_fast import clip, interp
@@ -9,16 +10,18 @@ from openpilot.selfdrive.car.honda import hondacan
 from openpilot.selfdrive.car.honda.values import CruiseButtons, VISUAL_HUD, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, HONDA_NIDEC_ALT_PCM_ACCEL, CarControllerParams
 from openpilot.selfdrive.controls.lib.drive_helpers import rate_limit
 
+NoImplicitAny = Any | Any
+
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 LongCtrlState = car.CarControl.Actuators.LongControlState
 
 
-def compute_gb_honda_bosch(accel, speed):
+def compute_gb_honda_bosch(accel, speed) -> NoImplicitAny:
   # TODO returns 0s, is unused
   return 0.0, 0.0
 
 
-def compute_gb_honda_nidec(accel, speed):
+def compute_gb_honda_nidec(accel, speed) -> NoImplicitAny:
   creep_brake = 0.0
   creep_speed = 2.3
   creep_brake_value = 0.15
@@ -28,7 +31,7 @@ def compute_gb_honda_nidec(accel, speed):
   return clip(gb, 0.0, 1.0), clip(-gb, 0.0, 1.0)
 
 
-def compute_gas_brake(accel, speed, fingerprint):
+def compute_gas_brake(accel, speed, fingerprint) -> NoImplicitAny:
   if fingerprint in HONDA_BOSCH:
     return compute_gb_honda_bosch(accel, speed)
   else:
@@ -36,7 +39,7 @@ def compute_gas_brake(accel, speed, fingerprint):
 
 
 # TODO not clear this does anything useful
-def actuator_hysteresis(brake, braking, brake_steady, v_ego, car_fingerprint):
+def actuator_hysteresis(brake, braking, brake_steady, v_ego, car_fingerprint) -> NoImplicitAny:
   # hyst params
   brake_hyst_on = 0.02    # to activate brakes exceed this value
   brake_hyst_off = 0.005  # to deactivate brakes below this value
@@ -59,7 +62,7 @@ def actuator_hysteresis(brake, braking, brake_steady, v_ego, car_fingerprint):
   return brake, braking, brake_steady
 
 
-def brake_pump_hysteresis(apply_brake, apply_brake_last, last_pump_ts, ts):
+def brake_pump_hysteresis(apply_brake, apply_brake_last, last_pump_ts, ts) -> NoImplicitAny:
   pump_on = False
 
   # reset pump timer if:
@@ -76,7 +79,7 @@ def brake_pump_hysteresis(apply_brake, apply_brake_last, last_pump_ts, ts):
   return pump_on, last_pump_ts
 
 
-def process_hud_alert(hud_alert):
+def process_hud_alert(hud_alert) -> NoImplicitAny:
   # initialize to no alert
   fcw_display = 0
   steer_required = 0
@@ -98,7 +101,7 @@ HUDData = namedtuple("HUDData",
                       "lanes_visible", "fcw", "acc_alert", "steer_required"])
 
 
-def rate_limit_steer(new_steer, last_steer):
+def rate_limit_steer(new_steer, last_steer) -> NoImplicitAny:
   # TODO just hardcoded ramp to min/max in 0.33s for all Honda
   MAX_DELTA = 3 * DT_CTRL
   return clip(new_steer, last_steer - MAX_DELTA, last_steer + MAX_DELTA)
@@ -124,7 +127,7 @@ class CarController:
     self.brake = 0.0
     self.last_steer = 0.0
 
-  def update(self, CC, CS, now_nanos):
+  def update(self, CC, CS, now_nanos) -> NoImplicitAny:
     actuators = CC.actuators
     hud_control = CC.hudControl
     conversion = hondacan.get_cruise_speed_conversion(self.CP.carFingerprint, CS.is_metric)

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
@@ -11,10 +12,12 @@ from openpilot.selfdrive.car.honda.values import CAR, DBC, STEER_THRESHOLD, HOND
                                                  HONDA_BOSCH_RADARLESS
 from openpilot.selfdrive.car.interfaces import CarStateBase
 
+NoImplicitAny = Any | Any
+
 TransmissionType = car.CarParams.TransmissionType
 
 
-def get_can_messages(CP, gearbox_msg):
+def get_can_messages(CP, gearbox_msg) -> NoImplicitAny:
   messages = [
     ("ENGINE_DATA", 100),
     ("WHEEL_SPEEDS", 50),
@@ -108,7 +111,7 @@ class CarState(CarStateBase):
     # However, on cars without a digital speedometer this is not always present (HRV, FIT, CRV 2016, ILX and RDX)
     self.dash_speed_seen = False
 
-  def update(self, cp, cp_cam, cp_body):
+  def update(self, cp, cp_cam, cp_body) -> NoImplicitAny:
     ret = car.CarState.new_message()
 
     # car params
@@ -265,12 +268,12 @@ class CarState(CarStateBase):
 
     return ret
 
-  def get_can_parser(self, CP):
+  def get_can_parser(self, CP) -> NoImplicitAny:
     messages = get_can_messages(CP, self.gearbox_msg)
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, get_pt_bus(CP.carFingerprint))
 
   @staticmethod
-  def get_cam_can_parser(CP):
+  def get_cam_can_parser(CP) -> NoImplicitAny:
     messages = [
       ("STEERING_CONTROL", 100),
     ]
@@ -290,7 +293,7 @@ class CarState(CarStateBase):
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, 2)
 
   @staticmethod
-  def get_body_can_parser(CP):
+  def get_body_can_parser(CP) -> NoImplicitAny:
     if CP.enableBsm:
       messages = [
         ("BSM_STATUS_LEFT", 3),

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -1,5 +1,9 @@
+from typing import Any
+
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car.honda.values import HondaFlags, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, CAR, CarControllerParams
+
+NoImplicitAny = Any | Any
 
 # CAN bus layout with relay
 # 0 = ACC-CAN - radar side
@@ -8,11 +12,11 @@ from openpilot.selfdrive.car.honda.values import HondaFlags, HONDA_BOSCH, HONDA_
 # 3 = F-CAN A - OBDII port
 
 
-def get_pt_bus(car_fingerprint):
+def get_pt_bus(car_fingerprint) -> NoImplicitAny:
   return 1 if car_fingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) else 0
 
 
-def get_lkas_cmd_bus(car_fingerprint, radar_disabled=False):
+def get_lkas_cmd_bus(car_fingerprint, radar_disabled=False) -> NoImplicitAny:
   no_radar = car_fingerprint in HONDA_BOSCH_RADARLESS
   if radar_disabled or no_radar:
     # when radar is disabled, steering commands are sent directly to powertrain bus
@@ -26,7 +30,7 @@ def get_cruise_speed_conversion(car_fingerprint: str, is_metric: bool) -> float:
   return CV.MPH_TO_MS if car_fingerprint in HONDA_BOSCH_RADARLESS and not is_metric else CV.KPH_TO_MS
 
 
-def create_brake_command(packer, apply_brake, pump_on, pcm_override, pcm_cancel_cmd, fcw, car_fingerprint, stock_brake):
+def create_brake_command(packer, apply_brake, pump_on, pcm_override, pcm_cancel_cmd, fcw, car_fingerprint, stock_brake) -> NoImplicitAny:
   # TODO: do we loose pressure if we keep pump off for long?
   brakelights = apply_brake > 0
   brake_rq = apply_brake > 0
@@ -51,7 +55,7 @@ def create_brake_command(packer, apply_brake, pump_on, pcm_override, pcm_cancel_
   return packer.make_can_msg("BRAKE_COMMAND", bus, values)
 
 
-def create_acc_commands(packer, enabled, active, accel, gas, stopping_counter, car_fingerprint):
+def create_acc_commands(packer, enabled, active, accel, gas, stopping_counter, car_fingerprint) -> NoImplicitAny:
   commands = []
   bus = get_pt_bus(car_fingerprint)
   min_gas_accel = CarControllerParams.BOSCH_GAS_LOOKUP_BP[0]
@@ -96,7 +100,7 @@ def create_acc_commands(packer, enabled, active, accel, gas, stopping_counter, c
   return commands
 
 
-def create_steering_control(packer, apply_steer, lkas_active, car_fingerprint, radar_disabled):
+def create_steering_control(packer, apply_steer, lkas_active, car_fingerprint, radar_disabled) -> NoImplicitAny:
   values = {
     "STEER_TORQUE": apply_steer if lkas_active else 0,
     "STEER_TORQUE_REQUEST": lkas_active,
@@ -105,7 +109,7 @@ def create_steering_control(packer, apply_steer, lkas_active, car_fingerprint, r
   return packer.make_can_msg("STEERING_CONTROL", bus, values)
 
 
-def create_bosch_supplemental_1(packer, car_fingerprint):
+def create_bosch_supplemental_1(packer, car_fingerprint) -> NoImplicitAny:
   # non-active params
   values = {
     "SET_ME_X04": 0x04,
@@ -116,7 +120,7 @@ def create_bosch_supplemental_1(packer, car_fingerprint):
   return packer.make_can_msg("BOSCH_SUPPLEMENTAL_1", bus, values)
 
 
-def create_ui_commands(packer, CP, enabled, pcm_speed, hud, is_metric, acc_hud, lkas_hud):
+def create_ui_commands(packer, CP, enabled, pcm_speed, hud, is_metric, acc_hud, lkas_hud) -> NoImplicitAny:
   commands = []
   bus_pt = get_pt_bus(CP.carFingerprint)
   radar_disabled = CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and CP.openpilotLongitudinalControl
@@ -181,7 +185,7 @@ def create_ui_commands(packer, CP, enabled, pcm_speed, hud, is_metric, acc_hud, 
   return commands
 
 
-def spam_buttons_command(packer, button_val, car_fingerprint):
+def spam_buttons_command(packer, button_val, car_fingerprint) -> NoImplicitAny:
   values = {
     'CRUISE_BUTTONS': button_val,
     'CRUISE_SETTING': 0,

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from typing import Any
+
 from cereal import car
 from panda import Panda
 from openpilot.common.conversions import Conversions as CV
@@ -8,6 +10,8 @@ from openpilot.selfdrive.car.honda.values import CarControllerParams, CruiseButt
 from openpilot.selfdrive.car import create_button_events, get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.car.disable_ecu import disable_ecu
+
+NoImplicitAny = Any | Any
 
 
 ButtonType = car.CarState.ButtonEvent.Type
@@ -19,7 +23,7 @@ BUTTONS_DICT = {CruiseButtons.RES_ACCEL: ButtonType.accelCruise, CruiseButtons.D
 
 class CarInterface(CarInterfaceBase):
   @staticmethod
-  def get_pid_accel_limits(CP, current_speed, cruise_speed):
+  def get_pid_accel_limits(CP, current_speed, cruise_speed) -> NoImplicitAny:
     if CP.carFingerprint in HONDA_BOSCH:
       return CarControllerParams.BOSCH_ACCEL_MIN, CarControllerParams.BOSCH_ACCEL_MAX
     elif CP.enableGasInterceptor:
@@ -32,7 +36,7 @@ class CarInterface(CarInterfaceBase):
       return CarControllerParams.NIDEC_ACCEL_MIN, interp(current_speed, ACCEL_MAX_BP, ACCEL_MAX_VALS)
 
   @staticmethod
-  def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs):
+  def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs) -> NoImplicitAny:
     ret.carName = "honda"
 
     if candidate in HONDA_BOSCH:
@@ -305,7 +309,7 @@ class CarInterface(CarInterfaceBase):
       disable_ecu(logcan, sendcan, bus=1, addr=0x18DAB0F1, com_cont_req=b'\x28\x83\x03')
 
   # returns a car.CarState
-  def _update(self, c):
+  def _update(self, c) -> NoImplicitAny:
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_body)
 
     ret.buttonEvents = [
@@ -339,5 +343,5 @@ class CarInterface(CarInterfaceBase):
 
   # pass in a car.CarControl
   # to be called @ 100hz
-  def apply(self, c, now_nanos):
+  def apply(self, c, now_nanos) -> NoImplicitAny:
     return self.CC.update(c, self.CS, now_nanos)

--- a/selfdrive/car/honda/radar_interface.py
+++ b/selfdrive/car/honda/radar_interface.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
+from typing import Any
+
 from cereal import car
 from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 from openpilot.selfdrive.car.honda.values import DBC
 
+NoImplicitAny = Any | Any
 
-def _create_nidec_can_parser(car_fingerprint):
+
+def _create_nidec_can_parser(car_fingerprint) -> NoImplicitAny:
   radar_messages = [0x400] + list(range(0x430, 0x43A)) + list(range(0x440, 0x446))
   messages = [(m, 20) for m in radar_messages]
   return CANParser(DBC[car_fingerprint]['radar'], messages, 1)
@@ -30,7 +34,7 @@ class RadarInterface(RadarInterfaceBase):
     self.trigger_msg = 0x445
     self.updated_messages = set()
 
-  def update(self, can_strings):
+  def update(self, can_strings) -> NoImplicitAny:
     # in Bosch radar and we are only steering for now, so sleep 0.05s to keep
     # radard at 20Hz and return no points
     if self.radar_off_can:
@@ -46,7 +50,7 @@ class RadarInterface(RadarInterfaceBase):
     self.updated_messages.clear()
     return rr
 
-  def _update(self, updated_messages):
+  def _update(self, updated_messages) -> NoImplicitAny:
     ret = car.RadarData.new_message()
 
     for ii in sorted(updated_messages):

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -1,3 +1,4 @@
+from typing import Any
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import clip
@@ -7,6 +8,9 @@ from openpilot.selfdrive.car import apply_driver_steer_torque_limits, common_fau
 from openpilot.selfdrive.car.hyundai import hyundaicanfd, hyundaican
 from openpilot.selfdrive.car.hyundai.hyundaicanfd import CanBus
 from openpilot.selfdrive.car.hyundai.values import HyundaiFlags, Buttons, CarControllerParams, CANFD_CAR, CAR
+
+
+NoImplicitAny = Any | Any
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 LongCtrlState = car.CarControl.Actuators.LongControlState
@@ -18,7 +22,7 @@ MAX_ANGLE_FRAMES = 89
 MAX_ANGLE_CONSECUTIVE_FRAMES = 2
 
 
-def process_hud_alert(enabled, fingerprint, hud_control):
+def process_hud_alert(enabled, fingerprint, hud_control) -> NoImplicitAny:
   sys_warning = (hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw))
 
   # initialize to no line visible
@@ -56,7 +60,7 @@ class CarController:
     self.car_fingerprint = CP.carFingerprint
     self.last_button_frame = 0
 
-  def update(self, CC, CS, now_nanos):
+  def update(self, CC, CS, now_nanos) -> NoImplicitAny:
     actuators = CC.actuators
     hud_control = CC.hudControl
 
@@ -170,7 +174,7 @@ class CarController:
     self.frame += 1
     return new_actuators, can_sends
 
-  def create_button_messages(self, CC: car.CarControl, CS: car.CarState, use_clu11: bool):
+  def create_button_messages(self, CC: car.CarControl, CS: car.CarState, use_clu11: bool) -> NoImplicitAny:
     can_sends = []
     if use_clu11:
       if CC.cruiseControl.cancel:

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -1,6 +1,7 @@
 from collections import deque
 import copy
 import math
+from typing import Any
 
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
@@ -10,6 +11,9 @@ from openpilot.selfdrive.car.hyundai.hyundaicanfd import CanBus
 from openpilot.selfdrive.car.hyundai.values import HyundaiFlags, CAR, DBC, CAN_GEARS, CAMERA_SCC_CAR, \
                                                    CANFD_CAR, EV_CAR, HYBRID_CAR, Buttons, CarControllerParams
 from openpilot.selfdrive.car.interfaces import CarStateBase
+
+
+NoImplicitAny = Any | Any
 
 PREV_BUTTON_SAMPLES = 8
 CLUSTER_SAMPLE_RATE = 20  # frames
@@ -52,7 +56,7 @@ class CarState(CarStateBase):
 
     self.params = CarControllerParams(CP)
 
-  def update(self, cp, cp_cam):
+  def update(self, cp, cp_cam) -> NoImplicitAny:
     if self.CP.carFingerprint in CANFD_CAR:
       return self.update_canfd(cp, cp_cam)
 
@@ -165,7 +169,7 @@ class CarState(CarStateBase):
 
     return ret
 
-  def update_canfd(self, cp, cp_cam):
+  def update_canfd(self, cp, cp_cam) -> NoImplicitAny:
     ret = car.CarState.new_message()
 
     self.is_metric = cp.vl["CRUISE_BUTTONS_ALT"]["DISTANCE_UNIT"] != 1
@@ -247,7 +251,7 @@ class CarState(CarStateBase):
 
     return ret
 
-  def get_can_parser(self, CP):
+  def get_can_parser(self, CP) -> NoImplicitAny:
     if CP.carFingerprint in CANFD_CAR:
       return self.get_can_parser_canfd(CP)
 
@@ -297,7 +301,7 @@ class CarState(CarStateBase):
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, 0)
 
   @staticmethod
-  def get_cam_can_parser(CP):
+  def get_cam_can_parser(CP) -> NoImplicitAny:
     if CP.carFingerprint in CANFD_CAR:
       return CarState.get_cam_can_parser_canfd(CP)
 
@@ -316,7 +320,7 @@ class CarState(CarStateBase):
 
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, 2)
 
-  def get_can_parser_canfd(self, CP):
+  def get_can_parser_canfd(self, CP) -> NoImplicitAny:
     messages = [
       (self.gear_msg_canfd, 100),
       (self.accelerator_msg_canfd, 100),
@@ -352,7 +356,7 @@ class CarState(CarStateBase):
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, CanBus(CP).ECAN)
 
   @staticmethod
-  def get_cam_can_parser_canfd(CP):
+  def get_cam_can_parser_canfd(CP) -> NoImplicitAny:
     messages = []
     if CP.flags & HyundaiFlags.CANFD_HDA2:
       block_lfa_msg = "CAM_0x362" if CP.flags & HyundaiFlags.CANFD_HDA2_ALT_STEERING else "CAM_0x2a4"

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -1,12 +1,15 @@
 import crcmod
+from typing import Any
 from openpilot.selfdrive.car.hyundai.values import CAR, CHECKSUM, CAMERA_SCC_CAR
+
+NoImplicitAny = Any | Any
 
 hyundai_checksum = crcmod.mkCrcFun(0x11D, initCrc=0xFD, rev=False, xorOut=0xdf)
 
 def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
                   torque_fault, lkas11, sys_warning, sys_state, enabled,
                   left_lane, right_lane,
-                  left_lane_depart, right_lane_depart):
+                  left_lane_depart, right_lane_depart) -> NoImplicitAny:
   values = {s: lkas11[s] for s in [
     "CF_Lkas_LdwsActivemode",
     "CF_Lkas_LdwsSysState",
@@ -95,7 +98,7 @@ def create_lkas11(packer, frame, car_fingerprint, apply_steer, steer_req,
   return packer.make_can_msg("LKAS11", 0, values)
 
 
-def create_clu11(packer, frame, clu11, button, car_fingerprint):
+def create_clu11(packer, frame, clu11, button, car_fingerprint) -> NoImplicitAny:
   values = {s: clu11[s] for s in [
     "CF_Clu_CruiseSwState",
     "CF_Clu_CruiseSwMain",
@@ -117,7 +120,7 @@ def create_clu11(packer, frame, clu11, button, car_fingerprint):
   return packer.make_can_msg("CLU11", bus, values)
 
 
-def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
+def create_lfahda_mfc(packer, enabled, hda_set_speed=0) -> NoImplicitAny:
   values = {
     "LFA_Icon_State": 2 if enabled else 0,
     "HDA_Active": 1 if hda_set_speed else 0,
@@ -126,7 +129,7 @@ def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 
-def create_acc_commands(packer, enabled, accel, upper_jerk, idx, lead_visible, set_speed, stopping, long_override, use_fca):
+def create_acc_commands(packer, enabled, accel, upper_jerk, idx, lead_visible, set_speed, stopping, long_override, use_fca) -> NoImplicitAny:
   commands = []
 
   scc11_values = {
@@ -187,7 +190,7 @@ def create_acc_commands(packer, enabled, accel, upper_jerk, idx, lead_visible, s
 
   return commands
 
-def create_acc_opt(packer):
+def create_acc_opt(packer) -> NoImplicitAny:
   commands = []
 
   scc13_values = {
@@ -206,7 +209,7 @@ def create_acc_opt(packer):
 
   return commands
 
-def create_frt_radar_opt(packer):
+def create_frt_radar_opt(packer) -> NoImplicitAny:
   frt_radar11_values = {
     "CF_FCA_Equip_Front_Radar": 1,
   }

--- a/selfdrive/car/hyundai/hyundaicanfd.py
+++ b/selfdrive/car/hyundai/hyundaicanfd.py
@@ -1,7 +1,11 @@
+from typing import Any, Dict
+
 from openpilot.common.numpy_fast import clip
 from openpilot.selfdrive.car import CanBusBase
 from openpilot.selfdrive.car.hyundai.values import HyundaiFlags
 
+
+NoImplicitAny = Any | Any
 
 class CanBus(CanBusBase):
   def __init__(self, CP, hda2=None, fingerprint=None) -> None:
@@ -35,9 +39,9 @@ class CanBus(CanBusBase):
     return self._cam
 
 
-def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_steer):
+def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_steer) -> NoImplicitAny:
 
-  ret = []
+  ret = [] # List
 
   values = {
     "LKA_MODE": 2,
@@ -61,7 +65,7 @@ def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_steer):
 
   return ret
 
-def create_suppress_lfa(packer, CAN, hda2_lfa_block_msg, hda2_alt_steering):
+def create_suppress_lfa(packer, CAN, hda2_lfa_block_msg, hda2_alt_steering) -> NoImplicitAny:
   suppress_msg = "CAM_0x362" if hda2_alt_steering else "CAM_0x2a4"
   msg_bytes = 32 if hda2_alt_steering else 24
 
@@ -73,7 +77,7 @@ def create_suppress_lfa(packer, CAN, hda2_lfa_block_msg, hda2_alt_steering):
   values["RIGHT_LANE_LINE"] = 0
   return packer.make_can_msg(suppress_msg, CAN.ACAN, values)
 
-def create_buttons(packer, CP, CAN, cnt, btn):
+def create_buttons(packer, CP, CAN, cnt, btn) -> NoImplicitAny:
   values = {
     "COUNTER": cnt,
     "SET_ME_1": 1,
@@ -83,7 +87,7 @@ def create_buttons(packer, CP, CAN, cnt, btn):
   bus = CAN.ECAN if CP.flags & HyundaiFlags.CANFD_HDA2 else CAN.CAM
   return packer.make_can_msg("CRUISE_BUTTONS", bus, values)
 
-def create_acc_cancel(packer, CP, CAN, cruise_info_copy):
+def create_acc_cancel(packer, CP, CAN, cruise_info_copy) -> NoImplicitAny:
   # TODO: why do we copy different values here?
   if CP.flags & HyundaiFlags.CANFD_CAMERA_SCC.value:
     values = {s: cruise_info_copy[s] for s in [
@@ -113,7 +117,7 @@ def create_acc_cancel(packer, CP, CAN, cruise_info_copy):
   })
   return packer.make_can_msg("SCC_CONTROL", CAN.ECAN, values)
 
-def create_lfahda_cluster(packer, CAN, enabled):
+def create_lfahda_cluster(packer, CAN, enabled) -> NoImplicitAny:
   values = {
     "HDA_ICON": 1 if enabled else 0,
     "LFA_ICON": 2 if enabled else 0,
@@ -121,7 +125,7 @@ def create_lfahda_cluster(packer, CAN, enabled):
   return packer.make_can_msg("LFAHDA_CLUSTER", CAN.ECAN, values)
 
 
-def create_acc_control(packer, CAN, enabled, accel_last, accel, stopping, gas_override, set_speed):
+def create_acc_control(packer, CAN, enabled, accel_last, accel, stopping, gas_override, set_speed) -> NoImplicitAny:
   jerk = 5
   jn = jerk / 50
   if not enabled or gas_override:
@@ -152,10 +156,10 @@ def create_acc_control(packer, CAN, enabled, accel_last, accel, stopping, gas_ov
   return packer.make_can_msg("SCC_CONTROL", CAN.ECAN, values)
 
 
-def create_spas_messages(packer, CAN, frame, left_blink, right_blink):
+def create_spas_messages(packer, CAN, frame, left_blink, right_blink) -> NoImplicitAny:
   ret = []
 
-  values = {
+  values:Dict[str,int] = {
   }
   ret.append(packer.make_can_msg("SPAS1", CAN.ECAN, values))
 
@@ -172,13 +176,13 @@ def create_spas_messages(packer, CAN, frame, left_blink, right_blink):
   return ret
 
 
-def create_adrv_messages(packer, CAN, frame):
+def create_adrv_messages(packer, CAN, frame) -> NoImplicitAny:
   # messages needed to car happy after disabling
   # the ADAS Driving ECU to do longitudinal control
 
   ret = []
 
-  values = {
+  values:Dict[str,int] = {
   }
   ret.append(packer.make_can_msg("ADRV_0x51", CAN.ACAN, values))
 

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from cereal import car
 from panda import Panda
 from openpilot.common.conversions import Conversions as CV
@@ -10,6 +12,8 @@ from openpilot.selfdrive.car import create_button_events, get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.car.disable_ecu import disable_ecu
 
+NoImplicitAny = Any | Any
+
 Ecu = car.CarParams.Ecu
 ButtonType = car.CarState.ButtonEvent.Type
 EventName = car.CarEvent.EventName
@@ -20,7 +24,7 @@ BUTTONS_DICT = {Buttons.RES_ACCEL: ButtonType.accelCruise, Buttons.SET_DECEL: Bu
 
 class CarInterface(CarInterfaceBase):
   @staticmethod
-  def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs):
+  def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs) -> NoImplicitAny:
     ret.carName = "hyundai"
     ret.radarUnavailable = RADAR_START_ADDR not in fingerprint[1] or DBC[ret.carFingerprint]["radar"] is None
 
@@ -333,7 +337,7 @@ class CarInterface(CarInterfaceBase):
     if CP.flags & HyundaiFlags.ENABLE_BLINKERS:
       disable_ecu(logcan, sendcan, bus=CanBus(CP).ECAN, addr=0x7B1, com_cont_req=b'\x28\x83\x01')
 
-  def _update(self, c):
+  def _update(self, c) -> NoImplicitAny:
     ret = self.CS.update(self.cp, self.cp_cam)
 
     if self.CS.CP.openpilotLongitudinalControl:
@@ -357,5 +361,5 @@ class CarInterface(CarInterfaceBase):
 
     return ret
 
-  def apply(self, c, now_nanos):
+  def apply(self, c, now_nanos) -> NoImplicitAny:
     return self.CC.update(c, self.CS, now_nanos)

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -1,16 +1,19 @@
 import math
+from typing import Any
 
 from cereal import car
 from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 from openpilot.selfdrive.car.hyundai.values import DBC
 
+NoImplicitAny = Any | Any
+
 RADAR_START_ADDR = 0x500
 RADAR_MSG_COUNT = 32
 
 # POC for parsing corner radars: https://github.com/commaai/openpilot/pull/24221/
 
-def get_radar_can_parser(CP):
+def get_radar_can_parser(CP) -> NoImplicitAny:
   if DBC[CP.carFingerprint]['radar'] is None:
     return None
 
@@ -28,7 +31,7 @@ class RadarInterface(RadarInterfaceBase):
     self.radar_off_can = CP.radarUnavailable
     self.rcp = get_radar_can_parser(CP)
 
-  def update(self, can_strings):
+  def update(self, can_strings) -> NoImplicitAny:
     if self.radar_off_can or (self.rcp is None):
       return super().update(None)
 
@@ -43,7 +46,7 @@ class RadarInterface(RadarInterfaceBase):
 
     return rr
 
-  def _update(self, updated_messages):
+  def _update(self, updated_messages) -> NoImplicitAny:
     ret = car.RadarData.new_message()
     if self.rcp is None:
       return ret

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from cereal import car
 from openpilot.common.numpy_fast import clip, interp
 from openpilot.selfdrive.car import apply_meas_steer_torque_limits, apply_std_steer_angle_limits, common_fault_avoidance, \
@@ -7,6 +9,8 @@ from openpilot.selfdrive.car.toyota.values import CAR, STATIC_DSU_MSGS, NO_STOP_
                                         MIN_ACC_SPEED, PEDAL_TRANSITION, CarControllerParams, ToyotaFlags, \
                                         UNSUPPORTED_DSU_CAR
 from opendbc.can.packer import CANPacker
+
+NoImplicitAny = Any | Any
 
 SteerControlType = car.CarParams.SteerControlType
 VisualAlert = car.CarControl.HUDControl.VisualAlert
@@ -41,7 +45,7 @@ class CarController:
     self.gas = 0
     self.accel = 0
 
-  def update(self, CC, CS, now_nanos):
+  def update(self, CC, CS, now_nanos) -> NoImplicitAny:
     actuators = CC.actuators
     hud_control = CC.hudControl
     pcm_cancel_cmd = CC.cruiseControl.cancel

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Any
 
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
@@ -10,6 +11,8 @@ from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, NO_STOP_TIMER_CAR, \
                                                   TSS2_CAR, RADAR_ACC_CAR, EPS_SCALE, UNSUPPORTED_DSU_CAR
+
+NoImplicitAny = Any | Any
 
 SteerControlType = car.CarParams.SteerControlType
 
@@ -44,7 +47,7 @@ class CarState(CarStateBase):
     self.acc_type = 1
     self.lkas_hud = {}
 
-  def update(self, cp, cp_cam):
+  def update(self, cp, cp_cam) -> NoImplicitAny:
     ret = car.CarState.new_message()
 
     ret.doorOpen = any([cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_FL"], cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_FR"],
@@ -164,7 +167,7 @@ class CarState(CarStateBase):
     return ret
 
   @staticmethod
-  def get_can_parser(CP):
+  def get_can_parser(CP) -> NoImplicitAny:
     messages = [
       ("GEAR_PACKET", 1),
       ("LIGHT_STALK", 1),
@@ -211,7 +214,7 @@ class CarState(CarStateBase):
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, 0)
 
   @staticmethod
-  def get_cam_can_parser(CP):
+  def get_cam_can_parser(CP) -> NoImplicitAny:
     messages = []
 
     if CP.carFingerprint != CAR.PRIUS_V:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from panda import Panda
@@ -8,17 +10,19 @@ from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.disable_ecu import disable_ecu
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 
+NoImplicitAny = Any | Any
+
 EventName = car.CarEvent.EventName
 SteerControlType = car.CarParams.SteerControlType
 
 
 class CarInterface(CarInterfaceBase):
   @staticmethod
-  def get_pid_accel_limits(CP, current_speed, cruise_speed):
+  def get_pid_accel_limits(CP, current_speed, cruise_speed) -> NoImplicitAny:
     return CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX
 
   @staticmethod
-  def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs):
+  def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs) -> NoImplicitAny:
     ret.carName = "toyota"
     ret.safetyConfigs = [get_safety_config(car.CarParams.SafetyModel.toyota)]
     ret.safetyConfigs[0].safetyParam = EPS_SCALE[candidate]
@@ -277,7 +281,7 @@ class CarInterface(CarInterfaceBase):
       disable_ecu(logcan, sendcan, bus=0, addr=0x750, sub_addr=0xf, com_cont_req=communication_control)
 
   # returns a car.CarState
-  def _update(self, c):
+  def _update(self, c) -> NoImplicitAny:
     ret = self.CS.update(self.cp, self.cp_cam)
 
     # events
@@ -308,5 +312,5 @@ class CarInterface(CarInterfaceBase):
 
   # pass in a car.CarControl
   # to be called @ 100hz
-  def apply(self, c, now_nanos):
+  def apply(self, c, now_nanos) -> NoImplicitAny:
     return self.CC.update(c, self.CS, now_nanos)

--- a/selfdrive/car/toyota/radar_interface.py
+++ b/selfdrive/car/toyota/radar_interface.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
+from typing import Any
+
 from opendbc.can.parser import CANParser
 from cereal import car
 from openpilot.selfdrive.car.toyota.values import DBC, TSS2_CAR
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
+NoImplicitAny = Any | Any
 
-def _create_radar_can_parser(car_fingerprint):
+def _create_radar_can_parser(car_fingerprint) -> NoImplicitAny:
   if car_fingerprint in TSS2_CAR:
     RADAR_A_MSGS = list(range(0x180, 0x190))
     RADAR_B_MSGS = list(range(0x190, 0x1a0))
@@ -38,7 +41,7 @@ class RadarInterface(RadarInterfaceBase):
     self.trigger_msg = self.RADAR_B_MSGS[-1]
     self.updated_messages = set()
 
-  def update(self, can_strings):
+  def update(self, can_strings) -> NoImplicitAny:
     if self.rcp is None:
       return super().update(None)
 
@@ -53,7 +56,7 @@ class RadarInterface(RadarInterfaceBase):
 
     return rr
 
-  def _update(self, updated_messages):
+  def _update(self, updated_messages) -> NoImplicitAny:
     ret = car.RadarData.new_message()
     errors = []
     if not self.rcp.can_valid:

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -1,4 +1,8 @@
-def create_steer_command(packer, steer, steer_req):
+from typing import Any
+
+NoImplicitAny = Any | Any
+
+def create_steer_command(packer, steer, steer_req) -> NoImplicitAny:
   """Creates a CAN message for the Toyota Steer Command."""
 
   values = {
@@ -9,7 +13,7 @@ def create_steer_command(packer, steer, steer_req):
   return packer.make_can_msg("STEERING_LKA", 0, values)
 
 
-def create_lta_steer_command(packer, steer_angle, steer_req, frame, setme_x64):
+def create_lta_steer_command(packer, steer_angle, steer_req, frame, setme_x64) -> NoImplicitAny:
   """Creates a CAN message for the Toyota LTA Steer Command."""
 
   values = {
@@ -27,7 +31,7 @@ def create_lta_steer_command(packer, steer_angle, steer_req, frame, setme_x64):
   return packer.make_can_msg("STEERING_LTA", 0, values)
 
 
-def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, acc_type, fcw_alert):
+def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, acc_type, fcw_alert) -> NoImplicitAny:
   # TODO: find the exact canceling bit that does not create a chime
   values = {
     "ACCEL_CMD": accel,
@@ -43,7 +47,7 @@ def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, acc_ty
   return packer.make_can_msg("ACC_CONTROL", 0, values)
 
 
-def create_acc_cancel_command(packer):
+def create_acc_cancel_command(packer) -> NoImplicitAny:
   values = {
     "GAS_RELEASED": 0,
     "CRUISE_ACTIVE": 0,
@@ -55,7 +59,7 @@ def create_acc_cancel_command(packer):
   return packer.make_can_msg("PCM_CRUISE", 0, values)
 
 
-def create_fcw_command(packer, fcw):
+def create_fcw_command(packer, fcw) -> NoImplicitAny:
   values = {
     "PCS_INDICATOR": 1,  # PCS turned off
     "FCW": fcw,
@@ -67,7 +71,7 @@ def create_fcw_command(packer, fcw):
   return packer.make_can_msg("PCS_HUD", 0, values)
 
 
-def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_depart, right_lane_depart, enabled, stock_lkas_hud):
+def create_ui_command(packer, steer, chime, left_line, right_line, left_lane_depart, right_lane_depart, enabled, stock_lkas_hud) -> NoImplicitAny:
   values = {
     "TWO_BEEPS": chime,
     "LDA_ALERT": steer,


### PR DESCRIPTION
During development, one may accidentally leave a return indented which can cause an implicit None return. In the case of a can message packing function this creates a useless error message at runtime. 

Example CAN packing function:
```
def create_command(param, actuator):
  if param:
      dat = actuator
  else:
      dat = 0
      return make_can_msg(addr, dat, bus)
```

Possible resulting error message:

```
"/root/openpilot/selfdrive/controls/controlsd.py", line 759, in publish_logs
    self.pm.send('sendcan', can_list_to_can_capnp(can_sends, msgtype='sendcan', valid=CS.canValid))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "selfdrive/boardd/boardd_api_impl.pyx", line 23, in selfdrive.boardd.boardd_api_impl.can_list_to_can_capnp
    f.address = can_msg[0]
TypeError: 'NoneType' object is not subscriptable
```

By adding the NoImplicitAny return type, mypy will catch this.



