### PR TITLE
hyundai: radarTimeStep 50Hz

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -276,6 +276,8 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalActuatorDelayLowerBound = 0.5
     ret.longitudinalActuatorDelayUpperBound = 0.5
 
+    ret.radarTimeStep = (1.0 / 50) # 0.02 s
+
     # *** feature detection ***
     if candidate in CANFD_CAR:
       ret.enableBsm = 0x1e5 in fingerprint[CAN.ECAN]


### PR DESCRIPTION
The radar reception frequency of Hyundai is 50Hz. 
However, the default value of radarTimeStep, 20Hz, is still being used. 
This may lead to inaccuracies in the aLeadK value.

If radarTimeStep is adjusted, more accurate aLeadK values can be obtained, which I believe would result in better long control performance.

https://github.com/commaai/openpilot/blob/31ef352234b3348aa96417e17d49a0cea5be6450/selfdrive/car/hyundai/radar_interface.py#L17