### PR TITLE
CI: automatically create PR to bump submodules

### DIFF
--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -50,3 +50,4 @@ jobs:
         branch: auto-package-updates
         base: master
         delete-branch: true
+        body: 'Update Python packages and pre-commit hooks'

--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -29,6 +29,7 @@ jobs:
         branch: auto-bump-submodules
         base: master
         delete-branch: true
+        body: 'Automatic PR from repo-maintenance -> bump_submodules'
   package_updates:
     name: package_updates
     runs-on: ubuntu-20.04
@@ -53,4 +54,4 @@ jobs:
         branch: auto-package-updates
         base: master
         delete-branch: true
-        body: 'Update Python packages and pre-commit hooks'
+        body: 'Automatic PR from repo-maintenance -> package_updates'

--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -17,6 +17,7 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         git -c submodule."tinygrad".update=none submodule update --remote
+        git add .
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5
       with:

--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -2,12 +2,32 @@ name: repo maintenance
 
 on:
   schedule:
-    - cron: "0 15 * * 2"
+    - cron: "0 15 * * *"
   workflow_dispatch:
 
 jobs:
-  updates:
-    name: updates
+  bump_submodules:
+    name: bump_submodules
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/commaai/openpilot-base:latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: bump submodules
+      run: |
+        git config --global --add safe.directory '*'
+        git -c submodule."tinygrad".update=none submodule update --remote
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5
+      with:
+        token: ${{ secrets.ACTIONS_CREATE_PR_PAT }}
+        commit-message: bump submodules
+        title: 'Bump submodules'
+        branch: auto-bump-submodules
+        base: master
+        delete-branch: true
+  package_updates:
+    name: package_updates
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/commaai/openpilot-base:latest

--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -13,6 +13,8 @@ jobs:
       image: ghcr.io/commaai/openpilot-base:latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: bump submodules
       run: |
         git config --global --add safe.directory '*'

--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -26,6 +26,7 @@ jobs:
         branch: auto-bump-submodules
         base: master
         delete-branch: true
+        body: 'Bump Submodules'
   package_updates:
     name: package_updates
     runs-on: ubuntu-20.04
@@ -50,3 +51,4 @@ jobs:
         branch: auto-package-updates
         base: master
         delete-branch: true
+        body: 'Update Python packages and pre-commit hooks'


### PR DESCRIPTION
Example automatic PR: https://github.com/jnewb1/openpilot/pull/57

opendbc hasn't been updated in over a month, and panda had some issues that weren't caught until merged with master. this would help catch those cases earlier.

If a PR is already open, it will just update the PR, so I think running repo_maintenance daily makes more sense