### PR TITLE
ui/setup: Initially disable continue button

### DIFF
--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -201,6 +201,7 @@ QWidget * Setup::network_setup() {
   QPushButton *cont = new QPushButton();
   cont->setObjectName("navBtn");
   cont->setProperty("primary", true);
+  cont->setEnabled(false);
   QObject::connect(cont, &QPushButton::clicked, this, &Setup::nextPage);
   blayout->addWidget(cont);
 


### PR DESCRIPTION
discovered this issue while debugging the wifiManager:
the continue button is enabled by default, only gets disabled after the first HTTP request failure.


