### PR TITLE
common: implement CachedDir class for efficient directory listing caching

### DIFF
--- a/common/cached_dir.py
+++ b/common/cached_dir.py
@@ -2,6 +2,7 @@ import os
 
 dir_cache: dict[str, 'CachedDir'] = {}
 
+
 class CachedDir:
   def __init__(self, path: str, listing: list[str], mtime: float):
     self.path = path

--- a/common/cached_dir.py
+++ b/common/cached_dir.py
@@ -1,0 +1,29 @@
+import os
+
+dir_cache: dict[str, 'CachedDir'] = {}
+
+class CachedDir:
+  def __init__(self, path: str, listing: list[str], mtime: float):
+    self.path = path
+    self.listing = listing
+    self.mtime = mtime
+
+  def is_fresh(self) -> bool:
+    """Check if the cached listing is still valid."""
+    current_mtime = os.path.getmtime(self.path)
+    return current_mtime == self.mtime
+
+  @staticmethod
+  def listdir(path: str) -> list[str]:
+    """
+    Return cached directory listing if the directory's mtime hasn't changed,
+    otherwise re-fetch and cache it.
+    """
+    # Check if the path is already cached and still fresh
+    if path in dir_cache and dir_cache[path].is_fresh():
+      return dir_cache[path].listing
+
+    # If not cached or stale, fetch the listing
+    listing: list[str] = os.listdir(path)
+    dir_cache[path] = CachedDir(path, listing, os.path.getmtime(path))
+    return listing

