### PR TITLE
Adding steerRatio for 4th gen Hyundai Tucson (2022+)

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -356,7 +356,7 @@ class CAR(Platforms):
       HyundaiCarInfo("Hyundai Tucson 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_n])),
       HyundaiCarInfo("Hyundai Tucson Hybrid 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_n])),
     ],
-    CarSpecs(mass=1630, wheelbase=2.756, steerRatio=16, tireStiffnessFactor=0.385),
+    CarSpecs(mass=1630, wheelbase=2.756, steerRatio=13.7, tireStiffnessFactor=0.385),
   )
   SANTA_CRUZ_1ST_GEN = HyundaiCanFDPlatformConfig(
     "HYUNDAI SANTA CRUZ 1ST GEN",


### PR DESCRIPTION
Updating the steering ratio for the 4th gen Hyundai Tucson based on: https://www.hyundainews.com/assets/documents/original/50311-2023TucsonProductSpecifications20220630.pdf

Steering is much less 'twitchy' with this value, with and without twilsonco's lateral controller.
