### PR TITLE
ruff: enable and configure import sorting

### DIFF
--- a/common/api/__init__.py
+++ b/common/api/__init__.py
@@ -1,7 +1,9 @@
-import jwt
 import os
-import requests
 from datetime import datetime, timedelta
+
+import jwt
+import requests
+
 from openpilot.system.hardware.hw import Paths
 from openpilot.system.version import get_version
 

--- a/common/basedir.py
+++ b/common/basedir.py
@@ -1,4 +1,3 @@
 import os
 
-
 BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"))

--- a/common/conversions.py
+++ b/common/conversions.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class Conversions:
   # Speed
   MPH_TO_KPH = 1.609344

--- a/common/file_helpers.py
+++ b/common/file_helpers.py
@@ -1,6 +1,6 @@
+import contextlib
 import os
 import tempfile
-import contextlib
 
 
 class CallbackReader:

--- a/common/gpio.py
+++ b/common/gpio.py
@@ -1,6 +1,7 @@
 import os
 from functools import lru_cache
 
+
 def gpio_init(pin: int, output: bool) -> None:
   try:
     with open(f"/sys/class/gpio/gpio{pin}/direction", 'wb') as f:

--- a/common/logging_extra.py
+++ b/common/logging_extra.py
@@ -1,16 +1,16 @@
-import io
-import os
-import sys
 import copy
+import io
 import json
-import time
-import uuid
-import socket
 import logging
+import os
+import socket
+import sys
+import time
 import traceback
-from threading import local
+import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
+from threading import local
 
 LOG_TIMESTAMPS = "LOG_TIMESTAMPS" in os.environ
 

--- a/common/mock/__init__.py
+++ b/common/mock/__init__.py
@@ -6,11 +6,11 @@ example in common/tests/test_mock.py
 
 import functools
 import threading
+
 from cereal.messaging import PubMaster
 from cereal.services import SERVICE_LIST
 from openpilot.common.mock.generators import generate_liveLocationKalman
 from openpilot.common.realtime import Ratekeeper
-
 
 MOCK_GENERATOR = {
   "liveLocationKalman": generate_liveLocationKalman

--- a/common/mock/generators.py
+++ b/common/mock/generators.py
@@ -1,6 +1,5 @@
 from cereal import messaging
 
-
 LOCATION1 = (32.7174, -117.16277)
 LOCATION2 = (32.7558, -117.2037)
 

--- a/common/params.py
+++ b/common/params.py
@@ -1,4 +1,5 @@
-from openpilot.common.params_pyx import Params, ParamKeyType, UnknownKeyName
+from openpilot.common.params_pyx import ParamKeyType, Params, UnknownKeyName
+
 assert Params
 assert ParamKeyType
 assert UnknownKeyName

--- a/common/prefix.py
+++ b/common/prefix.py
@@ -2,10 +2,9 @@ import os
 import shutil
 import uuid
 
-
 from openpilot.common.params import Params
-from openpilot.system.hardware.hw import Paths
-from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
+from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT, Paths
+
 
 class OpenpilotPrefix:
   def __init__(self, prefix: str | None = None, clean_dirs_on_exit: bool = True, shared_download_cache: bool = False):

--- a/common/realtime.py
+++ b/common/realtime.py
@@ -8,7 +8,6 @@ from setproctitle import getproctitle
 
 from openpilot.system.hardware import PC
 
-
 # time step for each process
 DT_CTRL = 0.01  # controlsd
 DT_MDL = 0.05  # model

--- a/common/retry.py
+++ b/common/retry.py
@@ -1,5 +1,5 @@
-import time
 import functools
+import time
 
 from openpilot.common.swaglog import cloudlog
 

--- a/common/spinner.py
+++ b/common/spinner.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+
 from openpilot.common.basedir import BASEDIR
 
 

--- a/common/stat_live.py
+++ b/common/stat_live.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class RunningStat():
   # tracks realtime mean and standard deviation without storing any data
   def __init__(self, priors=None, max_trackable=-1):

--- a/common/swaglog.py
+++ b/common/swaglog.py
@@ -2,12 +2,12 @@ import logging
 import os
 import time
 import warnings
-from pathlib import Path
 from logging.handlers import BaseRotatingHandler
+from pathlib import Path
 
 import zmq
 
-from openpilot.common.logging_extra import SwagLogger, SwagFormatter, SwagLogFileFormatter
+from openpilot.common.logging_extra import SwagFormatter, SwagLogFileFormatter, SwagLogger
 from openpilot.system.hardware.hw import Paths
 
 

--- a/common/tests/test_numpy_fast.py
+++ b/common/tests/test_numpy_fast.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 from openpilot.common.numpy_fast import interp
 

--- a/common/tests/test_params.py
+++ b/common/tests/test_params.py
@@ -1,10 +1,11 @@
 import os
 import threading
 import time
-import uuid
 import unittest
+import uuid
 
-from openpilot.common.params import Params, ParamKeyType, UnknownKeyName
+from openpilot.common.params import ParamKeyType, Params, UnknownKeyName
+
 
 class TestParams(unittest.TestCase):
   def setUp(self):

--- a/common/text_window.py
+++ b/common/text_window.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import os
-import time
 import subprocess
+import time
+
 from openpilot.common.basedir import BASEDIR
 
 

--- a/common/timeout.py
+++ b/common/timeout.py
@@ -1,5 +1,6 @@
 import signal
 
+
 class TimeoutException(Exception):
   pass
 

--- a/common/transformations/coordinates.py
+++ b/common/transformations/coordinates.py
@@ -1,7 +1,5 @@
 from openpilot.common.transformations.orientation import numpy_wrap
-from openpilot.common.transformations.transformations import (ecef2geodetic_single,
-                                                    geodetic2ecef_single)
-from openpilot.common.transformations.transformations import LocalCoord as LocalCoord_single
+from openpilot.common.transformations.transformations import LocalCoord as LocalCoord_single, ecef2geodetic_single, geodetic2ecef_single
 
 
 class LocalCoord(LocalCoord_single):

--- a/common/transformations/model.py
+++ b/common/transformations/model.py
@@ -1,9 +1,14 @@
 import numpy as np
 
-from openpilot.common.transformations.orientation import rot_from_euler
 from openpilot.common.transformations.camera import (
-  FULL_FRAME_SIZE, get_view_frame_from_calib_frame, view_frame_from_device_frame,
-  eon_fcam_intrinsics, tici_ecam_intrinsics, tici_fcam_intrinsics)
+  FULL_FRAME_SIZE,
+  eon_fcam_intrinsics,
+  get_view_frame_from_calib_frame,
+  tici_ecam_intrinsics,
+  tici_fcam_intrinsics,
+  view_frame_from_device_frame,
+)
+from openpilot.common.transformations.orientation import rot_from_euler
 
 # segnet
 SEGNET_SIZE = (512, 384)

--- a/common/transformations/orientation.py
+++ b/common/transformations/orientation.py
@@ -1,14 +1,17 @@
-import numpy as np
 from collections.abc import Callable
 
-from openpilot.common.transformations.transformations import (ecef_euler_from_ned_single,
-                                                    euler2quat_single,
-                                                    euler2rot_single,
-                                                    ned_euler_from_ecef_single,
-                                                    quat2euler_single,
-                                                    quat2rot_single,
-                                                    rot2euler_single,
-                                                    rot2quat_single)
+import numpy as np
+
+from openpilot.common.transformations.transformations import (
+  ecef_euler_from_ned_single,
+  euler2quat_single,
+  euler2rot_single,
+  ned_euler_from_ecef_single,
+  quat2euler_single,
+  quat2rot_single,
+  rot2euler_single,
+  rot2quat_single,
+)
 
 
 def numpy_wrap(function, input_shape, output_shape) -> Callable[..., np.ndarray]:

--- a/common/transformations/tests/test_coordinates.py
+++ b/common/transformations/tests/test_coordinates.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import numpy as np
 import unittest
+
+import numpy as np
 
 import openpilot.common.transformations.coordinates as coord
 

--- a/common/transformations/tests/test_orientation.py
+++ b/common/transformations/tests/test_orientation.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
-import numpy as np
 import unittest
 
