### PR TITLE
camerad: Localizing the variable "ret"

### DIFF
--- a/system/camerad/cameras/camera_util.cc
+++ b/system/camerad/cameras/camera_util.cc
@@ -86,11 +86,10 @@ void *alloc_w_mmu_hdl(int video0_fd, int len, uint32_t *handle, int align, int f
 }
 
 void release(int video0_fd, uint32_t handle) {
-  int ret;
   struct cam_mem_mgr_release_cmd mem_mgr_release_cmd = {0};
   mem_mgr_release_cmd.buf_handle = handle;
 
-  ret = do_cam_control(video0_fd, CAM_REQ_MGR_RELEASE_BUF, &mem_mgr_release_cmd, sizeof(mem_mgr_release_cmd));
+  int ret = do_cam_control(video0_fd, CAM_REQ_MGR_RELEASE_BUF, &mem_mgr_release_cmd, sizeof(mem_mgr_release_cmd));
   assert(ret == 0);
 }
 

--- a/system/camerad/main.cc
+++ b/system/camerad/main.cc
@@ -12,8 +12,7 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
-  int ret;
-  ret = util::set_realtime_priority(53);
+  int ret = util::set_realtime_priority(53);
   assert(ret == 0);
   ret = util::set_core_affinity({6});
   assert(ret == 0 || Params().getBool("IsOffroad")); // failure ok while offroad due to offlining cores


### PR DESCRIPTION
Update old C-style variable definitions from early versions of the code to C++ style:  "declaring variables where they are initialized."