### PR TITLE
cabana: add signal table for real-time signal value visualization

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -27,7 +27,7 @@ cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "asset
 
 cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/socketcanstream.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
                                                'streams/routes.cc', 'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
-                                               'utils/export.cc', 'utils/util.cc',
+                                               'utils/export.cc', 'utils/util.cc', 'utils/signaltable.cc',
                                                'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',
                                                'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -163,12 +163,14 @@ void ChartView::signalUpdated(const cabana::Signal *sig) {
     }
     updateTitle();
     updateSeries(sig);
+    emit charts_widget->seriesChanged();
   }
 }
 
 void ChartView::msgUpdated(MessageId id) {
   if (std::any_of(sigs.cbegin(), sigs.cend(), [=](auto &s) { return s.msg_id.address == id.address; })) {
     updateTitle();
+    emit charts_widget->seriesChanged();
   }
 }
 

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include <unordered_map>
 #include <utility>
 
@@ -42,6 +43,8 @@ public:
   ChartsWidget(QWidget *parent = nullptr);
   void showChart(const MessageId &id, const cabana::Signal *sig, bool show, bool merge);
   inline bool hasSignal(const MessageId &id, const cabana::Signal *sig) { return findChart(id, sig) != nullptr; }
+  std::set<std::pair<MessageId, QString>> allSignals() const;
+  int chartCount() const { return charts.size(); }
 
 public slots:
   void setColumnCount(int n);
@@ -49,7 +52,6 @@ public slots:
   void setZoom(double min, double max);
 
 signals:
-  void dock(bool floating);
   void rangeChanged(double min, double max, bool is_zommed);
   void seriesChanged();
 
@@ -75,19 +77,15 @@ private:
   void updateLayout(bool force = false);
   void settingChanged();
   void showValueTip(double sec);
-  bool eventFilter(QObject *obj, QEvent *event) override;
   void newTab();
   void removeTab(int index);
   inline QList<ChartView *> &currentCharts() { return tab_charts[tabbar->tabData(tabbar->currentIndex()).toInt()]; }
   ChartView *findChart(const MessageId &id, const cabana::Signal *sig);
 
-  QLabel *title_label;
   QLabel *range_lb;
   LogSlider *range_slider;
   QAction *range_lb_action;
   QAction *range_slider_action;
