### PR TITLE
Ford: Improve Long Controls

### DIFF
--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -121,7 +121,7 @@ class CarController:
     if (self.frame % CarControllerParams.ACC_UI_STEP) == 0 or send_ui:
       can_sends.append(fordcan.create_acc_ui_msg(self.packer, self.CAN, self.CP, main_on, CC.latActive,
                                          fcw_alert, CS.out.cruiseState.standstill, hud_control,
-                                         CS.acc_tja_status_stock_values, CS.gac_tr_cluster))
+                                         CS.acc_tja_status_stock_values))
 
     self.main_on_last = main_on
     self.lkas_enabled_last = CC.latActive

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -43,7 +43,7 @@ class CarController:
     self.main_on_last = False
     self.lkas_enabled_last = False
     self.steer_alert_last = False
-    self.accel_old = 0
+    self.actuate_last = 0
 
   def update(self, CC, CS, now_nanos):
     can_sends = []
@@ -107,8 +107,8 @@ class CarController:
       if not CC.longActive and hud_control.setSpeed:
         targetSpeed = hud_control.setSpeed
 
-      actuate = hysteresis(accel, self.accel_old, 0, 0.1)
-      self.accel_old = accel
+      actuate = hysteresis(accel, self.actuate_last, -0.05, 0.05)
+      self.actuate_last = actuate
 
       can_sends.append(fordcan.create_acc_msg(self.packer, self.CAN, CC.longActive, gas, accel, stopping, actuate, v_ego_kph=targetSpeed * CV.MS_TO_KPH))
 

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -1,4 +1,5 @@
 from cereal import car
+from openpilot.common.numpy_fast import clip
 from openpilot.selfdrive.car import CanBusBase
 
 HUDControl = car.CarControl.HUDControl
