### PR TITLE
Generate debugging launch.json for all openpilot processes

### DIFF
--- a/tools/vscode_debug/env_prompt.py
+++ b/tools/vscode_debug/env_prompt.py
@@ -15,9 +15,7 @@ def get_existing_env_vars(env_file_path):
   return existing_env_vars
 
 def main():
-  script_dir = os.path.dirname(__file__)
-  env_file_path = os.path.join(script_dir, ".env.temp")
-  existing_env_vars = get_existing_env_vars(env_file_path)
+  existing_env_vars = get_existing_env_vars(".env")
   # Set up readline history with existing environment variables
   for var in existing_env_vars:
       readline.add_history(f"{var}={existing_env_vars[var]}")
@@ -47,7 +45,7 @@ def main():
     env_value = input(f"Enter the value for {env_name}: ")
     existing_env_vars[env_name] = env_value
 
-  with open(env_file_path, "w", encoding='utf_8') as file:
+  with open(".env", "w", encoding='utf_8') as file:
     for name, value in existing_env_vars.items():
       file.write(f"{name}={value}\n")
 

--- a/tools/vscode_debug/env_prompt.py
+++ b/tools/vscode_debug/env_prompt.py
@@ -5,7 +5,7 @@ def get_existing_env_vars(env_file_path):
   existing_env_vars = {}
   if os.path.exists(env_file_path):
     with open(env_file_path, "r", encoding='utf_8') as file:
-        print("Existing debug enviroment variables:")
+        print("Existing debug environment variables:")
         for line in file:
           line = line.strip()
           if line:

--- a/tools/vscode_debug/env_prompt.py
+++ b/tools/vscode_debug/env_prompt.py
@@ -1,0 +1,55 @@
+import os
+import readline
+
+def get_existing_env_vars(env_file_path):
+  existing_env_vars = {}
+  if os.path.exists(env_file_path):
+    with open(env_file_path, "r", encoding='utf_8') as file:
+        print("Existing debug enviroment variables:")
+        for line in file:
+          line = line.strip()
+          if line:
+            key, value = line.split('=', 1) if "=" in line else [line, ""]
+            existing_env_vars[key] = value
+            print(line)
+  return existing_env_vars
+
+def main():
+  script_dir = os.path.dirname(__file__)
+  env_file_path = os.path.join(script_dir, ".env.temp")
+  existing_env_vars = get_existing_env_vars(env_file_path)
+  # Set up readline history with existing environment variables
+  for var in existing_env_vars:
+      readline.add_history(f"{var}={existing_env_vars[var]}")
+
+  while True:
+    env_name = input("Enter the environment variable name to add, modify or delete it. You can also assign it now with VAR=<val> or press enter to skip: ")
+    if not env_name:
+      break
+    if "=" in env_name:
+      key, value = env_name.split('=', 1)
+      existing_env_vars[key] = value
+      continue
+
+    if env_name in existing_env_vars:
+      action = input(f"Reuse(default), Modify, or Delete the value for {env_name} ({existing_env_vars[env_name]})? [r/m/d]: ")
+      if action.lower() in ['', 'r', 'reuse']:
+        continue
+      elif action.lower() in ['d', 'delete']:
+        del existing_env_vars[env_name]
+        continue
+      elif action.lower() in ['m', 'modify']:
+        pass
+      else:
+        print("Invalid input")
+        continue
+
+    env_value = input(f"Enter the value for {env_name}: ")
+    existing_env_vars[env_name] = env_value
+
+  with open(env_file_path, "w", encoding='utf_8') as file:
+    for name, value in existing_env_vars.items():
+      file.write(f"{name}={value}\n")
+
+if __name__ == "__main__":
+  main()

--- a/tools/vscode_debug/generate_vscode_debug_launch.py
+++ b/tools/vscode_debug/generate_vscode_debug_launch.py
@@ -50,7 +50,7 @@ def create_config(proc):
       "cwd": f"${{workspaceFolder}}/{path}",
       "environment": [],
       "preLaunchTask": "prompt-for-env",
-      "envFile": "${workspaceFolder}/tools/vscode_debug/.env.temp",
+      "envFile": "${workspaceFolder}/.env",
       "externalConsole": False,
       "MIMode": "gdb",
       "setupCommands": [
@@ -70,7 +70,7 @@ def create_config(proc):
       "args": [f"${{input:{input_id}}}"],
       "env": {},
       "preLaunchTask": "prompt-for-env",
-      "envFile": "${workspaceFolder}/tools/vscode_debug/.env.temp",
+      "envFile": "${workspaceFolder}/.env",
       "justMyCode" : False
     }
 

