### PR TITLE
Fixing Metadrive error in simulated_car.py

### DIFF
--- a/tools/sim/lib/simulated_car.py
+++ b/tools/sim/lib/simulated_car.py
@@ -107,6 +107,7 @@ class SimulatedCar:
       'controlsAllowed': True,
       'safetyModel': 'hondaNidec',
       'alternativeExperience': self.sm["carParams"].alternativeExperience
+      'safetyParam': 16
     }
     self.pm.send('pandaStates', dat)
 


### PR DESCRIPTION
Controls unresponsive fix in this file to let it engage in Metadrive simulation.
