### PR TITLE
script: update PlatformConfig programmatically

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -157,7 +157,7 @@ class CAR(Platforms):
   # TODO: is there an XV and Impreza too?
   CROSSTREK_HYBRID = SubaruPlatformConfig(
     "SUBARU CROSSTREK HYBRID 2020",
-    SubaruCarInfo("Subaru Crosstrek Hybrid 2020", car_parts=CarParts.common([CarHarness.subaru_b])),
+    SubaruCarInfo("Subaru Crosstrek Hybrid 2020", car_parts=CarParts([CarHarness.subaru_b, Device.threex])),
     CarSpecs(mass=0, wheelbase=2.67, steerRatio=123, centerToFrontRatio=1.0, minEnableSpeed=99, tireStiffnessFactor=0.66),
     flags=SubaruFlags.STEER_RATE_LIMITED | SubaruFlags.HYBRID,
   )

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -156,9 +156,9 @@ class CAR(Platforms):
   )
   # TODO: is there an XV and Impreza too?
   CROSSTREK_HYBRID = SubaruPlatformConfig(
-    "SUBARU CROSSTREK HYBRID 2020",
+    "TEST TEST TEST TEST TEST",
     SubaruCarInfo("Subaru Crosstrek Hybrid 2020", car_parts=CarParts.common([CarHarness.subaru_b])),
-    CarSpecs(mass=1668, wheelbase=2.67, steerRatio=17),
+    CarSpecs(mass=0, wheelbase=2.67, steerRatio=123),
     flags=SubaruFlags.HYBRID,
   )
   FORESTER = SubaruPlatformConfig(

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -156,10 +156,10 @@ class CAR(Platforms):
   )
   # TODO: is there an XV and Impreza too?
   CROSSTREK_HYBRID = SubaruPlatformConfig(
-    "TEST TEST TEST TEST TEST",
+    "SUBARU CROSSTREK HYBRID 2020",
     SubaruCarInfo("Subaru Crosstrek Hybrid 2020", car_parts=CarParts.common([CarHarness.subaru_b])),
     CarSpecs(mass=0, wheelbase=2.67, steerRatio=123),
-    flags=SubaruFlags.HYBRID,
+    flags=SubaruFlags.STEER_RATE_LIMITED | SubaruFlags.HYBRID,
   )
   FORESTER = SubaruPlatformConfig(
     "SUBARU FORESTER 2019",

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -158,7 +158,7 @@ class CAR(Platforms):
   CROSSTREK_HYBRID = SubaruPlatformConfig(
     "SUBARU CROSSTREK HYBRID 2020",
     SubaruCarInfo("Subaru Crosstrek Hybrid 2020", car_parts=CarParts.common([CarHarness.subaru_b])),
-    CarSpecs(mass=0, wheelbase=2.67, steerRatio=123),
+    CarSpecs(mass=0, wheelbase=2.67, steerRatio=123, centerToFrontRatio=1.0, minEnableSpeed=99, tireStiffnessFactor=0.66),
     flags=SubaruFlags.STEER_RATE_LIMITED | SubaruFlags.HYBRID,
   )
   FORESTER = SubaruPlatformConfig(

--- a/selfdrive/debug/update_config.py
+++ b/selfdrive/debug/update_config.py
@@ -7,13 +7,9 @@ from dataclasses import MISSING, fields
 
 class PlatformConfigFinder(ast.NodeVisitor):
   def __init__(self, platform):
-    super().__init__()
     self.platform = platform
-    self.target_node = None
 
   def visit_Assign(self, node):
-    if self.target_node is not None:
-      return
     for target in node.targets:
       if isinstance(target, ast.Name) and target.id == self.platform.name:
         self.target_node = node

--- a/selfdrive/debug/update_config.py
+++ b/selfdrive/debug/update_config.py
@@ -86,7 +86,12 @@ if __name__ == '__main__':
 
   original_config = CAR_SUBARU.CROSSTREK_HYBRID.config
 
-  new_specs = replace(original_config.specs, mass=0, steerRatio=123)
+  new_specs = replace(original_config.specs,
+                      mass=0,
+                      steerRatio=123,
+                      centerToFrontRatio=1.0,
+                      tireStiffnessFactor=0.66,
+                      minEnableSpeed=99)
   new_config = replace(original_config,
                        specs=new_specs,
                        flags=SubaruFlags.HYBRID | SubaruFlags.STEER_RATE_LIMITED)

--- a/selfdrive/debug/update_config.py
+++ b/selfdrive/debug/update_config.py
@@ -1,0 +1,75 @@
+import ast
+import inspect
+from dataclasses import MISSING, fields
+
+
+class PlatformConfigFinder(ast.NodeVisitor):
+  def __init__(self, platform):
+    super().__init__()
+    self.platform = platform
+    self.target_node = None
+
+  def visit_Assign(self, node):
+    for target in node.targets:
+      if isinstance(target, ast.Name) and target.id == self.platform.name:
+        self.target_node = node
+        return
+
+
+def dataclass_to_string(value):
+  def is_default_value(field):
+    default_value = field.default if field.default_factory is MISSING else field.default_factory()
+    return getattr(value, field.name) == default_value
+
+  s = ', '.join(f'{field.name}={getattr(value, field.name)!r}'
+                for field in fields(value) if not is_default_value(field))
+  return f'{value.__class__.__name__}({s})'
+
+
+def replace_colspan(source_lines, line, start, end, new_text):
+  source_lines[line] = source_lines[line][:start] + new_text + source_lines[line][end:]
+
+
+def update_field(source, field, node, config):
+  # TODO: support updating car_info, flags
+  if field.name == 'platform_str':
+    new_text = config.platform_str
+  elif field.name == 'specs':
+    new_text = dataclass_to_string(config.specs)
+  else:
+    print(f"Warning: Updating {field.name} is not supported")
+    return source
+  return replace_colspan(source, node.lineno, node.col_offset, node.end_col_offset, new_text)
+
+
+def update_config(platform, config):
+  car = type(platform)
+  source, starting_line = inspect.getsourcelines(car)
+  source = ''.join(source)
+  source_file = inspect.getsourcefile(car)
+
+  tree = ast.parse(source)
+  finder = PlatformConfigFinder(platform)
+  finder.visit(tree)
+
+  target_node = finder.target_node
+
+  platform_fields = fields(config)
+  platform_fields_by_name = {field.name: field for field in platform_fields}
+
+  for field, arg in zip(platform_fields, target_node.value.args, strict=False):
+    source = update_field(source, field, arg, config)
+  for kwarg in target_node.value.keywords:
+    source = update_field(source, platform_fields_by_name[kwarg.arg], kwarg.value, config)
+
+  with open(source_file, 'w') as f:
+    values = f.read()
+    values = replace_colspan(
+      values,
+      (starting_line + target_node.lineno - 1, target_node.col_offset),
+      (starting_line + target_node.end_lineno - 1, target_node.end_col_offset),
+      source,
+    )
+    f.write(values)
+
+  return source

--- a/selfdrive/debug/update_config.py
+++ b/selfdrive/debug/update_config.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import ast
 import inspect
 from dataclasses import MISSING, fields


### PR DESCRIPTION
Adds code to help write PlatformConfig changes back to `values.py`. Supports updating `CarSpecs` and `flags`.

Closes https://github.com/commaai/openpilot/issues/31713

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

