### PR TITLE
Add car interfacing class

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -12,6 +12,7 @@ source_modules =
 forbidden_modules =
     cereal
     capnp
+    openpilot.common.params
     openpilot.system
     openpilot.body
     openpilot.docs
@@ -44,4 +45,6 @@ ignore_imports =
     openpilot.selfdrive.car.tests.test_car_interfaces -> openpilot.selfdrive.test.fuzzy_generation
     openpilot.selfdrive.car.tests.test_models -> cereal.messaging
     openpilot.selfdrive.car.tests.test_models -> cereal
+    openpilot.selfdrive.car.card -> openpilot.common.params
+    openpilot.selfdrive.car.tests.test_models -> openpilot.common.params
 unmatched_ignore_imports_alerting = warn

--- a/.importlinter
+++ b/.importlinter
@@ -1,6 +1,8 @@
 [importlinter]
 root_packages =
     openpilot
+    cereal
+    capnp
 
 [importlinter:contract:1]
 name = Forbid imports from openpilot.selfdrive.car to openpilot.system
@@ -8,6 +10,8 @@ type = forbidden
 source_modules =
     openpilot.selfdrive.car
 forbidden_modules =
+    cereal
+    capnp
     openpilot.system
     openpilot.body
     openpilot.docs
@@ -34,4 +38,10 @@ ignore_imports =
     openpilot.selfdrive.car.tests.test_car_interfaces -> openpilot.selfdrive.controls.lib.longcontrol
     openpilot.selfdrive.car.tests.test_car_interfaces -> openpilot.selfdrive.controls.lib.latcontrol_torque
     openpilot.selfdrive.car.tests.test_car_interfaces -> openpilot.selfdrive.controls.lib.latcontrol_pid
+    openpilot.selfdrive.car.tests.test_models -> capnp
+    openpilot.selfdrive.car.tests.test_car_interfaces -> cereal.messaging
+    openpilot.selfdrive.car.tests.test_car_interfaces -> cereal
+    openpilot.selfdrive.car.tests.test_car_interfaces -> openpilot.selfdrive.test.fuzzy_generation
+    openpilot.selfdrive.car.tests.test_models -> cereal.messaging
+    openpilot.selfdrive.car.tests.test_models -> cereal
 unmatched_ignore_imports_alerting = warn

--- a/selfdrive/car/car.py
+++ b/selfdrive/car/car.py
@@ -6,6 +6,13 @@ from selfdrive.car.interfaces import CarInterfaceBase, DT_CTRL
 from openpilot.selfdrive.car.car_helpers import get_car, get_one_can
 
 
+@dataclass(frozen=True)
+class CanData:
+  address: int
+  dat: bytes
+  src: int
+
+
 class Car:
   """All encompassing class for interfacing with a vehicle."""
 

--- a/selfdrive/car/car.py
+++ b/selfdrive/car/car.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from collections import namedtuple
+
+# from selfdrive.car.interfaces import get_interface_attr
+from selfdrive.car.interfaces import CarInterfaceBase
+from openpilot.selfdrive.car.car_helpers import get_car, get_one_can
+
+
+class Car:
+  """All encompassing class for interfacing with a vehicle."""
+
+  def __init__(self, logcan, sendcan):
+    """
+    Inputs:
+    - logcan: function that returns a list of the latest CAN messages
+    - sendcan: function that sends a CAN message
+    """
+    self.logcan = logcan
+    self.sendcan = sendcan
+
+    self.CI: CarInterfaceBase | None = None
+
+  def fingerprint(self, experimental_long_allowed: bool, num_pandas: int) -> CarInterfaceBase:
+    """Fingerprint the vehicle and return a car interface."""
+
+    if self.CI is None:
+      # TODO: return a car interface object all filled out, with no cereal/capnp
+      self.CI = get_car(self.logcan, self.sendcan, experimental_long_allowed, num_pandas)
+    return self.CI

--- a/selfdrive/car/car.py
+++ b/selfdrive/car/car.py
@@ -2,21 +2,26 @@ from dataclasses import dataclass
 from collections import namedtuple
 
 # from selfdrive.car.interfaces import get_interface_attr
-from selfdrive.car.interfaces import CarInterfaceBase
+from selfdrive.car.interfaces import CarInterfaceBase, DT_CTRL
 from openpilot.selfdrive.car.car_helpers import get_car, get_one_can
 
 
 class Car:
   """All encompassing class for interfacing with a vehicle."""
 
