### PR TITLE
test_manager: ensure test independence

### DIFF
--- a/selfdrive/manager/test/test_manager.py
+++ b/selfdrive/manager/test/test_manager.py
@@ -5,6 +5,8 @@ import signal
 import time
 import unittest
 
+from parameterized import parameterized
+
 from cereal import car
 from openpilot.common.params import Params
 import openpilot.selfdrive.manager.manager as manager
@@ -38,6 +40,7 @@ class TestManager(unittest.TestCase):
     # TODO: ensure there are blacklisted procs until we have a dedicated test
     self.assertTrue(len(BLACKLIST_PROCS), "No blacklisted procs to test not_run")
 
+  @parameterized.expand(range(10))
   def test_startup_time(self):
     start = time.monotonic()
     os.environ['PREPAREONLY'] = '1'

--- a/selfdrive/manager/test/test_manager.py
+++ b/selfdrive/manager/test/test_manager.py
@@ -41,7 +41,7 @@ class TestManager(unittest.TestCase):
     self.assertTrue(len(BLACKLIST_PROCS), "No blacklisted procs to test not_run")
 
   @parameterized.expand(range(10))
-  def test_startup_time(self):
+  def test_startup_time(self, index):
     start = time.monotonic()
     os.environ['PREPAREONLY'] = '1'
     manager.main()

--- a/selfdrive/manager/test/test_manager.py
+++ b/selfdrive/manager/test/test_manager.py
@@ -39,12 +39,11 @@ class TestManager(unittest.TestCase):
     self.assertTrue(len(BLACKLIST_PROCS), "No blacklisted procs to test not_run")
 
   def test_startup_time(self):
-    for _ in range(10):
-      start = time.monotonic()
-      os.environ['PREPAREONLY'] = '1'
-      manager.main()
-      t = time.monotonic() - start
-      assert t < MAX_STARTUP_TIME, f"startup took {t}s, expected <{MAX_STARTUP_TIME}s"
+    start = time.monotonic()
+    os.environ['PREPAREONLY'] = '1'
+    manager.main()
+    t = time.monotonic() - start
+    assert t < MAX_STARTUP_TIME, f"startup took {t}s, expected <{MAX_STARTUP_TIME}s"
 
   @unittest.skip("this test is flaky the way it's currently written, should be moved to test_onroad")
   def test_clean_exit(self):


### PR DESCRIPTION
if you run in a loop like this, the OP Prefix doesn't apply and can cause test independence issues, like:

https://jenkins.comma.life/blue/organizations/jenkins/openpilot/detail/master/98/pipeline/