### PR TITLE
common/prefix.h: Fix incomplete path cleanup on exit

### DIFF
--- a/common/prefix.h
+++ b/common/prefix.h
@@ -5,6 +5,7 @@
 
 #include "common/params.h"
 #include "common/util.h"
+#include "system/hardware/hw.h"
 
 class OpenpilotPrefix {
 public:
@@ -25,6 +26,10 @@ public:
       system(util::string_format("rm %s -rf", real_path.c_str()).c_str());
       unlink(param_path.c_str());
     }
+    if (getenv("COMMA_CACHE") == nullptr) {
+      system(util::string_format("rm %s -rf", Path::download_cache_root().c_str()).c_str());
+    }
+    system(util::string_format("rm %s -rf", Path::comma_home().c_str()).c_str());
     system(util::string_format("rm %s -rf", msgq_path.c_str()).c_str());
     unsetenv("OPENPILOT_PREFIX");
   }


### PR DESCRIPTION
Fixed the issue where the download cache and comma home paths were not being removed on exit.