### PR TITLE
Pytest: fix local params overriden

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,12 @@ def openpilot_function_fixture():
 
   # setup a clean environment for each test
   with OpenpilotPrefix():
+    prefix = os.environ["OPENPILOT_PREFIX"]
+
     yield
+
+    # ensure the test doesn't change the prefix
+    assert "OPENPILOT_PREFIX" in os.environ and prefix == os.environ["OPENPILOT_PREFIX"]
 
   os.environ.clear()
   os.environ.update(starting_env)


### PR DESCRIPTION
replay_process has it's own OpenpilotPrefix, which was overriding the one from pytest. OpenPilot prefix should maintain the parent prefix if it exists.

also added a test within conftest to ensure the tests don't change the openpilot prefix