### PR TITLE
Keyboard UX: Easier to type URLs 

### DIFF
--- a/selfdrive/ui/qt/widgets/keyboard.cc
+++ b/selfdrive/ui/qt/widgets/keyboard.cc
@@ -11,7 +11,7 @@
 const QString BACKSPACE_KEY = "⌫";
 const QString ENTER_KEY = "→";
 
-const QMap<QString, int> KEY_STRETCH = {{"  ", 5}, {ENTER_KEY, 2}};
+const QMap<QString, int> KEY_STRETCH = {{"  ", 3}, {ENTER_KEY, 2}};
 
 const QStringList CONTROL_BUTTONS = {"↑", "↓", "ABC", "#+=", "123", BACKSPACE_KEY, ENTER_KEY};
 
@@ -107,7 +107,7 @@ Keyboard::Keyboard(QWidget *parent) : QFrame(parent) {
     {"q", "w", "e", "r", "t", "y", "u", "i", "o", "p"},
     {"a", "s", "d", "f", "g", "h", "j", "k", "l"},
     {"↑", "z", "x", "c", "v", "b", "n", "m", BACKSPACE_KEY},
-    {"123", "  ", ".", ENTER_KEY},
+    {"123", "/", "-", "  ", ".", ENTER_KEY},
   };
   main_layout->addWidget(new KeyboardLayout(this, lowercase));
 


### PR DESCRIPTION
Most branches use "/" and "-" in the name. Including these characters on the main keyboard decreases the amount of clicks it takes during setup when using URL. 

This problem was more apparent to me when I was installing different branches on my device and had to keep on navigating back and forth from the main keyboard to find the "/" and "-"


## Comparing keyboard changes
![comparingKeyboards](https://github.com/user-attachments/assets/b47f0cfd-819b-467c-8300-cf91c73bc0b5)
