### PR TITLE
ui: fix memory corruption by using std::vector for PubMaster initialization

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -11,7 +11,7 @@
 
 // Window that shows camera view and variety of info drawn on top
 AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget* parent) : fps_filter(UI_FREQ, 3, 1. / UI_FREQ), CameraWidget("camerad", type, true, parent) {
-  pm = std::make_unique<PubMaster, const std::initializer_list<const char *>>({"uiDebug"});
+  pm = std::make_unique<PubMaster>(std::vector<const char*>{"uiDebug"});
 
   main_layout = new QVBoxLayout(this);
   main_layout->setMargin(UI_BORDER_SIZE);

--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -37,7 +37,7 @@ Sidebar::Sidebar(QWidget *parent) : QFrame(parent), onroad(false), flag_pressed(
 
   QObject::connect(uiState(), &UIState::uiUpdate, this, &Sidebar::updateState);
 
-  pm = std::make_unique<PubMaster, const std::initializer_list<const char *>>({"userFlag"});
+  pm = std::make_unique<PubMaster>(std::vector<const char*>{"userFlag"});
 }
 
 void Sidebar::mousePressEvent(QMouseEvent *event) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -240,7 +240,7 @@ void UIState::updateStatus() {
 }
 
 UIState::UIState(QObject *parent) : QObject(parent) {
-  sm = std::make_unique<SubMaster, const std::initializer_list<const char *>>({
+  sm = std::make_unique<SubMaster>(std::vector<const char*>{
     "modelV2", "controlsState", "liveCalibration", "radarState", "deviceState",
     "pandaStates", "carParams", "driverMonitoringState", "carState", "driverStateV2",
     "wideRoadCameraState", "managerState", "clocks",


### PR DESCRIPTION
During debugging, I encountered a memory corruption issue with the following line:

`pm = std::make_unique<PubMaster, const std::initializer_list<const char *>>({"uiDebug"});`

The constructors for PubMaster and SubMaster had previously been updated to use std::vector as their parameter type. However, the initialization code was still using the old std::initializer_list version, which could lead to memory corruption and other undefined behavior in some rare cases.

This PR corrects the initialization by replacing the outdated use of std::initializer_list with the proper std::vector initialization.aligning with the current constructor definitions.