### PR TITLE
ui/map_eta: avoid divide by zero

### DIFF
--- a/selfdrive/ui/qt/maps/map_eta.cc
+++ b/selfdrive/ui/qt/maps/map_eta.cc
@@ -38,10 +38,13 @@ void MapETA::updateETA(float s, float s_typical, float d) {
   auto remaining = s < 3600 ? std::pair{QString::number(int(s / 60)), tr("min")}
                             : std::pair{QString("%1:%2").arg((int)s / 3600).arg(((int)s % 3600) / 60, 2, 10, QLatin1Char('0')), tr("hr")};
   QString color = "#25DA6E";
-  if (s / s_typical > 1.5)
-    color = "#DA3025";
-  else if (s / s_typical > 1.2)
-    color = "#DAA725";
+  if (std::abs(s_typical) > 1e-5) {
+    if (s / s_typical > 1.5) {
+      color = "#DA3025";
+    } else if (s / s_typical > 1.2) {
+      color = "#DAA725";
+    }
+  }
 
   // Distance
   auto distance = map_format_distance(d, uiState()->scene.is_metric);


### PR DESCRIPTION
Not quite sure if s_type （`TimeRemainingTypical`）is likely to be 0. But it would be safer to add a check here.