### PR TITLE
thneed: release GPU memory  in `~GPUMalloc()`

### DIFF
--- a/selfdrive/modeld/thneed/thneed.h
+++ b/selfdrive/modeld/thneed/thneed.h
@@ -31,6 +31,9 @@ class GPUMalloc {
   private:
     uint64_t base;
     int remaining;
+    uint64_t mmapsize;
+    unsigned int alloc_id;
+    int gpu_fd;
 };
 
 class CLQueuedKernel {


### PR DESCRIPTION
Ensure GPU memory is properly released in the ~GPUMalloc()  to prevent memory leaks.