### PR TITLE
ui/map: add missing null pointer check

### DIFF
--- a/selfdrive/ui/qt/maps/map.cc
+++ b/selfdrive/ui/qt/maps/map.cc
@@ -112,7 +112,7 @@ void MapWindow::initLayers() {
 }
 
 void MapWindow::updateState(const UIState &s) {
-  if (!uiState()->scene.started) {
+  if (!m_map || !uiState()->scene.started) {
     return;
   }
   const SubMaster &sm = *(s.sm);
@@ -165,7 +165,7 @@ void MapWindow::updateState(const UIState &s) {
     }
   }
 
-  loaded_once = loaded_once || (m_map && m_map->isFullyLoaded());
+  loaded_once = loaded_once || m_map->isFullyLoaded();
   if (!loaded_once) {
     setError(tr("Map Loading"));
     return;


### PR DESCRIPTION
the `m_map`  is initialized in `initializeGL(),`  which is called once before the first call to  paintGL() or resizeGL() :

> https://doc.qt.io/qt-6/qopenglwidget.html#initializeGL
> https://codebrowser.dev/qt5/qtbase/src/widgets/kernel/qopenglwidget.cpp.html#868

the `updateState()` is connected to` UIState::uiUpdate` in constructor, we cannot guarantee that the `m_map` is valid when `updateState()` is called. It is necessary to check if `m_map` is not null before using it.

