### PR TITLE
Events: remove dependency

### DIFF
--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import bisect
 import math
 import os
 from enum import IntEnum
@@ -61,8 +62,8 @@ class Events:
 
   def add(self, event_name: int, static: bool=False) -> None:
     if static:
-      self.static_events.append(event_name)
-    self.events.append(event_name)
+      bisect.insort(self.static_events, event_name)
+    bisect.insort(self.events, event_name)
 
   def clear(self) -> None:
     self.events_prev = {k: (v + 1 if k in self.events else 0) for k, v in self.events_prev.items()}
@@ -92,7 +93,7 @@ class Events:
 
   def add_from_msg(self, events):
     for e in events:
-      self.events.append(e.name.raw)
+      bisect.insort(self.events, e.name.raw)
 
   def to_msg(self):
     ret = []

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -3,7 +3,6 @@ import math
 import os
 from enum import IntEnum
 from collections.abc import Callable
-from sortedcontainers import SortedList
 
 from cereal import log, car
 import cereal.messaging as messaging
@@ -49,12 +48,12 @@ EVENT_NAME = {v: k for k, v in EventName.schema.enumerants.items()}
 
 class Events:
   def __init__(self):
-    self.events: SortedList[int] = SortedList()
-    self.static_events: SortedList[int] = SortedList()
+    self.events: list[int] = []
+    self.static_events: list[int] = []
     self.events_prev = dict.fromkeys(EVENTS.keys(), 0)
 
   @property
-  def names(self) -> SortedList[int]:
+  def names(self) -> list[int]:
     return self.events
 
   def __len__(self) -> int:
@@ -62,8 +61,8 @@ class Events:
 
   def add(self, event_name: int, static: bool=False) -> None:
     if static:
-      self.static_events.add(event_name)
-    self.events.add(event_name)
+      self.static_events.append(event_name)
+    self.events.append(event_name)
 
   def clear(self) -> None:
     self.events_prev = {k: (v + 1 if k in self.events else 0) for k, v in self.events_prev.items()}
@@ -93,7 +92,7 @@ class Events:
 
   def add_from_msg(self, events):
     for e in events:
-      self.events.add(e.name.raw)
+      self.events.append(e.name.raw)
 
   def to_msg(self):
     ret = []


### PR DESCRIPTION
The time complexity is worse (O(n) for the insertions rather than B-tree), but for the number of events we are working with, the SortedList overhead makes it slightly worst than bisect.insort

```
# 60s 50 events every frame w/ clear
lst 0.06214418599847704
bisect 0.16943592199822888
sortedcontainer 0.42731739798909985

# 60s 5 events every frame w/ clear
lst 0.00855735200457275
bisect 0.014480583005934022
sortedcontainer 0.0417225589917507
```