### PR TITLE
statsd: don't use datetime in filename

### DIFF
--- a/system/statsd.py
+++ b/system/statsd.py
@@ -2,6 +2,7 @@
 import os
 import zmq
 import time
+import uuid
 from pathlib import Path
 from collections import defaultdict
 from datetime import datetime, UTC
@@ -102,6 +103,7 @@ def main() -> NoReturn:
   sm = SubMaster(['deviceState'])
 
   idx = 0
+  boot_uid = str(uuid.uuid4())[:8]
   last_flush_time = time.monotonic()
   gauges = {}
   samples: dict[str, list[float]] = defaultdict(list)
@@ -164,7 +166,7 @@ def main() -> NoReturn:
         # check that we aren't filling up the drive
         if len(os.listdir(STATS_DIR)) < STATS_DIR_FILE_LIMIT:
           if len(result) > 0:
-            stats_path = os.path.join(STATS_DIR, f"{current_time.timestamp():.0f}_{idx}")
+            stats_path = os.path.join(STATS_DIR, f"{boot_uid}_{idx}")
             with atomic_write_in_dir(stats_path) as f:
               f.write(result)
             idx += 1


### PR DESCRIPTION
https://github.com/commaai/openpilot/issues/32758
```
Process statsd:                                                                                                                                                       Traceback (most recent call last):                                                                                                                                    
  File "/usr/local/pyenv/versions/3.11.4/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap                                                              self.run()                                                                                                                                                        
  File "/usr/local/pyenv/versions/3.11.4/lib/python3.11/multiprocessing/process.py", line 108, in run                                                                     self._target(*self._args, **self._kwargs)                                                                                                                         
  File "/data/openpilot/openpilot/system/manager/process.py", line 40, in launcher                                                                                        mod.main()                                                                                                                                                        
  File "/data/openpilot/system/statsd.py", line 168, in main                                                                                                          
    with atomic_write_in_dir(stats_path) as f:                                     
  File "/usr/local/pyenv/versions/3.11.4/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)                
           ^^^^^^^^^^^^^^                
  File "/data/openpilot/openpilot/common/file_helpers.py", line 32, in atomic_write_in_dir
    raise FileExistsError(f"File '{path}' already exists. To overwrite it, set 'overwrite' to True.")
FileExistsError: File '/data/stats/1700601054_0' already exists. To overwrite it, set 'overwrite' to True.
```