### PR TITLE
pandad: simplify `check_all_connected`

### DIFF
--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -44,13 +44,7 @@
 ExitHandler do_exit;
 
 bool check_all_connected(const std::vector<Panda *> &pandas) {
-  for (const auto& panda : pandas) {
-    if (!panda->connected()) {
-      do_exit = true;
-      return false;
-    }
-  }
-  return true;
+  return std::all_of(pandas.begin(), pandas.end(), [](Panda *p) { return p->connected(); });
 }
 
 Panda *connect(std::string serial="", uint32_t index=0) {


### PR DESCRIPTION
Simplify `check_all_connected` by using std::all_of and removing the do_exit update, as it's now unnecessary after the removal of the panda safety thread. The `check_all_connected` function is now always used with `do_exit` like this:

> if (!do_exit && check_all_connected()) {
> ...
> }