### PR TITLE
Fix `/usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1` warnings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -102,7 +102,6 @@ if arch == "larch64":
 
   libpath = [
     "/usr/local/lib",
-    "/usr/lib",
     "/system/vendor/lib64",
     f"#third_party/acados/{arch}/lib",
   ]


### PR DESCRIPTION
Fixed the multiple warnings related to incompatible library versions during the linking process on device:

> clang++ -o common/transformations/transformations.so -pthread -shared -Wl,-rpath=/data/openpilot/third_party/acados/larch64/lib -Wl,-rpath=/usr/local/lib common/transformations/transformations.o -L/usr/local/lib -L/usr/lib -L/system/vendor/lib64 -Lthird_party/acados/larch64/lib -Lthird_party/snpe/larch64 -Lthird_party/libyuv/larch64/lib -L/usr/lib/aarch64-linux-gnu -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> 
> 
> clang++ -o common/tests/test_common -Wl,--as-needed -Wl,--no-undefined -Wl,-rpath=/data/openpilot/third_party/acados/larch64/lib -Wl,-rpath=/usr/local/lib common/tests/test_runner.o common/tests/test_params.o common/tests/test_util.o common/tests/test_swaglog.o -L/usr/local/lib -L/usr/lib -L/system/vendor/lib64 -Lthird_party/acados/larch64/lib -Lthird_party/snpe/larch64 -Lthird_party/libyuv/larch64/lib -L/usr/lib/aarch64-linux-gnu -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers common/libcommon.a -ljson11 -lzmq -lpthread
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> 
> 
> ch64/lib -Lthird_party/snpe/larch64 -Lthird_party/libyuv/larch64/lib -L/usr/lib/aarch64-linux-gnu -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers msgq_repo/libmsgq.a -lzmq common/libcommon.a -ljson11
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> 
> 
> clang++ -o msgq_repo/msgq/visionipc/test_runner -Wl,--as-needed -Wl,--no-undefined -Wl,-rpath=/data/openpilot/third_party/acados/larch64/lib -Wl,-rpath=/usr/local/lib msgq_repo/msgq/visionipc/test_runner.o msgq_repo/msgq/visionipc/visionipc_tests.o -L/usr/local/lib -L/usr/lib -L/system/vendor/lib64 -Lthird_party/acados/larch64/lib -Lthird_party/snpe/larch64 -Lthird_party/libyuv/larch64/lib -L/usr/lib/aarch64-linux-gnu -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers -lpthread msgq_repo/libvisionipc.a msgq_repo/libmsgq.a common/libcommon.a -ljson11 -lzmq -lOpenCL
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> 
> 
> clang++ -o msgq_repo/msgq/visionipc/visionipc_pyx.so -pthread -shared -Wl,-rpath=/data/openpilot/third_party/acados/larch64/lib -Wl,-rpath=/usr/local/lib msgq_repo/msgq/visionipc/visionipc_pyx.o -L/usr/local/lib -L/usr/lib -L/system/vendor/lib64 -Lthird_party/acados/larch64/lib -Lthird_party/snpe/larch64 -Lthird_party/libyuv/larch64/lib -L/usr/lib/aarch64-linux-gnu -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers msgq_repo/libvisionipc.a msgq_repo/libmsgq.a common/libcommon.a -ljson11 -lzmq -lOpenCL
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
>     
> 
> clang++ -o opendbc/can/parser.o -c -std=c++1z -DQCOM2 -mcpu=cortex-a57 -DSWAGLOG="\"common/swaglog.h\"" -DDBC_FILE_PATH='"/data/openpilot/opendbc"' -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -Wno-vla-cxx-extension -DQCOM2 -mcpu=cortex-a57 -DSWAGLOG="\"common/swaglog.h\"" -Ithird_party/opencl/include -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/qrcode -Ithird_party -Icereal -Imsgq -Iopendbc/can opendbc/can/parser.cc
> clang++ -o opendbc/can/libdbc.so -Wl,--as-needed -Wl,--no-undefined -shared -Wl,-rpath=/data/openpilot/third_party/acados/larch64/lib -Wl,-rpath=/usr/local/lib opendbc/can/dbc.os opendbc/can/parser.os opendbc/can/packer.os opendbc/can/common.os -L/usr/local/lib -L/usr/lib -L/system/vendor/lib64 -Lthird_party/acados/larch64/lib -Lthird_party/snpe/larch64 -Lthird_party/libyuv/larch64/lib -L/usr/lib/aarch64-linux-gnu -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers common/libcommon.a -ljson11 -lcapnp -lkj -lzmq
> /usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
> 
> ...
> ...