### PR TITLE
sensord: Handle EINTR for GPIO event reading

### DIFF
--- a/system/sensord/sensors_qcom2.cc
+++ b/system/sensord/sensors_qcom2.cc
@@ -62,7 +62,7 @@ void interrupt_loop(std::vector<std::tuple<Sensor *, std::string>> sensors) {
 
     // Read all events
     struct gpioevent_data evdata[16];
-    err = read(fd, evdata, sizeof(evdata));
+    err = HANDLE_EINTR(read(fd, evdata, sizeof(evdata)));
     if (err < 0 || err % sizeof(*evdata) != 0) {
       LOGE("error reading event data %d", err);
       continue;


### PR DESCRIPTION
Improves error handling by ensuring that the `read` call properly manages the `EINTR` error, allowing for a more robust and reliable event reading process. 