### PR TITLE
SegmentRange: more explicit slice matching

### DIFF
--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -14,7 +14,7 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  SEGMENT_RANGE = r'{}(?:--|/)(?P<slice>({}))?/(?P<selector>([qras]))?'.format(ROUTE_NAME, SLICE)
+  SEGMENT_RANGE = '(?P<route_name>(?P<dongle_id>[a-f0-9]{16})[|_\/](?P<log_id>(?:(?P<timestamp>[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2})|(?P<count>[a-f0-9]{8})--(?P<uid>[a-z0-9]{10}))))(?:--|\/(?P<slice>((?P<start>-?[0-9]+)?:?(?P<end>-?[0-9]+)?:?(?P<step>-?[0-9]+)?)))?(?:\/(?P<selector>([qras])))?'
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -14,7 +14,7 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  SEGMENT_RANGE = '(?P<route_name>(?P<dongle_id>[a-f0-9]{16})[|_\/](?P<log_id>(?:(?P<timestamp>[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2})|(?P<count>[a-f0-9]{8})--(?P<uid>[a-z0-9]{10}))))(?:--|\/(?P<slice>((?P<start>-?[0-9]+)?:?(?P<end>-?[0-9]+)?:?(?P<step>-?[0-9]+)?)))?(?:\/(?P<selector>([qras])))?'
+  SEGMENT_RANGE = r'{}(?:--|\/(?P<slice>({})))?(?:\/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE)
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -14,7 +14,7 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  SEGMENT_RANGE = r'{}(?:--|/(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE)
+  SEGMENT_RANGE = r'{}(?:(--|/)(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE)
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -14,7 +14,7 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  SEGMENT_RANGE = r'{}(?:--|\/(?P<slice>({})))?(?:\/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE)
+  SEGMENT_RANGE = r'{}(?:--|/(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE)
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -14,7 +14,7 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  SEGMENT_RANGE = r'{}(?:--|/)?(?P<slice>({}))?/?(?P<selector>([qras]))?'.format(ROUTE_NAME, SLICE)
+  SEGMENT_RANGE = r'{}(?:--|/)(?P<slice>({}))?/(?P<selector>([qras]))?'.format(ROUTE_NAME, SLICE)
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -15,11 +15,7 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  # SEGMENT_RANGE = re.compile(r'{}(?:(--|/)(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE))
-  SEGMENT_RANGE = re.compile(r'{}(?:((--|/)(?P<slice>({}))))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE))
-  # SEGMENT_RANGE = re.compile(r'{}(?P<slice>((--|/){}))?/?(?P<selector>([qras]))?'.format(ROUTE_NAME, SLICE))
-  # SEGMENT_RANGE = re.compile(r'{}(?:((?:--|/)(?P<slice>{}))(?:/(?P<selector>[qras]))?)?'.format(ROUTE_NAME, SLICE))
-  re.compile('(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?')
+  SEGMENT_RANGE = re.compile(r'{}(?:(--|/)(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE))
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -1,5 +1,6 @@
 import bz2
 import datetime
+import re
 
 TIME_FMT = "%Y-%m-%d--%H-%M-%S"
 
@@ -14,7 +15,11 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  SEGMENT_RANGE = r'{}(?:(--|/)(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE)
+  # SEGMENT_RANGE = re.compile(r'{}(?:(--|/)(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE))
+  SEGMENT_RANGE = re.compile(r'{}(?:((--|/)(?P<slice>({}))))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE))
+  # SEGMENT_RANGE = re.compile(r'{}(?P<slice>((--|/){}))?/?(?P<selector>([qras]))?'.format(ROUTE_NAME, SLICE))
+  # SEGMENT_RANGE = re.compile(r'{}(?:((?:--|/)(?P<slice>{}))(?:/(?P<selector>[qras]))?)?'.format(ROUTE_NAME, SLICE))
+  re.compile('(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?')
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -1,6 +1,5 @@
 import bz2
 import datetime
-import re
 
 TIME_FMT = "%Y-%m-%d--%H-%M-%S"
 
@@ -16,7 +15,7 @@ class RE:
 
   INDEX = r'-?[0-9]+'
   SLICE = r'(?P<start>{})?:?(?P<end>{})?:?(?P<step>{})?'.format(INDEX, INDEX, INDEX)
-  SEGMENT_RANGE = re.compile(r'{}(?:(--|/)(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE))
+  SEGMENT_RANGE = r'{}(?:(--|/)(?P<slice>({})))?(?:/(?P<selector>([qras])))?'.format(ROUTE_NAME, SLICE)
 
   BOOTLOG_NAME = ROUTE_NAME
 

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -78,8 +78,8 @@ class ReadMode(enum.StrEnum):
   AUTO = "a" # default to rlogs, fallback to qlogs
   AUTO_INTERACIVE = "i" # default to rlogs, fallback to qlogs with a prompt from the user
 
-def create_slice_from_string(s: str):
-  m = re.fullmatch(RE.SLICE, s)
+def create_slice_from_string(s: str | None):
+  m = re.fullmatch(RE.SLICE, s or '')
   assert m is not None, f"Invalid slice: {s}"
   start, end, step = m.groups()
   start = int(start) if start is not None else None

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -265,7 +265,11 @@ class SegmentRange:
 
   @property
   def _slice(self) -> str:
-    return self.m.group("slice")
+    return self.m.group("slice") or ""
+
+  @property
+  def selector(self) -> str | None:
+    return self.m.group("selector")
 
   @property
   def seg_idxs(self) -> list[int]:
@@ -285,10 +289,6 @@ class SegmentRange:
       return list(range(get_max_seg_number_cached(self) + 1))[s]
     else:
       return list(range(end + 1))[s]
-
-  @property
-  def selector(self) -> str:
-    return self.m.group("selector")
 
   def __str__(self) -> str:
     return f"{self.dongle_id}/{self.timestamp}" + (f"/{self._slice}" if self._slice else "") + (f"/{self.selector}" if self.selector else "")

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -250,23 +250,23 @@ class SegmentRange:
     return get_max_seg_number_cached(self)
 
   @property
-  def route_name(self):
+  def route_name(self) -> str:
     return self.m.group("route_name")
 
   @property
-  def dongle_id(self):
+  def dongle_id(self) -> str:
     return self.m.group("dongle_id")
 
   @property
-  def timestamp(self):
+  def timestamp(self) -> str:
     return self.m.group("timestamp")
 
   @property
-  def _slice(self):
+  def _slice(self) -> str | None:
     return self.m.group("slice")
 
   @property
-  def selector(self):
+  def selector(self) -> str | None:
     return self.m.group("selector")
 
   def __str__(self):

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -86,6 +86,9 @@ class TestLogReader(unittest.TestCase):
     (f"{TEST_ROUTE}/j",),
     (f"{TEST_ROUTE}/0:1:2:3",),
     (f"{TEST_ROUTE}/:::3",),
+    (f"{TEST_ROUTE}3",),
+    (f"{TEST_ROUTE}-3",),
+    (f"{TEST_ROUTE}--3a",),
   ])
   def test_bad_ranges(self, segment_range):
     with self.assertRaises(AssertionError):

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import shutil
 import tempfile
 import numpy as np


### PR DESCRIPTION
Found by accidentally typing `1618132d68afc876/2024-02-14--12-13-50:-1` when passing into a tool. @jnewb1 is this desired? I feel like we should be explicit with our route syntax, but feel free to close if this is intentional.

You can also do this weirdness (disallowed by this PR):

```
1618132d68afc876/2024-02-14--12-13-501a
1618132d68afc876/2024-02-14--12-13-50-1a
1618132d68afc876/2024-02-14--12-13-50--1a
```