### PR TITLE
LogReader: add ```.filter```

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -275,9 +275,11 @@ are uploaded or auto fallback to qlogs with '/a' selector at the end of the rout
   def from_bytes(dat):
     return _LogFileReader("", dat=dat)
 
+  def filter(self, msg_type: str):
+    return (getattr(m, m.which()) for m in filter(lambda m: m.which() == msg_type, self))
+
   def first(self, msg_type: str):
-    m = next(filter(lambda m: m.which() == msg_type, self), None)
-    return None if m is None else getattr(m, msg_type)
+    return next(self.filter(msg_type), None)
 
 
 if __name__ == "__main__":

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -118,6 +118,12 @@ class TestLogReader(unittest.TestCase):
 
     self.assertEqual(qlog_len1, qlog_len2)
 
+  @pytest.mark.slow
+  def test_helpers(self):
+    lr = LogReader(f"{TEST_ROUTE}/0/q")
+    self.assertEqual(lr.first("carParams").carFingerprint, "SUBARU OUTBACK 6TH GEN")
+    self.assertTrue(0 < len(list(lr.filter("carParams"))) < len(list(lr)))
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
replaces a very common use case of logreader

```
can_msgs = []
for m in lr:
  if m.which() == "can":
    can_msgs.append(m.can)
```

for

```
can_msgs = lr.filter("can")
```