### PR TITLE
GM camera ACC: get VIN from camera

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -144,7 +144,7 @@ def fingerprint(logcan, sendcan, num_pandas):
       # enable OBD multiplexing for Vin query, also allows time for sendcan subscriber to connect
       set_obd_multiplexing(params, True)
       # Vin query only reliably works through OBDII
-      vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan, (0, 1))
+      vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan)
       ecu_rx_addrs = get_present_ecus(logcan, sendcan, num_pandas=num_pandas)
       car_fw = get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs, num_pandas=num_pandas)
       cached = False

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -144,7 +144,7 @@ def fingerprint(logcan, sendcan, num_pandas):
       # enable OBD multiplexing for Vin query, also allows time for sendcan subscriber to connect
       set_obd_multiplexing(params, True)
       # Vin query only reliably works through OBDII
-      vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan)
+      vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan, (0, 1))
       ecu_rx_addrs = get_present_ecus(logcan, sendcan, num_pandas=num_pandas)
       car_fw = get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs, num_pandas=num_pandas)
       cached = False

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -14,6 +14,9 @@ EcuAddrSubAddr = Tuple[int, int, Optional[int]]
 LiveFwVersions = Dict[AddrType, Set[bytes]]
 OfflineFwVersions = Dict[str, Dict[EcuAddrSubAddr, List[bytes]]]
 
+STANDARD_VIN_ADDRS = [0x7e0, 0x7e2, 0x18da10f1, 0x18da0ef1]  # engine, VMCU, 29-bit engine, PGM-FI
+
+
 def p16(val):
   return struct.pack("!H", val)
 
@@ -55,6 +58,9 @@ class StdQueries:
 
   UDS_VIN_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + p16(uds.DATA_IDENTIFIER_TYPE.VIN)
   UDS_VIN_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + p16(uds.DATA_IDENTIFIER_TYPE.VIN)
+
+  GM_VIN_REQUEST = b'\x1a\x90'
+  GM_VIN_RESPONSE = b'\x5a\x90'
 
 
 @dataclass

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -370,7 +370,7 @@ if __name__ == "__main__":
 
   t = time.time()
   print("Getting vin...")
-  vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan, retry=10, debug=args.debug)
+  vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan, (0, 1), retry=10, debug=args.debug)
   print(f'RX: {hex(vin_rx_addr)}, BUS: {vin_rx_bus}, VIN: {vin}')
   print(f"Getting VIN took {time.time() - t:.3f} s")
   print()

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -370,7 +370,7 @@ if __name__ == "__main__":
 
   t = time.time()
   print("Getting vin...")
-  vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan, (1, 0), retry=10, debug=args.debug)
+  vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan, retry=10, debug=args.debug)
   print(f'RX: {hex(vin_rx_addr)}, BUS: {vin_rx_bus}, VIN: {vin}')
   print(f"Getting VIN took {time.time() - t:.3f} s")
   print()

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -212,7 +212,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   def test_startup_timing(self):
     # Tests worse-case VIN query time and typical present ECU query time
-    vin_ref_times = {'worst': 1.5, 'best': 0.5}  # best assumes we go through every possible query to get a match
+    vin_ref_times = {'worst': 1.5, 'best': 0.5}  # best assumes we go through all queries to get a match
     present_ecu_ref_time = 0.75
 
     def fake_get_ecu_addrs(*_, timeout):

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -212,8 +212,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   def test_startup_timing(self):
     # Tests worse-case VIN query time and typical present ECU query time
-    best_vin_ref_time = 0.5  # assuming query is last one in the try
-    worst_vin_ref_time = 1.5
+    vin_ref_times = {'worst': 1.5, 'best': 0.5}  # best assumes we go through every possible query to get a match
     present_ecu_ref_time = 0.75
 
     def fake_get_ecu_addrs(*_, timeout):
@@ -230,19 +229,14 @@ class TestFwFingerprintTiming(unittest.TestCase):
     self._assert_timing(self.total_time / self.N, present_ecu_ref_time)
     print(f'get_present_ecus, query time={self.total_time / self.N} seconds')
 
