### PR TITLE
commabody: ignore fcw alerts

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -86,6 +86,10 @@ class Controls:
     ignore = self.sensor_packets + ['testJoystick']
     if SIMULATION:
       ignore += ['driverCameraState', 'managerState']
+
+    if (self.CP.notCar and self.joystick_mode):
+      ignore += ["modelV2, longitudinalPlan"]
+
     self.sm = messaging.SubMaster(['deviceState', 'pandaStates', 'peripheralState', 'modelV2', 'liveCalibration',
                                    'carOutput', 'driverMonitoringState', 'longitudinalPlan', 'liveLocationKalman',
                                    'managerState', 'liveParameters', 'radarState', 'liveTorqueParameters',

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -87,6 +87,8 @@ class Controls:
     if SIMULATION:
       ignore += ['driverCameraState', 'managerState']
 
+    self.joystick_mode = self.params.get_bool("JoystickDebugMode")
+
     if (self.CP.notCar and self.joystick_mode):
       ignore += ["modelV2, longitudinalPlan"]
 
@@ -96,8 +98,6 @@ class Controls:
                                    'testJoystick'] + self.camera_packets + self.sensor_packets,
                                   ignore_alive=ignore, ignore_avg_freq=ignore+['radarState', 'testJoystick'], ignore_valid=['testJoystick', ],
                                   frequency=int(1/DT_CTRL))
-
-    self.joystick_mode = self.params.get_bool("JoystickDebugMode")
 
     # read params
     self.disengage_on_accelerator = self.params.get_bool("DisengageOnAccelerator")


### PR DESCRIPTION
ignore fcw on the body 

first tried ignoring `modelV2` and `longitudinalPlan` messages (as we don't need them either) but joystick_mode isn't set to True before we initialize SubMaster