### PR TITLE
CI: increase notebook cache build timeout

### DIFF
--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -101,7 +101,7 @@ jobs:
         submodules: true
     - uses: ./.github/workflows/setup-with-retry
     - name: Build openpilot
-      timeout-minutes: 5
+      timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 10 || 30) }} # allow more time when we missed the scons cache
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Test notebooks
       timeout-minutes: 2


### PR DESCRIPTION
10 minutes is allowed everywhere else, more if cache miss

https://github.com/commaai/openpilot/actions/runs/7695697130/job/20984210413?pr=31207