### PR TITLE
athenad: close websocket before starting next loop iteration

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -801,6 +801,8 @@ def main(exit_event: threading.Event = None):
       cur_upload_items.clear()
 
       handle_long_poll(ws, exit_event)
+
+      ws.close()
     except (KeyboardInterrupt, SystemExit):
       break
     except (ConnectionError, TimeoutError, WebSocketException):


### PR DESCRIPTION
adds a `ws.close() `call to ensure the WebSocket is properly closed after handle_long_poll and before the next loop iteration. ensuring proper resource management. 