### PR TITLE
filereader should use connection pool for file_exists

### DIFF
--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -1,5 +1,4 @@
 import os
-import requests
 
 from openpilot.tools.lib.url_file import URLFile
 
@@ -13,7 +12,7 @@ def resolve_name(fn):
 def file_exists(fn):
   fn = resolve_name(fn)
   if fn.startswith(("http://", "https://")):
-    return requests.head(fn, allow_redirects=True).status_code == 200
+    return URLFile(fn, debug=debug).get_length_online() != -1
   return os.path.exists(fn)
 
 def FileReader(fn, debug=False):

--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -12,7 +12,7 @@ def resolve_name(fn):
 def file_exists(fn):
   fn = resolve_name(fn)
   if fn.startswith(("http://", "https://")):
-    return URLFile(fn, debug=debug).get_length_online() != -1
+    return URLFile(fn).get_length_online() != -1
   return os.path.exists(fn)
 
 def FileReader(fn, debug=False):


### PR DESCRIPTION
We don't want to make a new TCP connection for every URL that we check if it exists.  This can cause port exhaustion if you are accessing thousands of files over a small time window.