### PR TITLE
CarInterface: no platform config fallback

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -14,7 +14,6 @@ from openpilot.common.simple_kalman import KF1D, get_kalman_gain
 from openpilot.common.numpy_fast import clip
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car import apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness, STD_CARGO_KG
-from openpilot.selfdrive.car.mock.values import CAR as MOCK
 from openpilot.selfdrive.car.values import PLATFORMS
 from openpilot.selfdrive.controls.lib.drive_helpers import V_CRUISE_MAX, get_friction
 from openpilot.selfdrive.controls.lib.events import Events

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -111,10 +111,9 @@ class CarInterfaceBase(ABC):
 
   @classmethod
   def get_params(cls, candidate: str, fingerprint: dict[int, dict[int, int]], car_fw: list[car.CarParams.CarFw], experimental_long: bool, docs: bool):
-    platform = PLATFORMS.get(candidate, MOCK.MOCK)
-
     ret = CarInterfaceBase.get_std_params(candidate)
 
+    platform = PLATFORMS[candidate]
     ret.mass = platform.config.specs.mass
     ret.wheelbase = platform.config.specs.wheelbase
     ret.steerRatio = platform.config.specs.steerRatio


### PR DESCRIPTION
Extension of https://github.com/commaai/openpilot/pull/31871, so many things fail if the string is not any platform or in another brand already. I don't think falling back to mock is safe for some edge cases