### PR TITLE
replay: refactor `Event` to remove the readers

### DIFF
--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -9,8 +9,6 @@ if arch == "Darwin":
 else:
   base_libs.append('OpenCL')
 
-qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
-
 replay_lib_src = ["replay.cc", "consoleui.cc", "camera.cc", "filereader.cc", "logreader.cc", "framereader.cc", "route.cc", "util.cc"]
 replay_lib = qt_env.Library("qt_replay", replay_lib_src, LIBS=base_libs, FRAMEWORKS=base_frameworks)
 Export('replay_lib')

--- a/tools/replay/camera.h
+++ b/tools/replay/camera.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <unistd.h>
-
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -17,7 +15,7 @@ class CameraServer {
 public:
   CameraServer(std::pair<int, int> camera_size[MAX_CAMERAS] = nullptr);
   ~CameraServer();
-  void pushFrame(CameraType type, FrameReader* fr, const cereal::EncodeIndex::Reader& eidx);
+  void pushFrame(CameraType type, FrameReader* fr, const Event *event);
   void waitForSent();
 
 protected:
@@ -27,7 +25,7 @@ protected:
     int width;
     int height;
     std::thread thread;
-    SafeQueue<std::pair<FrameReader*, const cereal::EncodeIndex::Reader>> queue;
+    SafeQueue<std::pair<FrameReader*, const Event *>> queue;
     int cached_id = -1;
     int cached_seg = -1;
     VisionBuf * cached_buf;

--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -178,7 +178,7 @@ void TestReplay::testSeekTo(int seek_to) {
       continue;
     }
 
-    Event cur_event(cereal::Event::Which::INIT_DATA, cur_mono_time_);
+    Event cur_event(cereal::Event::Which::INIT_DATA, cur_mono_time_, {});
     auto eit = std::upper_bound(events_->begin(), events_->end(), &cur_event, Event::lessThan());
     if (eit == events_->end()) {
       qDebug() << "waiting for events...";

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -298,6 +298,7 @@ std::string decompressBZ2(const std::byte *in, size_t in_size, std::atomic<bool>
   BZ2_bzDecompressEnd(&strm);
   if (bzerror == BZ_STREAM_END && !(abort && *abort)) {
     out.resize(strm.total_out_lo32);
+    out.shrink_to_fit();
     return out;
   }
   return {};


### PR DESCRIPTION
In the current `class Event`, both `capnp::FlatArrayMessageReader` and `cereal::Event::Reader` are stored for direct event data access via `e->event`. However, during replay, only one `INIT_DATA` and one `CAR_PARAMS` are read from `e->event` during thread startup. Storing these readers in `Event` structure, despite infrequent use, leads to significant resource waste. For example, If there are tens of thousands of events in a segment, the same number of `FlatArrayMessageReader` and ` cereal::Event::Reader` will be created and stored in the event array. this leads to the memory usage of the event array exceeding even the size of the decompressed original rlog.

This refactoring removes these readers from the `class Event`, resulting in a more streamlined and efficient structure. After the refactoring, clients must use:

> capnp::FlatArrayMessageReader reader((*it)->data);
>   auto event = reader.getRoot<cereal::Event>();

to access event data instead of accessing event data directly through `(*it)->event`.

This refactoring reduces memory usage per segment by 50-80MB. 

After this PR and PR https://github.com/commaai/openpilot/pull/32236, memory usage in replay and cabana has been significantly reduced:


| - | Before  | After |
| - | ------------- | ------------- |
| replay --demo | ~ 1.5 GB  | ~ 450M  |
| cabana --demo | ~ 3.5 GB  | ~ 1.2 GB  |

Note: 
1. Tested with software decoding. the hardware decoding requires additional memory. further optimization is planned to potentially resulting in a reduction of 100MB of memory per segment for hw acceleration.
2. The default cache size for "replay" is 5 segments, while "cabana" caches 15 segments.
