### PR TITLE
 camerad: move camera exposure logic to CameraExposure Class 

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -149,10 +149,7 @@ void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &fr
   framed.setMeasuredGreyFraction(frame_data.measured_grey_fraction);
   framed.setTargetGreyFraction(frame_data.target_grey_fraction);
   framed.setProcessingTime(frame_data.processing_time);
-
-  const float ev = c->cur_ev[frame_data.frame_id % 3];
-  const float perc = util::map_val(ev, c->ci->min_ev, c->ci->max_ev, 0.0f, 100.0f);
-  framed.setExposureValPercent(perc);
+  framed.setExposureValPercent(frame_data.exposure_val_percent);
   framed.setSensor(c->ci->image_sensor);
 }
 
@@ -256,7 +253,7 @@ void publish_thumbnail(PubMaster *pm, const CameraBuf *b) {
   pm->send("thumbnail", msg);
 }
 
-float set_exposure_target(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip) {
+float CameraExposure::set_exposure_target(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip) {
   int lum_med;
   uint32_t lum_binning[256] = {0};
   const uint8_t *pix_ptr = b->cur_yuv_buf->y;

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -35,6 +35,7 @@ typedef struct FrameMetadata {
   float gain;
   float measured_grey_fraction;
   float target_grey_fraction;
+  float exposure_val_percent;
 
   float processing_time;
 } FrameMetadata;
@@ -70,7 +71,6 @@ public:
 
 void fill_frame_data(cereal::FrameData::Builder &framed, const FrameMetadata &frame_data, CameraState *c);
 kj::Array<uint8_t> get_raw_frame_image(const CameraBuf *b);
-float set_exposure_target(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip);
 void publish_thumbnail(PubMaster *pm, const CameraBuf *b);
 void cameras_init(VisionIpcServer *v, MultiCameraState *s, cl_device_id device_id, cl_context ctx);
 void cameras_open(MultiCameraState *s);

--- a/system/camerad/cameras/camera_exposure.h
+++ b/system/camerad/cameras/camera_exposure.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <mutex>
+#include "common/params.h"
+#include "common/util.h"
+#include "system/camerad/sensors/sensor.h"
+
+class CameraExposure {
+public:
+  CameraExposure(int camera_num, const SensorInfo *sensor_info, int rgb_width, int rgb_height, float focal_len);
+  void updateFrameMetaData(FrameMetadata &meta_data);
+  std::vector<i2c_random_wr_payload> getExposureRegisters(const CameraBuf &buf, int x_skip, int y_skip);
+  static float set_exposure_target(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip);
+
+private:
+  void updateScore(float desired_ev, int exp_t, int exp_g_idx, float exp_gain);
+
+  std::mutex exp_lock;
+  const SensorInfo *ci = nullptr;
+
+  int exposure_time = 5;
+  bool dc_gain_enabled = false;
+  int dc_gain_weight = 0;
+  int gain_idx = 0;
+  float analog_gain_frac = 0;
+
+  float cur_ev[3] = {};
+  float best_ev_score = 0;
+  int new_exp_g = 0;
+  int new_exp_t = 0;
+
+  Rect ae_xywh = {};
+  float measured_grey_fraction = 0;
+  float target_grey_fraction = 0.3;
+  // for debugging
+  Params params;
+};

--- a/system/camerad/test/test_ae_gray.cc
+++ b/system/camerad/test/test_ae_gray.cc
@@ -7,7 +7,7 @@
 #include <cstring>
 
 #include "common/util.h"
-#include "system/camerad/cameras/camera_common.h"
+#include "system/camerad/cameras/camera_exposure.h"
 
 #define W 240
 #define H 160
@@ -61,7 +61,7 @@ TEST_CASE("camera.test_set_exposure_target") {
           memset(&fb_y[h_0*W+h_1*W], l[2], h_2*W);
           memset(&fb_y[h_0*W+h_1*W+h_2*W], l[3], h_3*W);
           memset(&fb_y[h_0*W+h_1*W+h_2*W+h_3*W], l[4], h_4*W);
-          float ev = set_exposure_target((const CameraBuf*) &cb, rect, 1, 1);
+          float ev = CameraExposure::set_exposure_target((const CameraBuf*) &cb, rect, 1, 1);
           // printf("%d/%d/%d/%d/%d ev is %f\n", h_0, h_1, h_2, h_3, h_4, ev);
           // printf("%f\n", ev);
 


### PR DESCRIPTION
Reopened PR: https://github.com/commaai/openpilot/pull/33018

This PR refactors the camera exposure logic by encapsulating related functions and variables into a new `CameraExposure` class. 

Unlike the previous PR (#33018), this refactor is done in place of the original code, except for adding a new header file `camera_exposure.h` for the CameraExposure class. This approach ensures that the logic remains unchanged, making it easier to review and verify that the functionality of camerad is not affected.

Next step:

Move the source code of CameraExposure's member functions into camera_exposure.cc.