### PR TITLE
"low upload" vs. "default upload" toggle for cellular

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -87,6 +87,7 @@ private:
 
 std::unordered_map<std::string, uint32_t> keys = {
     {"AccessToken", CLEAR_ON_MANAGER_START | DONT_LOG},
+    {"AllowMeteredUploads", PERSISTENT},
     {"ApiCache_Device", PERSISTENT},
     {"ApiCache_NavDestinations", PERSISTENT},
     {"AssistNowToken", PERSISTENT},

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -77,18 +77,18 @@ class UploadFile:
   def upload_on_cellular_allowed_by_params(self) -> bool:
     # see uploadPolicyToggle in selfdrive/ui/qt/network/networking.cc#AdvancedNetworking::AdvancedNetworking
 
-    if Params().get_bool("AllowMeteredUploads", True):
-      # ^^^ This is the `default upload` policy. It's believed to use an *average* of 6 GiB/mo or so...
+    if not Params().get_bool("AllowMeteredUploads"):
+      # User has requested 'low upload' policy… upload nothing until we're connected to a full connection (e.g. home Wi-Fi)
+      # see also https://discord.com/channels/469524606043160576/819046761287909446/1161366616920051914
+      return False
+    else:
+      # This is the `default upload` policy. It's believed to use an *average* of 6 GiB/mo or so...
       # https://discord.com/channels/469524606043160576/819046761287909446/1161369395382202438
       # https://discord.com/channels/469524606043160576/819046761287909446/1161366312686198905
       # At the moment this means we fall back to the UploadFile's initial `allow_cellular` value which
       #  * will upload the qlogs & qcameras while the connection is metered
       #  * will upload everything if the connection is not metered
       return self.allow_cellular
-    else:
-      # 'low upload' policy is to upload nothing until we're connected to a full connection (e.g. home Wi-Fi)
-      # see also https://discord.com/channels/469524606043160576/819046761287909446/1161366616920051914
-      return False
 
   @classmethod
   def from_dict(cls, d: dict) -> UploadFile:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -240,7 +240,11 @@ def cb(sm, item, tid, sz: int, cur: int) -> None:
 
 def upload_handler(end_event: threading.Event) -> None:
   # `log_handler` and `stats_handler` add to the queues, but don't actually upload anything themselves
-  # all the upload activity happens here in `upload_handler`
+  # all the athenad upload activity happens here in `upload_handler`
+  #
+  # Meanwhile, loggerd has its own uploads:
+  # * system/loggerd/uploader.py#Uploader.upload
+  # * system/loggerd/uploader.py#Uploader.normal_upload
   sm = messaging.SubMaster(['deviceState'])
   tid = threading.get_ident()
 

--- a/selfdrive/athena/tests/helpers.py
+++ b/selfdrive/athena/tests/helpers.py
@@ -55,6 +55,7 @@ class MockParams():
     "GithubSshKeys": b"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC307aE+nuHzTAgaJhzSf5v7ZZQW9gaperjhCmyPyl4PzY7T1mDGenTlVTN7yoVFZ9UfO9oMQqo0n1OwDIiqbIFxqnhrHU0cYfj88rI85m5BEKlNu5RdaVTj1tcbaPpQc5kZEolaI1nDDjzV0lwS7jo5VYDHseiJHlik3HH1SgtdtsuamGR2T80q1SyW+5rHoMOJG73IH2553NnWuikKiuikGHUYBd00K1ilVAK2xSiMWJp55tQfZ0ecr9QjEsJ+J/efL4HqGNXhffxvypCXvbUYAFSddOwXUPo5BTKevpxMtH+2YrkpSjocWA04VnTYFiPG6U4ItKmbLOTFZtPzoez private", # noqa: E501
     "GithubUsername": b"commaci",
     "GsmMetered": True,
+    "AllowMeteredUploads": True,
     "AthenadUploadQueue": '[]',
   }
   params = default_params.copy()

