### PR TITLE
Bring back macOS CI

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -97,6 +97,8 @@ jobs:
       run: ./tools/mac_setup.sh
       env:
         SKIP_PROMPT: 1
+        # package install has DeprecationWarnings
+        PYTHONWARNINGS: default
     - name: Test openpilot environment
       run: poetry run scons -h
 

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -86,7 +86,21 @@ jobs:
         docker_hub_pat: ${{ secrets.DOCKER_HUB_PAT }}
     - uses: ./.github/workflows/compile-openpilot
       timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 15 || 30) }} # allow more time when we missed the scons cache
-
+  build_mac:
+    name: build macos
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+      env:
+        # package install has DeprecationWarnings
+        SKIP_PROMPT: 1
+    - name: Install dependencies
+      if: steps.dependency-cache.outputs.cache-hit != 'true'
+      run: ./tools/mac_setup.sh
+    - name: Test openpilot environment
+      run: poetry run scons -h
   static_analysis:
     name: static analysis
     runs-on: ${{ ((github.repository == 'commaai/openpilot') &&

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -93,12 +93,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-      env:
-        # package install has DeprecationWarnings
-        SKIP_PROMPT: 1
     - name: Install dependencies
       if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: ./tools/mac_setup.sh
+      env:
+        SKIP_PROMPT: 1
     - name: Test openpilot environment
       run: poetry run scons -h
   static_analysis:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -94,12 +94,12 @@ jobs:
       with:
         submodules: true
     - name: Install dependencies
-      if: steps.dependency-cache.outputs.cache-hit != 'true'
       run: ./tools/mac_setup.sh
       env:
         SKIP_PROMPT: 1
     - name: Test openpilot environment
       run: poetry run scons -h
+
   static_analysis:
     name: static analysis
     runs-on: ${{ ((github.repository == 'commaai/openpilot') &&

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -93,6 +93,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - run: git lfs pull
     - name: Install dependencies
       run: ./tools/mac_setup.sh
       env:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -90,7 +90,7 @@ jobs:
     name: build macos
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - run: git lfs pull

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -86,6 +86,7 @@ jobs:
         docker_hub_pat: ${{ secrets.DOCKER_HUB_PAT }}
     - uses: ./.github/workflows/compile-openpilot
       timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 15 || 30) }} # allow more time when we missed the scons cache
+      
   build_mac:
     name: build macos
     runs-on: macos-latest


### PR DESCRIPTION
Fixes #32791
Runs tools/mac_setup.sh and scons -h without any caching. mac_setup.sh takes ~4 minutes.