### PR TITLE
encoderd: use const reference for VisionBuf access

### DIFF
--- a/system/loggerd/encoderd.cc
+++ b/system/loggerd/encoderd.cc
@@ -59,7 +59,7 @@ void encoder_thread(EncoderdState *s, const LogCameraInfo &cam_info) {
 
     // init encoders
     if (encoders.empty()) {
-      VisionBuf buf_info = vipc_client.buffers[0];
+      const VisionBuf &buf_info = vipc_client.buffers[0];
       LOGW("encoder %s init %zux%zu", cam_info.thread_name, buf_info.width, buf_info.height);
       assert(buf_info.width > 0 && buf_info.height > 0);
 


### PR DESCRIPTION
Using a const reference prevents unnecessary copying of VisionBuf. While VisionBuf currently lacks a destructor, adding one in the future could cause problems, such as unintentionally releasing buffers from vipc_client.buffers[0] during a copy. By using a reference, we avoid this potential issue and ensure safe, efficient access.