### PR TITLE
lint.sh: check shebang format for bash + python3

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -67,7 +67,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         cp pyproject.toml $STRIPPED_DIR
         cd $STRIPPED_DIR
-        ${{ env.RUN }} "scripts/lint.sh --skip check_added_large_files"
+        ${{ env.RUN }} "scripts/lint/lint.sh --skip check_added_large_files"
 
   build:
     strategy:

--- a/scripts/lint/check_shebang_format.sh
+++ b/scripts/lint/check_shebang_format.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+FAIL=0
+
+if grep '^#!.*python$' $@ | grep -v '#!/usr/bin/env python3$'; then
+  echo -e "Invalid shebang! Must use '#!/usr/bin/env python3'\n"
+  FAIL=1
+fi
+
+if grep '^#!.*bash$' $@ | grep -v '#!/usr/bin/env bash$'; then
+  echo -e "Invalid shebang! Must use '#!/usr/bin/env bash'"
+  FAIL=1
+fi
+
+exit $FAIL

--- a/scripts/lint/lint.sh
+++ b/scripts/lint/lint.sh
@@ -8,7 +8,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-cd $DIR/../
+cd $DIR/../../
 
 FAILED=0
 
@@ -51,6 +51,7 @@ function run_tests() {
   run "lint-imports" lint-imports
   run "check_added_large_files" python3 -m pre_commit_hooks.check_added_large_files --enforce-all $ALL_FILES --maxkb=120
   run "check_shebang_scripts_are_executable" python3 -m pre_commit_hooks.check_shebang_scripts_are_executable $ALL_FILES
+  run "check_shebang_format" $DIR/check_shebang_format.sh $ALL_FILES
 
   if [[ -z "$FAST" ]]; then
     run "mypy" mypy $PYTHON_FILES

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -273,7 +273,7 @@ function op_juggle() {
 
 function op_lint() {
   op_before_cmd
-  op_run_command scripts/lint.sh $@
+  op_run_command scripts/lint/lint.sh $@
 }
 
 function op_test() {


### PR DESCRIPTION
https://github.com/commaai/openpilot/issues/32761

Enforce `#!/usr/bin/env python3` and `#!/usr/bin/env bash`