### PR TITLE
build_release only for commaai/openpilot repo

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -32,6 +32,7 @@ jobs:
   build_release:
     name: build release
     runs-on: ubuntu-20.04
+    if: github.repository == 'commaai/openpilot'
     env:
       STRIPPED_DIR: /tmp/releasepilot
     steps:
@@ -44,7 +45,7 @@ jobs:
       run: TARGET_DIR=$STRIPPED_DIR release/build_devel.sh
     - uses: ./.github/workflows/setup-with-retry
     - name: Check submodules
-      if: github.ref == 'refs/heads/master' && github.repository == 'commaai/openpilot'
+      if: github.ref == 'refs/heads/master'
       timeout-minutes: 1
       run: release/check-submodules.sh
     - name: Build openpilot and run checks


### PR DESCRIPTION
This depends on master-ci which is [only pushed for repo commaai/openpilot](https://github.com/commaai/openpilot/blob/8c1176ca839bdfd805f87d281a6d06b9af881eb5/.github/workflows/release.yaml#L16C1-L17C1) so it [fails on forks](https://github.com/gregjhogan/openpilot/actions/runs/7240518277/job/19723589840).