### PR TITLE
CI: Added preview links for new-docs

### DIFF
--- a/.github/workflows/new-docs.yaml
+++ b/.github/workflows/new-docs.yaml
@@ -1,0 +1,99 @@
+name: New Docs
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r docs/new/requirements.txt
+
+      - name: Build Docs site
+        run: |
+          source .venv/bin/activate
+          mkdocs build -f docs/new/mkdocs.yml
+
+      - name: Upload built project
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site-build
+          path: docs/new/site
+          retention-days: 1
+
+      - name: Deploy to Cloudflare Pages
+        if: github.ref == 'refs/heads/master'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages publish docs/new/site --project-name=docs-openpilot --branch=master
+
+  preview-docs:
+    needs: build-docs
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Find current PR
+        uses: jwalton/gh-find-current-pr@master
+        id: findPr
+        with:
+          state: open
+
+      - name: Download build artifacts
+        if: success() && steps.findPr.outputs.number
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-site-build
+          path: ./site
+
+      - name: Deploy to Cloudflare Pages
+        if: success() && steps.findPr.outputs.number
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./site --project-name=docs-openpilot --branch=pr-${{ steps.findPr.outputs.number }} --commit-dirty=true
+
+      - name: Comment URL on PR
+        if: success() && steps.findPr.outputs.number
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ steps.findPr.outputs.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**openpilot docs PR preview**
+              https://pr-${{ steps.findPr.outputs.number }}.docs-openpilot.pages.dev
+              <!-- _(run_id **${{ github.run_id }}**)_ -->`
+            })

--- a/docs/new/requirements.txt
+++ b/docs/new/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-terminal


### PR DESCRIPTION
- Doc site is built and deployed on Cloudflare Pages similar to new-connect
- Comments a preview link whenever a PR happens
- `CLOUDFLARE_PAGES_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are required.
- Instead of separating build and preview, I put them together into `new-docs.yaml`  
- As seen below, is an example out. I tested out this [here](https://github.com/ugtthis/openpilot/pull/15) to see how it looks.
- Link to PR Preview: [https://pr-15.docs-openpilot.pages.dev/](https://pr-15.docs-openpilot.pages.dev/)
- First step towards new docs.comma.ai [#32812](https://github.com/commaai/openpilot/issues/32812) 

![pr-link-example](https://github.com/commaai/openpilot/assets/142481257/463152b2-f459-471a-8c95-bb6185f29eb4)
