### PR TITLE
Toyota: don't calculate angle offset when angle rate is high

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -43,7 +43,6 @@ class CarState(CarStateBase):
     self.low_speed_lockout = False
     self.acc_type = 1
     self.lkas_hud = {}
-    self.frame = 0
 
   def update(self, cp, cp_cam):
     ret = car.CarState.new_message()
@@ -77,7 +76,6 @@ class CarState(CarStateBase):
     ret.steeringAngleDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_ANGLE"] + cp.vl["STEER_ANGLE_SENSOR"]["STEER_FRACTION"]
     ret.steeringRateDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_RATE"]
     torque_sensor_angle_deg = cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE"]
-    self.frame += 1
 
     # On some cars, the angle measurement is non-zero while initializing
     if abs(torque_sensor_angle_deg) > 1e-3 and not bool(cp.vl["STEER_TORQUE_SENSOR"]["STEER_ANGLE_INITIALIZING"]):
@@ -87,8 +85,6 @@ class CarState(CarStateBase):
       # Offset seems to be invalid for large steering angles and high angle rates
       if abs(ret.steeringAngleDeg) < 90 and abs(ret.steeringRateDeg) < 100 and cp.can_valid:
         self.angle_offset.update(torque_sensor_angle_deg - ret.steeringAngleDeg)
-        print('OFFSET', torque_sensor_angle_deg - ret.steeringAngleDeg, ret.steeringAngleDeg, ret.steeringRateDeg, self.frame)
-        raise Exception
 
       if self.angle_offset.initialized:
         ret.steeringAngleOffsetDeg = self.angle_offset.x

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -81,6 +81,7 @@ class CarState(CarStateBase):
       self.accurate_steer_angle_seen = True
 
     if self.accurate_steer_angle_seen:
+      # comment
       # Offset seems to be invalid for large steering angles
       if abs(ret.steeringAngleDeg) < 90 and cp.can_valid:
         self.angle_offset.update(torque_sensor_angle_deg - ret.steeringAngleDeg)


### PR DESCRIPTION
With this fix, the offset from route `ad5a3fa719bc2f83|2023-10-17--20-02-16` below now starts at `0.027` with a test models run.

If we initialize while the steering rate is high, the angle offset will not be accurate:

<img src="https://github.com/commaai/openpilot/assets/25857203/47801beb-999e-4034-b427-1e2ee6e0ff12" width="600px">

<img src="https://github.com/commaai/openpilot/assets/25857203/7330c286-496d-4da0-b784-f88b118937e9" width="600px">
