### PR TITLE
ui/map_eta: round remaining km/mi to one decimal place

### DIFF
--- a/selfdrive/ui/qt/maps/map_helpers.cc
+++ b/selfdrive/ui/qt/maps/map_helpers.cc
@@ -137,17 +137,17 @@ std::optional<QMapLibre::Coordinate> coordinate_from_param(const std::string &pa
 
 // return {distance, unit}
 std::pair<QString, QString> map_format_distance(float d, bool is_metric) {
-  auto round_distance = [](float d) -> float {
-    return (d > 10) ? std::nearbyint(d) : std::nearbyint(d * 10) / 10.0;
+  auto round_distance = [](float d) -> QString {
+    return (d > 10) ? QString::number(std::nearbyint(d)) : QString::number(std::nearbyint(d * 10) / 10.0, 'f', 1);
   };
 
   d = std::max(d, 0.0f);
   if (is_metric) {
-    return (d > 500) ? std::pair{QString::number(round_distance(d / 1000)), QObject::tr("km")}
+    return (d > 500) ? std::pair{round_distance(d / 1000), QObject::tr("km")}
                      : std::pair{QString::number(50 * std::nearbyint(d / 50)), QObject::tr("m")};
   } else {
     float feet = d * METER_TO_FOOT;
-    return (feet > 500) ? std::pair{QString::number(round_distance(d * METER_TO_MILE)), QObject::tr("mi")}
+    return (feet > 500) ? std::pair{round_distance(d * METER_TO_MILE), QObject::tr("mi")}
                         : std::pair{QString::number(50 * std::nearbyint(d / 50)), QObject::tr("ft")};
   }
 }


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| ![2024-03-22_10-43](https://github.com/commaai/openpilot/assets/27770/4a353573-d70c-42db-ba80-36851de048dc)  | ![2024-03-22_10-37](https://github.com/commaai/openpilot/assets/27770/894e39ff-5040-4337-88c2-4a21b27c014c)  |
| ![2024-03-22_10-43_2](https://github.com/commaai/openpilot/assets/27770/9cda9e60-1a37-49d9-bb6c-66db86a74bc5)  | ![2024-03-22_10-43_1](https://github.com/commaai/openpilot/assets/27770/41c05c47-4fbd-4288-b187-43a67d07f2e2)  |





