### PR TITLE
ui/keyboard: add TODO to fix margin variable usage in QPushButton stylesheet

### DIFF
--- a/selfdrive/ui/qt/widgets/keyboard.cc
+++ b/selfdrive/ui/qt/widgets/keyboard.cc
@@ -80,6 +80,8 @@ KeyboardLayout::KeyboardLayout(QWidget* parent, const std::vector<QVector<QStrin
     main_layout->addLayout(hlayout);
   }
 
+  // TODO: Fix variable usage. `key_spacing_vertical` should be used for vertical margins (top and bottom),
+  // and `key_spacing_horizontal` should be used for horizontal margins (left and right).
   setStyleSheet(QString(R"(
     QPushButton {
       font-size: 75px;


### PR DESCRIPTION
Adds a TODO to address a mistake in the QPushButton stylesheet where vertical and horizontal spacing variables were incorrectly used:  `key_spacing_vertical` is used for horizontal margins, and `key_spacing_horizontal` is used for vertical margins.

Since fixing this might change the layout, added a TODO to note the issue.