### PR TITLE
[cabana] fix clang17 warning

### DIFF
--- a/tools/cabana/tools/findsignal.cc
+++ b/tools/cabana/tools/findsignal.cc
@@ -214,7 +214,9 @@ void FindSignalDlg::setInitialSignals() {
   sig.factor = factor_edit->text().toDouble();
   sig.offset = offset_edit->text().toDouble();
 
-  auto [first_sec, last_sec] = std::minmax(first_time_edit->text().toDouble(), last_time_edit->text().toDouble());
+  double first_time_val = first_time_edit->text().toDouble();
+  double last_time_val = last_time_edit->text().toDouble();
+  auto [first_sec, last_sec] = std::minmax(first_time_val, last_time_val);
   uint64_t first_time = (can->routeStartTime() + first_sec) * 1e9;
   model->last_time = std::numeric_limits<uint64_t>::max();
   if (last_sec > 0) {


### PR DESCRIPTION


**Description** 
The variables `first_sec` and `last_sec` have been separately initialized first before being used in `std::minmax` for signal timings. This resolves compilation warnings and potential risks of using temporary values of these variables.

**Verification** 
* Run compilation with clang++ 17 

This solves https://github.com/commaai/openpilot/issues/30489
