### PR TITLE
agnos updater: faster flashing

### DIFF
--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -90,7 +90,7 @@ def unsparsify(f: StreamingDecompressor) -> Generator[bytes, None, None]:
 
 # noop wrapper with same API as unsparsify() for non sparse images
 def noop(f: StreamingDecompressor) -> Generator[bytes, None, None]:
-  while len(chunk := f.read(1024 * 1024)) > 0:
+  while chunk := f.read(1024 * 1024):
     yield chunk
 
 


### PR DESCRIPTION
There was a good intention [here](https://github.com/commaai/openpilot/pull/33320#discussion_r1720839619) but it's much slower. The `len` seems too expensive, and almost doubles the flashing time.

```
3m20s compared to 6m not using len
```
\* 3m26s was before [this](https://github.com/commaai/openpilot/pull/33320) whole change