### PR TITLE
ci: faster metadrive test

### DIFF
--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -41,7 +41,7 @@ jobs:
       run: |
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
                         source selfdrive/test/setup_vsound.sh && \
-                        CI=1 pytest -rx -rP tools/sim/tests/test_metadrive_bridge.py"
+                        CI=1 pytest tools/sim/tests/test_metadrive_bridge.py"
 
   devcontainer:
     name: devcontainer

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -41,7 +41,7 @@ jobs:
       run: |
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
                         source selfdrive/test/setup_vsound.sh && \
-                        CI=1 pytest tools/sim/tests/test_metadrive_bridge.py"
+                        CI=1 pytest -rx -rP tools/sim/tests/test_metadrive_bridge.py"
 
   devcontainer:
     name: devcontainer

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   simulator_driving:
     name: simulator driving
-    runs-on: namespace-profile-amd64-8x16
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   simulator_driving:
     name: simulator driving
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-amd64-8x16
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -27,7 +27,9 @@ env:
 jobs:
   simulator_driving:
     name: simulator driving
-    runs-on: namespace-profile-amd64-8x16
+    runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
+               ((github.event_name != 'pull_request') ||
+                (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-amd64-8x16' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4

--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -50,12 +50,13 @@ def create_map(track_size=60):
 class MetaDriveBridge(SimulatorBridge):
   TICKS_PER_FRAME = 5
 
-  def __init__(self, dual_camera, high_quality, test_duration=math.inf, test_run=False):
+  def __init__(self, dual_camera, high_quality, test_duration=math.inf, minimal_distance=0, test_run=False):
     super().__init__(dual_camera, high_quality)
 
     self.should_render = False
     self.test_run = test_run
     self.test_duration = test_duration if self.test_run else math.inf
+    self.minimal_distance = minimal_distance if self.test_run else 0
 
   def spawn_world(self, queue: Queue):
     sensors = {
@@ -90,4 +91,4 @@ class MetaDriveBridge(SimulatorBridge):
       anisotropic_filtering=False
     )
 
-    return MetaDriveWorld(queue, config, self.test_duration, self.test_run, self.dual_camera)
+    return MetaDriveWorld(queue, config, self.test_duration, self.minimal_distance, self.test_run, self.dual_camera)

--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -35,14 +35,13 @@ def create_map(track_size=60):
     lane_width=4.5,
     config=[
       None,
-      straight_block(track_size),
-      curve_block(curve_len, 90),
-      straight_block(track_size),
-      curve_block(curve_len, 90),
-      straight_block(track_size),
-      curve_block(curve_len, 90),
-      straight_block(track_size),
-      curve_block(curve_len, 90),
+      straight_block(2),
+      curve_block(60, 10),
+      straight_block(2),
+      curve_block(60, 10, direction=1),
+      straight_block(2),
+      curve_block(60, 10),
+      straight_block(500),
     ]
   )
 

--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -28,6 +28,7 @@ def curve_block(length, angle=45, direction=0):
   }
 
 def create_map(track_size=60):
+  curve_len = track_size * 2
   return dict(
     type=MapGenerateMethod.PG_MAP_FILE,
     lane_num=2,

--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -28,7 +28,6 @@ def curve_block(length, angle=45, direction=0):
   }
 
 def create_map(track_size=60):
-  curve_len = track_size * 2
   return dict(
     type=MapGenerateMethod.PG_MAP_FILE,
     lane_num=2,
@@ -36,11 +35,11 @@ def create_map(track_size=60):
     config=[
       None,
       straight_block(2),
-      curve_block(60, 10),
+      curve_block(track_size, 10),
       straight_block(2),
-      curve_block(60, 10, direction=1),
+      curve_block(track_size, 10, direction=1),
       straight_block(2),
-      curve_block(60, 10),
+      curve_block(track_size, 10),
       straight_block(500),
     ]
   )

