### PR TITLE
selfdrive/car: ban imports from external modules

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,36 @@
+[importlinter]
+root_packages =
+    openpilot
+
+[importlinter:contract:1]
+name = Forbid imports from openpilot.selfdrive.car to openpilot.system
+type = forbidden
+source_modules =
+    openpilot.selfdrive.car
+forbidden_modules =
+    openpilot.system
+    openpilot.body
+    openpilot.docs
+    openpilot.msgq
+    openpilot.panda
+    openpilot.rednose
+    openpilot.release
+    openpilot.teleoprtc
+    openpilot.tinygrad
+ignore_imports =
+    openpilot.selfdrive.car.card -> openpilot.common.realtime
+    openpilot.selfdrive.car.card -> openpilot.selfdrive.controls.lib.events
+    openpilot.selfdrive.car.interfaces -> openpilot.selfdrive.controls.lib.events
+    openpilot.selfdrive.car.tests.test_models -> openpilot.tools.lib.logreader
+    openpilot.selfdrive.car.tests.test_models -> openpilot.selfdrive.car.card
+    openpilot.selfdrive.car.tests.test_models -> openpilot.tools.lib.route
+    openpilot.selfdrive.car.tests.test_models -> openpilot.system.hardware.hw
+    openpilot.selfdrive.car.tests.test_models -> openpilot.selfdrive.test.helpers
+    openpilot.selfdrive.car.isotp_parallel_query -> openpilot.common.swaglog
+    openpilot.selfdrive.car.fw_versions -> openpilot.common.swaglog
+    openpilot.selfdrive.car.disable_ecu -> openpilot.common.swaglog
+    openpilot.selfdrive.car.vin -> openpilot.common.swaglog
+    openpilot.selfdrive.car.ecu_addrs -> openpilot.common.swaglog
+    openpilot.selfdrive.car.car_helpers -> openpilot.common.swaglog
+    openpilot.selfdrive.car.car_helpers -> openpilot.system.version
+unmatched_ignore_imports_alerting = warn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,3 +96,10 @@ repos:
     rev: 0.28.6
     hooks:
     -   id: check-github-workflows
