### PR TITLE
[bot] Fingerprints: add missing FW versions from CAN fingerprinting cars

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -85,6 +85,7 @@ FW_VERSIONS = {
       b'\xf1\x00AEhe SCC H-CUP      1.01 1.01 96400-G2100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
+      b'\xf1\x00AE  MDPS C 1.00 1.05 56310/G2501 4AEHC105',
       b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2301 4AEHC107',
       b'\xf1\x00AE  MDPS C 1.00 1.07 56310/G2501 4AEHC107',
     ],


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                    | Name from VIN 🆚 CarDocs                                               | Segments                                  | Bad seg tags                                                                          | Good seg tags                                                                       |
|:-------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|:------------------------------------------|:--------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
| [228af270c1879d5a](https://useradmin.comma.ai/?onebox=228af270c1879d5a)<br><sub>HYUNDAI_IONIQ<br>KMHC75LC7........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 24 routes,<br>473 segments<br>(7.9 hours) | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=228af270c1879d5a) | - valid torque params: 457<br>- all lat active: 79<br>- no input all lat active: 60 |

Dongles to re-run category: `228af270c1879d5a`
</details>

## ⏳️ 3 dongles (2 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                    | Name from VIN 🆚 CarDocs                                               | Segments                                | Bad seg tags                                                                          | Good seg tags                                                                     |
|:-------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------|:----------------------------------------|:--------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------|
| [cb04dcf47b20037d](https://useradmin.comma.ai/?onebox=cb04dcf47b20037d)<br><sub>HYUNDAI_IONIQ<br>KMHC75LCX........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2017 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 2 routes,<br>24 segments<br>(0.4 hours) | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=cb04dcf47b20037d) | - valid torque params: 10<br>- all lat active: 2                                  |
| [cd30864211945e4e](https://useradmin.comma.ai/?onebox=cd30864211945e4e)<br><sub>HYUNDAI_IONIQ<br>KMHC75LC2........</sub> | HYUNDAI Ioniq Hybrid Hatchback 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 5 routes,<br>25 segments<br>(0.4 hours) | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=cd30864211945e4e) | - all lat active: 0                                                               |
| [bfda978d009a7a95](https://useradmin.comma.ai/?onebox=bfda978d009a7a95)<br><sub>KIA_SORENTO<br>5XYPKDA55........</sub>   | KIA Sorento 2019 🆚<br>Kia Sorento 2019                                | 8 routes,<br>82 segments<br>(1.4 hours) |                                                                                       | - valid torque params: 62<br>- all lat active: 14<br>- no input all lat active: 8 |

Dongles to re-run category: `cb04dcf47b20037d bfda978d009a7a95 cd30864211945e4e`
</details>

## ⚠️ 4 dongles (4 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                            | Name from VIN 🆚 CarDocs                                | Segments                                     | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Good seg tags                                                                          |
|:---------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:---------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [50aa739c8332289a](https://useradmin.comma.ai/?onebox=50aa739c8332289a)<br><sub>NISSAN_ALTIMA<br>1N4BL4DW2........</sub>         | NISSAN Altima 2019 🆚<br>Nissan Altima 2019-20          | 4 routes,<br>57 segments<br>(0.9 hours)      | - [missing ECU FW: 57](https://useradmin.comma.ai/?onebox=50aa739c8332289a%7C2024-04-19--20-51-30)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=50aa739c8332289a%7C2024-04-19--20-51-30)                                                                                                                                                                                                                                                                                                              | - all lat active: 3<br>- no input all lat active: 2                                    |
| [1613602610c3e789](https://useradmin.comma.ai/?onebox=1613602610c3e789)<br><sub>HYUNDAI_IONIQ_EV_2020<br>000000000........</sub> | None 🆚<br>None                                         | 152 routes,<br>3202 segments<br>(53.4 hours) | - [missing ECU FW: 838](https://useradmin.comma.ai/?onebox=1613602610c3e789%7C2024-04-02--16-48-53)<br>- [spotty FW: 838](https://useradmin.comma.ai/?onebox=1613602610c3e789%7C2024-04-02--16-48-53)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 3202<br>- all lat active: 990<br>- no input all lat active: 718 |
| [395c77946e384c2f](https://useradmin.comma.ai/?onebox=395c77946e384c2f)<br><sub>KIA_NIRO_EV<br>000000000........</sub>           | None 🆚<br>None                                         | 32 routes,<br>475 segments<br>(7.9 hours)    | - [missing ECU FW: 13](https://useradmin.comma.ai/?onebox=395c77946e384c2f%7C2024-04-05--19-15-39)<br>- [spotty FW: 13](https://useradmin.comma.ai/?onebox=395c77946e384c2f%7C2024-04-05--19-15-39)                                                                                                                                                                                                                                                                                                                      | - valid torque params: 246<br>- all lat active: 132<br>- no input all lat active: 59   |
| [0e13ee2b821302f4](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br><sub>HYUNDAI_IONIQ<br>KNDCE3LC1........</sub>         | KIA Niro Hybrid 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 143 routes,<br>2464 segments<br>(41.1 hours) | - [high lateral accel factor: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-03-28--17-45-38)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-03-27--12-15-40)<br>- [brand fuzzy match disagrees: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-03-27--12-15-40)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4) | - valid torque params: 2345<br>- all lat active: 664<br>- no input all lat active: 442 |

Dongles to re-run category: `50aa739c8332289a 1613602610c3e789 0e13ee2b821302f4 395c77946e384c2f`
</details>