### PR TITLE
[bot] Fingerprints: add missing FW versions from CAN fingerprinting cars

### DIFF
--- a/selfdrive/car/volkswagen/fingerprints.py
+++ b/selfdrive/car/volkswagen/fingerprints.py
@@ -116,22 +116,26 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7e0, None): [
       b'\xf1\x8704L906056BP\xf1\x894729',
       b'\xf1\x8704L906056EK\xf1\x896391',
+      b'\xf1\x8704L906056SH\xf1\x899973',
       b'\xf1\x8705L906023BC\xf1\x892688',
     ],
     (Ecu.srs, 0x715, None): [
       b'\xf1\x873Q0959655AL\xf1\x890505\xf1\x82\x0e1411001413001203151311031100',
       b'\xf1\x873Q0959655BG\xf1\x890703\xf1\x82\x0e16120016130012051G1313052900',
+      b'\xf1\x873Q0959655CR\xf1\x890720\xf1\x82\x0e16120016130012051F1311052900',
       b'\xf1\x875QF959655AS\xf1\x890755\xf1\x82\x1315140015150011111100050200--1311120749',
     ],
     (Ecu.eps, 0x712, None): [
       b'\xf1\x872N0909143D\x00\xf1\x897010\xf1\x82\x05183AZ306A2',
       b'\xf1\x872N0909143E \xf1\x897021\xf1\x82\x05163AZ306A2',
+      b'\xf1\x872N0909144J \xf1\x897031\xf1\x82\x05193AZ806A2',
       b'\xf1\x872N0909144K \xf1\x897045\xf1\x82\x05233AZ810A2',
     ],
     (Ecu.fwdRadar, 0x757, None): [
       b'\xf1\x872Q0907572AA\xf1\x890396',
       b'\xf1\x872Q0907572J \xf1\x890156',
       b'\xf1\x872Q0907572M \xf1\x890233',
+      b'\xf1\x872Q0907572R \xf1\x890372',
     ],
   },
   CAR.VOLKSWAGEN_GOLF_MK7: {
@@ -304,6 +308,7 @@ FW_VERSIONS = {
       b'\xf1\x875QN909144A \xf1\x895081\xf1\x82\x0571A01A16A1',
       b'\xf1\x875QN909144A \xf1\x895081\xf1\x82\x0571A01A17A1',
       b'\xf1\x875QN909144A \xf1\x895081\xf1\x82\x0571A01A18A1',
+      b'\xf1\x875QN909144A \xf1\x895081\xf1\x82\x0571A0JA15A1',
       b'\xf1\x875QN909144B \xf1\x895082\xf1\x82\x0571A01A18A1',
     ],
     (Ecu.fwdRadar, 0x757, None): [
@@ -642,6 +647,7 @@ FW_VERSIONS = {
       b'\xf1\x872Q0907572Q \xf1\x890342',
       b'\xf1\x872Q0907572R \xf1\x890372',
       b'\xf1\x872Q0907572T \xf1\x890383',
+      b'\xf1\x875Q0907572J \xf1\x890654',
     ],
   },
   CAR.VOLKSWAGEN_TOURAN_MK2: {


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 2 dongles (3 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                             | Name from VIN 🆚 CarDocs                                                | Segments                                    | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Good seg tags                                                                          |
|:----------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------|:--------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [1a944f1463d214d5](https://useradmin.comma.ai/?onebox=1a944f1463d214d5)<br><sub>VOLKSWAGEN_GOLF_MK7<br>WVWVF7AU4........</sub>    | VOLKSWAGEN Golf R Hatchback 2018 🆚<br>Volkswagen Golf Alltrack 2015-19 | 82 routes,<br>1250 segments<br>(20.8 hours) | - [car faulted: 10](https://useradmin.comma.ai/?onebox=1a944f1463d214d5%7C2024-03-20--14-41-56)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=1a944f1463d214d5)                                                                                                                                                                                                                                                                                                                                                                                                                     | - valid torque params: 1219<br>- all lat active: 482<br>- no input all lat active: 165 |
| [1a944f1463d214d5](https://useradmin.comma.ai/?onebox=1a944f1463d214d5)<br><sub>VOLKSWAGEN_TIGUAN_MK2<br>WVWVF7AU4........</sub>  | VOLKSWAGEN Golf R Hatchback 2018 🆚<br>Volkswagen Tiguan 2018-24        | 68 routes,<br>915 segments<br>(15.2 hours)  | - [missing ECU FW: 34](https://useradmin.comma.ai/?onebox=1a944f1463d214d5%7C2024-03-19--16-20-09)<br>- [spotty FW: 897](https://useradmin.comma.ai/?onebox=1a944f1463d214d5%7C2024-03-13--23-43-25)<br>- [multiple VINs: 1](https://useradmin.comma.ai/?onebox=1a944f1463d214d5%7C2024-03-16--20-59-05)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=1a944f1463d214d5%7C2024-03-19--19-54-52)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=1a944f1463d214d5%7C2024-03-19--16-20-09)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=1a944f1463d214d5) | - valid torque params: 831<br>- all lat active: 311<br>- no input all lat active: 91   |
| [46e8fc71a2f4298d](https://useradmin.comma.ai/?onebox=46e8fc71a2f4298d)<br><sub>VOLKSWAGEN_CRAFTER_MK2<br>WV1ZZZSYZ........</sub> | VOLKSWAGEN  2020 🆚<br>Volkswagen Crafter 2017-23                       | 6 routes,<br>262 segments<br>(4.4 hours)    | - [spotty FW: 4](https://useradmin.comma.ai/?onebox=46e8fc71a2f4298d%7C00000009--79500ff6d2)<br>- [car faulted: 2](https://useradmin.comma.ai/?onebox=46e8fc71a2f4298d%7C00000009--79500ff6d2)                                                                                                                                                                                                                                                                                                                                                                                                               | - valid torque params: 257<br>- all lat active: 70<br>- no input all lat active: 36    |

Dongles to re-run category: `46e8fc71a2f4298d 1a944f1463d214d5`
</details>

## ⏳️ 0 dongles (0 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN   | Name from VIN 🆚 CarDocs   | Segments   | Bad seg tags   | Good seg tags   |
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>

## ⚠️ 0 dongles (0 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN   | Name from VIN 🆚 CarDocs   | Segments   | Bad seg tags   | Good seg tags   |
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>