### PR TITLE
loggerd: typing and remove unused default arg

### DIFF
--- a/system/loggerd/config.py
+++ b/system/loggerd/config.py
@@ -9,7 +9,7 @@ STATS_DIR_FILE_LIMIT = 10000
 STATS_SOCKET = "ipc:///tmp/stats"
 STATS_FLUSH_TIME_S = 60
 
-def get_available_percent(default=None):
+def get_available_percent(default: float) -> float:
   try:
     statvfs = os.statvfs(Paths.log_root())
     available_percent = 100.0 * statvfs.f_bavail / statvfs.f_blocks
@@ -19,7 +19,7 @@ def get_available_percent(default=None):
   return available_percent
 
 
-def get_available_bytes(default=None):
+def get_available_bytes(default: int) -> int:
   try:
     statvfs = os.statvfs(Paths.log_root())
     available_bytes = statvfs.f_bavail * statvfs.f_frsize


### PR DESCRIPTION
This was causing a mypy error in https://github.com/commaai/openpilot/blob/master/system/loggerd/deleter.py#L50 since these fns could return None, but everywhere they are used a default value is provided.