### PR TITLE
scons: remove default lib paths /usr/lib and /usr/local/lib on Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -142,8 +142,6 @@ else:
     libpath = [
       f"#third_party/acados/{arch}/lib",
       f"#third_party/libyuv/{arch}/lib",
-      "/usr/lib",
-      "/usr/local/lib",
     ]
 
     if arch == "x86_64":


### PR DESCRIPTION
updates the libpath to remove the default library paths /usr/lib and /usr/local/lib on linux. these paths are included by default in the linker's search paths and do not need to be specified explicitly.