### PR TITLE
CI/Simulator: Add Metadrive test to CI

### DIFF
--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -37,8 +37,8 @@ jobs:
       run: |
         ${{ env.RUN }} "pytest tools/plotjuggler/"
 
-  simulator:
-    name: simulator
+  simulator_build:
+    name: simulator docker build
     runs-on: ubuntu-latest
     if: github.repository == 'commaai/openpilot'
     timeout-minutes: 45
@@ -56,8 +56,8 @@ jobs:
       run: |
         selfdrive/test/docker_build.sh sim
 
-  simulator_bridge:
-    name: simulator bridge test
+  simulator_driving:
+    name: simulator driving
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -77,7 +77,6 @@ jobs:
                         source selfdrive/test/setup_xvfb.sh && \
                         source selfdrive/test/setup_vsound.sh && \
                         CI=1 tools/sim/tests/test_metadrive_bridge.py"
-
 
   devcontainer:
     name: devcontainer

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -56,6 +56,33 @@ jobs:
       run: |
         selfdrive/test/docker_build.sh sim
 
+  simulator_bridge:
+    strategy:
+     fail-fast: false
+     matrix:
+      #run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+      run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
+    name: simulator bridge test
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - run: git lfs pull
+    - uses: ./.github/workflows/setup-with-retry
+    - name: Build base docker image
+      run: eval "$BUILD"
+    - name: Build base cl image
+      run: eval "$BUILD_CL"
+    - name: Build openpilot
+      run: |
+        ${{ env.RUN }} "scons -j$(nproc)"
+    - name: Run bridge test
+      run: |
+        ${{ env.RUN_CL }} "source selfdrive/test/setup_xvfb.sh && source selfdrive/test/setup_vsound.sh && CI=1 tools/sim/tests/test_metadrive_bridge.py"
+
+
   devcontainer:
     name: devcontainer
     runs-on: ubuntu-latest

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -57,11 +57,6 @@ jobs:
         selfdrive/test/docker_build.sh sim
 
   simulator_bridge:
-    strategy:
-     fail-fast: false
-     matrix:
-      #run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-      run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
     name: simulator bridge test
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -73,7 +68,6 @@ jobs:
     - uses: ./.github/workflows/setup-with-retry
     - name: Build base docker image
       run: eval "$BUILD"
-
     - name: Build openpilot
       run: |
         ${{ env.RUN }} "scons -j$(nproc)"

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -79,7 +79,10 @@ jobs:
         ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run bridge test
       run: |
-        ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && source selfdrive/test/setup_vsound.sh && CI=1 tools/sim/tests/test_metadrive_bridge.py"
+        ${{ env.RUN }} "export MAPBOX_TOKEN='pk.eyJ1Ijoiam5ld2IiLCJhIjoiY2xxNW8zZXprMGw1ZzJwbzZneHd2NHljbSJ9.gV7VPRfbXFetD-1OVF0XZg' &&
+                        source selfdrive/test/setup_xvfb.sh &&
+                        source selfdrive/test/setup_vsound.sh &&
+                        CI=1 tools/sim/tests/test_metadrive_bridge.py"
 
 
   devcontainer:

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -60,11 +60,11 @@ jobs:
     strategy:
      fail-fast: false
      matrix:
-      #run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+      #run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
       run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
     name: simulator bridge test
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
       with:
@@ -73,14 +73,13 @@ jobs:
     - uses: ./.github/workflows/setup-with-retry
     - name: Build base docker image
       run: eval "$BUILD"
-    - name: Build base cl image
-      run: eval "$BUILD_CL"
+
     - name: Build openpilot
       run: |
         ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run bridge test
       run: |
-        ${{ env.RUN_CL }} "source selfdrive/test/setup_xvfb.sh && source selfdrive/test/setup_vsound.sh && CI=1 tools/sim/tests/test_metadrive_bridge.py"
+        ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && source selfdrive/test/setup_vsound.sh && CI=1 tools/sim/tests/test_metadrive_bridge.py"
 
 
   devcontainer:

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -79,9 +79,9 @@ jobs:
         ${{ env.RUN }} "scons -j$(nproc)"
     - name: Run bridge test
       run: |
