### PR TITLE
replay/framereader: no longer cache all AVPacket instances in memory

### DIFF
--- a/tools/replay/framereader.h
+++ b/tools/replay/framereader.h
@@ -22,11 +22,9 @@ public:
   ~FrameReader();
   bool load(const std::string &url, bool no_hw_decoder = false, std::atomic<bool> *abort = nullptr, bool local_cache = false,
             int chunk_size = -1, int retries = 0);
-  bool load(const std::byte *data, size_t size, bool no_hw_decoder = false, std::atomic<bool> *abort = nullptr);
+  bool loadFromFile(const std::string &file, bool no_hw_decoder = false, std::atomic<bool> *abort = nullptr);
   bool get(int idx, VisionBuf *buf);
-  int getYUVSize() const { return width * height * 3 / 2; }
-  size_t getFrameCount() const { return packets.size(); }
-  bool valid() const { return valid_; }
+  size_t getFrameCount() const { return packets_info.size(); }
 
   int width = 0, height = 0;
 
@@ -36,16 +34,17 @@ private:
   AVFrame * decodeFrame(AVPacket *pkt);
   bool copyBuffers(AVFrame *f, VisionBuf *buf);
 
-  std::vector<AVPacket*> packets;
   std::unique_ptr<AVFrame, AVFrameDeleter>av_frame_, hw_frame;
   AVFormatContext *input_ctx = nullptr;
   AVCodecContext *decoder_ctx = nullptr;
-  int key_frames_count_ = 0;
-  bool valid_ = false;
-  AVIOContext *avio_ctx_ = nullptr;
 
   AVPixelFormat hw_pix_fmt = AV_PIX_FMT_NONE;
   AVBufferRef *hw_device_ctx = nullptr;
   int prev_idx = -1;
+  struct PacketInfo {
+    int flags;
+    int64_t pos;
+  };
+  std::vector<PacketInfo> packets_info;
   inline static std::atomic<bool> has_hw_decoder = true;
 };


### PR DESCRIPTION
Caching all `AVPacket` instances in memory can simplify the seeking to a specific frame, but it consumes significant memory resources, limits the scalability of the `FrameReader`. especially when caching a greater number of segments in `Replay` or `Cabana`. it can lead to increased memory usage, potentially causing performance issues or even system instability if memory resources are exhausted.  

This PR only stores the pkt_pos of each frame in memory. it uses `avio_seek` to seek to the frame's position, greatly reducing the memory footprint of `FrameReader`. It saves nearly 100MB of memory per segment for the road camera, with even greater savings when playing multiple cameras.

It will be slightly slower than caching all AVPacket in memory, but since we have implemented frame prefetching in the camera thread, the performance gap is negligible.

