### PR TITLE
SegmentRange: __str__ get preferred format

### DIFF
--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -255,3 +255,6 @@ class SegmentRange:
   @property
   def selector(self):
     return self.m.group("selector")
+
+  def __str__(self):
+    return f"{self.dongle_id}/{self.timestamp}" + (f"/{self._slice}" if self._slice else "") + (f"/{self.selector}" if self.selector else "")

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -46,6 +46,18 @@ class TestLogReader(unittest.TestCase):
     segs = parse_slice(sr, route)
     self.assertListEqual(list(segs), expected)
 
+  @parameterized.expand([
+    (f"{TEST_ROUTE}", f"{TEST_ROUTE}"),
+    (f"{TEST_ROUTE.replace('/', '|')}", f"{TEST_ROUTE}"),
+    (f"{TEST_ROUTE}--5", f"{TEST_ROUTE}/5"),
+    (f"{TEST_ROUTE}/0/q", f"{TEST_ROUTE}/0/q"),
+    (f"{TEST_ROUTE}/5:6/r", f"{TEST_ROUTE}/5:6/r"),
+    (f"{TEST_ROUTE}/5", f"{TEST_ROUTE}/5"),
+  ])
+  def test_canonical_name(self, identifier, expected):
+    sr = SegmentRange(identifier)
+    self.assertEqual(str(sr), expected)
+
   def test_direct_parsing(self):
     qlog = tempfile.NamedTemporaryFile(mode='wb', delete=False)
 


### PR DESCRIPTION
```__str__``` will get the preferred format for segment ranges (with slashes instead of pipes and --)