### PR TITLE
selfdrived: remove redundant sound card check

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -80,7 +80,6 @@ struct OnroadEvent @0xc4fa6047f024e718 {
     commIssueAvgFreq @44;
     tooDistracted @45;
     posenetInvalid @46;
-    soundsUnavailable @47;
     preLaneChangeLeft @48;
     preLaneChangeRight @49;
     laneChange @50;
@@ -126,6 +125,8 @@ struct OnroadEvent @0xc4fa6047f024e718 {
     espActive @90;
     personalityChanged @91;
     aeb @92;
+
+    soundsUnavailableDEPRECATED @47;
   }
 }
 

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -724,11 +724,6 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
       Priority.LOWER, VisualAlert.none, AudibleAlert.none, .2, creation_delay=600.)
   },
 
-  EventName.soundsUnavailable: {
-    ET.PERMANENT: NormalPermanentAlert("Speaker not found", "Reboot your Device"),
-    ET.NO_ENTRY: NoEntryAlert("Speaker not found"),
-  },
-
   EventName.tooDistracted: {
     ET.NO_ENTRY: NoEntryAlert("Distraction Level Too High"),
   },

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -21,7 +21,6 @@ from openpilot.selfdrive.selfdrived.state import StateMachine
 from openpilot.selfdrive.selfdrived.alertmanager import AlertManager, set_offroad_alert
 from openpilot.selfdrive.controls.lib.latcontrol import MIN_LATERAL_CONTROL_SPEED
 
-from openpilot.system.hardware import HARDWARE
 from openpilot.system.version import get_build_metadata
 
 REPLAY = "REPLAY" in os.environ
@@ -88,9 +87,6 @@ class SelfdriveD:
     self.is_metric = self.params.get_bool("IsMetric")
     self.is_ldw_enabled = self.params.get_bool("IsLdwEnabled")
 
-    # detect sound card presence and ensure successful init
-    sounds_available = HARDWARE.get_sound_card_online()
-
     car_recognized = self.CP.carName != 'mock'
 
     # cleanup old params
@@ -129,8 +125,6 @@ class SelfdriveD:
     elif self.CP.secOcRequired and not self.CP.secOcKeyAvailable:
       self.startup_event = EventName.startupNoSecOcKey
 
-    if not sounds_available:
-      self.events.add(EventName.soundsUnavailable, static=True)
     if not car_recognized:
       self.events.add(EventName.carUnrecognized, static=True)
       set_offroad_alert("Offroad_CarUnrecognized", True)

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -42,10 +42,6 @@ class HardwareBase(ABC):
     pass
 
   @abstractmethod
-  def get_sound_card_online(self):
-    pass
-
-  @abstractmethod
   def get_imei(self, slot) -> str:
     pass
 

--- a/system/hardware/pc/hardware.py
+++ b/system/hardware/pc/hardware.py
@@ -14,9 +14,6 @@ class Pc(HardwareBase):
   def get_device_type(self):
     return "pc"
 
-  def get_sound_card_online(self):
-    return True
-
   def reboot(self, reason=None):
     print("REBOOT!")
 

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -123,12 +123,6 @@ class Tici(HardwareBase):
   def get_device_type(self):
     return get_device_type()
 
-  def get_sound_card_online(self):
-    if os.path.isfile('/proc/asound/card0/state'):
-      with open('/proc/asound/card0/state') as f:
-        return f.read().strip() == 'ONLINE'
-    return False
-
   def reboot(self, reason=None):
     subprocess.check_output(["sudo", "reboot"])
 


### PR DESCRIPTION
Now redundant with `soundd` and `micd` aliveness checks