### PR TITLE
VIN: lower retries

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -141,9 +141,10 @@ def fingerprint(logcan, sendcan, num_pandas):
       cached = True
     else:
       cloudlog.warning("Getting VIN & FW versions")
-      # enable OBD multiplexing for Vin query, also allows time for sendcan subscriber to connect
+      # enable OBD multiplexing for VIN query
+      # NOTE: this takes ~0.1s and is relied on to allow sendcan subscriber to connect in time
       set_obd_multiplexing(params, True)
-      # Vin query only reliably works through OBDII
+      # VIN query only reliably works through OBDII
       vin_rx_addr, vin_rx_bus, vin = get_vin(logcan, sendcan, (0, 1))
       ecu_rx_addrs = get_present_ecus(logcan, sendcan, num_pandas=num_pandas)
       car_fw = get_fw_versions_ordered(logcan, sendcan, ecu_rx_addrs, num_pandas=num_pandas)

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -225,7 +225,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
 
   def test_startup_timing(self):
     # Tests worse-case VIN query time and typical present ECU query time
-    vin_ref_times = {'worst': 1.5, 'best': 0.5}  # best assumes we go through all queries to get a match
+    vin_ref_times = {'worst': 1.0, 'best': 0.5}  # best assumes we go through all queries to get a match
     present_ecu_ref_time = 0.75
 
     def fake_get_ecu_addrs(*_, timeout):

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -15,7 +15,7 @@ def is_valid_vin(vin: str):
   return re.fullmatch(VIN_RE, vin) is not None
 
 
-def get_vin(logcan, sendcan, buses, timeout=0.1, retry=3, debug=False):
+def get_vin(logcan, sendcan, buses, timeout=0.1, retry=2, debug=False):
   for i in range(retry):
     for bus in buses:
       for request, response, valid_buses, vin_addrs, functional_addrs, rx_offset in (


### PR DESCRIPTION
The VIN query should be reliable and not need retries, like the FW queries. They were only there AFAIK because sendcan can take up to 100ms to connect, dropping the first few messages. Now we take more time in controlsd between creating the publisher and sending on it.

For https://github.com/commaai/openpilot/pull/31398, lowers total time taken if no VIN request works back down to before the recent changes to get vin on bus 0 and the Bolt query so release3 sees no change.

We are relying on `set_obd_multiplexing` always taking ~0.1 which is plenty of time for sendcan to connect at 100Hz in boardd, so I left a comment. https://github.com/commaai/openpilot/pull/31172 makes this reliable BTW