### PR TITLE
cabana: avoid dead locks and improve responsiveness

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -513,7 +513,7 @@ void ChartView::mouseReleaseEvent(QMouseEvent *event) {
       // no rubber dragged, seek to mouse position
       can->seekTo(min);
     } else if (rubber->width() > 10 && (max - min) > MIN_ZOOM_SECONDS) {
-      charts_widget->zoom_undo_stack->push(new ZoomCommand(charts_widget, {min, max}));
+      charts_widget->zoom_undo_stack->push(new ZoomCommand({min, max}));
     } else {
       viewport()->update();
     }

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -46,11 +46,10 @@ public:
 public slots:
   void setColumnCount(int n);
   void removeAll();
-  void setZoom(double min, double max);
+  void timeRangeChanged(const std::optional<std::pair<double, double>> &time_range);
 
 signals:
   void dock(bool floating);
-  void rangeChanged(double min, double max, bool is_zommed);
   void seriesChanged();
 
 private:
@@ -102,9 +101,7 @@ private:
   ChartsContainer *charts_container;
   QScrollArea *charts_scroll;
   uint32_t max_chart_range = 0;
-  bool is_zoomed = false;
   std::pair<double, double> display_range;
-  std::pair<double, double> zoomed_range;
   QAction *columns_action;
   int column_count = 1;
   int current_column_count = 0;
@@ -119,12 +116,11 @@ private:
 
 class ZoomCommand : public QUndoCommand {
 public:
-  ZoomCommand(ChartsWidget *charts, std::pair<double, double> range) : charts(charts), range(range), QUndoCommand() {
-    prev_range = charts->is_zoomed ? charts->zoomed_range : charts->display_range;
+  ZoomCommand(std::pair<double, double> range) : range(range), QUndoCommand() {
+    prev_range = can->timeRange();
     setText(QObject::tr("Zoom to %1-%2").arg(range.first, 0, 'f', 2).arg(range.second, 0, 'f', 2));
   }
-  void undo() override { charts->setZoom(prev_range.first, prev_range.second); }
-  void redo() override { charts->setZoom(range.first, range.second); }
-  ChartsWidget *charts;
-  std::pair<double, double> prev_range, range;
+  void undo() override { can->setTimeRange(prev_range); }
+  void redo() override { can->setTimeRange(range); }
+  std::optional<std::pair<double, double>> prev_range, range;
 };

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -192,7 +192,6 @@ void MainWindow::createDockWidgets() {
   video_splitter = new QSplitter(Qt::Vertical, this);
   video_widget = new VideoWidget(this);
   video_splitter->addWidget(video_widget);
-  QObject::connect(charts_widget, &ChartsWidget::rangeChanged, video_widget, &VideoWidget::updateTimeRange);
 
   video_splitter->addWidget(charts_container);
   video_splitter->setStretchFactor(1, 1);

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -3,8 +3,10 @@
 #include <array>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <QColor>
@@ -77,6 +79,8 @@ public:
   virtual double getSpeed() { return 1; }
   virtual bool isPaused() const { return false; }
   virtual void pause(bool pause) {}
+  void setTimeRange(const std::optional<std::pair<double, double>> &range);
+  const std::optional<std::pair<double, double>> &timeRange() const { return time_range_; }
 
   inline const std::unordered_map<MessageId, CanData> &lastMessages() const { return last_msgs; }
   inline const MessageEventsMap &eventsMap() const { return events_; }
@@ -91,8 +95,9 @@ public:
 signals:
   void paused();
   void resume();
-  void seekingTo(double sec);
+  void seeking(double sec);
   void seekedTo(double sec);
+  void timeRangeChanged(const std::optional<std::pair<double, double>> &range);
   void streamStarted();
   void eventsMerged(const MessageEventsMap &events_map);
   void msgsReceived(const std::set<MessageId> *new_msgs, bool has_new_ids);
@@ -110,6 +115,7 @@ protected:
 
   std::vector<const CanEvent *> all_events_;
   double current_sec_ = 0;
+  std::optional<std::pair<double, double>> time_range_;
   uint64_t lastest_event_ts = 0;
 
 private:

--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -53,9 +53,9 @@ bool ReplayStream::loadRoute(const QString &route, const QString &data_dir, uint
                           {}, nullptr, replay_flags, data_dir, this));
   replay->setSegmentCacheLimit(settings.max_cached_minutes);
   replay->installEventFilter(event_filter, this);
+  QObject::connect(replay.get(), &Replay::seeking, this, &AbstractStream::seeking);
   QObject::connect(replay.get(), &Replay::seekedTo, this, &AbstractStream::seekedTo);
   QObject::connect(replay.get(), &Replay::segmentsMerged, this, &ReplayStream::mergeSegments);
-  QObject::connect(replay.get(), &Replay::qLogLoaded, this, &ReplayStream::qLogLoaded, Qt::QueuedConnection);
   return replay->load();
 }
 
