### PR TITLE
CI: fix CI to run consistent tests 100% of the time

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -25,7 +25,7 @@ env:
   DOCKER_LOGIN: docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
   BUILD: selfdrive/test/docker_build.sh base
 
-  RUN: docker run --shm-size 1G -v $PWD:/tmp/openpilot -w /tmp/openpilot -e CI=1 -e PRE_COMMIT_HOME=/tmp/pre-commit -e PYTHONWARNINGS=error -e FILEREADER_CACHE=1 -e PYTHONPATH=/tmp/openpilot -e NUM_JOBS -e JOB_ID -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -v $GITHUB_WORKSPACE/.ci_cache/pre-commit:/tmp/pre-commit -v $GITHUB_WORKSPACE/.ci_cache/scons_cache:/tmp/scons_cache -v $GITHUB_WORKSPACE/.ci_cache/comma_download_cache:/tmp/comma_download_cache -v $GITHUB_WORKSPACE/.ci_cache/openpilot_cache:/tmp/openpilot_cache $BASE_IMAGE /bin/bash -c
+  RUN: docker run --shm-size 2G -v $PWD:/tmp/openpilot -w /tmp/openpilot -e CI=1 -e PRE_COMMIT_HOME=/tmp/pre-commit -e PYTHONWARNINGS=error -e FILEREADER_CACHE=1 -e PYTHONPATH=/tmp/openpilot -e NUM_JOBS -e JOB_ID -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -v $GITHUB_WORKSPACE/.ci_cache/pre-commit:/tmp/pre-commit -v $GITHUB_WORKSPACE/.ci_cache/scons_cache:/tmp/scons_cache -v $GITHUB_WORKSPACE/.ci_cache/comma_download_cache:/tmp/comma_download_cache -v $GITHUB_WORKSPACE/.ci_cache/openpilot_cache:/tmp/openpilot_cache $BASE_IMAGE /bin/bash -c
 
   PYTEST: pytest --continue-on-collection-errors --cov --cov-report=xml --cov-append --durations=0 --durations-min=5 --hypothesis-seed 0 -n logical
 

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -173,8 +173,8 @@ jobs:
       timeout-minutes: 15
       run: |
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
-                        $PYTEST --timeout 60 -m 'not slow and not serial' && \
-                        $PYTEST -n0 --timeout 60 -m 'serial' && \
+                        $PYTEST --timeout 60 -m 'not slow and not ci_serial' && \
+                        $PYTEST -n0 --timeout 60 -m 'ci_serial' && \
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         pytest -n0 ./selfdrive/ui/tests/test_translations.py"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -172,6 +172,8 @@ jobs:
     - name: Run unit tests
       timeout-minutes: 15
       run: |
+        # TODO: remove serially-run tests in CI. Issue tracker: https://github.com/pytest-dev/pytest/issues/3216
+        # Temporary workaround: https://github.com/pytest-dev/pytest/issues/3216#issuecomment-742143197
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
                         $PYTEST --timeout 60 -m 'not slow and not ci_serial' && \
                         $PYTEST -n0 --timeout 60 -m 'ci_serial' && \

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -25,7 +25,7 @@ env:
   DOCKER_LOGIN: docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
   BUILD: selfdrive/test/docker_build.sh base
 
-  RUN: docker run --shm-size 2G -v $PWD:/tmp/openpilot -w /tmp/openpilot -e CI=1 -e PRE_COMMIT_HOME=/tmp/pre-commit -e PYTHONWARNINGS=error -e FILEREADER_CACHE=1 -e PYTHONPATH=/tmp/openpilot -e NUM_JOBS -e JOB_ID -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -v $GITHUB_WORKSPACE/.ci_cache/pre-commit:/tmp/pre-commit -v $GITHUB_WORKSPACE/.ci_cache/scons_cache:/tmp/scons_cache -v $GITHUB_WORKSPACE/.ci_cache/comma_download_cache:/tmp/comma_download_cache -v $GITHUB_WORKSPACE/.ci_cache/openpilot_cache:/tmp/openpilot_cache $BASE_IMAGE /bin/bash -c
+  RUN: docker run --shm-size 1G -v $PWD:/tmp/openpilot -w /tmp/openpilot -e CI=1 -e PRE_COMMIT_HOME=/tmp/pre-commit -e PYTHONWARNINGS=error -e FILEREADER_CACHE=1 -e PYTHONPATH=/tmp/openpilot -e NUM_JOBS -e JOB_ID -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -v $GITHUB_WORKSPACE/.ci_cache/pre-commit:/tmp/pre-commit -v $GITHUB_WORKSPACE/.ci_cache/scons_cache:/tmp/scons_cache -v $GITHUB_WORKSPACE/.ci_cache/comma_download_cache:/tmp/comma_download_cache -v $GITHUB_WORKSPACE/.ci_cache/openpilot_cache:/tmp/openpilot_cache $BASE_IMAGE /bin/bash -c
 
   PYTEST: pytest --continue-on-collection-errors --cov --cov-report=xml --cov-append --durations=0 --durations-min=5 --hypothesis-seed 0 -n logical
 
