### PR TITLE
modeld: cleanup input buffer logic

### DIFF
--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -95,7 +95,6 @@ class ModelState:
 
     # if getCLBuffer is not None, frame will be None
     input_imgs = self.frame.prepare(buf, transform.flatten(), self.model.getCLBuffer("input_imgs"))
-    print(input_imgs.shape, input_imgs.dtype, type(input_imgs))
     self.model.setInputBuffer("input_imgs", input_imgs)
     if wbuf is not None:
       self.model.setInputBuffer("big_input_imgs", self.wide_frame.prepare(wbuf, transform_wide.flatten(), self.model.getCLBuffer("big_input_imgs")))

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -77,8 +77,8 @@ class ModelState:
     self.parser = Parser()
 
     self.model = ModelRunner(MODEL_PATHS, self.output, Runtime.GPU, False, context)
-    self.model.addInput("input_imgs", None)
-    self.model.addInput("big_input_imgs", None)
+    #self.model.addInput("input_imgs", None)
+    #self.model.addInput("big_input_imgs", None)
     for k,v in self.inputs.items():
       self.model.addInput(k, v)
 

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -78,8 +78,8 @@ class ModelState:
     self.parser = Parser()
 
     self.model = ModelRunner(MODEL_PATHS, self.output, Runtime.GPU, False, context)
-    #self.model.addInput("input_imgs", None)
-    #self.model.addInput("big_input_imgs", None)
+    self.model.addInput("input_imgs", None)
+    self.model.addInput("big_input_imgs", None)
     for k,v in self.inputs.items():
       self.model.addInput(k, v)
 

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -64,9 +64,10 @@ class ModelState:
       'lateral_control_params': np.zeros(ModelConstants.LATERAL_CONTROL_PARAMS_LEN, dtype=np.float32),
       'prev_desired_curv': np.zeros(ModelConstants.PREV_DESIRED_CURV_LEN * (ModelConstants.HISTORY_BUFFER_LEN+1), dtype=np.float32),
       'features_buffer': np.zeros(ModelConstants.HISTORY_BUFFER_LEN * ModelConstants.FEATURE_LEN, dtype=np.float32),
-      'input_imgs': np.zeros(MODEL_FRAME_SIZE*2, dtype=np.float32),
-      'big_input_imgs': np.zeros(MODEL_FRAME_SIZE*2, dtype=np.float32),
     }
+
+    self.input_imgs = np.zeros(MODEL_FRAME_SIZE*2, dtype=np.float32)
+    self.big_input_imgs = np.zeros(MODEL_FRAME_SIZE*2, dtype=np.float32)
 
     with open(METADATA_PATH, 'rb') as f:
       model_metadata = pickle.load(f)
@@ -101,12 +102,15 @@ class ModelState:
 
     # if getCLBuffer is not None, frame will be None
     new_img = self.frame.prepare(buf, transform.flatten(), self.model.getCLBuffer("input_imgs"))
-    self.inputs['input_imgs'][:MODEL_FRAME_SIZE] = self.inputs['input_imgs'][MODEL_FRAME_SIZE:]
-    self.inputs['input_imgs'][MODEL_FRAME_SIZE:] = new_img
+    self.input_imgs[:MODEL_FRAME_SIZE] = self.input_imgs[MODEL_FRAME_SIZE:]
+    self.input_imgs[MODEL_FRAME_SIZE:] = new_img
+    self.model.setInputBuffer("input_imgs", self.input_imgs)
     if wbuf is not None:
       new_big_img = self.wide_frame.prepare(wbuf, transform.flatten(), self.model.getCLBuffer("big_input_imgs"))
-      self.inputs['big_input_imgs'][:MODEL_FRAME_SIZE] = self.inputs['big_input_imgs'][MODEL_FRAME_SIZE:]
-      self.inputs['big_input_imgs'][MODEL_FRAME_SIZE:] = new_big_img
+      self.big_input_imgs[:MODEL_FRAME_SIZE] = self.big_input_imgs[MODEL_FRAME_SIZE:]
+      self.big_input_imgs[MODEL_FRAME_SIZE:] = new_big_img
+      self.model.setInputBuffer("big_input_imgs", self.big_input_imgs)
+
 
     if prepare_only:
       return None

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -94,7 +94,9 @@ class ModelState:
     self.inputs['lateral_control_params'][:] = inputs['lateral_control_params']
 
     # if getCLBuffer is not None, frame will be None
