### PR TITLE
[HKG-CAN] Consider FCW alerts from SCC

### DIFF
--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -146,7 +146,8 @@ class CarState(CarStateBase):
     if not self.CP.openpilotLongitudinalControl:
       aeb_src = "FCA11" if self.CP.flags & HyundaiFlags.USE_FCA.value else "SCC12"
       aeb_sig = "FCA_CmdAct" if self.CP.flags & HyundaiFlags.USE_FCA.value else "AEB_CmdAct"
-      aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0 or (cp_cruise.vl["SCC12"]["ACCMode"] == 1 and cp_cruise.vl["SCC12"]["TakeOverReq"] == 1)
+      aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0
+      scc_warning = cp_cruise.vl["SCC12"]["TakeOverReq"] == 1
       aeb_braking = cp_cruise.vl[aeb_src]["CF_VSM_DecCmdAct"] != 0 or cp_cruise.vl[aeb_src][aeb_sig] != 0
       ret.stockFcw = aeb_warning and not aeb_braking
       ret.stockAeb = aeb_warning and aeb_braking

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -149,7 +149,7 @@ class CarState(CarStateBase):
       aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0
       scc_warning = cp_cruise.vl["SCC12"]["TakeOverReq"] == 1
       aeb_braking = cp_cruise.vl[aeb_src]["CF_VSM_DecCmdAct"] != 0 or cp_cruise.vl[aeb_src][aeb_sig] != 0
-      ret.stockFcw = aeb_warning and not aeb_braking
+      ret.stockFcw = (aeb_warning or scc_warning) and not aeb_braking
       ret.stockAeb = aeb_warning and aeb_braking
 
     if self.CP.enableBsm:

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -146,7 +146,7 @@ class CarState(CarStateBase):
     if not self.CP.openpilotLongitudinalControl:
       aeb_src = "FCA11" if self.CP.flags & HyundaiFlags.USE_FCA.value else "SCC12"
       aeb_sig = "FCA_CmdAct" if self.CP.flags & HyundaiFlags.USE_FCA.value else "AEB_CmdAct"
-      aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0
+      aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0 or (cp_cruise.vl["SCC12"]["ACCMode"] == 1 and cp_cruise.vl["SCC12"]["TakeOverReq"] == 1)
       aeb_braking = cp_cruise.vl[aeb_src]["CF_VSM_DecCmdAct"] != 0 or cp_cruise.vl[aeb_src][aeb_sig] != 0
       ret.stockFcw = aeb_warning and not aeb_braking
       ret.stockAeb = aeb_warning and aeb_braking

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -147,7 +147,7 @@ class CarState(CarStateBase):
       aeb_src = "FCA11" if self.CP.flags & HyundaiFlags.USE_FCA.value else "SCC12"
       aeb_sig = "FCA_CmdAct" if self.CP.flags & HyundaiFlags.USE_FCA.value else "AEB_CmdAct"
       aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0
-      scc_warning = cp_cruise.vl["SCC12"]["TakeOverReq"] == 1
+      scc_warning = cp_cruise.vl["SCC12"]["TakeOverReq"] == 1  # sometimes only SCC system shows an FCW
       aeb_braking = cp_cruise.vl[aeb_src]["CF_VSM_DecCmdAct"] != 0 or cp_cruise.vl[aeb_src][aeb_sig] != 0
       ret.stockFcw = (aeb_warning or scc_warning) and not aeb_braking
       ret.stockAeb = aeb_warning and aeb_braking


### PR DESCRIPTION
**Description** 
I was driving the other day using SP with Custom Stock and the car's radar had a false positive which I let it continue to analyze the behavior afterwards. The car suddenly started warning of a collision but stock SCC was engaged and commanding the vehicle and the way ahead was clear. @sunnyhaibin and I looked through the logs and realized that when SCC is engaged, no FCA11 signals are sent, and instead everything is handled by the SCC12, but more importantly, `CF_VSM_Warn` was silent. The only message was the SCC requesting a takeover. 

This is the route where we observed this behavior `e1107f9d04dfb1e2|2023-12-22--10-30-52--3`

https://github.com/commaai/openpilot/assets/7696966/4c094269-b7ac-40dd-b69e-aa0a4bf183ba

**Verification**
In order to validate the cluster message I modified the OP code to send the takeOverReq always to see how the cluster reacted and I could see the collision warning flashing which confirmed that the `takeOverReq` of `SCC12` is an `FCW` when `AccEnabled = 1`

https://github.com/commaai/openpilot/assets/7696966/d2a68daa-ce53-40f5-bc42-27edd35ee644

And this is the route of the video above where I was permanently sending the `takeOverReq` to validate the cluster message:  `e1107f9d04dfb1e2|2023-12-29--00-19-47--1`


_Note: I have not done a run with this changes yet and they were written based on cabana's input, that's why I am creating this as draft. If he integration tests cover this, then feel free to mark it as ready. Otherwise I will try to do a run with this change soon_ 
