### PR TITLE
curl pc installer

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -208,7 +208,7 @@ function op_run() {
   (set -e
 
   op_before_cmd
-  op_run_command $OPENPILOT_ROOT/launch_openpilot.sh
+  op_run_command $OPENPILOT_ROOT/launch_openpilot.sh $@
 
   )
 }
@@ -258,6 +258,16 @@ function op_cabana() {
   )
 }
 
+function op_sim() {
+  (set -e
+
+  op_before_cmd
+  exec $OPENPILOT_ROOT/tools/sim/run_bridge.py &
+  exec $OPENPILOT_ROOT/tools/sim/launch_openpilot.sh
+
+  )
+}
+
 function op_default() {
   echo "An openpilot helper"
   echo ""
@@ -279,6 +289,7 @@ function op_default() {
   echo -e "  ${BOLD}install${NC}    Install requirements to use openpilot"
   echo -e "  ${BOLD}build${NC}      Build openpilot"
   echo -e "  ${BOLD}run${NC}        Run openpilot"
+  echo -e "  ${BOLD}sim${NC}        Run openpilot in a simulator"
   echo -e "  ${BOLD}juggle${NC}     Run Plotjuggler"
   echo -e "  ${BOLD}replay${NC}     Run replay"
   echo -e "  ${BOLD}cabana${NC}     Run cabana"
@@ -327,6 +338,7 @@ function _op() {
     cabana )    shift 1; op_cabana "$@" ;;
     linter )    shift 1; op_linter "$@" ;;
     replay )    shift 1; op_replay "$@" ;;
+    sim )       shift 1; op_sim "$@" ;;
     --install ) shift 1; op_first_install "$@" ;;
     * ) op_default "$@" ;;
   esac
@@ -354,6 +366,7 @@ unset -f op_replay
 unset -f op_cabana
 unset -f op_check_venv
 unset -f op_before_cmd
+unset -f op_sim
 unset DRY
 unset OPENPILOT_ROOT
 unset NO_VERIFY

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -262,8 +262,8 @@ function op_sim() {
   (set -e
 
   op_before_cmd
-  exec $OPENPILOT_ROOT/tools/sim/run_bridge.py &
-  exec $OPENPILOT_ROOT/tools/sim/launch_openpilot.sh
+  op_run_command exec $OPENPILOT_ROOT/tools/sim/run_bridge.py &
+  op_run_command exec $OPENPILOT_ROOT/tools/sim/launch_openpilot.sh
 
   )
 }

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -161,14 +161,23 @@ function op_install() {
   op_check_os
   op_check_python
 
+  echo "Installing dependencies..."
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     op_run_command $OPENPILOT_ROOT/tools/ubuntu_setup.sh
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     op_run_command $OPENPILOT_ROOT/tools/mac_setup.sh
   fi
+  echo -e " ↳ [${GREEN}✔${NC}] Dependencies installed successfully.\n"
 
+  echo "Getting git submodules..."
   op_run_command git submodule update --init --recursive
+  echo -e " ↳ [${GREEN}✔${NC}] Submodules installed successfully.\n"
+
+  echo "Pulling git lfs files..."
   op_run_command git lfs pull
+  echo -e " ↳ [${GREEN}✔${NC}] Files pulled successfully.\n"
+
+  op_check
 
   )
 }

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -2,8 +2,6 @@
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-UNDERLINE='\033[4m'
-BOLD='\033[1m'
 NC='\033[0m'
 
 if [ -z "$OPENPILOT_ROOT" ]; then
