### PR TITLE
Toyota: fix rare panda standstill mismatch

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -71,7 +71,9 @@ class CarState(CarStateBase):
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
     ret.vEgoCluster = ret.vEgo * 1.015  # minimum of all the cars
 
-    ret.standstill = ret.vEgoRaw == 0
+    print('wheel speeds', ret.wheelSpeeds)
+    print(ret.vEgoRaw, 'close to zero',  abs(ret.vEgoRaw - 0))
+    ret.standstill = abs(ret.vEgoRaw) < 2.5e-3
 
     ret.steeringAngleDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_ANGLE"] + cp.vl["STEER_ANGLE_SENSOR"]["STEER_FRACTION"]
     ret.steeringRateDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_RATE"]

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -71,7 +71,7 @@ class CarState(CarStateBase):
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
     ret.vEgoCluster = ret.vEgo * 1.015  # minimum of all the cars
 
-    ret.standstill = abs(ret.vEgoRaw) < 2.5e-3
+    ret.standstill = abs(ret.vEgoRaw) < 1e-3
 
     ret.steeringAngleDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_ANGLE"] + cp.vl["STEER_ANGLE_SENSOR"]["STEER_FRACTION"]
     ret.steeringRateDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_RATE"]

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -71,8 +71,6 @@ class CarState(CarStateBase):
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
     ret.vEgoCluster = ret.vEgo * 1.015  # minimum of all the cars
 
-    print('wheel speeds', ret.wheelSpeeds)
-    print(ret.vEgoRaw, 'close to zero',  abs(ret.vEgoRaw - 0))
     ret.standstill = abs(ret.vEgoRaw) < 2.5e-3
 
     ret.steeringAngleDeg = cp.vl["STEER_ANGLE_SENSOR"]["STEER_ANGLE"] + cp.vl["STEER_ANGLE_SENSOR"]["STEER_FRACTION"]


### PR DESCRIPTION
Reproducible with `@reproduce_failure('6.47.5', b'AXicY2ZkgIIhwGBkYs/mrQu+yAAAEe4CPA==')`. This is hit because the smallest value the mean of this signal can show if parsing as an int, interpreted as a float is `0.0025`:

```
BO_ 170 WHEEL_SPEEDS: 8 XXX
 SG_ WHEEL_SPEED_FR : 7|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
 ...
```

`((1 * 0.01 - 67.67) - (0 * 0.01 - 67.67)) / 4 = 0.0025`


Due to rounding errors the Python mean function returned `4.76837158203125e-07`, and `4.76837158203125e-07 != 0`. panda of course got an int of 0, so it correctly thought the car was stopped.

Not likely in the car: the wheel speed sensors need to return invalid data, plus it needs to accidentally and perfectly sum to 0 like this: `wheel speeds (fl = -13.522223, fr = -18.080555, rl = 40.805557, rr = -9.2027779)`