### PR TITLE
replay: get route datetime from INIT_DATA

### DIFF
--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -23,7 +23,7 @@ public:
   inline QString routeName() const override { return replay->route()->name(); }
   inline QString carFingerprint() const override { return replay->carFingerprint().c_str(); }
   double totalSeconds() const override { return replay->totalSeconds(); }
-  inline QDateTime beginDateTime() const { return replay->route()->datetime(); }
+  inline QDateTime beginDateTime() const { return replay->routeDateTime(); }
   inline double routeStartTime() const override { return replay->routeStartTime() / (double)1e9; }
   inline const Route *route() const { return replay->route(); }
   inline void setSpeed(float speed) override { replay->setSpeed(speed); }

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -290,12 +290,22 @@ void Replay::mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::
 void Replay::startStream(const Segment *cur_segment) {
   const auto &events = cur_segment->log->events;
 
-  // each segment has an INIT_DATA
   route_start_ts_ = events.front()->mono_time;
   cur_mono_time_ += route_start_ts_ - 1;
 
+  // get datetime from INIT_DATA, fallback to datetime in the route name
+  route_date_time_ = route()->datetime();
+  auto it = std::find_if(events.cbegin(), events.cend(),
+                         [](auto e) { return e->which == cereal::Event::Which::INIT_DATA; });
+  if (it != events.cend()) {
+    uint64_t wall_time = (*it)->event.getInitData().getWallTimeNanos();
+    if (wall_time > 0) {
+      route_date_time_ = QDateTime::fromMSecsSinceEpoch(wall_time / 1e6);
+    }
+  }
+
   // write CarParams
-  auto it = std::find_if(events.begin(), events.end(), [](auto e) { return e->which == cereal::Event::Which::CAR_PARAMS; });
+  it = std::find_if(events.begin(), events.end(), [](auto e) { return e->which == cereal::Event::Which::CAR_PARAMS; });
   if (it != events.end()) {
     car_fingerprint_ = (*it)->event.getCarParams().getCarFingerprint();
     capnp::MallocMessageBuilder builder;

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -72,7 +72,8 @@ public:
   inline void removeFlag(REPLAY_FLAGS flag) { flags_ &= ~flag; }
   inline const Route* route() const { return route_.get(); }
   inline double currentSeconds() const { return double(cur_mono_time_ - route_start_ts_) / 1e9; }
-  inline QDateTime currentDateTime() const { return route_->datetime().addSecs(currentSeconds()); }
+  inline QDateTime routeDateTime() const { return route_date_time_; }
+  inline QDateTime currentDateTime() const { return route_date_time_.addSecs(currentSeconds()); }
   inline uint64_t routeStartTime() const { return route_start_ts_; }
   inline double toSeconds(uint64_t mono_time) const { return (mono_time - route_start_ts_) / 1e9; }
   inline int totalSeconds() const { return (!segments_.empty()) ? (segments_.rbegin()->first + 1) * 60 : 0; }
@@ -121,6 +122,7 @@ protected:
   std::atomic<bool> exit_ = false;
   bool paused_ = false;
   bool events_updated_ = false;
+  QDateTime route_date_time_;
   uint64_t route_start_ts_ = 0;
   std::atomic<uint64_t> cur_mono_time_ = 0;
   std::unique_ptr<std::vector<Event *>> events_;


### PR DESCRIPTION
support timeless routes. get route datetime from wall time in the INIT_DATA