### PR TITLE
add size to system alt image manifest entry

### DIFF
--- a/system/hardware/tici/agnos.json
+++ b/system/hardware/tici/agnos.json
@@ -70,7 +70,8 @@
     "has_ab": true,
     "alt": {
       "hash": "2fb81e58f4bc6c4e5e71c8e7ac7553f85082c430627d7a5cc54a6bbc82862500",
-      "url": "https://commadist.azureedge.net/agnosupdate/system-skip-chunks-e1952bb363688c0f5c0646e39bcdfb45be25b5e2baed37d1ba7801aa1a3a9c98.img.xz"
+      "url": "https://commadist.azureedge.net/agnosupdate/system-skip-chunks-e1952bb363688c0f5c0646e39bcdfb45be25b5e2baed37d1ba7801aa1a3a9c98.img.xz",
+      "size": 4543090376
     }
   }
 ]


### PR DESCRIPTION
**Description**

To support calculating progress during unpacking of xz images in https://github.com/commaai/flash/pull/29, the system alt image needs a size property defined which I've added here.

**Verification**

No regression necessary