### PR TITLE
PlotJuggler: Update controls mismatch layout

### DIFF
--- a/tools/plotjuggler/layouts/controls_mismatch_debug.xml
+++ b/tools/plotjuggler/layouts/controls_mismatch_debug.xml
@@ -24,6 +24,7 @@
        <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
        <limitY/>
        <curve color="#1f77b4" name="/pandaStates/0/safetyRxInvalid"/>
+       <curve color="#e801ce" name="/pandaStates/0/safetyRxChecksInvalid"/>
       </plot>
      </DockArea>
      <DockArea name="...">

--- a/tools/plotjuggler/layouts/controls_mismatch_debug.xml
+++ b/tools/plotjuggler/layouts/controls_mismatch_debug.xml
@@ -1,44 +1,45 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <root>
- <tabbed_widget parent="main_window" name="Main Window">
+ <tabbed_widget name="Main Window" parent="main_window">
   <Tab tab_name="tab1" containers="1">
    <Container>
-    <DockSplitter orientation="-" count="5" sizes="0.2;0.2;0.2;0.2;0.2">
+    <DockSplitter sizes="0.200166;0.200166;0.199336;0.200166;0.200166" orientation="-" count="5">
      <DockArea name="...">
-      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
-       <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
+      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
+       <range bottom="-0.025000" right="50.400355" left="0.000000" top="1.025000"/>
        <limitY/>
-       <curve color="#1f77b4" name="/controlsState/enabled"/>
-       <curve color="#d62728" name="/pandaStates/0/controlsAllowed"/>
+       <curve name="/controlsState/enabled" color="#1f77b4"/>
+       <curve name="/pandaStates/0/controlsAllowed" color="#d62728"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
-       <range top="27.087398" bottom="-0.905168" left="0.018309" right="59.674401"/>
+      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
+       <range bottom="-11.322260" right="50.400355" left="0.000000" top="0.439077"/>
        <limitY/>
-       <curve color="#9467bd" name="/controlsState/cumLagMs"/>
+       <curve name="/controlsState/cumLagMs" color="#9467bd"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
-       <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
+      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
+       <range bottom="-0.025000" right="50.400355" left="0.000000" top="1.025000"/>
        <limitY/>
-       <curve color="#1f77b4" name="/pandaStates/0/safetyRxInvalid"/>
+       <curve name="/pandaStates/0/safetyRxInvalid" color="#f6a814"/>
+       <curve name="/pandaStates/0/safetyRxChecksInvalid" color="#e801ce"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
-       <range top="158.850000" bottom="-2.850000" left="0.018309" right="59.674401"/>
+      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
+       <range bottom="-0.750000" right="50.400355" left="0.000000" top="30.750000"/>
        <limitY/>
-       <curve color="#d62728" name="/pandaStates/0/safetyTxBlocked"/>
+       <curve name="/pandaStates/0/safetyTxBlocked" color="#d62728"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
-       <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
+      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
+       <range bottom="-0.025000" right="50.400355" left="0.000000" top="1.025000"/>
        <limitY/>
-       <curve color="#1ac938" name="/carState/gasPressed"/>
-       <curve color="#ff7f0e" name="/carState/brakePressed"/>
+       <curve name="/carState/gasPressed" color="#1ac938"/>
+       <curve name="/carState/brakePressed" color="#ff7f0e"/>
       </plot>
      </DockArea>
     </DockSplitter>

--- a/tools/plotjuggler/layouts/controls_mismatch_debug.xml
+++ b/tools/plotjuggler/layouts/controls_mismatch_debug.xml
@@ -1,45 +1,44 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <root>
- <tabbed_widget name="Main Window" parent="main_window">
+ <tabbed_widget parent="main_window" name="Main Window">
   <Tab tab_name="tab1" containers="1">
    <Container>
-    <DockSplitter sizes="0.200166;0.200166;0.199336;0.200166;0.200166" orientation="-" count="5">
+    <DockSplitter orientation="-" count="5" sizes="0.2;0.2;0.2;0.2;0.2">
      <DockArea name="...">
-      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
-       <range bottom="-0.025000" right="50.400355" left="0.000000" top="1.025000"/>
+      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
+       <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
        <limitY/>
-       <curve name="/controlsState/enabled" color="#1f77b4"/>
-       <curve name="/pandaStates/0/controlsAllowed" color="#d62728"/>
+       <curve color="#1f77b4" name="/controlsState/enabled"/>
+       <curve color="#d62728" name="/pandaStates/0/controlsAllowed"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
-       <range bottom="-11.322260" right="50.400355" left="0.000000" top="0.439077"/>
+      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
+       <range top="27.087398" bottom="-0.905168" left="0.018309" right="59.674401"/>
        <limitY/>
-       <curve name="/controlsState/cumLagMs" color="#9467bd"/>
+       <curve color="#9467bd" name="/controlsState/cumLagMs"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
-       <range bottom="-0.025000" right="50.400355" left="0.000000" top="1.025000"/>
+      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
+       <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
        <limitY/>
-       <curve name="/pandaStates/0/safetyRxInvalid" color="#f6a814"/>
-       <curve name="/pandaStates/0/safetyRxChecksInvalid" color="#e801ce"/>
+       <curve color="#1f77b4" name="/pandaStates/0/safetyRxInvalid"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
-       <range bottom="-0.750000" right="50.400355" left="0.000000" top="30.750000"/>
+      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
+       <range top="158.850000" bottom="-2.850000" left="0.018309" right="59.674401"/>
        <limitY/>
-       <curve name="/pandaStates/0/safetyTxBlocked" color="#d62728"/>
+       <curve color="#d62728" name="/pandaStates/0/safetyTxBlocked"/>
       </plot>
      </DockArea>
      <DockArea name="...">
-      <plot flip_x="false" mode="TimeSeries" style="Lines" flip_y="false">
-       <range bottom="-0.025000" right="50.400355" left="0.000000" top="1.025000"/>
+      <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
+       <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
        <limitY/>
-       <curve name="/carState/gasPressed" color="#1ac938"/>
-       <curve name="/carState/brakePressed" color="#ff7f0e"/>
+       <curve color="#1ac938" name="/carState/gasPressed"/>
+       <curve color="#ff7f0e" name="/carState/brakePressed"/>
       </plot>
      </DockArea>
     </DockSplitter>


### PR DESCRIPTION
**Description**

Add `SafetyRxChecksInvalid` to the PlotJuggler layout for controls mismatch troubleshooting. Needed this for Model 3 bringup.

Separately, I think it's a bug that Panda is willing to transition into controls_allowed with a preexisting Panda RX check failure. Panda monitors this, but only [openpilot acts on it](https://github.com/commaai/openpilot/blob/33f9193c94d3afb9120369e6557ddcd71133c5ee/selfdrive/controls/controlsd.py#L289), which is what caused our mismatch. Also, at a quick glance I don't see ANY action on the similar `safetyRxInvalid`.

**Verification**

Route: `8b67b428fd9fea5c/0000002f--4e2e5fc62e`

![image](https://github.com/commaai/openpilot/assets/46612682/394dfc7e-1030-4d5b-92fb-6e5b330b4227)
