### PR TITLE
pandad: fix return value in spi_transfer

### DIFF
--- a/selfdrive/pandad/spi.cc
+++ b/selfdrive/pandad/spi.cc
@@ -418,7 +418,7 @@ fail:
     }
   }
 
-  if (ret > 0) ret = -1;
+  if (ret >= 0) ret = -1;
   return ret;
 }
 #endif


### PR DESCRIPTION
Currently, if the `rx_buf` checksum fails or `rx_data_len >= SPI_BUF_SIZE`, we still return 0