@@ -76,8 +77,8 @@ def create_lat_ctl_msg(packer, CAN: CanBus, lat_active: bool, path_offset: float
                                                 #       3=InterventionRight, 4-7=NotUsed [0|7]
     "LatCtlRampType_D_Rq": 0,                   # Ramp speed: 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
                                                 #             Makes no difference with curvature control
-    "LatCtlPrecision_D_Rq": 1,                  # Precision: 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
-                                                #            The stock system always uses comfortable
+    "LatCtlPrecision_D_Rq": 0,                  # Precision: 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
+                                                # We have not observed the stock system using precise
     "LatCtlPathOffst_L_Actl": path_offset,      # Path offset [-5.12|5.11] meter
     "LatCtlPath_An_Actl": path_angle,           # Path angle [-0.5|0.5235] radians
     "LatCtlCurv_NoRate_Actl": curvature_rate,   # Curvature rate [-0.001024|0.00102375] 1/meter^2
@@ -101,7 +102,8 @@ def create_lat_ctl2_msg(packer, CAN: CanBus, mode: int, path_offset: float, path
     "LatCtl_D2_Rq": mode,                       # Mode: 0=None, 1=PathFollowingLimitedMode, 2=PathFollowingExtendedMode,
                                                 #       3=SafeRampOut, 4-7=NotUsed [0|7]
     "LatCtlRampType_D_Rq": 0,                   # 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
-    "LatCtlPrecision_D_Rq": 1,                  # 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
+    "LatCtlPrecision_D_Rq": 0,                  # 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
+                                                # We have not observed the stock system using precise
     "LatCtlPathOffst_L_Actl": path_offset,      # [-5.12|5.11] meter
     "LatCtlPath_An_Actl": path_angle,           # [-0.5|0.5235] radians
     "LatCtlCurv_No_Actl": curvature,            # [-0.02|0.02094] 1/meter
@@ -118,7 +120,7 @@ def create_lat_ctl2_msg(packer, CAN: CanBus, mode: int, path_offset: float, path
   return packer.make_can_msg("LateralMotionControl2", CAN.main, values)
 
 
-def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: float, stopping: bool, v_ego_kph: float):
+def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: float, stopping: bool, actuate: bool, v_ego_kph: float):
   """
   Creates a CAN message for the Ford ACC Command.
 
@@ -128,24 +130,28 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
   Frequency is 50Hz.
   """
 
-  actuateBrakes = gas == -5 and long_active
+  # precharge_actuator = accel < -0.25 and long_active
+  # brake_actuator = gas == -5 and long_active # and accel < -.75  
+  decel = actuate and long_active
+  brake_actuator = precharge_actuator = decel
+  gas_pred = clip(accel, -5, 0) if gas == -5 else accel
   values = {
     "AccBrkTot_A_Rq": accel,                          # Brake total accel request: [-20|11.9449] m/s^2
     "Cmbb_B_Enbl": 1 if long_active else 0,           # Enabled: 0=No, 1=Yes
     "AccPrpl_A_Rq": gas,                              # Acceleration request: [-5|5.23] m/s^2
-    "AccPrpl_A_Pred": gas,                            # Acceleration request: [-5|5.23] m/s^2
-    "AccResumEnbl_B_Rq": 1 if long_active else 0,
+    "AccPrpl_A_Pred": gas_pred,                            # Acceleration request: [-5|5.23] m/s^2
     "AccVeh_V_Trg": v_ego_kph,                        # Target speed: [0|255] km/h
-    # Pre-charging and actuating brake are typically only done in BlueCruise when under engine braking gas (MIN_GAS)
-    "AccBrkPrchg_B_Rq": 1 if actuateBrakes else 0,            # Pre-charge brake request: 0=No, 1=Yes
-    "AccBrkDecel_B_Rq": 1 if actuateBrakes else 0,            # Deceleration request: 0=Inactive, 1=Active
+    "AccResumEnbl_B_Rq": 1 if long_active else 0,
+    # TODO: we may be able to improve braking response by utilizing pre-charging better
+    "AccBrkPrchg_B_Rq": 1 if precharge_actuator else 0,     # Pre-charge brake request: 0=No, 1=Yes
+    "AccBrkDecel_B_Rq": 1 if brake_actuator else 0,     # Deceleration request: 0=Inactive, 1=Active
     "AccStopStat_B_Rq": 1 if stopping else 0,
   }
   return packer.make_can_msg("ACCDATA", CAN.main, values)
 
 
 def create_acc_ui_msg(packer, CAN: CanBus, CP, main_on: bool, enabled: bool, fcw_alert: bool, standstill: bool,
-                      hud_control, stock_values: dict):
+                      hud_control, stock_values: dict, gac_tr_cluster):
   """
   Creates a CAN message for the Ford IPC adaptive cruise, forward collision warning and traffic jam
   assist status.
@@ -213,7 +219,7 @@ def create_acc_ui_msg(packer, CAN: CanBus, CP, main_on: bool, enabled: bool, fcw
       "AccFllwMde_B_Dsply": 1 if hud_control.leadVisible else 0,  # Lead indicator
       "AccStopMde_B_Dsply": 1 if standstill else 0,
       "AccWarn_D_Dsply": 0,                                       # ACC warning
-      "AccTGap_D_Dsply": 4,                                       # Fixed time gap in UI
+      "AccTGap_D_Dsply": gac_tr_cluster,                          # Fixed time gap in UI
     })
 
   # Forwards FCW alert from IPMA

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -151,7 +151,7 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
 
 
 def create_acc_ui_msg(packer, CAN: CanBus, CP, main_on: bool, enabled: bool, fcw_alert: bool, standstill: bool,
-                      hud_control, stock_values: dict, gac_tr_cluster):
+                      hud_control, stock_values: dict):
   """
   Creates a CAN message for the Ford IPC adaptive cruise, forward collision warning and traffic jam
   assist status.

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -128,7 +128,6 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
   Frequency is 50Hz.
   """
 
-  decel = accel < 0 and long_active
   actuateBrakes = gas == -5 and long_active
   values = {
     "AccBrkTot_A_Rq": accel,                          # Brake total accel request: [-20|11.9449] m/s^2

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -136,6 +136,7 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
     "AccPrpl_A_Pred": gas,                            # Acceleration request: [-5|5.23] m/s^2
     "AccResumEnbl_B_Rq": 1 if long_active else 0,
     "AccVeh_V_Trg": v_ego_kph,                        # Target speed: [0|255] km/h
+    # Precharging and actuating the actual brake signals are typically only done in BlueCruise when approaching INACTIVE_GAS (-5)
     "AccBrkPrchg_B_Rq": 1 if actuateBrakes else 0,            # Pre-charge brake request: 0=No, 1=Yes
     "AccBrkDecel_B_Rq": 1 if actuateBrakes else 0,            # Deceleration request: 0=Inactive, 1=Active
     "AccStopStat_B_Rq": 1 if stopping else 0,

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -136,9 +136,6 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
     "AccPrpl_A_Pred": gas,                            # Acceleration request: [-5|5.23] m/s^2
     "AccResumEnbl_B_Rq": 1 if long_active else 0,
     "AccVeh_V_Trg": v_ego_kph,                        # Target speed: [0|255] km/h
-    # Precharging and actuating the actual brake signals are typically only done ine BlueCruise when approaching INACTIVE_GAS (-5)
-    # We've changed the logic to resemble this. Previously, precharging and actuation of the friction brakes would happen anytime
-    # There was no gas input, even if just coasting was intended
     "AccBrkPrchg_B_Rq": 1 if actuateBrakes else 0,            # Pre-charge brake request: 0=No, 1=Yes
     "AccBrkDecel_B_Rq": 1 if actuateBrakes else 0,            # Deceleration request: 0=Inactive, 1=Active
     "AccStopStat_B_Rq": 1 if stopping else 0,

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -131,7 +131,7 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
   """
 
   # precharge_actuator = accel < -0.25 and long_active
