### PR TITLE
UI/PrimeUserWidget: Fixed extra spacing illusion from "comma prime" being all lowercase

### DIFF
--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -121,7 +121,7 @@ PrimeUserWidget::PrimeUserWidget(QWidget *parent) : QFrame(parent) {
   setObjectName("primeWidget");
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
   mainLayout->setContentsMargins(56, 40, 56, 40);
-  mainLayout->setSpacing(20);
+  mainLayout->setSpacing(0); //Set to 0 cause "comma prime" is all lowercase, causing extra top space illusion
 
   QLabel *subscribed = new QLabel(tr("✓ SUBSCRIBED"));
   subscribed->setStyleSheet("font-size: 41px; font-weight: bold; color: #86FF4E;");
@@ -242,6 +242,9 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
     #primeWidget {
       border-radius: 10px;
       background-color: #333333;
+    }
+    PrimeUserWidget#primeWidget {
+      padding: 10px 0px; /*Top & bottom padding to keep the widget the same size as before*/
     }
   )");
 


### PR DESCRIPTION
## Problem:
Top spacing of "comma prime" is oddly bigger than the widget below it(WiFiPromptWidget). Technically the spacing code does match the widget below it, but because the "comma prime" string is all lower case it creates extra spacing making it seem like the sub-header "Subscribed" is even further away from the heading "comma prime".

## Solution:
Change setSpacing() value to "0" of PrimeUserWidget to compensate for the all lowercase "comma prime". I also needed to add top and bottom padding as explained below.

https://github.com/commaai/openpilot/assets/142481257/89e5f44d-aed8-4de4-9d17-29983c0a98d6

</br>

### With Gammaray outline visualization of spacing

https://github.com/commaai/openpilot/assets/142481257/39fd8291-b03b-4a3e-8ed1-3034ae2f801b


</br></br>
### Unexpected UI change consequence:
Removing the 20px spacing in PrimeUserWidget makes the widget 20px smaller making the WiFiPromptWidget move up causing it not to align with PrimeAdWidget. Refer to photo below. Gammaray(Introspection tool) highlights in red the border of the widget and how it is not aligning with PrimeAdWidget to the left.
![gammaray-showing misaligned-wifi](https://github.com/commaai/openpilot/assets/142481257/388168d0-cf79-4a6c-b6b9-3771432b8c66)


### Solution:
I added 10px padding-top and 10px padding-bottom to ONLY affect PrimeUserWidget so the widget still takes up the same amount of space as before. Adding this extra padding makes it so the layout and alignment stays the same. Refer to "new-ui.png" below.
</br></br>
### Old UI
![OLD-ui](https://github.com/commaai/openpilot/assets/142481257/e24aee1b-a5e5-4192-b8da-27c14d4bd983)
</br>
### New UI
![NEW-ui](https://github.com/commaai/openpilot/assets/142481257/dd7de639-687d-4259-8c3c-1abf46acae15)

