### PR TITLE
simulator: Correctly handle arrival at destination

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -75,6 +75,7 @@ class MetaDriveBridge(SimulatorBridge):
       on_continuous_line_done=False,
       crash_vehicle_done=False,
       crash_object_done=False,
+      arrive_dest_done=False,
       traffic_density=0.0, # traffic is incredibly expensive
       map_config=create_map(),
       decision_repeat=1,

--- a/tools/sim/scenarios/metadrive/stay_in_lane.py
+++ b/tools/sim/scenarios/metadrive/stay_in_lane.py
@@ -65,6 +65,7 @@ class MetaDriveBridge(SimulatorBridge):
       on_continuous_line_done=True,
       crash_vehicle_done=True,
       crash_object_done=True,
+      arrive_dest_done=True,
       traffic_density=0.0,
       map_config=create_map(),
       map_region_size=2048,


### PR DESCRIPTION
The world process will now correctly report:
```
World Status: {'status': 'terminating', 'reason': 'done', 'done_info': {'crash_vehicle': False, 'crash_object': False, 'crash_building': False, 'crash_human': False, 'crash_sidewalk': False, 'out_of_road': False, 'arrive_dest': True, 'max_step': False, 'env_seed': 0, 'crash': False}}
```