### PR TITLE
AlignedBuffer: avoid unnecessary data copying when already aligned

### DIFF
--- a/cereal/messaging/socketmaster.cc
+++ b/cereal/messaging/socketmaster.cc
@@ -94,6 +94,8 @@ void SubMaster::update(int timeout) {
     m->msg_reader->~FlatArrayMessageReader();
     capnp::ReaderOptions options;
     options.traversalLimitInWords = kj::maxValue; // Don't limit
+
+    // Reset the message buffer to the new one. Keep it for the message reader's lifetime.
     m->message.reset(msg);
     m->msg_reader = new (m->allocated_msg_reader) capnp::FlatArrayMessageReader(m->aligned_buf.align(msg), options);
     messages.push_back({m->name, m->msg_reader->getRoot<cereal::Event>()});

--- a/cereal/messaging/socketmaster.cc
+++ b/cereal/messaging/socketmaster.cc
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string>
+#include <memory>
 #include <mutex>
 
 #include "cereal/services.h"
@@ -40,6 +41,7 @@ struct SubMaster::SubMessage {
   bool is_polled = false;
   capnp::FlatArrayMessageReader *msg_reader = nullptr;
   AlignedBuffer aligned_buf;
+  std::unique_ptr<Message> message;
   cereal::Event::Reader event;
 };
 
@@ -92,8 +94,8 @@ void SubMaster::update(int timeout) {
     m->msg_reader->~FlatArrayMessageReader();
     capnp::ReaderOptions options;
     options.traversalLimitInWords = kj::maxValue; // Don't limit
+    m->message.reset(msg);
     m->msg_reader = new (m->allocated_msg_reader) capnp::FlatArrayMessageReader(m->aligned_buf.align(msg), options);
-    delete msg;
     messages.push_back({m->name, m->msg_reader->getRoot<cereal::Event>()});
   }
 


### PR DESCRIPTION
This update optimizes memory usage and execution time by avoiding unnecessary data copying when data is already aligned, which is typically the case.  It improves the performance of handling Capnp messages, particularly in critical code blocks like `can_send_thread()`, `can_capnp_to_can_list_cp`(#32009),  etc.

Cap'n Proto also performs the same alignment check internally.  You can see an example of this in the following code snippet:

https://github.com/capnproto/capnproto/blob/f668fb59515d182ef3e6cefa7842662d4b37a8d7/c%2B%2B/src/capnp/compat/websocket-rpc.c%2B%2B#L49-L63