### PR TITLE
pandad: remove return statement in constructor

### DIFF
--- a/selfdrive/pandad/panda.cc
+++ b/selfdrive/pandad/panda.cc
@@ -26,8 +26,6 @@ Panda::Panda(std::string serial, uint32_t bus_offset) : bus_offset(bus_offset) {
 
   hw_type = get_hw_type();
   can_reset_communications();
-
-  return;
 }
 
 bool Panda::connected() {


### PR DESCRIPTION
Removed the unnecessary return statement  for cleaner code.