### PR TITLE
`setup.sh`: add `--recurse-submodules`flag in `git clone` command

### DIFF
--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -142,7 +142,7 @@ function check_git() {
 function git_clone() {
   st="$(date +%s)"
   echo "Cloning openpilot..."
-  if $(git clone --filter=blob:none https://github.com/commaai/openpilot.git "$OPENPILOT_ROOT"); then
+  if $(git clone --filter=blob:none --recurse-submodules https://github.com/commaai/openpilot.git "$OPENPILOT_ROOT"); then
     if [[ -f $OPENPILOT_ROOT/launch_openpilot.sh ]]; then
       et="$(date +%s)"
       echo -e " ↳ [${GREEN}✔${NC}] Successfully cloned openpilot in $((et - st)) seconds.\n"


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

When running `bash <(curl -fsSL openpilot.comma.ai)` the setup performs a git clone without the `--recurse-submodules`. This prevents us from being able to build openpilot after setup. 

I confirmed this by performing the setup steps found in `tools/README.md` which does include the `--recurse-submodules` in the git clone command. Doing this allowed me to build openpilot with no issues.

[Reference to the tools/README.md](https://github.com/commaai/openpilot/tree/master/tools#native-setup-on-ubuntu-2404)