### PR TITLE
fix cluster displayed set speed skipping certain mph values

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 
 from cereal import car
-from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import clip, interp
 from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import DT_CTRL, rate_limit, make_tester_present_msg

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -126,8 +126,7 @@ class CarController(CarControllerBase):
   def update(self, CC, CS, now_nanos):
     actuators = CC.actuators
     hud_control = CC.hudControl
-    conversion = hondacan.get_cruise_speed_conversion(self.CP.carFingerprint, CS.is_metric)
-    hud_v_cruise = hud_control.setSpeed / conversion if hud_control.speedVisible else 255
+    hud_v_cruise = hondacan.cruise_speed_from_ms(hud_control.setSpeed, self.CP.carFingerprint, CS.is_metric) if hud_control.speedVisible else 255
     pcm_cancel_cmd = CC.cruiseControl.cancel
 
     if CC.longActive:

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -233,7 +233,7 @@ class CarController(CarControllerBase):
 
     # Send dashboard UI commands.
     if self.frame % 10 == 0:
-      hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_control.leadVisible,
+      hud = HUDData(int(pcm_accel), int(hud_v_cruise), hud_control.leadVisible,
                     hud_control.lanesVisible, fcw_display, acc_alert, steer_required, hud_control.leadDistanceBars)
       can_sends.extend(hondacan.create_ui_commands(self.packer, self.CAN, self.CP, CC.enabled, pcm_speed, hud, CS.is_metric, CS.acc_hud, CS.lkas_hud))
 

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 from cereal import car
+from openpilot.common.conversions import Conversions as CV
 from openpilot.common.numpy_fast import clip, interp
 from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import DT_CTRL, rate_limit, make_tester_present_msg
@@ -127,7 +128,7 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
     conversion = hondacan.get_cruise_speed_conversion(self.CP.carFingerprint, CS.is_metric)
-    hud_v_cruise = hud_control.setSpeed / conversion if hud_control.speedVisible else 255
+    hud_v_cruise = round(hud_control.setSpeed / conversion) if hud_control.speedVisible else 255
     pcm_cancel_cmd = CC.cruiseControl.cancel
 
     if CC.longActive:
@@ -234,7 +235,7 @@ class CarController(CarControllerBase):
 
     # Send dashboard UI commands.
     if self.frame % 10 == 0:
-      hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_control.leadVisible,
+      hud = HUDData(int(pcm_accel), int(hud_v_cruise), hud_control.leadVisible,
                     hud_control.lanesVisible, fcw_display, acc_alert, steer_required, hud_control.leadDistanceBars)
       can_sends.extend(hondacan.create_ui_commands(self.packer, self.CAN, self.CP, CC.enabled, pcm_speed, hud, CS.is_metric, CS.acc_hud, CS.lkas_hud))
 

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -127,7 +127,7 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
     conversion = hondacan.get_cruise_speed_conversion(self.CP.carFingerprint, CS.is_metric)
-    hud_v_cruise = round(hud_control.setSpeed / conversion) if hud_control.speedVisible else 255
+    hud_v_cruise = hud_control.setSpeed / conversion if hud_control.speedVisible else 255
     pcm_cancel_cmd = CC.cruiseControl.cancel
 
     if CC.longActive:
@@ -234,7 +234,7 @@ class CarController(CarControllerBase):
 
     # Send dashboard UI commands.
     if self.frame % 10 == 0:
-      hud = HUDData(int(pcm_accel), int(hud_v_cruise), hud_control.leadVisible,
+      hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_control.leadVisible,
                     hud_control.lanesVisible, fcw_display, acc_alert, steer_required, hud_control.leadDistanceBars)
       can_sends.extend(hondacan.create_ui_commands(self.packer, self.CAN, self.CP, CC.enabled, pcm_speed, hud, CS.is_metric, CS.acc_hud, CS.lkas_hud))
 

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -49,7 +49,8 @@ def get_cruise_speed_conversion(car_fingerprint: str, is_metric: bool) -> float:
   if car_fingerprint in HONDA_BOSCH_RADARLESS:
     return CV.MPH_TO_MS
 
