### PR TITLE
test_time_to_onroad: log events after engagability/timeout

### DIFF
--- a/selfdrive/test/test_time_to_onroad.py
+++ b/selfdrive/test/test_time_to_onroad.py
@@ -21,23 +21,23 @@ def test_time_to_onroad():
   sm = messaging.SubMaster(['controlsState', 'deviceState', 'onroadEvents'])
   try:
     # wait for onroad
+    with Timeout(20, "timed out waiting to go onroad"):
+      while True:
+        sm.update(1000)
+        if sm['deviceState'].started:
+          break
+        time.sleep(1)
+
+    # wait for engageability
     try:
-      with Timeout(20, "timed out waiting to go onroad"):
+      with Timeout(10, "timed out waiting for engageable"):
         while True:
           sm.update(1000)
-          if sm['deviceState'].started:
+          if sm['controlsState'].engageable:
             break
           time.sleep(1)
     finally:
       print(f"onroad events: {sm['onroadEvents']}")
-
-    # wait for engageability
-    with Timeout(10, "timed out waiting for engageable"):
-      while True:
-        sm.update(1000)
-        if sm['controlsState'].engageable:
-          break
-        time.sleep(1)
     print(f"engageable after {time.monotonic() - start_time:.2f}s")
 
     # once we're enageable, must be for the next few seconds


### PR DESCRIPTION
meant to put this around engagability not onroad