### PR TITLE
Add simple MetaDrive scenario

### DIFF
--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -171,7 +171,11 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
       steer_out = steer_op if self.simulator_state.is_engaged else steer_manual
 
       self.world.apply_controls(steer_out, throttle_out, brake_out)
+      self.world.read_state()
       self.world.read_sensors(self.simulator_state)
+
+      if self.world.exit_event.is_set():
+        self.shutdown()
 
       if self.rk.frame % self.TICKS_PER_FRAME == 0:
         self.world.tick()

--- a/tools/sim/bridge/metadrive/metadrive_common.py
+++ b/tools/sim/bridge/metadrive/metadrive_common.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from metadrive.component.sensors.rgb_camera import RGBCamera
+from panda3d.core import Texture, GraphicsOutput
+
+
+class CopyRamRGBCamera(RGBCamera):
+  """Camera which copies its content into RAM during the render process, for faster image grabbing."""
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.cpu_texture = Texture()
+    self.buffer.addRenderTexture(self.cpu_texture, GraphicsOutput.RTMCopyRam)
+
+  def get_rgb_array_cpu(self):
+    origin_img = self.cpu_texture
+    img = np.frombuffer(origin_img.getRamImage().getData(), dtype=np.uint8)
+    img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), -1))
+    img = img[:,:,:3] # RGBA to RGB
+    # img = np.swapaxes(img, 1, 0)
+    img = img[::-1] # Flip on vertical axis
+    return img
+
+
+class RGBCameraWide(CopyRamRGBCamera):
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    lens = self.get_lens()
+    lens.setFov(120)
+    lens.setNear(0.1)
+
+
+class RGBCameraRoad(CopyRamRGBCamera):
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    lens = self.get_lens()
+    lens.setFov(40)
+    lens.setNear(0.1)

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -5,7 +5,8 @@ import numpy as np
 import time
 
 from multiprocessing import Pipe, Array
-from openpilot.tools.sim.bridge.metadrive.metadrive_process import metadrive_process, metadrive_state
+from openpilot.tools.sim.bridge.metadrive.metadrive_process import (metadrive_process, metadrive_simulation_state,
+                                                                    metadrive_vehicle_state)
 from openpilot.tools.sim.lib.common import SimulatorState, World
 from openpilot.tools.sim.lib.camerad import W, H
 
@@ -21,14 +22,16 @@ class MetaDriveWorld(World):
       self.wide_road_image = np.frombuffer(self.wide_camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
 
     self.controls_send, self.controls_recv = Pipe()
-    self.state_send, self.state_recv = Pipe()
+    self.simulation_state_send, self.simulation_state_recv = Pipe()
+    self.vehicle_state_send, self.vehicle_state_recv = Pipe()
 
     self.exit_event = multiprocessing.Event()
 
     self.metadrive_process = multiprocessing.Process(name="metadrive process", target=
                               functools.partial(metadrive_process, dual_camera, config,
                                                 self.camera_array, self.wide_camera_array, self.image_lock,
-                                                self.controls_recv, self.state_send, self.exit_event))
+                                                self.controls_recv, self.simulation_state_send,
+                                                self.vehicle_state_send, self.exit_event))
 
     self.metadrive_process.start()
 
@@ -36,7 +39,7 @@ class MetaDriveWorld(World):
     print("---- Spawning Metadrive world, this might take awhile ----")
     print("----------------------------------------------------------")
 
-    self.state_recv.recv() # wait for a state message to ensure metadrive is launched
+    self.vehicle_state_recv.recv() # wait for a state message to ensure metadrive is launched
 
     self.steer_ratio = 15
     self.vc = [0.0,0.0]
@@ -58,13 +61,19 @@ class MetaDriveWorld(World):
     self.controls_send.send([*self.vc, self.should_reset])
     self.should_reset = False
 
+  def read_state(self):
+    while self.simulation_state_recv.poll(0):
+      md_state: metadrive_simulation_state = self.simulation_state_recv.recv()
+      if md_state.done:
+        self.exit_event.set()
+
   def read_sensors(self, state: SimulatorState):
-    while self.state_recv.poll(0):
-      md_state: metadrive_state = self.state_recv.recv()
-      state.velocity = md_state.velocity
-      state.bearing = md_state.bearing
-      state.steering_angle = md_state.steering_angle
-      state.gps.from_xy(md_state.position)
+    while self.vehicle_state_recv.poll(0):
+      md_vehicle: metadrive_vehicle_state = self.vehicle_state_recv.recv()
+      state.velocity = md_vehicle.velocity
+      state.bearing = md_vehicle.bearing
+      state.steering_angle = md_vehicle.steering_angle
+      state.gps.from_xy(md_vehicle.position)
       state.valid = True
 
   def read_cameras(self):

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -69,12 +69,18 @@ class World(ABC):
     self.road_image = np.zeros((H, W, 3), dtype=np.uint8)
     self.wide_road_image = np.zeros((H, W, 3), dtype=np.uint8)
 
+    self.exit_event = multiprocessing.Event()
+
   @abstractmethod
   def apply_controls(self, steer_sim, throttle_out, brake_out):
     pass
 
   @abstractmethod
   def tick(self):
+    pass
+
+  @abstractmethod
+  def read_state(self):
     pass
 
   @abstractmethod


### PR DESCRIPTION
Implements a simple MetaDrive scenario. Crashes and out of route/out of lane events are detected by MetaDrive and result in a termination of the simulation.

It is part of the work required for https://github.com/commaai/openpilot/issues/30694