### PR TITLE
op sim: fix car steering angle

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -103,7 +103,7 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
       velocity=vec3(x=float(env.vehicle.velocity[0]), y=float(env.vehicle.velocity[1]), z=0),
       position=env.vehicle.position,
       bearing=float(math.degrees(env.vehicle.heading_theta)),
-      steering_angle=env.vehicle.steering * env.vehicle.MAX_STEERING
+      steering_angle=env.vehicle.steering * env.vehicle.MAX_STEERING * steer_ratio
     )
     vehicle_state_send.send(vehicle_state)
 


### PR DESCRIPTION
selfdrived always is adding the turn exceeded warning without this

before:
![image](https://github.com/user-attachments/assets/c6067c41-3893-4261-803c-45e032977d92)

after:
![image](https://github.com/user-attachments/assets/6f7545bf-4a48-4630-90ba-e0c218200199)
