### PR TITLE
Correct issue with Ford vehicles where after a human initiated turn they will not straighten up, requiring drive to fight the wheel for 3-5 seconds.

### DIFF
--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -69,13 +69,23 @@ class CarController:
 
       self.apply_curvature_last = apply_curvature
 
+      steeringPressed = CS.out.steeringPressed
+      steeringTorqueEps = CS.out.steeringTorque
+      steeringAngleDeg = CS.out.steeringAngleDeg
+
+      if steeringPressed and (abs(steeringAngleDeg) > 100 or abs(steeringTorqueEps) > 2):
+        apply_curvature = 0
+        ramp_type = 3
+      else:
+        ramp_type = 0
+      
       if self.CP.carFingerprint in CANFD_CAR:
         # TODO: extended mode
         mode = 1 if CC.latActive else 0
         counter = (self.frame // CarControllerParams.STEER_STEP) % 0xF
-        can_sends.append(fordcan.create_lat_ctl2_msg(self.packer, self.CAN, mode, 0., 0., -apply_curvature, 0., counter))
+        can_sends.append(fordcan.create_lat_ctl2_msg(self.packer, self.CAN, mode, ramp_type, 0., 0., -apply_curvature, 0., counter))
       else:
-        can_sends.append(fordcan.create_lat_ctl_msg(self.packer, self.CAN, CC.latActive, 0., 0., -apply_curvature, 0.))
+        can_sends.append(fordcan.create_lat_ctl_msg(self.packer, self.CAN, CC.latActive, ramp_type, 0., 0., -apply_curvature, 0.))
 
     # send lka msg at 33Hz
     if (self.frame % CarControllerParams.LKA_STEP) == 0:

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -84,7 +84,7 @@ class CarController:
         counter = (self.frame // CarControllerParams.STEER_STEP) % 0xF
         can_sends.append(fordcan.create_lat_ctl2_msg(self.packer, self.CAN, mode, ramp_type, 0., 0., -apply_curvature, 0., counter))
       else:
-        can_sends.append(fordcan.create_lat_ctl_msg(self.packer, self.CAN, CC.latActive, ramp_type, 0., 0., -apply_curvature, 0.))
+        can_sends.append(fordcan.create_lat_ctl_msg(self.packer, self.CAN, ramp_type, CC.latActive, 0., 0., -apply_curvature, 0.))
 
     # send lka msg at 33Hz
     if (self.frame % CarControllerParams.LKA_STEP) == 0:

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -67,8 +67,6 @@ class CarController:
       else:
         apply_curvature = 0.
 
-      self.apply_curvature_last = apply_curvature
-
       steeringPressed = CS.out.steeringPressed
       steeringAngleDeg = CS.out.steeringAngleDeg
 
@@ -77,7 +75,9 @@ class CarController:
         ramp_type = 3
       else:
         ramp_type = 0
-      
+
+      self.apply_curvature_last = apply_curvature
+            
       if self.CP.carFingerprint in CANFD_CAR:
         # TODO: extended mode
         mode = 1 if CC.latActive else 0

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -70,10 +70,9 @@ class CarController:
       self.apply_curvature_last = apply_curvature
 
       steeringPressed = CS.out.steeringPressed
-      steeringTorqueEps = CS.out.steeringTorque
       steeringAngleDeg = CS.out.steeringAngleDeg
 
-      if steeringPressed and (abs(steeringAngleDeg) > 100 or abs(steeringTorqueEps) > 2):
+      if steeringPressed and abs(steeringAngleDeg) > 60:
         apply_curvature = 0
         ramp_type = 3
       else:

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -46,7 +46,7 @@ def create_lka_msg(packer, CAN: CanBus):
   return packer.make_can_msg("Lane_Assist_Data1", CAN.main, {})
 
 
-def create_lat_ctl_msg(packer, CAN: CanBus, lat_active: bool, path_offset: float, path_angle: float, curvature: float,
+def create_lat_ctl_msg(packer, CAN: CanBus, ramp_type: int, lat_active: bool, path_offset: float, path_angle: float, curvature: float,
                        curvature_rate: float):
   """
   Creates a CAN message for the Ford TJA/LCA Command.
@@ -74,7 +74,7 @@ def create_lat_ctl_msg(packer, CAN: CanBus, lat_active: bool, path_offset: float
     "HandsOffCnfm_B_Rq": 0,                     # Unknown: 0=Inactive, 1=Active [0|1]
     "LatCtl_D_Rq": 1 if lat_active else 0,      # Mode: 0=None, 1=ContinuousPathFollowing, 2=InterventionLeft,
                                                 #       3=InterventionRight, 4-7=NotUsed [0|7]
-    "LatCtlRampType_D_Rq": 0,                   # Ramp speed: 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
+    "LatCtlRampType_D_Rq": ramp_type,                   # Ramp speed: 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
                                                 #             Makes no difference with curvature control
     "LatCtlPrecision_D_Rq": 1,                  # Precision: 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
                                                 #            The stock system always uses comfortable
@@ -86,7 +86,7 @@ def create_lat_ctl_msg(packer, CAN: CanBus, lat_active: bool, path_offset: float
   return packer.make_can_msg("LateralMotionControl", CAN.main, values)
 
 
-def create_lat_ctl2_msg(packer, CAN: CanBus, mode: int, path_offset: float, path_angle: float, curvature: float,
+def create_lat_ctl2_msg(packer, CAN: CanBus, mode: int, ramp_type: int, path_offset: float, path_angle: float, curvature: float,
                         curvature_rate: float, counter: int):
   """
   Create a CAN message for the new Ford Lane Centering command.
@@ -100,7 +100,7 @@ def create_lat_ctl2_msg(packer, CAN: CanBus, mode: int, path_offset: float, path
   values = {
     "LatCtl_D2_Rq": mode,                       # Mode: 0=None, 1=PathFollowingLimitedMode, 2=PathFollowingExtendedMode,
                                                 #       3=SafeRampOut, 4-7=NotUsed [0|7]
-    "LatCtlRampType_D_Rq": 0,                   # 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
+    "LatCtlRampType_D_Rq": ramp_type,                   # 0=Slow, 1=Medium, 2=Fast, 3=Immediate [0|3]
     "LatCtlPrecision_D_Rq": 1,                  # 0=Comfortable, 1=Precise, 2/3=NotUsed [0|3]
     "LatCtlPathOffst_L_Actl": path_offset,      # [-5.12|5.11] meter
     "LatCtlPath_An_Actl": path_angle,           # [-0.5|0.5235] radians


### PR DESCRIPTION
<!--- ***** Template: Car Bugfix *****

**Description**

If Ford vehicles which are curvature based, if the driver takes over the steering wheel and makes a turn with OP lateral engaged (this happens in experimental mode at red lights and stop signs), the curvature will build up in the EPAS and the car will continue to try and turn after the maneuver is over, requiring the driver to fight the steering wheel until the curvature inside the EPAS completes.  This usually last 3-5 seconds, where if the driver goes hands free again, the car will exit the road in the direction the turn was navigated.

An analysis in PlotJuggler of Ford logic from dash cam routes on F150s, Mavericks, and Mach E's shows that Ford accounts for this by changing the ramp type to "immediate" and setting curvature to zero whenever it detects steering wheel pressed and the steering wheel angle is greater than 60 degrees.  This PR attempts to replicate that logic.

**Verification**

Tested on 3 F150 routes, 1 Edge Route, 1 Maverick Route, 1 Mach E Route.

**Route**


e36b272d5679115f/2024-02-19--12-00-50/1



**Verification**

Tested by 6 different drivers.  We have not found highway speed curves which result in > 60 degree wheel angle, but even if one did occur, unless the wheel is also touched with more than 1nM of force, this logic would not engage.  Ford stock logic is always in hands on mode during such a curve.



