### PR TITLE
uploader.py/listdir_by_creation: list directories only

### DIFF
--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -50,7 +50,7 @@ def get_directory_sort(d: str) -> List[str]:
 
 def listdir_by_creation(d: str) -> List[str]:
   try:
-    paths = os.listdir(d)
+    paths = [f for f in os.listdir(d) if os.path.isdir(os.path.join(d, f))]
     paths = sorted(paths, key=get_directory_sort)
     return paths
   except OSError:


### PR DESCRIPTION
issue:  `listdir_by_creation()` returns the list of all files and directories.  this can cause deleter/uploader to crash if there are files in the log_root.