### PR TITLE
camerad:  make SpectraCamera destructor virtual

### DIFF
--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -33,7 +33,7 @@ public:
 class SpectraCamera {
 public:
   SpectraCamera(SpectraMaster *master, const CameraConfig &config);
-  ~SpectraCamera();
+  virtual ~SpectraCamera();
 
   void camera_open();
   void camera_close();


### PR DESCRIPTION
 makes the destructor of `SpectraCamera` virtual to ensure proper cleanup in case of inheritance.