### PR TITLE
pytest: add default fixture option for pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ addopts = "--ignore=openpilot/ --ignore=opendbc/ --ignore=panda/ --ignore=rednos
 cpp_files = "test_*"
 cpp_harness = "selfdrive/test/cpp_harness.py"
 python_files = "test_*.py"
+asyncio_default_fixture_loop_scope = "function"
 #timeout = "30"  # you get this long by default
 markers = [
   "slow: tests that take awhile to run and can be skipped with -m 'not slow'",


### PR DESCRIPTION
For https://github.com/commaai/openpilot/issues/33423

See https://github.com/pytest-dev/pytest-asyncio/issues/924 for details