### PR TITLE
tools/sim: resolve import error on MacOS running Metadrive

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
@@ -73,6 +73,8 @@ lenv["CXXFLAGS"].append("-DACADOS_WITH_QPOASES")
 lenv["CCFLAGS"].append("-Wno-unused")
 if arch != "Darwin":
   lenv["LINKFLAGS"].append("-Wl,--disable-new-dtags")
+else:
+  lenv["LINKFLAGS"].append("-Wl,-install_name,@loader_path/libacados_ocp_solver_long.dylib")
 lib_solver = lenv.SharedLibrary(f"{gen}/acados_ocp_solver_long",
                                 build_files,
                                 LIBS=['m', 'acados', 'hpipm', 'blasfeo', 'qpOASES_e'])


### PR DESCRIPTION
no more of this import error when running `op sim`. similar to [this](https://github.com/commaai/opendbc/commit/de39b143a31cd29b4df4c0cbba71316c1bc8e71b)
```
ImportError: dlopen(/Users/bongb/mac_op/openpilot/selfdrive/controls/lib/longitudinal_mpc_lib/c_generated_code/acados_ocp_solver_pyx.so, 0x0002): Library not loaded: selfdrive/controls/libTraceback (most recent call last):
  File "/Users/bongb/mac_op/tools/sim/run_bridge.py", line 32, in <module>
    queue, simulator_process, simulator_bridge = create_bridge(args.dual_camera, args.high_quality)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```