### PR TITLE
ui/ParamControl: do not create ConfirmationDialog on every click

### DIFF
--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -114,3 +114,28 @@ void ElidedLabel::paintEvent(QPaintEvent *event) {
   opt.initFrom(this);
   style()->drawItemText(&painter, contentsRect(), alignment(), opt.palette, isEnabled(), elidedText_, foregroundRole());
 }
+
+// ParamControl
+
+ParamControl::ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, QWidget *parent)
+    : ToggleControl(title, desc, icon, false, parent) {
+  key = param.toStdString();
+  QObject::connect(this, &ParamControl::toggleFlipped, this, &ParamControl::toggleClicked);
+}
+
+void ParamControl::toggleClicked(bool state) {
+  auto do_confirm = [this]() {
+    QString content("<body><h2 style=\"text-align: center;\">" + title_label->text() + "</h2><br>"
+                    "<p style=\"text-align: center; margin: 0 128px; font-size: 50px;\">" + getDescription() + "</p></body>");
+    return ConfirmationDialog(content, tr("Enable"), tr("Cancel"), true, this).exec();
+  };
+
+  bool confirmed = store_confirm && params.getBool(key + "Confirmed");
+  if (!confirm || confirmed || !state || do_confirm()) {
+    if (store_confirm && state) params.putBool(key + "Confirmed", true);
+    params.putBool(key, state);
+    setIcon(state);
+  } else {
+    toggle.togglePosition();
+  }
+}

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -144,24 +144,7 @@ class ParamControl : public ToggleControl {
   Q_OBJECT
 
 public:
-  ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, QWidget *parent = nullptr) : ToggleControl(title, desc, icon, false, parent) {
-    key = param.toStdString();
-    QObject::connect(this, &ParamControl::toggleFlipped, [=](bool state) {
-      QString content("<body><h2 style=\"text-align: center;\">" + title + "</h2><br>"
-                      "<p style=\"text-align: center; margin: 0 128px; font-size: 50px;\">" + getDescription() + "</p></body>");
-      ConfirmationDialog dialog(content, tr("Enable"), tr("Cancel"), true, this);
-
-      bool confirmed = store_confirm && params.getBool(key + "Confirmed");
-      if (!confirm || confirmed || !state || dialog.exec()) {
-        if (store_confirm && state) params.putBool(key + "Confirmed", true);
-        params.putBool(key, state);
-        setIcon(state);
-      } else {
-        toggle.togglePosition();
-      }
-    });
-  }
-
+  ParamControl(const QString &param, const QString &title, const QString &desc, const QString &icon, QWidget *parent = nullptr);
   void setConfirmation(bool _confirm, bool _store_confirm) {
     confirm = _confirm;
     store_confirm = _store_confirm;
@@ -184,6 +167,7 @@ public:
   }
 
 private:
+  void toggleClicked(bool state);
   void setIcon(bool state) {
     if (state && !active_icon_pixmap.isNull()) {
       icon_label->setPixmap(active_icon_pixmap);


### PR DESCRIPTION
Fixed the `ConfirmationDialog` is always created on click, even if it won't be executed.