### PR TITLE
Docker: add xvfb

### DIFF
--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -77,6 +77,7 @@ function install_ubuntu_common_requirements() {
     libqt5x11extras5-dev \
     libreadline-dev \
     libdw1 \
+    xvfb \
     valgrind
 }
 


### PR DESCRIPTION
allows us to run maprenderer and eventually simulator in the docker image