### PR TITLE
buildjet: pin location to de

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -75,7 +75,7 @@ jobs:
            ((github.repository == 'commaai/openpilot') &&
               ((github.event_name != 'pull_request') || 
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ (matrix.arch == 'aarch64') && ['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm'] || 'ubuntu-20.04' }}
+    runs-on: ${{ (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']"" || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson( (github.repository == 'commaai/openpilot') && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ (matrix.arch == 'aarch64') && ['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm'] || 'ubuntu-20.04' }}
+    runs-on: ${{ (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' }}
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -75,7 +75,7 @@ jobs:
            ((github.repository == 'commaai/openpilot') &&
               ((github.event_name != 'pull_request') || 
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']"" || 'ubuntu-20.04' }}
+    runs-on: ${{ (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -75,7 +75,7 @@ jobs:
            ((github.repository == 'commaai/openpilot') &&
               ((github.event_name != 'pull_request') || 
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' }}
+    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' ) }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson( (github.repository == 'commaai/openpilot') && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' }}
+    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' ) }}
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -75,7 +75,7 @@ jobs:
            ((github.repository == 'commaai/openpilot') &&
               ((github.event_name != 'pull_request') || 
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ (matrix.arch == 'aarch64') && 'buildjet-2vcpu-ubuntu-2204-arm' || 'ubuntu-20.04' }}
+    runs-on: ${{ (matrix.arch == 'aarch64') && ['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm'] || 'ubuntu-20.04' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson( (github.repository == 'commaai/openpilot') && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ (matrix.arch == 'aarch64') && 'buildjet-2vcpu-ubuntu-2204-arm' || 'ubuntu-20.04' }}
+    runs-on: ${{ (matrix.arch == 'aarch64') && ['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm'] || 'ubuntu-20.04' }}
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -75,7 +75,7 @@ jobs:
            ((github.repository == 'commaai/openpilot') &&
               ((github.event_name != 'pull_request') || 
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && '["buildjet-2vcpu-ubuntu-2204-arm", "buildjet-pinned-location_de_arm"]' || "ubuntu-20.04" ) }}
+    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && '["buildjet-2vcpu-ubuntu-2204-arm", "buildjet-pinned-location_de_arm"]' || 'ubuntu-20.04' ) }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson( (github.repository == 'commaai/openpilot') && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && '["buildjet-2vcpu-ubuntu-2204-arm", "buildjet-pinned-location_de_arm"]' || "ubuntu-20.04" ) }}
+    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && '["buildjet-2vcpu-ubuntu-2204-arm", "buildjet-pinned-location_de_arm"]' || 'ubuntu-20.04' ) }}
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -75,7 +75,7 @@ jobs:
            ((github.repository == 'commaai/openpilot') &&
               ((github.event_name != 'pull_request') || 
                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' ) }}
+    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && '["buildjet-2vcpu-ubuntu-2204-arm", "buildjet-pinned-location_de_arm"]' || "ubuntu-20.04" ) }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson( (github.repository == 'commaai/openpilot') && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
-    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && "['buildjet-2vcpu-ubuntu-2204-arm', 'buildjet-pinned-location_de_arm']" || 'ubuntu-20.04' ) }}
+    runs-on: ${{ fromJson( (matrix.arch == 'aarch64') && '["buildjet-2vcpu-ubuntu-2204-arm", "buildjet-pinned-location_de_arm"]' || "ubuntu-20.04" ) }}
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
buildjet support wants to try pinning the location to see if it's a problem with their datacenter.

```
We have a theory that this could be due to the networking at one of our locations. As we can’t perfectly reproduce it, I’d like to restrict your runners to Germany only.
I’ve enabled the feature on your account, but you will need to update your workflows as well. You need to convert the runs-on property to an array, and add a special tag.
For AMD runners it could look like: [buildjet-2vcpu-ubuntu-2204, buildjet-pinned-location_de]
For ARM runners it could look like: [buildjet-2vcpu-ubuntu-2204-arm, buildjet-pinned-location_de_arm]
It works for all runner sizes as long as you have the pinned tag in the array.
Let’s keep an eye on how it goes after we pin the location to Germany, and take it from there.
```