### PR TITLE
cache get_torque_params

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -6,7 +6,7 @@ from abc import abstractmethod, ABC
 from enum import StrEnum
 from typing import Any, NamedTuple
 from collections.abc import Callable
-from functools import lru_cache
+from functools import cache
 
 from cereal import car
 from openpilot.common.basedir import BASEDIR
@@ -43,7 +43,7 @@ class LatControlInputs(NamedTuple):
 
 TorqueFromLateralAccelCallbackType = Callable[[LatControlInputs, car.CarParams.LateralTorqueTuning, float, float, bool, bool], float]
 
-@lru_cache
+@cache
 def get_torque_params(candidate):
   with open(TORQUE_SUBSTITUTE_PATH, 'rb') as f:
     sub = tomllib.load(f)

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -43,6 +43,7 @@ class LatControlInputs(NamedTuple):
 
 TorqueFromLateralAccelCallbackType = Callable[[LatControlInputs, car.CarParams.LateralTorqueTuning, float, float, bool, bool], float]
 
+
 @cache
 def get_torque_params(candidate):
   with open(TORQUE_SUBSTITUTE_PATH, 'rb') as f:

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -6,6 +6,7 @@ from abc import abstractmethod, ABC
 from enum import StrEnum
 from typing import Any, NamedTuple
 from collections.abc import Callable
+from functools import lru_cache
 
 from cereal import car
 from openpilot.common.basedir import BASEDIR
@@ -42,7 +43,7 @@ class LatControlInputs(NamedTuple):
 
 TorqueFromLateralAccelCallbackType = Callable[[LatControlInputs, car.CarParams.LateralTorqueTuning, float, float, bool, bool], float]
 
-
+@lru_cache
 def get_torque_params(candidate):
   with open(TORQUE_SUBSTITUTE_PATH, 'rb') as f:
     sub = tomllib.load(f)


### PR DESCRIPTION
lots of io in get_torque_params (and it's is called twice in get_params for a lot of cars)

could also pass it through
re: https://github.com/commaai/openpilot/issues/32536

I'll look for further ways to speed up