### PR TITLE
OpenpilotPrefix: mkdir for download_cache and comma_home

### DIFF
--- a/common/prefix.py
+++ b/common/prefix.py
@@ -27,6 +27,9 @@ class OpenpilotPrefix:
     if self.shared_download_cache:
       os.environ["COMMA_CACHE"] = DEFAULT_DOWNLOAD_CACHE_ROOT
 
+    os.makedirs(Paths.comma_home(), exist_ok=True)
+    os.makedirs(Paths.download_cache_root(), exist_ok=True)
+
     return self
 
   def __exit__(self, exc_type, exc_obj, exc_tb):


### PR DESCRIPTION
```
  File "/home/batman/pyenv/versions/3.11.4/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/home/batman/pyenv/versions/3.11.4/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/tmp/openpilot/openpilot/tools/lib/framereader.py", line 477, in _readahead_thread
    self._get_one(k, pix_fmt)
  File "/tmp/openpilot/openpilot/tools/lib/framereader.py", line 489, in _get_one
    frame_b, num_frames, skip_frames, rawdat = self.get_gop(num)
                                               ^^^^^^^^^^^^^^^^^
  File "/tmp/openpilot/openpilot/tools/lib/framereader.py", line 411, in get_gop
    rawdat = f.read(offset_e - offset_b)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/openpilot/openpilot/tools/lib/url_file.py", line 110, in read
    with atomic_write_in_dir(full_path, mode="wb") as new_cached_file:
  File "/home/batman/pyenv/versions/3.11.4/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/tmp/openpilot/openpilot/common/file_helpers.py", line 35, in atomic_write_in_dir
    with tempfile.NamedTemporaryFile(mode=mode, buffering=buffering, encoding=encoding, newline=newline, dir=dir_name, delete=False) as tmp_file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/pyenv/versions/3.11.4/lib/python3.11/tempfile.py", line 563, in NamedTemporaryFile
    file = _io.open(dir, mode, buffering=buffering,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/pyenv/versions/3.11.4/lib/python3.11/tempfile.py", line 560, in opener
    fd, name = _mkstemp_inner(dir, prefix, suffix, flags, output_type)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/pyenv/versions/3.11.4/lib/python3.11/tempfile.py", line 256, in _mkstemp_inner
    fd = _os.open(file, flags, 0o600)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/comma_download_cache7a962de42c214fe/tmp66jpb3f4'
```