### PR TITLE
`updater`: force `offroad` when updating

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -189,6 +189,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"TrainingVersion", PERSISTENT},
     {"UbloxAvailable", PERSISTENT},
     {"UpdateAvailable", CLEAR_ON_MANAGER_START | CLEAR_ON_ONROAD_TRANSITION},
+    {"Updating", CLEAR_ON_MANAGER_START | CLEAR_ON_ONROAD_TRANSITION},
     {"UpdateFailedCount", CLEAR_ON_MANAGER_START},
     {"UpdaterAvailableBranches", PERSISTENT},
     {"UpdaterCurrentDescription", CLEAR_ON_MANAGER_START},

--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -122,7 +122,7 @@ void BodyWindow::paintEvent(QPaintEvent *event) {
   }
 }
 
-void BodyWindow::offroadTransition(bool offroad) {
+void BodyWindow::offroadTransition(bool offroad, bool isUpdating) {
   btn->setChecked(true);
   btn->setEnabled(true);
   fuel_filter.reset(1.0);

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -34,5 +34,5 @@ private:
 
 private slots:
   void updateState(const UIState &s);
-  void offroadTransition(bool onroad);
+  void offroadTransition(bool onroad, bool isUpdating);
 };

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -58,10 +58,10 @@ void HomeWindow::updateState(const UIState &s) {
   }
 }
 
