### PR TITLE
logreader: fix auto source + interactive modes

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -89,7 +89,7 @@ def default_valid_file(fn: LogPath) -> bool:
 
 def auto_strategy(rlog_paths: LogPaths, qlog_paths: LogPaths, interactive: bool, valid_file: ValidFileCallable) -> LogPaths:
   # auto select logs based on availability
-  if any(rlog is None or not valid_file(rlog) for rlog in rlog_paths):
+  if any(rlog is None or not valid_file(rlog) for rlog in rlog_paths) and all(qlog is not None and valid_file(qlog) for qlog in qlog_paths):
     if interactive:
       if input("Some rlogs were not found, would you like to fallback to qlogs for those segments? (y/n) ").lower() != "y":
         return rlog_paths
@@ -172,6 +172,15 @@ def auto_source(sr: SegmentRange, mode=ReadMode.RLOG) -> LogPaths:
 
   SOURCES: list[Source] = [internal_source, openpilotci_source, comma_api_source, comma_car_segments_source,]
   exceptions = []
+
+  # for automatic fallback modes, auto_source needs to first check if rlogs exist for any source
+  if mode in [ReadMode.AUTO, ReadMode.AUTO_INTERACTIVE]:
+    for source in SOURCES:
+      try:
+        return check_source(source, sr, ReadMode.RLOG)
+      except Exception as e:
+        exceptions.append(e)
+
   # Automatically determine viable source
   for source in SOURCES:
     try:

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -178,8 +178,8 @@ def auto_source(sr: SegmentRange, mode=ReadMode.RLOG) -> LogPaths:
     for source in SOURCES:
       try:
         return check_source(source, sr, ReadMode.RLOG)
-      except Exception as e:
-        exceptions.append(e)
+      except Exception:
+        pass
 
   # Automatically determine viable source
   for source in SOURCES:


### PR DESCRIPTION
for interactive modes, if the logs aren't on the source it would prompt you if you want to fallback for every source. now it checks if rlogs exist for any source before finally falling back to the auto modes