### PR TITLE
fix bootlog params copying from other prefix

### DIFF
--- a/selfdrive/manager/helpers.py
+++ b/selfdrive/manager/helpers.py
@@ -52,7 +52,7 @@ def write_onroad_params(started, params):
 def save_bootlog():
   # copy current params
   tmp = tempfile.mkdtemp()
-  params_dir = os.path.join(tmp, os.environ.get("OPENPILOT_PREFIX", "d"))
+  params_dir = os.path.join(tmp, os.environ.get("OPENPILOT_PREFIX", ""))
   shutil.copytree(Params().get_param_path(), params_dir, dirs_exist_ok=True)
 
   def fn(tmpdir):

--- a/selfdrive/manager/helpers.py
+++ b/selfdrive/manager/helpers.py
@@ -52,7 +52,7 @@ def write_onroad_params(started, params):
 def save_bootlog():
   # copy current params
   tmp = tempfile.mkdtemp()
-  params_dir = os.path.join(tmp, "d")
+  params_dir = os.path.join(tmp, os.environ.get("OPENPILOT_PREFIX", "d"))
   shutil.copytree(Params().get_param_path(), params_dir, dirs_exist_ok=True)
 
   def fn(tmpdir):

--- a/selfdrive/manager/helpers.py
+++ b/selfdrive/manager/helpers.py
@@ -1,9 +1,10 @@
+import errno
+import fcntl
 import os
 import sys
-import fcntl
-import errno
-import signal
+import pathlib
 import shutil
+import signal
 import subprocess
 import tempfile
 import threading
@@ -52,7 +53,8 @@ def write_onroad_params(started, params):
 def save_bootlog():
   # copy current params
   tmp = tempfile.mkdtemp()
-  params_dir = os.path.join(tmp, os.environ.get("OPENPILOT_PREFIX", ""))
+  params_dirname = pathlib.Path(Params().get_param_path()).name
+  params_dir = os.path.join(tmp, params_dirname)
   shutil.copytree(Params().get_param_path(), params_dir, dirs_exist_ok=True)
 
   def fn(tmpdir):

--- a/selfdrive/manager/helpers.py
+++ b/selfdrive/manager/helpers.py
@@ -52,7 +52,8 @@ def write_onroad_params(started, params):
 def save_bootlog():
   # copy current params
   tmp = tempfile.mkdtemp()
-  shutil.copytree(Params().get_param_path() + "/..", tmp, dirs_exist_ok=True)
+  params_dir = os.path.join(tmp, "d")
+  shutil.copytree(Params().get_param_path(), params_dir, dirs_exist_ok=True)
 
   def fn(tmpdir):
     env = os.environ.copy()


### PR DESCRIPTION
with the way this was written, it seems to be copying params from other prefixes, which causes the test_manager failures.