### PR TITLE
Hyundai CAN-FD: Add `LKAS` and `LKAS_ALT` messages to HDA2 int flag

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -29,7 +29,9 @@ class CarInterface(CarInterfaceBase):
     # FIXME: the Optima Hybrid 2017 uses a different SCC12 checksum
     ret.dashcamOnly = candidate in {CAR.KIA_OPTIMA_H, }
 
-    hda2 = Ecu.adas in [fw.ecu for fw in car_fw]
+    _CAN_CAM = CanBus(None).CAM
+    hda2 = Ecu.adas in [fw.ecu for fw in car_fw] or \
+           0x50 in fingerprint[_CAN_CAM] or 0x110 in fingerprint[_CAN_CAM]
     CAN = CanBus(None, hda2, fingerprint)
 
     if candidate in CANFD_CAR:


### PR DESCRIPTION
**Description**

Introduces `LKAS` and `LKAS_ALT` messages to set the int flag for CAN-FD HDA2 platforms. Some newer HDA2 platforms do not have `Ecu.adas` from fingerprinting query, but still had `LKAS` or `LKAS_ALT` on the CAM bus.

**Affected platforms**
- Genesis GV70 3.5T 2022 (HDA2): https://github.com/commaai/openpilot/pull/31704

**Verification**

Similar changes are being tested in this PR:
- https://github.com/commaai/openpilot/pull/31704
