### PR TITLE
cabana: Copy log history selection to clipboard

### DIFF
--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -322,10 +322,12 @@ void LogsWidget::copySelectionToClipboard() {
   QModelIndexList selectedIndexes = selectionModel->selectedIndexes();
   QClipboard *clipboard = QApplication::clipboard();
   QString selectedText;
-  for (const QModelIndex &index : selectedIndexes) {
+  for (int i = 0; i < selectedIndexes.count(); ++i) {
+    const QModelIndex &index = selectedIndexes[i];
     QVariant data = model->data(index, Qt::DisplayRole);
     selectedText += data.toString() + ", ";
-    if (index.column() == model->columnCount() - 1) {
+    // Check if this is the last index or the next index is in a different row
+    if (i == selectedIndexes.count() - 1 || selectedIndexes[i + 1].row() != index.row()) {
       selectedText.chop(2);  // Remove the last comma and space
       selectedText += "\n";  // New line for new row
     }

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -233,7 +233,7 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   QFrame *line = new QFrame(this);
   line->setFrameStyle(QFrame::HLine | QFrame::Sunken);
   main_layout->addWidget(line);
-  main_layout->addWidget(logs = new QTableView(this));
+  main_layout->addWidget(logs = new CustomTableView(this));
   logs->setModel(model = new HistoryLogModel(this));
   delegate = new MessageBytesDelegate(this);
   logs->setHorizontalHeader(new HeaderView(Qt::Horizontal, this));

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -8,48 +8,11 @@
 #include <QHeaderView>
 #include <QLineEdit>
 #include <QTableView>
-#include <QKeyEvent>
 #include <QClipboard>
 
 #include "tools/cabana/dbc/dbcmanager.h"
 #include "tools/cabana/streams/abstractstream.h"
 #include "tools/cabana/util.h"
-
-class CustomTableView : public QTableView {
-    Q_OBJECT
-
-public:
-  using QTableView::QTableView;
-
-protected:
-  void keyPressEvent(QKeyEvent *event) override {
-    if (event->key() == Qt::Key_C && (event->modifiers() & Qt::ControlModifier)) {
-      copySelectionToClipboard();
-      event->accept();
-    } else {
-      QTableView::keyPressEvent(event);
-    }
-  }
-
-private:
-  void copySelectionToClipboard() {
-    QItemSelectionModel *selectionModel = this->selectionModel();
-    QModelIndexList selectedIndexes = selectionModel->selectedIndexes();
-
-    QString selectedText;
-    for (const QModelIndex &index : selectedIndexes) {
-      QVariant data = model()->data(index, Qt::DisplayRole);
-      selectedText += data.toString() + ", "; // Comma-separated values
-      if (index.column() == model()->columnCount() - 1) {
-        selectedText.chop(2); // Remove the last comma and space
-        selectedText += "\n"; // New line for new row
-      }
-    }
-
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setText(selectedText);
-  }
-};
 
 class HeaderView : public QHeaderView {
 public:
@@ -119,10 +82,14 @@ public:
 private slots:
   void setFilter();
 
+protected:
+  bool eventFilter(QObject *watched, QEvent *event) override;
+
 private:
   void refresh();
+  void copySelectionToClipboard();
 
-  CustomTableView *logs;
+  QTableView *logs;
   HistoryLogModel *model;
   QCheckBox *dynamic_mode;
   QComboBox *signals_cb, *comp_box, *display_type_cb;

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -19,15 +19,15 @@ class CustomTableView : public QTableView {
     Q_OBJECT
 
 public:
-  using QTableView::QTableView; // Inherit constructors
+  using QTableView::QTableView;
 
 protected:
   void keyPressEvent(QKeyEvent *event) override {
     if (event->key() == Qt::Key_C && (event->modifiers() & Qt::ControlModifier)) {
       copySelectionToClipboard();
-      event->accept(); // Prevent further processing
+      event->accept();
     } else {
-      QTableView::keyPressEvent(event); // Default behavior for other keys
+      QTableView::keyPressEvent(event);
     }
   }
 
@@ -39,9 +39,9 @@ private:
     QString selectedText;
     for (const QModelIndex &index : selectedIndexes) {
       QVariant data = model()->data(index, Qt::DisplayRole);
-      selectedText += data.toString() + ", "; // Tab-separated values
+      selectedText += data.toString() + ", "; // Comma-separated values
       if (index.column() == model()->columnCount() - 1) {
-        selectedText.chop(2); // Remove the last comma
+        selectedText.chop(2); // Remove the last comma and space
         selectedText += "\n"; // New line for new row
       }
     }


### PR DESCRIPTION
Allows you to copy the selection from the log history view.

![image](https://github.com/commaai/openpilot/assets/83676301/62e54f9b-ff71-4456-afff-993070d92950)

```
37570, 47587
33474, 47587
29378, 47587
25282, 47587
21186, 47587
17090, 47587
12994, 47587
8898, 47587
4802, 47587
706, 47587
62146, 47587
58050, 47587
53954, 47587
49858, 47587
45762, 47587
41666, 47587
37570, 47587
33474, 47587
29378, 47587
```
