### PR TITLE
cabana: stop stream thread before exiting main event loop

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -91,7 +91,6 @@ int main(int argc, char *argv[]) {
     w.openStream();
   }
   w.show();
-  int ret = app.exec();
-  delete can;
-  return ret;
+
+  return app.exec();
 }

--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <utility>
 
+#include <QApplication>
 #include "common/timing.h"
 #include "tools/cabana/settings.h"
 
@@ -19,6 +20,7 @@ AbstractStream::AbstractStream(QObject *parent) : QObject(parent) {
   assert(parent != nullptr);
   event_buffer_ = std::make_unique<MonotonicBuffer>(EVENT_NEXT_BUFFER_SIZE);
 
+  QObject::connect(QApplication::instance(), &QCoreApplication::aboutToQuit, this, &AbstractStream::stop);
   QObject::connect(this, &AbstractStream::privateUpdateLastMsgsSignal, this, &AbstractStream::updateLastMessages, Qt::QueuedConnection);
   QObject::connect(this, &AbstractStream::seekedTo, this, &AbstractStream::updateLastMsgsTo);
   QObject::connect(dbc(), &DBCManager::DBCFileChanged, this, &AbstractStream::updateMasks);

--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -64,6 +64,10 @@ void ReplayStream::start() {
   replay->start();
 }
 
+void ReplayStream::stop() {
+  replay.reset(nullptr);
+}
+
 bool ReplayStream::eventFilter(const Event *event) {
   static double prev_update_ts = 0;
   if (event->which == cereal::Event::Which::CAN) {

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -16,6 +16,7 @@ class ReplayStream : public AbstractStream {
 public:
   ReplayStream(QObject *parent);
   void start() override;
+  void stop() override;
   bool loadRoute(const QString &route, const QString &data_dir, uint32_t replay_flags = REPLAY_FLAG_NONE);
   bool eventFilter(const Event *event);
   void seekTo(double ts) override;

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -56,6 +56,7 @@ Replay::~Replay() {
     stream_thread_->quit();
     stream_thread_->wait();
     delete stream_thread_;
+    stream_thread_ = nullptr;
   }
   timeline_future.waitForFinished();
   rInfo("shutdown: done");


### PR DESCRIPTION
Ensures the stream thread stops before the main event loop exits, addressing:
1. Dangling Pointers: Prevents crashes from signals emitted to destroyed objects.
2. Undefined Behavior: Maintains correct signal-slot operation.
3. Resource Leaks: Ensures proper cleanup, preventing memory and resource leaks.