### PR TITLE
replay: add stop() function

### DIFF
--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -65,7 +65,9 @@ void ReplayStream::start() {
 }
 
 void ReplayStream::stop() {
-  replay.reset(nullptr);
+  if (replay) {
+    replay->stop();
+  }
 }
 
 bool ReplayStream::eventFilter(const Event *event) {

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -46,11 +46,15 @@ Replay::Replay(QString route, QStringList allow, QStringList block, SubMaster *s
 }
 
 Replay::~Replay() {
+  stop();
+}
+
+void Replay::stop() {
   if (!stream_thread_ && segments_.empty()) return;
 
   rInfo("shutdown: in progress...");
   if (stream_thread_ != nullptr) {
-    exit_ =true;
+    exit_ = true;
     paused_ = true;
     stream_cv_.notify_one();
     stream_thread_->quit();

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -54,6 +54,7 @@ public:
   ~Replay();
   bool load();
   void start(int seconds = 0);
+  void stop();
   void pause(bool pause);
   void seekToFlag(FindFlag flag);
   void seekTo(double seconds, bool relative);


### PR DESCRIPTION
Enhances replay lifecycle management by moving the cleanup code from `Replay::~Replay() `to a new `stop()` function. This change allows the Replay to be stopped at any time, ensuring safe access to its internal data by other modules after stopping. Additionally, it resolves a potential dangling pointer issue related to the Replay instance in Cabana. 
