### PR TITLE
Toyota: Allow DSU Re-routing

### DIFF
--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -128,7 +128,8 @@ class CarState(CarStateBase):
       conversion_factor = CV.KPH_TO_MS if is_metric else CV.MPH_TO_MS
       ret.cruiseState.speedCluster = cluster_set_speed * conversion_factor
 
-    cp_acc = cp_cam if (self.CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR) or bool(self.CP.flags & ToyotaFlags.DSU_BYPASS.value)) else cp
+    cp_acc = cp_cam if (self.CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR) or \
+             bool(self.CP.flags & ToyotaFlags.DSU_BYPASS.value)) else cp
 
     if (self.CP.flags & ToyotaFlags.DSU_BYPASS.value) or (self.CP.carFingerprint in TSS2_CAR \
        and not self.CP.flags & ToyotaFlags.DISABLE_RADAR.value):

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -128,9 +128,10 @@ class CarState(CarStateBase):
       conversion_factor = CV.KPH_TO_MS if is_metric else CV.MPH_TO_MS
       ret.cruiseState.speedCluster = cluster_set_speed * conversion_factor
 
-    cp_acc = cp_cam if self.CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR) else cp
+    cp_acc = cp_cam if (self.CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR) or bool(self.CP.flags & ToyotaFlags.DSU_BYPASS.value)) else cp
 
-    if self.CP.carFingerprint in TSS2_CAR and not self.CP.flags & ToyotaFlags.DISABLE_RADAR.value:
+    if (self.CP.flags & ToyotaFlags.DSU_BYPASS.value) or (self.CP.carFingerprint in TSS2_CAR \
+       and not self.CP.flags & ToyotaFlags.DISABLE_RADAR.value):
       if not (self.CP.flags & ToyotaFlags.SMART_DSU.value):
         self.acc_type = cp_acc.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp_acc.vl["PCS_HUD"]["FCW"])
@@ -208,7 +209,8 @@ class CarState(CarStateBase):
         ("PCS_HUD", 1),
       ]
 
-    if CP.carFingerprint not in (TSS2_CAR - RADAR_ACC_CAR) and not CP.enableDsu and not CP.flags & ToyotaFlags.DISABLE_RADAR.value:
+    if CP.carFingerprint not in (TSS2_CAR - RADAR_ACC_CAR) and not CP.enableDsu and \
+       not (CP.flags & ToyotaFlags.DISABLE_RADAR.value or CP.flags & ToyotaFlags.DSU_BYPASS.value):
       messages += [
         ("PRE_COLLISION", 33),
       ]
@@ -224,7 +226,7 @@ class CarState(CarStateBase):
         ("LKAS_HUD", 1),
       ]
 
-    if CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR):
+    if CP.flags & ToyotaFlags.DSU_BYPASS.value or CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR):
       messages += [
         ("PRE_COLLISION", 33),
         ("ACC_CONTROL", 33),

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -46,6 +46,8 @@ class ToyotaFlags(IntFlag):
   HYBRID = 1
   SMART_DSU = 2
   DISABLE_RADAR = 4
+  SECONDARY_STEER_ANGLE = 8
+  DSU_BYPASS = 512
 
   # Static flags
   TSS2 = 8


### PR DESCRIPTION
For future visitors and fork maintainers using this PR as a reference: a standalone repository has been created to document this setup and answer some questions that I've seen on discord. Link to which: https://github.com/cydia2020/toyota-dsu-reroute-harness

**Description**

In light of the recent "Harness Malfunction" issue relating to the SmartDSU, I have decided to make a harness that allows the DSU to be re-routed to the camera side of the existing harness. Thus eliminating the need for a SmartDSU, reducing hardware costs to the end-user, and, if widely adopted, allows most Toyota's longitudinal to be handled like TSS 2.0 cars.

A very crude hand drawn schematic is attached for your reference.

![schematic](https://github.com/commaai/openpilot/assets/12470297/77db1b39-afc3-4346-ba84-87f7124e9b93)

**Verification**

Drove with comma device, and verified that openpilot is controlling longitudinal; drove without comma device, and verified that the stock longitudinal is working as expected.

**Route**

Route: 7069d98b0de453c0/2024-03-05--18-53-02