### PR TITLE
cabana: refactor video widget for simplified layout and enhanced rendering

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -51,7 +51,7 @@ MainWindow::MainWindow(AbstractStream *stream, const QString &dbc_file) : QMainW
     emit static_main_win->updateProgressBar(cur, total, success);
   });
   qInstallMessageHandler([](QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-    if (type == QtDebugMsg) std::cout << msg.toStdString() << std::endl;
+    if (type == QtDebugMsg) return;
     emit static_main_win->showMessage(msg, 2000);
   });
   installMessageHandler([](ReplyMsgType type, const std::string msg) { qInfo() << msg.c_str(); });

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -60,8 +60,8 @@ public:
   inline int segmentCacheLimit() const { return segment_cache_limit; }
   inline void setSegmentCacheLimit(int n) { segment_cache_limit = std::max(MIN_SEGMENTS_CACHE, n); }
   inline bool hasFlag(REPLAY_FLAGS flag) const { return flags_ & flag; }
-  inline void addFlag(REPLAY_FLAGS flag) { flags_ |= flag; }
-  inline void removeFlag(REPLAY_FLAGS flag) { flags_ &= ~flag; }
+  void setLoop(bool loop) { loop ? flags_ &= ~REPLAY_FLAG_NO_LOOP : flags_ |= REPLAY_FLAG_NO_LOOP; }
+  bool loop() const { return !(flags_ & REPLAY_FLAG_NO_LOOP); }
   inline const Route* route() const { return route_.get(); }
   inline double currentSeconds() const { return double(cur_mono_time_ - route_start_ts_) / 1e9; }
   inline std::time_t routeDateTime() const { return route_date_time_; }

--- a/tools/replay/timeline.cc
+++ b/tools/replay/timeline.cc
@@ -70,11 +70,11 @@ void Timeline::buildTimeline(const Route &route, uint64_t route_start_ts, bool l
       }
     }
 
-    callback(log);  // Notify the callback once the log is processed
-
     // Sort and finalize the timeline entries
     std::sort(staging_entries_.begin(), staging_entries_.end(), [](auto &a, auto &b) { return a.start_time < b.start_time; });
     timeline_entries_ = std::make_shared<std::vector<Entry>>(staging_entries_);
+
+    callback(log);  // Notify the callback once the log is processed
   }
 }
 


### PR DESCRIPTION
This update simplifies the video widget by drawing thumbnails and alerts directly in `StreamCameraView::paintGL`, replacing the old tooltip-based method. Thumbnails are pre-rendered during the `parseQLog` process, reducing unnecessary redraws in the paint event. these changes simplify the codebase and enhance performance for smoother and more efficient video widget functionality.

### Main Changes:
1. Integrated Thumbnail Rendering: Thumbnails are now drawn directly in paingGL, eliminating the need for separate tooltip widgets.
2. Pre-rendered Thumbnails: Thumbnails and alert text are pre-drawn in the parseQLog thread, reducing redraws during the paint event.
3. Improved Performance: Streamlined layout and optimized rendering reduce complexity and increase efficiency.
4. Disabled qDebug Messages: Suppressed debug messages to prevent log clutter.
