### PR TITLE
replay: refactor checkSeekProgress to handle thread resumption internally

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -163,7 +163,6 @@ void AbstractStream::updateLastMsgsTo(double sec) {
   mutex_.unlock();
 
   emit msgsReceived(nullptr, id_changed);
-  resumeStream();
 }
 
 const CanEvent *AbstractStream::newEvent(uint64_t mono_time, const cereal::CanData::Reader &c) {

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -108,7 +108,6 @@ protected:
   void mergeEvents(const std::vector<const CanEvent *> &events);
   const CanEvent *newEvent(uint64_t mono_time, const cereal::CanData::Reader &c);
   void updateEvent(const MessageId &id, double sec, const uint8_t *data, uint8_t size);
-  virtual void resumeStream() {}
   std::vector<const CanEvent *> all_events_;
   double current_sec_ = 0;
   std::optional<std::pair<double, double>> time_range_;

--- a/tools/cabana/streams/replaystream.h
+++ b/tools/cabana/streams/replaystream.h
@@ -32,7 +32,6 @@ public:
   inline float getSpeed() const { return replay->getSpeed(); }
   inline Replay *getReplay() const { return replay.get(); }
   inline bool isPaused() const override { return replay->isPaused(); }
-  void resumeStream() override { return replay->resumeStream(); }
   void pause(bool pause) override;
 
 signals:

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -126,10 +126,10 @@ void Replay::seekTo(double seconds, bool relative) {
 void Replay::checkSeekProgress(double seeked_to_sec) {
   if (seeked_to_sec >= 0) {
     if (onSeekedTo) {
-      onSeekedTo(seeked_to_sec);
-    } else {
-      interruptStream([]() { return true; });
+      onSeekedTo(seeked_to_sec);  // Notify the seek completion event
     }
+    // Interrupt the stream to apply the final seek changes
+    interruptStream([]() { return true; });
   }
 }
 

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -57,7 +57,6 @@ public:
   inline const std::optional<Timeline::Entry> findAlertAtTime(double sec) const { return timeline_.findAlertAtTime(sec); }
   const std::shared_ptr<SegmentManager::EventData> getEventData() const { return event_data_; }
   void installEventFilter(std::function<bool(const Event *)> filter) { event_filter_ = filter; }
-  void resumeStream() { interruptStream([]() { return true; }); }
 
   // Event callback functions
   std::function<void()> onSegmentsMerged = nullptr;


### PR DESCRIPTION
This PR removes the need for external `resumeStream` calls after seeking. The `checkSeekProgress` function now manages thread resumption internally, simplifying the logic and eliminating dependencies on other modules for resuming threads after a seek operation. This improves code clarity and reduces external coupling.