### PR TITLE
Refactor update process execution and signaling

### DIFF
--- a/selfdrive/ui/qt/offroad/software_settings.cc
+++ b/selfdrive/ui/qt/offroad/software_settings.cc
@@ -17,7 +17,7 @@
 
 
 void SoftwarePanel::checkForUpdates() {
-  std::system("pkill -SIGUSR1 -f system.updated.updated");
+  std::system("pkill -SIGUSR1 -f updated");
 }
 
 SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
@@ -36,7 +36,7 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
     if (downloadBtn->text() == tr("CHECK")) {
       checkForUpdates();
     } else {
-      std::system("pkill -SIGHUP -f system.updated.updated");
+      std::system("pkill -SIGHUP -f updated");
     }
   });
   addItem(downloadBtn);

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -77,7 +77,7 @@ procs = [
   PythonProcess("radard", "selfdrive.controls.radard", only_onroad),
   PythonProcess("hardwared", "system.hardware.hardwared", always_run),
   PythonProcess("tombstoned", "system.tombstoned", always_run, enabled=not PC),
-  PythonProcess("updated", "system.updated.updated", only_offroad, enabled=not PC),
+  NativeProcess("updated", "system/updated", ["./updated.py"], only_offroad, enabled=not PC),
   PythonProcess("uploader", "system.loggerd.uploader", always_run),
   PythonProcess("statsd", "system.statsd", always_run),
 


### PR DESCRIPTION
Changed update process execution from a Python to a native process. Updated signal-based process control to match new process configurations.

**Description**

https://github.com/commaai/openpilot/pull/32716 removed the process title, which meant that we could no longer send signals to it as we used to which caused this issue https://github.com/commaai/openpilot/issues/32881. 

Following recommendations here https://github.com/commaai/openpilot/pull/32716#issuecomment-2166919909, we are updating it to be a native process and update the signal sent from software_settings

**Verification**

Installed this branch on my devices and clicked the update button and I saw on the logs the signal was received. 

