### PR TITLE
jenkins: set pythonpath for casync build

### DIFF
--- a/release/create_casync_build.sh
+++ b/release/create_casync_build.sh
@@ -7,7 +7,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 CASYNC_DIR="${CASYNC_DIR:=/tmp/casync}"
 SOURCE_DIR="$(git -C $DIR rev-parse --show-toplevel)"
 BUILD_DIR="${BUILD_DIR:=$(mktemp -d)}"
-PYTHONPATH=$SOURCE_DIR
+PYTHONPATH="$SOURCE_DIR"
 
 echo "Creating casync release from $SOURCE_DIR to $CASYNC_DIR"
 

--- a/release/create_casync_build.sh
+++ b/release/create_casync_build.sh
@@ -7,6 +7,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 CASYNC_DIR="${CASYNC_DIR:=/tmp/casync}"
 SOURCE_DIR="$(git -C $DIR rev-parse --show-toplevel)"
 BUILD_DIR="${BUILD_DIR:=$(mktemp -d)}"
+PYTHONPATH=$SOURCE_DIR
 
 echo "Creating casync release from $SOURCE_DIR to $CASYNC_DIR"
 


### PR DESCRIPTION
required because `/data/openpilot` is the default pythonpath, but we are building within that directory