### PR TITLE
CI: add a timeout on docker build

### DIFF
--- a/.github/workflows/setup-with-retry/action.yaml
+++ b/.github/workflows/setup-with-retry/action.yaml
@@ -19,6 +19,7 @@ runs:
   steps:
     - id: setup1
       uses: ./.github/workflows/setup
+      timeout-minutes: 15
       continue-on-error: true
       with:
         docker_hub_pat: ${{ inputs.docker_hub_pat }}
@@ -30,6 +31,7 @@ runs:
     - id: setup2
       if: steps.setup1.outcome == 'failure'
       uses: ./.github/workflows/setup
+      timeout-minutes: 15
       continue-on-error: true
       with:
         docker_hub_pat: ${{ inputs.docker_hub_pat }}
@@ -41,6 +43,7 @@ runs:
     - id: setup3
       if: steps.setup2.outcome == 'failure'
       uses: ./.github/workflows/setup
+      timeout-minutes: 15
       with:
         docker_hub_pat: ${{ inputs.docker_hub_pat }}
         cache_key_prefix: ${{ inputs.cache_key_prefix }}

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -76,3 +76,4 @@ runs:
     # build our docker image
     - shell: bash
       run: eval ${{ env.BUILD }}
+      timeout-minutes: 15

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -76,4 +76,3 @@ runs:
     # build our docker image
     - shell: bash
       run: eval ${{ env.BUILD }}
-      timeout-minutes: 15


### PR DESCRIPTION
buildjet internet was extremely slow in this run (not sure why, was fine on rerun), and caused this setup to run for 30+ minutes until I manually stopped it. 15 minutes should be plenty to rebuild even the full image.

https://github.com/commaai/openpilot/actions/runs/7117904537/job/19379679547?pr=30618