### PR TITLE
make pyproject.toml pep508 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dev = [
   "inputs",
   "lru-dict",
   "matplotlib",
-  "metadrive-simulator; platform_machine != 'aarch64'",
+  "metadrive-simulator@git+https://github.com/commaai/metadrive@opencv_headless ; platform_machine != 'aarch64'",
   "mpld3",
   "myst-parser",
   "natsort",
@@ -122,9 +122,6 @@ dev = [
 
 ]
 
-[tool.uv.sources]
-metadrive-simulator = { git = "https://github.com/commaai/metadrive.git", branch = "opencv_headless" }
-
 [project.urls]
 Homepage = "https://comma.ai"
 
@@ -134,6 +131,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = [ "." ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -214,12 +214,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/a6/edb201c436c820779b1f4e2bf5a74b6fd5e4d7d7b703336e5c0518e1b08f/casadi-3.6.5-cp27-none-manylinux1_i686.whl", hash = "sha256:b5192dfabf6f5266b168b984d124dd3086c1c5a408c0743ff3a82290a8ccf3b5", size = 47956673 },
     { url = "https://files.pythonhosted.org/packages/f7/4d/6c8f37e08a3a91a69be8fffa67ce4a27823d3d4ca2099312f938690938f9/casadi-3.6.5-cp27-none-manylinux2010_x86_64.whl", hash = "sha256:35b2ff6098e386a4d5e8bc681744e52bcd2f2f15cfa44c09814a8979b51a6794", size = 53936205 },
     { url = "https://files.pythonhosted.org/packages/b5/95/1a087e511ded93ab74f3a0adf36a4beaee22ce30d2951ab7115dad3d26b5/casadi-3.6.5-cp27-none-win_amd64.whl", hash = "sha256:caf395d1e36bfb215b154e8df61583d534a07ddabb18cbe50f259b7692a41ac8", size = 43027309 },
-    { url = "https://files.pythonhosted.org/packages/a6/29/11a974e24bdaa50c0ee4c03b8631c7cfed65b5caba5123d91331d4cb969b/casadi-3.6.5-cp310-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:314886ef44bd01f1a98579e7784a3bed6e0584e88f9465cf9596af2523efb0dd", size = 42876397 },
-    { url = "https://files.pythonhosted.org/packages/31/57/28043eca210517b9071ef41e4b965ed3f9366e4441b6af5d172466b76d5e/casadi-3.6.5-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:c6789c8060a99b329bb584d97c1eab6a5e4f3e2d2db391e6c2001c6323774990", size = 40753981 },
-    { url = "https://files.pythonhosted.org/packages/56/21/ef9baac75ada94da8d2470578533cbd3a48755277e9dbcd2d65b954678c2/casadi-3.6.5-cp310-none-manylinux2014_aarch64.whl", hash = "sha256:e40afb3c062817dd6ce2497cd001f00f107ee1ea41ec4d6ee9f9a5056d219e83", size = 42905440 },
-    { url = "https://files.pythonhosted.org/packages/3d/89/0bfc9a71d632750685763751698b233f5a9622cea8fbdb03f94bcfe04950/casadi-3.6.5-cp310-none-manylinux2014_i686.whl", hash = "sha256:ee5a4ed50d2becd0bd6d203c7a60ffad27c14a3e0ae357480de11c846a8dd928", size = 69778574 },
-    { url = "https://files.pythonhosted.org/packages/b4/b0/1289804327602e892c36f14fa2b4492afbeee8f465a365c8759b03186f1c/casadi-3.6.5-cp310-none-manylinux2014_x86_64.whl", hash = "sha256:1ddb6e4afdd1da95d7d9d652ed973c1b7f50ef1454965a9170b657e223a2c73e", size = 72306982 },
-    { url = "https://files.pythonhosted.org/packages/b3/bc/95a28e081c303b876b1fd85edc3acc26f73430c056b5aea273ece5765c66/casadi-3.6.5-cp310-none-win_amd64.whl", hash = "sha256:e96ca81b00b9621007d45db1254fcf232d518ebcc802f42853f57b4df977c567", size = 43057148 },
     { url = "https://files.pythonhosted.org/packages/7b/fa/7198dff19f2d6d511c220f1815709581ff9e533403cfeebe187f204f68b2/casadi-3.6.5-cp311-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:bebd3909db24ba711e094aacc0a2329b9903d422d73f61be851873731244b7d1", size = 42876397 },
     { url = "https://files.pythonhosted.org/packages/3d/fc/2ba7f33fa843f56cc4df55b4027a037f7f34e8396bd585003f113ee6bcfa/casadi-3.6.5-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:ccb962ea02b7d6d245d5cd40fb52c29e812040a45273c6eed32cb8fcff673dda", size = 40752910 },
     { url = "https://files.pythonhosted.org/packages/1f/c1/2a3290487330fa334c3a86308f9378dce226a7f0f3f7bd11a8f70ac47d3b/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:1ce199a4ea1d376edbe5399cd622a4564040c83f50c50114fe50a69a8ea81d92", size = 42905415 },
@@ -231,32 +225,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/49/551760cdcedcd8d0fd7109d620c7c9e332cb8a706b2bd1beec6e4fda1cd1/casadi-3.6.5-cp312-none-manylinux2014_i686.whl", hash = "sha256:be40e9897d80fb72a97e750b2143c32f63f8800cfb78f9b396d8ce7a913fca39", size = 69777406 },
     { url = "https://files.pythonhosted.org/packages/ff/17/2f97a9638072216448b50fd14855939abeff1632edac92739683ffac9b08/casadi-3.6.5-cp312-none-manylinux2014_x86_64.whl", hash = "sha256:0118637823e292a9270133e02c9c6d3f3c7f75e8c91a6f6dc5275ade82dd1d9d", size = 72311551 },
     { url = "https://files.pythonhosted.org/packages/88/08/c55e2172f033a44b831ee771bb32fa89c369311c0598a52c03755f29a75e/casadi-3.6.5-cp312-none-win_amd64.whl", hash = "sha256:fe2b64d777e36cc3f101220dd1e219a0e11c3e4ee2b5e708b30fea9a27107e41", size = 43057681 },
-    { url = "https://files.pythonhosted.org/packages/66/e7/2b24199211f92b8ba3533fe09bef42b352caccf381429e7fda449f07458b/casadi-3.6.5-cp35-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:a1ae36449adec534125d4af5be912b6fb9dafe74d1fee39f6c82263695e21ca5", size = 42869977 },
-    { url = "https://files.pythonhosted.org/packages/4d/0d/fea3604668c7bda76fa874d057a001d0006074cb6d2dca7af60d0635e1c6/casadi-3.6.5-cp35-none-manylinux1_i686.whl", hash = "sha256:32644c47fbfb643d5cf9769c7bbc94c6bdb9a40ea9c12c54af5e2754599c3186", size = 47970545 },
-    { url = "https://files.pythonhosted.org/packages/a1/5d/16cf69bb8a00059fb0e4c6e21ed5d550a99b17a1dee5e4cae304b4a1456e/casadi-3.6.5-cp35-none-manylinux2010_x86_64.whl", hash = "sha256:601b76b7afcb27b11563999f6ad1d9d2a2510ab3d00a6f4ce86a0bee97c9d17a", size = 53958472 },
-    { url = "https://files.pythonhosted.org/packages/ab/7d/9204a8c2e6a8a3f6447d2d9e5e0b177443dcd9f8b5165743f26a1335a3da/casadi-3.6.5-cp35-none-win_amd64.whl", hash = "sha256:febc645bcc0aed6d7a2bdb6e58b9a89cb8f74b19bc028c41cc807d75a5d54058", size = 43041688 },
-    { url = "https://files.pythonhosted.org/packages/a8/e4/a5ae1ef8909b26dd7c4ab7f5303a3ac298c143661b437d9070c0608d35ae/casadi-3.6.5-cp36-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:c98e68023c9e5905d9d6b99ae1fbbfe4b85ba9846b3685408bb498b20509f99a", size = 42869977 },
-    { url = "https://files.pythonhosted.org/packages/22/57/e7d2fad22a74f0ef7a5e4fc2ec77fbf11258743b94a0bbffa73f9cbdc468/casadi-3.6.5-cp36-none-manylinux2014_aarch64.whl", hash = "sha256:eb311088dca5359acc05aa4d8895bf99afaa16c7c04b27bf640ce4c2361b8cde", size = 42899148 },
-    { url = "https://files.pythonhosted.org/packages/d8/b5/c2dd2ff700d03db674cfacfa97678d7b6621cf02b47e9553616de48b3970/casadi-3.6.5-cp36-none-manylinux2014_i686.whl", hash = "sha256:bceb69bf9f04fded8a564eb64e298d19e945eaf4734f7145a5ee61cf9ac693e7", size = 69772344 },
-    { url = "https://files.pythonhosted.org/packages/92/fb/4c6b4682084eb8b567a909bea7d03b4f0bad00bdcf66aea4f29fd1dda66f/casadi-3.6.5-cp36-none-manylinux2014_x86_64.whl", hash = "sha256:c951031e26d987986dbc334492b2e6ef108077f11c00e178ff4007e4a9bf91d8", size = 72306252 },
-    { url = "https://files.pythonhosted.org/packages/8d/33/7c90f3fcb4dae99f9052a494d98c9d0c8c8b22cdca169af847a5ea4e9bb7/casadi-3.6.5-cp36-none-win_amd64.whl", hash = "sha256:e44af450ce944649932f9ef63ff00d2d21f642b506444418b4b20e69dba3adaf", size = 43041687 },
-    { url = "https://files.pythonhosted.org/packages/fd/28/b22c8206615ca24f71c2ea52ff552e74d6eb0afc850750ad8bd97d778a6d/casadi-3.6.5-cp37-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:c661fe88a93b7cc7ea42802aac76a674135cd65e3e564a6f08570dd3bea05201", size = 42869949 },
-    { url = "https://files.pythonhosted.org/packages/14/40/d5c1d9b3e964ef295eee7cc518c8e1abd7cb92bbfc6dcd74f9aa30839731/casadi-3.6.5-cp37-none-manylinux2014_aarch64.whl", hash = "sha256:5266fc82e39352e26cb1a4e0a5c3deb32d09e6333be637bd78c273fa50f9012b", size = 42899157 },
-    { url = "https://files.pythonhosted.org/packages/26/b3/85ff05610e862a90f70daa4e58772dc9719dde2a5481ff293ca27e056729/casadi-3.6.5-cp37-none-manylinux2014_i686.whl", hash = "sha256:02d6fb63c460abd99a450e861034d97568a8aec621fc0a4fed22f7494989c682", size = 69773643 },
-    { url = "https://files.pythonhosted.org/packages/6b/e4/12562e3b7411afc15f923fbd9a39d065590e48e5949a395114b4e3825e56/casadi-3.6.5-cp37-none-manylinux2014_x86_64.whl", hash = "sha256:5e8adffe2015cde370fc545b2d0fe731e96e583e4ea4c5f3044e818fea975cfc", size = 72306085 },
-    { url = "https://files.pythonhosted.org/packages/bb/0d/6af19e039d99342200b9418063501c0555a57e27b461a3112812422c854f/casadi-3.6.5-cp37-none-win_amd64.whl", hash = "sha256:7ea8545579872b6f5412985dafec26b906b67bd4639a6c718b7e07f802af4e42", size = 43041620 },
-    { url = "https://files.pythonhosted.org/packages/b6/67/68eebae41a005e3897dd69b83680f18a1548b2132b87e13b595cea83b0f1/casadi-3.6.5-cp38-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:0a38bf808bf51368607c64307dd77a7363fbe8e5c910cd5c605546be60edfaff", size = 42876576 },
-    { url = "https://files.pythonhosted.org/packages/d3/1d/faed4b8b127d336e27753d7f9ef6895edcf4697e0f027e9eb4f934fef49d/casadi-3.6.5-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:f62f779481b30e5ea88392bdb8225e9545a21c4460dc3e96c2b782405b938d04", size = 40757892 },
-    { url = "https://files.pythonhosted.org/packages/bf/6b/b47ff3b2dfc61cf0abbb0516f1621488afa199c0d79266d627e1e4c840c3/casadi-3.6.5-cp38-none-manylinux2014_aarch64.whl", hash = "sha256:deb2cb2bee8aba0c2cad03c832965b51ca305d0f8eb15de8b857ba86a76f0db0", size = 42906110 },
-    { url = "https://files.pythonhosted.org/packages/f6/0a/55839ba892dd3371b1ef96722fc11241834012c9fe5bef8396239470e244/casadi-3.6.5-cp38-none-manylinux2014_i686.whl", hash = "sha256:f6e10b66d6ae8216dab01532f7ad75cc9d66a95125d421b33d078a51ea0fc2a0", size = 69780479 },
-    { url = "https://files.pythonhosted.org/packages/70/25/b4aadc6efbab3603b9f344e09e415fd79cded82e3934d7ade6fd25c4df6e/casadi-3.6.5-cp38-none-manylinux2014_x86_64.whl", hash = "sha256:f9e82658c910e3317535d769334260e0a24d97bbce68cadb72f592e9fcbafd61", size = 72307901 },
-    { url = "https://files.pythonhosted.org/packages/07/e2/d859726b623a6239fcb3a95b78bc2aa932d9e162cf5755bd7ec942b02623/casadi-3.6.5-cp38-none-win_amd64.whl", hash = "sha256:092e448e05feaed8958d684e896d909e756d199b84d3b9d0182da38cd3deebf6", size = 43054557 },
-    { url = "https://files.pythonhosted.org/packages/42/32/0924ac73b83258322d2d4ab4aeabcc615b428e6b6e60eb72fc068428d4e0/casadi-3.6.5-cp39-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:f9c1de9a798767c00f89c27677b74059df4c9601d69270967b06d7fcff204b4d", size = 42876397 },
-    { url = "https://files.pythonhosted.org/packages/f4/09/8f56da3a01294ccbaeecc47ef6500b43a0abd5920e99fe7cf2ea28649b12/casadi-3.6.5-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:83e3404de4449cb7382e49d811eec79cd370e64b97b5c94b155c604d7c523a40", size = 40753984 },
-    { url = "https://files.pythonhosted.org/packages/ef/7a/8eb40df7b234ffff254714b48a51ad7181496122dbc342e4b7ce714c8103/casadi-3.6.5-cp39-none-manylinux2014_aarch64.whl", hash = "sha256:af95de5aa5942d627d43312834791623384c2ad6ba87928bf0e3cacc8a6698e8", size = 42905431 },
-    { url = "https://files.pythonhosted.org/packages/a1/78/3655586496b7560e9a3a789dc8185ed3e30a48b147069b2e26e8c98c9e23/casadi-3.6.5-cp39-none-manylinux2014_i686.whl", hash = "sha256:dbeb50726603454a1f85323cba7caf72524cd43ca0aeb1f286d07005a967ece9", size = 69778788 },
-    { url = "https://files.pythonhosted.org/packages/a1/f8/06b68c5f7fa724c8ce5b5a7c269c7836efc10914d97dc0d37c497f5937b0/casadi-3.6.5-cp39-none-manylinux2014_x86_64.whl", hash = "sha256:8bbfb2eb8cb6b9e2384814d6427e48bcf6df049bf7ed05b0a58bb311a1fbf18c", size = 72306869 },
-    { url = "https://files.pythonhosted.org/packages/81/16/c413a49a582935009f6fd9e7b031c43a3b2e919c02e38de0dba1b91d776f/casadi-3.6.5-cp39-none-win_amd64.whl", hash = "sha256:0e4a4ec2e26ebeb22b0c129f2db3cf90f730cf9fbe98adb9a12720ff6ca1834a", size = 43056766 },
 ]
 
 [[distribution]]
@@ -461,7 +429,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/ea/848f064727fe172e80f8a7abc77664c593b6bece14d5acab7d7087f1244e/coverage-7.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:76d5f82213aa78098b9b964ea89de4617e70e0d43e97900c2778a50856dac605", size = 238003 },
     { url = "https://files.pythonhosted.org/packages/c2/b1/8f54a56789aecc930e227fc5900d18628d6efae4a8ad24981d58fc14b1e3/coverage-7.6.0-cp312-cp312-win32.whl", hash = "sha256:3c59105f8d58ce500f348c5b56163a4113a440dad6daa2294b5052a10db866da", size = 208686 },
     { url = "https://files.pythonhosted.org/packages/cb/db/242c44433c5d342c8bf83864131e56af8c1c1ea5645a825b1800c19ad9bf/coverage-7.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca5d79cfdae420a1d52bf177de4bc2289c321d6c961ae321503b2ca59c17ae67", size = 209455 },
-    { url = "https://files.pythonhosted.org/packages/ea/69/2b79b6b37c57cd05c85b76ec5ceabf7e091ab0f4986dfefaddbb468881c0/coverage-7.6.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:6fe885135c8a479d3e37a7aae61cbd3a0fb2deccb4dda3c25f92a49189f766d6", size = 198032 },
 ]
 
 [[distribution]]