-  def __init__(self, logcan, sendcan):
+  def __init__(self, logcan, sendcan, dt_ctrl=DT_CTRL):
     """
     Inputs:
     - logcan: function that returns a list of the latest CAN messages
     - sendcan: function that sends a CAN message
+    - dt_ctrl: control loop time step
     """
     self.logcan = logcan
     self.sendcan = sendcan
+    self.dt_ctrl = dt_ctrl
+
+    # TODO: 100 Hz is currently the only supported rate
+    assert self.dt_ctrl == DT_CTRL
 
     self.CI: CarInterfaceBase | None = None
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -184,7 +184,7 @@ def get_car(logcan, sendcan, experimental_long_allowed, num_pandas=1):
   CP.fingerprintSource = source
   CP.fuzzyFingerprint = not exact_match
 
-  return get_car_interface(CP), CP
+  return get_car_interface(CP)
 
 def write_car_param(platform=MOCK.MOCK):
   params = Params()

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from cereal import car
 from openpilot.common.params import Params
 from openpilot.selfdrive.car import carlog
+# from openpilot.selfdrive.car.data_structures import CarParams
 from openpilot.selfdrive.car.interfaces import get_interface_attr
 from openpilot.selfdrive.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 from openpilot.selfdrive.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -51,7 +51,8 @@ class Car:
 
       num_pandas = len(messaging.recv_one_retry(self.sm.sock['pandaStates']).pandaStates)
       experimental_long_allowed = self.params.get_bool("ExperimentalLongitudinalEnabled")
-      self.CI, self.CP = get_car(self.can_sock, self.pm.sock['sendcan'], experimental_long_allowed, num_pandas)
+      self.CI = get_car(self.can_sock, self.pm.sock['sendcan'], experimental_long_allowed, num_pandas)
+      self.CP = self.CI.CP
     else:
       self.CI, self.CP = CI, CI.CP
 

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -14,7 +14,8 @@ from openpilot.common.swaglog import cloudlog, ForwardingHandler
 
 from openpilot.selfdrive.pandad import can_list_to_can_capnp
 from openpilot.selfdrive.car import DT_CTRL, carlog
-from openpilot.selfdrive.car.car_helpers import get_car, get_one_can
+from openpilot.selfdrive.car.car import Car as CarInterfacer  # FIXME: less confusing name
+from openpilot.selfdrive.car.car_helpers import get_one_can
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.controls.lib.events import Events
 
@@ -51,7 +52,8 @@ class Car:
 
       num_pandas = len(messaging.recv_one_retry(self.sm.sock['pandaStates']).pandaStates)
       experimental_long_allowed = self.params.get_bool("ExperimentalLongitudinalEnabled")
-      self.CI = get_car(self.can_sock, self.pm.sock['sendcan'], experimental_long_allowed, num_pandas)
+      self.car = CarInterfacer(self.can_sock, self.pm.sock['sendcan'], DT_CTRL)
+      self.CI = self.car.fingerprint(experimental_long_allowed, num_pandas)
       self.CP = self.CI.CP
     else:
       self.CI, self.CP = CI, CI.CP

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -14,7 +14,7 @@ from openpilot.common.swaglog import cloudlog, ForwardingHandler
 
 from openpilot.selfdrive.pandad import can_list_to_can_capnp
 from openpilot.selfdrive.car import DT_CTRL, carlog
-from openpilot.selfdrive.car.car import Car as CarInterfacer  # FIXME: less confusing name
+from openpilot.selfdrive.car.opencar import OpenCar
 from openpilot.selfdrive.car.car_helpers import get_one_can
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 from openpilot.selfdrive.controls.lib.events import Events
@@ -52,8 +52,8 @@ class Car:
 
       num_pandas = len(messaging.recv_one_retry(self.sm.sock['pandaStates']).pandaStates)
       experimental_long_allowed = self.params.get_bool("ExperimentalLongitudinalEnabled")
-      self.car = CarInterfacer(self.can_sock, self.pm.sock['sendcan'], DT_CTRL)
-      self.CI = self.car.fingerprint(experimental_long_allowed, num_pandas)
+      self.open_car = OpenCar(self.can_sock, self.pm.sock['sendcan'], DT_CTRL)
+      self.CI = self.open_car.fingerprint(experimental_long_allowed, num_pandas)
       self.CP = self.CI.CP
     else:
       self.CI, self.CP = CI, CI.CP

