### PR TITLE
camerad: fix running AR0231 in single road cam mode

### DIFF
--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -69,9 +69,9 @@ public:
 };
 
 void CameraState::init(VisionIpcServer *v, cl_device_id device_id, cl_context ctx) {
-  if (!camera.enabled) return;
-
   camera.camera_open(v, device_id, ctx);
+
+  if (!camera.enabled) return;
 
   fl_pix = camera.cc.focal_len / camera.sensor->pixel_size_mm;
   set_exposure_rect();

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -264,11 +264,11 @@ int SpectraCamera::clear_req_queue() {
 }
 
 void SpectraCamera::camera_open(VisionIpcServer *v, cl_device_id device_id, cl_context ctx) {
-  if (!enabled) return;
-
   if (!openSensor()) {
     return;
   }
+
+  if (!enabled) return;
 
   // size is driven by all the HW that handles frames,
   // the video encoder has certain alignment requirements in this case


### PR DESCRIPTION
Strobe signal is shared across the two road cams, so need to bring up both sensors to configure it properly.