### PR TITLE
numpy_fast.py: optimize `interp` with binary search

### DIFF
--- a/common/numpy_fast.py
+++ b/common/numpy_fast.py
@@ -1,17 +1,17 @@
+import bisect
+
 def clip(x, lo, hi):
   return max(lo, min(hi, x))
 
 def interp(x, xp, fp):
-  N = len(xp)
-
   def get_interp(xv):
-    hi = 0
-    while hi < N and xv > xp[hi]:
-      hi += 1
+    hi = bisect.bisect_left(xp, xv)
     low = hi - 1
-    return fp[-1] if hi == N and xv > xp[low] else (
-      fp[0] if hi == 0 else
-      (xv - xp[low]) * (fp[hi] - fp[low]) / (xp[hi] - xp[low]) + fp[low])
+    if hi == len(xp):
+        return fp[-1]
+    if hi == 0:
+        return fp[0]
+    return (xv - xp[low]) * (fp[hi] - fp[low]) / (xp[hi] - xp[low]) + fp[low]
 
   return [get_interp(v) for v in x] if hasattr(x, '__iter__') else get_interp(x)
 


### PR DESCRIPTION
Improves the performance of the custom `interp` function by replacing the linear search with `bisect_left` for interval lookup, reducing search complexity from O(N) to O(log⁡N)