### PR TITLE
ui: destroy egl_images in main thread

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -201,6 +201,7 @@ void CameraWidget::stopVipcThread() {
   assert(egl_display != EGL_NO_DISPLAY);
   for (auto &pair : egl_images) {
     eglDestroyImageKHR(egl_display, pair.second);
+    assert(eglGetError() == EGL_SUCCESS);
   }
   egl_images.clear();
 #endif

--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -188,12 +188,22 @@ void CameraWidget::showEvent(QShowEvent *event) {
 }
 
 void CameraWidget::stopVipcThread() {
+  makeCurrent();
   if (vipc_thread) {
     vipc_thread->requestInterruption();
     vipc_thread->quit();
     vipc_thread->wait();
     vipc_thread = nullptr;
   }
+
+#ifdef QCOM2
+  EGLDisplay egl_display = eglGetCurrentDisplay();
+  assert(egl_display != EGL_NO_DISPLAY);
+  for (auto &pair : egl_images) {
+    eglDestroyImageKHR(egl_display, pair.second);
+  }
+  egl_images.clear();
+#endif
 }
 
 void CameraWidget::availableStreamsUpdated(std::set<VisionStreamType> streams) {
@@ -324,8 +334,8 @@ void CameraWidget::vipcConnected(VisionIpcClient *vipc_client) {
   stream_stride = vipc_client->buffers[0].stride;
 
 #ifdef QCOM2
-  egl_display = eglGetCurrentDisplay();
-
+  EGLDisplay egl_display = eglGetCurrentDisplay();
+  assert(egl_display != EGL_NO_DISPLAY);
   for (auto &pair : egl_images) {
     eglDestroyImageKHR(egl_display, pair.second);
   }
@@ -416,13 +426,6 @@ void CameraWidget::vipcThread() {
       }
     }
   }
-
-#ifdef QCOM2
-  for (auto &pair : egl_images) {
-    eglDestroyImageKHR(egl_display, pair.second);
-  }
-  egl_images.clear();
-#endif
 }
 
 void CameraWidget::clearFrames() {

--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -70,7 +70,6 @@ protected:
   QColor bg = QColor("#000000");
 
 #ifdef QCOM2
-  EGLDisplay egl_display;
   std::map<int, EGLImageKHR> egl_images;
 #endif
 


### PR DESCRIPTION
according to the EGL Specification :
https://registry.khronos.org/EGL/sdk/docs/man/html/eglGetCurrentDisplay.xhtml
https://registry.khronos.org/EGL/specs/eglspec.1.5.pdf

the  `eglGetCurrentDisplay`&`eglDestroyImageKHR` should be called after `makeCurrent` and in the same thread with the egl context.