### PR TITLE
remove unnecessary debugging function from car_helpers.py

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -159,8 +159,8 @@ def fingerprint(logcan, sendcan, num_pandas):
     source = car.CarParams.FingerprintSource.fixed
 
   carlog.error({"event": "fingerprinted", "car_fingerprint": car_fingerprint, "source": source, "fuzzy": not exact_match,
-                 "cached": cached, "fw_count": len(car_fw), "ecu_responses": list(ecu_rx_addrs), "vin_rx_addr": vin_rx_addr,
-                 "vin_rx_bus": vin_rx_bus, "fingerprints": repr(finger), "fw_query_time": fw_query_time})
+                "cached": cached, "fw_count": len(car_fw), "ecu_responses": list(ecu_rx_addrs), "vin_rx_addr": vin_rx_addr,
+                "vin_rx_bus": vin_rx_bus, "fingerprints": repr(finger), "fw_query_time": fw_query_time})
 
   return car_fingerprint, finger, vin, car_fw, source, exact_match
 
@@ -186,11 +186,6 @@ def get_car(logcan, sendcan, experimental_long_allowed, num_pandas=1):
 
   return get_car_interface(CP), CP
 
-def write_car_param(platform=MOCK.MOCK):
-  params = Params()
-  CarInterface, _, _ = interfaces[platform]
-  CP = CarInterface.get_non_essential_params(platform)
-  params.put("CarParams", CP.to_bytes())
 
 def get_demo_car_params():
   platform = MOCK.MOCK

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -105,8 +105,8 @@ def fingerprint(logcan, sendcan, num_pandas):
         if cached_params.carName == "mock":
           cached_params = None
 
-    if (cached_params is not None and len(cached_params.carFw) > 0 and
-      cached_params.carVin is not VIN_UNKNOWN and not disable_fw_cache):
+    if cached_params is not None and len(cached_params.carFw) > 0 and \
+       cached_params.carVin is not VIN_UNKNOWN and not disable_fw_cache:
       carlog.warning("Using cached CarParams")
       vin_rx_addr, vin_rx_bus, vin = -1, -1, cached_params.carVin
       car_fw = list(cached_params.carFw)

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -105,8 +105,8 @@ def fingerprint(logcan, sendcan, num_pandas):
         if cached_params.carName == "mock":
           cached_params = None
 
-    if cached_params is not None and len(cached_params.carFw) > 0 and \
-       cached_params.carVin is not VIN_UNKNOWN and not disable_fw_cache:
+    if (cached_params is not None and len(cached_params.carFw) > 0 and
+      cached_params.carVin is not VIN_UNKNOWN and not disable_fw_cache):
       carlog.warning("Using cached CarParams")
       vin_rx_addr, vin_rx_bus, vin = -1, -1, cached_params.carVin
       car_fw = list(cached_params.carFw)

--- a/selfdrive/modeld/tests/test_modeld.py
+++ b/selfdrive/modeld/tests/test_modeld.py
@@ -3,9 +3,10 @@ import random
 
 import cereal.messaging as messaging
 from msgq.visionipc import VisionIpcServer, VisionStreamType
+from openpilot.common.params import Params
 from openpilot.common.transformations.camera import DEVICE_CAMERAS
 from openpilot.common.realtime import DT_MDL
-from openpilot.selfdrive.car.car_helpers import write_car_param
+from openpilot.selfdrive.car.car_helpers import get_demo_car_params
 from openpilot.system.manager.process_config import managed_processes
 from openpilot.selfdrive.test.process_replay.vision_meta import meta_from_camera_state
 
@@ -22,7 +23,7 @@ class TestModeld:
     self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_DRIVER, 40, False, CAM.width, CAM.height)
     self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_WIDE_ROAD, 40, False, CAM.width, CAM.height)
     self.vipc_server.start_listener()
-    write_car_param()
+    Params().put("CarParams", get_demo_car_params().to_bytes())
 
     self.sm = messaging.SubMaster(['modelV2', 'cameraOdometry'])
     self.pm = messaging.PubMaster(['roadCameraState', 'wideRoadCameraState', 'liveCalibration'])

--- a/system/hardware/tici/tests/test_power_draw.py
+++ b/system/hardware/tici/tests/test_power_draw.py
@@ -8,7 +8,8 @@ from tabulate import tabulate
 import cereal.messaging as messaging
 from cereal.services import SERVICE_LIST
 from openpilot.common.mock import mock_messages
-from openpilot.selfdrive.car.car_helpers import write_car_param
+from openpilot.common.params import Params
+from openpilot.selfdrive.car.car_helpers import get_demo_car_params
 from openpilot.system.hardware.tici.power_monitor import get_power
 from openpilot.system.manager.process_config import managed_processes
 from openpilot.system.manager.manager import manager_cleanup
@@ -41,7 +42,7 @@ PROCS = [
 class TestPowerDraw:
 
   def setup_method(self):
-    write_car_param()
+    Params().put("CarParams", get_demo_car_params().to_bytes())
 
     # wait a bit for power save to disable
     time.sleep(5)


### PR DESCRIPTION
remove a Params usage from car_helpers which shouldn't know about params

split from https://github.com/commaai/openpilot/pull/33198