### PR TITLE
[bot] Fingerprints: add missing FW versions from CAN fingerprinting cars

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -135,9 +135,11 @@ FW_VERSIONS = {
       b'\xf1\x00AEev SCC F-CUP      1.00 1.00 99110-G7200         ',
       b'\xf1\x00AEev SCC F-CUP      1.00 1.00 99110-G7500         ',
       b'\xf1\x00AEev SCC F-CUP      1.00 1.01 99110-G7000         ',
+      b'\xf1\x00AEev SCC F-CUP      1.00 1.01 99110-G7100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7310 4APEC101',
+      b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7510 4APEC101',
       b'\xf1\x00AE  MDPS C 1.00 1.01 56310/G7560 4APEC101',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
@@ -146,6 +148,7 @@ FW_VERSIONS = {
       b'\xf1\x00AEE MFC  AT EUR LHD 1.00 1.01 95740-G2600 190819',
       b'\xf1\x00AEE MFC  AT EUR LHD 1.00 1.03 95740-G2500 190516',
       b'\xf1\x00AEE MFC  AT EUR RHD 1.00 1.01 95740-G2600 190819',
+      b'\xf1\x00AEE MFC  AT USA LHD 1.00 1.01 95740-G2600 190819',
     ],
   },
   CAR.HYUNDAI_IONIQ_EV_LTD: {
@@ -1039,10 +1042,10 @@ FW_VERSIONS = {
   CAR.KIA_SPORTAGE_5TH_GEN: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NQ5 FR_CMR AT AUS RHD 1.00 1.00 99211-P1040 663',
+      b'\xf1\x00NQ5 FR_CMR AT EUR LHD 1.00 1.00 99211-P1040 663',
       b'\xf1\x00NQ5 FR_CMR AT GEN LHD 1.00 1.00 99211-P1060 665',
       b'\xf1\x00NQ5 FR_CMR AT USA LHD 1.00 1.00 99211-P1030 662',
       b'\xf1\x00NQ5 FR_CMR AT USA LHD 1.00 1.00 99211-P1040 663',
-      b'\xf1\x00NQ5 FR_CMR AT EUR LHD 1.00 1.00 99211-P1040 663',
       b'\xf1\x00NQ5 FR_CMR AT USA LHD 1.00 1.00 99211-P1060 665',
       b'\xf1\x00NQ5 FR_CMR AT USA LHD 1.00 1.00 99211-P1070 690',
     ],


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 1 dongles (1 platforms) in last 30 days:
<details open><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                            | Name from VIN 🆚 CarDocs   | Segments                                     | Bad seg tags   | Good seg tags                                                                          |
|:---------------------------------------------------------------------------------------------------------------------------------|:---------------------------|:---------------------------------------------|:---------------|:---------------------------------------------------------------------------------------|
| [1613602610c3e789](https://useradmin.comma.ai/?onebox=1613602610c3e789)<br><sub>HYUNDAI_IONIQ_EV_2020<br>000000000........</sub> | None 🆚<br>None            | 133 routes,<br>2918 segments<br>(48.6 hours) |                | - valid torque params: 2917<br>- all lat active: 960<br>- no input all lat active: 629 |

Dongles to re-run category: `1613602610c3e789`
</details>

## ⏳️ 0 dongles (0 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN   | Name from VIN 🆚 CarDocs   | Segments   | Bad seg tags   | Good seg tags   |
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>

## ⚠️ 4 dongles (4 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

| Dongle, platform, VIN                                                                                                      | Name from VIN 🆚 CarDocs                                | Segments                                    | Bad seg tags                                                                                                                                                                                                                                                                                                                                                                                             | Good seg tags                                                                          |
|:---------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:--------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
| [0e13ee2b821302f4](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br><sub>HYUNDAI_IONIQ<br>KNDCE3LC1........</sub>   | KIA Niro Hybrid 2018 🆚<br>Hyundai Ioniq Hybrid 2017-19 | 85 routes,<br>2012 segments<br>(33.5 hours) | - [FW not exact match: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-05-10--18-43-54)<br>- [brand fuzzy match disagrees: 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4%7C2024-05-10--18-43-54)<br>- [VIN model mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4)<br>- [VIN make mismatch (info): 1](https://useradmin.comma.ai/?onebox=0e13ee2b821302f4) | - valid torque params: 1833<br>- all lat active: 653<br>- no input all lat active: 437 |
| [9004767ba8fe7321](https://useradmin.comma.ai/?onebox=9004767ba8fe7321)<br><sub>KIA_NIRO_EV<br>000000000........</sub>     | None 🆚<br>None                                         | 1 routes,<br>13 segments<br>(0.2 hours)     | - [missing ECU FW: 13](https://useradmin.comma.ai/?onebox=9004767ba8fe7321%7C2024-05-17--04-56-30)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=9004767ba8fe7321%7C2024-05-17--04-56-30)                                                                                                                                                                                              |                                                                                        |
| [8a817d2073d02561](https://useradmin.comma.ai/?onebox=8a817d2073d02561)<br><sub>HYUNDAI_KONA_EV<br>000000000........</sub> | None 🆚<br>None                                         | 1 routes,<br>1 segments<br>(0.0 hours)      | - [missing ECU FW: 1](https://useradmin.comma.ai/?onebox=8a817d2073d02561%7C2024-05-19--20-53-54)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=8a817d2073d02561%7C2024-05-19--20-53-54)                                                                                                                                                                                               |                                                                                        |
| [50aa739c8332289a](https://useradmin.comma.ai/?onebox=50aa739c8332289a)<br><sub>NISSAN_ALTIMA<br>1N4BL4DW2........</sub>   | NISSAN Altima 2019 🆚<br>Nissan Altima 2019-20          | 60 routes,<br>2804 segments<br>(46.7 hours) | - [missing ECU FW: 2804](https://useradmin.comma.ai/?onebox=50aa739c8332289a%7C2024-05-11--15-10-23)<br>- [FW not exact match: 1](https://useradmin.comma.ai/?onebox=50aa739c8332289a%7C2024-05-11--15-10-23)                                                                                                                                                                                            | - all lat active: 585<br>- no input all lat active: 277                                |

Dongles to re-run category: `50aa739c8332289a 9004767ba8fe7321 8a817d2073d02561 0e13ee2b821302f4`
</details>