### PR TITLE
camerad: refactor to simplify camera management

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -293,15 +293,10 @@ void camerad_thread() {
 #endif
 
   {
-    MultiCameraState cameras;
     VisionIpcServer vipc_server("camerad", device_id, context);
-
-    cameras_open(&cameras);
-    cameras_init(&vipc_server, &cameras, device_id, context);
-
+    MultiCameraState cameras(&vipc_server, device_id, context);
     vipc_server.start_listener();
-
-    cameras_run(&cameras);
+    cameras.run();
   }
 
   CL_CHECK(clReleaseContext(context));

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -71,10 +71,6 @@ void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &fr
 kj::Array<uint8_t> get_raw_frame_image(const CameraBuf *b);
 float set_exposure_target(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip);
 void publish_thumbnail(PubMaster *pm, const CameraBuf *b);
-void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx);
-void cameras_open(MultiCameraState *s);
-void cameras_run(MultiCameraState *s);
-void cameras_close(MultiCameraState *s);
 void camerad_thread();
 
 int open_v4l_by_name_and_index(const char name[], int index = 0, int flags = O_RDWR | O_NONBLOCK);


### PR DESCRIPTION
This pull request centralizes and simplifies the initialization and management of camera operations in the codebase.

### Main Changes
1. **Vector Management:** Introduced a vector to manage all `CameraState` instances, removing individual `CameraState` declarations in `MultiCameraState`.
2. **Centralized Initialization:** Combined camera(s)_init, camera(s)_open, and other related initialization tasks that were scattered across different functions. All initialization tasks are now performed in the `MultiCameraState` constructor.
3. **Thread Management:** Moved thread management responsibilities from `MultiCameraState` to `CameraState`, which now starts and stops its own `run()` threads directly.
4. **Destructor Addition:** Added a destructor to `CameraState` to ensure cameras are properly stopped on destruction.
5. **Class Member Functions:** Converted C-style functions to class member functions for better encapsulation and organization.


### Next Steps:
1. Remove the `enabled` flag from `CameraState` and the associated `if (!enabled) `checks throughout the codebase. Instead, simply remove the camera from the `cameras` vector if it is not enabled.
2. Move `MultiCameraState` from camera_qcom2.cc/h to a separate file and consider renaming it to a more descriptive name.