### PR TITLE
pandad: simplify check for new pandas

### DIFF
--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -314,12 +314,6 @@ void send_peripheral_state(Panda *panda, PubMaster *pm) {
 
 void process_panda_state(std::vector<Panda *> &pandas, PubMaster *pm, bool spoofing_started) {
   static SubMaster sm({"controlsState"});
-
-  std::vector<std::string> connected_serials;
-  for (Panda *p : pandas) {
-    connected_serials.push_back(p->hw_serial());
-  }
-
   {
     auto ignition_opt = send_panda_states(pm, pandas, spoofing_started);
     if (!ignition_opt) {
@@ -341,7 +335,7 @@ void process_panda_state(std::vector<Panda *> &pandas, PubMaster *pm, bool spoof
       } else {
         // check for new pandas
         for (std::string &s : Panda::list(true)) {
-          if (!std::count(connected_serials.begin(), connected_serials.end(), s)) {
+          if (std::none_of(pandas.begin(), pandas.end(), [&s](Panda *p) { return p->hw_serial() == s; })) {
             LOGW("Reconnecting to new panda: %s", s.c_str());
             do_exit = true;
             break;


### PR DESCRIPTION
Removed the intermediate `connected_serials` vector and using std::none_of to check if serials exist in pandas. 