### PR TITLE
jenkins: remove pytest tici conf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,8 @@ export GIT_BRANCH=${env.GIT_BRANCH}
 export GIT_COMMIT=${env.GIT_COMMIT}
 export AZURE_TOKEN='${env.AZURE_TOKEN}'
 export MAPBOX_TOKEN='${env.MAPBOX_TOKEN}'
-export PYTEST_ADDOPTS="-c selfdrive/test/pytest-tici.ini --rootdir ."
+# only use 1 thread for tici tests since most require HIL
+export PYTEST_ADDOPTS="-n 1"
 
 
 export GIT_SSH_COMMAND="ssh -i /data/gitkey"

--- a/release/files_common
+++ b/release/files_common
@@ -297,7 +297,6 @@ selfdrive/test/helpers.py
 selfdrive/test/setup_device_ci.sh
 selfdrive/test/test_onroad.py
 selfdrive/test/test_time_to_onroad.py
-selfdrive/test/pytest-tici.ini
 
 selfdrive/ui/.gitignore
 selfdrive/ui/SConscript

--- a/selfdrive/test/pytest-tici.ini
+++ b/selfdrive/test/pytest-tici.ini
@@ -1,5 +1,0 @@
-[pytest]
-addopts = -Werror --strict-config --strict-markers --durations=10
-markers = 
-  slow: tests that take awhile to run and can be skipped with -m 'not slow'
-  tici: tests that are only meant to run on the C3/C3X


### PR DESCRIPTION
no longer needed after agnos9 since we synced the pytest depends

might be able to get some parallelization for the tici tests eventually by using xdist groups (for example, running panda tests and map tests at the same time), but for now we have to disable it because of the HIL tests