### PR TITLE
cabana(DBCFile): interleave msg and signal comments

### DIFF
--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -191,12 +191,12 @@ void DBCFile::parse(const QString &content) {
 }
 
 QString DBCFile::generateDBC() {
-  QString dbc_string, signal_comment, message_comment, val_desc;
+  QString dbc_string, comment, val_desc;
   for (const auto &[address, m] : msgs) {
     const QString transmitter = m.transmitter.isEmpty() ? DEFAULT_NODE_NAME : m.transmitter;
     dbc_string += QString("BO_ %1 %2: %3 %4\n").arg(address).arg(m.name).arg(m.size).arg(transmitter);
     if (!m.comment.isEmpty()) {
-      message_comment += QString("CM_ BO_ %1 \"%2\";\n").arg(address).arg(m.comment);
+      comment += QString("CM_ BO_ %1 \"%2\";\n").arg(address).arg(m.comment);
     }
     for (auto sig : m.getSignals()) {
       QString multiplexer_indicator;
@@ -219,7 +219,7 @@ QString DBCFile::generateDBC() {
                         .arg(sig->unit)
                         .arg(sig->receiver_name.isEmpty() ? DEFAULT_NODE_NAME : sig->receiver_name);
       if (!sig->comment.isEmpty()) {
-        signal_comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);
+        comment += QString("CM_ SG_ %1 %2 \"%3\";\n").arg(address).arg(sig->name).arg(sig->comment);
       }
       if (!sig->val_desc.empty()) {
         QStringList text;
@@ -231,5 +231,5 @@ QString DBCFile::generateDBC() {
     }
     dbc_string += "\n";
   }
-  return dbc_string + message_comment + signal_comment + val_desc;
+  return dbc_string + comment + val_desc;
 }

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -28,6 +28,23 @@ TEST_CASE("DBCFile::generateDBC") {
   }
 }
 
+TEST_CASE("DBCFile::generateDBC - comment order") {
+  // Ensure that message comments are followed by signal comments and in the correct order
+  auto content = R"(BO_ 160 message_1: 8 EON
+ SG_ signal_1 : 0|12@1+ (1,0) [0|4095] "unit" XXX
+
+BO_ 162 message_2: 8 EON
+ SG_ signal_2 : 0|12@1+ (1,0) [0|4095] "unit" XXX
+
+CM_ BO_ 160 "message comment";
+CM_ SG_ 160 signal_1 "signal comment";
+CM_ BO_ 162 "message comment";
+CM_ SG_ 162 signal_2 "signal comment";
+)";
+  DBCFile dbc("", content);
+  REQUIRE(dbc.generateDBC() == content);
+}
+
 TEST_CASE("parse_dbc") {
   QString content = R"(
 BO_ 160 message_1: 8 EON


### PR DESCRIPTION
This matches the behaviour of CANdb++

For example:
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

```
BO_ 160 message_1: 8 EON
 SG_ signal_1 : 0|12@1+ (1,0) [0|4095] "unit" XXX

BO_ 162 message_2: 8 EON
 SG_ signal_2 : 0|12@1+ (1,0) [0|4095] "unit" XXX

CM_ BO_ 160 "message comment";
CM_ BO_ 162 "message comment";
CM_ SG_ 160 signal_1 "signal comment";
CM_ SG_ 162 signal_2 "signal comment";
```

</td>
<td>

```
BO_ 160 message_1: 8 EON
 SG_ signal_1 : 0|12@1+ (1,0) [0|4095] "unit" XXX

BO_ 162 message_2: 8 EON
 SG_ signal_2 : 0|12@1+ (1,0) [0|4095] "unit" XXX

CM_ BO_ 160 "message comment";
CM_ SG_ 160 signal_1 "signal comment";
CM_ BO_ 162 "message comment";
CM_ SG_ 162 signal_2 "signal comment";
```

</td></tr>
</table>

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

