### PR TITLE
encoder: optimize MessageBuilder data handling by adopting encoded data

### DIFF
--- a/system/loggerd/encoder/encoder.cc
+++ b/system/loggerd/encoder/encoder.cc
@@ -33,7 +33,7 @@ void VideoEncoder::publisher_publish(int segment_num, uint32_t idx, VisionIpcBuf
   edata.setSegmentId(idx);
   edata.setFlags(flags);
   edata.setLen(dat.size());
-  edat.setData(dat);
+  edat.adoptData(msg.getOrphanage().referenceExternalData(dat));
   edat.setWidth(out_width);
   edat.setHeight(out_height);
   if (flags & V4L2_BUF_FLAG_KEYFRAME) edat.setHeader(header);


### PR DESCRIPTION
Optimized `MessageBuilder` data handling by directly adopting encoded data using `edat.adoptData(msg.getOrphanage().referenceExternalData(dat))`, eliminating data copying and reducing overhead.

**References**:
1.  [Cap’n Proto Discussion](https://groups.google.com/g/capnproto/c/vt3F9iQ6xWo/m/a9aIyfYEZYMJ)
2. `https://github.com/capnproto/pycapnp/issues/153`

![Screenshot from 2025-01-15 21-55-29](https://github.com/user-attachments/assets/4b40e9a1-afbd-4abe-8945-0baf724dbe4a)
