### PR TITLE
updated: close lock file on exit

### DIFF
--- a/selfdrive/manager/process.py
+++ b/selfdrive/manager/process.py
@@ -261,12 +261,11 @@ class DaemonProcess(ManagerProcess):
         pass
 
     cloudlog.info(f"starting daemon {self.name}")
-    with open('/dev/null') as null_output:
-      proc = subprocess.Popen(['python', '-m', self.module],
-                                stdin=null_output,
-                                stdout=null_output,
-                                stderr=null_output,
-                                preexec_fn=os.setpgrp)
+    proc = subprocess.Popen(['python', '-m', self.module],
+                               stdin=open('/dev/null'),
+                               stdout=open('/dev/null', 'w'),
+                               stderr=open('/dev/null', 'w'),
+                               preexec_fn=os.setpgrp)
 
     self.params.put(self.param_name, str(proc.pid))
 

--- a/selfdrive/manager/process.py
+++ b/selfdrive/manager/process.py
@@ -261,11 +261,12 @@ class DaemonProcess(ManagerProcess):
         pass
 
     cloudlog.info(f"starting daemon {self.name}")
-    proc = subprocess.Popen(['python', '-m', self.module],
-                               stdin=open('/dev/null'),
-                               stdout=open('/dev/null', 'w'),
-                               stderr=open('/dev/null', 'w'),
-                               preexec_fn=os.setpgrp)
+    with open('/dev/null') as f1, open('/dev/null', 'w') as f2, open('/dev/null', 'w') as f3:
+      proc = subprocess.Popen(['python', '-m', self.module],
+                                stdin=f1,
+                                stdout=f2,
+                                stderr=f3,
+                                preexec_fn=os.setpgrp)
 
     self.params.put(self.param_name, str(proc.pid))
 

--- a/selfdrive/manager/process.py
+++ b/selfdrive/manager/process.py
@@ -261,11 +261,11 @@ class DaemonProcess(ManagerProcess):
         pass
 
     cloudlog.info(f"starting daemon {self.name}")
-    with open('/dev/null') as f1, open('/dev/null', 'w') as f2, open('/dev/null', 'w') as f3:
+    with open('/dev/null') as null_output:
       proc = subprocess.Popen(['python', '-m', self.module],
-                                stdin=f1,
-                                stdout=f2,
-                                stderr=f3,
+                                stdin=null_output,
+                                stdout=null_output,
+                                stderr=null_output,
                                 preexec_fn=os.setpgrp)
 
     self.params.put(self.param_name, str(proc.pid))

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -413,96 +413,96 @@ def main() -> None:
     cloudlog.warning("updates are disabled by the DisableUpdates param")
     exit(0)
 
