### PR TITLE
cabana: support multiple cameras

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -26,6 +26,7 @@ int main(int argc, char *argv[]) {
   cmd_parser.addOption({"demo", "use a demo route instead of providing your own"});
   cmd_parser.addOption({"qcam", "load qcamera"});
   cmd_parser.addOption({"ecam", "load wide road camera"});
+  cmd_parser.addOption({"dcam", "load driver camera"});
   cmd_parser.addOption({"stream", "read can messages from live streaming"});
   cmd_parser.addOption({"panda", "read can messages from panda"});
   cmd_parser.addOption({"panda-serial", "read can messages from panda with given serial", "panda-serial"});
@@ -60,13 +61,10 @@ int main(int argc, char *argv[]) {
     stream = new SocketCanStream(&app, config);
   } else {
     uint32_t replay_flags = REPLAY_FLAG_NONE;
-    if (cmd_parser.isSet("ecam")) {
-      replay_flags |= REPLAY_FLAG_ECAM;
-    } else if (cmd_parser.isSet("qcam")) {
-      replay_flags |= REPLAY_FLAG_QCAMERA;
-    } else if (cmd_parser.isSet("no-vipc")) {
-      replay_flags |= REPLAY_FLAG_NO_VIPC;
-    }
+    if (cmd_parser.isSet("ecam")) replay_flags |= REPLAY_FLAG_ECAM;
+    if (cmd_parser.isSet("qcam")) replay_flags |= REPLAY_FLAG_QCAMERA;
+    if (cmd_parser.isSet("dcam")) replay_flags |= REPLAY_FLAG_DCAM;
+    if (cmd_parser.isSet("no-vipc")) replay_flags |= REPLAY_FLAG_NO_VIPC;
 
     const QStringList args = cmd_parser.positionalArguments();
     QString route;

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -3,7 +3,6 @@
 #include <array>
 #include <atomic>
 #include <memory>
-#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -70,7 +69,6 @@ public:
   virtual double currentSec() const = 0;
   virtual double totalSeconds() const { return lastEventMonoTime() / 1e9 - routeStartTime(); }
   const CanData &lastMessage(const MessageId &id);
-  virtual VisionStreamType visionStreamType() const { return VISION_STREAM_ROAD; }
   virtual const Route *route() const { return nullptr; }
   virtual void setSpeed(float speed) {}
   virtual double getSpeed() { return 1; }
@@ -79,7 +77,6 @@ public:
   const MessageEventsMap &eventsMap() const { return events_; }
   const std::vector<const CanEvent *> &allEvents() const { return all_events_; }
   const std::vector<const CanEvent *> &events(const MessageId &id) const;
-  virtual const std::vector<std::tuple<double, double, TimelineType>> getTimeline() { return {}; }
 
 signals:
   void paused();

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <QCheckBox>
 #include <algorithm>
 #include <memory>
 #include <set>
-#include <tuple>
 #include <vector>
 
 #include "common/prefix.h"
@@ -21,7 +21,6 @@ public:
   inline QString routeName() const override { return replay->route()->name(); }
   inline QString carFingerprint() const override { return replay->carFingerprint().c_str(); }
   double totalSeconds() const override { return replay->totalSeconds(); }
-  inline VisionStreamType visionStreamType() const override { return replay->hasFlag(REPLAY_FLAG_ECAM) ? VISION_STREAM_WIDE_ROAD : VISION_STREAM_ROAD; }
   inline QDateTime beginDateTime() const { return replay->route()->datetime(); }
   inline double routeStartTime() const override { return replay->routeStartTime() / (double)1e9; }
   inline double currentSec() const override { return replay->currentSeconds(); }
@@ -31,7 +30,6 @@ public:
   inline Replay *getReplay() const { return replay.get(); }
   inline bool isPaused() const override { return replay->isPaused(); }
   void pause(bool pause) override;
-  inline const std::vector<std::tuple<double, double, TimelineType>> getTimeline() override { return replay->getTimeline(); }
   static AbstractOpenStreamWidget *widget(AbstractStream **stream);
 
 signals:
@@ -54,5 +52,5 @@ public:
 
 private:
   QLineEdit *route_edit;
-  QComboBox *choose_video_cb;
+  std::vector<QCheckBox *> cameras;
 };

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -2,9 +2,11 @@
 
 #include <map>
 #include <memory>
+#include <set>
 
 #include <QHBoxLayout>
 #include <QSlider>
+#include <QTabBar>
 #include <QToolButton>
 
 #include "selfdrive/ui/qt/widgets/cameraview.h"
@@ -70,6 +72,7 @@ protected:
   QWidget *createCameraWidget();
   QHBoxLayout *createPlaybackController();
   void loopPlaybackClicked();
+  void vipcAvailableStreamsUpdated(std::set<VisionStreamType> streams);
 
   CameraWidget *cam_widget;
   double maximum_time = 0;
@@ -82,4 +85,5 @@ protected:
   ToolButton *skip_to_end_btn = nullptr;
   InfoLabel *alert_label = nullptr;
   Slider *slider = nullptr;
+  QTabBar *camera_tab = nullptr;
 };


### PR DESCRIPTION
![2023-10-26_17-49](https://github.com/commaai/openpilot/assets/27770/756655c7-9311-4efd-ac43-ab4886e1c69e)

[Kazam_screencast_00138.webm](https://github.com/commaai/openpilot/assets/27770/57ce07f7-4700-4c59-9ff9-1915e7f9bd77)

run cabana with road camera (the default) :
`cabana demo `

run cabana with road camera and driver camera:
`cabana demo --dcam`

run cabana with road camera, driver camera and wide road camera:
`cabana demo --dcam --ecam`

or run `cabana` without any arguments, and select cameras from the open stream dialog:


![2023-10-26_17-35](https://github.com/commaai/openpilot/assets/27770/abd917a5-0ea9-4f5e-9eee-4899f55d7af0)


