### PR TITLE
add `.vscode` into `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ venv/
 .tags
 .ipynb_checkpoints
 .idea
-.vscode
 .overlay_init
 .overlay_consistent
 .sconsign.dblite
@@ -84,3 +83,22 @@ build/
 
 poetry.toml
 Pipfile
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ venv/
 .tags
 .ipynb_checkpoints
 .idea
+.vscode
 .overlay_init
 .overlay_consistent
 .sconsign.dblite


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

I've come across needing to remove `.vscode` from a few PRs. Unless I'm missing something as to why this shouldn't be added into `.gitignore` the PR will do just that.

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

