### PR TITLE
Correct error calculation by using the current target acceleration

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -6,7 +6,7 @@ from cereal import car, log
 import cereal.messaging as messaging
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper
+from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper, DT_CTRL
 from openpilot.common.swaglog import cloudlog
 
 from opendbc.car.car_helpers import get_car_interface
@@ -106,7 +106,8 @@ class Controls:
 
     # accel PID loop
     pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, CS.vCruise * CV.KPH_TO_MS)
-    actuators.accel = self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop, pid_accel_limits)
+    t_since_plan = (self.sm.frame - self.sm.recv_frame['longitudinalPlan']) * DT_CTRL
+    actuators.accel = self.LoC.update(CC.longActive, CS, long_plan, pid_accel_limits, t_since_plan)
 
     # Steering PID loop and lateral MPC
     self.desired_curvature = clip_curvature(CS.vEgo, self.desired_curvature, model_v2.action.desiredCurvature)


### PR DESCRIPTION
**Summary**
This pull request fixes the error calculation in the PID controller by using the current target acceleration (a_target_now) instead of the delayed target acceleration (a_target), which accounts for actuator delay. The change ensures that the error is calculated based on the real-time target acceleration, resulting in more accurate control and improved system performance.

**Background**
Previously, the error was calculated as the difference between a_target (which includes actuator delay) and the current vehicle acceleration (CS.aEgo). However, this led to inaccuracies in the error calculation, as the delayed target acceleration does not reflect the real-time control goals. To address this, the error is now computed using a_target_now, the actual target acceleration at the current time, while a_target (which includes the delay) is still used for the feedforward control.

**Changes**
Modified the error calculation to use a_target_now instead of a_target for comparing with the current vehicle acceleration (CS.aEgo).
Retained a_target in the feedforward term to account for actuator delay in the control output.

**Benefits**
More accurate error computation by using the real-time target acceleration.
Improved control response due to better alignment between the target and actual vehicle state.
Maintains the benefit of using feedforward control with delayed target acceleration for predictive control.

**Testing**
The changes have been tested in simulation and real-world scenarios to verify the improved stability and accuracy of the PID control system. Results show smoother transitions and better overall control performance.