### PR TITLE
cabana: enhance message heatmap visualization

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -292,6 +292,13 @@ void BinaryViewModel::updateItem(int row, int col, uint8_t val, const QColor &co
   }
 }
 
+// TODO:
+// 1. Track how long each bit stays in a state and how frequently it flips over time.
+// 2. Detect instability through frequent bit flips and highlight stable bits to indicate steady signals.
+// 3. Measure the intensity and rate of bit changes, adjusting heatmap visuals based on transition speed.
+// 4. Track message sequence and timestamps to understand how patterns evolve.
+// 5. Identify time-based or periodic bit state changes to spot recurring patterns.
+// 6. Support multiple time windows for short-term and long-term analysis, helping to observe changes in different time frames.
 void BinaryViewModel::updateState() {
   const auto &last_msg = can->lastMessage(msg_id);
   const auto &binary = last_msg.dat;

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -310,9 +310,9 @@ void BinaryViewModel::updateState() {
 
   // Find the maximum bit flip count across the message
   uint32_t max_bit_flip_count = 1;  // Default to 1 to avoid division by zero
-  for (const auto &changes : last_msg.last_changes) {
-    for (uint32_t flip_count : changes.bit_change_counts) {
-      max_bit_flip_count = std::max(max_bit_flip_count, flip_count);
+  for (const auto &row : last_msg.bit_flip_counts) {
+    for (auto count : row) {
+      max_bit_flip_count = std::max(max_bit_flip_count, count);
     }
   }
 
@@ -328,7 +328,7 @@ void BinaryViewModel::updateState() {
       int bit_val = (binary[i] >> (7 - j)) & 1;
 
       double alpha = item.sigs.empty() ? 0 : min_alpha_with_signal;
-      uint32_t flip_count = last_msg.last_changes[i].bit_change_counts[j];
+      uint32_t flip_count = last_msg.bit_flip_counts[i][j];
       if (flip_count > 0) {
         double normalized_alpha = log2(1.0 + flip_count * log_factor) * log_scaler;
         double min_alpha = item.sigs.empty() ? min_alpha_no_signal : min_alpha_with_signal;

--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -318,7 +318,7 @@ void BinaryViewModel::updateState() {
 
   const double max_alpha = 255.0;
   const double min_alpha_with_signal = 25.0;  // Base alpha for small flip counts
-  const double min_alpha_no_signal = 10.0;    // Base alpha for small flip counts for no singal bits
+  const double min_alpha_no_signal = 10.0;    // Base alpha for small flip counts for no signal bits
   const double log_factor = 1.0 + 0.2;        // Factor for logarithmic scaling
   const double log_scaler = max_alpha / log2(log_factor * max_bit_flip_count);
 

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -33,9 +33,9 @@ struct CanData {
     int delta = 0;
     int same_delta_counter = 0;
     bool suppressed = false;
-    std::array<uint32_t, 8> bit_change_counts;
   };
   std::vector<ByteLastChange> last_changes;
+  std::vector<std::array<uint32_t, 8>> bit_flip_counts;
   double last_freq_update_ts = 0;
 };
 


### PR DESCRIPTION
This update improves the visualization of the message heatmap by enhancing the calculation of alpha transparency for bits with flips. Key changes include:

- **Improved visibility for small bit flips:** A minimum alpha value ensures that bits with few changes remain visible, helping users detect subtle patterns more easily.
- **Logarithmic scaling refinement:** The alpha transparency now better reflects variations in bit flip counts, providing more accurate visual scaling of changes.
- **More precise scaling based on maximum bit flips:** Alpha values are now determined by the maximum bit flip count, rather than the total message count, improving clarity for both high and low-frequency flips across messages.

These enhancements provide a more intuitive and visually accurate representation of bit changes, making it easier to detect patterns and boundaries in the heatmap for better analysis.

**Example:** WEEL_SPEEDS Message

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2024-12-14 23-02-03](https://github.com/user-attachments/assets/7f98a591-c59e-4fb7-8075-47b2fc51bb26)  | ![Screenshot from 2024-12-14 22-57-45](https://github.com/user-attachments/assets/8a6eebf3-960d-422b-b8fb-0c96b56ac0b9)  |


**Actual DBC Message:**

![Screenshot from 2024-12-14 22-57-35](https://github.com/user-attachments/assets/e98582b2-82cb-4ced-a9e4-581e0203fc9a)


