### PR TITLE
logreader: skip internal source if connection refused

### DIFF
--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -8,15 +8,15 @@ DATA_ENDPOINT = os.getenv("DATA_ENDPOINT", "http://data-raw.comma.internal/")
 
 
 def internal_source_available():
-    try:
-      hostname = urlparse(DATA_ENDPOINT).hostname
-      port = urlparse(DATA_ENDPOINT).port or 80
-      with socket.socket() as s:
-        s.connect((hostname, port))
-      return True
-    except (socket.gaierror, ConnectionRefusedError):
-      pass
-    return False
+  try:
+    hostname = urlparse(DATA_ENDPOINT).hostname
+    port = urlparse(DATA_ENDPOINT).port or 80
+    with socket.socket() as s:
+      s.connect((hostname, port))
+    return True
+  except (socket.gaierror, ConnectionRefusedError):
+    pass
+  return False
 
 def resolve_name(fn):
   if fn.startswith("cd:/"):

--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -8,15 +8,15 @@ DATA_ENDPOINT = os.getenv("DATA_ENDPOINT", "http://data-raw.comma.internal/")
 
 
 def internal_source_available():
-  try:
-    hostname = urlparse(DATA_ENDPOINT).hostname
-    if hostname:
-      socket.gethostbyname(hostname)
+    try:
+      hostname = urlparse(DATA_ENDPOINT).hostname
+      port = urlparse(DATA_ENDPOINT).port or 80
+      with socket.socket() as s:
+        s.connect((hostname, port))
       return True
-  except socket.gaierror:
-    pass
-  return False
-
+    except (socket.gaierror, ConnectionRefusedError):
+      pass
+    return False
 
 def resolve_name(fn):
   if fn.startswith("cd:/"):

--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -18,6 +18,7 @@ def internal_source_available():
     pass
   return False
 
+
 def resolve_name(fn):
   if fn.startswith("cd:/"):
     return fn.replace("cd:/", DATA_ENDPOINT)

--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -11,7 +11,7 @@ def internal_source_available():
   try:
     hostname = urlparse(DATA_ENDPOINT).hostname
     port = urlparse(DATA_ENDPOINT).port or 80
-    with socket.socket() as s:
+    with socket.socket(socket.AF_INET,socket.SOCK_STREAM) as s:
       s.connect((hostname, port))
     return True
   except (socket.gaierror, ConnectionRefusedError):


### PR DESCRIPTION
opening a TCP socket is a very quick check