--- a/tools/vscode_debug/generate_vscode_debug_launch.py
+++ b/tools/vscode_debug/generate_vscode_debug_launch.py
@@ -1,0 +1,132 @@
+import json
+import os
+
+from openpilot.selfdrive.manager.process_config import procs, PythonProcess, NativeProcess, DaemonProcess
+
+default_args = {
+  "process": ("arg1 arg2 --arg3"),
+}
+
+def next_backup_name(base_path, extension=".json"):
+  """Finds the next available backup file name."""
+  counter = 0
+  while True:
+    counter += 1
+    new_name = f"{base_path}_old_{counter}{extension}"
+    if not os.path.exists(new_name):
+      return new_name
+
+def write_with_backup(file_path, content, extension=".json"):
+  """
+  Writes content to a file, backing up the old file if it exists.
+  :param file_path: Path to the file to write
+  :param content: Content to write to the file
+  :param extension: Extension of the file (used for backup)
+  """
+  # Backs up the existing file by renaming it
+  if os.path.exists(file_path):
+    backup_path = next_backup_name(os.path.splitext(file_path)[0], extension)
+    os.rename(file_path, backup_path)
+    print(f"Renamed existing {os.path.basename(file_path)} to {os.path.basename(backup_path)}")
+  with open(file_path, 'w', encoding='utf_8') as file:
+    if extension == ".json":
+      json.dump(content, file, indent=4)
+    else:
+      file.write(content)
+    print(f"Wrote to {file_path}")
+
+def create_config(proc):
+  input_id = default_args.get(proc.name, "argInput")
+  if type(proc) == NativeProcess:
+    path = proc.cwd
+    executable = proc.cmdline[0].strip('./')
+    return {
+      "name": f"(gdb) {proc.name} Launch",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": f"${{workspaceFolder}}/{path}/{executable}",
+      "args": [f"${{input:{input_id}}}"],
+      "stopAtEntry": False,
+      "cwd": f"${{workspaceFolder}}/{path}",
+      "environment": [],
+      "preLaunchTask": "prompt-for-env",
+      "envFile": "${workspaceFolder}/tools/vscode_debug/.env.temp",
+      "externalConsole": False,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {"description": "Enable pretty-printing for gdb", "text": "-enable-pretty-printing", "ignoreFailures": True},
+        {"description": "Set Disassembly Flavor to Intel", "text": "-gdb-set disassembly-flavor intel", "ignoreFailures": True},
+        {"description": "ignore SIGUSR2 signal", "text": "handle SIGUSR2 nostop noprint pass"}
+      ]
+    }
+  elif isinstance(proc, (PythonProcess, DaemonProcess)):
+    path: str = proc.module
+    program_path = path.replace('.', '/')
+    return {
+      "name": f"Python: {proc.name}",
+      "type": "python",
+      "request": "launch",
+      "program": f"${{workspaceFolder}}/{program_path}.py",
+      "args": [f"${{input:{input_id}}}"],
+      "env": {},
+      "preLaunchTask": "prompt-for-env",
+      "envFile": "${workspaceFolder}/tools/vscode_debug/.env.temp",
+      "justMyCode" : False
+    }
+
+def generate_tasks_json():
+  tasks_content = {
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "prompt-for-env",
+        "type": "shell",
+        "command": "python",
+        "args": [
+          "${workspaceFolder}/tools/vscode_debug/env_prompt.py"
+        ],
+        "presentation": {
+          "echo": True,
+          "reveal": "always",
+          "focus": True,
+          "panel": "shared",
+          "showReuseMessage": False,
+          "clear": False
+        }
+      }
+    ]
+  }
+  tasks_path = '.vscode/tasks.json'
+  write_with_backup(tasks_path, tasks_content)
+
+def generate_launch_json():
+  inputs = [
+    {
+      "id": proc_name,
+      "type": "promptString",
+      "description": f"Enter the arguments for {proc_name}:",
+      "default": args
+    }
+    for proc_name, args in default_args.items()
+  ]
+
+  # Add a generic input for processes without specific defaults
+  inputs.append({
+    "id": "argInput",
+    "type": "promptString",
+    "description": "Enter the arguments for the script:",
+    "default": ""
+  })
+
+  launch_json = {
+    "version": "0.2.0",
+    "configurations": [create_config(proc) for proc in procs],
+    "inputs": inputs
+  }
+
+  launch_json_path = ".vscode/launch.json"
+  write_with_backup(launch_json_path, launch_json)
+
+if __name__ == "__main__":
+  generate_launch_json()
+  generate_tasks_json()


### PR DESCRIPTION
Run `tools/vscode_debug/generate_vscode_debug_launch.py` to automatically populate the launch.json file with all the openpilot processes. It also supports default arguments for debugging and environment variables.
Generating does not delete your existing launch.json, it will rename it.

![image](https://github.com/commaai/openpilot/assets/83676301/976bb68b-bda0-44c0-8df9-dda019023805)
![image](https://github.com/commaai/openpilot/assets/83676301/c8009385-cd44-4d71-bca1-d5c71ae9c642)
![image](https://github.com/commaai/openpilot/assets/83676301/83d80c69-b251-458f-bbe9-8aabbee6f495)
