### PR TITLE
Subaru: extra logging request for camera

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -246,6 +246,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [StdQueries.DEFAULT_DIAGNOSTIC_REQUEST, StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
       [StdQueries.DEFAULT_DIAGNOSTIC_RESPONSE, StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.fwdCamera],
+      bus=0,
       logging=True,
     ),
     # Non-OBD requests

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -242,6 +242,18 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [SUBARU_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.fwdCamera],
     ),
+    Request(
+      [StdQueries.SHORT_TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
+      [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.fwdCamera],
+      logging=True,
+    ),
+    Request(
+      [StdQueries.DEFAULT_DIAGNOSTIC_REQUEST, StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
+      [StdQueries.DEFAULT_DIAGNOSTIC_RESPONSE, StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.fwdCamera],
+      logging=True,
+    ),
     # Non-OBD requests
     Request(
       [StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -243,12 +243,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.fwdCamera],
     ),
     Request(
-      [StdQueries.SHORT_TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
-      [StdQueries.SHORT_TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera],
-      logging=True,
-    ),
-    Request(
       [StdQueries.DEFAULT_DIAGNOSTIC_REQUEST, StdQueries.TESTER_PRESENT_REQUEST, SUBARU_VERSION_REQUEST],
       [StdQueries.DEFAULT_DIAGNOSTIC_RESPONSE, StdQueries.TESTER_PRESENT_RESPONSE, SUBARU_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.fwdCamera],

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -263,7 +263,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         print(f'get_vin {name} case, query time={self.total_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = {1: 8.6, 2: 9.5}
+    total_ref_time = {1: 8.5, 2: 9.4}
     brand_ref_times = {
       1: {
         'gm': 1.0,
@@ -274,7 +274,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'hyundai': 1.05,
         'mazda': 0.1,
         'nissan': 0.8,
-        'subaru': 0.65,
+        'subaru': 0.55,
         'tesla': 0.3,
         'toyota': 1.6,
         'volkswagen': 0.65,

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -263,7 +263,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         print(f'get_vin {name} case, query time={self.total_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = {1: 8.4, 2: 9.3}
+    total_ref_time = {1: 8.6, 2: 9.5}
     brand_ref_times = {
       1: {
         'gm': 1.0,
@@ -274,7 +274,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'hyundai': 1.05,
         'mazda': 0.1,
         'nissan': 0.8,
-        'subaru': 0.45,
+        'subaru': 0.65,
         'tesla': 0.3,
         'toyota': 1.6,
         'volkswagen': 0.65,


### PR DESCRIPTION
The camera returns `7f - service not supported in active session` on the new cars the comment is talking about, which means that the subfunction is likely correct. I suspect putting it in the default diagnostic mode might allow some time for the ECU to fully initialize, if that is the problem.

We do this for Toyota, though we usually send TP first. We should sniff a dealer tool to see what is requested.

On Hyundai, the [diagnostic mode does change the data returned](https://github.com/commaai/openpilot/blob/fd51bfb27bbdd089833810bec49e67e4ce7a1800/selfdrive/debug/hyundai_enable_radar_points.py#L28-L29) from our RDBI DID 0xf100 query, so it's possible something like that could be taking place here.