### PR TITLE
scons:  remove -Wno-deprecated-register and -Wno-register 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -185,8 +185,6 @@ env = Environment(
     "-Werror",
     "-Wshadow",
     "-Wno-unknown-warning-option",
-    "-Wno-deprecated-register",
-    "-Wno-register",
     "-Wno-inconsistent-missing-override",
     "-Wno-c99-designator",
     "-Wno-reorder-init-list",


### PR DESCRIPTION
The -Wno-deprecated-register and -Wno-register flags are outdated. These warnings relate to features that have been deprecated and are no longer relevant in modern C++ standards (post-C++11).