### PR TITLE
cabana/sparkline: Fix "Painter not active" warning

### DIFF
--- a/tools/cabana/chart/sparkline.h
+++ b/tools/cabana/chart/sparkline.h
@@ -1,29 +1,24 @@
 #pragma once
 
-#include <algorithm>
-
 #include <QPixmap>
 #include <QPointF>
 #include <vector>
 
-#include "tools/cabana/dbc/dbcmanager.h"
+#include "tools/cabana/dbc/dbc.h"
 
 class Sparkline {
 public:
   void update(const MessageId &msg_id, const cabana::Signal *sig, double last_msg_ts, int range, QSize size);
-  const QSize size() const { return pixmap.size() / pixmap.devicePixelRatio(); }
-  inline double freq() const {
-    return values.empty() ? 0 : values.size() / std::max(values.back().x() - values.front().x(), 1.0);
-  }
+  inline double freq() const { return freq_; }
+  bool isEmpty() const { return pixmap.isNull(); }
 
   QPixmap pixmap;
   double min_val = 0;
   double max_val = 0;
-  double last_ts = 0;
-  int time_range = 0;
 
 private:
-  void render(const QColor &color, QSize size);
-  std::vector<QPointF> values;
+  void render(const QColor &color, int range, QSize size);
+
   std::vector<QPointF> points;
+  double freq_ = 0;
 };


### PR DESCRIPTION
1. fix Painter not active warning  when displaying sparkline for the first time:
```
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::setPen: Painter not active
QPainter::setPen: Painter not active
QPainter::setPen: Painter not active
QPainter::drawPoints: Painter not active
QPainter::setPen: Painter not active
QPainter::drawPoints: Painter not active
```
2. cleanup code.
