### PR TITLE
replay: remove Qt dependency from Segment and Timeline

### DIFF
--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -53,6 +53,10 @@ bool ReplayStream::loadRoute(const QString &route, const QString &data_dir, uint
                           {}, nullptr, replay_flags, data_dir.toStdString(), this));
   replay->setSegmentCacheLimit(settings.max_cached_minutes);
   replay->installEventFilter(event_filter, this);
+
+  // Forward replay callbacks to corresponding Qt signals.
+  replay->onQLogLoaded = [this](std::shared_ptr<LogReader> qlog) { emit qLogLoaded(qlog); };
+
   QObject::connect(replay.get(), &Replay::seeking, this, &AbstractStream::seeking);
   QObject::connect(replay.get(), &Replay::seekedTo, this, &AbstractStream::seekedTo);
   QObject::connect(replay.get(), &Replay::segmentsMerged, this, &ReplayStream::mergeSegments);

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -10,6 +10,8 @@
 #include "tools/cabana/streams/abstractstream.h"
 #include "tools/replay/replay.h"
 
+Q_DECLARE_METATYPE(std::shared_ptr<LogReader>);
+
 class ReplayStream : public AbstractStream {
   Q_OBJECT
 
@@ -24,13 +26,16 @@ public:
   inline QString carFingerprint() const override { return replay->carFingerprint().c_str(); }
   double minSeconds() const override { return replay->minSeconds(); }
   double maxSeconds() const { return replay->maxSeconds(); }
-  inline QDateTime beginDateTime() const { return replay->routeDateTime(); }
+  inline QDateTime beginDateTime() const { return QDateTime::fromSecsSinceEpoch(replay->routeDateTime()); }
   inline uint64_t beginMonoTime() const override { return replay->routeStartNanos(); }
   inline void setSpeed(float speed) override { replay->setSpeed(speed); }
   inline float getSpeed() const { return replay->getSpeed(); }
   inline Replay *getReplay() const { return replay.get(); }
   inline bool isPaused() const override { return replay->isPaused(); }
   void pause(bool pause) override;
+
+signals:
+  void qLogLoaded(std::shared_ptr<LogReader> qlog);
 
 private:
   void mergeSegments();

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -16,22 +16,17 @@
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 #include "tools/cabana/utils/util.h"
 #include "tools/replay/logreader.h"
-
-struct AlertInfo {
-  cereal::SelfdriveState::AlertStatus status;
-  QString text1;
-  QString text2;
-};
+#include "tools/cabana/streams/replaystream.h"
 
 class InfoLabel : public QWidget {
 public:
   InfoLabel(QWidget *parent);
-  void showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm, const AlertInfo &alert);
-  void showAlert(const AlertInfo &alert);
+  void showPixmap(const QPoint &pt, const QString &sec, const QPixmap &pm, const std::optional<Timeline::Entry> &alert);
+  void showAlert(const std::optional<Timeline::Entry> &alert);
   void paintEvent(QPaintEvent *event) override;
   QPixmap pixmap;
   QString second;
-  AlertInfo alert_info;
+  std::optional<Timeline::Entry> alert_info;
 };
 
 class Slider : public QSlider {
@@ -42,7 +37,7 @@ public:
   double currentSecond() const { return value() / factor; }
   void setCurrentSecond(double sec) { setValue(sec * factor); }
   void setTimeRange(double min, double max);
-  AlertInfo alertInfo(double sec);
+  std::optional<Timeline::Entry> alertInfo(double sec);
   QPixmap thumbnail(double sec);
   void parseQLog(std::shared_ptr<LogReader> qlog);
 
@@ -55,7 +50,6 @@ private:
   void paintEvent(QPaintEvent *ev) override;
 
   QMap<uint64_t, QPixmap> thumbnails;
-  std::map<uint64_t, AlertInfo> alerts;
   InfoLabel *thumbnail_label;
 };
 

