### PR TITLE
Enable OP w/ brakeHold active

### DIFF
--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -635,7 +635,11 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
  #Changing this allow brakehold active to resume OP w/ Standstill still showing?
   EventName.brakeHold: {
     ET.ENABLE: EngagementAlert(AudibleAlert.engage),
-   # ET.NO_ENTRY: NoEntryAlert("Brake Hold Active"),
+    ET.WARNING: Alert (
+      "Press Resume to Exit Standstill",
+      "",
+      AlertStatus.userPrompt, AlertSize.small,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, .2),
   },
 
   EventName.parkBrake: {

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -632,10 +632,10 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.USER_DISABLE: EngagementAlert(AudibleAlert.disengage),
     ET.NO_ENTRY: NoEntryAlert("Cancel Pressed"),
   },
-
+ #Changing this allow brakehold active to resume OP w/ Standstill still showing?
   EventName.brakeHold: {
-    ET.USER_DISABLE: EngagementAlert(AudibleAlert.disengage),
-    ET.NO_ENTRY: NoEntryAlert("Brake Hold Active"),
+    ET.ENABLE: EngagementAlert(AudibleAlert.engage),
+   # ET.NO_ENTRY: NoEntryAlert("Brake Hold Active"),
   },
 
   EventName.parkBrake: {


### PR DESCRIPTION
Following EventName.resumeRequired "Press Resume to Exit Standstill"

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for
Toyota, and various others 

**Route**
A route with the fingerprint
TBD 

-->

<!--- ***** Template: Car Bugfix *****

**Description**
Attempting to allow OP with brakeHold active. 
A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 
Edits to event.py relating to the alert for brakeHold
**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

