### PR TITLE
Volkswagen: fix PT bus query

### DIFF
--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -371,7 +371,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [VOLKSWAGEN_VERSION_REQUEST_MULTI],
       [VOLKSWAGEN_VERSION_RESPONSE],
-      # whitelist_ecus=[Ecu.srs, Ecu.eps, Ecu.fwdRadar],
+      whitelist_ecus=[Ecu.srs, Ecu.eps, Ecu.fwdRadar, Ecu.fwdCamera],
       rx_offset=VOLKSWAGEN_RX_OFFSET,
       bus=bus,
       logging=(bus != 1 or not obd_multiplexing),
@@ -380,7 +380,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [VOLKSWAGEN_VERSION_REQUEST_MULTI],
       [VOLKSWAGEN_VERSION_RESPONSE],
-      # whitelist_ecus=[Ecu.engine, Ecu.transmission],
+      whitelist_ecus=[Ecu.engine, Ecu.transmission],
       bus=bus,
       logging=(bus != 1 or not obd_multiplexing),
       obd_multiplexing=obd_multiplexing,


### PR DESCRIPTION
Fix radar and camera FW not returning on PT bus.

in https://github.com/commaai/openpilot/pull/31556, we added queries for the two possible PT buses. However, I didn't consider that we'd leave the radar and camera in bad states when querying them with the 0x8 rxoffset requests