### PR TITLE
Nissan/carstate: calculate `vEgoRaw` the same as speed in panda 

### DIFF
--- a/selfdrive/car/nissan/carstate.py
+++ b/selfdrive/car/nissan/carstate.py
@@ -47,7 +47,7 @@ class CarState(CarStateBase):
       cp.vl["WHEEL_SPEEDS_REAR"]["WHEEL_SPEED_RL"],
       cp.vl["WHEEL_SPEEDS_REAR"]["WHEEL_SPEED_RR"],
     )
-    ret.vEgoRaw = (ret.wheelSpeeds.fl + ret.wheelSpeeds.fr + ret.wheelSpeeds.rl + ret.wheelSpeeds.rr) / 4.
+    ret.vEgoRaw = (ret.wheelSpeeds.rl + ret.wheelSpeeds.rr) / 2.
 
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
     ret.standstill = cp.vl["WHEEL_SPEEDS_REAR"]["WHEEL_SPEED_RL"] == 0.0 and cp.vl["WHEEL_SPEEDS_REAR"]["WHEEL_SPEED_RR"] == 0.0


### PR DESCRIPTION
prereq for https://github.com/commaai/openpilot/pull/32897

How panda calculate  vehicle speed:
https://github.com/commaai/panda/blob/b4e3d5cdd2dec2a58807b0d710a5d3561a59529d/board/safety/safety_nissan.h#L59

fuzzing tx messages show that calculating `vEgoRaw` based on four wheels might be different from how panda calculate vehicle speed, and that might lead to the difference in allowable steering angle between openpilot and panda.

the propose solution is to make openpilot calculate vehicle speed similarly to how panda does this. Another solution is to calculate the vehicle speed in panda similarly to how openpilot does it, but we would have to wait for another message of front wheels speed which would add up complexity to panda rx hook