### PR TITLE
jenkins: cleanup stage names for analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,7 +205,7 @@ node {
         ])
       },
       'HW + Unit Tests': {
-        deviceStage("tici", "tici-common", ["UNSAFE=1"], [
+        deviceStage("tici-hardware", "tici-common", ["UNSAFE=1"], [
           ["build", "cd selfdrive/manager && ./build.py"],
           ["test pandad", "pytest selfdrive/boardd/tests/test_pandad.py", ["panda/", "selfdrive/boardd/"]],
           ["test power draw", "pytest -s system/hardware/tici/tests/test_power_draw.py"],
@@ -215,7 +215,7 @@ node {
         ])
       },
       'loopback': {
-        deviceStage("tici", "tici-loopback", ["UNSAFE=1"], [
+        deviceStage("loopback", "tici-loopback", ["UNSAFE=1"], [
           ["build openpilot", "cd selfdrive/manager && ./build.py"],
           ["test boardd loopback", "pytest selfdrive/boardd/tests/test_boardd_loopback.py"],
         ])
@@ -243,7 +243,7 @@ node {
         ])
       },
       'replay': {
-        deviceStage("tici", "tici-replay", ["UNSAFE=1"], [
+        deviceStage("model-replay", "tici-replay", ["UNSAFE=1"], [
           ["build", "cd selfdrive/manager && ./build.py"],
           ["model replay", "selfdrive/test/process_replay/model_replay.py"],
         ])


### PR DESCRIPTION
more descriptive stage names for analysis

currently, "tici" shows for a bunch of tests (model replay, hw + unit tests, and loopback)
![image](https://github.com/commaai/openpilot/assets/9648890/e7b559e6-c6f8-424c-9978-357870f0079b)
