### PR TITLE
ruff: set tab size and quote style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ build-backend = "poetry.core.masonry.api"
 
 # https://beta.ruff.rs/docs/configuration/#using-pyprojecttoml
 [tool.ruff]
+tab-size = 2
 lint.select = ["E", "F", "W", "PIE", "C4", "ISC", "RUF008", "RUF100", "A", "B", "TID251"]
 lint.ignore = ["E741", "E402", "C408", "ISC003", "B027", "B024"]
 line-length = 160
@@ -195,3 +196,5 @@ lint.flake8-implicit-str-concat.allow-multiline=false
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]
+[tool.ruff.format]
+quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,4 +197,4 @@ lint.flake8-implicit-str-concat.allow-multiline=false
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]
 [tool.ruff.format]
-quote-style = "single"
+quote-style = "preserve"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ build-backend = "poetry.core.masonry.api"
 
 # https://beta.ruff.rs/docs/configuration/#using-pyprojecttoml
 [tool.ruff]
-tab-size = 2
+indent-width = 2
 lint.select = ["E", "F", "W", "PIE", "C4", "ISC", "RUF008", "RUF100", "A", "B", "TID251"]
 lint.ignore = ["E741", "E402", "C408", "ISC003", "B027", "B024"]
 line-length = 160


### PR DESCRIPTION
---
name: Update the auto formatting config, pyproject.toml, with the right config
about:  ruff config file update
title: Update the pyptoject.toml file with the right tab size and quote style
labels: 'bugfix'
assignees: N/A
---


**Description**


As a first time user who just pulled the project down to local (and connected to VSCode), I immediately realized that the auto formating (formating on save) is changing the files with different tab size (4) and double quotes. Then I checked the settings json and find that we have already defined the tab size as 2. So the issue must be the inconsistency setting in the ruff config (the formatter in the project). And it turns out that we didn't explicitly define the tab size and quote style causing the formatter reverting the tab size to default 4 and quotes to default double.
By updating the pyptoject.toml file as per suggested in the official doc ( https://docs.astral.sh/ruff/settings/#format_quote-style), this issue gets resolved.


**Verification**


I tested after I made this change and the files are not being updated to 4 spaces, double quotes anymore in vscode.
