### PR TITLE
Fix Night Brightness

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -145,7 +145,7 @@ void Device::resetInteractiveTimeout(int timeout) {
 
 void Device::updateBrightness(const UIState &s) {
   float clipped_brightness = offroad_brightness;
-  if (s.scene.started && s.scene.light_sensor > 0) {
+  if (s.scene.started && s.scene.light_sensor >= 0) {
     clipped_brightness = s.scene.light_sensor;
 
     // CIE 1931 - https://www.photonstophotos.net/GeneralTopics/Exposure/Psychometric_Lightness_and_Gamma.htm


### PR DESCRIPTION
**Description**

Very simple fix with dramatic user experience improvement.

This commit f641d7e8517255888440faf4d496e7f7fb3074e6 six months ago introduced a test to ensure that the wide camera was available for calculating the light_sensor value.  If the wide camera was not present,  the resulting brightness defaulted to 50%.  This was achieved by setting light_sensor = -1.

A small typo in the test ( >0 rather than >= 0) meant that light_sensor values of 0 would result in 50% brightness, while a light sensor value of 8 would result in 10% brightness.

**Verification**

I tested the resulting output at night in my garage to confirm that it worked.

It is a dramatic improvement in user experience.