### PR TITLE
camerad: fix CAM_SYNC requests

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -37,6 +37,24 @@ int do_cam_control(int fd, int op_code, void *handle, int size) {
   return ret;
 }
 
+int do_sync_control(int fd, uint32_t id, void *handle, int size) {
+  struct cam_private_ioctl_arg arg = {0};
+  arg.id = id;
+  arg.size = size;
+  arg.ioctl_ptr = (uint64_t)handle;
+
+  int ret = HANDLE_EINTR(ioctl(fd, CAM_PRIVATE_IOCTL_CMD, &arg));
+  if (ret < 0) {
+    LOGE("CAM_SYNC error: id %u - errno %d - ret %d", id, errno, ret);
+    return ret;
+  }
+  if (arg.result < 0) {
+    LOGE("CAM_SYNC error: id %u - errno %d - ret %d", id, errno, ret);
+    return arg.result;
+  }
+  return ret;
+}
+
 std::optional<int32_t> device_acquire(int fd, int32_t session_handle, void *data, uint32_t num_resources) {
   struct cam_acquire_dev_cmd cmd = {
     .session_handle = session_handle,
@@ -558,7 +576,7 @@ void SpectraCamera::enqueue_buffer(int i, bool dp) {
     struct cam_sync_wait sync_wait = {0};
     sync_wait.sync_obj = sync_objs[i];
     sync_wait.timeout_ms = 50; // max dt tolerance, typical should be 23
-    ret = do_cam_control(m->cam_sync_fd, CAM_SYNC_WAIT, &sync_wait, sizeof(sync_wait));
+    ret = do_sync_control(m->cam_sync_fd, CAM_SYNC_WAIT, &sync_wait, sizeof(sync_wait));
     if (ret != 0) {
       LOGE("failed to wait for sync: %d %d", ret, sync_wait.sync_obj);
       // TODO: handle frame drop cleanly
@@ -570,7 +588,7 @@ void SpectraCamera::enqueue_buffer(int i, bool dp) {
     // destroy old output fence
     struct cam_sync_info sync_destroy = {0};
     sync_destroy.sync_obj = sync_objs[i];
-    ret = do_cam_control(m->cam_sync_fd, CAM_SYNC_DESTROY, &sync_destroy, sizeof(sync_destroy));
+    ret = do_sync_control(m->cam_sync_fd, CAM_SYNC_DESTROY, &sync_destroy, sizeof(sync_destroy));
     if (ret != 0) {
       LOGE("failed to destroy sync object: %d %d", ret, sync_destroy.sync_obj);
     }
@@ -579,7 +597,7 @@ void SpectraCamera::enqueue_buffer(int i, bool dp) {
   // create output fence
   struct cam_sync_info sync_create = {0};
   strcpy(sync_create.name, "NodeOutputPortFence");
-  ret = do_cam_control(m->cam_sync_fd, CAM_SYNC_CREATE, &sync_create, sizeof(sync_create));
+  ret = do_sync_control(m->cam_sync_fd, CAM_SYNC_CREATE, &sync_create, sizeof(sync_create));
   if (ret != 0) {
     LOGE("failed to create fence: %d %d", ret, sync_create.sync_obj);
   }

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -37,20 +37,22 @@ int do_cam_control(int fd, int op_code, void *handle, int size) {
   return ret;
 }
 
-int do_sync_control(int fd, uint32_t id, void *handle, int size) {
-  struct cam_private_ioctl_arg arg = {0};
-  arg.id = id;
-  arg.size = size;
-  arg.ioctl_ptr = (uint64_t)handle;
-
+int do_sync_control(int fd, uint32_t id, void *handle, uint32_t size) {
+  struct cam_private_ioctl_arg arg = {
+    .id = id,
+    .size = size,
+    .ioctl_ptr = (uint64_t)handle,
+  };
   int ret = HANDLE_EINTR(ioctl(fd, CAM_PRIVATE_IOCTL_CMD, &arg));
+
+  int32_t ioctl_result = (int32_t)arg.result;
   if (ret < 0) {
-    LOGE("CAM_SYNC error: id %u - errno %d - ret %d", id, errno, ret);
+    LOGE("CAM_SYNC error: id %u - errno %d - ret %d - ioctl_result %d", id, errno, ret, ioctl_result);
     return ret;
   }
-  if (arg.result < 0) {
-    LOGE("CAM_SYNC error: id %u - errno %d - ret %d", id, errno, ret);
-    return arg.result;
+  if (ioctl_result < 0) {
+    LOGE("CAM_SYNC error: id %u - errno %d - ret %d - ioctl_result %d", id, errno, ret, ioctl_result);
+    return ioctl_result;
   }
   return ret;
 }


### PR DESCRIPTION
The `camcontrol` struct happens to match enough that it worked to submit the request, but the result checking wasn't right.

Noticed while working on the debayer that camerad didn't care about this:
```
[26657.326035] CAM_ERR: CAM-ICP: cam_icp_mgr_process_msg_frame_process: 1525 failed with error : 4
[26657.351821] CAM_ERR: CAM-SYNC: cam_sync_wait: 393 Error: timed out for sync obj = 2
[26657.351851] CAM_WARN: CAM-SYNC: cam_sync_deinit_object: 183 Destroying an active sync object name:NodeOutputPortFence id:2
[26657.375468] CAM_ERR: CAM-ICP: cam_icp_mgr_process_msg_frame_process: 1525 failed with error : 4
[26657.401846] CAM_ERR: CAM-SYNC: cam_sync_wait: 393 Error: timed out for sync obj = 4
[26657.401870] CAM_WARN: CAM-SYNC: cam_sync_deinit_object: 183 Destroying an active sync object name:NodeOutputPortFence id:4
[26657.425543] CAM_ERR: CAM-ICP: cam_icp_mgr_process_msg_frame_process: 1525 failed with error : 4
[26657.451824] CAM_ERR: CAM-SYNC: cam_sync_wait: 393 Error: timed out for sync obj = 6
[26657.451848] CAM_WARN: CAM-SYNC: cam_sync_deinit_object: 183 Destroying an active sync object name:NodeOutputPortFence id:6
[26657.475506] CAM_ERR: CAM-ICP: cam_icp_mgr_process_msg_frame_process: 1525 failed with error : 4
[26657.501847] CAM_ERR: CAM-SYNC: cam_sync_wait: 393 Error: timed out for sync obj = 8
[26657.501870] CAM_WARN: CAM-SYNC: cam_sync_deinit_object: 183 Destroying an active sync object name:NodeOutputPortFence id:8
[26657.525448] CAM_ERR: CAM-ICP: cam_icp_mgr_process_msg_frame_process: 1525 failed with error : 4
[26657.551832] CAM_ERR: CAM-SYNC: cam_sync_wait: 393 Error: timed out for sync obj = 2
[26657.551866] CAM_WARN: CAM-SYNC: cam_sync_deinit_object: 183 Destroying an active sync object name:NodeOutputPortFence id:2
[26657.575471] CAM_ERR: CAM-ICP: cam_icp_mgr_process_msg_frame_process: 1525 failed with error : 4
[26657.601852] CAM_ERR: CAM-SYNC: cam_sync_wait: 393 Error: timed out for sync obj = 4
[26657.601879] CAM_WARN: CAM-SYNC: cam_sync_deinit_object: 183 Destroying an active sync object name:NodeOutputPortFence id:4
[26657.625458] CAM_ERR: CAM-ICP: cam_icp_mgr_process_msg_frame_process: 1525 failed with error : 4
[26657.651830] CAM_ERR: CAM-SYNC: cam_sync_wait: 393 Error: timed out for sync obj = 6
```