-  bool docking = true;
-  ToolButton *dock_btn;
 
   QAction *undo_zoom_action;
   QAction *redo_zoom_action;

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -194,6 +194,7 @@ LogsWidget::LogsWidget(QWidget *parent) : QFrame(parent) {
   main_layout->addWidget(logs = new QTableView(this));
   logs->setModel(model = new HistoryLogModel(this));
   logs->setItemDelegate(delegate = new MessageBytesDelegate(this));
+  logs->setSelectionMode(QAbstractItemView::NoSelection);
   logs->setHorizontalHeader(new HeaderView(Qt::Horizontal, this));
   logs->horizontalHeader()->setDefaultAlignment(Qt::AlignRight | (Qt::Alignment)Qt::TextWordWrap);
   logs->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -7,6 +7,7 @@
 #include <QProgressBar>
 #include <QSplitter>
 #include <QStatusBar>
+#include <QTabWidget>
 #include <set>
 
 #include "tools/cabana/chart/chartswidget.h"
@@ -15,13 +16,13 @@
 #include "tools/cabana/messageswidget.h"
 #include "tools/cabana/videowidget.h"
 #include "tools/cabana/tools/findsimilarbits.h"
+#include "tools/cabana/utils/signaltable.h"
 
 class MainWindow : public QMainWindow {
   Q_OBJECT
 
 public:
   MainWindow();
-  void dockCharts(bool dock);
   void showStatusMessage(const QString &msg, int timeout = 0) { statusBar()->showMessage(msg, timeout); }
   void loadFile(const QString &fn, SourceSet s = SOURCE_ALL);
   ChartsWidget *charts_widget = nullptr;
@@ -80,10 +81,12 @@ protected:
   VideoWidget *video_widget = nullptr;
   QDockWidget *video_dock;
   QDockWidget *messages_dock;
+  QTabWidget *left_tab_widget_ = nullptr;
+  QTabWidget *charts_tab_widget_ = nullptr;
   MessagesWidget *messages_widget = nullptr;
+  SignalTable *signal_table_ = nullptr;
+  SignalTable *charts_signal_table_ = nullptr;
   CenterWidget *center_widget;
-  QWidget *floating_window = nullptr;
-  QVBoxLayout *charts_layout;
   QProgressBar *progress_bar;
   QLabel *status_label;
   QJsonDocument fingerprint_to_dbc;

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -29,10 +29,9 @@ static bool isMessageActive(const MessageId &id) {
 MessagesWidget::MessagesWidget(QWidget *parent) : menu(new QMenu(this)), QWidget(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
-  // toolbar
-  main_layout->addWidget(createToolBar());
   // message table
   main_layout->addWidget(view = new MessageView(this));
+  main_layout->addWidget(createToolBar());
   view->setItemDelegate(delegate = new MessageBytesDelegate(view, settings.multiple_lines_hex));
   view->setModel(model = new MessageListModel(this));
   view->setHeader(header = new MessageViewHeader(this));
@@ -90,7 +89,7 @@ MessagesWidget::MessagesWidget(QWidget *parent) : menu(new QMenu(this)), QWidget
 QWidget *MessagesWidget::createToolBar() {
   QWidget *toolbar = new QWidget(this);
   QHBoxLayout *layout = new QHBoxLayout(toolbar);
-  layout->setContentsMargins(0, 9, 0, 0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->addWidget(suppress_add = new QPushButton("Suppress Highlighted"));
   layout->addWidget(suppress_clear = new QPushButton());
   suppress_clear->setToolTip(tr("Clear suppressed"));

--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -90,6 +90,7 @@ void ReplayStream::seekTo(double ts) {
   current_sec_ = ts;
   std::set<MessageId> new_msgs;
   msgsReceived(&new_msgs, false);
+  emit seekingTo(ts);
 
   // Seek to the specified timestamp
   replay->seekTo(std::max(double(0), ts), false);

--- a/tools/cabana/utils/signaltable.cc
+++ b/tools/cabana/utils/signaltable.cc
@@ -1,0 +1,89 @@
+#include "tools/cabana/utils/signaltable.h"
+
+#include <algorithm>
+#include <QHeaderView>
+#include <QScrollBar>
+#include <QWheelEvent>
+
+void SignalTableModel::setSignals(const std::set<std::pair<MessageId, QString>> &sigs) {
+  signals_ = sigs;
+  updateState(nullptr, true);
+}
+
+void SignalTableModel::updateState(const std::set<MessageId> *new_msgs, bool has_new_ids) {
+  beginResetModel();
+  if (new_msgs) {
+    for (const auto &id : *new_msgs)
+      updateMessage(id, can->lastMessage(id));
+  } else {
+    signals_map_.clear();
+    for (const auto &[id, msg] : can->lastMessages())
+      updateMessage(id, msg);
+  }
+
+  signal_items_.clear();
+  signal_items_.reserve(signals_map_.size());
+  for (const auto &[_, item] : signals_map_) {
+    signal_items_.push_back(&item);
+  }
+  std::sort(signal_items_.rbegin(), signal_items_.rend(),
+            [](const Item *l, const Item *r) { return l->seconds < r->seconds; });
+  endResetModel();
+}
+
+void SignalTableModel::updateMessage(const MessageId &id, const CanData &data) {
+  if (auto m = dbc()->msg(id); m && !data.dat.empty()) {
+    for (auto signal : m->getSignals()) {
+      double value;
+      auto key = std::make_pair(id, signal->name);
+      if ((display_all_ || signals_.count(key) > 0) &&
+          signal->getValue(data.dat.data(), data.dat.size(), &value)) {
+        auto &item = signals_map_[key];
+        item.seconds = data.ts;
+        item.msg_name = QString("%1 %2").arg(m->name, id.toString());
+        item.sig_name = signal->name;
+        item.unit = signal->unit;
+        item.value = signal->formatValue(value);
+      }
+    }
+  }
+}
+
+QVariant SignalTableModel::headerData(int section, Qt::Orientation orientation, int role) const {
+  const static QString titles[] = {tr("Time"), tr("Signal"), tr("Message"), tr("Value")};
+  if (orientation != Qt::Horizontal || role != Qt::DisplayRole) return {};
+  return titles[section];
+}
+
+QVariant SignalTableModel::data(const QModelIndex &index, int role) const {
+  if (role == Qt::DisplayRole) {
+    const Item *item = signal_items_.at(index.row());
+    switch (index.column()) {
+      case 0: return QString::number(item->seconds, 'f', 3);
+      case 1: return item->sig_name;
+      case 2: return item->msg_name;
+      case 3: return item->value;
+    }
+  } else if (role == Qt::TextAlignmentRole && index.column() == 3) {
+    return (uint32_t)(Qt::AlignRight | Qt::AlignVCenter);
+  }
+  return {};
+}
+
+SignalTable::SignalTable(QWidget *parent) : QTableView(parent) {
+  setModel(model_ = new SignalTableModel(this));
+  verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
+  horizontalHeader()->setStretchLastSection(true);
+  setSelectionMode(QAbstractItemView::NoSelection);
+  QObject::connect(can, &AbstractStream::msgsReceived, this, [this](const std::set<MessageId> *new_msgs, bool has_new_ids) {
+    if (isVisible()) model_->updateState(new_msgs, has_new_ids);
+  });
+}
+
+void SignalTable::wheelEvent(QWheelEvent *event) {
+  if (event->modifiers() == Qt::ShiftModifier) {
+    QApplication::sendEvent(horizontalScrollBar(), event);
+  } else {
+    QTableView::wheelEvent(event);
+  }
+}

--- a/tools/cabana/utils/signaltable.h
+++ b/tools/cabana/utils/signaltable.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+#include <QAbstractTableModel>
+#include <QTableView>
+
+#include "tools/cabana/dbc/dbc.h"
+#include "tools/cabana/streams/abstractstream.h"
+
+class SignalTableModel : public QAbstractTableModel {
+  Q_OBJECT
+public:
+  SignalTableModel(QObject *parent) : QAbstractTableModel(parent) {}
+  int rowCount(const QModelIndex &parent = QModelIndex()) const override { return signal_items_.size(); }
+  int columnCount(const QModelIndex &parent = QModelIndex()) const override { return 4; }
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+  void updateState(const std::set<MessageId> *new_msgs, bool has_new_ids);
+  void setSignals(const std::set<std::pair<MessageId, QString>> &sigs);
+
+protected:
+  void updateMessage(const MessageId &id, const CanData &data);
+
+  struct Item {
+    double seconds;
+    QString msg_name;
+    QString sig_name;
+    QString unit;
+    QString value;
+  };
+  std::vector<const Item *> signal_items_;
+  std::set<std::pair<MessageId, QString>> signals_;
+  std::map<std::pair<MessageId, QString>, Item> signals_map_;
+  bool display_all_ = false;
+  friend class SignalTable;
+};
+
+class SignalTable : public QTableView {
+  Q_OBJECT
+public:
+  SignalTable(QWidget *parent);
+  void wheelEvent(QWheelEvent *event) override;
+  void setSignals(const std::set<std::pair<MessageId, QString>> &sigs) { model_->setSignals(sigs); }
+  void setDisplayALlSignal(bool all) {
+    model_->display_all_ = all;
+    model_->updateState(nullptr, true);
+  }
+  void refresh() { model_->updateState(nullptr, true); }
+
+protected:
+  SignalTableModel *model_;
+};
+

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -10,6 +10,7 @@
 #include <QTabBar>
 
 #include "selfdrive/ui/qt/widgets/cameraview.h"
+#include "tools/cabana/streams/replaystream.h"
 #include "tools/cabana/utils/util.h"
 #include "tools/replay/logreader.h"
 
@@ -23,7 +24,6 @@ class InfoLabel : public QWidget {
 public:
   InfoLabel(QWidget *parent);
   void showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm, const AlertInfo &alert);
-  void showAlert(const AlertInfo &alert);
   void paintEvent(QPaintEvent *event) override;
   QPixmap pixmap;
   QString second;
@@ -58,6 +58,21 @@ private:
   InfoLabel *thumbnail_label;
 };
 
+class CustomCameraView : public CameraWidget {
+public:
+  CustomCameraView(QWidget *parent);
+  void setAlert(const AlertInfo &alert) {
+    if (alert.status != alert_.status || alert.text1 != alert_.text1 || alert.text2 != alert_.text2) {
+      alert_ = alert;
+      update();
+    }
+  }
+  void paintGL() override;
+  QTimer loading_timer_;
+  bool loading_ = false;
+  AlertInfo alert_;
+};
+
 class VideoWidget : public QFrame {
   Q_OBJECT
 
@@ -75,7 +90,7 @@ protected:
   void loopPlaybackClicked();
   void vipcAvailableStreamsUpdated(std::set<VisionStreamType> streams);
 
-  CameraWidget *cam_widget;
+  CustomCameraView *cam_widget;
   double maximum_time = 0;
   QToolButton *time_btn = nullptr;
   ToolButton *seek_backward_btn = nullptr;
@@ -84,7 +99,6 @@ protected:
   ToolButton *loop_btn = nullptr;
   QToolButton *speed_btn = nullptr;
   ToolButton *skip_to_end_btn = nullptr;
-  InfoLabel *alert_label = nullptr;
   Slider *slider = nullptr;
   QTabBar *camera_tab = nullptr;
 };


### PR DESCRIPTION
The Signal Table widget displays current signal values to users in a clear and intuitive manner.

1. In the message panel, the signal table shows the current values of all signals along with their recent reception times:
![Screenshot from 2024-05-09 02-32-22](https://github.com/commaai/openpilot/assets/27770/61175e55-2d07-4d43-9902-f6abe7324124)
 
2. In the chart panel, the signal table shows current values and recent reception times for selected signals.
![Screenshot from 2024-05-09 02-33-26](https://github.com/commaai/openpilot/assets/27770/d899c741-bdab-458b-9889-f3bf320f1520)

video:

[Kazam_screencast_00146.webm](https://github.com/commaai/openpilot/assets/27770/6e008084-dd18-4311-a87c-954b4f727b09)

This PR also simplifies video layouts, adding "LOADING", "PAUSED" text for clarity  the replay's status:

![2024-05-09_16-38](https://github.com/commaai/openpilot/assets/27770/33f841d1-cef7-4ea5-b126-128469114ee3)


