### PR TITLE
selfdrive/debug: fix broken check_can_parser_performance.py

### DIFF
--- a/selfdrive/debug/check_can_parser_performance.py
+++ b/selfdrive/debug/check_can_parser_performance.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     start_t = time.process_time_ns()
     for msg in msgs:
       can_list = can_capnp_to_list([msg])
-      for cp in tm.CI.can_parsers:
+      for cp in tm.CI.can_parsers.values():
         if cp is not None:
           cp.update_strings(can_list)
     ets.append((time.process_time_ns() - start_t) * 1e-6)


### PR DESCRIPTION
fixes the broken `check_can_parser_performance` which stopped working after PR [#335.](https://github.com/commaai/opendbc/pull/1470)