### PR TITLE
Ford: move to PlatformConfig

### DIFF
--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -3,7 +3,7 @@ from panda import Panda
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.ford.fordcan import CanBus
-from openpilot.selfdrive.car.ford.values import CANFD_CAR, CAR, Ecu
+from openpilot.selfdrive.car.ford.values import CANFD_CAR, Ecu
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 
 TransmissionType = car.CarParams.TransmissionType
@@ -38,51 +38,6 @@ class CarInterface(CarInterfaceBase):
 
     if candidate in CANFD_CAR:
       ret.safetyConfigs[-1].safetyParam |= Panda.FLAG_FORD_CANFD
-
-    if candidate == CAR.BRONCO_SPORT_MK1:
-      ret.wheelbase = 2.67
-      ret.steerRatio = 17.7
-      ret.mass = 1625
-
-    elif candidate == CAR.ESCAPE_MK4:
-      ret.wheelbase = 2.71
-      ret.steerRatio = 16.7
-      ret.mass = 1750
-
-    elif candidate == CAR.EXPLORER_MK6:
-      ret.wheelbase = 3.025
-      ret.steerRatio = 16.8
-      ret.mass = 2050
-
-    elif candidate == CAR.F_150_MK14:
-      # required trim only on SuperCrew
-      ret.wheelbase = 3.69
-      ret.steerRatio = 17.0
-      ret.mass = 2000
-
-    elif candidate == CAR.F_150_LIGHTNING_MK1:
-      # required trim only on SuperCrew
-      ret.wheelbase = 3.70
-      ret.steerRatio = 16.9
-      ret.mass = 2948
-
-    elif candidate == CAR.MUSTANG_MACH_E_MK1:
-      ret.wheelbase = 2.984
-      ret.steerRatio = 17.0  # guess
-      ret.mass = 2200
-
-    elif candidate == CAR.FOCUS_MK4:
-      ret.wheelbase = 2.7
-      ret.steerRatio = 15.0
-      ret.mass = 1350
-
-    elif candidate == CAR.MAVERICK_MK1:
-      ret.wheelbase = 3.076
-      ret.steerRatio = 17.0
-      ret.mass = 1650
-
-    else:
-      raise ValueError(f"Unsupported car: {candidate}")
 
     # Auto Transmission: 0x732 ECU or Gear_Shift_by_Wire_FD1
     found_ecus = [fw.ecu for fw in car_fw]

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -1,9 +1,8 @@
-from collections import defaultdict
-from dataclasses import dataclass
-from enum import Enum, StrEnum
+from dataclasses import dataclass, field
+from enum import Enum
 
 from cereal import car
-from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
+from openpilot.selfdrive.car import AngleRateLimit, dbc_dict, DbcDict, PlatformConfig, Platforms
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
                                                      Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
@@ -39,31 +38,9 @@ class CarControllerParams:
     pass
 
 
-class CAR(StrEnum):
-  BRONCO_SPORT_MK1 = "FORD BRONCO SPORT 1ST GEN"
-  ESCAPE_MK4 = "FORD ESCAPE 4TH GEN"
-  EXPLORER_MK6 = "FORD EXPLORER 6TH GEN"
-  F_150_MK14 = "FORD F-150 14TH GEN"
-  FOCUS_MK4 = "FORD FOCUS 4TH GEN"
-  MAVERICK_MK1 = "FORD MAVERICK 1ST GEN"
-  F_150_LIGHTNING_MK1 = "FORD F-150 LIGHTNING 1ST GEN"
-  MUSTANG_MACH_E_MK1 = "FORD MUSTANG MACH-E 1ST GEN"
-
-
-CANFD_CAR = {CAR.F_150_MK14, CAR.F_150_LIGHTNING_MK1, CAR.MUSTANG_MACH_E_MK1}
-
-
 class RADAR:
   DELPHI_ESR = 'ford_fusion_2018_adas'
   DELPHI_MRR = 'FORD_CADS'
