### PR TITLE
athenad: ensure no duplicate items in upload queue with snapshot approach

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -372,6 +372,8 @@ def uploadFilesToUrls(files_data: list[UploadFileDict]) -> UploadFilesToUrlRespo
 
   items: list[UploadItemDict] = []
   failed: list[str] = []
+  existing_urls = {item['url'].split('?')[0] for item in listUploadQueue()}
+
   for file in files:
     if len(file.fn) == 0 or file.fn[0] == '/' or '..' in file.fn or len(file.url) == 0:
       failed.append(file.fn)
@@ -384,7 +386,7 @@ def uploadFilesToUrls(files_data: list[UploadFileDict]) -> UploadFilesToUrlRespo
 
     # Skip item if already in queue
     url = file.url.split('?')[0]
-    if any(url == item['url'].split('?')[0] for item in listUploadQueue()):
+    if url in existing_urls:
       continue
 
     item = UploadItem(


### PR DESCRIPTION
This update improves performance and thread safety in the `uploadFilesToUrls` function. Instead of repeatedly calling `listUploadQueue()` within the loop, it captures a snapshot of the upload queue’s URLs at the beginning of the function. This snapshot is then used to check for duplicates, preventing the addition of items that are being taken from the upload queue by the `upload_handler` thread during the loop. 

this approach improves stability, boosts efficiency, and reduces lock contention from repeated queue locking within the loop.
