### PR TITLE
cereal: improve  `new_message` by removing intermediate dictionary and simplifying service initialization

### DIFF
--- a/cereal/messaging/__init__.py
+++ b/cereal/messaging/__init__.py
@@ -28,17 +28,9 @@ def log_from_bytes(dat: bytes, struct: capnp.lib.capnp._StructModule = log.Event
 
 
 def new_message(service: Optional[str], size: Optional[int] = None, **kwargs) -> capnp.lib.capnp._DynamicStructBuilder:
-  args = {
-    'valid': False,
-    'logMonoTime': int(time.monotonic() * 1e9),
-    **kwargs
-  }
-  dat = log.Event.new_message(**args)
+  dat = log.Event.new_message(valid=False, logMonoTime=int(time.monotonic() * 1e9), **kwargs)
   if service is not None:
-    if size is None:
-      dat.init(service)
-    else:
-      dat.init(service, size)
+    dat.init(service, size)
   return dat
 
 


### PR DESCRIPTION
1. The `valid` and `logMonoTime` parameters are now passed directly to `log.Event.new_message(),` eliminating the use of an unnecessary intermediate dictionary. 
2. Simplified service initialization logic, leveraging pycapnp's built-in handling for size=None.  (https://github.com/capnproto/pycapnp/blob/master/capnp/lib/capnp.pyx#L1426)