### PR TITLE
ui/cameraview: merge EGL Image Clearing code into `clearEGLImages()` 

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -6,14 +6,6 @@
 #include <GLES3/gl3.h>
 #endif
 
-#include <cmath>
-#include <set>
-#include <string>
-#include <utility>
-
-#include <QOpenGLBuffer>
-#include <QOffscreenSurface>
-
 namespace {
 
 const char frame_vertex_shader[] =
@@ -197,15 +189,7 @@ void CameraWidget::stopVipcThread() {
     vipc_thread = nullptr;
   }
 
-#ifdef QCOM2
-  EGLDisplay egl_display = eglGetCurrentDisplay();
-  assert(egl_display != EGL_NO_DISPLAY);
-  for (auto &pair : egl_images) {
-    eglDestroyImageKHR(egl_display, pair.second);
-    assert(eglGetError() == EGL_SUCCESS);
-  }
-  egl_images.clear();
-#endif
+  clearEGLImages();
 }
 
 void CameraWidget::availableStreamsUpdated(std::set<VisionStreamType> streams) {
@@ -336,12 +320,7 @@ void CameraWidget::vipcConnected(VisionIpcClient *vipc_client) {
   stream_stride = vipc_client->buffers[0].stride;
 
 #ifdef QCOM2
-  EGLDisplay egl_display = eglGetCurrentDisplay();
-  assert(egl_display != EGL_NO_DISPLAY);
-  for (auto &pair : egl_images) {
-    eglDestroyImageKHR(egl_display, pair.second);
-  }
-  egl_images.clear();
+  clearEGLImages();
 
   for (int i = 0; i < vipc_client->num_buffers; i++) {  // import buffers into OpenGL
     int fd = dup(vipc_client->buffers[i].fd);  // eglDestroyImageKHR will close, so duplicate
@@ -434,4 +413,16 @@ void CameraWidget::clearFrames() {
   std::lock_guard lk(frame_lock);
   frames.clear();
   available_streams.clear();
+}
+
+
+void CameraWidget::clearEGLImages() {
+#ifdef QCOM2
+  EGLDisplay egl_display = eglGetCurrentDisplay();
+  assert(egl_display != EGL_NO_DISPLAY);
+  for (auto &pair : egl_images) {
+    eglDestroyImageKHR(egl_display, pair.second);
+  }
+  egl_images.clear();
+#endif
 }

--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -58,6 +58,7 @@ protected:
   void updateCalibration(const mat3 &calib);
   void vipcThread();
   void clearFrames();
+  void clearEGLImages();
 
   int glWidth();
   int glHeight();


### PR DESCRIPTION
also cleaned up unnecessary includes.