### PR TITLE
common/params.cc: unlink tmp_path only if there's an error

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -273,7 +273,9 @@ int Params::put(const char* key, const char* value, size_t value_size) {
   } while (false);
 
   close(tmp_fd);
-  ::unlink(tmp_path.c_str());
+  if (result != 0) {
+    ::unlink(tmp_path.c_str());
+  }
   return result;
 }
 


### PR DESCRIPTION
 It should only be unlinked if the operation fails.