-
-
-DBC: dict[str, dict[str, str]] = defaultdict(lambda: dbc_dict("ford_lincoln_base_pt", RADAR.DELPHI_MRR))
-
-# F-150 radar is not yet supported
-DBC[CAR.F_150_MK14] = dbc_dict("ford_lincoln_base_pt", None)
-DBC[CAR.F_150_LIGHTNING_MK1] = dbc_dict("ford_lincoln_base_pt", None)
-DBC[CAR.MUSTANG_MACH_E_MK1] = dbc_dict("ford_lincoln_base_pt", None)
 
 
 class Footnote(Enum):
@@ -86,39 +63,74 @@ class FordCarInfo(CarInfo):
       self.car_parts = CarParts([Device.threex, harness])
 
 
-CAR_INFO: dict[str, CarInfo | list[CarInfo]] = {
-  CAR.BRONCO_SPORT_MK1: FordCarInfo("Ford Bronco Sport 2021-22"),
-  CAR.ESCAPE_MK4: [
-    FordCarInfo("Ford Escape 2020-22"),
-    FordCarInfo("Ford Escape Hybrid 2020-22"),
-    FordCarInfo("Ford Escape Plug-in Hybrid 2020-22"),
-    FordCarInfo("Ford Kuga 2020-22", "Adaptive Cruise Control with Lane Centering"),
-    FordCarInfo("Ford Kuga Hybrid 2020-22", "Adaptive Cruise Control with Lane Centering"),
-    FordCarInfo("Ford Kuga Plug-in Hybrid 2020-22", "Adaptive Cruise Control with Lane Centering"),
-  ],
-  CAR.EXPLORER_MK6: [
-    FordCarInfo("Ford Explorer 2020-23"),
-    FordCarInfo("Ford Explorer Hybrid 2020-23"),  # Limited and Platinum only
-    FordCarInfo("Lincoln Aviator 2020-23", "Co-Pilot360 Plus"),
-    FordCarInfo("Lincoln Aviator Plug-in Hybrid 2020-23", "Co-Pilot360 Plus"),  # Grand Touring only
-  ],
-  CAR.F_150_MK14: [
-    FordCarInfo("Ford F-150 2023", "Co-Pilot360 Active 2.0"),
-    FordCarInfo("Ford F-150 Hybrid 2023", "Co-Pilot360 Active 2.0"),
-  ],
-  CAR.F_150_LIGHTNING_MK1: FordCarInfo("Ford F-150 Lightning 2021-23", "Co-Pilot360 Active 2.0"),
-  CAR.MUSTANG_MACH_E_MK1: FordCarInfo("Ford Mustang Mach-E 2021-23", "Co-Pilot360 Active 2.0"),
-  CAR.FOCUS_MK4: [
-    FordCarInfo("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),
-    FordCarInfo("Ford Focus Hybrid 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),  # mHEV only
-  ],
-  CAR.MAVERICK_MK1: [
-    FordCarInfo("Ford Maverick 2022", "LARIAT Luxury"),
-    FordCarInfo("Ford Maverick Hybrid 2022", "LARIAT Luxury"),
-    FordCarInfo("Ford Maverick 2023", "Co-Pilot360 Assist"),
-    FordCarInfo("Ford Maverick Hybrid 2023", "Co-Pilot360 Assist"),
-  ],
-}
+@dataclass
+class FordPlatformConfig(PlatformConfig):
+  dbc_dict: DbcDict = field(default_factory=lambda: dbc_dict('ford_lincoln_base_pt', RADAR.DELPHI_MRR))
+
+
+class CAR(Platforms):
+  BRONCO_SPORT_MK1 = FordPlatformConfig(
+    "FORD BRONCO SPORT 1ST GEN",
+    FordCarInfo("Ford Bronco Sport 2021-22"),
+  )
+  ESCAPE_MK4 = FordPlatformConfig(
+    "FORD ESCAPE 4TH GEN",
+    [
+      FordCarInfo("Ford Escape 2020-22"),
+      FordCarInfo("Ford Escape Hybrid 2020-22"),
+      FordCarInfo("Ford Escape Plug-in Hybrid 2020-22"),
+      FordCarInfo("Ford Kuga 2020-22", "Adaptive Cruise Control with Lane Centering"),
+      FordCarInfo("Ford Kuga Hybrid 2020-22", "Adaptive Cruise Control with Lane Centering"),
+      FordCarInfo("Ford Kuga Plug-in Hybrid 2020-22", "Adaptive Cruise Control with Lane Centering"),
+    ],
+  )
+  EXPLORER_MK6 = FordPlatformConfig(
+    "FORD EXPLORER 6TH GEN",
+    [
+      FordCarInfo("Ford Explorer 2020-23"),
+      FordCarInfo("Ford Explorer Hybrid 2020-23"),  # Limited and Platinum only
+      FordCarInfo("Lincoln Aviator 2020-21", "Co-Pilot360 Plus"),
+      FordCarInfo("Lincoln Aviator Plug-in Hybrid 2020-21", "Co-Pilot360 Plus"),  # Grand Touring only
+    ],
+  )
+  F_150_MK14 = FordPlatformConfig(
+    "FORD F-150 14TH GEN",
+    [
+      FordCarInfo("Ford F-150 2023", "Co-Pilot360 Active 2.0"),
+      FordCarInfo("Ford F-150 Hybrid 2023", "Co-Pilot360 Active 2.0"),
+    ],
+    dbc_dict=dbc_dict('ford_lincoln_base_pt', None),
+  )
+  F_150_LIGHTNING_MK1 = FordPlatformConfig(
+    "FORD F-150 LIGHTNING 1ST GEN",
+    FordCarInfo("Ford F-150 Lightning 2021-23", "Co-Pilot360 Active 2.0"),
+    dbc_dict=dbc_dict('ford_lincoln_base_pt', None),
+  )
+  FOCUS_MK4 = FordPlatformConfig(
+    "FORD FOCUS 4TH GEN",
+    [
+      FordCarInfo("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),
+      FordCarInfo("Ford Focus Hybrid 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),  # mHEV only
+    ],
+  )
+  MAVERICK_MK1 = FordPlatformConfig(
+    "FORD MAVERICK 1ST GEN",
+    [
+      FordCarInfo("Ford Maverick 2022", "LARIAT Luxury"),
+      FordCarInfo("Ford Maverick Hybrid 2022", "LARIAT Luxury"),
+      FordCarInfo("Ford Maverick 2023", "Co-Pilot360 Assist"),
+      FordCarInfo("Ford Maverick Hybrid 2023", "Co-Pilot360 Assist"),
+    ],
+  )
+  MUSTANG_MACH_E_MK1 = FordPlatformConfig(
+    "FORD MUSTANG MACH-E 1ST GEN",
+    FordCarInfo("Ford Mustang Mach-E 2021-23", "Co-Pilot360 Active 2.0"),
+    dbc_dict=dbc_dict('ford_lincoln_base_pt', None),
+  )
+
+
+CANFD_CAR = {CAR.F_150_MK14, CAR.F_150_LIGHTNING_MK1, CAR.MUSTANG_MACH_E_MK1}
+
 
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
@@ -142,3 +154,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     (Ecu.shiftByWire, 0x732, None),
   ],
 )
+
+CAR_INFO = CAR.create_carinfo_map()
+DBC = CAR.create_dbc_map()

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from cereal import car
-from openpilot.selfdrive.car import AngleRateLimit, dbc_dict, DbcDict, PlatformConfig, Platforms
+from openpilot.selfdrive.car import AngleRateLimit, CarSpecs, dbc_dict, DbcDict, PlatformConfig, Platforms
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
                                                      Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
@@ -72,6 +72,7 @@ class CAR(Platforms):
   BRONCO_SPORT_MK1 = FordPlatformConfig(
     "FORD BRONCO SPORT 1ST GEN",
     FordCarInfo("Ford Bronco Sport 2021-22"),
+    specs=CarSpecs(mass=1625, wheelbase=2.67, steerRatio=17.7),
   )
   ESCAPE_MK4 = FordPlatformConfig(
     "FORD ESCAPE 4TH GEN",
@@ -83,6 +84,7 @@ class CAR(Platforms):
       FordCarInfo("Ford Kuga Hybrid 2020-22", "Adaptive Cruise Control with Lane Centering"),
       FordCarInfo("Ford Kuga Plug-in Hybrid 2020-22", "Adaptive Cruise Control with Lane Centering"),
     ],
+    specs=CarSpecs(mass=1750, wheelbase=2.71, steerRatio=16.7),
   )
   EXPLORER_MK6 = FordPlatformConfig(
     "FORD EXPLORER 6TH GEN",
@@ -92,6 +94,7 @@ class CAR(Platforms):
       FordCarInfo("Lincoln Aviator 2020-23", "Co-Pilot360 Plus"),
       FordCarInfo("Lincoln Aviator Plug-in Hybrid 2020-23", "Co-Pilot360 Plus"),  # Grand Touring only
     ],
+    specs=CarSpecs(mass=2050, wheelbase=3.025, steerRatio=16.8),
   )
   F_150_MK14 = FordPlatformConfig(
     "FORD F-150 14TH GEN",
@@ -100,11 +103,13 @@ class CAR(Platforms):
       FordCarInfo("Ford F-150 Hybrid 2023", "Co-Pilot360 Active 2.0"),
     ],
     dbc_dict=dbc_dict('ford_lincoln_base_pt', None),
