### PR TITLE
cabana: add live and time-window heatmap modes for enhanced signal analysis

### DIFF
--- a/tools/cabana/binaryview.h
+++ b/tools/cabana/binaryview.h
@@ -39,6 +39,12 @@ public:
   Qt::ItemFlags flags(const QModelIndex &index) const override {
     return (index.column() == column_count - 1) ? Qt::ItemIsEnabled : Qt::ItemIsEnabled | Qt::ItemIsSelectable;
   }
+  const std::vector<std::array<uint32_t, 8>> &getBitFlipChanges(size_t msg_size);
+
+  struct BitFlipTracker {
+    std::optional<std::pair<double, double>> time_range;
+    std::vector<std::array<uint32_t, 8>> flip_counts;
+  } bit_flip_tracker;
 
   struct Item {
     QColor bg_color = QColor(102, 86, 169, 255);
@@ -49,7 +55,7 @@ public:
     bool valid = false;
   };
   std::vector<Item> items;
-
+  bool heatmap_live_mode = true;
   MessageId msg_id;
   int row_count = 0;
   const int column_count = 9;
@@ -65,6 +71,7 @@ public:
   QSet<const cabana::Signal*> getOverlappingSignals() const;
   inline void updateState() { model->updateState(); }
   QSize minimumSizeHint() const override;
+  void setHeatmapLiveMode(bool live) { model->heatmap_live_mode = live; updateState(); }
 
 signals:
   void signalClicked(const cabana::Signal *sig);

