### PR TITLE
cabana: implement custom camera widget and remove ui/cameraview dependency

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -27,7 +27,7 @@ cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "asset
 
 cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/socketcanstream.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
                                                'streams/routes.cc', 'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
-                                               'utils/export.cc', 'utils/util.cc',
+                                               'utils/export.cc', 'utils/util.cc', 'widgets/camerawidget.cc',
                                                'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',
                                                'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -148,7 +148,7 @@ QWidget *VideoWidget::createCameraWidget() {
 
   QStackedLayout *stacked = new QStackedLayout();
   stacked->setStackingMode(QStackedLayout::StackAll);
-  stacked->addWidget(cam_widget = new StreamCameraView("camerad", VISION_STREAM_ROAD, false));
+  stacked->addWidget(cam_widget = new StreamCameraView("camerad", VISION_STREAM_ROAD));
   cam_widget->setMinimumHeight(MIN_VIDEO_HEIGHT);
   cam_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
   stacked->addWidget(alert_label = new InfoLabel(this));
@@ -234,6 +234,7 @@ void VideoWidget::updateState() {
   } else {
     time_btn->setText(formatTime(can->currentSec(), true));
   }
+  cam_widget->recvFrame();
 }
 
 void VideoWidget::updatePlayBtnState() {
@@ -420,8 +421,8 @@ void InfoLabel::paintEvent(QPaintEvent *event) {
   }
 }
 
