### PR TITLE
Disabling athenad on PC

### DIFF
--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -61,7 +61,7 @@ def and_(*fns):
   return lambda *args: operator.and_(*(fn(*args) for fn in fns))
 
 procs = [
-  DaemonProcess("manage_athenad", "system.athena.manage_athenad", "AthenadPid"),
+  DaemonProcess("manage_athenad", "system.athena.manage_athenad", "AthenadPid", enabled=not PC),
 
   NativeProcess("camerad", "system/camerad", ["./camerad"], driverview),
   NativeProcess("logcatd", "system/logcatd", ["./logcatd"], only_onroad),


### PR DESCRIPTION
**Description**

Disabling athenad when running on PC as it uncontrollably starts spawning processes.
This was observed on a mac but I believe this would happen with any PC that doesn't have device keys on it.

**Verification**

Been making this modification every time locally to avoid my computer running out of resources 