@@ -92,12 +92,7 @@ bool ReplayStream::eventFilter(const Event *event) {
 }
 
 void ReplayStream::seekTo(double ts) {
-  // Update timestamp and notify receivers of the time change.
   current_sec_ = ts;
-  std::set<MessageId> new_msgs;
-  msgsReceived(&new_msgs, false);
-
-  // Seek to the specified timestamp
   replay->seekTo(std::max(double(0), ts), false);
 }
 

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -34,9 +34,6 @@ public:
   void pause(bool pause) override;
   static AbstractOpenStreamWidget *widget(AbstractStream **stream);
 
-signals:
-  void qLogLoaded(int segnum, std::shared_ptr<LogReader> qlog);
-
 private:
   void mergeSegments();
   std::unique_ptr<Replay> replay = nullptr;

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <utility>
 
 #include <QHBoxLayout>
 #include <QFrame>
@@ -40,12 +41,9 @@ public:
   void setTimeRange(double min, double max);
   AlertInfo alertInfo(double sec);
   QPixmap thumbnail(double sec);
-  void parseQLog(int segnum, std::shared_ptr<LogReader> qlog);
+  void parseQLog(std::shared_ptr<LogReader> qlog);
 
   const double factor = 1000.0;
-
-signals:
-  void updateMaximumTime(double);
 
 private:
   void mousePressEvent(QMouseEvent *e) override;
