### PR TITLE
camerad: fix event check in poll loop to validate POLLPRI

### DIFF
--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -1009,7 +1009,7 @@ void cameras_run(MultiCameraState *s) {
       break;
     }
 
-    if (!fds[0].revents) continue;
+    if (!(fds[0].revents & POLLPRI)) continue;
 
     struct v4l2_event ev = {0};
     ret = HANDLE_EINTR(ioctl(fds[0].fd, VIDIOC_DQEVENT, &ev));


### PR DESCRIPTION
This PR corrects the event handling in the poll loop to specifically check for the `POLLPRI` event. 

Previously, the code used `if (!fds[0].revents) continue; `to skip iterations when no events were detected. However, this didn’t specifically check for the POLLPRI event. 

Even when POLLPRI is specified in the events field, the revents field can still include flags like POLLERR or POLLHUP, etc. after poll returns. These flags indicate different events or errors on the file descriptor, independent of the specific event being polled for. So, it’s important to specifically check for POLLPRI in the revents field.

The updated condition ensures that the code only continues when `POLLPRI` is correctly detected, preventing unintended event processing.