### PR TITLE
pandad: improve usb error handling

### DIFF
--- a/selfdrive/pandad/panda_comms.h
+++ b/selfdrive/pandad/panda_comms.h
@@ -52,7 +52,7 @@ private:
   libusb_context *ctx = NULL;
   libusb_device_handle *dev_handle = NULL;
   std::recursive_mutex hw_lock;
-  void handle_usb_issue(int err, const char func[]);
+  void handle_usb_issue(int err, const char func[], unsigned char endpoint = 0);
 };
 
 #ifndef __APPLE__


### PR DESCRIPTION
Improve the error handling  by adding checks for two specific error conditions: `LIBUSB_ERROR_PIPE` and `LIBUSB_ERROR_NO_MEM`.

1. LIBUSB_ERROR_PIPE: endpoints with halt status  are unable to receive or transmit data until the halt condition is stalled. this pr clears the stall on the relevant endpoint to resolve the issue and allow continued communication. https://github.com/libusb/libusb/blob/e678b3fad58a508cbd0a6e6dc777fb48346f948b/examples/xusb.c#L363
2. LIBUSB_ERROR_NO_MEM:  disconnects from the USB device as recovery is not possible.
