### PR TITLE
Subaru: eps is non-essential for gen2 cars

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -180,9 +180,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
       obd_multiplexing=False,
     ),
   ],
-  # We don't get the EPS from non-obd queries on gen2 cars
+  # We don't get the EPS from non-OBD queries on GEN2 cars. Note that we still attempt to match when it exists
   non_essential_ecus={
-    Ecu.eps: [c.value for c in GLOBAL_GEN2]
+    Ecu.eps: list(GLOBAL_GEN2),
   }
 )
 

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -180,6 +180,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       obd_multiplexing=False,
     ),
   ],
+  # We don't get the EPS from non-obd queries on gen2 cars
   non_essential_ecus={
     Ecu.eps: [c.value for c in GLOBAL_GEN2]
   }

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -137,6 +137,15 @@ CAR_INFO: Dict[str, Union[SubaruCarInfo, List[SubaruCarInfo]]] = {
   CAR.ASCENT_2023: SubaruCarInfo("Subaru Ascent 2023", "All", car_parts=CarParts.common([CarHarness.subaru_d])),
 }
 
+LKAS_ANGLE = {CAR.FORESTER_2022, CAR.OUTBACK_2023, CAR.ASCENT_2023}
+GLOBAL_GEN2 = {CAR.OUTBACK, CAR.LEGACY, CAR.OUTBACK_2023, CAR.ASCENT_2023}
+PREGLOBAL_CARS = {CAR.FORESTER_PREGLOBAL, CAR.LEGACY_PREGLOBAL, CAR.OUTBACK_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018}
+HYBRID_CARS = {CAR.CROSSTREK_HYBRID, CAR.FORESTER_HYBRID}
+
+# Cars that temporarily fault when steering angle rate is greater than some threshold.
+# Appears to be all torque-based cars produced around 2019 - present
+STEER_RATE_LIMITED = GLOBAL_GEN2 | {CAR.IMPREZA_2020, CAR.FORESTER}
+
 SUBARU_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
   p16(uds.DATA_IDENTIFIER_TYPE.APPLICATION_DATA_IDENTIFICATION)
 SUBARU_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
@@ -171,6 +180,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
       obd_multiplexing=False,
     ),
   ],
+  non_essential_ecus={
+    Ecu.eps: [c.value for c in GLOBAL_GEN2]
+  }
 )
 
 DBC = {
@@ -190,12 +202,3 @@ DBC = {
   CAR.OUTBACK_PREGLOBAL: dbc_dict('subaru_outback_2015_generated', None),
   CAR.OUTBACK_PREGLOBAL_2018: dbc_dict('subaru_outback_2019_generated', None),
 }
-
-LKAS_ANGLE = {CAR.FORESTER_2022, CAR.OUTBACK_2023, CAR.ASCENT_2023}
-GLOBAL_GEN2 = {CAR.OUTBACK, CAR.LEGACY, CAR.OUTBACK_2023, CAR.ASCENT_2023}
-PREGLOBAL_CARS = {CAR.FORESTER_PREGLOBAL, CAR.LEGACY_PREGLOBAL, CAR.OUTBACK_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018}
-HYBRID_CARS = {CAR.CROSSTREK_HYBRID, CAR.FORESTER_HYBRID}
-
-# Cars that temporarily fault when steering angle rate is greater than some threshold.
-# Appears to be all torque-based cars produced around 2019 - present
-STEER_RATE_LIMITED = GLOBAL_GEN2 | {CAR.IMPREZA_2020, CAR.FORESTER}


### PR DESCRIPTION
tried a few things to get eps at the camera without success, we do get some other interesting ecus though

assist monitor is the little lights that show up on the dash to show when a lead car is found and LDW.
alterative address for eyesight at ```0x737```
two radar modules

```
*** Results for address 0x733 ***


0xF182 APPLICATION_DATA_IDENTIFICATION: b'\x00\x00\x00'
0xF189 VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER: b'187A020000'
0xF18E VEHICLE_MANUFACTURER_KIT_ASSEMBLY_PART_NUMBER: b'85301AN00A'
0xF197 SYSTEM_NAME_OR_ENGINE_TYPE: b'EyeSight Assist Monitor         '


*** Results for address 0x737 ***


0xF182 APPLICATION_DATA_IDENTIFICATION: b'\x00\x00eJ\x00\x1f@ \x19\x00'
0xF186 ACTIVE_DIAGNOSTIC_SESSION: b'\x01'
0xF189 VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER: b'0000000000000'
0xF18E VEHICLE_MANUFACTURER_KIT_ASSEMBLY_PART_NUMBER: b'0000000000'
0xF197 SYSTEM_NAME_OR_ENGINE_TYPE: b'EyeSight System                 '
0xF198 REPAIR_SHOP_CODE_OR_TESTER_SERIAL_NUMBER: b'!\x853F'


*** Results for address 0x742 ***


0xF182 APPLICATION_DATA_IDENTIFICATION: b'\xe1\x00\x00'
0xF189 VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER: b'040000\x00\x00\x00\x00'
0xF18E VEHICLE_MANUFACTURER_KIT_ASSEMBLY_PART_NUMBER: b'87611AN00B'
0xF197 SYSTEM_NAME_OR_ENGINE_TYPE: b'RADAR ASSY B&S LH               '


*** Results for address 0x743 ***


0xF182 APPLICATION_DATA_IDENTIFICATION: b'\xe1\x10\x00'
0xF189 VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER: b'040000\x00\x00\x00\x00'
0xF18E VEHICLE_MANUFACTURER_KIT_ASSEMBLY_PART_NUMBER: b'87611AN00B'
0xF197 SYSTEM_NAME_OR_ENGINE_TYPE: b'RADAR ASSY B&S RH               '


*** Results for address 0x787 ***


0xF182 APPLICATION_DATA_IDENTIFICATION: b'\x00\x00eJ\x00\x1f@ \x19\x00'
0xF186 ACTIVE_DIAGNOSTIC_SESSION: b'\x03'
0xF189 VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER: b'0000000000000'
0xF18E VEHICLE_MANUFACTURER_KIT_ASSEMBLY_PART_NUMBER: b'0000000000'
0xF197 SYSTEM_NAME_OR_ENGINE_TYPE: b'EyeSight System                 '
0xF198 REPAIR_SHOP_CODE_OR_TESTER_SERIAL_NUMBER: b'!\x853F'
```