### PR TITLE
make vipc and msgq  prefix paths easier to cleanup

### DIFF
--- a/common/prefix.py
+++ b/common/prefix.py
@@ -5,23 +5,21 @@ import uuid
 from typing import Optional
 
 from openpilot.common.params import Params
-from openpilot.system.hardware.hw import Paths
-from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
+from openpilot.system.hardware.hw import Paths, DEFAULT_DOWNLOAD_CACHE_ROOT
 
 class OpenpilotPrefix:
   def __init__(self, prefix: Optional[str] = None, clean_dirs_on_exit: bool = True, shared_download_cache: bool = False):
     self.prefix = prefix if prefix else str(uuid.uuid4().hex[0:15])
     self.msgq_path = os.path.join('/dev/shm', self.prefix)
+    self.vipc_path = os.path.join('/tmp', f"{self.prefix}")
     self.clean_dirs_on_exit = clean_dirs_on_exit
     self.shared_download_cache = shared_download_cache
 
   def __enter__(self):
     self.original_prefix = os.environ.get('OPENPILOT_PREFIX', None)
     os.environ['OPENPILOT_PREFIX'] = self.prefix
-    try:
-      os.mkdir(self.msgq_path)
-    except FileExistsError:
-      pass
+    os.makedirs(self.msgq_path, exist_ok=True)
+    os.makedirs(self.vipc_path, exist_ok=True)
     os.makedirs(Paths.log_root(), exist_ok=True)
 
     if self.shared_download_cache:
@@ -45,6 +43,7 @@ class OpenpilotPrefix:
     if os.path.exists(symlink_path):
       shutil.rmtree(os.path.realpath(symlink_path), ignore_errors=True)
       os.remove(symlink_path)
+    shutil.rmtree(self.msgq_path, ignore_errors=True)
     shutil.rmtree(self.msgq_path, ignore_errors=True)
     shutil.rmtree(Paths.log_root(), ignore_errors=True)
     if not os.environ.get("COMMA_CACHE", False):

--- a/common/prefix.py
+++ b/common/prefix.py
@@ -44,7 +44,7 @@ class OpenpilotPrefix:
       shutil.rmtree(os.path.realpath(symlink_path), ignore_errors=True)
       os.remove(symlink_path)
     shutil.rmtree(self.msgq_path, ignore_errors=True)
-    shutil.rmtree(self.msgq_path, ignore_errors=True)
+    shutil.rmtree(self.vipc_path, ignore_errors=True)
     shutil.rmtree(Paths.log_root(), ignore_errors=True)
     if not os.environ.get("COMMA_CACHE", False):
       shutil.rmtree(Paths.download_cache_root(), ignore_errors=True)

--- a/conftest.py
+++ b/conftest.py
@@ -63,8 +63,8 @@ def openpilot_class_fixture():
   os.environ.update(starting_env)
 
 
-@pytest.fixture(scope="class")
-def tici_setup_fixture(openpilot_function_fixture):
+@pytest.fixture(scope="function")
+def tici_setup_fixture():
   """Ensure a consistent state for tests on-device. Needs the openpilot function fixture to run first."""
   HARDWARE.initialize_hardware()
   HARDWARE.set_power_save(False)

--- a/conftest.py
+++ b/conftest.py
@@ -64,12 +64,11 @@ def openpilot_class_fixture():
 
 
 @pytest.fixture(scope="class")
-def tici_setup_fixture():
-  """Ensure a consistent state for tests on-device"""
+def tici_setup_fixture(openpilot_function_fixture):
+  """Ensure a consistent state for tests on-device. Needs the openpilot function fixture to run first."""
   HARDWARE.initialize_hardware()
   HARDWARE.set_power_save(False)
   os.system("pkill -9 -f athena")
-  os.system("rm /dev/shm/*")
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,7 @@ def openpilot_class_fixture():
 
 
 @pytest.fixture(scope="function")
-def tici_setup_fixture():
+def tici_setup_fixture(openpilot_function_fixture):
   """Ensure a consistent state for tests on-device. Needs the openpilot function fixture to run first."""
   HARDWARE.initialize_hardware()
   HARDWARE.set_power_save(False)


### PR DESCRIPTION
move vipc from

```/tmp/08a0a2f211af48d_visionipc_navd```\
to
```/tmp/08a0a2f211af48d/visionipc_navd```

so it can be cleaned up easier

lots of these weren't being cleaned up: 
![image](https://github.com/commaai/openpilot/assets/9648890/12195cea-0943-4b2d-9c8a-e88f0823140f)
