### PR TITLE
Update Lexus LC Convertible Steer Ratio to 13

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -183,7 +183,7 @@ class CarInterface(CarInterfaceBase):
 
     elif candidate == CAR.LEXUS_LC_TSS2:
       ret.wheelbase = 2.87
-      ret.steerRatio = 14.7
+      ret.steerRatio = 13.0
       ret.tireStiffnessFactor = 0.444  # not optimized yet
       ret.mass = 4500 * CV.LB_TO_KG
 


### PR DESCRIPTION
https://media.lexus.co.uk/wp-content/uploads/sites/3/2021/06/1612190405210201MLCConvertibleTechSpec.pdf

Minor follow-up to port