+    specs=CarSpecs(mass=2000, wheelbase=3.69, steerRatio=17.0),
   )
   F_150_LIGHTNING_MK1 = FordPlatformConfig(
     "FORD F-150 LIGHTNING 1ST GEN",
     FordCarInfo("Ford F-150 Lightning 2021-23", "Co-Pilot360 Active 2.0"),
     dbc_dict=dbc_dict('ford_lincoln_base_pt', None),
+    specs=CarSpecs(mass=2948, wheelbase=3.70, steerRatio=16.9),
   )
   FOCUS_MK4 = FordPlatformConfig(
     "FORD FOCUS 4TH GEN",
@@ -112,6 +117,7 @@ class CAR(Platforms):
       FordCarInfo("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),
       FordCarInfo("Ford Focus Hybrid 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),  # mHEV only
     ],
+    specs=CarSpecs(mass=1350, wheelbase=2.7, steerRatio=15.0),
   )
   MAVERICK_MK1 = FordPlatformConfig(
     "FORD MAVERICK 1ST GEN",
@@ -121,11 +127,13 @@ class CAR(Platforms):
       FordCarInfo("Ford Maverick 2023", "Co-Pilot360 Assist"),
       FordCarInfo("Ford Maverick Hybrid 2023", "Co-Pilot360 Assist"),
     ],
+    specs=CarSpecs(mass=1650, wheelbase=3.076, steerRatio=17.0),
   )
   MUSTANG_MACH_E_MK1 = FordPlatformConfig(
     "FORD MUSTANG MACH-E 1ST GEN",
     FordCarInfo("Ford Mustang Mach-E 2021-23", "Co-Pilot360 Active 2.0"),
     dbc_dict=dbc_dict('ford_lincoln_base_pt', None),
+    specs=CarSpecs(mass=2200, wheelbase=2.984, steerRatio=17.0),  # TODO: check steer ratio
   )
 
 

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -89,8 +89,8 @@ class CAR(Platforms):
     [
       FordCarInfo("Ford Explorer 2020-23"),
       FordCarInfo("Ford Explorer Hybrid 2020-23"),  # Limited and Platinum only
-      FordCarInfo("Lincoln Aviator 2020-21", "Co-Pilot360 Plus"),
-      FordCarInfo("Lincoln Aviator Plug-in Hybrid 2020-21", "Co-Pilot360 Plus"),  # Grand Touring only
+      FordCarInfo("Lincoln Aviator 2020-23", "Co-Pilot360 Plus"),
+      FordCarInfo("Lincoln Aviator Plug-in Hybrid 2020-23", "Co-Pilot360 Plus"),  # Grand Touring only
     ],
   )
   F_150_MK14 = FordPlatformConfig(


### PR DESCRIPTION
Moved CarInfo and CarSpecs to PlatformConfig

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

