### PR TITLE
GM: signed wheel speeds

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -120,7 +120,7 @@ class CarSpecificEvents:
       # Enabling at a standstill with brake is allowed
       # TODO: verify 17 Volt can enable for the first time at a stop and allow for all GMs
       if CS.out.vEgo < self.CP.minEnableSpeed and not (CS.out.standstill and CS.out.brake >= 20 and
-                                         self.CP.networkLocation == NetworkLocation.fwdCamera):
+                                                       self.CP.networkLocation == NetworkLocation.fwdCamera):
         events.add(EventName.belowEngageSpeed)
       if CS.out.cruiseState.standstill:
         events.add(EventName.resumeRequired)

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -119,8 +119,7 @@ class CarSpecificEvents:
 
       # Enabling at a standstill with brake is allowed
       # TODO: verify 17 Volt can enable for the first time at a stop and allow for all GMs
-      below_min_enable_speed = CS.out.vEgo < self.CP.minEnableSpeed or CS.moving_backward  # type: ignore[attr-defined]
-      if below_min_enable_speed and not (CS.out.standstill and CS.out.brake >= 20 and
+      if CS.out.vEgo < self.CP.minEnableSpeed and not (CS.out.standstill and CS.out.brake >= 20 and
                                          self.CP.networkLocation == NetworkLocation.fwdCamera):
         events.add(EventName.belowEngageSpeed)
       if CS.out.cruiseState.standstill:

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -87,7 +87,7 @@ class Controls:
     CC.enabled = self.sm['selfdriveState'].enabled
 
     # Check which actuators can be enabled
-    standstill = CS.vEgo <= max(self.CP.minSteerSpeed, MIN_LATERAL_CONTROL_SPEED) or CS.standstill
+    standstill = abs(CS.vEgo) <= max(self.CP.minSteerSpeed, MIN_LATERAL_CONTROL_SPEED) or CS.standstill
     CC.latActive = self.sm['selfdriveState'].active and not CS.steerFaultTemporary and not CS.steerFaultPermanent and not standstill
     CC.longActive = CC.enabled and not any(e.overrideLongitudinal for e in self.sm['onroadEvents']) and self.CP.openpilotLongitudinalControl
 

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -334,7 +334,7 @@ class SelfdriveD:
         self.events.add(EventName.noGps)
       if gps_ok:
         self.distance_traveled = 0
-      self.distance_traveled += CS.vEgo * DT_CTRL
+      self.distance_traveled += abs(CS.vEgo) * DT_CTRL
 
       if self.sm['modelV2'].frameDropPerc > 20:
         self.events.add(EventName.modeldLagging)


### PR DESCRIPTION
Split from https://github.com/commaai/openpilot/pull/33693

Need to know when vehicle is traveling backwards as this prevents enabling just after switching to D when traveling backwards (Bolt allows you to do this at a relatively high speed)