### PR TITLE
interfaces: Stock Longitudinal: Prevent disengagement on release of cancel button

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -215,7 +215,7 @@ class CarSpecificEvents:
       if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed):
         events.add(EventName.buttonEnable)
       # Disable on rising and falling edge of cancel for both stock and OP long
-      if b.type == ButtonType.cancel:
+      if b.type == ButtonType.cancel and ((self.CP.pcmCruise and b.pressed) or not self.CP.pcmCruise):
         events.add(EventName.buttonCancel)
 
     # Handle permanent and temporary steering faults


### PR DESCRIPTION
**Description**

- **Currently, we are unable to use the PAUSE/RESUME button to re-engage openpilot due to a breaking change introduced in https://github.com/commaai/opendbc/pull/1326, which affects Hyundai/Kia/Genesis models using stock longitudinal control**
- For some newer model years of Hyundai/Kia/Genesis cars using stock longitudinal control, the `CANCEL` button acts as a `PAUSE/RESUME` based on PCM state.
- Button events for Hyundai are now published continuously, leading to unintended disengagement on CANCEL button release.

**Change**
- For stock longitudinal control, the `buttonCancel` event now only triggers on the rising edge (button press) of the CANCEL button.
- openpilot longitudinal control continues to trigger `buttonCancel` on both press and release.

**Verification**

1. Disable openpilot longitudinal control, then start the car.
2. Engage openpilot by pressing the CRUISE MAIN button.
3. Cancel openpilot by pressing then releasing the PAUSE/RESUME button.
4. Resume openpilot by pressing then releasing the PAUSE/RESUME button.
5. Verify step 4 that openpilot stays engaged after the PAUSE/RESUME button is released.

**Route**

Route: `2bbe12792a30f61f/0000048c--f94b4ede96`