### PR TITLE
Subaru: Increase Global Gen 2 steering torque

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -20,7 +20,7 @@ class CarControllerParams:
     self.STEER_DRIVER_FACTOR = 1       # from dbc
 
     if CP.flags & SubaruFlags.GLOBAL_GEN2:
-      self.STEER_MAX = 1000
+      self.STEER_MAX = 1600
       self.STEER_DELTA_UP = 40
       self.STEER_DELTA_DOWN = 40
     elif CP.carFingerprint == CAR.SUBARU_IMPREZA_2020:


### PR DESCRIPTION
Back in 2022, the max steering torque for Subaru Global Gen 2 vehicles had a value of to 2047. This was deemed to be too high and subsequently reduced to 1100, then 1000. These limits are far too low and make the vehicle incapable of handling basic highway curves.

After testing the factory EyeSight system on a 2020 Outback (f284f22298d498cc|2023-05-25--23-45-24--0) it's clear that the factory system sets the limit at 1400. A previous PR #29627 was made to increase the limit back to 1400 but was closed.

While 1400 is substantially better than 1000, it does not provide enough torque to handle all highway curves, requiring frequent manual intervention. I have been testing OpenPilot with a steering torque limit of 1600 for a few thousand miles of highway and city driving. This has worked great on nearly every road I've driven all up and down the East Coast. The increased torque has never caused me any safety concerns or made any maneuver that felt too aggressive to correct.

I propose increasing the limit to 1600 to provide a much better driving experience for all users affected by this and I'm happy to provide any logs or support necessary to facilitate merging this into master.


### Relevant Routes
```
f284f22298d498cc|2023-05-25--23-45-24--0 | Route 1: Stock Eyesight
```

**Requires**

* https://github.com/commaai/panda/pull/1950

**Addresses**

* https://github.com/commaai/openpilot/issues/29627

**Related (closed) PRs**

* https://github.com/commaai/openpilot/pull/23530
* https://github.com/commaai/openpilot/pull/29097


