### PR TITLE
split out dev apt dependencies

### DIFF
--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -13,7 +13,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 COPY tools/install_ubuntu_dependencies.sh /tmp/tools/
-RUN NON_INTERACTIVE=yes /tmp/tools/install_ubuntu_dependencies.sh && \
+RUN INSTALL_EXTRA_PACKAGES=no /tmp/tools/install_ubuntu_dependencies.sh && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
     cd /usr/lib/gcc/arm-none-eabi/9.2.1 && \
     rm -rf arm/ thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -13,14 +13,10 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 COPY tools/install_ubuntu_dependencies.sh /tmp/tools/
-RUN cd /tmp && \
-    tools/install_ubuntu_dependencies.sh && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/* && \
-    # remove unused architectures from gcc for panda
+RUN NON_INTERACTIVE=yes /tmp/tools/install_ubuntu_dependencies.sh && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && \
     cd /usr/lib/gcc/arm-none-eabi/9.2.1 && \
-    rm -rf arm/ && \
-    rm -rf thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
+    rm -rf arm/ thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
 
 # Add OpenCL
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -30,7 +30,6 @@ function install_ubuntu_common_requirements() {
     autoconf \
     build-essential \
     ca-certificates \
-    casync \
     clang \
     cmake \
     make \
@@ -41,8 +40,6 @@ function install_ubuntu_common_requirements() {
     liblzma-dev \
     libarchive-dev \
     libbz2-dev \
-    capnproto \
-    libcapnp-dev \
     curl \
     libcurl4-openssl-dev \
     git \
@@ -72,8 +69,6 @@ function install_ubuntu_common_requirements() {
     libsystemd-dev \
     locales \
     opencl-headers \
-    ocl-icd-libopencl1 \
-    ocl-icd-opencl-dev \
     portaudio19-dev \
     qml-module-qtquick2 \
     qtmultimedia5-dev \
@@ -93,8 +88,14 @@ function install_ubuntu_common_requirements() {
 
 # Install extra packages
 function install_extra_packages() {
+  echo "Installing extra packages..."
   $SUDO apt-get install -y --no-install-recommends \
-    clinfo
+    clinfo \
+    casync \
+    capnproto \
+    libcapnp-dev \
+    ocl-icd-libopencl1 \
+    ocl-icd-opencl-dev
 }
 
 # Install Ubuntu 24.04 LTS packages

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -56,6 +56,8 @@ function install_ubuntu_common_requirements() {
     libsystemd-dev \
     locales \
     opencl-headers \
+    ocl-icd-libopencl1 \
+    ocl-icd-opencl-dev \
     portaudio19-dev \
     qtmultimedia5-dev \
     qtlocation5-dev \
@@ -79,8 +81,6 @@ function install_extra_packages() {
     casync \
     cmake \
     make \
-    ocl-icd-libopencl1 \
-    ocl-icd-opencl-dev \
     libdw1
 }
 

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -12,7 +12,18 @@ if [[ ! $(id -u) -eq 0 ]]; then
   SUDO="sudo"
 fi
 
-# Install packages present in all supported versions of Ubuntu
+# Prompt the user for extra packages
+function prompt_extra_packages() {
+  read -p "Do you want to install extra packages (e.g., clinfo)? [Y/n]: " -n 1 -r
+  echo ""
+  if [[ $REPLY =~ ^[Nn]$ ]]; then
+    INSTALL_EXTRA_PACKAGES="no"
+  else
+    INSTALL_EXTRA_PACKAGES="yes"
+  fi
+}
+
+# Install common packages
 function install_ubuntu_common_requirements() {
   $SUDO apt-get update
   $SUDO apt-get install -y --no-install-recommends \
@@ -51,6 +62,7 @@ function install_ubuntu_common_requirements() {
     libncurses5-dev \
     libncursesw5-dev \
     libomp-dev \
+    libopencv-dev \
     libpng16-16 \
     libportaudio2 \
     libssl-dev \
@@ -62,7 +74,6 @@ function install_ubuntu_common_requirements() {
     opencl-headers \
     ocl-icd-libopencl1 \
     ocl-icd-opencl-dev \
-    clinfo \
     portaudio19-dev \
     qml-module-qtquick2 \
     qtmultimedia5-dev \
@@ -76,7 +87,14 @@ function install_ubuntu_common_requirements() {
     libqt5x11extras5-dev \
     libqt5opengl5-dev \
     libreadline-dev \
-    libdw1
+    libdw1 \
+    valgrind
+}
+
+# Install extra packages
+function install_extra_packages() {
+  $SUDO apt-get install -y --no-install-recommends \
+    clinfo
 }
 
 # Install Ubuntu 24.04 LTS packages
@@ -128,4 +146,14 @@ if [ -f "/etc/os-release" ]; then
 else
   echo "No /etc/os-release in the system"
   exit 1
+fi
+
+# Prompt for extra packages if not in non-interactive mode
+if [[ -z "$NON_INTERACTIVE" ]]; then
+  prompt_extra_packages
+fi
+
+# Install extra packages if required
+if [[ "$INSTALL_EXTRA_PACKAGES" == "yes" || "$NON_INTERACTIVE" == "yes" ]]; then
+  install_extra_packages
 fi

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -12,17 +12,6 @@ if [[ ! $(id -u) -eq 0 ]]; then
   SUDO="sudo"
 fi
 
-# Prompt the user for extra packages
-function prompt_extra_packages() {
-  read -p "Do you want to install extra packages (e.g., clinfo)? [Y/n]: " -n 1 -r
-  echo ""
-  if [[ $REPLY =~ ^[Nn]$ ]]; then
-    INSTALL_EXTRA_PACKAGES="no"
-  else
-    INSTALL_EXTRA_PACKAGES="yes"
-  fi
-}
-
 # Install common packages
 function install_ubuntu_common_requirements() {
   $SUDO apt-get update
@@ -31,15 +20,14 @@ function install_ubuntu_common_requirements() {
     build-essential \
     ca-certificates \
     clang \
-    cmake \
-    make \
     cppcheck \
     libtool \
     gcc-arm-none-eabi \
-    bzip2 \
     liblzma-dev \
     libarchive-dev \
     libbz2-dev \
+    capnproto \
+    libcapnp-dev \
     curl \
     libcurl4-openssl-dev \
     git \
@@ -59,7 +47,6 @@ function install_ubuntu_common_requirements() {
     libncurses5-dev \
     libncursesw5-dev \
     libomp-dev \
-    libopencv-dev \
     libpng16-16 \
     libportaudio2 \
     libssl-dev \
@@ -70,7 +57,6 @@ function install_ubuntu_common_requirements() {
     locales \
     opencl-headers \
     portaudio19-dev \
-    qml-module-qtquick2 \
     qtmultimedia5-dev \
     qtlocation5-dev \
     qtpositioning5-dev \
@@ -81,21 +67,21 @@ function install_ubuntu_common_requirements() {
     libqt5serialbus5-dev  \
     libqt5x11extras5-dev \
     libqt5opengl5-dev \
-    libreadline-dev \
-    libdw1 \
-    valgrind
+    libreadline-dev
 }
 
 # Install extra packages
 function install_extra_packages() {
   echo "Installing extra packages..."
   $SUDO apt-get install -y --no-install-recommends \
+    bzip2 \
     clinfo \
     casync \
-    capnproto \
-    libcapnp-dev \
+    cmake \
+    make \
     ocl-icd-libopencl1 \
-    ocl-icd-opencl-dev
+    ocl-icd-opencl-dev \
+    libdw1
 }
 
 # Install Ubuntu 24.04 LTS packages
@@ -144,17 +130,19 @@ if [ -f "/etc/os-release" ]; then
         install_ubuntu_lts_latest_requirements
       fi
   esac
+
+  # Install extra packages
+  if [[ -z "$INSTALL_EXTRA_PACKAGES" ]]; then
+    read -p "Base setup done. Do you want to install extra development packages? [Y/n]: " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      INSTALL_EXTRA_PACKAGES="yes"
+    fi
+  fi
+  if [[ "$INSTALL_EXTRA_PACKAGES" == "yes" ]]; then
+    install_extra_packages
+  fi
 else
-  echo "No /etc/os-release in the system"
+  echo "No /etc/os-release in the system. Make sure you're running on Ubuntu, or similar."
   exit 1
-fi
-
-# Prompt for extra packages if not in non-interactive mode
-if [[ -z "$NON_INTERACTIVE" ]]; then
-  prompt_extra_packages
-fi
-
-# Install extra packages if required
-if [[ "$INSTALL_EXTRA_PACKAGES" == "yes" || "$NON_INTERACTIVE" == "yes" ]]; then
-  install_extra_packages
 fi


### PR DESCRIPTION
resolves #32470

**Description**

This PR updates the `tools/install_ubuntu_dependencies.sh` script to improve flexibility and user interaction. 

**Changelog:**
- Adds a prompt for installing extra packages
- Adds a `NON_INTERACTIVE` variable for a non-interactive mode using an environment variable

**Verification**
To run interactively:

```sh
./tools/install_ubuntu_dependencies.sh
```

To run in non-interactive mode:
```sh
NON_INTERACTIVE=yes ./tools/install_ubuntu_dependencies.sh
```