### PR TITLE
pandad: wait until USB is up before panda recovery

### DIFF
--- a/selfdrive/boardd/pandad.py
+++ b/selfdrive/boardd/pandad.py
@@ -93,6 +93,11 @@ def main() -> NoReturn:
       cloudlog.event("pandad.flash_and_connect", count=count)
       params.remove("PandaSignatures")
 
+      # TODO: remove this in the next AGNOS
+      # wait until USB is up before counting
+      if time.monotonic() < 25.:
+        no_internal_panda_count = 0
+
       # Handle missing internal panda
       if no_internal_panda_count > 0:
         if no_internal_panda_count == 3:


### PR DESCRIPTION
fixes #31539. not a huge deal to delay this anyway, since this recovery is only for edge cases, such as a fork flashing an old bootstub that didn't support SPI on the 3X