### PR TITLE
Add write permissions for contents in badges.yaml workflow

### DIFF
--- a/.github/workflows/badges.yaml
+++ b/.github/workflows/badges.yaml
@@ -14,6 +14,8 @@ jobs:
     name: create badges
     runs-on: ubuntu-20.04
     if: github.repository == 'commaai/openpilot'
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This is needed for the action to be able to push back to the repository the generated badge SVG.