### PR TITLE
process replay: check missing services

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -159,6 +159,7 @@ class ProcessContainer:
     self.vipc_server: VisionIpcServer | None = None
     self.environ_config: dict[str, Any] | None = None
     self.capture: ProcessOutputCapture | None = None
+    self.seen = set()
 
   @property
   def has_empty_queue(self) -> bool:
@@ -308,6 +309,7 @@ class ProcessContainer:
         for socket in self.sockets:
           ms = messaging.drain_sock(socket)
           for m in ms:
+            self.seen.add(m.which())
             m = m.as_builder()
             m.logMonoTime = msg.logMonoTime + int(self.cfg.processing_time * 1e9)
             output_msgs.append(m.as_reader())
@@ -713,8 +715,13 @@ def _replay_multi_process(
             internal_pub_queue.append(m)
             heapq.heappush(internal_pub_index_heap, (m.logMonoTime, len(internal_pub_queue) - 1))
         log_msgs.extend(output_msgs)
+    for container in containers:
+      # print('subs, seen', set(container.subs), container.seen, set(container.subs) == container.seen)
+      assert set(container.subs) == container.seen or not container.seen, \
+        f"Seen messages do not match subscribed messages: {set(container.subs)} - {container.seen}"
   finally:
     for container in containers:
+      # print('subs, seen', set(container.subs), container.seen, set(container.subs) == container.seen)
       container.stop()
       if captured_output_store is not None:
         assert container.capture is not None

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -111,9 +111,11 @@ def test_process(cfg, lr, segment, ref_log_path, new_log_path, ignore_fields=Non
       if segment not in ("regen6CA24BC3035|2023-10-30--23-14-28--0", "regen7D2D3F82D5B|2023-10-30--23-15-55--0"):
         return f"Route did not enable at all or for long enough: {new_log_path}", log_msgs
 
-  seen_msgs = {m.which() for m in log_msgs}
-  if seen_msgs != set(cfg.subs):
-    return f"Expected messages: {cfg.subs}, but got: {seen_msgs}", log_msgs
+  if cfg.proc_name != 'ubloxd' or segment != 'regen6CA24BC3035|2023-10-30--23-14-28--0':
+    seen_msgs = {m.which() for m in log_msgs}
+    expected_msgs = set(cfg.subs)
+    if seen_msgs != expected_msgs:
+      return f"Expected messages: {expected_msgs}, but got: {seen_msgs}", log_msgs
 
   try:
     return compare_logs(ref_log_msgs, log_msgs, ignore_fields + cfg.ignore, ignore_msgs, cfg.tolerance), log_msgs

--- a/selfdrive/test/process_replay/test_processes.py
+++ b/selfdrive/test/process_replay/test_processes.py
@@ -111,6 +111,10 @@ def test_process(cfg, lr, segment, ref_log_path, new_log_path, ignore_fields=Non
       if segment not in ("regen6CA24BC3035|2023-10-30--23-14-28--0", "regen7D2D3F82D5B|2023-10-30--23-15-55--0"):
         return f"Route did not enable at all or for long enough: {new_log_path}", log_msgs
 
+  seen_msgs = {m.which() for m in log_msgs}
+  if seen_msgs != set(cfg.subs):
+    return f"Expected messages: {cfg.subs}, but got: {seen_msgs}", log_msgs
+
   try:
     return compare_logs(ref_log_msgs, log_msgs, ignore_fields + cfg.ignore, ignore_msgs, cfg.tolerance), log_msgs
   except Exception as e:


### PR DESCRIPTION
Fails processes that don't send all of their expected services defined in `subs`. Would have caught a bug in https://github.com/commaai/openpilot/pull/32380 where a condition wasn't getting hit, causing no `sendcan` or `carOutput` to be sent (card thought controlsState wasn't initialized from missing regen logic)