### PR TITLE
Honda Bosch Radarless: check nonAdaptive at all times

### DIFF
--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -276,9 +276,10 @@ class CarState(CarStateBase):
     ]
 
     if CP.carFingerprint in HONDA_BOSCH_RADARLESS:
-      messages.append(("LKAS_HUD", 10))
-      if not CP.openpilotLongitudinalControl:
-        messages.append(("ACC_HUD", 10))
+      messages += [
+        ("ACC_HUD", 10),
+        ("LKAS_HUD", 10),
+      ]
 
     elif CP.carFingerprint not in HONDA_BOSCH:
       messages += [

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -204,18 +204,19 @@ class CarState(CarStateBase):
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD.get(self.CP.carFingerprint, 1200)
 
     if self.CP.carFingerprint in HONDA_BOSCH:
-      cp_acc = cp if self.CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) else cp_cam
       # The PCM always manages its own cruise control state, but doesn't publish it
       if self.CP.carFingerprint in HONDA_BOSCH_RADARLESS:
-        ret.cruiseState.nonAdaptive = cp_acc.vl["ACC_HUD"]["CRUISE_CONTROL_LABEL"] != 0
+        ret.cruiseState.nonAdaptive = cp_cam.vl["ACC_HUD"]["CRUISE_CONTROL_LABEL"] != 0
 
       if not self.CP.openpilotLongitudinalControl:
-        ret.cruiseState.nonAdaptive = cp_acc.vl["ACC_HUD"]["CRUISE_CONTROL_LABEL"] != 0
-        ret.cruiseState.standstill = cp_acc.vl["ACC_HUD"]["CRUISE_SPEED"] == 252.
+        # ACC_HUD is on camera bus on radarless cars
+        acc_hud = cp_cam.vl["ACC_HUD"] if self.CP.carFingerprint in HONDA_BOSCH_RADARLESS else cp.vl["ACC_HUD"]
+        ret.cruiseState.nonAdaptive = acc_hud["CRUISE_CONTROL_LABEL"] != 0
+        ret.cruiseState.standstill = acc_hud["CRUISE_SPEED"] == 252.
 
         conversion = get_cruise_speed_conversion(self.CP.carFingerprint, self.is_metric)
         # On set, cruise set speed pulses between 254~255 and the set speed prev is set to avoid this.
-        ret.cruiseState.speed = self.v_cruise_pcm_prev if cp_acc.vl["ACC_HUD"]["CRUISE_SPEED"] > 160.0 else cp_acc.vl["ACC_HUD"]["CRUISE_SPEED"] * conversion
+        ret.cruiseState.speed = self.v_cruise_pcm_prev if acc_hud["CRUISE_SPEED"] > 160.0 else acc_hud["CRUISE_SPEED"] * conversion
         self.v_cruise_pcm_prev = ret.cruiseState.speed
     else:
       ret.cruiseState.speed = cp.vl["CRUISE"]["CRUISE_SPEED_PCM"] * CV.KPH_TO_MS

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -149,12 +149,6 @@ def create_ui_commands(packer, CAN, CP, enabled, pcm_speed, hud, is_metric, acc_
       'SET_ME_X01_2': 1,
     }
 
-    if CP.carFingerprint in HONDA_BOSCH_RADARLESS:
-      # Ensure Honda Bosch Radarless
-      # The camera can still enter non-adaptive cruise mode via sending this bit, make sure we block it
-      # TODO: Untested on other architectures, check to see if we need to set send this
-      acc_hud_values['CRUISE_CONTROL_LABEL'] = 0
-
     if CP.carFingerprint in HONDA_BOSCH:
       acc_hud_values['ACC_ON'] = int(enabled)
       acc_hud_values['FCM_OFF'] = 1

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -149,6 +149,12 @@ def create_ui_commands(packer, CAN, CP, enabled, pcm_speed, hud, is_metric, acc_
       'SET_ME_X01_2': 1,
     }
 
+    if CP.carFingerprint in HONDA_BOSCH_RADARLESS:
+      # Ensure Honda Bosch Radarless
+      # The camera can still enter non-adaptive cruise mode via sending this bit, make sure we block it
+      # TODO: Untested on other architectures, check to see if we need to set send this
+      acc_hud_values['CRUISE_CONTROL_LABEL'] = 0
+
     if CP.carFingerprint in HONDA_BOSCH:
       acc_hud_values['ACC_ON'] = int(enabled)
       acc_hud_values['FCM_OFF'] = 1


### PR DESCRIPTION
Honda Bosch only checks when `openpilotLongitudinalControl` because the message physically does not exist (we knock out the radar)

Checked on our Civic (camera-ACC, but Nidec) and if you hold down on the distance button to trigger the camera to send that ACC hud signal, openpilot can still actuate ACC perfectly fine, so no need to check there.