### PR TITLE
cast ci->image_sensor to unsigned short

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -29,7 +29,7 @@ public:
              "-DSENSOR_ID=%hu -DHDR_OFFSET=%d -DVIGNETTING=%d ",
              ci->frame_width, ci->frame_height, ci->hdr_offset > 0 ? ci->frame_stride * 2 : ci->frame_stride, ci->frame_offset,
              b->rgb_width, b->rgb_height, buf_width, uv_offset,
-             ci->image_sensor, ci->hdr_offset, s->camera_num == 1);
+             static_cast<unsigned short>(ci->image_sensor), ci->hdr_offset, s->camera_num == 1);
     const char *cl_file = "cameras/process_raw.cl";
     cl_program prg_imgproc = cl_program_from_file(context, device_id, cl_file, args);
     krnl_ = CL_CHECK_ERR(clCreateKernel(prg_imgproc, "process_raw", &err));


### PR DESCRIPTION
Otherwise I get this:

```
system/camerad/cameras/camera_common.cc:32:14: error: format specifies type 'unsigned short' but the argument has type 'cereal::FrameData::ImageSensor' (aka 'capnp::schemas::ImageSensor_d810b1e7705dd69c') [-Werror,-Wformat]
   29 |              "-DSENSOR_ID=%hu -DHDR_OFFSET=%d -DVIGNETTING=%d ",
      |                           ~~~
   30 |              ci->frame_width, ci->frame_height, ci->hdr_offset > 0 ? ci->frame_stride * 2 : ci->frame_stride, ci->frame_offset,
   31 |              b->rgb_width, b->rgb_height, buf_width, uv_offset,
   32 |              ci->image_sensor, ci->hdr_offset, s->camera_num == 1);
      |              ^~~~~~~~~~~~~~~~
      |              static_cast<uint16_t>( )
1 error generated.
scons: *** [system/camerad/cameras/camera_common.o] Error 1
```