### PR TITLE
WIP: Attempt to speed up CI

### DIFF
--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -4,31 +4,86 @@ ENV PYTHONUNBUFFERED=1
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo tzdata locales ssh pulseaudio xvfb x11-xserver-utils gnome-screenshot python3-tk python3-dev && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends sudo tzdata locales ssh pulseaudio xvfb x11-xserver-utils gnome-screenshot python3-tk python3-dev \
+    ca-certificates \
+    clang \
+    build-essential \
+    gcc-arm-none-eabi \
+    liblzma-dev \
+    capnproto \
+    libcapnp-dev \
+    libcurl4-openssl-dev \
+    git \
+    git-lfs \
+    ffmpeg && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libavformat-dev \q
+    libavcodec-dev \
+    libavdevice-dev \
+    libavutil-dev \
+    libavfilter-dev \
+    libbz2-dev \
+    libeigen3-dev \
+    libffi-dev \
+    libglew-dev \
+    libgles2-mesa-dev \
+    libglfw3-dev \
+    libglib2.0-0 \
+    libqt5charts5-dev \
+    libncurses5-dev \
+    libssl-dev \
+    libusb-1.0-0-dev \
+    libzmq3-dev \
+    libzstd-dev \
+    libsqlite3-dev \
+    libsystemd-dev && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    opencl-headers \
+    ocl-icd-libopencl1 \
+    ocl-icd-opencl-dev \
+    portaudio19-dev \
+    qttools5-dev-tools \
+    libqt5svg5-dev \
+    libqt5serialbus5-dev  \
+    libqt5x11extras5-dev \
+    g++-12 && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    qtbase5-dev \
+    qtchooser \
+    qt5-qmake \
+    qtbase5-dev-tools \
+    python3-dev \
+    python3-venv \
+    libqt5opengl5-dev && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && \
+    cd /usr/lib/gcc/arm-none-eabi/* && \
+    rm -rf arm/ thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
+
+
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-COPY tools/install_ubuntu_dependencies.sh /tmp/tools/
-RUN /tmp/tools/install_ubuntu_dependencies.sh && \
-    rm -rf /var/lib/apt/lists/* /tmp/* && \
-    cd /usr/lib/gcc/arm-none-eabi/* && \
-    rm -rf arm/ thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
-
 # Add OpenCL
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     alien \
-    unzip \
     tar \
     curl \
     xz-utils \
     dbus \
     gcc-arm-none-eabi \
-    tmux \
     vim \
     libx11-6 \
     wget \
@@ -61,6 +116,8 @@ ENV QTWEBENGINE_DISABLE_SANDBOX=1
 
 RUN dbus-uuidgen > /etc/machine-id
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 ARG USER=batman
 ARG USER_UID=1001
 RUN useradd -m -s /bin/bash -u $USER_UID $USER
@@ -69,13 +126,15 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER $USER
 
 COPY --chown=$USER pyproject.toml uv.lock /home/$USER
-COPY --chown=$USER tools/install_python_dependencies.sh /home/$USER/tools/
 
 ENV VIRTUAL_ENV=/home/$USER/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN cd /home/$USER && \
-    tools/install_python_dependencies.sh && \
+    uv sync --frozen --all-extras && \
+    . .venv/bin/activate && \
     rm -rf tools/ pyproject.toml uv.lock .cache
+
 
 USER root
 RUN sudo git config --global --add safe.directory /tmp/openpilot
+

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -137,4 +137,3 @@ RUN cd /home/$USER && \
 
 USER root
 RUN sudo git config --global --add safe.directory /tmp/openpilot
-

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -115,7 +115,7 @@ ENV QTWEBENGINE_DISABLE_SANDBOX=1
 
 RUN dbus-uuidgen > /etc/machine-id
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.5.18 /uv /uvx /bin/
 
 ARG USER=batman
 ARG USER_UID=1001

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -80,11 +80,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     alien \
     tar \
-    curl \
     xz-utils \
     dbus \
     gcc-arm-none-eabi \
-    vim \
     libx11-6 \
     wget \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -69,7 +69,8 @@ RUN apt-get update && \
     python3-venv \
     ffmpeg \
     wget \
-    libqt5opengl5-dev && \
+    libqt5opengl5-dev \
+    x11-xserver-utils && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
     rm -rf arm/ thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
 

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -20,7 +20,7 @@ RUN apt-get update && \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libavformat-dev \q
+    libavformat-dev \
     libavcodec-dev \
     libavdevice-dev \
     libavutil-dev \

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -3,19 +3,24 @@ FROM ubuntu:24.04
 ENV PYTHONUNBUFFERED=1
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo tzdata locales ssh pulseaudio xvfb x11-xserver-utils gnome-screenshot python3-tk python3-dev \
+    apt-get install -y --no-install-recommends sudo tzdata locales ssh pulseaudio xvfb gnome-screenshot python3-tk python3-dev \
+    python3-venv \
     ca-certificates \
-    clang \
-    build-essential \
-    gcc-arm-none-eabi \
-    liblzma-dev \
     capnproto \
     libcapnp-dev \
     libcurl4-openssl-dev \
     git \
-    git-lfs \
-    ffmpeg && \
+    git-lfs && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    liblzma-dev && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 RUN apt-get update && \
@@ -61,8 +66,8 @@ RUN apt-get update && \
     qtchooser \
     qt5-qmake \
     qtbase5-dev-tools \
-    python3-dev \
     python3-venv \
+    ffmpeg \
     libqt5opengl5-dev && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
     cd /usr/lib/gcc/arm-none-eabi/* && \
@@ -77,20 +82,16 @@ ENV LC_ALL=en_US.UTF-8
 
 # Add OpenCL
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    apt-utils \
-    alien \
     tar \
-    xz-utils \
     dbus \
     gcc-arm-none-eabi \
     libx11-6 \
-    wget \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /tmp/opencl-driver-intel && \
     cd /tmp/opencl-driver-intel && \
-    wget https://github.com/intel/llvm/releases/download/2024-WW14/oclcpuexp-2024.17.3.0.09_rel.tar.gz && \
-    wget https://github.com/oneapi-src/oneTBB/releases/download/v2021.12.0/oneapi-tbb-2021.12.0-lin.tgz && \
+    curl -L -O https://github.com/intel/llvm/releases/download/2024-WW14/oclcpuexp-2024.17.3.0.09_rel.tar.gz && \
+    curl -L -O https://github.com/oneapi-src/oneTBB/releases/download/v2021.12.0/oneapi-tbb-2021.12.0-lin.tgz && \
     mkdir -p /opt/intel/oclcpuexp_2024.17.3.0.09_rel && \
     cd /opt/intel/oclcpuexp_2024.17.3.0.09_rel && \
     tar -zxvf /tmp/opencl-driver-intel/oclcpuexp-2024.17.3.0.09_rel.tar.gz && \

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -68,9 +68,9 @@ RUN apt-get update && \
     qtbase5-dev-tools \
     python3-venv \
     ffmpeg \
+    wget \
     libqt5opengl5-dev && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
-    cd /usr/lib/gcc/arm-none-eabi/* && \
     rm -rf arm/ thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
 
 
@@ -82,7 +82,6 @@ ENV LC_ALL=en_US.UTF-8
 
 # Add OpenCL
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tar \
     dbus \
     gcc-arm-none-eabi \
     libx11-6 \
@@ -90,8 +89,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN mkdir -p /tmp/opencl-driver-intel && \
     cd /tmp/opencl-driver-intel && \
-    curl -L -O https://github.com/intel/llvm/releases/download/2024-WW14/oclcpuexp-2024.17.3.0.09_rel.tar.gz && \
-    curl -L -O https://github.com/oneapi-src/oneTBB/releases/download/v2021.12.0/oneapi-tbb-2021.12.0-lin.tgz && \
+    wget https://github.com/intel/llvm/releases/download/2024-WW14/oclcpuexp-2024.17.3.0.09_rel.tar.gz && \
+    wget https://github.com/oneapi-src/oneTBB/releases/download/v2021.12.0/oneapi-tbb-2021.12.0-lin.tgz && \
     mkdir -p /opt/intel/oclcpuexp_2024.17.3.0.09_rel && \
     cd /opt/intel/oclcpuexp_2024.17.3.0.09_rel && \
     tar -zxvf /tmp/opencl-driver-intel/oclcpuexp-2024.17.3.0.09_rel.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+TEMP CHANGE TO TRIGGER A BUILD
 <div align="center" style="text-align: center;">
 
 <h1>openpilot</h1>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-TEMP CHANGE TO TRIGGER A BUILD
 <div align="center" style="text-align: center;">
 
 <h1>openpilot</h1>


### PR DESCRIPTION
**Description**
This PR aims at reducing the execution time of the setup-with-retry Github action.
Resolve: https://github.com/commaai/openpilot/issues/30706
 * This action is a wrapper that loads form the cache, add 2 retry steps for any other action that `uses` the action,  and runs env.BUILD if defined. 
* The slowness of the builds when cached appears to be due to 
  * Pulling from the container image cache 
  * the install of the uv package manager causing a cache miss 
* Existing Image is ~ 3.8GB with the largest layer being 1.5 GB

**Solution** : 
1. Removing dependencies
2. creating more layers
3. update image tag have `pr-123` was triggered by a PR?  

**Verification**
1. All tests pass without modification
4. After this PR merges and the new openpilot_base image is published, build times fall. 