### PR TITLE
test_car_interface: run CC once

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -93,14 +93,12 @@ class TestCarInterfaces(unittest.TestCase):
     for _ in range(10):
       car_interface.update(CC, [])
       car_interface.apply(CC, now_nanos)
-      car_interface.apply(CC, now_nanos)
       now_nanos += DT_CTRL * 1e9  # 10 ms
 
     CC = car.CarControl.new_message(**cc_msg)
     CC.enabled = True
     for _ in range(10):
       car_interface.update(CC, [])
-      car_interface.apply(CC, now_nanos)
       car_interface.apply(CC, now_nanos)
       now_nanos += DT_CTRL * 1e9  # 10ms
 


### PR DESCRIPTION
The two `apply`s came from before this commit: https://github.com/commaai/openpilot/commit/60431802ba8ff197ae9f92d7b38be7c0d178ed2d where it ran once without enabled and once with, and was left as is when making into a loop. Remove two runs to be more representative of real use