### PR TITLE
build casync releases from tags off of master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,11 +197,11 @@ node {
 
   try {
     if (env.BRANCH_NAME == 'devel-staging') {
-      build_release("release3-staging")
+      build_git_release("release3-staging")
     }
 
     if (env.BRANCH_NAME == 'master-ci') {
-      build_release("nightly")
+      build_git_release("nightly")
     }
 
     if (env.BRANCH_NAME.startsWith('channel/')) {


### PR DESCRIPTION
rather than basing releases off of master-ci, we can base them off tags which are tagged directly on master

`channel/nightly` tag: https://github.com/commaai/openpilot/releases/tag/channel%2Fnightly

so we would have tags for

`channel/nightly`
`channel/release`

example build:
https://jenkins.comma.life/blue/organizations/jenkins/openpilot/detail/channel%2Fnightly/2/pipeline/14