### PR TITLE
agnos: move metadrive-simulator & rerun-sdk to a separate tools group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ dev = [
   "flaky",
   "lru-dict",
   "matplotlib",
-  "metadrive-simulator @ https://github.com/commaai/metadrive/releases/download/MetaDrive-minimal/metadrive_simulator-0.4.2.3-py3-none-any.whl ; (platform_machine != 'aarch64')",
   "parameterized >=0.8, <0.9",
   #"pprofile",
   "pyautogui",
@@ -109,13 +108,17 @@ dev = [
   "pytools < 2024.1.11; platform_machine != 'aarch64'", # pyopencl use a broken version
   "pywinctl",
   "pyprof2calltree",
-  "rerun-sdk >= 0.18",
   "tabulate",
   "types-requests",
   "types-tabulate",
 
   # this is only pinned since 5.15.11 is broken
   "pyqt5 ==5.15.2; platform_machine == 'x86_64'", # no aarch64 wheels for macOS/linux
+]
+
+tools = [
+  "metadrive-simulator @ https://github.com/commaai/metadrive/releases/download/MetaDrive-minimal/metadrive_simulator-0.4.2.3-py3-none-any.whl ; (platform_machine != 'aarch64')",
+  "rerun-sdk >= 0.18",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1481,7 +1481,6 @@ dev = [
     { name = "flaky" },
     { name = "lru-dict" },
     { name = "matplotlib" },
-    { name = "metadrive-simulator", marker = "platform_machine != 'aarch64'" },
     { name = "parameterized" },
     { name = "pyautogui" },
     { name = "pyopencl", marker = "platform_machine != 'aarch64'" },
@@ -1489,7 +1488,6 @@ dev = [
     { name = "pyqt5", marker = "platform_machine == 'x86_64'" },
     { name = "pytools", marker = "platform_machine != 'aarch64'" },
     { name = "pywinctl" },
-    { name = "rerun-sdk" },
     { name = "tabulate" },
     { name = "types-requests" },
     { name = "types-tabulate" },
@@ -1517,6 +1515,10 @@ testing = [
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
+tools = [
+    { name = "metadrive-simulator", marker = "platform_machine != 'aarch64'" },
+    { name = "rerun-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1541,7 +1543,7 @@ requires-dist = [
     { name = "libusb1" },
     { name = "lru-dict", marker = "extra == 'dev'" },
     { name = "matplotlib", marker = "extra == 'dev'" },
-    { name = "metadrive-simulator", marker = "platform_machine != 'aarch64' and extra == 'dev'", url = "https://github.com/commaai/metadrive/releases/download/MetaDrive-minimal/metadrive_simulator-0.4.2.3-py3-none-any.whl" },
+    { name = "metadrive-simulator", marker = "platform_machine != 'aarch64' and extra == 'tools'", url = "https://github.com/commaai/metadrive/releases/download/MetaDrive-minimal/metadrive_simulator-0.4.2.3-py3-none-any.whl" },
     { name = "mkdocs", marker = "extra == 'docs'" },
     { name = "mypy", marker = "extra == 'testing'" },
     { name = "natsort", marker = "extra == 'docs'" },
@@ -1575,7 +1577,7 @@ requires-dist = [
     { name = "pywinctl", marker = "extra == 'dev'" },
     { name = "pyzmq" },
     { name = "requests" },
-    { name = "rerun-sdk", marker = "extra == 'dev'", specifier = ">=0.18" },
+    { name = "rerun-sdk", marker = "extra == 'tools'", specifier = ">=0.18" },
     { name = "ruff", marker = "extra == 'testing'" },
     { name = "scons" },
     { name = "sentry-sdk" },


### PR DESCRIPTION
Moving metadrive-simulator & rerun-sdk to prevent (PC) tools get installed in AGNOS 11