### PR TITLE
camerad: pass std::vector by const reference

### DIFF
--- a/system/camerad/cameras/cdm.cc
+++ b/system/camerad/cameras/cdm.cc
@@ -14,7 +14,7 @@ int write_dmi(uint8_t *dst, uint64_t *addr, uint32_t length, uint32_t dmi_addr, 
   return sizeof(struct cdm_dmi_cmd);
 }
 
-int write_cont(uint8_t *dst, uint32_t reg, std::vector<uint32_t> vals) {
+int write_cont(uint8_t *dst, uint32_t reg, const std::vector<uint32_t> &vals) {
   struct cdm_regcontinuous_cmd *cmd = (struct cdm_regcontinuous_cmd*)dst;
   cmd->cmd = CAM_CDM_CMD_REG_CONT;
   cmd->count = vals.size();
@@ -31,7 +31,7 @@ int write_cont(uint8_t *dst, uint32_t reg, std::vector<uint32_t> vals) {
   return sizeof(struct cdm_regcontinuous_cmd) + vals.size()*sizeof(uint32_t);
 }
 
-int write_random(uint8_t *dst, std::vector<uint32_t> vals) {
+int write_random(uint8_t *dst, const std::vector<uint32_t> &vals) {
   struct cdm_regrandom_cmd *cmd = (struct cdm_regrandom_cmd*)dst;
   cmd->cmd = CAM_CDM_CMD_REG_RANDOM;
   cmd->count = vals.size() / 2;

--- a/system/camerad/cameras/cdm.h
+++ b/system/camerad/cameras/cdm.h
@@ -7,8 +7,8 @@
 #include <memory>
 
 // our helpers
-int write_random(uint8_t *dst, std::vector<uint32_t> vals);
-int write_cont(uint8_t *dst, uint32_t reg, std::vector<uint32_t> vals);
+int write_random(uint8_t *dst, const std::vector<uint32_t> &vals);
+int write_cont(uint8_t *dst, uint32_t reg, const std::vector<uint32_t> &vals);
 int write_dmi(uint8_t *dst, uint64_t *addr, uint32_t length, uint32_t dmi_addr, uint8_t sel);
 
 // from drivers/media/platform/msm/camera/cam_cdm/cam_cdm_util.{c,h}


### PR DESCRIPTION
Changed the `write_cont`,  `write_random`  to pass std::vector<uint32_t> by const reference, improving efficiency and avoiding unnecessary copies.