### PR TITLE
replay: refine video frame push after seek to when paused

### DIFF
--- a/tools/replay/camera.h
+++ b/tools/replay/camera.h
@@ -18,6 +18,7 @@ public:
   ~CameraServer();
   void pushFrame(CameraType type, FrameReader* fr, const Event *event);
   void waitForSent();
+  void clearQueue();
 
 protected:
   struct Camera {

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -89,7 +89,7 @@ void Replay::interruptStream(const std::function<bool()> &update_fn) {
     interrupt_requested_ = true;
     std::unique_lock lock(stream_lock_);
     events_ready_ = update_fn();
-    interrupt_requested_ = user_paused_ && !pause_after_next_frame_;
+    interrupt_requested_ = user_paused_;
   }
   stream_cv_.notify_one();
 }
@@ -116,9 +116,6 @@ void Replay::seekTo(double seconds, bool relative) {
       seeked_to_sec = *seeking_to_;
       seeking_to_.reset();
     }
-
-    // if paused, resume for exactly one frame to update
-    pause_after_next_frame_ = user_paused_;
     return false;
   });
 
@@ -147,7 +144,6 @@ void Replay::pause(bool pause) {
     interruptStream([=]() {
       rWarning("%s at %.2f s", pause ? "paused..." : "resuming", currentSeconds());
       user_paused_ = pause;
-      pause_after_next_frame_ = false;
       return !pause;
     });
   }
@@ -309,7 +305,6 @@ std::vector<Event>::const_iterator Replay::publishEvents(std::vector<Event>::con
   uint64_t evt_start_ts = cur_mono_time_;
   uint64_t loop_start_ts = nanos_since_boot();
   double prev_replay_speed = speed_;
-  uint64_t first_mono_time = first->mono_time;
 
   for (; !interrupt_requested_ && first != last; ++first) {
     const Event &evt = *first;
@@ -347,12 +342,6 @@ std::vector<Event>::const_iterator Replay::publishEvents(std::vector<Event>::con
         camera_server_->waitForSent();
       }
       publishFrame(&evt);
-    }
-
-    const auto T_ONE_FRAME = 0.050;
-    if (pause_after_next_frame_ && abs(toSeconds(evt.mono_time) - toSeconds(first_mono_time)) > T_ONE_FRAME) {
-      pause_after_next_frame_ = false;
-      interrupt_requested_ = true;
     }
   }
 

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -247,6 +247,7 @@ void Replay::publishMessage(const Event *e) {
 }
 
 void Replay::publishFrame(double seconds) {
+  // TODO: Extend to support pushing frames from the wide road camera and driver camera if available
   const auto &events = event_data_->events;
   uint64_t mono_time = route_start_ts_ + seconds * 1e9;
   auto it = std::lower_bound(events.begin(), events.end(), Event(cereal::Event::Which::INIT_DATA, mono_time, {}));

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -85,7 +85,6 @@ private:
   std::thread stream_thread_;
   std::mutex stream_lock_;
   bool user_paused_ = false;
-  bool pause_after_next_frame_ = false;
   std::condition_variable stream_cv_;
   int current_segment_ = 0;
   std::optional<double> seeking_to_;

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -76,6 +76,7 @@ private:
                                                    std::vector<Event>::const_iterator last);
   void publishMessage(const Event *e);
   void publishFrame(const Event *e);
+  void publishFrame(double seconds);
   void checkSeekProgress(double seeked_to_sec);
 
   std::unique_ptr<SegmentManager> seg_mgr_;


### PR DESCRIPTION
This PR resolves the issue of reactivating the stream thread after a seek to push the next video frame, which could trigger unnecessary events and disrupt the pause functionality, as mentioned [here](https://github.com/commaai/openpilot/pull/34237#issuecomment-2556801587). The updated approach directly pushes the frame using publishFrame after a successful seek, maintaining the pause state and preventing unwanted disruptions.

The frame queue is also cleared before calling publishFrame, improving the scrubbing experience, especially during software decoding.

**TODO after this pr:**

Since this feature will significantly increase decoding workload, especially during scrubbing, where each seek requires finding the previous keyframe and decompressing sequentially until the desired frame is reached, we may need to dynamically enable or disable FFmpeg's threaded decoding based on the current decoding time. If decoding is slow, threading will be automatically enabled to improve performance. with the trade-off that CPU usage could increase by up to 100%.