### PR TITLE
test_athena: remove no-op line

### DIFF
--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -46,7 +46,7 @@ class TestAthenadMethods(unittest.TestCase):
       else:
         os.unlink(p)
 
-    dispatcher["listUploadQueue"]() # ensure queue is empty at start
+    # dispatcher["listUploadQueue"]() # ensure queue is empty at start
 
   # *** test helpers ***
 

--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -46,8 +46,6 @@ class TestAthenadMethods(unittest.TestCase):
       else:
         os.unlink(p)
 
-    # dispatcher["listUploadQueue"]() # ensure queue is empty at start
-
   # *** test helpers ***
 
   @staticmethod


### PR DESCRIPTION
just lists the upload queue after it's already been replaced with a new Queue object.

from https://github.com/commaai/openpilot/pull/29709