### PR TITLE
UI/sidebar_widget: Improved hierarchy between UI elements in settings sidebar

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -351,19 +351,23 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
   QPushButton *close_btn = new QPushButton(tr("×"));
   close_btn->setStyleSheet(R"(
     QPushButton {
-      font-size: 140px;
+      color: grey;
+      background-color: transparent;
+      border: none;
+      font-size: 190px;
+      font-weight: 450;
+      text-align: left;
+      padding-left: 0px;
       padding-bottom: 20px;
-      border-radius: 100px;
-      background-color: #292929;
-      font-weight: 400;
     }
     QPushButton:pressed {
-      background-color: #3B3B3B;
+      color: #ADADAD;
+      background-color: transparent;
     }
   )");
   close_btn->setFixedSize(200, 200);
-  sidebar_layout->addSpacing(45);
-  sidebar_layout->addWidget(close_btn, 0, Qt::AlignCenter);
+  sidebar_layout->addWidget(close_btn, 0, Qt::AlignLeft);
+  sidebar_layout->addSpacing(95);
   QObject::connect(close_btn, &QPushButton::clicked, this, &SettingsWindow::closeSettings);
 
   // setup panels
@@ -393,6 +397,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
         background: none;
         font-size: 65px;
         font-weight: 500;
+        padding-left: 15px;
       }
       QPushButton:checked {
         color: white;
@@ -403,7 +408,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
     )");
     btn->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     nav_btns->addButton(btn);
-    sidebar_layout->addWidget(btn, 0, Qt::AlignRight);
+    sidebar_layout->addWidget(btn, 0, Qt::AlignLeft);
 
     const int lr_margin = name != tr("Network") ? 50 : 0;  // Network panel handles its own margins
     panel->setContentsMargins(lr_margin, 25, lr_margin, 25);
@@ -416,7 +421,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
       panel_widget->setCurrentWidget(w);
     });
   }
-  sidebar_layout->setContentsMargins(50, 50, 100, 50);
+  sidebar_layout->setContentsMargins(50, 0, 100, 50);
 
   // main settings layout, sidebar + main panel
   QHBoxLayout *main_layout = new QHBoxLayout(this);


### PR DESCRIPTION
**Modified elements:**
-No circle/background around "x"
-"x" slightly bigger, and bolder
-Spacing is added below close_btn instead of above
-Only 1 element is white IF pressed versus the "x" and current menu text
-Text is aligned left
-Menu text added left padding to align with "x" close_btn 

https://github.com/commaai/openpilot/assets/142481257/d8e57e0b-b3a0-4935-a214-80d6d8666465


### Noise in sidebar
To much is grabbing for attention in sidebar when settings is opened up. There is a circle emphasizing the "x" and also the color white making the X stand out while also using that color white to show your active tab/section. 
Over using a color to differentiate makes the emphasis less impactful. Ideally one element should be highlighted in white to mark as the "pressed" element. Making it white and with a circle behind it is overkill and adds more noise to the UI. 
</br>
### Why place close_btn top left?
Placing the close_btn in the top left corner is more familiar for users and is where most back/close buttons are found on mobile and web apps making it easier to interact with. 
<br>
### Why left-align text matters for vertical menus?
Aligning menu items to the left helps users eyes scan rapidly in a straight downward motion versus a zigzag motion when using right-aligned text in vertical menus. Link below talks deeper about it. Not a huge deal on its own , but the little things of experiences add up. 

https://www.nngroup.com/articles/right-justified-navigation-menus/
</br>
### New sidebar UI
![NEW_sidebar-UI](https://github.com/commaai/openpilot/assets/142481257/d7bda607-8026-4207-9bf9-0ce58085b459)
</br>
### Old sidebar UI
![old_sidebar-UI](https://github.com/commaai/openpilot/assets/142481257/9469bc2e-d007-482e-a570-2acc78bc8a2e)
