### PR TITLE
camerad: Use std::vector<float> for sensor_analog_gains

### DIFF
--- a/system/camerad/sensors/ar0231.cc
+++ b/system/camerad/sensors/ar0231.cc
@@ -110,7 +110,7 @@ AR0231::AR0231() {
   analog_gain_cost_low = 0.1;
   analog_gain_cost_high = 5.0;
   for (int i = 0; i <= analog_gain_max_idx; i++) {
-    sensor_analog_gains[i] = sensor_analog_gains_AR0231[i];
+    sensor_analog_gains.push_back(sensor_analog_gains_AR0231[i]);
   }
   min_ev = exposure_time_min * sensor_analog_gains[analog_gain_min_idx];
   max_ev = exposure_time_max * dc_gain_factor * sensor_analog_gains[analog_gain_max_idx];

--- a/system/camerad/sensors/os04c10.cc
+++ b/system/camerad/sensors/os04c10.cc
@@ -53,7 +53,7 @@ OS04C10::OS04C10() {
   analog_gain_cost_low = 0.4;
   analog_gain_cost_high = 6.4;
   for (int i = 0; i <= analog_gain_max_idx; i++) {
-    sensor_analog_gains[i] = sensor_analog_gains_OS04C10[i];
+    sensor_analog_gains.push_back(sensor_analog_gains_OS04C10[i]);
   }
   min_ev = (exposure_time_min) * sensor_analog_gains[analog_gain_min_idx];
   max_ev = exposure_time_max * dc_gain_factor * sensor_analog_gains[analog_gain_max_idx];

--- a/system/camerad/sensors/ox03c10.cc
+++ b/system/camerad/sensors/ox03c10.cc
@@ -53,7 +53,7 @@ OX03C10::OX03C10() {
   analog_gain_cost_low = 0.4;
   analog_gain_cost_high = 6.4;
   for (int i = 0; i <= analog_gain_max_idx; i++) {
-    sensor_analog_gains[i] = sensor_analog_gains_OX03C10[i];
+    sensor_analog_gains.push_back(sensor_analog_gains_OX03C10[i]);
   }
   min_ev = (exposure_time_min + VS_TIME_MIN_OX03C10) * sensor_analog_gains[analog_gain_min_idx];
   max_ev = exposure_time_max * dc_gain_factor * sensor_analog_gains[analog_gain_max_idx];

--- a/system/camerad/sensors/sensor.h
+++ b/system/camerad/sensors/sensor.h
@@ -12,8 +12,6 @@
 #include "system/camerad/sensors/ox03c10_registers.h"
 #include "system/camerad/sensors/os04c10_registers.h"
 
-#define ANALOG_GAIN_MAX_CNT 55
-
 class SensorInfo {
 public:
   SensorInfo() = default;
@@ -41,7 +39,7 @@ public:
   float dc_gain_on_grey;
   float dc_gain_off_grey;
 
-  float sensor_analog_gains[ANALOG_GAIN_MAX_CNT];
+  std::vector<float> sensor_analog_gains;
   int analog_gain_min_idx;
   int analog_gain_max_idx;
   int analog_gain_rec_idx;


### PR DESCRIPTION
Replace fixed-size array with std::vector<float> for sensor_analog_gains