### PR TITLE
torqued: keep track of all points

### DIFF
--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -50,10 +50,10 @@ class TorqueBuckets(PointBuckets):
 
 
 class TorqueEstimator(ParameterEstimator):
-  def __init__(self, CP, decimated=False, filter_max_lat_accel=True):
-    self.hist_len = int(HISTORY / DT_MDL)
+  def __init__(self, CP, decimated=False, track_all_points=False):
+    self.hist_len = int(HISTORY / DT_MDL / 5)
     self.lag = CP.steerActuatorDelay + .2  # from controlsd
-    self.filter_max_lat_accel = filter_max_lat_accel  # for finding max lat accel, note that torque params won't match online
+    self.track_all_points = track_all_points
     if decimated:
       self.min_bucket_points = MIN_BUCKET_POINTS / 10
       self.min_points_total = MIN_POINTS_TOTAL_QLOG
@@ -136,6 +136,7 @@ class TorqueEstimator(ParameterEstimator):
                                          min_points_total=self.min_points_total,
                                          points_per_bucket=POINTS_PER_BUCKET,
                                          rowsize=3)
+    self.all_torque_points = []
 
   def estimate_params(self):
     points = self.filtered_points.get_points(self.fit_points)
@@ -175,11 +176,15 @@ class TorqueEstimator(ParameterEstimator):
         lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carControl_t'], self.raw_points['lat_active']).astype(bool)
         steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carState_t'], self.raw_points['steer_override']).astype(bool)
         vego = np.interp(t, self.raw_points['carState_t'], self.raw_points['vego'])
-        steer = np.interp(t, self.raw_points['carOutput_t'], self.raw_points['steer_torque'])
-        lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY)
+        steer = np.interp(t, self.raw_points['carOutput_t'], self.raw_points['steer_torque']).item()
+        lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY).item()
         if all(lat_active) and not any(steer_override) and (vego > MIN_VEL) and (abs(steer) > STEER_MIN_THRESHOLD):
-          if abs(lateral_acc) <= LAT_ACC_THRESHOLD or not self.filter_max_lat_accel:
-            self.filtered_points.add_point(float(steer), float(lateral_acc))
+          if abs(lateral_acc) <= LAT_ACC_THRESHOLD:
+            self.filtered_points.add_point(steer, lateral_acc)
+
+          # for offline analysis, without max lateral accel or max steer torque filters
+          if self.track_all_points:
+            self.all_torque_points.append([steer, lateral_acc])
 
   def get_msg(self, valid=True, with_points=False):
     msg = messaging.new_message('liveTorqueParameters')

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -50,9 +50,10 @@ class TorqueBuckets(PointBuckets):
 
 
 class TorqueEstimator(ParameterEstimator):
-  def __init__(self, CP, decimated=False):
+  def __init__(self, CP, decimated=False, filter_max_lat_accel=True):
     self.hist_len = int(HISTORY / DT_MDL)
     self.lag = CP.steerActuatorDelay + .2  # from controlsd
+    self.filter_max_lat_accel = filter_max_lat_accel  # for finding max lat accel, note that torque params won't match online
     if decimated:
       self.min_bucket_points = MIN_BUCKET_POINTS / 10
       self.min_points_total = MIN_POINTS_TOTAL_QLOG
@@ -135,7 +136,6 @@ class TorqueEstimator(ParameterEstimator):
                                          min_points_total=self.min_points_total,
                                          points_per_bucket=POINTS_PER_BUCKET,
                                          rowsize=3)
-    self.all_torque_points = []
 
   def estimate_params(self):
     points = self.filtered_points.get_points(self.fit_points)
@@ -175,13 +175,11 @@ class TorqueEstimator(ParameterEstimator):
         lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carControl_t'], self.raw_points['lat_active']).astype(bool)
         steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carState_t'], self.raw_points['steer_override']).astype(bool)
         vego = np.interp(t, self.raw_points['carState_t'], self.raw_points['vego'])
-        steer = np.interp(t, self.raw_points['carOutput_t'], self.raw_points['steer_torque']).item()
-        lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY).item()
+        steer = np.interp(t, self.raw_points['carOutput_t'], self.raw_points['steer_torque'])
+        lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY)
         if all(lat_active) and not any(steer_override) and (vego > MIN_VEL) and (abs(steer) > STEER_MIN_THRESHOLD):
