### PR TITLE
cabana: fix chart value tip flickers when the mouse moves over it

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -421,13 +421,6 @@ qreal ChartView::niceNumber(qreal x, bool ceiling) {
   return q * z;
 }
 
-void ChartView::leaveEvent(QEvent *event) {
-  if (tip_label->isVisible()) {
-    charts_widget->showValueTip(-1);
-  }
-  QChartView::leaveEvent(event);
-}
-
 QPixmap getBlankShadowPixmap(const QPixmap &px, int radius) {
   QGraphicsDropShadowEffect *e = new QGraphicsDropShadowEffect;
   e->setColor(QColor(40, 40, 40, 245));
@@ -546,7 +539,7 @@ void ChartView::mouseMoveEvent(QMouseEvent *ev) {
   bool is_zooming = rubber && rubber->isVisible();
   clearTrackPoints();
 
-  if (!is_zooming && plot_area.contains(ev->pos())) {
+  if (!is_zooming && plot_area.contains(ev->pos()) && isActiveWindow()) {
     const double sec = chart()->mapToValue(ev->pos()).x();
     charts_widget->showValueTip(sec);
   } else if (tip_label->isVisible()) {

--- a/tools/cabana/chart/chart.h
+++ b/tools/cabana/chart/chart.h
@@ -76,7 +76,6 @@ private:
   void dragLeaveEvent(QDragLeaveEvent *event) override { drawDropIndicator(false); }
   void dragMoveEvent(QDragMoveEvent *event) override;
   void dropEvent(QDropEvent *event) override;
-  void leaveEvent(QEvent *event) override;
   void resizeEvent(QResizeEvent *event) override;
   QSize sizeHint() const override;
   void updateAxisY();

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -47,14 +47,14 @@ public slots:
   void setColumnCount(int n);
   void removeAll();
   void timeRangeChanged(const std::optional<std::pair<double, double>> &time_range);
+  void setIsDocked(bool dock);
 
 signals:
-  void dock(bool floating);
+  void toggleChartsDocking();
   void seriesChanged();
 
 private:
   QSize minimumSizeHint() const override;
-  void resizeEvent(QResizeEvent *event) override;
   bool event(QEvent *event) override;
   void alignCharts();
   void newChart();
@@ -85,7 +85,7 @@ private:
   LogSlider *range_slider;
   QAction *range_lb_action;
   QAction *range_slider_action;
-  bool docking = true;
+  bool is_docked = true;
   ToolButton *dock_btn;
 
   QAction *undo_zoom_action;
@@ -109,6 +109,7 @@ private:
   QTimer *auto_scroll_timer;
   QTimer *align_timer;
   int current_theme = 0;
+  bool value_tip_visible_ = false;
   friend class ZoomCommand;
   friend class ChartView;
   friend class ChartsContainer;

--- a/tools/cabana/chart/tiplabel.cc
+++ b/tools/cabana/chart/tiplabel.cc
@@ -9,8 +9,12 @@
 #include "tools/cabana/settings.h"
 
 TipLabel::TipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::FramelessWindowHint) {
+  setAttribute(Qt::WA_ShowWithoutActivating);
+  setAttribute(Qt::WA_TransparentForMouseEvents);
+
   setForegroundRole(QPalette::ToolTipText);
   setBackgroundRole(QPalette::ToolTipBase);
+
   QFont font;
   font.setPointSizeF(8.34563465);
   setFont(font);
@@ -22,9 +26,7 @@ TipLabel::TipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::Frameless
   setPalette(palette);
   ensurePolished();
   setMargin(1 + style()->pixelMetric(QStyle::PM_ToolTipLabelFrameWidth, nullptr, this));
-  setAttribute(Qt::WA_ShowWithoutActivating);
   setTextFormat(Qt::RichText);
-  setVisible(false);
 }
 
 void TipLabel::showText(const QPoint &pt, const QString &text, QWidget *w, const QRect &rect) {

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -21,7 +21,7 @@ class MainWindow : public QMainWindow {
 
 public:
   MainWindow();
-  void dockCharts(bool dock);
+  void toggleChartsDocking();
   void showStatusMessage(const QString &msg, int timeout = 0) { statusBar()->showMessage(msg, timeout); }
   void loadFile(const QString &fn, SourceSet s = SOURCE_ALL);
   ChartsWidget *charts_widget = nullptr;
@@ -46,6 +46,7 @@ signals:
   void updateProgressBar(uint64_t cur, uint64_t total, bool success);
 
 protected:
+  bool eventFilter(QObject *obj, QEvent *event) override;
   void remindSaveChanges();
   void closeFile(SourceSet s = SOURCE_ALL);
   void closeFile(DBCFile *dbc_file);


### PR DESCRIPTION
**Issue**: value tip flckers on mose moves over it:

[Kazam_screencast_00147.webm](https://github.com/commaai/openpilot/assets/27770/df306681-2d33-47a4-b746-78628cdc5302)


This fix includes many changes because **Qt Chart** sets **Qt::WA_AlwaysStackOnTop** internally for its OpenGL drawing window to improve performance. This requires additional code to handle multiple value tips displayed on top of it correctly.