### PR TITLE
Auto translate: fix prompt & formatting

### DIFF
--- a/selfdrive/ui/translations/auto_translate.py
+++ b/selfdrive/ui/translations/auto_translate.py
@@ -14,7 +14,7 @@ TRANSLATIONS_LANGUAGES = TRANSLATIONS_DIR / "languages.json"
 
 OPENAI_MODEL = "gpt-4"
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
-OPENAI_PROMPT = "You are a professional translator from English to {language} (ISO 639 language code)." + \
+OPENAI_PROMPT = "You are a professional translator from English to {language} (ISO 639 language code). " + \
                 "The following sentence or word is in the GUI of a software called openpilot, translate it accordingly."
 
 
@@ -55,10 +55,12 @@ def translate_phrase(text: str, language: str) -> str:
     },
     headers={
       "Authorization": f"Bearer {OPENAI_API_KEY}",
+      "Content-Type": "application/json",
     },
   )
 
-  response.raise_for_status()
+  if 400 <= response.status_code < 600:
+    raise requests.HTTPError(f'Error {response.status_code}: {response.json()}', response=response)
 
   data = response.json()
 
@@ -89,9 +91,9 @@ def translate_file(path: pathlib.Path, language: str, all_: bool) -> None:
 
       llm_translation = translate_phrase(cast(str, source.text), language)
 
-      print(f"Source: {source.text}\n" + \
-                f"Current translation: {translation.text}\n" + \
-                f"LLM translation: {llm_translation}")
+      print(f"Source: {source.text}\n" +
+            f"Current translation: {translation.text}\n" +
+            f"LLM translation: {llm_translation}")
 
       translation.text = llm_translation
 
@@ -113,7 +115,7 @@ def main():
   args = arg_parser.parse_args()
 
   if OPENAI_API_KEY is None:
-    print("OpenAI API key is missing. (Hint: use `export OPENAI_API_KEY=YOUR-KEY` before you run the script).\n" + \
+    print("OpenAI API key is missing. (Hint: use `export OPENAI_API_KEY=YOUR-KEY` before you run the script).\n" +
           "If you don't have one go to: https://beta.openai.com/account/api-keys.")
     exit(1)
 


### PR DESCRIPTION
E502 would have caught some of this stuff, but ruff doesn't implement it yet. No space between sentences in prompt, probably should fix

Also add the error message from the API, since you have no clue why it doesn't work (you get 2 different error messages for new accounts). GPT4 isn't available without billing, and then if you switch to GPT4 turbo, it says you've used all your credits

```python
Traceback (most recent call last):
  File "/home/batman/openpilot/selfdrive/ui/translations/./auto_translate.py", line 139, in <module>
    main()
  File "/home/batman/openpilot/selfdrive/ui/translations/./auto_translate.py", line 135, in main
    translate_file(path, lang, args.all_translations)
  File "/home/batman/openpilot/selfdrive/ui/translations/./auto_translate.py", line 92, in translate_file
    llm_translation = translate_phrase(cast(str, source.text), language)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/openpilot/selfdrive/ui/translations/./auto_translate.py", line 63, in translate_phrase
    raise requests.HTTPError(f'Error {response.status_code}: {response.json()}', response=response)
requests.exceptions.HTTPError: Error 404: {'error': {'message': 'The model `gpt-4` does not exist or you do not have access to it. Learn more: https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4.', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_found'}}
```