### PR TITLE
ui: generate JWT on every request

### DIFF
--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -84,14 +84,7 @@ void HttpRequest::sendRequest(const QString &requestURL, const HttpRequest::Meth
     qDebug() << "HttpRequest is active";
     return;
   }
-  QString token;
-  if (create_jwt) {
-    token = CommaApi::create_jwt();
-  } else {
-    QString token_json = QString::fromStdString(util::read_file(util::getenv("HOME") + "/.comma/auth.json"));
-    QJsonDocument json_d = QJsonDocument::fromJson(token_json.toUtf8());
-    token = json_d["access_token"].toString();
-  }
+  QString token = CommaApi::create_jwt();
 
   QNetworkRequest request;
   request.setUrl(QUrl(requestURL));


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->
Fixes #32398
### Fix Description
Took a look at this, the only areas where `create_jwt` is explicitly set to false is in `sshkeys.cc` and `setup.cc`. Since #32398 mentions wanting to create a new JWT in every request we can just make some changes in `HttpRequest::sendRequest` from  `api.cc` where `CommaApi::create_jwt()` is used for `token` whenever `sendRequest` is called. Before their were some conditions in place where `token_json` would sometimes be used instead of creating a new JWT.

### Verification

The flow shouldn't change since all we're doing is making sure `create_jwt` is being used for every `sendRequest` now.

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

