### PR TITLE
Updated path filters in release_files.py

### DIFF
--- a/release/release_files.py
+++ b/release/release_files.py
@@ -43,7 +43,7 @@ blacklist = [
   "Darwin/",
   ".vscode",
   ".idea",
-  ".run"
+  ".run",
 
   # no LFS
   ".lfsconfig",

--- a/release/release_files.py
+++ b/release/release_files.py
@@ -22,6 +22,9 @@ blacklist = [
   "cereal/.*test.*",
   "^common/tests/",
 
+  ".pytest_cache/",
+  "__pycache__/",
+
   # particularly large text files
   "poetry.lock",
   "third_party/catch2",
@@ -39,6 +42,8 @@ blacklist = [
   ".devcontainer/",
   "Darwin/",
   ".vscode",
+  ".idea",
+  ".run"
 
   # no LFS
   ".lfsconfig",
@@ -47,7 +52,7 @@ blacklist = [
 
 # gets you through the blacklist
 whitelist = [
-  "tools/lib/",
+  "^tools/lib/(?!.*__pycache__).*$",
   "tools/bodyteleop/",
 
   "tinygrad_repo/openpilot/compile2.py",

--- a/release/release_files.py
+++ b/release/release_files.py
@@ -22,7 +22,7 @@ blacklist = [
   "cereal/.*test.*",
   "^common/tests/",
 
-  "\.pytest_cache/",
+  ".pytest_cache/",
   "__pycache__/",
 
   # particularly large text files
@@ -42,8 +42,8 @@ blacklist = [
   ".devcontainer/",
   "Darwin/",
   ".vscode",
-  "\.idea",
-  "\.run",
+  ".idea/",
+  ".run/",
 
   # no LFS
   ".lfsconfig",

--- a/release/release_files.py
+++ b/release/release_files.py
@@ -22,7 +22,7 @@ blacklist = [
   "cereal/.*test.*",
   "^common/tests/",
 
-  ".pytest_cache/",
+  "\.pytest_cache/",
   "__pycache__/",
 
   # particularly large text files
@@ -42,8 +42,8 @@ blacklist = [
   ".devcontainer/",
   "Darwin/",
   ".vscode",
-  ".idea",
-  ".run",
+  "\.idea",
+  "\.run",
 
   # no LFS
   ".lfsconfig",


### PR DESCRIPTION
Exclude intellij directories and exclude .pytest_cache and __pycache__ directories thereby reducing clutter and ignoring unnecessary files. Improved whitelist rule to exclude any __pycache__ within tools/lib.
