### PR TITLE
test_models: fallback to public route when route isn't uploaded to CI bucket

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -33,7 +33,7 @@ NUM_JOBS = int(os.environ.get("NUM_JOBS", "1"))
 JOB_ID = int(os.environ.get("JOB_ID", "0"))
 INTERNAL_SEG_LIST = os.environ.get("INTERNAL_SEG_LIST", "")
 INTERNAL_SEG_CNT = int(os.environ.get("INTERNAL_SEG_CNT", "0"))
-
+CI = os.environ.get("CI", None) is not None
 
 def get_test_cases() -> List[Tuple[str, Optional[CarTestRoute]]]:
   # build list of test cases
@@ -64,11 +64,30 @@ def get_test_cases() -> List[Tuple[str, Optional[CarTestRoute]]]:
 class TestCarModelBase(unittest.TestCase):
   car_model: Optional[str] = None
   test_route: Optional[CarTestRoute] = None
-  ci: bool = True
+  test_route_on_bucket: bool = True # whether the route is on the preserved CI bucket
 
   can_msgs: List[capnp.lib.capnp._DynamicStructReader]
   elm_frame: Optional[int]
   car_safety_mode_frame: Optional[int]
+
+  @classmethod
+  def get_logreader(cls, seg):
+    if len(INTERNAL_SEG_LIST):
+      route_name = RouteName(cls.test_route.route)
+      return LogReader(f"cd:/{route_name.dongle_id}/{route_name.time_str}/{seg}/rlog.bz2")
+    else:
+      # Attempt to use CI bucket first
+      try:
+        return LogReader(get_url(cls.test_route.route, seg))
+      except Exception as e:
+        print(f"Route is not accessible via CI bucket. Attempting to use public bucket. {e}")
+        cls.test_route_on_bucket = False
+
+      # Fallback to public route, which will fail the test_route_on_ci_bucket when running in CI
+      try:
+        return LogReader(Route(cls.test_route.route).log_paths()[seg])
+      except Exception as e:
+        print(f"Route is not valid or not a publicly accessible route. {e}")
 
   @classmethod
   def setUpClass(cls):
@@ -91,13 +110,7 @@ class TestCarModelBase(unittest.TestCase):
 
     for seg in test_segs:
       try:
-        if len(INTERNAL_SEG_LIST):
-          route_name = RouteName(cls.test_route.route)
-          lr = LogReader(f"cd:/{route_name.dongle_id}/{route_name.time_str}/{seg}/rlog.bz2")
-        elif cls.ci:
-          lr = LogReader(get_url(cls.test_route.route, seg))
-        else:
-          lr = LogReader(Route(cls.test_route.route).log_paths()[seg])
+        lr = cls.get_logreader(seg)
       except Exception:
         continue
 
@@ -379,6 +392,10 @@ class TestCarModelBase(unittest.TestCase):
 
     failed_checks = {k: v for k, v in checks.items() if v > 0}
     self.assertFalse(len(failed_checks), f"panda safety doesn't agree with openpilot: {failed_checks}")
+
+  @pytest.mark.skipif(not CI, reason="When running in CI we want to make sure all the routes are uploaded to the preserved CI bucket.")
+  def test_route_on_ci_bucket(self):
+    assert self.test_route_on_bucket, "This is fine to fail for WIP car ports, just let us know and we can upload your routes to the CI bucket."
 
 
 @parameterized_class(('car_model', 'test_route'), get_test_cases())

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -79,15 +79,16 @@ class TestCarModelBase(unittest.TestCase):
       # Attempt to use CI bucket first
       try:
         return LogReader(get_url(cls.test_route.route, seg))
-      except Exception as e:
-        print(f"Route is not accessible via CI bucket. Attempting to use public bucket. {e}")
+      except Exception:
         cls.test_route_on_bucket = False
 
       # Fallback to public route, which will fail the test_route_on_ci_bucket when running in CI
       try:
         return LogReader(Route(cls.test_route.route).log_paths()[seg])
-      except Exception as e:
-        print(f"Route is not valid or not a publicly accessible route. {e}")
+      except Exception:
+        pass
+
+      raise Exception("Unable to get route. Check that the route is valid, and either public or uploaded to the CI bucket.")
 
   @classmethod
   def setUpClass(cls):

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -154,7 +154,7 @@ class TestCarModelBase(unittest.TestCase):
       if len(can_msgs) > int(50 / DT_CTRL):
         break
     else:
-      raise Exception(f"Route: {repr(cls.test_route.route)} with segments: {test_segs} not found or no CAN msgs found. Is it uploaded?")
+      raise Exception(f"Route: {repr(cls.test_route.route)} with segments: {test_segs} not found or no CAN msgs found. Is it uploaded and public?")
 
     # if relay is expected to be open in the route
     cls.openpilot_enabled = cls.car_safety_mode_frame is not None

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -396,7 +396,8 @@ class TestCarModelBase(unittest.TestCase):
 
   @pytest.mark.skipif(not CI, reason="When running in CI we want to make sure all the routes are uploaded to the preserved CI bucket.")
   def test_route_on_ci_bucket(self):
-    assert self.test_route_on_bucket, "This is fine to fail for WIP car ports, just let us know and we can upload your routes to the CI bucket."
+    assert self.test_route_on_bucket, "Route not on CI bucket. \
+                                       This is fine to fail for WIP car ports, just let us know and we can upload your routes to the CI bucket."
 
 
 @parameterized_class(('car_model', 'test_route'), get_test_cases())


### PR DESCRIPTION
```test_route_on_ci_bucket``` will fail to let us know that we need to upload the route, but the rest of the tests should run to give the contributor feedback

new route, not public or in CI bucket:
```Exception: Route: '4822a427b188122a|2023-08-14--16-22-21' with segments: (10,) not found or no CAN msgs found. Is it uploaded and public?```

new route, public, not in CI:
tests are run on the new route, no errors

new route, public, in CI:
tests are on on the new route, but this error also will show up
```test_route_on_ci_bucket -> AssertionError: This is fine to fail for WIP car ports, just let us know and we can upload your routes to the CI bucket.```