### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/honda/fingerprints.py
+++ b/selfdrive/car/honda/fingerprints.py
@@ -834,6 +834,7 @@ FW_VERSIONS = {
     (Ecu.programmedFuelInjection, 0x18da10f1, None): [
       b'37805-5MR-3050\x00\x00',
       b'37805-5MR-3250\x00\x00',
+      b'37805-5MR-4070\x00\x00',
       b'37805-5MR-4080\x00\x00',
       b'37805-5MR-4180\x00\x00',
       b'37805-5MR-A240\x00\x00',

--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -1566,9 +1566,9 @@ FW_VERSIONS = {
   },
   CAR.TUCSON_4TH_GEN: {
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 1.00 99211-N9220 14K',
       b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 2.02 99211-N9000 14E',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9210 14G',
-      b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 1.00 99211-N9220 14K',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9220 14K',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9240 14Q',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9250 14W',
@@ -1638,9 +1638,9 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00MQ4_ SCC F-CUP      1.00 1.06 99110-P2000         ',
+      b'\xf1\x00MQ4_ SCC FHCUP      1.00 1.00 99110-R5000         ',
       b'\xf1\x00MQ4_ SCC FHCUP      1.00 1.06 99110-P2000         ',
       b'\xf1\x00MQ4_ SCC FHCUP      1.00 1.08 99110-P2000         ',
-      b'\xf1\x00MQ4_ SCC FHCUP      1.00 1.00 99110-R5000         ',
     ],
   },
   CAR.KIA_SORENTO_HEV_4TH_GEN: {


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 0.5 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                         | Name from VIN 🆚 CarInfo                       | Segments              | Bad seg tags   | Good seg tags                                       |
|:------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|:----------------------|:---------------|:----------------------------------------------------|
| [7e870a7ec3860511](https://useradmin.comma.ai/?onebox=7e870a7ec3860511)<br><sub>HONDA ODYSSEY 2018<br>5FNRL6H9X........</sub> | HONDA Odyssey 2019 🆚<br>Honda Odyssey 2018-20 | 1 routes, 52 segments |                | - all lat active: 1<br>- no input all lat active: 1 |

Dongles to re-run category: `7e870a7ec3860511`
</details>

## ⏳️ 10 dongles (8 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                               | Name from VIN 🆚 CarInfo                                       | Segments               | Bad seg tags                                                                          | Good seg tags                                         |
|:------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------|:-----------------------|:--------------------------------------------------------------------------------------|:------------------------------------------------------|
| [57c9cc7b786fc5a7](https://useradmin.comma.ai/?onebox=57c9cc7b786fc5a7)<br><sub>LEXUS NX 2020<br>000000000........</sub>            | None 🆚<br>None                                                | 3 routes, 31 segments  |                                                                                       | - all lat active: 3                                   |
| [e1fcfe631f560c6a](https://useradmin.comma.ai/?onebox=e1fcfe631f560c6a)<br><sub>LEXUS RX 2016<br>2T2ZZMCA2........</sub>            | LEXUS RX 2016 🆚<br>Lexus RX 2016                              | 3 routes, 35 segments  |                                                                                       | - all lat active: 0                                   |
| [030e7d18f7c4ea9d](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHTX........</sub>         | RAM 1500 2021 🆚<br>Ram 1500 2019-24                           | 3 routes, 49 segments  |                                                                                       | - all lat active: 0                                   |
| [22dbdf2ca2bce921](https://useradmin.comma.ai/?onebox=22dbdf2ca2bce921)<br><sub>HONDA PILOT 2017<br>5FNYF6H5X........</sub>         | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                     | 11 routes, 63 segments |                                                                                       | - all lat active: 0                                   |
| [63dd0d6adc9099a0](https://useradmin.comma.ai/?onebox=63dd0d6adc9099a0)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHT1........</sub>         | RAM 1500 2023 🆚<br>Ram 1500 2019-24                           | 1 routes, 67 segments  |                                                                                       | - all lat active: 49<br>- no input all lat active: 10 |
| [fc4d8f4e5f8b353a](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a)<br><sub>HONDA CIVIC 2022<br>19XFL1H88........</sub>         | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23 | 1 routes, 25 segments  | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a) | - all lat active: 9<br>- no input all lat active: 5   |
| [54833a82f26c7a11](https://useradmin.comma.ai/?onebox=54833a82f26c7a11)<br><sub>TOYOTA AVALON 2019<br>4T1D21FB2........</sub>       | TOYOTA Avalon Hybrid 2020 🆚<br>Toyota Avalon Hybrid 2019-21   | 3 routes, 19 segments  |                                                                                       | - all lat active: 2<br>- no input all lat active: 1   |
| [9bac7575fac62395](https://useradmin.comma.ai/?onebox=9bac7575fac62395)<br><sub>HONDA PILOT 2017<br>5FNYF6H93........</sub>         | HONDA Pilot 2018 🆚<br>Honda Pilot 2016-22                     | 4 routes, 34 segments  |                                                                                       | - all lat active: 5                                   |
| [0e4bac1d711fd551](https://useradmin.comma.ai/?onebox=0e4bac1d711fd551)<br><sub>HONDA ODYSSEY 2018<br>5FNRL6H4X........</sub>       | HONDA Odyssey 2020 🆚<br>Honda Odyssey 2018-20                 | 5 routes, 54 segments  |                                                                                       | - all lat active: 0                                   |
| [0662797832aac2eb](https://useradmin.comma.ai/?onebox=0662797832aac2eb)<br><sub>TOYOTA COROLLA TSS2 2019<br>JTHU95BH8........</sub> | None 🆚<br>None                                                | 1 routes, 2 segments   |                                                                                       | - all lat active: 0                                   |

Dongles to re-run category: `0662797832aac2eb 57c9cc7b786fc5a7 54833a82f26c7a11 e1fcfe631f560c6a 9bac7575fac62395 22dbdf2ca2bce921 fc4d8f4e5f8b353a 0e4bac1d711fd551 63dd0d6adc9099a0 030e7d18f7c4ea9d`
</details>

## ⚠️ 1 dongles (1 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                       | Name from VIN 🆚 CarInfo                   | Segments              | Bad seg tags                                                                                                                                                                                                | Good seg tags   |
|:----------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------|:----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------|
| [6e12554fbd20d6d1](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1)<br><sub>HONDA CIVIC 2022<br>2HGFE1F98........</sub> | HONDA Civic 2022 🆚<br>Honda Civic 2022-23 | 1 routes, 13 segments | - [missing ECU FW: 13](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1%7C2024-02-07--11-52-49)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1%7C2024-02-07--11-52-49) |                 |

Dongles to re-run category: `6e12554fbd20d6d1`
</details>