### PR TITLE
docs: don't support multi-type car info

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -245,9 +245,6 @@ class CanSignalRateCalculator:
     return self.rate
 
 
-CarInfos = CarInfo | list[CarInfo] | None
-
-
 @dataclass(frozen=True, kw_only=True)
 class CarSpecs:
   mass: float  # kg, curb weight
@@ -265,7 +262,7 @@ class CarSpecs:
 @dataclass(order=True)
 class PlatformConfig(Freezable):
   platform_str: str
-  car_info: CarInfos
+  car_info: list[CarInfo]
   specs: CarSpecs
 
   dbc_dict: DbcDict

--- a/selfdrive/car/body/values.py
+++ b/selfdrive/car/body/values.py
@@ -22,7 +22,7 @@ class CarControllerParams:
 class CAR(Platforms):
   BODY = PlatformConfig(
     "COMMA BODY",
-    CarInfo("comma body", package="All"),
+    [CarInfo("comma body", package="All")],
     CarSpecs(mass=9, wheelbase=0.406, steerRatio=0.5, centerToFrontRatio=0.44),
     dbc_dict('comma_body', None),
   )

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -34,22 +34,22 @@ class CAR(Platforms):
   # Chrysler
   PACIFICA_2017_HYBRID = ChryslerPlatformConfig(
     "CHRYSLER PACIFICA HYBRID 2017",
-    ChryslerCarInfo("Chrysler Pacifica Hybrid 2017"),
+    [ChryslerCarInfo("Chrysler Pacifica Hybrid 2017")],
     ChryslerCarSpecs(mass=2242., wheelbase=3.089, steerRatio=16.2),
   )
   PACIFICA_2018_HYBRID = ChryslerPlatformConfig(
     "CHRYSLER PACIFICA HYBRID 2018",
-    ChryslerCarInfo("Chrysler Pacifica Hybrid 2018"),
+    [ChryslerCarInfo("Chrysler Pacifica Hybrid 2018")],
     PACIFICA_2017_HYBRID.specs,
   )
   PACIFICA_2019_HYBRID = ChryslerPlatformConfig(
     "CHRYSLER PACIFICA HYBRID 2019",
-    ChryslerCarInfo("Chrysler Pacifica Hybrid 2019-23"),
+    [ChryslerCarInfo("Chrysler Pacifica Hybrid 2019-23")],
     PACIFICA_2017_HYBRID.specs,
   )
   PACIFICA_2018 = ChryslerPlatformConfig(
     "CHRYSLER PACIFICA 2018",
-    ChryslerCarInfo("Chrysler Pacifica 2017-18"),
+    [ChryslerCarInfo("Chrysler Pacifica 2017-18")],
     PACIFICA_2017_HYBRID.specs,
   )
   PACIFICA_2020 = ChryslerPlatformConfig(
@@ -64,27 +64,27 @@ class CAR(Platforms):
   # Dodge
   DODGE_DURANGO = ChryslerPlatformConfig(
     "DODGE DURANGO 2021",
-    ChryslerCarInfo("Dodge Durango 2020-21"),
+    [ChryslerCarInfo("Dodge Durango 2020-21")],
     PACIFICA_2017_HYBRID.specs,
   )
 
   # Jeep
   JEEP_GRAND_CHEROKEE = ChryslerPlatformConfig(  # includes 2017 Trailhawk
     "JEEP GRAND CHEROKEE V6 2018",
-    ChryslerCarInfo("Jeep Grand Cherokee 2016-18", video_link="https://www.youtube.com/watch?v=eLR9o2JkuRk"),
+    [ChryslerCarInfo("Jeep Grand Cherokee 2016-18", video_link="https://www.youtube.com/watch?v=eLR9o2JkuRk")],
     ChryslerCarSpecs(mass=1778., wheelbase=2.71, steerRatio=16.7),
   )
 
   JEEP_GRAND_CHEROKEE_2019 = ChryslerPlatformConfig(  # includes 2020 Trailhawk
     "JEEP GRAND CHEROKEE 2019",
-    ChryslerCarInfo("Jeep Grand Cherokee 2019-21", video_link="https://www.youtube.com/watch?v=jBe4lWnRSu4"),
+    [ChryslerCarInfo("Jeep Grand Cherokee 2019-21", video_link="https://www.youtube.com/watch?v=jBe4lWnRSu4")],
     JEEP_GRAND_CHEROKEE.specs,
   )
 
   # Ram
   RAM_1500 = ChryslerPlatformConfig(
     "RAM 1500 5TH GEN",
-    ChryslerCarInfo("Ram 1500 2019-24", car_parts=CarParts.common([CarHarness.ram])),
+    [ChryslerCarInfo("Ram 1500 2019-24", car_parts=CarParts.common([CarHarness.ram]))],
     ChryslerCarSpecs(mass=2493., wheelbase=3.88, steerRatio=16.3, minSteerSpeed=14.5),
     dbc_dict('chrysler_ram_dt_generated', None),
   )

--- a/selfdrive/car/docs.py
+++ b/selfdrive/car/docs.py
@@ -34,13 +34,10 @@ def get_all_car_info() -> list[CarInfo]:
     CP = interfaces[model][0].get_params(platform, fingerprint=gen_empty_fingerprint(),
                                          car_fw=[car.CarParams.CarFw(ecu="unknown")], experimental_long=True, docs=True)
 
-    if CP.dashcamOnly or car_info is None:
+    if CP.dashcamOnly or not len(car_info):
       continue
 
     # A platform can include multiple car models
-    if not isinstance(car_info, list):
-      car_info = [car_info,]
-
     for _car_info in car_info:
       if not hasattr(_car_info, "row"):
         _car_info.init_make(CP)

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -86,7 +86,7 @@ class FordCANFDPlatformConfig(FordPlatformConfig):
 class CAR(Platforms):
   BRONCO_SPORT_MK1 = FordPlatformConfig(
     "FORD BRONCO SPORT 1ST GEN",
-    FordCarInfo("Ford Bronco Sport 2021-23"),
+    [FordCarInfo("Ford Bronco Sport 2021-23")],
     CarSpecs(mass=1625, wheelbase=2.67, steerRatio=17.7),
   )
   ESCAPE_MK4 = FordPlatformConfig(
@@ -121,7 +121,7 @@ class CAR(Platforms):
   )
   F_150_LIGHTNING_MK1 = FordCANFDPlatformConfig(
     "FORD F-150 LIGHTNING 1ST GEN",
-    FordCarInfo("Ford F-150 Lightning 2021-23", "Co-Pilot360 Active 2.0"),
+    [FordCarInfo("Ford F-150 Lightning 2021-23", "Co-Pilot360 Active 2.0")],
     CarSpecs(mass=2948, wheelbase=3.70, steerRatio=16.9),
   )
   FOCUS_MK4 = FordPlatformConfig(
@@ -144,7 +144,7 @@ class CAR(Platforms):
   )
   MUSTANG_MACH_E_MK1 = FordCANFDPlatformConfig(
     "FORD MUSTANG MACH-E 1ST GEN",
-    FordCarInfo("Ford Mustang Mach-E 2021-23", "Co-Pilot360 Active 2.0"),
+    [FordCarInfo("Ford Mustang Mach-E 2021-23", "Co-Pilot360 Active 2.0")],
     CarSpecs(mass=2200, wheelbase=2.984, steerRatio=17.0),  # TODO: check steer ratio
   )
 

--- a/selfdrive/car/gm/values.py
+++ b/selfdrive/car/gm/values.py
@@ -92,52 +92,52 @@ class GMPlatformConfig(PlatformConfig):
 class CAR(Platforms):
   HOLDEN_ASTRA = GMPlatformConfig(
     "HOLDEN ASTRA RS-V BK 2017",
-    GMCarInfo("Holden Astra 2017"),
+    [GMCarInfo("Holden Astra 2017")],
     GMCarSpecs(mass=1363, wheelbase=2.662, steerRatio=15.7, centerToFrontRatio=0.4),
   )
   VOLT = GMPlatformConfig(
     "CHEVROLET VOLT PREMIER 2017",
-    GMCarInfo("Chevrolet Volt 2017-18", min_enable_speed=0, video_link="https://youtu.be/QeMCN_4TFfQ"),
+    [GMCarInfo("Chevrolet Volt 2017-18", min_enable_speed=0, video_link="https://youtu.be/QeMCN_4TFfQ")],
     GMCarSpecs(mass=1607, wheelbase=2.69, steerRatio=17.7, centerToFrontRatio=0.45, tireStiffnessFactor=0.469),
   )
   CADILLAC_ATS = GMPlatformConfig(
     "CADILLAC ATS Premium Performance 2018",
-    GMCarInfo("Cadillac ATS Premium Performance 2018"),
+    [GMCarInfo("Cadillac ATS Premium Performance 2018")],
     GMCarSpecs(mass=1601, wheelbase=2.78, steerRatio=15.3),
   )
   MALIBU = GMPlatformConfig(
     "CHEVROLET MALIBU PREMIER 2017",
-    GMCarInfo("Chevrolet Malibu Premier 2017"),
+    [GMCarInfo("Chevrolet Malibu Premier 2017")],
     GMCarSpecs(mass=1496, wheelbase=2.83, steerRatio=15.8, centerToFrontRatio=0.4),
   )
   ACADIA = GMPlatformConfig(
     "GMC ACADIA DENALI 2018",
-    GMCarInfo("GMC Acadia 2018", video_link="https://www.youtube.com/watch?v=0ZN6DdsBUZo"),
+    [GMCarInfo("GMC Acadia 2018", video_link="https://www.youtube.com/watch?v=0ZN6DdsBUZo")],
     GMCarSpecs(mass=1975, wheelbase=2.86, steerRatio=14.4, centerToFrontRatio=0.4),
   )
   BUICK_LACROSSE = GMPlatformConfig(
     "BUICK LACROSSE 2017",
-    GMCarInfo("Buick LaCrosse 2017-19", "Driver Confidence Package 2"),
+    [GMCarInfo("Buick LaCrosse 2017-19", "Driver Confidence Package 2")],
     GMCarSpecs(mass=1712, wheelbase=2.91, steerRatio=15.8, centerToFrontRatio=0.4),
   )
   BUICK_REGAL = GMPlatformConfig(
     "BUICK REGAL ESSENCE 2018",
-    GMCarInfo("Buick Regal Essence 2018"),
+    [GMCarInfo("Buick Regal Essence 2018")],
     GMCarSpecs(mass=1714, wheelbase=2.83, steerRatio=14.4, centerToFrontRatio=0.4),
   )
   ESCALADE = GMPlatformConfig(
     "CADILLAC ESCALADE 2017",
-    GMCarInfo("Cadillac Escalade 2017", "Driver Assist Package"),
+    [GMCarInfo("Cadillac Escalade 2017", "Driver Assist Package")],
     GMCarSpecs(mass=2564, wheelbase=2.95, steerRatio=17.3),
   )
   ESCALADE_ESV = GMPlatformConfig(
     "CADILLAC ESCALADE ESV 2016",
-    GMCarInfo("Cadillac Escalade ESV 2016", "Adaptive Cruise Control (ACC) & LKAS"),
+    [GMCarInfo("Cadillac Escalade ESV 2016", "Adaptive Cruise Control (ACC) & LKAS")],
     GMCarSpecs(mass=2739, wheelbase=3.302, steerRatio=17.3, tireStiffnessFactor=1.0),
   )
   ESCALADE_ESV_2019 = GMPlatformConfig(
     "CADILLAC ESCALADE ESV 2019",
-    GMCarInfo("Cadillac Escalade ESV 2019", "Adaptive Cruise Control (ACC) & LKAS"),
+    [GMCarInfo("Cadillac Escalade ESV 2019", "Adaptive Cruise Control (ACC) & LKAS")],
     ESCALADE_ESV.specs,
   )
   BOLT_EUV = GMPlatformConfig(
@@ -158,12 +158,12 @@ class CAR(Platforms):
   )
   EQUINOX = GMPlatformConfig(
     "CHEVROLET EQUINOX 2019",
-    GMCarInfo("Chevrolet Equinox 2019-22"),
+    [GMCarInfo("Chevrolet Equinox 2019-22")],
     GMCarSpecs(mass=1588, wheelbase=2.72, steerRatio=14.4, centerToFrontRatio=0.4),
   )
   TRAILBLAZER = GMPlatformConfig(
     "CHEVROLET TRAILBLAZER 2021",
-    GMCarInfo("Chevrolet Trailblazer 2021-22"),
+    [GMCarInfo("Chevrolet Trailblazer 2021-22")],
     GMCarSpecs(mass=1345, wheelbase=2.64, steerRatio=16.8, centerToFrontRatio=0.4, tireStiffnessFactor=1.0),
   )
 

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -138,7 +138,7 @@ class CAR(Platforms):
   )
   CIVIC_BOSCH_DIESEL = HondaBoschPlatformConfig(
     "HONDA CIVIC SEDAN 1.6 DIESEL 2019",
-    None,  # don't show in docs
+    [],  # don't show in docs
     CIVIC_BOSCH.specs,
     dbc_dict('honda_accord_2018_can_generated', None),
   )
