### PR TITLE
deleter now deletes files in addition to directories

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from datetime import datetime
 import os
 import shutil
 import threading

--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -47,20 +47,6 @@ def get_preserved_segments(dirs_by_creation: List[str]) -> List[str]:
 
   return preserved
 
-def separate_segments_and_nonsegments(dirs):
-  segments, non_segments = [], []
-  for d in dirs:
-      date_str, _, seg_str = d.rpartition("--")
-
-      try:
-        int(seg_str)
-        datetime.strptime(date_str, DATE_FORMAT)
-        segments.append(d)
-      except ValueError:
-        non_segments.append(d)
-
-  return segments, non_segments
-
 def contains_lockfiles(path: str) -> bool:
   if not os.path.isdir(path):
     return False

--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -48,18 +48,18 @@ def get_preserved_segments(dirs_by_creation: List[str]) -> List[str]:
   return preserved
 
 def separate_segments_and_nonsegments(dirs):
-    segments, non_segments = [], []
-    for d in dirs:
-        date_str, _, seg_str = d.rpartition("--")
+  segments, non_segments = [], []
+  for d in dirs:
+      date_str, _, seg_str = d.rpartition("--")
 
-        try:
-          int(seg_str)
-          datetime.strptime(date_str, DATE_FORMAT)
-          segments.append(d)
-        except ValueError:
-          non_segments.append(d)
+      try:
+        int(seg_str)
+        datetime.strptime(date_str, DATE_FORMAT)
+        segments.append(d)
+      except ValueError:
+        non_segments.append(d)
 
-    return segments, non_segments
+  return segments, non_segments
 
 def contains_lockfiles(path: str) -> bool:
   if not os.path.isdir(path):

--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -73,13 +73,12 @@ def deleter_thread(exit_event):
 
     if out_of_percent or out_of_bytes:
       dirs = listdir_by_creation(Paths.log_root())
-      segments, non_segments = separate_segments_and_nonsegments(dirs)
       files_only = [f for f in os.listdir(Paths.log_root()) if os.path.isfile(os.path.join(Paths.log_root(), f))]
 
-      all_contents = files_only + non_segments + segments
+      all_contents = files_only + dirs
 
       # skip deleting most recent N preserved segments (and their prior segment)
-      preserved_segments = get_preserved_segments(segments)
+      preserved_segments = get_preserved_segments(dirs)
 
       # remove the earliest directory we can
       for delete_item in sorted(all_contents, key=lambda d: (d in DELETE_LAST, d in preserved_segments)):


### PR DESCRIPTION
**Description**

[deleter.py](https://github.com/commaai/openpilot/blob/master/system/loggerd/deleter.py) only deleted directories in `Paths.log_root()` and ignored ordinary top-level files. Because it ignored files, [this bug was reported](https://github.com/commaai/openpilot/issues/30102). 

The code now first deletes ordinary files, followed by directories that are not openpilot segments, followed by openpilot segment directories according to the existing ordering from oldest to newest.

**Verification**

Unit tests were added to `system/loggerd/tests/test_deleter.py` that failed prior to the bugfix being implemented. After the bugfix was implemented, these tests now pass.

**Note**

Please note that this bugfix carries a [$100 bounty](https://github.com/commaai/openpilot/issues/30102).