### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/chrysler/fingerprints.py
+++ b/selfdrive/car/chrysler/fingerprints.py
@@ -266,6 +266,7 @@ FW_VERSIONS = {
     (Ecu.combinationMeter, 0x742, None): [
       b'68302211AC',
       b'68302212AD',
+      b'68302223AC',
       b'68302246AC',
       b'68331511AC',
       b'68331574AC',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                          | Name from VIN 🆚 CarDocs                                   | Segments                                   | Bad seg tags   | Good seg tags                                                                         |
|:-------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|:-------------------------------------------|:---------------|:--------------------------------------------------------------------------------------|
| [c88f65eeaee4003a](https://useradmin.comma.ai/?onebox=c88f65eeaee4003a)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFCG8........</sub> | JEEP Grand Cherokee 2017 🆚<br>Jeep Grand Cherokee 2016-18 | 28 routes,<br>668 segments<br>(11.1 hours) |                | - valid torque params: 668<br>- all lat active: 249<br>- no input all lat active: 106 |

Dongles to re-run category: `c88f65eeaee4003a`
</details>

## ⏳️ 43 dongles (29 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                    | Name from VIN 🆚 CarDocs                                                                          | Segments                                     | Bad seg tags                                                                                                                                                                                          | Good seg tags                                                                        |
|:-----------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|:---------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------|
| [30f476405b31e063](https://useradmin.comma.ai/?onebox=30f476405b31e063)<br><sub>TOYOTA_HIGHLANDER<br>5TDDGRFH0........</sub>             | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19                              | 102 routes,<br>1584 segments<br>(26.4 hours) |                                                                                                                                                                                                       | - valid torque params: 1584<br>- all lat active: 22<br>- no input all lat active: 6  |
| [ec62067436775681](https://useradmin.comma.ai/?onebox=ec62067436775681)<br><sub>CHRYSLER_PACIFICA_2019_HYBRID<br>2C4RC1L78........</sub> | CHRYSLER Pacifica 2022 🆚<br>Chrysler Pacifica Hybrid 2019-23                                     | 103 routes,<br>864 segments<br>(14.4 hours)  | - [segment too short (info): 87](https://useradmin.comma.ai/?onebox=ec62067436775681%7C2024-05-07--10-55-48)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=ec62067436775681) | - valid torque params: 864<br>- all lat active: 40<br>- no input all lat active: 9   |
| [dbeeb342988e0a18](https://useradmin.comma.ai/?onebox=dbeeb342988e0a18)<br><sub>VOLKSWAGEN_GOLF_MK7<br>3VW6T7AU6........</sub>           | VOLKSWAGEN Golf GTI 2020 🆚<br>Volkswagen Golf GTI 2015-21                                        | 12 routes,<br>155 segments<br>(2.6 hours)    |                                                                                                                                                                                                       | - all lat active: 45<br>- valid torque params: 145<br>- no input all lat active: 25  |
| [8f755f62fd10cbc0](https://useradmin.comma.ai/?onebox=8f755f62fd10cbc0)<br><sub>KIA_SORENTO_HEV_4TH_GEN<br>000000000........</sub>       | None 🆚<br>None                                                                                   | 15 routes,<br>387 segments<br>(6.5 hours)    |                                                                                                                                                                                                       | - valid torque params: 382<br>- all lat active: 30<br>- no input all lat active: 17  |
| [95bdaa23fcf50877](https://useradmin.comma.ai/?onebox=95bdaa23fcf50877)<br><sub>TOYOTA_ALPHARD_TSS2<br>000000000........</sub>           | None 🆚<br>None                                                                                   | 4 routes,<br>60 segments<br>(1.0 hours)      |                                                                                                                                                                                                       | - all lat active: 1                                                                  |
| [6ebcefea49711168](https://useradmin.comma.ai/?onebox=6ebcefea49711168)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>             | None 🆚<br>None                                                                                   | 12 routes,<br>65 segments<br>(1.1 hours)     |                                                                                                                                                                                                       | - valid torque params: 33<br>- all lat active: 3                                     |
| [772b833c28f493b5](https://useradmin.comma.ai/?onebox=772b833c28f493b5)<br><sub>ACURA_RDX_3G<br>5J8TC1H5X........</sub>                  | ACURA RDX 2019 🆚<br>Acura RDX 2019-22                                                            | 4 routes,<br>22 segments<br>(0.4 hours)      |                                                                                                                                                                                                       | - valid torque params: 10<br>- all lat active: 2<br>- no input all lat active: 1     |
| [2fe829d661707c32](https://useradmin.comma.ai/?onebox=2fe829d661707c32)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81BF........</sub>               | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 2 routes,<br>15 segments<br>(0.2 hours)      |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [58b82272a271b722](https://useradmin.comma.ai/?onebox=58b82272a271b722)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC1BG4........</sub>        | CHRYSLER Pacifica 2021 🆚<br>Chrysler Pacifica 2021-23                                            | 6 routes,<br>110 segments<br>(1.8 hours)     |                                                                                                                                                                                                       | - all lat active: 40<br>- valid torque params: 90<br>- no input all lat active: 31   |
| [a20d9fc9c0db2a9d](https://useradmin.comma.ai/?onebox=a20d9fc9c0db2a9d)<br><sub>KIA_EV6<br>000000000........</sub>                       | None 🆚<br>None                                                                                   | 1 routes,<br>19 segments<br>(0.3 hours)      |                                                                                                                                                                                                       | - all lat active: 2<br>- no input all lat active: 1                                  |
| [b53e882f1a5c30ae](https://useradmin.comma.ai/?onebox=b53e882f1a5c30ae)<br><sub>LEXUS_IS<br>JTHBA1D23........</sub>                      | LEXUS IS 2018 🆚<br>Lexus IS 2017-19                                                              | 2 routes,<br>7 segments<br>(0.1 hours)       |                                                                                                                                                                                                       | - valid torque params: 7<br>- all lat active: 0                                      |
| [befb93dbd957450b](https://useradmin.comma.ai/?onebox=befb93dbd957450b)<br><sub>CHRYSLER_PACIFICA_2018_HYBRID<br>2C4RC1N70........</sub> | CHRYSLER Pacifica 2018 🆚<br>Chrysler Pacifica Hybrid 2018                                        | 2 routes,<br>10 segments<br>(0.2 hours)      | - [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=befb93dbd957450b)                                                                                                                 | - all lat active: 0                                                                  |
| [cafc2abb29052277](https://useradmin.comma.ai/?onebox=cafc2abb29052277)<br><sub>AUDI_A3_MK3<br>WAUHJGFF9........</sub>                   | AUDI A3 2015 🆚<br>Audi A3 2014-19                                                                | 6 routes,<br>47 segments<br>(0.8 hours)      |                                                                                                                                                                                                       | - all lat active: 6<br>- valid torque params: 41<br>- no input all lat active: 3     |
| [5cec29f6d48ebf27](https://useradmin.comma.ai/?onebox=5cec29f6d48ebf27)<br><sub>HYUNDAI_IONIQ_5<br>KMHKL81AF........</sub>               | HYUNDAI  1992 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 1 routes,<br>10 segments<br>(0.2 hours)      |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [584a2bd2348d19c9](https://useradmin.comma.ai/?onebox=584a2bd2348d19c9)<br><sub>LEXUS_RX<br>2T2BGMCA2........</sub>                      | LEXUS RX Hybrid 2018 🆚<br>Lexus RX Hybrid 2017-19                                                | 11 routes,<br>114 segments<br>(1.9 hours)    |                                                                                                                                                                                                       | - all lat active: 16<br>- valid torque params: 102<br>- no input all lat active: 5   |
| [f56e1b6b8d3d4326](https://useradmin.comma.ai/?onebox=f56e1b6b8d3d4326)<br><sub>TOYOTA_CAMRY_TSS2<br>4T1C11BK0........</sub>             | TOYOTA Camry 2022 🆚<br>Toyota Camry 2021-24                                                      | 8 routes,<br>99 segments<br>(1.6 hours)      |                                                                                                                                                                                                       | - valid torque params: 99<br>- all lat active: 0                                     |
| [12fdf6595e41b23a](https://useradmin.comma.ai/?onebox=12fdf6595e41b23a)<br><sub>KIA_NIRO_EV<br>000000000........</sub>                   | None 🆚<br>None                                                                                   | 8 routes,<br>1602 segments<br>(26.7 hours)   | - [segment too short (info): 337](https://useradmin.comma.ai/?onebox=12fdf6595e41b23a%7C2024-04-24--10-43-54)                                                                                         | - all lat active: 0                                                                  |
| [47ba5e6f0490d659](https://useradmin.comma.ai/?onebox=47ba5e6f0490d659)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT4........</sub>              | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                                              | 4 routes,<br>174 segments<br>(2.9 hours)     |                                                                                                                                                                                                       | - valid torque params: 162<br>- all lat active: 77<br>- no input all lat active: 43  |
| [a97d27ce2a78958a](https://useradmin.comma.ai/?onebox=a97d27ce2a78958a)<br><sub>VOLKSWAGEN_JETTA_MK7<br>3VWG57BUX........</sub>          | VOLKSWAGEN Jetta 2019 🆚<br>Volkswagen Jetta 2018-24                                              | 37 routes,<br>929 segments<br>(15.5 hours)   |                                                                                                                                                                                                       | - valid torque params: 929<br>- all lat active: 0                                    |
| [de5d8c07f52dbb73](https://useradmin.comma.ai/?onebox=de5d8c07f52dbb73)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81CP........</sub>               | HYUNDAI  1992 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 3 routes,<br>19 segments<br>(0.3 hours)      |                                                                                                                                                                                                       | - valid torque params: 19<br>- all lat active: 15<br>- no input all lat active: 11   |
| [9bac7575fac62395](https://useradmin.comma.ai/?onebox=9bac7575fac62395)<br><sub>HONDA_PILOT<br>5FNYF6H93........</sub>                   | HONDA Pilot 2018 🆚<br>Honda Pilot 2016-22                                                        | 145 routes,<br>1764 segments<br>(29.4 hours) |                                                                                                                                                                                                       | - valid torque params: 1764<br>- all lat active: 293<br>- no input all lat active: 5 |
| [fdf7c1f93a13cfc9](https://useradmin.comma.ai/?onebox=fdf7c1f93a13cfc9)<br><sub>HYUNDAI_IONIQ_5<br>KMHKL81AF........</sub>               | HYUNDAI  1992 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                         | 1 routes,<br>18 segments<br>(0.3 hours)      |                                                                                                                                                                                                       | - all lat active: 2<br>- no input all lat active: 1                                  |
| [b952ae0f9a30d194](https://useradmin.comma.ai/?onebox=b952ae0f9a30d194)<br><sub>MAZDA_CX5_2022<br>JM3KFBXYX........</sub>                | MAZDA CX-5 2022 🆚<br>Mazda CX-5 2022-24                                                          | 2 routes,<br>93 segments<br>(1.6 hours)      |                                                                                                                                                                                                       | - valid torque params: 93<br>- all lat active: 22<br>- no input all lat active: 9    |
| [22901377be496047](https://useradmin.comma.ai/?onebox=22901377be496047)<br><sub>HYUNDAI_IONIQ_5<br>000000000........</sub>               | None 🆚<br>None                                                                                   | 63 routes,<br>976 segments<br>(16.3 hours)   |                                                                                                                                                                                                       | - valid torque params: 976<br>- all lat active: 32<br>- no input all lat active: 7   |
| [8b84fb6a13c8384e](https://useradmin.comma.ai/?onebox=8b84fb6a13c8384e)<br><sub>TOYOTA_COROLLA_TSS2<br>5YFS4RCE7........</sub>           | TOYOTA Corolla 2020 🆚<br>Toyota Corolla 2020-22                                                  | 6 routes,<br>116 segments<br>(1.9 hours)     |                                                                                                                                                                                                       | - valid torque params: 113<br>- all lat active: 27<br>- no input all lat active: 13  |
| [38de598ff0dcd4de](https://useradmin.comma.ai/?onebox=38de598ff0dcd4de)<br><sub>GENESIS_G70_2020<br>KMTG541E9........</sub>              | GENESIS  1988 🆚<br>Genesis G70 2019-21                                                           | 2 routes,<br>7 segments<br>(0.1 hours)       |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [49d86a89cd5e9827](https://useradmin.comma.ai/?onebox=49d86a89cd5e9827)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHM2........</sub>              | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                                              | 1 routes,<br>1 segments<br>(0.0 hours)       |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [e8151619f03d6c11](https://useradmin.comma.ai/?onebox=e8151619f03d6c11)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC1EG1........</sub>        | CHRYSLER Pacifica 2019 🆚<br>Chrysler Pacifica 2019-20                                            | 4 routes,<br>50 segments<br>(0.8 hours)      |                                                                                                                                                                                                       | - valid torque params: 5<br>- all lat active: 0                                      |
| [59eacd2185bd7885](https://useradmin.comma.ai/?onebox=59eacd2185bd7885)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC1BG5........</sub>        | CHRYSLER Pacifica 2024 🆚<br>Chrysler Pacifica 2021-23<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 10 routes,<br>210 segments<br>(3.5 hours)    |                                                                                                                                                                                                       | - valid torque params: 155<br>- all lat active: 13<br>- no input all lat active: 6   |
| [6c5691f19a404c9e](https://useradmin.comma.ai/?onebox=6c5691f19a404c9e)<br><sub>CHRYSLER_PACIFICA_2020<br>2C4RC3GG2........</sub>        | CHRYSLER Pacifica 2021 🆚<br>Chrysler Pacifica 2021-23                                            | 1 routes,<br>3 segments<br>(0.1 hours)       |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [6868a58803419504](https://useradmin.comma.ai/?onebox=6868a58803419504)<br><sub>HONDA_PILOT<br>5FNYF6H29........</sub>                   | HONDA Pilot 2021 🆚<br>Honda Pilot 2016-22                                                        | 3 routes,<br>201 segments<br>(3.4 hours)     |                                                                                                                                                                                                       | - valid torque params: 201<br>- all lat active: 95<br>- no input all lat active: 66  |
| [6adf1dffa8619f41](https://useradmin.comma.ai/?onebox=6adf1dffa8619f41)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub>    | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                                              | 3 routes,<br>32 segments<br>(0.5 hours)      |                                                                                                                                                                                                       | - valid torque params: 32<br>- all lat active: 0                                     |
| [4d557403960fd84c](https://useradmin.comma.ai/?onebox=4d557403960fd84c)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFKT5........</sub>              | RAM 1500 2019 🆚<br>Ram 1500 2019-24                                                              | 21 routes,<br>598 segments<br>(10.0 hours)   |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [df616cb5c6ab97f2](https://useradmin.comma.ai/?onebox=df616cb5c6ab97f2)<br><sub>TOYOTA_RAV4_TSS2_2022<br>4T3RWRFV6........</sub>         | TOYOTA RAV4 Hybrid 2022 🆚<br>Toyota RAV4 Hybrid 2022                                             | 1 routes,<br>12 segments<br>(0.2 hours)      |                                                                                                                                                                                                       | - valid torque params: 12<br>- all lat active: 8<br>- no input all lat active: 7     |
| [c2c75f785c43d4b9](https://useradmin.comma.ai/?onebox=c2c75f785c43d4b9)<br><sub>TOYOTA_RAV4_TSS2<br>000000000........</sub>              | None 🆚<br>None                                                                                   | 1 routes,<br>10 segments<br>(0.2 hours)      |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [a2153ee04e30ac3c](https://useradmin.comma.ai/?onebox=a2153ee04e30ac3c)<br><sub>TOYOTA_HIGHLANDER<br>5TDJGRFH6........</sub>             | TOYOTA Highlander Hybrid 2017 🆚<br>Toyota Highlander Hybrid 2017-19                              | 16 routes,<br>232 segments<br>(3.9 hours)    |                                                                                                                                                                                                       | - valid torque params: 217<br>- all lat active: 3                                    |
| [70de7ca8aacf461f](https://useradmin.comma.ai/?onebox=70de7ca8aacf461f)<br><sub>LEXUS_ES_TSS2<br>JTHB21B17........</sub>                 | None 🆚<br>None                                                                                   | 1 routes,<br>13 segments<br>(0.2 hours)      |                                                                                                                                                                                                       | - all lat active: 5<br>- valid torque params: 7<br>- no input all lat active: 2      |
| [b8798e927311b269](https://useradmin.comma.ai/?onebox=b8798e927311b269)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AGX........</sub>          | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                                | 12 routes,<br>264 segments<br>(4.4 hours)    |                                                                                                                                                                                                       | - valid torque params: 264<br>- all lat active: 2<br>- no input all lat active: 2    |
| [7037f9c72bc6f964](https://useradmin.comma.ai/?onebox=7037f9c72bc6f964)<br><sub>TOYOTA_COROLLA_TSS2<br>5YFBPMBE9........</sub>           | TOYOTA Corolla 2022 🆚<br>Toyota Corolla 2020-22                                                  | 3 routes,<br>40 segments<br>(0.7 hours)      |                                                                                                                                                                                                       | - valid torque params: 40<br>- all lat active: 0                                     |
| [c04a3b5508dc7bc3](https://useradmin.comma.ai/?onebox=c04a3b5508dc7bc3)<br><sub>HONDA_ACCORD<br>1HGCV2F90........</sub>                  | HONDA Accord 2021 🆚<br>Honda Accord 2018-22                                                      | 40 routes,<br>409 segments<br>(6.8 hours)    |                                                                                                                                                                                                       | - valid torque params: 409<br>- all lat active: 3<br>- no input all lat active: 2    |
| [a6de4da35307d7b8](https://useradmin.comma.ai/?onebox=a6de4da35307d7b8)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT4........</sub>              | RAM 1500 2022 🆚<br>Ram 1500 2019-24                                                              | 2 routes,<br>73 segments<br>(1.2 hours)      |                                                                                                                                                                                                       | - valid torque params: 73<br>- all lat active: 1                                     |
| [53e72b24183861cc](https://useradmin.comma.ai/?onebox=53e72b24183861cc)<br><sub>GENESIS_GV60_EV_1ST_GEN<br>000000000........</sub>       | None 🆚<br>None                                                                                   | 3 routes,<br>3 segments<br>(0.1 hours)       |                                                                                                                                                                                                       | - all lat active: 0                                                                  |
| [fbd0d5e8ac16f6d9](https://useradmin.comma.ai/?onebox=fbd0d5e8ac16f6d9)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHT7........</sub>              | RAM 1500 2024 🆚<br>Ram 1500 2019-24                                                              | 12 routes,<br>170 segments<br>(2.8 hours)    |                                                                                                                                                                                                       | - valid torque params: 164<br>- all lat active: 56<br>- no input all lat active: 48  |

Dongles to re-run category: `befb93dbd957450b 7037f9c72bc6f964 c04a3b5508dc7bc3 df616cb5c6ab97f2 a6de4da35307d7b8 772b833c28f493b5 cafc2abb29052277 8b84fb6a13c8384e ec62067436775681 95bdaa23fcf50877 a2153ee04e30ac3c b952ae0f9a30d194 e8151619f03d6c11 2fe829d661707c32 5cec29f6d48ebf27 6c5691f19a404c9e 8f755f62fd10cbc0 30f476405b31e063 38de598ff0dcd4de c2c75f785c43d4b9 a97d27ce2a78958a 53e72b24183861cc 70de7ca8aacf461f 584a2bd2348d19c9 f56e1b6b8d3d4326 6868a58803419504 de5d8c07f52dbb73 6adf1dffa8619f41 58b82272a271b722 22901377be496047 fbd0d5e8ac16f6d9 49d86a89cd5e9827 dbeeb342988e0a18 59eacd2185bd7885 4d557403960fd84c b8798e927311b269 9bac7575fac62395 6ebcefea49711168 b53e882f1a5c30ae 12fdf6595e41b23a a20d9fc9c0db2a9d fdf7c1f93a13cfc9 47ba5e6f0490d659`
</details>

## ⚠️ 30 dongles (15 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                                 | Name from VIN 🆚 CarDocs                                                                                          | Segments                                     | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Good seg tags                                                                          |
|:--------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------|:---------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [9e7b03d47798346e](https://useradmin.comma.ai/?onebox=9e7b03d47798346e)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub> | VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23                                                              | 157 routes,<br>2008 segments<br>(33.5 hours) | - [car faulted: 16](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C2024-05-02--12-36-06)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 2006<br>- all lat active: 148<br>- no input all lat active: 39  |
| [d8e00d93d49817ea](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea)<br><sub>LEXUS_RX<br>2T2ZZMCA6........</sub>                   | LEXUS RX 2018 🆚<br>Lexus RX 2017-19                                                                              | 132 routes,<br>2185 segments<br>(36.4 hours) | - [missing ECU FW: 469](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-18--13-51-57)<br>- [spotty FW: 1716](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-05-12--13-51-51)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d8e00d93d49817ea%7C2024-04-18--13-51-57)                                                                                                                                                                                                                | - valid torque params: 2184<br>- all lat active: 178<br>- no input all lat active: 138 |
| [23daff6c438612d2](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br><sub>AUDI_A3_MK3<br>3VWCA7AU3........</sub>                | VOLKSWAGEN Golf SportWagen 2015 🆚<br>Audi A3 Sportback e-tron 2017-18<br><sub>🎉 <b>New model year!</b> 🎉</sub> | 35 routes,<br>1505 segments<br>(25.1 hours)  | - [FW not exact match: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-05-02--13-28-37)<br>- [brand fuzzy match disagrees: 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2%7C2024-05-02--13-28-37)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=23daff6c438612d2)                                                                                                                       | - valid torque params: 1428<br>- all lat active: 172<br>- no input all lat active: 110 |
| [243b583079fa8d95](https://useradmin.comma.ai/?onebox=243b583079fa8d95)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 4 routes,<br>73 segments<br>(1.2 hours)      | - [invalid FW: 73](https://useradmin.comma.ai/?onebox=243b583079fa8d95%7C2024-04-24--13-13-14)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 73<br>- all lat active: 5<br>- no input all lat active: 2       |
| [2fa352365f86a9b2](https://useradmin.comma.ai/?onebox=2fa352365f86a9b2)<br><sub>HYUNDAI_IONIQ_5<br>KMHKR81EU........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                                         | 8 routes,<br>8 segments<br>(0.1 hours)       | - [spotty FW: 2](https://useradmin.comma.ai/?onebox=2fa352365f86a9b2%7C2024-05-09--14-32-31)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=2fa352365f86a9b2%7C2024-05-10--08-14-54)                                                                                                                                                                                                                                                                                                                           |                                                                                        |
| [485e3501abcacc80](https://useradmin.comma.ai/?onebox=485e3501abcacc80)<br><sub>HONDA_CIVIC_2022<br>19XFL1H8X........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 1 routes,<br>2 segments<br>(0.0 hours)       | - [missing ECU FW: 2](https://useradmin.comma.ai/?onebox=485e3501abcacc80%7C2024-05-14--03-31-03)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=485e3501abcacc80%7C2024-05-14--03-31-03)                                                                                                                                                                                                                                                                                                                     |                                                                                        |
| [d031a8c98c8863da](https://useradmin.comma.ai/?onebox=d031a8c98c8863da)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 15 routes,<br>409 segments<br>(6.8 hours)    | - [missing ECU FW: 409](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-18--02-09-58)<br>- [segment too short (info): 9](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-20--12-27-55)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d031a8c98c8863da%7C2024-04-18--02-09-58)                                                                                                                                                                                                    | - valid torque params: 409<br>- all lat active: 59<br>- no input all lat active: 24    |
| [4e92a7e0078767c8](https://useradmin.comma.ai/?onebox=4e92a7e0078767c8)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLP4AGX........</sub>       | HYUNDAI Elantra 2021 🆚<br>Hyundai Elantra 2021-23                                                                | 16 routes,<br>363 segments<br>(6.0 hours)    | - [high lateral accel factor: 7](https://useradmin.comma.ai/?onebox=4e92a7e0078767c8%7C2024-04-20--18-39-36)                                                                                                                                                                                                                                                                                                                                                                                                                   | - all lat active: 174<br>- no input all lat active: 130<br>- valid torque params: 348  |
| [39ecd9e9391c1810](https://useradmin.comma.ai/?onebox=39ecd9e9391c1810)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 2 routes,<br>3 segments<br>(0.1 hours)       | - [invalid FW: 3](https://useradmin.comma.ai/?onebox=39ecd9e9391c1810%7C2024-04-23--17-13-16)                                                                                                                                                                                                                                                                                                                                                                                                                                  |                                                                                        |
| [7e63a5eee34d3fb0](https://useradmin.comma.ai/?onebox=7e63a5eee34d3fb0)<br><sub>KIA_EV6<br>000000000........</sub>                    | None 🆚<br>None                                                                                                   | 14 routes,<br>567 segments<br>(9.4 hours)    | - [CAN invalid: 4](https://useradmin.comma.ai/?onebox=7e63a5eee34d3fb0%7C2024-05-08--20-17-16)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 567<br>- all lat active: 12<br>- no input all lat active: 3     |
| [858feae53f7053c3](https://useradmin.comma.ai/?onebox=858feae53f7053c3)<br><sub>HONDA_CIVIC_2022<br>19XFL2H88........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 47 routes,<br>917 segments<br>(15.3 hours)   | - [missing ECU FW: 917](https://useradmin.comma.ai/?onebox=858feae53f7053c3%7C2024-05-13--12-11-26)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=858feae53f7053c3%7C2024-05-13--12-11-26)                                                                                                                                                                                                                                                                                                                   | - valid torque params: 908<br>- all lat active: 190<br>- no input all lat active: 134  |
| [dafb0cb9e28e0249](https://useradmin.comma.ai/?onebox=dafb0cb9e28e0249)<br><sub>TOYOTA_PRIUS_TSS2<br>JTDKA3FP6........</sub>          | None 🆚<br>None                                                                                                   | 13 routes,<br>103 segments<br>(1.7 hours)    | - [car faulted: 1](https://useradmin.comma.ai/?onebox=dafb0cb9e28e0249%7C2024-04-17--18-45-40)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - all lat active: 7<br>- no input all lat active: 7<br>- valid torque params: 6        |
| [93bc5d4df12aa933](https://useradmin.comma.ai/?onebox=93bc5d4df12aa933)<br><sub>JEEP_GRAND_CHEROKEE<br>1C4RJFJT2........</sub>        | JEEP Grand Cherokee 2018 🆚<br>Jeep Grand Cherokee 2016-18                                                        | 14 routes,<br>180 segments<br>(3.0 hours)    | - [car faulted: 1](https://useradmin.comma.ai/?onebox=93bc5d4df12aa933%7C2024-04-26--00-14-46)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 134<br>- all lat active: 4<br>- no input all lat active: 1      |
| [73bcac1960e3f6a4](https://useradmin.comma.ai/?onebox=73bcac1960e3f6a4)<br><sub>HYUNDAI_SANTA_FE_2022<br>5NMS44AL4........</sub>      | HYUNDAI Santa Fe 2023 🆚<br>Hyundai Santa Fe 2021-23                                                              | 27 routes,<br>484 segments<br>(8.1 hours)    | - [missing ECU FW: 14](https://useradmin.comma.ai/?onebox=73bcac1960e3f6a4%7C2024-04-28--14-06-30)<br>- [spotty FW: 14](https://useradmin.comma.ai/?onebox=73bcac1960e3f6a4%7C2024-04-28--14-06-30)                                                                                                                                                                                                                                                                                                                            | - valid torque params: 484<br>- all lat active: 66<br>- no input all lat active: 59    |
| [c042beb296a531c3](https://useradmin.comma.ai/?onebox=c042beb296a531c3)<br><sub>CHRYSLER_PACIFICA_2018<br>2C4RC1GG5........</sub>     | CHRYSLER Pacifica 2018 🆚<br>Chrysler Pacifica 2017-18                                                            | 62 routes,<br>1481 segments<br>(24.7 hours)  | - [car faulted: 236](https://useradmin.comma.ai/?onebox=c042beb296a531c3%7C2024-04-18--12-16-55)                                                                                                                                                                                                                                                                                                                                                                                                                               | - valid torque params: 1480<br>- all lat active: 84<br>- no input all lat active: 37   |
| [0dacabc563f7e7d7](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 45 routes,<br>686 segments<br>(11.4 hours)   | - [missing ECU FW: 642](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-04-18--11-35-11)<br>- [spotty FW: 44](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-04-29--12-28-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0dacabc563f7e7d7%7C2024-04-18--11-35-11)                                                                                                                                                                                                                  | - valid torque params: 686<br>- all lat active: 146<br>- no input all lat active: 88   |
| [61c374c8e5e59db3](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3)<br><sub>HONDA_CIVIC_2022<br>19XFL2H89........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 222 routes,<br>5079 segments<br>(84.7 hours) | - [missing ECU FW: 3828](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-05-11--17-26-48)<br>- [spotty FW: 1251](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-05-02--09-15-35)<br>- [segment too short (info): 290](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-04-26--19-28-43)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=61c374c8e5e59db3%7C2024-05-11--17-26-48)                                                                                              | - valid torque params: 5079<br>- all lat active: 861<br>- no input all lat active: 293 |
| [72c57a77995168b4](https://useradmin.comma.ai/?onebox=72c57a77995168b4)<br><sub>TOYOTA_HIGHLANDER_TSS2<br>5TDFZRBH9........</sub>     | TOYOTA Highlander 2021 🆚<br>Toyota Highlander 2020-23                                                            | 1 routes,<br>1 segments<br>(0.0 hours)       | - [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=72c57a77995168b4%7C2024-04-16--07-53-40)                                                                                                                                                                                                                                                                                                                     | - valid torque params: 1                                                               |
| [fc4d8f4e5f8b353a](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a)<br><sub>HONDA_CIVIC_2022<br>19XFL1H88........</sub>           | HONDA Civic Hatchback 2023 🆚<br>Honda Civic Hatchback 2022-23                                                    | 90 routes,<br>1556 segments<br>(25.9 hours)  | - [missing ECU FW: 1213](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-05-06--18-44-41)<br>- [spotty FW: 343](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-04-24--21-03-14)<br>- [segment too short (info): 63](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-05-06--18-44-41)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=fc4d8f4e5f8b353a%7C2024-05-06--18-44-41)                                                                                                | - valid torque params: 1556<br>- all lat active: 350<br>- no input all lat active: 246 |
| [a72482b4766832e9](https://useradmin.comma.ai/?onebox=a72482b4766832e9)<br><sub>HONDA_CIVIC_2022<br>2HGFE1F90........</sub>           | HONDA Civic 2023 🆚<br>Honda Civic 2022-23                                                                        | 45 routes,<br>1290 segments<br>(21.5 hours)  | - [missing ECU FW: 917](https://useradmin.comma.ai/?onebox=a72482b4766832e9%7C2024-04-27--21-06-34)<br>- [spotty FW: 373](https://useradmin.comma.ai/?onebox=a72482b4766832e9%7C2024-05-03--15-05-53)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=a72482b4766832e9%7C2024-04-27--21-06-34)                                                                                                                                                                                                                 | - valid torque params: 1280<br>- all lat active: 606<br>- no input all lat active: 395 |
| [13858e4047f4aec8](https://useradmin.comma.ai/?onebox=13858e4047f4aec8)<br><sub>AUDI_Q3_MK2<br>WA1EECF35........</sub>                | AUDI Q3 2021 🆚<br>Audi Q3 2019-23                                                                                | 3 routes,<br>16 segments<br>(0.3 hours)      | - [car faulted: 3](https://useradmin.comma.ai/?onebox=13858e4047f4aec8%7C2024-05-02--14-26-26)                                                                                                                                                                                                                                                                                                                                                                                                                                 |                                                                                        |
| [672d4090a6b92b0b](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b)<br><sub>HYUNDAI_IONIQ_5<br>KMHKN81BF........</sub>            | HYUNDAI  1993 🆚<br>Hyundai Ioniq 5 (with HDA II) 2022-23                                                         | 7 routes,<br>138 segments<br>(2.3 hours)     | - [spotty FW: 1](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b%7C2024-05-07--14-57-38)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b%7C2024-05-08--06-24-23)<br>- [high lateral accel factor: 62](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b%7C2023-11-22--06-10-45)<br>- [segment too short (info): 2](https://useradmin.comma.ai/?onebox=672d4090a6b92b0b%7C2023-11-22--06-10-44)                                                                                           | - all lat active: 14<br>- no input all lat active: 8<br>- valid torque params: 3       |
| [ad48d1930c6a3571](https://useradmin.comma.ai/?onebox=ad48d1930c6a3571)<br><sub>TOYOTA_PRIUS<br>000000000........</sub>               | None 🆚<br>None                                                                                                   | 16 routes,<br>506 segments<br>(8.4 hours)    | - [invalid FW: 506](https://useradmin.comma.ai/?onebox=ad48d1930c6a3571%7C2024-04-25--22-52-48)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 506<br>- all lat active: 71<br>- no input all lat active: 39    |
| [c7ee9a8554861f8f](https://useradmin.comma.ai/?onebox=c7ee9a8554861f8f)<br><sub>HYUNDAI_ELANTRA_2021<br>KMHLS4AG8........</sub>       | HYUNDAI Elantra 2023 🆚<br>Hyundai Elantra 2021-23                                                                | 11 routes,<br>167 segments<br>(2.8 hours)    | - [high lateral accel factor: 4](https://useradmin.comma.ai/?onebox=c7ee9a8554861f8f%7C2024-05-06--21-16-29)                                                                                                                                                                                                                                                                                                                                                                                                                   | - valid torque params: 145<br>- all lat active: 62<br>- no input all lat active: 52    |
| [d15c6c91d28a861b](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H53........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 15 routes,<br>479 segments<br>(8.0 hours)    | - [missing ECU FW: 447](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [spotty FW: 32](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-17--22-52-19)<br>- [segment too short (info): 3](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [CAN invalid: 7](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=d15c6c91d28a861b%7C2024-04-15--13-47-18) | - valid torque params: 400<br>- all lat active: 183<br>- no input all lat active: 121  |
| [a74cb70b7a19e427](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427)<br><sub>TOYOTA_PRIUS_TSS2<br>000000000........</sub>          | None 🆚<br>None                                                                                                   | 12 routes,<br>141 segments<br>(2.4 hours)    | - [invalid FW: 141](https://useradmin.comma.ai/?onebox=a74cb70b7a19e427%7C2024-04-18--19-01-36)                                                                                                                                                                                                                                                                                                                                                                                                                                | - valid torque params: 140<br>- all lat active: 15<br>- no input all lat active: 5     |
| [aefbee9202b5ae99](https://useradmin.comma.ai/?onebox=aefbee9202b5ae99)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFMT8........</sub>           | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                                                              | 15 routes,<br>329 segments<br>(5.5 hours)    | - [spotty FW: 160](https://useradmin.comma.ai/?onebox=aefbee9202b5ae99%7C2024-05-12--10-23-27)<br>- [multiple VINs: 1](https://useradmin.comma.ai/?onebox=aefbee9202b5ae99%7C2024-05-07--20-41-21)                                                                                                                                                                                                                                                                                                                             | - valid torque params: 325<br>- all lat active: 147<br>- no input all lat active: 90   |
| [030e7d18f7c4ea9d](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFHTX........</sub>           | RAM 1500 2021 🆚<br>Ram 1500 2019-24                                                                              | 137 routes,<br>2234 segments<br>(37.2 hours) | - [car faulted: 3](https://useradmin.comma.ai/?onebox=030e7d18f7c4ea9d%7C2024-04-29--15-11-58)                                                                                                                                                                                                                                                                                                                                                                                                                                 | - valid torque params: 2082<br>- all lat active: 49<br>- no input all lat active: 23   |
| [11d207f3143e07b3](https://useradmin.comma.ai/?onebox=11d207f3143e07b3)<br><sub>KIA_EV6<br>KNAC381AF........</sub>                    | KIA  1993 🆚<br>Kia EV6 (with HDA II) 2022-23                                                                     | 7 routes,<br>93 segments<br>(1.6 hours)      | - [spotty FW: 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)<br>- [VIN spotty (info): 1](https://useradmin.comma.ai/?onebox=11d207f3143e07b3%7C2024-04-19--12-22-37)                                                                                                                                                                                                                                                                                                                           | - valid torque params: 79<br>- all lat active: 38<br>- no input all lat active: 14     |
| [251122482046c71b](https://useradmin.comma.ai/?onebox=251122482046c71b)<br><sub>HONDA_CIVIC_2022<br>19XFL2H87........</sub>           | HONDA Civic Hatchback 2024 🆚<br>Honda Civic Hatchback 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>         | 93 routes,<br>1427 segments<br>(23.8 hours)  | - [missing ECU FW: 1178](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--18-03-38)<br>- [spotty FW: 249](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-29--13-12-54)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=251122482046c71b%7C2024-04-19--18-03-38)                                                                                                                                                                                                                | - valid torque params: 1402<br>- all lat active: 499<br>- no input all lat active: 283 |

Dongles to re-run category: `13858e4047f4aec8 9e7b03d47798346e 672d4090a6b92b0b d15c6c91d28a861b 11d207f3143e07b3 858feae53f7053c3 aefbee9202b5ae99 2fa352365f86a9b2 243b583079fa8d95 dafb0cb9e28e0249 485e3501abcacc80 93bc5d4df12aa933 d8e00d93d49817ea 39ecd9e9391c1810 73bcac1960e3f6a4 a74cb70b7a19e427 c042beb296a531c3 72c57a77995168b4 fc4d8f4e5f8b353a 61c374c8e5e59db3 ad48d1930c6a3571 a72482b4766832e9 7e63a5eee34d3fb0 d031a8c98c8863da 4e92a7e0078767c8 251122482046c71b c7ee9a8554861f8f 23daff6c438612d2 030e7d18f7c4ea9d 0dacabc563f7e7d7`
</details>