### PR TITLE
maneuversd: Add note about cars requiring resume button press to exit standstill

### DIFF
--- a/tools/longitudinal_maneuvers/README.md
+++ b/tools/longitudinal_maneuvers/README.md
@@ -18,7 +18,7 @@ Test your vehicle's longitudinal control tuning with this tool. The tool will te
 
    ![videoframe_6652](https://github.com/user-attachments/assets/e9d4c95a-cd76-4ab7-933e-19937792fa0f)
 
-5. Ensure the road ahead is clear, as openpilot will not brake for any obstructions in this mode. Once you are ready, press "Set" on your steering wheel to start the tests. The tests will run for about 4 minutes. If you need to pause the tests, press "Cancel" on your steering wheel. You can resume the tests by pressing "Resume" on your steering wheel.
+5. Ensure the road ahead is clear, as openpilot will not brake for any obstructions in this mode. Once you are ready, press "Set" on your steering wheel to start the tests. The tests will run for about 4 minutes. If you need to pause the tests, press "Cancel" on your steering wheel. You can resume the tests by pressing "Resume" on your steering wheel. **Note:** on cars requiring the resume button to be pressed to exit a standstill, the resume button will need to be pressed for about 3-5 seconds to get the car to start moving again. It is recommended to hold down the resume button for all low-speed tests (starting, stopping and creep) to avoid the car entering standstill.
 
    ![cog-clip-00 01 11 250-00 01 22 250](https://github.com/user-attachments/assets/c312c1cc-76e8-46e1-a05e-bb9dfb58994f)
 

--- a/tools/longitudinal_maneuvers/README.md
+++ b/tools/longitudinal_maneuvers/README.md
@@ -18,7 +18,9 @@ Test your vehicle's longitudinal control tuning with this tool. The tool will te
 
    ![videoframe_6652](https://github.com/user-attachments/assets/e9d4c95a-cd76-4ab7-933e-19937792fa0f)
 
-5. Ensure the road ahead is clear, as openpilot will not brake for any obstructions in this mode. Once you are ready, press "Set" on your steering wheel to start the tests. The tests will run for about 4 minutes. If you need to pause the tests, press "Cancel" on your steering wheel. You can resume the tests by pressing "Resume" on your steering wheel. **Note:** on cars requiring the resume button to be pressed to exit a standstill, the resume button will need to be pressed for about 3-5 seconds to get the car to start moving again. It is recommended to hold down the resume button for all low-speed tests (starting, stopping and creep) to avoid the car entering standstill.
+5. Ensure the road ahead is clear, as openpilot will not brake for any obstructions in this mode. Once you are ready, press "Set" on your steering wheel to start the tests. The tests will run for about 4 minutes. If you need to pause the tests, press "Cancel" on your steering wheel. You can resume the tests by pressing "Resume" on your steering wheel. 
+
+   **Note:** For GM cars, it is recommended to hold down the resume button for all low-speed tests (starting, stopping and creep) to avoid the car entering standstill.
 
    ![cog-clip-00 01 11 250-00 01 22 250](https://github.com/user-attachments/assets/c312c1cc-76e8-46e1-a05e-bb9dfb58994f)
 

--- a/tools/longitudinal_maneuvers/maneuversd.py
+++ b/tools/longitudinal_maneuvers/maneuversd.py
@@ -22,7 +22,6 @@ class Maneuver:
   initial_speed: float = 0.  # m/s
 
   _active: bool = False
-  _prev_cruise_standstill: bool = False
   _finished: bool = False
   _action_index: int = 0
   _action_frames: int = 0
@@ -33,14 +32,10 @@ class Maneuver:
     ready = abs(v_ego - self.initial_speed) < 0.3 and long_active and not cruise_standstill
     if self.initial_speed < 0.01:
       ready = ready and standstill
-      if ready and self._prev_cruise_standstill:
-        self._active = True
     self._ready_cnt = (self._ready_cnt + 1) if ready else 0
 
     if self._ready_cnt > (3. / DT_MDL):
       self._active = True
-
-    self._prev_cruise_standstill = cruise_standstill
 
     if not self._active:
       return min(max(self.initial_speed - v_ego, -2.), 2.)

--- a/tools/longitudinal_maneuvers/maneuversd.py
+++ b/tools/longitudinal_maneuvers/maneuversd.py
@@ -22,6 +22,7 @@ class Maneuver:
   initial_speed: float = 0.  # m/s
 
   _active: bool = False
+  _prev_cruise_standstill: bool = False
   _finished: bool = False
   _action_index: int = 0
   _action_frames: int = 0
@@ -32,10 +33,14 @@ class Maneuver:
     ready = abs(v_ego - self.initial_speed) < 0.3 and long_active and not cruise_standstill
     if self.initial_speed < 0.01:
       ready = ready and standstill
+      if ready and self._prev_cruise_standstill:
+        self._active = True
     self._ready_cnt = (self._ready_cnt + 1) if ready else 0
 
     if self._ready_cnt > (3. / DT_MDL):
       self._active = True
+
+    self._prev_cruise_standstill = cruise_standstill
 
     if not self._active:
       return min(max(self.initial_speed - v_ego, -2.), 2.)


### PR DESCRIPTION
**Description**

Longitudinal Maneuvers Testing Tool did not work with cars that do not have Stop and Go support. Pressing resume did not let the car exist standstill mode for long enough to set active true

**Verification**

It worked on my car. Ideally someone would test that has SNG to make sure it still works for them. (https://discord.com/channels/469524606043160576/1282121586002104402/1289365807624749056)