### PR TITLE
tici: fix params permissions on startup

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -15,6 +15,9 @@ function agnos_init {
   # set success flag for current boot slot
   sudo abctl --set_success
 
+  # ensure params permissions are set correctly
+  sudo chown -R comma:comma /data/params/
+
   # Check if AGNOS update is required
   if [ $(< /VERSION) != "$AGNOS_VERSION" ]; then
     AGNOS_PY="$DIR/system/hardware/tici/agnos.py"


### PR DESCRIPTION
agnos system services, like the power drop monitor, might write out params as root