### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/ford/fingerprints.py
+++ b/selfdrive/car/ford/fingerprints.py
@@ -85,8 +85,8 @@ FW_VERSIONS = {
       b'ML3T-14D049-AL\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.fwdCamera, 0x706, None): [
-      b'PJ6T-14H102-ABJ\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'ML3T-14H102-ABR\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+      b'PJ6T-14H102-ABJ\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
   CAR.F_150_LIGHTNING_MK1: {

--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -535,25 +535,31 @@ FW_VERSIONS = {
   CAR.SANTA_FE_HEV_2022: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00TMhe SCC FHCUP      1.00 1.00 99110-CL500         ',
+      b'\xf1\x00TMhe SCC FHCUP      1.00 1.01 99110-CL500         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00TM  MDPS C 1.00 1.02 56310-CLAC0 4TSHC102',
       b'\xf1\x00TM  MDPS C 1.00 1.02 56310-CLEC0 4TSHC102',
       b'\xf1\x00TM  MDPS C 1.00 1.02 56310-GA000 4TSHA100',
       b'\xf1\x00TM  MDPS R 1.00 1.05 57700-CL000 4TSHP105',
+      b'\xf1\x00TM  MDPS R 1.00 1.06 57700-CL000 4TSHP106',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00TMA MFC  AT USA LHD 1.00 1.03 99211-S2500 220414',
       b'\xf1\x00TMH MFC  AT EUR LHD 1.00 1.06 99211-S1500 220727',
+      b'\xf1\x00TMH MFC  AT KOR LHD 1.00 1.06 99211-S1500 220727',
       b'\xf1\x00TMH MFC  AT USA LHD 1.00 1.03 99211-S1500 210224',
+      b'\xf1\x00TMH MFC  AT USA LHD 1.00 1.05 99211-S1500 220126',
       b'\xf1\x00TMH MFC  AT USA LHD 1.00 1.06 99211-S1500 220727',
     ],
     (Ecu.transmission, 0x7e1, None): [
+      b'\xf1\x00PSBG2333  E16\x00\x00\x00\x00\x00\x00\x00TTM2H16KA1\xc6\x15Q\x1e',
       b'\xf1\x00PSBG2333  E16\x00\x00\x00\x00\x00\x00\x00TTM2H16SA3\xa3\x1b\xe14',
       b'\xf1\x00PSBG2333  E16\x00\x00\x00\x00\x00\x00\x00TTM2H16UA3I\x94\xac\x8f',
       b'\xf1\x87959102T250\x00\x00\x00\x00\x00\xf1\x81E14\x00\x00\x00\x00\x00\x00\x00\xf1\x00PSBG2333  E14\x00\x00\x00\x00\x00\x00\x00TTM2H16SA2\x80\xd7l\xb2',
     ],
     (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x87391312MTA0',
       b'\xf1\x87391312MTC1',
       b'\xf1\x87391312MTE0',
       b'\xf1\x87391312MTL0',
@@ -561,6 +567,7 @@ FW_VERSIONS = {
   },
   CAR.SANTA_FE_PHEV_2022: {
     (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00TMhe SCC F-CUP      1.00 1.00 99110-CL500         ',
       b'\xf1\x00TMhe SCC FHCUP      1.00 1.01 99110-CL500         ',
       b'\xf1\x8799110CL500\xf1\x00TMhe SCC FHCUP      1.00 1.00 99110-CL500         ',
     ],
@@ -574,6 +581,7 @@ FW_VERSIONS = {
       b'\xf1\x00TMP MFC  AT USA LHD 1.00 1.06 99211-S1500 220727',
     ],
     (Ecu.transmission, 0x7e1, None): [
+      b'\xf1\x00PSBG2333  E16\x00\x00\x00\x00\x00\x00\x00TTM2P16SA0o\x88^\xbe',
       b'\xf1\x00PSBG2333  E16\x00\x00\x00\x00\x00\x00\x00TTM2P16SA1\x0b\xc5\x0f\xea',
       b'\xf1\x8795441-3D121\x00\xf1\x81E16\x00\x00\x00\x00\x00\x00\x00\xf1\x00PSBG2333  E16\x00\x00\x00\x00\x00\x00\x00TTM2P16SA0o\x88^\xbe',
       b'\xf1\x8795441-3D121\x00\xf1\x81E16\x00\x00\x00\x00\x00\x00\x00\xf1\x00PSBG2333  E16\x00\x00\x00\x00\x00\x00\x00TTM2P16SA1\x0b\xc5\x0f\xea',

--- a/selfdrive/car/volkswagen/fingerprints.py
+++ b/selfdrive/car/volkswagen/fingerprints.py
@@ -656,8 +656,8 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdRadar, 0x757, None): [
       b'\xf1\x872Q0907572AA\xf1\x890396',
-      b'\xf1\x875Q0907572R \xf1\x890771',
       b'\xf1\x873Q0907572C \xf1\x890195',
+      b'\xf1\x875Q0907572R \xf1\x890771',
     ],
   },
   CAR.TRANSPORTER_T61: {


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 3 dongles (2 platforms) in last 2.0 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                           | Name from VIN 🆚 CarInfo                                                           | Segments                | Bad seg tags   | Good seg tags                                                                        |
|:------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|:------------------------|:---------------|:-------------------------------------------------------------------------------------|
| [c879647c02650645](https://useradmin.comma.ai/?onebox=c879647c02650645)<br><sub>HYUNDAI SANTA FE HYBRID 2022<br>KMHS5811B........</sub>         | HYUNDAI  1993 🆚<br>Hyundai Santa Fe Hybrid 2022-23                                | 5 routes, 270 segments  |                | - all lat active: 65<br>- no input all lat active: 33<br>- valid torque params: 270  |
| [1d10de75f6b8c570](https://useradmin.comma.ai/?onebox=1d10de75f6b8c570)<br><sub>HYUNDAI SANTA FE PlUG-IN HYBRID 2022<br>KM8S6DA29........</sub> | HYUNDAI Santa Fe Plug-in Hybrid 2022 🆚<br>Hyundai Santa Fe Plug-in Hybrid 2022-23 | 13 routes, 324 segments |                | - valid torque params: 324<br>- all lat active: 116<br>- no input all lat active: 60 |
| [2acc6988a1fef659](https://useradmin.comma.ai/?onebox=2acc6988a1fef659)<br><sub>HYUNDAI SANTA FE HYBRID 2022<br>KM8S5DA15........</sub>         | HYUNDAI Santa Fe Hybrid 2022 🆚<br>Hyundai Santa Fe Hybrid 2022-23                 | 12 routes, 292 segments |                | - valid torque params: 292<br>- all lat active: 119<br>- no input all lat active: 26 |

Dongles to re-run category: `1d10de75f6b8c570 c879647c02650645 2acc6988a1fef659`
</details>

## ⏳️ 28 dongles (9 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                           | Name from VIN 🆚 CarInfo                                                           | Segments                | Bad seg tags   | Good seg tags                                                                       |
|:------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|:------------------------|:---------------|:------------------------------------------------------------------------------------|
| [124457b31149107e](https://useradmin.comma.ai/?onebox=124457b31149107e)<br><sub>HYUNDAI SANTA FE 2019<br>5NMS3CAD3........</sub>                | HYUNDAI Santa Fe 2019 🆚<br>Hyundai Santa Fe 2019-20                               | 6 routes, 107 segments  |                | - valid torque params: 107<br>- all lat active: 43<br>- no input all lat active: 33 |
| [dec47dd6b2d62da2](https://useradmin.comma.ai/?onebox=dec47dd6b2d62da2)<br><sub>HYUNDAI SANTA FE 2019<br>5NMS53AA2........</sub>                | HYUNDAI Santa Fe 2020 🆚<br>Hyundai Santa Fe 2019-20                               | 1 routes, 89 segments   |                | - all lat active: 69<br>- valid torque params: 89<br>- no input all lat active: 48  |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI IONIQ 5 2022<br>000000000........</sub>                 | None 🆚<br>None                                                                    | 13 routes, 182 segments |                | - valid torque params: 182<br>- all lat active: 13<br>- no input all lat active: 4  |
| [0cb48444dd180504](https://useradmin.comma.ai/?onebox=0cb48444dd180504)<br><sub>HYUNDAI SANTA FE 2022<br>5NMS5DAL7........</sub>                | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                               | 1 routes, 5 segments    |                | - all lat active: 0                                                                 |
| [9acd533a0f402e80](https://useradmin.comma.ai/?onebox=9acd533a0f402e80)<br><sub>HYUNDAI ELANTRA 2021<br>5NPLS4AG8........</sub>                 | HYUNDAI Elantra 2022 🆚<br>Hyundai Elantra 2021-23                                 | 10 routes, 139 segments |                | - valid torque params: 139<br>- all lat active: 0                                   |
| [d3ef9b7c8fc585a3](https://useradmin.comma.ai/?onebox=d3ef9b7c8fc585a3)<br><sub>HYUNDAI PALISADE 2020<br>KM8R7DHE1........</sub>                | HYUNDAI Palisade 2021 🆚<br>Hyundai Palisade 2020-22                               | 5 routes, 108 segments  |                | - valid torque params: 108<br>- all lat active: 44<br>- no input all lat active: 24 |
| [6026525261343755](https://useradmin.comma.ai/?onebox=6026525261343755)<br><sub>HYUNDAI PALISADE 2020<br>5XYP5DHC9........</sub>                | KIA Telluride 2022 🆚<br>Kia Telluride 2020-22                                     | 5 routes, 63 segments   |                | - valid torque params: 63<br>- all lat active: 1                                    |
| [350d89a7bad7f485](https://useradmin.comma.ai/?onebox=350d89a7bad7f485)<br><sub>HYUNDAI ELANTRA 2021<br>KMHLP4AG6........</sub>                 | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                 | 6 routes, 38 segments   |                | - valid torque params: 30<br>- all lat active: 3<br>- no input all lat active: 2    |
| [028e246a2b8e3144](https://useradmin.comma.ai/?onebox=028e246a2b8e3144)<br><sub>HYUNDAI PALISADE 2020<br>KM8R5DHEX........</sub>                | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                               | 13 routes, 145 segments |                | - valid torque params: 145<br>- all lat active: 14<br>- no input all lat active: 11 |
| [058ff2b75b84c4b6](https://useradmin.comma.ai/?onebox=058ff2b75b84c4b6)<br><sub>HYUNDAI PALISADE 2020<br>KM8R74HE5........</sub>                | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                               | 4 routes, 86 segments   |                | - valid torque params: 86<br>- all lat active: 12<br>- no input all lat active: 9   |
| [baf9c744e8d3aedc](https://useradmin.comma.ai/?onebox=baf9c744e8d3aedc)<br><sub>HYUNDAI PALISADE 2020<br>KM8R14HE2........</sub>                | HYUNDAI Palisade 2021 🆚<br>Hyundai Palisade 2020-22                               | 5 routes, 118 segments  |                | - all lat active: 10<br>- valid torque params: 118<br>- no input all lat active: 3  |
| [83f627fc1e48c846](https://useradmin.comma.ai/?onebox=83f627fc1e48c846)<br><sub>HYUNDAI SONATA 2020<br>5NPEF4JA3........</sub>                  | HYUNDAI Sonata 2020 🆚<br>Hyundai Sonata 2020-23                                   | 6 routes, 52 segments   |                | - valid torque params: 52<br>- all lat active: 0                                    |
| [afe94a76bd8f5676](https://useradmin.comma.ai/?onebox=afe94a76bd8f5676)<br><sub>HYUNDAI PALISADE 2020<br>5XYP3DHC5........</sub>                | KIA Telluride 2022 🆚<br>Kia Telluride 2020-22                                     | 1 routes, 9 segments    |                | - valid torque params: 9<br>- all lat active: 0                                     |
| [b64e506d0ccb4cdb](https://useradmin.comma.ai/?onebox=b64e506d0ccb4cdb)<br><sub>HYUNDAI PALISADE 2020<br>KM8R7DHE5........</sub>                | HYUNDAI Palisade 2021 🆚<br>Hyundai Palisade 2020-22                               | 7 routes, 55 segments   |                | - valid torque params: 55<br>- all lat active: 3                                    |
| [0b2b36cf5a0789db](https://useradmin.comma.ai/?onebox=0b2b36cf5a0789db)<br><sub>HYUNDAI SANTA FE 2019<br>5NMS33AD5........</sub>                | HYUNDAI Santa Fe 2020 🆚<br>Hyundai Santa Fe 2019-20                               | 4 routes, 125 segments  |                | - valid torque params: 125<br>- all lat active: 53<br>- no input all lat active: 47 |
| [ee6cdcf74e577f1f](https://useradmin.comma.ai/?onebox=ee6cdcf74e577f1f)<br><sub>HYUNDAI PALISADE 2020<br>5XYP5DHC6........</sub>                | KIA Telluride 2022 🆚<br>Kia Telluride 2020-22                                     | 10 routes, 69 segments  |                | - valid torque params: 69<br>- all lat active: 1                                    |
| [e0c6f1daf613f27e](https://useradmin.comma.ai/?onebox=e0c6f1daf613f27e)<br><sub>HYUNDAI PALISADE 2020<br>KM8R54HE4........</sub>                | HYUNDAI Palisade 2021 🆚<br>Hyundai Palisade 2020-22                               | 2 routes, 12 segments   |                | - valid torque params: 12<br>- all lat active: 0                                    |
| [1c5b0ef6f666062d](https://useradmin.comma.ai/?onebox=1c5b0ef6f666062d)<br><sub>HYUNDAI PALISADE 2020<br>KM8R5DHE4........</sub>                | HYUNDAI Palisade 2020 🆚<br>Hyundai Palisade 2020-22                               | 10 routes, 109 segments |                | - valid torque params: 109<br>- all lat active: 14<br>- no input all lat active: 13 |
| [a204ef4b8bc8b99d](https://useradmin.comma.ai/?onebox=a204ef4b8bc8b99d)<br><sub>GENESIS G80 2017<br>KMHGN4JE0........</sub>                     | GENESIS G80 2018 🆚<br>Genesis G80 2018-19                                         | 6 routes, 116 segments  |                | - valid torque params: 116<br>- all lat active: 42<br>- no input all lat active: 6  |
| [4ea994afc80a04cf](https://useradmin.comma.ai/?onebox=4ea994afc80a04cf)<br><sub>HYUNDAI SANTA FE 2019<br>5NMS5CAA8........</sub>                | HYUNDAI Santa Fe 2019 🆚<br>Hyundai Santa Fe 2019-20                               | 6 routes, 114 segments  |                | - valid torque params: 114<br>- all lat active: 8<br>- no input all lat active: 4   |
| [0c0bea43f366283f](https://useradmin.comma.ai/?onebox=0c0bea43f366283f)<br><sub>HYUNDAI ELANTRA HYBRID 2021<br>KMHLN4AJ5........</sub>          | HYUNDAI Elantra Hybrid 2023 🆚<br>Hyundai Elantra Hybrid 2021-23                   | 8 routes, 17 segments   |                | - valid torque params: 17<br>- all lat active: 0                                    |
| [73bcac1960e3f6a4](https://useradmin.comma.ai/?onebox=73bcac1960e3f6a4)<br><sub>HYUNDAI SANTA FE 2022<br>5NMS44AL4........</sub>                | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                               | 4 routes, 291 segments  |                | - valid torque params: 291<br>- all lat active: 0                                   |
| [4983362ff1eaa006](https://useradmin.comma.ai/?onebox=4983362ff1eaa006)<br><sub>HYUNDAI SANTA FE 2022<br>5NMS6DAJ3........</sub>                | HYUNDAI Santa Fe 2022 🆚<br>Hyundai Santa Fe 2021-23                               | 16 routes, 260 segments |                | - all lat active: 75<br>- no input all lat active: 47<br>- valid torque params: 0   |
| [8446c299c2daac81](https://useradmin.comma.ai/?onebox=8446c299c2daac81)<br><sub>HYUNDAI PALISADE 2020<br>KM8R54HE5........</sub>                | HYUNDAI Palisade 2021 🆚<br>Hyundai Palisade 2020-22                               | 4 routes, 27 segments   |                | - valid torque params: 27<br>- all lat active: 0                                    |
| [e72c47871c46dde1](https://useradmin.comma.ai/?onebox=e72c47871c46dde1)<br><sub>HYUNDAI ELANTRA HYBRID 2021<br>KMHLN4AJ6........</sub>          | HYUNDAI Elantra Hybrid 2023 🆚<br>Hyundai Elantra Hybrid 2021-23                   | 1 routes, 4 segments    |                | - valid torque params: 4<br>- all lat active: 0                                     |
| [bade6cd7ae9bb600](https://useradmin.comma.ai/?onebox=bade6cd7ae9bb600)<br><sub>HYUNDAI PALISADE 2020<br>KM8R7DHE5........</sub>                | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                               | 5 routes, 34 segments   |                | - valid torque params: 34<br>- all lat active: 0                                    |
| [4e77fe0c3543bda2](https://useradmin.comma.ai/?onebox=4e77fe0c3543bda2)<br><sub>HYUNDAI SANTA FE PlUG-IN HYBRID 2022<br>KM8S6DA21........</sub> | HYUNDAI Santa Fe Plug-in Hybrid 2022 🆚<br>Hyundai Santa Fe Plug-in Hybrid 2022-23 | 9 routes, 163 segments  |                | - valid torque params: 163<br>- all lat active: 0                                   |
| [ee68f816a9d743ee](https://useradmin.comma.ai/?onebox=ee68f816a9d743ee)<br><sub>HYUNDAI SANTA FE 2019<br>5NMS33AD5........</sub>                | HYUNDAI Santa Fe 2019 🆚<br>Hyundai Santa Fe 2019-20                               | 17 routes, 239 segments |                | - valid torque params: 239<br>- all lat active: 2                                   |

Dongles to re-run category: `124457b31149107e dec47dd6b2d62da2 22901377be496047 0cb48444dd180504 9acd533a0f402e80 d3ef9b7c8fc585a3 6026525261343755 350d89a7bad7f485 028e246a2b8e3144 058ff2b75b84c4b6 83f627fc1e48c846 afe94a76bd8f5676 baf9c744e8d3aedc b64e506d0ccb4cdb ee6cdcf74e577f1f 0b2b36cf5a0789db e0c6f1daf613f27e 1c5b0ef6f666062d a204ef4b8bc8b99d 4ea994afc80a04cf 0c0bea43f366283f 73bcac1960e3f6a4 8446c299c2daac81 4983362ff1eaa006 e72c47871c46dde1 bade6cd7ae9bb600 4e77fe0c3543bda2 ee68f816a9d743ee`
</details>

## ⚠️ 1 dongles (1 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                       | Name from VIN 🆚 CarInfo                                                              | Segments              | Bad seg tags                                                                                          | Good seg tags             |
|:----------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------|:----------------------|:------------------------------------------------------------------------------------------------------|:--------------------------|
| [9fafce4de77b8cdf](https://useradmin.comma.ai/?onebox=9fafce4de77b8cdf)<br><sub>GENESIS G70 2020<br>KMTG74LE0........</sub> | GENESIS G70 2019 🆚<br>Genesis G70 2020-23<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 2 routes, 26 segments | - [FW not exact match: 1](https://useradmin.comma.ai/?onebox=9fafce4de77b8cdf%7C2024-03-11--19-26-30) | - valid torque params: 26 |

Dongles to re-run category: `9fafce4de77b8cdf`
</details>