### PR TITLE
ui: Make ui independent of launch path

### DIFF
--- a/selfdrive/ui/main.cc
+++ b/selfdrive/ui/main.cc
@@ -1,4 +1,6 @@
 #include <sys/resource.h>
+#include <unistd.h>
+#include <libgen.h>
 
 #include <QApplication>
 #include <QTranslator>
@@ -10,6 +12,18 @@
 
 int main(int argc, char *argv[]) {
   setpriority(PRIO_PROCESS, 0, -20);
+
+  // Set working directory so asset paths are valid independent of launch path
+  char path[PATH_MAX];
+  memset(path, 0, sizeof(path));
+  if (readlink("/proc/self/exe", path, sizeof(path)) == -1) {
+    perror("readlink failed");
+    return EXIT_FAILURE;
+  }
+  if (chdir(dirname(path)) == -1) {
+    perror("chdir failed");
+    return EXIT_FAILURE;
+  }
 
   qInstallMessageHandler(swagLogMessageHandler);
   initApp(argc, argv);


### PR DESCRIPTION
**Description**

Prior to this change using the wrong launch path would result in crashes since asset paths can't be found.

**Verification**

Ran './selfdrive/ui/ui', no crash, UI comes up.
Ran 'cd ./selfdrive/ui && ./ui', no crash UI comes up.