### PR TITLE
ui: fix flipped experimental path acceleration

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -175,12 +175,17 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     const auto &acceleration = sm["modelV2"].getModelV2().getAcceleration().getX();
     const int max_len = std::min<int>(scene.track_vertices.length() / 2, acceleration.size());
 
+    for (int i = 0; i < scene.track_vertices.length(); i++) {
+      qDebug() << "track_vertices[" << i << "] = " << scene.track_vertices[i];
+    }
+
     for (int i = 0; i < max_len; ++i) {
       // Some points are out of frame
-      if (scene.track_vertices[i].y() < 0 || scene.track_vertices[i].y() > height()) continue;
+      int track_vertices_idx = (scene.track_vertices.length() / 2) - i;
+      if (scene.track_vertices[track_vertices_idx].y() < 0 || scene.track_vertices[track_vertices_idx].y() > height()) continue;
 
       // Flip so 0 is bottom of frame
-      float lin_grad_point = (height() - scene.track_vertices[i].y()) / height();
+      float lin_grad_point = (height() - scene.track_vertices[track_vertices_idx].y()) / height();
 
       // speed up: 120, slow down: 0
       float path_hue = fmax(fmin(60 + acceleration[i] * 35, 120), 0);

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -177,7 +177,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
 
     for (int i = 0; i < max_len; ++i) {
       // Some points are out of frame
-      int track_idx = (scene.track_vertices.length() / 2) - i;  // points start at top right of path
+      int track_idx = (scene.track_vertices.length() / 2) - i;  // flip idx to start from bottom
       if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) continue;
 
       // Flip so 0 is bottom of frame

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -177,7 +177,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
 
     for (int i = 0; i < max_len; ++i) {
       // Some points are out of frame
-      int track_idx = (scene.track_vertices.length() / 2) - i;  // flip idx to start from bottom
+      int track_idx = (scene.track_vertices.length() / 2) - i;  // flip idx to start from top
       if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) continue;
 
       // Flip so 0 is bottom of frame

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -175,17 +175,13 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     const auto &acceleration = sm["modelV2"].getModelV2().getAcceleration().getX();
     const int max_len = std::min<int>(scene.track_vertices.length() / 2, acceleration.size());
 
-    for (int i = 0; i < scene.track_vertices.length(); i++) {
-      qDebug() << "track_vertices[" << i << "] = " << scene.track_vertices[i];
-    }
-
     for (int i = 0; i < max_len; ++i) {
       // Some points are out of frame
-      int track_vertices_idx = (scene.track_vertices.length() / 2) - i;
-      if (scene.track_vertices[track_vertices_idx].y() < 0 || scene.track_vertices[track_vertices_idx].y() > height()) continue;
+      int track_idx = (scene.track_vertices.length() / 2) - i;  // points start at top right of path
+      if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) continue;
 
       // Flip so 0 is bottom of frame
-      float lin_grad_point = (height() - scene.track_vertices[track_vertices_idx].y()) / height();
+      float lin_grad_point = (height() - scene.track_vertices[track_idx].y()) / height();
 
       // speed up: 120, slow down: 0
       float path_hue = fmax(fmin(60 + acceleration[i] * 35, 120), 0);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -56,6 +56,7 @@ void update_leads(UIState *s, const cereal::RadarState::Reader &radar_state, con
 
 void update_line_data(const UIState *s, const cereal::XYZTData::Reader &line,
                       float y_off, float z_off, QPolygonF *pvd, int max_idx, bool allow_invert=true) {
+  qDebug() << "\n";
   const auto line_x = line.getX(), line_y = line.getY(), line_z = line.getZ();
   QPointF left, right;
   pvd->clear();
@@ -70,6 +71,7 @@ void update_line_data(const UIState *s, const cereal::XYZTData::Reader &line,
       if (!allow_invert && pvd->size() && left.y() > pvd->back().y()) {
         continue;
       }
+      qDebug() << i << left << right;
       pvd->push_back(left);
       pvd->push_front(right);
     }

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -56,7 +56,6 @@ void update_leads(UIState *s, const cereal::RadarState::Reader &radar_state, con
 
 void update_line_data(const UIState *s, const cereal::XYZTData::Reader &line,
                       float y_off, float z_off, QPolygonF *pvd, int max_idx, bool allow_invert=true) {
-  qDebug() << "\n";
   const auto line_x = line.getX(), line_y = line.getY(), line_z = line.getZ();
   QPointF left, right;
   pvd->clear();
@@ -71,7 +70,6 @@ void update_line_data(const UIState *s, const cereal::XYZTData::Reader &line,
       if (!allow_invert && pvd->size() && left.y() > pvd->back().y()) {
         continue;
       }
-      qDebug() << i << left << right;
       pvd->push_back(left);
       pvd->push_front(right);
     }


### PR DESCRIPTION
`scene.track_vertices` starts at the top right of the path now after https://github.com/commaai/openpilot/pull/32354, whereas before it was assumed it was bottom left

Here the car was still braking for this intersection but the colors are flipped:

Current:

![image](https://github.com/user-attachments/assets/2ebe2643-9bc8-4340-ab88-2d5fb2c6e57f)

Now:

![image](https://github.com/user-attachments/assets/1a0b7087-44c1-4ea8-8c57-850f3f7b0096)