### PR TITLE
qlog_size.py: more accurate msg size breakdown

### DIFF
--- a/selfdrive/debug/internal/qlog_size.py
+++ b/selfdrive/debug/internal/qlog_size.py
@@ -1,33 +1,62 @@
 #!/usr/bin/env python3
 import argparse
 import bz2
+import zstd
+import lz4.frame
+import zlib
 from collections import defaultdict
 
 import matplotlib.pyplot as plt
 
+from cereal.services import SERVICE_LIST
 from openpilot.tools.lib.logreader import LogReader
+from openpilot.tools.lib.route import Route
+from tqdm import tqdm
 
-MIN_SIZE = 0.5  # Percent size of total to show as separate entry
+MIN_SIZE = 0.1  # Percent size of total to show as separate entry
+
+
+def compress(data):
+  # return lz4.frame.compress(data)
+  # return zlib.compress(data)
+  # return bz2.compress(data)
+  return zstd.compress(data)
 
 
 def make_pie(msgs, typ):
   msgs_by_type = defaultdict(list)
+  print(len(msgs))
   for m in msgs:
-    msgs_by_type[m.which()].append(m.as_builder().to_bytes())
+    # # print(dir(m.as_builder()))
+    # print(m.which())
+    # print(len(m.as_builder().to_bytes()))
+    # print(len(m.as_builder().to_bytes_packed()))
+    # break
+    msgs_by_type[m.which()].append(m.as_builder().to_bytes_packed())
 
   length_by_type = {k: len(b"".join(v)) for k, v in msgs_by_type.items()}
-  compressed_length_by_type = {k: len(bz2.compress(b"".join(v))) for k, v in msgs_by_type.items()}
+  compressed_length_by_type = {k: len(compress(b"".join(v))) for k, v in msgs_by_type.items()}
+
+  compressed_length_by_type_v2 = {}
 
   total = sum(compressed_length_by_type.values())
-  uncompressed_total = len(b"".join([m.as_builder().to_bytes() for m in msgs]))
+  real_total = len(compress(b"".join([m.as_builder().to_bytes_packed() for m in msgs])))
+  uncompressed_total = len(b"".join([m.as_builder().to_bytes_packed() for m in msgs]))
+
+  for k in tqdm(msgs_by_type.keys()):
+    compressed_length_by_type_v2[k] = real_total - len(compress(b"".join([m.as_builder().to_bytes_packed() for m in msgs if m.which() != k])))
+    # print(k, compressed_length_by_type_v2[k])
 
   sizes = sorted(compressed_length_by_type.items(), key=lambda kv: kv[1])
+  # sizes = sorted(compressed_length_by_type_v2.items(), key=lambda kv: kv[1])
 
   print("name - comp. size (uncomp. size)")
   for (name, sz) in sizes:
-    print(f"{name:<22} - {sz / 1024:.2f} kB ({length_by_type[name] / 1024:.2f} kB)")
+    print(f"{name:<22} - {sz / 1024:.2f} kB / {compressed_length_by_type_v2[name] / 1024:.2f} kB ({length_by_type[name] / 1024:.2f} kB)")
   print()
   print(f"{typ} - Total {total / 1024:.2f} kB")
+  print(f"{typ} - Real {real_total / 1024:.2f} kB")
+  print(f"{typ} - Simulated total (v2) {sum(compressed_length_by_type_v2.values()) / 1024:.2f} MB")
   print(f"{typ} - Uncompressed total {uncompressed_total / 1024 / 1024:.2f} MB")
 
   sizes_large = [(k, sz) for (k, sz) in sizes if sz >= total * MIN_SIZE / 100]
@@ -41,7 +70,7 @@ def make_pie(msgs, typ):
 
 
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description='View log size breakdown by message type')
+  parser = argparse.ArgumentParser(description='Check qlog size based on a rlog')
   parser.add_argument('route', help='route to use')
   args = parser.parse_args()
 

--- a/selfdrive/debug/internal/qlog_size.py
+++ b/selfdrive/debug/internal/qlog_size.py
@@ -13,7 +13,7 @@ from openpilot.tools.lib.logreader import LogReader
 from openpilot.tools.lib.route import Route
 from tqdm import tqdm
 
-MIN_SIZE = 0.1  # Percent size of total to show as separate entry
+MIN_SIZE = 0.5  # Percent size of total to show as separate entry
 
 
 def compress(data):
@@ -25,38 +25,29 @@ def compress(data):
 
 def make_pie(msgs, typ):
   msgs_by_type = defaultdict(list)
-  print(len(msgs))
   for m in msgs:
