### PR TITLE
CarParams: set no traversal limit

### DIFF
--- a/cereal/messaging/__init__.py
+++ b/cereal/messaging/__init__.py
@@ -17,8 +17,8 @@ from cereal.services import SERVICE_LIST
 NO_TRAVERSAL_LIMIT = 2**64-1
 
 
-def log_from_bytes(dat: bytes) -> capnp.lib.capnp._DynamicStructReader:
-  with log.Event.from_bytes(dat, traversal_limit_in_words=NO_TRAVERSAL_LIMIT) as msg:
+def log_from_bytes(dat: bytes, struct: capnp.lib.capnp._StructModule = log.Event) -> capnp.lib.capnp._DynamicStructReader:
+  with struct.from_bytes(dat, traversal_limit_in_words=NO_TRAVERSAL_LIMIT) as msg:
     return msg
 
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -217,3 +217,7 @@ def get_demo_car_params():
   CarInterface, _, _ = interfaces[platform]
   CP = CarInterface.get_non_essential_params(platform)
   return CP
+
+def blocking_get_car_params(params):
+  with car.CarParams.from_bytes(params.get("CarParams", block=True), traversal_limit_in_words=messaging.NO_TRAVERSAL_LIMIT) as car_params:
+    return car_params

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -217,7 +217,3 @@ def get_demo_car_params():
   CarInterface, _, _ = interfaces[platform]
   CP = CarInterface.get_non_essential_params(platform)
   return CP
-
-def blocking_get_car_params(params):
-  with car.CarParams.from_bytes(params.get("CarParams", block=True), traversal_limit_in_words=messaging.NO_TRAVERSAL_LIMIT) as car_params:
-    return car_params

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -18,7 +18,7 @@ from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper, DT_CTRL
 from openpilot.common.swaglog import cloudlog
 
-from openpilot.selfdrive.car.car_helpers import get_car_interface, get_startup_event
+from openpilot.selfdrive.car.car_helpers import get_car_interface, blocking_get_car_params, get_startup_event
 from openpilot.selfdrive.controls.lib.alertmanager import AlertManager, set_offroad_alert
 from openpilot.selfdrive.controls.lib.drive_helpers import VCruiseHelper, clip_curvature
 from openpilot.selfdrive.controls.lib.events import Events, ET
@@ -64,8 +64,7 @@ class Controls:
 
     if CI is None:
       cloudlog.info("controlsd is waiting for CarParams")
-      with car.CarParams.from_bytes(self.params.get("CarParams", block=True)) as msg:
-        self.CP = msg
+      self.CP = blocking_get_car_params(self.params)
       cloudlog.info("controlsd got CarParams")
 
       # Uses car interface helper functions, altering state won't be considered by card for actuation

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -18,7 +18,7 @@ from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper, DT_CTRL
 from openpilot.common.swaglog import cloudlog
 
-from openpilot.selfdrive.car.car_helpers import get_car_interface, blocking_get_car_params, get_startup_event
+from openpilot.selfdrive.car.car_helpers import get_car_interface, get_startup_event
 from openpilot.selfdrive.controls.lib.alertmanager import AlertManager, set_offroad_alert
 from openpilot.selfdrive.controls.lib.drive_helpers import VCruiseHelper, clip_curvature
 from openpilot.selfdrive.controls.lib.events import Events, ET
@@ -64,7 +64,7 @@ class Controls:
 
     if CI is None:
       cloudlog.info("controlsd is waiting for CarParams")
-      self.CP = blocking_get_car_params(self.params)
+      self.CP = messaging.log_from_bytes(self.params.get("CarParams", block=True), car.CarParams)
       cloudlog.info("controlsd got CarParams")
 
       # Uses car interface helper functions, altering state won't be considered by card for actuation

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from cereal import car
 from openpilot.common.params import Params
 from openpilot.common.realtime import Priority, config_realtime_process
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 from openpilot.selfdrive.controls.lib.longitudinal_planner import LongitudinalPlanner
 import cereal.messaging as messaging
 
@@ -12,8 +12,7 @@ def plannerd_thread():
 
   cloudlog.info("plannerd is waiting for CarParams")
   params = Params()
-  with car.CarParams.from_bytes(params.get("CarParams", block=True)) as msg:
-    CP = msg
+  CP = blocking_get_car_params(params)
   cloudlog.info("plannerd got CarParams: %s", CP.carName)
 
   longitudinal_planner = LongitudinalPlanner(CP)

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
+from cereal import car
 from openpilot.common.params import Params
 from openpilot.common.realtime import Priority, config_realtime_process
 from openpilot.common.swaglog import cloudlog