--- a/tools/cabana/chart/sparkline.cc
+++ b/tools/cabana/chart/sparkline.cc
@@ -5,15 +5,9 @@
 #include <QPainter>
 
 void Sparkline::update(const MessageId &msg_id, const cabana::Signal *sig, double last_msg_ts, int range, QSize size) {
-  const auto &msgs = can->events(msg_id);
-
-  auto range_start = can->toMonoTime(last_msg_ts - range);
-  auto range_end = can->toMonoTime(last_msg_ts);
-  auto first = std::lower_bound(msgs.cbegin(), msgs.cend(), range_start, CompareCanEvent());
-  auto last = std::upper_bound(first, msgs.cend(), range_end, CompareCanEvent());
-
   points.clear();
   double value = 0;
+  auto [first, last] = can->eventsInRange(msg_id, std::make_pair(last_msg_ts -range, last_msg_ts));
   for (auto it = first; it != last; ++it) {
     if (sig->getValue((*it)->dat, (*it)->size, &value)) {
       points.emplace_back(((*it)->mono_time - (*first)->mono_time) / 1e9, value);

--- a/tools/cabana/detailwidget.cc
+++ b/tools/cabana/detailwidget.cc
@@ -2,7 +2,8 @@
 
 #include <QFormLayout>
 #include <QMenu>
-#include <QSpacerItem>
+#include <QRadioButton>
+#include <QToolBar>
 
 #include "tools/cabana/commands.h"
 #include "tools/cabana/mainwin.h"
@@ -20,19 +21,7 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   tabbar->setContextMenuPolicy(Qt::CustomContextMenu);
   main_layout->addWidget(tabbar);
 
-  // message title
-  QHBoxLayout *title_layout = new QHBoxLayout();
-  title_layout->setContentsMargins(3, 6, 3, 0);
-  auto spacer = new QSpacerItem(0, 1);
-  title_layout->addItem(spacer);
-  title_layout->addWidget(name_label = new ElidedLabel(this), 1);
-  name_label->setStyleSheet("QLabel{font-weight:bold;}");
-  name_label->setAlignment(Qt::AlignCenter);
-  auto edit_btn = new ToolButton("pencil", tr("Edit Message"));
-  title_layout->addWidget(edit_btn);
-  title_layout->addWidget(remove_btn = new ToolButton("x-lg", tr("Remove Message")));
-  spacer->changeSize(edit_btn->sizeHint().width() * 2 + 9, 1);
-  main_layout->addLayout(title_layout);
+  createToolBar();
 
   // warning
   warning_widget = new QWidget(this);
@@ -58,8 +47,6 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   tab_widget->addTab(history_log = new LogsWidget(this), utils::icon("stopwatch"), "&Logs");
   main_layout->addWidget(tab_widget);
 
-  QObject::connect(edit_btn, &QToolButton::clicked, this, &DetailWidget::editMsg);
-  QObject::connect(remove_btn, &QToolButton::clicked, this, &DetailWidget::removeMsg);
   QObject::connect(binary_view, &BinaryView::signalHovered, signal_view, &SignalView::signalHovered);
   QObject::connect(binary_view, &BinaryView::signalClicked, [this](const cabana::Signal *s) { signal_view->selectSignal(s, true); });
   QObject::connect(binary_view, &BinaryView::editSignal, signal_view->model, &SignalModel::saveSignal);
@@ -78,6 +65,41 @@ DetailWidget::DetailWidget(ChartsWidget *charts, QWidget *parent) : charts(chart
   });
   QObject::connect(tabbar, &QTabBar::tabCloseRequested, tabbar, &QTabBar::removeTab);
   QObject::connect(charts, &ChartsWidget::seriesChanged, signal_view, &SignalView::updateChartState);
+}
+
+void DetailWidget::createToolBar() {
+  QToolBar *toolbar = new QToolBar(this);
+  int icon_size = style()->pixelMetric(QStyle::PM_SmallIconSize);
+  toolbar->setIconSize({icon_size, icon_size});
+  toolbar->addWidget(name_label = new ElidedLabel(this));
+  name_label->setStyleSheet("QLabel{font-weight:bold;}");
+
+  QWidget *spacer = new QWidget();
+  spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+  toolbar->addWidget(spacer);
+
+// Heatmap label and radio buttons
+  toolbar->addWidget(new QLabel(tr("Heatmap:"), this));
+  auto *heatmap_live = new QRadioButton(tr("Live"), this);
+  auto *heatmap_all = new QRadioButton(tr("All"), this);
+  heatmap_live->setChecked(true);
+
+  toolbar->addWidget(heatmap_live);
+  toolbar->addWidget(heatmap_all);
+
+  // Edit and remove buttons
+  toolbar->addSeparator();
+  toolbar->addAction(utils::icon("pencil"), tr("Edit Message"), this, &DetailWidget::editMsg);
+  action_remove_msg = toolbar->addAction(utils::icon("x-lg"), tr("Remove Message"), this, &DetailWidget::removeMsg);
+
+  layout()->addWidget(toolbar);
+
+  connect(heatmap_live, &QAbstractButton::toggled, this, [this](bool on) { binary_view->setHeatmapLiveMode(on); });
+  connect(can, &AbstractStream::timeRangeChanged, this, [=](const std::optional<std::pair<double, double>> &range) {
+    auto text = range ? QString("%1 - %2").arg(range->first, 0, 'f', 3).arg(range->second, 0, 'f', 3) : "All";
+    heatmap_all->setText(text);
+    (range ? heatmap_all : heatmap_live)->setChecked(true);
+  });
 }
 
 void DetailWidget::showTabBarContextMenu(const QPoint &pt) {
@@ -131,14 +153,11 @@ void DetailWidget::refresh() {
     for (auto s : binary_view->getOverlappingSignals()) {
       warnings.push_back(tr("%1 has overlapping bits.").arg(s->name));
     }
-  } else {
-    warnings.push_back(tr("Drag-Select in binary view to create new signal."));
   }
-
   QString msg_name = msg ? QString("%1 (%2)").arg(msg->name, msg->transmitter) : msgName(msg_id);
   name_label->setText(msg_name);
   name_label->setToolTip(msg_name);
-  remove_btn->setEnabled(msg != nullptr);
+  action_remove_msg->setEnabled(msg != nullptr);
 
   if (!warnings.isEmpty()) {
     warning_label->setText(warnings.join('\n'));

--- a/tools/cabana/detailwidget.h
+++ b/tools/cabana/detailwidget.h
@@ -36,6 +36,7 @@ public:
   void refresh();
 
 private:
+  void createToolBar();
   void showTabBarContextMenu(const QPoint &pt);
   void editMsg();
   void removeMsg();
@@ -47,7 +48,7 @@ private:
   QWidget *warning_widget;
   TabBar *tabbar;
   QTabWidget *tab_widget;
-  QToolButton *remove_btn;
+  QAction *action_remove_msg;
   LogsWidget *history_log;
   BinaryView *binary_view;
   SignalView *signal_view;

--- a/tools/cabana/streams/abstractstream.h
+++ b/tools/cabana/streams/abstractstream.h
@@ -53,6 +53,7 @@ struct CompareCanEvent {
 };
 
 typedef std::unordered_map<MessageId, std::vector<const CanEvent *>> MessageEventsMap;
+using CanEventIter = std::vector<const CanEvent *>::const_iterator;
 
 class AbstractStream : public QObject {
   Q_OBJECT
@@ -85,6 +86,7 @@ public:
   inline const std::vector<const CanEvent *> &allEvents() const { return all_events_; }
   const CanData &lastMessage(const MessageId &id) const;
   const std::vector<const CanEvent *> &events(const MessageId &id) const;
+  std::pair<CanEventIter, CanEventIter> eventsInRange(const MessageId &id, std::optional<std::pair<double, double>> time_range) const;
 
   size_t suppressHighlighted();
   void clearSuppressed();


### PR DESCRIPTION
This PR adds two heatmap modes: Live for real-time bit changes and Time-Window for comparing bit patterns across multiple time frames. 

- **Time-Window mode** allows users to select diffent time windows for comparing signal behavior. It's particularly useful for detecting long-term trends vs. short bursts of activity. Visualizing heatmaps across different time frames helps users identify evolving patterns or activity during specific periods.
- **Live mode** enables real-time analysis of incoming messages, offering immediate feedback on bit-level changes as they occur.

These modes enhance users' ability to track trends and fluctuations in CAN message signals over time.

| Live mode  | Time-Window mode |
| ------------- | ------------- |
| ![Screenshot from 2024-12-20 14-55-45](https://github.com/user-attachments/assets/e8cfe468-6d9c-4238-adc2-dbe913bcbd2f)  | ![Screenshot from 2024-12-20 14-55-56](https://github.com/user-attachments/assets/55aa81b1-1278-4fb5-814c-dc90aa735ffb)  |

