### PR TITLE
ui: add prefix PRIME_TYPE_ to PrimeType enum values

### DIFF
--- a/selfdrive/ui/qt/network/networking.cc
+++ b/selfdrive/ui/qt/network/networking.cc
@@ -205,7 +205,7 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   wifi->updateGsmSettings(roamingEnabled, QString::fromStdString(params.get("GsmApn")), metered);
 
   connect(uiState(), &UIState::primeTypeChanged, this, [=](PrimeType prime_type) {
-    bool gsmVisible = prime_type == PrimeType::NONE || prime_type == PrimeType::LITE;
+    bool gsmVisible = prime_type == PrimeType::PRIME_TYPE_NONE || prime_type == PrimeType::PRIME_TYPE_LITE;
     roamingToggle->setVisible(gsmVisible);
     editApnButton->setVisible(gsmVisible);
     meteredToggle->setVisible(gsmVisible);

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -446,7 +446,7 @@ void WifiManager::addTetheringConnection() {
 
 void WifiManager::tetheringActivated(QDBusPendingCallWatcher *call) {
   int prime_type = uiState()->primeType();
-  int ipv4_forward = (prime_type == PrimeType::NONE || prime_type == PrimeType::LITE);
+  int ipv4_forward = (prime_type == PrimeType::PRIME_TYPE_NONE || prime_type == PrimeType::PRIME_TYPE_LITE);
 
   if (!ipv4_forward) {
     QTimer::singleShot(5000, this, [=] {

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -248,7 +248,7 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   addItem(translateBtn);
 
   QObject::connect(uiState(), &UIState::primeTypeChanged, [this] (PrimeType type) {
-    pair_device->setVisible(type == PrimeType::UNPAIRED);
+    pair_device->setVisible(type == PrimeType::PRIME_TYPE_UNPAIRED);
   });
   QObject::connect(uiState(), &UIState::offroadTransition, [=](bool offroad) {
     for (auto btn : findChildren<ButtonControl *>()) {
@@ -336,7 +336,7 @@ void DevicePanel::poweroff() {
 }
 
 void DevicePanel::showEvent(QShowEvent *event) {
-  pair_device->setVisible(uiState()->primeType() == PrimeType::UNPAIRED);
+  pair_device->setVisible(uiState()->primeType() == PrimeType::PRIME_TYPE_UNPAIRED);
   ListWidget::showEvent(event);
 }
 

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -267,7 +267,7 @@ void SetupWidget::replyFinished(const QString &response, bool success) {
   QJsonObject json = doc.object();
   bool is_paired = json["is_paired"].toBool();
   PrimeType prime_type = static_cast<PrimeType>(json["prime_type"].toInt());
-  uiState()->setPrimeType(is_paired ? prime_type : PrimeType::UNPAIRED);
+  uiState()->setPrimeType(is_paired ? prime_type : PrimeType::PRIME_TYPE_UNPAIRED);
 
   if (!is_paired) {
     mainLayout->setCurrentIndex(0);

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -53,14 +53,14 @@ typedef enum UIStatus {
 } UIStatus;
 
 enum PrimeType {
-  UNKNOWN = -2,
-  UNPAIRED = -1,
-  NONE = 0,
-  MAGENTA = 1,
-  LITE = 2,
-  BLUE = 3,
-  MAGENTA_NEW = 4,
-  PURPLE = 5,
+  PRIME_TYPE_UNKNOWN = -2,
+  PRIME_TYPE_UNPAIRED = -1,
+  PRIME_TYPE_NONE = 0,
+  PRIME_TYPE_MAGENTA = 1,
+  PRIME_TYPE_LITE = 2,
+  PRIME_TYPE_BLUE = 3,
+  PRIME_TYPE_MAGENTA_NEW = 4,
+  PRIME_TYPE_PURPLE = 5,
 };
 
 const QColor bg_colors [] = {
@@ -115,7 +115,7 @@ public:
 
   void setPrimeType(PrimeType type);
   inline PrimeType primeType() const { return prime_type; }
-  inline bool hasPrime() const { return prime_type > PrimeType::NONE; }
+  inline bool hasPrime() const { return prime_type > PrimeType::PRIME_TYPE_NONE; }
 
   int fb_w = 0, fb_h = 0;
 
@@ -140,7 +140,7 @@ private slots:
 private:
   QTimer *timer;
   bool started_prev = false;
-  PrimeType prime_type = PrimeType::UNKNOWN;
+  PrimeType prime_type = PrimeType::PRIME_TYPE_UNKNOWN;
 };
 
 UIState *uiState();


### PR DESCRIPTION
this changes avoid  naming conflicts with raylib and aligns with naming conventions for clarity.
```
./selfdrive/ui/ui.h:59:3: error: redefinition of 'Color'
  MAGENTA = 1,
  ^
/usr/local/include/raylib.h:194:29: note: expanded from macro 'MAGENTA'
#define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
                            ^
/usr/local/include/raylib.h:246:3: note: previous definition is here
} Color;
  ^
In file included from selfdrive/ui/ui.cc:1:
./selfdrive/ui/ui.h:59:3: error: expected '= constant-expression' or end of enumerator definition
  MAGENTA = 1,
  ^
/usr/local/include/raylib.h:194:35: note: expanded from macro 'MAGENTA'
#define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
                                  ^
In file included from selfdrive/ui/ui.cc:1:
./selfdrive/ui/ui.h:61:3: error: redefinition of 'Color'
  BLUE = 3,
  ^
/usr/local/include/raylib.h:182:29: note: expanded from macro 'BLUE'
#define BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
                            ^
/usr/local/include/raylib.h:246:3: note: previous definition is here
} Color;
  ^
In file included from selfdrive/ui/ui.cc:1:
./selfdrive/ui/ui.h:61:3: error: expected '= constant-expression' or end of enumerator definition
  BLUE = 3,
  ^
/usr/local/include/raylib.h:182:35: note: expanded from macro 'BLUE'
#define BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
                                  ^
In file included from selfdrive/ui/ui.cc:1:
./selfdrive/ui/ui.h:63:3: error: redefinition of 'Color'
  PURPLE = 5,
```
  ^


