### PR TITLE
Hyundai longitudinal (CAN): don't send `FCA12` on non-FCA cars

### DIFF
--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -146,10 +146,10 @@ class CarController(CarControllerBase):
       if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
         # TODO: unclear if this is needed
         jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
-        use_fca = self.CP.flags & HyundaiFlags.USE_FCA.value
+        use_fca11 = self.CP.flags & HyundaiFlags.USE_FCA11.value
         can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
                                                         hud_control, set_speed_in_units, stopping,
-                                                        CC.cruiseControl.override, use_fca))
+                                                        CC.cruiseControl.override, use_fca11))
 
       # 20 Hz LFA MFA message
       if self.frame % 5 == 0 and self.CP.flags & HyundaiFlags.SEND_LFA.value:
@@ -157,7 +157,8 @@ class CarController(CarControllerBase):
 
       # 5 Hz ACC options
       if self.frame % 20 == 0 and self.CP.openpilotLongitudinalControl:
-        can_sends.extend(hyundaican.create_acc_opt(self.packer))
+        use_fca12 = self.CP.flags & HyundaiFlags.USE_FCA12.value
+        can_sends.extend(hyundaican.create_acc_opt(self.packer, use_fca12))
 
       # 2 Hz front radar options
       if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -145,8 +145,8 @@ class CarState(CarStateBase):
     ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(gear))
 
     if not self.CP.openpilotLongitudinalControl:
-      aeb_src = "FCA11" if self.CP.flags & HyundaiFlags.USE_FCA.value else "SCC12"
-      aeb_sig = "FCA_CmdAct" if self.CP.flags & HyundaiFlags.USE_FCA.value else "AEB_CmdAct"
+      aeb_src = "FCA11" if self.CP.flags & HyundaiFlags.USE_FCA11.value else "SCC12"
+      aeb_sig = "FCA_CmdAct" if self.CP.flags & HyundaiFlags.USE_FCA11.value else "AEB_CmdAct"
       aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0
       scc_warning = cp_cruise.vl["SCC12"]["TakeOverReq"] == 1  # sometimes only SCC system shows an FCW
       aeb_braking = cp_cruise.vl[aeb_src]["CF_VSM_DecCmdAct"] != 0 or cp_cruise.vl[aeb_src][aeb_sig] != 0
@@ -274,7 +274,7 @@ class CarState(CarStateBase):
         ("SCC11", 50),
         ("SCC12", 50),
       ]
-      if CP.flags & HyundaiFlags.USE_FCA.value:
+      if CP.flags & HyundaiFlags.USE_FCA11.value:
         messages.append(("FCA11", 50))
 
     if CP.enableBsm:
@@ -314,7 +314,7 @@ class CarState(CarStateBase):
         ("SCC12", 50),
       ]
 
