### PR TITLE
camerad: refactor camera_open() into separate functions for clarity

### DIFF
--- a/system/camerad/cameras/camera_qcom2.h
+++ b/system/camerad/cameras/camera_qcom2.h
@@ -86,6 +86,11 @@ public:
   void sensors_i2c(const struct i2c_random_wr_payload* dat, int len, int op_code, bool data_word);
 
 private:
+  bool openSensor();
+  void configISP();
+  void configCSIPHY();
+  void linkDevices();
+
   // for debugging
   Params params;
 };


### PR DESCRIPTION
The lengthy `camera_open()` method was refactored into logical parts, each handling a specific aspect of the camera setup. This change improves clarity and makes the code easier to work with.

Following this PR, we can further refine these functions to improve the robustness and readability of the camera initialization code, as well as clarify the logging.
