### PR TITLE
UI/sidebar_layout: Removed redundant piece of margin code

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -345,7 +345,6 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
   // setup two main layouts
   sidebar_widget = new QWidget;
   QVBoxLayout *sidebar_layout = new QVBoxLayout(sidebar_widget);
-  sidebar_layout->setMargin(0);
   panel_widget = new QStackedWidget();
 
   // close button


### PR DESCRIPTION
1) `sidebar_layout->setMargin(0);` this code is at line 348

2) `sidebar_layout->setContentsMargins(50, 50, 100, 50);` this code is at line 420


The 2 code lines above set margins for sidebar_layout. Setting margin to 0 is not needed because it then gets overwritten by the already existing later code using `setContentsMargins()`

Also, in regards to `setMargin()` the link below says "This function is obsolete. It is provided to keep old source code working. We strongly advise against using it in new code."  So even if setting margin to 0 is necessary for some reason I overlooked, the link would recommend using `setContentsMargins(0, 0, 0, 0);`

https://doc.qt.io/qt-5/qlayout-obsolete.html