### PR TITLE
ui: initialize tethering connection on startup

### DIFF
--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -65,10 +65,6 @@ WifiManager::WifiManager(QObject *parent) : QObject(parent) {
   timer.callOnTimeout(this, &WifiManager::requestScan);
 
   initConnections();
-
-  if (!isKnownConnection(tethering_ssid)) {
-    addTetheringConnection();
-  }
 }
 
 void WifiManager::setup() {
@@ -333,6 +329,10 @@ void WifiManager::initConnections() {
     } else if (settings.value("connection").value("id") == "lte") {
       lteConnectionPath = path;
     }
+  }
+
+  if (!isKnownConnection(tethering_ssid)) {
+    addTetheringConnection();
   }
 }
 

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -438,7 +438,7 @@ void WifiManager::addTetheringConnection() {
   connection["ipv4"]["route-metric"] = 1100;
   connection["ipv6"]["method"] = "ignore";
 
-  asyncCall<QDBusObjectPath>(NM_DBUS_PATH_SETTINGS, NM_DBUS_INTERFACE_SETTINGS, "AddConnection", QVariant::fromValue(connection));
+  asyncCall(NM_DBUS_PATH_SETTINGS, NM_DBUS_INTERFACE_SETTINGS, "AddConnection", QVariant::fromValue(connection));
 }
 
 void WifiManager::tetheringActivated(QDBusPendingCallWatcher *call) {


### PR DESCRIPTION
It would not be a good experience if the user has to wait 3s when trying to edit the tethering password or enabling it, so let's initalize it asynchronously on WifiManager startup.