### PR TITLE
cabana: introduce `OneShotHttpRequest` to prevent concurrent HTTP requests

### DIFF
--- a/tools/cabana/streams/routes.h
+++ b/tools/cabana/streams/routes.h
@@ -6,15 +6,15 @@
 #include "selfdrive/ui/qt/api.h"
 
 class RouteListWidget;
+class OneShotHttpRequest;
 
 class RoutesDialog : public QDialog {
   Q_OBJECT
 public:
   RoutesDialog(QWidget *parent);
-  QString route() const { return route_; }
+  QString route();
 
 protected:
-  void accept() override;
   void parseDeviceList(const QString &json, bool success, QNetworkReply::NetworkError err);
   void parseRouteList(const QString &json, bool success, QNetworkReply::NetworkError err);
   void fetchRoutes();
@@ -22,5 +22,5 @@ protected:
   QComboBox *device_list_;
   QComboBox *period_selector_;
   RouteListWidget *route_list_;
-  QString route_;
+  OneShotHttpRequest *route_requester_;
 };


### PR DESCRIPTION
Cabana relies on the `HttpRequest` class from` selfdrive/ui/qt/api.h` to retrieve the remote route list.  but the current implementation lacks a method to abort ongoing HTTP requests. This limitation can lead to concurrent requests being sent when fetching the route list, resulting in wasted resources and potentially incorrect data being returned due to overlapping responses.

This PR introduces the `OneShotHttpRequest` class, a subclass of `HttpRequest`, designed to handle single-use HTTP requests. It ensures that any ongoing request is properly aborted and cleaned up before sending a new one. This solution prevents concurrent route list requests, optimizing resource usage and ensuring that the route list is accurately filled.