### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/chrysler/fingerprints.py
+++ b/selfdrive/car/chrysler/fingerprints.py
@@ -409,6 +409,7 @@ FW_VERSIONS = {
       b'68527403AD',
       b'68546047AF',
       b'68631938AA',
+      b'68631940AA',
       b'68631942AA',
     ],
     (Ecu.srs, 0x744, None): [
@@ -530,6 +531,7 @@ FW_VERSIONS = {
       b'68586101AA ',
       b'68586105AB ',
       b'68629922AC ',
+      b'68629925AC ',
       b'68629926AC ',
     ],
     (Ecu.transmission, 0x7e1, None): [

--- a/selfdrive/car/subaru/fingerprints.py
+++ b/selfdrive/car/subaru/fingerprints.py
@@ -149,6 +149,7 @@ FW_VERSIONS = {
       b'\xe3\xf5C\x00\x00',
       b'\xe3\xf5F\x00\x00',
       b'\xe3\xf5G\x00\x00',
+      b'\xe4\xe5\x021\x00',
       b'\xe4\xe5\x061\x00',
       b'\xe4\xf5\x02\x00\x00',
       b'\xe4\xf5\x07\x00\x00',
@@ -196,6 +197,7 @@ FW_VERSIONS = {
       b'\xe6"fp\x07',
       b'\xf3"f@\x07',
       b'\xf3"fp\x07',
+      b'\xf3"fr\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xe6\xf5\x04\x00\x00',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 3 dongles (3 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                  | Name from VIN 🆚 CarDocs                             | Segments                                   | Bad seg tags   | Good seg tags                                                                        |
|:---------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------|:-------------------------------------------|:---------------|:-------------------------------------------------------------------------------------|
| [9f9dda362178312b](https://useradmin.comma.ai/?onebox=9f9dda362178312b)<br><sub>SUBARU IMPREZA LIMITED 2019<br>000000000........</sub> | None 🆚<br>None                                      | 14 routes,<br>623 segments<br>(10.4 hours) |                | - valid torque params: 623<br>- all lat active: 249<br>- no input all lat active: 94 |
| [42dc6bc38c9931ce](https://useradmin.comma.ai/?onebox=42dc6bc38c9931ce)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHT1........</sub>            | RAM 1500 2024 🆚<br>Ram 1500 2019-24                 | 28 routes,<br>442 segments<br>(7.4 hours)  |                | - all lat active: 74<br>- no input all lat active: 44<br>- valid torque params: 408  |
| [b0af8f0d66998715](https://useradmin.comma.ai/?onebox=b0af8f0d66998715)<br><sub>SUBARU IMPREZA SPORT 2020<br>JF2GTHNC3........</sub>   | SUBARU Crosstrek 2023 🆚<br>Subaru Crosstrek 2020-23 | 31 routes,<br>564 segments<br>(9.4 hours)  |                | - valid torque params: 550<br>- all lat active: 146<br>- no input all lat active: 76 |

Dongles to re-run category: `42dc6bc38c9931ce 9f9dda362178312b b0af8f0d66998715`
</details>

## ⏳️ 46 dongles (26 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                  | Name from VIN 🆚 CarDocs                                             | Segments                                     | Bad seg tags                                                                                         | Good seg tags                                                                         |
|:---------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------|
| [3a02fd61e8d654b9](https://useradmin.comma.ai/?onebox=3a02fd61e8d654b9)<br><sub>HONDA ODYSSEY 2018<br>5FNRL6H89........</sub>          | HONDA Odyssey 2020 🆚<br>Honda Odyssey 2018-20                       | 39 routes,<br>455 segments<br>(7.6 hours)    |                                                                                                      | - valid torque params: 455<br>- all lat active: 0                                     |
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFCG8........</sub> | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18           | 12 routes,<br>256 segments<br>(4.3 hours)    |                                                                                                      | - valid torque params: 256<br>- all lat active: 6<br>- no input all lat active: 1     |
| [030e7d18f7c4ea9d](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHTX........</sub>            | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                 | 69 routes,<br>1365 segments<br>(22.8 hours)  |                                                                                                      | - valid torque params: 1365<br>- all lat active: 4                                    |
| [8d348ed0b5cb0e07](https://useradmin.comma.ai/?onebox=8d348ed0b5cb0e07)<br><sub>RAM 1500 5TH GEN<br>1C6SRFMT5........</sub>            | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 19 routes,<br>190 segments<br>(3.2 hours)    | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=8d348ed0b5cb0e07%7C2024-02-25--10-07-57) | - valid torque params: 158<br>- all lat active: 15<br>- no input all lat active: 7    |
| [608b7c507e205a58](https://useradmin.comma.ai/?onebox=608b7c507e205a58)<br><sub>RAM 1500 5TH GEN<br>1C6RREHT4........</sub>            | RAM 1500 2020 🆚<br>Ram 1500 2019-24                                 | 23 routes,<br>340 segments<br>(5.7 hours)    |                                                                                                      | - valid torque params: 322<br>- all lat active: 36<br>- no input all lat active: 15   |
| [94e347d5008dd03c](https://useradmin.comma.ai/?onebox=94e347d5008dd03c)<br><sub>SUBARU IMPREZA SPORT 2020<br>JF2GTAMC9........</sub>   | SUBARU Crosstrek 2020 🆚<br>Subaru Crosstrek 2020-23                 | 6 routes,<br>29 segments<br>(0.5 hours)      |                                                                                                      | - valid torque params: 26<br>- all lat active: 1<br>- no input all lat active: 1      |
| [326e3f80dd5fcbfc](https://useradmin.comma.ai/?onebox=326e3f80dd5fcbfc)<br><sub>HYUNDAI IONIQ 5 2022<br>000000000........</sub>        | None 🆚<br>None                                                      | 4 routes,<br>105 segments<br>(1.8 hours)     |                                                                                                      | - valid torque params: 78<br>- all lat active: 11<br>- no input all lat active: 4     |
| [a86f8c298cdf3887](https://useradmin.comma.ai/?onebox=a86f8c298cdf3887)<br><sub>LEXUS NX 2018<br>JTJBARBZ9........</sub>               | LEXUS NX 2019 🆚<br>Lexus NX 2018-19                                 | 41 routes,<br>450 segments<br>(7.5 hours)    |                                                                                                      | - valid torque params: 450<br>- all lat active: 45<br>- no input all lat active: 34   |
| [eb5e7e06aa56a47f](https://useradmin.comma.ai/?onebox=eb5e7e06aa56a47f)<br><sub>HONDA INSIGHT 2019<br>19XZE4F92........</sub>          | HONDA Insight Hybrid 2022 🆚<br>Honda Insight 2019-22                | 2 routes,<br>3 segments<br>(0.1 hours)       | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=eb5e7e06aa56a47f)                | - all lat active: 0                                                                   |
| [e3a0c1d2ac034212](https://useradmin.comma.ai/?onebox=e3a0c1d2ac034212)<br><sub>SUBARU OUTBACK 6TH GEN<br>4S4BTADC0........</sub>      | SUBARU Outback 2021 🆚<br>Subaru Outback 2020-22                     | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - all lat active: 0                                                                   |
| [3b1e68fd17e4d223](https://useradmin.comma.ai/?onebox=3b1e68fd17e4d223)<br><sub>LEXUS ES 2019<br>JTHB21B15........</sub>               | None 🆚<br>None                                                      | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - all lat active: 0                                                                   |
| [4a816f1ed461f594](https://useradmin.comma.ai/?onebox=4a816f1ed461f594)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHM9........</sub>            | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 31 routes,<br>297 segments<br>(5.0 hours)    |                                                                                                      | - all lat active: 0                                                                   |
| [53da2df25520d1c7](https://useradmin.comma.ai/?onebox=53da2df25520d1c7)<br><sub>KIA EV6 2022<br>000000000........</sub>                | None 🆚<br>None                                                      | 2 routes,<br>11 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 0                                                                   |
| [25e52fc98275aa65](https://useradmin.comma.ai/?onebox=25e52fc98275aa65)<br><sub>JEEP GRAND CHEROKEE V6 2018<br>1C4RJFBG7........</sub> | JEEP Grand Cherokee 2018 🆚<br>Jeep Grand Cherokee 2016-18           | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - all lat active: 0                                                                   |
| [da7d4c7c00a25e08](https://useradmin.comma.ai/?onebox=da7d4c7c00a25e08)<br><sub>HONDA PILOT 2017<br>5FNYF8H0X........</sub>            | HONDA Passport 2021 🆚<br>Honda Passport 2019-23                     | 7 routes,<br>454 segments<br>(7.6 hours)     |                                                                                                      | - valid torque params: 454<br>- all lat active: 107<br>- no input all lat active: 1   |
| [c8a98e58647765ad](https://useradmin.comma.ai/?onebox=c8a98e58647765ad)<br><sub>RAM 1500 5TH GEN<br>1C6SRFU92........</sub>            | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                 | 6 routes,<br>129 segments<br>(2.1 hours)     |                                                                                                      | - valid torque params: 106<br>- all lat active: 14<br>- no input all lat active: 5    |
| [3ac08dbb3c723ffb](https://useradmin.comma.ai/?onebox=3ac08dbb3c723ffb)<br><sub>HONDA PILOT 2017<br>5FNYF5H59........</sub>            | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                           | 3 routes,<br>14 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 5<br>- no input all lat active: 1                                   |
| [9bac7575fac62395](https://useradmin.comma.ai/?onebox=9bac7575fac62395)<br><sub>HONDA PILOT 2017<br>5FNYF6H93........</sub>            | HONDA Pilot 2018 🆚<br>Honda Pilot 2016-22                           | 179 routes,<br>1982 segments<br>(33.0 hours) |                                                                                                      | - valid torque params: 1956<br>- all lat active: 189<br>- no input all lat active: 12 |
| [90e19871a5f0753d](https://useradmin.comma.ai/?onebox=90e19871a5f0753d)<br><sub>TOYOTA HIGHLANDER 2017<br>5TDJGRFH0........</sub>      | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19 | 4 routes,<br>65 segments<br>(1.1 hours)      |                                                                                                      | - valid torque params: 48<br>- all lat active: 10<br>- no input all lat active: 7     |
| [2653b4b309780e1a](https://useradmin.comma.ai/?onebox=2653b4b309780e1a)<br><sub>TOYOTA COROLLA TSS2 2019<br>000000000........</sub>    | None 🆚<br>None                                                      | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - valid torque params: 1<br>- all lat active: 0                                       |
| [5dccf40c6d8d548e](https://useradmin.comma.ai/?onebox=5dccf40c6d8d548e)<br><sub>HONDA PILOT 2017<br>5FNYF6H38........</sub>            | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                           | 3 routes,<br>92 segments<br>(1.5 hours)      |                                                                                                      | - valid torque params: 72<br>- all lat active: 15<br>- no input all lat active: 8     |
| [a235b6d8ca3b6544](https://useradmin.comma.ai/?onebox=a235b6d8ca3b6544)<br><sub>LEXUS IS 2023<br>JTHGZ1E2X........</sub>               | LEXUS IS 2022 🆚<br>Lexus IS 2022-23                                 | 6 routes,<br>58 segments<br>(1.0 hours)      |                                                                                                      | - all lat active: 9<br>- no input all lat active: 1                                   |
| [b892faae698fe7ca](https://useradmin.comma.ai/?onebox=b892faae698fe7ca)<br><sub>TOYOTA COROLLA TSS2 2019<br>JTHY65BHX........</sub>    | None 🆚<br>None                                                      | 1 routes,<br>66 segments<br>(1.1 hours)      |                                                                                                      | - all lat active: 1                                                                   |
| [a092febc6c1ef5e8](https://useradmin.comma.ai/?onebox=a092febc6c1ef5e8)<br><sub>HONDA CR-V 2017<br>7FARW2H57........</sub>             | HONDA CR-V 2022 🆚<br>Honda CR-V 2017-22                             | 10 routes,<br>147 segments<br>(2.5 hours)    |                                                                                                      | - valid torque params: 144<br>- all lat active: 15<br>- no input all lat active: 5    |
| [b3ac0e70e5b188a7](https://useradmin.comma.ai/?onebox=b3ac0e70e5b188a7)<br><sub>TOYOTA RAV4 2023<br>JTMY1RFV1........</sub>            | TOYOTA RAV4 2023 🆚<br>Toyota RAV4 2023-24                           | 5 routes,<br>29 segments<br>(0.5 hours)      |                                                                                                      | - all lat active: 1<br>- no input all lat active: 1                                   |
| [7de93c2ac463075e](https://useradmin.comma.ai/?onebox=7de93c2ac463075e)<br><sub>HONDA ACCORD 2018<br>1HGCV1F40........</sub>           | HONDA Accord 2021 🆚<br>Honda Accord 2018-22                         | 6 routes,<br>51 segments<br>(0.8 hours)      |                                                                                                      | - all lat active: 10<br>- no input all lat active: 8<br>- valid torque params: 10     |
| [22dbdf2ca2bce921](https://useradmin.comma.ai/?onebox=22dbdf2ca2bce921)<br><sub>HONDA PILOT 2017<br>5FNYF6H5X........</sub>            | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                           | 212 routes,<br>1797 segments<br>(29.9 hours) |                                                                                                      | - valid torque params: 1797<br>- all lat active: 22<br>- no input all lat active: 4   |
| [46fd83d2d64f69e7](https://useradmin.comma.ai/?onebox=46fd83d2d64f69e7)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHT7........</sub>            | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                 | 24 routes,<br>206 segments<br>(3.4 hours)    |                                                                                                      | - valid torque params: 197<br>- all lat active: 16<br>- no input all lat active: 13   |
| [d9e0f65392d02c7c](https://useradmin.comma.ai/?onebox=d9e0f65392d02c7c)<br><sub>TOYOTA CAMRY 2021<br>JTNB23HK4........</sub>           | None 🆚<br>None                                                      | 14 routes,<br>249 segments<br>(4.2 hours)    |                                                                                                      | - valid torque params: 200<br>- all lat active: 24<br>- no input all lat active: 7    |
| [3924ecbd385d35b4](https://useradmin.comma.ai/?onebox=3924ecbd385d35b4)<br><sub>LEXUS RX 2020<br>000000000........</sub>               | None 🆚<br>None                                                      | 5 routes,<br>80 segments<br>(1.3 hours)      |                                                                                                      | - all lat active: 2                                                                   |
| [de5d8c07f52dbb73](https://useradmin.comma.ai/?onebox=de5d8c07f52dbb73)<br><sub>HYUNDAI IONIQ 5 2022<br>000000000........</sub>        | None 🆚<br>None                                                      | 7 routes,<br>178 segments<br>(3.0 hours)     |                                                                                                      | - valid torque params: 178<br>- all lat active: 29<br>- no input all lat active: 20   |
| [34b4b14d5a5f8d56](https://useradmin.comma.ai/?onebox=34b4b14d5a5f8d56)<br><sub>RAM 1500 5TH GEN<br>1C6SRFET9........</sub>            | RAM 1500 2020 🆚<br>Ram 1500 2019-24                                 | 3 routes,<br>61 segments<br>(1.0 hours)      |                                                                                                      | - all lat active: 22<br>- no input all lat active: 13<br>- valid torque params: 52    |
| [3678d13114bf2ce4](https://useradmin.comma.ai/?onebox=3678d13114bf2ce4)<br><sub>NISSAN LEAF 2018<br>1N4AZ1CV9........</sub>            | NISSAN Leaf Hatchback 2021 🆚<br>Nissan Leaf 2018-23                 | 1 routes,<br>7 segments<br>(0.1 hours)       | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=3678d13114bf2ce4)                | - all lat active: 0                                                                   |
| [a830fccaa7fc265d](https://useradmin.comma.ai/?onebox=a830fccaa7fc265d)<br><sub>SUBARU IMPREZA LIMITED 2019<br>JF2GTAMC0........</sub> | SUBARU Crosstrek 2019 🆚<br>Subaru Crosstrek 2018-19                 | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - valid torque params: 1<br>- all lat active: 0                                       |
| [5067e70bf087ef1c](https://useradmin.comma.ai/?onebox=5067e70bf087ef1c)<br><sub>SUBARU IMPREZA SPORT 2020<br>4S3GTAM65........</sub>   | SUBARU Impreza Hatchback 2020 🆚<br>Subaru Impreza 2020-22           | 4 routes,<br>8 segments<br>(0.1 hours)       | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=5067e70bf087ef1c)                | - all lat active: 0                                                                   |
| [1c4fc0356cdd79fb](https://useradmin.comma.ai/?onebox=1c4fc0356cdd79fb)<br><sub>CHRYSLER PACIFICA 2020<br>2C4RC3BG8........</sub>      | CHRYSLER Pacifica 2023 🆚<br>Chrysler Pacifica 2021-23               | 15 routes,<br>174 segments<br>(2.9 hours)    |                                                                                                      | - valid torque params: 154<br>- all lat active: 17<br>- no input all lat active: 12   |
| [007f1416e7b53998](https://useradmin.comma.ai/?onebox=007f1416e7b53998)<br><sub>TOYOTA RAV4 2023<br>2T3N1RFV0........</sub>            | TOYOTA RAV4 2024 🆚<br>Toyota RAV4 2023-24                           | 1 routes,<br>6 segments<br>(0.1 hours)       |                                                                                                      | - all lat active: 0                                                                   |
| [d034c46e95362cf1](https://useradmin.comma.ai/?onebox=d034c46e95362cf1)<br><sub>SUBARU IMPREZA SPORT 2020<br>4S3GKAB67........</sub>   | SUBARU Impreza 2020 🆚<br>Subaru Impreza 2020-22                     | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - all lat active: 0                                                                   |
| [a6de4da35307d7b8](https://useradmin.comma.ai/?onebox=a6de4da35307d7b8)<br><sub>RAM 1500 5TH GEN<br>1C6SRFHT4........</sub>            | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 12 routes,<br>205 segments<br>(3.4 hours)    |                                                                                                      | - valid torque params: 205<br>- all lat active: 20                                    |
| [20441008e70112d0](https://useradmin.comma.ai/?onebox=20441008e70112d0)<br><sub>TOYOTA CAMRY 2018<br>JTNBF3HK4........</sub>           | None 🆚<br>None                                                      | 3 routes,<br>11 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 1<br>- no input all lat active: 1                                   |
| [0ad7facc77922c3e](https://useradmin.comma.ai/?onebox=0ad7facc77922c3e)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMACD0........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21                       | 12 routes,<br>201 segments<br>(3.4 hours)    |                                                                                                      | - all lat active: 61<br>- no input all lat active: 19<br>- valid torque params: 0     |
| [a736222ad5f6aabd](https://useradmin.comma.ai/?onebox=a736222ad5f6aabd)<br><sub>CHRYSLER PACIFICA 2020<br>2C4RC1FGX........</sub>      | CHRYSLER Pacifica 2021 🆚<br>Chrysler Pacifica 2021-23               | 9 routes,<br>210 segments<br>(3.5 hours)     |                                                                                                      | - valid torque params: 202<br>- all lat active: 43<br>- no input all lat active: 29   |
| [fb6065fa2bd50916](https://useradmin.comma.ai/?onebox=fb6065fa2bd50916)<br><sub>LEXUS RX 2016<br>JTJGZKCA4........</sub>               | LEXUS RX 2019 🆚<br>Lexus RX 2017-19                                 | 2 routes,<br>3 segments<br>(0.1 hours)       |                                                                                                      | - valid torque params: 2<br>- all lat active: 0                                       |
| [3aea2f5376c16768](https://useradmin.comma.ai/?onebox=3aea2f5376c16768)<br><sub>TOYOTA PRIUS TSS2 2021<br>JTDKAMFP2........</sub>      | TOYOTA Prius Prime 2022 🆚<br>Toyota Prius Prime 2021-22             | 5 routes,<br>31 segments<br>(0.5 hours)      |                                                                                                      | - valid torque params: 31<br>- all lat active: 0                                      |
| [a28b99df3908f6d8](https://useradmin.comma.ai/?onebox=a28b99df3908f6d8)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMAMD3........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21                       | 2 routes,<br>29 segments<br>(0.5 hours)      |                                                                                                      | - all lat active: 9<br>- no input all lat active: 4                                   |
| [30f476405b31e063](https://useradmin.comma.ai/?onebox=30f476405b31e063)<br><sub>TOYOTA HIGHLANDER 2017<br>5TDDGRFH0........</sub>      | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19 | 36 routes,<br>565 segments<br>(9.4 hours)    |                                                                                                      | - valid torque params: 532<br>- all lat active: 14<br>- no input all lat active: 4    |

Dongles to re-run category: `3924ecbd385d35b4 b892faae698fe7ca 20441008e70112d0 2653b4b309780e1a a092febc6c1ef5e8 7de93c2ac463075e a6de4da35307d7b8 46fd83d2d64f69e7 e3a0c1d2ac034212 53da2df25520d1c7 326e3f80dd5fcbfc 1c4fc0356cdd79fb 3aea2f5376c16768 c8a98e58647765ad 608b7c507e205a58 007f1416e7b53998 3ac08dbb3c723ffb a28b99df3908f6d8 5dccf40c6d8d548e de5d8c07f52dbb73 3678d13114bf2ce4 a830fccaa7fc265d 0ad7facc77922c3e 8d348ed0b5cb0e07 a86f8c298cdf3887 9bac7575fac62395 d9e0f65392d02c7c 25e52fc98275aa65 34b4b14d5a5f8d56 b3ac0e70e5b188a7 3b1e68fd17e4d223 c88f65eeaee4003a eb5e7e06aa56a47f 30f476405b31e063 94e347d5008dd03c 22dbdf2ca2bce921 5067e70bf087ef1c a736222ad5f6aabd 3a02fd61e8d654b9 030e7d18f7c4ea9d 4a816f1ed461f594 d034c46e95362cf1 fb6065fa2bd50916 90e19871a5f0753d a235b6d8ca3b6544 da7d4c7c00a25e08`
</details>

## ⚠️ 41 dongles (18 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                  | Name from VIN 🆚 CarDocs                                                                                  | Segments                                     | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Good seg tags                                                                          |
|:---------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [fc4d8f4e5f8b353a](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a)<br><sub>HONDA CIVIC 2022<br>19XFL1H88........</sub>            | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                            | 101 routes,<br>1585 segments<br>(26.4 hours) | - [missing ECU FW: 1400](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-02-29--07-25-59)<br>- [spotty FW: 1400](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-02-29--07-25-59)                                                                                                                                                                                                                                                                                                          | - valid torque params: 1585<br>- all lat active: 487<br>- no input all lat active: 306 |
| [1e5a973a279c1a95](https://useradmin.comma.ai/?onebox=1e5a973a279c1a95)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMAPD8........</sub>  | SUBARU Ascent 2021 🆚<br>Subaru Ascent 2019-21                                                            | 153 routes,<br>2674 segments<br>(44.6 hours) | - [spotty FW: 1387](https://useradmin.comma.ai/?onebox=1e5a973a279c1a95%7C2024-03-14--15-22-46)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=1e5a973a279c1a95%7C2024-02-25--12-12-47)                                                                                                                                                                                                                                                                                                                | - all lat active: 461<br>- valid torque params: 2674<br>- no input all lat active: 278 |
| [cafb4800ec0a7892](https://useradmin.comma.ai/?onebox=cafb4800ec0a7892)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMAPD1........</sub>  | SUBARU Ascent 2020 🆚<br>Subaru Ascent 2019-21                                                            | 162 routes,<br>1286 segments<br>(21.4 hours) | - [spotty FW: 754](https://useradmin.comma.ai/?onebox=cafb4800ec0a7892%7C2024-03-04--14-32-43)<br>- [car faulted: 4](https://useradmin.comma.ai/?onebox=cafb4800ec0a7892%7C2024-02-28--19-14-13)                                                                                                                                                                                                                                                                                                                 | - valid torque params: 1286<br>- all lat active: 26<br>- no input all lat active: 19   |
| [790069c4b2f63926](https://useradmin.comma.ai/?onebox=790069c4b2f63926)<br><sub>TOYOTA PRIUS 2017<br>JTDKARFU5........</sub>           | TOYOTA Prius 2016 🆚<br>Toyota Prius 2016                                                                 | 23 routes,<br>1030 segments<br>(17.2 hours)  | - [invalid FW: 982](https://useradmin.comma.ai/?onebox=790069c4b2f63926%7C2024-03-08--06-56-54)<br>- [missing ECU FW: 48](https://useradmin.comma.ai/?onebox=790069c4b2f63926%7C2024-02-17--20-47-00)<br>- [spotty FW: 48](https://useradmin.comma.ai/?onebox=790069c4b2f63926%7C2024-02-17--20-47-00)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=790069c4b2f63926%7C2024-02-17--20-47-00)<br>- [CAN invalid: 1](https://useradmin.comma.ai/?onebox=790069c4b2f63926%7C2024-03-06--19-37-10) | - valid torque params: 1030<br>- all lat active: 216<br>- no input all lat active: 186 |
| [698b51bf70bd1fa8](https://useradmin.comma.ai/?onebox=698b51bf70bd1fa8)<br><sub>HONDA CIVIC 2022<br>19XFL1H80........</sub>            | HONDA Civic Hatchback 2022 🆚<br>Honda Civic Hatchback 2022-23                                            | 62 routes,<br>1085 segments<br>(18.1 hours)  | - [missing ECU FW: 1034](https://useradmin.comma.ai/?onebox=698b51bf70bd1fa8%7C2024-02-18--16-28-40)<br>- [spotty FW: 51](https://useradmin.comma.ai/?onebox=698b51bf70bd1fa8%7C2024-02-22--17-33-05)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=698b51bf70bd1fa8%7C2024-02-18--16-28-40)                                                                                                                                                                                                   | - valid torque params: 1085                                                            |
| [2024aefc4c4f766c](https://useradmin.comma.ai/?onebox=2024aefc4c4f766c)<br><sub>MAZDA CX-9 2021<br>JM3TCBAYX........</sub>             | MAZDA CX-9 2023 🆚<br>Mazda CX-9 2021-23                                                                  | 73 routes,<br>1273 segments<br>(21.2 hours)  | - [spotty FW: 832](https://useradmin.comma.ai/?onebox=2024aefc4c4f766c%7C2024-02-21--18-02-29)<br>- [car faulted: 2](https://useradmin.comma.ai/?onebox=2024aefc4c4f766c%7C2024-02-18--15-54-11)                                                                                                                                                                                                                                                                                                                 | - all lat active: 322<br>- no input all lat active: 195<br>- valid torque params: 1273 |
| [3a7b42f8f856b809](https://useradmin.comma.ai/?onebox=3a7b42f8f856b809)<br><sub>CHRYSLER PACIFICA 2018<br>2C4RC1GG2........</sub>      | CHRYSLER Pacifica 2017 🆚<br>Chrysler Pacifica 2017-18                                                    | 40 routes,<br>1091 segments<br>(18.2 hours)  | - [car faulted: 6](https://useradmin.comma.ai/?onebox=3a7b42f8f856b809%7C2024-03-11--09-54-04)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 1085<br>- all lat active: 318<br>- no input all lat active: 134 |
| [ad6511c266bbf3ad](https://useradmin.comma.ai/?onebox=ad6511c266bbf3ad)<br><sub>SUBARU IMPREZA LIMITED 2019<br>JF2GTANC7........</sub> | SUBARU Crosstrek 2019 🆚<br>Subaru Crosstrek 2018-19                                                      | 74 routes,<br>1329 segments<br>(22.1 hours)  | - [spotty FW: 905](https://useradmin.comma.ai/?onebox=ad6511c266bbf3ad%7C2024-02-19--12-35-31)<br>- [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=ad6511c266bbf3ad%7C2024-03-17--16-50-03)                                                                                                                                                                                                                                                                                                              | - valid torque params: 1321<br>- all lat active: 260<br>- no input all lat active: 105 |
| [aca6c37cdceab59a](https://useradmin.comma.ai/?onebox=aca6c37cdceab59a)<br><sub>SUBARU FORESTER 2019<br>JF2SKACC0........</sub>        | SUBARU Forester 2019 🆚<br>Subaru Forester 2019-21                                                        | 32 routes,<br>857 segments<br>(14.3 hours)   | - [spotty FW: 11](https://useradmin.comma.ai/?onebox=aca6c37cdceab59a%7C2024-03-02--01-07-34)                                                                                                                                                                                                                                                                                                                                                                                                                    | - all lat active: 579<br>- no input all lat active: 500<br>- valid torque params: 857  |
| [53ecc962c9d86d50](https://useradmin.comma.ai/?onebox=53ecc962c9d86d50)<br><sub>TOYOTA PRIUS TSS2 2021<br>000000000........</sub>      | None 🆚<br>None                                                                                           | 4 routes,<br>267 segments<br>(4.5 hours)     | - [invalid FW: 267](https://useradmin.comma.ai/?onebox=53ecc962c9d86d50%7C2024-03-10--13-08-08)                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 267<br>- all lat active: 91<br>- no input all lat active: 63    |
| [7a4ef9e9f44480ee](https://useradmin.comma.ai/?onebox=7a4ef9e9f44480ee)<br><sub>SUBARU IMPREZA LIMITED 2019<br>JF2GTAMC7........</sub> | SUBARU Crosstrek 2019 🆚<br>Subaru Crosstrek 2018-19                                                      | 18 routes,<br>177 segments<br>(3.0 hours)    | - [spotty FW: 46](https://useradmin.comma.ai/?onebox=7a4ef9e9f44480ee%7C2024-03-03--10-25-27)                                                                                                                                                                                                                                                                                                                                                                                                                    | - valid torque params: 50                                                              |
| [b952ae0f9a30d194](https://useradmin.comma.ai/?onebox=b952ae0f9a30d194)<br><sub>MAZDA CX-5 2022<br>JM3KFBXYX........</sub>             | MAZDA CX-5 2022 🆚<br>Mazda CX-5 2022-24                                                                  | 5 routes,<br>145 segments<br>(2.4 hours)     | - [spotty FW: 1](https://useradmin.comma.ai/?onebox=b952ae0f9a30d194%7C2024-03-13--13-30-42)                                                                                                                                                                                                                                                                                                                                                                                                                     | - valid torque params: 110<br>- all lat active: 62<br>- no input all lat active: 35    |
| [7c4c77e442583f42](https://useradmin.comma.ai/?onebox=7c4c77e442583f42)<br><sub>TOYOTA PRIUS TSS2 2021<br>JTDKA3FP6........</sub>      | None 🆚<br>None                                                                                           | 6 routes,<br>193 segments<br>(3.2 hours)     | - [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=7c4c77e442583f42%7C2024-03-17--07-56-53)<br>- [spotty FW: 1](https://useradmin.comma.ai/?onebox=7c4c77e442583f42%7C2024-03-17--07-56-53)                                                                                                                                                                                                                                                                                                                | - valid torque params: 180<br>- all lat active: 24<br>- no input all lat active: 17    |
| [319908404e59fb49](https://useradmin.comma.ai/?onebox=319908404e59fb49)<br><sub>TOYOTA PRIUS 2017<br>JTDKBRFU6........</sub>           | TOYOTA Prius 2018 🆚<br>Toyota Prius 2017-20                                                              | 6 routes,<br>181 segments<br>(3.0 hours)     | - [invalid FW: 181](https://useradmin.comma.ai/?onebox=319908404e59fb49%7C2024-02-18--21-03-08)                                                                                                                                                                                                                                                                                                                                                                                                                  |                                                                                        |
| [a1459329fb4cd970](https://useradmin.comma.ai/?onebox=a1459329fb4cd970)<br><sub>TOYOTA COROLLA TSS2 2019<br>JTNC4RBE6........</sub>    | TOYOTA Corolla Hatchback 2020 🆚<br>Toyota Corolla Hatchback 2019-22                                      | 1 routes,<br>2 segments<br>(0.0 hours)       | - [CAN invalid: 1](https://useradmin.comma.ai/?onebox=a1459329fb4cd970%7C2024-03-12--16-46-04)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 2                                                               |
| [c04a3b5508dc7bc3](https://useradmin.comma.ai/?onebox=c04a3b5508dc7bc3)<br><sub>HONDA ACCORD 2018<br>1HGCV2F90........</sub>           | HONDA Accord 2021 🆚<br>Honda Accord 2018-22                                                              | 49 routes,<br>548 segments<br>(9.1 hours)    | - [spotty FW: 52](https://useradmin.comma.ai/?onebox=c04a3b5508dc7bc3%7C2024-03-16--17-19-20)                                                                                                                                                                                                                                                                                                                                                                                                                    | - valid torque params: 542<br>- all lat active: 5<br>- no input all lat active: 2      |
| [86921fe3be40b1e9](https://useradmin.comma.ai/?onebox=86921fe3be40b1e9)<br><sub>SUBARU IMPREZA LIMITED 2019<br>JF2GTADC7........</sub> | SUBARU Crosstrek 2018 🆚<br>Subaru Crosstrek 2018-19                                                      | 46 routes,<br>886 segments<br>(14.8 hours)   | - [spotty FW: 567](https://useradmin.comma.ai/?onebox=86921fe3be40b1e9%7C2024-02-24--11-04-40)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 886<br>- all lat active: 191<br>- no input all lat active: 129  |
| [ca5d1d3f94ea106b](https://useradmin.comma.ai/?onebox=ca5d1d3f94ea106b)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD6........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21                                                            | 143 routes,<br>2822 segments<br>(47.0 hours) | - [spotty FW: 1389](https://useradmin.comma.ai/?onebox=ca5d1d3f94ea106b%7C2024-03-12--12-38-06)                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 2822<br>- all lat active: 89<br>- no input all lat active: 58   |
| [0dacabc563f7e7d7](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7)<br><sub>HONDA CIVIC 2022<br>19XFL2H89........</sub>            | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 18 routes,<br>260 segments<br>(4.3 hours)    | - [missing ECU FW: 260](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-03-09--17-19-00)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-03-09--17-19-00)                                                                                                                                                                                                                                                                                                     | - valid torque params: 260<br>- all lat active: 67<br>- no input all lat active: 51    |
| [7976728ccd58249f](https://useradmin.comma.ai/?onebox=7976728ccd58249f)<br><sub>ACURA RDX 2020<br>5J8TC2H61........</sub>              | ACURA RDX 2019 🆚<br>Acura RDX 2019-22                                                                    | 77 routes,<br>954 segments<br>(15.9 hours)   | - [spotty FW: 215](https://useradmin.comma.ai/?onebox=7976728ccd58249f%7C2024-02-26--10-16-02)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 947<br>- all lat active: 22<br>- no input all lat active: 7     |
| [214c417708d4eabc](https://useradmin.comma.ai/?onebox=214c417708d4eabc)<br><sub>HONDA CIVIC 2022<br>2HGFE2F26........</sub>            | HONDA Civic 2024 🆚<br>Honda Civic 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>                     | 47 routes,<br>505 segments<br>(8.4 hours)    | - [missing ECU FW: 505](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-03-13--19-19-14)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-03-13--19-19-14)                                                                                                                                                                                                                                                                                                     | - valid torque params: 443<br>- all lat active: 35<br>- no input all lat active: 17    |
| [d083dc54dae836f0](https://useradmin.comma.ai/?onebox=d083dc54dae836f0)<br><sub>TOYOTA PRIUS TSS2 2021<br>000000000........</sub>      | None 🆚<br>None                                                                                           | 4 routes,<br>101 segments<br>(1.7 hours)     | - [invalid FW: 101](https://useradmin.comma.ai/?onebox=d083dc54dae836f0%7C2024-02-19--14-27-39)                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 101<br>- all lat active: 28<br>- no input all lat active: 13    |
| [549b4287ecf880e1](https://useradmin.comma.ai/?onebox=549b4287ecf880e1)<br><sub>SUBARU OUTBACK 6TH GEN<br>4S4BTACC9........</sub>      | SUBARU Outback 2020 🆚<br>Subaru Outback 2020-22                                                          | 82 routes,<br>1374 segments<br>(22.9 hours)  | - [spotty FW: 487](https://useradmin.comma.ai/?onebox=549b4287ecf880e1%7C2024-02-20--20-05-18)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 1374<br>- all lat active: 129<br>- no input all lat active: 46  |
| [525e127ee4148aed](https://useradmin.comma.ai/?onebox=525e127ee4148aed)<br><sub>LEXUS RX 2016<br>JTJBGMCA5........</sub>               | None 🆚<br>None                                                                                           | 26 routes,<br>431 segments<br>(7.2 hours)    | - [missing ECU FW: 33](https://useradmin.comma.ai/?onebox=525e127ee4148aed%7C2024-03-08--05-47-00)<br>- [spotty FW: 33](https://useradmin.comma.ai/?onebox=525e127ee4148aed%7C2024-03-08--05-47-00)<br>- [car faulted: 86](https://useradmin.comma.ai/?onebox=525e127ee4148aed%7C2024-03-17--18-35-27)<br>- [CAN invalid: 3](https://useradmin.comma.ai/?onebox=525e127ee4148aed%7C2024-03-17--13-42-12)                                                                                                         | - valid torque params: 420                                                             |
| [53d5a1841c64512d](https://useradmin.comma.ai/?onebox=53d5a1841c64512d)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD0........</sub>  | SUBARU Ascent 2019 🆚<br>Subaru Ascent 2019-21                                                            | 18 routes,<br>161 segments<br>(2.7 hours)    | - [spotty FW: 18](https://useradmin.comma.ai/?onebox=53d5a1841c64512d%7C2024-02-23--03-38-22)                                                                                                                                                                                                                                                                                                                                                                                                                    | - all lat active: 25<br>- no input all lat active: 12                                  |
| [52e65eec8d24616b](https://useradmin.comma.ai/?onebox=52e65eec8d24616b)<br><sub>SUBARU IMPREZA SPORT 2020<br>JF2GTAPC1........</sub>   | SUBARU Crosstrek 2020 🆚<br>Subaru Crosstrek 2020-23                                                      | 126 routes,<br>878 segments<br>(14.6 hours)  | - [spotty FW: 534](https://useradmin.comma.ai/?onebox=52e65eec8d24616b%7C2024-02-28--09-47-44)<br>- [segment too short (info): 2](https://useradmin.comma.ai/?onebox=52e65eec8d24616b%7C2024-02-24--18-39-55)                                                                                                                                                                                                                                                                                                    | - valid torque params: 878<br>- all lat active: 37<br>- no input all lat active: 22    |
| [ad1ea1e2e4af46d3](https://useradmin.comma.ai/?onebox=ad1ea1e2e4af46d3)<br><sub>RAM 1500 5TH GEN<br>1C6SRFU92........</sub>            | RAM 1500 2023 🆚<br>Ram 1500 2019-24                                                                      | 9 routes,<br>22 segments<br>(0.4 hours)      | - [car faulted: 2](https://useradmin.comma.ai/?onebox=ad1ea1e2e4af46d3%7C2024-03-17--22-00-17)                                                                                                                                                                                                                                                                                                                                                                                                                   |                                                                                        |
| [e12c50f77a67608c](https://useradmin.comma.ai/?onebox=e12c50f77a67608c)<br><sub>SUBARU FORESTER 2019<br>JF2SKAJC0........</sub>        | SUBARU Forester 2020 🆚<br>Subaru Forester 2019-21                                                        | 130 routes,<br>2795 segments<br>(46.6 hours) | - [spotty FW: 2360](https://useradmin.comma.ai/?onebox=e12c50f77a67608c%7C2024-03-05--07-50-45)                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 2795<br>- all lat active: 75<br>- no input all lat active: 42   |
| [61c374c8e5e59db3](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3)<br><sub>HONDA CIVIC 2022<br>19XFL2H89........</sub>            | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                            | 130 routes,<br>2467 segments<br>(41.1 hours) | - [missing ECU FW: 503](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-03-15--18-15-02)<br>- [spotty FW: 503](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-03-15--18-15-02)                                                                                                                                                                                                                                                                                                            | - valid torque params: 2467<br>- all lat active: 261<br>- no input all lat active: 61  |
| [f920bbfae4f3886f](https://useradmin.comma.ai/?onebox=f920bbfae4f3886f)<br><sub>SUBARU IMPREZA SPORT 2020<br>JF2GTANC8........</sub>   | SUBARU Crosstrek 2020 🆚<br>Subaru Crosstrek 2020-23                                                      | 174 routes,<br>2115 segments<br>(35.2 hours) | - [spotty FW: 1056](https://useradmin.comma.ai/?onebox=f920bbfae4f3886f%7C2024-02-27--11-15-44)                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 2115<br>- all lat active: 21<br>- no input all lat active: 20   |
| [7d4aed44f10c933f](https://useradmin.comma.ai/?onebox=7d4aed44f10c933f)<br><sub>SUBARU IMPREZA LIMITED 2019<br>4S3GTAD62........</sub> | SUBARU Impreza Hatchback 2018 🆚<br>Subaru Impreza 2017-19                                                | 85 routes,<br>1699 segments<br>(28.3 hours)  | - [spotty FW: 1216](https://useradmin.comma.ai/?onebox=7d4aed44f10c933f%7C2024-03-16--21-59-53)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=7d4aed44f10c933f)                                                                                                                                                                                                                                                                                                                         | - valid torque params: 1699<br>- all lat active: 439<br>- no input all lat active: 47  |
| [162a8aff24ff56bc](https://useradmin.comma.ai/?onebox=162a8aff24ff56bc)<br><sub>SUBARU ASCENT LIMITED 2019<br>4S4WMARD1........</sub>  | SUBARU Ascent 2021 🆚<br>Subaru Ascent 2019-21                                                            | 166 routes,<br>2769 segments<br>(46.1 hours) | - [spotty FW: 1212](https://useradmin.comma.ai/?onebox=162a8aff24ff56bc%7C2024-03-14--15-15-56)                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 2477<br>- all lat active: 678<br>- no input all lat active: 89  |
| [083fdc4bd2407595](https://useradmin.comma.ai/?onebox=083fdc4bd2407595)<br><sub>SUBARU FORESTER 2019<br>JF2SKAJC2........</sub>        | SUBARU Forester 2021 🆚<br>Subaru Forester 2019-21                                                        | 62 routes,<br>811 segments<br>(13.5 hours)   | - [spotty FW: 388](https://useradmin.comma.ai/?onebox=083fdc4bd2407595%7C2024-03-10--10-39-52)<br>- [CAN invalid: 1](https://useradmin.comma.ai/?onebox=083fdc4bd2407595%7C2024-03-02--16-38-29)                                                                                                                                                                                                                                                                                                                 | - valid torque params: 810<br>- all lat active: 225<br>- no input all lat active: 116  |
| [7bb60d25bb1ed55c](https://useradmin.comma.ai/?onebox=7bb60d25bb1ed55c)<br><sub>TOYOTA PRIUS 2017<br>000000000........</sub>           | None 🆚<br>None                                                                                           | 23 routes,<br>744 segments<br>(12.4 hours)   | - [invalid FW: 744](https://useradmin.comma.ai/?onebox=7bb60d25bb1ed55c%7C2024-02-27--08-28-21)                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 744<br>- all lat active: 129<br>- no input all lat active: 85   |
| [1ef3d03831782308](https://useradmin.comma.ai/?onebox=1ef3d03831782308)<br><sub>TOYOTA PRIUS 2017<br>JTDKARFP2........</sub>           | TOYOTA Prius Prime 2017 🆚<br>Toyota Prius Prime 2017-20                                                  | 65 routes,<br>1340 segments<br>(22.3 hours)  | - [invalid FW: 61](https://useradmin.comma.ai/?onebox=1ef3d03831782308%7C2024-02-25--17-22-56)<br>- [spotty FW: 1279](https://useradmin.comma.ai/?onebox=1ef3d03831782308%7C2024-03-09--09-49-48)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=1ef3d03831782308%7C2024-03-14--13-04-48)                                                                                                                                                                                                        | - valid torque params: 1249<br>- all lat active: 43<br>- no input all lat active: 14   |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI IONIQ 5 2022<br>000000000........</sub>        | None 🆚<br>None                                                                                           | 51 routes,<br>863 segments<br>(14.4 hours)   | - [CAN invalid: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-03-12--09-07-38)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-03-12--09-07-38)                                                                                                                                                                                                                                                                                                                 | - valid torque params: 863<br>- all lat active: 35<br>- no input all lat active: 9     |
| [ace607260543d257](https://useradmin.comma.ai/?onebox=ace607260543d257)<br><sub>SUBARU FORESTER 2019<br>JF2SKAPC0........</sub>        | SUBARU Forester 2019 🆚<br>Subaru Forester 2019-21                                                        | 74 routes,<br>744 segments<br>(12.4 hours)   | - [spotty FW: 331](https://useradmin.comma.ai/?onebox=ace607260543d257%7C2024-02-24--17-58-24)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 744<br>- all lat active: 29<br>- no input all lat active: 21    |
| [21ee3cec8babd95a](https://useradmin.comma.ai/?onebox=21ee3cec8babd95a)<br><sub>SUBARU OUTBACK 6TH GEN<br>4S4BTGPD2........</sub>      | SUBARU Outback 2021 🆚<br>Subaru Outback 2020-22                                                          | 102 routes,<br>1612 segments<br>(26.9 hours) | - [spotty FW: 583](https://useradmin.comma.ai/?onebox=21ee3cec8babd95a%7C2024-02-27--17-12-13)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 1612<br>- all lat active: 24<br>- no input all lat active: 13   |
| [6e12554fbd20d6d1](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1)<br><sub>HONDA CIVIC 2022<br>2HGFE1F98........</sub>            | HONDA Civic 2022 🆚<br>Honda Civic 2022-23                                                                | 218 routes,<br>2967 segments<br>(49.5 hours) | - [missing ECU FW: 2322](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1%7C2024-02-17--21-47-19)<br>- [spotty FW: 645](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1%7C2024-02-20--19-57-58)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=6e12554fbd20d6d1%7C2024-02-17--21-47-19)                                                                                                                                                                                                  | - valid torque params: 2967<br>- all lat active: 305<br>- no input all lat active: 159 |
| [041e083d86170f22](https://useradmin.comma.ai/?onebox=041e083d86170f22)<br><sub>SUBARU FORESTER 2019<br>JF2SKAJC8........</sub>        | SUBARU Forester 2020 🆚<br>Subaru Forester 2019-21                                                        | 67 routes,<br>1805 segments<br>(30.1 hours)  | - [spotty FW: 754](https://useradmin.comma.ai/?onebox=041e083d86170f22%7C2024-02-18--21-39-27)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 1805<br>- all lat active: 24<br>- no input all lat active: 19   |
| [6ca0bbb0b026b5a5](https://useradmin.comma.ai/?onebox=6ca0bbb0b026b5a5)<br><sub>HONDA CR-V HYBRID 2019<br>5J6RT6H87........</sub>      | HONDA CR-V Hybrid 2022 🆚<br>Honda CR-V Hybrid 2017-20<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 64 routes,<br>1329 segments<br>(22.1 hours)  | - [spotty FW: 993](https://useradmin.comma.ai/?onebox=6ca0bbb0b026b5a5%7C2024-03-08--13-03-41)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 1228<br>- all lat active: 143<br>- no input all lat active: 37  |

Dongles to re-run category: `e12c50f77a67608c 7c4c77e442583f42 aca6c37cdceab59a 7a4ef9e9f44480ee ad6511c266bbf3ad 7bb60d25bb1ed55c ace607260543d257 a1459329fb4cd970 7976728ccd58249f 319908404e59fb49 c04a3b5508dc7bc3 86921fe3be40b1e9 6e12554fbd20d6d1 61c374c8e5e59db3 d083dc54dae836f0 214c417708d4eabc 6ca0bbb0b026b5a5 549b4287ecf880e1 f920bbfae4f3886f 525e127ee4148aed ad1ea1e2e4af46d3 53d5a1841c64512d ca5d1d3f94ea106b 7d4aed44f10c933f 21ee3cec8babd95a cafb4800ec0a7892 162a8aff24ff56bc b952ae0f9a30d194 1ef3d03831782308 790069c4b2f63926 52e65eec8d24616b 3a7b42f8f856b809 fc4d8f4e5f8b353a 698b51bf70bd1fa8 1e5a973a279c1a95 041e083d86170f22 22901377be496047 0dacabc563f7e7d7 2024aefc4c4f766c 53ecc962c9d86d50 083fdc4bd2407595`
</details>