-StreamCameraView::StreamCameraView(std::string stream_name, VisionStreamType stream_type, bool zoom, QWidget *parent)
-    : CameraWidget(stream_name, stream_type, zoom, parent) {
+StreamCameraView::StreamCameraView(std::string stream_name, VisionStreamType stream_type, QWidget *parent)
+    : CameraWidget(stream_name, stream_type, parent) {
   fade_animation = new QPropertyAnimation(this, "overlayOpacity");
   fade_animation->setDuration(500);
   fade_animation->setStartValue(0.2f);

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -13,8 +13,8 @@
 #include <QSlider>
 #include <QTabBar>
 
-#include "selfdrive/ui/qt/widgets/cameraview.h"
 #include "tools/cabana/utils/util.h"
+#include "tools/cabana/widgets/camerawidget.h"
 #include "tools/replay/logreader.h"
 
 struct AlertInfo {
@@ -64,7 +64,7 @@ class StreamCameraView : public CameraWidget {
   Q_PROPERTY(float overlayOpacity READ overlayOpacity WRITE setOverlayOpacity)
 
 public:
-  StreamCameraView(std::string stream_name, VisionStreamType stream_type, bool zoom, QWidget *parent = nullptr);
+  StreamCameraView(std::string stream_name, VisionStreamType stream_type, QWidget *parent = nullptr);
   void paintGL() override;
   void showPausedOverlay() { fade_animation->start(); }
   float overlayOpacity() const { return overlay_opacity; }

--- a/tools/cabana/widgets/camerawidget.cc
+++ b/tools/cabana/widgets/camerawidget.cc
@@ -1,0 +1,186 @@
+#include "tools/cabana/widgets/camerawidget.h"
+
+#ifdef __APPLE__
+#include <OpenGL/gl3.h>
+#else
+#include <GLES3/gl3.h>
+#endif
+
+const char frame_vertex_shader[] =
+#ifdef __APPLE__
+  "#version 330 core\n"
+#else
+  "#version 300 es\n"
+#endif
+  "layout(location = 0) in vec4 aPosition;\n"
+  "layout(location = 1) in vec2 aTexCoord;\n"
+  "uniform mat4 uTransform;\n"
+  "out vec2 vTexCoord;\n"
+  "void main() {\n"
+  "  gl_Position = uTransform * aPosition;\n"
+  "  vTexCoord = aTexCoord;\n"
+  "}\n";
+
+const char frame_fragment_shader[] =
+#ifdef __APPLE__
+  "#version 330 core\n"
+#else
+  "#version 300 es\n"
+  "precision mediump float;\n"
+#endif
+  "uniform sampler2D uTextureY;\n"
+  "uniform sampler2D uTextureUV;\n"
+  "in vec2 vTexCoord;\n"
+  "out vec4 colorOut;\n"
+  "void main() {\n"
+  "  float y = texture(uTextureY, vTexCoord).r;\n"
+  "  vec2 uv = texture(uTextureUV, vTexCoord).rg - 0.5;\n"
+  "  float r = y + 1.402 * uv.y;\n"
+  "  float g = y - 0.344 * uv.x - 0.714 * uv.y;\n"
+  "  float b = y + 1.772 * uv.x;\n"
+  "  colorOut = vec4(r, g, b, 1.0);\n"
+  "}\n";
+
+CameraWidget::CameraWidget(const std::string &stream_name, VisionStreamType stream_type, QWidget *parent)
+    : stream_name(stream_name), QOpenGLWidget(parent) {
+  vipc_client = std::make_unique<VisionIpcClient>(stream_name, stream_type, true);
+}
+
+void CameraWidget::setStreamType(VisionStreamType stream_type) {
+  if (stream_type != vipc_client->type) {
+    vipc_client = std::make_unique<VisionIpcClient>(stream_name, stream_type, true);
+  }
+}
+
+void CameraWidget::initializeGL() {
+  initializeOpenGLFunctions();
+
+  program = std::make_unique<QOpenGLShaderProgram>(context());
+  bool ret = program->addShaderFromSourceCode(QOpenGLShader::Vertex, frame_vertex_shader);
+  assert(ret);
+  ret = program->addShaderFromSourceCode(QOpenGLShader::Fragment, frame_fragment_shader);
+  assert(ret);
+  program->link();
+
+  GLint frame_pos_loc = program->attributeLocation("aPosition");
+  GLint frame_texcoord_loc = program->attributeLocation("aTexCoord");
+
+  const uint8_t frame_indicies[] = {0, 1, 2, 0, 2, 3};
+  const float frame_coords[4][4] = {
+    -1.0f, -1.0f, 0.0f, 1.0f, // bottom-left
+    -1.0f,  1.0f, 0.0f, 0.0f, // top-left
+     1.0f,  1.0f, 1.0f, 0.0f, // top-right
+     1.0f, -1.0f, 1.0f, 1.0f  // bottom-right
+  };
+
+  glGenVertexArrays(1, &frame_vao);
+  glBindVertexArray(frame_vao);
+  glGenBuffers(1, &frame_vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, frame_vbo);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(frame_coords), frame_coords, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(frame_pos_loc);
+  glVertexAttribPointer(frame_pos_loc, 2, GL_FLOAT, GL_FALSE, sizeof(frame_coords[0]), (const void *)0);
+  glEnableVertexAttribArray(frame_texcoord_loc);
+  glVertexAttribPointer(frame_texcoord_loc, 2, GL_FLOAT, GL_FALSE, sizeof(frame_coords[0]), (const void *)(sizeof(float) * 2));
+  glGenBuffers(1, &frame_ibo);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, frame_ibo);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(frame_indicies), frame_indicies, GL_STATIC_DRAW);
+
+  glGenTextures(2, textures);
+  glUseProgram(program->programId());
+  glUniform1i(program->uniformLocation("uTextureY"), 0);
+  glUniform1i(program->uniformLocation("uTextureUV"), 1);
+}
+
+void CameraWidget::updateFrameMat() {
+    // Scale the frame to fit the widget while maintaining the aspect ratio.
+  float widget_aspect_ratio = (float)width() / height();
+  float frame_aspect_ratio = (float)stream_width / stream_height;
+  float zx = std::min(frame_aspect_ratio / widget_aspect_ratio, 1.0f);
+  float zy = std::min(widget_aspect_ratio / frame_aspect_ratio, 1.0f);
+
+  frame_mat = mat4{{
+    zx, 0.0, 0.0, 0.0,
+    0.0, zy, 0.0, 0.0,
+    0.0, 0.0, 1.0, 0.0,
+    0.0, 0.0, 0.0, 1.0,
+  }};
+}
+
+void CameraWidget::paintGL() {
+  if (!frame) return;
+
+  glClearColor(0, 0, 0, 0);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  updateFrameMat();
+
+  glViewport(0, 0, glWidth(), glHeight());
+  glBindVertexArray(frame_vao);
+  glUseProgram(program->programId());
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+  // fallback to copy
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, stream_stride);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, textures[0]);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, stream_width, stream_height, GL_RED, GL_UNSIGNED_BYTE, frame->y);
+  assert(glGetError() == GL_NO_ERROR);
+
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, stream_stride/2);
+  glActiveTexture(GL_TEXTURE0 + 1);
+  glBindTexture(GL_TEXTURE_2D, textures[1]);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, stream_width/2, stream_height/2, GL_RG, GL_UNSIGNED_BYTE, frame->uv);
+  assert(glGetError() == GL_NO_ERROR);
+
+  glUniformMatrix4fv(program->uniformLocation("uTransform"), 1, GL_TRUE, frame_mat.v);
+  glEnableVertexAttribArray(0);
+  glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, (const void *)0);
+  glDisableVertexAttribArray(0);
+  glBindVertexArray(0);
+
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glActiveTexture(GL_TEXTURE0);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+}
+
+void CameraWidget::recvFrame() {
+  frame = nullptr;
+  if (!vipc_client->connected) {
+    auto streams = VisionIpcClient::getAvailableStreams(stream_name, false);
+    if (streams.empty()) {
+      return;
+    }
+    emit vipcAvailableStreamsUpdated(streams);
+
+    if (!vipc_client->connect(false)) {
+      return;
+    }
+    makeCurrent();
+    stream_width = vipc_client->buffers[0].width;
+    stream_height = vipc_client->buffers[0].height;
+    stream_stride = vipc_client->buffers[0].stride;
+
+    glBindTexture(GL_TEXTURE_2D, textures[0]);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, stream_width, stream_height, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
+    assert(glGetError() == GL_NO_ERROR);
+
+    glBindTexture(GL_TEXTURE_2D, textures[1]);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RG8, stream_width / 2, stream_height / 2, 0, GL_RG, GL_UNSIGNED_BYTE, nullptr);
+    assert(glGetError() == GL_NO_ERROR);
+  }
+
+  VisionIpcBufExtra meta_main = {0};
+  if ((frame = vipc_client->recv(&meta_main, 0)) != nullptr) {
+    update();
+  }
+}

