### PR TITLE
qcomgpsd: set horizontal accuracy

### DIFF
--- a/system/qcomgpsd/qcomgpsd.py
+++ b/system/qcomgpsd/qcomgpsd.py
@@ -348,6 +348,7 @@ def main() -> NoReturn:
       gps.unixTimestampMillis = dt_timestamp.timestamp()*1e3
       gps.source = log.GpsLocationData.SensorSource.qcomdiag
       gps.vNED = vNED
+      gps.accuracy = report["q_FltHdop"]
       gps.verticalAccuracy = report["q_FltVdop"]
       gps.bearingAccuracyDeg = report["q_FltHeadingUncRad"] * 180/math.pi if (report["q_FltHeadingUncRad"] != 0) else 180
       gps.speedAccuracy = math.sqrt(sum([x**2 for x in vNEDsigma]))


### PR DESCRIPTION
**Description**

qcomgpsd.py was not setting `accuracy` parameter that is present in capnp and so it was always 0.
```
    accuracy = 0,
    verticalAccuracy = 1.3863411,
    bearingAccuracyDeg = 83.561844,
```

**Verification**
I can see plausible accuracy value. 
```
    accuracy = 0.79913158,
    verticalAccuracy = 1.3863411,
    bearingAccuracyDeg = 83.561844,
```