### PR TITLE
replay: replace Qt data types with standard C++ data types

### DIFF
--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -49,8 +49,8 @@ void ReplayStream::mergeSegments() {
 }
 
 bool ReplayStream::loadRoute(const QString &route, const QString &data_dir, uint32_t replay_flags) {
-  replay.reset(new Replay(route, {"can", "roadEncodeIdx", "driverEncodeIdx", "wideRoadEncodeIdx", "carParams"},
-                          {}, nullptr, replay_flags, data_dir, this));
+  replay.reset(new Replay(route.toStdString(), {"can", "roadEncodeIdx", "driverEncodeIdx", "wideRoadEncodeIdx", "carParams"},
+                          {}, nullptr, replay_flags, data_dir.toStdString(), this));
   replay->setSegmentCacheLimit(settings.max_cached_minutes);
   replay->installEventFilter(event_filter, this);
   QObject::connect(replay.get(), &Replay::seeking, this, &AbstractStream::seeking);
@@ -153,7 +153,7 @@ AbstractStream *OpenReplayWidget::open() {
     route = route.mid(idx + 1);
   }
 
-  bool is_valid_format = Route::parseRoute(route).str.size() > 0;
+  bool is_valid_format = Route::parseRoute(route.toStdString()).str.size() > 0;
   if (!is_valid_format) {
     QMessageBox::warning(nullptr, tr("Warning"), tr("Invalid route format: '%1'").arg(route));
   } else {

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -20,7 +20,7 @@ public:
   bool eventFilter(const Event *event);
   void seekTo(double ts) override { replay->seekTo(std::max(double(0), ts), false); }
   bool liveStreaming() const override { return false; }
-  inline QString routeName() const override { return replay->route()->name(); }
+  inline QString routeName() const override { return QString::fromStdString(replay->route()->name()); }
   inline QString carFingerprint() const override { return replay->carFingerprint().c_str(); }
   double minSeconds() const override { return replay->minSeconds(); }
   double maxSeconds() const { return replay->maxSeconds(); }

--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -247,7 +247,7 @@ void ConsoleUI::updateProgressBar(uint64_t cur, uint64_t total, bool success) {
 
 void ConsoleUI::updateSummary() {
   const auto &route = replay->route();
-  mvwprintw(w[Win::Stats], 0, 0, "Route: %s, %lu segments", qPrintable(route->name()), route->segments().size());
+  mvwprintw(w[Win::Stats], 0, 0, "Route: %s, %lu segments", route->name().c_str(), route->segments().size());
   mvwprintw(w[Win::Stats], 1, 0, "Car Fingerprint: %s", replay->carFingerprint().c_str());
   wrefresh(w[Win::Stats]);
 }

--- a/tools/replay/main.cc
+++ b/tools/replay/main.cc
@@ -4,10 +4,12 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "common/prefix.h"
 #include "tools/replay/consoleui.h"
 #include "tools/replay/replay.h"
+#include "tools/replay/util.h"
 
 const std::string helpText =
 R"(Usage: replay [options]
@@ -32,10 +34,10 @@ Options:
 )";
 
 struct ReplayConfig {
-  QString route;
-  QStringList allow;
-  QStringList block;
-  QString data_dir;
+  std::string route;
+  std::vector<std::string> allow;
+  std::vector<std::string> block;
+  std::string data_dir;
   std::string prefix;
   uint32_t flags = REPLAY_FLAG_NONE;
   int start_seconds = 0;
@@ -84,8 +86,8 @@ bool parseArgs(int argc, char *argv[], ReplayConfig &config) {
   int opt, option_index = 0;
   while ((opt = getopt_long(argc, argv, "a:b:c:s:x:d:p:h", cli_options, &option_index)) != -1) {
     switch (opt) {
-      case 'a': config.allow = QString(optarg).split(","); break;
-      case 'b': config.block = QString(optarg).split(","); break;
+      case 'a': config.allow = split(optarg, ','); break;
+      case 'b': config.block = split(optarg, ','); break;
       case 'c': config.cache_segments = std::atoi(optarg); break;
       case 's': config.start_seconds = std::atoi(optarg); break;
       case 'x': config.playback_speed = std::atof(optarg); break;
@@ -106,11 +108,11 @@ bool parseArgs(int argc, char *argv[], ReplayConfig &config) {
   }
 
   // Check for a route name (first positional argument)
-  if (config.route.isEmpty() && optind < argc) {
+  if (config.route.empty() && optind < argc) {
     config.route = argv[optind];
   }
 
-  if (config.route.isEmpty()) {
+  if (config.route.empty()) {
     std::cerr << "No route provided. Use --help for usage information.\n";
     return false;
   }

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -15,7 +15,7 @@
 #include "tools/replay/camera.h"
 #include "tools/replay/route.h"
 
-const QString DEMO_ROUTE = "a2a0ccea32023010|2023-07-27--13-01-19";
+#define DEMO_ROUTE "a2a0ccea32023010|2023-07-27--13-01-19"
 
 // one segment uses about 100M of memory
 constexpr int MIN_SEGMENTS_CACHE = 5;
@@ -49,8 +49,8 @@ class Replay : public QObject {
   Q_OBJECT
 
 public:
-  Replay(QString route, QStringList allow, QStringList block, SubMaster *sm = nullptr,
-         uint32_t flags = REPLAY_FLAG_NONE, QString data_dir = "", QObject *parent = 0);
+  Replay(const std::string &route, std::vector<std::string> allow, std::vector<std::string> block, SubMaster *sm = nullptr,
+         uint32_t flags = REPLAY_FLAG_NONE, const std::string &data_dir = "", QObject *parent = 0);
   ~Replay();
   bool load();
   RouteLoadError lastRouteError() const { return route_->lastError(); }

--- a/tools/replay/route.h
+++ b/tools/replay/route.h
@@ -21,42 +21,42 @@ enum class RouteLoadError {
 };
 
 struct RouteIdentifier {
-  QString dongle_id;
-  QString timestamp;
+  std::string dongle_id;
+  std::string timestamp;
   int begin_segment = 0;
   int end_segment = -1;
-  QString str;
+  std::string str;
 };
 
 struct SegmentFile {
-  QString rlog;
-  QString qlog;
-  QString road_cam;
-  QString driver_cam;
-  QString wide_road_cam;
-  QString qcamera;
+  std::string rlog;
+  std::string qlog;
+  std::string road_cam;
+  std::string driver_cam;
+  std::string wide_road_cam;
+  std::string qcamera;
 };
 
 class Route {
 public:
-  Route(const QString &route, const QString &data_dir = {});
+  Route(const std::string &route, const std::string &data_dir = {});
   bool load();
   RouteLoadError lastError() const { return err_; }
-  inline const QString &name() const { return route_.str; }
+  inline const std::string &name() const { return route_.str; }
   inline const QDateTime datetime() const { return date_time_; }
-  inline const QString &dir() const { return data_dir_; }
+  inline const std::string &dir() const { return data_dir_; }
   inline const RouteIdentifier &identifier() const { return route_; }
   inline const std::map<int, SegmentFile> &segments() const { return segments_; }
   inline const SegmentFile &at(int n) { return segments_.at(n); }
-  static RouteIdentifier parseRoute(const QString &str);
+  static RouteIdentifier parseRoute(const std::string &str);
 
 protected:
   bool loadFromLocal();
   bool loadFromServer(int retries = 3);
   bool loadFromJson(const QString &json);
-  void addFileToSegment(int seg_num, const QString &file);
+  void addFileToSegment(int seg_num, const std::string &file);
   RouteIdentifier route_ = {};
-  QString data_dir_;
+  std::string data_dir_;
   std::map<int, SegmentFile> segments_;
   QDateTime date_time_;
   RouteLoadError err_ = RouteLoadError::None;

--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -122,12 +122,12 @@ std::string download_demo_route() {
     assert(remote_route.load());
 
     // Create a local route from remote for testing
-    const std::string route_name = DEMO_ROUTE.mid(17).toStdString();
+    const std::string route_name = std::string(DEMO_ROUTE).substr(17);
     for (int i = 0; i < 2; ++i) {
       std::string log_path = util::string_format("%s/%s--%d/", data_dir.c_str(), route_name.c_str(), i);
       util::create_directories(log_path, 0755);
-      REQUIRE(download_to_file(remote_route.at(i).rlog.toStdString(), log_path + "rlog.bz2"));
-      REQUIRE(download_to_file(remote_route.at(i).qcamera.toStdString(), log_path + "qcamera.ts"));
+      REQUIRE(download_to_file(remote_route.at(i).rlog, log_path + "rlog.bz2"));
+      REQUIRE(download_to_file(remote_route.at(i).qcamera, log_path + "qcamera.ts"));
     }
   }
 
@@ -139,7 +139,7 @@ TEST_CASE("Local route") {
   std::string data_dir = download_demo_route();
 
   auto flags = GENERATE(0, REPLAY_FLAG_QCAMERA);
-  Route route(DEMO_ROUTE, QString::fromStdString(data_dir));
+  Route route(DEMO_ROUTE, data_dir);
   REQUIRE(route.load());
   REQUIRE(route.segments().size() == 2);
   for (int i = 0; i < TEST_REPLAY_SEGMENTS; ++i) {

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -14,6 +14,7 @@
 #include <map>
 #include <mutex>
 #include <numeric>
+#include <sstream>
 #include <utility>
 #include <zstd.h>
 
@@ -388,6 +389,35 @@ std::string sha256(const std::string &str) {
   SHA256_Update(&sha256, str.c_str(), str.size());
   SHA256_Final(hash, &sha256);
   return util::hexdump(hash, SHA256_DIGEST_LENGTH);
+}
+
+std::vector<std::string> split(std::string_view source, char delimiter) {
+  std::vector<std::string> fields;
+  size_t last = 0;
+  for (size_t i = 0; i < source.length(); ++i) {
+    if (source[i] == delimiter) {
+      fields.emplace_back(source.substr(last, i - last));
+      last = i + 1;
+    }
+  }
+  fields.emplace_back(source.substr(last));
+  return fields;
+}
+
+std::string join(const std::vector<std::string> &elements, char separator) {
+  std::ostringstream oss;
+  for (size_t i = 0; i < elements.size(); ++i) {
+    if (i != 0) oss << separator;
+    oss << elements[i];
+  }
+  return oss.str();
+}
+
+std::string extractFileName(const std::string &file) {
+  size_t queryPos = file.find_first_of("?");
+  std::string path = (queryPos != std::string::npos) ? file.substr(0, queryPos) : file;
+  size_t lastSlash = path.find_last_of("/\\");
+  return (lastSlash != std::string::npos) ? path.substr(lastSlash + 1) : path;
 }
 
 // MonotonicBuffer

--- a/tools/replay/util.h
+++ b/tools/replay/util.h
@@ -4,6 +4,8 @@
 #include <deque>
 #include <functional>
 #include <string>
+#include <string_view>
+#include <vector>
 #include "cereal/messaging/messaging.h"
 
 enum CameraType {
@@ -57,3 +59,6 @@ typedef std::function<void(uint64_t cur, uint64_t total, bool success)> Download
 void installDownloadProgressHandler(DownloadProgressHandler);
 bool httpDownload(const std::string &url, const std::string &file, size_t chunk_size = 0, std::atomic<bool> *abort = nullptr);
 std::string formattedDataSize(size_t size);
+std::vector<std::string> split(std::string_view source, char delimiter);
+std::string join(const std::vector<std::string> &elements, char separator);
+std::string extractFileName(const std::string& file);


### PR DESCRIPTION
1. Replaced `QString` with `std::string`.
2. Replaced `QStringList` with `std::vector<std::string>`, Two helper functions were introduced:
   - `join()`: to replace `QStringList::join()` functionality.
   - `split()`:  to replace `QStringList::split()` functionality.
3. Replaced `QUrl(file).fileName()` with a custom `extractFileName()` function.
5. Replaced `QRegularExpression` with `std::regex`.
6. Replaced `QDirIterator` with `std::filesystem`.
7. Replaced QDebug, QInfo with rDebug, rInfo.