### PR TITLE
CSID cropping for IFE

### DIFF
--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -55,7 +55,7 @@ public:
 
   float fl_pix = 0;
 
-  CameraState(SpectraMaster *master, const CameraConfig &config) : camera(master, config, true /*config.stream_type == VISION_STREAM_ROAD*/) {};
+  CameraState(SpectraMaster *master, const CameraConfig &config) : camera(master, config, config.stream_type == VISION_STREAM_ROAD) {};
   ~CameraState();
   void init(VisionIpcServer *v, cl_device_id device_id, cl_context ctx);
   void update_exposure_score(float desired_ev, int exp_t, int exp_g_idx, float exp_gain);

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -262,7 +262,9 @@ void CameraState::run() {
     }
 
     // Process camera registers and set camera exposure
-    camera.sensor->processRegisters((uint8_t *)camera.buf.cur_camera_buf->addr, framed);
+    if (camera.is_raw) {
+      camera.sensor->processRegisters((uint8_t *)camera.buf.cur_camera_buf->addr, framed);
+    }
     set_camera_exposure(set_exposure_target(&camera.buf, ae_xywh, 2, camera.cc.stream_type != VISION_STREAM_DRIVER ? 2 : 4));
 
     // Send the message

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -589,8 +589,8 @@ void SpectraCamera::config_ife(int idx, int request_id, bool init) {
       io_cfg[0].planes[0] = (struct cam_plane_cfg){
         .width = sensor->frame_width,
         .height = sensor->frame_height,
-        .plane_stride = stride,
-        .slice_height = y_height,
+        .plane_stride = sensor->frame_stride,
+        .slice_height = sensor->frame_height + sensor->extra_height,
       };
       io_cfg[0].format = sensor->mipi_format;
       io_cfg[0].color_space = CAM_COLOR_SPACE_BASE;
@@ -799,9 +799,9 @@ void SpectraCamera::configISP() {
     .right_stop = sensor->frame_width - 1,
     .right_width = sensor->frame_width,
 
-    .line_start = 0,
-    .line_stop = sensor->frame_height + sensor->extra_height - 1,
-    .height = sensor->frame_height + sensor->extra_height,
+    .line_start = sensor->frame_offset,
+    .line_stop = sensor->frame_height + sensor->frame_offset - 1,
+    .height = sensor->frame_height + sensor->frame_offset,
 
     .pixel_clk = 0x0,
     .batch_size = 0x0,
@@ -821,6 +821,10 @@ void SpectraCamera::configISP() {
   };
 
   if (is_raw) {
+    in_port_info.line_start = 0;
+    in_port_info.line_stop = sensor->frame_height + sensor->extra_height - 1;
+    in_port_info.height = sensor->frame_height + sensor->extra_height;
+
     in_port_info.data[0].res_type = CAM_ISP_IFE_OUT_RES_RDI_0;
     in_port_info.data[0].format = sensor->mipi_format;
   }


### PR DESCRIPTION
Large diffs will cause a SOF/EOF error in the IFE and stop all processing, but not clear why this small difference didn't. Also not clear what it was even doing with those extra rows.

Leaving embedded stats enabled for now. Ideally we can get them out without keeping around the whole raw image.