### PR TITLE
VW: Cleanup, migrate center-to-front ratio to CarSpecs

### DIFF
--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -100,11 +100,8 @@ class CarInterface(CarInterfaceBase):
     ret.vEgoStopping = 0.5
     ret.longitudinalTuning.kpV = [0.1]
     ret.longitudinalTuning.kiV = [0.0]
-
-    # Per-chassis tuning values, override tuning defaults here if desired
-
     ret.autoResumeSng = ret.minEnableSpeed == -1
-    ret.centerToFront = ret.wheelbase * 0.45
+
     return ret
 
   # returns a car.CarState

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -121,6 +121,7 @@ class VolkswagenFlags(IntFlag):
 class VolkswagenMQBPlatformConfig(PlatformConfig):
   dbc_dict: DbcDict = field(default_factory=lambda: dbc_dict('vw_mqb_2010', None))
 
+
 @dataclass
 class VolkswagenPQPlatformConfig(PlatformConfig):
   dbc_dict: DbcDict = field(default_factory=lambda: dbc_dict('vw_golf_mk4', None))

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -121,7 +121,6 @@ class VolkswagenFlags(IntFlag):
 class VolkswagenMQBPlatformConfig(PlatformConfig):
   dbc_dict: DbcDict = field(default_factory=lambda: dbc_dict('vw_mqb_2010', None))
 
-
 @dataclass
 class VolkswagenPQPlatformConfig(PlatformConfig):
   dbc_dict: DbcDict = field(default_factory=lambda: dbc_dict('vw_golf_mk4', None))
@@ -132,6 +131,7 @@ class VolkswagenPQPlatformConfig(PlatformConfig):
 
 @dataclass(frozen=True, kw_only=True)
 class VolkswagenCarSpecs(CarSpecs):
+  centerToFrontRatio: float = 0.45
   steerRatio: float = 15.6
 
 


### PR DESCRIPTION
**Description**

Use the new CarSpecs field for center-to-front mass ratio, which came into being after VW moved to PlatformConfig. Garbage-collect a comment that no longer applies.

**Verification**

CI testing.