### PR TITLE
ui/hud: add Q_OBJECT macro

### DIFF
--- a/selfdrive/ui/qt/onroad/hud.h
+++ b/selfdrive/ui/qt/onroad/hud.h
@@ -4,6 +4,8 @@
 #include "selfdrive/ui/ui.h"
 
 class HudRenderer : public QObject {
+  Q_OBJECT
+
 public:
   HudRenderer();
   void updateState(const UIState &s);


### PR DESCRIPTION
resolve warning:
`/data/openpilot/selfdrive/ui/qt/onroad/hud.cc:84: Class 'HudRenderer' lacks Q_OBJECT macro`