### PR TITLE
jenkins: lock device resource first before making container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,8 +78,8 @@ def deviceStage(String stageName, String deviceType, List extra_env, def steps) 
     def extra = extra_env.collect { "export ${it}" }.join('\n');
     def branch = env.BRANCH_NAME ?: 'master';
 
-    docker.image('ghcr.io/commaai/alpine-ssh').inside('--user=root') {
-      lock(resource: "", label: deviceType, inversePrecedence: true, variable: 'device_ip', quantity: 1, resourceSelectStrategy: 'random') {
+    lock(resource: "", label: deviceType, inversePrecedence: true, variable: 'device_ip', quantity: 1, resourceSelectStrategy: 'random') {
+      docker.image('ghcr.io/commaai/alpine-ssh').inside('--user=root') {
         timeout(time: 20, unit: 'MINUTES') {
           retry (3) {
             device(device_ip, "git checkout", extra + "\n" + readFile("selfdrive/test/setup_device_ci.sh"))


### PR DESCRIPTION
so we don't create a bunch of docker containers while waiting for the resource to open up