--- a/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -34,13 +34,14 @@ def create_map(track_size=60):
     lane_width=4.5,
     config=[
       None,
-      straight_block(2),
-      curve_block(track_size, 10),
-      straight_block(2),
-      curve_block(track_size, 10, direction=1),
-      straight_block(2),
-      curve_block(track_size, 10),
-      straight_block(500),
+      straight_block(track_size),
+      curve_block(curve_len, 90),
+      straight_block(track_size),
+      curve_block(curve_len, 90),
+      straight_block(track_size),
+      curve_block(curve_len, 90),
+      straight_block(track_size),
+      curve_block(curve_len, 90),
     ]
   )
 

--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -70,6 +70,7 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
     env.reset()
     env.vehicle.config["max_speed_km_h"] = 1000
     lane_idx_prev, _ = get_current_lane_info(env.vehicle)
+    env.vehicle.set_position([40, 4.5])
 
     simulation_state = metadrive_simulation_state(
       running=True,

--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -19,6 +19,7 @@ from openpilot.tools.sim.lib.camerad import W, H
 C3_POSITION = Vec3(0.0, 0, 1.22)
 C3_HPR = Vec3(0, 0,0)
 
+VEHICLE_STARTING_POS = [85, 4.5]
 
 metadrive_simulation_state = namedtuple("metadrive_simulation_state", ["running", "done", "done_info"])
 metadrive_vehicle_state = namedtuple("metadrive_vehicle_state", ["velocity", "position", "bearing", "steering_angle"])
@@ -50,7 +51,7 @@ def apply_metadrive_patches(arrive_dest_done=True):
 
 def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera_array, image_lock,
                       controls_recv: Connection, simulation_state_send: Connection, vehicle_state_send: Connection,
-                      exit_event, op_engaged, test_duration, test_run):
+                      exit_event, op_engaged, test_duration, minimal_distance, test_run):
   arrive_dest_done = config.pop("arrive_dest_done", True)
   apply_metadrive_patches(arrive_dest_done)
 
@@ -70,7 +71,7 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
     env.reset()
     env.vehicle.config["max_speed_km_h"] = 1000
     lane_idx_prev, _ = get_current_lane_info(env.vehicle)