+-   repo: local
+    hooks:
+    -   id: import-linter
+        name: import linter
+        entry: lint-imports
+        language: system
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ docs = [
 testing = [
   "coverage",
   "hypothesis ==6.47.*",
+  "import-linter",
   "mypy",
   "pre-commit",
   "pytest",

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -11,6 +11,7 @@ from openpilot.common.numpy_fast import clip, interp
 from openpilot.common.utils import Freezable
 from openpilot.selfdrive.car.docs_definitions import CarDocs
 
+DT_CTRL = 0.01 # car state and control loop timestep (s)
 
 # kg of standard extra cargo to count for drive, gas, etc...
 STD_CARGO_KG = 136.

--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -11,7 +11,7 @@ from openpilot.common.numpy_fast import clip, interp
 from openpilot.common.utils import Freezable
 from openpilot.selfdrive.car.docs_definitions import CarDocs
 
-DT_CTRL = 0.01 # car state and control loop timestep (s)
+DT_CTRL = 0.01  # car state and control loop timestep (s)
 
 # kg of standard extra cargo to count for drive, gas, etc...
 STD_CARGO_KG = 136.

--- a/selfdrive/car/body/carcontroller.py
+++ b/selfdrive/car/body/carcontroller.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from openpilot.common.realtime import DT_CTRL
 from opendbc.can.packer import CANPacker
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.body import bodycan
 from openpilot.selfdrive.car.body.values import SPEED_FROM_RPM
 from openpilot.selfdrive.car.interfaces import CarControllerBase

--- a/selfdrive/car/body/interface.py
+++ b/selfdrive/car/body/interface.py
@@ -1,7 +1,6 @@
 import math
 from cereal import car
-from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.car import get_safety_config
+from openpilot.selfdrive.car import DT_CTRL, get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.car.body.values import SPEED_FROM_RPM
 

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -9,9 +9,10 @@ from cereal import car
 from panda import ALTERNATIVE_EXPERIENCE
 
 from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper, DT_CTRL
+from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper
 
 from openpilot.selfdrive.pandad import can_list_to_can_capnp
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.car_helpers import get_car, get_one_can
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.controls.lib.events import Events

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -1,6 +1,5 @@
 from opendbc.can.packer import CANPacker
-from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.car import apply_meas_steer_torque_limits
+from openpilot.selfdrive.car import DT_CTRL, apply_meas_steer_torque_limits
 from openpilot.selfdrive.car.chrysler import chryslercan
 from openpilot.selfdrive.car.chrysler.values import RAM_CARS, CarControllerParams, ChryslerFlags
 from openpilot.selfdrive.car.interfaces import CarControllerBase

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -1,9 +1,8 @@
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import interp
-from openpilot.common.realtime import DT_CTRL
 from opendbc.can.packer import CANPacker
-from openpilot.selfdrive.car import apply_driver_steer_torque_limits
+from openpilot.selfdrive.car import DT_CTRL, apply_driver_steer_torque_limits
 from openpilot.selfdrive.car.gm import gmcan
 from openpilot.selfdrive.car.gm.values import DBC, CanBus, CarControllerParams, CruiseButtons
 from openpilot.selfdrive.car.interfaces import CarControllerBase

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -2,8 +2,8 @@ from collections import namedtuple
 
 from cereal import car
 from openpilot.common.numpy_fast import clip, interp
-from openpilot.common.realtime import DT_CTRL
 from opendbc.can.packer import CANPacker
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.honda import hondacan
 from openpilot.selfdrive.car.honda.values import CruiseButtons, VISUAL_HUD, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, HONDA_NIDEC_ALT_PCM_ACCEL, CarControllerParams
 from openpilot.selfdrive.car.interfaces import CarControllerBase

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -1,9 +1,8 @@
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import clip
-from openpilot.common.realtime import DT_CTRL
 from opendbc.can.packer import CANPacker
-from openpilot.selfdrive.car import apply_driver_steer_torque_limits, common_fault_avoidance
+from openpilot.selfdrive.car import DT_CTRL, apply_driver_steer_torque_limits, common_fault_avoidance
 from openpilot.selfdrive.car.hyundai import hyundaicanfd, hyundaican
 from openpilot.selfdrive.car.hyundai.hyundaicanfd import CanBus
 from openpilot.selfdrive.car.hyundai.values import HyundaiFlags, Buttons, CarControllerParams, CANFD_CAR, CAR

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -13,8 +13,7 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.simple_kalman import KF1D, get_kalman_gain
 from openpilot.common.numpy_fast import clip
-from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.car import apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness, STD_CARGO_KG
+from openpilot.selfdrive.car import DT_CTRL, apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness, STD_CARGO_KG
 from openpilot.selfdrive.car.values import PLATFORMS
 from openpilot.selfdrive.controls.lib.drive_helpers import V_CRUISE_MAX, get_friction
 from openpilot.selfdrive.controls.lib.events import Events

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -6,8 +6,7 @@ import importlib
 from parameterized import parameterized
 
 from cereal import car, messaging
-from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.car import gen_empty_fingerprint
+from openpilot.selfdrive.car import DT_CTRL, gen_empty_fingerprint
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.car.fingerprints import all_known_cars
 from openpilot.selfdrive.car.fw_versions import FW_VERSIONS, FW_QUERY_CONFIGS

--- a/selfdrive/car/tests/test_lateral_limits.py
+++ b/selfdrive/car/tests/test_lateral_limits.py
@@ -5,7 +5,7 @@ from parameterized import parameterized_class
 import pytest
 import sys
 
-from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.car.fingerprints import all_known_cars
 from openpilot.selfdrive.car.interfaces import get_torque_params

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -12,14 +12,13 @@ from parameterized import parameterized_class
 from cereal import messaging, log, car
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
-from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.car import gen_empty_fingerprint
-from openpilot.selfdrive.car.card import Car
+from openpilot.selfdrive.car import DT_CTRL, gen_empty_fingerprint
 from openpilot.selfdrive.car.fingerprints import all_known_cars, MIGRATION
 from openpilot.selfdrive.car.car_helpers import FRAME_FINGERPRINT, interfaces
 from openpilot.selfdrive.car.honda.values import CAR as HONDA, HondaFlags
 from openpilot.selfdrive.car.tests.routes import non_tested_cars, routes, CarTestRoute
 from openpilot.selfdrive.car.values import Platform
+from openpilot.selfdrive.car.card import Car
 from openpilot.selfdrive.test.helpers import read_segment_list
 from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
 from openpilot.tools.lib.logreader import LogReader, internal_source, openpilotci_source

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -4,9 +4,9 @@ from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import mean
 from openpilot.common.filter_simple import FirstOrderFilter
-from openpilot.common.realtime import DT_CTRL
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, NO_STOP_TIMER_CAR, \
                                                   TSS2_CAR, RADAR_ACC_CAR, EPS_SCALE, UNSUPPORTED_DSU_CAR

--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -2,8 +2,7 @@ from cereal import car
 from opendbc.can.packer import CANPacker
 from openpilot.common.numpy_fast import clip
 from openpilot.common.conversions import Conversions as CV
-from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.car import apply_driver_steer_torque_limits
+from openpilot.selfdrive.car import DT_CTRL, apply_driver_steer_torque_limits
 from openpilot.selfdrive.car.interfaces import CarControllerBase
 from openpilot.selfdrive.car.volkswagen import mqbcan, pqcan
 from openpilot.selfdrive.car.volkswagen.values import CANBUS, CarControllerParams, VolkswagenFlags

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -15,9 +15,10 @@ from openpilot.common.conversions import Conversions as CV
 from openpilot.common.git import get_short_branch
 from openpilot.common.numpy_fast import clip
 from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper, DT_CTRL
+from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper
 from openpilot.common.swaglog import cloudlog
 
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.car_helpers import get_car_interface, get_startup_event
 from openpilot.selfdrive.controls.lib.alertmanager import AlertManager, set_offroad_alert
 from openpilot.selfdrive.controls.lib.drive_helpers import VCruiseHelper, clip_curvature

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -3,7 +3,7 @@ import math
 from cereal import car, log
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import clip, interp
-from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import DT_CTRL
 
 # WARNING: this value was determined based on the model's training distribution,
 #          model predictions above this speed can be unpredictable

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -9,7 +9,7 @@ from cereal import log, car
 import cereal.messaging as messaging
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.git import get_short_branch
-from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.locationd.calibrationd import MIN_SPEED_FILTER
 
 AlertSize = log.ControlsState.AlertSize

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABC
 
 from openpilot.common.numpy_fast import clip
-from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import DT_CTRL
 
 MIN_LATERAL_CONTROL_SPEED = 0.3  # m/s
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -1,6 +1,6 @@
 from cereal import car
 from openpilot.common.numpy_fast import clip
-from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.controls.lib.drive_helpers import CONTROL_N
 from openpilot.selfdrive.controls.lib.pid import PIDController
 from openpilot.selfdrive.modeld.constants import ModelConstants

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -8,10 +8,11 @@ import capnp
 from cereal import messaging, log, car
 from openpilot.common.numpy_fast import interp
 from openpilot.common.params import Params
-from openpilot.common.realtime import DT_CTRL, Ratekeeper, Priority, config_realtime_process
+from openpilot.common.realtime import Ratekeeper, Priority, config_realtime_process
 from openpilot.common.swaglog import cloudlog
 
 from openpilot.common.simple_kalman import KF1D
+from openpilot.selfdrive.car import DT_CTRL
 
 
 # Default lead acceleration decay set to 50% at 1s

--- a/selfdrive/controls/tests/test_state_machine.py
+++ b/selfdrive/controls/tests/test_state_machine.py
@@ -1,5 +1,5 @@
 from cereal import car, log
-from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.car_helpers import interfaces
 from openpilot.selfdrive.controls.controlsd import Controls, SOFT_DISABLE_TIME
 from openpilot.selfdrive.controls.lib.events import Events, ET, Alert, Priority, AlertSize, AlertStatus, VisualAlert, \

--- a/selfdrive/debug/cycle_alerts.py
+++ b/selfdrive/debug/cycle_alerts.py
@@ -4,7 +4,7 @@ import random
 
 from cereal import car, log
 import cereal.messaging as messaging
-from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.honda.interface import CarInterface
 from openpilot.selfdrive.controls.lib.events import ET, Events
 from openpilot.selfdrive.controls.lib.alertmanager import AlertManager

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -20,8 +20,8 @@ from msgq.visionipc import VisionIpcServer, get_endpoint_name as vipc_get_endpoi
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix
 from openpilot.common.timeout import Timeout
-from openpilot.common.realtime import DT_CTRL
 from panda.python import ALTERNATIVE_EXPERIENCE
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.car.car_helpers import get_car, interfaces
 from openpilot.system.manager.process_config import managed_processes
 from openpilot.selfdrive.test.process_replay.vision_meta import meta_from_camera_state, available_streams

--- a/tools/replay/can_replay.py
+++ b/tools/replay/can_replay.py
@@ -7,7 +7,8 @@ import threading
 
 os.environ['FILEREADER_CACHE'] = '1'
 
-from openpilot.common.realtime import config_realtime_process, Ratekeeper, DT_CTRL
+from openpilot.common.realtime import config_realtime_process, Ratekeeper
+from openpilot.selfdrive.car import DT_CTRL
 from openpilot.selfdrive.pandad import can_capnp_to_can_list
 from openpilot.tools.lib.logreader import LogReader
 from panda import PandaJungle


### PR DESCRIPTION
continue work from PR https://github.com/commaai/openpilot/pull/32726, Added an `ignore_imports` section for modules that will not be checked for now.