### PR TITLE
add advisory speed to the custom capnp

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -12,7 +12,9 @@ struct CustomReserved0 @0x81c2f05a394cf4af {
 }
 
 struct CustomReserved1 @0xaedffd8f31e7b55d {
+  speed @0 :Float32;  # The advisory speed data (e.g., in km/h)
 }
+
 
 struct CustomReserved2 @0xf35cc4560bbf6ec2 {
 }
@@ -37,3 +39,7 @@ struct CustomReserved8 @0xf416ec09499d9d19 {
 
 struct CustomReserved9 @0xa1680744031fdb2d {
 }
+
+
+
+

--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -12,7 +12,7 @@ struct CustomReserved0 @0x81c2f05a394cf4af {
 }
 
 struct CustomReserved1 @0xaedffd8f31e7b55d {
-  speed @0 :Float32;  # The advisory speed data (e.g., in km/h)
+  advisorySpeed @0 :Float32;  # The advisory speed data (e.g., in km/h)
 }
 
 

--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -23,6 +23,7 @@ enum LongitudinalPersonality {
   relaxed @2;
 }
 
+
 struct InitData {
   kernelArgs @0 :List(Text);
   kernelVersion @15 :Text;

--- a/selfdrive/controls/advisory_speed_receiver.py
+++ b/selfdrive/controls/advisory_speed_receiver.py
@@ -1,0 +1,30 @@
+import cereal.messaging as messaging
+import serial
+import time
+from cereal import custom  # This will import the message from custom.capnp
+
+def main():
+    pm = messaging.PubMaster(['advisorySpeed'])
+    
+    # Open the USB serial port where the tablet is sending advisory speed
+    ser = serial.Serial('/dev/ttyGS0', baudrate=9600, timeout=1)
+    
+    while True:
+        try:
+            # Read data from the serial port
+            line = ser.readline().decode('utf-8').strip()
+            if line:
+                advisory_speed = float(line)  # Convert string to float
+                
+                # Create and send the message using custom.AdvisorySpeed
+                dat = messaging.new_message('advisorySpeed')
+                dat.advisorySpeed.speed = advisory_speed
+                pm.send('advisorySpeed', dat)
+            
+            time.sleep(0.1)  # Adjust delay as needed
+        except Exception as e:
+            print(f"Error: {e}")
+            time.sleep(1)
+
+if __name__ == "__main__":
+    main()

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -34,9 +34,9 @@ class Controls:
     cloudlog.info("controlsd got CarParams")
 
     self.CI = get_car_interface(self.CP)
-
+    ## add 'advisorySpeed' to the subscribed messages in the control thread
     self.sm = messaging.SubMaster(['liveParameters', 'liveTorqueParameters', 'modelV2', 'selfdriveState',
-                                   'liveCalibration', 'livePose', 'longitudinalPlan', 'carState', 'carOutput',
+                                   'liveCalibration', 'livePose', 'longitudinalPlan', 'carState', 'carOutput', 'advisorySpeed', 
                                    'driverMonitoringState', 'onroadEvents', 'driverAssistance'], poll='selfdriveState')
     self.pm = messaging.PubMaster(['carControl', 'controlsState'])
 

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -102,6 +102,13 @@ class LongitudinalPlanner:
     v_cruise_kph = min(sm['carState'].vCruise, V_CRUISE_MAX)
     v_cruise = v_cruise_kph * CV.KPH_TO_MS
 
+    #66 Get the advisory speed from the SubMaster
+    advisory_speed = sm['advisorySpeed'].advisorySpeed
+    advisory_speed_ms = advisory_speed * CV.KPH_TO_MS  # Convert advisory speed from km/h to m/s
+
+    #66 Limit the cruise speed by the advisory speed
+    v_cruise = min(v_cruise, advisory_speed_ms)
+
     long_control_off = sm['controlsState'].longControlState == LongCtrlState.off
     force_slow_decel = sm['controlsState'].forceDecel
 

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -19,13 +19,14 @@ def main():
   ldw = LaneDepartureWarning()
   longitudinal_planner = LongitudinalPlanner(CP)
   pm = messaging.PubMaster(['longitudinalPlan', 'driverAssistance'])
-  sm = messaging.SubMaster(['carControl', 'carState', 'controlsState', 'radarState', 'modelV2', 'selfdriveState'],
+  ### add advisorySpeed to sm in the planner
+  sm = messaging.SubMaster(['carControl', 'carState', 'controlsState', 'radarState', 'modelV2', 'selfdriveState', 'advisorySpeed'],
                            poll='modelV2', ignore_avg_freq=['radarState'])
 
   while True:
     sm.update()
     if sm.updated['modelV2']:
-      longitudinal_planner.update(sm)
+      longitudinal_planner.update(sm) ### long planner can access 'advisorySpeed' through the sm
       longitudinal_planner.publish(sm, pm)
 
       ldw.update(sm.frame, sm['modelV2'], sm['carState'], sm['carControl'])

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -96,6 +96,9 @@ procs = [
   PythonProcess("uploader", "system.loggerd.uploader", always_run),
   PythonProcess("statsd", "system.statsd", always_run),
 
+  ##66 add the new process for receiving advisory speed
+  PythonProcess("advisory_speed_receiver", "selfdrive.controls.advisory_speed_receiver", always_run),
+
   # debug procs
   NativeProcess("bridge", "cereal/messaging", ["./bridge"], notcar),
   PythonProcess("webrtcd", "system.webrtc.webrtcd", notcar),


### PR DESCRIPTION
as openpilot suggests, remain back compatability

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

