### PR TITLE
openpilot CI: fix azure bucket names

### DIFF
--- a/selfdrive/test/openpilotci.py
+++ b/selfdrive/test/openpilotci.py
@@ -7,8 +7,9 @@ from typing import IO, Union
 
 DATA_CI_ACCOUNT = "commadataci"
 DATA_CI_ACCOUNT_URL = f"https://{DATA_CI_ACCOUNT}.blob.core.windows.net"
-DATA_CI_CONTAINER = "openpilotci"
-BASE_URL = f"{DATA_CI_ACCOUNT_URL}/{DATA_CI_CONTAINER}/"
+OPENPILOT_CI_CONTAINER = "openpilotci"
+DATA_CI_CONTAINER = "commadataci"
+BASE_URL = f"{DATA_CI_ACCOUNT_URL}/{OPENPILOT_CI_CONTAINER}/"
 
 TOKEN_PATH = Path("/data/azure_token")
 
@@ -51,7 +52,7 @@ def upload_bytes(data: Union[bytes, IO], blob_name: str) -> str:
   from azure.storage.blob import BlobClient
   blob = BlobClient(
     account_url=DATA_CI_ACCOUNT_URL,
-    container_name=DATA_CI_CONTAINER,
+    container_name=OPENPILOT_CI_CONTAINER,
     blob_name=blob_name,
     credential=get_azure_credential(),
   )

--- a/selfdrive/test/update_ci_routes.py
+++ b/selfdrive/test/update_ci_routes.py
@@ -9,8 +9,8 @@ from tqdm import tqdm
 
 from openpilot.selfdrive.car.tests.routes import routes as test_car_models_routes
 from openpilot.selfdrive.test.process_replay.test_processes import source_segments as replay_segments
-from openpilot.selfdrive.test.openpilotci import (DATA_CI_ACCOUNT, DATA_CI_ACCOUNT_URL, DATA_CI_CONTAINER,
-                                                  get_azure_credential, get_container_sas)
+from openpilot.selfdrive.test.openpilotci import (DATA_CI_ACCOUNT, DATA_CI_ACCOUNT_URL, OPENPILOT_CI_CONTAINER,
+                                                  DATA_CI_CONTAINER, get_azure_credential, get_container_sas)
 
 DATA_PROD_ACCOUNT = "commadata2"
 DATA_PROD_CONTAINER = "commadata2"
@@ -23,15 +23,15 @@ SOURCES = [
 
 @lru_cache
 def get_azure_keys():
-  dest_container = ContainerClient(DATA_CI_ACCOUNT_URL, DATA_CI_CONTAINER, credential=get_azure_credential())
-  dest_key = get_container_sas(DATA_CI_ACCOUNT, DATA_CI_CONTAINER)
+  dest_container = ContainerClient(DATA_CI_ACCOUNT_URL, OPENPILOT_CI_CONTAINER, credential=get_azure_credential())
+  dest_key = get_container_sas(DATA_CI_ACCOUNT, OPENPILOT_CI_CONTAINER)
   source_keys = [get_container_sas(*s) for s in SOURCES]
   return dest_container, dest_key, source_keys
 
 
 def upload_route(path: str, exclude_patterns: Optional[Iterable[str]] = None) -> None:
   # TODO: use azure-storage-blob instead of azcopy, simplifies auth
-  dest_key = get_container_sas(DATA_CI_ACCOUNT, DATA_CI_CONTAINER)
+  dest_key = get_container_sas(DATA_CI_ACCOUNT, OPENPILOT_CI_CONTAINER)
   if exclude_patterns is None:
     exclude_patterns = ['*/dcamera.hevc']
 
@@ -42,7 +42,7 @@ def upload_route(path: str, exclude_patterns: Optional[Iterable[str]] = None) ->
     "azcopy",
     "copy",
     f"{path}/*",
-    f"https://{DATA_CI_ACCOUNT}.blob.core.windows.net/{DATA_CI_CONTAINER}/{destpath}?{dest_key}",
+    f"https://{DATA_CI_ACCOUNT}.blob.core.windows.net/{OPENPILOT_CI_CONTAINER}/{destpath}?{dest_key}",
     "--recursive=false",
     "--overwrite=false",
   ] + [f"--exclude-pattern={p}" for p in exclude_patterns]
@@ -65,7 +65,7 @@ def sync_to_ci_public(route: str) -> bool:
       "azcopy",
       "copy",
       f"https://{source_account}.blob.core.windows.net/{source_bucket}/{key_prefix}?{source_key}",
-      f"https://{DATA_CI_ACCOUNT}.blob.core.windows.net/{DATA_CI_CONTAINER}/{dongle_id}?{dest_key}",
+      f"https://{DATA_CI_ACCOUNT}.blob.core.windows.net/{OPENPILOT_CI_CONTAINER}/{dongle_id}?{dest_key}",
       "--recursive=true",
       "--overwrite=false",
       "--exclude-pattern=*/dcamera.hevc",


### PR DESCRIPTION
commadataci/commadataci (a private container) was added here but is no longer active/used anywhere as far as I can tell: https://github.com/commaai/openpilot/commit/a25acaae0770a32aa54abd4d41dc0f5ab5077f9a

but was replaced (by accident?) with the public destination account and bucket here, so it doesn't do anything (since if route exists in dest bucket it skips trying to get it from the dest bucket): https://github.com/commaai/openpilot/pull/29411/commits/bc9d0b302d608ae46b8628e515d0bc305ec916c6 in https://github.com/commaai/openpilot/pull/29411

---

Renames `DATA_CI_CONTAINER` to `OPENPILOT_CI_CONTAINER`, leaving alone the `SOURCES` list so the second source is not also the destination. This fixes cases where we need to re-copy/overwrite the public routes in `openpilotci` with the ones in the private bucket which wasn't being referenced since the PR above.

```python
SOURCES = [
  (DATA_PROD_ACCOUNT, DATA_PROD_CONTAINER),
  (DATA_CI_ACCOUNT, DATA_CI_CONTAINER),
]
```