### PR TITLE
camerad: remove `CameraType` enum from `camera_common.h`

### DIFF
--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -11,12 +11,6 @@
 
 const int YUV_BUFFER_COUNT = 20;
 
-enum CameraType {
-  RoadCam = 0,
-  DriverCam,
-  WideRoadCam
-};
-
 // for debugging
 const bool env_debug_frames = getenv("DEBUG_FRAMES") != NULL;
 const bool env_log_raw_frames = getenv("LOG_RAW_FRAMES") != NULL;

--- a/system/loggerd/encoder/encoder.h
+++ b/system/loggerd/encoder/encoder.h
@@ -17,7 +17,6 @@
 #include "cereal/messaging/messaging.h"
 #include "msgq/visionipc/visionipc.h"
 #include "common/queue.h"
-#include "system/camerad/cameras/camera_common.h"
 #include "system/loggerd/loggerd.h"
 
 class VideoEncoder {

--- a/system/loggerd/encoderd.cc
+++ b/system/loggerd/encoderd.cc
@@ -18,12 +18,12 @@ struct EncoderdState {
   // Sync logic for startup
   std::atomic<int> encoders_ready = 0;
   std::atomic<uint32_t> start_frame_id = 0;
-  bool camera_ready[WideRoadCam + 1] = {};
-  bool camera_synced[WideRoadCam + 1] = {};
+  bool camera_ready[VISION_STREAM_WIDE_ROAD + 1] = {};
+  bool camera_synced[VISION_STREAM_WIDE_ROAD + 1] = {};
 };
 
 // Handle initial encoder syncing by waiting for all encoders to reach the same frame id
-bool sync_encoders(EncoderdState *s, CameraType cam_type, uint32_t frame_id) {
+bool sync_encoders(EncoderdState *s, VisionStreamType cam_type, uint32_t frame_id) {
   if (s->camera_synced[cam_type]) return true;
 
   if (s->max_waiting > 1 && s->encoders_ready != s->max_waiting) {
@@ -85,7 +85,7 @@ void encoder_thread(EncoderdState *s, const LogCameraInfo &cam_info) {
       }
       lagging = false;
 
-      if (!sync_encoders(s, cam_info.type, extra.frame_id)) {
+      if (!sync_encoders(s, cam_info.stream_type, extra.frame_id)) {
         continue;
       }
       if (do_exit) break;

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -5,7 +5,6 @@
 #include "cereal/messaging/messaging.h"
 #include "cereal/services.h"
 #include "msgq/visionipc/visionipc_client.h"
-#include "system/camerad/cameras/camera_common.h"
 #include "system/hardware/hw.h"
 #include "common/params.h"
 #include "common/swaglog.h"
@@ -51,7 +50,6 @@ class LogCameraInfo {
 public:
   const char *thread_name;
   int fps = MAIN_FPS;
-  CameraType type;
   VisionStreamType stream_type;
   std::vector<EncoderInfo> encoder_infos;
 };
@@ -112,42 +110,36 @@ const EncoderInfo qcam_encoder_info = {
 
 const LogCameraInfo road_camera_info{
   .thread_name = "road_cam_encoder",
-  .type = RoadCam,
   .stream_type = VISION_STREAM_ROAD,
   .encoder_infos = {main_road_encoder_info, qcam_encoder_info}
 };
 
 const LogCameraInfo wide_road_camera_info{
   .thread_name = "wide_road_cam_encoder",
-  .type = WideRoadCam,
   .stream_type = VISION_STREAM_WIDE_ROAD,
   .encoder_infos = {main_wide_road_encoder_info}
 };
 
 const LogCameraInfo driver_camera_info{
   .thread_name = "driver_cam_encoder",
-  .type = DriverCam,
   .stream_type = VISION_STREAM_DRIVER,
   .encoder_infos = {main_driver_encoder_info}
 };
 
 const LogCameraInfo stream_road_camera_info{
   .thread_name = "road_cam_encoder",
-  .type = RoadCam,
   .stream_type = VISION_STREAM_ROAD,
   .encoder_infos = {stream_road_encoder_info}
 };
 
 const LogCameraInfo stream_wide_road_camera_info{
   .thread_name = "wide_road_cam_encoder",
-  .type = WideRoadCam,
   .stream_type = VISION_STREAM_WIDE_ROAD,
   .encoder_infos = {stream_wide_road_encoder_info}
 };
 
 const LogCameraInfo stream_driver_camera_info{
   .thread_name = "driver_cam_encoder",
-  .type = DriverCam,
   .stream_type = VISION_STREAM_DRIVER,
   .encoder_infos = {stream_driver_encoder_info}
 };

--- a/tools/replay/framereader.h
+++ b/tools/replay/framereader.h
@@ -4,8 +4,8 @@
 #include <vector>
 
 #include "msgq/visionipc/visionbuf.h"
-#include "system/camerad/cameras/camera_common.h"
 #include "tools/replay/filereader.h"
+#include "tools/replay/util.h"
 
 extern "C" {
 #include <libavcodec/avcodec.h>

--- a/tools/replay/logreader.h
+++ b/tools/replay/logreader.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "cereal/gen/cpp/log.capnp.h"
-#include "system/camerad/cameras/camera_common.h"
 #include "tools/replay/util.h"
 
 const CameraType ALL_CAMERAS[] = {RoadCam, DriverCam, WideRoadCam};

--- a/tools/replay/util.h
+++ b/tools/replay/util.h
@@ -4,6 +4,13 @@
 #include <deque>
 #include <functional>
 #include <string>
+#include "cereal/messaging/messaging.h"
+
+enum CameraType {
+  RoadCam = 0,
+  DriverCam,
+  WideRoadCam
+};
 
 enum class ReplyMsgType {
   Info,


### PR DESCRIPTION
Refactors the use of the `CameraType` enum, which was primarily used by the replay tool.

1. Move `CameraType` enum from `camerad/camera_common.h` to `tools/replay`, as its usage is mostly within replay.
2. Removed the `CameraType type;` field from the `LogCameraInfo` class and replaced it with stream_type to simplify the `LogCameraInfo`.
3. Removed unnecessary `#include system/camerad/cameras/camera_common.h` from `loggerd`, `encoderd`, and `tools/replay`, reducing dependencies.