### PR TITLE
CI: remove redundant save cache step

### DIFF
--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -73,12 +73,6 @@ jobs:
           scons-${{ runner.arch }}-ubuntu2004
     - name: Building openpilot
       run: uv run scons -u -j$(nproc)
-    - name: Saving scons cache
-      uses: actions/cache/save@v4
-      if: github.ref == 'refs/heads/master'
-      with:
-        path: /tmp/scons_cache
-        key: scons-${{ runner.arch }}-ubuntu2004-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
 
   devcontainer:
     name: devcontainer


### PR DESCRIPTION
`actions/cache@4` already does the final cache saving step automatically