### PR TITLE
step8.png/training: Updated img to reflect current UI

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,4 +1,4 @@
 [lfs]
-	url = https://gitlab.com/commaai/openpilot-lfs.git/info/lfs
-	pushurl = ssh://git@gitlab.com/commaai/openpilot-lfs.git
+	url = https://github.com/ugtthis/openpilot.git/info/lfs
+	pushurl = https://github.com/ugtthis/openpilot.git/info/lfs
 	locksverify = false

--- a/selfdrive/assets/training/step8.png
+++ b/selfdrive/assets/training/step8.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7550d18943d77a2b0d8b3a1e702af4ceb7c3e9d08614a8d941a9f73a615cf7b7
-size 728928
+oid sha256:38ea164c5706f44c6d31783bac4fc87d6c2127d2be2406584ac8e916769b8c4f
+size 330725


### PR DESCRIPTION
# Problem
Old step8.png has outdated UI and the white car in the middle is bright and draws attention<br>
![OLD-step8](https://github.com/commaai/openpilot/assets/142481257/a0a8f131-b28c-4adf-864e-a9b3ab4a5f8e)


# Solution
New photo with the current UI and a slightly blurred background to increase focus on comma device. The `boundingRect` which is the clickable area to proceed to the next screen will still work with the new image when going through the training flow since `boundingRect` goes around comma device screen. The new photo is 331KB while the old photo is 729KB<br>
![NEW-step8](https://github.com/commaai/openpilot/assets/142481257/3ce6e03f-f37e-4b9e-9a60-2b1651b1bd22)
<br><br>
### Comparing old vs new

https://github.com/commaai/openpilot/assets/142481257/34889b37-dec7-411d-b821-e1a3c7990ee5

