### PR TITLE
Honda Accord: label non-essential ECUs

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -207,6 +207,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Ecu.combinationMeter: [CAR.CIVIC_BOSCH, CAR.CRV_5G],
     Ecu.gateway: [CAR.CIVIC_BOSCH, CAR.CRV_5G],
     Ecu.electricBrakeBooster: [CAR.CIVIC_BOSCH, CAR.CRV_5G],
+    Ecu.shiftByWire: [CAR.ACCORD],  # existence correlates with transmission type
+    Ecu.hud: [CAR.ACCORD],  # existence correlates with trim level
   },
   extra_ecus=[
     # The only other ECU on PT bus accessible by camera on radarless Civic

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -207,8 +207,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Ecu.combinationMeter: [CAR.CIVIC_BOSCH, CAR.CRV_5G],
     Ecu.gateway: [CAR.CIVIC_BOSCH, CAR.CRV_5G],
     Ecu.electricBrakeBooster: [CAR.CIVIC_BOSCH, CAR.CRV_5G],
-    Ecu.shiftByWire: [CAR.ACCORD],  # existence correlates with transmission type
-    Ecu.hud: [CAR.ACCORD],  # existence correlates with trim level
+    Ecu.shiftByWire: [CAR.ACCORD],  # existence correlates with transmission type for ICE
+    Ecu.hud: [CAR.ACCORD, CAR.ACCORDH],  # existence correlates with trim level
   },
   extra_ecus=[
     # The only other ECU on PT bus accessible by camera on radarless Civic


### PR DESCRIPTION
Prep for https://github.com/commaai/openpilot/pull/31477. These are ECUs that not always return *when we have OBD-II* access. I labeled the reason for each as a comment.

Checked last 1 year on comma remotes: `Checked routes: 40110, dongles: 182 platforms: 2`