### PR TITLE
test manager again in CI

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -60,7 +60,7 @@ jobs:
       run: |
         cd $STRIPPED_DIR
         ${{ env.RUN }} "release/check-dirty.sh && \
-                        MAX_EXAMPLES=5 $PYTEST -m 'not slow' selfdrive/car"
+                        MAX_EXAMPLES=5 $PYTEST -m 'not slow' selfdrive/car system/manager"
     - name: Static analysis
       timeout-minutes: 1
       run: |

--- a/release/release_files.py
+++ b/release/release_files.py
@@ -52,6 +52,7 @@ blacklist = [
 whitelist = [
   "tools/lib/",
   "tools/bodyteleop/",
+  "tools/joystick/",
 
   "tinygrad_repo/openpilot/compile2.py",
   "tinygrad_repo/extra/onnx.py",

--- a/system/manager/test/test_manager.py
+++ b/system/manager/test/test_manager.py
@@ -18,7 +18,6 @@ MAX_STARTUP_TIME = 3
 BLACKLIST_PROCS = ['manage_athenad', 'pandad', 'pigeond']
 
 
-@pytest.mark.tici
 class TestManager:
   def setup_method(self):
     HARDWARE.set_power_save(False)


### PR DESCRIPTION
This used to be tested in CI before https://github.com/commaai/openpilot/pull/30412. Catches https://github.com/commaai/openpilot/issues/33519