-    env.vehicle.set_position([85, 4.5])
+    env.vehicle.set_position(VEHICLE_STARTING_POS)
 
     simulation_state = metadrive_simulation_state(
       running=True,
@@ -99,6 +100,9 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
   steer_ratio = 8
   vc = [0,0]
 
+  total_distance = 0
+  prev_x_pos = VEHICLE_STARTING_POS[0]
+
   while not exit_event.is_set():
     vehicle_state = metadrive_vehicle_state(
       velocity=vec3(x=float(env.vehicle.velocity[0]), y=float(env.vehicle.velocity[1]), z=0),
@@ -107,6 +111,9 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
       steering_angle=env.vehicle.steering * env.vehicle.MAX_STEERING
     )
     vehicle_state_send.send(vehicle_state)
+
+    total_distance += abs(env.vehicle.position[0] - prev_x_pos)
+    prev_x_pos = env.vehicle.position[0]
 
     if controls_recv.poll(0):
       while controls_recv.poll(0):
@@ -138,7 +145,10 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
         elif out_of_lane:
           done_result = (True, {"out_of_lane" : True})
         elif timeout:
-          done_result = (True, {"timeout" : True})
+          if total_distance < minimal_distance:
+            done_result = (True, {"minimal_distance" : True})
+          else:
+            done_result = (True, {"timeout" : True})
 
         simulation_state = metadrive_simulation_state(
           running=False,

--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -145,6 +145,7 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
         elif out_of_lane:
           done_result = (True, {"out_of_lane" : True})
         elif timeout:
+          print('XXXXXXXXXXXXXXXXXX', total_distance)
           if total_distance < minimal_distance:
             done_result = (True, {"minimal_distance" : True})
           else:

--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -19,7 +19,7 @@ from openpilot.tools.sim.lib.camerad import W, H
 C3_POSITION = Vec3(0.0, 0, 1.22)
 C3_HPR = Vec3(0, 0,0)
 
-VEHICLE_STARTING_POS = [85, 4.5]
+VEHICLE_STARTING_POS = [110, 4.5]
 
 metadrive_simulation_state = namedtuple("metadrive_simulation_state", ["running", "done", "done_info"])
 metadrive_vehicle_state = namedtuple("metadrive_vehicle_state", ["velocity", "position", "bearing", "steering_angle"])

--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -145,7 +145,6 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
         elif out_of_lane:
           done_result = (True, {"out_of_lane" : True})
         elif timeout:
-          print('XXXXXXXXXXXXXXXXXX', total_distance)
           if total_distance < minimal_distance:
             done_result = (True, {"minimal_distance" : True})
           else:

--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -70,7 +70,7 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
     env.reset()
     env.vehicle.config["max_speed_km_h"] = 1000
     lane_idx_prev, _ = get_current_lane_info(env.vehicle)
-    env.vehicle.set_position([40, 4.5])
+    env.vehicle.set_position([85, 4.5])
 
     simulation_state = metadrive_simulation_state(
       running=True,

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -101,7 +101,6 @@ class MetaDriveWorld(World):
 
       x_dist = abs(curr_pos[0] - self.vehicle_last_pos[0])
       y_dist = abs(curr_pos[1] - self.vehicle_last_pos[1])
-      #print(curr_pos, time.monotonic())
       dist_threshold = 1
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -14,7 +14,7 @@ from openpilot.tools.sim.lib.camerad import W, H
 
 
 class MetaDriveWorld(World):
-  def __init__(self, status_q, config, test_duration, test_run, dual_camera=False):
+  def __init__(self, status_q, config, test_duration, minimal_distance, test_run, dual_camera=False):
     super().__init__(dual_camera)
     self.status_q = status_q
     self.camera_array = Array(ctypes.c_uint8, W*H*3)
@@ -41,7 +41,7 @@ class MetaDriveWorld(World):
                               functools.partial(metadrive_process, dual_camera, config,
                                                 self.camera_array, self.wide_camera_array, self.image_lock,
                                                 self.controls_recv, self.simulation_state_send,
-                                                self.vehicle_state_send, self.exit_event, self.op_engaged, test_duration, self.test_run))
+                                                self.vehicle_state_send, self.exit_event, self.op_engaged, test_duration, minimal_distance, self.test_run))
 
     self.metadrive_process.start()
     self.status_q.put(QueueMessage(QueueMessageType.START_STATUS, "starting"))
@@ -101,12 +101,12 @@ class MetaDriveWorld(World):
 
       x_dist = abs(curr_pos[0] - self.vehicle_last_pos[0])
       y_dist = abs(curr_pos[1] - self.vehicle_last_pos[1])
-      print(curr_pos, time.monotonic())
+      #print(curr_pos, time.monotonic())
       dist_threshold = 1
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 8
+      time_check_threshold = 7.5
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -101,6 +101,7 @@ class MetaDriveWorld(World):
 
       x_dist = abs(curr_pos[0] - self.vehicle_last_pos[0])
       y_dist = abs(curr_pos[1] - self.vehicle_last_pos[1])
+      print(curr_pos)
       dist_threshold = 1
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -117,6 +117,7 @@ class MetaDriveWorld(World):
         self.last_check_timestamp = current_time
         self.distance_moved = 0
         self.vehicle_last_pos = curr_pos
+        assert False
 
   def read_cameras(self):
     pass

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -106,7 +106,7 @@ class MetaDriveWorld(World):
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 30
+      time_check_threshold = 8
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -70,8 +70,6 @@ class MetaDriveWorld(World):
       self.vc[0] = 0
       self.vc[1] = 0
 
-    self.vc[0] = 0
-    self.vc[1] = 0
     self.controls_send.send([*self.vc, self.should_reset])
     self.should_reset = False
 

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -106,7 +106,7 @@ class MetaDriveWorld(World):
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 10
+      time_check_threshold = 30
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -102,11 +102,11 @@ class MetaDriveWorld(World):
       x_dist = abs(curr_pos[0] - self.vehicle_last_pos[0])
       y_dist = abs(curr_pos[1] - self.vehicle_last_pos[1])
       print(curr_pos, time.monotonic())
