### PR TITLE
modeld: properly release OpenCL context in  `__dealloc__` method

### DIFF
--- a/common/clutil.cc
+++ b/common/clutil.cc
@@ -79,6 +79,10 @@ cl_context cl_create_context(cl_device_id device_id) {
   return CL_CHECK_ERR(clCreateContext(NULL, 1, &device_id, NULL, NULL, &err));
 }
 
+void cl_release_context(cl_context context) {
+  clReleaseContext(context);
+}
+
 cl_program cl_program_from_file(cl_context ctx, cl_device_id device_id, const char* path, const char* args) {
   return cl_program_from_source(ctx, device_id, util::read_file(path), args);
 }

--- a/common/clutil.h
+++ b/common/clutil.h
@@ -23,6 +23,7 @@
 
 cl_device_id cl_get_device_id(cl_device_type device_type);
 cl_context cl_create_context(cl_device_id device_id);
+void cl_release_context(cl_context context);
 cl_program cl_program_from_source(cl_context ctx, cl_device_id device_id, const std::string& src, const char* args = nullptr);
 cl_program cl_program_from_binary(cl_context ctx, cl_device_id device_id, const uint8_t* binary, size_t length, const char* args = nullptr);
 cl_program cl_program_from_file(cl_context ctx, cl_device_id device_id, const char* path, const char* args);

--- a/selfdrive/modeld/models/commonmodel.pxd
+++ b/selfdrive/modeld/models/commonmodel.pxd
@@ -10,6 +10,7 @@ cdef extern from "common/clutil.h":
   cdef unsigned long CL_DEVICE_TYPE_DEFAULT
   cl_device_id cl_get_device_id(unsigned long)
   cl_context cl_create_context(cl_device_id)
+  void cl_release_context(cl_context)
 
 cdef extern from "selfdrive/modeld/models/commonmodel.h":
   cppclass ModelFrame:

--- a/selfdrive/modeld/models/commonmodel_pyx.pyx
+++ b/selfdrive/modeld/models/commonmodel_pyx.pyx
@@ -8,7 +8,7 @@ from libc.stdint cimport uintptr_t
 
 from msgq.visionipc.visionipc cimport cl_mem
 from msgq.visionipc.visionipc_pyx cimport VisionBuf, CLContext as BaseCLContext
-from .commonmodel cimport CL_DEVICE_TYPE_DEFAULT, cl_get_device_id, cl_create_context
+from .commonmodel cimport CL_DEVICE_TYPE_DEFAULT, cl_get_device_id, cl_create_context, cl_release_context
 from .commonmodel cimport mat3, ModelFrame as cppModelFrame, DrivingModelFrame as cppDrivingModelFrame, MonitoringModelFrame as cppMonitoringModelFrame
 
 
@@ -16,6 +16,10 @@ cdef class CLContext(BaseCLContext):
   def __cinit__(self):
     self.device_id = cl_get_device_id(CL_DEVICE_TYPE_DEFAULT)
     self.context = cl_create_context(self.device_id)
+
+  def __dealloc__(self):
+    if self.context:
+      cl_release_context(self.context)
 
 cdef class CLMem:
   @staticmethod


### PR DESCRIPTION
This change ensures the OpenCL context is properly released in the `__dealloc__` method, aligning with best practices for OpenCL context handling and preventing potential memory leaks.