### PR TITLE
ui: bypass 'alive' check if REPLAY environment variable is set

### DIFF
--- a/selfdrive/ui/qt/onroad/hud.cc
+++ b/selfdrive/ui/qt/onroad/hud.cc
@@ -13,7 +13,7 @@ void HudRenderer::updateState(const UIState &s) {
   status = s.status;
 
   const SubMaster &sm = *(s.sm);
-  if (!sm.alive("carState")) {
+  if (Hardware::TICI() && !sm.alive("carState")) {
     is_cruise_set = false;
     set_speed = SET_SPEED_NA;
     speed = 0.0;

--- a/selfdrive/ui/qt/onroad/hud.cc
+++ b/selfdrive/ui/qt/onroad/hud.cc
@@ -13,7 +13,7 @@ void HudRenderer::updateState(const UIState &s) {
   status = s.status;
 
   const SubMaster &sm = *(s.sm);
-  if (Hardware::TICI() && !sm.alive("carState")) {
+  if (!REPLAY && !sm.alive("carState")) {
     is_cruise_set = false;
     set_speed = SET_SPEED_NA;
     speed = 0.0;

--- a/selfdrive/ui/qt/onroad/model.cc
+++ b/selfdrive/ui/qt/onroad/model.cc
@@ -16,7 +16,7 @@ static int get_path_length_idx(const cereal::XYZTData::Reader &line, const float
 void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
   auto &sm = *(uiState()->sm);
   // Check if data is up-to-date
-  if (Hardware::TICI() && !(sm.alive("liveCalibration") && sm.alive("modelV2"))) {
+  if (!REPLAY && !(sm.alive("liveCalibration") && sm.alive("modelV2"))) {
     return;
   }
 

--- a/selfdrive/ui/qt/onroad/model.cc
+++ b/selfdrive/ui/qt/onroad/model.cc
@@ -16,7 +16,7 @@ static int get_path_length_idx(const cereal::XYZTData::Reader &line, const float
 void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
   auto &sm = *(uiState()->sm);
   // Check if data is up-to-date
-  if (!(sm.alive("liveCalibration") && sm.alive("modelV2"))) {
+  if (Hardware::TICI() && !(sm.alive("liveCalibration") && sm.alive("modelV2"))) {
     return;
   }
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -21,6 +21,8 @@ const int UI_HEADER_HEIGHT = 420;
 const int UI_FREQ = 20; // Hz
 const int BACKLIGHT_OFFROAD = 50;
 
+const bool REPLAY = getenv("REPLAY") != nullptr;
+
 const Eigen::Matrix3f VIEW_FROM_DEVICE = (Eigen::Matrix3f() <<
   0.0, 1.0, 0.0,
   0.0, 0.0, 1.0,


### PR DESCRIPTION
This PR fixes the issue where the path disappears and the speed resets to 0 when the replay is paused. 