### PR TITLE
fix pre-commit install process

### DIFF
--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -75,7 +75,7 @@ pyenv rehash
 
 [ -n "$POETRY_VIRTUALENVS_CREATE" ] && RUN="" || RUN="poetry run"
 
-if [ "$(uname)" != "Darwin" ]; then
+if [ "$(uname)" != "Darwin" ] && [ -e "$ROOT/.git" ]; then
   echo "pre-commit hooks install..."
   $RUN pre-commit install
   $RUN git submodule foreach pre-commit install

--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -77,10 +77,6 @@ pyenv rehash
 
 if [ "$(uname)" != "Darwin" ]; then
   echo "pre-commit hooks install..."
-  shopt -s nullglob
-  for f in .pre-commit-config.yaml */.pre-commit-config.yaml; do
-    if [ -e "$ROOT/$(dirname $f)/.git" ]; then
-      $RUN pre-commit install -c "$f"
-    fi
-  done
+  $RUN pre-commit install
+  $RUN git submodule foreach pre-commit install
 fi


### PR DESCRIPTION
**Description**

The first commit to a properly installed openpilot dev environment fails with some non-intuitive errors. This also happens after re-running `tools/install_python_dependencies.sh` manually to refresh dependencies.

```
(openpilot-py3.11) jyoung@DESKTOP-6JPRDTA:~/openpilot$ git commit --allow-empty -m "test"
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/jyoung/.cache/pre-commit/patch1707881573-5675.
ruff.....................................................................Passed
docs.....................................................................Failed
- hook id: docs
- exit code: 2

/home/jyoung/.cache/pypoetry/virtualenvs/openpilot-3UaNDeHd-py3.11/bin/python3: can't open file '/home/jyoung/openpilot/docs/abstractions.py': [Errno 2] No such file or directory

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

Executable `flake8` not found

mypy.....................................................................Failed
- hook id: mypy
- exit code: 2

There are no .py[i] files in directory 'tinygrad'

subset of (CPU) tests....................................................Failed
- hook id: tests
- exit code: 5

============================= test session starts ==============================
platform linux -- Python 3.11.4, pytest-8.0.0, pluggy-1.4.0
Using --randomly-seed=2977995024
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/jyoung/openpilot
configfile: pyproject.toml
plugins: cov-4.1.0, cpp-2.5.0, randomly-3.15.0, xdist-3.5.0, timeout-2.2.0, hypothesis-6.47.5, flaky-3.7.0, timeouts-1.2.1, subtests-0.11.0, random-order-1.1.0
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
4 workers [0 items]

============================ no tests ran in 2.00s =============================

pylint...................................................................Failed
- hook id: pylint
- exit code: 1

/home/jyoung/.cache/pypoetry/virtualenvs/openpilot-3UaNDeHd-py3.11/bin/python: No module named pylint

[INFO] Restored changes from /home/jyoung/.cache/pre-commit/patch1707881573-5675.
```

**Fix**

When `tools/install_python_dependencies.sh` (called from `tools/ubuntu_setup.sh`) sets up pre-commit, it tries to do so for openpilot and for each submodule. What it actually does is replace the openpilot pre-commit hooks eight times, the last time with tinygrad's config, and doesn't install anything at the submodule level.

```
pre-commit hooks install...
[WARNING] The 'files' field in hook 'test_translations' is a regex, not a glob -- matching '/*' probably isn't what you want here
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at .git/hooks/pre-commit
pre-commit installed at .git/hooks/pre-commit
```

Replaced the pre-commit hook installer routine with a simpler approach that does what we need.

```
pre-commit hooks install...
[WARNING] The 'files' field in hook 'test_translations' is a regex, not a glob -- matching '/*' probably isn't what you want here
pre-commit installed at .git/hooks/pre-commit
Entering 'body'
pre-commit installed at /home/jyoung/openpilot/.git/modules/body/hooks/pre-commit
Entering 'cereal'
pre-commit installed at /home/jyoung/openpilot/.git/modules/cereal/hooks/pre-commit
Entering 'opendbc'
pre-commit installed at /home/jyoung/openpilot/.git/modules/opendbc/hooks/pre-commit
Entering 'panda'
pre-commit installed at /home/jyoung/openpilot/.git/modules/panda/hooks/pre-commit
Entering 'rednose_repo'
pre-commit installed at /home/jyoung/openpilot/.git/modules/rednose_repo/hooks/pre-commit
Entering 'teleoprtc_repo'
pre-commit installed at /home/jyoung/openpilot/.git/modules/teleoprtc_repo/hooks/pre-commit
Entering 'tinygrad_repo'
pre-commit installed at /home/jyoung/openpilot/.git/modules/tinygrad/hooks/pre-commit
```

**Verification**

Re-ran the install process several times, both ways, and made test commits in both openpilot and a submodule.