### PR TITLE
Simplify cabana dbc dict

### DIFF
--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -343,10 +343,10 @@ MIGRATION = {
 MapFunc = Callable[[Platform], Any]
 
 
-def create_platform_map(func: MapFunc):
-  ret = {str(platform): func(platform) for platform in PLATFORMS.values() if func(platform) is not None}
-
-  for m in MIGRATION:
-    ret[m] = ret[MIGRATION[m]]
-
-  return ret
+# def create_platform_map(func: MapFunc):
+#   ret = {str(platform): func(platform) for platform in PLATFORMS.values() if func(platform) is not None}
+#
+#   for m in MIGRATION:
+#     ret[m] = ret[MIGRATION[m]]
+#
+#   return ret

--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -1,4 +1,3 @@
-from typing import Any, Callable
 from openpilot.selfdrive.car.interfaces import get_interface_attr
 from openpilot.selfdrive.car.body.values import CAR as BODY
 from openpilot.selfdrive.car.chrysler.values import CAR as CHRYSLER
@@ -338,15 +337,3 @@ MIGRATION = {
   "SKODA SCALA 1ST GEN": VW.SKODA_SCALA_MK1,
   "SKODA SUPERB 3RD GEN": VW.SKODA_SUPERB_MK3,
 }
-
-
-MapFunc = Callable[[Platform], Any]
-
-
-# def create_platform_map(func: MapFunc):
-#   ret = {str(platform): func(platform) for platform in PLATFORMS.values() if func(platform) is not None}
-#
-#   for m in MIGRATION:
-#     ret[m] = ret[MIGRATION[m]]
-#
-#   return ret

--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -10,7 +10,6 @@ from openpilot.selfdrive.car.nissan.values import CAR as NISSAN
 from openpilot.selfdrive.car.subaru.values import CAR as SUBARU
 from openpilot.selfdrive.car.tesla.values import CAR as TESLA
 from openpilot.selfdrive.car.toyota.values import CAR as TOYOTA
-from openpilot.selfdrive.car.values import PLATFORMS, Platform
 from openpilot.selfdrive.car.volkswagen.values import CAR as VW
 
 FW_VERSIONS = get_interface_attr('FW_VERSIONS', combine_brands=True, ignore_none=True)

--- a/tools/cabana/dbc/generate_dbc_json.py
+++ b/tools/cabana/dbc/generate_dbc_json.py
@@ -8,8 +8,10 @@ from openpilot.selfdrive.car.values import PLATFORMS
 
 def generate_dbc_json() -> str:
   dbc_map = {platform.name: platform.config.dbc_dict['pt'] for platform in PLATFORMS.values() if platform != "MOCK"}
+
   for m in MIGRATION:
     dbc_map[m] = dbc_map[MIGRATION[m]]
+
   return json.dumps(dict(sorted(dbc_map.items())), indent=2)
 
 

--- a/tools/cabana/dbc/generate_dbc_json.py
+++ b/tools/cabana/dbc/generate_dbc_json.py
@@ -2,21 +2,14 @@
 import argparse
 import json
 
-from openpilot.selfdrive.car.fingerprints import MIGRATION  #, create_platform_map
+from openpilot.selfdrive.car.fingerprints import MIGRATION
 from openpilot.selfdrive.car.values import PLATFORMS
-
-
-# def generate_dbc_json() -> str:
-#   dbc_map = create_platform_map(lambda platform: platform.config.dbc_dict["pt"] if platform != "MOCK" else None)
-#   return json.dumps(dict(sorted(dbc_map.items())), indent=2)
 
 
 def generate_dbc_json() -> str:
   dbc_map = {platform.name: platform.config.dbc_dict['pt'] for platform in PLATFORMS.values() if platform != "MOCK"}
-
   for m in MIGRATION:
     dbc_map[m] = dbc_map[MIGRATION[m]]
-
   return json.dumps(dict(sorted(dbc_map.items())), indent=2)
 
 

--- a/tools/cabana/dbc/generate_dbc_json.py
+++ b/tools/cabana/dbc/generate_dbc_json.py
@@ -2,11 +2,24 @@
 import argparse
 import json
 
-from openpilot.selfdrive.car.fingerprints import create_platform_map
+from openpilot.selfdrive.car.fingerprints import MIGRATION  #, create_platform_map
+from openpilot.selfdrive.car.values import PLATFORMS
+
+
+# def generate_dbc_json() -> str:
+#   dbc_map = create_platform_map(lambda platform: platform.config.dbc_dict["pt"] if platform != "MOCK" else None)
+#   return json.dumps(dict(sorted(dbc_map.items())), indent=2)
 
 
 def generate_dbc_json() -> str:
-  dbc_map = create_platform_map(lambda platform: platform.config.dbc_dict["pt"] if platform != "MOCK" else None)
+  print(PLATFORMS)
+  dbc_map = {platform.name: platform.config.dbc_dict['pt'] for platform in PLATFORMS.values() if platform != "MOCK"}
+
+  # exit()
+  # dbc_map = create_platform_map(lambda platform: platform.config.dbc_dict["pt"] if platform != "MOCK" else None)
+  for k, v in MIGRATION.items():
+    if v in dbc_map:
+      dbc_map[k] = dbc_map[v]
   return json.dumps(dict(sorted(dbc_map.items())), indent=2)
 
 

--- a/tools/cabana/dbc/generate_dbc_json.py
+++ b/tools/cabana/dbc/generate_dbc_json.py
@@ -12,14 +12,11 @@ from openpilot.selfdrive.car.values import PLATFORMS
 
 
 def generate_dbc_json() -> str:
-  print(PLATFORMS)
   dbc_map = {platform.name: platform.config.dbc_dict['pt'] for platform in PLATFORMS.values() if platform != "MOCK"}
 
-  # exit()
-  # dbc_map = create_platform_map(lambda platform: platform.config.dbc_dict["pt"] if platform != "MOCK" else None)
-  for k, v in MIGRATION.items():
-    if v in dbc_map:
-      dbc_map[k] = dbc_map[v]
+  for m in MIGRATION:
+    dbc_map[m] = dbc_map[MIGRATION[m]]
+
   return json.dumps(dict(sorted(dbc_map.items())), indent=2)
 
 


### PR DESCRIPTION
https://github.com/commaai/openpilot/pull/31920

@jnewb1 If a certain output is only used in one place, and generalizing it requires passing lambdas around, I think we should keep it inside the specific place we only want to use it to avoid unnecessary complexity.