@@ -752,6 +719,47 @@ wheels = [
 ]
 
 [[distribution]]
+name = "grimp"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/6c/6b071cc23c6c643b333af6f54147b59687e79b3a49bba80b4a0627bc5d90/grimp-3.4.1.tar.gz", hash = "sha256:c743c989ea49582171a93ac5aa0d22ecf04fd57143f956b3e35b6a1c7cddafec", size = 833762 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/73/9e0db6d8b2c38021cabe8a757b7cab00cd2175d08c4f026b552d39c6ec7a/grimp-3.4.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:cc6740e0b467cd4e67a43a4b4c7137a561b8118a59af1faef258ed2901dfdb52", size = 351435 },
+    { url = "https://files.pythonhosted.org/packages/44/75/87e4965da3d03cb27c606876f8e0be98fbb7f7222760472e28454b88aa05/grimp-3.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f4be0ded7b5882c5e94024c5424dd1f252da9905dca0051ca41b520d771dcb92", size = 345021 },
+    { url = "https://files.pythonhosted.org/packages/a5/cd/e61e225bf53b12f5eb1cde4f6c78649236548b44019c5f4a04537a9e7fda/grimp-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54b04f3ec0a88fa3d0da5a83560da80a53392bea35541834847bdc8bc29d38af", size = 403355 },
+    { url = "https://files.pythonhosted.org/packages/0d/89/8cb3b7e385e566f1fecd455db06324e0e6ba33d376118f9a9b98e35e7cfc/grimp-3.4.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c820bc059a2fa80a53303c1fe6923787e999c653c39f351d4d812dd1edd37217", size = 405186 },
+    { url = "https://files.pythonhosted.org/packages/ac/4e/d8effd090a36ddd6da18b5e75ac0a88e99cee704a9a42ea5d36113f94ca6/grimp-3.4.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28b383fca3271e77f690a789b756abcc01fcd6f820886ecf0ea1189c82469c85", size = 415890 },
+    { url = "https://files.pythonhosted.org/packages/d4/f2/a739d0d98142f47ede1aa1eb45f669352d14e86cd9d0f9e4926c554d1dfd/grimp-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d9a585ed5f65dba3b5aeb4176061068768362dea3a3205b305ad87e06e11a66", size = 438923 },
+    { url = "https://files.pythonhosted.org/packages/5e/ea/00dc7cc41003de2f8d2c98dd326fb1cc1ff118244992cdfffcddaa3d9efe/grimp-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:09196954a1f7f4e2388d3537fd0d6d4e89193d808a842b961431214c1eb2f689", size = 443130 },
+    { url = "https://files.pythonhosted.org/packages/fb/a4/eb40d954d4eb0db4128c18b319133997676dc50bba08104c07a2631f25b5/grimp-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44a65e100ac856050ac845d90925498c50bbbcb7fde2a4dfdb2ae19aea2b3574", size = 396429 },
+    { url = "https://files.pythonhosted.org/packages/52/78/0814d4005b62814f7d09c01af7130d5df7724842280a380676362ebfcd95/grimp-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a532febfef86fa99bb17c4e1a0bd1955ee865529595c9743572327008faaed16", size = 580018 },
+    { url = "https://files.pythonhosted.org/packages/e7/ce/86ae2ffb59f2966c89d62e455c154a4a25e7a566e367c94a36710519477f/grimp-3.4.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ed9f6c594de624f9cf5e00c793f903b445233c3e1267dc46294e0e55692a33f4", size = 666042 },
+    { url = "https://files.pythonhosted.org/packages/bb/82/c4bc5ad12c0f385d6d412730c7e231e43bf8d4e761c0e6a0a42653a360ed/grimp-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:000656b94398d62112ef0f5d8a46ea06a0c56084caf7f1d89b6360638bcb2f14", size = 589481 },
+    { url = "https://files.pythonhosted.org/packages/cd/1b/270cd24d2dc9586170c044be78b04414eb05898a70f38ebece50868a387a/grimp-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a4b0b2ee2364bcfd20c9f0a4dd42d3875b6d928d9105ff56249eb03554fb840a", size = 566755 },
+    { url = "https://files.pythonhosted.org/packages/7f/ef/890b80433b156f2184783321a9eb168e91dc2e8a17e097a0bd64cacec9a1/grimp-3.4.1-cp311-none-win32.whl", hash = "sha256:65d0dbc64b51878460c80257540e81aa502bcb1021cbefcbe5862649860822db", size = 229097 },
+    { url = "https://files.pythonhosted.org/packages/99/c6/685b7fbf50844522b3d2db0c89997835f8df3ffaed3a811d7603e5ea1933/grimp-3.4.1-cp311-none-win_amd64.whl", hash = "sha256:8a54c6bddfdb74f6c3c5c0f9c0668d0cf6299f8d3ef7767eaa319dc888c2e7e8", size = 240189 },
+    { url = "https://files.pythonhosted.org/packages/09/53/98f52df9b801d71f615e4588f34139e0cf8ae0a600c0502f61365f4f0b15/grimp-3.4.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2e4e283e7c8ab5597c4f98dd706f7cdf7c6085d966b34c00e00815d79c05a29d", size = 350902 },
+    { url = "https://files.pythonhosted.org/packages/87/cc/bab79b2460c1fdc8d147ffd427794480cbdd9a6439ddd3a07e4da9312add/grimp-3.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c085f77cc0ecd875ab11f7c5ebbaea2a7e09b8c1e3eb7bee0c29127f9f744bfc", size = 344973 },
+    { url = "https://files.pythonhosted.org/packages/94/65/f50fb78d5e8db1a51fd23c34c7ad7a3279fb28832b96477096d67bc95c8e/grimp-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5904d270dc4663c653287891b34ddfbe20c24a26053d673f41a51f949d719699", size = 403442 },
+    { url = "https://files.pythonhosted.org/packages/a0/d4/38393d4c12d94c6941b8978aaee3d3046fd7cdbc27415df5b78f9457e3a5/grimp-3.4.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011a04ed6927d1931851858331dbbe1e52f240923135bfa15dece8c78ba5b1bf", size = 405686 },
+    { url = "https://files.pythonhosted.org/packages/e6/75/a917fe65ff386f62beb2b51f7ac3f710a3f8ff4b8379cb9b1a3199335f4b/grimp-3.4.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:caed62820ee04ed115ef6a925a349f244b0c1cc2577deba6802f253eed65fbb2", size = 415748 },
+    { url = "https://files.pythonhosted.org/packages/1b/1b/8769b0e851b40dd78f4a8a4311c3f8c3e4513d6b0498720b38fee89d568e/grimp-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:762cdbb0184cadfcaaac5e16aa5fa96b805f9720edce81a5e2a85114bc335f78", size = 439676 },
+    { url = "https://files.pythonhosted.org/packages/22/69/ebf9e7c6265b24464570b01ad41d2ff087f0938cce3de953849a4ec7bea4/grimp-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:761ff441888a0e344fdea7f385275b4c4e2acdadc1dd4e71d0753a6bf34ac58e", size = 445123 },
+    { url = "https://files.pythonhosted.org/packages/38/68/c556897049b8057218990e6b044e8a4528a38b83f5d76f1887e495285b86/grimp-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0a00d521c3d41a5b257c92960ebb7f3bebdc7ea996801364c213f1ff74a5a4a", size = 396054 },
+    { url = "https://files.pythonhosted.org/packages/4c/ad/7cc7983dcd828fe72473cfb2a53502875e98d5136d570df2429120b75ee4/grimp-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c4adaac06c6f18ee4ba2dd5a2e94183e0419f5c156c427ccc27728fa4bbddd0", size = 579813 },
+    { url = "https://files.pythonhosted.org/packages/8d/a4/fefc216034465d942c33af20cc9be6b19dc76316a5f4938baef23fd09eae/grimp-3.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:84acd1ceb07a543768bc022df543f870efb90f95147e6172b75437811c364faa", size = 666867 },
+    { url = "https://files.pythonhosted.org/packages/4e/e3/17718e5b5379df057ade916d3b9bf426f5f4ccda1069e13aa269afd982ee/grimp-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0b8e9cfd0d62bf632304229afc4c4bf40c2371c9a23cefce762df1f22a7b55d1", size = 589948 },
+    { url = "https://files.pythonhosted.org/packages/6d/01/bcf152d063b2c69920e2a1c3e8b4e104b68a1d717e530f4f60804bb5c824/grimp-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c44522ffd385d99ab2f12be049c38bc60dcd09ae80b4c28c83df89ad9b9456f", size = 566425 },
+    { url = "https://files.pythonhosted.org/packages/1f/f9/a02824142dd43a86287a6dd31586b7e50beea97f80aed1c793d4a7ed60e6/grimp-3.4.1-cp312-none-win32.whl", hash = "sha256:ca8e67309b353b3e4f63bcc1f2be66ce67712a9bc9c777472dd946ab90e0614d", size = 229109 },
+    { url = "https://files.pythonhosted.org/packages/7d/f8/910deab3002c6c70909430d99854889886090f4c9bf1063b63e18747414e/grimp-3.4.1-cp312-none-win_amd64.whl", hash = "sha256:2d515079b33497d83d3bd34c47ebb6bc6cbadcb0ec5405100c15027176e618ca", size = 239266 },
+    { url = "https://files.pythonhosted.org/packages/ad/8e/7188f23347b39a0144f9f94337d6fc32fa22c5a2d79b35c545183ddca3d0/grimp-3.4.1-cp313-none-win32.whl", hash = "sha256:e3a5e969246562cb405a3acfc35a1d1a014f1764d5d0398b4d3e9b6a9f956efb", size = 228767 },
+    { url = "https://files.pythonhosted.org/packages/00/ab/fd0b42471e3bc167761e1406732b57ba9448fa7ecb9bc9af97dd55fe1c3c/grimp-3.4.1-cp313-none-win_amd64.whl", hash = "sha256:17edd54ad125a9650c8dc9ca7a57ba913043ace3f7053e51ffa900236f8fddc9", size = 239009 },
+]
+
+[[distribution]]
 name = "gymnasium"
 version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
