### PR TITLE
Simulator: pin metadrive + use pip version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2213,8 +2213,8 @@ ros = ["zmq"]
 [package.source]
 type = "git"
 url = "https://github.com/metadriverse/metadrive.git"
-reference = "main"
-resolved_reference = "bc162e1b423bd194a58ef2269103f1bcea5f53c7"
+reference = "MetaDrive-0.4.2.2"
+resolved_reference = "8d08034e7cfa6504c1942bb4b5aaeb703d4b204f"
 
 [[package]]
 name = "mouseinfo"
@@ -7791,4 +7791,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "80980e271850e99a5b9005dda4b25a822a4d2b15ba152697c5fb692be4b3bb13"
+content-hash = "655f89fd5a454ec8a22c0223efd3e1f14041e80a60a50ecee9edc6ee8951fd9c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2178,8 +2178,10 @@ version = "0.4.2.2"
 description = "An open-ended driving simulator with infinite scenes"
 optional = false
 python-versions = ">=3.6, <3.12"
-files = []
-develop = false
+files = [
+    {file = "metadrive-simulator-0.4.2.2.tar.gz", hash = "sha256:dcce9f9c73b6055e70480af8543058b95e8c4f68d2595107f3ef36c9be03f6bb"},
+    {file = "metadrive_simulator-0.4.2.2-py3-none-any.whl", hash = "sha256:165ba0b5275313a71090ba0e73d51b7b5e05391b071d3a2114d999ac9287d150"},
+]
 
 [package.dependencies]
 filelock = "*"
@@ -2209,12 +2211,6 @@ yapf = "*"
 cuda = ["PyOpenGL (==3.1.6)", "PyOpenGL-accelerate (==3.1.6)", "cuda-python (==12.0.0)", "glfw", "pyrr (==0.10.3)"]
 gym = ["gym (>=0.19.0,<=0.26.0)"]
 ros = ["zmq"]
-
-[package.source]
-type = "git"
-url = "https://github.com/metadriverse/metadrive.git"
-reference = "MetaDrive-0.4.2.2"
-resolved_reference = "8d08034e7cfa6504c1942bb4b5aaeb703d4b204f"
 
 [[package]]
 name = "mouseinfo"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7791,4 +7791,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "655f89fd5a454ec8a22c0223efd3e1f14041e80a60a50ecee9edc6ee8951fd9c"
+content-hash = "4f771435666b64f677d7dd2b4c9b4ec4bbe6fcbb004d13f19e0e79ae138c92b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ inputs = "*"
 Jinja2 = "*"
 lru-dict = "*"
 matplotlib = "*"
-metadrive-simulator = { git = "https://github.com/metadriverse/metadrive.git", rev ="main", markers = "platform_machine != 'aarch64'" } # no linux/aarch64 wheels for certain dependencies
+metadrive-simulator = { git = "https://github.com/metadriverse/metadrive.git", rev = "MetaDrive-0.4.2.2", markers = "platform_machine != 'aarch64'" } # no linux/aarch64 wheels for certain dependencies
 mpld3 = "*"
 mypy = "*"
 myst-parser = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ inputs = "*"
 Jinja2 = "*"
 lru-dict = "*"
 matplotlib = "*"
-metadrive-simulator = { git = "https://github.com/metadriverse/metadrive.git", rev = "MetaDrive-0.4.2.2", markers = "platform_machine != 'aarch64'" } # no linux/aarch64 wheels for certain dependencies
+metadrive-simulator = { version = "0.4.2.2", markers = "platform_machine != 'aarch64'" } # no linux/aarch64 wheels for certain dependencies
 mpld3 = "*"
 mypy = "*"
 myst-parser = "*"


### PR DESCRIPTION
on main, things break often, so lets just pin it (we were on main because it had a hotfix for the camera stuff we were using, but this is on the release version now)

checked sim engaged with new version:

![image](https://github.com/commaai/openpilot/assets/9648890/80f80f97-abbb-48a2-8c56-9dc307a04b45)