--- a/common/tests/test_cached_dir.py
+++ b/common/tests/test_cached_dir.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+import time
+
+from openpilot.common.cached_dir import CachedDir, dir_cache
+
+
+class TestCachedDir:
+  def setup_method(self):
+    self.tmp_dir = tempfile.mkdtemp()
+
+  def teardown_method(self):
+    for f in os.listdir(self.tmp_dir):
+      os.remove(os.path.join(self.tmp_dir, f))
+    os.rmdir(self.tmp_dir)
+
+  def test_cache_populated_on_first_access(self):
+    with open(os.path.join(self.tmp_dir, "file1.txt"), "w") as f:
+      f.write("Test file")
+
+    listing = CachedDir.listdir(self.tmp_dir)
+
+    assert "file1.txt" in listing
+    assert self.tmp_dir in dir_cache
+    assert dir_cache[self.tmp_dir].mtime == os.path.getmtime(self.tmp_dir)
+
+  def test_cache_refresh_on_change(self):
+    listing = CachedDir.listdir(self.tmp_dir)  # Initial access
+
+    time.sleep(1)
+    # Add a new file and wait for the mtime to update
+    with open(os.path.join(self.tmp_dir, "file2.txt"), "w") as f:
+      f.write("Another test file")
+    time.sleep(1)
+
+    # Check if the new file appears
+    updated_listing = CachedDir.listdir(self.tmp_dir)
+    assert(listing != updated_listing)
+    assert "file2.txt" in updated_listing
+    assert dir_cache[self.tmp_dir].mtime == os.path.getmtime(self.tmp_dir)
+
+  def test_cache_updates_on_file_removal(self):
+    with open(os.path.join(self.tmp_dir, "file1.txt"), "w") as f:
+      f.write("File 1")
+    with open(os.path.join(self.tmp_dir, "file2.txt"), "w") as f:
+      f.write("File 2")
+
+    CachedDir.listdir(self.tmp_dir)  # Initial access
+    time.sleep(1)
+    # Remove file and update cache
+    os.remove(os.path.join(self.tmp_dir, "file1.txt"))
+    time.sleep(1)
+
+    updated_listing = CachedDir.listdir(self.tmp_dir)
+    assert "file1.txt" not in updated_listing
+    assert "file2.txt" in updated_listing

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -30,6 +30,7 @@ from websocket import (ABNF, WebSocket, WebSocketException, WebSocketTimeoutExce
 import cereal.messaging as messaging
 from cereal import log
 from cereal.services import SERVICE_LIST
+from common.cached_dir import CachedDir
 from openpilot.common.api import Api
 from openpilot.common.file_helpers import CallbackReader
 from openpilot.common.params import Params
@@ -554,7 +555,7 @@ def get_logs_to_send_sorted() -> list[str]:
   # TODO: scan once then use inotify to detect file creation/deletion
   curr_time = int(time.time())
   logs = []
-  for log_entry in os.listdir(Paths.swaglog_root()):
+  for log_entry in CachedDir.listdir(Paths.swaglog_root()):
     log_path = os.path.join(Paths.swaglog_root(), log_entry)
     time_sent = 0
     try:
@@ -640,7 +641,7 @@ def stat_handler(end_event: threading.Event) -> None:
     curr_scan = time.monotonic()
     try:
       if curr_scan - last_scan > 10:
-        stat_filenames = list(filter(lambda name: not name.startswith(tempfile.gettempprefix()), os.listdir(STATS_DIR)))
+        stat_filenames = list(filter(lambda name: not name.startswith(tempfile.gettempprefix()), CachedDir.listdir(STATS_DIR)))
         if len(stat_filenames) > 0:
           stat_path = os.path.join(STATS_DIR, stat_filenames[0])
           with open(stat_path) as f:

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -552,7 +552,6 @@ def takeSnapshot() -> str | dict[str, str] | None:
 
 
 def get_logs_to_send_sorted() -> list[str]:
-  # TODO: scan once then use inotify to detect file creation/deletion
   curr_time = int(time.time())
   logs = []
   for log_entry in CachedDir.listdir(Paths.swaglog_root()):

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -30,8 +30,8 @@ from websocket import (ABNF, WebSocket, WebSocketException, WebSocketTimeoutExce
 import cereal.messaging as messaging
 from cereal import log
 from cereal.services import SERVICE_LIST
-from common.cached_dir import CachedDir
 from openpilot.common.api import Api
+from openpilot.common.cached_dir import CachedDir
 from openpilot.common.file_helpers import CallbackReader
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_core_affinity

--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -13,6 +13,7 @@ from collections.abc import Iterator
 
 from cereal import log
 import cereal.messaging as messaging
+from common.cached_dir import CachedDir
 from openpilot.common.api import Api
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_core_affinity
@@ -57,7 +58,7 @@ def listdir_by_creation(d: str) -> list[str]:
     return []
 
   try:
-    paths = [f for f in os.listdir(d) if os.path.isdir(os.path.join(d, f))]
+    paths = [f for f in CachedDir.listdir(d) if os.path.isdir(os.path.join(d, f))]
     paths = sorted(paths, key=get_directory_sort)
     return paths
   except OSError:
@@ -96,7 +97,7 @@ class Uploader:
     for logdir in listdir_by_creation(self.root):
       path = os.path.join(self.root, logdir)
       try:
-        names = os.listdir(path)
+        names = CachedDir.listdir(path)
       except OSError:
         continue
 

--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -13,8 +13,8 @@ from collections.abc import Iterator
 
 from cereal import log
 import cereal.messaging as messaging
-from common.cached_dir import CachedDir
 from openpilot.common.api import Api
+from openpilot.common.cached_dir import CachedDir
 from openpilot.common.params import Params
 from openpilot.common.realtime import set_core_affinity
 from openpilot.system.hardware.hw import Paths


### PR DESCRIPTION
This PR introduces the `CachedDir` class, which caches directory listings and uses the directory's modification time (`mtime`) to determine the cache validity.
`mtime` updates when a file or directory is added, removed, or renamed, but not when file contents change. Since our concern is limited to structural changes in the directory (such as files or directories being added, removed, or renamed), we can rely on `mtime` for cache management.

This eliminates the need for more complex mechanisms like inotify or FSEvents and ensures efficient caching. As a result, repeated os.listdir() calls are avoided unless the cache becomes invalid due to relevant directory changes.