### PR TITLE
camerad:  remove Hardware::PC() check

### DIFF
--- a/system/camerad/main.cc
+++ b/system/camerad/main.cc
@@ -4,14 +4,8 @@
 
 #include "common/params.h"
 #include "common/util.h"
-#include "system/hardware/hw.h"
 
 int main(int argc, char *argv[]) {
-  if (Hardware::PC()) {
-    printf("exiting, camerad is not meant to run on PC\n");
-    return 0;
-  }
-
   int ret = util::set_realtime_priority(53);
   assert(ret == 0);
   ret = util::set_core_affinity({6});


### PR DESCRIPTION
camerad is now only compiled on the device (if arch == "larch64") and can't be built on PC, so the Hardware::PC() check in main() is unnecessary and only adds confusion.