-  # brake_actuator = gas == -5 and long_active # and accel < -.75  
+  # brake_actuator = gas == -5 and long_active # and accel < -.75
   decel = actuate and long_active
   brake_actuator = precharge_actuator = decel
   gas_pred = clip(accel, -5, 0) if gas == -5 else accel

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -137,7 +137,7 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
     "AccResumEnbl_B_Rq": 1 if long_active else 0,
     "AccVeh_V_Trg": v_ego_kph,                        # Target speed: [0|255] km/h
     # Precharging and actuating the actual brake signals are typically only done ine BlueCruise when approaching INACTIVE_GAS (-5)
-    # We've changed the logic to resemble this. Previously, precharging and actuation of the friction brakes would happen anytime 
+    # We've changed the logic to resemble this. Previously, precharging and actuation of the friction brakes would happen anytime
     # There was no gas input, even if just coasting was intended
     "AccBrkPrchg_B_Rq": 1 if actuateBrakes else 0,            # Pre-charge brake request: 0=No, 1=Yes
     "AccBrkDecel_B_Rq": 1 if actuateBrakes else 0,            # Deceleration request: 0=Inactive, 1=Active

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -136,7 +136,7 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
     "AccPrpl_A_Pred": gas,                            # Acceleration request: [-5|5.23] m/s^2
     "AccResumEnbl_B_Rq": 1 if long_active else 0,
     "AccVeh_V_Trg": v_ego_kph,                        # Target speed: [0|255] km/h
-    # Precharging and actuating the actual brake signals are typically only done in BlueCruise when approaching INACTIVE_GAS (-5)
+    # Pre-charging and actuating brake are typically only done in BlueCruise when under engine braking gas (MIN_GAS)
     "AccBrkPrchg_B_Rq": 1 if actuateBrakes else 0,            # Pre-charge brake request: 0=No, 1=Yes
     "AccBrkDecel_B_Rq": 1 if actuateBrakes else 0,            # Deceleration request: 0=Inactive, 1=Active
     "AccStopStat_B_Rq": 1 if stopping else 0,

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -218,8 +218,7 @@ def create_acc_ui_msg(packer, CAN: CanBus, CP, main_on: bool, enabled: bool, fcw
       "AccTGap_B_Dsply": 0,                                       # Show time gap control UI
       "AccFllwMde_B_Dsply": 1 if hud_control.leadVisible else 0,  # Lead indicator
       "AccStopMde_B_Dsply": 1 if standstill else 0,
-      "AccWarn_D_Dsply": 0,                                       # ACC warning
-      "AccTGap_D_Dsply": gac_tr_cluster,                          # Fixed time gap in UI
+      "AccWarn_D_Dsply": 0,                                       # ACC warning                         # Fixed time gap in UI
     })
 
   # Forwards FCW alert from IPMA

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -35,7 +35,7 @@ class CarInterface(CarInterfaceBase):
     if candidate in CANFD_CAR:
       ret.safetyConfigs[-1].safetyParam |= Panda.FLAG_FORD_CANFD
 
