### PR TITLE
ui: fix wrong path color indexing

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -174,11 +174,20 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     // The first half of track_vertices are the points for the right side of the path
     const auto &acceleration = sm["modelV2"].getModelV2().getAcceleration().getX();
     const int max_len = std::min<int>(scene.track_vertices.length() / 2, acceleration.size());
+    qDebug() << "track vs accel:" << scene.track_vertices.length() / 2 << acceleration.size();
+
+    qDebug() << "\n";
+    qDebug() << "---max_len:" << max_len;
 
     for (int i = 0; i < max_len; ++i) {
+      qDebug() << "i:" << i;
       // Some points are out of frame
-      int track_idx = (scene.track_vertices.length() / 2) - i;  // flip idx to start from top
-      if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) continue;
+      int track_idx = max_len - i - 1;  // flip idx to start from bottom right
+      qDebug() << 0 << scene.track_vertices[track_idx].y() << height();
+
+      if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) {
+        continue;
+      }
 
       // Flip so 0 is bottom of frame
       float lin_grad_point = (height() - scene.track_vertices[track_idx].y()) / height();
@@ -192,6 +201,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       float lightness = util::map_val(saturation, 0.0f, 1.0f, 0.95f, 0.62f);  // lighter when grey
       float alpha = util::map_val(lin_grad_point, 0.75f / 2.f, 0.75f, 0.4f, 0.0f);  // matches previous alpha fade
       bg.setColorAt(lin_grad_point, QColor::fromHslF(path_hue / 360., saturation, lightness, alpha));
+      qDebug() << "path_hue: " << path_hue << "saturation: " << saturation << "lightness: " << lightness << "alpha: " << alpha;
 
       // Skip a point, unless next is last
       i += (i + 2) < max_len ? 1 : 0;

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -178,9 +178,7 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     for (int i = 0; i < max_len; ++i) {
       // Some points are out of frame
       int track_idx = max_len - i - 1;  // flip idx to start from bottom right
-      if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) {
-        continue;
-      }
+      if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) continue;
 
       // Flip so 0 is bottom of frame
       float lin_grad_point = (height() - scene.track_vertices[track_idx].y()) / height();

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -174,16 +174,10 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     // The first half of track_vertices are the points for the right side of the path
     const auto &acceleration = sm["modelV2"].getModelV2().getAcceleration().getX();
     const int max_len = std::min<int>(scene.track_vertices.length() / 2, acceleration.size());
-    qDebug() << "track vs accel:" << scene.track_vertices.length() / 2 << acceleration.size();
-
-    qDebug() << "\n";
-    qDebug() << "---max_len:" << max_len;
 
     for (int i = 0; i < max_len; ++i) {
-      qDebug() << "i:" << i;
       // Some points are out of frame
       int track_idx = max_len - i - 1;  // flip idx to start from bottom right
-      qDebug() << 0 << scene.track_vertices[track_idx].y() << height();
 
       if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) {
         continue;
@@ -201,7 +195,6 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
       float lightness = util::map_val(saturation, 0.0f, 1.0f, 0.95f, 0.62f);  // lighter when grey
       float alpha = util::map_val(lin_grad_point, 0.75f / 2.f, 0.75f, 0.4f, 0.0f);  // matches previous alpha fade
       bg.setColorAt(lin_grad_point, QColor::fromHslF(path_hue / 360., saturation, lightness, alpha));
-      qDebug() << "path_hue: " << path_hue << "saturation: " << saturation << "lightness: " << lightness << "alpha: " << alpha;
 
       // Skip a point, unless next is last
       i += (i + 2) < max_len ? 1 : 0;

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -178,7 +178,6 @@ void AnnotatedCameraWidget::drawLaneLines(QPainter &painter, const UIState *s) {
     for (int i = 0; i < max_len; ++i) {
       // Some points are out of frame
       int track_idx = max_len - i - 1;  // flip idx to start from bottom right
-
       if (scene.track_vertices[track_idx].y() < 0 || scene.track_vertices[track_idx].y() > height()) {
         continue;
       }


### PR DESCRIPTION
Off by one index from the fix in https://github.com/commaai/openpilot/pull/33026

This caused the path to be black when only a few points were showing in some situations.

Old:

![image](https://github.com/user-attachments/assets/b371eccb-6e6c-4a4c-9134-485952e42a9b)

New:

![image](https://github.com/user-attachments/assets/6fc049d6-e950-4117-979c-acf0def7e512)