### PR TITLE
Hyundai: clean up FW queries

### DIFF
--- a/selfdrive/car/hyundai/tests/test_hyundai.py
+++ b/selfdrive/car/hyundai/tests/test_hyundai.py
@@ -36,6 +36,8 @@ NO_DATES_PLATFORMS = {
   CAR.HYUNDAI_VELOSTER,
 }
 
+CANFD_EXPECTED_ECUS = {Ecu.fwdCamera, Ecu.fwdRadar}
+
 
 class TestHyundaiFingerprint(unittest.TestCase):
   def test_can_features(self):
@@ -51,13 +53,11 @@ class TestHyundaiFingerprint(unittest.TestCase):
     self.assertEqual(HYBRID_CAR & EV_CAR, set(), "Shared cars between hybrid and EV")
     self.assertEqual(CANFD_CAR & HYBRID_CAR, set(), "Hard coding CAN FD cars as hybrid is no longer supported")
 
-  def test_auxiliary_request_ecu_whitelist(self):
+  def test_canfd_ecu_whitelist(self):
     # Asserts only auxiliary Ecus can exist in database for CAN-FD cars
-    whitelisted_ecus = {ecu for r in FW_QUERY_CONFIG.requests for ecu in r.whitelist_ecus if r.auxiliary}
-
     for car_model in CANFD_CAR:
       ecus = {fw[0] for fw in FW_VERSIONS[car_model].keys()}
-      ecus_not_in_whitelist = ecus - whitelisted_ecus
+      ecus_not_in_whitelist = ecus - CANFD_EXPECTED_ECUS
       ecu_strings = ", ".join([f"Ecu.{ECU_NAME[ecu]}" for ecu in ecus_not_in_whitelist])
       self.assertEqual(len(ecus_not_in_whitelist), 0,
                        f"{car_model}: Car model has ECUs not in auxiliary request whitelists: {ecu_strings}")

--- a/selfdrive/car/hyundai/tests/test_hyundai.py
+++ b/selfdrive/car/hyundai/tests/test_hyundai.py
@@ -54,7 +54,7 @@ class TestHyundaiFingerprint(unittest.TestCase):
     self.assertEqual(CANFD_CAR & HYBRID_CAR, set(), "Hard coding CAN FD cars as hybrid is no longer supported")
 
   def test_canfd_ecu_whitelist(self):
-    # Asserts only auxiliary Ecus can exist in database for CAN-FD cars
+    # Asserts only expected Ecus can exist in database for CAN-FD cars
     for car_model in CANFD_CAR:
       ecus = {fw[0] for fw in FW_VERSIONS[car_model].keys()}
       ecus_not_in_whitelist = ecus - CANFD_EXPECTED_ECUS

--- a/selfdrive/car/hyundai/tests/test_hyundai.py
+++ b/selfdrive/car/hyundai/tests/test_hyundai.py
@@ -60,7 +60,7 @@ class TestHyundaiFingerprint(unittest.TestCase):
       ecus_not_in_whitelist = ecus - CANFD_EXPECTED_ECUS
       ecu_strings = ", ".join([f"Ecu.{ECU_NAME[ecu]}" for ecu in ecus_not_in_whitelist])
       self.assertEqual(len(ecus_not_in_whitelist), 0,
-                       f"{car_model}: Car model has ECUs not in auxiliary request whitelists: {ecu_strings}")
+                       f"{car_model}: Car model has unexpected ECUs: {ecu_strings}")
 
   def test_blacklisted_parts(self):
     # Asserts no ECUs known to be shared across platforms exist in the database.

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -647,20 +647,16 @@ PLATFORM_CODE_ECUS = [Ecu.fwdRadar, Ecu.fwdCamera, Ecu.eps]
 # TODO: there are date codes in the ABS firmware versions in hex
 DATE_FW_ECUS = [Ecu.fwdCamera]
 
-ALL_HYUNDAI_ECUS = [Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera, Ecu.parkingAdas,
-                    Ecu.adas, Ecu.hvac, Ecu.cornerRadar, Ecu.combinationMeter]
-
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
-    # TODO: minimize shared whitelists for CAN and cornerRadar for CAN-FD
+    # TODO: add back whitelists
     # CAN queries (OBD-II port)
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
     ),
 
-    # CAN-FD queries (from camera)
-    # TODO: combine shared whitelists with CAN requests
+    # CAN & CAN-FD queries (from camera)
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
@@ -685,24 +681,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
       logging=True,
     ),
 
-    # CAN & CAN FD logging queries (from camera)
-    Request(
-      [HYUNDAI_VERSION_REQUEST_LONG],
-      [HYUNDAI_VERSION_RESPONSE],
-      bus=0,
-      auxiliary=True,
-      logging=True,
-    ),
-    Request(
-      [HYUNDAI_VERSION_REQUEST_LONG],
-      [HYUNDAI_VERSION_RESPONSE],
-      bus=1,
-      auxiliary=True,
-      obd_multiplexing=False,
-      logging=True,
-    ),
-
     # CAN-FD alt request logging queries
+    # TODO: do we need this anymore?
     Request(
       [HYUNDAI_VERSION_REQUEST_ALT],
       [HYUNDAI_VERSION_RESPONSE],

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -662,12 +662,10 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar, Ecu.fwdCamera],
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_MULTI],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar],
       logging=True,
     ),
 
