### PR TITLE
scons: remove redundant -DSWAGLOG Flag

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -169,7 +169,6 @@ if arch != "Darwin":
   ldflags += ["-Wl,--as-needed", "-Wl,--no-undefined"]
 
 # Enable swaglog include in submodules
-cflags += ['-DSWAGLOG="\\"common/swaglog.h\\""']
 cxxflags += ['-DSWAGLOG="\\"common/swaglog.h\\""']
 
 ccflags_option = GetOption('ccflags')


### PR DESCRIPTION
This PR prevents the -DSWAGLOG flag from being included twice during compilation:

> clang++ -o msgq_repo/msgq/ipc_pyx.o -c -std=c++1z **-DSWAGLOG="\"common/swaglog.h\""** -g -fPIC -O2 -Wunused -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -Wno-vla-cxx-extension **-DSWAGLOG="\"common/swaglog.h\""** -Wno-#warnings -Wno-shadow -Wno-deprecated-declarations -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/qrcode -Ithird_party -Icereal -Imsgq -Iopendbc/can -I/home/dean/.pyenv/versions/3.11.4/include/python3.11 -I.venv/lib/python3.11/site-packages/numpy/core/include msgq_repo/msgq/ipc_pyx.cpp
> clang++ -o msgq_repo/msgq/msgq_tests.o -c -std=c++1z **-DSWAGLOG="\"common/swaglog.h\""** -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -Wno-vla-cxx-extension **-DSWAGLOG="\"common/swaglog.h\""** -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/qrcode -Ithird_party -Icereal -Imsgq -Iopendbc/can -Ithird_party/json11 msgq_repo/msgq/msgq_tests.cc
> clang++ -o msgq_repo/msgq/test_runner.o -c -std=c++1z **-DSWAGLOG="\"common/swaglog.h\""** -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -Wno-vla-cxx-extension **-DSWAGLOG="\"common/swaglog.h\""** -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/qrcode -Ithird_party -Icereal -Imsgq -Iopendbc/can -Ithird_party/json11 msgq_repo/msgq/test_runner.cc
> clang++ -o msgq_repo/msgq/visionipc/test_runner.o -c -std=c++1z **-DSWAGLOG="\"common/swaglog.h\""** -g -fPIC -O2 -Wunused -Werror -Wshadow -Wno-unknown-warning-option -Wno-deprecated-register -Wno-register -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-reorder-init-list -Wno-error=unused-but-set-variable -Wno-vla-cxx-extension **-DSWAGLOG="\"common/swaglog.h\""** -I. -Ithird_party/acados/include -Ithird_party/acados/include/blasfeo/include -Ithird_party/acados/include/hpipm/include -Ithird_party/catch2/include -Ithird_party/libyuv/include -Ithird_party/json11 -Ithird_party/linux/include -Ithird_party/snpe/include -Ithird_party/qrcode -Ithird_party -Icereal -Imsgq -Iopendbc/can -Ithird_party/json11 msgq_repo/msgq/visionipc/test_runner.cc
....
...


 The flag has been removed from cflags because it is not needed there, avoiding redundancy.