### PR TITLE
Set-up-on-retry Openpilot on GHA runners (WIP)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: ./.github/workflows/setup-with-retry
+    - uses: ./.github/workflows/setup-with-retry-test
     - name: Build openpilot
       run: |
         ${{ env.RUN }} "scons -j$(nproc)"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches:
+    branch:
       - master
   pull_request:
 
@@ -11,11 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BASE_IMAGE: openpilot-base
-
-  BUILD: selfdrive/test/docker_build.sh base
-
-  RUN: docker run --shm-size 1G -v $GITHUB_WORKSPACE:/tmp/openpilot -w /tmp/openpilot -e FILEREADER_CACHE=1 -e PYTHONPATH=/tmp/openpilot -e NUM_JOBS -e JOB_ID -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -v $GITHUB_WORKSPACE/.ci_cache/scons_cache:/tmp/scons_cache -v $GITHUB_WORKSPACE/.ci_cache/comma_download_cache:/tmp/comma_download_cache -v $GITHUB_WORKSPACE/.ci_cache/openpilot_cache:/tmp/openpilot_cache $BASE_IMAGE /bin/bash -c
+  PYTHON_VERSION: 3.11
+  APT_PACKAGES: autoconf build-essential ca-certificates casync clang cmake make cppcheck libtool gcc-arm-none-eabi bzip2 liblzma-dev libarchive-dev libbz2-dev capnproto libcapnp-dev curl libcurl4-openssl-dev git git-lfs ffmpeg libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev  libavfilter-dev libeigen3-dev libffi-dev libglew-dev libgles2-mesa-dev libglfw3-dev libglib2.0-0 libncurses5-dev libncursesw5-dev libomp-dev libopencv-dev libpng16-16 libportaudio2 libssl-dev libsqlite3-dev libusb-1.0-0-dev libzmq3-dev libsystemd-dev  locales opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev clinfo portaudio19-dev qml-module-qtquick2 qtmultimedia5-dev qtlocation5-dev qtpositioning5-dev qttools5-dev-tools libqt5sql5-sqlite libqt5svg5-dev libqt5charts5-dev libqt5serialbus5-dev  libqt5x11extras5-dev libreadline-dev libdw1 xvfb valgrind libavresample-dev qt5-default python-dev
 
 jobs:
   docs:
@@ -26,13 +23,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: ./.github/workflows/setup-with-retry-test
+    - uses: ./.github/workflows/setup-with-retry-new
     - name: Build openpilot
-      run: |
-        ${{ env.RUN }} "scons -j$(nproc)"
+      run: python -m poetry run scons -j$(nproc)
     - name: Build docs
-      run: |
-        ${{ env.RUN }} "apt update && apt install -y doxygen && cd docs && make -j$(nproc) html"
+      run: bash -i -c "sudo apt update && sudo apt install -y doxygen && cd docs && python -m poetry run make -j$(nproc) html"
 
     - uses: actions/checkout@v4
       if: github.ref == 'refs/heads/master' && github.repository == 'commaai/openpilot'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,6 @@ jobs:
       run: python -m poetry run scons -j$(nproc)
     - name: Build docs
       run: bash -i -c "sudo apt update && sudo apt install -y doxygen && cd docs && python -m poetry run make -j$(nproc) html"
-
     - uses: actions/checkout@v4
       if: github.ref == 'refs/heads/master' && github.repository == 'commaai/openpilot'
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,8 +2,6 @@ name: docs
 
 on:
   push:
-    branch:
-      - master
   pull_request:
 
 concurrency:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: ./.github/workflows/setup-with-retry-new
+    - uses: ./.github/workflows/setup-with-retry-test
     - name: Build openpilot
       run: python -m poetry run scons -j$(nproc)
     - name: Build docs

--- a/.github/workflows/setup-runner/action.yaml
+++ b/.github/workflows/setup-runner/action.yaml
@@ -28,6 +28,7 @@ runs:
       with:
         packages: ${{ env.APT_PACKAGES }}
         version: 1.0
+
     - id: cache-python-dep
       uses: actions/cache@v3
       with: 

