### PR TITLE
locationd: optimize predict_and_update_batch by conditionally skipping return values 

### DIFF
--- a/selfdrive/locationd/locationd.py
+++ b/selfdrive/locationd/locationd.py
@@ -106,7 +106,7 @@ class LocationEstimator:
       if np.linalg.norm(meas) >= ACCEL_SANITY_CHECK:
         return HandleLogResult.INPUT_INVALID
 
-      acc_res = self.kf.predict_and_observe(sensor_time, ObservationKind.PHONE_ACCEL, meas)
+      acc_res = self.kf.predict_and_observe(sensor_time, ObservationKind.PHONE_ACCEL, meas, return_result=self.debug)
       if acc_res is not None:
         _, new_x, _, new_P, _, _, (acc_err,), _, _ = acc_res
         self.observation_errors[ObservationKind.PHONE_ACCEL] = np.array(acc_err)
@@ -132,7 +132,7 @@ class LocationEstimator:
       if np.linalg.norm(meas) >= ROTATION_SANITY_CHECK or not gyro_valid:
         return HandleLogResult.INPUT_INVALID
 
-      gyro_res = self.kf.predict_and_observe(sensor_time, ObservationKind.PHONE_GYRO, meas)
+      gyro_res = self.kf.predict_and_observe(sensor_time, ObservationKind.PHONE_GYRO, meas, return_result=self.debug)
       if gyro_res is not None:
         _, new_x, _, new_P, _, _, (gyro_err,), _, _ = gyro_res
         self.observation_errors[ObservationKind.PHONE_GYRO] = np.array(gyro_err)
@@ -181,8 +181,8 @@ class LocationEstimator:
       rot_device_noise = rot_device_std ** 2
       trans_device_noise = trans_device_std ** 2
 
-      cam_odo_rot_res = self.kf.predict_and_observe(t, ObservationKind.CAMERA_ODO_ROTATION, rot_device, rot_device_noise)
-      cam_odo_trans_res = self.kf.predict_and_observe(t, ObservationKind.CAMERA_ODO_TRANSLATION, trans_device, trans_device_noise)
+      cam_odo_rot_res = self.kf.predict_and_observe(t, ObservationKind.CAMERA_ODO_ROTATION, rot_device, rot_device_noise, return_result=self.debug)
+      cam_odo_trans_res = self.kf.predict_and_observe(t, ObservationKind.CAMERA_ODO_TRANSLATION, trans_device, trans_device_noise, return_result=self.debug)
       self.camodo_yawrate_distribution =  np.array([rot_device[2], rot_device_std[2]])
       if cam_odo_rot_res is not None:
         _, new_x, _, new_P, _, _, (cam_odo_rot_err,), _, _ = cam_odo_rot_res

--- a/selfdrive/locationd/models/pose_kf.py
+++ b/selfdrive/locationd/models/pose_kf.py
@@ -115,12 +115,12 @@ class PoseKalman:
   def t(self):
     return self.filter.get_filter_time()
 
-  def predict_and_observe(self, t, kind, data, obs_noise=None):
+  def predict_and_observe(self, t, kind, data, obs_noise=None, return_result=False):
     data = np.atleast_2d(data)
     if obs_noise is None:
       obs_noise = self.obs_noise[kind]
     R = self._get_R(len(data), obs_noise)
-    return self.filter.predict_and_update_batch(t, kind, data, R)
+    return self.filter.predict_and_update_batch(t, kind, data, R, return_result=return_result)
 
   def reset(self, t, x_init, P_init):
     self.filter.init_state(x_init, P_init, t)


### PR DESCRIPTION
This PR requires the changes in https://github.com/commaai/rednose/pull/48

The key modification is to conditionally return the result of the `predict_and_update_batch` function only when `debug` is set to True. By skipping the return value construction during normal execution (when debug=False), the execution time of the function is significantly reduced, resulting in a 2x performance improvement.

- Original execution (with return):

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     6096    0.580    0.000    0.920    0.000 ekf_sym_pyx.pyx:144(predict_and_update_batch)
```
     
- Optimized execution (without return):
     
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     6097    0.466    0.000    0.466    0.000 ekf_sym_pyx.pyx:144(predict_and_update_batch)
```