-from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 from openpilot.selfdrive.controls.lib.longitudinal_planner import LongitudinalPlanner
 import cereal.messaging as messaging
 
@@ -12,7 +12,7 @@ def plannerd_thread():
 
   cloudlog.info("plannerd is waiting for CarParams")
   params = Params()
-  CP = blocking_get_car_params(params)
+  CP = messaging.log_from_bytes(params.get("CarParams", block=True), car.CarParams)
   cloudlog.info("plannerd got CarParams: %s", CP.carName)
 
   longitudinal_planner = LongitudinalPlanner(CP)

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -5,14 +5,14 @@ from collections import deque
 from typing import Any
 
 import capnp
-from cereal import messaging, log, car
+from cereal import messaging, log
 from openpilot.common.numpy_fast import interp
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_CTRL, Ratekeeper, Priority, config_realtime_process
 from openpilot.common.swaglog import cloudlog
 
 from openpilot.common.simple_kalman import KF1D
-
+from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 
 # Default lead acceleration decay set to 50% at 1s
 _LEAD_ACCEL_TAU = 1.5
@@ -288,8 +288,7 @@ def main():
 
   # wait for stats about the car to come in from controls
   cloudlog.info("radard is waiting for CarParams")
-  with car.CarParams.from_bytes(Params().get("CarParams", block=True)) as msg:
-    CP = msg
+  CP = blocking_get_car_params(Params())
   cloudlog.info("radard got CarParams")
 
   # import the radar from the fingerprint

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -5,14 +5,13 @@ from collections import deque
 from typing import Any
 
 import capnp
-from cereal import messaging, log
+from cereal import messaging, log, car
 from openpilot.common.numpy_fast import interp
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_CTRL, Ratekeeper, Priority, config_realtime_process
 from openpilot.common.swaglog import cloudlog
 
 from openpilot.common.simple_kalman import KF1D
-from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 
 # Default lead acceleration decay set to 50% at 1s
 _LEAD_ACCEL_TAU = 1.5
@@ -288,7 +287,7 @@ def main():
 
   # wait for stats about the car to come in from controls
   cloudlog.info("radard is waiting for CarParams")
-  CP = blocking_get_car_params(Params())
+  CP = messaging.log_from_bytes(Params().get("CarParams", block=True), car.CarParams)
   cloudlog.info("radard got CarParams")
 
   # import the radar from the fingerprint

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -13,6 +13,7 @@ from openpilot.common.swaglog import cloudlog
 
 from openpilot.common.simple_kalman import KF1D
 
+
 # Default lead acceleration decay set to 50% at 1s
 _LEAD_ACCEL_TAU = 1.5
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -5,11 +5,11 @@ import json
 import numpy as np
 
 import cereal.messaging as messaging
-from cereal import car
 from cereal import log
 from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process, DT_MDL
 from openpilot.common.numpy_fast import clip
+from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 from openpilot.selfdrive.locationd.models.car_kf import CarKalman, ObservationKind, States
 from openpilot.selfdrive.locationd.models.constants import GENERATED_DIR
 from openpilot.common.swaglog import cloudlog
@@ -129,8 +129,7 @@ def main():
   params_reader = Params()
   # wait for stats about the car to come in from controls
   cloudlog.info("paramsd is waiting for CarParams")
-  with car.CarParams.from_bytes(params_reader.get("CarParams", block=True)) as msg:
-    CP = msg
+  CP = blocking_get_car_params(params_reader)
   cloudlog.info("paramsd got CarParams")
 
   min_sr, max_sr = 0.5 * CP.steerRatio, 2.0 * CP.steerRatio

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -5,11 +5,10 @@ import json
 import numpy as np
 
 import cereal.messaging as messaging
-from cereal import log
+from cereal import car, log
 from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process, DT_MDL
 from openpilot.common.numpy_fast import clip
-from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 from openpilot.selfdrive.locationd.models.car_kf import CarKalman, ObservationKind, States
 from openpilot.selfdrive.locationd.models.constants import GENERATED_DIR
 from openpilot.common.swaglog import cloudlog
@@ -129,7 +128,7 @@ def main():
   params_reader = Params()
   # wait for stats about the car to come in from controls
   cloudlog.info("paramsd is waiting for CarParams")
-  CP = blocking_get_car_params(params_reader)
+  CP = messaging.log_from_bytes(params_reader.get("CarParams", block=True), car.CarParams)
   cloudlog.info("paramsd got CarParams")
 
   min_sr, max_sr = 0.5 * CP.steerRatio, 2.0 * CP.steerRatio

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -8,7 +8,6 @@ from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process, DT_MDL
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.swaglog import cloudlog
-from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 from openpilot.selfdrive.controls.lib.vehicle_model import ACCELERATION_DUE_TO_GRAVITY
 from openpilot.selfdrive.locationd.helpers import PointBuckets, ParameterEstimator
 
