### PR TITLE
camerad: fix use of uninitialized `CameraInfo` in `camera_open()`

### DIFF
--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -597,8 +597,6 @@ void CameraState::camera_init(MultiCameraState *s, VisionIpcServer * v, int came
   request_id_last = 0;
   skipped = true;
 
-  camera_set_parameters();
-
   buf.init(device_id, ctx, this, v, FRAME_BUF_COUNT, yuv_type);
   camera_map_bufs(s);
 }
@@ -633,6 +631,8 @@ void CameraState::camera_open(MultiCameraState *multi_cam_state_, int camera_num
     enabled = false;
     return;
   }
+
+  camera_set_parameters();
 
   // create session
   struct cam_req_mgr_session_info session_info = {};


### PR DESCRIPTION
camera_open use uninitialized `ci` to initialize the `struct in_port_info`.  If you add a print function it will show the default values (width=0, height=0, extra_height=0.)

