### PR TITLE
include hash in agnos casync filenames

### DIFF
--- a/release/create_casync_agnos_release.py
+++ b/release/create_casync_agnos_release.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 import pathlib
 import tempfile
 import time
 from openpilot.common.basedir import BASEDIR
 from openpilot.system.hardware.tici.agnos import StreamingDecompressor, unsparsify, noop, AGNOS_MANIFEST_FILE
 from openpilot.system.updated.casync.common import create_casync_from_file
-from openpilot.system.version import get_agnos_version
 
 
 
@@ -15,7 +15,6 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="creates a casync release")
   parser.add_argument("output_dir", type=str, help="output directory for the channel")
   parser.add_argument("working_dir", type=str, help="working directory")
-  parser.add_argument("--version", type=str, help="version of agnos this is", default=get_agnos_version())
   parser.add_argument("--manifest", type=str, help="json manifest to create agnos release from", \
                         default=str(pathlib.Path(BASEDIR) / AGNOS_MANIFEST_FILE))
   args = parser.parse_args()
@@ -53,5 +52,6 @@ if __name__ == "__main__":
       print(f"downloaded in {time.monotonic() - start}")
 
       start = time.monotonic()
-      create_casync_from_file(entry_path, output_dir, f"agnos-{args.version}-{entry['name']}")
+      agnos_filename = os.path.basename(entry["url"]).split(".")[0]
+      create_casync_from_file(entry_path, output_dir, agnos_filename)
       print(f"created casnc in {time.monotonic() - start}")

--- a/release/create_release_manifest.py
+++ b/release/create_release_manifest.py
@@ -2,6 +2,7 @@
 import argparse
 import dataclasses
 import json
+import os
 import pathlib
 
 from openpilot.system.hardware.tici.agnos import AGNOS_MANIFEST_FILE, get_partition_path
@@ -17,10 +18,12 @@ AGNOS_RELEASES = f"{BASE_URL}/openpilot-releases/agnos"
 
 
 def create_partition_manifest(agnos_version, partition):
+  agnos_filename = os.path.basename(partition["url"]).split(".")[0]
+
   return {
     "type": "partition",
     "casync": {
-      "caibx": f"{AGNOS_RELEASES}/agnos-{agnos_version}-{partition['name']}.caibx"
+      "caibx": f"{AGNOS_RELEASES}/{agnos_filename}.caibx"
     },
     "path": get_partition_path(0, partition),
     "ab": True,


### PR DESCRIPTION
`agnos-9.7-system.caibx` -> `system-0f69173d5f3058f7197c139442a6556be59e52f15402a263215a329ba5ec41e2.caibx` (in case we do multiple builds with the same agnos verison), keeps it consistent with `agnos.json`