### PR TITLE
tools/rerun: new image API for rerun 0.18

### DIFF
--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -37,6 +37,9 @@ echo "installing python packages..."
 uv --no-cache sync --frozen --all-extras
 source .venv/bin/activate
 
+# TODO: remove this. Workaround till get a new release. PEP508 doesn't seem to have find-links option
+uv pip install --pre -f https://build.rerun.io/commit/a93faab/wheels --upgrade rerun-sdk
+
 echo "PYTHONPATH=${PWD}" > $ROOT/.env
 if [[ "$(uname)" == 'Darwin' ]]; then
   echo "# msgq doesn't work on mac" >> $ROOT/.env

--- a/tools/rerun/run.py
+++ b/tools/rerun/run.py
@@ -127,10 +127,9 @@ class Rerunner:
     rr.init(RR_WIN)
     rr.connect(default_blueprint=blueprint)
 
-    size_hint = (h, w)
     for ts, frame in fr:
       rr.set_time_nanos(RR_TIMELINE_NAME, int(ts * 1e9))
-      rr.log(cam_type, rr.ImageEncoded(contents=frame,format=rr.ImageFormat.NV12(size_hint)))
+      rr.log(cam_type, rr.Image(bytes=frame, width=w, height=h, pixel_format=rr.PixelFormat.NV12))
 
   def load_data(self):
     self._start_rerun()


### PR DESCRIPTION
small part of adapting to rerun 0.18. Currently in pre-release of 0.18