### PR TITLE
ci: faster unit tests

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -172,7 +172,7 @@ jobs:
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
         ${{ env.RUN }} "$PYTEST --collect-only -m 'not slow' &> /dev/null && \
-                        MAX_EXAMPLES=1 $PYTEST -m 'not slow' && \
+                        MAX_EXAMPLES=1 $PYTEST -m 'not slow' -vv && \
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -172,15 +172,15 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .ci_cache/comma_download_cache
-        key: unit_tests-${{ hashFiles('selfdrive/car/tests/routes.py') }}
+        key: unit_tests_${{ hashFiles('selfdrive/locationd/tests/test_locationd.py', 'selfdrive/locationd/tests/test_calibrationd.py') }}
     - name: Run unit tests
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
-        ${{ env.RUN }} "$PYTEST --collect-only -m 'not slow' &> /dev/null && \
-                        MAX_EXAMPLES=1 $PYTEST -m 'not slow' -vv && \
+        ${{ env.RUN }} "time $PYTEST --collect-only -m 'not slow' &> /dev/null && \
+                        time MAX_EXAMPLES=1 $PYTEST -m 'not slow' -vv && \
                         time ./selfdrive/ui/tests/create_test_translations.sh && \
                         time QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
-                        chmod -R 777 /tmp/comma_download_cache"
+                        time chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -178,10 +178,10 @@ jobs:
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
         ${{ env.RUN }} "time $PYTEST --collect-only -m 'not slow' &> /dev/null && \
-                        time MAX_EXAMPLES=1 $PYTEST -m 'not slow' -v && \
+                        time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' -v && \
                         time ./selfdrive/ui/tests/create_test_translations.sh && \
                         time QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
-                        time chmod -R 777 /tmp/comma_download_cache"
+                        chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -168,11 +168,12 @@ jobs:
     - uses: ./.github/workflows/setup-with-retry
     - name: Build openpilot
       run: ${{ env.RUN }} "scons -j$(nproc)"
-    - name: Cache
+    - name: caching tests
+      id: tests-cache
       uses: actions/cache@v4
       with:
         path: .ci_cache/comma_download_cache
-        key: unit_tests_${{ hashFiles('selfdrive/locationd/tests/test_locationd.py', 'selfdrive/locationd/tests/test_calibrationd.py') }}
+        key: u_test_seg_${{ hashFiles('selfdrive/ui/tests/test_ui/run.py') }}
     - name: Run unit tests
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -178,8 +178,8 @@ jobs:
       run: |
         ${{ env.RUN }} "$PYTEST --collect-only -m 'not slow' &> /dev/null && \
                         MAX_EXAMPLES=1 $PYTEST -m 'not slow' -vv && \
-                        ./selfdrive/ui/tests/create_test_translations.sh && \
-                        QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
+                        time ./selfdrive/ui/tests/create_test_translations.sh && \
+                        time QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -178,7 +178,7 @@ jobs:
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
         ${{ env.RUN }} "time $PYTEST --collect-only -m 'not slow' &> /dev/null && \
-                        time MAX_EXAMPLES=1 $PYTEST -m 'not slow' -vv && \
+                        time MAX_EXAMPLES=1 $PYTEST -m 'not slow' -v && \
                         time ./selfdrive/ui/tests/create_test_translations.sh && \
                         time QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         time chmod -R 777 /tmp/comma_download_cache"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -168,6 +168,11 @@ jobs:
     - uses: ./.github/workflows/setup-with-retry
     - name: Build openpilot
       run: ${{ env.RUN }} "scons -j$(nproc)"
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: .ci_cache/comma_download_cache
+        key: unit_tests-${{ hashFiles('selfdrive/car/tests/routes.py') }}
     - name: Run unit tests
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -168,34 +168,20 @@ jobs:
     - uses: ./.github/workflows/setup-with-retry
     - name: Build openpilot
       run: ${{ env.RUN }} "scons -j$(nproc)"
