### PR TITLE
Revert "CI: codecov for multiprocessing"

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -213,7 +213,6 @@ jobs:
       run: |
         ${{ env.RUN }} "CI=1 coverage run selfdrive/test/process_replay/test_processes.py -j$(nproc) && \
                         chmod -R 777 /tmp/comma_download_cache && \
-                        coverage combine && \
                         coverage xml"
     - name: Print diff
       id: print-diff
@@ -283,7 +282,6 @@ jobs:
       run: |
         ${{ env.RUN_CL }} "unset PYTHONWARNINGS && \
                            ONNXCPU=1 CI=1 NO_NAV=1 coverage run selfdrive/test/process_replay/model_replay.py && \
-                           coverage combine && \
                            coverage xml"
     - name: Run unit tests
       timeout-minutes: 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,3 @@ flake8-implicit-str-concat.allow-multiline=false
 "system".msg = "Use openpilot.system"
 "third_party".msg = "Use openpilot.third_party"
 "tools".msg = "Use openpilot.tools"
-
-[tool.coverage.run]
-concurrency = ["multiprocessing", "thread"]

--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -87,7 +87,7 @@ class TestAthenadMethods(unittest.TestCase):
 
     p = Process(target=send_deviceState)
     p.start()
-    time.sleep(0.2)
+    time.sleep(0.1)
     try:
       deviceState = dispatcher["getMessage"]("deviceState")
       assert deviceState['deviceState']


### PR DESCRIPTION
Reverts commaai/openpilot#30428

causes timeout in athenad test