### PR TITLE
uploader: use context manager for response handling 

### DIFF
--- a/system/loggerd/tests/loggerd_tests_common.py
+++ b/system/loggerd/tests/loggerd_tests_common.py
@@ -33,6 +33,12 @@ class MockResponse:
     self.text = text
     self.status_code = status_code
 
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    pass
+
 class MockApi:
   def __init__(self, dongle_id):
     pass

--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -46,6 +46,12 @@ class FakeResponse:
     self.status_code = 200
     self.request = FakeRequest()
 
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    pass
+
 
 def get_directory_sort(d: str) -> list[str]:
   # ensure old format is sorted sooner

--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -148,14 +148,14 @@ class Uploader:
     return None
 
   def do_upload(self, key: str, fn: str):
-    url_resp = self.api.get("v1.4/" + self.dongle_id + "/upload_url/", timeout=10, path=key, access_token=self.api.get_token())
-    if url_resp.status_code == 412:
-      return url_resp
+    with self.api.get("v1.4/" + self.dongle_id + "/upload_url/", timeout=10, path=key, access_token=self.api.get_token()) as url_resp:
+      if url_resp.status_code == 412:
+        return url_resp
 
-    url_resp_json = json.loads(url_resp.text)
-    url = url_resp_json['url']
-    headers = url_resp_json['headers']
-    cloudlog.debug("upload_url v1.4 %s %s", url, str(headers))
+      url_resp_json = json.loads(url_resp.text)
+      url = url_resp_json['url']
+      headers = url_resp_json['headers']
+      cloudlog.debug("upload_url v1.4 %s %s", url, str(headers))
 
     if fake_upload:
       return FakeResponse()


### PR DESCRIPTION
1. auto-close Response using `with`
2. add `__enter__` and `__exit__` to `FakeResponse` and `MockResponse`,  to support the new `with` usage.
