### PR TITLE
athenad: fix thread safety issues in upload handing

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -99,9 +99,12 @@ send_queue: Queue[str] = queue.Queue()
 upload_queue: Queue[UploadItem] = queue.Queue()
 low_priority_send_queue: Queue[str] = queue.Queue()
 log_recv_queue: Queue[str] = queue.Queue()
+
 cancelled_uploads: set[str] = set()
+cancelled_uploads_lock = threading.Lock()
 
 cur_upload_items: dict[int, UploadItem | None] = {}
+cur_upload_items_lock = threading.Lock()
 
 
 def strip_zst_extension(fn: str) -> str:
@@ -129,8 +132,12 @@ class UploadQueueCache:
   @staticmethod
   def cache(upload_queue: Queue[UploadItem]) -> None:
     try:
-      queue: list[UploadItem | None] = list(upload_queue.queue)
-      items = [asdict(i) for i in queue if i is not None and (i.id not in cancelled_uploads)]
+      with upload_queue.mutex:
+        queue: list[UploadItem | None] = list(upload_queue.queue)
+
+      with cancelled_uploads_lock:
+        items = [asdict(i) for i in queue if i is not None and (i.id not in cancelled_uploads)]
+
       Params().put("AthenadUploadQueue", json.dumps(items))
     except Exception:
       cloudlog.exception("athena.UploadQueueCache.cache.exception")
@@ -187,7 +194,9 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
 
 
 def retry_upload(tid: int, end_event: threading.Event, increase_count: bool = True) -> None:
-  item = cur_upload_items[tid]
+  with cur_upload_items_lock:
+    item = cur_upload_items[tid]
+
   if item is not None and item.retry_count < MAX_RETRY_COUNT:
     new_retry_count = item.retry_count + 1 if increase_count else item.retry_count
 
