### PR TITLE
ci: add controlsState back to ui report 

### DIFF
--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -26,7 +26,7 @@ TEST_ROUTE = "a2a0ccea32023010|2023-07-27--13-01-19"
 
 STREAMS: list[tuple[VisionStreamType, CameraConfig, bytes]] = []
 DATA: dict[str, capnp.lib.capnp._DynamicStructBuilder] = dict.fromkeys(
-  ["deviceState", "pandaStates", "selfdriveState", "liveCalibration",
+  ["deviceState", "pandaStates", "controlsState", "selfdriveState", "liveCalibration",
   "modelV2", "radarState", "driverMonitoringState", "carState",
   "driverStateV2", "roadCameraState", "wideRoadCameraState", "driverCameraState"], None)
 


### PR DESCRIPTION
The 'controlsState' message was removed in [#33421](https://github.com/commaai/openpilot/pull/33421), but the UI still requires this message to correctly render the on-road widget