### PR TITLE
controlsd: fix steer saturation premature warning

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -143,6 +143,7 @@ class Controls:
     self.logged_comm_issue = None
     self.not_running_prev = None
     self.steer_limited = False
+    self.last_actuators = car.CarControl.Actuators.new_message()
     self.desired_curvature = 0.0
     self.experimental_mode = False
     self.personality = self.read_personality_param()
@@ -620,7 +621,7 @@ class Controls:
         undershooting = abs(lac_log.desiredLateralAccel) / abs(1e-3 + lac_log.actualLateralAccel) > 1.2
         turning = abs(lac_log.desiredLateralAccel) > 1.0
         good_speed = CS.vEgo > 5
-        max_torque = abs(actuators.steer) > 0.99
+        max_torque = abs(self.last_actuators.steer) > 0.99
         if undershooting and turning and good_speed and max_torque:
           lac_log.active and self.events.add(EventName.steerSaturated)
       elif lac_log.saturated:
@@ -727,6 +728,7 @@ class Controls:
 
     if not self.CP.passive and self.initialized:
       self.card.controls_update(CC)
+      self.last_actuators = CO.actuatorsOutput
       if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
         self.steer_limited = abs(CC.actuators.steeringAngleDeg - CO.actuatorsOutput.steeringAngleDeg) > \
                              STEER_ANGLE_SATURATION_THRESHOLD


### PR DESCRIPTION
closes: https://github.com/commaai/openpilot/issues/31876

verified with process replay that there is no diff in the onroadEvents
`7852e9f76b7e6e8a/00000010--a52a24a21e/21`

`master`
```
startupMaster
controlsInitializing
controlsInitializing
controlsInitializing
steerSaturated
steerSaturated
steerSaturated
steerSaturated
```
`master before card refactor`
```
startupMaster
controlsInitializing
controlsInitializing
controlsInitializing
```
`this branch`
```
startupMaster
controlsInitializing
controlsInitializing
controlsInitializing
```