### PR TITLE
add more `bootlog` info

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -116,6 +116,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"DisengageOnAccelerator", PERSISTENT},
     {"DmModelInitialized", CLEAR_ON_ONROAD_TRANSITION},
     {"DongleId", PERSISTENT},
+    {"BootlogId", PERSISTENT}
     {"DoReboot", CLEAR_ON_MANAGER_START},
     {"DoShutdown", CLEAR_ON_MANAGER_START},
     {"DoUninstall", CLEAR_ON_MANAGER_START},

--- a/system/loggerd/logger.cc
+++ b/system/loggerd/logger.cc
@@ -49,6 +49,7 @@ kj::Array<capnp::word> logger_build_init_data() {
   init.setGitRemote(params_map["GitRemote"]);
   init.setPassive(false);
   init.setDongleId(params_map["DongleId"]);
+  init.setBootlogId(params_map["BootLogId"])
 
   auto lparams = init.initParams().initEntries(params_map.size());
   int j = 0;


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

Fixes #32015

Looks like to fix this I'll also need to make changes to cereal, such as adding `bootlogId` into `log.capnp` file.

Draft since this is first time looking into logging within openpilot


- [ ] add bootlog id to initData
- [ ] add previous route to the bootlog
- [ ] add power on reason to bootlog (cold boot, warm boot, etc.)

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

