### PR TITLE
Subaru: group steer rate limited with GEN2

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -109,6 +109,7 @@ class SubaruPlatformConfig(PlatformConfig):
 @dataclass
 class SubaruGen2PlatformConfig(SubaruPlatformConfig):
   def init(self):
+    super().init()
     self.flags |= SubaruFlags.GLOBAL_GEN2
     if not (self.flags & SubaruFlags.LKAS_ANGLE):
       self.flags |= SubaruFlags.STEER_RATE_LIMITED

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -102,6 +102,9 @@ class SubaruPlatformConfig(PlatformConfig):
   dbc_dict: DbcDict = field(default_factory=lambda: dbc_dict('subaru_global_2017_generated', None))
 
   def init(self):
+    if self.flags & SubaruFlags.GLOBAL_GEN2:
+      self.flags |= SubaruFlags.STEER_RATE_LIMITED
+
     if self.flags & SubaruFlags.HYBRID:
       self.dbc_dict = dbc_dict('subaru_global_2020_hybrid_generated', None)
 
@@ -117,13 +120,13 @@ class CAR(Platforms):
     "SUBARU OUTBACK 6TH GEN",
     SubaruCarInfo("Subaru Outback 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b])),
     specs=CarSpecs(mass=1568, wheelbase=2.67, steerRatio=17),
-    flags=SubaruFlags.GLOBAL_GEN2 | SubaruFlags.STEER_RATE_LIMITED,
+    flags=SubaruFlags.GLOBAL_GEN2,
   )
   LEGACY = SubaruPlatformConfig(
     "SUBARU LEGACY 7TH GEN",
     SubaruCarInfo("Subaru Legacy 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b])),
     specs=OUTBACK.specs,
-    flags=SubaruFlags.GLOBAL_GEN2 | SubaruFlags.STEER_RATE_LIMITED,
+    flags=SubaruFlags.GLOBAL_GEN2,
   )
   IMPREZA = SubaruPlatformConfig(
     "SUBARU IMPREZA LIMITED 2019",

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -109,6 +109,7 @@ class SubaruPlatformConfig(PlatformConfig):
 @dataclass
 class SubaruGen2PlatformConfig(SubaruPlatformConfig):
   def init(self):
+    self.flags |= SubaruFlags.GLOBAL_GEN2
     if not (self.flags & SubaruFlags.LKAS_ANGLE):
       self.flags |= SubaruFlags.STEER_RATE_LIMITED
 

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -102,11 +102,15 @@ class SubaruPlatformConfig(PlatformConfig):
   dbc_dict: DbcDict = field(default_factory=lambda: dbc_dict('subaru_global_2017_generated', None))
 
   def init(self):
-    if self.flags & SubaruFlags.GLOBAL_GEN2:
-      self.flags |= SubaruFlags.STEER_RATE_LIMITED
-
     if self.flags & SubaruFlags.HYBRID:
       self.dbc_dict = dbc_dict('subaru_global_2020_hybrid_generated', None)
+
+
+@dataclass
+class SubaruGen2PlatformConfig(SubaruPlatformConfig):
+  def init(self):
+    if not (self.flags & SubaruFlags.LKAS_ANGLE):
+      self.flags |= SubaruFlags.STEER_RATE_LIMITED
 
 
 class CAR(Platforms):
@@ -116,17 +120,15 @@ class CAR(Platforms):
     SubaruCarInfo("Subaru Ascent 2019-21", "All"),
     specs=CarSpecs(mass=2031, wheelbase=2.89, steerRatio=13.5),
   )
-  OUTBACK = SubaruPlatformConfig(
+  OUTBACK = SubaruGen2PlatformConfig(
     "SUBARU OUTBACK 6TH GEN",
     SubaruCarInfo("Subaru Outback 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b])),
     specs=CarSpecs(mass=1568, wheelbase=2.67, steerRatio=17),
-    flags=SubaruFlags.GLOBAL_GEN2,
   )
-  LEGACY = SubaruPlatformConfig(
+  LEGACY = SubaruGen2PlatformConfig(
     "SUBARU LEGACY 7TH GEN",
     SubaruCarInfo("Subaru Legacy 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b])),
     specs=OUTBACK.specs,
-    flags=SubaruFlags.GLOBAL_GEN2,
   )
   IMPREZA = SubaruPlatformConfig(
     "SUBARU IMPREZA LIMITED 2019",
@@ -202,17 +204,17 @@ class CAR(Platforms):
     specs=FORESTER.specs,
     flags=SubaruFlags.LKAS_ANGLE,
   )
-  OUTBACK_2023 = SubaruPlatformConfig(
+  OUTBACK_2023 = SubaruGen2PlatformConfig(
     "SUBARU OUTBACK 7TH GEN",
     SubaruCarInfo("Subaru Outback 2023", "All", car_parts=CarParts.common([CarHarness.subaru_d])),
     specs=OUTBACK.specs,
-    flags=SubaruFlags.GLOBAL_GEN2 | SubaruFlags.LKAS_ANGLE,
+    flags=SubaruFlags.LKAS_ANGLE,
   )
-  ASCENT_2023 = SubaruPlatformConfig(
+  ASCENT_2023 = SubaruGen2PlatformConfig(
     "SUBARU ASCENT 2023",
     SubaruCarInfo("Subaru Ascent 2023", "All", car_parts=CarParts.common([CarHarness.subaru_d])),
     specs=ASCENT.specs,
-    flags=SubaruFlags.GLOBAL_GEN2 | SubaruFlags.LKAS_ANGLE,
+    flags=SubaruFlags.LKAS_ANGLE,
   )
 
 


### PR DESCRIPTION
Mimics the old set union/hierarchy behavior. Fixes the two angle cars not having this attribute removed in https://github.com/commaai/openpilot/pull/31584