### PR TITLE
scons: remove Wno-error=unused-but-set-variable

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -190,7 +190,6 @@ env = Environment(
     "-Wno-inconsistent-missing-override",
     "-Wno-c99-designator",
     "-Wno-reorder-init-list",
-    "-Wno-error=unused-but-set-variable",
     "-Wno-vla-cxx-extension",
   ] + cflags + ccflags,
 


### PR DESCRIPTION
 Since the `-Wunused` flag already catches unused variables, the `-Wno-error=unused-but-set-variable` is redundant and just downgrades the severity of these warnings. removing it will ensure that unused variables are treated as errors, promoting stricter code quality.