### PR TITLE
cabana: fix QChart leak

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -25,20 +25,18 @@ const int AXIS_X_TOP_MARGIN = 4;
 static inline bool xLessThan(const QPointF &p, float x) { return p.x() < x; }
 
 ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent)
-    : charts_widget(parent), tip_label(this), QChartView(nullptr, parent) {
+    : charts_widget(parent), tip_label(this), QChartView(parent) {
   series_type = (SeriesType)settings.chart_series_type;
-  QChart *chart = new QChart();
-  chart->setBackgroundVisible(false);
+  chart()->setBackgroundVisible(false);
   axis_x = new QValueAxis(this);
   axis_y = new QValueAxis(this);
-  chart->addAxis(axis_x, Qt::AlignBottom);
-  chart->addAxis(axis_y, Qt::AlignLeft);
-  chart->legend()->layout()->setContentsMargins(0, 0, 0, 0);
-  chart->legend()->setShowToolTips(true);
-  chart->setMargins({0, 0, 0, 0});
+  chart()->addAxis(axis_x, Qt::AlignBottom);
+  chart()->addAxis(axis_y, Qt::AlignLeft);
+  chart()->legend()->layout()->setContentsMargins(0, 0, 0, 0);
+  chart()->legend()->setShowToolTips(true);
+  chart()->setMargins({0, 0, 0, 0});
 
   axis_x->setRange(x_range.first, x_range.second);
-  setChart(chart);
 
   createToolButtons();
   setRubberBand(QChartView::HorizontalRubberBand);


### PR DESCRIPTION
Issue: `QChartView ` will create a default `QChart` in constructor (https://codebrowser.dev/qt5/qtcharts/src/charts/qchartview.cpp.html#301), call `setChart` will cause memory leaks.

https://doc.qt.io/qt-6/qchartview.html#setChart
> void QChartView::setChart([QChart](https://doc.qt.io/qt-6/qchart.html) *chart)
> 
> Sets the current chart to chart. The ownership of the new chart is passed to the chart view and the ownership of the previous chart is released.
> 
> To avoid memory leaks, the previous chart must be deleted.

fixed: use default QChart instead of create a new one.