### PR TITLE
Car port KIA K9 2019

### DIFF
--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -1157,4 +1157,15 @@ FW_VERSIONS = {
       b'\xf1\x00US4_ RDR -----      1.00 1.00 99110-CG000         ',
     ],
   },
+  CAR.KIA_K9_2019: {
+    (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00RJ__ SCC FHCUP      1.01 1.01 99110-J6000         ',
+    ],
+    (Ecu.eps, 0x7d4, None): [
+      b'\xf1\x00RJ  MDPS R 1.00 1.00 56320-J6000 8118',
+    ],
+    (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00RJ  MFC  AT KOR LHD 1.00 1.01 99211-J6000 180228',
+    ],
+  },
 }

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -493,6 +493,11 @@ class CAR(Platforms):
     CarSpecs(mass=2087, wheelbase=3.09, steerRatio=14.23),
     flags=HyundaiFlags.RADAR_SCC,
   )
+  KIA_K9_2019 = HyundaiPlatformConfig(
+    [HyundaiCarDocs("Kia K9 2019", car_parts=CarParts.common([CarHarness.hyundai_d]))],
+    # steerRatio = variable
+    CarSpecs(mass=2005, wheelbase=3.105, steerRatio=14.5, tireStiffnessFactor=0.5)
+  )
 
   # Genesis
   GENESIS_GV60_EV_1ST_GEN = HyundaiCanFDPlatformConfig(

--- a/selfdrive/car/torque_data/override.toml
+++ b/selfdrive/car/torque_data/override.toml
@@ -68,6 +68,7 @@ legend = ["LAT_ACCEL_FACTOR", "MAX_LAT_ACCEL_MEASURED", "FRICTION"]
 "HYUNDAI_CUSTIN_1ST_GEN" = [2.5, 2.5, 0.1]
 "LEXUS_GS_F" = [2.5, 2.5, 0.08]
 "HYUNDAI_STARIA_4TH_GEN" = [1.8, 2.0, 0.15]
+"KIA_K9_2019" = [2.5, 2.5, 0.1]
 
 # Dashcam or fallback configured as ideal car
 "MOCK" = [10.0, 10, 0.0]


### PR DESCRIPTION
- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [x] route with openpilot: 51489459ad31cccc/00000004--9df4e9185e
- [x] route with stock system: 51489459ad31cccc/0000004f--3be6385412
- [x] car harness used (if comma doesn't sell it, put N/A): Hyundai-D