### PR TITLE
athenad: immediate WebSocket reconnection on timeout with abort()

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -725,9 +725,11 @@ def ws_recv(ws: WebSocket, end_event: threading.Event) -> None:
       ns_since_last_ping = int(time.monotonic() * 1e9) - last_ping
       if ns_since_last_ping > RECONNECT_TIMEOUT_S * 1e9:
         cloudlog.exception("athenad.ws_recv.timeout")
+        ws.abort()
         end_event.set()
     except Exception:
       cloudlog.exception("athenad.ws_recv.exception")
+      ws.abort()
       end_event.set()
 
 
@@ -747,6 +749,7 @@ def ws_send(ws: WebSocket, end_event: threading.Event) -> None:
       pass
     except Exception:
       cloudlog.exception("athenad.ws_send.exception")
+      ws.abort()
       end_event.set()
 
 


### PR DESCRIPTION
Add calls to ws.abort() to wake up threads waiting in recv and send, enabling faster reconnection by ensuring waiting threads are interrupted.

resolve : #29231 