### PR TITLE
fix multiprocessing issue with can_replay.py on macOS

### DIFF
--- a/tools/replay/can_replay.py
+++ b/tools/replay/can_replay.py
@@ -80,6 +80,17 @@ def connect():
 
     time.sleep(1)
 
+def process(lr):
+  return [can_capnp_to_can_list(m.can) for m in lr if m.which() == 'can']
+
+def load_route(route_or_segment_name):
+  print("Loading log...")
+  sr = LogReader(route_or_segment_name)
+  CP = sr.first("carParams")
+  print(f"carFingerprint (for hardcoding fingerprint): '{CP.carFingerprint}'")
+  CAN_MSGS = sr.run_across_segments(24, process)
+  print("Finished loading...")
+  return CAN_MSGS
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Replay CAN messages from a route to all connected pandas and jungles in a loop.",
@@ -87,22 +98,10 @@ if __name__ == "__main__":
   parser.add_argument("route_or_segment_name", nargs='?', help="The route or segment name to replay. If not specified, a default public route will be used.")
   args = parser.parse_args()
 
-  def process(lr):
-    return [can_capnp_to_can_list(m.can) for m in lr if m.which() == 'can']
-
-  print("Loading log...")
   if args.route_or_segment_name is None:
     args.route_or_segment_name = "77611a1fac303767/2020-03-24--09-50-38/1:3"
 
-  sr = LogReader(args.route_or_segment_name)
-
-  CP = sr.first("carParams")
-
-  print(f"carFingerprint (for hardcoding fingerprint): '{CP.carFingerprint}'")
-
-  CAN_MSGS = sr.run_across_segments(24, process)
-
-  print("Finished loading...")
+  CAN_MSGS = load_route(args.route_or_segment_name)
 
   if ENABLE_PWR:
     print(f"Cycling power: on for {PWR_ON}s, off for {PWR_OFF}s")


### PR DESCRIPTION
<details>
  <summary>Otherwise, this happens:</summary>

```
Process SpawnPoolWorker-16:
Traceback (most recent call last):
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/pool.py", line 114, in worker
    task = get()
           ^^^^^
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/queues.py", line 389, in get
    return _ForkingPickler.loads(res)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'process' on <module '__mp_main__' from '/Users/andiradulescu/Projects/openpilot/tools/replay/can_replay.py'>
Process SpawnPoolWorker-4:
Traceback (most recent call last):
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/pool.py", line 114, in worker
    task = get()
           ^^^^^
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/queues.py", line 389, in get
    return _ForkingPickler.loads(res)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'process' on <module '__mp_main__' from '/Users/andiradulescu/Projects/openpilot/tools/replay/can_replay.py'>
^CProcess SpawnPoolWorker-25:
Process SpawnPoolWorker-23:
Process SpawnPoolWorker-22:
Process SpawnPoolWorker-24:
Process SpawnPoolWorker-26:
Process SpawnPoolWorker-21:
Process SpawnPoolWorker-20:
Process SpawnPoolWorker-18:
Process SpawnPoolWorker-19:
Process SpawnPoolWorker-17:
Process SpawnPoolWorker-14:
Process SpawnPoolWorker-13:
Process SpawnPoolWorker-12:
Process SpawnPoolWorker-11:
Process SpawnPoolWorker-10:
Process SpawnPoolWorker-9:
Process SpawnPoolWorker-8:
Process SpawnPoolWorker-7:
Process SpawnPoolWorker-6:
Process SpawnPoolWorker-5:
Process SpawnPoolWorker-3:
Process SpawnPoolWorker-2:
Process SpawnPoolWorker-1:
Process SpawnPoolWorker-15:
  0%|                                                                                                        | 0/2 [00:02<?, ?it/s]
Traceback (most recent call last):
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/pool.py", line 856, in next
    item = self._items.popleft()
           ^^^^^^^^^^^^^^^^^^^^^
IndexError: pop from an empty deque

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/andiradulescu/Projects/openpilot/tools/replay/can_replay.py", line 103, in <module>
    CAN_MSGS = sr.run_across_segments(24, process)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/andiradulescu/Projects/openpilot/openpilot/tools/lib/logreader.py", line 300, in run_across_segments
    for p in tqdm.tqdm(pool.imap(partial(self._run_on_segment, func), range(num_segs)), total=num_segs):
  File "/Users/andiradulescu/Projects/openpilot/.venv/lib/python3.12/site-packages/tqdm/std.py", line 1181, in __iter__
    for obj in iterable:
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/multiprocessing/pool.py", line 861, in next
    self._cond.wait(timeout)
  File "/Users/andiradulescu/Library/Application Support/uv/python/cpython-3.12.4-macos-x86_64-none/lib/python3.12/threading.py", line 355, in wait
    waiter.acquire()
KeyboardInterrupt
```

</details>