### PR TITLE
ui/setup: use the mode "wb" instead of "w".

### DIFF
--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -51,7 +51,7 @@ void Setup::download(QString url) {
   list = curl_slist_append(list, ("X-openpilot-serial: " + Hardware::get_serial()).c_str());
 
   char tmpfile[] = "/tmp/installer_XXXXXX";
-  FILE *fp = fdopen(mkstemp(tmpfile), "w");
+  FILE *fp = fdopen(mkstemp(tmpfile), "wb");
 
   curl_easy_setopt(curl, CURLOPT_URL, url.toStdString().c_str());
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);


### PR DESCRIPTION
use "wb" for writing in binary mode. 
Although 'w' and 'wb' are the same on Linux, it would be more consistent to use 'wb' for writing since we've already used 'rb' to read the downloaded file:
https://github.com/commaai/openpilot/blob/1f37de1870f127cd8c1c9943b026fe952fd34b8d/selfdrive/ui/qt/setup/setup.cc#L26
