### PR TITLE
ui: remove QtConcurrent dependency

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -265,14 +265,14 @@ Export('envCython', 'np_version')
 
 # Qt build environment
 qt_env = env.Clone()
-qt_modules = ["Widgets", "Gui", "Core", "Network", "Concurrent", "DBus", "Xml"]
+qt_modules = ["Widgets", "Gui", "Core", "Network", "DBus", "Xml"]
 
 qt_libs = []
 if arch == "Darwin":
   qt_env['QTDIR'] = f"{brew_prefix}/opt/qt@5"
-  qt_dirs = [
-    os.path.join(qt_env['QTDIR'], "include"),
-  ]
+  qt_install_headers = os.path.join(qt_env['QTDIR'], "include")
+  qt_env['QT_INSTALL_HEADERS'] = qt_install_headers
+  qt_dirs = [qt_install_headers ]
   qt_dirs += [f"{qt_env['QTDIR']}/include/Qt{m}" for m in qt_modules]
   qt_env["LINKFLAGS"] += ["-F" + os.path.join(qt_env['QTDIR'], "lib")]
   qt_env["FRAMEWORKS"] += [f"Qt{m}" for m in qt_modules] + ["OpenGL"]
@@ -282,6 +282,7 @@ else:
   qt_install_headers = subprocess.check_output(['qmake', '-query', 'QT_INSTALL_HEADERS'], encoding='utf8').strip()
 
   qt_env['QTDIR'] = qt_install_prefix
+  qt_env['QT_INSTALL_HEADERS'] = qt_install_headers
   qt_dirs = [
     f"{qt_install_headers}",
   ]

--- a/selfdrive/ui/qt/onroad/alerts.h
+++ b/selfdrive/ui/qt/onroad/alerts.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QMap>
 #include <QWidget>
 
 #include "selfdrive/ui/ui.h"

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -4,8 +4,6 @@
 #include <cassert>
 #include <cmath>
 
-#include <QtConcurrent>
-
 #include "common/transformations/orientation.hpp"
 #include "common/params.h"
 #include "common/swaglog.h"
@@ -339,8 +337,9 @@ void Device::updateBrightness(const UIState &s) {
   }
 
   if (brightness != last_brightness) {
-    if (!brightness_future.isRunning()) {
-      brightness_future = QtConcurrent::run(Hardware::set_brightness, brightness);
+    if (!brightness_future.valid() ||
+        brightness_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+      brightness_future = std::async(std::launch::async, Hardware::set_brightness, brightness);
       last_brightness = brightness;
     }
   }

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <future>
 #include <memory>
 #include <string>
 
 #include <QObject>
 #include <QTimer>
 #include <QColor>
-#include <QFuture>
 #include <QPolygonF>
 #include <QTransform>
 
@@ -164,7 +164,7 @@ private:
   int offroad_brightness = BACKLIGHT_OFFROAD;
   int last_brightness = 0;
   FirstOrderFilter brightness_filter;
-  QFuture<void> brightness_future;
+  std::future<void> brightness_future;
 
   void updateBrightness(const UIState &s);
   void updateWakefulness(const UIState &s);

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -1,20 +1,18 @@
+import os
 Import('qt_env', 'arch', 'common', 'messaging', 'visionipc', 'replay_lib', 'cereal', 'widgets')
 
 base_frameworks = qt_env['FRAMEWORKS']
 base_libs = [common, messaging, cereal, visionipc, 'qt_util', 'm', 'ssl', 'crypto', 'pthread'] + qt_env["LIBS"]
 
 if arch == "Darwin":
-  base_frameworks.append('OpenCL')
-  base_frameworks.append('QtCharts')
-  base_frameworks.append('QtSerialBus')
+  base_frameworks += ['QtConcurrent', 'OpenCL', 'QtCharts', 'QtSerialBus']
 else:
-  base_libs.append('OpenCL')
-  base_libs.append('Qt5Charts')
-  base_libs.append('Qt5SerialBus')
+  base_libs += ['Qt5Concurrent', 'OpenCL', 'Qt5Charts', 'Qt5SerialBus']
 
 qt_libs = ['qt_util'] + base_libs
 
 cabana_env = qt_env.Clone()
+cabana_env['CPPPATH'].append(os.path.join(qt_env['QT_INSTALL_HEADERS'], 'QtConcurrent'))
 cabana_libs = [widgets, cereal, messaging, visionipc, replay_lib, 'panda', 'avutil', 'avcodec', 'avformat', 'bz2', 'zstd', 'curl', 'yuv', 'usb-1.0'] + qt_libs
 opendbc_path = '-DOPENDBC_FILE_PATH=\'"%s"\'' % (cabana_env.Dir("../../opendbc/dbc").abspath)
 cabana_env['CXXFLAGS'] += [opendbc_path]

--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -1,19 +1,22 @@
-Import('env', 'qt_env', 'arch', 'common', 'messaging', 'visionipc', 'cereal')
+import os
+Import('qt_env', 'arch', 'common', 'messaging', 'visionipc', 'cereal')
 
-base_frameworks = qt_env['FRAMEWORKS']
+replay_env = qt_env.Clone()
+base_frameworks = replay_env['FRAMEWORKS']
 base_libs = [common, messaging, cereal, visionipc,
-             'm', 'ssl', 'crypto', 'pthread', 'qt_util'] + qt_env["LIBS"]
+             'm', 'ssl', 'crypto', 'pthread', 'qt_util'] + replay_env["LIBS"]
 
 if arch == "Darwin":
-  base_frameworks.append('OpenCL')
+  base_frameworks += ['QtConcurrent', 'OpenCL']
 else:
-  base_libs.append('OpenCL')
+  base_libs += ['Qt5Concurrent', 'OpenCL']
 
+replay_env['CPPPATH'].append(os.path.join(replay_env['QT_INSTALL_HEADERS'], 'QtConcurrent'))
 replay_lib_src = ["replay.cc", "consoleui.cc", "camera.cc", "filereader.cc", "logreader.cc", "framereader.cc", "route.cc", "util.cc"]
-replay_lib = qt_env.Library("qt_replay", replay_lib_src, LIBS=base_libs, FRAMEWORKS=base_frameworks)
+replay_lib = replay_env.Library("qt_replay", replay_lib_src, LIBS=base_libs, FRAMEWORKS=base_frameworks)
 Export('replay_lib')
 replay_libs = [replay_lib, 'avutil', 'avcodec', 'avformat', 'bz2', 'zstd', 'curl', 'yuv', 'ncurses'] + base_libs
-qt_env.Program("replay", ["main.cc"], LIBS=replay_libs, FRAMEWORKS=base_frameworks)
+replay_env.Program("replay", ["main.cc"], LIBS=replay_libs, FRAMEWORKS=base_frameworks)
 
 if GetOption('extras'):
-  qt_env.Program('tests/test_replay', ['tests/test_runner.cc', 'tests/test_replay.cc'], LIBS=[replay_libs, base_libs])
+  replay_env.Program('tests/test_replay', ['tests/test_runner.cc', 'tests/test_replay.cc'], LIBS=[replay_libs, base_libs])


### PR DESCRIPTION
Changes:
1. Eliminates the dependency on QtConcurrent from the UI by replacing  `QtConcurrent::run` with `std::async` and `std::future`. making the code more portable.
2. Modified Sconstruct to exclude QtConcurrent paths and libraries for the UI.
3. Retained QtConcurrent dependency in the replay and cabana tools, as they still heavily rely on QtConcurrent for their asynchronous operations.