--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -9,7 +9,8 @@ if arch == "Darwin":
 else:
   base_libs.append('OpenCL')
 
-replay_lib_src = ["replay.cc", "consoleui.cc", "camera.cc", "filereader.cc", "logreader.cc", "framereader.cc", "route.cc", "util.cc"]
+replay_lib_src = ["replay.cc", "consoleui.cc", "camera.cc", "filereader.cc", "logreader.cc", "framereader.cc",
+                  "route.cc", "util.cc", "timeline.cc"]
 replay_lib = qt_env.Library("qt_replay", replay_lib_src, LIBS=base_libs, FRAMEWORKS=base_frameworks)
 Export('replay_lib')
 replay_libs = [replay_lib, 'avutil', 'avcodec', 'avformat', 'bz2', 'zstd', 'curl', 'yuv', 'ncurses'] + base_libs

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -1,7 +1,5 @@
 #include "tools/replay/replay.h"
 
-#include <QDebug>
-#include <QtConcurrent>
 #include <capnp/dynamic.h>
 #include <csignal>
 #include "cereal/services.h"
@@ -10,6 +8,14 @@
 #include "tools/replay/util.h"
 
 static void interrupt_sleep_handler(int signal) {}
+
+// Helper function to notify events with safety checks
+template <typename Callback, typename... Args>
+void notifyEvent(Callback &callback, Args &&...args) {
+  if (callback) {
+    callback(std::forward<Args>(args)...);
+  }
+}
 
 Replay::Replay(const std::string &route, std::vector<std::string> allow, std::vector<std::string> block, SubMaster *sm_,
                uint32_t flags, const std::string &data_dir, QObject *parent) : sm(sm_), flags_(flags), QObject(parent) {
@@ -40,7 +46,7 @@ Replay::Replay(const std::string &route, std::vector<std::string> allow, std::ve
     }
   }
 
-  rInfo("active services: %s", join(active_services, ',').c_str());
+  rInfo("active services: %s", join(active_services, ", ").c_str());
   rInfo("loading route %s", route.c_str());
 
   if (sm == nullptr) {
@@ -68,7 +74,6 @@ void Replay::stop() {
     stream_thread_ = nullptr;
     rInfo("shutdown: done");
   }
-  timeline_future.waitForFinished();
   camera_server_.reset(nullptr);
   segments_.clear();
 }