-          self.all_torque_points.append([steer, lateral_acc])
-          # reduces effects of non-linearity near the limits of the steering range
-          if abs(lateral_acc) <= LAT_ACC_THRESHOLD:
-            self.filtered_points.add_point(steer, lateral_acc)
+          if abs(lateral_acc) <= LAT_ACC_THRESHOLD or not self.filter_max_lat_accel:
+            self.filtered_points.add_point(float(steer), float(lateral_acc))
 
   def get_msg(self, valid=True, with_points=False):
     msg = messaging.new_message('liveTorqueParameters')

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -109,7 +109,7 @@ class TorqueEstimator(ParameterEstimator):
             }
           initial_params['points'] = cache_ltp.points
           self.decay = cache_ltp.decay
-          self.torque_points.load_points(initial_params['points'])
+          self.filtered_points.load_points(initial_params['points'])
           cloudlog.info("restored torque params from cache")
       except Exception:
         cloudlog.exception("failed to restore cached torque params")
@@ -130,7 +130,7 @@ class TorqueEstimator(ParameterEstimator):
     self.resets += 1.0
     self.decay = MIN_FILTER_DECAY
     self.data_points = defaultdict(lambda: deque(maxlen=self.hist_len))
-    self.torque_points = TorqueBuckets(x_bounds=STEER_BUCKET_BOUNDS,
+    self.filtered_points = TorqueBuckets(x_bounds=STEER_BUCKET_BOUNDS,
                                        min_points=self.min_bucket_points,
                                        min_points_total=self.min_points_total,
                                        points_per_bucket=POINTS_PER_BUCKET,
@@ -138,7 +138,7 @@ class TorqueEstimator(ParameterEstimator):
     self.all_torque_points = []
 
   def estimate_params(self):
-    points = self.torque_points.get_points(self.fit_points)
+    points = self.filtered_points.get_points(self.fit_points)
     # total least square solution as both x and y are noisy observations
     # this is empirically the slope of the hysteresis parallelogram as opposed to the line through the diagonals
     try:
@@ -179,8 +179,9 @@ class TorqueEstimator(ParameterEstimator):
         lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY).item()
         if all(lat_active) and not any(steer_override) and (vego > MIN_VEL) and (abs(steer) > STEER_MIN_THRESHOLD):
           self.all_torque_points.append([steer, lateral_acc])
+          # reduces effects of non-linearity near the limits of the steering range
           if abs(lateral_acc) <= LAT_ACC_THRESHOLD:
-            self.torque_points.add_point(steer, lateral_acc)
+            self.filtered_points.add_point(steer, lateral_acc)
 
   def get_msg(self, valid=True, with_points=False):
     msg = messaging.new_message('liveTorqueParameters')
@@ -190,13 +191,13 @@ class TorqueEstimator(ParameterEstimator):
     liveTorqueParameters.useParams = self.use_params
 
     # Calculate raw estimates when possible, only update filters when enough points are gathered
-    if self.torque_points.is_calculable():
+    if self.filtered_points.is_calculable():
       latAccelFactor, latAccelOffset, frictionCoeff = self.estimate_params()
       liveTorqueParameters.latAccelFactorRaw = float(latAccelFactor)
       liveTorqueParameters.latAccelOffsetRaw = float(latAccelOffset)
       liveTorqueParameters.frictionCoefficientRaw = float(frictionCoeff)
 
-      if self.torque_points.is_valid():
+      if self.filtered_points.is_valid():
         if any(val is None or np.isnan(val) for val in [latAccelFactor, latAccelOffset, frictionCoeff]):
           cloudlog.exception("Live torque parameters are invalid.")
           liveTorqueParameters.liveValid = False
@@ -208,12 +209,12 @@ class TorqueEstimator(ParameterEstimator):
           self.update_params({'latAccelFactor': latAccelFactor, 'latAccelOffset': latAccelOffset, 'frictionCoefficient': frictionCoeff})
 
     if with_points:
-      liveTorqueParameters.points = self.torque_points.get_points()[:, [0, 2]].tolist()
+      liveTorqueParameters.points = self.filtered_points.get_points()[:, [0, 2]].tolist()
 
     liveTorqueParameters.latAccelFactorFiltered = float(self.filtered_params['latAccelFactor'].x)
     liveTorqueParameters.latAccelOffsetFiltered = float(self.filtered_params['latAccelOffset'].x)
     liveTorqueParameters.frictionCoefficientFiltered = float(self.filtered_params['frictionCoefficient'].x)
-    liveTorqueParameters.totalBucketPoints = len(self.torque_points)
+    liveTorqueParameters.totalBucketPoints = len(self.filtered_points)
     liveTorqueParameters.decay = self.decay
     liveTorqueParameters.maxResets = self.resets
     return msg

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -53,7 +53,7 @@ class TorqueEstimator(ParameterEstimator):
   def __init__(self, CP, decimated=False, track_all_points=False):
     self.hist_len = int(HISTORY / DT_MDL)
     self.lag = CP.steerActuatorDelay + .2  # from controlsd
-    self.track_all_points = track_all_points
+    self.track_all_points = track_all_points  # for offline analysis, without max lateral accel or max steer torque filters
     if decimated:
       self.min_bucket_points = MIN_BUCKET_POINTS / 10
       self.min_points_total = MIN_POINTS_TOTAL_QLOG
@@ -182,7 +182,6 @@ class TorqueEstimator(ParameterEstimator):
           if abs(lateral_acc) <= LAT_ACC_THRESHOLD:
             self.filtered_points.add_point(steer, lateral_acc)
 
-          # for offline analysis, without max lateral accel or max steer torque filters
           if self.track_all_points:
             self.all_torque_points.append([steer, lateral_acc])
 

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -131,10 +131,10 @@ class TorqueEstimator(ParameterEstimator):
     self.decay = MIN_FILTER_DECAY
     self.data_points = defaultdict(lambda: deque(maxlen=self.hist_len))
     self.filtered_points = TorqueBuckets(x_bounds=STEER_BUCKET_BOUNDS,
-                                       min_points=self.min_bucket_points,
-                                       min_points_total=self.min_points_total,
-                                       points_per_bucket=POINTS_PER_BUCKET,
-                                       rowsize=3)
+                                         min_points=self.min_bucket_points,
+                                         min_points_total=self.min_points_total,
+                                         points_per_bucket=POINTS_PER_BUCKET,
+                                         rowsize=3)
     self.all_torque_points = []
 
   def estimate_params(self):

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -109,7 +109,7 @@ class TorqueEstimator(ParameterEstimator):
             }
           initial_params['points'] = cache_ltp.points
           self.decay = cache_ltp.decay
