### PR TITLE
cabana: fix wrong file path handling for recent files menu

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -487,7 +487,7 @@ void MainWindow::updateRecentFileMenu() {
 
   for (int i = 0; i < num_recent_files; ++i) {
     QString text = tr("&%1 %2").arg(i + 1).arg(QFileInfo(settings.recent_files[i]).fileName());
-    open_recent_menu->addAction(text, this, [this, i=i](){ loadFile(settings.recent_files[i]); });
+    open_recent_menu->addAction(text, this, [this, file = settings.recent_files[i]]() { loadFile(file); });
   }
 }
 


### PR DESCRIPTION
**Issue:**
The previous implementation captured the loop index i by value and accessed settings.recent_files[i] within the lambda. This method could result in incorrect file paths being used if settings.recent_files was modified after lambda creation.

**Fix:**
Refactored the lambda to capture file path (file=settings.recent_files[i]) directly by value. This ensures that each lambda operates with the correct file path, independent of subsequent modifications to settings.recent_files.