### PR TITLE
Remove control usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ dev = [
   "av",
   "azure-identity",
   "azure-storage-blob",
-  "control",
   "dictdiffer",
   "flaky",
   "inputs",

--- a/selfdrive/controls/lib/tests/test_vehicle_model.py
+++ b/selfdrive/controls/lib/tests/test_vehicle_model.py
@@ -2,7 +2,6 @@ import pytest
 import math
 
 import numpy as np
-from control import StateSpace
 
 from openpilot.selfdrive.car.honda.interface import CarInterface
 from openpilot.selfdrive.car.honda.values import CAR
@@ -47,8 +46,12 @@ class TestVehicleModel:
         A, B = create_dyn_state_matrices(u, self.VM)
 
         # Convert to discrete time system
-        ss = StateSpace(A, B, np.eye(2), np.zeros((2, 2)))
-        ss = ss.sample(0.01)
+        dt = 0.01
+        top = np.hstack((A, B))
+        full = np.vstack((top, np.zeros_like(top))) * dt
+        Md = sum([np.linalg.matrix_power(full, k) / math.factorial(k) for k in range(25)])
+        Ad = Md[:A.shape[0], :A.shape[1]]
+        Bd = Md[:A.shape[0], A.shape[1]:]
 
         for sa in np.linspace(math.radians(-20), math.radians(20), num=11):
           inp = np.array([[sa], [roll]])
@@ -56,7 +59,7 @@ class TestVehicleModel:
           # Simulate for 1 second
           x1 = np.zeros((2, 1))
           for _ in range(100):
-            x1 = ss.A @ x1 + ss.B @ inp
+            x1 = Ad @ x1 + Bd @ inp
 
           # Compute steady state solution directly
           x2 = dyn_ss_sol(sa, u, roll, self.VM)

--- a/uv.lock
+++ b/uv.lock
@@ -370,20 +370,6 @@ wheels = [
 ]
 
 [[distribution]]
-name = "control"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "scipy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/64/02fedcf78b070571f5e446efb55b7ec82b68187323402b99b6f98f769530/control-0.10.0.tar.gz", hash = "sha256:2c18b767537f45c7fd07b2e4afe8fbe5964019499b5f52f888edb5d8560bab53", size = 8956376 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/de/327ab576657cb6bd5678e5d4fa266f3c4c7094e99df2bb7760e89176772d/control-0.10.0-py3-none-any.whl", hash = "sha256:ed1e0eb73f1e2945fc9af9d7b9121ef328fe980e7903b2a14b149d4f1855a808", size = 513858 },
-]
-
-[[distribution]]
 name = "coverage"
 version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1439,7 +1425,6 @@ dev = [
     { name = "av" },
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
-    { name = "control" },
     { name = "dictdiffer" },
     { name = "flaky" },
     { name = "hexdump" },


### PR DESCRIPTION
Remove the only usage of the control package.

Use a simple Taylor expansion to obtain the discretized version of A and B in a single step.

The new matrices Ad and Bd are equal up to 10 decimals from the old ss.A and ss.B + the test run just as fast