### PR TITLE
ui/cameraview: fix accessing uninitialized variable

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -98,7 +98,7 @@ mat4 get_fit_view_transform(float widget_aspect_ratio, float frame_aspect_ratio)
 } // namespace
 
 CameraWidget::CameraWidget(std::string stream_name, VisionStreamType type, bool zoom, QWidget* parent) :
-                          stream_name(stream_name), requested_stream_type(type), zoomed_view(zoom), QOpenGLWidget(parent) {
+                          stream_name(stream_name), active_stream_type(type), requested_stream_type(type), zoomed_view(zoom), QOpenGLWidget(parent) {
   setAttribute(Qt::WA_OpaquePaintEvent);
   qRegisterMetaType<std::set<VisionStreamType>>("availableStreams");
   QObject::connect(this, &CameraWidget::vipcThreadConnected, this, &CameraWidget::vipcConnected, Qt::BlockingQueuedConnection);


### PR DESCRIPTION
valgrind runs showed the following errors:

> ==80698== 1 errors in context 2 of 66:
==80698== Conditional jump or move depends on uninitialised value(s)
==80698==    at 0x486358: CameraWidget::updateFrameMat() (cameraview.cc:219)
==80698==    by 0x4521B2: AnnotatedCameraWidget::updateFrameMat() (onroad.cc:451)
==80698==    by 0x5268C6A: QOpenGLWidget::resizeEvent(QResizeEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x5246946: QWidget::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x5203A65: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x520D0EF: QApplication::notify(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x5FA5809: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.12.8)
==80698==    by 0x523EE6D: QWidgetPrivate::sendPendingMoveAndResizeEvents(bool, bool) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x5242BD6: QWidgetPrivate::show_helper() (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x5245D6A: QWidgetPrivate::setVisible(bool) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x5242B60: QWidgetPrivate::showChildren(bool) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698==    by 0x5242BF2: QWidgetPrivate::show_helper() (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.12.8)
==80698== 

issue: the `active_stream_type` can be accessed in `updateFrameMat` before it's initialized by `vipcThread`:

https://github.com/commaai/openpilot/blob/35b31df7f716d4d5de045d6dd5305572c20d01f9/selfdrive/ui/qt/widgets/cameraview.cc#L219

fix: init `active_stream_type` in CTOR