### PR TITLE
ui/controls.cc: fix QLabel leak

### DIFF
--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -12,13 +12,14 @@ AbstractControl::AbstractControl(const QString &title, const QString &desc, cons
   hlayout->setSpacing(20);
 
   // left icon
-  icon_label = new QLabel();
+  icon_label = new QLabel(this);
+  hlayout->addWidget(icon_label);
   if (!icon.isEmpty()) {
     icon_pixmap = QPixmap(icon).scaledToWidth(80, Qt::SmoothTransformation);
     icon_label->setPixmap(icon_pixmap);
     icon_label->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
-    hlayout->addWidget(icon_label);
   }
+  icon_label->setVisible(!icon.isEmpty());
 
   // title
   title_label = new QPushButton(title);


### PR DESCRIPTION
**issue**: `AbstractControl` will create a parentless `QLabel` If there is no icon, this will cause a memory leak, and there will be many invisible qlabel  floating on the the main UI interface.