-  # for other cars, CRUISE_SPEED is always metric and a conversion factor rounded to 1 MPH is used
+  # for other cars, CRUISE_SPEED is always kph and the vehicle converts to mph using a conversion
+  # value rounded to 1 decimal place (without this our value is off by more than 0.5 mph at 90 mph)
   return 1 / round(CV.MPH_TO_KPH, 1) * CV.MPH_TO_MS
 
 

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -50,7 +50,7 @@ def get_cruise_speed_conversion(car_fingerprint: str, is_metric: bool) -> float:
     return CV.MPH_TO_MS
 
   # for other cars, CRUISE_SPEED is always kph and the vehicle converts to mph using a conversion
-  # value rounded to 1 decimal place (without this our value is off by more than 0.5 mph at 90 mph)
+  # value rounded to 1 decimal place (without this the value would be off by 0.5 mph at 85 mph)
   return 1 / round(CV.MPH_TO_KPH, 1) * CV.MPH_TO_MS
 
 

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -42,8 +42,15 @@ def get_lkas_cmd_bus(CAN, car_fingerprint, radar_disabled=False):
 
 
 def get_cruise_speed_conversion(car_fingerprint: str, is_metric: bool) -> float:
+  if is_metric:
+    return CV.KPH_TO_MS
+
   # on certain cars, CRUISE_SPEED changes to imperial with car's unit setting
-  return CV.MPH_TO_MS if car_fingerprint in HONDA_BOSCH_RADARLESS and not is_metric else CV.KPH_TO_MS
+  if car_fingerprint in HONDA_BOSCH_RADARLESS:
+    return CV.MPH_TO_MS
+
+  # for other cars, CRUISE_SPEED is always metric and a conversion factor rounded to 1 MPH is used
+  return 1 / round(CV.MPH_TO_KPH, 1) * CV.MPH_TO_MS
 
 
 def create_brake_command(packer, CAN, apply_brake, pump_on, pcm_override, pcm_cancel_cmd, fcw, car_fingerprint, stock_brake):

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -79,7 +79,7 @@ class CarController(CarControllerBase):
     # accel + longitudinal
     accel = clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
     stopping = actuators.longControlState == LongCtrlState.stopping
