### PR TITLE
boardd: improve the performance of `PandaUsbHandle::list()`

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -68,7 +68,7 @@ PROCS.update({
     "system.sensord.pigeond": 6.0,
   },
   "tizi": {
-     "./boardd": 19.0,
+     "./boardd": 10.0,
     "system.qcomgpsd.qcomgpsd": 1.0,
   }
 }.get(HARDWARE.get_device_type(), {}))

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -68,7 +68,7 @@ PROCS.update({
     "system.sensord.pigeond": 6.0,
   },
   "tizi": {
-     "./boardd": 10.0,
+     "./boardd": 19.0,
     "system.qcomgpsd.qcomgpsd": 1.0,
   }
 }.get(HARDWARE.get_device_type(), {}))


### PR DESCRIPTION
`libusb_init` is very time consuming. using a static libusb_context to improve the performnce of `PandaUsbHandle::list()`. this reduces the boardd's offroad cpu usage from about 19% to 9%

