### PR TITLE
LogReader: remove redirect message for internal data

### DIFF
--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 import threading
@@ -12,6 +13,7 @@ from openpilot.system.hardware.hw import Paths
 K = 1000
 CHUNK_SIZE = 1000 * K
 
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 def hash_256(link):
   hsh = str(sha256((link.split("?")[0]).encode('utf-8')).hexdigest())


### PR DESCRIPTION
fix annoying redirect message when using the internal dataset

```
Redirecting http://data-raw.comma.internal/d9df6f87e8feff94/2023-03-28--17-41-10/1/rlog.bz2 -> http://data-volume-31.comma.life:3001/sv04/7d/a7/L2Q5ZGY2Zjg3ZThmZWZmOTQvMjAyMy0wMy0yOC0tMTctNDEtMTAvMS9ybG9nLmJ6Mg==
Redirecting http://data-raw.comma.internal/d9df6f87e8feff94/2023-03-28--17-41-10/2/rlog.bz2 -> http://data-volume-37.comma.life:3001/sv02/01/58/L2Q5ZGY2Zjg3ZThmZWZmOTQvMjAyMy0wMy0yOC0tMTctNDEtMTAvMi9ybG9nLmJ6Mg==
Redirecting http://data-raw.comma.internal/d9df6f87e8feff94/2023-03-28--17-41-10/3/rlog.bz2 -> http://data-volume-22.comma.life:3001/sv09/06/c6/L2Q5ZGY2Zjg3ZThmZWZmOTQvMjAyMy0wMy0yOC0tMTctNDEtMTAvMy9ybG9nLmJ6Mg==
```

https://github.com/urllib3/urllib3/blob/bbba48753448a9e9b642cf32efe041683f3324f8/src/urllib3/poolmanager.py#L487