### PR TITLE
Remove qlog param from demo example

### DIFF
--- a/tools/plotjuggler/README.md
+++ b/tools/plotjuggler/README.md
@@ -58,7 +58,7 @@ If streaming to PlotJuggler from a replay on your PC, simply run: `./juggle.py -
 
 For a quick demo, go through the installation step and run this command:
 
-`./juggle.py --demo --qlog --layout=layouts/demo.xml`
+`./juggle.py --demo --layout=layouts/demo.xml`
 
 ## Layouts
 


### PR DESCRIPTION
qlog param was removed in this commit

https://github.com/commaai/openpilot/commit/d7e7659852f14ca458605f13c2bdae90f5de5a45