### PR TITLE
Update CTF.md - Run selfdrive ui inside the folder to avoid QPixmap errors

### DIFF
--- a/tools/CTF.md
+++ b/tools/CTF.md
@@ -16,5 +16,6 @@ cd tools/replay
 ./replay '0c7f0c7f0c7f0c7f|2021-10-13--13-00-00' --dcam --ecam
 
 # start the UI in another terminal
-selfdrive/ui/ui
+cd selfdrive/ui/
+./ui
 ```


### PR DESCRIPTION
**Description**

Run selfdrive ui inside the folder to avoid QPixmap errors in WLS.

: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaled: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
: QPixmap::scaleWidth: Pixmap is a null pixmap
Segmentation fault
