### PR TITLE
camerad: release ISP buffer on camera close

### DIFF
--- a/system/camerad/cameras/camera_qcom2.h
+++ b/system/camerad/cameras/camera_qcom2.h
@@ -102,6 +102,7 @@ public:
 
   int32_t link_handle = -1;
 
+  void *buf0_address = nullptr;
   int buf0_handle = 0;
   int buf_handle[FRAME_BUF_COUNT] = {};
   int sync_objs[FRAME_BUF_COUNT] = {};

--- a/system/camerad/cameras/camera_util.h
+++ b/system/camerad/cameras/camera_util.h
@@ -15,6 +15,7 @@ int device_control(int fd, int op_code, int session_handle, int dev_handle);
 int do_cam_control(int fd, int op_code, void *handle, int size);
 void *alloc_w_mmu_hdl(int video0_fd, int len, uint32_t *handle, int align = 8, int flags = CAM_MEM_FLAG_KMD_ACCESS | CAM_MEM_FLAG_UMD_ACCESS | CAM_MEM_FLAG_CMD_BUF_TYPE,
                       int mmu_hdl = 0, int mmu_hdl2 = 0);
+void release_fd(int video0_fd, uint32_t handle);
 void release(int video0_fd, uint32_t handle);
 
 class MemoryManager {


### PR DESCRIPTION
Release ISP buffer on camera close. ensure that the buffer is unmapped and the file descriptor is released, preventing potential memory leaks and ensuring clean resource management.