### PR TITLE
hardwared: don't ignore quick ignition cycles

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -483,6 +483,20 @@ CONFIGS = [
     processing_time=0.004,
   ),
   ProcessConfig(
+    proc_name="hardwared",
+    pubs=[
+      "peripheralState", "gpsLocationExternal", "controlsState", "pandaStates",
+    ],
+    subs=["deviceState"],
+    ignore=["logMonoTime"],
+    # config_callback=controlsd_config_callback,
+    # init_callback=get_car_params_callback,
+    # should_recv_callback=controlsd_rcv_callback,
+    should_recv_callback=MessageBasedRcvCallback("pandaStates"),
+    tolerance=NUMPY_TOLERANCE,
+    # processing_time=0.004,
+  ),
+  ProcessConfig(
     proc_name="card",
     pubs=["pandaStates", "carControl", "onroadEvents", "can"],
     subs=["sendcan", "carState", "carParams", "carOutput"],

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -483,20 +483,6 @@ CONFIGS = [
     processing_time=0.004,
   ),
   ProcessConfig(
-    proc_name="hardwared",
-    pubs=[
-      "peripheralState", "gpsLocationExternal", "controlsState", "pandaStates",
-    ],
-    subs=["deviceState"],
-    ignore=["logMonoTime"],
-    # config_callback=controlsd_config_callback,
-    # init_callback=get_car_params_callback,
-    # should_recv_callback=controlsd_rcv_callback,
-    should_recv_callback=MessageBasedRcvCallback("pandaStates"),
-    tolerance=NUMPY_TOLERANCE,
-    # processing_time=0.004,
-  ),
-  ProcessConfig(
     proc_name="card",
     pubs=["pandaStates", "carControl", "onroadEvents", "can"],
     subs=["sendcan", "carState", "carParams", "carOutput"],

--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -231,7 +231,7 @@ def hardware_thread(end_event, hw_queue) -> None:
         cloudlog.error("panda timed out onroad")
 
     # Run at 2Hz, plus either edge of ignition
-    ign_edge = (started_ts is None) != onroad_conditions["ignition"]
+    ign_edge = (started_ts is not None) != onroad_conditions["ignition"]
     if (sm.frame % round(SERVICE_LIST['pandaStates'].frequency * DT_HW) != 0) and not ign_edge:
       continue
 

--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -295,11 +295,11 @@ def hardware_thread(end_event, hw_queue) -> None:
 
     startup_conditions["up_to_date"] = params.get("Offroad_ConnectivityNeeded") is None or params.get_bool("DisableUpdates") or params.get_bool("SnoozeUpdate")
     startup_conditions["not_uninstalling"] = not params.get_bool("DoUninstall")
-    # startup_conditions["accepted_terms"] = params.get("HasAcceptedTerms") == terms_version
+    startup_conditions["accepted_terms"] = params.get("HasAcceptedTerms") == terms_version
 
     # with 2% left, we killall, otherwise the phone will take a long time to boot
     startup_conditions["free_space"] = msg.deviceState.freeSpacePercent > 2
-    # startup_conditions["completed_training"] = params.get("CompletedTrainingVersion") == training_version
+    startup_conditions["completed_training"] = params.get("CompletedTrainingVersion") == training_version
     startup_conditions["not_driver_view"] = not params.get_bool("IsDriverViewEnabled")
     startup_conditions["not_taking_snapshot"] = not params.get_bool("IsTakingSnapshot")
 
@@ -392,7 +392,6 @@ def hardware_thread(end_event, hw_queue) -> None:
       params.put_bool("DoShutdown", True)
 
     msg.deviceState.started = started_ts is not None
-    print('started', msg.deviceState.started)
     msg.deviceState.startedMonoTime = int(1e9*(started_ts or 0))
 
     last_ping = params.get("LastAthenaPingTime")

--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -230,8 +230,8 @@ def hardware_thread(end_event, hw_queue) -> None:
         onroad_conditions["ignition"] = False
         cloudlog.error("panda timed out onroad")
 
-    # Run at 2Hz, plus rising edge of ignition
-    ign_edge = started_ts is None and onroad_conditions["ignition"]
+    # Run at 2Hz, plus either edge of ignition
+    ign_edge = (started_ts is None) != onroad_conditions["ignition"]
     if (sm.frame % round(SERVICE_LIST['pandaStates'].frequency * DT_HW) != 0) and not ign_edge:
       continue
 
@@ -295,11 +295,11 @@ def hardware_thread(end_event, hw_queue) -> None:
 
     startup_conditions["up_to_date"] = params.get("Offroad_ConnectivityNeeded") is None or params.get_bool("DisableUpdates") or params.get_bool("SnoozeUpdate")
     startup_conditions["not_uninstalling"] = not params.get_bool("DoUninstall")
-    startup_conditions["accepted_terms"] = params.get("HasAcceptedTerms") == terms_version
+    # startup_conditions["accepted_terms"] = params.get("HasAcceptedTerms") == terms_version
 
     # with 2% left, we killall, otherwise the phone will take a long time to boot
     startup_conditions["free_space"] = msg.deviceState.freeSpacePercent > 2
-    startup_conditions["completed_training"] = params.get("CompletedTrainingVersion") == training_version
+    # startup_conditions["completed_training"] = params.get("CompletedTrainingVersion") == training_version
     startup_conditions["not_driver_view"] = not params.get_bool("IsDriverViewEnabled")
     startup_conditions["not_taking_snapshot"] = not params.get_bool("IsTakingSnapshot")
 
@@ -392,6 +392,7 @@ def hardware_thread(end_event, hw_queue) -> None:
       params.put_bool("DoShutdown", True)
 
     msg.deviceState.started = started_ts is not None
+    print('started', msg.deviceState.started)
     msg.deviceState.startedMonoTime = int(1e9*(started_ts or 0))
 
     last_ping = params.get("LastAthenaPingTime")


### PR DESCRIPTION
On cycling the ignition, it could be possible that pandad drops out for some time and only publishes a few frames of low ignition which might be ignored.

Besides that niche issue, it's totally possible for a car to allow a user to quickly cycle the ignition in 40-50ms which openpilot ignores but pandad sees and resets the safety mode, both causing a controls mismatch.