### PR TITLE
LogReader: support lists of identifiers

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -11,7 +11,7 @@ import sys
 import urllib.parse
 import warnings
 
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, List
 from urllib.parse import parse_qs, urlparse
 
 from cereal import log as capnp_log
@@ -161,7 +161,10 @@ def parse_indirect(identifier):
 
 
 class LogReader:
-  def _logreaders_from_identifier(self, identifier):
+  def _logreaders_from_identifier(self, identifier: str | List[str]):
+    if isinstance(identifier, list):
+      return [LogReader(i) for i in identifier]
+
     parsed, source, is_indirect = parse_indirect(identifier)
 
     if not is_indirect:
@@ -175,7 +178,7 @@ class LogReader:
 
     return source(sr, mode, sort_by_time=self.sort_by_time, only_union_types=self.only_union_types)
 
-  def __init__(self, identifier: str, default_mode=ReadMode.RLOG, default_source=auto_source, sort_by_time=False, only_union_types=False):
+  def __init__(self, identifier: str | List[str], default_mode=ReadMode.RLOG, default_source=auto_source, sort_by_time=False, only_union_types=False):
     self.default_mode = default_mode
     self.default_source = default_source
     self.identifier = identifier

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 import numpy as np
 import unittest
+import pytest
 from parameterized import parameterized
 import requests
 from openpilot.tools.lib.logreader import LogReader, parse_indirect, parse_slice, ReadMode
@@ -69,21 +70,21 @@ class TestLogReader(unittest.TestCase):
       sr = SegmentRange(segment_range)
       parse_slice(sr)
 
-  @unittest.skip("this test is too slow for the minimal coverage it provides")
+  @pytest.mark.slow
   def test_modes(self):
     qlog_len = len(list(LogReader(f"{TEST_ROUTE}/0", ReadMode.QLOG)))
     rlog_len = len(list(LogReader(f"{TEST_ROUTE}/0", ReadMode.RLOG)))
 
     self.assertLess(qlog_len * 6, rlog_len)
 
-  @unittest.skip("this test is too slow for the minimal coverage it provides")
+  @pytest.mark.slow
   def test_modes_from_name(self):
     qlog_len = len(list(LogReader(f"{TEST_ROUTE}/0/q")))
     rlog_len = len(list(LogReader(f"{TEST_ROUTE}/0/r")))
 
     self.assertLess(qlog_len * 6, rlog_len)
 
-  @unittest.skip("this test is too slow for the minimal coverage it provides")
+  @pytest.mark.slow
   def test_list(self):
     qlog_len = len(list(LogReader(f"{TEST_ROUTE}/0/q")))
     qlog_len_2 = len(list(LogReader([f"{TEST_ROUTE}/0/q", f"{TEST_ROUTE}/0/q"])))

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -83,6 +83,13 @@ class TestLogReader(unittest.TestCase):
 
     self.assertLess(qlog_len * 6, rlog_len)
 
+  @unittest.skip("this test is too slow for the minimal coverage it provides")
+  def test_list(self):
+    qlog_len = len(list(LogReader(f"{TEST_ROUTE}/0/q")))
+    qlog_len_2 = len(list(LogReader([f"{TEST_ROUTE}/0/q", f"{TEST_ROUTE}/0/q"])))
+
+    self.assertEqual(qlog_len*2, qlog_len_2)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
ex: LogReader([''72df1a0f641d5d4f|2024-01-12--10-38-38/0', ''72df1a0f641d5d4f|2024-01-12--10-38-39/5'])