### PR TITLE
ui: init `longitudinal_control` from CarParams

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -251,6 +251,18 @@ UIState::UIState(QObject *parent) : QObject(parent) {
     prime_type = static_cast<PrimeType>(std::atoi(prime_value.c_str()));
   }
 
+  auto car_params = params.get("CarParams");
+  if (!car_params.empty()) {
+    try {
+      AlignedBuffer aligned_buf;
+      capnp::FlatArrayMessageReader cmsg(aligned_buf.align(car_params.data(), car_params.size()));
+      cereal::CarParams::Reader car_params_reader = cmsg.getRoot<cereal::CarParams>();
+      scene.longitudinal_control = car_params_reader.getOpenpilotLongitudinalControl();
+    } catch (const kj::Exception &e) {
+      LOGD("Failed to read CarParams");
+    }
+  }
+
   // update timer
   timer = new QTimer(this);
   QObject::connect(timer, &QTimer::timeout, this, &UIState::update);


### PR DESCRIPTION
`carParams` is sent every 50 seconds, UI may not receive this message for some time after startup (or restart after a crash), causes the leader indicator to not be displayed during this period.

before
![Screenshot 2023-10-16 21:17:08](https://github.com/commaai/openpilot/assets/27770/9d415341-f1db-45fc-a204-68940169d882)
after
![Screenshot 2023-10-16 21:16:09](https://github.com/commaai/openpilot/assets/27770/60c68b4b-ff2b-4f49-b696-3d0e6b4694b4)
