### PR TITLE
navd: use `NavDestination` instead of `NavDestinationWaypoints`

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -160,7 +160,6 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"LiveTorqueParameters", PERSISTENT | DONT_LOG},
     {"LongitudinalPersonality", PERSISTENT},
     {"NavDestination", CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION},
-    {"NavDestinationWaypoints", CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION},
     {"NavPastDestinations", PERSISTENT},
     {"NavSettingLeftSide", PERSISTENT},
     {"NavSettingTime24h", PERSISTENT},

--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -136,8 +136,7 @@ class RouteEngine:
       'language': lang,
     }
 
-    # TODO: move waypoints into NavDestination param?
-    waypoints = self.params.get('NavDestinationWaypoints', encoding='utf8')
+    waypoints = self.params.get('NavDestination', encoding='utf8')
     waypoint_coords = []
     if waypoints is not None and len(waypoints) > 0:
       waypoint_coords = json.loads(waypoints)
@@ -193,7 +192,7 @@ class RouteEngine:
 
       # clear waypoints to avoid a re-route including past waypoints
       # TODO: only clear once we're past a waypoint
-      self.params.remove('NavDestinationWaypoints')
+      self.params.remove('NavDestination')
 
     except requests.exceptions.RequestException:
       cloudlog.exception("failed to get route")

--- a/selfdrive/navd/set_destination.py
+++ b/selfdrive/navd/set_destination.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
       "longitude": float(coords[1])
     }
     params.put("NavDestination", json.dumps(dest))
-    params.remove("NavDestinationWaypoints")
+    params.remove("NavDestination")
   else:
     print("Setting to Taco Bell")
     dest = {
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     waypoints = [
       (-117.16020713111648, 32.71997612490662),
     ]
-    params.put("NavDestinationWaypoints", json.dumps(waypoints))
+    params.put("NavDestination", json.dumps(waypoints))
 
     print(dest)
     print(waypoints)


### PR DESCRIPTION
saw that both are declared with a TODO left to use `NavDestination` instead; replacing `NavDestinationWaypoints` as they contain the same variables:

```cc
    {"NavDestination", CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION},
    {"NavDestinationWaypoints", CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION},
```
