### PR TITLE
Revert "Pytest: run tests in random order"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ignore=openpilot/ --ignore=cereal/ --ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ -Werror --strict-config --strict-markers --durations=10 -n auto --dist=loadgroup --random-order"
+addopts = "--ignore=openpilot/ --ignore=cereal/ --ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ -Werror --strict-config --strict-markers --durations=10 -n auto --dist=loadgroup"
 cpp_files = "test_*"
 python_files = "test_*.py"
 #timeout = "30"  # you get this long by default

--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -34,8 +34,6 @@ class TestAthenadMethods(unittest.TestCase):
     athenad.LOCAL_PORT_WHITELIST = {cls.SOCKET_PORT}
 
   def setUp(self):
-    dispatcher["listUploadQueue"]() # ensure queue is empty at start
-
     MockParams.restore_defaults()
     athenad.upload_queue = queue.Queue()
     athenad.cur_upload_items.clear()
@@ -47,6 +45,8 @@ class TestAthenadMethods(unittest.TestCase):
         shutil.rmtree(p)
       else:
         os.unlink(p)
+
+    dispatcher["listUploadQueue"]() # ensure queue is empty at start
 
   # *** test helpers ***
 

--- a/selfdrive/controls/tests/test_state_machine.py
+++ b/selfdrive/controls/tests/test_state_machine.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-import copy
 import unittest
-from unittest import mock
 
 from cereal import car, log
 from openpilot.common.realtime import DT_CTRL
@@ -19,7 +17,6 @@ ALL_STATES = tuple(State.schema.enumerants.values())
 # The event types checked in DISABLED section of state machine
 ENABLE_EVENT_TYPES = (ET.ENABLE, ET.PRE_ENABLE, ET.OVERRIDE_LATERAL, ET.OVERRIDE_LONGITUDINAL)
 
-EVENTS = copy.copy(EVENTS)
 
 def make_event(event_types):
   event = {}
@@ -30,7 +27,6 @@ def make_event(event_types):
   return 0
 
 
-@mock.patch("openpilot.selfdrive.controls.lib.events.EVENTS", EVENTS)
 class TestStateMachine(unittest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
still causes unittest failures?