### PR TITLE
Simulator: fix keyboard ctrl messing with pytest

### DIFF
--- a/tools/sim/lib/keyboard_ctrl.py
+++ b/tools/sim/lib/keyboard_ctrl.py
@@ -15,8 +15,6 @@ ISPEED = 4
 OSPEED = 5
 CC = 6
 
-STDIN_FD = sys.stdin.fileno()
-
 
 KEYBOARD_HELP = """
   | key  |   functionality       |
@@ -32,6 +30,7 @@ KEYBOARD_HELP = """
 
 
 def getch() -> str:
+  STDIN_FD = sys.stdin.fileno()
   old_settings = termios.tcgetattr(STDIN_FD)
   try:
     # set


### PR DESCRIPTION
```pytest .``` was failing to collect sim tests because of this