### PR TITLE
watch3 arguments support

### DIFF
--- a/selfdrive/ui/watch3.cc
+++ b/selfdrive/ui/watch3.cc
@@ -19,21 +19,21 @@ int main(int argc, char *argv[]) {
 
   QCommandLineParser cmd_parser;
   cmd_parser.addHelpOption();
-  cmd_parser.addOption({"cams", "cameras to decode e.g. 0 or 0,1 or 0,1,2"});
-  cmd_parser.addOption({"nav", "load nav"});
-  cmd_parser.addOption({"qcam", "load qcamera"});
-  cmd_parser.addOption({"ecam", "load wide road camera"});
-  cmd_parser.addOption({"dcam", "load driver camera"});
+  QCommandLineOption cams_option = QCommandLineOption("cams", "cameras to decode, separated by a comma", "0,1,2");
+  cmd_parser.addOption(cams_option);
+  cmd_parser.addOption({"nav", "decode nav"});
+  cmd_parser.addOption({"qcam", "decode qcamera"});
+  cmd_parser.addOption({"ecam", "decode wide road camera"});
+  cmd_parser.addOption({"dcam", "decode driver camera"});
   cmd_parser.process(app);
-  const QStringList args = cmd_parser.positionalArguments();
 
   if (cmd_parser.isSet("cams")) {
-    QStringList indexes = QString(cmd_parser.value("cams")).split(',');
-    for (const QString &index : indexes) {
+    QStringList indexes = cmd_parser.value(cams_option).split(',');
+    for (QString &index : indexes) {
       VisionStreamType streamType = static_cast<VisionStreamType>(index.toInt());
       layout->addWidget(new CameraWidget("camerad", streamType, false));
     }
-  } else if (!args.empty()) {
+  } else if (cmd_parser.optionNames().count() > 0) {
     if (cmd_parser.isSet("nav")) {
       layout->addWidget(new CameraWidget("navd", VISION_STREAM_MAP, false));
     }

--- a/selfdrive/ui/watch3.cc
+++ b/selfdrive/ui/watch3.cc
@@ -25,7 +25,7 @@ int main(int argc, char *argv[]) {
   cmd_parser.addOption({"ecam", "load wide road camera"});
   cmd_parser.addOption({"dcam", "load driver camera"});
   cmd_parser.process(app);
-  const QStringList args = parser.positionalArguments();
+  const QStringList args = cmd_parser.positionalArguments();
 
   if (cmd_parser.isSet("cams")) {
     QStringList indexes = QString(cmd_parser.value("cams")).split(',');
@@ -47,15 +47,19 @@ int main(int argc, char *argv[]) {
       layout->addWidget(new CameraWidget("camerad", VISION_STREAM_WIDE_ROAD, false));
     }
   } else {
-    QHBoxLayout *hlayout = new QHBoxLayout();
-    layout->addLayout(hlayout);
-    hlayout->addWidget(new CameraWidget("navd", VISION_STREAM_MAP, false));
-    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_ROAD, false));
+    {
+      QHBoxLayout *hlayout = new QHBoxLayout();
+      layout->addLayout(hlayout);
+      hlayout->addWidget(new CameraWidget("navd", VISION_STREAM_MAP, false));
+      hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_ROAD, false));
+    }
 
-    QHBoxLayout *hlayout = new QHBoxLayout();
-    layout->addLayout(hlayout);
-    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_DRIVER, false));
-    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_WIDE_ROAD, false));
+    {
+      QHBoxLayout *hlayout = new QHBoxLayout();
+      layout->addLayout(hlayout);
+      hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_DRIVER, false));
+      hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_WIDE_ROAD, false));
+    }
   }
 
   return app.exec();

--- a/selfdrive/ui/watch3.cc
+++ b/selfdrive/ui/watch3.cc
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QtWidgets>
+#include <QCommandLineParser>
 
 #include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/util.h"
