### PR TITLE
cabana: fix messages not updated correctly after `seekto()`

### DIFF
--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -38,15 +38,16 @@ public:
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
   void setFilterStrings(const QMap<int, QString> &filters);
   void msgsReceived(const std::set<MessageId> *new_msgs, bool has_new_ids);
-  void filterAndSort(bool force_reset = false);
+  void filterAndSort();
   void dbcModified();
 
   struct Item {
     MessageId id;
     QString name;
     QString node;
-    const CanData *data;
-    bool operator==(const Item &other) const { return id == other.id; }
+    bool operator==(const Item &other) const {
+      return id == other.id && name == other.name && node == other.node;
+    }
   };
   std::vector<Item> items_;
 


### PR DESCRIPTION
this bug introduced by https://github.com/commaai/openpilot/pull/30336 