### PR TITLE
`CI`: add check to prevent comments on draft PRs from `ui_preview.yaml`

### DIFF
--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   preview:
-    if: github.repository == 'commaai/openpilot'
+    if: github.repository == 'commaai/openpilot' && github.event.pull_request.draft == false
     name: preview
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -79,7 +79,7 @@ jobs:
           git push origin openpilot_master_ui --force
 
       - name: Finding diff
-        if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
+        if: github.event_name == 'pull_request_target'
         id: find_diff
         run: >-
           sudo apt-get install -y imagemagick

--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -79,7 +79,7 @@ jobs:
           git push origin openpilot_master_ui --force
 
       - name: Finding diff
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
         id: find_diff
         run: >-
           sudo apt-get install -y imagemagick


### PR DESCRIPTION
Doesn't really make sense to have comments be posted on draft PRs when as a draft they're constantly being worked on. This just prevents unnecessary noise on draft PRs. ui_preview will only run once it's taken off draft.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

