### PR TITLE
Auto translate with OpenAI

### DIFF
--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 
 import requests
 
-MODEL = "gpt-3.5-turbo"
+MODEL = "gpt-4"
 
 OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
 

--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -10,7 +10,7 @@ import requests
 
 OPENAI_MODEL = "gpt-4"
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
-OPENAI_PROMPT = "You are a professional translator from English to {language} (ISO 639 language code)." \
+OPENAI_PROMPT = "You are a professional translator from English to {language} (ISO 639 language code)." + \
                 "The following sentence or word is in the GUI of a software called openpilot, translate it accordingly."
 
 
@@ -49,7 +49,7 @@ def translate_phrase(text: str, language: str) -> str:
   return cast(str, data["choices"][0]["message"]["content"])
 
 
-def translate_file(input_file: TextIO, output_file: TextIO, language: str, all: bool) -> None:
+def translate_file(input_file: TextIO, output_file: TextIO, language: str, all_: bool) -> None:
   tree = ET.parse(input_file)
 
   root = tree.getroot()
@@ -70,13 +70,13 @@ def translate_file(input_file: TextIO, output_file: TextIO, language: str, all: 
       if source is None or translation is None:
         raise ValueError("source or translation not found")
 
-      if not all and translation.attrib.get("type") != "unfinished":
+      if not all_ and translation.attrib.get("type") != "unfinished":
         continue
 
       llm_translation = translate_phrase(cast(str, source.text), language)
 
-      print_log(f"Source: {source.text}\n"
-                f"Current translation: {translation.text}\n"
+      print_log(f"Source: {source.text}\n" + \
+                f"Current translation: {translation.text}\n" + \
                 f"LLM translation: {llm_translation}")
 
       translation.text = llm_translation
@@ -88,7 +88,7 @@ def translate_file(input_file: TextIO, output_file: TextIO, language: str, all: 
 
 def main() -> None:
   if OPENAI_API_KEY is None:
-    print("OpenAI api key is missing. (Hint: use `export OPENAI_API_KEY=YOUR-KEY` before you run the script).\n"
+    print("OpenAI api key is missing. (Hint: use `export OPENAI_API_KEY=YOUR-KEY` before you run the script).\n" + \
           "If you don't have one go to: https://beta.openai.com/account/api-keys.")
     exit(1)
 

--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import os
 import pathlib
-import sys
 import xml.etree.ElementTree as ET
 from typing import cast
 
@@ -33,10 +32,6 @@ def get_language_files(languages: list[str] | None = None) -> dict[str, pathlib.
         files[language] = path
 
   return files
-
-
-def print_log(text: str) -> None:
-  print(text, file=sys.stderr)
 
 
 def translate_phrase(text: str, language: str) -> str:
@@ -80,7 +75,7 @@ def translate_file(path: pathlib.Path, language: str, all_: bool) -> None:
     if name is None:
       raise ValueError("name not found")
 
-    print_log(f"Context: {name.text}")
+    print(f"Context: {name.text}")
 
     for message in context.findall("./message"):
       source = message.find("source")
@@ -94,7 +89,7 @@ def translate_file(path: pathlib.Path, language: str, all_: bool) -> None:
 
       llm_translation = translate_phrase(cast(str, source.text), language)
 
-      print_log(f"Source: {source.text}\n" + \
+      print(f"Source: {source.text}\n" + \
                 f"Current translation: {translation.text}\n" + \
                 f"LLM translation: {llm_translation}")
 
@@ -127,13 +122,13 @@ def main():
   if args.file:
     missing_files = set(args.file) - set(files)
     if len(missing_files):
-      print_log(f"No language files found: {missing_files}")
+      print(f"No language files found: {missing_files}")
       exit(1)
 
-  print_log(f"Translation mode: {'all' if args.all_translations else 'only unfinished'}. Files: {list(files)}")
+  print(f"Translation mode: {'all' if args.all_translations else 'only unfinished'}. Files: {list(files)}")
 
   for lang, path in files.items():
-    print_log(f"Translate {lang} ({path})")
+    print(f"Translate {lang} ({path})")
     translate_file(path, lang, args.all_translations)
 
 

--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -87,11 +87,6 @@ def translate_file(input_file: TextIO, output_file: TextIO, language: str, all_:
 
 
 def main() -> None:
-  if OPENAI_API_KEY is None:
-    print("OpenAI api key is missing. (Hint: use `export OPENAI_API_KEY=YOUR-KEY` before you run the script).\n" + \
-          "If you don't have one go to: https://beta.openai.com/account/api-keys.")
-    exit(1)
-
   arg_parser = argparse.ArgumentParser()
   arg_parser.add_argument("input", nargs="?", type=argparse.FileType("r"), help="The input file")
   arg_parser.add_argument("output", nargs="?", type=argparse.FileType("w", encoding="utf-8"), default=sys.stdout, help="The output file")
@@ -99,6 +94,11 @@ def main() -> None:
   arg_parser.add_argument("-l", "--language", required=True, help="Translate to (Language code)")
 
   args = arg_parser.parse_args()
+
+  if OPENAI_API_KEY is None:
+    print("OpenAI api key is missing. (Hint: use `export OPENAI_API_KEY=YOUR-KEY` before you run the script).\n" + \
+          "If you don't have one go to: https://beta.openai.com/account/api-keys.")
+    exit(1)
 
   print_log(f"Translates to {args.language} ({'all' if args.all else 'only unfinished'})")
 

--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+import requests
+
+MODEL = "gpt-3.5-turbo"
+
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+
+logger = logging.getLogger()
+
+handler = logging.StreamHandler(sys.stdout)
+
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+
+def translate_phrase(text: str, to: str) -> str:
+    response = requests.post(
+        "https://api.openai.com/v1/chat/completions",
+        json={
+            "model": MODEL,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": f"Translate the following text from English to {to} (ISO 639 language code)",
+                },
+                {
+                    "role": "user",
+                    "content": text,
+                },
+            ],
+            "temperature": 0.8,
+            "max_tokens": 64,
+            "top_p": 1,
+        },
+        headers={
+            "Authorization": f"Bearer {OPENAI_API_KEY}",
+        },
+    )
+
+    data = response.json()
+
+    return data["choices"][0]["message"]["content"]
+
+
+def translate_file(
+    path: str, language: str, only_unfinished: bool, output_path: str
+) -> None:
+    tree = ET.parse(path)
+
+    root = tree.getroot()
+
+    root.attrib["language"] = language
+
+    for context in root.findall("./context"):
+        name = context.find("name")
+
+        logger.info("Context: %s", name.text)
+
+        for message in context.findall("./message"):
+            source = message.find("source")
+            translation = message.find("translation")
+
+            if only_unfinished and translation.attrib.get("type") != "unfinished":
+                continue
+
+            llm_translation = translate_phrase(source.text, language)
+
+            logger.info("Source: %s", source.text)
+            logger.info("Current translation: %s", translation.text)
+            logger.info("LLM translation: %s", llm_translation)
+
+            translation.text = llm_translation
+
+    # tree.write(output_path, encoding="utf-8", xml_declaration=True) not add <!DOCTYPE TS>
+
+    with open(output_path, "w", encoding="utf-8") as fp:
+        doc_type = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n'
+        tostring = ET.tostring(root, encoding="utf-8")
+
+        fp.write(doc_type)
+        fp.write(tostring.decode())
+
+
+def main() -> None:
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument("-s", "--source", help="The source file")
+    arg_parser.add_argument(
+        "-u",
+        "--only-unfinished",
+        action="store_true",
+        default=False,
+        help="Translate only unfinished",
+    )
+    arg_parser.add_argument(
+        "-l", "--language", required=True, help="Translate to (Language code)"
+    )
+    arg_parser.add_argument("-o", "--output", required=True, help="Path to output file")
+
+    args = arg_parser.parse_args()
+
+    logger.info(
+        "Translates %s (%s) from English to %s.",
+        args.source,
+        "only unfinished" if args.only_unfinished else "all",
+        args.language,
+    )
+
+    translate_file(args.source, args.language, args.only_unfinished, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -88,7 +88,7 @@ def translate_file(input_file: TextIO, output_file: TextIO, language: str, all_:
 
 def main() -> None:
   arg_parser = argparse.ArgumentParser()
-  arg_parser.add_argument("input", nargs="?", type=argparse.FileType("r"), help="The input file")
+  arg_parser.add_argument("input", type=argparse.FileType("r"), help="The input file")
   arg_parser.add_argument("output", nargs="?", type=argparse.FileType("w", encoding="utf-8"), default=sys.stdout, help="The output file")
   arg_parser.add_argument("-a", "--all", action="store_true", default=False, help="Translate all")
   arg_parser.add_argument("-l", "--language", required=True, help="Translate to (Language code)")

--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import xml.etree.ElementTree as ET
+from typing import cast
 
 import requests
 
@@ -46,7 +47,7 @@ def translate_phrase(text: str, to: str) -> str:
 
     data = response.json()
 
-    return data["choices"][0]["message"]["content"]
+    return cast(str, data["choices"][0]["message"]["content"])
 
 
 def translate_file(
@@ -60,6 +61,8 @@ def translate_file(
 
     for context in root.findall("./context"):
         name = context.find("name")
+        if name is None:
+            raise ValueError("name not found")
 
         logger.info("Context: %s", name.text)
 
@@ -67,10 +70,13 @@ def translate_file(
             source = message.find("source")
             translation = message.find("translation")
 
+            if source is None or translation is None:
+                raise ValueError("source or translation not found")
+
             if only_unfinished and translation.attrib.get("type") != "unfinished":
                 continue
 
-            llm_translation = translate_phrase(source.text, language)
+            llm_translation = translate_phrase(cast(str, source.text), language)
 
             logger.info("Source: %s", source.text)
             logger.info("Current translation: %s", translation.text)


### PR DESCRIPTION
Hi,

I wrote a script that can translate a whole file or parts of it using the OpenAI API. (#30883)

Example of usage (use `source.xml` as template, translate to French, write the new file to `out.xml`):

```
export OPENAI_API_KEY=YOUR-KEY
./auto_translate.py -s source.xml -l fr -o out.xml
```

It is possible to translate only places marked as `unfinished` if you add `-u`.

Example of diff between regular translate and the script:

```diff
--- source.xml  2024-01-03 09:42:02
+++ out.xml     2024-01-03 09:43:55
@@ -6,17 +6,17 @@
     <message>
         <source>Dongle ID</source>
-        <translation>Dongle ID</translation>
+        <translation>ID de dongle</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation>N/A</translation>
+        <translation>S/O</translation>
     </message>
     <message>
         <source>Serial</source>
-        <translation>N° de série</translation>
+        <translation>Série</translation>
     </message>
     <message>
         <source>Driver Camera</source>
-        <translation>Caméra conducteur</translation>
+        <translation>Caméra de Conducteur</translation>
     </message>
     <message>
\ No newline at end of file
@@ -26,9 +26,9 @@
     <message>
         <source>Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)</source>
-        <translation>Aperçu de la caméra orientée vers le conducteur pour assurer une bonne visibilité de la surveillance du conducteur. (véhicule doit être éteint)</translation>
+        <translation>Prévisualisez la caméra orientée vers le conducteur pour vous assurer que le suivi du conducteur a une bonne visibilité. (le véhicule doit être éteint)</translation>
     </message>
     <message>
         <source>Reset Calibration</source>
-        <translation>Réinitialiser la calibration</translation>
+        <translation>Réinitialiser l'étalonnage</translation>
     </message>
     <message>
\ No newline at end of file
@@ -46,21 +46,21 @@
     <message>
         <source>Review Training Guide</source>
-        <translation>Revoir le guide de formation</translation>
+        <translation>Guide de Formation d'Examen</translation>
     </message>
     <message>
         <source>REVIEW</source>
-        <translation>REVOIR</translation>
+        <translation>CRITIQUE</translation>
     </message>
     <message>
         <source>Review the rules, features, and limitations of openpilot</source>
-        <translation>Revoir les règles, fonctionnalités et limitations d&apos;openpilot</translation>
+        <translation>Examinez les règles, les fonctionnalités et les limites de openpilot</translation>
     </message>
     <message>
         <source>Are you sure you want to review the training guide?</source>
-        <translation>Êtes-vous sûr de vouloir revoir le guide de formation ?</translation>
+        <translation>Êtes-vous sûr de vouloir revoir le guide de formation?</translation>
     </message>
     <message>
         <source>Review</source>
-        <translation>Revoir</translation>
+        <translation>Critique</translation>
     </message>
     <message>
\ No newline at end of file
@@ -78,9 +78,9 @@
     <message>
         <source>CHANGE</source>
-        <translation>CHANGER</translation>
+        <translation>CHANGEMENT</translation>
     </message>
     <message>
         <source>Select a language</source>
-        <translation>Choisir une langue</translation>
+        <translation>Sélectionnez une langue</translation>
     </message>
     <message>
\ No newline at end of file
@@ -94,17 +94,17 @@
     <message>
         <source>openpilot requires the device to be mounted within 4° left or right and within 5° up or 9° down. openpilot is continuously calibrating, resetting is rarely required.</source>
-        <translation>openpilot nécessite que l&apos;appareil soit monté à 4° à gauche ou à droite et à 5° vers le haut ou 9° vers le bas. openpilot se calibre en continu, la réinitialisation est rarement nécessaire.</translation>
+        <translation>openpilot nécessite que l'appareil soit monté à moins de 4° à gauche ou à droite et à moins de 5° vers le haut ou 9° vers le bas. openpilot se calibre continuellement, une réinitialisation est rarement nécessaire.</translation>
     </message>
     <message>
         <source> Your device is pointed %1° %2 and %3° %4.</source>
-        <translation> Votre appareil est orienté %1° %2 et %3° %4.</translation>
+        <translation>Votre appareil est orienté à %1° %2 et %3° %4.</translation>
     </message>
     <message>
         <source>down</source>
-        <translation>bas</translation>
+        <translation>en bas</translation>
     </message>
     <message>
         <source>up</source>
-        <translation>haut</translation>
+        <translation>en haut</translation>
     </message>
     <message>
\ No newline at end of file
@@ -114,5 +114,5 @@
     <message>
         <source>right</source>
-        <translation>droite</translation>
+        <translation>droit</translation>
     </message>
     <message>
\ No newline at end of file
@@ -122,5 +122,5 @@
     <message>
         <source>Disengage to Reboot</source>
-        <translation>Désengager pour redémarrer</translation>
+        <translation>Désengagez pour redémarrer</translation>
     </message>
     <message>
```