-from openpilot.common.transformations.orientation import euler2quat, quat2euler, euler2rot, rot2euler, \
-                                               rot2quat, quat2rot, \
-                                               ned_euler_from_ecef
+import numpy as np
+
+from openpilot.common.transformations.orientation import euler2quat, euler2rot, ned_euler_from_ecef, quat2euler, quat2rot, rot2euler, rot2quat
 
 eulers = np.array([[ 1.46520501,  2.78688383,  2.92780854],
        [ 4.86909526,  3.60618161,  4.30648981],

--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,13 @@
 import contextlib
 import gc
 import os
-import pytest
 import random
+
+import pytest
 
 from openpilot.common.prefix import OpenpilotPrefix
 from openpilot.selfdrive.manager import manager
-from openpilot.system.hardware import TICI, HARDWARE
+from openpilot.system.hardware import HARDWARE, TICI
 
 
 def pytest_sessionstart(session):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,8 +167,6 @@ build-backend = "poetry.core.masonry.api"
 
 # https://beta.ruff.rs/docs/configuration/#using-pyprojecttoml
 [tool.ruff]
-lint.select = ["E", "F", "W", "PIE", "C4", "ISC", "RUF008", "RUF100", "A", "B", "TID251"]
-lint.ignore = ["E741", "E402", "C408", "ISC003", "B027", "B024"]
 line-length = 160
 target-version="py311"
 exclude = [
@@ -180,13 +178,26 @@ exclude = [
   "teleoprtc_repo",
   "third_party",
 ]
-lint.flake8-implicit-str-concat.allow-multiline=false
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "PIE", "C4", "ISC", "RUF008", "RUF100", "A", "B", "TID251", "I001", "I002"]
+ignore = ["E741", "E402", "C408", "ISC003", "B027", "B024"]
+
+flake8-implicit-str-concat.allow-multiline=false
+
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "selfdrive".msg = "Use openpilot.selfdrive"
 "common".msg = "Use openpilot.common"
 "system".msg = "Use openpilot.system"
 "third_party".msg = "Use openpilot.third_party"
 "tools".msg = "Use openpilot.tools"
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
+known-first-party = ["cereal", "opendbc", "panda", "rednose"]
+known-local-folder = ["openpilot"]
+no-lines-before = ["local-folder"]
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]

--- a/scripts/code_stats.py
+++ b/scripts/code_stats.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import os
 import ast
+import os
 import stat
 import subprocess
 

--- a/scripts/pyqt_demo.py
+++ b/scripts/pyqt_demo.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 from PyQt5.QtWidgets import QApplication, QLabel
-from openpilot.selfdrive.ui.qt.python_helpers import set_main_window
 
+from openpilot.selfdrive.ui.qt.python_helpers import set_main_window
 
 if __name__ == "__main__":
   app = QApplication([])

--- a/scripts/waste.py
+++ b/scripts/waste.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 import os
 import time
-import numpy as np
 from multiprocessing import Process
+
+import numpy as np
 from setproctitle import setproctitle
+
 
 def waste(core):
   os.sched_setaffinity(0, [core,])

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -15,17 +15,16 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from functools import partial
 from queue import Queue
 from typing import cast
-from collections.abc import Callable
 
 import requests
 from jsonrpc import JSONRPCResponseManager, dispatcher
-from websocket import (ABNF, WebSocket, WebSocketException, WebSocketTimeoutException,
-                       create_connection)
+from websocket import ABNF, WebSocket, WebSocketException, WebSocketTimeoutException, create_connection
 
 import cereal.messaging as messaging
 from cereal import log
@@ -34,12 +33,11 @@ from openpilot.common.api import Api
 from openpilot.common.file_helpers import CallbackReader
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_core_affinity
-from openpilot.system.hardware import HARDWARE, PC
-from openpilot.system.loggerd.xattr_cache import getxattr, setxattr
 from openpilot.common.swaglog import cloudlog
-from openpilot.system.version import get_commit, get_normalized_origin, get_short_branch, get_version
+from openpilot.system.hardware import HARDWARE, PC
 from openpilot.system.hardware.hw import Paths
-
+from openpilot.system.loggerd.xattr_cache import getxattr, setxattr
+from openpilot.system.version import get_commit, get_normalized_origin, get_short_branch, get_version
 
 ATHENA_HOST = os.getenv('ATHENA_HOST', 'wss://athena.comma.ai')
 HANDLER_THREADS = int(os.getenv('HANDLER_THREADS', "4"))

--- a/selfdrive/athena/manage_athenad.py
+++ b/selfdrive/athena/manage_athenad.py
@@ -4,10 +4,10 @@ import time
 from multiprocessing import Process
 
 from openpilot.common.params import Params
-from openpilot.selfdrive.manager.process import launcher
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.manager.process import launcher
 from openpilot.system.hardware import HARDWARE
-from openpilot.system.version import get_version, get_normalized_origin, get_short_branch, get_commit, is_dirty
+from openpilot.system.version import get_commit, get_normalized_origin, get_short_branch, get_version, is_dirty
 
 ATHENA_MGR_PID_PARAM = "AthenadPid"
 

--- a/selfdrive/athena/registration.py
+++ b/selfdrive/athena/registration.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-import time
 import json
-import jwt
+import time
+from datetime import datetime, timedelta
 from pathlib import Path
 
-from datetime import datetime, timedelta
+import jwt
+
 from openpilot.common.api import api_get
 from openpilot.common.params import Params
 from openpilot.common.spinner import Spinner
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.alertmanager import set_offroad_alert
 from openpilot.system.hardware import HARDWARE, PC
 from openpilot.system.hardware.hw import Paths
-from openpilot.common.swaglog import cloudlog
-
 
 UNREGISTERED_DONGLE_ID = "UnregisteredDevice"
 

--- a/selfdrive/athena/tests/helpers.py
+++ b/selfdrive/athena/tests/helpers.py
@@ -1,6 +1,6 @@
 import http.server
-import threading
 import socket
+import threading
 from functools import wraps
 
 

--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -1,31 +1,29 @@
 #!/usr/bin/env python3
-from functools import partial, wraps
 import json
 import multiprocessing
 import os
-import requests
-import shutil
-import time
-import threading
 import queue
+import shutil
+import threading
+import time
 import unittest
 from dataclasses import asdict, replace
 from datetime import datetime, timedelta
-from parameterized import parameterized
-
+from functools import partial, wraps
 from unittest import mock
+
+import requests
+from parameterized import parameterized
 from websocket import ABNF
 from websocket._exceptions import WebSocketConnectionClosedException
 
 from cereal import messaging
-
 from openpilot.common.params import Params
 from openpilot.common.timeout import Timeout
 from openpilot.selfdrive.athena import athenad
 from openpilot.selfdrive.athena.athenad import MAX_RETRY_COUNT, dispatcher
-from openpilot.selfdrive.athena.tests.helpers import MockWebsocket, MockApi, EchoSocket, with_http_server
+from openpilot.selfdrive.athena.tests.helpers import EchoSocket, HTTPRequestHandler, MockApi, MockWebsocket, with_http_server
 from openpilot.system.hardware.hw import Paths
-from openpilot.selfdrive.athena.tests.helpers import HTTPRequestHandler
 
 
 def seed_athena_server(host, port):

--- a/selfdrive/athena/tests/test_registration.py
+++ b/selfdrive/athena/tests/test_registration.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 import json
 import unittest
-from Crypto.PublicKey import RSA
 from pathlib import Path
 from unittest import mock
 
+from Crypto.PublicKey import RSA
+
 from openpilot.common.params import Params
-from openpilot.selfdrive.athena.registration import register, UNREGISTERED_DONGLE_ID
+from openpilot.selfdrive.athena.registration import UNREGISTERED_DONGLE_ID, register
 from openpilot.selfdrive.athena.tests.helpers import MockResponse
 from openpilot.system.hardware.hw import Paths
 

--- a/selfdrive/boardd/boardd.py
+++ b/selfdrive/boardd/boardd.py
@@ -1,5 +1,6 @@
 # Cython, now uses scons to build
 from openpilot.selfdrive.boardd.boardd_api_impl import can_list_to_can_capnp
+
 assert can_list_to_can_capnp
 
 def can_capnp_to_can_list(can, src_filter=None):

--- a/selfdrive/boardd/pandad.py
+++ b/selfdrive/boardd/pandad.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 # simple boardd wrapper that updates the panda first
 import os
-import usb1
-import time
 import subprocess
-from typing import NoReturn
+import time
 from functools import cmp_to_key
+from typing import NoReturn
 
-from panda import Panda, PandaDFU, PandaProtocolMismatch, FW_PATH
+import usb1
+
+from panda import FW_PATH, Panda, PandaDFU, PandaProtocolMismatch
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.boardd.set_time import set_time
 from openpilot.system.hardware import HARDWARE
-from openpilot.common.swaglog import cloudlog
 
 
 def get_expected_signature(panda: Panda) -> bytes:

--- a/selfdrive/boardd/set_time.py
+++ b/selfdrive/boardd/set_time.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-import os
 import datetime
-from panda import Panda
+import os
 
+from panda import Panda
 from openpilot.common.time import MIN_DATE
+
 
 def set_time(logger):
   sys_time = datetime.datetime.today()

--- a/selfdrive/boardd/tests/test_boardd_loopback.py
+++ b/selfdrive/boardd/tests/test_boardd_loopback.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import os
 import copy
+import os
 import random
 import time
 import unittest
@@ -13,8 +13,8 @@ from openpilot.common.params import Params
 from openpilot.common.timeout import Timeout
 from openpilot.selfdrive.boardd.boardd import can_list_to_can_capnp
 from openpilot.selfdrive.car import make_can_msg
-from openpilot.system.hardware import TICI
 from openpilot.selfdrive.test.helpers import phone_only, with_processes
+from openpilot.system.hardware import TICI
 
 
 class TestBoardd(unittest.TestCase):

--- a/selfdrive/boardd/tests/test_pandad.py
+++ b/selfdrive/boardd/tests/test_pandad.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 import os
-import pytest
 import time
 import unittest
 
+import pytest
+
 import cereal.messaging as messaging
 from cereal import log
-from openpilot.common.gpio import gpio_set, gpio_init
 from panda import Panda, PandaDFU, PandaProtocolMismatch
+from openpilot.common.gpio import gpio_init, gpio_set
 from openpilot.selfdrive.manager.process_config import managed_processes
 from openpilot.system.hardware import HARDWARE
 from openpilot.system.hardware.tici.pins import GPIO

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -9,7 +9,6 @@ from cereal import car
 from openpilot.common.numpy_fast import clip, interp
 from openpilot.selfdrive.car.docs_definitions import CarInfo
 
-
 # kg of standard extra cargo to count for drive, gas, etc...
 STD_CARGO_KG = 136.
 

--- a/selfdrive/car/body/carcontroller.py
+++ b/selfdrive/car/body/carcontroller.py
@@ -1,12 +1,11 @@
 import numpy as np
 
+from opendbc.can.packer import CANPacker
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_CTRL
-from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car.body import bodycan
 from openpilot.selfdrive.car.body.values import SPEED_FROM_RPM
 from openpilot.selfdrive.controls.lib.pid import PIDController
-
 
 MAX_TORQUE = 500
 MAX_TORQUE_RATE = 50

--- a/selfdrive/car/body/carstate.py
+++ b/selfdrive/car/body/carstate.py
@@ -1,7 +1,7 @@
 from cereal import car
 from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.body.values import DBC
+from openpilot.selfdrive.car.interfaces import CarStateBase
 
 STARTUP_TICKS = 100
 

--- a/selfdrive/car/body/interface.py
+++ b/selfdrive/car/body/interface.py
@@ -1,9 +1,11 @@
 import math
+
 from cereal import car
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car import get_safety_config
-from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.car.body.values import SPEED_FROM_RPM
+from openpilot.selfdrive.car.interfaces import CarInterfaceBase
+
 
 class CarInterface(CarInterfaceBase):
   @staticmethod

--- a/selfdrive/car/body/radar_interface.py
+++ b/selfdrive/car/body/radar_interface.py
@@ -1,4 +1,5 @@
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -2,18 +2,18 @@ import os
 import time
 from collections.abc import Callable
 
-from cereal import car
-from openpilot.common.params import Params
-from openpilot.common.basedir import BASEDIR
-from openpilot.selfdrive.car.values import PLATFORMS
-from openpilot.system.version import is_comma_remote, is_tested_branch
-from openpilot.selfdrive.car.interfaces import get_interface_attr
-from openpilot.selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
-from openpilot.selfdrive.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
-from openpilot.selfdrive.car.fw_versions import get_fw_versions_ordered, get_present_ecus, match_fw_to_car, set_obd_multiplexing
-from openpilot.common.swaglog import cloudlog
 import cereal.messaging as messaging
+from cereal import car
+from openpilot.common.basedir import BASEDIR
+from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.car import gen_empty_fingerprint
+from openpilot.selfdrive.car.fingerprints import all_legacy_fingerprint_cars, eliminate_incompatible_cars
+from openpilot.selfdrive.car.fw_versions import get_fw_versions_ordered, get_present_ecus, match_fw_to_car, set_obd_multiplexing
+from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.car.values import PLATFORMS
+from openpilot.selfdrive.car.vin import VIN_UNKNOWN, get_vin, is_valid_vin
+from openpilot.system.version import is_comma_remote, is_tested_branch
 
 FRAME_FINGERPRINT = 100  # 1s
 

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -1,9 +1,9 @@
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
-from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine
+from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
+from openpilot.selfdrive.car.chrysler.values import DBC, RAM_CARS, STEER_THRESHOLD
 from openpilot.selfdrive.car.interfaces import CarStateBase
-from openpilot.selfdrive.car.chrysler.values import DBC, STEER_THRESHOLD, RAM_CARS
 
 
 class CarState(CarStateBase):

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -2,7 +2,7 @@
 from cereal import car
 from panda import Panda
 from openpilot.selfdrive.car import get_safety_config
-from openpilot.selfdrive.car.chrysler.values import CAR, RAM_HD, RAM_DT, RAM_CARS, ChryslerFlags
+from openpilot.selfdrive.car.chrysler.values import CAR, RAM_CARS, RAM_DT, RAM_HD, ChryslerFlags
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 
 

--- a/selfdrive/car/chrysler/radar_interface.py
+++ b/selfdrive/car/chrysler/radar_interface.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from opendbc.can.parser import CANParser
 from cereal import car
-from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
+from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.chrysler.values import DBC
+from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
 RADAR_MSGS_C = list(range(0x2c2, 0x2d4+2, 2))  # c_ messages 706,...,724
 RADAR_MSGS_D = list(range(0x2a2, 0x2b4+2, 2))  # d_ messages

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -1,5 +1,5 @@
-from enum import IntFlag, StrEnum
 from dataclasses import dataclass, field
+from enum import IntFlag, StrEnum
 
 from cereal import car
 from panda.python import uds

--- a/selfdrive/car/disable_ecu.py
+++ b/selfdrive/car/disable_ecu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-from openpilot.selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
 
 EXT_DIAG_REQUEST = b'\x10\x03'
 EXT_DIAG_RESPONSE = b'\x50\x03'
@@ -39,6 +39,7 @@ def disable_ecu(logcan, sendcan, bus=0, addr=0x7d0, sub_addr=None, com_cont_req=
 
 if __name__ == "__main__":
   import time
+
   import cereal.messaging as messaging
   sendcan = messaging.pub_sock('sendcan')
   logcan = messaging.sub_sock('can')

--- a/selfdrive/car/docs.py
+++ b/selfdrive/car/docs.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 import argparse
-from collections import defaultdict
-import jinja2
 import os
+from collections import defaultdict
 from enum import Enum
+
+import jinja2
 from natsort import natsorted
 
 from cereal import car
 from openpilot.common.basedir import BASEDIR
 from openpilot.selfdrive.car import gen_empty_fingerprint
+from openpilot.selfdrive.car.car_helpers import get_interface_attr, interfaces
 from openpilot.selfdrive.car.docs_definitions import CarInfo, Column, CommonFootnote, PartType
-from openpilot.selfdrive.car.car_helpers import interfaces, get_interface_attr
 
 
 def get_all_footnotes() -> dict[Enum, int]:

--- a/selfdrive/car/docs_definitions.py
+++ b/selfdrive/car/docs_definitions.py
@@ -1,6 +1,6 @@
+import copy
 import re
 from collections import namedtuple
-import copy
 from dataclasses import dataclass, field
 from enum import Enum
 

--- a/selfdrive/car/ecu_addrs.py
+++ b/selfdrive/car/ecu_addrs.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-import capnp
 import time
+
+import capnp
 
 import cereal.messaging as messaging
 from panda.python.uds import SERVICE_TYPE
+from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.boardd.boardd import can_list_to_can_capnp
 from openpilot.selfdrive.car import make_can_msg
 from openpilot.selfdrive.car.fw_query_definitions import EcuAddrBusType
-from openpilot.selfdrive.boardd.boardd import can_list_to_can_capnp
-from openpilot.common.swaglog import cloudlog
 
 
 def make_tester_present_msg(addr, bus, subaddr=None):

--- a/selfdrive/car/ford/carcontroller.py
+++ b/selfdrive/car/ford/carcontroller.py
@@ -1,6 +1,6 @@
 from cereal import car
-from openpilot.common.numpy_fast import clip
 from opendbc.can.packer import CANPacker
+from openpilot.common.numpy_fast import clip
 from openpilot.selfdrive.car import apply_std_steer_angle_limits
 from openpilot.selfdrive.car.ford import fordcan
 from openpilot.selfdrive.car.ford.values import CANFD_CAR, CarControllerParams

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -1,10 +1,10 @@
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.interfaces import CarStateBase
+from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car.ford.fordcan import CanBus
-from openpilot.selfdrive.car.ford.values import CANFD_CAR, CarControllerParams, DBC
+from openpilot.selfdrive.car.ford.values import CANFD_CAR, DBC, CarControllerParams
+from openpilot.selfdrive.car.interfaces import CarStateBase
 
 GearShifter = car.CarState.GearShifter
 TransmissionType = car.CarParams.TransmissionType

--- a/selfdrive/car/ford/radar_interface.py
+++ b/selfdrive/car/ford/radar_interface.py
@@ -1,4 +1,5 @@
 from math import cos, sin
+
 from cereal import car
 from opendbc.can.parser import CANParser
 from openpilot.common.conversions import Conversions as CV

--- a/selfdrive/car/ford/tests/test_ford.py
+++ b/selfdrive/car/ford/tests/test_ford.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 import unittest
-from parameterized import parameterized
 from collections.abc import Iterable
 
 import capnp
+from parameterized import parameterized
 
 from cereal import car
-from openpilot.selfdrive.car.ford.values import FW_QUERY_CONFIG
 from openpilot.selfdrive.car.ford.fingerprints import FW_VERSIONS
+from openpilot.selfdrive.car.ford.values import FW_QUERY_CONFIG
 
 Ecu = car.CarParams.Ecu
 

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -4,8 +4,7 @@ from enum import Enum, StrEnum
 
 from cereal import car
 from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
-from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
-                                                     Device
+from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
 Ecu = car.CarParams.Ecu

--- a/selfdrive/car/fw_query_definitions.py
+++ b/selfdrive/car/fw_query_definitions.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-import capnp
 import copy
-from dataclasses import dataclass, field
 import struct
 from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import capnp
 
 import panda.python.uds as uds
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
 from collections import defaultdict
-from typing import Any, TypeVar
 from collections.abc import Iterator
-from tqdm import tqdm
+from typing import Any, TypeVar
+
 import capnp
+from tqdm import tqdm
 
 import panda.python.uds as uds
 from cereal import car
 from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.car.ecu_addrs import get_ecu_addrs
+from openpilot.selfdrive.car.fingerprints import FW_VERSIONS
 from openpilot.selfdrive.car.fw_query_definitions import AddrType, EcuAddrBusType, FwQueryConfig
 from openpilot.selfdrive.car.interfaces import get_interface_attr
-from openpilot.selfdrive.car.fingerprints import FW_VERSIONS
 from openpilot.selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
-from openpilot.common.swaglog import cloudlog
 
 Ecu = car.CarParams.Ecu
 ESSENTIAL_ECUS = [Ecu.engine, Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.vsa]
@@ -331,8 +332,9 @@ def get_fw_versions(logcan, sendcan, query_brand=None, extra=None, timeout=0.1, 
 
 
 if __name__ == "__main__":
-  import time
   import argparse
+  import time
+
   import cereal.messaging as messaging
   from openpilot.selfdrive.car.vin import get_vin
 

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -1,8 +1,8 @@
 from cereal import car
+from opendbc.can.packer import CANPacker
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import interp
 from openpilot.common.realtime import DT_CTRL
-from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import apply_driver_steer_torque_limits
 from openpilot.selfdrive.car.gm import gmcan
 from openpilot.selfdrive.car.gm.values import DBC, CanBus, CarControllerParams, CruiseButtons

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -1,11 +1,12 @@
 import copy
+
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
-from openpilot.common.numpy_fast import mean
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
+from openpilot.common.numpy_fast import mean
+from openpilot.selfdrive.car.gm.values import DBC, STEER_THRESHOLD, AccState, CanBus
 from openpilot.selfdrive.car.interfaces import CarStateBase
-from openpilot.selfdrive.car.gm.values import DBC, AccState, CanBus, STEER_THRESHOLD
 
 TransmissionType = car.CarParams.TransmissionType
 NetworkLocation = car.CarParams.NetworkLocation

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 import os
-from cereal import car
-from math import fabs, exp
-from panda import Panda
+from math import exp, fabs
 
+from cereal import car
+from panda import Panda
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car import create_button_events, get_safety_config
 from openpilot.selfdrive.car.gm.radar_interface import RADAR_HEADER_MSG
-from openpilot.selfdrive.car.gm.values import CAR, CruiseButtons, CarControllerParams, EV_CAR, CAMERA_ACC_CAR, CanBus
-from openpilot.selfdrive.car.interfaces import CarInterfaceBase, TorqueFromLateralAccelCallbackType, FRICTION_THRESHOLD, LatControlInputs, NanoFFModel
+from openpilot.selfdrive.car.gm.values import CAMERA_ACC_CAR, CAR, EV_CAR, CanBus, CarControllerParams, CruiseButtons
+from openpilot.selfdrive.car.interfaces import FRICTION_THRESHOLD, CarInterfaceBase, LatControlInputs, NanoFFModel, TorqueFromLateralAccelCallbackType
 from openpilot.selfdrive.controls.lib.drive_helpers import get_friction
 
 ButtonType = car.CarState.ButtonEvent.Type

--- a/selfdrive/car/gm/radar_interface.py
+++ b/selfdrive/car/gm/radar_interface.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import math
+
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
 from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car.gm.values import DBC, CanBus
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 

--- a/selfdrive/car/gm/tests/test_gm.py
+++ b/selfdrive/car/gm/tests/test_gm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-from parameterized import parameterized
 import unittest
+
+from parameterized import parameterized
 
 from openpilot.selfdrive.car.gm.fingerprints import FINGERPRINTS
 from openpilot.selfdrive.car.gm.values import CAMERA_ACC_CAR, CAR, GM_RX_OFFSET

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -1,12 +1,12 @@
 from collections import namedtuple
 
 from cereal import car
+from opendbc.can.packer import CANPacker
 from openpilot.common.numpy_fast import clip, interp
 from openpilot.common.realtime import DT_CTRL
-from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import create_gas_interceptor_command
 from openpilot.selfdrive.car.honda import hondacan
-from openpilot.selfdrive.car.honda.values import CruiseButtons, VISUAL_HUD, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, HONDA_NIDEC_ALT_PCM_ACCEL, CarControllerParams
+from openpilot.selfdrive.car.honda.values import HONDA_BOSCH, HONDA_BOSCH_RADARLESS, HONDA_NIDEC_ALT_PCM_ACCEL, VISUAL_HUD, CarControllerParams, CruiseButtons
 from openpilot.selfdrive.controls.lib.drive_helpers import rate_limit
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -1,14 +1,12 @@
 from collections import defaultdict
 
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
-from openpilot.common.numpy_fast import interp
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
+from openpilot.common.numpy_fast import interp
 from openpilot.selfdrive.car.honda.hondacan import get_cruise_speed_conversion, get_pt_bus
-from openpilot.selfdrive.car.honda.values import CAR, DBC, STEER_THRESHOLD, HONDA_BOSCH, \
-                                                 HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, \
-                                                 HondaFlags
+from openpilot.selfdrive.car.honda.values import CAR, DBC, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, HONDA_NIDEC_ALT_SCM_MESSAGES, STEER_THRESHOLD, HondaFlags
 from openpilot.selfdrive.car.interfaces import CarStateBase
 
 TransmissionType = car.CarParams.TransmissionType

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -1,5 +1,5 @@
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car.honda.values import HondaFlags, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, CAR, CarControllerParams
+from openpilot.selfdrive.car.honda.values import CAR, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, CarControllerParams, HondaFlags
 
 # CAN bus layout with relay
 # 0 = ACC-CAN - radar side

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -3,13 +3,19 @@ from cereal import car
 from panda import Panda
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import interp
-from openpilot.selfdrive.car.honda.hondacan import get_pt_bus
-from openpilot.selfdrive.car.honda.values import CarControllerParams, CruiseButtons, HondaFlags, CAR, HONDA_BOSCH, HONDA_NIDEC_ALT_SCM_MESSAGES, \
-                                                 HONDA_BOSCH_RADARLESS
 from openpilot.selfdrive.car import create_button_events, get_safety_config
-from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.car.disable_ecu import disable_ecu
-
+from openpilot.selfdrive.car.honda.hondacan import get_pt_bus
+from openpilot.selfdrive.car.honda.values import (
+  CAR,
+  HONDA_BOSCH,
+  HONDA_BOSCH_RADARLESS,
+  HONDA_NIDEC_ALT_SCM_MESSAGES,
+  CarControllerParams,
+  CruiseButtons,
+  HondaFlags,
+)
+from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 
 ButtonType = car.CarState.ButtonEvent.Type
 EventName = car.CarEvent.EventName

--- a/selfdrive/car/honda/radar_interface.py
+++ b/selfdrive/car/honda/radar_interface.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 from cereal import car
 from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 from openpilot.selfdrive.car.honda.values import DBC
+from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
 
 def _create_nidec_can_parser(car_fingerprint):

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from enum import Enum, IntFlag, StrEnum
 
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
 from panda.python import uds
+from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car import dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -1,12 +1,12 @@
 from cereal import car
+from opendbc.can.packer import CANPacker
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import clip
 from openpilot.common.realtime import DT_CTRL
-from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import apply_driver_steer_torque_limits, common_fault_avoidance
-from openpilot.selfdrive.car.hyundai import hyundaicanfd, hyundaican
+from openpilot.selfdrive.car.hyundai import hyundaican, hyundaicanfd
 from openpilot.selfdrive.car.hyundai.hyundaicanfd import CanBus
-from openpilot.selfdrive.car.hyundai.values import HyundaiFlags, Buttons, CarControllerParams, CANFD_CAR, CAR
+from openpilot.selfdrive.car.hyundai.values import CANFD_CAR, CAR, Buttons, CarControllerParams, HyundaiFlags
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 LongCtrlState = car.CarControl.Actuators.LongControlState

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -1,14 +1,13 @@
-from collections import deque
 import copy
 import math
+from collections import deque
 
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
-from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine
+from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car.hyundai.hyundaicanfd import CanBus
-from openpilot.selfdrive.car.hyundai.values import HyundaiFlags, CAR, DBC, CAN_GEARS, CAMERA_SCC_CAR, \
-                                                   CANFD_CAR, Buttons, CarControllerParams
+from openpilot.selfdrive.car.hyundai.values import CAMERA_SCC_CAR, CAN_GEARS, CANFD_CAR, CAR, DBC, Buttons, CarControllerParams, HyundaiFlags
 from openpilot.selfdrive.car.interfaces import CarStateBase
 
 PREV_BUTTON_SAMPLES = 8

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -1,5 +1,6 @@
 import crcmod
-from openpilot.selfdrive.car.hyundai.values import CAR, CHECKSUM, CAMERA_SCC_CAR
+
+from openpilot.selfdrive.car.hyundai.values import CAMERA_SCC_CAR, CAR, CHECKSUM
 
 hyundai_checksum = crcmod.mkCrcFun(0x11D, initCrc=0xFD, rev=False, xorOut=0xdf)
 

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -1,14 +1,25 @@
 from cereal import car
 from panda import Panda
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car.hyundai.hyundaicanfd import CanBus
-from openpilot.selfdrive.car.hyundai.values import HyundaiFlags, CAR, DBC, CANFD_CAR, CAMERA_SCC_CAR, CANFD_RADAR_SCC_CAR, \
-                                         CANFD_UNSUPPORTED_LONGITUDINAL_CAR, EV_CAR, HYBRID_CAR, LEGACY_SAFETY_MODE_CAR, \
-                                         UNSUPPORTED_LONGITUDINAL_CAR, Buttons
-from openpilot.selfdrive.car.hyundai.radar_interface import RADAR_START_ADDR
 from openpilot.selfdrive.car import create_button_events, get_safety_config
-from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.car.disable_ecu import disable_ecu
+from openpilot.selfdrive.car.hyundai.hyundaicanfd import CanBus
+from openpilot.selfdrive.car.hyundai.radar_interface import RADAR_START_ADDR
+from openpilot.selfdrive.car.hyundai.values import (
+  CAMERA_SCC_CAR,
+  CANFD_CAR,
+  CANFD_RADAR_SCC_CAR,
+  CANFD_UNSUPPORTED_LONGITUDINAL_CAR,
+  CAR,
+  DBC,
+  EV_CAR,
+  HYBRID_CAR,
+  LEGACY_SAFETY_MODE_CAR,
+  UNSUPPORTED_LONGITUDINAL_CAR,
+  Buttons,
+  HyundaiFlags,
+)
+from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 
 Ecu = car.CarParams.Ecu
 ButtonType = car.CarState.ButtonEvent.Type

--- a/selfdrive/car/hyundai/radar_interface.py
+++ b/selfdrive/car/hyundai/radar_interface.py
@@ -2,8 +2,8 @@ import math
 
 from cereal import car
 from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 from openpilot.selfdrive.car.hyundai.values import DBC
+from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
 RADAR_START_ADDR = 0x500
 RADAR_MSG_COUNT = 32

--- a/selfdrive/car/hyundai/tests/print_platform_codes.py
+++ b/selfdrive/car/hyundai/tests/print_platform_codes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from cereal import car
-from openpilot.selfdrive.car.hyundai.values import PLATFORM_CODE_ECUS, get_platform_codes
 from openpilot.selfdrive.car.hyundai.fingerprints import FW_VERSIONS
+from openpilot.selfdrive.car.hyundai.values import PLATFORM_CODE_ECUS, get_platform_codes
 
 Ecu = car.CarParams.Ecu
 ECU_NAME = {v: k for k, v in Ecu.schema.enumerants.items()}

--- a/selfdrive/car/hyundai/tests/test_hyundai.py
+++ b/selfdrive/car/hyundai/tests/test_hyundai.py
@@ -1,14 +1,28 @@
 #!/usr/bin/env python3
-from hypothesis import settings, given, strategies as st
 import unittest
+
+from hypothesis import given, settings, strategies as st
 
 from cereal import car
 from openpilot.selfdrive.car.fw_versions import build_fw_dict
-from openpilot.selfdrive.car.hyundai.values import CAMERA_SCC_CAR, CANFD_CAR, CAN_GEARS, CAR, CHECKSUM, DATE_FW_ECUS, \
-                                         HYBRID_CAR, EV_CAR, FW_QUERY_CONFIG, LEGACY_SAFETY_MODE_CAR, CANFD_FUZZY_WHITELIST, \
-                                         UNSUPPORTED_LONGITUDINAL_CAR, PLATFORM_CODE_ECUS, HYUNDAI_VERSION_REQUEST_LONG, \
-                                         get_platform_codes
 from openpilot.selfdrive.car.hyundai.fingerprints import FW_VERSIONS
+from openpilot.selfdrive.car.hyundai.values import (
+  CAMERA_SCC_CAR,
+  CAN_GEARS,
+  CANFD_CAR,
+  CANFD_FUZZY_WHITELIST,
+  CAR,
+  CHECKSUM,
+  DATE_FW_ECUS,
+  EV_CAR,
+  FW_QUERY_CONFIG,
+  HYBRID_CAR,
+  HYUNDAI_VERSION_REQUEST_LONG,
+  LEGACY_SAFETY_MODE_CAR,
+  PLATFORM_CODE_ECUS,
+  UNSUPPORTED_LONGITUDINAL_CAR,
+  get_platform_codes,
+)
 
 Ecu = car.CarParams.Ecu
 ECU_NAME = {v: k for k, v in Ecu.schema.enumerants.items()}

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -1,19 +1,20 @@
 import json
 import os
-import numpy as np
 import tomllib
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
+from collections.abc import Callable
 from enum import StrEnum
 from typing import Any, NamedTuple, cast
-from collections.abc import Callable
+
+import numpy as np
 
 from cereal import car
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.conversions import Conversions as CV
-from openpilot.common.simple_kalman import KF1D, get_kalman_gain
 from openpilot.common.numpy_fast import clip
 from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.car import PlatformConfig, apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness, STD_CARGO_KG
+from openpilot.common.simple_kalman import KF1D, get_kalman_gain
+from openpilot.selfdrive.car import STD_CARGO_KG, PlatformConfig, apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness
 from openpilot.selfdrive.car.values import Platform
 from openpilot.selfdrive.controls.lib.drive_helpers import V_CRUISE_MAX, get_friction
 from openpilot.selfdrive.controls.lib.events import Events

--- a/selfdrive/car/isotp_parallel_query.py
+++ b/selfdrive/car/isotp_parallel_query.py
@@ -3,10 +3,10 @@ from collections import defaultdict
 from functools import partial
 
 import cereal.messaging as messaging
+from panda.python.uds import FUNCTIONAL_ADDRS, CanClient, IsoTpMessage, get_rx_addr_for_tx_addr
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.boardd.boardd import can_list_to_can_capnp
 from openpilot.selfdrive.car.fw_query_definitions import AddrType
-from panda.python.uds import CanClient, IsoTpMessage, FUNCTIONAL_ADDRS, get_rx_addr_for_tx_addr
 
 
 class IsoTpParallelQuery:

--- a/selfdrive/car/mazda/carcontroller.py
+++ b/selfdrive/car/mazda/carcontroller.py
@@ -2,7 +2,7 @@ from cereal import car
 from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import apply_driver_steer_torque_limits
 from openpilot.selfdrive.car.mazda import mazdacan
-from openpilot.selfdrive.car.mazda.values import CarControllerParams, Buttons
+from openpilot.selfdrive.car.mazda.values import Buttons, CarControllerParams
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 

--- a/selfdrive/car/mazda/carstate.py
+++ b/selfdrive/car/mazda/carstate.py
@@ -1,9 +1,10 @@
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car.interfaces import CarStateBase
-from openpilot.selfdrive.car.mazda.values import DBC, LKAS_LIMITS, GEN1
+from openpilot.selfdrive.car.mazda.values import DBC, GEN1, LKAS_LIMITS
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):

--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car.mazda.values import CAR, LKAS_LIMITS
 from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
+from openpilot.selfdrive.car.mazda.values import CAR, LKAS_LIMITS
 
 ButtonType = car.CarState.ButtonEvent.Type
 EventName = car.CarEvent.EventName

--- a/selfdrive/car/mazda/radar_interface.py
+++ b/selfdrive/car/mazda/radar_interface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/mock/interface.py
+++ b/selfdrive/car/mock/interface.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-from cereal import car
 import cereal.messaging as messaging
+from cereal import car
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
+
 
 # mocked car interface for dashcam mode
 class CarInterface(CarInterfaceBase):

--- a/selfdrive/car/mock/radar_interface.py
+++ b/selfdrive/car/mock/radar_interface.py
@@ -1,4 +1,5 @@
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/nissan/carstate.py
+++ b/selfdrive/car/nissan/carstate.py
@@ -1,10 +1,11 @@
 import copy
 from collections import deque
+
 from cereal import car
 from opendbc.can.can_define import CANDefine
-from openpilot.selfdrive.car.interfaces import CarStateBase
-from openpilot.common.conversions import Conversions as CV
 from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
+from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.nissan.values import CAR, DBC, CarControllerParams
 
 TORQUE_SAMPLES = 12

--- a/selfdrive/car/nissan/nissancan.py
+++ b/selfdrive/car/nissan/nissancan.py
@@ -1,4 +1,5 @@
 import crcmod
+
 from openpilot.selfdrive.car.nissan.values import CAR
 
 # TODO: add this checksum to the CANPacker

--- a/selfdrive/car/nissan/radar_interface.py
+++ b/selfdrive/car/nissan/radar_interface.py
@@ -1,4 +1,5 @@
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/nissan/values.py
+++ b/selfdrive/car/nissan/values.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from cereal import car
 from panda.python import uds
 from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
-from openpilot.selfdrive.car.docs_definitions import CarInfo, CarHarness, CarParts
+from openpilot.selfdrive.car.docs_definitions import CarHarness, CarInfo, CarParts
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
 Ecu = car.CarParams.Ecu

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -1,9 +1,18 @@
-from openpilot.common.numpy_fast import clip, interp
 from opendbc.can.packer import CANPacker
+from openpilot.common.numpy_fast import clip, interp
 from openpilot.selfdrive.car import apply_driver_steer_torque_limits, common_fault_avoidance
 from openpilot.selfdrive.car.subaru import subarucan
-from openpilot.selfdrive.car.subaru.values import DBC, GLOBAL_ES_ADDR, GLOBAL_GEN2, PREGLOBAL_CARS, HYBRID_CARS, STEER_RATE_LIMITED, \
-                                                  CanBus, CarControllerParams, SubaruFlags
+from openpilot.selfdrive.car.subaru.values import (
+  DBC,
+  GLOBAL_ES_ADDR,
+  GLOBAL_GEN2,
+  HYBRID_CARS,
+  PREGLOBAL_CARS,
+  STEER_RATE_LIMITED,
+  CanBus,
+  CarControllerParams,
+  SubaruFlags,
+)
 
 # FIXME: These limits aren't exact. The real limit is more than likely over a larger time period and
 # involves the total steering angle change rather than rate, but these limits work well for now

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -1,11 +1,12 @@
 import copy
+
 from cereal import car
 from opendbc.can.can_define import CANDefine
-from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car.interfaces import CarStateBase
 from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.subaru.values import DBC, GLOBAL_GEN2, PREGLOBAL_CARS, HYBRID_CARS, CanBus, SubaruFlags
+from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car import CanSignalRateCalculator
+from openpilot.selfdrive.car.interfaces import CarStateBase
+from openpilot.selfdrive.car.subaru.values import DBC, GLOBAL_GEN2, HYBRID_CARS, PREGLOBAL_CARS, CanBus, SubaruFlags
 
 
 class CarState(CarStateBase):

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -1,10 +1,10 @@
 from cereal import car
 from panda import Panda
 from openpilot.selfdrive.car import get_safety_config
-from openpilot.selfdrive.car.values import Platform
 from openpilot.selfdrive.car.disable_ecu import disable_ecu
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
-from openpilot.selfdrive.car.subaru.values import CAR, GLOBAL_ES_ADDR, LKAS_ANGLE, GLOBAL_GEN2, PREGLOBAL_CARS, HYBRID_CARS, SubaruFlags
+from openpilot.selfdrive.car.subaru.values import CAR, GLOBAL_ES_ADDR, GLOBAL_GEN2, HYBRID_CARS, LKAS_ANGLE, PREGLOBAL_CARS, SubaruFlags
+from openpilot.selfdrive.car.values import Platform
 
 
 class CarInterface(CarInterfaceBase):

--- a/selfdrive/car/subaru/radar_interface.py
+++ b/selfdrive/car/subaru/radar_interface.py
@@ -1,4 +1,5 @@
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/subaru/tests/test_subaru.py
+++ b/selfdrive/car/subaru/tests/test_subaru.py
@@ -1,5 +1,6 @@
-from cereal import car
 import unittest
+
+from cereal import car
 from openpilot.selfdrive.car.subaru.fingerprints import FW_VERSIONS
 
 Ecu = car.CarParams.Ecu

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -4,7 +4,7 @@ from enum import Enum, IntFlag
 from cereal import car
 from panda.python import uds
 from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, Platforms, dbc_dict
-from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Tool, Column
+from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, Tool
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16
 
 Ecu = car.CarParams.Ecu

--- a/selfdrive/car/tesla/carcontroller.py
+++ b/selfdrive/car/tesla/carcontroller.py
@@ -1,8 +1,8 @@
-from openpilot.common.numpy_fast import clip
 from opendbc.can.packer import CANPacker
+from openpilot.common.numpy_fast import clip
 from openpilot.selfdrive.car import apply_std_steer_angle_limits
 from openpilot.selfdrive.car.tesla.teslacan import TeslaCAN
-from openpilot.selfdrive.car.tesla.values import DBC, CANBUS, CarControllerParams
+from openpilot.selfdrive.car.tesla.values import CANBUS, DBC, CarControllerParams
 
 
 class CarController:

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -1,11 +1,13 @@
 import copy
 from collections import deque
+
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car.tesla.values import DBC, CANBUS, GEAR_MAP, DOORS, BUTTONS
-from openpilot.selfdrive.car.interfaces import CarStateBase
-from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine
+from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
+from openpilot.selfdrive.car.interfaces import CarStateBase
+from openpilot.selfdrive.car.tesla.values import BUTTONS, CANBUS, DBC, DOORS, GEAR_MAP
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):

--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 from cereal import car
 from panda import Panda
-from openpilot.selfdrive.car.tesla.values import CANBUS, CAR
 from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
+from openpilot.selfdrive.car.tesla.values import CANBUS, CAR
 
 
 class CarInterface(CarInterfaceBase):

--- a/selfdrive/car/tesla/radar_interface.py
+++ b/selfdrive/car/tesla/radar_interface.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 from cereal import car
 from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.tesla.values import DBC, CANBUS
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
+from openpilot.selfdrive.car.tesla.values import CANBUS, DBC
 
 RADAR_MSGS_A = list(range(0x310, 0x36E, 3))
 RADAR_MSGS_B = list(range(0x311, 0x36F, 3))

--- a/selfdrive/car/tests/routes.py
+++ b/selfdrive/car/tests/routes.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 from typing import NamedTuple
 
+from openpilot.selfdrive.car.body.values import CAR as COMMA
 from openpilot.selfdrive.car.chrysler.values import CAR as CHRYSLER
-from openpilot.selfdrive.car.gm.values import CAR as GM
 from openpilot.selfdrive.car.ford.values import CAR as FORD
+from openpilot.selfdrive.car.gm.values import CAR as GM
 from openpilot.selfdrive.car.honda.values import CAR as HONDA
 from openpilot.selfdrive.car.hyundai.values import CAR as HYUNDAI
-from openpilot.selfdrive.car.nissan.values import CAR as NISSAN
 from openpilot.selfdrive.car.mazda.values import CAR as MAZDA
+from openpilot.selfdrive.car.nissan.values import CAR as NISSAN
 from openpilot.selfdrive.car.subaru.values import CAR as SUBARU
+from openpilot.selfdrive.car.tesla.values import CAR as TESLA
 from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.car.volkswagen.values import CAR as VOLKSWAGEN
-from openpilot.selfdrive.car.tesla.values import CAR as TESLA
-from openpilot.selfdrive.car.body.values import CAR as COMMA
 
 # TODO: add routes for these cars
 non_tested_cars = [

--- a/selfdrive/car/tests/test_can_fingerprint.py
+++ b/selfdrive/car/tests/test_can_fingerprint.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-from parameterized import parameterized
 import unittest
+
+from parameterized import parameterized
 
 from cereal import log, messaging
 from openpilot.selfdrive.car.car_helpers import FRAME_FINGERPRINT, can_fingerprint

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-import os
+import importlib
 import math
+import os
 import unittest
+
 import hypothesis.strategies as st
 from hypothesis import Phase, given, settings
-import importlib
 from parameterized import parameterized
 
 from cereal import car, messaging

--- a/selfdrive/car/tests/test_docs.py
+++ b/selfdrive/car/tests/test_docs.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-from collections import defaultdict
 import os
 import re
 import unittest
+from collections import defaultdict
 
 from openpilot.common.basedir import BASEDIR
-from openpilot.selfdrive.car.car_helpers import interfaces, get_interface_attr
+from openpilot.selfdrive.car.car_helpers import get_interface_attr, interfaces
 from openpilot.selfdrive.car.docs import CARS_MD_OUT, CARS_MD_TEMPLATE, generate_cars_md, get_all_car_info
 from openpilot.selfdrive.car.docs_definitions import Cable, Column, PartType, Star
 from openpilot.selfdrive.car.honda.values import CAR as HONDA

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -3,14 +3,23 @@ import random
 import time
 import unittest
 from collections import defaultdict
-from parameterized import parameterized
 from unittest import mock
+
+from parameterized import parameterized
 
 from cereal import car
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.car.fingerprints import FW_VERSIONS
-from openpilot.selfdrive.car.fw_versions import FW_QUERY_CONFIGS, FUZZY_EXCLUDE_ECUS, VERSIONS, build_fw_dict, \
-                                                match_fw_to_car, get_brand_ecu_matches, get_fw_versions, get_present_ecus
+from openpilot.selfdrive.car.fw_versions import (
+  FUZZY_EXCLUDE_ECUS,
+  FW_QUERY_CONFIGS,
+  VERSIONS,
+  build_fw_dict,
+  get_brand_ecu_matches,
+  get_fw_versions,
+  get_present_ecus,
+  match_fw_to_car,
+)
 from openpilot.selfdrive.car.vin import get_vin
 
 CarFw = car.CarParams.CarFw

--- a/selfdrive/car/tests/test_lateral_limits.py
+++ b/selfdrive/car/tests/test_lateral_limits.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-from collections import defaultdict
 import importlib
-from parameterized import parameterized_class
 import sys
 import unittest
+from collections import defaultdict
+
+from parameterized import parameterized_class
 
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car.car_helpers import interfaces

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -1,31 +1,31 @@
 #!/usr/bin/env python3
-import capnp
-import os
 import importlib
-import pytest
+import os
 import random
 import unittest
-from collections import defaultdict, Counter
+from collections import Counter, defaultdict
+
+import capnp
 import hypothesis.strategies as st
+import pytest
 from hypothesis import Phase, given, settings
 from parameterized import parameterized_class
 
-from cereal import messaging, log, car
+from cereal import car, log, messaging
+from panda.tests.libpanda import libpanda_py
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car import gen_empty_fingerprint
-from openpilot.selfdrive.car.fingerprints import all_known_cars
 from openpilot.selfdrive.car.car_helpers import FRAME_FINGERPRINT, interfaces
+from openpilot.selfdrive.car.fingerprints import all_known_cars
 from openpilot.selfdrive.car.honda.values import CAR as HONDA, HONDA_BOSCH
-from openpilot.selfdrive.car.tests.routes import non_tested_cars, routes, CarTestRoute
+from openpilot.selfdrive.car.tests.routes import CarTestRoute, non_tested_cars, routes
 from openpilot.selfdrive.controls.controlsd import Controls
 from openpilot.selfdrive.test.helpers import read_segment_list
 from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
 from openpilot.tools.lib.logreader import LogReader, internal_source, openpilotci_source
 from openpilot.tools.lib.route import SegmentName
-
-from panda.tests.libpanda import libpanda_py
 
 EventName = car.CarEvent.EventName
 PandaType = log.PandaState.PandaType

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -1,12 +1,25 @@
 from cereal import car
-from openpilot.common.numpy_fast import clip, interp
-from openpilot.selfdrive.car import apply_meas_steer_torque_limits, apply_std_steer_angle_limits, common_fault_avoidance, \
-                          create_gas_interceptor_command, make_can_msg
-from openpilot.selfdrive.car.toyota import toyotacan
-from openpilot.selfdrive.car.toyota.values import CAR, STATIC_DSU_MSGS, NO_STOP_TIMER_CAR, TSS2_CAR, \
-                                        MIN_ACC_SPEED, PEDAL_TRANSITION, CarControllerParams, ToyotaFlags, \
-                                        UNSUPPORTED_DSU_CAR
 from opendbc.can.packer import CANPacker
+from openpilot.common.numpy_fast import clip, interp
+from openpilot.selfdrive.car import (
+  apply_meas_steer_torque_limits,
+  apply_std_steer_angle_limits,
+  common_fault_avoidance,
+  create_gas_interceptor_command,
+  make_can_msg,
+)
+from openpilot.selfdrive.car.toyota import toyotacan
+from openpilot.selfdrive.car.toyota.values import (
+  CAR,
+  MIN_ACC_SPEED,
+  NO_STOP_TIMER_CAR,
+  PEDAL_TRANSITION,
+  STATIC_DSU_MSGS,
+  TSS2_CAR,
+  UNSUPPORTED_DSU_CAR,
+  CarControllerParams,
+  ToyotaFlags,
+)
 
 SteerControlType = car.CarParams.SteerControlType
 VisualAlert = car.CarControl.HUDControl.VisualAlert

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -1,15 +1,24 @@
 import copy
 
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
-from openpilot.common.numpy_fast import mean
-from openpilot.common.filter_simple import FirstOrderFilter
-from openpilot.common.realtime import DT_CTRL
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
+from openpilot.common.conversions import Conversions as CV
+from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.numpy_fast import mean
+from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car.interfaces import CarStateBase
-from openpilot.selfdrive.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, NO_STOP_TIMER_CAR, \
-                                                  TSS2_CAR, RADAR_ACC_CAR, EPS_SCALE, UNSUPPORTED_DSU_CAR
+from openpilot.selfdrive.car.toyota.values import (
+  CAR,
+  DBC,
+  EPS_SCALE,
+  NO_STOP_TIMER_CAR,
+  RADAR_ACC_CAR,
+  STEER_THRESHOLD,
+  TSS2_CAR,
+  UNSUPPORTED_DSU_CAR,
+  ToyotaFlags,
+)
 
 SteerControlType = car.CarParams.SteerControlType
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -1,12 +1,25 @@
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
 from panda import Panda
 from panda.python import uds
-from openpilot.selfdrive.car.toyota.values import Ecu, CAR, DBC, ToyotaFlags, CarControllerParams, TSS2_CAR, RADAR_ACC_CAR, NO_DSU_CAR, \
-                                        MIN_ACC_SPEED, EPS_SCALE, UNSUPPORTED_DSU_CAR, NO_STOP_TIMER_CAR, ANGLE_CONTROL_CAR
+from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.disable_ecu import disable_ecu
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
+from openpilot.selfdrive.car.toyota.values import (
+  ANGLE_CONTROL_CAR,
+  CAR,
+  DBC,
+  EPS_SCALE,
+  MIN_ACC_SPEED,
+  NO_DSU_CAR,
+  NO_STOP_TIMER_CAR,
+  RADAR_ACC_CAR,
+  TSS2_CAR,
+  UNSUPPORTED_DSU_CAR,
+  CarControllerParams,
+  Ecu,
+  ToyotaFlags,
+)
 
 EventName = car.CarEvent.EventName
 SteerControlType = car.CarParams.SteerControlType

--- a/selfdrive/car/toyota/radar_interface.py
+++ b/selfdrive/car/toyota/radar_interface.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from opendbc.can.parser import CANParser
 from cereal import car
-from openpilot.selfdrive.car.toyota.values import DBC, TSS2_CAR
+from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
+from openpilot.selfdrive.car.toyota.values import DBC, TSS2_CAR
 
 
 def _create_radar_can_parser(car_fingerprint):

--- a/selfdrive/car/toyota/tests/print_platform_codes.py
+++ b/selfdrive/car/toyota/tests/print_platform_codes.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 from collections import defaultdict
+
 from cereal import car
-from openpilot.selfdrive.car.toyota.values import PLATFORM_CODE_ECUS, get_platform_codes
 from openpilot.selfdrive.car.toyota.fingerprints import FW_VERSIONS
+from openpilot.selfdrive.car.toyota.values import PLATFORM_CODE_ECUS, get_platform_codes
 
 Ecu = car.CarParams.Ecu
 ECU_NAME = {v: k for k, v in Ecu.schema.enumerants.items()}

--- a/selfdrive/car/toyota/tests/test_toyota.py
+++ b/selfdrive/car/toyota/tests/test_toyota.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python3
-from hypothesis import given, settings, strategies as st
 import unittest
+
+from hypothesis import given, settings, strategies as st
 
 from cereal import car
 from openpilot.selfdrive.car.fw_versions import build_fw_dict
 from openpilot.selfdrive.car.toyota.fingerprints import FW_VERSIONS
-from openpilot.selfdrive.car.toyota.values import CAR, DBC, TSS2_CAR, ANGLE_CONTROL_CAR, RADAR_ACC_CAR, \
-                                                  FW_QUERY_CONFIG, PLATFORM_CODE_ECUS, FUZZY_EXCLUDED_PLATFORMS, \
-                                                  get_platform_codes
+from openpilot.selfdrive.car.toyota.values import (
+  ANGLE_CONTROL_CAR,
+  CAR,
+  DBC,
+  FUZZY_EXCLUDED_PLATFORMS,
+  FW_QUERY_CONFIG,
+  PLATFORM_CODE_ECUS,
+  RADAR_ACC_CAR,
+  TSS2_CAR,
+  get_platform_codes,
+)
 
 Ecu = car.CarParams.Ecu
 ECU_NAME = {v: k for k, v in Ecu.schema.enumerants.items()}

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -6,7 +6,7 @@ from enum import Enum, IntFlag, StrEnum
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
-from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarInfo, Column, CarParts, CarHarness
+from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
 Ecu = car.CarParams.Ecu

--- a/selfdrive/car/values.py
+++ b/selfdrive/car/values.py
@@ -1,4 +1,5 @@
 from typing import cast
+
 from openpilot.selfdrive.car.body.values import CAR as BODY
 from openpilot.selfdrive.car.chrysler.values import CAR as CHRYSLER
 from openpilot.selfdrive.car.ford.values import CAR as FORD

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -2,10 +2,10 @@
 import re
 
 import cereal.messaging as messaging
-from panda.python.uds import get_rx_addr_for_tx_addr, FUNCTIONAL_ADDRS
-from openpilot.selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
-from openpilot.selfdrive.car.fw_query_definitions import STANDARD_VIN_ADDRS, StdQueries
+from panda.python.uds import FUNCTIONAL_ADDRS, get_rx_addr_for_tx_addr
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.car.fw_query_definitions import STANDARD_VIN_ADDRS, StdQueries
+from openpilot.selfdrive.car.isotp_parallel_query import IsoTpParallelQuery
 
 VIN_UNKNOWN = "0" * 17
 VIN_RE = "[A-HJ-NPR-Z0-9]{17}"

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -1,7 +1,7 @@
 from cereal import car
 from opendbc.can.packer import CANPacker
-from openpilot.common.numpy_fast import clip
 from openpilot.common.conversions import Conversions as CV
+from openpilot.common.numpy_fast import clip
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car import apply_driver_steer_torque_limits
 from openpilot.selfdrive.car.volkswagen import mqbcan, pqcan

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -1,10 +1,10 @@
 import numpy as np
+
 from cereal import car
+from opendbc.can.parser import CANParser
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car.interfaces import CarStateBase
-from opendbc.can.parser import CANParser
-from openpilot.selfdrive.car.volkswagen.values import DBC, CANBUS, PQ_CARS, NetworkLocation, TransmissionType, GearShifter, \
-                                            CarControllerParams, VolkswagenFlags
+from openpilot.selfdrive.car.volkswagen.values import CANBUS, DBC, PQ_CARS, CarControllerParams, GearShifter, NetworkLocation, TransmissionType, VolkswagenFlags
 
 
 class CarState(CarStateBase):

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -3,7 +3,7 @@ from panda import Panda
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
-from openpilot.selfdrive.car.volkswagen.values import CAR, PQ_CARS, CANBUS, NetworkLocation, TransmissionType, GearShifter, VolkswagenFlags
+from openpilot.selfdrive.car.volkswagen.values import CANBUS, CAR, PQ_CARS, GearShifter, NetworkLocation, TransmissionType, VolkswagenFlags
 
 ButtonType = car.CarState.ButtonEvent.Type
 EventName = car.CarEvent.EventName

--- a/selfdrive/car/volkswagen/radar_interface.py
+++ b/selfdrive/car/volkswagen/radar_interface.py
@@ -1,4 +1,5 @@
 from openpilot.selfdrive.car.interfaces import RadarInterfaceBase
 
+
 class RadarInterface(RadarInterfaceBase):
   pass

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -3,11 +3,10 @@ from dataclasses import dataclass, field
 from enum import Enum, IntFlag, StrEnum
 
 from cereal import car
-from panda.python import uds
 from opendbc.can.can_define import CANDefine
+from panda.python import uds
 from openpilot.selfdrive.car import dbc_dict
-from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
-                                           Device
+from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
 
 Ecu = car.CarParams.Ecu

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -1,36 +1,31 @@
 #!/usr/bin/env python3
-import os
 import math
-import time
+import os
 import threading
+import time
 from typing import SupportsFloat
 
 import cereal.messaging as messaging
-
 from cereal import car, log
 from cereal.visionipc import VisionIpcClient, VisionStreamType
-
 from panda import ALTERNATIVE_EXPERIENCE
-
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import clip
 from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper, DT_CTRL
+from openpilot.common.realtime import DT_CTRL, Priority, Ratekeeper, config_realtime_process
 from openpilot.common.swaglog import cloudlog
-
 from openpilot.selfdrive.boardd.boardd import can_list_to_can_capnp
-from openpilot.selfdrive.car.car_helpers import get_car, get_startup_event, get_one_can
+from openpilot.selfdrive.car.car_helpers import get_car, get_one_can, get_startup_event
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.controls.lib.alertmanager import AlertManager, set_offroad_alert
 from openpilot.selfdrive.controls.lib.drive_helpers import VCruiseHelper, clip_curvature
-from openpilot.selfdrive.controls.lib.events import Events, ET
-from openpilot.selfdrive.controls.lib.latcontrol import LatControl, MIN_LATERAL_CONTROL_SPEED
+from openpilot.selfdrive.controls.lib.events import ET, Events
+from openpilot.selfdrive.controls.lib.latcontrol import MIN_LATERAL_CONTROL_SPEED, LatControl
+from openpilot.selfdrive.controls.lib.latcontrol_angle import STEER_ANGLE_SATURATION_THRESHOLD, LatControlAngle
 from openpilot.selfdrive.controls.lib.latcontrol_pid import LatControlPID
-from openpilot.selfdrive.controls.lib.latcontrol_angle import LatControlAngle, STEER_ANGLE_SATURATION_THRESHOLD
 from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque
 from openpilot.selfdrive.controls.lib.longcontrol import LongControl
 from openpilot.selfdrive.controls.lib.vehicle_model import VehicleModel
-
 from openpilot.system.hardware import HARDWARE
 from openpilot.system.version import get_short_branch
 

--- a/selfdrive/controls/lib/alertmanager.py
+++ b/selfdrive/controls/lib/alertmanager.py
@@ -1,13 +1,12 @@
 import copy
-import os
 import json
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.selfdrive.controls.lib.events import Alert
-
 
 with open(os.path.join(BASEDIR, "selfdrive/controls/lib/alerts_offroad.json")) as f:
   OFFROAD_ALERTS = json.load(f)

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 import math
 import os
-from enum import IntEnum
 from collections.abc import Callable
+from enum import IntEnum
 
-from cereal import log, car
 import cereal.messaging as messaging
+from cereal import car, log
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.locationd.calibrationd import MIN_SPEED_FILTER
@@ -961,8 +961,9 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
 
 if __name__ == '__main__':
   # print all alerts by type and priority
-  from cereal.services import SERVICE_LIST
   from collections import defaultdict
+
+  from cereal.services import SERVICE_LIST
 
   event_names = {v: k for k, v in EventName.schema.enumerants.items()}
   alerts_by_type: dict[str, dict[Priority, list[str]]] = defaultdict(lambda: defaultdict(list))

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 
 from openpilot.common.numpy_fast import clip
 from openpilot.common.realtime import DT_CTRL

--- a/selfdrive/controls/lib/lateral_mpc_lib/lat_mpc.py
+++ b/selfdrive/controls/lib/lateral_mpc_lib/lat_mpc.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import os
 import time
-import numpy as np
 
-from casadi import SX, vertcat, sin, cos
+import numpy as np
+from casadi import SX, cos, sin, vertcat
+
 # WARNING: imports outside of constants will not trigger a rebuild
 from openpilot.selfdrive.modeld.constants import ModelConstants
 

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 import os
 import time
+
 import numpy as np
+
 from cereal import log
 from openpilot.common.numpy_fast import clip
 from openpilot.common.swaglog import cloudlog
-# WARNING: imports outside of constants will not trigger a rebuild
-from openpilot.selfdrive.modeld.constants import index_function
 from openpilot.selfdrive.car.interfaces import ACCEL_MIN
 from openpilot.selfdrive.controls.radard import _LEAD_ACCEL_TAU
+
+# WARNING: imports outside of constants will not trigger a rebuild
+from openpilot.selfdrive.modeld.constants import index_function
 
 if __name__ == '__main__':  # generating code
   from openpilot.third_party.acados.acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 import math
+
 import numpy as np
-from openpilot.common.numpy_fast import clip, interp
-from openpilot.common.params import Params
-from cereal import log
 
 import cereal.messaging as messaging
+from cereal import log
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.numpy_fast import clip, interp
+from openpilot.common.params import Params
 from openpilot.common.realtime import DT_MDL
-from openpilot.selfdrive.modeld.constants import ModelConstants
-from openpilot.selfdrive.car.interfaces import ACCEL_MIN, ACCEL_MAX
-from openpilot.selfdrive.controls.lib.longcontrol import LongCtrlState
-from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import LongitudinalMpc
-from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import T_IDXS as T_IDXS_MPC
-from openpilot.selfdrive.controls.lib.drive_helpers import V_CRUISE_MAX, CONTROL_N, get_speed_error
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.car.interfaces import ACCEL_MAX, ACCEL_MIN
+from openpilot.selfdrive.controls.lib.drive_helpers import CONTROL_N, V_CRUISE_MAX, get_speed_error
+from openpilot.selfdrive.controls.lib.longcontrol import LongCtrlState
+from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import T_IDXS as T_IDXS_MPC, LongitudinalMpc
+from openpilot.selfdrive.modeld.constants import ModelConstants
 
 LON_MPC_STEP = 0.2  # first step is 0.2s
 A_CRUISE_MIN = -1.2

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -1,5 +1,6 @@
-import numpy as np
 from numbers import Number
+
+import numpy as np
 
 from openpilot.common.numpy_fast import clip, interp
 

--- a/selfdrive/controls/lib/tests/test_alertmanager.py
+++ b/selfdrive/controls/lib/tests/test_alertmanager.py
@@ -2,8 +2,8 @@
 import random
 import unittest
 
-from openpilot.selfdrive.controls.lib.events import Alert, EVENTS
 from openpilot.selfdrive.controls.lib.alertmanager import AlertManager
+from openpilot.selfdrive.controls.lib.events import EVENTS, Alert
 
 
 class TestAlertManager(unittest.TestCase):

--- a/selfdrive/controls/lib/tests/test_latcontrol.py
+++ b/selfdrive/controls/lib/tests/test_latcontrol.py
@@ -4,15 +4,15 @@ import unittest
 from parameterized import parameterized
 
 from cereal import car, log
+from openpilot.common.mock.generators import generate_liveLocationKalman
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.car.honda.values import CAR as HONDA
-from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.car.nissan.values import CAR as NISSAN
+from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
+from openpilot.selfdrive.controls.lib.latcontrol_angle import LatControlAngle
 from openpilot.selfdrive.controls.lib.latcontrol_pid import LatControlPID
 from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque
-from openpilot.selfdrive.controls.lib.latcontrol_angle import LatControlAngle
 from openpilot.selfdrive.controls.lib.vehicle_model import VehicleModel
-from openpilot.common.mock.generators import generate_liveLocationKalman
 
 
 class TestLatControl(unittest.TestCase):

--- a/selfdrive/controls/lib/tests/test_vehicle_model.py
+++ b/selfdrive/controls/lib/tests/test_vehicle_model.py
@@ -7,7 +7,7 @@ from control import StateSpace
 
 from openpilot.selfdrive.car.honda.interface import CarInterface
 from openpilot.selfdrive.car.honda.values import CAR
-from openpilot.selfdrive.controls.lib.vehicle_model import VehicleModel, dyn_ss_sol, create_dyn_state_matrices
+from openpilot.selfdrive.controls.lib.vehicle_model import VehicleModel, create_dyn_state_matrices, dyn_ss_sol
 
 
 class TestVehicleModel(unittest.TestCase):

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
+import cereal.messaging as messaging
 from cereal import car
 from openpilot.common.params import Params
 from openpilot.common.realtime import Priority, config_realtime_process
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.longitudinal_planner import LongitudinalPlanner
-import cereal.messaging as messaging
+
 
 def publish_ui_plan(sm, pm, longitudinal_planner):
   ui_send = messaging.new_message('uiPlan')

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -5,14 +5,13 @@ from collections import deque
 from typing import Any, Optional
 
 import capnp
-from cereal import messaging, log, car
+
+from cereal import car, log, messaging
 from openpilot.common.numpy_fast import interp
 from openpilot.common.params import Params
-from openpilot.common.realtime import DT_CTRL, Ratekeeper, Priority, config_realtime_process
-from openpilot.common.swaglog import cloudlog
-
+from openpilot.common.realtime import DT_CTRL, Priority, Ratekeeper, config_realtime_process
 from openpilot.common.simple_kalman import KF1D
-
+from openpilot.common.swaglog import cloudlog
 
 # Default lead acceleration decay set to 50% at 1s
 _LEAD_ACCEL_TAU = 1.5

--- a/selfdrive/controls/tests/test_alerts.py
+++ b/selfdrive/controls/tests/test_alerts.py
@@ -2,16 +2,17 @@
 import copy
 import json
 import os
-import unittest
 import random
+import unittest
+
 from PIL import Image, ImageDraw, ImageFont
 
-from cereal import log, car
+from cereal import car, log
 from cereal.messaging import SubMaster
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
-from openpilot.selfdrive.controls.lib.events import Alert, EVENTS, ET
 from openpilot.selfdrive.controls.lib.alertmanager import set_offroad_alert
+from openpilot.selfdrive.controls.lib.events import ET, EVENTS, Alert
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS
 
 AlertSize = log.ControlsState.AlertSize

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 import itertools
-import numpy as np
 import unittest
 
+import numpy as np
 from parameterized import parameterized_class
-from cereal import log
-from openpilot.common.params import Params
-from openpilot.selfdrive.controls.lib.drive_helpers import VCruiseHelper, V_CRUISE_MIN, V_CRUISE_MAX, V_CRUISE_INITIAL, IMPERIAL_INCREMENT
-from cereal import car
+
+from cereal import car, log
 from openpilot.common.conversions import Conversions as CV
+from openpilot.common.params import Params
+from openpilot.selfdrive.controls.lib.drive_helpers import IMPERIAL_INCREMENT, V_CRUISE_INITIAL, V_CRUISE_MAX, V_CRUISE_MIN, VCruiseHelper
 from openpilot.selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 
 ButtonEvent = car.CarState.ButtonEvent

--- a/selfdrive/controls/tests/test_following_distance.py
+++ b/selfdrive/controls/tests/test_following_distance.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-import unittest
 import itertools
+import unittest
+
 from parameterized import parameterized_class
 
-from openpilot.common.params import Params
 from cereal import log
-
+from openpilot.common.params import Params
 from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import desired_follow_distance, get_T_FOLLOW
 from openpilot.selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
 

--- a/selfdrive/controls/tests/test_lateral_mpc.py
+++ b/selfdrive/controls/tests/test_lateral_mpc.py
@@ -1,8 +1,9 @@
 import unittest
+
 import numpy as np
-from openpilot.selfdrive.controls.lib.lateral_mpc_lib.lat_mpc import LateralMpc
+
 from openpilot.selfdrive.controls.lib.drive_helpers import CAR_ROTATION_RADIUS
-from openpilot.selfdrive.controls.lib.lateral_mpc_lib.lat_mpc import N as LAT_MPC_N
+from openpilot.selfdrive.controls.lib.lateral_mpc_lib.lat_mpc import LateralMpc, N as LAT_MPC_N
 
 
 def run_mpc(lat_mpc=None, v_ref=30., x_init=0., y_init=0., psi_init=0., curvature_init=0.,

--- a/selfdrive/controls/tests/test_leads.py
+++ b/selfdrive/controls/tests/test_leads.py
@@ -2,9 +2,8 @@
 import unittest
 
 import cereal.messaging as messaging
-
-from openpilot.selfdrive.test.process_replay import replay_process_with_name
 from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
+from openpilot.selfdrive.test.process_replay import replay_process_with_name
 
 
 class TestLeads(unittest.TestCase):

--- a/selfdrive/controls/tests/test_startup.py
+++ b/selfdrive/controls/tests/test_startup.py
@@ -1,13 +1,14 @@
 import os
+
 from parameterized import parameterized
 
-from cereal import log, car
 import cereal.messaging as messaging
+from cereal import car, log
 from openpilot.common.params import Params
 from openpilot.selfdrive.boardd.boardd_api_impl import can_list_to_can_capnp
 from openpilot.selfdrive.car.fingerprints import _FINGERPRINTS
-from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.car.mazda.values import CAR as MAZDA
+from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.controls.lib.events import EVENT_NAME
 from openpilot.selfdrive.manager.process_config import managed_processes
 

--- a/selfdrive/controls/tests/test_state_machine.py
+++ b/selfdrive/controls/tests/test_state_machine.py
@@ -4,9 +4,8 @@ import unittest
 from cereal import car, log
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car.car_helpers import interfaces
-from openpilot.selfdrive.controls.controlsd import Controls, SOFT_DISABLE_TIME
-from openpilot.selfdrive.controls.lib.events import Events, ET, Alert, Priority, AlertSize, AlertStatus, VisualAlert, \
-                                          AudibleAlert, EVENTS
+from openpilot.selfdrive.controls.controlsd import SOFT_DISABLE_TIME, Controls
+from openpilot.selfdrive.controls.lib.events import ET, EVENTS, Alert, AlertSize, AlertStatus, AudibleAlert, Events, Priority, VisualAlert
 
 State = log.ControlsState.OpenpilotState
 

--- a/selfdrive/debug/can_table.py
+++ b/selfdrive/debug/can_table.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+
 import pandas as pd
 
 import cereal.messaging as messaging

--- a/selfdrive/debug/check_can_parser_performance.py
+++ b/selfdrive/debug/check_can_parser_performance.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import numpy as np
 import time
+
+import numpy as np
 from tqdm import tqdm
 
 from cereal import car

--- a/selfdrive/debug/check_freq.py
+++ b/selfdrive/debug/check_freq.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import argparse
-import numpy as np
 import time
 from collections import defaultdict, deque
 from collections.abc import MutableSequence
 
-import cereal.messaging as messaging
+import numpy as np
 
+import cereal.messaging as messaging
 
 if __name__ == "__main__":
   context = messaging.Context()

--- a/selfdrive/debug/check_timings.py
+++ b/selfdrive/debug/check_timings.py
@@ -2,9 +2,10 @@
 
 import sys
 import time
-import numpy as np
-from collections.abc import MutableSequence
 from collections import defaultdict, deque
+from collections.abc import MutableSequence
+
+import numpy as np
 
 import cereal.messaging as messaging
 

--- a/selfdrive/debug/clear_dtc.py
+++ b/selfdrive/debug/clear_dtc.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-import sys
 import argparse
-from subprocess import check_output, CalledProcessError
+import sys
+from subprocess import CalledProcessError, check_output
+
 from panda import Panda
-from panda.python.uds import UdsClient, MessageTimeoutError, SESSION_TYPE, DTC_GROUP_TYPE
+from panda.python.uds import DTC_GROUP_TYPE, SESSION_TYPE, MessageTimeoutError, UdsClient
 
 parser = argparse.ArgumentParser(description="clear DTC status")
 parser.add_argument("addr", type=lambda x: int(x,0), nargs="?", default=0x7DF) # default is functional (broadcast) address

--- a/selfdrive/debug/count_events.py
+++ b/selfdrive/debug/count_events.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-import sys
-import math
 import datetime
+import math
+import sys
 from collections import Counter
 from pprint import pprint
 from typing import cast

--- a/selfdrive/debug/cpu_usage_stat.py
+++ b/selfdrive/debug/cpu_usage_stat.py
@@ -15,14 +15,15 @@ System tools like top/htop can only show current cpu usage values, so I write th
     boardd: 1.96%, min: 1.96%, max: 1.96%, acc: 1.96%
     ubloxd.py: 0.39%, min: 0.39%, max: 0.39%, acc: 0.39%
 '''
-import psutil
-import time
-import os
-import sys
-import numpy as np
 import argparse
+import os
 import re
+import sys
+import time
 from collections import defaultdict
+
+import numpy as np
+import psutil
 
 from openpilot.selfdrive.manager.process_config import managed_processes
 

--- a/selfdrive/debug/cycle_alerts.py
+++ b/selfdrive/debug/cycle_alerts.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-import time
 import random
+import time
 
-from cereal import car, log
 import cereal.messaging as messaging
+from cereal import car, log
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car.honda.interface import CarInterface
-from openpilot.selfdrive.controls.lib.events import ET, Events
 from openpilot.selfdrive.controls.lib.alertmanager import AlertManager
+from openpilot.selfdrive.controls.lib.events import ET, Events
 from openpilot.selfdrive.manager.process_config import managed_processes
 
 EventName = car.CarEvent.EventName

--- a/selfdrive/debug/debug_fw_fingerprinting_offline.py
+++ b/selfdrive/debug/debug_fw_fingerprinting_offline.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 
-from openpilot.tools.lib.logreader import LogReader, ReadMode
 from panda.python import uds
+from openpilot.tools.lib.logreader import LogReader, ReadMode
 
 
 def main(route: str, addrs: list[int]):

--- a/selfdrive/debug/dump.py
+++ b/selfdrive/debug/dump.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-import sys
 import argparse
-import json
 import codecs
+import json
+import sys
 
 from hexdump import hexdump
+
 from cereal import log
 from cereal.services import SERVICE_LIST
 from openpilot.tools.lib.live_logreader import raw_live_logreader
-
 
 codecs.register_error("strict", codecs.backslashreplace_errors)
 

--- a/selfdrive/debug/fingerprint_from_route.py
+++ b/selfdrive/debug/fingerprint_from_route.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+
 from openpilot.tools.lib.logreader import LogReader, ReadMode
 
 

--- a/selfdrive/debug/format_fingerprints.py
+++ b/selfdrive/debug/format_fingerprints.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import jinja2
 import os
+
+import jinja2
 
 from cereal import car
 from openpilot.common.basedir import BASEDIR

--- a/selfdrive/debug/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/hyundai_enable_radar_points.py
@@ -11,13 +11,14 @@ to go back to the default values.
 
 USE AT YOUR OWN RISK! Safety features, like AEB and FCW, might be affected by these changes."""
 
-import sys
 import argparse
+import sys
+from subprocess import CalledProcessError, check_output
 from typing import NamedTuple
-from subprocess import check_output, CalledProcessError
 
 from panda.python import Panda
-from panda.python.uds import UdsClient, SESSION_TYPE, DATA_IDENTIFIER_TYPE
+from panda.python.uds import DATA_IDENTIFIER_TYPE, SESSION_TYPE, UdsClient
+
 
 class ConfigValues(NamedTuple):
   default_config: bytes

--- a/selfdrive/debug/internal/fuzz_fw_fingerprint.py
+++ b/selfdrive/debug/internal/fuzz_fw_fingerprint.py
@@ -6,11 +6,10 @@ from collections import defaultdict
 from tqdm import tqdm
 
 from openpilot.selfdrive.car.fw_versions import match_fw_to_car_fuzzy
-from openpilot.selfdrive.car.toyota.values import FW_VERSIONS as TOYOTA_FW_VERSIONS
 from openpilot.selfdrive.car.honda.values import FW_VERSIONS as HONDA_FW_VERSIONS
 from openpilot.selfdrive.car.hyundai.values import FW_VERSIONS as HYUNDAI_FW_VERSIONS
+from openpilot.selfdrive.car.toyota.values import FW_VERSIONS as TOYOTA_FW_VERSIONS
 from openpilot.selfdrive.car.volkswagen.values import FW_VERSIONS as VW_FW_VERSIONS
-
 
 FWS = {}
 FWS.update(TOYOTA_FW_VERSIONS)

--- a/selfdrive/debug/internal/measure_torque_time_to_max.py
+++ b/selfdrive/debug/internal/measure_torque_time_to_max.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 # type: ignore
 
-import os
 import argparse
+import os
 import struct
 from collections import deque
 from statistics import mean
 
-from cereal import log
 import cereal.messaging as messaging
+from cereal import log
 
 if __name__ == "__main__":
 

--- a/selfdrive/debug/live_cpu_and_temp.py
+++ b/selfdrive/debug/live_cpu_and_temp.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 import argparse
-import capnp
 from collections import defaultdict
+
+import capnp
 
 from cereal.messaging import SubMaster
 from openpilot.common.numpy_fast import mean
+
 
 def cputime_total(ct):
   return ct.user + ct.nice + ct.system + ct.idle + ct.iowait + ct.irq + ct.softirq

--- a/selfdrive/debug/print_docs_diff.py
+++ b/selfdrive/debug/print_docs_diff.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import argparse
-from collections import defaultdict
 import difflib
 import pickle
+from collections import defaultdict
 
 from openpilot.selfdrive.car.docs import get_all_car_info
 from openpilot.selfdrive.car.docs_definitions import Column

--- a/selfdrive/debug/read_dtc_status.py
+++ b/selfdrive/debug/read_dtc_status.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-import sys
 import argparse
-from subprocess import check_output, CalledProcessError
+import sys
+from subprocess import CalledProcessError, check_output
+
 from panda import Panda
-from panda.python.uds import UdsClient, SESSION_TYPE, DTC_REPORT_TYPE, DTC_STATUS_MASK_TYPE
-from panda.python.uds import get_dtc_num_as_str, get_dtc_status_names
+from panda.python.uds import DTC_REPORT_TYPE, DTC_STATUS_MASK_TYPE, SESSION_TYPE, UdsClient, get_dtc_num_as_str, get_dtc_status_names
 
 parser = argparse.ArgumentParser(description="read DTC status")
 parser.add_argument("addr", type=lambda x: int(x,0))

--- a/selfdrive/debug/set_car_params.py
+++ b/selfdrive/debug/set_car_params.py
@@ -3,8 +3,8 @@ import sys
 
 from cereal import car
 from openpilot.common.params import Params
-from openpilot.tools.lib.route import Route
 from openpilot.tools.lib.logreader import LogReader
+from openpilot.tools.lib.route import Route
 
 if __name__ == "__main__":
   CP = None

--- a/selfdrive/debug/show_matching_cars.py
+++ b/selfdrive/debug/show_matching_cars.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-from openpilot.selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 import cereal.messaging as messaging
-
+from openpilot.selfdrive.car.fingerprints import all_legacy_fingerprint_cars, eliminate_incompatible_cars
 
 # rav4 2019 and corolla tss2
 fingerprint = {896: 8, 898: 8, 900: 6, 976: 1, 1541: 8, 902: 6, 905: 8, 810: 2, 1164: 8, 1165: 8, 1166: 8, 1167: 8, 1552: 8, 1553: 8, 1556: 8, 1571: 8, 921: 8, 1056: 8, 544: 4, 1570: 8, 1059: 1, 36: 8, 37: 8, 550: 8, 935: 8, 552: 4, 170: 8, 812: 8, 944: 8, 945: 8, 562: 6, 180: 8, 1077: 8, 951: 8, 1592: 8, 1076: 8, 186: 4, 955: 8, 956: 8, 1001: 8, 705: 8, 452: 8, 1788: 8, 464: 8, 824: 8, 466: 8, 467: 8, 761: 8, 728: 8, 1572: 8, 1114: 8, 933: 8, 800: 8, 608: 8, 865: 8, 610: 8, 1595: 8, 934: 8, 998: 5, 1745: 8, 1000: 8, 764: 8, 1002: 8, 999: 7, 1789: 8, 1649: 8, 1779: 8, 1568: 8, 1017: 8, 1786: 8, 1787: 8, 1020: 8, 426: 6, 1279: 8} # noqa: E501

--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 # type: ignore
 
-from collections import defaultdict
 import argparse
 import os
 import traceback
+from collections import defaultdict
+
 from tqdm import tqdm
-from openpilot.tools.lib.logreader import LogReader, ReadMode
-from openpilot.tools.lib.route import SegmentRange
+
 from openpilot.selfdrive.car.car_helpers import interface_names
 from openpilot.selfdrive.car.fw_versions import VERSIONS, match_fw_to_car
-
+from openpilot.tools.lib.logreader import LogReader, ReadMode
+from openpilot.tools.lib.route import SegmentRange
 
 NO_API = "NO_API" in os.environ
 SUPPORTED_BRANDS = VERSIONS.keys()

--- a/selfdrive/debug/toyota_eps_factor.py
+++ b/selfdrive/debug/toyota_eps_factor.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import sys
-import numpy as np
-import matplotlib.pyplot as plt
-from sklearn import linear_model
-from openpilot.selfdrive.car.toyota.values import STEER_THRESHOLD
 
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn import linear_model
+
+from openpilot.selfdrive.car.toyota.values import STEER_THRESHOLD
 from openpilot.tools.lib.logreader import LogReader
 
 MIN_SAMPLES = 30 * 100

--- a/selfdrive/debug/vw_mqb_config.py
+++ b/selfdrive/debug/vw_mqb_config.py
@@ -3,9 +3,10 @@
 import argparse
 import struct
 from enum import IntEnum
+
 from panda import Panda
-from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE,\
-  DATA_IDENTIFIER_TYPE, ACCESS_TYPE
+from panda.python.uds import ACCESS_TYPE, DATA_IDENTIFIER_TYPE, SESSION_TYPE, MessageTimeoutError, NegativeResponseError, UdsClient
+
 
 # TODO: extend UDS library to allow custom/vendor-defined data identifiers without ignoring type checks
 class VOLKSWAGEN_DATA_IDENTIFIER_TYPE(IntEnum):

--- a/selfdrive/locationd/calibrationd.py
+++ b/selfdrive/locationd/calibrationd.py
@@ -8,17 +8,18 @@ and the image input into the neural network is not corrected for roll.
 
 import gc
 import os
-import capnp
-import numpy as np
 from typing import NoReturn
 
-from cereal import log
+import capnp
+import numpy as np
+
 import cereal.messaging as messaging
+from cereal import log
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_realtime_priority
-from openpilot.common.transformations.orientation import rot_from_euler, euler_from_rot
 from openpilot.common.swaglog import cloudlog
+from openpilot.common.transformations.orientation import euler_from_rot, rot_from_euler
 
 MIN_SPEED_FILTER = 15 * CV.MPH_TO_MS
 MAX_VEL_ANGLE_STD = np.radians(0.25)

--- a/selfdrive/locationd/helpers.py
+++ b/selfdrive/locationd/helpers.py
@@ -1,5 +1,6 @@
-import numpy as np
 from typing import Any
+
+import numpy as np
 
 from cereal import log
 

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -5,14 +5,14 @@ from typing import Any
 
 import numpy as np
 
+from rednose.helpers.kalmanfilter import KalmanFilter
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.vehicle_model import ACCELERATION_DUE_TO_GRAVITY
 from openpilot.selfdrive.locationd.models.constants import ObservationKind
-from openpilot.common.swaglog import cloudlog
-
-from rednose.helpers.kalmanfilter import KalmanFilter
 
 if __name__ == '__main__':  # Generating sympy
   import sympy as sp
+
   from rednose.helpers.ekf_sym import gen_code
 else:
   from rednose.helpers.ekf_sym_pyx import EKF_sym_pyx

--- a/selfdrive/locationd/models/live_kf.py
+++ b/selfdrive/locationd/models/live_kf.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-import sys
-import os
-import numpy as np
-
-from openpilot.selfdrive.locationd.models.constants import ObservationKind
-
-import sympy as sp
 import inspect
-from rednose.helpers.sympy_helpers import euler_rotate, quat_matrix_r, quat_rotate
+import os
+import sys
+
+import numpy as np
+import sympy as sp
+
 from rednose.helpers.ekf_sym import gen_code
+from rednose.helpers.sympy_helpers import euler_rotate, quat_matrix_r, quat_rotate
+from openpilot.selfdrive.locationd.models.constants import ObservationKind
 
 EARTH_GM = 3.986005e14  # m^3/s^2 (gravitational constant * mass of earth)
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
-import os
-import math
 import json
+import math
+import os
+
 import numpy as np
 
 import cereal.messaging as messaging
-from cereal import car
-from cereal import log
-from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, DT_MDL
+from cereal import car, log
 from openpilot.common.numpy_fast import clip
+from openpilot.common.params import Params
+from openpilot.common.realtime import DT_MDL, config_realtime_process
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.locationd.models.car_kf import CarKalman, ObservationKind, States
 from openpilot.selfdrive.locationd.models.constants import GENERATED_DIR
-from openpilot.common.swaglog import cloudlog
-
 
 MAX_ANGLE_OFFSET_DELTA = 20 * DT_MDL  # Max 20 deg/s
 ROLL_MAX_DELTA = math.radians(20.0) * DT_MDL  # 20deg in 1 second is well within curvature limits

--- a/selfdrive/locationd/test/test_calibrationd.py
+++ b/selfdrive/locationd/test/test_calibrationd.py
@@ -7,8 +7,18 @@ import numpy as np
 import cereal.messaging as messaging
 from cereal import log
 from openpilot.common.params import Params
-from openpilot.selfdrive.locationd.calibrationd import Calibrator, INPUTS_NEEDED, INPUTS_WANTED, BLOCK_SIZE, MIN_SPEED_FILTER, \
-                                                         MAX_YAW_RATE_FILTER, SMOOTH_CYCLES, HEIGHT_INIT, MAX_ALLOWED_PITCH_SPREAD, MAX_ALLOWED_YAW_SPREAD
+from openpilot.selfdrive.locationd.calibrationd import (
+  BLOCK_SIZE,
+  HEIGHT_INIT,
+  INPUTS_NEEDED,
+  INPUTS_WANTED,
+  MAX_ALLOWED_PITCH_SPREAD,
+  MAX_ALLOWED_YAW_SPREAD,
+  MAX_YAW_RATE_FILTER,
+  MIN_SPEED_FILTER,
+  SMOOTH_CYCLES,
+  Calibrator,
+)
 
 
 def process_messages(c, cam_odo_calib, cycles,

--- a/selfdrive/locationd/test/test_locationd.py
+++ b/selfdrive/locationd/test/test_locationd.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 import json
 import random
-import unittest
 import time
+import unittest
+
 import capnp
 
 import cereal.messaging as messaging
 from cereal.services import SERVICE_LIST
 from openpilot.common.params import Params
 from openpilot.common.transformations.coordinates import ecef2geodetic
-
 from openpilot.selfdrive.manager.process_config import managed_processes
 
 

--- a/selfdrive/locationd/test/test_locationd_scenarios.py
+++ b/selfdrive/locationd/test/test_locationd_scenarios.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-import pytest
 import unittest
-import numpy as np
 from collections import defaultdict
 from enum import Enum
 
-from openpilot.tools.lib.logreader import LogReader
+import numpy as np
+import pytest
+
 from openpilot.selfdrive.test.process_replay.process_replay import replay_process_with_name
+from openpilot.tools.lib.logreader import LogReader
 
 TEST_ROUTE = "ff2bd20623fcaeaa|2023-09-05--10-14-54/4"
 GPS_MESSAGES = ['gpsLocationExternal', 'gpsLocation']

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
+from collections import defaultdict, deque
+
 import numpy as np
-from collections import deque, defaultdict
 
 import cereal.messaging as messaging
 from cereal import car, log
-from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, DT_MDL
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.params import Params
+from openpilot.common.realtime import DT_MDL, config_realtime_process
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.vehicle_model import ACCELERATION_DUE_TO_GRAVITY
-from openpilot.selfdrive.locationd.helpers import PointBuckets, ParameterEstimator
+from openpilot.selfdrive.locationd.helpers import ParameterEstimator, PointBuckets
 
 HISTORY = 5  # secs
 POINTS_PER_BUCKET = 1500

--- a/selfdrive/manager/build.py
+++ b/selfdrive/manager/build.py
@@ -6,9 +6,9 @@ from pathlib import Path
 # NOTE: Do NOT import anything here that needs be built (e.g. params)
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.spinner import Spinner
+from openpilot.common.swaglog import add_file_handler, cloudlog
 from openpilot.common.text_window import TextWindow
 from openpilot.system.hardware import AGNOS
-from openpilot.common.swaglog import cloudlog, add_file_handler
 from openpilot.system.version import is_dirty
 
 MAX_CACHE_SIZE = 4e9 if "CI" in os.environ else 2e9

--- a/selfdrive/manager/helpers.py
+++ b/selfdrive/manager/helpers.py
@@ -1,16 +1,17 @@
 import errno
 import fcntl
 import os
-import sys
 import pathlib
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
+
 
 def unblock_stdout() -> None:
   # get a non-blocking stdout

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -5,21 +5,30 @@ import signal
 import sys
 import traceback
 
-from cereal import log
 import cereal.messaging as messaging
+from cereal import log
 import openpilot.selfdrive.sentry as sentry
-from openpilot.common.params import Params, ParamKeyType
+from openpilot.common.params import ParamKeyType, Params
+from openpilot.common.swaglog import add_file_handler, cloudlog
 from openpilot.common.text_window import TextWindow
-from openpilot.system.hardware import HARDWARE, PC
-from openpilot.selfdrive.manager.helpers import unblock_stdout, write_onroad_params, save_bootlog
+from openpilot.selfdrive.athena.registration import UNREGISTERED_DONGLE_ID, register
+from openpilot.selfdrive.manager.helpers import save_bootlog, unblock_stdout, write_onroad_params
 from openpilot.selfdrive.manager.process import ensure_running
 from openpilot.selfdrive.manager.process_config import managed_processes
-from openpilot.selfdrive.athena.registration import register, UNREGISTERED_DONGLE_ID
-from openpilot.common.swaglog import cloudlog, add_file_handler
-from openpilot.system.version import is_dirty, get_commit, get_version, get_origin, get_short_branch, \
-                           get_normalized_origin, terms_version, training_version, \
-                           is_tested_branch, is_release_branch, get_commit_date
-
+from openpilot.system.hardware import HARDWARE, PC
+from openpilot.system.version import (
+  get_commit,
+  get_commit_date,
+  get_normalized_origin,
+  get_origin,
+  get_short_branch,
+  get_version,
+  is_dirty,
+  is_release_branch,
+  is_tested_branch,
+  terms_version,
+  training_version,
+)
 
 
 def manager_init() -> None:

--- a/selfdrive/manager/process.py
+++ b/selfdrive/manager/process.py
@@ -2,16 +2,16 @@ import importlib
 import os
 import signal
 import struct
-import time
 import subprocess
-from collections.abc import Callable, ValuesView
+import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable, ValuesView
 from multiprocessing import Process
 
 from setproctitle import setproctitle
 
-from cereal import car, log
 import cereal.messaging as messaging
+from cereal import car, log
 import openpilot.selfdrive.sentry as sentry
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params

--- a/selfdrive/manager/process_config.py
+++ b/selfdrive/manager/process_config.py
@@ -2,8 +2,8 @@ import os
 
 from cereal import car
 from openpilot.common.params import Params
+from openpilot.selfdrive.manager.process import DaemonProcess, NativeProcess, PythonProcess
 from openpilot.system.hardware import PC, TICI
-from openpilot.selfdrive.manager.process import PythonProcess, NativeProcess, DaemonProcess
 
 WEBCAM = os.getenv("USE_WEBCAM") is not None
 

--- a/selfdrive/manager/test/test_manager.py
+++ b/selfdrive/manager/test/test_manager.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 import os
-import pytest
 import signal
 import time
 import unittest
 
+import pytest
 from parameterized import parameterized
 
 from cereal import car
-from openpilot.common.params import Params
 import openpilot.selfdrive.manager.manager as manager
+from openpilot.common.params import Params
 from openpilot.selfdrive.manager.process import ensure_running
 from openpilot.selfdrive.manager.process_config import managed_processes
 from openpilot.system.hardware import HARDWARE

--- a/selfdrive/modeld/constants.py
+++ b/selfdrive/modeld/constants.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def index_function(idx, max_val=192, max_idx=32):
   return (max_val) * ((idx/max_idx)**2)
 

--- a/selfdrive/modeld/dmonitoringmodeld.py
+++ b/selfdrive/modeld/dmonitoringmodeld.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
-import os
+import ctypes
 import gc
 import math
+import os
 import time
-import ctypes
-import numpy as np
 from pathlib import Path
+
+import numpy as np
 
 from cereal import messaging
 from cereal.messaging import PubMaster, SubMaster
-from cereal.visionipc import VisionIpcClient, VisionStreamType, VisionBuf
-from openpilot.common.swaglog import cloudlog
+from cereal.visionipc import VisionBuf, VisionIpcClient, VisionStreamType
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_realtime_priority
-from openpilot.selfdrive.modeld.runners import ModelRunner, Runtime
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.modeld.models.commonmodel_pyx import sigmoid
+from openpilot.selfdrive.modeld.runners import ModelRunner, Runtime
 
 CALIB_LEN = 3
 REG_SCALE = 0.25

--- a/selfdrive/modeld/fill_model_msg.py
+++ b/selfdrive/modeld/fill_model_msg.py
@@ -1,8 +1,10 @@
 import os
+
 import capnp
 import numpy as np
+
 from cereal import log
-from openpilot.selfdrive.modeld.constants import ModelConstants, Plan, Meta
+from openpilot.selfdrive.modeld.constants import Meta, ModelConstants, Plan
 
 SEND_RAW_PRED = os.getenv('SEND_RAW_PRED')
 

--- a/selfdrive/modeld/get_model_metadata.py
+++ b/selfdrive/modeld/get_model_metadata.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-import sys
-import pathlib
-import onnx
 import codecs
+import pathlib
 import pickle
+import sys
+
+import onnx
+
 
 def get_name_and_shape(value_info:onnx.ValueInfoProto) -> tuple[str, tuple[int,...]]:
   shape = tuple([int(dim.dim_value) for dim in value_info.type.tensor_type.shape.dim])

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -1,27 +1,29 @@
 #!/usr/bin/env python3
 import os
-import time
 import pickle
+import time
+from pathlib import Path
+
 import numpy as np
+from setproctitle import setproctitle
+
 import cereal.messaging as messaging
 from cereal import car, log
-from pathlib import Path
-from setproctitle import setproctitle
 from cereal.messaging import PubMaster, SubMaster
-from cereal.visionipc import VisionIpcClient, VisionStreamType, VisionBuf
-from openpilot.common.swaglog import cloudlog
-from openpilot.common.params import Params
+from cereal.visionipc import VisionBuf, VisionIpcClient, VisionStreamType
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process
+from openpilot.common.swaglog import cloudlog
 from openpilot.common.transformations.model import get_warp_matrix
 from openpilot.selfdrive import sentry
 from openpilot.selfdrive.car.car_helpers import get_demo_car_params
 from openpilot.selfdrive.controls.lib.desire_helper import DesireHelper
-from openpilot.selfdrive.modeld.runners import ModelRunner, Runtime
-from openpilot.selfdrive.modeld.parse_model_outputs import Parser
-from openpilot.selfdrive.modeld.fill_model_msg import fill_model_msg, fill_pose_msg, PublishState
 from openpilot.selfdrive.modeld.constants import ModelConstants
-from openpilot.selfdrive.modeld.models.commonmodel_pyx import ModelFrame, CLContext
+from openpilot.selfdrive.modeld.fill_model_msg import PublishState, fill_model_msg, fill_pose_msg
+from openpilot.selfdrive.modeld.models.commonmodel_pyx import CLContext, ModelFrame
+from openpilot.selfdrive.modeld.parse_model_outputs import Parser
+from openpilot.selfdrive.modeld.runners import ModelRunner, Runtime
 
 PROCESS_NAME = "selfdrive.modeld.modeld"
 SEND_RAW_PRED = os.getenv('SEND_RAW_PRED')

--- a/selfdrive/modeld/navmodeld.py
+++ b/selfdrive/modeld/navmodeld.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
+import ctypes
 import gc
 import math
 import time
-import ctypes
-import numpy as np
 from pathlib import Path
+
+import numpy as np
 
 from cereal import messaging
 from cereal.messaging import PubMaster, SubMaster
 from cereal.visionipc import VisionIpcClient, VisionStreamType
-from openpilot.common.swaglog import cloudlog
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_realtime_priority
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.modeld.constants import ModelConstants
 from openpilot.selfdrive.modeld.runners import ModelRunner, Runtime
 

--- a/selfdrive/modeld/parse_model_outputs.py
+++ b/selfdrive/modeld/parse_model_outputs.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 from openpilot.selfdrive.modeld.constants import ModelConstants
+
 
 def sigmoid(x):
   return 1. / (1. + np.exp(-x))

--- a/selfdrive/modeld/runners/__init__.py
+++ b/selfdrive/modeld/runners/__init__.py
@@ -1,6 +1,8 @@
 import os
-from openpilot.system.hardware import TICI
+
 from openpilot.selfdrive.modeld.runners.runmodel_pyx import RunModel, Runtime
+from openpilot.system.hardware import TICI
+
 assert Runtime
 
 USE_THNEED = int(os.getenv('USE_THNEED', str(int(TICI))))

--- a/selfdrive/modeld/runners/onnxmodel.py
+++ b/selfdrive/modeld/runners/onnxmodel.py
@@ -1,9 +1,10 @@
-import onnx
 import itertools
 import os
 import sys
-import numpy as np
 from typing import Any
+
+import numpy as np
+import onnx
 
 from openpilot.selfdrive.modeld.runners.runmodel_pyx import RunModel
 

--- a/selfdrive/modeld/tests/test_modeld.py
+++ b/selfdrive/modeld/tests/test_modeld.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-import unittest
-import numpy as np
 import random
+import unittest
+
+import numpy as np
 
 import cereal.messaging as messaging
 from cereal.visionipc import VisionIpcServer, VisionStreamType
-from openpilot.common.transformations.camera import tici_f_frame_size
 from openpilot.common.realtime import DT_MDL
+from openpilot.common.transformations.camera import tici_f_frame_size
 from openpilot.selfdrive.car.car_helpers import write_car_param
 from openpilot.selfdrive.manager.process_config import managed_processes
 from openpilot.selfdrive.test.process_replay.vision_meta import meta_from_camera_state

--- a/selfdrive/modeld/tests/tf_test/pb_loader.py
+++ b/selfdrive/modeld/tests/tf_test/pb_loader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+
 import tensorflow as tf
 
 with open(sys.argv[1], "rb") as f:

--- a/selfdrive/modeld/tests/timing/benchmark.py
+++ b/selfdrive/modeld/tests/timing/benchmark.py
@@ -3,11 +3,11 @@
 
 import os
 import time
+
 import numpy as np
 
 import cereal.messaging as messaging
 from openpilot.selfdrive.manager.process_config import managed_processes
-
 
 N = int(os.getenv("N", "5"))
 TIME = int(os.getenv("TIME", "30"))

--- a/selfdrive/monitoring/driver_monitor.py
+++ b/selfdrive/monitoring/driver_monitor.py
@@ -1,9 +1,9 @@
 from math import atan2
 
 from cereal import car
+from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.numpy_fast import interp
 from openpilot.common.realtime import DT_DMON
-from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.stat_live import RunningStatFilter
 from openpilot.common.transformations.camera import tici_d_frame_size
 

--- a/selfdrive/monitoring/test_monitoring.py
+++ b/selfdrive/monitoring/test_monitoring.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import unittest
+
 import numpy as np
 
 from cereal import car, log
 from openpilot.common.realtime import DT_DMON
 from openpilot.selfdrive.controls.lib.events import Events
-from openpilot.selfdrive.monitoring.driver_monitor import DriverStatus, DRIVER_MONITOR_SETTINGS
+from openpilot.selfdrive.monitoring.driver_monitor import DRIVER_MONITOR_SETTINGS, DriverStatus
 
 EventName = car.CarEvent.EventName
 dm_settings = DRIVER_MONITOR_SETTINGS()

--- a/selfdrive/navd/map_renderer.py
+++ b/selfdrive/navd/map_renderer.py
@@ -3,12 +3,13 @@
 
 import os
 import time
+
 import numpy as np
 import polyline
 from cffi import FFI
 
-from openpilot.common.ffi_wrapper import suffix
 from openpilot.common.basedir import BASEDIR
+from openpilot.common.ffi_wrapper import suffix
 
 HEIGHT = WIDTH = SIZE = 256
 METERS_PER_PIXEL = 2

--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -11,11 +11,15 @@ from cereal import log
 from openpilot.common.api import Api
 from openpilot.common.params import Params
 from openpilot.common.realtime import Ratekeeper
-from openpilot.selfdrive.navd.helpers import (Coordinate, coordinate_from_param,
-                                    distance_along_geometry, maxspeed_to_ms,
-                                    minimum_distance,
-                                    parse_banner_instructions)
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.navd.helpers import (
+  Coordinate,
+  coordinate_from_param,
+  distance_along_geometry,
+  maxspeed_to_ms,
+  minimum_distance,
+  parse_banner_instructions,
+)
 
 REROUTE_DISTANCE = 25
 MANEUVER_TRANSITION_THRESHOLD = 10

--- a/selfdrive/navd/tests/test_map_renderer.py
+++ b/selfdrive/navd/tests/test_map_renderer.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-import time
-import numpy as np
-import os
-import pytest
-import unittest
-import requests
-import threading
 import http.server
-import cereal.messaging as messaging
-
+import os
+import threading
+import time
+import unittest
 from typing import Any
+
+import numpy as np
+import pytest
+import requests
+
+import cereal.messaging as messaging
 from cereal.visionipc import VisionIpcClient, VisionStreamType
 from openpilot.common.mock.generators import LLK_DECIMATION, LOCATION1, LOCATION2, generate_liveLocationKalman
 from openpilot.selfdrive.test.helpers import with_processes

--- a/selfdrive/navd/tests/test_navd.py
+++ b/selfdrive/navd/tests/test_navd.py
@@ -2,8 +2,8 @@
 import json
 import random
 import unittest
-import numpy as np
 
+import numpy as np
 from parameterized import parameterized
 
 import cereal.messaging as messaging

--- a/selfdrive/sentry.py
+++ b/selfdrive/sentry.py
@@ -1,14 +1,14 @@
 """Install exception handler for process crash."""
-import sentry_sdk
 from enum import Enum
+
+import sentry_sdk
 from sentry_sdk.integrations.threading import ThreadingIntegration
 
 from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.athena.registration import is_registered_device
 from openpilot.system.hardware import HARDWARE, PC
-from openpilot.common.swaglog import cloudlog
-from openpilot.system.version import get_branch, get_commit, get_origin, get_version, \
-                              is_comma_remote, is_dirty, is_tested_branch
+from openpilot.system.version import get_branch, get_commit, get_origin, get_version, is_comma_remote, is_dirty, is_tested_branch
 
 
 class SentryProject(Enum):

--- a/selfdrive/statsd.py
+++ b/selfdrive/statsd.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 import os
-import zmq
 import time
-from pathlib import Path
 from collections import defaultdict
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import NoReturn
 
-from openpilot.common.params import Params
+import zmq
+
 from cereal.messaging import SubMaster
-from openpilot.system.hardware.hw import Paths
+from openpilot.common.file_helpers import atomic_write_in_dir
+from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware import HARDWARE
-from openpilot.common.file_helpers import atomic_write_in_dir
+from openpilot.system.hardware.hw import Paths
+from openpilot.system.loggerd.config import STATS_DIR_FILE_LIMIT, STATS_FLUSH_TIME_S, STATS_SOCKET
 from openpilot.system.version import get_normalized_origin, get_short_branch, get_short_version, is_dirty
-from openpilot.system.loggerd.config import STATS_DIR_FILE_LIMIT, STATS_SOCKET, STATS_FLUSH_TIME_S
 
 
 class METRIC_TYPE:

--- a/selfdrive/test/ciui.py
+++ b/selfdrive/test/ciui.py
@@ -6,8 +6,10 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel
+from PyQt5.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+
 from openpilot.selfdrive.ui.qt.python_helpers import set_main_window
+
 
 class Window(QWidget):
   def __init__(self, parent=None):

--- a/selfdrive/test/cpp_harness.py
+++ b/selfdrive/test/cpp_harness.py
@@ -4,7 +4,6 @@ import sys
 
 from openpilot.common.prefix import OpenpilotPrefix
 
-
 with OpenpilotPrefix():
   ret = subprocess.call(sys.argv[1:])
 

--- a/selfdrive/test/fuzzy_generation.py
+++ b/selfdrive/test/fuzzy_generation.py
@@ -1,7 +1,8 @@
+from collections.abc import Callable
+from typing import Any
+
 import capnp
 import hypothesis.strategies as st
-from typing import Any
-from collections.abc import Callable
 
 from cereal import log
 

--- a/selfdrive/test/helpers.py
+++ b/selfdrive/test/helpers.py
@@ -1,13 +1,12 @@
 import os
 import time
-
 from functools import wraps
 
 import cereal.messaging as messaging
 from openpilot.common.params import Params
 from openpilot.selfdrive.manager.process_config import managed_processes
 from openpilot.system.hardware import PC
-from openpilot.system.version import training_version, terms_version
+from openpilot.system.version import terms_version, training_version
 
 
 def set_params_enabled():

--- a/selfdrive/test/longitudinal_maneuvers/maneuver.py
+++ b/selfdrive/test/longitudinal_maneuvers/maneuver.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from openpilot.selfdrive.test.longitudinal_maneuvers.plant import Plant
 
 

--- a/selfdrive/test/longitudinal_maneuvers/plant.py
+++ b/selfdrive/test/longitudinal_maneuvers/plant.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 import time
+
 import numpy as np
 
-from cereal import log
 import cereal.messaging as messaging
-from openpilot.common.realtime import Ratekeeper, DT_MDL
+from cereal import log
+from openpilot.common.realtime import DT_MDL, Ratekeeper
 from openpilot.selfdrive.controls.lib.longcontrol import LongCtrlState
-from openpilot.selfdrive.modeld.constants import ModelConstants
 from openpilot.selfdrive.controls.lib.longitudinal_planner import LongitudinalPlanner
 from openpilot.selfdrive.controls.radard import _LEAD_ACCEL_TAU
+from openpilot.selfdrive.modeld.constants import ModelConstants
 
 
 class Plant:
@@ -46,8 +47,8 @@ class Plant:
     time.sleep(0.1)
     self.sm = messaging.SubMaster(['longitudinalPlan'])
 
-    from openpilot.selfdrive.car.honda.values import CAR
     from openpilot.selfdrive.car.honda.interface import CarInterface
+    from openpilot.selfdrive.car.honda.values import CAR
 
     self.planner = LongitudinalPlanner(CarInterface.get_non_essential_params(CAR.CIVIC), init_v=self.speed)
 

--- a/selfdrive/test/longitudinal_maneuvers/test_longitudinal.py
+++ b/selfdrive/test/longitudinal_maneuvers/test_longitudinal.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import itertools
 import unittest
+
 from parameterized import parameterized_class
 
 from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import STOP_DISTANCE

--- a/selfdrive/test/process_replay/__init__.py
+++ b/selfdrive/test/process_replay/__init__.py
@@ -1,2 +1,2 @@
-from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, get_process_config, get_custom_params_from_lr, \
-                                                                  replay_process, replay_process_with_name  # noqa: F401
+from openpilot.selfdrive.test.process_replay.process_replay import (CONFIGS, get_process_config, get_custom_params_from_lr,  # noqa: I001, F401
+                                                                    replay_process, replay_process_with_name)

--- a/selfdrive/test/process_replay/capture.py
+++ b/selfdrive/test/process_replay/capture.py
@@ -1,7 +1,7 @@
 import os
 import sys
-
 from typing import no_type_check
+
 
 class FdRedirect:
   def __init__(self, file_prefix: str, fd: int):

--- a/selfdrive/test/process_replay/compare_logs.py
+++ b/selfdrive/test/process_replay/compare_logs.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-import sys
 import math
-import capnp
 import numbers
-import dictdiffer
+import sys
 from collections import Counter
+
+import capnp
+import dictdiffer
 
 from openpilot.tools.lib.logreader import LogReader
 

--- a/selfdrive/test/process_replay/migration.py
+++ b/selfdrive/test/process_replay/migration.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
 
 from cereal import messaging
-from openpilot.selfdrive.test.process_replay.vision_meta import meta_from_encode_index
+from panda import Panda
 from openpilot.selfdrive.car.toyota.values import EPS_SCALE
 from openpilot.selfdrive.manager.process_config import managed_processes
-from panda import Panda
+from openpilot.selfdrive.test.process_replay.vision_meta import meta_from_encode_index
 
 
 def migrate_all(lr, old_logtime=False, manager_states=False, panda_states=False, camera_states=False):

--- a/selfdrive/test/process_replay/model_replay.py
+++ b/selfdrive/test/process_replay/model_replay.py
@@ -7,15 +7,15 @@ from typing import Any
 
 import cereal.messaging as messaging
 from openpilot.common.params import Params
-from openpilot.system.hardware import PC
 from openpilot.selfdrive.manager.process_config import managed_processes
-from openpilot.tools.lib.openpilotci import BASE_URL, get_url
 from openpilot.selfdrive.test.process_replay.compare_logs import compare_logs, format_diff
 from openpilot.selfdrive.test.process_replay.process_replay import get_process_config, replay_process
+from openpilot.system.hardware import PC
 from openpilot.system.version import get_commit
 from openpilot.tools.lib.framereader import FrameReader
-from openpilot.tools.lib.logreader import LogReader
 from openpilot.tools.lib.helpers import save_log
+from openpilot.tools.lib.logreader import LogReader
+from openpilot.tools.lib.openpilotci import BASE_URL, get_url
 
 TEST_ROUTE = "2f4452b03ccb98f0|2022-12-03--13-45-30"
 SEGMENT = 6
@@ -139,10 +139,12 @@ if __name__ == "__main__":
 
   # Update tile refs
   if update:
-    import urllib
-    import requests
-    import threading
     import http.server
+    import threading
+    import urllib
+
+    import requests
+
     from openpilot.tools.lib.openpilotci import upload_bytes
     os.environ['MAPS_HOST'] = 'http://localhost:5000'
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -1,34 +1,35 @@
 #!/usr/bin/env python3
-import os
-import time
 import copy
-import json
 import heapq
-import signal
+import json
+import os
 import platform
+import signal
+import time
 from collections import OrderedDict
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from typing import Any
-from collections.abc import Callable, Iterable
-from tqdm import tqdm
+
 import capnp
+from tqdm import tqdm
 
 import cereal.messaging as messaging
 from cereal import car
 from cereal.services import SERVICE_LIST
 from cereal.visionipc import VisionIpcServer, get_endpoint_name as vipc_get_endpoint_name
+from panda.python import ALTERNATIVE_EXPERIENCE
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix
-from openpilot.common.timeout import Timeout
 from openpilot.common.realtime import DT_CTRL
-from panda.python import ALTERNATIVE_EXPERIENCE
+from openpilot.common.timeout import Timeout
 from openpilot.selfdrive.car.car_helpers import get_car, interfaces
 from openpilot.selfdrive.manager.process_config import managed_processes
-from openpilot.selfdrive.test.process_replay.vision_meta import meta_from_camera_state, available_streams
-from openpilot.selfdrive.test.process_replay.migration import migrate_all
 from openpilot.selfdrive.test.process_replay.capture import ProcessOutputCapture
-from openpilot.tools.lib.logreader import LogIterable
+from openpilot.selfdrive.test.process_replay.migration import migrate_all
+from openpilot.selfdrive.test.process_replay.vision_meta import available_streams, meta_from_camera_state
 from openpilot.tools.lib.framereader import BaseFrameReader
+from openpilot.tools.lib.logreader import LogIterable
 
 # Numpy gives different results based on CPU features after version 19
 NUMPY_TOLERANCE = 1e-7

--- a/selfdrive/test/process_replay/regen.py
+++ b/selfdrive/test/process_replay/regen.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python3
-import os
 import argparse
+import os
 import time
+from collections.abc import Iterable
+from typing import Any
+
 import capnp
 import numpy as np
 
-from typing import Any
-from collections.abc import Iterable
-
-from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, FAKEDATA, ProcessConfig, replay_process, get_process_config, \
-                                                                   check_openpilot_enabled, get_custom_params_from_lr
+from openpilot.selfdrive.test.process_replay.process_replay import (
+  CONFIGS,
+  FAKEDATA,
+  ProcessConfig,
+  check_openpilot_enabled,
+  get_custom_params_from_lr,
+  get_process_config,
+  replay_process,
+)
 from openpilot.selfdrive.test.process_replay.vision_meta import DRIVER_FRAME_SIZES
 from openpilot.selfdrive.test.update_ci_routes import upload_route
-from openpilot.tools.lib.route import Route
-from openpilot.tools.lib.framereader import FrameReader, BaseFrameReader, FrameType
-from openpilot.tools.lib.logreader import LogReader, LogIterable
+from openpilot.tools.lib.framereader import BaseFrameReader, FrameReader, FrameType
 from openpilot.tools.lib.helpers import save_log
+from openpilot.tools.lib.logreader import LogIterable, LogReader
+from openpilot.tools.lib.route import Route
 
 
 class DummyFrameReader(BaseFrameReader):

--- a/selfdrive/test/process_replay/regen_all.py
+++ b/selfdrive/test/process_replay/regen_all.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import os
 import random
 import traceback
+
 from tqdm import tqdm
 
 from openpilot.common.prefix import OpenpilotPrefix

--- a/selfdrive/test/process_replay/test_debayer.py
+++ b/selfdrive/test/process_replay/test_debayer.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
+import bz2
 import os
 import sys
-import bz2
-import numpy as np
 
+import numpy as np
 import pyopencl as cl  # install with `PYOPENCL_CL_PRETEND_VERSION=2.0 pip install pyopencl`
 
-from openpilot.system.hardware import PC, TICI
 from openpilot.common.basedir import BASEDIR
-from openpilot.tools.lib.openpilotci import BASE_URL
-from openpilot.system.version import get_commit
 from openpilot.system.camerad.snapshot.snapshot import yuv_to_rgb
-from openpilot.tools.lib.logreader import LogReader
+from openpilot.system.hardware import PC, TICI
+from openpilot.system.version import get_commit
 from openpilot.tools.lib.filereader import FileReader
+from openpilot.tools.lib.logreader import LogReader
+from openpilot.tools.lib.openpilotci import BASE_URL
 
 TEST_ROUTE = "8345e3b82948d454|2022-05-04--13-45-33/0"
 

--- a/selfdrive/test/process_replay/test_fuzzy.py
+++ b/selfdrive/test/process_replay/test_fuzzy.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 import copy
-from hypothesis import given, HealthCheck, Phase, settings
-import hypothesis.strategies as st
-from parameterized import parameterized
 import unittest
 
+import hypothesis.strategies as st
+from hypothesis import HealthCheck, Phase, given, settings
+from parameterized import parameterized
+
 from cereal import log
+import openpilot.selfdrive.test.process_replay.process_replay as pr
 from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.test.fuzzy_generation import FuzzyGenerator
-import openpilot.selfdrive.test.process_replay.process_replay as pr
 
 # These processes currently fail because of unrealistic data breaking assumptions
 # that openpilot makes causing error with NaN, inf, int size, array indexing ...

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -4,17 +4,18 @@ import concurrent.futures
 import os
 import sys
 from collections import defaultdict
-from tqdm import tqdm
 from typing import Any
 
+from tqdm import tqdm
+
 from openpilot.selfdrive.car.car_helpers import interface_names
-from openpilot.tools.lib.openpilotci import get_url, upload_file
 from openpilot.selfdrive.test.process_replay.compare_logs import compare_logs, format_diff
-from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, PROC_REPLAY_DIR, FAKEDATA, check_openpilot_enabled, replay_process
+from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS, FAKEDATA, PROC_REPLAY_DIR, check_openpilot_enabled, replay_process
 from openpilot.system.version import get_commit
 from openpilot.tools.lib.filereader import FileReader
-from openpilot.tools.lib.logreader import LogReader
 from openpilot.tools.lib.helpers import save_log
+from openpilot.tools.lib.logreader import LogReader
+from openpilot.tools.lib.openpilotci import get_url, upload_file
 
 source_segments = [
   ("BODY", "937ccb7243511b65|2022-05-24--16-03-09--1"),        # COMMA.BODY

--- a/selfdrive/test/process_replay/test_regen.py
+++ b/selfdrive/test/process_replay/test_regen.py
@@ -4,11 +4,11 @@ import unittest
 
 from parameterized import parameterized
 
-from openpilot.selfdrive.test.process_replay.regen import regen_segment, DummyFrameReader
 from openpilot.selfdrive.test.process_replay.process_replay import check_openpilot_enabled
-from openpilot.tools.lib.openpilotci import get_url
-from openpilot.tools.lib.logreader import LogReader
+from openpilot.selfdrive.test.process_replay.regen import DummyFrameReader, regen_segment
 from openpilot.tools.lib.framereader import FrameReader
+from openpilot.tools.lib.logreader import LogReader
+from openpilot.tools.lib.openpilotci import get_url
 
 TESTED_SEGMENTS = [
   ("PRIUS_C2", "0982d79ebb0de295|2021-01-04--17-13-21--13"), # TOYOTA PRIUS 2017:     NEO, pandaStateDEPRECATED, no peripheralState, sensorEventsDEPRECATED

--- a/selfdrive/test/process_replay/vision_meta.py
+++ b/selfdrive/test/process_replay/vision_meta.py
@@ -1,7 +1,8 @@
 from collections import namedtuple
+
 from cereal.visionipc import VisionStreamType
-from openpilot.common.realtime import DT_MDL, DT_DMON
-from openpilot.common.transformations.camera import tici_f_frame_size, tici_d_frame_size, tici_e_frame_size, eon_f_frame_size, eon_d_frame_size
+from openpilot.common.realtime import DT_DMON, DT_MDL
+from openpilot.common.transformations.camera import eon_d_frame_size, eon_f_frame_size, tici_d_frame_size, tici_e_frame_size, tici_f_frame_size
 
 VideoStreamMeta = namedtuple("VideoStreamMeta", ["camera_state", "encode_index", "stream", "dt", "frame_sizes"])
 ROAD_CAMERA_FRAME_SIZES = {"tici": tici_f_frame_size, "tizi": tici_f_frame_size, "neo": eon_f_frame_size}

--- a/selfdrive/test/profiling/lib.py
+++ b/selfdrive/test/profiling/lib.py
@@ -1,7 +1,9 @@
 from collections import defaultdict, deque
-from cereal.services import SERVICE_LIST
-import cereal.messaging as messaging
+
 import capnp
+
+import cereal.messaging as messaging
+from cereal.services import SERVICE_LIST
 
 
 class ReplayDone(Exception):

--- a/selfdrive/test/profiling/profiler.py
+++ b/selfdrive/test/profiling/profiler.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
+import cProfile
 import os
 import sys
-import cProfile
+
 import pprofile
 import pyprof2calltree
 
 from openpilot.common.params import Params
-from openpilot.tools.lib.logreader import LogReader
-from openpilot.selfdrive.test.profiling.lib import SubMaster, PubMaster, SubSocket, ReplayDone
-from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS
-from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.car.honda.values import CAR as HONDA
+from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.car.volkswagen.values import CAR as VW
+from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS
+from openpilot.selfdrive.test.profiling.lib import PubMaster, ReplayDone, SubMaster, SubSocket
+from openpilot.tools.lib.logreader import LogReader
 
 BASE_URL = "https://commadataci.blob.core.windows.net/openpilotci/"
 
@@ -80,8 +81,8 @@ def profile(proc, func, car='toyota'):
 
 if __name__ == '__main__':
   from openpilot.selfdrive.controls.controlsd import main as controlsd_thread
-  from openpilot.selfdrive.locationd.paramsd import main as paramsd_thread
   from openpilot.selfdrive.controls.plannerd import main as plannerd_thread
+  from openpilot.selfdrive.locationd.paramsd import main as paramsd_thread
 
   procs = {
     'controlsd': controlsd_thread,

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -1,29 +1,30 @@
 #!/usr/bin/env python3
 import bz2
-import math
 import json
+import math
 import os
 import pathlib
-import psutil
-import pytest
 import shutil
 import subprocess
 import time
-import numpy as np
 import unittest
 from collections import Counter, defaultdict
 from functools import cached_property
 from pathlib import Path
 
-from cereal import car
+import numpy as np
+import psutil
+import pytest
+
 import cereal.messaging as messaging
+from cereal import car
 from cereal.services import SERVICE_LIST
 from openpilot.common.basedir import BASEDIR
-from openpilot.common.timeout import Timeout
 from openpilot.common.params import Params
-from openpilot.selfdrive.controls.lib.events import EVENTS, ET
+from openpilot.common.timeout import Timeout
+from openpilot.selfdrive.controls.lib.events import ET, EVENTS
+from openpilot.selfdrive.test.helpers import release_only, set_params_enabled
 from openpilot.system.hardware import HARDWARE
-from openpilot.selfdrive.test.helpers import set_params_enabled, release_only
 from openpilot.system.hardware.hw import Paths
 from openpilot.tools.lib.logreader import LogReader
 

--- a/selfdrive/test/test_time_to_onroad.py
+++ b/selfdrive/test/test_time_to_onroad.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import os
-import pytest
-import time
 import subprocess
+import time
+
+import pytest
 
 import cereal.messaging as messaging
 from openpilot.common.basedir import BASEDIR

--- a/selfdrive/test/test_updated.py
+++ b/selfdrive/test/test_updated.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 import datetime
 import os
-import pytest
-import time
-import tempfile
-import unittest
+import random
 import shutil
 import signal
 import subprocess
-import random
+import tempfile
+import time
+import unittest
+
+import pytest
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params

--- a/selfdrive/test/test_valgrind_replay.py
+++ b/selfdrive/test/test_valgrind_replay.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python3
 import os
+import signal
+import subprocess
 import threading
 import time
 import unittest
-import subprocess
-import signal
 
 if "CI" in os.environ:
   def tqdm(x):
     return x
 else:
-  from tqdm import tqdm   # type: ignore
+  from tqdm import tqdm  # type: ignore
+
+from collections import namedtuple
 
 import cereal.messaging as messaging
-from collections import namedtuple
+from openpilot.common.basedir import BASEDIR
 from openpilot.tools.lib.logreader import LogReader
 from openpilot.tools.lib.openpilotci import get_url
-from openpilot.common.basedir import BASEDIR
 
 ProcessConfig = namedtuple('ProcessConfig', ['proc_name', 'pub_sub', 'ignore', 'command', 'path', 'segment', 'wait_for_response'])
 

--- a/selfdrive/thermald/fan_controller.py
+++ b/selfdrive/thermald/fan_controller.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 from abc import ABC, abstractmethod
 
-from openpilot.common.realtime import DT_TRML
 from openpilot.common.numpy_fast import interp
+from openpilot.common.realtime import DT_TRML
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.pid import PIDController
+
 
 class BaseFanController(ABC):
   @abstractmethod

--- a/selfdrive/thermald/power_monitoring.py
+++ b/selfdrive/thermald/power_monitoring.py
@@ -1,10 +1,10 @@
-import time
 import threading
+import time
 
 from openpilot.common.params import Params
-from openpilot.system.hardware import HARDWARE
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.statsd import statlog
+from openpilot.system.hardware import HARDWARE
 
 CAR_VOLTAGE_LOW_PASS_K = 0.011 # LPF gain for 45s tau (dt/tau / (dt/tau + 1))
 

--- a/selfdrive/thermald/tests/test_fan_controller.py
+++ b/selfdrive/thermald/tests/test_fan_controller.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import unittest
 from unittest.mock import Mock, patch
+
 from parameterized import parameterized
 
 from openpilot.selfdrive.thermald.fan_controller import TiciFanController

--- a/selfdrive/thermald/tests/test_power_monitoring.py
+++ b/selfdrive/thermald/tests/test_power_monitoring.py
@@ -3,9 +3,13 @@ import unittest
 from unittest.mock import patch
 
 from openpilot.common.params import Params
-from openpilot.selfdrive.thermald.power_monitoring import PowerMonitoring, CAR_BATTERY_CAPACITY_uWh, \
-                                                CAR_CHARGING_RATE_W, VBATT_PAUSE_CHARGING, DELAY_SHUTDOWN_TIME_S
-
+from openpilot.selfdrive.thermald.power_monitoring import (
+  CAR_CHARGING_RATE_W,
+  DELAY_SHUTDOWN_TIME_S,
+  VBATT_PAUSE_CHARGING,
+  CAR_BATTERY_CAPACITY_uWh,
+  PowerMonitoring,
+)
 
 # Create fake time
 ssb = 0.

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import os
 import json
+import os
 import queue
 import threading
 import time
@@ -16,13 +16,13 @@ from openpilot.common.dict_helpers import strip_deprecated_keys
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_TRML
-from openpilot.selfdrive.controls.lib.alertmanager import set_offroad_alert
-from openpilot.system.hardware import HARDWARE, TICI, AGNOS
-from openpilot.system.loggerd.config import get_available_percent
-from openpilot.selfdrive.statsd import statlog
 from openpilot.common.swaglog import cloudlog
-from openpilot.selfdrive.thermald.power_monitoring import PowerMonitoring
+from openpilot.selfdrive.controls.lib.alertmanager import set_offroad_alert
+from openpilot.selfdrive.statsd import statlog
 from openpilot.selfdrive.thermald.fan_controller import TiciFanController
+from openpilot.selfdrive.thermald.power_monitoring import PowerMonitoring
+from openpilot.system.hardware import AGNOS, HARDWARE, TICI
+from openpilot.system.loggerd.config import get_available_percent
 from openpilot.system.version import terms_version, training_version
 
 ThermalStatus = log.DeviceState.ThermalStatus

--- a/selfdrive/tombstoned.py
+++ b/selfdrive/tombstoned.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 import datetime
+import glob
 import os
 import re
 import shutil
 import signal
 import subprocess
 import time
-import glob
 from typing import NoReturn
 
 import openpilot.selfdrive.sentry as sentry
-from openpilot.system.hardware.hw import Paths
 from openpilot.common.swaglog import cloudlog
+from openpilot.system.hardware.hw import Paths
 from openpilot.system.version import get_commit
 
 MAX_SIZE = 1_000_000 * 100  # allow up to 100M

--- a/selfdrive/ui/qt/python_helpers.py
+++ b/selfdrive/ui/qt/python_helpers.py
@@ -1,10 +1,10 @@
 import os
-from cffi import FFI
 
 import sip
+from cffi import FFI
 
-from openpilot.common.ffi_wrapper import suffix
 from openpilot.common.basedir import BASEDIR
+from openpilot.common.ffi_wrapper import suffix
 
 
 def get_ffi():

--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -1,8 +1,8 @@
 import math
-import numpy as np
 import time
 import wave
 
+import numpy as np
 
 from cereal import car, messaging
 from openpilot.common.basedir import BASEDIR
@@ -10,7 +10,6 @@ from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.realtime import Ratekeeper
 from openpilot.common.retry import retry
 from openpilot.common.swaglog import cloudlog
-
 from openpilot.system import micd
 
 SAMPLE_RATE = 48000

--- a/selfdrive/ui/tests/body.py
+++ b/selfdrive/ui/tests/body.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import time
+
 import cereal.messaging as messaging
 
 if __name__ == "__main__":

--- a/selfdrive/ui/tests/cycle_offroad_alerts.py
+++ b/selfdrive/ui/tests/cycle_offroad_alerts.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
+import json
 import os
 import sys
 import time
-import json
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
+import time
 import unittest
 
-from cereal import car
-from cereal import messaging
-from cereal.messaging import SubMaster, PubMaster
+from cereal import car, messaging
+from cereal.messaging import PubMaster, SubMaster
 from openpilot.selfdrive.ui.soundd import CONTROLS_TIMEOUT, check_controls_timeout_alert
-
-import time
 
 AudibleAlert = car.CarControl.HUDControl.AudibleAlert
 

--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -2,15 +2,16 @@
 import json
 import os
 import re
-import unittest
 import shutil
-import tempfile
-import xml.etree.ElementTree as ET
 import string
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
 import requests
 from parameterized import parameterized_class
 
-from openpilot.selfdrive.ui.update_translations import TRANSLATIONS_DIR, LANGUAGES_FILE, update_translations
+from openpilot.selfdrive.ui.update_translations import LANGUAGES_FILE, TRANSLATIONS_DIR, update_translations
 
 with open(LANGUAGES_FILE) as f:
   translation_files = json.load(f)

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -1,20 +1,20 @@
-from collections import namedtuple
+import os
 import pathlib
 import shutil
 import sys
+import time
+import unittest
+from collections import namedtuple
+
 import jinja2
 import matplotlib.pyplot as plt
 import numpy as np
-import os
 import pywinctl
-import time
-import unittest
-
 from parameterized import parameterized
-from cereal import messaging, car, log
-from cereal.visionipc import VisionIpcServer, VisionStreamType
 
-from cereal.messaging import SubMaster, PubMaster
+from cereal import car, log, messaging
+from cereal.messaging import PubMaster, SubMaster
+from cereal.visionipc import VisionIpcServer, VisionStreamType
 from openpilot.common.mock import mock_messages
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_MDL

--- a/selfdrive/ui/translations/create_badges.py
+++ b/selfdrive/ui/translations/create_badges.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import json
 import os
-import requests
 import xml.etree.ElementTree as ET
+
+import requests
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.selfdrive.ui.tests.test_translations import UNFINISHED_TRANSLATION_TAG

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
+import datetime
+import fcntl
 import os
 import re
-import datetime
-import subprocess
-import psutil
 import shutil
 import signal
-import fcntl
-import time
+import subprocess
 import threading
+import time
 from collections import defaultdict
 from pathlib import Path
+
+import psutil
 from markdown_it import MarkdownIt
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
-from openpilot.common.time import system_time_valid
-from openpilot.system.hardware import AGNOS, HARDWARE
 from openpilot.common.swaglog import cloudlog
+from openpilot.common.time import system_time_valid
 from openpilot.selfdrive.controls.lib.alertmanager import set_offroad_alert
+from openpilot.system.hardware import AGNOS, HARDWARE
 from openpilot.system.version import is_tested_branch
 
 LOCK_FILE = os.getenv("UPDATER_LOCK_FILE", "/tmp/safe_staging_overlay.lock")

--- a/site_scons/site_tools/cython.py
+++ b/site_scons/site_tools/cython.py
@@ -1,4 +1,5 @@
 import re
+
 import SCons
 from SCons.Action import Action
 from SCons.Scanner import Scanner

--- a/system/camerad/snapshot/snapshot.py
+++ b/system/camerad/snapshot/snapshot.py
@@ -9,10 +9,9 @@ import cereal.messaging as messaging
 from cereal.visionipc import VisionIpcClient, VisionStreamType
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_MDL
-from openpilot.system.hardware import PC
 from openpilot.selfdrive.controls.lib.alertmanager import set_offroad_alert
 from openpilot.selfdrive.manager.process_config import managed_processes
-
+from openpilot.system.hardware import PC
 
 VISION_STREAMS = {
   "roadCameraState": VisionStreamType.VISION_STREAM_ROAD,

--- a/system/camerad/test/get_thumbnails_for_segment.py
+++ b/system/camerad/test/get_thumbnails_for_segment.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+
 from tqdm import tqdm
 
 from openpilot.tools.lib.logreader import LogReader

--- a/system/camerad/test/test_camerad.py
+++ b/system/camerad/test/test_camerad.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-import pytest
 import time
-import numpy as np
-from flaky import flaky
 from collections import defaultdict
+
+import numpy as np
+import pytest
+from flaky import flaky
 
 import cereal.messaging as messaging
 from cereal import log

--- a/system/camerad/test/test_exposure.py
+++ b/system/camerad/test/test_exposure.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import time
 import unittest
+
 import numpy as np
 
-from openpilot.selfdrive.test.helpers import with_processes, phone_only
+from openpilot.selfdrive.test.helpers import phone_only, with_processes
 from openpilot.system.camerad.snapshot.snapshot import get_snapshots
 
 TEST_TIME = 45

--- a/system/hardware/__init__.py
+++ b/system/hardware/__init__.py
@@ -2,8 +2,8 @@ import os
 from typing import cast
 
 from openpilot.system.hardware.base import HardwareBase
-from openpilot.system.hardware.tici.hardware import Tici
 from openpilot.system.hardware.pc.hardware import Pc
+from openpilot.system.hardware.tici.hardware import Tici
 
 TICI = os.path.isfile('/TICI')
 AGNOS = os.path.isfile('/AGNOS')

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from collections import namedtuple
 
 from cereal import log

--- a/system/hardware/tici/amplifier.py
+++ b/system/hardware/tici/amplifier.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import time
-from smbus2 import SMBus
 from collections import namedtuple
+
+from smbus2 import SMBus
 
 # https://datasheets.maximintegrated.com/en/ds/MAX98089.pdf
 

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-import os
-import math
-import time
 import binascii
+import math
+import os
+import subprocess
+import time
+
 import requests
 import serial
-import subprocess
 
 
 def post(url, payload):

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -2,18 +2,18 @@ import json
 import math
 import os
 import subprocess
-import time
 import tempfile
+import time
 from enum import IntEnum
 from functools import cached_property, lru_cache
 from pathlib import Path
 
 from cereal import log
-from openpilot.common.gpio import gpio_set, gpio_init, get_irqs_for_action
+from openpilot.common.gpio import get_irqs_for_action, gpio_init, gpio_set
 from openpilot.system.hardware.base import HardwareBase, ThermalConfig
 from openpilot.system.hardware.tici import iwlist
-from openpilot.system.hardware.tici.pins import GPIO
 from openpilot.system.hardware.tici.amplifier import Amplifier
+from openpilot.system.hardware.tici.pins import GPIO
 
 NM = 'org.freedesktop.NetworkManager'
 NM_CON_ACT = NM + '.Connection.Active'

--- a/system/hardware/tici/power_monitor.py
+++ b/system/hardware/tici/power_monitor.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
+import datetime
 import sys
 import time
-import datetime
-import numpy as np
 from collections import deque
 
-from openpilot.common.realtime import Ratekeeper
+import numpy as np
+
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.realtime import Ratekeeper
 
 
 def read_power():

--- a/system/hardware/tici/precise_power_measure.py
+++ b/system/hardware/tici/precise_power_measure.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import numpy as np
+
 from openpilot.system.hardware.tici.power_monitor import sample_power
 
 if __name__ == '__main__':

--- a/system/hardware/tici/tests/test_agnos_updater.py
+++ b/system/hardware/tici/tests/test_agnos_updater.py
@@ -2,6 +2,7 @@
 import json
 import os
 import unittest
+
 import requests
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))

--- a/system/hardware/tici/tests/test_amplifier.py
+++ b/system/hardware/tici/tests/test_amplifier.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-import time
 import random
-import unittest
 import subprocess
+import time
+import unittest
 
 from panda import Panda
-from openpilot.system.hardware import TICI, HARDWARE
-from openpilot.system.hardware.tici.hardware import Tici
+from openpilot.system.hardware import HARDWARE, TICI
 from openpilot.system.hardware.tici.amplifier import Amplifier
+from openpilot.system.hardware.tici.hardware import Tici
 
 
 class TestAmplifier(unittest.TestCase):

--- a/system/hardware/tici/tests/test_casync.py
+++ b/system/hardware/tici/tests/test_casync.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import os
-import unittest
-import tempfile
 import subprocess
+import tempfile
+import unittest
 
 import openpilot.system.hardware.tici.casync as casync
 

--- a/system/hardware/tici/tests/test_hardware.py
+++ b/system/hardware/tici/tests/test_hardware.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-import pytest
 import time
 import unittest
+
 import numpy as np
+import pytest
 
 from openpilot.system.hardware.tici.hardware import Tici
 

--- a/system/hardware/tici/tests/test_power_draw.py
+++ b/system/hardware/tici/tests/test_power_draw.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
-from collections import defaultdict, deque
 import sys
-import pytest
-import unittest
 import time
-import numpy as np
+import unittest
+from collections import defaultdict, deque
 from dataclasses import dataclass
+
+import numpy as np
+import pytest
 from tabulate import tabulate
 
 import cereal.messaging as messaging
 from cereal.services import SERVICE_LIST
 from openpilot.common.mock import mock_messages
 from openpilot.selfdrive.car.car_helpers import write_car_param
-from openpilot.system.hardware.tici.power_monitor import get_power
-from openpilot.selfdrive.manager.process_config import managed_processes
 from openpilot.selfdrive.manager.manager import manager_cleanup
+from openpilot.selfdrive.manager.process_config import managed_processes
+from openpilot.system.hardware.tici.power_monitor import get_power
 
 SAMPLE_TIME = 8       # seconds to sample power
 MAX_WARMUP_TIME = 30  # seconds to wait for SAMPLE_TIME consecutive valid samples

--- a/system/loggerd/config.py
+++ b/system/loggerd/config.py
@@ -1,6 +1,6 @@
 import os
-from openpilot.system.hardware.hw import Paths
 
+from openpilot.system.hardware.hw import Paths
 
 CAMERA_FPS = 20
 SEGMENT_LENGTH = 60

--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -2,8 +2,9 @@
 import os
 import shutil
 import threading
-from openpilot.system.hardware.hw import Paths
+
 from openpilot.common.swaglog import cloudlog
+from openpilot.system.hardware.hw import Paths
 from openpilot.system.loggerd.config import get_available_bytes, get_available_percent
 from openpilot.system.loggerd.uploader import listdir_by_creation
 from openpilot.system.loggerd.xattr_cache import getxattr

--- a/system/loggerd/tests/loggerd_tests_common.py
+++ b/system/loggerd/tests/loggerd_tests_common.py
@@ -3,7 +3,6 @@ import random
 import unittest
 from pathlib import Path
 
-
 import openpilot.system.loggerd.deleter as deleter
 import openpilot.system.loggerd.uploader as uploader
 from openpilot.common.params import Params

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-import time
 import threading
+import time
 import unittest
 from collections import namedtuple
-from pathlib import Path
 from collections.abc import Sequence
+from pathlib import Path
 
 import openpilot.system.loggerd.deleter as deleter
 from openpilot.common.timeout import Timeout, TimeoutException

--- a/system/loggerd/tests/test_encoder.py
+++ b/system/loggerd/tests/test_encoder.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import math
 import os
-import pytest
 import random
 import shutil
 import subprocess
@@ -9,15 +8,16 @@ import time
 import unittest
 from pathlib import Path
 
+import pytest
 from parameterized import parameterized
 from tqdm import trange
 
 from openpilot.common.params import Params
 from openpilot.common.timeout import Timeout
-from openpilot.system.hardware import TICI
 from openpilot.selfdrive.manager.process_config import managed_processes
-from openpilot.tools.lib.logreader import LogReader
+from openpilot.system.hardware import TICI
 from openpilot.system.hardware.hw import Paths
+from openpilot.tools.lib.logreader import LogReader
 
 SEGMENT_LENGTH = 2
 FULL_SIZE = 2507572

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -1,30 +1,31 @@
 #!/usr/bin/env python3
-import numpy as np
 import os
-import re
 import random
+import re
 import string
 import subprocess
 import time
 from collections import defaultdict
 from pathlib import Path
+
+import numpy as np
 from flaky import flaky
 
 import cereal.messaging as messaging
 from cereal import log
 from cereal.services import SERVICE_LIST
+from cereal.visionipc import VisionIpcServer, VisionStreamType
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.timeout import Timeout
-from openpilot.system.hardware.hw import Paths
-from openpilot.system.loggerd.xattr_cache import getxattr
-from openpilot.system.loggerd.deleter import PRESERVE_ATTR_NAME, PRESERVE_ATTR_VALUE
+from openpilot.common.transformations.camera import tici_d_frame_size, tici_e_frame_size, tici_f_frame_size
 from openpilot.selfdrive.manager.process_config import managed_processes
+from openpilot.system.hardware.hw import Paths
+from openpilot.system.loggerd.deleter import PRESERVE_ATTR_NAME, PRESERVE_ATTR_VALUE
+from openpilot.system.loggerd.xattr_cache import getxattr
 from openpilot.system.version import get_version
 from openpilot.tools.lib.helpers import RE
 from openpilot.tools.lib.logreader import LogReader
-from cereal.visionipc import VisionIpcServer, VisionStreamType
-from openpilot.common.transformations.camera import tici_f_frame_size, tici_d_frame_size, tici_e_frame_size
 
 SentinelType = log.Sentinel.SentinelType
 

--- a/system/loggerd/tests/test_uploader.py
+++ b/system/loggerd/tests/test_uploader.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
-import os
-import time
-import threading
-import unittest
-import logging
 import json
+import logging
+import os
+import threading
+import time
+import unittest
 from pathlib import Path
-from openpilot.system.hardware.hw import Paths
 
 from openpilot.common.swaglog import cloudlog
-from openpilot.system.loggerd.uploader import main, UPLOAD_ATTR_NAME, UPLOAD_ATTR_VALUE
-
+from openpilot.system.hardware.hw import Paths
 from openpilot.system.loggerd.tests.loggerd_tests_common import UploaderTestCase
+from openpilot.system.loggerd.uploader import UPLOAD_ATTR_NAME, UPLOAD_ATTR_VALUE, main
 
 
 class FakeLogHandler(logging.Handler):

--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -1,25 +1,26 @@
 #!/usr/bin/env python3
 import bz2
+import datetime
 import io
 import json
 import os
 import random
-import requests
 import threading
 import time
 import traceback
-import datetime
-from typing import BinaryIO
 from collections.abc import Iterator
+from typing import BinaryIO
 
-from cereal import log
+import requests
+
 import cereal.messaging as messaging
+from cereal import log
 from openpilot.common.api import Api
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_core_affinity
+from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.hw import Paths
 from openpilot.system.loggerd.xattr_cache import getxattr, setxattr
-from openpilot.common.swaglog import cloudlog
 
 NetworkType = log.DeviceState.NetworkType
 UPLOAD_ATTR_NAME = 'user.upload'

--- a/system/loggerd/xattr_cache.py
+++ b/system/loggerd/xattr_cache.py
@@ -1,5 +1,5 @@
-import os
 import errno
+import os
 
 _cached_attributes: dict[tuple, bytes | None] = {}
 

--- a/system/logmessaged.py
+++ b/system/logmessaged.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-import zmq
 from typing import NoReturn
+
+import zmq
 
 import cereal.messaging as messaging
 from openpilot.common.logging_extra import SwagLogFileFormatter
-from openpilot.system.hardware.hw import Paths
 from openpilot.common.swaglog import get_file_handler
+from openpilot.system.hardware.hw import Paths
 
 
 def main() -> NoReturn:

--- a/system/qcomgpsd/modemdiag.py
+++ b/system/qcomgpsd/modemdiag.py
@@ -1,7 +1,9 @@
 import select
-from serial import Serial
+from struct import calcsize, pack, unpack_from
+
 from crcmod import mkCrcFun
-from struct import pack, unpack_from, calcsize
+from serial import Serial
+
 
 class ModemDiag:
   def __init__(self):

--- a/system/qcomgpsd/nmeaport.py
+++ b/system/qcomgpsd/nmeaport.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from dataclasses import dataclass, fields
-from subprocess import check_output, CalledProcessError
+from subprocess import CalledProcessError, check_output
 from time import sleep
 from typing import NoReturn
 

--- a/system/qcomgpsd/qcomgpsd.py
+++ b/system/qcomgpsd/qcomgpsd.py
@@ -1,32 +1,43 @@
 #!/usr/bin/env python3
-import os
-import sys
-import signal
+import datetime
 import itertools
 import math
-import time
-import requests
+import os
 import shutil
+import signal
 import subprocess
-import datetime
-from multiprocessing import Process, Event
+import sys
+import time
+from multiprocessing import Event, Process
+from struct import calcsize, pack, unpack_from
 from typing import NoReturn
-from struct import unpack_from, calcsize, pack
 
-from cereal import log
+import requests
+
 import cereal.messaging as messaging
+from cereal import log
 from openpilot.common.gpio import gpio_init, gpio_set
 from openpilot.common.retry import retry
-from openpilot.system.hardware.tici.pins import GPIO
 from openpilot.common.swaglog import cloudlog
-from openpilot.system.qcomgpsd.modemdiag import ModemDiag, DIAG_LOG_F, setup_logs, send_recv
-from openpilot.system.qcomgpsd.structs import (dict_unpacker, position_report, relist,
-                                              gps_measurement_report, gps_measurement_report_sv,
-                                              glonass_measurement_report, glonass_measurement_report_sv,
-                                              oemdre_measurement_report, oemdre_measurement_report_sv, oemdre_svpoly_report,
-                                              LOG_GNSS_GPS_MEASUREMENT_REPORT, LOG_GNSS_GLONASS_MEASUREMENT_REPORT,
-                                              LOG_GNSS_POSITION_REPORT, LOG_GNSS_OEMDRE_MEASUREMENT_REPORT,
-                                              LOG_GNSS_OEMDRE_SVPOLY_REPORT)
+from openpilot.system.hardware.tici.pins import GPIO
+from openpilot.system.qcomgpsd.modemdiag import DIAG_LOG_F, ModemDiag, send_recv, setup_logs
+from openpilot.system.qcomgpsd.structs import (
+  LOG_GNSS_GLONASS_MEASUREMENT_REPORT,
+  LOG_GNSS_GPS_MEASUREMENT_REPORT,
+  LOG_GNSS_OEMDRE_MEASUREMENT_REPORT,
+  LOG_GNSS_OEMDRE_SVPOLY_REPORT,
+  LOG_GNSS_POSITION_REPORT,
+  dict_unpacker,
+  glonass_measurement_report,
+  glonass_measurement_report_sv,
+  gps_measurement_report,
+  gps_measurement_report_sv,
+  oemdre_measurement_report,
+  oemdre_measurement_report_sv,
+  oemdre_svpoly_report,
+  position_report,
+  relist,
+)
 
 DEBUG = int(os.getenv("DEBUG", "0"))==1
 ASSIST_DATA_FILE = '/tmp/xtra3grc.bin'

--- a/system/qcomgpsd/structs.py
+++ b/system/qcomgpsd/structs.py
@@ -1,4 +1,4 @@
-from struct import unpack_from, calcsize
+from struct import calcsize, unpack_from
 
 LOG_GNSS_POSITION_REPORT = 0x1476
 LOG_GNSS_GPS_MEASUREMENT_REPORT = 0x1477

--- a/system/qcomgpsd/tests/test_qcomgpsd.py
+++ b/system/qcomgpsd/tests/test_qcomgpsd.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-import os
-import pytest
-import json
-import time
 import datetime
-import unittest
+import json
+import os
 import subprocess
+import time
+import unittest
+
+import pytest
 
 import cereal.messaging as messaging
-from openpilot.system.qcomgpsd.qcomgpsd import at_cmd, wait_for_modem
 from openpilot.selfdrive.manager.process_config import managed_processes
+from openpilot.system.qcomgpsd.qcomgpsd import at_cmd, wait_for_modem
 
 GOOD_SIGNAL = bool(int(os.getenv("GOOD_SIGNAL", '0')))
 

--- a/system/sensord/pigeond.py
+++ b/system/sensord/pigeond.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
+import signal
+import struct
 import sys
 import time
-import signal
-import serial
-import struct
-import requests
 import urllib.parse
 from datetime import datetime
 
+import requests
+import serial
+
 from cereal import messaging
+from openpilot.common.gpio import gpio_init, gpio_set
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware import TICI
-from openpilot.common.gpio import gpio_init, gpio_set
 from openpilot.system.hardware.tici.pins import GPIO
 
 UBLOX_TTY = "/dev/ttyHS0"

--- a/system/sensord/tests/test_pigeond.py
+++ b/system/sensord/tests/test_pigeond.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-import pytest
 import time
 import unittest
+
+import pytest
 
 import cereal.messaging as messaging
 from cereal.services import SERVICE_LIST
 from openpilot.common.gpio import gpio_read
-from openpilot.selfdrive.test.helpers import with_processes
 from openpilot.selfdrive.manager.process_config import managed_processes
+from openpilot.selfdrive.test.helpers import with_processes
 from openpilot.system.hardware.tici.pins import GPIO
 
 

--- a/system/sensord/tests/test_sensord.py
+++ b/system/sensord/tests/test_sensord.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import os
-import pytest
 import time
 import unittest
+from collections import defaultdict, namedtuple
+
 import numpy as np
-from collections import namedtuple, defaultdict
+import pytest
 
 import cereal.messaging as messaging
 from cereal import log

--- a/system/sensord/tests/ttff_test.py
+++ b/system/sensord/tests/ttff_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import time
 import atexit
+import time
 
 from cereal import messaging
 from openpilot.selfdrive.manager.process_config import managed_processes

--- a/system/tests/test_logmessaged.py
+++ b/system/tests/test_logmessaged.py
@@ -5,9 +5,9 @@ import time
 import unittest
 
 import cereal.messaging as messaging
+from openpilot.common.swaglog import cloudlog, ipchandler
 from openpilot.selfdrive.manager.process_config import managed_processes
 from openpilot.system.hardware.hw import Paths
-from openpilot.common.swaglog import cloudlog, ipchandler
 
 
 class TestLogmessaged(unittest.TestCase):

--- a/system/ubloxd/tests/print_gps_stats.py
+++ b/system/ubloxd/tests/print_gps_stats.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import time
+
 import cereal.messaging as messaging
 
 if __name__ == "__main__":

--- a/system/ubloxd/tests/ubloxd.py
+++ b/system/ubloxd/tests/ubloxd.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # type: ignore
 
-from openpilot.selfdrive.locationd.test import ublox
 import struct
+
+from openpilot.selfdrive.locationd.test import ublox
 
 baudrate = 460800
 rate = 100  # send new data every 100ms

--- a/system/version.py
+++ b/system/version.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 import os
 import subprocess
-from typing import TypeVar
 from collections.abc import Callable
 from functools import lru_cache
+from typing import TypeVar
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.swaglog import cloudlog

--- a/system/webrtc/device/video.py
+++ b/system/webrtc/device/video.py
@@ -1,10 +1,10 @@
 import asyncio
 
 import av
-from teleoprtc.tracks import TiciVideoStreamTrack
 
 from cereal import messaging
-from openpilot.common.realtime import DT_MDL, DT_DMON
+from teleoprtc.tracks import TiciVideoStreamTrack
+from openpilot.common.realtime import DT_DMON, DT_MDL
 
 
 class LiveStreamVideoStreamTrack(TiciVideoStreamTrack):

--- a/system/webrtc/schema.py
+++ b/system/webrtc/schema.py
@@ -1,5 +1,6 @@
-import capnp
 from typing import Any
+
+import capnp
 
 
 def generate_type(type_walker, schema_walker) -> str | list[Any] | dict[str, Any]:

--- a/system/webrtc/tests/test_stream_session.py
+++ b/system/webrtc/tests/test_stream_session.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
 import asyncio
-import unittest
-from unittest.mock import Mock, MagicMock, patch
 import json
+import unittest
+
 # for aiortc and its dependencies
 import warnings
+from unittest.mock import MagicMock, Mock, patch
+
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-from aiortc import RTCDataChannel
-from aiortc.mediastreams import VIDEO_CLOCK_RATE, VIDEO_TIME_BASE
 import capnp
 import pyaudio
+from aiortc import RTCDataChannel
+from aiortc.mediastreams import VIDEO_CLOCK_RATE, VIDEO_TIME_BASE
 
-from cereal import messaging, log
-
-from openpilot.system.webrtc.webrtcd import CerealOutgoingMessageProxy, CerealIncomingMessageProxy
-from openpilot.system.webrtc.device.video import LiveStreamVideoStreamTrack
-from openpilot.system.webrtc.device.audio import AudioInputStreamTrack
+from cereal import log, messaging
 from openpilot.common.realtime import DT_DMON
+from openpilot.system.webrtc.device.audio import AudioInputStreamTrack
+from openpilot.system.webrtc.device.video import LiveStreamVideoStreamTrack
+from openpilot.system.webrtc.webrtcd import CerealIncomingMessageProxy, CerealOutgoingMessageProxy
 
 
 class TestStreamSession(unittest.TestCase):

--- a/system/webrtc/tests/test_webrtcd.py
+++ b/system/webrtc/tests/test_webrtcd.py
@@ -2,15 +2,17 @@
 import asyncio
 import json
 import unittest
-from unittest.mock import MagicMock, AsyncMock
+
 # for aiortc and its dependencies
 import warnings
+from unittest.mock import AsyncMock, MagicMock
+
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-from openpilot.system.webrtc.webrtcd import get_stream
-
 import aiortc
+
 from teleoprtc import WebRTCOfferBuilder
+from openpilot.system.webrtc.webrtcd import get_stream
 
 
 class TestWebrtcdProc(unittest.IsolatedAsyncioTestCase):

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -3,22 +3,24 @@
 import argparse
 import asyncio
 import json
-import uuid
 import logging
-from dataclasses import dataclass, field
-from typing import Any, TYPE_CHECKING
+import uuid
 
 # aiortc and its dependencies have lots of internal warnings :(
 import warnings
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 import capnp
 from aiohttp import web
+
 if TYPE_CHECKING:
   from aiortc.rtcdatachannel import RTCDataChannel
 
+from cereal import log, messaging
 from openpilot.system.webrtc.schema import generate_field
-from cereal import messaging, log
 
 
 class CerealOutgoingMessageProxy:
@@ -104,12 +106,13 @@ class CerealProxyRunner:
 
 class StreamSession:
   def __init__(self, sdp: str, cameras: list[str], incoming_services: list[str], outgoing_services: list[str], debug_mode: bool = False):
-    from aiortc.mediastreams import VideoStreamTrack, AudioStreamTrack
     from aiortc.contrib.media import MediaBlackhole
-    from openpilot.system.webrtc.device.video import LiveStreamVideoStreamTrack
-    from openpilot.system.webrtc.device.audio import AudioInputStreamTrack, AudioOutputSpeaker
+    from aiortc.mediastreams import AudioStreamTrack, VideoStreamTrack
+
     from teleoprtc import WebRTCAnswerBuilder
     from teleoprtc.info import parse_info_from_offer
+    from openpilot.system.webrtc.device.audio import AudioInputStreamTrack, AudioOutputSpeaker
+    from openpilot.system.webrtc.device.video import LiveStreamVideoStreamTrack
 
     config = parse_info_from_offer(sdp)
     builder = WebRTCAnswerBuilder(sdp)

--- a/tools/bodyteleop/web.py
+++ b/tools/bodyteleop/web.py
@@ -5,15 +5,14 @@ import logging
 import os
 import ssl
 import subprocess
+import wave
 
 import pyaudio
-import wave
-from aiohttp import web
-from aiohttp import ClientSession
+from aiohttp import ClientSession, web
 
 from openpilot.common.basedir import BASEDIR
-from openpilot.system.webrtc.webrtcd import StreamRequestBody
 from openpilot.common.params import Params
+from openpilot.system.webrtc.webrtcd import StreamRequestBody
 
 logger = logging.getLogger("bodyteleop")
 logging.basicConfig(level=logging.INFO)

--- a/tools/camerastream/compressed_vipc.py
+++ b/tools/camerastream/compressed_vipc.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-import av
+import argparse
+import multiprocessing
 import os
 import sys
-import argparse
-import numpy as np
-import multiprocessing
 import time
+
+import av
+import numpy as np
 
 import cereal.messaging as messaging
 from cereal.visionipc import VisionIpcServer, VisionStreamType

--- a/tools/car_porting/auto_fingerprint.py
+++ b/tools/car_porting/auto_fingerprint.py
@@ -2,12 +2,11 @@
 
 import argparse
 from collections import defaultdict
-from openpilot.selfdrive.debug.format_fingerprints import format_brand_fw_versions
 
 from openpilot.selfdrive.car.fw_versions import match_fw_to_car
 from openpilot.selfdrive.car.interfaces import get_interface_attr
+from openpilot.selfdrive.debug.format_fingerprints import format_brand_fw_versions
 from openpilot.tools.lib.logreader import LogReader, ReadMode
-
 
 ALL_FW_VERSIONS = get_interface_attr("FW_VERSIONS")
 ALL_CARS = get_interface_attr("CAR")

--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
-import os
 import argparse
+import os
 import threading
+
 from inputs import get_gamepad
 
 import cereal.messaging as messaging
-from openpilot.common.realtime import Ratekeeper
-from openpilot.common.numpy_fast import interp, clip
+from openpilot.common.numpy_fast import clip, interp
 from openpilot.common.params import Params
+from openpilot.common.realtime import Ratekeeper
 from openpilot.tools.lib.kbhit import KBHit
 
 

--- a/tools/latencylogger/latency_logger.py
+++ b/tools/latencylogger/latency_logger.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 import argparse
 import json
-import matplotlib.patches as mpatches
-import matplotlib.pyplot as plt
-import mpld3
 import sys
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
+
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import mpld3
 
 from openpilot.tools.lib.logreader import LogReader
 

--- a/tools/lib/api.py
+++ b/tools/lib/api.py
@@ -1,5 +1,7 @@
 import os
+
 import requests
+
 API_HOST = os.getenv('API_HOST', 'https://api.commadotai.com')
 
 class CommaApi():

--- a/tools/lib/auth.py
+++ b/tools/lib/auth.py
@@ -22,15 +22,15 @@ Examples::
 """
 
 import argparse
-import sys
 import pprint
+import sys
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlencode
 
 from openpilot.tools.lib.api import APIError, CommaApi, UnauthorizedError
-from openpilot.tools.lib.auth_config import set_token, get_token
+from openpilot.tools.lib.auth_config import get_token, set_token
 
 PORT = 3000
 

--- a/tools/lib/auth_config.py
+++ b/tools/lib/auth_config.py
@@ -1,5 +1,6 @@
 import json
 import os
+
 from openpilot.system.hardware.hw import Paths
 
 

--- a/tools/lib/azure_container.py
+++ b/tools/lib/azure_container.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 from pathlib import Path
 from typing import IO
 
-
 TOKEN_PATH = Path("/data/azure_token")
 
 @lru_cache

--- a/tools/lib/bootlog.py
+++ b/tools/lib/bootlog.py
@@ -1,8 +1,8 @@
 import functools
 import re
 
-from openpilot.tools.lib.auth_config import get_token
 from openpilot.tools.lib.api import CommaApi
+from openpilot.tools.lib.auth_config import get_token
 from openpilot.tools.lib.helpers import RE
 
 

--- a/tools/lib/comma_car_segments.py
+++ b/tools/lib/comma_car_segments.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 
 # Forks with additional car support can fork the commaCarSegments repo on huggingface or host the LFS files themselves

--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -7,16 +7,15 @@ import threading
 from enum import IntEnum
 from functools import wraps
 
+import _io
 import numpy as np
 from lru import LRU
 
-import _io
-from openpilot.tools.lib.cache import cache_path_for_file_path, DEFAULT_CACHE_DIR
-from openpilot.tools.lib.exceptions import DataUnreadableError
-from openpilot.tools.lib.vidindex import hevc_index
 from openpilot.common.file_helpers import atomic_write_in_dir
-
+from openpilot.tools.lib.cache import DEFAULT_CACHE_DIR, cache_path_for_file_path
+from openpilot.tools.lib.exceptions import DataUnreadableError
 from openpilot.tools.lib.filereader import FileReader, resolve_name
+from openpilot.tools.lib.vidindex import hevc_index
 
 HEVC_SLICE_B = 0
 HEVC_SLICE_P = 1

--- a/tools/lib/kbhit.py
+++ b/tools/lib/kbhit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
+import atexit
 import sys
 import termios
-import atexit
 from select import select
 
 STDIN_FD = sys.stdin.fileno()

--- a/tools/lib/live_logreader.py
+++ b/tools/lib/live_logreader.py
@@ -1,9 +1,8 @@
 import os
+
 from cereal import log as capnp_log, messaging
 from cereal.services import SERVICE_LIST
-
 from openpilot.tools.lib.logreader import LogIterable, RawLogIterable
-
 
 ALL_SERVICES = list(SERVICE_LIST.keys())
 

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python3
 import bz2
-from functools import partial
-import multiprocessing
-import capnp
 import enum
+import multiprocessing
 import os
 import pathlib
 import sys
-import tqdm
 import urllib.parse
 import warnings
-
 from collections.abc import Callable, Iterable, Iterator
+from functools import partial
 from urllib.parse import parse_qs, urlparse
+
+import capnp
+import tqdm
 
 from cereal import log as capnp_log
 from openpilot.common.swaglog import cloudlog
 from openpilot.tools.lib.comma_car_segments import get_url as get_comma_segments_url
-from openpilot.tools.lib.openpilotci import get_url
 from openpilot.tools.lib.filereader import FileReader, file_exists, internal_source_available
+from openpilot.tools.lib.openpilotci import get_url
 from openpilot.tools.lib.route import Route, SegmentRange
 
 LogMessage = type[capnp._DynamicStructReader]

--- a/tools/lib/openpilotci.py
+++ b/tools/lib/openpilotci.py
@@ -1,5 +1,6 @@
 from openpilot.tools.lib.openpilotcontainers import OpenpilotCIContainer
 
+
 def get_url(*args, **kwargs):
   return OpenpilotCIContainer.get_url(*args, **kwargs)
 

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -1,13 +1,13 @@
 import os
 import re
-from functools import cache
-from urllib.parse import urlparse
 from collections import defaultdict
+from functools import cache
 from itertools import chain
 from typing import cast
+from urllib.parse import urlparse
 
-from openpilot.tools.lib.auth_config import get_token
 from openpilot.tools.lib.api import CommaApi
+from openpilot.tools.lib.auth_config import get_token
 from openpilot.tools.lib.helpers import RE
 
 QLOG_FILENAMES = ['qlog', 'qlog.bz2']

--- a/tools/lib/tests/test_caching.py
+++ b/tools/lib/tests/test_caching.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-from functools import partial
 import http.server
 import os
 import shutil
 import socket
 import unittest
+from functools import partial
 
 from parameterized import parameterized
+
 from openpilot.selfdrive.athena.tests.helpers import with_http_server
 from openpilot.system.hardware.hw import Paths
 from openpilot.tools.lib.url_file import URLFile

--- a/tools/lib/tests/test_comma_car_segments.py
+++ b/tools/lib/tests/test_comma_car_segments.py
@@ -1,6 +1,7 @@
 import unittest
 
 import requests
+
 from openpilot.tools.lib.comma_car_segments import get_comma_car_segments_database, get_url
 from openpilot.tools.lib.logreader import LogReader
 from openpilot.tools.lib.route import SegmentRange

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 import contextlib
 import io
+import os
 import shutil
 import tempfile
-import os
 import unittest
-import pytest
-import requests
-
-from parameterized import parameterized
 from unittest import mock
 
-from openpilot.tools.lib.logreader import LogIterable, LogReader, comma_api_source, parse_indirect, ReadMode, InternalUnavailableException
+import pytest
+import requests
+from parameterized import parameterized
+
+from openpilot.tools.lib.logreader import InternalUnavailableException, LogIterable, LogReader, ReadMode, comma_api_source, parse_indirect
 from openpilot.tools.lib.route import SegmentRange
 from openpilot.tools.lib.url_file import URLFileException
 

--- a/tools/lib/tests/test_readers.py
+++ b/tools/lib/tests/test_readers.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-import unittest
-import requests
 import tempfile
-
+import unittest
 from collections import defaultdict
+
 import numpy as np
+import requests
+
 from openpilot.tools.lib.framereader import FrameReader
 from openpilot.tools.lib.logreader import LogReader
 

--- a/tools/lib/tests/test_route_library.py
+++ b/tools/lib/tests/test_route_library.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 from openpilot.tools.lib.route import SegmentName
 
+
 class TestRouteLibrary(unittest.TestCase):
   def test_segment_name_formats(self):
     Case = namedtuple('Case', ['input', 'expected_route', 'expected_segment_num', 'expected_data_dir'])

--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -3,12 +3,14 @@ import os
 import socket
 import time
 from hashlib import sha256
+
 from urllib3 import PoolManager, Retry
 from urllib3.response import BaseHTTPResponse
 from urllib3.util import Timeout
 
 from openpilot.common.file_helpers import atomic_write_in_dir
 from openpilot.system.hardware.hw import Paths
+
 #  Cache chunk size
 K = 1000
 CHUNK_SIZE = 1000 * K

--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
+import argparse
 import os
-import sys
 import platform
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
-import requests
-import argparse
 from functools import partial
+
+import requests
 
 from openpilot.common.basedir import BASEDIR
 from openpilot.tools.lib.helpers import save_log
-
 from openpilot.tools.lib.logreader import LogReader, ReadMode
 
 juggle_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tools/plotjuggler/test_plotjuggler.py
+++ b/tools/plotjuggler/test_plotjuggler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import os
 import glob
+import os
 import signal
 import subprocess
 import time

--- a/tools/replay/can_replay.py
+++ b/tools/replay/can_replay.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 import argparse
 import os
-import time
-import usb1
 import threading
+import time
+
+import usb1
 
 os.environ['FILEREADER_CACHE'] = '1'
 
-from openpilot.common.realtime import config_realtime_process, Ratekeeper, DT_CTRL
+from panda import PandaJungle
+from openpilot.common.realtime import DT_CTRL, Ratekeeper, config_realtime_process
 from openpilot.selfdrive.boardd.boardd import can_capnp_to_can_list
 from openpilot.tools.lib.logreader import LogReader
-from panda import PandaJungle
 
 # set both to cycle power or ignition
 PWR_ON = int(os.getenv("PWR_ON", "0"))

--- a/tools/replay/lib/ui_helpers.py
+++ b/tools/replay/lib/ui_helpers.py
@@ -4,14 +4,16 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 import pygame
-
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
-from openpilot.common.transformations.camera import (eon_f_frame_size, eon_f_focal_length,
-                                           tici_f_frame_size, tici_f_focal_length,
-                                           get_view_frame_from_calib_frame)
+from openpilot.common.transformations.camera import (
+  eon_f_focal_length,
+  eon_f_frame_size,
+  get_view_frame_from_calib_frame,
+  tici_f_focal_length,
+  tici_f_frame_size,
+)
 from openpilot.selfdrive.controls.radard import RADAR_TO_CAMERA
-
 
 RED = (255, 0, 0)
 GREEN = (0, 255, 0)

--- a/tools/replay/ui.py
+++ b/tools/replay/ui.py
@@ -8,16 +8,24 @@ import numpy as np
 import pygame
 
 import cereal.messaging as messaging
-from openpilot.common.numpy_fast import clip
-from openpilot.common.basedir import BASEDIR
-from openpilot.tools.replay.lib.ui_helpers import (_BB_TO_FULL_FRAME, UP,
-                                         _INTRINSICS, BLACK, GREEN,
-                                         YELLOW, Calibration,
-                                         get_blank_lid_overlay, init_plots,
-                                         maybe_update_radar_points, plot_lead,
-                                         plot_model,
-                                         pygame_modules_have_loaded)
 from cereal.visionipc import VisionIpcClient, VisionStreamType
+from openpilot.common.basedir import BASEDIR
+from openpilot.common.numpy_fast import clip
+from openpilot.tools.replay.lib.ui_helpers import (
+  _BB_TO_FULL_FRAME,
+  _INTRINSICS,
+  BLACK,
+  GREEN,
+  UP,
+  YELLOW,
+  Calibration,
+  get_blank_lid_overlay,
+  init_plots,
+  maybe_update_radar_points,
+  plot_lead,
+  plot_model,
+  pygame_modules_have_loaded,
+)
 
 os.environ['BASEDIR'] = BASEDIR
 

--- a/tools/scripts/fetch_image_from_route.py
+++ b/tools/scripts/fetch_image_from_route.py
@@ -14,6 +14,7 @@ cameras = {
 
 import requests
 from PIL import Image
+
 from openpilot.tools.lib.auth_config import get_token
 from openpilot.tools.lib.framereader import FrameReader
 

--- a/tools/scripts/save_ubloxraw_stream.py
+++ b/tools/scripts/save_ubloxraw_stream.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import sys
+
 from openpilot.common.basedir import BASEDIR
 from openpilot.tools.lib.logreader import LogReader
 

--- a/tools/scripts/setup_ssh_keys.py
+++ b/tools/scripts/setup_ssh_keys.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-import requests
-from openpilot.common.params import Params
 import sys
 
+import requests
+
+from openpilot.common.params import Params
 
 if __name__ == "__main__":
   if len(sys.argv) < 2:

--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -1,19 +1,18 @@
+import functools
 import signal
 import threading
-import functools
-
-from multiprocessing import Process, Queue, Value
 from abc import ABC, abstractmethod
+from multiprocessing import Process, Queue, Value
 
-from openpilot.common.params import Params
 from openpilot.common.numpy_fast import clip
+from openpilot.common.params import Params
 from openpilot.common.realtime import Ratekeeper
-from openpilot.selfdrive.test.helpers import set_params_enabled
 from openpilot.selfdrive.car.honda.values import CruiseButtons
+from openpilot.selfdrive.test.helpers import set_params_enabled
 from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.keyboard_ctrl import KEYBOARD_HELP
 from openpilot.tools.sim.lib.simulated_car import SimulatedCar
 from openpilot.tools.sim.lib.simulated_sensors import SimulatedSensors
-from openpilot.tools.sim.lib.keyboard_ctrl import KEYBOARD_HELP
 
 
 def rk_loop(function, hz, exit_event: threading.Event):

--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -1,14 +1,12 @@
 import numpy as np
-
-from metadrive.component.sensors.rgb_camera import RGBCamera
-from metadrive.component.sensors.base_camera import _cuda_enable
 from metadrive.component.map.pg_map import MapGenerateMethod
-from panda3d.core import Texture, GraphicsOutput
+from metadrive.component.sensors.base_camera import _cuda_enable
+from metadrive.component.sensors.rgb_camera import RGBCamera
+from panda3d.core import GraphicsOutput, Texture
 
 from openpilot.tools.sim.bridge.common import SimulatorBridge
 from openpilot.tools.sim.bridge.metadrive.metadrive_world import MetaDriveWorld
-from openpilot.tools.sim.lib.camerad import W, H
-
+from openpilot.tools.sim.lib.camerad import H, W
 
 
 class CopyRamRGBCamera(RGBCamera):

--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -1,19 +1,17 @@
 import math
-import numpy as np
-
 from collections import namedtuple
-from panda3d.core import Vec3
 from multiprocessing.connection import Connection
 
+import numpy as np
 from metadrive.engine.core.engine_core import EngineCore
 from metadrive.engine.core.image_buffer import ImageBuffer
 from metadrive.envs.metadrive_env import MetaDriveEnv
 from metadrive.obs.image_obs import ImageObservation
+from panda3d.core import Vec3
 
 from openpilot.common.realtime import Ratekeeper
-
+from openpilot.tools.sim.lib.camerad import H, W
 from openpilot.tools.sim.lib.common import vec3
-from openpilot.tools.sim.lib.camerad import W, H
 
 C3_POSITION = Vec3(0.0, 0, 1.22)
 C3_HPR = Vec3(0, 0,0)

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -1,13 +1,14 @@
 import ctypes
 import functools
 import multiprocessing
-import numpy as np
 import time
+from multiprocessing import Array, Pipe
 
-from multiprocessing import Pipe, Array
+import numpy as np
+
 from openpilot.tools.sim.bridge.metadrive.metadrive_process import metadrive_process, metadrive_state
+from openpilot.tools.sim.lib.camerad import H, W
 from openpilot.tools.sim.lib.common import SimulatorState, World
-from openpilot.tools.sim.lib.camerad import W, H
 
 
 class MetaDriveWorld(World):

--- a/tools/sim/lib/camerad.py
+++ b/tools/sim/lib/camerad.py
@@ -1,13 +1,14 @@
-import numpy as np
 import os
+
+import numpy as np
 import pyopencl as cl
 import pyopencl.array as cl_array
 
-from cereal.visionipc import VisionIpcServer, VisionStreamType
 from cereal import messaging
-
+from cereal.visionipc import VisionIpcServer, VisionStreamType
 from openpilot.common.basedir import BASEDIR
-from openpilot.tools.sim.lib.common import W, H
+from openpilot.tools.sim.lib.common import H, W
+
 
 class Camerad:
   """Simulates the camerad daemon"""

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -1,9 +1,9 @@
 import math
 import multiprocessing
-import numpy as np
-
 from abc import ABC, abstractmethod
 from collections import namedtuple
+
+import numpy as np
 
 W, H = 1928, 1208
 

--- a/tools/sim/lib/keyboard_ctrl.py
+++ b/tools/sim/lib/keyboard_ctrl.py
@@ -1,9 +1,7 @@
 import sys
 import termios
 import time
-
-from termios import (BRKINT, CS8, CSIZE, ECHO, ICANON, ICRNL, IEXTEN, INPCK,
-                     ISTRIP, IXON, PARENB, VMIN, VTIME)
+from termios import BRKINT, CS8, CSIZE, ECHO, ICANON, ICRNL, IEXTEN, INPCK, ISTRIP, IXON, PARENB, VMIN, VTIME
 from typing import NoReturn
 
 # Indexes for termios list.

--- a/tools/sim/lib/manual_ctrl.py
+++ b/tools/sim/lib/manual_ctrl.py
@@ -136,7 +136,7 @@ def wheel_poll_thread(q: 'Queue[str]') -> NoReturn:
 
   # Enable FF
   import evdev
-  from evdev import ecodes, InputDevice
+  from evdev import InputDevice, ecodes
   device = evdev.list_devices()[0]
   evtdev = InputDevice(device)
   val = 24000

--- a/tools/sim/lib/simulated_car.py
+++ b/tools/sim/lib/simulated_car.py
@@ -1,12 +1,11 @@
 import cereal.messaging as messaging
-
 from opendbc.can.packer import CANPacker
 from opendbc.can.parser import CANParser
+from panda.python import Panda
 from openpilot.common.params import Params
 from openpilot.selfdrive.boardd.boardd_api_impl import can_list_to_can_capnp
 from openpilot.selfdrive.car import crc8_pedal
 from openpilot.tools.sim.lib.common import SimulatorState
-from panda.python import Panda
 
 
 class SimulatedCar:

--- a/tools/sim/lib/simulated_sensors.py
+++ b/tools/sim/lib/simulated_sensors.py
@@ -1,14 +1,13 @@
 import time
+from typing import TYPE_CHECKING
 
-from cereal import log
 import cereal.messaging as messaging
-
+from cereal import log
 from openpilot.common.realtime import DT_DMON
 from openpilot.tools.sim.lib.camerad import Camerad
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-  from openpilot.tools.sim.lib.common import World, SimulatorState
+  from openpilot.tools.sim.lib.common import SimulatorState, World
 
 
 class SimulatedSensors:

--- a/tools/sim/run_bridge.py
+++ b/tools/sim/run_bridge.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import argparse
-
-from typing import Any
 from multiprocessing import Queue
+from typing import Any
 
 from openpilot.tools.sim.bridge.metadrive.metadrive_bridge import MetaDriveBridge
+
 
 def create_bridge(dual_camera, high_quality):
   queue: Any = Queue()

--- a/tools/sim/tests/test_metadrive_bridge.py
+++ b/tools/sim/tests/test_metadrive_bridge.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-import pytest
 import unittest
+
+import pytest
 
 from openpilot.tools.sim.bridge.metadrive.metadrive_bridge import MetaDriveBridge
 from openpilot.tools.sim.tests.test_sim_bridge import TestSimBridgeBase
+
 
 @pytest.mark.slow
 class TestMetaDriveBridge(TestSimBridgeBase):

--- a/tools/sim/tests/test_sim_bridge.py
+++ b/tools/sim/tests/test_sim_bridge.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import time
 import unittest
-
 from multiprocessing import Queue
 
 from cereal import messaging

--- a/tools/tuning/measure_steering_accuracy.py
+++ b/tools/tuning/measure_steering_accuracy.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 # type: ignore
 
-import os
-import time
 import argparse
+import os
 import signal
+import time
 from collections import defaultdict
 
 import cereal.messaging as messaging
 from openpilot.tools.lib.logreader import LogReader
+
 
 def sigint_handler(signal, frame):
   exit(0)

--- a/tools/webcam/camera.py
+++ b/tools/webcam/camera.py
@@ -1,6 +1,7 @@
 import cv2 as cv
 import numpy as np
 
+
 class Camera:
   def __init__(self, cam_type_state, stream_type, camera_id):
     try:

--- a/tools/webcam/camerad.py
+++ b/tools/webcam/camerad.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-import threading
 import os
+import threading
 from collections import namedtuple
 
-from cereal.visionipc import VisionIpcServer, VisionStreamType
 from cereal import messaging
-
-from openpilot.tools.webcam.camera import Camera
+from cereal.visionipc import VisionIpcServer, VisionStreamType
 from openpilot.common.realtime import Ratekeeper
+from openpilot.tools.webcam.camera import Camera
 
 DUAL_CAM = os.getenv("DUAL_CAMERA")
 CameraType = namedtuple("CameraType", ["msg_name", "stream_type", "cam_id"])

--- a/tools/zookeeper/check_consumption.py
+++ b/tools/zookeeper/check_consumption.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+
 from openpilot.tools.zookeeper import Zookeeper
 
 # Usage: check_consumption.py <averaging_time_sec> <max_average_power_W>

--- a/tools/zookeeper/enable_and_wait.py
+++ b/tools/zookeeper/enable_and_wait.py
@@ -2,8 +2,10 @@
 import os
 import sys
 import time
-from socket import gethostbyname, gaierror
+from socket import gaierror, gethostbyname
+
 from openpilot.tools.zookeeper import Zookeeper
+
 
 def is_online(ip):
   try:

--- a/tools/zookeeper/ignition.py
+++ b/tools/zookeeper/ignition.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import sys
-from openpilot.tools.zookeeper import Zookeeper
 
+from openpilot.tools.zookeeper import Zookeeper
 
 if __name__ == "__main__":
   z = Zookeeper()

--- a/tools/zookeeper/power_monitor.py
+++ b/tools/zookeeper/power_monitor.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
+import datetime
 import sys
 import time
-import datetime
 
-from openpilot.common.realtime import Ratekeeper
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.realtime import Ratekeeper
 from openpilot.tools.zookeeper import Zookeeper
 
 if __name__ == "__main__":

--- a/tools/zookeeper/test_zookeeper.py
+++ b/tools/zookeeper/test_zookeeper.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import time
-from openpilot.tools.zookeeper import Zookeeper
 
+from openpilot.tools.zookeeper import Zookeeper
 
 if __name__ == "__main__":
   z = Zookeeper()


### PR DESCRIPTION
I enabled the isort rules (`I001`, `I002`) and configured it to group the imports for cereal, opendbc, panda, rednose, teleoprtc ("first party" section) and openpilot ("local folder" section) together (`no-lines-before = ["local-folder"]`).

The entire diff is from running `ruff --fix`, except I tweaked `selfdrive/test/process_replay/__init__.py` to match the ruff import format, preserving the `noqa: F401` for unused imports.

- Unfortunately Ruff [doesn't yet support](https://github.com/astral-sh/ruff/issues/2600) the ["multi line output modes"](https://pycqa.github.io/isort/docs/configuration/multi_line_output_modes.html) option from isort, so long lines of imports are wrapped and split onto seperate lines. Mode 0 or 11 would be closest to what we have now, but Ruff has implemented mode 3.
- I also don't think it's possible to configure it to split up the imports section when it becomes large, like in `controlsd.py` it has grouped all of our first-party and openpilot imports together.

If you think this is a good thing to have, but want to try isort instead to choose the multi line output mode, I could open another PR to add it as a pre-commit hook.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

