### PR TITLE
ui: don't show PrimeUserWidget on PrimeType.UNKNOWN

### DIFF
--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -235,7 +235,7 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
 
   mainLayout->addWidget(content);
 
-  primeUser->setVisible(uiState()->primeType());
+  primeUser->setVisible(uiState()->hasPrime());
   mainLayout->setCurrentIndex(1);
 
   setStyleSheet(R"(


### PR DESCRIPTION
Reproduces on PC, showing "Subscribed to comma prime", when it isn't.

Before:

![Screenshot from 2024-03-22 08-05-04](https://github.com/commaai/openpilot/assets/76900/8d6261d9-6ad1-4b6f-b635-2d9e4d698b63)

After:

![Screenshot from 2024-03-22 08-39-15](https://github.com/commaai/openpilot/assets/76900/0a05fb96-125f-407a-afd4-067610334829)
