### PR TITLE
op setup: don't remove extra packages

### DIFF
--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -33,7 +33,7 @@ echo "updating uv..."
 update_uv
 
 echo "installing python packages..."
-uv sync --frozen --all-extras
+uv sync --frozen --all-extras --inexact
 source .venv/bin/activate
 
 echo "PYTHONPATH=${PWD}" > $ROOT/.env


### PR DESCRIPTION
I install some libraries such as pytest-sugar to try out, or vpic-api to parse VINs in the openpilot venv, but `op setup` will nuke these