### PR TITLE
Kia: add missing fwdCamea FW for Sorento PHEV 4th gen

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1908,11 +1908,20 @@ FW_VERSIONS = {
   },
   CAR.KIA_SORENTO_PHEV_4TH_GEN: {
     (Ecu.fwdRadar, 0x7d0, None): [
-      b'\xf1\x00MQhe SCC FHCUP      1.00 1.06 99110-P4000         ',
+      b'\xf1\x00MQhe SCC FHCUP      1.00 1.06 99110-P4000         '
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
-      b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.11 99210-P2000 211217',
-    ]
+      b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.11 99210-P2000 211217'
+    ],
+    (Ecu.hvac, 0x7B3, None): [
+     b"\xf1\x00MQ4   97255-P4230CONTROL ASS'Y-DATC  1.02 MQ4 PHEV(-) 0.6     "
+    ],
+    (Ecu.cornerRadar, 0x7B7, None): [
+     b'\xf1\x00MQ4 BCW RR 1.00 , 1.01 (t\x00W!\x02Q\x07I'
+    ],
+    (Ecu.parkingAdas, 0x7B1, None): [
+     b'\xf1\x10MQ4H ADAS_PRK ANL 1.00 1.06 99910-P4150'
+    ],
   },
   CAR.KIA_EV6: {
     (Ecu.fwdRadar, 0x7d0, None): [

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1908,20 +1908,11 @@ FW_VERSIONS = {
   },
   CAR.KIA_SORENTO_PHEV_4TH_GEN: {
     (Ecu.fwdRadar, 0x7d0, None): [
-      b'\xf1\x00MQhe SCC FHCUP      1.00 1.06 99110-P4000         '
+      b'\xf1\x00MQhe SCC FHCUP      1.00 1.06 99110-P4000         ',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.11 99210-P2000 211217',
       b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.10 99210-P2000 210406',
-      b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.11 99210-P2000 211217'
-    ],
-    (Ecu.hvac, 0x7B3, None): [
-     b"\xf1\x00MQ4   97255-P4230CONTROL ASS'Y-DATC  1.02 MQ4 PHEV(-) 0.6     "
-    ],
-    (Ecu.cornerRadar, 0x7B7, None): [
-     b'\xf1\x00MQ4 BCW RR 1.00 , 1.01 (t\x00W!\x02Q\x07I'
-    ],
-    (Ecu.parkingAdas, 0x7B1, None): [
-     b'\xf1\x10MQ4H ADAS_PRK ANL 1.00 1.06 99910-P4150'
     ],
   },
   CAR.KIA_EV6: {

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1911,6 +1911,7 @@ FW_VERSIONS = {
       b'\xf1\x00MQhe SCC FHCUP      1.00 1.06 99110-P4000         '
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.10 99210-P2000 210406',
       b'\xf1\x00MQ4HMFC  AT USA LHD 1.00 1.11 99210-P2000 211217'
     ],
     (Ecu.hvac, 0x7B3, None): [


### PR DESCRIPTION
**Car**
2022 Kia Sorento

**Route**
0b6e3a5ec849ddf7\|2023-11-25--11-55-44
