### PR TITLE
CI: add codecov token

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -185,6 +185,8 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         name: ${{ github.job }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   process_replay:
     name: process replay
@@ -232,6 +234,8 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         name: ${{ github.job }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   regen:
     name: regen
@@ -293,6 +297,8 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         name: ${{ github.job }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test_cars:
     name: cars
@@ -326,6 +332,8 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         name: ${{ github.job }}-${{ matrix.job }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   car_docs_diff:
     name: PR comments


### PR DESCRIPTION
codecov seems to randomly fail to upload, and it recommends adding the codecov token to CI secrets

https://github.com/commaai/openpilot/actions/runs/7190601758/job/19583989822#step:6:43
https://github.com/commaai/openpilot/actions/runs/7198609662/job/19608455470#step:6:43

token is found here: https://app.codecov.io/gh/commaai/openpilot/settings