### PR TITLE
paramsd: remove usages of llk nested structures

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2082,7 +2082,7 @@ struct LiveParametersData {
   stiffnessFactorStd @12 :Float32;
   steerRatioStd @13 :Float32;
   roll @14 :Float32;
-  debugFilterState @16 :FilterState
+  debugFilterState @16 :FilterState;
 
   yawRateDEPRECATED @7 :Float32;
   filterStateDEPRECATED @15 :LiveLocationKalman.Measurement;

--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2082,7 +2082,7 @@ struct LiveParametersData {
   stiffnessFactorStd @12 :Float32;
   steerRatioStd @13 :Float32;
   roll @14 :Float32;
-  filterState @16 :FilterState
+  debugFilterState @16 :FilterState
 
   yawRateDEPRECATED @7 :Float32;
   filterStateDEPRECATED @15 :LiveLocationKalman.Measurement;

--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2082,9 +2082,15 @@ struct LiveParametersData {
   stiffnessFactorStd @12 :Float32;
   steerRatioStd @13 :Float32;
   roll @14 :Float32;
-  filterState @15 :LiveLocationKalman.Measurement;
+  filterState @16 :FilterState
 
   yawRateDEPRECATED @7 :Float32;
+  filterStateDEPRECATED @15 :LiveLocationKalman.Measurement;
+
+  struct FilterState {
+    value @0 : List(Float64);
+    std @1 : List(Float64);
+  }
 }
 
 struct LiveTorqueParametersData {

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -242,9 +242,9 @@ def main():
       liveParameters.angleOffsetAverageStd = float(P[States.ANGLE_OFFSET].item())
       liveParameters.angleOffsetFastStd = float(P[States.ANGLE_OFFSET_FAST].item())
       if DEBUG:
-        liveParameters.filterState = log.LiveParametersData.FilterState.new_message()
-        liveParameters.filterState.value = x.tolist()
-        liveParameters.filterState.std = P.tolist()
+        liveParameters.debugFilterState = log.LiveParametersData.FilterState.new_message()
+        liveParameters.debugFilterState.value = x.tolist()
+        liveParameters.debugFilterState.std = P.tolist()
 
       msg.valid = sm.all_checks()
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -242,10 +242,9 @@ def main():
       liveParameters.angleOffsetAverageStd = float(P[States.ANGLE_OFFSET].item())
       liveParameters.angleOffsetFastStd = float(P[States.ANGLE_OFFSET_FAST].item())
       if DEBUG:
-        liveParameters.filterState = log.LiveLocationKalman.Measurement.new_message()
+        liveParameters.filterState = log.LiveParametersData.FilterState.new_message()
         liveParameters.filterState.value = x.tolist()
         liveParameters.filterState.std = P.tolist()
-        liveParameters.filterState.valid = True
 
       msg.valid = sm.all_checks()
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -177,7 +177,7 @@ def main():
 
   pInitial = None
   if DEBUG:
-    pInitial = np.array(params['filterState']['std']) if 'filterState' in params else None
+    pInitial = np.array(params['debugFilterState']['std']) if 'debugFilterState' in params else None
 
   learner = ParamsLearner(CP, params['steerRatio'], params['stiffnessFactor'], math.radians(params['angleOffsetAverageDeg']), pInitial)
   angle_offset_average = params['angleOffsetAverageDeg']


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

