### PR TITLE
Fix athenad test

### DIFF
--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -698,7 +698,6 @@ def ws_recv(ws: WebSocket, end_event: threading.Event) -> None:
   last_ping = int(time.monotonic() * 1e9)
   while not end_event.is_set():
     try:
-      ret = ws.recv_data(control_frame=True)
       opcode, data = ws.recv_data(control_frame=True)
       if opcode in (ABNF.OPCODE_TEXT, ABNF.OPCODE_BINARY):
         if opcode == ABNF.OPCODE_TEXT:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -699,7 +699,6 @@ def ws_recv(ws: WebSocket, end_event: threading.Event) -> None:
   while not end_event.is_set():
     try:
       ret = ws.recv_data(control_frame=True)
-      print(ret, type(ret))
       opcode, data = ws.recv_data(control_frame=True)
       if opcode in (ABNF.OPCODE_TEXT, ABNF.OPCODE_BINARY):
         if opcode == ABNF.OPCODE_TEXT:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -698,6 +698,8 @@ def ws_recv(ws: WebSocket, end_event: threading.Event) -> None:
   last_ping = int(time.monotonic() * 1e9)
   while not end_event.is_set():
     try:
+      ret = ws.recv_data(control_frame=True)
+      print(ret, type(ret))
       opcode, data = ws.recv_data(control_frame=True)
       if opcode in (ABNF.OPCODE_TEXT, ABNF.OPCODE_BINARY):
         if opcode == ABNF.OPCODE_TEXT:

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -70,7 +70,6 @@ class TestAthenadPing(unittest.TestCase):
       print("ping received")
 
     mock_create_connection.assert_not_called()
-    return
 
     # websocket should attempt reconnect after short time
     with self.subTest("LTE: attempt reconnect"):
@@ -95,7 +94,7 @@ class TestAthenadPing(unittest.TestCase):
     write_onroad_params(False, self.params)
     self.assertTimeout(100)  # expect approx 90s
 
-  # @unittest.skipIf(not TICI, "only run on desk")
+  @unittest.skipIf(not TICI, "only run on desk")
   def test_onroad(self) -> None:
     write_onroad_params(True, self.params)
     self.assertTimeout(30)  # expect 20-30s

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -5,15 +5,12 @@ import time
 import unittest
 from typing import cast, Optional
 from unittest import mock
-from unittest.mock import MagicMock
 
 from openpilot.common.params import Params
 from openpilot.common.timeout import Timeout
 from openpilot.selfdrive.athena import athenad
 from openpilot.selfdrive.manager.helpers import write_onroad_params
 from openpilot.system.hardware import TICI
-from websocket import (ABNF, WebSocket, WebSocketException, WebSocketTimeoutException,
-                       create_connection)
 
 
 def wifi_radio(on: bool) -> None:
@@ -58,24 +55,19 @@ class TestAthenadPing(unittest.TestCase):
       self.exit_event.set()
       self.athenad.join()
 
-  # @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new_callable=lambda: MagicMock(wraps=athenad.create_connection))
-  @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new=MagicMock(wraps=athenad.create_connection))
-  def assertTimeout(self, reconnect_time: float) -> None:
-    print(athenad.create_connection.call_count)
+  @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new_callable=lambda: mock.MagicMock(wraps=athenad.create_connection))
+  def assertTimeout(self, reconnect_time: float, mock_create_connection: mock.MagicMock) -> None:
     self.athenad.start()
 
     time.sleep(1)
-    print(athenad.create_connection.call_count)
     mock_create_connection.assert_called_once()
     mock_create_connection.reset_mock()
-    print(mock_create_connection.call_count)
 
     # check normal behaviour
     with self.subTest("Wi-Fi: receives ping"), Timeout(70, "no ping received"):
       while not self._received_ping():
         time.sleep(0.1)
       print("ping received")
-    print(mock_create_connection.call_count)
 
     mock_create_connection.assert_not_called()
     return

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -58,9 +58,9 @@ class TestAthenadPing(unittest.TestCase):
       self.exit_event.set()
       self.athenad.join()
 
-  # @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new_callable=lambda: MagicMock(wraps=create_connection))
-  @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new=MagicMock(wraps=create_connection))
-  def assertTimeout(self, reconnect_time: float) -> None:
+  @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new_callable=lambda: MagicMock(wraps=athenad.create_connection))
+  # @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new=MagicMock(wraps=create_connection))
+  def assertTimeout(self, reconnect_time: float, mock_create_connection) -> None:
     print(athenad.create_connection.call_count)
     # mock_create_connection.side_effect = create_connection
     self.athenad.start()

--- a/selfdrive/athena/tests/test_athenad_ping.py
+++ b/selfdrive/athena/tests/test_athenad_ping.py
@@ -58,15 +58,14 @@ class TestAthenadPing(unittest.TestCase):
       self.exit_event.set()
       self.athenad.join()
 
-  @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new_callable=lambda: MagicMock(wraps=athenad.create_connection))
-  # @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new=MagicMock(wraps=create_connection))
-  def assertTimeout(self, reconnect_time: float, mock_create_connection) -> None:
+  # @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new_callable=lambda: MagicMock(wraps=athenad.create_connection))
+  @mock.patch('openpilot.selfdrive.athena.athenad.create_connection', new=MagicMock(wraps=athenad.create_connection))
+  def assertTimeout(self, reconnect_time: float) -> None:
     print(athenad.create_connection.call_count)
-    # mock_create_connection.side_effect = create_connection
     self.athenad.start()
-    print(mock_create_connection.call_count)
 
     time.sleep(1)
+    print(athenad.create_connection.call_count)
     mock_create_connection.assert_called_once()
     mock_create_connection.reset_mock()
     print(mock_create_connection.call_count)


### PR DESCRIPTION
Regression from https://github.com/commaai/openpilot/pull/30664, it replaced the wrapping mock with a blank one that didn't call the original `create_connection` function