### PR TITLE
casync build: remove channel from build metadata json

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,11 +197,11 @@ node {
 
   try {
     if (env.BRANCH_NAME == 'devel-staging') {
-      build_release("release3-staging")
+      build_git_release("release3-staging")
     }
 
     if (env.BRANCH_NAME == 'master-ci') {
-      build_release("nightly")
+      build_git_release("nightly")
     }
 
     if (env.BRANCH_NAME == 'no-channel') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,21 +145,27 @@ def setupCredentials() {
 }
 
 
-def build_release(String channel_name) {
+def build_git_release(String channel_name) {
   return parallel (
     "${channel_name} (git)": {
       deviceStage("build git", "tici-needs-can", [], [
         ["build ${channel_name}", "RELEASE_BRANCH=${channel_name} $SOURCE_DIR/release/build_release.sh"],
       ])
-    },
-    "${channel_name} (casync)": {
+    }
+  )
+}
+
+
+def build_release() {
+  return parallel (
+    "build openpilot": {
       deviceStage("build casync", "tici-needs-can", [], [
-        ["build ${channel_name}", "RELEASE=1 OPENPILOT_CHANNEL=${channel_name} BUILD_DIR=/data/openpilot CASYNC_DIR=/data/casync/openpilot $SOURCE_DIR/release/create_casync_build.sh"],
+        ["build", "RELEASE=1 BUILD_DIR=/data/openpilot CASYNC_DIR=/data/casync/openpilot $SOURCE_DIR/release/create_casync_build.sh"],
         ["create manifest", "$SOURCE_DIR/release/create_release_manifest.py /data/openpilot /data/manifest.json && cat /data/manifest.json"],
-        ["upload and cleanup ${channel_name}", "PYTHONWARNINGS=ignore $SOURCE_DIR/release/upload_casync_release.py /data/casync && rm -rf /data/casync"],
+        ["upload and cleanup", "PYTHONWARNINGS=ignore $SOURCE_DIR/release/upload_casync_release.py /data/casync && rm -rf /data/casync"],
       ])
     },
-    "publish agnos": {
+    "build agnos": {
       pcStage("publish agnos") {
         sh "release/create_casync_agnos_release.py /tmp/casync/agnos /tmp/casync_tmp"
         sh "PYTHONWARNINGS=ignore ${env.WORKSPACE}/release/upload_casync_release.py /tmp/casync"
@@ -196,6 +202,10 @@ node {
 
     if (env.BRANCH_NAME == 'master-ci') {
       build_release("nightly")
+    }
+
+    if (env.BRANCH_NAME == 'no-channel') {
+      build_release()
     }
 
     if (!env.BRANCH_NAME.matches(excludeRegex)) {

--- a/release/README.md
+++ b/release/README.md
@@ -32,7 +32,6 @@
 # of a tarball containing the full prebuilt openpilot release
 BUILD_DIR=/data/openpilot_build    \
 CASYNC_DIR=/data/casync            \
-OPENPILOT_CHANNEL=nightly          \
 release/create_casync_build.sh
 ```
 

--- a/release/create_casync_build.sh
+++ b/release/create_casync_build.sh
@@ -20,4 +20,4 @@ release/copy_build_files.sh $SOURCE_DIR $BUILD_DIR
 release/create_prebuilt.sh $BUILD_DIR
 
 cd $SOURCE_DIR
-release/create_casync_release.py $BUILD_DIR $CASYNC_DIR $OPENPILOT_CHANNEL
+release/create_casync_release.py $BUILD_DIR $CASYNC_DIR

--- a/release/create_casync_release.py
+++ b/release/create_casync_release.py
@@ -12,7 +12,6 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="creates a casync release")
   parser.add_argument("target_dir", type=str, help="target directory to build channel from")
   parser.add_argument("output_dir", type=str, help="output directory for the channel")
-  parser.add_argument("channel", type=str, help="what channel this build is")
   args = parser.parse_args()
 
   target_dir = pathlib.Path(args.target_dir)
@@ -21,7 +20,7 @@ if __name__ == "__main__":
   build_metadata = get_build_metadata()
   build_metadata.openpilot.build_style = "release" if os.environ.get("RELEASE", None) is not None else "debug"
 
-  create_build_metadata_file(target_dir, build_metadata, args.channel)
+  create_build_metadata_file(target_dir, build_metadata)
 
   digest, caibx = create_casync_release(target_dir, output_dir, build_metadata.canonical)
 

--- a/release/create_release_manifest.py
+++ b/release/create_release_manifest.py
@@ -6,18 +6,16 @@ import os
 import pathlib
 
 from openpilot.system.hardware.tici.agnos import AGNOS_MANIFEST_FILE, get_partition_path
-from openpilot.system.version import get_build_metadata, get_agnos_version
+from openpilot.system.version import get_build_metadata
 
 
 BASE_URL = "https://commadist.blob.core.windows.net"
-
-CHANNEL_DATA = pathlib.Path(__file__).parent / "channel_data" / "agnos"
 
 OPENPILOT_RELEASES = f"{BASE_URL}/openpilot-releases/openpilot"
 AGNOS_RELEASES = f"{BASE_URL}/openpilot-releases/agnos"
 
 
-def create_partition_manifest(agnos_version, partition):
+def create_partition_manifest(partition):
   agnos_filename = os.path.basename(partition["url"]).split(".")[0]
 
   return {
@@ -57,7 +55,7 @@ if __name__ == "__main__":
   ret = {
     "build_metadata": dataclasses.asdict(build_metadata),
     "manifest": [
-      *[create_partition_manifest(get_agnos_version(args.target_dir), entry) for entry in agnos_manifest],
+      *[create_partition_manifest(entry) for entry in agnos_manifest],
       create_openpilot_manifest(build_metadata)
     ]
   }

--- a/system/updated/casync/common.py
+++ b/system/updated/casync/common.py
@@ -33,6 +33,7 @@ def create_build_metadata_file(path: pathlib.Path, build_metadata: BuildMetadata
   with open(path / BUILD_METADATA_FILENAME, "w") as f:
     build_metadata_dict = dataclasses.asdict(build_metadata)
     build_metadata_dict["openpilot"].pop("is_dirty")  # this is determined at runtime
+    build_metadata_dict.pop("channel")                # channel is unrelated to the build itself
     f.write(json.dumps(build_metadata_dict))
 
 

--- a/system/updated/casync/common.py
+++ b/system/updated/casync/common.py
@@ -29,10 +29,9 @@ def get_exclude_set(path) -> set[str]:
   return exclude_set
 
 
-def create_build_metadata_file(path: pathlib.Path, build_metadata: BuildMetadata, channel: str):
+def create_build_metadata_file(path: pathlib.Path, build_metadata: BuildMetadata):
   with open(path / BUILD_METADATA_FILENAME, "w") as f:
     build_metadata_dict = dataclasses.asdict(build_metadata)
-    build_metadata_dict["channel"] = channel
     build_metadata_dict["openpilot"].pop("is_dirty")  # this is determined at runtime
     f.write(json.dumps(build_metadata_dict))
 

--- a/system/version.py
+++ b/system/version.py
@@ -137,7 +137,6 @@ def get_build_metadata(path: str = BASEDIR) -> BuildMetadata:
 
   if build_metadata_path.exists():
     build_metadata = json.loads(build_metadata_path.read_text())
-    build_metadata["channel"] = Params().get("UpdaterTargetChannel", "unknown")
     return build_metadata_from_dict(build_metadata)
 
   git_folder = pathlib.Path(path) / ".git"

--- a/system/version.py
+++ b/system/version.py
@@ -10,7 +10,6 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.utils import cache
 from openpilot.common.git import get_commit, get_origin, get_branch, get_short_branch, get_commit_date
-from openpilot.common.run import run_cmd
 
 RELEASE_BRANCHES = ['release3-staging', 'release3', 'nightly']
 TESTED_BRANCHES = RELEASE_BRANCHES + ['devel', 'devel-staging']
@@ -138,6 +137,7 @@ def get_build_metadata(path: str = BASEDIR) -> BuildMetadata:
 
   if build_metadata_path.exists():
     build_metadata = json.loads(build_metadata_path.read_text())
+    build_metadata["channel"] = Params().get("UpdaterTargetChannel", "unknown")
     return build_metadata_from_dict(build_metadata)
 
   git_folder = pathlib.Path(path) / ".git"
@@ -155,11 +155,6 @@ def get_build_metadata(path: str = BASEDIR) -> BuildMetadata:
 
   cloudlog.exception("unable to get build metadata")
   raise Exception("invalid build metadata")
-
-
-def get_agnos_version(directory: str = BASEDIR) -> str:
-  return run_cmd(["bash", "-c", r"unset AGNOS_VERSION && source launch_env.sh && \
-                          echo -n $AGNOS_VERSION"], cwd=directory).strip()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
we should be able to just store the channel as a param rather than within the `build.json`