### PR TITLE
macos: use /tmp instead of /dev/shm

### DIFF
--- a/cereal/messaging/tests/test_services.py
+++ b/cereal/messaging/tests/test_services.py
@@ -17,5 +17,5 @@ class TestServices:
 
   def test_generated_header(self):
     with tempfile.NamedTemporaryFile(suffix=".h") as f:
-      ret = os.system(f"python3 {services.__file__} > {f.name} && clang++ {f.name}")
+      ret = os.system(f"python3 {services.__file__} > {f.name} && clang++ {f.name} -std=c++11")
       assert ret == 0, "generated services header is not valid C"

--- a/common/prefix.h
+++ b/common/prefix.h
@@ -13,7 +13,7 @@ public:
     if (prefix.empty()) {
       prefix = util::random_string(15);
     }
-    msgq_path = "/dev/shm/" + prefix;
+    msgq_path = Path::shm_path() + "/" + prefix;
     bool ret = util::create_directories(msgq_path, 0777);
     assert(ret);
     setenv("OPENPILOT_PREFIX", prefix.c_str(), 1);

--- a/common/prefix.py
+++ b/common/prefix.py
@@ -11,7 +11,7 @@ from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
 class OpenpilotPrefix:
   def __init__(self, prefix: str = None, clean_dirs_on_exit: bool = True, shared_download_cache: bool = False):
     self.prefix = prefix if prefix else str(uuid.uuid4().hex[0:15])
-    self.msgq_path = os.path.join('/dev/shm', self.prefix)
+    self.msgq_path = os.path.join(Paths.shm_path(), self.prefix)
     self.clean_dirs_on_exit = clean_dirs_on_exit
     self.shared_download_cache = shared_download_cache
 

--- a/common/watchdog.cc
+++ b/common/watchdog.cc
@@ -2,8 +2,9 @@
 
 #include "common/watchdog.h"
 #include "common/util.h"
+#include "system/hardware/hw.h"
 
