### PR TITLE
Keyboard: add missing control btns to uppercase

### DIFF
--- a/selfdrive/ui/qt/widgets/keyboard.cc
+++ b/selfdrive/ui/qt/widgets/keyboard.cc
@@ -116,7 +116,7 @@ Keyboard::Keyboard(QWidget *parent) : QFrame(parent) {
     {"Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"},
     {"A", "S", "D", "F", "G", "H", "J", "K", "L"},
     {"↓", "Z", "X", "C", "V", "B", "N", "M", BACKSPACE_KEY},
-    {"123", "  ", ".", ENTER_KEY},
+    {"123", "/", "-", "  ", ".", ENTER_KEY},
   };
   main_layout->addWidget(new KeyboardLayout(this, uppercase));
 


### PR DESCRIPTION
When toggling between lowercase and uppercase the control buttons `/` and `-` don't appear. These control buttons are still useful for branch names and wifi for both lowercase and uppercase.
- Bigger space button for uppercase keyboard is less useful than having the same control btns as lowercase
- `/` and `-` added to uppercase keyboard
- Added the keyboard_uppercase to show in `ui_preview.yaml` with PR #34347 
<br>

# Current UI
![no-slash-when-caps](https://github.com/user-attachments/assets/56975a60-6838-4181-9d41-7302ef7e992c)
<br>

# Proposed UI
![added-slash](https://github.com/user-attachments/assets/fb3e09bc-36d6-409d-ab43-d07115192f30)
