### PR TITLE
LogReader: fix issue when your dns resolves all requests

### DIFF
--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -5,12 +5,14 @@ from urllib.parse import urlparse
 from openpilot.tools.lib.url_file import URLFile
 
 DATA_ENDPOINT = os.getenv("DATA_ENDPOINT", "http://data-raw.comma.internal/")
-
+LOCAL_IPS = ["10.", "192.168.", *[f"172.{i}" for i in range(16, 32)]]
 
 def internal_source_available(url=DATA_ENDPOINT):
   try:
     hostname = urlparse(url).hostname
     port = urlparse(url).port or 80
+    if not socket.gethostbyname(hostname).startswith(LOCAL_IPS):
+      return False
     with socket.socket(socket.AF_INET,socket.SOCK_STREAM) as s:
       s.settimeout(0.5)
       s.connect((hostname, port))

--- a/tools/lib/filereader.py
+++ b/tools/lib/filereader.py
@@ -7,6 +7,7 @@ from openpilot.tools.lib.url_file import URLFile
 DATA_ENDPOINT = os.getenv("DATA_ENDPOINT", "http://data-raw.comma.internal/")
 LOCAL_IPS = ["10.", "192.168.", *[f"172.{i}" for i in range(16, 32)]]
 
+
 def internal_source_available(url=DATA_ENDPOINT):
   try:
     hostname = urlparse(url).hostname


### PR DESCRIPTION
my AT&T internet provider default DNS has this terrible system where a missed DNS query will resolve to their server and perform a search for you. This is probably common for other providers as well
![image](https://github.com/user-attachments/assets/3273dc87-bbeb-401e-8aa7-2a7fd8142f2e)



This means that `data-raw.comma.internal` will resolve to this IP and also pass the `socket.connect` test, so LogReader tries to use the internal source and fails.
![image](https://github.com/user-attachments/assets/512b97f6-ef2a-43ab-89c9-34deea1f58e8)



This PR solves my issue by ensuring that the IP is a non-internet (i.e. one of the reserved local ips)
![image](https://github.com/user-attachments/assets/926126dd-a228-4e13-8736-3c055f6d3a5d)


There is likely a better solution to this, maybe just hardcoding the IP that comma uses for the internal data endpoint