--- a/.github/workflows/setup-runner/action.yaml
+++ b/.github/workflows/setup-runner/action.yaml
@@ -1,0 +1,69 @@
+name: 'Set up ubuntu 20.04 runner'
+
+inputs:
+  docker_hub_pat:
+    description: 'Auth token for Docker Hub, required for BuildJet jobs'
+    required: true
+    default: ''
+  cache_key_prefix:
+    description: 'Prefix for caching key'
+    required: true
+    default: 'scons_x86_64'
+  is_retried:
+    description: 'A mock param that asserts that we use the setup-with-retry instead of this action directly'
+    required: false
+    default: 'false'
+
+runs: 
+  using: "composite"
+  steps:
+    - id: date
+      shell: bash
+      run: echo "CACHE_COMMIT_DATE=$(git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d-%H:%M')" >> $GITHUB_ENV
+    - id: lfs-pull
+      shell: bash
+      run: git lfs pull
+    - id: setup-up-apt-pkgs
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: ${{ env.APT_PACKAGES }}
+        version: 1.0
+    - id: cache-python-dep
+      uses: actions/cache@v3
+      with: 
+        path: |
+          ${{ github.workspace }}/.venv
+        key: poetry-cache-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock')}}
+    - id: setup-python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION}}
+    - id: cache-poetry-package
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.11/site-packages
+        key: poetry-pip-${{ env.PYTHON_VERSION }}
+    - id: poetry-setup
+      shell: bash
+      if: steps.cache-poetry-package.outputs.cache-hit != 'true'
+      run: pip install poetry==1.6.1
+    - id: pre-poetry-install
+      shell: bash
+      if: steps.cache-python-dep.outputs.cache-hit != true
+      run: rm -rf ~/.cache/virtualenvs/*
+    - id: poetry-install
+      shell: bash
+      run: | 
+          python -m poetry env use ${{ env.PYTHON_VERSION }}
+          python -m poetry config virtualenvs.in-project true
+          echo "PYTHONPATH=${{ github.workspace }}" > ${{ github.workspace }}/.env
+          python -m poetry self add poetry-dotenv-plugin@^0.1.0
+          python -m poetry install --no-root
+    - id: restore-scons-cache
+      uses: actions/cache@v3
+      with: 
+        path: /tmp/scons_cache
+        key: ${{ inputs.cache_key_prefix }}-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache_key_prefix }}-${{ env.CACHE_COMMIT_DATE }}-
+          ${{ inputs.cache_key_prefix }}-

--- a/.github/workflows/setup-runner/action.yaml
+++ b/.github/workflows/setup-runner/action.yaml
@@ -54,7 +54,6 @@ runs:
     - id: poetry-install
       shell: bash
       run: | 
-          python -m poetry env use ${{ env.PYTHON_VERSION }}
           python -m poetry config virtualenvs.in-project true
           echo "PYTHONPATH=${{ github.workspace }}" > ${{ github.workspace }}/.env
           python -m poetry self add poetry-dotenv-plugin@^0.1.0

--- a/.github/workflows/setup-runner/action.yaml
+++ b/.github/workflows/setup-runner/action.yaml
@@ -28,7 +28,6 @@ runs:
       with:
         packages: ${{ env.APT_PACKAGES }}
         version: 1.0
-
     - id: cache-python-dep
       uses: actions/cache@v3
       with: 

--- a/.github/workflows/setup-runner/action.yaml
+++ b/.github/workflows/setup-runner/action.yaml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: git lfs pull
     - id: setup-up-apt-pkgs
-      uses: awalsh128/cache-apt-pkgs-action@latest
+      uses: awalsh128/cache-apt-pkgs-action@master
       with:
         packages: ${{ env.APT_PACKAGES }}
         version: 1.0

--- a/.github/workflows/setup-with-retry-test/action.yaml
+++ b/.github/workflows/setup-with-retry-test/action.yaml
@@ -1,0 +1,47 @@
+name: 'openpilot env setup, with retry on failure'
+
+inputs:
+  docker_hub_pat:
+    description: 'Auth token for Docker Hub, required for BuildJet jobs'
+    required: false
+    default: ''
+  cache_key_prefix:
+    description: 'Prefix for caching key'
+    required: false
+    default: 'scons_x86_64'
+  sleep_time:
+    description: 'Time to sleep between retries'
+    required: false
+    default: 30
+
+runs:
+  using: "composite"
+  steps:
+    - id: setup1
+      uses: ./.github/workflows/setup-runner
+      continue-on-error: true
+      with:
+        docker_hub_pat: ${{ inputs.docker_hub_pat }}
+        cache_key_prefix: ${{ inputs.cache_key_prefix }}
+        is_retried: true
+    - if: steps.setup1.outcome == 'failure'
+      shell: bash
+      run: sleep ${{ inputs.sleep_time }}
+    - id: setup2
+      if: steps.setup1.outcome == 'failure'
+      uses: ./.github/workflows/setup-runner
+      continue-on-error: true
+      with:
+        docker_hub_pat: ${{ inputs.docker_hub_pat }}
+        cache_key_prefix: ${{ inputs.cache_key_prefix }}
+        is_retried: true
+    - if: steps.setup2.outcome == 'failure'
+      shell: bash
+      run: sleep ${{ inputs.sleep_time }}
+    - id: setup3
+      if: steps.setup2.outcome == 'failure'
+      uses: ./.github/workflows/setup-runner
+      with:
+        docker_hub_pat: ${{ inputs.docker_hub_pat }}
+        cache_key_prefix: ${{ inputs.cache_key_prefix }}
+        is_retried: true


### PR DESCRIPTION
For [#30706](https://github.com/commaai/openpilot/issues/30706). 

Currently, caching the apt packages and dependencies on GHA runners chops off 10~15s on setup with retry on docs.yaml:
[52s on setup](https://github.com/bongbui321/openpilot/actions/runs/7368088776/job/20052010492)
[45s on setup](https://github.com/bongbui321/openpilot/actions/runs/7366962811/job/20049696301)
However, it sometimes take the same amount as caching from ghrc within bounds of 5s. Most slow down is from extracting the tar and downloading the cache.

I have also tested with caching docker image with local and new experimental gha cache, but most of the time is from loading or pulling the image, and they are significantly slower (around 30s to 1 min)

Then the feasible good way to shorten this is to cut off the dependencies