### PR TITLE
Volkswagen: enable OBD-less fingerprinting for gateway-integrated cars

### DIFF
--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -366,13 +366,13 @@ VOLKSWAGEN_RX_OFFSET = 0x6a
 # TODO: determine the unknown groups
 SPARE_PART_FW_PATTERN = re.compile(b'\xf1\x87(?P<gateway>[0-9][0-9A-Z]{2})(?P<unknown>[0-9][0-9A-Z][0-9])(?P<unknown2>[0-9A-Z]{2}[0-9])([A-Z0-9]| )')
 
-FW_QUERY_CONFIG = FwQueryConfig(
-  # TODO: add back whitelists after we gather enough data
-  requests=[request for bus, obd_multiplexing in [(1, True), (1, False), (0, False)] for request in [
+
+def get_volkswagen_requests(bus: int, obd_multiplexing: bool = True, whitelist: tuple = ()) -> list:
+  return [
     Request(
       [VOLKSWAGEN_VERSION_REQUEST_MULTI],
       [VOLKSWAGEN_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.srs, Ecu.eps, Ecu.fwdRadar, Ecu.fwdCamera],
+      whitelist_ecus=[ecu for ecu in [Ecu.srs, Ecu.eps, Ecu.fwdRadar, Ecu.fwdCamera] if ecu in whitelist or not len(whitelist)],
       rx_offset=VOLKSWAGEN_RX_OFFSET,
       bus=bus,
       logging=(bus != 1 or not obd_multiplexing),
@@ -381,12 +381,19 @@ FW_QUERY_CONFIG = FwQueryConfig(
     Request(
       [VOLKSWAGEN_VERSION_REQUEST_MULTI],
       [VOLKSWAGEN_VERSION_RESPONSE],
-      whitelist_ecus=[Ecu.engine, Ecu.transmission],
+      whitelist_ecus=[ecu for ecu in [Ecu.engine, Ecu.transmission] if ecu in whitelist or not len(whitelist)],
       bus=bus,
       logging=(bus != 1 or not obd_multiplexing),
       obd_multiplexing=obd_multiplexing,
     ),
-  ]],
+  ]
+
+
+FW_QUERY_CONFIG = FwQueryConfig(
+  # TODO: add back whitelists after we gather enough data
+  requests=(get_volkswagen_requests(1) +
+            get_volkswagen_requests(1, False, whitelist=(Ecu.srs, Ecu.engine, Ecu.transmission)) +
+            get_volkswagen_requests(0, whitelist=(Ecu.fwdRadar, Ecu.fwdCamera))),
   extra_ecus=[(Ecu.fwdCamera, 0x74f, None)],
 )
 

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -384,6 +384,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       obd_multiplexing=obd_multiplexing,
     ),
   ]],
+  non_essential_ecus={Ecu.eps: list(CAR)},
   extra_ecus=[(Ecu.fwdCamera, 0x74f, None)],
 )
 

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -366,13 +366,13 @@ VOLKSWAGEN_RX_OFFSET = 0x6a
 # TODO: determine the unknown groups
 SPARE_PART_FW_PATTERN = re.compile(b'\xf1\x87(?P<gateway>[0-9][0-9A-Z]{2})(?P<unknown>[0-9][0-9A-Z][0-9])(?P<unknown2>[0-9A-Z]{2}[0-9])([A-Z0-9]| )')
 
-
-def get_volkswagen_requests(bus: int, obd_multiplexing: bool = True, whitelist: tuple = ()) -> list:
-  return [
+FW_QUERY_CONFIG = FwQueryConfig(
+  # TODO: add back whitelists after we gather enough data
+  requests=[request for bus, obd_multiplexing in [(1, True), (1, False), (0, False)] for request in [
     Request(
       [VOLKSWAGEN_VERSION_REQUEST_MULTI],
       [VOLKSWAGEN_VERSION_RESPONSE],
-      whitelist_ecus=[ecu for ecu in [Ecu.srs, Ecu.eps, Ecu.fwdRadar, Ecu.fwdCamera] if ecu in whitelist or not len(whitelist)],
+      whitelist_ecus=[Ecu.srs, Ecu.eps, Ecu.fwdRadar, Ecu.fwdCamera],
       rx_offset=VOLKSWAGEN_RX_OFFSET,
       bus=bus,
       logging=(bus != 1 or not obd_multiplexing),
@@ -381,19 +381,12 @@ def get_volkswagen_requests(bus: int, obd_multiplexing: bool = True, whitelist: 
     Request(
       [VOLKSWAGEN_VERSION_REQUEST_MULTI],
       [VOLKSWAGEN_VERSION_RESPONSE],
-      whitelist_ecus=[ecu for ecu in [Ecu.engine, Ecu.transmission] if ecu in whitelist or not len(whitelist)],
+      whitelist_ecus=[Ecu.engine, Ecu.transmission],
       bus=bus,
       logging=(bus != 1 or not obd_multiplexing),
       obd_multiplexing=obd_multiplexing,
     ),
-  ]
-
-
-FW_QUERY_CONFIG = FwQueryConfig(
-  # TODO: add back whitelists after we gather enough data
-  requests=(get_volkswagen_requests(1) +
-            get_volkswagen_requests(1, False, whitelist=(Ecu.srs, Ecu.engine, Ecu.transmission)) +
-            get_volkswagen_requests(0, whitelist=(Ecu.fwdRadar, Ecu.fwdCamera))),
+  ]],
   extra_ecus=[(Ecu.fwdCamera, 0x74f, None)],
 )
 

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -367,7 +367,6 @@ VOLKSWAGEN_RX_OFFSET = 0x6a
 SPARE_PART_FW_PATTERN = re.compile(b'\xf1\x87(?P<gateway>[0-9][0-9A-Z]{2})(?P<unknown>[0-9][0-9A-Z][0-9])(?P<unknown2>[0-9A-Z]{2}[0-9])([A-Z0-9]| )')
 
 FW_QUERY_CONFIG = FwQueryConfig(
-  # TODO: add back whitelists after we gather enough data
   requests=[request for bus, obd_multiplexing in [(1, True), (1, False), (0, False)] for request in [
     Request(
       [VOLKSWAGEN_VERSION_REQUEST_MULTI],
@@ -375,7 +374,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       whitelist_ecus=[Ecu.srs, Ecu.eps, Ecu.fwdRadar, Ecu.fwdCamera],
       rx_offset=VOLKSWAGEN_RX_OFFSET,
       bus=bus,
-      logging=(bus != 1 or not obd_multiplexing),
       obd_multiplexing=obd_multiplexing,
     ),
     Request(
@@ -383,7 +381,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [VOLKSWAGEN_VERSION_RESPONSE],
       whitelist_ecus=[Ecu.engine, Ecu.transmission],
       bus=bus,
-      logging=(bus != 1 or not obd_multiplexing),
       obd_multiplexing=obd_multiplexing,
     ),
   ]],


### PR DESCRIPTION
For https://github.com/commaai/openpilot/pull/32148

This is only needed for the gateway cars without a camera to get the VIN from (~20 users). We can get the VIN from the engine on bus 1 non-OBD, but the vin function currently isn't set up to switch OBD multiplexing modes.

The VIN query is starting to take a while, so I'm blocking it on https://github.com/commaai/cereal/pull/588. That allows us to identify the brand before anything else, so we can just run the specific VIN queries we need, speeding things up.