### PR TITLE
CI: enable virtual audio sink for soundd

### DIFF
--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -4,7 +4,7 @@ ENV PYTHONUNBUFFERED 1
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo tzdata locales ssh && \
+    apt-get install -y --no-install-recommends sudo tzdata locales ssh pulseaudio && \
     rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen

--- a/selfdrive/test/setup_vsound.sh
+++ b/selfdrive/test/setup_vsound.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#start pulseaudio daemon
+sudo pulseaudio -D > /dev/null 2>&1
+
+# create a virtual null audio and set it to default device
+sudo pactl load-module module-null-sink sink_name=virtual_audio > /dev/null 2>&1
+sudo pactl set-default-sink virtual_audio > /dev/null 2>&1

--- a/selfdrive/test/setup_vsound.sh
+++ b/selfdrive/test/setup_vsound.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-#start pulseaudio daemon
-sudo pulseaudio -D > /dev/null 2>&1
+{
+  #start pulseaudio daemon
+  sudo pulseaudio -D
 
-# create a virtual null audio and set it to default device
-sudo pactl load-module module-null-sink sink_name=virtual_audio > /dev/null 2>&1
-sudo pactl set-default-sink virtual_audio > /dev/null 2>&1
+  # create a virtual null audio and set it to default device
+  sudo pactl load-module module-null-sink sink_name=virtual_audio
+  sudo pactl set-default-sink virtual_audio
+} > /dev/null 2>&1

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -77,6 +77,7 @@ function install_ubuntu_common_requirements() {
     libqt5x11extras5-dev \
     libreadline-dev \
     libdw1 \
+    pulseaudio \
     xvfb \
     valgrind
 }

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -77,7 +77,6 @@ function install_ubuntu_common_requirements() {
     libqt5x11extras5-dev \
     libreadline-dev \
     libdw1 \
-    pulseaudio \
     xvfb \
     valgrind
 }


### PR DESCRIPTION
**Description**
I enable virtual audio sink for soundd to be used in CI

**Verification**

I tested by running the script `./selfdrive/test/setup_vsound.sh && python3 selfdrive/ui/soundd.py` in docker container. Before it would not be able to find an output device. If there is more testing you want me to do lmk

