### PR TITLE
casync build: caidx filename is canonical representation of build

### DIFF
--- a/release/copy_build_files.sh
+++ b/release/copy_build_files.sh
@@ -11,5 +11,5 @@ else
 fi
 
 cd $SOURCE_DIR
-cp -pR --parents $(cat release/files_common) $BUILD_DIR/
+cp -pR --parents $(cat release/files_common) $TARGET_DIR/
 cp -pR --parents $(cat $FILES_SRC) $TARGET_DIR/

--- a/release/create_casync_release.py
+++ b/release/create_casync_release.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="creates a casync release")
   parser.add_argument("target_dir", type=str, help="target directory to build channel from")
   parser.add_argument("output_dir", type=str, help="output directory for the channel")
+  parser.add_argument("channel", type=str, help="what channel this build is")
   args = parser.parse_args()
 
   target_dir = pathlib.Path(args.target_dir)

--- a/release/create_casync_release.py
+++ b/release/create_casync_release.py
@@ -24,6 +24,6 @@ if __name__ == "__main__":
   create_build_metadata_file(target_dir, build_metadata, args.channel)
   create_caexclude_file(target_dir)
 
-  digest, caidx = create_casync_release(target_dir, output_dir, build_metadata.canonical())
+  digest, caidx = create_casync_release(target_dir, output_dir, build_metadata.canonical)
 
   print(f"Created casync release from {target_dir} to {caidx} with digest {digest}")

--- a/release/create_casync_release.py
+++ b/release/create_casync_release.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import os
 import pathlib
 
 from openpilot.system.updated.casync.common import create_caexclude_file, create_casync_release, create_build_metadata_file
@@ -18,6 +19,7 @@ if __name__ == "__main__":
   output_dir = pathlib.Path(args.output_dir)
 
   build_metadata = get_build_metadata()
+  build_metadata.openpilot.build_style = "release" if os.environ.get("RELEASE", None) is not None else "debug"
 
   create_build_metadata_file(target_dir, build_metadata, args.channel)
   create_caexclude_file(target_dir)

--- a/release/create_casync_release.py
+++ b/release/create_casync_release.py
@@ -17,10 +17,10 @@ if __name__ == "__main__":
   target_dir = pathlib.Path(args.target_dir)
   output_dir = pathlib.Path(args.output_dir)
 
-  create_build_metadata_file(target_dir, get_build_metadata(), args.channel)
-  create_caexclude_file(target_dir)
-
   build_metadata = get_build_metadata()
+
+  create_build_metadata_file(target_dir, build_metadata, args.channel)
+  create_caexclude_file(target_dir)
 
   digest, caidx = create_casync_release(target_dir, output_dir, build_metadata.canonical())
 

--- a/release/create_casync_release.py
+++ b/release/create_casync_release.py
@@ -11,7 +11,6 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="creates a casync release")
   parser.add_argument("target_dir", type=str, help="target directory to build channel from")
   parser.add_argument("output_dir", type=str, help="output directory for the channel")
-  parser.add_argument("channel", type=str, help="what channel this build is")
   args = parser.parse_args()
 
   target_dir = pathlib.Path(args.target_dir)
@@ -20,6 +19,8 @@ if __name__ == "__main__":
   create_build_metadata_file(target_dir, get_build_metadata(), args.channel)
   create_caexclude_file(target_dir)
 
-  digest, caidx = create_casync_release(target_dir, output_dir, args.channel)
+  build_metadata = get_build_metadata()
+
+  digest, caidx = create_casync_release(target_dir, output_dir, build_metadata.canonical())
 
   print(f"Created casync release from {target_dir} to {caidx} with digest {digest}")

--- a/system/updated/casync/common.py
+++ b/system/updated/casync/common.py
@@ -1,6 +1,5 @@
 import dataclasses
 import json
-import os
 import pathlib
 import subprocess
 