--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -176,6 +176,10 @@ class TestAthenadMethods(unittest.TestCase):
     self.assertIsNotNone(resp['items'][0].get('id'))
     self.assertEqual(athenad.upload_queue.qsize(), 1)
 
+    # Compare selfdrive/athena/athenad.py#uploadFileToUrl vs. selfdrive/athena/athenad.py#UploadFile.from_dict
+    # Even with 'GsmMetered' and 'AllowMeteredUploads' set, athenad uploadFileToUrl logs aren't uploaded on metered connections by default
+    self.assertEqual(resp['items'][0].get('allow_cellular'), False)
+
   @with_http_server
   def test_uploadFileToUrl_duplicate(self, host):
     self._create_file('qlog.bz2')

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -42,6 +42,7 @@ def manager_init() -> None:
     ("CompletedTrainingVersion", "0"),
     ("DisengageOnAccelerator", "0"),
     ("GsmMetered", "1"),
+    ("AllowMeteredUploads", "1"),
     ("HasAcceptedTerms", "0"),
     ("LanguageSetting", "main_en"),
     ("OpenpilotEnabledToggle", "1"),

--- a/selfdrive/ui/qt/network/networking.h
+++ b/selfdrive/ui/qt/network/networking.h
@@ -63,6 +63,7 @@ private:
   ToggleControl* roamingToggle;
   ButtonControl* editApnButton;
   ToggleControl* meteredToggle;
+  ToggleControl* uploadPolicyToggle;
   WifiManager* wifi = nullptr;
   Params params;
 

--- a/selfdrive/ui/translations/main_ar.ts
+++ b/selfdrive/ui/translations/main_ar.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>منع تحميل البيانات الكبيرة عندما يكون الاتصال محدوداً</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>Hochladen großer Dateien über getaktete Verbindungen unterbinden</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>Éviter les transferts de données importants sur une connexion limitée</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>大量のデータのアップロードを防止します。</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>데이터 요금제 연결 시 대용량 데이터 업로드를 방지합니다</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>Evite grandes uploads de dados quando estiver em uma conexão limitada</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_th.ts
+++ b/selfdrive/ui/translations/main_th.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>ปิดการอัพโหลดข้อมูลขนาดใหญ่เมื่อเชื่อมต่อผ่านเซลลูล่าร์</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_tr.ts
+++ b/selfdrive/ui/translations/main_tr.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>当使用按流量计费的连接时，避免上传大流量数据</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -66,6 +66,14 @@
         <source>Prevent large data uploads when on a metered connection</source>
         <translation>防止使用行動網路上傳大量的數據</translation>
     </message>
+    <message>
+        <source>Upload when Metered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow uploads when on a metered connection (such as if the cellular SIM is on a limited data plan, or if connected to a Wi-Fi hotspot that is reporting as a metered connection of its own)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AnnotatedCameraWidget</name>

--- a/system/loggerd/tests/test_uploader.py
+++ b/system/loggerd/tests/test_uploader.py
@@ -7,6 +7,7 @@ import logging
 import json
 from pathlib import Path
 from typing import List, Optional
+import cereal.messaging as messaging
 from openpilot.system.hardware.hw import Paths
 
 from openpilot.system.swaglog import cloudlog
@@ -96,6 +97,10 @@ class TestUploader(UploaderTestCase):
     self.gen_files(lock=False)
 
     MockParams().put('AllowMeteredUploads', b'0')
+
+    sm = messaging.SubMaster(['deviceState'])
+    sm.update(0)  # timeout=0 during tests
+    self.assertTrue(sm['deviceState'].networkMetered, "For this test we should be testing what happens on a metered connection")
 
     self.start_thread()
     # allow enough time that files would upload

--- a/system/loggerd/tests/test_uploader.py
+++ b/system/loggerd/tests/test_uploader.py
@@ -8,7 +8,6 @@ import json
 from pathlib import Path
 from typing import List, Optional
 import cereal.messaging as messaging