-    # We have tested these values with CAN-FD Ford. This can be included for all vehicles after 
+    # We have tested these values with CAN-FD Ford. This can be included for all vehicles after
     # we have validated that CAN (Q3) Ford users also enjoy these changes.
     # This prevents massive amounts of brake pumping when coming to a stop.
     if candidate in CANFD_CAR:
@@ -44,7 +44,7 @@ class CarInterface(CarInterfaceBase):
       ret.longitudinalTuning.kiV = [0.]
       ret.longitudinalTuning.deadzoneBP = [0., 9.]
       ret.longitudinalTuning.deadzoneV = [.0, .20]
-    
+
     if candidate == CAR.BRONCO_SPORT_MK1:
       ret.wheelbase = 2.67
       ret.steerRatio = 17.7
@@ -86,7 +86,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 3.076
       ret.steerRatio = 17.0
       ret.mass = 1650
-    
+
     else:
       raise ValueError(f"Unsupported car: {candidate}")
 

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -87,7 +87,7 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.kpV = [0.5]
     ret.longitudinalTuning.kiV = [0.]
     ret.longitudinalTuning.deadzoneBP = [0., 9.]
-    ret.longitudinalTuning.deadzoneV = [.0, .20]
+    ret.longitudinalTuning.deadzoneV = [.0, .2]
 
     # Auto Transmission: 0x732 ECU or Gear_Shift_by_Wire_FD1
     found_ecus = [fw.ecu for fw in car_fw]

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -35,6 +35,16 @@ class CarInterface(CarInterfaceBase):
     if candidate in CANFD_CAR:
       ret.safetyConfigs[-1].safetyParam |= Panda.FLAG_FORD_CANFD
 
+    # We have tested these values with CAN-FD Ford. This can be included for all vehicles after 
+    # we have validated that CAN (Q3) Ford users also enjoy these changes.
+    # This prevents massive amounts of brake pumping when coming to a stop.
+    if candidate in CANFD_CAR:
+      ret.longitudinalTuning.kpBP = [0.]
+      ret.longitudinalTuning.kpV = [0.5]
+      ret.longitudinalTuning.kiV = [0.]
+      ret.longitudinalTuning.deadzoneBP = [0., 9.]
+      ret.longitudinalTuning.deadzoneV = [.0, .20]
+    
     if candidate == CAR.BRONCO_SPORT_MK1:
       ret.wheelbase = 2.67
       ret.steerRatio = 17.7
@@ -76,19 +86,7 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 3.076
       ret.steerRatio = 17.0
       ret.mass = 1650
-      
-    # We have tested these values with CAN-FD Ford. This can be included for all vehicles after 
-    # we have validated that CAN (Q3) Ford users also enjoy these changes.
-    # This prevents massive amounts of brake pumping when coming to a stop.
-    if candidate in CANFD_CAR:
-      ret.longitudinalTuning.kpBP = [0.]
-      ret.longitudinalTuning.kpV = [0.5]
-      ret.longitudinalTuning.kiV = [0.]
-      ret.longitudinalTuning.deadzoneBP = [0., 9.]
-      ret.longitudinalTuning.deadzoneV = [.0, .20]
-      
-
-
+    
     else:
       raise ValueError(f"Unsupported car: {candidate}")
 

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -76,6 +76,18 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 3.076
       ret.steerRatio = 17.0
       ret.mass = 1650
