### PR TITLE
#32536 Speedup test_car_interfaces.py 

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -18,15 +18,16 @@ from openpilot.selfdrive.controls.lib.latcontrol_pid import LatControlPID
 from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque
 from openpilot.selfdrive.controls.lib.longcontrol import LongControl
 from openpilot.selfdrive.test.fuzzy_generation import DrawType, FuzzyGenerator
+from functools import lru_cache
 
 ALL_ECUS = {ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()}
 ALL_ECUS |= {ecu for config in FW_QUERY_CONFIGS.values() for ecu in config.extra_ecus}
 
 ALL_REQUESTS = {tuple(r.request) for config in FW_QUERY_CONFIGS.values() for r in config.requests}
 
-MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '40'))
+MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '10'))
 
-
+@lru_cache(maxsize=1024)
 def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
   # Fuzzy CAN fingerprints and FW versions to test more states of the CarInterface
   fingerprint_strategy = st.fixed_dictionaries({key: st.dictionaries(st.integers(min_value=0, max_value=0x800),


### PR DESCRIPTION
#32536 Speedup test_car_interfaces.py 

**Description**
Increased the speed of testing from 1-2 seconds per car to a max of 0.48s per car, give or take a couple ms when testing multiple times (latest test on my workstation below).

I achieved this by decreasing the MAX_EXAMPLES to 10, which sped this up quite a bit, then added lru_cache, which helped speed it up a couple more ms. 

I was skeptical of reducing the MAX_EXAMPLES, though I ran pytest-cov and compared the results between MAX_EXAMPLES=10 & MAX_EXAMPLES=40 and the coverage seemed to remain the same.  

**Verification**
Command I ran:
```pytest --durations=0 selfdrive/car/tests/test_car_interfaces.py``` 

Output:
```(openpilot-py3.11) lilb@lilb:~/openpilot$ pytest --durations=0 selfdrive/car/tests/test_car_interfaces.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.4, pytest-8.2.1, pluggy-1.5.0
Using --randomly-seed=2373055758
rootdir: /home/lilb/openpilot
configfile: pyproject.toml
plugins: cov-5.0.0, timeout-2.3.1, mock-3.14.0, profiling-1.7.0, cpp-2.5.0, flaky-3.8.1, asyncio-0.23.7, hypothesis-6.47.5, subtests-0.12.1, xdist-3.6.1, randomly-3.15.0
asyncio: mode=Mode.STRICT
4 workers [209 items]   
........................................................................................................................................................................................................... [ 97%]
......                                                                                                                                                                                              [100%]
============================================================================================ slowest durations ============================================================================================
0.48s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_026_FORD_EXPLORER_MK6
0.46s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_003_AUDI_A3_MK3
0.45s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_078_HYUNDAI_KONA_EV
0.44s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_004_AUDI_Q2_MK1
0.43s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_106_KIA_NIRO_HEV_2021
0.43s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_027_FORD_FOCUS_MK4
0.43s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_178_TOYOTA_COROLLA
0.43s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_072_HYUNDAI_IONIQ_EV_2020
0.43s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_005_AUDI_Q3_MK2
0.43s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_025_FORD_ESCAPE_MK4
0.43s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_073_HYUNDAI_IONIQ_EV_LTD
0.42s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_033_GENESIS_G70
0.42s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_149_SKODA_KAROQ_MK1
0.42s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_089_HYUNDAI_SONATA_HYBRID
0.41s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_115_KIA_SORENTO
0.41s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_119_KIA_STINGER
0.41s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_176_TOYOTA_CHR
0.41s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_065_HYUNDAI_ELANTRA_2021
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_104_KIA_NIRO_EV
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_030_FORD_MAVERICK_MK1
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_114_KIA_SELTOS
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_036_GENESIS_G90
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_082_HYUNDAI_PALISADE
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_077_HYUNDAI_KONA
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_085_HYUNDAI_SANTA_FE_2022
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_152_SKODA_SUPERB_MK3
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_111_KIA_OPTIMA_G4_FL
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_109_KIA_NIRO_PHEV_2022
0.40s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_000_ACURA_ILX
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_092_HYUNDAI_TUCSON
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_069_HYUNDAI_IONIQ
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_160_SUBARU_IMPREZA
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_006_BUICK_LACROSSE
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_032_FORD_RANGER_MK2
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_086_HYUNDAI_SANTA_FE_HEV_2022
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_064_HYUNDAI_ELANTRA
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_192_VOLKSWAGEN_ARTEON_MK1
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_034_GENESIS_G70_2020
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_068_HYUNDAI_GENESIS
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_100_KIA_FORTE
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_112_KIA_OPTIMA_H
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_156_SUBARU_FORESTER
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_024_FORD_BRONCO_SPORT_MK1
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_181_TOYOTA_HIGHLANDER_TSS2
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_063_HYUNDAI_CUSTIN_1ST_GEN
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_084_HYUNDAI_SANTA_FE
0.39s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_108_KIA_NIRO_PHEV
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_081_HYUNDAI_KONA_HEV
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_110_KIA_OPTIMA_G4
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_161_SUBARU_IMPREZA_2020
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_076_HYUNDAI_IONIQ_PHEV_2019
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_090_HYUNDAI_SONATA_LF
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_120_KIA_STINGER_2022
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_035_GENESIS_G80
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_151_SKODA_OCTAVIA_MK3
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_088_HYUNDAI_SONATA
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_071_HYUNDAI_IONIQ_6
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_067_HYUNDAI_ELANTRA_HEV_2021
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_075_HYUNDAI_IONIQ_PHEV
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_153_SUBARU_ASCENT
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_031_FORD_MUSTANG_MACH_E_MK1
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_162_SUBARU_LEGACY
0.38s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_079_HYUNDAI_KONA_EV_2022
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_061_HYUNDAI_AZERA_6TH_GEN
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_101_KIA_K5_2021
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_145_RAM_HD_5TH_GEN
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_037_GENESIS_GV60_EV_1ST_GEN
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_102_KIA_K5_HEV_2020
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_189_TOYOTA_RAV4_TSS2_2022
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_011_CADILLAC_ESCALADE_ESV_2019
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_164_SUBARU_OUTBACK
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_199_VOLKSWAGEN_PASSAT_NMS
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_097_KIA_CARNIVAL_4TH_GEN
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_200_VOLKSWAGEN_POLO_MK6
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_087_HYUNDAI_SANTA_FE_PHEV_2022
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_094_HYUNDAI_VELOSTER
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_098_KIA_CEED
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_028_FORD_F_150_LIGHTNING_MK1
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_009_CADILLAC_ESCALADE
0.37s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_177_TOYOTA_CHR_TSS2
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_170_TOYOTA_ALPHARD_TSS2
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_074_HYUNDAI_IONIQ_HEV_2022
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_062_HYUNDAI_AZERA_HEV_6TH_GEN
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_148_SKODA_KAMIQ_MK1
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_066_HYUNDAI_ELANTRA_GT_I30
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_194_VOLKSWAGEN_CADDY_MK3
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_201_VOLKSWAGEN_SHARAN_MK2
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_173_TOYOTA_AVALON_TSS2
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_029_FORD_F_150_MK14
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_175_TOYOTA_CAMRY_TSS2
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_172_TOYOTA_AVALON_2019
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_179_TOYOTA_COROLLA_TSS2
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_113_KIA_OPTIMA_H_G4_FL
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_196_VOLKSWAGEN_GOLF_MK7
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_043_HONDA_CIVIC
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_205_VOLKSWAGEN_TOURAN_MK2
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_185_TOYOTA_PRIUS_V
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_124_LEXUS_GS_F
0.36s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_123_LEXUS_ES_TSS2
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_013_CHEVROLET_EQUINOX
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_186_TOYOTA_RAV4
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_007_BUICK_REGAL
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_127_LEXUS_LC_TSS2
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_184_TOYOTA_PRIUS_TSS2
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_138_MAZDA_CX9_2021
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_131_LEXUS_RX
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_091_HYUNDAI_STARIA_4TH_GEN
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_180_TOYOTA_HIGHLANDER
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_116_KIA_SORENTO_4TH_GEN
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_001_ACURA_RDX
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_099_KIA_EV6
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_158_SUBARU_FORESTER_HYBRID
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_126_LEXUS_IS_TSS2
0.35s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_128_LEXUS_NX
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_202_VOLKSWAGEN_TAOS_MK1
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_129_LEXUS_NX_TSS2
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_038_GENESIS_GV70_1ST_GEN
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_093_HYUNDAI_TUCSON_4TH_GEN
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_039_GENESIS_GV80
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_133_MAZDA_3
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_197_VOLKSWAGEN_JETTA_MK7
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_019_CHRYSLER_PACIFICA_2018_HYBRID
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_182_TOYOTA_MIRAI
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_204_VOLKSWAGEN_TIGUAN_MK2
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_147_SKODA_FABIA_MK4
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_080_HYUNDAI_KONA_EV_2ND_GEN
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_188_TOYOTA_RAV4_TSS2
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_070_HYUNDAI_IONIQ_5
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_122_LEXUS_ES
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_144_RAM_1500_5TH_GEN
0.34s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_103_KIA_K8_HEV_1ST_GEN
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_117_KIA_SORENTO_HEV_4TH_GEN
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_130_LEXUS_RC
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_168_TESLA_AP2_MODELS
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_171_TOYOTA_AVALON
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_150_SKODA_KODIAQ_MK1
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_165_SUBARU_OUTBACK_2023
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_137_MAZDA_CX9
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_053_HONDA_FREED
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_083_HYUNDAI_SANTA_CRUZ_1ST_GEN
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_206_VOLKSWAGEN_TRANSPORTER_T61
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_121_LEXUS_CTH
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_040_GMC_ACADIA
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_207_VOLKSWAGEN_TROC_MK1
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_193_VOLKSWAGEN_ATLAS_MK1
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_146_SEAT_ATECA_MK1
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_191_TOYOTA_SIENNA
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_135_MAZDA_CX5
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_012_CHEVROLET_BOLT_EUV
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_118_KIA_SPORTAGE_5TH_GEN
0.33s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_049_HONDA_CRV_EU
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_155_SUBARU_CROSSTREK_HYBRID
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_105_KIA_NIRO_EV_2ND_GEN
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_183_TOYOTA_PRIUS
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_157_SUBARU_FORESTER_2022
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_134_MAZDA_6
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_015_CHEVROLET_SILVERADO
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_132_LEXUS_RX_TSS2
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_057_HONDA_ODYSSEY
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_203_VOLKSWAGEN_TCROSS_MK1
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_136_MAZDA_CX5_2022
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_195_VOLKSWAGEN_CRAFTER_MK2
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_125_LEXUS_IS
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_052_HONDA_FIT
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_008_CADILLAC_ATS
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_174_TOYOTA_CAMRY
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_167_SUBARU_OUTBACK_PREGLOBAL_2018
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_107_KIA_NIRO_HEV_2ND_GEN
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_190_TOYOTA_RAV4_TSS2_2023
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_187_TOYOTA_RAV4H
0.32s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_163_SUBARU_LEGACY_PREGLOBAL
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_020_CHRYSLER_PACIFICA_2019_HYBRID
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_060_HONDA_RIDGELINE
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_023_DODGE_DURANGO
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_166_SUBARU_OUTBACK_PREGLOBAL
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_045_HONDA_CIVIC_BOSCH
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_169_TESLA_MODELS_RAVEN
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_021_CHRYSLER_PACIFICA_2020
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_198_VOLKSWAGEN_PASSAT_MK8
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_017_CHRYSLER_PACIFICA_2017_HYBRID
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_095_JEEP_GRAND_CHEROKEE
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_141_NISSAN_LEAF_IC
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_159_SUBARU_FORESTER_PREGLOBAL
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_059_HONDA_PILOT
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_018_CHRYSLER_PACIFICA_2018
0.31s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_054_HONDA_HRV
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_096_JEEP_GRAND_CHEROKEE_2019
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_056_HONDA_INSIGHT
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_154_SUBARU_ASCENT_2023
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_055_HONDA_HRV_3G
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_042_HONDA_ACCORD
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_014_CHEVROLET_MALIBU
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_143_NISSAN_XTRAIL
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_002_ACURA_RDX_3G
0.30s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_058_HONDA_ODYSSEY_CHN
0.29s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_142_NISSAN_ROGUE
0.29s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_140_NISSAN_LEAF
0.29s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_046_HONDA_CIVIC_BOSCH_DIESEL
0.29s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_047_HONDA_CRV
0.29s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_041_HOLDEN_ASTRA
0.29s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_051_HONDA_E
0.28s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_050_HONDA_CRV_HYBRID
0.28s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_048_HONDA_CRV_5G
0.28s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_044_HONDA_CIVIC_2022
0.28s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_010_CADILLAC_ESCALADE_ESV
0.27s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_016_CHEVROLET_VOLT
0.27s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_139_NISSAN_ALTIMA
0.24s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_022_COMMA_BODY
0.03s call     selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_interface_attrs
0.01s teardown selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_161_SUBARU_IMPREZA_2020
0.01s teardown selfdrive/car/tests/test_car_interfaces.py::TestCarInterfaces::test_car_interfaces_003_AUDI_A3_MK3

(416 durations < 0.005s hidden.  Use -vv to show these durations.)
========================================================================================== 209 passed in 20.82s ===========================================================================================
```

pytest-cov commands:
```MAX_EXAMPLES=10 pytest --cov=selfdrive --cov-report=html:cov_10 selfdrive/car/tests/test_car_interfaces.py```

```MAX_EXAMPLES=40 pytest --cov=selfdrive --cov-report=html:cov_40 selfdrive/car/tests/test_car_interfaces.py```