### PR TITLE
athenad: set a timeout on proxy WebSocket receive

### DIFF
--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -465,7 +465,8 @@ def startLocalProxy(global_end_event: threading.Event, remote_ws_uri: str, local
     identity_token = Api(dongle_id).get_token()
     ws = create_connection(remote_ws_uri,
                            cookie="jwt=" + identity_token,
-                           enable_multithread=True)
+                           enable_multithread=True,
+                           timeout=30.0)
 
     ssock, csock = socket.socketpair()
     local_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -657,12 +658,10 @@ def stat_handler(end_event: threading.Event) -> None:
 def ws_proxy_recv(ws: WebSocket, local_sock: socket.socket, ssock: socket.socket, end_event: threading.Event, global_end_event: threading.Event) -> None:
   while not (end_event.is_set() or global_end_event.is_set()):
     try:
-      r = select.select([ws], [], [], 10)
-      if r[0]:
-        data = ws.recv()
-        if isinstance(data, str):
-          data = data.encode("utf-8")
-        local_sock.sendall(data)
+      data = ws.recv()
+      if isinstance(data, str):
+        data = data.encode("utf-8")
+      local_sock.sendall(data)
     except WebSocketTimeoutException:
       pass
     except Exception:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -657,7 +657,7 @@ def stat_handler(end_event: threading.Event) -> None:
 def ws_proxy_recv(ws: WebSocket, local_sock: socket.socket, ssock: socket.socket, end_event: threading.Event, global_end_event: threading.Event) -> None:
   while not (end_event.is_set() or global_end_event.is_set()):
     try:
-      r = select.select([ws], [], [], 10)
+      r = select.select((ws,), (), (), 30)
       if r[0]:
         data = ws.recv()
         if isinstance(data, str):

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -467,13 +467,6 @@ def startLocalProxy(global_end_event: threading.Event, remote_ws_uri: str, local
                            cookie="jwt=" + identity_token,
                            enable_multithread=True)
 
-    onroad = True
-    sock = ws.sock
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, 16000 if onroad else 0)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
-
     ssock, csock = socket.socketpair()
     local_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     local_sock.connect(('127.0.0.1', local_port))

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -657,7 +657,7 @@ def stat_handler(end_event: threading.Event) -> None:
 def ws_proxy_recv(ws: WebSocket, local_sock: socket.socket, ssock: socket.socket, end_event: threading.Event, global_end_event: threading.Event) -> None:
   while not (end_event.is_set() or global_end_event.is_set()):
     try:
-      r = select.select((ws,), (), (), 30)
+      r = select.select((ws.sock,), (), (), 30)
       if r[0]:
         data = ws.recv()
         if isinstance(data, str):

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -467,6 +467,13 @@ def startLocalProxy(global_end_event: threading.Event, remote_ws_uri: str, local
                            cookie="jwt=" + identity_token,
                            enable_multithread=True)
 
+    onroad = True
+    sock = ws.sock
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, 16000 if onroad else 0)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
+
     ssock, csock = socket.socketpair()
     local_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     local_sock.connect(('127.0.0.1', local_port))

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -465,8 +465,7 @@ def startLocalProxy(global_end_event: threading.Event, remote_ws_uri: str, local
     identity_token = Api(dongle_id).get_token()
     ws = create_connection(remote_ws_uri,
                            cookie="jwt=" + identity_token,
-                           enable_multithread=True,
-                           timeout=30.0)
+                           enable_multithread=True)
 
     ssock, csock = socket.socketpair()
     local_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -658,10 +657,12 @@ def stat_handler(end_event: threading.Event) -> None:
 def ws_proxy_recv(ws: WebSocket, local_sock: socket.socket, ssock: socket.socket, end_event: threading.Event, global_end_event: threading.Event) -> None:
   while not (end_event.is_set() or global_end_event.is_set()):
     try:
-      data = ws.recv()
-      if isinstance(data, str):
-        data = data.encode("utf-8")
-      local_sock.sendall(data)
+      r = select.select([ws], [], [], 10)
+      if r[0]:
+        data = ws.recv()
+        if isinstance(data, str):
+          data = data.encode("utf-8")
+        local_sock.sendall(data)
     except WebSocketTimeoutException:
       pass
     except Exception:

--- a/selfdrive/athena/athenad.py
+++ b/selfdrive/athena/athenad.py
@@ -657,10 +657,12 @@ def stat_handler(end_event: threading.Event) -> None:
 def ws_proxy_recv(ws: WebSocket, local_sock: socket.socket, ssock: socket.socket, end_event: threading.Event, global_end_event: threading.Event) -> None:
   while not (end_event.is_set() or global_end_event.is_set()):
     try:
-      data = ws.recv()
-      if isinstance(data, str):
-        data = data.encode("utf-8")
-      local_sock.sendall(data)
+      r = select.select([ws], [], [], 10)
+      if r[0]:
+        data = ws.recv()
+        if isinstance(data, str):
+          data = data.encode("utf-8")
+        local_sock.sendall(data)
     except WebSocketTimeoutException:
       pass
     except Exception:
@@ -670,6 +672,7 @@ def ws_proxy_recv(ws: WebSocket, local_sock: socket.socket, ssock: socket.socket
   cloudlog.debug("athena.ws_proxy_recv closing sockets")
   ssock.close()
   local_sock.close()
+  ws.close()
   cloudlog.debug("athena.ws_proxy_recv done closing sockets")
 
   end_event.set()

--- a/selfdrive/athena/tests/helpers.py
+++ b/selfdrive/athena/tests/helpers.py
@@ -43,6 +43,8 @@ class MockApi():
 
 
 class MockWebsocket():
+  sock = socket.socket()
+
   def __init__(self, recv_queue, send_queue):
     self.recv_queue = recv_queue
     self.send_queue = send_queue
@@ -55,6 +57,9 @@ class MockWebsocket():
 
   def send(self, data, opcode):
     self.send_queue.put_nowait((data, opcode))
+
+  def close(self):
+    pass
 
 
 class HTTPRequestHandler(http.server.SimpleHTTPRequestHandler):


### PR DESCRIPTION
When you disconnect from athenad's ssh function, it leaves open the WebSocket and the local socket to sshd for a while as the default socket timeout is 2 hours