### PR TITLE
add nightly-dev to tested_branches

### DIFF
--- a/system/version.py
+++ b/system/version.py
@@ -11,7 +11,7 @@ from openpilot.common.swaglog import cloudlog
 from openpilot.common.git import get_commit, get_origin, get_branch, get_short_branch, get_commit_date
 
 RELEASE_BRANCHES = ['release3-staging', 'release3', 'nightly']
-TESTED_BRANCHES = RELEASE_BRANCHES + ['devel', 'devel-staging']
+TESTED_BRANCHES = RELEASE_BRANCHES + ['devel', 'devel-staging', 'nightly-dev']
 
 BUILD_METADATA_FILENAME = "build.json"
 


### PR DESCRIPTION
Needed to display the expected warning on startup in test_onroad