### PR TITLE
ci: bring back aarch64

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -74,8 +74,11 @@ jobs:
   build:
     strategy:
       matrix:
-        arch: ${{ fromJson('["x86_64"]') }} # TODO: Re-add build test for aarch64 once we switched to ubuntu-2404
-    runs-on: ubuntu-latest
+        arch: ${{ fromJson(
+           ((github.repository == 'commaai/openpilot') &&
+              ((github.event_name != 'pull_request') ||
+               (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && '["x86_64", "aarch64"]' || '["x86_64"]' ) }}
+    runs-on: ${{ (matrix.arch == 'aarch64') && 'namespace-profile-arm64-2x8' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -84,7 +87,7 @@ jobs:
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
       run: |
         echo "PUSH_IMAGE=true" >> "$GITHUB_ENV"
-        : # (TODO: Re-add this once we test other archs) echo "TARGET_ARCHITECTURE=${{ matrix.arch }}" >> "$GITHUB_ENV"
+        echo "TARGET_ARCHITECTURE=${{ matrix.arch }}" >> "$GITHUB_ENV"
         $DOCKER_LOGIN
     - uses: ./.github/workflows/setup-with-retry
       with:
@@ -117,6 +120,23 @@ jobs:
           scons-${{ runner.arch }}-macos
     - name: Building openpilot
       run: . .venv/bin/activate && scons -j$(nproc)
+
+  docker_push_multiarch:
+    name: docker push multiarch tag
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/openpilot'
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: false
+    - name: Setup docker
+      run: |
+        $DOCKER_LOGIN
+    - name: Merge x64 and arm64 tags
+      run: |
+        export PUSH_IMAGE=true
+        scripts/retry.sh selfdrive/test/docker_tag_multiarch.sh base x86_64 aarch64
 
   static_analysis:
     name: static analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
   "websocket_client",
 
   # acados deps
-  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64'",
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.12'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.11'",
   "casadi; platform_machine == 'x86_64'",
   "future-fstrings",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,7 @@ dependencies = [
 
   # acados deps
   "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.12'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
-  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.11'",
-  "casadi; platform_machine == 'x86_64'",
+  "casadi; platform_machine == 'x86_64' or (python_version != '3.12' and platform_machine == 'aarch64') ",
   "future-fstrings",
 
   # these should be removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "websocket_client",
 
   # acados deps
-  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.12' and platform_system == 'Linux'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl ; (python_version == '3.12' and platform_machine == 'aarch64')", # TODO: Go back to pypi casadi when they fix aarch64 for python312
   "casadi; platform_machine != 'aarch64' or python_version != '3.12'",
   "future-fstrings",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "websocket_client",
 
   # acados deps
-  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl ; (python_version == '3.12' and platform_machine == 'aarch64')", # TODO: Go back to pypi casadi when they fix aarch64 for python312
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.6/casadi-3.6.6-cp312-none-manylinux2014_aarch64.whl ; (python_version == '3.12' and platform_machine == 'aarch64')", # TODO: Go back to pypi casadi when they fix aarch64 for python312
   "casadi; platform_machine != 'aarch64' or python_version != '3.12'",
   "future-fstrings",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
   "websocket_client",
 
   # acados deps
-  "casadi",
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64'",
+  "casadi; platform_machine == 'x86_64'",
   "future-fstrings",
 
   # these should be removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "websocket_client",
 
   # acados deps
-  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64'",
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64'",
   "casadi; platform_machine == 'x86_64'",
   "future-fstrings",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,10 @@ dependencies = [
   "websocket_client",
 
   # acados deps
-  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.12'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
-  "casadi; platform_machine == 'x86_64' or (python_version != '3.12' and platform_machine == 'aarch64') ",
+  #"casadi; platform_machine == 'x86_64' ",
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.11' and platform_system == 'Linux'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
+  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.12' and platform_system == 'Linux'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
+  "casadi; platform_machine != 'aarch64'",
   "future-fstrings",
 
   # these should be removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,8 @@ dependencies = [
   "websocket_client",
 
   # acados deps
-  #"casadi; platform_machine == 'x86_64' ",
-  "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.11' and platform_system == 'Linux'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
   "casadi @ https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl ; platform_machine == 'aarch64' and python_version == '3.12' and platform_system == 'Linux'", # TODO: Go back to pypi casadi when they fix aarch64 for python312
-  "casadi; platform_machine != 'aarch64'",
+  "casadi; platform_machine != 'aarch64' or python_version != '3.12'",
   "future-fstrings",
 
   # these should be removed

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -109,7 +109,7 @@ if GetOption('extras') and arch != "Darwin":
     obj = senv.Object(f"installer/installers/installer_{name}.o", ["installer/installer.cc"], CPPDEFINES=d)
     f = senv.Program(f"installer/installers/installer_{name}", [obj, cont], LIBS=qt_libs)
     # keep installers small
-    assert f[0].get_size() < 350*1e3
+    assert f[0].get_size() < 370*1e3
 
 # build watch3
 if arch in ['x86_64', 'aarch64', 'Darwin'] or GetOption('extras'):

--- a/third_party/libyuv/larch64/lib/libyuv.a
+++ b/third_party/libyuv/larch64/lib/libyuv.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85e765be665eab8ce8b64d6a884148e0ff3905fadcef6c0daa75e4efd84bb5cb
-size 499734
+oid sha256:320bef5a75a62dd2731a496040921d5000f1ed237ae70fd7aeb6c010a1534363
+size 462482

--- a/uv.lock
+++ b/uv.lock
@@ -203,6 +203,17 @@ wheels = [
 
 [[distribution]]
 name = "casadi"
+version = "3.6.5.dev0+python312.aarch64"
+source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:d961f418ed42ab05b8e76c53a2c4f87a40679e056e09f33b9d555ac824f15aa1" },
+]
+
+[[distribution]]
+name = "casadi"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -225,14 +236,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/49/551760cdcedcd8d0fd7109d620c7c9e332cb8a706b2bd1beec6e4fda1cd1/casadi-3.6.5-cp312-none-manylinux2014_i686.whl", hash = "sha256:be40e9897d80fb72a97e750b2143c32f63f8800cfb78f9b396d8ce7a913fca39", size = 69777406 },
     { url = "https://files.pythonhosted.org/packages/ff/17/2f97a9638072216448b50fd14855939abeff1632edac92739683ffac9b08/casadi-3.6.5-cp312-none-manylinux2014_x86_64.whl", hash = "sha256:0118637823e292a9270133e02c9c6d3f3c7f75e8c91a6f6dc5275ade82dd1d9d", size = 72311551 },
     { url = "https://files.pythonhosted.org/packages/88/08/c55e2172f033a44b831ee771bb32fa89c369311c0598a52c03755f29a75e/casadi-3.6.5-cp312-none-win_amd64.whl", hash = "sha256:fe2b64d777e36cc3f101220dd1e219a0e11c3e4ee2b5e708b30fea9a27107e41", size = 43057681 },
-]
-
-[[distribution]]
-name = "casadi"
-version = "3.6.5"
-source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl" }
-wheels = [
-    { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:a593fe09150274af809a207129ada14314c637dc8b0d394a2ec8abb3feba7533" },
 ]
 
 [[distribution]]
@@ -1533,7 +1536,8 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '3.12' or python_version > '3.12' or platform_machine != 'aarch64' or (python_version == '3.12' and platform_machine == 'aarch64' and platform_system == 'Linux')" },
+    { name = "casadi", version = "3.6.5.dev0+python312.aarch64", source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }, marker = "python_version == '3.12' and platform_machine == 'aarch64'" },
+    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '3.12' or python_version > '3.12' or platform_machine != 'aarch64'" },
     { name = "cffi" },
     { name = "crcmod" },
     { name = "cython" },

--- a/uv.lock
+++ b/uv.lock
@@ -230,14 +230,6 @@ wheels = [
 [[distribution]]
 name = "casadi"
 version = "3.6.5"
-source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl" }
-wheels = [
-    { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:711f97f31212d13d31070a87d68b8abffbfb1fadfb29f760581f501e98427a04" },
-]
-
-[[distribution]]
-name = "casadi"
-version = "3.6.5"
 source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl" }
 wheels = [
     { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:a593fe09150274af809a207129ada14314c637dc8b0d394a2ec8abb3feba7533" },
@@ -1541,7 +1533,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' or (python_version == '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux') or (python_version == '3.12' and platform_machine == 'aarch64' and platform_system == 'Linux')" },
+    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '3.12' or python_version > '3.12' or platform_machine != 'aarch64' or (python_version == '3.12' and platform_machine == 'aarch64' and platform_system == 'Linux')" },
     { name = "cffi" },
     { name = "crcmod" },
     { name = "cython" },

--- a/uv.lock
+++ b/uv.lock
@@ -230,6 +230,14 @@ wheels = [
 [[distribution]]
 name = "casadi"
 version = "3.6.5"
+source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl" }
+wheels = [
+    { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:711f97f31212d13d31070a87d68b8abffbfb1fadfb29f760581f501e98427a04" },
+]
+
+[[distribution]]
+name = "casadi"
+version = "3.6.5"
 source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl" }
 wheels = [
     { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:a593fe09150274af809a207129ada14314c637dc8b0d394a2ec8abb3feba7533" },
@@ -1533,7 +1541,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' or (python_version == '3.12' and platform_machine == 'aarch64') or (platform_machine == 'aarch64' and (python_version < '3.12' or python_version > '3.12'))" },
+    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' or (python_version == '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux') or (python_version == '3.12' and platform_machine == 'aarch64' and platform_system == 'Linux')" },
     { name = "cffi" },
     { name = "crcmod" },
     { name = "cython" },

--- a/uv.lock
+++ b/uv.lock
@@ -204,12 +204,12 @@ wheels = [
 [[distribution]]
 name = "casadi"
 version = "3.6.5.dev0+python312.aarch64"
-source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl" }
+source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }
 dependencies = [
     { name = "numpy" },
 ]
 wheels = [
-    { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:f2f15ca5680061926c2b7205e4f1ed1d387a77c23b35d7fac9fcae11ee1b405e" },
+    { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:d961f418ed42ab05b8e76c53a2c4f87a40679e056e09f33b9d555ac824f15aa1" },
 ]
 
 [[distribution]]
@@ -1536,7 +1536,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi", version = "3.6.5.dev0+python312.aarch64", source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl" }, marker = "platform_machine == 'aarch64'" },
+    { name = "casadi", version = "3.6.5.dev0+python312.aarch64", source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }, marker = "platform_machine == 'aarch64'" },
     { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
     { name = "cffi" },
     { name = "crcmod" },

--- a/uv.lock
+++ b/uv.lock
@@ -203,17 +203,6 @@ wheels = [
 
 [[distribution]]
 name = "casadi"
-version = "3.6.5.dev0+python312.aarch64"
-source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }
-dependencies = [
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:d961f418ed42ab05b8e76c53a2c4f87a40679e056e09f33b9d555ac824f15aa1" },
-]
-
-[[distribution]]
-name = "casadi"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -236,6 +225,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/49/551760cdcedcd8d0fd7109d620c7c9e332cb8a706b2bd1beec6e4fda1cd1/casadi-3.6.5-cp312-none-manylinux2014_i686.whl", hash = "sha256:be40e9897d80fb72a97e750b2143c32f63f8800cfb78f9b396d8ce7a913fca39", size = 69777406 },
     { url = "https://files.pythonhosted.org/packages/ff/17/2f97a9638072216448b50fd14855939abeff1632edac92739683ffac9b08/casadi-3.6.5-cp312-none-manylinux2014_x86_64.whl", hash = "sha256:0118637823e292a9270133e02c9c6d3f3c7f75e8c91a6f6dc5275ade82dd1d9d", size = 72311551 },
     { url = "https://files.pythonhosted.org/packages/88/08/c55e2172f033a44b831ee771bb32fa89c369311c0598a52c03755f29a75e/casadi-3.6.5-cp312-none-win_amd64.whl", hash = "sha256:fe2b64d777e36cc3f101220dd1e219a0e11c3e4ee2b5e708b30fea9a27107e41", size = 43057681 },
+]
+
+[[distribution]]
+name = "casadi"
+version = "3.6.5"
+source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl" }
+wheels = [
+    { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:711f97f31212d13d31070a87d68b8abffbfb1fadfb29f760581f501e98427a04" },
+]
+
+[[distribution]]
+name = "casadi"
+version = "3.6.5"
+source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl" }
+wheels = [
+    { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:a593fe09150274af809a207129ada14314c637dc8b0d394a2ec8abb3feba7533" },
 ]
 
 [[distribution]]
@@ -1536,8 +1541,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi", version = "3.6.5.dev0+python312.aarch64", source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }, marker = "platform_machine == 'aarch64'" },
-    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
+    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' or (python_version == '3.11' and platform_machine == 'aarch64') or (python_version == '3.12' and platform_machine == 'aarch64')" },
     { name = "cffi" },
     { name = "crcmod" },
     { name = "cython" },

--- a/uv.lock
+++ b/uv.lock
@@ -203,6 +203,17 @@ wheels = [
 
 [[distribution]]
 name = "casadi"
+version = "3.6.5.dev0+python312.aarch64"
+source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:f2f15ca5680061926c2b7205e4f1ed1d387a77c23b35d7fac9fcae11ee1b405e" },
+]
+
+[[distribution]]
+name = "casadi"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -1525,7 +1536,8 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi" },
+    { name = "casadi", version = "3.6.5.dev0+python312.aarch64", source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp311-none-manylinux2014_aarch64.whl" }, marker = "platform_machine == 'aarch64'" },
+    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
     { name = "cffi" },
     { name = "crcmod" },
     { name = "cython" },

--- a/uv.lock
+++ b/uv.lock
@@ -203,17 +203,6 @@ wheels = [
 
 [[distribution]]
 name = "casadi"
-version = "3.6.5.dev0+python312.aarch64"
-source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }
-dependencies = [
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:d961f418ed42ab05b8e76c53a2c4f87a40679e056e09f33b9d555ac824f15aa1" },
-]
-
-[[distribution]]
-name = "casadi"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -236,6 +225,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/49/551760cdcedcd8d0fd7109d620c7c9e332cb8a706b2bd1beec6e4fda1cd1/casadi-3.6.5-cp312-none-manylinux2014_i686.whl", hash = "sha256:be40e9897d80fb72a97e750b2143c32f63f8800cfb78f9b396d8ce7a913fca39", size = 69777406 },
     { url = "https://files.pythonhosted.org/packages/ff/17/2f97a9638072216448b50fd14855939abeff1632edac92739683ffac9b08/casadi-3.6.5-cp312-none-manylinux2014_x86_64.whl", hash = "sha256:0118637823e292a9270133e02c9c6d3f3c7f75e8c91a6f6dc5275ade82dd1d9d", size = 72311551 },
     { url = "https://files.pythonhosted.org/packages/88/08/c55e2172f033a44b831ee771bb32fa89c369311c0598a52c03755f29a75e/casadi-3.6.5-cp312-none-win_amd64.whl", hash = "sha256:fe2b64d777e36cc3f101220dd1e219a0e11c3e4ee2b5e708b30fea9a27107e41", size = 43057681 },
+]
+
+[[distribution]]
+name = "casadi"
+version = "3.6.6"
+source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.6/casadi-3.6.6-cp312-none-manylinux2014_aarch64.whl" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.6/casadi-3.6.6-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:06a15e0099657b960620a2491e565c7f126030018da80c39f6bd33439160c669" },
 ]
 
 [[distribution]]
@@ -1536,8 +1536,8 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi", version = "3.6.5.dev0+python312.aarch64", source = { url = "https://github.com/commaai/casadi/releases/download/nightly-python312_aarch64/casadi-3.6.5.dev+python312.aarch64-cp312-none-manylinux2014_aarch64.whl" }, marker = "python_version == '3.12' and platform_machine == 'aarch64'" },
     { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '3.12' or python_version > '3.12' or platform_machine != 'aarch64'" },
+    { name = "casadi", version = "3.6.6", source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.6/casadi-3.6.6-cp312-none-manylinux2014_aarch64.whl" }, marker = "python_version == '3.12' and platform_machine == 'aarch64'" },
     { name = "cffi" },
     { name = "crcmod" },
     { name = "cython" },

--- a/uv.lock
+++ b/uv.lock
@@ -230,14 +230,6 @@ wheels = [
 [[distribution]]
 name = "casadi"
 version = "3.6.5"
-source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl" }
-wheels = [
-    { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:711f97f31212d13d31070a87d68b8abffbfb1fadfb29f760581f501e98427a04" },
-]
-
-[[distribution]]
-name = "casadi"
-version = "3.6.5"
 source = { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl" }
 wheels = [
     { url = "https://github.com/commaai/casadi/releases/download/nightly-release-3.6.5/casadi-3.6.5-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:a593fe09150274af809a207129ada14314c637dc8b0d394a2ec8abb3feba7533" },
@@ -1541,7 +1533,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
-    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' or (python_version == '3.11' and platform_machine == 'aarch64') or (python_version == '3.12' and platform_machine == 'aarch64')" },
+    { name = "casadi", version = "3.6.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' or (python_version == '3.12' and platform_machine == 'aarch64') or (platform_machine == 'aarch64' and (python_version < '3.12' or python_version > '3.12'))" },
     { name = "cffi" },
     { name = "crcmod" },
     { name = "cython" },


### PR DESCRIPTION
- seems to have problems building with the old libyuv -> built new one
- tested on 24.04 and 20.04