### PR TITLE
simulator: Remove comma pedal sensor

### DIFF
--- a/tools/sim/lib/simulated_car.py
+++ b/tools/sim/lib/simulated_car.py
@@ -49,13 +49,6 @@ class SimulatedCar:
 
     msg.append(self.packer.make_can_msg("SCM_BUTTONS", 0, {"CRUISE_BUTTONS": simulator_state.cruise_button}))
 
-    values = {
-      "COUNTER_PEDAL": self.idx & 0xF,
-      "INTERCEPTOR_GAS": simulator_state.user_gas * 2**12,
-      "INTERCEPTOR_GAS2": simulator_state.user_gas * 2**12,
-    }
-    msg.append(self.packer.make_can_msg("GAS_SENSOR", 0, values))
-
     msg.append(self.packer.make_can_msg("GEARBOX", 0, {"GEAR": 4, "GEAR_SHIFTER": 8}))
     msg.append(self.packer.make_can_msg("GAS_PEDAL_2", 0, {}))
     msg.append(self.packer.make_can_msg("SEATBELT_STATUS", 0, {"SEATBELT_DRIVER_LATCHED": 1}))


### PR DESCRIPTION
Since comma pedal was removed in https://github.com/commaai/openpilot/commit/fa12a6722868d436f15bea31537df1277bcc4027 it makes no sense to simulate its output.