### PR TITLE
agnos updater: set decompress max_length

### DIFF
--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -41,8 +41,7 @@ class StreamingDecompressor:
       else:
         compressed = b''
 
-      out = self.decompressor.decompress(compressed, max_length=length)
-      self.buf += out
+      self.buf += self.decompressor.decompress(compressed, max_length=length)
 
       if self.decompressor.eof:
         self.eof = True
@@ -91,10 +90,7 @@ def unsparsify(f: StreamingDecompressor) -> Generator[bytes, None, None]:
 
 # noop wrapper with same API as unsparsify() for non sparse images
 def noop(f: StreamingDecompressor) -> Generator[bytes, None, None]:
-  while True:
-    chunk = f.read(1024 * 1024)
-    if not chunk:
-      break
+  while len(chunk := f.read(1024 * 1024)) > 0:
     yield chunk
 
 

--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -29,7 +29,7 @@ class StreamingDecompressor:
     self.sha256 = hashlib.sha256()
 
   def read(self, length: int) -> bytes:
-    while len(self.buf) < length:
+    while len(self.buf) < length and not self.eof:
       if self.decompressor.needs_input:
         self.req.raise_for_status()
 
@@ -91,8 +91,11 @@ def unsparsify(f: StreamingDecompressor) -> Generator[bytes, None, None]:
 
 # noop wrapper with same API as unsparsify() for non sparse images
 def noop(f: StreamingDecompressor) -> Generator[bytes, None, None]:
-  while not f.eof:
-    yield f.read(1024 * 1024)
+  while True:
+    chunk = f.read(1024 * 1024)
+    if not chunk:
+      break
+    yield chunk
 
 
 def get_target_slot_number() -> int:

--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -41,7 +41,7 @@ class StreamingDecompressor:
       else:
         compressed = b''
 
-      out = self.decompressor.decompress(compressed, max_length=256 * 1024 * 1024)
+      out = self.decompressor.decompress(compressed, max_length=length)
       self.buf += out
 
       if self.decompressor.eof:


### PR DESCRIPTION
This fixes the "MemoryError: Unable to allocate output buffer." when flashing big raw images. Write-up [here](https://github.com/commaai/agnos-builder/pull/275#issuecomment-2288508865).

The following changes have been implemented.
- `noop` flashes until no more data is returned - this way any data that remains in `self.buf` after `eof` is detected gets flashed in every case - since the loop will call read until buffer is empty
- decompress `max_length` is now set to `length` ([`max_length=-1`](https://docs.python.org/3/library/lzma.html#lzma.LZMADecompressor.decompress) if not set) - so the output of decompress will never be more than the size of the return
- setting `b''` when [`needs_input=false`](https://docs.python.org/3/library/lzma.html#lzma.LZMADecompressor.needs_input) - when it has more data to decompress after the previous length
- if the last decompressed output has [`eof=True`](https://docs.python.org/3/library/lzma.html#lzma.LZMADecompressor.eof) then we reached the end of file and the process stops

Flashing time for the sparse system image is similar (a little faster with `max_length=length`).

Flashing time for non-sparse raw 10GB image is ~5min.