### PR TITLE
tools: print VIN when getting UDS fingerprints from a route

### DIFF
--- a/selfdrive/debug/fingerprint_from_route.py
+++ b/selfdrive/debug/fingerprint_from_route.py
@@ -12,6 +12,7 @@ def get_fingerprint(lr):
   for msg in lr:
     if msg.which() == 'carParams':
       fw = msg.carParams.carFw
+      vin = msg.carParams.carVin
     elif msg.which() == 'can':
       for c in msg.can:
         # read also msgs sent by EON on CAN bus 0x80 and filter out the
@@ -32,6 +33,7 @@ def get_fingerprint(lr):
     print(f"      {f.fwVersion},")
     print("    ],")
   print()
+  print(f"VIN: {vin}")
 
 
 if __name__ == "__main__":

--- a/selfdrive/debug/fingerprint_from_route.py
+++ b/selfdrive/debug/fingerprint_from_route.py
@@ -8,6 +8,7 @@ def get_fingerprint(lr):
   # TODO: make this a nice tool for car ports. should also work with qlogs for FW
 
   fw = None
+  vin = None
   msgs = {}
   for msg in lr:
     if msg.which() == 'carParams':


### PR DESCRIPTION
**Description**

Print the VIN when running `selfdrive/debug/fingerprint_from_route.py`.

**Verification**

Needed (and used) this several times in the past couple weeks.

* VIN is now relevant to fingerprinting for multiple car platforms
* Sometimes I need the VIN from a route that's marked public but device not shared, so no useradmin
* Sometimes useradmin can't parse logs: for new car ports, or after big capnp changes, or from forks