### PR TITLE
GM torque control: robust sig function

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -53,7 +53,12 @@ class CarInterface(CarInterfaceBase):
     friction = get_friction(lateral_accel_error, lateral_accel_deadzone, FRICTION_THRESHOLD, torque_params, friction_compensation)
 
     def sig(val):
-      return 1 / (1 + exp(-val)) - 0.5
+      # https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick
+      if val >= 0:
+        return 1 / (1 + exp(-val)) - 0.5
+      else:
+        z = exp(val)
+        return z / (1 + z) - 0.5
 
     # The "lat_accel vs torque" relationship is assumed to be the sum of "sigmoid + linear" curves
     # An important thing to consider is that the slope at 0 should be > 0 (ideally >1)


### PR DESCRIPTION
Fixes https://github.com/commaai/openpilot/issues/32841

```python
for _ in range(10000000):
  val = random.uniform(-100, 100)
  v1 = sig(val)
  v2 = sig2(val)
  assert abs(v1 - v2) < 1e-15, (v1, v2)
```

```python
>>> sig(-1000)
Traceback (most recent call last):
  File "/snap/pycharm-professional/395/plugins/python/helpers/pydev/pydevconsole.py", line 364, in runcode
    coro = func()
           ^^^^^^
  File "<input>", line 1, in <module>
  File "<input>", line 2, in sig
OverflowError: math range error
>>> sig2(-100000000000000)
-0.5
>>> sig2(100000000000000)
0.5
```