### PR TITLE
camerad: move `handle_camera_event` to SpectraCamera class

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -102,7 +102,7 @@ CameraBuf::~CameraBuf() {
   if (imgproc) delete imgproc;
 }
 
-bool CameraBuf::acquire() {
+bool CameraBuf::acquire(int expo_time) {
   if (!safe_queue.try_pop(cur_buf_idx, 50)) return false;
 
   if (camera_bufs_metadata[cur_buf_idx].frame_id == -1) {
@@ -115,7 +115,7 @@ bool CameraBuf::acquire() {
   cur_camera_buf = &camera_bufs[cur_buf_idx];
 
   double start_time = millis_since_boot();
-  imgproc->runKernel(camera_bufs[cur_buf_idx].buf_cl, cur_yuv_buf->buf_cl, out_img_width, out_img_height, cur_frame_data.integ_lines);
+  imgproc->runKernel(camera_bufs[cur_buf_idx].buf_cl, cur_yuv_buf->buf_cl, out_img_width, out_img_height, expo_time);
   cur_frame_data.processing_time = (millis_since_boot() - start_time) / 1000.0;
 
   VisionIpcBufExtra extra = {

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -19,13 +19,6 @@ typedef struct FrameMetadata {
   uint64_t timestamp_sof;
   uint64_t timestamp_eof;
 
-  // Exposure
-  unsigned int integ_lines;
-  bool high_conversion_gain;
-  float gain;
-  float measured_grey_fraction;
-  float target_grey_fraction;
-
   float processing_time;
 } FrameMetadata;
 
@@ -53,7 +46,7 @@ public:
   CameraBuf() = default;
   ~CameraBuf();
   void init(cl_device_id device_id, cl_context context, SpectraCamera *cam, VisionIpcServer * v, int frame_cnt, VisionStreamType type);
-  bool acquire();
+  bool acquire(int expo_time);
   void queue(size_t buf_idx);
 };
 

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -36,6 +36,7 @@ public:
   ~SpectraCamera();
 
   void camera_open();
+  void handle_camera_event(const cam_req_mgr_message *event_data);
   void camera_close();
   void camera_map_bufs();
   void camera_init(VisionIpcServer *v, cl_device_id device_id, cl_context ctx);


### PR DESCRIPTION
**Key changes:**
1. **Moved exposure handling to CameraState::run():** Exposure-related parameters are now managed exclusively in `CameraState::run()`, ensuring they are read and written within the same camera thread. This refactor leaves `handle_camera_event()` dedicated solely to processing camera events.
2. **Removed exp_lock:** With exposure parameters being accessed within the same thread, the exp_lock is no longer required, simplifying the code, removing unnecessary synchronization, and avoiding potential concurrency issues.
3. **Removed exposure-related parameters from FrameMetadata:**  Exposure data is no longer included in `FrameMetadata` and is now tracked within `CameraState`, which streamlines `FrameMetadata` to concentrate on camera frame details