### PR TITLE
Add 2020 Hyundai Kona Fingerprint

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -927,6 +927,7 @@ FW_VERSIONS = {
     ],
     (Ecu.engine, 0x7e0, None): [
       b'"\x01TOS-0NU06F301J02',
+      b'391182BCK6\x00',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00OS  MDPS C 1.00 1.05 56310J9030\x00 4OSDC105',
@@ -936,6 +937,7 @@ FW_VERSIONS = {
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x816U2VE051\x00\x00\xf1\x006U2V0_C2\x00\x006U2VE051\x00\x00DOS4T16NS3\x00\x00\x00\x00',
+      b'DOS0T16NS3',
     ],
   },
   CAR.KIA_CEED: {

--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -924,6 +924,7 @@ FW_VERSIONS = {
     ],
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x816V5RAK00018.ELF\xf1\x00\x00\x00\x00\x00\x00\x00',
+      b'\xf1\x00\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'"\x01TOS-0NU06F301J02',
@@ -934,9 +935,11 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00OS9 LKAS AT USA LHD 1.00 1.00 95740-J9300 g21',
+      b'\xf1\x8b \x19\x12)',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x816U2VE051\x00\x00\xf1\x006U2V0_C2\x00\x006U2VE051\x00\x00DOS4T16NS3\x00\x00\x00\x00',
+      b'\xf1\x006U2V0_C2\x00\x006U2VE051\x00\x00DOS0T16NS3\x00\x00\x00\x00',
       b'DOS0T16NS3',
     ],
   },


### PR DESCRIPTION
**Car**
Which car (make, model, year) this fingerprint is for
2020 Hyundai Kona
**Route**
A route with the fingerprint
Dongle: 5e0ef2fcec8677b6
Route with fix: 5e0ef2fcec8677b6/00000003--823c44ece7

