### PR TITLE
Pytest: reenable gc in pytest fixture + re-combine jenkins car tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,9 +272,8 @@ node {
       'car tests': {
         pcStage("car tests") {
           sh label: "build", script: "selfdrive/manager/build.py"
-          sh label: "test_models", script: "INTERNAL_SEG_CNT=300 FILEREADER_CACHE=1 INTERNAL_SEG_LIST=selfdrive/car/tests/test_models_segs.txt \
-                                            pytest selfdrive/car/tests/test_models.py"
-          sh label: "test_car_interfaces", script: "MAX_EXAMPLES=300 pytest selfdrive/car/tests/test_car_interfaces.py"
+          sh label: "run car tests", script: "cd selfdrive/car/tests && MAX_EXAMPLES=300 INTERNAL_SEG_CNT=300 FILEREADER_CACHE=1 \
+              INTERNAL_SEG_LIST=selfdrive/car/tests/test_models_segs.txt pytest test_models.py test_car_interfaces.py"
         }
       },
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import pytest
 import random
@@ -44,6 +45,11 @@ def openpilot_function_fixture(request):
 
   # cleanup any started processes
   manager.manager_cleanup()
+
+  # some processes disable gc for performace, reenable here and run to ensure old memory is cleaned up
+  if not gc.isenabled():
+    gc.enable()
+    gc.collect()
 
 # If you use setUpClass, the environment variables won't be cleared properly,
 # so we need to hook both the function and class pytest fixtures

--- a/conftest.py
+++ b/conftest.py
@@ -46,7 +46,7 @@ def openpilot_function_fixture(request):
   # cleanup any started processes
   manager.manager_cleanup()
 
-  # some processes disable gc for performance, re-enable here and run to ensure old memory is cleaned up
+  # some processes disable gc for performance, re-enable here
   if not gc.isenabled():
     gc.enable()
     gc.collect()

--- a/conftest.py
+++ b/conftest.py
@@ -46,7 +46,7 @@ def openpilot_function_fixture(request):
   # cleanup any started processes
   manager.manager_cleanup()
 
-  # some processes disable gc for performace, reenable here and run to ensure old memory is cleaned up
+  # some processes disable gc for performance, re-enable here and run to ensure old memory is cleaned up
   if not gc.isenabled():
     gc.enable()
     gc.collect()


### PR DESCRIPTION
@sshane found the gc gets disabled in the test_models tests and causes high memory usage