### PR TITLE
rerun: fix install checker

### DIFF
--- a/tools/rerun/run.py
+++ b/tools/rerun/run.py
@@ -4,6 +4,9 @@ import sys
 import argparse
 import multiprocessing
 from functools import partial
+import importlib.util
+import rerun as rr
+import rerun.blueprint as rrb
 
 from openpilot.tools.lib.logreader import LogReader
 from cereal.services import SERVICE_LIST
@@ -90,10 +93,7 @@ if __name__ == '__main__':
     install()
     sys.exit()
 
-  try:
-    import rerun as rr
-    import rerun.blueprint as rrb
-  except ImportError:
+  if importlib.util.find_spec("rerun") is None:
     print("Rerun is not installed, run with --install first")
     sys.exit()
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

I ran into `"rr" not defined Error` despite rerun being installed successfully. I then found out it was due to how rerun install check was done. PR fixes the error while still keeping the package checker.

Before:
```bash
openpilot-py3.11(base) ┌─(~/Dev/openpilot)───────────────────────────────────────────────(mau@mau-JKDT676NCP:s039)─┐
└─(01:18:49 on master ✹)──> tools/rerun/run.py --install                  1 ↵ ──(Sat,May18)─┘
Looking in links: https://build.rerun.io/commit/660463d/wheels
Requirement already satisfied: rerun-sdk in ./.venv/lib/python3.11/site-packages (0.16.0)
Requirement already satisfied: attrs>=23.1.0 in ./.venv/lib/python3.11/site-packages (from rerun-sdk) (23.2.0)
Requirement already satisfied: numpy<2,>=1.23 in ./.venv/lib/python3.11/site-packages (from rerun-sdk) (1.24.2)
Requirement already satisfied: pillow>=8.0.0 in ./.venv/lib/python3.11/site-packages (from rerun-sdk) (10.3.0)
Requirement already satisfied: pyarrow>=14.0.2 in ./.venv/lib/python3.11/site-packages (from rerun-sdk) (16.1.0)
Requirement already satisfied: typing-extensions>=4.5 in ./.venv/lib/python3.11/site-packages (from rerun-sdk) (4.11.0)
Rerun installed
openpilot-py3.11(base) ┌─(~/Dev/openpilot)───────────────────────────────────────────────(mau@mau-JKDT676NCP:s039)─┐
└─(01:19:11 on master ✹)──> tools/rerun/run.py --demo                         ──(Sat,May18)─┘
Getting route log paths
  0%|                                                                  | 0/13 [00:05<?, ?it/s]
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/Users/mau/Dev/openpilot/openpilot/tools/lib/logreader.py", line 268, in _run_on_segment
    return func(self._get_lr(i))
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mau/Dev/openpilot/tools/rerun/run.py", line 66, in process
    rr.init("rerun_test", spawn=True, default_blueprint=blueprint)
    ^^
NameError: name 'rr' is not defined
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/mau/Dev/openpilot/tools/rerun/run.py", line 104, in <module>
    lr.run_across_segments(NUM_CPUS, partial(process, blueprint))
  File "/Users/mau/Dev/openpilot/openpilot/tools/lib/logreader.py", line 274, in run_across_segments
    for p in tqdm.tqdm(pool.imap(partial(self._run_on_segment, func), range(num_segs)), total=num_segs):
  File "/Users/mau/Dev/openpilot/.venv/lib/python3.11/site-packages/tqdm/std.py", line 1181, in __iter__
    for obj in iterable:
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/pool.py", line 873, in next
    raise value
NameError: name 'rr' is not defined
```

After:
```bash
openpilot-py3.11(base) ┌─(~/Dev/openpilot)───────────────────────────────────────────────(mau@mau-JKDT676NCP:s039)─┐
└─(01:20:43 on fix-rerun-install-checker ✹)──> tools/rerun/run.py --demo      ──(Sat,May18)─┘
Getting route log paths
  0%|                                                                  | 0/13 [00:00<?, ?it/s][2024-05-18T08:20:55Z INFO  re_sdk::spawn] A process is already listening at this address. Assuming it's a Rerun Viewer. addr=0.0.0.0:9876
[2024-05-18T08:20:56Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:65419
[2024-05-18T08:20:56Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:65420
```

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