@@ -63,11 +61,11 @@ class VideoWidget : public QFrame {
 
 public:
   VideoWidget(QWidget *parnet = nullptr);
-  void updateTimeRange(double min, double max, bool is_zommed);
   void setMaximumTime(double sec);
 
 protected:
   QString formatTime(double sec, bool include_milliseconds = false);
+  void timeRangeChanged(const std::optional<std::pair<double, double>> &time_range);
   void updateState();
   void updatePlayBtnState();
   QWidget *createCameraWidget();

--- a/tools/replay/camera.cc
+++ b/tools/replay/camera.cc
@@ -60,7 +60,6 @@ void CameraServer::cameraThread(Camera &cam) {
     capnp::FlatArrayMessageReader reader(event->data);
     auto evt = reader.getRoot<cereal::Event>();
     auto eidx = capnp::AnyStruct::Reader(evt).getPointerSection()[0].getAs<cereal::EncodeIndex>();
-    if (eidx.getType() != cereal::EncodeIndex::Type::FULL_H_E_V_C) continue;
 
     int segment_id = eidx.getSegmentId();
     uint32_t frame_id = eidx.getFrameId();

--- a/tools/replay/logreader.cc
+++ b/tools/replay/logreader.cc
@@ -42,10 +42,10 @@ bool LogReader::load(const char *data, size_t size, std::atomic<bool> *abort) {
           evt.which == cereal::Event::DRIVER_ENCODE_IDX ||
           evt.which == cereal::Event::WIDE_ROAD_ENCODE_IDX) {
         auto idx = capnp::AnyStruct::Reader(event).getPointerSection()[0].getAs<cereal::EncodeIndex>();
-        if (uint64_t sof = idx.getTimestampSof()) {
-          mono_time = sof;
+        if (idx.getType() == cereal::EncodeIndex::Type::FULL_H_E_V_C) {
+          uint64_t sof = idx.getTimestampSof();
+          events.emplace_back(which, sof ? sof : mono_time, event_data, idx.getSegmentNum());
         }
-        events.emplace_back(which, mono_time, event_data, idx.getSegmentNum());
       }
     }
   } catch (const kj::Exception &e) {

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -85,14 +85,16 @@ public:
   inline const std::string &carFingerprint() const { return car_fingerprint_; }
   inline const std::vector<std::tuple<double, double, TimelineType>> getTimeline() {
     std::lock_guard lk(timeline_lock);
-    return timeline;
+    return timeline_;
   }
 
 signals:
   void streamStarted();
   void segmentsMerged();
+  void seeking(double sec);
   void seekedTo(double sec);
-  void qLogLoaded(int segnum, std::shared_ptr<LogReader> qlog);
+  void qLogLoaded(std::shared_ptr<LogReader> qlog);
+  void totalSecondsUpdated(double sec);
 
 protected slots:
   void segmentLoadFinished(bool success);
@@ -112,6 +114,7 @@ protected:
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);
   void buildTimeline();
+  void checkSeekProgress();
   inline bool isSegmentMerged(int n) const { return merged_segments_.count(n) > 0; }
 
   pthread_t stream_thread_id = 0;
@@ -120,7 +123,7 @@ protected:
   bool user_paused_ = false;
   std::condition_variable stream_cv_;
   std::atomic<int> current_segment_ = 0;
-  double seeking_to_seconds_ = -1;
+  std::optional<double> seeking_to_;
   SegmentMap segments_;
   // the following variables must be protected with stream_lock_
   std::atomic<bool> exit_ = false;
@@ -143,7 +146,7 @@ protected:
 
   std::mutex timeline_lock;
   QFuture<void> timeline_future;
-  std::vector<std::tuple<double, double, TimelineType>> timeline;
+  std::vector<std::tuple<double, double, TimelineType>> timeline_;
   std::string car_fingerprint_;
   std::atomic<float> speed_ = 1.0;
   replayEventFilter event_filter = nullptr;

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -318,33 +318,23 @@ std::string decompressBZ2(const std::byte *in, size_t in_size, std::atomic<bool>
   return {};
 }
 
-void precise_nano_sleep(int64_t nanoseconds) {
-#ifdef __APPLE__
-  const long estimate_ns = 1 * 1e6;  // 1ms
-  struct timespec req = {.tv_nsec = estimate_ns};
-  uint64_t start_sleep = nanos_since_boot();
-  while (nanoseconds > estimate_ns) {
-    nanosleep(&req, nullptr);
-    uint64_t end_sleep = nanos_since_boot();
-    nanoseconds -= (end_sleep - start_sleep);
-    start_sleep = end_sleep;
-  }
-  // spin wait
-  if (nanoseconds > 0) {
-    while ((nanos_since_boot() - start_sleep) <= nanoseconds) {
-      std::this_thread::yield();
-    }
-  }
-#else
+void precise_nano_sleep(int64_t nanoseconds, std::atomic<bool> &should_exit) {
   struct timespec req, rem;
-
-  req.tv_sec = nanoseconds / 1e9;
-  req.tv_nsec = nanoseconds % (int64_t)1e9;
-  while (clock_nanosleep(CLOCK_MONOTONIC, 0, &req, &rem) && errno == EINTR) {
+  req.tv_sec = nanoseconds / 1000000000;
+  req.tv_nsec = nanoseconds % 1000000000;
+  while (!should_exit) {
+#ifdef __APPLE_
+    int ret = nanosleep(&req, &rem);
+    if (ret == 0 || errno != EINTR)
+      break;
+#else
+    int ret = clock_nanosleep(CLOCK_MONOTONIC, 0, &req, &rem);
+    if (ret == 0 || ret != EINTR)
+      break;
+#endif
     // Retry sleep if interrupted by a signal
     req = rem;
   }
-#endif
 }
 
 std::string sha256(const std::string &str) {

--- a/tools/replay/util.h
+++ b/tools/replay/util.h
@@ -37,7 +37,7 @@ private:
 };
 
 std::string sha256(const std::string &str);
-void precise_nano_sleep(int64_t nanoseconds);
+void precise_nano_sleep(int64_t nanoseconds, std::atomic<bool> &should_exit);
 std::string decompressBZ2(const std::string &in, std::atomic<bool> *abort = nullptr);
 std::string decompressBZ2(const std::byte *in, size_t in_size, std::atomic<bool> *abort = nullptr);
 std::string getUrlWithoutQuery(const std::string &url);


### PR DESCRIPTION
This PR addresses potential deadlocks and enhances the overall responsiveness.

Main Changes:
1.  Enhanced the handling of thread states to prevent deadlocks, especially during the seeking.Introduced more granular locks and condition variable notifications to ensure smooth transitions between different states (e.g., seeking, pausing, merging and resuming).
2.  Improved the mechanism for updating events and seeking within the timeline to make the UI more responsive to user inputs.
3. Optimized the event processing loop to avoid recursive calls, reducing latency and ensuring timely updates.
4. Introduced mechanisms to detect and handle incorrect timestamps, preventing hangs caused by erroneous timestamps and ensuring smooth playback.
5. fix race conditions in replay::buildTimeline.

