### PR TITLE
Hyundai CAN-FD: Universal gear checks

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -48,14 +48,16 @@ class CarInterface(CarInterfaceBase):
         # non-HDA2
         if 0x1cf not in fingerprint[CAN.ECAN]:
           ret.flags |= HyundaiFlags.CANFD_ALT_BUTTONS.value
-        # ICE cars do not have 0x130; GEARS message on 0x40 or 0x70 instead
-        if 0x130 not in fingerprint[CAN.ECAN]:
-          if 0x40 not in fingerprint[CAN.ECAN]:
-            ret.flags |= HyundaiFlags.CANFD_ALT_GEARS_2.value
-          else:
-            ret.flags |= HyundaiFlags.CANFD_ALT_GEARS.value
         if candidate not in CANFD_RADAR_SCC_CAR:
           ret.flags |= HyundaiFlags.CANFD_CAMERA_SCC.value
+
+      # ICE cars do not have 0x130; GEARS message on 0x40 or 0x70 instead
+      # Applies to both HDA2 and non-HDA2
+      if 0x130 not in fingerprint[CAN.ECAN]:
+        if 0x40 not in fingerprint[CAN.ECAN]:
+          ret.flags |= HyundaiFlags.CANFD_ALT_GEARS_2.value
+        else:
+          ret.flags |= HyundaiFlags.CANFD_ALT_GEARS.value
     else:
       # TODO: detect EV and hybrid
       if candidate in HYBRID_CAR:


### PR DESCRIPTION
**Description**

The refactor's goal is to improve the gear checking logic to be applicable to both HDA2 and non-HDA2 Hyundai vehicles, which was previously only applied to non-HDA2 cars.

**Verification**

This is tested in the following active PRs:
- https://github.com/commaai/openpilot/pull/32633
- https://github.com/commaai/openpilot/pull/31704