@@ -224,7 +223,7 @@ def main(demo=False):
   sm = messaging.SubMaster(['carControl', 'carOutput', 'carState', 'liveLocationKalman'], poll='liveLocationKalman')
 
   params = Params()
-  estimator = TorqueEstimator(blocking_get_car_params(params))
+  estimator = TorqueEstimator(messaging.log_from_bytes(params.get("CarParams", block=True), car.CarParams))
 
   while True:
     sm.update()

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -8,6 +8,7 @@ from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process, DT_MDL
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.car.car_helpers import blocking_get_car_params
 from openpilot.selfdrive.controls.lib.vehicle_model import ACCELERATION_DUE_TO_GRAVITY
 from openpilot.selfdrive.locationd.helpers import PointBuckets, ParameterEstimator
 
@@ -223,8 +224,7 @@ def main(demo=False):
   sm = messaging.SubMaster(['carControl', 'carOutput', 'carState', 'liveLocationKalman'], poll='liveLocationKalman')
 
   params = Params()
-  with car.CarParams.from_bytes(params.get("CarParams", block=True)) as CP:
-    estimator = TorqueEstimator(CP)
+  estimator = TorqueEstimator(blocking_get_car_params(params))
 
   while True:
     sm.update()

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -4,7 +4,7 @@ import time
 import pickle
 import numpy as np
 import cereal.messaging as messaging
-from cereal import car, log
+from cereal import log
 from pathlib import Path
 from openpilot.common.threadname import setthreadname
 from cereal.messaging import PubMaster, SubMaster
@@ -16,7 +16,7 @@ from openpilot.common.realtime import config_realtime_process
 from openpilot.common.transformations.camera import DEVICE_CAMERAS
 from openpilot.common.transformations.model import get_warp_matrix
 from openpilot.system import sentry
-from openpilot.selfdrive.car.car_helpers import get_demo_car_params
+from openpilot.selfdrive.car.car_helpers import get_demo_car_params, blocking_get_car_params
 from openpilot.selfdrive.controls.lib.desire_helper import DesireHelper
 from openpilot.selfdrive.modeld.runners import ModelRunner, Runtime
 from openpilot.selfdrive.modeld.parse_model_outputs import Parser
@@ -172,8 +172,8 @@ def main(demo=False):
   if demo:
     CP = get_demo_car_params()
   else:
-    with car.CarParams.from_bytes(params.get("CarParams", block=True)) as msg:
-      CP = msg
+    CP = blocking_get_car_params(params)
+
   cloudlog.info("modeld got CarParams: %s", CP.carName)
 
   # TODO this needs more thought, use .2s extra for now to estimate other delays

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -4,7 +4,7 @@ import time
 import pickle
 import numpy as np
 import cereal.messaging as messaging
-from cereal import log
+from cereal import car, log
 from pathlib import Path
 from openpilot.common.threadname import setthreadname
 from cereal.messaging import PubMaster, SubMaster
@@ -16,7 +16,7 @@ from openpilot.common.realtime import config_realtime_process
 from openpilot.common.transformations.camera import DEVICE_CAMERAS
 from openpilot.common.transformations.model import get_warp_matrix
 from openpilot.system import sentry
-from openpilot.selfdrive.car.car_helpers import get_demo_car_params, blocking_get_car_params
+from openpilot.selfdrive.car.car_helpers import get_demo_car_params
 from openpilot.selfdrive.controls.lib.desire_helper import DesireHelper
 from openpilot.selfdrive.modeld.runners import ModelRunner, Runtime
 from openpilot.selfdrive.modeld.parse_model_outputs import Parser
@@ -172,7 +172,7 @@ def main(demo=False):
   if demo:
     CP = get_demo_car_params()
   else:
-    CP = blocking_get_car_params(params)
+    CP = messaging.log_from_bytes(params.get("CarParams", block=True), car.CarParams)
 
   cloudlog.info("modeld got CarParams: %s", CP.carName)
 


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/32928

The car.Params object acts as a Cap'n Proto reader used to repeatedly access car parameters. However, during prolonged execution, it will encounters the default `traversalLimitInWords`(8MB) limitation, leading to crashes with an "Exceeded message traversal limit" error.

This PR introduces `blocking_get_car_params` function, which resolves this issue by setting `traversal_limit_in_words` to `NO_TRAVERSAL_LIMIT` in the Cap'n Proto reader. This change ensures uninterrupted access to car.Params during message deserialization.
