### PR TITLE
fp - 2023 Subaru Ascent Touring

### DIFF
--- a/selfdrive/car/subaru/fingerprints.py
+++ b/selfdrive/car/subaru/fingerprints.py
@@ -41,12 +41,14 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x05!\x08\x1dK\x05!\x08\x01/',
+      b'\x05!\x08\x1dK\x00\x00\x00\x00\x00',
     ],
     (Ecu.engine, 0x7a2, None): [
       b'\xe5,\xa0P\x07',
     ],
     (Ecu.transmission, 0x7a3, None): [
       b'\x04\xfe\xf3\x00\x00',
+      b'\x04\xfe\xf6\x00\x00',
     ],
   },
   CAR.LEGACY: {


### PR DESCRIPTION
**Car**
2023 Subaru Ascent Touring

**Route**
5a781ec4c7a813d2/2024-02-22--15-22-31

------------------
{'carParams': {'alternativeExperience': 1,
               'autoResumeSng': False,
               'carFingerprint': 'SUBARU ASCENT 2023',
               'carFw': [{'address': 1862,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'eps',
                          'fwVersion': b'%\xc0\xd0\x11',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1870,
                          'subAddress': 0},
                         {'address': 1968,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'abs',
                          'fwVersion': b'\xa5 #\x03\x00',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1976,
                          'subAddress': 0},
                         {'address': 1954,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'engine',
                          'fwVersion': b'\xe5,\xa0p\x07',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1962,
                          'subAddress': 0},
                         {'address': 1955,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'transmission',
                          'fwVersion': b'\x04\xfe\xf6\x00\x00',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1963,
                          'subAddress': 0},
                         {'address': 1927,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'fwdCamera',
                          'fwVersion': b'\x05!\x08\x1dK\x00\x00\x00\x00\x00',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x82'],
                          'responseAddress': 1935,
                          'subAddress': 0},
                         {'address': 1862,
                          'brand': 'subaru',
                          'bus': 0,
                          'ecu': 'eps',
                          'fwVersion': b'%\xc0\xd0\x11',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1870,
                          'subAddress': 0},
                         {'address': 1968,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'abs',
                          'fwVersion': b'\xa5 #\x03\x00',
                          'logging': False,
                          'obdMultiplexing': False,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1976,
                          'subAddress': 0},
                         {'address': 1954,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'engine',
                          'fwVersion': b'\xe5,\xa0p\x07',
                          'logging': False,
                          'obdMultiplexing': False,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1962,
                          'subAddress': 0},
                         {'address': 1955,
                          'brand': 'subaru',
                          'bus': 1,
                          'ecu': 'transmission',
                          'fwVersion': b'\x04\xfe\xf6\x00\x00',
                          'logging': False,
                          'obdMultiplexing': False,
                          'request': [b'>\x00', b'"\xf1\x82'],
                          'responseAddress': 1963,
                          'subAddress': 0}],
               'carName': 'subaru',
               'carVin': '4S4WMAWD3P3445819',
               'centerToFront': 1.4450000524520874,
               'communityFeatureDEPRECATED': False,
               'dashcamOnly': False,
               'directAccelControlDEPRECATED': False,
               'enableApgsDEPRECATED': False,
               'enableBsm': True,
               'enableCameraDEPRECATED': False,
               'enableDsu': False,
               'enableGasInterceptor': False,
               'experimentalLongitudinalAvailable': False,
               'fingerprintSource': 'fw',
               'flags': 1,
               'fuzzyFingerprint': True,
               'hasStockCameraDEPRECATED': False,
               'isPandaBlackDEPRECATED': False,
               'lateralTuning': {'pid': {'kf': 2.9999999242136255e-05,
                                         'kiBP': [0.0, 20.0],
                                         'kiV': [0.0002500000118743628, 0.009999999776482582],
                                         'kpBP': [0.0, 20.0],
                                         'kpV': [0.0024999999441206455, 0.10000000149011612]}},
               'longitudinalActuatorDelayLowerBound': 0.15000000596046448,
               'longitudinalActuatorDelayUpperBound': 0.15000000596046448,
               'longitudinalTuning': {'deadzoneBP': [0.0], 'deadzoneV': [0.0], 'kf': 1.0, 'kiBP': [0.0], 'kiV': [1.0], 'kpBP': [0.0], 'kpV': [1.0]},
               'mass': 2167.0,
               'maxLateralAccel': 3.0,
               'maxSteeringAngleDegDEPRECATED': 0.0,
               'minEnableSpeed': -1.0,
               'minSpeedCanDEPRECATED': 0.0,
               'minSteerSpeed': 0.0,
               'networkLocation': 'fwdCamera',
               'notCar': False,
               'openpilotLongitudinalControl': False,
               'passive': False,
               'pcmCruise': True,
               'radarTimeStep': 0.05000000074505806,
               'radarUnavailable': True,
               'rotationalInertia': 4245.4111328125,
               'safetyConfigs': [{'safetyModel': 'subaru', 'safetyParam': 1, 'safetyParam2DEPRECATED': 0, 'safetyParamDEPRECATED': 0}],
               'safetyModelDEPRECATED': 'silent',
               'safetyModelPassiveDEPRECATED': 'silent',
               'safetyParamDEPRECATED': 0,
               'startAccel': 0.0,
               'startingAccelRateDEPRECATED': 0.0,
               'startingState': False,
               'steerActuatorDelay': 0.30000001192092896,
               'steerControlType': 'angle',
               'steerLimitAlert': False,
               'steerLimitTimer': 0.4000000059604645,
               'steerRateCostDEPRECATED': 0.0,
               'steerRatio': 13.5,
               'steerRatioRear': 0.0,
               'stopAccel': -2.0,
               'stoppingControl': True,
               'stoppingDecelRate': 0.800000011920929,
               'tireStiffnessFactor': 1.0,
               'tireStiffnessFront': 237339.859375,
               'tireStiffnessRear': 375185.96875,
               'transmissionType': 'unknown',
               'vEgoStarting': 0.5,
               'vEgoStopping': 0.5,
               'wheelSpeedFactor': 1.0,
               'wheelbase': 2.890000104904175},
 'logMonoTime': 488361129852,
 'valid': True}
