### PR TITLE
selfdrive_tests: allow manual run

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.run_id || github.head_ref || github.ref }}-${{ github.workflow }}-${{ github.event_name }}
@@ -73,7 +74,7 @@ jobs:
       matrix:
         arch: ${{ fromJson(
            ((github.repository == 'commaai/openpilot') &&
-              ((github.event_name != 'pull_request') || 
+              ((github.event_name != 'pull_request') ||
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
     runs-on: ${{ (matrix.arch == 'aarch64') && 'buildjet-2vcpu-ubuntu-2204-arm' || 'ubuntu-20.04' }}
     steps:
@@ -187,7 +188,7 @@ jobs:
   process_replay:
     name: process replay
     runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
-                   ((github.event_name != 'pull_request') || 
+                   ((github.event_name != 'pull_request') ||
                     (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v4
@@ -231,7 +232,7 @@ jobs:
   regen:
     name: regen
     runs-on: 'ubuntu-20.04'
-    steps: 
+    steps:
     - uses: actions/checkout@v4
       with:
         submodules: true

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         arch: ${{ fromJson(
            ((github.repository == 'commaai/openpilot') &&
-              ((github.event_name != 'pull_request') ||
+              ((github.event_name != 'pull_request') || 
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
     runs-on: ${{ (matrix.arch == 'aarch64') && 'buildjet-2vcpu-ubuntu-2204-arm' || 'ubuntu-20.04' }}
     steps:
@@ -188,7 +188,7 @@ jobs:
   process_replay:
     name: process replay
     runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
-                   ((github.event_name != 'pull_request') ||
+                   ((github.event_name != 'pull_request') || 
                     (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'buildjet-8vcpu-ubuntu-2004' || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v4
@@ -232,7 +232,7 @@ jobs:
   regen:
     name: regen
     runs-on: 'ubuntu-20.04'
-    steps:
+    steps: 
     - uses: actions/checkout@v4
       with:
         submodules: true


### PR DESCRIPTION
since it doesn't run on pushes, allow manual dispatches to test stuff on branches

useful if you want to run multiple tests on different branches at once, on mobile, on machine without env, etc.