### PR TITLE
remove unittest test_models

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -4,7 +4,6 @@ import os
 import importlib
 import pytest
 import random
-import unittest # noqa: TID251
 from collections import defaultdict, Counter
 import hypothesis.strategies as st
 from hypothesis import Phase, given, settings
@@ -64,7 +63,7 @@ def get_test_cases() -> list[tuple[str, CarTestRoute | None]]:
 
 @pytest.mark.slow
 @pytest.mark.shared_download_cache
-class TestCarModelBase(unittest.TestCase):
+class TestCarModelBase:
   platform: Platform | None = None
   test_route: CarTestRoute | None = None
   test_route_on_bucket: bool = True  # whether the route is on the preserved CI bucket
@@ -153,14 +152,13 @@ class TestCarModelBase(unittest.TestCase):
 
 
   @classmethod
-  def setUpClass(cls):
+  def setup_class(cls):
     if cls.__name__ == 'TestCarModel' or cls.__name__.endswith('Base'):
-      raise unittest.SkipTest
+      pytest.skip()
 
     if cls.test_route is None:
       if cls.platform in non_tested_cars:
-        print(f"Skipping tests for {cls.platform}: missing route")
-        raise unittest.SkipTest
+        pytest.skip("Skipping tests for {cls.platform}: missing route")
       raise Exception(f"missing test route for {cls.platform}")
 
     car_fw, can_msgs, experimental_long = cls.get_testing_data()
@@ -178,10 +176,10 @@ class TestCarModelBase(unittest.TestCase):
     os.environ["COMMA_CACHE"] = DEFAULT_DOWNLOAD_CACHE_ROOT
 
   @classmethod
-  def tearDownClass(cls):
+  def teardown_class(cls):
     del cls.can_msgs
 
-  def setUp(self):
+  def setup_method(self):
     self.CI = self.CarInterface(self.CP.copy(), self.CarController, self.CarState)
     assert self.CI
 
@@ -192,22 +190,22 @@ class TestCarModelBase(unittest.TestCase):
 
     cfg = self.CP.safetyConfigs[-1]
     set_status = self.safety.set_safety_hooks(cfg.safetyModel.raw, cfg.safetyParam)
-    self.assertEqual(0, set_status, f"failed to set safetyModel {cfg}")
+    assert 0 == set_status, f"failed to set safetyModel {cfg}"
     self.safety.init_tests()
 
   def test_car_params(self):
     if self.CP.dashcamOnly:
-      self.skipTest("no need to check carParams for dashcamOnly")
+      pytest.skip("no need to check carParams for dashcamOnly")
 
     # make sure car params are within a valid range
-    self.assertGreater(self.CP.mass, 1)
+    assert self.CP.mass > 1
 
     if self.CP.steerControlType != car.CarParams.SteerControlType.angle:
       tuning = self.CP.lateralTuning.which()
       if tuning == 'pid':
-        self.assertTrue(len(self.CP.lateralTuning.pid.kpV))
+        assert len(self.CP.lateralTuning.pid.kpV)
       elif tuning == 'torque':
-        self.assertTrue(self.CP.lateralTuning.torque.kf > 0)
+        assert self.CP.lateralTuning.torque.kf > 0
       else:
         raise Exception("unknown tuning")
 
@@ -228,7 +226,7 @@ class TestCarModelBase(unittest.TestCase):
       if i > 200 or can_valid:
         can_invalid_cnt += not CS.canValid
 
-    self.assertEqual(can_invalid_cnt, 0)
+    assert can_invalid_cnt == 0
 
   def test_radar_interface(self):
     RadarInterface = importlib.import_module(f'selfdrive.car.{self.CP.carName}.radar_interface').RadarInterface
@@ -242,11 +240,11 @@ class TestCarModelBase(unittest.TestCase):
       rr = RI.update((msg.as_builder().to_bytes(),))
       if rr is not None and i > 50:
         error_cnt += car.RadarData.Error.canError in rr.errors
