### PR TITLE
cabana: fix crash in live streaming mode by skipping thumbnail display

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -222,6 +222,8 @@ void VideoWidget::updatePlayBtnState() {
 }
 
 void VideoWidget::showThumbnail(double seconds) {
+  if (can->liveStreaming()) return;
+
   cam_widget->thumbnail_dispaly_time = seconds;
   slider->thumbnail_dispaly_time = seconds;
   cam_widget->update();


### PR DESCRIPTION
This issue was introduced by https://github.com/commaai/openpilot/pull/34301.
In live streaming mode, there is no video widget or slider bar, which causes a crash when attempting to display thumbnails. This PR resolves the issue by skipping the thumbnail display function when live streaming mode is active.