### PR TITLE
camerad: fix: Explicitly include necessary headers

### DIFF
--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "media/cam_req_mgr.h"

--- a/system/camerad/sensors/ar0231.cc
+++ b/system/camerad/sensors/ar0231.cc
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cmath>
 
 #include "common/swaglog.h"
 #include "system/camerad/sensors/sensor.h"

--- a/system/camerad/sensors/os04c10.cc
+++ b/system/camerad/sensors/os04c10.cc
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "system/camerad/sensors/sensor.h"
 
 namespace {

--- a/system/camerad/sensors/ox03c10.cc
+++ b/system/camerad/sensors/ox03c10.cc
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "system/camerad/sensors/sensor.h"
 
 namespace {


### PR DESCRIPTION
**Description**

Latest master OP build fails on agnos 11 with missing includes in recently changed camerad code.
Explicitly include the necessary header files.

**Verification**

Compiled and run on C3 with both agnos 10 and 11.
