### PR TITLE
ui/network: add error handling for refreshFinished

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,12 @@
     "system/**",
     "third_party/**",
     "tools/**",
-  ]
+  ],
+  "files.associations": {
+    "*.py": "python",
+    "*.tcc": "cpp",
+    "optional": "cpp",
+    "system_error": "cpp",
+    "regex": "cpp"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,12 +23,5 @@
     "system/**",
     "third_party/**",
     "tools/**",
-  ],
-  "files.associations": {
-    "*.py": "python",
-    "*.tcc": "cpp",
-    "optional": "cpp",
-    "system_error": "cpp",
-    "regex": "cpp"
-  }
+  ]
 }

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -99,10 +99,20 @@ void WifiManager::refreshFinished(QDBusPendingCallWatcher *watcher) {
   seenNetworks.clear();
 
   const QDBusReply<QList<QDBusObjectPath>> watcher_reply = *watcher;
+  if (!wather_reply.isValid()) {
+    qCritical() << "Failed to refresh.";
+    watcher->deleteLater();
+    return;
+  }
+
   for (const QDBusObjectPath &path : watcher_reply.value()) {
     QDBusReply<QVariantMap> reply = call(path.path(), NM_DBUS_INTERFACE_PROPERTIES, "GetAll", NM_DBUS_INTERFACE_ACCESS_POINT);
-    auto properties = reply.value();
+    if (!reply.isValid()) {
+      qCritical() << "Failed to retrieve properties for path:" << path.path();
+      continue;
+    }
 
+    auto properties = replay.value();
     const QByteArray ssid = properties["Ssid"].toByteArray();
     if (ssid.isEmpty()) continue;
 

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -99,8 +99,8 @@ void WifiManager::refreshFinished(QDBusPendingCallWatcher *watcher) {
   seenNetworks.clear();
 
   const QDBusReply<QList<QDBusObjectPath>> watcher_reply = *watcher;
-  if (!wather_reply.isValid()) {
-    qCritical() << "Failed to refresh.";
+  if (!watcher_reply.isValid()) {
+    qCritical() << "Failed to refresh";
     watcher->deleteLater();
     return;
   }
@@ -112,7 +112,7 @@ void WifiManager::refreshFinished(QDBusPendingCallWatcher *watcher) {
       continue;
     }
 
-    auto properties = replay.value();
+    auto properties = reply.value();
     const QByteArray ssid = properties["Ssid"].toByteArray();
     if (ssid.isEmpty()) continue;
 


### PR DESCRIPTION
There's no error handling for the case where reply is not valid. we should check if these replies contain valid data before attempting to use them.