### PR TITLE
[bot] Fingerprints: add missing FW versions from CAN fingerprinting cars

### DIFF
--- a/selfdrive/car/ford/fingerprints.py
+++ b/selfdrive/car/ford/fingerprints.py
@@ -161,5 +161,5 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x706, None): [
       b'PJ6T-14H102-ABJ\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
-  }
+  },
 }

--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -82,12 +82,15 @@ FW_VERSIONS = {
   CAR.HYUNDAI_IONIQ: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2000         ',
+      b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2301 4AEHC107',
+      b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2501 4AEHC107',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00AEH MFC  AT EUR LHD 1.00 1.00 95740-G2400 180222',
+      b'\xf1\x00AEH MFC  AT USA LHD 1.00 1.00 95740-G2400 180222',
     ],
   },
   CAR.HYUNDAI_IONIQ_PHEV_2019: {
@@ -600,6 +603,7 @@ FW_VERSIONS = {
   CAR.HYUNDAI_KONA_EV: {
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00OS IEB \x01 212 \x11\x13 58520-K4000',
+      b'\xf1\x00OS IEB \x02 210 \x02\x14 58520-K4000',
       b'\xf1\x00OS IEB \x02 212 \x11\x13 58520-K4000',
       b'\xf1\x00OS IEB \x03 210 \x02\x14 58520-K4000',
       b'\xf1\x00OS IEB \x03 212 \x11\x13 58520-K4000',
@@ -610,6 +614,7 @@ FW_VERSIONS = {
       b'\xf1\x00OSE LKAS AT EUR LHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT EUR RHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT KOR LHD 1.00 1.00 95740-K4100 W40',
+      b'\xf1\x00OSE LKAS AT USA LHD 1.00 1.00 95740-K4100 W40',
       b'\xf1\x00OSE LKAS AT USA LHD 1.00 1.00 95740-K4300 W50',
     ],
     (Ecu.eps, 0x7d4, None): [
@@ -908,14 +913,17 @@ FW_VERSIONS = {
   },
   CAR.KIA_SORENTO: {
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00UMP LKAS AT KOR LHD 1.00 1.00 95740-C5550 S30',
       b'\xf1\x00UMP LKAS AT USA LHD 1.00 1.00 95740-C6550 d00',
       b'\xf1\x00UMP LKAS AT USA LHD 1.01 1.01 95740-C6550 d01',
     ],
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00UM ESC \x02 12 \x18\x05\x05 58910-C6300',
       b'\xf1\x00UM ESC \x0c 12 \x18\x05\x06 58910-C6330',
+      b'\xf1\x00UM ESC \x13 12 \x17\x07\x05 58910-C5320',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00UM__ SCC F-CUP      1.00 1.00 96400-C5500         ',
       b'\xf1\x00UM__ SCC F-CUP      1.00 1.00 96400-C6500         ',
     ],
   },


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 4 dongles (3 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                      | Name from VIN 🆚 CarDocs                                               | Segments                                     | Bad seg tags                                                                                         | Good seg tags                                                                           |
|:---------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
| [1d123e7a239cca62](https://useradmin.comma.ai/?onebox=1d123e7a239cca62)<br><sub>HYUNDAI_KONA_EV<br>000000000........</sub> | None 🆚<br>None                                                        | 79 routes,<br>1945 segments<br>(32.4 hours)  |                                                                                                      | - valid torque params: 1945<br>- all lat active: 333<br>- no input all lat active: 205  |
| [95040c267966a52c](https://useradmin.comma.ai/?onebox=95040c267966a52c)<br><sub>HYUNDAI_IONIQ<br>KMHC85LC5........</sub>   | HYUNDAI Ioniq Hybrid Hatchback 2019 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 94 routes,<br>2487 segments<br>(41.5 hours)  | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=95040c267966a52c)                | - valid torque params: 2478<br>- all lat active: 1170<br>- no input all lat active: 811 |
| [6b111e8e45cc2d07](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07)<br><sub>KIA_SORENTO<br>KNAPH81BD........</sub>     | KIA  1988 🆚<br>Kia Sorento 2019                                       | 71 routes,<br>2969 segments<br>(49.5 hours)  | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=6b111e8e45cc2d07%7C2024-03-30--21-05-04) | - valid torque params: 2623<br>- all lat active: 464<br>- no input all lat active: 156  |
| [c9508b688d2009f6](https://useradmin.comma.ai/?onebox=c9508b688d2009f6)<br><sub>HYUNDAI_KONA_EV<br>000000000........</sub> | None 🆚<br>None                                                        | 110 routes,<br>2591 segments<br>(43.2 hours) |                                                                                                      | - valid torque params: 2380<br>- all lat active: 299<br>- no input all lat active: 276  |

Dongles to re-run category: `c9508b688d2009f6 6b111e8e45cc2d07 1d123e7a239cca62 95040c267966a52c`
</details>

## ⏳️ 5 dongles (2 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                    | Name from VIN 🆚 CarDocs                                               | Segments                                  | Bad seg tags                                                                          | Good seg tags                                                                       |
|:-------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|:------------------------------------------|:--------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
| [61cb482c0e565685](https://useradmin.comma.ai/?onebox=61cb482c0e565685)<br><sub>HYUNDAI_IONIQ<br>KMHC85LC4........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2019 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 28 routes,<br>476 segments<br>(7.9 hours) | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=61cb482c0e565685) | - valid torque params: 476<br>- all lat active: 53<br>- no input all lat active: 38 |
| [228af270c1879d5a](https://useradmin.comma.ai/?onebox=228af270c1879d5a)<br><sub>HYUNDAI_IONIQ<br>KMHC75LC7........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 9 routes,<br>182 segments<br>(3.0 hours)  | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=228af270c1879d5a) | - valid torque params: 166<br>- all lat active: 44<br>- no input all lat active: 33 |
| [cd30864211945e4e](https://useradmin.comma.ai/?onebox=cd30864211945e4e)<br><sub>HYUNDAI_IONIQ<br>KMHC75LC2........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 5 routes,<br>25 segments<br>(0.4 hours)   | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=cd30864211945e4e) | - all lat active: 0                                                                 |
| [bfda978d009a7a95](https://useradmin.comma.ai/?onebox=bfda978d009a7a95)<br><sub>KIA_SORENTO<br>5XYPKDA55........</sub>   | KIA Sorento 2019 🆚<br>Kia Sorento 2019                                | 8 routes,<br>82 segments<br>(1.4 hours)   |                                                                                       | - valid torque params: 62<br>- all lat active: 14<br>- no input all lat active: 8   |
| [cb04dcf47b20037d](https://useradmin.comma.ai/?onebox=cb04dcf47b20037d)<br><sub>HYUNDAI_IONIQ<br>KMHC75LCX........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2017 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 2 routes,<br>24 segments<br>(0.4 hours)   | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=cb04dcf47b20037d) | - valid torque params: 10<br>- all lat active: 2                                    |

Dongles to re-run category: `cb04dcf47b20037d 228af270c1879d5a cd30864211945e4e 61cb482c0e565685 bfda978d009a7a95`
</details>

## ⚠️ 4 dongles (4 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                            | Name from VIN 🆚 CarDocs                                | Segments                                     | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Good seg tags                                                                          |
|:---------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:---------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [8d663db5b69a9cda](https://useradmin.comma.ai/?onebox=8d663db5b69a9cda)<br><sub>HYUNDAI_PALISADE<br>000000000........</sub>      | None 🆚<br>None                                         | 17 routes,<br>194 segments<br>(3.2 hours)    | - [missing ECU FW: 194](https://useradmin.comma.ai/?onebox=8d663db5b69a9cda%7C2024-03-28--14-13-37)<br>- [car faulted: 168](https://useradmin.comma.ai/?onebox=8d663db5b69a9cda%7C2024-03-28--14-13-37)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=8d663db5b69a9cda%7C2024-03-28--14-13-37)                                                                                                                                                                                                         |                                                                                        |
| [395c77946e384c2f](https://useradmin.comma.ai/?onebox=395c77946e384c2f)<br><sub>KIA_NIRO_EV<br>000000000........</sub>           | None 🆚<br>None                                         | 16 routes,<br>271 segments<br>(4.5 hours)    | - [missing ECU FW: 13](https://useradmin.comma.ai/?onebox=395c77946e384c2f%7C2024-04-05--19-15-39)<br>- [spotty FW: 13](https://useradmin.comma.ai/?onebox=395c77946e384c2f%7C2024-04-05--19-15-39)                                                                                                                                                                                                                                                                                                                      | - all lat active: 100<br>- no input all lat active: 48<br>- valid torque params: 122   |
| [1613602610c3e789](https://useradmin.comma.ai/?onebox=1613602610c3e789)<br><sub>HYUNDAI_IONIQ_EV_2020<br>000000000........</sub> | None 🆚<br>None                                         | 139 routes,<br>2996 segments<br>(49.9 hours) | - [missing ECU FW: 807](https://useradmin.comma.ai/?onebox=1613602610c3e789%7C2024-04-01--15-38-24)<br>- [spotty FW: 807](https://useradmin.comma.ai/?onebox=1613602610c3e789%7C2024-04-01--15-38-24)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 2996<br>- all lat active: 928<br>- no input all lat active: 685 |
| [0e13ee2b821302f4](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br><sub>HYUNDAI_IONIQ<br>KNDCE3LC1........</sub>         | KIA Niro Hybrid 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 127 routes,<br>2095 segments<br>(34.9 hours) | - [high lateral accel factor: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-03-28--17-45-38)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-03-27--11-57-59)<br>- [brand fuzzy match disagrees: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-03-27--11-57-59)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4) | - valid torque params: 1941<br>- all lat active: 530<br>- no input all lat active: 357 |

Dongles to re-run category: `0e13ee2b821302f4 1613602610c3e789 395c77946e384c2f 8d663db5b69a9cda`
</details>