### PR TITLE
start for `curl openpilot.comma.ai | bash`

### DIFF
--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -f launch_openpilot.sh ]; then
+  if [ ! -d openpilot ]; then
+    git clone --recurse-submodules https://github.com/commaai/openpilot.git
+    git lfs pull
+  fi
+  cd openpilot
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  tools/mac_setup.sh
+else
+  tools/ubuntu_setup.sh
+fi
+
+source .venv/bin/activate
+
+echo "Building openpilot"
+scons -u -j$(nproc)

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ ! -f launch_openpilot.sh ]; then
   if [ ! -d openpilot ]; then
-    git clone --recurse-submodules https://github.com/commaai/openpilot.git
+    git clone --single-branch --recurse-submodules https://github.com/commaai/openpilot.git
     git lfs pull
   fi
   cd openpilot
@@ -20,3 +20,12 @@ source .venv/bin/activate
 
 echo "Building openpilot"
 scons -u -j$(nproc)
+
+echo
+echo "----   OPENPILOT BUILDING DONE   ----"
+echo "To push changes to your fork, run the following commands:"
+echo "git remote remove origin"
+echo "git remote add origin git@github.com:<YOUR_USERNAME>/openpilot.git"
+echo "git fetch"
+echo "git commit -m \"first commit\""
+echo "git push"

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -5,7 +5,6 @@ set -e
 if [ ! -f launch_openpilot.sh ]; then
   if [ ! -d openpilot ]; then
     git clone --single-branch --recurse-submodules https://github.com/commaai/openpilot.git
-    git lfs pull
   fi
   cd openpilot
 fi
@@ -15,6 +14,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
   tools/ubuntu_setup.sh
 fi
+
+git lfs pull
 
 source .venv/bin/activate
 


### PR DESCRIPTION
Wrote an initial script for `curl openpilot.comma.ai | bash`

Merging this is not enough, of course, another script must be deployed so that `openpilot.run` and/or `openpilot.sh` points to it.

To deploy it with GitHub Pages the instructions are the following:

1. Create a new repo (e.g. openpilot-installer) and push the needed files (e.g. https://github.com/andiradulescu/openpilot-installer)
2. Optional, but important, verify the domain here: https://github.com/settings/pages (be sure to be in `commaai` org)
3. Set the DNS records for the domain: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#dns-records-for-your-custom-domain
4. Set the `Custom domain` for the new repo: https://github.com/commaai/openpilot-installer/settings/pages

:rocket: 