-    - name: caching tests
-      id: tests-cache
-      uses: actions/cache@v4
-      with:
-        path: .ci_cache/comma_download_cache
-        key: u_test_seg_test_${{ hashFiles('selfdrive/ui/tests/test_ui/run.py') }}
     - name: Run unit tests
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
         ${{ env.RUN }} "$PYTEST --collect-only -m 'not slow' &> /dev/null && \
-                        time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' && \
+                        MAX_EXAMPLES=1 $PYTEST -m 'not slow' && \
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
-        echo "real?"
-        sudo chown -R runner:runner .ci_cache
-        sudo chmod -R 777 .ci_cache
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4
       with:
         name: ${{ github.job }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    - name: debug shell
-      uses: namespacelabs/breakpoint-action@v0
-      with:
-        duration: 30m
-        authorized-users: maxime-desroches
 
   process_replay:
     name: process replay

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -177,7 +177,8 @@ jobs:
     - name: Run unit tests
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
-        ${{ env.RUN }} "time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' && \
+        ${{ env.RUN }} "$PYTEST --collect-only -m 'not slow' &> /dev/null && \
+                        time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' && \
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
@@ -189,6 +190,11 @@ jobs:
         name: ${{ github.job }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    - name: debug shell
+      uses: namespacelabs/breakpoint-action@v0
+      with:
+        duration: 30m
+        authorized-users: maxime-desroches
 
   process_replay:
     name: process replay

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -181,6 +181,7 @@ jobs:
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
+        echo "real?"
         sudo chmod -R 777 .ci_cache/comma_download_cache
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -178,8 +178,8 @@ jobs:
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
         ${{ env.RUN }} "time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' -v && \
-                        time ./selfdrive/ui/tests/create_test_translations.sh && \
-                        time QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
+                        ./selfdrive/ui/tests/create_test_translations.sh && \
+                        QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -183,7 +183,7 @@ jobs:
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
         echo "real?"
-        sudo chmod -R 777 .ci_cache/comma_download_cache
+        sudo chmod -R 777 .ci_cache/*
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -177,8 +177,7 @@ jobs:
     - name: Run unit tests
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
-        ${{ env.RUN }} "time $PYTEST --collect-only -m 'not slow' &> /dev/null && \
-                        time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' -v && \
+        ${{ env.RUN }} "time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' -v && \
                         time ./selfdrive/ui/tests/create_test_translations.sh && \
                         time QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -183,7 +183,8 @@ jobs:
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
         echo "real?"
-        sudo chmod -R 777 .ci_cache/*
+        sudo chown runner:runner .ci_cache
+        sudo chmod -R 777 .ci_cache
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -173,14 +173,15 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .ci_cache/comma_download_cache
-        key: u_test_seg_${{ hashFiles('selfdrive/ui/tests/test_ui/run.py') }}
+        key: u_test_seg_test_${{ hashFiles('selfdrive/ui/tests/test_ui/run.py') }}
     - name: Run unit tests
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 1 || 20 }}
       run: |
-        ${{ env.RUN }} "time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' -v && \
+        ${{ env.RUN }} "time CACHE_ROOT=/tmp/comma_download_cache MAX_EXAMPLES=1 $PYTEST -m 'not slow' && \
                         ./selfdrive/ui/tests/create_test_translations.sh && \
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
+        sudo chmod -R 777 .ci_cache/comma_download_cache
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -183,7 +183,7 @@ jobs:
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
         echo "real?"
-        sudo chown runner:runner .ci_cache
+        sudo chown -R runner:runner .ci_cache
         sudo chmod -R 777 .ci_cache
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v4

--- a/selfdrive/locationd/test/test_locationd_scenarios.py
+++ b/selfdrive/locationd/test/test_locationd_scenarios.py
@@ -1,4 +1,3 @@
-#import pytest
 import numpy as np
 from collections import defaultdict
 from enum import Enum
@@ -87,8 +86,6 @@ def run_scenarios(scenario, logs):
   return get_select_fields_data(logs), get_select_fields_data(replayed_logs)
 
 
-#@pytest.mark.xdist_group("test_locationd_scenarios")
-#@pytest.mark.shared_download_cache
 class TestLocationdScenarios:
   """
   Test locationd with different scenarios. In all these scenarios, we expect the following:

--- a/selfdrive/locationd/test/test_locationd_scenarios.py
+++ b/selfdrive/locationd/test/test_locationd_scenarios.py
@@ -1,4 +1,4 @@
-import pytest
+#import pytest
 import numpy as np
 from collections import defaultdict
 from enum import Enum

--- a/selfdrive/locationd/test/test_locationd_scenarios.py
+++ b/selfdrive/locationd/test/test_locationd_scenarios.py
@@ -87,8 +87,8 @@ def run_scenarios(scenario, logs):
   return get_select_fields_data(logs), get_select_fields_data(replayed_logs)
 
 
-@pytest.mark.xdist_group("test_locationd_scenarios")
-@pytest.mark.shared_download_cache
+#@pytest.mark.xdist_group("test_locationd_scenarios")
+#@pytest.mark.shared_download_cache
 class TestLocationdScenarios:
   """
   Test locationd with different scenarios. In all these scenarios, we expect the following:

--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -82,7 +82,7 @@ class URLFile:
 
     self._length = self.get_length_online()
     if not self._force_download and self._length != -1:
-      with atomic_write_in_dir(file_length_path, mode="w") as file_length:
+      with atomic_write_in_dir(file_length_path, mode="w", overwrite=True) as file_length:
         file_length.write(str(self._length))
     return self._length
 
@@ -105,7 +105,7 @@ class URLFile:
       #  If we don't have a file, download it
       if not os.path.exists(full_path):
         data = self.read_aux(ll=CHUNK_SIZE)
-        with atomic_write_in_dir(full_path, mode="wb") as new_cached_file:
+        with atomic_write_in_dir(full_path, mode="wb", overwrite=True) as new_cached_file:
           new_cached_file.write(data)
       else:
         with open(full_path, "rb") as cached_file:


### PR DESCRIPTION
Got slower since https://github.com/commaai/openpilot/pull/34080 , should now be back to ~30s
Unfortunately, each new scenario will increase the runtime