### PR TITLE
ui/installer: hardcode SSH Keys in installer.cc

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -106,10 +106,6 @@ if GetOption('extras') and arch != "Darwin":
     if "internal" in name:
       d['INTERNAL'] = "1"
 
-      import requests
-      r = requests.get("https://github.com/commaci2.keys")
-      r.raise_for_status()
-      d['SSH_KEYS'] = f'\\"{r.text.strip()}\\"'
     obj = senv.Object(f"installer/installers/installer_{name}.o", ["installer/installer.cc"], CPPDEFINES=d)
     f = senv.Program(f"installer/installers/installer_{name}", [obj, cont], LIBS=qt_libs)
     # keep installers small

--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -180,10 +180,12 @@ void Installer::cloneFinished(int exitCode, QProcess::ExitStatus exitStatus) {
 #ifdef INTERNAL
   run("mkdir -p /data/params/d/");
 
+  // https://github.com/commaci2.keys
+  const std::string ssh_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMX2kU8eBZyEWmbq0tjMPxksWWVuIV/5l64GabcYbdpI";
   std::map<std::string, std::string> params = {
     {"SshEnabled", "1"},
     {"RecordFrontLock", "1"},
-    {"GithubSshKeys", SSH_KEYS},
+    {"GithubSshKeys", ssh_keys},
   };
   for (const auto& [key, value] : params) {
     std::ofstream param;


### PR DESCRIPTION
Hardcode SSH keys in the "installer.cc"  to eliminate the inefficiency of fetching SSH keys from "http://github/" during each run. Currently, this practice can cause issues such as compilation failures or delays in poor network conditions, and it also prevents offline compilation.

this change aims to improve compilation speed and reliability, particularly in environments with limited or unreliable internet connectivity.