### PR TITLE
cabana: improve isMessageActive

### DIFF
--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -45,7 +45,6 @@ public:
     MessageId id;
     QString name;
     QString node;
-    bool active;
     bool operator==(const Item &other) const {
       return id == other.id && name == other.name && node == other.node;
     }


### PR DESCRIPTION
1. The check for DummyStream was removed as it is no longer relevant to the logic of this function.
2. Replaced the comparison for near-zero frequency with std::numeric_limits<double>::epsilon().
3. Improved performance by restricting isMessageActive checks to only the items that require repainting.