@@ -43,8 +42,6 @@ def create_build_metadata_file(path: pathlib.Path, build_metadata: BuildMetadata
   with open(path / BUILD_METADATA_FILENAME, "w") as f:
     build_metadata_dict = dataclasses.asdict(build_metadata)
     build_metadata_dict["channel"] = channel
-    build_style = "release" if os.environ.get("RELEASE", None) is not None else "debug"
-    build_metadata_dict["openpilot"]["build_style"] = build_style
     build_metadata_dict["openpilot"].pop("is_dirty")  # this is determined at runtime
     f.write(json.dumps(build_metadata_dict))
 

--- a/system/updated/casync/common.py
+++ b/system/updated/casync/common.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import os
 import pathlib
 import subprocess
 
@@ -42,12 +43,14 @@ def create_build_metadata_file(path: pathlib.Path, build_metadata: BuildMetadata
   with open(path / BUILD_METADATA_FILENAME, "w") as f:
     build_metadata_dict = dataclasses.asdict(build_metadata)
     build_metadata_dict["channel"] = channel
+    build_style = "release" if os.environ.get("RELEASE", None) is not None else "debug"
+    build_metadata_dict["openpilot"]["build_style"] = build_style
     build_metadata_dict["openpilot"].pop("is_dirty")  # this is determined at runtime
     f.write(json.dumps(build_metadata_dict))
 
 
-def create_casync_release(target_dir: pathlib.Path, output_dir: pathlib.Path, channel: str):
-  caidx_file = output_dir / f"{channel}.caidx"
+def create_casync_release(target_dir: pathlib.Path, output_dir: pathlib.Path, caidx_name: str):
+  caidx_file = output_dir / f"{caidx_name}.caidx"
   run(["casync", "make", *CASYNC_ARGS, caidx_file, target_dir])
   digest = run(["casync", "digest", *CASYNC_ARGS, target_dir]).decode("utf-8").strip()
   return digest, caidx_file

--- a/system/version.py
+++ b/system/version.py
@@ -77,6 +77,10 @@ class OpenpilotMetadata:
     return self.version.split('-')[0]
 
   @property
+  def short_commit(self) -> str:
+    return self.git_commit[:6]
+
+  @property
   def comma_remote(self) -> bool:
     # note to fork maintainers, this is used for release metrics. please do not
     # touch this to get rid of the orange startup alert. there's better ways to do that
@@ -105,7 +109,7 @@ class BuildMetadata:
     return self.channel in RELEASE_BRANCHES
 
   def canonical(self) -> str:
-    return f"{self.openpilot.version}-{self.openpilot.git_commit}-{self.openpilot.build_style}"
+    return f"{self.openpilot.version}-{self.openpilot.short_commit}-{self.openpilot.build_style}"
 
 
 def build_metadata_from_dict(build_metadata: dict) -> BuildMetadata:

--- a/system/version.py
+++ b/system/version.py
@@ -104,6 +104,7 @@ class BuildMetadata:
   def release_channel(self) -> bool:
     return self.channel in RELEASE_BRANCHES
 
+  @property
   def canonical(self) -> str:
     return f"{self.openpilot.version}-{self.openpilot.git_commit}-{self.openpilot.build_style}"
 

--- a/system/version.py
+++ b/system/version.py
@@ -62,7 +62,7 @@ def is_dirty(cwd: str = BASEDIR) -> bool:
   return dirty
 
 
-@dataclass(frozen=True)
+@dataclass
 class OpenpilotMetadata:
   version: str
   release_notes: str
@@ -75,10 +75,6 @@ class OpenpilotMetadata:
   @property
   def short_version(self) -> str:
     return self.version.split('-')[0]
-
-  @property
-  def short_commit(self) -> str:
-    return self.git_commit[:9]
 
   @property
   def comma_remote(self) -> bool:
@@ -95,7 +91,7 @@ class OpenpilotMetadata:
       .replace(":", "/", 1)
 
 
-@dataclass(frozen=True)
+@dataclass
 class BuildMetadata:
   channel: str
   openpilot: OpenpilotMetadata
@@ -109,7 +105,7 @@ class BuildMetadata:
     return self.channel in RELEASE_BRANCHES
 
   def canonical(self) -> str:
-    return f"{self.openpilot.version}-{self.openpilot.short_commit}-{self.openpilot.build_style}"
+    return f"{self.openpilot.version}-{self.openpilot.git_commit}-{self.openpilot.build_style}"
 
 
 def build_metadata_from_dict(build_metadata: dict) -> BuildMetadata:
@@ -149,7 +145,7 @@ def get_build_metadata(path: str = BASEDIR) -> BuildMetadata:
                       git_commit=get_commit(path),
                       git_origin=get_origin(path),
                       git_commit_date=get_commit_date(path),
-                      build_style="debug",
+                      build_style="unknown",
                       is_dirty=is_dirty(path)))
 
   cloudlog.exception("unable to get build metadata")

--- a/system/version.py
+++ b/system/version.py
@@ -78,7 +78,7 @@ class OpenpilotMetadata:
 
   @property
   def short_commit(self) -> str:
-    return self.git_commit[:6]
+    return self.git_commit[:9]
 
   @property
   def comma_remote(self) -> bool:

--- a/system/version.py
+++ b/system/version.py
@@ -69,6 +69,7 @@ class OpenpilotMetadata:
   git_commit: str
   git_origin: str
   git_commit_date: str
+  build_style: str
   is_dirty: bool  # whether there are local changes
 
   @property
@@ -103,6 +104,9 @@ class BuildMetadata:
   def release_channel(self) -> bool:
     return self.channel in RELEASE_BRANCHES
 
+  def canonical(self) -> str:
+    return f"{self.openpilot.version}-{self.openpilot.git_commit}-{self.openpilot.build_style}"
+
 
 def build_metadata_from_dict(build_metadata: dict) -> BuildMetadata:
   channel = build_metadata.get("channel", "unknown")
@@ -112,6 +116,7 @@ def build_metadata_from_dict(build_metadata: dict) -> BuildMetadata:
   git_commit = openpilot_metadata.get("git_commit", "unknown")
   git_origin = openpilot_metadata.get("git_origin", "unknown")
   git_commit_date = openpilot_metadata.get("git_commit_date", "unknown")
+  build_style = openpilot_metadata.get("build_style", "unknown")
   return BuildMetadata(channel,
             OpenpilotMetadata(
               version=version,
@@ -119,6 +124,7 @@ def build_metadata_from_dict(build_metadata: dict) -> BuildMetadata:
               git_commit=git_commit,
               git_origin=git_origin,
               git_commit_date=git_commit_date,
+              build_style=build_style,
               is_dirty=False))
 
 
@@ -139,6 +145,7 @@ def get_build_metadata(path: str = BASEDIR) -> BuildMetadata:
                       git_commit=get_commit(path),
                       git_origin=get_origin(path),
                       git_commit_date=get_commit_date(path),
+                      build_style="debug",
                       is_dirty=is_dirty(path)))
 
   cloudlog.exception("unable to get build metadata")


### PR DESCRIPTION
`nightly.caidx` -> `0.9.7-9c8aedf-release.caidx`

then api can point

`/channels/nightly`
to
`https://commadist.azureedge.net/openpilot-releases/0.9.7-9c8aedf-release.caidx`

and `/channels/master`
to
`https://commadist.azureedge.net/openpilot-releases/0.9.7-9c8aedf-debug.caidx`