### PR TITLE
replay: Update video immediately after seek when paused.

### DIFF
--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -85,6 +85,7 @@ private:
   std::thread stream_thread_;
   std::mutex stream_lock_;
   bool user_paused_ = false;
+  bool pause_after_next_frame_ = false;
   std::condition_variable stream_cv_;
   int current_segment_ = 0;
   std::optional<double> seeking_to_;


### PR DESCRIPTION
Currently, if playback is paused and you seek to a new point then have to resume playback for the video frame to update.

Implemented by having the seek function temporarily un-pause replay for a single frame period, then pause again.

Tested with Cabana but not in the Replay tool itself.
