### PR TITLE
util: safer `ends_with`

### DIFF
--- a/common/util.cc
+++ b/common/util.cc
@@ -256,9 +256,9 @@ bool starts_with(const std::string &s1, const std::string &s2) {
   return strncmp(s1.c_str(), s2.c_str(), s2.size()) == 0;
 }
 
-bool ends_with(const std::string &s1, const std::string &s2) {
-  if (s2.size() > s1.size()) return false;
-  return strcmp(s1.c_str() + (s1.size() - s2.size()), s2.c_str()) == 0;
+bool ends_with(const std::string& s, const std::string& suffix) {
+  return s.size() >= suffix.size() &&
+         strcmp(s.c_str() + (s.size() - suffix.size()), suffix.c_str()) == 0;
 }
 
 std::string check_output(const std::string& command) {

--- a/common/util.cc
+++ b/common/util.cc
@@ -257,6 +257,7 @@ bool starts_with(const std::string &s1, const std::string &s2) {
 }
 
 bool ends_with(const std::string &s1, const std::string &s2) {
+  if (s2.size() > s1.size()) return false;
   return strcmp(s1.c_str() + (s1.size() - s2.size()), s2.c_str()) == 0;
 }
 

--- a/common/util.h
+++ b/common/util.h
@@ -77,7 +77,7 @@ float getenv(const char* key, float default_val);
 std::string hexdump(const uint8_t* in, const size_t size);
 std::string dir_name(std::string const& path);
 bool starts_with(const std::string &s1, const std::string &s2);
-bool ends_with(const std::string &s1, const std::string &s2);
+bool ends_with(const std::string &s, const std::string &suffix);
 
 // ***** random helpers *****
 int random_int(int min, int max);


### PR DESCRIPTION
it's safer to check the size before `strcmp` to avoid access invalid address.