### PR TITLE
camerad: reduce internal ISP buffer count

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -711,8 +711,7 @@ void SpectraCamera::configISP() {
   LOGD("acquire isp dev");
 
   // config ISP
-  // TODO: unclear where this 15 comes from
-  alloc_w_mmu_hdl(m->video0_fd, 15*ALIGNED_SIZE(buf0_size, buf0_alignment), (uint32_t*)&buf0_handle, buf0_alignment,
+  alloc_w_mmu_hdl(m->video0_fd, FRAME_BUF_COUNT*ALIGNED_SIZE(buf0_size, buf0_alignment), (uint32_t*)&buf0_handle, buf0_alignment,
                   CAM_MEM_FLAG_HW_READ_WRITE | CAM_MEM_FLAG_KMD_ACCESS | CAM_MEM_FLAG_UMD_ACCESS | CAM_MEM_FLAG_CMD_BUF_TYPE,
                   m->device_iommu, m->cdm_iommu);
   config_isp(0, 0, 1, 0);


### PR DESCRIPTION
From a HAL dump:
```
    mem_handle: 870054  offset:   0 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 68480 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 136960 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 205440 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 273920 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 342400 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 410880 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 479360 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 547840 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 616320 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 684800 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 753280 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 821760 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 890240 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 958720 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset:   0 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 68480 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 136960 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 205440 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 273920 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 342400 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 410880 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 479360 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 547840 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 616320 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 684800 size: 68472 length: 1172 type:   5 meta_data: 3
    mem_handle: 870054  offset: 753280 size: 68472 length: 1172 type:   5 meta_data: 3
```