### PR TITLE
simulator: Increase map size to contain road

### DIFF
--- a/tools/sim/scenarios/metadrive/stay_in_lane.py
+++ b/tools/sim/scenarios/metadrive/stay_in_lane.py
@@ -67,6 +67,7 @@ class MetaDriveBridge(SimulatorBridge):
       crash_object_done=True,
       traffic_density=0.0,
       map_config=create_map(),
+      map_region_size=2048,
       decision_repeat=1,
       physics_world_step_size=self.TICKS_PER_FRAME/100,
       preload_models=False


### PR DESCRIPTION
As explained in https://github.com/metadriverse/metadrive/issues/676, MetaDrive will simply cut the road if it gets out of the map without even showing any warning.