-from cereal import log
 from openpilot.system.hardware.hw import Paths
 
 from openpilot.system.swaglog import cloudlog
@@ -102,8 +101,7 @@ class TestUploader(UploaderTestCase):
 
     msg = messaging.new_message('deviceState')
     # https://github.com/commaai/cereal/blob/d11688a90a1cebacb3fe00dcfbba5f27551b2d89/log.capnp#L308
-    # https://capnproto.github.io/pycapnp/quickstart.html#serializing-deserializing
-    msg.deviceState = log.DeviceState.from_bytes(sm['deviceState'].to_bytes())
+    msg.deviceState = sm['deviceState']
     # Keep everything the same, except `.networkMetered` is now True
     msg.deviceState.networkMetered = True
     pm = messaging.PubMaster(['deviceState'])

--- a/system/loggerd/tests/test_uploader.py
+++ b/system/loggerd/tests/test_uploader.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 from typing import List, Optional
 import cereal.messaging as messaging
+from cereal import log
 from openpilot.system.hardware.hw import Paths
 
 from openpilot.system.swaglog import cloudlog
@@ -99,10 +100,11 @@ class TestUploader(UploaderTestCase):
     sm = messaging.SubMaster(['deviceState'])
     sm.update(0)  # timeout=0 during tests
 
-    # msg = messaging.new_message('deviceState')
-    msg = messaging.DeviceState.from_bytes(sm['deviceState'].to_bytes())
-    # https://capnproto.github.io/pycapnp/quickstart.html#serializing-deserializing
+    msg = messaging.new_message('deviceState')
     # https://github.com/commaai/cereal/blob/d11688a90a1cebacb3fe00dcfbba5f27551b2d89/log.capnp#L308
+    # https://capnproto.github.io/pycapnp/quickstart.html#serializing-deserializing
+    msg.deviceState = log.DeviceState.from_bytes(sm['deviceState'].to_bytes())
+    # Keep everything the same, except `.networkMetered` is now True
     msg.deviceState.networkMetered = True
     pm = messaging.PubMaster(['deviceState'])
     pm.send("deviceState", msg)

--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -270,6 +270,11 @@ def uploader_fn(exit_event: threading.Event) -> None:
         time.sleep(60 if offroad else 5)
       continue
 
+    if sm['deviceState'].networkMetered and not params.get_bool("AllowMeteredUploads"):  # Metered uploads, user toggle
+      if allow_sleep:
+        time.sleep(60 if offroad else 5)
+      continue
+
     d = uploader.next_file_to_upload()
     if d is None:  # Nothing to upload
       if allow_sleep:


### PR DESCRIPTION
**Description**

This current Pull Request adds a toggle to further restrict uploads until openpilot is on a non-metered connection.

This aims to be a lighter-weight / simplified version of https://github.com/commaai/openpilot/pull/30500 that omits [the "full upload" option originally described](https://discord.com/channels/469524606043160576/954493346250887168/1161103504761434182)

Special thanks to @jakethesnake420 for suggesting a [simplified route](https://github.com/commaai/openpilot/pull/30500#issuecomment-1830119606). If the [original three choices](https://discord.com/channels/469524606043160576/954493346250887168/1161103504761434182) are still desired in the future, https://github.com/commaai/openpilot/pull/30500 might be a useful starting point, or not.

**Purpose**

The goal here is to hopefully reduce data usage for people bringing their own SIMs…
- from the current ~6GB/mo
  - https://discord.com/channels/469524606043160576/819046761287909446/1161369395382202438
  - https://discord.com/channels/469524606043160576/819046761287909446/1161366312686198905
- down to more like 1~2GB/mo
  - https://discord.com/channels/469524606043160576/819046761287909446/1161366616920051914

**Verification**

I'm completely new to the openpilot codebase, so any pointers on how I can test this would be super helpful!