### PR TITLE
camerad: move debugging parameters from camera_common.h to camera_qcom2.cc

### DIFF
--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -17,11 +17,6 @@ enum CameraType {
   WideRoadCam
 };
 
-// for debugging
-const bool env_debug_frames = getenv("DEBUG_FRAMES") != NULL;
-const bool env_log_raw_frames = getenv("LOG_RAW_FRAMES") != NULL;
-const bool env_ctrl_exp_from_params = getenv("CTRL_EXP_FROM_PARAMS") != NULL;
-
 typedef struct FrameMetadata {
   uint32_t frame_id;
   uint32_t request_id;

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -25,6 +25,11 @@
 
 ExitHandler do_exit;
 
+// for debugging
+const bool env_debug_frames = getenv("DEBUG_FRAMES") != nullptr;
+const bool env_log_raw_frames = getenv("LOG_RAW_FRAMES") != nullptr;
+const bool env_ctrl_exp_from_params = getenv("CTRL_EXP_FROM_PARAMS") != nullptr;
+
 
 // high level camera state
 class CameraState : public SpectraCamera {


### PR DESCRIPTION
Move debugging-specific parameters from the global `camera_common.h` include to `camera_qcom2.cc`, where they are actually used. 
This change reduces unnecessary global parameters and keeps the debugging logic localized to the qcom2.cc