### PR TITLE
ci: integrate offroad alerts and update notifications to ui report

### DIFF
--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -76,7 +76,11 @@ jobs:
             <table>
               <tr>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/homescreen.png"></td>
-                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/settings_network.png"></td>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/settings_device.png"></td>
+              </tr>
+              <tr>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/offroad_alert.png"></td>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/update_available.png"></td>
               </tr>
               <tr>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad.png"></td>
@@ -87,16 +91,12 @@ jobs:
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_wide_sidebar.png"></td>
               </tr>
               <tr>
-                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/settings_device.png"></td>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_alert_small.png"></td>
-              </tr>
-              <tr>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_alert_mid.png"></td>
-                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_alert_full.png"></td>
               </tr>
               <tr>
+                <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/onroad_alert_full.png"></td>
                 <td><img src="https://raw.githubusercontent.com/commaai/ci-artifacts/openpilot/pr-${{ github.event.number }}/driver_camera.png"></td>
-                <td></td>
               </tr>
             </table>
           comment_tag: run_id_screenshots


### PR DESCRIPTION
**Changes**

1. integrate offroad alerts and update notifications:

alerts

![Screenshot from 2024-08-30 14-58-07](https://github.com/user-attachments/assets/21d59312-72c1-4a34-95bf-89a82e12782d)

update available:

![Screenshot from 2024-08-30 14-58-24](https://github.com/user-attachments/assets/48f8551d-1cd0-4ea0-9ab0-7183b7106bb3)

2. Remove the meaningless WiFi Manager screenshot:

![settings_network](https://github.com/user-attachments/assets/922565d8-3748-46d6-992b-bd81cf50ca1f)

3. categorize the UI Screenshots, make it more clear.
4. use the fcam instead of the ecam for capturing on-road alert screenshots.