### PR TITLE
common/ratekeeper: change frame() return type from double to uint64_t

### DIFF
--- a/common/ratekeeper.h
+++ b/common/ratekeeper.h
@@ -9,7 +9,7 @@ public:
   ~RateKeeper() {}
   bool keepTime();
   bool monitorTime();
-  inline double frame() const { return frame_; }
+  inline uint64_t frame() const { return frame_; }
   inline double remaining() const { return remaining_; }
 
 private:


### PR DESCRIPTION
This change ensures the return type matches the frame_ member variable