### PR TITLE
tinygrad: switch to compile2

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -582,7 +582,7 @@ opendbc/tesla_can.dbc
 opendbc/tesla_radar.dbc
 opendbc/tesla_powertrain.dbc
 
-tinygrad_repo/openpilot/compile.py
+tinygrad_repo/openpilot/compile2.py
 tinygrad_repo/extra/onnx.py
 tinygrad_repo/extra/onnx_ops.py
 tinygrad_repo/extra/thneed.py

--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -62,7 +62,7 @@ if arch == "larch64" or GetOption('pc_thneed'):
   if not GetOption('pc_thneed'):
     # use FLOAT16 on device for speed + don't cache the CL kernels for space
     tinygrad_opts += ["FLOAT16=1", "PYOPENCL_NO_CACHE=1"]
-  cmd = f"cd {Dir('#').abspath}/tinygrad_repo && " + ' '.join(tinygrad_opts) + f" python3 openpilot/compile.py {fn}.onnx {fn}.thneed"
+  cmd = f"cd {Dir('#').abspath}/tinygrad_repo && " + ' '.join(tinygrad_opts) + f" python3 openpilot/compile2.py {fn}.onnx {fn}.thneed"
 
   tinygrad_files = sum([lenv.Glob("#"+x) for x in open(File("#release/files_common").abspath).read().split("\n") if x.startswith("tinygrad_repo/")], [])
   lenv.Command(fn + ".thneed", [fn + ".onnx"] + tinygrad_files, cmd)


### PR DESCRIPTION
Fingers crossed this doesn't change model replay. Should be faster to compile and required for small_vit