### PR TITLE
`sefldrive/ui/Sconscript`: move updater ui outside of `arch != 'Darwin'` check

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -67,6 +67,9 @@ if GetOption('extras'):
   qt_src.remove("main.cc")  # replaced by test_runner
   qt_env.Program('tests/test_translations', [asset_obj, 'tests/test_runner.cc', 'tests/test_translations.cc'] + qt_src, LIBS=qt_libs)
 
+  # build updater UI
+  qt_env.Program("qt/setup/updater", ["qt/setup/updater.cc", asset_obj], LIBS=qt_libs)
+
 if GetOption('extras') and arch != "Darwin":
   qt_env.SharedLibrary("qt/python_helpers", ["qt/qt_window.cc"], LIBS=qt_libs)
 
@@ -74,14 +77,10 @@ if GetOption('extras') and arch != "Darwin":
   qt_env.Program("_text", ["qt/text.cc"], LIBS=qt_libs)
   qt_env.Program("_spinner", ["qt/spinner.cc"], LIBS=qt_libs)
 
-
   # setup and factory resetter
   qt_env.Program("qt/setup/reset", ["qt/setup/reset.cc"], LIBS=qt_libs)
   qt_env.Program("qt/setup/setup", ["qt/setup/setup.cc", asset_obj],
                  LIBS=qt_libs + ['curl', 'common'])
-
-  # build updater UI
-  qt_env.Program("qt/setup/updater", ["qt/setup/updater.cc", asset_obj], LIBS=qt_libs)
 
   # build installers
   senv = qt_env.Clone()


### PR DESCRIPTION
Was playing around with the build script for `selfdrive/ui` and found that we can move lines outside of the `!Darwin` check since they run perfectly fine. Only one worth moving is `updater` since I needed to do this change to run updater ui.

I'm sure there's a good reason why this was set but chose to open since it removes an extra step needed to work on `updater` something that will be of focus soon.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

