### PR TITLE
Resizing content

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -21,11 +21,11 @@ HomeWindow::HomeWindow(QWidget* parent) : QWidget(parent) {
   main_layout->setSpacing(0);
 
   sidebar = new Sidebar(this);
-  main_layout->addWidget(sidebar);
+  main_layout->addWidget(sidebar, 1);
   QObject::connect(sidebar, &Sidebar::openSettings, this, &HomeWindow::openSettings);
 
   slayout = new QStackedLayout();
-  main_layout->addLayout(slayout);
+  main_layout->addLayout(slayout, 4);
 
   home = new OffroadHome(this);
   QObject::connect(home, &OffroadHome::openSettings, this, &HomeWindow::openSettings);
@@ -86,6 +86,7 @@ void HomeWindow::showDriverView(bool show) {
   }
   sidebar->setVisible(show == false);
 }
+
 
 void HomeWindow::mousePressEvent(QMouseEvent* e) {
   // Handle sidebar collapsing
@@ -166,7 +167,6 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
     QWidget* right_widget = new QWidget(this);
     QVBoxLayout* right_column = new QVBoxLayout(right_widget);
     right_column->setContentsMargins(0, 0, 0, 0);
-    right_widget->setFixedWidth(750);
     right_column->setSpacing(30);
 
     ExperimentalModeButton *experimental_mode = new ExperimentalModeButton(this);

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -417,7 +417,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
         color: grey;
         border: none;
         background: none;
-        font-size: 65px;
+        font-size: 55px;
         font-weight: 500;
       }
       QPushButton:checked {
@@ -447,7 +447,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
   // main settings layout, sidebar + main panel
   QHBoxLayout *main_layout = new QHBoxLayout(this);
 
-  sidebar_widget->setFixedWidth(500);
+  sidebar_widget->setFixedWidth(400);
   main_layout->addWidget(sidebar_widget);
   main_layout->addWidget(panel_widget);
 

--- a/selfdrive/ui/qt/sidebar.h
+++ b/selfdrive/ui/qt/sidebar.h
@@ -30,6 +30,7 @@ public slots:
   void updateState(const UIState &s);
 
 protected:
+  void resizeEvent(QResizeEvent *event) override; //moje
   void paintEvent(QPaintEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
@@ -47,8 +48,8 @@ protected:
     {cereal::DeviceState::NetworkType::CELL5_G, tr("5G")}
   };
 
-  const QRect home_btn = QRect(60, 860, 180, 180);
-  const QRect settings_btn = QRect(50, 35, 200, 117);
+  QRect home_btn = QRect(60, 760, 180, 180);
+  QRect settings_btn = QRect(50, 35, 200, 117);
   const QColor good_color = QColor(255, 255, 255);
   const QColor warning_color = QColor(218, 202, 37);
   const QColor danger_color = QColor(201, 34, 49);

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -144,7 +144,7 @@ PrimeAdWidget::PrimeAdWidget(QWidget* parent) : QFrame(parent) {
   main_layout->addSpacing(50);
 
   QLabel *description = new QLabel(tr("Become a comma prime member at connect.comma.ai"));
-  description->setStyleSheet("font-size: 56px; font-weight: light; color: white;");
+  description->setStyleSheet("font-size: 46px; font-weight: light; color: white;");
   description->setWordWrap(true);
   main_layout->addWidget(description, 0, Qt::AlignTop);
 
@@ -160,7 +160,7 @@ PrimeAdWidget::PrimeAdWidget(QWidget* parent) : QFrame(parent) {
     const QString check = "<b><font color='#465BEA'>✓</font></b> ";
     QLabel *l = new QLabel(check + b);
     l->setAlignment(Qt::AlignLeft);
-    l->setStyleSheet("font-size: 50px; margin-bottom: 15px;");
+    l->setStyleSheet("font-size: 44px; margin-bottom: 15px;");
     main_layout->addWidget(l, 0, Qt::AlignBottom);
   }
 

--- a/selfdrive/ui/qt/widgets/scrollview.cc
+++ b/selfdrive/ui/qt/widgets/scrollview.cc
@@ -8,7 +8,6 @@
 ScrollView::ScrollView(QWidget *w, QWidget *parent) : QScrollArea(parent) {
   setWidget(w);
   setWidgetResizable(true);
-  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setStyleSheet("background-color: transparent; border:none");
 

--- a/selfdrive/ui/qt/widgets/wifi.cc
+++ b/selfdrive/ui/qt/widgets/wifi.cc
@@ -19,7 +19,7 @@ WiFiPromptWidget::WiFiPromptWidget(QWidget *parent) : QFrame(parent) {
     {
       QLabel *icon = new QLabel;
       QPixmap pixmap("../assets/offroad/icon_wifi_strength_full.svg");
-      icon->setPixmap(pixmap.scaledToWidth(80, Qt::SmoothTransformation));
+      icon->setPixmap(pixmap.scaledToWidth(100, Qt::SmoothTransformation));
       title_layout->addWidget(icon);
 
       QLabel *title = new QLabel(tr("Setup Wi-Fi"));
@@ -38,17 +38,18 @@ WiFiPromptWidget::WiFiPromptWidget(QWidget *parent) : QFrame(parent) {
     connect(settings_btn, &QPushButton::clicked, [=]() { emit openSettings(1); });
     settings_btn->setStyleSheet(R"(
       QPushButton {
-        font-size: 48px;
+        font-size: 64px;
         font-weight: 500;
         border-radius: 10px;
         background-color: #465BEA;
-        padding: 32px;
+        padding: 16px;
       }
       QPushButton:pressed {
         background-color: #3049F4;
       }
     )");
     setup_layout->addWidget(settings_btn);
+    setup_layout->addStretch();
   }
   stack->addWidget(setup);
 
@@ -56,9 +57,10 @@ WiFiPromptWidget::WiFiPromptWidget(QWidget *parent) : QFrame(parent) {
   QWidget *uploading = new QWidget;
   QVBoxLayout *uploading_layout = new QVBoxLayout(uploading);
   uploading_layout->setContentsMargins(64, 56, 64, 56);
-  uploading_layout->setSpacing(36);
+  uploading_layout->setSpacing(20);
   {
     QHBoxLayout *title_layout = new QHBoxLayout;
+    title_layout->setSpacing(32);
     {
       QLabel *title = new QLabel(tr("Ready to upload"));
       title->setStyleSheet("font-size: 64px; font-weight: 600;");
@@ -69,7 +71,7 @@ WiFiPromptWidget::WiFiPromptWidget(QWidget *parent) : QFrame(parent) {
 
       QLabel *icon = new QLabel;
       QPixmap pixmap("../assets/offroad/icon_wifi_uploading.svg");
-      icon->setPixmap(pixmap.scaledToWidth(120, Qt::SmoothTransformation));
+      icon->setPixmap(pixmap.scaledToWidth(100, Qt::SmoothTransformation));
       title_layout->addWidget(icon);
     }
     uploading_layout->addLayout(title_layout);
@@ -78,6 +80,24 @@ WiFiPromptWidget::WiFiPromptWidget(QWidget *parent) : QFrame(parent) {
     desc->setStyleSheet("font-size: 48px; font-weight: 400;");
     desc->setWordWrap(true);
     uploading_layout->addWidget(desc);
+    uploading_layout->setSpacing(52);
+
+    QPushButton *settings_btn = new QPushButton(tr("Open Settings"));
+    connect(settings_btn, &QPushButton::clicked, [=]() { emit openSettings(1); });
+    settings_btn->setStyleSheet(R"(
+      QPushButton {
+        font-size: 48px;
+        font-weight: 500;
+        border-radius: 10px;
+        background-color: #465BEA;
+        padding: 16px;
+      }
+      QPushButton:pressed {
+        background-color: #3049F4;
+      }
+    )");
+    uploading_layout->addWidget(settings_btn);
+    uploading_layout->addStretch();
   }
   stack->addWidget(uploading);
 


### PR DESCRIPTION
There was an issue before https://github.com/commaai/openpilot/issues/31683 which was closed due to not optimal solution. Content is bigger than a screen size, so i edited some fonts and margins, now it looks like this:

![launch_openpilot](https://github.com/commaai/openpilot/assets/159032106/db3c21a1-5879-4ddd-b928-55cc3cc3acd3)

Also, noticed that there is no widget that says if the user is subscribed anymore, i can put it back if needed.