### PR TITLE
Enable variable pass between test and metadrive processes

### DIFF
--- a/tools/sim/tests/test_sim_bridge.py
+++ b/tools/sim/tests/test_sim_bridge.py
@@ -3,7 +3,7 @@ import subprocess
 import time
 import unittest
 
-from multiprocessing import Queue
+from multiprocessing import Queue, Value
 
 from cereal import messaging
 from openpilot.common.basedir import BASEDIR
@@ -27,6 +27,7 @@ class TestSimBridgeBase(unittest.TestCase):
     sm = messaging.SubMaster(['controlsState', 'onroadEvents', 'managerState'])
     q = Queue()
     bridge = self.create_bridge()
+    bridge.started = Value('b', False)
     p_bridge = bridge.run(q, retries=10)
     self.processes.append(p_bridge)
 


### PR DESCRIPTION
In metadrive bridge test, one of the test is to see if the metadrive process loop is started by checking `bridge.started`, but it wasn't viewable through multiprocessing, so it was stuck in that loop for 60s, which increases the time for the test significantly. It used to take ~60s now only ~20s
Before:
```Test shutting down. CommIssues are acceptable
{"event": "commIssue", "error": true, "invalid": [], "not_alive": ["testJoystick", "driverCameraState", "wideRoadCameraState"], "not_freq_ok": ["testJoystick", "driverCameraState", "wideRoadCameraState"], "can_rcv_timeout": true}
vipc_client_main no frame
vipc_client_main no frame
child selfdrive.navd.navd got SIGINT
child system.loggerd.deleter got SIGINT
child selfdrive.thermald.thermald got SIGINT
child selfdrive.modeld.modeld got SIGINT
child selfdrive.locationd.calibrationd got SIGINT
SIGINT received, exiting
SIGINT received, exiting
child selfdrive.ui.soundd got SIGINT
child selfdrive.locationd.paramsd got SIGINT
child selfdrive.locationd.torqued got SIGINT
child selfdrive.controls.plannerd got SIGINT
child selfdrive.statsd got SIGINT
.s
----------------------------------------------------------------------
Ran 1 test in 62.897s
```

After:
```Test shutting down. CommIssues are acceptable
{"event": "commIssue", "error": true, "invalid": [], "not_alive": ["testJoystick", "driverCameraState", "wideRoadCameraState"], "not_freq_ok": ["testJoystick", "driverCameraState", "wideRoadCameraState"], "can_rcv_timeout": true}
vipc_client_main no frame
vipc_client_main no frame
vipc_client_main no frame
vipc_client_main no frame
vipc_client_main no frame
child selfdrive.navd.navd got SIGINT
child system.loggerd.deleter got SIGINT
child selfdrive.thermald.thermald got SIGINT
SIGINT received, exiting
child selfdrive.modeld.modeld got SIGINT
child selfdrive.locationd.calibrationd got SIGINT
child selfdrive.ui.soundd got SIGINT
SIGINT received, exiting
child selfdrive.locationd.paramsd got SIGINT
child selfdrive.locationd.torqued got SIGINT
child selfdrive.controls.plannerd got SIGINT
child selfdrive.statsd got SIGINT
.s
----------------------------------------------------------------------
Ran 1 test in 19.412s
```