### PR TITLE
cleanup macOS dependencies

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -36,12 +36,9 @@ if [[ $(command -v brew) == "" ]]; then
 fi
 
 brew bundle --file=- <<-EOS
-brew "catch2"
-brew "cmake"
 brew "cppcheck"
 brew "git-lfs"
 brew "zlib"
-brew "bzip2"
 brew "capnp"
 brew "coreutils"
 brew "eigen"


### PR DESCRIPTION
* catch2 is in `third_party/`
* bz2 is all in Python now
* not sure why cmake was here, probably for building stuff checked into `third_party/`