### PR TITLE
navd: simple roundabout directions

### DIFF
--- a/selfdrive/navd/helpers.py
+++ b/selfdrive/navd/helpers.py
@@ -166,8 +166,12 @@ def parse_banner_instructions(banners: Any, distance_to_maneuver: float = 0.0) -
 
     # handle roundabout directions, TODO: add slight/sharp modifiers
     if p['type'] in ('rotary', 'roundabout') and field_valid(p, 'degrees'):
-      modifier = 'left' if p['degrees'] > 180 else 'right'
-      if abs(p['degrees'] - 180) < 45:
+      degrees = p['degrees']
+      if p.get('driving_side', 'right') == 'left':
+        degrees = 360 - degrees
+
+      modifier = 'left' if degrees > 180 else 'right'
+      if abs(degrees - 180) < 45:
         modifier = 'straight'
 
     instruction['maneuverModifier'] = modifier

--- a/selfdrive/navd/helpers.py
+++ b/selfdrive/navd/helpers.py
@@ -165,15 +165,14 @@ def parse_banner_instructions(banners: Any, distance_to_maneuver: float = 0.0) -
     modifier = p['modifier']
 
     # handle roundabout directions, TODO: add slight/sharp modifiers
-    if p['type'] in ('rotary', 'roundabout'):# and field_valid(p, 'degrees'):
-      degrees = p.get('degrees', 0)
-      driving_side = p.get('driving_side', 'right')
+    if p['type'] in ('rotary', 'roundabout') and field_valid(p, 'degrees'):
+      degrees = p['degrees']
       if p.get('driving_side', 'right') == 'left':
         degrees = 360 - degrees
 
       modifier = 'left' if degrees > 180 else 'right'
       if abs(degrees - 180) < 45:
-        modifier = f'straight {driving_side}'
+        modifier = 'straight'
 
     instruction['maneuverModifier'] = modifier
 

--- a/selfdrive/navd/helpers.py
+++ b/selfdrive/navd/helpers.py
@@ -163,6 +163,7 @@ def parse_banner_instructions(banners: Any, distance_to_maneuver: float = 0.0) -
     instruction['maneuverType'] = p['type']
   if field_valid(p, 'modifier'):
     modifier = p['modifier']
+
     # handle roundabout directions, TODO: add slight/sharp modifiers
     if p['type'] in ('rotary', 'roundabout') and field_valid(p, 'degrees'):
       modifier = 'left' if p['degrees'] > 180 else 'right'

--- a/selfdrive/navd/helpers.py
+++ b/selfdrive/navd/helpers.py
@@ -165,14 +165,15 @@ def parse_banner_instructions(banners: Any, distance_to_maneuver: float = 0.0) -
     modifier = p['modifier']
 
     # handle roundabout directions, TODO: add slight/sharp modifiers
-    if p['type'] in ('rotary', 'roundabout') and field_valid(p, 'degrees'):
-      degrees = p['degrees']
+    if p['type'] in ('rotary', 'roundabout'):# and field_valid(p, 'degrees'):
+      degrees = p.get('degrees', 0)
+      driving_side = p.get('driving_side', 'right')
       if p.get('driving_side', 'right') == 'left':
         degrees = 360 - degrees
 
       modifier = 'left' if degrees > 180 else 'right'
       if abs(degrees - 180) < 45:
-        modifier = 'straight'
+        modifier = f'straight {driving_side}'
 
     instruction['maneuverModifier'] = modifier
 

--- a/selfdrive/navd/helpers.py
+++ b/selfdrive/navd/helpers.py
@@ -162,7 +162,16 @@ def parse_banner_instructions(banners: Any, distance_to_maneuver: float = 0.0) -
   if field_valid(p, 'type'):
     instruction['maneuverType'] = p['type']
   if field_valid(p, 'modifier'):
-    instruction['maneuverModifier'] = p['modifier']
+    modifier = p['modifier']
+    # handle roundabout directions, TODO: add slight/sharp modifiers
+    if p['type'] in ('rotary', 'roundabout') and field_valid(p, 'degrees'):
+      degrees = p['degrees']
+      print('degrees', degrees)
+      modifier = 'left' if degrees > 180 else 'right'
+      if abs(degrees - 180) < 45:
+        modifier = 'straight'
+
+    instruction['maneuverModifier'] = modifier
 
   # Secondary
   if field_valid(current_banner, 'secondary'):

