### PR TITLE
radard: check y_sane

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -142,7 +142,8 @@ def match_vision_to_track(v_ego: float, lead: capnp._DynamicStructReader, tracks
   # stationary radar points can be false positives
   dist_sane = abs(track.dRel - offset_vision_dist) < max([(offset_vision_dist)*.25, 5.0])
   vel_sane = (abs(track.vRel + v_ego - lead.v[0]) < 10) or (v_ego + track.vRel > 3)
-  if dist_sane and vel_sane:
+  y_sane = (abs(-lead.y[0]-track.yRel) < 3.2 / 2.)  #TODO: lane_width assumed 3.2M
+  if dist_sane and vel_sane and y_sane:
     return track
   else:
     return None


### PR DESCRIPTION
Sometimes, the vision system detects a lead car, but there might be no radar detections around the detected lead car. 

In the match_vision_to_track function, the optimal track is found through a Laplacian process. 
However, without radar detections near the vision-detected car, the function may end up returning the track of a vehicle next to the driving lane as the optimal one. 

The best approach would be to validate the probability values of the Laplacian. 
Nevertheless, I believe that adding a y_sane check to verify the difference in the y-values between the detected vision and the track could be a simpler method. 
The set limit for this is the typical lane width of 3.2 meters