@@ -151,99 +156,9 @@ void Replay::checkSeekProgress() {
 }
 
 void Replay::seekToFlag(FindFlag flag) {
-  if (auto next = find(flag)) {
+  if (auto next = timeline_.find(currentSeconds(), flag)) {
     seekTo(*next - 2, false);  // seek to 2 seconds before next
   }
-}
-
-void Replay::buildTimeline() {
-  uint64_t engaged_begin = 0;
-  bool engaged = false;
-
-  auto alert_status = cereal::SelfdriveState::AlertStatus::NORMAL;
-  auto alert_size = cereal::SelfdriveState::AlertSize::NONE;
-  uint64_t alert_begin = 0;
-  std::string alert_type;
-
-  const TimelineType timeline_types[] = {
-    [(int)cereal::SelfdriveState::AlertStatus::NORMAL] = TimelineType::AlertInfo,
-    [(int)cereal::SelfdriveState::AlertStatus::USER_PROMPT] = TimelineType::AlertWarning,
-    [(int)cereal::SelfdriveState::AlertStatus::CRITICAL] = TimelineType::AlertCritical,
-  };
-
-  const auto &route_segments = route_->segments();
-  for (auto it = route_segments.cbegin(); it != route_segments.cend() && !exit_; ++it) {
-    std::shared_ptr<LogReader> log(new LogReader());
-    if (!log->load(it->second.qlog, &exit_, !hasFlag(REPLAY_FLAG_NO_FILE_CACHE), 0, 3) || log->events.empty()) continue;
-
-    std::vector<std::tuple<double, double, TimelineType>> timeline;
-    for (const Event &e : log->events) {
-      if (e.which == cereal::Event::Which::SELFDRIVE_STATE) {
-        capnp::FlatArrayMessageReader reader(e.data);
-        auto event = reader.getRoot<cereal::Event>();
-        auto cs = event.getSelfdriveState();
-
-        if (engaged != cs.getEnabled()) {
-          if (engaged) {
-            timeline.push_back({toSeconds(engaged_begin), toSeconds(e.mono_time), TimelineType::Engaged});
-          }
-          engaged_begin = e.mono_time;
-          engaged = cs.getEnabled();
-        }
-
-        if (alert_type != cs.getAlertType().cStr() || alert_status != cs.getAlertStatus()) {
-          if (!alert_type.empty() && alert_size != cereal::SelfdriveState::AlertSize::NONE) {
-            timeline.push_back({toSeconds(alert_begin), toSeconds(e.mono_time), timeline_types[(int)alert_status]});
-          }
-          alert_begin = e.mono_time;
-          alert_type = cs.getAlertType().cStr();
-          alert_size = cs.getAlertSize();
-          alert_status = cs.getAlertStatus();
-        }
-      } else if (e.which == cereal::Event::Which::USER_FLAG) {
-        timeline.push_back({toSeconds(e.mono_time), toSeconds(e.mono_time), TimelineType::UserFlag});
-      }
-    }
-
-    if (it->first == route_segments.rbegin()->first) {
-      if (engaged) {
-        timeline.push_back({toSeconds(engaged_begin), toSeconds(log->events.back().mono_time), TimelineType::Engaged});
-      }
-      if (!alert_type.empty() && alert_size != cereal::SelfdriveState::AlertSize::NONE) {
-        timeline.push_back({toSeconds(alert_begin), toSeconds(log->events.back().mono_time), timeline_types[(int)alert_status]});
-      }
-
-      max_seconds_ = std::ceil(toSeconds(log->events.back().mono_time));
-      emit minMaxTimeChanged(route_segments.cbegin()->first * 60.0, max_seconds_);
-    }
-    {
-      std::lock_guard lk(timeline_lock);
-      timeline_.insert(timeline_.end(), timeline.begin(), timeline.end());
-      std::sort(timeline_.begin(), timeline_.end(), [](auto &l, auto &r) { return std::get<2>(l) < std::get<2>(r); });
-    }
-    emit qLogLoaded(log);
-  }
-}
-
-std::optional<uint64_t> Replay::find(FindFlag flag) {
-  int cur_ts = currentSeconds();
-  for (auto [start_ts, end_ts, type] : getTimeline()) {
-    if (type == TimelineType::Engaged) {
-      if (flag == FindFlag::nextEngagement && start_ts > cur_ts) {
-        return start_ts;
-      } else if (flag == FindFlag::nextDisEngagement && end_ts > cur_ts) {
-        return end_ts;
-      }
-    } else if (start_ts > cur_ts) {
-      if ((flag == FindFlag::nextUserFlag && type == TimelineType::UserFlag) ||
-          (flag == FindFlag::nextInfo && type == TimelineType::AlertInfo) ||
-          (flag == FindFlag::nextWarning && type == TimelineType::AlertWarning) ||
-          (flag == FindFlag::nextCritical && type == TimelineType::AlertCritical)) {
-        return start_ts;
-      }
-    }
-  }
-  return std::nullopt;
 }
 
 void Replay::pause(bool pause) {
@@ -266,16 +181,15 @@ void Replay::pauseStreamThread() {
   }
 }
 
-void Replay::segmentLoadFinished(bool success) {
+void Replay::segmentLoadFinished(int seg_num, bool success) {
   if (!success) {
-    Segment *seg = qobject_cast<Segment *>(sender());
-    rWarning("failed to load segment %d, removing it from current replay list", seg->seg_num);
+    rWarning("failed to load segment %d, removing it from current replay list", seg_num);
     updateEvents([&]() {
-      segments_.erase(seg->seg_num);
+      segments_.erase(seg_num);
       return !segments_.empty();
     });
   }
-  updateSegmentsCache();
+  QMetaObject::invokeMethod(this, &Replay::updateSegmentsCache, Qt::QueuedConnection);
 }
 
 void Replay::updateSegmentsCache() {
@@ -306,8 +220,10 @@ void Replay::loadSegmentInRange(SegmentMap::iterator begin, SegmentMap::iterator
     auto it = std::find_if(first, last, [](const auto &seg_it) { return !seg_it.second || !seg_it.second->isLoaded(); });
     if (it != last && !it->second) {
       rDebug("loading segment %d...", it->first);
-      it->second = std::make_unique<Segment>(it->first, route_->at(it->first), flags_, filters_);
-      QObject::connect(it->second.get(), &Segment::loadFinished, this, &Replay::segmentLoadFinished);
+      it->second = std::make_unique<Segment>(it->first, route_->at(it->first), flags_, filters_,
+                                             [this](int seg_num, bool success) {
+                                               segmentLoadFinished(seg_num, success);
+                                             });
       return true;
     }
     return false;
@@ -373,7 +289,7 @@ void Replay::startStream(const Segment *cur_segment) {
     auto event = reader.getRoot<cereal::Event>();
     uint64_t wall_time = event.getInitData().getWallTimeNanos();
     if (wall_time > 0) {
-      route_date_time_ = QDateTime::fromMSecsSinceEpoch(wall_time / 1e6);
+      route_date_time_ = wall_time / 1e6;
     }
   }
 
@@ -405,12 +321,16 @@ void Replay::startStream(const Segment *cur_segment) {
   }
 
   emit segmentsMerged();
+
+  timeline_.initialize(*route_, route_start_ts_, !(flags_ & REPLAY_FLAG_NO_FILE_CACHE),
+                       [this](std::shared_ptr<LogReader> log) {
+                         notifyEvent(onQLogLoaded, log);
+                       });
   // start stream thread
   stream_thread_ = new QThread();
   QObject::connect(stream_thread_, &QThread::started, [=]() { streamThread(); });
   stream_thread_->start();
 
-  timeline_future = QtConcurrent::run(this, &Replay::buildTimeline);
   emit streamStarted();
 }
 

--- a/tools/replay/timeline.cc
+++ b/tools/replay/timeline.cc
@@ -1,0 +1,109 @@
+#include "tools/replay/timeline.h"
+
+#include <array>
+
+#include "cereal/gen/cpp/log.capnp.h"
+
+Timeline::~Timeline() {
+  should_exit_.store(true);
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void Timeline::initialize(const Route &route, uint64_t route_start_ts, bool local_cache,
+                          std::function<void(std::shared_ptr<LogReader>)> callback) {
+  thread_ = std::thread(&Timeline::buildTimeline, this, route, route_start_ts, local_cache, callback);
+}
+
+std::optional<uint64_t> Timeline::find(double cur_ts, FindFlag flag) const {
+  for (const auto &entry : *get()) {
+    if (entry.type == TimelineType::Engaged) {
+      if (flag == FindFlag::nextEngagement && entry.start_time > cur_ts) {
+        return entry.start_time;
+      } else if (flag == FindFlag::nextDisEngagement && entry.end_time > cur_ts) {
+        return entry.end_time;
+      }
+    } else if (entry.start_time > cur_ts) {
+      if ((flag == FindFlag::nextUserFlag && entry.type == TimelineType::UserFlag) ||
+          (flag == FindFlag::nextInfo && entry.type == TimelineType::AlertInfo) ||
+          (flag == FindFlag::nextWarning && entry.type == TimelineType::AlertWarning) ||
+          (flag == FindFlag::nextCritical && entry.type == TimelineType::AlertCritical)) {
+        return entry.start_time;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<Timeline::Entry> Timeline::findAlertAtTime(double target_time) const {
+  for (const auto &entry : *get()) {
+    if (entry.start_time > target_time) break;
+    if (entry.end_time >= target_time && entry.type >= TimelineType::AlertInfo) {
+      return entry;
+    }
+  }
+  return std::nullopt;
+}
+
+void Timeline::buildTimeline(const Route &route, uint64_t route_start_ts, bool local_cache,
+                             std::function<void(std::shared_ptr<LogReader>)> callback) {
+  std::optional<size_t> current_engaged_idx, current_alert_idx;
+
+  for (const auto &segment : route.segments()) {
+    if (should_exit_) break;
+
+    auto log = std::make_shared<LogReader>();
+    if (!log->load(segment.second.qlog, &should_exit_, local_cache, 0, 3) || log->events.empty()) {
+      continue;  // Skip if log loading fails or no events
+    }
+
+    for (const Event &e : log->events) {
+      double seconds = (e.mono_time - route_start_ts) / 1e9;
+      if (e.which == cereal::Event::Which::SELFDRIVE_STATE) {
+        capnp::FlatArrayMessageReader reader(e.data);
+        auto cs = reader.getRoot<cereal::Event>().getSelfdriveState();
+        updateEngagementStatus(cs, current_engaged_idx, seconds);
+        updateAlertStatus(cs, current_alert_idx, seconds);
+      } else if (e.which == cereal::Event::Which::USER_FLAG) {
+        staging_entries_.emplace_back(Entry{seconds, seconds, TimelineType::UserFlag});
+      }
+    }
+
+    callback(log);  // Notify the callback once the log is processed
+
+    // Sort and finalize the timeline entries
+    std::sort(staging_entries_.begin(), staging_entries_.end(), [](auto &a, auto &b) { return a.start_time < b.start_time; });
+    timeline_entries_ = std::make_shared<std::vector<Entry>>(staging_entries_);
+  }
+}
+
+void Timeline::updateEngagementStatus(const cereal::SelfdriveState::Reader &cs, std::optional<size_t> &idx, double seconds) {
+  if (idx) staging_entries_[*idx].end_time = seconds;
+  if (cs.getEnabled()) {
+    if (!idx) {
+      idx = staging_entries_.size();
+      staging_entries_.emplace_back(Entry{seconds, seconds, TimelineType::Engaged});
+    }
+  } else {
+    idx.reset();
+  }
+}
+
+void Timeline::updateAlertStatus(const cereal::SelfdriveState::Reader &cs, std::optional<size_t> &idx, double seconds) {
+  static auto alert_types = std::array{TimelineType::AlertInfo, TimelineType::AlertWarning, TimelineType::AlertCritical};
+
+  Entry *entry = idx ? &staging_entries_[*idx] : nullptr;
+  if (entry) entry->end_time = seconds;
+  if (cs.getAlertSize() != cereal::SelfdriveState::AlertSize::NONE) {
+    auto type = alert_types[(int)cs.getAlertStatus()];
+    std::string text1 = cs.getAlertText1().cStr();
+    std::string text2 = cs.getAlertText2().cStr();
+    if (!entry || entry->type != type || entry->text1 != text1 || entry->text2 != text2) {
+      idx = staging_entries_.size();
+      staging_entries_.emplace_back(Entry{seconds, seconds, type, text1, text2});  // Start a new entry
+    }
+  } else {
+    idx.reset();
+  }
+}

--- a/tools/replay/timeline.h
+++ b/tools/replay/timeline.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <atomic>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include "tools/replay/route.h"
+
+enum class TimelineType { None, Engaged, AlertInfo, AlertWarning, AlertCritical, UserFlag };
+enum class FindFlag { nextEngagement, nextDisEngagement, nextUserFlag, nextInfo, nextWarning, nextCritical };
+
+class Timeline {
+public:
+  struct Entry {
+    double start_time;
+    double end_time;
+    TimelineType type;
+    std::string text1;
+    std::string text2;
+  };
+
+  Timeline() : timeline_entries_(std::make_shared<std::vector<Entry>>()) {}
+  ~Timeline();
+
+  void initialize(const Route &route, uint64_t route_start_ts, bool local_cache,
+                  std::function<void(std::shared_ptr<LogReader>)> callback);
+  std::optional<uint64_t> find(double cur_ts, FindFlag flag) const;
+  std::optional<Entry> findAlertAtTime(double target_time) const;
+  const std::shared_ptr<std::vector<Entry>> get() const { return timeline_entries_; }
+
+private:
+ void buildTimeline(const Route &route, uint64_t route_start_ts, bool local_cache,
+                    std::function<void(std::shared_ptr<LogReader>)> callback);
+ void updateEngagementStatus(const cereal::SelfdriveState::Reader &cs, std::optional<size_t> &idx, double seconds);
+ void updateAlertStatus(const cereal::SelfdriveState::Reader &cs, std::optional<size_t> &idx, double seconds);
+
+ std::thread thread_;
+ std::atomic<bool> should_exit_ = false;
+
+ // Temporarily holds entries before they are sorted and finalized
+ std::vector<Entry> staging_entries_;
+
+ // Final sorted timeline entries
+ std::shared_ptr<std::vector<Entry>> timeline_entries_;
+};

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -14,7 +14,6 @@
 #include <map>
 #include <mutex>
 #include <numeric>
-#include <sstream>
 #include <utility>
 #include <zstd.h>
 
@@ -402,15 +401,6 @@ std::vector<std::string> split(std::string_view source, char delimiter) {
   }
   fields.emplace_back(source.substr(last));
   return fields;
-}
-
-std::string join(const std::vector<std::string> &elements, char separator) {
-  std::ostringstream oss;
-  for (size_t i = 0; i < elements.size(); ++i) {
-    if (i != 0) oss << separator;
-    oss << elements[i];
-  }
-  return oss.str();
 }
 
 std::string extractFileName(const std::string &file) {

--- a/tools/replay/util.h
+++ b/tools/replay/util.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <deque>
 #include <functional>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -59,6 +60,15 @@ typedef std::function<void(uint64_t cur, uint64_t total, bool success)> Download
 void installDownloadProgressHandler(DownloadProgressHandler);
 bool httpDownload(const std::string &url, const std::string &file, size_t chunk_size = 0, std::atomic<bool> *abort = nullptr);
 std::string formattedDataSize(size_t size);
-std::vector<std::string> split(std::string_view source, char delimiter);
-std::string join(const std::vector<std::string> &elements, char separator);
 std::string extractFileName(const std::string& file);
+std::vector<std::string> split(std::string_view source, char delimiter);
+
+template <typename Iterable>
+std::string join(const Iterable& elements, const std::string& separator) {
+  std::ostringstream oss;
+  for (auto it = elements.begin(); it != elements.end(); ++it) {
+    if (it != elements.begin()) oss << separator;
+    oss << *it;
+  }
+  return oss.str();
+}


### PR DESCRIPTION
Remove Qt dependencies from Segment and Timeline, and move the timeline code out of Replay into its own class to simplify Replay's role.

#### Main Changes:
1. **Timeline Refactor:**
   - Moved timeline code out of `Replay` into its own `Timeline` class.
   - Replaced `QThread` and queued signal/slot usage with `std::thread` and `std::shared_ptr` for thread-safe updates and notifications.
   - Updated `Cabana` to use the new notification mechanism.

2. **Segment Class:**
   - Replaced `QFutureSynchronizer` with `std::thread` and a callback to notify the main thread after a segment is loaded.

3. **Date Handling:**
   - Replaced `QDateTime` with `std::time_t` to remove Qt dependencies.
