### PR TITLE
Update SConstruct allow no-inline

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -38,6 +38,10 @@ AddOption('--compile_db',
           action='store_true',
           help='build clang compilation database')
 
+AddOption('--fno-inline',
+          action='store_true',
+          help='Disabled inlined functions when compiling to aid with debugging.')
+
 AddOption('--snpe',
           action='store_true',
           help='use SNPE on PC')
@@ -169,6 +173,9 @@ if arch != "Darwin":
 # Enable swaglog include in submodules
 cflags += ['-DSWAGLOG="\\"common/swaglog.h\\""']
 cxxflags += ['-DSWAGLOG="\\"common/swaglog.h\\""']
+
+if GetOption('fno-inline'):
+  ccflags += ["-fno-inline"]
 
 env = Environment(
   ENV=lenv,

--- a/SConstruct
+++ b/SConstruct
@@ -38,9 +38,9 @@ AddOption('--compile_db',
           action='store_true',
           help='build clang compilation database')
 
-AddOption('--fno-inline',
+AddOption('--fno_inline',
           action='store_true',
-          help='Disabled inlined functions when compiling to aid with debugging.')
+          help='Disables inlined functions when compiling to aid with debugging.')
 
 AddOption('--snpe',
           action='store_true',
@@ -174,7 +174,7 @@ if arch != "Darwin":
 cflags += ['-DSWAGLOG="\\"common/swaglog.h\\""']
 cxxflags += ['-DSWAGLOG="\\"common/swaglog.h\\""']
 
-if GetOption('fno-inline'):
+if GetOption('fno_inline'):
   ccflags += ["-fno-inline"]
 
 env = Environment(


### PR DESCRIPTION
Allows disabling inline functions when compiling to help with the debugging process
