### PR TITLE
jenkins: remove inverse precedence

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ def deviceStage(String stageName, String deviceType, List env, def steps) {
     def extra = env.collect { "export ${it}" }.join('\n');
 
     docker.image('ghcr.io/commaai/alpine-ssh').inside('--user=root') {
-      lock(resource: "", label: deviceType, inversePrecedence: true, variable: 'device_ip', quantity: 1) {
+      lock(resource: "", label: deviceType, variable: 'device_ip', quantity: 1) {
         timeout(time: 20, unit: 'MINUTES') {
           retry (3) {
             device(device_ip, "git checkout", extra + "\n" + readFile("selfdrive/test/setup_device_ci.sh"))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,8 +63,10 @@ def deviceStage(String stageName, String deviceType, List env, def steps) {
 
     def extra = env.collect { "export ${it}" }.join('\n');
 
+    def high_priority_branches = ['master', 'devel-staging', 'master-ci']
+
     docker.image('ghcr.io/commaai/alpine-ssh').inside('--user=root') {
-      lock(resource: "", label: deviceType, variable: 'device_ip', quantity: 1) {
+      lock(resource: "", label: deviceType, inversePrecedence: high_priority_branches.contains(env.BRANCH_NAME), variable: 'device_ip', quantity: 1) {
         timeout(time: 20, unit: 'MINUTES') {
           retry (3) {
             device(device_ip, "git checkout", extra + "\n" + readFile("selfdrive/test/setup_device_ci.sh"))


### PR DESCRIPTION
this flag causes the most recent job to be pushed to the front of the queue, @adeebshihadeh any particular reason we had this?