### PR TITLE
[bot] Fingerprints: add missing FW versions from CAN fingerprinting cars

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -96,17 +96,22 @@ FW_VERSIONS = {
   CAR.IONIQ: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2000         ',
+      b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2301 4AEHC107',
+      b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2501 4AEHC107',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00AEH MFC  AT EUR LHD 1.00 1.00 95740-G2400 180222',
+      b'\xf1\x00AEH MFC  AT USA LHD 1.00 1.00 95740-G2400 180222',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xf1\x816H6F2051\x00\x00\x00\x00\x00\x00\x00\x00',
+      b'\xf1\x816H6F6051\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.transmission, 0x7e1, None): [
+      b'\xf1\x006U3H0_C2\x00\x006U3J2051\x00\x00HAE0G16NS4L\xfad\x91',
       b'\xf1\x816U3H1051\x00\x00\xf1\x006U3H0_C2\x00\x006U3H1051\x00\x00HAE0G16US2\x00\x00\x00\x00',
     ],
   },
@@ -167,9 +172,11 @@ FW_VERSIONS = {
       b'\xf1\x00AEev SCC F-CUP      1.00 1.00 99110-G7200         ',
       b'\xf1\x00AEev SCC F-CUP      1.00 1.00 99110-G7500         ',
       b'\xf1\x00AEev SCC F-CUP      1.00 1.01 99110-G7000         ',
+      b'\xf1\x00AEev SCC F-CUP      1.00 1.01 99110-G7100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7310 4APEC101',
+      b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7510 4APEC101',
       b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7560 4APEC101',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
@@ -178,6 +185,7 @@ FW_VERSIONS = {
       b'\xf1\x00AEE MFC  AT EUR LHD 1.00 1.01 95740-G2600 190819',
       b'\xf1\x00AEE MFC  AT EUR LHD 1.00 1.03 95740-G2500 190516',
       b'\xf1\x00AEE MFC  AT EUR RHD 1.00 1.01 95740-G2600 190819',
+      b'\xf1\x00AEE MFC  AT USA LHD 1.00 1.01 95740-G2600 190819',
     ],
   },
   CAR.IONIQ_EV_LTD: {
@@ -1066,6 +1074,7 @@ FW_VERSIONS = {
   CAR.KONA_EV: {
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00OS IEB \x01 212 \x11\x13 58520-K4000',
+      b'\xf1\x00OS IEB \x02 210 \x02\x14 58520-K4000',
       b'\xf1\x00OS IEB \x02 212 \x11\x13 58520-K4000',
       b'\xf1\x00OS IEB \x03 210 \x02\x14 58520-K4000',
       b'\xf1\x00OS IEB \x03 212 \x11\x13 58520-K4000',
@@ -1076,6 +1085,7 @@ FW_VERSIONS = {
       b'\xf1\x00OSE LKAS AT EUR LHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT EUR RHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT KOR LHD 1.00 1.00 95740-K4100 W40',
+      b'\xf1\x00OSE LKAS AT USA LHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT USA LHD 1.00 1.00 95740-K4300 W50',
     ],
     (Ecu.eps, 0x7d4, None): [


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 4 dongles (3 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                     | Name from VIN 🆚 CarDocs                                               | Segments                                     | Bad seg tags                                                                                                                                                                                         | Good seg tags                                                                          |
|:------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [c9508b688d2009f6](https://useradmin.comma.ai/?onebox=c9508b688d2009f6)<br><sub>HYUNDAI KONA ELECTRIC 2019<br>000000000........</sub>     | None 🆚<br>None                                                        | 120 routes,<br>2796 segments<br>(46.6 hours) |                                                                                                                                                                                                      | - valid torque params: 2201<br>- all lat active: 450<br>- no input all lat active: 402 |
| [1613602610c3e789](https://useradmin.comma.ai/?onebox=1613602610c3e789)<br><sub>HYUNDAI IONIQ ELECTRIC 2020<br>000000000........</sub>    | None 🆚<br>None                                                        | 118 routes,<br>2737 segments<br>(45.6 hours) |                                                                                                                                                                                                      | - valid torque params: 2096<br>- all lat active: 979<br>- no input all lat active: 699 |
| [95040c267966a52c](https://useradmin.comma.ai/?onebox=95040c267966a52c)<br><sub>HYUNDAI IONIQ HYBRID 2017-2019<br>KMHC85LC5........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2019 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 65 routes,<br>1754 segments<br>(29.2 hours)  | - [segment too short (info): 4](https://useradmin.comma.ai/?onebox=95040c267966a52c%7C2024-02-19--06-48-42)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=95040c267966a52c) | - valid torque params: 1754<br>- all lat active: 789<br>- no input all lat active: 532 |
| [1d123e7a239cca62](https://useradmin.comma.ai/?onebox=1d123e7a239cca62)<br><sub>HYUNDAI KONA ELECTRIC 2019<br>000000000........</sub>     | None 🆚<br>None                                                        | 97 routes,<br>2395 segments<br>(39.9 hours)  |                                                                                                                                                                                                      | - valid torque params: 2326<br>- all lat active: 410<br>- no input all lat active: 247 |

Dongles to re-run category: `c9508b688d2009f6 1613602610c3e789 95040c267966a52c 1d123e7a239cca62`
</details>

## ⏳️ 4 dongles (3 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                     | Name from VIN 🆚 CarDocs                                               | Segments                                  | Bad seg tags                                                                          | Good seg tags                                                                       |
|:------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|:------------------------------------------|:--------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
| [61cb482c0e565685](https://useradmin.comma.ai/?onebox=61cb482c0e565685)<br><sub>HYUNDAI IONIQ HYBRID 2017-2019<br>KMHC85LC4........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2019 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 29 routes,<br>456 segments<br>(7.6 hours) | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=61cb482c0e565685) | - valid torque params: 373<br>- all lat active: 10<br>- no input all lat active: 7  |
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFCG8........</sub>    | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18             | 6 routes,<br>78 segments<br>(1.3 hours)   |                                                                                       | - all lat active: 0                                                                 |
| [70d27b3a88b6d4b5](https://useradmin.comma.ai/?onebox=70d27b3a88b6d4b5)<br><sub>CHRYSLER PACIFICA 2020<br>2C4RC1BG1........</sub>         | CHRYSLER Pacifica 2021 🆚<br>Chrysler Pacifica 2021-23                 | 6 routes,<br>113 segments<br>(1.9 hours)  |                                                                                       | - valid torque params: 113<br>- all lat active: 5<br>- no input all lat active: 1   |
| [02da77066f2ae12f](https://useradmin.comma.ai/?onebox=02da77066f2ae12f)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFBT0........</sub>    | JEEP Grand Cherokee 2018 🆚<br>Jeep Grand Cherokee 2016-18             | 3 routes,<br>115 segments<br>(1.9 hours)  |                                                                                       | - all lat active: 71<br>- valid torque params: 115<br>- no input all lat active: 39 |

Dongles to re-run category: `61cb482c0e565685 70d27b3a88b6d4b5 c88f65eeaee4003a 02da77066f2ae12f`
</details>

## ⚠️ 5 dongles (5 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                     | Name from VIN 🆚 CarDocs                                | Segments                                     | Bad seg tags                                                                                                                                                                                                                                                                                                          | Good seg tags                                                                           |
|:------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:---------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
| [8d507ae7a75ef190](https://useradmin.comma.ai/?onebox=8d507ae7a75ef190)<br><sub>CHRYSLER PACIFICA 2018<br>2C4RC1EG7........</sub>         | CHRYSLER Pacifica 2017 🆚<br>Chrysler Pacifica 2017-18  | 14 routes,<br>218 segments<br>(3.6 hours)    | - [car faulted: 7](https://useradmin.comma.ai/?onebox=8d507ae7a75ef190%7C2024-02-24--17-05-58)                                                                                                                                                                                                                        | - all lat active: 49<br>- valid torque params: 178<br>- no input all lat active: 34     |
| [6b111e8e45cc2d07](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07)<br><sub>KIA SORENTO GT LINE 2018<br>KNAPH81BD........</sub>       | KIA  1988 🆚<br>Kia Sorento 2019                        | 76 routes,<br>2259 segments<br>(37.6 hours)  | - [missing ECU FW: 2259](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07%7C2024-03-16--10-39-14)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07%7C2024-02-23--05-41-49)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07%7C2024-03-16--10-39-14) | - valid torque params: 2258<br>- all lat active: 223<br>- no input all lat active: 77   |
| [47ffae6b1d1580b2](https://useradmin.comma.ai/?onebox=47ffae6b1d1580b2)<br><sub>HYUNDAI IONIQ ELECTRIC 2020<br>000000000........</sub>    | None 🆚<br>None                                         | 3 routes,<br>14 segments<br>(0.2 hours)      | - [high lateral accel factor: 9](https://useradmin.comma.ai/?onebox=47ffae6b1d1580b2%7C2024-03-06--13-58-20)                                                                                                                                                                                                          | - all lat active: 2<br>- no input all lat active: 2<br>- valid torque params: 3         |
| [0e13ee2b821302f4](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br><sub>HYUNDAI IONIQ HYBRID 2017-2019<br>KNDCE3LC1........</sub> | KIA Niro Hybrid 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 167 routes,<br>4005 segments<br>(66.8 hours) | - [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-02-21--08-27-03)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)                                | - valid torque params: 3585<br>- all lat active: 1414<br>- no input all lat active: 989 |
| [b87cc0e9df910375](https://useradmin.comma.ai/?onebox=b87cc0e9df910375)<br><sub>NISSAN ALTIMA 2020<br>1N4BL4FW1........</sub>             | NISSAN Altima 2019 🆚<br>Nissan Altima 2019-20          | 91 routes,<br>3321 segments<br>(55.4 hours)  | - [missing ECU FW: 3321](https://useradmin.comma.ai/?onebox=b87cc0e9df910375%7C2024-02-28--21-18-53)<br>- [spotty FW: 3261](https://useradmin.comma.ai/?onebox=b87cc0e9df910375%7C2024-03-12--13-13-48)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=b87cc0e9df910375%7C2024-02-28--21-18-53)      | - all lat active: 1490<br>- no input all lat active: 785                                |

Dongles to re-run category: `0e13ee2b821302f4 6b111e8e45cc2d07 b87cc0e9df910375 8d507ae7a75ef190 47ffae6b1d1580b2`
</details>