### PR TITLE
AGNOS 11

### DIFF
--- a/launch_env.sh
+++ b/launch_env.sh
@@ -7,7 +7,7 @@ export OPENBLAS_NUM_THREADS=1
 export VECLIB_MAXIMUM_THREADS=1
 
 if [ -z "$AGNOS_VERSION" ]; then
-  export AGNOS_VERSION="10.1"
+  export AGNOS_VERSION="11"
 fi
 
 export STAGING_ROOT="/data/safe_staging"

--- a/system/hardware/tici/agnos.json
+++ b/system/hardware/tici/agnos.json
@@ -1,22 +1,22 @@
 [
   {
     "name": "boot",
-    "url": "https://commadist.azureedge.net/agnosupdate/boot-5674ea6767e7198cf1e7def3de66a57061f001ed76d43dc4b4f84de545c53c6f.img.xz",
-    "hash": "5674ea6767e7198cf1e7def3de66a57061f001ed76d43dc4b4f84de545c53c6f",
-    "hash_raw": "5674ea6767e7198cf1e7def3de66a57061f001ed76d43dc4b4f84de545c53c6f",
+    "url": "https://commadist.azureedge.net/agnosupdate-staging/boot-68227215e67079b85b85632b113d5de1c50ca7c92d63a77eea00e5c72ebb753f.img.xz",
+    "hash": "68227215e67079b85b85632b113d5de1c50ca7c92d63a77eea00e5c72ebb753f",
+    "hash_raw": "68227215e67079b85b85632b113d5de1c50ca7c92d63a77eea00e5c72ebb753f",
     "size": 16029696,
     "sparse": false,
     "full_check": true,
     "has_ab": true
   },
   {
-    "name": "abl",
-    "url": "https://commadist.azureedge.net/agnosupdate/abl-eeb89a74c968a5a2ffce96f23158b72e03e2814adf72ef59d1200ba8ea5d2f39.img.xz",
-    "hash": "eeb89a74c968a5a2ffce96f23158b72e03e2814adf72ef59d1200ba8ea5d2f39",
-    "hash_raw": "eeb89a74c968a5a2ffce96f23158b72e03e2814adf72ef59d1200ba8ea5d2f39",
-    "size": 274432,
+    "name": "system",
+    "url": "https://commadist.azureedge.net/agnosupdate-staging/system-d1d51bfb7e2cb46be31220184cde832d7ef3628e79993cc0768b082ebaed6f24.img.xz",
+    "hash": "d1d51bfb7e2cb46be31220184cde832d7ef3628e79993cc0768b082ebaed6f24",
+    "hash_raw": "d1d51bfb7e2cb46be31220184cde832d7ef3628e79993cc0768b082ebaed6f24",
+    "size": 4194304000,
     "sparse": false,
-    "full_check": true,
+    "full_check": false,
     "has_ab": true
   },
   {
@@ -25,6 +25,16 @@
     "hash": "bcef195b00a1ab685da601f4072722569773ab161e91c8753ad99ca4217a28f5",
     "hash_raw": "bcef195b00a1ab685da601f4072722569773ab161e91c8753ad99ca4217a28f5",
     "size": 3282672,
+    "sparse": false,
+    "full_check": true,
+    "has_ab": true
+  },
+  {
+    "name": "abl",
+    "url": "https://commadist.azureedge.net/agnosupdate/abl-6ce46c75c6270e4cb2f98998b4415177d46d0197e1348dea7d510534b206179b.img.xz",
+    "hash": "6ce46c75c6270e4cb2f98998b4415177d46d0197e1348dea7d510534b206179b",
+    "hash_raw": "6ce46c75c6270e4cb2f98998b4415177d46d0197e1348dea7d510534b206179b",
+    "size": 274432,
     "sparse": false,
     "full_check": true,
     "has_ab": true
@@ -58,20 +68,5 @@
     "sparse": false,
     "full_check": true,
     "has_ab": true
-  },
-  {
-    "name": "system",
-    "url": "https://commadist.azureedge.net/agnosupdate/system-1badfe72851628d6cf9200a53a6151bb4e797b49c717141409fc57138eae388a.img.xz",
-    "hash": "328e90c62068222dfd98f71dd3f6251fcb962f082b49c6be66ab2699f5db6f4f",
-    "hash_raw": "1badfe72851628d6cf9200a53a6151bb4e797b49c717141409fc57138eae388a",
-    "size": 10737418240,
-    "sparse": true,
-    "full_check": false,
-    "has_ab": true,
-    "alt": {
-      "hash": "bc11d2148f29862ee1326aca2af1cf6bbf5fed831e3f8f6b8f7a0f110dfe8d26",
-      "url": "https://commadist.azureedge.net/agnosupdate/system-skip-chunks-1badfe72851628d6cf9200a53a6151bb4e797b49c717141409fc57138eae388a.img.xz",
-      "size": 4548070000
-    }
   }
 ]

