### PR TITLE
increase longitudinalPlan decimation

### DIFF
--- a/cereal/services.py
+++ b/cereal/services.py
@@ -38,7 +38,7 @@ _services: dict[str, tuple] = {
   "carState": (True, 100., 10),
   "carControl": (True, 100., 10),
   "carOutput": (True, 100., 10),
-  "longitudinalPlan": (True, 20., 5),
+  "longitudinalPlan": (True, 20., 10),
   "procLog": (True, 0.5, 15),
   "gpsLocationExternal": (True, 10., 10),
   "gpsLocation": (True, 1., 1),


### PR DESCRIPTION
This will soon be gone when the model does long planning. For now, I would like to keep it in the qlog so we can still view different time steps along the plan for debugging