### PR TITLE
LogReader: add tqdm back to run_across_segments

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import re
 import sys
+import tqdm
 import urllib.parse
 import warnings
 
@@ -259,7 +260,8 @@ class LogReader:
   def run_across_segments(self, num_processes, func):
     with multiprocessing.Pool(num_processes) as pool:
       ret = []
-      for p in pool.map(partial(self._run_on_segment, func), range(len(self.logreader_identifiers))):
+      num_segs = len(self.logreader_identifiers)
+      for p in tqdm.tqdm(pool.imap(partial(self._run_on_segment, func), range(num_segs)), total=num_segs):
         ret.extend(p)
       return ret
 


### PR DESCRIPTION
for PJ and other tools that require long preprocessing first

![image](https://github.com/commaai/openpilot/assets/9648890/949e3460-d17f-43ee-a692-56e41679300a)
