### PR TITLE
cabana: fix README example for streaming CAN messages from device

### DIFF
--- a/tools/cabana/README.md
+++ b/tools/cabana/README.md
@@ -68,7 +68,7 @@ cd /data/openpilot/cereal/messaging/
 Then Run Cabana with the device's IP address:
 
 ```shell
-cabana --stream <ipaddress>
+cabana --stream --zmq <ipaddress>
 ```
 
 Replace &lt;ipaddress&gt; with your comma device's IP address.


### PR DESCRIPTION
Fixes an issue in the README where the example for streaming messages from a device was missing the --zmq flag, which is necessary for correct operation.