### PR TITLE
get_vin: respond to full 11-bit diagnostic address range

### DIFF
--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -28,7 +28,9 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
 
         # When querying functional addresses, ideally we respond to everything that sends a first frame to avoid leaving the
         # ECU in a temporary bad state. Note that we may not cover all ECUs and response offsets. TODO: query physical addrs
-        tx_addrs = vin_addrs if not functional_addrs else [a for a in range(0x700, 0x800) if a != 0x7DF] + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
+        tx_addrs = vin_addrs
+        if functional_addrs is not None:
+           tx_addrs = [a for a in range(0x700, 0x800) if a != 0x7DF] + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
 
         try:
           query = IsoTpParallelQuery(sendcan, logcan, bus, tx_addrs, [request, ], [response, ], response_offset=rx_offset,

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -26,8 +26,12 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
         if bus not in valid_buses:
           continue
 
+        # When querying functional addresses, ideally we respond to everything that sends a first frame to avoid leaving the
+        # ECU in a temporary bad state. Note that we may not cover all ECUs and response offsets. TODO: query physical addrs
+        tx_addrs = vin_addrs if not functional_addrs else list(range(0x700, 0x800)) + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
+
         try:
-          query = IsoTpParallelQuery(sendcan, logcan, bus, vin_addrs, [request, ], [response, ], response_offset=rx_offset,
+          query = IsoTpParallelQuery(sendcan, logcan, bus, tx_addrs, [request, ], [response, ], response_offset=rx_offset,
                                      functional_addrs=functional_addrs, debug=debug)
           results = query.get_data(timeout)
 

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -28,7 +28,7 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
 
         # When querying functional addresses, ideally we respond to everything that sends a first frame to avoid leaving the
         # ECU in a temporary bad state. Note that we may not cover all ECUs and response offsets. TODO: query physical addrs
-        tx_addrs = vin_addrs if not functional_addrs else list(range(0x700, 0x800)) + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
+        tx_addrs = vin_addrs if not functional_addrs else [a for a in range(0x700, 0x800) if a != 0x7DF] + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
 
         try:
           query = IsoTpParallelQuery(sendcan, logcan, bus, tx_addrs, [request, ], [response, ], response_offset=rx_offset,

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -30,7 +30,7 @@ def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
         # ECU in a temporary bad state. Note that we may not cover all ECUs and response offsets. TODO: query physical addrs
         tx_addrs = vin_addrs
         if functional_addrs is not None:
-           tx_addrs = [a for a in range(0x700, 0x800) if a != 0x7DF] + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
+          tx_addrs = [a for a in range(0x700, 0x800) if a != 0x7DF] + list(range(0x18DA00F1, 0x18DB00F1, 0x100))
 
         try:
           query = IsoTpParallelQuery(sendcan, logcan, bus, tx_addrs, [request, ], [response, ], response_offset=rx_offset,


### PR DESCRIPTION
Split from https://github.com/commaai/openpilot/pull/31308, fixes https://github.com/commaai/openpilot/issues/31307

We currently do not respond to some responding addresses for our VIN query, such as Ford's ABS and EPS, leaving them in a bad state as they wait for our flow control continue message for on the order of seconds. This likely doesn't cover some ECUs with non-standard response offsets like Chrysler, but is a good start (no other known failures to respond to queries).

Querying with physical addresses (and putting the brand-specific queries in the config) will fully fix this, but requires some more logging on release: https://github.com/commaai/openpilot/pull/31314. Plus @gregjhogan suspects at least one car doesn't respond without the functional addressing, so we will need to test all brands