### PR TITLE
camerad:  centralize enabled handling and simplify camera Initialization  

### DIFF
--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -123,6 +123,7 @@ void CameraState::update_exposure_score(float desired_ev, int exp_t, int exp_g_i
 }
 
 void CameraState::set_camera_exposure(float grey_frac) {
+  if (!enabled) return;
   const float dt = 0.05;
 
   const float ts_grey = 10.0;
@@ -267,11 +268,6 @@ void CameraState::run() {
 }
 
 void camerad_thread() {
-  /*
-    TODO: future cleanups
-    - centralize enabled handling
-  */
-
   cl_device_id device_id = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT);
   const cl_context_properties props[] = {CL_CONTEXT_PRIORITY_HINT_QCOM, CL_PRIORITY_HINT_HIGH_QCOM, 0};
   cl_context ctx = CL_CHECK_ERR(clCreateContext(props, 1, &device_id, NULL, NULL, &err));

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -197,6 +197,7 @@ void SpectraMaster::init() {
 
 SpectraCamera::SpectraCamera(SpectraMaster *master, const CameraConfig &config)
   : m(master),
+    enabled(true),
     cc(config) {
   mm.init(m->video0_fd);
 }
@@ -259,6 +260,7 @@ void SpectraCamera::sensors_poke(int request_id) {
   int ret = device_config(sensor_fd, session_handle, sensor_dev_handle, cam_packet_handle);
   if (ret != 0) {
     LOGE("** sensor %d FAILED poke, disabling", cc.camera_num);
+    enabled = false;
     return;
   }
 }
@@ -288,6 +290,7 @@ void SpectraCamera::sensors_i2c(const struct i2c_random_wr_payload* dat, int len
   int ret = device_config(sensor_fd, session_handle, sensor_dev_handle, cam_packet_handle);
   if (ret != 0) {
     LOGE("** sensor %d FAILED i2c, disabling", cc.camera_num);
+    enabled = false;
     return;
   }
 }

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -86,6 +86,7 @@ public:
   // *** state ***
 
   bool open = false;
+  bool enabled = true;
   CameraConfig cc;
   std::unique_ptr<const SensorInfo> sensor;
 

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -61,13 +61,12 @@ public:
 class SpectraCamera {
 public:
   SpectraCamera(SpectraMaster *master, const CameraConfig &config);
-  ~SpectraCamera();
+  virtual ~SpectraCamera();
 
-  void camera_open();
+  bool camera_open(VisionIpcServer *v, cl_device_id device_id, cl_context ctx);
   void handle_camera_event(const cam_req_mgr_message *event_data);
   void camera_close();
   void camera_map_bufs();
-  void camera_init(VisionIpcServer *v, cl_device_id device_id, cl_context ctx);
   void config_isp(int io_mem_handle, int fence, int request_id, int buf0_idx);
 
   int clear_req_queue();
@@ -87,7 +86,6 @@ public:
   // *** state ***
 
   bool open = false;
-  bool enabled = true;
   CameraConfig cc;
   std::unique_ptr<const SensorInfo> sensor;
 


### PR DESCRIPTION
1. **Centralized enabled Handling:** Removed redundant enabled checks from individual functions. The enabled state is now handled during the camera initialization phase, ensuring that cameras are set up correctly at the start.
2. **Simplified Camera Initialization:** Moved all camera setup tasks to `CameraState::init`. This consolidates the initialization process, making the flow more streamlined and easier to maintain.
3. **Simplified Thread Management:** Threads are now managed directly by `CameraState`, removing the need to track them in a separate vector or manually join them on exit. 