### PR TITLE
Add permissions to build_masterci in release workflow so it can push master-ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
     if: github.repository == 'commaai/openpilot'
     permissions:
       checks: read
+      contents: write
     steps:
     - name: Install wait-on-check-action dependencies
       run: |


### PR DESCRIPTION
https://github.com/commaai/openpilot/actions/runs/7467883257/job/20322264611

Follow on of https://github.com/commaai/openpilot/pull/30948
