### PR TITLE
ui: refactor  `CommaApi` functions to remove Qt dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,10 +23,5 @@
     "system/**",
     "third_party/**",
     "tools/**",
-  ],
-  "files.associations": {
-    "*.py": "python",
-    "sstream": "cpp",
-    "regex": "cpp"
-  }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,10 @@
     "system/**",
     "third_party/**",
     "tools/**",
-  ]
+  ],
+  "files.associations": {
+    "*.py": "python",
+    "sstream": "cpp",
+    "regex": "cpp"
+  }
 }

--- a/common/SConscript
+++ b/common/SConscript
@@ -1,6 +1,7 @@
 Import('env', 'envCython', 'arch')
 
 common_libs = [
+  'api.cc',
   'params.cc',
   'swaglog.cc',
   'util.cc',

--- a/common/api.cc
+++ b/common/api.cc
@@ -1,0 +1,111 @@
+
+#include "common/api.h"
+
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+
+#include <cassert>
+#include <chrono>
+#include <iostream>
+
+#include "common/params.h"
+#include "system/hardware/hw.h"
+
+namespace CommaApi {
+
+// Base64 URL-safe character set (uses '-' and '_' instead of '+' and '/')
+static const std::string base64url_chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789-_";
+
+std::string base64url_encode(const std::string &in) {
+  std::string out;
+  int val = 0, valb = -6;
+  for (unsigned char c : in) {
+    val = (val << 8) + c;
+    valb += 8;
+    while (valb >= 0) {
+      out.push_back(base64url_chars[(val >> valb) & 0x3F]);
+      valb -= 6;
+    }
+  }
+  if (valb > -6) {
+    out.push_back(base64url_chars[((val << 8) >> (valb + 8)) & 0x3F]);
+  }
+
+  return out;
+}
+
+RSA *get_rsa_private_key() {
+  static std::unique_ptr<RSA, decltype(&RSA_free)> rsa_private(nullptr, RSA_free);
+  if (!rsa_private) {
+    FILE *fp = fopen(Path::rsa_file().c_str(), "rb");
+    if (!fp) {
+      std::cerr << "No RSA private key found, please run manager.py or registration.py" << std::endl;
+      return nullptr;
+    }
+    rsa_private.reset(PEM_read_RSAPrivateKey(fp, NULL, NULL, NULL));
+    fclose(fp);
+  }
+  return rsa_private.get();
+}
+
+std::string rsa_sign(const std::string &data) {
+  RSA *rsa_private = get_rsa_private_key();
+  if (!rsa_private) return {};
+
+  std::vector<uint8_t> sig(RSA_size(rsa_private));
+  unsigned int sig_len;
+  int ret = RSA_sign(NID_sha256, (unsigned char *)data.data(), data.size(),
+                     sig.data(), &sig_len, rsa_private);
+  assert(ret == 1);
+  assert(sig.size() == sig_len);
+  return std::string(sig.begin(), sig.begin() + sig_len);
+}
+
+std::string create_jwt(const json11::Json &extra, int exp_time) {
+  int now = std::chrono::seconds(std::time(nullptr)).count();
+  std::string dongle_id = Params().get("DongleId");
+
+  // Create header and payload
+  json11::Json header = json11::Json::object{{"alg", "RS256"}};
+  auto payload = json11::Json::object{
+      {"identity", dongle_id},
+      {"iat", now},
+      {"nbf", now},
+      {"exp", now + exp_time},
+  };
+  // Merge extra payload
+  for (const auto &item : extra.object_items()) {
+    payload[item.first] = item.second;
+  }
+
+  // JWT construction
+  std::string jwt = base64url_encode(header.dump()) + '.' +
+                    base64url_encode(json11::Json(payload).dump());
+
+  // Hash and sign
+  std::string hash(SHA256_DIGEST_LENGTH, '\0');
+  SHA256((uint8_t *)jwt.data(), jwt.size(), (uint8_t *)hash.data());
+  std::string signature = rsa_sign(hash);
+
+  return jwt + "." + base64url_encode(signature);
+}
+
+std::string create_token(bool use_jwt, const json11::Json &payloads, int expiry) {
+  if (use_jwt) {
+    return create_jwt(payloads, expiry);
+  }
+
+  std::string token_json = util::read_file(util::getenv("HOME") + "/.comma/auth.json");
+  std::string err;
+  auto json = json11::Json::parse(token_json, err);
+  if (!err.empty()) {
+    std::cerr << "Error parsing auth.json " << err << std::endl;
+    return "";
+  }
+  return json["access_token"].string_value();
+}
+
+}  // namespace CommaApi

--- a/common/api.h
+++ b/common/api.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+#include "common/util.h"
+#include "third_party/json11/json11.hpp"
+
+namespace CommaApi {
+
+const std::string BASE_URL = util::getenv("API_HOST", "https://api.commadotai.com").c_str();
+std::string create_token(bool use_jwt, const json11::Json& payloads = {}, int expiry = 3600);
+
+}  // namespace CommaApi

--- a/selfdrive/ui/qt/api.cc
+++ b/selfdrive/ui/qt/api.cc
@@ -1,68 +1,10 @@
 #include "selfdrive/ui/qt/api.h"
 
-#include <openssl/pem.h>
-#include <openssl/rsa.h>
-
 #include <QApplication>
-#include <QCryptographicHash>
-#include <QDateTime>
 #include <QDebug>
-#include <QJsonDocument>
 #include <QNetworkRequest>
 
-#include <memory>
-#include <string>
-
-#include "common/util.h"
-#include "system/hardware/hw.h"
 #include "selfdrive/ui/qt/util.h"
-
-namespace CommaApi {
-
-RSA *get_rsa_private_key() {
-  static std::unique_ptr<RSA, decltype(&RSA_free)> rsa_private(nullptr, RSA_free);
-  if (!rsa_private) {
-    FILE *fp = fopen(Path::rsa_file().c_str(), "rb");
-    if (!fp) {
-      qDebug() << "No RSA private key found, please run manager.py or registration.py";
-      return nullptr;
-    }
-    rsa_private.reset(PEM_read_RSAPrivateKey(fp, NULL, NULL, NULL));
-    fclose(fp);
-  }
-  return rsa_private.get();
-}
-
-QByteArray rsa_sign(const QByteArray &data) {
-  RSA *rsa_private = get_rsa_private_key();
-  if (!rsa_private) return {};
-
-  QByteArray sig(RSA_size(rsa_private), Qt::Uninitialized);
-  unsigned int sig_len;
-  int ret = RSA_sign(NID_sha256, (unsigned char*)data.data(), data.size(), (unsigned char*)sig.data(), &sig_len, rsa_private);
-  assert(ret == 1);
-  assert(sig.size() == sig_len);
-  return sig;
-}
-
-QString create_jwt(const QJsonObject &payloads, int expiry) {
-  QJsonObject header = {{"alg", "RS256"}};
-
-  auto t = QDateTime::currentSecsSinceEpoch();
-  QJsonObject payload = {{"identity", getDongleId().value_or("")}, {"nbf", t}, {"iat", t}, {"exp", t + expiry}};
-  for (auto it = payloads.begin(); it != payloads.end(); ++it) {
-    payload.insert(it.key(), it.value());
-  }
-
-  auto b64_opts = QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals;
-  QString jwt = QJsonDocument(header).toJson(QJsonDocument::Compact).toBase64(b64_opts) + '.' +
-                QJsonDocument(payload).toJson(QJsonDocument::Compact).toBase64(b64_opts);
-
-  auto hash = QCryptographicHash::hash(jwt.toUtf8(), QCryptographicHash::Sha256);
-  return jwt + "." + rsa_sign(hash).toBase64(b64_opts);
-}
-
-}  // namespace CommaApi
 
 HttpRequest::HttpRequest(QObject *parent, bool create_jwt, int timeout) : create_jwt(create_jwt), QObject(parent) {
   networkTimer = new QTimer(this);
@@ -84,15 +26,7 @@ void HttpRequest::sendRequest(const QString &requestURL, const HttpRequest::Meth
     qDebug() << "HttpRequest is active";
     return;
   }
-  QString token;
-  if (create_jwt) {
-    token = CommaApi::create_jwt();
-  } else {
-    QString token_json = QString::fromStdString(util::read_file(util::getenv("HOME") + "/.comma/auth.json"));
-    QJsonDocument json_d = QJsonDocument::fromJson(token_json.toUtf8());
-    token = json_d["access_token"].toString();
-  }
-
+  QString token = QString::fromStdString(CommaApi::create_token(create_jwt));
   QNetworkRequest request;
   request.setUrl(QUrl(requestURL));
   request.setRawHeader("User-Agent", getUserAgent().toUtf8());

--- a/selfdrive/ui/qt/api.h
+++ b/selfdrive/ui/qt/api.h
@@ -1,19 +1,10 @@
 #pragma once
 
-#include <QJsonObject>
 #include <QNetworkReply>
 #include <QString>
 #include <QTimer>
 
-#include "common/util.h"
-
-namespace CommaApi {
-
-const QString BASE_URL = util::getenv("API_HOST", "https://api.commadotai.com").c_str();
-QByteArray rsa_sign(const QByteArray &data);
-QString create_jwt(const QJsonObject &payloads = {}, int expiry = 3600);
-
-}  // namespace CommaApi
+#include "common/api.h"
 
 /**
  * Makes a request to the request endpoint.

--- a/selfdrive/ui/qt/prime_state.cc
+++ b/selfdrive/ui/qt/prime_state.cc
@@ -1,6 +1,7 @@
 #include "selfdrive/ui/qt/prime_state.h"
 
 #include <QJsonDocument>
+#include <QJsonObject>
 
 #include "selfdrive/ui/qt/api.h"
 #include "selfdrive/ui/qt/request_repeater.h"
@@ -15,7 +16,7 @@ PrimeState::PrimeState(QObject* parent) : QObject(parent) {
   }
 
   if (auto dongleId = getDongleId()) {
-    QString url = CommaApi::BASE_URL + "/v1.1/devices/" + *dongleId + "/";
+    QString url = QString::fromStdString(CommaApi::BASE_URL) + "/v1.1/devices/" + *dongleId + "/";
     RequestRepeater* repeater = new RequestRepeater(this, url, "ApiCache_Device", 5);
     QObject::connect(repeater, &RequestRepeater::requestDone, this, &PrimeState::handleReply);
   }

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -35,8 +35,8 @@ void PairingQRWidget::hideEvent(QHideEvent *event) {
 }
 
 void PairingQRWidget::refresh() {
-  QString pairToken = CommaApi::create_jwt({{"pair", true}});
-  QString qrString = "https://connect.comma.ai/?pair=" + pairToken;
+  std::string pairToken = CommaApi::create_token(true, json11::Json::object{{"pair", true}});
+  QString qrString = "https://connect.comma.ai/?pair=" + QString::fromStdString(pairToken);
   this->updateQrCode(qrString);
   update();
 }

--- a/tools/cabana/streams/routes.cc
+++ b/tools/cabana/streams/routes.cc
@@ -56,7 +56,7 @@ RoutesDialog::RoutesDialog(QWidget *parent) : QDialog(parent) {
   // Send request to fetch devices
   HttpRequest *http = new HttpRequest(this, !Hardware::PC());
   QObject::connect(http, &HttpRequest::requestDone, this, &RoutesDialog::parseDeviceList);
-  http->sendRequest(CommaApi::BASE_URL + "/v1/me/devices/");
+  http->sendRequest(QString::fromStdString(CommaApi::BASE_URL) + "/v1/me/devices/");
 }
 
 void RoutesDialog::parseDeviceList(const QString &json, bool success, QNetworkReply::NetworkError err) {
@@ -89,7 +89,7 @@ void RoutesDialog::fetchRoutes() {
   auto dongle_id = device_list_->currentData().toString();
   QDateTime current = QDateTime::currentDateTime();
   QString url = QString("%1/v1/devices/%2/routes_segments?start=%3&end=%4")
-                    .arg(CommaApi::BASE_URL).arg(dongle_id)
+                    .arg(CommaApi::BASE_URL.c_str()).arg(dongle_id)
                     .arg(current.addDays(-(period_selector_->currentData().toInt())).toMSecsSinceEpoch())
                     .arg(current.toMSecsSinceEpoch());
   http->sendRequest(url);

--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -1,8 +1,8 @@
 Import('env', 'qt_env', 'arch', 'common', 'messaging', 'visionipc', 'cereal')
 
 base_frameworks = qt_env['FRAMEWORKS']
-base_libs = [common, messaging, cereal, visionipc,
-             'm', 'ssl', 'crypto', 'pthread', 'qt_util'] + qt_env["LIBS"]
+base_libs = [messaging, cereal, visionipc,
+             'm', 'ssl', 'crypto', 'pthread', 'qt_util', common] + qt_env["LIBS"]
 
 if arch == "Darwin":
   base_frameworks.append('OpenCL')

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -78,7 +78,7 @@ bool Route::loadFromServer(int retries) {
       result = json;
       loop.exit((int)err);
     });
-    http.sendRequest(CommaApi::BASE_URL + "/v1/route/" + QString::fromStdString(route_.str) + "/files");
+    http.sendRequest(QString::fromStdString(CommaApi::BASE_URL + "/v1/route/" + route_.str + "/files"));
     auto err = (QNetworkReply::NetworkError)loop.exec();
     if (err == QNetworkReply::NoError) {
       return loadFromJson(result);


### PR DESCRIPTION
Refactors functions within the `CommaApi` namespace to eliminate Qt dependencies, improving the codebase's portability, and relocates the `CommaApi` implementation to` /common/api.h` and `/common/api.cc`. Key updates include:

1. Migrated CommaApi functions from` ui/qt/api` to `/common/api` for better modularity.
2. Introduced the `base64url_encode` helper function to replace the `QByteArray::base64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals)` method.
3. Replaced `QJsonDocument` with `json11` for JSON parsing and generation.
4. Replaced `QDateTime` with `std::chrono` for time handling.
5. Update RSA functionality to replace deprecated functions ( https://github.com/commaai/openpilot/actions/runs/11418681004/job/31772408385)

With these changes, we may be able to eliminate the Python JWT package, as we can write a simple Cython wrapper around common/api.
