### PR TITLE
WIP: remove QtDBus dependency, use pure C++ and libdbus

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -309,7 +309,8 @@ try:
 except SCons.Errors.UserError:
   qt_env.Tool('qt')
 
-qt_env['CPPPATH'] += qt_dirs + ["#third_party/qrcode"]
+#pkg-config --cflags --libs dbus-1
+qt_env['CPPPATH'] += qt_dirs + ["#third_party/qrcode", "/usr/include/dbus-1.0", "/usr/lib/x86_64-linux-gnu/dbus-1.0/include"]
 qt_flags = [
   "-D_REENTRANT",
   "-DQT_NO_DEBUG",

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -24,7 +24,7 @@ widgets_src = ["qt/widgets/input.cc", "qt/widgets/wifi.cc", "qt/prime_state.cc",
 
 widgets = qt_env.Library("qt_widgets", widgets_src, LIBS=base_libs)
 Export('widgets')
-qt_libs = [widgets, qt_util] + base_libs
+qt_libs = [widgets, qt_util, 'dbus-1'] + base_libs
 
 qt_src = ["main.cc", "ui.cc", "qt/sidebar.cc", "qt/body.cc",
           "qt/window.cc", "qt/home.cc", "qt/offroad/settings.cc",

--- a/selfdrive/ui/qt/network/networkmanager.h
+++ b/selfdrive/ui/qt/network/networkmanager.h
@@ -17,20 +17,20 @@ const int NM_802_11_AP_SEC_GROUP_WEP104    = 0x00000020;
 const int NM_802_11_AP_SEC_KEY_MGMT_PSK    = 0x00000100;
 const int NM_802_11_AP_SEC_KEY_MGMT_802_1X = 0x00000200;
 
-const QString NM_DBUS_PATH                          = "/org/freedesktop/NetworkManager";
-const QString NM_DBUS_PATH_SETTINGS                 = "/org/freedesktop/NetworkManager/Settings";
+#define NM_DBUS_PATH                          "/org/freedesktop/NetworkManager"
+#define  NM_DBUS_PATH_SETTINGS                "/org/freedesktop/NetworkManager/Settings"
 
-const QString NM_DBUS_INTERFACE                     = "org.freedesktop.NetworkManager";
-const QString NM_DBUS_INTERFACE_PROPERTIES          = "org.freedesktop.DBus.Properties";
-const QString NM_DBUS_INTERFACE_SETTINGS            = "org.freedesktop.NetworkManager.Settings";
-const QString NM_DBUS_INTERFACE_SETTINGS_CONNECTION = "org.freedesktop.NetworkManager.Settings.Connection";
-const QString NM_DBUS_INTERFACE_DEVICE              = "org.freedesktop.NetworkManager.Device";
-const QString NM_DBUS_INTERFACE_DEVICE_WIRELESS     = "org.freedesktop.NetworkManager.Device.Wireless";
-const QString NM_DBUS_INTERFACE_ACCESS_POINT        = "org.freedesktop.NetworkManager.AccessPoint";
-const QString NM_DBUS_INTERFACE_ACTIVE_CONNECTION   = "org.freedesktop.NetworkManager.Connection.Active";
-const QString NM_DBUS_INTERFACE_IP4_CONFIG          = "org.freedesktop.NetworkManager.IP4Config";
+#define NM_DBUS_INTERFACE                     "org.freedesktop.NetworkManager"
+#define NM_DBUS_INTERFACE_PROPERTIES          "org.freedesktop.DBus.Properties"
+#define NM_DBUS_INTERFACE_SETTINGS            "org.freedesktop.NetworkManager.Settings"
+#define NM_DBUS_INTERFACE_SETTINGS_CONNECTION "org.freedesktop.NetworkManager.Settings.Connection"
+#define NM_DBUS_INTERFACE_DEVICE              "org.freedesktop.NetworkManager.Device"
+#define NM_DBUS_INTERFACE_DEVICE_WIRELESS     "org.freedesktop.NetworkManager.Device.Wireless"
+#define NM_DBUS_INTERFACE_ACCESS_POINT        "org.freedesktop.NetworkManager.AccessPoint"
+#define NM_DBUS_INTERFACE_ACTIVE_CONNECTION   "org.freedesktop.NetworkManager.Connection.Active"
+#define NM_DBUS_INTERFACE_IP4_CONFIG          "org.freedesktop.NetworkManager.IP4Config"
 
-const QString NM_DBUS_SERVICE                        = "org.freedesktop.NetworkManager";
+#define NM_DBUS_SERVICE                       "org.freedesktop.NetworkManager"
 
 const int NM_DEVICE_STATE_UNKNOWN = 0;
 const int NM_DEVICE_STATE_ACTIVATED = 100;

--- a/selfdrive/ui/qt/network/wifi_manager.h
+++ b/selfdrive/ui/qt/network/wifi_manager.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <cassert>
 #include <optional>
 #include <QtDBus>
 #include <QTimer>
+#include <iostream>
+#include <dbus/dbus.h>
 
 #include "selfdrive/ui/qt/network/networkmanager.h"
 
@@ -63,6 +66,94 @@ public:
   QString getTetheringPassword();
 
 private:
+
+  DBusConnection *dbus;
+  DBusError error;
+
+  template <typename T>
+  T extractFromMessage(DBusMessage *message) {
+    DBusMessageIter args;
+    dbus_bool_t ret = dbus_message_iter_init(message, &args);
+    assert(ret);
+
+    if constexpr (std::is_same_v<T, uint32_t>) {
+      assert(DBUS_TYPE_VARIANT == dbus_message_iter_get_arg_type(&args) && "Argument is not an variant");
+      DBusMessageIter variantIter;
+      dbus_message_iter_recurse(&args, &variantIter);
+      assert(DBUS_TYPE_UINT32 == dbus_message_iter_get_arg_type(&variantIter) && "Argument is not an uint32.");
+      uint32_t value;
+      dbus_message_iter_get_basic(&variantIter, &value);
+      return value;
+
+    } else if constexpr (std::is_same_v<T, std::string>) {
+      assert(DBUS_TYPE_STRING == dbus_message_iter_get_arg_type(&args) && "Argument is not a string.");
+      const char *str;
+      dbus_message_iter_get_basic(&args, &str);
+      return std::string(str);
+
+    } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+      assert(DBUS_TYPE_ARRAY == dbus_message_iter_get_arg_type(&args) && "Argument is not an array.");
+      std::vector<std::string> result;
+      DBusMessageIter subIter;
+      dbus_message_iter_recurse(&args, &subIter);
+
+      // Iterate over the array of strings
+      while (dbus_message_iter_get_arg_type(&subIter) != DBUS_TYPE_INVALID) {
+        const char *str;
+        dbus_message_iter_get_basic(&subIter, &str);
+        result.emplace_back(str);
+        dbus_message_iter_next(&subIter);
+      }
+
+      return result;
+
+    } else {
+      // If T is unsupported, trigger a static assert
+      assert(0 && "Unsupported type for extraction.");
+    }
+  }
+
+  template <typename T=void, typename... Args>
+  T sendMethodCall(const char *path, const char *interface, const char *method, Args &&...args) {
+    DBusMessage *msg = dbus_message_new_method_call(NM_DBUS_SERVICE, path, interface, method);
+    assert(msg != nullptr && "Failed to create D-Bus message");
+
+    // Function to append the arguments one by one
+    auto appendArgs = [&msg](auto &&arg) {
+      using ArgType = std::decay_t<decltype(arg)>;
+      if constexpr (std::is_same_v<ArgType, int>) {
+        int v = arg;
+        return dbus_message_append_args(msg, DBUS_TYPE_INT32, &v, DBUS_TYPE_INVALID);
+      } else if constexpr (std::is_same_v<ArgType, const char *>) {
+        const char *v = arg;
+        return dbus_message_append_args(msg, DBUS_TYPE_STRING, &v, DBUS_TYPE_INVALID);
+      } else {
+        return false;  // Unsupported type
+      }
+    };
+
+    bool success = (appendArgs(args) && ...);
+    assert(success);
+
+    DBusMessage *reply = dbus_connection_send_with_reply_and_block(dbus, msg, DBUS_TIMEOUT_INFINITE, &error);
+    dbus_message_unref(msg);
+
+    if (dbus_error_is_set(&error)) {
+      std::cerr << "Error in D-Bus method call: " << error.message << std::endl;
+      dbus_error_free(&error);
+      assert(0);
+    }
+    if constexpr (std::is_void_v<T>) {
+      dbus_message_unref(reply);
+      return T();
+    } else {
+      T result = extractFromMessage<T>(reply);
+      dbus_message_unref(reply);
+      return result;
+    }
+  }
+
+
   QString adapter;  // Path to network manager wifi-device
   QTimer timer;
   unsigned int raw_adapter_state = NM_DEVICE_STATE_UNKNOWN;  // Connection status https://developer.gnome.org/NetworkManager/1.26/nm-dbus-types.html#NMDeviceState
@@ -74,6 +165,7 @@ private:
 
   QString getAdapter(const uint = NM_DEVICE_TYPE_WIFI);
   uint getAdapterType(const QDBusObjectPath &path);
+  uint getAdapterType(const std::string &path);
   QString getIp4Address();
   void deactivateConnectionBySsid(const QString &ssid);
   void deactivateConnection(const QDBusObjectPath &path);

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -40,6 +40,7 @@ function install_ubuntu_common_requirements() {
     libavutil-dev \
     libavfilter-dev \
     libbz2-dev \
+    libdbus-1-dev\
     libeigen3-dev \
     libffi-dev \
     libglew-dev \


### PR DESCRIPTION
This PR refactors the Wi-Fi Manager by removing Qt dependencies and switching to libdbus for D-Bus communication. The functionality remains the same, but now uses libdbus and standard C++ types. Key changes:
- [x] Replace `call<T>(...)` with libdbus version for synchronous D-Bus calls.
- [ ] Replace `asyncCall<T>(...)` with libdbus version for asynchronous calls.
- [ ] Remove all Qt types (e.g., QString, QVector) and use standard C++ (std::string, std::vector).


