### PR TITLE
Car docs: utilize post init

### DIFF
--- a/selfdrive/car/docs_definitions.py
+++ b/selfdrive/car/docs_definitions.py
@@ -244,10 +244,13 @@ class CarInfo:
   # all the parts needed for the supported car
   car_parts: CarParts = field(default_factory=CarParts)
 
+  def __post_init__(self):
+    self.make, self.model, self.years = split_name(self.name)
+    self.year_list = get_year_list(self.years)
+
   def init(self, CP: car.CarParams, all_footnotes: Dict[Enum, int]):
     self.car_name = CP.carName
     self.car_fingerprint = CP.carFingerprint
-    self.make, self.model, self.years = split_name(self.name)
 
     # longitudinal column
     op_long = "Stock"
@@ -309,7 +312,6 @@ class CarInfo:
       self.row[Column.STEERING_TORQUE] = Star.FULL
 
     self.all_footnotes = all_footnotes
-    self.year_list = get_year_list(self.years)
     self.detail_sentence = self.get_detail_sentence(CP)
 
     return self


### PR DESCRIPTION
No reason to wait on the make init function. I wanted to access the model years for a car info from an import and noticed that it wasn't created unless you give it a CP. `init` should be for things that need the extra arguments

Before:

```python
from selfdrive.car.toyota.values import CAR_INFO
CAR_INFO['TOYOTA CAMRY 2018'][0].years
Traceback (most recent call last):
  File "/home/batman/.pyenv/versions/3.11.4/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3548, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-fe2c4efebe0a>", line 1, in <module>
    CAR_INFO['TOYOTA CAMRY 2018'][0].years
AttributeError: 'ToyotaCarInfo' object has no attribute 'years'
```

After:

```python
from selfdrive.car.toyota.values import CAR_INFO
CAR_INFO['TOYOTA CAMRY 2018'][0].years
Out[4]: '2018-20'
```