### PR TITLE
simulator: Block mapsd and navd

### DIFF
--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -4,7 +4,7 @@ openpilot in simulator
 openpilot implements a [bridge](run_bridge.py) that allows it to run in the [MetaDrive simulator](https://github.com/metadriverse/metadrive).
 
 ## Launching openpilot
-First, start openpilot. Note that you will either need a [mapbox token](https://docs.mapbox.com/help/getting-started/access-tokens/#how-access-tokens-work) (set with ```export MAPBOX_TOKEN="1234"```), or to disable mapsd with ```export BLOCK=mapsd```
+First, start openpilot.
 ``` bash
 # Run locally
 ./tools/sim/launch_openpilot.sh

--- a/tools/sim/launch_openpilot.sh
+++ b/tools/sim/launch_openpilot.sh
@@ -6,7 +6,7 @@ export SIMULATION="1"
 export SKIP_FW_QUERY="1"
 export FINGERPRINT="HONDA_CIVIC"
 
-export BLOCK="${BLOCK},camerad,loggerd,encoderd,micd,logmessaged"
+export BLOCK="${BLOCK},mapsd,navd,camerad,loggerd,encoderd,micd,logmessaged"
 if [[ "$CI" ]]; then
   # TODO: offscreen UI should work
   export BLOCK="${BLOCK},ui"


### PR DESCRIPTION
For them to actually be useful we would need to run a mapbox server and load the same map into metadrive and that mapbox server.