-    self.assertEqual(error_cnt, 0)
+    assert error_cnt == 0
 
   def test_panda_safety_rx_checks(self):
     if self.CP.dashcamOnly:
-      self.skipTest("no need to check panda safety for dashcamOnly")
+      pytest.skip("no need to check panda safety for dashcamOnly")
 
     start_ts = self.can_msgs[0].logMonoTime
 
@@ -268,26 +266,26 @@ class TestCarModelBase(unittest.TestCase):
       # ensure all msgs defined in the addr checks are valid
       self.safety.safety_tick_current_safety_config()
       if t > 1e6:
-        self.assertTrue(self.safety.safety_config_valid())
+        assert self.safety.safety_config_valid()
 
       # Don't check relay malfunction on disabled routes (relay closed),
       # or before fingerprinting is done (elm327 and noOutput)
       if self.openpilot_enabled and t / 1e4 > self.car_safety_mode_frame:
-        self.assertFalse(self.safety.get_relay_malfunction())
+        assert not self.safety.get_relay_malfunction()
       else:
         self.safety.set_relay_malfunction(False)
 
-    self.assertFalse(len(failed_addrs), f"panda safety RX check failed: {failed_addrs}")
+    assert not len(failed_addrs), f"panda safety RX check failed: {failed_addrs}"
 
     # ensure RX checks go invalid after small time with no traffic
     self.safety.set_timer(int(t + (2*1e6)))
     self.safety.safety_tick_current_safety_config()
-    self.assertFalse(self.safety.safety_config_valid())
+    assert not self.safety.safety_config_valid()
 
   def test_panda_safety_tx_cases(self, data=None):
     """Asserts we can tx common messages"""
     if self.CP.notCar:
-      self.skipTest("Skipping test for notCar")
+      pytest.skip("Skipping test for notCar")
 
     def test_car_controller(car_control):
       now_nanos = 0
@@ -301,10 +299,10 @@ class TestCarModelBase(unittest.TestCase):
         msgs_sent += len(sendcan)
         for addr, _, dat, bus in sendcan:
           to_send = libpanda_py.make_CANPacket(addr, bus % 4, dat)
-          self.assertTrue(self.safety.safety_tx_hook(to_send), (addr, dat, bus))
+          assert self.safety.safety_tx_hook(to_send), (addr, dat, bus)
 
       # Make sure we attempted to send messages
-      self.assertGreater(msgs_sent, 50)
+      assert msgs_sent > 50
 
     # Make sure we can send all messages while inactive
     CC = car.CarControl.new_message()