@@ -200,7 +209,8 @@ def retry_upload(tid: int, end_event: threading.Event, increase_count: bool = Tr
     upload_queue.put_nowait(item)
     UploadQueueCache.cache(upload_queue)
 
-    cur_upload_items[tid] = None
+    with cur_upload_items_lock:
+      cur_upload_items[tid] = None
 
     for _ in range(RETRY_DELAY):
       time.sleep(1)
@@ -219,7 +229,8 @@ def cb(sm, item, tid, end_event: threading.Event, sz: int, cur: int) -> None:
   if end_event.is_set():
     raise AbortTransferException
 
-  cur_upload_items[tid] = replace(item, progress=cur / sz if sz else 1)
+  with cur_upload_items_lock:
+    cur_upload_items[tid] = replace(item, progress=cur / sz if sz else 1)
 
 
 def upload_handler(end_event: threading.Event) -> None:
@@ -227,14 +238,15 @@ def upload_handler(end_event: threading.Event) -> None:
   tid = threading.get_ident()
 
   while not end_event.is_set():
-    cur_upload_items[tid] = None
-
     try:
-      cur_upload_items[tid] = item = replace(upload_queue.get(timeout=1), current=True)
+      with cur_upload_items_lock:
+        cur_upload_items[tid] = None
+        cur_upload_items[tid] = item = replace(upload_queue.get(timeout=1), current=True)
 
-      if item.id in cancelled_uploads:
-        cancelled_uploads.remove(item.id)
-        continue
+      with cancelled_uploads_lock:
+        if item.id in cancelled_uploads:
+          cancelled_uploads.remove(item.id)
+          continue
 
       # Remove item if too old
       age = datetime.now() - datetime.fromtimestamp(item.created_at / 1000)
@@ -413,8 +425,14 @@ def uploadFilesToUrls(files_data: list[UploadFileDict]) -> UploadFilesToUrlRespo
 
 @dispatcher.add_method
 def listUploadQueue() -> list[UploadItemDict]:
-  items = list(upload_queue.queue) + list(cur_upload_items.values())
-  return [asdict(i) for i in items if (i is not None) and (i.id not in cancelled_uploads)]
+  with upload_queue.mutex:
+    items = list(upload_queue.queue)
+
+  with cur_upload_items_lock:
+    items += list(cur_upload_items.values())
+
+  with cancelled_uploads_lock:
+    return [asdict(i) for i in items if (i is not None) and (i.id not in cancelled_uploads)]
 
 
 @dispatcher.add_method
@@ -422,12 +440,16 @@ def cancelUpload(upload_id: str | list[str]) -> dict[str, int | str]:
   if not isinstance(upload_id, list):
     upload_id = [upload_id]
 
-  uploading_ids = {item.id for item in list(upload_queue.queue)}
+  with upload_queue.mutex:
+    uploading_ids = {item.id for item in list(upload_queue.queue)}
+
   cancelled_ids = uploading_ids.intersection(upload_id)
   if len(cancelled_ids) == 0:
     return {"success": 0, "error": "not found"}
 
-  cancelled_uploads.update(cancelled_ids)
+  with cancelled_uploads_lock:
+    cancelled_uploads.update(cancelled_ids)
+
   return {"success": 1}
 
 @dispatcher.add_method

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -100,9 +100,6 @@ upload_queue: Queue[UploadItem] = queue.Queue()
 low_priority_send_queue: Queue[str] = queue.Queue()
 log_recv_queue: Queue[str] = queue.Queue()
 
-cancelled_uploads: set[str] = set()
-cancelled_uploads_lock = threading.Lock()
-
 cur_upload_items: dict[int, UploadItem | None] = {}
 cur_upload_items_lock = threading.Lock()
 
@@ -133,10 +130,7 @@ class UploadQueueCache:
   def cache(upload_queue: Queue[UploadItem]) -> None:
     try:
       with upload_queue.mutex:
-        queue: list[UploadItem | None] = list(upload_queue.queue)
-
-      with cancelled_uploads_lock:
-        items = [asdict(i) for i in queue if i is not None and (i.id not in cancelled_uploads)]
+        items = [asdict(item) for item in upload_queue.queue]
 
       Params().put("AthenadUploadQueue", json.dumps(items))
     except Exception:
@@ -194,9 +188,7 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
 
 
 def retry_upload(tid: int, end_event: threading.Event, increase_count: bool = True) -> None:
-  with cur_upload_items_lock:
-    item = cur_upload_items[tid]
-
+  item = cur_upload_items[tid]
   if item is not None and item.retry_count < MAX_RETRY_COUNT:
     new_retry_count = item.retry_count + 1 if increase_count else item.retry_count
 
@@ -242,11 +234,6 @@ def upload_handler(end_event: threading.Event) -> None:
       with cur_upload_items_lock:
         cur_upload_items[tid] = None
         cur_upload_items[tid] = item = replace(upload_queue.get(timeout=1), current=True)
-
-      with cancelled_uploads_lock:
-        if item.id in cancelled_uploads:
-          cancelled_uploads.remove(item.id)
-          continue
 
       # Remove item if too old
       age = datetime.now() - datetime.fromtimestamp(item.created_at / 1000)
@@ -431,8 +418,7 @@ def listUploadQueue() -> list[UploadItemDict]:
   with cur_upload_items_lock:
     items += list(cur_upload_items.values())
 
-  with cancelled_uploads_lock:
-    return [asdict(i) for i in items if (i is not None) and (i.id not in cancelled_uploads)]
+  return [asdict(item) for item in items]
 
 
 @dispatcher.add_method
@@ -441,16 +427,13 @@ def cancelUpload(upload_id: str | list[str]) -> dict[str, int | str]:
     upload_id = [upload_id]
 
   with upload_queue.mutex:
-    uploading_ids = {item.id for item in list(upload_queue.queue)}
+    remaining_items = [item for item in upload_queue.queue if item.id not in upload_id]
+    if len(remaining_items) == len(upload_queue.queue):
+      return {"success": 0, "error": "not found"}
 
-  cancelled_ids = uploading_ids.intersection(upload_id)
-  if len(cancelled_ids) == 0:
-    return {"success": 0, "error": "not found"}
-
-  with cancelled_uploads_lock:
-    cancelled_uploads.update(cancelled_ids)
-
-  return {"success": 1}
+    upload_queue.queue.clear()
+    upload_queue.queue.extend(remaining_items)
+    return {"success": 1}
 
 @dispatcher.add_method
 def setRouteViewed(route: str) -> dict[str, int | str]:

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -78,7 +78,6 @@ class TestAthenadMethods:
 
     athenad.upload_queue = queue.Queue()
     athenad.cur_upload_items.clear()
-    athenad.cancelled_uploads.clear()
 
     for i in os.listdir(Paths.log_root()):
       p = os.path.join(Paths.log_root(), i)
@@ -282,13 +281,10 @@ class TestAthenadMethods:
     athenad.upload_queue.put_nowait(item)
     dispatcher["cancelUpload"](item.id)
 
-    assert item.id in athenad.cancelled_uploads
-
     self._wait_for_upload()
     time.sleep(0.1)
 
     assert athenad.upload_queue.qsize() == 0
-    assert len(athenad.cancelled_uploads) == 0
 
   @with_upload_handler
   def test_cancel_expiry(self):
@@ -331,7 +327,7 @@ class TestAthenadMethods:
     assert items[0] == asdict(item)
     assert not items[0]['current']
 
-    athenad.cancelled_uploads.add(item.id)
+    dispatcher["cancelUpload"](item.id)
     items = dispatcher["listUploadQueue"]()
     assert len(items) == 0
 
@@ -343,7 +339,7 @@ class TestAthenadMethods:
     athenad.upload_queue.put_nowait(item2)
 
     # Ensure canceled items are not persisted
-    athenad.cancelled_uploads.add(item2.id)
+    dispatcher["cancelUpload"](item2.id)
 
     # serialize item
     athenad.UploadQueueCache.cache(athenad.upload_queue)


### PR DESCRIPTION
This PR addresses thread safety issues by adding synchronization for shared variables, which previously led to race conditions and data inconsistencies. The updates enhance data integrity and system stability.

1. **Simplified Queue Management:**  Removed `cancelled_uploads`. Canceled items are now directly removed from `upload_queue` in the `cancelUpload` function, reducing complexity and ensuring consistent synchronization.
2. **Thread-Safe Access:**    Direct access to `upload_queue.queue` bypassed the Queue’s synchronization. This update ensures thread-safe access by using the `mutex` lock provided by the Queue, preventing race conditions.
3. **Mutex Protection for cur_upload_items**: Ensured safe access with a mutex for `cur_upload_items`.


