### PR TITLE
CI: Move repo maintenance bots to 6am

### DIFF
--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -2,7 +2,7 @@ name: repo maintenance
 
 on:
   schedule:
-    - cron: "0 12 * * 1" # every Monday at 12am UTC (4am PST)
+    - cron: "0 14 * * 1" # every Monday at 2am UTC (6am PST)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
so it doesn't conflict with our 4am restart of jenkins