### PR TITLE
ui/model: use height from LiveCalibration instead of hardcoded offset Z

### DIFF
--- a/selfdrive/ui/qt/onroad/model.cc
+++ b/selfdrive/ui/qt/onroad/model.cc
@@ -3,6 +3,7 @@
 constexpr int CLIP_MARGIN = 500;
 constexpr float MIN_DRAW_DISTANCE = 10.0;
 constexpr float MAX_DRAW_DISTANCE = 100.0;
+constexpr float PATH_OFFSET_Z = 1.22;
 
 static int get_path_length_idx(const cereal::XYZTData::Reader &line, const float path_height) {
   const auto &line_x = line.getX();
@@ -53,7 +54,7 @@ void ModelRenderer::update_leads(const cereal::RadarState::Reader &radar_state, 
     const auto &lead_data = (i == 0) ? radar_state.getLeadOne() : radar_state.getLeadTwo();
     if (lead_data.getStatus()) {
       float z = line.getZ()[get_path_length_idx(line, lead_data.getDRel())];
-      mapToScreen(lead_data.getDRel(), -lead_data.getYRel(), z + 1.22, &lead_vertices[i]);
+      mapToScreen(lead_data.getDRel(), -lead_data.getYRel(), z + PATH_OFFSET_Z, &lead_vertices[i]);
     }
   }
 }
@@ -85,7 +86,7 @@ void ModelRenderer::update_model(const cereal::ModelDataV2::Reader &model, const
     max_distance = std::clamp((float)(lead_d - fmin(lead_d * 0.35, 10.)), 0.0f, max_distance);
   }
   max_idx = get_path_length_idx(model_position, max_distance);
-  mapLineToPolygon(model_position, 0.9, 1.22, &track_vertices, max_idx, false);
+  mapLineToPolygon(model_position, 0.9, PATH_OFFSET_Z, &track_vertices, max_idx, false);
 }
 
 void ModelRenderer::drawLaneLines(QPainter &painter) {

--- a/selfdrive/ui/qt/onroad/model.cc
+++ b/selfdrive/ui/qt/onroad/model.cc
@@ -3,7 +3,6 @@
 constexpr int CLIP_MARGIN = 500;
 constexpr float MIN_DRAW_DISTANCE = 10.0;
 constexpr float MAX_DRAW_DISTANCE = 100.0;
-constexpr float PATH_OFFSET_Z = 1.22;
 
 static int get_path_length_idx(const cereal::XYZTData::Reader &line, const float path_height) {
   const auto &line_x = line.getX();
@@ -24,6 +23,7 @@ void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
   clip_region = surface_rect.adjusted(-CLIP_MARGIN, -CLIP_MARGIN, CLIP_MARGIN, CLIP_MARGIN);
   experimental_mode = sm["selfdriveState"].getSelfdriveState().getExperimentalMode();
   longitudinal_control = sm["carParams"].getCarParams().getOpenpilotLongitudinalControl();
+  path_offset_z = sm["liveCalibration"].getLiveCalibration().getHeight()[0];
 
   painter.save();
 
@@ -54,7 +54,7 @@ void ModelRenderer::update_leads(const cereal::RadarState::Reader &radar_state, 
     const auto &lead_data = (i == 0) ? radar_state.getLeadOne() : radar_state.getLeadTwo();
     if (lead_data.getStatus()) {
       float z = line.getZ()[get_path_length_idx(line, lead_data.getDRel())];
-      mapToScreen(lead_data.getDRel(), -lead_data.getYRel(), z + PATH_OFFSET_Z, &lead_vertices[i]);
+      mapToScreen(lead_data.getDRel(), -lead_data.getYRel(), z + path_offset_z, &lead_vertices[i]);
     }
   }
 }
@@ -86,7 +86,7 @@ void ModelRenderer::update_model(const cereal::ModelDataV2::Reader &model, const
     max_distance = std::clamp((float)(lead_d - fmin(lead_d * 0.35, 10.)), 0.0f, max_distance);
   }
   max_idx = get_path_length_idx(model_position, max_distance);
-  mapLineToPolygon(model_position, 0.9, PATH_OFFSET_Z, &track_vertices, max_idx, false);
+  mapLineToPolygon(model_position, 0.9, path_offset_z, &track_vertices, max_idx, false);
 }
 
 void ModelRenderer::drawLaneLines(QPainter &painter) {

--- a/selfdrive/ui/qt/onroad/model.h
+++ b/selfdrive/ui/qt/onroad/model.h
@@ -29,6 +29,7 @@ private:
   bool prev_allow_throttle = true;
   float lane_line_probs[4] = {};
   float road_edge_stds[2] = {};
+  float path_offset_z = 1.22f;
   QPolygonF track_vertices;
   QPolygonF lane_line_vertices[4] = {};
   QPolygonF road_edge_vertices[2] = {};


### PR DESCRIPTION
~Replaced hardcoded Z-offsets with `PATH_OFFSET_Z` to ensure consistent Z-offset usage for both the lead and path, improving visual clarity.~ updated. use height from LiveCalibration