@@ -831,6 +839,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769 },
+]
+
+[[distribution]]
+name = "import-linter"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/3a/6b433eace42d2f92cb96667f326b11582004b74acd045bf10a277761eed4/import-linter-2.0.tar.gz", hash = "sha256:b067cf0cdbf11c4f87524e32c2e3eaa62d46572e9e06511e6b453198b15b1c9a", size = 28678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/82/5a23aefe774927b45d9964282496c5228d537bb5de1e54eedce832fa4901/import_linter-2.0-py3-none-any.whl", hash = "sha256:200f9b46d20a055c1f6f514e4cd8074852261bc9c8733d028201a55be6058bb0", size = 41018 },
 ]
 
 [[distribution]]
@@ -1142,7 +1164,7 @@ wheels = [
 [[distribution]]
 name = "metadrive-simulator"
 version = "0.4.2.3"
-source = { git = "https://github.com/commaai/metadrive.git?branch=opencv_headless#9b6ddb791919249effa0573883076681514787e4" }
+source = { git = "https://github.com/commaai/metadrive?rev=opencv_headless#9b6ddb791919249effa0573883076681514787e4" }
 dependencies = [
     { name = "filelock" },
     { name = "geopandas" },
@@ -1571,6 +1593,7 @@ docs = [
 testing = [
     { name = "coverage" },
     { name = "hypothesis" },
+    { name = "import-linter" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -4623,8 +4646,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/28/6c/640e3f5c734c296a7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/28/fcaf2aeede42456538d1543aefa253d70282bf326f5f795c99233366b66f/PyQt5-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-abi3-macosx_10_13_intel.whl", hash = "sha256:894ca4ae767a8d6cf5903784b71f755073c78cb8c167eecf6e4ed6b3b055ac6a", size = 47599356 },
     { url = "https://files.pythonhosted.org/packages/91/cf/cc705497cdae04c3c0bc34f94b91e31b6585bb65eb561f18473c998caae1/PyQt5-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:29889845688a54d62820585ad5b2e0200a36b304ff3d7a555e95599f110ba4ce", size = 68328841 },
-    { url = "https://files.pythonhosted.org/packages/b7/3e/a10c682f8ee33583cdc86a0d0eafe82b39156be3771abaa219b6e50251cd/PyQt5-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-none-win32.whl", hash = "sha256:ea24f24b7679bf393dd2e4f53fe0ce65021be18304c1ff7a226c2fc5c356d0da", size = 48859916 },
-    { url = "https://files.pythonhosted.org/packages/aa/72/754c693db0e745b9fe47debc3ec52844461f090d5beff28489a0cde5ef82/PyQt5-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-none-win_amd64.whl", hash = "sha256:faaecb76ec65e12673a968e7f5bc02495957e6996f0a3fa0d98895f9e4113746", size = 56911575 },
 ]
 
 [[distribution]]


### PR DESCRIPTION
no need for `[uv.sources]` anymore