### PR TITLE
card: remove redundant CAN data conversion

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -155,15 +155,16 @@ class Car:
   def state_update(self) -> tuple[car.CarState, structs.RadarData | None]:
     """carState update loop, driven by can"""
 
-    # Update carState from CAN
     can_strs = messaging.drain_sock_raw(self.can_sock, wait_for_one=True)
-    CS = convert_to_capnp(self.CI.update(can_capnp_to_list(can_strs)))
+    can_data = can_capnp_to_list(can_strs)
 
+    # Update carState from CAN
+    CS = convert_to_capnp(self.CI.update(can_data))
     if self.CP.carName == 'mock':
       CS = self.mock_carstate.update(CS)
 
     # Update radar tracks from CAN
-    RD: structs.RadarData | None = self.RI.update(can_capnp_to_list(can_strs))
+    RD: structs.RadarData | None = self.RI.update(can_data)
 
     self.sm.update(0)
 

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -156,15 +156,15 @@ class Car:
     """carState update loop, driven by can"""
 
     can_strs = messaging.drain_sock_raw(self.can_sock, wait_for_one=True)
-    can_data = can_capnp_to_list(can_strs)
+    can_list = can_capnp_to_list(can_strs)
 
     # Update carState from CAN
-    CS = convert_to_capnp(self.CI.update(can_data))
+    CS = convert_to_capnp(self.CI.update(can_list))
     if self.CP.carName == 'mock':
       CS = self.mock_carstate.update(CS)
 
     # Update radar tracks from CAN
-    RD: structs.RadarData | None = self.RI.update(can_data)
+    RD: structs.RadarData | None = self.RI.update(can_list)
 
     self.sm.update(0)
 

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -36,7 +36,7 @@ MAX_TOTAL_CPU = 260.  # total for all 8 cores
 PROCS = {
   # Baseline CPU usage by process
   "selfdrive.controls.controlsd": 32.0,
-  "selfdrive.car.card": 31.0,
+  "selfdrive.car.card": 30.0,
   "./loggerd": 14.0,
   "./encoderd": 17.0,
   "./camerad": 14.5,


### PR DESCRIPTION
Remove duplicate conversions of CAN data by reusing the converted `can_data` for both car state and radar updates.