### PR TITLE
FwQueryConfig: test non-essential ecus aren't needless

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -300,21 +300,9 @@ FW_QUERY_CONFIG = FwQueryConfig(
   # We lose these ECUs without the comma power on these cars.
   # Note that we still attempt to match with them when they are present
   non_essential_ecus={
-    Ecu.programmedFuelInjection: [CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CIVIC, CAR.HONDA_CIVIC_BOSCH, CAR.HONDA_CIVIC_2022, CAR.HONDA_CRV_5G,
-                                  CAR.HONDA_PILOT],
-    Ecu.transmission: [CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CIVIC, CAR.HONDA_CIVIC_BOSCH, CAR.HONDA_CIVIC_2022, CAR.HONDA_CRV_5G, CAR.HONDA_PILOT],
-    Ecu.srs: [CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CIVIC_2022, CAR.HONDA_E],
     Ecu.eps: [CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CIVIC_2022, CAR.HONDA_E],
     Ecu.vsa: [CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CIVIC, CAR.HONDA_CIVIC_BOSCH, CAR.HONDA_CIVIC_2022, CAR.HONDA_CRV_5G, CAR.HONDA_CRV_HYBRID,
               CAR.HONDA_E, CAR.HONDA_INSIGHT],
-    Ecu.gateway: [CAR.ACURA_ILX, CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CIVIC, CAR.HONDA_CIVIC_BOSCH, CAR.HONDA_CIVIC_2022, CAR.HONDA_FIT,
-                  CAR.HONDA_FREED, CAR.HONDA_HRV, CAR.HONDA_RIDGELINE, CAR.HONDA_CRV_5G, CAR.HONDA_CRV_HYBRID, CAR.HONDA_E, CAR.HONDA_INSIGHT,
-                  CAR.HONDA_ODYSSEY, CAR.HONDA_ODYSSEY_CHN, CAR.HONDA_PILOT],
-    Ecu.electricBrakeBooster: [CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CIVIC_BOSCH, CAR.HONDA_CRV_5G],
-    # existence correlates with transmission type for Accord ICE
-    Ecu.shiftByWire: [CAR.ACURA_RDX_3G, CAR.HONDA_ACCORD, CAR.HONDA_CRV_HYBRID, CAR.HONDA_E, CAR.HONDA_INSIGHT, CAR.HONDA_PILOT],
-    # existence correlates with trim level
-    Ecu.hud: [CAR.HONDA_ACCORD],
   },
   extra_ecus=[
     (Ecu.combinationMeter, 0x18da60f1, None),

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -9,7 +9,7 @@ from unittest import mock
 from cereal import car
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.car.fingerprints import FW_VERSIONS
-from openpilot.selfdrive.car.fw_versions import FW_QUERY_CONFIGS, FUZZY_EXCLUDE_ECUS, VERSIONS, build_fw_dict, \
+from openpilot.selfdrive.car.fw_versions import ESSENTIAL_ECUS, FW_QUERY_CONFIGS, FUZZY_EXCLUDE_ECUS, VERSIONS, build_fw_dict, \
                                                 match_fw_to_car, get_brand_ecu_matches, get_fw_versions, get_present_ecus
 from openpilot.selfdrive.car.vin import get_vin
 
@@ -145,6 +145,14 @@ class TestFwFingerprint(unittest.TestCase):
           if CP.carFingerprint.startswith("RAM HD"):
             for ecu in ecus.keys():
               self.assertNotEqual(ecu[0], Ecu.transmission, f"{car_model}: Blacklisted ecu: (Ecu.{ECU_NAME[ecu[0]]}, {hex(ecu[1])})")
+
+  def test_non_essential_ecus(self):
+    for brand, config in FW_QUERY_CONFIGS.items():
+      with self.subTest(brand):
+        # These ECUs are already not in ESSENTIAL_ECUS which the fingeprint functions give a pass if missing
+        unnecessary_non_essential_ecus = set(config.non_essential_ecus) - set(ESSENTIAL_ECUS)
+        self.assertEqual(unnecessary_non_essential_ecus, set(), "Declaring non-essential ECUs non-essential is not required: " +
+                                                                f"{', '.join([f'Ecu.{ECU_NAME[ecu]}' for ecu in unnecessary_non_essential_ecus])}")
 
   def test_missing_versions_and_configs(self):
     brand_versions = set(VERSIONS.keys())

--- a/selfdrive/car/tests/test_fw_fingerprint.py
+++ b/selfdrive/car/tests/test_fw_fingerprint.py
@@ -149,7 +149,7 @@ class TestFwFingerprint(unittest.TestCase):
   def test_non_essential_ecus(self):
     for brand, config in FW_QUERY_CONFIGS.items():
       with self.subTest(brand):
-        # These ECUs are already not in ESSENTIAL_ECUS which the fingeprint functions give a pass if missing
+        # These ECUs are already not in ESSENTIAL_ECUS which the fingerprint functions give a pass if missing
         unnecessary_non_essential_ecus = set(config.non_essential_ecus) - set(ESSENTIAL_ECUS)
         self.assertEqual(unnecessary_non_essential_ecus, set(), "Declaring non-essential ECUs non-essential is not required: " +
                                                                 f"{', '.join([f'Ecu.{ECU_NAME[ecu]}' for ecu in unnecessary_non_essential_ecus])}")


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/32231 to make it easier

let's go:

```python
======================================================================
FAIL: test_non_essential_ecus (__main__.TestFwFingerprint.test_non_essential_ecus) [honda]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/batman/openpilot/selfdrive/car/tests/../tests/test_fw_fingerprint.py", line 154, in test_non_essential_ecus
    self.assertEqual(unnecessary_non_essential_ecus, set(), "Declaring non-essential ECUs non-essential is not required: " +
AssertionError: Items in the first set but not the second:
16
8
9
10
11
14
15 : Declaring non-essential ECUs non-essential is not required: Ecu.transmission, Ecu.srs, Ecu.gateway, Ecu.hud, Ecu.programmedFuelInjection, Ecu.electricBrakeBooster, Ecu.shiftByWire
```