### PR TITLE
boardd: Improve performance of `can_list_to_can_capnp()`

### DIFF
--- a/selfdrive/boardd/boardd_api_impl.pyx
+++ b/selfdrive/boardd/boardd_api_impl.pyx
@@ -15,16 +15,17 @@ cdef extern from "can_list_to_can_capnp.cc":
   void can_list_to_can_capnp_cpp(const vector[can_frame] &can_list, string &out, bool sendCan, bool valid)
 
 def can_list_to_can_capnp(can_msgs, msgtype='can', valid=True):
+  cdef can_frame *f
   cdef vector[can_frame] can_list
-  can_list.reserve(len(can_msgs))
 
-  cdef can_frame f
+  can_list.reserve(len(can_msgs))
   for can_msg in can_msgs:
+    f = &(can_list.emplace_back())
     f.address = can_msg[0]
     f.busTime = can_msg[1]
     f.dat = can_msg[2]
     f.src = can_msg[3]
-    can_list.push_back(f)
+
   cdef string out
   can_list_to_can_capnp_cpp(can_list, out, msgtype == 'sendcan', valid)
   return out


### PR DESCRIPTION
Updated the loop to construct `can_frame` objects directly within the vector using `emplace_back`, cutting out unnecessary memory allocations and can data copies during iteration over can_msgs, leading to smoother performance.