### PR TITLE
UI/MapETA: Increased contrast of widget texts for better readability

### DIFF
--- a/selfdrive/ui/qt/maps/map_eta.cc
+++ b/selfdrive/ui/qt/maps/map_eta.cc
@@ -20,7 +20,7 @@ void MapETA::paintEvent(QPaintEvent *event) {
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
     p.setPen(Qt::NoPen);
-    p.setBrush(QColor(0, 0, 0, 150));
+    p.setBrush(QColor(0, 0, 0, 255));
     QSizeF txt_size = eta_doc.size();
     p.drawRoundedRect((width() - txt_size.width()) / 2 - UI_BORDER_SIZE, 0, txt_size.width() + UI_BORDER_SIZE * 2, height() + 25, 25, 25);
     p.translate((width() - txt_size.width()) / 2, (height() - txt_size.height()) / 2);


### PR DESCRIPTION
There is little benefit of having a semi-transparent black background. It is at the bottom of the screen so past driven roads by users are irrelevant to where they are going. Increase of contrast of the ETA metrics increases clarity compared to a semi-transparent bottom ETA.

![imgCompare](https://github.com/commaai/openpilot/assets/142481257/7b88ec6b-72f7-448e-993b-2aecf666b421)