### PR TITLE
cabana: allocate qt objects on the heap instead of stack

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -25,7 +25,7 @@ const int AXIS_X_TOP_MARGIN = 4;
 static inline bool xLessThan(const QPointF &p, float x) { return p.x() < x; }
 
 ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent)
-    : charts_widget(parent), tip_label(this), QChartView(parent) {
+    : charts_widget(parent), QChartView(parent) {
   series_type = (SeriesType)settings.chart_series_type;
   chart()->setBackgroundVisible(false);
   axis_x = new QValueAxis(this);
@@ -38,6 +38,7 @@ ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *par
 
   axis_x->setRange(x_range.first, x_range.second);
 
+  tip_label = new TipLabel(this);
   createToolButtons();
   setRubberBand(QChartView::HorizontalRubberBand);
   setMouseTracking(true);
@@ -416,7 +417,7 @@ qreal ChartView::niceNumber(qreal x, bool ceiling) {
 }
 
 void ChartView::leaveEvent(QEvent *event) {
-  if (tip_label.isVisible()) {
+  if (tip_label->isVisible()) {
     charts_widget->showValueTip(-1);
   }
   QChartView::leaveEvent(event);
@@ -543,7 +544,7 @@ void ChartView::mouseMoveEvent(QMouseEvent *ev) {
   if (!is_zooming && plot_area.contains(ev->pos())) {
     const double sec = chart()->mapToValue(ev->pos()).x();
     charts_widget->showValueTip(sec);
-  } else if (tip_label.isVisible()) {
+  } else if (tip_label->isVisible()) {
     charts_widget->showValueTip(-1);
   }
 
@@ -563,7 +564,7 @@ void ChartView::showTip(double sec) {
   QRect tip_area(0, chart()->plotArea().top(), rect().width(), chart()->plotArea().height());
   QRect visible_rect = charts_widget->chartVisibleRect(this).intersected(tip_area);
   if (visible_rect.isEmpty()) {
-    tip_label.hide();
+    tip_label->hide();
     return;
   }
 
@@ -593,14 +594,14 @@ void ChartView::showTip(double sec) {
   QPoint pt(x, chart()->plotArea().top());
   text_list.push_front(QString::number(chart()->mapToValue({x, 0}).x(), 'f', 3));
   QString text = "<p style='white-space:pre'>" % text_list.join("<br />") % "</p>";
-  tip_label.showText(pt, text, this, visible_rect);
+  tip_label->showText(pt, text, this, visible_rect);
   viewport()->update();
 }
 
 void ChartView::hideTip() {
   clearTrackPoints();
   tooltip_x = -1;
-  tip_label.hide();
+  tip_label->hide();
   viewport()->update();
 }
 

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -108,7 +108,7 @@ private:
   QGraphicsPixmapItem *move_icon;
   QGraphicsProxyWidget *close_btn_proxy;
   QGraphicsProxyWidget *manage_btn_proxy;
-  TipLabel tip_label;
+  TipLabel *tip_label;
   std::vector<SigItem> sigs;
   double cur_sec = 0;
   SeriesType series_type = SeriesType::Line;

--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -14,7 +14,9 @@
 const int MAX_COLUMN_COUNT = 4;
 const int CHART_SPACING = 4;
 
-ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_timer(this), QFrame(parent) {
+ChartsWidget::ChartsWidget(QWidget *parent) : QFrame(parent) {
+  align_timer = new QTimer(this);
+  auto_scroll_timer = new QTimer(this);
   setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
@@ -95,9 +97,9 @@ ChartsWidget::ChartsWidget(QWidget *parent) : align_timer(this), auto_scroll_tim
   range_slider->setValue(max_chart_range);
   updateToolBar();
 
-  align_timer.setSingleShot(true);
-  QObject::connect(&align_timer, &QTimer::timeout, this, &ChartsWidget::alignCharts);
-  QObject::connect(&auto_scroll_timer, &QTimer::timeout, this, &ChartsWidget::doAutoScroll);
+  align_timer->setSingleShot(true);
+  QObject::connect(align_timer, &QTimer::timeout, this, &ChartsWidget::alignCharts);
+  QObject::connect(auto_scroll_timer, &QTimer::timeout, this, &ChartsWidget::doAutoScroll);
   QObject::connect(dbc(), &DBCManager::DBCFileChanged, this, &ChartsWidget::removeAll);
   QObject::connect(can, &AbstractStream::eventsMerged, this, &ChartsWidget::eventsMerged);
   QObject::connect(can, &AbstractStream::msgsReceived, this, &ChartsWidget::updateState);
@@ -253,7 +255,7 @@ ChartView *ChartsWidget::createChart() {
   chart->setFixedHeight(settings.chart_height);
   chart->setMinimumWidth(CHART_MIN_WIDTH);
   chart->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
-  QObject::connect(chart, &ChartView::axisYLabelWidthChanged, &align_timer, qOverload<>(&QTimer::start));
+  QObject::connect(chart, &ChartView::axisYLabelWidthChanged, align_timer, qOverload<>(&QTimer::start));
   charts.push_front(chart);
   currentCharts().push_front(chart);
   updateLayout(true);
@@ -334,11 +336,11 @@ void ChartsWidget::updateLayout(bool force) {
 }
 
 void ChartsWidget::startAutoScroll() {
-  auto_scroll_timer.start(50);
+  auto_scroll_timer->start(50);
 }
 
 void ChartsWidget::stopAutoScroll() {
-  auto_scroll_timer.stop();
+  auto_scroll_timer->stop();
   auto_scroll_count = 0;
 }
 

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -109,8 +109,8 @@ private:
   int column_count = 1;
   int current_column_count = 0;
   int auto_scroll_count = 0;
-  QTimer auto_scroll_timer;
-  QTimer align_timer;
+  QTimer *auto_scroll_timer;
+  QTimer *align_timer;
   int current_theme = 0;
   friend class ZoomCommand;
   friend class ChartView;

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -232,7 +232,8 @@ void VideoWidget::updatePlayBtnState() {
 
 // Slider
 
-Slider::Slider(QWidget *parent) : thumbnail_label(parent), QSlider(Qt::Horizontal, parent) {
+Slider::Slider(QWidget *parent) : QSlider(Qt::Horizontal, parent) {
+  thumbnail_label = new InfoLabel(parent);
   setMouseTracking(true);
 }
 
@@ -321,9 +322,9 @@ void Slider::mouseMoveEvent(QMouseEvent *e) {
   if (!thumb.isNull()) {
     int x = std::clamp(pos - thumb.width() / 2, THUMBNAIL_MARGIN, width() - thumb.width() - THUMBNAIL_MARGIN + 1);
     int y = -thumb.height() - THUMBNAIL_MARGIN;
-    thumbnail_label.showPixmap(mapToParent(QPoint(x, y)), utils::formatSeconds(seconds), thumb, alertInfo(seconds));
+    thumbnail_label->showPixmap(mapToParent(QPoint(x, y)), utils::formatSeconds(seconds), thumb, alertInfo(seconds));
   } else {
-    thumbnail_label.hide();
+    thumbnail_label->hide();
   }
   QSlider::mouseMoveEvent(e);
 }
@@ -335,7 +336,7 @@ bool Slider::event(QEvent *event) {
     case QEvent::FocusIn:
     case QEvent::FocusOut:
     case QEvent::Leave:
-      thumbnail_label.hide();
+      thumbnail_label->hide();
       break;
     default:
       break;

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -56,7 +56,7 @@ private:
 
   QMap<uint64_t, QPixmap> thumbnails;
   std::map<uint64_t, AlertInfo> alerts;
-  InfoLabel thumbnail_label;
+  InfoLabel *thumbnail_label;
 };
 
 class VideoWidget : public QFrame {


### PR DESCRIPTION
**Issue**: the `QSlider::thumbnail_label`'  was deleted twice on exit.

create qt objects with parent on the stack is dangerous. it can cause double delete & undefined behavior on exit: 
https://doc.qt.io/qt-6/objecttrees.html

https://softwareengineering.stackexchange.com/questions/382975/should-i-always-allocate-qobject-and-derived-classes-to-the-heap:

> The rule actually ought to be that you should only create parentless QObjects on the stack. If the QObject has a parent, its parent ought to be in control of destroying it, not the stack. If it has no parent, then it is fine for the stack to be responsible for destroying it.

**fixed**: allocate `QSlider::thumbnail_label` and other qt objects with parent on the heap.
