### PR TITLE
Update actions to replace deprecated versions

### DIFF
--- a/.github/workflows/auto-cache/action.yaml
+++ b/.github/workflows/auto-cache/action.yaml
@@ -26,7 +26,7 @@ runs:
 
     - name: setup github cache
       if: ${{ !contains(runner.name, 'nsc') && inputs.save != 'false' }}
-      uses: 'actions/cache@v3'
+      uses: 'actions/cache@v4'
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}
@@ -34,7 +34,7 @@ runs:
 
     - name: setup github cache
       if: ${{ !contains(runner.name, 'nsc') && inputs.save == 'false' }}
-      uses: 'actions/cache/restore@v3'
+      uses: 'actions/cache/restore@v4'
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}

--- a/.github/workflows/auto_pr_review.yaml
+++ b/.github/workflows/auto_pr_review.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'commaai/openpilot'
     steps:
-    - uses: Vankka/pr-target-branch-action@69ab6dd5c221de3548b3b6c4d102c1f4913d3baa
+    - uses: Vankka/pr-target-branch-action@def32ec9d93514138d6ac0132ee62e120a72aed5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/compile-openpilot/action.yaml
+++ b/.github/workflows/compile-openpilot/action.yaml
@@ -14,7 +14,7 @@ runs:
           ${{ env.RUN }} "rm -rf /tmp/scons_cache/* && \
                           scons -j$(nproc) --cache-populate"
     - name: Save scons cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       if: github.ref == 'refs/heads/master'
       with:
         path: .ci_cache/scons_cache

--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -22,7 +22,7 @@ jobs:
         git -c submodule."tinygrad".update=none submodule update --remote
         git add .
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5
+      uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
       with:
         token: ${{ secrets.ACTIONS_CREATE_PR_PAT }}
         commit-message: bump submodules
@@ -49,7 +49,7 @@ jobs:
         git config --global --add safe.directory '*'
         pre-commit autoupdate
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5
+      uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
       with:
         token: ${{ secrets.ACTIONS_CREATE_PR_PAT }}
         commit-message: Update Python packages and pre-commit hooks

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -197,7 +197,7 @@ jobs:
         docker_hub_pat: ${{ secrets.DOCKER_HUB_PAT }}
     - name: Cache test routes
       id: dependency-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .ci_cache/comma_download_cache
         key: proc-replay-${{ hashFiles('.github/workflows/selfdrive_tests.yaml', 'selfdrive/test/process_replay/ref_commit') }}
@@ -215,7 +215,7 @@ jobs:
       id: print-diff
       if: always()
       run: cat selfdrive/test/process_replay/diff.txt
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       continue-on-error: true
       with:
@@ -242,7 +242,7 @@ jobs:
     - uses: ./.github/workflows/setup-with-retry
     - name: Cache test routes
       id: dependency-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .ci_cache/comma_download_cache
         key: regen-${{ hashFiles('.github/workflows/selfdrive_tests.yaml', 'selfdrive/test/process_replay/test_regen.py') }}
@@ -357,14 +357,14 @@ jobs:
           echo "::set-output name=diff::$output"
       - name: Find comment
         if: ${{ env.AZURE_TOKEN != '' }}
-        uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: This PR makes changes to
       - name: Update comment
         if: ${{ steps.save_diff.outputs.diff != '' && env.AZURE_TOKEN != '' }}
-        uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -372,7 +372,7 @@ jobs:
           edit-mode: replace
       - name: Delete comment
         if: ${{ steps.fc.outputs.comment-id != '' && steps.save_diff.outputs.diff == '' && env.AZURE_TOKEN != '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.deleteComment({
@@ -398,7 +398,7 @@ jobs:
                             export MAPBOX_TOKEN='pk.eyJ1Ijoiam5ld2IiLCJhIjoiY2xxNW8zZXprMGw1ZzJwbzZneHd2NHljbSJ9.gV7VPRfbXFetD-1OVF0XZg' &&
                             python selfdrive/ui/tests/test_ui/run.py"
       - name: Upload Test Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: report
           path: selfdrive/ui/tests/test_ui/report


### PR DESCRIPTION
actions/cache@v3 uses the deprecated Node.js 16 so update to use v4 which uses Node.js 20. This also applies to save and restore

**Description**

Deprecation warnings seen in logs
https://github.com/commaai/openpilot/actions/runs/8733625813

Documentation for actions/cache
https://github.com/marketplace/actions/cache

**Verification**

Code inspection
