### PR TITLE
cabana: real-time cursor and video frame sync for chart and video

### DIFF
--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -176,6 +176,7 @@ QRect ChartsWidget::chartVisibleRect(ChartView *chart) {
 }
 
 void ChartsWidget::showValueTip(double sec) {
+  emit showTip(sec);
   if (sec < 0 && !value_tip_visible_) return;
 
   value_tip_visible_ = sec >= 0;
@@ -529,20 +530,14 @@ void ChartsContainer::dropEvent(QDropEvent *event) {
 
 void ChartsContainer::paintEvent(QPaintEvent *ev) {
   if (!drop_indictor_pos.isNull() && !childAt(drop_indictor_pos)) {
-    QRect r;
+    QRect r = geometry();
+    r.setHeight(CHART_SPACING);
     if (auto insert_after = getDropAfter(drop_indictor_pos)) {
-      QRect area = insert_after->geometry();
-      r = QRect(area.left(), area.bottom() + 1, area.width(), CHART_SPACING);
-    } else {
-      r = geometry();
-      r.setHeight(CHART_SPACING);
+      r.moveTop(insert_after->geometry().bottom());
     }
 
     QPainter p(this);
-    p.setPen(QPen(palette().highlight(), 2));
-    p.drawLine(r.topLeft() + QPoint(1, 0), r.bottomLeft() + QPoint(1, 0));
-    p.drawLine(r.topLeft() + QPoint(0, r.height() / 2), r.topRight() + QPoint(0, r.height() / 2));
-    p.drawLine(r.topRight(), r.bottomRight());
+    p.fillRect(r, palette().highlight());
   }
 }
 

--- a/tools/cabana/chart/chartswidget.h
+++ b/tools/cabana/chart/chartswidget.h
@@ -52,6 +52,7 @@ public slots:
 signals:
   void toggleChartsDocking();
   void seriesChanged();
+  void showTip(double seconds);
 
 private:
   QSize minimumSizeHint() const override;

--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -191,6 +191,7 @@ void MainWindow::createDockWidgets() {
   video_splitter->handle(1)->setEnabled(!can->liveStreaming());
   video_dock->setWidget(video_splitter);
   QObject::connect(charts_widget, &ChartsWidget::toggleChartsDocking, this, &MainWindow::toggleChartsDocking);
+  QObject::connect(charts_widget, &ChartsWidget::showTip, video_widget, &VideoWidget::showThumbnail);
 }
 
 void MainWindow::createStatusBar() {

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -328,20 +328,26 @@ void StreamCameraView::paintGL() {
   CameraWidget::paintGL();
 
   QPainter p(this);
-  if (auto alert = getReplay()->findAlertAtTime(can->currentSec())) {
-    drawAlert(p, rect(), *alert);
+  double display_time = can->currentSec();
+
+  if (thumbnail_dispaly_time >= 0) {
+    if (can->isPaused()) {
+      display_time = thumbnail_dispaly_time;
+      p.fillRect(rect(), Qt::black);
+      auto it = big_thumbnails.lowerBound(can->toMonoTime(thumbnail_dispaly_time));
+      if (it != big_thumbnails.end()) {
+        QPixmap scaled_thumb = it.value().scaled(rect().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        int x = (rect().width() - scaled_thumb.width()) / 2;
+        int y = (rect().height() - scaled_thumb.height()) / 2;
+        p.drawPixmap(x, y, scaled_thumb);
+      }
+    } else {
+      drawThumbnail(p);
+    }
   }
 
-  if (can->isPaused()) {
-    auto it = big_thumbnails.lowerBound(can->toMonoTime(thumbnail_dispaly_time));
-    if (it != big_thumbnails.end()) {
-      QPixmap scaled_thumb = it.value().scaled(rect().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-      int x = (rect().width() - scaled_thumb.width()) / 2;
-      int y = (rect().height() - scaled_thumb.height()) / 2;
-      p.drawPixmap(x, y, scaled_thumb);
-    }
-  } else {
-    drawThumbnail(p);
+  if (auto alert = getReplay()->findAlertAtTime(display_time)) {
+    drawAlert(p, rect(), *alert);
   }
 
   if (can->isPaused()) {

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -150,7 +150,6 @@ QWidget *VideoWidget::createCameraWidget() {
 
   QObject::connect(slider, &QSlider::sliderReleased, [this]() { can->seekTo(slider->currentSecond()); });
   QObject::connect(can, &AbstractStream::paused, cam_widget, [c = cam_widget]() { c->showPausedOverlay(); });
-  QObject::connect(can, &AbstractStream::resume, cam_widget, [c = cam_widget]() { c->update(); });
   QObject::connect(can, &AbstractStream::eventsMerged, this, [this]() { slider->update(); });
   QObject::connect(cam_widget, &CameraWidget::clicked, []() { can->pause(!can->isPaused()); });
   QObject::connect(cam_widget, &CameraWidget::vipcAvailableStreamsUpdated, this, &VideoWidget::vipcAvailableStreamsUpdated);
@@ -227,10 +226,10 @@ void VideoWidget::showThumbnail(double seconds) {
   slider->update();
 }
 
-bool VideoWidget::eventFilter(QObject *, QEvent *event) {
+bool VideoWidget::eventFilter(QObject *obj, QEvent *event) {
   if (event->type() == QEvent::MouseMove) {
     auto [min_sec, max_sec] = can->timeRange().value_or(std::make_pair(can->minSeconds(), can->maxSeconds()));
-    showThumbnail(min_sec + (((QMouseEvent *)event)->pos().x() * (max_sec - min_sec) / width()));
+    showThumbnail(min_sec + static_cast<QMouseEvent *>(event)->pos().x() * (max_sec - min_sec) / slider->width());
   } else if (event->type() == QEvent::Leave) {
     showThumbnail(-1);
   }

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -360,10 +360,9 @@ void StreamCameraView::drawScrubThumbnail(QPainter &p) {
   auto it = big_thumbnails.lowerBound(can->toMonoTime(thumbnail_dispaly_time));
   if (it != big_thumbnails.end()) {
     QPixmap scaled_thumb = it.value().scaled(rect().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    int x = (rect().width() - scaled_thumb.width()) / 2;
-    int y = (rect().height() - scaled_thumb.height()) / 2;
-    p.drawPixmap(x, y, scaled_thumb);
-    drawTime(p, QRect{x, y, scaled_thumb.width(), scaled_thumb.height()}, thumbnail_dispaly_time);
+    QRect thumb_rect(rect().center() - scaled_thumb.rect().center(), scaled_thumb.size());
+    p.drawPixmap(thumb_rect.topLeft(), scaled_thumb);
+    drawTime(p, thumb_rect, thumbnail_dispaly_time);
   }
 }
 

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -43,6 +43,8 @@ private:
   QPixmap generateThumbnail(QPixmap thumbnail, double seconds);
   void drawAlert(QPainter &p, const QRect &rect, const Timeline::Entry &alert);
   void drawThumbnail(QPainter &p);
+  void drawScrubThumbnail(QPainter &p);
+  void drawTime(QPainter &p, const QRect &rect, double seconds);
 
   QPropertyAnimation *fade_animation;
   QMap<uint64_t, QPixmap> big_thumbnails;

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -28,6 +27,7 @@ public:
   void mousePressEvent(QMouseEvent *e) override;
   void paintEvent(QPaintEvent *ev) override;
   const double factor = 1000.0;
+  double thumbnail_dispaly_time = -1;
 };
 
 class StreamCameraView : public CameraWidget {
@@ -43,11 +43,11 @@ private:
   QPixmap generateThumbnail(QPixmap thumbnail, double seconds);
   void drawAlert(QPainter &p, const QRect &rect, const Timeline::Entry &alert);
   void drawThumbnail(QPainter &p);
-  bool eventFilter(QObject *obj, QEvent *event) override;
 
   QPropertyAnimation *fade_animation;
   QMap<uint64_t, QPixmap> thumbnails;
-  std::optional<QPoint> thumbnail_pt_;
+  double thumbnail_dispaly_time = -1;
+  friend class VideoWidget;
 };
 
 class VideoWidget : public QFrame {
@@ -55,8 +55,10 @@ class VideoWidget : public QFrame {
 
 public:
   VideoWidget(QWidget *parnet = nullptr);
+  void showThumbnail(double seconds);
 
 protected:
+  bool eventFilter(QObject *obj, QEvent *event) override;
   QString formatTime(double sec, bool include_milliseconds = false);
   void timeRangeChanged();
   void updateState();

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -45,6 +45,7 @@ private:
   void drawThumbnail(QPainter &p);
 
   QPropertyAnimation *fade_animation;
+  QMap<uint64_t, QPixmap> big_thumbnails;
   QMap<uint64_t, QPixmap> thumbnails;
   double thumbnail_dispaly_time = -1;
   friend class VideoWidget;

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -89,7 +89,7 @@ void Replay::interruptStream(const std::function<bool()> &update_fn) {
     interrupt_requested_ = true;
     std::unique_lock lock(stream_lock_);
     events_ready_ = update_fn();
-    interrupt_requested_ = user_paused_ && !pause_after_next_frame_;
+    interrupt_requested_ = user_paused_;
   }
   stream_cv_.notify_one();
 }
@@ -116,9 +116,6 @@ void Replay::seekTo(double seconds, bool relative) {
       seeked_to_sec = *seeking_to_;
       seeking_to_.reset();
     }
-
-    // if paused, resume for exactly one frame to update
-    pause_after_next_frame_ = user_paused_;
     return false;
   });
 
@@ -147,7 +144,6 @@ void Replay::pause(bool pause) {
     interruptStream([=]() {
       rWarning("%s at %.2f s", pause ? "paused..." : "resuming", currentSeconds());
       user_paused_ = pause;
-      pause_after_next_frame_ = false;
       return !pause;
     });
   }
@@ -309,7 +305,6 @@ std::vector<Event>::const_iterator Replay::publishEvents(std::vector<Event>::con
   uint64_t evt_start_ts = cur_mono_time_;
   uint64_t loop_start_ts = nanos_since_boot();
   double prev_replay_speed = speed_;
-  uint64_t first_mono_time = first->mono_time;
 
   for (; !interrupt_requested_ && first != last; ++first) {
     const Event &evt = *first;
@@ -347,12 +342,6 @@ std::vector<Event>::const_iterator Replay::publishEvents(std::vector<Event>::con
         camera_server_->waitForSent();
       }
       publishFrame(&evt);
-    }
-
-    const auto T_ONE_FRAME = 0.050;
-    if (pause_after_next_frame_ && abs(toSeconds(evt.mono_time) - toSeconds(first_mono_time)) > T_ONE_FRAME) {
-      pause_after_next_frame_ = false;
-      interrupt_requested_ = true;
     }
   }
 

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -85,7 +85,6 @@ private:
   std::thread stream_thread_;
   std::mutex stream_lock_;
   bool user_paused_ = false;
-  bool pause_after_next_frame_ = false;
   std::condition_variable stream_cv_;
   int current_segment_ = 0;
   std::optional<double> seeking_to_;


### PR DESCRIPTION
This PR introduces real-time, high-performance synchronization between the cursor and video frames, enhancing the user experience when interacting with the chart and video stream.

- **During Playback:** While the stream is playing, hovering over the chart updates the video thumbnail to display the corresponding frame, allowing users to visually align data points with the video.

    https://github.com/user-attachments/assets/008fc43b-9d18-44d2-83a6-10d22166da27

- **While Paused:**  When the stream is paused, the video area is painted with a larger thumbnail that syncs with the cursor’s position on the chart, providing a preview of the corresponding frame—similar to YouTube’s scrubbing behavior.

    https://github.com/user-attachments/assets/182898e9-0944-4c6a-91f9-56c813970d48

- **Slider Interaction:** Dragging the slider also scrubs through the video frames, providing real-time feedback as the user navigates through the timeline.

    https://github.com/user-attachments/assets/dafe3b27-7f72-4462-ab69-b308598eb57a

- **Slider time indicator:** Added a dynamic time indicator on the slider bar that follows the cursor, displaying the corresponding time position on the slider.
   ![2024-12-21_15-48](https://github.com/user-attachments/assets/8e04799f-28ff-44fb-bb4a-371497810963)

**NOTE:**

Changes from PR #34237 have been reverted in this PR due to event synchronization issues and significant performance delays on laptops without CUDA decoding, For more details, refer to the discussions in PRs #34237 and #34298.

**TODO:**

// TODO: Dynamically generate more thumbnails during frame decoding to improve scrubbing smoothness.