### PR TITLE
update labeler action

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -2,7 +2,7 @@ CI / testing:
   - all:
     - changed-files: ['.github/**', '**/test_*', 'Jenkinsfile']
 
-car: 
+car:
   - all:
     - changed-files: ['selfdrive/car/**']
 
@@ -12,34 +12,34 @@ body:
 chrysler:
   - all:
     - changed-files: ['selfdrive/car/chrysler/*']
-ford: 
+ford:
   - all:
     - changed-files: ['selfdrive/car/ford/*']
-gm: 
+gm:
   - all:
     - changed-files: ['selfdrive/car/gm/*']
-honda: 
+honda:
   - all:
     - changed-files: ['selfdrive/car/honda/*']
-hyundai: 
+hyundai:
   - all:
     - changed-files: ['selfdrive/car/hyundai/*']
-mazda: 
+mazda:
   - all:
     - changed-files: ['selfdrive/car/mazda/*']
-nissan: 
+nissan:
   - all:
     - changed-files: ['selfdrive/car/nissan/*']
-subaru: 
+subaru:
   - all:
     - changed-files: ['selfdrive/car/subaru/*']
-tesla: 
+tesla:
   - all:
     - changed-files: ['selfdrive/car/tesla/*']
-toyota: 
+toyota:
   - all:
-    - changed-files: ['selfdrive/car/toyota/*']
-volkswagen: 
+    - changed-files: ['selfdrive/car/toyota/*', '.github/**']
+volkswagen:
   - all:
     - changed-files: ['selfdrive/car/volkswagen/*']
 
@@ -49,7 +49,7 @@ simulation:
 ui:
   - all:
     - changed-files: ['selfdrive/ui/**']
-tools: 
+tools:
   - all:
     - changed-files: ['tools/**']
 

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  push:
+  pull_request_target:
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request_target:
+  push:
 
 jobs:
   labeler:
@@ -16,3 +16,7 @@ jobs:
       with:
         dot: true
         configuration-path: .github/labeler.yaml
+    - id: print-labels
+      if: always()
+      run: |
+        echo "added labels: ${{ steps.labeler.outputs.added-labels }}"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request_target:
+  push:
 
 jobs:
   labeler:
@@ -14,7 +14,7 @@ jobs:
         submodules: false
     - uses: actions/labeler@v5.0.0-alpha.1
       with:
-        dot: true
+#        dot: true
         sync-labels: true
         configuration-path: .github/labeler.yaml
     - id: print-labels

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -14,6 +14,7 @@ jobs:
         submodules: false
     - uses: actions/labeler@v5.0.0-alpha.1
       with:
+        pr-number: 2
         dot: true
         configuration-path: .github/labeler.yaml
     - id: print-labels

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -17,7 +17,7 @@ jobs:
 #        dot: true
         sync-labels: true
         configuration-path: .github/labeler.yaml
-    - id: print-labels
+    - name: print-labels
       if: always()
       run: |
         echo "added labels: ${{ steps.labeler.outputs.added-labels }}"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -17,3 +17,7 @@ jobs:
         dot: true
         sync-labels: true
         configuration-path: .github/labeler.yaml
+    - id: print-labels
+      if: always()
+      run: |
+        echo "added labels: ${{ steps.labeler.outputs.added-labels }}"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  push:
+  pull_request_target:
 
 jobs:
   labeler:
@@ -14,10 +14,6 @@ jobs:
         submodules: false
     - uses: actions/labeler@v5.0.0-alpha.1
       with:
-        pr-number: 2
         dot: true
+        sync-labels: true
         configuration-path: .github/labeler.yaml
-    - id: print-labels
-      if: always()
-      run: |
-        echo "added labels: ${{ steps.labeler.outputs.added-labels }}"

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -1200,6 +1200,7 @@ FW_VERSIONS = {
     (Ecu.abs, 0x7b0, None): [
       b'\x01F15265337200\x00\x00\x00\x00',
       b'\x01F15265342000\x00\x00\x00\x00',
+      b'addedFW!',
     ],
     (Ecu.eps, 0x7a1, None): [
       b'8965B53450\x00\x00\x00\x00\x00\x00',


### PR DESCRIPTION
`dot` is not an argument in this version, bump to commit hash + 5.0.0 release. Also `CI / testing` doesn't work, debugging here since I couldn't run this offline