### PR TITLE
ui: simplify speed and cruise speed updating

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -25,7 +25,6 @@ private:
   QString speedUnit;
   float setSpeed;
   float speedLimit;
-  bool is_cruise_set = false;
   bool is_metric = false;
   bool dmActive = false;
   bool hideBottomIcons = false;
@@ -33,7 +32,6 @@ private:
   float dm_fade_state = 1.0;
   bool has_us_speed_limit = false;
   bool has_eu_speed_limit = false;
-  bool v_ego_cluster_seen = false;
   int status = STATUS_DISENGAGED;
   std::unique_ptr<PubMaster> pm;
 


### PR DESCRIPTION
1. Update the speed and cruise speed within the `if (sm.alive("controlsState")) {}` block. Remove multiple ternary expressions used to check their validity, along with a custom invalid value: SET_SPEED_NA.
2. Remove the unnecessary variable **v_ego_cluster_seen**, as the value for old routes is always 0. using `std::max` is sufficient to ensure compatibility with old routes.
3. Remove variable **is_cruise_set**,  and use `setSpeed > 0` instead.
