### PR TITLE
common PlatformFlags base class + test for < 32 bits

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -318,3 +318,9 @@ class Platforms(str, ReprEnum):
 
     for flag, platforms in platforms_with_flag.items():
       print(f"{flag:32s}: {', '.join(p.name for p in platforms)}")
+
+
+
+class PlatformFlags(IntFlag):
+  def __init__(self, value: int):
+    assert value < 2**32, "undefined behaviour with >32 bit flags"

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -320,7 +320,6 @@ class Platforms(str, ReprEnum):
       print(f"{flag:32s}: {', '.join(p.name for p in platforms)}")
 
 
-
 class PlatformFlags(IntFlag):
   def __init__(self, value: int):
     assert value < 2**32, "undefined behaviour with >32 bit flags"

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -321,5 +321,4 @@ class Platforms(str, ReprEnum):
 
 
 class PlatformFlags(IntFlag):
-  def __init__(self, value: int):
-    assert value < 2**32, "undefined behaviour with >32 bit flags"
+  pass

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -321,4 +321,5 @@ class Platforms(str, ReprEnum):
 
 
 class PlatformFlags(IntFlag):
-  pass
+  def __init__(self, value: int):
+    assert value < 2**32, "undefined behaviour with >32 bit flags"

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -1,16 +1,15 @@
-from enum import IntFlag
 from dataclasses import dataclass, field
 
 from cereal import car
 from panda.python import uds
-from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, Platforms, dbc_dict
+from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, PlatformFlags, Platforms, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarHarness, CarInfo, CarParts
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
 
 Ecu = car.CarParams.Ecu
 
 
-class ChryslerFlags(IntFlag):
+class ChryslerFlags(PlatformFlags):
   # Detected flags
   HIGHER_MIN_STEERING_SPEED = 1
 

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
-from enum import Enum, IntFlag
+from enum import Enum
 
 import panda.python.uds as uds
 from cereal import car
-from openpilot.selfdrive.car import AngleRateLimit, CarSpecs, dbc_dict, DbcDict, PlatformConfig, Platforms
+from openpilot.selfdrive.car import AngleRateLimit, CarSpecs, PlatformFlags, dbc_dict, DbcDict, PlatformConfig, Platforms
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
                                                      Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16
@@ -39,7 +39,7 @@ class CarControllerParams:
     pass
 
 
-class FordFlags(IntFlag):
+class FordFlags(PlatformFlags):
   # Static flags
   CANFD = 1
 

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from enum import Enum, IntFlag
+from enum import Enum
 
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from panda.python import uds
-from openpilot.selfdrive.car import CarSpecs, PlatformConfig, Platforms, dbc_dict
+from openpilot.selfdrive.car import CarSpecs, PlatformConfig, PlatformFlags, Platforms, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16
 
@@ -45,7 +45,7 @@ class CarControllerParams:
     self.STEER_LOOKUP_V = [v * -1 for v in CP.lateralParams.torqueV][1:][::-1] + list(CP.lateralParams.torqueV)
 
 
-class HondaFlags(IntFlag):
+class HondaFlags(PlatformFlags):
   # Detected flags
   # Bosch models with alternate set of LKAS_HUD messages
   BOSCH_EXT_HUD = 1

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass, field
-from enum import Enum, IntFlag
+from enum import Enum
 
 from cereal import car
 from panda.python import uds
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, Platforms, dbc_dict
+from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, PlatformFlags, Platforms, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
 
@@ -51,7 +51,7 @@ class CarControllerParams:
       self.STEER_MAX = 384
 
 
-class HyundaiFlags(IntFlag):
+class HyundaiFlags(PlatformFlags):
   # Dynamic Flags
   CANFD_HDA2 = 1
   CANFD_ALT_BUTTONS = 2

--- a/selfdrive/car/mazda/values.py
+++ b/selfdrive/car/mazda/values.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass, field
-from enum import IntFlag
 
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, Platforms, dbc_dict
+from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, PlatformFlags, Platforms, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarHarness, CarInfo, CarParts
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
@@ -37,7 +36,7 @@ class MazdaCarSpecs(CarSpecs):
   tireStiffnessFactor: float = 0.7  # not optimized yet
 
 
-class MazdaFlags(IntFlag):
+class MazdaFlags(PlatformFlags):
   # Static flags
   # Gen 1 hardware: same CAN messages and same camera
   GEN1 = 1

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
-from enum import Enum, IntFlag
+from enum import Enum
 
 from cereal import car
 from panda.python import uds
-from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, Platforms, dbc_dict
+from openpilot.selfdrive.car import CarSpecs, DbcDict, PlatformConfig, Platforms, PlatformFlags, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Tool, Column
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries, p16
 
@@ -52,7 +52,7 @@ class CarControllerParams:
   BRAKE_LOOKUP_V = [BRAKE_MAX, BRAKE_MIN]
 
 
-class SubaruFlags(IntFlag):
+class SubaruFlags(PlatformFlags):
   # Detected flags
   SEND_INFOTAINMENT = 1
   DISABLE_EYESIGHT = 2

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -1,11 +1,11 @@
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
-from enum import Enum, IntFlag
+from enum import Enum
 
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car import CarSpecs, PlatformConfig, Platforms
+from openpilot.selfdrive.car import CarSpecs, PlatformConfig, PlatformFlags, Platforms
 from openpilot.selfdrive.car import AngleRateLimit, dbc_dict
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarInfo, Column, CarParts, CarHarness
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
@@ -41,7 +41,7 @@ class CarControllerParams:
       self.STEER_DELTA_DOWN = 25     # always lower than 45 otherwise the Rav4 faults (Prius seems ok with 50)
 
 
-class ToyotaFlags(IntFlag):
+class ToyotaFlags(PlatformFlags):
   # Detected flags
   HYBRID = 1
   SMART_DSU = 2

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -1,12 +1,12 @@
 from collections import namedtuple
 from dataclasses import dataclass, field
-from enum import Enum, IntFlag
+from enum import Enum
 
 from cereal import car
 from panda.python import uds
 from opendbc.can.can_define import CANDefine
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car import dbc_dict, CarSpecs, DbcDict, PlatformConfig, Platforms
+from openpilot.selfdrive.car import PlatformFlags, dbc_dict, CarSpecs, DbcDict, PlatformConfig, Platforms
 from openpilot.selfdrive.car.docs_definitions import CarFootnote, CarHarness, CarInfo, CarParts, Column, \
                                            Device
 from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, p16
@@ -109,7 +109,7 @@ class CANBUS:
   cam = 2
 
 
-class VolkswagenFlags(IntFlag):
+class VolkswagenFlags(PlatformFlags):
   # Detected flags
   STOCK_HCA_PRESENT = 1
 


### PR DESCRIPTION
\>32 bit flags would not be supported because in cereal, flags is 32 bits. good check to have, especially because Hyundai exists

also allows for a helper on the flags, ex: for checking exact flag matches: https://github.com/commaai/openpilot/pull/31645