### PR TITLE
athenad: explicitly delete socket in getMessage

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -309,13 +309,16 @@ def getMessage(service: str, timeout: int = 1000) -> dict:
     raise Exception("invalid service")
 
   socket = messaging.sub_sock(service, timeout=timeout)
-  ret = messaging.recv_one(socket)
+  try:
+    ret = messaging.recv_one(socket)
 
-  if ret is None:
-    raise TimeoutError
+    if ret is None:
+      raise TimeoutError
 
-  # this is because capnp._DynamicStructReader doesn't have typing information
-  return cast(dict, ret.to_dict())
+    # this is because capnp._DynamicStructReader doesn't have typing information
+    return cast(dict, ret.to_dict())
+  finally:
+    del socket
 
 
 @dispatcher.add_method


### PR DESCRIPTION
Explicit socket deletion ensures timely resource release, reducing the risk of leaks or resource exhaustion in the long-running, potentially high-load athenad process, where relying on delayed garbage collection could lead to issues.