### PR TITLE
ui: fix Incorrect path in .gitignore for test_ui/report

### DIFF
--- a/selfdrive/ui/tests/.gitignore
+++ b/selfdrive/ui/tests/.gitignore
@@ -1,3 +1,3 @@
 test
 test_translations
-test_ui/report
+test_ui/report_1


### PR DESCRIPTION
updates the .gitignore ,  from test_ui/report to test_ui/report_1 to correctly ignore the file
![Screenshot from 2024-08-30 03-30-03](https://github.com/user-attachments/assets/8812cb77-1931-407c-9901-904ba4ab0c87)
