### PR TITLE
replay/cabana : support segment range

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -81,7 +81,7 @@ bool Replay::load() {
 }
 
 void Replay::start(int seconds) {
-  seekTo(route_->identifier().segment_id * 60 + seconds, false);
+  seekTo(route_->identifier().begin_segment * 60 + seconds, false);
 }
 
 void Replay::updateEvents(const std::function<bool()> &lambda) {

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -18,11 +18,24 @@ Route::Route(const QString &route, const QString &data_dir) : data_dir_(data_dir
 }
 
 RouteIdentifier Route::parseRoute(const QString &str) {
-  QRegExp rx(R"(^(?:([a-z0-9]{16})([|_/]))?(.{20})(?:(--|/)(\d*))?$)");
-  if (rx.indexIn(str) == -1) return {};
-
-  const QStringList list = rx.capturedTexts();
-  return {.dongle_id = list[1], .timestamp = list[3], .segment_id = list[5].toInt(), .str = list[1] + "|" + list[3]};
+  RouteIdentifier identifier = {};
+  QRegularExpression rx(R"(^((?<dongle_id>[a-z0-9]{16})[|_/])?(?<timestamp>.{20})((?<separator>--|/)(?<range>((-?\d+(:(-?\d+)?)?)|(:-?\d+))))?$)");
+  if (auto match = rx.match(str); match.hasMatch()) {
+    identifier.dongle_id = match.captured("dongle_id");
+    identifier.timestamp = match.captured("timestamp");
+    identifier.str = identifier.dongle_id + "|" + identifier.timestamp;
+    auto range_str = match.captured("range");
+    if (auto separator = match.captured("separator"); separator == "/" && !range_str.isEmpty()) {
+      auto range = range_str.split(":");
+      identifier.begin_segment = identifier.end_segment = range[0].toInt();
+      if (range.size() == 2) {
+        identifier.end_segment = range[1].isEmpty() ? -1 : range[1].toInt();
+      }
+    } else if (separator == "--") {
+      identifier.begin_segment = range_str.toInt();
+    }
+  }
+  return identifier;
 }
 
 bool Route::load() {
@@ -31,7 +44,19 @@ bool Route::load() {
     return false;
   }
   date_time_ = QDateTime::fromString(route_.timestamp, "yyyy-MM-dd--HH-mm-ss");
-  return data_dir_.isEmpty() ? loadFromServer() : loadFromLocal();
+  bool ret = data_dir_.isEmpty() ? loadFromServer() : loadFromLocal();
+  if (ret) {
+    if (route_.begin_segment == -1) route_.begin_segment = segments_.rbegin()->first;
+    if (route_.end_segment == -1) route_.end_segment = segments_.rbegin()->first;
+    for (auto it = segments_.begin(); it != segments_.end(); /**/) {
+      if (it->first < route_.begin_segment || it->first > route_.end_segment) {
+        it = segments_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+  return !segments_.empty();
 }
 
 bool Route::loadFromServer() {
@@ -62,15 +87,13 @@ bool Route::loadFromJson(const QString &json) {
 }
 
 bool Route::loadFromLocal() {
-  QDir log_dir(data_dir_);
-  for (const auto &folder : log_dir.entryList(QDir::Dirs | QDir::NoDot | QDir::NoDotDot, QDir::NoSort)) {
-    int pos = folder.lastIndexOf("--");
-    if (pos != -1 && folder.left(pos) == route_.timestamp) {
-      const int seg_num = folder.mid(pos + 2).toInt();
-      QDir segment_dir(log_dir.filePath(folder));
-      for (const auto &f : segment_dir.entryList(QDir::Files)) {
-        addFileToSegment(seg_num, segment_dir.absoluteFilePath(f));
-      }
+  QDirIterator it(data_dir_, {QString("%1--*").arg(route_.timestamp)}, QDir::Dirs | QDir::NoDotAndDotDot);
+  while (it.hasNext()) {
+    QString segment = it.next();
+    const int seg_num = segment.mid(segment.lastIndexOf("--") + 2).toInt();
+    QDir segment_dir(segment);
+    for (const auto &f : segment_dir.entryList(QDir::Files)) {
+      addFileToSegment(seg_num, segment_dir.absoluteFilePath(f));
     }
   }
   return !segments_.empty();

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -4,7 +4,7 @@
 #include <QEventLoop>
 #include <QJsonArray>
 #include <QJsonDocument>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QtConcurrent>
 #include <array>
 

--- a/tools/replay/route.h
+++ b/tools/replay/route.h
@@ -14,7 +14,8 @@
 struct RouteIdentifier {
   QString dongle_id;
   QString timestamp;
-  int segment_id;
+  int begin_segment = 0;
+  int end_segment = -1;
   QString str;
 };
 


### PR DESCRIPTION
the syntax is the same as the python version:

> replay "a2a0ccea32023010|2023-07-27--13-01-19/4"   # 4th segment
> replay "a2a0ccea32023010|2023-07-27--13-01-19/4:6" # 4th and 5th segment
> replay "a2a0ccea32023010|2023-07-27--13-01-19/-1"  # last segment
> replay "a2a0ccea32023010|2023-07-27--13-01-19/:5"  # first 5 segments
> replay "a2a0ccea32023010|2023-07-27--13-01-19/1:"  # all except first segment
> 
