### PR TITLE
simulator: Improve simulator controls

### DIFF
--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -113,15 +113,22 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
     for _ in range(20):
       self.world.tick()
 
+    self.simulator_state.cruise_button = 0
+    self.simulator_state.left_blinker = False
+    self.simulator_state.right_blinker = False
+    state_changed = False
+
     while self._keep_alive:
       throttle_out = steer_out = brake_out = 0.0
       throttle_op = steer_op = brake_op = 0.0
 
-      self.simulator_state.cruise_button = 0
-      self.simulator_state.left_blinker = False
-      self.simulator_state.right_blinker = False
-
       throttle_manual = steer_manual = brake_manual = 0.
+
+      if state_changed and not self.simulator_state.button_pending.is_set():
+        self.simulator_state.cruise_button = 0
+        self.simulator_state.left_blinker = False
+        self.simulator_state.right_blinker = False
+        state_changed = False
 
       # Read manual controls
       if not q.empty():
@@ -135,6 +142,7 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
           elif m[0] == "brake":
             brake_manual = float(m[1])
           elif m[0] == "cruise":
+            state_changed = True
             if m[1] == "down":
               self.simulator_state.cruise_button = CruiseButtons.DECEL_SET
             elif m[1] == "up":
@@ -144,6 +152,7 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
             elif m[1] == "main":
               self.simulator_state.cruise_button = CruiseButtons.MAIN
           elif m[0] == "blinker":
+            state_changed = True
             if m[1] == "left":
               self.simulator_state.left_blinker = True
             elif m[1] == "right":

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -1,6 +1,7 @@
 import math
 import multiprocessing
 import numpy as np
+import threading
 
 from abc import ABC, abstractmethod
 from collections import namedtuple
@@ -55,6 +56,8 @@ class SimulatorState:
 
     self.left_blinker = False
     self.right_blinker = False
+
+    self.button_pending = threading.Event()
 
   @property
   def speed(self):

--- a/tools/sim/lib/simulated_car.py
+++ b/tools/sim/lib/simulated_car.py
@@ -33,6 +33,8 @@ class SimulatedCar:
 
     msg = []
 
+    button_press_pending = simulator_state.button_pending.is_set()
+
     # *** powertrain bus ***
 
     speed = simulator_state.speed * 3.6 # convert m/s to kph
@@ -77,6 +79,9 @@ class SimulatedCar:
     msg.append(self.packer.make_can_msg("STEERING_CONTROL", 2, {}))
     msg.append(self.packer.make_can_msg("ACC_HUD", 2, {}))
     msg.append(self.packer.make_can_msg("LKAS_HUD", 2, {}))
+
+    if button_press_pending:
+      simulator_state.button_pending.clear()
 
     self.pm.send('can', can_list_to_can_capnp(msg))
 


### PR DESCRIPTION
Ensure that the cruise buttons and the blinkers are seen by the thread that sends the CAN messages before being overwritten. This makes them usable.

**Description**

After launching the simulator it was impossible to enable cruise control, the button presses were ignored. 

**Verification**

After launching the simulator it is now possible to enable cruise control as expected. 

