### PR TITLE
"important" logging level

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2353,6 +2353,7 @@ struct Event {
     clocks @35 :Clocks;
     deviceState @6 :DeviceState;
     logMessage @18 :Text;
+    importantLogMessage @130 :Text;
     errorLogMessage @85 :Text;
 
     # navigation

--- a/cereal/services.py
+++ b/cereal/services.py
@@ -31,6 +31,7 @@ _services: dict[str, tuple] = {
   "liveTracks": (True, 20.),
   "sendcan": (True, 100., 139),
   "logMessage": (True, 0.),
+  "importantLogMessage": (True, 0., 1),
   "errorLogMessage": (True, 0., 1),
   "liveCalibration": (True, 4., 4),
   "liveTorqueParameters": (True, 4., 1),

--- a/common/logging_extra.py
+++ b/common/logging_extra.py
@@ -12,6 +12,15 @@ from threading import local
 from collections import OrderedDict
 from contextlib import contextmanager
 
+LEVELS = {
+  "DEBUG": 10,
+  "INFO": 20,
+  "WARNING": 30,
+  "IMPORTANT": 35,
+  "ERROR": 40,
+  "CRITICAL": 50,
+}
+
 LOG_TIMESTAMPS = "LOG_TIMESTAMPS" in os.environ
 
 def json_handler(obj):
@@ -154,9 +163,8 @@ class SwagLogger(logging.Logger):
     self.global_ctx.update(kwargs)
 
   def important(self, msg, *args, **kwargs):
-    IMPORTANT = 35
-    if self.isEnabledFor(IMPORTANT):
-      self._log(IMPORTANT, msg, args, **kwargs)
+    if self.isEnabledFor(LEVELS["IMPORTANT"]):
+      self._log(LEVELS["IMPORTANT"], msg, args, **kwargs)
 
   def event(self, event, *args, **kwargs):
     evt = NiceOrderedDict()

--- a/common/logging_extra.py
+++ b/common/logging_extra.py
@@ -153,6 +153,11 @@ class SwagLogger(logging.Logger):
   def bind_global(self, **kwargs):
     self.global_ctx.update(kwargs)
 
+  def important(self, msg, *args, **kwargs):
+    IMPORTANT = 35
+    if self.isEnabledFor(IMPORTANT):
+      self._log(IMPORTANT, msg, args, **kwargs)
+
   def event(self, event, *args, **kwargs):
     evt = NiceOrderedDict()
     evt['event'] = event
@@ -161,6 +166,8 @@ class SwagLogger(logging.Logger):
     evt.update(kwargs)
     if 'error' in kwargs:
       self.error(evt)
+    elif 'important' in kwargs:
+      self.important(evt)
     elif 'debug' in kwargs:
       self.debug(evt)
     else:

--- a/common/swaglog.h
+++ b/common/swaglog.h
@@ -5,6 +5,7 @@
 #define CLOUDLOG_DEBUG 10
 #define CLOUDLOG_INFO 20
 #define CLOUDLOG_WARNING 30
+#define CLOUDLOG_IMPORTANT 35
 #define CLOUDLOG_ERROR 40
 #define CLOUDLOG_CRITICAL 50
 
@@ -68,9 +69,11 @@ void cloudlog_te(int levelnum, const char* filename, int lineno, const char* fun
 #define LOGD(fmt, ...) cloudlog(CLOUDLOG_DEBUG, fmt, ## __VA_ARGS__)
 #define LOG(fmt, ...) cloudlog(CLOUDLOG_INFO, fmt, ## __VA_ARGS__)
 #define LOGW(fmt, ...) cloudlog(CLOUDLOG_WARNING, fmt, ## __VA_ARGS__)
+#define LOGI(fmt, ...) cloudlog(CLOUDLOG_IMPORTANT, fmt, ## __VA_ARGS__)
 #define LOGE(fmt, ...) cloudlog(CLOUDLOG_ERROR, fmt, ## __VA_ARGS__)
 
 #define LOGD_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_DEBUG, fmt, ## __VA_ARGS__)
 #define LOG_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_INFO, fmt, ## __VA_ARGS__)
 #define LOGW_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_WARNING, fmt, ## __VA_ARGS__)
+#define LOGI_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_IMPORTANT, fmt, ## __VA_ARGS__)
 #define LOGE_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_ERROR, fmt, ## __VA_ARGS__)

--- a/common/swaglog.py
+++ b/common/swaglog.py
@@ -110,7 +110,10 @@ class ForwardingHandler(logging.Handler):
     self.target_logger = target_logger
 
   def emit(self, record):
-    self.target_logger.handle(record)
+    if record.levelno == logging.INFO and hasattr(record, 'important') and hasattr(self.target_logger, 'important'):
+      self.target_logger.important(record.msg)
+    else:
+      self.target_logger.handle(record)
 
 
 def add_file_handler(log):

--- a/common/swaglog.py
+++ b/common/swaglog.py
@@ -110,7 +110,7 @@ class ForwardingHandler(logging.Handler):
     self.target_logger = target_logger
 
   def emit(self, record):
-    if record.levelno == logging.INFO and hasattr(record, 'important') and hasattr(self.target_logger, 'important'):
+    if record.levelno < logging.ERROR and hasattr(record, 'important') and hasattr(self.target_logger, 'important'):
       self.target_logger.important(record.msg)
     else:
       self.target_logger.handle(record)

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -141,9 +141,9 @@ def fingerprint(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_mu
     car_fingerprint = fixed_fingerprint
     source = car.CarParams.FingerprintSource.fixed
 
-  carlog.error({"event": "fingerprinted", "car_fingerprint": str(car_fingerprint), "source": source, "fuzzy": not exact_match,
+  carlog.info({"event": "fingerprinted", "car_fingerprint": str(car_fingerprint), "source": source, "fuzzy": not exact_match,
                 "cached": cached, "fw_count": len(car_fw), "ecu_responses": list(ecu_rx_addrs), "vin_rx_addr": vin_rx_addr,
-                "vin_rx_bus": vin_rx_bus, "fingerprints": repr(finger), "fw_query_time": fw_query_time})
+                "vin_rx_bus": vin_rx_bus, "fingerprints": repr(finger), "fw_query_time": fw_query_time}, extra={"important": True})
 
   return car_fingerprint, finger, vin, car_fw, source, exact_match
 

--- a/selfdrive/car/fw_versions.py
+++ b/selfdrive/car/fw_versions.py
@@ -98,7 +98,7 @@ def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, match_brand: str = N
   # if there are enough matches. FIXME: parameterize this or require all ECUs to exist like exact matching
   if match and len(matched_ecus) >= 2:
     if log:
-      carlog.error(f"Fingerprinted {match} using fuzzy match. {len(matched_ecus)} matching ECUs")
+      carlog.info(f"Fingerprinted {match} using fuzzy match. {len(matched_ecus)} matching ECUs", extra={"important": True})
     return {match}
   else:
     return set()

--- a/selfdrive/car/vin.py
+++ b/selfdrive/car/vin.py
@@ -49,7 +49,7 @@ def get_vin(can_recv, can_send, buses, timeout=0.1, retry=2, debug=False):
               if vin.startswith(b'\x11'):
                 vin = vin[1:18]
 
-              carlog.error(f"got vin with {request=}")
+              carlog.info(f"got vin with {request=}", extra={"important": True})
               return get_rx_addr_for_tx_addr(addr, rx_offset=rx_offset), bus, vin.decode()
         except Exception:
           carlog.exception("VIN query exception")

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -414,7 +414,7 @@ class Controls:
           invalid=[s for s, valid in self.sm.valid.items() if not valid],
           not_alive=[s for s, alive in self.sm.alive.items() if not alive],
           not_freq_ok=[s for s, freq_ok in self.sm.freq_ok.items() if not freq_ok],
-          error=True,
+          important=True,
         )
 
     # When the panda and controlsd do not agree on controls_allowed

--- a/selfdrive/debug/filter_log_message.py
+++ b/selfdrive/debug/filter_log_message.py
@@ -4,15 +4,7 @@ import json
 
 import cereal.messaging as messaging
 from openpilot.tools.lib.logreader import LogReader
-
-LEVELS = {
-  "DEBUG": 10,
-  "INFO": 20,
-  "WARNING": 30,
-  "IMPORTANT": 35,
-  "ERROR": 40,
-  "CRITICAL": 50,
-}
+from openpilot.common.logging_extra import LEVELS
 
 ANDROID_LOG_SOURCE = {
   0: "MAIN",
@@ -66,6 +58,8 @@ if __name__ == "__main__":
           print_logmessage(m.logMonoTime-st, m.logMessage, min_level)
         elif m.which() == 'errorLogMessage':
           print_logmessage(m.logMonoTime-st, m.errorLogMessage, min_level)
+        elif m.which() == 'importantLogMessage':
+          print_logmessage(m.logMonoTime-st, m.importantLogMessage, min_level)
         elif m.which() == 'androidLog':
           print_androidlog(m.logMonoTime-st, m.androidLog)
   else:

--- a/selfdrive/debug/filter_log_message.py
+++ b/selfdrive/debug/filter_log_message.py
@@ -9,6 +9,7 @@ LEVELS = {
   "DEBUG": 10,
   "INFO": 20,
   "WARNING": 30,
+  "IMPORTANT": 35,
   "ERROR": 40,
   "CRITICAL": 50,
 }

--- a/system/logmessaged.py
+++ b/system/logmessaged.py
@@ -3,7 +3,7 @@ import zmq
 from typing import NoReturn
 
 import cereal.messaging as messaging
-from openpilot.common.logging_extra import SwagLogFileFormatter
+from openpilot.common.logging_extra import SwagLogFileFormatter, LEVELS
 from openpilot.system.hardware.hw import Paths
 from openpilot.common.swaglog import get_file_handler
 
@@ -20,6 +20,7 @@ def main() -> NoReturn:
   # and we publish them
   log_message_sock = messaging.pub_sock('logMessage')
   error_log_message_sock = messaging.pub_sock('errorLogMessage')
+  important_log_message_sock = messaging.pub_sock('importantLogMessage')
 
   try:
     while True:
@@ -38,7 +39,10 @@ def main() -> NoReturn:
       msg = messaging.new_message(None, valid=True, logMessage=record)
       log_message_sock.send(msg.to_bytes())
 
-      if level >= 35:  # logging.IMPORTANT
+      if level == LEVELS["IMPORTANT"]:
+        msg = messaging.new_message(None, valid=True, importantLogMessage=record)
+        important_log_message_sock.send(msg.to_bytes())
+      elif level >= LEVELS["ERROR"]:
         msg = messaging.new_message(None, valid=True, errorLogMessage=record)
         error_log_message_sock.send(msg.to_bytes())
   finally:

--- a/system/logmessaged.py
+++ b/system/logmessaged.py
@@ -38,7 +38,7 @@ def main() -> NoReturn:
       msg = messaging.new_message(None, valid=True, logMessage=record)
       log_message_sock.send(msg.to_bytes())
 
-      if level >= 40:  # logging.ERROR
+      if level >= 35:  # logging.IMPORTANT
         msg = messaging.new_message(None, valid=True, errorLogMessage=record)
         error_log_message_sock.send(msg.to_bytes())
   finally:


### PR DESCRIPTION
Adds the "important" logging level for events which need to be in qlogs but aren't errors.
Currently this list is:
 - controlsd.initialized
 - fingerprinted (forwarded INFO event from carlogger with `extra={"important": True}` attribute)

Not sure if [swaglog.h](https://github.com/commaai/openpilot/blob/master/common/swaglog.h) and [logger.h](https://github.com/commaai/msgq/blob/master/msgq/logger/logger.h) in [various](https://github.com/commaai/opendbc/blob/master/opendbc/can/logger.h) [submodules](https://github.com/commaai/rednose/blob/master/rednose/logger/logger.h) should all be updated with the following defines (currently not)
```c
#define CLOUDLOG_WARNING 30
#define CLOUDLOG_IMPORTANT 35
#define CLOUDLOG_ERROR 40
...

#define LOGW(fmt, ...) cloudlog(CLOUDLOG_WARNING, fmt, ## __VA_ARGS__)
#define LOGI(fmt, ...) cloudlog(CLOUDLOG_IMPORTANT, fmt, ## __VA_ARGS__)
#define LOGE(fmt, ...) cloudlog(CLOUDLOG_ERROR, fmt, ## __VA_ARGS__)
...
#define LOGW_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_WARNING, fmt, ## __VA_ARGS__)
#define LOGI_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_IMPORTANT, fmt, ## __VA_ARGS__)
#define LOGE_100(fmt, ...) cloudlog_rl(2, 100, CLOUDLOG_ERROR, fmt, ## __VA_ARGS__)
```

