### PR TITLE
util: enhance sleep_for function to support double milliseconds

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -93,9 +93,9 @@ bool create_directories(const std::string &dir, mode_t mode);
 
 std::string check_output(const std::string& command);
 
-inline void sleep_for(const int milliseconds) {
+inline void sleep_for(double milliseconds) {
   if (milliseconds > 0) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+    std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(milliseconds));
   }
 }
 


### PR DESCRIPTION
updates the sleep_for function to accept a double parameter, enabling support for fractional milliseconds and allowing for more precise timing control.

Note:
The RateKeeper requires double precision for accurate timing. By updating the sleep_for function, we align with the precision needs of the RateKeeper implementation, ensuring that the timing calculations are as accurate as possible:

https://github.com/commaai/openpilot/blob/7248b00086f9b8d5d95c80a2eb7fe89c387f44ea/common/ratekeeper.cc#L17-L23