--- a/selfdrive/navd/helpers.py
+++ b/selfdrive/navd/helpers.py
@@ -165,10 +165,8 @@ def parse_banner_instructions(banners: Any, distance_to_maneuver: float = 0.0) -
     modifier = p['modifier']
     # handle roundabout directions, TODO: add slight/sharp modifiers
     if p['type'] in ('rotary', 'roundabout') and field_valid(p, 'degrees'):
-      degrees = p['degrees']
-      print('degrees', degrees)
-      modifier = 'left' if degrees > 180 else 'right'
-      if abs(degrees - 180) < 45:
+      modifier = 'left' if p['degrees'] > 180 else 'right'
+      if abs(p['degrees'] - 180) < 45:
         modifier = 'straight'
 
     instruction['maneuverModifier'] = modifier

--- a/selfdrive/ui/qt/maps/map_instructions.cc
+++ b/selfdrive/ui/qt/maps/map_instructions.cc
@@ -9,7 +9,7 @@
 const QString ICON_SUFFIX = ".png";
 
 MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
-  is_rhd = Params().getBool("IsRhdDetected");
+  is_rhd = true;  // Params().getBool("IsRhdDetected");
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(11, UI_BORDER_SIZE, 11, 20);
 
@@ -63,6 +63,7 @@ void MapInstructions::buildPixmapCache() {
     if (key.contains("_left")) {
       pixmap_cache["rhd_" + key.replace("_left", "_right")] = pm.transformed(QTransform().scale(-1, 1));
     } else if (key.contains("_right")) {
+      qDebug() << "replacing:" << key << "with:" << key.replace("_right", "_left");
       pixmap_cache["rhd_" + key.replace("_right", "_left")] = pm.transformed(QTransform().scale(-1, 1));
     }
   }
@@ -92,6 +93,7 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     }
     fn = fn.replace(' ', '_');
     bool rhd = is_rhd && (fn.contains("_left") || fn.contains("_right"));
+    qDebug() << "fn: " << (!rhd ? fn : "rhd_" + fn);
     icon_01->setPixmap(pixmap_cache[!rhd ? fn : "rhd_" + fn]);
     icon_01->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
     icon_01->setVisible(true);

--- a/selfdrive/ui/qt/maps/map_instructions.cc
+++ b/selfdrive/ui/qt/maps/map_instructions.cc
@@ -9,7 +9,7 @@
 const QString ICON_SUFFIX = ".png";
 
 MapInstructions::MapInstructions(QWidget *parent) : QWidget(parent) {
-  is_rhd = true;  // Params().getBool("IsRhdDetected");
+  is_rhd = Params().getBool("IsRhdDetected");
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(11, UI_BORDER_SIZE, 11, 20);
 
@@ -63,7 +63,6 @@ void MapInstructions::buildPixmapCache() {
     if (key.contains("_left")) {
       pixmap_cache["rhd_" + key.replace("_left", "_right")] = pm.transformed(QTransform().scale(-1, 1));
     } else if (key.contains("_right")) {
-      qDebug() << "replacing:" << key << "with:" << key.replace("_right", "_left");
       pixmap_cache["rhd_" + key.replace("_right", "_left")] = pm.transformed(QTransform().scale(-1, 1));
     }
   }
@@ -93,7 +92,6 @@ void MapInstructions::updateInstructions(cereal::NavInstruction::Reader instruct
     }
     fn = fn.replace(' ', '_');
     bool rhd = is_rhd && (fn.contains("_left") || fn.contains("_right"));
-    qDebug() << "fn: " << (!rhd ? fn : "rhd_" + fn);
     icon_01->setPixmap(pixmap_cache[!rhd ? fn : "rhd_" + fn]);
     icon_01->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
     icon_01->setVisible(true);


### PR DESCRIPTION
Adds modifiers for right, straight, and left roundabouts which is an improvement over always being right (or left for left hand countries). Doesn't handle RHD 180deg

How various angles are handled:

RHD:

![image](https://github.com/commaai/openpilot/assets/25857203/43265760-37c6-4af2-8420-c776d9e408cb)

![image](https://github.com/commaai/openpilot/assets/25857203/d912610d-d5a8-4d01-90d3-2d190b61bfc3)

![image](https://github.com/commaai/openpilot/assets/25857203/32db65c8-074c-425e-8fcb-58f36ede7100)

![image](https://github.com/commaai/openpilot/assets/25857203/9b503ac7-722d-4dbe-af0c-da2a1429a402)

LHD:

![image](https://github.com/commaai/openpilot/assets/25857203/337904cf-c646-4771-b487-ee557281669b)
