### PR TITLE
Fingerprints: automatically add missing FW versions from users [bot]

### DIFF
--- a/selfdrive/car/toyota/fingerprints.py
+++ b/selfdrive/car/toyota/fingerprints.py
@@ -1412,6 +1412,7 @@ FW_VERSIONS = {
   CAR.LEXUS_RC: {
     (Ecu.engine, 0x700, None): [
       b'\x01896632461100\x00\x00\x00\x00',
+      b'\x01896632478100\x00\x00\x00\x00',
       b'\x01896632478200\x00\x00\x00\x00',
     ],
     (Ecu.engine, 0x7e0, None): [


### PR DESCRIPTION
Updating FW version database with FW from 1 dongles (1 platforms) in last 14 days:
| Dongle, platform, VIN                                                                                                    | Name from VIN 🆚 CarInfo            |
|:-------------------------------------------------------------------------------------------------------------------------|:------------------------------------|
| [83dbf2d109574495](https://useradmin.comma.ai/?onebox=83dbf2d109574495)<br><sub>LEXUS RC 2020<br>JTHSZ5BCXXXXXXXXX</sub> | LEXUS RC 2019 🆚<br>Lexus RC 2018-20 |
