### PR TITLE
test_fw_query_on_routes: get first qlog

### DIFF
--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -44,10 +44,14 @@ if __name__ == "__main__":
 
   dongles = []
   for route in tqdm(routes):
-    dongle_id = SegmentRange(route).dongle_id
+    sr = SegmentRange(route)
+    dongle_id = sr.dongle_id
 
     if dongle_id in dongles:
       continue
+
+    if sr.slice == '' and sr.selector is None:
+      route += '/0'
 
     lr = LogReader(route, default_mode=ReadMode.QLOG)
 

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -264,7 +264,7 @@ class SegmentRange:
     return self.m.group("timestamp")
 
   @property
-  def _slice(self) -> str:
+  def slice(self) -> str:
     return self.m.group("slice") or ""
 
   @property
@@ -273,12 +273,12 @@ class SegmentRange:
 
   @property
   def seg_idxs(self) -> list[int]:
-    m = re.fullmatch(RE.SLICE, self._slice)
-    assert m is not None, f"Invalid slice: {self._slice}"
+    m = re.fullmatch(RE.SLICE, self.slice)
+    assert m is not None, f"Invalid slice: {self.slice}"
     start, end, step = (None if s is None else int(s) for s in m.groups())
 
     # one segment specified
-    if start is not None and end is None and ':' not in self._slice:
+    if start is not None and end is None and ':' not in self.slice:
       if start < 0:
         start += get_max_seg_number_cached(self) + 1
       return [start]
@@ -291,7 +291,7 @@ class SegmentRange:
       return list(range(end + 1))[s]
 
   def __str__(self) -> str:
-    return f"{self.dongle_id}/{self.timestamp}" + (f"/{self._slice}" if self._slice else "") + (f"/{self.selector}" if self.selector else "")
+    return f"{self.dongle_id}/{self.timestamp}" + (f"/{self.slice}" if self.slice else "") + (f"/{self.selector}" if self.selector else "")
 
   def __repr__(self) -> str:
     return self.__str__()

--- a/tools/lib/tests/test_comma_car_segments.py
+++ b/tools/lib/tests/test_comma_car_segments.py
@@ -25,7 +25,7 @@ class TestCommaCarSegments(unittest.TestCase):
 
     sr = SegmentRange(segment)
 
-    url = get_url(sr.route_name, sr._slice)
+    url = get_url(sr.route_name, sr.slice)
 
     resp = requests.get(url)
     self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
reverts to previous behavior of getting first qlog: https://github.com/commaai/openpilot/commit/998eb8cde2c81964c883595ee84eeab4172c99ae

@jnewb1 an argument for default seg idx would be nice, just like the default source