### PR TITLE
torqued: fix history length

### DIFF
--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -178,8 +178,8 @@ class TorqueEstimator(ParameterEstimator):
       if len(self.raw_points['steer_torque']) == self.raw_hist_len:
         yaw_rate = msg.angularVelocityCalibrated.value[2]
         roll = msg.orientationNED.value[0]
-        lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carControl_t'], self.raw_points['lat_active']).astype(bool)
-        steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carState_t'], self.raw_points['steer_override']).astype(bool)
+        lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_CTRL), self.raw_points['carControl_t'], self.raw_points['lat_active']).astype(bool)
+        steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_CTRL), self.raw_points['carState_t'], self.raw_points['steer_override']).astype(bool)
         vego = np.interp(t, self.raw_points['carState_t'], self.raw_points['vego'])
         steer = np.interp(t, self.raw_points['carOutput_t'], self.raw_points['steer_torque']).item()
         lateral_acc = (vego * yaw_rate) - (np.sin(roll) * ACCELERATION_DUE_TO_GRAVITY).item()

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -5,7 +5,7 @@ from collections import deque, defaultdict
 import cereal.messaging as messaging
 from cereal import car, log
 from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, DT_MDL
+from openpilot.common.realtime import config_realtime_process, DT_CTRL, DT_MDL
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.vehicle_model import ACCELERATION_DUE_TO_GRAVITY
@@ -51,8 +51,9 @@ class TorqueBuckets(PointBuckets):
 
 class TorqueEstimator(ParameterEstimator):
   def __init__(self, CP, decimated=False, track_all_points=False):
-    self.raw_hist_len = int(HISTORY / DT_MDL)
+    self.raw_hist_len = int(HISTORY / DT_CTRL)
     self.lag = CP.steerActuatorDelay + .2  # from controlsd
+    self.decimated = decimated
     self.track_all_points = track_all_points  # for offline analysis, without max lateral accel or max steer torque filters
     if decimated:
       self.min_bucket_points = MIN_BUCKET_POINTS / 10

--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -51,7 +51,7 @@ class TorqueBuckets(PointBuckets):
 
 class TorqueEstimator(ParameterEstimator):
   def __init__(self, CP, decimated=False, track_all_points=False):
-    self.hist_len = int(HISTORY / DT_MDL)
+    self.raw_hist_len = int(HISTORY / DT_MDL)
     self.lag = CP.steerActuatorDelay + .2  # from controlsd
     self.track_all_points = track_all_points  # for offline analysis, without max lateral accel or max steer torque filters
     if decimated:
@@ -131,7 +131,7 @@ class TorqueEstimator(ParameterEstimator):
   def reset(self):
     self.resets += 1.0
     self.decay = MIN_FILTER_DECAY
-    self.raw_points = defaultdict(lambda: deque(maxlen=self.hist_len))
+    self.raw_points = defaultdict(lambda: deque(maxlen=self.raw_hist_len))
     self.filtered_points = TorqueBuckets(x_bounds=STEER_BUCKET_BOUNDS,
                                          min_points=self.min_bucket_points,
                                          min_points_total=self.min_points_total,
@@ -174,7 +174,7 @@ class TorqueEstimator(ParameterEstimator):
 
     # calculate lateral accel from past steering torque
     elif which == "liveLocationKalman":
-      if len(self.raw_points['steer_torque']) == self.hist_len:
+      if len(self.raw_points['steer_torque']) == self.raw_hist_len:
         yaw_rate = msg.angularVelocityCalibrated.value[2]
         roll = msg.orientationNED.value[0]
         lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t, DT_MDL), self.raw_points['carControl_t'], self.raw_points['lat_active']).astype(bool)


### PR DESCRIPTION
This increases the history length from 1 second to 5 seconds (as specified), and the steering pressed + lat active lookback from 0.4 seconds to 2 seconds (also as specified).