### PR TITLE
Docs: Content ideas and added section index

### DIFF
--- a/docs/new/docs/car-porting/index.md
+++ b/docs/new/docs/car-porting/index.md
@@ -1,0 +1,3 @@
+# Car Porting
+
+Would be great if this section also included a table with models and links to PR of great car ports done by community.

--- a/docs/new/docs/contributing/contributing-guidelines.md
+++ b/docs/new/docs/contributing/contributing-guidelines.md
@@ -1,0 +1,1 @@
+CONTRIBUTING.md will be put here.

--- a/docs/new/docs/contributing/esv-redirect.md
+++ b/docs/new/docs/contributing/esv-redirect.md
@@ -1,0 +1,3 @@
+# Read this before contributing
+
+[http://www.catb.org/~esr/faqs/smart-questions.html](http://www.catb.org/~esr/faqs/smart-questions.html)

--- a/docs/new/docs/contributing/index.md
+++ b/docs/new/docs/contributing/index.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Would be cool to post successful bounties that were done very well.

--- a/docs/new/docs/getting-started/building-openpilot.md
+++ b/docs/new/docs/getting-started/building-openpilot.md
@@ -1,0 +1,1 @@
+This doc would includes the readme's from [tools](https://github.com/commaai/openpilot/blob/master/tools/README.md) and [dev workflows](https://github.com/commaai/openpilot/blob/master/docs/WORKFLOW.md) plus anything else that is similar.

--- a/docs/new/docs/getting-started/directory-overview.md
+++ b/docs/new/docs/getting-started/directory-overview.md
@@ -1,0 +1,37 @@
+# Directory Overview
+This is a quick reference of all the different folders openpilot has.
+
+```
+.
+├── cereal              # The messaging spec and libs used for all logs
+├── common              # Library like functionality we've developed here
+├── docs                # Documentation
+├── opendbc             # Files showing how to interpret data from cars
+├── panda               # Code used to communicate on CAN
+├── third_party         # External libraries
+└── system              # Generic services
+    ├── camerad         # Driver to capture images from the camera sensors
+    ├── clocksd         # Broadcasts current time
+    ├── hardware        # Hardware abstraction classes
+    ├── logcatd         # systemd journal as a service
+    ├── loggerd         # Logger and uploader of car data
+    ├── proclogd        # Logs information from /proc
+    ├── sensord         # IMU interface code
+    └── ubloxd          # u-blox GNSS module interface code
+└── selfdrive           # Code needed to drive the car
+    ├── assets          # Fonts, images, and sounds for UI
+    ├── athena          # Allows communication with the app
+    ├── boardd          # Daemon to talk to the board
+    ├── car             # Car specific code to read states and control actuators
+    ├── controls        # Planning and controls
+    ├── debug           # Tools to help you debug and do car ports
+    ├── locationd       # Precise localization and vehicle parameter estimation
+    ├── manager         # Daemon that starts/stops all other daemons as needed
+    ├── modeld          # Driving and monitoring model runners
+    ├── monitoring      # Daemon to determine driver attention
+    ├── navd            # Turn-by-turn navigation
+    ├── test            # Unit tests, system tests, and a car simulator
+    └── ui              # The UI
+```
+
+*Found this in Sunny's repo https://github.com/sunnyhaibin/openpilot-1

--- a/docs/new/docs/getting-started/need-more-help.md
+++ b/docs/new/docs/getting-started/need-more-help.md
@@ -1,0 +1,1 @@
+I was thinking about putting something like [https://docs.howtocomma.com/docs/search-before-you-ask](https://docs.howtocomma.com/docs/search-before-you-ask)

--- a/docs/new/docs/how-to/index.md
+++ b/docs/new/docs/how-to/index.md
@@ -7,3 +7,5 @@ Previous ideas from Github comment:
 - how to replay a route
 - how to debug a process crash
 - how to live stream the cameras to your PC
+
+- how to feedback [https://github.com/commaai/openpilot/pull/32752](https://github.com/commaai/openpilot/pull/32752)

--- a/docs/new/docs/how-to/index.md
+++ b/docs/new/docs/how-to/index.md
@@ -1,3 +1,9 @@
 # How to
 
 This section will include common things devs may want to do.
+
+Previous ideas from Github comment:
+
+- how to replay a route
+- how to debug a process crash
+- how to live stream the cameras to your PC

--- a/docs/new/docs/how-to/index.md
+++ b/docs/new/docs/how-to/index.md
@@ -1,0 +1,3 @@
+# How to
+
+This section will include common things devs may want to do.

--- a/docs/new/docs/how-to/turning-the-speed-blue.md
+++ b/docs/new/docs/how-to/turning-the-speed-blue.md
@@ -1,4 +1,2 @@
-This section is for how-to's on common workflows.
-
 They'll be like this blog post we wrote:
 https://blog.comma.ai/turning-the-speed-blue/

--- a/docs/new/docs/index.md
+++ b/docs/new/docs/index.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+Would be cool to add in this section *How openpilot works in 2024* similar to this blog post. [https://blog.comma.ai/openpilot-in-2021/](https://blog.comma.ai/openpilot-in-2021/)

--- a/docs/new/docs/index.md
+++ b/docs/new/docs/index.md
@@ -1,3 +1,6 @@
 # Getting Started
 
-Would be cool to add in this section *How openpilot works in 2024* similar to this blog post. [https://blog.comma.ai/openpilot-in-2021/](https://blog.comma.ai/openpilot-in-2021/)
+Would be cool to add in this section:
+
+- *How openpilot works in 2024* similar to this blog post. [https://blog.comma.ai/openpilot-in-2021/](https://blog.comma.ai/openpilot-in-2021/)
+- A post similar to this [https://github.com/commaai/openpilot/wiki/Introduction-to-openpilot](https://github.com/commaai/openpilot/wiki/Introduction-to-openpilot)

--- a/docs/new/docs/reference/LIMITATIONS.md
+++ b/docs/new/docs/reference/LIMITATIONS.md
@@ -1,0 +1,58 @@
+# Limitations
+## Limitations of openpilot ALC and LDW
+
+openpilot ALC and openpilot LDW do not automatically drive the vehicle or reduce the amount of attention that must be paid to operate your vehicle. The driver must always keep control of the steering wheel and be ready to correct the openpilot ALC action at all times.
+
+While changing lanes, openpilot is not capable of looking next to you or checking your blind spot. Only nudge the wheel to initiate a lane change after you have confirmed it's safe to do so.
+
+Many factors can impact the performance of openpilot ALC and openpilot LDW, causing them to be unable to function as intended. These include, but are not limited to:
+
+* Poor visibility (heavy rain, snow, fog, etc.) or weather conditions that may interfere with sensor operation.
+* The road facing camera is obstructed, covered or damaged by mud, ice, snow, etc.
+* Obstruction caused by applying excessive paint or adhesive products (such as wraps, stickers, rubber coating, etc.) onto the vehicle.
+* The device is mounted incorrectly.
+* When in sharp curves, like on-off ramps, intersections etc...; openpilot is designed to be limited in the amount of steering torque it can produce.
+* In the presence of restricted lanes or construction zones.
+* When driving on highly banked roads or in presence of strong cross-wind.
+* Extremely hot or cold temperatures.
+* Bright light (due to oncoming headlights, direct sunlight, etc.).
+* Driving on hills, narrow, or winding roads.
+
+The list above does not represent an exhaustive list of situations that may interfere with proper operation of openpilot components. It is the driver's responsibility to be in control of the vehicle at all times.
+
+## Limitations of openpilot ACC and FCW
+
+openpilot ACC and openpilot FCW are not systems that allow careless or inattentive driving. It is still necessary for the driver to pay close attention to the vehicle’s surroundings and to be ready to re-take control of the gas and the brake at all times.
+
+Many factors can impact the performance of openpilot ACC and openpilot FCW, causing them to be unable to function as intended. These include, but are not limited to:
+
+* Poor visibility (heavy rain, snow, fog, etc.) or weather conditions that may interfere with sensor operation.
+* The road facing camera or radar are obstructed, covered, or damaged by mud, ice, snow, etc.
+* Obstruction caused by applying excessive paint or adhesive products (such as wraps, stickers, rubber coating, etc.) onto the vehicle.
+* The device is mounted incorrectly.
+* Approaching a toll booth, a bridge or a large metal plate.
+* When driving on roads with pedestrians, cyclists, etc...
+* In presence of traffic signs or stop lights, which are not detected by openpilot at this time.
+* When the posted speed limit is below the user selected set speed. openpilot does not detect speed limits at this time.
+* In presence of vehicles in the same lane that are not moving.
+* When abrupt braking maneuvers are required. openpilot is designed to be limited in the amount of deceleration and acceleration that it can produce.
+* When surrounding vehicles perform close cut-ins from neighbor lanes.
+* Driving on hills, narrow, or winding roads.
+* Extremely hot or cold temperatures.
+* Bright light (due to oncoming headlights, direct sunlight, etc.).
+* Interference from other equipment that generates radar waves.
+
+The list above does not represent an exhaustive list of situations that may interfere with proper operation of openpilot components. It is the driver's responsibility to be in control of the vehicle at all times.
+
+## Limitations of openpilot DM
+
+openpilot DM should not be considered an exact measurement of the alertness of the driver.
+
+Many factors can impact the performance of openpilot DM, causing it to be unable to function as intended. These include, but are not limited to:
+
+* Low light conditions, such as driving at night or in dark tunnels.
+* Bright light (due to oncoming headlights, direct sunlight, etc.).
+* The driver's face is partially or completely outside field of view of the driver facing camera.
+* The driver facing camera is obstructed, covered, or damaged.
+
+The list above does not represent an exhaustive list of situations that may interfere with proper operation of openpilot components. A driver should not rely on openpilot DM to assess their level of attention.

--- a/docs/new/docs/reference/SAFETY.md
+++ b/docs/new/docs/reference/SAFETY.md
@@ -1,0 +1,36 @@
+# Safety
+
+openpilot is an Adaptive Cruise Control (ACC) and Automated Lane Centering (ALC) system.
+Like other ACC and ALC systems, openpilot is a failsafe passive system and it requires the
+driver to be alert and to pay attention at all times.
+
+In order to enforce driver alertness, openpilot includes a driver monitoring feature
+that alerts the driver when distracted.
+
+However, even with an attentive driver, we must make further efforts for the system to be
+safe. We repeat, **driver alertness is necessary, but not sufficient, for openpilot to be
+used safely** and openpilot is provided with no warranty of fitness for any purpose.
+
+openpilot is developed in good faith to be compliant with FMVSS requirements and to follow
+industry standards of safety for Level 2 Driver Assistance Systems. In particular, we observe
+ISO26262 guidelines, including those from [pertinent documents](https://www.nhtsa.gov/sites/nhtsa.dot.gov/files/documents/13498a_812_573_alcsystemreport.pdf)
+released by NHTSA. In addition, we impose strict coding guidelines (like [MISRA C : 2012](https://www.misra.org.uk/what-is-misra/))
+on parts of openpilot that are safety relevant. We also perform software-in-the-loop,
+hardware-in-the-loop and in-vehicle tests before each software release.
+
+Following Hazard and Risk Analysis and FMEA, at a very high level, we have designed openpilot
+ensuring two main safety requirements.
+
+1. The driver must always be capable to immediately retake manual control of the vehicle,
+   by stepping on the brake pedal or by pressing the cancel button.
+2. The vehicle must not alter its trajectory too quickly for the driver to safely
+   react. This means that while the system is engaged, the actuators are constrained
+   to operate within reasonable limits[^1]. 
+
+For additional safety implementation details, refer to [panda safety model](https://github.com/commaai/panda#safety-model). For vehicle specific implementation of the safety concept, refer to [panda/board/safety/](https://github.com/commaai/panda/tree/master/board/safety).
+
+**Extra note**: comma.ai strongly discourages the use of openpilot forks with safety code either missing or
+  not fully meeting the above requirements.
+
+[^1]: For these actuator limits we observe ISO11270 and ISO15622. Lateral limits described there translate to 0.9 seconds of maximum actuation to achieve a 1m lateral deviation. 
+

--- a/docs/new/docs/reference/about-comma.md
+++ b/docs/new/docs/reference/about-comma.md
@@ -1,0 +1,3 @@
+# About comma
+
+Would be cool to add a timeline of commas history. Nothing to complex, just the year and a TLDR of what happened that was a meaningnful event both good and bad.

--- a/docs/new/docs/reference/index.md
+++ b/docs/new/docs/reference/index.md
@@ -1,0 +1,3 @@
+# Reference
+
+This section would have things that aren't essential to being able to start developing with openpilot.

--- a/docs/new/docs/reference/index.md
+++ b/docs/new/docs/reference/index.md
@@ -1,3 +1,8 @@
 # Reference
 
 This section would have things that aren't essential to being able to start developing with openpilot.
+
+Maybe we can add:
+
+- Up to date specs on comma3x hardware. Lightning hard versus old circuit board.
+- How comma 3x is made. It's essentially just what Adeeb walked through during the "Touring comma HQ..." livestream but in a blog post format with pictures of each station and the parts that come out of it.

--- a/docs/new/docs/reference/supported-cars.md
+++ b/docs/new/docs/reference/supported-cars.md
@@ -1,0 +1,1 @@
+This will show content simlair to - [https://github.com/commaai/openpilot/blob/master/docs/CARS.md](https://github.com/commaai/openpilot/blob/master/docs/CARS.md)

--- a/docs/new/docs/submodules/cereal.md
+++ b/docs/new/docs/submodules/cereal.md
@@ -1,0 +1,51 @@
+# What is cereal?
+
+cereal is the messaging system for openpilot. It uses [msgq](https://github.com/commaai/msgq) as a pub/sub backend, and [Cap'n proto](https://capnproto.org/capnp-tool.html) for serialization of the structs.
+
+
+## Messaging Spec
+
+You'll find the message types in [log.capnp](log.capnp). It uses [Cap'n proto](https://capnproto.org/capnp-tool.html) and defines one struct called `Event`.
+
+All `Events` have a `logMonoTime` and a `valid`. Then a big union defines the packet type.
+
+### Best Practices
+
+- **All fields must describe quantities in SI units**, unless otherwise specified in the field name.
+- In the context of the message they are in, field names should be completely unambiguous.
+- All values should be easy to plot and be human-readable with minimal parsing.
+
+### Maintaining backwards-compatibility
+
+When making changes to the messaging spec you want to maintain backwards-compatibility, such that old logs can
+be parsed with a new version of cereal. Adding structs and adding members to structs is generally safe, most other
+things are not. Read more details [here](https://capnproto.org/language.html).
+
+### Custom forks
+
+Forks of [openpilot](https://github.com/commaai/openpilot) might want to add things to the messaging
+spec, however this could conflict with future changes made in mainline cereal/openpilot. Rebasing against mainline openpilot
+then means breaking backwards-compatibility with all old logs of your fork. So we added reserved events in
+[custom.capnp](custom.capnp) that we will leave empty in mainline cereal/openpilot. **If you only modify those, you can ensure your
+fork will remain backwards-compatible with all versions of mainline openpilot and your fork.**
+
+Example
+---
+```python
+import cereal.messaging as messaging
+
+# in subscriber
+sm = messaging.SubMaster(['sensorEvents'])
+while 1:
+  sm.update()
+  print(sm['sensorEvents'])
+
+```
+
+```python
+# in publisher
+pm = messaging.PubMaster(['sensorEvents'])
+dat = messaging.new_message('sensorEvents', size=1)
+dat.sensorEvents[0] = {"gyro": {"v": [0.1, -0.1, 0.1]}}
+pm.send('sensorEvents', dat)
+```

--- a/docs/new/docs/submodules/index.md
+++ b/docs/new/docs/submodules/index.md
@@ -1,0 +1,3 @@
+# Submodules
+
+This section talks about how the submodules connect and their role in openpilot.

--- a/docs/new/docs/submodules/opendbc.md
+++ b/docs/new/docs/submodules/opendbc.md
@@ -1,0 +1,49 @@
+## DBC file basics
+
+A DBC file encodes, in a humanly readable way, the information needed to understand a vehicle's CAN bus traffic. A vehicle might have multiple CAN buses and every CAN bus is represented by its own dbc file.
+Wondering what's the DBC file format? [Here](http://www.socialledge.com/sjsu/index.php?title=DBC_Format) and [Here](https://github.com/stefanhoelzl/CANpy/blob/master/docs/DBC_Specification.md) a couple of good overviews.
+
+## How to start reverse engineering cars
+
+[opendbc](https://github.com/commaai/opendbc) is integrated with [cabana](https://github.com/commaai/openpilot/tree/master/tools/cabana).
+
+Use [panda](https://github.com/commaai/panda) to connect your car to a computer.
+
+## How to use reverse engineered DBC
+To create custom CAN simulations or send reverse engineered signals back to the car you can use [CANdevStudio](https://github.com/GENIVI/CANdevStudio) project.
+
+## DBC file preprocessor
+
+DBC files for different models of the same brand have a lot of overlap. Therefore, we wrote a preprocessor to create DBC files from a brand DBC file and a model specific DBC file. The source DBC files can be found in the generator folder. After changing one of the files run the generator.py script to regenerate the output files. These output files will be placed in the root of the opendbc repository and are suffixed by _generated.
+
+## Good practices for contributing to opendbc
+
+- Comments: the best way to store comments is to add them directly to the DBC files. For example:
+    ```
+    CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
+    ```
+    is a comment that refers to signal `LONG_ACCEL` in message `490`. Using comments is highly recommended, especially for doubts and uncertainties. [cabana](https://community.comma.ai/cabana/) can easily display/add/edit comments to signals and messages.
+
+- Units: when applicable, it's recommended to convert signals into physical units, by using a proper signal factor. Using a SI unit is preferred, unless a non-SI unit rounds the signal factor much better.
+For example:
+    ```
+    SG_ VEHICLE_SPEED : 7|15@0+ (0.00278,0) [0|70] "m/s" PCM
+    ```
+    is better than:
+    ```
+    SG_ VEHICLE_SPEED : 7|15@0+ (0.00620,0) [0|115] "mph" PCM
+    ```
+    However, the cleanest option is really:
+    ```
+    SG_ VEHICLE_SPEED : 7|15@0+ (0.01,0) [0|250] "kph" PCM
+    ```
+
+- Signal size: always use the smallest amount of bits possible. For example, let's say I'm reverse engineering the gas pedal position and I've determined that it's in a 3 bytes message. For 0% pedal position I read a message value of `0x00 0x00 0x00`, while for 100% of pedal position I read `0x64 0x00 0x00`: clearly, the gas pedal position is within the first byte of the message and I might be tempted to define the signal `GAS_POS` as:
+    ```
+    SG_ GAS_POS : 7|8@0+ (1,0) [0|100] "%" PCM
+    ```
+    However, I can't be sure that the very first bit of the message is referred to the pedal position: I haven't seen it changing! Therefore, a safer way of defining the signal is:
+    ```
+    SG_ GAS_POS : 6|7@0+ (1,0) [0|100] "%" PCM
+    ```
+    which leaves the first bit unallocated. This prevents from very erroneous reading of the gas pedal position, in case the first bit is indeed used for something else.

--- a/docs/new/docs/submodules/panda.md
+++ b/docs/new/docs/submodules/panda.md
@@ -1,0 +1,105 @@
+# Welcome to panda
+
+![panda tests](https://github.com/commaai/panda/workflows/tests/badge.svg)
+![panda drivers](https://github.com/commaai/panda/workflows/drivers/badge.svg)
+
+panda speaks CAN and CAN FD, and it runs on [STM32F413](https://www.st.com/resource/en/reference_manual/rm0430-stm32f413423-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) and [STM32H725](https://www.st.com/resource/en/reference_manual/rm0468-stm32h723733-stm32h725735-and-stm32h730-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf).
+
+## Directory structure
+
+```
+.
+├── board           # Code that runs on the STM32
+├── drivers         # Drivers (not needed for use with Python)
+├── python          # Python userspace library for interfacing with the panda
+├── tests           # Tests and helper programs for panda
+```
+
+## Safety Model
+
+When a panda powers up, by default it's in `SAFETY_SILENT` mode. While in `SAFETY_SILENT` mode, the CAN buses are forced to be silent. In order to send messages, you have to select a safety mode. Some of safety modes (for example `SAFETY_ALLOUTPUT`) are disabled in release firmwares. In order to use them, compile and flash your own build.
+
+Safety modes optionally support `controls_allowed`, which allows or blocks a subset of messages based on a customizable state in the board.
+
+## Code Rigor
+
+The panda firmware is written for its use in conjunction with [openpilot](https://github.com/commaai/openpilot). The panda firmware, through its safety model, provides and enforces the
+[openpilot safety](https://github.com/commaai/openpilot/blob/master/docs/SAFETY.md). Due to its critical function, it's important that the application code rigor within the `board` folder is held to high standards.
+
+These are the [CI regression tests](https://github.com/commaai/panda/actions) we have in place:
+* A generic static code analysis is performed by [cppcheck](https://github.com/danmar/cppcheck/).
+* In addition, [cppcheck](https://github.com/danmar/cppcheck/) has a specific addon to check for [MISRA C:2012](https://misra.org.uk/) violations. See [current coverage](https://github.com/commaai/panda/blob/master/tests/misra/coverage_table).
+* Compiler options are relatively strict: the flags `-Wall -Wextra -Wstrict-prototypes -Werror` are enforced.
+* The [safety logic](https://github.com/commaai/panda/tree/master/board/safety) is tested and verified by [unit tests](https://github.com/commaai/panda/tree/master/tests/safety) for each supported car variant.
+to ensure that the behavior remains unchanged.
+* A hardware-in-the-loop test verifies panda's functionalities on all active panda variants, including:
+  * additional safety model checks
+  * compiling and flashing the bootstub and app code
+  * receiving, sending, and forwarding CAN messages on all buses
+  * CAN loopback and latency tests through USB and SPI
+
+The above tests are themselves tested by:
+* a [mutation test](tests/misra/test_mutation.py) on the MISRA coverage
+* 100% line coverage enforced on the safety unit tests
+
+In addition, we run the [ruff linter](https://github.com/astral-sh/ruff) and [mypy](https://mypy-lang.org/) on panda's Python library.
+
+## Usage
+
+Setup dependencies:
+```bash
+# Ubuntu
+sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip libffi-dev git
+
+# macOS
+brew install --cask gcc-arm-embedded
+brew install python3 dfu-util gcc@13
+```
+
+Clone panda repository and install:
+``` bash
+git clone https://github.com/commaai/panda.git
+cd panda
+
+# install dependencies
+pip install -r requirements.txt
+
+# install panda
+python setup.py install
+```
+
+See [the Panda class](https://github.com/commaai/panda/blob/master/python/__init__.py) for how to interact with the panda.
+
+For example, to receive CAN messages:
+``` python
+>>> from panda import Panda
+>>> panda = Panda()
+>>> panda.can_recv()
+```
+And to send one on bus 0:
+``` python
+>>> panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+>>> panda.can_send(0x1aa, b'message', 0)
+```
+Note that you may have to setup [udev rules](https://github.com/commaai/panda/tree/master/drivers/linux) for Linux, such as
+``` bash
+sudo tee /etc/udev/rules.d/11-panda.rules <<EOF
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcc", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
+EOF
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+The panda jungle uses different udev rules. See [the repo](https://github.com/commaai/panda_jungle#udev-rules) for instructions.
+
+## Software interface support
+
+As a universal car interface, it should support every reasonable software interface.
+
+- [Python library](https://github.com/commaai/panda/tree/master/python)
+- [C++ library](https://github.com/commaai/openpilot/tree/master/selfdrive/boardd)
+- [socketcan in kernel](https://github.com/commaai/panda/tree/master/drivers/linux) (alpha)
+
+## Licensing
+
+panda software is released under the MIT license unless otherwise specified.

--- a/docs/new/docs/submodules/rednose.md
+++ b/docs/new/docs/submodules/rednose.md
@@ -1,0 +1,1 @@
+Insert rednose content here.

--- a/docs/new/docs/tools/cabana.md
+++ b/docs/new/docs/tools/cabana.md
@@ -1,0 +1,1 @@
+Insert content here.

--- a/docs/new/docs/tools/index.md
+++ b/docs/new/docs/tools/index.md
@@ -1,0 +1,3 @@
+# Tools
+
+This section will include all tools that people use with openpilot, like replay, cabana, rerun, etc.

--- a/docs/new/docs/tools/plotjuggler.md
+++ b/docs/new/docs/tools/plotjuggler.md
@@ -1,0 +1,1 @@
+Insert content here.

--- a/docs/new/docs/tools/ssh.md
+++ b/docs/new/docs/tools/ssh.md
@@ -1,0 +1,1 @@
+Insert content here.

--- a/docs/new/mkdocs.yml
+++ b/docs/new/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - Guidelines: contributing/contributing-guidelines.md
   - Reference:
     - Index: reference/index.md
+    - Supported cars : reference/supported-cars.md
     - About comma : reference/about-comma.md
     - Limitations : reference/LIMITATIONS.md
     - Safety : reference/SAFETY.md

--- a/docs/new/mkdocs.yml
+++ b/docs/new/mkdocs.yml
@@ -18,17 +18,17 @@ nav:
   - How-to:
     - Index: how-to/index.md
     - Turn the speed blue: how-to/turning-the-speed-blue.md
-  - Car Porting:
-    - Index: car-porting/index.md
-    - What is a car port?: car-porting/what-is-a-car-port.md
-    - Porting a car brand: car-porting/brand-port.md
-    - Porting a car model: car-porting/model-port.md
   - Submodules:
     - Index: submodules/index.md
     - cereal : submodules/cereal.md
     - opendbc : submodules/opendbc.md
     - panda : submodules/panda.md
     - rednose : submodules/rednose.md
+  - Car Porting:
+    - Index: car-porting/index.md
+    - What is a car port?: car-porting/what-is-a-car-port.md
+    - Porting a car brand: car-porting/brand-port.md
+    - Porting a car model: car-porting/model-port.md
   - Tools:
     - Index: tools/index.md
     - Cabana : tools/cabana.md

--- a/docs/new/mkdocs.yml
+++ b/docs/new/mkdocs.yml
@@ -6,13 +6,40 @@ theme:
   name: terminal
   features:
     - navigation.side.toc.hide
+    - navigation.side.indexes # Allows for the section header to have a document
 
 nav:
   - Getting Started:
+    - Index: index.md # Also acts as the first page users will see
     - What is openpilot?: getting-started/what-is-openpilot.md
+    - Directory Overview: getting-started/directory-overview.md
+    - Building openpilot: getting-started/building-openpilot.md
+    - Need more help?: getting-started/need-more-help.md
   - How-to:
+    - Index: how-to/index.md
     - Turn the speed blue: how-to/turning-the-speed-blue.md
   - Car Porting:
+    - Index: car-porting/index.md
     - What is a car port?: car-porting/what-is-a-car-port.md
     - Porting a car brand: car-porting/brand-port.md
     - Porting a car model: car-porting/model-port.md
+  - Submodules:
+    - Index: submodules/index.md
+    - cereal : submodules/cereal.md
+    - opendbc : submodules/opendbc.md
+    - panda : submodules/panda.md
+    - rednose : submodules/rednose.md
+  - Tools:
+    - Index: tools/index.md
+    - Cabana : tools/cabana.md
+    - PlotJuggler : tools/plotjuggler.md
+    - SSH : tools/ssh.md
+  - Contributing :
+    - Index: contributing/index.md
+    - How to ask questions: contributing/esv-redirect.md
+    - Guidelines: contributing/contributing-guidelines.md
+  - Reference:
+    - Index: reference/index.md
+    - About comma : reference/about-comma.md
+    - Limitations : reference/LIMITATIONS.md
+    - Safety : reference/SAFETY.md


### PR DESCRIPTION
- General structure with content ideas
- Ability to have an overview document of what each section is about(section example = Getting Started, How to, Car Porting,etc). This overview document is `index.md` in respective folders.
- No changes to overall theme
- In regards to #32812 