### PR TITLE
test_qcomgpsd: let qcomgpsd delete the assistance

### DIFF
--- a/system/qcomgpsd/tests/test_qcomgpsd.py
+++ b/system/qcomgpsd/tests/test_qcomgpsd.py
@@ -27,7 +27,7 @@ class TestRawgpsd:
     os.system("sudo systemctl restart ModemManager lte")
 
   def setup_method(self):
-    at_cmd("AT+QGPSDEL=0")
+    os.environ['GPS_COLD_START'] = '1'
     self.sm = messaging.SubMaster(['qcomGnss', 'gpsLocation', 'gnssMeasurements'])
 
   def teardown_method(self):

--- a/system/qcomgpsd/tests/test_qcomgpsd.py
+++ b/system/qcomgpsd/tests/test_qcomgpsd.py
@@ -16,6 +16,7 @@ GOOD_SIGNAL = bool(int(os.getenv("GOOD_SIGNAL", '0')))
 class TestRawgpsd:
   @classmethod
   def setup_class(cls):
+    os.environ['GPS_COLD_START'] = '1'
     os.system("sudo systemctl start systemd-resolved")
     os.system("sudo systemctl restart ModemManager lte")
     wait_for_modem()
@@ -27,7 +28,6 @@ class TestRawgpsd:
     os.system("sudo systemctl restart ModemManager lte")
 
   def setup_method(self):
-    os.environ['GPS_COLD_START'] = '1'
     self.sm = messaging.SubMaster(['qcomGnss', 'gpsLocation', 'gnssMeasurements'])
 
   def teardown_method(self):


### PR DESCRIPTION
Deleting the assistance (`AT+QGPSDEL=0`) will fail if the GNSS is on.  `qcomgpsd` handles that when starting. We still enforce the same behavior of a cold start (deletetype 0) by setting `GPS_COLD_START`