### PR TITLE
replay: fix hangs on exit

### DIFF
--- a/tools/replay/camera.cc
+++ b/tools/replay/camera.cc
@@ -27,6 +27,13 @@ CameraServer::CameraServer(std::pair<int, int> camera_size[MAX_CAMERAS]) {
 CameraServer::~CameraServer() {
   for (auto &cam : cameras_) {
     if (cam.thread.joinable()) {
+      // Clear the queue
+      std::pair<FrameReader*, const Event *> item;
+      while (cam.queue.try_pop(item)) {
+        --publishing_;
+      }
+
+      // Signal termination and join the thread
       cam.queue.push({});
       cam.thread.join();
     }

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -50,20 +50,20 @@ Replay::~Replay() {
 }
 
 void Replay::stop() {
-  if (!stream_thread_ && segments_.empty()) return;
-
-  rInfo("shutdown: in progress...");
+  exit_ = true;
   if (stream_thread_ != nullptr) {
-    exit_ = true;
+    rInfo("shutdown: in progress...");
     pauseStreamThread();
     stream_cv_.notify_one();
     stream_thread_->quit();
     stream_thread_->wait();
     stream_thread_->deleteLater();
     stream_thread_ = nullptr;
+    rInfo("shutdown: done");
   }
   timeline_future.waitForFinished();
-  rInfo("shutdown: done");
+  camera_server_.reset(nullptr);
+  segments_.clear();
 }
 
 bool Replay::load() {


### PR DESCRIPTION
This PR fixes an issue where the app could hang during exit due to unhandled camera queue items and unreset segments. 

These changes ensure a reliable shutdown by properly managing and releasing resources, preventing QApplication from hanging by waiting for thread pool to complete before shutdown (https://codebrowser.dev/qt5/qtbase/src/corelib/kernel/qcoreapplication.cpp.html#874)