### PR TITLE
cabana: refactor HistoryLog for simplification and enhancements

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -142,7 +142,7 @@ void cabana::Signal::update() {
   precision = std::max(num_decimals(factor), num_decimals(offset));
 }
 
-QString cabana::Signal::formatValue(double value) const {
+QString cabana::Signal::formatValue(double value, bool with_unit) const {
   // Show enum string
   int64_t raw_value = round((value - offset) / factor);
   for (const auto &[val, desc] : val_desc) {
@@ -152,7 +152,7 @@ QString cabana::Signal::formatValue(double value) const {
   }
 
   QString val_str = QString::number(value, 'f', precision);
-  if (!unit.isEmpty()) {
+  if (with_unit && !unit.isEmpty()) {
     val_str += " " + unit;
   }
   return val_str;

--- a/tools/cabana/dbc/dbc.h
+++ b/tools/cabana/dbc/dbc.h
@@ -55,7 +55,7 @@ public:
   Signal(const Signal &other) = default;
   void update();
   bool getValue(const uint8_t *data, size_t data_size, double *val) const;
-  QString formatValue(double value) const;
+  QString formatValue(double value, bool with_unit = true) const;
   bool operator==(const cabana::Signal &other) const;
   inline bool operator!=(const cabana::Signal &other) const { return !(*this == other); }
 

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -10,61 +10,49 @@
 #include "tools/cabana/utils/export.h"
 
 QVariant HistoryLogModel::data(const QModelIndex &index, int role) const {
-  const bool show_signals = display_signals_mode && sigs.size() > 0;
   const auto &m = messages[index.row()];
+  const int col = index.column();
   if (role == Qt::DisplayRole) {
-    if (index.column() == 0) {
-      return QString::number((m.mono_time / (double)1e9) - can->routeStartTime(), 'f', 2);
-    }
-    int i = index.column() - 1;
-    return show_signals ? QString::number(m.sig_values[i], 'f', sigs[i]->precision) : QString();
-  } else if (role == ColorsRole) {
-    return QVariant::fromValue((void *)(&m.colors));
-  } else if (role == BytesRole) {
-    return QVariant::fromValue((void *)(&m.data));
+    if (col == 0) return QString::number((m.mono_time / (double)1e9) - can->routeStartTime(), 'f', 3);
+    if (!isHexMode()) return sigs[col - 1]->formatValue(m.sig_values[col - 1], false);
   } else if (role == Qt::TextAlignmentRole) {
     return (uint32_t)(Qt::AlignRight | Qt::AlignVCenter);
+  }
+
+  if (isHexMode() && col == 1) {
+    if (role == ColorsRole) return QVariant::fromValue((void *)(&m.colors));
+    if (role == BytesRole) return QVariant::fromValue((void *)(&m.data));
   }
   return {};
 }
 
 void HistoryLogModel::setMessage(const MessageId &message_id) {
   msg_id = message_id;
+  reset();
 }
 
-void HistoryLogModel::refresh(bool fetch_message) {
+void HistoryLogModel::reset() {
   beginResetModel();
   sigs.clear();
   if (auto dbc_msg = dbc()->msg(msg_id)) {
     sigs = dbc_msg->getSignals();
   }
-  last_fetch_time = 0;
-  has_more_data = true;
   messages.clear();
   hex_colors = {};
-  if (fetch_message) {
-    updateState();
-  }
   endResetModel();
+  setFilter(0, "", nullptr);
 }
 
 QVariant HistoryLogModel::headerData(int section, Qt::Orientation orientation, int role) const {
   if (orientation == Qt::Horizontal) {
-    const bool show_signals = display_signals_mode && !sigs.empty();
     if (role == Qt::DisplayRole || role == Qt::ToolTipRole) {
-      if (section == 0) {
-        return "Time";
-      }
-      if (show_signals) {
-        QString name = sigs[section - 1]->name;
-        if (!sigs[section - 1]->unit.isEmpty()) {
-          name += QString(" (%1)").arg(sigs[section - 1]->unit);
-        }
-        return name;
-      } else {
-        return "Data";
-      }
-    } else if (role == Qt::BackgroundRole && section > 0 && show_signals) {
+      if (section == 0) return "Time";
+      if (isHexMode()) return "Data";
+
+      QString name = sigs[section - 1]->name;
+      QString unit = sigs[section - 1]->unit;
+      return unit.isEmpty() ? name : QString("%1 (%2)").arg(name, unit);
+    } else if (role == Qt::BackgroundRole && section > 0 && !isHexMode()) {
       // Alpha-blend the signal color with the background to ensure contrast
       QColor sigColor = sigs[section - 1]->color;
       sigColor.setAlpha(128);
@@ -74,110 +62,80 @@ QVariant HistoryLogModel::headerData(int section, Qt::Orientation orientation, i
   return {};
 }
 
-void HistoryLogModel::setDynamicMode(int state) {
-  dynamic_mode = state != 0;
-  refresh();
-}
-
-void HistoryLogModel::setDisplayType(int type) {
-  display_signals_mode = type == 0;
-  refresh();
-}
-
-void HistoryLogModel::segmentsMerged() {
-  if (!dynamic_mode) {
-    has_more_data = true;
-  }
+void HistoryLogModel::setHexMode(bool hex) {
+  hex_mode = hex;
+  reset();
 }
 
 void HistoryLogModel::setFilter(int sig_idx, const QString &value, std::function<bool(double, double)> cmp) {
   filter_sig_idx = sig_idx;
   filter_value = value.toDouble();
   filter_cmp = value.isEmpty() ? nullptr : cmp;
+  updateState(true);
 }
 
-void HistoryLogModel::updateState() {
-  uint64_t current_time = (can->lastMessage(msg_id).ts + can->routeStartTime()) * 1e9 + 1;
-  auto new_msgs = dynamic_mode ? fetchData(current_time, last_fetch_time) : fetchData(0);
-  if (!new_msgs.empty()) {
-    beginInsertRows({}, 0, new_msgs.size() - 1);
-    messages.insert(messages.begin(), std::move_iterator(new_msgs.begin()), std::move_iterator(new_msgs.end()));
-    endInsertRows();
+void HistoryLogModel::updateState(bool clear) {
+  if (clear && !messages.empty()) {
+    beginRemoveRows({}, 0, messages.size() - 1);
+    messages.clear();
+    endRemoveRows();
   }
-  has_more_data = new_msgs.size() >= batch_size;
-  last_fetch_time = current_time;
+  uint64_t current_time = (can->lastMessage(msg_id).ts + can->routeStartTime()) * 1e9 + 1;
+  fetchData(messages.begin(), current_time, messages.empty() ? 0 : messages.front().mono_time);
+}
+
+bool HistoryLogModel::canFetchMore(const QModelIndex &parent) const {
+  const auto &events = can->events(msg_id);
+  return !events.empty() && !messages.empty() && messages.back().mono_time > events.front()->mono_time;
 }
 
 void HistoryLogModel::fetchMore(const QModelIndex &parent) {
-  if (!messages.empty()) {
-    auto new_msgs = fetchData(messages.back().mono_time);
-    if (!new_msgs.empty()) {
-      beginInsertRows({}, messages.size(), messages.size() + new_msgs.size() - 1);
-      messages.insert(messages.end(), std::move_iterator(new_msgs.begin()), std::move_iterator(new_msgs.end()));
-      endInsertRows();
-    }
-    has_more_data = new_msgs.size() >= batch_size;
-  }
+  if (!messages.empty())
+    fetchData(messages.end(), messages.back().mono_time, 0);
 }
 
-template <class InputIt>
-std::deque<HistoryLogModel::Message> HistoryLogModel::fetchData(InputIt first, InputIt last, uint64_t min_time) {
-  std::deque<HistoryLogModel::Message> msgs;
+void HistoryLogModel::fetchData(std::deque<Message>::iterator insert_pos, uint64_t from_time, uint64_t min_time) {
+  const auto &events = can->events(msg_id);
+  auto first = std::upper_bound(events.rbegin(), events.rend(), from_time, [](uint64_t ts, auto e) {
+    return ts > e->mono_time;
+  });
+
+  std::vector<HistoryLogModel::Message> msgs;
   std::vector<double> values(sigs.size());
-  for (; first != last && (*first)->mono_time > min_time; ++first) {
+  msgs.reserve(batch_size);
+  for (; first != events.rend() && (*first)->mono_time > min_time; ++first) {
     const CanEvent *e = *first;
     for (int i = 0; i < sigs.size(); ++i) {
       sigs[i]->getValue(e->dat, e->size, &values[i]);
     }
     if (!filter_cmp || filter_cmp(values[filter_sig_idx], filter_value)) {
-      auto &m = msgs.emplace_back();
-      m.mono_time = e->mono_time;
-      m.data.assign(e->dat, e->dat + e->size);
-      m.sig_values = values;
+       msgs.emplace_back(Message{e->mono_time, values, {e->dat, e->dat + e->size}});
       if (msgs.size() >= batch_size && min_time == 0) {
-        return msgs;
+        break;
       }
     }
   }
-  return msgs;
-}
 
-std::deque<HistoryLogModel::Message> HistoryLogModel::fetchData(uint64_t from_time, uint64_t min_time) {
-  const auto &events = can->events(msg_id);
-  const auto freq = can->lastMessage(msg_id).freq;
-  const bool update_colors = !display_signals_mode || sigs.empty();
-  const std::vector<uint8_t> no_mask;
-  const auto speed = can->getSpeed();
-  if (dynamic_mode) {
-    auto first = std::upper_bound(events.rbegin(), events.rend(), from_time, [](uint64_t ts, auto e) {
-      return ts > e->mono_time;
-    });
-    auto msgs = fetchData(first, events.rend(), min_time);
-    if (update_colors && (min_time > 0 || messages.empty())) {
-      for (auto it = msgs.rbegin(); it != msgs.rend(); ++it) {
-        hex_colors.compute(msg_id, it->data.data(), it->data.size(), it->mono_time / (double)1e9, speed, no_mask, freq);
-        it->colors = hex_colors.colors;
+  if (!msgs.empty()) {
+    if (isHexMode() && (min_time > 0 || messages.empty())) {
+      const auto freq = can->lastMessage(msg_id).freq;
+      const std::vector<uint8_t> no_mask;
+      for (auto &m : msgs) {
+        hex_colors.compute(msg_id, m.data.data(), m.data.size(), m.mono_time / (double)1e9, can->getSpeed(), no_mask, freq);
+        m.colors = hex_colors.colors;
       }
     }
-    return msgs;
-  } else {
-    assert(min_time == 0);
-    auto first = std::upper_bound(events.cbegin(), events.cend(), from_time, CompareCanEvent());
-    auto msgs = fetchData(first, events.cend(), 0);
-    if (update_colors) {
-      for (auto it = msgs.begin(); it != msgs.end(); ++it) {
-        hex_colors.compute(msg_id, it->data.data(), it->data.size(), it->mono_time / (double)1e9, speed, no_mask, freq);
-        it->colors = hex_colors.colors;
-      }
-    }
-    return msgs;
+    int pos = std::distance(messages.begin(), insert_pos);
+    beginInsertRows({}, pos , pos + msgs.size() - 1);
+    messages.insert(insert_pos, std::move_iterator(msgs.begin()), std::move_iterator(msgs.end()));
+    endInsertRows();
   }
 }
 
 // HeaderView
 
 QSize HeaderView::sectionSizeFromContents(int logicalIndex) const {
-  static const QSize time_col_size = fontMetrics().boundingRect({0, 0, 200, 200}, defaultAlignment(), "000000.000").size() + QSize(10, 6);
+  static const QSize time_col_size = fontMetrics().size(Qt::TextSingleLine, "000000.000") + QSize(10, 6);
   if (logicalIndex == 0) {
     return time_col_size;
   } else {
@@ -220,8 +178,7 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   filter_layout->addWidget(value_edit = new QLineEdit(this));
   h->addWidget(filters_widget);
   h->addStretch(0);
-  h->addWidget(dynamic_mode = new QCheckBox(tr("Dynamic")), 0, Qt::AlignRight);
-  ToolButton *export_btn = new ToolButton("filetype-csv", tr("Export to CSV file..."));
+  export_btn = new ToolButton("filetype-csv", tr("Export to CSV file..."));
   h->addWidget(export_btn, 0, Qt::AlignRight);
 
   display_type_cb->addItems({"Signal", "Hex"});
@@ -229,8 +186,6 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   comp_box->addItems({">", "=", "!=", "<"});
   value_edit->setClearButtonEnabled(true);
   value_edit->setValidator(new DoubleValidator(this));
-  dynamic_mode->setChecked(true);
-  dynamic_mode->setEnabled(!can->liveStreaming());
 
   main_layout->addWidget(toolbar);
   QFrame *line = new QFrame(this);
@@ -238,52 +193,38 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   main_layout->addWidget(line);
   main_layout->addWidget(logs = new QTableView(this));
   logs->setModel(model = new HistoryLogModel(this));
-  delegate = new MessageBytesDelegate(this);
+  logs->setItemDelegate(delegate = new MessageBytesDelegate(this));
   logs->setHorizontalHeader(new HeaderView(Qt::Horizontal, this));
   logs->horizontalHeader()->setDefaultAlignment(Qt::AlignRight | (Qt::Alignment)Qt::TextWordWrap);
   logs->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
   logs->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
   logs->verticalHeader()->setDefaultSectionSize(delegate->sizeForBytes(8).height());
-  logs->verticalHeader()->setVisible(false);
   logs->setFrameShape(QFrame::NoFrame);
 
-  QObject::connect(display_type_cb, qOverload<int>(&QComboBox::activated), [this](int index) {
-    logs->setItemDelegateForColumn(1, index == 1 ? delegate : nullptr);
-    model->setDisplayType(index);
-  });
-  QObject::connect(dynamic_mode, &QCheckBox::stateChanged, model, &HistoryLogModel::setDynamicMode);
-  QObject::connect(signals_cb, SIGNAL(activated(int)), this, SLOT(setFilter()));
-  QObject::connect(comp_box, SIGNAL(activated(int)), this, SLOT(setFilter()));
-  QObject::connect(value_edit, &QLineEdit::textChanged, this, &LogsWidget::setFilter);
+  QObject::connect(display_type_cb, qOverload<int>(&QComboBox::activated), model, &HistoryLogModel::setHexMode);
+  QObject::connect(signals_cb, SIGNAL(activated(int)), this, SLOT(filterChanged()));
+  QObject::connect(comp_box, SIGNAL(activated(int)), this, SLOT(filterChanged()));
+  QObject::connect(value_edit, &QLineEdit::textEdited, this, &LogsWidget::filterChanged);
   QObject::connect(export_btn, &QToolButton::clicked, this, &LogsWidget::exportToCSV);
-  QObject::connect(can, &AbstractStream::seekedTo, model, &HistoryLogModel::refresh);
-  QObject::connect(dbc(), &DBCManager::DBCFileChanged, this, &LogsWidget::refresh);
-  QObject::connect(UndoStack::instance(), &QUndoStack::indexChanged, this, &LogsWidget::refresh);
-  QObject::connect(can, &AbstractStream::eventsMerged, model, &HistoryLogModel::segmentsMerged);
+  QObject::connect(can, &AbstractStream::seekedTo, model, &HistoryLogModel::reset);
+  QObject::connect(dbc(), &DBCManager::DBCFileChanged, model, &HistoryLogModel::reset);
+  QObject::connect(UndoStack::instance(), &QUndoStack::indexChanged, model, &HistoryLogModel::reset);
+  QObject::connect(model, &HistoryLogModel::modelReset, this, &LogsWidget::modelReset);
+  QObject::connect(model, &HistoryLogModel::rowsInserted, [this]() { export_btn->setEnabled(true); });
 }
 
-void LogsWidget::setMessage(const MessageId &message_id) {
-  model->setMessage(message_id);
-  refresh();
-}
-
-void LogsWidget::refresh() {
-  model->setFilter(0, "", nullptr);
-  model->refresh(isVisible());
-  bool has_signal = model->sigs.size();
-  if (has_signal) {
-    signals_cb->clear();
-    for (auto s : model->sigs) {
-      signals_cb->addItem(s->name);
-    }
+void LogsWidget::modelReset() {
+  signals_cb->clear();
+  for (auto s : model->sigs) {
+    signals_cb->addItem(s->name);
   }
-  logs->setItemDelegateForColumn(1, !has_signal || display_type_cb->currentIndex() == 1 ? delegate : nullptr);
+  export_btn->setEnabled(false);
   value_edit->clear();
   comp_box->setCurrentIndex(0);
-  filters_widget->setVisible(has_signal);
+  filters_widget->setVisible(!model->sigs.empty());
 }
 
-void LogsWidget::setFilter() {
+void LogsWidget::filterChanged() {
   if (value_edit->text().isEmpty() && !value_edit->isModified()) return;
 
   std::function<bool(double, double)> cmp = nullptr;
@@ -294,19 +235,6 @@ void LogsWidget::setFilter() {
     case 3: cmp = std::less<double>{}; break;
   }
   model->setFilter(signals_cb->currentIndex(), value_edit->text(), cmp);
-  model->refresh();
-}
-
-void LogsWidget::updateState() {
-  if (isVisible() && dynamic_mode->isChecked()) {
-    model->updateState();
-  }
-}
-
-void LogsWidget::showEvent(QShowEvent *event) {
-  if (dynamic_mode->isChecked() || model->canFetchMore({}) && model->rowCount() == 0) {
-    model->refresh();
-  }
 }
 
 void LogsWidget::exportToCSV() {
@@ -314,7 +242,7 @@ void LogsWidget::exportToCSV() {
   QString fn = QFileDialog::getSaveFileName(this, QString("Export %1 to CSV file").arg(msgName(model->msg_id)),
                                             dir, tr("csv (*.csv)"));
   if (!fn.isEmpty()) {
-    const bool export_signals = model->display_signals_mode && model->sigs.size() > 0;
-    export_signals ? utils::exportSignalsToCSV(fn, model->msg_id) : utils::exportToCSV(fn, model->msg_id);
+    model->isHexMode() ? utils::exportToCSV(fn, model->msg_id)
+                       : utils::exportSignalsToCSV(fn, model->msg_id);
   }
 }

--- a/tools/cabana/historylog.h
+++ b/tools/cabana/historylog.h
@@ -3,7 +3,6 @@
 #include <deque>
 #include <vector>
 
-#include <QCheckBox>
 #include <QComboBox>
 #include <QHeaderView>
 #include <QLineEdit>
@@ -11,7 +10,6 @@
 
 #include "tools/cabana/dbc/dbcmanager.h"
 #include "tools/cabana/streams/abstractstream.h"
-#include "tools/cabana/utils/util.h"
 
 class HeaderView : public QHeaderView {
 public:
@@ -26,24 +24,18 @@ class HistoryLogModel : public QAbstractTableModel {
 public:
   HistoryLogModel(QObject *parent) : QAbstractTableModel(parent) {}
   void setMessage(const MessageId &message_id);
-  void updateState();
+  void updateState(bool clear = false);
   void setFilter(int sig_idx, const QString &value, std::function<bool(double, double)> cmp);
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
   void fetchMore(const QModelIndex &parent) override;
-  inline bool canFetchMore(const QModelIndex &parent) const override { return has_more_data; }
+  bool canFetchMore(const QModelIndex &parent) const override;
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return messages.size(); }
-  int columnCount(const QModelIndex &parent = QModelIndex()) const override {
-    return display_signals_mode && !sigs.empty() ? sigs.size() + 1 : 2;
-  }
-  void refresh(bool fetch_message = true);
+  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return !isHexMode() ? sigs.size() + 1 : 2; }
+  inline bool isHexMode() const { return sigs.empty() || hex_mode; }
+  void reset();
+  void setHexMode(bool hex_mode);
 
-public slots:
-  void setDisplayType(int type);
-  void setDynamicMode(int state);
-  void segmentsMerged();
-
-public:
   struct Message {
     uint64_t mono_time = 0;
     std::vector<double> sig_values;
@@ -51,22 +43,17 @@ public:
     std::vector<QColor> colors;
   };
 
-  template <class InputIt>
-  std::deque<HistoryLogModel::Message> fetchData(InputIt first, InputIt last, uint64_t min_time);
-  std::deque<Message> fetchData(uint64_t from_time, uint64_t min_time = 0);
+  void fetchData(std::deque<Message>::iterator insert_pos, uint64_t from_time, uint64_t min_time);
 
   MessageId msg_id;
   CanData hex_colors;
-  bool has_more_data = true;
   const int batch_size = 50;
   int filter_sig_idx = -1;
   double filter_value = 0;
-  uint64_t last_fetch_time = 0;
   std::function<bool(double, double)> filter_cmp = nullptr;
   std::deque<Message> messages;
   std::vector<cabana::Signal *> sigs;
-  bool dynamic_mode = true;
-  bool display_signals_mode = true;
+  bool hex_mode = true;
 };
 
 class LogsWidget : public QFrame {
@@ -74,22 +61,21 @@ class LogsWidget : public QFrame {
 
 public:
   LogsWidget(QWidget *parent);
-  void setMessage(const MessageId &message_id);
-  void updateState();
-  void showEvent(QShowEvent *event) override;
+  void setMessage(const MessageId &message_id) { model->setMessage(message_id); }
+  void updateState() { model->updateState(); }
+  void showEvent(QShowEvent *event) override { model->updateState(true); }
 
 private slots:
-  void setFilter();
+  void filterChanged();
   void exportToCSV();
+  void modelReset();
 
 private:
-  void refresh();
-
   QTableView *logs;
   HistoryLogModel *model;
-  QCheckBox *dynamic_mode;
   QComboBox *signals_cb, *comp_box, *display_type_cb;
   QLineEdit *value_edit;
   QWidget *filters_widget;
+  ToolButton *export_btn;
   MessageBytesDelegate *delegate;
 };

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -137,9 +137,11 @@ void AbstractStream::updateLastMsgsTo(double sec) {
       auto prev = std::prev(it);
       double ts = (*prev)->mono_time / 1e9 - routeStartTime();
       auto &m = msgs[id];
-      // Keep last changes
+      // Keep suppressed bits.
       if (auto old_m = messages_.find(id); old_m != messages_.end()) {
-        m.last_changes = old_m->second.last_changes;
+        std::transform(old_m->second.last_changes.cbegin(), old_m->second.last_changes.cend(),
+                       std::back_inserter(m.last_changes),
+                       [](const auto &change) { return CanData::ByteLastChange{.suppressed = change.suppressed}; });
       }
       m.compute(id, (*prev)->dat, (*prev)->size, ts, getSpeed(), {});
       m.count = std::distance(ev.begin(), prev) + 1;


### PR DESCRIPTION
This PR focus on simplifying the HistoryLog code, which has remained largely unchanged since its initial release and is quite messy. It also introducing several improvements:

1. Time precision has been increased from two to three decimal places to match the precision used elsewhere in Cabana.
2. Display meaningful value descriptors instead of raw values.
3. Disable the export button when there is no data available.
   ![2024-04-23_22-43](https://github.com/commaai/openpilot/assets/27770/67784dd5-db56-4de0-a79e-4f32bfae07df)
5. Fixed the issue where the initial active byte color values were incorrect after seeking.
6. Fixed a bug where `canFetchMore()` incorrectly returned true when there was no more data available.
7. Improved the performance of the `fetchData()` function.