### PR TITLE
Honda: remove hud ECU from CR-V Hybrid

### DIFF
--- a/selfdrive/car/honda/fingerprints.py
+++ b/selfdrive/car/honda/fingerprints.py
@@ -744,9 +744,6 @@ FW_VERSIONS = {
       b'78109-TPG-A110\x00\x00',
       b'78109-TPG-A210\x00\x00',
     ],
-    (Ecu.hud, 0x18da61f1, None): [
-      b'78209-TLA-X010\x00\x00',
-    ],
     (Ecu.fwdRadar, 0x18dab0f1, None): [
       b'36802-TMB-H040\x00\x00',
       b'36802-TPA-E040\x00\x00',


### PR DESCRIPTION
Prevents fe90f3d7403f2411 from being valid for the fingerprint PR bot, which doesn't have this ECU response.

Added here without a reference where it came from: https://github.com/commaai/openpilot/commit/7c94b361717306f13b02839fd79d87072ca879a5 although this user has the same hud FW: 11fa019479471a0a

For 14 users driving in the last 90 days, only that one user has this ECU, all the others can never exact match because of this.

With this deletion, we gain a new MY with the bot (not yet, it will open that PR later)!

| Dongle           | Platform               | VIN               | Name from VIN          | Name from CarInfo         | New model year   |   Fuzzy segments |
|:-----------------|:-----------------------|:------------------|:-----------------------|:--------------------------|:-----------------|-----------------:|
| fe90f3d7403f2411 | HONDA CR-V HYBRID 2019 | 7FART6H9XXXXXXXXX | HONDA CR-V Hybrid 2021 | Honda CR-V Hybrid 2017-19 | True             |               65 |