### PR TITLE
selfdrive/debug: fix broken check_can_parser_performance.py

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -93,7 +93,7 @@ class TestCarModelBase(unittest.TestCase):
         car_fw = msg.carParams.carFw
         if msg.carParams.openpilotLongitudinalControl:
           experimental_long = True
-        if cls.platform is None and not cls.test_route_on_bucket:
+        if cls.platform is None:
           live_fingerprint = msg.carParams.carFingerprint
           cls.platform = MIGRATION.get(live_fingerprint, live_fingerprint)
 

--- a/selfdrive/debug/check_can_parser_performance.py
+++ b/selfdrive/debug/check_can_parser_performance.py
@@ -14,7 +14,7 @@ N_RUNS = 10
 
 class CarModelTestCase(TestCarModelBase):
   test_route = CarTestRoute(DEMO_ROUTE, None)
-  ci = False
+  test_route_on_bucket = False
 
 
 if __name__ == '__main__':

--- a/selfdrive/debug/check_can_parser_performance.py
+++ b/selfdrive/debug/check_can_parser_performance.py
@@ -14,7 +14,6 @@ N_RUNS = 10
 
 class CarModelTestCase(TestCarModelBase):
   test_route = CarTestRoute(DEMO_ROUTE, None)
-  test_route_on_bucket = False
 
 
 if __name__ == '__main__':

--- a/tools/car_porting/test_car_model.py
+++ b/tools/car_porting/test_car_model.py
@@ -8,11 +8,11 @@ from openpilot.selfdrive.car.tests.test_models import TestCarModel
 from openpilot.tools.lib.route import SegmentName
 
 
-def create_test_models_suite(routes: list[CarTestRoute], ci=False) -> unittest.TestSuite:
+def create_test_models_suite(routes: list[CarTestRoute]) -> unittest.TestSuite:
   test_suite = unittest.TestSuite()
   for test_route in routes:
     # create new test case and discover tests
-    test_case_args = {"platform": test_route.car_model, "test_route": test_route, "test_route_on_bucket": ci}
+    test_case_args = {"platform": test_route.car_model, "test_route": test_route}
     CarModelTestCase = type("CarModelTestCase", (TestCarModel,), test_case_args)
     test_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(CarModelTestCase))
   return test_suite
@@ -23,7 +23,6 @@ if __name__ == "__main__":
                                                "Uses selfdrive/car/tests/test_models.py")
   parser.add_argument("route_or_segment_name", help="Specify route to run tests on")
   parser.add_argument("--car", help="Specify car model for test route")
-  parser.add_argument("--ci", action="store_true", help="Attempt to get logs using openpilotci, need to specify car")
   args = parser.parse_args()
   if len(sys.argv) == 1:
     parser.print_help()
@@ -33,6 +32,6 @@ if __name__ == "__main__":
   segment_num = route_or_segment_name.segment_num if route_or_segment_name.segment_num != -1 else None
 
   test_route = CarTestRoute(route_or_segment_name.route_name.canonical_name, args.car, segment=segment_num)
-  test_suite = create_test_models_suite([test_route], ci=args.ci)
+  test_suite = create_test_models_suite([test_route])
 
   unittest.TextTestRunner().run(test_suite)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

