### PR TITLE
ci: fix ui report issues

### DIFF
--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -12,7 +12,7 @@ import time
 
 from cereal import log
 from msgq.visionipc import VisionIpcServer, VisionStreamType
-from cereal.messaging import PubMaster, log_from_bytes
+from cereal.messaging import PubMaster, log_from_bytes, sub_sock
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix
@@ -51,7 +51,15 @@ def setup_onroad(click, pm: PubMaster):
     vipc_server.create_buffers(stream_type, 5, False, cam.width, cam.height)
   vipc_server.start_listener()
 
-  for packet_id in range(30):
+  uidebug_received_cnt = 0
+  packet_id = 0
+  uidebug_sock = sub_sock('uiDebug')
+
+  # Condition check for uiDebug processing
+  check_uidebug = DATA['deviceState'].deviceState.started and not DATA['carParams'].carParams.notCar
+
+  # Loop until 20 'uiDebug' messages are received
+  while (uidebug_received_cnt <= 20):
     for service, data in DATA.items():
       if data:
         data.clear_write_flag()
@@ -60,6 +68,13 @@ def setup_onroad(click, pm: PubMaster):
     for stream_type, _, image in STREAMS:
       vipc_server.send(stream_type, image, packet_id, packet_id, packet_id)
 
+    if check_uidebug:
+      while uidebug_sock.receive(non_blocking=True):
+          uidebug_received_cnt += 1
+    else:
+      uidebug_received_cnt += 1
+
+    packet_id += 1
     time.sleep(0.05)
 
 def setup_onroad_wide(click, pm: PubMaster):
@@ -70,10 +85,12 @@ def setup_onroad_wide(click, pm: PubMaster):
 def setup_onroad_sidebar(click, pm: PubMaster):
   setup_onroad(click, pm)
   click(500, 500)
+  setup_onroad(click, pm)
 
 def setup_onroad_wide_sidebar(click, pm: PubMaster):
   setup_onroad_wide(click, pm)
   click(500, 500)
+  setup_onroad_wide(click, pm)
 
 def setup_body(click, pm: PubMaster):
   DATA['carParams'].carParams.carName = "BODY"

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -70,7 +70,7 @@ def setup_onroad(click, pm: PubMaster):
 
     if check_uidebug:
       while uidebug_sock.receive(non_blocking=True):
-          uidebug_received_cnt += 1
+        uidebug_received_cnt += 1
     else:
       uidebug_received_cnt += 1
 

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -59,7 +59,7 @@ def setup_onroad(click, pm: PubMaster):
   check_uidebug = DATA['deviceState'].deviceState.started and not DATA['carParams'].carParams.notCar
 
   # Loop until 20 'uiDebug' messages are received
-  while (uidebug_received_cnt <= 20):
+  while uidebug_received_cnt <= 20:
     for service, data in DATA.items():
       if data:
         data.clear_write_flag()


### PR DESCRIPTION
**1. fix driver monitor diff issue**
The dm_fade_state in the driver monitor was being updated on every frame using:

> dm_fade_state = std::clamp(dm_fade_state + 0.2f * (0.5f - is_active), 0.0f, 1.0f); 

If the frame count was insufficient to reset dm_fade_state to zero, it caused inconsistent diffs. This PR tracks the uiDebug messages (ensuring 20 frames are processed) to guarantee consistent results across runs.
![onroad_diff](https://github.com/user-attachments/assets/3f37efce-cf3d-4d66-876c-29c90665c7e9)
**2. fix onroad sidebar diff issue:**
Packets are now continuously sent after the sidebar is shown, preventing the alive check from failing, which previously caused the speed display to show 0.
![onroad_sidebar_diff](https://github.com/user-attachments/assets/154cf201-9378-46ef-9282-859564b1378c)
