### PR TITLE
replay: handle route not found error with user warning message

### DIFF
--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -73,6 +73,9 @@ bool ReplayStream::loadRoute(const QString &route, const QString &data_dir, uint
     } else if (replay->lastRouteError() == RouteLoadError::NetworkError) {
       QMessageBox::warning(nullptr, tr("Network Error"),
                           tr("Unable to load the route:\n\n %1.\n\nPlease check your network connection and try again.").arg(route));
+    } else if (replay->lastRouteError() == RouteLoadError::FileNotFound) {
+      QMessageBox::warning(nullptr, tr("Route Not Found"),
+                           tr("The specified route could not be found:\n\n %1.\n\nPlease check the route name and try again.").arg(route));
     } else {
       QMessageBox::warning(nullptr, tr("Route Load Failed"), tr("Failed to load route: '%1'").arg(route));
     }

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -39,6 +39,7 @@ RouteIdentifier Route::parseRoute(const QString &str) {
 }
 
 bool Route::load() {
+  err_ = RouteLoadError::None;
   if (route_.str.isEmpty() || (data_dir_.isEmpty() && route_.dongle_id.isEmpty())) {
     rInfo("invalid route format");
     return false;
@@ -75,6 +76,10 @@ bool Route::loadFromServer(int retries) {
     } else if (err == QNetworkReply::ContentAccessDenied || err == QNetworkReply::AuthenticationRequiredError) {
       rWarning(">>  Unauthorized. Authenticate with tools/lib/auth.py  <<");
       err_ = RouteLoadError::AccessDenied;
+      return false;
+    } else if (err == QNetworkReply::ContentNotFoundError) {
+      rWarning("The specified route could not be found on the server.");
+      err_ = RouteLoadError::FileNotFound;
       return false;
     } else {
       err_ = RouteLoadError::NetworkError;


### PR DESCRIPTION
Enhances error handling by displaying an error message and halting retries on 404 error.