### PR TITLE
ci: add cameras to ui reports

### DIFF
--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -76,11 +76,15 @@ jobs:
             <table>
               <tr>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/homescreen.png"></td>
-                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad.png"></td>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/settings_network.png"></td>
               </tr>
               <tr>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad.png"></td>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_sidebar.png"></td>
-                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/settings_network.png"></td>
+              </tr>
+              <tr>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_wide.png"></td>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_wide_sidebar.png"></td>
               </tr>
               <tr>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/settings_device.png"></td>


### PR DESCRIPTION
This update adds the fcam and ecam to the UI reports. Two new PNG files, `onroad_wide.png` and `onroad_wide_sidebar.png`, have been added to the UI preview.  Additionally, the transforms for the wide camera are applied in the updated UI preview.

fcam:


![Screenshot from 2024-08-30 00-01-58](https://github.com/user-attachments/assets/3f6c38a0-3c60-412e-a5d7-813a317a9b2c)


ecam:

![Screenshot from 2024-08-30 00-02-12](https://github.com/user-attachments/assets/c30949e7-0717-4722-885e-23a9794e7332)

ecam with sidebar:

![Screenshot from 2024-08-30 00-39-26](https://github.com/user-attachments/assets/eddf217c-927d-4d2d-9665-30be7dd38a88)
