### PR TITLE
Add autoconnect support for hidden WiFi networks

### DIFF
--- a/selfdrive/ui/qt/network/networking.cc
+++ b/selfdrive/ui/qt/network/networking.cc
@@ -82,11 +82,11 @@ void Networking::connectToNetwork(const Network n) {
   if (wifi->isKnownConnection(n.ssid)) {
     wifi->activateWifiConnection(n.ssid);
   } else if (n.security_type == SecurityType::OPEN) {
-    wifi->connect(n);
+    wifi->connect(n, false);
   } else if (n.security_type == SecurityType::WPA) {
     QString pass = InputDialog::getText(tr("Enter password"), this, tr("for \"%1\"").arg(QString::fromUtf8(n.ssid)), true, 8);
     if (!pass.isEmpty()) {
-      wifi->connect(n, pass);
+      wifi->connect(n, false, pass);
     }
   }
 }
@@ -96,7 +96,7 @@ void Networking::wrongPassword(const QString &ssid) {
     const Network &n = wifi->seenNetworks.value(ssid);
     QString pass = InputDialog::getText(tr("Wrong password"), this, tr("for \"%1\"").arg(QString::fromUtf8(n.ssid)), true, 8);
     if (!pass.isEmpty()) {
-      wifi->connect(n, pass);
+      wifi->connect(n, false, pass);
     }
   }
 }
@@ -192,9 +192,9 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
       hidden_network.ssid = ssid.toUtf8();
       if (!pass.isEmpty()) {
         hidden_network.security_type = SecurityType::WPA;
-        wifi->connect(hidden_network, pass);
+        wifi->connect(hidden_network, true, pass);
       } else {
-        wifi->connect(hidden_network);
+        wifi->connect(hidden_network, true);
       }
       emit requestWifiScreen();
     }

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -176,7 +176,7 @@ void WifiManager::connect(const Network &n, const QString &password, const QStri
   connection["connection"]["autoconnect-retries"] = 0;
 
   connection["802-11-wireless"]["ssid"] = n.ssid;
-  connection["802-11-wireless"]["hidden"] = true
+  connection["802-11-wireless"]["hidden"] = true;
   connection["802-11-wireless"]["mode"] = "infrastructure";
 
   if (n.security_type == SecurityType::WPA) {

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -173,10 +173,10 @@ void WifiManager::connect(const Network &n, const QString &password, const QStri
   connection["connection"]["type"] = "802-11-wireless";
   connection["connection"]["uuid"] = QUuid::createUuid().toString().remove('{').remove('}');
   connection["connection"]["id"] = "openpilot connection " + QString::fromStdString(n.ssid.toStdString());
-  connection["connection"]["autoconnect"] = true; // set to autoconnect to hidden networks
   connection["connection"]["autoconnect-retries"] = 0;
 
   connection["802-11-wireless"]["ssid"] = n.ssid;
+  connection["802-11-wireless"]["hidden"] = true
   connection["802-11-wireless"]["mode"] = "infrastructure";
 
   if (n.security_type == SecurityType::WPA) {

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -173,6 +173,7 @@ void WifiManager::connect(const Network &n, const QString &password, const QStri
   connection["connection"]["type"] = "802-11-wireless";
   connection["connection"]["uuid"] = QUuid::createUuid().toString().remove('{').remove('}');
   connection["connection"]["id"] = "openpilot connection " + QString::fromStdString(n.ssid.toStdString());
+  connection["connection"]["autoconnect"] = true; // set to autoconnect to hidden networks
   connection["connection"]["autoconnect-retries"] = 0;
 
   connection["802-11-wireless"]["ssid"] = n.ssid;

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -166,7 +166,7 @@ SecurityType WifiManager::getSecurityType(const QVariantMap &properties) {
   }
 }
 
-void WifiManager::connect(const Network &n, const QString &password, const QString &username) {
+void WifiManager::connect(const Network &n, const bool is_hidden, const QString &password, const QString &username) {
   setCurrentConnecting(n.ssid);
   forgetConnection(n.ssid);  // Clear all connections that may already exist to the network we are connecting
   Connection connection;
@@ -176,7 +176,7 @@ void WifiManager::connect(const Network &n, const QString &password, const QStri
   connection["connection"]["autoconnect-retries"] = 0;
 
   connection["802-11-wireless"]["ssid"] = n.ssid;
-  connection["802-11-wireless"]["hidden"] = true;
+  connection["802-11-wireless"]["hidden"] = is_hidden;
   connection["802-11-wireless"]["mode"] = "infrastructure";
 
   if (n.security_type == SecurityType::WPA) {

--- a/selfdrive/ui/qt/network/wifi_manager.h
+++ b/selfdrive/ui/qt/network/wifi_manager.h
@@ -52,7 +52,7 @@ public:
   std::optional<QDBusPendingCall> activateWifiConnection(const QString &ssid);
   NetworkType currentNetworkType();
   void updateGsmSettings(bool roaming, QString apn, bool metered);
-  void connect(const Network &ssid, const bool is_hidden, const QString &password = {}, const QString &username = {});
+  void connect(const Network &ssid, const bool is_hidden = false, const QString &password = {}, const QString &username = {});
 
   // Tethering functions
   void setTetheringEnabled(bool enabled);

--- a/selfdrive/ui/qt/network/wifi_manager.h
+++ b/selfdrive/ui/qt/network/wifi_manager.h
@@ -52,7 +52,7 @@ public:
   std::optional<QDBusPendingCall> activateWifiConnection(const QString &ssid);
   NetworkType currentNetworkType();
   void updateGsmSettings(bool roaming, QString apn, bool metered);
-  void connect(const Network &ssid, const QString &password = {}, const QString &username = {});
+  void connect(const Network &ssid, const bool is_hidden, const QString &password = {}, const QString &username = {});
 
   // Tethering functions
   void setTetheringEnabled(bool enabled);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->
Fixes #31651

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

