### PR TITLE
Subaru: non-obd FW queries logging

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -141,6 +141,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.abs, Ecu.eps, Ecu.fwdCamera, Ecu.engine, Ecu.transmission],
     ),
     # Some Eyesight modules fail on TESTER_PRESENT_REQUEST
     # TODO: check if this resolves the fingerprinting issue for the 2023 Ascent and other new Subaru cars
@@ -153,12 +154,14 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.abs, Ecu.eps, Ecu.fwdCamera, Ecu.engine, Ecu.transmission],
       bus=0,
       logging=True,
     ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.abs, Ecu.eps, Ecu.fwdCamera, Ecu.engine, Ecu.transmission],
       bus=1,
       logging=True,
       obd_multiplexing=False,

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -147,21 +147,21 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [SUBARU_VERSION_REQUEST],
       [SUBARU_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.fwdCamera],
     ),
-
     # Non-OBD requests
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
       bus=0,
-      logging=True
+      logging=True,
     ),
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
       bus=1,
       logging=True,
-      obd_multiplexing=False
+      obd_multiplexing=False,
     ),
   ],
 )

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -148,6 +148,21 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [SUBARU_VERSION_REQUEST],
       [SUBARU_VERSION_RESPONSE],
     ),
+
+    # Non-OBD requests
+    Request(
+      [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
+      [StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
+      bus=0,
+      logging=True
+    ),
+    Request(
+      [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
+      [StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
+      bus=1,
+      logging=True,
+      obd_multiplexing=False
+    ),
   ],
 )
 

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -227,7 +227,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   @pytest.mark.timeout(60)
   def test_fw_query_timing(self):
-    total_ref_time = 6.07
+    total_ref_time = 6.27
     brand_ref_times = {
       1: {
         'body': 0.11,
@@ -237,7 +237,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'hyundai': 0.72,
         'mazda': 0.2,
         'nissan': 0.4,
-        'subaru': 0.2,
+        'subaru': 0.4,
         'tesla': 0.2,
         'toyota': 1.6,
         'volkswagen': 0.2,

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -151,9 +151,10 @@ class TestFwFingerprint(unittest.TestCase):
   def test_fw_request_ecu_whitelist(self):
     for brand, config in FW_QUERY_CONFIGS.items():
       with self.subTest(brand=brand):
-        whitelisted_ecus = {ecu for r in config.requests for ecu in r.whitelist_ecus}
         brand_ecus = {fw[0] for car_fw in VERSIONS[brand].values() for fw in car_fw}
         brand_ecus |= {ecu[0] for ecu in config.extra_ecus}
+
+        whitelisted_ecus = {ecu for r in config.requests for ecu in (r.whitelist_ecus if len(r.whitelist_ecus) > 0 else brand_ecus)}
 
         # each ecu in brand's fw versions + extra ecus needs to be whitelisted at least once
         ecus_not_whitelisted = brand_ecus - whitelisted_ecus

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -151,10 +151,9 @@ class TestFwFingerprint(unittest.TestCase):
   def test_fw_request_ecu_whitelist(self):
     for brand, config in FW_QUERY_CONFIGS.items():
       with self.subTest(brand=brand):
+        whitelisted_ecus = {ecu for r in config.requests for ecu in r.whitelist_ecus}
         brand_ecus = {fw[0] for car_fw in VERSIONS[brand].values() for fw in car_fw}
         brand_ecus |= {ecu[0] for ecu in config.extra_ecus}
-
-        whitelisted_ecus = {ecu for r in config.requests for ecu in (r.whitelist_ecus if len(r.whitelist_ecus) > 0 else brand_ecus)}
 
         # each ecu in brand's fw versions + extra ecus needs to be whitelisted at least once
         ecus_not_whitelisted = brand_ecus - whitelisted_ecus


### PR DESCRIPTION
for gen2:
bus 1 -> powertrain ecus (abs, transmission, engine)
bus 0 -> camera

gen1 will likely have everything on bus0

still need a way to get eps, should be on bus 0