### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/honda/fingerprints.py
+++ b/selfdrive/car/honda/fingerprints.py
@@ -658,6 +658,7 @@ FW_VERSIONS = {
     ],
     (Ecu.programmedFuelInjection, 0x18da10f1, None): [
       b'37805-5MR-3050\x00\x00',
+      b'37805-5MR-3150\x00\x00',
       b'37805-5MR-3250\x00\x00',
       b'37805-5MR-4070\x00\x00',
       b'37805-5MR-4080\x00\x00',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 30.0 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                    | Name from VIN 🆚 CarDocs                       | Segments                                  | Bad seg tags   | Good seg tags                                                                       |
|:-------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|:------------------------------------------|:---------------|:------------------------------------------------------------------------------------|
| [4b885cbaada16ae4](https://useradmin.comma.ai/?onebox=4b885cbaada16ae4)<br><sub>HONDA_ODYSSEY<br>5FNRL6H85........</sub> | HONDA Odyssey 2018 🆚<br>Honda Odyssey 2018-20 | 30 routes,<br>507 segments<br>(8.4 hours) |                | - valid torque params: 480<br>- all lat active: 84<br>- no input all lat active: 40 |

Dongles to re-run category: `4b885cbaada16ae4`
</details>

## ⏳️ 51 dongles (29 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                             | Segments                                     | Bad seg tags                                                                                         | Good seg tags                                                                        |
|:--------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------|
| [5928b56aca881917](https://useradmin.comma.ai/?onebox=5928b56aca881917)<br><sub>HYUNDAI_SANTA_FE_2022<br>RLUSW81KD........</sub>      | None 🆚<br>None                                                      | 10 routes,<br>69 segments<br>(1.1 hours)     | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=5928b56aca881917%7C2024-04-15--18-31-16) | - all lat active: 3                                                                  |
| [fdf7c1f93a13cfc9](https://useradmin.comma.ai/?onebox=fdf7c1f93a13cfc9)<br><sub>HYUNDAI_IONIQ_5<br>KMHKL81AF........</sub>            | HYUNDAI  1992 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23            | 1 routes,<br>18 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 2<br>- no input all lat active: 1                                  |
| [2151dc7da83b9c9d](https://useradmin.comma.ai/?onebox=2151dc7da83b9c9d)<br><sub>HYUNDAI_PALISADE<br>KM8R2DHE7........</sub>           | HYUNDAI Palisade 2022 🆚<br>Hyundai Palisade 2020-22                 | 9 routes,<br>176 segments<br>(2.9 hours)     |                                                                                                      | - all lat active: 56<br>- no input all lat active: 27<br>- valid torque params: 158  |
| [a97d27ce2a78958a](https://useradmin.comma.ai/?onebox=a97d27ce2a78958a)<br><sub>VOLKSWAGEN_JETTA_MK7<br>3VWG57BUX........</sub>       | VOLKSWAGEN Jetta 2019 🆚<br>Volkswagen Jetta 2018-24                 | 5 routes,<br>173 segments<br>(2.9 hours)     |                                                                                                      | - valid torque params: 173<br>- all lat active: 0                                    |
| [e8151619f03d6c11](https://useradmin.comma.ai/?onebox=e8151619f03d6c11)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC1EG1........</sub>     | CHRYSLER Pacifica 2019 🆚<br>Chrysler Pacifica 2019-20               | 4 routes,<br>50 segments<br>(0.8 hours)      |                                                                                                      | - valid torque params: 5<br>- all lat active: 0                                      |
| [df616cb5c6ab97f2](https://useradmin.comma.ai/?onebox=df616cb5c6ab97f2)<br><sub>TOYOTA_RAV4_TSS2_2022<br>4T3RWRFV6........</sub>      | TOYOTA RAV4 Hybrid 2022 🆚<br>Toyota RAV4 Hybrid 2022                | 1 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 8<br>- no input all lat active: 7<br>- valid torque params: 12     |
| [4fee1b468aea7202](https://useradmin.comma.ai/?onebox=4fee1b468aea7202)<br><sub>LEXUS_ES<br>JTHBW1GG2........</sub>                   | LEXUS ES Hybrid 2018 🆚<br>Lexus ES Hybrid 2017-18                   | 13 routes,<br>163 segments<br>(2.7 hours)    |                                                                                                      | - valid torque params: 158<br>- all lat active: 17<br>- no input all lat active: 15  |
| [3044cbf1071171ba](https://useradmin.comma.ai/?onebox=3044cbf1071171ba)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23            | 3 routes,<br>19 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 3                                                                  |
| [6bb60ccda0ac419f](https://useradmin.comma.ai/?onebox=6bb60ccda0ac419f)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23            | 2 routes,<br>11 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 1                                                                  |
| [6ebcefea49711168](https://useradmin.comma.ai/?onebox=6ebcefea49711168)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>          | None 🆚<br>None                                                      | 12 routes,<br>94 segments<br>(1.6 hours)     |                                                                                                      | - valid torque params: 68<br>- all lat active: 2<br>- no input all lat active: 1     |
| [55f5c1dbae4f93d0](https://useradmin.comma.ai/?onebox=55f5c1dbae4f93d0)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFKT6........</sub>           | RAM 1500 2024 🆚<br>Ram 1500 2019-24                                 | 6 routes,<br>59 segments<br>(1.0 hours)      |                                                                                                      | - valid torque params: 48<br>- all lat active: 1<br>- no input all lat active: 1     |
| [4a816f1ed461f594](https://useradmin.comma.ai/?onebox=4a816f1ed461f594)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHM9........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 2 routes,<br>43 segments<br>(0.7 hours)      |                                                                                                      | - valid torque params: 31<br>- all lat active: 4<br>- no input all lat active: 1     |
| [6adf1dffa8619f41](https://useradmin.comma.ai/?onebox=6adf1dffa8619f41)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub> | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                 | 8 routes,<br>42 segments<br>(0.7 hours)      |                                                                                                      | - all lat active: 14<br>- valid torque params: 26<br>- no input all lat active: 11   |
| [70de7ca8aacf461f](https://useradmin.comma.ai/?onebox=70de7ca8aacf461f)<br><sub>LEXUS_ES_TSS2<br>JTHB21B17........</sub>              | None 🆚<br>None                                                      | 7 routes,<br>83 segments<br>(1.4 hours)      |                                                                                                      | - valid torque params: 45<br>- all lat active: 19<br>- no input all lat active: 4    |
| [d075d065f1c27b98](https://useradmin.comma.ai/?onebox=d075d065f1c27b98)<br><sub>KIA_EV6<br>KNAC381CP........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                        | 1 routes,<br>10 segments<br>(0.2 hours)      |                                                                                                      | - valid torque params: 3<br>- all lat active: 0                                      |
| [a20d9fc9c0db2a9d](https://useradmin.comma.ai/?onebox=a20d9fc9c0db2a9d)<br><sub>KIA_EV6<br>000000000........</sub>                    | None 🆚<br>None                                                      | 1 routes,<br>19 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 2<br>- no input all lat active: 1                                  |
| [93b0d4e6d059e288](https://useradmin.comma.ai/?onebox=93b0d4e6d059e288)<br><sub>MAZDA_CX5_2022<br>JM3KFBAY3........</sub>             | MAZDA CX-5 2022 🆚<br>Mazda CX-5 2022-24                             | 6 routes,<br>113 segments<br>(1.9 hours)     |                                                                                                      | - valid torque params: 104<br>- all lat active: 11<br>- no input all lat active: 8   |
| [a10cb44801fea034](https://useradmin.comma.ai/?onebox=a10cb44801fea034)<br><sub>VOLKSWAGEN_JETTA_MK7<br>WVWZZZBUZ........</sub>       | VOLKSWAGEN  2021 🆚<br>Volkswagen Jetta 2018-24                      | 5 routes,<br>22 segments<br>(0.4 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [672d4090a6b92b0b](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81BF........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23            | 2 routes,<br>27 segments<br>(0.5 hours)      |                                                                                                      | - all lat active: 1<br>- no input all lat active: 1                                  |
| [636f850472924d8b](https://useradmin.comma.ai/?onebox=636f850472924d8b)<br><sub>TOYOTA_COROLLA_TSS2<br>JTNC4MBE8........</sub>        | TOYOTA Corolla Hatchback 2022 🆚<br>Toyota Corolla Hatchback 2019-22 | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - valid torque params: 1<br>- all lat active: 0                                      |
| [30f476405b31e063](https://useradmin.comma.ai/?onebox=30f476405b31e063)<br><sub>TOYOTA_HIGHLANDER<br>5TDDGRFH0........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19 | 116 routes,<br>1595 segments<br>(26.6 hours) |                                                                                                      | - valid torque params: 1594<br>- all lat active: 20<br>- no input all lat active: 4  |
| [030e7d18f7c4ea9d](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHTX........</sub>           | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                 | 95 routes,<br>1444 segments<br>(24.1 hours)  |                                                                                                      | - valid torque params: 1443<br>- all lat active: 2                                   |
| [99ab2642595ea390](https://useradmin.comma.ai/?onebox=99ab2642595ea390)<br><sub>HONDA_CIVIC_BOSCH<br>SHHFK7H94........</sub>          | HONDA Civic Hatchback 2017 🆚<br>Honda Civic Hatchback 2017-21       | 2 routes,<br>23 segments<br>(0.4 hours)      |                                                                                                      | - valid torque params: 23<br>- all lat active: 0                                     |
| [e903f78de77036c7](https://useradmin.comma.ai/?onebox=e903f78de77036c7)<br><sub>TOYOTA_RAV4_TSS2_2023<br>2T3N1RFV8........</sub>      | TOYOTA RAV4 2024 🆚<br>Toyota RAV4 2023-24                           | 2 routes,<br>28 segments<br>(0.5 hours)      |                                                                                                      | - all lat active: 6<br>- no input all lat active: 5                                  |
| [f56e1b6b8d3d4326](https://useradmin.comma.ai/?onebox=f56e1b6b8d3d4326)<br><sub>TOYOTA_CAMRY_TSS2<br>4T1C11BK0........</sub>          | TOYOTA Camry 2022 🆚<br>Toyota Camry 2021-24                         | 2 routes,<br>30 segments<br>(0.5 hours)      |                                                                                                      | - valid torque params: 30<br>- all lat active: 0                                     |
| [d624493e04d36bdd](https://useradmin.comma.ai/?onebox=d624493e04d36bdd)<br><sub>HYUNDAI_SANTA_FE_HEV_2022<br>5NMS5DA15........</sub>  | HYUNDAI Santa Fe Hybrid 2023 🆚<br>Hyundai Santa Fe Hybrid 2022-23   | 10 routes,<br>215 segments<br>(3.6 hours)    |                                                                                                      | - all lat active: 3<br>- no input all lat active: 3                                  |
| [95bdaa23fcf50877](https://useradmin.comma.ai/?onebox=95bdaa23fcf50877)<br><sub>TOYOTA_ALPHARD_TSS2<br>000000000........</sub>        | None 🆚<br>None                                                      | 62 routes,<br>749 segments<br>(12.5 hours)   |                                                                                                      | - all lat active: 16<br>- no input all lat active: 4                                 |
| [46cdc864ec865f4b](https://useradmin.comma.ai/?onebox=46cdc864ec865f4b)<br><sub>TOYOTA_ALPHARD_TSS2<br>000000000........</sub>        | None 🆚<br>None                                                      | 7 routes,<br>177 segments<br>(3.0 hours)     |                                                                                                      | - valid torque params: 140<br>- all lat active: 28<br>- no input all lat active: 12  |
| [b53e882f1a5c30ae](https://useradmin.comma.ai/?onebox=b53e882f1a5c30ae)<br><sub>LEXUS_IS<br>000000000........</sub>                   | None 🆚<br>None                                                      | 11 routes,<br>282 segments<br>(4.7 hours)    |                                                                                                      | - all lat active: 18<br>- no input all lat active: 10                                |
| [2d2ed4682dfe5a78](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)<br><sub>KIA_EV6<br>KNDC3DLC3........</sub>                    | KIA EV6 2023 🆚<br>Kia EV6 (with HDA II) 2022-23                     | 1 routes,<br>2 segments<br>(0.0 hours)       | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)                | - all lat active: 0                                                                  |
| [dafb0cb9e28e0249](https://useradmin.comma.ai/?onebox=dafb0cb9e28e0249)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>          | None 🆚<br>None                                                      | 9 routes,<br>61 segments<br>(1.0 hours)      |                                                                                                      | - all lat active: 7<br>- no input all lat active: 7<br>- valid torque params: 6      |
| [c04a3b5508dc7bc3](https://useradmin.comma.ai/?onebox=c04a3b5508dc7bc3)<br><sub>HONDA_ACCORD<br>1HGCV2F90........</sub>               | HONDA Accord 2021 🆚<br>Honda Accord 2018-22                         | 34 routes,<br>378 segments<br>(6.3 hours)    |                                                                                                      | - valid torque params: 378<br>- all lat active: 2<br>- no input all lat active: 2    |
| [7e63a5eee34d3fb0](https://useradmin.comma.ai/?onebox=7e63a5eee34d3fb0)<br><sub>KIA_EV6<br>000000000........</sub>                    | None 🆚<br>None                                                      | 10 routes,<br>258 segments<br>(4.3 hours)    |                                                                                                      | - valid torque params: 187<br>- all lat active: 17<br>- no input all lat active: 13  |
| [a6de4da35307d7b8](https://useradmin.comma.ai/?onebox=a6de4da35307d7b8)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT4........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 9 routes,<br>192 segments<br>(3.2 hours)     |                                                                                                      | - valid torque params: 192<br>- all lat active: 7                                    |
| [6e6e342fad47dd29](https://useradmin.comma.ai/?onebox=6e6e342fad47dd29)<br><sub>VOLKSWAGEN_GOLF_MK7<br>WVWVF7AU2........</sub>        | VOLKSWAGEN Golf R 2018 🆚<br>Volkswagen Golf R 2015-19               | 11 routes,<br>137 segments<br>(2.3 hours)    |                                                                                                      | - valid torque params: 137<br>- all lat active: 5<br>- no input all lat active: 3    |
| [ac4a1cfc3a2bfcd1](https://useradmin.comma.ai/?onebox=ac4a1cfc3a2bfcd1)<br><sub>TOYOTA_COROLLA_TSS2<br>JTNA4MBE7........</sub>        | TOYOTA Corolla Hatchback 2022 🆚<br>Toyota Corolla Hatchback 2019-22 | 15 routes,<br>29 segments<br>(0.5 hours)     |                                                                                                      | - all lat active: 0                                                                  |
| [890eca14f09fc03e](https://useradmin.comma.ai/?onebox=890eca14f09fc03e)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHTX........</sub>           | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                 | 5 routes,<br>46 segments<br>(0.8 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [dffad723f47fd44b](https://useradmin.comma.ai/?onebox=dffad723f47fd44b)<br><sub>TOYOTA_RAV4_TSS2<br>2T3B6RFV6........</sub>           | TOYOTA RAV4 Hybrid 2021 🆚<br>Toyota RAV4 Hybrid 2019-21             | 3 routes,<br>266 segments<br>(4.4 hours)     |                                                                                                      | - valid torque params: 248<br>- all lat active: 129<br>- no input all lat active: 0  |
| [4b775e9a125afbc7](https://useradmin.comma.ai/?onebox=4b775e9a125afbc7)<br><sub>TOYOTA_RAV4_TSS2_2023<br>2T3S1RFV7........</sub>      | TOYOTA RAV4 2024 🆚<br>Toyota RAV4 2023-24                           | 1 routes,<br>20 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 11<br>- no input all lat active: 5                                 |
| [9bac7575fac62395](https://useradmin.comma.ai/?onebox=9bac7575fac62395)<br><sub>HONDA_PILOT<br>5FNYF6H93........</sub>                | HONDA Pilot 2018 🆚<br>Honda Pilot 2016-22                           | 194 routes,<br>2255 segments<br>(37.6 hours) |                                                                                                      | - valid torque params: 2253<br>- all lat active: 296<br>- no input all lat active: 2 |
| [a875d8a10c299893](https://useradmin.comma.ai/?onebox=a875d8a10c299893)<br><sub>LEXUS_CTH<br>000000000........</sub>                  | None 🆚<br>None                                                      | 2 routes,<br>15 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 1<br>- no input all lat active: 1                                  |
| [9acd533a0f402e80](https://useradmin.comma.ai/?onebox=9acd533a0f402e80)<br><sub>HYUNDAI_ELANTRA_2021<br>5NPLS4AG8........</sub>       | HYUNDAI Elantra 2022 🆚<br>Hyundai Elantra 2021-23                   | 97 routes,<br>1539 segments<br>(25.6 hours)  |                                                                                                      | - valid torque params: 1539<br>- all lat active: 13<br>- no input all lat active: 13 |
| [b9ed9a8b2b604ddf](https://useradmin.comma.ai/?onebox=b9ed9a8b2b604ddf)<br><sub>KIA_OPTIMA_G4<br>5XXGW4L23........</sub>              | KIA Optima 2017 🆚<br>Kia Optima 2017                                | 2 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [6605a3f2fd20e6af](https://useradmin.comma.ai/?onebox=6605a3f2fd20e6af)<br><sub>TOYOTA_HIGHLANDER<br>5TDDGRFH4........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19 | 11 routes,<br>154 segments<br>(2.6 hours)    |                                                                                                      | - valid torque params: 150<br>- all lat active: 2                                    |
| [80094e04a713b065](https://useradmin.comma.ai/?onebox=80094e04a713b065)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>            | None 🆚<br>None                                                      | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                      | - all lat active: 0                                                                  |
| [f9d8d0552e557f8e](https://useradmin.comma.ai/?onebox=f9d8d0552e557f8e)<br><sub>TOYOTA_RAV4_TSS2_2022<br>JTMW1RFV0........</sub>      | TOYOTA RAV4 2022 🆚<br>Toyota RAV4 2022                              | 1 routes,<br>6 segments<br>(0.1 hours)       |                                                                                                      | - valid torque params: 6<br>- all lat active: 0                                      |
| [187d267de5d35af0](https://useradmin.comma.ai/?onebox=187d267de5d35af0)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AG6........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                   | 4 routes,<br>16 segments<br>(0.3 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [6f915c784c00bb10](https://useradmin.comma.ai/?onebox=6f915c784c00bb10)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFKT6........</sub>           | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                 | 8 routes,<br>44 segments<br>(0.7 hours)      |                                                                                                      | - all lat active: 0                                                                  |
| [d64a913d6bc60932](https://useradmin.comma.ai/?onebox=d64a913d6bc60932)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFPT5........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                 | 1 routes,<br>16 segments<br>(0.3 hours)      |                                                                                                      | - valid torque params: 12<br>- all lat active: 2<br>- no input all lat active: 1     |
| [f1d460a711a7fdbf](https://useradmin.comma.ai/?onebox=f1d460a711a7fdbf)<br><sub>HONDA_CRV<br>5J6RM3H92........</sub>                  | HONDA CR-V 2015 🆚<br>Honda CR-V 2015-16                             | 1 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                      | - valid torque params: 5<br>- all lat active: 1<br>- no input all lat active: 1      |
| [6868a58803419504](https://useradmin.comma.ai/?onebox=6868a58803419504)<br><sub>HONDA_PILOT<br>5FNYF6H29........</sub>                | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                           | 10 routes,<br>237 segments<br>(4.0 hours)    |                                                                                                      | - valid torque params: 237<br>- all lat active: 36<br>- no input all lat active: 24  |

Dongles to re-run category: `e903f78de77036c7 df616cb5c6ab97f2 5928b56aca881917 93b0d4e6d059e288 6605a3f2fd20e6af 95bdaa23fcf50877 a10cb44801fea034 6adf1dffa8619f41 d075d065f1c27b98 80094e04a713b065 30f476405b31e063 d64a913d6bc60932 f1d460a711a7fdbf 6e6e342fad47dd29 46cdc864ec865f4b 4a816f1ed461f594 f56e1b6b8d3d4326 f9d8d0552e557f8e 9bac7575fac62395 b53e882f1a5c30ae 7e63a5eee34d3fb0 fdf7c1f93a13cfc9 030e7d18f7c4ea9d a97d27ce2a78958a a875d8a10c299893 70de7ca8aacf461f ac4a1cfc3a2bfcd1 6ebcefea49711168 a20d9fc9c0db2a9d 3044cbf1071171ba b9ed9a8b2b604ddf 9acd533a0f402e80 2d2ed4682dfe5a78 99ab2642595ea390 dffad723f47fd44b 6868a58803419504 a6de4da35307d7b8 890eca14f09fc03e 187d267de5d35af0 dafb0cb9e28e0249 2151dc7da83b9c9d 636f850472924d8b d624493e04d36bdd 6f915c784c00bb10 c04a3b5508dc7bc3 4b775e9a125afbc7 4fee1b468aea7202 55f5c1dbae4f93d0 6bb60ccda0ac419f 672d4090a6b92b0b e8151619f03d6c11`
</details>

## ⚠️ 31 dongles (17 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                                                          | Segments                                       | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Good seg tags                                                                             |
|:--------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------|
| [8fc26118039f0a8e](https://useradmin.comma.ai/?onebox=8fc26118039f0a8e)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS4DAL8........</sub>      | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                                                              | 3 routes,<br>64 segments<br>(1.1 hours)        | - [high lateral accel factor: 42](https://useradmin.comma.ai/?onebox=8fc26118039f0a8e%7C2024-03-29--17-19-03)                                                                                                                                                                                                                                                                                                                                                                                                                  | - all lat active: 18<br>- no input all lat active: 13<br>- valid torque params: 1         |
| [ef8c34c763849757](https://useradmin.comma.ai/?onebox=ef8c34c763849757)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLL4AG6........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                                                | 21 routes,<br>21 segments<br>(0.3 hours)       | - [missing ECU FW: 21](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-11--14-57-46)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-11--14-57-46)                                                                                                                                                                                                                                                                                                                    |                                                                                           |
| [d2245f33562396ab](https://useradmin.comma.ai/?onebox=d2245f33562396ab)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS14AJ4........</sub>      | HYUNDAI Santa Fe 2021 🆚<br>Hyundai Santa Fe 2021-23                                                              | 1 routes,<br>18 segments<br>(0.3 hours)        | - [high lateral accel factor: 6](https://useradmin.comma.ai/?onebox=d2245f33562396ab%7C2024-03-26--18-34-32)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 1<br>- all lat active: 1<br>- no input all lat active: 1           |
| [23daff6c438612d2](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br><sub>AUDI_A3_MK3<br>3VWCA7AU3........</sub>                | VOLKSWAGEN Golf SportWagen 2015 🆚<br>Audi A3 Sportback e-tron 2017-18<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 45 routes,<br>2630 segments<br>(43.8 hours)    | - [FW not exact match: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-04-11--16-17-08)<br>- [brand fuzzy match disagrees: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-04-11--16-17-08)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)                                                                                                                       | - valid torque params: 2630<br>- all lat active: 172<br>- no input all lat active: 128    |
| [4e92a7e0078767c8](https://useradmin.comma.ai/?onebox=4e92a7e0078767c8)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AGX........</sub>       | HYUNDAI Elantra 2021 🆚<br>Hyundai Elantra 2021-23                                                                | 3 routes,<br>113 segments<br>(1.9 hours)       | - [high lateral accel factor: 7](https://useradmin.comma.ai/?onebox=4e92a7e0078767c8%7C2024-04-20--18-39-36)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 98<br>- all lat active: 68<br>- no input all lat active: 49        |
| [cc2b9c9f221f1812](https://useradmin.comma.ai/?onebox=cc2b9c9f221f1812)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 1 routes,<br>4 segments<br>(0.1 hours)         | - [invalid FW: 4](https://useradmin.comma.ai/?onebox=cc2b9c9f221f1812%7C2024-03-24--18-32-08)                                                                                                                                                                                                                                                                                                                                                                                                                                  | - valid torque params: 4                                                                  |
| [fc4d8f4e5f8b353a](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a)<br><sub>HONDA_CIVIC_2022<br>19XFL1H88........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 104 routes,<br>2440 segments<br>(40.7 hours)   | - [missing ECU FW: 1989](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-03-22--07-19-10)<br>- [spotty FW: 451](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-03--11-22-11)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-03-22--07-19-10)                                                                                                                                                                                                                | - valid torque params: 2440<br>- all lat active: 580<br>- no input all lat active: 375    |
| [72c57a77995168b4](https://useradmin.comma.ai/?onebox=72c57a77995168b4)<br><sub>TOYOTA_HIGHLANDER_TSS2<br>5TDFZRBH9........</sub>     | TOYOTA Highlander 2021 🆚<br>Toyota Highlander 2020-23                                                            | 1 routes,<br>1 segments<br>(0.0 hours)         | - [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)                                                                                                                                                                                                                                                                                                                     | - valid torque params: 1                                                                  |
| [61c374c8e5e59db3](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 153 routes,<br>4221 segments<br>(70.3 hours)   | - [missing ECU FW: 4221](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-19--10-32-04)<br>- [segment too short (info): 2](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-09--12-54-44)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-19--10-32-04)                                                                                                                                                                                                   | - valid torque params: 4221<br>- all lat active: 1069<br>- no input all lat active: 415   |
| [723b102eb5d8291e](https://useradmin.comma.ai/?onebox=723b102eb5d8291e)<br><sub>TOYOTA_PRIUS<br>JTDKARFUX........</sub>               | TOYOTA Prius 2017 🆚<br>Toyota Prius 2017-20                                                                      | 246 routes,<br>10667 segments<br>(177.8 hours) | - [invalid FW: 331](https://useradmin.comma.ai/?onebox=723b102eb5d8291e%7C2024-03-29--12-47-02)<br>- [spotty FW: 10336](https://useradmin.comma.ai/?onebox=723b102eb5d8291e%7C2024-03-30--10-10-36)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=723b102eb5d8291e%7C2024-04-16--21-51-43)<br>- [car faulted: 11](https://useradmin.comma.ai/?onebox=723b102eb5d8291e%7C2024-03-25--11-19-05)                                                                                                                 | - valid torque params: 10666<br>- all lat active: 6432<br>- no input all lat active: 4236 |
| [2da6c3d026c53b35](https://useradmin.comma.ai/?onebox=2da6c3d026c53b35)<br><sub>HONDA_CIVIC_2022<br>19XFL1H77........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 3 routes,<br>25 segments<br>(0.4 hours)        | - [missing ECU FW: 25](https://useradmin.comma.ai/?onebox=2da6c3d026c53b35%7C2024-03-23--18-49-29)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=2da6c3d026c53b35%7C2024-03-23--18-49-29)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 16                                                                 |
| [903ac8da1aa52026](https://useradmin.comma.ai/?onebox=903ac8da1aa52026)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 14 routes,<br>83 segments<br>(1.4 hours)       | - [invalid FW: 83](https://useradmin.comma.ai/?onebox=903ac8da1aa52026%7C2024-04-10--21-08-08)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 83<br>- all lat active: 21<br>- no input all lat active: 20        |
| [734971c66100033f](https://useradmin.comma.ai/?onebox=734971c66100033f)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHM6........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                                                              | 139 routes,<br>2634 segments<br>(43.9 hours)   | - [spotty FW: 2525](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-05--14-17-21)<br>- [car faulted: 103](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-13--16-01-08)<br>- [CAN invalid: 3](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-07--09-07-17)                                                                                                                                                                                                                          |                                                                                           |
| [9e7b03d47798346e](https://useradmin.comma.ai/?onebox=9e7b03d47798346e)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub> | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                                                              | 96 routes,<br>1425 segments<br>(23.8 hours)    | - [segment too short (info): 145](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C2024-04-08--08-11-39)<br>- [car faulted: 643](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C2024-04-08--08-11-39)                                                                                                                                                                                                                                                                                                              | - valid torque params: 688<br>- all lat active: 27<br>- no input all lat active: 14       |
| [11d207f3143e07b3](https://useradmin.comma.ai/?onebox=11d207f3143e07b3)<br><sub>KIA_EV6<br>KNAC381AF........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                                                                     | 7 routes,<br>93 segments<br>(1.6 hours)        | - [spotty FW: 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)                                                                                                                                                                                                                                                                                                                           | - valid torque params: 79<br>- all lat active: 38<br>- no input all lat active: 14        |
| [c042beb296a531c3](https://useradmin.comma.ai/?onebox=c042beb296a531c3)<br><sub>CHRYSLER_PACIFICA_2018<br>2C4RC1GG5........</sub>     | CHRYSLER Pacifica 2018 🆚<br>Chrysler Pacifica 2017-18                                                            | 17 routes,<br>396 segments<br>(6.6 hours)      | - [car faulted: 214](https://useradmin.comma.ai/?onebox=c042beb296a531c3%7C2024-04-18--12-16-55)                                                                                                                                                                                                                                                                                                                                                                                                                               | - valid torque params: 376<br>- all lat active: 50<br>- no input all lat active: 17       |
| [a74cb70b7a19e427](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427)<br><sub>TOYOTA_PRIUS_TSS2<br>000000000........</sub>          | None 🆚<br>None                                                                                                   | 12 routes,<br>141 segments<br>(2.4 hours)      | - [invalid FW: 141](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427%7C2024-04-18--19-01-36)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 140<br>- all lat active: 15<br>- no input all lat active: 5        |
| [a2153ee04e30ac3c](https://useradmin.comma.ai/?onebox=a2153ee04e30ac3c)<br><sub>TOYOTA_HIGHLANDER<br>5TDJGRFH6........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19                                              | 3 routes,<br>48 segments<br>(0.8 hours)        | - [missing ECU FW: 48](https://useradmin.comma.ai/?onebox=a2153ee04e30ac3c%7C2024-03-23--12-06-48)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=a2153ee04e30ac3c%7C2024-03-23--12-06-48)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 48<br>- all lat active: 8<br>- no input all lat active: 4          |
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFCG8........</sub>        | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18                                                        | 21 routes,<br>386 segments<br>(6.4 hours)      | - [car faulted: 10](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a%7C2024-04-10--14-57-01)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 386<br>- all lat active: 12<br>- no input all lat active: 4        |
| [d8e00d93d49817ea](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea)<br><sub>LEXUS_RX<br>2T2ZZMCA6........</sub>                   | LEXUS RX 2018 🆚<br>Lexus RX 2017-19                                                                              | 79 routes,<br>1310 segments<br>(21.8 hours)    | - [missing ECU FW: 557](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-17--08-31-24)<br>- [spotty FW: 557](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-17--08-31-24)                                                                                                                                                                                                                                                                                                                          | - valid torque params: 1181<br>- all lat active: 95<br>- no input all lat active: 55      |
| [0226b40cca56c9e6](https://useradmin.comma.ai/?onebox=0226b40cca56c9e6)<br><sub>HONDA_CIVIC_2022<br>2HGFE2F57........</sub>           | HONDA Civic 2022 🆚<br>Honda Civic 2022-23                                                                        | 2 routes,<br>18 segments<br>(0.3 hours)        | - [missing ECU FW: 18](https://useradmin.comma.ai/?onebox=0226b40cca56c9e6%7C2024-03-26--09-40-26)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0226b40cca56c9e6%7C2024-03-26--09-40-26)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 18                                                                 |
| [d031a8c98c8863da](https://useradmin.comma.ai/?onebox=d031a8c98c8863da)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 19 routes,<br>429 segments<br>(7.2 hours)      | - [missing ECU FW: 429](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-05--10-57-11)<br>- [segment too short (info): 9](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-20--12-27-55)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-05--10-57-11)                                                                                                                                                                                                    | - valid torque params: 422<br>- all lat active: 67<br>- no input all lat active: 25       |
| [251122482046c71b](https://useradmin.comma.ai/?onebox=251122482046c71b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 6 routes,<br>36 segments<br>(0.6 hours)        | - [missing ECU FW: 36](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--18-06-16)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--18-06-16)                                                                                                                                                                                                                                                                                                                    | - valid torque params: 31<br>- all lat active: 3<br>- no input all lat active: 2          |
| [9fafce4de77b8cdf](https://useradmin.comma.ai/?onebox=9fafce4de77b8cdf)<br><sub>GENESIS_G70_2020<br>KMTG74LE0........</sub>           | GENESIS G70 2019 🆚<br>Genesis G70 2020-21<br><sub>🎉 <b>New model year!</b> 🎉</sub>                             | 30 routes,<br>778 segments<br>(13.0 hours)     | - [spotty FW: 228](https://useradmin.comma.ai/?onebox=9fafce4de77b8cdf%7C2024-03-22--07-07-02)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 778<br>- all lat active: 303<br>- no input all lat active: 275     |
| [71d06cb96a5d802f](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f)<br><sub>HONDA_CIVIC_2022<br>19XFL1H87........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 27 routes,<br>307 segments<br>(5.1 hours)      | - [missing ECU FW: 70](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f%7C2024-03-25--19-35-14)<br>- [spotty FW: 237](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f%7C2024-03-28--17-02-45)<br>- [high lateral accel factor: 29](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f%7C2024-03-29--18-23-49)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=71d06cb96a5d802f%7C2024-03-25--19-35-14)                                                                                                 | - valid torque params: 260<br>- all lat active: 81<br>- no input all lat active: 52       |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>            | None 🆚<br>None                                                                                                   | 80 routes,<br>1150 segments<br>(19.2 hours)    | - [CAN invalid: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)                                                                                                                                                                                                                                                                                                                               | - valid torque params: 1149<br>- all lat active: 40<br>- no input all lat active: 17      |
| [214c417708d4eabc](https://useradmin.comma.ai/?onebox=214c417708d4eabc)<br><sub>HONDA_CIVIC_2022<br>2HGFE2F26........</sub>           | HONDA Civic 2024 🆚<br>Honda Civic 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>                             | 195 routes,<br>3119 segments<br>(52.0 hours)   | - [missing ECU FW: 1739](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-20--16-21-41)<br>- [spotty FW: 1739](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-20--16-21-41)<br>- [segment too short (info): 1](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-15--13-12-06)<br>- [CAN invalid: 1](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-15--13-12-06)                                                                                                       | - valid torque params: 3023<br>- all lat active: 338<br>- no input all lat active: 217    |
| [d15c6c91d28a861b](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H53........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 21 routes,<br>772 segments<br>(12.9 hours)     | - [missing ECU FW: 740](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [spotty FW: 32](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-17--22-52-19)<br>- [segment too short (info): 3](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [CAN invalid: 7](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18) | - valid torque params: 679<br>- all lat active: 334<br>- no input all lat active: 234     |
| [d49be4cedad6f71d](https://useradmin.comma.ai/?onebox=d49be4cedad6f71d)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFBG6........</sub>        | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18                                                        | 3 routes,<br>24 segments<br>(0.4 hours)        | - [car faulted: 2](https://useradmin.comma.ai/?onebox=d49be4cedad6f71d%7C2024-04-01--18-33-50)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 17                                                                 |
| [0dacabc563f7e7d7](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 144 routes,<br>2186 segments<br>(36.4 hours)   | - [missing ECU FW: 2186](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-03-27--14-40-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-03-27--14-40-40)                                                                                                                                                                                                                                                                                                                  | - valid torque params: 2186<br>- all lat active: 261<br>- no input all lat active: 179    |
| [0cfeef7447cc668a](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a)<br><sub>TOYOTA_RAV4_TSS2_2023<br>JTMDW3FV6........</sub>      | None 🆚<br>None                                                                                                   | 19 routes,<br>295 segments<br>(4.9 hours)      | - [missing ECU FW: 262](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a%7C2024-03-30--07-06-04)<br>- [spotty FW: 33](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a%7C2024-03-28--12-43-51)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0cfeef7447cc668a%7C2024-03-30--07-06-04)                                                                                                                                                                                                                  | - all lat active: 27<br>- no input all lat active: 9                                      |

Dongles to re-run category: `d8e00d93d49817ea 71d06cb96a5d802f d49be4cedad6f71d 8fc26118039f0a8e 734971c66100033f 0226b40cca56c9e6 9e7b03d47798346e c042beb296a531c3 11d207f3143e07b3 a2153ee04e30ac3c 23daff6c438612d2 22901377be496047 251122482046c71b 0dacabc563f7e7d7 a74cb70b7a19e427 ef8c34c763849757 61c374c8e5e59db3 d031a8c98c8863da 2da6c3d026c53b35 c88f65eeaee4003a 4e92a7e0078767c8 0cfeef7447cc668a 903ac8da1aa52026 d2245f33562396ab cc2b9c9f221f1812 214c417708d4eabc 9fafce4de77b8cdf fc4d8f4e5f8b353a 723b102eb5d8291e d15c6c91d28a861b 72c57a77995168b4`
</details>