### PR TITLE
SegmentRange: test API call

### DIFF
--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -92,7 +92,7 @@ class TestLogReader(unittest.TestCase):
 
   @parameterized.expand([
     (f"{TEST_ROUTE}/0", False),
-    (f"{TEST_ROUTE}/0:2", False),
+    (f"{TEST_ROUTE}/:2", False),
     (f"{TEST_ROUTE}/0:", True),
     (f"{TEST_ROUTE}/-1", True),
     (f"{TEST_ROUTE}", True),

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -90,6 +90,22 @@ class TestLogReader(unittest.TestCase):
       sr = SegmentRange(segment_range)
       parse_slice(sr)
 
+  @parameterized.expand([
+    (f"{TEST_ROUTE}/0", False),
+    (f"{TEST_ROUTE}/0:2", False),
+    (f"{TEST_ROUTE}/0:", True),
+    (f"{TEST_ROUTE}/-1", True),
+    (f"{TEST_ROUTE}", True),
+  ])
+  def test_slicing_api_call(self, segment_range, api_call):
+    with mock.patch("openpilot.tools.lib.route.get_max_seg_number_cached") as max_seg_mock:
+      max_seg_mock.return_value = NUM_SEGS
+      parse_slice(SegmentRange(segment_range))
+      if api_call:
+        max_seg_mock.assert_called()
+      else:
+        max_seg_mock.assert_not_called()
+
   @pytest.mark.slow
   def test_modes(self):
     qlog_len = len(list(LogReader(f"{TEST_ROUTE}/0", ReadMode.QLOG)))

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -101,10 +101,7 @@ class TestLogReader(unittest.TestCase):
     with mock.patch("openpilot.tools.lib.route.get_max_seg_number_cached") as max_seg_mock:
       max_seg_mock.return_value = NUM_SEGS
       parse_slice(SegmentRange(segment_range))
-      if api_call:
-        max_seg_mock.assert_called()
-      else:
-        max_seg_mock.assert_not_called()
+      self.assertEqual(api_call, max_seg_mock.called)
 
   @pytest.mark.slow
   def test_modes(self):


### PR DESCRIPTION
currently `SegmentRange` can either make an API call or not depending on the exact slice you make (relative or absolute, ie. `[-1]`, `[:2]`, `[:]`), but the logic is confusing so we should test it