### PR TITLE
jenkins: kill subprocesses on exit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ ssh -tt -o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 
 
 set -e
 
+shopt -s huponexit
+
 export CI=1
 export PYTHONWARNINGS=error
 export LOGPRINT=debug

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ ssh -tt -o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 
 
 set -e
 
-shopt -s huponexit
+shopt -s huponexit # kill all child processes when the shell exits
 
 export CI=1
 export PYTHONWARNINGS=error


### PR DESCRIPTION
I think this happens when you kill a jenkins job by pushing a new commit

updated still running on one of the devices: ![image](https://github.com/commaai/openpilot/assets/9648890/a7d901f2-714b-442d-bcb4-69295581133c)

boardd still running here: 
![image](https://github.com/commaai/openpilot/assets/9648890/7974ce0b-5de0-488e-a1a7-4df18a07d85a)
