### PR TITLE
Toyota/carcontroller: set `apply_steer` to 0 when there is fault

### DIFF
--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -59,7 +59,7 @@ class CarController(CarControllerBase):
     self.steer_rate_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringRateDeg) >= MAX_STEER_RATE, lat_active,
                                                                       self.steer_rate_counter, MAX_STEER_RATE_FRAMES)
 
-    if not lat_active:
+    if not (lat_active and apply_steer_req):
       apply_steer = 0
 
     # *** steer angle ***


### PR DESCRIPTION
prereq for https://github.com/commaai/openpilot/pull/32897

apply_steer should be 0 when the steer_req is False.