### PR TITLE
scons: cleanup cpppath

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -199,7 +199,6 @@ env = Environment(
     "#third_party/linux/include",
     "#third_party/snpe/include",
     "#third_party",
-    "#cereal",
     "#msgq",
   ],
 

--- a/third_party/SConscript
+++ b/third_party/SConscript
@@ -1,6 +1,4 @@
 Import('env')
 
 env.Library('json11', ['json11/json11.cpp'], CCFLAGS=env['CCFLAGS'] + ['-Wno-unqualified-std-cast-call'])
-env.Append(CPPPATH=[Dir('json11')])
-
 env.Library('kaitai', ['kaitai/kaitaistream.cpp'], CPPDEFINES=['KS_STR_ENCODING_NONE'])


### PR DESCRIPTION
1. remove redundant CPPPATH  for 'json11' from third-party. it's already included in root sconstruct:
   https://github.com/commaai/openpilot/blob/73d9f6e05e354986b3fd225546e8aa1dbc58cf04/SConstruct#L198
2. remove CPPPATH for 'cereal'. it's not submodule now