-    set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_KPH if CS.is_metric else CV.MS_TO_MPH)
+    set_speed_in_units = round(hud_control.setSpeed * (CV.MS_TO_KPH if CS.is_metric else CV.MS_TO_MPH))
 
     # HUD messages
     sys_warning, sys_state, left_lane_warning, right_lane_warning = process_hud_alert(CC.enabled, self.car_fingerprint,

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -24,7 +24,7 @@ ButtonType = car.CarState.ButtonEvent.Type
 GearShifter = car.CarState.GearShifter
 EventName = car.CarEvent.EventName
 
-MAX_CTRL_SPEED = (V_CRUISE_MAX + 4) * CV.KPH_TO_MS
+MAX_CTRL_SPEED = (V_CRUISE_MAX[1] + 4) * CV.KPH_TO_MS
 ACCEL_MAX = 2.0
 ACCEL_MIN = -3.5
 FRICTION_THRESHOLD = 0.3

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -509,7 +509,7 @@ class Controls:
           else:
             self.state = State.enabled
           self.current_alert_types.append(ET.ENABLE)
-          self.v_cruise_helper.initialize_v_cruise(CS, self.experimental_mode)
+          self.v_cruise_helper.initialize_v_cruise(CS, self.experimental_mode, self.is_metric)
 
     # Check if openpilot is engaged and actuators are enabled
     self.enabled = self.state in ENABLED_STATES

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -61,9 +61,8 @@ class VCruiseHelper:
         self.v_cruise_cluster_kph = self.v_cruise_kph
         self.update_button_timers(CS, enabled)
       else:
-        # rounding to 1 decimal place for mph prevents getting 0.5 mph off
-        self.v_cruise_kph = round(CS.cruiseState.speed * CV.MS_TO_KPH, 0 if is_metric else 1)
-        self.v_cruise_cluster_kph = round(CS.cruiseState.speedCluster * CV.MS_TO_KPH, 0 if is_metric else 1)
+        self.v_cruise_kph = round(CS.cruiseState.speed * CV.MS_TO_KPH, 1)
+        self.v_cruise_cluster_kph = round(CS.cruiseState.speedCluster * CV.MS_TO_KPH, 1)
     else:
       self.v_cruise_kph = V_CRUISE_UNSET
       self.v_cruise_cluster_kph = V_CRUISE_UNSET
@@ -115,7 +114,7 @@ class VCruiseHelper:
     if CS.gasPressed and button_type in (ButtonType.decelCruise, ButtonType.setCruise):
       self.v_cruise_kph = max(self.v_cruise_kph, CS.vEgo * CV.MS_TO_KPH)
 
-    self.v_cruise_kph = clip(round(self.v_cruise_kph, 0 if is_metric else 1), V_CRUISE_MIN[is_metric], V_CRUISE_MAX[is_metric])
+    self.v_cruise_kph = clip(round(self.v_cruise_kph, 1), V_CRUISE_MIN[is_metric], V_CRUISE_MAX[is_metric])
 
   def update_button_timers(self, CS, enabled):
     # increment timer for buttons still pressed
@@ -140,7 +139,7 @@ class VCruiseHelper:
     if any(b.type in (ButtonType.accelCruise, ButtonType.resumeCruise) for b in CS.buttonEvents) and self.v_cruise_kph_last < 250:
       self.v_cruise_kph = self.v_cruise_kph_last
     else:
-      self.v_cruise_kph = clip(round(CS.vEgo * CV.MS_TO_KPH, 0 if is_metric else 1), initial, V_CRUISE_MAX[is_metric])
+      self.v_cruise_kph = clip(round(CS.vEgo * CV.MS_TO_KPH, 1), initial, V_CRUISE_MAX[is_metric])
 
     self.v_cruise_cluster_kph = self.v_cruise_kph
 

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -98,7 +98,7 @@ class LongitudinalPlanner:
     self.mpc.mode = 'blended' if sm['controlsState'].experimentalMode else 'acc'
 
     v_ego = sm['carState'].vEgo
-    v_cruise_kph = min(sm['controlsState'].vCruise, V_CRUISE_MAX)
+    v_cruise_kph = min(sm['controlsState'].vCruise, V_CRUISE_MAX[1])
     v_cruise = v_cruise_kph * CV.KPH_TO_MS
 
     long_control_off = sm['controlsState'].longControlState == LongCtrlState.off

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -122,8 +122,8 @@ class TestVCruiseHelper:
       self.reset_cruise_speed_state()
       self.enable(V_CRUISE_INITIAL * CV.KPH_TO_MS, False)
 
-      # first decrement speed, then perform gas pressed logic
-      expected_v_cruise_kph = self.v_cruise_helper.v_cruise_kph - 1
+      # first decrement speed by 1 mph, then perform gas pressed logic
+      expected_v_cruise_kph = round(round(self.v_cruise_helper.v_cruise_kph * CV.KPH_TO_MPH - 1) * CV.MPH_TO_KPH, 1)
       expected_v_cruise_kph = max(expected_v_cruise_kph, v_ego * CV.MS_TO_KPH)  # clip to min of vEgo
       expected_v_cruise_kph = float(np.clip(round(expected_v_cruise_kph, 1), V_CRUISE_MIN, V_CRUISE_MAX))
 

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from parameterized import parameterized_class
 from cereal import log
-from openpilot.selfdrive.controls.lib.drive_helpers import VCruiseHelper, V_CRUISE_MIN, V_CRUISE_MAX, V_CRUISE_INITIAL, IMPERIAL_INCREMENT
+from openpilot.selfdrive.controls.lib.drive_helpers import VCruiseHelper, V_CRUISE_MIN, V_CRUISE_MAX, V_CRUISE_INITIAL
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.test.longitudinal_maneuvers.maneuver import Maneuver
@@ -123,7 +123,7 @@ class TestVCruiseHelper:
       self.enable(V_CRUISE_INITIAL * CV.KPH_TO_MS, False)
 
       # first decrement speed, then perform gas pressed logic
-      expected_v_cruise_kph = self.v_cruise_helper.v_cruise_kph - IMPERIAL_INCREMENT
+      expected_v_cruise_kph = self.v_cruise_helper.v_cruise_kph - 1
       expected_v_cruise_kph = max(expected_v_cruise_kph, v_ego * CV.MS_TO_KPH)  # clip to min of vEgo
       expected_v_cruise_kph = float(np.clip(round(expected_v_cruise_kph, 1), V_CRUISE_MIN, V_CRUISE_MAX))
 

--- a/selfdrive/controls/tests/test_cruise_speed.py
+++ b/selfdrive/controls/tests/test_cruise_speed.py
@@ -13,9 +13,9 @@ ButtonEvent = car.CarState.ButtonEvent
 ButtonType = car.CarState.ButtonEvent.Type
 
 MPH_INCR_BY_1_VALUES = range(round(V_CRUISE_MIN * CV.KPH_TO_MPH), round(V_CRUISE_MAX * CV.KPH_TO_MPH)+1)
-MPH_INCR_BY_5_VALUES = MPH_INCR_BY_1_VALUES[next(i for i, v in enumerate(MPH_INCR_BY_1_VALUES) if v % 5 == 0)::5]
+MPH_INCR_BY_5_VALUES = [MPH_INCR_BY_1_VALUES[i] for i, v in enumerate(MPH_INCR_BY_1_VALUES) if i == 0 or v % 5 == 0]
 KPH_INCR_BY_1_VALUES = range(V_CRUISE_MIN, V_CRUISE_MAX+1)
-KPH_INCR_BY_5_VALUES = KPH_INCR_BY_1_VALUES[next(i for i, v in enumerate(KPH_INCR_BY_1_VALUES) if v % 5 == 0)::5]
+KPH_INCR_BY_5_VALUES = [KPH_INCR_BY_1_VALUES[i] for i, v in enumerate(KPH_INCR_BY_1_VALUES) if i == 0 or v % 5 == 0]
 
 def run_cruise_simulation(cruise, e2e, personality, t_end=20.):
   man = Maneuver(
@@ -243,7 +243,7 @@ class TestVCruiseHelper:
     Asserts that speed increments by 5 kph when holding ACCEL button.
     """
 
-    self.simulate_cruise_speed_range(ButtonType.accelCruise, list(KPH_INCR_BY_5_VALUES), V_CRUISE_MIN, True, True)
+    self.simulate_cruise_speed_range(ButtonType.accelCruise, list(KPH_INCR_BY_5_VALUES[1:]), V_CRUISE_MIN, True, True)
 
   def test_decrement_by_5_kph(self):
     """


### PR DESCRIPTION
When incrementing set speed, convert to display units, increment in display units, then convert back to original units.

No clusters display set speed units with decimal places, and this ensures when you convert the stored value to any units and round to the nearest integer you always get the desired set speed value.
 
- Hyundai simply requires we send the correct value in display units, and previously the higher the set speed the further off the conversion back to mph gets until it rounded down to the incorrect value. (e.g. set speeds above 85 mph)
- Honda requires the kph value we send divided by 1.6 to round to the mph value, and previously all the conversions going on introduced error (e.g. it would never show a set speed of 65 mph)
- Volkswagen also has issues based on this comment? 
https://github.com/commaai/openpilot/blob/0907b30d7b87957ae14cad7954358c1d78d9a528/selfdrive/car/volkswagen/carcontroller.py#L102
