### PR TITLE
cabana: fix potential dangling pointer Issue

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -151,7 +151,7 @@ QWidget *VideoWidget::createCameraWidget() {
   setMaximumTime(can->totalSeconds());
   QObject::connect(slider, &QSlider::sliderReleased, [this]() { can->seekTo(slider->currentSecond()); });
   QObject::connect(slider, &Slider::updateMaximumTime, this, &VideoWidget::setMaximumTime, Qt::QueuedConnection);
-  QObject::connect(can, &AbstractStream::eventsMerged, [this]() { slider->update(); });
+  QObject::connect(can, &AbstractStream::eventsMerged, this, [this]() { slider->update(); });
   QObject::connect(static_cast<ReplayStream*>(can), &ReplayStream::qLogLoaded, slider, &Slider::parseQLog);
   QObject::connect(cam_widget, &CameraWidget::clicked, []() { can->pause(!can->isPaused()); });
   QObject::connect(cam_widget, &CameraWidget::vipcAvailableStreamsUpdated, this, &VideoWidget::vipcAvailableStreamsUpdated);


### PR DESCRIPTION
fixes a potential dangling pointer issue in the `QObject::connect` call. By including `this` as the context object, the connection is automatically disconnected when the parent object is destroyed. This prevents the lambda from being called after `this` has been deleted, avoiding undefined behavior.