### PR TITLE
cabana: SG_ parse allow no space before colon

### DIFF
--- a/tools/cabana/dbc/dbcfile.cc
+++ b/tools/cabana/dbc/dbcfile.cc
@@ -145,7 +145,7 @@ void DBCFile::parseCM_BO(const QString &line, const QString &content, const QStr
 }
 
 void DBCFile::parseSG(const QString &line, cabana::Msg *current_msg, int &multiplexor_cnt) {
-  static QRegularExpression sg_regexp(R"(^SG_ (\w+) : (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*))");
+  static QRegularExpression sg_regexp(R"(^SG_ (\w+) *: (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*))");
   static QRegularExpression sgm_regexp(R"(^SG_ (\w+) (\w+) *: (\d+)\|(\d+)@(\d+)([\+|\-]) \(([0-9.+\-eE]+),([0-9.+\-eE]+)\) \[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] \"(.*)\" (.*))");
 
   if (!current_msg)


### PR DESCRIPTION
DBC signal definitions sometimes don't have a space before the colon, I don't see anything in the spec that says it is required, and we already allow this for multiplexed signals.

Example DBC that cannot be parsed currently:
https://raw.githubusercontent.com/onyx-m2/onyx-m2-dbc/master/tesla_model3.dbc