### PR TITLE
ui: remove Qt transforms

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -325,9 +325,9 @@ void AnnotatedCameraWidget::paintGL() {
     }
     CameraWidget::setStreamType(wide_cam_requested ? VISION_STREAM_WIDE_ROAD : VISION_STREAM_ROAD);
 
-    s->scene.wide_cam = CameraWidget::getStreamType() == VISION_STREAM_WIDE_ROAD;
+    bool wide_cam = CameraWidget::getStreamType() == VISION_STREAM_WIDE_ROAD;
     if (s->scene.calibration_valid) {
-      auto calib = s->scene.wide_cam ? s->scene.view_from_wide_calib : s->scene.view_from_calib;
+      auto calib = wide_cam ? s->scene.view_from_wide_calib : s->scene.view_from_calib;
       CameraWidget::updateCalibration(calib);
     } else {
       CameraWidget::updateCalibration(DEFAULT_CALIBRATION);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <limits>
 
 #include <QtConcurrent>
 
@@ -19,20 +20,18 @@
 // Projects a point in car to space to the corresponding point in full frame
 // image space.
 static bool calib_frame_to_full_frame(const UIState *s, float in_x, float in_y, float in_z, QPointF *out) {
-  const float margin = 500.0f;
-  const QRectF clip_region{-margin, -margin, s->fb_w + 2 * margin, s->fb_h + 2 * margin};
-
-  const vec3 pt = (vec3){{in_x, in_y, in_z}};
-  const vec3 Ep = matvecmul3(s->scene.wide_cam ? s->scene.view_from_wide_calib : s->scene.view_from_calib, pt);
-  const vec3 KEp = matvecmul3(s->scene.wide_cam ? ECAM_INTRINSIC_MATRIX : FCAM_INTRINSIC_MATRIX, Ep);
-
-  // Project.
-  QPointF point = s->car_space_transform.map(QPointF{KEp.v[0] / KEp.v[2], KEp.v[1] / KEp.v[2]});
-  if (clip_region.contains(point)) {
-    *out = point;
-    return true;
+  const vec3 pt = matvecmul3(s->car_space_transform, (vec3){{in_x, in_y, in_z}});
+  if (pt.v[2] < std::numeric_limits<float>::epsilon()) {
+    return false;
   }
-  return false;
+
+  QPointF screen_point(pt.v[0] / pt.v[2], pt.v[1] / pt.v[2]);
+  if (!s->clip_region.contains(screen_point)) {
+    return false;
+  }
+
+  *out = screen_point;
+  return true;
 }
 
 int get_path_length_idx(const cereal::XYZTData::Reader &line, const float path_height) {

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -8,7 +8,6 @@
 #include <QColor>
 #include <QFuture>
 #include <QPolygonF>
-#include <QTransform>
 
 #include "cereal/messaging/messaging.h"
 #include "common/mat.h"
@@ -117,16 +116,14 @@ public:
   inline PrimeType primeType() const { return prime_type; }
   inline bool hasPrime() const { return prime_type > PrimeType::PRIME_TYPE_NONE; }
 
-  int fb_w = 0, fb_h = 0;
-
   std::unique_ptr<SubMaster> sm;
-
   UIStatus status;
   UIScene scene = {};
 
   QString language;
 
-  QTransform car_space_transform;
+  mat3 car_space_transform;
+  QRectF clip_region;
 
 signals:
   void uiUpdate(const UIState &s);

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -72,7 +72,6 @@ const QColor bg_colors [] = {
 typedef struct UIScene {
   bool calibration_valid = false;
   bool calibration_wide_valid  = false;
-  bool wide_cam = true;
   mat3 view_from_calib = DEFAULT_CALIBRATION;
   mat3 view_from_wide_calib = DEFAULT_CALIBRATION;
   cereal::PandaState::PandaType pandaType;


### PR DESCRIPTION
Main Changes:

1. **Remove Qt Transforms:** Utilized direct matrix multiplication to compute screen coordinates, eliminating the need for Qt-specific transformation functions.
2. **Consolidated Transformations:** Merged multiple transformation steps within `calib_frame_to_full_frame`() into a single matrix operation.
3. **Optimized Clipping Region Calculation:**  Removed `fb_w` and `fb_h` from `UIState` and replaced the dynamic calculation of the clipping region with a precomputed `s->clip_region`, avoiding redundant computations.
4. **Added Divide-by-Zero Check:** Implemented a check to ensure pt.v[2] is greater than a small epsilon value, preventing potential divide-by-zero errors during the transformation process.