### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -421,6 +421,7 @@ FW_VERSIONS = {
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00LX ESC \x01 103\x19\t\x10 58910-S8360',
       b'\xf1\x00LX ESC \x01 1031\t\x10 58910-S8360',
+      b'\xf1\x00LX ESC \x01 104 \x10\x15 58910-S8350',
       b'\xf1\x00LX ESC \x01 104 \x10\x16 58910-S8360',
       b'\xf1\x00LX ESC \x0b 101\x19\x03\x17 58910-S8330',
       b'\xf1\x00LX ESC \x0b 101\x19\x03  58910-S8360',
@@ -966,6 +967,7 @@ FW_VERSIONS = {
       b'\xf1\x00NE1_ RDR -----      1.00 1.00 99110-GI000         ',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00NE1 MFC  AT CAN LHD 1.00 1.05 99211-GI010 220614',
       b'\xf1\x00NE1 MFC  AT EUR LHD 1.00 1.01 99211-GI010 211007',
       b'\xf1\x00NE1 MFC  AT EUR LHD 1.00 1.06 99211-GI000 210813',
       b'\xf1\x00NE1 MFC  AT EUR LHD 1.00 1.06 99211-GI010 230110',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 2 dongles (2 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                       | Name from VIN 🆚 CarDocs                             | Segments                                    | Bad seg tags   | Good seg tags                                                                        |
|:----------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------|:--------------------------------------------|:---------------|:-------------------------------------------------------------------------------------|
| [baf9c744e8d3aedc](https://useradmin.comma.ai/?onebox=baf9c744e8d3aedc)<br><sub>HYUNDAI_PALISADE<br>KM8R14HE2........</sub> | HYUNDAI Palisade 2021 🆚<br>Hyundai Palisade 2020-22 | 65 routes,<br>1425 segments<br>(23.8 hours) |                | - valid torque params: 1425<br>- all lat active: 66<br>- no input all lat active: 32 |
| [987423e0e2eb516a](https://useradmin.comma.ai/?onebox=987423e0e2eb516a)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>  | None 🆚<br>None                                      | 20 routes,<br>320 segments<br>(5.3 hours)   |                | - valid torque params: 281<br>- all lat active: 110<br>- no input all lat active: 73 |

Dongles to re-run category: `987423e0e2eb516a baf9c744e8d3aedc`
</details>

## ⏳️ 54 dongles (33 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                | Segments                                     | Bad seg tags                                                                                         | Good seg tags                                                                        |
|:--------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------|
| [030e7d18f7c4ea9d](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHTX........</sub>           | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                    | 97 routes,<br>1555 segments<br>(25.9 hours)  |                                                                                                      | - valid torque params: 1554<br>- all lat active: 2                                   |
| [a97d27ce2a78958a](https://useradmin.comma.ai/?onebox=a97d27ce2a78958a)<br><sub>VOLKSWAGEN_JETTA_MK7<br>3VWG57BUX........</sub>       | VOLKSWAGEN Jetta 2019 🆚<br>Volkswagen Jetta 2018-24                    | 9 routes,<br>208 segments<br>(3.5 hours)     |                                                                                                      | - valid torque params: 208<br>- all lat active: 0                                    |
| [30f476405b31e063](https://useradmin.comma.ai/?onebox=30f476405b31e063)<br><sub>TOYOTA_HIGHLANDER<br>5TDDGRFH0........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19    | 117 routes,<br>1618 segments<br>(27.0 hours) |                                                                                                      | - valid torque params: 1617<br>- all lat active: 20<br>- no input all lat active: 4  |
| [2151dc7da83b9c9d](https://useradmin.comma.ai/?onebox=2151dc7da83b9c9d)<br><sub>HYUNDAI_PALISADE<br>KM8R2DHE7........</sub>           | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                    | 9 routes,<br>176 segments<br>(2.9 hours)     |                                                                                                      | - valid torque params: 158<br>- all lat active: 56<br>- no input all lat active: 27  |
| [df616cb5c6ab97f2](https://useradmin.comma.ai/?onebox=df616cb5c6ab97f2)<br><sub>TOYOTA_RAV4_TSS2_2022<br>4T3RWRFV6........</sub>      | TOYOTA RAV4 Hybrid 2022 🆚<br>Toyota RAV4 Hybrid 2022                   | 1 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 8<br>- no input all lat active: 7<br>- valid torque params: 12     |
| [9bac7575fac62395](https://useradmin.comma.ai/?onebox=9bac7575fac62395)<br><sub>HONDA_PILOT<br>5FNYF6H93........</sub>                | HONDA Pilot 2018 🆚<br>Honda Pilot 2016-22                              | 188 routes,<br>2166 segments<br>(36.1 hours) |                                                                                                      | - valid torque params: 2164<br>- all lat active: 271<br>- no input all lat active: 1 |
| [4a816f1ed461f594](https://useradmin.comma.ai/?onebox=4a816f1ed461f594)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHM9........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                    | 15 routes,<br>150 segments<br>(2.5 hours)    |                                                                                                      | - valid torque params: 79<br>- all lat active: 11<br>- no input all lat active: 5    |
| [93b0d4e6d059e288](https://useradmin.comma.ai/?onebox=93b0d4e6d059e288)<br><sub>MAZDA_CX5_2022<br>JM3KFBAY3........</sub>             | MAZDA CX-5 2022 🆚<br>Mazda CX-5 2022-24                                | 6 routes,<br>113 segments<br>(1.9 hours)     |                                                                                                      | - valid torque params: 104<br>- all lat active: 11<br>- no input all lat active: 8   |
| [55f5c1dbae4f93d0](https://useradmin.comma.ai/?onebox=55f5c1dbae4f93d0)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFKT6........</sub>           | RAM 1500 2024 🆚<br>Ram 1500 2019-24                                    | 6 routes,<br>59 segments<br>(1.0 hours)      |                                                                                                      | - valid torque params: 48<br>- all lat active: 1<br>- no input all lat active: 1     |
| [c04a3b5508dc7bc3](https://useradmin.comma.ai/?onebox=c04a3b5508dc7bc3)<br><sub>HONDA_ACCORD<br>1HGCV2F90........</sub>               | HONDA Accord 2021 🆚<br>Honda Accord 2018-22                            | 32 routes,<br>364 segments<br>(6.1 hours)    |                                                                                                      | - valid torque params: 364<br>- all lat active: 1<br>- no input all lat active: 1    |
| [6f915c784c00bb10](https://useradmin.comma.ai/?onebox=6f915c784c00bb10)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFKT6........</sub>           | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                    | 8 routes,<br>44 segments<br>(0.7 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [6605a3f2fd20e6af](https://useradmin.comma.ai/?onebox=6605a3f2fd20e6af)<br><sub>TOYOTA_HIGHLANDER<br>5TDDGRFH4........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19    | 11 routes,<br>154 segments<br>(2.6 hours)    |                                                                                                      | - valid torque params: 150<br>- all lat active: 2                                    |
| [70de7ca8aacf461f](https://useradmin.comma.ai/?onebox=70de7ca8aacf461f)<br><sub>LEXUS_ES_TSS2<br>JTHB21B17........</sub>              | None 🆚<br>None                                                         | 7 routes,<br>83 segments<br>(1.4 hours)      |                                                                                                      | - valid torque params: 45<br>- all lat active: 19<br>- no input all lat active: 4    |
| [890eca14f09fc03e](https://useradmin.comma.ai/?onebox=890eca14f09fc03e)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHTX........</sub>           | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                    | 5 routes,<br>46 segments<br>(0.8 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [2d2ed4682dfe5a78](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)<br><sub>KIA_EV6<br>KNDC3DLC3........</sub>                    | KIA EV6 2023 🆚<br>Kia EV6 (with HDA II) 2022-23                        | 1 routes,<br>2 segments<br>(0.0 hours)       | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)                | - all lat active: 0                                                                  |
| [6bb60ccda0ac419f](https://useradmin.comma.ai/?onebox=6bb60ccda0ac419f)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23               | 2 routes,<br>11 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 1                                                                  |
| [d624493e04d36bdd](https://useradmin.comma.ai/?onebox=d624493e04d36bdd)<br><sub>HYUNDAI_SANTA_FE_HEV_2022<br>5NMS5DA15........</sub>  | HYUNDAI Santa Fe Hybrid 2023 🆚<br>Hyundai Santa Fe Hybrid 2022-23      | 10 routes,<br>215 segments<br>(3.6 hours)    |                                                                                                      | - all lat active: 3<br>- no input all lat active: 3                                  |
| [99ab2642595ea390](https://useradmin.comma.ai/?onebox=99ab2642595ea390)<br><sub>HONDA_CIVIC_BOSCH<br>SHHFK7H94........</sub>          | HONDA Civic Hatchback 2017 🆚<br>Honda Civic Hatchback 2017-21          | 2 routes,<br>23 segments<br>(0.4 hours)      |                                                                                                      | - valid torque params: 23<br>- all lat active: 0                                     |
| [f1d460a711a7fdbf](https://useradmin.comma.ai/?onebox=f1d460a711a7fdbf)<br><sub>HONDA_CRV<br>5J6RM3H92........</sub>                  | HONDA CR-V 2015 🆚<br>Honda CR-V 2015-16                                | 1 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                      | - valid torque params: 5<br>- all lat active: 1<br>- no input all lat active: 1      |
| [636f850472924d8b](https://useradmin.comma.ai/?onebox=636f850472924d8b)<br><sub>TOYOTA_COROLLA_TSS2<br>JTNC4MBE8........</sub>        | TOYOTA Corolla Hatchback 2022 🆚<br>Toyota Corolla Hatchback 2019-22    | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - valid torque params: 1<br>- all lat active: 0                                      |
| [80094e04a713b065](https://useradmin.comma.ai/?onebox=80094e04a713b065)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>            | None 🆚<br>None                                                         | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - all lat active: 0                                                                  |
| [46cdc864ec865f4b](https://useradmin.comma.ai/?onebox=46cdc864ec865f4b)<br><sub>TOYOTA_ALPHARD_TSS2<br>000000000........</sub>        | None 🆚<br>None                                                         | 7 routes,<br>177 segments<br>(3.0 hours)     |                                                                                                      | - valid torque params: 140<br>- all lat active: 28<br>- no input all lat active: 12  |
| [d926d3b6cbdb1433](https://useradmin.comma.ai/?onebox=d926d3b6cbdb1433)<br><sub>CHRYSLER_PACIFICA_2018<br>2C4RC1EG5........</sub>     | CHRYSLER Pacifica 2017 🆚<br>Chrysler Pacifica 2017-18                  | 7 routes,<br>32 segments<br>(0.5 hours)      |                                                                                                      | - valid torque params: 28<br>- all lat active: 6                                     |
| [4fee1b468aea7202](https://useradmin.comma.ai/?onebox=4fee1b468aea7202)<br><sub>LEXUS_ES<br>JTHBW1GG2........</sub>                   | LEXUS ES Hybrid 2018 🆚<br>Lexus ES Hybrid 2017-18                      | 13 routes,<br>163 segments<br>(2.7 hours)    |                                                                                                      | - valid torque params: 158<br>- all lat active: 17<br>- no input all lat active: 15  |
| [95bdaa23fcf50877](https://useradmin.comma.ai/?onebox=95bdaa23fcf50877)<br><sub>TOYOTA_ALPHARD_TSS2<br>000000000........</sub>        | None 🆚<br>None                                                         | 62 routes,<br>749 segments<br>(12.5 hours)   |                                                                                                      | - all lat active: 16<br>- no input all lat active: 4                                 |
| [a6de4da35307d7b8](https://useradmin.comma.ai/?onebox=a6de4da35307d7b8)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT4........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                    | 9 routes,<br>192 segments<br>(3.2 hours)     |                                                                                                      | - valid torque params: 192<br>- all lat active: 7                                    |
| [dffad723f47fd44b](https://useradmin.comma.ai/?onebox=dffad723f47fd44b)<br><sub>TOYOTA_RAV4_TSS2<br>2T3B6RFV6........</sub>           | TOYOTA RAV4 Hybrid 2021 🆚<br>Toyota RAV4 Hybrid 2019-21                | 3 routes,<br>266 segments<br>(4.4 hours)     |                                                                                                      | - valid torque params: 248<br>- all lat active: 129<br>- no input all lat active: 0  |
| [6868a58803419504](https://useradmin.comma.ai/?onebox=6868a58803419504)<br><sub>HONDA_PILOT<br>5FNYF6H29........</sub>                | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                              | 10 routes,<br>237 segments<br>(4.0 hours)    |                                                                                                      | - valid torque params: 237<br>- all lat active: 36<br>- no input all lat active: 24  |
| [3044cbf1071171ba](https://useradmin.comma.ai/?onebox=3044cbf1071171ba)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23               | 3 routes,<br>19 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 3                                                                  |
| [e903f78de77036c7](https://useradmin.comma.ai/?onebox=e903f78de77036c7)<br><sub>TOYOTA_RAV4_TSS2_2023<br>2T3N1RFV8........</sub>      | TOYOTA RAV4 2024 🆚<br>Toyota RAV4 2023-24                              | 2 routes,<br>28 segments<br>(0.5 hours)      |                                                                                                      | - all lat active: 6<br>- no input all lat active: 5                                  |
| [a875d8a10c299893](https://useradmin.comma.ai/?onebox=a875d8a10c299893)<br><sub>LEXUS_CTH<br>000000000........</sub>                  | None 🆚<br>None                                                         | 2 routes,<br>15 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 1<br>- no input all lat active: 1                                  |
| [ac4a1cfc3a2bfcd1](https://useradmin.comma.ai/?onebox=ac4a1cfc3a2bfcd1)<br><sub>TOYOTA_COROLLA_TSS2<br>JTNA4MBE7........</sub>        | TOYOTA Corolla Hatchback 2022 🆚<br>Toyota Corolla Hatchback 2019-22    | 15 routes,<br>29 segments<br>(0.5 hours)     |                                                                                                      | - all lat active: 0                                                                  |
| [4b775e9a125afbc7](https://useradmin.comma.ai/?onebox=4b775e9a125afbc7)<br><sub>TOYOTA_RAV4_TSS2_2023<br>2T3S1RFV7........</sub>      | TOYOTA RAV4 2024 🆚<br>Toyota RAV4 2023-24                              | 1 routes,<br>20 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 11<br>- no input all lat active: 5                                 |
| [d64a913d6bc60932](https://useradmin.comma.ai/?onebox=d64a913d6bc60932)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFPT5........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                    | 1 routes,<br>16 segments<br>(0.3 hours)      |                                                                                                      | - valid torque params: 12<br>- all lat active: 2<br>- no input all lat active: 1     |
| [6adf1dffa8619f41](https://useradmin.comma.ai/?onebox=6adf1dffa8619f41)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub> | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                    | 8 routes,<br>42 segments<br>(0.7 hours)      |                                                                                                      | - valid torque params: 26<br>- all lat active: 14<br>- no input all lat active: 11   |
| [f9d8d0552e557f8e](https://useradmin.comma.ai/?onebox=f9d8d0552e557f8e)<br><sub>TOYOTA_RAV4_TSS2_2022<br>JTMW1RFV0........</sub>      | TOYOTA RAV4 2022 🆚<br>Toyota RAV4 2022                                 | 1 routes,<br>6 segments<br>(0.1 hours)       |                                                                                                      | - valid torque params: 6<br>- all lat active: 0                                      |
| [9acd533a0f402e80](https://useradmin.comma.ai/?onebox=9acd533a0f402e80)<br><sub>HYUNDAI_ELANTRA_2021<br>5NPLS4AG8........</sub>       | HYUNDAI Elantra 2022 🆚<br>Hyundai Elantra 2021-23                      | 101 routes,<br>1567 segments<br>(26.1 hours) |                                                                                                      | - valid torque params: 1567<br>- all lat active: 13<br>- no input all lat active: 13 |
| [7e63a5eee34d3fb0](https://useradmin.comma.ai/?onebox=7e63a5eee34d3fb0)<br><sub>KIA_EV6<br>000000000........</sub>                    | None 🆚<br>None                                                         | 10 routes,<br>258 segments<br>(4.3 hours)    |                                                                                                      | - valid torque params: 187<br>- all lat active: 17<br>- no input all lat active: 13  |
| [fa2c57632891fe1c](https://useradmin.comma.ai/?onebox=fa2c57632891fe1c)<br><sub>HYUNDAI_SANTA_FE<br>5NMS3CAD5........</sub>           | HYUNDAI Santa Fe 2020 🆚<br>Hyundai Santa Fe 2019-20                    | 1 routes,<br>2 segments<br>(0.0 hours)       |                                                                                                      | - all lat active: 0                                                                  |
| [45a7520f43e36e38](https://useradmin.comma.ai/?onebox=45a7520f43e36e38)<br><sub>ACURA_RDX_3G<br>5J8TC2H73........</sub>               | ACURA RDX 2021 🆚<br>Acura RDX 2019-22                                  | 2 routes,<br>15 segments<br>(0.2 hours)      |                                                                                                      | - valid torque params: 15<br>- all lat active: 0                                     |
| [e8151619f03d6c11](https://useradmin.comma.ai/?onebox=e8151619f03d6c11)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC1EG1........</sub>     | CHRYSLER Pacifica 2019 🆚<br>Chrysler Pacifica 2019-20                  | 4 routes,<br>50 segments<br>(0.8 hours)      |                                                                                                      | - valid torque params: 5<br>- all lat active: 0                                      |
| [f56e1b6b8d3d4326](https://useradmin.comma.ai/?onebox=f56e1b6b8d3d4326)<br><sub>TOYOTA_CAMRY_TSS2<br>4T1C11BK0........</sub>          | TOYOTA Camry 2022 🆚<br>Toyota Camry 2021-24                            | 2 routes,<br>30 segments<br>(0.5 hours)      |                                                                                                      | - valid torque params: 30<br>- all lat active: 0                                     |
| [6ebcefea49711168](https://useradmin.comma.ai/?onebox=6ebcefea49711168)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>          | None 🆚<br>None                                                         | 12 routes,<br>94 segments<br>(1.6 hours)     |                                                                                                      | - valid torque params: 68<br>- all lat active: 2<br>- no input all lat active: 1     |
| [fdf7c1f93a13cfc9](https://useradmin.comma.ai/?onebox=fdf7c1f93a13cfc9)<br><sub>HYUNDAI_IONIQ_5<br>KMHKL81AF........</sub>            | HYUNDAI  1992 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23               | 1 routes,<br>18 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 2<br>- no input all lat active: 1                                  |
| [a10cb44801fea034](https://useradmin.comma.ai/?onebox=a10cb44801fea034)<br><sub>VOLKSWAGEN_JETTA_MK7<br>WVWZZZBUZ........</sub>       | VOLKSWAGEN  2021 🆚<br>Volkswagen Jetta 2018-24                         | 5 routes,<br>22 segments<br>(0.4 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [b9ed9a8b2b604ddf](https://useradmin.comma.ai/?onebox=b9ed9a8b2b604ddf)<br><sub>KIA_OPTIMA_G4<br>5XXGW4L23........</sub>              | KIA Optima 2017 🆚<br>Kia Optima 2017                                   | 2 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [6e6e342fad47dd29](https://useradmin.comma.ai/?onebox=6e6e342fad47dd29)<br><sub>VOLKSWAGEN_GOLF_MK7<br>WVWVF7AU2........</sub>        | VOLKSWAGEN Golf R Hatchback 2018 🆚<br>Volkswagen Golf Alltrack 2015-19 | 10 routes,<br>124 segments<br>(2.1 hours)    | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=6e6e342fad47dd29)                | - valid torque params: 124<br>- all lat active: 5<br>- no input all lat active: 3    |
| [5928b56aca881917](https://useradmin.comma.ai/?onebox=5928b56aca881917)<br><sub>HYUNDAI_SANTA_FE_2022<br>RLUSW81KD........</sub>      | None 🆚<br>None                                                         | 10 routes,<br>69 segments<br>(1.1 hours)     | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=5928b56aca881917%7C2024-04-15--10-37-20) | - all lat active: 3                                                                  |
| [d075d065f1c27b98](https://useradmin.comma.ai/?onebox=d075d065f1c27b98)<br><sub>KIA_EV6<br>KNAC381CP........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                           | 1 routes,<br>10 segments<br>(0.2 hours)      |                                                                                                      | - valid torque params: 3<br>- all lat active: 0                                      |
| [187d267de5d35af0](https://useradmin.comma.ai/?onebox=187d267de5d35af0)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AG6........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                      | 4 routes,<br>16 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [b53e882f1a5c30ae](https://useradmin.comma.ai/?onebox=b53e882f1a5c30ae)<br><sub>LEXUS_IS<br>000000000........</sub>                   | None 🆚<br>None                                                         | 11 routes,<br>282 segments<br>(4.7 hours)    |                                                                                                      | - all lat active: 18<br>- no input all lat active: 10                                |
| [4b885cbaada16ae4](https://useradmin.comma.ai/?onebox=4b885cbaada16ae4)<br><sub>HONDA_ODYSSEY<br>5FNRL6H85........</sub>              | HONDA Odyssey 2018 🆚<br>Honda Odyssey 2018-20                          | 23 routes,<br>260 segments<br>(4.3 hours)    |                                                                                                      | - valid torque params: 233<br>- all lat active: 20<br>- no input all lat active: 7   |
| [dafb0cb9e28e0249](https://useradmin.comma.ai/?onebox=dafb0cb9e28e0249)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>          | None 🆚<br>None                                                         | 11 routes,<br>64 segments<br>(1.1 hours)     |                                                                                                      | - all lat active: 7<br>- no input all lat active: 7<br>- valid torque params: 6      |
| [672d4090a6b92b0b](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81BF........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23               | 2 routes,<br>27 segments<br>(0.5 hours)      |                                                                                                      | - all lat active: 1<br>- no input all lat active: 1                                  |

Dongles to re-run category: `4b885cbaada16ae4 f56e1b6b8d3d4326 dafb0cb9e28e0249 9bac7575fac62395 55f5c1dbae4f93d0 672d4090a6b92b0b 030e7d18f7c4ea9d 93b0d4e6d059e288 d64a913d6bc60932 a10cb44801fea034 b9ed9a8b2b604ddf 6adf1dffa8619f41 c04a3b5508dc7bc3 4fee1b468aea7202 45a7520f43e36e38 f9d8d0552e557f8e 6e6e342fad47dd29 890eca14f09fc03e 4b775e9a125afbc7 6605a3f2fd20e6af f1d460a711a7fdbf 6868a58803419504 9acd533a0f402e80 dffad723f47fd44b 6ebcefea49711168 e8151619f03d6c11 5928b56aca881917 d624493e04d36bdd df616cb5c6ab97f2 80094e04a713b065 95bdaa23fcf50877 a97d27ce2a78958a 30f476405b31e063 4a816f1ed461f594 fdf7c1f93a13cfc9 3044cbf1071171ba 2d2ed4682dfe5a78 2151dc7da83b9c9d 636f850472924d8b b53e882f1a5c30ae e903f78de77036c7 46cdc864ec865f4b 7e63a5eee34d3fb0 70de7ca8aacf461f d075d065f1c27b98 fa2c57632891fe1c a6de4da35307d7b8 99ab2642595ea390 a875d8a10c299893 6f915c784c00bb10 d926d3b6cbdb1433 ac4a1cfc3a2bfcd1 187d267de5d35af0 6bb60ccda0ac419f`
</details>

## ⚠️ 30 dongles (17 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                                                          | Segments                                     | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Good seg tags                                                                           |
|:--------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------|:---------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
| [9e7b03d47798346e](https://useradmin.comma.ai/?onebox=9e7b03d47798346e)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub> | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                                                              | 93 routes,<br>1367 segments<br>(22.8 hours)  | - [car faulted: 643](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C2024-03-31--14-59-40)<br>- [segment too short (info): 145](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C2024-04-10--10-55-28)                                                                                                                                                                                                                                                                                                              | - valid torque params: 630<br>- all lat active: 25<br>- no input all lat active: 14     |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>            | None 🆚<br>None                                                                                                   | 80 routes,<br>1150 segments<br>(19.2 hours)  | - [CAN invalid: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)                                                                                                                                                                                                                                                                                                                               | - valid torque params: 1149<br>- all lat active: 40<br>- no input all lat active: 17    |
| [d15c6c91d28a861b](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H53........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 21 routes,<br>772 segments<br>(12.9 hours)   | - [missing ECU FW: 740](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--16-05-22)<br>- [spotty FW: 32](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-17--18-32-42)<br>- [CAN invalid: 7](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [segment too short (info): 3](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--16-05-22) | - valid torque params: 679<br>- all lat active: 334<br>- no input all lat active: 234   |
| [cc2b9c9f221f1812](https://useradmin.comma.ai/?onebox=cc2b9c9f221f1812)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 2 routes,<br>15 segments<br>(0.2 hours)      | - [invalid FW: 15](https://useradmin.comma.ai/?onebox=cc2b9c9f221f1812%7C2024-03-21--07-35-12)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 15                                                               |
| [71d06cb96a5d802f](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f)<br><sub>HONDA_CIVIC_2022<br>19XFL1H87........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 27 routes,<br>307 segments<br>(5.1 hours)    | - [missing ECU FW: 70](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f%7C2024-03-25--16-14-15)<br>- [spotty FW: 70](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f%7C2024-03-25--16-14-15)<br>- [high lateral accel factor: 29](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f%7C2024-03-29--15-49-21)                                                                                                                                                                                                           | - valid torque params: 260<br>- all lat active: 81<br>- no input all lat active: 52     |
| [0226b40cca56c9e6](https://useradmin.comma.ai/?onebox=0226b40cca56c9e6)<br><sub>HONDA_CIVIC_2022<br>2HGFE2F57........</sub>           | HONDA Civic 2022 🆚<br>Honda Civic 2022-23                                                                        | 2 routes,<br>18 segments<br>(0.3 hours)      | - [missing ECU FW: 18](https://useradmin.comma.ai/?onebox=0226b40cca56c9e6%7C2024-03-26--08-25-55)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0226b40cca56c9e6%7C2024-03-26--08-25-55)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 18                                                               |
| [903ac8da1aa52026](https://useradmin.comma.ai/?onebox=903ac8da1aa52026)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 14 routes,<br>83 segments<br>(1.4 hours)     | - [invalid FW: 83](https://useradmin.comma.ai/?onebox=903ac8da1aa52026%7C2024-04-11--06-49-15)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - all lat active: 21<br>- no input all lat active: 20<br>- valid torque params: 83      |
| [251122482046c71b](https://useradmin.comma.ai/?onebox=251122482046c71b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 6 routes,<br>36 segments<br>(0.6 hours)      | - [missing ECU FW: 36](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--17-32-55)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--17-32-55)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 31<br>- all lat active: 3<br>- no input all lat active: 2        |
| [fc4d8f4e5f8b353a](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a)<br><sub>HONDA_CIVIC_2022<br>19XFL1H88........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 106 routes,<br>2462 segments<br>(41.0 hours) | - [missing ECU FW: 2011](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-12--11-28-04)<br>- [spotty FW: 451](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-05--11-03-36)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-12--11-28-04)                                                                                                                                                                                                                | - valid torque params: 2462<br>- all lat active: 592<br>- no input all lat active: 383  |
| [0cfeef7447cc668a](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a)<br><sub>TOYOTA_RAV4_TSS2_2023<br>JTMDW3FV6........</sub>      | None 🆚<br>None                                                                                                   | 19 routes,<br>295 segments<br>(4.9 hours)    | - [missing ECU FW: 262](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a%7C2024-03-29--13-52-30)<br>- [spotty FW: 33](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a%7C2024-03-28--12-43-51)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a%7C2024-03-29--13-52-30)                                                                                                                                                                                                                  | - all lat active: 27<br>- no input all lat active: 9                                    |
| [d031a8c98c8863da](https://useradmin.comma.ai/?onebox=d031a8c98c8863da)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 4 routes,<br>20 segments<br>(0.3 hours)      | - [missing ECU FW: 20](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-05--10-57-11)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-05--10-57-11)                                                                                                                                                                                                                                                                                                                    | - all lat active: 8<br>- valid torque params: 13<br>- no input all lat active: 1        |
| [a2153ee04e30ac3c](https://useradmin.comma.ai/?onebox=a2153ee04e30ac3c)<br><sub>TOYOTA_HIGHLANDER<br>5TDJGRFH6........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19                                              | 3 routes,<br>48 segments<br>(0.8 hours)      | - [missing ECU FW: 48](https://useradmin.comma.ai/?onebox=a2153ee04e30ac3c%7C2024-03-23--12-06-48)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=a2153ee04e30ac3c%7C2024-03-23--12-06-48)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 48<br>- all lat active: 8<br>- no input all lat active: 4        |
| [2da6c3d026c53b35](https://useradmin.comma.ai/?onebox=2da6c3d026c53b35)<br><sub>HONDA_CIVIC_2022<br>19XFL1H77........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 3 routes,<br>25 segments<br>(0.4 hours)      | - [missing ECU FW: 25](https://useradmin.comma.ai/?onebox=2da6c3d026c53b35%7C2024-03-23--18-49-29)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=2da6c3d026c53b35%7C2024-03-23--18-49-29)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 16                                                               |
| [c042beb296a531c3](https://useradmin.comma.ai/?onebox=c042beb296a531c3)<br><sub>CHRYSLER_PACIFICA_2018<br>2C4RC1GG5........</sub>     | CHRYSLER Pacifica 2018 🆚<br>Chrysler Pacifica 2017-18                                                            | 17 routes,<br>396 segments<br>(6.6 hours)    | - [car faulted: 214](https://useradmin.comma.ai/?onebox=c042beb296a531c3%7C2024-04-18--12-16-55)                                                                                                                                                                                                                                                                                                                                                                                                                               | - valid torque params: 376<br>- all lat active: 50<br>- no input all lat active: 17     |
| [d49be4cedad6f71d](https://useradmin.comma.ai/?onebox=d49be4cedad6f71d)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFBG6........</sub>        | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18                                                        | 3 routes,<br>24 segments<br>(0.4 hours)      | - [car faulted: 2](https://useradmin.comma.ai/?onebox=d49be4cedad6f71d%7C2024-04-01--18-33-50)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 17                                                               |
| [73bcac1960e3f6a4](https://useradmin.comma.ai/?onebox=73bcac1960e3f6a4)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS44AL4........</sub>      | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                                                              | 53 routes,<br>847 segments<br>(14.1 hours)   | - [missing ECU FW: 196](https://useradmin.comma.ai/?onebox=73bcac1960e3f6a4%7C2024-04-13--20-12-51)<br>- [spotty FW: 196](https://useradmin.comma.ai/?onebox=73bcac1960e3f6a4%7C2024-04-13--20-12-51)                                                                                                                                                                                                                                                                                                                          | - valid torque params: 847<br>- all lat active: 25<br>- no input all lat active: 20     |
| [0dacabc563f7e7d7](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 145 routes,<br>2190 segments<br>(36.5 hours) | - [missing ECU FW: 2190](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-03-28--07-25-38)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-03-28--07-25-38)                                                                                                                                                                                                                                                                                                                  | - valid torque params: 2190<br>- all lat active: 261<br>- no input all lat active: 179  |
| [ef8c34c763849757](https://useradmin.comma.ai/?onebox=ef8c34c763849757)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLL4AG6........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                                                | 21 routes,<br>21 segments<br>(0.3 hours)     | - [missing ECU FW: 21](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-03--01-59-30)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-03--01-59-30)                                                                                                                                                                                                                                                                                                                    |                                                                                         |
| [d2245f33562396ab](https://useradmin.comma.ai/?onebox=d2245f33562396ab)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS14AJ4........</sub>      | HYUNDAI Santa Fe 2021 🆚<br>Hyundai Santa Fe 2021-23                                                              | 1 routes,<br>18 segments<br>(0.3 hours)      | - [high lateral accel factor: 6](https://useradmin.comma.ai/?onebox=d2245f33562396ab%7C2024-03-26--18-34-32)                                                                                                                                                                                                                                                                                                                                                                                                                   | - all lat active: 1<br>- no input all lat active: 1<br>- valid torque params: 1         |
| [23daff6c438612d2](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br><sub>AUDI_A3_MK3<br>3VWCA7AU3........</sub>                | VOLKSWAGEN Golf SportWagen 2015 🆚<br>Audi A3 Sportback e-tron 2017-18<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 45 routes,<br>2630 segments<br>(43.8 hours)  | - [FW not exact match: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-04-04--19-17-07)<br>- [brand fuzzy match disagrees: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-04-04--19-17-07)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)                                                                                                                       | - valid torque params: 2630<br>- all lat active: 172<br>- no input all lat active: 128  |
| [61c374c8e5e59db3](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 148 routes,<br>4236 segments<br>(70.6 hours) | - [missing ECU FW: 4236](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-02--15-39-46)<br>- [segment too short (info): 2](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-09--12-54-44)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-02--15-39-46)                                                                                                                                                                                                   | - valid torque params: 4236<br>- all lat active: 1102<br>- no input all lat active: 418 |
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFCG8........</sub>        | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18                                                        | 24 routes,<br>421 segments<br>(7.0 hours)    | - [car faulted: 10](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a%7C2024-04-10--14-57-01)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 421<br>- all lat active: 12<br>- no input all lat active: 4      |
| [d8e00d93d49817ea](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea)<br><sub>LEXUS_RX<br>2T2ZZMCA6........</sub>                   | LEXUS RX 2018 🆚<br>Lexus RX 2017-19                                                                              | 78 routes,<br>1296 segments<br>(21.6 hours)  | - [missing ECU FW: 543](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-17--08-31-24)<br>- [spotty FW: 543](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-17--08-31-24)                                                                                                                                                                                                                                                                                                                          | - valid torque params: 1167<br>- all lat active: 95<br>- no input all lat active: 55    |
| [11d207f3143e07b3](https://useradmin.comma.ai/?onebox=11d207f3143e07b3)<br><sub>KIA_EV6<br>KNAC381AF........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                                                                     | 7 routes,<br>93 segments<br>(1.6 hours)      | - [spotty FW: 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)                                                                                                                                                                                                                                                                                                                           | - valid torque params: 79<br>- all lat active: 38<br>- no input all lat active: 14      |
| [a74cb70b7a19e427](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427)<br><sub>TOYOTA_PRIUS_TSS2<br>000000000........</sub>          | None 🆚<br>None                                                                                                   | 12 routes,<br>141 segments<br>(2.4 hours)    | - [invalid FW: 141](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427%7C2024-04-18--19-01-36)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 140<br>- all lat active: 15<br>- no input all lat active: 5      |
| [9fafce4de77b8cdf](https://useradmin.comma.ai/?onebox=9fafce4de77b8cdf)<br><sub>GENESIS_G70_2020<br>KMTG74LE0........</sub>           | GENESIS G70 2019 🆚<br>Genesis G70 2020-21<br><sub>🎉 <b>New model year!</b> 🎉</sub>                             | 31 routes,<br>804 segments<br>(13.4 hours)   | - [spotty FW: 254](https://useradmin.comma.ai/?onebox=9fafce4de77b8cdf%7C2024-03-22--07-07-02)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 804<br>- all lat active: 303<br>- no input all lat active: 275   |
| [8fc26118039f0a8e](https://useradmin.comma.ai/?onebox=8fc26118039f0a8e)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS4DAL8........</sub>      | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                                                              | 3 routes,<br>64 segments<br>(1.1 hours)      | - [high lateral accel factor: 42](https://useradmin.comma.ai/?onebox=8fc26118039f0a8e%7C2024-03-29--17-19-03)                                                                                                                                                                                                                                                                                                                                                                                                                  | - all lat active: 18<br>- no input all lat active: 13<br>- valid torque params: 1       |
| [214c417708d4eabc](https://useradmin.comma.ai/?onebox=214c417708d4eabc)<br><sub>HONDA_CIVIC_2022<br>2HGFE2F26........</sub>           | HONDA Civic 2024 🆚<br>Honda Civic 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>                             | 190 routes,<br>2999 segments<br>(50.0 hours) | - [missing ECU FW: 1619](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-03-25--19-46-19)<br>- [spotty FW: 1619](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-03-25--19-46-19)<br>- [segment too short (info): 1](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-15--13-12-06)<br>- [CAN invalid: 1](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-15--13-12-06)                                                                                                       | - valid torque params: 2903<br>- all lat active: 334<br>- no input all lat active: 214  |
| [72c57a77995168b4](https://useradmin.comma.ai/?onebox=72c57a77995168b4)<br><sub>TOYOTA_HIGHLANDER_TSS2<br>5TDFZRBH9........</sub>     | TOYOTA Highlander 2021 🆚<br>Toyota Highlander 2020-23                                                            | 1 routes,<br>1 segments<br>(0.0 hours)       | - [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)                                                                                                                                                                                                                                                                                                                     | - valid torque params: 1                                                                |
| [734971c66100033f](https://useradmin.comma.ai/?onebox=734971c66100033f)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHM6........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                                                              | 139 routes,<br>2634 segments<br>(43.9 hours) | - [spotty FW: 109](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-13--19-43-20)<br>- [car faulted: 103](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-13--16-01-08)<br>- [CAN invalid: 3](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-07--09-07-17)                                                                                                                                                                                                                           |                                                                                         |

Dongles to re-run category: `0dacabc563f7e7d7 c042beb296a531c3 d2245f33562396ab 71d06cb96a5d802f 2da6c3d026c53b35 22901377be496047 9e7b03d47798346e d15c6c91d28a861b 903ac8da1aa52026 251122482046c71b d49be4cedad6f71d 214c417708d4eabc cc2b9c9f221f1812 fc4d8f4e5f8b353a ef8c34c763849757 a74cb70b7a19e427 0cfeef7447cc668a 9fafce4de77b8cdf d031a8c98c8863da a2153ee04e30ac3c 72c57a77995168b4 61c374c8e5e59db3 8fc26118039f0a8e 23daff6c438612d2 734971c66100033f d8e00d93d49817ea c88f65eeaee4003a 11d207f3143e07b3 73bcac1960e3f6a4 0226b40cca56c9e6`
</details>