### PR TITLE
Locale independent json

### DIFF
--- a/common/tests/test_swaglog.cc
+++ b/common/tests/test_swaglog.cc
@@ -1,6 +1,7 @@
 #include <zmq.h>
 
 #include <iostream>
+#include <locale>
 
 #include "catch2/catch.hpp"
 #include "common/swaglog.h"
@@ -75,6 +76,7 @@ TEST_CASE("swaglog") {
   setenv("MANAGER_DAEMON", daemon_name.c_str(), 1);
   setenv("DONGLE_ID", dongle_id.c_str(), 1);
   setenv("dirty", "1", 1);
+  setlocale(LC_ALL, "de_DE.UTF-8");
   const int thread_cnt = 5;
   const int thread_msg_cnt = 100;
 

--- a/third_party/json11/json11.cpp
+++ b/third_party/json11/json11.cpp
@@ -56,9 +56,11 @@ static void dump(NullStruct, string &out) {
 
 static void dump(double value, string &out) {
     if (std::isfinite(value)) {
-        char buf[32];
-        std::to_chars(buf, buf + sizeof buf, value, std::chars_format::general, 17);
-        out += buf;
+        std::ostringstream s;
+        s.imbue(std::locale::classic());
+        s.precision(17);
+        s << value;
+        out += s.str();
     } else {
         out += "null";
     }

--- a/third_party/json11/json11.cpp
+++ b/third_party/json11/json11.cpp
@@ -57,7 +57,7 @@ static void dump(NullStruct, string &out) {
 static void dump(double value, string &out) {
     if (std::isfinite(value)) {
         char buf[32];
-        snprintf(buf, sizeof buf, "%.17g", value);
+        std::to_chars(buf, buf + sizeof buf, value, std::chars_format::general, 17);
         out += buf;
     } else {
         out += "null";

--- a/third_party/json11/json11.hpp
+++ b/third_party/json11/json11.hpp
@@ -55,7 +55,6 @@
 #include <map>
 #include <memory>
 #include <initializer_list>
-#include <cstring>
 #include <sstream>
 
 #ifdef _MSC_VER

--- a/third_party/json11/json11.hpp
+++ b/third_party/json11/json11.hpp
@@ -55,7 +55,8 @@
 #include <map>
 #include <memory>
 #include <initializer_list>
-#include <charconv>
+#include <cstring>
+#include <sstream>
 
 #ifdef _MSC_VER
     #if _MSC_VER <= 1800 // VS 2013

--- a/third_party/json11/json11.hpp
+++ b/third_party/json11/json11.hpp
@@ -55,6 +55,7 @@
 #include <map>
 #include <memory>
 #include <initializer_list>
+#include <charconv>
 
 #ifdef _MSC_VER
     #if _MSC_VER <= 1800 // VS 2013


### PR DESCRIPTION
**Description**
When outputting json in swaglog it formats floats using the current locale resulting in invalid json when the locale uses commas as the decimal separator. https://github.com/commaai/openpilot/issues/24523

To resolve this bug i've updated the json library to use string streams when outputting floats. The string stream is imbued with the classic locale which uses periods for the decimal separator.

**Verification** 
To test I forced the locale in the unit tests for swaglog to use the german locale. This results in failing tests as the tests try to parse the output json. I then applied the fix and tests return to passing.
