### PR TITLE
ui: show tethering status in sidebar

### DIFF
--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -448,6 +448,7 @@ void WifiManager::tetheringActivated(QDBusPendingCallWatcher *call) {
     });
   }
   call->deleteLater();
+  tethering_on = true;
 }
 
 void WifiManager::setTetheringEnabled(bool enabled) {
@@ -465,6 +466,7 @@ void WifiManager::setTetheringEnabled(bool enabled) {
 
   } else {
     deactivateConnectionBySsid(tethering_ssid);
+    tethering_on = false;
   }
 }
 

--- a/selfdrive/ui/qt/network/wifi_manager.h
+++ b/selfdrive/ui/qt/network/wifi_manager.h
@@ -42,6 +42,7 @@ public:
   QMap<QString, Network> seenNetworks;
   QMap<QDBusObjectPath, QString> knownConnections;
   QString ipv4_address;
+  bool tethering_on = false;
   bool ipv4_forward = false;
 
   explicit WifiManager(QObject* parent);

--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -74,9 +74,11 @@ void Sidebar::updateState(const UIState &s) {
 
   auto &sm = *(s.sm);
 
+  networking = networking ? networking : window()->findChild<Networking *>("");
+  bool tethering_on = networking && networking->wifi->tethering_on;
   auto deviceState = sm["deviceState"].getDeviceState();
-  setProperty("netType", network_type[deviceState.getNetworkType()]);
-  int strength = (int)deviceState.getNetworkStrength();
+  setProperty("netType", tethering_on ? "Hotspot": network_type[deviceState.getNetworkType()]);
+  int strength = tethering_on ? 4 : (int)deviceState.getNetworkStrength();
   setProperty("netStrength", strength > 0 ? strength + 1 : 0);
 
   ItemStatus connectStatus;
@@ -131,8 +133,8 @@ void Sidebar::paintEvent(QPaintEvent *event) {
 
   p.setFont(InterFont(35));
   p.setPen(QColor(0xff, 0xff, 0xff));
-  const QRect r = QRect(50, 247, 100, 50);
-  p.drawText(r, Qt::AlignCenter, net_type);
+  const QRect r = QRect(58, 247, width() - 100, 50);
+  p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter, net_type);
 
   // metrics
   drawMetric(p, temp_status.first, temp_status.second, 338);

--- a/selfdrive/ui/qt/sidebar.h
+++ b/selfdrive/ui/qt/sidebar.h
@@ -6,6 +6,7 @@
 #include <QMap>
 
 #include "selfdrive/ui/ui.h"
+#include "selfdrive/ui/qt/network/networking.h"
 
 typedef QPair<QPair<QString, QString>, QColor> ItemStatus;
 Q_DECLARE_METATYPE(ItemStatus);
@@ -59,4 +60,5 @@ protected:
 
 private:
   std::unique_ptr<PubMaster> pm;
+  Networking *networking = nullptr;
 };


### PR DESCRIPTION
Displays "Hotspot" and full signal strength in the sidebar when tethering is enabled.

![Screenshot from 2024-10-15 01-07-02](https://github.com/user-attachments/assets/4d831fc6-a850-4095-8fdc-352b9f7934aa)

To avoid using a long signal-slot chain from WifiManager to the Sidebar for tethering notifications, a cached `Networking *networking` instance is used in the sidebar class.
Additionally, the previous width of 100px for displaying the network type was insufficient for "Hotspot," so it has been increased to 200px (width() - 100), and left-aligned with the signal strength display. This slightly changes the layout, but the new alignment is more logical. For example, the "Wi-Fi" text previously extended 8 pixels past the left edge of the signal strength, causing misalignment. Now, the alignment is cleaner.

resolve: https://github.com/commaai/openpilot/issues/33428