### PR TITLE
ui: fix wayland requestActivate warning on device

### DIFF
--- a/selfdrive/ui/qt/qt_window.cc
+++ b/selfdrive/ui/qt/qt_window.cc
@@ -18,7 +18,9 @@ void setMainWindow(QWidget *w) {
   wl_surface *s = reinterpret_cast<wl_surface*>(native->nativeResourceForWindow("surface", w->windowHandle()));
   wl_surface_set_buffer_transform(s, WL_OUTPUT_TRANSFORM_270);
   wl_surface_commit(s);
-  w->showFullScreen();
+
+  w->setWindowState(Qt::WindowFullScreen);
+  w->setVisible(true);
 
   // ensure we have a valid eglDisplay, otherwise the ui will silently fail
   void *egl = native->nativeResourceForWindow("egldisplay", w->windowHandle());


### PR DESCRIPTION
This PR addresses the `Wayland does not support QWindow::requestActivate()` warning that occurs when attempting to show  window in fullscreen mode, This warning can appear during UI startup, dialog popups, and other similar actions:

![2024-07-24_12-54](https://github.com/user-attachments/assets/70f01cf6-6244-4f44-9ea3-e019e3f8ece2)

**Changes:**

For Wayland, instead of using showFullScreen(), we manually set the window state to fullscreen and ensure it is visible. This avoids any internal calls to requestActivate() that be triggered by showFullScreen() which is unsupported on Wayland.

