### PR TITLE
Add rerun.io to the op.sh tool

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -362,8 +362,8 @@ function op_default() {
   echo "  op build -j4"
   echo "          Compile openpilot using 4 cores"
   echo ""
-  echo "  op juggle --demo"
-  echo "          Run PlotJuggler on the demo route"
+  echo "  op rerun --demo"
+  echo "          Run rerun on the demo route"
 }
 
 

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -336,7 +336,7 @@ function op_default() {
   echo ""
   echo -e "${BOLD}${UNDERLINE}Commands [Tooling]:${NC}"
   echo -e "  ${BOLD}juggle${NC}       Run PlotJuggler"
-  echo -e "  ${BOLD}rerun${NC}        Run rerun"
+  echo -e "  ${BOLD}rerun${NC}        Run Rerun"
   echo -e "  ${BOLD}replay${NC}       Run Replay"
   echo -e "  ${BOLD}cabana${NC}       Run Cabana"
   echo ""

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -281,6 +281,11 @@ function op_juggle() {
   op_run_command tools/plotjuggler/juggle.py $@
 }
 
+function op_rerun() {
+  op_before_cmd
+  op_run_command tools/rerun/run.sh $@
+}
+
 function op_lint() {
   op_before_cmd
   op_run_command scripts/lint/lint.sh $@
@@ -331,6 +336,7 @@ function op_default() {
   echo ""
   echo -e "${BOLD}${UNDERLINE}Commands [Tooling]:${NC}"
   echo -e "  ${BOLD}juggle${NC}       Run PlotJuggler"
+  echo -e "  ${BOLD}rerun${NC}        Run rerun"
   echo -e "  ${BOLD}replay${NC}       Run Replay"
   echo -e "  ${BOLD}cabana${NC}       Run Cabana"
   echo ""
@@ -377,6 +383,7 @@ function _op() {
     setup )         shift 1; op_setup "$@" ;;
     build )         shift 1; op_build "$@" ;;
     juggle )        shift 1; op_juggle "$@" ;;
+    rerun )         shift 1; op_rerun "$@" ;;
     cabana )        shift 1; op_cabana "$@" ;;
     lint )          shift 1; op_lint "$@" ;;
     test )          shift 1; op_test "$@" ;;

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -362,8 +362,8 @@ function op_default() {
   echo "  op build -j4"
   echo "          Compile openpilot using 4 cores"
   echo ""
-  echo "  op rerun --demo"
-  echo "          Run rerun on the demo route"
+  echo "  op juggle --demo"
+  echo "          Run PlotJuggler on the demo route"
 }
 
 


### PR DESCRIPTION
**Description**

Adds rerun as a sub-command in the op.sh tool. Also updates the help text to suggest trying the rerun demo instead of the plotjuggler demo as plotjuggler no longer works inside of the devcontainer.

**Verification**

Ran the command on my computer.

