### PR TITLE
ui: disable horizontal scrolling and resize

### DIFF
--- a/selfdrive/ui/qt/widgets/scrollview.cc
+++ b/selfdrive/ui/qt/widgets/scrollview.cc
@@ -1,9 +1,8 @@
 #include "selfdrive/ui/qt/widgets/scrollview.h"
 
+#include <QResizeEvent>
 #include <QScrollBar>
 #include <QScroller>
-
-// TODO: disable horizontal scrolling and resize
 
 ScrollView::ScrollView(QWidget *w, QWidget *parent) : QScrollArea(parent) {
   setWidget(w);
@@ -37,8 +36,8 @@ ScrollView::ScrollView(QWidget *w, QWidget *parent) : QScrollArea(parent) {
   QScroller *scroller = QScroller::scroller(this->viewport());
   QScrollerProperties sp = scroller->scrollerProperties();
 
-  sp.setScrollMetric(QScrollerProperties::VerticalOvershootPolicy, QVariant::fromValue<QScrollerProperties::OvershootPolicy>(QScrollerProperties::OvershootAlwaysOff));
-  sp.setScrollMetric(QScrollerProperties::HorizontalOvershootPolicy, QVariant::fromValue<QScrollerProperties::OvershootPolicy>(QScrollerProperties::OvershootAlwaysOff));
+  sp.setScrollMetric(QScrollerProperties::VerticalOvershootPolicy, QScrollerProperties::OvershootAlwaysOff);
+  sp.setScrollMetric(QScrollerProperties::HorizontalOvershootPolicy, QScrollerProperties::OvershootAlwaysOff);
   sp.setScrollMetric(QScrollerProperties::MousePressEventDelay, 0.01);
   scroller->grabGesture(this->viewport(), QScroller::LeftMouseButtonGesture);
   scroller->setScrollerProperties(sp);
@@ -46,4 +45,13 @@ ScrollView::ScrollView(QWidget *w, QWidget *parent) : QScrollArea(parent) {
 
 void ScrollView::hideEvent(QHideEvent *e) {
   verticalScrollBar()->setValue(0);
+}
+
+void ScrollView::resizeEvent(QResizeEvent *event) {
+  if (widget()) {
+    // Ensure the scroll view cannot be resized smaller than the widget's minimum size or size hint
+    QSize minSize = widget()->minimumSizeHint().expandedTo(widget()->minimumSize());
+    setMinimumSize(minSize);
+  }
+  QScrollArea::resizeEvent(event);
 }

--- a/selfdrive/ui/qt/widgets/scrollview.h
+++ b/selfdrive/ui/qt/widgets/scrollview.h
@@ -7,6 +7,8 @@ class ScrollView : public QScrollArea {
 
 public:
   explicit ScrollView(QWidget *w = nullptr, QWidget *parent = nullptr);
+
 protected:
   void hideEvent(QHideEvent *e) override;
+  void resizeEvent(QResizeEvent *event) override;
 };


### PR DESCRIPTION
1. Modifies the ScrollView class to ensure that it cannot be resized to a size smaller than the minimum size or minimum size hint of its child widget. This guarantees that the ScrollView always remains at least as large as the minimum required size of its contents.
2. Simplify QScrollerProperties metric setting. the use of QVariant::fromValue is redundant when setting these metrics, as they can be set directly using the enum values.

before:

[Kazam_screencast_00149.webm](https://github.com/user-attachments/assets/84e03482-aa87-4acc-89f5-1fc8116c526f)

after:

[Kazam_screencast_00150.webm](https://github.com/user-attachments/assets/29c45549-dbad-4920-9778-fcfb4c850b0f)

