### PR TITLE
[bot] Fingerprints: add missing FW versions from CAN fingerprinting cars

### DIFF
--- a/selfdrive/car/nissan/fingerprints.py
+++ b/selfdrive/car/nissan/fingerprints.py
@@ -46,6 +46,7 @@ FW_VERSIONS = {
   CAR.LEAF: {
     (Ecu.abs, 0x740, None): [
       b'476605SA1C',
+      b'476605SA7D',
       b'476605SC2D',
       b'476606WK7B',
       b'476606WK9B',
@@ -65,6 +66,7 @@ FW_VERSIONS = {
     ],
     (Ecu.gateway, 0x18dad0f1, None): [
       b'284U25SA3C',
+      b'284U25SP0C',
       b'284U25SP1C',
       b'284U26WK0A',
       b'284U26WK0C',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                       | Name from VIN 🆚 CarInfo   | Segments                | Bad seg tags   | Good seg tags                                          |
|:----------------------------------------------------------------------------------------------------------------------------|:---------------------------|:------------------------|:---------------|:-------------------------------------------------------|
| [583fec7ca1188a8a](https://useradmin.comma.ai/?onebox=583fec7ca1188a8a)<br><sub>NISSAN LEAF 2018<br>000000000........</sub> | None 🆚<br>None            | 40 routes, 567 segments |                | - all lat active: 125<br>- no input all lat active: 96 |

Dongles to re-run category: `583fec7ca1188a8a`
</details>

## ⏳️ 2 dongles (2 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                             | Name from VIN 🆚 CarInfo                               | Segments                | Bad seg tags   | Good seg tags                                         |
|:----------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------|:------------------------|:---------------|:------------------------------------------------------|
| [3678d13114bf2ce4](https://useradmin.comma.ai/?onebox=3678d13114bf2ce4)<br><sub>NISSAN LEAF 2018<br>000000000........</sub>       | None 🆚<br>None                                        | 11 routes, 136 segments |                | - all lat active: 34<br>- no input all lat active: 11 |
| [70d27b3a88b6d4b5](https://useradmin.comma.ai/?onebox=70d27b3a88b6d4b5)<br><sub>CHRYSLER PACIFICA 2020<br>2C4RC1BG1........</sub> | CHRYSLER Pacifica 2021 🆚<br>Chrysler Pacifica 2021-23 | 15 routes, 236 segments |                | - all lat active: 8<br>- no input all lat active: 6   |

Dongles to re-run category: `70d27b3a88b6d4b5 3678d13114bf2ce4`
</details>

## ⚠️ 3 dongles (2 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                  | Name from VIN 🆚 CarInfo                                   | Segments                | Bad seg tags                                                                                                                                                                                               | Good seg tags                                          |
|:---------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|:------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------|
| [02da77066f2ae12f](https://useradmin.comma.ai/?onebox=02da77066f2ae12f)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFBT0........</sub> | JEEP Grand Cherokee 2018 🆚<br>Jeep Grand Cherokee 2016-18 | 21 routes, 315 segments | - [car faulted: 4](https://useradmin.comma.ai/?onebox=02da77066f2ae12f%7C2024-02-15--15-15-37)                                                                                                             | - all lat active: 130<br>- no input all lat active: 76 |
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFCG8........</sub> | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18 | 18 routes, 242 segments | - [car faulted: 12](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a%7C2024-02-11--11-12-52)                                                                                                            | - all lat active: 1                                    |
| [742442ec7a49776d](https://useradmin.comma.ai/?onebox=742442ec7a49776d)<br><sub>NISSAN ALTIMA 2020<br>1N4BL4AW4........</sub>          | NISSAN Altima 2019 🆚<br>Nissan Altima 2019-20             | 3 routes, 6 segments    | - [missing ECU FW: 6](https://useradmin.comma.ai/?onebox=742442ec7a49776d%7C2024-01-25--10-11-09)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=742442ec7a49776d%7C2024-01-25--10-11-09) |                                                        |

Dongles to re-run category: `742442ec7a49776d c88f65eeaee4003a 02da77066f2ae12f`
</details>