### PR TITLE
cabana(DBCFile): preserve original header

### DIFF
--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -98,10 +98,13 @@ void DBCFile::parse(const QString &content) {
   QTextStream stream((QString *)&content);
   cabana::Msg *current_msg = nullptr;
   int multiplexor_cnt = 0;
+  bool seen_first = false;
   while (!stream.atEnd()) {
     ++line_num;
     QString raw_line = stream.readLine();
     line = raw_line.trimmed();
+
+    bool seen = true;
     if (line.startsWith("BO_ ")) {
       multiplexor_cnt = 0;
       auto match = bo_regexp.match(line);
@@ -182,6 +185,14 @@ void DBCFile::parse(const QString &content) {
       if (auto s = get_sig(match.captured(1).toUInt(), match.captured(2))) {
         s->comment = match.captured(3).trimmed();
       }
+    } else {
+      seen = false;
+    }
+
+    if (seen) {
+      seen_first = true;
+    } else if (!seen_first) {
+      header += raw_line + "\n";
     }
   }
 
@@ -231,5 +242,5 @@ QString DBCFile::generateDBC() {
     }
     dbc_string += "\n";
   }
-  return dbc_string + message_comment + signal_comment + val_desc;
+  return header + dbc_string + message_comment + signal_comment + val_desc;
 }

--- a/tools/cabana/dbc/dbcfile.h
+++ b/tools/cabana/dbc/dbcfile.h
@@ -34,6 +34,7 @@ public:
 
 private:
   void parse(const QString &content);
+  QString header;
   std::map<uint32_t, cabana::Msg> msgs;
   QString name_;
 };

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -28,6 +28,26 @@ TEST_CASE("DBCFile::generateDBC") {
   }
 }
 
+TEST_CASE("DBCFile::generateDBC -- preserve original header") {
+  QString content = R"(VERSION "1.0"
+
+NS_ :
+ CM_
+
+BS_:
+
+BU_: EON
+
+BO_ 160 message_1: 8 EON
+ SG_ signal_1 : 0|12@1+ (1,0) [0|4095] "unit" XXX
+
+CM_ BO_ 160 "message comment";
+CM_ SG_ 160 signal_1 "signal comment";
+)";
+  DBCFile dbc("", content);
+  REQUIRE(dbc.generateDBC() == content);
+}
+
 TEST_CASE("parse_dbc") {
   QString content = R"(
 BO_ 160 message_1: 8 EON

--- a/tools/cabana/tests/test_cabana.cc
+++ b/tools/cabana/tests/test_cabana.cc
@@ -79,7 +79,7 @@ VAL_ 160 signal_1 0 "disabled" 1.2 "initializing" 2 "fault";
 
 CM_ BO_ 160 "message comment" ;
 CM_ SG_ 160 signal_1 "signal comment";
-CM_ SG_ 160 signal_2 "multiple line comment
+CM_ SG_ 160 signal_2 "multiple line comment 
 1
 2
 ";)";


### PR DESCRIPTION
Most DBC files have headers which cabana can't decode or generate yet, but it would still be helpful to preserve these lines when updating and saving the file.

**Verification**
- [x] added test case
- [x] tested opening and saving DBCs in cabana

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

