### PR TITLE
Fix DriverViewWindow crash

### DIFF
--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -69,7 +69,7 @@ DriverViewDialog::DriverViewDialog(QWidget *parent) : DialogBase(parent) {
 
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
-  auto camera = new DriverViewWindow(this);
+  DriverViewWindow camera(this);
   main_layout->addWidget(camera);
   QObject::connect(camera, &DriverViewWindow::clicked, this, &DialogBase::accept);
   QObject::connect(device(), &Device::interactiveTimeout, this, &DialogBase::accept);

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -70,8 +70,8 @@ DriverViewDialog::DriverViewDialog(QWidget *parent) : DialogBase(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
   DriverViewWindow camera(this);
-  main_layout->addWidget(camera);
-  QObject::connect(camera, &DriverViewWindow::clicked, this, &DialogBase::accept);
+  main_layout->addWidget(&camera);
+  QObject::connect(&camera, &DriverViewWindow::clicked, this, &DialogBase::accept);
   QObject::connect(device(), &Device::interactiveTimeout, this, &DialogBase::accept);
 }
 


### PR DESCRIPTION
When previewing the window twice

```
(gdb) bt                                                                                                 
#0  0x0000007fb4d40de0 in main_arena () from /lib/aarch64-linux-gnu/libc.so.6                                                                                                                                      
#1  0x0000007fb3c16624 in ?? () from /lib/aarch64-linux-gnu/libffi.so.8                                  
#2  0x0000007fb3c1383c in ?? () from /lib/aarch64-linux-gnu/libffi.so.8                                  
#3  0x0000007fb50567c4 in ?? () from /lib/aarch64-linux-gnu/libwayland-client.so.0                                                                                                                                 
#4  0x0000007fb505711c in ?? () from /lib/aarch64-linux-gnu/libwayland-client.so.0                                                                                                                                 
#5  0x0000007fb5057444 in wl_display_dispatch_queue_pending () from /lib/aarch64-linux-gnu/libwayland-client.so.0                                                                                                  
#6  0x0000007fafe36078 in EglWaylandWlWindowSurface::CommitBuffer(void*, unsigned int) () from /lib/aarch64-linux-gnu/libeglSubDriverWayland.so                                                                    
#7  0x0000007fafe37e78 in EglWaylandUpdater::UpdaterThread() () from /lib/aarch64-linux-gnu/libeglSubDriverWayland.so                                                                                              
#8  0x0000007fb4c1597c in start_thread (arg=0x0) at ./nptl/pthread_create.c:447                                                                                                                                    
#9  0x0000007fb4c7b7dc in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:79
```