### PR TITLE
Updated Fingerprints for Hyundai PHEV 2019 for Australian Model

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -92,12 +92,15 @@ FW_VERSIONS = {
   },
   CAR.HYUNDAI_IONIQ_PHEV_2019: {
     (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2000         ',
       b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2501 4AEHC107',
+      b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2551 4AEHC107',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00AEP MFC  AT AUS RHD 1.00 1.00 95740-G2400 180222',
       b'\xf1\x00AEP MFC  AT USA LHD 1.00 1.00 95740-G2400 180222',
     ],
   },


### PR DESCRIPTION
Extended ECUs for PHEV 2019 for Australian Model - Updated for the latest Hyundai Changes

**Car**
Hyundai PHEV 2019 Australian Model

**Route**
ca5e3e5194d31b63/0000000c--778efe9244