@@ -154,7 +154,7 @@ class CAR(Platforms):
   )
   CRV_5G = HondaBoschPlatformConfig(
     "HONDA CR-V 2017",
-    HondaCarInfo("Honda CR-V 2017-22", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda CR-V 2017-22", min_steer_speed=12. * CV.MPH_TO_MS)],
     # steerRatio: 12.3 is spec end-to-end
     CarSpecs(mass=3410 * CV.LB_TO_KG, wheelbase=2.66, steerRatio=16.0, centerToFrontRatio=0.41, tireStiffnessFactor=0.677),
     dbc_dict('honda_crv_ex_2017_can_generated', None, body_dbc='honda_crv_ex_2017_body_generated'),
@@ -162,34 +162,34 @@ class CAR(Platforms):
   )
   CRV_HYBRID = HondaBoschPlatformConfig(
     "HONDA CR-V HYBRID 2019",
-    HondaCarInfo("Honda CR-V Hybrid 2017-20", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda CR-V Hybrid 2017-20", min_steer_speed=12. * CV.MPH_TO_MS)],
     # mass: mean of 4 models in kg, steerRatio: 12.3 is spec end-to-end
     CarSpecs(mass=1667, wheelbase=2.66, steerRatio=16, centerToFrontRatio=0.41, tireStiffnessFactor=0.677),
     dbc_dict('honda_accord_2018_can_generated', None),
   )
   HRV_3G = HondaBoschPlatformConfig(
     "HONDA HR-V 2023",
-    HondaCarInfo("Honda HR-V 2023", "All"),
+    [HondaCarInfo("Honda HR-V 2023", "All")],
     CarSpecs(mass=3125 * CV.LB_TO_KG, wheelbase=2.61, steerRatio=15.2, centerToFrontRatio=0.41, tireStiffnessFactor=0.5),
     dbc_dict('honda_civic_ex_2022_can_generated', None),
     flags=HondaFlags.BOSCH_RADARLESS | HondaFlags.BOSCH_ALT_BRAKE,
   )
   ACURA_RDX_3G = HondaBoschPlatformConfig(
     "ACURA RDX 2020",
-    HondaCarInfo("Acura RDX 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS),
+    [HondaCarInfo("Acura RDX 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
     CarSpecs(mass=4068 * CV.LB_TO_KG, wheelbase=2.75, steerRatio=11.95, centerToFrontRatio=0.41, tireStiffnessFactor=0.677),  # as spec
     dbc_dict('acura_rdx_2020_can_generated', None),
     flags=HondaFlags.BOSCH_ALT_BRAKE,
   )
   INSIGHT = HondaBoschPlatformConfig(
     "HONDA INSIGHT 2019",
-    HondaCarInfo("Honda Insight 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda Insight 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
     CarSpecs(mass=2987 * CV.LB_TO_KG, wheelbase=2.7, steerRatio=15.0, centerToFrontRatio=0.39, tireStiffnessFactor=0.82),  # as spec
     dbc_dict('honda_insight_ex_2019_can_generated', None),
   )
   HONDA_E = HondaBoschPlatformConfig(
     "HONDA E 2020",
-    HondaCarInfo("Honda e 2020", "All", min_steer_speed=3. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda e 2020", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
     CarSpecs(mass=3338.8 * CV.LB_TO_KG, wheelbase=2.5, centerToFrontRatio=0.5, steerRatio=16.71, tireStiffnessFactor=0.82),
     dbc_dict('acura_rdx_2020_can_generated', None),
   )
@@ -197,63 +197,63 @@ class CAR(Platforms):
   # Nidec Cars
   ACURA_ILX = HondaNidecPlatformConfig(
     "ACURA ILX 2016",
-    HondaCarInfo("Acura ILX 2016-19", "AcuraWatch Plus", min_steer_speed=25. * CV.MPH_TO_MS),
+    [HondaCarInfo("Acura ILX 2016-19", "AcuraWatch Plus", min_steer_speed=25. * CV.MPH_TO_MS)],
     CarSpecs(mass=3095 * CV.LB_TO_KG, wheelbase=2.67, steerRatio=18.61, centerToFrontRatio=0.37, tireStiffnessFactor=0.72),  # 15.3 is spec end-to-end
     dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   CRV = HondaNidecPlatformConfig(
     "HONDA CR-V 2016",
-    HondaCarInfo("Honda CR-V 2015-16", "Touring Trim", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda CR-V 2015-16", "Touring Trim", min_steer_speed=12. * CV.MPH_TO_MS)],
     CarSpecs(mass=3572 * CV.LB_TO_KG, wheelbase=2.62, steerRatio=16.89, centerToFrontRatio=0.41, tireStiffnessFactor=0.444),  # as spec
     dbc_dict('honda_crv_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   CRV_EU = HondaNidecPlatformConfig(
     "HONDA CR-V EU 2016",
-    None,  # Euro version of CRV Touring, don't show in docs
+    [],  # Euro version of CRV Touring, don't show in docs
     CRV.specs,
     dbc_dict('honda_crv_executive_2016_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   FIT = HondaNidecPlatformConfig(
     "HONDA FIT 2018",
-    HondaCarInfo("Honda Fit 2018-20", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda Fit 2018-20", min_steer_speed=12. * CV.MPH_TO_MS)],
     CarSpecs(mass=2644 * CV.LB_TO_KG, wheelbase=2.53, steerRatio=13.06, centerToFrontRatio=0.39, tireStiffnessFactor=0.75),
     dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   FREED = HondaNidecPlatformConfig(
     "HONDA FREED 2020",
-    HondaCarInfo("Honda Freed 2020", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda Freed 2020", min_steer_speed=12. * CV.MPH_TO_MS)],
     CarSpecs(mass=3086. * CV.LB_TO_KG, wheelbase=2.74, steerRatio=13.06, centerToFrontRatio=0.39, tireStiffnessFactor=0.75),  # mostly copied from FIT
     dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   HRV = HondaNidecPlatformConfig(
     "HONDA HRV 2019",
-    HondaCarInfo("Honda HR-V 2019-22", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda HR-V 2019-22", min_steer_speed=12. * CV.MPH_TO_MS)],
     HRV_3G.specs,
     dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   ODYSSEY = HondaNidecPlatformConfig(
     "HONDA ODYSSEY 2018",
-    HondaCarInfo("Honda Odyssey 2018-20"),
+    [HondaCarInfo("Honda Odyssey 2018-20")],
     CarSpecs(mass=1900, wheelbase=3.0, steerRatio=14.35, centerToFrontRatio=0.41, tireStiffnessFactor=0.82),
     dbc_dict('honda_odyssey_exl_2018_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_PCM_ACCEL,
   )
   ODYSSEY_CHN = HondaNidecPlatformConfig(
     "HONDA ODYSSEY CHN 2019",
-    None,  # Chinese version of Odyssey, don't show in docs
+    [],  # Chinese version of Odyssey, don't show in docs
     ODYSSEY.specs,
     dbc_dict('honda_odyssey_extreme_edition_2018_china_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   ACURA_RDX = HondaNidecPlatformConfig(
     "ACURA RDX 2018",
-    HondaCarInfo("Acura RDX 2016-18", "AcuraWatch Plus", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Acura RDX 2016-18", "AcuraWatch Plus", min_steer_speed=12. * CV.MPH_TO_MS)],
     CarSpecs(mass=3925 * CV.LB_TO_KG, wheelbase=2.68, steerRatio=15.0, centerToFrontRatio=0.38, tireStiffnessFactor=0.444),  # as spec
     dbc_dict('acura_rdx_2018_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
@@ -270,14 +270,14 @@ class CAR(Platforms):
   )
   RIDGELINE = HondaNidecPlatformConfig(
     "HONDA RIDGELINE 2017",
-    HondaCarInfo("Honda Ridgeline 2017-24", min_steer_speed=12. * CV.MPH_TO_MS),
+    [HondaCarInfo("Honda Ridgeline 2017-24", min_steer_speed=12. * CV.MPH_TO_MS)],
     CarSpecs(mass=4515 * CV.LB_TO_KG, wheelbase=3.18, centerToFrontRatio=0.41, steerRatio=15.59, tireStiffnessFactor=0.444),  # as spec
     dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   CIVIC = HondaNidecPlatformConfig(
     "HONDA CIVIC 2016",
-    HondaCarInfo("Honda Civic 2016-18", min_steer_speed=12. * CV.MPH_TO_MS, video_link="https://youtu.be/-IkImTe1NYE"),
+    [HondaCarInfo("Honda Civic 2016-18", min_steer_speed=12. * CV.MPH_TO_MS, video_link="https://youtu.be/-IkImTe1NYE")],
     CarSpecs(mass=1326, wheelbase=2.70, centerToFrontRatio=0.4, steerRatio=15.38),  # 10.93 is end-to-end spec
     dbc_dict('honda_civic_touring_2016_can_generated', 'acura_ilx_2016_nidec'),
   )

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -136,7 +136,7 @@ class CAR(Platforms):
   # Hyundai
   AZERA_6TH_GEN = HyundaiPlatformConfig(
     "HYUNDAI AZERA 6TH GEN",
-    HyundaiCarInfo("Hyundai Azera 2022", "All", car_parts=CarParts.common([CarHarness.hyundai_k])),
+    [HyundaiCarInfo("Hyundai Azera 2022", "All", car_parts=CarParts.common([CarHarness.hyundai_k]))],
     CarSpecs(mass=1600, wheelbase=2.885, steerRatio=14.5),
   )
   AZERA_HEV_6TH_GEN = HyundaiPlatformConfig(
@@ -170,14 +170,14 @@ class CAR(Platforms):
   )
   ELANTRA_2021 = HyundaiPlatformConfig(
     "HYUNDAI ELANTRA 2021",
-    HyundaiCarInfo("Hyundai Elantra 2021-23", video_link="https://youtu.be/_EdYQtV52-c", car_parts=CarParts.common([CarHarness.hyundai_k])),
+    [HyundaiCarInfo("Hyundai Elantra 2021-23", video_link="https://youtu.be/_EdYQtV52-c", car_parts=CarParts.common([CarHarness.hyundai_k]))],
     CarSpecs(mass=2800 * CV.LB_TO_KG, wheelbase=2.72, steerRatio=12.9, tireStiffnessFactor=0.65),
     flags=HyundaiFlags.CHECKSUM_CRC8,
   )
   ELANTRA_HEV_2021 = HyundaiPlatformConfig(
     "HYUNDAI ELANTRA HYBRID 2021",
-    HyundaiCarInfo("Hyundai Elantra Hybrid 2021-23", video_link="https://youtu.be/_EdYQtV52-c",
-                   car_parts=CarParts.common([CarHarness.hyundai_k])),
+    [HyundaiCarInfo("Hyundai Elantra Hybrid 2021-23", video_link="https://youtu.be/_EdYQtV52-c",
+                    car_parts=CarParts.common([CarHarness.hyundai_k]))],
     CarSpecs(mass=3017 * CV.LB_TO_KG, wheelbase=2.72, steerRatio=12.9, tireStiffnessFactor=0.65),
     flags=HyundaiFlags.CHECKSUM_CRC8 | HyundaiFlags.HYBRID,
   )
@@ -193,114 +193,114 @@ class CAR(Platforms):
   )
   IONIQ = HyundaiPlatformConfig(
     "HYUNDAI IONIQ HYBRID 2017-2019",
-    HyundaiCarInfo("Hyundai Ioniq Hybrid 2017-19", car_parts=CarParts.common([CarHarness.hyundai_c])),
+    [HyundaiCarInfo("Hyundai Ioniq Hybrid 2017-19", car_parts=CarParts.common([CarHarness.hyundai_c]))],
     CarSpecs(mass=1490, wheelbase=2.7, steerRatio=13.73, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.HYBRID | HyundaiFlags.MIN_STEER_32_MPH,
   )
   IONIQ_HEV_2022 = HyundaiPlatformConfig(
     "HYUNDAI IONIQ HYBRID 2020-2022",
-    HyundaiCarInfo("Hyundai Ioniq Hybrid 2020-22", car_parts=CarParts.common([CarHarness.hyundai_h])),  # TODO: confirm 2020-21 harness,
+    [HyundaiCarInfo("Hyundai Ioniq Hybrid 2020-22", car_parts=CarParts.common([CarHarness.hyundai_h]))],  # TODO: confirm 2020-21 harness,
     CarSpecs(mass=1490, wheelbase=2.7, steerRatio=13.73, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.HYBRID | HyundaiFlags.LEGACY,
   )
   IONIQ_EV_LTD = HyundaiPlatformConfig(
     "HYUNDAI IONIQ ELECTRIC LIMITED 2019",
-    HyundaiCarInfo("Hyundai Ioniq Electric 2019", car_parts=CarParts.common([CarHarness.hyundai_c])),
+    [HyundaiCarInfo("Hyundai Ioniq Electric 2019", car_parts=CarParts.common([CarHarness.hyundai_c]))],
     CarSpecs(mass=1490, wheelbase=2.7, steerRatio=13.73, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.MANDO_RADAR | HyundaiFlags.EV | HyundaiFlags.LEGACY | HyundaiFlags.MIN_STEER_32_MPH,
   )
   IONIQ_EV_2020 = HyundaiPlatformConfig(
     "HYUNDAI IONIQ ELECTRIC 2020",
-    HyundaiCarInfo("Hyundai Ioniq Electric 2020", "All", car_parts=CarParts.common([CarHarness.hyundai_h])),
+    [HyundaiCarInfo("Hyundai Ioniq Electric 2020", "All", car_parts=CarParts.common([CarHarness.hyundai_h]))],
     CarSpecs(mass=1490, wheelbase=2.7, steerRatio=13.73, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.EV,
   )
   IONIQ_PHEV_2019 = HyundaiPlatformConfig(
     "HYUNDAI IONIQ PLUG-IN HYBRID 2019",
-    HyundaiCarInfo("Hyundai Ioniq Plug-in Hybrid 2019", car_parts=CarParts.common([CarHarness.hyundai_c])),
+    [HyundaiCarInfo("Hyundai Ioniq Plug-in Hybrid 2019", car_parts=CarParts.common([CarHarness.hyundai_c]))],
     CarSpecs(mass=1490, wheelbase=2.7, steerRatio=13.73, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.HYBRID | HyundaiFlags.MIN_STEER_32_MPH,
   )
   IONIQ_PHEV = HyundaiPlatformConfig(
     "HYUNDAI IONIQ PHEV 2020",
-    HyundaiCarInfo("Hyundai Ioniq Plug-in Hybrid 2020-22", "All", car_parts=CarParts.common([CarHarness.hyundai_h])),
+    [HyundaiCarInfo("Hyundai Ioniq Plug-in Hybrid 2020-22", "All", car_parts=CarParts.common([CarHarness.hyundai_h]))],
     CarSpecs(mass=1490, wheelbase=2.7, steerRatio=13.73, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.HYBRID,
   )
   KONA = HyundaiPlatformConfig(
     "HYUNDAI KONA 2020",
-    HyundaiCarInfo("Hyundai Kona 2020", car_parts=CarParts.common([CarHarness.hyundai_b])),
+    [HyundaiCarInfo("Hyundai Kona 2020", car_parts=CarParts.common([CarHarness.hyundai_b]))],
     CarSpecs(mass=1275, wheelbase=2.6, steerRatio=13.42, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.CLUSTER_GEARS,
   )
   KONA_EV = HyundaiPlatformConfig(
     "HYUNDAI KONA ELECTRIC 2019",
-    HyundaiCarInfo("Hyundai Kona Electric 2018-21", car_parts=CarParts.common([CarHarness.hyundai_g])),
+    [HyundaiCarInfo("Hyundai Kona Electric 2018-21", car_parts=CarParts.common([CarHarness.hyundai_g]))],
     CarSpecs(mass=1685, wheelbase=2.6, steerRatio=13.42, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.EV,
   )
   KONA_EV_2022 = HyundaiPlatformConfig(
     "HYUNDAI KONA ELECTRIC 2022",
-    HyundaiCarInfo("Hyundai Kona Electric 2022-23", car_parts=CarParts.common([CarHarness.hyundai_o])),
+    [HyundaiCarInfo("Hyundai Kona Electric 2022-23", car_parts=CarParts.common([CarHarness.hyundai_o]))],
     CarSpecs(mass=1743, wheelbase=2.6, steerRatio=13.42, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.CAMERA_SCC | HyundaiFlags.EV,
   )
   KONA_EV_2ND_GEN = HyundaiCanFDPlatformConfig(
     "HYUNDAI KONA ELECTRIC 2ND GEN",
-    HyundaiCarInfo("Hyundai Kona Electric (with HDA II, Korea only) 2023", video_link="https://www.youtube.com/watch?v=U2fOCmcQ8hw",
-                   car_parts=CarParts.common([CarHarness.hyundai_r])),
+    [HyundaiCarInfo("Hyundai Kona Electric (with HDA II, Korea only) 2023", video_link="https://www.youtube.com/watch?v=U2fOCmcQ8hw",
+                    car_parts=CarParts.common([CarHarness.hyundai_r]))],
     CarSpecs(mass=1740, wheelbase=2.66, steerRatio=13.6, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.EV | HyundaiFlags.CANFD_NO_RADAR_DISABLE,
   )
   KONA_HEV = HyundaiPlatformConfig(
     "HYUNDAI KONA HYBRID 2020",
-    HyundaiCarInfo("Hyundai Kona Hybrid 2020", car_parts=CarParts.common([CarHarness.hyundai_i])),  # TODO: check packages,
+    [HyundaiCarInfo("Hyundai Kona Hybrid 2020", car_parts=CarParts.common([CarHarness.hyundai_i]))],  # TODO: check packages,
     CarSpecs(mass=1425, wheelbase=2.6, steerRatio=13.42, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.HYBRID,
   )
   SANTA_FE = HyundaiPlatformConfig(
     "HYUNDAI SANTA FE 2019",
-    HyundaiCarInfo("Hyundai Santa Fe 2019-20", "All", video_link="https://youtu.be/bjDR0YjM__s",
-                   car_parts=CarParts.common([CarHarness.hyundai_d])),
+    [HyundaiCarInfo("Hyundai Santa Fe 2019-20", "All", video_link="https://youtu.be/bjDR0YjM__s",
+                    car_parts=CarParts.common([CarHarness.hyundai_d]))],
     CarSpecs(mass=3982 * CV.LB_TO_KG, wheelbase=2.766, steerRatio=16.55, tireStiffnessFactor=0.82),
     flags=HyundaiFlags.MANDO_RADAR | HyundaiFlags.CHECKSUM_CRC8,
   )
   SANTA_FE_2022 = HyundaiPlatformConfig(
     "HYUNDAI SANTA FE 2022",
-    HyundaiCarInfo("Hyundai Santa Fe 2021-23", "All", video_link="https://youtu.be/VnHzSTygTS4",
-                   car_parts=CarParts.common([CarHarness.hyundai_l])),
+    [HyundaiCarInfo("Hyundai Santa Fe 2021-23", "All", video_link="https://youtu.be/VnHzSTygTS4",
+                    car_parts=CarParts.common([CarHarness.hyundai_l]))],
     SANTA_FE.specs,
     flags=HyundaiFlags.CHECKSUM_CRC8,
   )
   SANTA_FE_HEV_2022 = HyundaiPlatformConfig(
     "HYUNDAI SANTA FE HYBRID 2022",
-    HyundaiCarInfo("Hyundai Santa Fe Hybrid 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_l])),
+    [HyundaiCarInfo("Hyundai Santa Fe Hybrid 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_l]))],
     SANTA_FE.specs,
     flags=HyundaiFlags.CHECKSUM_CRC8 | HyundaiFlags.HYBRID,
   )
   SANTA_FE_PHEV_2022 = HyundaiPlatformConfig(
     "HYUNDAI SANTA FE PlUG-IN HYBRID 2022",
-    HyundaiCarInfo("Hyundai Santa Fe Plug-in Hybrid 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_l])),
+    [HyundaiCarInfo("Hyundai Santa Fe Plug-in Hybrid 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_l]))],
     SANTA_FE.specs,
     flags=HyundaiFlags.CHECKSUM_CRC8 | HyundaiFlags.HYBRID,
   )
   SONATA = HyundaiPlatformConfig(
     "HYUNDAI SONATA 2020",
-    HyundaiCarInfo("Hyundai Sonata 2020-23", "All", video_link="https://www.youtube.com/watch?v=ix63r9kE3Fw",
-                   car_parts=CarParts.common([CarHarness.hyundai_a])),
+    [HyundaiCarInfo("Hyundai Sonata 2020-23", "All", video_link="https://www.youtube.com/watch?v=ix63r9kE3Fw",
+                   car_parts=CarParts.common([CarHarness.hyundai_a]))],
     CarSpecs(mass=1513, wheelbase=2.84, steerRatio=13.27 * 1.15, tireStiffnessFactor=0.65),  # 15% higher at the center seems reasonable
     flags=HyundaiFlags.MANDO_RADAR | HyundaiFlags.CHECKSUM_CRC8,
   )
   SONATA_LF = HyundaiPlatformConfig(
     "HYUNDAI SONATA 2019",
-    HyundaiCarInfo("Hyundai Sonata 2018-19", car_parts=CarParts.common([CarHarness.hyundai_e])),
+    [HyundaiCarInfo("Hyundai Sonata 2018-19", car_parts=CarParts.common([CarHarness.hyundai_e]))],
     CarSpecs(mass=1536, wheelbase=2.804, steerRatio=13.27 * 1.15),  # 15% higher at the center seems reasonable
 
     flags=HyundaiFlags.UNSUPPORTED_LONGITUDINAL | HyundaiFlags.TCU_GEARS,
   )
   STARIA_4TH_GEN = HyundaiCanFDPlatformConfig(
     "HYUNDAI STARIA 4TH GEN",
-    HyundaiCarInfo("Hyundai Staria 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_k])),
+    [HyundaiCarInfo("Hyundai Staria 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_k]))],
     CarSpecs(mass=2205, wheelbase=3.273, steerRatio=11.94),  # https://www.hyundai.com/content/dam/hyundai/au/en/models/staria-load/premium-pip-update-2023/spec-sheet/STARIA_Load_Spec-Table_March_2023_v3.1.pdf
   )
   TUCSON = HyundaiPlatformConfig(
@@ -323,13 +323,13 @@ class CAR(Platforms):
   )
   VELOSTER = HyundaiPlatformConfig(
     "HYUNDAI VELOSTER 2019",
-    HyundaiCarInfo("Hyundai Veloster 2019-20", min_enable_speed=5. * CV.MPH_TO_MS, car_parts=CarParts.common([CarHarness.hyundai_e])),
+    [HyundaiCarInfo("Hyundai Veloster 2019-20", min_enable_speed=5. * CV.MPH_TO_MS, car_parts=CarParts.common([CarHarness.hyundai_e]))],
     CarSpecs(mass=2917 * CV.LB_TO_KG, wheelbase=2.8, steerRatio=13.75 * 1.15, tireStiffnessFactor=0.5),
     flags=HyundaiFlags.LEGACY | HyundaiFlags.TCU_GEARS,
   )
   SONATA_HYBRID = HyundaiPlatformConfig(
     "HYUNDAI SONATA HYBRID 2021",
-    HyundaiCarInfo("Hyundai Sonata Hybrid 2020-23", "All", car_parts=CarParts.common([CarHarness.hyundai_a])),
+    [HyundaiCarInfo("Hyundai Sonata Hybrid 2020-23", "All", car_parts=CarParts.common([CarHarness.hyundai_a]))],
     SONATA.specs,
     flags=HyundaiFlags.MANDO_RADAR | HyundaiFlags.CHECKSUM_CRC8 | HyundaiFlags.HYBRID,
   )
@@ -345,7 +345,7 @@ class CAR(Platforms):
   )
   IONIQ_6 = HyundaiCanFDPlatformConfig(
     "HYUNDAI IONIQ 6 2023",
-    HyundaiCarInfo("Hyundai Ioniq 6 (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p])),
+    [HyundaiCarInfo("Hyundai Ioniq 6 (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]))],
     IONIQ_5.specs,
     flags=HyundaiFlags.EV | HyundaiFlags.CANFD_NO_RADAR_DISABLE,
   )
@@ -360,13 +360,13 @@ class CAR(Platforms):
   )
   SANTA_CRUZ_1ST_GEN = HyundaiCanFDPlatformConfig(
     "HYUNDAI SANTA CRUZ 1ST GEN",
-    HyundaiCarInfo("Hyundai Santa Cruz 2022-24", car_parts=CarParts.common([CarHarness.hyundai_n])),
+    [HyundaiCarInfo("Hyundai Santa Cruz 2022-24", car_parts=CarParts.common([CarHarness.hyundai_n]))],
     # weight from Limited trim - the only supported trim, steering ratio according to Hyundai News https://www.hyundainews.com/assets/documents/original/48035-2022SantaCruzProductGuideSpecsv2081521.pdf
     CarSpecs(mass=1870, wheelbase=3, steerRatio=14.2),
   )
   CUSTIN_1ST_GEN = HyundaiPlatformConfig(
     "HYUNDAI CUSTIN 1ST GEN",
-    HyundaiCarInfo("Hyundai Custin 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_k])),
+    [HyundaiCarInfo("Hyundai Custin 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_k]))],
     CarSpecs(mass=1690, wheelbase=3.055, steerRatio=17),  # mass: from https://www.hyundai-motor.com.tw/clicktobuy/custin#spec_0, steerRatio: from learner
     flags=HyundaiFlags.CHECKSUM_CRC8,
   )
@@ -382,19 +382,19 @@ class CAR(Platforms):
   )
   KIA_K5_2021 = HyundaiPlatformConfig(
     "KIA K5 2021",
-    HyundaiCarInfo("Kia K5 2021-24", car_parts=CarParts.common([CarHarness.hyundai_a])),
+    [HyundaiCarInfo("Kia K5 2021-24", car_parts=CarParts.common([CarHarness.hyundai_a]))],
     CarSpecs(mass=3381 * CV.LB_TO_KG, wheelbase=2.85, steerRatio=13.27, tireStiffnessFactor=0.5),  # 2021 Kia K5 Steering Ratio (all trims)
     flags=HyundaiFlags.CHECKSUM_CRC8,
   )
   KIA_K5_HEV_2020 = HyundaiPlatformConfig(
     "KIA K5 HYBRID 2020",
-    HyundaiCarInfo("Kia K5 Hybrid 2020-22", car_parts=CarParts.common([CarHarness.hyundai_a])),
+    [HyundaiCarInfo("Kia K5 Hybrid 2020-22", car_parts=CarParts.common([CarHarness.hyundai_a]))],
     KIA_K5_2021.specs,
     flags=HyundaiFlags.MANDO_RADAR | HyundaiFlags.CHECKSUM_CRC8 | HyundaiFlags.HYBRID,
   )
   KIA_K8_HEV_1ST_GEN = HyundaiCanFDPlatformConfig(
     "KIA K8 HYBRID 1ST GEN",
-    HyundaiCarInfo("Kia K8 Hybrid (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q])),
+    [HyundaiCarInfo("Kia K8 Hybrid (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q]))],
     # mass: https://carprices.ae/brands/kia/2023/k8/1.6-turbo-hybrid, steerRatio: guesstimate from K5 platform
     CarSpecs(mass=1630, wheelbase=2.895, steerRatio=13.27)
   )
@@ -411,7 +411,7 @@ class CAR(Platforms):
   )
   KIA_NIRO_EV_2ND_GEN = HyundaiCanFDPlatformConfig(
     "KIA NIRO EV 2ND GEN",
-    HyundaiCarInfo("Kia Niro EV 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_a])),
+    [HyundaiCarInfo("Kia Niro EV 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_a]))],
     KIA_NIRO_EV.specs,
     flags=HyundaiFlags.EV,
   )
@@ -445,38 +445,38 @@ class CAR(Platforms):
   )
   KIA_NIRO_HEV_2ND_GEN = HyundaiCanFDPlatformConfig(
     "KIA NIRO HYBRID 2ND GEN",
-    HyundaiCarInfo("Kia Niro Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_a])),
+    [HyundaiCarInfo("Kia Niro Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_a]))],
     KIA_NIRO_EV.specs,
   )
   KIA_OPTIMA_G4 = HyundaiPlatformConfig(
     "KIA OPTIMA 4TH GEN",
-    HyundaiCarInfo("Kia Optima 2017", "Advanced Smart Cruise Control",
-                   car_parts=CarParts.common([CarHarness.hyundai_b])),  # TODO: may support 2016, 2018
+    [HyundaiCarInfo("Kia Optima 2017", "Advanced Smart Cruise Control",
+                    car_parts=CarParts.common([CarHarness.hyundai_b]))],  # TODO: may support 2016, 2018
     CarSpecs(mass=3558 * CV.LB_TO_KG, wheelbase=2.8, steerRatio=13.75, tireStiffnessFactor=0.5),
     flags=HyundaiFlags.LEGACY | HyundaiFlags.TCU_GEARS | HyundaiFlags.MIN_STEER_32_MPH,
   )
   KIA_OPTIMA_G4_FL = HyundaiPlatformConfig(
     "KIA OPTIMA 4TH GEN FACELIFT",
-    HyundaiCarInfo("Kia Optima 2019-20", car_parts=CarParts.common([CarHarness.hyundai_g])),
+    [HyundaiCarInfo("Kia Optima 2019-20", car_parts=CarParts.common([CarHarness.hyundai_g]))],
     CarSpecs(mass=3558 * CV.LB_TO_KG, wheelbase=2.8, steerRatio=13.75, tireStiffnessFactor=0.5),
     flags=HyundaiFlags.UNSUPPORTED_LONGITUDINAL | HyundaiFlags.TCU_GEARS,
   )
   # TODO: may support adjacent years. may have a non-zero minimum steering speed
   KIA_OPTIMA_H = HyundaiPlatformConfig(
     "KIA OPTIMA HYBRID 2017 & SPORTS 2019",
-    HyundaiCarInfo("Kia Optima Hybrid 2017", "Advanced Smart Cruise Control", car_parts=CarParts.common([CarHarness.hyundai_c])),
+    [HyundaiCarInfo("Kia Optima Hybrid 2017", "Advanced Smart Cruise Control", car_parts=CarParts.common([CarHarness.hyundai_c]))],
     CarSpecs(mass=3558 * CV.LB_TO_KG, wheelbase=2.8, steerRatio=13.75, tireStiffnessFactor=0.5),
     flags=HyundaiFlags.HYBRID | HyundaiFlags.LEGACY,
   )
   KIA_OPTIMA_H_G4_FL = HyundaiPlatformConfig(
     "KIA OPTIMA HYBRID 4TH GEN FACELIFT",
-    HyundaiCarInfo("Kia Optima Hybrid 2019", car_parts=CarParts.common([CarHarness.hyundai_h])),
+    [HyundaiCarInfo("Kia Optima Hybrid 2019", car_parts=CarParts.common([CarHarness.hyundai_h]))],
     CarSpecs(mass=3558 * CV.LB_TO_KG, wheelbase=2.8, steerRatio=13.75, tireStiffnessFactor=0.5),
     flags=HyundaiFlags.HYBRID | HyundaiFlags.UNSUPPORTED_LONGITUDINAL,
   )
   KIA_SELTOS = HyundaiPlatformConfig(
     "KIA SELTOS 2021",
-    HyundaiCarInfo("Kia Seltos 2021", car_parts=CarParts.common([CarHarness.hyundai_a])),
+    [HyundaiCarInfo("Kia Seltos 2021", car_parts=CarParts.common([CarHarness.hyundai_a]))],
     CarSpecs(mass=1337, wheelbase=2.63, steerRatio=14.56),
     flags=HyundaiFlags.CHECKSUM_CRC8,
   )
@@ -501,7 +501,7 @@ class CAR(Platforms):
   )
   KIA_SORENTO_4TH_GEN = HyundaiCanFDPlatformConfig(
     "KIA SORENTO 4TH GEN",
-    HyundaiCarInfo("Kia Sorento 2021-23", car_parts=CarParts.common([CarHarness.hyundai_k])),
+    [HyundaiCarInfo("Kia Sorento 2021-23", car_parts=CarParts.common([CarHarness.hyundai_k]))],
     CarSpecs(mass=3957 * CV.LB_TO_KG, wheelbase=2.81, steerRatio=13.5),  # average of the platforms
     flags=HyundaiFlags.RADAR_SCC,
   )
@@ -516,18 +516,18 @@ class CAR(Platforms):
   )
   KIA_STINGER = HyundaiPlatformConfig(
     "KIA STINGER GT2 2018",
-    HyundaiCarInfo("Kia Stinger 2018-20", video_link="https://www.youtube.com/watch?v=MJ94qoofYw0",
-                   car_parts=CarParts.common([CarHarness.hyundai_c])),
+    [HyundaiCarInfo("Kia Stinger 2018-20", video_link="https://www.youtube.com/watch?v=MJ94qoofYw0",
+                    car_parts=CarParts.common([CarHarness.hyundai_c]))],
     CarSpecs(mass=1825, wheelbase=2.78, steerRatio=14.4 * 1.15)  # 15% higher at the center seems reasonable
   )
   KIA_STINGER_2022 = HyundaiPlatformConfig(
     "KIA STINGER 2022",
-    HyundaiCarInfo("Kia Stinger 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_k])),
+    [HyundaiCarInfo("Kia Stinger 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_k]))],
     KIA_STINGER.specs,
   )
   KIA_CEED = HyundaiPlatformConfig(
     "KIA CEED INTRO ED 2019",
-    HyundaiCarInfo("Kia Ceed 2019", car_parts=CarParts.common([CarHarness.hyundai_e])),
+    [HyundaiCarInfo("Kia Ceed 2019", car_parts=CarParts.common([CarHarness.hyundai_e]))],
     CarSpecs(mass=1450, wheelbase=2.65, steerRatio=13.75, tireStiffnessFactor=0.5),
     flags=HyundaiFlags.LEGACY,
   )
@@ -563,13 +563,13 @@ class CAR(Platforms):
   )
   GENESIS_G70 = HyundaiPlatformConfig(
     "GENESIS G70 2018",
-    HyundaiCarInfo("Genesis G70 2018-19", "All", car_parts=CarParts.common([CarHarness.hyundai_f])),
+    [HyundaiCarInfo("Genesis G70 2018-19", "All", car_parts=CarParts.common([CarHarness.hyundai_f]))],
     CarSpecs(mass=1640, wheelbase=2.84, steerRatio=13.56),
     flags=HyundaiFlags.LEGACY,
   )
   GENESIS_G70_2020 = HyundaiPlatformConfig(
     "GENESIS G70 2020",
-    HyundaiCarInfo("Genesis G70 2020-23", "All", car_parts=CarParts.common([CarHarness.hyundai_f])),
+    [HyundaiCarInfo("Genesis G70 2020-23", "All", car_parts=CarParts.common([CarHarness.hyundai_f]))],
     CarSpecs(mass=3673 * CV.LB_TO_KG, wheelbase=2.83, steerRatio=12.9),
     flags=HyundaiFlags.MANDO_RADAR,
   )
@@ -584,18 +584,18 @@ class CAR(Platforms):
   )
   GENESIS_G80 = HyundaiPlatformConfig(
     "GENESIS G80 2017",
-    HyundaiCarInfo("Genesis G80 2018-19", "All", car_parts=CarParts.common([CarHarness.hyundai_h])),
+    [HyundaiCarInfo("Genesis G80 2018-19", "All", car_parts=CarParts.common([CarHarness.hyundai_h]))],
     CarSpecs(mass=2060, wheelbase=3.01, steerRatio=16.5),
     flags=HyundaiFlags.LEGACY,
   )
   GENESIS_G90 = HyundaiPlatformConfig(
     "GENESIS G90 2017",
-    HyundaiCarInfo("Genesis G90 2017-18", "All", car_parts=CarParts.common([CarHarness.hyundai_c])),
+    [HyundaiCarInfo("Genesis G90 2017-18", "All", car_parts=CarParts.common([CarHarness.hyundai_c]))],
     CarSpecs(mass=2200, wheelbase=3.15, steerRatio=12.069),
   )
   GENESIS_GV80 = HyundaiCanFDPlatformConfig(
     "GENESIS GV80 2023",
-    HyundaiCarInfo("Genesis GV80 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_m])),
+    [HyundaiCarInfo("Genesis GV80 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_m]))],
     CarSpecs(mass=2258, wheelbase=2.95, steerRatio=14.14),
     flags=HyundaiFlags.RADAR_SCC,
   )

--- a/selfdrive/car/mazda/values.py
+++ b/selfdrive/car/mazda/values.py
@@ -52,32 +52,32 @@ class MazdaPlatformConfig(PlatformConfig):
 class CAR(Platforms):
   CX5 = MazdaPlatformConfig(
     "MAZDA CX-5",
-    MazdaCarInfo("Mazda CX-5 2017-21"),
+    [MazdaCarInfo("Mazda CX-5 2017-21")],
     MazdaCarSpecs(mass=3655 * CV.LB_TO_KG, wheelbase=2.7, steerRatio=15.5)
   )
   CX9 = MazdaPlatformConfig(
     "MAZDA CX-9",
-    MazdaCarInfo("Mazda CX-9 2016-20"),
+    [MazdaCarInfo("Mazda CX-9 2016-20")],
     MazdaCarSpecs(mass=4217 * CV.LB_TO_KG, wheelbase=3.1, steerRatio=17.6)
   )
   MAZDA3 = MazdaPlatformConfig(
     "MAZDA 3",
-    MazdaCarInfo("Mazda 3 2017-18"),
+    [MazdaCarInfo("Mazda 3 2017-18")],
     MazdaCarSpecs(mass=2875 * CV.LB_TO_KG, wheelbase=2.7, steerRatio=14.0)
   )
   MAZDA6 = MazdaPlatformConfig(
     "MAZDA 6",
-    MazdaCarInfo("Mazda 6 2017-20"),
+    [MazdaCarInfo("Mazda 6 2017-20")],
     MazdaCarSpecs(mass=3443 * CV.LB_TO_KG, wheelbase=2.83, steerRatio=15.5)
   )
   CX9_2021 = MazdaPlatformConfig(
     "MAZDA CX-9 2021",
-    MazdaCarInfo("Mazda CX-9 2021-23", video_link="https://youtu.be/dA3duO4a0O4"),
+    [MazdaCarInfo("Mazda CX-9 2021-23", video_link="https://youtu.be/dA3duO4a0O4")],
     CX9.specs
   )
   CX5_2022 = MazdaPlatformConfig(
     "MAZDA CX-5 2022",
-    MazdaCarInfo("Mazda CX-5 2022-24"),
+    [MazdaCarInfo("Mazda CX-5 2022-24")],
     CX5.specs,
   )
 

--- a/selfdrive/car/mock/values.py
+++ b/selfdrive/car/mock/values.py
@@ -4,7 +4,7 @@ from openpilot.selfdrive.car import CarSpecs, PlatformConfig, Platforms
 class CAR(Platforms):
   MOCK = PlatformConfig(
     'mock',
-    None,
+    [],
     CarSpecs(mass=1700, wheelbase=2.7, steerRatio=13),
     {}
   )

--- a/selfdrive/car/nissan/values.py
+++ b/selfdrive/car/nissan/values.py
@@ -39,26 +39,26 @@ class NissanPlaformConfig(PlatformConfig):
 class CAR(Platforms):
   XTRAIL = NissanPlaformConfig(
     "NISSAN X-TRAIL 2017",
-    NissanCarInfo("Nissan X-Trail 2017"),
+    [NissanCarInfo("Nissan X-Trail 2017")],
     NissanCarSpecs(mass=1610, wheelbase=2.705)
   )
   LEAF = NissanPlaformConfig(
     "NISSAN LEAF 2018",
-    NissanCarInfo("Nissan Leaf 2018-23", video_link="https://youtu.be/vaMbtAh_0cY"),
+    [NissanCarInfo("Nissan Leaf 2018-23", video_link="https://youtu.be/vaMbtAh_0cY")],
     NissanCarSpecs(mass=1610, wheelbase=2.705),
     dbc_dict('nissan_leaf_2018_generated', None),
   )
   # Leaf with ADAS ECU found behind instrument cluster instead of glovebox
   # Currently the only known difference between them is the inverted seatbelt signal.
-  LEAF_IC = LEAF.override(platform_str="NISSAN LEAF 2018 Instrument Cluster", car_info=None)
+  LEAF_IC = LEAF.override(platform_str="NISSAN LEAF 2018 Instrument Cluster", car_info=[])
   ROGUE = NissanPlaformConfig(
     "NISSAN ROGUE 2019",
-    NissanCarInfo("Nissan Rogue 2018-20"),
+    [NissanCarInfo("Nissan Rogue 2018-20")],
     NissanCarSpecs(mass=1610, wheelbase=2.705)
   )
   ALTIMA = NissanPlaformConfig(
     "NISSAN ALTIMA 2020",
-    NissanCarInfo("Nissan Altima 2019-20", car_parts=CarParts.common([CarHarness.nissan_b])),
+    [NissanCarInfo("Nissan Altima 2019-20", car_parts=CarParts.common([CarHarness.nissan_b]))],
     NissanCarSpecs(mass=1492, wheelbase=2.824)
   )
 

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -122,17 +122,17 @@ class CAR(Platforms):
   # Global platform
   ASCENT = SubaruPlatformConfig(
     "SUBARU ASCENT LIMITED 2019",
-    SubaruCarInfo("Subaru Ascent 2019-21", "All"),
+    [SubaruCarInfo("Subaru Ascent 2019-21", "All")],
     CarSpecs(mass=2031, wheelbase=2.89, steerRatio=13.5),
   )
   OUTBACK = SubaruGen2PlatformConfig(
     "SUBARU OUTBACK 6TH GEN",
-    SubaruCarInfo("Subaru Outback 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b])),
+    [SubaruCarInfo("Subaru Outback 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b]))],
     CarSpecs(mass=1568, wheelbase=2.67, steerRatio=17),
   )
   LEGACY = SubaruGen2PlatformConfig(
     "SUBARU LEGACY 7TH GEN",
-    SubaruCarInfo("Subaru Legacy 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b])),
+    [SubaruCarInfo("Subaru Legacy 2020-22", "All", car_parts=CarParts.common([CarHarness.subaru_b]))],
     OUTBACK.specs,
   )
   IMPREZA = SubaruPlatformConfig(
@@ -157,47 +157,47 @@ class CAR(Platforms):
   # TODO: is there an XV and Impreza too?
   CROSSTREK_HYBRID = SubaruPlatformConfig(
     "SUBARU CROSSTREK HYBRID 2020",
-    SubaruCarInfo("Subaru Crosstrek Hybrid 2020", car_parts=CarParts.common([CarHarness.subaru_b])),
+    [SubaruCarInfo("Subaru Crosstrek Hybrid 2020", car_parts=CarParts.common([CarHarness.subaru_b]))],
     CarSpecs(mass=1668, wheelbase=2.67, steerRatio=17),
     flags=SubaruFlags.HYBRID,
   )
   FORESTER = SubaruPlatformConfig(
     "SUBARU FORESTER 2019",
-    SubaruCarInfo("Subaru Forester 2019-21", "All"),
+    [SubaruCarInfo("Subaru Forester 2019-21", "All")],
     CarSpecs(mass=1568, wheelbase=2.67, steerRatio=17),
     flags=SubaruFlags.STEER_RATE_LIMITED,
   )
   FORESTER_HYBRID = SubaruPlatformConfig(
     "SUBARU FORESTER HYBRID 2020",
-    SubaruCarInfo("Subaru Forester Hybrid 2020"),
+    [SubaruCarInfo("Subaru Forester Hybrid 2020")],
     FORESTER.specs,
     flags=SubaruFlags.HYBRID,
   )
   # Pre-global
   FORESTER_PREGLOBAL = SubaruPlatformConfig(
     "SUBARU FORESTER 2017 - 2018",
-    SubaruCarInfo("Subaru Forester 2017-18"),
+    [SubaruCarInfo("Subaru Forester 2017-18")],
     CarSpecs(mass=1568, wheelbase=2.67, steerRatio=20),
     dbc_dict('subaru_forester_2017_generated', None),
     flags=SubaruFlags.PREGLOBAL,
   )
   LEGACY_PREGLOBAL = SubaruPlatformConfig(
     "SUBARU LEGACY 2015 - 2018",
-    SubaruCarInfo("Subaru Legacy 2015-18"),
+    [SubaruCarInfo("Subaru Legacy 2015-18")],
     CarSpecs(mass=1568, wheelbase=2.67, steerRatio=12.5),
     dbc_dict('subaru_outback_2015_generated', None),
     flags=SubaruFlags.PREGLOBAL,
   )
   OUTBACK_PREGLOBAL = SubaruPlatformConfig(
     "SUBARU OUTBACK 2015 - 2017",
-    SubaruCarInfo("Subaru Outback 2015-17"),
+    [SubaruCarInfo("Subaru Outback 2015-17")],
     FORESTER_PREGLOBAL.specs,
     dbc_dict('subaru_outback_2015_generated', None),
     flags=SubaruFlags.PREGLOBAL,
   )
   OUTBACK_PREGLOBAL_2018 = SubaruPlatformConfig(
     "SUBARU OUTBACK 2018 - 2019",
-    SubaruCarInfo("Subaru Outback 2018-19"),
+    [SubaruCarInfo("Subaru Outback 2018-19")],
     FORESTER_PREGLOBAL.specs,
     dbc_dict('subaru_outback_2019_generated', None),
     flags=SubaruFlags.PREGLOBAL,
@@ -205,19 +205,19 @@ class CAR(Platforms):
   # Angle LKAS
   FORESTER_2022 = SubaruPlatformConfig(
     "SUBARU FORESTER 2022",
-    SubaruCarInfo("Subaru Forester 2022-24", "All", car_parts=CarParts.common([CarHarness.subaru_c])),
+    [SubaruCarInfo("Subaru Forester 2022-24", "All", car_parts=CarParts.common([CarHarness.subaru_c]))],
     FORESTER.specs,
     flags=SubaruFlags.LKAS_ANGLE,
   )
   OUTBACK_2023 = SubaruGen2PlatformConfig(
     "SUBARU OUTBACK 7TH GEN",
-    SubaruCarInfo("Subaru Outback 2023", "All", car_parts=CarParts.common([CarHarness.subaru_d])),
+    [SubaruCarInfo("Subaru Outback 2023", "All", car_parts=CarParts.common([CarHarness.subaru_d]))],
     OUTBACK.specs,
     flags=SubaruFlags.LKAS_ANGLE,
   )
   ASCENT_2023 = SubaruGen2PlatformConfig(
     "SUBARU ASCENT 2023",
-    SubaruCarInfo("Subaru Ascent 2023", "All", car_parts=CarParts.common([CarHarness.subaru_d])),
+    [SubaruCarInfo("Subaru Ascent 2023", "All", car_parts=CarParts.common([CarHarness.subaru_d]))],
     ASCENT.specs,
     flags=SubaruFlags.LKAS_ANGLE,
   )

--- a/selfdrive/car/tesla/values.py
+++ b/selfdrive/car/tesla/values.py
@@ -12,19 +12,19 @@ Button = namedtuple('Button', ['event_type', 'can_addr', 'can_msg', 'values'])
 class CAR(Platforms):
   AP1_MODELS = PlatformConfig(
     'TESLA AP1 MODEL S',
-    CarInfo("Tesla AP1 Model S", "All"),
+    [CarInfo("Tesla AP1 Model S", "All")],
     CarSpecs(mass=2100., wheelbase=2.959, steerRatio=15.0),
     dbc_dict('tesla_powertrain', 'tesla_radar_bosch_generated', chassis_dbc='tesla_can')
   )
   AP2_MODELS = PlatformConfig(
     'TESLA AP2 MODEL S',
-    CarInfo("Tesla AP2 Model S", "All"),
+    [CarInfo("Tesla AP2 Model S", "All")],
     AP1_MODELS.specs,
     AP1_MODELS.dbc_dict
   )
   MODELS_RAVEN = PlatformConfig(
     'TESLA MODEL S RAVEN',
-    CarInfo("Tesla Model S Raven", "All"),
+    [CarInfo("Tesla Model S Raven", "All")],
     AP1_MODELS.specs,
     dbc_dict('tesla_powertrain', 'tesla_radar_continental_generated', chassis_dbc='tesla_can')
   )

--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -158,7 +158,7 @@ class CAR(Platforms):
   )
   COROLLA = PlatformConfig(
     "TOYOTA COROLLA 2017",
-    ToyotaCarInfo("Toyota Corolla 2017-19"),
+    [ToyotaCarInfo("Toyota Corolla 2017-19")],
     CarSpecs(mass=2860. * CV.LB_TO_KG, wheelbase=2.7, steerRatio=18.27, tireStiffnessFactor=0.444),
     dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
   )
@@ -207,7 +207,7 @@ class CAR(Platforms):
   )
   PRIUS_V = PlatformConfig(
     "TOYOTA PRIUS v 2017",
-    ToyotaCarInfo("Toyota Prius v 2017", "Toyota Safety Sense P", min_enable_speed=MIN_ACC_SPEED),
+    [ToyotaCarInfo("Toyota Prius v 2017", "Toyota Safety Sense P", min_enable_speed=MIN_ACC_SPEED)],
     CarSpecs(mass=3340. * CV.LB_TO_KG, wheelbase=2.78, steerRatio=17.4, tireStiffnessFactor=0.5533),
     dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
     flags=ToyotaFlags.NO_STOP_TIMER | ToyotaFlags.SNG_WITHOUT_DSU,
@@ -267,12 +267,12 @@ class CAR(Platforms):
   )
   MIRAI = ToyotaTSS2PlatformConfig(
     "TOYOTA MIRAI 2021",  # TSS 2.5
-    ToyotaCarInfo("Toyota Mirai 2021"),
+    [ToyotaCarInfo("Toyota Mirai 2021")],
     CarSpecs(mass=4300. * CV.LB_TO_KG, wheelbase=2.91, steerRatio=14.8, tireStiffnessFactor=0.8),
   )
   SIENNA = PlatformConfig(
     "TOYOTA SIENNA 2018",
-    ToyotaCarInfo("Toyota Sienna 2018-20", video_link="https://www.youtube.com/watch?v=q1UPOo4Sh68", min_enable_speed=MIN_ACC_SPEED),
+    [ToyotaCarInfo("Toyota Sienna 2018-20", video_link="https://www.youtube.com/watch?v=q1UPOo4Sh68", min_enable_speed=MIN_ACC_SPEED)],
     CarSpecs(mass=4590. * CV.LB_TO_KG, wheelbase=3.03, steerRatio=15.5, tireStiffnessFactor=0.444),
     dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
     flags=ToyotaFlags.NO_STOP_TIMER,
@@ -281,7 +281,7 @@ class CAR(Platforms):
   # Lexus
   LEXUS_CTH = PlatformConfig(
     "LEXUS CT HYBRID 2018",
-    ToyotaCarInfo("Lexus CT Hybrid 2017-18", "Lexus Safety System+"),
+    [ToyotaCarInfo("Lexus CT Hybrid 2017-18", "Lexus Safety System+")],
     CarSpecs(mass=3108. * CV.LB_TO_KG, wheelbase=2.6, steerRatio=18.6, tireStiffnessFactor=0.517),
     dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
   )
@@ -304,14 +304,14 @@ class CAR(Platforms):
   )
   LEXUS_IS = PlatformConfig(
     "LEXUS IS 2018",
-    ToyotaCarInfo("Lexus IS 2017-19"),
+    [ToyotaCarInfo("Lexus IS 2017-19")],
     CarSpecs(mass=3736.8 * CV.LB_TO_KG, wheelbase=2.79908, steerRatio=13.3, tireStiffnessFactor=0.444),
     dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
     flags=ToyotaFlags.UNSUPPORTED_DSU,
   )
   LEXUS_IS_TSS2 = ToyotaTSS2PlatformConfig(
     "LEXUS IS 2023",
-    ToyotaCarInfo("Lexus IS 2022-23"),
+    [ToyotaCarInfo("Lexus IS 2022-23")],
     LEXUS_IS.specs,
   )
   LEXUS_NX = PlatformConfig(
@@ -333,12 +333,12 @@ class CAR(Platforms):
   )
   LEXUS_LC_TSS2 = ToyotaTSS2PlatformConfig(
     "LEXUS LC 2024",
-    ToyotaCarInfo("Lexus LC 2024"),
+    [ToyotaCarInfo("Lexus LC 2024")],
     CarSpecs(mass=4500. * CV.LB_TO_KG, wheelbase=2.87, steerRatio=13.0, tireStiffnessFactor=0.444),
   )
   LEXUS_RC = PlatformConfig(
     "LEXUS RC 2020",
-    ToyotaCarInfo("Lexus RC 2018-20"),
+    [ToyotaCarInfo("Lexus RC 2018-20")],
     LEXUS_IS.specs,
     dbc_dict('toyota_tnga_k_pt_generated', 'toyota_adas'),
     flags=ToyotaFlags.UNSUPPORTED_DSU,
@@ -365,7 +365,7 @@ class CAR(Platforms):
   )
   LEXUS_GS_F = PlatformConfig(
     "LEXUS GS F 2016",
-    ToyotaCarInfo("Lexus GS F 2016"),
+    [ToyotaCarInfo("Lexus GS F 2016")],
     CarSpecs(mass=4034. * CV.LB_TO_KG, wheelbase=2.84988, steerRatio=13.3, tireStiffnessFactor=0.444),
     dbc_dict('toyota_new_mc_pt_generated', 'toyota_adas'),
     flags=ToyotaFlags.UNSUPPORTED_DSU,

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -250,7 +250,7 @@ class CAR(Platforms):
   )
   PASSAT_NMS = VolkswagenPQPlatformConfig(
     "VOLKSWAGEN PASSAT NMS",  # Chassis A3
-    VWCarInfo("Volkswagen Passat NMS 2017-22"),
+    [VWCarInfo("Volkswagen Passat NMS 2017-22")],
     VolkswagenCarSpecs(mass=1503, wheelbase=2.80, minSteerSpeed=50*CV.KPH_TO_MS, minEnableSpeed=20*CV.KPH_TO_MS),
   )
   POLO_MK6 = VolkswagenMQBPlatformConfig(
@@ -271,12 +271,12 @@ class CAR(Platforms):
   )
   TAOS_MK1 = VolkswagenMQBPlatformConfig(
     "VOLKSWAGEN TAOS 1ST GEN",  # Chassis B2
-    VWCarInfo("Volkswagen Taos 2022-23"),
+    [VWCarInfo("Volkswagen Taos 2022-23")],
     VolkswagenCarSpecs(mass=1498, wheelbase=2.69),
   )
   TCROSS_MK1 = VolkswagenMQBPlatformConfig(
     "VOLKSWAGEN T-CROSS 1ST GEN",  # Chassis C1
-    VWCarInfo("Volkswagen T-Cross 2021", footnotes=[Footnote.VW_MQB_A0]),
+    [VWCarInfo("Volkswagen T-Cross 2021", footnotes=[Footnote.VW_MQB_A0])],
     VolkswagenCarSpecs(mass=1150, wheelbase=2.60),
   )
   TIGUAN_MK2 = VolkswagenMQBPlatformConfig(
@@ -289,7 +289,7 @@ class CAR(Platforms):
   )
   TOURAN_MK2 = VolkswagenMQBPlatformConfig(
     "VOLKSWAGEN TOURAN 2ND GEN",  # Chassis 1T
-    VWCarInfo("Volkswagen Touran 2016-23"),
+    [VWCarInfo("Volkswagen Touran 2016-23")],
     VolkswagenCarSpecs(mass=1516, wheelbase=2.79),
   )
   TRANSPORTER_T61 = VolkswagenMQBPlatformConfig(
@@ -302,7 +302,7 @@ class CAR(Platforms):
   )
   TROC_MK1 = VolkswagenMQBPlatformConfig(
     "VOLKSWAGEN T-ROC 1ST GEN",  # Chassis A1
-    VWCarInfo("Volkswagen T-Roc 2018-22", footnotes=[Footnote.VW_MQB_A0]),
+    [VWCarInfo("Volkswagen T-Roc 2018-22", footnotes=[Footnote.VW_MQB_A0])],
     VolkswagenCarSpecs(mass=1413, wheelbase=2.63),
   )
   AUDI_A3_MK3 = VolkswagenMQBPlatformConfig(
@@ -317,42 +317,42 @@ class CAR(Platforms):
   )
   AUDI_Q2_MK1 = VolkswagenMQBPlatformConfig(
     "AUDI Q2 1ST GEN",  # Chassis GA
-    VWCarInfo("Audi Q2 2018"),
+    [VWCarInfo("Audi Q2 2018")],
     VolkswagenCarSpecs(mass=1205, wheelbase=2.61),
   )
   AUDI_Q3_MK2 = VolkswagenMQBPlatformConfig(
     "AUDI Q3 2ND GEN",  # Chassis 8U/F3/FS
-    VWCarInfo("Audi Q3 2019-23"),
+    [VWCarInfo("Audi Q3 2019-23")],
     VolkswagenCarSpecs(mass=1623, wheelbase=2.68),
   )
   SEAT_ATECA_MK1 = VolkswagenMQBPlatformConfig(
     "SEAT ATECA 1ST GEN",  # Chassis 5F
-    VWCarInfo("SEAT Ateca 2018"),
+    [VWCarInfo("SEAT Ateca 2018")],
     VolkswagenCarSpecs(mass=1900, wheelbase=2.64),
   )
   SEAT_LEON_MK3 = VolkswagenMQBPlatformConfig(
     "SEAT LEON 3RD GEN",  # Chassis 5F
-    VWCarInfo("SEAT Leon 2014-20"),
+    [VWCarInfo("SEAT Leon 2014-20")],
     VolkswagenCarSpecs(mass=1227, wheelbase=2.64),
   )
   SKODA_FABIA_MK4 = VolkswagenMQBPlatformConfig(
     "SKODA FABIA 4TH GEN",  # Chassis PJ
-    VWCarInfo("Škoda Fabia 2022-23", footnotes=[Footnote.VW_MQB_A0]),
+    [VWCarInfo("Škoda Fabia 2022-23", footnotes=[Footnote.VW_MQB_A0])],
     VolkswagenCarSpecs(mass=1266, wheelbase=2.56),
   )
   SKODA_KAMIQ_MK1 = VolkswagenMQBPlatformConfig(
     "SKODA KAMIQ 1ST GEN",  # Chassis NW
-    VWCarInfo("Škoda Kamiq 2021-23", footnotes=[Footnote.VW_MQB_A0, Footnote.KAMIQ]),
+    [VWCarInfo("Škoda Kamiq 2021-23", footnotes=[Footnote.VW_MQB_A0, Footnote.KAMIQ])],
     VolkswagenCarSpecs(mass=1265, wheelbase=2.66),
   )
   SKODA_KAROQ_MK1 = VolkswagenMQBPlatformConfig(
     "SKODA KAROQ 1ST GEN",  # Chassis NU
-    VWCarInfo("Škoda Karoq 2019-23"),
+    [VWCarInfo("Škoda Karoq 2019-23")],
     VolkswagenCarSpecs(mass=1278, wheelbase=2.66),
   )
   SKODA_KODIAQ_MK1 = VolkswagenMQBPlatformConfig(
     "SKODA KODIAQ 1ST GEN",  # Chassis NS
-    VWCarInfo("Škoda Kodiaq 2017-23"),
+    [VWCarInfo("Škoda Kodiaq 2017-23")],
     VolkswagenCarSpecs(mass=1569, wheelbase=2.79),
   )
   SKODA_OCTAVIA_MK3 = VolkswagenMQBPlatformConfig(
@@ -365,12 +365,12 @@ class CAR(Platforms):
   )
   SKODA_SCALA_MK1 = VolkswagenMQBPlatformConfig(
     "SKODA SCALA 1ST GEN",  # Chassis NW
-    VWCarInfo("Škoda Scala 2020-23", footnotes=[Footnote.VW_MQB_A0]),
+    [VWCarInfo("Škoda Scala 2020-23", footnotes=[Footnote.VW_MQB_A0])],
     VolkswagenCarSpecs(mass=1192, wheelbase=2.65),
   )
   SKODA_SUPERB_MK3 = VolkswagenMQBPlatformConfig(
     "SKODA SUPERB 3RD GEN",  # Chassis 3V/NP
-    VWCarInfo("Škoda Superb 2015-22"),
+    [VWCarInfo("Škoda Superb 2015-22")],
     VolkswagenCarSpecs(mass=1505, wheelbase=2.84),
   )
 


### PR DESCRIPTION
it was a hack in the beginning, see no reason why we can't always specify lists