### PR TITLE
tools/logreader: add desc arg to run_across_segments()

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -293,11 +293,11 @@ are uploaded or auto fallback to qlogs with '/a' selector at the end of the rout
   def _run_on_segment(self, func, i):
     return func(self._get_lr(i))
 
-  def run_across_segments(self, num_processes, func):
+  def run_across_segments(self, num_processes, func, desc=None):
     with multiprocessing.Pool(num_processes) as pool:
       ret = []
       num_segs = len(self.logreader_identifiers)
-      for p in tqdm.tqdm(pool.imap(partial(self._run_on_segment, func), range(num_segs)), total=num_segs):
+      for p in tqdm.tqdm(pool.imap(partial(self._run_on_segment, func), range(num_segs)), total=num_segs, desc=desc):
         ret.extend(p)
       return ret
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bf7cd623-f4ce-4675-a0c9-2154835c3ace)

Nice to have something like this