### PR TITLE
Nissan: log FW responses on bus 0

### DIFF
--- a/selfdrive/car/nissan/values.py
+++ b/selfdrive/car/nissan/values.py
@@ -59,27 +59,35 @@ NISSAN_VERSION_RESPONSE_KWP = b'\x61\x83'
 NISSAN_RX_OFFSET = 0x20
 
 FW_QUERY_CONFIG = FwQueryConfig(
-  requests=[
+  requests=[request for bus, logging in ((0, True), (1, False)) for request in [
     Request(
       [NISSAN_DIAGNOSTIC_REQUEST_KWP, NISSAN_VERSION_REQUEST_KWP],
       [NISSAN_DIAGNOSTIC_RESPONSE_KWP, NISSAN_VERSION_RESPONSE_KWP],
+      bus=bus,
+      logging=logging,
     ),
     Request(
       [NISSAN_DIAGNOSTIC_REQUEST_KWP, NISSAN_VERSION_REQUEST_KWP],
       [NISSAN_DIAGNOSTIC_RESPONSE_KWP, NISSAN_VERSION_RESPONSE_KWP],
       rx_offset=NISSAN_RX_OFFSET,
+      bus=bus,
+      logging=logging,
     ),
     # Rogue's engine solely responds to this
     Request(
       [NISSAN_DIAGNOSTIC_REQUEST_KWP_2, NISSAN_VERSION_REQUEST_KWP],
       [NISSAN_DIAGNOSTIC_RESPONSE_KWP_2, NISSAN_VERSION_RESPONSE_KWP],
+      bus=bus,
+      logging=logging,
     ),
     Request(
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
       rx_offset=NISSAN_RX_OFFSET,
+      bus=bus,
+      logging=logging,
     ),
-  ],
+  ]],
 )
 
 DBC = {

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -238,7 +238,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   @pytest.mark.timeout(60)
   def test_fw_query_timing(self):
-    total_ref_time = 6.1
+    total_ref_time = 6.5
     brand_ref_times = {
       1: {
         'body': 0.1,
@@ -247,7 +247,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'honda': 0.45,
         'hyundai': 0.65,
         'mazda': 0.2,
-        'nissan': 0.4,
+        'nissan': 0.8,
         'subaru': 0.45,
         'tesla': 0.2,
         'toyota': 1.6,


### PR DESCRIPTION
Before we remove CAN fingerprints for Nissan I want to make sure it can fingerprint without the comma power, which some users are using according to the FP bot.

for: https://github.com/commaai/openpilot/issues/25755#issuecomment-1668749626

fa9224be239005c7|2022-07-15--18-12-02

![image](https://github.com/commaai/openpilot/assets/25857203/3da38977-520e-49f2-a221-cdc489f256cc)