-    self.total_time = 0.0
-    with (mock.patch("openpilot.selfdrive.car.isotp_parallel_query.IsoTpParallelQuery.get_data", self.fake_get_data)):
-      for _ in range(self.N):
-        get_vin(fake_socket, fake_socket)
-    self._assert_timing(self.total_time / self.N, worst_vin_ref_time)
-    print(f'get_vin worst case, query time={self.total_time / self.N} seconds')
-
-    self.total_time = 0.0
-    with (mock.patch("openpilot.selfdrive.car.isotp_parallel_query.IsoTpParallelQuery.get_data", self.fake_get_data)):
-      for _ in range(self.N):
-        get_vin(fake_socket, fake_socket, retry=1)
-    self._assert_timing(self.total_time / self.N, best_vin_ref_time)
-    print(f'get_vin best case, query time={self.total_time / self.N} seconds')
+    for name, args in (('worst', {}), ('best', {'retry': 1})):
+      with self.subTest(name=name):
+        self.total_time = 0.0
+        with (mock.patch("openpilot.selfdrive.car.isotp_parallel_query.IsoTpParallelQuery.get_data", self.fake_get_data)):
+          for _ in range(self.N):
+            get_vin(fake_socket, fake_socket, (0, 1), **args)
+        self._assert_timing(self.total_time / self.N, vin_ref_times[name])
+        print(f'get_vin {name} case, query time={self.total_time / self.N} seconds')
 
   @pytest.mark.timeout(60)
   def test_fw_query_timing(self):

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -212,7 +212,8 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   def test_startup_timing(self):
     # Tests worse-case VIN query time and typical present ECU query time
-    vin_ref_time = 1.2
+    best_vin_ref_time = 0.5  # assuming query is last one in the try
+    worst_vin_ref_time = 1.5
     present_ecu_ref_time = 0.75
 
     def fake_get_ecu_addrs(*_, timeout):
@@ -232,9 +233,16 @@ class TestFwFingerprintTiming(unittest.TestCase):
     self.total_time = 0.0
     with (mock.patch("openpilot.selfdrive.car.isotp_parallel_query.IsoTpParallelQuery.get_data", self.fake_get_data)):
       for _ in range(self.N):
-        get_vin(fake_socket, fake_socket, (0, 1))
-    self._assert_timing(self.total_time / self.N, vin_ref_time)
-    print(f'get_vin, query time={self.total_time / self.N} seconds')
+        get_vin(fake_socket, fake_socket)
+    self._assert_timing(self.total_time / self.N, worst_vin_ref_time)
+    print(f'get_vin worst case, query time={self.total_time / self.N} seconds')
+
+    self.total_time = 0.0
+    with (mock.patch("openpilot.selfdrive.car.isotp_parallel_query.IsoTpParallelQuery.get_data", self.fake_get_data)):
+      for _ in range(self.N):
+        get_vin(fake_socket, fake_socket, retry=1)
+    self._assert_timing(self.total_time / self.N, best_vin_ref_time)
+    print(f'get_vin best case, query time={self.total_time / self.N} seconds')
 
   @pytest.mark.timeout(60)
   def test_fw_query_timing(self):

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -17,34 +17,37 @@ def is_valid_vin(vin: str):
 
 def get_vin(logcan, sendcan, timeout=0.1, retry=3, debug=False):
   for i in range(retry):
-    for request, response, bus, vin_addrs, functional_addrs, rx_offset in (
-      *[(StdQueries.UDS_VIN_REQUEST, StdQueries.UDS_VIN_RESPONSE, bus, STANDARD_VIN_ADDRS, FUNCTIONAL_ADDRS, 0x8) for bus in (0, 1)],
-      *[(StdQueries.OBD_VIN_REQUEST, StdQueries.OBD_VIN_RESPONSE, bus, STANDARD_VIN_ADDRS, FUNCTIONAL_ADDRS, 0x8) for bus in (0, 1)],
-      (StdQueries.GM_VIN_REQUEST, StdQueries.GM_VIN_RESPONSE, 0, [0x24b], None, 0x400),  # Bolt fwdCamera
-    ):
-      # print(request, response, bus, vin_addrs, functional_addrs, rx_offset)
-      # continue
-      try:
-        query = IsoTpParallelQuery(sendcan, logcan, bus, vin_addrs, [request, ], [response, ], response_offset=rx_offset,
-                                   functional_addrs=functional_addrs, debug=debug)
-        results = query.get_data(timeout)
+    for bus in (0, 1):
+      for request, response, valid_buses, vin_addrs, functional_addrs, rx_offset in (
+        (StdQueries.UDS_VIN_REQUEST, StdQueries.UDS_VIN_RESPONSE, (0, 1), STANDARD_VIN_ADDRS, FUNCTIONAL_ADDRS, 0x8),
+        (StdQueries.OBD_VIN_REQUEST, StdQueries.OBD_VIN_RESPONSE, (0, 1), STANDARD_VIN_ADDRS, FUNCTIONAL_ADDRS, 0x8),
+        (StdQueries.GM_VIN_REQUEST, StdQueries.GM_VIN_RESPONSE, (0,), [0x24b], None, 0x400),  # Bolt fwdCamera
+      ):
+        if bus not in valid_buses:
+          continue
+        # print(request, response, bus, vin_addrs, functional_addrs, rx_offset)
+        # continue
+        try:
+          query = IsoTpParallelQuery(sendcan, logcan, bus, vin_addrs, [request, ], [response, ], response_offset=rx_offset,
+                                     functional_addrs=functional_addrs, debug=debug)
+          results = query.get_data(timeout)
 
