### PR TITLE
selfdrive: move self.events_prev update inside if Block

### DIFF
--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -436,7 +436,7 @@ class SelfdriveD:
       ce_send.valid = True
       ce_send.onroadEvents = self.events.to_msg()
       self.pm.send('onroadEvents', ce_send)
-    self.events_prev = self.events.names.copy()
+      self.events_prev = self.events.names.copy()
 
   def step(self):
     CS = self.data_sample()


### PR DESCRIPTION
This change avoids unnecessary copying of event names when not needed, improving efficiency.