### PR TITLE
precommit: enable format_fingerprints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 exclude: '^(tinygrad_repo)'
 repos:
+-   repo: local
+    hooks:
+    -   id: format-fingerprints
+        name: format-fingerprints
+        entry: selfdrive/debug/format_fingerprints.py
+        language: system
+        types: [python]
+        pass_filenames: false
 -   repo: meta
     hooks:
     -   id: check-hooks-apply
@@ -89,10 +97,3 @@ repos:
     rev: 0.27.2
     hooks:
     -   id: check-github-workflows
-# -   repo: local
-#     hooks:
-#     -   id: format-fingerprints
-#         name: format-fingerprints
-#         entry: selfdrive/debug/format_fingerprints.py
-#         language: system
-#         types: [python]

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -1,10 +1,13 @@
 # functions common among cars
 from collections import namedtuple
-from typing import Dict, List, Optional
+from enum import StrEnum
+import os
+from typing import Any, Dict, List, Optional
 
 import capnp
 
 from cereal import car
+from openpilot.common.basedir import BASEDIR
 from openpilot.common.numpy_fast import clip, interp
 
 
@@ -236,3 +239,36 @@ class CanSignalRateCalculator:
     self.previous_value = current_value
 
     return self.rate
+
+
+# interface-specific helpers
+
+INTERFACE_ATTR_FILE = {
+  "FINGERPRINTS": "fingerprints",
+  "FW_VERSIONS": "fingerprints",
+}
+
+def get_interface_attr(attr: str, combine_brands: bool = False, ignore_none: bool = False) -> Dict[str | StrEnum, Any]:
+  # read all the folders in selfdrive/car and return a dict where:
+  # - keys are all the car models or brand names
+  # - values are attr values from all car folders
+  result = {}
+  for car_folder in sorted([x[0] for x in os.walk(BASEDIR + '/selfdrive/car')]):
+    try:
+      brand_name = car_folder.split('/')[-1]
+      brand_values = __import__(f'openpilot.selfdrive.car.{brand_name}.{INTERFACE_ATTR_FILE.get(attr, "values")}', fromlist=[attr])
+      if hasattr(brand_values, attr) or not ignore_none:
+        attr_data = getattr(brand_values, attr, None)
+      else:
+        continue
+
+      if combine_brands:
+        if isinstance(attr_data, dict):
+          for f, v in attr_data.items():
+            result[f] = v
+      else:
+        result[brand_name] = attr_data
+    except (ImportError, OSError):
+      pass
+
+  return result

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -6,7 +6,7 @@ from cereal import car
 from openpilot.common.params import Params
 from openpilot.common.basedir import BASEDIR
 from openpilot.system.version import is_comma_remote, is_tested_branch
-from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.car import get_interface_attr
 from openpilot.selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 from openpilot.selfdrive.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
 from openpilot.selfdrive.car.fw_versions import get_fw_versions_ordered, get_present_ecus, match_fw_to_car, set_obd_multiplexing

--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -1,4 +1,4 @@
-from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.car import get_interface_attr
 
 FW_VERSIONS = get_interface_attr('FW_VERSIONS', combine_brands=True, ignore_none=True)
 _FINGERPRINTS = get_interface_attr('FINGERPRINTS', combine_brands=True, ignore_none=True)

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -9,7 +9,7 @@ from cereal import car
 from openpilot.common.params import Params
 from openpilot.selfdrive.car.ecu_addrs import get_ecu_addrs
 from openpilot.selfdrive.car.fw_query_definitions import AddrType, EcuAddrBusType
-from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.car import get_interface_attr
 from openpilot.selfdrive.car.fingerprints import FW_VERSIONS
 from openpilot.selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
 from openpilot.common.swaglog import cloudlog

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -3,8 +3,7 @@ import time
 import numpy as np
 import tomllib
 from abc import abstractmethod, ABC
-from enum import StrEnum
-from typing import Any, Dict, Optional, Tuple, List, Callable
+from typing import Dict, Optional, Tuple, List, Callable
 
 from cereal import car
 from openpilot.common.basedir import BASEDIR
@@ -432,36 +431,3 @@ class CarStateBase(ABC):
   @staticmethod
   def get_loopback_can_parser(CP):
     return None
-
-
-INTERFACE_ATTR_FILE = {
-  "FINGERPRINTS": "fingerprints",
-  "FW_VERSIONS": "fingerprints",
-}
-
-# interface-specific helpers
-
-def get_interface_attr(attr: str, combine_brands: bool = False, ignore_none: bool = False) -> Dict[str | StrEnum, Any]:
-  # read all the folders in selfdrive/car and return a dict where:
-  # - keys are all the car models or brand names
-  # - values are attr values from all car folders
-  result = {}
-  for car_folder in sorted([x[0] for x in os.walk(BASEDIR + '/selfdrive/car')]):
-    try:
-      brand_name = car_folder.split('/')[-1]
-      brand_values = __import__(f'openpilot.selfdrive.car.{brand_name}.{INTERFACE_ATTR_FILE.get(attr, "values")}', fromlist=[attr])
-      if hasattr(brand_values, attr) or not ignore_none:
-        attr_data = getattr(brand_values, attr, None)
-      else:
-        continue
-
-      if combine_brands:
-        if isinstance(attr_data, dict):
-          for f, v in attr_data.items():
-            result[f] = v
-      else:
-        result[brand_name] = attr_data
-    except (ImportError, OSError):
-      pass
-
-  return result

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -13,7 +13,7 @@ from openpilot.selfdrive.car import gen_empty_fingerprint
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.car.fingerprints import all_known_cars
 from openpilot.selfdrive.car.fw_versions import FW_VERSIONS
-from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.car import get_interface_attr
 from openpilot.selfdrive.test.fuzzy_generation import DrawType, FuzzyGenerator
 
 ALL_ECUS = list({ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()})

--- a/selfdrive/debug/auto_fingerprint.py
+++ b/selfdrive/debug/auto_fingerprint.py
@@ -8,7 +8,7 @@ from openpilot.selfdrive.debug.format_fingerprints import format_brand_fw_versio
 from openpilot.tools.lib.logreader import MultiLogIterator
 from openpilot.tools.lib.route import Route
 from openpilot.selfdrive.car.fw_versions import match_fw_to_car
-from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.car import get_interface_attr
 
 
 ALL_FW_VERSIONS = get_interface_attr("FW_VERSIONS")

--- a/selfdrive/debug/format_fingerprints.py
+++ b/selfdrive/debug/format_fingerprints.py
@@ -4,7 +4,7 @@ import os
 
 from cereal import car
 from openpilot.common.basedir import BASEDIR
-from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.car import get_interface_attr
 
 Ecu = car.CarParams.Ecu
 


### PR DESCRIPTION
requires moving get_interface_attr to selfdrive.car.__init__.py to avoid having to fully build openpilot to run the precommit