### PR TITLE
torqued: clean up

### DIFF
--- a/selfdrive/locationd/helpers.py
+++ b/selfdrive/locationd/helpers.py
@@ -38,7 +38,7 @@ class PointBuckets:
   def is_calculable(self) -> bool:
     return all(len(v) > 0 for v in self.buckets.values())
 
-  def add_point(self, x: float, y: float, bucket_val: float) -> None:
+  def add_point(self, x: float, y: float) -> None:
     raise NotImplementedError
 
   def get_points(self, num_points: int = None) -> Any:

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -36,8 +36,8 @@ ALLOWED_CARS = ['toyota', 'hyundai']
 
 
 def slope2rot(slope):
-  sin = np.sqrt(slope**2 / (slope**2 + 1))
-  cos = np.sqrt(1 / (slope**2 + 1))
+  sin = np.sqrt(slope ** 2 / (slope ** 2 + 1))
+  cos = np.sqrt(1 / (slope ** 2 + 1))
   return np.array([[cos, -sin], [sin, cos]])
 
 
@@ -52,7 +52,7 @@ class TorqueBuckets(PointBuckets):
 class TorqueEstimator(ParameterEstimator):
   def __init__(self, CP, decimated=False):
     self.hist_len = int(HISTORY / DT_MDL)
-    self.lag = CP.steerActuatorDelay + .2   # from controlsd
+    self.lag = CP.steerActuatorDelay + .2  # from controlsd
     if decimated:
       self.min_bucket_points = MIN_BUCKET_POINTS / 10
       self.min_points_total = MIN_POINTS_TOTAL_QLOG
@@ -242,8 +242,10 @@ def main(demo=False):
       msg = estimator.get_msg(valid=sm.all_checks(), with_points=True)
       params.put_nonblocking("LiveTorqueParameters", msg.to_bytes())
 
+
 if __name__ == "__main__":
   import argparse
+
   parser = argparse.ArgumentParser(description='Process the --demo argument.')
   parser.add_argument('--demo', action='store_true', help='A boolean for demo mode.')
   args = parser.parse_args()

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -119,7 +119,8 @@ class TorqueEstimator(ParameterEstimator):
     for param in initial_params:
       self.filtered_params[param] = FirstOrderFilter(initial_params[param], self.decay, DT_MDL)
 
-  def get_restore_key(self, CP, version):
+  @staticmethod
+  def get_restore_key(CP, version):
     a, b = None, None
     if CP.lateralTuning.which() == 'torque':
       a = CP.lateralTuning.torque.friction

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -166,6 +166,7 @@ class TorqueEstimator(ParameterEstimator):
       self.data_points["steer_torque"].append(-msg.actuatorsOutput.steer)
     elif which == "carState":
       self.data_points["carState_t"].append(t + self.lag)
+      # TODO: check if high aEgo affects resulting lateral accel
       self.data_points["vego"].append(msg.vEgo)
       self.data_points["steer_override"].append(msg.steeringPressed)
 

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -158,6 +158,7 @@ class TorqueEstimator(ParameterEstimator):
       self.filtered_params[param].update_alpha(self.decay)
 
   def handle_log(self, t, which, msg):
+    # all car state points are offset by the lateral actuator delay
     if which == "carControl":
       self.data_points["carControl_t"].append(t + self.lag)
       self.data_points["lat_active"].append(msg.latActive)

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -158,7 +158,6 @@ class TorqueEstimator(ParameterEstimator):
       self.filtered_params[param].update_alpha(self.decay)
 
   def handle_log(self, t, which, msg):
-    # all car state points are offset by the lateral actuator delay
     if which == "carControl":
       self.data_points["carControl_t"].append(t + self.lag)
       self.data_points["lat_active"].append(msg.latActive)
@@ -169,6 +168,8 @@ class TorqueEstimator(ParameterEstimator):
       self.data_points["carState_t"].append(t + self.lag)
       self.data_points["vego"].append(msg.vEgo)
       self.data_points["steer_override"].append(msg.steeringPressed)
+
+    # calculate lateral accel from past steering torque
     elif which == "liveLocationKalman":
       if len(self.data_points['steer_torque']) == self.hist_len:
         yaw_rate = msg.angularVelocityCalibrated.value[2]


### PR DESCRIPTION
Rename `filtered_points` and `raw_points`, as "filtered" and "raw" are already terminology used for the calculated params (first order filter and raw noisy calculations) to reduce confusion. For the points, raw was the source data points and filtered was the calculated lateral accels from steering torques