### PR TITLE
Fix incorrect korean translation

### DIFF
--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -762,7 +762,7 @@ This may take up to a minute.</source>
     <name>Sidebar</name>
     <message>
         <source>CONNECT</source>
-        <translation>연결됨</translation>
+        <translation>커넥트</translation>
     </message>
     <message>
         <source>OFFLINE</source>


### PR DESCRIPTION
**Description**

Fixed incorrect Korean translation of the sidebar.

CONNECT
연결됨 -> 커넥트