-    # # print(dir(m.as_builder()))
-    # print(m.which())
-    # print(len(m.as_builder().to_bytes()))
-    # print(len(m.as_builder().to_bytes_packed()))
-    # break
-    msgs_by_type[m.which()].append(m.as_builder().to_bytes_packed())
+    msgs_by_type[m.which()].append(m.as_builder().to_bytes())
 
   length_by_type = {k: len(b"".join(v)) for k, v in msgs_by_type.items()}
-  compressed_length_by_type = {k: len(compress(b"".join(v))) for k, v in msgs_by_type.items()}
 
-  compressed_length_by_type_v2 = {}
+  # calculate compressed size by removing it from segment and compressing
+  compressed_length_by_type = {}
 
-  total = sum(compressed_length_by_type.values())
-  real_total = len(compress(b"".join([m.as_builder().to_bytes_packed() for m in msgs])))
-  uncompressed_total = len(b"".join([m.as_builder().to_bytes_packed() for m in msgs]))
+  total = len(compress(b"".join([m.as_builder().to_bytes() for m in msgs])))
+  uncompressed_total = len(b"".join([m.as_builder().to_bytes() for m in msgs]))
 
   for k in tqdm(msgs_by_type.keys()):
-    compressed_length_by_type_v2[k] = real_total - len(compress(b"".join([m.as_builder().to_bytes_packed() for m in msgs if m.which() != k])))
-    # print(k, compressed_length_by_type_v2[k])
+    compressed_length_by_type[k] = total - len(compress(b"".join([m.as_builder().to_bytes() for m in msgs if m.which() != k])))
 
   sizes = sorted(compressed_length_by_type.items(), key=lambda kv: kv[1])
-  # sizes = sorted(compressed_length_by_type_v2.items(), key=lambda kv: kv[1])
 
   print("name - comp. size (uncomp. size)")
   for (name, sz) in sizes:
-    print(f"{name:<22} - {sz / 1024:.2f} kB / {compressed_length_by_type_v2[name] / 1024:.2f} kB ({length_by_type[name] / 1024:.2f} kB)")
+    print(f"{name:<22} - {sz / 1024:.2f} kB / {compressed_length_by_type[name] / 1024:.2f} kB ({length_by_type[name] / 1024:.2f} kB)")
   print()
-  print(f"{typ} - Total {total / 1024:.2f} kB")
-  print(f"{typ} - Real {real_total / 1024:.2f} kB")
-  print(f"{typ} - Simulated total (v2) {sum(compressed_length_by_type_v2.values()) / 1024:.2f} MB")
+  # print(f"{typ} - Total {total / 1024:.2f} kB")
+  print(f"{typ} - Real {total / 1024:.2f} kB")
+  print(f"{typ} - Simulated total (v2) {sum(compressed_length_by_type.values()) / 1024:.2f} MB")
   print(f"{typ} - Uncompressed total {uncompressed_total / 1024 / 1024:.2f} MB")
 
   sizes_large = [(k, sz) for (k, sz) in sizes if sz >= total * MIN_SIZE / 100]

--- a/selfdrive/debug/internal/qlog_size.py
+++ b/selfdrive/debug/internal/qlog_size.py
@@ -29,9 +29,9 @@ def make_pie(msgs, typ):
 
   print("name - comp. size (uncomp. size)")
   for (name, sz) in sizes:
-    print(f"{name:<22} - {sz / 1024:.2f} kB / {compressed_length_by_type[name] / 1024:.2f} kB ({length_by_type[name] / 1024:.2f} kB)")
+    print(f"{name:<22} - {sz / 1024:.2f} kB ({length_by_type[name] / 1024:.2f} kB)")
   print()
-  print(f"{typ} - Real {total / 1024:.2f} kB")
+  print(f"{typ} - Real total {total / 1024:.2f} kB")
   print(f"{typ} - Breakdown total {sum(compressed_length_by_type.values()) / 1024:.2f} kB")
   print(f"{typ} - Uncompressed total {uncompressed_total / 1024 / 1024:.2f} MB")
 

--- a/selfdrive/debug/internal/qlog_size.py
+++ b/selfdrive/debug/internal/qlog_size.py
@@ -22,7 +22,7 @@ def make_pie(msgs, typ):
   length_by_type = {k: len(b"".join(v)) for k, v in msgs_by_type.items()}
   # calculate compressed size by calculating diff when removed from the segment
   compressed_length_by_type = {}
