### PR TITLE
common/util: refactor `sleep_for` for high-precision sleep 

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -93,11 +93,7 @@ bool create_directories(const std::string &dir, mode_t mode);
 
 std::string check_output(const std::string& command);
 
-inline void sleep_for(const int milliseconds) {
-  if (milliseconds > 0) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
-  }
-}
+void sleep_for(double milliseconds);
 
 }  // namespace util
 


### PR DESCRIPTION
Changes:

1. Refactored` util::sleep_for` to use `clock_nanosleep` (or `nanosleep` on macOS) for more accurate sleep durations than `std::thread::sleep_for`, especially for very short sleep durations. 
2. support double values for fractional millisecond timing.

This refactor enhances sleep precision across C++ modules, with significant benefits for the `RateKeeper` class: It also improves event scheduling accuracy in Python modules that rely on stable rate keeping provided by the `RateKeeper` in the C++ module.
