### PR TITLE
cabana: fix missing transmitter after undoing DBC message removal

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -45,6 +45,7 @@ cabana::Msg &cabana::Msg::operator=(const cabana::Msg &other) {
   name = other.name;
   size = other.size;
   comment = other.comment;
+  transmitter = other.transmitter;
 
   for (auto s : sigs) delete s;
   sigs.clear();


### PR DESCRIPTION
This PR addresses a bug where the transmitter is missing after undoing the removal of a DBC message. The issue occurs when a message with a defined transmitter (e.g., "DSU") is removed, and then the undo action (Ctrl+Z) is performed. After undoing, the transmitter is incorrectly displayed as the default transmitter "XXX" instead of the original one.

Steps to reproduce:
1. Remove a message with a transmitter (e.g., "DSU").
2. Press Ctrl+Z to undo the removal.
3. The transmitter is incorrectly shown as "XXX" instead of the original transmitter.

This fix ensures the correct transmitter is restored after the undo action.