### PR TITLE
Avoid UI crash when asset is not available

### DIFF
--- a/selfdrive/ui/qt/widgets/offroad_alerts.cc
+++ b/selfdrive/ui/qt/widgets/offroad_alerts.cc
@@ -68,6 +68,9 @@ int OffroadAlert::refresh() {
     QString json = util::read_file("../controls/lib/alerts_offroad.json").c_str();
     QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
 
+    if (obj.empty())
+      return 0;
+
     // descending sort labels by severity
     std::vector<std::pair<std::string, int>> sorted;
     for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {


### PR DESCRIPTION
**Description** 
If UI cannot find resource from relative path at launch, it crashes due to null reference.

```
int OffroadAlert::refresh() {
  // build widgets for each offroad alert on first refresh
  if (alerts.empty()) {
    QString json = util::read_file("../controls/lib/alerts_offroad.json").c_str();  <= If this file not found

  ....
  snooze_btn->setVisible(!alerts["Offroad_ConnectivityNeeded"]->text().isEmpty());  <= Crash here due to null reference 
```


**Verification** 
After applying patch, launch UI in invalid workspace does not lead to crash.
Instead, a broken UI is shown, and developer should notice something is going wrong  :)

