### PR TITLE
pytest: group test_models by route instead of car name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,8 +235,8 @@ node {
         pcStage("car tests") {
           sh label: "build", script: "selfdrive/manager/build.py"
           sh label: "test_models.py", script: "INTERNAL_SEG_CNT=250 INTERNAL_SEG_LIST=selfdrive/car/tests/test_models_segs.txt FILEREADER_CACHE=1 \
-              pytest -n auto --dist=loadscope selfdrive/car/tests/test_models.py"
-          sh label: "test_car_interfaces.py", script: "MAX_EXAMPLES=100 pytest -n auto --dist=load selfdrive/car/tests/test_car_interfaces.py"
+              pytest selfdrive/car/tests/test_models.py"
+          sh label: "test_car_interfaces.py", script: "MAX_EXAMPLES=100 pytest selfdrive/car/tests/test_car_interfaces.py"
         }
       },
 

--- a/conftest.py
+++ b/conftest.py
@@ -45,8 +45,9 @@ def pytest_collection_modifyitems(config, items):
       item.add_marker(skipper)
 
     if "xdist_group_class_property" in item.keywords:
-      class_property = item.get_closest_marker('xdist_group_class_property').args[0]
-      item.add_marker(pytest.mark.xdist_group(getattr(item.cls, class_property)))
+      class_property_name = item.get_closest_marker('xdist_group_class_property').args[0]
+      class_property_value = getattr(item.cls, class_property_name)
+      item.add_marker(pytest.mark.xdist_group(class_property_value))
 
 
 @pytest.hookimpl(trylast=True)

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -382,7 +382,7 @@ class TestCarModelBase(unittest.TestCase):
 
 
 @parameterized_class(('car_model', 'test_route'), get_test_cases())
-@pytest.mark.xdist_group_class_property('car_model')
+@pytest.mark.xdist_group_class_property('test_route')
 class TestCarModel(TestCarModelBase):
   pass
 


### PR DESCRIPTION
relevant to internal segment tests where we have multiple segments for each car