### PR TITLE
ui: always check for longitudinal control

### DIFF
--- a/selfdrive/ui/qt/onroad/model.cc
+++ b/selfdrive/ui/qt/onroad/model.cc
@@ -15,10 +15,6 @@ static int get_path_length_idx(const cereal::XYZTData::Reader &line, const float
 
 void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
   auto &sm = *(uiState()->sm);
-  if (sm.updated("carParams")) {
-    longitudinal_control = sm["carParams"].getCarParams().getOpenpilotLongitudinalControl();
-  }
-
   // Check if data is up-to-date
   if (!(sm.alive("liveCalibration") && sm.alive("modelV2"))) {
     return;
@@ -26,6 +22,7 @@ void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
 
   clip_region = surface_rect.adjusted(-CLIP_MARGIN, -CLIP_MARGIN, CLIP_MARGIN, CLIP_MARGIN);
   experimental_mode = sm["selfdriveState"].getSelfdriveState().getExperimentalMode();
+  longitudinal_control = sm["carParams"].getCarParams().getOpenpilotLongitudinalControl();
 
   painter.save();
 


### PR DESCRIPTION
Potential regression from https://github.com/commaai/openpilot/pull/33702, now it's possible to not show radar leads in the ui for the first minute on first onroad transition after power up.

@deanlee let me know if you want to solve this any other way, but I'm going to merge to fix the regression now.