### PR TITLE
Only print keyboard help on poll start and unknown command

### DIFF
--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -13,7 +13,6 @@ from openpilot.selfdrive.car.honda.values import CruiseButtons
 from openpilot.tools.sim.lib.common import SimulatorState, World
 from openpilot.tools.sim.lib.simulated_car import SimulatedCar
 from openpilot.tools.sim.lib.simulated_sensors import SimulatedSensors
-from openpilot.tools.sim.lib.keyboard_ctrl import KEYBOARD_HELP
 
 
 def rk_loop(function, hz, exit_event: threading.Event):
@@ -74,9 +73,6 @@ class SimulatorBridge(ABC):
   def print_status(self):
     print(
     f"""
-Keyboard Commands:
-{KEYBOARD_HELP}
-
 State:
 Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_engaged}
     """)

--- a/tools/sim/lib/keyboard_ctrl.py
+++ b/tools/sim/lib/keyboard_ctrl.py
@@ -49,7 +49,12 @@ def getch() -> str:
     termios.tcsetattr(STDIN_FD, termios.TCSADRAIN, old_settings)
   return ch
 
+def print_keyboard_help():
+  print(f"Keyboard Commands:\n{KEYBOARD_HELP}")
+
 def keyboard_poll_thread(q: 'Queue[str]'):
+  print_keyboard_help()
+
   while True:
     c = getch()
     if c == '1':
@@ -77,6 +82,8 @@ def keyboard_poll_thread(q: 'Queue[str]'):
     elif c == 'q':
       q.put("quit")
       break
+    else:
+      print_keyboard_help()
 
 def test(q: 'Queue[str]') -> NoReturn:
   while True:


### PR DESCRIPTION
Avoids spamming the bridge output every 25 frames