### PR TITLE
Subaru: remove engine and transmission fw versions

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -269,6 +269,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
   # We don't get the EPS from non-OBD queries on GEN2 cars. Note that we still attempt to match when it exists
   non_essential_ecus={
     Ecu.eps: list(CAR.with_flags(SubaruFlags.GLOBAL_GEN2)),
+    Ecu.engine: list(CAR),
+    Ecu.transmission: list(CAR),
   }
 )
 

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -270,7 +270,6 @@ FW_QUERY_CONFIG = FwQueryConfig(
   non_essential_ecus={
     Ecu.eps: list(CAR.with_flags(SubaruFlags.GLOBAL_GEN2)),
     Ecu.engine: list(CAR),
-    Ecu.transmission: list(CAR),
   }
 )
 


### PR DESCRIPTION
This PR adds Subaru engine ecu to non-essential ecus to simplify fingerprinting (less fw versions PR-s to merge) and improve the first-use experience for openpilot

**Verification**

I checked all the different models that use same ecu fw version for the remaining essential ecus and did not find any overlaps over all three:
```
Ecu.abs, 0x7b0, None, b'\xa2 \x193\x00', CAR.SUBARU_IMPREZA
Ecu.abs, 0x7b0, None, b'\xa2 \x193\x00', CAR.SUBARU_IMPREZA_2020
Ecu.abs, 0x7b0, None, b'\xa2 \x194\x00', CAR.SUBARU_IMPREZA
Ecu.abs, 0x7b0, None, b'\xa2 \x194\x00', CAR.SUBARU_IMPREZA_2020

Ecu.eps, 0x746, None, b'k\xb0\x00\x00', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.eps, 0x746, None, b'k\xb0\x00\x00', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.eps, 0x746, None, b'{\xb0\x00\x01', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.eps, 0x746, None, b'{\xb0\x00\x01', CAR.SUBARU_OUTBACK_PREGLOBAL_2018

Ecu.fwdCamera, 0x787, None, b'\x00\x00c\x94\x1f@\x10\x08', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\x94\x1f@\x10\x08', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xb7\x1f@\x10\x16', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xb7\x1f@\x10\x16', CAR.SUBARU_OUTBACK_PREGLOBAL
 
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xec\x1f@ \x04', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xec\x1f@ \x04', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00e\x80\x00\x1f@ \x19\x00', CAR.SUBARU_LEGACY
Ecu.fwdCamera, 0x787, None, b'\x00\x00e\x80\x00\x1f@ \x19\x00', CAR.SUBARU_OUTBACK
```
