### PR TITLE
cabana: highlight dowloaded segments

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -14,7 +14,6 @@
 #include <QtConcurrent>
 
 #include "tools/cabana/streams/replaystream.h"
-#include "tools/cabana/util.h"
 
 const int MIN_VIDEO_HEIGHT = 100;
 const int THUMBNAIL_MARGIN = 3;
@@ -290,12 +289,23 @@ void Slider::paintEvent(QPaintEvent *ev) {
   double min = minimum() / factor;
   double max = maximum() / factor;
 
-  for (auto [begin, end, type] : qobject_cast<ReplayStream *>(can)->getReplay()->getTimeline()) {
-    if (begin > max || end < min)
-      continue;
+  auto fillRange = [&](double begin, double end, const QColor &color) {
+    if (begin > max || end < min) return;
     r.setLeft(((std::max(min, begin) - min) / (max - min)) * width());
     r.setRight(((std::min(max, end) - min) / (max - min)) * width());
-    p.fillRect(r, timeline_colors[(int)type]);
+    p.fillRect(r, color);
+  };
+
+  const auto replay = qobject_cast<ReplayStream *>(can)->getReplay();
+  for (auto [begin, end, type] : replay->getTimeline()) {
+    fillRange(begin, end, timeline_colors[(int)type]);
+  }
+
+  QColor empty_color = palette().color(QPalette::Window);
+  empty_color.setAlpha(160);
+  for (const auto &[n, seg] : replay->segments()) {
+    if (!(seg && seg->isLoaded()))
+      fillRange(n * 60.0, (n + 1) * 60.0, empty_color);
   }
 
   QStyleOptionSlider opt;

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -8,7 +8,6 @@
 #include <QFrame>
 #include <QSlider>
 #include <QTabBar>
-#include <QToolButton>
 
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 #include "tools/cabana/util.h"


### PR DESCRIPTION
Highlight downloaded/cached segments, make It is easy to know the current cache status.

![2023-11-14_13-25](https://github.com/commaai/openpilot/assets/27770/3863330f-7fa6-45ba-aa51-396a4d2a06ed)
dark theme:
![2023-11-14_13-26](https://github.com/commaai/openpilot/assets/27770/ab855d14-1f30-4770-8d02-4b39b513a5de)

