### PR TITLE
replay: bug fixes and improvements

### DIFF
--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -33,13 +33,12 @@ void ReplayStream::mergeSegments() {
 
       std::vector<const CanEvent *> new_events;
       new_events.reserve(seg->log->events.size());
-      for (auto it = seg->log->events.cbegin(); it != seg->log->events.cend(); ++it) {
-        if ((*it)->which == cereal::Event::Which::CAN) {
-          const uint64_t ts = (*it)->mono_time;
-          capnp::FlatArrayMessageReader reader((*it)->data);
+      for (const Event &e : seg->log->events) {
+        if (e.which == cereal::Event::Which::CAN) {
+          capnp::FlatArrayMessageReader reader(e.data);
           auto event = reader.getRoot<cereal::Event>();
           for (const auto &c : event.getCan()) {
-            new_events.push_back(newEvent(ts, c));
+            new_events.push_back(newEvent(e.mono_time, c));
           }
         }
       }

--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -172,7 +172,7 @@ void ConsoleUI::updateStatus() {
   if (status != Status::Paused) {
     auto events = replay->events();
     uint64_t current_mono_time = replay->routeStartTime() + replay->currentSeconds() * 1e9;
-    bool playing = !events->empty() && events->back()->mono_time > current_mono_time;
+    bool playing = !events->empty() && events->back().mono_time > current_mono_time;
     status = playing ? Status::Playing : Status::Waiting;
   }
   auto [status_str, status_color] = status_text[status];
@@ -368,7 +368,6 @@ void ConsoleUI::handleKey(char c) {
   } else if (c == ' ') {
     pauseReplay(!replay->isPaused());
   } else if (c == 'q' || c == 'Q') {
-    replay->stop();
     qApp->exit();
   }
 }

--- a/tools/replay/filereader.cc
+++ b/tools/replay/filereader.cc
@@ -35,7 +35,10 @@ std::string FileReader::read(const std::string &file, std::atomic<bool> *abort) 
 
 std::string FileReader::download(const std::string &url, std::atomic<bool> *abort) {
   for (int i = 0; i <= max_retries_ && !(abort && *abort); ++i) {
-    if (i > 0) rWarning("download failed, retrying %d", i);
+    if (i > 0) {
+      rWarning("download failed, retrying %d", i);
+      util::sleep_for(3000);
+    }
 
     std::string result = httpGet(url, chunk_size_, abort);
     if (!result.empty()) {

--- a/tools/replay/logreader.cc
+++ b/tools/replay/logreader.cc
@@ -4,16 +4,6 @@
 #include "tools/replay/filereader.h"
 #include "tools/replay/util.h"
 
-LogReader::LogReader(size_t memory_pool_block_size) {
-  events.reserve(memory_pool_block_size);
-}
-
-LogReader::~LogReader() {
-  for (Event *e : events) {
-    delete e;
-  }
-}
-
 bool LogReader::load(const std::string &url, std::atomic<bool> *abort, bool local_cache, int chunk_size, int retries) {
   raw_ = FileReader(local_cache, chunk_size, retries).read(url, abort);
   if (raw_.empty()) return false;
@@ -22,17 +12,13 @@ bool LogReader::load(const std::string &url, std::atomic<bool> *abort, bool loca
     raw_ = decompressBZ2(raw_, abort);
     if (raw_.empty()) return false;
   }
-  return parse(abort);
+  return load(raw_.data(), raw_.size(), abort);
 }
 
-bool LogReader::load(const std::byte *data, size_t size, std::atomic<bool> *abort) {
-  raw_.assign((const char *)data, size);
-  return parse(abort);
-}
-
-bool LogReader::parse(std::atomic<bool> *abort) {
+bool LogReader::load(const char *data, size_t size, std::atomic<bool> *abort) {
   try {
-    kj::ArrayPtr<const capnp::word> words((const capnp::word *)raw_.data(), raw_.size() / sizeof(capnp::word));
+    events.reserve(65000);
+    kj::ArrayPtr<const capnp::word> words((const capnp::word *)data, size / sizeof(capnp::word));
     while (words.size() > 0 && !(abort && *abort)) {
       capnp::FlatArrayMessageReader reader(words);
       auto event = reader.getRoot<cereal::Event>();
@@ -40,16 +26,16 @@ bool LogReader::parse(std::atomic<bool> *abort) {
       uint64_t mono_time = event.getLogMonoTime();
       auto event_data = kj::arrayPtr(words.begin(), reader.getEnd());
 
-      Event *evt = events.emplace_back(newEvent(which, mono_time, event_data));
+      const Event &evt = events.emplace_back(which, mono_time, event_data);
       // Add encodeIdx packet again as a frame packet for the video stream
-      if (evt->which == cereal::Event::ROAD_ENCODE_IDX ||
-          evt->which == cereal::Event::DRIVER_ENCODE_IDX ||
-          evt->which == cereal::Event::WIDE_ROAD_ENCODE_IDX) {
+      if (evt.which == cereal::Event::ROAD_ENCODE_IDX ||
+          evt.which == cereal::Event::DRIVER_ENCODE_IDX ||
+          evt.which == cereal::Event::WIDE_ROAD_ENCODE_IDX) {
         auto idx = capnp::AnyStruct::Reader(event).getPointerSection()[0].getAs<cereal::EncodeIndex>();
         if (uint64_t sof = idx.getTimestampSof()) {
           mono_time = sof;
         }
-        events.emplace_back(newEvent(which, mono_time, event_data, idx.getSegmentNum()));
+        events.emplace_back(which, mono_time, event_data, idx.getSegmentNum());
       }
 
       words = kj::arrayPtr(reader.getEnd(), words.end());
@@ -59,16 +45,9 @@ bool LogReader::parse(std::atomic<bool> *abort) {
   }
 
   if (!events.empty() && !(abort && *abort)) {
-    std::sort(events.begin(), events.end(), Event::lessThan());
+    events.shrink_to_fit();
+    std::sort(events.begin(), events.end());
     return true;
   }
   return false;
-}
-
-Event *LogReader::newEvent(cereal::Event::Which which, uint64_t mono_time, const kj::ArrayPtr<const capnp::word> &words, int eidx_segnum) {
-#ifdef HAS_MEMORY_RESOURCE
-  return new (&mbr_) Event(which, mono_time, words, eidx_segnum);
-#else
-  return new Event(which, mono_time, words, eidx_segnum);
-#endif
 }

--- a/tools/replay/logreader.h
+++ b/tools/replay/logreader.h
@@ -1,10 +1,5 @@
 #pragma once
 
-#if __has_include(<memory_resource>)
-#define HAS_MEMORY_RESOURCE 1
-#include <memory_resource>
-#endif
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -13,27 +8,15 @@
 
 const CameraType ALL_CAMERAS[] = {RoadCam, DriverCam, WideRoadCam};
 const int MAX_CAMERAS = std::size(ALL_CAMERAS);
-const int DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE = 65000;
 
 class Event {
 public:
   Event(cereal::Event::Which which, uint64_t mono_time, const kj::ArrayPtr<const capnp::word> &data, int eidx_segnum = -1)
     : which(which), mono_time(mono_time), data(data), eidx_segnum(eidx_segnum) {}
 
-  struct lessThan {
-    inline bool operator()(const Event *l, const Event *r) {
-      return l->mono_time < r->mono_time || (l->mono_time == r->mono_time && l->which < r->which);
-    }
-  };
-
-#if HAS_MEMORY_RESOURCE
-  void *operator new(size_t size, std::pmr::monotonic_buffer_resource *mbr) {
-    return mbr->allocate(size);
+  bool operator<(const Event &other) const {
+    return mono_time < other.mono_time || (mono_time == other.mono_time && which < other.which);
   }
-  void operator delete(void *ptr) {
-    // No-op. memory used by EventMemoryPool increases monotonically until the logReader is destroyed.
-  }
-#endif
 
   uint64_t mono_time;
   cereal::Event::Which which;
@@ -43,18 +26,11 @@ public:
 
 class LogReader {
 public:
-  LogReader(size_t memory_pool_block_size = DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE);
-  ~LogReader();
   bool load(const std::string &url, std::atomic<bool> *abort = nullptr,
             bool local_cache = false, int chunk_size = -1, int retries = 0);
-  bool load(const std::byte *data, size_t size, std::atomic<bool> *abort = nullptr);
-  std::vector<Event*> events;
+  bool load(const char *data, size_t size, std::atomic<bool> *abort = nullptr);
+  std::vector<Event> events;
 
 private:
-  Event *newEvent(cereal::Event::Which which, uint64_t mono_time, const kj::ArrayPtr<const capnp::word> &words, int eidx_segnum = -1);
-  bool parse(std::atomic<bool> *abort);
   std::string raw_;
-#ifdef HAS_MEMORY_RESOURCE
-  std::pmr::monotonic_buffer_resource mbr_{DEFAULT_EVENT_MEMORY_POOL_BLOCK_SIZE * sizeof(Event)};
-#endif
 };

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -53,11 +54,10 @@ public:
   ~Replay();
   bool load();
   void start(int seconds = 0);
-  void stop();
   void pause(bool pause);
   void seekToFlag(FindFlag flag);
   void seekTo(double seconds, bool relative);
-  inline bool isPaused() const { return paused_; }
+  inline bool isPaused() const { return user_paused_; }
   // the filter is called in streaming thread.try to return quickly from it to avoid blocking streaming.
   // the filter function must return true if the event should be filtered.
   // otherwise it must return false.
@@ -79,7 +79,7 @@ public:
   inline int totalSeconds() const { return (!segments_.empty()) ? (segments_.rbegin()->first + 1) * 60 : 0; }
   inline void setSpeed(float speed) { speed_ = speed; }
   inline float getSpeed() const { return speed_; }
-  inline const std::vector<Event *> *events() const { return events_.get(); }
+  inline const std::vector<Event> *events() const { return &events_; }
   inline const std::map<int, std::unique_ptr<Segment>> &segments() const { return segments_; }
   inline const std::string &carFingerprint() const { return car_fingerprint_; }
   inline const std::vector<std::tuple<double, double, TimelineType>> getTimeline() {
@@ -99,36 +99,37 @@ protected slots:
 protected:
   typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;
   std::optional<uint64_t> find(FindFlag flag);
+  void pauseStreamThread();
   void startStream(const Segment *cur_segment);
-  void stream();
-  void setCurrentSegment(int n);
-  void queueSegment();
+  void streamThread();
+  void updateSegmentsCache();
+  void loadSegmentInRange(SegmentMap::iterator begin, SegmentMap::iterator cur, SegmentMap::iterator end);
   void mergeSegments(const SegmentMap::iterator &begin, const SegmentMap::iterator &end);
-  void updateEvents(const std::function<bool()>& lambda);
+  void updateEvents(const std::function<bool()>& update_events_function);
+  std::vector<Event>::const_iterator publishEvents(std::vector<Event>::const_iterator first,
+                                                   std::vector<Event>::const_iterator last);
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);
   void buildTimeline();
-  inline bool isSegmentMerged(int n) {
-    return std::find(segments_merged_.begin(), segments_merged_.end(), n) != segments_merged_.end();
-  }
+  inline bool isSegmentMerged(int n) const { return merged_segments_.count(n) > 0; }
 
+  pthread_t stream_thread_id = 0;
   QThread *stream_thread_ = nullptr;
   std::mutex stream_lock_;
+  bool user_paused_ = false;
   std::condition_variable stream_cv_;
-  std::atomic<bool> updating_events_ = false;
   std::atomic<int> current_segment_ = 0;
   double seeking_to_seconds_ = -1;
   SegmentMap segments_;
   // the following variables must be protected with stream_lock_
   std::atomic<bool> exit_ = false;
-  bool paused_ = false;
-  bool events_updated_ = false;
+  std::atomic<bool> paused_ = false;
+  bool events_ready_ = false;
   QDateTime route_date_time_;
   uint64_t route_start_ts_ = 0;
   std::atomic<uint64_t> cur_mono_time_ = 0;
-  std::unique_ptr<std::vector<Event *>> events_;
-  std::unique_ptr<std::vector<Event *>> new_events_;
-  std::vector<int> segments_merged_;
+  std::vector<Event> events_;
+  std::set<int> merged_segments_;
 
   // messaging
   SubMaster *sm = nullptr;

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -77,7 +77,7 @@ bool Route::loadFromServer(int retries) {
       return false;
     }
     rWarning("Retrying %d/%d", i, retries);
-    util::sleep_for(500);
+    util::sleep_for(3000);
   }
   return false;
 }

--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -1,7 +1,6 @@
 #include <chrono>
 #include <thread>
 
-#include <QDebug>
 #include <QEventLoop>
 
 #include "catch2/catch.hpp"
@@ -67,7 +66,7 @@ TEST_CASE("LogReader") {
     corrupt_content.resize(corrupt_content.length() / 2);
     corrupt_content = decompressBZ2(corrupt_content);
     LogReader log;
-    REQUIRE(log.load((std::byte *)corrupt_content.data(), corrupt_content.size()));
+    REQUIRE(log.load(corrupt_content.data(), corrupt_content.size()));
     REQUIRE(log.events.size() > 0);
   }
 }
@@ -88,7 +87,7 @@ void read_segment(int n, const SegmentFile &segment_file, uint32_t flags) {
 
     // test LogReader & FrameReader
     REQUIRE(segment.log->events.size() > 0);
-    REQUIRE(std::is_sorted(segment.log->events.begin(), segment.log->events.end(), Event::lessThan()));
+    REQUIRE(std::is_sorted(segment.log->events.begin(), segment.log->events.end()));
 
     for (auto cam : ALL_CAMERAS) {
       auto &fr = segment.frames[cam];
@@ -158,63 +157,20 @@ TEST_CASE("Remote route") {
   }
 }
 
-// helper class for unit tests
-class TestReplay : public Replay {
- public:
-  TestReplay(const QString &route, uint32_t flags = REPLAY_FLAG_NO_FILE_CACHE | REPLAY_FLAG_NO_VIPC) : Replay(route, {}, {}, nullptr, flags) {}
-  void test_seek();
-  void testSeekTo(int seek_to);
-};
-
-void TestReplay::testSeekTo(int seek_to) {
-  seekTo(seek_to, false);
-
-  while (true) {
-    std::unique_lock lk(stream_lock_);
-    stream_cv_.wait(lk, [=]() { return events_updated_ == true; });
-    events_updated_ = false;
-    if (cur_mono_time_ != route_start_ts_ + seek_to * 1e9) {
-      // wake up by the previous merging, skip it.
-      continue;
-    }
-
-    Event cur_event(cereal::Event::Which::INIT_DATA, cur_mono_time_, {});
-    auto eit = std::upper_bound(events_->begin(), events_->end(), &cur_event, Event::lessThan());
-    if (eit == events_->end()) {
-      qDebug() << "waiting for events...";
-      continue;
-    }
-
-    REQUIRE(std::is_sorted(events_->begin(), events_->end(), Event::lessThan()));
-    const int seek_to_segment = seek_to / 60;
-    const int event_seconds = ((*eit)->mono_time - route_start_ts_) / 1e9;
-    current_segment_ = event_seconds / 60;
-    INFO("seek to [" << seek_to << "s segment " << seek_to_segment << "], events [" << event_seconds << "s segment" << current_segment_ << "]");
-    REQUIRE(event_seconds >= seek_to);
-    if (event_seconds > seek_to) {
-      auto it = segments_.lower_bound(seek_to_segment);
-      REQUIRE(it->first == current_segment_);
-    }
-    break;
-  }
-}
-
-void TestReplay::test_seek() {
-  // create a dummy stream thread
-  stream_thread_ = new QThread(this);
+TEST_CASE("seek_to") {
   QEventLoop loop;
-  std::thread thread = std::thread([&]() {
-    for (int i = 0; i < 10; ++i) {
-      testSeekTo(util::random_int(0, 2 * 60));
-    }
+  int seek_to = util::random_int(0, 2 * 59);
+  Replay replay(DEMO_ROUTE, {}, {}, nullptr, REPLAY_FLAG_NO_VIPC);
+
+  QObject::connect(&replay, &Replay::seekedTo, [&](double sec) {
+    INFO("seek to " << seek_to << "s seeked to" << sec);
+    REQUIRE(sec >= seek_to);
     loop.quit();
   });
-  loop.exec();
-  thread.join();
-}
 
-TEST_CASE("Replay") {
-  TestReplay replay(DEMO_ROUTE);
   REQUIRE(replay.load());
-  replay.test_seek();
+  replay.start();
+  replay.seekTo(seek_to, false);
+
+  loop.exec();
 }

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -4,10 +4,10 @@
 #include <curl/curl.h>
 #include <openssl/sha.h>
 
-#include <cstdarg>
-#include <cstring>
 #include <cassert>
 #include <cmath>
+#include <cstdarg>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -158,7 +158,10 @@ size_t getRemoteFileSize(const std::string &url, std::atomic<bool> *abort) {
   int still_running = 1;
   while (still_running > 0 && !(abort && *abort)) {
     CURLMcode mc = curl_multi_perform(cm, &still_running);
-    if (!mc) curl_multi_wait(cm, nullptr, 0, 1000, nullptr);
+    if (mc != CURLM_OK) break;
+    if (still_running > 0) {
+      curl_multi_wait(cm, nullptr, 0, 1000, nullptr);
+    }
   }
 
   double content_length = -1;
@@ -208,10 +211,20 @@ bool httpDownload(const std::string &url, T &buf, size_t chunk_size, size_t cont
   }
 
   int still_running = 1;
+  size_t prev_written = 0;
   while (still_running > 0 && !(abort && *abort)) {
-    curl_multi_wait(cm, nullptr, 0, 1000, nullptr);
-    curl_multi_perform(cm, &still_running);
-    download_stats.update(url, written);
+    CURLMcode mc = curl_multi_perform(cm, &still_running);
+    if (mc != CURLM_OK) {
+      break;
+    }
+    if (still_running > 0) {
+      curl_multi_wait(cm, nullptr, 0, 1000, nullptr);
+    }
+
+    if (((written - prev_written) / (double)content_length) >= 0.01) {
+      download_stats.update(url, written);
+      prev_written = written;
+    }
   }
 
   CURLMsg *msg;
@@ -304,9 +317,11 @@ std::string decompressBZ2(const std::byte *in, size_t in_size, std::atomic<bool>
   return {};
 }
 
-void precise_nano_sleep(long sleep_ns) {
-  struct timespec req = {.tv_sec = 0, .tv_nsec = sleep_ns};
-  struct timespec rem = {};
+void precise_nano_sleep(int64_t nanoseconds) {
+  struct timespec req, rem;
+
+  req.tv_sec = nanoseconds / 1e9;
+  req.tv_nsec = nanoseconds % (int64_t)1e9;
   while (clock_nanosleep(CLOCK_MONOTONIC, 0, &req, &rem) && errno == EINTR) {
     // Retry sleep if interrupted by a signal
     req = rem;

--- a/tools/replay/util.h
+++ b/tools/replay/util.h
@@ -21,7 +21,7 @@ void logMessage(ReplyMsgType type, const char* fmt, ...);
 #define rError(fmt, ...) ::logMessage(ReplyMsgType::Critical , fmt,  ## __VA_ARGS__)
 
 std::string sha256(const std::string &str);
-void precise_nano_sleep(long sleep_ns);
+void precise_nano_sleep(int64_t nanoseconds);
 std::string decompressBZ2(const std::string &in, std::atomic<bool> *abort = nullptr);
 std::string decompressBZ2(const std::byte *in, size_t in_size, std::atomic<bool> *abort = nullptr);
 std::string getUrlWithoutQuery(const std::string &url);


### PR DESCRIPTION
Fixed bugs:
1. Fixed a bug in **pause()**: when in the paused state and **mergeSegments()** is blocking the stream thread while loading a segment, the stream thread would be incorrectly awakened  and resume execution bye **pause(false)**."
2. Resolve https://github.com/commaai/openpilot/issues/31546 . simplify the code for testing **seekTo()**, fixed random failures.
3. Fix the issue in **publishFrame** where missing camera files would cause a crash when publishing multiple cameras.
4. Fixed the issue where if **Replay** is destructed outside the event loop of QApplication, the **stream_thread_** cannot be delete by **deleteLater()**.
5. Fixed the issue where **mergeSegments** would still continue merging segments even when **segments_to_merge** and **merged_segments_** were the same. this fix can greatly improve the performance of seeking.
6. Fixed signal **segmentsMerged** emitted twice on startup
7. use map::at() instead of map[] to provides bounds checking and avoid accidentally adding keys to **segments_**.
8. set **events_ready_** to false  if no events can be published, to prevent excessive console messages of 'Waiting for events...'
9. If all segments fail to load, set **events_ready_** to false to avoid crashing

Improvements:
1. improve **queueSegment()**: After loading the current segment and those following it, proceed to load segments preceding the current one in reverse order. 
![2024-04-13_22-15](https://github.com/commaai/openpilot/assets/27770/22650b29-9c49-46ca-b6fd-7e6af1618e90)
 Before this PR, replay can only load the current and subsequent segments. It will not load segments before the current segment. for example, if seeking to the 6th segment, replay will load segments 6, 7, 8, and so on, but segments before 6 will not be loaded.
2. If download fails, retry after 3 seconds
3. improve error handling for **curl_multi_perform**, Reduce unnecessary sleep calls.
4. Check if progress threshold is reached and update stats to save CPU usage while downloading.
5. Improve the accuracy of  cur_mono_time_
6. rename some variables & functions for clarity.
7. Interrupt **clock_nanosleep** during exit, seek, load segment.
8. breaking down big functions.
9. remove std::pmr::monotonic_buffer_resource
10. cleanup code.


