### PR TITLE
Fingerprints: add missing FW versions from users for Toyota, Honda, Chrysler [bot]

### DIFF
--- a/selfdrive/car/honda/fingerprints.py
+++ b/selfdrive/car/honda/fingerprints.py
@@ -156,6 +156,7 @@ FW_VERSIONS = {
       b'36802-TVA-A150\x00\x00',
       b'36802-TVA-A160\x00\x00',
       b'36802-TVA-A170\x00\x00',
+      b'36802-TVA-A180\x00\x00',
       b'36802-TVA-A330\x00\x00',
       b'36802-TVC-A330\x00\x00',
       b'36802-TVE-H070\x00\x00',
@@ -831,6 +832,7 @@ FW_VERSIONS = {
       b'38897-THR-A020\x00\x00',
     ],
     (Ecu.programmedFuelInjection, 0x18da10f1, None): [
+      b'37805-5MR-3250\x00\x00',
       b'37805-5MR-4080\x00\x00',
       b'37805-5MR-4180\x00\x00',
       b'37805-5MR-A240\x00\x00',
@@ -980,6 +982,7 @@ FW_VERSIONS = {
       b'37805-RLV-C530\x00\x00',
       b'37805-RLV-C910\x00\x00',
       b'37805-RLV-F120\x00\x00',
+      b'37805-RLV-L080\x00\x00',
       b'37805-RLV-L090\x00\x00',
       b'37805-RLV-L160\x00\x00',
       b'37805-RLV-L180\x00\x00',
@@ -1102,6 +1105,7 @@ FW_VERSIONS = {
     (Ecu.combinationMeter, 0x18da60f1, None): [
       b'78109-TX4-A210\x00\x00',
       b'78109-TX4-A310\x00\x00',
+      b'78109-TX5-A210\x00\x00',
       b'78109-TX5-A310\x00\x00',
     ],
   },


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 4 dongles (4 platforms) in last 45.0 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                         | Name from VIN 🆚 CarInfo                       | Segments                  | Bad seg tags   | Good seg tags                                          |
|:------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|:--------------------------|:---------------|:-------------------------------------------------------|
| [569e73e7fca0e803](https://useradmin.comma.ai/?onebox=569e73e7fca0e803)<br><sub>ACURA RDX 2018<br>5J8TB3H72........</sub>     | ACURA RDX 2017 🆚<br>Acura RDX 2016-18         | 44 routes, 584 segments   |                | - all lat active: 112<br>- no input all lat active: 25 |
| [23d8d880f7936549](https://useradmin.comma.ai/?onebox=23d8d880f7936549)<br><sub>HONDA ODYSSEY 2018<br>5FNRL6H95........</sub> | HONDA Odyssey 2018 🆚<br>Honda Odyssey 2018-20 | 179 routes, 5608 segments |                | - all lat active: 83<br>- no input all lat active: 68  |
| [4658d860b9f9e969](https://useradmin.comma.ai/?onebox=4658d860b9f9e969)<br><sub>HONDA ACCORD 2018<br>1HGCV1F90........</sub>  | HONDA Accord 2018 🆚<br>Honda Accord 2018-22   | 25 routes, 573 segments   |                | - all lat active: 156<br>- no input all lat active: 75 |
| [2f46ad8f2394b80f](https://useradmin.comma.ai/?onebox=2f46ad8f2394b80f)<br><sub>HONDA PILOT 2017<br>5FNYF6H68........</sub>   | HONDA Pilot 2019 🆚<br>Honda Pilot 2016-22     | 184 routes, 2391 segments |                | - all lat active: 180<br>- no input all lat active: 31 |

Dongles to re-run category: `4658d860b9f9e969 23d8d880f7936549 2f46ad8f2394b80f 569e73e7fca0e803`
</details>

## ⏳️ 23 dongles (18 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                              | Name from VIN 🆚 CarInfo                                             | Segments                  | Bad seg tags   | Good seg tags                                         |
|:-----------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:--------------------------|:---------------|:------------------------------------------------------|
| [a94a569641ca1889](https://useradmin.comma.ai/?onebox=a94a569641ca1889)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHT5........</sub>        | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 27 routes, 494 segments   |                | - all lat active: 35<br>- no input all lat active: 22 |
| [c06049eaf49b65d1](https://useradmin.comma.ai/?onebox=c06049eaf49b65d1)<br><sub>TOYOTA HIGHLANDER 2017<br>5TDZARFH3........</sub>  | TOYOTA Highlander 2018 🆚<br>Toyota Highlander 2017-19               | 57 routes, 1529 segments  |                | - all lat active: 30<br>- no input all lat active: 25 |
| [de8a11185df288e5](https://useradmin.comma.ai/?onebox=de8a11185df288e5)<br><sub>RAM 1500 5TH GEN<br>1C6SRFU96........</sub>        | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 103 routes, 935 segments  |                | - all lat active: 58<br>- no input all lat active: 15 |
| [030e7d18f7c4ea9d](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHTX........</sub>        | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                 | 126 routes, 2353 segments |                | - all lat active: 1                                   |
| [e8d0444db1e4ad8b](https://useradmin.comma.ai/?onebox=e8d0444db1e4ad8b)<br><sub>TOYOTA HIGHLANDER 2020<br>5TDEBRCHX........</sub>  | TOYOTA Highlander Hybrid 2021 🆚<br>Toyota Highlander Hybrid 2020-23 | 29 routes, 807 segments   |                | - all lat active: 4                                   |
| [3ee12c8d081d7949](https://useradmin.comma.ai/?onebox=3ee12c8d081d7949)<br><sub>LEXUS RX 2016<br>JTJDGKCA5........</sub>           | LEXUS RX Hybrid 2018 🆚<br>Lexus RX Hybrid 2017-19                   | 36 routes, 436 segments   |                | - all lat active: 43<br>- no input all lat active: 27 |
| [a6de4da35307d7b8](https://useradmin.comma.ai/?onebox=a6de4da35307d7b8)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHT4........</sub>        | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 45 routes, 661 segments   |                | - all lat active: 21<br>- no input all lat active: 1  |
| [45a7520f43e36e38](https://useradmin.comma.ai/?onebox=45a7520f43e36e38)<br><sub>ACURA RDX 2020<br>5J8TC2H73........</sub>          | ACURA RDX 2021 🆚<br>Acura RDX 2019-22                               | 16 routes, 449 segments   |                | - all lat active: 44<br>- no input all lat active: 19 |
| [2d31d2cc29847b1f](https://useradmin.comma.ai/?onebox=2d31d2cc29847b1f)<br><sub>TOYOTA RAV4 HYBRID 2017<br>JTMDJREV2........</sub> | None 🆚<br>None                                                      | 6 routes, 61 segments     |                | - all lat active: 0                                   |
| [c4e9230919b74f75](https://useradmin.comma.ai/?onebox=c4e9230919b74f75)<br><sub>TOYOTA CAMRY 2021<br>4T1F31AK1........</sub>       | TOYOTA Camry Hybrid 2022 🆚<br>Toyota Camry Hybrid 2021-24           | 3 routes, 3 segments      |                | - all lat active: 0                                   |
| [1d0a133611de7ec9](https://useradmin.comma.ai/?onebox=1d0a133611de7ec9)<br><sub>TOYOTA PRIUS 2017<br>000000000........</sub>       | None 🆚<br>None                                                      | 3 routes, 29 segments     |                | - all lat active: 0                                   |
| [c27e776f2a552b38](https://useradmin.comma.ai/?onebox=c27e776f2a552b38)<br><sub>TOYOTA PRIUS TSS2 2021<br>JTDKAMFP1........</sub>  | TOYOTA Prius Prime 2022 🆚<br>Toyota Prius Prime 2021-22             | 1 routes, 1 segments      |                | - all lat active: 0                                   |
| [c04a3b5508dc7bc3](https://useradmin.comma.ai/?onebox=c04a3b5508dc7bc3)<br><sub>HONDA ACCORD 2018<br>1HGCV2F90........</sub>       | HONDA Accord 2021 🆚<br>Honda Accord 2018-22                         | 58 routes, 756 segments   |                | - all lat active: 11<br>- no input all lat active: 5  |
| [099a22613f8cff48](https://useradmin.comma.ai/?onebox=099a22613f8cff48)<br><sub>TOYOTA RAV4 2023<br>2T3S1RFV9........</sub>        | TOYOTA RAV4 2023 🆚<br>Toyota RAV4 2023-24                           | 3 routes, 32 segments     |                | - all lat active: 0                                   |
| [7d1b9fb1892e3415](https://useradmin.comma.ai/?onebox=7d1b9fb1892e3415)<br><sub>HONDA ODYSSEY 2018<br>5FNRL6H92........</sub>      | HONDA Odyssey 2018 🆚<br>Honda Odyssey 2018-20                       | 4 routes, 75 segments     |                | - all lat active: 1                                   |
| [0f01a384405811ca](https://useradmin.comma.ai/?onebox=0f01a384405811ca)<br><sub>LEXUS ES 2018<br>58ABK1GG2........</sub>           | LEXUS ES 2017 🆚<br>Lexus ES 2017-18                                 | 5 routes, 76 segments     |                | - all lat active: 32<br>- no input all lat active: 15 |
| [22dbdf2ca2bce921](https://useradmin.comma.ai/?onebox=22dbdf2ca2bce921)<br><sub>HONDA PILOT 2017<br>5FNYF6H5X........</sub>        | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                           | 272 routes, 2416 segments |                | - all lat active: 8<br>- no input all lat active: 1   |
| [60649ef97e4c53de](https://useradmin.comma.ai/?onebox=60649ef97e4c53de)<br><sub>HONDA CIVIC 2016<br>2HGFC3B96........</sub>        | HONDA Civic 2017 🆚<br>Honda Civic 2016-18                           | 17 routes, 233 segments   |                | - all lat active: 10<br>- no input all lat active: 2  |
| [3a02fd61e8d654b9](https://useradmin.comma.ai/?onebox=3a02fd61e8d654b9)<br><sub>HONDA ODYSSEY 2018<br>5FNRL6H89........</sub>      | HONDA Odyssey 2020 🆚<br>Honda Odyssey 2018-20                       | 14 routes, 266 segments   |                | - all lat active: 0                                   |
| [b53e882f1a5c30ae](https://useradmin.comma.ai/?onebox=b53e882f1a5c30ae)<br><sub>LEXUS IS 2018<br>JTHBA1D23........</sub>           | LEXUS IS 2018 🆚<br>Lexus IS 2017-19                                 | 19 routes, 299 segments   |                | - all lat active: 57<br>- no input all lat active: 34 |
| [ed2d431bb7d5b112](https://useradmin.comma.ai/?onebox=ed2d431bb7d5b112)<br><sub>HONDA CR-V 2017<br>5J6RW2H87........</sub>         | HONDA CR-V 2018 🆚<br>Honda CR-V 2017-22                             | 4 routes, 47 segments     |                | - all lat active: 1<br>- no input all lat active: 1   |
| [e1fcfe631f560c6a](https://useradmin.comma.ai/?onebox=e1fcfe631f560c6a)<br><sub>LEXUS RX 2016<br>2T2ZZMCA2........</sub>           | LEXUS RX 2016 🆚<br>Lexus RX 2016                                    | 27 routes, 517 segments   |                | - all lat active: 17<br>- no input all lat active: 13 |
| [06a5e5d1657e6282](https://useradmin.comma.ai/?onebox=06a5e5d1657e6282)<br><sub>LEXUS IS 2023<br>JTHGZ1E27........</sub>           | LEXUS IS 2023 🆚<br>Lexus IS 2022-23                                 | 2 routes, 32 segments     |                | - all lat active: 25<br>- no input all lat active: 14 |

Dongles to re-run category: `1d0a133611de7ec9 030e7d18f7c4ea9d 2d31d2cc29847b1f c27e776f2a552b38 a94a569641ca1889 45a7520f43e36e38 c04a3b5508dc7bc3 a6de4da35307d7b8 3a02fd61e8d654b9 e8d0444db1e4ad8b b53e882f1a5c30ae c06049eaf49b65d1 de8a11185df288e5 ed2d431bb7d5b112 e1fcfe631f560c6a 06a5e5d1657e6282 099a22613f8cff48 7d1b9fb1892e3415 0f01a384405811ca 22dbdf2ca2bce921 3ee12c8d081d7949 c4e9230919b74f75 60649ef97e4c53de`
</details>

## ⚠️ 11 dongles (5 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                             | Name from VIN 🆚 CarInfo                                                                          | Segments                  | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Good seg tags                                           |
|:----------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|:--------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|
| [7976728ccd58249f](https://useradmin.comma.ai/?onebox=7976728ccd58249f)<br><sub>ACURA RDX 2020<br>5J8TC2H61........</sub>         | ACURA RDX 2019 🆚<br>Acura RDX 2019-22                                                            | 47 routes, 1081 segments  | - [missing ECU FW: 17](https://useradmin.comma.ai/?onebox=7976728ccd58249f%7C2024-01-07--21-00-29)<br>- [spotty FW: 17](https://useradmin.comma.ai/?onebox=7976728ccd58249f%7C2024-01-07--21-00-29)                                                                                                                                                                                                                                                                                           | - all lat active: 283<br>- no input all lat active: 159 |
| [698b51bf70bd1fa8](https://useradmin.comma.ai/?onebox=698b51bf70bd1fa8)<br><sub>HONDA CIVIC 2022<br>19XFL1H80........</sub>       | HONDA Civic 2022 🆚<br>Honda Civic 2022-23                                                        | 133 routes, 2878 segments | - [missing ECU FW: 1963](https://useradmin.comma.ai/?onebox=698b51bf70bd1fa8%7C2024-01-25--16-41-26)<br>- [spotty FW: 1963](https://useradmin.comma.ai/?onebox=698b51bf70bd1fa8%7C2024-01-25--16-41-26)                                                                                                                                                                                                                                                                                       | - all lat active: 2<br>- no input all lat active: 1     |
| [61c374c8e5e59db3](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3)<br><sub>HONDA CIVIC 2022<br>19XFL2H89........</sub>       | HONDA Civic 2023 🆚<br>Honda Civic 2022-23                                                        | 28 routes, 666 segments   | - [missing ECU FW: 529](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-01-15--15-29-25)<br>- [spotty FW: 137](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-01-21--16-40-33)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3)                                                                                                                                                                                                       | - all lat active: 42<br>- no input all lat active: 26   |
| [fe90f3d7403f2411](https://useradmin.comma.ai/?onebox=fe90f3d7403f2411)<br><sub>HONDA CR-V HYBRID 2019<br>7FART6H97........</sub> | HONDA CR-V Hybrid 2021 🆚<br>Honda CR-V Hybrid 2017-19<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 73 routes, 1346 segments  | - [CAN invalid: 129](https://useradmin.comma.ai/?onebox=fe90f3d7403f2411%7C2024-01-10--16-14-56)                                                                                                                                                                                                                                                                                                                                                                                              | - all lat active: 416<br>- no input all lat active: 194 |
| [1a84d15fb9cec604](https://useradmin.comma.ai/?onebox=1a84d15fb9cec604)<br><sub>HONDA CIVIC 2022<br>2HGFE2F55........</sub>       | HONDA Civic 2024 🆚<br>Honda Civic 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>             | 74 routes, 1564 segments  | - [missing ECU FW: 1010](https://useradmin.comma.ai/?onebox=1a84d15fb9cec604%7C2024-01-11--11-05-17)<br>- [spotty FW: 1010](https://useradmin.comma.ai/?onebox=1a84d15fb9cec604%7C2024-01-11--11-05-17)                                                                                                                                                                                                                                                                                       | - all lat active: 284<br>- no input all lat active: 159 |
| [fc4d8f4e5f8b353a](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a)<br><sub>HONDA CIVIC 2022<br>19XFL1H88........</sub>       | HONDA Civic 2023 🆚<br>Honda Civic 2022-23                                                        | 157 routes, 2644 segments | - [missing ECU FW: 747](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2023-12-24--09-38-45)<br>- [spotty FW: 747](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2023-12-24--09-38-45)                                                                                                                                                                                                                                                                                         | - all lat active: 377<br>- no input all lat active: 261 |
| [6ac3c7b8c9981640](https://useradmin.comma.ai/?onebox=6ac3c7b8c9981640)<br><sub>HONDA CIVIC 2022<br>19XFL1H8X........</sub>       | HONDA Civic 2023 🆚<br>Honda Civic 2022-23                                                        | 11 routes, 62 segments    | - [missing ECU FW: 26](https://useradmin.comma.ai/?onebox=6ac3c7b8c9981640%7C2023-12-28--16-43-39)<br>- [spotty FW: 26](https://useradmin.comma.ai/?onebox=6ac3c7b8c9981640%7C2023-12-28--16-43-39)                                                                                                                                                                                                                                                                                           |                                                         |
| [30f476405b31e063](https://useradmin.comma.ai/?onebox=30f476405b31e063)<br><sub>TOYOTA HIGHLANDER 2017<br>5TDDGRFH0........</sub> | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19                              | 11 routes, 39 segments    | - [missing ECU FW: 39](https://useradmin.comma.ai/?onebox=30f476405b31e063%7C2023-12-27--13-29-38)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=30f476405b31e063)                                                                                                                                                                                                                                                                                                          |                                                         |
| [cee1f89fd5ca2190](https://useradmin.comma.ai/?onebox=cee1f89fd5ca2190)<br><sub>HONDA PILOT 2017<br>5FNYF5H99........</sub>       | HONDA Pilot 2016 🆚<br>Honda Pilot 2016-22                                                        | 67 routes, 1695 segments  | - [missing ECU FW: 32](https://useradmin.comma.ai/?onebox=cee1f89fd5ca2190%7C2024-01-07--10-41-22)<br>- [spotty FW: 1663](https://useradmin.comma.ai/?onebox=cee1f89fd5ca2190%7C2023-12-16--19-34-45)<br>- [CAN invalid: 16](https://useradmin.comma.ai/?onebox=cee1f89fd5ca2190%7C2024-01-07--10-41-22)<br>- [car faulted: 16](https://useradmin.comma.ai/?onebox=cee1f89fd5ca2190%7C2024-01-07--10-41-22)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=cee1f89fd5ca2190) | - all lat active: 979<br>- no input all lat active: 702 |
| [6e12554fbd20d6d1](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1)<br><sub>HONDA CIVIC 2022<br>2HGFE1F98........</sub>       | HONDA Civic 2022 🆚<br>Honda Civic 2022-23                                                        | 284 routes, 4174 segments | - [missing ECU FW: 3835](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1%7C2024-01-06--11-45-35)<br>- [spotty FW: 339](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1%7C2023-12-26--12-56-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1)                                                                                                                                                                                                      | - all lat active: 224<br>- no input all lat active: 150 |
| [9bac7575fac62395](https://useradmin.comma.ai/?onebox=9bac7575fac62395)<br><sub>HONDA PILOT 2017<br>5FNYF6H93........</sub>       | HONDA Pilot 2018 🆚<br>Honda Pilot 2016-22                                                        | 140 routes, 2571 segments | - [missing ECU FW: 461](https://useradmin.comma.ai/?onebox=9bac7575fac62395%7C2024-01-22--11-45-14)<br>- [spotty FW: 461](https://useradmin.comma.ai/?onebox=9bac7575fac62395%7C2024-01-22--11-45-14)                                                                                                                                                                                                                                                                                         | - all lat active: 909<br>- no input all lat active: 98  |

Dongles to re-run category: `6ac3c7b8c9981640 cee1f89fd5ca2190 61c374c8e5e59db3 30f476405b31e063 6e12554fbd20d6d1 7976728ccd58249f fc4d8f4e5f8b353a 1a84d15fb9cec604 9bac7575fac62395 fe90f3d7403f2411 698b51bf70bd1fa8`
</details>