### PR TITLE
29344 cython stub generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ build/
 
 poetry.toml
 Pipfile
+
+*.pyi

--- a/scripts/parse_cython_to_stub.py
+++ b/scripts/parse_cython_to_stub.py
@@ -3,7 +3,7 @@ import fnmatch
 import argparse
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from third_party.CythonPEG import cython_peg as cp
+from openpilot.third_party.CythonPEG import cython_peg as cp
 
 extensions = ['*.pyx', '*.pxd']
 dirs_to_ignore = ['openpilot', 'third_party']
@@ -24,13 +24,13 @@ def read_parse_and_write(file_path):
     stubs_path = new_path + '/stubs'
     os.makedirs(stubs_path, exist_ok=True)
     pyi_file_path =  stubs_path + '/' + file_path[last_slash_index + 1:] + '.pyi'
-    
+
     with open(pyi_file_path, mode='w+') as f:
         f.write(stub_file)
 
 def has_openpilot(path):
-    for dir in os.listdir(path):
-        if dir == 'openpilot':
+    for d in os.listdir(path):
+        if d == 'openpilot':
             return True
     return False
 

--- a/scripts/parse_cython_to_stub.py
+++ b/scripts/parse_cython_to_stub.py
@@ -21,9 +21,7 @@ def read_parse_and_write(file_path):
     file_path = os.path.splitext(file_path)[0]
     last_slash_index = file_path.rfind('/')
     new_path = file_path[:last_slash_index]
-    stubs_path = new_path + '/stubs'
-    os.makedirs(stubs_path, exist_ok=True)
-    pyi_file_path =  stubs_path + '/' + file_path[last_slash_index + 1:] + '.pyi'
+    pyi_file_path =  new_path + '/' + file_path[last_slash_index + 1:] + '.pyi'
 
     with open(pyi_file_path, mode='w+') as f:
         f.write(stub_file)
@@ -44,7 +42,7 @@ def parse_all_files():
     else:
         openpilot_path = current_path[:last_index-1]
 
-    cp.set_indent(" ")
+    cp.set_indent("  ")
     for root, dirs, files in os.walk(openpilot_path):
         dirs[:] = [d for d in dirs if not (d.startswith('.') or d in dirs_to_ignore)]
         for filename in files:

--- a/scripts/parse_cython_to_stub.py
+++ b/scripts/parse_cython_to_stub.py
@@ -1,0 +1,62 @@
+import os
+import fnmatch
+import argparse
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from third_party.CythonPEG import cython_peg as cp
+
+extensions = ['*.pyx', '*.pxd']
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('files', type=str, nargs='*', default=[], help='Path(s) to the .pyx or .pxd file(s).')
+    return parser.parse_args()
+
+def read_parse_and_write(file_path):
+    with open(file_path, 'r') as file:
+        cython_tokens = file.read()
+
+    stub_file, unparsed_tokens = cp.cython_string_2_stub(cython_tokens)
+    file_path = os.path.splitext(file_path)[0]
+    last_slash_index = file_path.rfind('/')
+    new_path = file_path[:last_slash_index]
+    pyi_file_path = new_path + '/stubs/' + file_path[last_slash_index + 1:] + '.pyi'
+
+    with open(pyi_file_path, mode='w+') as f:
+        f.write(stub_file)
+
+def has_openpilot(path):
+    for dir in os.listdir(path):
+        if dir == 'openpilot':
+            return True
+    return False
+
+def parse_all_files():
+    current_path = os.getcwd()
+    last_index = current_path.rfind('openpilot')
+    last_openpilot_path = current_path[:last_index+9]
+
+    if(has_openpilot(last_openpilot_path)):
+        openpilot_path = last_openpilot_path
+    else:
+        openpilot_path = current_path[:last_index-1]
+
+    cp.set_indent(" ")
+    for root, dirs, files in os.walk(openpilot_path):
+        dirs[:] = [d for d in dirs if not (d.startswith('.') or d == 'openpilot' or d == 'CythonPEG')]
+        for filename in files:
+            if any(fnmatch.fnmatch(filename, extension) for extension in extensions):
+                file_path = os.path.join(root, filename)
+                read_parse_and_write(file_path)
+
+def parse_one_or_more_files(files):
+    for file in files:
+        file_path = os.path.join(os.getcwd(), file)
+        read_parse_and_write(file_path)
+
+if __name__ == '__main__':
+    args = parse_arguments()
+    if args.files:
+        parse_one_or_more_files(args.files)
+    else:
+        parse_all_files()

--- a/scripts/parse_cython_to_stub.py
+++ b/scripts/parse_cython_to_stub.py
@@ -20,7 +20,9 @@ def read_parse_and_write(file_path):
     file_path = os.path.splitext(file_path)[0]
     last_slash_index = file_path.rfind('/')
     new_path = file_path[:last_slash_index]
-    pyi_file_path = new_path + '/stubs/' + file_path[last_slash_index + 1:] + '.pyi'
+    stubs_path = new_path + '/stubs'
+    os.makedirs(stubs_path, exist_ok=True)
+    pyi_file_path =  stubs_path + '/' + file_path[last_slash_index + 1:] + '.pyi'
 
     with open(pyi_file_path, mode='w+') as f:
         f.write(stub_file)

--- a/scripts/parse_cython_to_stub.py
+++ b/scripts/parse_cython_to_stub.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from third_party.CythonPEG import cython_peg as cp
 
 extensions = ['*.pyx', '*.pxd']
+dirs_to_ignore = ['openpilot', 'third_party']
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
@@ -23,7 +24,7 @@ def read_parse_and_write(file_path):
     stubs_path = new_path + '/stubs'
     os.makedirs(stubs_path, exist_ok=True)
     pyi_file_path =  stubs_path + '/' + file_path[last_slash_index + 1:] + '.pyi'
-
+    
     with open(pyi_file_path, mode='w+') as f:
         f.write(stub_file)
 
@@ -45,7 +46,7 @@ def parse_all_files():
 
     cp.set_indent(" ")
     for root, dirs, files in os.walk(openpilot_path):
-        dirs[:] = [d for d in dirs if not (d.startswith('.') or d == 'openpilot' or d == 'CythonPEG')]
+        dirs[:] = [d for d in dirs if not (d.startswith('.') or d in dirs_to_ignore)]
         for filename in files:
             if any(fnmatch.fnmatch(filename, extension) for extension in extensions):
                 file_path = os.path.join(root, filename)


### PR DESCRIPTION
Hey @sshane, @jnewb1, @adeebshihadeh,  

[CythonPEG](https://github.com/RaubCamaioni/CythonPEG) is a parser that was specifically developed for the automatic generation of Python stub files from Cython files. I forked it and implemented several changes and additions to enhance its usability and functionality. Below is the summary of its functionalities including both the original features and the ones that have been added or modified:
- Object definition,
- Expression definition,
- Class definitions,
- Function definitions,
- Struct definition,
- Enum definitions, 
- Alias definition,
- Import statement definition, 
- External declaration definition, 
- Compiler directives definition, 
- Docstring definition,
- Recursive definitions. 

I've also implemented a script that utilizes this parser to generate stubs (.pyi) from Cython files (.pyx, .pxd). It has the capability to parse either all relevant Cython files within the openpilot repository or specific ones provided as arguments via the command line. I've also utilized the script to generate stubs and place each of them in a 'stubs' directory alongisde the original file. I'm looking forward to your feedback to ensure that this is something you wanted for this issue. Please let me know if there are any changes you would like me to make.

Thanks! 