### PR TITLE
scons: remove duplicate linker flags for -ljson11, -lzmq 

### DIFF
--- a/cereal/SConscript
+++ b/cereal/SConscript
@@ -22,7 +22,7 @@ env.SharedLibrary('cereal_shared', cereal_objects)
 # Build messaging
 
 services_h = env.Command(['services.h'], ['services.py'], 'python3 ' + cereal_dir.path + '/services.py > $TARGET')
-env.Program('messaging/bridge', ['messaging/bridge.cc'], LIBS=[msgq, 'zmq', common])
+env.Program('messaging/bridge', ['messaging/bridge.cc'], LIBS=[msgq, common])
 
 
 socketmaster = env.SharedObject(['messaging/socketmaster.cc'])

--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -4,7 +4,7 @@ Import('env', 'envCython', 'arch', 'cereal', 'messaging', 'common', 'gpucommon',
 lenv = env.Clone()
 lenvCython = envCython.Clone()
 
-libs = [cereal, messaging, visionipc, gpucommon, common, 'capnp', 'zmq', 'kj', 'pthread']
+libs = [cereal, messaging, visionipc, gpucommon, common, 'capnp', 'kj', 'pthread']
 frameworks = []
 
 common_src = [
@@ -69,6 +69,6 @@ if arch == "larch64" or GetOption('pc_thneed'):
 
   lenv.Command(fn + ".thneed", [fn + ".onnx"] + tinygrad_files, cmd)
 
-  thneed_lib = env.SharedLibrary('thneed', thneed_src, LIBS=[gpucommon, common, 'zmq', 'OpenCL', 'dl'])
+  thneed_lib = env.SharedLibrary('thneed', thneed_src, LIBS=[gpucommon, common, 'OpenCL', 'dl'])
   thneedmodel_lib = env.Library('thneedmodel', ['runners/thneedmodel.cc'])
-  lenvCython.Program('runners/thneedmodel_pyx.so', 'runners/thneedmodel_pyx.pyx', LIBS=envCython["LIBS"]+[thneedmodel_lib, thneed_lib, gpucommon, common, 'dl', 'zmq', 'OpenCL'])
+  lenvCython.Program('runners/thneedmodel_pyx.so', 'runners/thneedmodel_pyx.pyx', LIBS=envCython["LIBS"]+[thneedmodel_lib, thneed_lib, gpucommon, common, 'dl', 'OpenCL'])

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -79,7 +79,7 @@ if GetOption('extras') and arch != "Darwin":
   # setup and factory resetter
   qt_env.Program("qt/setup/reset", ["qt/setup/reset.cc"], LIBS=qt_libs)
   qt_env.Program("qt/setup/setup", ["qt/setup/setup.cc", asset_obj],
-                 LIBS=qt_libs + ['curl', 'common', 'json11'])
+                 LIBS=qt_libs + ['curl', 'common'])
 
   # build updater UI
   qt_env.Program("qt/setup/updater", ["qt/setup/updater.cc", asset_obj], LIBS=qt_libs)
@@ -113,4 +113,4 @@ if GetOption('extras') and arch != "Darwin":
 
 # build watch3
 if arch in ['x86_64', 'aarch64', 'Darwin'] or GetOption('extras'):
-  qt_env.Program("watch3", ["watch3.cc"], LIBS=qt_libs + ['common', 'json11', 'msgq', 'visionipc'])
+  qt_env.Program("watch3", ["watch3.cc"], LIBS=qt_libs + ['common', 'msgq', 'visionipc'])

--- a/system/logcatd/SConscript
+++ b/system/logcatd/SConscript
@@ -1,3 +1,3 @@
 Import('env', 'messaging', 'common')
 
-env.Program('logcatd', 'logcatd_systemd.cc', LIBS=[messaging, common, 'systemd', 'json11'])
+env.Program('logcatd', 'logcatd_systemd.cc', LIBS=[messaging, common, 'systemd'])

--- a/system/proclogd/SConscript
+++ b/system/proclogd/SConscript
@@ -1,5 +1,5 @@
 Import('env', 'messaging', 'common')
-libs = [messaging, 'pthread', 'common', 'zmq', 'json11']
+libs = [messaging, 'pthread', common]
 env.Program('proclogd', ['main.cc', 'proclog.cc'], LIBS=libs)
 
 if GetOption('extras'):


### PR DESCRIPTION
These libraries are already included in the common group, defined as `common = [_common, 'json11', 'zmq']` in the root SConscript file. By removing these duplicates, we avoid unnecessary redundancy and ensure a cleaner linking process. 

> test_runner.o tools/replay/tests/test_replay.o -Lthird_party/acados/x86_64/lib -Lthird_party/libyuv/x86_64/lib -L/usr/lib -L/usr/local/lib -Lthird_party/snpe/x86_64 -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers -L/usr/lib -Lselfdrive/ui tools/replay/libqt_replay.a -lavutil -lavcodec -lavformat -lbz2 -lzstd -lcurl -lyuv -lncurses common/libcommon.a **-ljson11** **-lzmq** cereal/libsocketmaster.a msgq_repo/libmsgq.a -lzmq -lcapnp -lkj cereal/libcereal.a msgq_repo/libvisionipc.a -lm -lssl -lcrypto -lpthread -lqt_util -lQt5Widgets -lQt5Gui -lQt5Core -lQt5Network -lQt5Concurrent -lQt5DBus -lQt5Xml -lGL -lOpenCL common/libcommon.a **-ljson11** **-lzmq** cereal/libsocketmaster.a msgq_repo/libmsgq.a -lzmq -lcapnp -lkj cereal/libcereal.a msgq_repo/libvisionipc.a -lm -lssl -lcrypto -lpthread -lqt_util -lQt5Widgets -lQt5Gui -lQt5Core -lQt5Network -lQt5Concurrent -lQt5DBus -lQt5Xml -lGL -lOpenCL