-    self.model.setInputBuffer("input_imgs", self.frame.prepare(buf, transform.flatten(), self.model.getCLBuffer("input_imgs")))
+    input_imgs = self.frame.prepare(buf, transform.flatten(), self.model.getCLBuffer("input_imgs"))
+    print(input_imgs.shape, input_imgs.dtype, type(input_imgs))
+    self.model.setInputBuffer("input_imgs", input_imgs)
     if wbuf is not None:
       self.model.setInputBuffer("big_input_imgs", self.wide_frame.prepare(wbuf, transform_wide.flatten(), self.model.getCLBuffer("big_input_imgs")))
 

--- a/selfdrive/modeld/models/commonmodel.cc
+++ b/selfdrive/modeld/models/commonmodel.cc
@@ -24,19 +24,12 @@ float* ModelFrame::prepare(cl_mem yuv_cl, int frame_width, int frame_height, int
                   yuv_cl, frame_width, frame_height, frame_stride, frame_uv_offset,
                   y_cl, u_cl, v_cl, MODEL_WIDTH, MODEL_HEIGHT, projection);
 
-  if (output == NULL) {
-    loadyuv_queue(&loadyuv, q, y_cl, u_cl, v_cl, net_input_cl);
+  loadyuv_queue(&loadyuv, q, y_cl, u_cl, v_cl, net_input_cl);
 
-    std::memmove(&input_frames[0], &input_frames[MODEL_FRAME_SIZE], sizeof(float) * MODEL_FRAME_SIZE);
-    CL_CHECK(clEnqueueReadBuffer(q, net_input_cl, CL_TRUE, 0, MODEL_FRAME_SIZE * sizeof(float), &input_frames[MODEL_FRAME_SIZE], 0, nullptr, nullptr));
-    clFinish(q);
-    return &input_frames[0];
-  } else {
-    loadyuv_queue(&loadyuv, q, y_cl, u_cl, v_cl, *output, true);
-    // NOTE: Since thneed is using a different command queue, this clFinish is needed to ensure the image is ready.
-    clFinish(q);
-    return NULL;
-  }
+  std::memmove(&input_frames[0], &input_frames[MODEL_FRAME_SIZE], sizeof(float) * MODEL_FRAME_SIZE);
+  CL_CHECK(clEnqueueReadBuffer(q, net_input_cl, CL_TRUE, 0, MODEL_FRAME_SIZE * sizeof(float), &input_frames[MODEL_FRAME_SIZE], 0, nullptr, nullptr));
+  clFinish(q);
+  return &input_frames[0];
 }
 
 ModelFrame::~ModelFrame() {

--- a/selfdrive/modeld/models/commonmodel.h
+++ b/selfdrive/modeld/models/commonmodel.h
@@ -27,12 +27,11 @@ public:
   const int MODEL_WIDTH = 512;
   const int MODEL_HEIGHT = 256;
   const int MODEL_FRAME_SIZE = MODEL_WIDTH * MODEL_HEIGHT * 3 / 2;
-  const int buf_size = MODEL_FRAME_SIZE * 2;
 
 private:
   Transform transform;
   LoadYUVState loadyuv;
   cl_command_queue q;
   cl_mem y_cl, u_cl, v_cl, net_input_cl;
-  std::unique_ptr<float[]> input_frames;
+  std::unique_ptr<float[]> frame;
 };

--- a/selfdrive/modeld/models/commonmodel.pxd
+++ b/selfdrive/modeld/models/commonmodel.pxd
@@ -15,6 +15,6 @@ cdef extern from "selfdrive/modeld/models/commonmodel.h":
   float sigmoid(float)
 
   cppclass ModelFrame:
-    int buf_size
+    int MODEL_FRAME_SIZE
     ModelFrame(cl_device_id, cl_context)
     float * prepare(cl_mem, int, int, int, int, mat3, cl_mem*)

--- a/selfdrive/modeld/models/commonmodel_pyx.pyx
+++ b/selfdrive/modeld/models/commonmodel_pyx.pyx
@@ -44,4 +44,4 @@ cdef class ModelFrame:
       data = self.frame.prepare(buf.buf.buf_cl, buf.width, buf.height, buf.stride, buf.uv_offset, cprojection, output.mem)
     if not data:
       return None
-    return np.asarray(<cnp.float32_t[:self.frame.buf_size]> data)
+    return np.asarray(<cnp.float32_t[:self.frame.MODEL_FRAME_SIZE]> data)


### PR DESCRIPTION
Is there a cleaner way to make this fast, that still keeps the logic in python?