@@ -33,7 +31,7 @@ function check_git() {
 
 function git_clone() {
   echo "Cloning openpilot..."
-  if $(git clone --depth=1 -b curl_op https://github.com/commaai/openpilot.git "$OPENPILOT_ROOT"); then
+  if $(git clone --depth=1 https://github.com/commaai/openpilot.git "$OPENPILOT_ROOT"); then
     if [[ -f $OPENPILOT_ROOT/launch_openpilot.sh ]]; then
       echo -e " ↳ [${GREEN}✔${NC}] Successfully cloned openpilot.\n"
       return 0
@@ -50,7 +48,7 @@ function install_with_op() {
   $OPENPILOT_ROOT/tools/op.sh install
 
   # make op usable right now
-  alias op="$OPENPILOT_ROOT/tools/op.sh"
+  alias op="source $OPENPILOT_ROOT/tools/op.sh \"\$@\""
 }
 
 check_dir && check_git && git_clone && install_with_op

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -6,8 +6,6 @@ UNDERLINE='\033[4m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-set -e
-
 if [ -z "$OPENPILOT_ROOT" ]; then
   # default to current directory for installation
   OPENPILOT_ROOT="$(pwd)/openpilot"
@@ -35,7 +33,7 @@ function check_git() {
 
 function git_clone() {
   echo "Cloning openpilot..."
-  if $(git clone --depth=1 https://github.com/commaai/openpilot.git "$OPENPILOT_ROOT"); then
+  if $(git clone --depth=1 -b curl_op https://github.com/commaai/openpilot.git "$OPENPILOT_ROOT"); then
     if [[ -f $OPENPILOT_ROOT/launch_openpilot.sh ]]; then
       echo -e " ↳ [${GREEN}✔${NC}] Successfully cloned openpilot.\n"
       return 0
@@ -50,9 +48,9 @@ function install_with_op() {
   cd $OPENPILOT_ROOT
   $OPENPILOT_ROOT/tools/op.sh --install
   $OPENPILOT_ROOT/tools/op.sh install
+
+  # make op usable right now
+  alias op="$OPENPILOT_ROOT/tools/op.sh"
 }
 
-check_dir
-check_git
-git_clone
-install_with_op
+check_dir && check_git && git_clone && install_with_op

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -13,13 +13,23 @@ if [ -z "$OPENPILOT_ROOT" ]; then
   OPENPILOT_ROOT="$(pwd)/openpilot"
 fi
 
+function check_dir() {
+  echo "Checking for installation directory..."
+  if [ -d "$OPENPILOT_ROOT" ]; then
+    echo -e " ↳ [${RED}✗${NC}] can't install openpilot in $OPENPILOT_ROOT !"
+    return 1
+  fi
+
+  echo -e " ↳ [${GREEN}✔${NC}] Successfully chosen $OPENPILOT_ROOT as installation directory\n"
+}
+
 function check_git() {
   echo "Checking for git..."
   if ! command -v "git" > /dev/null 2>&1; then
     echo -e " ↳ [${RED}✗${NC}] git not found on your system, can't continue!"
     return 1
   else
-    echo -e " ↳ [${GREEN}✔${NC}] git found on your system.\n"
+    echo -e " ↳ [${GREEN}✔${NC}] git found.\n"
   fi
 }
 
@@ -36,22 +46,13 @@ function git_clone() {
   return 1
 }
 
-function check_dir() {
-  echo "Checking for installation directory..."
-  if [ -d "$OPENPILOT_ROOT" ]; then
-    echo -e " ↳ [${RED}✗${NC}] can't install openpilot in $OPENPILOT_ROOT !"
-    return 1
-  fi
-
-  echo -e " ↳ [${GREEN}✔${NC}] Successfully chosen $OPENPILOT_ROOT as installation directory\n"
-}
-
 function install_with_op() {
   cd $OPENPILOT_ROOT
+  $OPENPILOT_ROOT/tools/op.sh --install
   $OPENPILOT_ROOT/tools/op.sh install
 }
 
-#check_dir
+check_dir
 check_git
-#git_clone
+git_clone
 install_with_op

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -8,8 +8,3 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 $DIR/install_ubuntu_dependencies.sh
 $DIR/install_python_dependencies.sh
-
-echo
-echo "----   OPENPILOT SETUP DONE   ----"
-echo "Open a new shell or configure your active shell env by running:"
-echo "source ~/.bashrc"


### PR DESCRIPTION
steps:
- check for an installation directory
- check for git
- git clone
- op install
- op sim

~might be cleaner to activate venv in new shell so we don't have to source op.sh anymore~


usage:   `source <(curl -L openpilot.comma.ai)`