### PR TITLE
cabana: fix messages not updated correctly after seekto

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -140,11 +140,8 @@ void AbstractStream::updateLastMsgsTo(double sec) {
     }
   }
 
-  bool id_changed = messages_.size() != last_msgs.size() ||
-                    std::any_of(messages_.cbegin(), messages_.cend(),
-                                [this](const auto &m) { return !last_msgs.count(m.first); });
   last_msgs = messages_;
-  emit msgsReceived(nullptr, id_changed);
+  emit msgsReceived(nullptr, true);
 }
 
 const CanEvent *AbstractStream::newEvent(uint64_t mono_time, const cereal::CanData::Reader &c) {


### PR DESCRIPTION
this bug introduced by https://github.com/commaai/openpilot/pull/30336