### PR TITLE
car tests on namespace

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -307,7 +307,9 @@ jobs:
 
   test_cars:
     name: cars
-    runs-on: ubuntu-20.04
+    runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
+                   ((github.event_name != 'pull_request') || 
+                    (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-amd64-8x16' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
we paid for 4,652 8 vCPUs minutes with buildjet last month, with only running process replay and unit tests

enabling car tests would mean an extra 5 jobs per commit (that take approximently the same amount of time, 2-3 minutes per job), which would be approximately 16000 minutes, which at namespace would be approx 150$/month

on namespace it takes 3 minutes for the car tests rather than 6-7

