### PR TITLE
athenad: move last_scan outside the loop

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -626,8 +626,9 @@ def log_handler(end_event: threading.Event) -> None:
 
 def stat_handler(end_event: threading.Event) -> None:
   STATS_DIR = Paths.stats_root()
+  last_scan = 0.0
+
   while not end_event.is_set():
-    last_scan = 0.
     curr_scan = time.monotonic()
     try:
       if curr_scan - last_scan > 10:


### PR DESCRIPTION
moves the `last_scan` variable outside of the loop in the `stat_handler` function to prevent it from being reset on each iteration.