### PR TITLE
raylib/ui: Wi-Fi manager

### DIFF
--- a/system/ui/.gitignore
+++ b/system/ui/.gitignore
@@ -1,1 +1,2 @@
 spinner
+wifi_demo

--- a/system/ui/SConscript
+++ b/system/ui/SConscript
@@ -21,5 +21,5 @@ if not UBUNTU_FOCAL:
 
   if arch != 'aarch64':
     renv.Program("spinner", ["raylib/spinner.cc"], LIBS=linked_libs, FRAMEWORKS=mac_frameworks)
-    renv['CCFLAGS'] += ['-Wno-error=unused-but-set-variable']
+    renv['CCFLAGS'] += ['-Wno-error=unused-but-set-variable', '-Wno-deprecated-declarations']
     renv.Program("wifi_demo", ["raylib/wifi_manager/wifi_manager.cc", "raylib/wifi_manager/nmcli_backend.cc", "raylib/wifi_manager/main.cc"], LIBS=linked_libs, FRAMEWORKS=mac_frameworks)

--- a/system/ui/SConscript
+++ b/system/ui/SConscript
@@ -21,3 +21,4 @@ if not UBUNTU_FOCAL:
 
   if arch != 'aarch64':
     renv.Program("spinner", ["raylib/spinner.cc"], LIBS=linked_libs, FRAMEWORKS=mac_frameworks)
+    renv.Program("wifi_demo", ["raylib/wifi_manager/wifi_manager.cc", "raylib/wifi_manager/nmcli_backend.cc", "raylib/wifi_manager/main.cc"], LIBS=linked_libs, FRAMEWORKS=mac_frameworks)

--- a/system/ui/SConscript
+++ b/system/ui/SConscript
@@ -21,4 +21,5 @@ if not UBUNTU_FOCAL:
 
   if arch != 'aarch64':
     renv.Program("spinner", ["raylib/spinner.cc"], LIBS=linked_libs, FRAMEWORKS=mac_frameworks)
+    renv['CCFLAGS'] += ['-Wno-error=unused-but-set-variable']
     renv.Program("wifi_demo", ["raylib/wifi_manager/wifi_manager.cc", "raylib/wifi_manager/nmcli_backend.cc", "raylib/wifi_manager/main.cc"], LIBS=linked_libs, FRAMEWORKS=mac_frameworks)