-        for addr in vin_addrs:
-          vin = results.get((addr, None))
-          if vin is not None:
-            # Ford pads with null bytes
-            if len(vin) == 24:
-              vin = re.sub(b'\x00*$', b'', vin)
+          for addr in vin_addrs:
+            vin = results.get((addr, None))
+            if vin is not None:
+              # Ford pads with null bytes
+              if len(vin) == 24:
+                vin = re.sub(b'\x00*$', b'', vin)
 
-            # Honda Bosch response starts with a length, trim to correct length
-            if vin.startswith(b'\x11'):
-              vin = vin[1:18]
+              # Honda Bosch response starts with a length, trim to correct length
+              if vin.startswith(b'\x11'):
+                vin = vin[1:18]
 
-            return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
+              return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
 
-        cloudlog.error(f"vin query retry ({i+1}) ...")
-      except Exception:
-        cloudlog.exception("VIN query exception")
+          cloudlog.error(f"vin query retry ({i+1}) ...")
+        except Exception:
+          cloudlog.exception("VIN query exception")
 
   return -1, -1, VIN_UNKNOWN
 

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -16,8 +16,6 @@ def is_valid_vin(vin: str):
 
 
 def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
-  # if we're doing a functional query, addrs to process/wait for. we don't send to these
-  addrs = list(range(0x7e0, 0x7e8)) + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
   for i in range(retry):
     for bus in buses:
       for request, response, vin_addrs, functional_addrs, rx_offset in (
@@ -25,7 +23,7 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
         (StdQueries.UDS_VIN_REQUEST, StdQueries.UDS_VIN_RESPONSE, STANDARD_VIN_ADDRS, FUNCTIONAL_ADDRS, 0x8),
         (StdQueries.OBD_VIN_REQUEST, StdQueries.OBD_VIN_RESPONSE, STANDARD_VIN_ADDRS, FUNCTIONAL_ADDRS, 0x8)):
         try:
-          query = IsoTpParallelQuery(sendcan, logcan, bus, addrs, [request, ], [response, ], response_offset=rx_offset,
+          query = IsoTpParallelQuery(sendcan, logcan, bus, vin_addrs, [request, ], [response, ], response_offset=rx_offset,
                                      functional_addrs=functional_addrs, debug=debug)
           results = query.get_data(timeout)
 


### PR DESCRIPTION
Can potentially use this to fingerprint camera-ACC GMs. Note that we still rely on OBD port for ASCM-based cars to get the VIN, but can potentially get it from another ECU in the future

---

```python
>>> get_vin(None, None, retry=1, buses=(0, 1))
# print(request, response, bus, vin_addrs, functional_addrs, rx_offset)
b'"\xf1\x90' b'b\xf1\x90' 0 [2016, 2018, 416944369, 416943857] [2015, 417018865] 8
b'\t\x02' b'I\x02\x01' 0 [2016, 2018, 416944369, 416943857] [2015, 417018865] 8
b'\x1a\x90' b'Z\x90' 0 [587] None 1024
b'"\xf1\x90' b'b\xf1\x90' 1 [2016, 2018, 416944369, 416943857] [2015, 417018865] 8
b'\t\x02' b'I\x02\x01' 1 [2016, 2018, 416944369, 416943857] [2015, 417018865] 8
```