### PR TITLE
athenad: fix memory leak by closing Response objects

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -258,13 +258,16 @@ def upload_handler(end_event: threading.Event) -> None:
           sz = -1
 
         cloudlog.event("athena.upload_handler.upload_start", fn=fn, sz=sz, network_type=network_type, metered=metered, retry_count=item.retry_count)
-        response = _do_upload(item, partial(cb, sm, item, tid, end_event))
 
-        if response.status_code not in (200, 201, 401, 403, 412):
-          cloudlog.event("athena.upload_handler.retry", status_code=response.status_code, fn=fn, sz=sz, network_type=network_type, metered=metered)
-          retry_upload(tid, end_event)
-        else:
-          cloudlog.event("athena.upload_handler.success", fn=fn, sz=sz, network_type=network_type, metered=metered)
+        response = _do_upload(item, partial(cb, sm, item, tid, end_event))
+        try:
+          if response.status_code not in (200, 201, 401, 403, 412):
+            cloudlog.event("athena.upload_handler.retry", status_code=response.status_code, fn=fn, sz=sz, network_type=network_type, metered=metered)
+            retry_upload(tid, end_event)
+          else:
+            cloudlog.event("athena.upload_handler.success", fn=fn, sz=sz, network_type=network_type, metered=metered)
+        finally:
+          response.close()
 
         UploadQueueCache.cache(upload_queue)
       except (requests.exceptions.Timeout, requests.exceptions.ConnectionError, requests.exceptions.SSLError):

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -259,15 +259,12 @@ def upload_handler(end_event: threading.Event) -> None:
 
         cloudlog.event("athena.upload_handler.upload_start", fn=fn, sz=sz, network_type=network_type, metered=metered, retry_count=item.retry_count)
 
-        response = _do_upload(item, partial(cb, sm, item, tid, end_event))
-        try:
+        with _do_upload(item, partial(cb, sm, item, tid, end_event)) as response:
           if response.status_code not in (200, 201, 401, 403, 412):
             cloudlog.event("athena.upload_handler.retry", status_code=response.status_code, fn=fn, sz=sz, network_type=network_type, metered=metered)
             retry_upload(tid, end_event)
           else:
             cloudlog.event("athena.upload_handler.success", fn=fn, sz=sz, network_type=network_type, metered=metered)
-        finally:
-          response.close()
 
         UploadQueueCache.cache(upload_queue)
       except (requests.exceptions.Timeout, requests.exceptions.ConnectionError, requests.exceptions.SSLError):

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -240,7 +240,7 @@ class TestAthenadMethods:
   @with_upload_handler
   def test_upload_handler_retry(self, mocker, host, status, retry):
     mock_put = mocker.patch('requests.put')
-    mock_put.return_value.status_code = status
+    mock_put.return_value.__enter__.return_value.status_code = status
     fn = self._create_file('qlog.zst')
     item = athenad.UploadItem(path=fn, url=f"{host}/qlog.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True)
 


### PR DESCRIPTION
Fixes a common memory leak when using the requests library, where unclosed HTTP Response objects prevent garbage collection and cause memory leaks. if Response objects are not explicitly closed, requests retains references to them, causing resource exhaustion over time.

~Since we can't use a `with` statement due to `mock_put = mocker.patch('requests.put')` in `test_athenad.py,`  this fix explicitly closes the Response object after use.This ensures proper memory management and prevents resource exhaustion, particularly during large or repeated uploads.~

see https://github.com/psf/requests/issues/4601#issuecomment-603326738 for details

resolve: https://github.com/commaai/openpilot/issues/34079

Note: We should also review other areas where the requests library is used, such as the uploader, to ensure that Response objects are properly closed and to prevent potential memory leaks.