### PR TITLE
pytest: fix tici setup fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -63,13 +63,12 @@ def openpilot_class_fixture():
   os.environ.update(starting_env)
 
 
-@pytest.fixture(scope="class")
-def tici_setup_fixture():
-  """Ensure a consistent state for tests on-device"""
+@pytest.fixture(scope="function")
+def tici_setup_fixture(openpilot_function_fixture):
+  """Ensure a consistent state for tests on-device. Needs the openpilot function fixture to run first."""
   HARDWARE.initialize_hardware()
   HARDWARE.set_power_save(False)
   os.system("pkill -9 -f athena")
-  os.system("rm /dev/shm/*")
 
 
 @pytest.hookimpl(tryfirst=True)


### PR DESCRIPTION
- ensure we run this in the prefix
- shm is already cleaned up with the prefix
- run before every function