### PR TITLE
camerad: move `do_exit` to camera_qcom2.cc

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -15,8 +15,6 @@
 #include "CL/cl_ext_qcom.h"
 #endif
 
-ExitHandler do_exit;
-
 class ImgProc {
 public:
   ImgProc(cl_device_id device_id, cl_context context, const CameraBuf *b, const CameraState *s, int buf_width, int uv_offset) {

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -24,7 +24,7 @@ const int MIPI_SETTLE_CNT = 33;  // Calculated by camera_freqs.py
 // For debugging:
 // echo "4294967295" > /sys/module/cam_debug_util/parameters/debug_mdl
 
-extern ExitHandler do_exit;
+ExitHandler do_exit;
 
 CameraState::CameraState(MultiCameraState *multi_camera_state, const CameraConfig &config)
   : multi_cam_state(multi_camera_state),


### PR DESCRIPTION
After  [camerad: merge thread functions into one](https://github.com/commaai/openpilot/pull/33025) , only camera_qcom2.cc needs `do_exit`, so we no longer need to keep it in camera_common.cc.