### PR TITLE
Reapply "Hyundai Azera: allow fingerprinting without comma power (#31717)"

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -650,15 +650,9 @@ def match_fw_to_car_fuzzy(live_fw_versions, offline_fw_versions) -> set[str]:
       expected_dates = {date for _, date in codes if date is not None}
 
       # Found platform codes & dates
-      found_versions = live_fw_versions.get(addr, set())
-      codes = get_platform_codes(found_versions)
+      codes = get_platform_codes(live_fw_versions.get(addr, set()))
       found_platform_codes = {code for code, _ in codes}
       found_dates = {date for _, date in codes if date is not None}
-
-      # Some models are missing ECUs
-      if not len(found_versions) and candidate in FW_QUERY_CONFIG.non_essential_ecus.get(ecu[0], []):
-        valid_found_ecus.add(addr)
-        continue
 
       # Check platform code + part number matches for any found versions
       if not any(found_platform_code in expected_platform_codes for found_platform_code in found_platform_codes):
@@ -810,7 +804,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
   # We lose these ECUs without the comma power on these cars.
   # Note that we still attempt to match with them when they are present
   non_essential_ecus={
-    Ecu.eps: [CAR.AZERA_6TH_GEN, CAR.AZERA_HEV_6TH_GEN],  # FIXME: EPS responds on a few cars from PT
     Ecu.transmission: [CAR.AZERA_6TH_GEN, CAR.AZERA_HEV_6TH_GEN],
     Ecu.engine: [CAR.AZERA_6TH_GEN, CAR.AZERA_HEV_6TH_GEN],
   },

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -731,7 +731,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac, Ecu.eps],
       bus=0,
       auxiliary=True,
     ),


### PR DESCRIPTION
I just realized why we might only see EPS on some cars, and it's probably from https://github.com/commaai/openpilot/pull/31334