### PR TITLE
FCA Giorgio: Reserve safety ID

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -619,6 +619,7 @@ struct CarParams {
     volkswagenMqbEvo @29;
     chryslerCusw @30;
     psa @31;
+    fcaGiorgio @32;
   }
 
   enum SteerControlType {


### PR DESCRIPTION
**Car**

For the [FCA Giorgio](https://en.wikipedia.org/wiki/FCA_Giorgio_platform) platform, initially supporting Alfa Romeo Stelvio and Giulia.

There's an older version of the port in #32898, a newer post-refactor version is forthcoming.

**Route**

N/A

**Verification**

N/A
