### PR TITLE
tests: Fix selfdrive state machine imports

### DIFF
--- a/selfdrive/selfdrived/tests/test_state_machine.py
+++ b/selfdrive/selfdrived/tests/test_state_machine.py
@@ -1,7 +1,6 @@
 from cereal import log
 from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.selfdrived.selfdrived import StateMachine
-from openpilot.selfdrive.selfdrived.state import SOFT_DISABLE_TIME
+from openpilot.selfdrive.selfdrived.state import StateMachine, SOFT_DISABLE_TIME
 from openpilot.selfdrive.selfdrived.events import Events, ET, EVENTS, NormalPermanentAlert
 
 State = log.SelfdriveState.OpenpilotState

--- a/selfdrive/selfdrived/tests/test_state_machine.py
+++ b/selfdrive/selfdrived/tests/test_state_machine.py
@@ -1,6 +1,7 @@
 from cereal import log
 from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.controls.lib.selfdrive import StateMachine, SOFT_DISABLE_TIME
+from openpilot.selfdrive.selfdrived.selfdrived import StateMachine
+from openpilot.selfdrive.selfdrived.state import SOFT_DISABLE_TIME
 from openpilot.selfdrive.selfdrived.events import Events, ET, EVENTS, NormalPermanentAlert
 
 State = log.SelfdriveState.OpenpilotState

--- a/selfdrive/selfdrived/tests/test_state_machine.py
+++ b/selfdrive/selfdrived/tests/test_state_machine.py
@@ -1,6 +1,6 @@
 from cereal import log
 from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.selfdrived.state import SOFT_DISABLE_TIME, StateMachine
+from openpilot.selfdrive.selfdrived.state import StateMachine, SOFT_DISABLE_TIME
 from openpilot.selfdrive.selfdrived.events import Events, ET, EVENTS, NormalPermanentAlert
 
 State = log.SelfdriveState.OpenpilotState

--- a/selfdrive/selfdrived/tests/test_state_machine.py
+++ b/selfdrive/selfdrived/tests/test_state_machine.py
@@ -1,6 +1,6 @@
 from cereal import log
 from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.selfdrived.state import StateMachine, SOFT_DISABLE_TIME
+from openpilot.selfdrive.selfdrived.state import SOFT_DISABLE_TIME, StateMachine
 from openpilot.selfdrive.selfdrived.events import Events, ET, EVENTS, NormalPermanentAlert
 
 State = log.SelfdriveState.OpenpilotState


### PR DESCRIPTION
**Description**
- Fixed incorrect import paths in `test_state_machine.py`
- Changed import of `StateMachine` and `SOFT_DISABLE_TIME` from `openpilot.selfdrive.controls.lib.selfdrive` to `openpilot.selfdrive.selfdrived` and `openpilot.selfdrive.selfdrived.state`

**Verification**
- Ran unit test for `selfdrive/selfdrived/tests/test_state_machine.py`
- Verified all tests passed with the correct imports