### PR TITLE
Subaru: longitudinal cleanup and dash status fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "panda"]
   path = panda
-  url = ../../jnewb1/panda.git
+  url = ../../commaai/panda.git
 [submodule "opendbc"]
   path = opendbc
-  url = ../../jnewb1/opendbc.git
+  url = ../../commaai/opendbc.git
 [submodule "cereal"]
   path = cereal
   url = ../../commaai/cereal.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "panda"]
   path = panda
-  url = ../../commaai/panda.git
+  url = ../../jnewb1/panda.git
 [submodule "opendbc"]
   path = opendbc
-  url = ../../commaai/opendbc.git
+  url = ../../jnewb1/opendbc.git
 [submodule "cereal"]
   path = cereal
   url = ../../commaai/cereal.git

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -204,7 +204,6 @@ def create_es_status(packer, frame, es_status_msg, long_enabled, long_active, cr
     "Signal1",
     "Cruise_Fault",
     "Cruise_RPM",
-    "Signal2",
     "Cruise_Activated",
     "Brake_Lights",
     "Cruise_Hold",

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -154,7 +154,7 @@ def create_es_dashstatus(packer, frame, dashstatus_msg, enabled, long_enabled, l
 
   if long_enabled:
     values["Cruise_State"] = 0
-    values["Cruise_Activated"] = long_active
+    values["Cruise_Activated"] = enabled
     values["Cruise_Disengaged"] = 0
     values["Car_Follow"] = int(lead_visible)
 

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -153,13 +153,12 @@ def create_es_dashstatus(packer, frame, dashstatus_msg, enabled, long_enabled, l
 
   values["COUNTER"] = frame % 0x10
 
-  if enabled and long_active:
+  if long_enabled:
     values["Cruise_State"] = 0
-    values["Cruise_Activated"] = 1
+    values["Cruise_Activated"] = long_active
     values["Cruise_Disengaged"] = 0
     values["Car_Follow"] = int(lead_visible)
 
-  if long_enabled:
     values["PCB_Off"] = 1 # AEB is not presevered, so show the PCB_Off on dash
     values["Cruise_Fault"] = 0
 

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -201,7 +201,6 @@ def create_es_status(packer, frame, es_status_msg, long_enabled, long_active, cr
     "Signal1",
     "Cruise_Fault",
     "Cruise_RPM",
-    "Signal2",
     "Cruise_Activated",
     "Brake_Lights",
     "Cruise_Hold",

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -160,6 +160,7 @@ def create_es_dashstatus(packer, frame, dashstatus_msg, enabled, long_enabled, l
     values["Car_Follow"] = int(lead_visible)
 
     values["PCB_Off"] = 1 # AEB is not presevered, so show the PCB_Off on dash
+    values["LDW_Off"] = 0
     values["Cruise_Fault"] = 0
 
   # Filter stock LKAS disabled and Keep hands on steering wheel OFF alerts

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -187,11 +187,11 @@ def create_es_brake(packer, frame, es_brake_msg, long_enabled, long_active, brak
     values["Cruise_Brake_Fault"] = 0
     values["Cruise_Activated"] = long_active
 
-  values["Brake_Pressure"] = brake_value
+    values["Brake_Pressure"] = brake_value
 
-  if brake_value > 0:
-    values["Cruise_Brake_Active"] = 1
-    values["Cruise_Brake_Lights"] = 1 if brake_value >= 70 else 0
+    if brake_value > 0:
+      values["Cruise_Brake_Active"] = 1
+      values["Cruise_Brake_Lights"] = 1 if brake_value >= 70 else 0
 
   return packer.make_can_msg("ES_Brake", CanBus.main, values)
 

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -48,8 +48,7 @@ def create_es_distance(packer, frame, es_distance_msg, bus, pcm_cancel_cmd, long
     values["Cruise_Soft_Disable"] = 0
     values["Cruise_Fault"] = 0
 
-    if brake_cmd:
-      values["Cruise_Brake_Active"] = 1
+    values["Cruise_Brake_Active"] = brake_cmd
 
   if pcm_cancel_cmd:
     values["Cruise_Cancel"] = 1
@@ -186,9 +185,7 @@ def create_es_brake(packer, frame, es_brake_msg, long_enabled, long_active, brak
 
   if long_enabled:
     values["Cruise_Brake_Fault"] = 0
-
-    if long_active:
-      values["Cruise_Activated"] = 1
+    values["Cruise_Activated"] = long_active
 
   values["Brake_Pressure"] = brake_value
 
@@ -217,8 +214,7 @@ def create_es_status(packer, frame, es_status_msg, long_enabled, long_active, cr
     values["Cruise_RPM"] = cruise_rpm
     values["Cruise_Fault"] = 0
 
-    if long_active:
-      values["Cruise_Activated"] = 1
+    values["Cruise_Activated"] = long_active
 
   return packer.make_can_msg("ES_Status", CanBus.main, values)
 

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -189,9 +189,8 @@ def create_es_brake(packer, frame, es_brake_msg, long_enabled, long_active, brak
 
     values["Brake_Pressure"] = brake_value
 
-    if brake_value > 0:
-      values["Cruise_Brake_Active"] = 1
-      values["Cruise_Brake_Lights"] = 1 if brake_value >= 70 else 0
+    values["Cruise_Brake_Active"] = brake_value > 0
+    values["Cruise_Brake_Lights"] = brake_value >= 70
 
   return packer.make_can_msg("ES_Brake", CanBus.main, values)
 


### PR DESCRIPTION
- cleanup long control carcontroller logic
- fix bug where dashstatus would stop showing when gas was pressed
- ignore lane departure warning on dash