### PR TITLE
CarState: add low speed alert field

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -207,6 +207,7 @@ struct CarState {
   carFaultedNonCritical @47 :Bool;  # some ECU is faulted, but car remains controllable
   espActive @51 :Bool;
   vehicleSensorsInvalid @52 :Bool;  # invalid steering angle readings, etc.
+  lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -45,7 +45,7 @@ class CarSpecificEvents:
     if self.CP.carName in ('body', 'mock'):
       events = Events()
 
-    elif self.CP.carName == 'subaru':
+    elif self.CP.carName in ('subaru', 'mazda'):
       events = self.create_common_events(CS.out, CS_prev)
 
     elif self.CP.carName == 'ford':
@@ -53,12 +53,6 @@ class CarSpecificEvents:
 
     elif self.CP.carName == 'nissan':
       events = self.create_common_events(CS.out, CS_prev, extra_gears=[GearShifter.brake])
-
-    elif self.CP.carName == 'mazda':
-      events = self.create_common_events(CS.out, CS_prev)
-
-      if CS.low_speed_alert:  # type: ignore[attr-defined]
-        events.add(EventName.belowSteerSpeed)
 
     elif self.CP.carName == 'chrysler':
       events = self.create_common_events(CS.out, CS_prev, extra_gears=[GearShifter.low])
@@ -212,6 +206,8 @@ class CarSpecificEvents:
       events.add(EventName.vehicleSensorsInvalid)
     if CS.invalidLkasSetting:
       events.add(EventName.invalidLkasSetting)
+    if CS.lowSpeedAlert:
+      events.add(EventName.belowSteerSpeed)
 
     # Handle button presses
     for b in CS.buttonEvents:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

