### PR TITLE
replay: flush codec buffers after seeking

### DIFF
--- a/tools/replay/framereader.cc
+++ b/tools/replay/framereader.cc
@@ -177,8 +177,10 @@ bool VideoDecoder::decode(FrameReader *reader, int idx, VisionBuf *buf) {
         break;
       }
     }
-    avio_seek(reader->input_ctx->pb, reader->packets_info[from_idx].pos, SEEK_SET);
-    avcodec_flush_buffers(decoder_ctx);
+    auto pos = reader->packets_info[from_idx].pos;
+    if (avformat_seek_file(reader->input_ctx, 0, pos, pos, pos, AVSEEK_FLAG_BYTE) >= 0) {
+      avcodec_flush_buffers(decoder_ctx);
+    }
   }
   reader->prev_idx = idx;
 

--- a/tools/replay/framereader.cc
+++ b/tools/replay/framereader.cc
@@ -177,10 +177,14 @@ bool VideoDecoder::decode(FrameReader *reader, int idx, VisionBuf *buf) {
         break;
       }
     }
+
     auto pos = reader->packets_info[from_idx].pos;
-    if (avformat_seek_file(reader->input_ctx, 0, pos, pos, pos, AVSEEK_FLAG_BYTE) >= 0) {
-      avcodec_flush_buffers(decoder_ctx);
+    int ret = avformat_seek_file(reader->input_ctx, 0, pos, pos, pos, AVSEEK_FLAG_BYTE);
+    if (ret < 0) {
+      rError("Failed to seek to byte position %lld: %d", pos, AVERROR(ret));
+      return false;
     }
+    avcodec_flush_buffers(decoder_ctx);
   }
   reader->prev_idx = idx;
 

--- a/tools/replay/framereader.cc
+++ b/tools/replay/framereader.cc
@@ -178,6 +178,7 @@ bool VideoDecoder::decode(FrameReader *reader, int idx, VisionBuf *buf) {
       }
     }
     avio_seek(reader->input_ctx->pb, reader->packets_info[from_idx].pos, SEEK_SET);
+    avcodec_flush_buffers(decoder_ctx);
   }
   reader->prev_idx = idx;
 


### PR DESCRIPTION
Flush codec buffers after seeking to ensure clean state and prevent decoding issues