### PR TITLE
MapLibre: Ubuntu 22.04 support

### DIFF
--- a/third_party/maplibre-native-qt/x86_64/lib/libQMapLibre.so.3.0.0
+++ b/third_party/maplibre-native-qt/x86_64/lib/libQMapLibre.so.3.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b718e4ea770105893dc41f64be36f806586a9471e2bb9d18d5ad97e906434548
-size 11000296
+oid sha256:3dcb1a8d30ac9a659960e75e5d414ce6c6a7f82f8d0c295cff0fd6765ba221e8
+size 10883728


### PR DESCRIPTION
**Description**
Introduced in https://github.com/commaai/openpilot/pull/31185, the library does not allow scons to build in Ubuntu 22.04.

**Verification**
After rebuilding the library in Ubuntu 22.04, scons was able to build successfully.