### PR TITLE
Metadrive: set near clip

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -37,6 +37,7 @@ class RGBCameraWide(CopyRamRGBCamera):
     cam.setPos(C3_POSITION)
     lens = self.get_lens()
     lens.setFov(120)
+    lens.setNear(0.1)
 
 class RGBCameraRoad(CopyRamRGBCamera):
   def __init__(self, *args, **kwargs):
@@ -45,6 +46,7 @@ class RGBCameraRoad(CopyRamRGBCamera):
     cam.setPos(C3_POSITION)
     lens = self.get_lens()
     lens.setFov(40)
+    lens.setNear(0.1)
 
 
 def straight_block(length):


### PR DESCRIPTION
set near clip so the full car is rendered in the wide screen

before:
![image](https://github.com/commaai/openpilot/assets/9648890/728b6c51-3a94-41f3-b3c8-e1ef49e58762)

after:
![image](https://github.com/commaai/openpilot/assets/9648890/395e0c64-2b13-4968-ba22-bd80d5f05705)