--- a/system/hardware/tici/agnos.json
+++ b/system/hardware/tici/agnos.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "boot",
-    "url": "https://commadist.azureedge.net/agnosupdate-staging/boot-68227215e67079b85b85632b113d5de1c50ca7c92d63a77eea00e5c72ebb753f.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate/boot-68227215e67079b85b85632b113d5de1c50ca7c92d63a77eea00e5c72ebb753f.img.xz",
     "hash": "68227215e67079b85b85632b113d5de1c50ca7c92d63a77eea00e5c72ebb753f",
     "hash_raw": "68227215e67079b85b85632b113d5de1c50ca7c92d63a77eea00e5c72ebb753f",
     "size": 16029696,
@@ -11,7 +11,7 @@
   },
   {
     "name": "system",
-    "url": "https://commadist.azureedge.net/agnosupdate-staging/system-d1d51bfb7e2cb46be31220184cde832d7ef3628e79993cc0768b082ebaed6f24.img.xz",
+    "url": "https://commadist.azureedge.net/agnosupdate/system-d1d51bfb7e2cb46be31220184cde832d7ef3628e79993cc0768b082ebaed6f24.img.xz",
     "hash": "d1d51bfb7e2cb46be31220184cde832d7ef3628e79993cc0768b082ebaed6f24",
     "hash_raw": "d1d51bfb7e2cb46be31220184cde832d7ef3628e79993cc0768b082ebaed6f24",
     "size": 4194304000,


### PR DESCRIPTION
https://github.com/commaai/agnos-builder/issues/321
* Ubuntu 20.04 -> 24.04
* kernel support for ISP debayering
* 3s shaved off boot time
* misc package updates

---

## Release Checklist

- [x] [`test_onroad`](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_onroad.py) passes
- [x] Wi-Fi: lists networks and connects
- [x] Modem: connects to cell network
- [x] Image sizes haven't increased
- [x] Sounds work
- [x] `python` is our python, not system version
- [x] Clean openpilot build: `scons -c && scons -j8`
- [ ] Factory reset
  - [ ] from openpilot menu
  - [ ] tapping on boot
  - [ ] corrupt userdata
- [ ] Color calibration
  - [x] from /persist/comma/
  - [ ] directly from panel over sysfs
- [ ] Clean setup: factory reset -> install openpilot -> openpilot works
- [ ] AGNOS update works on warm boot
  - [ ] previous -> new
  - [ ] new -> previous
- [ ] comma three: NVMe works

### ABL

- [ ] Fastboot USB enumeration
- [ ] Boot time hasn't regressed (3.8s)

### XBL

- [ ] Display init works in cold and hot temperatures
- [ ] Boot time hasn't regressed (2.4s)

### Setup

#### Networking

- [ ] Continue button disabled when no connection
- [ ] Forget/connect to wifi

#### Custom URL
- (a) Not a real URL (e.g. `comma`, `abc123`, `...`)
  - [ ] "Ensure the entered URL is valid"
  - [ ] Start over
  - [ ] Reboot device
- (b) Website but not an installer URL (e.g. `github.com`, `comma.ai`, `installer.comma.ai`)
  - [ ] "No custom software found at this URL."
- (c) Valid installer URL (e.g. `openpilot.comma.ai`)
  - [ ] Download successful (comma logo or installer appears)
  - [ ] `/tmp/installer_url` should contain the installer URL