-      if CP.flags & HyundaiFlags.USE_FCA.value:
+      if CP.flags & HyundaiFlags.USE_FCA11.value:
         messages.append(("FCA11", 50))
 
     return CANParser(DBC[CP.carFingerprint]["pt"], messages, 2)

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -126,7 +126,7 @@ def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 
-def create_acc_commands(packer, enabled, accel, upper_jerk, idx, hud_control, set_speed, stopping, long_override, use_fca):
+def create_acc_commands(packer, enabled, accel, upper_jerk, idx, hud_control, set_speed, stopping, long_override, use_fca11):
   commands = []
 
   scc11_values = {
@@ -152,7 +152,7 @@ def create_acc_commands(packer, enabled, accel, upper_jerk, idx, hud_control, se
 
   # show AEB disabled indicator on dash with SCC12 if not sending FCA messages.
   # these signals also prevent a TCS fault on non-FCA cars with alpha longitudinal
-  if not use_fca:
+  if not use_fca11:
     scc12_values["CF_VSM_ConfMode"] = 1
     scc12_values["AEB_Status"] = 1  # AEB disabled
 
@@ -172,7 +172,7 @@ def create_acc_commands(packer, enabled, accel, upper_jerk, idx, hud_control, se
   commands.append(packer.make_can_msg("SCC14", 0, scc14_values))
 
   # Only send FCA11 on cars where it exists on the bus
-  if use_fca:
+  if use_fca11:
     # note that some vehicles most likely have an alternate checksum/counter definition
     # https://github.com/commaai/opendbc/commit/9ddcdb22c4929baf310295e832668e6e7fcfa602
     fca11_values = {
@@ -187,7 +187,7 @@ def create_acc_commands(packer, enabled, accel, upper_jerk, idx, hud_control, se
 
   return commands
 
-def create_acc_opt(packer):
+def create_acc_opt(packer, use_fca12):
   commands = []
 
   scc13_values = {
@@ -197,12 +197,13 @@ def create_acc_opt(packer):
   }
   commands.append(packer.make_can_msg("SCC13", 0, scc13_values))
 
-  # TODO: this needs to be detected and conditionally sent on unsupported long cars
-  fca12_values = {
-    "FCA_DrvSetState": 2,
-    "FCA_USM": 1, # AEB disabled
-  }
-  commands.append(packer.make_can_msg("FCA12", 0, fca12_values))
+  # Only send FCA12 on cars where it exists on the bus
+  if use_fca12:
+    fca12_values = {
+      "FCA_DrvSetState": 2,
+      "FCA_USM": 1, # AEB disabled
+    }
+    commands.append(packer.make_can_msg("FCA12", 0, fca12_values))
 
   return commands
 

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -69,7 +69,10 @@ class CarInterface(CarInterfaceBase):
 
       # These cars use the FCA11 message for the AEB and FCW signals, all others use SCC12
       if 0x38d in fingerprint[0] or 0x38d in fingerprint[2]:
-        ret.flags |= HyundaiFlags.USE_FCA.value
+        ret.flags |= HyundaiFlags.USE_FCA11.value
+
+      if 0x483 in fingerprint[0] or 0x483 in fingerprint[2]:
+        ret.flags |= HyundaiFlags.USE_FCA12.value
 
     ret.steerActuatorDelay = 0.1  # Default delay
     ret.steerLimitTimer = 0.4

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -71,6 +71,7 @@ class CarInterface(CarInterfaceBase):
       if 0x38d in fingerprint[0] or 0x38d in fingerprint[2]:
         ret.flags |= HyundaiFlags.USE_FCA11.value
 
+      # These cars use the FCA12 message for the status of AEB and FCW, all others use SCC13a
       if 0x483 in fingerprint[0] or 0x483 in fingerprint[2]:
         ret.flags |= HyundaiFlags.USE_FCA12.value
 

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -62,7 +62,7 @@ class HyundaiFlags(IntFlag):
   ENABLE_BLINKERS = 2 ** 5
   CANFD_ALT_GEARS_2 = 2 ** 6
   SEND_LFA = 2 ** 7
-  USE_FCA = 2 ** 8
+  USE_FCA11 = 2 ** 8
   CANFD_HDA2_ALT_STEERING = 2 ** 9
 
   # these cars use a different gas signal
@@ -94,6 +94,8 @@ class HyundaiFlags(IntFlag):
   TCU_GEARS = 2 ** 22
 
   MIN_STEER_32_MPH = 2 ** 23
+
+  USE_FCA12 = 2 ** 24
 
 
 class Footnote(Enum):


### PR DESCRIPTION
**Description**

- Added int flag `USE_FCA12`. Some platforms such as the `GENESIS_G80` do not have both `FCA11` and `FCA12`. This PR introduces a new int flag that conditionally checks if `FCA12` exists on the CAN bus. If `FCA12` does not exist, we do not try to send `FCA12` when openpilot longitudinal control is enabled.
- Renamed int flag `USE_FCA` --> `USE_FCA11`

**Verification**

- `openpilot Longitudinal Control (Alpha)` engaged successfully on the `GENESIS_G80`, which does not have `FCA11` and `FCA12`.

**Route**

- Route: `fc0b0898f920f030/00000001--ab82eecd02`

**Prerequisite of**
- https://github.com/commaai/openpilot/pull/32580

Thanks to community 2018 Genesis G80 owner `gogrant43` (Discord).