### PR TITLE
vscode: remove non-symlinked openpilot directories from python analysis

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,15 @@
     "**/.git": true,
     "**/.venv": true,
     "**/__pycache__": true
-  }
+  },
+  "python.analysis.exclude": [
+    "**/.git",
+    "**/.venv",
+    "**/__pycache__",
+    // exclude directories should be using the symlinked version
+    "common/**",
+    "selfdrive/**",
+    "system/**",
+    "tools/**",
+  ]
 }


### PR DESCRIPTION
before: you would get both `openpilot.` and non `openpilot.` suggestions. also if you took the default suggestion with a hotkey it would always take the non-`openpilot` one, which was very frustrating
![image](https://github.com/commaai/openpilot/assets/9648890/f11ee798-087e-4877-877a-45e29154b890)



now: only the correct suggestion
![image](https://github.com/commaai/openpilot/assets/9648890/806a16c2-d7f8-4691-95ac-e392253476e3)
