### PR TITLE
camerad: assert probe success

### DIFF
--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -193,6 +193,7 @@ int CameraState::sensors_init() {
 
   int ret = do_cam_control(sensor_fd, CAM_SENSOR_PROBE_CMD, (void *)(uintptr_t)cam_packet_handle, 0);
   LOGD("probing the sensor: %d", ret);
+  assert(ret == 0);
   return ret;
 }
 


### PR DESCRIPTION
error here: https://0xgj055t-9097.usw3.devtunnels.ms/blue/organizations/jenkins/openpilot/detail/master/45/pipeline/19

```
system/camerad/cameras/camera_util.cc: VIDIOC_CAM_CONTROL error: op_code 266 - errno 19
system/camerad/cameras/camera_qcom2.cc: probing the sensor: -1
```

then test_encoder failed with not enough frames