### PR TITLE
cabana: improve playback controller

### DIFF
--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -190,7 +190,7 @@ void ChartsWidget::updateState() {
     if (pos < 0 || pos > 0.8) {
       display_range.first = std::max(0.0, cur_sec - max_chart_range * 0.1);
     }
-    double max_sec = std::min(std::floor(display_range.first + max_chart_range), can->totalSeconds());
+    double max_sec = std::min(display_range.first + max_chart_range, can->totalSeconds());
     display_range.first = std::max(0.0, max_sec - max_chart_range);
     display_range.second = display_range.first + max_chart_range;
   } else if (cur_sec < (zoomed_range.first - 0.1) || cur_sec >= zoomed_range.second) {

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -2,6 +2,7 @@
 
 #include <QFormLayout>
 #include <QMenu>
+#include <QSpacerItem>
 
 #include "tools/cabana/commands.h"
 #include "tools/cabana/mainwin.h"
@@ -22,19 +23,15 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   // message title
   QHBoxLayout *title_layout = new QHBoxLayout();
   title_layout->setContentsMargins(3, 6, 3, 0);
-  time_label = new QLabel(this);
-  time_label->setToolTip(tr("Current time"));
-  time_label->setStyleSheet("QLabel{font-weight:bold;}");
-  title_layout->addWidget(time_label);
-  name_label = new ElidedLabel(this);
+  auto spacer = new QSpacerItem(0, 1);
+  title_layout->addItem(spacer);
+  title_layout->addWidget(name_label = new ElidedLabel(this), 1);
   name_label->setStyleSheet("QLabel{font-weight:bold;}");
   name_label->setAlignment(Qt::AlignCenter);
-  name_label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-  title_layout->addWidget(name_label);
   auto edit_btn = new ToolButton("pencil", tr("Edit Message"));
   title_layout->addWidget(edit_btn);
-  remove_btn = new ToolButton("x-lg", tr("Remove Message"));
-  title_layout->addWidget(remove_btn);
+  title_layout->addWidget(remove_btn = new ToolButton("x-lg", tr("Remove Message")));
+  spacer->changeSize(edit_btn->sizeHint().width() * 2 + 9, 1);
   main_layout->addLayout(title_layout);
 
   // warning
@@ -151,7 +148,6 @@ void DetailWidget::refresh() {
 }
 
 void DetailWidget::updateState(const QHash<MessageId, CanData> *msgs) {
-  time_label->setText(QString::number(can->currentSec(), 'f', 3));
   if ((msgs && !msgs->contains(msg_id)))
     return;
 

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -42,7 +42,7 @@ private:
   void updateState(const QHash<MessageId, CanData> * msgs = nullptr);
 
   MessageId msg_id;
-  QLabel *time_label, *warning_icon, *warning_label;
+  QLabel *warning_icon, *warning_label;
   ElidedLabel *name_label;
   QWidget *warning_widget;
   TabBar *tabbar;

--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -14,6 +14,7 @@ Settings settings;
 
 QSettings::Status Settings::save() {
   QSettings s(filePath(), QSettings::IniFormat);
+  s.setValue("absolute_time", absolute_time);
   s.setValue("fps", fps);
   s.setValue("max_cached_minutes", max_cached_minutes);
   s.setValue("chart_height", chart_height);
@@ -40,6 +41,7 @@ QSettings::Status Settings::save() {
 
 void Settings::load() {
   QSettings s(filePath(), QSettings::IniFormat);
+  absolute_time = s.value("absolute_time", false).toBool();
   fps = s.value("fps", 10).toInt();
   max_cached_minutes = s.value("max_cached_minutes", 30).toInt();
   chart_height = s.value("chart_height", 200).toInt();

--- a/tools/cabana/settings.h
+++ b/tools/cabana/settings.h
@@ -29,6 +29,7 @@ public:
   void load();
   inline static QString filePath() { return QApplication::applicationDirPath() + "/settings"; }
 
+  bool absolute_time = false;
   int fps = 10;
   int max_cached_minutes = 30;
   int chart_height = 200;

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <QColor>
+#include <QDateTime>
 #include <QHash>
 
 #include "common/timing.h"
@@ -63,6 +64,7 @@ public:
   virtual void seekTo(double ts) {}
   virtual QString routeName() const = 0;
   virtual QString carFingerprint() const { return ""; }
+  virtual QDateTime beginDateTime() const { return {}; }
   virtual double routeStartTime() const { return 0; }
   virtual double currentSec() const = 0;
   virtual double totalSeconds() const { return lastEventMonoTime() / 1e9 - routeStartTime(); }

--- a/tools/cabana/streams/livestream.cc
+++ b/tools/cabana/streams/livestream.cc
@@ -46,6 +46,7 @@ void LiveStream::start() {
   emit streamStarted();
   stream_thread->start();
   startUpdateTimer();
+  begin_date_time = QDateTime::currentDateTime();
 }
 
 LiveStream::~LiveStream() {

--- a/tools/cabana/streams/livestream.h
+++ b/tools/cabana/streams/livestream.h
@@ -15,6 +15,7 @@ public:
   LiveStream(QObject *parent);
   virtual ~LiveStream();
   void start() override;
+  inline QDateTime beginDateTime() const { return begin_date_time; }
   inline double routeStartTime() const override { return begin_event_ts / 1e9; }
   inline double currentSec() const override { return (current_event_ts - begin_event_ts) / 1e9; }
   void setSpeed(float speed) override { speed_ = speed; }
@@ -49,6 +50,7 @@ private:
   int timer_id;
   QBasicTimer update_timer;
 
+  QDateTime begin_date_time;
   uint64_t begin_event_ts = 0;
   uint64_t current_event_ts = 0;
   uint64_t first_event_ts = 0;

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -22,11 +22,13 @@ public:
   inline QString carFingerprint() const override { return replay->carFingerprint().c_str(); }
   double totalSeconds() const override { return replay->totalSeconds(); }
   inline VisionStreamType visionStreamType() const override { return replay->hasFlag(REPLAY_FLAG_ECAM) ? VISION_STREAM_WIDE_ROAD : VISION_STREAM_ROAD; }
+  inline QDateTime beginDateTime() const { return replay->route()->datetime(); }
   inline double routeStartTime() const override { return replay->routeStartTime() / (double)1e9; }
   inline double currentSec() const override { return replay->currentSeconds(); }
   inline const Route *route() const override { return replay->route(); }
   inline void setSpeed(float speed) override { replay->setSpeed(speed); }
   inline float getSpeed() const { return replay->getSpeed(); }
+  inline Replay *getReplay() const { return replay.get(); }
   inline bool isPaused() const override { return replay->isPaused(); }
   void pause(bool pause) override;
   inline const std::vector<std::tuple<double, double, TimelineType>> getTimeline() override { return replay->getTimeline(); }

--- a/tools/cabana/util.cc
+++ b/tools/cabana/util.cc
@@ -242,6 +242,13 @@ void setTheme(int theme) {
   }
 }
 
+QString formatSeconds(double sec, bool include_milliseconds, bool absolute_time) {
+  QString format = absolute_time ? "yyyy-MM-dd hh:mm:ss"
+                                 : (sec > 60 * 60 ? "hh:mm:ss" : "mm:ss");
+  if (include_milliseconds) format += ".zzz";
+  return QDateTime::fromMSecsSinceEpoch(sec * 1000).toString(format);
+}
+
 }  // namespace utils
 
 QString toHex(uint8_t byte) {

--- a/tools/cabana/util.h
+++ b/tools/cabana/util.h
@@ -103,9 +103,7 @@ public:
 namespace utils {
 QPixmap icon(const QString &id);
 void setTheme(int theme);
-inline QString formatSeconds(int seconds) {
-  return QDateTime::fromSecsSinceEpoch(seconds, Qt::UTC).toString(seconds > 60 * 60 ? "hh:mm:ss" : "mm:ss");
-}
+QString formatSeconds(double sec, bool include_milliseconds = false, bool absolute_time = false);
 inline void drawStaticText(QPainter *p, const QRect &r, const QStaticText &text) {
   auto size = (r.size() - text.size()) / 2;
   p->drawStaticText(r.left() + size.width(), r.top() + size.height(), text);

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -3,7 +3,7 @@
 #include <map>
 #include <memory>
 
-#include <QLabel>
+#include <QHBoxLayout>
 #include <QSlider>
 #include <QToolButton>
 
@@ -39,6 +39,8 @@ public:
   QPixmap thumbnail(double sec);
   void parseQLog(int segnum, std::shared_ptr<LogReader> qlog);
 
+  const double factor = 1000.0;
+
 signals:
   void updateMaximumTime(double);
 
@@ -48,7 +50,6 @@ private:
   bool event(QEvent *event) override;
   void paintEvent(QPaintEvent *ev) override;
 
-  const double factor = 1000.0;
   QMap<uint64_t, QPixmap> thumbnails;
   std::map<uint64_t, AlertInfo> alerts;
   InfoLabel thumbnail_label;
@@ -63,16 +64,22 @@ public:
   void setMaximumTime(double sec);
 
 protected:
+  QString formatTime(double sec, bool include_milliseconds = false);
   void updateState();
   void updatePlayBtnState();
   QWidget *createCameraWidget();
+  QHBoxLayout *createPlaybackController();
+  void loopPlaybackClicked();
 
   CameraWidget *cam_widget;
   double maximum_time = 0;
-  QLabel *end_time_label;
-  QLabel *time_label;
-  QToolButton *play_btn;
-  QToolButton *skip_to_end_btn = nullptr;
-  InfoLabel *alert_label;
-  Slider *slider;
+  QToolButton *time_btn = nullptr;
+  ToolButton *seek_backward_btn = nullptr;
+  ToolButton *play_btn = nullptr;
+  ToolButton *seek_forward_btn = nullptr;
+  ToolButton *loop_btn = nullptr;
+  QToolButton *speed_btn = nullptr;
+  ToolButton *skip_to_end_btn = nullptr;
+  InfoLabel *alert_label = nullptr;
+  Slider *slider = nullptr;
 };


### PR DESCRIPTION
implement a foxglove like playback controller. add support for displaying absolute time

![Screenshot 2023-10-25 14:13:35](https://github.com/commaai/openpilot/assets/27770/38a17ca9-48d0-44ba-bf5e-3604fdaf72f8)
![2023-10-25_14-15](https://github.com/commaai/openpilot/assets/27770/89c9f96a-bf2c-4505-b6de-225af9f410db)

1. seek backward (1 sec)
2. play / pause
3. seek forward (1 sec)
4. current time / total time (click to switch between elapsed time and absolute time)
5. loop playback
6. playback speed selector (with more options):
![2023-10-25_14-17](https://github.com/commaai/openpilot/assets/27770/588179ec-2bb8-4f64-a9c6-aeb8dbda0904)

