### PR TITLE
vin: fix retry logging

### DIFF
--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -14,6 +14,9 @@ EcuAddrSubAddr = Tuple[int, int, Optional[int]]
 LiveFwVersions = Dict[AddrType, Set[bytes]]
 OfflineFwVersions = Dict[str, Dict[EcuAddrSubAddr, List[bytes]]]
 
+STANDARD_VIN_ADDRS = [0x7e0, 0x7e2, 0x18da10f1, 0x18da0ef1]  # engine, VMCU, 29-bit engine, PGM-FI
+
+
 def p16(val):
   return struct.pack("!H", val)
 

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -36,8 +36,10 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
 
               cloudlog.warning(f"got vin with {request=}")
               return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
+
         except Exception:
           cloudlog.exception("VIN query exception")
+
     cloudlog.error(f"vin query retry ({i+1}) ...")
 
   return -1, -1, VIN_UNKNOWN

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -4,7 +4,7 @@ import re
 import cereal.messaging as messaging
 from panda.python.uds import get_rx_addr_for_tx_addr, FUNCTIONAL_ADDRS
 from openpilot.selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
-from openpilot.selfdrive.car.fw_query_definitions import StdQueries
+from openpilot.selfdrive.car.fw_query_definitions import STANDARD_VIN_ADDRS, StdQueries
 from openpilot.common.swaglog import cloudlog
 
 VIN_UNKNOWN = "0" * 17
@@ -16,16 +16,14 @@ def is_valid_vin(vin: str):
 
 
 def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
-  addrs = list(range(0x7e0, 0x7e8)) + list(range(0x18DA00F1, 0x18DB00F1, 0x100))  # addrs to process/wait for
-  valid_vin_addrs = [0x7e0, 0x7e2, 0x18da10f1, 0x18da0ef1]  # engine, VMCU, 29-bit engine, PGM-FI
   for i in range(retry):
     for bus in buses:
       for request, response in ((StdQueries.UDS_VIN_REQUEST, StdQueries.UDS_VIN_RESPONSE), (StdQueries.OBD_VIN_REQUEST, StdQueries.OBD_VIN_RESPONSE)):
         try:
-          query = IsoTpParallelQuery(sendcan, logcan, bus, addrs, [request, ], [response, ], functional_addrs=FUNCTIONAL_ADDRS, debug=debug)
+          query = IsoTpParallelQuery(sendcan, logcan, bus, STANDARD_VIN_ADDRS, [request, ], [response, ], functional_addrs=FUNCTIONAL_ADDRS, debug=debug)
           results = query.get_data(timeout)
 
-          for addr in valid_vin_addrs:
+          for addr in STANDARD_VIN_ADDRS:
             vin = results.get((addr, None))
             if vin is not None:
               # Ford pads with null bytes
@@ -36,11 +34,11 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
               if vin.startswith(b'\x11'):
                 vin = vin[1:18]
 
+              cloudlog.warning(f"got vin with {request=}, {response=}")
               return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
-
-          cloudlog.error(f"vin query retry ({i+1}) ...")
         except Exception:
           cloudlog.exception("VIN query exception")
+    cloudlog.error(f"vin query retry ({i+1}) ...")
 
   return -1, -1, VIN_UNKNOWN
 

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -34,7 +34,7 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
               if vin.startswith(b'\x11'):
                 vin = vin[1:18]
 
-              cloudlog.warning(f"got vin with {request=}")
+              cloudlog.error(f"got vin with {request=}")
               return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
         except Exception:
           cloudlog.exception("VIN query exception")

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -34,7 +34,7 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
               if vin.startswith(b'\x11'):
                 vin = vin[1:18]
 
-              cloudlog.warning(f"got vin with {request=}, {response=}")
+              cloudlog.warning(f"got vin with {request=}")
               return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
         except Exception:
           cloudlog.exception("VIN query exception")

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -36,7 +36,6 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
 
               cloudlog.warning(f"got vin with {request=}")
               return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
-
         except Exception:
           cloudlog.exception("VIN query exception")
 

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -34,7 +34,7 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
               if vin.startswith(b'\x11'):
                 vin = vin[1:18]
 
-              cloudlog.error(f"got vin with {request=}")
+              cloudlog.warning(f"got vin with {request=}")
               return get_rx_addr_for_tx_addr(addr), bus, vin.decode()
         except Exception:
           cloudlog.exception("VIN query exception")


### PR DESCRIPTION
- don't print retry multiple times for when we try different queries, added here: https://github.com/commaai/openpilot/pull/24311. we should just log the request that got us the vin. we expect some queries to fail since not all support the UDS/OBD/GM query
  `got vin with request=b'\t\x02'`
- move STANDARD_VIN_ADDRS to fw query defs
- don't need to create isotp message clients for every address, just the ones we will ever consider