### PR TITLE
simulator: Improve keyboard controls

### DIFF
--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -104,21 +104,24 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
       throttle_out = steer_out = brake_out = 0.0
       throttle_op = steer_op = brake_op = 0.0
 
-      self.simulator_state.cruise_button = 0
-      self.simulator_state.left_blinker = False
-      self.simulator_state.right_blinker = False
+      if self.rk.frame % 50 == 0:
+        self.simulator_state.cruise_button = 0
+        self.simulator_state.left_blinker = False
+        self.simulator_state.right_blinker = False
 
-      throttle_manual = steer_manual = brake_manual = 0.
+        throttle_manual = steer_manual = brake_manual = 0.0
 
       # Read manual controls
       if not q.empty():
         message = q.get()
         m = message.split('_')
         if m[0] == "steer":
-          steer_manual = float(m[1])
+          steer_manual = -float(m[1])
         elif m[0] == "throttle":
+          brake_manual = 0.0
           throttle_manual = float(m[1])
         elif m[0] == "brake":
+          throttle_manual = 0.0
           brake_manual = float(m[1])
         elif m[0] == "cruise":
           if m[1] == "down":
@@ -131,8 +134,10 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
             self.simulator_state.cruise_button = CruiseButtons.MAIN
         elif m[0] == "blinker":
           if m[1] == "left":
+            self.simulator_state.right_blinker = False
             self.simulator_state.left_blinker = True
           elif m[1] == "right":
+            self.simulator_state.left_blinker = False
             self.simulator_state.right_blinker = True
         elif m[0] == "ignition":
           self.simulator_state.ignition = not self.simulator_state.ignition
@@ -143,9 +148,7 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
 
       self.simulator_state.user_brake = brake_manual
       self.simulator_state.user_gas = throttle_manual
-      self.simulator_state.user_torque = steer_manual * -10000
-
-      steer_manual = steer_manual * -40
+      self.simulator_state.user_torque = steer_manual
 
       # Update openpilot on current sensor state
       self.simulated_sensors.update(self.simulator_state, self.world)

--- a/tools/sim/lib/keyboard_ctrl.py
+++ b/tools/sim/lib/keyboard_ctrl.py
@@ -66,11 +66,15 @@ def keyboard_poll_thread(q: 'Queue[str]'):
     elif c == 'w':
       q.put("throttle_%f" % 1.0)
     elif c == 'a':
-      q.put("steer_%f" % -0.15)
+      q.put("steer_%f" % -20.0)
+    elif c == 'A':
+      q.put("steer_%f" % -40.0)
     elif c == 's':
       q.put("brake_%f" % 1.0)
     elif c == 'd':
-      q.put("steer_%f" % 0.15)
+      q.put("steer_%f" % 20.0)
+    elif c == 'D':
+      q.put("steer_%f" % 40.0)
     elif c == 'z':
       q.put("blinker_left")
     elif c == 'x':

--- a/tools/sim/lib/manual_ctrl.py
+++ b/tools/sim/lib/manual_ctrl.py
@@ -164,7 +164,7 @@ def wheel_poll_thread(q: 'Queue[str]') -> NoReturn:
       elif axis == "x":  # steer angle
         fvalue = value / 32767.0
         axis_states[axis] = fvalue
-        normalized = fvalue
+        normalized = fvalue * 40
         q.put(f"steer_{normalized:f}")
 
     elif mtype & 0x01:  # buttons


### PR DESCRIPTION
Let's keep the controls for 0.5s (50 cycles of 100Hz) to improve keyboard control usability and make sure that OP registers them.