### PR TITLE
test_models: group by route

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -382,7 +382,7 @@ class TestCarModelBase(unittest.TestCase):
 
 
 @parameterized_class(('car_model', 'test_route'), get_test_cases())
-@pytest.mark.xdist_group_class_property('car_model')
+@pytest.mark.xdist_group_class_property('test_route')
 class TestCarModel(TestCarModelBase):
   pass
 


### PR DESCRIPTION
Since there can be multiple segments per platform, we want to dedicate a new thread to those segments, not wait around. Effect probably minimal in most cases