-      dist_threshold = 0.5
+      dist_threshold = 1
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 7
+      time_check_threshold = 10
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -106,12 +106,10 @@ class MetaDriveWorld(World):
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 30
+      time_check_threshold = 12
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:
-        if after_engaged_check:
-          assert False
         if after_engaged_check and self.distance_moved == 0:
           self.status_q.put(QueueMessage(QueueMessageType.TERMINATION_INFO, {"vehicle_not_moving" : True}))
           self.exit_event.set()

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -105,7 +105,7 @@ class MetaDriveWorld(World):
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 1
+      time_check_threshold = 10
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -110,6 +110,8 @@ class MetaDriveWorld(World):
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:
+        if after_engaged_check:
+          assert False
         if after_engaged_check and self.distance_moved == 0:
           self.status_q.put(QueueMessage(QueueMessageType.TERMINATION_INFO, {"vehicle_not_moving" : True}))
           self.exit_event.set()
@@ -117,7 +119,6 @@ class MetaDriveWorld(World):
         self.last_check_timestamp = current_time
         self.distance_moved = 0
         self.vehicle_last_pos = curr_pos
-        assert False
 
   def read_cameras(self):
     pass

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -105,7 +105,7 @@ class MetaDriveWorld(World):
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 30
+      time_check_threshold = 1
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -70,6 +70,8 @@ class MetaDriveWorld(World):
       self.vc[0] = 0
       self.vc[1] = 0
 
+    self.vc[0] = 0
+    self.vc[1] = 0
     self.controls_send.send([*self.vc, self.should_reset])
     self.should_reset = False
 
@@ -101,12 +103,12 @@ class MetaDriveWorld(World):
 
       x_dist = abs(curr_pos[0] - self.vehicle_last_pos[0])
       y_dist = abs(curr_pos[1] - self.vehicle_last_pos[1])
-      print(curr_pos)
+      print(curr_pos, time.monotonic())
       dist_threshold = 1
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 10
+      time_check_threshold = 30
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -102,11 +102,11 @@ class MetaDriveWorld(World):
       x_dist = abs(curr_pos[0] - self.vehicle_last_pos[0])
       y_dist = abs(curr_pos[1] - self.vehicle_last_pos[1])
       print(curr_pos, time.monotonic())
-      dist_threshold = 1
+      dist_threshold = 0.5
       if x_dist >= dist_threshold or y_dist >= dist_threshold: # position not the same during staying still, > threshold is considered moving
         self.distance_moved += x_dist + y_dist
 
-      time_check_threshold = 12
+      time_check_threshold = 7
       current_time = time.monotonic()
       since_last_check = current_time - self.last_check_timestamp
       if since_last_check >= time_check_threshold:

--- a/tools/sim/tests/test_metadrive_bridge.py
+++ b/tools/sim/tests/test_metadrive_bridge.py
@@ -12,7 +12,7 @@ from openpilot.tools.sim.tests.test_sim_bridge import TestSimBridgeBase
 class TestMetaDriveBridge(TestSimBridgeBase):
   @pytest.fixture(autouse=True)
   def setup_create_bridge(self):
-    self.test_duration = 60
+    self.test_duration = 15
 
   def create_bridge(self):
     return MetaDriveBridge(False, False, self.test_duration, True)

--- a/tools/sim/tests/test_metadrive_bridge.py
+++ b/tools/sim/tests/test_metadrive_bridge.py
@@ -12,7 +12,7 @@ from openpilot.tools.sim.tests.test_sim_bridge import TestSimBridgeBase
 class TestMetaDriveBridge(TestSimBridgeBase):
   @pytest.fixture(autouse=True)
   def setup_create_bridge(self):
-    self.test_duration = 24
+    self.test_duration = 20
 
   def create_bridge(self):
     return MetaDriveBridge(False, False, self.test_duration, True)

--- a/tools/sim/tests/test_metadrive_bridge.py
+++ b/tools/sim/tests/test_metadrive_bridge.py
@@ -11,11 +11,8 @@ from openpilot.tools.sim.tests.test_sim_bridge import TestSimBridgeBase
 @pytest.mark.filterwarnings("ignore::pyopencl.CompilerWarning") # Unimportant warning of non-empty compile log
 class TestMetaDriveBridge(TestSimBridgeBase):
   @pytest.fixture(autouse=True)
