### PR TITLE
Dev panel: disable long maneuver toggle for stock long

### DIFF
--- a/selfdrive/ui/qt/offroad/developer_panel.cc
+++ b/selfdrive/ui/qt/offroad/developer_panel.cc
@@ -37,13 +37,12 @@ void DeveloperPanel::updateToggles(bool offroad) {
     btn->setEnabled(offroad);
   }
 
+  // longManeuverToggle should not be toggleable if the car don't have longitudinal control
   auto cp_bytes = params.get("CarParamsPersistent");
   if (!cp_bytes.empty()) {
     AlignedBuffer aligned_buf;
     capnp::FlatArrayMessageReader cmsg(aligned_buf.align(cp_bytes.data(), cp_bytes.size()));
     cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
-
-    // longManeuverToggle should not be toggleable if the car don't have longitudinal control
     longManeuverToggle->setEnabled(hasLongitudinalControl(CP) && offroad);
   } else {
     longManeuverToggle->setEnabled(false);

--- a/selfdrive/ui/qt/offroad/developer_panel.cc
+++ b/selfdrive/ui/qt/offroad/developer_panel.cc
@@ -3,6 +3,7 @@
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
+#include "common/util.h"
 
 DeveloperPanel::DeveloperPanel(SettingsWindow *parent) : ListWidget(parent) {
   // SSH keys
@@ -24,13 +25,35 @@ DeveloperPanel::DeveloperPanel(SettingsWindow *parent) : ListWidget(parent) {
   addItem(longManeuverToggle);
 
   // Joystick and longitudinal maneuvers should be hidden on release branches
-  // also the toggles should be not available to change in onroad state
   const bool is_release = params.getBool("IsReleaseBranch");
+  for (auto btn : findChildren<ParamControl *>()) {
+    btn->setVisible(!is_release);
+  }
+
+  // Toggles should be not available to change in onroad state
   QObject::connect(uiState(), &UIState::offroadTransition, [=](bool offroad) {
     for (auto btn : findChildren<ParamControl *>()) {
-      btn->setVisible(!is_release);
       btn->setEnabled(offroad);
     }
   });
+}
 
+void DeveloperPanel::updateToggles() {
+  auto cp_bytes = params.get("CarParamsPersistent");
+  if (!cp_bytes.empty()) {
+    AlignedBuffer aligned_buf;
+    capnp::FlatArrayMessageReader cmsg(aligned_buf.align(cp_bytes.data(), cp_bytes.size()));
+    cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
+
+    // longManeuverToggle should not be toggable if the car don't have longitudinal control
+    if (hasLongitudinalControl(CP)) {
+      longManeuverToggle->setEnabled(true);
+    }
+  } else {
+    longManeuverToggle->setEnabled(false);
+  }
+}
+
+void DeveloperPanel::showEvent(QShowEvent *event) {
+  updateToggles();
 }

--- a/selfdrive/ui/qt/offroad/developer_panel.cc
+++ b/selfdrive/ui/qt/offroad/developer_panel.cc
@@ -31,10 +31,10 @@ DeveloperPanel::DeveloperPanel(SettingsWindow *parent) : ListWidget(parent) {
   QObject::connect(uiState(), &UIState::offroadTransition, this, &DeveloperPanel::updateToggles);
 }
 
-void DeveloperPanel::updateToggles(bool offroad) {
+void DeveloperPanel::updateToggles(bool _offroad) {
   for (auto btn : findChildren<ParamControl *>()) {
     btn->setVisible(!is_release);
-    btn->setEnabled(offroad);
+    btn->setEnabled(_offroad);
   }
 
   // longManeuverToggle should not be toggleable if the car don't have longitudinal control
@@ -43,8 +43,14 @@ void DeveloperPanel::updateToggles(bool offroad) {
     AlignedBuffer aligned_buf;
     capnp::FlatArrayMessageReader cmsg(aligned_buf.align(cp_bytes.data(), cp_bytes.size()));
     cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
-    longManeuverToggle->setEnabled(hasLongitudinalControl(CP) && offroad);
+    longManeuverToggle->setEnabled(hasLongitudinalControl(CP) && _offroad);
   } else {
     longManeuverToggle->setEnabled(false);
   }
+
+  offroad = _offroad;
+}
+
+void DeveloperPanel::showEvent(QShowEvent *event) {
+  updateToggles(offroad);
 }

--- a/selfdrive/ui/qt/offroad/developer_panel.h
+++ b/selfdrive/ui/qt/offroad/developer_panel.h
@@ -6,9 +6,12 @@ class DeveloperPanel : public ListWidget {
   Q_OBJECT
 public:
   explicit DeveloperPanel(SettingsWindow *parent);
+  void showEvent(QShowEvent *event) override;
 
 private:
   Params params;
   ParamControl* joystickToggle;
   ParamControl* longManeuverToggle;
+
+  void updateToggles();
 };

--- a/selfdrive/ui/qt/offroad/developer_panel.h
+++ b/selfdrive/ui/qt/offroad/developer_panel.h
@@ -6,13 +6,15 @@ class DeveloperPanel : public ListWidget {
   Q_OBJECT
 public:
   explicit DeveloperPanel(SettingsWindow *parent);
+  void showEvent(QShowEvent *event) override;
 
 private:
   Params params;
   ParamControl* joystickToggle;
   ParamControl* longManeuverToggle;
   bool is_release;
+  bool offroad;
 
 private slots:
-  void updateToggles(bool offroad);
+  void updateToggles(bool _offroad);
 };

--- a/selfdrive/ui/qt/offroad/developer_panel.h
+++ b/selfdrive/ui/qt/offroad/developer_panel.h
@@ -6,12 +6,13 @@ class DeveloperPanel : public ListWidget {
   Q_OBJECT
 public:
   explicit DeveloperPanel(SettingsWindow *parent);
-  void showEvent(QShowEvent *event) override;
 
 private:
   Params params;
   ParamControl* joystickToggle;
   ParamControl* longManeuverToggle;
+  bool is_release;
 
-  void updateToggles();
+private slots:
+  void updateToggles(bool offroad);
 };


### PR DESCRIPTION
Fix two design errors in the developerPanel:
1 - the non release toggles would only disappear after ignition on the release branch;
2 - cars without longitudinal control could activate longitudinal maneuvers.