### PR TITLE
Fixup repo abstractions

### DIFF
--- a/common/tests/test_modules_dependency.py
+++ b/common/tests/test_modules_dependency.py
@@ -18,11 +18,11 @@ def parse_file(file_path='', leading_folder='', errors=None, main_dirs=None):
         errors = []
     excluded_main_dirs = [item for item in main_dirs if item != leading_folder]
     with open(file_path, 'r') as file:
-        for line_num, line in enumerate(file, start=1): 
+        for line_num, line in enumerate(file, start=1):
             if 'import' in line or 'from' in line:
                 for f_name in excluded_main_dirs:
-                    if ' '+f_name+'.' in line.strip() and not 'openpilot.' in line.strip():
-                        if not f_name+'_repo' in file_path:
+                    if ' '+f_name+'.' in line.strip() and 'openpilot.' not in line.strip():
+                        if f_name+'_repo' not in file_path:
                             error_msg = f"Error: File: {file_path}, External folder: {f_name}, Line #{line_num}: {line.strip()}"
                             errors.append(error_msg)
     return errors
@@ -42,13 +42,13 @@ class TestParseFiles(unittest.TestCase):
 
         self.main_dirs = get_main_directories(self.root_dir)
         self.excluded_dir_list = ['cereal', 'body', 'rednose', 'rednose_repo', 'opendbc', 'panda', 'generated']
-        self.main_dirs = [dir for dir in self.main_dirs if dir not in self.excluded_dir_list]
+        self.main_dirs = [dir_temp for dir_temp in self.main_dirs if dir_temp not in self.excluded_dir_list]
 
 
     def test_parse_files(self):
         error_list = []
 
-        for root, dirs, files in os.walk(self.root_dir, topdown=True):
+        for root, dirs, _ in os.walk(self.root_dir, topdown=True):
             for name in dirs:
                 dir_path = os.path.join(root, name)
                 if dir_path.split(self.root_dir)[1].startswith('/.'):

--- a/common/tests/test_modules_dependency.py
+++ b/common/tests/test_modules_dependency.py
@@ -1,0 +1,67 @@
+import unittest
+import os
+
+
+def get_main_directories(path=''):
+    main_directories = []
+    for item in os.listdir(path):
+        if item.startswith('.'):
+            continue
+        item_path = os.path.join(path, item)
+        if os.path.isdir(item_path):
+            main_directories.append(os.path.basename(item_path))
+    return main_directories
+
+
+def parse_file(file_path='', leading_folder='', errors=None, main_dirs=None):
+    if errors is None:
+        errors = []
+    excluded_main_dirs = [item for item in main_dirs if item != leading_folder]
+    with open(file_path, 'r') as file:
+        for line_num, line in enumerate(file, start=1): 
+            if 'import' in line or 'from' in line:
+                for f_name in excluded_main_dirs:
+                    if ' '+f_name+'.' in line.strip() and not 'openpilot.' in line.strip():
+                        if not f_name+'_repo' in file_path:
+                            error_msg = f"Error: File: {file_path}, External folder: {f_name}, Line #{line_num}: {line.strip()}"
+                            errors.append(error_msg)
+    return errors
+
+
+class TestParseFiles(unittest.TestCase):
+    def setUp(self):
+        self.current_dir = os.path.dirname(__file__)
+        self.relative_path = ""
+
+        while not os.path.exists(os.path.join(self.current_dir, "openpilot")) and self.current_dir != os.path.dirname(self.current_dir):
+            self.current_dir = os.path.dirname(self.current_dir)
+            self.relative_path = os.path.join("..", self.relative_path)
+
+        if os.path.exists(os.path.join(self.current_dir, "openpilot")):
+            self.root_dir = self.current_dir
+
+        self.main_dirs = get_main_directories(self.root_dir)
+        self.excluded_dir_list = ['cereal', 'body', 'rednose', 'rednose_repo', 'opendbc', 'panda', 'generated']
+        self.main_dirs = [dir for dir in self.main_dirs if dir not in self.excluded_dir_list]
+
+
+    def test_parse_files(self):
+        error_list = []
+
+        for root, dirs, files in os.walk(self.root_dir, topdown=True):
+            for name in dirs:
+                dir_path = os.path.join(root, name)
+                if dir_path.split(self.root_dir)[1].startswith('/.'):
+                    continue
+                leading_folder = dir_path.split(self.root_dir)[1].split("/")[1]
+                for file in os.listdir(dir_path):
+                    file_path = os.path.join(dir_path, file)
+                    if file_path.endswith('.py'):
+                        parse_file(file_path, leading_folder, error_list, self.main_dirs)
+
+        error_message = "\n".join(error_list)
+        self.assertEqual(len(error_list), 0, f"Errors found, unexpected dependencies! : \n{error_message}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes  #29598

**Description**

@adeebshihadeh, @jnewb1, can you please take a look at this PR.

I created test which checks imports in `.py` files in top repo directories that are not in exclude list that I created `'cereal', 'body', 'rednose', 'rednose_repo', 'opendbc', 'panda', 'generated'`(I took exclude list from your git pre-commit).

The idea of the test is to get list of files which include functions/modules from other top level directories. When I run the test, I get two errors:
![Screenshot from 2024-02-19 15-37-41](https://github.com/commaai/openpilot/assets/156184842/9949202e-c7ba-4175-a04e-72a5275eb14c)

I left them as is in the repo, and created a draft PR as I would like some additional input from you on this issue. I have a couple of questions regarding this issue and PR and any help would be greatly appreciated.

Questions that I have for you are:
1. What directories should be checked, 4 directories mentioned in the issue or all directories?
2. Are there some dependencies allowed? For example: teleoprtc_repo is importing teleoprtct, tinygrad_repo is importing tinygrad, almost all selfdrive files are importing opendbc
3. Should this test be a git hook as translations test?

**Verification**

I run pre-commit hooks and python tests run via `pytest`

