### PR TITLE
webrtcd: stop cereal proxy runner when data channel is closed

### DIFF
--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -15,6 +15,7 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 import aiortc
 from aiortc.mediastreams import VideoStreamTrack, AudioStreamTrack
 from aiortc.contrib.media import MediaBlackhole
+from aiortc.exceptions import InvalidStateError
 from aiohttp import web
 import capnp
 from teleoprtc import WebRTCAnswerBuilder
@@ -97,6 +98,9 @@ class CerealProxyRunner:
     while True:
       try:
         self.proxy.update()
+      except InvalidStateError:
+        self.logger.warning("Cereal outgoing proxy invalid state (connection closed)")
+        break
       except Exception as ex:
         self.logger.error("Cereal outgoing proxy failure: %s", ex)
       await asyncio.sleep(0.01)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
