### PR TITLE
camerad: set EOF based on readout time

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -114,6 +114,7 @@ bool CameraBuf::acquire(int expo_time) {
     cur_frame_data.processing_time = (millis_since_boot() - start_time) / 1000.0;
   } else {
     cur_yuv_buf = vipc_server->get_buffer(stream_type, cur_buf_idx);
+    cur_frame_data.processing_time = (double)(cur_frame_data.timestamp_end_of_isp - cur_frame_data.timestamp_eof)*1e-6;
   }
 
   VisionIpcBufExtra extra = {

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -15,6 +15,7 @@ typedef struct FrameMetadata {
   uint32_t request_id;
   uint64_t timestamp_sof;
   uint64_t timestamp_eof;
+  uint64_t timestamp_end_of_isp;
   float processing_time;
 } FrameMetadata;
 

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -251,9 +251,6 @@ void CameraState::run() {
     framed.setTargetGreyFraction(target_grey_fraction);
     framed.setProcessingTime(meta.processing_time);
 
-    double dms = ((double)meta.timestamp_eof - (double)meta.timestamp_end_of_isp)*1e-9;
-    printf("%s diff %f ms\n", camera.cc.publish_name, dms);
-
     const float ev = cur_ev[meta.frame_id % 3];
     const float perc = util::map_val(ev, camera.sensor->min_ev, camera.sensor->max_ev, 0.0f, 100.0f);
     framed.setExposureValPercent(perc);

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -251,6 +251,9 @@ void CameraState::run() {
     framed.setTargetGreyFraction(target_grey_fraction);
     framed.setProcessingTime(meta.processing_time);
 
+    double dms = ((double)meta.timestamp_eof - (double)meta.timestamp_end_of_isp)*1e-9;
+    printf("%s diff %f ms\n", camera.cc.publish_name, dms);
+
     const float ev = cur_ev[meta.frame_id % 3];
     const float perc = util::map_val(ev, camera.sensor->min_ev, camera.sensor->max_ev, 0.0f, 100.0f);
     framed.setExposureValPercent(perc);

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -671,8 +671,8 @@ void SpectraCamera::enqueue_buffer(int i, bool dp) {
       LOGE("failed to wait for sync: %d %d", ret, sync_wait.sync_obj);
       // TODO: handle frame drop cleanly
     }
-
-    buf.frame_metadata[i].timestamp_eof = (uint64_t)nanos_since_boot(); // set true eof
+    buf.frame_metadata[i].timestamp_end_of_isp = (uint64_t)nanos_since_boot();
+    buf.frame_metadata[i].timestamp_eof = buf.frame_metadata[i].timestamp_sof + sensor->readout_time_ns;
     if (dp) buf.queue(i);
 
     // destroy old output fence

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1083,7 +1083,7 @@ void SpectraCamera::handle_camera_event(const cam_req_mgr_message *event_data) {
     auto &meta_data = buf.frame_metadata[buf_idx];
     meta_data.frame_id = main_id - idx_offset;
     meta_data.request_id = real_id;
-    meta_data.timestamp_sof = timestamp;
+    meta_data.timestamp_sof = timestamp; // this is timestamped in the kernel's SOF IRQ callback
 
     // dispatch
     enqueue_req_multi(real_id + FRAME_BUF_COUNT, 1, 1);

--- a/system/camerad/sensors/ar0231.cc
+++ b/system/camerad/sensors/ar0231.cc
@@ -98,7 +98,7 @@ AR0231::AR0231() {
   frame_data_type = 0x12;  // Changing stats to 0x2C doesn't work, so change pixels to 0x12 instead
   mclk_frequency = 19200000; //Hz
 
-  readout_time_ns = 0;
+  readout_time_ns = 22850000;
 
   dc_gain_factor = 2.5;
   dc_gain_min_weight = 0;

--- a/system/camerad/sensors/ar0231.cc
+++ b/system/camerad/sensors/ar0231.cc
@@ -98,6 +98,8 @@ AR0231::AR0231() {
   frame_data_type = 0x12;  // Changing stats to 0x2C doesn't work, so change pixels to 0x12 instead
   mclk_frequency = 19200000; //Hz
 
+  readout_time_ns = 0;
+
   dc_gain_factor = 2.5;
   dc_gain_min_weight = 0;
   dc_gain_max_weight = 1;

--- a/system/camerad/sensors/ar0231_registers.h
+++ b/system/camerad/sensors/ar0231_registers.h
@@ -6,6 +6,8 @@ const struct i2c_random_wr_payload stop_reg_array_ar0231[] = {{0x301A, 0x918}};
 const struct i2c_random_wr_payload init_array_ar0231[] = {
   {0x301A, 0x0018}, // RESET_REGISTER
 
+  // **NOTE**: if this is changed, readout_time_ns must be updated in the Sensor config
+
   // CLOCK Settings
   // input clock is 19.2 / 2 * 0x37 = 528 MHz
   // pixclk is 528 / 6 = 88 MHz

--- a/system/camerad/sensors/ox03c10.cc
+++ b/system/camerad/sensors/ox03c10.cc
@@ -42,7 +42,7 @@ OX03C10::OX03C10() {
   frame_data_type = 0x2c; // one is 0x2a, two are 0x2b
   mclk_frequency = 24000000; //Hz
 
-  readout_time_ns = 0;
+  readout_time_ns = 14697000;
 
   dc_gain_factor = 7.32;
   dc_gain_min_weight = 1;  // always on is fine

--- a/system/camerad/sensors/ox03c10.cc
+++ b/system/camerad/sensors/ox03c10.cc
@@ -42,6 +42,8 @@ OX03C10::OX03C10() {
   frame_data_type = 0x2c; // one is 0x2a, two are 0x2b
   mclk_frequency = 24000000; //Hz
 
+  readout_time_ns = 0;
+
   dc_gain_factor = 7.32;
   dc_gain_min_weight = 1;  // always on is fine
   dc_gain_max_weight = 1;

--- a/system/camerad/sensors/ox03c10_registers.h
+++ b/system/camerad/sensors/ox03c10_registers.h
@@ -31,6 +31,7 @@ const struct i2c_random_wr_payload init_array_ox03c10[] = {
   // delay launch group 2
   {0x3208, 0xa2},*/
 
+  // **NOTE**: if this is changed, readout_time_ns must be updated in the Sensor config
   // PLL setup
   {0x0301, 0xc8}, // pll1_divs, pll1_predivp, pll1_divpix
   {0x0303, 0x01}, // pll1_prediv

--- a/system/camerad/sensors/sensor.h
+++ b/system/camerad/sensors/sensor.h
@@ -66,6 +66,8 @@ public:
   uint32_t mclk_frequency;
   uint32_t frame_data_type;
 
+  uint32_t readout_time_ns;  // used to recover EOF from SOF
+
   // ISP image processing params
   uint32_t black_level;
   std::vector<uint32_t> color_correct_matrix;  // 3x3


### PR DESCRIPTION
EOF is currently set in camerad after we get the raw frame out, but that'll now be the time we get the fully processed images which is ~1ms after EOF.

---

**Before / After**
* diff is `new_eof - old_eof`
* the consistent diff between driver, wide, and road is due to them being timestamped sequentially on the same core. this is fixed with the new EOF

AR0231
```
driverCameraState diff -0.945149 ms
roadCameraState diff -0.799943 ms
wideRoadCameraState diff -0.850515 ms
driverCameraState diff -0.909889 ms
wideRoadCameraState diff -0.803433 ms
roadCameraState diff -0.884004 ms
driverCameraState diff -0.947858 ms
wideRoadCameraState diff -0.807860 ms
roadCameraState diff -0.892650 ms
driverCameraState diff -0.951867 ms
roadCameraState diff -0.818484 ms
wideRoadCameraState diff -0.882077 ms
```

OX03C10
```
driverCameraState diff -0.192674 ms
roadCameraState diff -0.573863 ms
wideRoadCameraState diff -0.933335 ms
driverCameraState diff -0.208403 ms
roadCameraState diff -0.579436 ms
wideRoadCameraState diff -0.936043 ms
driverCameraState diff -0.196267 ms
roadCameraState diff -0.581259 ms
wideRoadCameraState diff -0.948386 ms
driverCameraState diff -0.193559 ms
roadCameraState diff -0.562770 ms
wideRoadCameraState diff -0.928074 ms
driverCameraState diff -0.180799 ms
roadCameraState diff -0.565322 ms
```