### PR TITLE
create_badges.py: Changed to higher contrast colors 

### DIFF
--- a/selfdrive/ui/translations/create_badges.py
+++ b/selfdrive/ui/translations/create_badges.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         unfinished_translations += 1
 
     percent_finished = int(100 - (unfinished_translations / total_translations * 100.))
-    color = "green" if percent_finished == 100 else "orange" if percent_finished > 90 else "red"
+    color = f"rgb{(94, 188, 0) if percent_finished == 100 else (248, 255, 50) if percent_finished > 90 else (204, 55, 27)}"
 
     # Download badge
     badge_label = f"LANGUAGE {name}"


### PR DESCRIPTION
I thought these colors had better contrast from each other. Looks like `.github/workflows/badges.yaml` takes care of the badge svg generation so I didn't push the SVG. 

`shields.io` determines the text color depending on the bg color which is why the text turns to a darker color for the yellow background.

# Color changes
![comparing-color-changes](https://github.com/user-attachments/assets/897475eb-a86e-44ec-b6ad-711ce25c9a3a)