-        ${{ env.RUN }} "export MAPBOX_TOKEN='pk.eyJ1Ijoiam5ld2IiLCJhIjoiY2xxNW8zZXprMGw1ZzJwbzZneHd2NHljbSJ9.gV7VPRfbXFetD-1OVF0XZg' &&
-                        source selfdrive/test/setup_xvfb.sh &&
-                        source selfdrive/test/setup_vsound.sh &&
+        ${{ env.RUN }} "export MAPBOX_TOKEN='pk.eyJ1Ijoiam5ld2IiLCJhIjoiY2xxNW8zZXprMGw1ZzJwbzZneHd2NHljbSJ9.gV7VPRfbXFetD-1OVF0XZg' && \
+                        source selfdrive/test/setup_xvfb.sh && \
+                        source selfdrive/test/setup_vsound.sh && \
                         CI=1 tools/sim/tests/test_metadrive_bridge.py"
 
 

--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -46,7 +46,7 @@ class SimulatorBridge(ABC):
     self.world: World | None = None
 
     self.past_startup_engaged = False
-    self.startup_button_pingpong = True
+    self.startup_button_prev = True
 
   def _on_shutdown(self, signal, frame):
     self.shutdown()
@@ -162,8 +162,8 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
 
         self.past_startup_engaged = True
       elif not self.past_startup_engaged and controlsState.engageable:
-        self.simulator_state.cruise_button = CruiseButtons.DECEL_SET if self.startup_button_pingpong else CruiseButtons.MAIN # force engagement on startup
-        self.startup_button_pingpong = not self.startup_button_pingpong
+        self.simulator_state.cruise_button = CruiseButtons.DECEL_SET if self.startup_button_prev else CruiseButtons.MAIN # force engagement on startup
+        self.startup_button_prev = not self.startup_button_prev
 
       throttle_out = throttle_op if self.simulator_state.is_engaged else throttle_manual
       brake_out = brake_op if self.simulator_state.is_engaged else brake_manual

--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -46,6 +46,7 @@ class SimulatorBridge(ABC):
     self.world: World | None = None
 
     self.past_startup_engaged = False
+    self.startup_button_pingpong = True
 
   def _on_shutdown(self, signal, frame):
     self.shutdown()
@@ -161,7 +162,8 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
 
         self.past_startup_engaged = True
       elif not self.past_startup_engaged and controlsState.engageable:
-        self.simulator_state.cruise_button = CruiseButtons.DECEL_SET # force engagement on startup
+        self.simulator_state.cruise_button = CruiseButtons.DECEL_SET if self.startup_button_pingpong else 0 # force engagement on startup
+        self.startup_button_pingpong = not self.startup_button_pingpong
 
       throttle_out = throttle_op if self.simulator_state.is_engaged else throttle_manual
       brake_out = brake_op if self.simulator_state.is_engaged else brake_manual

--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -162,7 +162,7 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
 
         self.past_startup_engaged = True
       elif not self.past_startup_engaged and controlsState.engageable:
-        self.simulator_state.cruise_button = CruiseButtons.DECEL_SET if self.startup_button_pingpong else 0 # force engagement on startup
+        self.simulator_state.cruise_button = CruiseButtons.DECEL_SET if self.startup_button_pingpong else CruiseButtons.MAIN # force engagement on startup
         self.startup_button_pingpong = not self.startup_button_pingpong
 
       throttle_out = throttle_op if self.simulator_state.is_engaged else throttle_manual

--- a/tools/sim/tests/test_sim_bridge.py
+++ b/tools/sim/tests/test_sim_bridge.py
@@ -62,8 +62,6 @@ class TestSimBridgeBase(unittest.TestCase):
     while time.monotonic() < start_time + max_time_per_step:
       sm.update()
 
-      q.put("cruise_down")  # Try engaging
-
       if sm.all_alive() and sm['controlsState'].active:
         control_active += 1
 


### PR DESCRIPTION
Before, when trying to force engage using by pressing the same `CruiseButton.Decel`, which is intended to force engagement, and it should work probably. However, the model might drop eval and OP would not engage. Since our last cruise button was `CruiseButton.Decel` already, pressing it again would not trigger any button event. This PR "pingpong" two value of `CruiseButton` which ensures the OP engage (ran local test 60 times successfully). This is due to how Metadrive starts `onroad` differently compared to normal driving

Prereq to run consistent test: https://github.com/commaai/openpilot/pull/32308
Also resolves:  [#31125](https://github.com/commaai/openpilot/issues/31125)

two successful CI run with this PR, with 50 simulator_bridge test each:
https://github.com/commaai/openpilot/actions/runs/8956045113/job/24597388950
https://github.com/commaai/openpilot/actions/runs/8955986123