### PR TITLE
raylib: fix symbols redefinition

### DIFF
--- a/scripts/lint/check_raylib_includes.sh
+++ b/scripts/lint/check_raylib_includes.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+FAIL=0
+
+if grep -n '#include "third_party/raylib/include/raylib\.h"' $@ | grep -v '^system/ui/raylib/raylib\.h'; then
+  echo -e "Bad raylib include found! Use '#include \"system/ui/raylib/raylib.h\"' instead\n"
+  FAIL=1
+fi
+
+exit $FAIL

--- a/scripts/lint/lint.sh
+++ b/scripts/lint/lint.sh
@@ -53,6 +53,7 @@ function run_tests() {
   run "check_shebang_scripts_are_executable" python3 -m pre_commit_hooks.check_shebang_scripts_are_executable $ALL_FILES
   run "check_shebang_format" $DIR/check_shebang_format.sh $ALL_FILES
   run "check_nomerge_comments" $DIR/check_nomerge_comments.sh $ALL_FILES
+  run "check_raylib_includes" $DIR/check_raylib_includes.sh $ALL_FILES
 
   if [[ -z "$FAST" ]]; then
     run "mypy" mypy $PYTHON_FILES

--- a/system/ui/raylib/raylib.h
+++ b/system/ui/raylib/raylib.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define OPENPILOT_RAYLIB
+
+#include "third_party/raylib/include/raylib.h"

--- a/system/ui/raylib/spinner.cc
+++ b/system/ui/raylib/spinner.cc
@@ -3,7 +3,6 @@
 #include <iostream>
 
 #include "system/ui/raylib/util.h"
-#include "third_party/raylib/include/raylib.h"
 
 constexpr int kProgressBarWidth = 1000;
 constexpr int kProgressBarHeight = 20;
@@ -27,7 +26,7 @@ int main(int argc, char *argv[]) {
 
   while (!WindowShouldClose()) {
     BeginDrawing();
-    ClearBackground(BLACK);
+    ClearBackground(RAYLIB_BLACK);
 
     rotation = fmod(rotation + kRotationRate, 360.0f);
     Vector2 center = {GetScreenWidth() / 2.0f, GetScreenHeight() / 2.0f};
@@ -37,8 +36,8 @@ int main(int argc, char *argv[]) {
     // Draw rotating spinner and static comma logo
     DrawTexturePro(spinnerTexture, {0, 0, (float)kTextureSize, (float)kTextureSize},
                    {center.x, center.y, (float)kTextureSize, (float)kTextureSize},
-                   spinnerOrigin, rotation, WHITE);
-    DrawTextureV(commaTexture, commaPosition, WHITE);
+                   spinnerOrigin, rotation, RAYLIB_WHITE);
+    DrawTextureV(commaTexture, commaPosition, RAYLIB_WHITE);
 
     // Check for user input
     if (std::cin.rdbuf()->in_avail() > 0) {
@@ -50,14 +49,14 @@ int main(int argc, char *argv[]) {
       float yPos = GetScreenHeight() - kMargin - kProgressBarHeight;
       if (std::all_of(userInput.begin(), userInput.end(), ::isdigit)) {
         Rectangle bar = {center.x - kProgressBarWidth / 2.0f, yPos, kProgressBarWidth, kProgressBarHeight};
-        DrawRectangleRounded(bar, 0.5f, 10, GRAY);
+        DrawRectangleRounded(bar, 0.5f, 10, RAYLIB_GRAY);
 
         int progress = std::clamp(std::stoi(userInput), 0, 100);
         bar.width *= progress / 100.0f;
-        DrawRectangleRounded(bar, 0.5f, 10, RAYWHITE);
+        DrawRectangleRounded(bar, 0.5f, 10, RAYLIB_RAYWHITE);
       } else {
         Vector2 textSize = MeasureTextEx(getFont(), userInput.c_str(), kFontSize, 1.0);
-        DrawTextEx(getFont(), userInput.c_str(), {center.x - textSize.x / 2, yPos}, kFontSize, 1.0, WHITE);
+        DrawTextEx(getFont(), userInput.c_str(), {center.x - textSize.x / 2, yPos}, kFontSize, 1.0, RAYLIB_WHITE);
       }
     }
 

--- a/system/ui/raylib/util.h
+++ b/system/ui/raylib/util.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "third_party/raylib/include/raylib.h"
+#include "system/ui/raylib/raylib.h"
 
 enum class FontWeight {
   Normal,

--- a/third_party/raylib/include/raylib.h
+++ b/third_party/raylib/include/raylib.h
@@ -172,33 +172,91 @@
 
 // Some Basic Colors
 // NOTE: Custom raylib color palette for amazing visuals on WHITE background
-#define LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
-#define GRAY       CLITERAL(Color){ 130, 130, 130, 255 }   // Gray
-#define DARKGRAY   CLITERAL(Color){ 80, 80, 80, 255 }      // Dark Gray
-#define YELLOW     CLITERAL(Color){ 253, 249, 0, 255 }     // Yellow
-#define GOLD       CLITERAL(Color){ 255, 203, 0, 255 }     // Gold
-#define ORANGE     CLITERAL(Color){ 255, 161, 0, 255 }     // Orange
-#define PINK       CLITERAL(Color){ 255, 109, 194, 255 }   // Pink
-#define RED        CLITERAL(Color){ 230, 41, 55, 255 }     // Red
-#define MAROON     CLITERAL(Color){ 190, 33, 55, 255 }     // Maroon
-#define GREEN      CLITERAL(Color){ 0, 228, 48, 255 }      // Green
-#define LIME       CLITERAL(Color){ 0, 158, 47, 255 }      // Lime
-#define DARKGREEN  CLITERAL(Color){ 0, 117, 44, 255 }      // Dark Green
-#define SKYBLUE    CLITERAL(Color){ 102, 191, 255, 255 }   // Sky Blue
-#define BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
-#define DARKBLUE   CLITERAL(Color){ 0, 82, 172, 255 }      // Dark Blue
-#define PURPLE     CLITERAL(Color){ 200, 122, 255, 255 }   // Purple
-#define VIOLET     CLITERAL(Color){ 135, 60, 190, 255 }    // Violet
-#define DARKPURPLE CLITERAL(Color){ 112, 31, 126, 255 }    // Dark Purple
-#define BEIGE      CLITERAL(Color){ 211, 176, 131, 255 }   // Beige
-#define BROWN      CLITERAL(Color){ 127, 106, 79, 255 }    // Brown
-#define DARKBROWN  CLITERAL(Color){ 76, 63, 47, 255 }      // Dark Brown
+#define _rl_LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
+#define _rl_GRAY       CLITERAL(Color){ 130, 130, 130, 255 }   // Gray
+#define _rl_DARKGRAY   CLITERAL(Color){ 80, 80, 80, 255 }      // Dark Gray
+#define _rl_YELLOW     CLITERAL(Color){ 253, 249, 0, 255 }     // Yellow
+#define _rl_GOLD       CLITERAL(Color){ 255, 203, 0, 255 }     // Gold
+#define _rl_ORANGE     CLITERAL(Color){ 255, 161, 0, 255 }     // Orange
+#define _rl_PINK       CLITERAL(Color){ 255, 109, 194, 255 }   // Pink
+#define _rl_RED        CLITERAL(Color){ 230, 41, 55, 255 }     // Red
+#define _rl_MAROON     CLITERAL(Color){ 190, 33, 55, 255 }     // Maroon
+#define _rl_GREEN      CLITERAL(Color){ 0, 228, 48, 255 }      // Green
+#define _rl_LIME       CLITERAL(Color){ 0, 158, 47, 255 }      // Lime
+#define _rl_DARKGREEN  CLITERAL(Color){ 0, 117, 44, 255 }      // Dark Green
+#define _rl_SKYBLUE    CLITERAL(Color){ 102, 191, 255, 255 }   // Sky Blue
+#define _rl_BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
+#define _rl_DARKBLUE   CLITERAL(Color){ 0, 82, 172, 255 }      // Dark Blue
+#define _rl_PURPLE     CLITERAL(Color){ 200, 122, 255, 255 }   // Purple
+#define _rl_VIOLET     CLITERAL(Color){ 135, 60, 190, 255 }    // Violet
+#define _rl_DARKPURPLE CLITERAL(Color){ 112, 31, 126, 255 }    // Dark Purple
+#define _rl_BEIGE      CLITERAL(Color){ 211, 176, 131, 255 }   // Beige
+#define _rl_BROWN      CLITERAL(Color){ 127, 106, 79, 255 }    // Brown
+#define _rl_DARKBROWN  CLITERAL(Color){ 76, 63, 47, 255 }      // Dark Brown
 
-#define WHITE      CLITERAL(Color){ 255, 255, 255, 255 }   // White
-#define BLACK      CLITERAL(Color){ 0, 0, 0, 255 }         // Black
-#define BLANK      CLITERAL(Color){ 0, 0, 0, 0 }           // Blank (Transparent)
-#define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
-#define RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
+#define _rl_WHITE      CLITERAL(Color){ 255, 255, 255, 255 }   // White
+#define _rl_BLACK      CLITERAL(Color){ 0, 0, 0, 255 }         // Black
+#define _rl_BLANK      CLITERAL(Color){ 0, 0, 0, 0 }           // Blank (Transparent)
+#define _rl_MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
+#define _rl_RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
+
+#ifndef OPENPILOT_RAYLIB
+  #define LIGHTGRAY  _rl_LIGHTGRAY
+  #define GRAY       _rl_GRAY
+  #define DARKGRAY   _rl_DARKGRAY
+  #define YELLOW     _rl_YELLOW
+  #define GOLD       _rl_GOLD
+  #define ORANGE     _rl_ORANGE
+  #define PINK       _rl_PINK
+  #define RED        _rl_RED
+  #define MAROON     _rl_MAROON
+  #define GREEN      _rl_GREEN
+  #define LIME       _rl_LIME
+  #define DARKGREEN  _rl_DARKGREEN
+  #define SKYBLUE    _rl_SKYBLUE
+  #define BLUE       _rl_BLUE
+  #define DARKBLUE   _rl_DARKBLUE
+  #define PURPLE     _rl_PURPLE
+  #define VIOLET     _rl_VIOLET
+  #define DARKPURPLE _rl_DARKBLUE
+  #define BEIGE      _rl_BEIGE
+  #define BROWN      _rl_BROWN
+  #define DARKBROWN  _rl_DARKBROWN
+
+  #define WHITE      _rl_WHITE
+  #define BLACK      _rl_BLACK
+  #define BLANK      _rl_BLANK
+  #define MAGENTA    _rl_MAGENTA
+  #define RAYWHITE   _rl_RAYWHITE
+#else
+  #define RAYLIB_LIGHTGRAY  _rl_LIGHTGRAY
+  #define RAYLIB_GRAY       _rl_GRAY
+  #define RAYLIB_DARKGRAY   _rl_DARKGRAY
+  #define RAYLIB_YELLOW     _rl_YELLOW
+  #define RAYLIB_GOLD       _rl_GOLD
+  #define RAYLIB_ORANGE     _rl_ORANGE
+  #define RAYLIB_PINK       _rl_PINK
+  #define RAYLIB_RED        _rl_RED
+  #define RAYLIB_MAROON     _rl_MAROON
+  #define RAYLIB_GREEN      _rl_GREEN
+  #define RAYLIB_LIME       _rl_LIME
+  #define RAYLIB_DARKGREEN  _rl_DARKGREEN
+  #define RAYLIB_SKYBLUE    _rl_SKYBLUE
+  #define RAYLIB_BLUE       _rl_BLUE
+  #define RAYLIB_DARKBLUE   _rl_DARKBLUE
+  #define RAYLIB_PURPLE     _rl_PURPLE
+  #define RAYLIB_VIOLET     _rl_VIOLET
+  #define RAYLIB_DARKPURPLE _rl_DARKBLUE
+  #define RAYLIB_BEIGE      _rl_BEIGE
+  #define RAYLIB_BROWN      _rl_BROWN
+  #define RAYLIB_DARKBROWN  _rl_DARKBROWN
+
+  #define RAYLIB_WHITE      _rl_WHITE
+  #define RAYLIB_BLACK      _rl_BLACK
+  #define RAYLIB_BLANK      _rl_BLANK
+  #define RAYLIB_MAGENTA    _rl_MAGENTA
+  #define RAYLIB_RAYWHITE   _rl_RAYWHITE
+#endif
 
 //----------------------------------------------------------------------------------
 // Structures Definition

--- a/third_party/raylib/setup.sh
+++ b/third_party/raylib/setup.sh
@@ -30,7 +30,7 @@ fi
 
 cd raylib_repo
 
-COMMIT="5b56f44b1f1014300fbf03b636571f2bbdfc0d05"
+COMMIT="f5b0a7237c6e45f0e8a6ff68322d19b49298d798"
 git fetch origin $COMMIT
 git reset --hard $COMMIT
 git clean -xdff .


### PR DESCRIPTION
Only `system/ui/raylib/raylib.h` is allowed to include `third_party/raylib/include/raylib.h` directly now (enforced by our linter) since we need to define `OPENPILOT_RAYLIB`