### PR TITLE
debug/check_can_parser_performance: remove overhead of capnp conversion

### DIFF
--- a/selfdrive/debug/check_can_parser_performance.py
+++ b/selfdrive/debug/check_can_parser_performance.py
@@ -25,11 +25,12 @@ if __name__ == '__main__':
   CC = car.CarControl.new_message()
   ets = []
   for _ in tqdm(range(N_RUNS)):
+    msgs = [(m.as_builder().to_bytes(),) for m in tm.can_msgs]
     start_t = time.process_time_ns()
-    for msg in tm.can_msgs:
+    for msg in msgs:
       for cp in tm.CI.can_parsers:
         if cp is not None:
-          cp.update_strings((msg.as_builder().to_bytes(),))
+          cp.update_strings(msg)
     ets.append((time.process_time_ns() - start_t) * 1e-6)
 
   print(f'{len(tm.can_msgs)} CAN packets, {N_RUNS} runs')


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

