### PR TITLE
locationd/helpers.py: use Params().put_nonblocking

### DIFF
--- a/selfdrive/locationd/helpers.py
+++ b/selfdrive/locationd/helpers.py
@@ -2,7 +2,7 @@ import numpy as np
 from typing import List, Optional, Tuple, Any
 
 from cereal import log
-from openpilot.common.params import put_nonblocking
+from openpilot.common.params import Params
 
 
 class NPQueue:
@@ -67,4 +67,4 @@ class ParameterEstimator:
 
 def cache_points(param_name, estimator, valid):
   msg = estimator.get_msg(valid=valid, with_points=True)
-  put_nonblocking(param_name, msg.to_bytes())
+  Params().put_nonblocking(param_name, msg.to_bytes())


### PR DESCRIPTION
continue https://github.com/commaai/openpilot/pull/29808,  fix the error  `selfdrive/locationd/helpers.py:5: error: Module "openpilot.common.params" has no attribute "put_nonblocking"  [attr-defined]`
This file is newer than https://github.com/commaai/openpilot/pull/29808, so no changes have been made by https://github.com/commaai/openpilot/pull/29808