### PR TITLE
Revert "spinner: fix missing colon in QProgressBar border style"

### DIFF
--- a/selfdrive/ui/qt/spinner.cc
+++ b/selfdrive/ui/qt/spinner.cc
@@ -83,7 +83,7 @@ Spinner::Spinner(QWidget *parent) : QWidget(parent) {
     QProgressBar {
       background-color: #373737;
       width: 1000px;
-      border: 1px solid white;
+      border solid white;
       border-radius: 10px;
     }
     QProgressBar::chunk {


### PR DESCRIPTION
Reverts commaai/openpilot#33258

this changes the style

![image](https://github.com/user-attachments/assets/23e98b67-850c-4231-85b4-47c71d3e9042)

OG:
![image](https://github.com/user-attachments/assets/da25ece1-04a5-45b5-9ab4-9633509c7601)
