### PR TITLE
ui: refactor calibration logic into a dedicated `Calibration` Class

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -20,7 +20,7 @@ widgets_src = ["ui.cc", "qt/widgets/input.cc", "qt/widgets/wifi.cc",
                "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/controls.cc",
                "qt/widgets/offroad_alerts.cc", "qt/widgets/prime.cc", "qt/widgets/keyboard.cc",
                "qt/widgets/scrollview.cc", "qt/widgets/cameraview.cc", "#third_party/qrcode/QrCode.cc",
-               "qt/request_repeater.cc", "qt/qt_window.cc", "qt/network/networking.cc", "qt/network/wifi_manager.cc"]
+               "qt/request_repeater.cc", "qt/qt_window.cc", "qt/network/networking.cc", "qt/network/wifi_manager.cc", "qt/onroad/calibration.cc"]
 
 widgets = qt_env.Library("qt_widgets", widgets_src, LIBS=base_libs)
 Export('widgets')

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -7,7 +7,7 @@
 
 const int FACE_IMG_SIZE = 130;
 
-DriverViewWindow::DriverViewWindow(QWidget* parent) : CameraWidget("camerad", VISION_STREAM_DRIVER, true, parent) {
+DriverViewWindow::DriverViewWindow(QWidget* parent) : CameraWidget("camerad", VISION_STREAM_DRIVER, parent) {
   face_img = loadPixmap("../assets/img_driver_face_static.png", {FACE_IMG_SIZE, FACE_IMG_SIZE});
   QObject::connect(this, &CameraWidget::clicked, this, &DriverViewWindow::done);
   QObject::connect(device(), &Device::interactiveTimeout, this, [this]() {
@@ -74,4 +74,16 @@ void DriverViewWindow::paintGL() {
   const int img_y = rect().bottom() - FACE_IMG_SIZE - img_offset;
   p.setOpacity(face_detected ? 1.0 : 0.2);
   p.drawPixmap(img_x, img_y, face_img);
+}
+
+mat4 DriverViewWindow::calcFrameMatrix() {
+  const float driver_view_ratio = 2.0;
+  const float yscale = stream_height * driver_view_ratio / stream_width;
+  const float xscale = yscale * glHeight() / glWidth() * stream_width / stream_height;
+  return mat4{{
+    xscale,  0.0, 0.0, 0.0,
+    0.0,  yscale, 0.0, 0.0,
+    0.0,  0.0, 1.0, 0.0,
+    0.0,  0.0, 0.0, 1.0,
+  }};
 }

--- a/selfdrive/ui/qt/offroad/driverview.h
+++ b/selfdrive/ui/qt/offroad/driverview.h
@@ -12,6 +12,7 @@ signals:
   void done();
 
 protected:
+  mat4 calcFrameMatrix() override;
   void showEvent(QShowEvent *event) override;
   void hideEvent(QHideEvent *event) override;
   void paintGL() override;

--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -39,7 +39,7 @@ protected:
   void paintGL() override;
   void initializeGL() override;
   void showEvent(QShowEvent *event) override;
-  void updateFrameMat() override;
+  mat4 calcFrameMatrix() override;
   void drawLaneLines(QPainter &painter, const UIState *s);
   void drawLead(QPainter &painter, const cereal::RadarState::LeadData::Reader &lead_data, const QPointF &vd);
   void drawHud(QPainter &p);

--- a/selfdrive/ui/qt/onroad/calibration.cc
+++ b/selfdrive/ui/qt/onroad/calibration.cc
@@ -1,0 +1,91 @@
+#include "selfdrive/ui/qt/onroad/calibration.h"
+
+const Eigen::Matrix3d VIEW_FROM_DEVICE = (Eigen::Matrix3d() <<
+  0.0, 1.0, 0.0,
+  0.0, 0.0, 1.0,
+  1.0, 0.0, 0.0).finished();
+
+const Eigen::Matrix3d FCAM_INTRINSIC_MATRIX = (Eigen::Matrix3d() <<
+  2648.0, 0.0, 1928.0 / 2,
+  0.0, 2648.0, 1208.0 / 2,
+  0.0, 0.0, 1.0).finished();
+
+// tici ecam focal probably wrong? magnification is not consistent across frame
+// Need to retrain model before this can be changed
+const Eigen::Matrix3d ECAM_INTRINSIC_MATRIX = (Eigen::Matrix3d() <<
+  567.0, 0.0, 1928.0 / 2,
+  0.0, 567.0, 1208.0 / 2,
+  0.0, 0.0, 1.0).finished();
+
+void Calibration::update(bool wide_cam, const cereal::LiveCalibrationData::Reader &live_calib, int width, int height) {
+  auto _euler2rot = [](const capnp::List<float>::Reader &rpy_list) {
+    return euler2rot({rpy_list[0], rpy_list[1], rpy_list[2]});
+  };
+
+  if (live_calib.getCalStatus() == cereal::LiveCalibrationData::Status::CALIBRATED) {
+    view_from_calib = VIEW_FROM_DEVICE * _euler2rot(live_calib.getRpyCalib());
+    if (wide_cam) {
+      view_from_calib *= _euler2rot(live_calib.getWideFromDeviceEuler());
+    }
+  } else {
+    view_from_calib = VIEW_FROM_DEVICE;
+  }
+
+  intrinsic_matrix = wide_cam ? ECAM_INTRINSIC_MATRIX: FCAM_INTRINSIC_MATRIX;
+  updateCalibration(width, height, wide_cam ? 2.0 : 1.1);
+}
+
+void Calibration::updateCalibration(int width, int height, float zoom) {
+  // Project point at "infinity" to compute x and y offsets
+  // to ensure this ends up in the middle of the screen
+  // for narrow come and a little lower for wide cam.
+  // TODO: use proper perspective transform?
+
+  Eigen::Vector3d inf(1000., 0., 0.);
+  auto Ep = view_from_calib * inf;
+  auto Kep = intrinsic_matrix * Ep;
+
+  float center_x = intrinsic_matrix(0, 2);
+  float center_y = intrinsic_matrix(1, 2);
+
+  float max_x_offset = center_x * zoom - width / 2 - 5;
+  float max_y_offset = center_y * zoom - height / 2 - 5;
+
+  float x_offset = std::clamp<float>((Kep.x() / Kep.z() - center_x) * zoom, -max_x_offset, max_x_offset);
+  float y_offset = std::clamp<float>((Kep.y() / Kep.z() - center_y) * zoom, -max_y_offset, max_y_offset);
+
+  float zx = zoom * 2 * center_x / width;
+  float zy = zoom * 2 * center_y / height;
+
+  frame_matrix = mat4{{
+    zx, 0.0, 0.0, -x_offset / width * 2,
+    0.0, zy, 0.0, y_offset / height * 2,
+    0.0, 0.0, 1.0, 0.0,
+    0.0, 0.0, 0.0, 1.0,
+  }};
+
+  // Apply transformation such that video pixel coordinates match video
+  // 1) Put (0, 0) in the middle of the video
+  // 2) Apply same scaling as video
+  // 3) Put (0, 0) in top left corner of video
+  car_space_transform.reset();
+  car_space_transform.translate(width / 2 - x_offset, height / 2 - y_offset)
+      .scale(zoom, zoom)
+      .translate(-center_x, -center_y);
+
+  clip_region = QRectF{-clip_margin, -clip_margin, width + 2 * clip_margin, height + 2 * clip_margin};
+}
+
+// Projects a point in car to space to the corresponding point in full frame image space.
+bool Calibration::mapToFrame(float x, float y, float z, QPointF *out) const {
+  Eigen::Vector3d pt(x, y, z);
+  auto Ep = view_from_calib * pt;
+  auto KEp = intrinsic_matrix * Ep;
+  QPointF point = car_space_transform.map(QPointF{KEp.x() / KEp.z(), KEp.y() / KEp.z()});
+
+  if (clip_region.contains(point)) {
+    *out = point;
+    return true;
+  }
+  return false;
+}

--- a/selfdrive/ui/qt/onroad/calibration.h
+++ b/selfdrive/ui/qt/onroad/calibration.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QTransform>
+
+#include "common/mat.h"
+#include "common/transformations/orientation.hpp"
+#include "cereal/messaging/messaging.h"
+
+class Calibration {
+ public:
+  Calibration() = default;
+  void update(bool wide_cam, const cereal::LiveCalibrationData::Reader &live_calib, int width, int height);
+  bool mapToFrame(float x, float y, float z, QPointF *out) const;
+  mat4 frameMatrix() const { return frame_matrix; }
+
+protected:
+  void updateCalibration(int width, int height, float zoom);
+
+  const float clip_margin = 500.0f;
+  Eigen::Matrix3d view_from_calib;
+  Eigen::Matrix3d intrinsic_matrix;
+  QTransform car_space_transform;
+  mat4 frame_matrix;
+  QRectF clip_region;
+};

--- a/selfdrive/ui/qt/onroad/onroad_home.cc
+++ b/selfdrive/ui/qt/onroad/onroad_home.cc
@@ -21,7 +21,7 @@ OnroadWindow::OnroadWindow(QWidget *parent) : QWidget(parent) {
   split->addWidget(nvg);
 
   if (getenv("DUAL_CAMERA_VIEW")) {
-    CameraWidget *arCam = new CameraWidget("camerad", VISION_STREAM_ROAD, true, this);
+    CameraWidget *arCam = new CameraWidget("camerad", VISION_STREAM_ROAD, this);
     split->insertWidget(0, arCam);
   }
 

--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -6,14 +6,11 @@
 #include <GLES3/gl3.h>
 #endif
 
+#include <algorithm>
 #include <cmath>
-#include <set>
-#include <string>
 #include <utility>
 
 #include <QApplication>
-#include <QOpenGLBuffer>
-#include <QOffscreenSurface>
 
 namespace {
 
@@ -66,40 +63,10 @@ const char frame_fragment_shader[] =
   "}\n";
 #endif
 
-mat4 get_driver_view_transform(int screen_width, int screen_height, int stream_width, int stream_height) {
-  const float driver_view_ratio = 2.0;
-  const float yscale = stream_height * driver_view_ratio / stream_width;
-  const float xscale = yscale*screen_height/screen_width*stream_width/stream_height;
-  mat4 transform = (mat4){{
-    xscale,  0.0, 0.0, 0.0,
-    0.0,  yscale, 0.0, 0.0,
-    0.0,  0.0, 1.0, 0.0,
-    0.0,  0.0, 0.0, 1.0,
-  }};
-  return transform;
-}
-
-mat4 get_fit_view_transform(float widget_aspect_ratio, float frame_aspect_ratio) {
-  float zx = 1, zy = 1;
-  if (frame_aspect_ratio > widget_aspect_ratio) {
-    zy = widget_aspect_ratio / frame_aspect_ratio;
-  } else {
-    zx = frame_aspect_ratio / widget_aspect_ratio;
-  }
-
-  const mat4 frame_transform = {{
-    zx, 0.0, 0.0, 0.0,
-    0.0, zy, 0.0, 0.0,
-    0.0, 0.0, 1.0, 0.0,
-    0.0, 0.0, 0.0, 1.0,
-  }};
-  return frame_transform;
-}
-
 } // namespace
 
-CameraWidget::CameraWidget(std::string stream_name, VisionStreamType type, bool zoom, QWidget* parent) :
-                          stream_name(stream_name), active_stream_type(type), requested_stream_type(type), zoomed_view(zoom), QOpenGLWidget(parent) {
+CameraWidget::CameraWidget(std::string stream_name, VisionStreamType type, QWidget* parent) :
+                          stream_name(stream_name), active_stream_type(type), requested_stream_type(type), QOpenGLWidget(parent) {
   setAttribute(Qt::WA_OpaquePaintEvent);
   qRegisterMetaType<std::set<VisionStreamType>>("availableStreams");
   QObject::connect(this, &CameraWidget::vipcThreadConnected, this, &CameraWidget::vipcConnected, Qt::BlockingQueuedConnection);
@@ -118,16 +85,6 @@ CameraWidget::~CameraWidget() {
     glDeleteBuffers(2, textures);
   }
   doneCurrent();
-}
-
-// Qt uses device-independent pixels, depending on platform this may be
-// different to what OpenGL uses
-int CameraWidget::glWidth() {
-    return width() * devicePixelRatio();
-}
-
-int CameraWidget::glHeight() {
-  return height() * devicePixelRatio();
 }
 
 void CameraWidget::initializeGL() {
@@ -214,59 +171,19 @@ void CameraWidget::availableStreamsUpdated(std::set<VisionStreamType> streams) {
   available_streams = streams;
 }
 
-void CameraWidget::updateFrameMat() {
-  int w = glWidth(), h = glHeight();
+mat4 CameraWidget::calcFrameMatrix() {
+  // Scale the frame to fit the widget while maintaining the aspect ratio.
+  float widget_aspect_ratio = (float)width() / height();
+  float frame_aspect_ratio = (float)stream_width / stream_height;
+  float zx = std::min(frame_aspect_ratio / widget_aspect_ratio, 1.0f);
+  float zy = std::min(widget_aspect_ratio / frame_aspect_ratio, 1.0f);
 
-  if (zoomed_view) {
-    if (active_stream_type == VISION_STREAM_DRIVER) {
-      if (stream_width > 0 && stream_height > 0) {
-        frame_mat = get_driver_view_transform(w, h, stream_width, stream_height);
-      }
-    } else {
-      // Project point at "infinity" to compute x and y offsets
-      // to ensure this ends up in the middle of the screen
-      // for narrow come and a little lower for wide cam.
-      // TODO: use proper perspective transform?
-      if (active_stream_type == VISION_STREAM_WIDE_ROAD) {
-        intrinsic_matrix = ECAM_INTRINSIC_MATRIX;
-        zoom = 2.0;
-      } else {
-        intrinsic_matrix = FCAM_INTRINSIC_MATRIX;
-        zoom = 1.1;
-      }
-      const vec3 inf = {{1000., 0., 0.}};
-      const vec3 Ep = matvecmul3(calibration, inf);
-      const vec3 Kep = matvecmul3(intrinsic_matrix, Ep);
-
-      float x_offset_ = (Kep.v[0] / Kep.v[2] - intrinsic_matrix.v[2]) * zoom;
-      float y_offset_ = (Kep.v[1] / Kep.v[2] - intrinsic_matrix.v[5]) * zoom;
-
-      float max_x_offset = intrinsic_matrix.v[2] * zoom - w / 2 - 5;
-      float max_y_offset = intrinsic_matrix.v[5] * zoom - h / 2 - 5;
-
-      x_offset = std::clamp(x_offset_, -max_x_offset, max_x_offset);
-      y_offset = std::clamp(y_offset_, -max_y_offset, max_y_offset);
-
-      float zx = zoom * 2 * intrinsic_matrix.v[2] / w;
-      float zy = zoom * 2 * intrinsic_matrix.v[5] / h;
-      const mat4 frame_transform = {{
-        zx, 0.0, 0.0, -x_offset / w * 2,
-        0.0, zy, 0.0, y_offset / h * 2,
-        0.0, 0.0, 1.0, 0.0,
-        0.0, 0.0, 0.0, 1.0,
-      }};
-      frame_mat = frame_transform;
-    }
-  } else if (stream_width > 0 && stream_height > 0) {
-    // fit frame to widget size
-    float widget_aspect_ratio = (float)w / h;
-    float frame_aspect_ratio = (float)stream_width  / stream_height;
-    frame_mat = get_fit_view_transform(widget_aspect_ratio, frame_aspect_ratio);
-  }
-}
-
-void CameraWidget::updateCalibration(const mat3 &calib) {
-  calibration = calib;
+  return mat4{{
+    zx, 0.0, 0.0, 0.0,
+    0.0, zy, 0.0, 0.0,
+    0.0, 0.0, 1.0, 0.0,
+    0.0, 0.0, 0.0, 1.0,
+  }};
 }
 
 void CameraWidget::paintGL() {
@@ -293,7 +210,7 @@ void CameraWidget::paintGL() {
   VisionBuf *frame = frames[frame_idx].second;
   assert(frame != nullptr);
 
-  updateFrameMat();
+  mat4 frame_mat = calcFrameMatrix();
 
   glViewport(0, 0, glWidth(), glHeight());
   glBindVertexArray(frame_vao);

--- a/selfdrive/ui/qt/widgets/cameraview.h
+++ b/selfdrive/ui/qt/widgets/cameraview.h
@@ -34,7 +34,7 @@ class CameraWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
 public:
   using QOpenGLWidget::QOpenGLWidget;
-  explicit CameraWidget(std::string stream_name, VisionStreamType stream_type, bool zoom, QWidget* parent = nullptr);
+  explicit CameraWidget(std::string stream_name, VisionStreamType stream_type, QWidget* parent = nullptr);
   ~CameraWidget();
   void setBackgroundColor(const QColor &color) { bg = color; }
   void setFrameId(int frame_id) { draw_frame_id = frame_id; }
@@ -51,21 +51,15 @@ signals:
 protected:
   void paintGL() override;
   void initializeGL() override;
-  void resizeGL(int w, int h) override { updateFrameMat(); }
   void showEvent(QShowEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override { emit clicked(); }
-  virtual void updateFrameMat();
-  void updateCalibration(const mat3 &calib);
+  virtual mat4 calcFrameMatrix();
   void vipcThread();
   void clearFrames();
-
-  int glWidth();
-  int glHeight();
-
-  bool zoomed_view;
+  int glWidth() const { return width() * devicePixelRatio(); }
+  int glHeight() const { return height() * devicePixelRatio(); }
   GLuint frame_vao, frame_vbo, frame_ibo;
   GLuint textures[2];
-  mat4 frame_mat = {};
   std::unique_ptr<QOpenGLShaderProgram> program;
   QColor bg = QColor("#000000");
 
@@ -81,13 +75,6 @@ protected:
   std::atomic<VisionStreamType> requested_stream_type;
   std::set<VisionStreamType> available_streams;
   QThread *vipc_thread = nullptr;
-
-  // Calibration
-  float x_offset = 0;
-  float y_offset = 0;
-  float zoom = 1.0;
-  mat3 calibration = DEFAULT_CALIBRATION;
-  mat3 intrinsic_matrix = FCAM_INTRINSIC_MATRIX;
 
   std::recursive_mutex frame_lock;
   std::deque<std::pair<uint32_t, VisionBuf*>> frames;

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -8,12 +8,11 @@
 #include <QColor>
 #include <QFuture>
 #include <QPolygonF>
-#include <QTransform>
 
 #include "cereal/messaging/messaging.h"
-#include "common/mat.h"
 #include "common/params.h"
 #include "common/timing.h"
+#include "selfdrive/ui/qt/onroad/calibration.h"
 #include "system/hardware/hw.h"
 
 const int UI_BORDER_SIZE = 30;
@@ -24,16 +23,6 @@ const int BACKLIGHT_OFFROAD = 50;
 
 const float MIN_DRAW_DISTANCE = 10.0;
 const float MAX_DRAW_DISTANCE = 100.0;
-constexpr mat3 DEFAULT_CALIBRATION = {{ 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0 }};
-constexpr mat3 FCAM_INTRINSIC_MATRIX = (mat3){{2648.0, 0.0, 1928.0 / 2,
-                                           0.0, 2648.0, 1208.0 / 2,
-                                           0.0, 0.0, 1.0}};
-// tici ecam focal probably wrong? magnification is not consistent across frame
-// Need to retrain model before this can be changed
-constexpr mat3 ECAM_INTRINSIC_MATRIX = (mat3){{567.0, 0.0, 1928.0 / 2,
-                                           0.0, 567.0, 1208.0 / 2,
-                                           0.0, 0.0, 1.0}};
-
 
 constexpr vec3 default_face_kpts_3d[] = {
   {-5.98, -51.20, 8.00}, {-17.64, -49.14, 8.00}, {-23.81, -46.40, 8.00}, {-29.98, -40.91, 8.00}, {-32.04, -37.49, 8.00},
@@ -71,11 +60,6 @@ const QColor bg_colors [] = {
 
 
 typedef struct UIScene {
-  bool calibration_valid = false;
-  bool calibration_wide_valid  = false;
-  bool wide_cam = true;
-  mat3 view_from_calib = DEFAULT_CALIBRATION;
-  mat3 view_from_wide_calib = DEFAULT_CALIBRATION;
   cereal::PandaState::PandaType pandaType;
 
   // modelV2
@@ -117,16 +101,13 @@ public:
   inline PrimeType primeType() const { return prime_type; }
   inline bool hasPrime() const { return prime_type > PrimeType::NONE; }
 
-  int fb_w = 0, fb_h = 0;
-
   std::unique_ptr<SubMaster> sm;
 
   UIStatus status;
   UIScene scene = {};
 
   QString language;
-
-  QTransform car_space_transform;
+  Calibration calibration;
 
 signals:
   void uiUpdate(const UIState &s);

--- a/selfdrive/ui/watch3.cc
+++ b/selfdrive/ui/watch3.cc
@@ -19,14 +19,14 @@ int main(int argc, char *argv[]) {
   {
     QHBoxLayout *hlayout = new QHBoxLayout();
     layout->addLayout(hlayout);
-    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_ROAD, false));
+    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_ROAD));
   }
 
   {
     QHBoxLayout *hlayout = new QHBoxLayout();
     layout->addLayout(hlayout);
-    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_DRIVER, false));
-    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_WIDE_ROAD, false));
+    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_DRIVER));
+    hlayout->addWidget(new CameraWidget("camerad", VISION_STREAM_WIDE_ROAD));
   }
 
   return a.exec();

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -148,7 +148,7 @@ QWidget *VideoWidget::createCameraWidget() {
 
   QStackedLayout *stacked = new QStackedLayout();
   stacked->setStackingMode(QStackedLayout::StackAll);
-  stacked->addWidget(cam_widget = new StreamCameraView("camerad", VISION_STREAM_ROAD, false));
+  stacked->addWidget(cam_widget = new StreamCameraView("camerad", VISION_STREAM_ROAD));
   cam_widget->setMinimumHeight(MIN_VIDEO_HEIGHT);
   cam_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
   stacked->addWidget(alert_label = new InfoLabel(this));
@@ -420,8 +420,8 @@ void InfoLabel::paintEvent(QPaintEvent *event) {
   }
 }
 
-StreamCameraView::StreamCameraView(std::string stream_name, VisionStreamType stream_type, bool zoom, QWidget *parent)
-    : CameraWidget(stream_name, stream_type, zoom, parent) {
+StreamCameraView::StreamCameraView(std::string stream_name, VisionStreamType stream_type, QWidget *parent)
+    : CameraWidget(stream_name, stream_type, parent) {
   fade_animation = new QPropertyAnimation(this, "overlayOpacity");
   fade_animation->setDuration(500);
   fade_animation->setStartValue(0.2f);

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -64,7 +64,7 @@ class StreamCameraView : public CameraWidget {
   Q_PROPERTY(float overlayOpacity READ overlayOpacity WRITE setOverlayOpacity)
 
 public:
-  StreamCameraView(std::string stream_name, VisionStreamType stream_type, bool zoom, QWidget *parent = nullptr);
+  StreamCameraView(std::string stream_name, VisionStreamType stream_type, QWidget *parent = nullptr);
   void paintGL() override;
   void showPausedOverlay() { fade_animation->start(); }
   float overlayOpacity() const { return overlay_opacity; }


### PR DESCRIPTION
This PR introduces a dedicated `Calibration` class to centralize all calibration-related functions and variables previously scattered across `uiState`, `AnnotatedCameraWidget`, and `CameraView`

**Key changes include:**
1. Introducing a new `Calibration` class.
2. Removing calibration-related functions and variables from `uiState`.
3. Refactoring `CameraView` to be a generic class for displaying vision streams without any embedded calibration logic. By default, it scales the frame to fit the widget while maintaining the aspect ratio. Inherited classes `DriverViewWindow` and `AnnotatedCameraWidget` now override the new `calcFrameMatrix()` method to set their specific transforms.
4. Standardizing matrix operations by using Eigen consistently throughout the `Calibration` class, eliminating the mix of Eigen and custom matrix representations from `common/mat.h`.

**Note:** The Calibration instance is still retained in `uiState` for updating model-related data in `ui.cc`. Following PR [#33005](https://github.com/commaai/openpilot/pull/33005), the Calibration instance will be removed from uiState, allowing the uiState  to focus on storing common data.
