### PR TITLE
migrate can_print_changes to segmentrangereader

### DIFF
--- a/selfdrive/debug/can_print_changes.py
+++ b/selfdrive/debug/can_print_changes.py
@@ -3,10 +3,12 @@ import argparse
 import binascii
 import time
 from collections import defaultdict
+from typing import Optional
 
 import cereal.messaging as messaging
 from openpilot.selfdrive.debug.can_table import can_table
-from openpilot.tools.lib.logreader import logreader_from_route_or_segment
+from openpilot.tools.lib.logreader import LogIterable
+from openpilot.tools.lib.srreader import SegmentRangeReader
 
 RED = '\033[91m'
 CLEAR = '\033[0m'
@@ -95,13 +97,15 @@ if __name__ == "__main__":
 
   args = parser.parse_args()
 
-  init_lr, new_lr = None, None
+  init_lr: Optional[LogIterable] = None
+  new_lr: Optional[LogIterable] = None
+
   if args.init:
     if args.init == '':
       init_lr = []
     else:
-      init_lr = logreader_from_route_or_segment(args.init)
+      init_lr = SegmentRangeReader(args.init)
   if args.comp:
-    new_lr = logreader_from_route_or_segment(args.comp)
+    new_lr = SegmentRangeReader(args.comp)
 
   can_printer(args.bus, init_msgs=init_lr, new_msgs=new_lr, table=args.table)


### PR DESCRIPTION
a very convenient example use case for the ```can_print_changes``` tool (look for changes between the first 3 segments and the 4th)

```bash
> python selfdrive/debug/can_print_changes.py 'd9df6f87e8feff94|2023-12-29--18-01-11/:3' 'd9df6f87e8feff94|2023-12-29--18-01-11/3'
```