### PR TITLE
add get_build_metadata function

### DIFF
--- a/common/git.py
+++ b/common/git.py
@@ -1,27 +1,26 @@
 import subprocess
-from openpilot.common.basedir import BASEDIR
 from openpilot.common.utils import cache
 from openpilot.common.run import run_cmd, run_cmd_default
 
 
 @cache
-def get_commit(path: str = BASEDIR, branch: str = "HEAD") -> str:
-  return run_cmd_default(["git", "rev-parse", branch], cwd=path)
+def get_commit(cwd: str = None, branch: str = "HEAD") -> str:
+  return run_cmd_default(["git", "rev-parse", branch], cwd=cwd)
 
 
 @cache
-def get_commit_date(path: str = BASEDIR, commit: str = "HEAD") -> str:
-  return run_cmd_default(["git", "show", "--no-patch", "--format='%ct %ci'", commit], cwd=path)
+def get_commit_date(cwd: str = None, commit: str = "HEAD") -> str:
+  return run_cmd_default(["git", "show", "--no-patch", "--format='%ct %ci'", commit], cwd=cwd)
 
 
 @cache
-def get_short_branch(path: str = BASEDIR) -> str:
-  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=path)
+def get_short_branch(cwd: str = None) -> str:
+  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd)
 
 
 @cache
-def get_branch(path: str = BASEDIR) -> str:
-  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd=path)
+def get_branch(cwd: str = None) -> str:
+  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd=cwd)
 
 
 @cache

--- a/common/git.py
+++ b/common/git.py
@@ -1,26 +1,27 @@
 import subprocess
+from openpilot.common.basedir import BASEDIR
 from openpilot.common.utils import cache
 from openpilot.common.run import run_cmd, run_cmd_default
 
 
 @cache
-def get_commit(branch: str = "HEAD") -> str:
-  return run_cmd_default(["git", "rev-parse", branch])
+def get_commit(path: str = BASEDIR, branch: str = "HEAD") -> str:
+  return run_cmd_default(["git", "rev-parse", branch], cwd=path)
 
 
 @cache
-def get_commit_date(commit: str = "HEAD") -> str:
-  return run_cmd_default(["git", "show", "--no-patch", "--format='%ct %ci'", commit])
+def get_commit_date(path: str = BASEDIR, commit: str = "HEAD") -> str:
+  return run_cmd_default(["git", "show", "--no-patch", "--format='%ct %ci'", commit], cwd=path)
 
 
 @cache
-def get_short_branch() -> str:
-  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+def get_short_branch(path: str = BASEDIR) -> str:
+  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=path)
 
 
 @cache
-def get_branch() -> str:
-  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+def get_branch(path: str = BASEDIR) -> str:
+  return run_cmd_default(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd=path)
 
 
 @cache

--- a/common/run.py
+++ b/common/run.py
@@ -1,13 +1,13 @@
 import subprocess
 
 
-def run_cmd(cmd: list[str]) -> str:
-  return subprocess.check_output(cmd, encoding='utf8').strip()
+def run_cmd(cmd: list[str], cwd=None) -> str:
+  return subprocess.check_output(cmd, encoding='utf8', cwd=cwd).strip()
 
 
-def run_cmd_default(cmd: list[str], default: str = "") -> str:
+def run_cmd_default(cmd: list[str], default: str = "", cwd=None) -> str:
   try:
-    return run_cmd(cmd)
+    return run_cmd(cmd, cwd=cwd)
   except subprocess.CalledProcessError:
     return default
 

--- a/system/version.py
+++ b/system/version.py
@@ -16,11 +16,16 @@ training_version: bytes = b"0.2.0"
 terms_version: bytes = b"2"
 
 
-@cache
-def get_version() -> str:
-  with open(os.path.join(BASEDIR, "common", "version.h")) as _versionf:
+def get_version(path: str = BASEDIR) -> str:
+  with open(os.path.join(path, "common", "version.h")) as _versionf:
     version = _versionf.read().split('"')[1]
   return version
