### PR TITLE
tools: fix setup for directories with spaces

### DIFF
--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -5,8 +5,8 @@ set -e
 export PIP_DEFAULT_TIMEOUT=200
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-ROOT=$DIR/../
-cd $ROOT
+ROOT="$DIR"/../
+cd "$ROOT"
 
 # updating uv on macOS results in 403 sometimes
 function update_uv() {
@@ -24,9 +24,9 @@ function update_uv() {
 if ! command -v "uv" > /dev/null 2>&1; then
   echo "installing uv..."
   curl -LsSf https://astral.sh/uv/install.sh | sh
-  UV_BIN='$HOME/.cargo/env'
+  UV_BIN="$HOME/.cargo/env"
   ADD_PATH_CMD=". \"$UV_BIN\""
-  eval $ADD_PATH_CMD
+  eval "$ADD_PATH_CMD"
 fi
 
 echo "updating uv..."
@@ -36,9 +36,9 @@ echo "installing python packages..."
 uv sync --frozen --all-extras
 source .venv/bin/activate
 
-echo "PYTHONPATH=${PWD}" > $ROOT/.env
+echo "PYTHONPATH=${PWD}" > "$ROOT"/.env
 if [[ "$(uname)" == 'Darwin' ]]; then
-  echo "# msgq doesn't work on mac" >> $ROOT/.env
-  echo "export ZMQ=1" >> $ROOT/.env
-  echo "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES" >> $ROOT/.env
+  echo "# msgq doesn't work on mac" >> "$ROOT"/.env
+  echo "export ZMQ=1" >> "$ROOT"/.env
+  echo "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES" >> "$ROOT"/.env
 fi

--- a/tools/ubuntu_setup.sh
+++ b/tools/ubuntu_setup.sh
@@ -6,5 +6,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # NOTE: this is used in a docker build, so do not run any scripts here.
 
-$DIR/install_ubuntu_dependencies.sh
-$DIR/install_python_dependencies.sh
+"$DIR"/install_ubuntu_dependencies.sh
+"$DIR"/install_python_dependencies.sh


### PR DESCRIPTION
Now handles $DIR with spaces. Also fixes UV_BIN variable.

**Description**

Ubuntu setup script failed when running in a directory whose parent has spaces. This PR fixes the problem.

**Verification**

Script tested in a clean Ubuntu 24.04 install.


