### PR TITLE
ui: fix texture deletion

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -115,7 +115,7 @@ CameraWidget::~CameraWidget() {
     glDeleteVertexArrays(1, &frame_vao);
     glDeleteBuffers(1, &frame_vbo);
     glDeleteBuffers(1, &frame_ibo);
-    glDeleteBuffers(2, textures);
+    glDeleteTextures(2, textures);
   }
   doneCurrent();
 }


### PR DESCRIPTION
Fixes a bug in CameraWidget where textures were incorrectly deleted with `glDeleteBuffers` instead of `glDeleteTextures`. This update ensures proper texture management and prevents undefined behavior/crashes.