### PR TITLE
deleter handles files at log_root

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -56,10 +56,10 @@ def delete(path: str) -> bool:
     return True
   elif os.path.isdir(path):
     for f in filter(lambda n: not n.endswith('.lock'), os.listdir(path)):
-      delete(os.path.join(path, f))
-      if len(os.listdir(path)) == 0:
-        cloudlog.info(f"deleting directory: {path}")
-        shutil.rmtree(path)
+      if delete(os.path.join(path, f)):
+        if len(os.listdir(path)) == 0:
+          cloudlog.info(f"deleting directory: {path}")
+          shutil.rmtree(path)
         return True
   return False
 

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import time
 import threading
 import unittest
@@ -9,7 +8,6 @@ from collections.abc import Sequence
 
 import openpilot.system.loggerd.deleter as deleter
 from openpilot.common.timeout import Timeout, TimeoutException
-from openpilot.system.hardware.hw import Paths
 from openpilot.system.loggerd.tests.loggerd_tests_common import UploaderTestCase
 
 Stats = namedtuple("Stats", ['f_bavail', 'f_blocks', 'f_frsize'])
@@ -68,33 +66,13 @@ class TestDeleter(UploaderTestCase):
 
     self.assertEqual(deleted_order, f_paths, "Files not deleted in expected order")
 
-  def test_delete_empty_dir(self):
-    f_path = self.make_file_with_data(os.path.join('test'), self.f_type)
-    self.start_thread()
-    self.join_thread()
-
-    assert not f_path.exists()
-    assert not os.path.exists(os.path.join(Paths.log_root(), 'test'))
-
   def test_delete_file_log_root(self):
     f_path = self.make_file_with_data('', 'file.txt')
-    f_path_lock = self.make_file_with_data('', self.f_type, lock=True)
 
     self.start_thread()
-    start_time = time.monotonic()
-    while f_path.exists() and time.monotonic() - start_time < 2:
-      time.sleep(0.01)
     self.join_thread()
 
-    assert f_path_lock.exists(), "Lock file deleted"
     assert not f_path.exists(), "File not deleted"
-
-  def test_delete_deletes_one(self):
-    f_path = self.make_file_with_data(self.seg_format.format(0), 'a.txt')
-    f_path2 = self.make_file_with_data(self.seg_format.format(0), 'b.txt')
-
-    assert deleter.delete(os.path.join(Paths.log_root(), self.seg_format.format(0)))
-    assert(sum([f_path.exists(), f_path2.exists()])) == 1
 
   def test_delete_order(self):
     self.assertDeleteOrder([

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -66,13 +66,18 @@ class TestDeleter(UploaderTestCase):
 
     self.assertEqual(deleted_order, f_paths, "Files not deleted in expected order")
 
-  def test_delete_file_log_root(self):
-    f_path = self.make_file_with_data('', 'file.txt')
+  def test_delete_user_created(self):
+    f_paths = [
+      self.make_file_with_data(Path(''), 'file.txt'),
+      self.make_file_with_data(Path('a'), 'file.txt'),
+      self.make_file_with_data(Path('b') / 'c', 'file.txt')
+    ]
 
     self.start_thread()
+    time.sleep(0.3)
     self.join_thread()
 
-    assert not f_path.exists(), "File not deleted"
+    assert all(not f.exists() for f in f_paths), "Files not deleted"
 
   def test_delete_order(self):
     self.assertDeleteOrder([

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -89,6 +89,13 @@ class TestDeleter(UploaderTestCase):
     assert f_path_lock.exists(), "Lock file deleted"
     assert not f_path.exists(), "File not deleted"
 
+  def test_delete_deletes_one(self):
+    f_path = self.make_file_with_data(self.seg_format.format(0), 'a.txt')
+    f_path2 = self.make_file_with_data(self.seg_format.format(0), 'b.txt')
+
+    assert deleter.delete(os.path.join(Paths.log_root(), self.seg_format.format(0)))
+    assert(sum([f_path.exists(), f_path2.exists()])) == 1
+
   def test_delete_order(self):
     self.assertDeleteOrder([
       self.make_file_with_data(self.seg_format.format(0), self.f_type),


### PR DESCRIPTION
deleter was only looking to delete directories, this allows it to find files at `log_root`
it sticks them in front to be deleted first if space is needed