--- a/tools/cabana/widgets/camerawidget.h
+++ b/tools/cabana/widgets/camerawidget.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <memory>
+#include <set>
+#include <string>
+
+#include <QOpenGLFunctions>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLWidget>
+#include "common/mat.h"
+#include "msgq/visionipc/visionipc_client.h"
+
+class CameraWidget : public QOpenGLWidget, protected QOpenGLFunctions {
+  Q_OBJECT
+
+public:
+  using QOpenGLWidget::QOpenGLWidget;
+  explicit CameraWidget(const std::string &stream_name, VisionStreamType stream_type, QWidget* parent = nullptr);
+  void setStreamType(VisionStreamType type);
+  VisionStreamType getStreamType() const { return vipc_client->type; }
+  void recvFrame();
+
+signals:
+  void clicked();
+  void vipcAvailableStreamsUpdated(std::set<VisionStreamType> streams);
+
+protected:
+  void initializeGL() override;
+  void paintGL() override;
+  void mouseReleaseEvent(QMouseEvent *event) override { emit clicked(); }
+  void updateFrameMat();
+  inline int glWidth() const { return width() * devicePixelRatio(); };
+  inline int glHeight() const { return height() * devicePixelRatio(); }
+
+  GLuint frame_vao, frame_vbo, frame_ibo;
+  GLuint textures[2];
+  mat4 frame_mat = {};
+  std::unique_ptr<QOpenGLShaderProgram> program;
+
+  std::string stream_name;
+  int stream_width = 0;
+  int stream_height = 0;
+  int stream_stride = 0;
+  std::unique_ptr<VisionIpcClient> vipc_client;
+  VisionBuf *frame = nullptr;
+};
+
+Q_DECLARE_METATYPE(std::set<VisionStreamType>);


### PR DESCRIPTION
Removes the dependency on the `ui/cameraview` and introduces a custom, lightweight camera widget implementation. The new camera widget is designed to be simple and single-threaded, aiming to provide a more streamlined and efficient way to handle camera input and display within the cabana.