### PR TITLE
ui: remove copy initialization of dialogs

### DIFF
--- a/selfdrive/ui/qt/widgets/input.cc
+++ b/selfdrive/ui/qt/widgets/input.cc
@@ -151,7 +151,7 @@ InputDialog::InputDialog(const QString &title, QWidget *parent, const QString &s
 
 QString InputDialog::getText(const QString &prompt, QWidget *parent, const QString &subtitle,
                              bool secret, int minLength, const QString &defaultText) {
-  InputDialog d = InputDialog(prompt, parent, subtitle, secret);
+  InputDialog d(prompt, parent, subtitle, secret);
   d.line->setText(defaultText);
   d.setMinLength(minLength);
   const int ret = d.exec();
@@ -230,17 +230,17 @@ ConfirmationDialog::ConfirmationDialog(const QString &prompt_text, const QString
 }
 
 bool ConfirmationDialog::alert(const QString &prompt_text, QWidget *parent) {
-  ConfirmationDialog d = ConfirmationDialog(prompt_text, tr("Ok"), "", false, parent);
+  ConfirmationDialog d(prompt_text, tr("Ok"), "", false, parent);
   return d.exec();
 }
 
 bool ConfirmationDialog::confirm(const QString &prompt_text, const QString &confirm_text, QWidget *parent) {
-  ConfirmationDialog d = ConfirmationDialog(prompt_text, confirm_text, tr("Cancel"), false, parent);
+  ConfirmationDialog d(prompt_text, confirm_text, tr("Cancel"), false, parent);
   return d.exec();
 }
 
 bool ConfirmationDialog::rich(const QString &prompt_text, QWidget *parent) {
-  ConfirmationDialog d = ConfirmationDialog(prompt_text, tr("Ok"), "", true, parent);
+  ConfirmationDialog d(prompt_text, tr("Ok"), "", true, parent);
   return d.exec();
 }
 
@@ -328,7 +328,7 @@ MultiOptionDialog::MultiOptionDialog(const QString &prompt_text, const QStringLi
 }
 
 QString MultiOptionDialog::getSelection(const QString &prompt_text, const QStringList &l, const QString &current, QWidget *parent) {
-  MultiOptionDialog d = MultiOptionDialog(prompt_text, l, current, parent);
+  MultiOptionDialog d(prompt_text, l, current, parent);
   if (d.exec()) {
     return d.selection;
   }


### PR DESCRIPTION
This PR updates dialog-based objects to use direct initialization rather than copy initialization, aligning with Qt's design principles and preventing undefined behavior. 

QWidget and its subclasses, including QDialog, are non-copyable: QWidget explicitly disables copying to avoid complications with the underlying GUI resource management. Attempting to copy these objects can lead to undefined behavior and resource management problems. Using direct initialization enhances code stability, ensures proper dialog handling, and reduces the risk of runtime errors.