### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -287,6 +287,7 @@ FW_VERSIONS = {
       b'\xf1\x00TM ESC \x02 101 \x08\x04 58910-S2GA0',
       b'\xf1\x00TM ESC \x02 103"\x07\x08 58910-S2GA0',
       b'\xf1\x00TM ESC \x03 101 \x08\x02 58910-S2DA0',
+      b'\xf1\x00TM ESC \x03 102!\x04\x03 58910-S2DA0',
       b'\xf1\x00TM ESC \x04 101 \x08\x04 58910-S2GA0',
       b'\xf1\x00TM ESC \x04 102!\x04\x05 58910-S2GA0',
       b'\xf1\x00TM ESC \x1e 102 \x08\x08 58910-S1DA0',
@@ -410,6 +411,7 @@ FW_VERSIONS = {
       b'\xf1\x00LX2_ SCC FHCUP      1.00 1.05 99110-S8100         ',
       b'\xf1\x00ON__ FCA FHCUP      1.00 1.01 99110-S9110         ',
       b'\xf1\x00ON__ FCA FHCUP      1.00 1.02 99110-S9100         ',
+      b'\xf1\x00ON__ FCA FHCUP      1.00 1.03 99110-S9100         ',
     ],
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00LX ESC \x01 103\x19\t\x10 58910-S8360',
@@ -499,6 +501,7 @@ FW_VERSIONS = {
       b'\xf1\x00DH__ SCC FHCUP      1.00 1.01 96400-B1110         ',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00DH  LKAS AT KOR LHD 1.01 1.01 95895-B1500 161014',
       b'\xf1\x00DH  LKAS AT KOR LHD 1.01 1.02 95895-B1500 170810',
       b'\xf1\x00DH  LKAS AT USA LHD 1.01 1.01 95895-B1500 161014',
       b'\xf1\x00DH  LKAS AT USA LHD 1.01 1.02 95895-B1500 170810',
@@ -585,6 +588,7 @@ FW_VERSIONS = {
       b'\xf1\x00DL ESC \x06 103"\x08\x06 58910-L3200',
       b'\xf1\x00DL ESC \t 100 \x06\x02 58910-L3800',
       b'\xf1\x00DL ESC \t 101 \x07\x02 58910-L3800',
+      b'\xf1\x00DL ESC \t 102"\x08\x10 58910-L3800',
     ],
   },
   CAR.KIA_K5_HEV_2020: {
@@ -735,9 +739,9 @@ FW_VERSIONS = {
       b'\xf1\x00DE  MDPS C 1.00 1.01 56310G5520\x00 4DEPC101',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00DEH MFC  AT KOR LHD 1.00 1.04 99211-G5000 190516',
       b'\xf1\x00DEH MFC  AT USA LHD 1.00 1.00 99211-G5500 210428',
       b'\xf1\x00DEH MFC  AT USA LHD 1.00 1.07 99211-G5000 201221',
-      b'\xf1\x00DEH MFC  AT KOR LHD 1.00 1.04 99211-G5000 190516',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00DEhe SCC FHCUP      1.00 1.00 99110-G5600         ',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 4 dongles (4 platforms) in last 3.0 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                            | Name from VIN 🆚 CarDocs                             | Segments                                   | Bad seg tags                                                                         | Good seg tags                                                                         |
|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------|:-------------------------------------------|:-------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------|
| [c6aaf0a8faa7f18b](https://useradmin.comma.ai/?onebox=c6aaf0a8faa7f18b)<br><sub>GENESIS_G80<br>KMHGL41DB........</sub>           | HYUNDAI  1988 🆚<br>Genesis G80 2018-19              | 11 routes,<br>453 segments<br>(7.5 hours)  | - [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=c6aaf0a8faa7f18b) | - valid torque params: 453<br>- all lat active: 125<br>- no input all lat active: 116 |
| [4983362ff1eaa006](https://useradmin.comma.ai/?onebox=4983362ff1eaa006)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS6DAJ3........</sub> | HYUNDAI Santa Fe 2022 🆚<br>Hyundai Santa Fe 2021-23 | 20 routes,<br>559 segments<br>(9.3 hours)  |                                                                                      | - valid torque params: 557<br>- all lat active: 126<br>- no input all lat active: 51  |
| [cc20792f8f18dee1](https://useradmin.comma.ai/?onebox=cc20792f8f18dee1)<br><sub>HYUNDAI_PALISADE<br>5XYP3DHCX........</sub>      | KIA Telluride 2021 🆚<br>Kia Telluride 2020-22       | 12 routes,<br>301 segments<br>(5.0 hours)  |                                                                                      | - valid torque params: 301<br>- all lat active: 63<br>- no input all lat active: 59   |
| [f05351cfc44b2d73](https://useradmin.comma.ai/?onebox=f05351cfc44b2d73)<br><sub>KIA_K5_2021<br>5XXG64J21........</sub>           | KIA K5 2023 🆚<br>Kia K5 2021-24                     | 24 routes,<br>622 segments<br>(10.4 hours) |                                                                                      | - valid torque params: 622<br>- all lat active: 185<br>- no input all lat active: 120 |

Dongles to re-run category: `c6aaf0a8faa7f18b 4983362ff1eaa006 cc20792f8f18dee1 f05351cfc44b2d73`
</details>

## ⏳️ 15 dongles (7 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                           | Segments                                  | Bad seg tags                                                                                         | Good seg tags                                                                       |
|:--------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|:------------------------------------------|:-----------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
| [5928b56aca881917](https://useradmin.comma.ai/?onebox=5928b56aca881917)<br><sub>HYUNDAI_SANTA_FE_2022<br>RLUSW81KD........</sub>      | None 🆚<br>None                                                                    | 10 routes,<br>69 segments<br>(1.1 hours)  | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=5928b56aca881917%7C2024-04-15--18-14-19) | - all lat active: 3                                                                 |
| [54115eef466ff9a8](https://useradmin.comma.ai/?onebox=54115eef466ff9a8)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS2DAJ0........</sub>      | HYUNDAI Santa Fe 2022 🆚<br>Hyundai Santa Fe 2021-23                               | 15 routes,<br>419 segments<br>(7.0 hours) |                                                                                                      | - valid torque params: 419<br>- all lat active: 53<br>- no input all lat active: 32 |
| [974bae894627779c](https://useradmin.comma.ai/?onebox=974bae894627779c)<br><sub>HYUNDAI_PALISADE<br>5XYP5DHC0........</sub>           | KIA Telluride 2020 🆚<br>Kia Telluride 2020-22                                     | 5 routes,<br>15 segments<br>(0.2 hours)   |                                                                                                      | - valid torque params: 15<br>- all lat active: 0                                    |
| [d075d065f1c27b98](https://useradmin.comma.ai/?onebox=d075d065f1c27b98)<br><sub>KIA_EV6<br>KNAC381CP........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                                      | 1 routes,<br>10 segments<br>(0.2 hours)   |                                                                                                      | - valid torque params: 3<br>- all lat active: 0                                     |
| [325d76d16fb6cb36](https://useradmin.comma.ai/?onebox=325d76d16fb6cb36)<br><sub>HYUNDAI_PALISADE<br>KM8R24HE8........</sub>           | HYUNDAI Palisade 2020 🆚<br>Hyundai Palisade 2020-22                               | 10 routes,<br>152 segments<br>(2.5 hours) |                                                                                                      | - valid torque params: 152<br>- all lat active: 57<br>- no input all lat active: 50 |
| [028e246a2b8e3144](https://useradmin.comma.ai/?onebox=028e246a2b8e3144)<br><sub>HYUNDAI_PALISADE<br>KM8R5DHEX........</sub>           | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                               | 3 routes,<br>26 segments<br>(0.4 hours)   |                                                                                                      | - valid torque params: 26<br>- all lat active: 0                                    |
| [b0e1cdf87262c7ad](https://useradmin.comma.ai/?onebox=b0e1cdf87262c7ad)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AG2........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                 | 1 routes,<br>74 segments<br>(1.2 hours)   |                                                                                                      | - valid torque params: 74<br>- all lat active: 26<br>- no input all lat active: 20  |
| [d61540bf6f3ff5fd](https://useradmin.comma.ai/?onebox=d61540bf6f3ff5fd)<br><sub>HYUNDAI_SANTA_FE_PHEV_2022<br>KM8S6DA20........</sub> | HYUNDAI Santa Fe Plug-in Hybrid 2022 🆚<br>Hyundai Santa Fe Plug-in Hybrid 2022-23 | 3 routes,<br>58 segments<br>(1.0 hours)   |                                                                                                      | - valid torque params: 58<br>- all lat active: 6<br>- no input all lat active: 2    |
| [ab43edcde8ddb9db](https://useradmin.comma.ai/?onebox=ab43edcde8ddb9db)<br><sub>HYUNDAI_PALISADE<br>000000000........</sub>           | None 🆚<br>None                                                                    | 1 routes,<br>17 segments<br>(0.3 hours)   |                                                                                                      | - valid torque params: 17<br>- all lat active: 8<br>- no input all lat active: 7    |
| [b848ccad8ec7b386](https://useradmin.comma.ai/?onebox=b848ccad8ec7b386)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS14AJ2........</sub>      | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                               | 12 routes,<br>136 segments<br>(2.3 hours) |                                                                                                      | - valid torque params: 136<br>- all lat active: 25<br>- no input all lat active: 16 |
| [350d89a7bad7f485](https://useradmin.comma.ai/?onebox=350d89a7bad7f485)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AG6........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                 | 9 routes,<br>98 segments<br>(1.6 hours)   |                                                                                                      | - valid torque params: 98<br>- all lat active: 2<br>- no input all lat active: 2    |
| [2b083a4ff77c6828](https://useradmin.comma.ai/?onebox=2b083a4ff77c6828)<br><sub>KIA_K5_2021<br>5XXG44J83........</sub>                | KIA K5 2023 🆚<br>Kia K5 2021-24                                                   | 4 routes,<br>17 segments<br>(0.3 hours)   |                                                                                                      | - valid torque params: 17<br>- all lat active: 0                                    |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>            | None 🆚<br>None                                                                    | 16 routes,<br>223 segments<br>(3.7 hours) |                                                                                                      | - valid torque params: 222<br>- all lat active: 8<br>- no input all lat active: 3   |
| [9acd533a0f402e80](https://useradmin.comma.ai/?onebox=9acd533a0f402e80)<br><sub>HYUNDAI_ELANTRA_2021<br>5NPLS4AG8........</sub>       | HYUNDAI Elantra 2022 🆚<br>Hyundai Elantra 2021-23                                 | 3 routes,<br>55 segments<br>(0.9 hours)   |                                                                                                      | - valid torque params: 55<br>- all lat active: 0                                    |
| [2d2ed4682dfe5a78](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)<br><sub>KIA_EV6<br>KNDC3DLC3........</sub>                    | KIA EV6 2023 🆚<br>Kia EV6 (with HDA II) 2022-23                                   | 1 routes,<br>2 segments<br>(0.0 hours)    | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)                | - all lat active: 0                                                                 |

Dongles to re-run category: `325d76d16fb6cb36 ab43edcde8ddb9db 028e246a2b8e3144 54115eef466ff9a8 b848ccad8ec7b386 5928b56aca881917 350d89a7bad7f485 974bae894627779c b0e1cdf87262c7ad 2b083a4ff77c6828 22901377be496047 2d2ed4682dfe5a78 d61540bf6f3ff5fd 9acd533a0f402e80 d075d065f1c27b98`
</details>

## ⚠️ 0 dongles (0 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN   | Name from VIN 🆚 CarDocs   | Segments   | Bad seg tags   | Good seg tags   |
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>