### PR TITLE
cabana: fix route load error handing

### DIFF
--- a/tools/cabana/streams/replaystream.cc
+++ b/tools/cabana/streams/replaystream.cc
@@ -62,7 +62,7 @@ bool ReplayStream::loadRoute(const QString &route, const QString &data_dir, uint
   QObject::connect(replay.get(), &Replay::segmentsMerged, this, &ReplayStream::mergeSegments);
   bool success = replay->load();
   if (!success) {
-    if (replay->lastRouteError() == RouteLoadError::AccessDenied) {
+    if (replay->lastRouteError() == RouteLoadError::Unauthorized) {
       auto auth_content = util::read_file(util::getenv("HOME") + "/.comma/auth.json");
       QString message;
       if (auth_content.empty()) {


### PR DESCRIPTION
The replay now uses `Unauthorized` for access denial, breaking Cabana's error handling. This PR fixes the issue to handle unauthorized access correctly.