### PR TITLE
fix lead distance bars w/ joystick mode

### DIFF
--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -31,6 +31,7 @@ def joystickd_thread():
     CC.enabled = sm['selfdriveState'].enabled
     CC.latActive = sm['selfdriveState'].active and not sm['carState'].steerFaultTemporary and not sm['carState'].steerFaultPermanent
     CC.longActive = CC.enabled and not any(e.overrideLongitudinal for e in sm['onroadEvents']) and CP.openpilotLongitudinalControl
+    CC.hudControl.leadDistanceBars = 2
 
     actuators = CC.actuators
 


### PR DESCRIPTION
For Toyota, we continually spam the distance button since it can never be 0.