### PR TITLE
RadarInterfaceBase: remove no_radar_sleep field

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -334,7 +334,6 @@ class RadarInterfaceBase(ABC):
     self.delay = 0
     self.radar_ts = CP.radarTimeStep
     self.frame = 0
-    self.no_radar_sleep = 'NO_RADAR_SLEEP' in os.environ
 
   def update(self, can_strings):
     self.frame += 1


### PR DESCRIPTION
It was removed with https://github.com/commaai/openpilot/commit/6f905ed979cb8e217c182c653528df3a6094015b