### PR TITLE
replay: fix segfault in `Replay::queueSegment`

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -225,7 +225,7 @@ void Replay::queueSegment() {
   if (cur == segments_.end()) return;
 
   auto begin = std::prev(cur, std::min<int>(segment_cache_limit / 2, std::distance(segments_.begin(), cur)));
-  auto end = std::next(begin, std::min<int>(segment_cache_limit, segments_.size()));
+  auto end = std::next(begin, std::min<int>(segment_cache_limit, std::distance(begin, segments_.end())));
   // load one segment at a time
   auto it = std::find_if(cur, end, [](auto &it) { return !it.second || !it.second->isLoaded(); });
   if (it != end && !it->second) {


### PR DESCRIPTION
fixed the issue https://github.com/commaai/openpilot/discussions/26091#discussioncomment-8120589

> @nworb-cire : 
 I've been getting segfaults lately on M1 macos whenever cabana enters segment 16 or later of a route. Segments 0-15 have no issues. It happens either when I let the stream play through the end of segment 15, or if I launch the segment directly by appending `--16` (or some number greater than 16) to the route ID.
> 
> Log from one such incident: [segfault.log](https://github.com/commaai/openpilot/files/13929574/segfault.log)

