### PR TITLE
ButtonParamControl: use buttonClicked

### DIFF
--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -223,10 +223,8 @@ public:
       button_group->addButton(button, i);
     }
 
-    QObject::connect(button_group, QOverload<int, bool>::of(&QButtonGroup::buttonToggled), [=](int id, bool checked) {
-      if (checked) {
-        params.put(key, std::to_string(id));
-      }
+    QObject::connect(button_group, QOverload<int>::of(&QButtonGroup::buttonClicked), [=](int id) {
+      params.put(key, std::to_string(id));
     });
   }
 


### PR DESCRIPTION
From https://github.com/commaai/openpilot/pull/31792, allows you to set the checked button without triggering this signal. Nothing relies on this behavior