### PR TITLE
ui/network: initialize raw_adapter_state to NM_DEVICE_STATE_UNKNOWN

### DIFF
--- a/selfdrive/ui/qt/network/networkmanager.h
+++ b/selfdrive/ui/qt/network/networkmanager.h
@@ -32,6 +32,7 @@ const QString NM_DBUS_INTERFACE_IP4_CONFIG          = "org.freedesktop.NetworkMa
 
 const QString NM_DBUS_SERVICE                        = "org.freedesktop.NetworkManager";
 
+const int NM_DEVICE_STATE_UNKNOWN = 0;
 const int NM_DEVICE_STATE_ACTIVATED = 100;
 const int NM_DEVICE_STATE_NEED_AUTH = 60;
 const int NM_DEVICE_TYPE_WIFI = 2;

--- a/selfdrive/ui/qt/network/wifi_manager.h
+++ b/selfdrive/ui/qt/network/wifi_manager.h
@@ -63,7 +63,7 @@ public:
 private:
   QString adapter;  // Path to network manager wifi-device
   QTimer timer;
-  unsigned int raw_adapter_state;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState
+  unsigned int raw_adapter_state = NM_DEVICE_STATE_UNKNOWN;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState
   QString connecting_to_network;
   QString tethering_ssid;
   const QString defaultTetheringPassword = "swagswagcomma";


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

