### PR TITLE
Subaru: remove incorrect fingerprints from other brands queries

### DIFF
--- a/selfdrive/car/subaru/fingerprints.py
+++ b/selfdrive/car/subaru/fingerprints.py
@@ -8,7 +8,6 @@ FW_VERSIONS = {
     (Ecu.abs, 0x7b0, None): [
       b'\xa5 \x19\x02\x00',
       b'\xa5 !\x02\x00',
-      b'\xf1\x82\xa5 \x19\x02\x00',
     ],
     (Ecu.eps, 0x746, None): [
       b'\x05\xc0\xd0\x00',
@@ -25,10 +24,6 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7e0, None): [
       b'\xbb,\xa0t\x07',
       b'\xd1,\xa0q\x07',
-      b'\xf1\x82\xbb,\xa0t\x07',
-      b'\xf1\x82\xbb,\xa0t\x87',
-      b'\xf1\x82\xd1,\xa0q\x07',
-      b'\xf1\x82\xd9,\xa0@\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\x00\xfe\xf7\x00\x00',
@@ -96,7 +91,6 @@ FW_VERSIONS = {
       b'\xa2 \x193\x00',
       b'\xa2 \x194\x00',
       b'\xa2 \x19`\x00',
-      b'\xf1\x00\xb2\x06\x04',
     ],
     (Ecu.eps, 0x746, None): [
       b'z\xc0\x00\x00',
@@ -170,7 +164,6 @@ FW_VERSIONS = {
       b'\xa2 !3\x00',
       b'\xa2 !`\x00',
       b'\xa2 !i\x00',
-      b'\xf1\x00\xb2\x06\x04',
     ],
     (Ecu.eps, 0x746, None): [
       b'\n\xc0\x04\x00',
@@ -214,7 +207,6 @@ FW_VERSIONS = {
       b'\xe9\xf5B0\x00',
       b'\xe9\xf6B0\x00',
       b'\xe9\xf6F0\x00',
-      b'\xf1\x00\xd7\x10@',
     ],
   },
   CAR.CROSSTREK_HYBRID: {
@@ -243,7 +235,6 @@ FW_VERSIONS = {
       b'\xa3 \x19&\x00',
       b'\xa3  \x14\x00',
       b'\xa3  \x14\x01',
-      b'\xf1\x00\xbb\r\x05',
     ],
     (Ecu.eps, 0x746, None): [
       b'\x8d\xc0\x00\x00',
@@ -257,7 +248,6 @@ FW_VERSIONS = {
       b'\x00\x00e`\x1f@  ',
       b'\x00\x00e\x97\x00\x00\x00\x00',
       b'\x00\x00e\x97\x1f@ 0',
-      b'\xf1\x00\xac\x02\x00',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xb6"`A\x07',
@@ -266,7 +256,6 @@ FW_VERSIONS = {
       b'\xcb"`p\x07',
       b'\xcf"`0\x07',
       b'\xcf"`p\x07',
-      b'\xf1\x00\xa2\x10\n',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\x1a\xe6B1\x00',
@@ -299,7 +288,6 @@ FW_VERSIONS = {
     (Ecu.abs, 0x7b0, None): [
       b'm\x97\x14@',
       b'}\x97\x14@',
-      b'\xf1\x00\xbb\x0c\x04',
     ],
     (Ecu.eps, 0x746, None): [
       b'm\xc0\x10\x00',
@@ -316,7 +304,6 @@ FW_VERSIONS = {
       b'\xa7)\xa0q\x07',
       b'\xba"@@\x07',
       b'\xba"@p\x07',
-      b'\xf1\x82\xa7)\xa0q\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\x1a\xf6F`\x00',
@@ -387,7 +374,6 @@ FW_VERSIONS = {
       b'\x00\x00c\xd1\x1f@\x10\x17',
       b'\x00\x00c\xec\x1f@ \x04',
       b'\x00\x00c\xec7@\x04',
-      b'\xf1\x00\xf0\xe0\x0e',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xa0"@\x80\x07',
@@ -494,9 +480,6 @@ FW_VERSIONS = {
       b'\xe2"`0\x07',
       b'\xe2"`p\x07',
       b'\xe3,\xa0@\x07',
-      b'\xf1\x82\xbc,\xa0q\x07',
-      b'\xf1\x82\xe2,\xa0@\x07',
-      b'\xf1\x82\xe3,\xa0@\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xa5\xf6D@\x00',
@@ -506,7 +489,6 @@ FW_VERSIONS = {
       b'\xa7\x8e\xf40\x00',
       b'\xa7\xf6D@\x00',
       b'\xa7\xfe\xf4@\x00',
-      b'\xf1\x82\xa7\xf6D@\x00',
     ],
   },
   CAR.FORESTER_2022: {


### PR DESCRIPTION
looks like these were added when there wasn't brand specific queries, because hyundai and subaru share some of the same ECU id's

for example, the one added to engine here: https://github.com/commaai/openpilot/pull/23848

```
b'\xf1\x00\xa4\x10@',
```

is actually a hyundai response

most of them came from the first dump of fingerprints: https://github.com/commaai/openpilot/pull/23389

with these removed, the rest of the fw versions seems to follow some kind of pattern