### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/subaru/fingerprints.py
+++ b/selfdrive/car/subaru/fingerprints.py
@@ -26,6 +26,7 @@ FW_VERSIONS = {
       b'\xd1,\xa0q\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
+      b'\x00>\xf0\x00\x00',
       b'\x00\xfe\xf7\x00\x00',
       b'\x01\xfe\xf7\x00\x00',
       b'\x01\xfe\xf9\x00\x00',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 30.0 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarInfo                       | Segments                 | Bad seg tags   | Good seg tags                                                                          |
|:--------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|:-------------------------|:---------------|:---------------------------------------------------------------------------------------|
| [ba36806befceca9d](https://useradmin.comma.ai/?onebox=ba36806befceca9d)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD8........</sub> | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21 | 87 routes, 1652 segments |                | - all lat active: 587<br>- valid torque params: 1651<br>- no input all lat active: 295 |

Dongles to re-run category: `ba36806befceca9d`
</details>

## ⏳️ 4 dongles (2 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarInfo                                   | Segments               | Bad seg tags                                                                          | Good seg tags                                                                    |
|:--------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|:-----------------------|:--------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------|
| [05b1a2556c5bc638](https://useradmin.comma.ai/?onebox=05b1a2556c5bc638)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD5........</sub> | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21             | 4 routes, 139 segments |                                                                                       | - all lat active: 15<br>- no input all lat active: 1                             |
| [5067e70bf087ef1c](https://useradmin.comma.ai/?onebox=5067e70bf087ef1c)<br><sub>SUBARU IMPREZA SPORT 2020<br>4S3GTAM65........</sub>  | SUBARU Impreza Hatchback 2020 🆚<br>Subaru Impreza 2020-22 | 4 routes, 8 segments   | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=5067e70bf087ef1c) | - all lat active: 0                                                              |
| [b0af8f0d66998715](https://useradmin.comma.ai/?onebox=b0af8f0d66998715)<br><sub>SUBARU IMPREZA SPORT 2020<br>JF2GTHNC3........</sub>  | SUBARU Crosstrek 2023 🆚<br>Subaru Crosstrek 2020-23       | 2 routes, 35 segments  |                                                                                       | - all lat active: 6<br>- no input all lat active: 5<br>- valid torque params: 30 |
| [a28b99df3908f6d8](https://useradmin.comma.ai/?onebox=a28b99df3908f6d8)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMAMD3........</sub> | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21             | 2 routes, 29 segments  |                                                                                       | - all lat active: 9<br>- no input all lat active: 4                              |

Dongles to re-run category: `05b1a2556c5bc638 b0af8f0d66998715 a28b99df3908f6d8 5067e70bf087ef1c`
</details>

## ⚠️ 21 dongles (5 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                  | Name from VIN 🆚 CarInfo                                   | Segments                  | Bad seg tags                                                                                                                                                                                                   | Good seg tags                                                                          |
|:---------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|:--------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [52e65eec8d24616b](https://useradmin.comma.ai/?onebox=52e65eec8d24616b)<br><sub>SUBARU IMPREZA SPORT 2020<br>JF2GTAPC1........</sub>   | SUBARU Crosstrek 2020 🆚<br>Subaru Crosstrek 2020-23       | 160 routes, 1147 segments | - [spotty FW: 192](https://useradmin.comma.ai/?onebox=52e65eec8d24616b%7C2024-03-04--15-00-21)<br>- [segment too short (info): 2](https://useradmin.comma.ai/?onebox=52e65eec8d24616b%7C2024-02-24--16-04-13)  | - valid torque params: 1146<br>- all lat active: 54<br>- no input all lat active: 26   |
| [ca5d1d3f94ea106b](https://useradmin.comma.ai/?onebox=ca5d1d3f94ea106b)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD6........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21             | 137 routes, 3280 segments | - [spotty FW: 288](https://useradmin.comma.ai/?onebox=ca5d1d3f94ea106b%7C2024-03-05--17-22-43)                                                                                                                 | - valid torque params: 3280<br>- all lat active: 110<br>- no input all lat active: 75  |
| [f920bbfae4f3886f](https://useradmin.comma.ai/?onebox=f920bbfae4f3886f)<br><sub>SUBARU IMPREZA SPORT 2020<br>JF2GTANC8........</sub>   | SUBARU Crosstrek 2020 🆚<br>Subaru Crosstrek 2020-23       | 149 routes, 1895 segments | - [spotty FW: 258](https://useradmin.comma.ai/?onebox=f920bbfae4f3886f%7C2024-03-02--12-14-26)                                                                                                                 | - valid torque params: 1895<br>- all lat active: 33<br>- no input all lat active: 29   |
| [ad6511c266bbf3ad](https://useradmin.comma.ai/?onebox=ad6511c266bbf3ad)<br><sub>SUBARU IMPREZA LIMITED 2019<br>JF2GTANC7........</sub> | SUBARU Crosstrek 2019 🆚<br>Subaru Crosstrek 2018-19       | 98 routes, 2407 segments  | - [spotty FW: 117](https://useradmin.comma.ai/?onebox=ad6511c266bbf3ad%7C2024-03-01--13-35-54)<br>- [CAN invalid: 1](https://useradmin.comma.ai/?onebox=ad6511c266bbf3ad%7C2024-02-09--06-10-39)               | - all lat active: 666<br>- valid torque params: 2406<br>- no input all lat active: 266 |
| [083fdc4bd2407595](https://useradmin.comma.ai/?onebox=083fdc4bd2407595)<br><sub>SUBARU FORESTER 2019<br>JF2SKAJC2........</sub>        | SUBARU Forester 2021 🆚<br>Subaru Forester 2019-21         | 92 routes, 1312 segments  | - [spotty FW: 48](https://useradmin.comma.ai/?onebox=083fdc4bd2407595%7C2024-03-04--17-14-18)<br>- [CAN invalid: 1](https://useradmin.comma.ai/?onebox=083fdc4bd2407595%7C2024-03-02--16-38-29)                | - valid torque params: 1311<br>- all lat active: 410<br>- no input all lat active: 230 |
| [a7739f091adab414](https://useradmin.comma.ai/?onebox=a7739f091adab414)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD9........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21             | 120 routes, 1494 segments | - [spotty FW: 184](https://useradmin.comma.ai/?onebox=a7739f091adab414%7C2024-02-16--11-08-15)                                                                                                                 | - valid torque params: 1494<br>- all lat active: 238<br>- no input all lat active: 32  |
| [0ad7facc77922c3e](https://useradmin.comma.ai/?onebox=0ad7facc77922c3e)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMACD0........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21             | 21 routes, 313 segments   | - [spotty FW: 2](https://useradmin.comma.ai/?onebox=0ad7facc77922c3e%7C2024-02-16--22-29-57)                                                                                                                   | - all lat active: 79<br>- no input all lat active: 27                                  |
| [7d4aed44f10c933f](https://useradmin.comma.ai/?onebox=7d4aed44f10c933f)<br><sub>SUBARU IMPREZA LIMITED 2019<br>4S3GTAD62........</sub> | SUBARU Impreza Hatchback 2018 🆚<br>Subaru Impreza 2017-19 | 99 routes, 1820 segments  | - [spotty FW: 1439](https://useradmin.comma.ai/?onebox=7d4aed44f10c933f%7C2024-02-16--20-34-33)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=7d4aed44f10c933f)                       | - valid torque params: 1820<br>- all lat active: 371<br>- no input all lat active: 45  |
| [ace607260543d257](https://useradmin.comma.ai/?onebox=ace607260543d257)<br><sub>SUBARU FORESTER 2019<br>JF2SKAPC0........</sub>        | SUBARU Forester 2019 🆚<br>Subaru Forester 2019-21         | 96 routes, 1445 segments  | - [spotty FW: 109](https://useradmin.comma.ai/?onebox=ace607260543d257%7C2024-03-04--12-52-30)                                                                                                                 | - valid torque params: 1445<br>- all lat active: 549<br>- no input all lat active: 310 |
| [549b4287ecf880e1](https://useradmin.comma.ai/?onebox=549b4287ecf880e1)<br><sub>SUBARU OUTBACK 6TH GEN<br>4S4BTACC9........</sub>      | SUBARU Outback 2020 🆚<br>Subaru Outback 2020-22           | 97 routes, 1952 segments  | - [spotty FW: 378](https://useradmin.comma.ai/?onebox=549b4287ecf880e1%7C2024-03-03--09-39-53)<br>- [car faulted: 2](https://useradmin.comma.ai/?onebox=549b4287ecf880e1%7C2024-02-08--09-09-18)               | - valid torque params: 1952<br>- all lat active: 439<br>- no input all lat active: 143 |
| [e12c50f77a67608c](https://useradmin.comma.ai/?onebox=e12c50f77a67608c)<br><sub>SUBARU FORESTER 2019<br>JF2SKAJC0........</sub>        | SUBARU Forester 2020 🆚<br>Subaru Forester 2019-21         | 132 routes, 2872 segments | - [spotty FW: 975](https://useradmin.comma.ai/?onebox=e12c50f77a67608c%7C2024-03-02--14-47-11)                                                                                                                 | - valid torque params: 2871<br>- all lat active: 100<br>- no input all lat active: 52  |
| [cafb4800ec0a7892](https://useradmin.comma.ai/?onebox=cafb4800ec0a7892)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMAPD1........</sub>  | SUBARU Ascent 2020 🆚<br>Subaru Ascent 2019-21             | 220 routes, 1682 segments | - [spotty FW: 241](https://useradmin.comma.ai/?onebox=cafb4800ec0a7892%7C2024-03-05--09-36-13)<br>- [car faulted: 4](https://useradmin.comma.ai/?onebox=cafb4800ec0a7892%7C2024-02-18--00-16-18)               | - valid torque params: 1682                                                            |
| [aca6c37cdceab59a](https://useradmin.comma.ai/?onebox=aca6c37cdceab59a)<br><sub>SUBARU FORESTER 2019<br>JF2SKACC0........</sub>        | SUBARU Forester 2019 🆚<br>Subaru Forester 2019-21         | 49 routes, 1101 segments  | - [spotty FW: 66](https://useradmin.comma.ai/?onebox=aca6c37cdceab59a%7C2024-02-09--09-48-16)                                                                                                                  | - valid torque params: 1101<br>- all lat active: 595<br>- no input all lat active: 509 |
| [86921fe3be40b1e9](https://useradmin.comma.ai/?onebox=86921fe3be40b1e9)<br><sub>SUBARU IMPREZA LIMITED 2019<br>JF2GTADC7........</sub> | SUBARU Crosstrek 2018 🆚<br>Subaru Crosstrek 2018-19       | 73 routes, 1359 segments  | - [spotty FW: 312](https://useradmin.comma.ai/?onebox=86921fe3be40b1e9%7C2024-03-05--12-38-40)                                                                                                                 | - valid torque params: 1358<br>- all lat active: 246<br>- no input all lat active: 159 |
| [53d5a1841c64512d](https://useradmin.comma.ai/?onebox=53d5a1841c64512d)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD0........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21             | 18 routes, 161 segments   | - [spotty FW: 18](https://useradmin.comma.ai/?onebox=53d5a1841c64512d%7C2024-02-23--03-38-22)                                                                                                                  | - all lat active: 25<br>- no input all lat active: 12                                  |
| [21ee3cec8babd95a](https://useradmin.comma.ai/?onebox=21ee3cec8babd95a)<br><sub>SUBARU OUTBACK 6TH GEN<br>4S4BTGPD2........</sub>      | SUBARU Outback 2021 🆚<br>Subaru Outback 2020-22           | 91 routes, 1503 segments  | - [spotty FW: 155](https://useradmin.comma.ai/?onebox=21ee3cec8babd95a%7C2024-02-10--15-04-52)<br>- [segment too short (info): 20](https://useradmin.comma.ai/?onebox=21ee3cec8babd95a%7C2024-02-14--19-31-38) | - valid torque params: 1502<br>- all lat active: 21<br>- no input all lat active: 13   |
| [041e083d86170f22](https://useradmin.comma.ai/?onebox=041e083d86170f22)<br><sub>SUBARU FORESTER 2019<br>JF2SKAJC8........</sub>        | SUBARU Forester 2020 🆚<br>Subaru Forester 2019-21         | 74 routes, 2102 segments  | - [spotty FW: 224](https://useradmin.comma.ai/?onebox=041e083d86170f22%7C2024-03-03--20-54-40)                                                                                                                 | - valid torque params: 2102<br>- all lat active: 32<br>- no input all lat active: 21   |
| [9f9dda362178312b](https://useradmin.comma.ai/?onebox=9f9dda362178312b)<br><sub>SUBARU IMPREZA LIMITED 2019<br>000000000........</sub> | None 🆚<br>None                                            | 25 routes, 906 segments   | - [spotty FW: 27](https://useradmin.comma.ai/?onebox=9f9dda362178312b%7C2024-02-09--16-19-26)                                                                                                                  | - valid torque params: 828<br>- all lat active: 324<br>- no input all lat active: 139  |
| [1e5a973a279c1a95](https://useradmin.comma.ai/?onebox=1e5a973a279c1a95)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMAPD8........</sub>  | SUBARU Ascent 2021 🆚<br>Subaru Ascent 2019-21             | 163 routes, 3037 segments | - [spotty FW: 207](https://useradmin.comma.ai/?onebox=1e5a973a279c1a95%7C2024-03-05--07-58-17)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=1e5a973a279c1a95%7C2024-02-25--12-12-47)               | - valid torque params: 3036<br>- all lat active: 409<br>- no input all lat active: 246 |
| [162a8aff24ff56bc](https://useradmin.comma.ai/?onebox=162a8aff24ff56bc)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD1........</sub>  | SUBARU Ascent 2021 🆚<br>Subaru Ascent 2019-21             | 149 routes, 2402 segments | - [spotty FW: 2292](https://useradmin.comma.ai/?onebox=162a8aff24ff56bc%7C2024-02-13--07-25-45)                                                                                                                | - valid torque params: 1357<br>- all lat active: 517<br>- no input all lat active: 86  |
| [7a4ef9e9f44480ee](https://useradmin.comma.ai/?onebox=7a4ef9e9f44480ee)<br><sub>SUBARU IMPREZA LIMITED 2019<br>JF2GTAMC7........</sub> | SUBARU Crosstrek 2019 🆚<br>Subaru Crosstrek 2018-19       | 20 routes, 184 segments   | - [spotty FW: 46](https://useradmin.comma.ai/?onebox=7a4ef9e9f44480ee%7C2024-03-03--10-12-48)                                                                                                                  | - valid torque params: 57                                                              |

Dongles to re-run category: `52e65eec8d24616b ad6511c266bbf3ad 083fdc4bd2407595 0ad7facc77922c3e f920bbfae4f3886f a7739f091adab414 ca5d1d3f94ea106b 7d4aed44f10c933f ace607260543d257 549b4287ecf880e1 e12c50f77a67608c cafb4800ec0a7892 aca6c37cdceab59a 86921fe3be40b1e9 53d5a1841c64512d 21ee3cec8babd95a 041e083d86170f22 9f9dda362178312b 1e5a973a279c1a95 162a8aff24ff56bc 7a4ef9e9f44480ee`
</details>