### PR TITLE
cereal: use nanos_since_boot() from common/timing.h

### DIFF
--- a/cereal/messaging/messaging.h
+++ b/cereal/messaging/messaging.h
@@ -5,19 +5,12 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include <time.h>
 
 #include <capnp/serialize.h>
 
 #include "cereal/gen/cpp/log.capnp.h"
+#include "common/timing.h"
 #include "msgq/ipc.h"
-
-#ifdef __APPLE__
-#define CLOCK_BOOTTIME CLOCK_MONOTONIC
-#endif
-
-#define MSG_MULTIPLE_PUBLISHERS 100
-
 
 class SubMaster {
 public:
@@ -53,10 +46,7 @@ public:
 
   cereal::Event::Builder initEvent(bool valid = true) {
     cereal::Event::Builder event = initRoot<cereal::Event>();
-    struct timespec t;
-    clock_gettime(CLOCK_BOOTTIME, &t);
-    uint64_t current_time = t.tv_sec * 1000000000ULL + t.tv_nsec;
-    event.setLogMonoTime(current_time);
+    event.setLogMonoTime(nanos_since_boot());
     event.setValid(valid);
     return event;
   }

--- a/cereal/messaging/socketmaster.cc
+++ b/cereal/messaging/socketmaster.cc
@@ -1,4 +1,3 @@
-#include <time.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <string>
@@ -7,14 +6,7 @@
 #include "cereal/services.h"
 #include "cereal/messaging/messaging.h"
 
-
 const bool SIMULATION = (getenv("SIMULATION") != nullptr) && (std::string(getenv("SIMULATION")) == "1");
-
-static inline uint64_t nanos_since_boot() {
-  struct timespec t;
-  clock_gettime(CLOCK_BOOTTIME, &t);
-  return t.tv_sec * 1000000000ULL + t.tv_nsec;
-}
 
 static inline bool inList(const std::vector<const char *> &list, const char *value) {
   for (auto &v : list) {


### PR DESCRIPTION
1. Removed the redundant `nanos_since_boot()` function and uses the implementation from `common/timing.h`.
2. Removed the unused and outdated macro `MSG_MULTIPLE_PUBLISHERS`.