### PR TITLE
UI/close_btn: Removed unused border code

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -356,7 +356,6 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
     QPushButton {
       font-size: 140px;
       padding-bottom: 20px;
-      border 1px grey solid;
       border-radius: 100px;
       background-color: #292929;
       font-weight: 400;


### PR DESCRIPTION
Code with typo: `border 1px grey solid;`
Corrected code: `border: 1px solid grey;`

There was a typo in the border code and even after fixing the typo, the code looked more of an accident versus an intentional aesthetic opinion. Accident because a border width of 1px is difficult to even notice or be helpful on the comma device especially since typically comma devices are on windshield and not close to face.  Decided to remove code since a border around a circle for the close button is not needed(1px width too thin to be helpful/noticeable) and will just add more unnecessary noise and bulk to the sidebar layout.

![compareUI](https://github.com/commaai/openpilot/assets/142481257/3bf56db5-cbe8-4b35-b75b-3a71e61779b3)
