### PR TITLE
Ford: additional FW query request

### DIFF
--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -111,14 +111,24 @@ FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
     # CAN and CAN FD queries are combined.
     # FIXME: For CAN FD, ECUs respond with frames larger than 8 bytes on the powertrain bus
+    # TODO: properly handle auxiliary requests to separate queries and add whitelists
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
+      # whitelist_ecus=[Ecu.abs, Ecu.engine, Ecu.eps, Ecu.fwdCamera, Ecu.fwdRadar, Ecu.shiftByWire],
+      bus=0,
+      auxiliary=True,
+    ),
+    Request(
+      [StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
+      [StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
+      # whitelist_ecus=[Ecu.abs, Ecu.engine, Ecu.eps],
       bus=0,
       auxiliary=True,
     ),
   ],
   extra_ecus=[
+    # We are unlikely to get a response from the PCM from behind the gateway.
     (Ecu.engine, 0x7e0, None),
     (Ecu.shiftByWire, 0x732, None),
   ],

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -254,13 +254,13 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   @pytest.mark.timeout(60)
   def test_fw_query_timing(self):
-    total_ref_time = 6.8
+    total_ref_time = 7.0
     brand_ref_times = {
       1: {
         'gm': 0.5,
         'body': 0.1,
         'chrysler': 0.3,
-        'ford': 0.1,
+        'ford': 0.2,
         'honda': 0.55,
         'hyundai': 0.65,
         'mazda': 0.1,
@@ -271,7 +271,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'volkswagen': 0.2,
       },
       2: {
-        'ford': 0.2,
+        'ford': 0.3,
         'hyundai': 1.05,
       }
     }


### PR DESCRIPTION
**Description**
After removing the FW query sent to the OBD port (https://github.com/commaai/openpilot/pull/31195), the ABS and EPS do not respond to the remaining FW query request on my Focus Mk4. For unknown reasons they do respond again when sending both of these requests to bus 0.

- [ ] Also, I added `Ecu.engine` to `extra_ecus` in the last PR, but we could remove this since it's unlikely we'll ever get a response from behind the gateway (I don't believe it works on the Q3 cars).

**Verification**
Tested with and without the comma power connected.

- [x] Test route (manual - Ford Focus): `e886087f430e7fe7/2024-02-04--21-05-25`
- [ ] Test route (automatic): TODO - I'll need someone to try it to see if the GSM (`Ecu.shiftByWire`) is still responding too.

Sending only the request without `TESTER_PRESENT` does not yield a respnse from the ABS or EPS either. See additional notes in https://github.com/commaai/openpilot/pull/31296.