### PR TITLE
GM Camera based ACC Allow all throttle range

### DIFF
--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -39,9 +39,10 @@ class CarControllerParams:
     self.MAX_BRAKE = 400  # ~ -4.0 m/s^2 with regen
 
     if CP.carFingerprint in CAMERA_ACC_CAR:
-      self.MAX_GAS = 3400
+      self.MAX_GAS = 4095
       self.MAX_ACC_REGEN = 1514
       self.INACTIVE_REGEN = 1554
+      self.ZERO_GAS = 1514
       # Camera ACC vehicles have no regen while enabled.
       # Camera transitions to MAX_ACC_REGEN from ZERO_GAS and uses friction brakes instantly
       max_regen_acceleration = 0.


### PR DESCRIPTION
Allow up to 4095 throttle, remove 2048 cutout for camera based ACC cars at lower throttle for full range off throttle control

**Car**
2020 GMC Sierra/Chevy Silverado 1500

**Route**
dc7716b32bf25574|2023-11-29--18-59-18--0

-->

<!--- ***** Template: Car bug fix *****

**Description** 
Throttle pegged out at 3400 at take off and light throttle to maintain speed behind lead on highway cuts off at 2048 causes to oscillate behind lead cars


**Verification** 

This route has the changes showing it can follow lead from departure and also maintain the speed with lead ahead normally with these changes

**Route**
Route: dc7716b32bf25574|2023-11-29--18-59-18--0

referencing more details on issue #30557 to compare before and after