@@ -676,14 +674,12 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.fwdRadar, Ecu.cornerRadar, Ecu.hvac, Ecu.eps],
       bus=0,
       auxiliary=True,
     ),
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera, Ecu.adas, Ecu.cornerRadar, Ecu.hvac],
       bus=1,
       auxiliary=True,
       obd_multiplexing=False,
@@ -694,7 +690,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_ECU_MANUFACTURING_DATE],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera],
       bus=0,
       auxiliary=True,
       logging=True,
@@ -704,7 +699,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=ALL_HYUNDAI_ECUS,
       bus=0,
       auxiliary=True,
       logging=True,
@@ -712,7 +706,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_MULTI],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=ALL_HYUNDAI_ECUS,
       bus=0,
       auxiliary=True,
       logging=True,
@@ -720,7 +713,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=ALL_HYUNDAI_ECUS,
       bus=1,
       auxiliary=True,
       obd_multiplexing=False,
@@ -731,7 +723,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_ALT],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.parkingAdas, Ecu.hvac],
       bus=0,
       auxiliary=True,
       logging=True,
@@ -739,7 +730,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_VERSION_REQUEST_ALT],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.parkingAdas, Ecu.hvac],
       bus=1,
       auxiliary=True,
       logging=True,

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -676,7 +676,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_ECU_MANUFACTURING_DATE],
       [HYUNDAI_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.fwdCamera],
       bus=0,
       auxiliary=True,
       logging=True,

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -676,6 +676,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [HYUNDAI_ECU_MANUFACTURING_DATE],
       [HYUNDAI_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.fwdCamera],
       bus=0,
       auxiliary=True,
       logging=True,

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -668,6 +668,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_REQUEST_MULTI],
       [HYUNDAI_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.eps, Ecu.abs, Ecu.fwdRadar],
+      logging=True,
     ),
 
     # CAN-FD queries (from camera)

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -624,11 +624,6 @@ HYUNDAI_VERSION_REQUEST_LONG = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER])
 HYUNDAI_VERSION_REQUEST_ALT = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
   p16(0xf110)  # Alt long description
 
-HYUNDAI_VERSION_REQUEST_MULTI = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
-  p16(uds.DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_SPARE_PART_NUMBER) + \
-  p16(uds.DATA_IDENTIFIER_TYPE.APPLICATION_SOFTWARE_IDENTIFICATION) + \
-  p16(0xf100)
-
 HYUNDAI_ECU_MANUFACTURING_DATE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
   p16(uds.DATA_IDENTIFIER_TYPE.ECU_MANUFACTURING_DATE)
 
@@ -663,11 +658,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [HYUNDAI_VERSION_REQUEST_LONG],
       [HYUNDAI_VERSION_RESPONSE],
     ),
-    Request(
-      [HYUNDAI_VERSION_REQUEST_MULTI],
-      [HYUNDAI_VERSION_RESPONSE],
-      logging=True,
-    ),
 
     # CAN-FD queries (from camera)
     # TODO: combine shared whitelists with CAN requests
@@ -698,13 +688,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
     # CAN & CAN FD logging queries (from camera)
     Request(
       [HYUNDAI_VERSION_REQUEST_LONG],
-      [HYUNDAI_VERSION_RESPONSE],
-      bus=0,
-      auxiliary=True,
-      logging=True,
-    ),
-    Request(
-      [HYUNDAI_VERSION_REQUEST_MULTI],
       [HYUNDAI_VERSION_RESPONSE],
       bus=0,
       auxiliary=True,

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -681,8 +681,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       logging=True,
     ),
 
-    # CAN-FD alt request logging queries
-    # TODO: do we need this anymore?
+    # CAN-FD alt request logging queries for hvac and parkingAdas
     Request(
       [HYUNDAI_VERSION_REQUEST_ALT],
       [HYUNDAI_VERSION_RESPONSE],

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -263,7 +263,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         print(f'get_vin {name} case, query time={self.total_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = {1: 8.5, 2: 9.4}
+    total_ref_time = {1: 8.1, 2: 8.7}
     brand_ref_times = {
       1: {
         'gm': 1.0,
@@ -271,7 +271,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         'chrysler': 0.3,
         'ford': 1.5,
         'honda': 0.45,
-        'hyundai': 1.05,
+        'hyundai': 0.65,
         'mazda': 0.1,
         'nissan': 0.8,
         'subaru': 0.65,
@@ -281,7 +281,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
       },
       2: {
         'ford': 1.6,
-        'hyundai': 1.85,
+        'hyundai': 1.15,
         'tesla': 0.3,
       }
     }


### PR DESCRIPTION
Enabled by: https://github.com/commaai/openpilot/pull/31985 (removal of engine and transmission), https://github.com/commaai/openpilot/pull/32020, https://github.com/commaai/openpilot/pull/32019, https://github.com/commaai/openpilot/pull/32008

- combine explicit CAN camera logging queries (that shouldn't be logging because we are starting to rely on them) with the CAN FD camera queries (that are also getting queried on CAN vehicles)
- remove whitelists. this was causing more complications than the minor amount of time they could be saving. will re-evaluate in the future now that we have less ECUs (no trans or engine)
- remove the MULTI query. neither fwdRadar, fwdCamera, abs, or eps don't support the simpler LONG query with the platform code at the start. the MULTI query just has redundant part number at the start, nothing new generally (except engine and trans)