### PR TITLE
devcontainer: mount /dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
     "force_color_prompt": "1"
   },
   "runArgs": [
+    "--volume=/dev:/dev",
     "--volume=/tmp/.X11-unix:/tmp/.X11-unix",
     "--volume=${localWorkspaceFolder}/.devcontainer/.host/.Xauthority:/home/batman/.Xauthority",
     "--volume=${localEnv:HOME}/.comma:/home/batman/.comma",


### PR DESCRIPTION
**Description**

I want to mount the host's /dev directory to the container's /dev directory. I think it would be convenient if devices like webcams could be treated the same way on the host and within containers.











