### PR TITLE
Webcam fixes

### DIFF
--- a/tools/webcam/camerad.py
+++ b/tools/webcam/camerad.py
@@ -25,9 +25,10 @@ class Camerad:
 
     self.cameras = []
     for c in CAMERAS:
+      print(f"opening {c.msg_name} at {c.cam_id}")
       cam = Camera(c.msg_name, c.stream_type, c.cam_id)
       self.cameras.append(cam)
-      self.vipc_server.create_buffers(c.stream_type, 20, False, cam.W, cam.H)
+      self.vipc_server.create_buffers(c.stream_type, 20, cam.W, cam.H)
 
     self.vipc_server.start_listener()
 

--- a/tools/webcam/camerad.py
+++ b/tools/webcam/camerad.py
@@ -12,8 +12,8 @@ from openpilot.common.realtime import Ratekeeper
 DUAL_CAM = os.getenv("DUAL_CAMERA")
 CameraType = namedtuple("CameraType", ["msg_name", "stream_type", "cam_id"])
 CAMERAS = [
-  CameraType("roadCameraState", VisionStreamType.VISION_STREAM_ROAD, os.getenv("CAMERA_ROAD_ID", "0")),
-  CameraType("driverCameraState", VisionStreamType.VISION_STREAM_DRIVER, os.getenv("CAMERA_DRIVER_ID", "1")),
+  CameraType("roadCameraState", VisionStreamType.VISION_STREAM_ROAD, os.getenv("CAMERA_ROAD_ID", "/dev/video0")),
+  CameraType("driverCameraState", VisionStreamType.VISION_STREAM_DRIVER, os.getenv("CAMERA_DRIVER_ID", "/dev/video1")),
 ]
 if DUAL_CAM:
   CAMERAS.append(CameraType("wideRoadCameraState", VisionStreamType.VISION_STREAM_WIDE_ROAD, DUAL_CAM))

--- a/tools/webcam/start_camerad.sh
+++ b/tools/webcam/start_camerad.sh
@@ -5,9 +5,9 @@ export BLOCK="${BLOCK},camerad"
 export USE_WEBCAM="1"
 
 # Change camera index according to your setting
-export CAMERA_ROAD_ID="0"
-export CAMERA_DRIVER_ID="1"
-export DUAL_CAMERA="2" # camera index for wide road camera
+export CAMERA_ROAD_ID="/dev/video0"
+export CAMERA_DRIVER_ID="/dev/video1"
+#export DUAL_CAMERA="/dev/video2" # optional, camera index for wide road camera
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 


### PR DESCRIPTION
**Description**

* Added logging so that we can troubleshoot which camera devices are failing to open
* Follow VIPC API change
* Use full device pathname instead of just a numeric ID (not sure why the numeric ID doesn't work for some)
* Disable forward wide cam by default (not sure this is actually valid/usable for driving)

**Verification**

1. `tools/webcam/start_camerad.sh` (with mods to point to my local camera devices)
2. `system/manager/manager.py` (in a separate terminal)

![image](https://github.com/user-attachments/assets/2f5684c1-cd93-42d2-82ff-f1ce9d826e92)

