### PR TITLE
Update fingerprints.py

### DIFF
--- a/selfdrive/car/subaru/fingerprints.py
+++ b/selfdrive/car/subaru/fingerprints.py
@@ -188,6 +188,7 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7e0, None): [
       b'\xca!`0\x07',
       b'\xca!`p\x07',
+      b'\xca!`t\x07',
       b'\xca!ap\x07',
       b'\xca!f@\x07',
       b'\xca!fp\x07',


### PR DESCRIPTION
Added Missing Engine Firmware Version for 2020 Subaru Impreza.

Verified fwVersion in routes from Dashcam Mode and Sunny Pilot.

Route: 2e7f34ee218f76b6/00000049--8537e775a3

