### PR TITLE
CAN Replay changes

### DIFF
--- a/tools/replay/can_replay.py
+++ b/tools/replay/can_replay.py
@@ -75,7 +75,7 @@ def connect():
     # try to join all send threads
     cur_serials = serials.copy()
     for s, t in cur_serials.items():
-      if t is  not None:
+      if t is not None:
         t.join(0.01)
         if not t.is_alive():
           del serials[s]
@@ -90,7 +90,7 @@ def load_route(route_or_segment_name):
   sr = LogReader(route_or_segment_name)
   CP = sr.first("carParams")
   print(f"carFingerprint (for hardcoding fingerprint): '{CP.carFingerprint}'")
-  CAN_MSGS = sr.run_across_segments(24, process)
+  CAN_MSGS = sr.run_across_segments(os.cpu_count()//2, process)
   print("Finished loading...")
   return CAN_MSGS
 


### PR DESCRIPTION
With Jungle V2, the panda on each connected Comma 3X is an enumerated USB device. If the CAN Replay host is a 3X, we run into an issue where the 3X is not fast enough to handle enumeration of many devices connected to Jungles, so we automatically remove new 3X pandas from connecting to the host and also remove already connected pandas.

Also set number of processes to 1/2 CPU count since default of 24 was causing OOM on 3X.

Last commit is for sending different segments to different jungles.