### PR TITLE
camerad: add exposure_val_percent to FrameMetadata and set in lock to avoid race condition

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -149,10 +149,7 @@ void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &fr
   framed.setMeasuredGreyFraction(frame_data.measured_grey_fraction);
   framed.setTargetGreyFraction(frame_data.target_grey_fraction);
   framed.setProcessingTime(frame_data.processing_time);
-
-  const float ev = c->cur_ev[frame_data.frame_id % 3];
-  const float perc = util::map_val(ev, c->ci->min_ev, c->ci->max_ev, 0.0f, 100.0f);
-  framed.setExposureValPercent(perc);
+  framed.setExposureValPercent(frame_data.exposure_val_percent);
   framed.setSensor(c->ci->image_sensor);
 }
 

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -35,6 +35,7 @@ typedef struct FrameMetadata {
   float gain;
   float measured_grey_fraction;
   float target_grey_fraction;
+  float exposure_val_percent;
 
   float processing_time;
 } FrameMetadata;

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -817,6 +817,7 @@ void CameraState::handle_camera_event(void *evdat) {
     meta_data.integ_lines = exposure_time;
     meta_data.measured_grey_fraction = measured_grey_fraction;
     meta_data.target_grey_fraction = target_grey_fraction;
+    meta_data.exposure_val_percent = util::map_val(cur_ev[meta_data.frame_id % 3], ci->min_ev, ci->max_ev, 0.0f, 100.0f);
     exp_lock.unlock();
 
     // dispatch


### PR DESCRIPTION
The `cur_ev` is set within a lock, as seen here: 
https://github.com/commaai/openpilot/blob/c96dbd5a0b681c76b94191d1b928e29eb2b72119/system/camerad/cameras/camera_qcom2.cc#L914-L916 

However, access to `cur_ev` for setting `FrameMetadata` was not protected by the lock, potentially causing race conditions.

This PR updates the code to ensure that access to `cur_ev` is also protected by a lock, maintaining thread safety when setting `FrameMetadata`.
