### PR TITLE
 athena: pagination to listDataDirectory

### DIFF
--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -360,8 +360,14 @@ def scan_dir(path: str, prefix: str) -> list[str]:
   return files
 
 @dispatcher.add_method
-def listDataDirectory(prefix='') -> list[str]:
-  return scan_dir(Paths.log_root(), prefix)
+def listDataDirectory(start: str, limit: int, prefix='') -> list[str]:
+  files = sorted(scan_dir(Paths.log_root(), prefix))
+  start_index = 0
+  if start in files:
+    start_index = files.index(start) + 1
+  batch = files[start_index:start_index+limit]
+  start_index += limit
+  return batch
 
 
 @dispatcher.add_method

--- a/selfdrive/athena/tests/test_athenad.py
+++ b/selfdrive/athena/tests/test_athenad.py
@@ -142,34 +142,62 @@ class TestAthenadMethods(unittest.TestCase):
     for file in files:
       self._create_file(file)
 
-    resp = dispatcher["listDataDirectory"]()
+    batch1 = ['2021-03-29--13-32-47--0/dcamera.hevc', '2021-03-29--13-32-47--0/ecamera.hevc', '2021-03-29--13-32-47--0/fcamera.hevc',
+              '2021-03-29--13-32-47--0/qcamera.ts', '2021-03-29--13-32-47--0/qlog', '2021-03-29--13-32-47--0/rlog', '2021-03-29--13-32-47--1/dcamera.hevc',
+                '2021-03-29--13-32-47--1/ecamera.hevc', '2021-03-29--13-32-47--1/fcamera.hevc', '2021-03-29--13-32-47--1/qcamera.ts']
+    batch2 = ['2021-03-29--13-32-47--1/qlog', '2021-03-29--13-32-47--1/rlog', '2021-03-29--13-32-47--11/dcamera.hevc', '2021-03-29--13-32-47--11/ecamera.hevc',
+               '2021-03-29--13-32-47--11/fcamera.hevc', '2021-03-29--13-32-47--11/qcamera.ts', '2021-03-29--13-32-47--11/qlog',
+                 '2021-03-29--13-32-47--11/rlog', '2021-03-29--13-32-47--2/dcamera.hevc', '2021-03-29--13-32-47--2/ecamera.hevc']
+    batch3 = ['2021-03-29--13-32-47--2/fcamera.hevc', '2021-03-29--13-32-47--2/qcamera.ts', '2021-03-29--13-32-47--2/qlog', '2021-03-29--13-32-47--2/rlog',
+               '2021-03-29--13-32-47--3/dcamera.hevc', '2021-03-29--13-32-47--3/ecamera.hevc', '2021-03-29--13-32-47--3/fcamera.hevc',
+                 '2021-03-29--13-32-47--3/qcamera.ts', '2021-03-29--13-32-47--3/qlog', '2021-03-29--13-32-47--3/rlog']
+
+    resp = dispatcher["listDataDirectory"]('', 50)
     self.assertTrue(resp, 'list empty!')
     self.assertCountEqual(resp, files)
 
-    resp = dispatcher["listDataDirectory"](f'{route}--123')
+    resp = dispatcher["listDataDirectory"]('', 0)
+    self.assertCountEqual(resp, [])
+
+    resp = dispatcher["listDataDirectory"]('', 10)
+    self.assertTrue(resp, 'list empty!')
+    self.assertCountEqual(resp, batch1)
+
+    resp = dispatcher["listDataDirectory"]('2021-03-29--13-32-47--1/qcamera.ts', 10)
+    self.assertTrue(resp, 'list empty!')
+    self.assertCountEqual(resp, batch2)
+
+    resp = dispatcher["listDataDirectory"]('2021-03-29--13-32-47--2/ecamera.hevc', 10)
+    self.assertTrue(resp, 'list empty!')
+    self.assertCountEqual(resp, batch3)
+
+    resp = dispatcher["listDataDirectory"]('2021-03-29--13-32-47--3/rlog', 10)
+    self.assertCountEqual(resp, [])
+
+    resp = dispatcher["listDataDirectory"]('', 50, f'{route}--123')
     self.assertCountEqual(resp, [])
 
     prefix = f'{route}'
     expected = filter(lambda f: f.startswith(prefix), files)
-    resp = dispatcher["listDataDirectory"](prefix)
+    resp = dispatcher["listDataDirectory"]('', 50, prefix)
     self.assertTrue(resp, 'list empty!')
     self.assertCountEqual(resp, expected)
 
     prefix = f'{route}--1'
     expected = filter(lambda f: f.startswith(prefix), files)
-    resp = dispatcher["listDataDirectory"](prefix)
+    resp = dispatcher["listDataDirectory"]('', 50, prefix)
     self.assertTrue(resp, 'list empty!')
     self.assertCountEqual(resp, expected)
 
     prefix = f'{route}--1/'
     expected = filter(lambda f: f.startswith(prefix), files)
-    resp = dispatcher["listDataDirectory"](prefix)
+    resp = dispatcher["listDataDirectory"]('', 50, prefix)
     self.assertTrue(resp, 'list empty!')
     self.assertCountEqual(resp, expected)
 
     prefix = f'{route}--1/q'
     expected = filter(lambda f: f.startswith(prefix), files)
-    resp = dispatcher["listDataDirectory"](prefix)
+    resp = dispatcher["listDataDirectory"]('', 50, prefix)
     self.assertTrue(resp, 'list empty!')
     self.assertCountEqual(resp, expected)
 


### PR DESCRIPTION
Fixes #24571

**Description**

@adeebshihadeh, @jnewb1, @gregjhogan,  can you please take a look at this PR.

I added pagination to listDataDirectory method in athenad.py file, and created test method in test_athenad.py file.

Is this the implementation that was required by the issue? This returns just one batch (page) at the time, for example there is way it can yield all the batches, or save last file that passed etc. I didn't do it that way because i wanted input from you guys.

**Verification**

I run pre-commit hooks and python tests run via pytest
