### PR TITLE
remove unused img_driver_face_static.png

### DIFF
--- a/selfdrive/assets/img_driver_face_static.png
+++ b/selfdrive/assets/img_driver_face_static.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7565541b4e6213221174839b9b2b67397ced0b9807ea56413989fd37325b3b6
-size 4908


### PR DESCRIPTION
The image file `img_driver_face_static.png` is no longer used after the changes made in PR #33776. 