### PR TITLE
UI: DM icon shows engaged IF always-on

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "common/params.h"
 #include "common/swaglog.h"
 #include "selfdrive/ui/qt/onroad/buttons.h"
 #include "selfdrive/ui/qt/util.h"
@@ -21,6 +22,12 @@ AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget* par
   main_layout->addWidget(experimental_btn, 0, Qt::AlignTop | Qt::AlignRight);
 
   dm_img = loadPixmap("../assets/img_driver_face.png", {img_size + 5, img_size + 5});
+}
+
+// Checks if "Always-On Driver Monitoring" toggle is enabled in settings
+bool AnnotatedCameraWidget::isDMAlwaysOn() const {
+  Params params;
+  return params.getBool("AlwaysOnDM");
 }
 
 void AnnotatedCameraWidget::updateState(const UIState &s) {
@@ -236,9 +243,12 @@ void AnnotatedCameraWidget::drawDriverState(QPainter &painter, const UIState *s)
   const int arc_l = 133;
   const float arc_t_default = 6.7;
   const float arc_t_extend = 12.0;
-  QColor arc_color = QColor::fromRgbF(0.545 - 0.445 * s->engaged(),
-                                      0.545 + 0.4 * s->engaged(),
-                                      0.545 - 0.285 * s->engaged(),
+
+  bool show_dm_engaged = s->engaged() || isDMAlwaysOn();
+
+  QColor arc_color = QColor::fromRgbF(0.545 - 0.445 * show_dm_engaged,
+                                      0.545 + 0.4 * show_dm_engaged,
+                                      0.545 - 0.285 * show_dm_engaged,
                                       0.4 * (1.0 - dm_fade_state));
   float delta_x = -scene.driver_pose_sins[1] * arc_l / 2;
   float delta_y = -scene.driver_pose_sins[0] * arc_l / 2;

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -10,6 +10,10 @@
 #include "selfdrive/ui/qt/onroad/buttons.h"
 #include "selfdrive/ui/qt/util.h"
 
+// Colors for the DM tracking arcs
+const QColor DM_ENGAGED_COLOR = QColor::fromRgbF(0.1, 0.945, 0.26, 0.6);
+const QColor DM_DISENGAGED_COLOR = QColor::fromRgbF(0.545, 0.545, 0.545, 0.6);
+
 // Window that shows camera view and variety of info drawn on top
 AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget* parent) : fps_filter(UI_FREQ, 3, 1. / UI_FREQ), CameraWidget("camerad", type, true, parent) {
   pm = std::make_unique<PubMaster, const std::initializer_list<const char *>>({"uiDebug"});
@@ -246,10 +250,9 @@ void AnnotatedCameraWidget::drawDriverState(QPainter &painter, const UIState *s)
 
   bool show_dm_engaged = s->engaged() || isDMAlwaysOn();
 
-  const QColor ENGAGED_COLOR = QColor::fromRgbF(0.1, 0.945, 0.26, 0.6);
-  const QColor DISENGAGED_COLOR = QColor::fromRgbF(0.545, 0.545, 0.545, 0.6);
+  QColor arc_color = show_dm_engaged ? DM_ENGAGED_COLOR : DM_DISENGAGED_COLOR;
+  arc_color.setAlphaF(0.4 * (1.0 - dm_fade_state));
 
-  QColor arc_color = show_dm_engaged ? ENGAGED_COLOR : DISENGAGED_COLOR;
   float delta_x = -scene.driver_pose_sins[1] * arc_l / 2;
   float delta_y = -scene.driver_pose_sins[0] * arc_l / 2;
   painter.setPen(QPen(arc_color, arc_t_default+arc_t_extend*fmin(1.0, scene.driver_pose_diff[1] * 5.0), Qt::SolidLine, Qt::RoundCap));

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cmath>
 
-#include "common/params.h"
 #include "common/swaglog.h"
 #include "selfdrive/ui/qt/onroad/buttons.h"
 #include "selfdrive/ui/qt/util.h"
@@ -22,12 +21,6 @@ AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget* par
   main_layout->addWidget(experimental_btn, 0, Qt::AlignTop | Qt::AlignRight);
 
   dm_img = loadPixmap("../assets/img_driver_face.png", {img_size + 5, img_size + 5});
-}
-
-// Checks if "Always-On Driver Monitoring" toggle is enabled in settings
-bool AnnotatedCameraWidget::isDMAlwaysOn() const {
-  Params params;
-  return params.getBool("AlwaysOnDM");
 }
 
 void AnnotatedCameraWidget::updateState(const UIState &s) {
@@ -244,7 +237,7 @@ void AnnotatedCameraWidget::drawDriverState(QPainter &painter, const UIState *s)
   const float arc_t_default = 6.7;
   const float arc_t_extend = 12.0;
 
-  bool show_dm_engaged = s->engaged() || isDMAlwaysOn();
+  bool show_dm_engaged = s->engaged() || scene.always_on_dm;
 
   const QColor ENGAGED_COLOR = QColor::fromRgbF(0.1, 0.945, 0.26, 0.6);
   const QColor DISENGAGED_COLOR = QColor::fromRgbF(0.545, 0.545, 0.545, 0.6);

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -246,10 +246,10 @@ void AnnotatedCameraWidget::drawDriverState(QPainter &painter, const UIState *s)
 
   bool show_dm_engaged = s->engaged() || isDMAlwaysOn();
 
-  QColor arc_color = QColor::fromRgbF(0.545 - 0.445 * show_dm_engaged,
-                                      0.545 + 0.4 * show_dm_engaged,
-                                      0.545 - 0.285 * show_dm_engaged,
-                                      0.4 * (1.0 - dm_fade_state));
+  const QColor ENGAGED_COLOR = QColor::fromRgbF(0.1, 0.945, 0.26, 0.6);
+  const QColor DISENGAGED_COLOR = QColor::fromRgbF(0.545, 0.545, 0.545, 0.6);
+
+  QColor arc_color = show_dm_engaged ? ENGAGED_COLOR : DISENGAGED_COLOR;
   float delta_x = -scene.driver_pose_sins[1] * arc_l / 2;
   float delta_y = -scene.driver_pose_sins[0] * arc_l / 2;
   painter.setPen(QPen(arc_color, arc_t_default+arc_t_extend*fmin(1.0, scene.driver_pose_diff[1] * 5.0), Qt::SolidLine, Qt::RoundCap));

--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -35,6 +35,8 @@ private:
   int skip_frame_count = 0;
   bool wide_cam_requested = false;
 
+  bool isDMAlwaysOn() const;
+
 protected:
   void paintGL() override;
   void initializeGL() override;

--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -35,8 +35,6 @@ private:
   int skip_frame_count = 0;
   bool wide_cam_requested = false;
 
-  bool isDMAlwaysOn() const;
-
 protected:
   void paintGL() override;
   void initializeGL() override;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -213,6 +213,7 @@ static void update_state(UIState *s) {
 
 void ui_update_params(UIState *s) {
   auto params = Params();
+  s->scene.always_on_dm = params.getBool("AlwaysOnDM");
   s->scene.is_metric = params.getBool("IsMetric");
 }
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -98,7 +98,7 @@ typedef struct UIScene {
   cereal::LongitudinalPersonality personality;
 
   float light_sensor = -1;
-  bool started, ignition, is_metric, longitudinal_control;
+  bool always_on_dm, started, ignition, is_metric, longitudinal_control;
   bool world_objects_visible = false;
   uint64_t started_frame;
 } UIScene;


### PR DESCRIPTION
**Problem:** DM icon only shows engaged when openpilot is engaged. DM icon does not show it is engaged if "Always-on driver monitoring" is enabled. 

**Solution:** Make DM Icon show as engaged(with green tracking arcs as shown below) when either openpilot is engaged OR when Always-on driver monitoring is enabled. <br>
  <img width="177" alt="dm-engaged" src="https://github.com/user-attachments/assets/dbba54e6-a6da-43f8-ac06-78a21059250e">


<br>

## DM icon not engaged showing grey tracking arc color
![dm-icon-not-engaged](https://github.com/user-attachments/assets/2aa72a6d-db0b-48f6-a02f-a44e9f2c5eec)