### PR TITLE
UI: set `eye_btn->checked` to be true by default

### DIFF
--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -130,7 +130,7 @@ InputDialog::InputDialog(const QString &title, QWidget *parent, const QString &s
       }
     });
     eye_btn->toggle();
-    eye_btn->setChecked(false);
+    eye_btn->setChecked(true);
     textbox_layout->addWidget(eye_btn);
   }
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

When inputting the wifi password I would've expected it to be hiding each text after each input just like on every other place where a wifi password is asked. however this is not the case.

This PR changes it so that by default it does the expected behavior:
![Screenshot from 2024-06-02 19-49-42](https://github.com/commaai/openpilot/assets/65101411/bf8902e3-b2d6-4570-a7be-2e1f657d0450)



<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

