### PR TITLE
cabana: increase cache limits

### DIFF
--- a/tools/cabana/settings.cc
+++ b/tools/cabana/settings.cc
@@ -12,6 +12,9 @@
 
 #include "tools/cabana/utils/util.h"
 
+const int MIN_CACHE_MINIUTES = 30;
+const int MAX_CACHE_MINIUTES = 120;
+
 Settings settings;
 
 template <class SettingOperation>
@@ -72,7 +75,7 @@ SettingsDlg::SettingsDlg(QWidget *parent) : QDialog(parent) {
   fps->setValue(settings.fps);
 
   form_layout->addRow(tr("Max Cached Minutes"), cached_minutes = new QSpinBox(this));
-  cached_minutes->setRange(5, 60);
+  cached_minutes->setRange(MIN_CACHE_MINIUTES, MAX_CACHE_MINIUTES);
   cached_minutes->setSingleStep(1);
   cached_minutes->setValue(settings.max_cached_minutes);
   main_layout->addWidget(groupbox);


### PR DESCRIPTION
After recent PRs, Cabana's memory usage has significantly decreased, so we can safely increase the cache limit.