### PR TITLE
Pytest: consistent codecov

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -27,7 +27,7 @@ env:
   RUN_CL: docker run --shm-size 1G -v $PWD:/tmp/openpilot -w /tmp/openpilot -e PYTHONWARNINGS=error -e PYTHONPATH=/tmp/openpilot -e NUM_JOBS -e JOB_ID -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -v $GITHUB_WORKSPACE/.ci_cache/scons_cache:/tmp/scons_cache -v $GITHUB_WORKSPACE/.ci_cache/comma_download_cache:/tmp/comma_download_cache -v $GITHUB_WORKSPACE/.ci_cache/openpilot_cache:/tmp/openpilot_cache $CL_BASE_IMAGE /bin/sh -c
 
   UNIT_TEST: coverage run --append -m unittest discover
-  PYTEST: pytest --continue-on-collection-errors --cov --cov-report=xml --cov-append --durations=0 --durations-min=5
+  PYTEST: pytest --continue-on-collection-errors --cov --cov-report=xml --cov-append --durations=0 --durations-min=5 --hypothesis-seed 0
 
 jobs:
   build_release:

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,4 @@ coverage:
 ignore:
   - "**/test_*.py"
   - "selfdrive/test/**"
+  - "system/version.py" # codecov changes depending on if we are in a branch or not

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import random
 
 from openpilot.common.prefix import OpenpilotPrefix
 from openpilot.system.hardware import TICI
@@ -8,6 +9,8 @@ from openpilot.system.hardware import TICI
 @pytest.fixture(scope="function", autouse=True)
 def openpilot_function_fixture():
   starting_env = dict(os.environ)
+
+  random.seed(0)
 
   # setup a clean environment for each test
   with OpenpilotPrefix():

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -18,7 +18,7 @@ from openpilot.selfdrive.test.fuzzy_generation import DrawType, FuzzyGenerator
 
 ALL_ECUS = list({ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()})
 
-MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '10'))
+MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '20'))
 
 
 def get_fuzzy_car_interface_args(draw: DrawType) -> dict:

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -18,7 +18,7 @@ from openpilot.selfdrive.test.fuzzy_generation import DrawType, FuzzyGenerator
 
 ALL_ECUS = list({ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()})
 
-MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '5'))
+MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '10'))
 
 
 def get_fuzzy_car_interface_args(draw: DrawType) -> dict:


### PR DESCRIPTION
Codecov changes slightly every commit, I think because of some randomness in hypothesis, which makes it hard to really see if you are changing the codecoverage, for example in https://github.com/commaai/openpilot/pull/30260

- Set random seed to 0
- Increase number of samples so we don't lose any coverage in test_car_interfaces

Example commit that did not change any car-related stuff:
![image](https://github.com/commaai/openpilot/assets/9648890/e2d1b278-f74e-41f2-9b54-45bdbaab5f30)