+
+
+def get_release_notes(path: str = BASEDIR) -> str:
+  with open(os.path.join(path, "RELEASES.md"), "r") as f:
+    return f.read().split('\n\n', 1)[0]
+
 
 @cache
 def get_short_version() -> str:

--- a/system/version.py
+++ b/system/version.py
@@ -80,7 +80,6 @@ def is_dirty() -> bool:
   return dirty
 
 
-
 class OpenpilotMetadata(TypedDict):
   version: str
   release_notes: str

--- a/system/version.py
+++ b/system/version.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+from dataclasses import dataclass
 import json
 import os
 import pathlib
 import subprocess
-from typing import TypedDict
 
 
 from openpilot.common.basedir import BASEDIR
@@ -80,26 +80,18 @@ def is_dirty() -> bool:
   return dirty
 
 
-class OpenpilotMetadata(TypedDict):
+@dataclass(frozen=True)
+class OpenpilotMetadata:
   version: str
   release_notes: str
   git_commit: str
 
 
-class BuildMetadata(TypedDict):
+@dataclass(frozen=True)
+class BuildMetadata:
   channel: str
   openpilot: OpenpilotMetadata
 
-
-def create_build_metadata(channel, version, release_notes, commit) -> BuildMetadata:
-  return {
-    "channel": channel,
-    "openpilot": {
-      "version": version,
-      "release_notes": release_notes,
-      "git_commit": commit
-    }
-  }
 
 
 def get_build_metadata(path: str = BASEDIR) -> BuildMetadata | None:
@@ -113,12 +105,12 @@ def get_build_metadata(path: str = BASEDIR) -> BuildMetadata | None:
     version = openpilot_metadata.get("version", "unknown")
     release_notes = openpilot_metadata.get("release_notes", "unknown")
     git_commit = openpilot_metadata.get("git_commit", "unknown")
-    return create_build_metadata(channel, version, release_notes, git_commit)
+    return BuildMetadata(channel, OpenpilotMetadata(version, release_notes, git_commit))
 
   git_folder = pathlib.Path(path) / ".git"
 
   if git_folder.exists():
-    return create_build_metadata(get_short_branch(path), get_version(path), get_release_notes(path), get_commit(path))
+    return BuildMetadata(get_short_branch(path), OpenpilotMetadata(get_version(path), get_release_notes(path), get_commit(path)))
 
   return None
 

--- a/system/version.py
+++ b/system/version.py
@@ -87,13 +87,13 @@ class OpenpilotMetadata(TypedDict):
 
 
 class BuildMetadata(TypedDict):
-  name: str
+  channel: str
   openpilot: OpenpilotMetadata
 
 
 def create_build_metadata(channel, version, release_notes, commit) -> BuildMetadata:
   return {
-    "name": channel,
+    "channel": channel,
     "openpilot": {
       "version": version,
       "release_notes": release_notes,

--- a/system/version.py
+++ b/system/version.py
@@ -3,7 +3,7 @@ import json
 import os
 import pathlib
 import subprocess
-from typing import TypedDict, cast
+from typing import TypedDict
 
 
 from openpilot.common.basedir import BASEDIR
@@ -106,7 +106,14 @@ def get_build_metadata(path: str = BASEDIR) -> BuildMetadata | None:
   build_metadata_path = pathlib.Path(path) / BUILD_METADATA_FILENAME
 
   if build_metadata_path.exists():
-    return cast(BuildMetadata, json.loads(build_metadata_path.read_text()))
+    build_metadata = json.loads(build_metadata_path.read_text())
+    openpilot_metadata = build_metadata.get("openpilot", {})
+
+    channel = build_metadata.get("channel", "unknown")
+    version = openpilot_metadata.get("version", "unknown")
+    release_notes = openpilot_metadata.get("release_notes", "unknown")
+    git_commit = openpilot_metadata.get("git_commit", "unknown")
+    return create_build_metadata(channel, version, release_notes, git_commit)
 
   git_folder = pathlib.Path(path) / ".git"
 


### PR DESCRIPTION
reads from local `build.json` if available, otherwise falls back to creating manually from the git commands like we talked about @adeebshihadeh 