### PR TITLE
CI: add `restart()` for  `encoderd` if not running

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -155,6 +155,10 @@ jobs:
       run: ${{ env.RUN }} "unset PYTHONWARNINGS && pre-commit run --all && chmod -R 777 /tmp/pre-commit"
 
   unit_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
     name: unit tests
     runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
                    ((github.event_name != 'pull_request') ||

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -157,7 +157,7 @@ class TestLoggerd:
     length = random.randint(1, 3)
     os.environ["LOGGERD_SEGMENT_LENGTH"] = str(length)
 
-    processes = [managed_processes["loggerd"], managed_processes["encoderd"]]
+    processes = (managed_processes["loggerd"], managed_processes["encoderd"])
     for p in processes:
       p.start()
 

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -170,7 +170,7 @@ class TestLoggerd:
         for p in processes:
           i = 0
           while not p.proc.is_alive():
-            if i > 5:
+            if i >= 5:
               raise Exception(f"Process {p.name} failed to run after 5 restarts")
             p.restart()
             i += 1

--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -164,14 +164,15 @@ class TestLoggerd:
     assert pm.wait_for_readers_to_update("roadCameraState", timeout=5)
 
     fps = 20.0
+    restart_limit = 5
     for n in range(1, int(num_segs*length*fps)+1):
       for stream_type, frame_spec, state in streams:
 
         for p in processes:
           i = 0
           while not p.proc.is_alive():
-            if i >= 5:
-              raise Exception(f"Process {p.name} failed to run after 5 restarts")
+            if i >= restart_limit:
+              raise Exception(f"Process {p.name} failed to run after {restart_limit} restarts")
             p.restart()
             i += 1
 


### PR DESCRIPTION
pytest-xdist has a bug in interacting with tests that have multiple processes. We encounter a lot in `test_rotation()` where the `encoderd` not running even when `start()` was called.

This PR checks if encoderd is running before sending data, and try to restart if not already running. Fails after 5 restart() calls