### PR TITLE
fix(modeld): Fix for unpredictable behavior in commonmodel_pyx.pyx

### DIFF
--- a/selfdrive/modeld/models/commonmodel_pyx.pyx
+++ b/selfdrive/modeld/models/commonmodel_pyx.pyx
@@ -37,7 +37,11 @@ cdef class ModelFrame:
   def prepare(self, VisionBuf buf, float[:] projection, CLMem output):
     cdef mat3 cprojection
     memcpy(cprojection.v, &projection[0], 9*sizeof(float))
-    cdef float * data = self.frame.prepare(buf.buf.buf_cl, buf.width, buf.height, buf.stride, buf.uv_offset, cprojection, output.mem)
+    cdef float * data
+    if output is None:
+      data = self.frame.prepare(buf.buf.buf_cl, buf.width, buf.height, buf.stride, buf.uv_offset, cprojection, NULL)
+    else:
+      data = self.frame.prepare(buf.buf.buf_cl, buf.width, buf.height, buf.stride, buf.uv_offset, cprojection, output.mem)
     if not data:
       return None
     return np.asarray(<cnp.float32_t[:self.frame.buf_size]> data)


### PR DESCRIPTION

**Description**
In the `prepare` function of `commonmodel_pyx.pyx`, the behavior of `output.mem` is unstable when `output` is None. Specifically, when running openpilot on a Arm-based SoC, the check for `output == NULL` in `commonmodel.cc` returned False, whereas it returned True when running on a PC. Therefore, I modified `commonmodel_pyx.pyx` to use `NULL` explicitly instead of `output.mem` when output is `None`.

**Validation**
I have confirmed that this change results in the desired behavior on both the SoC and PC environments.