### PR TITLE
SegmentRange: remove timestamp

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -135,7 +135,7 @@ def internal_source(sr: SegmentRange, mode: ReadMode) -> LogPaths:
     raise InternalUnavailableException
 
   def get_internal_url(sr: SegmentRange, seg, file):
-    return f"cd:/{sr.dongle_id}/{sr.timestamp}/{seg}/{file}.bz2"
+    return f"cd:/{sr.dongle_id}/{sr.log_id}/{seg}/{file}.bz2"
 
   rlog_paths = [get_internal_url(sr, seg, "rlog") for seg in sr.seg_idxs]
   qlog_paths = [get_internal_url(sr, seg, "qlog") for seg in sr.seg_idxs]

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -261,13 +261,6 @@ class SegmentRange:
     return self.m.group("dongle_id")
 
   @property
-  def timestamp(self) -> str:
-    match = self.m.group("timestamp")
-    if match is None:
-      raise DeprecationWarning("Route timestamp is deprecated, use log_id")
-    return match
-
-  @property
   def log_id(self) -> str:
     return self.m.group("log_id")
 

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -262,7 +262,10 @@ class SegmentRange:
 
   @property
   def timestamp(self) -> str:
-    return self.m.group("timestamp")
+    match = self.m.group("timestamp")
+    if match is None:
+      raise DeprecationWarning("Route timestamp is deprecated, use log_id")
+    return match
 
   @property
   def log_id(self) -> str:


### PR DESCRIPTION
internal source was broken on new routes, as it should be log_id