### PR TITLE
silence xvfb

### DIFF
--- a/selfdrive/test/setup_xvfb.sh
+++ b/selfdrive/test/setup_xvfb.sh
@@ -5,7 +5,7 @@
 DISP_ID=99
 export DISPLAY=:$DISP_ID
 
-sudo Xvfb $DISPLAY -screen 0 2160x1080x24 &
+sudo Xvfb $DISPLAY -screen 0 2160x1080x24 2>/dev/null &
 
 # check for x11 socket for the specified display ID
 while [ ! -S /tmp/.X11-unix/X$DISP_ID ]


### PR DESCRIPTION
these appear in unittests

```
1 XSELINUXs still allocated at reset
SCREEN: 0 objects of 304 bytes = 0 total bytes 0 private allocs
DEVICE: 0 objects of 88 bytes = 0 total bytes 0 private allocs
CLIENT: 0 objects of 136 bytes = 0 total bytes 0 private allocs
WINDOW: 0 objects of 48 bytes = 0 total bytes 0 private allocs
PIXMAP: 0 objects of 16 bytes = 0 total bytes 0 private allocs
GC: 0 objects of 16 bytes = 0 total bytes 0 private allocs
CURSOR: 1 objects of 8 bytes = 8 total bytes 0 private allocs
TOTAL: 1 objects, 8 bytes, 0 allocs
1 CURSORs still allocated at reset
CURSOR: 1 objects of 8 bytes = 8 total bytes 0 private allocs
TOTAL: 1 objects, 8 bytes, 0 allocs
1 CURSOR_BITSs still allocated at reset
TOTAL: 0 objects, 0 bytes, 0 allocs
```