### PR TITLE
soundd/micd: retry getting stream

### DIFF
--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -8,12 +8,11 @@ from typing import Dict, Optional, Tuple
 from cereal import car, messaging
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.realtime import Ratekeeper
+from openpilot.common.retry import retry
+from openpilot.common.swaglog import cloudlog
 
 from openpilot.system import micd
-from openpilot.system.hardware import TICI
-
-from openpilot.common.realtime import Ratekeeper
-from openpilot.common.swaglog import cloudlog
 
 SAMPLE_RATE = 48000
 SAMPLE_BUFFER = 4096 # (approx 100ms)
@@ -127,16 +126,21 @@ class Soundd:
     volume = ((weighted_db - AMBIENT_DB) / DB_SCALE) * (MAX_VOLUME - MIN_VOLUME) + MIN_VOLUME
     return math.pow(10, (np.clip(volume, MIN_VOLUME, MAX_VOLUME) - 1))
 
+  @retry(attempts=7, delay=3)
+  def get_stream(self, sd):
+    # reload sounddevice to reinitialize portaudio
+    sd._terminate()
+    sd._initialize()
+    return sd.OutputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback, blocksize=SAMPLE_BUFFER)
+
   def soundd_thread(self):
     # sounddevice must be imported after forking processes
     import sounddevice as sd
 
-    if TICI:
-      micd.wait_for_devices(sd) # wait for alsa to be initialized on device
+    sm = messaging.SubMaster(['controlsState', 'microphone'])
 
-    with sd.OutputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback, blocksize=SAMPLE_BUFFER) as stream:
+    with self.get_stream(sd) as stream:
       rk = Ratekeeper(20)
-      sm = messaging.SubMaster(['controlsState', 'microphone'])
 
       cloudlog.info(f"soundd stream started: {stream.samplerate=} {stream.channels=} {stream.dtype=} {stream.device=}, {stream.blocksize=}")
       while True:

--- a/system/micd.py
+++ b/system/micd.py
@@ -5,25 +5,12 @@ from cereal import messaging
 from openpilot.common.realtime import Ratekeeper
 from openpilot.common.retry import retry
 from openpilot.common.swaglog import cloudlog
-from openpilot.system.hardware import TICI
 
 RATE = 10
 FFT_SAMPLES = 4096
 REFERENCE_SPL = 2e-5  # newtons/m^2
 SAMPLE_RATE = 44100
 SAMPLE_BUFFER = 4096 # (approx 100ms)
-
-
-@retry(attempts=7, delay=3)
-def wait_for_devices(sd):
-  # reload sounddevice to reinitialize portaudio
-  sd._terminate()
-  sd._initialize()
-
-  devices = sd.query_devices()
-  cloudlog.info(f"sounddevice available devices: {list(devices)}")
-
-  assert len(devices) > 0
 
 
 def calculate_spl(measurements):
@@ -92,14 +79,18 @@ class Mic:
 
       self.measurements = self.measurements[FFT_SAMPLES:]
 
+  @retry(attempts=7, delay=3)
+  def get_stream(self, sd):
+    # reload sounddevice to reinitialize portaudio
+    sd._terminate()
+    sd._initialize()
+    return sd.InputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback, blocksize=SAMPLE_BUFFER)
+
   def micd_thread(self):
     # sounddevice must be imported after forking processes
     import sounddevice as sd
 
-    if TICI:
-      wait_for_devices(sd) # wait for alsa to be initialized on device
-
-    with sd.InputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback, blocksize=SAMPLE_BUFFER) as stream:
+    with self.get_stream(sd) as stream:
       cloudlog.info(f"micd stream started: {stream.samplerate=} {stream.channels=} {stream.dtype=} {stream.device=}, {stream.blocksize=}")
       while True:
         self.update()


### PR DESCRIPTION
this seems like the best solution to capture and recover from the random alsa errors


ran 150 times across release (skip build, faster launch) and dev devices, and checked that it recovers from these errors:
```
/home/batman/soundd/tmux-justin-tici2-2023-12-12--13:05:42.txt

sounddevice.PortAudioError: Error opening InputStream: Illegal combination of I/
O devices [PaErrorCode -9993]

--------------------------------------------------------------------------------------------

/home/batman/soundd/tmux-justin-tizi2-2023-12-12--12:57:31.txt

sounddevice.PortAudioError: Error opening InputStream: Unanticipated host error
[PaErrorCode -9999]: 'Invalid argument' [ALSA error -22]

--------------------------------------------------------------------------------------------

/home/batman/soundd/tmux-justin-tizi2-2023-12-12--12:57:31.txt

sounddevice.PortAudioError: Error opening InputStream: Unanticipated host error
[PaErrorCode -9999]: 'Operation already in progress' [ALSA error -114]

--------------------------------------------------------------------------------------------

/home/batman/soundd/tmux-justin-tizi-2023-12-12--11:59:08.txt

sounddevice.PortAudioError: Error opening InputStream: Illegal combination of I/
O devices [PaErrorCode -9993]
```

these errors seem to happen about 1/40 restarts