### PR TITLE
ui: revert the 'alive' check to compare with scene.started_frame

### DIFF
--- a/selfdrive/ui/qt/onroad/hud.cc
+++ b/selfdrive/ui/qt/onroad/hud.cc
@@ -13,7 +13,7 @@ void HudRenderer::updateState(const UIState &s) {
   status = s.status;
 
   const SubMaster &sm = *(s.sm);
-  if (!sm.alive("carState")) {
+  if (sm.rcv_frame("carState") < s.scene.started_frame) {
     is_cruise_set = false;
     set_speed = SET_SPEED_NA;
     speed = 0.0;

--- a/selfdrive/ui/qt/onroad/model.cc
+++ b/selfdrive/ui/qt/onroad/model.cc
@@ -14,9 +14,11 @@ static int get_path_length_idx(const cereal::XYZTData::Reader &line, const float
 }
 
 void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
-  auto &sm = *(uiState()->sm);
+  auto *s = uiState();
+  auto &sm = *(s->sm);
   // Check if data is up-to-date
-  if (!(sm.alive("liveCalibration") && sm.alive("modelV2"))) {
+  if (sm.rcv_frame("liveCalibration") < s->scene.started_frame ||
+      sm.rcv_frame("modelV2") < s->scene.started_frame) {
     return;
   }
 


### PR DESCRIPTION
This PR fixes the issue where the path disappears and the speed resets to 0 when the replay is paused.