### PR TITLE
replay: refactor ConsoleUI to remove Qt dependency

### DIFF
--- a/tools/replay/main.cc
+++ b/tools/replay/main.cc
@@ -151,5 +151,5 @@ int main(int argc, char *argv[]) {
 
   ConsoleUI console_ui(replay);
   replay->start(config.start_seconds);
-  return app.exec();
+  return console_ui.exec();
 }

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -43,6 +43,7 @@ enum class FindFlag {
 
 enum class TimelineType { None, Engaged, AlertInfo, AlertWarning, AlertCritical, UserFlag };
 typedef bool (*replayEventFilter)(const Event *, void *);
+typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;
 Q_DECLARE_METATYPE(std::shared_ptr<LogReader>);
 
 class Replay : public QObject {
@@ -82,8 +83,7 @@ public:
   inline double maxSeconds() const { return max_seconds_; }
   inline void setSpeed(float speed) { speed_ = speed; }
   inline float getSpeed() const { return speed_; }
-  inline const std::vector<Event> *events() const { return &events_; }
-  inline const std::map<int, std::unique_ptr<Segment>> &segments() const { return segments_; }
+  inline const SegmentMap &segments() const { return segments_; }
   inline const std::string &carFingerprint() const { return car_fingerprint_; }
   inline const std::vector<std::tuple<double, double, TimelineType>> getTimeline() {
     std::lock_guard lk(timeline_lock);
@@ -102,7 +102,6 @@ protected slots:
   void segmentLoadFinished(bool success);
 
 protected:
-  typedef std::map<int, std::unique_ptr<Segment>> SegmentMap;
   std::optional<uint64_t> find(FindFlag flag);
   void pauseStreamThread();
   void startStream(const Segment *cur_segment);


### PR DESCRIPTION
Removed QObject inheritance and signals/slots. ConsoleUI now uses `RateKeeper` for ncurses updates and user input in a while loop. Note that a call to qApp->processEvents() remains to handle event processing, which will be eliminated once all Qt dependencies in the replay module are removed.