### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -407,6 +407,7 @@ FW_VERSIONS = {
       b'\xf1\x00LX2_ SCC F-CUP      1.00 1.05 99110-S8100         ',
       b'\xf1\x00LX2_ SCC FHCU-      1.00 1.05 99110-S8100         ',
       b'\xf1\x00LX2_ SCC FHCUP      1.00 1.00 99110-S8110         ',
+      b'\xf1\x00LX2_ SCC FHCUP      1.00 1.03 99110-S8100         ',
       b'\xf1\x00LX2_ SCC FHCUP      1.00 1.04 99110-S8100         ',
       b'\xf1\x00LX2_ SCC FHCUP      1.00 1.05 99110-S8100         ',
       b'\xf1\x00ON__ FCA FHCUP      1.00 1.01 99110-S9110         ',
@@ -418,6 +419,7 @@ FW_VERSIONS = {
       b'\xf1\x00LX ESC \x01 1031\t\x10 58910-S8360',
       b'\xf1\x00LX ESC \x01 104 \x10\x16 58910-S8360',
       b'\xf1\x00LX ESC \x0b 101\x19\x03\x17 58910-S8330',
+      b'\xf1\x00LX ESC \x0b 101\x19\x03  58910-S8360',
       b'\xf1\x00LX ESC \x0b 102\x19\x05\x07 58910-S8330',
       b'\xf1\x00LX ESC \x0b 103\x19\t\x07 58910-S8330',
       b'\xf1\x00LX ESC \x0b 103\x19\t\t 58910-S8350',
@@ -432,6 +434,7 @@ FW_VERSIONS = {
       b'\xf1\x00LX2 MDPS C 1,00 1,03 56310-S8020 4LXDC103',
       b'\xf1\x00LX2 MDPS C 1.00 1.03 56310-S8000 4LXDC103',
       b'\xf1\x00LX2 MDPS C 1.00 1.03 56310-S8020 4LXDC103',
+      b'\xf1\x00LX2 MDPS C 1.00 1.03 56310-XX000 4LXDC103',
       b'\xf1\x00LX2 MDPS C 1.00 1.04 56310-S8020 4LXDC104',
       b'\xf1\x00LX2 MDPS R 1.00 1.02 56370-S8300 9318',
       b'\xf1\x00ON  MDPS C 1.00 1.00 56340-S9000 8B13',
@@ -584,6 +587,7 @@ FW_VERSIONS = {
     ],
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00DL ESC \x01 104 \x07\x12 58910-L2200',
+      b'\xf1\x00DL ESC \x03 100 \x08\x02 58910-L3600',
       b'\xf1\x00DL ESC \x06 101 \x04\x02 58910-L3200',
       b'\xf1\x00DL ESC \x06 103"\x08\x06 58910-L3200',
       b'\xf1\x00DL ESC \t 100 \x06\x02 58910-L3800',
@@ -850,6 +854,7 @@ FW_VERSIONS = {
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00CN7 MDPS C 1.00 1.06 56310/AA070 4CNDC106',
       b'\xf1\x00CN7 MDPS C 1.00 1.06 56310AA050\x00 4CNDC106',
+      b'\xf1\x00CN7 MDPS C 1.00 1.07 56310AA050\x00 4CNDC107',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00CN7 MFC  AT USA LHD 1.00 1.00 99210-AB000 200819',
@@ -857,6 +862,7 @@ FW_VERSIONS = {
       b'\xf1\x00CN7 MFC  AT USA LHD 1.00 1.03 99210-AA000 200819',
       b'\xf1\x00CN7 MFC  AT USA LHD 1.00 1.03 99210-AB000 220426',
       b'\xf1\x00CN7 MFC  AT USA LHD 1.00 1.06 99210-AA000 220111',
+      b'\xf1\x00CN7 MFC  AT USA LHD 1.00 1.08 99210-AA000 220728',
     ],
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00CN ESC \t 101 \x10\x03 58910-AB800',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 5 dongles (3 platforms) in last 7.0 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                           | Name from VIN 🆚 CarDocs                             | Segments                                  | Bad seg tags                                                                                         | Good seg tags                                                                         |
|:--------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------|:------------------------------------------|:-----------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------|
| [2b083a4ff77c6828](https://useradmin.comma.ai/?onebox=2b083a4ff77c6828)<br><sub>KIA_K5_2021<br>5XXG44J83........</sub>          | KIA K5 2023 🆚<br>Kia K5 2021-24                     | 13 routes,<br>320 segments<br>(5.3 hours) |                                                                                                      | - all lat active: 174<br>- valid torque params: 320<br>- no input all lat active: 150 |
| [325d76d16fb6cb36](https://useradmin.comma.ai/?onebox=325d76d16fb6cb36)<br><sub>HYUNDAI_PALISADE<br>KM8R24HE8........</sub>     | HYUNDAI Palisade 2020 🆚<br>Hyundai Palisade 2020-22 | 21 routes,<br>347 segments<br>(5.8 hours) |                                                                                                      | - valid torque params: 347<br>- all lat active: 112<br>- no input all lat active: 89  |
| [350d89a7bad7f485](https://useradmin.comma.ai/?onebox=350d89a7bad7f485)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AG6........</sub> | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23   | 18 routes,<br>318 segments<br>(5.3 hours) |                                                                                                      | - valid torque params: 318<br>- all lat active: 78<br>- no input all lat active: 65   |
| [ab43edcde8ddb9db](https://useradmin.comma.ai/?onebox=ab43edcde8ddb9db)<br><sub>HYUNDAI_PALISADE<br>KM8R4DHE7........</sub>     | HYUNDAI Palisade 2020 🆚<br>Hyundai Palisade 2020-22 | 19 routes,<br>492 segments<br>(8.2 hours) | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=ab43edcde8ddb9db%7C2024-04-11--17-47-42) | - valid torque params: 492<br>- all lat active: 291<br>- no input all lat active: 209 |
| [b0e1cdf87262c7ad](https://useradmin.comma.ai/?onebox=b0e1cdf87262c7ad)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AG2........</sub> | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23   | 5 routes,<br>245 segments<br>(4.1 hours)  |                                                                                                      | - valid torque params: 245<br>- all lat active: 109<br>- no input all lat active: 82  |

Dongles to re-run category: `2b083a4ff77c6828 350d89a7bad7f485 b0e1cdf87262c7ad ab43edcde8ddb9db 325d76d16fb6cb36`
</details>

## ⏳️ 12 dongles (7 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                           | Segments                                  | Bad seg tags                                                                                         | Good seg tags                                                                       |
|:--------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|:------------------------------------------|:-----------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
| [3044cbf1071171ba](https://useradmin.comma.ai/?onebox=3044cbf1071171ba)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                          | 3 routes,<br>19 segments<br>(0.3 hours)   |                                                                                                      | - all lat active: 3                                                                 |
| [bade6cd7ae9bb600](https://useradmin.comma.ai/?onebox=bade6cd7ae9bb600)<br><sub>HYUNDAI_PALISADE<br>KM8R7DHE5........</sub>           | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                               | 29 routes,<br>378 segments<br>(6.3 hours) |                                                                                                      | - valid torque params: 378<br>- all lat active: 22<br>- no input all lat active: 12 |
| [d075d065f1c27b98](https://useradmin.comma.ai/?onebox=d075d065f1c27b98)<br><sub>KIA_EV6<br>KNAC381CP........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                                      | 1 routes,<br>10 segments<br>(0.2 hours)   |                                                                                                      | - valid torque params: 3<br>- all lat active: 0                                     |
| [baf9c744e8d3aedc](https://useradmin.comma.ai/?onebox=baf9c744e8d3aedc)<br><sub>HYUNDAI_PALISADE<br>KM8R14HE2........</sub>           | HYUNDAI Palisade 2021 🆚<br>Hyundai Palisade 2020-22                               | 4 routes,<br>73 segments<br>(1.2 hours)   |                                                                                                      | - valid torque params: 73<br>- all lat active: 5<br>- no input all lat active: 4    |
| [d61540bf6f3ff5fd](https://useradmin.comma.ai/?onebox=d61540bf6f3ff5fd)<br><sub>HYUNDAI_SANTA_FE_PHEV_2022<br>KM8S6DA20........</sub> | HYUNDAI Santa Fe Plug-in Hybrid 2022 🆚<br>Hyundai Santa Fe Plug-in Hybrid 2022-23 | 12 routes,<br>165 segments<br>(2.8 hours) |                                                                                                      | - valid torque params: 165<br>- all lat active: 18<br>- no input all lat active: 3  |
| [2d2ed4682dfe5a78](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)<br><sub>KIA_EV6<br>KNDC3DLC3........</sub>                    | KIA EV6 2023 🆚<br>Kia EV6 (with HDA II) 2022-23                                   | 1 routes,<br>2 segments<br>(0.0 hours)    | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)                | - all lat active: 0                                                                 |
| [b9ed9a8b2b604ddf](https://useradmin.comma.ai/?onebox=b9ed9a8b2b604ddf)<br><sub>KIA_OPTIMA_G4<br>5XXGW4L23........</sub>              | KIA Optima 2017 🆚<br>Kia Optima 2017                                              | 2 routes,<br>12 segments<br>(0.2 hours)   |                                                                                                      | - all lat active: 0                                                                 |
| [5928b56aca881917](https://useradmin.comma.ai/?onebox=5928b56aca881917)<br><sub>HYUNDAI_SANTA_FE_2022<br>RLUSW81KD........</sub>      | None 🆚<br>None                                                                    | 10 routes,<br>69 segments<br>(1.1 hours)  | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=5928b56aca881917%7C2024-04-15--10-37-20) | - all lat active: 3                                                                 |
| [9acd533a0f402e80](https://useradmin.comma.ai/?onebox=9acd533a0f402e80)<br><sub>HYUNDAI_ELANTRA_2021<br>5NPLS4AG8........</sub>       | HYUNDAI Elantra 2022 🆚<br>Hyundai Elantra 2021-23                                 | 22 routes,<br>362 segments<br>(6.0 hours) |                                                                                                      | - valid torque params: 362<br>- all lat active: 0                                   |
| [b848ccad8ec7b386](https://useradmin.comma.ai/?onebox=b848ccad8ec7b386)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS14AJ2........</sub>      | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                               | 41 routes,<br>440 segments<br>(7.3 hours) |                                                                                                      | - valid torque params: 440<br>- all lat active: 42<br>- no input all lat active: 25 |
| [028e246a2b8e3144](https://useradmin.comma.ai/?onebox=028e246a2b8e3144)<br><sub>HYUNDAI_PALISADE<br>KM8R5DHEX........</sub>           | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                               | 13 routes,<br>186 segments<br>(3.1 hours) |                                                                                                      | - valid torque params: 186<br>- all lat active: 9<br>- no input all lat active: 9   |
| [672d4090a6b92b0b](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81BF........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                          | 2 routes,<br>27 segments<br>(0.5 hours)   |                                                                                                      | - all lat active: 1<br>- no input all lat active: 1                                 |

Dongles to re-run category: `3044cbf1071171ba baf9c744e8d3aedc d61540bf6f3ff5fd b848ccad8ec7b386 028e246a2b8e3144 2d2ed4682dfe5a78 b9ed9a8b2b604ddf 672d4090a6b92b0b bade6cd7ae9bb600 5928b56aca881917 d075d065f1c27b98 9acd533a0f402e80`
</details>

## ⚠️ 2 dongles (2 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                           | Name from VIN 🆚 CarDocs                           | Segments                                  | Bad seg tags                                                                                                                                                                                               | Good seg tags                                                                      |
|:--------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|:------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|
| [ef8c34c763849757](https://useradmin.comma.ai/?onebox=ef8c34c763849757)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLL4AG6........</sub> | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23 | 8 routes,<br>8 segments<br>(0.1 hours)    | - [missing ECU FW: 8](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-11--13-42-08)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-11--13-42-08) |                                                                                    |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>      | None 🆚<br>None                                    | 28 routes,<br>388 segments<br>(6.5 hours) | - [CAN invalid: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)           | - valid torque params: 387<br>- all lat active: 16<br>- no input all lat active: 8 |

Dongles to re-run category: `22901377be496047 ef8c34c763849757`
</details>