--- a/selfdrive/car/data_structures.py
+++ b/selfdrive/car/data_structures.py
@@ -1,0 +1,120 @@
+# TODO: maybe call comms.py?
+# TODO: maybe put in car_helpers.py? need to remove fingerprinting from car_helpers.py
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import NamedTuple
+
+
+# TODO namedtuple doesn't support dict -> tuple conversion, it's purely order based.
+# dataclass seems to be the best for easy conversion in openpilot
+@dataclass
+class CarParams:
+  carName: str
+  carFingerprint: str
+  fuzzyFingerprint: bool
+
+  notCar: bool
+
+  pcmCruise: bool
+  enableDsu: bool
+  enableBsm: bool
+  flags: int
+  experimentalLongitudinalAvailable: bool
+
+  minEnableSpeed: float
+  minSteerSpeed: float
+  # safetyConfigs: list[SafetyConfig]
+  alternativeExperience: int
+
+  # Car docs fields
+  maxLateralAccel: float
+  autoResumeSng: bool
+
+  # things about the car in the manual
+  mass: float
+  wheelbase: float
+  centerToFront: float
+  steerRatio: float
+  steerRatioRear: float
+
+  # things we can derive
+  rotationalInertia: float
+  tireStiffnessFactor: float
+  tireStiffnessFront: float
+  tireStiffnessRear: float
+
+  # TODO: the rest
+  # longitudinalTuning: LongitudinalPIDTuning
+  # lateralParams: LateralParams
+  #
+  # pid: LateralPIDTuning
+  # indiDEPRECATED: LateralINDITuning
+  # lqrDEPRECATED: LateralLQRTuning
+  # torque: LateralTorqueTuning
+  # steerLimitAlert: bool
+  # steerLimitTimer: float
+  #
+  # vEgoStopping: float
+  # vEgoStarting: float
+  # stoppingControl: bool
+  # steerControlType: SteerControlType
+  # radarUnavailable: bool
+  # stopAccel: float
+  # stoppingDecelRate: float
+  # startAccel: float
+  # startingState: bool
+  #
+  # steerActuatorDelay: float
+  # longitudinalActuatorDelay: float
+  # openpilotLongitudinalControl: bool
+  # carVin: str
+  # transmissionType: TransmissionType
+  # networkLocation: NetworkLocation
+  #
+  # wheelSpeedFactor: float
+  #
+  #
+  #
+  # safetyModel: SafetyModel
+  # safetyParam: UInt16
+  # safetyParamDEPRECATED: Int16
+  # safetyParam2DEPRECATED: int
+  # kf: float
+  # useSteeringAngle: bool
+  # kp: float
+  # ki: float
+  # friction: float
+  # kf: float
+  # steeringAngleDeadzoneDeg: float
+  # latAccelFactor: float
+  # latAccelOffset: float
+  # kf: float
+  # outerLoopGainDEPRECATED: float
+  # innerLoopGainDEPRECATED: float
+  # timeConstantDEPRECATED: float
+  # actuatorEffectivenessDEPRECATED: float
+  # scale: float
+  # ki: float
+  # dcGain: float
+  # ecu: Ecu
+  # fwVersion: Data
+  # address: int
+  # subAddress: UInt8
+  # responseAddress: int
+  # brand: str
+  # bus: UInt8
+  # logging: bool
+  # obdMultiplexing: bool
+  # enableGasInterceptorDEPRECATED: bool
+  # enableCameraDEPRECATED: bool
+  # enableApgsDEPRECATED: bool
+  # steerRateCostDEPRECATED: float
+  # isPandaBlackDEPRECATED: bool
+  # hasStockCameraDEPRECATED: bool
+  # safetyParamDEPRECATED: Int16
+  # safetyModelDEPRECATED: SafetyModel
+  # minSpeedCanDEPRECATED: float
+  # startingAccelRateDEPRECATED: float
+  # directAccelControlDEPRECATED: bool
+  # maxSteeringAngleDegDEPRECATED: float
+  # longitudinalActuatorDelayLowerBoundDEPRECATEDDEPRECATED: float

--- a/selfdrive/car/opencar.py
+++ b/selfdrive/car/opencar.py
@@ -13,7 +13,7 @@ class CanData:
   src: int
 
 
-class Car:
+class OpenCar:
   """All encompassing class for interfacing with a vehicle."""
 
   def __init__(self, logcan, sendcan, dt_ctrl=DT_CTRL):


### PR DESCRIPTION
Doesn't quite make sense to put this inside CarInterfaceBase, as the child classes import from the base class file, causing circular import errors.