### PR TITLE
RFC: move dbc definitions to new CarData dataclass

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -1,5 +1,6 @@
 # functions common among cars
 from collections import namedtuple
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import capnp
@@ -72,8 +73,9 @@ def scale_tire_stiffness(mass, wheelbase, center_to_front, tire_stiffness_factor
 
   return tire_stiffness_front, tire_stiffness_rear
 
+DbcDict = Dict[str, str]
 
-def dbc_dict(pt_dbc, radar_dbc, chassis_dbc=None, body_dbc=None) -> Dict[str, str]:
+def dbc_dict(pt_dbc, radar_dbc, chassis_dbc=None, body_dbc=None) -> DbcDict:
   return {'pt': pt_dbc, 'radar': radar_dbc, 'chassis': chassis_dbc, 'body': body_dbc}
 
 
@@ -236,3 +238,8 @@ class CanSignalRateCalculator:
     self.previous_value = current_value
 
     return self.rate
+
+
+@dataclass
+class CarData:
+  dbc: DbcDict

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -1,6 +1,6 @@
 # functions common among cars
 from collections import namedtuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 import capnp
@@ -242,4 +242,4 @@ class CanSignalRateCalculator:
 
 @dataclass
 class CarData:
-  dbc: DbcDict
+  dbc: DbcDict = field(init=False)

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -1,6 +1,6 @@
 # functions common among cars
 from collections import namedtuple
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import capnp
@@ -242,4 +242,4 @@ class CanSignalRateCalculator:
 
 @dataclass
 class CarData:
-  dbc: DbcDict = field(init=False)
+  dbc: Optional[DbcDict] = None

--- a/selfdrive/car/body/values.py
+++ b/selfdrive/car/body/values.py
@@ -44,7 +44,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
 
 CARS = {
   CAR.BODY: CarData(
-    dbc_dict('comma_body', None),
+    dbc=dbc_dict('comma_body', None),
   )
 }
 

--- a/selfdrive/car/body/values.py
+++ b/selfdrive/car/body/values.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 from typing import Dict
 
 from cereal import car
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import dbc_dict, CarData
 from openpilot.selfdrive.car.docs_definitions import CarInfo
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -42,6 +42,10 @@ FW_QUERY_CONFIG = FwQueryConfig(
 )
 
 
-DBC = {
-  CAR.BODY: dbc_dict('comma_body', None),
+CARS = {
+  CAR.BODY: CarData(
+    dbc_dict('comma_body', None),
+  )
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Union
 
 from cereal import car
 from panda.python import uds
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarHarness, CarInfo, CarParts
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
 
@@ -121,15 +121,36 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ],
 )
 
+COMMON_DBC = dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion')
 
-DBC = {
-  CAR.PACIFICA_2017_HYBRID: dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion'),
-  CAR.PACIFICA_2018: dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion'),
-  CAR.PACIFICA_2020: dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion'),
-  CAR.PACIFICA_2018_HYBRID: dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion'),
-  CAR.PACIFICA_2019_HYBRID: dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion'),
-  CAR.JEEP_GRAND_CHEROKEE: dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion'),
-  CAR.JEEP_GRAND_CHEROKEE_2019: dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion'),
-  CAR.RAM_1500: dbc_dict('chrysler_ram_dt_generated', None),
-  CAR.RAM_HD: dbc_dict('chrysler_ram_hd_generated', None),
+CARS = {
+  CAR.PACIFICA_2017_HYBRID: CarData(
+    COMMON_DBC,
+  ),
+  CAR.PACIFICA_2018: CarData(
+    COMMON_DBC,
+  ),
+  CAR.PACIFICA_2020: CarData(
+    COMMON_DBC,
+  ),
+  CAR.PACIFICA_2018_HYBRID: CarData(
+    COMMON_DBC,
+  ),
+  CAR.PACIFICA_2019_HYBRID: CarData(
+    COMMON_DBC,
+  ),
+  CAR.JEEP_GRAND_CHEROKEE: CarData(
+    COMMON_DBC,
+  ),
+  CAR.JEEP_GRAND_CHEROKEE_2019: CarData(
+    COMMON_DBC,
+  ),
+  CAR.RAM_1500: CarData(
+    dbc_dict('chrysler_ram_dt_generated', None),
+  ),
+  CAR.RAM_HD: CarData(
+    dbc_dict('chrysler_ram_hd_generated', None),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Union
 
 from cereal import car
 from panda.python import uds
-from openpilot.selfdrive.car import CarData, dbc_dict
+from openpilot.selfdrive.car import CarData, DbcDict, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarHarness, CarInfo, CarParts
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
 
@@ -123,33 +123,32 @@ FW_QUERY_CONFIG = FwQueryConfig(
 
 COMMON_DBC = dbc_dict('chrysler_pacifica_2017_hybrid_generated', 'chrysler_pacifica_2017_hybrid_private_fusion')
 
+
+@dataclass
+class ChryslerCarData(CarData):
+  dbc: DbcDict = field(default_factory=lambda: COMMON_DBC)
+
+
 CARS = {
-  CAR.PACIFICA_2017_HYBRID: CarData(
-    COMMON_DBC,
+  CAR.PACIFICA_2017_HYBRID: ChryslerCarData(
   ),
-  CAR.PACIFICA_2018: CarData(
-    COMMON_DBC,
+  CAR.PACIFICA_2018: ChryslerCarData(
   ),
-  CAR.PACIFICA_2020: CarData(
-    COMMON_DBC,
+  CAR.PACIFICA_2020: ChryslerCarData(
   ),
-  CAR.PACIFICA_2018_HYBRID: CarData(
-    COMMON_DBC,
+  CAR.PACIFICA_2018_HYBRID: ChryslerCarData(
   ),
-  CAR.PACIFICA_2019_HYBRID: CarData(
-    COMMON_DBC,
+  CAR.PACIFICA_2019_HYBRID: ChryslerCarData(
   ),
-  CAR.JEEP_GRAND_CHEROKEE: CarData(
-    COMMON_DBC,
+  CAR.JEEP_GRAND_CHEROKEE: ChryslerCarData(
   ),
-  CAR.JEEP_GRAND_CHEROKEE_2019: CarData(
-    COMMON_DBC,
+  CAR.JEEP_GRAND_CHEROKEE_2019: ChryslerCarData(
   ),
-  CAR.RAM_1500: CarData(
-    dbc_dict('chrysler_ram_dt_generated', None),
+  CAR.RAM_1500: ChryslerCarData(
+    dbc=dbc_dict('chrysler_ram_dt_generated', None),
   ),
-  CAR.RAM_HD: CarData(
-    dbc_dict('chrysler_ram_hd_generated', None),
+  CAR.RAM_HD: ChryslerCarData(
+    dbc=dbc_dict('chrysler_ram_hd_generated', None),
   ),
 }
 

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -61,31 +61,35 @@ class RADAR:
 RADAR_DBC = dbc_dict("ford_lincoln_base_pt", RADAR.DELPHI_ESR)
 NO_RADAR_DBC = dbc_dict("ford_lincoln_base_pt", None)
 
+
+@dataclass
+class FordCarData(CarData):
+  radar_enabled: bool = True
+
+  def __post_init__(self):
+    self.dbc = RADAR_DBC if self.radar_enabled else NO_RADAR_DBC
+
+
 CARS = {
-  CAR.BRONCO_SPORT_MK1: CarData(
-    RADAR_DBC,
+  CAR.BRONCO_SPORT_MK1: FordCarData(
   ),
-  CAR.ESCAPE_MK4: CarData(
-    RADAR_DBC,
+  CAR.ESCAPE_MK4: FordCarData(
   ),
-  CAR.EXPLORER_MK6: CarData(
-    RADAR_DBC,
+  CAR.EXPLORER_MK6: FordCarData(
   ),
-  CAR.FOCUS_MK4: CarData(
-    RADAR_DBC,
+  CAR.FOCUS_MK4: FordCarData(
   ),
-  CAR.MAVERICK_MK1: CarData(
-    RADAR_DBC,
+  CAR.MAVERICK_MK1: FordCarData(
   ),
   # F-150 radar is not yet supported
-  CAR.F_150_MK14: CarData(
-    NO_RADAR_DBC,
+  CAR.F_150_MK14: FordCarData(
+    radar_enabled=False,
   ),
-  CAR.F_150_LIGHTNING_MK1: CarData(
-    NO_RADAR_DBC,
+  CAR.F_150_LIGHTNING_MK1: FordCarData(
+    radar_enabled=False,
   ),
-  CAR.MUSTANG_MACH_E_MK1: CarData(
-    NO_RADAR_DBC,
+  CAR.MUSTANG_MACH_E_MK1: FordCarData(
+    radar_enabled=False,
   ),
 }
 

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -1,10 +1,9 @@
-from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, StrEnum
 from typing import Dict, List, Union
 
 from cereal import car
-from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
+from openpilot.selfdrive.car import AngleRateLimit, CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
                                                      Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
@@ -59,13 +58,38 @@ class RADAR:
   DELPHI_MRR = 'FORD_CADS'
 
 
-DBC: Dict[str, Dict[str, str]] = defaultdict(lambda: dbc_dict("ford_lincoln_base_pt", RADAR.DELPHI_MRR))
+RADAR_DBC = dbc_dict("ford_lincoln_base_pt", RADAR.DELPHI_ESR)
+NO_RADAR_DBC = dbc_dict("ford_lincoln_base_pt", None)
 
-# F-150 radar is not yet supported
-DBC[CAR.F_150_MK14] = dbc_dict("ford_lincoln_base_pt", None)
-DBC[CAR.F_150_LIGHTNING_MK1] = dbc_dict("ford_lincoln_base_pt", None)
-DBC[CAR.MUSTANG_MACH_E_MK1] = dbc_dict("ford_lincoln_base_pt", None)
+CARS = {
+  CAR.BRONCO_SPORT_MK1: CarData(
+    RADAR_DBC,
+  ),
+  CAR.ESCAPE_MK4: CarData(
+    RADAR_DBC,
+  ),
+  CAR.EXPLORER_MK6: CarData(
+    RADAR_DBC,
+  ),
+  CAR.FOCUS_MK4: CarData(
+    RADAR_DBC,
+  ),
+  CAR.MAVERICK_MK1: CarData(
+    RADAR_DBC,
+  ),
+  # F-150 radar is not yet supported
+  CAR.F_150_MK14: CarData(
+    NO_RADAR_DBC,
+  ),
+  CAR.F_150_LIGHTNING_MK1: CarData(
+    NO_RADAR_DBC,
+  ),
+  CAR.MUSTANG_MACH_E_MK1: CarData(
+    NO_RADAR_DBC,
+  ),
+}
 
+DBC = {c: CARS[c].dbc for c in CARS}
 
 class Footnote(Enum):
   FOCUS = CarFootnote(

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -1,10 +1,9 @@
-from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, StrEnum
 from typing import Dict, List, Union
 
 from cereal import car
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -181,7 +180,54 @@ FW_QUERY_CONFIG = FwQueryConfig(
   extra_ecus=[(Ecu.fwdCamera, 0x24b, None)],
 )
 
-DBC: Dict[str, Dict[str, str]] = defaultdict(lambda: dbc_dict('gm_global_a_powertrain_generated', 'gm_global_a_object', chassis_dbc='gm_global_a_chassis'))
+COMMON_DBC = dbc_dict('gm_global_a_powertrain_generated', 'gm_global_a_object', chassis_dbc='gm_global_a_chassis')
+
+CARS = {
+  CAR.HOLDEN_ASTRA: CarData(
+    COMMON_DBC,
+  ),
+  CAR.VOLT: CarData(
+    COMMON_DBC,
+  ),
+  CAR.CADILLAC_ATS: CarData(
+    COMMON_DBC,
+  ),
+  CAR.MALIBU: CarData(
+    COMMON_DBC,
+  ),
+  CAR.ACADIA: CarData(
+    COMMON_DBC,
+  ),
+  CAR.BUICK_LACROSSE: CarData(
+    COMMON_DBC,
+  ),
+  CAR.BUICK_REGAL: CarData(
+    COMMON_DBC,
+  ),
+  CAR.ESCALADE: CarData(
+    COMMON_DBC,
+  ),
+  CAR.ESCALADE_ESV: CarData(
+    COMMON_DBC,
+  ),
+  CAR.ESCALADE_ESV_2019: CarData(
+    COMMON_DBC,
+  ),
+  CAR.BOLT_EUV: CarData(
+    COMMON_DBC,
+  ),
+  CAR.SILVERADO: CarData(
+    COMMON_DBC,
+  ),
+  CAR.EQUINOX: CarData(
+    COMMON_DBC,
+  ),
+  CAR.TRAILBLAZER: CarData(
+    COMMON_DBC,
+  ),
+}
+
+DBC = {c: CARS[c].dbc for c in CARS}
 
 EV_CAR = {CAR.VOLT, CAR.BOLT_EUV}
 

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, StrEnum
 from typing import Dict, List, Union
 
 from cereal import car
-from openpilot.selfdrive.car import CarData, dbc_dict
+from openpilot.selfdrive.car import CarData, DbcDict, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -182,48 +182,40 @@ FW_QUERY_CONFIG = FwQueryConfig(
 
 COMMON_DBC = dbc_dict('gm_global_a_powertrain_generated', 'gm_global_a_object', chassis_dbc='gm_global_a_chassis')
 
+
+@dataclass
+class GMCarData(CarData):
+  dbc: DbcDict = field(default_factory=lambda: COMMON_DBC)
+
+
 CARS = {
-  CAR.HOLDEN_ASTRA: CarData(
-    COMMON_DBC,
+  CAR.HOLDEN_ASTRA: GMCarData(
   ),
-  CAR.VOLT: CarData(
-    COMMON_DBC,
+  CAR.VOLT: GMCarData(
   ),
-  CAR.CADILLAC_ATS: CarData(
-    COMMON_DBC,
+  CAR.CADILLAC_ATS: GMCarData(
   ),
-  CAR.MALIBU: CarData(
-    COMMON_DBC,
+  CAR.MALIBU: GMCarData(
   ),
-  CAR.ACADIA: CarData(
-    COMMON_DBC,
+  CAR.ACADIA: GMCarData(
   ),
-  CAR.BUICK_LACROSSE: CarData(
-    COMMON_DBC,
+  CAR.BUICK_LACROSSE: GMCarData(
   ),
-  CAR.BUICK_REGAL: CarData(
-    COMMON_DBC,
+  CAR.BUICK_REGAL: GMCarData(
   ),
-  CAR.ESCALADE: CarData(
-    COMMON_DBC,
+  CAR.ESCALADE: GMCarData(
   ),
-  CAR.ESCALADE_ESV: CarData(
-    COMMON_DBC,
+  CAR.ESCALADE_ESV: GMCarData(
   ),
-  CAR.ESCALADE_ESV_2019: CarData(
-    COMMON_DBC,
+  CAR.ESCALADE_ESV_2019: GMCarData(
   ),
-  CAR.BOLT_EUV: CarData(
-    COMMON_DBC,
+  CAR.BOLT_EUV: GMCarData(
   ),
-  CAR.SILVERADO: CarData(
-    COMMON_DBC,
+  CAR.SILVERADO: GMCarData(
   ),
-  CAR.EQUINOX: CarData(
-    COMMON_DBC,
+  CAR.EQUINOX: GMCarData(
   ),
-  CAR.TRAILBLAZER: CarData(
-    COMMON_DBC,
+  CAR.TRAILBLAZER: GMCarData(
   ),
 }
 

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from panda.python import uds
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16
 
@@ -214,32 +214,79 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ],
 )
 
-
-DBC = {
-  CAR.ACCORD: dbc_dict('honda_accord_2018_can_generated', None),
-  CAR.ACCORDH: dbc_dict('honda_accord_2018_can_generated', None),
-  CAR.ACURA_ILX: dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.ACURA_RDX: dbc_dict('acura_rdx_2018_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.ACURA_RDX_3G: dbc_dict('acura_rdx_2020_can_generated', None),
-  CAR.CIVIC: dbc_dict('honda_civic_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.CIVIC_BOSCH: dbc_dict('honda_civic_hatchback_ex_2017_can_generated', None),
-  CAR.CIVIC_BOSCH_DIESEL: dbc_dict('honda_accord_2018_can_generated', None),
-  CAR.CRV: dbc_dict('honda_crv_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.CRV_5G: dbc_dict('honda_crv_ex_2017_can_generated', None, body_dbc='honda_crv_ex_2017_body_generated'),
-  CAR.CRV_EU: dbc_dict('honda_crv_executive_2016_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.CRV_HYBRID: dbc_dict('honda_accord_2018_can_generated', None),
-  CAR.FIT: dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.FREED: dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.HRV: dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.HRV_3G: dbc_dict('honda_civic_ex_2022_can_generated', None),
-  CAR.ODYSSEY: dbc_dict('honda_odyssey_exl_2018_generated', 'acura_ilx_2016_nidec'),
-  CAR.ODYSSEY_CHN: dbc_dict('honda_odyssey_extreme_edition_2018_china_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.PILOT: dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.RIDGELINE: dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
-  CAR.INSIGHT: dbc_dict('honda_insight_ex_2019_can_generated', None),
-  CAR.HONDA_E: dbc_dict('acura_rdx_2020_can_generated', None),
-  CAR.CIVIC_2022: dbc_dict('honda_civic_ex_2022_can_generated', None),
+CARS = {
+  CAR.ACCORD: CarData(
+    dbc_dict('honda_accord_2018_can_generated', None),
+  ),
+  CAR.ACCORDH: CarData(
+    dbc_dict('honda_accord_2018_can_generated', None),
+  ),
+  CAR.ACURA_ILX: CarData(
+    dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.ACURA_RDX: CarData(
+    dbc_dict('acura_rdx_2018_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.ACURA_RDX_3G: CarData(
+    dbc_dict('acura_rdx_2020_can_generated', None),
+  ),
+  CAR.CIVIC: CarData(
+    dbc_dict('honda_civic_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.CIVIC_BOSCH: CarData(
+    dbc_dict('honda_civic_hatchback_ex_2017_can_generated', None),
+  ),
+  CAR.CIVIC_BOSCH_DIESEL: CarData(
+    dbc_dict('honda_accord_2018_can_generated', None),
+  ),
+  CAR.CRV: CarData(
+    dbc_dict('honda_crv_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.CRV_5G: CarData(
+    dbc_dict('honda_crv_ex_2017_can_generated', None, body_dbc='honda_crv_ex_2017_body_generated'),
+  ),
+  CAR.CRV_EU: CarData(
+    dbc_dict('honda_crv_executive_2016_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.CRV_HYBRID: CarData(
+    dbc_dict('honda_accord_2018_can_generated', None),
+  ),
+  CAR.FIT: CarData(
+    dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.FREED: CarData(
+    dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.HRV: CarData(
+    dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.HRV_3G: CarData(
+    dbc_dict('honda_civic_ex_2022_can_generated', None),
+  ),
+  CAR.ODYSSEY: CarData(
+    dbc_dict('honda_odyssey_exl_2018_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.ODYSSEY_CHN: CarData(
+    dbc_dict('honda_odyssey_extreme_edition_2018_china_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.PILOT: CarData(
+    dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.RIDGELINE: CarData(
+    dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
+  ),
+  CAR.INSIGHT: CarData(
+    dbc_dict('honda_insight_ex_2019_can_generated', None),
+  ),
+  CAR.HONDA_E: CarData(
+    dbc_dict('acura_rdx_2020_can_generated', None),
+  ),
+  CAR.CIVIC_2022: CarData(
+    dbc_dict('honda_civic_ex_2022_can_generated', None),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}
 
 STEER_THRESHOLD = {
   # default is 1200, overrides go here

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 from cereal import car
 from panda.python import uds
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
 
@@ -567,70 +567,202 @@ UNSUPPORTED_LONGITUDINAL_CAR = LEGACY_SAFETY_MODE_CAR | {CAR.KIA_NIRO_PHEV, CAR.
 
 # If 0x500 is present on bus 1 it probably has a Mando radar outputting radar points.
 # If no points are outputted by default it might be possible to turn it on using  selfdrive/debug/hyundai_enable_radar_points.py
-DBC = {
-  CAR.AZERA_6TH_GEN: dbc_dict('hyundai_kia_generic', None),
-  CAR.AZERA_HEV_6TH_GEN: dbc_dict('hyundai_kia_generic', None),
-  CAR.ELANTRA: dbc_dict('hyundai_kia_generic', None),
-  CAR.ELANTRA_GT_I30: dbc_dict('hyundai_kia_generic', None),
-  CAR.ELANTRA_2021: dbc_dict('hyundai_kia_generic', None),
-  CAR.ELANTRA_HEV_2021: dbc_dict('hyundai_kia_generic', None),
-  CAR.GENESIS_G70: dbc_dict('hyundai_kia_generic', None),
-  CAR.GENESIS_G70_2020: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.GENESIS_G80: dbc_dict('hyundai_kia_generic', None),
-  CAR.GENESIS_G90: dbc_dict('hyundai_kia_generic', None),
-  CAR.HYUNDAI_GENESIS: dbc_dict('hyundai_kia_generic', None),
-  CAR.IONIQ_PHEV_2019: dbc_dict('hyundai_kia_generic', None),
-  CAR.IONIQ_PHEV: dbc_dict('hyundai_kia_generic', None),
-  CAR.IONIQ_EV_2020: dbc_dict('hyundai_kia_generic', None),
-  CAR.IONIQ_EV_LTD: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.IONIQ: dbc_dict('hyundai_kia_generic', None),
-  CAR.IONIQ_HEV_2022: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_FORTE: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_K5_2021: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_K5_HEV_2020: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.KIA_NIRO_EV: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.KIA_NIRO_PHEV: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.KIA_NIRO_HEV_2021: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_OPTIMA_G4: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_OPTIMA_G4_FL: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_OPTIMA_H: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_OPTIMA_H_G4_FL: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_SELTOS: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_SORENTO: dbc_dict('hyundai_kia_generic', None), # Has 0x5XX messages, but different format
-  CAR.KIA_STINGER: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_STINGER_2022: dbc_dict('hyundai_kia_generic', None),
-  CAR.KONA: dbc_dict('hyundai_kia_generic', None),
-  CAR.KONA_EV: dbc_dict('hyundai_kia_generic', None),
-  CAR.KONA_EV_2022: dbc_dict('hyundai_kia_generic', None),
-  CAR.KONA_HEV: dbc_dict('hyundai_kia_generic', None),
-  CAR.SANTA_FE: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.SANTA_FE_2022: dbc_dict('hyundai_kia_generic', None),
-  CAR.SANTA_FE_HEV_2022: dbc_dict('hyundai_kia_generic', None),
-  CAR.SANTA_FE_PHEV_2022: dbc_dict('hyundai_kia_generic', None),
-  CAR.SONATA: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.SONATA_LF: dbc_dict('hyundai_kia_generic', None), # Has 0x5XX messages, but different format
-  CAR.TUCSON: dbc_dict('hyundai_kia_generic', None),
-  CAR.PALISADE: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.VELOSTER: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_CEED: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_EV6: dbc_dict('hyundai_canfd', None),
-  CAR.SONATA_HYBRID: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.TUCSON_4TH_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.IONIQ_5: dbc_dict('hyundai_canfd', None),
-  CAR.IONIQ_6: dbc_dict('hyundai_canfd', None),
-  CAR.SANTA_CRUZ_1ST_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.KIA_SPORTAGE_5TH_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.GENESIS_GV70_1ST_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.GENESIS_GV60_EV_1ST_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.KIA_SORENTO_4TH_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.KIA_NIRO_HEV_2ND_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.KIA_NIRO_EV_2ND_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.GENESIS_GV80: dbc_dict('hyundai_canfd', None),
-  CAR.KIA_CARNIVAL_4TH_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.KIA_SORENTO_HEV_4TH_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.KONA_EV_2ND_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.KIA_K8_HEV_1ST_GEN: dbc_dict('hyundai_canfd', None),
-  CAR.CUSTIN_1ST_GEN: dbc_dict('hyundai_kia_generic', None),
-  CAR.KIA_NIRO_PHEV_2022: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
-  CAR.STARIA_4TH_GEN: dbc_dict('hyundai_canfd', None),
+CARS = {
+  CAR.AZERA_6TH_GEN: CarData(
+    dbc_dict('hyundai_kia_generic', None),
+  ),
+  CAR.AZERA_HEV_6TH_GEN: CarData(
+    dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.ELANTRA: CarData(
+    dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.ELANTRA_GT_I30: CarData(
+    dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.ELANTRA_2021: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.ELANTRA_HEV_2021: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.GENESIS_G70: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.GENESIS_G70_2020: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.GENESIS_G80: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.GENESIS_G90: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.HYUNDAI_GENESIS: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.IONIQ_PHEV_2019: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.IONIQ_PHEV: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.IONIQ_EV_2020: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.IONIQ_EV_LTD: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.IONIQ: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.IONIQ_HEV_2022: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_FORTE: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_K5_2021: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_K5_HEV_2020: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.KIA_NIRO_EV: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.KIA_NIRO_PHEV: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.KIA_NIRO_HEV_2021: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_OPTIMA_G4: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_OPTIMA_G4_FL: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_OPTIMA_H: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_OPTIMA_H_G4_FL: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_SELTOS: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_SORENTO: CarData(
+   dbc_dict('hyundai_kia_generic', None), # Has 0x5XX messages, but different format
+  ),
+  CAR.KIA_STINGER: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_STINGER_2022: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KONA: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KONA_EV: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KONA_EV_2022: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KONA_HEV: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.SANTA_FE: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.SANTA_FE_2022: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.SANTA_FE_HEV_2022: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.SANTA_FE_PHEV_2022: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.SONATA: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.SONATA_LF: CarData(
+   dbc_dict('hyundai_kia_generic', None), # Has 0x5XX messages, but different format
+  ),
+  CAR.TUCSON: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.PALISADE: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.VELOSTER: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_CEED: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_EV6: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.SONATA_HYBRID: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.TUCSON_4TH_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.IONIQ_5: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.IONIQ_6: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.SANTA_CRUZ_1ST_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KIA_SPORTAGE_5TH_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.GENESIS_GV70_1ST_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.GENESIS_GV60_EV_1ST_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KIA_SORENTO_4TH_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KIA_NIRO_HEV_2ND_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KIA_NIRO_EV_2ND_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.GENESIS_GV80: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KIA_CARNIVAL_4TH_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KIA_SORENTO_HEV_4TH_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KONA_EV_2ND_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.KIA_K8_HEV_1ST_GEN: CarData(
+   dbc_dict('hyundai_canfd', None)
+  ),
+  CAR.CUSTIN_1ST_GEN: CarData(
+   dbc_dict('hyundai_kia_generic', None)
+  ),
+  CAR.KIA_NIRO_PHEV_2022: CarData(
+   dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated')
+  ),
+  CAR.STARIA_4TH_GEN: CarData(
+   dbc_dict('hyundai_canfd', None),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}

--- a/selfdrive/car/mazda/values.py
+++ b/selfdrive/car/mazda/values.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import Dict, List, Union
 
 from cereal import car
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarHarness, CarInfo, CarParts
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -77,14 +77,28 @@ FW_QUERY_CONFIG = FwQueryConfig(
 )
 
 
-DBC = {
-  CAR.CX5: dbc_dict('mazda_2017', None),
-  CAR.CX9: dbc_dict('mazda_2017', None),
-  CAR.MAZDA3: dbc_dict('mazda_2017', None),
-  CAR.MAZDA6: dbc_dict('mazda_2017', None),
-  CAR.CX9_2021: dbc_dict('mazda_2017', None),
-  CAR.CX5_2022: dbc_dict('mazda_2017', None),
+CARS = {
+  CAR.CX5: CarData(
+    dbc_dict('mazda_2017', None),
+  ),
+  CAR.CX9: CarData(
+    dbc_dict('mazda_2017', None),
+  ),
+  CAR.MAZDA3: CarData(
+    dbc_dict('mazda_2017', None),
+  ),
+  CAR.MAZDA6: CarData(
+    dbc_dict('mazda_2017', None),
+  ),
+  CAR.CX9_2021: CarData(
+    dbc_dict('mazda_2017', None),
+  ),
+  CAR.CX5_2022: CarData(
+    dbc_dict('mazda_2017', None),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}
 
 # Gen 1 hardware: same CAN messages and same camera
 GEN1 = {CAR.CX5, CAR.CX9, CAR.CX9_2021, CAR.MAZDA3, CAR.MAZDA6, CAR.CX5_2022}

--- a/selfdrive/car/nissan/values.py
+++ b/selfdrive/car/nissan/values.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Union
 
 from cereal import car
 from panda.python import uds
-from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
+from openpilot.selfdrive.car import AngleRateLimit, CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarInfo, CarHarness, CarParts
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -90,10 +90,22 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ]],
 )
 
-DBC = {
-  CAR.XTRAIL: dbc_dict('nissan_x_trail_2017_generated', None),
-  CAR.LEAF: dbc_dict('nissan_leaf_2018_generated', None),
-  CAR.LEAF_IC: dbc_dict('nissan_leaf_2018_generated', None),
-  CAR.ROGUE: dbc_dict('nissan_x_trail_2017_generated', None),
-  CAR.ALTIMA: dbc_dict('nissan_x_trail_2017_generated', None),
+CARS = {
+  CAR.XTRAIL: CarData(
+    dbc_dict('nissan_x_trail_2017_generated', None),
+  ),
+  CAR.LEAF: CarData(
+    dbc_dict('nissan_leaf_2018_generated', None),
+  ),
+  CAR.LEAF_IC: CarData(
+    dbc_dict('nissan_leaf_2018_generated', None),
+  ),
+  CAR.ROGUE: CarData(
+    dbc_dict('nissan_x_trail_2017_generated', None),
+  ),
+  CAR.ALTIMA: CarData(
+    dbc_dict('nissan_x_trail_2017_generated', None),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Union
 
 from cereal import car
 from panda.python import uds
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Tool, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16
 
@@ -186,20 +186,52 @@ FW_QUERY_CONFIG = FwQueryConfig(
   }
 )
 
-DBC = {
-  CAR.ASCENT: dbc_dict('subaru_global_2017_generated', None),
-  CAR.ASCENT_2023: dbc_dict('subaru_global_2017_generated', None),
-  CAR.IMPREZA: dbc_dict('subaru_global_2017_generated', None),
-  CAR.IMPREZA_2020: dbc_dict('subaru_global_2017_generated', None),
-  CAR.FORESTER: dbc_dict('subaru_global_2017_generated', None),
-  CAR.FORESTER_2022: dbc_dict('subaru_global_2017_generated', None),
-  CAR.OUTBACK: dbc_dict('subaru_global_2017_generated', None),
-  CAR.FORESTER_HYBRID: dbc_dict('subaru_global_2020_hybrid_generated', None),
-  CAR.CROSSTREK_HYBRID: dbc_dict('subaru_global_2020_hybrid_generated', None),
-  CAR.OUTBACK_2023: dbc_dict('subaru_global_2017_generated', None),
-  CAR.LEGACY: dbc_dict('subaru_global_2017_generated', None),
-  CAR.FORESTER_PREGLOBAL: dbc_dict('subaru_forester_2017_generated', None),
-  CAR.LEGACY_PREGLOBAL: dbc_dict('subaru_outback_2015_generated', None),
-  CAR.OUTBACK_PREGLOBAL: dbc_dict('subaru_outback_2015_generated', None),
-  CAR.OUTBACK_PREGLOBAL_2018: dbc_dict('subaru_outback_2019_generated', None),
+CARS = {
+  CAR.ASCENT: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.ASCENT_2023: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.IMPREZA: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.IMPREZA_2020: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.FORESTER: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.FORESTER_2022: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.OUTBACK: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.FORESTER_HYBRID: CarData(
+    dbc_dict('subaru_global_2020_hybrid_generated', None),
+  ),
+  CAR.CROSSTREK_HYBRID: CarData(
+    dbc_dict('subaru_global_2020_hybrid_generated', None),
+  ),
+  CAR.OUTBACK_2023: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.LEGACY: CarData(
+    dbc_dict('subaru_global_2017_generated', None),
+  ),
+  CAR.FORESTER_PREGLOBAL: CarData(
+    dbc_dict('subaru_forester_2017_generated', None),
+  ),
+  CAR.LEGACY_PREGLOBAL: CarData(
+    dbc_dict('subaru_outback_2015_generated', None),
+  ),
+  CAR.OUTBACK_PREGLOBAL: CarData(
+    dbc_dict('subaru_outback_2015_generated', None),
+  ),
+  CAR.OUTBACK_PREGLOBAL_2018: CarData(
+    dbc_dict('subaru_outback_2019_generated', None),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}

--- a/selfdrive/car/tesla/values.py
+++ b/selfdrive/car/tesla/values.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import Dict, List, Union
 
 from cereal import car
-from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
+from openpilot.selfdrive.car import AngleRateLimit, CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarInfo
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -22,11 +22,16 @@ CAR_INFO: Dict[str, Union[CarInfo, List[CarInfo]]] = {
   CAR.AP2_MODELS: CarInfo("Tesla AP2 Model S", "All"),
 }
 
-
-DBC = {
-  CAR.AP2_MODELS: dbc_dict('tesla_powertrain', 'tesla_radar', chassis_dbc='tesla_can'),
-  CAR.AP1_MODELS: dbc_dict('tesla_powertrain', 'tesla_radar', chassis_dbc='tesla_can'),
+CARS = {
+  CAR.AP1_MODELS: CarData(
+    dbc_dict('tesla_powertrain', 'tesla_radar', chassis_dbc='tesla_can'),
+  ),
+  CAR.AP2_MODELS: CarData(
+    dbc_dict('tesla_powertrain', 'tesla_radar', chassis_dbc='tesla_can'),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Set, Union
 
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
+from openpilot.selfdrive.car import AngleRateLimit, CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarInfo, Column, CarParts, CarHarness
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -440,42 +440,112 @@ FW_QUERY_CONFIG = FwQueryConfig(
 
 STEER_THRESHOLD = 100
 
-DBC = {
-  CAR.RAV4H: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.RAV4: dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
-  CAR.PRIUS: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
-  CAR.PRIUS_V: dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
-  CAR.COROLLA: dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_LC_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.LEXUS_RC: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_RX: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_RX_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.CHR: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
-  CAR.CHR_TSS2: dbc_dict('toyota_nodsu_pt_generated', None),
-  CAR.CAMRY: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
-  CAR.CAMRY_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.HIGHLANDER: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.HIGHLANDER_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.AVALON: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.AVALON_2019: dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
-  CAR.AVALON_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.RAV4_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.RAV4_TSS2_2022: dbc_dict('toyota_nodsu_pt_generated', None),
-  CAR.RAV4_TSS2_2023: dbc_dict('toyota_nodsu_pt_generated', None),
-  CAR.COROLLA_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.LEXUS_ES: dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_ES_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.SIENNA: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_IS: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_IS_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.LEXUS_CTH: dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_NX: dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
-  CAR.LEXUS_NX_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.PRIUS_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.MIRAI: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.ALPHARD_TSS2: dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
-  CAR.LEXUS_GS_F: dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
+CARS = {
+  CAR.RAV4H: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.RAV4: CarData(
+    dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
+  ),
+  CAR.PRIUS: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
+  ),
+  CAR.PRIUS_V: CarData(
+    dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
+  ),
+  CAR.COROLLA: CarData(
+    dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_LC_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.LEXUS_RC: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_RX: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_RX_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.CHR: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
+  ),
+  CAR.CHR_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', None),
+  ),
+  CAR.CAMRY: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
+  ),
+  CAR.CAMRY_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.HIGHLANDER: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.HIGHLANDER_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.AVALON: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.AVALON_2019: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_adas'),
+  ),
+  CAR.AVALON_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.RAV4_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.RAV4_TSS2_2022: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', None),
+  ),
+  CAR.RAV4_TSS2_2023: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', None),
+  ),
+  CAR.COROLLA_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.LEXUS_ES: CarData(
+    dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_ES_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.SIENNA: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_IS: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_IS_TSS2:CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.LEXUS_CTH: CarData(
+    dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_NX: CarData(
+    dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
+  ),
+  CAR.LEXUS_NX_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.PRIUS_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.MIRAI: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.ALPHARD_TSS2: CarData(
+    dbc_dict('toyota_nodsu_pt_generated', 'toyota_tss2_adas'),
+  ),
+  CAR.LEXUS_GS_F: CarData(
+    dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
+  ),
 }
+
+DBC = {c: CARS[c].dbc for c in CARS}
 
 # These cars have non-standard EPS torque scale factors. All others are 73
 EPS_SCALE = defaultdict(lambda: 73, {CAR.PRIUS: 66, CAR.COROLLA: 88, CAR.LEXUS_IS: 77, CAR.LEXUS_RC: 77, CAR.LEXUS_CTH: 100, CAR.PRIUS_V: 100})

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, IntFlag, StrEnum
 from typing import Dict, List, Union
@@ -6,7 +6,7 @@ from typing import Dict, List, Union
 from cereal import car
 from panda.python import uds
 from opendbc.can.can_define import CANDefine
-from openpilot.selfdrive.car import dbc_dict
+from openpilot.selfdrive.car import CarData, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
                                            Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
@@ -151,10 +151,94 @@ class CAR(StrEnum):
 PQ_CARS = {CAR.PASSAT_NMS, CAR.SHARAN_MK2}
 
 
-DBC: Dict[str, Dict[str, str]] = defaultdict(lambda: dbc_dict("vw_mqb_2010", None))
-for car_type in PQ_CARS:
-  DBC[car_type] = dbc_dict("vw_golf_mk4", None)
+MQB_DBC = dbc_dict("vw_mqb_2010", None)
+PQ_DBC = dbc_dict("vw_golf_mk4", None)
 
+CARS = {
+  CAR.ARTEON_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.ATLAS_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.CRAFTER_MK2: CarData(
+    MQB_DBC
+  ),
+  CAR.GOLF_MK7: CarData(
+    MQB_DBC
+  ),
+  CAR.JETTA_MK7: CarData(
+    MQB_DBC
+  ),
+  CAR.PASSAT_MK8: CarData(
+    MQB_DBC
+  ),
+  CAR.POLO_MK6: CarData(
+    MQB_DBC
+  ),
+  CAR.TAOS_MK1 : CarData(
+    MQB_DBC
+  ),
+  CAR.TCROSS_MK1 : CarData(
+    MQB_DBC
+  ),
+  CAR.TIGUAN_MK2 : CarData(
+    MQB_DBC
+  ),
+  CAR.TOURAN_MK2 : CarData(
+    MQB_DBC
+  ),
+  CAR.TRANSPORTER_T61: CarData(
+    MQB_DBC
+  ),
+  CAR.TROC_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.AUDI_A3_MK3: CarData(
+    MQB_DBC
+  ),
+  CAR.AUDI_Q2_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.AUDI_Q3_MK2: CarData(
+    MQB_DBC
+  ),
+  CAR.SEAT_ATECA_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.SEAT_LEON_MK3: CarData(
+    MQB_DBC
+  ),
+  CAR.SKODA_FABIA_MK4: CarData(
+    MQB_DBC
+  ),
+  CAR.SKODA_KAMIQ_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.SKODA_KAROQ_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.SKODA_KODIAQ_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.SKODA_SCALA_MK1: CarData(
+    MQB_DBC
+  ),
+  CAR.SKODA_SUPERB_MK3 : CarData(
+    MQB_DBC
+  ),
+  CAR.SKODA_OCTAVIA_MK3: CarData(
+    MQB_DBC
+  ),
+  CAR.PASSAT_NMS: CarData(
+    PQ_DBC
+  ),
+  CAR.SHARAN_MK2 : CarData(
+    PQ_DBC
+  ),
+}
+
+DBC = {c: CARS[c].dbc for c in CARS}
 
 class Footnote(Enum):
   KAMIQ = CarFootnote(

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -154,87 +154,71 @@ PQ_CARS = {CAR.PASSAT_NMS, CAR.SHARAN_MK2}
 MQB_DBC = dbc_dict("vw_mqb_2010", None)
 PQ_DBC = dbc_dict("vw_golf_mk4", None)
 
+
+@dataclass
+class VolkswagenCarData(CarData):
+  is_pq: bool = False
+
+  def __post_init__(self):
+    self.dbc = PQ_DBC if self.is_pq else MQB_DBC
+
+
 CARS = {
-  CAR.ARTEON_MK1: CarData(
-    MQB_DBC
+  CAR.ARTEON_MK1: VolkswagenCarData(
   ),
-  CAR.ATLAS_MK1: CarData(
-    MQB_DBC
+  CAR.ATLAS_MK1: VolkswagenCarData(
   ),
-  CAR.CRAFTER_MK2: CarData(
-    MQB_DBC
+  CAR.CRAFTER_MK2: VolkswagenCarData(
   ),
-  CAR.GOLF_MK7: CarData(
-    MQB_DBC
+  CAR.GOLF_MK7: VolkswagenCarData(
   ),
-  CAR.JETTA_MK7: CarData(
-    MQB_DBC
+  CAR.JETTA_MK7: VolkswagenCarData(
   ),
-  CAR.PASSAT_MK8: CarData(
-    MQB_DBC
+  CAR.PASSAT_MK8: VolkswagenCarData(
   ),
-  CAR.POLO_MK6: CarData(
-    MQB_DBC
+  CAR.POLO_MK6: VolkswagenCarData(
   ),
-  CAR.TAOS_MK1 : CarData(
-    MQB_DBC
+  CAR.TAOS_MK1 : VolkswagenCarData(
   ),
-  CAR.TCROSS_MK1 : CarData(
-    MQB_DBC
+  CAR.TCROSS_MK1 : VolkswagenCarData(
   ),
-  CAR.TIGUAN_MK2 : CarData(
-    MQB_DBC
+  CAR.TIGUAN_MK2 : VolkswagenCarData(
   ),
-  CAR.TOURAN_MK2 : CarData(
-    MQB_DBC
+  CAR.TOURAN_MK2 : VolkswagenCarData(
   ),
-  CAR.TRANSPORTER_T61: CarData(
-    MQB_DBC
+  CAR.TRANSPORTER_T61: VolkswagenCarData(
   ),
-  CAR.TROC_MK1: CarData(
-    MQB_DBC
+  CAR.TROC_MK1: VolkswagenCarData(
   ),
-  CAR.AUDI_A3_MK3: CarData(
-    MQB_DBC
+  CAR.AUDI_A3_MK3: VolkswagenCarData(
   ),
-  CAR.AUDI_Q2_MK1: CarData(
-    MQB_DBC
+  CAR.AUDI_Q2_MK1: VolkswagenCarData(
   ),
-  CAR.AUDI_Q3_MK2: CarData(
-    MQB_DBC
+  CAR.AUDI_Q3_MK2: VolkswagenCarData(
   ),
-  CAR.SEAT_ATECA_MK1: CarData(
-    MQB_DBC
+  CAR.SEAT_ATECA_MK1: VolkswagenCarData(
   ),
-  CAR.SEAT_LEON_MK3: CarData(
-    MQB_DBC
+  CAR.SEAT_LEON_MK3: VolkswagenCarData(
   ),
-  CAR.SKODA_FABIA_MK4: CarData(
-    MQB_DBC
+  CAR.SKODA_FABIA_MK4: VolkswagenCarData(
   ),
-  CAR.SKODA_KAMIQ_MK1: CarData(
-    MQB_DBC
+  CAR.SKODA_KAMIQ_MK1: VolkswagenCarData(
   ),
-  CAR.SKODA_KAROQ_MK1: CarData(
-    MQB_DBC
+  CAR.SKODA_KAROQ_MK1: VolkswagenCarData(
   ),
-  CAR.SKODA_KODIAQ_MK1: CarData(
-    MQB_DBC
+  CAR.SKODA_KODIAQ_MK1: VolkswagenCarData(
   ),
-  CAR.SKODA_SCALA_MK1: CarData(
-    MQB_DBC
+  CAR.SKODA_SCALA_MK1: VolkswagenCarData(
   ),
-  CAR.SKODA_SUPERB_MK3 : CarData(
-    MQB_DBC
+  CAR.SKODA_SUPERB_MK3 : VolkswagenCarData(
   ),
-  CAR.SKODA_OCTAVIA_MK3: CarData(
-    MQB_DBC
+  CAR.SKODA_OCTAVIA_MK3: VolkswagenCarData(
   ),
-  CAR.PASSAT_NMS: CarData(
-    PQ_DBC
+  CAR.PASSAT_NMS: VolkswagenCarData(
+    is_pq=True
   ),
-  CAR.SHARAN_MK2 : CarData(
-    PQ_DBC
+  CAR.SHARAN_MK2 : VolkswagenCarData(
+    is_pq=True
   ),
 }
 


### PR DESCRIPTION
start of https://github.com/commaai/openpilot/issues/31337

example

```python
CARS = {
  CAR.ACCORD: CarData(
    dbc_dict('honda_accord_2018_can_generated', None),
  ),
  CAR.ACCORDH: CarData(
    dbc_dict('honda_accord_2018_can_generated', None),
  ),
...
}
```

can eventually become
````python
CARS = {
  CAR.ACCORD: CarData(
    dbc=dbc_dict('honda_accord_2018_can_generated', None),
    mass=1234,
    wheelbase=1.234,
  ),
  CAR.ACCORDH: CarData(
    dbc_dict('honda_accord_2018_can_generated', None),
    mass=4567,
    wheelbase=1.234,
  ),
```