### PR TITLE
fix bug in modelV2 service which was triggering test_loggerd failure

### DIFF
--- a/cereal/messaging/tests/test_services.py
+++ b/cereal/messaging/tests/test_services.py
@@ -15,6 +15,7 @@ class TestServices(unittest.TestCase):
   def test_services(self, s):
     service = SERVICE_LIST[s]
     self.assertTrue(service.frequency <= 104)
+    self.assertTrue(service.decimation != 0)
 
   def test_generated_header(self):
     with tempfile.NamedTemporaryFile(suffix=".h") as f:

--- a/cereal/services.py
+++ b/cereal/services.py
@@ -61,7 +61,7 @@ _services: dict[str, tuple] = {
   "wideRoadEncodeIdx": (False, 20., 1),
   "wideRoadCameraState": (True, 20., 20),
   "drivingModelData": (True, 20., 10),
-  "modelV2": (True, 20., 0),
+  "modelV2": (True, 20.),
   "managerState": (True, 2., 1),
   "uploaderState": (True, 0., 1),
   "navInstruction": (True, 1., 10),


### PR DESCRIPTION
**Description**

Decimation of modelV2 was incorrectly set to 0. This caused 
```cpp
const bool in_qlog = service.freq != -1 && (service.counter++ % service.freq == 0);
```
in [system/loggerd/logger.cc](https://github.com/commaai/openpilot/blob/master/system/loggerd/logger.cc) to fail since modulo 0 is undefined. (`.freq = it.decimation` earlier in the file)

The bug would randomly cause any number of the below unit test failures as services are randomly sampled in each test in [test_loggerd.py](https://github.com/commaai/openpilot/blob/master/system/loggerd/tests/test_loggerd.py)
```
FAILED system/loggerd/tests/test_loggerd.py::TestLoggerd::test_rlog - AssertionError: assert False
FAILED system/loggerd/tests/test_loggerd.py::TestLoggerd::test_not_preserving_unflagged_segments - AssertionError: assert False
FAILED system/loggerd/tests/test_loggerd.py::TestLoggerd::test_preserving_flagged_segments - AssertionError: assert False
FAILED system/loggerd/tests/test_loggerd.py::TestLoggerd::test_qlog - AssertionError: assert False
```

**Verification**

Added `["modelV2"]` to the services array which is passed to `self._publish_random_messages(services)` which guaranteed an error every test run. Removing the decimation (making it None) fixed the error and any subsequent division by zero errors caused by dividing by the decimation value.

Interestingly, despite rebuilding with `scons -c` and `scons --no-cache` after making the fix, the problem persisted until I made a clean install of openpilot, leading me on a wild goose chase as it incorrectly appeared the bug was elsewhere.

Perhaps adding all services to the unit tests instead of a random sampling would be better for the future?