### PR TITLE
Add testing closet to LogReader source

### DIFF
--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -7,10 +7,10 @@ from openpilot.tools.lib.url_file import URLFile
 DATA_ENDPOINT = os.getenv("DATA_ENDPOINT", "http://data-raw.comma.internal/")
 
 
-def internal_source_available():
+def internal_source_available(url=DATA_ENDPOINT):
   try:
-    hostname = urlparse(DATA_ENDPOINT).hostname
-    port = urlparse(DATA_ENDPOINT).port or 80
+    hostname = urlparse(url).hostname
+    port = urlparse(url).port or 80
     with socket.socket(socket.AF_INET,socket.SOCK_STREAM) as s:
       s.connect((hostname, port))
     return True

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -174,6 +174,10 @@ def comma_car_segments_source(sr: SegmentRange, mode=ReadMode.RLOG) -> LogPaths:
   return [get_comma_segments_url(sr.route_name, seg) for seg in sr.seg_idxs]
 
 
+def testing_closet_source(sr: SegmentRange, mode=ReadMode.RLOG) -> LogPaths:
+  return [f"http://testing.comma.life/download/{sr.route_name.replace('|', '/')}/{seg}/rlog" for seg in sr.seg_idxs]
+
+
 def direct_source(file_or_url: str) -> LogPaths:
   return [file_or_url]
 
@@ -195,7 +199,7 @@ def auto_source(sr: SegmentRange, mode=ReadMode.RLOG) -> LogPaths:
   if mode == ReadMode.SANITIZED:
     return comma_car_segments_source(sr, mode)
 
-  SOURCES: list[Source] = [internal_source, internal_source_zst, openpilotci_source, comma_api_source, comma_car_segments_source,]
+  SOURCES: list[Source] = [internal_source, internal_source_zst, openpilotci_source, comma_api_source, comma_car_segments_source, testing_closet_source,]
   exceptions = {}
 
   # for automatic fallback modes, auto_source needs to first check if rlogs exist for any source

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -11,7 +11,6 @@ import tqdm
 import urllib.parse
 import warnings
 import zstandard as zstd
-import socket
 
 from collections.abc import Callable, Iterable, Iterator
 from urllib.parse import parse_qs, urlparse
@@ -176,12 +175,9 @@ def comma_car_segments_source(sr: SegmentRange, mode=ReadMode.RLOG) -> LogPaths:
 
 
 def testing_closet_source(sr: SegmentRange, mode=ReadMode.RLOG) -> LogPaths:
-  try:
-    with socket.socket(socket.AF_INET,socket.SOCK_STREAM) as s:
-      s.connect(("testing.comma.life", 80))
-    return [f"http://testing.comma.life/download/{sr.route_name.replace('|', '/')}/{seg}/rlog" for seg in sr.seg_idxs]
-  except (socket.gaierror, ConnectionRefusedError) as err:
-    raise InternalUnavailableException from err
+  if not internal_source_available('http://testing.comma.life'):
+    raise InternalUnavailableException
+  return [f"http://testing.comma.life/download/{sr.route_name.replace('|', '/')}/{seg}/rlog" for seg in sr.seg_idxs]
 
 
 def direct_source(file_or_url: str) -> LogPaths:


### PR DESCRIPTION
Adds testing.comma.life as a LogReader source to easily pull logs from the testing closet.