### PR TITLE
Tools: Update setup command for macOS native setup

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -6,7 +6,7 @@ openpilot is developed and tested on **Ubuntu 24.04**, which is the primary deve
 
 Most of openpilot should work natively on macOS. On Windows you can use WSL for a nearly native Ubuntu experience. Running natively on any other system is not currently recommended and will likely require modifications.
 
-## Native setup on Ubuntu 24.04
+## Native setup on Ubuntu 24.04 and macOS
 
 **1. Clone openpilot**
 
@@ -24,9 +24,16 @@ git clone --recurse-submodules https://github.com/commaai/openpilot.git
 
 **2. Run the setup script**
 
+Ubuntu 24.04:
 ``` bash
 cd openpilot
 tools/ubuntu_setup.sh
+```
+
+macOS:
+``` bash
+cd openpilot
+tools/mac_setup.sh
 ```
 
 **3. Git LFS**


### PR DESCRIPTION
**Description**
- Updated the setup documentation to include macOS support for native installation.
- Added a dedicated command for macOS users to use the `mac_setup.sh` script.
- Clarified the distinction between setup steps for Ubuntu and macOS in the documentation.