### PR TITLE
ui: show driver camera in popup on demand

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -33,11 +33,6 @@ HomeWindow::HomeWindow(QWidget* parent) : QWidget(parent) {
   body = new BodyWindow(this);
   slayout->addWidget(body);
 
-  driver_view = new DriverViewWindow(this);
-  connect(driver_view, &DriverViewWindow::done, [=] {
-    showDriverView(false);
-  });
-  slayout->addWidget(driver_view);
   setAttribute(Qt::WA_NoSystemBackground);
   QObject::connect(uiState(), &UIState::uiUpdate, this, &HomeWindow::updateState);
   QObject::connect(uiState(), &UIState::offroadTransition, this, &HomeWindow::offroadTransition);
@@ -66,16 +61,6 @@ void HomeWindow::offroadTransition(bool offroad) {
   } else {
     slayout->setCurrentWidget(onroad);
   }
-}
-
-void HomeWindow::showDriverView(bool show) {
-  if (show) {
-    emit closeSettings();
-    slayout->setCurrentWidget(driver_view);
-  } else {
-    slayout->setCurrentWidget(home);
-  }
-  sidebar->setVisible(show == false);
 }
 
 void HomeWindow::mousePressEvent(QMouseEvent* e) {

--- a/selfdrive/ui/qt/home.h
+++ b/selfdrive/ui/qt/home.h
@@ -8,7 +8,6 @@
 #include <QWidget>
 
 #include "common/params.h"
-#include "selfdrive/ui/qt/offroad/driverview.h"
 #include "selfdrive/ui/qt/body.h"
 #include "selfdrive/ui/qt/onroad/onroad_home.h"
 #include "selfdrive/ui/qt/sidebar.h"
@@ -53,7 +52,6 @@ signals:
 
 public slots:
   void offroadTransition(bool offroad);
-  void showDriverView(bool show);
   void showSidebar(bool show);
 
 protected:
@@ -65,7 +63,6 @@ private:
   OffroadHome *home;
   OnroadWindow *onroad;
   BodyWindow *body;
-  DriverViewWindow *driver_view;
   QStackedLayout *slayout;
 
 private slots:

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -6,24 +6,6 @@
 #include "selfdrive/ui/qt/util.h"
 
 DriverViewWindow::DriverViewWindow(QWidget* parent) : CameraWidget("camerad", VISION_STREAM_DRIVER, parent) {
-  QObject::connect(this, &CameraWidget::clicked, this, &DriverViewWindow::done);
-  QObject::connect(device(), &Device::interactiveTimeout, this, [this]() {
-    if (isVisible()) {
-      emit done();
-    }
-  });
-}
-
-void DriverViewWindow::showEvent(QShowEvent* event) {
-  params.putBool("IsDriverViewEnabled", true);
-  device()->resetInteractiveTimeout(60);
-  CameraWidget::showEvent(event);
-}
-
-void DriverViewWindow::hideEvent(QHideEvent* event) {
-  params.putBool("IsDriverViewEnabled", false);
-  stopVipcThread();
-  CameraWidget::hideEvent(event);
 }
 
 void DriverViewWindow::paintGL() {
@@ -79,4 +61,20 @@ mat4 DriverViewWindow::calcFrameMatrix() {
     0.0,  0.0, 1.0, 0.0,
     0.0,  0.0, 0.0, 1.0,
   }};
+}
+
+DriverViewDialog::DriverViewDialog(QWidget *parent) : DialogBase(parent) {
+  params.putBool("IsDriverViewEnabled", true);
+  device()->resetInteractiveTimeout(60);
+
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  auto camera = new DriverViewWindow(this);
+  main_layout->addWidget(camera);
+  QObject::connect(camera, &DriverViewWindow::clicked, this, &DialogBase::accept);
+  QObject::connect(device(), &Device::interactiveTimeout, this, &DialogBase::accept);
+}
+
+void DriverViewDialog::done(int r) {
+  params.putBool("IsDriverViewEnabled", false);
+  QDialog::done(r);
 }

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -64,7 +64,7 @@ mat4 DriverViewWindow::calcFrameMatrix() {
 }
 
 DriverViewDialog::DriverViewDialog(QWidget *parent) : DialogBase(parent) {
-  params.putBool("IsDriverViewEnabled", true);
+  Params().putBool("IsDriverViewEnabled", true);
   device()->resetInteractiveTimeout(60);
 
   QVBoxLayout *main_layout = new QVBoxLayout(this);
@@ -76,6 +76,6 @@ DriverViewDialog::DriverViewDialog(QWidget *parent) : DialogBase(parent) {
 }
 
 void DriverViewDialog::done(int r) {
-  params.putBool("IsDriverViewEnabled", false);
+  Params().putBool("IsDriverViewEnabled", false);
   QDialog::done(r);
 }

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -68,6 +68,7 @@ DriverViewDialog::DriverViewDialog(QWidget *parent) : DialogBase(parent) {
   device()->resetInteractiveTimeout(60);
 
   QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
   auto camera = new DriverViewWindow(this);
   main_layout->addWidget(camera);
   QObject::connect(camera, &DriverViewWindow::clicked, this, &DialogBase::accept);

--- a/selfdrive/ui/qt/offroad/driverview.h
+++ b/selfdrive/ui/qt/offroad/driverview.h
@@ -2,22 +2,22 @@
 
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 #include "selfdrive/ui/qt/onroad/driver_monitoring.h"
+#include "selfdrive/ui/qt/widgets/input.h"
 
 class DriverViewWindow : public CameraWidget {
   Q_OBJECT
-
 public:
   explicit DriverViewWindow(QWidget *parent);
-
-signals:
-  void done();
-
-protected:
-  mat4 calcFrameMatrix() override;
-  void showEvent(QShowEvent *event) override;
-  void hideEvent(QHideEvent *event) override;
   void paintGL() override;
+  mat4 calcFrameMatrix() override;
+  QPixmap face_img;
+};
 
+class DriverViewDialog : public DialogBase {
+  Q_OBJECT
+public:
+  DriverViewDialog(QWidget *parent);
+  void done(int r) override;
   Params params;
   DriverMonitorRenderer driver_monitor;
 };

--- a/selfdrive/ui/qt/offroad/driverview.h
+++ b/selfdrive/ui/qt/offroad/driverview.h
@@ -10,7 +10,7 @@ public:
   explicit DriverViewWindow(QWidget *parent);
   void paintGL() override;
   mat4 calcFrameMatrix() override;
-  QPixmap face_img;
+  DriverMonitorRenderer driver_monitor;
 };
 
 class DriverViewDialog : public DialogBase {
@@ -18,6 +18,4 @@ class DriverViewDialog : public DialogBase {
 public:
   DriverViewDialog(QWidget *parent);
   void done(int r) override;
-  Params params;
-  DriverMonitorRenderer driver_monitor;
 };

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -8,6 +8,7 @@
 
 #include "common/watchdog.h"
 #include "common/util.h"
+#include "selfdrive/ui/qt/offroad/driverview.h"
 #include "selfdrive/ui/qt/network/networking.h"
 #include "selfdrive/ui/qt/offroad/settings.h"
 #include "selfdrive/ui/qt/qt_window.h"
@@ -204,7 +205,12 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
 
   auto dcamBtn = new ButtonControl(tr("Driver Camera"), tr("PREVIEW"),
                                    tr("Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)"));
-  connect(dcamBtn, &ButtonControl::clicked, [=]() { emit showDriverView(); });
+  connect(dcamBtn, &ButtonControl::clicked, [this, dcamBtn]() {
+    dcamBtn->setEnabled(false);
+    DriverViewDialog driver_view(this);
+    driver_view.exec();
+    dcamBtn->setEnabled(true);
+  });
   addItem(dcamBtn);
 
   auto resetCalibBtn = new ButtonControl(tr("Reset Calibration"), tr("RESET"), "");
@@ -376,7 +382,6 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
   // setup panels
   DevicePanel *device = new DevicePanel(this);
   QObject::connect(device, &DevicePanel::reviewTrainingGuide, this, &SettingsWindow::reviewTrainingGuide);
-  QObject::connect(device, &DevicePanel::showDriverView, this, &SettingsWindow::showDriverView);
 
   TogglesPanel *toggles = new TogglesPanel(this);
   QObject::connect(this, &SettingsWindow::expandToggleDescription, toggles, &TogglesPanel::expandToggleDescription);

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -28,7 +28,6 @@ protected:
 signals:
   void closeSettings();
   void reviewTrainingGuide();
-  void showDriverView();
   void expandToggleDescription(const QString &param);
 
 private:
@@ -45,7 +44,6 @@ public:
 
 signals:
   void reviewTrainingGuide();
-  void showDriverView();
 
 private slots:
   void poweroff();

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -20,9 +20,6 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     onboardingWindow->showTrainingGuide();
     main_layout->setCurrentWidget(onboardingWindow);
   });
-  QObject::connect(settingsWindow, &SettingsWindow::showDriverView, [=] {
-    homeWindow->showDriverView(true);
-  });
 
   onboardingWindow = new OnboardingWindow(this);
   main_layout->addWidget(onboardingWindow);


### PR DESCRIPTION
The driver camera has been removed from the MainWindow's static layout. It now initializes and displays only when the "Preview Driver View" button is clicked, showing up in a separate popup window.

This change simplifies the MainWindow layout, removes signal/slot chains for the driver view, reduces UI resource usage, and eases migration to Raylib.