### PR TITLE
jenkins: disable xdist on tici

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ export GIT_COMMIT=${env.GIT_COMMIT}
 export AZURE_TOKEN='${env.AZURE_TOKEN}'
 export MAPBOX_TOKEN='${env.MAPBOX_TOKEN}'
 # only use 1 thread for tici tests since most require HIL
-export PYTEST_ADDOPTS="-n 1"
+export PYTEST_ADDOPTS="-n 0"
 
 
 export GIT_SSH_COMMAND="ssh -i /data/gitkey"


### PR DESCRIPTION
with xdist, -s doesn't work anymore (stdout is captured no matter what).
-n 0 effectively disables xdist and should allow test_onroad to have the output logged again