### PR TITLE
Dont check for socketcan when not available

### DIFF
--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
       qWarning() << e.what();
       return 0;
     }
-  } else if (cmd_parser.isSet("socketcan")) {
+  } else if (SocketCanStream::available() && cmd_parser.isSet("socketcan")) {
     stream = new SocketCanStream(&app, {.device = cmd_parser.value("socketcan")});
   } else {
     uint32_t replay_flags = REPLAY_FLAG_NONE;


### PR DESCRIPTION
**Description**

Not a huge value PR I know but helps me get started.

Closes https://github.com/commaai/openpilot/issues/34038

**Verification**

Run:
```bash
./tools/cabana/cabana
```
