### PR TITLE
Hyundai: match cancel button panda safety logic

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -215,8 +215,8 @@ class CarSpecificEvents:
       # Enable OP long on falling edge of enable buttons (defaults to accelCruise and decelCruise, overridable per-port)
       if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed):
         events.add(EventName.buttonEnable)
-      # Disable on rising and falling edge of cancel for both stock and OP long
-      if b.type == ButtonType.cancel:
+      # Disable on rising edge of cancel for both stock and OP long
+      if b.type == ButtonType.cancel and b.pressed:
         events.add(EventName.buttonCancel)
 
     # Handle permanent and temporary steering faults

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -216,6 +216,7 @@ class CarSpecificEvents:
       if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed):
         events.add(EventName.buttonEnable)
       # Disable on rising and falling edge of cancel for both stock and OP long
+      # TODO: don't check the cancel button with openpilot longitudinal on all brands to match panda safety
       if b.type == ButtonType.cancel and (allow_button_cancel or not self.CP.pcmCruise):
         events.add(EventName.buttonCancel)
 

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -216,7 +216,7 @@ class CarSpecificEvents:
       if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed):
         events.add(EventName.buttonEnable)
       # Disable on rising and falling edge of cancel for both stock and OP long
-      # TODO: don't check the cancel button with openpilot longitudinal on all brands to match panda safety
+      # TODO: only check the cancel button with openpilot longitudinal on all brands to match panda safety
       if b.type == ButtonType.cancel and (allow_button_cancel or not self.CP.pcmCruise):
         events.add(EventName.buttonCancel)
 

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -149,7 +149,7 @@ class CarSpecificEvents:
       # Main button also can trigger an engagement on these cars
       self.cruise_buttons.append(any(ev.type in HYUNDAI_ENABLE_BUTTONS for ev in CS.buttonEvents))
       events = self.create_common_events(CS, CS_prev, extra_gears=(GearShifter.sport, GearShifter.manumatic),
-                                         pcm_enable=self.CP.pcmCruise, allow_enable=any(self.cruise_buttons))
+                                         pcm_enable=self.CP.pcmCruise, allow_enable=any(self.cruise_buttons), allow_button_cancel=False)
 
       # low speed steer alert hysteresis logic (only for cars with steer cut off above 10 m/s)
       if CS.vEgo < (self.CP.minSteerSpeed + 2.) and self.CP.minSteerSpeed > 10.:
@@ -165,7 +165,7 @@ class CarSpecificEvents:
     return events
 
   def create_common_events(self, CS: structs.CarState, CS_prev: car.CarState, extra_gears=None, pcm_enable=True,
-                           allow_enable=True, enable_buttons=(ButtonType.accelCruise, ButtonType.decelCruise)):
+                           allow_enable=True, allow_button_cancel=True, enable_buttons=(ButtonType.accelCruise, ButtonType.decelCruise)):
     events = Events()
 
     if CS.doorOpen:
@@ -215,8 +215,8 @@ class CarSpecificEvents:
       # Enable OP long on falling edge of enable buttons (defaults to accelCruise and decelCruise, overridable per-port)
       if not self.CP.pcmCruise and (b.type in enable_buttons and not b.pressed):
         events.add(EventName.buttonEnable)
-      # Disable on rising edge of cancel for both stock and OP long
-      if b.type == ButtonType.cancel and b.pressed:
+      # Disable on rising and falling edge of cancel for both stock and OP long
+      if b.type == ButtonType.cancel and (allow_button_cancel or not self.CP.pcmCruise):
         events.add(EventName.buttonCancel)
 
     # Handle permanent and temporary steering faults


### PR DESCRIPTION
Closes https://github.com/commaai/openpilot/issues/34203

This is to fix the problem where the logged button presses cause disengagement on pause/resume release with stock long. Still need a good way to support this with openpilot long, but that's lower priority as it doesn't jankily enable then disable in the first place, and long isn't in release

Stock long:
- Pressing cancel (pause/resume) enables as normal, letting go does not cancel

openpilot long:
- Pressing cancel is not considered an enable button and does not enable

This works by matching panda safety and not checking the cancel button when stock long is active, letting the radar handle both enabling and disabling.