### PR TITLE
params: wrap fsync and close in HANDLE_EINTR for robustness

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -24,8 +24,8 @@ int fsync_dir(const std::string &path) {
   int result = -1;
   int fd = HANDLE_EINTR(open(path.c_str(), O_RDONLY, 0755));
   if (fd >= 0) {
-    result = fsync(fd);
-    close(fd);
+    result = HANDLE_EINTR(fsync(fd));
+    HANDLE_EINTR(close(fd));
   }
   return result;
 }


### PR DESCRIPTION
fsync https://man7.org/linux/man-pages/man2/fsync.2.html and close can be interrupted by signals; using HANDLE_EINTR ensures that these interruptions are handled properly.