--- a/system/ui/raylib/util.cc
+++ b/system/ui/raylib/util.cc
@@ -45,7 +45,10 @@ App::App(const char *title, int fps) {
   // Load fonts
   fonts_.reserve(FONT_FILE_PATHS.size());
   for (int i = 0; i < FONT_FILE_PATHS.size(); ++i) {
-    fonts_.push_back(LoadFontEx(FONT_FILE_PATHS[i], 120, nullptr, 250));
+    fonts_.push_back(LoadFontEx(FONT_FILE_PATHS[i], 260, nullptr, 0));
+    // Improve font texture quality with mipmaps and bilinear filtering
+    GenTextureMipmaps(&fonts_[i].texture);
+    SetTextureFilter(fonts_[i].texture, TEXTURE_FILTER_BILINEAR);
   }
 
   pApp = this;

--- a/system/ui/raylib/wifi_manager/main.cc
+++ b/system/ui/raylib/wifi_manager/main.cc
@@ -10,7 +10,7 @@ int main() {
     BeginDrawing();
       ClearBackground(RAYLIB_BLACK);
       GuiLabel({40, 20, 300, 40}, "Wi-Fi Manager");
-      wifi_manager.draw({40, 100, GetScreenWidth() - 80.0f, GetScreenHeight() - 180.0f});
+      wifi_manager.render({40, 100, GetScreenWidth() - 80.0f, GetScreenHeight() - 180.0f});
     EndDrawing();
   }
   return 0;

--- a/system/ui/raylib/wifi_manager/main.cc
+++ b/system/ui/raylib/wifi_manager/main.cc
@@ -10,7 +10,7 @@ int main() {
     BeginDrawing();
       ClearBackground(RAYLIB_BLACK);
       GuiLabel({40, 20, 300, 40}, "Wi-Fi Manager");
-      wifi_manager.draw({40, 100, GetScreenWidth() - 40.0f, GetScreenHeight() - 140.0f});
+      wifi_manager.draw({40, 100, GetScreenWidth() - 80.0f, GetScreenHeight() - 180.0f});
     EndDrawing();
   }
 

--- a/system/ui/raylib/wifi_manager/main.cc
+++ b/system/ui/raylib/wifi_manager/main.cc
@@ -1,5 +1,6 @@
 #include "system/ui/raylib/util.h"
 #include "system/ui/raylib/wifi_manager/wifi_manager.h"
+#include "third_party/raylib/include/raygui.h"
 
 int main() {
   initApp("Wi-Fi Manager", 30);
@@ -8,7 +9,8 @@ int main() {
   while (!WindowShouldClose()) {
     BeginDrawing();
       ClearBackground(RAYLIB_BLACK);
-      wifi_manager.draw({0, 0, (float)GetScreenWidth(), (float)GetScreenHeight()});
+      GuiLabel({40, 20, 300, 40}, "Wi-Fi Manager");
+      wifi_manager.draw({40, 100, GetScreenWidth() - 40.0f, GetScreenHeight() - 140.0f});
     EndDrawing();
   }
 

--- a/system/ui/raylib/wifi_manager/main.cc
+++ b/system/ui/raylib/wifi_manager/main.cc
@@ -1,0 +1,17 @@
+#include "system/ui/raylib/util.h"
+#include "system/ui/raylib/wifi_manager/wifi_manager.h"
+
+int main() {
+  initApp("Wi-Fi Manager", 30);
+
+  WifiManager wifi_manager;
+  while (!WindowShouldClose()) {
+    BeginDrawing();
+      ClearBackground(RAYLIB_BLACK);
+      wifi_manager.draw({0, 0, (float)GetScreenWidth(), (float)GetScreenHeight()});
+    EndDrawing();
+  }
+
+  CloseWindow();
+  return 0;
+}

--- a/system/ui/raylib/wifi_manager/main.cc
+++ b/system/ui/raylib/wifi_manager/main.cc
@@ -3,7 +3,7 @@
 #include "third_party/raylib/include/raygui.h"
 
 int main() {
-  initApp("Wi-Fi Manager", 30);
+  App app("Wi-Fi Manager", 30);
 
   WifiManager wifi_manager;
   while (!WindowShouldClose()) {
@@ -13,7 +13,5 @@ int main() {
       wifi_manager.draw({40, 100, GetScreenWidth() - 80.0f, GetScreenHeight() - 180.0f});
     EndDrawing();
   }
-
-  CloseWindow();
   return 0;
 }

--- a/system/ui/raylib/wifi_manager/nmcli_backend.cc
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.cc
@@ -1,0 +1,38 @@
+#include "system/ui/raylib/wifi_manager/nmcli_backend.h"
+
+#include "common/util.h"
+
+std::vector<std::string> split(std::string_view source, char delimiter) {
+  std::vector<std::string> fields;
+  size_t last = 0;
+  for (size_t i = 0; i < source.length(); ++i) {
+    if (source[i] == delimiter) {
+      fields.emplace_back(source.substr(last, i - last));
+      last = i + 1;
+    }
+  }
+  fields.emplace_back(source.substr(last));
+  return fields;
+}
+
+std::vector<Network> list_wifi_networks() {
+  std::vector<Network> networks;
+  std::string output = util::check_output("nmcli -t -f IN-USE,SSID --colors no device wifi list");
+  for (const auto& line : split(output, '\n')) {
+    auto items = split(line, ':');
+    if (items.size() != 2 || items[1].empty()) continue;
+
+    networks.emplace_back(Network{items[0] == "*", items[1]});
+  }
+  return networks;
+}
+
+bool connect_to_wifi(const std::string& ssid, const std::string& password) {
+  std::string command = "nmcli device wifi connect '" + ssid + "' password '" + password + "'";
+  return system(command.c_str()) == 0;
+}
+
+bool forget_wifi(const std::string& ssid) {
+  std::string command = "nmcli connection delete id '" + ssid + "'";
+  return system(command.c_str()) == 0;
+}

--- a/system/ui/raylib/wifi_manager/nmcli_backend.cc
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.cc
@@ -15,24 +15,49 @@ std::vector<std::string> split(std::string_view source, char delimiter) {
   return fields;
 }
 
-std::vector<Network> list_wifi_networks() {
+SecurityType getSecurityType(const std::string& security) {
+  if (security.empty() || security == "--") {
+    return SecurityType::OPEN;
+  } else if (security.find("WPA") != std::string::npos || security.find("RSN") != std::string::npos) {
+    return SecurityType::WPA;
+  }
+  return SecurityType::UNSUPPORTED;
+}
+
+namespace wifi {
+
+std::vector<Network> scan_networks() {
   std::vector<Network> networks;
-  std::string output = util::check_output("nmcli -t -f IN-USE,SSID --colors no device wifi list");
+
+  std::string output = util::check_output("nmcli -t -f SSID,IN-USE,SIGNAL,SECURITY --colors no device wifi list");
   for (const auto& line : split(output, '\n')) {
     auto items = split(line, ':');
-    if (items.size() != 2 || items[1].empty()) continue;
+    if (items.size() != 4 || items[0].empty()) continue;
 
-    networks.emplace_back(Network{items[0] == "*", items[1]});
+    networks.emplace_back(Network{items[0], items[1] == "*", std::stoi(items[2]), getSecurityType(items[3])});
   }
+
+  std::sort(networks.begin(), networks.end(), [](const Network& a, const Network& b) {
+    return std::tie(b.connected, b.strength, b.ssid) < std::tie(a.connected, a.strength, a.ssid);
+  });
+
   return networks;
 }
 
-bool connect_to_wifi(const std::string& ssid, const std::string& password) {
+std::set<std::string> saved_networks() {
+  std::string cmd = "nmcli -t -f NAME,TYPE --colors no connection show | grep \":802-11-wireless\" | sed 's/^Auto //g' | cut -d':' -f1";
+  auto networks = split(util::check_output(cmd), '\n');
+  return std::set<std::string>(networks.begin(), networks.end());
+}
+
+bool connect(const std::string& ssid, const std::string& password) {
   std::string command = "nmcli device wifi connect '" + ssid + "' password '" + password + "'";
   return system(command.c_str()) == 0;
 }
 
-bool forget_wifi(const std::string& ssid) {
+bool forget(const std::string& ssid) {
   std::string command = "nmcli connection delete id '" + ssid + "'";
   return system(command.c_str()) == 0;
 }
+
+}  // namespace wifi

--- a/system/ui/raylib/wifi_manager/nmcli_backend.cc
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.cc
@@ -28,13 +28,13 @@ namespace wifi {
 
 std::vector<Network> scan_networks() {
   std::vector<Network> networks;
-
   std::string output = util::check_output("nmcli -t -f SSID,IN-USE,SIGNAL,SECURITY --colors no device wifi list");
-  for (const auto& line : split(output, '\n')) {
-    auto items = split(line, ':');
-    if (items.size() != 4 || items[0].empty()) continue;
 
-    networks.emplace_back(Network{items[0], items[1] == "*", std::stoi(items[2]), getSecurityType(items[3])});
+  for (const auto& line : split(output, '\n')) {
+    auto fields = split(line, ':');
+    if (fields.size() == 4 && !fields[0].empty()) {
+      networks.emplace_back(Network{fields[0], fields[1] == "*", std::stoi(fields[2]), getSecurityType(fields[3])});
+    }
   }
 
   std::sort(networks.begin(), networks.end(), [](const Network& a, const Network& b) {
@@ -51,7 +51,10 @@ std::set<std::string> saved_networks() {
 }
 
 bool connect(const std::string& ssid, const std::string& password) {
-  std::string command = "nmcli device wifi connect '" + ssid + "' password '" + password + "'";
+  std::string command = "nmcli device wifi connect '" + ssid + "'";
+  if (!password.empty()) {
+    command += " password '" + password + "'";
+  }
   return system(command.c_str()) == 0;
 }
 

--- a/system/ui/raylib/wifi_manager/nmcli_backend.cc
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.cc
@@ -42,6 +42,7 @@ std::vector<Network> scan_networks() {
 }
 
 std::set<std::string> saved_networks() {
+  // Get UUIDs of all saved wireless connections
   std::string uuids;
   std::string cmd = "nmcli -t -f UUID,TYPE connection show | grep 802-11-wireless";
   for (auto& line : split(util::check_output(cmd), '\n')) {
@@ -51,6 +52,7 @@ std::set<std::string> saved_networks() {
     }
   }
 
+  // Get SSIDs for the saved connections
   std::set<std::string> network_ssids;
   std::string ssid_cmd = "nmcli -t -f 802-11-wireless.ssid connection show " + uuids;
   for (const auto& line : split(util::check_output(ssid_cmd), '\n')) {

--- a/system/ui/raylib/wifi_manager/nmcli_backend.h
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.h
@@ -20,6 +20,6 @@ struct Network {
 namespace wifi {
 std::vector<Network> scan_networks();
 std::set<std::string> saved_networks();
-bool connect(const std::string& ssid, const std::string& password);
+bool connect(const std::string& ssid, const std::string& password = "");
 bool forget(const std::string& ssid);
 }  // namespace wifi

--- a/system/ui/raylib/wifi_manager/nmcli_backend.h
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.h
@@ -2,6 +2,7 @@
 
 #include <set>
 #include <string>
+#include <tuple>
 #include <vector>
 
 enum class SecurityType {
@@ -17,9 +18,15 @@ struct Network {
   SecurityType security_type;
 };
 
+inline bool operator<(const Network& lhs, const Network& rhs) {
+  return std::tie(rhs.connected, rhs.strength, rhs.ssid) < std::tie(lhs.connected, lhs.strength, lhs.ssid);
+}
+
 namespace wifi {
+
 std::vector<Network> scan_networks();
 std::set<std::string> saved_networks();
 bool connect(const std::string& ssid, const std::string& password = "");
 bool forget(const std::string& ssid);
+
 }  // namespace wifi

--- a/system/ui/raylib/wifi_manager/nmcli_backend.h
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.h
@@ -1,13 +1,25 @@
 #pragma once
 
+#include <set>
 #include <string>
 #include <vector>
 
-struct Network {
-  bool connected;
-  std::string ssid;
+enum class SecurityType {
+  OPEN,
+  WPA,
+  UNSUPPORTED
 };
 
-std::vector<Network> list_wifi_networks();
-bool connect_to_wifi(const std::string& ssid, const std::string& password);
-bool forget_wifi(const std::string& ssid);
+struct Network {
+  std::string ssid;
+  bool connected;
+  int strength;
+  SecurityType security_type;
+};
+
+namespace wifi {
+std::vector<Network> scan_networks();
+std::set<std::string> saved_networks();
+bool connect(const std::string& ssid, const std::string& password);
+bool forget(const std::string& ssid);
+}  // namespace wifi

--- a/system/ui/raylib/wifi_manager/nmcli_backend.h
+++ b/system/ui/raylib/wifi_manager/nmcli_backend.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct Network {
+  bool connected;
+  std::string ssid;
+};
+
+std::vector<Network> list_wifi_networks();
+bool connect_to_wifi(const std::string& ssid, const std::string& password);
+bool forget_wifi(const std::string& ssid);

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -42,6 +42,7 @@ void WifiManager::draw(const Rectangle& rect) {
 }
 
 void WifiManager::showPasswordDialog() {
+  // TODO: Implement a keyboard input dialog
   const auto& ssid = wifi_networks_[selected_network_index_].ssid;
   int result = GuiTextInputBox(
       (Rectangle){GetScreenWidth() / 2.0f - 120, GetScreenHeight() / 2.0f - 60, 240, 140},

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -17,6 +17,12 @@ WifiManager::WifiManager() {
 }
 
 void WifiManager::draw(const Rectangle& rect) {
+  double current_time = GetTime();
+  if (current_time - last_scan_time_ > 60.0) {  // 1 minute
+    last_scan_time_ = current_time;
+    loadWifiNetworksAsync();  // Rescan the Wi-Fi networks
+  }
+
   std::unique_lock lock(mutex_);
   if (wifi_networks_.empty()) {
     GuiDrawText("Loading Wi-Fi networks...", rect, TEXT_ALIGN_CENTER, RAYLIB_WHITE);

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -8,7 +8,7 @@
 #include "third_party/raylib/include/raygui.h"
 
 WifiManager::WifiManager() {
-  GuiSetFont(getFont());
+  GuiSetFont(pApp->getFont());
   GuiSetStyle(DEFAULT, TEXT_SIZE, 40);
   GuiSetStyle(DEFAULT, BACKGROUND_COLOR, ColorToInt({30, 30, 30, 255}));
   GuiSetStyle(DEFAULT, BASE_COLOR_NORMAL, ColorToInt({50, 50, 50, 255}));

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -1,7 +1,8 @@
 
 #include "system/ui/raylib/wifi_manager/wifi_manager.h"
 #define RAYGUI_IMPLEMENTATION
-#include "raygui.h"  // Raylib's GUI extension
+#define BLANK RAYLIB_BLANK
+#include "third_party/raylib/include/raygui.h"
 #include "system/ui/raylib/util.h"
 
 WifiManager::WifiManager() {

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -1,10 +1,18 @@
 #include "system/ui/raylib/wifi_manager/wifi_manager.h"
 
+#include <algorithm>
 #include <chrono>
 
 #include "system/ui/raylib/util.h"
 #define RAYGUI_IMPLEMENTATION
 #define BLANK RAYLIB_BLANK
+#define RAYGUI_WINDOWBOX_STATUSBAR_HEIGHT 50
+#define RAYGUI_MESSAGEBOX_BUTTON_HEIGHT 100
+#define RAYGUI_MESSAGEBOX_BUTTON_PADDING 30
+#define RAYGUI_TEXTINPUTBOX_BUTTON_PADDING 50
+#define RAYGUI_TEXTINPUTBOX_BUTTON_HEIGHT 100
+#define RAYGUI_TEXTINPUTBOX_HEIGHT 40
+
 #include "third_party/raylib/include/raygui.h"
 
 WifiManager::WifiManager() {
@@ -17,45 +25,48 @@ WifiManager::WifiManager() {
   scanNetworksAsync();
 }
 
-void WifiManager::draw(const Rectangle& rect) {
+void WifiManager::render(const Rectangle& rect) {
   rescanIfNeeded();
 
   std::unique_lock lock(mutex_);
-  if (wifi_networks_.empty()) {
-    GuiDrawText("Loading Wi-Fi networks...", rect, TEXT_ALIGN_CENTER, RAYLIB_WHITE);
-    return;
+
+  if (current_action_ == ActionState::Forget) {
+    if (!forgetNetwork()) return;
+  }
+  if (current_action_ == ActionState::Connect) {
+    if (!connectToNetwork()) return;
   }
 
-  if (requires_password_) {
-    showPasswordDialog();
-  } else {
-    drawNetworkList(rect);
-  }
+  renderNetworkList(rect);
 }
 
 void WifiManager::rescanIfNeeded() {
   double current_time = GetTime();
-  if (current_time - last_scan_time_ > 60.0) {  // Rescan after 1 minute
+  if (current_action_ == ActionState::None && current_time - last_scan_time_ > 60.0) {
     last_scan_time_ = current_time;
     scanNetworksAsync();
   }
 }
 
-void WifiManager::drawNetworkList(const Rectangle& rect) {
-  Rectangle content_rect = {rect.x, rect.y, rect.width - 20, wifi_networks_.size() * item_height_};
+void WifiManager::renderNetworkList(const Rectangle& rect) {
+  if (available_networks_.empty()) {
+    GuiDrawText("Loading Wi-Fi networks...", rect, TEXT_ALIGN_CENTER, RAYLIB_WHITE);
+    return;
+  }
+
+  Rectangle content_rect = {rect.x, rect.y, rect.width - 20, available_networks_.size() * item_height_};
   Rectangle scissor = {0};
   GuiScrollPanel(rect, nullptr, content_rect, &scroll_offset_, &scissor);
 
-  const int padding = 20;
   BeginScissorMode(scissor.x, scissor.y, scissor.width, scissor.height);
-
-  for (size_t i = 0; i < wifi_networks_.size(); ++i) {
+  const int padding = 20;
+  for (size_t i = 0; i < available_networks_.size(); ++i) {
     float y = content_rect.y + i * item_height_ + scroll_offset_.y;
     Rectangle item_rect = {content_rect.x + padding, y, content_rect.width - padding * 2, item_height_};
 
-    drawNetworkItem(item_rect, wifi_networks_[i]);
+    renderNetworkItem(item_rect, available_networks_[i]);
 
-    if (i != wifi_networks_.size() - 1) {
+    if (i != available_networks_.size() - 1) {
       float line_y = item_rect.y + item_height_ - 1;
       DrawLine(item_rect.x, line_y, item_rect.x + item_rect.width, line_y, RAYLIB_LIGHTGRAY);
     }
@@ -64,70 +75,122 @@ void WifiManager::drawNetworkList(const Rectangle& rect) {
   EndScissorMode();
 }
 
-void WifiManager::drawNetworkItem(const Rectangle& rect, const Network& network) {
+void WifiManager::renderNetworkItem(const Rectangle& rect, const Network& network) {
   const int btn_width = 200;
   Rectangle label_rect{rect.x, rect.y, rect.width - btn_width * 2, item_height_};
   GuiLabel(label_rect, network.ssid.c_str());
 
-  if (network.connected) {
-    GuiLabel({rect.x + rect.width - btn_width * 2 - 20, rect.y, btn_width, item_height_}, "Connected");
-  } else if (CheckCollisionPointRec(GetMousePosition(), label_rect) && IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
-    initiateConnection(network.ssid);
+  Rectangle state_rect = {rect.x + rect.width - btn_width * 2 - 30, rect.y, btn_width, item_height_};
+  if (network.connected && current_action_ != ActionState::Connecting) {
+    GuiLabel(state_rect, "Connected");
+  } else if (current_action_ == ActionState::Connecting && selected_network_->ssid == network.ssid) {
+    GuiLabel(state_rect, "CONNECTING...");
+  } else if (current_action_ == ActionState::None &&
+             CheckCollisionPointRec(GetMousePosition(), label_rect) &&
+             IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
+    initiateAction(network, ActionState::Connect);
   }
 
   if (saved_networks_.count(network.ssid)) {
-    if (GuiButton({rect.x + rect.width - btn_width, rect.y + (item_height_ - 80) / 2, btn_width, 80}, "Forget")) {
-      forgetNetwork(network.ssid);
+    if (GuiButton({rect.x + rect.width - btn_width, rect.y + (item_height_ - 80) / 2, btn_width, 80}, "Forget") &&
+        current_action_ == ActionState::None) {
+      initiateAction(network, ActionState::Forget);
     }
   }
 }
 
-void WifiManager::initiateConnection(const std::string& ssid) {
-  if (saved_networks_.count(ssid)) {
-    wifi::connect(ssid);  // Directly connect to saved network
-    return;
+void WifiManager::initiateAction(const Network& network, ActionState action) {
+  current_action_ = action;
+  selected_network_ = network;
+}
+
+bool WifiManager::forgetNetwork() {
+  int result = GuiMessageBox(
+      {GetScreenWidth() / 2.0f - 512, GetScreenHeight() / 2.0f - 384, 1024, 768},
+      ("Forget " + selected_network_->ssid + "?").c_str(), "Are you sure you want to forget this network?", "Yes;No");
+
+  if (result < 0) return false;
+
+  selected_network_.reset();
+  if (result != 1) {
+    current_action_ = ActionState::None;
+    return true;
   }
 
-  connecting_ssid_ = ssid;
-  memset(password_input_, 0, sizeof(password_input_));
-  requires_password_ = true;
-}
-
-void WifiManager::forgetNetwork(const std::string& ssid) {
-  wifi::forget(ssid);
-  saved_networks_.erase(ssid);
-  scanNetworksAsync();
-}
-
-void WifiManager::showPasswordDialog() {
-  // TODO: Implement a keyboard input dialog
-  int result = GuiTextInputBox(
-      {GetScreenWidth() / 2.0f - 120, GetScreenHeight() / 2.0f - 60, 240, 140},
-      ("Connect to " + connecting_ssid_).c_str(), "Password:", "Ok;Cancel", password_input_, 128, NULL);
-  if (result < 0) return;
-
-  if (result == 1) {
-    if (wifi::connect(connecting_ssid_, password_input_)) {
-      saved_networks_.insert(connecting_ssid_);
+  current_action_ = ActionState::Forgetting;
+  saved_networks_.erase(selected_network_->ssid);
+  for (auto& n : available_networks_) {
+    if (n.ssid == selected_network_->ssid) {
+      n.connected = false;
+      break;
     }
   }
 
-  connecting_ssid_.clear();
-  requires_password_ = false;
+  async_forget_task_ = std::async(std::launch::async, [this, ssid = selected_network_->ssid]() {
+    wifi::forget(ssid);
+    scanNetworksAsync();
+    current_action_ = ActionState::None;
+  });
+  return true;
+}
+
+bool WifiManager::connectToNetwork() {
+  std::string password;
+  if (!saved_networks_.count(selected_network_->ssid) && selected_network_->security_type != SecurityType::OPEN) {
+    // TODO: Implement a software keyboard input dialog
+    int result = GuiTextInputBox(
+        {GetScreenWidth() / 2.0f - 512, GetScreenHeight() / 2.0f - 200, 1024, 400},
+        ("Connect to " + selected_network_->ssid).c_str(), "Password:", "Ok;Cancel", password_input_buffer_, 128, NULL);
+    if (result < 0) return false;
+
+    password = password_input_buffer_;
+    memset(password_input_buffer_, 0, sizeof(password_input_buffer_));
+    if (result != 1) {
+      selected_network_.reset();
+      current_action_ = ActionState::None;
+      return true;
+    }
+  }
+
+  connectToNetworkAsync(selected_network_->ssid, password);
+  current_action_ = ActionState::Connecting;
+  return true;
 }
 
 void WifiManager::scanNetworksAsync() {
-  // Check if the previous scan is still running
-  if (async_task_.valid() && async_task_.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+  if (async_scan_task_.valid() && async_scan_task_.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
     return;
   }
 
-  async_task_ = std::async(std::launch::async, [this]() {
-    auto networks = wifi::scan_networks();
+  async_scan_task_ = std::async(std::launch::async, [this]() {
+    auto scanned_networks = wifi::scan_networks();
     auto known_networks = wifi::saved_networks();
 
     std::unique_lock lock(mutex_);
-    wifi_networks_ = std::move(networks);
+    available_networks_ = std::move(scanned_networks);
     saved_networks_ = std::move(known_networks);
+  });
+}
+
+void WifiManager::connectToNetworkAsync(const std::string& ssid, const std::string& password) {
+  if (async_connection_task_.valid() && async_connection_task_.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+    return;
+  }
+
+  async_connection_task_ = std::async(std::launch::async, [this, ssid, password]() {
+    if (wifi::connect(ssid, password)) {
+      std::unique_lock lock(mutex_);
+      saved_networks_.insert(ssid);
+      selected_network_.reset();
+      current_action_ = ActionState::None;
+
+      for (auto& network : available_networks_) {
+        network.connected = (network.ssid == ssid);
+      }
+      std::sort(available_networks_.begin(), available_networks_.end());
+    } else {
+      selected_network_->security_type = SecurityType::WPA;
+      current_action_ = ActionState::Connect;
+    }
   });
 }

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -1,11 +1,9 @@
-
 #include "system/ui/raylib/wifi_manager/wifi_manager.h"
+#include "system/ui/raylib/util.h"
 #define RAYGUI_IMPLEMENTATION
 #define BLANK RAYLIB_BLANK
-#include <cassert>
-
-#include "system/ui/raylib/util.h"
 #include "third_party/raylib/include/raygui.h"
+
 WifiManager::WifiManager() {
   GuiSetFont(getFont());
   GuiSetStyle(DEFAULT, TEXT_SIZE, 40);
@@ -13,15 +11,11 @@ WifiManager::WifiManager() {
   GuiSetStyle(DEFAULT, BASE_COLOR_NORMAL, ColorToInt((Color){50, 50, 50, 255}));     // Dark button background
   GuiSetStyle(DEFAULT, TEXT_COLOR_NORMAL, ColorToInt((Color){200, 200, 200, 255}));  // Light grey text
 
-  loadWifiNetworksAsync();
+  scanNetworksAsync();
 }
 
 void WifiManager::draw(const Rectangle& rect) {
-  double current_time = GetTime();
-  if (current_time - last_scan_time_ > 60.0) {  // 1 minute
-    last_scan_time_ = current_time;
-    loadWifiNetworksAsync();  // Rescan the Wi-Fi networks
-  }
+  rescanIfNeeded();
 
   std::unique_lock lock(mutex_);
   if (wifi_networks_.empty()) {
@@ -29,54 +23,87 @@ void WifiManager::draw(const Rectangle& rect) {
     return;
   }
 
-  if (is_connecting_) {
+  if (requires_password_) {
     showPasswordDialog();
-    return;
+  } else {
+    drawNetworkList(rect);
   }
+}
 
-  // Handle scrollable panel for displaying Wi-Fi networks
-  Rectangle content_rect = {0, 0, rect.width - 20, wifi_networks_.size() * item_height_};
+void WifiManager::rescanIfNeeded() {
+  double current_time = GetTime();
+  if (current_time - last_scan_time_ > 60.0) {  // Rescan if more than 1 minute has passed
+    last_scan_time_ = current_time;
+    scanNetworksAsync();
+  }
+}
+
+void WifiManager::drawNetworkList(const Rectangle& rect) {
+  Rectangle content_rect = {rect.x, rect.y, rect.width - 20, wifi_networks_.size() * item_height_};
   Rectangle scissor = {0};
   GuiScrollPanel(rect, nullptr, content_rect, &scroll_offset_, &scissor);
 
-  // Draw Wi-Fi networks inside the scrollable area
+  bool left_btn_pressed = IsMouseButtonPressed(MOUSE_LEFT_BUTTON);
   BeginScissorMode(scissor.x, scissor.y, scissor.width, scissor.height);
   for (int i = 0; i < wifi_networks_.size(); ++i) {
-    float yPos = i * item_height_ + scroll_offset_.y;
+    Rectangle item_rect = {rect.x, rect.y + i * item_height_ + scroll_offset_.y, rect.width, item_height_};
     const auto& network = wifi_networks_[i];
 
-    // Draw network SSID and buttons for each network
-    GuiLabel((Rectangle){20, yPos, 500, item_height_}, network.ssid.c_str());
+    // Display SSID and buttons for each network
+    Rectangle label_rect{item_rect.x + 20, item_rect.y, 500, item_height_};
+    GuiLabel(label_rect, network.ssid.c_str());
     if (network.connected) {
-      GuiLabel((Rectangle){550, yPos + 3, 220, item_height_ - 6}, "Connected");
-    } else if (GuiButton((Rectangle){550, yPos + 3, 180, item_height_ - 6}, "Connect")) {
-      selected_network_index_ = i;
-      memset(password_input_, 0, sizeof(password_input_));
-      is_connecting_ = true;
+      GuiLabel((Rectangle){550, item_rect.y + 3, 220, item_height_ - 6}, "Connected");
+    } else if (left_btn_pressed && CheckCollisionPointRec(GetMousePosition(), label_rect)) {
+      initiateConnection(network.ssid);
     }
-    if (saved_networks_.count(network.ssid) && GuiButton((Rectangle){780, yPos + 3, 150, item_height_ - 6}, "Forget")) {
-      wifi::forget(network.ssid);
-      saved_networks_.erase(network.ssid);
-      wifi_networks_ = wifi::scan_networks();  // Refresh the list
+
+    if (saved_networks_.count(network.ssid)) {
+      if (GuiButton({780, item_rect.y + (item_height_ - 80) / 2, 150, 80}, "Forget")) {
+        forgetNetwork(network.ssid);
+      }
     }
+
+    float line_y_pos = item_rect.y + item_height_ - 1;
+    DrawLine(item_rect.x + 20, line_y_pos, item_rect.x + item_rect.width - 20, line_y_pos, RAYLIB_LIGHTGRAY);
   }
   EndScissorMode();
 }
 
-void WifiManager::showPasswordDialog() {
-  // TODO: Implement a keyboard input dialog
-  const auto& ssid = wifi_networks_[selected_network_index_].ssid;
-  int result = GuiTextInputBox(
-      (Rectangle){GetScreenWidth() / 2.0f - 120, GetScreenHeight() / 2.0f - 60, 240, 140},
-      ("Connect to " + ssid).c_str(), "Password:", "Ok;Cancel", password_input_, 128, NULL);
-  is_connecting_ = (result < 0);
-  if (result == 1) {
-    wifi::connect(ssid, password_input_);
-    saved_networks_.insert(ssid);
+void WifiManager::initiateConnection(const std::string& ssid) {
+  if (saved_networks_.count(ssid)) {
+    wifi::connect(ssid);  // Directly connect to saved network
+    return;
   }
+
+  connecting_ssid_ = ssid;
+  memset(password_input_, 0, sizeof(password_input_));
+  requires_password_ = true;
 }
 
-void WifiManager::loadWifiNetworksAsync() {
+void WifiManager::forgetNetwork(const std::string& ssid) {
+  wifi::forget(ssid);
+  saved_networks_.erase(ssid);
+  scanNetworksAsync();
+}
+
+void WifiManager::showPasswordDialog() {
+  // TODO: Implement a keyboard input dialog
+  int result = GuiTextInputBox(
+      (Rectangle){GetScreenWidth() / 2.0f - 120, GetScreenHeight() / 2.0f - 60, 240, 140},
+      ("Connect to " + connecting_ssid_).c_str(), "Password:", "Ok;Cancel", password_input_, 128, NULL);
+  if (result < 0) return;
+
+  if (result == 1) {
+    if (wifi::connect(connecting_ssid_, password_input_)) {
+      saved_networks_.insert(connecting_ssid_);
+    }
+  }
+  connecting_ssid_.clear();
+  requires_password_ = false;
+}
+
+void WifiManager::scanNetworksAsync() {
   async_task_ = std::async(std::launch::async, [this]() {
     auto networks = wifi::scan_networks();
     auto known_networks = wifi::saved_networks();

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -1,4 +1,5 @@
 #include "system/ui/raylib/wifi_manager/wifi_manager.h"
+
 #include "system/ui/raylib/util.h"
 #define RAYGUI_IMPLEMENTATION
 #define BLANK RAYLIB_BLANK
@@ -7,9 +8,9 @@
 WifiManager::WifiManager() {
   GuiSetFont(getFont());
   GuiSetStyle(DEFAULT, TEXT_SIZE, 40);
-  GuiSetStyle(DEFAULT, BACKGROUND_COLOR, ColorToInt((Color){30, 30, 30, 255}));      // Dark grey background
-  GuiSetStyle(DEFAULT, BASE_COLOR_NORMAL, ColorToInt((Color){50, 50, 50, 255}));     // Dark button background
-  GuiSetStyle(DEFAULT, TEXT_COLOR_NORMAL, ColorToInt((Color){200, 200, 200, 255}));  // Light grey text
+  GuiSetStyle(DEFAULT, BACKGROUND_COLOR, ColorToInt({30, 30, 30, 255}));
+  GuiSetStyle(DEFAULT, BASE_COLOR_NORMAL, ColorToInt({50, 50, 50, 255}));
+  GuiSetStyle(DEFAULT, TEXT_COLOR_NORMAL, ColorToInt({200, 200, 200, 255}));
 
   scanNetworksAsync();
 }
@@ -32,7 +33,7 @@ void WifiManager::draw(const Rectangle& rect) {
 
 void WifiManager::rescanIfNeeded() {
   double current_time = GetTime();
-  if (current_time - last_scan_time_ > 60.0) {  // Rescan if more than 1 minute has passed
+  if (current_time - last_scan_time_ > 60.0) {  // Rescan after 1 minute
     last_scan_time_ = current_time;
     scanNetworksAsync();
   }
@@ -43,34 +44,40 @@ void WifiManager::drawNetworkList(const Rectangle& rect) {
   Rectangle scissor = {0};
   GuiScrollPanel(rect, nullptr, content_rect, &scroll_offset_, &scissor);
 
-  const int btn_width = 200;
   const int padding = 20;
-  bool left_btn_pressed = IsMouseButtonPressed(MOUSE_LEFT_BUTTON);
   BeginScissorMode(scissor.x, scissor.y, scissor.width, scissor.height);
-  for (int i = 0; i < wifi_networks_.size(); ++i) {
+
+  for (size_t i = 0; i < wifi_networks_.size(); ++i) {
     float y = content_rect.y + i * item_height_ + scroll_offset_.y;
     Rectangle item_rect = {content_rect.x + padding, y, content_rect.width - padding * 2, item_height_};
-    const auto& network = wifi_networks_[i];
 
-    // Display SSID and buttons for each network
-    Rectangle label_rect{item_rect.x, item_rect.y, item_rect.width - btn_width * 2, item_height_};
-    GuiLabel(label_rect, network.ssid.c_str());
-    if (network.connected) {
-      GuiLabel({item_rect.x + item_rect.width - btn_width * 2 - padding, item_rect.y, btn_width, item_height_}, "Connected");
-    } else if (left_btn_pressed && CheckCollisionPointRec(GetMousePosition(), label_rect)) {
-      initiateConnection(network.ssid);
+    drawNetworkItem(item_rect, wifi_networks_[i]);
+
+    if (i != wifi_networks_.size() - 1) {
+      float line_y = item_rect.y + item_height_ - 1;
+      DrawLine(item_rect.x, line_y, item_rect.x + item_rect.width, line_y, RAYLIB_LIGHTGRAY);
     }
-
-    if (saved_networks_.count(network.ssid)) {
-      if (GuiButton({item_rect.x + item_rect.width - btn_width, item_rect.y + (item_height_ - 80) / 2, btn_width, 80}, "Forget")) {
-        forgetNetwork(network.ssid);
-      }
-    }
-
-    float line_y_pos = item_rect.y + item_height_ - 1;
-    DrawLine(item_rect.x + 20, line_y_pos, item_rect.x + item_rect.width - 20, line_y_pos, RAYLIB_LIGHTGRAY);
   }
+
   EndScissorMode();
+}
+
+void WifiManager::drawNetworkItem(const Rectangle& rect, const Network& network) {
+  const int btn_width = 200;
+  Rectangle label_rect{rect.x, rect.y, rect.width - btn_width * 2, item_height_};
+  GuiLabel(label_rect, network.ssid.c_str());
+
+  if (network.connected) {
+    GuiLabel({rect.x + rect.width - btn_width * 2 - 20, rect.y, btn_width, item_height_}, "Connected");
+  } else if (CheckCollisionPointRec(GetMousePosition(), label_rect) && IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
+    initiateConnection(network.ssid);
+  }
+
+  if (saved_networks_.count(network.ssid)) {
+    if (GuiButton({rect.x + rect.width - btn_width, rect.y + (item_height_ - 80) / 2, btn_width, 80}, "Forget")) {
+      forgetNetwork(network.ssid);
+    }
+  }
 }
 
 void WifiManager::initiateConnection(const std::string& ssid) {
@@ -93,7 +100,7 @@ void WifiManager::forgetNetwork(const std::string& ssid) {
 void WifiManager::showPasswordDialog() {
   // TODO: Implement a keyboard input dialog
   int result = GuiTextInputBox(
-      (Rectangle){GetScreenWidth() / 2.0f - 120, GetScreenHeight() / 2.0f - 60, 240, 140},
+      {GetScreenWidth() / 2.0f - 120, GetScreenHeight() / 2.0f - 60, 240, 140},
       ("Connect to " + connecting_ssid_).c_str(), "Password:", "Ok;Cancel", password_input_, 128, NULL);
   if (result < 0) return;
 
@@ -102,6 +109,7 @@ void WifiManager::showPasswordDialog() {
       saved_networks_.insert(connecting_ssid_);
     }
   }
+
   connecting_ssid_.clear();
   requires_password_ = false;
 }
@@ -112,7 +120,7 @@ void WifiManager::scanNetworksAsync() {
     auto known_networks = wifi::saved_networks();
 
     std::unique_lock lock(mutex_);
-    wifi_networks_.swap(networks);
-    saved_networks_.swap(known_networks);
+    wifi_networks_ = std::move(networks);
+    saved_networks_ = std::move(known_networks);
   });
 }

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -1,0 +1,53 @@
+
+#include "system/ui/raylib/wifi_manager/wifi_manager.h"
+#define RAYGUI_IMPLEMENTATION
+#include "raygui.h"  // Raylib's GUI extension
+#include "system/ui/raylib/util.h"
+
+WifiManager::WifiManager() {
+  auto font = getFont();
+  font.baseSize = 50;
+  GuiSetFont(font);
+  wifi_networks_ = list_wifi_networks();
+}
+
+void WifiManager::draw(const Rectangle& rect) {
+  if (is_connecting_) {
+    showPasswordDialog();
+    return;
+  }
+
+  // Handle scrollable panel for displaying Wi-Fi networks
+  Rectangle content_rect = {0, 0, rect.width - 20, wifi_networks_.size() * item_height_};
+  Rectangle scissor = {0};
+  GuiScrollPanel(rect, nullptr, content_rect, &scroll_offset_, &scissor);
+
+  // Draw Wi-Fi networks inside the scrollable area
+  BeginScissorMode(scissor.x, scissor.y, scissor.width, scissor.height);
+  for (int i = 0; i < wifi_networks_.size(); ++i) {
+    // Draw network SSID and buttons for each network
+    float yPos = i * item_height_ + scroll_offset_.y;
+    GuiLabel((Rectangle){20, yPos, 500, item_height_}, wifi_networks_[i].ssid.c_str());
+    if (GuiButton((Rectangle){550, yPos + 2, 80, item_height_ - 4}, "Connect")) {
+      selected_network_index_ = i;
+      memset(password_input_, 0, sizeof(password_input_));
+      is_connecting_ = true;
+    }
+    if (GuiButton((Rectangle){670, yPos + 2, 80, item_height_ - 4}, "Forget")) {
+      forget_wifi(wifi_networks_[i].ssid);
+      wifi_networks_ = list_wifi_networks();  // Refresh the list
+    }
+  }
+  EndScissorMode();
+}
+
+void WifiManager::showPasswordDialog() {
+  const auto& ssid = wifi_networks_[selected_network_index_].ssid;
+  int result = GuiTextInputBox(
+      (Rectangle){GetScreenWidth() / 2.0f - 120, GetScreenHeight() / 2.0f - 60, 240, 140},
+      ("Connect to " + ssid).c_str(), "Password:", "Ok;Cancel", password_input_, 128, NULL);
+  is_connecting_ = (result < 0);
+  if (result == 1) {
+    connect_to_wifi(ssid, password_input_);
+  }
+}

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -43,23 +43,26 @@ void WifiManager::drawNetworkList(const Rectangle& rect) {
   Rectangle scissor = {0};
   GuiScrollPanel(rect, nullptr, content_rect, &scroll_offset_, &scissor);
 
+  const int btn_width = 200;
+  const int padding = 20;
   bool left_btn_pressed = IsMouseButtonPressed(MOUSE_LEFT_BUTTON);
   BeginScissorMode(scissor.x, scissor.y, scissor.width, scissor.height);
   for (int i = 0; i < wifi_networks_.size(); ++i) {
-    Rectangle item_rect = {rect.x, rect.y + i * item_height_ + scroll_offset_.y, rect.width, item_height_};
+    float y = content_rect.y + i * item_height_ + scroll_offset_.y;
+    Rectangle item_rect = {content_rect.x + padding, y, content_rect.width - padding * 2, item_height_};
     const auto& network = wifi_networks_[i];
 
     // Display SSID and buttons for each network
-    Rectangle label_rect{item_rect.x + 20, item_rect.y, 500, item_height_};
+    Rectangle label_rect{item_rect.x, item_rect.y, item_rect.width - btn_width * 2, item_height_};
     GuiLabel(label_rect, network.ssid.c_str());
     if (network.connected) {
-      GuiLabel((Rectangle){550, item_rect.y + 3, 220, item_height_ - 6}, "Connected");
+      GuiLabel({item_rect.x + item_rect.width - btn_width * 2 - padding, item_rect.y, btn_width, item_height_}, "Connected");
     } else if (left_btn_pressed && CheckCollisionPointRec(GetMousePosition(), label_rect)) {
       initiateConnection(network.ssid);
     }
 
     if (saved_networks_.count(network.ssid)) {
-      if (GuiButton({780, item_rect.y + (item_height_ - 80) / 2, 150, 80}, "Forget")) {
+      if (GuiButton({item_rect.x + item_rect.width - btn_width, item_rect.y + (item_height_ - 80) / 2, btn_width, 80}, "Forget")) {
         forgetNetwork(network.ssid);
       }
     }

--- a/system/ui/raylib/wifi_manager/wifi_manager.cc
+++ b/system/ui/raylib/wifi_manager/wifi_manager.cc
@@ -1,5 +1,7 @@
 #include "system/ui/raylib/wifi_manager/wifi_manager.h"
 
+#include <chrono>
+
 #include "system/ui/raylib/util.h"
 #define RAYGUI_IMPLEMENTATION
 #define BLANK RAYLIB_BLANK
@@ -115,6 +117,11 @@ void WifiManager::showPasswordDialog() {
 }
 
 void WifiManager::scanNetworksAsync() {
+  // Check if the previous scan is still running
+  if (async_task_.valid() && async_task_.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+    return;
+  }
+
   async_task_ = std::async(std::launch::async, [this]() {
     auto networks = wifi::scan_networks();
     auto known_networks = wifi::saved_networks();

--- a/system/ui/raylib/wifi_manager/wifi_manager.h
+++ b/system/ui/raylib/wifi_manager/wifi_manager.h
@@ -17,6 +17,7 @@ protected:
   void scanNetworksAsync();
   void rescanIfNeeded();
   void drawNetworkList(const Rectangle &rect);
+  void drawNetworkItem(const Rectangle& rect, const Network &network);
   void initiateConnection(const std::string &ssid);
   void forgetNetwork(const std::string& ssid);
 

--- a/system/ui/raylib/wifi_manager/wifi_manager.h
+++ b/system/ui/raylib/wifi_manager/wifi_manager.h
@@ -14,7 +14,11 @@ public:
 
 protected:
   void showPasswordDialog();
-  void loadWifiNetworksAsync();
+  void scanNetworksAsync();
+  void rescanIfNeeded();
+  void drawNetworkList(const Rectangle &rect);
+  void initiateConnection(const std::string &ssid);
+  void forgetNetwork(const std::string& ssid);
 
   std::mutex mutex_;
   std::future<void> async_task_;
@@ -23,9 +27,8 @@ protected:
   double last_scan_time_ = 0;
 
   Vector2 scroll_offset_ = {0, 0};
-  int selected_network_index_ = 0;
-  const float item_height_ = 60;
-  bool is_connecting_ = false;
+  std::string connecting_ssid_;
+  const float item_height_ = 160;
+  bool requires_password_ = false;
   char password_input_[128] = {};
-
 };

--- a/system/ui/raylib/wifi_manager/wifi_manager.h
+++ b/system/ui/raylib/wifi_manager/wifi_manager.h
@@ -17,12 +17,15 @@ protected:
   void loadWifiNetworksAsync();
 
   std::mutex mutex_;
+  std::future<void> async_task_;
   std::vector<Network> wifi_networks_;
   std::set<std::string> saved_networks_;
+  double last_scan_time_ = 0;
+
   Vector2 scroll_offset_ = {0, 0};
   int selected_network_index_ = 0;
   const float item_height_ = 60;
   bool is_connecting_ = false;
   char password_input_[128] = {};
-  std::future<void> async_task_;
+
 };

--- a/system/ui/raylib/wifi_manager/wifi_manager.h
+++ b/system/ui/raylib/wifi_manager/wifi_manager.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "system/ui/raylib/raylib.h"
+#include "system/ui/raylib/wifi_manager/nmcli_backend.h"
+
+class WifiManager {
+public:
+  WifiManager();
+  void draw(const Rectangle &rect);
+
+protected:
+  void showPasswordDialog();
+
+  std::vector<Network> wifi_networks_;
+  Vector2 scroll_offset_ = {0, 0};
+  int selected_network_index_ = 0;
+  const float item_height_ = 40;
+  bool is_connecting_ = false;
+  char password_input_[128] = {};
+};

--- a/system/ui/raylib/wifi_manager/wifi_manager.h
+++ b/system/ui/raylib/wifi_manager/wifi_manager.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <future>
+#include <mutex>
+#include <thread>
 
 #include "system/ui/raylib/raylib.h"
 #include "system/ui/raylib/wifi_manager/nmcli_backend.h"
@@ -13,11 +14,15 @@ public:
 
 protected:
   void showPasswordDialog();
+  void loadWifiNetworksAsync();
 
+  std::mutex mutex_;
   std::vector<Network> wifi_networks_;
+  std::set<std::string> saved_networks_;
   Vector2 scroll_offset_ = {0, 0};
   int selected_network_index_ = 0;
-  const float item_height_ = 40;
+  const float item_height_ = 60;
   bool is_connecting_ = false;
   char password_input_[128] = {};
+  std::future<void> async_task_;
 };


### PR DESCRIPTION
~A demonstration of a Wi-Fi manager implemented using `raygui` and `nmcli`. This is an initial draft version designed to showcase the core functionality.~  . The features have been mostly completed, with the exception of advanced network-related operations

File Descriptions:
1.` nmcli_backend.cc`:  Contains the backend logic for Wi-Fi management, interfacing with the system’s `nmcli` commands to handle network operations.
2. `wifi_manager.cc`: A reusable widget for managing Wi-Fi networks using `raygui`. This widget can be easily embedded into other raylib windows (UI, setup, etc.) by calling `WifiManager::render(Rectangle)`, which allows it to be placed within a specified rectangle on the screen for flexible UI integration.
3. `main.cc`: A demo application that uses the Wi-Fi manager to display available networks and connect/forgot to them. This serves as an example of how to integrate the Wi-Fi manager widget.

~This is an early draft intended for demonstration purposes. Future improvements could include error handling, enhanced styling, background threading, and additional features to further enhance both functionality and user experience.~

Screenshot:

![Screenshot from 2025-01-13 23-18-26](https://github.com/user-attachments/assets/ed6f317b-1694-4b9d-bf0e-886a546f7a49)

**TODO:**

1. Add software keyboard input dialog.
2. Implement message box for notifications.
3. Enable mouse drag scrolling.
4. Display a signal strength icon for networks.
5. Make check_output non-blocking with select().