### PR TITLE
ui/cameraview: fix deadlock on exit due to Qt::BlockingQueuedConnection

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 
+#include <QApplication>
 #include <QOpenGLBuffer>
 #include <QOffscreenSurface>
 
@@ -104,6 +105,7 @@ CameraWidget::CameraWidget(std::string stream_name, VisionStreamType type, bool 
   QObject::connect(this, &CameraWidget::vipcThreadConnected, this, &CameraWidget::vipcConnected, Qt::BlockingQueuedConnection);
   QObject::connect(this, &CameraWidget::vipcThreadFrameReceived, this, &CameraWidget::vipcFrameReceived, Qt::QueuedConnection);
   QObject::connect(this, &CameraWidget::vipcAvailableStreamsUpdated, this, &CameraWidget::availableStreamsUpdated, Qt::QueuedConnection);
+  QObject::connect(QApplication::instance(), &QCoreApplication::aboutToQuit, this, &CameraWidget::stopVipcThread);
 }
 
 CameraWidget::~CameraWidget() {


### PR DESCRIPTION
**Issue:**

the `vicpConnected` is connected to `vipcThreadConnected` using `Qt::BlockingQueuedConnection`

> QObject::connect(this, &CameraWidget::vipcThreadConnected, this, &CameraWidget::vipcConnected, Qt::BlockingQueuedConnection);


When the `~CameraWidget` is called and the `CameraWidget::vipcThread` is notified to exit:
```

CameraWidget::~CameraWidget() {
  makeCurrent();
  stopVipcThread();
  ...
  doneCurrent();
}
```
If vipcThread successfully connect to vipc server at this point, it emits the `vipcThreadConnected` signal and blocks  waiting for `vipcConnected` to return. However, since `QApplication` has exited the main event loop before `~CameraWidget`, the `vipcConnected` will never be executed. This causes `vipcThread` to hang and prevents it from exiting properly.

This deadlock rarely occurs in the UI but is more common in Cabana

**resolve:**

 connect to QCoreApplication::aboutToQuit to stop vipcThread before QApplication exits the main event loop.

