### PR TITLE
Fixed joystickd.py incorrect steering control

### DIFF
--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -47,7 +47,7 @@ class Joystick:
     else:
       self.cancel_button = 'BTN_TRIGGER'
       accel_axis = 'ABS_Y'
-      steer_axis = 'ABS_RZ'
+      steer_axis = 'ABS_RX'
     self.min_axis_value = {accel_axis: 0., steer_axis: 0.}
     self.max_axis_value = {accel_axis: 255., steer_axis: 255.}
     self.axes_values = {accel_axis: 0., steer_axis: 0.}


### PR DESCRIPTION
**Description**
Having tested with an [Xbox Core Wireless Gaming Controller](https://www.amazon.com/Microsoft-Xbox-Wireless-Controller-USB-C-Cable/dp/B08K2Y2KQN), the steer_axis was incorrectly mapped to **ABS_RZ** which on this controller maps to the right trigger (RT). This meant that release of the trigger made the car swerve left, and holding down trigger would swerve right. This instead should be **ABS_RX**, which is the right joystick.

**Verification**
I changed the value and performed a test drive and the right joystick now correctly controls steering.

This is the controller I used:
![Xbox Core Wireless Gaming Controller](https://m.media-amazon.com/images/W/MEDIAX_792452-T2/images/I/51n+2Ioj4jL._SL1200_.jpg)


