### PR TITLE
athenad: move dispatcher setup outside jsonrpc_handler for thread safety

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -139,6 +139,7 @@ class UploadQueueCache:
 
 def handle_long_poll(ws: WebSocket, exit_event: threading.Event | None) -> None:
   end_event = threading.Event()
+  dispatcher["startLocalProxy"] = partial(startLocalProxy, end_event)
 
   threads = [
     threading.Thread(target=ws_manage, args=(ws, end_event), name='ws_manage'),
@@ -168,7 +169,6 @@ def handle_long_poll(ws: WebSocket, exit_event: threading.Event | None) -> None:
 
 
 def jsonrpc_handler(end_event: threading.Event) -> None:
-  dispatcher["startLocalProxy"] = partial(startLocalProxy, end_event)
   while not end_event.is_set():
     try:
       data = recv_queue.get(timeout=1)


### PR DESCRIPTION
The dispatcher dictionary is modified inside the `jsonrpc_handler`, which is accessed by multiple threads concurrently. This change moves the dispatcher setup outside the handler to ensure thread safety and prevent potential race conditions.