### PR TITLE
add common/mock to release

### DIFF
--- a/release/files_common
+++ b/release/files_common
@@ -87,8 +87,8 @@ selfdrive/car/__init__.py
 selfdrive/car/docs_definitions.py
 selfdrive/car/car_helpers.py
 selfdrive/car/fingerprints.py
-selfdrive/car/values.py
 selfdrive/car/interfaces.py
+selfdrive/car/values.py
 selfdrive/car/vin.py
 selfdrive/car/disable_ecu.py
 selfdrive/car/fw_versions.py

--- a/release/files_common
+++ b/release/files_common
@@ -87,7 +87,7 @@ selfdrive/car/__init__.py
 selfdrive/car/docs_definitions.py
 selfdrive/car/car_helpers.py
 selfdrive/car/fingerprints.py
-selfdrive/car/interfaces.py
+selfdrive/car/values.py
 selfdrive/car/interfaces.py
 selfdrive/car/vin.py
 selfdrive/car/disable_ecu.py

--- a/release/files_common
+++ b/release/files_common
@@ -23,6 +23,7 @@ common/.gitignore
 common/__init__.py
 common/*.py
 common/*.pyx
+common/mock/*
 
 common/transformations/__init__.py
 common/transformations/camera.py
@@ -87,7 +88,7 @@ selfdrive/car/docs_definitions.py
 selfdrive/car/car_helpers.py
 selfdrive/car/fingerprints.py
 selfdrive/car/interfaces.py
-selfdrive/car/values.py
+selfdrive/car/interfaces.py
 selfdrive/car/vin.py
 selfdrive/car/disable_ecu.py
 selfdrive/car/fw_versions.py


### PR DESCRIPTION
```
__________ ERROR collecting selfdrive/navd/tests/test_map_renderer.py __________

ImportError while importing test module '/data/openpilot/selfdrive/navd/tests/test_map_renderer.py'.

Hint: make sure your test modules/packages have valid Python names.

Traceback:

/usr/local/pyenv/versions/3.11.4/lib/python3.11/importlib/__init__.py:126: in import_module

    return _bootstrap._gcd_import(name[level:], package, level)

selfdrive/navd/tests/test_map_renderer.py:14: in <module>

    from openpilot.common.mock.generators import LLK_DECIMATION, LOCATION1, LOCATION2, generate_liveLocationKalman

E   ModuleNotFoundError: No module named 'openpilot.common.mock'

```