### PR TITLE
pytest: don't delete logs on-device

### DIFF
--- a/common/prefix.py
+++ b/common/prefix.py
@@ -4,6 +4,7 @@ import uuid
 
 
 from openpilot.common.params import Params
+from openpilot.system.hardware import PC
 from openpilot.system.hardware.hw import Paths
 from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
 
@@ -45,7 +46,8 @@ class OpenpilotPrefix:
       shutil.rmtree(os.path.realpath(symlink_path), ignore_errors=True)
       os.remove(symlink_path)
     shutil.rmtree(self.msgq_path, ignore_errors=True)
-    shutil.rmtree(Paths.log_root(), ignore_errors=True)
+    if PC:
+      shutil.rmtree(Paths.log_root(), ignore_errors=True)
     if not os.environ.get("COMMA_CACHE", False):
       shutil.rmtree(Paths.download_cache_root(), ignore_errors=True)
     shutil.rmtree(Paths.comma_home(), ignore_errors=True)


### PR DESCRIPTION
wanted to look into an issue on jenkins but the logs are deleted because we are running with pytest

https://github.com/commaai/openpilot/issues/31536