### PR TITLE
Nissan/carcontroller: add max steering angle safeguard for nissan

### DIFF
--- a/selfdrive/car/nissan/carcontroller.py
+++ b/selfdrive/car/nissan/carcontroller.py
@@ -12,6 +12,7 @@ VisualAlert = car.CarControl.HUDControl.VisualAlert
 #   CANPacker packs wrong angle output to be decoded by panda
 MAX_STEER_ANGLE = 1310
 
+
 class CarController(CarControllerBase):
   def __init__(self, dbc_name, CP, VM):
     self.CP = CP

--- a/selfdrive/car/nissan/carcontroller.py
+++ b/selfdrive/car/nissan/carcontroller.py
@@ -8,10 +8,6 @@ from openpilot.selfdrive.car.nissan.values import CAR, CarControllerParams
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 
-# When output steering Angle not within range -1311 and 1310,
-#   CANPacker packs wrong angle output to be decoded by panda
-MAX_STEER_ANGLE = 1310
-
 
 class CarController(CarControllerBase):
   def __init__(self, dbc_name, CP, VM):
@@ -54,7 +50,7 @@ class CarController(CarControllerBase):
       apply_angle = CS.out.steeringAngleDeg
       self.lkas_max_torque = 0
 
-    self.apply_angle_last = clip(apply_angle, -MAX_STEER_ANGLE, MAX_STEER_ANGLE)
+    self.apply_angle_last = clip(apply_angle, -CarControllerParams.MAX_STEER_ANGLE, CarControllerParams.MAX_STEER_ANGLE)
 
     if self.CP.carFingerprint in (CAR.NISSAN_ROGUE, CAR.NISSAN_XTRAIL, CAR.NISSAN_ALTIMA) and pcm_cancel_cmd:
       can_sends.append(nissancan.create_acc_cancel_cmd(self.packer, self.car_fingerprint, CS.cruise_throttle_msg))

--- a/selfdrive/car/nissan/carcontroller.py
+++ b/selfdrive/car/nissan/carcontroller.py
@@ -1,5 +1,6 @@
 from cereal import car
 from opendbc.can.packer import CANPacker
+from openpilot.common.numpy_fast import clip
 from openpilot.selfdrive.car import apply_std_steer_angle_limits
 from openpilot.selfdrive.car.interfaces import CarControllerBase
 from openpilot.selfdrive.car.nissan import nissancan
@@ -7,6 +8,9 @@ from openpilot.selfdrive.car.nissan.values import CAR, CarControllerParams
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 
+# When output steering Angle not within range -1311 and 1310,
+#   CANPacker packs wrong angle output to be decoded by panda
+MAX_STEER_ANGLE = 1310
 
 class CarController(CarControllerBase):
   def __init__(self, dbc_name, CP, VM):
@@ -49,6 +53,7 @@ class CarController(CarControllerBase):
       apply_angle = CS.out.steeringAngleDeg
       self.lkas_max_torque = 0
 
+    apply_angle = clip(apply_angle, -MAX_STEER_ANGLE, MAX_STEER_ANGLE)
     self.apply_angle_last = apply_angle
 
     if self.CP.carFingerprint in (CAR.NISSAN_ROGUE, CAR.NISSAN_XTRAIL, CAR.NISSAN_ALTIMA) and pcm_cancel_cmd:

--- a/selfdrive/car/nissan/carcontroller.py
+++ b/selfdrive/car/nissan/carcontroller.py
@@ -54,8 +54,7 @@ class CarController(CarControllerBase):
       apply_angle = CS.out.steeringAngleDeg
       self.lkas_max_torque = 0
 
-    apply_angle = clip(apply_angle, -MAX_STEER_ANGLE, MAX_STEER_ANGLE)
-    self.apply_angle_last = apply_angle
+    self.apply_angle_last = clip(apply_angle, -MAX_STEER_ANGLE, MAX_STEER_ANGLE)
 
     if self.CP.carFingerprint in (CAR.NISSAN_ROGUE, CAR.NISSAN_XTRAIL, CAR.NISSAN_ALTIMA) and pcm_cancel_cmd:
       can_sends.append(nissancan.create_acc_cancel_cmd(self.packer, self.car_fingerprint, CS.cruise_throttle_msg))

--- a/selfdrive/car/nissan/nissancan.py
+++ b/selfdrive/car/nissan/nissancan.py
@@ -1,11 +1,15 @@
 import crcmod
-from openpilot.selfdrive.car.nissan.values import CAR
+import warnings
+from openpilot.selfdrive.car.nissan.values import CAR, CarControllerParams
 
 # TODO: add this checksum to the CANPacker
 nissan_checksum = crcmod.mkCrcFun(0x11d, initCrc=0x00, rev=False, xorOut=0xff)
 
 
 def create_steering_control(packer, apply_steer, frame, steer_on, lkas_max_torque):
+  if not (-CarControllerParams.MAX_STEER_ANGLE <= apply_steer <= CarControllerParams.MAX_STEER_ANGLE):
+    warnings.warn(f"Nissan apply steering angle is out of bound: {apply_steer}", RuntimeWarning, stacklevel=1)
+
   values = {
     "COUNTER": frame % 0x10,
     "DESIRED_ANGLE": apply_steer,

--- a/selfdrive/car/nissan/values.py
+++ b/selfdrive/car/nissan/values.py
@@ -15,6 +15,10 @@ class CarControllerParams:
   LKAS_MAX_TORQUE = 1               # A value of 1 is easy to overpower
   STEER_THRESHOLD = 1.0
 
+  # When output steering Angle not within range -1311 and 1310,
+  #   CANPacker packs wrong angle output to be decoded by panda
+  MAX_STEER_ANGLE = 1310
+
   def __init__(self, CP):
     pass
 


### PR DESCRIPTION
Resolves: https://github.com/commaai/opendbc/issues/1145

Unlikely this is going to happen in real scenario, but I think it's worth to have a safeguard. It seems that panda decodes by adding a 1310 offset to the angle

https://github.com/commaai/panda/blob/f6375848ca393a9483921665b6a2d131d7ec9b20/board/safety/safety_nissan.h#L107