### PR TITLE
proclogd: improve cache robustness and prevent memory bloat

### DIFF
--- a/system/proclogd/proclog.h
+++ b/system/proclogd/proclog.h
@@ -1,4 +1,5 @@
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -13,7 +14,8 @@ struct CPUTime {
 
 struct ProcCache {
   int pid;
-  std::string name, exe;
+  unsigned long start_time;
+  std::string exe;
   std::vector<std::string> cmdline;
 };
 
@@ -28,12 +30,12 @@ struct ProcStat {
 
 namespace Parser {
 
-std::vector<int> pids();
+std::set<int> pids();
 std::optional<ProcStat> procStat(std::string stat);
 std::vector<std::string> cmdline(std::istream &stream);
 std::vector<CPUTime> cpuTimes(std::istream &stream);
 std::unordered_map<std::string, uint64_t> memInfo(std::istream &stream);
-const ProcCache &getProcExtraInfo(int pid, const std::string &name);
+ProcCache getProcExtraInfo(int pid, unsigned long start_time);
 
 };  // namespace Parser
 

--- a/system/proclogd/tests/test_proclog.cc
+++ b/system/proclogd/tests/test_proclog.cc
@@ -31,7 +31,7 @@ TEST_CASE("Parser::procStat") {
     REQUIRE(stat->processor == 2);
   }
   SECTION("all processes") {
-    std::vector<int> pids = Parser::pids();
+    std::set<int> pids = Parser::pids();
     REQUIRE(pids.size() > 1);
     for (int pid : pids) {
       std::string stat_path = "/proc/" + std::to_string(pid) + "/stat";


### PR DESCRIPTION
1. **Use starttime for validation:** Switches to using process `starttime` instead of process `name` to track PID reuse and process restarts, ensuring that cached data is valid and accurately reflects the current process.
2. **Faster PID lookup:** Replaces std::vector with std::set for quicker PID lookups and more efficient cache cleanup.
3. **Cleanup stale entries::** Adds a cleanup process for stale entries in proc_cache to prevent unbounded memory growth and manage memory more effectively.

This PR improves cache robustness and resolves the issue of gradual memory bloat in proclogd over time, enhancing long-term stability and performance.