@@ -332,7 +330,7 @@ class TestCarModelBase(unittest.TestCase):
     """
 
     if self.CP.dashcamOnly:
-      self.skipTest("no need to check panda safety for dashcamOnly")
+      pytest.skip("no need to check panda safety for dashcamOnly")
 
     valid_addrs = [(addr, bus, size) for bus, addrs in self.fingerprint.items() for addr, size in addrs.items()]
     address, bus, size = data.draw(st.sampled_from(valid_addrs))
@@ -362,7 +360,7 @@ class TestCarModelBase(unittest.TestCase):
       CS = self.CI.update(CC, (can.to_bytes(),))
 
       if self.safety.get_gas_pressed_prev() != prev_panda_gas:
-        self.assertEqual(CS.gasPressed, self.safety.get_gas_pressed_prev())
+        assert CS.gasPressed == self.safety.get_gas_pressed_prev()
 
       if self.safety.get_brake_pressed_prev() != prev_panda_brake:
         # TODO: remove this exception once this mismatch is resolved
@@ -371,28 +369,28 @@ class TestCarModelBase(unittest.TestCase):
           if self.CP.carFingerprint in (HONDA.HONDA_PILOT, HONDA.HONDA_RIDGELINE) and CS.brake > 0.05:
             brake_pressed = False
 
-        self.assertEqual(brake_pressed, self.safety.get_brake_pressed_prev())
+        assert brake_pressed == self.safety.get_brake_pressed_prev()
 
       if self.safety.get_regen_braking_prev() != prev_panda_regen_braking:
-        self.assertEqual(CS.regenBraking, self.safety.get_regen_braking_prev())
+        assert CS.regenBraking == self.safety.get_regen_braking_prev()
 
       if self.safety.get_vehicle_moving() != prev_panda_vehicle_moving:
-        self.assertEqual(not CS.standstill, self.safety.get_vehicle_moving())
+        assert not CS.standstill == self.safety.get_vehicle_moving()
 
       if not (self.CP.carName == "honda" and not (self.CP.flags & HondaFlags.BOSCH)):
         if self.safety.get_cruise_engaged_prev() != prev_panda_cruise_engaged:
-          self.assertEqual(CS.cruiseState.enabled, self.safety.get_cruise_engaged_prev())
+          assert CS.cruiseState.enabled == self.safety.get_cruise_engaged_prev()
 
       if self.CP.carName == "honda":
         if self.safety.get_acc_main_on() != prev_panda_acc_main_on:
-          self.assertEqual(CS.cruiseState.available, self.safety.get_acc_main_on())
+          assert CS.cruiseState.available == self.safety.get_acc_main_on()
 
   def test_panda_safety_carstate(self):
     """
       Assert that panda safety matches openpilot's carState
     """
     if self.CP.dashcamOnly:
-      self.skipTest("no need to check panda safety for dashcamOnly")
+      pytest.skip("no need to check panda safety for dashcamOnly")
 
     CC = car.CarControl.new_message()
 
@@ -412,7 +410,7 @@ class TestCarModelBase(unittest.TestCase):
       for msg in filter(lambda m: m.src in range(64), can.can):
         to_send = libpanda_py.make_CANPacket(msg.address, msg.src % 4, msg.dat)
         ret = self.safety.safety_rx_hook(to_send)
-        self.assertEqual(1, ret, f"safety rx failed ({ret=}): {to_send}")
+        assert 1 == ret, f"safety rx failed ({ret=}): {to_send}"
 
       # Skip first frame so CS_prev is properly initialized
       if idx == 0:
@@ -467,19 +465,15 @@ class TestCarModelBase(unittest.TestCase):
       CS_prev = CS
 
     failed_checks = {k: v for k, v in checks.items() if v > 0}
-    self.assertFalse(len(failed_checks), f"panda safety doesn't agree with openpilot: {failed_checks}")
+    assert not len(failed_checks), f"panda safety doesn't agree with openpilot: {failed_checks}"
 
-  @unittest.skipIf(not CI, "Accessing non CI-bucket routes is allowed only when not in CI")
+  @pytest.mark.skipif(not CI, reason="Accessing non CI-bucket routes is allowed only when not in CI")
   def test_route_on_ci_bucket(self):
-    self.assertTrue(self.test_route_on_bucket, "Route not on CI bucket. " +
-                    "This is fine to fail for WIP car ports, just let us know and we can upload your routes to the CI bucket.")
+    assert self.test_route_on_bucket, "Route not on CI bucket. " + \
+                    "This is fine to fail for WIP car ports, just let us know and we can upload your routes to the CI bucket."
 
 
 @parameterized_class(('platform', 'test_route'), get_test_cases())
 @pytest.mark.xdist_group_class_property('test_route')
 class TestCarModel(TestCarModelBase):
   pass
-
-
-if __name__ == "__main__":
-  unittest.main()

--- a/selfdrive/debug/check_can_parser_performance.py
+++ b/selfdrive/debug/check_can_parser_performance.py
@@ -19,8 +19,8 @@ class CarModelTestCase(TestCarModelBase):
 if __name__ == '__main__':
   # Get CAN messages and parsers
   tm = CarModelTestCase()
-  tm.setUpClass()
-  tm.setUp()
+  tm.setup_class()
+  tm.setup_method()
 
   CC = car.CarControl.new_message()
   ets = []

--- a/tools/car_porting/README.md
+++ b/tools/car_porting/README.md
@@ -45,7 +45,7 @@ Given a route, runs most of the car interface to check for common errors like mi
 
 #### Example: panda safety mismatch for gasPressed
 ```bash
-> python tools/car_porting/test_car_model.py '4822a427b188122a|2023-08-14--16-22-21'
+> ROUTE='4822a427b188122a|2023-08-14--16-22-21' pytest tools/car_porting/test_car_model.py
 
 =====================================================================
 FAIL: test_panda_safety_carstate (__main__.CarModelTestCase.test_panda_safety_carstate)

--- a/tools/car_porting/test_car_model.py
+++ b/tools/car_porting/test_car_model.py
@@ -1,38 +1,23 @@
 #!/usr/bin/env python3
-import argparse
-import sys
-import unittest # noqa: TID251
+import os
+import pytest
+from parameterized import parameterized_class
+from typing import Any
 
 from openpilot.selfdrive.car.tests.routes import CarTestRoute
-from openpilot.selfdrive.car.tests.test_models import TestCarModel
+from openpilot.selfdrive.car.tests.test_models import TestCarModelBase
 from openpilot.tools.lib.route import SegmentName
 
+route = os.getenv('ROUTE')
+car: Any = os.getenv('CAR')
 
-def create_test_models_suite(routes: list[CarTestRoute], ci=False) -> unittest.TestSuite:
-  test_suite = unittest.TestSuite()
-  for test_route in routes:
-    # create new test case and discover tests
-    test_case_args = {"platform": test_route.car_model, "test_route": test_route, "test_route_on_bucket": ci}
-    CarModelTestCase = type("CarModelTestCase", (TestCarModel,), test_case_args)
-    test_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(CarModelTestCase))
-  return test_suite
+assert route is not None, "Must specify route or segment name"
 
+route_or_segment_name = SegmentName(route, allow_route_name=True)
+segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
+test_route = CarTestRoute(route_or_segment_name.route_name.canonical_name, car, segment=segment_num)
 
-if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description="Test any route against common issues with a new car port. " +
-                                               "Uses selfdrive/car/tests/test_models.py")
-  parser.add_argument("route_or_segment_name", help="Specify route to run tests on")
-  parser.add_argument("--car", help="Specify car model for test route")
-  parser.add_argument("--ci", action="store_true", help="Attempt to get logs using openpilotci, need to specify car")
-  args = parser.parse_args()
-  if len(sys.argv) == 1:
-    parser.print_help()
-    sys.exit()
-
-  route_or_segment_name = SegmentName(args.route_or_segment_name.strip(), allow_route_name=True)
-  segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
-
-  test_route = CarTestRoute(route_or_segment_name.route_name.canonical_name, args.car, segment=segment_num)
-  test_suite = create_test_models_suite([test_route], ci=args.ci)
-
-  unittest.TextTestRunner().run(test_suite)
+@parameterized_class(('platform', 'test_route'), [(test_route.car_model, test_route)])
+@pytest.mark.xdist_group_class_property('test_route')
+class TestCarModel(TestCarModelBase):
+  pass

--- a/tools/car_porting/test_car_model.py
+++ b/tools/car_porting/test_car_model.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 import os
-import pytest
-from parameterized import parameterized_class
 from typing import Any
 
 from openpilot.selfdrive.car.tests.routes import CarTestRoute
@@ -17,7 +15,6 @@ route_or_segment_name = SegmentName(route, allow_route_name=True)
 segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
 test_route = CarTestRoute(route_or_segment_name.route_name.canonical_name, car, segment=segment_num)
 
-@parameterized_class(('platform', 'test_route'), [(test_route.car_model, test_route)])
-@pytest.mark.xdist_group_class_property('test_route')
-class TestCarModel(TestCarModelBase):
-  pass
+class TestCarModelCarPorting(TestCarModelBase):
+  platform = test_route.car_model
+  test_route = test_route


### PR DESCRIPTION
- removes unittest from `openpilot.selfdrive.car.tests.test_models.py`
- switches `tools/car_porting/test_car_model.py` to inherit from `test_models.py`

not totally ideal but keeps use