### PR TITLE
cabana: fix double comparisons

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -22,7 +22,9 @@
 
 // ChartAxisElement's padding is 4 (https://codebrowser.dev/qt5/qtcharts/src/charts/axis/chartaxiselement_p.h.html)
 const int AXIS_X_TOP_MARGIN = 4;
-static inline bool xLessThan(const QPointF &p, float x) { return p.x() < x; }
+// Define a small value of epsilon to compare double values
+const float EPSILON = 0.000001;
+static inline bool xLessThan(const QPointF &p, float x) { return p.x() < (x - EPSILON); }
 
 ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *parent)
     : charts_widget(parent), QChartView(parent) {
@@ -768,7 +770,8 @@ void ChartView::drawSignalValue(QPainter *painter) {
   painter->setPen(chart()->legend()->labelColor());
   int i = 0;
   for (auto &s : sigs) {
-    auto it = std::lower_bound(s.vals.crbegin(), s.vals.crend(), cur_sec, [](auto &p, double x) { return p.x() > x; });
+    auto it = std::lower_bound(s.vals.crbegin(), s.vals.crend(), cur_sec,
+                               [](auto &p, double x) { return p.x() > x + EPSILON; });
     QString value = (it != s.vals.crend() && it->x() >= axis_x->min()) ? s.sig->formatValue(it->y()) : "--";
     QRectF marker_rect = legend_markers[i++]->sceneBoundingRect();
     QRectF value_rect(marker_rect.bottomLeft() - QPoint(0, 1), marker_rect.size());

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -91,7 +91,9 @@ void AbstractStream::updateLastMessages() {
   {
     std::lock_guard lk(mutex_);
     for (const auto &id : new_msgs_) {
-      last_msgs[id] = messages_[id];
+      const auto &can_data = messages_[id];
+      current_sec_ = std::max(current_sec_, can_data.ts);
+      last_msgs[id] = can_data;
       sources.insert(id.source);
     }
     msgs = std::move(new_msgs_);
@@ -128,6 +130,7 @@ void AbstractStream::updateLastMsgsTo(double sec) {
   new_msgs_.clear();
   messages_.clear();
 
+  current_sec_ = sec;
   uint64_t last_ts = (sec + routeStartTime()) * 1e9;
   for (const auto &[id, ev] : events_) {
     auto it = std::upper_bound(ev.begin(), ev.end(), last_ts, CompareCanEvent());

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -69,7 +69,7 @@ public:
   virtual QString carFingerprint() const { return ""; }
   virtual QDateTime beginDateTime() const { return {}; }
   virtual double routeStartTime() const { return 0; }
-  virtual double currentSec() const = 0;
+  inline double currentSec() const { return current_sec_; }
   virtual double totalSeconds() const { return lastEventMonoTime() / 1e9 - routeStartTime(); }
   virtual void setSpeed(float speed) {}
   virtual double getSpeed() { return 1; }
@@ -113,6 +113,7 @@ private:
   void updateLastMsgsTo(double sec);
   void updateMasks();
 
+  double current_sec_ = 0;
   MessageEventsMap events_;
   std::unordered_map<MessageId, CanData> last_msgs;
   std::unique_ptr<MonotonicBuffer> event_buffer_;
@@ -140,7 +141,6 @@ public:
   DummyStream(QObject *parent) : AbstractStream(parent) {}
   QString routeName() const override { return tr("No Stream"); }
   void start() override { emit streamStarted(); }
-  double currentSec() const override { return 0; }
 };
 
 class StreamNotifier : public QObject {

--- a/tools/cabana/streams/livestream.h
+++ b/tools/cabana/streams/livestream.h
@@ -16,7 +16,6 @@ public:
   void start() override;
   inline QDateTime beginDateTime() const { return begin_date_time; }
   inline double routeStartTime() const override { return begin_event_ts / 1e9; }
-  inline double currentSec() const override { return (current_event_ts - begin_event_ts) / 1e9; }
   void setSpeed(float speed) override { speed_ = speed; }
   double getSpeed() override { return speed_; }
   bool isPaused() const override { return paused_; }

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -25,7 +25,6 @@ public:
   double totalSeconds() const override { return replay->totalSeconds(); }
   inline QDateTime beginDateTime() const { return replay->route()->datetime(); }
   inline double routeStartTime() const override { return replay->routeStartTime() / (double)1e9; }
-  inline double currentSec() const override { return replay->currentSeconds(); }
   inline const Route *route() const { return replay->route(); }
   inline void setSpeed(float speed) override { replay->setSpeed(speed); }
   inline float getSpeed() const { return replay->getSpeed(); }


### PR DESCRIPTION
use a small epsilon to fix double comparison issue that causes time mismatch:

![2023-11-15_12-23](https://github.com/commaai/openpilot/assets/27770/36b6bbd7-83a7-4c10-a9b8-04a99782b876)
