### PR TITLE
Speed up CI setup to ~25-~40s with actions/cache use

### DIFF
--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -51,6 +51,36 @@ runs:
       run: |
         find . -type f -executable -not -perm 755 -exec chmod 755 {} \;
         find . -type f -not -executable -not -perm 644 -exec chmod 644 {} \;
+    - id: docker-cache-restore
+      uses: ./.github/workflows/auto-cache
+      with:
+        path: .ci_cache/docker
+        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_build.sh') }}
+        restore-keys: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_build.sh') }}
+
+    - shell: bash
+      if: steps.docker-cache-restore.outputs.cache-hit == 'true'
+      run: |
+        sudo setfacl --restore=.ci_cache/docker/permissions
+        sudo rm -rf /var/lib/docker
+        sudo mv .ci_cache/docker /var/lib/
+        sudo systemctl restart docker
     # build our docker image
     - shell: bash
-      run: eval ${{ env.BUILD }}
+      if: steps.docker-cache-restore.outputs.cache-hit != 'true'
+      run: |
+        eval ${{ env.BUILD }}
+        docker builder prune -a --force
+        sudo systemctl stop docker
+        sudo rm -rf /var/lib/docker/volumes
+        sudo cp -R /var/lib/docker .ci_cache/
+        sudo getfacl -R .ci_cache/docker > .ci_cache/docker/permissions
+        sudo chmod -R 777 .ci_cache/docker
+    - id: docker-cache-save
+      if: steps.docker-cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      env:
+        ZSTD_NBTHREADS: 0
+      with:
+        path: .ci_cache/docker
+        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_build.sh') }}

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -55,8 +55,8 @@ runs:
       uses: ./.github/workflows/auto-cache
       with:
         path: .ci_cache/docker
-        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_*') }}
-        restore-keys: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_*') }}
+        restore-keys: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml') }}
+        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml') }}
 
     - shell: bash
       if: steps.docker-cache-restore.outputs.cache-hit == 'true'
@@ -83,4 +83,4 @@ runs:
         ZSTD_NBTHREADS: 0
       with:
         path: .ci_cache/docker
-        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_*') }}
+        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml') }}

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -55,8 +55,8 @@ runs:
       uses: ./.github/workflows/auto-cache
       with:
         path: .ci_cache/docker
-        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_build.sh') }}
-        restore-keys: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_build.sh') }}
+        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_*') }}
+        restore-keys: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_*') }}
 
     - shell: bash
       if: steps.docker-cache-restore.outputs.cache-hit == 'true'
@@ -83,4 +83,4 @@ runs:
         ZSTD_NBTHREADS: 0
       with:
         path: .ci_cache/docker
-        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_build.sh') }}
+        key: docker-${{ hashFiles('Dockerfile.openpilot_base', 'tools/install_ubuntu_dependencies.sh', 'tools/install_python_dependencies.sh', 'uv.lock', '.github/workflows/setup/action.yaml', 'selfdrive/test/docker_*') }}


### PR DESCRIPTION
For #30706
Github actions cache speed is quite inconsistent (varies from 50MB/s to 300+MB/s), so worst case scenario is ~40s.
Example run: https://github.com/commaai/openpilot/actions/runs/12552012526