### PR TITLE
VW: Add 3C chassis code for Passat

### DIFF
--- a/selfdrive/car/volkswagen/fingerprints.py
+++ b/selfdrive/car/volkswagen/fingerprints.py
@@ -458,6 +458,7 @@ FW_VERSIONS = {
       b'\xf1\x873Q0907572C \xf1\x890196',
       b'\xf1\x875Q0907572P \xf1\x890682',
       b'\xf1\x875Q0907572R \xf1\x890771',
+      b'\xf1\x875Q0907572S \xf1\x890780',
     ],
   },
   CAR.VOLKSWAGEN_PASSAT_NMS: {

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -278,7 +278,7 @@ class CAR(Platforms):
       VWCarDocs("Volkswagen Passat GTE 2015-22"),
     ],
     VolkswagenCarSpecs(mass=1551, wheelbase=2.79),
-    chassis_codes={"3G"},
+    chassis_codes={"3C", "3G"},
     wmis={WMI.VOLKSWAGEN_EUROPE_CAR},
   )
   VOLKSWAGEN_PASSAT_NMS = VolkswagenPQPlatformConfig(


### PR DESCRIPTION
For 340ebc76c286aedc. Looks like the previous gen platform code (2005), but Australia is using it in their VINs. https://www.service.transport.qld.gov.au/checkrego claims it's a `2018 VOLKSWAGEN PASSAT WAGON`.