### PR TITLE
Using carControl/enabled on PJ template

### DIFF
--- a/tools/plotjuggler/layouts/controls_mismatch_debug.xml
+++ b/tools/plotjuggler/layouts/controls_mismatch_debug.xml
@@ -8,7 +8,7 @@
       <plot style="Lines" flip_x="false" mode="TimeSeries" flip_y="false">
        <range top="1.025000" bottom="-0.025000" left="0.018309" right="59.674401"/>
        <limitY/>
-       <curve color="#1f77b4" name="/controlsState/enabled"/>
+       <curve color="#1f77b4" name="/carControl/enabled"/>
        <curve color="#d62728" name="/pandaStates/0/controlsAllowed"/>
       </plot>
      </DockArea>


### PR DESCRIPTION
**Description**

When using this template it would fail saying controlsState/enabled wasn't available

**Verification**

Open any recent route with PJ and you'll get the error.

