### PR TITLE
replay: refactor `Route::loadFromServer` to use libcurl instead of HttpRequest

### DIFF
--- a/tools/replay/route.h
+++ b/tools/replay/route.h
@@ -53,7 +53,7 @@ public:
 protected:
   bool loadFromLocal();
   bool loadFromServer(int retries = 3);
-  bool loadFromJson(const QString &json);
+  bool loadFromJson(const std::string &json);
   void addFileToSegment(int seg_num, const std::string &file);
   RouteIdentifier route_ = {};
   std::string data_dir_;


### PR DESCRIPTION
Refactors the `Route::loadFromServer` to replace the Qt HttpRequest with libcurl. 

This refactor requires PR #33824 to handle authentication.