@@ -173,10 +173,11 @@ jobs:
       timeout-minutes: 15
       run: |
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
-                        $PYTEST --timeout 60 -m 'not slow' && \
+                        $PYTEST --timeout 60 -m 'not slow and not serial' && \
+                        $PYTEST -n0 --timeout 60 -m 'serial' && \
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
-                        pytest ./selfdrive/ui/tests/test_translations.py"
+                        pytest -n0 ./selfdrive/ui/tests/test_translations.py"
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -172,8 +172,9 @@ jobs:
     - name: Run unit tests
       timeout-minutes: 15
       run: |
-        # TODO: remove serially-run tests in CI. Issue tracker: https://github.com/pytest-dev/pytest/issues/3216
+        # TODO: remove ci_serial marker. Issue tracker: https://github.com/pytest-dev/pytest/issues/3216
         # Temporary workaround: https://github.com/pytest-dev/pytest/issues/3216#issuecomment-742143197
+        #   current tests run serially: test_loggerd.py::test_rotation and test_translations.py
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
                         $PYTEST --timeout 60 -m 'not slow and not ci_serial' && \
                         $PYTEST -n0 --timeout 60 -m 'ci_serial' && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,8 @@ python_files = "test_*.py"
 markers = [
   "slow: tests that take awhile to run and can be skipped with -m 'not slow'",
   "tici: tests that are only meant to run on the C3/C3X",
-  "serial: tests that are run serially to avoid concurrent issues with pytest-xdist",
+  # TODO: remove serially-run tests in CI. Issue tracker: https://github.com/pytest-dev/pytest/issues/3216
+  "ci_serial: tests that are run serially to avoid concurrent issues with pytest-xdist in CI ubuntu runners",
 ]
 testpaths = [
   "common",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ python_files = "test_*.py"
 markers = [
   "slow: tests that take awhile to run and can be skipped with -m 'not slow'",
   "tici: tests that are only meant to run on the C3/C3X",
+  "serial: tests that are run serially to avoid concurrent issues with pytest-xdist",
 ]
 testpaths = [
   "common",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ python_files = "test_*.py"
 markers = [
   "slow: tests that take awhile to run and can be skipped with -m 'not slow'",
   "tici: tests that are only meant to run on the C3/C3X",
-  # TODO: remove serially-run tests in CI. Issue tracker: https://github.com/pytest-dev/pytest/issues/3216
   "ci_serial: tests that are run serially to avoid concurrent issues with pytest-xdist in CI ubuntu runners",
 ]
 testpaths = [

--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -34,7 +34,6 @@ class TestTranslations:
     assert os.path.exists(os.path.join(TRANSLATIONS_DIR, f"{self.file}.ts")), \
                     f"{self.name} has no XML translation file, run selfdrive/ui/update_translations.py"
 
-  @pytest.mark.serial
   def test_translations_updated(self):
     with tempfile.TemporaryDirectory() as tmpdir:
       shutil.copytree(TRANSLATIONS_DIR, tmpdir, dirs_exist_ok=True)

--- a/selfdrive/ui/tests/test_translations.py
+++ b/selfdrive/ui/tests/test_translations.py
@@ -34,6 +34,7 @@ class TestTranslations:
     assert os.path.exists(os.path.join(TRANSLATIONS_DIR, f"{self.file}.ts")), \
                     f"{self.name} has no XML translation file, run selfdrive/ui/update_translations.py"
 
+  @pytest.mark.serial
   def test_translations_updated(self):
     with tempfile.TemporaryDirectory() as tmpdir:
       shutil.copytree(TRANSLATIONS_DIR, tmpdir, dirs_exist_ok=True)

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import os
 import re
@@ -136,6 +137,7 @@ class TestLoggerd:
       assert getattr(initData, initData_key) == v
       assert logged_params[param_key].decode() == v
 
+  @pytest.mark.serial
   @flaky(max_runs=3)
   def test_rotation(self):
     os.environ["LOGGERD_TEST"] = "1"

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -137,7 +137,7 @@ class TestLoggerd:
       assert getattr(initData, initData_key) == v
       assert logged_params[param_key].decode() == v
 
-  @pytest.mark.serial
+  @pytest.mark.ci_serial
   @flaky(max_runs=3)
   def test_rotation(self):
     os.environ["LOGGERD_TEST"] = "1"


### PR DESCRIPTION
~Recently, I only see that mostly unit_test section is failing, and from looking at the failing logs, it seems that there is this `Fatal Python error: Bus error` that causes crashes in pytest-xdist workers~. ~This error is most likly from workers trying to access a unavailable memory region, so I just increase the shm-size of docker from 1GB -> 2GB~. 

~From running 2 runs of this new size (50 runs of unit_test each), I don't see that error happening anymore. `~
~run 1: https://github.com/commaai/openpilot/actions/runs/10115487281/job/27976375147~
~run 2: https://github.com/commaai/openpilot/actions/runs/10115625540/job/27976846602~

~The failing tests of these two runs are from a known flaky test in `test_loggerd.py` and I guess it has some weird association with matrix that causing it to fail (didn't investigate further)~, ~but should be fine if we have one run of `unit_test`~

~I did another run to make sure that if the shm-size is 1GB then we would see the bus error in unittest again~

~https://github.com/commaai/openpilot/actions/runs/10115830453/job/27977440198~

~If the issues still continues after this is merged, I'll happy to finish it.~

This is probably something due to pytest-xdist running tests that mess around with threading.

resolves [#32939](https://github.com/commaai/openpilot/issues/32939)
- [x] serial testing. Works!