### PR TITLE
[bot] Fingerprints: add missing FW versions from new users

### DIFF
--- a/selfdrive/car/chrysler/fingerprints.py
+++ b/selfdrive/car/chrysler/fingerprints.py
@@ -26,6 +26,7 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdRadar, 0x753, None): [
       b'04672758AA',
+      b'04672758AB',
       b'68226356AF',
       b'68226356AH',
       b'68226356AI',
@@ -47,6 +48,7 @@ FW_VERSIONS = {
       b'68352654AE ',
       b'68366851AH ',
       b'68366853AE ',
+      b'68366853AG ',
       b'68372861AF ',
     ],
     (Ecu.transmission, 0x7e1, None): [
@@ -60,6 +62,7 @@ FW_VERSIONS = {
       b'68277374AD',
       b'68277374AN',
       b'68367471AC',
+      b'68367471AD',
       b'68380571AB',
     ],
   },

--- a/selfdrive/car/hyundai/fingerprints.py
+++ b/selfdrive/car/hyundai/fingerprints.py
@@ -408,6 +408,7 @@ FW_VERSIONS = {
       b'\xf1\x00ON ESC \x0b 100\x18\x12\x18 58910-S9360',
       b'\xf1\x00ON ESC \x0b 101\x19\t\x05 58910-S9320',
       b'\xf1\x00ON ESC \x0b 101\x19\t\x08 58910-S9360',
+      b'\xf1\x00ON ESC \x0b 103$\x04\x08 58910-S9360',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00LX2 MDPS C 1,00 1,03 56310-S8020 4LXDC103',


### PR DESCRIPTION

## ✅ Updating FW version database with FW from 2 dongles (2 platforms) in last 30 days:
<details open><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|:----------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------|:---------------------------------------------|:---------------|:---------------------------------------------------------------------------------------|
|[57ba8343c45221d5](https://useradmin.comma.ai/?onebox=57ba8343c45221d5)<br><sub>CHRYSLER_PACIFICA_2018<br>2C4RC1GG6........</sub>|CHRYSLER Pacifica 2018 🆚<br>Chrysler Pacifica 2017-18|14 routes,<br>359 segments<br>(6.0 hours)||- valid torque params: 349<br>- all lat active: 146<br>- no input all lat active: 104|
|[366df0f08bbf18b8](https://useradmin.comma.ai/?onebox=366df0f08bbf18b8)<br><sub>HYUNDAI_PALISADE<br>5XYP5DHC9........</sub>|KIA Telluride 2022 🆚<br>Kia Telluride 2020-22|162 routes,<br>3201 segments<br>(53.4 hours)||- valid torque params: 3201<br>- all lat active: 461<br>- no input all lat active: 292|

Dongles to re-run category: `57ba8343c45221d5 366df0f08bbf18b8`
</details>

## ⏳️ 1 dongles (1 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|:----------------------------------------------------------------------------------------------------------------------------|:-------------------------------------|:-----------------------------------------|:---------------|:-----------------------------------------------------------------------------------|
|[51dee9c7e9c87e4e](https://useradmin.comma.ai/?onebox=51dee9c7e9c87e4e)<br><sub>RAM_1500_5TH_GEN<br>1C6SRFKT5........</sub>|RAM 1500 2021 🆚<br>Ram 1500 2019-24|8 routes,<br>199 segments<br>(3.3 hours)||- all lat active: 60<br>- valid torque params: 175<br>- no input all lat active: 9|

Dongles to re-run category: `51dee9c7e9c87e4e`
</details>

## ⚠️ 3 dongles (3 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|:--------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------|
|[2189343dec8fa7cf](https://useradmin.comma.ai/?onebox=2189343dec8fa7cf)<br><sub>LEXUS_IS_TSS2<br>JTHAP1D2X........</sub>|LEXUS IS 2024 🆚<br>Lexus IS 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>|2 routes,<br>66 segments<br>(1.1 hours)|- [invalid FW: 31](https://useradmin.comma.ai/?onebox=2189343dec8fa7cf%7C00000001--ac7b3abbe3)<br>- [spotty FW: 31](https://useradmin.comma.ai/?onebox=2189343dec8fa7cf%7C00000001--ac7b3abbe3)|- valid torque params: 54<br>- all lat active: 13<br>- no input all lat active: 7|
|[b892faae698fe7ca](https://useradmin.comma.ai/?onebox=b892faae698fe7ca)<br><sub>TOYOTA_COROLLA_TSS2<br>JTHY65BHX........</sub>|None 🆚<br>None|6 routes,<br>154 segments<br>(2.6 hours)|- [car faulted: 1](https://useradmin.comma.ai/?onebox=b892faae698fe7ca%7C00000000--ffa099166a)|- valid torque params: 97<br>- all lat active: 18<br>- no input all lat active: 16|
|[9e7b03d47798346e](https://useradmin.comma.ai/?onebox=9e7b03d47798346e)<br><sub>VOLKSWAGEN_TRANSPORTER_T61<br>WV2ZZZ7HZ........</sub>|VOLKSWAGEN  1993 🆚<br>Volkswagen California 2021-23|168 routes,<br>1804 segments<br>(30.1 hours)|- [car faulted: 158](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C0000007d--7e55836de1)<br>- [segment too short (info): 20](https://useradmin.comma.ai/?onebox=9e7b03d47798346e%7C000000e1--622b625cf0)|- valid torque params: 1660<br>- all lat active: 118<br>- no input all lat active: 50|

Dongles to re-run category: `2189343dec8fa7cf b892faae698fe7ca 9e7b03d47798346e`
</details>