### PR TITLE
Hyundai: mark less ECUs as logging

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -670,7 +670,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac, Ecu.eps],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac, Ecu.eps, Ecu.abs, Ecu.transmission, Ecu.engine],
       bus=0,
       auxiliary=True,
     ),

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -670,7 +670,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac, Ecu.eps, Ecu.abs, Ecu.transmission, Ecu.engine],
+      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac],
       bus=0,
       auxiliary=True,
     ),
@@ -701,7 +701,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=ALL_HYUNDAI_ECUS,
       bus=0,
       auxiliary=True,
-      logging=True,
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_MULTI],
@@ -709,7 +708,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=ALL_HYUNDAI_ECUS,
       bus=0,
       auxiliary=True,
-      logging=True,
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],


### PR DESCRIPTION
Needed for https://github.com/commaai/openpilot/pull/31969, we currently only log these ECUs. We should do a clean up of Hyundai's queries very soon. Removing engine and transmission would also clean up much of this, and it's so far not needed at all to identify the vehicles