@@ -8,7 +9,7 @@
 int main(int argc, char *argv[]) {
   initApp(argc, argv);
 
-  QApplication a(argc, argv);
+  QApplication app(argc, argv);
   QWidget w;
   setMainWindow(&w);
 
@@ -16,19 +17,46 @@ int main(int argc, char *argv[]) {
   layout->setMargin(0);
   layout->setSpacing(0);
 
-  {
+  QCommandLineParser cmd_parser;
+  cmd_parser.addHelpOption();
+  cmd_parser.addOption({"cams", "cameras to decode e.g. 0 or 0,1 or 0,1,2"});
+  cmd_parser.addOption({"nav", "load nav"});
+  cmd_parser.addOption({"qcam", "load qcamera"});
+  cmd_parser.addOption({"ecam", "load wide road camera"});
+  cmd_parser.addOption({"dcam", "load driver camera"});
+  cmd_parser.process(app);
+  const QStringList args = parser.positionalArguments();
+
+  if (cmd_parser.isSet("cams")) {
+    QStringList indexes = QString(cmd_parser.value("cams")).split(',');
+    for (const QString &index : indexes) {
+      VisionStreamType streamType = static_cast<VisionStreamType>(index.toInt());
+      layout->addWidget(new CameraWidget("camerad", streamType, false));
+    }
+  } else if (!args.empty()) {
+    if (cmd_parser.isSet("nav")) {
+      layout->addWidget(new CameraWidget("navd", VISION_STREAM_MAP, false));
+    }
+    if (cmd_parser.isSet("qcam")) {
+      layout->addWidget(new CameraWidget("camerad", VISION_STREAM_ROAD, false));
+    }
+    if (cmd_parser.isSet("dcam")) {
+      layout->addWidget(new CameraWidget("camerad", VISION_STREAM_DRIVER, false));
+    }
+    if (cmd_parser.isSet("ecam")) {
+      layout->addWidget(new CameraWidget("camerad", VISION_STREAM_WIDE_ROAD, false));
+    }
+  } else {
     QHBoxLayout *hlayout = new QHBoxLayout();
     layout->addLayout(hlayout);
     hlayout->addWidget(new CameraWidget("navd", VISION_STREAM_MAP, false));
     hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_ROAD, false));
-  }
 
-  {
     QHBoxLayout *hlayout = new QHBoxLayout();
     layout->addLayout(hlayout);
     hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_DRIVER, false));
     hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_WIDE_ROAD, false));
   }
 
-  return a.exec();
+  return app.exec();
 }

--- a/tools/camerastream/README.md
+++ b/tools/camerastream/README.md
@@ -37,9 +37,13 @@ Decode the stream with `compressed_vipc.py`:
 
 ```cd ~/openpilot/tools/camerastream && ./compressed_vipc.py <ip>```
 
-To actually display the stream, run `watch3` in separate terminal:
+To actually display the stream of all cameras, run `watch3` in separate terminal:
 
 ```cd ~/openpilot/selfdrive/ui/ && ./watch3```
+
+To display one camera (or specific cameras), run `watch3` with the `--cams` flag:
+
+```cd ~/openpilot/selfdrive/ui/ && ./watch3 --cams 0```
 
 ## compressed_vipc.py usage
 ```

--- a/tools/camerastream/README.md
+++ b/tools/camerastream/README.md
@@ -37,7 +37,7 @@ Decode the stream with `compressed_vipc.py`:
 
 ```cd ~/openpilot/tools/camerastream && ./compressed_vipc.py <ip>```
 
-To actually display the stream of all cameras, run `watch3` in separate terminal:
+To actually display the stream, run `watch3` in separate terminal:
 
 ```cd ~/openpilot/selfdrive/ui/ && ./watch3```
 

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -58,6 +58,11 @@ cd tools/replay && ./replay --demo --dcam --ecam
 cd selfdrive/ui && ./watch3
 ```
 
+to only display one camera (or specific cameras), run `watch3` with camera flags:
+```bash
+cd selfdrive/ui && ./watch3 --dcam --ecam
+```
+
 ![](https://i.imgur.com/IeaOdAb.png)
 
 ## Stream CAN messages to your device


### PR DESCRIPTION
This is a proposal to supporting arguments for `watch3`. This is what `watch3 -h` says with this PR:

```
Usage: selfdrive/ui/watch3 [options]

Options:
  -h, --help      Displays help on commandline options.
  --help-all      Displays help including Qt specific options.
  --cams <0,1,2>  cameras to decode, separated by a comma
  --nav           decode nav
  --qcam          decode qcamera
  --ecam          decode wide road camera
  --dcam          decode driver camera
```

Not using any argument, works as before.