### PR TITLE
panda.cc: pass capnp list by reference

### DIFF
--- a/selfdrive/pandad/panda.cc
+++ b/selfdrive/pandad/panda.cc
@@ -206,7 +206,7 @@ void Panda::pack_can_buffer(const capnp::List<cereal::CanData>::Reader &can_data
   if (pos > 0) write_func(send_buf, pos);
 }
 
-void Panda::can_send(capnp::List<cereal::CanData>::Reader can_data_list) {
+void Panda::can_send(const capnp::List<cereal::CanData>::Reader &can_data_list) {
   pack_can_buffer(can_data_list, [=](uint8_t* data, size_t size) {
     handle->bulk_write(3, data, size, 5);
   });

--- a/selfdrive/pandad/panda.h
+++ b/selfdrive/pandad/panda.h
@@ -79,7 +79,7 @@ public:
   void set_can_speed_kbps(uint16_t bus, uint16_t speed);
   void set_data_speed_kbps(uint16_t bus, uint16_t speed);
   void set_canfd_non_iso(uint16_t bus, bool non_iso);
-  void can_send(capnp::List<cereal::CanData>::Reader can_data_list);
+  void can_send(const capnp::List<cereal::CanData>::Reader &can_data_list);
   bool can_receive(std::vector<can_frame>& out_vec);
   void can_reset_communications();
 


### PR DESCRIPTION
`capnp::List<cereal::CanData>::Reader` has a private member _::ListReader which makes pass-by-value costly. Changed to pass by reference.