### PR TITLE
VW: Early EPS faults are temporary, round deux

### DIFF
--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -49,14 +49,12 @@ class CarState(CarStateBase):
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
     ret.standstill = ret.vEgoRaw == 0
 
-    # Update steering angle, rate, yaw rate, and driver input torque. VW send
-    # the sign/direction in a separate signal so they must be recombined.
+    # Update EPS position and state info. For signed values, VW sends the sign in a separate signal.
     ret.steeringAngleDeg = pt_cp.vl["LWI_01"]["LWI_Lenkradwinkel"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradwinkel"])]
     ret.steeringRateDeg = pt_cp.vl["LWI_01"]["LWI_Lenkradw_Geschw"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradw_Geschw"])]
     ret.steeringTorque = pt_cp.vl["LH_EPS_03"]["EPS_Lenkmoment"] * (1, -1)[int(pt_cp.vl["LH_EPS_03"]["EPS_VZ_Lenkmoment"])]
     ret.steeringPressed = abs(ret.steeringTorque) > self.CCP.STEER_DRIVER_ALLOWANCE
     ret.yawRate = pt_cp.vl["ESP_02"]["ESP_Gierrate"] * (1, -1)[int(pt_cp.vl["ESP_02"]["ESP_VZ_Gierrate"])] * CV.DEG_TO_RAD
-
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
     ret.steerFaultTemporary, ret.steerFaultPermanent = self.update_hca_state(hca_status)
 
@@ -169,14 +167,12 @@ class CarState(CarStateBase):
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
     ret.standstill = ret.vEgoRaw == 0
 
-    # Update steering angle, rate, yaw rate, and driver input torque. VW send
-    # the sign/direction in a separate signal so they must be recombined.
+    # Update EPS position and state info. For signed values, VW sends the sign in a separate signal.
     ret.steeringAngleDeg = pt_cp.vl["Lenkhilfe_3"]["LH3_BLW"] * (1, -1)[int(pt_cp.vl["Lenkhilfe_3"]["LH3_BLWSign"])]
     ret.steeringRateDeg = pt_cp.vl["Lenkwinkel_1"]["Lenkradwinkel_Geschwindigkeit"] * (1, -1)[int(pt_cp.vl["Lenkwinkel_1"]["Lenkradwinkel_Geschwindigkeit_S"])]
     ret.steeringTorque = pt_cp.vl["Lenkhilfe_3"]["LH3_LM"] * (1, -1)[int(pt_cp.vl["Lenkhilfe_3"]["LH3_LMSign"])]
     ret.steeringPressed = abs(ret.steeringTorque) > self.CCP.STEER_DRIVER_ALLOWANCE
     ret.yawRate = pt_cp.vl["Bremse_5"]["Giergeschwindigkeit"] * (1, -1)[int(pt_cp.vl["Bremse_5"]["Vorzeichen_der_Giergeschwindigk"])] * CV.DEG_TO_RAD
-
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["Lenkhilfe_2"]["LH2_Sta_HCA"])
     ret.steerFaultTemporary, ret.steerFaultPermanent = self.update_hca_state(hca_status)
 

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -60,10 +60,10 @@ class CarState(CarStateBase):
     # Verify EPS readiness to accept steering commands
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
-    hca_available = hca_status not in ("DISABLED", "INITIALIZING", "FAULT")
+    hca_available = hca_status not in ("INITIALIZING", "FAULT")
     self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_available)
+    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and not hca_available)
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
-    ret.steerFaultPermanent = self.eps_init_complete and not hca_available
 
     # VW Emergency Assist status tracking and mitigation
     self.eps_stock_values = pt_cp.vl["LH_EPS_03"]
@@ -185,10 +185,10 @@ class CarState(CarStateBase):
     # Verify EPS readiness to accept steering commands
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["Lenkhilfe_2"]["LH2_Sta_HCA"])
-    hca_available = hca_status not in ("DISABLED", "INITIALIZING", "FAULT")
+    hca_available = hca_status not in ("INITIALIZING", "FAULT")
     self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_available)
+    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and not hca_available)
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
-    ret.steerFaultPermanent = self.eps_init_complete and not hca_available
 
     # Update gas, brakes, and gearshift.
     ret.gas = pt_cp.vl["Motor_3"]["Fahrpedal_Rohsignal"] / 100.0

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -61,7 +61,7 @@ class CarState(CarStateBase):
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
-    self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_status in ("DISABLED", "READY", "ACTIVE"))
+    self.eps_init_complete = self.eps_init_complete or (hca_status in ("DISABLED", "READY", "ACTIVE") or self.frame > 600)
     ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and hca_status in ("INITIALIZING", "FAULT"))
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
 
