### PR TITLE
fix docs.py path references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/car_port.md
+++ b/.github/PULL_REQUEST_TEMPLATE/car_port.md
@@ -8,7 +8,7 @@ assignees: ''
 
 **Checklist**
 
-- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
+- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
 - [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
 - [ ] route with openpilot:
 - [ ] route with stock system:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,7 +44,7 @@ Explain how you tested this bug fix.
 
 **Checklist**
 
-- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
+- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
 - [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
 - [ ] route with openpilot:
 - [ ] route with stock system:

--- a/selfdrive/car/tests/test_docs.py
+++ b/selfdrive/car/tests/test_docs.py
@@ -17,7 +17,7 @@ class TestCarDocs:
     with open(CARS_MD_OUT) as f:
       current_cars_md = f.read()
 
-    assert generated_cars_md == current_cars_md, "Run selfdrive/opcar/docs.py to update the compatibility documentation"
+    assert generated_cars_md == current_cars_md, "Run selfdrive/car/docs.py to update the compatibility documentation"
 
   def test_docs_diff(self):
     dump_path = os.path.join(BASEDIR, "selfdrive", "car", "tests", "cars_dump")


### PR DESCRIPTION
**Description**

fixed the old 'selfdrive/opcar/docs.py' path references

**Verification**

run 'python3 selfdrive/car/docs.py'

