### PR TITLE
camerastream instructions

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -68,6 +68,7 @@ Learn about the openpilot ecosystem and tools by playing our [CTF](/tools/CTF.md
 ├── ubuntu_setup.sh     # Setup script for Ubuntu
 ├── mac_setup.sh        # Setup script for macOS
 ├── cabana/             # View and plot CAN messages from drives or in realtime
+├── camerastream        # Cameras stream over the network
 ├── joystick/           # Control your car with a joystick
 ├── lib/                # Libraries to support the tools and reading openpilot logs
 ├── plotjuggler/        # A tool to plot openpilot logs

--- a/tools/README.md
+++ b/tools/README.md
@@ -68,7 +68,7 @@ Learn about the openpilot ecosystem and tools by playing our [CTF](/tools/CTF.md
 ├── ubuntu_setup.sh     # Setup script for Ubuntu
 ├── mac_setup.sh        # Setup script for macOS
 ├── cabana/             # View and plot CAN messages from drives or in realtime
-├── camerastream        # Cameras stream over the network
+├── camerastream/       # Cameras stream over the network
 ├── joystick/           # Control your car with a joystick
 ├── lib/                # Libraries to support the tools and reading openpilot logs
 ├── plotjuggler/        # A tool to plot openpilot logs

--- a/tools/camerastream/README.md
+++ b/tools/camerastream/README.md
@@ -1,0 +1,72 @@
+# Camera stream
+
+`compressed_vipc.py` allows to connect to Comma device and decode video streams. 
+
+## Usage
+
+### On the device 
+SSH to the Comma device and run following lines in separate terminals:
+
+`cd /data/openpilot/cereal/messaging && ./bridge`
+
+`cd /data/openpilot/system/loggerd && ./encoderd`
+
+`cd /data/openpilot/system/camerad && ./camerad`
+
+Note: Your device need to be on `master` branch.
+Make sure both the device and PC is roughly at the same commit level.
+Run `./scons` on the PC and reboot the comma device if you are updating from older versions.
+
+Alternatively paste this as a single command:
+```
+(
+  cd /data/openpilot/cereal/messaging/
+  ./bridge &
+
+  cd /data/openpilot/system/camerad/
+  ./camerad &
+
+  cd /data/openpilot/system/loggerd/
+  ./encoderd &
+
+  wait
+) ; trap 'kill $(jobs -p)' SIGINT
+```
+Ctrl+C will stop all three processes. 
+
+### On the PC
+Decode the stream with `compressed_vipc.py`:
+
+```cd ~/openpilot/tools/camerastream && ./compressed_vipc.py <ip>```
+
+Note: make sure you run python scripts in `poetry shell` virtual environment.
+
+To actually display the stream, run `watch3` in separate terminal:
+
+```cd ~/openpilot/selfdrive/ui/ && ./watch3```
+
+If this step fails, try limiting active cameras by adding `--cams=0` to `compressed_vipc.py`.
+
+## compressed_vipc.py usage
+```
+$ python compressed_vipc.py -h
+usage: compressed_vipc.py [-h] [--nvidia] [--cams CAMS] [--silent] addr
+
+Decode video streams and broadcast on VisionIPC
+
+positional arguments:
+  addr         Address of comma three
+
+options:
+  -h, --help   show this help message and exit
+  --nvidia     Use nvidia instead of ffmpeg
+  --cams CAMS  Cameras to decode
+  --silent     Suppress debug output
+```
+
+
+## Example:
+```
+cd ~/openpilot/tools/camerastream && ./compressed_vipc.py comma-ffffffff --cams 0
+cd ~/openpilot/selfdrive/ui/ && ./watch3
+```

--- a/tools/camerastream/README.md
+++ b/tools/camerastream/README.md
@@ -1,11 +1,11 @@
 # Camera stream
 
-`compressed_vipc.py` allows to connect to Comma device and decode video streams. 
+`compressed_vipc.py` connects to a remote device running openpilot, decodes the video streams, and republishes them over VisionIPC. 
 
 ## Usage
 
 ### On the device 
-SSH to the Comma device and run following lines in separate terminals:
+SSH into the device and run following in separate terminals:
 
 `cd /data/openpilot/cereal/messaging && ./bridge`
 
@@ -13,9 +13,7 @@ SSH to the Comma device and run following lines in separate terminals:
 
 `cd /data/openpilot/system/camerad && ./camerad`
 
-Note: Your device need to be on `master` branch.
-Make sure both the device and PC is roughly at the same commit level.
-Run `./scons` on the PC and reboot the comma device if you are updating from older versions.
+Note that both the device and your PC must be on the same openpilot commit.
 
 Alternatively paste this as a single command:
 ```
@@ -39,13 +37,9 @@ Decode the stream with `compressed_vipc.py`:
 
 ```cd ~/openpilot/tools/camerastream && ./compressed_vipc.py <ip>```
 
-Note: make sure you run python scripts in `poetry shell` virtual environment.
-
 To actually display the stream, run `watch3` in separate terminal:
 
 ```cd ~/openpilot/selfdrive/ui/ && ./watch3```
-
-If this step fails, try limiting active cameras by adding `--cams=0` to `compressed_vipc.py`.
 
 ## compressed_vipc.py usage
 ```

--- a/tools/camerastream/compressed_vipc.py
+++ b/tools/camerastream/compressed_vipc.py
@@ -12,6 +12,10 @@ from cereal.visionipc import VisionIpcServer, VisionStreamType
 
 V4L2_BUF_FLAG_KEYFRAME = 8
 
+# start encoderd
+# also start cereal messaging bridge
+# then run this "./compressed_vipc.py <ip>"
+
 ENCODE_SOCKETS = {
   VisionStreamType.VISION_STREAM_ROAD: "roadEncodeData",
   VisionStreamType.VISION_STREAM_WIDE_ROAD: "wideRoadEncodeData",


### PR DESCRIPTION

**Description**

Added instructions how to display camera feed from the device to ubuntu PC

**Verification**

I followed my instructions step by step  - they work with older commits (end of 2023 332a21965da4060d411fb65286cddc61b555ae48).  
With the latest `master`, `watch3` displays green screen, but I think this is an issue with the encoder/decoder. 


