### PR TITLE
cabana: issue filtering by addresses in FindSignal tool

### DIFF
--- a/tools/cabana/tools/findsignal.cc
+++ b/tools/cabana/tools/findsignal.cc
@@ -225,7 +225,7 @@ void FindSignalDlg::setInitialSignals() {
   model->initial_signals.clear();
 
   for (const auto &[id, m] : can->lastMessages()) {
-    if (buses.isEmpty() || buses.contains(id.source) && (addresses.isEmpty() || addresses.contains(id.address))) {
+    if ((buses.isEmpty() || buses.contains(id.source)) && (addresses.isEmpty() || addresses.contains(id.address))) {
       const auto &events = can->events(id);
       auto e = std::lower_bound(events.cbegin(), events.cend(), first_time, CompareCanEvent());
       if (e != events.cend()) {


### PR DESCRIPTION
**Description**

When no buses are set in the filter of the FindSignal tool, the address filter is ignored due to incorrect parentheses.