### PR TITLE
Fix panda sorting logic in pandad

### DIFF
--- a/selfdrive/boardd/pandad.py
+++ b/selfdrive/boardd/pandad.py
@@ -74,10 +74,10 @@ def panda_sort_cmp(a: Panda, b: Panda):
 
   # sort by hardware type
   if a_type != b_type:
-    return a_type < b_type
+    return -1 if a_type < b_type else 1
 
   # last resort: sort by serial number
-  return a.get_usb_serial() < b.get_usb_serial()
+  return -1 if a.get_usb_serial() < b.get_usb_serial() else 0 if a.get_usb_serial() == b.get_usb_serial() else 1
 
 
 def main() -> NoReturn:

--- a/selfdrive/boardd/pandad.py
+++ b/selfdrive/boardd/pandad.py
@@ -77,7 +77,7 @@ def panda_sort_cmp(a: Panda, b: Panda):
     return -1 if a_type < b_type else 1
 
   # last resort: sort by serial number
-  return -1 if a.get_usb_serial() < b.get_usb_serial() else 0 if a.get_usb_serial() == b.get_usb_serial() else 1
+  return -1 if a.get_usb_serial() < b.get_usb_serial() else 1
 
 
 def main() -> NoReturn:

--- a/selfdrive/boardd/pandad.py
+++ b/selfdrive/boardd/pandad.py
@@ -5,7 +5,6 @@ import usb1
 import time
 import subprocess
 from typing import NoReturn
-from functools import cmp_to_key
 
 from panda import Panda, PandaDFU, PandaProtocolMismatch, FW_PATH
 from openpilot.common.basedir import BASEDIR
@@ -60,24 +59,6 @@ def flash_panda(panda_serial: str) -> Panda:
     raise AssertionError
 
   return panda
-
-
-def panda_sort_cmp(a: Panda, b: Panda):
-  a_type = a.get_type()
-  b_type = b.get_type()
-
-  # make sure the internal one is always first
-  if a.is_internal() and not b.is_internal():
-    return -1
-  if not a.is_internal() and b.is_internal():
-    return 1
-
-  # sort by hardware type
-  if a_type != b_type:
-    return -1 if a_type < b_type else 1
-
-  # last resort: sort by serial number
-  return -1 if a.get_usb_serial() < b.get_usb_serial() else 1
 
 
 def main() -> NoReturn:
@@ -136,7 +117,10 @@ def main() -> NoReturn:
       no_internal_panda_count = 0
 
       # sort pandas to have deterministic order
-      pandas.sort(key=cmp_to_key(panda_sort_cmp))
+      # * the internal one is always first
+      # * then sort by hardware type
+      # * as a last resort, sort by serial number
+      pandas.sort(key=lambda x: (not x.is_internal(), x.get_type(), x.get_usb_serial()))
       panda_serials = [p.get_usb_serial() for p in pandas]
 
       # log panda fw versions


### PR DESCRIPTION
Hi, I'm new to this project, and I'd like to suggest a small fix of pandad implementation.

**Description**

Corrected the panda sorting logic in pandad. The previous implementation returned boolean values (0 or 1) as a return value, where 0 indicated equality in comparison functions. This led to a minor issue in environments with multiple pandas, as sorting occasionally became nondeterministic. The fix ensures proper sorting by returning -1 for less than, 0 for equal to, and 1 for greater than comparisons.

**Verification**

This solves nondeterministic panda selection in our environment.