### PR TITLE
Honda: add logging request for radarless Civic 2022+ camera

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -169,6 +169,14 @@ FW_QUERY_CONFIG = FwQueryConfig(
     ),
 
     # Data collection requests:
+    # Attempt to get the radarless Civic 2022+ camera FW
+    Request(
+      [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.UDS_VERSION_REQUEST],
+      [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.UDS_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.camera],
+      bus=0,
+      logging=True
+    ),
     # Log extra identifiers for current ECUs
     Request(
       [HONDA_VERSION_REQUEST],

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -173,7 +173,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.UDS_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.camera],
+      whitelist_ecus=[Ecu.fwdRadar],
       bus=0,
       logging=True
     ),

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -173,7 +173,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.UDS_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.UDS_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdRadar],
       bus=0,
       logging=True
     ),

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -244,7 +244,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'body': 0.1,
         'chrysler': 0.3,
         'ford': 0.2,
-        'honda': 0.45,
+        'honda': 0.55,
         'hyundai': 0.65,
         'mazda': 0.2,
         'nissan': 0.8,


### PR DESCRIPTION
Camera doesn't respond at all or is spotty for some dongles, with no response in the CAN data:

In this route it responded to tester present fc4d8f4e5f8b353a|2024-01-22--07-19-26:

```
28792596236 rxaddr=416985329, bus=129, 560.49 ms, 0x023e000000000000, b'\x02>\x00\x00\x00\x00\x00\x00', len(can.dat)=8
28792596236 rxaddr=416985329, bus=0, 560.49 ms, 0x023e000000000000, b'\x02>\x00\x00\x00\x00\x00\x00', len(can.dat)=8
28792596236 rxaddr=416985329, bus=2, 560.49 ms, 0x023e000000000000, b'\x02>\x00\x00\x00\x00\x00\x00', len(can.dat)=8
28792596236 rxaddr=416985329, bus=128, 560.49 ms, 0x023e000000000000, b'\x02>\x00\x00\x00\x00\x00\x00', len(can.dat)=8
28792596236 rxaddr=416985329, bus=2, 560.49 ms, 0x023e000000000000, b'\x02>\x00\x00\x00\x00\x00\x00', len(can.dat)=8
28803838528 rxaddr=417001904, bus=0, 571.73 ms, 0x027e005555555555, b'\x02~\x00UUUUU', len(can.dat)=8
28803838528 rxaddr=417001904, bus=2, 571.73 ms, 0x027e005555555555, b'\x02~\x00UUUUU', len(can.dat)=8
28803838528 rxaddr=417001904, bus=1, 571.73 ms, 0x027e005555555555, b'\x02~\x00UUUUU', len(can.dat)=8
```

But not the query later:

```
29777426444 rxaddr=416985329, bus=1, 1545.32 ms, 0x0322f18100000000, b'\x03"\xf1\x81\x00\x00\x00\x00', len(can.dat)=8
29782198684 rxaddr=416985329, bus=129, 1550.09 ms, 0x0322f18100000000, b'\x03"\xf1\x81\x00\x00\x00\x00', len(can.dat)=8
29782198684 rxaddr=416985329, bus=0, 1550.09 ms, 0x0322f18100000000, b'\x03"\xf1\x81\x00\x00\x00\x00', len(can.dat)=8
29782198684 rxaddr=416985329, bus=2, 1550.09 ms, 0x0322f18100000000, b'\x03"\xf1\x81\x00\x00\x00\x00', len(can.dat)=8
29889410507 rxaddr=416985329, bus=1, 1657.31 ms, 0x0322f11200000000, b'\x03"\xf1\x12\x00\x00\x00\x00', len(can.dat)=8
```

Strangely it then responded to one of our logging queries right after (but some routes it doesn't):

```
29893295715 rxaddr=416985329, bus=129, 1661.19 ms, 0x0322f11200000000, b'\x03"\xf1\x12\x00\x00\x00\x00', len(can.dat)=8
29893295715 rxaddr=416985329, bus=0, 1661.19 ms, 0x0322f11200000000, b'\x03"\xf1\x12\x00\x00\x00\x00', len(can.dat)=8
29893295715 rxaddr=416985329, bus=2, 1661.19 ms, 0x0322f11200000000, b'\x03"\xf1\x12\x00\x00\x00\x00', len(can.dat)=8
29911584934 rxaddr=417001904, bus=0, 1679.48 ms, 0x102262f112184542, b'\x10"b\xf1\x12\x18EB', len(can.dat)=8
29911584934 rxaddr=417001904, bus=2, 1679.48 ms, 0x102262f112184542, b'\x10"b\xf1\x12\x18EB', len(can.dat)=8
29911584934 rxaddr=417001904, bus=1, 1679.48 ms, 0x102262f112184542, b'\x10"b\xf1\x12\x18EB', len(can.dat)=8
```