### PR TITLE
ui/network: update known connections after adding tethering connection.

### DIFF
--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -428,7 +428,10 @@ void WifiManager::addTetheringConnection() {
   connection["ipv4"]["route-metric"] = 1100;
   connection["ipv6"]["method"] = "ignore";
 
-  call(NM_DBUS_PATH_SETTINGS, NM_DBUS_INTERFACE_SETTINGS, "AddConnection", QVariant::fromValue(connection));
+  auto path = call<QDBusObjectPath>(NM_DBUS_PATH_SETTINGS, NM_DBUS_INTERFACE_SETTINGS, "AddConnection", QVariant::fromValue(connection));
+  if (!path.path().isEmpty()) {
+    knownConnections[path] = tethering_ssid;
+  }
 }
 
 void WifiManager::tetheringActivated(QDBusPendingCallWatcher *call) {


### PR DESCRIPTION
currently ,we rely on the dbus's "NewConnection" signal to add tethering to the list of known connections (`knownConnections`) after adding tethering. this introduces a dependency on external events. If this signal is not reliably triggered by dbus or handled incorrectly, it could lead to synchronization issues,  and there may be a delay between adding the tethering connection and it being recognized by the "NewConnection" signal, potentially causing inconsistencies bug.

relying on the "NewConnection" signal could lead to `isKnownConnection(tethering_ssid)` return false and duplicate tethering connections being created. This can lead to enable tethering failed, or confusion among devices about which hotspot to connect to, potentially resulting in connection failures or unstable connections.

> if (!isKnownConnection(tethering_ssid)) {
>       addTetheringConnection();
>     }

it's a good practice to manual update `knownConnections` after adding tethering connection. Since the tethering connection might not be automatically included in the list of known connections obtained from ListConnections, manually adding the tethering SSID to the list of known connections ensures wifiManager has an up-to-date record of all relevant connections.