-          self.filtered_points.load_points(initial_params['points'])
+          self.torque_buckets.load_points(initial_params['points'])
           cloudlog.info("restored torque params from cache")
       except Exception:
         cloudlog.exception("failed to restore cached torque params")
@@ -129,15 +129,16 @@ class TorqueEstimator(ParameterEstimator):
   def reset(self):
     self.resets += 1.0
     self.decay = MIN_FILTER_DECAY
-    self.raw_points = defaultdict(lambda: deque(maxlen=self.hist_len))
-    self.filtered_points = TorqueBuckets(x_bounds=STEER_BUCKET_BOUNDS,
-                                         min_points=self.min_bucket_points,
-                                         min_points_total=self.min_points_total,
-                                         points_per_bucket=POINTS_PER_BUCKET,
-                                         rowsize=3)
+    self.data_points = defaultdict(lambda: deque(maxlen=self.hist_len))
+    self.torque_buckets = TorqueBuckets(x_bounds=STEER_BUCKET_BOUNDS,
+                                        min_points=self.min_bucket_points,
+                                        min_points_total=self.min_points_total,
+                                        points_per_bucket=POINTS_PER_BUCKET,
+                                        rowsize=3)
+    self.all_torque_points = []
 
   def estimate_params(self):
-    points = self.filtered_points.get_points(self.fit_points)
+    points = self.torque_buckets.get_points(self.fit_points)
     # total least square solution as both x and y are noisy observations
     # this is empirically the slope of the hysteresis parallelogram as opposed to the line through the diagonals
     try:
@@ -158,26 +159,28 @@ class TorqueEstimator(ParameterEstimator):
 
   def handle_log(self, t, which, msg):
     if which == "carControl":
-      self.raw_points["carControl_t"].append(t + self.lag)
-      self.raw_points["lat_active"].append(msg.latActive)
+      self.data_points["carControl_t"].append(t + self.lag)
+      self.data_points["lat_active"].append(msg.latActive)
     elif which == "carOutput":
-      self.raw_points["carOutput_t"].append(t + self.lag)
-      self.raw_points["steer_torque"].append(-msg.actuatorsOutput.steer)
+      self.data_points["carOutput_t"].append(t + self.lag)
+      self.data_points["steer_torque"].append(-msg.actuatorsOutput.steer)
     elif which == "carState":
-      self.raw_points["carState_t"].append(t + self.lag)
-      self.raw_points["vego"].append(msg.vEgo)
-      self.raw_points["steer_override"].append(msg.steeringPressed)
+      self.data_points["carState_t"].append(t + self.lag)
+      self.data_points["vego"].append(msg.vEgo)
+      self.data_points["steer_override"].append(msg.steeringPressed)
     elif which == "liveLocationKalman":
