### PR TITLE
Volkswagen PQ Longitudinal: Display personality in instrument cluster

### DIFF
--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -94,7 +94,7 @@ def create_acc_accel_control(packer, bus, acc_type, acc_enabled, accel, acc_cont
 def create_acc_hud_control(packer, bus, acc_hud_status, set_speed, lead_distance, distance):
   values = {
     "ACA_StaACC": acc_hud_status,
-    "ACA_Zeitluecke": 2,
+    "ACA_Zeitluecke": distance + 2,
     "ACA_V_Wunsch": set_speed,
     "ACA_gemZeitl": lead_distance,
     "ACA_PrioDisp": 3,


### PR DESCRIPTION
Displays Longitudinal Personality with 3rd, 4th, and 5th bar.

**Requires**
- https://github.com/commaai/openpilot/pull/31760

**Related**
- https://github.com/commaai/openpilot/pull/31800

**Route**
- `578742b26807f756/2024-03-10--10-51-24`

[Screencast from 03-12-2024 01:04:16 AM.webm](https://github.com/commaai/openpilot/assets/47793918/467cded4-3131-418c-b320-f73cfc41a68a)