-  ov_lock_fd = open(LOCK_FILE, 'w')
-  try:
-    fcntl.flock(ov_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-  except OSError as e:
-    raise RuntimeError("couldn't get overlay lock; is another instance running?") from e
-
-  # Set low io priority
-  proc = psutil.Process()
-  if psutil.LINUX:
-    proc.ionice(psutil.IOPRIO_CLASS_BE, value=7)
-
-  # Check if we just performed an update
-  if Path(os.path.join(STAGING_ROOT, "old_openpilot")).is_dir():
-    cloudlog.event("update installed")
-
-  if not params.get("InstallDate"):
-    t = datetime.datetime.utcnow().isoformat()
-    params.put("InstallDate", t.encode('utf8'))
-
-  updater = Updater()
-  update_failed_count = 0 # TODO: Load from param?
-  wait_helper = WaitTimeHelper()
-
-  # invalidate old finalized update
-  set_consistent_flag(False)
-
-  # set initial state
-  params.put("UpdaterState", "idle")
-
-  # Run the update loop
-  first_run = True
-  while True:
-    wait_helper.ready_event.clear()
-
-    # Attempt an update
-    exception = None
+  with open(LOCK_FILE, 'w') as ov_lock_fd:
     try:
-      # TODO: reuse overlay from previous updated instance if it looks clean
-      init_overlay()
+      fcntl.flock(ov_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as e:
+      raise RuntimeError("couldn't get overlay lock; is another instance running?") from e
 
-      # ensure we have some params written soon after startup
-      updater.set_params(False, update_failed_count, exception)
+    # Set low io priority
+    proc = psutil.Process()
+    if psutil.LINUX:
+      proc.ionice(psutil.IOPRIO_CLASS_BE, value=7)
 
-      if not system_time_valid() or first_run:
-        first_run = False
-        wait_helper.sleep(60)
-        continue
+    # Check if we just performed an update
+    if Path(os.path.join(STAGING_ROOT, "old_openpilot")).is_dir():
+      cloudlog.event("update installed")
 
-      update_failed_count += 1
+    if not params.get("InstallDate"):
+      t = datetime.datetime.utcnow().isoformat()
+      params.put("InstallDate", t.encode('utf8'))
 
-      # check for update
-      params.put("UpdaterState", "checking...")
-      updater.check_for_update()
+    updater = Updater()
+    update_failed_count = 0 # TODO: Load from param?
+    wait_helper = WaitTimeHelper()
 
-      # download update
-      last_fetch = read_time_from_param(params, "UpdaterLastFetchTime")
-      timed_out = last_fetch is None or (datetime.datetime.utcnow() - last_fetch > datetime.timedelta(days=3))
-      user_requested_fetch = wait_helper.user_request == UserRequest.FETCH
-      if params.get_bool("NetworkMetered") and not timed_out and not user_requested_fetch:
-        cloudlog.info("skipping fetch, connection metered")
-      elif wait_helper.user_request == UserRequest.CHECK:
-        cloudlog.info("skipping fetch, only checking")
-      else:
-        updater.fetch_update()
-        write_time_to_param(params, "UpdaterLastFetchTime")
-      update_failed_count = 0
-    except subprocess.CalledProcessError as e:
-      cloudlog.event(
-        "update process failed",
-        cmd=e.cmd,
-        output=e.output,
-        returncode=e.returncode
-      )
-      exception = f"command failed: {e.cmd}\n{e.output}"
-      OVERLAY_INIT.unlink(missing_ok=True)
-    except Exception as e:
-      cloudlog.exception("uncaught updated exception, shouldn't happen")
-      exception = str(e)
-      OVERLAY_INIT.unlink(missing_ok=True)
+    # invalidate old finalized update
+    set_consistent_flag(False)
 
-    try:
-      params.put("UpdaterState", "idle")
-      update_successful = (update_failed_count == 0)
-      updater.set_params(update_successful, update_failed_count, exception)
-    except Exception:
-      cloudlog.exception("uncaught updated exception while setting params, shouldn't happen")
+    # set initial state
+    params.put("UpdaterState", "idle")
 
-    # infrequent attempts if we successfully updated recently
-    wait_helper.user_request = UserRequest.NONE
-    wait_helper.sleep(5*60 if update_failed_count > 0 else 1.5*60*60)
+    # Run the update loop
+    first_run = True
+    while True:
+      wait_helper.ready_event.clear()
+
+      # Attempt an update
+      exception = None
+      try:
+        # TODO: reuse overlay from previous updated instance if it looks clean
+        init_overlay()
+
+        # ensure we have some params written soon after startup
+        updater.set_params(False, update_failed_count, exception)
+
+        if not system_time_valid() or first_run:
+          first_run = False
+          wait_helper.sleep(60)
+          continue
+
+        update_failed_count += 1
+
+        # check for update
+        params.put("UpdaterState", "checking...")
+        updater.check_for_update()
+
+        # download update
+        last_fetch = read_time_from_param(params, "UpdaterLastFetchTime")
+        timed_out = last_fetch is None or (datetime.datetime.utcnow() - last_fetch > datetime.timedelta(days=3))
+        user_requested_fetch = wait_helper.user_request == UserRequest.FETCH
+        if params.get_bool("NetworkMetered") and not timed_out and not user_requested_fetch:
+          cloudlog.info("skipping fetch, connection metered")
+        elif wait_helper.user_request == UserRequest.CHECK:
+          cloudlog.info("skipping fetch, only checking")
+        else:
+          updater.fetch_update()
+          write_time_to_param(params, "UpdaterLastFetchTime")
+        update_failed_count = 0
+      except subprocess.CalledProcessError as e:
+        cloudlog.event(
+          "update process failed",
+          cmd=e.cmd,
+          output=e.output,
+          returncode=e.returncode
+        )
+        exception = f"command failed: {e.cmd}\n{e.output}"
+        OVERLAY_INIT.unlink(missing_ok=True)
+      except Exception as e:
+        cloudlog.exception("uncaught updated exception, shouldn't happen")
+        exception = str(e)
+        OVERLAY_INIT.unlink(missing_ok=True)
+
+      try:
+        params.put("UpdaterState", "idle")
+        update_successful = (update_failed_count == 0)
+        updater.set_params(update_successful, update_failed_count, exception)
+      except Exception:
+        cloudlog.exception("uncaught updated exception while setting params, shouldn't happen")
+
+      # infrequent attempts if we successfully updated recently
+      wait_helper.user_request = UserRequest.NONE
+      wait_helper.sleep(5*60 if update_failed_count > 0 else 1.5*60*60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this unclosed file is the cause of a warning in test_onroad:

```
Exception ignored in: <_io.FileIO name='/tmp/safe_staging_overlay.lock' mode='wb' closefd=True>

Traceback (most recent call last):

  File "/data/pythonpath/openpilot/selfdrive/manager/process.py", line 42, in launcher

    cloudlog.warning(f"child {proc} got SIGINT")

ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/safe_staging_overlay.lock' mode='w' encoding='UTF-8'>
```

and also seems to cause errors in jenkins because updated can't start in the time_to_onroad test:
```
Traceback (most recent call last):

  File "/data/pythonpath/selfdrive/updated.py", line 418, in main

    fcntl.flock(ov_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)

BlockingIOError: [Errno 11] Resource temporarily unavailable
```