### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -284,6 +284,7 @@ FW_VERSIONS = {
       b'\xf1\x00TM__ SCC F-CUP      1.00 1.00 99110-S1500         ',
       b'\xf1\x00TM__ SCC F-CUP      1.00 1.01 99110-S1500         ',
       b'\xf1\x00TM__ SCC FHCUP      1.00 1.00 99110-S1500         ',
+      b'\xf1\x00TM__ SCC FHCUP      1.00 1.01 99110-S1500         ',
     ],
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00TM ESC \x01 102!\x04\x03 58910-S2DA0',
@@ -294,6 +295,7 @@ FW_VERSIONS = {
       b'\xf1\x00TM ESC \x03 102!\x04\x03 58910-S2DA0',
       b'\xf1\x00TM ESC \x04 101 \x08\x04 58910-S2GA0',
       b'\xf1\x00TM ESC \x04 102!\x04\x05 58910-S2GA0',
+      b'\xf1\x00TM ESC \x04 103"\x07\x08 58910-S2GA0',
       b'\xf1\x00TM ESC \x1e 102 \x08\x08 58910-S1DA0',
       b'\xf1\x00TM ESC   103!\x030 58910-S1MA0',
     ],


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                            | Name from VIN 🆚 CarDocs                             | Segments                                  | Bad seg tags   | Good seg tags                                                                        |
|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------|:------------------------------------------|:---------------|:-------------------------------------------------------------------------------------|
| [2cd5c775e97b2458](https://useradmin.comma.ai/?onebox=2cd5c775e97b2458)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS5DAL9........</sub> | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23 | 17 routes,<br>321 segments<br>(5.3 hours) |                | - valid torque params: 302<br>- all lat active: 118<br>- no input all lat active: 95 |

Dongles to re-run category: `2cd5c775e97b2458`
</details>

## ⏳️ 46 dongles (26 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                                          | Segments                                     | Bad seg tags                                                                                                  | Good seg tags                                                                        |
|:--------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|:---------------------------------------------|:--------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------|
| [9bac7575fac62395](https://useradmin.comma.ai/?onebox=9bac7575fac62395)<br><sub>HONDA_PILOT<br>5FNYF6H93........</sub>                | HONDA Pilot 2018 🆚<br>Honda Pilot 2016-22                                                        | 203 routes,<br>2310 segments<br>(38.5 hours) |                                                                                                               | - valid torque params: 2308<br>- all lat active: 268<br>- no input all lat active: 5 |
| [30f476405b31e063](https://useradmin.comma.ai/?onebox=30f476405b31e063)<br><sub>TOYOTA_HIGHLANDER<br>5TDDGRFH0........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19                              | 123 routes,<br>1808 segments<br>(30.1 hours) |                                                                                                               | - valid torque params: 1807<br>- all lat active: 23<br>- no input all lat active: 7  |
| [b53e882f1a5c30ae](https://useradmin.comma.ai/?onebox=b53e882f1a5c30ae)<br><sub>LEXUS_IS<br>000000000........</sub>                   | None 🆚<br>None                                                                                   | 11 routes,<br>282 segments<br>(4.7 hours)    |                                                                                                               | - all lat active: 18<br>- no input all lat active: 10                                |
| [7037f9c72bc6f964](https://useradmin.comma.ai/?onebox=7037f9c72bc6f964)<br><sub>TOYOTA_COROLLA_TSS2<br>5YFBPMBE9........</sub>        | TOYOTA Corolla 2022 🆚<br>Toyota Corolla 2020-22                                                  | 3 routes,<br>40 segments<br>(0.7 hours)      |                                                                                                               | - valid torque params: 40<br>- all lat active: 0                                     |
| [4a816f1ed461f594](https://useradmin.comma.ai/?onebox=4a816f1ed461f594)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHM9........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                                              | 2 routes,<br>43 segments<br>(0.7 hours)      |                                                                                                               | - valid torque params: 31<br>- all lat active: 4<br>- no input all lat active: 1     |
| [70de7ca8aacf461f](https://useradmin.comma.ai/?onebox=70de7ca8aacf461f)<br><sub>LEXUS_ES_TSS2<br>JTHB21B17........</sub>              | None 🆚<br>None                                                                                   | 7 routes,<br>83 segments<br>(1.4 hours)      |                                                                                                               | - valid torque params: 45<br>- all lat active: 19<br>- no input all lat active: 4    |
| [b8798e927311b269](https://useradmin.comma.ai/?onebox=b8798e927311b269)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AGX........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                                | 7 routes,<br>164 segments<br>(2.7 hours)     |                                                                                                               | - valid torque params: 164<br>- all lat active: 1<br>- no input all lat active: 1    |
| [a6de4da35307d7b8](https://useradmin.comma.ai/?onebox=a6de4da35307d7b8)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT4........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                                              | 2 routes,<br>24 segments<br>(0.4 hours)      |                                                                                                               | - valid torque params: 24<br>- all lat active: 0                                     |
| [f9d8d0552e557f8e](https://useradmin.comma.ai/?onebox=f9d8d0552e557f8e)<br><sub>TOYOTA_RAV4_TSS2_2022<br>JTMW1RFV0........</sub>      | TOYOTA RAV4 2022 🆚<br>Toyota RAV4 2022                                                           | 1 routes,<br>6 segments<br>(0.1 hours)       |                                                                                                               | - valid torque params: 6<br>- all lat active: 0                                      |
| [afe94a76bd8f5676](https://useradmin.comma.ai/?onebox=afe94a76bd8f5676)<br><sub>HYUNDAI_PALISADE<br>5XYP3DHC5........</sub>           | KIA Telluride 2022 🆚<br>Kia Telluride 2020-22                                                    | 12 routes,<br>149 segments<br>(2.5 hours)    |                                                                                                               | - valid torque params: 149<br>- all lat active: 42<br>- no input all lat active: 26  |
| [fbd0d5e8ac16f6d9](https://useradmin.comma.ai/?onebox=fbd0d5e8ac16f6d9)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT7........</sub>           | RAM 1500 2024 🆚<br>Ram 1500 2019-24                                                              | 11 routes,<br>165 segments<br>(2.8 hours)    |                                                                                                               | - valid torque params: 159<br>- all lat active: 52<br>- no input all lat active: 47  |
| [d64a913d6bc60932](https://useradmin.comma.ai/?onebox=d64a913d6bc60932)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFPT5........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                                              | 1 routes,<br>16 segments<br>(0.3 hours)      |                                                                                                               | - valid torque params: 12<br>- all lat active: 2<br>- no input all lat active: 1     |
| [b9ed9a8b2b604ddf](https://useradmin.comma.ai/?onebox=b9ed9a8b2b604ddf)<br><sub>KIA_OPTIMA_G4<br>5XXGW4L23........</sub>              | KIA Optima 2017 🆚<br>Kia Optima 2017                                                             | 2 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                               | - all lat active: 0                                                                  |
| [d624493e04d36bdd](https://useradmin.comma.ai/?onebox=d624493e04d36bdd)<br><sub>HYUNDAI_SANTA_FE_HEV_2022<br>5NMS5DA15........</sub>  | HYUNDAI Santa Fe Hybrid 2023 🆚<br>Hyundai Santa Fe Hybrid 2022-23                                | 9 routes,<br>191 segments<br>(3.2 hours)     |                                                                                                               | - all lat active: 3<br>- no input all lat active: 3                                  |
| [6e6e342fad47dd29](https://useradmin.comma.ai/?onebox=6e6e342fad47dd29)<br><sub>VOLKSWAGEN_GOLF_MK7<br>WVWVF7AU2........</sub>        | VOLKSWAGEN Golf R 2018 🆚<br>Volkswagen Golf R 2015-19                                            | 32 routes,<br>361 segments<br>(6.0 hours)    |                                                                                                               | - valid torque params: 361<br>- all lat active: 25<br>- no input all lat active: 11  |
| [a97d27ce2a78958a](https://useradmin.comma.ai/?onebox=a97d27ce2a78958a)<br><sub>VOLKSWAGEN_JETTA_MK7<br>3VWG57BUX........</sub>       | VOLKSWAGEN Jetta 2019 🆚<br>Volkswagen Jetta 2018-24                                              | 22 routes,<br>520 segments<br>(8.7 hours)    |                                                                                                               | - valid torque params: 520<br>- all lat active: 0                                    |
| [636f850472924d8b](https://useradmin.comma.ai/?onebox=636f850472924d8b)<br><sub>TOYOTA_COROLLA_TSS2<br>JTNC4MBE8........</sub>        | TOYOTA Corolla Hatchback 2022 🆚<br>Toyota Corolla Hatchback 2019-22                              | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                               | - valid torque params: 1<br>- all lat active: 0                                      |
| [dbeeb342988e0a18](https://useradmin.comma.ai/?onebox=dbeeb342988e0a18)<br><sub>VOLKSWAGEN_GOLF_MK7<br>3VW6T7AU6........</sub>        | VOLKSWAGEN Golf GTI 2020 🆚<br>Volkswagen Golf GTI 2015-21                                        | 12 routes,<br>155 segments<br>(2.6 hours)    |                                                                                                               | - valid torque params: 145<br>- all lat active: 45<br>- no input all lat active: 25  |
| [c04a3b5508dc7bc3](https://useradmin.comma.ai/?onebox=c04a3b5508dc7bc3)<br><sub>HONDA_ACCORD<br>1HGCV2F90........</sub>               | HONDA Accord 2021 🆚<br>Honda Accord 2018-22                                                      | 30 routes,<br>274 segments<br>(4.6 hours)    |                                                                                                               | - valid torque params: 274<br>- all lat active: 3<br>- no input all lat active: 2    |
| [2fe829d661707c32](https://useradmin.comma.ai/?onebox=2fe829d661707c32)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81BF........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 2 routes,<br>15 segments<br>(0.2 hours)      |                                                                                                               | - all lat active: 0                                                                  |
| [6bb60ccda0ac419f](https://useradmin.comma.ai/?onebox=6bb60ccda0ac419f)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 2 routes,<br>11 segments<br>(0.2 hours)      |                                                                                                               | - all lat active: 1                                                                  |
| [a10cb44801fea034](https://useradmin.comma.ai/?onebox=a10cb44801fea034)<br><sub>VOLKSWAGEN_JETTA_MK7<br>WVWZZZBUZ........</sub>       | VOLKSWAGEN  2021 🆚<br>Volkswagen Jetta 2018-24                                                   | 5 routes,<br>22 segments<br>(0.4 hours)      |                                                                                                               | - all lat active: 0                                                                  |
| [9acd533a0f402e80](https://useradmin.comma.ai/?onebox=9acd533a0f402e80)<br><sub>HYUNDAI_ELANTRA_2021<br>5NPLS4AG8........</sub>       | HYUNDAI Elantra 2022 🆚<br>Hyundai Elantra 2021-23                                                | 91 routes,<br>1364 segments<br>(22.7 hours)  |                                                                                                               | - valid torque params: 1364<br>- all lat active: 2<br>- no input all lat active: 2   |
| [fdf7c1f93a13cfc9](https://useradmin.comma.ai/?onebox=fdf7c1f93a13cfc9)<br><sub>HYUNDAI_IONIQ_5<br>KMHKL81AF........</sub>            | HYUNDAI  1992 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 1 routes,<br>18 segments<br>(0.3 hours)      |                                                                                                               | - all lat active: 2<br>- no input all lat active: 1                                  |
| [6605a3f2fd20e6af](https://useradmin.comma.ai/?onebox=6605a3f2fd20e6af)<br><sub>TOYOTA_HIGHLANDER<br>5TDDGRFH4........</sub>          | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19                              | 11 routes,<br>154 segments<br>(2.6 hours)    |                                                                                                               | - valid torque params: 150<br>- all lat active: 2                                    |
| [e8151619f03d6c11](https://useradmin.comma.ai/?onebox=e8151619f03d6c11)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC1EG1........</sub>     | CHRYSLER Pacifica 2019 🆚<br>Chrysler Pacifica 2019-20                                            | 4 routes,<br>50 segments<br>(0.8 hours)      |                                                                                                               | - valid torque params: 5<br>- all lat active: 0                                      |
| [6868a58803419504](https://useradmin.comma.ai/?onebox=6868a58803419504)<br><sub>HONDA_PILOT<br>5FNYF6H29........</sub>                | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                                                        | 1 routes,<br>4 segments<br>(0.1 hours)       |                                                                                                               | - all lat active: 4<br>- valid torque params: 4<br>- no input all lat active: 1      |
| [772b833c28f493b5](https://useradmin.comma.ai/?onebox=772b833c28f493b5)<br><sub>ACURA_RDX_3G<br>5J8TC1H5X........</sub>               | ACURA RDX 2019 🆚<br>Acura RDX 2019-22                                                            | 4 routes,<br>22 segments<br>(0.4 hours)      |                                                                                                               | - valid torque params: 10<br>- all lat active: 2<br>- no input all lat active: 1     |
| [2d2ed4682dfe5a78](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)<br><sub>KIA_EV6<br>KNDC3DLC3........</sub>                    | KIA EV6 2023 🆚<br>Kia EV6 (with HDA II) 2022-23                                                  | 1 routes,<br>2 segments<br>(0.0 hours)       | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=2d2ed4682dfe5a78)                         | - all lat active: 0                                                                  |
| [12fdf6595e41b23a](https://useradmin.comma.ai/?onebox=12fdf6595e41b23a)<br><sub>KIA_NIRO_EV<br>000000000........</sub>                | None 🆚<br>None                                                                                   | 8 routes,<br>1602 segments<br>(26.7 hours)   | - [segment too short (info): 337](https://useradmin.comma.ai/?onebox=12fdf6595e41b23a%7C2024-04-24--10-43-54) | - all lat active: 0                                                                  |
| [95bdaa23fcf50877](https://useradmin.comma.ai/?onebox=95bdaa23fcf50877)<br><sub>TOYOTA_ALPHARD_TSS2<br>000000000........</sub>        | None 🆚<br>None                                                                                   | 53 routes,<br>659 segments<br>(11.0 hours)   |                                                                                                               | - all lat active: 11<br>- no input all lat active: 4                                 |
| [6f915c784c00bb10](https://useradmin.comma.ai/?onebox=6f915c784c00bb10)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFKT6........</sub>           | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                                              | 8 routes,<br>44 segments<br>(0.7 hours)      |                                                                                                               | - all lat active: 0                                                                  |
| [6ebcefea49711168](https://useradmin.comma.ai/?onebox=6ebcefea49711168)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>          | None 🆚<br>None                                                                                   | 20 routes,<br>132 segments<br>(2.2 hours)    |                                                                                                               | - valid torque params: 74<br>- all lat active: 5<br>- no input all lat active: 1     |
| [59eacd2185bd7885](https://useradmin.comma.ai/?onebox=59eacd2185bd7885)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC1BG5........</sub>     | CHRYSLER Pacifica 2024 🆚<br>Chrysler Pacifica 2021-23<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 10 routes,<br>210 segments<br>(3.5 hours)    |                                                                                                               | - valid torque params: 155<br>- all lat active: 13<br>- no input all lat active: 6   |
| [f56e1b6b8d3d4326](https://useradmin.comma.ai/?onebox=f56e1b6b8d3d4326)<br><sub>TOYOTA_CAMRY_TSS2<br>4T1C11BK0........</sub>          | TOYOTA Camry 2022 🆚<br>Toyota Camry 2021-24                                                      | 10 routes,<br>129 segments<br>(2.1 hours)    |                                                                                                               | - valid torque params: 129<br>- all lat active: 0                                    |
| [6adf1dffa8619f41](https://useradmin.comma.ai/?onebox=6adf1dffa8619f41)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub> | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                                              | 12 routes,<br>75 segments<br>(1.2 hours)     |                                                                                                               | - valid torque params: 59<br>- all lat active: 14<br>- no input all lat active: 11   |
| [3044cbf1071171ba](https://useradmin.comma.ai/?onebox=3044cbf1071171ba)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 3 routes,<br>19 segments<br>(0.3 hours)      |                                                                                                               | - all lat active: 3                                                                  |
| [47ba5e6f0490d659](https://useradmin.comma.ai/?onebox=47ba5e6f0490d659)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT4........</sub>           | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                                              | 4 routes,<br>174 segments<br>(2.9 hours)     |                                                                                                               | - valid torque params: 162<br>- all lat active: 77<br>- no input all lat active: 43  |
| [df616cb5c6ab97f2](https://useradmin.comma.ai/?onebox=df616cb5c6ab97f2)<br><sub>TOYOTA_RAV4_TSS2_2022<br>4T3RWRFV6........</sub>      | TOYOTA RAV4 Hybrid 2022 🆚<br>Toyota RAV4 Hybrid 2022                                             | 1 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                               | - valid torque params: 12<br>- all lat active: 8<br>- no input all lat active: 7     |
| [c2c75f785c43d4b9](https://useradmin.comma.ai/?onebox=c2c75f785c43d4b9)<br><sub>TOYOTA_RAV4_TSS2<br>000000000........</sub>           | None 🆚<br>None                                                                                   | 1 routes,<br>10 segments<br>(0.2 hours)      |                                                                                                               | - all lat active: 0                                                                  |
| [d075d065f1c27b98](https://useradmin.comma.ai/?onebox=d075d065f1c27b98)<br><sub>KIA_EV6<br>KNAC381CP........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                                                     | 1 routes,<br>10 segments<br>(0.2 hours)      |                                                                                                               | - valid torque params: 3<br>- all lat active: 0                                      |
| [5cec29f6d48ebf27](https://useradmin.comma.ai/?onebox=5cec29f6d48ebf27)<br><sub>HYUNDAI_IONIQ_5<br>KMHKL81AF........</sub>            | HYUNDAI  1992 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 1 routes,<br>10 segments<br>(0.2 hours)      |                                                                                                               | - all lat active: 0                                                                  |
| [5928b56aca881917](https://useradmin.comma.ai/?onebox=5928b56aca881917)<br><sub>HYUNDAI_SANTA_FE_2022<br>RLUSW81KD........</sub>      | None 🆚<br>None                                                                                   | 10 routes,<br>69 segments<br>(1.1 hours)     | - [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=5928b56aca881917%7C2024-04-15--10-37-20)          | - all lat active: 3                                                                  |
| [e903f78de77036c7](https://useradmin.comma.ai/?onebox=e903f78de77036c7)<br><sub>TOYOTA_RAV4_TSS2_2023<br>2T3N1RFV8........</sub>      | TOYOTA RAV4 2024 🆚<br>Toyota RAV4 2023-24                                                        | 2 routes,<br>28 segments<br>(0.5 hours)      |                                                                                                               | - all lat active: 6<br>- no input all lat active: 5                                  |
| [8b84fb6a13c8384e](https://useradmin.comma.ai/?onebox=8b84fb6a13c8384e)<br><sub>TOYOTA_COROLLA_TSS2<br>5YFS4RCE7........</sub>        | TOYOTA Corolla 2020 🆚<br>Toyota Corolla 2020-22                                                  | 6 routes,<br>116 segments<br>(1.9 hours)     |                                                                                                               | - all lat active: 27<br>- no input all lat active: 13<br>- valid torque params: 113  |
| [a20d9fc9c0db2a9d](https://useradmin.comma.ai/?onebox=a20d9fc9c0db2a9d)<br><sub>KIA_EV6<br>000000000........</sub>                    | None 🆚<br>None                                                                                   | 1 routes,<br>19 segments<br>(0.3 hours)      |                                                                                                               | - all lat active: 2<br>- no input all lat active: 1                                  |

Dongles to re-run category: `47ba5e6f0490d659 772b833c28f493b5 6e6e342fad47dd29 df616cb5c6ab97f2 59eacd2185bd7885 4a816f1ed461f594 afe94a76bd8f5676 636f850472924d8b 6bb60ccda0ac419f 12fdf6595e41b23a c2c75f785c43d4b9 8b84fb6a13c8384e dbeeb342988e0a18 7037f9c72bc6f964 fbd0d5e8ac16f6d9 b8798e927311b269 f56e1b6b8d3d4326 2fe829d661707c32 95bdaa23fcf50877 a20d9fc9c0db2a9d a10cb44801fea034 6adf1dffa8619f41 fdf7c1f93a13cfc9 d075d065f1c27b98 9acd533a0f402e80 6605a3f2fd20e6af d624493e04d36bdd 5cec29f6d48ebf27 e8151619f03d6c11 c04a3b5508dc7bc3 b53e882f1a5c30ae 30f476405b31e063 a97d27ce2a78958a 9bac7575fac62395 70de7ca8aacf461f 6f915c784c00bb10 a6de4da35307d7b8 d64a913d6bc60932 5928b56aca881917 6868a58803419504 e903f78de77036c7 3044cbf1071171ba b9ed9a8b2b604ddf 6ebcefea49711168 f9d8d0552e557f8e 2d2ed4682dfe5a78`
</details>

## ⚠️ 29 dongles (14 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                                                          | Segments                                     | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Good seg tags                                                                           |
|:--------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------|:---------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
| [ad48d1930c6a3571](https://useradmin.comma.ai/?onebox=ad48d1930c6a3571)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 16 routes,<br>506 segments<br>(8.4 hours)    | - [invalid FW: 506](https://useradmin.comma.ai/?onebox=ad48d1930c6a3571%7C2024-04-29--14-11-09)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 506<br>- all lat active: 71<br>- no input all lat active: 39     |
| [734971c66100033f](https://useradmin.comma.ai/?onebox=734971c66100033f)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHM6........</sub>           | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                                                              | 118 routes,<br>2448 segments<br>(40.8 hours) | - [spotty FW: 109](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-13--17-05-19)<br>- [car faulted: 96](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-13--19-51-21)<br>- [CAN invalid: 3](https://useradmin.comma.ai/?onebox=734971c66100033f%7C2024-04-06--14-21-15)                                                                                                                                                                                                                            |                                                                                         |
| [7e63a5eee34d3fb0](https://useradmin.comma.ai/?onebox=7e63a5eee34d3fb0)<br><sub>KIA_EV6<br>000000000........</sub>                    | None 🆚<br>None                                                                                                   | 10 routes,<br>278 segments<br>(4.6 hours)    | - [CAN invalid: 1](https://useradmin.comma.ai/?onebox=7e63a5eee34d3fb0%7C2024-04-30--17-47-06)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 278<br>- all lat active: 5<br>- no input all lat active: 2       |
| [9e7b03d47798346e](https://useradmin.comma.ai/?onebox=9e7b03d47798346e)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub> | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                                                              | 150 routes,<br>1703 segments<br>(28.4 hours) | - [car faulted: 282](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C2024-04-06--08-24-28)<br>- [segment too short (info): 145](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C2024-04-10--12-45-25)                                                                                                                                                                                                                                                                                                              | - valid torque params: 1355<br>- all lat active: 69<br>- no input all lat active: 24    |
| [fc4d8f4e5f8b353a](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a)<br><sub>HONDA_CIVIC_2022<br>19XFL1H88........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 90 routes,<br>1833 segments<br>(30.6 hours)  | - [missing ECU FW: 1221](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-17--16-05-32)<br>- [spotty FW: 612](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-03--15-17-31)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-17--16-05-32)                                                                                                                                                                                                                | - all lat active: 294<br>- no input all lat active: 174<br>- valid torque params: 1833  |
| [93bc5d4df12aa933](https://useradmin.comma.ai/?onebox=93bc5d4df12aa933)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFJT2........</sub>        | JEEP Grand Cherokee 2018 🆚<br>Jeep Grand Cherokee 2016-18                                                        | 14 routes,<br>180 segments<br>(3.0 hours)    | - [car faulted: 1](https://useradmin.comma.ai/?onebox=93bc5d4df12aa933%7C2024-04-26--00-14-46)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 134<br>- all lat active: 4<br>- no input all lat active: 1       |
| [903ac8da1aa52026](https://useradmin.comma.ai/?onebox=903ac8da1aa52026)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 14 routes,<br>83 segments<br>(1.4 hours)     | - [invalid FW: 83](https://useradmin.comma.ai/?onebox=903ac8da1aa52026%7C2024-04-10--20-55-20)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 83<br>- all lat active: 21<br>- no input all lat active: 20      |
| [13858e4047f4aec8](https://useradmin.comma.ai/?onebox=13858e4047f4aec8)<br><sub>AUDI_Q3_MK2<br>WA1EECF35........</sub>                | AUDI Q3 2021 🆚<br>Audi Q3 2019-23                                                                                | 3 routes,<br>16 segments<br>(0.3 hours)      | - [car faulted: 3](https://useradmin.comma.ai/?onebox=13858e4047f4aec8%7C2024-05-02--14-26-26)                                                                                                                                                                                                                                                                                                                                                                                                                                 |                                                                                         |
| [11d207f3143e07b3](https://useradmin.comma.ai/?onebox=11d207f3143e07b3)<br><sub>KIA_EV6<br>KNAC381AF........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                                                                     | 7 routes,<br>93 segments<br>(1.6 hours)      | - [spotty FW: 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)                                                                                                                                                                                                                                                                                                                           | - all lat active: 38<br>- no input all lat active: 14<br>- valid torque params: 79      |
| [39ecd9e9391c1810](https://useradmin.comma.ai/?onebox=39ecd9e9391c1810)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 2 routes,<br>3 segments<br>(0.1 hours)       | - [invalid FW: 3](https://useradmin.comma.ai/?onebox=39ecd9e9391c1810%7C2024-04-23--17-13-16)                                                                                                                                                                                                                                                                                                                                                                                                                                  |                                                                                         |
| [72c57a77995168b4](https://useradmin.comma.ai/?onebox=72c57a77995168b4)<br><sub>TOYOTA_HIGHLANDER_TSS2<br>5TDFZRBH9........</sub>     | TOYOTA Highlander 2021 🆚<br>Toyota Highlander 2020-23                                                            | 1 routes,<br>1 segments<br>(0.0 hours)       | - [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)                                                                                                                                                                                                                                                                                                                     | - valid torque params: 1                                                                |
| [a74cb70b7a19e427](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427)<br><sub>TOYOTA_PRIUS_TSS2<br>000000000........</sub>          | None 🆚<br>None                                                                                                   | 12 routes,<br>141 segments<br>(2.4 hours)    | - [invalid FW: 141](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427%7C2024-04-18--19-01-36)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 140<br>- all lat active: 15<br>- no input all lat active: 5      |
| [23daff6c438612d2](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br><sub>AUDI_A3_MK3<br>3VWCA7AU3........</sub>                | VOLKSWAGEN Golf SportWagen 2015 🆚<br>Audi A3 Sportback e-tron 2017-18<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 26 routes,<br>1270 segments<br>(21.2 hours)  | - [FW not exact match: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-04-04--19-17-07)<br>- [brand fuzzy match disagrees: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-04-04--19-17-07)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)                                                                                                                       | - valid torque params: 1270<br>- all lat active: 189<br>- no input all lat active: 135  |
| [61c374c8e5e59db3](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 159 routes,<br>4447 segments<br>(74.1 hours) | - [missing ECU FW: 3773](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-19--10-32-04)<br>- [spotty FW: 674](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-28--16-17-25)<br>- [segment too short (info): 107](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-26--19-33-51)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-19--10-32-04)                                                                                               | - valid torque params: 4447<br>- all lat active: 1081<br>- no input all lat active: 422 |
| [d031a8c98c8863da](https://useradmin.comma.ai/?onebox=d031a8c98c8863da)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 16 routes,<br>410 segments<br>(6.8 hours)    | - [missing ECU FW: 410](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-20--12-27-55)<br>- [segment too short (info): 9](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-20--12-27-55)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-20--12-27-55)                                                                                                                                                                                                    | - valid torque params: 409<br>- all lat active: 59<br>- no input all lat active: 24     |
| [ef8c34c763849757](https://useradmin.comma.ai/?onebox=ef8c34c763849757)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLL4AG6........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                                                | 9 routes,<br>9 segments<br>(0.1 hours)       | - [missing ECU FW: 9](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-06--17-36-32)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=ef8c34c763849757%7C2024-04-06--17-36-32)                                                                                                                                                                                                                                                                                                                     |                                                                                         |
| [a72482b4766832e9](https://useradmin.comma.ai/?onebox=a72482b4766832e9)<br><sub>HONDA_CIVIC_2022<br>2HGFE1F90........</sub>           | HONDA Civic 2023 🆚<br>Honda Civic 2022-23                                                                        | 12 routes,<br>345 segments<br>(5.8 hours)    | - [missing ECU FW: 344](https://useradmin.comma.ai/?onebox=a72482b4766832e9%7C2024-04-27--21-06-34)<br>- [spotty FW: 1](https://useradmin.comma.ai/?onebox=a72482b4766832e9%7C2024-04-27--00-10-58)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=a72482b4766832e9%7C2024-04-27--21-06-34)                                                                                                                                                                                                                   | - valid torque params: 335<br>- all lat active: 162<br>- no input all lat active: 122   |
| [214c417708d4eabc](https://useradmin.comma.ai/?onebox=214c417708d4eabc)<br><sub>HONDA_CIVIC_2022<br>2HGFE2F26........</sub>           | HONDA Civic 2024 🆚<br>Honda Civic 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>                             | 211 routes,<br>2987 segments<br>(49.8 hours) | - [missing ECU FW: 1162](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-20--16-21-41)<br>- [spotty FW: 1162](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-20--16-21-41)<br>- [segment too short (info): 1](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-15--13-12-06)<br>- [CAN invalid: 1](https://useradmin.comma.ai/?onebox=214c417708d4eabc%7C2024-04-15--13-12-06)                                                                                                       | - valid torque params: 2891<br>- all lat active: 273<br>- no input all lat active: 191  |
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFCG8........</sub>        | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18                                                        | 26 routes,<br>489 segments<br>(8.2 hours)    | - [car faulted: 10](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a%7C2024-04-10--14-57-01)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 489<br>- all lat active: 12<br>- no input all lat active: 4      |
| [030e7d18f7c4ea9d](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHTX........</sub>           | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                                                              | 128 routes,<br>2032 segments<br>(33.9 hours) | - [car faulted: 3](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d%7C2024-04-29--15-11-58)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 1879<br>- all lat active: 47<br>- no input all lat active: 23    |
| [d8e00d93d49817ea](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea)<br><sub>LEXUS_RX<br>2T2ZZMCA6........</sub>                   | LEXUS RX 2018 🆚<br>Lexus RX 2017-19                                                                              | 89 routes,<br>1542 segments<br>(25.7 hours)  | - [missing ECU FW: 575](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-16--15-07-37)<br>- [spotty FW: 575](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-16--15-07-37)                                                                                                                                                                                                                                                                                                                          | - valid torque params: 1542<br>- all lat active: 155<br>- no input all lat active: 113  |
| [4e92a7e0078767c8](https://useradmin.comma.ai/?onebox=4e92a7e0078767c8)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AGX........</sub>       | HYUNDAI Elantra 2021 🆚<br>Hyundai Elantra 2021-23                                                                | 16 routes,<br>363 segments<br>(6.0 hours)    | - [high lateral accel factor: 7](https://useradmin.comma.ai/?onebox=4e92a7e0078767c8%7C2024-04-20--18-39-36)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 348<br>- all lat active: 174<br>- no input all lat active: 130   |
| [0dacabc563f7e7d7](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 88 routes,<br>1543 segments<br>(25.7 hours)  | - [missing ECU FW: 1499](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-04-17--17-36-06)<br>- [spotty FW: 44](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-04-29--12-28-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-04-17--17-36-06)                                                                                                                                                                                                                 | - valid torque params: 1543<br>- all lat active: 281<br>- no input all lat active: 187  |
| [dafb0cb9e28e0249](https://useradmin.comma.ai/?onebox=dafb0cb9e28e0249)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>          | None 🆚<br>None                                                                                                   | 13 routes,<br>103 segments<br>(1.7 hours)    | - [car faulted: 1](https://useradmin.comma.ai/?onebox=dafb0cb9e28e0249%7C2024-04-17--18-45-40)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - all lat active: 7<br>- no input all lat active: 7<br>- valid torque params: 6         |
| [672d4090a6b92b0b](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81BF........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                                         | 7 routes,<br>130 segments<br>(2.2 hours)     | - [high lateral accel factor: 61](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b%7C2023-11-22--06-10-45)<br>- [segment too short (info): 2](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b%7C2023-11-22--06-10-45)                                                                                                                                                                                                                                                                                                   | - all lat active: 6<br>- no input all lat active: 4<br>- valid torque params: 3         |
| [c042beb296a531c3](https://useradmin.comma.ai/?onebox=c042beb296a531c3)<br><sub>CHRYSLER_PACIFICA_2018<br>2C4RC1GG5........</sub>     | CHRYSLER Pacifica 2018 🆚<br>Chrysler Pacifica 2017-18                                                            | 53 routes,<br>1185 segments<br>(19.8 hours)  | - [car faulted: 236](https://useradmin.comma.ai/?onebox=c042beb296a531c3%7C2024-04-21--08-33-18)                                                                                                                                                                                                                                                                                                                                                                                                                               | - valid torque params: 1164<br>- all lat active: 68<br>- no input all lat active: 24    |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>            | None 🆚<br>None                                                                                                   | 89 routes,<br>1317 segments<br>(21.9 hours)  | - [CAN invalid: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)<br>- [car faulted: 1](https://useradmin.comma.ai/?onebox=22901377be496047%7C2024-04-10--15-24-44)                                                                                                                                                                                                                                                                                                                               | - valid torque params: 1316<br>- all lat active: 41<br>- no input all lat active: 17    |
| [251122482046c71b](https://useradmin.comma.ai/?onebox=251122482046c71b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 49 routes,<br>574 segments<br>(9.6 hours)    | - [missing ECU FW: 329](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--18-03-38)<br>- [spotty FW: 245](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-29--13-12-54)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--18-03-38)                                                                                                                                                                                                                 | - valid torque params: 550<br>- all lat active: 85<br>- no input all lat active: 52     |
| [d15c6c91d28a861b](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H53........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 21 routes,<br>772 segments<br>(12.9 hours)   | - [missing ECU FW: 740](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--07-56-18)<br>- [spotty FW: 32](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-17--22-52-19)<br>- [CAN invalid: 7](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [segment too short (info): 3](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--07-56-18) | - valid torque params: 679<br>- all lat active: 334<br>- no input all lat active: 234   |

Dongles to re-run category: `ef8c34c763849757 030e7d18f7c4ea9d 72c57a77995168b4 4e92a7e0078767c8 7e63a5eee34d3fb0 903ac8da1aa52026 251122482046c71b 0dacabc563f7e7d7 d15c6c91d28a861b a72482b4766832e9 11d207f3143e07b3 dafb0cb9e28e0249 d031a8c98c8863da ad48d1930c6a3571 734971c66100033f a74cb70b7a19e427 214c417708d4eabc 23daff6c438612d2 d8e00d93d49817ea 672d4090a6b92b0b 61c374c8e5e59db3 fc4d8f4e5f8b353a 22901377be496047 13858e4047f4aec8 39ecd9e9391c1810 c042beb296a531c3 c88f65eeaee4003a 93bc5d4df12aa933 9e7b03d47798346e`
</details>