### PR TITLE
ui/sidebar: do not send the `userFlag` while offroad

### DIFF
--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -55,7 +55,7 @@ void Sidebar::mouseReleaseEvent(QMouseEvent *event) {
     flag_pressed = settings_pressed = false;
     update();
   }
-  if (home_btn.contains(event->pos())) {
+  if (onroad && home_btn.contains(event->pos())) {
     MessageBuilder msg;
     msg.initEvent().initUserFlag();
     pm->send("userFlag", msg);


### PR DESCRIPTION
fixed the issue that the `userFlag` message will still be sent if the user clicks the home button while offroad.