### PR TITLE
set ruff as VSCode defaultFormatter for python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,8 @@
     "system/**",
     "third_party/**",
     "tools/**",
-  ]
+  ],
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ warn_return_any=true
 # allow implicit optionals for default args
 implicit_optional = true
 
-# https://beta.ruff.rs/docs/configuration/#using-pyprojecttoml
+# https://docs.astral.sh/ruff/configuration/#using-pyprojecttoml
 [tool.ruff]
 indent-width = 2
 lint.select = [
@@ -247,5 +247,6 @@ lint.flake8-implicit-str-concat.allow-multiline = false
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]
 
+# https://docs.astral.sh/ruff/settings/#format
 [tool.ruff.format]
 quote-style = "preserve"

--- a/tools/replay/can_replay.py
+++ b/tools/replay/can_replay.py
@@ -38,10 +38,10 @@ def send_thread(j: PandaJungle, flock):
   while True:
     # handle cycling
     if ENABLE_PWR:
-      i = (rk.frame*DT_CTRL) % (PWR_ON + PWR_OFF) < PWR_ON
+      i = (rk.frame * DT_CTRL) % (PWR_ON + PWR_OFF) < PWR_ON
       j.set_panda_power(i)
     if ENABLE_IGN:
-      i = (rk.frame*DT_CTRL) % (IGN_ON + IGN_OFF) < IGN_ON
+      i = (rk.frame * DT_CTRL) % (IGN_ON + IGN_OFF) < IGN_ON
       j.set_ignition(i)
 
     snd = CAN_MSGS[rk.frame % len(CAN_MSGS)]
@@ -73,15 +73,17 @@ def connect():
     # try to join all send threads
     cur_serials = serials.copy()
     for s, t in cur_serials.items():
-      if t is  not None:
+      if t is not None:
         t.join(0.01)
         if not t.is_alive():
           del serials[s]
 
     time.sleep(1)
 
+
 def process(lr):
   return [can_capnp_to_can_list(m.can) for m in lr if m.which() == 'can']
+
 
 def load_route(route_or_segment_name):
   print("Loading log...")
@@ -92,9 +94,11 @@ def load_route(route_or_segment_name):
   print("Finished loading...")
   return CAN_MSGS
 
+
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description="Replay CAN messages from a route to all connected pandas and jungles in a loop.",
-                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser = argparse.ArgumentParser(
+    description="Replay CAN messages from a route to all connected pandas and jungles in a loop.", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+  )
   parser.add_argument("route_or_segment_name", nargs='?', help="The route or segment name to replay. If not specified, a default public route will be used.")
   args = parser.parse_args()
 


### PR DESCRIPTION
Proof of concept on setting ruff as VSCode defaultFormatter for python.

"Format Document" has been run on `can_replay.py`.