### PR TITLE
UI/ListWidget: extended border for improved UI consistency

### DIFF
--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -266,7 +266,7 @@ private:
       if (widget == nullptr || widget->isVisible()) {
         QRect r = inner_layout.itemAt(i)->geometry();
         int bottom = r.bottom() + inner_layout.spacing() / 2;
-        p.drawLine(r.left() + 40, bottom, r.right() - 40, bottom);
+        p.drawLine(r.left(), bottom, r.right(), bottom);
       }
     }
   }


### PR DESCRIPTION
The current ListWidget border length is inconsistent with the border in the networking.cc(WiFi UI). The ListWidget/inner_layout border is shorter than the widget's width, causing the title and toggle buttons to extend beyond the border on both sides, as shown in the attached video and images. Although the border is better than no border (to help with scannability), this inconsistency is more obvious when an item is expanded; the details align with the border, but the title and toggle appear to overflow.


https://github.com/commaai/openpilot/assets/142481257/5c8d23c8-5a62-4be9-b1b5-7f348d7a5ade

![border-length_comparison](https://github.com/commaai/openpilot/assets/142481257/1b5eb94c-f44c-4b7b-ac36-05caa3a931de)
<br>
<br>
**Current Wifi UI** 
(*side note:* On actual device I noticed the border gap on each side is a little bit bigger compared to the UI screenshot from my Ubuntu 20.04 machine using a 4k monitor)
![wifi-networks-current-UI](https://github.com/commaai/openpilot/assets/142481257/dfce256d-6d09-47ce-81cb-e8ed65a3a731)

Green box shows spacing is a little bit bigger than the screenshot of the UI above.
![comma3x_wifiUI](https://github.com/commaai/openpilot/assets/142481257/a371a630-85f0-4e37-9748-c72900ca0f47)
