### PR TITLE
Tesla: use raw speed for standstill detection

### DIFF
--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -27,7 +27,7 @@ class CarState(CarStateBase):
     # Vehicle speed
     ret.vEgoRaw = cp.vl["ESP_B"]["ESP_vehicleSpeed"] * CV.KPH_TO_MS
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
-    ret.standstill = (ret.vEgo < 0.1)
+    ret.standstill = ret.vEgoRaw <= 0.1
 
     # Gas pedal
     ret.gas = cp.vl["DI_torque1"]["DI_pedalPos"] / 100.0


### PR DESCRIPTION
I believe test_models still reports mismatches due to the different messages they use. This is a Model S multi panda problem and will be resolved with the Model 3 port, right @robbederks?