### PR TITLE
Cabana:  bug fixes

### DIFF
--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -255,12 +255,12 @@ void MessageListModel::dbcModified() {
 void MessageListModel::sortItems(std::vector<MessageListModel::Item> &items) {
   auto compare = [this](const auto &l, const auto &r) {
     switch (sort_column) {
-      case Column::NAME: return l.name < r.name;
-      case Column::SOURCE: return l.id.source < r.id.source;
-      case Column::ADDRESS: return l.id.address < r.id.address;
-      case Column::NODE: return l.node < r.node;
-      case Column::FREQ: return can->lastMessage(l.id).freq < can->lastMessage(r.id).freq;
-      case Column::COUNT: return can->lastMessage(l.id).count < can->lastMessage(r.id).count;
+      case Column::NAME: return std::tie(l.name, l.id) < std::tie(r.name, r.id);
+      case Column::SOURCE: return std::tie(l.id.source, l.id.address) < std::tie(r.id.source, r.id.address);
+      case Column::ADDRESS: return std::tie(l.id.address, l.id.source) < std::tie(r.id.address, r.id.source);
+      case Column::NODE: return std::tie(l.node, l.id) < std::tie(r.node, r.id);
+      case Column::FREQ: return std::tie(can->lastMessage(l.id).freq, l.id) < std::tie(can->lastMessage(r.id).freq, r.id);
+      case Column::COUNT: return std::tie(can->lastMessage(l.id).count, l.id) < std::tie(can->lastMessage(r.id).count, r.id);
       default: return false; // Default case to suppress compiler warning
     }
   };

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -151,6 +151,7 @@ QWidget *VideoWidget::createCameraWidget() {
   setMaximumTime(can->totalSeconds());
   QObject::connect(slider, &QSlider::sliderReleased, [this]() { can->seekTo(slider->currentSecond()); });
   QObject::connect(slider, &Slider::updateMaximumTime, this, &VideoWidget::setMaximumTime, Qt::QueuedConnection);
+  QObject::connect(can, &AbstractStream::eventsMerged, [this]() { slider->update(); });
   QObject::connect(static_cast<ReplayStream*>(can), &ReplayStream::qLogLoaded, slider, &Slider::parseQLog);
   QObject::connect(cam_widget, &CameraWidget::clicked, []() { can->pause(!can->isPaused()); });
   QObject::connect(cam_widget, &CameraWidget::vipcAvailableStreamsUpdated, this, &VideoWidget::vipcAvailableStreamsUpdated);
@@ -405,7 +406,7 @@ void InfoLabel::paintEvent(QPaintEvent *event) {
       font.setPixelSize(11);
       p.setFont(font);
     }
-    QRect text_rect = rect().adjusted(2, 2, -2, -2);
+    QRect text_rect = rect().adjusted(1, 1, -1, -1);
     QRect r = p.fontMetrics().boundingRect(text_rect, Qt::AlignTop | Qt::AlignHCenter | Qt::TextWordWrap, text);
     p.fillRect(text_rect.left(), r.top(), text_rect.width(), r.height(), color);
     p.drawText(text_rect, Qt::AlignTop | Qt::AlignHCenter | Qt::TextWordWrap, text);


### PR DESCRIPTION
1. Fix SIGSEGV due to thread race conditions after seeking. introduced by https://github.com/commaai/openpilot/pull/32121
2. Stabilize message list sorting by adding Message ID as a secondary sorting factor.
3. Remove extra white space around on-road alert messages.
4. Resolve the issue where the timeline fails to update promptly after segment loading when playback is paused