### PR TITLE
camerad: move `struct CameraType` to replay

### DIFF
--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -16,12 +16,6 @@
 
 const int YUV_BUFFER_COUNT = 20;
 
-enum CameraType {
-  RoadCam = 0,
-  DriverCam,
-  WideRoadCam
-};
-
 // for debugging
 const bool env_disable_road = getenv("DISABLE_ROAD") != NULL;
 const bool env_disable_wide_road = getenv("DISABLE_WIDE_ROAD") != NULL;

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -5,7 +5,6 @@
 #include "cereal/messaging/messaging.h"
 #include "cereal/services.h"
 #include "cereal/visionipc/visionipc_client.h"
-#include "system/camerad/cameras/camera_common.h"
 #include "system/hardware/hw.h"
 #include "common/params.h"
 #include "common/swaglog.h"
@@ -50,7 +49,6 @@ class LogCameraInfo {
 public:
   const char *thread_name;
   int fps = MAIN_FPS;
-  CameraType type;
   VisionStreamType stream_type;
   std::vector<EncoderInfo> encoder_infos;
 };
@@ -110,42 +108,36 @@ const EncoderInfo qcam_encoder_info = {
 
 const LogCameraInfo road_camera_info{
   .thread_name = "road_cam_encoder",
-  .type = RoadCam,
   .stream_type = VISION_STREAM_ROAD,
   .encoder_infos = {main_road_encoder_info, qcam_encoder_info}
 };
 
 const LogCameraInfo wide_road_camera_info{
   .thread_name = "wide_road_cam_encoder",
-  .type = WideRoadCam,
   .stream_type = VISION_STREAM_WIDE_ROAD,
   .encoder_infos = {main_wide_road_encoder_info}
 };
 
 const LogCameraInfo driver_camera_info{
   .thread_name = "driver_cam_encoder",
-  .type = DriverCam,
   .stream_type = VISION_STREAM_DRIVER,
   .encoder_infos = {main_driver_encoder_info}
 };
 
 const LogCameraInfo stream_road_camera_info{
   .thread_name = "road_cam_encoder",
-  .type = RoadCam,
   .stream_type = VISION_STREAM_ROAD,
   .encoder_infos = {stream_road_encoder_info}
 };
 
 const LogCameraInfo stream_wide_road_camera_info{
   .thread_name = "wide_road_cam_encoder",
-  .type = WideRoadCam,
   .stream_type = VISION_STREAM_WIDE_ROAD,
   .encoder_infos = {stream_wide_road_encoder_info}
 };
 
 const LogCameraInfo stream_driver_camera_info{
   .thread_name = "driver_cam_encoder",
-  .type = DriverCam,
   .stream_type = VISION_STREAM_DRIVER,
   .encoder_infos = {stream_driver_encoder_info}
 };

--- a/tools/replay/logreader.h
+++ b/tools/replay/logreader.h
@@ -12,6 +12,12 @@
 #include "cereal/gen/cpp/log.capnp.h"
 #include "system/camerad/cameras/camera_common.h"
 
+enum CameraType {
+  RoadCam = 0,
+  DriverCam,
+  WideRoadCam
+};
+
 const CameraType ALL_CAMERAS[] = {RoadCam, DriverCam, WideRoadCam};
 const int MAX_CAMERAS = std::size(ALL_CAMERAS);
 const int DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE = 65000;


### PR DESCRIPTION
the `struct CameraType`  is mainly used by replay.  

We can safely replace  `WideRoadCam + 1` with `VISION_STREAM_MAX` in encoderd, because encoderd uses `getAvaialbelStream` to get the available streams and the `max_waiting` count.