### PR TITLE
pandad: removed the redundant .c_str() call

### DIFF
--- a/selfdrive/pandad/panda_comms.cc
+++ b/selfdrive/pandad/panda_comms.cc
@@ -120,7 +120,7 @@ std::vector<std::string> PandaUsbHandle::list() {
       libusb_close(handle);
       if (ret < 0) { goto finish; }
 
-      serials.push_back(std::string((char *)desc_serial, ret).c_str());
+      serials.push_back(std::string((char *)desc_serial, ret));
     }
   }
 


### PR DESCRIPTION
The original code unnecessarily converts a std::string to a c string, and then back to a std::string, which is redundant and impacts readability. 