### PR TITLE
loggerd/logger.cc:  use std::stoul instead of std::stol 

### DIFF
--- a/system/loggerd/logger.cc
+++ b/system/loggerd/logger.cc
@@ -96,7 +96,7 @@ std::string logger_get_identifier(std::string key) {
   Params params;
   uint32_t cnt;
   try {
-    cnt = std::stol(params.get(key));
+    cnt = std::stoul(params.get(key));
   } catch (std::exception &e) {
     cnt = 0;
   }


### PR DESCRIPTION
 Use std::stoul to convert to unsigned integer (uint32_t cnt)