### PR TITLE
camerad: replace magic number with computed buffer size for `cam_cmd_power`

### DIFF
--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -140,8 +140,9 @@ int CameraState::sensors_init() {
   probe->expected_data = ci->probe_expected_data;
   probe->data_mask = 0;
 
-  //buf_desc[1].size = buf_desc[1].length = 148;
-  buf_desc[1].size = buf_desc[1].length = 196;
+  const uint32_t buf_size = sizeof(cam_cmd_power) * 7 + sizeof(cam_cmd_unconditional_wait) * 6 + sizeof(cam_power_settings) * 5;
+  assert(buf_size == 196);
+  buf_desc[1].size = buf_desc[1].length = buf_size;
   buf_desc[1].type = CAM_CMD_BUF_I2C;
   auto power_settings = mm.alloc<struct cam_cmd_power>(buf_desc[1].size, (uint32_t*)&buf_desc[1].mem_handle);
 


### PR DESCRIPTION
Replacing the hardcoded magic number **196** with a computed buffer size using the `sizeof` operator.
an assertion is added to ensure the computed size matches the original magic number for safety and validation.