### PR TITLE
Docs: Added venv step

### DIFF
--- a/docs/docs/how-to/turn-the-speed-blue.md
+++ b/docs/docs/how-to/turn-the-speed-blue.md
@@ -12,9 +12,14 @@ Run this to clone openpilot and install all the dependencies:
 curl -fsSL openpilot.comma.ai | bash
 ```
 
-Then, compile openpilot:
+Navigate to openpilot folder & activate a Python virtual environment
 ```bash
 cd openpilot
+source .venv/bin/activate
+```
+
+Then, compile openpilot:
+```bash
 scons -j8
 ```
 


### PR DESCRIPTION
`scons -j8` doesn't work if Python virtual environment isn't activated first

## Changed to
<img width="666" alt="added-step" src="https://github.com/user-attachments/assets/4d38a0a0-a031-4fe7-9613-80b803b151a0">
