### PR TITLE
camerad: encapsulate cl_command_queue in ImgProc

### DIFF
--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -53,7 +53,6 @@ private:
   int frame_buf_count;
 
 public:
-  cl_command_queue q;
   FrameMetadata cur_frame_data;
   VisionBuf *cur_yuv_buf;
   VisionBuf *cur_camera_buf;


### PR DESCRIPTION
Changes:

1. Moved `cl_command_queue q` from `CameraBuf` to `ImgProc` as it is only used within the `ImgProc` class. This improves encapsulation and makes the code more modular.
2. Renamed `q` to `queue` to enhance readability.
