### PR TITLE
[bot] Fingerprints: add missing FW versions from CAN fingerprinting cars

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -129,18 +129,30 @@ FW_VERSIONS = {
   CAR.IONIQ: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2000         ',
+      b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2100         ',
+      b'\xf1\x00DEhe SCC H-CUP      1.01 1.02 96400-G5100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2301 4AEHC107',
+      b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2501 4AEHC107',
+      b'\xf1\x00DE  MDPS C 1.00 1.09 56310G5301\x00 4DEHC109',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00AEH MFC  AT EUR LHD 1.00 1.00 95740-G2400 180222',
+      b'\xf1\x00AEH MFC  AT USA LHD 1.00 1.00 95740-G2400 180222',
+      b'\xf1\x00DEH MFC  AT USA LHD 1.00 1.00 95740-G5010 170117',
     ],
     (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x816H6D0051\x00\x00\x00\x00\x00\x00\x00\x00',
       b'\xf1\x816H6F2051\x00\x00\x00\x00\x00\x00\x00\x00',
+      b'\xf1\x816H6F6051\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.transmission, 0x7e1, None): [
+      b'\xf1\x006U3H0_C2\x00\x006U3G0051\x00\x00HDE0G16NS2\x00\x00\x00\x00',
+      b'\xf1\x006U3H0_C2\x00\x006U3J2051\x00\x00HAE0G16NS4L\xfad\x91',
+      b'\xf1\x816U3G0051\x00\x00\xf1\x006U3H0_C2\x00\x006U3G0051\x00\x00HDE0G16NS2\x00\x00\x00\x00',
       b'\xf1\x816U3H1051\x00\x00\xf1\x006U3H0_C2\x00\x006U3H1051\x00\x00HAE0G16US2\x00\x00\x00\x00',
+      b'\xf1\x816U3J2051\x00\x00\xf1\x006U3H0_C2\x00\x006U3J2051\x00\x00HAE0G16NS4L\xfad\x91',
     ],
   },
   CAR.IONIQ_PHEV_2019: {
@@ -200,9 +212,11 @@ FW_VERSIONS = {
       b'\xf1\x00AEev SCC F-CUP      1.00 1.00 99110-G7200         ',
       b'\xf1\x00AEev SCC F-CUP      1.00 1.00 99110-G7500         ',
       b'\xf1\x00AEev SCC F-CUP      1.00 1.01 99110-G7000         ',
+      b'\xf1\x00AEev SCC F-CUP      1.00 1.01 99110-G7100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7310 4APEC101',
+      b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7510 4APEC101',
       b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7560 4APEC101',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
@@ -211,6 +225,7 @@ FW_VERSIONS = {
       b'\xf1\x00AEE MFC  AT EUR LHD 1.00 1.01 95740-G2600 190819',
       b'\xf1\x00AEE MFC  AT EUR LHD 1.00 1.03 95740-G2500 190516',
       b'\xf1\x00AEE MFC  AT EUR RHD 1.00 1.01 95740-G2600 190819',
+      b'\xf1\x00AEE MFC  AT USA LHD 1.00 1.01 95740-G2600 190819',
     ],
   },
   CAR.IONIQ_EV_LTD: {
@@ -1075,6 +1090,7 @@ FW_VERSIONS = {
   CAR.KONA_EV: {
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00OS IEB \x01 212 \x11\x13 58520-K4000',
+      b'\xf1\x00OS IEB \x02 210 \x02\x14 58520-K4000',
       b'\xf1\x00OS IEB \x02 212 \x11\x13 58520-K4000',
       b'\xf1\x00OS IEB \x03 210 \x02\x14 58520-K4000',
       b'\xf1\x00OS IEB \x03 212 \x11\x13 58520-K4000',
@@ -1085,6 +1101,7 @@ FW_VERSIONS = {
       b'\xf1\x00OSE LKAS AT EUR LHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT EUR RHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT KOR LHD 1.00 1.00 95740-K4100 W40',
+      b'\xf1\x00OSE LKAS AT USA LHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT USA LHD 1.00 1.00 95740-K4300 W50',
     ],
     (Ecu.eps, 0x7d4, None): [


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 5 dongles (3 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                     | Name from VIN 🆚 CarInfo                                               | Segments                  | Bad seg tags                                                                                                                                                                                         | Good seg tags                                                                           |
|:------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|:--------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
| [0e13ee2b821302f4](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br><sub>HYUNDAI IONIQ HYBRID 2017-2019<br>KNDCE3LC1........</sub> | KIA Niro Hybrid 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19                | 138 routes, 3516 segments | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)                        | - valid torque params: 3168<br>- all lat active: 1204<br>- no input all lat active: 875 |
| [1613602610c3e789](https://useradmin.comma.ai/?onebox=1613602610c3e789)<br><sub>HYUNDAI IONIQ ELECTRIC 2020<br>000000000........</sub>    | None 🆚<br>None                                                        | 63 routes, 1363 segments  |                                                                                                                                                                                                      | - valid torque params: 722<br>- all lat active: 468<br>- no input all lat active: 327   |
| [95040c267966a52c](https://useradmin.comma.ai/?onebox=95040c267966a52c)<br><sub>HYUNDAI IONIQ HYBRID 2017-2019<br>KMHC85LC5........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2019 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 60 routes, 1615 segments  | - [segment too short (info): 4](https://useradmin.comma.ai/?onebox=95040c267966a52c%7C2024-02-19--06-48-42)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=95040c267966a52c) | - valid torque params: 1615<br>- all lat active: 733<br>- no input all lat active: 490  |
| [c9508b688d2009f6](https://useradmin.comma.ai/?onebox=c9508b688d2009f6)<br><sub>HYUNDAI KONA ELECTRIC 2019<br>000000000........</sub>     | None 🆚<br>None                                                        | 130 routes, 2884 segments |                                                                                                                                                                                                      | - valid torque params: 2499<br>- all lat active: 307<br>- no input all lat active: 276  |
| [1d123e7a239cca62](https://useradmin.comma.ai/?onebox=1d123e7a239cca62)<br><sub>HYUNDAI KONA ELECTRIC 2019<br>000000000........</sub>     | None 🆚<br>None                                                        | 78 routes, 2049 segments  |                                                                                                                                                                                                      | - valid torque params: 1950<br>- all lat active: 329<br>- no input all lat active: 183  |

Dongles to re-run category: `1d123e7a239cca62 1613602610c3e789 c9508b688d2009f6 95040c267966a52c 0e13ee2b821302f4`
</details>

## ⏳️ 4 dongles (4 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                             | Name from VIN 🆚 CarInfo                               | Segments                 | Bad seg tags   | Good seg tags                                                                     |
|:----------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------|:-------------------------|:---------------|:----------------------------------------------------------------------------------|
| [7ae1c131629d96e5](https://useradmin.comma.ai/?onebox=7ae1c131629d96e5)<br><sub>HYUNDAI SONATA 2019<br>5NPE34AF9........</sub>    | HYUNDAI Sonata 2019 🆚<br>Hyundai Sonata 2018-19       | 23 routes, 430 segments  |                | - valid torque params: 430<br>- all lat active: 9<br>- no input all lat active: 2 |
| [3c0cd95403384ee2](https://useradmin.comma.ai/?onebox=3c0cd95403384ee2)<br><sub>CHRYSLER PACIFICA 2018<br>2C4RC1GG2........</sub> | CHRYSLER Pacifica 2017 🆚<br>Chrysler Pacifica 2017-18 | 1 routes, 4 segments     |                | - all lat active: 0                                                               |
| [2eefb4d20c7c1f62](https://useradmin.comma.ai/?onebox=2eefb4d20c7c1f62)<br><sub>GENESIS G80 2017<br>KMTFN4JE4........</sub>       | GENESIS G80 2019 🆚<br>Genesis G80 2018-19             | 76 routes, 1053 segments |                | - all lat active: 1<br>- no input all lat active: 1                               |
| [70d27b3a88b6d4b5](https://useradmin.comma.ai/?onebox=70d27b3a88b6d4b5)<br><sub>CHRYSLER PACIFICA 2020<br>2C4RC1BG1........</sub> | CHRYSLER Pacifica 2021 🆚<br>Chrysler Pacifica 2021-23 | 8 routes, 132 segments   |                | - valid torque params: 132<br>- all lat active: 5<br>- no input all lat active: 1 |

Dongles to re-run category: `3c0cd95403384ee2 7ae1c131629d96e5 70d27b3a88b6d4b5 2eefb4d20c7c1f62`
</details>

## ⚠️ 7 dongles (5 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                  | Name from VIN 🆚 CarInfo                                                    | Segments                 | Bad seg tags                                                                                                                                                                                                                                                                                                          | Good seg tags                                                                         |
|:---------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------|
| [8d507ae7a75ef190](https://useradmin.comma.ai/?onebox=8d507ae7a75ef190)<br><sub>CHRYSLER PACIFICA 2018<br>2C4RC1EG7........</sub>      | CHRYSLER Pacifica 2017 🆚<br>Chrysler Pacifica 2017-18                      | 14 routes, 218 segments  | - [car faulted: 7](https://useradmin.comma.ai/?onebox=8d507ae7a75ef190%7C2024-02-24--17-05-58)                                                                                                                                                                                                                        | - valid torque params: 178<br>- all lat active: 49<br>- no input all lat active: 34   |
| [d23a555519923793](https://useradmin.comma.ai/?onebox=d23a555519923793)<br><sub>HYUNDAI PALISADE 2020<br>000000000........</sub>       | None 🆚<br>None                                                             | 5 routes, 57 segments    | - [missing ECU FW: 57](https://useradmin.comma.ai/?onebox=d23a555519923793%7C2024-02-15--12-47-38)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d23a555519923793%7C2024-02-15--12-47-38)                                                                                                           | - all lat active: 10<br>- no input all lat active: 4                                  |
| [02da77066f2ae12f](https://useradmin.comma.ai/?onebox=02da77066f2ae12f)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFBT0........</sub> | JEEP Grand Cherokee 2018 🆚<br>Jeep Grand Cherokee 2016-18                  | 21 routes, 315 segments  | - [car faulted: 4](https://useradmin.comma.ai/?onebox=02da77066f2ae12f%7C2024-02-15--15-15-37)                                                                                                                                                                                                                        | - valid torque params: 255<br>- all lat active: 130<br>- no input all lat active: 76  |
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFCG8........</sub> | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18                  | 20 routes, 280 segments  | - [car faulted: 10](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a%7C2024-02-11--11-12-52)                                                                                                                                                                                                                       |                                                                                       |
| [b87cc0e9df910375](https://useradmin.comma.ai/?onebox=b87cc0e9df910375)<br><sub>NISSAN ALTIMA 2020<br>1N4BL4FW1........</sub>          | NISSAN Altima 2019 🆚<br>Nissan Altima 2019-20                              | 34 routes, 1644 segments | - [missing ECU FW: 1644](https://useradmin.comma.ai/?onebox=b87cc0e9df910375%7C2024-02-28--21-28-57)<br>- [spotty FW: 1584](https://useradmin.comma.ai/?onebox=b87cc0e9df910375%7C2024-03-01--11-40-05)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=b87cc0e9df910375%7C2024-02-28--21-28-57)      | - all lat active: 1042<br>- no input all lat active: 571                              |
| [0af43ba62cc3ffc4](https://useradmin.comma.ai/?onebox=0af43ba62cc3ffc4)<br><sub>HYUNDAI PALISADE 2020<br>KM8R74HE5........</sub>       | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                        | 1 routes, 1 segments     | - [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=0af43ba62cc3ffc4%7C2024-02-23--15-31-31)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0af43ba62cc3ffc4%7C2024-02-23--15-31-31)                                                                                                            |                                                                                       |
| [6b111e8e45cc2d07](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07)<br><sub>KIA SORENTO GT LINE 2018<br>KNAPH81BD........</sub>    | KIA  1988 🆚<br>Kia Sorento 2019<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 42 routes, 1711 segments | - [missing ECU FW: 1711](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07%7C2024-02-09--14-51-54)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07%7C2024-02-10--16-55-12)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07%7C2024-02-09--14-51-54) | - valid torque params: 1709<br>- all lat active: 288<br>- no input all lat active: 89 |

Dongles to re-run category: `6b111e8e45cc2d07 8d507ae7a75ef190 0af43ba62cc3ffc4 c88f65eeaee4003a b87cc0e9df910375 d23a555519923793 02da77066f2ae12f`
</details>