### PR TITLE
deleter: preserve two previous segments on user flag

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -37,9 +37,9 @@ def get_preserved_segments(dirs_by_creation: list[str]) -> list[str]:
     except ValueError:
       continue
 
-    # preserve segment and its prior
-    preserved.append(d)
-    preserved.append(f"{date_str}--{seg_num - 1}")
+    # preserve segment and two prior
+    for _seg_num in range(max(0, seg_num - 2), seg_num + 1):
+      preserved.append(f"{date_str}--{_seg_num}")
 
   return preserved
 


### PR DESCRIPTION
extension of https://github.com/commaai/openpilot/pull/28814

also fixes no-consequence `---1` segments in the list when you preserved the first segment (0 - 1)