### PR TITLE
ui/network: use initialize list

### DIFF
--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -411,7 +411,7 @@ void WifiManager::updateGsmSettings(bool roaming, QString apn, bool metered) {
 
 // Functions for tethering
 void WifiManager::addTetheringConnection() {
-    QVariantMap address = {
+  QVariantMap address = {
     {"address", "192.168.43.1"},
     {"prefix", 24u},
   };


### PR DESCRIPTION
using initializer lists to grouping related properties together, which improves readability and reduces redundancy.
