### PR TITLE
test_models: use gen_empty_fingerprint

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -13,6 +13,7 @@ from cereal import log, car
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import gen_empty_fingerprint
 from openpilot.selfdrive.car.fingerprints import all_known_cars
 from openpilot.selfdrive.car.car_helpers import FRAME_FINGERPRINT, interfaces
 from openpilot.selfdrive.car.honda.values import CAR as HONDA, HONDA_BOSCH
@@ -105,7 +106,7 @@ class TestCarModelBase(unittest.TestCase):
       can_msgs = []
       cls.elm_frame = None
       cls.car_safety_mode_frame = None
-      fingerprint = defaultdict(dict)
+      fingerprint = gen_empty_fingerprint()
       experimental_long = False
       for msg in lr:
         if msg.which() == "can":


### PR DESCRIPTION
not sure why defaultdict was used