-  def setup_create_bridge(self, test_duration):
-    # run bridge test for at least 60s, since not-moving check runs every 30s
-    if test_duration < 60:
-      test_duration = 60
-    self.test_duration = test_duration
+  def setup_create_bridge(self):
+    self.test_duration = 20
 
   def create_bridge(self):
     return MetaDriveBridge(False, False, self.test_duration, True)

--- a/tools/sim/tests/test_metadrive_bridge.py
+++ b/tools/sim/tests/test_metadrive_bridge.py
@@ -13,6 +13,7 @@ class TestMetaDriveBridge(TestSimBridgeBase):
   @pytest.fixture(autouse=True)
   def setup_create_bridge(self):
     self.test_duration = 15
+    self.minimal_distance = 10
 
   def create_bridge(self):
-    return MetaDriveBridge(False, False, self.test_duration, True)
+    return MetaDriveBridge(False, False, self.test_duration, self.minimal_distance, True)

--- a/tools/sim/tests/test_metadrive_bridge.py
+++ b/tools/sim/tests/test_metadrive_bridge.py
@@ -12,7 +12,7 @@ from openpilot.tools.sim.tests.test_sim_bridge import TestSimBridgeBase
 class TestMetaDriveBridge(TestSimBridgeBase):
   @pytest.fixture(autouse=True)
   def setup_create_bridge(self):
-    self.test_duration = 60
+    self.test_duration = 24
 
   def create_bridge(self):
     return MetaDriveBridge(False, False, self.test_duration, True)

--- a/tools/sim/tests/test_metadrive_bridge.py
+++ b/tools/sim/tests/test_metadrive_bridge.py
@@ -12,7 +12,7 @@ from openpilot.tools.sim.tests.test_sim_bridge import TestSimBridgeBase
 class TestMetaDriveBridge(TestSimBridgeBase):
   @pytest.fixture(autouse=True)
   def setup_create_bridge(self):
-    self.test_duration = 20
+    self.test_duration = 60
 
   def create_bridge(self):
     return MetaDriveBridge(False, False, self.test_duration, True)

--- a/tools/sim/tests/test_sim_bridge.py
+++ b/tools/sim/tests/test_sim_bridge.py
@@ -87,3 +87,9 @@ class TestSimBridgeBase:
     print("Test shutting down. CommIssues are acceptable")
     for p in reversed(self.processes):
       p.terminate()
+
+    for p in reversed(self.processes):
+      if isinstance(p, subprocess.Popen):
+        p.wait(15)
+      else:
+        p.join(15)

--- a/tools/sim/tests/test_sim_bridge.py
+++ b/tools/sim/tests/test_sim_bridge.py
@@ -87,9 +87,3 @@ class TestSimBridgeBase:
     print("Test shutting down. CommIssues are acceptable")
     for p in reversed(self.processes):
       p.terminate()
-
-    for p in reversed(self.processes):
-      if isinstance(p, subprocess.Popen):
-        p.wait(1)
-      else:
-        p.join(1)

--- a/tools/sim/tests/test_sim_bridge.py
+++ b/tools/sim/tests/test_sim_bridge.py
@@ -90,6 +90,6 @@ class TestSimBridgeBase:
 
     for p in reversed(self.processes):
       if isinstance(p, subprocess.Popen):
-        p.wait(15)
+        p.wait(1)
       else:
-        p.join(15)
+        p.join(1)

--- a/tools/sim/tests/test_sim_bridge.py
+++ b/tools/sim/tests/test_sim_bridge.py
@@ -87,9 +87,3 @@ class TestSimBridgeBase:
     print("Test shutting down. CommIssues are acceptable")
     for p in reversed(self.processes):
       p.terminate()
-
-    for p in reversed(self.processes):
-      if isinstance(p, subprocess.Popen):
-        p.wait(15)
-      else:
-        p.join(15)


### PR DESCRIPTION
Currently, the test drives on barely 10 meters. We can do slightly better (13 meters) but in 30 seconds on a namespace runner