-  for k in tqdm(msgs_by_type.keys()):
+  for k in tqdm(msgs_by_type.keys(), desc="Compressing"):
     compressed_length_by_type[k] = total - len(bz2.compress(b"".join([m.as_builder().to_bytes() for m in msgs if m.which() != k])))
 
   sizes = sorted(compressed_length_by_type.items(), key=lambda kv: kv[1])

--- a/selfdrive/debug/internal/qlog_size.py
+++ b/selfdrive/debug/internal/qlog_size.py
@@ -8,9 +8,7 @@ from collections import defaultdict
 
 import matplotlib.pyplot as plt
 
-from cereal.services import SERVICE_LIST
 from openpilot.tools.lib.logreader import LogReader
-from openpilot.tools.lib.route import Route
 from tqdm import tqdm
 
 MIN_SIZE = 0.5  # Percent size of total to show as separate entry
@@ -30,7 +28,7 @@ def make_pie(msgs, typ):
 
   length_by_type = {k: len(b"".join(v)) for k, v in msgs_by_type.items()}
 
-  # calculate compressed size by removing it from segment and compressing
+  # calculate compressed size by calculating diff when removed from the segment
   compressed_length_by_type = {}
 
   total = len(compress(b"".join([m.as_builder().to_bytes() for m in msgs])))
@@ -45,9 +43,8 @@ def make_pie(msgs, typ):
   for (name, sz) in sizes:
     print(f"{name:<22} - {sz / 1024:.2f} kB / {compressed_length_by_type[name] / 1024:.2f} kB ({length_by_type[name] / 1024:.2f} kB)")
   print()
-  # print(f"{typ} - Total {total / 1024:.2f} kB")
   print(f"{typ} - Real {total / 1024:.2f} kB")
-  print(f"{typ} - Simulated total (v2) {sum(compressed_length_by_type.values()) / 1024:.2f} MB")
+  print(f"{typ} - Breakdown total {sum(compressed_length_by_type.values()) / 1024:.2f} kB")
   print(f"{typ} - Uncompressed total {uncompressed_total / 1024 / 1024:.2f} MB")
 
   sizes_large = [(k, sz) for (k, sz) in sizes if sz >= total * MIN_SIZE / 100]
@@ -61,7 +58,7 @@ def make_pie(msgs, typ):
 
 
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description='Check qlog size based on a rlog')
+  parser = argparse.ArgumentParser(description='View log size breakdown by message type')
   parser.add_argument('route', help='route to use')
   args = parser.parse_args()
 

--- a/selfdrive/debug/internal/qlog_size.py
+++ b/selfdrive/debug/internal/qlog_size.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import bz2
-import zstd
-import lz4.frame
-import zlib
 from collections import defaultdict
 
 import matplotlib.pyplot as plt
@@ -14,28 +11,19 @@ from tqdm import tqdm
 MIN_SIZE = 0.5  # Percent size of total to show as separate entry
 
 
-def compress(data):
-  # return lz4.frame.compress(data)
-  # return zlib.compress(data)
-  # return bz2.compress(data)
-  return zstd.compress(data)
-
-
 def make_pie(msgs, typ):
   msgs_by_type = defaultdict(list)
   for m in msgs:
     msgs_by_type[m.which()].append(m.as_builder().to_bytes())
 
-  length_by_type = {k: len(b"".join(v)) for k, v in msgs_by_type.items()}
-
-  # calculate compressed size by calculating diff when removed from the segment
-  compressed_length_by_type = {}
-
-  total = len(compress(b"".join([m.as_builder().to_bytes() for m in msgs])))
+  total = len(bz2.compress(b"".join([m.as_builder().to_bytes() for m in msgs])))
   uncompressed_total = len(b"".join([m.as_builder().to_bytes() for m in msgs]))
 
+  length_by_type = {k: len(b"".join(v)) for k, v in msgs_by_type.items()}
+  # calculate compressed size by calculating diff when removed from the segment
+  compressed_length_by_type = {}
   for k in tqdm(msgs_by_type.keys()):
-    compressed_length_by_type[k] = total - len(compress(b"".join([m.as_builder().to_bytes() for m in msgs if m.which() != k])))
+    compressed_length_by_type[k] = total - len(bz2.compress(b"".join([m.as_builder().to_bytes() for m in msgs if m.which() != k])))
 
   sizes = sorted(compressed_length_by_type.items(), key=lambda kv: kv[1])
 


### PR DESCRIPTION
Related to https://github.com/commaai/openpilot/pull/32719

Compressing groups of message types often compresses differently than interleaving them (what our logs look like). The sum of this is much closer to the total compressed size, and the size is literally what is saved by removing that message type