### PR TITLE
Fix running torqued on decimated data

### DIFF
--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -51,7 +51,7 @@ class TorqueBuckets(PointBuckets):
 
 class TorqueEstimator(ParameterEstimator):
   def __init__(self, CP, decimated=False):
-    self.hist_len = int(HISTORY / DT_MDL)
+    self.hist_len = int(HISTORY / DT_MDL / 5) if decimated else int(HISTORY / DT_MDL)
     self.lag = CP.steerActuatorDelay + .2   # from controlsd
     if decimated:
       self.min_bucket_points = MIN_BUCKET_POINTS / 10


### PR DESCRIPTION
Noticed while I was trying to use the TorqueEstimator class on qlog data to find the max lat accel for a Lexus. We change behavior on calculating the params based on decimation, but not the frequencies we consider points (which means single segments return almost no points!)