-const std::string watchdog_fn_prefix = "/dev/shm/wd_";  // + <pid>
+const std::string watchdog_fn_prefix = Path::shm_path() + "/wd_";  // + <pid>
 
 bool watchdog_kick(uint64_t ts) {
   static std::string fn = watchdog_fn_prefix + std::to_string(getpid());

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -12,6 +12,7 @@ from typing import Any
 from collections.abc import Callable, Iterable
 from tqdm import tqdm
 import capnp
+from openpilot.system.hardware.hw import Paths
 
 import cereal.messaging as messaging
 from cereal import car
@@ -780,8 +781,7 @@ def generate_params_config(lr=None, CP=None, fingerprint=None, custom_params=Non
 
 def generate_environ_config(CP=None, fingerprint=None, log_dir=None) -> dict[str, Any]:
   environ_dict = {}
-  if platform.system() != "Darwin":
-    environ_dict["PARAMS_ROOT"] = "/dev/shm/params"
+  environ_dict["PARAMS_ROOT"] = f"${Paths.shm_path()}/params"
   if log_dir is not None:
     environ_dict["LOG_ROOT"] = log_dir
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -5,7 +5,6 @@ import copy
 import json
 import heapq
 import signal
-import platform
 from collections import Counter, OrderedDict
 from dataclasses import dataclass, field
 from typing import Any
@@ -781,7 +780,7 @@ def generate_params_config(lr=None, CP=None, fingerprint=None, custom_params=Non
 
 def generate_environ_config(CP=None, fingerprint=None, log_dir=None) -> dict[str, Any]:
   environ_dict = {}
-  environ_dict["PARAMS_ROOT"] = f"${Paths.shm_path()}/params"
+  environ_dict["PARAMS_ROOT"] = f"{Paths.shm_path()}/params"
   if log_dir is not None:
     environ_dict["LOG_ROOT"] = log_dir
 

--- a/system/hardware/hw.h
+++ b/system/hardware/hw.h
@@ -49,6 +49,10 @@ namespace Path {
   }
 
  inline std::string shm_path() {
-   return #ifdef __APPLE__ ? "/tmp" : "/dev/shm";
+    #ifdef __APPLE__
+     return"/tmp"
+    #else
+     return "/dev/shm";
+    #endif
  }
 }  // namespace Path

--- a/system/hardware/hw.h
+++ b/system/hardware/hw.h
@@ -50,7 +50,7 @@ namespace Path {
 
  inline std::string shm_path() {
     #ifdef __APPLE__
-     return"/tmp"
+     return"/tmp";
     #else
      return "/dev/shm";
     #endif

--- a/system/hardware/hw.h
+++ b/system/hardware/hw.h
@@ -47,4 +47,8 @@ namespace Path {
     }
     return "/tmp/comma_download_cache" + Path::openpilot_prefix() + "/";
   }
+
+ inline std::string shm_path() {
+   return #ifdef __APPLE__ ? "/tmp" : "/dev/shm";
+ }
 }  // namespace Path

--- a/system/hardware/hw.py
+++ b/system/hardware/hw.py
@@ -61,5 +61,5 @@ class Paths:
   @staticmethod
   def shm_path() -> str:
     if PC and platform.system() == "Darwin":
-      return f"/tmp"  # This is not really shared memory on macOS, but it's the closest we can get
+      return "/tmp"  # This is not really shared memory on macOS, but it's the closest we can get
     return "/dev/shm"

--- a/system/hardware/hw.py
+++ b/system/hardware/hw.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from pathlib import Path
 
 from openpilot.system.hardware import PC
@@ -56,3 +57,9 @@ class Paths:
       return Paths.comma_home()
     else:
       return "/tmp/.comma"
+
+  @staticmethod
+  def shm_path() -> str:
+    if PC and platform.system() == "Darwin":
+      return f"/tmp"  # This is not really shared memory on macOS, but it's the closest we can get
+    return "/dev/shm"

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -17,7 +17,7 @@ from openpilot.system.manager.process_config import managed_processes
 from openpilot.system.athena.registration import register, UNREGISTERED_DONGLE_ID
 from openpilot.common.swaglog import cloudlog, add_file_handler
 from openpilot.system.version import get_build_metadata, terms_version, training_version
-
+from openpilot.system.hardware.hw import Paths
 
 
 def manager_init() -> None:
@@ -52,11 +52,11 @@ def manager_init() -> None:
 
   # Create folders needed for msgq
   try:
-    os.mkdir("/dev/shm")
+    os.mkdir(Paths.shm_path())
   except FileExistsError:
     pass
   except PermissionError:
-    print("WARNING: failed to make /dev/shm")
+    print(f"WARNING: failed to make {Paths.shm_path()}")
 
   # set version params
   params.put("Version", build_metadata.openpilot.version)

--- a/system/manager/process.py
+++ b/system/manager/process.py
@@ -18,7 +18,7 @@ from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.hw import Paths
 
-WATCHDOG_FN = f"${Paths.shm_path()}/wd_"
+WATCHDOG_FN = f"{Paths.shm_path()}/wd_"
 ENABLE_WATCHDOG = os.getenv("NO_WATCHDOG") is None
 
 

--- a/system/manager/process.py
+++ b/system/manager/process.py
@@ -16,8 +16,9 @@ import openpilot.system.sentry as sentry
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
+from openpilot.system.hardware.hw import Paths
 
-WATCHDOG_FN = "/dev/shm/wd_"
+WATCHDOG_FN = f"${Paths.shm_path()}/wd_"
 ENABLE_WATCHDOG = os.getenv("NO_WATCHDOG") is None
 
 


### PR DESCRIPTION
Some things (specially around tests) seem to rely on `/dev/shm` itself existing. `OPENPILOT_PREFIX` can't be used when ZMQ which is needed for macos... So  I thought it'd be better to just give a path for the "/dev/shm" on macos on /tmp which is the closest we can get to it

### This is **NOT** intended to bring msgq support into MacOS. 
It is only intended to allow a more graceful approach as things around still seem to rely indirectly on the path `/dev/shm` even though you are using ZMQ