+      
+    # We have tested these values with CAN-FD Ford. This can be included for all vehicles after 
+    # we have validated that CAN (Q3) Ford users also enjoy these changes.
+    # This prevents massive amounts of brake pumping when coming to a stop.
+    if candidate in CANFD_CAR:
+      ret.longitudinalTuning.kpBP = [0.]
+      ret.longitudinalTuning.kpV = [0.5]
+      ret.longitudinalTuning.kiV = [0.]
+      ret.longitudinalTuning.deadzoneBP = [0., 9.]
+      ret.longitudinalTuning.deadzoneV = [.0, .20]
+      
+
 
     else:
       raise ValueError(f"Unsupported car: {candidate}")

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -35,16 +35,6 @@ class CarInterface(CarInterfaceBase):
     if candidate in CANFD_CAR:
       ret.safetyConfigs[-1].safetyParam |= Panda.FLAG_FORD_CANFD
 
-    # We have tested these values with CAN-FD Ford. This can be included for all vehicles after
-    # we have validated that CAN (Q3) Ford users also enjoy these changes.
-    # This prevents massive amounts of brake pumping when coming to a stop.
-    if candidate in CANFD_CAR:
-      ret.longitudinalTuning.kpBP = [0.]
-      ret.longitudinalTuning.kpV = [0.5]
-      ret.longitudinalTuning.kiV = [0.]
-      ret.longitudinalTuning.deadzoneBP = [0., 9.]
-      ret.longitudinalTuning.deadzoneV = [.0, .20]
-
     if candidate == CAR.BRONCO_SPORT_MK1:
       ret.wheelbase = 2.67
       ret.steerRatio = 17.7
@@ -89,6 +79,15 @@ class CarInterface(CarInterfaceBase):
 
     else:
       raise ValueError(f"Unsupported car: {candidate}")
+
+    # We have tested these values with CAN-FD Ford. This can be included for all vehicles after
+    # we have validated that CAN (Q3) Ford users also enjoy these changes.
+    # This prevents massive amounts of brake pumping when coming to a stop.
+    ret.longitudinalTuning.kpBP = [0.]
+    ret.longitudinalTuning.kpV = [0.5]
+    ret.longitudinalTuning.kiV = [0.]
+    ret.longitudinalTuning.deadzoneBP = [0., 9.]
+    ret.longitudinalTuning.deadzoneV = [.0, .20]
 
     # Auto Transmission: 0x732 ECU or Gear_Shift_by_Wire_FD1
     found_ecus = [fw.ecu for fw in car_fw]

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -706,6 +706,9 @@ class Controls:
     if len(speeds):
       CC.cruiseControl.resume = self.enabled and CS.cruiseState.standstill and speeds[-1] > 0.1
 
+    if len(speeds) > 0:
+      CC.actuators.speed = speeds[0]
+    
     hudControl = CC.hudControl
     hudControl.setSpeed = float(self.v_cruise_helper.v_cruise_cluster_kph * CV.KPH_TO_MS)
     hudControl.speedVisible = self.enabled

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -708,7 +708,7 @@ class Controls:
 
     if len(speeds) > 0:
       CC.actuators.speed = speeds[0]
-    
+      
     hudControl = CC.hudControl
     hudControl.setSpeed = float(self.v_cruise_helper.v_cruise_cluster_kph * CV.KPH_TO_MS)
     hudControl.speedVisible = self.enabled

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -708,7 +708,7 @@ class Controls:
 
     if len(speeds) > 0:
       CC.actuators.speed = speeds[0]
-      
+
     hudControl = CC.hudControl
     hudControl.setSpeed = float(self.v_cruise_helper.v_cruise_cluster_kph * CV.KPH_TO_MS)
     hudControl.speedVisible = self.enabled


### PR DESCRIPTION
**Description** [x]
Current CAN-FD Ford Platforms experience a massive amount of brake spamming when approaching red lights/stop signs/stopped cars. 

A few of us have deduced that this was due to the longitudinal tuning as well as the signals being off-base from what BlueCruise was doing.

**Verification** [x]
Through the efforts of several community members, we've found that if we don't actuate braking til true INACTIVE_GAS is used (-5), as well as some longitudinal tuning, we can effectively eliminate the brake pumping/stuttering that can be seen in the current iteration of the Ford long control

We have been testing this in our forks for over a month and we have all experienced the same thing - improved long control when coming to a stop.