### PR TITLE
docs: Improve CTF docs to avoid a crash

### DIFF
--- a/tools/CTF.md
+++ b/tools/CTF.md
@@ -16,5 +16,6 @@ cd tools/replay
 ./replay '0c7f0c7f0c7f0c7f|2021-10-13--13-00-00' --dcam --ecam
 
 # start the UI in another terminal
-selfdrive/ui/ui
+cd selfdrive/ui
+./ui
 ```


### PR DESCRIPTION
Running ui from the workspace root causes a Segmentation fault due to a resource file not being found using a relative path.