### PR TITLE
debug FW query offline: annotate sendcan/can

### DIFF
--- a/selfdrive/debug/debug_fw_fingerprinting_offline.py
+++ b/selfdrive/debug/debug_fw_fingerprinting_offline.py
@@ -13,7 +13,7 @@ def main(route: str, addrs: list[int]):
   - print as fixed width table, easier to read
   """
 
-  lr = LogReader(route, default_mode=ReadMode.RLOG)
+  lr = LogReader(route, default_mode=ReadMode.RLOG, sort_by_time=True)
 
   start_mono_time = None
   prev_mono_time = 0
@@ -32,7 +32,7 @@ def main(route: str, addrs: list[int]):
           if msg.logMonoTime != prev_mono_time:
             print()
             prev_mono_time = msg.logMonoTime
-          print(f"{msg.logMonoTime} rxaddr={can.address}, bus={can.src}, {round((msg.logMonoTime - start_mono_time) * 1e-6, 2)} ms, " +
+          print(f"{msg.which():>7}: rxaddr={can.address}, bus={can.src}, {round((msg.logMonoTime - start_mono_time) * 1e-6, 2)} ms, " +
                 f"0x{can.dat.hex()}, {can.dat}, {len(can.dat)=}")
 
 


### PR DESCRIPTION
much easier to follow now

```
sendcan: rxaddr=1953, bus=0, 1310.64 ms, 0x031a880100000000, b'\x03\x1a\x88\x01\x00\x00\x00\x00', len(can.dat)=8

    can: rxaddr=1953, bus=128, 1320.62 ms, 0x031a880100000000, b'\x03\x1a\x88\x01\x00\x00\x00\x00', len(can.dat)=8
    can: rxaddr=1953, bus=2, 1320.62 ms, 0x031a880100000000, b'\x03\x1a\x88\x01\x00\x00\x00\x00', len(can.dat)=8

    can: rxaddr=1961, bus=2, 1389.3 ms, 0x10135a8801383936, b'\x10\x13Z\x88\x01896', len(can.dat)=8
    can: rxaddr=1961, bus=0, 1389.3 ms, 0x10135a8801383936, b'\x10\x13Z\x88\x01896', len(can.dat)=8

sendcan: rxaddr=1953, bus=0, 1391.9 ms, 0x30000a0000000000, b'0\x00\n\x00\x00\x00\x00\x00', len(can.dat)=8

    can: rxaddr=1953, bus=128, 1400.44 ms, 0x30000a0000000000, b'0\x00\n\x00\x00\x00\x00\x00', len(can.dat)=8
    can: rxaddr=1953, bus=2, 1400.44 ms, 0x30000a0000000000, b'0\x00\n\x00\x00\x00\x00\x00', len(can.dat)=8

    can: rxaddr=1961, bus=2, 1430.33 ms, 0x2135423333363330, b'!5B33630', len(can.dat)=8
    can: rxaddr=1961, bus=0, 1430.33 ms, 0x2135423333363330, b'!5B33630', len(can.dat)=8

    can: rxaddr=1961, bus=2, 1450.5 ms, 0x2200000000000000, b'"\x00\x00\x00\x00\x00\x00\x00', len(can.dat)=8
    can: rxaddr=1961, bus=0, 1450.5 ms, 0x2200000000000000, b'"\x00\x00\x00\x00\x00\x00\x00', len(can.dat)=8
```