### PR TITLE
loggerd: direct Initialize params instead of copy

### DIFF
--- a/system/loggerd/logger.cc
+++ b/system/loggerd/logger.cc
@@ -40,7 +40,7 @@ kj::Array<capnp::word> logger_build_init_data() {
   init.setOsVersion(util::read_file("/VERSION"));
 
   // log params
-  auto params = Params(util::getenv("PARAMS_COPY_PATH", ""));
+  Params params(util::getenv("PARAMS_COPY_PATH", ""));
   std::map<std::string, std::string> params_map = params.readAll();
 
   init.setGitCommit(params_map["GitCommit"]);


### PR DESCRIPTION
Changed the initialization of the Params object to direct initialization, eliminating the temporary object and preventing the copy constructor from being invoked. 