@@ -186,7 +186,7 @@ class CarState(CarStateBase):
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["Lenkhilfe_2"]["LH2_Sta_HCA"])
-    self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_status in ("DISABLED", "READY", "ACTIVE"))
+    self.eps_init_complete = self.eps_init_complete or (hca_status in ("DISABLED", "READY", "ACTIVE") or self.frame > 600)
     ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and hca_status in ("INITIALIZING", "FAULT"))
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
 

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -60,10 +60,10 @@ class CarState(CarStateBase):
     # Verify EPS readiness to accept steering commands
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
-    hca_available = hca_status not in ("INITIALIZING", "FAULT")
+    hca_available = hca_status not in ("DISABLED", "INITIALIZING", "FAULT")
     self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_available)
-    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and not hca_available)
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
+    ret.steerFaultPermanent = self.eps_init_complete and not hca_available
 
     # VW Emergency Assist status tracking and mitigation
     self.eps_stock_values = pt_cp.vl["LH_EPS_03"]
@@ -185,10 +185,10 @@ class CarState(CarStateBase):
     # Verify EPS readiness to accept steering commands
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["Lenkhilfe_2"]["LH2_Sta_HCA"])
-    hca_available = hca_status not in ("INITIALIZING", "FAULT")
+    hca_available = hca_status not in ("DISABLED", "INITIALIZING", "FAULT")
     self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_available)
-    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and not hca_available)
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
+    ret.steerFaultPermanent = self.eps_init_complete and not hca_available
 
     # Update gas, brakes, and gearshift.
     ret.gas = pt_cp.vl["Motor_3"]["Fahrpedal_Rohsignal"] / 100.0

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -59,10 +59,10 @@ class CarState(CarStateBase):
 
     # Verify EPS readiness to accept steering commands
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
+    # DISABLED means the EPS hasn't been configured to support Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
-    hca_available = hca_status not in ("INITIALIZING", "FAULT")
-    self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_available)
-    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and not hca_available)
+    self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_status in ("DISABLED", "READY", "ACTIVE"))
+    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and hca_status in ("INITIALIZING", "FAULT"))
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
 
     # VW Emergency Assist status tracking and mitigation
@@ -184,10 +184,10 @@ class CarState(CarStateBase):
 
     # Verify EPS readiness to accept steering commands
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
+    # DISABLED means the EPS hasn't been configured to support Lane Assist
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["Lenkhilfe_2"]["LH2_Sta_HCA"])
-    hca_available = hca_status not in ("INITIALIZING", "FAULT")
-    self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_available)
-    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and not hca_available)
+    self.eps_init_complete = self.eps_init_complete or (self.frame > 600 or hca_status in ("DISABLED", "READY", "ACTIVE"))
+    ret.steerFaultPermanent = hca_status == "DISABLED" or (self.eps_init_complete and hca_status in ("INITIALIZING", "FAULT"))
     ret.steerFaultTemporary = hca_status == "REJECTED" or not self.eps_init_complete
 
     # Update gas, brakes, and gearshift.


### PR DESCRIPTION
**Description**

Improved version of #25318. Same requirement and same logic applies to both MQB and PQ.

**Verification**

Tested three configuration variants on my 2018 Volkswagen Golf R, one typical and two less-typical.

The second test represents pseudo-officially supported cars that came from the factory without Lane Assist, and are using openpilot courtesy of `vw_mqb_config.py` or their diagnostic tool of choice. On these cars, HCA_01 isn't present until openpilot starts sending it, so the EPS HCA interface doesn't come ready until after openpilot starts. This PR quietly holds those cars in steerFaultTemporary until the EPS recovers, which happens within a second or two.

The third test represents cars like the second, but the owner hasn't made the EPS config change yet, so it will refuse to accept HCA steering commands. For these cars, this PR jumps into steerFaultPermanent immediately. You'll see these routes occasionally as part of those new owners setting up openpilot on their car.

The openpilot MTBF report should not treat any of these routes as having openpilot-relevant bugs. The third variant could be considered a verified failure of the car if you track such things.

**Route**

1) `f39cf149898833ff/2024-02-22--15-24-48/0`: Normal startup on a fully-supported car.

2) `f39cf149898833ff/2024-02-22--15-31-33/0`: With VCDS, de-configured Lane Assist support on my camera.

3) `f39cf149898833ff/2024-02-22--15-38-35/0`: With VCDS, de-configured Lane Assist support on my EPS.
