### PR TITLE
Params: remove unused key

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -207,7 +207,6 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"UpdaterTargetBranch", CLEAR_ON_MANAGER_START},
     {"UpdaterLastFetchTime", PERSISTENT},
     {"Version", PERSISTENT},
-    {"VisionRadarToggle", PERSISTENT},
 };
 
 } // namespace


### PR DESCRIPTION
`VisionRadarToggle` is no longer used and is superseded by `ExperimentalLongitudinalEnabled`.