### PR TITLE
ui: Always display Wi-Fi list when navigating to Network panel

### DIFF
--- a/selfdrive/ui/qt/network/networking.cc
+++ b/selfdrive/ui/qt/network/networking.cc
@@ -101,6 +101,7 @@ void Networking::wrongPassword(const QString &ssid) {
 }
 
 void Networking::showEvent(QShowEvent *event) {
+  main_layout->setCurrentWidget(wifiScreen);
   wifi->start();
 }
 

--- a/selfdrive/ui/qt/network/networking.cc
+++ b/selfdrive/ui/qt/network/networking.cc
@@ -101,11 +101,11 @@ void Networking::wrongPassword(const QString &ssid) {
 }
 
 void Networking::showEvent(QShowEvent *event) {
-  main_layout->setCurrentWidget(wifiScreen);
   wifi->start();
 }
 
 void Networking::hideEvent(QHideEvent *event) {
+  main_layout->setCurrentWidget(wifiScreen);
   wifi->stop();
 }
 


### PR DESCRIPTION
Currently, the "Advanced" panel remains displayed in the `Network` panel when we navigate back from it after exiting the settings or navigating to another panel.

We reset the `Network` panel to the Wi-Fi list when the "Advanced" panel under `Network` is opened and:
- Exiting the settings menu
- Navigating to another settings panel