### PR TITLE
Make SimulatorBridge picklable (MacOS support)

### DIFF
--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -36,11 +36,16 @@ class UnknownKeyName(Exception):
 
 cdef class Params:
   cdef c_Params* p
+  cdef str d
 
   def __cinit__(self, d=""):
     cdef string path = <string>d.encode()
     with nogil:
       self.p = new c_Params(path)
+    self.d = d
+
+  def __reduce__(self):
+    return (type(self), (self.d,))
 
   def __dealloc__(self):
     del self.p

--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -52,7 +52,6 @@ class SimulatorBridge(ABC):
     self._keep_alive = True
     self.started = Value('i', False)
     signal.signal(signal.SIGTERM, self._on_shutdown)
-    self._exit = threading.Event()
     self.simulator_state = SimulatorState()
 
     self.world: World | None = None

--- a/tools/sim/bridge/common.py
+++ b/tools/sim/bridge/common.py
@@ -47,7 +47,7 @@ class SimulatorBridge(ABC):
     self.dual_camera = dual_camera
     self.high_quality = high_quality
 
-    self._exit_event = threading.Event()
+    self._exit_event: threading.Event | None = None
     self._threads = []
     self._keep_alive = True
     self.started = Value('i', False)
@@ -75,7 +75,9 @@ class SimulatorBridge(ABC):
 
   def close(self, reason):
     self.started.value = False
-    self._exit_event.set()
+
+    if self._exit_event is not None:
+      self._exit_event.set()
 
     if self.world is not None:
       self.world.close(reason)
@@ -101,6 +103,8 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
 
     self.simulated_car = SimulatedCar()
     self.simulated_sensors = SimulatedSensors(self.dual_camera)
+
+    self._exit_event = threading.Event()
 
     self.simulated_car_thread = threading.Thread(target=rk_loop, args=(functools.partial(self.simulated_car.update, self.simulator_state),
                                                                         100, self._exit_event))


### PR DESCRIPTION
**Description**

Required for https://github.com/commaai/openpilot/issues/33207

Makes instances of `SimulatorBridge` (in `tools/sim/bridge/common.py`) picklable.

Required since Python multiprocessing now [defaults to spawn on MacOS](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) (with [good reason](https://github.com/python/cpython/issues/77906)).

**Verification**

Ran `python tools/sim/run_bridge.py` on Mac (did not verify on Ubuntu).