-      if len(self.raw_points['steer_torque']) == self.hist_len:
+      if len(self.data_points['steer_torque']) == self.hist_len:
         yaw_rate = msg.angularVelocityCalibrated.value[2]
         roll = msg.orientationNED.value[0]
-        lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carControl_t'], self.raw_points['lat_active']).astype(bool)
-        steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carState_t'], self.raw_points['steer_override']).astype(bool)
-        vego = np.interp(t, self.raw_points['carState_t'], self.raw_points['vego'])
-        steer = np.interp(t, self.raw_points['carOutput_t'], self.raw_points['steer_torque'])
-        lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY)
-        if all(lat_active) and not any(steer_override) and (vego > MIN_VEL) and (abs(steer) > STEER_MIN_THRESHOLD) and (abs(lateral_acc) <= LAT_ACC_THRESHOLD):
-          self.filtered_points.add_point(float(steer), float(lateral_acc))
+        lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.data_points['carControl_t'], self.data_points['lat_active']).astype(bool)
+        steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.data_points['carState_t'], self.data_points['steer_override']).astype(bool)
+        vego = np.interp(t, self.data_points['carState_t'], self.data_points['vego'])
+        steer = np.interp(t, self.data_points['carOutput_t'], self.data_points['steer_torque']).item()
+        lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY).item()
+        if all(lat_active) and not any(steer_override) and (vego > MIN_VEL) and (abs(steer) > STEER_MIN_THRESHOLD):
+          self.all_torque_points.append([steer, lateral_acc])
+          if abs(lateral_acc) <= LAT_ACC_THRESHOLD:
+            self.torque_buckets.add_point(steer, lateral_acc)
 
   def get_msg(self, valid=True, with_points=False):
     msg = messaging.new_message('liveTorqueParameters')
@@ -187,13 +190,13 @@ class TorqueEstimator(ParameterEstimator):
     liveTorqueParameters.useParams = self.use_params
 
     # Calculate raw estimates when possible, only update filters when enough points are gathered
-    if self.filtered_points.is_calculable():
+    if self.torque_buckets.is_calculable():
       latAccelFactor, latAccelOffset, frictionCoeff = self.estimate_params()
       liveTorqueParameters.latAccelFactorRaw = float(latAccelFactor)
       liveTorqueParameters.latAccelOffsetRaw = float(latAccelOffset)
       liveTorqueParameters.frictionCoefficientRaw = float(frictionCoeff)
 
-      if self.filtered_points.is_valid():
+      if self.torque_buckets.is_valid():
         if any(val is None or np.isnan(val) for val in [latAccelFactor, latAccelOffset, frictionCoeff]):
           cloudlog.exception("Live torque parameters are invalid.")
           liveTorqueParameters.liveValid = False
@@ -205,12 +208,12 @@ class TorqueEstimator(ParameterEstimator):
           self.update_params({'latAccelFactor': latAccelFactor, 'latAccelOffset': latAccelOffset, 'frictionCoefficient': frictionCoeff})
 
     if with_points:
-      liveTorqueParameters.points = self.filtered_points.get_points()[:, [0, 2]].tolist()
+      liveTorqueParameters.points = self.torque_buckets.get_points()[:, [0, 2]].tolist()
 
     liveTorqueParameters.latAccelFactorFiltered = float(self.filtered_params['latAccelFactor'].x)
     liveTorqueParameters.latAccelOffsetFiltered = float(self.filtered_params['latAccelOffset'].x)
     liveTorqueParameters.frictionCoefficientFiltered = float(self.filtered_params['frictionCoefficient'].x)
-    liveTorqueParameters.totalBucketPoints = len(self.filtered_points)
+    liveTorqueParameters.totalBucketPoints = len(self.torque_buckets)
     liveTorqueParameters.decay = self.decay
     liveTorqueParameters.maxResets = self.resets
     return msg

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -51,7 +51,7 @@ class TorqueBuckets(PointBuckets):
 
 class TorqueEstimator(ParameterEstimator):
   def __init__(self, CP, decimated=False, track_all_points=False):
-    self.hist_len = int(HISTORY / DT_MDL / 5)
+    self.hist_len = int(HISTORY / DT_MDL)
     self.lag = CP.steerActuatorDelay + .2  # from controlsd
     self.track_all_points = track_all_points
     if decimated:


### PR DESCRIPTION
Useful for offline analysis of max lat accel, currently this is done in some notebooks somewhere, and I'm sure the filtering isn't all the same. This starts to standardize how we calculate this value.

Not used online yet, but I could see a field for a certain upper range of max seen lat accels, which would be really helpful for debugging car issues and verifying car fingerprints (right now we hope that the lat accel factor is close to the max lat accel!)