### PR TITLE
tools/rerun: streaming to one Viewer from multiple processes

### DIFF
--- a/tools/rerun/run.py
+++ b/tools/rerun/run.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
 
   blueprint = createBlueprint()
   rr.init("rerun_test", default_blueprint=blueprint)
-  rr.spawn(connect=False)
+  rr.spawn(connect=False) # child processes stream data to Viewer
 
   route_or_segment_name = DEMO_ROUTE if args.demo else args.route_or_segment_name.strip()
   print("Getting route log paths")

--- a/tools/rerun/run.py
+++ b/tools/rerun/run.py
@@ -53,8 +53,8 @@ def log_thumbnail(thumbnailMsg):
   rr.log("/thumbnail", rr.ImageEncoded(contents=bytesImgData))
 
 @rr.shutdown_at_exit
-def process(blueprint, lr):
-  rr.init("rerun_test", default_blueprint=blueprint)
+def process(lr):
+  rr.init("rerun_test")
   rr.connect()
 
   ret = []
@@ -86,4 +86,4 @@ if __name__ == '__main__':
   route_or_segment_name = DEMO_ROUTE if args.demo else args.route_or_segment_name.strip()
   print("Getting route log paths")
   lr = LogReader(route_or_segment_name)
-  lr.run_across_segments(NUM_CPUS, partial(process, blueprint))
+  lr.run_across_segments(NUM_CPUS, partial(process))

--- a/tools/rerun/run.py
+++ b/tools/rerun/run.py
@@ -39,6 +39,7 @@ def log_msg(msg, parent_key=''):
       pass  # Not a plottable value
 
 def createBlueprint():
+  blueprint = None
   timeSeriesViews = []
   for topic in sorted(SERVICE_LIST.keys()):
     timeSeriesViews.append(rrb.TimeSeriesView(name=topic, origin=f"/{topic}/", visible=False))
@@ -51,9 +52,12 @@ def log_thumbnail(thumbnailMsg):
   bytesImgData = thumbnailMsg.get('thumbnail')
   rr.log("/thumbnail", rr.ImageEncoded(contents=bytesImgData))
 
+@rr.shutdown_at_exit
 def process(blueprint, lr):
+  rr.init("rerun_test", default_blueprint=blueprint)
+  rr.connect()
+
   ret = []
-  rr.init("rerun_test", spawn=True, default_blueprint=blueprint)
   for msg in lr:
     ret.append(msg)
     rr.set_time_nanos("TIMELINE", msg.logMonoTime)
@@ -75,8 +79,11 @@ if __name__ == '__main__':
 
   args = parser.parse_args()
 
-  route_or_segment_name = DEMO_ROUTE if args.demo else args.route_or_segment_name.strip()
   blueprint = createBlueprint()
+  rr.init("rerun_test", default_blueprint=blueprint)
+  rr.spawn(connect=False)
+
+  route_or_segment_name = DEMO_ROUTE if args.demo else args.route_or_segment_name.strip()
   print("Getting route log paths")
   lr = LogReader(route_or_segment_name)
   lr.run_across_segments(NUM_CPUS, partial(process, blueprint))


### PR DESCRIPTION
There can be multiple inits, but the `Viewer` should only spawned oncee, and the other processes can log their data into the same `Viewer` through the designated port

After the change (no more bloated log info) and the processes would just stream logged data to the port:
```
[2024-06-02T14:05:45Z INFO  re_sdk_comms::server] Hosting a SDK server over TCP at 0.0.0.0:9876. Connect with the Rerun logging SDK.
[2024-06-02T14:05:45Z INFO  winit::platform_impl::platform::x11::window] Guessed window scale factor: 1
[2024-06-02T14:05:45Z WARN  wgpu_hal::vulkan::instance] Unable to find extension: VK_EXT_swapchain_colorspace
Getting route log paths
[2024-06-02T14:05:45Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:45872
MESA-INTEL: warning: Performance support disabled, consider sysctl dev.i915.perf_stream_paranoid=0

[2024-06-02T14:05:46Z INFO  egui_wgpu] There were 3 available wgpu adapters: {backend: Vulkan, device_type: DiscreteGpu, name: "NVIDIA GeForce GTX 1650", driver: "NVIDIA", driver_info: "535.171.04", vendor: 0x10DE, device: 0x1F9D}, {backend: Vulkan, device_type: Cpu, name: "llvmpipe (LLVM 12.0.0, 256 bits)", driver: "llvmpipe", driver_info: "Mesa 21.2.6 (LLVM 12.0.0)", vendor: 0x10005}, {backend: Vulkan, device_type: IntegratedGpu, name: "Intel(R) Xe Graphics (TGL GT2)", driver: "Intel open-source Mesa driver", driver_info: "Mesa 21.2.6", vendor: 0x8086, device: 0x9A49}
  0%|                                                                                                                                                                                  | 0/13 [00:00<?, ?it/s]
[2024-06-02T14:05:54Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57324
[2024-06-02T14:05:54Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57338
[2024-06-02T14:05:54Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57340
[2024-06-02T14:05:54Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57346
[2024-06-02T14:05:55Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57356
[2024-06-02T14:05:55Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57362
[2024-06-02T14:05:56Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57366
[2024-06-02T14:05:57Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:57368
```

Will do further improvements

