### PR TITLE
Platforms: less redundant string repr

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -266,6 +266,9 @@ class Platforms(str, ReprEnum, metaclass=PlatformsType):
     member._value_ = platform_config.platform_str
     return member
 
+  def __repr__(self):
+    return f"<{self.__class__.__name__}.{self.name}>"
+
   @classmethod
   def create_dbc_map(cls) -> dict[str, DbcDict]:
     return {p: p.config.dbc_dict for p in cls}


### PR DESCRIPTION
Only affects debugging use cases, `__str__` is still the value/name.

The current repr is far too verbose and redundant:

```
matches differ! {<CAR.HONDA_CIVIC_2022: 'HONDA_CIVIC_2022'>} set()
matches differ! {<CAR.TOYOTA_RAV4H: 'TOYOTA_RAV4H'>} set()
matches differ! {<CAR.HONDA_CIVIC_2022: 'HONDA_CIVIC_2022'>} set()
matches differ! {<CAR.HONDA_CIVIC_2022: 'HONDA_CIVIC_2022'>} set()
matches differ! {<CAR.HONDA_HRV_3G: 'HONDA_HRV_3G'>} set()
```

New:

```
matches differ! {<CAR.HONDA_CIVIC_2022>} set()
matches differ! {<CAR.TOYOTA_RAV4H>} set()
matches differ! {<CAR.HONDA_CIVIC_2022>} set()
matches differ! {<CAR.HONDA_CIVIC_2022>} set()
matches differ! {<CAR.HONDA_HRV_3G>} set()
```