### PR TITLE
Simulator: only send camera frames at rate that they are generated

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -39,7 +39,8 @@ def apply_metadrive_patches():
 
   MetaDriveEnv._is_arrive_destination = arrive_destination_patch
 
-def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera_array, controls_recv: Connection, state_send: Connection, exit_event):
+def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera_array, image_lock,
+                      controls_recv: Connection, state_send: Connection, exit_event):
   apply_metadrive_patches()
 
   road_image = np.frombuffer(camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
@@ -98,5 +99,6 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
       if dual_camera:
         wide_road_image[...] = get_cam_as_rgb("rgb_wide")
       road_image[...] = get_cam_as_rgb("rgb_road")
+      image_lock.release()
 
     rk.keep_time()

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -27,7 +27,9 @@ class MetaDriveWorld(World):
 
     self.metadrive_process = multiprocessing.Process(name="metadrive process", target=
                               functools.partial(metadrive_process, dual_camera, config,
-                                                self.camera_array, self.wide_camera_array, self.controls_recv, self.state_send, self.exit_event))
+                                                self.camera_array, self.wide_camera_array, self.image_lock,
+                                                self.controls_recv, self.state_send, self.exit_event))
+
     self.metadrive_process.start()
 
     print("----------------------------------------------------------")

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -1,5 +1,5 @@
 import math
-import threading
+import multiprocessing
 import numpy as np
 
 from abc import ABC, abstractmethod
@@ -65,7 +65,7 @@ class World(ABC):
   def __init__(self, dual_camera):
     self.dual_camera = dual_camera
 
-    self.image_lock = threading.Lock()
+    self.image_lock = multiprocessing.Semaphore(value=0)
     self.road_image = np.zeros((H, W, 3), dtype=np.uint8)
     self.wide_road_image = np.zeros((H, W, 3), dtype=np.uint8)
 

--- a/tools/sim/lib/simulated_sensors.py
+++ b/tools/sim/lib/simulated_sensors.py
@@ -102,13 +102,13 @@ class SimulatedSensors:
     self.pm.send('driverMonitoringState', dat)
 
   def send_camera_images(self, world: 'World'):
-    with world.image_lock:
-      yuv = self.camerad.rgb_to_yuv(world.road_image)
-      self.camerad.cam_send_yuv_road(yuv)
+    world.image_lock.acquire()
+    yuv = self.camerad.rgb_to_yuv(world.road_image)
+    self.camerad.cam_send_yuv_road(yuv)
 
-      if world.dual_camera:
-        yuv = self.camerad.rgb_to_yuv(world.wide_road_image)
-        self.camerad.cam_send_yuv_wide_road(yuv)
+    if world.dual_camera:
+      yuv = self.camerad.rgb_to_yuv(world.wide_road_image)
+      self.camerad.cam_send_yuv_wide_road(yuv)
 
   def update(self, simulator_state: 'SimulatorState', world: 'World'):
     now = time.time()


### PR DESCRIPTION
since we put the simulator in it's own process for performance, the camera frames could be sent faster than they were generated