-void HomeWindow::offroadTransition(bool offroad) {
+void HomeWindow::offroadTransition(bool offroad, bool isUpdating) {
   body->setEnabled(false);
-  sidebar->setVisible(offroad);
-  if (offroad) {
+  sidebar->setVisible(offroad || isUpdating);
+  if (offroad || isUpdating) {
     slayout->setCurrentWidget(home);
   } else {
     slayout->setCurrentWidget(onroad);

--- a/selfdrive/ui/qt/home.h
+++ b/selfdrive/ui/qt/home.h
@@ -52,7 +52,7 @@ signals:
   void closeSettings();
 
 public slots:
-  void offroadTransition(bool offroad);
+  void offroadTransition(bool offroad, bool isUpdating);
   void showDriverView(bool show);
   void showSidebar(bool show);
 

--- a/selfdrive/ui/qt/offroad/software_settings.cc
+++ b/selfdrive/ui/qt/offroad/software_settings.cc
@@ -88,7 +88,7 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
     updateLabels();
   });
 
-  connect(uiState(), &UIState::offroadTransition, [=](bool offroad) {
+  connect(uiState(), &UIState::offroadTransition, [=](bool offroad, bool isUpdating) {
     is_onroad = !offroad;
     updateLabels();
   });
@@ -109,6 +109,7 @@ void SoftwarePanel::updateLabels() {
   fs_watch->addParam("UpdateFailedCount");
   fs_watch->addParam("UpdaterState");
   fs_watch->addParam("UpdateAvailable");
+  fs_watch->addParam("Updating");
 
   if (!isVisible()) {
     return;

--- a/selfdrive/ui/qt/onroad/onroad_home.cc
+++ b/selfdrive/ui/qt/onroad/onroad_home.cc
@@ -55,7 +55,7 @@ void OnroadWindow::updateState(const UIState &s) {
   }
 }
 
-void OnroadWindow::offroadTransition(bool offroad) {
+void OnroadWindow::offroadTransition(bool offroad, bool isUpdating) {
   alerts->clear();
 }
 

--- a/selfdrive/ui/qt/onroad/onroad_home.h
+++ b/selfdrive/ui/qt/onroad/onroad_home.h
@@ -17,6 +17,6 @@ private:
   QHBoxLayout* split;
 
 private slots:
-  void offroadTransition(bool offroad);
+  void offroadTransition(bool offroad, bool isUpdating);
   void updateState(const UIState &s);
 };

--- a/selfdrive/ui/qt/setup/updater.cc
+++ b/selfdrive/ui/qt/setup/updater.cc
@@ -44,9 +44,9 @@ Updater::Updater(const QString &updater_path, const QString &manifest_path, QWid
     });
     hlayout->addWidget(connect);
 
-    QPushButton *install = new QPushButton(tr("Install"));
-    install->setObjectName("navBtn");
-    install->setStyleSheet(R"(
+    QPushButton *update = new QPushButton(tr("Update Now"));
+    update->setObjectName("navBtn");
+    update->setStyleSheet(R"(
       QPushButton {
         background-color: #465BEA;
       }
@@ -54,8 +54,8 @@ Updater::Updater(const QString &updater_path, const QString &manifest_path, QWid
         background-color: #3049F4;
       }
     )");
-    QObject::connect(install, &QPushButton::clicked, this, &Updater::installUpdate);
-    hlayout->addWidget(install);
+    QObject::connect(update, &QPushButton::clicked, this, &Updater::updateNow);
+    hlayout->addWidget(update);
   }
 
   // wifi connection screen
@@ -144,7 +144,7 @@ Updater::Updater(const QString &updater_path, const QString &manifest_path, QWid
   )");
 }
 
-void Updater::installUpdate() {
+void Updater::updateNow() {
   setCurrentWidget(progress);
   QObject::connect(&proc, &QProcess::readyReadStandardOutput, this, &Updater::readProgress);
   QObject::connect(&proc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &Updater::updateFinished);
@@ -168,9 +168,7 @@ void Updater::readProgress() {
 
 void Updater::updateFinished(int exitCode, QProcess::ExitStatus exitStatus) {
   qDebug() << "finished with " << exitCode;
-  if (exitCode == 0) {
-    Hardware::reboot();
-  } else {
+  if (exitCode != 0) {
     text->setText(tr("Update failed"));
     reboot->show();
   }

--- a/selfdrive/ui/qt/setup/updater.h
+++ b/selfdrive/ui/qt/setup/updater.h
@@ -14,7 +14,7 @@ public:
   explicit Updater(const QString &updater_path, const QString &manifest_path, QWidget *parent = 0);
 
 private slots:
-  void installUpdate();
+  void updateNow();
   void readProgress();
   void updateFinished(int exitCode, QProcess::ExitStatus exitStatus);
 

--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -64,7 +64,7 @@ void Sidebar::mouseReleaseEvent(QMouseEvent *event) {
   }
 }
 
-void Sidebar::offroadTransition(bool offroad) {
+void Sidebar::offroadTransition(bool offroad, bool isUpdating) {
   onroad = !offroad;
   update();
 }

--- a/selfdrive/ui/qt/sidebar.h
+++ b/selfdrive/ui/qt/sidebar.h
@@ -26,7 +26,7 @@ signals:
   void valueChanged();
 
 public slots:
-  void offroadTransition(bool offroad);
+  void offroadTransition(bool offroad, bool isUpdating);
   void updateState(const UIState &s);
 
 protected:

--- a/selfdrive/ui/qt/widgets/offroad_alerts.cc
+++ b/selfdrive/ui/qt/widgets/offroad_alerts.cc
@@ -43,7 +43,7 @@ AbstractAlert::AbstractAlert(bool hasRebootBtn, QWidget *parent) : QFrame(parent
   snooze_btn->setStyleSheet(R"(color: white; background-color: #4F4F4F;)");
 
   if (hasRebootBtn) {
-    QPushButton *rebootBtn = new QPushButton(tr("Reboot and Update"));
+    QPushButton *rebootBtn = new QPushButton(tr("Reboot"));
     rebootBtn->setFixedSize(600, 125);
     footer_layout->addWidget(rebootBtn, 0, Qt::AlignBottom | Qt::AlignRight);
     QObject::connect(rebootBtn, &QPushButton::clicked, [=]() { Hardware::reboot(); });

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -33,8 +33,8 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     main_layout->setCurrentWidget(onboardingWindow);
   }
 
-  QObject::connect(uiState(), &UIState::offroadTransition, [=](bool offroad) {
-    if (!offroad) {
+  QObject::connect(uiState(), &UIState::offroadTransition, [=](bool offroad, bool isUpdating) {
+    if (!offroad && !isUpdating) {
       closeSettings();
     }
   });

--- a/selfdrive/ui/translations/main_ar.ts
+++ b/selfdrive/ui/translations/main_ar.ts
@@ -12,8 +12,8 @@
         <translation>تأخير التحديث</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>إعادة التشغيل والتحديث</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1083,7 +1083,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>تثبيت</translation>
+        <translation type="vanished">تثبيت</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1100,6 +1100,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>فشل التحديث</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -12,8 +12,8 @@
         <translation>Update pausieren</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>Aktualisieren und neu starten</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1067,7 +1067,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>Installieren</translation>
+        <translation type="vanished">Installieren</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1084,6 +1084,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>Aktualisierung fehlgeschlagen</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_es.ts
+++ b/selfdrive/ui/translations/main_es.ts
@@ -12,8 +12,8 @@
         <translation>Posponer Actualización</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>Reiniciar y Actualizar</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1067,7 +1067,7 @@ Esto puede tardar un minuto.</translation>
     </message>
     <message>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="vanished">Instalar</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1084,6 +1084,10 @@ Esto puede tardar un minuto.</translation>
     <message>
         <source>Update failed</source>
         <translation>Actualización fallida</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -12,8 +12,8 @@
         <translation>Reporter la mise à jour</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>Redémarrer et mettre à jour</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1067,7 +1067,7 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
     </message>
     <message>
         <source>Install</source>
-        <translation>Installer</translation>
+        <translation type="vanished">Installer</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1084,6 +1084,10 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
     <message>
         <source>Update failed</source>
         <translation>Échec de la mise à jour</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -12,8 +12,8 @@
         <translation>更新の一時停止</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>再起動してアップデート</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1061,7 +1061,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>インストール</translation>
+        <translation type="vanished">インストール</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1078,6 +1078,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>更新失敗</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -12,8 +12,8 @@
         <translation>업데이트 일시 중지</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>업데이트 및 재부팅</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1063,7 +1063,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>설치</translation>
+        <translation type="vanished">설치</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1080,6 +1080,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>업데이트 실패</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -12,8 +12,8 @@
         <translation>Adiar Atualização</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>Reiniciar e Atualizar</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1067,7 +1067,7 @@ Isso pode levar até um minuto.</translation>
     </message>
     <message>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="vanished">Instalar</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1084,6 +1084,10 @@ Isso pode levar até um minuto.</translation>
     <message>
         <source>Update failed</source>
         <translation>Falha na atualização</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_th.ts
+++ b/selfdrive/ui/translations/main_th.ts
@@ -12,8 +12,8 @@
         <translation>เลื่อนการอัปเดต</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>รีบูตและอัปเดต</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1063,7 +1063,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>ติดตั้ง</translation>
+        <translation type="vanished">ติดตั้ง</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1080,6 +1080,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>การอัปเดตล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_tr.ts
+++ b/selfdrive/ui/translations/main_tr.ts
@@ -12,8 +12,8 @@
         <translation>Güncellemeyi sessize al</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>Güncelle ve Yeniden başlat</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1061,7 +1061,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>Yükle</translation>
+        <translation type="vanished">Yükle</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1078,6 +1078,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>Güncelleme başarız oldu</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -12,8 +12,8 @@
         <translation>暂停更新</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>重启并更新</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1063,7 +1063,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>安装</translation>
+        <translation type="vanished">安装</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1080,6 +1080,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>更新失败</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -12,8 +12,8 @@
         <translation>暫停更新</translation>
     </message>
     <message>
-        <source>Reboot and Update</source>
-        <translation>重啟並更新</translation>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1063,7 +1063,7 @@ This may take up to a minute.</source>
     </message>
     <message>
         <source>Install</source>
-        <translation>安裝</translation>
+        <translation type="vanished">安裝</translation>
     </message>
     <message>
         <source>Back</source>
@@ -1080,6 +1080,10 @@ This may take up to a minute.</source>
     <message>
         <source>Update failed</source>
         <translation>更新失敗</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -178,7 +178,9 @@ void UIState::updateStatus() {
     }
     started_prev = scene.started;
     scene.world_objects_visible = false;
-    emit offroadTransition(!scene.started);
+    auto params = Params();
+    bool isUpdating = params.getBool("Updating"); // TODO: figure out why this is true
+    emit offroadTransition(!scene.started, isUpdating);
   }
 }
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -98,7 +98,7 @@ public:
 
 signals:
   void uiUpdate(const UIState &s);
-  void offroadTransition(bool offroad);
+  void offroadTransition(bool offroad, bool isUpdating);
 
 private slots:
   void update();

--- a/system/updated/updated.py
+++ b/system/updated/updated.py
@@ -143,6 +143,7 @@ def init_overlay() -> None:
 
   params = Params()
   params.put_bool("UpdateAvailable", False)
+  params.put_bool("Updating", False)
   set_consistent_flag(False)
   dismount_overlay()
   run(["sudo", "rm", "-rf", STAGING_ROOT])
@@ -318,6 +319,8 @@ class Updater:
     self.params.put("UpdaterNewDescription", get_description(FINALIZED))
     self.params.put("UpdaterNewReleaseNotes", parse_release_notes(FINALIZED))
     self.params.put_bool("UpdateAvailable", self.update_ready)
+    self.params.put_bool("Updating", False)
+
 
     # Handle user prompt
     for alert in ("Offroad_UpdateFailed", "Offroad_ConnectivityNeeded", "Offroad_ConnectivityNeededPrompt"):
@@ -377,6 +380,7 @@ class Updater:
     # TODO: cleanly interrupt this and invalidate old update
     set_consistent_flag(False)
     self.params.put_bool("UpdateAvailable", False)
+    self.params.put_bool("Updating", False)
 
     setup_git_options(OVERLAY_MERGED)
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

initially looking how the ui would handle `update now` instead of `reboot and update`

Fixes #33141

- [ ] sends signal to trigger update in the background
- [ ] show progress bar in offroad home. would be the same screen found in updater already just moved to offroad home
- [ ] show `update` offroad alert for when update is finished
- [x] locks `homeWindow` to `offRoad`
- [x] unlocks `homeWindow` from `offRoad` once update completes


<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

