### PR TITLE
fix uv

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -304,11 +304,11 @@ wheels = [
 
 [[package]]
 name = "cloudpickle"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/97/c7/f746cadd08c4c08129215cf1b984b632f9e579fc781301e63da9e85c76c1/cloudpickle-3.1.0.tar.gz", hash = "sha256:81a929b6e3c7335c863c771d673d105f02efdb89dfaba0c90495d1c64796601b", size = 66155 }
+sdist = { url = "https://files.pythonhosted.org/packages/52/39/069100b84d7418bc358d81669d5748efb14b9cceacd2f9c75f550424132f/cloudpickle-3.1.1.tar.gz", hash = "sha256:b216fa8ae4019d5482a8ac3c95d8f6346115d8835911fd4aefd1a445e4242c64", size = 22113 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/41/e1d85ca3cab0b674e277c8c4f678cf66a91cd2cecf93df94353a606fe0db/cloudpickle-3.1.0-py3-none-any.whl", hash = "sha256:fe11acda67f61aaaec473e3afe030feb131d78a43461b718185363384f1ba12e", size = 22021 },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl", hash = "sha256:c8c5a44295039331ee9dad40ba100a9c7297b6f988e50e87ccdf3765a668350e", size = 20992 },
 ]
 
 [[package]]
@@ -1748,8 +1748,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93", size = 2254397 },
     { url = "https://files.pythonhosted.org/packages/14/71/4cbd3870d3e926c34706f705d6793159ac49d9a213e3ababcdade5864663/pycryptodome-3.21.0-cp36-abi3-win32.whl", hash = "sha256:280b67d20e33bb63171d55b1067f61fbd932e0b1ad976b3a184303a3dad22764", size = 1775641 },
     { url = "https://files.pythonhosted.org/packages/43/1d/81d59d228381576b92ecede5cd7239762c14001a828bdba30d64896e9778/pycryptodome-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b7aa25fc0baa5b1d95b7633af4f5f1838467f1815442b22487426f94e0d66c53", size = 1812863 },
-    { url = "https://files.pythonhosted.org/packages/25/b3/09ff7072e6d96c9939c24cf51d3c389d7c345bf675420355c22402f71b68/pycryptodome-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:2cb635b67011bc147c257e61ce864879ffe6d03342dc74b6045059dfbdedafca", size = 1691593 },
-    { url = "https://files.pythonhosted.org/packages/a8/91/38e43628148f68ba9b68dedbc323cf409e537fd11264031961fd7c744034/pycryptodome-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:4c26a2f0dc15f81ea3afa3b0c87b87e501f235d332b7f27e2225ecb80c0b1cdd", size = 1765997 },
 ]
 
 [[package]]
@@ -1837,7 +1835,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/7d/ff/4c6f31a4f08979f12
 
 [[package]]
 name = "pyobjc"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -1862,6 +1860,7 @@ dependencies = [
     { name = "pyobjc-framework-businesschat", marker = "platform_release >= '18.0'" },
     { name = "pyobjc-framework-calendarstore", marker = "platform_release >= '9.0'" },
     { name = "pyobjc-framework-callkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-carbon" },
     { name = "pyobjc-framework-cfnetwork" },
     { name = "pyobjc-framework-cinematic", marker = "platform_release >= '23.0'" },
     { name = "pyobjc-framework-classkit", marker = "platform_release >= '20.0'" },
@@ -1889,6 +1888,7 @@ dependencies = [
     { name = "pyobjc-framework-cryptotokenkit", marker = "platform_release >= '14.0'" },
     { name = "pyobjc-framework-datadetection", marker = "platform_release >= '21.0'" },
     { name = "pyobjc-framework-devicecheck", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-devicediscoveryextension", marker = "platform_release >= '24.0'" },
     { name = "pyobjc-framework-dictionaryservices", marker = "platform_release >= '9.0'" },
     { name = "pyobjc-framework-discrecording" },
     { name = "pyobjc-framework-discrecordingui" },
@@ -1929,6 +1929,7 @@ dependencies = [
     { name = "pyobjc-framework-mailkit", marker = "platform_release >= '21.0'" },
     { name = "pyobjc-framework-mapkit", marker = "platform_release >= '13.0'" },
     { name = "pyobjc-framework-mediaaccessibility", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaextension", marker = "platform_release >= '24.0'" },
     { name = "pyobjc-framework-medialibrary", marker = "platform_release >= '13.0'" },
     { name = "pyobjc-framework-mediaplayer", marker = "platform_release >= '16.0'" },
     { name = "pyobjc-framework-mediatoolbox", marker = "platform_release >= '13.0'" },
@@ -1994,127 +1995,123 @@ dependencies = [
     { name = "pyobjc-framework-vision", marker = "platform_release >= '17.0'" },
     { name = "pyobjc-framework-webkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/89/982c55c5f4fc9ae1f22fb92b4dc003424df1d43da67f305d0a62ee00f6ac/pyobjc-10.3.2.tar.gz", hash = "sha256:1f35f3f8fc48028f2fdca48f55ac72073fe8980b9fa11a94b86ad69f50c9bd75", size = 10976 }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/d6/27b1c9a02f6cb4954984ce1a0239618e52f78c329c7e7450bf1f219b0f0a/pyobjc-11.0.tar.gz", hash = "sha256:a8f7baed65797f67afd46290b02f652c23f4b158ddf960bce0441b78f6803418", size = 11044 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/70/6097a795974795dbe645d6ae57ef4d5147002445eb02dbeef4778a264757/pyobjc-10.3.2-py3-none-any.whl", hash = "sha256:b46e480c8988d17b87b89095c9f74d3cb6f0334aaa38690d02cfd614aa12c71c", size = 4069 },
+    { url = "https://files.pythonhosted.org/packages/18/55/d0971bccf8a5a347eaccf8caa4718766a68281baab83d2b5e211b2767504/pyobjc-11.0-py3-none-any.whl", hash = "sha256:3ed5e4e993192fd7fadd42a4148d266a3587af7453ea3b240bab724d02e34e64", size = 4169 },
 ]
 
 [[package]]
 name = "pyobjc-core"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5d/07/2b3d63c0349fe4cf34d787a52a22faa156225808db2d1531fe58fabd779d/pyobjc_core-10.3.2.tar.gz", hash = "sha256:dbf1475d864ce594288ce03e94e3a98dc7f0e4639971eb1e312bdf6661c21e0e", size = 935182 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/94/a111239b98260869780a5767e5d74bfd3a8c13a40457f479c28dcd91f89d/pyobjc_core-11.0.tar.gz", hash = "sha256:63bced211cb8a8fb5c8ff46473603da30e51112861bd02c438fbbbc8578d9a70", size = 994931 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/11/f28af2cb4446743c8515f40f8dfac1bc078566c4a5cd7dcc6d24219ff3c9/pyobjc_core-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cea5e77659619ad93c782ca07644b6efe7d7ec6f59e46128843a0a87c1af511a", size = 775537 },
-    { url = "https://files.pythonhosted.org/packages/13/89/8808fe75efb03b29e082f9d12da31d55d5be3f55260c7b4e4cde7ebf81af/pyobjc_core-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:16644a92fb9661de841ba6115e5354db06a1d193a5e239046e840013c7b3874d", size = 826024 },
+    { url = "https://files.pythonhosted.org/packages/52/05/fa97309c3b1bc1ec90d701db89902e0bd5e1024023aa2c5387b889458b1b/pyobjc_core-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:50675c0bb8696fe960a28466f9baf6943df2928a1fd85625d678fa2f428bd0bd", size = 727295 },
+    { url = "https://files.pythonhosted.org/packages/56/ce/bf3ff9a9347721a398c3dfb83e29b43fb166b7ef590f3f7b7ddcd283df39/pyobjc_core-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a03061d4955c62ddd7754224a80cdadfdf17b6b5f60df1d9169a3b1b02923f0b", size = 739750 },
 ]
 
 [[package]]
 name = "pyobjc-framework-accessibility"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/08/e87e90c8de6851589bd8c02ca64eac2dbe1cf51b62fd06a3cb2e52cddb91/pyobjc_framework_accessibility-10.3.2.tar.gz", hash = "sha256:2a7f29d7fae54db6e447d746d29f1c720b48b4d41cf3ed927a58949917c2b7ed", size = 29704 }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/61/7484cc4ad3aa7854cd4c969379a5f044261259d08f7c20b6718493b484f9/pyobjc_framework_accessibility-11.0.tar.gz", hash = "sha256:097450c641fa9ac665199762e77867f2a82775be2f749b8fa69223b828f60656", size = 44597 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/f8/dc3d13d754a661d417c17e7076aacf600462acbe3cc7b3abb1979410ae58/pyobjc_framework_Accessibility-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:46c8fae7ca20250e0ad269963d06d091f09f3a706940cd0933195d23eb4589b6", size = 9993 },
-    { url = "https://files.pythonhosted.org/packages/7d/b7/0f3facfe12cf06e4e17966d584be3d522bdca6d5f466f1274b414b975d2c/pyobjc_framework_Accessibility-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:03e4e425c29129989a00090c2abd69d07806dc220d3ed5de17271f7ce0b2f394", size = 9976 },
-    { url = "https://files.pythonhosted.org/packages/75/64/2ff6691699e30829aec8e0b47d3913900b5af01fdbd55bdf2547c33136ee/pyobjc_framework_Accessibility-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4428855b982f0e161f29adfd2f7cca5c0ac17b727fc62771bfd278c7786b9469", size = 7350 },
-    { url = "https://files.pythonhosted.org/packages/74/5d/dbad50959899094264276931b309b65aa4ddb9453b13da581647555811f2/pyobjc_framework_Accessibility-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:9301daabe0a906c6621e86afbe8f8dd7cd8d1b118ccc7d19e9b8a7a6502b12d1", size = 10472 },
+    { url = "https://files.pythonhosted.org/packages/52/2e/babcd02cd833c0aba34e10c34a2184021b8a3c7cb45d1ae806156c2b519d/pyobjc_framework_Accessibility-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c3a751d17b288bb56a98a10b52b253b3002c885fe686b604788acac1e9739437", size = 10948 },
+    { url = "https://files.pythonhosted.org/packages/e8/ea/da3f982eeaffb80efb480892106caa19a2c9c8b8954570837ddbcd983520/pyobjc_framework_Accessibility-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:34536f3d60aeda618b384b1207a8c6f9978de278ce229c3469ef14fd27a3befa", size = 10962 },
 ]
 
 [[package]]
 name = "pyobjc-framework-accounts"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/99/587ce238d38c7ebe52c3f9ecc7a50b47ce51e6ace833e6b82435558fc086/pyobjc_framework_accounts-10.3.2.tar.gz", hash = "sha256:50460f185206d57755ddf942f216177ff10b3cda48e6969ed88e57aad1f354d6", size = 16498 }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/fa/b64f3f02e0a8b189dc07c391546e2dbe30ef1b3515d1427cdab743545b90/pyobjc_framework_accounts-11.0.tar.gz", hash = "sha256:afc4ae277be1e3e1f90269001c2fd886093a5465e365d7f9a3a0af3e17f06210", size = 17340 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/9d/08208de5cf4fa5aeba16112696be54ecc5c58a76c23b2cbfb65f5657825b/pyobjc_framework_Accounts-10.3.2-py2.py3-none-any.whl", hash = "sha256:40ab8fa23b10bb3328c31adbf541d7862e5cf6a2c7c9d30a8ed92d9b45e9851b", size = 4727 },
-    { url = "https://files.pythonhosted.org/packages/68/ed/f8aa50ad8d9a4a9609086d481d25ae13a725e0a3d54fc01461d845fa1ec8/pyobjc_framework_Accounts-10.3.2-py3-none-any.whl", hash = "sha256:45eed359516530a25c5ed1da91d5eedf7c4e944fb76fe90dba83d90032a0c528", size = 4722 },
+    { url = "https://files.pythonhosted.org/packages/93/45/5dfc72c82087d458ce7ddb17a338a38ae1848e72620537f31ed97192c65e/pyobjc_framework_Accounts-11.0-py2.py3-none-any.whl", hash = "sha256:3e4b494e1158e3250e4b4a09e9ff33b38f82d31aefe50dd47152c4a20ecdeec4", size = 5035 },
+    { url = "https://files.pythonhosted.org/packages/96/96/39b0cc9ced1180a93c75924a06598f24d0a7554b3e8ddfcb0828c0957476/pyobjc_framework_Accounts-11.0-py3-none-any.whl", hash = "sha256:ad0e378bd07ca7c88b45cda63b85424bc344e81ea44c0ae7327872d91cad311a", size = 5104 },
 ]
 
 [[package]]
 name = "pyobjc-framework-addressbook"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/8a/613db5bbbce90439322a8c2a40274af2780f65e9996604e00061690badbf/pyobjc_framework_addressbook-10.3.2.tar.gz", hash = "sha256:d5c9677aa64e8116b31a1d3f39f0bf2d1681f7cb93dbdc21db314c9dd8ac82f7", size = 85044 }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ef/5b5f6b61907ae43509fbf1654e043115d9a64d97efdc28fbb90d06c199f6/pyobjc_framework_addressbook-11.0.tar.gz", hash = "sha256:87073c85bb342eb27faa6eceb7a0e8a4c1e32ad1f2b62bb12dafb5e7b9f15837", size = 97116 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/6b/d12aa535162a5aca827a73182e927ec87b7de82485c69322e77b82e19088/pyobjc_framework_AddressBook-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:d04c22bb124a8b329c8142c76d6235877ca642f05b6c5176e6364c24b7a7633a", size = 13137 },
-    { url = "https://files.pythonhosted.org/packages/4f/79/2fcaa4e2ddfcef3ffb55faf064b7ef1a8985b1c467d28241621626e3462b/pyobjc_framework_AddressBook-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1793ed4a9e4068a376881832da0a445b31afa0e1a0806475091592b3991ebd96", size = 13100 },
-    { url = "https://files.pythonhosted.org/packages/e6/65/7fbb60cbfc743c00368e808147bc00332999c4c47ac2982d16229f9314b1/pyobjc_framework_AddressBook-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:26140d825b7141e576a2f84b6535965421334498ba6cb4235c9a9ccb75523aac", size = 10710 },
-    { url = "https://files.pythonhosted.org/packages/79/c7/70430efcfdd286f0cc3791bf368914b3ba12bb0cd97e7697a6e37315db66/pyobjc_framework_AddressBook-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:546f9c2619856fd0ccc3189f14cfe8a3c63e653abc0f021f09cca944ccbff4b8", size = 13515 },
+    { url = "https://files.pythonhosted.org/packages/2d/7a/8b874a52ff57dad999330ac1f899e6df8e35cec2cad8a90d8002d3c5f196/pyobjc_framework_AddressBook-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:af7de23aac7571a3b9dad5b2881d8f186653aa72903db8d7dbfd2c7b993156b9", size = 13010 },
+    { url = "https://files.pythonhosted.org/packages/0c/b4/93de1195c22cbaf4996aeb6d55e79fc7d76311cacfe8fd716c70fb20e391/pyobjc_framework_AddressBook-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b634ef80920ab9208f2937527e4a498e7afa6e2ceb639ebb483387ab5b9accc", size = 13039 },
 ]
 
 [[package]]
 name = "pyobjc-framework-adservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/49/b3fccd144e3357762278c40a669dfa53a6fdf6ced47217156f7112228dfc/pyobjc_framework_adservices-10.3.2.tar.gz", hash = "sha256:217c25adad25365a65ae9bbdd7e110b3b4597bcb78d9a914b00067a2135906df", size = 12169 }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7c/0c6e01f83b0c5c7968564a40146f4d07080df278457bdb5a982c8f26a74d/pyobjc_framework_adservices-11.0.tar.gz", hash = "sha256:d2e1a2f395e93e1bbe754ab0d76ce1d64c0d3928472634437e0382eafc6765cd", size = 12732 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a5/bf3ecbaa1930055be55aa5c2fcabe259ae707ee0aa00568aca3041b7fa32/pyobjc_framework_AdServices-10.3.2-py2.py3-none-any.whl", hash = "sha256:8c2644006198f9aa733f4ab4bd64d60e3e2a76d9a4347f0f307c18eaf264c18d", size = 3105 },
-    { url = "https://files.pythonhosted.org/packages/d0/c4/918b68b508bc4807d4a407022fd202cad102c396ac1d412155b777b4520b/pyobjc_framework_AdServices-10.3.2-py3-none-any.whl", hash = "sha256:94857b7938d1ed190289f3f28b246089533899fa970f06c5abce98b7a0f52f2e", size = 3100 },
+    { url = "https://files.pythonhosted.org/packages/1d/10/601c9f5a07450ce75e166042d9ac5efe6286ac2d15212885a920260af9e3/pyobjc_framework_AdServices-11.0-py2.py3-none-any.whl", hash = "sha256:7cd1458f60175cd46bd88061c20e82f04b2576fc00bc5d54d67c18dcb870e27f", size = 3420 },
+    { url = "https://files.pythonhosted.org/packages/89/40/98a9116790e163d6c9ac0d19ce66307b03f9ac5ee64631db69899457b154/pyobjc_framework_AdServices-11.0-py3-none-any.whl", hash = "sha256:6426d4e4a43f5ee5ce7bab44d85647dbded3e17c0c62d8923cebaf927c4162ca", size = 3486 },
 ]
 
 [[package]]
 name = "pyobjc-framework-adsupport"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/dd/bdeecdde652e82bfe7d75fddc2e70682433d564bafc5fc851c5e2c558443/pyobjc_framework_adsupport-10.3.2.tar.gz", hash = "sha256:71cac2c9a4dd764fefc7b257483338f73d9783038d52028b97446ea83ad37c87", size = 12307 }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/07/b8b5f741d1e2cad97100444b255e6ecaca3668e7414039981799aa330035/pyobjc_framework_adsupport-11.0.tar.gz", hash = "sha256:20eb8a683d34fb7a6efeceaf964a24b88c3434875c44f66db5e1b609e678043a", size = 12819 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/b3/95ac315013f863c87ff1c78520db60e995d67f9c30f5679c8806fdc03823/pyobjc_framework_AdSupport-10.3.2-py2.py3-none-any.whl", hash = "sha256:4fe1d3a85dd5489ae990490991262d1402689ae13dc32f0fc53f94fe59544101", size = 3019 },
-    { url = "https://files.pythonhosted.org/packages/1f/c5/20758d41c8af927f6686e2ae5e9ea74f885d069879515114877ecd560438/pyobjc_framework_AdSupport-10.3.2-py3-none-any.whl", hash = "sha256:212c8b52c3870a21e3be476f565d5e1f3c298b244842fa4967c2fa3310c0e57d", size = 3017 },
+    { url = "https://files.pythonhosted.org/packages/6f/7f/2023c0a973f8823175c7e409fdbd306b275b0bb2723acf12ffade6ba5dbe/pyobjc_framework_AdSupport-11.0-py2.py3-none-any.whl", hash = "sha256:59161f5046def176d3aa6fdd6a05916029ca69ac69f836c67e0dd780a5efcf0f", size = 3334 },
+    { url = "https://files.pythonhosted.org/packages/cf/84/26c4275732952416603026888ca5462ed84372d412d0ccd7a1c750c01673/pyobjc_framework_AdSupport-11.0-py3-none-any.whl", hash = "sha256:91ba05eb5602911287bd04b0efefb7a485f9af255095b87c3e77bb7d1d1242ed", size = 3405 },
 ]
 
 [[package]]
 name = "pyobjc-framework-applescriptkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/78/5abe58d1698dfacc0e5ab719aa2cd93879230e45b9387bcc3b0bb91040d3/pyobjc_framework_applescriptkit-10.3.2.tar.gz", hash = "sha256:a4d74fc6b28d1ff7d39b60c9e0c2d5d1baf575ade6e6d1ea06ed077facec47db", size = 12102 }
+sdist = { url = "https://files.pythonhosted.org/packages/14/c3/d7f9a33de7ab8e3950350e0862214e66f27ed6bff1a491bc391c377ab83e/pyobjc_framework_applescriptkit-11.0.tar.gz", hash = "sha256:4bafac4a036f0fb8ba01488b8e91d3ac861ce6e61154ffbd0b26f82b99779b50", size = 12638 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/7b/2abb01be55d4633ecae77af4d85077e7825452ece51daf4cd0cde0d8ae49/pyobjc_framework_AppleScriptKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:a970410ece8004a912918eed3173b2771c857fb8eb3b61f8d796d3e0e0b759d6", size = 3931 },
-    { url = "https://files.pythonhosted.org/packages/50/bb/2e8ff9f8d4b72ba43e3e0e45f9aa4ce8d02352e8dd4a6321bfc61371ec21/pyobjc_framework_AppleScriptKit-10.3.2-py3-none-any.whl", hash = "sha256:38e7b573d3d5b3773d8a7f2189cad2378d32353d597dcd6342e2419dd6310c0e", size = 3926 },
+    { url = "https://files.pythonhosted.org/packages/97/4b/5e7f6a182129be6f229ee6c036d84359b46b0f5f695824315c47b19d3149/pyobjc_framework_AppleScriptKit-11.0-py2.py3-none-any.whl", hash = "sha256:e8acc5ca99f5123ec4e60cb356c7cc407d5fe533ca53e5fa341b51f65495973b", size = 4246 },
+    { url = "https://files.pythonhosted.org/packages/b6/ce/7965604f553c91fbd5602e17057b0935c100542abaf76291921335b6f75c/pyobjc_framework_AppleScriptKit-11.0-py3-none-any.whl", hash = "sha256:92cffd943a4d17f684bb51245744e9d0bb8992b2967125845dfeab09d26fc624", size = 4317 },
 ]
 
 [[package]]
 name = "pyobjc-framework-applescriptobjc"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/8b/d720f671b21a07a8d1815c54ce4e8f313f73ea645a82faa8331a2a05d9c2/pyobjc_framework_applescriptobjc-10.3.2.tar.gz", hash = "sha256:6af16cab0fe4e2d50775e67501bcecae1c5acdba7ed560eba38e5f8e3c8ac38c", size = 12166 }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/9f/bb4fdbcea418f8472d7a67d4d2e4a15fca11fed04648db5208b0fce84807/pyobjc_framework_applescriptobjc-11.0.tar.gz", hash = "sha256:baff9988b6e886aed0e76441358417707de9088be5733f22055fed7904ca1001", size = 12675 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/46/eff05f226e5834c9f24cc96b12e09d0da08165264f1fde813ba715ca2f6e/pyobjc_framework_AppleScriptObjC-10.3.2-py2.py3-none-any.whl", hash = "sha256:a932ffdcf6a5b5ac884666bb0ae2a8075528f489b0b5aa4336fc22e6f011664e", size = 4030 },
-    { url = "https://files.pythonhosted.org/packages/81/6b/b00195e4431651ffdb313d35da3c3f27a8b2558a3219bb00221500b75b59/pyobjc_framework_AppleScriptObjC-10.3.2-py3-none-any.whl", hash = "sha256:e0a0496fc05e7b23d6030d9dfcd706167ad05e7032f69117bc0136234eebc12e", size = 4026 },
+    { url = "https://files.pythonhosted.org/packages/b8/7d/b3e28759df060f26a31407282e789a1a321612afcee3871134fdac8dc75f/pyobjc_framework_AppleScriptObjC-11.0-py2.py3-none-any.whl", hash = "sha256:a4c8d417fdb64180a283eadf8ddb804ba7f9e3cef149216a11b65e1d3509c55b", size = 4347 },
+    { url = "https://files.pythonhosted.org/packages/0d/e7/c080a1cd77ce04e3bf4079a941105d3d670b9ba0fc91a54d4a1764bea02d/pyobjc_framework_AppleScriptObjC-11.0-py3-none-any.whl", hash = "sha256:681006b0cdf0279cd06b6d0f62b542b7f3b3b9b5d2391f7aa3798d8b355d67bf", size = 4416 },
 ]
 
 [[package]]
 name = "pyobjc-framework-applicationservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -2122,91 +2119,85 @@ dependencies = [
     { name = "pyobjc-framework-coretext" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/a0/32cd02c3e5f0f740f86064a078278c180d3058c857b8425a5128866e3931/pyobjc_framework_applicationservices-10.3.2.tar.gz", hash = "sha256:2116c3854ac07c022268eebc7cb40ccba30727df78442e57e0280b5193c8183c", size = 183088 }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/fb/4e42573b0d3baa3fa18ec53614cf979f951313f1451e8f2e17df9429da1f/pyobjc_framework_applicationservices-11.0.tar.gz", hash = "sha256:d6ea18dfc7d5626a3ecf4ac72d510405c0d3a648ca38cae8db841acdebecf4d2", size = 224334 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/07/168a9fe2a9431faa765f83768dba8e74a103ce70649e66a249e1bcfcbf71/pyobjc_framework_ApplicationServices-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0a0b47a0371246a02efcf9335ae3d18166e80e4237e25c25a13993f8df5cc1d", size = 30724 },
-    { url = "https://files.pythonhosted.org/packages/f7/c0/59d4a79aac12052c2c594c7e4e8f16ddf16be0aaae8f8321f93ac1f92a16/pyobjc_framework_ApplicationServices-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b9174444599b6adf37c1d28915445d716324f1cdc70a1818f7cb4f181caeee1b", size = 30776 },
+    { url = "https://files.pythonhosted.org/packages/99/37/3d4dc6c004aaeb67bd43f7261d7c169ff45b8fc0eefbc7ba8cd6b0c881bc/pyobjc_framework_ApplicationServices-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:61a99eef23abb704257310db4f5271137707e184768f6407030c01de4731b67b", size = 30846 },
+    { url = "https://files.pythonhosted.org/packages/74/a9/7a45a67e126d32c61ea22ffd80e87ff7e05b4acf32bede6cce071fbfffc8/pyobjc_framework_ApplicationServices-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5fbeb425897d6129471d451ec61a29ddd5b1386eb26b1dd49cb313e34616ee21", size = 30908 },
 ]
 
 [[package]]
 name = "pyobjc-framework-apptrackingtransparency"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/9f/bd8bb6d37c96060ea265d65e2dd9b6bf30801f6ffd922db7635165ac0968/pyobjc_framework_apptrackingtransparency-10.3.2.tar.gz", hash = "sha256:b1a0c19321f103d7f9c146b921d260083bb536a4d28b9d4337ca2ea4f88318a1", size = 12863 }
+sdist = { url = "https://files.pythonhosted.org/packages/36/40/c1c48ed49b5e55c7a635aa1e7ca41ffa1c5547e26243f26489c4768cd730/pyobjc_framework_apptrackingtransparency-11.0.tar.gz", hash = "sha256:cd5c834b5b19c21ad6c317ba5d29f30a8d0ae5d14e7cf557da22abc0850f1e91", size = 13385 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/de/d5c22f0328ac7c7f68eebddb0e30acc4eb45e36bd6a4b3baee583e89cca8/pyobjc_framework_AppTrackingTransparency-10.3.2-py2.py3-none-any.whl", hash = "sha256:9dd9ccd50ef9553e8810a2b0ef1824f5c42aff44f7eedf30a7a38dd1dc57f0c3", size = 3463 },
-    { url = "https://files.pythonhosted.org/packages/ee/02/ea1b1a78396a84356d44bdbf9a25ab6d72dd7d75a93cdcc052282740357a/pyobjc_framework_AppTrackingTransparency-10.3.2-py3-none-any.whl", hash = "sha256:f68058481a48626375db21965e7bfecad8500103f21febfe3baeba8c59a3737c", size = 3457 },
+    { url = "https://files.pythonhosted.org/packages/c4/72/6e460cd763a3048c4d75769ed60a5af7832122b78224f710e40a9eb1c5cf/pyobjc_framework_AppTrackingTransparency-11.0-py2.py3-none-any.whl", hash = "sha256:1bf6d4f148d9f5d5befe90fcfd88ce988458a52719d53d5989b08e4fbed58864", size = 3805 },
+    { url = "https://files.pythonhosted.org/packages/33/cb/ef2622ee08349293aae6f81216cfee2423ad37d8a1d14ba4690b537d8850/pyobjc_framework_AppTrackingTransparency-11.0-py3-none-any.whl", hash = "sha256:347f876aea9d9f47d9fbf6dfa6d3f250ecd46f56a7c4616386327061e2ecc4e9", size = 3878 },
 ]
 
 [[package]]
 name = "pyobjc-framework-audiovideobridging"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/67984a0d4065cbf6982d4e18581fa2b8a0023c37ee5bf436ccebb6c8f552/pyobjc_framework_audiovideobridging-10.3.2.tar.gz", hash = "sha256:72b1c8a07fb5ab4f988c9172e5ddf44f1fd15214aa5dc2f80852c6152e13b2b8", size = 59579 }
+sdist = { url = "https://files.pythonhosted.org/packages/89/5f/0bd5beded0415b53f443da804410eda6a53e1bc64f8779ed9a592719da8c/pyobjc_framework_audiovideobridging-11.0.tar.gz", hash = "sha256:dbc45b06418dd780c365956fdfd69d007436b5ee54c51e671196562eb8290ba6", size = 72418 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/c5/f7df33105def20bc69f694287be6a68ec59b0b9d98dd047b7380bf3e8e5d/pyobjc_framework_AudioVideoBridging-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:827233f90741adc6d7b0288e13d489599c818b7069de59dd1f64868d9b532b3e", size = 11000 },
-    { url = "https://files.pythonhosted.org/packages/87/9c/7ef810b3c36a492fdeca06b3b66a1fd5541f9fa90d04e126ef68fd29a29c/pyobjc_framework_AudioVideoBridging-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1eba2ef24a191b698e6a991a5b37e1b047ab8d20b436f008c80b68e727ef0fb4", size = 11035 },
+    { url = "https://files.pythonhosted.org/packages/3c/33/2ee33542febb40174d40ae8bbdf672b4e438a3fb41ba6a4d4a3e6800121b/pyobjc_framework_AudioVideoBridging-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d025e49ca6238be96d0a1c22942b548a8d445ef8eb71259b4769e119810f42c6", size = 10944 },
+    { url = "https://files.pythonhosted.org/packages/45/ea/db8295e17b0b544b06620e4019afcc76d7b743a8f03cb8a1024b2bc118ac/pyobjc_framework_AudioVideoBridging-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d414ecffeb23cddc8e64262af170e663c93e8d462d18aa7067d4584069967859", size = 10962 },
 ]
 
 [[package]]
 name = "pyobjc-framework-authenticationservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/16/ca8a01b9ff6bb50fd35465b1a31785575096b4aa079ccbc90cbd40cf7db1/pyobjc_framework_authenticationservices-10.3.2.tar.gz", hash = "sha256:ff990cb7bc2ac9599082f162e38e4db3bf7504c71948c09ec5fb625f4c2e05e1", size = 86841 }
+sdist = { url = "https://files.pythonhosted.org/packages/31/0f/2de0d941e9c9b2eb1ce8b22eb31adc7227badfe1e53f615431d3a7fdcd48/pyobjc_framework_authenticationservices-11.0.tar.gz", hash = "sha256:6a060ce651df142e8923d1383449bc6f2c7f5eb0b517152dac609bde3901064e", size = 140036 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/0b/0086583835b1a222a115ddefe1b4107eb049f4b652af26750094845365a4/pyobjc_framework_AuthenticationServices-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c26c369ba44177b2b019fbe0691b4d243fc4cb734c8704067fca4b56006547de", size = 19342 },
-    { url = "https://files.pythonhosted.org/packages/e9/ea/e289b858ceee4e527b35e8738ac9f87e556c4af5eef2d4ad5d5b2a95b944/pyobjc_framework_AuthenticationServices-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:06cae95f3f4e6ae22d763d84fd91b031f60c8154d72b0955275247024f5bec51", size = 19279 },
-    { url = "https://files.pythonhosted.org/packages/fc/bd/d41336e93c0fef8b9c993996e0f6d16d21c12895f5a883ef06262f5b16a8/pyobjc_framework_AuthenticationServices-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4db6591872a577d8dfb60f1060b7a1fde08d1becd9f98c13c03bc66fb278852f", size = 13374 },
-    { url = "https://files.pythonhosted.org/packages/77/80/67881e9edb677be974c8751e46b3e30828fb2e2cc4ae1769c52dd82479b8/pyobjc_framework_AuthenticationServices-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:19276f6fa81f2e1541a5902938fc204aa4e432b8fc44f20bfda95321a9341416", size = 19357 },
+    { url = "https://files.pythonhosted.org/packages/45/16/6246cf10e2d245f4018c02f351f8eb4cc93823f6e7e4dd584ab292cda786/pyobjc_framework_AuthenticationServices-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:84e3b23478cf8995883acfe6c1a24503c84caf2f8dbe540377fe19fb787ce9b2", size = 20079 },
+    { url = "https://files.pythonhosted.org/packages/b7/ca/81a55a0714e73695b536bfbcbf0f5ddf68da9485b468406f6ef887a04938/pyobjc_framework_AuthenticationServices-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1779f72c264f749946fcbfba0575a985c1e297d426617739a533554dbf172f9a", size = 20105 },
 ]
 
 [[package]]
 name = "pyobjc-framework-automaticassessmentconfiguration"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/dd/53aeb33bdd6c137af18e487d7f3e023d5dc36eaa049775ffb7a9d21721b2/pyobjc_framework_automaticassessmentconfiguration-10.3.2.tar.gz", hash = "sha256:cbb1313e5ad4162664a92225a9e4a685a92d03a81e81664acbc51857ec415292", size = 22841 }
+sdist = { url = "https://files.pythonhosted.org/packages/09/d5/5febfee260b88e426c7e799cc95990818feeaa9f740fb9dd516559c96520/pyobjc_framework_automaticassessmentconfiguration-11.0.tar.gz", hash = "sha256:5d3691af2b94e44ca594b6791556e15a9f0a3f9432df51cb891f5f859a65e467", size = 24420 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/da/d8ad97f6db9b4c4e073500c911cc460d3e979623839b45d26fcbbcfd96ea/pyobjc_framework_AutomaticAssessmentConfiguration-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:62a1f51491bf69790546664f4bcfa0b0f82d8a67a7cd6c88c23269607ed0ee40", size = 8535 },
-    { url = "https://files.pythonhosted.org/packages/c4/21/b83cfdff8547ddba8c60c629b621a91c3558eefdf652efa783451814c3d8/pyobjc_framework_AutomaticAssessmentConfiguration-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:267fe8f273b1d06ca277572ea3f75bb30ceb89cac7a114f1c9f5a76331607809", size = 8513 },
-    { url = "https://files.pythonhosted.org/packages/d4/25/0ab4924032579e405e683c31c4c413dc02165dde3323f7a6fdcb5e82181d/pyobjc_framework_AutomaticAssessmentConfiguration-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d92d60ddc36169c88073ec2ded594eab199a8bc59905fd3b4234bbce38cc71ee", size = 6513 },
-    { url = "https://files.pythonhosted.org/packages/d0/60/25052beafd141534d2cbee639e5c40342fa46f58b3b8709fe415fcd298f8/pyobjc_framework_AutomaticAssessmentConfiguration-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:be9f4570d41779d1ecde943eeef2d460def2315f91513555b37b1d67be4762c4", size = 8874 },
+    { url = "https://files.pythonhosted.org/packages/50/3f/b593adce2f5b9f9427d784db56d8195adc2cfb340d4d3578914539a17faa/pyobjc_framework_AutomaticAssessmentConfiguration-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:25f2db399eb0a47e345d0471c7af930f5a3be899ba6edb40bd9125719e4b526f", size = 9015 },
+    { url = "https://files.pythonhosted.org/packages/4e/c3/b6b779d783dcf3667a2011d8af0d801f6639df9735cdc34c6e6b79822298/pyobjc_framework_AutomaticAssessmentConfiguration-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b6433452d2c4cdb0eef16cc78a24ba9c61efb5bb04709ee10ca94b69119e889c", size = 9034 },
 ]
 
 [[package]]
 name = "pyobjc-framework-automator"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/16/3796b8abb209e8ff41a19064b88f53e48b886bcd004f6b05afc4f23ada70/pyobjc_framework_automator-10.3.2.tar.gz", hash = "sha256:ee7ec981275e5dbdd2e4d83d4d4be3c3efdcaadf0a9917d935328363dd49085f", size = 195443 }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1b/1ba4eb296c3915f2e367e45470cb310a9c78b4dd65a37bd522f458f245aa/pyobjc_framework_automator-11.0.tar.gz", hash = "sha256:412d330f8c6f30066cad15e1bdecdc865510bbce469cc7d9477384c4e9f2550f", size = 200905 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/1a/97a29dd795e0b82cc497cfaf1a4b2f1e39b0516efe06ab7a5fd2eabcdb83/pyobjc_framework_Automator-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c54bc8ebd7bf9a7978019e87e3952c8abb4c2b86049f0c444a31429c1ca216f2", size = 9958 },
-    { url = "https://files.pythonhosted.org/packages/d9/30/608f709bd0cbca8ab71ea1631fdc4e8aee3e616dad056c053c21d75a7a69/pyobjc_framework_Automator-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:62534dd8ba98e1749f54e633d02f8678d771bb66b2245b170c52ea0fcbcf1d64", size = 9926 },
-    { url = "https://files.pythonhosted.org/packages/41/d5/bc14c813c444cce511d37a40734eb3f449f67fe455a5aa7d75b05a72377c/pyobjc_framework_Automator-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e1b6fae892fca95e9229da1f42df851376dcd97840b99c34ae509a4dbc1f9c7f", size = 7676 },
-    { url = "https://files.pythonhosted.org/packages/f3/c4/7502081fb3cc64dab53983c0a4da5fde70475c55e7fd3a86012aaca35fcf/pyobjc_framework_Automator-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:62459585c850945736264d1251fb4a37b3a1f87b4749dbe1f8bb204099527481", size = 10311 },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/bfe673491042849ad400bebf557b8047317757283b98ad9921fbb6f6cae9/pyobjc_framework_Automator-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:850f9641a54cc8d9a3d02c2d87a4e80aed2413b37aa6c26a7046088b77da5b42", size = 9811 },
+    { url = "https://files.pythonhosted.org/packages/13/00/e60db832c536fd354fab7e813ee781327358e6bcbc4cacbd9695dade7006/pyobjc_framework_Automator-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eb1b9b16873ec1d2f8af9a04ca1b2fcaa324ce4a1fada0d02fa239f6fecf773b", size = 9827 },
 ]
 
 [[package]]
 name = "pyobjc-framework-avfoundation"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -2215,66 +2206,58 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/8d/8a78df7d0ccbf7e8f7a80692f7891895b323334bde2781a6018452c92eb1/pyobjc_framework_avfoundation-10.3.2.tar.gz", hash = "sha256:e4baa1cb8d63c2b366f90341dee54a646004ad02d4b01119c79904cb869e7a6a", size = 695532 }
+sdist = { url = "https://files.pythonhosted.org/packages/76/06/018ad0e2a38dbdbc5c126d7ce37488c4d581d4e2a2b9ef678162bb36d5f6/pyobjc_framework_avfoundation-11.0.tar.gz", hash = "sha256:269a592bdaf8a16948d8935f0cf7c8cb9a53e7ea609a963ada0e55f749ddb530", size = 871064 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/2a/f4710ceee7ff485d5e63893fd97e2cfebbef006c593e2f49cbd507cdca21/pyobjc_framework_AVFoundation-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:1a357b4264909c9f29a467d6706e12a822c1d6b9b9b274dd5892500cc9265681", size = 66809 },
-    { url = "https://files.pythonhosted.org/packages/49/29/30f7a6718e40d027ee9aff93fa5ea63f2a8c8367a8ff359fb682380f6ed7/pyobjc_framework_AVFoundation-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:cf41bd0c3e1269d892bd112c893507f8a3991244a9217d103dc2beb4366a8769", size = 66742 },
-    { url = "https://files.pythonhosted.org/packages/63/62/9ada601d16d4cba65076aae40d869a16e4ea07755f989c84723cd12e5b63/pyobjc_framework_AVFoundation-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4c257341a4baeb10371e4bd8eaa89a077a1fb8095a0ebed15117b7cb424e0b57", size = 54727 },
-    { url = "https://files.pythonhosted.org/packages/73/18/b76ec3753432034f7f290c2894f812302d037b831304f7ef4c932e70ce34/pyobjc_framework_AVFoundation-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:50a4e245d5e65f525e23c9bda78ccfbaf3492b661cb006f2c9b6f0d9c9d368f8", size = 66874 },
+    { url = "https://files.pythonhosted.org/packages/44/b5/327654548fa210b4637350de016183fbb1f6f8f9213d2c6c9b492eb8b44c/pyobjc_framework_AVFoundation-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:87db350311c1d7e07d68036cdde3d01c09d97b8ba502241c0c1699d7a9c6f2e4", size = 71345 },
+    { url = "https://files.pythonhosted.org/packages/f5/36/e09b20f280953fa7be95a9266e5ad75f2e8b184cc39260c0537b3e60b534/pyobjc_framework_AVFoundation-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6bb6f4be53c0fb42bee3f46cf0bb5396a8fd13f92d47a01f6b77037a1134f26b", size = 71314 },
 ]
 
 [[package]]
 name = "pyobjc-framework-avkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a9/ee16b75e0a509ab19e1a911c09bddef11b3e426cc7c8294006c583529172/pyobjc_framework_avkit-10.3.2.tar.gz", hash = "sha256:b4c63941aafc7f83790ec6039b3384a19ada304c98c889a2d6ad66ad843fb41d", size = 39355 }
+sdist = { url = "https://files.pythonhosted.org/packages/de/79/5b2fcb94b051da32a24b54bb0d90b1d01b190e1402b6303747de47fb17ac/pyobjc_framework_avkit-11.0.tar.gz", hash = "sha256:5fa40919320277b820df3e4c6e84cba91ef7221a28f4eb5374e3dbd80d1e521a", size = 46311 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/ba/0b8e6bdb782b7df797b96d931535c8dcfcbfcefbebca7b98864d1f193fc9/pyobjc_framework_AVKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:d884f5a51cf1e4f2ffaeba85ac8153635da54444a4a1b9be337f4994d0e7141d", size = 12142 },
-    { url = "https://files.pythonhosted.org/packages/c1/bc/097af60dac8f11ec531864435520b334d92c5aa938d745ee0c609b7bad2c/pyobjc_framework_AVKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e65230536c8ac53863e5b8060a9351976f83487416b589b694bd3c59cb146a5", size = 12114 },
-    { url = "https://files.pythonhosted.org/packages/81/ed/fde1819d30a3d3bfbc1121ec1a53920ae35320124c12f8ad5b5757ffdfe9/pyobjc_framework_AVKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a67b031ce160998c100c61880dbc0ea0788f1e07c0e06fe71e7d238261d64353", size = 8259 },
-    { url = "https://files.pythonhosted.org/packages/d0/ba/d23ddf14a5bccf69009fd0841b295173db6aafc186f8b6cd00f30bd7afed/pyobjc_framework_AVKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:2fd40cbe60c5f0bd4feab6a999da4be877258ffe61c8c1becf2b4106e5fb0ab1", size = 12082 },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/aed1023150483a288922c447e1997f4f4e9d0460038e1a070a3a53b85c19/pyobjc_framework_AVKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:16b5560860c1e13e692c677ad04d8e194d0b9931dd3f15e3df4dbd7217cc8ab1", size = 11960 },
+    { url = "https://files.pythonhosted.org/packages/01/f4/08684e5af2a2e8940e6411e96ef1d7ed1e51a121abb19c93c25c34969213/pyobjc_framework_AVKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f4da468b97bb7f356024e31647619cd1cd435b543e467209da0ee0abdfdc7121", size = 11969 },
 ]
 
 [[package]]
 name = "pyobjc-framework-avrouting"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/89/b45d19ddc5c780fa7e6736cb782bc9b01a1c6ec8690326904020339dd39b/pyobjc_framework_avrouting-10.3.2.tar.gz", hash = "sha256:0c36464e80c77e0d44483c68880ea2d239084c378d200f02e0688967c3de4f55", size = 19018 }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/80/63680dc7788bc3573a20fc5421dfcf606970a0cd3b2457829d9b66603ae0/pyobjc_framework_avrouting-11.0.tar.gz", hash = "sha256:54ec9ea0b5adb5149b554e23c07c6b4f4bdb2892ca2ed7b3e88a5de936313025", size = 20561 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/80/990a5e9b45b9f3973299f94e18ed8c8a561ede2cf33e505710151c7249e9/pyobjc_framework_AVRouting-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:8c053fdcbf6609371c11178593cc6a75258a83797aa668c28d0be924d60f2262", size = 8199 },
-    { url = "https://files.pythonhosted.org/packages/87/cc/4a202e8a53c2f6be57ad1d8b1d66b19ef37b4c9f4e0840bf69bd4fc48339/pyobjc_framework_AVRouting-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e4b438576d627e8d97bc9690b7250a3a9821c94cfd7002b63c9ee50a60287aaa", size = 8175 },
-    { url = "https://files.pythonhosted.org/packages/9f/3b/0f4227d9cbc12ba57f8ac00b4d1dfbe6b2056bb267966aa62b1af34baaf9/pyobjc_framework_AVRouting-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fcc9bc9e18aafd4709159a6d7a00771a6d018f7e8945759c0864ba24aeca38f5", size = 5909 },
-    { url = "https://files.pythonhosted.org/packages/23/b0/e3c0e9bd6f5d7b92234ae106fa0567cdde9019b4ef854250317372f91f98/pyobjc_framework_AVRouting-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:a0ef3bb4b3e0f37d253e17c7669ee4a0fe086c6cc32a10dd8241ea1512135e68", size = 8587 },
+    { url = "https://files.pythonhosted.org/packages/8b/9c/ea6924de09e13f858210d6dd934f00773b1e3db6af886c72841ed545560f/pyobjc_framework_AVRouting-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:54e58cd0292f734aba035599f37a0c00f03761e9ff5cf53a0857cec7949bb39c", size = 8067 },
+    { url = "https://files.pythonhosted.org/packages/3f/92/774e10af5aba5742c4a2dd563fa819550d9caa755d2648b3cc87bbe30129/pyobjc_framework_AVRouting-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:779db3fb0048b22c5dcf5871930025c0fd93068f87946e8053f31a3366fa6fb0", size = 8078 },
 ]
 
 [[package]]
 name = "pyobjc-framework-backgroundassets"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/15/38a5d93d6e03abcfe6833df574fd5087c4bfeccb49dff450a771e2221e08/pyobjc_framework_backgroundassets-10.3.2.tar.gz", hash = "sha256:17436f7eb08d407603e2e633272a7d51023d40b6f81dd577ad34b9db16fdcb6d", size = 22162 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/17/83b873069b0c0763365de88648ad4a2472e9e96fcac39fa534f3633552e8/pyobjc_framework_backgroundassets-11.0.tar.gz", hash = "sha256:9488c3f86bf427898a88b7100e77200c08a487a35c75c1b5735bd69c57ba38cb", size = 23658 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/ed/e40e34f2790887776809e857055968f95247f68db9b1dfbdde9cba6b71b2/pyobjc_framework_BackgroundAssets-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:6d9f714ed58ec15c54b3204287b924e9bffecad1762763eb646612adc1c2e1e1", size = 9588 },
-    { url = "https://files.pythonhosted.org/packages/6b/2b/4d8d5c63771847b46007fcdb4bb4ae9f43df64d146694d58b900174b9c0c/pyobjc_framework_BackgroundAssets-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9c427818c613f5eed9fb16aeedcd86998b46e7edf5a3e66c5319aa81f8421a82", size = 9553 },
-    { url = "https://files.pythonhosted.org/packages/88/c5/b6386bb414a408116db33b2826fdb347a831c429ad6fd0c9f6cef6cb7a0c/pyobjc_framework_BackgroundAssets-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:34a1bb9f48b3f4222f798704e63851fdccc5ec352eb7dc331c941bb73826569a", size = 7116 },
-    { url = "https://files.pythonhosted.org/packages/75/88/8df35ff15c008a21f189649ede50b0228c43f4fb35943a2c3271baec661a/pyobjc_framework_BackgroundAssets-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:7893c4f9635cbf5a73218e801c5712a4e93b2120a525609c0c1f69b96c69e05e", size = 10138 },
+    { url = "https://files.pythonhosted.org/packages/e9/9d/bea4408649199340ec7ed154bbaa1942a0b0955006b3153088b3f35e6ff6/pyobjc_framework_BackgroundAssets-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:812bcc4eaf71c1cc42e94edc2b5ad0414d16cfe1da5c421edd9382417d625f06", size = 9499 },
+    { url = "https://files.pythonhosted.org/packages/bd/79/726c14fd26553c8bbe8b2ed55caa45d89093e2e85b45c1b598dd04ea7589/pyobjc_framework_BackgroundAssets-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:96b3fc40c514867d4a0b3ad4d256bc5134d789e22fa306a6b21e49ecadc51698", size = 9521 },
 ]
 
 [[package]]
 name = "pyobjc-framework-browserenginekit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -2283,75 +2266,85 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/ab/d09654cb647e5c1c751bd9c819d79a31dfe4072cc79eae28e66f58c05688/pyobjc_framework_browserenginekit-10.3.2.tar.gz", hash = "sha256:5c4d50f2358376c36a3d2721b8d5c259f77e9e62f48503030c2312b8b6b58943", size = 21390 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/2e/df3d2f7e53132d398c2922d331dd1d2aa352997a1a4a1390e59db51c1d13/pyobjc_framework_browserenginekit-11.0.tar.gz", hash = "sha256:51971527f5103c0e09a4ef438c352ebb037fcad8971f8420a781c72ee421f758", size = 31352 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/1c/47864ac702e146422128232ac5842eac12a3a6a5ed860dc491bdd76d3894/pyobjc_framework_BrowserEngineKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:d52afa42b38f2b7963ecd82314e0c33f2aa63417df78075affc026fd4e9dfb8d", size = 9895 },
-    { url = "https://files.pythonhosted.org/packages/cc/6e/5a8824fdbb4dba2048569a0615eff24f74fe65825920f921dc3a3cfa9350/pyobjc_framework_BrowserEngineKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:17cfc4f745d04727fcaa23ce794dc1aa1caf002f937cc9c764cfba118a494cca", size = 9850 },
-    { url = "https://files.pythonhosted.org/packages/ea/f6/68aab1ae276238ad86973fe96ba3d5b4b2ebec883524b27dd1005fd570d4/pyobjc_framework_BrowserEngineKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9927e3b21185113a0260e6e033961d4c09b2d9b9561eb3406713dcb903bdc448", size = 7296 },
-    { url = "https://files.pythonhosted.org/packages/31/0d/22c0c398540cd0b81abb9ccd58fc7a2203b50d6d9219618d9f601fae3795/pyobjc_framework_BrowserEngineKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:b5c86adf07b7ff00c0fd3b04fc4f94ca5780080edb65c219bc08df08b0f5accd", size = 10345 },
+    { url = "https://files.pythonhosted.org/packages/da/6d/6aa929d4993453817523db9c82a4e6e2cce7104fa59e29ee857f9e926b0d/pyobjc_framework_BrowserEngineKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:58494bc3ccc21a63751b7c9f8788d0240c3f1aad84cf221c0e42c9764a069ba4", size = 10913 },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/dd18f7ff9438ad4612febfbdb2e4bded37033347b9f0e1355df76f2c5213/pyobjc_framework_BrowserEngineKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0925edfd60a24f53819cfd11f07926fd42bc0fbeb7a4982998a08742e859dbff", size = 10933 },
 ]
 
 [[package]]
 name = "pyobjc-framework-businesschat"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/ea/e2df6cda4ef666165c97e513cd48f9a4bfc92f8f5137a4df6adf77591448/pyobjc_framework_businesschat-10.3.2.tar.gz", hash = "sha256:a598f401d5f391f0c78aa62a58d0a7f9908fa86abffb884138795f36105800ea", size = 12402 }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/f2/4541989f2c9c5fc3cdfc94ebf31fc6619554b6c22dafdbb57f866a392bc1/pyobjc_framework_businesschat-11.0.tar.gz", hash = "sha256:20fe1c8c848ef3c2e132172d9a007a8aa65b08875a9ca5c27afbfc4396b16dbb", size = 12953 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/ce/1e43411f02adb0fcc284fc7b55be12939dfa844ebe8057d8d6968951aee4/pyobjc_framework_BusinessChat-10.3.2-py2.py3-none-any.whl", hash = "sha256:99f520ec64de7d7dab540456ac39bc9931f843a5aa86280d86372c76821fa6c1", size = 3085 },
-    { url = "https://files.pythonhosted.org/packages/22/fc/b14d18869c44924e0f4bcaa50f99cabc779057ede1667bf7434c62147ee0/pyobjc_framework_BusinessChat-10.3.2-py3-none-any.whl", hash = "sha256:d2a9e2af6e23ebf096b3e8a1107a762f08eb309b18b5a2be34125c0e6a7d3998", size = 3078 },
+    { url = "https://files.pythonhosted.org/packages/d4/5b/d7313368ea4056092400c7a4ed5c705d3d21a443641d98b140054edbd930/pyobjc_framework_BusinessChat-11.0-py2.py3-none-any.whl", hash = "sha256:1f732fdace31d2abdd14b3054f27a5e0f4591c7e1bef069b6aeb4f9c8d9ec487", size = 3408 },
+    { url = "https://files.pythonhosted.org/packages/8a/e6/c82e2eb2b4ad4407f1ada6d41ef583eb211cce88ffcc2e05c826760f721d/pyobjc_framework_BusinessChat-11.0-py3-none-any.whl", hash = "sha256:47a2e4da9b061daa89a6367cb0e6bb8cdea0627379dd6d5095a8fd20243d8613", size = 3477 },
 ]
 
 [[package]]
 name = "pyobjc-framework-calendarstore"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/ef/032c20f2cd77d1e860f757f47b14fad657735d094f8dcd5dbad96b136376/pyobjc_framework_calendarstore-10.3.2.tar.gz", hash = "sha256:0fbc2133045c18228efc11f8442979381f6060fc18f7e8e25b0395b2d6106c29", size = 63247 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/d3/722c1b16c7d9bdd5c408735c15193e8396f2d22ab6410b0af4569f39c46e/pyobjc_framework_calendarstore-11.0.tar.gz", hash = "sha256:40173f729df56b70ec14f9680962a248c3ce7b4babb46e8b0d760a13975ef174", size = 68475 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/94/8132b78f2556181f832353291407ed8bc8dcecf5b2a083f033f0fc66e379/pyobjc_framework_CalendarStore-10.3.2-py2.py3-none-any.whl", hash = "sha256:bf70bed667dea41ad20c707183804b375e979c185a73c6863810d59c62282ced", size = 4869 },
-    { url = "https://files.pythonhosted.org/packages/3e/bd/95771eb2e16db76e282a762505d0509b27920554a83b591020cf4654b8ec/pyobjc_framework_CalendarStore-10.3.2-py3-none-any.whl", hash = "sha256:80eb8909be1cf0972fdafb4a29bca1acb0bb86d5b1e343c795b94f4189799324", size = 4863 },
+    { url = "https://files.pythonhosted.org/packages/e3/e1/02bda98aae43957943adb09700265603f8ff8ff2197e57b082237a8e1a8f/pyobjc_framework_CalendarStore-11.0-py2.py3-none-any.whl", hash = "sha256:67ddc18c96bba42118fc92f1117b053c58c8888edb74193f0be67a10051cc9e2", size = 5183 },
+    { url = "https://files.pythonhosted.org/packages/a2/5b/922df21b738e8d349df27b2a73eaf8bba93c84c8c4d0d133fdd5de2ff236/pyobjc_framework_CalendarStore-11.0-py3-none-any.whl", hash = "sha256:9b310fe66ac12e0feb7c8e3166034bec357a45f7f8b8916e93eddc6f199d08c8", size = 5251 },
 ]
 
 [[package]]
 name = "pyobjc-framework-callkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/69/365d23487489b14a4a9c19de4447b9974bf71c321f487bb8e2cb465b7961/pyobjc_framework_callkit-10.3.2.tar.gz", hash = "sha256:8d67962c8e385d31ee66ad68e9c15760ba2cad709ce0305efa5f142247e5026a", size = 32282 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/0a/9d39ebac92006960b8059f664d8eb7b9cdb8763fe4e8102b2d24b853004f/pyobjc_framework_callkit-11.0.tar.gz", hash = "sha256:52e44a05d0357558e1479977ed2bcb325fabc8d337f641f0249178b5b491fc59", size = 39720 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/44/6dc2820dd4d249a82ce413886fbc03e24aa5989d62f4bee9e19bb503f0f7/pyobjc_framework_CallKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:b3b9952b9c813f0eb3e99ac400fb5c40aeda4abce216efbe4aacc7c14324c395", size = 4920 },
-    { url = "https://files.pythonhosted.org/packages/c2/19/7f5c2ba1bcbeeb1a8a5034029465c5d1f8c626cb18064d494d4094c038e7/pyobjc_framework_CallKit-10.3.2-py3-none-any.whl", hash = "sha256:97a6b9e0ee4f9c8b6f668834197d6eab5d24655b655a3357b26f2a0fd2762e4a", size = 4913 },
+    { url = "https://files.pythonhosted.org/packages/22/86/8d7dc24702ae810b6230d8b2cebb1c31e12abc31507095b1a9655715c921/pyobjc_framework_CallKit-11.0-py2.py3-none-any.whl", hash = "sha256:f19d94b61ecd981f4691fd244f536f947687b872ac793ccc2b3122b3854e887a", size = 5248 },
+    { url = "https://files.pythonhosted.org/packages/25/bd/ff89f7e5438c767fc43f603bee42a447315be48a09f64b9aa4da719ecdfc/pyobjc_framework_CallKit-11.0-py3-none-any.whl", hash = "sha256:95394b7f7a50916debe4f7a884ce9135d11733a14e07a8c502171e77bd0087a4", size = 5314 },
+]
+
+[[package]]
+name = "pyobjc-framework-carbon"
+version = "11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/15/51964f36a8ae1002b16d213d2e5ba11cc861bdd9369f1e3f116350d788c5/pyobjc_framework_carbon-11.0.tar.gz", hash = "sha256:476f690f0b34aa9e4cb3923e61481aefdcf33e38ec6087b530a94871eee2b914", size = 37538 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/fb/e5724934c3a2bbed4fbda4230e15a8b7b86313b39491876647300cb4fb11/pyobjc_framework_Carbon-11.0-py2.py3-none-any.whl", hash = "sha256:beef5095269d8e5427e09f9687963515c1b79fbf6927ff756a8414445892987d", size = 4700 },
+    { url = "https://files.pythonhosted.org/packages/1a/3d/b53c2d8949067f3f45491e250620e437569f1b4e6a028f2f5e721726283e/pyobjc_framework_Carbon-11.0-py3-none-any.whl", hash = "sha256:9a269042e8f5705897ac64d2b48515ba055462c88460cf140f5d8d4b8c806a42", size = 4768 },
 ]
 
 [[package]]
 name = "pyobjc-framework-cfnetwork"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/f7/628d3733d72268e2210b7c66196e53ed1516b814dad6660e179aa8023e6e/pyobjc_framework_cfnetwork-10.3.2.tar.gz", hash = "sha256:1fa3953b3b240a57bc4b3bf72043a3addadf2d9a473aeaf9fdb09df442fdd7e0", size = 67213 }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/36/7cebdfb621c7d46eeab3173256bc2e1cba1bbbbe6c0ac8aeb9a4fe2a4627/pyobjc_framework_cfnetwork-11.0.tar.gz", hash = "sha256:eb742fc6a42b248886ff09c3cf247d56e65236864bbea4264e70af8377948d96", size = 78532 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/5e/0c13b201320e0221dcd1e659ed213c153056046bfdc25e69f9359778d327/pyobjc_framework_CFNetwork-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:e7786c29cdd26260e45c29378d8790d218cdd3c9e788a86b135ef6024adff0f4", size = 18801 },
-    { url = "https://files.pythonhosted.org/packages/24/08/01550e13608ace7d13c652b74fed1abfe50ec549b56aee94597ac34d2edf/pyobjc_framework_CFNetwork-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:dace0bfd00073706fdb5222d73b49066be2abfaa73f12b59ebbd831906580fd5", size = 18880 },
-    { url = "https://files.pythonhosted.org/packages/51/08/5e84a8c3857ca41cec07fbdfd11cb6d69dd25492bd921f61079a271cf52a/pyobjc_framework_CFNetwork-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:24060afabd102e0f7162a0b5a1a5d54978eb1819dd733c167c61285ea04fe639", size = 13669 },
-    { url = "https://files.pythonhosted.org/packages/3f/0c/3da009e706ce2e1bf23cef1e8716cba6f7fe11029825a883c26eba1f44f9/pyobjc_framework_CFNetwork-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:2e09c3faca0c4f139d98ea28d185a275bf00d8549263fce07e9cf17d35e76139", size = 18858 },
+    { url = "https://files.pythonhosted.org/packages/d9/85/11047cfe2d31c242694d780783f0dea81d73cbb09929c7d4b918ce2d29bf/pyobjc_framework_CFNetwork-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e6905c86ccb5608f4153aacb931758ad39af8b708fcebb497431f9741f39e6d", size = 18988 },
+    { url = "https://files.pythonhosted.org/packages/3e/6e/7d90c329030e7dd6ebbec217434820ff6158a3af9906e2abbb43e9b685d6/pyobjc_framework_CFNetwork-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5f61010503073e3518e29d440079a7c0b40aef91be6d3c2032e492c21bada80b", size = 19144 },
 ]
 
 [[package]]
 name = "pyobjc-framework-cinematic"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -2360,31 +2353,29 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/e0/31644814a4f4d51c379c350de0db093b2e5ff7adf98f3b320f499b37916d/pyobjc_framework_cinematic-10.3.2.tar.gz", hash = "sha256:8a249b79905a13cc6234ca9167734bc30bbf9672a65630a69faae4415ed8a87b", size = 19667 }
+sdist = { url = "https://files.pythonhosted.org/packages/33/ef/b5857d567cd6e0366f61c381ebea52383b98d1ac03341f39e779a085812a/pyobjc_framework_cinematic-11.0.tar.gz", hash = "sha256:94a2de8bf3f38bd190311b6bf98d1e2cea7888840b3ce3aa92e464c0216a5cdb", size = 25740 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/1a/c815d806e2a37bf34b4a32c987972014b99312b58b66194d4c9a0f24ac1a/pyobjc_framework_Cinematic-10.3.2-py2.py3-none-any.whl", hash = "sha256:67ad6860b0f171d2f2cede0afdd2707858cb7cb53b750b002e380e26500cb620", size = 4199 },
-    { url = "https://files.pythonhosted.org/packages/b2/76/52e8f70d040feaf53f07bc8d1f9903a3f97379442ae6c7becc85746edda6/pyobjc_framework_Cinematic-10.3.2-py3-none-any.whl", hash = "sha256:8eb1dfbddb95676a20e94ac6844e935d25faa58dfa5926427386004d0300f3e8", size = 4197 },
+    { url = "https://files.pythonhosted.org/packages/55/cf/a60e131bddf5cced32a3c0050d264f2255d63c45be398cede1db03ea8b51/pyobjc_framework_Cinematic-11.0-py2.py3-none-any.whl", hash = "sha256:281721969978d726ded9bae38c4acd6713495c399025ff2b4179fc02ec68b336", size = 4508 },
+    { url = "https://files.pythonhosted.org/packages/09/a8/4ea347c1fc5774e2bbe7bb688fc625d583103d1e212f7b896ed19d14844b/pyobjc_framework_Cinematic-11.0-py3-none-any.whl", hash = "sha256:3a24f3528d7f77637f51fd1862cc8c79e4d0da4ba6fd3dd02b54adddec365826", size = 4580 },
 ]
 
 [[package]]
 name = "pyobjc-framework-classkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/e2/b3ace38d1aab8e576349a18dc618b7f397ed37a8d68c01b508b134fcdf6e/pyobjc_framework_classkit-10.3.2.tar.gz", hash = "sha256:afc44c16791e27331b73be3269c3c794f3502515ddd916c0b3bfe2fa060854e6", size = 32863 }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/81/126075eaf5ccf254ddb4cfd99d92a266c30803c5b4572ea3a920fd85e850/pyobjc_framework_classkit-11.0.tar.gz", hash = "sha256:dc5b3856612cafdc7071fbebc252b8908dbf2433e0e5ddb15a0bcd1ee282d27c", size = 39301 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/00/cb02df7c7281c35f4e555ffb2904670ded5268996a0b98bb53e27f7f7c3e/pyobjc_framework_ClassKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:1046a6cc5e78bc1688ea4f42d40d51fab99cf91885c8fa80d071387c9381f0b6", size = 8312 },
-    { url = "https://files.pythonhosted.org/packages/ff/90/ef557df6035c5d1442ce36a216dd3969b4a1bd056b0ba388d7a60cdfa18d/pyobjc_framework_ClassKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c8924fa4684496daee2a22f5045189ecd1afd603307340098fb57096c6ecb984", size = 8296 },
-    { url = "https://files.pythonhosted.org/packages/4d/4b/bba5e5cfdc79b6eb2b701287facf5d71e7bb52d3d01f8b10a5fbbfa635e4/pyobjc_framework_ClassKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bfb239e4d01a004aaa3020e18bc3f9d2994f793a9a4d1187e8c5d1dd707e2bbf", size = 6364 },
-    { url = "https://files.pythonhosted.org/packages/72/67/a4c009ebe122fd9f4cf6e777cc07fc28567ef21617dc864f4e4ae8c39ba4/pyobjc_framework_ClassKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:b5c56ca2b6f4e6cf7618fcf7538a7242a1dd1866e7b284c27b36442e40f5cac2", size = 8619 },
+    { url = "https://files.pythonhosted.org/packages/a8/77/2e31bcf1e9b63f6723c01329c1191ac163e79b0f548b7cd92414115c26ff/pyobjc_framework_ClassKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:723a07591e1e40380c339b58033e8491e58be4080c0f77a26be0728f1c5025c8", size = 8776 },
+    { url = "https://files.pythonhosted.org/packages/68/87/f566c4f1ffd1e383c7b38cd22753dfef0863f30bfdb0b3c5102293057fc2/pyobjc_framework_ClassKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7c7ff2eb8a9d87cb69618668e96c41ed9467fd4b4a8fef517c49923c0f6418e6", size = 8794 },
 ]
 
 [[package]]
 name = "pyobjc-framework-cloudkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -2393,931 +2384,893 @@ dependencies = [
     { name = "pyobjc-framework-coredata" },
     { name = "pyobjc-framework-corelocation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/70/daa2a428e1d8c39e55e3480c0bc9c8b39f882b544c88cad3a105e217f6ae/pyobjc_framework_cloudkit-10.3.2.tar.gz", hash = "sha256:ba05c8edb7f73ada94f9d2f8fbeae7302e53b56b2abb956012b84ba7faea141d", size = 99236 }
+sdist = { url = "https://files.pythonhosted.org/packages/89/6c/b0709fed7fc5a1e81de311b9273bb7ba3820a636f8ba880e90510bb6d460/pyobjc_framework_cloudkit-11.0.tar.gz", hash = "sha256:e3f6bf2c3358dd394174b1e69fcec6859951fcd15f6433c6fa3082e3b7e2656d", size = 123034 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/a1/d6a839b7889b076e39ec45a569072fd3c91cd0acae095ba5ccdd8c53beb2/pyobjc_framework_CloudKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:6c9a17f085876874bf98328f608384228d1d841d387d977adef9a277e549709b", size = 10477 },
-    { url = "https://files.pythonhosted.org/packages/88/42/b9d478ffdd77acf02750c191d5389d47e20d3d971d14691bf3b4ce5363f5/pyobjc_framework_CloudKit-10.3.2-py3-none-any.whl", hash = "sha256:fb4872f1cec3135610237c763ca8ddef7ac3607f0fc502b67c678419d64ffb5c", size = 10475 },
+    { url = "https://files.pythonhosted.org/packages/c2/db/9f914422be88eb2c917d67aebac9dde2e272ea1b510ca1e0db17a09db125/pyobjc_framework_CloudKit-11.0-py2.py3-none-any.whl", hash = "sha256:10cb153d7185dd260d21596f75fca8502236f6afd8e72e866cff8acd9c025f14", size = 10785 },
+    { url = "https://files.pythonhosted.org/packages/53/73/239581763a1bd56475ebd9bdde52a79cf0b6cac20b3d4442283b1ef8705c/pyobjc_framework_CloudKit-11.0-py3-none-any.whl", hash = "sha256:b2376d92d5822ce7e4feefcffdc3f4d1d230929f1735793da6d36b52b161b552", size = 10854 },
 ]
 
 [[package]]
 name = "pyobjc-framework-cocoa"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/41/4f09a5e9a6769b4dafb293ea597ed693cc0def0e07867ad0a42664f530b6/pyobjc_framework_cocoa-10.3.2.tar.gz", hash = "sha256:673968e5435845bef969bfe374f31a1a6dc660c98608d2b84d5cae6eafa5c39d", size = 4942530 }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/32/53809096ad5fc3e7a2c5ddea642590a5f2cb5b81d0ad6ea67fdb2263d9f9/pyobjc_framework_cocoa-11.0.tar.gz", hash = "sha256:00346a8cb81ad7b017b32ff7bf596000f9faa905807b1bd234644ebd47f692c5", size = 6173848 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/52/a41bf62d1467d74e61a729a1e36e064abb47f124a5e484643f021388873f/pyobjc_framework_Cocoa-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7caaf8b260e81b27b7b787332846f644b9423bfc1536f6ec24edbde59ab77a87", size = 381529 },
-    { url = "https://files.pythonhosted.org/packages/22/fc/496c6ce1386f93d22d9a1ee1889215ed69989d976efa27e46b37b95a4f2d/pyobjc_framework_Cocoa-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c49e99fc4b9e613fb308651b99d52a8a9ae9916c8ef27aa2f5d585b6678a59bf", size = 381866 },
+    { url = "https://files.pythonhosted.org/packages/23/97/81fd41ad90e9c241172110aa635a6239d56f50d75923aaedbbe351828580/pyobjc_framework_Cocoa-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3ea7be6e6dd801b297440de02d312ba3fa7fd3c322db747ae1cb237e975f5d33", size = 385534 },
+    { url = "https://files.pythonhosted.org/packages/5b/8d/0e2558447c26b3ba64f7c9776a5a6c9d2ae8abf9d34308b174ae0934402e/pyobjc_framework_Cocoa-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:280a577b83c68175a28b2b7138d1d2d3111f2b2b66c30e86f81a19c2b02eae71", size = 385811 },
 ]
 
 [[package]]
 name = "pyobjc-framework-collaboration"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/d8/5f17469cee1fe7c10c971cc425a57cc820dff14cbd2fb35d26e2a4f62d7e/pyobjc_framework_collaboration-10.3.2.tar.gz", hash = "sha256:0d4ee33154ea1d6ac7b9338b2bb1a9bcb5f5e9e3ffc390195643d60576606b74", size = 16157 }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/ee/1f6893eb882af5ecc6a6f4182b2ec85df777c4bc6b9a20a6b42c23abff3f/pyobjc_framework_collaboration-11.0.tar.gz", hash = "sha256:9f53929dd6d5b1a5511494432bf83807041c6f8b9ab6cf6ff184eee0b6f8226f", size = 17084 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/6e/c97f0f14050810549d1099b0c95c9c5bd1c00a5c0bfaefcf6a88923a72b5/pyobjc_framework_Collaboration-10.3.2-py2.py3-none-any.whl", hash = "sha256:4735cb4b8d701806a88cc295406308992d641ed88ae78053feb3ed3b79c91301", size = 4495 },
-    { url = "https://files.pythonhosted.org/packages/9f/b8/f050b55e2fd6379c1f05dedf0890d5a52dd4453d59ea9f83684f8bf1bb6b/pyobjc_framework_Collaboration-10.3.2-py3-none-any.whl", hash = "sha256:a96ae9f4f8320fe533e16d3c254f6f117b28ba0f4b0990aa350be23c388979f1", size = 4489 },
+    { url = "https://files.pythonhosted.org/packages/c1/ee/95883b6fbdbeecd99217c50c415ca024db5beb1923b935189a113412203d/pyobjc_framework_Collaboration-11.0-py2.py3-none-any.whl", hash = "sha256:acf11e584e21f6342e6d7be1675f36c92804082c29d2f373d1ca623a63959e76", size = 4807 },
+    { url = "https://files.pythonhosted.org/packages/c0/e5/d3ba7e3e3f306ba93c021c083287c668704d84605e0f788583abcfde815f/pyobjc_framework_Collaboration-11.0-py3-none-any.whl", hash = "sha256:e7789503ea9280ba365ce2c4e6c7c8b13dfa9174b2ecf9d174bbf9773f25f97a", size = 4876 },
 ]
 
 [[package]]
 name = "pyobjc-framework-colorsync"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/a2/3b6a7409e238ea577bb250bd5164be9c235ca1ba9629c21b8f29b70659d0/pyobjc_framework_colorsync-10.3.2.tar.gz", hash = "sha256:d4a8bcb7a3c13b6ac4ac25498e53b738104d49fadc97278f553268fb2ad7f487", size = 32297 }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/24/397a80cd2313cc9e1b73b9acb1de66b740bbece4fe87ed4ea158de8fcef8/pyobjc_framework_colorsync-11.0.tar.gz", hash = "sha256:4f531f6075d9cc4b9d426620a1b04d3aaeb56b5ff178d0a6b0e93d068a5db0d2", size = 39249 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/52/08db02e8cee7dbf8f4c22e3fba5008c6f1c5e851bd1961819d97a26129ce/pyobjc_framework_ColorSync-10.3.2-py2.py3-none-any.whl", hash = "sha256:ca2c0af7e22c02d32d8751d5a9cd8be11a51af51c526a3bdd536004401ba0f0c", size = 5603 },
-    { url = "https://files.pythonhosted.org/packages/0d/dc/e3958a7e4687275501c66d4ddf92f58dbab98c1cb409117b0711c8bb08da/pyobjc_framework_ColorSync-10.3.2-py3-none-any.whl", hash = "sha256:3b1ad179c6442464d8ec995fb824895617272fd30cfc519851019efe82bbe431", size = 5598 },
+    { url = "https://files.pythonhosted.org/packages/78/16/d806b5c3ff5bf8f46a4770f89b2076d2596c1301c851c60bb43aea457cd3/pyobjc_framework_ColorSync-11.0-py2.py3-none-any.whl", hash = "sha256:24f5c3e0987bfdfe6a0de36f2f908e30ea52000eb649db7b0373928140518163", size = 5916 },
+    { url = "https://files.pythonhosted.org/packages/06/18/777bad37aab42f75d2ef2efb9240308c15c33b3a0636278111ec6c5df550/pyobjc_framework_ColorSync-11.0-py3-none-any.whl", hash = "sha256:cbee2211f64be927eb4e4717bf6e275bf28954ed86e4a4655d367c30f856494d", size = 5987 },
 ]
 
 [[package]]
 name = "pyobjc-framework-contacts"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/94/14eb1abc06a88d1621eeb39784a9a1346f417c8584d37d767875c50bf54f/pyobjc_framework_contacts-10.3.2.tar.gz", hash = "sha256:f912a1bbd3cee3d8af740e02abc083828604265394871c2c166bc9c1de3130ce", size = 68818 }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/a2/89053853b28c1f2f2e69092d3e81b7c26073bc8396fc87772b3b1bfb9d57/pyobjc_framework_contacts-11.0.tar.gz", hash = "sha256:fc215baa9f66dbf9ffa1cb8170d102a3546cfd708b2b42de4e9d43645aec03d9", size = 84253 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/36/f20ab836c3d1ca92ad064258387dd96598a47f9328056b10373aed4a3232/pyobjc_framework_Contacts-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:8723c5e472b6fbe7cbdee5c999ffd32b4d93900cdb47f156d9304abe3f0068c1", size = 12037 },
-    { url = "https://files.pythonhosted.org/packages/81/3b/3217719eae52514bd040a2123774b2023b06765cada2ce10ae727f91c788/pyobjc_framework_Contacts-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:86b7bc80e0b82665eb6e74aecd8efcfe2bb8678bf34097133a6b1a34fb200e93", size = 11936 },
-    { url = "https://files.pythonhosted.org/packages/4d/7e/3e979ec7cfdbddaf33762b129d6c6ef772ec88b71fad2603cef723912969/pyobjc_framework_Contacts-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:528164fc9c9f15e5fc51a8c1d89bc211d93b3cf5ee659d492d7fb414f265f1e9", size = 9246 },
-    { url = "https://files.pythonhosted.org/packages/77/f3/776bba456e4f3703e94cd50849c8f432b6e3149879e76eec4a024fabd530/pyobjc_framework_Contacts-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:8eee545f6605dc44fe35dcb8018b530d05ccbb0fa6fda61a0df4e13666c9377d", size = 12499 },
+    { url = "https://files.pythonhosted.org/packages/91/4f/b7a7b08535015494940a62fd63825eccf4cace7f8ca87050f0837470eca8/pyobjc_framework_Contacts-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b16758fc1edc40f0ec288d67b7e39b59609fb1df2523f4362c958d150619dbe5", size = 11880 },
+    { url = "https://files.pythonhosted.org/packages/07/4b/0d2b41a32b6432182548cb84bb6b1c3228a7ff428ea15dfaf812b39c028f/pyobjc_framework_Contacts-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:80972851e2163b94d82fd4b0d9801790ad420dffa91a37c90fa2949031881c02", size = 11957 },
 ]
 
 [[package]]
 name = "pyobjc-framework-contactsui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-contacts" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/90/014388a37e3a1e2ec9a4d8e4336a6d5bb9e805c1087a3d3f38fc1b655be4/pyobjc_framework_contactsui-10.3.2.tar.gz", hash = "sha256:c004d225f17cbbb5c8b627275cf6a6f91a05aa956ab62d08e0fd3276fae80558", size = 18259 }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/67/122b16fd7f2da7f0f48c1d7fcaf0f1951253ddd5489d909a1b5fb80f3925/pyobjc_framework_contactsui-11.0.tar.gz", hash = "sha256:d0f2a4afea807fbe4db1518c4f81f0dc9aa1817fe7cb16115308fc00375a70db", size = 19486 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/80/504c86fefdce76b11c78c3fc0c579a3beaf699948cce1c61c9bbbd1a6fe9/pyobjc_framework_ContactsUI-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c138defc6399ff4fb94861a8b6a17d8b13d254ebb101570131a790eda2dec32d", size = 7839 },
-    { url = "https://files.pythonhosted.org/packages/d7/8c/fc0e5ede553010085124437df58f748fd3008f079cfd4e8e3fb4eaf520da/pyobjc_framework_ContactsUI-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3ab62d3ced5ef1c16d56b7730f388a579dda9baec26234e6efd7b0c8de0c21af", size = 7820 },
-    { url = "https://files.pythonhosted.org/packages/b8/d3/dea2aee9fda3647fb841e18a5cd89421f4f60ec0bfd929f0ab1098a05c15/pyobjc_framework_ContactsUI-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ae7ea14e086602f833c112b628a4e272e78e4d4b9893c0cbbbd42d1ca4d53069", size = 5594 },
-    { url = "https://files.pythonhosted.org/packages/9a/02/81ef6da547cc4d217f02ce7fb69b8a1e9d7759257866c5ed20c2090c56be/pyobjc_framework_ContactsUI-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:baf61007722c26727f33f423873af5dd79b7ebe01fa43f8d15732cea71ddffe9", size = 8193 },
+    { url = "https://files.pythonhosted.org/packages/fc/47/b1dbe48c64e2d061bf8b4ee532413b97e6c5748fdba43598a30421086fcc/pyobjc_framework_ContactsUI-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fd3efaf3f67e92704f41927c5de06ccc4aa9daa09865cba7ac476da9c6e1c3c2", size = 7734 },
+    { url = "https://files.pythonhosted.org/packages/5d/c5/465656c744301bfb7640e4077c57170d245843311e0e66702b53295e2534/pyobjc_framework_ContactsUI-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:da9c85dccdf518a0ac80c627daca32d56a4636e3f118359579de51a428e85ba7", size = 7739 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreaudio"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/54/0fcdab30ac31a594d699d909aa94c841fd94e173774f36e8c19e18536991/pyobjc_framework_coreaudio-10.3.2.tar.gz", hash = "sha256:c53e3247144b4f316cd588dd684a5f4edc6eebf9ca6beba488711b890bf0ff5f", size = 125996 }
+sdist = { url = "https://files.pythonhosted.org/packages/31/e6/3b7a8af3defec012d6cacf277fd8d5c3e254ceace63a05447dc1119f3a7e/pyobjc_framework_coreaudio-11.0.tar.gz", hash = "sha256:38b6b531381119be6998cf704d04c9ea475aaa33f6dd460e0584351475acd0ae", size = 140507 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/d9/e609309a3f128f4e0710e5992eea7d580bf1e7ff64482d32fe51b8c39e05/pyobjc_framework_CoreAudio-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0c60e2cc3c80462a7053ff5955ce68c15619326f1b14009b6f966d7b3ac6151f", size = 35091 },
-    { url = "https://files.pythonhosted.org/packages/aa/f5/b7d346f55c7c20590a303dcb33fb86a75e25ba2cffe3730225cdb76403e0/pyobjc_framework_CoreAudio-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:731afa9876be9de326dd5219ee5ce83ffbd303083d51b45f61e17c5d4ac25d3a", size = 35301 },
+    { url = "https://files.pythonhosted.org/packages/78/f8/6f583376d2ef6a6123141d310f7f7e3e93ba9129ffbbc6eb26e25c4289c5/pyobjc_framework_CoreAudio-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:143cd44d5c069aee1abc5a88794e9531250b9fe70a98f6a08e493184dcf64b3e", size = 35750 },
+    { url = "https://files.pythonhosted.org/packages/df/14/b33556c06529a3c54853c41c5163e30a3fb9b2ae920e0c65a42ccd82e279/pyobjc_framework_CoreAudio-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d26eac5bc325bf046fc0bfdaa3322ddc828690dab726275f1c4c118bb888cc00", size = 36584 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreaudiokit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-coreaudio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/52/e03a7a497102acb95018e653c4c03c7fdc6a01ee4bcaf403234d7b37c87d/pyobjc_framework_coreaudiokit-10.3.2.tar.gz", hash = "sha256:a41b0ab17d413bae5b6d673e6c97cfec0d80cb423f590cc4cd3970887ad22f49", size = 20079 }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/1a/604cac8d992b6e66adbb98edb1f65820116f5d74d8decd6d43898ae2929d/pyobjc_framework_coreaudiokit-11.0.tar.gz", hash = "sha256:1a4c3de4a02b0dfa7410c012c7f0939edd2e127d439fb934aeafc68450615f1d", size = 21450 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/9b/d8756cd1661abed7300896bd5592a2b803bb0a2887a7985e1392df85f402/pyobjc_framework_CoreAudioKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:7076e71f6430bd099296032aeeff6ced2c46a6581332bda242118442ab539883", size = 7295 },
-    { url = "https://files.pythonhosted.org/packages/6a/02/37e5ff092edda5365f3f8b22517f67e931e7ec2a7b3233070cd54916e457/pyobjc_framework_CoreAudioKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:76cd44b0b596cc380fa12433cc57f9a4f517293cf7a1bf84e76b3610f17012c4", size = 7276 },
-    { url = "https://files.pythonhosted.org/packages/b8/88/c483777d9a5150906ec596dae7be75de543be14fb92a0410b3c18ec22f8a/pyobjc_framework_CoreAudioKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:46693dbc7f88f488fe8d119f6d57ec8258bd46ac027e51d5e0b2f99e691806b9", size = 5381 },
-    { url = "https://files.pythonhosted.org/packages/78/79/79426dbd2de7d6fd786ae5860ecf673c7f102a850da6a1a84b28354de69f/pyobjc_framework_CoreAudioKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:1d9288f54fc332dda03de163dfd6af1eb8ba1065d33dc79f699db734a6b4e53e", size = 7415 },
+    { url = "https://files.pythonhosted.org/packages/4c/b9/d75a4da2d6a3cb75bafd363c447d45e134fe78a340dee408423a40c04aac/pyobjc_framework_CoreAudioKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6dbf01f2625689b392c2ba02f3ab8186c914d84d6bd896bdef5181a15a9463df", size = 7192 },
+    { url = "https://files.pythonhosted.org/packages/46/1f/5c15023665cc0476cdd7cbc054d5b06489fc09990f068768ed2fda8a02a2/pyobjc_framework_CoreAudioKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8ccf2d92052a446d1d38bfd7eaa1dcd2451d59c37e73070a9a1fee394a532d9d", size = 7214 },
 ]
 
 [[package]]
 name = "pyobjc-framework-corebluetooth"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/ca/35d205c3e153e7bc59a417560a45e27a2410439e6f78390f97c1a996c922/pyobjc_framework_corebluetooth-10.3.2.tar.gz", hash = "sha256:c0a077bc3a2466271efa382c1e024630bc43cc6f9ab8f3f97431ad08b1ad52bb", size = 50622 }
+sdist = { url = "https://files.pythonhosted.org/packages/93/74/66a62a36da9db5924ee15de6fe1eb544930609b307b3bfbc021b5cf43781/pyobjc_framework_corebluetooth-11.0.tar.gz", hash = "sha256:1dcb7c039c2efa7c72dc14cdda80e677240b49fa38999941a77ee02ca142998d", size = 59797 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/b0/9006d9d6cc5780fc190629ff42d8825fe7737dbe2077fbaae38813f0242e/pyobjc_framework_CoreBluetooth-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:973b78f47c7e2209a475e60bcc7d1b4a87be6645d39b4e8290ee82640e1cc364", size = 13891 },
-    { url = "https://files.pythonhosted.org/packages/02/dd/b415258a86495c23962005bab11604562828dd183a009d04a82bc1f3a816/pyobjc_framework_CoreBluetooth-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4bafdf1be15eae48a4878dbbf1bf19877ce28cbbba5baa0267a9564719ee736e", size = 13843 },
-    { url = "https://files.pythonhosted.org/packages/c4/7d/d8a340f3ca0862969a02c6fe053902388e45966040b41d7e023b9dcf97c8/pyobjc_framework_CoreBluetooth-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4d7dc7494de66c850bda7b173579df7481dc97046fa229d480fe9bf90b2b9651", size = 10082 },
-    { url = "https://files.pythonhosted.org/packages/e9/10/d9554ce442269a3c25d9bed9d8a5ffdc1fb5ab71b74bc52749a5f26a96c7/pyobjc_framework_CoreBluetooth-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:62e09e730f4d98384f1b6d44718812195602b3c82d5c78e09f60e8a934e7b266", size = 13815 },
+    { url = "https://files.pythonhosted.org/packages/53/a8/df866e8a84fd33d29af1ee383f13715bbd98ad67d5795dfb276a3887560f/pyobjc_framework_CoreBluetooth-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:044069d63447554ba2c65cb1bf58d489d14ea279344810386392e583a2e611ef", size = 13683 },
+    { url = "https://files.pythonhosted.org/packages/44/fa/ad2165bc93c9d3fb174a0d8d5a4db3a7dfcf4dcaeca7913d59748ef62fdb/pyobjc_framework_CoreBluetooth-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bae8f909512d014eed85f80deae671185af4bb5a671fba19f85c7b4c973b61bb", size = 13713 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coredata"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/dc/8b5d84afead6a72d42fd227af7de8dcd5aad3738179737e91cba8bdd529f/pyobjc_framework_coredata-10.3.2.tar.gz", hash = "sha256:e6da6cb3b5ec7bc1ff4fc71bf933e8a0d9ecd1d1c4028b7f2a2a24b1e2089078", size = 230246 }
+sdist = { url = "https://files.pythonhosted.org/packages/84/22/6787205b91cb6d526b6b472ebaa5baff275200774050a55b4b25d2bd957a/pyobjc_framework_coredata-11.0.tar.gz", hash = "sha256:b11acb51ff31cfb69a53f4e127996bf194bcac770e8fa67cb5ba3fb16a496058", size = 260029 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/b1/abe31281aab75a1dde452c07586b759cf2806651b3c53e2b4d64b8ea6b8c/pyobjc_framework_CoreData-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:bfe935839722c8889919afffd0adc3ae0b67b1b1dce2b4f1e657af8a83380fd0", size = 16551 },
-    { url = "https://files.pythonhosted.org/packages/4b/1b/059ee506d99db86d81fba37933a08f3a2171cfdb12e0a346be69a5968d36/pyobjc_framework_CoreData-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4cf569f99c427374cb83c4d38299c442a23cdc9e888c5fb632b117b87a73cf9a", size = 16526 },
-    { url = "https://files.pythonhosted.org/packages/f7/50/465a45ec1edaf60493567a9d42a032eb50f67928eba815aaa7785ed43120/pyobjc_framework_CoreData-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c4e5fa3339e36cc79852353562d7c8f77f2999b07d08e06a0d3352145998603e", size = 14087 },
-    { url = "https://files.pythonhosted.org/packages/2c/40/c8193919dda05e4a39f973c0413ba31ea208d348fced9692ee840ee54a6e/pyobjc_framework_CoreData-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:74dce9de732c5c653225fd3124fff7cf27c72b4271ff0c8fd6245a97061a5354", size = 17057 },
+    { url = "https://files.pythonhosted.org/packages/86/b0/32c23ee168e5081391daa8737fddde79670b083e948dffb8d74308f1dd43/pyobjc_framework_CoreData-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74ac5e7658df10544708f6017a8823a100fbe41dc3aa9f61bf2fd4f8773c3dd7", size = 16194 },
+    { url = "https://files.pythonhosted.org/packages/6a/9e/39ca8124c6d87dc6fa85bcf850a2c23a062a408a26300062041c10363a3f/pyobjc_framework_CoreData-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c23b8c9106b0ec6f43aca80d2b2e0b0cc8fcb4ba78db4ae3c1f39a67464357d7", size = 16208 },
 ]
 
 [[package]]
 name = "pyobjc-framework-corehaptics"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/47/9f1dc2645fe5d25560f6d16c12a91997f66038d798b7926fbd3598bef3af/pyobjc_framework_corehaptics-10.3.2.tar.gz", hash = "sha256:dcd595bfa0b02212377be6426457eef76dd0a343dc73416a81ba001adbb0d2aa", size = 37194 }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/b8/66481497362171e7ad42fc8fcc0272c04b95a707c5c1e7e8f8a8bfe58917/pyobjc_framework_corehaptics-11.0.tar.gz", hash = "sha256:1949b56ac0bd4219eb04c466cdd0f7f93d6826ed92ee61f01a4b5e98139ee039", size = 42956 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/ff/6de5c3683d07afe21cb6a651b0cb047a030d4fc4b736b21278bc9aa0bb31/pyobjc_framework_CoreHaptics-10.3.2-py2.py3-none-any.whl", hash = "sha256:7d09397cc514037b628b1d19716c9b750df8077410086e40071991ecc63cbda8", size = 4991 },
-    { url = "https://files.pythonhosted.org/packages/0d/10/5dcee4a9f90b52f2cbee2561054f471b698837771803fd7dd469aacd1c1c/pyobjc_framework_CoreHaptics-10.3.2-py3-none-any.whl", hash = "sha256:d360af7d72730e3c891f4034045a72837683ca82cb763e82e6b15dc5b47ee9fa", size = 4985 },
+    { url = "https://files.pythonhosted.org/packages/96/16/16d4365c8da1f708e145500237a3cdbbdde3e83b7f3f8673b038efac03b9/pyobjc_framework_CoreHaptics-11.0-py2.py3-none-any.whl", hash = "sha256:ff1d8f58dd3b29287dfad16a60bb45706c91f1910e400b632cb664eb2e56588b", size = 5307 },
+    { url = "https://files.pythonhosted.org/packages/12/72/b9fca92b3704af8f5f3b5507d0d9f3d0f5eb16605664de669f4468858627/pyobjc_framework_CoreHaptics-11.0-py3-none-any.whl", hash = "sha256:33f7a767efe6867fa6821ad73872ea88aec44650a22217bcdc9c1ec7c41fd9dc", size = 5377 },
 ]
 
 [[package]]
 name = "pyobjc-framework-corelocation"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/a6/14450410f233a8e8d3ed1e48702a0b405f402bd3efa77b8bd62c424ca0fc/pyobjc_framework_corelocation-10.3.2.tar.gz", hash = "sha256:3fc543ff9b5a347bece0668e9c4d73cc94bf47624a723fad0d568d360567583f", size = 89656 }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/2d/b21ca49a34db49390420a9d7d05fd9eb89850dbec0a555c9ee408f52609c/pyobjc_framework_corelocation-11.0.tar.gz", hash = "sha256:05055c3b567f7f8f796845da43fb755d84d630909b927a39f25cf706ef52687d", size = 103955 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/bf/f3ae97ea404e85cb0b5c4dfe58d35df35b0e20ed7b19b2eef5390a27a617/pyobjc_framework_CoreLocation-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:787837f678048e593ac21f0308156c237f1fcea07c4ce6d3a3a983074a87f14b", size = 12855 },
-    { url = "https://files.pythonhosted.org/packages/17/b1/3b5a40c95861e3ac5357276e434b78e85585f78e79a420922a67ddf2a16a/pyobjc_framework_CoreLocation-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:79d7306946e62a930d280be7496fce645d59190135a527b4df21cf9ad74b77a1", size = 12827 },
-    { url = "https://files.pythonhosted.org/packages/75/bd/a2c6400680103b28f9ef454d159116b08344c2214b20ec2caf610090cdce/pyobjc_framework_CoreLocation-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:eae5f2e857672f4c771aeb96aee7103a45c12f987adae230f23ef4ff23b40914", size = 9767 },
-    { url = "https://files.pythonhosted.org/packages/e8/1b/ba7436abd8eba1b016e5a4385bdbcc44c0b9a2760f9424ce54e80af9833e/pyobjc_framework_CoreLocation-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:3882873ec834531e1bbd641b56c591d8c15b016a4a959e3782459b51e4eddf79", size = 12794 },
+    { url = "https://files.pythonhosted.org/packages/10/99/c7844f6e583f4764c6fab4a5b5ad9e949c6fce8c30f95226118bead41e01/pyobjc_framework_CoreLocation-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:046f211a23de55364c8553cfd660dc5adeff28af4d25f5ed9b5a8bfa83266b4d", size = 13075 },
+    { url = "https://files.pythonhosted.org/packages/88/6b/bb4fbcd259404fb60fdbfecef3c426dc23da5a0f0bc5bf96a4169b047478/pyobjc_framework_CoreLocation-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9bca9974f143bc9e93bd7ec4ef91655964d8ad0ca5ffccc8404fb6f098fa08dc", size = 13076 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremedia"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/99/01b557daec18114166ae5fb602437477a60325e08dd9cfa5aac9d1c5174c/pyobjc_framework_coremedia-10.3.2.tar.gz", hash = "sha256:cf69753c12cd193df5ff25eb8f6da857c9aa93e73b8e497ddd77a3f48d1b171c", size = 181120 }
+sdist = { url = "https://files.pythonhosted.org/packages/02/60/7c7b9f13c94910882de6cc08f48a52cce9739e75cc3b3b6de5c857e6536a/pyobjc_framework_coremedia-11.0.tar.gz", hash = "sha256:a414db97ba30b43c9dd96213459d6efb169f9e92ce1ad7a75516a679b181ddfb", size = 249161 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/b2/3f1481b5ca972c0864b97083fd617c91e4b47c8182bfa899c10266c44d3f/pyobjc_framework_CoreMedia-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:62f4c0307a789bf13eaaac0674aadb9067535bbcb02c511a0cf2a3520bb3a839", size = 28760 },
-    { url = "https://files.pythonhosted.org/packages/9c/52/c112d26aac4f90e849caedd652a70d7eda8c9aaca3a57fd8382f4e784cb7/pyobjc_framework_CoreMedia-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b2af51e1169824bec72c1f814a633ca616e93e1489f35ecdd006a16403f70d97", size = 28560 },
+    { url = "https://files.pythonhosted.org/packages/a5/b3/7baca352ddd7256840a4eb8f38fda39bc2e023b222b86d11c1a77cc0a8fa/pyobjc_framework_CoreMedia-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:057e63e533577fe5d764a5a9d307f60e8d9c58803112951ace42183abe9437e3", size = 29422 },
+    { url = "https://files.pythonhosted.org/packages/68/73/7ed3eba9c5a4a2071c3a64d6b1388d13474ad8d972529f3d5c950942513d/pyobjc_framework_CoreMedia-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:afd8eb59f5ce0730ff15476ad3989aa84ffb8d8d02c9b8b2c9c1248b0541dbff", size = 29297 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremediaio"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/ec/f32539575a5a2cf24c2328f49317b07aff2aa993abbaf44777bcd8e271f1/pyobjc_framework_coremediaio-10.3.2.tar.gz", hash = "sha256:a648ff9ecb49c37353f912801f86d3985df74fd27e880d22c4eb3d7bc8a66db2", size = 88994 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/59/904af57d302caa4c20d3bfebb9fb9300ccc3c396134460821c9f1e8ab65b/pyobjc_framework_coremediaio-11.0.tar.gz", hash = "sha256:7d652cf1a2a75c78ea6e8dbc7fc8b782bfc0f07eafc84b700598172c82f373d8", size = 107856 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/f5/e205fd06ae5dc11444f4b3c674fa36b3102345a43c8f1436666cbb531115/pyobjc_framework_CoreMediaIO-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:5d5a8fa4d45e6704cf7281cca4d8d57db1cfd4b3ee6885acfd6ead630babb4f8", size = 17040 },
-    { url = "https://files.pythonhosted.org/packages/86/9a/73e1ff679818715e2a08026caadf193224f188de84abd288b8fcc8eb6681/pyobjc_framework_CoreMediaIO-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ff39bf38a1bae412f0ed4e0008e14ac8fa81555a715f8492012fbdb1a013c471", size = 16997 },
-    { url = "https://files.pythonhosted.org/packages/d5/53/97606817724ab66e0a4ab9624807aabe15d42b9b1967fb202f3a5089c289/pyobjc_framework_CoreMediaIO-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7a6fba175643e094bf38536cc4d058853b9109aa0527391454ee663ed3da7652", size = 13236 },
-    { url = "https://files.pythonhosted.org/packages/64/31/57aa82a7a098e61a37c1d12ffad7f27224670df11105eaa9822f169079c3/pyobjc_framework_CoreMediaIO-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:0b2c77f4f08daacdc4ca3e89cd97fb18840a039d5de3246f8b1685c568c9b667", size = 16970 },
+    { url = "https://files.pythonhosted.org/packages/27/02/09fda96c4727ff0c632c3cf4b09faa5b82be9f18422860dd80b5bc676ae1/pyobjc_framework_CoreMediaIO-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a4182b91c72923d5c4d52eca3c221cc6f149d80a96242c0caab1d5bc9ccbcbbb", size = 17492 },
+    { url = "https://files.pythonhosted.org/packages/3f/db/a7b11cbf7d31964a65c5593ac30a02b0db35260845431046d467b08fc059/pyobjc_framework_CoreMediaIO-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1ad1e0f74126b6c6d25017e4ba08f66fe5422c902060d64b69e06a0c10214355", size = 17534 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremidi"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/27/8b01da065b8fc166f91dcae96e38ed4c723743e714aba8e8c51f2f26330e/pyobjc_framework_coremidi-10.3.2.tar.gz", hash = "sha256:53f37f70abeaf67d90d03997517cb5085fcb29d41aa809f3c2b0809571f5258f", size = 78823 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/90/d004cdf4c52b8b16842e15135495de882d743b4f0217946bd8ae1a920173/pyobjc_framework_coremidi-11.0.tar.gz", hash = "sha256:acace4448b3e4802ab5dd75bbf875aae5e1f6c8cab2b2f1d58af20fc8b2a5a7f", size = 107342 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/26/441fd1cf939be8ff18471dcef3cabfc052c40d611f62362b631147b49610/pyobjc_framework_CoreMIDI-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:e9edf7fd3bbc1afb19dd939d4b057a118a0de8c10f688903167edb6d8a4dedc5", size = 17366 },
-    { url = "https://files.pythonhosted.org/packages/83/bc/fc4f22ea464e3d4e7fa3ec775059e443240a1adb72cb44a8332463e50a8b/pyobjc_framework_CoreMIDI-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b8bf65e16c8cefcfdf84ee0c77af274fcc17daf9f28a469db20c1ae317f7cd5a", size = 17360 },
-    { url = "https://files.pythonhosted.org/packages/e0/ce/1a6c02d15df8ef984c0ffe0816dbe0f9ab28cef77367643f93b25008abcd/pyobjc_framework_CoreMIDI-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c8aa31a28774e23ad471de1eb5a0aab4098ef899b9fbacc892de8dfddf1e2edd", size = 12564 },
-    { url = "https://files.pythonhosted.org/packages/d2/f6/ae2c59234be316041f5f8f67791f249ffa9e0929700840967a9b7db7779e/pyobjc_framework_CoreMIDI-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:048ed8188d62fbaae47426b4240a9187b7785e175cc4d489699a4b9290c67cb9", size = 17851 },
+    { url = "https://files.pythonhosted.org/packages/4d/b9/c67886891ad3cd21107cf1e65f1431cbdcff33acd74bf55ad3d6e10f3adf/pyobjc_framework_CoreMIDI-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:78dec1bcd253a0385ac0b758a455e2a9367fc3cb9e2306d410c61bafa8d4c2eb", size = 24314 },
+    { url = "https://files.pythonhosted.org/packages/c0/7a/0639bc1ac35373b68f0f15fbcb9bb4f317cc4452997ea8e611ce79f623e9/pyobjc_framework_CoreMIDI-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:97158830d76b999255d87191f31624d4373ee8ff662af4f4376c584cfb805573", size = 24346 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreml"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/7c/476d4459ce4d44d622365f721620f56fff7cebf50ade3560ae452244adaf/pyobjc_framework_coreml-10.3.2.tar.gz", hash = "sha256:f2e6eabe41fa34e964b707ba7a1269d5e049d5a7ac5574f35c4faa0647f385ba", size = 67101 }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/4f0a990ec0955fe9b88f1fa58303c8471c551996670216527b4ac559ed8f/pyobjc_framework_coreml-11.0.tar.gz", hash = "sha256:143a1f73a0ea0a0ea103f3175cb87a61bbcb98f70f85320ed4c61302b9156d58", size = 81452 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/17/ca68b24e0263d974a169f83cd597cc130e92741c0fbdca3c93e123ea2080/pyobjc_framework_CoreML-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:feea183b192cc806485b7713f135e544e7fa7ece3cea0e8cde92db4ae19374ab", size = 11553 },
-    { url = "https://files.pythonhosted.org/packages/66/4e/a939d232626b475f33727063bbcd5fda1f11a25e45c58ca52ff0005b8ece/pyobjc_framework_CoreML-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:15c89f9f37e46924357eb1c9859dfe4802a409263bb502b6a997046548097983", size = 11514 },
-    { url = "https://files.pythonhosted.org/packages/02/9d/4937bce9b3dff47a1bd822dbd2582aad6bf27ee6b7759d4120fa908327dc/pyobjc_framework_CoreML-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a975f2667d7e5ad81091db5a89a27c0e091f20ac4be8de309b3b20d177d83637", size = 9006 },
-    { url = "https://files.pythonhosted.org/packages/8b/38/37ab623af9825bc5fb106feea54f46ebb06ca9c4f0c9bc73bdac949ac88c/pyobjc_framework_CoreML-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:559967fa7dd82e75cf84ae53b176ea6da8d7705e589213aea9fe10ac0ce1d100", size = 11491 },
+    { url = "https://files.pythonhosted.org/packages/50/dc/334823bb3faa490259df7611772e804eb883c56436fc69123e8a3a5ba0ea/pyobjc_framework_CoreML-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e290ad9c0ac5f057ce3885d35e33fadc115f59111f2e04f168c45e2890cb86e8", size = 11320 },
+    { url = "https://files.pythonhosted.org/packages/90/9f/3d053b95fbeeaf480d33fcc067504e205049591f6bee17e3a700b988d96c/pyobjc_framework_CoreML-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:48320a57589634c206d659799284a5133aaa006cf4562f772697df5b479043e4", size = 11321 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremotion"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/f8/829dbf6ac3caad858cd68ba6a12f53ee3eeaef15c4107b34bcc0a1886f98/pyobjc_framework_coremotion-10.3.2.tar.gz", hash = "sha256:7bf2b3ae72e665035d57875a1c179fa4bef89021403ee44ddffacea04e9eb70d", size = 54848 }
+sdist = { url = "https://files.pythonhosted.org/packages/be/79/5c4ff39a48f0dc0f764d1330b2360e9f31e3a32414e8690e7f20e4574e93/pyobjc_framework_coremotion-11.0.tar.gz", hash = "sha256:d1e7ca418897e35365d07c6fd5b5d625a3c44261b6ce46dcf80787f634ad6fa5", size = 66508 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/09/1e60d54ec7cbd89896a67d6aa0d3a6faf31912d03d2b232e5ee95a631d2d/pyobjc_framework_CoreMotion-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1425400fcddf426ff9269368c0256a67d81e4be86c012f2ec12810737d369044", size = 9672 },
-    { url = "https://files.pythonhosted.org/packages/20/a2/f2fd58d8816ab0d955fab476e5abd1930ce25fcbb3806c7848621bbd678d/pyobjc_framework_CoreMotion-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bbe34b09dcd78f9f1e38e83252ab61329f5ee478c719c1f07d791693af39bc6b", size = 9694 },
+    { url = "https://files.pythonhosted.org/packages/01/35/da29fd7350cd68bfe70f30a9e03e1350d7363c7c4fcdb5b0cd16f4bb47e2/pyobjc_framework_CoreMotion-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8e32de44e30028500e4d17c114eea69e7e74e5ae7aef6c208edc5bac34dfc21e", size = 10229 },
+    { url = "https://files.pythonhosted.org/packages/ca/f6/8061b58f0f3e1daf34c19511f0eeefe4ad66d10d1994b84d7fa3733b7852/pyobjc_framework_CoreMotion-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:697a3121615e95e56808f388b0882217a50e5ff6b459eccae93f2809d5ea4389", size = 10250 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-fsevents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/d2/2f5c63ad1b4f7c7c45c4da45cbeb3b13328d21794f5cec2b2018e42c177f/pyobjc_framework_coreservices-10.3.2.tar.gz", hash = "sha256:ee3cf8379839efe4300bbd33dca204ebe873e2671160fff856569976d45c68a8", size = 860352 }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b5/19c096b9938d6e2fdb1b436f21ad989b77dbeb4e59b3db4bd344800fa1e8/pyobjc_framework_coreservices-11.0.tar.gz", hash = "sha256:ac96954f1945a1153bdfef685611665749eaa8016b5af6f34bd56a274952b03a", size = 1244406 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/e9/b36b9e111789b9bcf4ccc5ffa9fe87ba7a2e94a3da84d8cfc65753e4f379/pyobjc_framework_CoreServices-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:4512811b1c2737451b76969237ef5b8d7fd0e6b588652d50a1b6dc9fe3fa6226", size = 29714 },
-    { url = "https://files.pythonhosted.org/packages/85/87/6d96ee4520d27bc3776f7f8d4ab188a57b1031b3eb6269e1e8b7b1ef9938/pyobjc_framework_CoreServices-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b73da63630903cb0d64138a933e92130ff3ad36770dd9da7b23047a3f362cc9f", size = 29708 },
-    { url = "https://files.pythonhosted.org/packages/16/74/9b40d27fb07ba6cf8ce389421d59bc5974bcbd5b47c2ec94e6071730ca40/pyobjc_framework_CoreServices-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bbc1ac3fa0076c61221196346a715da32b0ff9c3f20cc5ebf59ba78688a40ad5", size = 28164 },
-    { url = "https://files.pythonhosted.org/packages/bd/a4/d28dff168700859df15e4dda7ac13f08185953e4c1d905bc20ba67b4b333/pyobjc_framework_CoreServices-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:40522a64a07276b8b577a71013f6c9272f35ebda3194d805d00f959c2ad26d83", size = 29762 },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/3899a59ed62fa36d2c1b95b94ff52e181ac48fde4011b68ca6abcbddd47a/pyobjc_framework_CoreServices-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f7538ca6e22f4da0c3a70ddd9781f9240a3fe2fd7a7aa4dfb31c31f2532f008e", size = 30258 },
+    { url = "https://files.pythonhosted.org/packages/82/7b/8e059764951d0414f053bfebb6b1fba803a3b14397755cfd388b0a6363a7/pyobjc_framework_CoreServices-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b175b5aa7a78484fd07b93533174b125901a6b791df2c51e05df1ea5d5badab", size = 30250 },
 ]
 
 [[package]]
 name = "pyobjc-framework-corespotlight"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/a5/d34b1be8a07cb0940792b964407a8744b4081204200349557a0dba5b93dc/pyobjc_framework_corespotlight-10.3.2.tar.gz", hash = "sha256:0ae1656bc3e8ece5278d690d1155b025271564fcdfe33f5b780a15f4a10c3e03", size = 69762 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6a/6707d7ef339b9ad2dd0994d1df42969ee3b231f2d098f3377d40aed60b4f/pyobjc_framework_corespotlight-11.0.tar.gz", hash = "sha256:a96c9b4ba473bc3ee19afa01a9af989458e6a56e9656c2cdea1850d2b13720e6", size = 86130 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/00/81f26161aa7021f684d2ba474e766585f6a5edfe417a9f9e75ada6eae69b/pyobjc_framework_CoreSpotlight-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:da9d240831d0945214b265ebde82ee066ae187034275096591e26c9e243fa81b", size = 9544 },
-    { url = "https://files.pythonhosted.org/packages/64/ea/30516e4924907790db75140e9635230f12345799735b0535d5552a5b53f1/pyobjc_framework_CoreSpotlight-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:0d5951b18ebccee0bc7a9498790378ecbc8a5bb8ec7f9b1584b0244fd4508f90", size = 9516 },
-    { url = "https://files.pythonhosted.org/packages/09/25/de9c5d3445d8e2a686ed2c4b0195f55f67971451de3ac3891c6cb4954a97/pyobjc_framework_CoreSpotlight-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cbd1897afd79f57afa5b4553c4a6cb7cb186e17f490ab07c5467af4950b5e3f0", size = 7218 },
-    { url = "https://files.pythonhosted.org/packages/bf/1b/aee27e034c965059824287c8c638d159e5782c1e57485717728ed94edf91/pyobjc_framework_CoreSpotlight-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:0ca8e5d0ca7e3ecf48698a2edd0b7bebe8dfda4eb34aab39813d37e97c67fb42", size = 10027 },
+    { url = "https://files.pythonhosted.org/packages/ba/f1/54f9522d7f6ec7a6618c86abe0236869f61dd371b49df02dff7930433656/pyobjc_framework_CoreSpotlight-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:551878bfb9cc815fe2532fdf455f500dda44f8cd203dd836a6f1eb5cc0d49a9a", size = 9579 },
+    { url = "https://files.pythonhosted.org/packages/6c/24/dae8d0be7cb90328a8c1100c454e52faef95acc59940796f530b665b9555/pyobjc_framework_CoreSpotlight-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b0c595d0a422a0f81008df93a0a2b38a1fd62434c6f61e31f1dceec927803b80", size = 9597 },
 ]
 
 [[package]]
 name = "pyobjc-framework-coretext"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/8e/bb442edfeeada13d2c96796bd36e3dcc0b91ac5c1a6774c21c12b7498770/pyobjc_framework_coretext-10.3.2.tar.gz", hash = "sha256:b1184146c628ba59c21c59eaa8e12256118daf8823deb7fb12013ecdfbc7f578", size = 233780 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/9b68dc788828e38143a3e834e66346713751cb83d7f0955016323005c1a2/pyobjc_framework_coretext-11.0.tar.gz", hash = "sha256:a68437153e627847e3898754dd3f13ae0cb852246b016a91f9c9cbccb9f91a43", size = 274222 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/33/66f7f410ae46bf0200bf8af8dbb68fe95a6ea9c2cc5f6696f8aef4837bc6/pyobjc_framework_CoreText-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c3b3cdf462442294319472bdacb013ce57f63f99325fa885b4b4a54a25bce201", size = 30084 },
-    { url = "https://files.pythonhosted.org/packages/50/b6/44e23a558a777e25f98bc54ecd2a7a0febcec67e1ebe9b4ba90c3ddd0701/pyobjc_framework_CoreText-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6be644434ac69969cbf3cd4638ab0dfa5485da399d0e79e52b006658346d3881", size = 30226 },
+    { url = "https://files.pythonhosted.org/packages/f6/20/b8a967101b585a2425ffe645135f8618edd51e1430aeb668373475a07d1f/pyobjc_framework_CoreText-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:56a4889858308b0d9f147d568b4d91c441cc0ffd332497cb4f709bb1990450c1", size = 30397 },
+    { url = "https://files.pythonhosted.org/packages/0d/14/d300b8bf18acd1d98d40820d2a9b5c5b6cf96325bdfc5020bc963218e001/pyobjc_framework_CoreText-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb90e7f370b3fd7cb2fb442e3dc63fedf0b4af6908db1c18df694d10dc94669d", size = 30456 },
 ]
 
 [[package]]
 name = "pyobjc-framework-corewlan"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/4d/132d46a120db80d9bc30ab24f7dae22f67a484eaaef47c0bb7f8ee9ed2ee/pyobjc_framework_corewlan-10.3.2.tar.gz", hash = "sha256:cb166e835e92332d34597c42d54886baf329363559c7bb017f15ce68a685508c", size = 58109 }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/a9/cda522b270adb75d62bae447b2131da62912b5eda058a07e3a433689116f/pyobjc_framework_corewlan-11.0.tar.gz", hash = "sha256:8803981d64e3eb4fa0ea56657a9b98e4004de5a84d56e32e5444815d8ed6fa6f", size = 65254 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/de/729fb392e0547f98f7c0fd60b2509a2a2722940c790a79d3e494c1733b4a/pyobjc_framework_CoreWLAN-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:5225a2db40dbc1ca701a9d8b30155c929c504005ad0abd296945f89ccd2c1d1f", size = 10014 },
-    { url = "https://files.pythonhosted.org/packages/15/65/5368ca4f45f6d9dbb35b5cf0cfb0368d8ade66643572bcf2fc2699d69fe9/pyobjc_framework_CoreWLAN-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4c7ba480405584d15ea2e9fad158e58e5bf7a37c8c38d875ff14949c842699d7", size = 9988 },
-    { url = "https://files.pythonhosted.org/packages/9f/e5/78c39ccff7bce3fd3ba226c62d8d25754fc85c6e9583dd1187bf3b6e9868/pyobjc_framework_CoreWLAN-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7d9b4ca65c7ee9f5954bc1fbc4c81b7724c5ac7620b962b413bfe6288fc862e9", size = 8090 },
-    { url = "https://files.pythonhosted.org/packages/82/a6/4192ca2244d9042b0730c814bf92fd00a6b77f6f69b6a01acf72cec3ad3b/pyobjc_framework_CoreWLAN-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:d81150eaea01dac71dea9be0e748ed7faf79ee6b8bd2ddd44692cf01f6953ba8", size = 10259 },
+    { url = "https://files.pythonhosted.org/packages/da/e7/a869bf3e8673c8fdf496706672dac77fc305493db3c1057e3ca5f8d49c3f/pyobjc_framework_CoreWLAN-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4384ba68d4beb4d610ca0d661593e16efe541faf1790222b898b3f4dd389c98a", size = 9895 },
+    { url = "https://files.pythonhosted.org/packages/7c/d7/87626e23f010aa865eef10c796d1d87ddd87b78656f4e4ef0e808c8268f7/pyobjc_framework_CoreWLAN-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5f5c365f6ebdae4a87d534cf8af877a57d2aabe50fe5949a9334e75173291898", size = 9917 },
 ]
 
 [[package]]
 name = "pyobjc-framework-cryptotokenkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/72/e771d7856e50da7650618fe46452b5fbd3b0bd7e2827356776d467aa2276/pyobjc_framework_cryptotokenkit-10.3.2.tar.gz", hash = "sha256:996a81a96af6928c5157f8a6f2d2bba8fe68c3948119f2d59918e00fc46f48d0", size = 48947 }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/72/b871fa5476479e4a22a4a0e971fb4724b0eb94c721365539ad55f4dc3135/pyobjc_framework_cryptotokenkit-11.0.tar.gz", hash = "sha256:a1bbfe9170c35cb427d39167af55aefea651c5c8a45c0de60226dae04b61a6b1", size = 58734 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/00/df5ed222234dacae6d809b0f26bc3494802c97deabd8b3ffeaa6ef392f8c/pyobjc_framework_CryptoTokenKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:31bb0480a87da217208b0e77a2461ac398d5f407a86507820e44b94c16f48d81", size = 13101 },
-    { url = "https://files.pythonhosted.org/packages/06/9f/843d972b14980691b619dfddcc574b4819385bba814da444203798d03098/pyobjc_framework_CryptoTokenKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:2053411961b5bb37c25fb431dc6618b304e3b2d62adb6296ac77fc538d3bd0da", size = 13084 },
-    { url = "https://files.pythonhosted.org/packages/81/f8/655cfd72998698eb7d0656aac9607e394fe947e7d01343a8ba4e4cf66d36/pyobjc_framework_CryptoTokenKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d6cd5f5843d86cc16ddbf90849798eaaf8e557d1d8703101f68204f85c52f917", size = 9510 },
-    { url = "https://files.pythonhosted.org/packages/b9/d0/8f27f40a735a6305ba26f33fa5c68a6a8aa52a0640070a1bce3b4dbee5c8/pyobjc_framework_CryptoTokenKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:487b0aa95f77c372ce32f60ceed4ab2a8c9ae316f72ce67e4b7b7f3bb083e8ed", size = 13043 },
+    { url = "https://files.pythonhosted.org/packages/ac/60/ddf022ce94f829a605992f11b9bfa861d7a1579f794e03d969c209d0de2a/pyobjc_framework_CryptoTokenKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3c42620047cc75a749fbed045d181dc76284bc27edea904b97df1ad82c2fdafc", size = 12949 },
+    { url = "https://files.pythonhosted.org/packages/d7/2d/9641cae1800281faace48698646f71c3de23ea1343031c12f6637d31e6f1/pyobjc_framework_CryptoTokenKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:95b05efb06b09987e23fb62dc3af378f38cfd0bd5872940cd95cf0f39dac6a57", size = 12978 },
 ]
 
 [[package]]
 name = "pyobjc-framework-datadetection"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1b/ce373fd11d2696f5dc25462d5e1f91afca6ee322d6576fb4a7131e077358/pyobjc_framework_datadetection-10.3.2.tar.gz", hash = "sha256:4e68c6f53042e2dd90a047d6a443227bf481aa9e3cf7aad1b2f164ff1b19dd0f", size = 13002 }
+sdist = { url = "https://files.pythonhosted.org/packages/33/6b/b896feb16e914dc81b6ed6cdbd0b6e6390eaafc80fff5297ec17eb0bd716/pyobjc_framework_datadetection-11.0.tar.gz", hash = "sha256:9967555151892f8400cffac86e8656f2cb8d7866963fdee255e0747fa1386533", size = 13738 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/d1/a5494de6c8d9751c333422f518e7fdd6b3f117d81e654d7072582bb401cb/pyobjc_framework_DataDetection-10.3.2-py2.py3-none-any.whl", hash = "sha256:f0fdf9d10fd45715f8e932d9dc508d6d63cd96a6e4b13ad92322dd21b79c882b", size = 3107 },
-    { url = "https://files.pythonhosted.org/packages/56/0a/64a0516ec0f46ffa50e81070e541f1ced074d8f70dae2323ddb8ace4b572/pyobjc_framework_DataDetection-10.3.2-py3-none-any.whl", hash = "sha256:3d528510722b62851b9d53fe16fe9cdc1646433a33b07a64b5fafc29397509ef", size = 3104 },
+    { url = "https://files.pythonhosted.org/packages/11/a1/63653827a78c8329a0106ac06e68ec0434e7f104f022dee5929bdf8fed62/pyobjc_framework_DataDetection-11.0-py2.py3-none-any.whl", hash = "sha256:0fd191ddee9bc6a491e05dfb7de780c0266fd6c90ca783e168786c4b0b5d7d7c", size = 3428 },
+    { url = "https://files.pythonhosted.org/packages/1b/61/ee4579efb7c02b794d26ab0458722598726678d0bb227c9aa925a34f36af/pyobjc_framework_DataDetection-11.0-py3-none-any.whl", hash = "sha256:21b4a1dbf6cb56fdc971224476453dd1a7a4bb72d2c670444e81ae96fde97cb2", size = 3501 },
 ]
 
 [[package]]
 name = "pyobjc-framework-devicecheck"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/b0/afcc4f467fc26674c01570ee5623a5b1ba904181ba71c710b646880c1fb9/pyobjc_framework_devicecheck-10.3.2.tar.gz", hash = "sha256:028fbec7a0efad0a5952063d9382017f0d860d31d768db2097e71754b93c9922", size = 13455 }
+sdist = { url = "https://files.pythonhosted.org/packages/de/f8/237a92dd9ba8a88b7027f78cba83e61b0011bfc2a49351ecaa177233f639/pyobjc_framework_devicecheck-11.0.tar.gz", hash = "sha256:66cff0323dc8eef1b76d60f9c9752684f11e534ebda60ecbf6858a9c73553f64", size = 14198 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/6a/8eaf7ac056d74490dfb010ef4f6dc43e776a7e33728baa4fa9e9b5a8b0fc/pyobjc_framework_DeviceCheck-10.3.2-py2.py3-none-any.whl", hash = "sha256:d496ee7045ee92977cdc16625cf7cb871f8f798bf8253fe4fdffbd3cd58da0f5", size = 3296 },
-    { url = "https://files.pythonhosted.org/packages/18/bf/566694aafa303c6772e4cd034830b18202437572355b1ac1385249f48ebe/pyobjc_framework_DeviceCheck-10.3.2-py3-none-any.whl", hash = "sha256:6bf642ce5c88b556dd743ad0f39db32ddd23c9ac9ff830805b8b3ca831a5a4de", size = 3294 },
+    { url = "https://files.pythonhosted.org/packages/5c/c1/d889e1c515c23b911594aa0b53a9d8ab6173e07adaaad8db89324a731fb7/pyobjc_framework_DeviceCheck-11.0-py2.py3-none-any.whl", hash = "sha256:d9252173a57dfba09ae37ccc3049f4b4990c1cbdcde338622b42c66296a8740e", size = 3612 },
+    { url = "https://files.pythonhosted.org/packages/65/8b/fa0cc2da2d49897f64e27a8a4e2a68f5784515f1adcea3a90f90b8ae8d44/pyobjc_framework_DeviceCheck-11.0-py3-none-any.whl", hash = "sha256:e8ed3965808963b2f0a7e069537d752bc659b75db1901cc24e5138925b9a7052", size = 3684 },
+]
+
+[[package]]
+name = "pyobjc-framework-devicediscoveryextension"
+version = "11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/48/178a1879109128f34334fdae2fe4463c7620f169593bea96704f347d945e/pyobjc_framework_devicediscoveryextension-11.0.tar.gz", hash = "sha256:576dac3f418cfc4f71020a45f06231d14e4b2a8e182ef0020dd9da3cf238d02f", size = 14511 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/be/3353a87691796a277ff4c048c4fa9a43db6f353fd683e8bb9e297651950c/pyobjc_framework_DeviceDiscoveryExtension-11.0-py2.py3-none-any.whl", hash = "sha256:82032e567d0031839d626947368d6d3d4ca97c915f15d2779a444cf4b2ffa4a3", size = 4194 },
+    { url = "https://files.pythonhosted.org/packages/06/87/52137a60498c03ab0acd3b9eadafe3c371c12e0549718e6a1f0fff8b7725/pyobjc_framework_DeviceDiscoveryExtension-11.0-py3-none-any.whl", hash = "sha256:9c94057173f13472089d561b780d93b5aa244d048b4760a0e1ab54fe7c2253c5", size = 4265 },
 ]
 
 [[package]]
 name = "pyobjc-framework-dictionaryservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-coreservices" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/4f/f4669fc0429415ea3f01b01ffb4a3ed41c91cae4fcdcc453874b7d2c16de/pyobjc_framework_dictionaryservices-10.3.2.tar.gz", hash = "sha256:d74effe983246e2d8ea53aba0ea47cdfe5d3687d110d13e235279c92cb9aeaf5", size = 10430 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/cf/2913c7df737eb8519acb7ef6429127e40d6c334415e38cfa18d6481150eb/pyobjc_framework_dictionaryservices-11.0.tar.gz", hash = "sha256:6b5f27c75424860f169e7c7e182fabffdba22854fedb8023de180e8770661dce", size = 10823 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/dd/7f167c845eb58ce4069872d047c86e56a3afed9112db4baa2e10b3de275b/pyobjc_framework_DictionaryServices-10.3.2-py2.py3-none-any.whl", hash = "sha256:cb04610493fd54dd6647766b9f569d09c79626faf4949e892708c725fb0431ef", size = 3506 },
-    { url = "https://files.pythonhosted.org/packages/3a/2e/2ae88bccd2a8e9fe804ae79d89c44de3b1d4d6191f8845eb42704783e7b4/pyobjc_framework_DictionaryServices-10.3.2-py3-none-any.whl", hash = "sha256:f5da9f55cb8c6bbf2eeeb9053cab9271f189ce28b1d09feb7b194197f1215d96", size = 3501 },
+    { url = "https://files.pythonhosted.org/packages/0a/68/5ea9766a8a6301f1a2ee39d595fe03d50b84b979d3d059e3e0ff541eab45/pyobjc_framework_DictionaryServices-11.0-py2.py3-none-any.whl", hash = "sha256:7c081371855240ac8e22783a71f32393c0f1e0b94d2fd193e8fef0a8be007080", size = 3829 },
+    { url = "https://files.pythonhosted.org/packages/dd/c4/62b73f813c012f72a3a8e2f6326506803b45e91dc4ce6683e02a52a7f414/pyobjc_framework_DictionaryServices-11.0-py3-none-any.whl", hash = "sha256:15cdc3b64cb73713ee928cdcc0a12c845729f117bb8e73c7511f6e3f256d9d39", size = 3901 },
 ]
 
 [[package]]
 name = "pyobjc-framework-discrecording"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/e8/546a077194be0e9f8b99dfd62923e7cf29eaaed97ec355533861c00d6813/pyobjc_framework_discrecording-10.3.2.tar.gz", hash = "sha256:996df211530867edbd82dac9b82209da8686f6814c7ee58411131f965f5fea79", size = 101951 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/cc/f36612b67ca1fff7659d7933b563dce61f8c84dad0bf79fab08bb34949ad/pyobjc_framework_discrecording-11.0.tar.gz", hash = "sha256:6bdc533f067d049ea5032f65af70b5cdab68673574ac32dacb46509a9411d256", size = 122426 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/65/d4c1089fe5cfa87806f07a107a268fcc36f141eff9a4dabaad3e14d34537/pyobjc_framework_DiscRecording-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:09481087c17289ed45c53ebde9955090eddcbd495f713412bd9d7fd7c9f04752", size = 14593 },
-    { url = "https://files.pythonhosted.org/packages/ea/84/2a2618121c8c90600b0eca123ecb4020209eae2fec3158422014db9545ce/pyobjc_framework_DiscRecording-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e08fac1518de20bf7617bc513f3a1113a29033d8f6cb95ef5ebfc81446d8f9b3", size = 14564 },
-    { url = "https://files.pythonhosted.org/packages/fe/30/96a7a219b40a6345db9fa287663cb934b5d600af3db65bbf902f23b6a885/pyobjc_framework_DiscRecording-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:497c92fea3fc861c0e8ba25910bc87a88829a016df9574871a148a1fb0ff8929", size = 12432 },
-    { url = "https://files.pythonhosted.org/packages/ae/7b/265556d1b053e9499844bf981e4e02187c8ac35c1408468d7d65a3f5e9fa/pyobjc_framework_DiscRecording-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:f20acc95c57549802f822ef56c21d66d277918b47c6c2796b8049b38094abf05", size = 14929 },
+    { url = "https://files.pythonhosted.org/packages/7e/0b/fbe460ccddb4c613eb04e2b81cc9c75b0e0c407fd9fb91776381416f99af/pyobjc_framework_DiscRecording-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eab79d83c2d974aa5564f3f6f4415218573dca69010026d2d000d232494a9d81", size = 14491 },
+    { url = "https://files.pythonhosted.org/packages/10/6f/c4c220d979771f4d7782deddef5ea9026baa177abe81cbe63d626a215de7/pyobjc_framework_DiscRecording-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e309e7394aed23d6ccce2e035f23c0c015d029c2ad531c6b1dce820b7eea8512", size = 14505 },
 ]
 
 [[package]]
 name = "pyobjc-framework-discrecordingui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-discrecording" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/cd/c44a59e6b6e893ef6117e3621f6d5faec326a98a6ebcaf70047a9f54a584/pyobjc_framework_discrecordingui-10.3.2.tar.gz", hash = "sha256:9cf1f1256c1c6dd4fc7debaff7e415949b43e86dd77be5ddc644822566cb3423", size = 18521 }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6b/3c120c59a939854dd4b7a162fad47011375c5ba00a12940f7217aea90eeb/pyobjc_framework_discrecordingui-11.0.tar.gz", hash = "sha256:bec8a252fd2022dce6c58b1f3366a7295efb0c7c77817f11f9efcce70527d7a2", size = 19614 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/de/9233551472133f4a29de4169d48cbfe1d95c458dc4a0a92fe3d879b8dee8/pyobjc_framework_DiscRecordingUI-10.3.2-py2.py3-none-any.whl", hash = "sha256:4622c47f89cd73e8a9c9ff324c50133a82a596d6f71f69c2fb99a9168b632f50", size = 4346 },
-    { url = "https://files.pythonhosted.org/packages/3d/05/cfe3577ad1fc27f3eab10117f62251159315b64dbe530a03eda4e8c6f7ca/pyobjc_framework_DiscRecordingUI-10.3.2-py3-none-any.whl", hash = "sha256:370b1a4ef613401047c479f3d5121dbc1ee12de93585cf1784672edc4239b927", size = 4342 },
+    { url = "https://files.pythonhosted.org/packages/de/45/4852afc5e093b76ba8f718d80fe1cc8604122a752806354379a7dbc41dc3/pyobjc_framework_DiscRecordingUI-11.0-py2.py3-none-any.whl", hash = "sha256:1af226c9350bb1d49960c02505e1e2f286e9377040dc2777a3f9a318925e081b", size = 4671 },
+    { url = "https://files.pythonhosted.org/packages/98/01/c5645513eeaadf0b9e387849fa656fc22524a1881f0d3a44d5b78784f836/pyobjc_framework_DiscRecordingUI-11.0-py3-none-any.whl", hash = "sha256:943df030f497a5ab73e969a04df8a653138fb67ebcf2380fedb4b4886d4ffba0", size = 4736 },
 ]
 
 [[package]]
 name = "pyobjc-framework-diskarbitration"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/c3/fbb59379378f679473375d7a3532986c7fc06f192ce0855d0a6e02de8dec/pyobjc_framework_diskarbitration-10.3.2.tar.gz", hash = "sha256:5e3a4a35b209bd9b983ae6248275784f913318d689b368f7ef584c87b7157336", size = 19001 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fb/5d3ff093144f499904b1e1bce18d010fe2171b9be62b4679d3dda8b3ad19/pyobjc_framework_diskarbitration-11.0.tar.gz", hash = "sha256:1c3e21398b366a1ce96cf68501a2e415f5ccad4b43a3e7cc901e09e896dfb545", size = 20096 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/75/f182ed20fd579f0b8c5414d7cdb0d6834c773ffd70b0d55a76a1b1ec09a8/pyobjc_framework_DiskArbitration-10.3.2-py2.py3-none-any.whl", hash = "sha256:b7524092e8aae06262243523ff9dc7480185d8cbe4d3dd3604bca02a1ad66b7b", size = 4437 },
-    { url = "https://files.pythonhosted.org/packages/36/f2/84a21000963c9c09fa0462700b758a8601e36ac127033e1bf4bca190121c/pyobjc_framework_DiskArbitration-10.3.2-py3-none-any.whl", hash = "sha256:4c1e901351ea8e264ab673ff181d4d67cd68b5bdff344353b385b05e084be243", size = 4433 },
+    { url = "https://files.pythonhosted.org/packages/d2/f4/f7ad86b2bb922b94745c369b90420cda984e6ad1ac9eb79ec32f5e332123/pyobjc_framework_DiskArbitration-11.0-py2.py3-none-any.whl", hash = "sha256:58823297eb09ff020ee156649170ab824fec32825bd32f2814c32e005920a72c", size = 4793 },
+    { url = "https://files.pythonhosted.org/packages/8e/87/bf0fc2aa781a819421e572cf6315fae7d0baf46607f9a67c86525c7e0e03/pyobjc_framework_DiskArbitration-11.0-py3-none-any.whl", hash = "sha256:7d41189a2d82045a7195c4661d8ec16195b6325a2f68f9d960e9a9f6649d1131", size = 4865 },
 ]
 
 [[package]]
 name = "pyobjc-framework-dvdplayback"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/63/52a3b4c53494cd1ad993b9ceba026cd2f226f45f6c634b429e22b43efaf9/pyobjc_framework_dvdplayback-10.3.2.tar.gz", hash = "sha256:1df1a41cd777559edc585bf097e3ed20a898e3a33f6b2627b6d321fc060ff97c", size = 53372 }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/89/89ebee4863fd6f173bff9373b5bda4ffa87eba6197337617ab086e23c7d5/pyobjc_framework_dvdplayback-11.0.tar.gz", hash = "sha256:9a005f441afbc34aea301857e166fd650d82762a75d024253e18d1102b21b2f8", size = 64798 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/7e/5bfa41e1daae50496682931b31c27f23c13215a3ac4119eaf4b70a3ead7b/pyobjc_framework_DVDPlayback-10.3.2-py2.py3-none-any.whl", hash = "sha256:d79086ae1919582ae7e721b088c4ec55864f045d1be45370d616020cdfbcb5da", size = 7836 },
-    { url = "https://files.pythonhosted.org/packages/75/88/b3386af4aebf48d214056a227482cafa6e81714c8d8d63cf1a3be4d2d84f/pyobjc_framework_DVDPlayback-10.3.2-py3-none-any.whl", hash = "sha256:625edd783022f5a1dbe91de6089906115870ddbbba5671fc075e339fabbc123d", size = 7833 },
+    { url = "https://files.pythonhosted.org/packages/6b/7f/6073ef2c5170abf55a15750cd069b0c3fdd03e48f3c86761a6a8ecaa0a38/pyobjc_framework_DVDPlayback-11.0-py2.py3-none-any.whl", hash = "sha256:2013289aa38166d81bcbf25d6600ead1996e50de2bc689e5cf36f36a45346424", size = 8171 },
+    { url = "https://files.pythonhosted.org/packages/db/e4/97ed8d41491f366908581efb8644376fd81ede07ec2cf204cdb3c300ed1e/pyobjc_framework_DVDPlayback-11.0-py3-none-any.whl", hash = "sha256:c6be6ae410d8dce7179d6ee8c9bc421468d4b9c19af3ff0e59c93ae71cfc33e0", size = 8245 },
 ]
 
 [[package]]
 name = "pyobjc-framework-eventkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/34/ae6a87901b93a020dc0b982b5704096fbcfba50840db4666d3a263cd86de/pyobjc_framework_eventkit-10.3.2.tar.gz", hash = "sha256:a31581cde80f03fc40ca8980d160570bcc747fec035311029fb4cddf9b35993a", size = 64364 }
+sdist = { url = "https://files.pythonhosted.org/packages/54/13/38a98e5cee62e1655d84cfb88cad54fdec4ec272b5fd0c5ac3fc21e33e49/pyobjc_framework_eventkit-11.0.tar.gz", hash = "sha256:3d412203a510b3d62a5eb0987406e0951b13ed39c3351c0ec874afd72496627c", size = 75399 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/18/aaa0d29a091be2e49ed8ef16e09fbbcbe5a1f01d1281fc58b6fc7dad6329/pyobjc_framework_EventKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:9dcadf1fc7f21d8bf9b81a9226849bd8a11fe0427c0ea39cd98ec5b60a85970c", size = 6412 },
-    { url = "https://files.pythonhosted.org/packages/5a/7b/3aa805146f23299092c4acf84cc9eacb7d2970347b9e33d5814dbdbc8c0f/pyobjc_framework_EventKit-10.3.2-py3-none-any.whl", hash = "sha256:f83f3ef7f2067cbc23039077a691fee7c284e38593b0fed0fe4785ed2b7b17b1", size = 6409 },
+    { url = "https://files.pythonhosted.org/packages/97/d5/e866c951237fb1b6423b85e1623a7f8cc417862261196e276ecc23141976/pyobjc_framework_EventKit-11.0-py2.py3-none-any.whl", hash = "sha256:934e31f4c82f887e1bf01f96d33de4c7c6727de3fdb55bc739e1c686c10cc151", size = 6717 },
+    { url = "https://files.pythonhosted.org/packages/dc/47/3c0cc7b8c95e6759804b426e78510f65b8e7409c425b85f1b0109d14cdcc/pyobjc_framework_EventKit-11.0-py3-none-any.whl", hash = "sha256:5467977c79649dac9e0183dc72511f7dd49aab0260b67c2cfa25079a5a303f11", size = 6789 },
 ]
 
 [[package]]
 name = "pyobjc-framework-exceptionhandling"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/9d/161094a7d8f39b943db22e11db8b7874b151550b0645668f7b6a33b6d8f2/pyobjc_framework_exceptionhandling-10.3.2.tar.gz", hash = "sha256:e49e05db37d15816699585ca9a0f5fccf37bec3f32cf3446f7595b7475678b90", size = 17521 }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/46/6c2c4805697a0cfb8413eb7bc6901298e7a1febd49bb1ea960274fc33af3/pyobjc_framework_exceptionhandling-11.0.tar.gz", hash = "sha256:b11562c6eeaef5d8d43e9d817cf50feceb02396e5eb6a7f61df2c0cec93d912b", size = 18157 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/46/60da28c48a458598263d0794f7af7b09aea73ea218d81b2fc99b1e2e0bff/pyobjc_framework_ExceptionHandling-10.3.2-py2.py3-none-any.whl", hash = "sha256:3d5cf8243c137bc69c5ae63db8a844d1d61335d82672f462b2fd4d511c80e18c", size = 6674 },
-    { url = "https://files.pythonhosted.org/packages/f6/75/56044ce3397e22b5b680fcd0a08e601dfd60cf909ae02fa91f789b9258f6/pyobjc_framework_ExceptionHandling-10.3.2-py3-none-any.whl", hash = "sha256:08d82814c3ce28d836de85fd0bf3c5b354b9b43df09d8c9b47d81f537e3ec8a9", size = 6669 },
+    { url = "https://files.pythonhosted.org/packages/e7/9d/c25b0bc0d300dd5aedd61f0cbd94a91ec6608b550821108d554e9eea0ed7/pyobjc_framework_ExceptionHandling-11.0-py2.py3-none-any.whl", hash = "sha256:972e0a376fee4d3d4c5161f82a8e5f6305392dbf19e98c4c6486d737759ebd89", size = 6993 },
+    { url = "https://files.pythonhosted.org/packages/cb/04/4b75e083325313e80e66f42d9a932c3febd2db48609d5d960a319b568f7c/pyobjc_framework_ExceptionHandling-11.0-py3-none-any.whl", hash = "sha256:d7f95fdb60a2636416066d3d12fad06cbf597e038576f8ed46fd3c742cc22252", size = 7063 },
 ]
 
 [[package]]
 name = "pyobjc-framework-executionpolicy"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/d8/bb30e70540f1f12b748f3c1c69539d750bcdb0493fbafb2ea5a37052c0fd/pyobjc_framework_executionpolicy-10.3.2.tar.gz", hash = "sha256:736b469e395fef859c1b506ab520e22cdd8937d71026901435fa7b2fcf08b8a4", size = 13158 }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/91/2e4cacbdabf01bc1207817edacc814b6bc486df12e857a8d86964d98fef4/pyobjc_framework_executionpolicy-11.0.tar.gz", hash = "sha256:de953a8acae98079015b19e75ec8154a311ac1a70fb6d885e17fab09464c98a9", size = 13753 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/c9/75b81b3b40175e830005eb47ac834c8ec796597b69ae30a046842f2b543d/pyobjc_framework_ExecutionPolicy-10.3.2-py2.py3-none-any.whl", hash = "sha256:509337de7c066c7fbf7f448391f73fb755baab132feee41858a948d59824e076", size = 3346 },
-    { url = "https://files.pythonhosted.org/packages/e4/0b/b1f1dbfd9a0c4d9f86f14bdf380917def1910dc547254324ed56b9265899/pyobjc_framework_ExecutionPolicy-10.3.2-py3-none-any.whl", hash = "sha256:8fa8ea42f61deb9be8c71fa54b0121ae25f23996e77d29e29764b76fdbce4b05", size = 3340 },
+    { url = "https://files.pythonhosted.org/packages/d5/03/a433c64c21c754ed796ae5ca0bad63fcb1d51134968ce0c53d4ee806ccd8/pyobjc_framework_ExecutionPolicy-11.0-py2.py3-none-any.whl", hash = "sha256:fdf78bf22fa6ea6f27b574f73856a8a22992d0c0d5a6ed64823e00000c06ffe7", size = 3668 },
+    { url = "https://files.pythonhosted.org/packages/0b/47/da969dd9d56403e23cc95e68c4816563f64ed6fde7ff4e3c3710e8e8efcf/pyobjc_framework_ExecutionPolicy-11.0-py3-none-any.whl", hash = "sha256:d2dba6f3f7803d1cd0a5608a7ad75085b73097b6c3a935b7f1326c7202249751", size = 3737 },
 ]
 
 [[package]]
 name = "pyobjc-framework-extensionkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/be/25e45cccd58fc61525d1f92684bed8d274a186706f2222144eb6b268c387/pyobjc_framework_extensionkit-10.3.2.tar.gz", hash = "sha256:626ba65aba8ce021c53eb52a3482d1fcb26d54e94d8ffb9b7376d444309e5bb3", size = 18034 }
+sdist = { url = "https://files.pythonhosted.org/packages/22/98/803e3cb000dac227eb0d223802a0aeb052d34a741e572d9584e7d83afca7/pyobjc_framework_extensionkit-11.0.tar.gz", hash = "sha256:82d9e79532e5a0ff0eadf1ccac236c5d3dca344e1090a0f3e88519faa24143c7", size = 19200 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/97/f603f26eea364f087b07360e490d66c26e1523b2914149c36a458923e1e0/pyobjc_framework_ExtensionKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:f5146745dce217fae8cd7d78488fe64fff0b615d35fe62f13ca3b39a2a433188", size = 7892 },
-    { url = "https://files.pythonhosted.org/packages/c0/16/97725ca9725a8094d67860c7cf63a20350491e38e0c718479fa88d53c11e/pyobjc_framework_ExtensionKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ed7144c2cb1a2038385174f40eaab143d2f8c4dcb858d538bf454b0668338106", size = 7866 },
-    { url = "https://files.pythonhosted.org/packages/a6/72/ffff99e8ece0e86ef632a29b52c26ef8ab0ea1747918558675905bd3ee05/pyobjc_framework_ExtensionKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:058cc769a3dc0abca97f3bc2da4138a4a94ac4a58b1cb598f4c41daf7a3d059d", size = 5641 },
-    { url = "https://files.pythonhosted.org/packages/36/85/ed3035f98962dbc39bfb7025c2c1733199984394306aef489f47b14635ca/pyobjc_framework_ExtensionKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:05896938ed222d658a8e21a9b0880876c54eb2e06e5103e0c9aeee0417abd89a", size = 8226 },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/ed580ce024d7e9a1ea88ee592d03b34f0b688414793bf8b7be5a367ecea8/pyobjc_framework_ExtensionKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:98957dd51f0a4e02aa3d9d3a184f37ca5f99f4cb9e11282a2fc793d18de02af8", size = 7781 },
+    { url = "https://files.pythonhosted.org/packages/fd/9e/a68989bf7bbba7b5fb1ade168d2179e37164439daaad63a27ccb790a6593/pyobjc_framework_ExtensionKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e341979ee4a7fc5978fe44d6d1d461c774411042cac4e119a32704d6c989de6f", size = 7783 },
 ]
 
 [[package]]
 name = "pyobjc-framework-externalaccessory"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/96/6c4dcab9a457bcbd38401e6d081867f46a07e0fcadfc6cbd05d9a9ffac97/pyobjc_framework_externalaccessory-10.3.2.tar.gz", hash = "sha256:abd334e5da791409378fed7e09b0f488a7e55eb5740d279f0c7f85984c74add4", size = 21090 }
+sdist = { url = "https://files.pythonhosted.org/packages/67/b0/ac0a02fe26e66c33fee751a65c1ed06bbd2934db8636e08bb491e8334bad/pyobjc_framework_externalaccessory-11.0.tar.gz", hash = "sha256:39e59331ced75cdcccf23bb5ffe0fa9d67e0c190c1da8887a0e4349b7e27584f", size = 22577 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/f0/e3af41a9df33c8a2e76ecb24b0df50fcddbabb15e0431a56e07927403f6e/pyobjc_framework_ExternalAccessory-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:045735ec21ecc1fb922aee7add867e7abb8f9412cd1fc62b48df8e553957f7f9", size = 8853 },
-    { url = "https://files.pythonhosted.org/packages/26/09/b81692b1b382ea2e97030f9843bb26cf9bf47cd65084c1dc65471a40e003/pyobjc_framework_ExternalAccessory-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:5bae8cc178eee73a4a03239f0d328a44f6f97665f815861e71afad5e63deb04c", size = 8817 },
-    { url = "https://files.pythonhosted.org/packages/bb/71/269296e1656d5c5bac038cc5d90bf186a28ba96efb5c728a847bb97e7d1e/pyobjc_framework_ExternalAccessory-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7fccd659b8962fd7bd9d419dad75e13ef3c45a9e9fa7fb17c2088901731d0641", size = 6427 },
-    { url = "https://files.pythonhosted.org/packages/08/cf/b262dd1c8a464f5a5a1759217ce49a7516121eb6943654159b8c16bb74fc/pyobjc_framework_ExternalAccessory-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:9cb0e33d4ef5389991dd19466ea1ef56576b8dffb8af74a5317702f19e6d6106", size = 9246 },
+    { url = "https://files.pythonhosted.org/packages/a3/96/bddfe9f72a59a3038ec3208a7d2a62332d5e171d7e3c338ccff6bd6e76b8/pyobjc_framework_ExternalAccessory-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:319f66edb96505f833fe7fe9ba810cb3b0d0c65605b8674bea52f040e8caebd6", size = 8785 },
+    { url = "https://files.pythonhosted.org/packages/e7/e2/26e9cbb18723200ef71580e46c46f037b7feecc07cf50051cd6fcb426472/pyobjc_framework_ExternalAccessory-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:aaae920c9241d1b35a58ba76dba761689b248250d782179526f6dea151b1fda0", size = 8808 },
 ]
 
 [[package]]
 name = "pyobjc-framework-fileprovider"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/14/b7ccfbce5457b5d86d61b0dcf0fb6a56c5421ddc0a6e17b4b16d0402d621/pyobjc_framework_fileprovider-10.3.2.tar.gz", hash = "sha256:b671131fa42d4e58f661362ef32e996de2f9a09a1ca20218983d7334efc39242", size = 63933 }
+sdist = { url = "https://files.pythonhosted.org/packages/44/fc/b8593d8645b9933e60a885f451d0c12d9c0e1b00e62121d8660d95852dff/pyobjc_framework_fileprovider-11.0.tar.gz", hash = "sha256:dcc3ac3c90117c1b8027ea5f26dad6fe5045f688ce3e60d07ece12ec56e17ab3", size = 78701 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/0b/a81ecfac3d6fe75865594071f96b394849b7bc10c726d10ea9b3cd2a4dbd/pyobjc_framework_FileProvider-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:765d03584ccb85fae5c5df6e87cb2485a35d178c330f5021958b4b0165c044d0", size = 17714 },
-    { url = "https://files.pythonhosted.org/packages/df/81/93c7971de7f325e57a3a0884207debfef01bd717385811ff576a5fe7d86c/pyobjc_framework_FileProvider-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b20703765fbf72351de76a9f4727b28293d70893cc0324b9e1c98de881075854", size = 17690 },
+    { url = "https://files.pythonhosted.org/packages/4a/57/1f959ec54650d1afc08e89d2995a1534f44229b1371cf66429a45b27c32d/pyobjc_framework_FileProvider-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8c7e803a37f7327c191a4de7dbb36e5fbf8bd08dadbcc7f626e491451c7a3849", size = 19179 },
+    { url = "https://files.pythonhosted.org/packages/30/79/ff4dfe06eb43c97bd723f066ef2b92b00b1020206b4dcc5abe9b49746cad/pyobjc_framework_FileProvider-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d7acdc5e0f4b5488bcbf47d3eea469b22897a4b783fe3f5d4b2b1f3288e82038", size = 19154 },
 ]
 
 [[package]]
 name = "pyobjc-framework-fileproviderui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-fileprovider" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/30/e2b049d329cce54157faa5a5f6f4b3ae3cffe39cd600e3df254320ad2611/pyobjc_framework_fileproviderui-10.3.2.tar.gz", hash = "sha256:0a62ebbf3ae3b9f73f4a36c511f3c143d2cdb657030366c04e7bec1ad27066ce", size = 12868 }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/9d/ca4aed36e6188623e9da633634af772f239bee74934322e1c19ae7b79a53/pyobjc_framework_fileproviderui-11.0.tar.gz", hash = "sha256:cf5c7d32b29d344b65217397eea7b1a2913ce52ce923c9e04135a7a298848d04", size = 13419 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/be/a7d992c7d3a8ab638c807fdcc6bca719796f0a1c2c6d1f31c06c4e07eeb9/pyobjc_framework_FileProviderUI-10.3.2-py2.py3-none-any.whl", hash = "sha256:c97456b4bccd0a9d2de5539dad0cf99013d64e77ee9bdea6eec17b803c6515ae", size = 3322 },
-    { url = "https://files.pythonhosted.org/packages/80/fd/b8a5fe26a04704ff099c7fc8b54defe7e78272467361dceb05166d2e9ed5/pyobjc_framework_FileProviderUI-10.3.2-py3-none-any.whl", hash = "sha256:27553165ac3f8ee4a348602f691fdeb27f2322d2792dd3bd51a988243077d877", size = 3317 },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/8a91cfa9485a2e9ad295da8bb5505d0dc1046dec8557d2ae17eef75f3912/pyobjc_framework_FileProviderUI-11.0-py2.py3-none-any.whl", hash = "sha256:5102651febb5a6140f99b116b73d0fd6c9822372a5203506e4904ac0ebb1313c", size = 3642 },
+    { url = "https://files.pythonhosted.org/packages/75/9b/a542159b1aefedb24f01440a929b7bbc6f4bbae3a74d09ad05a7f4adb9c0/pyobjc_framework_FileProviderUI-11.0-py3-none-any.whl", hash = "sha256:b75f70eef2af3696f3cb2e0de88bbb437343b53070078573ae72d64bf56fce9d", size = 3712 },
 ]
 
 [[package]]
 name = "pyobjc-framework-findersync"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/27/d505d5a508bacb971eb4ec4196372f9a9f286ce319bff1d24296feeadd58/pyobjc_framework_findersync-10.3.2.tar.gz", hash = "sha256:a5ab6ac34ea2c9184111b33b5248009f8a86a994c6d813e2bfd00cc20863046e", size = 14563 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/e3/24df6e24b589073815be13f2943b93feb12afbf558f6e54c4033b57c29ee/pyobjc_framework_findersync-11.0.tar.gz", hash = "sha256:8dab3feff5debd6bc3746a21ded991716723d98713d1ba37cec1c5e2ad78ee63", size = 15295 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/e7/1599de82a5da5257eefda6c5174985686c6d8e9472a6287e07666a3e2aba/pyobjc_framework_FinderSync-10.3.2-py2.py3-none-any.whl", hash = "sha256:6217be137f38e225ce10d6b12eced87ffaee0e63e70d80dffd86cdf78932232a", size = 4482 },
-    { url = "https://files.pythonhosted.org/packages/21/0a/3283b6028259954a8b5313e71d89ec4ceb54cca1f2eb9e7c7bfe1fe71388/pyobjc_framework_FinderSync-10.3.2-py3-none-any.whl", hash = "sha256:74061ba4fd76a84530ad5150a7bd141a198fc67cbde77a09e011af0415cc6d83", size = 4476 },
+    { url = "https://files.pythonhosted.org/packages/96/f1/42797ae9065e0127df4b5bb7a45e06eff8568a476edbc8d590cea9d25228/pyobjc_framework_FinderSync-11.0-py2.py3-none-any.whl", hash = "sha256:cafb262d1ad1e3a86af333f673aeda4f9bdcf528ded97c2232fd1cf440d1db5a", size = 4788 },
+    { url = "https://files.pythonhosted.org/packages/d8/96/2ed2ca5536f76102ea3bfb886cdc7b34ec51f53b122b9c535b4ac9b1ee03/pyobjc_framework_FinderSync-11.0-py3-none-any.whl", hash = "sha256:d00285b85038c5546e8566bec9cd3a4615708f0e6cb774d0ea804c69546ec915", size = 4860 },
 ]
 
 [[package]]
 name = "pyobjc-framework-fsevents"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/70/a37b1b8397bb3e23a8c15c78209f998d0294311a70b81104a5f22cbe9b26/pyobjc_framework_fsevents-10.3.2.tar.gz", hash = "sha256:fb215032d65aa39eb5af1b6481f605e71afa77f881b37ba804af77bf24d2fde3", size = 27720 }
+sdist = { url = "https://files.pythonhosted.org/packages/82/37/4c09cc7b8678e2bb5b68ebc62e817eb88c409b1c41bdc1510d7d24a0372d/pyobjc_framework_fsevents-11.0.tar.gz", hash = "sha256:e01dab04704a518e4c3e1f7d8722819a4f228d5082978e11618aa7abba3883fe", size = 29078 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/99/628dc96c74256d5663aef13a133ab4ac8c01cf6fac306ad7721bf63e8d16/pyobjc_framework_FSEvents-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:a26f3f4f390584a55de16a2441fd7444de60ad677549c05a7c83c25498712564", size = 12944 },
-    { url = "https://files.pythonhosted.org/packages/25/63/f6cc9bcd34428084384f2ef8df96622128684a2f4015a5c73ecfda5a68c9/pyobjc_framework_FSEvents-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a13389f7ac8dfe177c045c069dc224129f6f9b6871aa7892a4a1bc164fba99c1", size = 12938 },
-    { url = "https://files.pythonhosted.org/packages/9c/2c/1b705962aba38e701c3c8af1a870ebe09b796808203a396e630d0a696bf9/pyobjc_framework_FSEvents-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aa2ea7bed475e69b3b1ec745e65bbaa4afd480cdef80600591f97a0bd1bece06", size = 8773 },
-    { url = "https://files.pythonhosted.org/packages/88/f0/a0ce3245a2e5505bacfbc079e45d9068485b7a9ac8a6fdd8f13ed633dce0/pyobjc_framework_FSEvents-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:5cbb808069ca184b7d75cc5cee2e18b1152d89b47f60a6be3aeaa918e03144f0", size = 12915 },
+    { url = "https://files.pythonhosted.org/packages/1f/8a/75fd630865c9f9d69b1364208582872fc818b4c1a70fd9ae85a5cf7a2c5a/pyobjc_framework_FSEvents-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e0b3c7835251a35453e3079cf929b9e5329d02e2f4eaac2ebabbe19e1abd18ab", size = 13209 },
+    { url = "https://files.pythonhosted.org/packages/19/c6/cae1a6a96ad493339e9f0f175bcf18c1526abe422b63309d873acd663dc2/pyobjc_framework_FSEvents-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb8a5a7f7b5a70e15dae80672f10ecc16b5d1c1afe62ad2ccadb17a8098876cd", size = 13274 },
 ]
 
 [[package]]
 name = "pyobjc-framework-gamecenter"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/e2/aa9d68a95afae2740b2b5af02bf4cdde11788c6e294cc2fdbcaed86723bb/pyobjc_framework_gamecenter-10.3.2.tar.gz", hash = "sha256:f641026c98c11e0c6d81cea0abdf1b113499e61327da63dc783c94f7ec4c460a", size = 30461 }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/3b/e66caebc948d9fe3b2671659caab220aff6d5e80ac25442d83331b523d23/pyobjc_framework_gamecenter-11.0.tar.gz", hash = "sha256:18a05500dbcf2cca4a0f05839ec010c76ee08ab65b65020c9538a31feb274483", size = 31459 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/4c/85429e3ad1e69f440b90454186ad1051199f42852bcea145931f4b6c09e7/pyobjc_framework_GameCenter-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:30bb9ec68e800fe65f9515e3b6b1e4a276e96ca5839aeed63833a87b488cf3fb", size = 18630 },
-    { url = "https://files.pythonhosted.org/packages/5d/d4/e7f2cd9561cabf0824c3c2311ca39e18da4599b654581a8b52c084145358/pyobjc_framework_GameCenter-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9bcc5822e39b589329f4f9be7992d0a9a5c01296f50602005ec60ad602704c07", size = 18618 },
-    { url = "https://files.pythonhosted.org/packages/8a/44/db3a72bf187cf492047c88efeb720effa1421278e3c62a77d46346230232/pyobjc_framework_GameCenter-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:32c945732db707946fd7f6e2cfef131c707bf541c7980090963ede4fb0ed732a", size = 12386 },
-    { url = "https://files.pythonhosted.org/packages/41/08/1dcf28bd3bab56237b13d250c07bc9e6addefb9140446f836952d5dab0ac/pyobjc_framework_GameCenter-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:b2b9e4ebf571c49e7f945404d3b269fbee307dba62f13155a828ae8ed5e0fa37", size = 18666 },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/8a41ab9880e415143baf771d55566e2a863ec538837480a5ee17e1ddc08b/pyobjc_framework_GameCenter-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f8bff2a36cf3cb52cbe321203147766e95997f881062143171cdd8ef2fde9e53", size = 18472 },
+    { url = "https://files.pythonhosted.org/packages/c4/78/846aa21be2303cba955aaf781a362504a722183b8f6a030ba02f2b2073ad/pyobjc_framework_GameCenter-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8de57380e3b51579a6e8bc397c2bb5be5d0f6dcd4bf5abed587700cf7f57afd4", size = 18437 },
 ]
 
 [[package]]
 name = "pyobjc-framework-gamecontroller"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/e8/909649206c4781bebe19f20d76287c473418b39ff501c161586ad37e16d2/pyobjc_framework_gamecontroller-10.3.2.tar.gz", hash = "sha256:57225d1a760315bc3f11828780076dc1b12a470b52bde2b7a20f45d6556e5e4a", size = 94410 }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/30/02ca5a4fb911acf3e8018abcbd29631a842aeac02958ae91fab1acb13ad1/pyobjc_framework_gamecontroller-11.0.tar.gz", hash = "sha256:6d62f4493d634eba03a43a14c4d1e4511e1e3a2ca2e9cbefa6ae9278a272c1d0", size = 115318 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/4d/764bded9655619f761c28785cadf503820b7a403c1244dc110353257a3ab/pyobjc_framework_GameController-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:33ace4bf412413713db81c366ab27f98cda99cbfac3c83aa83eef55eba6fdf8c", size = 19907 },
-    { url = "https://files.pythonhosted.org/packages/7d/8e/61bdced3b5fe4bc3416e7bccd2a6d2a9cd941879b2a6f3a9c85493754c33/pyobjc_framework_GameController-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3deda3a4c7228c02bc2d875c5ae3c820231212771a552798813a1016d92645c9", size = 19935 },
-    { url = "https://files.pythonhosted.org/packages/74/26/303f7c466c6ab5b1b1ebaae8cc5b8223a4116386e5fdb217ac38c30cdb53/pyobjc_framework_GameController-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b75dcca0145a6c3cb88f04f574c30dffee1cb4392ce1bfdfd37726ee91e49afa", size = 13814 },
-    { url = "https://files.pythonhosted.org/packages/ac/ba/cfe3174d61a9729116244ea2e8c190eb88e9aae8a7a04476fae78c2424b5/pyobjc_framework_GameController-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:5e372336e1f0aea1c34b7e745f9d263dd578348d23086076fb8d7e9f7d83d469", size = 19967 },
+    { url = "https://files.pythonhosted.org/packages/98/ec/05f356ab2d747a385c2a68908f2f67ee1b1e7a169b1497b0771b2226a174/pyobjc_framework_GameController-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:30e8f251be49ff67491df758c73149e7c7e87bee89919966ed1b2bf56fdaacf7", size = 20995 },
+    { url = "https://files.pythonhosted.org/packages/66/b3/38319c9232e3508297bfedde700b125676845b1e27afe2bb681e8829f34a/pyobjc_framework_GameController-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:46403f23aaaf6a2e1a51e3954c53d6e910b80058117fdcf3a0a8100f25e30f07", size = 20919 },
 ]
 
 [[package]]
 name = "pyobjc-framework-gamekit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/ca/a3229141293e5128e5968428d34c5d2071e7eaf111b1d648dddb1b6d10e8/pyobjc_framework_gamekit-10.3.2.tar.gz", hash = "sha256:a1df3c59cdae5693a29d81057853b053871196197b56bce05d98dc84b233e0e4", size = 137941 }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/df/c161460e5736a34f9b59aa0a3f2d6ad1d1cd9a913aa63c89c41a6ba3b6ae/pyobjc_framework_gamekit-11.0.tar.gz", hash = "sha256:29b5464ca78f0de62e6b6d56e80bbeccb96dc13820b6d5b4e835ab1cc127e5b9", size = 164394 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/df/143d5a6f6bca2c125e1d79896a71b883afed08849c80bf6f2999c5ba1adb/pyobjc_framework_GameKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:557cea3328545f5d2a23535f0919d5b9c6e3c5c45f6043708ca7daaa57c8e2fa", size = 21780 },
-    { url = "https://files.pythonhosted.org/packages/df/cc/8986bd7108ce8878ccb1ec8d81d6114db62081bb3c66180ba45b549bcecb/pyobjc_framework_GameKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:6eca13802c6d5543b52237030f6442f443cfdadfafcd7a47cea4a0fd5b6b758a", size = 21768 },
-    { url = "https://files.pythonhosted.org/packages/4f/c4/64996d76a6c311d5501439688f28643b1365d4b1a2f06bafb2251076895c/pyobjc_framework_GameKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b960c6c2e3a225386229a65885bca06d42e77a33a13f82e16ae82c53560fe015", size = 15360 },
-    { url = "https://files.pythonhosted.org/packages/af/dd/1c7da1376a2b5d1d381a5dea90174c9cae7c91c3c6b949f24bb6eb5e1d90/pyobjc_framework_GameKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:f225c51e9a4a8c583093cae8c243f1f3fddad04ad6bfb7ff6b930ac34e864124", size = 21797 },
+    { url = "https://files.pythonhosted.org/packages/88/4d/9fe843671c7b94d8e8a925662775d4b2632c138c6a0a9d1bb2c379f225c0/pyobjc_framework_GameKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dabe856c8638940d2b346abc7a1828cca12d00b47d2951d0ac9f4e27ecc8d3ec", size = 21667 },
+    { url = "https://files.pythonhosted.org/packages/98/b2/d4d1f123fead83bf68eb4ecfab2125933f3114eaf2ed420d7bb99238ba67/pyobjc_framework_GameKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:40d506505f71ed57779c8be9b4e07ec9337c45aebe323b3f8dd8f8c75e6fce50", size = 21627 },
 ]
 
 [[package]]
 name = "pyobjc-framework-gameplaykit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-spritekit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/0b/e0f9e58ff69017b9b2bd17ef682672f63013670bb2c01b310fd74c2eb0ba/pyobjc_framework_gameplaykit-10.3.2.tar.gz", hash = "sha256:399a7ab7b47203f4506f98b6c121e6faa5bf7e77c154af6e6e486359f201a818", size = 56131 }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f0/980c4fc3c594d9726b7eb6ae83f73127b22560e1541c7d272d23d17fdf0d/pyobjc_framework_gameplaykit-11.0.tar.gz", hash = "sha256:90eeec464fba992d75a406ccbddb35ed7420a4f5226f19c018982fa3ba7bf431", size = 72837 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/98/69a46de78c3dd7a8d05ade778cc3ca7c458fc847261729a009e670816990/pyobjc_framework_GameplayKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:9c5350e8a7277363abf4bcfee70ab389523af8f4fa41b522c7c0abe35668516e", size = 13557 },
-    { url = "https://files.pythonhosted.org/packages/00/48/352d1c67f99dab6775aa181bf2a0523cc4a902123e36293ef2702d0adfa8/pyobjc_framework_GameplayKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:53772a09189f7b5d3506481511ae0b865243aa9c88876d54295434fdd4de1c58", size = 13515 },
-    { url = "https://files.pythonhosted.org/packages/11/d0/7a6fb3ea86f7d8b93b7a88e2c0e80b3bbb480fd4a5993b451cdccb17110a/pyobjc_framework_GameplayKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ebf76c5fa9fbd7ae49faa4d1065c8c79446171bafe61bb7a6d05ba7351899c1e", size = 9670 },
-    { url = "https://files.pythonhosted.org/packages/2f/ef/e638a59543054e279399acc0726abe37d00f7d5de61a3ee0c1ab6ec8c9b5/pyobjc_framework_GameplayKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:64e461bb2af457ae224998e2ae6c84ed5f604ca5377d88a9ae58c7a7baa8b5ad", size = 13479 },
+    { url = "https://files.pythonhosted.org/packages/30/e7/3530071bf1897f2fe2e5f0c54620f0df9fcac586b9ba6bb5726fc9d295c2/pyobjc_framework_GameplayKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:01f59bbf5beb0cfcfea17011987995f1cccf2ec081d91269f95e71283dd83c67", size = 13381 },
+    { url = "https://files.pythonhosted.org/packages/b9/07/075369dd9d4e3849646285d4083a9d28214fdd043b499c7929047b942c7f/pyobjc_framework_GameplayKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f2d56af0a84439b3ddc64cdec90e3fab08b1d43da97bed0fb8d60714f47c4372", size = 13382 },
 ]
 
 [[package]]
 name = "pyobjc-framework-healthkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/76/0bec0e66cd86756dfe28be0cd66f2b4a43fac0a83f46a9c067c738018c10/pyobjc_framework_healthkit-10.3.2.tar.gz", hash = "sha256:01a575de6fdeb38e98f8e04c720c5e1edc4e90ed3ef3b36e991dd18f8b37e83a", size = 114164 }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/2f/d79d2ec7c23bfc94bfaa7b7c6f6487a8bffdb73263eea6900aab56135889/pyobjc_framework_healthkit-11.0.tar.gz", hash = "sha256:e78ccb05f747ae3e70b5d73522030b7ba01ef2d390155fba7d50c1c614ae241f", size = 201558 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/79/42e6d9bd6e120c049c8edbddfba2859ee041d40247b3dbd2e12b8796d22d/pyobjc_framework_HealthKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:0a4bdc0467da93d0cff1d7ea17e4f85e02acd572eb5a8924f6e618749624036d", size = 18813 },
-    { url = "https://files.pythonhosted.org/packages/da/28/b41f919873b05a161e3c3b11e33ba5de3d538423e7a355739b195605b6bb/pyobjc_framework_HealthKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b7c2674b08681ac3fc53955fc600df32bb13b1b5ab21fcfe613b06e43b6ab636", size = 18783 },
-    { url = "https://files.pythonhosted.org/packages/88/79/44505350f4c2d577c43189370cc647fdad88aef6cb4feb00ba113e52f902/pyobjc_framework_HealthKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:183c145021effd1ee5ff61922113ab35423c2157d4964579cd7620a154642dbc", size = 16317 },
-    { url = "https://files.pythonhosted.org/packages/97/df/13f5101d91aed72e0db65277062120a82af7f9f18128f925a4246cedac35/pyobjc_framework_HealthKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:c9571199e699d1f752bf5c0fa2e0993f962efa629923ef0cfb34f0326fd60cae", size = 19347 },
+    { url = "https://files.pythonhosted.org/packages/f0/66/36a2fa7ef61b54a8e283355518ed003aa28b26e1dfad9ecbb7f543a08acd/pyobjc_framework_HealthKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ee87453c28bd4040b12a3bc834f0ea1989e331400845a14079e8f4a6ede70aa2", size = 20139 },
+    { url = "https://files.pythonhosted.org/packages/5f/fd/95d40483d9d185317adbf8433d0c7e83ba36ec6c5a824159b87160f6cebe/pyobjc_framework_HealthKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:680da6d67b0c79d15e897f1c588a8b02d780573aef3692e982294c43727eecf3", size = 20163 },
 ]
 
 [[package]]
 name = "pyobjc-framework-imagecapturecore"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/6b/f0fdad6e56b28723a1136ae282ef2252b483d15aeebb8ae8deb1e062e0c8/pyobjc_framework_imagecapturecore-10.3.2.tar.gz", hash = "sha256:ed62f815a124e2a7560356b370ccf36eb422d211fe187ef720eb7651a9a16469", size = 82245 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/fe/db1fc3ffd784a9010070cd87a05d7fd2542c400395589341fab5970a01e1/pyobjc_framework_imagecapturecore-11.0.tar.gz", hash = "sha256:f5d185d8c8b564f8b4a815381bcdb424b10d203ba5bdf0fc887085e007df6f7a", size = 99935 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/d7/5538683c130edf4ae79eb60d1c78b5d9a601257faf97170ddf25aafe21d7/pyobjc_framework_ImageCaptureCore-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:03f9f57ceaf72423087cb2f619151bd7eca326476038b2161869214e0707b4fc", size = 16784 },
-    { url = "https://files.pythonhosted.org/packages/39/0f/b26fa05124d70c49e44947ad215ea73ec060581e3c4997c860599bbb2dfe/pyobjc_framework_ImageCaptureCore-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:2d7a650cf6b779bfddec6c43e1a6ea57fc82d2f50ae1997c2e52a9d3818a6924", size = 16762 },
-    { url = "https://files.pythonhosted.org/packages/05/54/282003f227f25ed039ea988528b204672e88d206d40e4ded86ab16e24355/pyobjc_framework_ImageCaptureCore-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0f65d7e348ebe79bb7a5ff6980777737f2d0dd0d5a87d895ac12cc7834107f7e", size = 12624 },
-    { url = "https://files.pythonhosted.org/packages/ca/95/797cee0c1d672cedc6dd8f19001147fcede8b574ea4792b2deb92ea78921/pyobjc_framework_ImageCaptureCore-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:942860c7508ce4564084899e5c331798c965f4b0f49acdf93617d9d2e17c6480", size = 16730 },
+    { url = "https://files.pythonhosted.org/packages/e2/fb/29f20521e0df5da0110f1d6a48e4ed3530a2c0b670bf62d89ceeddd42c18/pyobjc_framework_ImageCaptureCore-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fd78aa4a69e24caed38ae17a69b973e505324d966df86b47441318800a52db9", size = 16611 },
+    { url = "https://files.pythonhosted.org/packages/0e/ce/404666e27318435a0513dcf64b85d7cd99195b2e822e03796b03af549c52/pyobjc_framework_ImageCaptureCore-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c5cc6c6acbfca05977adc0e339e1225d5cd314af2fa455a70baebb54f9fb2b64", size = 16636 },
 ]
 
 [[package]]
 name = "pyobjc-framework-inputmethodkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/de/fca23e845f47ff685b9ce2a67f59d9a78eba1617a3718014810be8326ec8/pyobjc_framework_inputmethodkit-10.3.2.tar.gz", hash = "sha256:e722e6658df548183435013c450191d9157f2f97e7b96b9c1d180eb8da8138ec", size = 24867 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/e9/13d007285582e598903264a7d25cc6771a2a52d6c2a96a68fe91db0844fb/pyobjc_framework_inputmethodkit-11.0.tar.gz", hash = "sha256:86cd648bf98c4e777c884b7f69ebcafba84866740430d297645bf388eee6ce52", size = 26684 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/63/751da17c97e70bb0b1a1389d05dad75257588a432e1623ffdd3fe55ca099/pyobjc_framework_InputMethodKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:613831ad328f0d7e0642c9a772fb0a6d6ca030704775d930bf8c2115ddfd0c36", size = 9465 },
-    { url = "https://files.pythonhosted.org/packages/53/03/fcb730b8444d23886d2c2cc9891b193248b73e4110c2940d1d01693a6ffd/pyobjc_framework_InputMethodKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:70bf8cd079af707996a4425ae399f5851def0270d4047e735d61d024ca9ee80c", size = 9433 },
-    { url = "https://files.pythonhosted.org/packages/14/15/31ab3bf7b164a702b0a10aae4be4422530d471bf94e91f5ea082ad00eaad/pyobjc_framework_InputMethodKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:dade51ebd4488dabc1fc1bcba0f04363df0a9300cf1f4d917e61685146c3aa16", size = 7376 },
-    { url = "https://files.pythonhosted.org/packages/ff/fb/d98a172e0f4280f89575d86a2f327280fd01e4798758df98ea952437bd7c/pyobjc_framework_InputMethodKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:18d522ab5dba423a300f03276a6a630697580a13df8e46fa277526ea8e01df30", size = 9739 },
+    { url = "https://files.pythonhosted.org/packages/b5/08/18572def66bf1e0ee6d079b45b34f8b4cbf2ab40b3024c351e4bd83cfa4c/pyobjc_framework_InputMethodKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1a58273233e236cb9fa2d8d9295017c6bf26d6f47cc3a5dc9ba81f1c1e64a346", size = 9369 },
+    { url = "https://files.pythonhosted.org/packages/9d/c9/7793b0d7b363548e62499660899893dff2953ae3a56aa5080e9b199d1291/pyobjc_framework_InputMethodKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7869db2b08586e97181ec2b60b8f5b9d3a683097bae4ce4bb29dc3c5709c3f13", size = 9390 },
 ]
 
 [[package]]
 name = "pyobjc-framework-installerplugins"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/f4/dda750337702cee8cca7ca36eb8d4b5464f6dbd5210b9a21620f6cf54117/pyobjc_framework_installerplugins-10.3.2.tar.gz", hash = "sha256:f271955cb92531a4f8be254572e92d3837a34dfa3b0dd582fa37673b788eb70c", size = 26832 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/f3/0379655e8ea3566002768d5e7b3ccd72ca845390632a8dabf801348af3a7/pyobjc_framework_installerplugins-11.0.tar.gz", hash = "sha256:88ec84e6999e8b2df874758b09878504a4fbfc8471cf3cd589d57e556f5b916e", size = 27687 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/e2/6f5132317b151c25bdf125e836c06f425579d94ea0c5486e5005fad8ab2a/pyobjc_framework_InstallerPlugins-10.3.2-py2.py3-none-any.whl", hash = "sha256:1a5d3d3b72a44ffa6f83edc4bf32df209aa36d4af4994a242ea1b4b28507f6d0", size = 4394 },
-    { url = "https://files.pythonhosted.org/packages/84/65/2994eb72b7a9cfaf6e7d7f33fe13d804d43818cfc9c5a5c7ed89d9ef61e0/pyobjc_framework_InstallerPlugins-10.3.2-py3-none-any.whl", hash = "sha256:177634f052a13a0fa453cdf293012b8b6dd60b01fc418e98b45b3b7a38413929", size = 4390 },
+    { url = "https://files.pythonhosted.org/packages/03/db/0f3334648a53c8ad663fd19d5421863cb0b711e38a2eb742798d50ed33ef/pyobjc_framework_InstallerPlugins-11.0-py2.py3-none-any.whl", hash = "sha256:cb21bfd5597233a2de3d8c0a8d50f23cf92c43e8963edf85787430ac3cadf4a3", size = 4716 },
+    { url = "https://files.pythonhosted.org/packages/f7/56/fe6f50d74d19b0f85035aba977db7039eedbd2de5ac991278a6a5be475a0/pyobjc_framework_InstallerPlugins-11.0-py3-none-any.whl", hash = "sha256:2221301f466d30d6fd32c7317560c85926a3ee93f1de52d320e3b3cd826a8f93", size = 4784 },
 ]
 
 [[package]]
 name = "pyobjc-framework-instantmessage"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/79/d2d1b92734c3225c67341908e07dea47217260ed1c00456999826731d57e/pyobjc_framework_instantmessage-10.3.2.tar.gz", hash = "sha256:cc32e911c0d7574a48a0b2b1e298e979ea1396ddfac71cc3cef63d5ef8affd9e", size = 33093 }
+sdist = { url = "https://files.pythonhosted.org/packages/08/4d/6810a1f2039ff24d9498858b3ebb46357d4091aa5cec9ff4e41bbcdb25de/pyobjc_framework_instantmessage-11.0.tar.gz", hash = "sha256:ec5c4c70c9b0e61ae82888067246e4f931e700d625b3c42604e54759d4fbf65c", size = 34027 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/52/9832fc3dcb701e0388afcd43e4dfe801824ed69c797c1d0401d70a1465d8/pyobjc_framework_InstantMessage-10.3.2-py2.py3-none-any.whl", hash = "sha256:ced4abd3e1c9bdafade9d3020130c9c4ea73141f97150583ac1f5945e3aa320c", size = 5018 },
-    { url = "https://files.pythonhosted.org/packages/69/65/81bc3a377f52e47708c7eeaab29d92d97d8b61f67fd2c02a08bb2370d853/pyobjc_framework_InstantMessage-10.3.2-py3-none-any.whl", hash = "sha256:3886994feea5374b443ae7c73e2ab6c6f3bce43212fa8eeb71bb4dc1cd7fc788", size = 5013 },
+    { url = "https://files.pythonhosted.org/packages/8c/41/4c0ec3d59f9930e9c52570f7e26d79055881e0009e07466b4988c107ef7c/pyobjc_framework_InstantMessage-11.0-py2.py3-none-any.whl", hash = "sha256:ce364e4e18ec8551512b7d968c0d950ccf7de4bb470f66fe524f3bc8d23df0d1", size = 5334 },
+    { url = "https://files.pythonhosted.org/packages/19/d9/e3620a5316c986b27361d2f21dd74b48f70c6f7bfe580075e970ca9d7bd6/pyobjc_framework_InstantMessage-11.0-py3-none-any.whl", hash = "sha256:a2817353eaf8f37fe6063c28006b2a0889892e3de801b51b059c153a9d3f35f8", size = 5402 },
 ]
 
 [[package]]
 name = "pyobjc-framework-intents"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/fb/5e69eb244560faaf7ff992b0ee8645467f16af4377d16a92246d76ae863c/pyobjc_framework_intents-10.3.2.tar.gz", hash = "sha256:24c080176487bb957ea06599e62eaa8f728d690362a2cc6efd1335abb30c1f1c", size = 362250 }
+sdist = { url = "https://files.pythonhosted.org/packages/56/88/07e47b0c5c46fe97c23c883ae7a053c2ca6f6fd6afe851d1c2c784644f0f/pyobjc_framework_intents-11.0.tar.gz", hash = "sha256:6405c816dfed8ffa8b3f8b0fae75f61d64787dbae8db1c475bb4450cf8fdf6b5", size = 447921 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b5/957cf266b119eccd739410734c8080f9f1b5747cd9533834fa0adb65d29e/pyobjc_framework_Intents-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:2beca607ebc1abf9d538ff6909e7182ef11eeb0f3dcd2584f1f5d3a35f21cc6b", size = 31999 },
-    { url = "https://files.pythonhosted.org/packages/37/6b/45a8afe6c2694c298d3939943a69705e470ab9bfbbb34503ab74089caa91/pyobjc_framework_Intents-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f0ee2a16c31272f7d7f2cf5dd04906b1adf21879379bcbe52d32f52e3890c42", size = 31975 },
-    { url = "https://files.pythonhosted.org/packages/36/3a/22be0b88625d3510e0bf048bc3246e9263f6d1c9e538441a499473611b29/pyobjc_framework_Intents-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7787df975d41234b65be7de4377dd5f1405970e1751382e6e5aeffde96067985", size = 26546 },
-    { url = "https://files.pythonhosted.org/packages/2b/08/22df757a7b90ac042f2598ddba6d22b89406eb0adf4296401967c38d3439/pyobjc_framework_Intents-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:57c220d23498b81ae0eb470316505770b9bf7aaf64f6a9c0333f3760646dc95c", size = 32016 },
+    { url = "https://files.pythonhosted.org/packages/86/2e/cd8a4aa10a1d3808dd6f71195a28906c573345673dd92b774fbb8c93dd75/pyobjc_framework_Intents-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a9a445a3d4a0622ebf96c65b0ac0be7cec1e72cf7fd9900cd5ace6acf4e84bce", size = 32021 },
+    { url = "https://files.pythonhosted.org/packages/4a/0e/05c457dab601e3eb5ed7243a04fede32423f08dd03a08e988611359d55b4/pyobjc_framework_Intents-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e148accce2c7c9243ff90ab3f1a200f93d93506da9c3a2cd034fd5579cb839a", size = 32008 },
 ]
 
 [[package]]
 name = "pyobjc-framework-intentsui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-intents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/96/460efe35ca330ef828a364ea0b8ba5efd1eedc3f2ec3d029fd955716a99d/pyobjc_framework_intentsui-10.3.2.tar.gz", hash = "sha256:e2192a7d1858b1a510b5acefe44f9ff8df89a2c7b65868366bb15befb76804dc", size = 19163 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/96/3b3b367f70a4d0a60d2c6251e4a1f4bf470945ae939e0ba20e6d56d10c7a/pyobjc_framework_intentsui-11.0.tar.gz", hash = "sha256:4ce04f926c823fbc1fba7d9c5b33d512b514396719e6bc50ef65b82774e42bc5", size = 20774 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/da/916cf9f3928f293324317a4c28b4f8c0a8f8be8b5eb7ca54bac1294eedea/pyobjc_framework_IntentsUI-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3ef19904246ffca3c544298807a0deb08aa0f5a345feb00ce56cb20c86aa689f", size = 8847 },
-    { url = "https://files.pythonhosted.org/packages/0d/ba/768b2e190b80fe01ea2f23460c86f5fad40d6728f8439f71afeae91e6b98/pyobjc_framework_IntentsUI-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:80cb30a9ca34916e80b729c01519603e14141087d7733730b23f8bcc085d0a4c", size = 9410 },
+    { url = "https://files.pythonhosted.org/packages/89/19/f32a14585e749258bb945805da93fd71e05534b14e09fab243fb5ec507ff/pyobjc_framework_IntentsUI-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7c677225d38fffc5e00df803f93a6a627c466b35a362ed27173f7901e185882e", size = 8772 },
+    { url = "https://files.pythonhosted.org/packages/2f/d4/e81e9cfafef63cef481ab251a961ca98e176ca244be91368e0f6b6fe8793/pyobjc_framework_IntentsUI-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b93a1d9594f471596f255db354c13d67caed7aa020afb9f4e69cde2674f4db71", size = 8789 },
 ]
 
 [[package]]
 name = "pyobjc-framework-iobluetooth"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/91/c57034bf6ccfbc7716141dd9e0d863a46e595322257085e1a69f310086ec/pyobjc_framework_iobluetooth-10.3.2.tar.gz", hash = "sha256:aa8e054cec1066513c4c130ff5d08a1ac020b62ae23fab1d94cbf29ca69e3374", size = 226443 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/46/62913f8e5ac307b154b3dd50a7a0b167c9d7ac2a579223e33208c141c387/pyobjc_framework_iobluetooth-11.0.tar.gz", hash = "sha256:869f01f573482da92674abbae4a154143e993b1fe4b2c3523f9e0f9c48b798d4", size = 300463 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d1/fd07294cc4adffe2d89c09f19813865f32d2bc9de5f2a8a81bb29bf094c1/pyobjc_framework_IOBluetooth-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:19fffb89a5d39c16a10bb515be35326e1cf82d9ed8ddc3654e2a61c482ed4d41", size = 41170 },
-    { url = "https://files.pythonhosted.org/packages/99/99/a605146198c6e0bcc55be57234b9673776e8a2f3b8e7575ab501e816eb1f/pyobjc_framework_IOBluetooth-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:14899a6d717969243a56005b5ce64de758999a81bbc3728b51630d9831b6c458", size = 41141 },
-    { url = "https://files.pythonhosted.org/packages/ea/ed/68b32c452a6b63d4c3d25dc065b8d995b910b11084e60e26fdfee0b14b69/pyobjc_framework_IOBluetooth-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7712af50d602d05a9f0f82c246207ceb9da3b1ad0479254cc3b2e6a4002f3e83", size = 36763 },
-    { url = "https://files.pythonhosted.org/packages/91/ea/22427661fd0b13d94d245a5f3ec296988babd7038c30e5a71f5ddaee9415/pyobjc_framework_IOBluetooth-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:c53c5a0b169e6d6815a496f1d6e35c76d7d165d067328abda9fef6214b2674c4", size = 41127 },
+    { url = "https://files.pythonhosted.org/packages/7a/2e/2037b1c3459008ccdc41d65ab236d7919eed9bbadd0f02f65dc0193bb170/pyobjc_framework_IOBluetooth-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7d2005d3eff2afed4b5930613ae3c1b50004ebabffb86c0d5dd28d54436e16e6", size = 41010 },
+    { url = "https://files.pythonhosted.org/packages/2a/52/c266636ff3edc98c1aaf2cc154392876a68d4167bed0351dc2933d5ccc3c/pyobjc_framework_IOBluetooth-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f86d2e675ee2a61ba3d2a446322e918e8ef2dc3e242e893ef81abfc480a6f2c2", size = 41012 },
 ]
 
 [[package]]
 name = "pyobjc-framework-iobluetoothui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-iobluetooth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/ab/f171f336c7ed09f8e3ff1f8a74cac297046fa7feade6cc32a2848d99cbd5/pyobjc_framework_iobluetoothui-10.3.2.tar.gz", hash = "sha256:00093d69bf0eded017848908b96055648e61de115a270b9c61c06ab77c612c62", size = 19545 }
+sdist = { url = "https://files.pythonhosted.org/packages/76/55/d194de8cfa63c96970e6c90c35e80ce3fceb42934a85d3728736a0e416ff/pyobjc_framework_iobluetoothui-11.0.tar.gz", hash = "sha256:a583758d3e54149ee2dcf00374685aa99e8ae407e044f7c378acc002f9f27e63", size = 23091 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/e2/4bf252c66402db1f89a4cae75ff5d2586c021db6bf3dd389a458870c3d86/pyobjc_framework_IOBluetoothUI-10.3.2-py2.py3-none-any.whl", hash = "sha256:5cad8e43694656b62b9fabdf8d41132090cfc36d1f2cf0656a0cc3506263d16c", size = 3659 },
-    { url = "https://files.pythonhosted.org/packages/46/b2/30d1606c02cb80496aac802ef7251c31b1c08d369e6c5f3fa8078b1df712/pyobjc_framework_IOBluetoothUI-10.3.2-py3-none-any.whl", hash = "sha256:3c0ed4a3b3672331aafb5eff95f36e526c88a4429804d5e15b6af5afaab0305b", size = 3653 },
+    { url = "https://files.pythonhosted.org/packages/d9/75/9401ae099f32a6be2e5759f8d25c573bcf103833343457ca5981153262ab/pyobjc_framework_IOBluetoothUI-11.0-py2.py3-none-any.whl", hash = "sha256:0f94afeb5ecbde07712ea7658a38d6b0e3558154a6bc29c9a33b633f5952b2c3", size = 3972 },
+    { url = "https://files.pythonhosted.org/packages/11/a3/75e473de9d25084bfbfa4c0ba24edf038956a604d78219894dc0b412e501/pyobjc_framework_IOBluetoothUI-11.0-py3-none-any.whl", hash = "sha256:5bc366a9904532168ac2c49523e7f090f81b6acbb7b8929ffc7855be0b1d4cf7", size = 4043 },
 ]
 
 [[package]]
 name = "pyobjc-framework-iosurface"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/93/4d67e85a15a23158e52ea7360731f228f151f4472797306944c4592be627/pyobjc_framework_iosurface-10.3.2.tar.gz", hash = "sha256:f308cc99c91ec4f7e3c3472a7a8396d842536881472beeff34f32e85dd0772d7", size = 19661 }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/91/ae9ca9e1a777eb786d9d43649437d01d24386736cffe9bb2f504b57e8db6/pyobjc_framework_iosurface-11.0.tar.gz", hash = "sha256:24da8d1cf9356717b1c7e75a1c61e9a9417b62f051d13423a4a7b0978d3dcda5", size = 20555 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/84/eec56559bf22009492efd8439cedf48041c03ee24ca6c7df2ac07ef59961/pyobjc_framework_IOSurface-10.3.2-py2.py3-none-any.whl", hash = "sha256:261778a5f28750ed878a0ce9e386748f196d1544ff116056edbb64c51c301b95", size = 4580 },
-    { url = "https://files.pythonhosted.org/packages/4f/2b/abfedadcb93c297c3b8d3497e7501661d764be62e5d78cfc634dbeb3560f/pyobjc_framework_IOSurface-10.3.2-py3-none-any.whl", hash = "sha256:4b913aca8b1e2e35d0263684faea7e39327e825c65ce746ef37f95d958be0f73", size = 4574 },
+    { url = "https://files.pythonhosted.org/packages/b8/08/b96f84b623e2dd2ef733ccdd67a1694f51bfdb4dfd81d38e7755566ab9e5/pyobjc_framework_IOSurface-11.0-py2.py3-none-any.whl", hash = "sha256:58c6e79401a00dc63a5797cd3cc067542d4f94fcd2fc8979dc248c3b06c3b829", size = 4905 },
+    { url = "https://files.pythonhosted.org/packages/2d/af/4d7ece43c993369a8593c36e0f239b739b78c01e71d74553a630dadd1599/pyobjc_framework_IOSurface-11.0-py3-none-any.whl", hash = "sha256:f2bc13cbfd178396bde6e7558b05a49f69cce376885a07f645a5dd69d2b578fc", size = 4972 },
 ]
 
 [[package]]
 name = "pyobjc-framework-ituneslibrary"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/49/7fd55a0b5f9772f73e7aff273b9dab999843559b2bdd4b2683cc90137938/pyobjc_framework_ituneslibrary-10.3.2.tar.gz", hash = "sha256:a8b8fb857ae428677e30c90c24264c69070c9eaae90c58ec40dddc5cac6c2069", size = 40393 }
+sdist = { url = "https://files.pythonhosted.org/packages/41/fe/881ab1058d795fe68ccc1e14df0d5e161601dced15d3be84105ecc44bae6/pyobjc_framework_ituneslibrary-11.0.tar.gz", hash = "sha256:2e15dcfbb9d5e95634ddff153de159a28f5879f1a13fdf95504e011773056c6e", size = 47647 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/1e/01131fc0e23b7b77ce05ea87060806795d44de7b8338e2850c6057d99e56/pyobjc_framework_iTunesLibrary-10.3.2-py2.py3-none-any.whl", hash = "sha256:ed4a2185662bb99cad5b83236f94c3a146c0ba3cb30d904bf19272e3748bdcbf", size = 4823 },
-    { url = "https://files.pythonhosted.org/packages/4a/3b/5de7e6f3943d1b4f3d74f0bbcc5c0d86d2a95f4163e214ce1c44c66a84b4/pyobjc_framework_iTunesLibrary-10.3.2-py3-none-any.whl", hash = "sha256:a596908e42e6c5f001b3fd259900935e07869dd5d2715c7126743426c8993c75", size = 4818 },
+    { url = "https://files.pythonhosted.org/packages/5f/d2/52d1c71ec91ec299e1324658d023954cf62ce4c275155dc66cd298517ae2/pyobjc_framework_iTunesLibrary-11.0-py2.py3-none-any.whl", hash = "sha256:3836fccec315f5186e4b029b486fd18d4b1f24a4c2e73f2d9f3e157ee66d294d", size = 5147 },
+    { url = "https://files.pythonhosted.org/packages/dc/97/c23c522d506ae01740c04982a1db5861888056dc65d56876a2de0fc490bc/pyobjc_framework_iTunesLibrary-11.0-py3-none-any.whl", hash = "sha256:bfd40fde3f057318329e5fb6e256051eea3f6cd2e2adb9c1f1f51fcb87deb05a", size = 5210 },
 ]
 
 [[package]]
 name = "pyobjc-framework-kernelmanagement"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/1a/7ecb8bc2bc0bba690bb85279fbee52162f810816e92b54ec60b96efd5ebb/pyobjc_framework_kernelmanagement-10.3.2.tar.gz", hash = "sha256:c4220bc64bddccdbb57c1040c16f6e04d4eccc1c48df86c66e255236698b5b1a", size = 12262 }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/ea/8ef534fce78817fc577f18de2b34e363873f785894f2bbbfc694823f5088/pyobjc_framework_kernelmanagement-11.0.tar.gz", hash = "sha256:812479d5f85eae27aeeaa22f64c20b926b28b5b9b2bf31c8eab9496d3e038028", size = 12794 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/9e/5feae936bb4bf122940b7465662716cb4c936d3a87cbf994e16f652625f6/pyobjc_framework_KernelManagement-10.3.2-py2.py3-none-any.whl", hash = "sha256:eecdb649c96004ccfabb3a51393505a412fbd6e09a6d6ad7fad8cfd016c3c16f", size = 3279 },
-    { url = "https://files.pythonhosted.org/packages/cd/c7/0855f2cbc06af2cdf10706bb7826e71def86c3bb8456c950cdc5559769d5/pyobjc_framework_KernelManagement-10.3.2-py3-none-any.whl", hash = "sha256:4f07160a18129c099080d64cf2373817cf0e5b6458b82a6d29bcd04dabbb64ea", size = 3274 },
+    { url = "https://files.pythonhosted.org/packages/ee/fe/ad7278325d8c760d5366b08d6162193612a3bf33bb0fa98d83d7dcc41918/pyobjc_framework_KernelManagement-11.0-py2.py3-none-any.whl", hash = "sha256:e2ad0efd00c0dce90fc05efac296733282c482d54ec7c5fdcb86b4fb8dff1eb8", size = 3604 },
+    { url = "https://files.pythonhosted.org/packages/1e/20/8aff6699bf780c88770214f72e92b9db736de078aa1aaaea45312758116e/pyobjc_framework_KernelManagement-11.0-py3-none-any.whl", hash = "sha256:90baacf8bea2883fd62ffb5d7dc6e6ae43fcc6f444458c884da8d92170fcaa5e", size = 3675 },
 ]
 
 [[package]]
 name = "pyobjc-framework-latentsemanticmapping"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/a4/34ff1d3358ab11d98a81a306d478a8530014af18f125f172de00d150055c/pyobjc_framework_latentsemanticmapping-10.3.2.tar.gz", hash = "sha256:477e25832c19e269c969dd25e3c9a7659b237b80ab130f1e4b7f0b98fda9f0a8", size = 16958 }
+sdist = { url = "https://files.pythonhosted.org/packages/42/29/8838eefeb82da95931134b06624364812dedf7e9cc905f36d95d497f2904/pyobjc_framework_latentsemanticmapping-11.0.tar.gz", hash = "sha256:6f578c3e0a171706bdbfcfc2c572a8059bf8039d22c1475df13583749a35cec1", size = 17704 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/20/4f5878cd2b09373dbee188b3b972a3751c26236e88ace92b64eec911172a/pyobjc_framework_LatentSemanticMapping-10.3.2-py2.py3-none-any.whl", hash = "sha256:1a39c9dd7c1f202a202387e5a7dd760585bb4011f1dd84f55bf129758b832681", size = 5038 },
-    { url = "https://files.pythonhosted.org/packages/e4/b7/35f723760b7aade349cbde003e10ee8c6d90e160eb6ad60a4c46309a94d4/pyobjc_framework_LatentSemanticMapping-10.3.2-py3-none-any.whl", hash = "sha256:4e2402d16c208563a9ee6c7c76b87d24d5cf6cceab41733b3e547ea4a1b28a81", size = 5034 },
+    { url = "https://files.pythonhosted.org/packages/7f/87/a8d2f508c021afa4f8af51773ab22cbd883270bfda8368a86d473736b05a/pyobjc_framework_LatentSemanticMapping-11.0-py2.py3-none-any.whl", hash = "sha256:87fd91320fb7ce0b2c482fda41a5c38388f5a694ee2d7208725d22ff75438c00", size = 5369 },
+    { url = "https://files.pythonhosted.org/packages/df/f0/cea2a0d25ad20aef6eb38c432d2c93bda2cb2239c6286b6086f8687a8072/pyobjc_framework_LatentSemanticMapping-11.0-py3-none-any.whl", hash = "sha256:073b8a4e7a22e6abd58005b7d7091144aec4fc1d4b519e9f972b3aee9da30009", size = 5435 },
 ]
 
 [[package]]
 name = "pyobjc-framework-launchservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-coreservices" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/21/1d36e3d7461b0521270b06717443c4bec4aaac7cddd17b36427608b6adbe/pyobjc_framework_launchservices-10.3.2.tar.gz", hash = "sha256:8aabb555e93702f43d2d6c5f85c9efa5d1f03b1caeec75a8359ab72f84fb6299", size = 20337 }
+sdist = { url = "https://files.pythonhosted.org/packages/da/59/eb847389224c670c885ae3d008b1ffe3b996bbe094b43e49dfa84f3947a9/pyobjc_framework_launchservices-11.0.tar.gz", hash = "sha256:7c5c8a8cec013e2cb3fa82a167ca2d61505c36a79f75c718f3f913e597f9ffee", size = 20691 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/86/c2c87a92d993a25b97b08b2ff193eece802c63a7485dbcc8167b24d8df5f/pyobjc_framework_LaunchServices-10.3.2-py2.py3-none-any.whl", hash = "sha256:ce0990585e893b13ef77c18335796d48a5f82d468a8c0b0fe713fa69f0283dd7", size = 3490 },
-    { url = "https://files.pythonhosted.org/packages/f7/eb/b8bed6f66a7358a281b7ca8e9c381dd2116b80adc5e463af7233c382502c/pyobjc_framework_LaunchServices-10.3.2-py3-none-any.whl", hash = "sha256:614351778550c62c06f11534084096ae706e71f2700d159db3e7bdae08470488", size = 3485 },
+    { url = "https://files.pythonhosted.org/packages/35/46/72937390e3eb0f31809f0d56004a388d20b49724495885e8be677707c07c/pyobjc_framework_LaunchServices-11.0-py2.py3-none-any.whl", hash = "sha256:654572e5f2997d8f802b97f619fc6c7d4f927abb03ce53b3dad89b376517b2d1", size = 3807 },
+    { url = "https://files.pythonhosted.org/packages/c0/12/74b96f187beb2f5605f9d487c3141ac8d25193556f2f5febff3580e8b2cb/pyobjc_framework_LaunchServices-11.0-py3-none-any.whl", hash = "sha256:dbc169442deae53f881d1d07fc79c9da6459e5f0b411e8dd1cfd1c519b3a99c8", size = 3876 },
 ]
 
 [[package]]
 name = "pyobjc-framework-libdispatch"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/12/a908f3f94952c8c9e3d6e6bd425613a79692e7d400557ede047992439edc/pyobjc_framework_libdispatch-10.3.2.tar.gz", hash = "sha256:e9f4311fbf8df602852557a98d2a64f37a9d363acf4d75634120251bbc7b7304", size = 45132 }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/33/4ec96a9edd37948f09e94635852c2db695141430cc1adc7b25968e1f3a95/pyobjc_framework_libdispatch-11.0.tar.gz", hash = "sha256:d22df11b07b1c3c8e7cfc4ba9e876a95c19f44acd36cf13d40c5cccc1ffda04b", size = 53496 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/d9/901df936da47707045924eb231adf374e8ff7553202474df7cfb43d4e1e5/pyobjc_framework_libdispatch-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:061f6aa0f88d11d993e6546ec734303cb8979f40ae0f5cd23541236a6b426abd", size = 20201 },
-    { url = "https://files.pythonhosted.org/packages/e0/e9/8e364765ccb1f3c686d922e2512499f2b4e25bfbfa5d73e833478bff88b5/pyobjc_framework_libdispatch-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6bb528f34538f35e1b79d839dbfc398dd426990e190d9301fe2d811fddc3da62", size = 15572 },
+    { url = "https://files.pythonhosted.org/packages/24/1f/f3273cc8261d45a6bef1fa48ac39cd94f6a1e77b1ec70f79bae52ad54015/pyobjc_framework_libdispatch-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cebdc33a1a771c9ab03fe5c8a2b0ed9698804e7bccdbfcd3cc0045c4b4aad4f3", size = 20607 },
+    { url = "https://files.pythonhosted.org/packages/32/08/40638a5e916b1b94b4b29abacb18628fd47871d80fdf2fc1ef7216726d29/pyobjc_framework_libdispatch-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:999815af50ad2216e28d76893023b7839b7f1e8f22bcf7062d81d9a51ade4613", size = 15949 },
 ]
 
 [[package]]
 name = "pyobjc-framework-libxpc"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/fa/0776ec3eef69bb343cd5e3072d87814448fdde98b6a8d1f41ca044b7737c/pyobjc_framework_libxpc-10.3.2.tar.gz", hash = "sha256:c22b7c7de66152643a50b3c10a5899ae44c99b5d6bda7d76c0f7efda0c6ea831", size = 40167 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/9fa73ce6925db9cfd8a6b45d97943af8fe59f92251e7fd201b6e4608c172/pyobjc_framework_libxpc-11.0.tar.gz", hash = "sha256:e0c336913ab6a526b036915aa9038de2a5281e696ac2d3db3347b3040519c11d", size = 48627 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/12/dcde70a4d57f6616a60c2a4a42ae305497dd121fab23a280c13289d064c5/pyobjc_framework_libxpc-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d175ac69780cd6ea608a8ad5bba124941a2ae621b8ad4cc0cab655822b97b213", size = 19193 },
-    { url = "https://files.pythonhosted.org/packages/6e/81/49c684cba518f3443f29349589b5ce6b30761282030da7e64e992c32edfd/pyobjc_framework_libxpc-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d6ecfbadd1f55156529d28dc76d54ceb99136b453460cae01c605302d993cc72", size = 19286 },
+    { url = "https://files.pythonhosted.org/packages/21/c2/b77019e344b3f46ca4169c19e0539cff9586c8db0a97715590696993bd00/pyobjc_framework_libxpc-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5f05f9eb3662df5832ff09ab788d6f6099f4674cb015200db317ea8c69f8c5e8", size = 19683 },
+    { url = "https://files.pythonhosted.org/packages/3c/b9/bf34709c2d8f62a029f4c8e7f9a58c6eb5f3a68542cbcd2a15070b66485a/pyobjc_framework_libxpc-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e000cad8588a961a3e6e5016736cd76b5d992b080cfe8b95745691db5a0ce8df", size = 19788 },
 ]
 
 [[package]]
 name = "pyobjc-framework-linkpresentation"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/24/fb62451a1c4846a69a5914e755cab2b35940f631d87c903e32eea4d4a2d1/pyobjc_framework_linkpresentation-10.3.2.tar.gz", hash = "sha256:345761452e2e441fc21c1898a4e14dba26315d2f46a66a876153d46c823f39e6", size = 14524 }
+sdist = { url = "https://files.pythonhosted.org/packages/95/5c/dac9fe4ad0a4076c863b5ac9925e751fc18c637ae411e4891c4b7558a5b3/pyobjc_framework_linkpresentation-11.0.tar.gz", hash = "sha256:bc4ace4aab4da4a4e4df10517bd478b6d51ebf00b423268ee8d9f356f9e87be9", size = 15231 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/1c/da1a1f610489817e1f8675405378cfe1deb3c3592d8ee3d050049c6e12af/pyobjc_framework_LinkPresentation-10.3.2-py2.py3-none-any.whl", hash = "sha256:f0222073074c74a9985b4f655ec1caeb9dde7a62143ea0c0575e2a5640589ee9", size = 3471 },
-    { url = "https://files.pythonhosted.org/packages/8c/33/883baef16dbf178a4417f9955031aac12aabd51eb4b3356b62ccb808e3ee/pyobjc_framework_LinkPresentation-10.3.2-py3-none-any.whl", hash = "sha256:6fc65ab6e2bb91f5a17a49f760982d13dea719c8c2702d43be5f3df96adb3795", size = 3465 },
+    { url = "https://files.pythonhosted.org/packages/12/fc/aa3f0016e2246c4574cce0e323416303992411a012266b5bdda74095ebef/pyobjc_framework_LinkPresentation-11.0-py2.py3-none-any.whl", hash = "sha256:c10ee1ac48bb7cd2d67ade7f354ec71af1f4244a8deb8530ba646fd4ba327b21", size = 3799 },
+    { url = "https://files.pythonhosted.org/packages/85/0b/77c16f2d4541a4490723e18c03c3bd6ecf7db789cf4988e628753e2e4526/pyobjc_framework_LinkPresentation-11.0-py3-none-any.whl", hash = "sha256:5b063900715c5bcf58f533e6c9672473cb07fe3eaa0f0454d93947defa09f13e", size = 3865 },
 ]
 
 [[package]]
 name = "pyobjc-framework-localauthentication"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-security" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/e0/642b80c3320c654fc57497fe78e423a9c010fe49d6142da807bb774f4365/pyobjc_framework_localauthentication-10.3.2.tar.gz", hash = "sha256:20774489eaa5f5f91f089d801b84e51018e3eaf972e01743997678ad4b65e62c", size = 26544 }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/b1/bea4b5f8adbb69c0b34eddee63e052f35271cc630db43fbef6873352e21f/pyobjc_framework_localauthentication-11.0.tar.gz", hash = "sha256:eb55a3de647894092d6ed3f8f13fdc38e5dbf4850be320ea14dd2ac83176b298", size = 40020 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/df/171015b07cedfcc3d303225afc3bed762106f8e7d2e6b1ecf0e0b68605ef/pyobjc_framework_LocalAuthentication-10.3.2-py2.py3-none-any.whl", hash = "sha256:307d1dc7f361b52a9929ac961c33cfae2536e1eddeff25e2b3a5b996002dd86e", size = 5686 },
-    { url = "https://files.pythonhosted.org/packages/fd/b0/b4266a949801275a4d32a9f92d382de4746d9f40b4c0f1190ec6bfa8ae95/pyobjc_framework_LocalAuthentication-10.3.2-py3-none-any.whl", hash = "sha256:fb53b0b7d75cc3a6b580dfc80daa4cf94215b397c420c379239e063e14dbd8a3", size = 5680 },
+    { url = "https://files.pythonhosted.org/packages/d1/dd/eaa44e4fe3b5c312190c0468afcab0a4372da29535fe9f860b6b9e1e6b4a/pyobjc_framework_LocalAuthentication-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8c6500bb5b195799d70f2a622d89a9c2531cb13d6afe30916cf073a195dd86eb", size = 10515 },
+    { url = "https://files.pythonhosted.org/packages/31/86/f4e913e966a6dbefbaa95aed35e7d235ba2f172d079d3c0b4351a584357b/pyobjc_framework_LocalAuthentication-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c0291e743fb1534c1df900e9adacc809af0651744627ce8ae25cfd021e3db73b", size = 10530 },
 ]
 
 [[package]]
 name = "pyobjc-framework-localauthenticationembeddedui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-localauthentication" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/6b/7e340412752aab504fe1bf51b5bf2063a99dda2f7a28e8f171103be2291c/pyobjc_framework_localauthenticationembeddedui-10.3.2.tar.gz", hash = "sha256:5c4c01c6ccbc042b66d06147f24b6aea8f3f41bfbaefd26f2b441da6a5ee1303", size = 13657 }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/ee/821f2d2e9da4cba3dc47e50c8367c6405e91551fb7d8ec842858d5b1d45d/pyobjc_framework_localauthenticationembeddedui-11.0.tar.gz", hash = "sha256:7e9bf6df77ff12a4e827988d8578c15b4431694b2fcfd5b0dad5d7738757ee6a", size = 14204 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/03/3938cfa6350e70b066a7ba7267e0a5f6c933679ec199f9c10274c5753f84/pyobjc_framework_LocalAuthenticationEmbeddedUI-10.3.2-py2.py3-none-any.whl", hash = "sha256:be046e8a9b0d0145850621c9dab2d264cbc5f79a34d55db8b8c6514135766ba1", size = 3560 },
-    { url = "https://files.pythonhosted.org/packages/d7/13/56772c918f3564a749469f83afccc8a33ef385bf79f5f9b25cbc3b0822ae/pyobjc_framework_LocalAuthenticationEmbeddedUI-10.3.2-py3-none-any.whl", hash = "sha256:0bc1a4f2ac2e908e686c1da2965a9ef51f13e95fe8baee84d6d1396ebcdcbd08", size = 3554 },
+    { url = "https://files.pythonhosted.org/packages/da/66/2151e5ee7fb97b34c7eda9f8b1442683cced27bcb273d34c8aa2c564e528/pyobjc_framework_LocalAuthenticationEmbeddedUI-11.0-py2.py3-none-any.whl", hash = "sha256:0ccbbdd8c7142b1670885881c803f684ee356df83a5338be9135f46462caae6c", size = 3914 },
+    { url = "https://files.pythonhosted.org/packages/d8/a9/c362ac3586bb2d46868b8ea9da3747c9aae3f0c9448ee09934a1be805383/pyobjc_framework_LocalAuthenticationEmbeddedUI-11.0-py3-none-any.whl", hash = "sha256:e8da98dc38a88995e344742585d3735af9b5bd9926a29774d77e2aa6dd46b7af", size = 3984 },
 ]
 
 [[package]]
 name = "pyobjc-framework-mailkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/e3/b394d68e0b8db1f9b6b055bc8751433ee09afd3a2d9fe080091bc359fd88/pyobjc_framework_mailkit-10.3.2.tar.gz", hash = "sha256:56bc122e7681ffff1811f596ce665f5d95df7619650710d9385bad9763965406", size = 26357 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/79/9c9140f726ba14898762ddc19e7142724e0ce5930f08eb20f33f78b05be8/pyobjc_framework_mailkit-11.0.tar.gz", hash = "sha256:d08a2dcc95b5e7955c7c385fe6e018325113d02c007c4178d3fb3c9ab326c163", size = 32274 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/c8/7059eeb124d4a8a5dca28ae317e2fc2725a1cb93afa2d1bdb478af3ff24d/pyobjc_framework_MailKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:d0a6961d1adc0cda9c782265157365def72b65cfeb87a6552e2faf26fc42c0a0", size = 4495 },
-    { url = "https://files.pythonhosted.org/packages/24/a8/15bb2e288cbb8df76e621305cf63883f3795db0d83046e0c85219a46a2d8/pyobjc_framework_MailKit-10.3.2-py3-none-any.whl", hash = "sha256:b13d4d0bb125e90215d4c933334c07ccd3e8b30ab379510513a42f924e6392fc", size = 4491 },
+    { url = "https://files.pythonhosted.org/packages/d2/38/f9bcd204c1ba0943365f3cc505d934ea93fe4b99d61e961ced0f0991a4f9/pyobjc_framework_MailKit-11.0-py2.py3-none-any.whl", hash = "sha256:78e54ff3988fd1af16c06e0c39dea3b7ff522e367d262f58e88962772291c7f9", size = 4803 },
+    { url = "https://files.pythonhosted.org/packages/64/4a/f3596583795c608838c7fa84fc4836f365c5744a3e412392d47a200a6221/pyobjc_framework_MailKit-11.0-py3-none-any.whl", hash = "sha256:0573ee0be66419130774aca36b611d0d07fcf7c756524860acba8fe17eefeec2", size = 4874 },
 ]
 
 [[package]]
 name = "pyobjc-framework-mapkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3325,320 +3278,314 @@ dependencies = [
     { name = "pyobjc-framework-corelocation" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/a9/7b736ad9922c96183930db3a526dab59ff9e3eab5cd6c652ffed093ce6cb/pyobjc_framework_mapkit-10.3.2.tar.gz", hash = "sha256:7c3e04c4e6f2c85a489c95a8a69c319b135438d3aa38bd43d16bab1d0934978c", size = 135878 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/7e/ef86c6e218a58bb9497ce9754a77f12ffe01c4b3609279727b7d7e44655a/pyobjc_framework_mapkit-11.0.tar.gz", hash = "sha256:cd8a91df4c0b442fcf1b14d735e566a06b21b3f48a2a4afe269fca45bfa49117", size = 165080 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/ea/846f441f5abd61d817f323d1eb007a4a1b708834d46621c7e17ad3641770/pyobjc_framework_MapKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:0d4e1fbc0ef04aeac430ed5ba4abd99a5f36b823b3e3ff6cab138addcd54190c", size = 22555 },
-    { url = "https://files.pythonhosted.org/packages/90/9f/cb2b04955ef67dd1fbaa8a7c392aa8a0716f4457178f8a8686e96d04b0f0/pyobjc_framework_MapKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:f2ec324a7704fab6b991e499d35fa6b14b3a4d0d4c970121e8a76c3bda9b7d55", size = 22531 },
-    { url = "https://files.pythonhosted.org/packages/09/3b/27254dd26833b04385ba9762861266c388e585baae58a409e839b9f3845f/pyobjc_framework_MapKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:dc5f524853412c06407e9e1ad0e544342c5251d238d9837d465e0cf651930eee", size = 15931 },
-    { url = "https://files.pythonhosted.org/packages/a5/db/4ae370ad930ffd1d68f87188e0f2686e5ea03fb010684db1143d308bc0fb/pyobjc_framework_MapKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:b8480821f437b5a4de3afe02e37fccd4bc6d185ae6d5c545e127542e0acd18e7", size = 22634 },
+    { url = "https://files.pythonhosted.org/packages/fc/7e/f0457c7ca001a01f47aa944c1f86a24d2d04db0aa1c19f51cbf77a65cc9b/pyobjc_framework_MapKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:83128d79aa7644e5b966b32346f7da749b1dbb110dadba857b93ecf5663e24e6", size = 23045 },
+    { url = "https://files.pythonhosted.org/packages/d5/b0/532b4f57f8783cf6394b17e76174c393d0503ee41e026782a9950bd46279/pyobjc_framework_MapKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6aa1d00cfe2e02b301467e24ca51e469e9a8a2ec2a9f097b73adca1a5a2a054", size = 23040 },
 ]
 
 [[package]]
 name = "pyobjc-framework-mediaaccessibility"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/ba/1c5df04734fea28cb24b855fe176a80ebcfe55c8541a31c68b45701573be/pyobjc_framework_mediaaccessibility-10.3.2.tar.gz", hash = "sha256:b709ecc94cb2b04e7ab1d4ba5d0654c6fd24fb5c0b977d0a531d258178e409ed", size = 17011 }
+sdist = { url = "https://files.pythonhosted.org/packages/81/8e/9fe2cb251ff6107a03bafa07f63b6593df145a2579fffb096023fb21b167/pyobjc_framework_mediaaccessibility-11.0.tar.gz", hash = "sha256:1298cc0128e1c0724e8f8e63a6167ea6809a985922c67399b997f8243de59ab4", size = 18671 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/15/39296c0e64c17d3923d62bdd70cd590862395f3e082baa18de46bdc54601/pyobjc_framework_MediaAccessibility-10.3.2-py2.py3-none-any.whl", hash = "sha256:65ee99905df8be28fef7998e6683811e1c59c1278c49ebd80f9b77fabd6de661", size = 4115 },
-    { url = "https://files.pythonhosted.org/packages/89/20/7836c7cffe02256885f9c6d4332f55c05b631c41932bd15cc39eb2c73864/pyobjc_framework_MediaAccessibility-10.3.2-py3-none-any.whl", hash = "sha256:94e633bcc4aea20093f2b5741e70c23288fecfbcd95d359cd63219b106b86b15", size = 4114 },
+    { url = "https://files.pythonhosted.org/packages/50/1f/36b1115cfd02d68d39cc3fe976fe3d40bad1d1a0a9c8175c66d230bb7276/pyobjc_framework_MediaAccessibility-11.0-py2.py3-none-any.whl", hash = "sha256:901961f171f7af184decbf5a3899debfa56dbd1a63a53d0ff3d93eff90f2f464", size = 4637 },
+    { url = "https://files.pythonhosted.org/packages/72/3f/fa350681a6599ed6756dc598fcd17fda1521249e4570a57b4a9b9c900f47/pyobjc_framework_MediaAccessibility-11.0-py3-none-any.whl", hash = "sha256:3f4b9e4d1ac8e7f8cdb7a2e9839ab75cb358dead3e6365ccd8d6017d7e93811e", size = 4708 },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaextension"
+version = "11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/1f/e31d9431bc71077b09583ea863b3c91b7de9371d0cc17a8be99be8119daa/pyobjc_framework_mediaextension-11.0.tar.gz", hash = "sha256:ecd8a64939e1c16be005690117c21fd406fc04d3036e2adea7600d2a0c53f4ea", size = 57931 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/94/1e4aa67e424a043dfa886c946bb872f9653cc12ad59bd7c2c24e3d19a4f5/pyobjc_framework_MediaExtension-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9f25d674f381bae800761efe1628959293009d287f7127616f75318a87e4543d", size = 39781 },
+    { url = "https://files.pythonhosted.org/packages/02/3c/2cbd4498950daadd111639a7b8dea2aaa6825526677b31ae49bc940f1036/pyobjc_framework_MediaExtension-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9a167725f7a6921d446084b132505392bb375a5ef91498f7be5d94c0d48d26ae", size = 39777 },
 ]
 
 [[package]]
 name = "pyobjc-framework-medialibrary"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/98/34bf44d4d2ffe1dbd2641dba92f0ab8f34b172ff07b1e427e15dc7b87fd1/pyobjc_framework_medialibrary-10.3.2.tar.gz", hash = "sha256:b9070f65f93f6b892918021e4655cc1c68ab6757d8554e28bedbc1dceba92276", size = 17990 }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/a4/8c7d1635994800dc412a5db2c4b43ed499184651efcec0c8da3cf8e2bcc7/pyobjc_framework_medialibrary-11.0.tar.gz", hash = "sha256:692889fab1e479a9c207f0ff23c900dad5f47caf47c05cc995d9bb7c1e56e8b9", size = 18975 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/34/a368b7876c6ca25da739c8abc56b94c4242aa02e7ab60c4e5d2deffb2db0/pyobjc_framework_MediaLibrary-10.3.2-py2.py3-none-any.whl", hash = "sha256:37f33b8a1cb3e8b6a2a02edb8cf842fef8d27c65f36fc1702aafa0b611411282", size = 3971 },
-    { url = "https://files.pythonhosted.org/packages/78/88/872e020d4a381ea1c521764d68b8caceba1a0ea84be254e70e4a7dfe0fdd/pyobjc_framework_MediaLibrary-10.3.2-py3-none-any.whl", hash = "sha256:76ab6de61de1c4e77976d1e4dfde2f441246d74121fa1de52be08414ce767baa", size = 3966 },
+    { url = "https://files.pythonhosted.org/packages/16/b6/c079b41a7a4b6b856b4ba7196500f058fb9d9f4f021269b49cf0861ace1f/pyobjc_framework_MediaLibrary-11.0-py2.py3-none-any.whl", hash = "sha256:3d273d4db7e1894fd2a95448c26eeced6e13e33555f727988aeec4b2762246fb", size = 4288 },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/05f2ee15f5e8524b27d6e446822edfed977c1ed0d3201644ae4d5d78bdde/pyobjc_framework_MediaLibrary-11.0-py3-none-any.whl", hash = "sha256:b8b97bb9067cf81942ce69d3273e2b18d093290c3fd692172a54f012ab64c0b3", size = 4359 },
 ]
 
 [[package]]
 name = "pyobjc-framework-mediaplayer"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-avfoundation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/e2/d06d712043f5dfe7db4aa69c5fbc922a8e30c8bf6c18070cd819b362c552/pyobjc_framework_mediaplayer-10.3.2.tar.gz", hash = "sha256:b57558c771ec922381333bf05bf642e1420785806c97b10d660bc6eb0740bab4", size = 77668 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/ce/3d2783f2f96ddf51bebcf6537a4a0f2a8a1fe4e520de218fc1b7c5b219ed/pyobjc_framework_mediaplayer-11.0.tar.gz", hash = "sha256:c61be0ba6c648db6b1d013a52f9afb8901a8d7fbabd983df2175c1b1fbff81e5", size = 94020 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/ee/0dfc122bd464c96b3fb5217b39fbadd812ed41992c0a920d3079f767b70f/pyobjc_framework_MediaPlayer-10.3.2-py2.py3-none-any.whl", hash = "sha256:6fa3a7edf52d0bf0668d51fbd5603151f39bd8ad7507f14385a92da1076c5aee", size = 6549 },
-    { url = "https://files.pythonhosted.org/packages/f2/bf/443307f9fcab42c757ee6ad5128dc6053eda7de55178761ffa42d14b958f/pyobjc_framework_MediaPlayer-10.3.2-py3-none-any.whl", hash = "sha256:1476330e42cb4eb08ceaa20e66d06477b6a2c55897f742002ead6ad9d2fc4f22", size = 6546 },
+    { url = "https://files.pythonhosted.org/packages/96/b2/57b7b75bb5f2b624ce48cd48fb7d651d2f24d279918b352ae8fb03384b47/pyobjc_framework_MediaPlayer-11.0-py2.py3-none-any.whl", hash = "sha256:b124b0f18444b69b64142bad2579287d0b1a4a35cb6b14526523a822066d527d", size = 6903 },
+    { url = "https://files.pythonhosted.org/packages/e9/8e/4969374f0fb243dd06336f2edc8c755743a683e73a57c3253279d048a455/pyobjc_framework_MediaPlayer-11.0-py3-none-any.whl", hash = "sha256:1a051624b536666feb5fd1a4bb54000ab45dac0c8aea4cd4707cbde1773acf57", size = 6977 },
 ]
 
 [[package]]
 name = "pyobjc-framework-mediatoolbox"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/87/73808a57088e6760d0c9b1be893e1f54947f54094330cfa982fff3613bc0/pyobjc_framework_mediatoolbox-10.3.2.tar.gz", hash = "sha256:0545b375b268594c3e0a63973d6efcce0310b39b316bd0b41fe5d60b3fa0e33d", size = 21849 }
+sdist = { url = "https://files.pythonhosted.org/packages/da/46/cf5f3bde6cad32f10095850ca44f24ba241d18b26379187c412be1260f39/pyobjc_framework_mediatoolbox-11.0.tar.gz", hash = "sha256:de949a44f10b5a15e5a7131ee53b2806b8cb753fd01a955970ec0f475952ba24", size = 23067 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/8a/7162b34b000cdf43866c4950785b773905455d1522dc186c118a9ccbfc43/pyobjc_framework_MediaToolbox-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:a8aaa627956b9b504f6674acdfcdf3c80b9fc22decdd9063fcd459386d0a34db", size = 13054 },
-    { url = "https://files.pythonhosted.org/packages/29/07/1e1f620c87fa5ea1a714d194762bbb35b1b8d0fd7acf9ae778f3e5f63830/pyobjc_framework_MediaToolbox-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:aed075e22d6a063ba8d679f61d1a7c17a51eaf7b4f31528bfbd86200edb4a3cb", size = 12916 },
-    { url = "https://files.pythonhosted.org/packages/86/fc/7e0973dd7d723e6caed0030a616e7f244a4b9a7e801d977571843305c34b/pyobjc_framework_MediaToolbox-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc78f2a2a7a1c2d495bc9c69c300a941f70f5452f64acdc756e15c458ee8c76e", size = 8058 },
-    { url = "https://files.pythonhosted.org/packages/24/94/130df05de871c29da12d4fc770b6d2298ec3b58b00f971919077db2499ae/pyobjc_framework_MediaToolbox-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:774b284e86ee09f36f7a99a4543db72f56f63c88eae730a086bdf188a9aa716c", size = 12867 },
+    { url = "https://files.pythonhosted.org/packages/c3/d5/ee184e33bd743c363d7ab59d8412289c6ac14c78a035545a067b98704ae2/pyobjc_framework_MediaToolbox-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:df09e4db52d4efeafe4a324600b9c5062fd87c1d1217ebec2df65c8b6b0ce9ef", size = 12776 },
+    { url = "https://files.pythonhosted.org/packages/e9/a5/c02d2c44ebcd5884d7ccf55c597c0960d14e4e8f386b65dcd76f9f50ec3d/pyobjc_framework_MediaToolbox-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e80e3057f5030fb034ac93c3e891cee346716e1669f280ebbd63ccfa52b2b7ff", size = 12937 },
 ]
 
 [[package]]
 name = "pyobjc-framework-metal"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/12/a7695cab9ee18c2500ada306b283fc80f6628cb5fc396ee19fcc470bf186/pyobjc_framework_metal-10.3.2.tar.gz", hash = "sha256:59246982eab788b955f6d45dfb8c80e8f97bd1b56e1d678c90e91ad4a9376e35", size = 300113 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/e0/a6d18a1183410a5d8610ca1ae6c065b8944586441f8669faee7509817246/pyobjc_framework_metal-11.0.tar.gz", hash = "sha256:cad390150aa63502d5cfe242026b55ed39ffaf816342ddf51e44a9aead6c24be", size = 446102 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/8c/b3eea5f2137694d107ffa276621d4e7b79fc2584f2144d27ee68eec85239/pyobjc_framework_Metal-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:3ba684bac796177c1646bf4da8d4acaa747f2598ca369eb8df8012db660e3cd5", size = 54712 },
-    { url = "https://files.pythonhosted.org/packages/c3/3f/d6013e14be2217dc86d2be68421fbab832e4630c2196265db4670d635316/pyobjc_framework_Metal-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b83a72464df9e533e739fbc2a576a4d2c78bfedc826dcd4c821be9e08569bb44", size = 54843 },
-    { url = "https://files.pythonhosted.org/packages/a6/21/88549e155912110d8fff35856d4ecb034b5ad5c56ae52836f5db92beec86/pyobjc_framework_Metal-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:17b22be2a312ee6512c9118a5b18c4eeed264a796de39af81677e0e198c79066", size = 37366 },
-    { url = "https://files.pythonhosted.org/packages/5a/79/adbaf11e2cdb0b82a73f6d6d28a13bb553751314a503a16b6edc99968929/pyobjc_framework_Metal-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:34817e32470c4acdeb89b3fd8815c4e42ac27bcb034aa6d25b7855d97d48c15a", size = 54802 },
+    { url = "https://files.pythonhosted.org/packages/e2/fe/083727028e63ffcf7455d10288df05696737ee74a31decdc671e32624f58/pyobjc_framework_Metal-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ac5f317d52cd7523dea2e172fbe8b03e7452b907da42a0a5e5c5ab427c5e9de", size = 57321 },
+    { url = "https://files.pythonhosted.org/packages/78/85/396ad46929ec6e2aa554c29a3fae2f7c7ffb2e1a3fbb9c41948d5a573dc8/pyobjc_framework_Metal-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45802d48d1a35cc66fee08539c8ca9fc6a0dc4ab700cf78a81cf5f8982ed6f5b", size = 57099 },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalfx"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/7e/409a363fba2ae9582d64771e64f5465908a08d8632f07d1ca64e7ecdd2dc/pyobjc_framework_metalfx-10.3.2.tar.gz", hash = "sha256:02e83be7f013a416af42605120431b01c4a02fe2c80f898b7e45f90c30300a19", size = 21954 }
+sdist = { url = "https://files.pythonhosted.org/packages/68/cf/ff9367e4737a12ebd12a17e693ec247028cf065761acc073ebefb2b2393a/pyobjc_framework_metalfx-11.0.tar.gz", hash = "sha256:2ae41991bf7a733c44fcd5b6550cedea3accaaf0f529643975d3da113c9f0caa", size = 26436 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/2a/c17f1f7eeb3994447b17b5b29fde1be8fc80df113ff8a2a52aa97ea0778a/pyobjc_framework_MetalFX-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:b9bc0e6633360fb99199d6e5269b0091af47a0d41868d782680ad65026517931", size = 10408 },
-    { url = "https://files.pythonhosted.org/packages/be/9b/733171d7841dfbc625af0f5276acc52829a5fd579f726fa815f11672e178/pyobjc_framework_MetalFX-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a2cbf3bc72ddb81700457c96d5c7062fd4b22290cb18c32e72e6ca5fe9379d0d", size = 10371 },
-    { url = "https://files.pythonhosted.org/packages/5f/98/0910701afa1849299488026b05d48f8f4f75bb89895f8036d4249ea9c9d4/pyobjc_framework_MetalFX-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2e19eee956cd7292df9df8af00240575292c79ef66c8d9cb625052cd0770d823", size = 6917 },
-    { url = "https://files.pythonhosted.org/packages/4c/32/fe9496f06b2b7c36ae45eacb48c50db508b40942714405631957a62138c9/pyobjc_framework_MetalFX-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:7970af3048f994546aa90172bb5066924b31bbedb16d510582c0e1b5366d406a", size = 10397 },
+    { url = "https://files.pythonhosted.org/packages/16/f1/4140b63b3128cb2f12e136c4158a082ce170e4eb979bccb628768c59fd98/pyobjc_framework_MetalFX-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a3a3847812d40cb6bb7a5f0e735f9f28cba83a1e1264d4dafc630ce894e98a20", size = 10308 },
+    { url = "https://files.pythonhosted.org/packages/c0/85/460abd4f96a7a3efd36404a480ed4d31a51f4b3ed64dc4595502a5f725c3/pyobjc_framework_MetalFX-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a37dc271513b217fcba4a99c6cd92997ee171b49b974e0a9dd1b35feb32b7109", size = 10338 },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/f0/73fbc89e07f98e66666f7e7bf95dff809e270fc7e04ad9e89f67840e402c/pyobjc_framework_metalkit-10.3.2.tar.gz", hash = "sha256:309042ce797def3c2b20db41f471e939c9860e810c717a88665e5fdf140a478b", size = 38634 }
+sdist = { url = "https://files.pythonhosted.org/packages/92/27/fb3c1b10914abf2ae6682837abf76bcd8cb7af2ba613fbc55fb9d055bb95/pyobjc_framework_metalkit-11.0.tar.gz", hash = "sha256:1bbbe35c7c6a481383d32f6eaae59a1cd8084319a65c1aa343d63a257d8b4ddb", size = 44628 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/49/db7a8146b5e83deace125266d92fb8e70e0b222a35aa0084c931a25ff4da/pyobjc_framework_MetalKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:a23af118759422859b4e2112c30eff96950ba804d5dec51cad2165d7fd4b1386", size = 8713 },
-    { url = "https://files.pythonhosted.org/packages/38/ca/601329e8768de9e037769dee1d563164b6838998d2f93a917ebb657fd1f9/pyobjc_framework_MetalKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b531d8c9e01f036df8880281f27df1f305c9b30d6dceabc6dba372f52946c25f", size = 8688 },
-    { url = "https://files.pythonhosted.org/packages/cc/fb/b14fe7b7a27f677c9eb74929f2652640f7f05f8505cfa4826326495aad03/pyobjc_framework_MetalKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b8ec4d313cfdb7595c7b20bf0e5fa8488de3aa9231dc79b0f00b9f1a83b36daf", size = 6489 },
-    { url = "https://files.pythonhosted.org/packages/cd/9a/53f980f80e69c2ea0443742a02e438f9411ee5bd6595c342650ba438afdb/pyobjc_framework_MetalKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:8863a49ac557c7ec141618bd03b90ae1b9282a865f28a8a18581d90d768162b4", size = 9065 },
+    { url = "https://files.pythonhosted.org/packages/d3/44/e7eb6746d9e1ad0ad08ab0a8ac20d264b049960363a8f28a744d1d9c319c/pyobjc_framework_MetalKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f314478a5d772d2f7b4db09957ecb63acd6e3f0cde8c18b1b6b35caa9ea7def2", size = 8598 },
+    { url = "https://files.pythonhosted.org/packages/a6/1c/1ae6d629065e495e8e0b7def36e1d632e461a933f616f9776a914d69b2fd/pyobjc_framework_MetalKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1f2d93180e7ac5abd906e492165a72f82d308d68101eadd213bba68a4b1dc4a8", size = 8611 },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalperformanceshaders"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/d2/4f38e3c4f673dcf13d2e79e68e2e33382174c36416e423a1da30a9dc0cb9/pyobjc_framework_metalperformanceshaders-10.3.2.tar.gz", hash = "sha256:e224a9ab8fb9218bb4d7acf8dad946631f89ee0b8f800264ed57443e5df0982f", size = 215765 }
+sdist = { url = "https://files.pythonhosted.org/packages/14/c2/c08996a8c6cfef09fb9e726cc99b0bf3ad0ffcef66d5c2543e6b35dd4e2e/pyobjc_framework_metalperformanceshaders-11.0.tar.gz", hash = "sha256:41179e3a11e55325153fffd84f48946d47c1dc1944677febd871a127021e056d", size = 301444 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/e3/3748a3566ac6d4ef7688dd981ec8935b4e745becc6c57e3727939785f091/pyobjc_framework_MetalPerformanceShaders-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:595894af4a3b2aa8ad2f48cbfd2af421ce065a232d7ed09a6d4441304e5d3272", size = 32212 },
-    { url = "https://files.pythonhosted.org/packages/d9/9b/a2df9404f5fcb403ed455fa42618134b681574f8531d7a59eb042497becb/pyobjc_framework_MetalPerformanceShaders-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:2689990eba79f5ca335e653fe4a1e754fb585451a6a23ba9c7737209f7478178", size = 32023 },
-    { url = "https://files.pythonhosted.org/packages/c6/50/8fe17e6bc9b8672b3f08a58235114c57c7018644fd9e8f59caed363e583a/pyobjc_framework_MetalPerformanceShaders-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f0545eadcff8a576680ec027e5ae3919156ab5f40c112c177652bf7d8ee60cb9", size = 26026 },
-    { url = "https://files.pythonhosted.org/packages/78/c3/cc6e1d846af28eda7ffdb69e11ee708f9b78b96e41113589542a9c4c4ee9/pyobjc_framework_MetalPerformanceShaders-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:395d4e43e9ea6a388a2eb7766f0224ffefa65c7c2b0e7b851468b1431b2093bb", size = 32365 },
+    { url = "https://files.pythonhosted.org/packages/e6/e9/3741ac0e745e1014961f12cf967eac1d4ec5b110d3ed13fdf9dd4ce27933/pyobjc_framework_MetalPerformanceShaders-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:460a30ff31f04bbe82bf3304949171e148e3171ba0c0773dd9bfc42dad766d2e", size = 33004 },
+    { url = "https://files.pythonhosted.org/packages/39/b4/51434a9a897a47f6a0d1f6079725e3de4dbc75a7004275f116a2043cf80b/pyobjc_framework_MetalPerformanceShaders-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:abd4649de32aedfa45f8535d74227ba3e1411b6426f794026e8426feab43ea8e", size = 33222 },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalperformanceshadersgraph"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-metalperformanceshaders" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/a2/7b0d61e70af9eeae2f428e3d5b8acaf4b5011d6cf07d23e539534510fe4f/pyobjc_framework_metalperformanceshadersgraph-10.3.2.tar.gz", hash = "sha256:d83a4f1343c823674d2dc2730a0f0bd6231ad54409cf467c6bd5fe4a9791c22e", size = 81917 }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b8/353852c76eb437e907ca0acf8a5b5f9255e9b9ee8c0706b69b0c17498f97/pyobjc_framework_metalperformanceshadersgraph-11.0.tar.gz", hash = "sha256:33077ebbbe1aa7787de2552a83534be6c439d7f4272de17915a85fda8fd3b72d", size = 105381 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/af/0d907121de5f621833e65ac3bfcbfa472483bd74650d8e1483051eb0c2f8/pyobjc_framework_MetalPerformanceShadersGraph-10.3.2-py2.py3-none-any.whl", hash = "sha256:b9b8f0ec18a299e095c79eacfc36ce6f2546a14462cf702efb8a9ec1954fc6e9", size = 6045 },
-    { url = "https://files.pythonhosted.org/packages/e0/68/bb1e72e834e2fcc5cfa11bd92a6dd24aa0f118ae852d241001c98627ca2d/pyobjc_framework_MetalPerformanceShadersGraph-10.3.2-py3-none-any.whl", hash = "sha256:6136cb33f653853bf70b9818794cc2f79471f2e4f3d9434d16d5b929bb4ecbb2", size = 6041 },
+    { url = "https://files.pythonhosted.org/packages/0d/8c/3d8f1cc6cfe7f9fd73f3911bb62256fdefc4d7f5375b8be84870d8c15650/pyobjc_framework_MetalPerformanceShadersGraph-11.0-py2.py3-none-any.whl", hash = "sha256:d48ffe401fbc8273a23e908685635a51c64d4ebfb5ad32742664ab9fac6c5194", size = 6403 },
+    { url = "https://files.pythonhosted.org/packages/ef/26/ca0441ac11d5ecc7814b48b3af9df467ead93622f0edc67e947f1a4afe97/pyobjc_framework_MetalPerformanceShadersGraph-11.0-py3-none-any.whl", hash = "sha256:f0702a6e91b273e552283ff2782220ce08eb65325aa45ad428e0b7f3b45cf211", size = 6474 },
 ]
 
 [[package]]
 name = "pyobjc-framework-metrickit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/e9/7bb34b031109e3cde9e8b59af4e1b66a59868ec57f40c3c84140ba281704/pyobjc_framework_metrickit-10.3.2.tar.gz", hash = "sha256:5a3b6f9a9db09a6521ab54610fd8f6a8644622ff248992e8608cfbe721efedca", size = 32121 }
+sdist = { url = "https://files.pythonhosted.org/packages/28/82/605ad654f40ff4480ba9366ad3726da80c98e33b73f122fb91259be1ce81/pyobjc_framework_metrickit-11.0.tar.gz", hash = "sha256:ee3da403863beec181a2d6dc7b7eeb4d07e954b88bbabac58a82523b2f83fdc7", size = 40414 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/16/ad778e7939c120db1089bb488339f9dcd9935fd7e7b0b41df29c6179263d/pyobjc_framework_MetricKit-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:29bbc80d73b7a0c1ab4cae05c6273b363b467e4887fde3e4f6f7bfbcb8304ea0", size = 8041 },
-    { url = "https://files.pythonhosted.org/packages/84/15/74f105587cfd82533a4f5c5cf5aa6b9c22bc9750838e7540dfc98f7ccce5/pyobjc_framework_MetricKit-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4c95fb05070cae690d1f87432672a64d44026b354175eb49af4b228c435fa0b1", size = 8063 },
+    { url = "https://files.pythonhosted.org/packages/13/1f/cc897b07b3ed96a26a3008f43e0deefaa60e280ac13118a2ff4224fca0d8/pyobjc_framework_MetricKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:422b6ca1f082dae864df8cc4aa0bac3829be95675b72ef63cd3ee00d30966b97", size = 7958 },
+    { url = "https://files.pythonhosted.org/packages/19/63/f37010479670958d3c976d007d45107c3fc53b5626586527c6310821e15a/pyobjc_framework_MetricKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b94313601bbf0181c8f75712e82646261ff0e020da5c83d25914952db53a7955", size = 7966 },
 ]
 
 [[package]]
 name = "pyobjc-framework-mlcompute"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/83/d1af0d51ce57e96adb86c43507ec7fa6f6d3cb0ac92c4c881e04c88ec149/pyobjc_framework_mlcompute-10.3.2.tar.gz", hash = "sha256:be84c8ff600d2dde5abd9b5d27e4607a14361c6fef404803ad4681f6ecac5569", size = 68700 }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/c9/22fe4720685724ec1444c8e5cdb41d360b1434d0971fb3e43cf3e9bf51fd/pyobjc_framework_mlcompute-11.0.tar.gz", hash = "sha256:1a1ee9ab43d1824300055ff94b042a26f38f1d18f6f0aa08be1c88278e7284d9", size = 89265 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/e4/51fcd5f13184c09d0e6044626b88e5ad9b5e0f24a11af1fb10aff8996696/pyobjc_framework_MLCompute-10.3.2-py2.py3-none-any.whl", hash = "sha256:d8755b4b74bfa8f6a96221ac18edce0d7a94158ab92b94cdb8a91f1d224ae497", size = 6413 },
-    { url = "https://files.pythonhosted.org/packages/a4/24/0383000300a44432a3ee9f952a67dfc809da5fa465965fef9435e28c77a3/pyobjc_framework_MLCompute-10.3.2-py3-none-any.whl", hash = "sha256:7472f29e04478c06a20f6fcc90a0c85a67ebf4282f3d940382215191c85e74df", size = 6409 },
+    { url = "https://files.pythonhosted.org/packages/75/06/a5865c0e4db4e7289bf6b40242b7149af87d5779f34ca168df5cabf2d5a4/pyobjc_framework_MLCompute-11.0-py2.py3-none-any.whl", hash = "sha256:16ec2942af9915f931df76b42e7f42348109b599faef955f5bea540735f87677", size = 6729 },
+    { url = "https://files.pythonhosted.org/packages/b5/15/3c69df5b5b99cea4a573e1d0e3c0b607cfe4ea1404ea1fe3a302361eb452/pyobjc_framework_MLCompute-11.0-py3-none-any.whl", hash = "sha256:bcdf94fe060fb034aed41db84af1cfcdbf3925e69b2b11df89d4546fac6cf0bf", size = 6799 },
 ]
 
 [[package]]
 name = "pyobjc-framework-modelio"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/9c/93d1bf803924372e31547c1faef512c457f11ecb61ae6554d903cb1acf48/pyobjc_framework_modelio-10.3.2.tar.gz", hash = "sha256:ab0b2ed488e7ba4e4d2862cbc8629d309832bdfcdde3b0c32f87dd2d9e7134bf", size = 93453 }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/7c/b75b84d41e7854ffe9c9a42846f8105227a5fd0b02b690b4a75018b2caa3/pyobjc_framework_modelio-11.0.tar.gz", hash = "sha256:c875eb6ff7f94d18362a00faaa3016ae0c28140326338d18aa03c0b62f1c6b9d", size = 122652 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/c2/22848c2d1993852bb36d98ce9e104f996fc551cb8f11a48f0df59874ba39/pyobjc_framework_ModelIO-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c8668b6758f4c3b303263d2dd47160c61891813d3e7afdb9069f6bb2f5a914cd", size = 20894 },
-    { url = "https://files.pythonhosted.org/packages/5e/96/580e595281aa664ed2a8cf9e23e8baeedacab9d66923524d006e97e64eb0/pyobjc_framework_ModelIO-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:acee6bea07960babf1d42e201af847090e061363ca9ad92660b58916556b2867", size = 20876 },
-    { url = "https://files.pythonhosted.org/packages/eb/cd/14632e23b6bfdb91db4724c6a0465fba5f8e8b46db7a99cde12b74b7af8d/pyobjc_framework_ModelIO-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ef429310ccc062c7153287e9db1b6bb45cbb3d682a589376c8c5269b56189872", size = 15919 },
-    { url = "https://files.pythonhosted.org/packages/7c/7f/1909d22c16e195deac883303e4de6ea7b3b77854e0d13afbf9987da32aef/pyobjc_framework_ModelIO-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:b57cfcb1bbfdf96d80420060c468092e49d53806c45baa2d0dbacfd6fd12f943", size = 20881 },
+    { url = "https://files.pythonhosted.org/packages/11/98/a30e8df5624c7929dfcd9748bf859929e8aa2c7d836efe5888dafc05f729/pyobjc_framework_ModelIO-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c126318b878ffb31c39b0c7c91ca20a3b46c14c18f000e3bfb854e4541fe0147", size = 20715 },
+    { url = "https://files.pythonhosted.org/packages/a9/f8/bb4bc635eb16331c20731cae2e495645d0d10e25962451631eb9085a3f85/pyobjc_framework_ModelIO-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a7357f07b77f3ab0a8107d827acdbc3e1fd458ce396335c057930b6a3f225a93", size = 20715 },
 ]
 
 [[package]]
 name = "pyobjc-framework-multipeerconnectivity"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/e9/f511850e84be7d8645e70934da5f80faa7bd688cd244a1dfbc76ef464870/pyobjc_framework_multipeerconnectivity-10.3.2.tar.gz", hash = "sha256:12f04aca1142ef91ac8292f76ab7fcb3c93eefcb1a1333073dd011cad97cab8a", size = 23803 }
+sdist = { url = "https://files.pythonhosted.org/packages/14/80/4137cb9751aa3846c4954b3e61f948aae17afeb6851e01194aa50683caef/pyobjc_framework_multipeerconnectivity-11.0.tar.gz", hash = "sha256:8278a3483c0b6b88a8888ca76c46fd85808f9df56d45708cbc4e4182a5565cd3", size = 25534 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/df/5b7c7915d2f7872fbdf2ad5df4dfb867161b5c63987cdbe67187a0aaa5e4/pyobjc_framework_MultipeerConnectivity-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c4b50190d9c6891de31be4a36beba8e093150dd448e94026e4645ee33aa1a7db", size = 12582 },
-    { url = "https://files.pythonhosted.org/packages/13/a8/ed891b4f26c72e913de85510f65dcbe8635faf599fad1f96a0b3d3d17246/pyobjc_framework_MultipeerConnectivity-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1edbd1dd5f0e137686e6236d59fa5f5d217558c9badfd52d68ee351330ff5ead", size = 12559 },
-    { url = "https://files.pythonhosted.org/packages/04/04/f007eaec81170b1ecce0325b3b83161c0fce69fda349b565209fe6ca8eb8/pyobjc_framework_MultipeerConnectivity-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fe9a65446b303b6b6c23f66c57c3aaf780780fe796d6c04370d84afccfeeaefe", size = 8800 },
-    { url = "https://files.pythonhosted.org/packages/81/5e/876900a911c753f0dd903b6a958a6f191c50b35ccd8a78786290079685e7/pyobjc_framework_MultipeerConnectivity-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:ebb4e10bce3a298e4f5b9478f8a6a97393ea01590493725949b76b1633a23405", size = 12543 },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/a4144f966cbe998f8da46b936783561bcd3e7e84b8f2dc45eb49ee3f6f21/pyobjc_framework_MultipeerConnectivity-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e338b22f5b0fcb398e316552398c252bedfc3375c058340861eb205e3cdf994e", size = 12423 },
+    { url = "https://files.pythonhosted.org/packages/7b/50/ac9213aca34d30993a36525c23d19ba5a568d3ea4e31e3bc2a6940ddafde/pyobjc_framework_MultipeerConnectivity-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:66bef15f5e5afd6b966cdadf2162082b0171f4a45af6d2cb2644f38431011911", size = 12447 },
 ]
 
 [[package]]
 name = "pyobjc-framework-naturallanguage"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/f8/a7a3d00c1eb5bc8c1d7efd24e655e2f5100322d6adf4c5f12d77018bcc9f/pyobjc_framework_naturallanguage-10.3.2.tar.gz", hash = "sha256:a3a81148b24b744ce5c4289074279cfe4947a79ca9de4d88aa1dbdc44182dede", size = 39472 }
+sdist = { url = "https://files.pythonhosted.org/packages/62/64/63e97635fa637384bc8c980796573dc7a9e7074a6866aef073b1faf3e11d/pyobjc_framework_naturallanguage-11.0.tar.gz", hash = "sha256:4c9471fa2c48a8fd4899de4406823e66cb0292dbba7b471622017f3647d53fa4", size = 46385 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/ed/108b676bad76e576a62e1fde8739ed172f6da809e555756cb8f3a870344e/pyobjc_framework_NaturalLanguage-10.3.2-py2.py3-none-any.whl", hash = "sha256:d8cfa0f37f89ce2737334b64b3c9412c18abb60613b0d3e691ffbc66e3cd5636", size = 4929 },
-    { url = "https://files.pythonhosted.org/packages/4a/33/e691f99a4f585e9fb0b5e2b2b6e38c8f5b3d1a686b1bf4a1f48e3970a393/pyobjc_framework_NaturalLanguage-10.3.2-py3-none-any.whl", hash = "sha256:b684aa6a8023de2297c5673693ade2dbd0289950c6262d425ce7c90fefd9c4a0", size = 4921 },
+    { url = "https://files.pythonhosted.org/packages/7d/72/2246c0a6dc2d087951a626157f52c81cf88fe28393994163e9572fd1eb61/pyobjc_framework_NaturalLanguage-11.0-py2.py3-none-any.whl", hash = "sha256:0744a2871690dcc9ec9e7169023b492abdde63ef97abde46013c01477b4d047c", size = 5250 },
+    { url = "https://files.pythonhosted.org/packages/3a/49/f5faf3fab0f1ffb21882115878f1e5023257239aa576d6c01c31e42dd1da/pyobjc_framework_NaturalLanguage-11.0-py3-none-any.whl", hash = "sha256:7c021b270fda5469b56b9804e860cf5a80a485b817fc5fd3bb002383b2982d94", size = 5321 },
 ]
 
 [[package]]
 name = "pyobjc-framework-netfs"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/32/c6614fa0255968b8eea59c76da292b6c65f9caf8929d5f524b8155c6e006/pyobjc_framework_netfs-10.3.2.tar.gz", hash = "sha256:931239d3a0171d09b089f229bc58add8098c0d45a37f8f0ef45059ec0d4e69d6", size = 15546 }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/29/eb569870b52c7581104ed2806cae2d425d60b5ab304128cd58155d5b567f/pyobjc_framework_netfs-11.0.tar.gz", hash = "sha256:3de5f627a62addf4aab8a4d2d07213e9b2b6c8adbe6cc4c332ee868075785a6a", size = 16173 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/5e/ecd5b171be0148899b9ea783fa0edef066a8ffe17ef57fd542564d5b484c/pyobjc_framework_NetFS-10.3.2-py2.py3-none-any.whl", hash = "sha256:d728d2b69042a18e7441fcbc6109d3ee7fcd9b5afa43cf48c28e6b9ce2acd047", size = 3790 },
-    { url = "https://files.pythonhosted.org/packages/bd/55/1e2d99036dc1d2c0009f8643a0d1ee0051c0c04be7065b75657612be309c/pyobjc_framework_NetFS-10.3.2-py3-none-any.whl", hash = "sha256:75089ddd8d0e2ca837ed64d0a0eeccfcc9f47d13ff586b427cbb64c2a6c8ba8e", size = 3785 },
+    { url = "https://files.pythonhosted.org/packages/00/e7/4be35bc2adbebffb5ac7ede2b8459432194a82bd8f325af12b77b7c26248/pyobjc_framework_NetFS-11.0-py2.py3-none-any.whl", hash = "sha256:11e06da73a1d590b8462f3a1412604758d49b5e04d134b6e991282453b76abb8", size = 4088 },
+    { url = "https://files.pythonhosted.org/packages/fe/83/b7c8dfaee82c0312af25c2b31621505ce19f01fab7bb55eec69c0b4d24ad/pyobjc_framework_NetFS-11.0-py3-none-any.whl", hash = "sha256:9b69a36e3a6782ce37cd3140c584dd7d5c96f7355662d004a2927583b112b4dd", size = 4162 },
 ]
 
 [[package]]
 name = "pyobjc-framework-network"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/52/6a1309a9b5766053ce5b2c7fed21751fc1bd9c8dedaf84d3fc6b2753bc98/pyobjc_framework_network-10.3.2.tar.gz", hash = "sha256:351a0eda913c84e3b7c0ffe0f1d4679b2bc21118ccc0e59fd4943326b23ba4e3", size = 104316 }
+sdist = { url = "https://files.pythonhosted.org/packages/78/8e/18e55aff83549e041484d2ee94dd91b29cec9de40508e7fe9c4afec110a7/pyobjc_framework_network-11.0.tar.gz", hash = "sha256:d4dcc02773d7d642a385c7f0d951aeb7361277446c912a49230cddab60a65ab8", size = 124160 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/b0/cad0271dc3b87279fc3c1109c8297758535c33899309e96ed768ef2181a1/pyobjc_framework_Network-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c4b3f36a7869b4b69ed497cf99798339921c6ffb0e2796df2eda120a184cab18", size = 18972 },
-    { url = "https://files.pythonhosted.org/packages/78/9d/44e18e433ff8ff1f05b18b094c419182d6405ce3bebe517960a8f3e8b6c9/pyobjc_framework_Network-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:07b2c9395c194346b2b8bbb146f46b23d0eb8bcbb0e378c186ceb7c1542a89f5", size = 18956 },
-    { url = "https://files.pythonhosted.org/packages/ef/0c/4a4d5abcf96b92ec8a54653a3f11c31dd25b57095757b9221264af831912/pyobjc_framework_Network-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cedf79a69c0e9039b58b217f1769a282f0f19320d5c4831ebd547387794717cc", size = 14544 },
-    { url = "https://files.pythonhosted.org/packages/f0/30/4619dac55319fed574e2bd60cf1e708a032fb15a445a82858cf42070ba79/pyobjc_framework_Network-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:6e47555e25ffd986a09c677f9a13d758163100450bb31612d607e404a0c0cb79", size = 14360 },
+    { url = "https://files.pythonhosted.org/packages/24/b5/16800524e6d8d99467f53dbafa661abb1405d08d50def7edb933504197a3/pyobjc_framework_Network-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6fc797537690a241b555475923bcee28824efacd501e235457daeb4496b4b700", size = 19507 },
+    { url = "https://files.pythonhosted.org/packages/36/7c/a5966976564e8e71c0e66bf68e9282c279ad0c3ce81be61fa20ca8e0ca2e/pyobjc_framework_Network-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0b9bb4a0cbd01cc4acb120ce313662763bca0c5ef11c01a0a0cae64c80b120c5", size = 19532 },
 ]
 
 [[package]]
 name = "pyobjc-framework-networkextension"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/91/132fc6782b988b67c6e65d569c5a83c8cf567ef38d6d69016ef7acc902b7/pyobjc_framework_networkextension-10.3.2.tar.gz", hash = "sha256:d79ebd6fa4489e61e95e96e868352c9cef20c48ccb1d90680300c814b659529b", size = 131032 }
+sdist = { url = "https://files.pythonhosted.org/packages/59/90/97dcfac5895b07e891adf634c3a074b68992d132ccfab386c186ac1a598c/pyobjc_framework_networkextension-11.0.tar.gz", hash = "sha256:5ba2254e2c13010b6c4f1e2948047d95eff86bfddfc77716747718fa3a8cb1af", size = 188551 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/49/b0d984409fed5d7ea9c482f32d2c311e3fb3c9727dc0e8ebc4f7e3eb5e73/pyobjc_framework_NetworkExtension-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:fc85398073d1626e4e4cd87b9f152489c2fb54361eac9424d786927170e24a9f", size = 13748 },
-    { url = "https://files.pythonhosted.org/packages/c0/64/b06272c35f3c72b0dcff9df97d143aa36395fe9d1b3bdc859fb494070503/pyobjc_framework_NetworkExtension-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1866e6d65ca4d86ef2cc12d321fa39d842fb5ae4c5b6ae826daea2ff07373a13", size = 13720 },
-    { url = "https://files.pythonhosted.org/packages/18/cb/575065d39a56ee94118a7a9f2ec0d9db52c684bd9db70936d4998db1cb6e/pyobjc_framework_NetworkExtension-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c20fd0bab4ac386b198616a1dc77db9b1f61354afe36bf38bd9867c3d35e4c6a", size = 11457 },
-    { url = "https://files.pythonhosted.org/packages/c3/3b/6c6fffffdcd5f1c70de6e2ac912347a3613e076dc0f66bb98b41d98bdcef/pyobjc_framework_NetworkExtension-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:9973a5b4b7d623180c1efa33c42760c48f4b5c119000917d3916b84e9433d532", size = 14171 },
+    { url = "https://files.pythonhosted.org/packages/f2/a4/120aba6e1ccf473d7294c200687f500b096947fec58d94dc772b1a444ecc/pyobjc_framework_NetworkExtension-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4bba4f338748c8ad2cb4320c4dd64b64772a863c6b6f991c2636b2a2f4cb839a", size = 13945 },
+    { url = "https://files.pythonhosted.org/packages/d1/0f/f7039d2bae0dcd63f66aff008613860499b6014dbd272726026f6c4c768d/pyobjc_framework_NetworkExtension-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:abf63433992ff1830f42cb813d1575473f0034ca6f62827f43bb2b33cc31e095", size = 13960 },
 ]
 
 [[package]]
 name = "pyobjc-framework-notificationcenter"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/ec/befdaf13ca4a9056a3760fbb95ae581b0484dc2b5749be30326c9ea2a799/pyobjc_framework_notificationcenter-10.3.2.tar.gz", hash = "sha256:d0dc85e4da0f0e139e032279893db4827595f8f11830080e294f63f57e984c1f", size = 21367 }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d0/f0a602e01173531a2b639e283a092cf1f307fd873abd2ed590b9c4122337/pyobjc_framework_notificationcenter-11.0.tar.gz", hash = "sha256:f878b318c693d63d6b8bd1c3e2ad4f8097b22872f18f40142e394d84f1ead9f6", size = 22844 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/8d/697597e6823d3467b4288d3b52ba333631f5ed6e49859d55e84de1690469/pyobjc_framework_NotificationCenter-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:573e45bc8726296b3830690b2896a8f2e1d6b5d15a4010b34cc1656bbd6c4311", size = 10426 },
-    { url = "https://files.pythonhosted.org/packages/bd/dd/a17d894e8039d80065f89d4e05f9616375b75e585bd873dfc1123ecceab1/pyobjc_framework_NotificationCenter-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fe43ab134afcc08a9006cb04143473e6757bc59e9e7c4957c99ab9cb09a9bdb4", size = 10374 },
-    { url = "https://files.pythonhosted.org/packages/13/4e/0260b61f5fed08d51209e345783a66d3d4585a9793eee2dedd5acfbc56e2/pyobjc_framework_NotificationCenter-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5659d3cf2bd217b7aa9039e657c7939e6bce59b7e4ce170319aa01b8a1926cdd", size = 6990 },
-    { url = "https://files.pythonhosted.org/packages/e4/41/780412624dbdf5fd988b7534a0d4a60b02b172b17824e68c2eec96c77804/pyobjc_framework_NotificationCenter-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:313e3c38c49f29c46c1d2d94df0a1c79b8538f97cef3ad778635ad4ac9384d0e", size = 10354 },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/22f04062b772e2f47ee2d54eac3f80c5aef727ec468ef5ab9a3272dd2a73/pyobjc_framework_NotificationCenter-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:075853f3e36eb4377182589e552226b2207a575035d7e128055cfde9dcad84b7", size = 9684 },
+    { url = "https://files.pythonhosted.org/packages/16/22/531c2aab1639ab13aeaf3ac324afa102515b8d5eb860cb1a566018d98058/pyobjc_framework_NotificationCenter-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:093e50badfbc78edf088f9241cddba7516a58188d401f299e361f1ec85e93fce", size = 9707 },
 ]
 
 [[package]]
 name = "pyobjc-framework-opendirectory"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/cf/5e0c2c3b1c29f3869c17149a69d3142b93343161af135c2a822404c8a61a/pyobjc_framework_opendirectory-10.3.2.tar.gz", hash = "sha256:d506f66c888284e50edb766222d9e3311d9a3ec51b561df1994c498233730f62", size = 159962 }
+sdist = { url = "https://files.pythonhosted.org/packages/55/cf/ba0cf807758acdc6a19e4787fdcda2eb59034aa22c4203d04fd49b276981/pyobjc_framework_opendirectory-11.0.tar.gz", hash = "sha256:0c82594f4f0bcf2318c4641527f9243962d7b03e67d4f3fb111b899a299fc7eb", size = 189165 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/2c/11c3118709be26f58b510bb1eeeaa7d536c2610d72fef37b598eba338ab5/pyobjc_framework_OpenDirectory-10.3.2-py2.py3-none-any.whl", hash = "sha256:276eb1615898e134e0bedd142b9003db65db5d542696c796567bc223882bea63", size = 11427 },
-    { url = "https://files.pythonhosted.org/packages/19/76/ce9d2bea40e3def7055547c14ed5f59c5f77570109408b36a195a56264f5/pyobjc_framework_OpenDirectory-10.3.2-py3-none-any.whl", hash = "sha256:2f4fd45bac828eeb17c778cf8be0883f58828baa59bfdc3ebf5876aad1318627", size = 11422 },
+    { url = "https://files.pythonhosted.org/packages/b4/0a/e5a03c46a5873db83fb89ea829e4a0c02fb3f56f3639a6053e72854f435b/pyobjc_framework_OpenDirectory-11.0-py2.py3-none-any.whl", hash = "sha256:8a0feeda5a7f34b25b72c71cd1e4dd57b636cc4103248ff91bcb8571d4915eb4", size = 11747 },
+    { url = "https://files.pythonhosted.org/packages/da/fd/be3815a19978ab2a3abe9563a031195b40647077fcebbee86232af260176/pyobjc_framework_OpenDirectory-11.0-py3-none-any.whl", hash = "sha256:bfac495de433a62e3934619e2f5d2254177f960b7d4e905ed4ef359127e23b24", size = 11816 },
 ]
 
 [[package]]
 name = "pyobjc-framework-osakit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/5a/11674938bd217abdfc5ccbd23ebfc0bd21f003cf2609cf545503efdd9214/pyobjc_framework_osakit-10.3.2.tar.gz", hash = "sha256:2a718d4bf08d1b09d41eca1131604ee87929b991506d56951e992e2112a0b4e7", size = 18610 }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/4a/e49680f7f3ab9c0632ed9be76a0a59299e7fd797335690b3da4d117f2d7b/pyobjc_framework_osakit-11.0.tar.gz", hash = "sha256:77ac18e2660133a9eeb01c76ad3df3b4b36fd29005fc36bca00f57cca121aac3", size = 22535 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/ae/4c69f54462d8282ca2c633717fcfe5706a85fc660e658f2099d1af791bbb/pyobjc_framework_OSAKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:85d19162d36b94db640a5811351995cfb86a59c28fbd4ee383c3fc5a44139e54", size = 3786 },
-    { url = "https://files.pythonhosted.org/packages/09/eb/3f88a1cbbde852869378530567867cbda21306bab82bae416357a54ef51c/pyobjc_framework_OSAKit-10.3.2-py3-none-any.whl", hash = "sha256:86be4f7f9167e7a84e15b218d378ed6b9e301f5b6c000e313e6882a99aa13b04", size = 3781 },
+    { url = "https://files.pythonhosted.org/packages/56/f6/1dcff2f76280946368ee75ab39c92e261a851656c5979a50513563d08cf0/pyobjc_framework_OSAKit-11.0-py2.py3-none-any.whl", hash = "sha256:3183414e345af83a2187b00356130909a7c2a41b2227dc579b662737300c3ba4", size = 4094 },
+    { url = "https://files.pythonhosted.org/packages/17/75/745985429f0ff4776ffb8ba261199e11f4d6977b1814ad2b39084f83bad5/pyobjc_framework_OSAKit-11.0-py3-none-any.whl", hash = "sha256:79150c47d2aeffc72fb6551060518ce472275edbad3b56aef5923a6086371c28", size = 4162 },
 ]
 
 [[package]]
 name = "pyobjc-framework-oslog"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3646,625 +3593,585 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/1b/1a404937e72478a6698ac935b7dc0e754b76459a913c6dd26a042a12ebcd/pyobjc_framework_oslog-10.3.2.tar.gz", hash = "sha256:3f9680b737130579e1317e8bb25d6eb044a1a9569b9dbe33c056654a0d40efbd", size = 22643 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/93/0a72353d0212a815bd5e43aec528ce7b28b71d461d26e5fa3882ff96ffa3/pyobjc_framework_oslog-11.0.tar.gz", hash = "sha256:9d29eb7c89a41d7c702dffb6e2e338a2d5219387c8dae22b67754ddf9e2fcb3f", size = 24151 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/7e/397f1b87759d399efa1c2422ac80733a97133946c7cc02bb0eb017ddad3f/pyobjc_framework_OSLog-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:958c7cbaa87f6da0dc89092010249b4f880c748b735ae4343c5e60dd9e0c0a31", size = 7828 },
-    { url = "https://files.pythonhosted.org/packages/56/10/6e281f06ecae1f490694e52eed475f8ce3dca8f71659de9a7cd9c7b15aab/pyobjc_framework_OSLog-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfa98b576c67cdebe48f6bf0a3a4bc29fb9d80f78c9f2056b01cb97215b7e0d8", size = 7796 },
-    { url = "https://files.pythonhosted.org/packages/f3/53/066e596b9e0cf21667bebefd7248437f8b316c2937c6df6e48fa0ef78d52/pyobjc_framework_OSLog-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3659796f54ebeb44e186da42b4d7af6fec7a2a8c78d2145ff235e0b4fffd5d69", size = 5687 },
-    { url = "https://files.pythonhosted.org/packages/c4/16/d1962e9de38e8b1b160c8b7cb5bbe56faa5c6aadd8935c09365218474d5e/pyobjc_framework_OSLog-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:43bc2ec01fc6d527ba6880fee1d5b5b500f3e2b30c8b5822bb290fa8f3af7a95", size = 7995 },
+    { url = "https://files.pythonhosted.org/packages/9c/54/6b507a18d0adadf8b707be9616bc9bab157963b81fa3c9928a0148d3bfd8/pyobjc_framework_OSLog-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c0131851fca9b741f290ffa727dd30328dd8526b87c8cef623b79239bed99187", size = 7694 },
+    { url = "https://files.pythonhosted.org/packages/d1/79/81e64a55023f458aa5d99d10671fd9bcc6c0dcf8339768152fbc28c92cef/pyobjc_framework_OSLog-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:17d8b49113a476372b24ac8e544d88f6d12f878f1081dd611ab203c4484f2039", size = 7720 },
 ]
 
 [[package]]
 name = "pyobjc-framework-passkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/4d/c89c17233d3e3510c7d609384f71fe7b70432f15d16e31ae61deda8c03cc/pyobjc_framework_passkit-10.3.2.tar.gz", hash = "sha256:e85d94062cab45b99dc7123f8de048720730439b66d3b0386eabddb8856aaf12", size = 95237 }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/f8/ebb2bc840f87292a4f60080463ee698ca08516cc958364741dfff2858b33/pyobjc_framework_passkit-11.0.tar.gz", hash = "sha256:2044d9d634dd98b7b624ee09487b27e5f26a7729f6689abba23a4a011febe19c", size = 120495 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/98/2f79e705d7074509722479f8e2040e46f2a12ed5e35ccf9da19f5f0a1f17/pyobjc_framework_PassKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:f37d18fe27453a845ffdf1bb70d9a9f48ddb117ad6ad6f3fd8863b09294c5ae9", size = 13760 },
-    { url = "https://files.pythonhosted.org/packages/17/59/b0140880ed90376f97eb30aa0159b54b6627b2552051a89cc9d985c28d01/pyobjc_framework_PassKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:202f716409b9c9fb3a01183db7b46bdd26bd2556184f9ac4e71b67c2d2b0d6bb", size = 13730 },
-    { url = "https://files.pythonhosted.org/packages/e5/c1/57a69723e67269493076ec758f8353d493bcfa73155b67c1ebc1a06b70e3/pyobjc_framework_PassKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b433fbddc78f9fca0d7e97268c8f2529e376cae44a4681a6012137c7288025e7", size = 10684 },
-    { url = "https://files.pythonhosted.org/packages/6b/8f/a316b95eec95c68805ef82ac2ef42b2d9ab1491b8d15e142ebd7235b7d75/pyobjc_framework_PassKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:fedb99158ba5ba1c437e2fd4b0d408b0e0590ca58e299ddda7db7d99fe83874f", size = 13687 },
+    { url = "https://files.pythonhosted.org/packages/53/72/d7dae8f5a1c5b12d9cf404a71a82fd5a638bc4de2d1099bf838aee1026f0/pyobjc_framework_PassKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:710372134c3adedb9017bfc2fbc592ef0e94ae916145b58e57234239bf903b90", size = 14354 },
+    { url = "https://files.pythonhosted.org/packages/c3/b1/5ee2f5581877241a4fc2db4ab4a33d595a918bde1b4a59796240e2b2244b/pyobjc_framework_PassKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe0144177f7feb96577bea53841d9b9b3f63185735a1bf1b36368ab189fd6282", size = 14391 },
 ]
 
 [[package]]
 name = "pyobjc-framework-pencilkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/630fc7219b046446705771406d9ae6ec027878478e7d8699892786aaec21/pyobjc_framework_pencilkit-10.3.2.tar.gz", hash = "sha256:2390317a7de5f68fb9594f9eccbe55183ee5f40a7efc59c827c5fc2d4abce508", size = 19159 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8d/1e97cd72b776e5e1294cbda84325b364702617dd435d32448dcc0a80bd93/pyobjc_framework_pencilkit-11.0.tar.gz", hash = "sha256:9598c28e83f5b7f091592cc1af2b16f7ae94cf00045d8d14ed2c17cb9e4ffd50", size = 22812 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/fe/94ac0bfe7a93dadf3cce2b9893b7a659e8f2db4faadafb52c7ea04394a6a/pyobjc_framework_PencilKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:680a17eb204db9741545259be29e747f0fc0e35ae9c8ba889ffe4443236b19d8", size = 3660 },
-    { url = "https://files.pythonhosted.org/packages/0f/cd/ae0f42e684b7be5924de8f7815b6e8482c1eceb692cec69fe3541c2a6677/pyobjc_framework_PencilKit-10.3.2-py3-none-any.whl", hash = "sha256:a0780237de28e1cade0f3533d94ebf0c4844ca809eed3dea70e94d98ee708251", size = 3656 },
+    { url = "https://files.pythonhosted.org/packages/af/5b/24fb83a97648eaa0d231df7908532dff7b36d5f516d55c92ed9ae07c4e1b/pyobjc_framework_PencilKit-11.0-py2.py3-none-any.whl", hash = "sha256:22cbb6ed2504be4c8d631c4711b00fae48ef731c10c69861b4de1e4fcdc19279", size = 3970 },
+    { url = "https://files.pythonhosted.org/packages/08/fd/89a005c86b06137837952838d976ce6e39b31082392d78c382d44e03944d/pyobjc_framework_PencilKit-11.0-py3-none-any.whl", hash = "sha256:a4e606c5b69e6adb80ef30fc95fe0095971735d12ab6fc4fe4d982e4c8a3881a", size = 4045 },
 ]
 
 [[package]]
 name = "pyobjc-framework-phase"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-avfoundation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/ff/088a94515efb4c9be86bc45ce1024a924f71a7a836462a9177da42447c0a/pyobjc_framework_phase-10.3.2.tar.gz", hash = "sha256:87a0f4d2e6b9db186fda3e700cfc52bc15a9d38f53f5cb3335be93c75d7cccf2", size = 44249 }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/a2/65182dcb44fceb2173f4134d6cd4325dfd0731225b621aa2027d2a03d043/pyobjc_framework_phase-11.0.tar.gz", hash = "sha256:e06a0f8308ae4f3731f88b3e1239b7bdfdda3eef97023e3ce972e2f386451d80", size = 59214 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/6b/cdd547dc958ab14cce0843f8c848c136b9063598a32ae412c0a1ce7d6c06/pyobjc_framework_PHASE-10.3.2-py2.py3-none-any.whl", hash = "sha256:24791034d0c81023d8fd4d22a0373ed508a1624410c1364d4db12c615f6f0247", size = 6236 },
-    { url = "https://files.pythonhosted.org/packages/36/c7/39d37817d10b87ebbfdc10005d41b79ead25782b3a6d8737556450093d97/pyobjc_framework_PHASE-10.3.2-py3-none-any.whl", hash = "sha256:a5a6672ed560b264e7f89ca5e50fcd5f3d2a3c5bd783cf5e85468d1efc8bceef", size = 6231 },
+    { url = "https://files.pythonhosted.org/packages/a9/97/efb9d770ba05d285384b0c121e9e911929893356da1944a0bb03ea0df0f2/pyobjc_framework_PHASE-11.0-py2.py3-none-any.whl", hash = "sha256:d3e41c2b2fdf4b2ce39f558a08762c6864449ff87b618e42747777ad3f821323", size = 6777 },
+    { url = "https://files.pythonhosted.org/packages/38/85/03420927e4243d0ef8e3e8aa1ca511b5638743d7ec319a570a472a50d60f/pyobjc_framework_PHASE-11.0-py3-none-any.whl", hash = "sha256:78c0600477ea294304b51f8284a2fb299be284c33ae2c135e1c7cd26fdf4def4", size = 6846 },
 ]
 
 [[package]]
 name = "pyobjc-framework-photos"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/29/43357f5a2a57972bd4cdd4bbc5a914cee4e4eb1f9a9ba6b0aaed2f6308e3/pyobjc_framework_photos-10.3.2.tar.gz", hash = "sha256:4aa7180a45ef0b5245a277980c2be32195d6b512d66f8abbfdad480466e06434", size = 74548 }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/c3/fc755c1f8f411433d7ba2e92f3fe3e7b417e9629675ad6baf94ac8b01e64/pyobjc_framework_photos-11.0.tar.gz", hash = "sha256:cfdfdefb0d560b091425227d5c0e24a40b445b5251ff4d37bd326cd8626b80cd", size = 92122 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/de/6335cefc3dedd876a2fa30bfb86ef3f83fc8dbd088c32d925b8735b65770/pyobjc_framework_Photos-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:2a8453c5069ae6929bbc0880a0979d4b72986541366e2d0c4665c0874cde832a", size = 12211 },
-    { url = "https://files.pythonhosted.org/packages/55/60/e5bc1fd38551bf8bfa90294fe196144c0b6e0a1202c0e5684be08bae339a/pyobjc_framework_Photos-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:95b88aaea9f96489195a9e9957d02588ed1968438998d2afcf0cb6b15d959670", size = 12170 },
-    { url = "https://files.pythonhosted.org/packages/26/32/a19d5e44d99b2a9b7e0e74ff3aca8256c7513c4258da873695454da8b658/pyobjc_framework_Photos-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fa8edf4669c3ef6561f3cbafda9776f4183b358f492a77c67da1a8f515f72634", size = 9632 },
-    { url = "https://files.pythonhosted.org/packages/af/0d/dd7e6bc36b19610ed4a26db28814992d1c72136a246f06d82f8ae9bd5e07/pyobjc_framework_Photos-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:83bf410aa6e6dfdd0168df4ce2962cdb2a92c73e8422962642010467d0fd1749", size = 12574 },
+    { url = "https://files.pythonhosted.org/packages/80/27/62e5833b9629121b4b6ea8f2b2aa295cf6b719dc6316387f77ec0bd41d77/pyobjc_framework_Photos-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:71bf849888713e4a00eb44074c5000ed081c905ba35b3a55ee84c6367ce60ce8", size = 12085 },
+    { url = "https://files.pythonhosted.org/packages/b9/6e/54108271ea34b0fc51bf8d0bf677788e4d39a1e29ad481f8c78c100f3159/pyobjc_framework_Photos-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ea630c3abf4620b022f23167ef5f3d6b157b38697d7ffc5df0fc507e95bed655", size = 12107 },
 ]
 
 [[package]]
 name = "pyobjc-framework-photosui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/78/c30494b5207d1ece728541ec21632317a054a6bfb8aecdac770c79d8ab72/pyobjc_framework_photosui-10.3.2.tar.gz", hash = "sha256:0cafb53b9c6014c524ee230d3278cf224e44c885e1166524db9160f8c928e6ba", size = 39302 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/2c/70ac99fb2b7ba14d220c78cf6401c0c7a47992269f85f699220a6a2cff09/pyobjc_framework_photosui-11.0.tar.gz", hash = "sha256:3c65342e31f6109d8229992b2712b29cab1021475969b55f4f215dd97e2a99db", size = 47898 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/f2/acda4a9592c414807a29193ded54c6d8d5cd4f8b34fd18dda2551345fa4f/pyobjc_framework_PhotosUI-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:574f03450feb9280904c32dc97c11a00aff1ddcf36250b4d8b100fc14509a7b0", size = 12327 },
-    { url = "https://files.pythonhosted.org/packages/3f/07/225f0947f310591b626f407dcb59300bfcac2c212d015d279cb4a49421fb/pyobjc_framework_PhotosUI-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ce192ce1568b04878478ff9d6e50f516b72d919dcd88985b184e762e0661e4cb", size = 12310 },
-    { url = "https://files.pythonhosted.org/packages/cd/57/826848c90c049b39f231e2f2b408049b8069b4efa2753f47a1ff951600d5/pyobjc_framework_PhotosUI-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:afc8ecdaddaf184b220b784fe0ab74335207768511a9afe3bdaf1342e5911e6b", size = 8397 },
-    { url = "https://files.pythonhosted.org/packages/18/f5/694afc2ea709a3b2b3ecd0a52f9f1fdbe90301b9dd116a75076dcec918a8/pyobjc_framework_PhotosUI-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:a45eb45ab5a6115afd2dc6d68c4b3cc85c2a668b32f91ac2ccf399035a0cb571", size = 12279 },
+    { url = "https://files.pythonhosted.org/packages/94/ec/9574692e2852d546b28bac853b2b0584c4d4f093a4befac0e105789ee9f6/pyobjc_framework_PhotosUI-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b3865d2cc4fad4d34255941fe93ce504b9d2c7a7043bd0f4c715da9f4af1cf1", size = 12165 },
+    { url = "https://files.pythonhosted.org/packages/90/a9/85d70fe9eee0d15a0615a3f7b2ef92120c32614e350286d347d733fcf1d0/pyobjc_framework_PhotosUI-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:66826184121cd15415750d801160721adad80b53cbb315192522229b17252ebb", size = 12176 },
 ]
 
 [[package]]
 name = "pyobjc-framework-preferencepanes"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/63/d76bc32761d619cadb93fe37054c5f4f7d7e805b68e565170d5412452253/pyobjc_framework_preferencepanes-10.3.2.tar.gz", hash = "sha256:e1cee875450f43700cdfc47d6e9f636b82df31420a0bc29b213670a773225cd6", size = 25669 }
+sdist = { url = "https://files.pythonhosted.org/packages/35/01/81cc46e0a92d15f2b664b2efdcc8fd310acac570c9f63a99d446e0489784/pyobjc_framework_preferencepanes-11.0.tar.gz", hash = "sha256:ee000c351befeb81f4fa678ada85695ca4af07933b6bd9b1947164e16dd0b3e5", size = 26419 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/0a/2b0a8c01542d23e509be406bbdc33b79fc405c1484c637d0b46e55a8436e/pyobjc_framework_PreferencePanes-10.3.2-py2.py3-none-any.whl", hash = "sha256:3fdef9a7f8c4e0d3d63cd25879acaf9baf273a702734dd6a507eb8d892110794", size = 4384 },
-    { url = "https://files.pythonhosted.org/packages/6c/43/6e2b97312d15e375b16150dc31e1200b8efd54c4b69428aae58b58108c22/pyobjc_framework_PreferencePanes-10.3.2-py3-none-any.whl", hash = "sha256:e5a78d01706c23eaf90eea941cf10dfb01b4a53324a996561dba0b7db0587c5c", size = 4380 },
+    { url = "https://files.pythonhosted.org/packages/70/f7/5d0d9b94563ef06fe0a9c15ba2b77922b73bcc4b6630c487936edf382e20/pyobjc_framework_PreferencePanes-11.0-py2.py3-none-any.whl", hash = "sha256:2143851549430d6bb951adae44cb65c1986662ac7c8cbe15891ed194cbe283a2", size = 4706 },
+    { url = "https://files.pythonhosted.org/packages/9b/0e/76d694eea953b39318249ae24c956c3e115d8222343fb01f0186f7ca0043/pyobjc_framework_PreferencePanes-11.0-py3-none-any.whl", hash = "sha256:9f1287716374338fa99445ca13dfcc6c9be5597c8a5ce06680a8ca245b4e0acc", size = 4772 },
 ]
 
 [[package]]
 name = "pyobjc-framework-pushkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/41/8e9e021c0168e7c8460038bd3f3289232b1b9429c002bc981dbb8bba2a68/pyobjc_framework_pushkit-10.3.2.tar.gz", hash = "sha256:852e8a19424b8a83973f7c3f1ada325871ec2645071abf519712ead972dd0395", size = 19530 }
+sdist = { url = "https://files.pythonhosted.org/packages/17/ab/7fe55ce5b32c434142be026ec27b1801a2d4694b159b502f9ecd568eebf2/pyobjc_framework_pushkit-11.0.tar.gz", hash = "sha256:df9854ed4065c50022863b3c11c2a21c4279b36c2b5c8f08b834174aacb44e81", size = 20816 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/67/b8083c6f4565d2b3056c68381d5455bee293568561522883973d598881b1/pyobjc_framework_PushKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:9231a7b66cb672f26500fbe9a6f3cd251ff2ff3e4def001b9f153a524c1bbfbb", size = 8136 },
-    { url = "https://files.pythonhosted.org/packages/d0/ca/48ec49977623a24dbee4a8b0f6bfa5ea06e6c858300c772d285b9cb264c2/pyobjc_framework_PushKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:d254b0ddd529e38bbb43b487b3ab57c4e6ada810337a5c8459976998e421ede6", size = 8109 },
-    { url = "https://files.pythonhosted.org/packages/bc/92/9f266c225113a434a0e769da36c494a9d1fff47ca460edc6edc9db0c731b/pyobjc_framework_PushKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f7ddc930a2b9966793c6412b008a4b4eca39e8062a49ca5028de00b96b56376e", size = 5874 },
-    { url = "https://files.pythonhosted.org/packages/02/a0/12ded7d84cc40af56bc0880cc17a77c609ddcfd3c3523822d1f7ca27d46e/pyobjc_framework_PushKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:3ca308738b1b339873ca833678ea42b3a1b3b3f14c2e9f0d065e0156b00dfeea", size = 8578 },
+    { url = "https://files.pythonhosted.org/packages/17/5f/de178da22fa628cd88f599fea2a70b7d1d9ebc65576307df0bf29822a347/pyobjc_framework_PushKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0185cebcc5aad73aae50804c7a2412da6275717b8f872b830d71c484efcdea7a", size = 8010 },
+    { url = "https://files.pythonhosted.org/packages/5f/a5/60f93031302aba7cdff28728b8141b58c3bd5c12f4a6cef5796a8cc2e666/pyobjc_framework_PushKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:43bd1ed31664982e4d8397a7e07e58a7deb85bf9c9866ea966fd7ca25796014c", size = 8032 },
 ]
 
 [[package]]
 name = "pyobjc-framework-quartz"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/bd/d78c845a6f0640975e837d1d0f04d6bbd95bb88b77dcee22482144ac5ad0/pyobjc_framework_quartz-10.3.2.tar.gz", hash = "sha256:193e7752c93e2d1304f914e3a8c069f4b66de237376c5285ba7c72e9ee0e3b15", size = 3776754 }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ad/f00f3f53387c23bbf4e0bb1410e11978cbf87c82fa6baff0ee86f74c5fb6/pyobjc_framework_quartz-11.0.tar.gz", hash = "sha256:3205bf7795fb9ae34747f701486b3db6dfac71924894d1f372977c4d70c3c619", size = 3952463 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/0c/465bb4415be16d96106f972500bc0fba5cd8a64951e24b37467d331e68f7/pyobjc_framework_Quartz-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4697f3ef1991f7877c201778005dc4098ced3d19d938ebf916384c8f795488d3", size = 209298 },
-    { url = "https://files.pythonhosted.org/packages/ca/92/29f0726d1031f0958db7639ab25fd1d2591b2c0638f3a7ca771bbf2cceee/pyobjc_framework_Quartz-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:604188ee8ff051ffe74a12cb3274403fe9c3fa02b15fc4132685c0f74285ffe5", size = 209183 },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/68957c8c5e8f0128d4d419728bac397d48fa7ad7a66e82b70e64d129ffca/pyobjc_framework_Quartz-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d251696bfd8e8ef72fbc90eb29fec95cb9d1cc409008a183d5cc3246130ae8c2", size = 212349 },
+    { url = "https://files.pythonhosted.org/packages/60/5d/df827b78dcb5140652ad08af8038c9ddd7e01e6bdf84462bfee644e6e661/pyobjc_framework_Quartz-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cb4a9f2d9d580ea15e25e6b270f47681afb5689cafc9e25712445ce715bcd18e", size = 212061 },
 ]
 
 [[package]]
 name = "pyobjc-framework-quicklookthumbnailing"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/12/d8dc4cb3be565df9e245bf8b234a07a74aa7d0966e643e17a3ed2a645bc3/pyobjc_framework_quicklookthumbnailing-10.3.2.tar.gz", hash = "sha256:f6d35495fdad885ae928a074eb9b45d2f426cf161a557510db3fc1f872a76ad1", size = 15877 }
+sdist = { url = "https://files.pythonhosted.org/packages/50/a1/35ca40d2d4ab05acbc9766986d482482d466529003711c7b4e52a8df4935/pyobjc_framework_quicklookthumbnailing-11.0.tar.gz", hash = "sha256:40763284bd0f71e6a55803f5234ad9cd8e8dd3aaaf5e1fd204e6c952b3f3530d", size = 16784 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/f1/7bec1fb48497f98727a22e3750e21691dae8a00a121f1bccdae9a9463047/pyobjc_framework_QuickLookThumbnailing-10.3.2-py2.py3-none-any.whl", hash = "sha256:fa3f98ae2e014ea3afeac071aeb9eb29ee405d4bf122980de11de0b9ce18b908", size = 3812 },
-    { url = "https://files.pythonhosted.org/packages/07/31/45aa6af2ff642c19d8c189a5b7386ca837538fe72bda4f8bfdb4149edc3b/pyobjc_framework_QuickLookThumbnailing-10.3.2-py3-none-any.whl", hash = "sha256:9d6a7c7c733a447d8076813fdf68532e5b5d81d75af85cf64efa32b992d52dae", size = 3805 },
+    { url = "https://files.pythonhosted.org/packages/9d/85/1a66fefa99e7a4eb7534b2f56f9a24d33beda450dd2ca45d180307e76c74/pyobjc_framework_QuickLookThumbnailing-11.0-py2.py3-none-any.whl", hash = "sha256:6e567a764942845ce4db7ccfc0f8a9d091216bd029ecca955e618a43d64a5d84", size = 4164 },
+    { url = "https://files.pythonhosted.org/packages/05/d7/26decb13136b7c95a1ca3ecf202644ad2fd515a57e1117c71bfc86429b20/pyobjc_framework_QuickLookThumbnailing-11.0-py3-none-any.whl", hash = "sha256:e0f7f62b9a1df55e5f717518baf3260dc2cb8a9722cc5e9c6fffc643f69bda27", size = 4229 },
 ]
 
 [[package]]
 name = "pyobjc-framework-replaykit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/b1/b8539b171c6a335378928e077d5a8f05e97d43d459c4f1578cd7ed82ac83/pyobjc_framework_replaykit-10.3.2.tar.gz", hash = "sha256:05c15651ad4051037e7647b04e0304b288fa4663ab182d5848958a33a3b6c136", size = 23771 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/43/c751c517dbb8ee599a31e59832c01080473c7964b6996ca29906f46c0967/pyobjc_framework_replaykit-11.0.tar.gz", hash = "sha256:e5693589423eb9ad99d63a7395169f97b484a58108321877b0fc27c748344593", size = 25589 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/aa/59e930709f3e1ec0d1843cceb11c9f76ecd4760868563fe808fe94a00615/pyobjc_framework_ReplayKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:fbcfae19fbd4f066c1135baf07c0513b6edd8b4392a3b18b44e31567f63e35a4", size = 9456 },
-    { url = "https://files.pythonhosted.org/packages/21/06/cf598b30960b5fee4189c83348df62152aad7d9625a33134844b4013f81c/pyobjc_framework_ReplayKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:31aca6e24618d0c65bbaa4e51fbcdcf41d55287e2ebd549fd91c8e9f1f02a83c", size = 9440 },
-    { url = "https://files.pythonhosted.org/packages/7c/1b/0951dd465b3bc7ffd43c8a935abe92137bef71a1c0a74cf717fc7cc039e4/pyobjc_framework_ReplayKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:872cf7f8c86a393b2f5ee90e34732a6a026e3b6f9f76195ab9691954b7a3de79", size = 7040 },
-    { url = "https://files.pythonhosted.org/packages/87/8d/8173d946668af4103648d39d4229b6eaba7a0eda44a6ac294046d6cbc70b/pyobjc_framework_ReplayKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:136373b12d38c497c6e2f4f8b1f6bd66b2c534903475f07d5ad3c9912659c757", size = 9900 },
+    { url = "https://files.pythonhosted.org/packages/fe/56/89a8544426a46bf176c9462511c08d4c94ae7e0403abb2d73632af68ee8e/pyobjc_framework_ReplayKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:262fb834400e8379f4c795e65137763348992f3010284602d876050b8adb9ea4", size = 9904 },
+    { url = "https://files.pythonhosted.org/packages/47/af/9abfa41060efc96000cc9ae77f302bb8210f3be0f793ba5d11f98a03e468/pyobjc_framework_ReplayKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:da9db123ee52761a670c6e41e5f9d9a47a2ca5582a9c4a7c8662a8bb56a0f593", size = 9903 },
 ]
 
 [[package]]
 name = "pyobjc-framework-safariservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/ae/b9a7063c6ecce49efe37298b0d80a00aeb51c7777898a574d78791181046/pyobjc_framework_safariservices-10.3.2.tar.gz", hash = "sha256:3601d177ac3900c681a1dd77a3dab28341c40705572006f3fe7834c9890bb708", size = 29867 }
+sdist = { url = "https://files.pythonhosted.org/packages/40/ec/c9a97b1aa713145cc8c522c4146af06b293cfe1a959a03ee91007949533b/pyobjc_framework_safariservices-11.0.tar.gz", hash = "sha256:dba416bd0ed5f4481bc400bf56ce57e982c19feaae94bc4eb75d8bda9af15b7e", size = 34367 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/b6/a9bf1642528f19f0a4c48696e92adcb969d6e04bb6051228ad71da928f0e/pyobjc_framework_SafariServices-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:afd1cce5f71f1d9c91c092c86e2d0b48fbfdc27793c8aab0222aa727e2440f10", size = 7373 },
-    { url = "https://files.pythonhosted.org/packages/d5/74/ffdefe977900ad26c494cf7a5ee0ac1ff4164ca10f7f20baf2308450bfd6/pyobjc_framework_SafariServices-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4927005cf9da3e270cb465d98a0178e025f224daaeabd7b119cb4994c2cb8eb7", size = 7371 },
-    { url = "https://files.pythonhosted.org/packages/2b/a8/6249178c2fe9ece375f782b4a0f6c1361e23d5115286b195bd69c4948fb5/pyobjc_framework_SafariServices-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:085c78a57fcf98675f48624c4a8d62a2a97681233d7bd003c914a091b8893b72", size = 5869 },
-    { url = "https://files.pythonhosted.org/packages/24/5f/e9efc48646ea1a3d589c26e2a397cc76fb587b97c39414a32ebf294eb05c/pyobjc_framework_SafariServices-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:6e4ffcbfe31dfb553bb061d1dffdfa551069ef37595d4d663943a2a57cc651f7", size = 7453 },
+    { url = "https://files.pythonhosted.org/packages/40/39/d69f8e7dbf6f366cb5fdaa8aa7ceef1dadb93a5e4d9fc63217477bba5e32/pyobjc_framework_SafariServices-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:55c02a533073e0a2aaf6db544f087fd861bace6b62035c3bb2e6b20f0b921b2b", size = 7262 },
+    { url = "https://files.pythonhosted.org/packages/36/76/a625330bdf7a5d9962299562b6e19f6cbd1ea1b14887958e42a4372d3344/pyobjc_framework_SafariServices-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:31ba086a39ee06d8622a504e3ea3a1f6dc8fab1d4c4c7930d5af6e989f38ec56", size = 7262 },
 ]
 
 [[package]]
 name = "pyobjc-framework-safetykit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/b3/b5fa5d14cc95c52a67b3e676a8badc671057bd3b483dcd2dd37b37bc9c2b/pyobjc_framework_safetykit-10.3.2.tar.gz", hash = "sha256:d6902abba592532ae7c4864d16df9cb88dab2451e9fcecaa48b5e01948dd84fd", size = 19392 }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/30/89bfdbdca93e57b19891ddeff1742b20a2019cdeb2e44902027dce2642e1/pyobjc_framework_safetykit-11.0.tar.gz", hash = "sha256:9ec996a6a8eecada4b9fd1138244bcffea96a37722531f0ec16566049dfd4cdb", size = 20745 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/f2/abffc58ec75a3426722601acaae5315077b201e595ef849c46e659755e2e/pyobjc_framework_SafetyKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c49962f2d082558561750f46b776433dd53828835ebd9a8a5bb0f6069b0b9c8c", size = 7945 },
-    { url = "https://files.pythonhosted.org/packages/3f/04/ae861242521826bb8bb4585ce05050aeb26bfd8ecb4d2748204cf968111f/pyobjc_framework_SafetyKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9c2d51465702538e141b44822bc729d8f5f74b03c949bd998a123173f33753a0", size = 7916 },
-    { url = "https://files.pythonhosted.org/packages/d6/cb/e2227d08b809e71a59f28a8af9008845caca5c2d4a269b84a4f77af68617/pyobjc_framework_SafetyKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:04dd10134b8ead357d8f1cbbd643cd0fc81faf1b78c9825a45f9d2cde87c7edd", size = 5818 },
-    { url = "https://files.pythonhosted.org/packages/b4/d0/b3cd5cb3c8f71f392a43dfe74a9088b13dcd3dbacbdbad6f4a89fefb39fd/pyobjc_framework_SafetyKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:7dc3810c60614499da7afe460fe779f5b1c5c70ba22076760fdc9706ee52efc4", size = 8238 },
+    { url = "https://files.pythonhosted.org/packages/37/c5/68b79c0f128eb735397aa68a40e5ac48b88c12967f69358f25f753a3fc1c/pyobjc_framework_SafetyKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:83a1f313c9c63ba107a7c543a8300ae225fa5ff17d963b1c499859da45ceaf55", size = 8395 },
+    { url = "https://files.pythonhosted.org/packages/99/02/2853a00e75cca8db8b5053ff2648ff2a26f5c02f07af1c70630a36b58d04/pyobjc_framework_SafetyKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c6dd23fcaca9c41d6aadf2ca0a6d07c4032a0c4ea8873ee06da6efd1e868f97e", size = 8418 },
 ]
 
 [[package]]
 name = "pyobjc-framework-scenekit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/60/9140bd2f59c00c05a549cad6f6ef303d1ea12bf39ac70cfd9c244ed775a9/pyobjc_framework_scenekit-10.3.2.tar.gz", hash = "sha256:451b02c3b58f78adeb06239f9e4d2ac8545277056e5945eca3592b04c5f3ed67", size = 155651 }
+sdist = { url = "https://files.pythonhosted.org/packages/26/3f/a2761585399e752bce8275c9d56990d4b83e57b13d06dd98335891176a89/pyobjc_framework_scenekit-11.0.tar.gz", hash = "sha256:c0f37019f8de2a583f66e6d14dfd4ae23c8d8703e93f61c1c91728a21f62cd26", size = 213647 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/f1/7045b96b6e13dc3c85852b104dfe4aa8af220032639536cea7cfcfc822c2/pyobjc_framework_SceneKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:9a344a455136e186c9ecd92cc195aa64b41e9686db1890ae646499e654589c21", size = 32468 },
-    { url = "https://files.pythonhosted.org/packages/ed/73/56b9b0a58b3b71cd2478bbc7b6abdbcaf14fde59874b77cceec10b5cadf1/pyobjc_framework_SceneKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:0984cd93e2cd2aabcd4b259a15dc24c17d39e195bfb7ede060f5fc21cec680a8", size = 32466 },
-    { url = "https://files.pythonhosted.org/packages/8c/a0/baf35780cdefcda65b0f7d730bb1ec18f9378dee93824baa5d81313a6cb3/pyobjc_framework_SceneKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8fbec8b31375bcf3b146198abaece8cfe6bbbffab642c013dfb4ba0092ae208f", size = 22074 },
-    { url = "https://files.pythonhosted.org/packages/f2/41/ea3461de6bad2004ac4e5ba332dc7fd2de2bc5e01caf5b3014e31a11844d/pyobjc_framework_SceneKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:4eee24aca5fa88d7a5dc7cfd2f3dfcbf215556fc633ae67ac3c68da9e8a805a5", size = 32591 },
+    { url = "https://files.pythonhosted.org/packages/aa/4c/5ec624ae043fbbe15be2a989e3fc6cb08d992e0a5061450b84b33f96429c/pyobjc_framework_SceneKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:86d23456e4c7a7bb7bb49be2b98647678ac7a39955e6bb242e0ac125d8b770e8", size = 33108 },
+    { url = "https://files.pythonhosted.org/packages/b8/7f/fef1cf3eaf1366a6f3f93c5a6b164acfdfdc2d15b3243b70763ac217ce03/pyobjc_framework_SceneKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d0a0d557167adddf27a42fb109a1dce29a22ff09aca34558fccd1c22f08ae2b4", size = 33130 },
 ]
 
 [[package]]
 name = "pyobjc-framework-screencapturekit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-coremedia" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/f6/0f9a509f86d5b876ebdbcf4b96a01a824ecdaf4f3e8ff9516f7e7c13abc9/pyobjc_framework_screencapturekit-10.3.2.tar.gz", hash = "sha256:948d6663243e141acfc4ea1499f4690e5ec51d9cad9db843d5450548a2a7028f", size = 35192 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/90/71f10db2f52ea324f82eaccc959442c43d21778cc5b1294c29e1942e635c/pyobjc_framework_screencapturekit-11.0.tar.gz", hash = "sha256:ca2c960e28216e56f33e4ca9b9b1eda12d9c17b719bae727181e8b96f0314c4b", size = 53046 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/2a/41de89612952e64e3c9eee4334675d8155f3bde562d262047a844689b4c0/pyobjc_framework_ScreenCaptureKit-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:050f322024ea3c19c46068a8a994eb39f70b349efb43fbe2512484a09923fbb9", size = 10613 },
-    { url = "https://files.pythonhosted.org/packages/55/7e/56d2350e1068f1a7b57c3548da2bcec4d2151f1c52cb276e3e1bf097b3f9/pyobjc_framework_ScreenCaptureKit-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d835c7cb37ae009240934cb15d9a11320031c4f2b15a15f265da684433fb6a6d", size = 10655 },
+    { url = "https://files.pythonhosted.org/packages/af/aa/d6d0818564570065411874cbe3de86dee105dc9906161c0584009a1a63bc/pyobjc_framework_ScreenCaptureKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:38468e833ec1498778bd33ce30578afed2e13ac14c73e8e6290ff06a2e0c50d8", size = 11110 },
+    { url = "https://files.pythonhosted.org/packages/27/61/557e725aef9ad76a1a7c48b361f8c5636a606cbaf9ba520ff8f69d3cf791/pyobjc_framework_ScreenCaptureKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7d8a83dcc0950699242677cfefda545b9c0a0567111f8f3d3df1cf6ed75ea480", size = 11121 },
 ]
 
 [[package]]
 name = "pyobjc-framework-screensaver"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/7f/b4472750bc0f66b6b43ae462e2bfccc113fa135780ab9b4e43e648f19a51/pyobjc_framework_screensaver-10.3.2.tar.gz", hash = "sha256:2e0bc1406848607931123b87a59235712c40d362247be6c0c0746b26a4bd8e5f", size = 22469 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b6/71c20259a1bfffcb5103be62564006b1bbc21f80180658101e2370683bcb/pyobjc_framework_screensaver-11.0.tar.gz", hash = "sha256:2e4c643624cc0cffeafc535c43faf5f8de8be030307fa8a5bea257845e8af474", size = 23774 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/e2/4e249dcec82b09bccf1377bd9f03b57d9e26ef691bd64e2db3dfdd2c108e/pyobjc_framework_ScreenSaver-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:8cee3c2f9d57ad208fe43e4c8bfa90530ab90de876dad75b787185e2c6a3db5f", size = 7936 },
-    { url = "https://files.pythonhosted.org/packages/15/ca/29f190e05f8176715c6cf40bff362ff8bd54e80a68de6c99c4f930481e5f/pyobjc_framework_ScreenSaver-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:bbcea74b13915adee1c96e9b78b27ec6c5e1130eea3ce6babd8ca4ce9cfa1ff5", size = 8013 },
-    { url = "https://files.pythonhosted.org/packages/9a/07/36d055c00a729fb0ba25540ec378ef0f3b634199ce301d2c74407ccebd94/pyobjc_framework_ScreenSaver-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2e29925bd49a0a8d5494197110a3c0464e4d4201991dbc3f735a668de25a3f9", size = 6150 },
-    { url = "https://files.pythonhosted.org/packages/8e/45/26d4d3172b3243bdf3c96cc16789d1e52944a1f1234324b05eab58558322/pyobjc_framework_ScreenSaver-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:ff407e1550771ba147e2285d46c8725f6f0433f62e40f3a33b4f3b98fdcc840d", size = 7996 },
+    { url = "https://files.pythonhosted.org/packages/d7/ab/f17cd36458e6cf6d64c412128641edcfc220b8147283f6b34ef56c7db111/pyobjc_framework_ScreenSaver-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:436357c822d87220df64912da04b421e82a5e1e6464d48f2dbccc69529d19cd3", size = 8445 },
+    { url = "https://files.pythonhosted.org/packages/52/57/300b641e929741a5d38cf80c74496918be1d2fe5e210d3fceb3e768747b2/pyobjc_framework_ScreenSaver-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:03b12e89bc164cb01527ca795f3f590f286d15de6ee0e4ff1d36705740d6d72f", size = 8372 },
 ]
 
 [[package]]
 name = "pyobjc-framework-screentime"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/50/6189139ea6736443f8b9f3ff6b776b62070b967965c4292d60e121884fed/pyobjc_framework_screentime-10.3.2.tar.gz", hash = "sha256:1f57188ea57d71204a65e1f342ed34128704bcee3ff7d8566f503d87b779e902", size = 13688 }
+sdist = { url = "https://files.pythonhosted.org/packages/42/a7/ee60ee5b0471a4367eaa1c8a243418874fd48fac5dbdfdd318a653d94aaa/pyobjc_framework_screentime-11.0.tar.gz", hash = "sha256:6dd74dc64be1865346fcff63b8849253697f7ac68d83ee2708019cf3852c1cd7", size = 14398 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/fb/1801ac9b9209e71dc46248c73145800a5adf82581979c9819e0283d79318/pyobjc_framework_ScreenTime-10.3.2-py2.py3-none-any.whl", hash = "sha256:5b56da2b391ad73ca31a29439637b911b49424d7c6194138de45a3242313b53a", size = 3404 },
-    { url = "https://files.pythonhosted.org/packages/b3/bd/6dab7269cd3e7ac2440c6afdf42b018a3abb8e0a06e4cbec3c3a419a53e3/pyobjc_framework_ScreenTime-10.3.2-py3-none-any.whl", hash = "sha256:e6667965389139f8abbbf85759de6bf11ffa8c95fb8b2dd767f80d56f7deb8ac", size = 3399 },
+    { url = "https://files.pythonhosted.org/packages/40/7a/8df61f80725e993fd0dc1a111217de6a8efec35b02a4796749de0b7e8c34/pyobjc_framework_ScreenTime-11.0-py2.py3-none-any.whl", hash = "sha256:723938c7d47e3c5c1c0f79010a01139762384bd0c03c51ee7a4736fc3f128fed", size = 3721 },
+    { url = "https://files.pythonhosted.org/packages/c4/62/2f86cedd4cc439625976848832c1d1571fcb69cc087dd71c9cf09e793db5/pyobjc_framework_ScreenTime-11.0-py3-none-any.whl", hash = "sha256:45db846ec9249cab90e86cbb31cf70e13800305b7c74819ab681a91854c91df2", size = 3790 },
 ]
 
 [[package]]
 name = "pyobjc-framework-scriptingbridge"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/0c/fff6cf7279cb78e8bd09a9a605d06f6e53a7d7d6b8a5c80f66477010d68b/pyobjc_framework_scriptingbridge-10.3.2.tar.gz", hash = "sha256:07655aff60a238fcf25918bd62fda007aef6076a92c47ea543dd71028e812a8c", size = 21176 }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f0/592af19047935e44c07ddd1eba4f05aa8eb460ee842f7d5d48501231cd69/pyobjc_framework_scriptingbridge-11.0.tar.gz", hash = "sha256:65e5edd0ea608ae7f01808b963dfa25743315f563705d75c493c2fa7032f88cc", size = 22626 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/a2/12a2444f9ee7554e6a8b1b038dea9dbc2c3e4c3f9f50ec6c1b9726e4c3b2/pyobjc_framework_ScriptingBridge-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:f045ba439b8ba13febb76254c5a21ba9f76c82a0e27f0f414b5f782625f2e46f", size = 8318 },
-    { url = "https://files.pythonhosted.org/packages/9b/1c/6654a91890627904f68c75d796d13e241f71a5b868f68adc36ec92662f6b/pyobjc_framework_ScriptingBridge-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9223cd568170f6842df6bdf2d6719a3719b977e91a8d8e531d1a1eb0ef45c302", size = 8299 },
-    { url = "https://files.pythonhosted.org/packages/47/23/222e3b61927366ba94c3ba591b96b13f07f4b4cc52fc0b3588c822332164/pyobjc_framework_ScriptingBridge-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:dc4db637b1422c47b8aa4d33319f216de116832ef16fe1195e84e6fb7ca8f732", size = 6451 },
-    { url = "https://files.pythonhosted.org/packages/ed/aa/96bb253340c58403904089ff0235da77970ec816337706701456241f95ac/pyobjc_framework_ScriptingBridge-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:0d99ba4d7ed9a538b666f3aa81bd94b298f6663361dc3bccfe2718d9e28f1a2c", size = 8480 },
+    { url = "https://files.pythonhosted.org/packages/7d/2c/2fd33c0318a8fe35f00f0089a44a2c27d4d0fd0b4b5e13628051a4d8c9d3/pyobjc_framework_ScriptingBridge-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c98d080446aa8ba4074e43eb0be1feed96781dbc0718496f172fcd20e84a9158", size = 8209 },
+    { url = "https://files.pythonhosted.org/packages/93/3b/b2b721248e951eef6b7e6b25cb3a1d6683702235bc73683d0239f068d2df/pyobjc_framework_ScriptingBridge-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:23a4b2e2e57b7b4d992777ea9efb15273ccd8e8105385143dab9bd5a10962317", size = 8238 },
 ]
 
 [[package]]
 name = "pyobjc-framework-searchkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-coreservices" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/6a/586d7534ef7dd9277297d25ef96e96da5ee701cdaad1d4039c3f9219c1ae/pyobjc_framework_searchkit-10.3.2.tar.gz", hash = "sha256:1acaf21339e6583e901535f82271578b43ec44797b9b1293a3b7692deca3d704", size = 30823 }
+sdist = { url = "https://files.pythonhosted.org/packages/15/27/9676327cf7d13346d546325b411a5deaa072bd0fbe733c8aae8a9a00c0e0/pyobjc_framework_searchkit-11.0.tar.gz", hash = "sha256:36f3109e74bc5e6fab60c02be804d5ed1c511ad51ea0d597a6c6a9653573ddf5", size = 31182 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/2d/4110a048d6a2625547d133084ab2cb564d9f9720d0fdabdc337e67b383ad/pyobjc_framework_SearchKit-10.3.2-py2.py3-none-any.whl", hash = "sha256:e0d80867d2367b6c1b0367b9f5cb8295284608c5a589f85c0ce3479593918479", size = 3325 },
-    { url = "https://files.pythonhosted.org/packages/45/61/cb4a0a1674e6ad587a6e28232192a38bd9a4bb39715ade068d434503ffea/pyobjc_framework_SearchKit-10.3.2-py3-none-any.whl", hash = "sha256:516f460aba35be34da0c216be8e3ebb34a67dfe198d251ff11c800fa981fbf96", size = 3320 },
+    { url = "https://files.pythonhosted.org/packages/f2/d4/64fa608b5d91859b11c26ceca83a41d2bf1d0dcbf1d9df847bab5a52ccc8/pyobjc_framework_SearchKit-11.0-py2.py3-none-any.whl", hash = "sha256:332f9d30ec3b223efaac681fbdd923ba660575e241abb4ed5e03207c97799530", size = 3633 },
+    { url = "https://files.pythonhosted.org/packages/93/e2/83e94c505c5436821982d724cc890f74d717f9473782f7278ce78634685d/pyobjc_framework_SearchKit-11.0-py3-none-any.whl", hash = "sha256:5f4304cb77c327b28ac0f7ec9b99313075afd742091d39368eb64f076bb7d141", size = 3699 },
 ]
 
 [[package]]
 name = "pyobjc-framework-security"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/08/bbbfa295aef75986d7204ba3d856b26779d9eb2d0efbdcce2ddcb468d9b9/pyobjc_framework_security-10.3.2.tar.gz", hash = "sha256:8e018ad36a5ba4ebf1da45cc3ca2a658906ed1e3f9ffdde8f743c813a233d735", size = 252834 }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/75/4b916bff8c650e387077a35916b7a7d331d5ff03bed7275099d96dcc6cd9/pyobjc_framework_security-11.0.tar.gz", hash = "sha256:ac078bb9cc6762d6f0f25f68325dcd7fe77acdd8c364bf4378868493f06a0758", size = 347059 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/ee/ee20b313ee18094424e4f3064eac99f234e4440da0c8198dd49335facd13/pyobjc_framework_Security-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9b4505472e21d18f1cebfc773c2148efc6446d62389304330fd7f7f5b30eea97", size = 40779 },
-    { url = "https://files.pythonhosted.org/packages/af/b2/99d5e08eafd89750d81d36201dd8faeb3c5880dd1241b070084675486ef9/pyobjc_framework_Security-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2fae458eaa4263c3daf8a12ad62a92bc14be32ed251dcaa95d2caca324520036", size = 40832 },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/092940f8c46cf09000a9d026e9854772846d5335e3e8a44d0a81aa1f359e/pyobjc_framework_Security-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:93bc23630563de2551ac49048af010ac9cb40f927cc25c898b7cc48550ccd526", size = 41499 },
+    { url = "https://files.pythonhosted.org/packages/0b/fc/8710bbe80b825c97ecc312aaead3b0f606a23b62b895f6e0a07df8bfeeae/pyobjc_framework_Security-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:421e03b8560ed296a7f5ee67f42f5f978f8c7959d65c8fec99cd77dc65786355", size = 41523 },
 ]
 
 [[package]]
 name = "pyobjc-framework-securityfoundation"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-security" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/3f/0b46d29ef0075c27f48288da2daaca83cf3707a922a0fd9051e111045a42/pyobjc_framework_securityfoundation-10.3.2.tar.gz", hash = "sha256:738e8034f7c7a91f37e6e5b0bc94d9d74ad8016c96508994fdc4d76915d76fc4", size = 12907 }
+sdist = { url = "https://files.pythonhosted.org/packages/84/d6/0d817edb11d2bdb0f536059e913191e587f1984e39397bb3341209d92c21/pyobjc_framework_securityfoundation-11.0.tar.gz", hash = "sha256:5ae906ded5dd40046c013a7e0c1f59416abafb4b72bc947b6cd259749745e637", size = 13526 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/0f/acb4eced9fec6d7f4c72dc7849318e33c52805f49f203f1398feb11883ae/pyobjc_framework_SecurityFoundation-10.3.2-py2.py3-none-any.whl", hash = "sha256:c1d2e04a0f7cf96c2e0b8287c7a626fa8f4d1f70990593d33dbfc6ec20bbff0f", size = 3388 },
-    { url = "https://files.pythonhosted.org/packages/a7/b5/0776c9515726b47d71a001e73b9771fe8353d2fd21f4af7a54c077752b8c/pyobjc_framework_SecurityFoundation-10.3.2-py3-none-any.whl", hash = "sha256:f518c3f6221d93a4e8880547fda6d4642be20076c683a5118b6707e97f4b06ce", size = 3383 },
+    { url = "https://files.pythonhosted.org/packages/f8/41/50da30e87841c8b9ee1f17e9720dc9dbb2c2e59abac84fffe899ed5f9188/pyobjc_framework_SecurityFoundation-11.0-py2.py3-none-any.whl", hash = "sha256:8f8e43b91ae7cb45f3251c14c0c6caf5fdcdb93794176c4b118214a108ee2ef3", size = 3716 },
+    { url = "https://files.pythonhosted.org/packages/cb/61/e73a61de62e31b33378ee635534228f4801b1554fbd89a47e0b36965908d/pyobjc_framework_SecurityFoundation-11.0-py3-none-any.whl", hash = "sha256:1fa89969fbf7a4fd57214388a43f7ed6b6b1fd0c0ec7aa77752444eb1604143c", size = 3787 },
 ]
 
 [[package]]
 name = "pyobjc-framework-securityinterface"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-security" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/ea/1dfdf32ab13daa11f99d33ce62cc99076a6162dd4175442675f01711dbd2/pyobjc_framework_securityinterface-10.3.2.tar.gz", hash = "sha256:9d90589f165b2c4fb8c252179f5c0003c8ee6df22d0ead2b8f77e07ff4733dfe", size = 32274 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/88/d7c4942650707fe5b1d3b45b42684f58f2cab7d2772ec74ca96ecef575eb/pyobjc_framework_securityinterface-11.0.tar.gz", hash = "sha256:8843a27cf30a8e4dd6e2cb7702a6d65ad4222429f0ccc6c062537af4683b1c08", size = 37118 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5c/0c805ed633823e0eaf8581718ab527665f63ee4588ac18dfc22d912db8d5/pyobjc_framework_SecurityInterface-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:4cd7207a47490a04f309463cad285209e53f322a2a6819e87c1b1f5ecc2ea831", size = 10682 },
-    { url = "https://files.pythonhosted.org/packages/9d/39/966d55400afd8ef27b6a4ed753b853a5460b0703beacf2f05b5c7be45d4f/pyobjc_framework_SecurityInterface-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c5b709804645b3dfc5a2b5c13ee350cd0c3e7a2bd47fd66d4b638b52801f597a", size = 10634 },
-    { url = "https://files.pythonhosted.org/packages/52/bf/38d9222b20c97ed6f94d0451297da82066ef3d3bcfd3701be9f8fe17bfc4/pyobjc_framework_SecurityInterface-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:94a7b6fcac0ab9dd6e53a526633c1698f17e39f80d6e4727e5b5866288912763", size = 7432 },
-    { url = "https://files.pythonhosted.org/packages/58/57/7d343e70f9ac8841f8fcaa549baa7256d919b91ad9002b17bf435da160a2/pyobjc_framework_SecurityInterface-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:d7e415b53d6cc5f62543546948a18e1f85a0cf77258a0f9065a563c6f1fa0ea9", size = 10776 },
+    { url = "https://files.pythonhosted.org/packages/88/5f/a96da5f43da5a9d0e5d016bc672a4dca09f88d091c96d9ecff5f753ad1d5/pyobjc_framework_SecurityInterface-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2771dae043c8aa278887f96c7d206957164c7a81a562fa391bf0b9316d6755eb", size = 10706 },
+    { url = "https://files.pythonhosted.org/packages/50/86/fc41dcf8f5300ad2c6508568535d9c0a83b412b0a4a961616441c8acf10f/pyobjc_framework_SecurityInterface-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6453732f7608d514e8f7005d80d238422cbebc4ab4d6d6fed1e51175f9f7244f", size = 10781 },
 ]
 
 [[package]]
 name = "pyobjc-framework-sensitivecontentanalysis"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/c0/b23985c0a71168317a15c3b440cf02b3f546d8248b3d82cb9f13b4fe2b5e/pyobjc_framework_sensitivecontentanalysis-10.3.2.tar.gz", hash = "sha256:561c0b19144648a0dab19da1896cbdfbf484f3cb752e95aa42e27ff7c5da923b", size = 12323 }
+sdist = { url = "https://files.pythonhosted.org/packages/00/e4/f1e0f150ae6c6ad7dde9b248f34f324f4f8b1c42260dbf62420f80d79ba9/pyobjc_framework_sensitivecontentanalysis-11.0.tar.gz", hash = "sha256:0f09034688f894c0f4409c16adaf857d78714d55472de4aa2ac40fbd7ba233d6", size = 13060 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/82/aa5693d5b6e2dceb98d4ca4c50042800fcd11f51ff999f4ed772f7b627b6/pyobjc_framework_SensitiveContentAnalysis-10.3.2-py2.py3-none-any.whl", hash = "sha256:1c31183ca67bda6c5b1982b094d2aea35deac13260d586238cebe26db5d755fa", size = 3447 },
-    { url = "https://files.pythonhosted.org/packages/fd/fc/c173077c769011c0204f6030da75ff6b80b4fda3b82666e412a45e2f683d/pyobjc_framework_SensitiveContentAnalysis-10.3.2-py3-none-any.whl", hash = "sha256:8d0e4bf06939706d48a6d24b326c9d388e943a3988f97df0591ecd5f575047d7", size = 3441 },
+    { url = "https://files.pythonhosted.org/packages/3d/eb/e0d60b3e233860a237fdddd44ab961c9115c33e947058d73c222dafc50af/pyobjc_framework_SensitiveContentAnalysis-11.0-py2.py3-none-any.whl", hash = "sha256:e19d2edc807f98aef31fa4db5472a509cf90523436c971d1095a000b0e357058", size = 3791 },
+    { url = "https://files.pythonhosted.org/packages/c4/1c/fb2138cf08cd0215ea4f78032871a1d89e7e41d9fad18b55e937f0577c03/pyobjc_framework_SensitiveContentAnalysis-11.0-py3-none-any.whl", hash = "sha256:027bd0be0785f7aea3bfd56ff7c3496e5d383211122393c599c28ea392675589", size = 3863 },
 ]
 
 [[package]]
 name = "pyobjc-framework-servicemanagement"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/d1/06333ad3eb0fd5f7f2f34d9f3c48f81c1732aa66f7d97c63899c7832fbc3/pyobjc_framework_servicemanagement-10.3.2.tar.gz", hash = "sha256:60415ce7ce789062a1bb066a1e698325cc110fcab94324368f1697cb171387e5", size = 16076 }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/59/8d38b5cdbcfb57ab842e080436dbd04d5a5d2080e99a2ea1e286cfad12a8/pyobjc_framework_servicemanagement-11.0.tar.gz", hash = "sha256:10b1bbcee3de5bb2b9fc3d6763eb682b7a1d9ddd4bd2c882fece62783cb17885", size = 16882 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/49/f6d2e07a8876c3bbe1bef26e3e69738214a18945546db4dc2ae9259ef77a/pyobjc_framework_ServiceManagement-10.3.2-py2.py3-none-any.whl", hash = "sha256:cd5e5e0e461550bb7c9ddb7170372530eb3a391c7ba797675be86f87fbd062b3", size = 4930 },
-    { url = "https://files.pythonhosted.org/packages/db/e2/6128e99978d7e81b03162f06338ebd831ac579ead7065daa527cdb6a0317/pyobjc_framework_ServiceManagement-10.3.2-py3-none-any.whl", hash = "sha256:c7b4ff6cddc0ad2ff229432cddb77bf19cfba70296f54928c8004b87040d4255", size = 4926 },
+    { url = "https://files.pythonhosted.org/packages/5b/35/cbac7db272d0e5e71b300be1517b0a1dc7cf035944675eaed7066d41e883/pyobjc_framework_ServiceManagement-11.0-py2.py3-none-any.whl", hash = "sha256:35cfd7a369a120fa55e64b719a2dda00295b2cc6ddab16ffa8939f4326d1b37d", size = 5254 },
+    { url = "https://files.pythonhosted.org/packages/b3/40/26c5d63d131e3e415815bfbb4bd035ba10d45f0d87733646221966871b6b/pyobjc_framework_ServiceManagement-11.0-py3-none-any.whl", hash = "sha256:7ec19c9632f67d589ad37815d001e8e443d92e75001c370486a1070a4359e166", size = 5322 },
 ]
 
 [[package]]
 name = "pyobjc-framework-sharedwithyou"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-sharedwithyoucore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/21/4b28cac56c3637a942c8ad70490fc48586fbfbc503088594b0110325b116/pyobjc_framework_sharedwithyou-10.3.2.tar.gz", hash = "sha256:2a2717f85b7a8db33ef04dc90dfdfcb9f6891740112bdcd739a7d5ff37185107", size = 28260 }
+sdist = { url = "https://files.pythonhosted.org/packages/20/84/db667061f815537717a6cac891df01a45b65e6feaa2dfa0c9d2e3803a1ef/pyobjc_framework_sharedwithyou-11.0.tar.gz", hash = "sha256:a3a03daac77ad7364ed22109ca90c6cd2dcb7611a96cbdf37d30543ef1579399", size = 33696 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/29/9f12d223d61b8e5fdbb95c37d80cb2496788e0c012082a99ac2d782d87c5/pyobjc_framework_SharedWithYou-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:d94d88115fac7a200fb36c7d4eff8960f3b0663074e290d096b92b7aababa66f", size = 8708 },
-    { url = "https://files.pythonhosted.org/packages/45/7c/4451b22a26c0aed24f3bd42cc6d489827c2172f359bda13b69c6959b30df/pyobjc_framework_SharedWithYou-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3bab53551624aa7921deacf0ed7c107a6c4eb247a9aec6dde0e0bf819d39e955", size = 8689 },
-    { url = "https://files.pythonhosted.org/packages/3f/bc/fe41bdc5303f31b2aeec22d3e876bcf93f2733ed13d07732e3d53d6ed845/pyobjc_framework_SharedWithYou-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:89728935f8382691082a398f3308ca4401125718f1a5a8600face26ccf7f0f6a", size = 6496 },
-    { url = "https://files.pythonhosted.org/packages/b1/96/08aa3df73accc42a9da5e585e831f03bf6a36ded8fd8070b040f3d3a176a/pyobjc_framework_SharedWithYou-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:a1af4e482dfa4d4365e8e9cab0bf13bd9b3da95809684c31ed76a96e637ad439", size = 9034 },
+    { url = "https://files.pythonhosted.org/packages/3c/ab/391ef0de3021997ec9a12d8044c0b7e884780a9bead7f847254e06d0f075/pyobjc_framework_SharedWithYou-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6dac74375d3dc18d67cae46f3f16a45cef699b1976a4012827c0f15256da55df", size = 8606 },
+    { url = "https://files.pythonhosted.org/packages/cf/04/6a3eb12bf9c35f3063be678f36430beb92b7e2683f4b952596396473a74d/pyobjc_framework_SharedWithYou-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6076a0893a3597e054918c136f3391671a225a37fe1b1a070046817e3a232954", size = 8629 },
 ]
 
 [[package]]
 name = "pyobjc-framework-sharedwithyoucore"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/8a/62a767e8e37faf7720ef0e9a0743bf6d0b5f0776813ab5a4d0fe7c4d5507/pyobjc_framework_sharedwithyoucore-10.3.2.tar.gz", hash = "sha256:8c877f0e4590da6c687cecabfd15ca5cab3ca82cf70c7d228473e02e0e796225", size = 24687 }
+sdist = { url = "https://files.pythonhosted.org/packages/52/2a/86904cd9cc3bf5cdb9101481e17e67358f39f81ffa0f36768097287e34b3/pyobjc_framework_sharedwithyoucore-11.0.tar.gz", hash = "sha256:3932452677df5d67ea27845ab26ccaaa1d1779196bf16b62c5655f13d822c82d", size = 28877 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/96/373a9b2cc73ce06a654e210bace0bb6a9318fc067dd0821a126fcb07d1b7/pyobjc_framework_SharedWithYouCore-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:3bbeba3bf8549d7a2515edb9fbe0f1e6f164717c746f301e16efa65acdb0d076", size = 8465 },
-    { url = "https://files.pythonhosted.org/packages/6f/8d/379db8a9c54058f0e326dfbfd9cf4e46ebe4fae7df6bc7a5a732016f5bc5/pyobjc_framework_SharedWithYouCore-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:34a1686e43a735c4ec7dafcd40894e8128d2ef878091cf1e33adbe70e5ae3f08", size = 8443 },
-    { url = "https://files.pythonhosted.org/packages/d1/56/5d93dc68a35656cb85068958a4c68c24cbbd4f8f525afea61f01e3b6e870/pyobjc_framework_SharedWithYouCore-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3e83e14e511de3cb347eebd17ace42a47cfb9b19432eef89dc40fcda6f3be6fa", size = 6224 },
-    { url = "https://files.pythonhosted.org/packages/76/21/c41e928af1f0a841af681cd2263d2c76fe6ee0e9742b249f6883c1ff4c49/pyobjc_framework_SharedWithYouCore-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:82117418a290198ab369da72051776440ce26ede46530c08af3ff2bee6459cc3", size = 8824 },
+    { url = "https://files.pythonhosted.org/packages/21/40/69ae712e223991cd975c1f8ba2b00a5aa4c129ac0e76838b4d936740e4c7/pyobjc_framework_SharedWithYouCore-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:46cd00a97c5fec747ef057000daa88495699ea5d5d6fe1f302bfb89b2d431645", size = 8366 },
+    { url = "https://files.pythonhosted.org/packages/c2/ce/500ad643f2d07e8ef065e8ddc5a08954f5d59cc199c89b700581eaf821ee/pyobjc_framework_SharedWithYouCore-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8b5f180371a63da718fe6c3b58e7613c6b2adf9b483cefbf6d9467eb8ac2f0ca", size = 8380 },
 ]
 
 [[package]]
 name = "pyobjc-framework-shazamkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/f3/8626b1f52c3c7665cb8f84966db045877456b9d9c55d9faa686cc773590b/pyobjc_framework_shazamkit-10.3.2.tar.gz", hash = "sha256:6158120a2d25b74a88c1ddc9d5f70df30ad4cd9c19b4f9db95434cc5fbb99f70", size = 23291 }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/2a/1f4ad92260860e500cb61119e8e7fe604b0788c32f5b00446b5a56705a2b/pyobjc_framework_shazamkit-11.0.tar.gz", hash = "sha256:cea736cefe90b6bb989d0a8abdc21ef4b3b431b27657abb09d6deb0b2c1bd37a", size = 25172 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/67/e240edb4005befd797b948c9b2416769991cbc5f45a65b3b7a3a86c10666/pyobjc_framework_ShazamKit-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aba33267e5624473fc4985ffbc10b74542694c0ec96050e69bf7afc25367a3e1", size = 8498 },
-    { url = "https://files.pythonhosted.org/packages/be/a5/1c74ed5f624b525988353a488eea817c14be391d910271b551b54d60a7a4/pyobjc_framework_ShazamKit-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e97ee0a5f00d3ff1ab22540049cf1facfd7c8eb550730d67b56b328672e9fb67", size = 8532 },
+    { url = "https://files.pythonhosted.org/packages/05/81/edfcd4be626aae356dd1b991f521eaeffa1798e91ddae9e7d9ae8ed371d1/pyobjc_framework_ShazamKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ecdc2392d7e8d6e2540c7ad3073a229d08b0818c5dd044a26c93b765ce9868aa", size = 8411 },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/f3d2ae7a604e3e3c0de93ed229895be6757edfa0cc76f2a44670f28a81c8/pyobjc_framework_ShazamKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ef79d863cc7d4023aa552f55d4120653eceed862baf1edba8e08b1af10fab036", size = 8419 },
 ]
 
 [[package]]
 name = "pyobjc-framework-social"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/6f/83f92ac162fbb14fef97f100da2ad35ed2ed5bff2cb864e59b34ab5608c8/pyobjc_framework_social-10.3.2.tar.gz", hash = "sha256:8d55fe68ea1dff205c6b10fd57b0ab8e8ff1b0801ae61fd358a1c97b1a88f733", size = 14063 }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/56/ed483f85105ef929241ab1a6ed3dbfd0be558bb900e36b274f997db9c869/pyobjc_framework_social-11.0.tar.gz", hash = "sha256:ccedd6eddb6744049467bce19b4ec4f0667ec60552731c02dcbfa8938a3ac798", size = 14806 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/b2/96baecef2802c20ab47bb74d9d27c9291c0600d4a5681af4a9b7bb69be27/pyobjc_framework_Social-10.3.2-py2.py3-none-any.whl", hash = "sha256:9a2cbb8a25f1923e867ead924d9252992109a8462272dba47c1097e1fae4a61b", size = 4065 },
-    { url = "https://files.pythonhosted.org/packages/ce/26/f25c19bc0d7f69992920b3c300384228cf476cc1703baa0db3ffd5ebd9a5/pyobjc_framework_Social-10.3.2-py3-none-any.whl", hash = "sha256:741e8017d737ae3288dc7b242238ab5248657f5f00c575f7e924b65c8bfbedec", size = 4060 },
+    { url = "https://files.pythonhosted.org/packages/46/1d/2cc0f753ac8b1f5c15cfa9201d8584ff4de6dc940fc954cd9c52d1a615f9/pyobjc_framework_Social-11.0-py2.py3-none-any.whl", hash = "sha256:aa379009738afb0d6abc0347e8189f7f316109e9dfcb904f7f14e6b7c3d5bad8", size = 4362 },
+    { url = "https://files.pythonhosted.org/packages/a8/25/b762b1f9429f8ea0df754e7d58bafd48d73e5527b0423e67570661a7907e/pyobjc_framework_Social-11.0-py3-none-any.whl", hash = "sha256:94db183e8b3ad21272a1ba24e9cda763d603c6021fd80a96d00ce78b6b94e1c2", size = 4428 },
 ]
 
 [[package]]
 name = "pyobjc-framework-soundanalysis"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/99/52fead19bfc957466758e76f540c3bced518958f64cc73c6f34b6b21e856/pyobjc_framework_soundanalysis-10.3.2.tar.gz", hash = "sha256:3e5326c40b62238d448da9d52c78b22a659a1ec00eeed4358f58d5dc6758b2aa", size = 15900 }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/14/697ca1b76228a96bb459f3cf43234798b05fdf11691202449d98d9d887af/pyobjc_framework_soundanalysis-11.0.tar.gz", hash = "sha256:f541fcd04ec5d7528dd2ae2d873a92a3092e87fb70b8df229c79defb4d807d1a", size = 16789 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/c1/94e0d04655e4d02f7b3cb3590dbfe5ec85018df85400a7bd3b3d67585e18/pyobjc_framework_SoundAnalysis-10.3.2-py2.py3-none-any.whl", hash = "sha256:8d654057428004c6ffeccc92e663560a544dc1a8b4234c404af089c55e1ad803", size = 3791 },
-    { url = "https://files.pythonhosted.org/packages/e5/94/6c078f840ccfe2d02024d5340279cd60be0e120d63662d0d1dfceca71933/pyobjc_framework_SoundAnalysis-10.3.2-py3-none-any.whl", hash = "sha256:2c964e811adbdd5b86f207e6011e7ab6deb89896fb1bff19c1d7936ed6af7665", size = 3786 },
+    { url = "https://files.pythonhosted.org/packages/ab/d4/91afb41c514d1e236567b971a981f96c1d20f16eb0658256369c53a4bf45/pyobjc_framework_SoundAnalysis-11.0-py2.py3-none-any.whl", hash = "sha256:5969096cadb07f9ba9855cedf6f53674ddb030a324b4981091834d1b31c8c27e", size = 4111 },
+    { url = "https://files.pythonhosted.org/packages/af/7a/f960ad1e727f6d917e6c84b7383f3eacbb2948bc60396be3bce40cbd8128/pyobjc_framework_SoundAnalysis-11.0-py3-none-any.whl", hash = "sha256:70f70923756e118203cde4ac25083a34ead69a6034baed9c694a36f5fe2325f3", size = 4182 },
 ]
 
 [[package]]
 name = "pyobjc-framework-speech"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/3a/c9f92ab6b648b1ea346d2c8aac78e8a82fd56c9e8c1fa0c369c09ce535b7/pyobjc_framework_speech-10.3.2.tar.gz", hash = "sha256:86e825076ce65b5dbdf3ce0b37ab1d251beff3e97773114d3933012d6d771fd8", size = 30314 }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/39/e9f0a73243c38d85f8da6a1a2afda73503e2fcc31a72f5479770bceae0c1/pyobjc_framework_speech-11.0.tar.gz", hash = "sha256:92a191c3ecfe7032eea2140ab5dda826a59c7bb84b13a2edb0ebc471a76e6d7b", size = 40620 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/06/af0e21c571e61f6f43a1c0244f1c7eba2f5cffeb609408d538f8b1d3ae44/pyobjc_framework_Speech-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:372efaf0ace54a4b3a3dd09525e94f7dc9c964062cfe3523de89a68f0e75839f", size = 9034 },
-    { url = "https://files.pythonhosted.org/packages/1b/45/fa71effc59cb835d3f05315ea9bec250f0089cc57876f78e1b0e2f1837bd/pyobjc_framework_Speech-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c4601f2012c0299b3191baff9a35d14bc40a4139ac6aac1439731a287b50558f", size = 8997 },
-    { url = "https://files.pythonhosted.org/packages/20/14/e633e89e1be1b87331e0e715e887b01a6944d08d1b0bff4f67a93ae9a742/pyobjc_framework_Speech-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3958d497b20a567afd7382360738809049f02cb712a8c21a5f6bbcb962857da2", size = 6597 },
-    { url = "https://files.pythonhosted.org/packages/ac/bb/c927eff4762523f5c31e878371af3f3dd9bbfbdb926c3468c50c5c858412/pyobjc_framework_Speech-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:8c562b43963a2764e5565f5151ebacb31af87bfc1de3556cada8358eb9ad6855", size = 9466 },
+    { url = "https://files.pythonhosted.org/packages/b0/85/e989076ff0cd40c7cfb3ed7d621703de11bfd8286f1729aca759db1f42a3/pyobjc_framework_Speech-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:353179210683e38bfbd675df6a35eec46b30ce30b7291bcb07a5cadaf11a3bd7", size = 9016 },
+    { url = "https://files.pythonhosted.org/packages/00/03/827acde068787c2318981e2bfef2c3cadbe8552434ccc0634b30084ef914/pyobjc_framework_Speech-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:134e08025f4638e428602f7e16bbec94b00477eec090316138d758a86e10fd5f", size = 9037 },
 ]
 
 [[package]]
 name = "pyobjc-framework-spritekit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/11/aefc94b7d2d8a3e43f51bf448d7dea48fca8c637439b2708e203fe16e4c3/pyobjc_framework_spritekit-10.3.2.tar.gz", hash = "sha256:cd28510d2158455ab9f0109655ecbebbdaff98daf3fb6af19e2f472a91496270", size = 95884 }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/6e/642e64f5b62a7777c784931c7f018788b5620e307907d416c837fd0c4315/pyobjc_framework_spritekit-11.0.tar.gz", hash = "sha256:aa43927e325d4ac253b7c0ec4df95393b0354bd278ebe9871803419d12d1ef80", size = 129851 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/49/e213e65c43746eb6d7ffcbcd12b585f23c45bc37683ec7ad07e407926333/pyobjc_framework_SpriteKit-10.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:76b215b7834d03f7b1d87b5566d254dca73fa1a66c70c2e8d2d2802c916fdbf5", size = 17608 },
-    { url = "https://files.pythonhosted.org/packages/5a/02/a9b5cf9724065d2b21f159bb5eac81b1ad25fcee2063d6504aaebbe24850/pyobjc_framework_SpriteKit-10.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1eb4e7106897702398b4b975268f94291b4747f04d0cb9ea8765ba3b12eff3e6", size = 17671 },
+    { url = "https://files.pythonhosted.org/packages/e1/80/319f156ac6f6cab0dbc85881d81a74d4a7f17913256338683ae8d9ed56c4/pyobjc_framework_SpriteKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3d0971a7a85786edc521ab897bdb0c78696278e6417bf389abdfe2151358e854", size = 18077 },
+    { url = "https://files.pythonhosted.org/packages/bb/09/303d76844a10745cdbac1ff76c2c8630c1ef46455014562dc79aaa72a6e3/pyobjc_framework_SpriteKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0da5f2b52636a2f04fc38a123fed9d7f8d6fd353df027c51c0bfc91e244a9d2b", size = 18145 },
 ]
 
 [[package]]
 name = "pyobjc-framework-storekit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/eb/cf77c88a0a957b142869b184600ca0a43b8a944fd257429e64a9a04b1abe/pyobjc_framework_storekit-10.3.2.tar.gz", hash = "sha256:8112857047363c200708ba4472e644d1d465a134edcd5edd4b0da6ab4bcff143", size = 64015 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/ca/f4e5a1ff8c98bbbf208639b2bef7bf3b88936bccda1d8ed34aa7d052f589/pyobjc_framework_storekit-11.0.tar.gz", hash = "sha256:ef7e75b28f1fa8b0b6413e64b9d5d78b8ca358fc2477483d2783f688ff8d75e0", size = 75855 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/f3/63bfd03cc831a79cf5bb8424dd69fdcad7a642df5a3dc7f747a8d8cd33b1/pyobjc_framework_StoreKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:f5747eea8acbdabb91f6928072724fc4e3519bc9c0b13ba3555b595cf434398a", size = 12437 },
-    { url = "https://files.pythonhosted.org/packages/da/1c/64b95c69253c72c070bee14572958e5592a7e3c5cc46233a94c641e7e677/pyobjc_framework_StoreKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c90c764811e234d8fe84b6ed1cabfc920e6672b0886325d70f055c3177e35c5f", size = 12409 },
-    { url = "https://files.pythonhosted.org/packages/e1/c1/be31ee465e631ef391120851922bc7fd89f2e116dd51f0d89255ebbfd02d/pyobjc_framework_StoreKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1cc915f33f4fb6fd064e2cdd06afedb65e4e369d4daf8a9ec0b12088ae298411", size = 8920 },
-    { url = "https://files.pythonhosted.org/packages/79/9a/4bb361811778d13744a2f806c53ec15ad167afeba3ff11acbb3592e859ff/pyobjc_framework_StoreKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:63856ef6decc3240dbb53131710b35d2d65d878010c3deeb62e2af52867d0d6f", size = 12390 },
+    { url = "https://files.pythonhosted.org/packages/ab/40/af53ad7781515866003c2c71056a053d2f033cf2aa31920a8a1fdb829d7a/pyobjc_framework_StoreKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1d51a05a5e0277c542978b1f5a6aa33331359de7c0a2cf0ad922760b36e5066a", size = 11655 },
+    { url = "https://files.pythonhosted.org/packages/f3/11/ba3259d3b22980e08c5e8255a48cc97180bec47d72ffbbd41ab699df39b1/pyobjc_framework_StoreKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:29269183e91043bbfee79851ae712073feba1e10845b8deeb7e6aaa20cfb3cf4", size = 11680 },
 ]
 
 [[package]]
 name = "pyobjc-framework-symbols"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/bc/80ed504beaeddebaeca4fd1237315987971af99ade2f6e755f4663b8dbeb/pyobjc_framework_symbols-10.3.2.tar.gz", hash = "sha256:b6293ac919513f8f91e2f4d847bca3b67a10e3a9e636bd2a6a05d7d2b43bb3ad", size = 12118 }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/92/a20a3d7af3c99e0ea086e43715675160a04b86c1d069bdaeb3acdb015d92/pyobjc_framework_symbols-11.0.tar.gz", hash = "sha256:e3de7736dfb8107f515cfd23f03e874dd9468e88ab076d01d922a73fefb620fa", size = 13682 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/e3/8ef641dd42b3225bf907b9b877d9d67c3d8684a3563b6ef989f29de5f8be/pyobjc_framework_Symbols-10.3.2-py2.py3-none-any.whl", hash = "sha256:f2d003989d857f62d9cf5f93dce83ea58f59319b0cdd6ef178ce1d380907831e", size = 2958 },
-    { url = "https://files.pythonhosted.org/packages/ab/98/860c1b05b9be35d74d716db421daf654cd984188cb5998c2beac5557889c/pyobjc_framework_Symbols-10.3.2-py3-none-any.whl", hash = "sha256:bcc5453605ecbf462c1f868db91921eab4d23039d1ddc04f3be5fba719efe3c3", size = 2954 },
+    { url = "https://files.pythonhosted.org/packages/66/ff/341d44f5347d48491682bece366444f3e230e33109266dcc6a17e6a7fc3d/pyobjc_framework_Symbols-11.0-py2.py3-none-any.whl", hash = "sha256:f1490823f40a8a540ac10628190695f27a717343914fe5db5fafa500f7c7bf44", size = 3263 },
+    { url = "https://files.pythonhosted.org/packages/94/a4/c21353872a2fc643206a44ac55b92b5b7533cdb2cb26c44a9048debc295a/pyobjc_framework_Symbols-11.0-py3-none-any.whl", hash = "sha256:0919e85fcf6f420f61d8d9a67cafa2ab4678666441ef4f001b31f5457900b314", size = 3335 },
 ]
 
 [[package]]
 name = "pyobjc-framework-syncservices"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-coredata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/49/2a72d27312a7b41f814f0dec33d6b27972a4842e509d2db39200a189ac63/pyobjc_framework_syncservices-10.3.2.tar.gz", hash = "sha256:4ccd394746027b788907af2846dd1ab3505f340f0bf24400191017e5d0e6300e", size = 49889 }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/22/642186906f672461bab1d7773b35ef74e432b9789ca2248186b766e9fd3b/pyobjc_framework_syncservices-11.0.tar.gz", hash = "sha256:7867c23895a8289da8d56e962c144c36ed16bd101dc07d05281c55930b142471", size = 57453 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/00/9661a6f584bee05d1620f18799e049e8956391ff7178ec8de193fc4b80a8/pyobjc_framework_SyncServices-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:1ce9b66103d83021ca52b86cf3ad431a1ff29a2ad14c72e208c67cbf90b01eac", size = 14200 },
-    { url = "https://files.pythonhosted.org/packages/29/31/b3c5f90858431f637b8acd5d8870521c27526e11c850fc933b4bc4dd71a3/pyobjc_framework_SyncServices-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:363d3a2e0bd067b0369921d9dc22707cc0c0b4a0aca0dad313b2de3ba52e943b", size = 14175 },
-    { url = "https://files.pythonhosted.org/packages/55/8e/83e26740b02c11ef37b7a88fcfb3c0ae0f4dba85c0687ca8f34455152890/pyobjc_framework_SyncServices-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:88a35e31ca3ea3e29dcda259aee2bea9fe6eab97cb4017aa03d622efe21d11b8", size = 10190 },
-    { url = "https://files.pythonhosted.org/packages/18/b2/0c9004d26bda69ad1be0d258b57a038a2023d0fe462d2600b208cb86b34b/pyobjc_framework_SyncServices-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:bb2f187ffae9627ce5745b61d9427e9234e73e043bda7471efa332be4092a9c4", size = 14140 },
+    { url = "https://files.pythonhosted.org/packages/15/9b/484db4eed6b1e29e0d69275bd459ab21a6b3f98e8b2ce61beeb9971303ca/pyobjc_framework_SyncServices-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:89a398df6518cff1c63b7cccf3025e388f3ef299645734112c5aa1ac5f7ca30a", size = 13989 },
+    { url = "https://files.pythonhosted.org/packages/8d/d8/dc86d708434b7cb59825c56549e64b118ba4b8584d2eb5a1514d1cd5d1bd/pyobjc_framework_SyncServices-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e870e82ed34c43607cc50dbae57a81dd419b75abc06670630cbbf41ae6e1402c", size = 14008 },
 ]
 
 [[package]]
 name = "pyobjc-framework-systemconfiguration"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/df/28b0da49f01b3f6b0b26d9ae530d4ad5d225e67c812469204552c8bc4c34/pyobjc_framework_systemconfiguration-10.3.2.tar.gz", hash = "sha256:6d98d26da42501abceb9b374ba8e31b01a96af87a77cd578ea1b691f8152bc86", size = 124533 }
+sdist = { url = "https://files.pythonhosted.org/packages/70/70/ebebf311523f436df2407f35d7ce62482c01e530b77aceb3ca6356dcef43/pyobjc_framework_systemconfiguration-11.0.tar.gz", hash = "sha256:06487f0fdd43c6447b5fd3d7f3f59826178d32bcf74f848c5b3ea597191d471d", size = 142949 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/22/f97e03c121c7046232a2a66c04fe4b2b5cf9e7ee73d7b2da8c6ea55b57ea/pyobjc_framework_SystemConfiguration-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:e62d0aeb92b13f35bcba98ab40cc032af680f90e238929b9b5009517eac2eb1b", size = 21597 },
-    { url = "https://files.pythonhosted.org/packages/a6/9b/332fe6055868fa3388c76023e658d0dbcdcadb8efb590da20f3317e2fae6/pyobjc_framework_SystemConfiguration-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a346b119cf8b648d54d407a925a3492a4765312f7d9e1101db3dbc04d5d5d11e", size = 21607 },
-    { url = "https://files.pythonhosted.org/packages/8f/4c/146579fc7ac78b416a15e353e058737c200be7abb3a660303446f44ed7a8/pyobjc_framework_SystemConfiguration-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3584696d9a69ac45eea07ae26a7605ccd6d6b1da5786d4b8115b0f667a61c730", size = 16838 },
-    { url = "https://files.pythonhosted.org/packages/dd/81/14d32e91cf38feaa0761fecf3b1e5a926c62d8f00ff569b5a23ee92d23e7/pyobjc_framework_SystemConfiguration-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:9ca01e70d675811c27e6dde4ed662b5f29da5f131832129e4dc0d229f17d6059", size = 21577 },
+    { url = "https://files.pythonhosted.org/packages/28/8f/1b5f7e8e848d2c84204da08d5c63e42feff86b26cd508da7a4f95960b842/pyobjc_framework_SystemConfiguration-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:89d3c54abedcedbc2ce52c31ff4878251ca54a8535407ed6bd6584ce099c148b", size = 21836 },
+    { url = "https://files.pythonhosted.org/packages/6d/49/8660b3d0a46ac2f88e73cec3d10e21885b107f54635680ef0c677ac5cf3e/pyobjc_framework_SystemConfiguration-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8cbcb9662dbb5a034cfc5a44adaf2a0226a2985ae299a4ef4fd75bb49f30f5a0", size = 21727 },
 ]
 
 [[package]]
 name = "pyobjc-framework-systemextensions"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/45/df446df16f431d2c8c1733f5076b75eb3119ac21371dbe9c900542488099/pyobjc_framework_systemextensions-10.3.2.tar.gz", hash = "sha256:8e513fbc750cce3af0a77fab08c05c9cc2ba0d64116490bd1f7b0f9fe8ba6972", size = 20236 }
+sdist = { url = "https://files.pythonhosted.org/packages/62/4b/904d818debf6216b7be009d492d998c819bf2f2791bfb75870a952e32cf9/pyobjc_framework_systemextensions-11.0.tar.gz", hash = "sha256:da293c99b428fb7f18a7a1d311b17177f73a20c7ffa94de3f72d760df924255e", size = 22531 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/25/83c77f5df751edc0a6012f1382287107646b4f86c514e58bf1bf18cc5aed/pyobjc_framework_SystemExtensions-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:ea3c137f9ce6cc151fd10bf5e6575a3078621c8483999a35d10f9eb2cd1e0940", size = 8598 },
-    { url = "https://files.pythonhosted.org/packages/57/12/09f8865804700124acb5acac808c14db115fd076bad24669561a6531203e/pyobjc_framework_SystemExtensions-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7678aaac1b0b704515448018544ee75cb4ed21a097e6cfeef1f3366ee4d4426a", size = 8573 },
-    { url = "https://files.pythonhosted.org/packages/33/27/a8dcf0a653ed93e28cc77b754537f769dee761b1afb467fcd37f7740f108/pyobjc_framework_SystemExtensions-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:baf0ae2a280719162017be54ad7f5492db784f2e720f09b30399823020ebfa25", size = 6316 },
-    { url = "https://files.pythonhosted.org/packages/07/cb/951dee2b1f50a29dfca6503eab062ca83b6536fa0789d6d99e52536cd749/pyobjc_framework_SystemExtensions-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:de854daa0a31a795a679b8695213a55d8de829e0047945539658afd25ec447bf", size = 9023 },
+    { url = "https://files.pythonhosted.org/packages/15/3c/8f91b89554ef3127e037d90b3ef83c77a994bb889b7884a995756cd06b63/pyobjc_framework_SystemExtensions-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f7a2ec417fa0d383cc066bc292541aa78fd2aec9cca83a98d41b7982f185d1f7", size = 8975 },
+    { url = "https://files.pythonhosted.org/packages/21/8c/cf2a018b5f1ecd216f8cb26a3b6fbe590d08de81a6c6b4658e001a203886/pyobjc_framework_SystemExtensions-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:62b99c6bd88bce642960fc2b9d5903fbfca680d16be9a4565a883eb4ba17ca5e", size = 8999 },
 ]
 
 [[package]]
 name = "pyobjc-framework-threadnetwork"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/85/821d14d8118329be7106e2d656fd8466ceb20d6d90e4341ac8e7b43dc970/pyobjc_framework_threadnetwork-10.3.2.tar.gz", hash = "sha256:1d8b73000c077da1dafc4c4298acda6df8ec615a4bf94ffc2f9f3ef8c209dc45", size = 12976 }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/17/fc8fde4eeb6697e0a5ba1a306cd62d3a95b53f3334744cd22b87037d8a14/pyobjc_framework_threadnetwork-11.0.tar.gz", hash = "sha256:f5713579380f6fb89c877796de86cb4e98428d7a9cbfebe566fb827ba23b2d8e", size = 13820 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/9d/3b4ea6436886cb61ac948310de2d2ca9c151aef0a7884722820143c61e11/pyobjc_framework_ThreadNetwork-10.3.2-py2.py3-none-any.whl", hash = "sha256:291d6cd9b7ccec8d82ab6be21597b9478a022d6cf2f63006c05fba2e0764c36f", size = 3382 },
-    { url = "https://files.pythonhosted.org/packages/ea/b6/53f54252118508eeabf049a607af47f79c7748d34cd14c8977314b4d77b4/pyobjc_framework_ThreadNetwork-10.3.2-py3-none-any.whl", hash = "sha256:dd218e6f246e3a006b46cb76c4a82d7f45e2c827e91464fe12026fb0dcaa0409", size = 3376 },
+    { url = "https://files.pythonhosted.org/packages/55/a9/908184da457e33a110de7d2d262efa69beaba6db243342df5654da03566b/pyobjc_framework_ThreadNetwork-11.0-py2.py3-none-any.whl", hash = "sha256:950d46a009cb992b12dbd8169a0450d8cc101fc982e03e6543078c6d7790e353", size = 3700 },
+    { url = "https://files.pythonhosted.org/packages/59/d4/4694fc7a627d2b6b37c51433ba7f02a39a283a445dc77349b82fe24534f1/pyobjc_framework_ThreadNetwork-11.0-py3-none-any.whl", hash = "sha256:1218649e4f488ca411af13b74f1dee1e7a178169e0f5963342ba8a7c46037ea7", size = 3770 },
 ]
 
 [[package]]
 name = "pyobjc-framework-uniformtypeidentifiers"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/2b/665cebe17818d7cf6bb5edf38319bcb3dd2915e1eb6c9e65db8c7fb045a0/pyobjc_framework_uniformtypeidentifiers-10.3.2.tar.gz", hash = "sha256:59e8b11d78d89a24f7fb944853b93705ca48febf1ae42be57d16100e38703f69", size = 18820 }
+sdist = { url = "https://files.pythonhosted.org/packages/56/4f/fd571c1f87d5ee3d86c4d2008806e9623d2662bbc788d9001b3fff35275f/pyobjc_framework_uniformtypeidentifiers-11.0.tar.gz", hash = "sha256:6ae6927a3ed1f0197a8c472226f11f46ccd5ed398b4449613e1d10346d9ed15d", size = 20860 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/82/3cf17596335b4f88e078761aae5940575d314921d3c1f4b3c82ef040766e/pyobjc_framework_UniformTypeIdentifiers-10.3.2-py2.py3-none-any.whl", hash = "sha256:9ee1c3297efead181deeae50d3322582517f6e5fd45e247f5691cdae995bda62", size = 4470 },
-    { url = "https://files.pythonhosted.org/packages/62/02/032ad4a30d0e834ba3863562cdc962d7cbf4202530067a3437ac564737c7/pyobjc_framework_UniformTypeIdentifiers-10.3.2-py3-none-any.whl", hash = "sha256:a1a01cf7d41346e9c2002f979783d797b35f07def5b3c7c426f2c4f34f8163d1", size = 4461 },
+    { url = "https://files.pythonhosted.org/packages/82/f2/094888af07fb7f0443996e5d91915e74b87e8705b599b68b516a0e94a63d/pyobjc_framework_UniformTypeIdentifiers-11.0-py2.py3-none-any.whl", hash = "sha256:acffb86e8b03b66c49274236b3df3a254cacd32b9f25bd7a5bd59baaaf738624", size = 4841 },
+    { url = "https://files.pythonhosted.org/packages/88/9c/4cc0522cc546e6a3bf8a921e3a9f0ed078e3cf907d616760d9f3d7754919/pyobjc_framework_UniformTypeIdentifiers-11.0-py3-none-any.whl", hash = "sha256:a3097f186c7e231b19218a3ceecb3b70a8f2b2e9e642ef409dc7a195a30c869e", size = 4910 },
 ]
 
 [[package]]
 name = "pyobjc-framework-usernotifications"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/87/2cf1c42e4686fe407b1043ae6fce7484da9a05d5f930ef4807aeb7f62233/pyobjc_framework_usernotifications-10.3.2.tar.gz", hash = "sha256:84743b40d950959b92bc15265278d4e4de45bf84fc3a45d8636f38476d7201c1", size = 46431 }
+sdist = { url = "https://files.pythonhosted.org/packages/78/f5/ca3e6a7d940b3aca4323e4f5409b14b5d2eb45432158430c584e3800ce4d/pyobjc_framework_usernotifications-11.0.tar.gz", hash = "sha256:7950a1c6a8297f006c26c3d286705ffc2a07061d6e844f1106290572097b872c", size = 54857 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/21/2c83a778d0da60260bbde94ce1bf005a701925166b6026f097ed958fe456/pyobjc_framework_UserNotifications-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:4b4374e72846f9773e1b424760d2b198e77a38497068822be1cf31da2861c421", size = 9594 },
-    { url = "https://files.pythonhosted.org/packages/0a/93/5a5f4e51ca777b48c46c7c355687be7a03e17a995429661a864d7306da58/pyobjc_framework_UserNotifications-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:72bf46de155743fa642f00b842d94335590f6b764a4d252d6fd8d8c93fb94292", size = 9556 },
-    { url = "https://files.pythonhosted.org/packages/d7/76/18d38dfed670c633d818a04cb952a42551a6e386e1691ea9a55e289a8c7d/pyobjc_framework_UserNotifications-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a8430e6fc5e8ac7f5f4a10a28d609d3b995f682a93213e656f0bb60c725f104e", size = 7202 },
-    { url = "https://files.pythonhosted.org/packages/cf/b2/948d5494c85fc77d64c69c01c7259c0fcd7006d09fee49bd4a73dfb92538/pyobjc_framework_UserNotifications-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:809c9b19ebca72928fc1f78dfa6a4010c5ba20a36d7a355405a87c8b3e30c0ee", size = 9971 },
+    { url = "https://files.pythonhosted.org/packages/1f/bf/5545d5c9d0d10a603ad406a5ce727de6a47daace9c38d4484818611599f3/pyobjc_framework_UserNotifications-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4bf78fa37f574f5b43db9b83ca02e82ab45803589f970042afdcd1cb8c01396d", size = 9483 },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/41f4d18120b2c006f756edde1845a2df45fdbd6957e540f8ebcfae25747f/pyobjc_framework_UserNotifications-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0b4c06c3862405e103e964327581c28e5390a2d4cd0cef3d8e64afda03c9f431", size = 9506 },
 ]
 
 [[package]]
 name = "pyobjc-framework-usernotificationsui"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-usernotifications" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/14/c028e54d93df12c4b84376bb1f343bbcf338dea8f21bd724c32de8841efe/pyobjc_framework_usernotificationsui-10.3.2.tar.gz", hash = "sha256:9e21f207dcb4305b2dd80ed5329515867aee0caf8f40157911f8b4c6674e4b60", size = 13611 }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e8/f0d50cdc678260a628b92e55b5752155f941c2f72b96fe3f2412a28c5d79/pyobjc_framework_usernotificationsui-11.0.tar.gz", hash = "sha256:d0ec597d189b4d228b0b836474aef318652c1c287b33442a1403c49dc59fdb7f", size = 14369 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/48/f1151d0a32375c0ec62307dd742f04653bd997787cfd936be8184394329a/pyobjc_framework_UserNotificationsUI-10.3.2-py2.py3-none-any.whl", hash = "sha256:fc7c1b88c59f64e9b0d859b456f8f08cdded7daa6360e073f99d91ae84d641af", size = 3526 },
-    { url = "https://files.pythonhosted.org/packages/5c/c9/16ceccd1c95f899b503be31ab4d39b898df9c1179001cf15f1b5caa34e3e/pyobjc_framework_UserNotificationsUI-10.3.2-py3-none-any.whl", hash = "sha256:6a59e6a08dfd1d9d4e0a9e3f61099731b2a901d189e14d97ccf8fe12fd011be4", size = 3520 },
+    { url = "https://files.pythonhosted.org/packages/bb/f7/64c95c6f82e92bb1cbcb8d5c3658c79c954668627eef28f11e76025a3ed1/pyobjc_framework_UserNotificationsUI-11.0-py2.py3-none-any.whl", hash = "sha256:6185d9c9513b6a823cd72dcf40d2fb33bbf0f2c9a98528e0e112580b47ac3632", size = 3856 },
+    { url = "https://files.pythonhosted.org/packages/eb/c3/e1d64c9e523b5192e0179b6723ee465e74d6c282104a49a67347d527a65d/pyobjc_framework_UserNotificationsUI-11.0-py3-none-any.whl", hash = "sha256:e4439e549265929ddad1feca7b062d00c2d3732470f349cb0d594705e0257919", size = 3932 },
 ]
 
 [[package]]
 name = "pyobjc-framework-videosubscriberaccount"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/05/6a25c1ef8189288ae7267cacf444031083840c9bd7fc0f8d9c6e61de34d6/pyobjc_framework_videosubscriberaccount-10.3.2.tar.gz", hash = "sha256:6072e55242c150bfc09417679813966482570fcfd0f0dd740c241ef5589f546a", size = 24126 }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/2e/6a7debd84911a9384b4e7a9cc3f308e3461a00a9d74f33b153bdd872f15f/pyobjc_framework_videosubscriberaccount-11.0.tar.gz", hash = "sha256:163b32f361f48b9d20f317461464abd4427b3242693ae011633fc443c7d5449c", size = 29100 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/bb/5e6281b9eaf8e0f70ba59cabcc7198ca385b5c3b42aca9472c6701f82334/pyobjc_framework_VideoSubscriberAccount-10.3.2-py2.py3-none-any.whl", hash = "sha256:aa3695a742f6ba04285a3721ca33bd537adcafd3ca018757fd95234a5c11baa1", size = 4297 },
-    { url = "https://files.pythonhosted.org/packages/32/aa/5c135299b1b3fdcea0fb87075fd512710f348d7771a946326e9fbf84b2db/pyobjc_framework_VideoSubscriberAccount-10.3.2-py3-none-any.whl", hash = "sha256:c0ad86a912eed0d21fe8b93dda213928bad5c06cc106afa0d6fb7cf012f55f54", size = 4293 },
+    { url = "https://files.pythonhosted.org/packages/51/82/94650fe5cc68c0c32fe56fe22cd7eb2874b28f987a9e259fac12cbea7705/pyobjc_framework_VideoSubscriberAccount-11.0-py2.py3-none-any.whl", hash = "sha256:1deec8d5a0138ae51b5ca7bfb7f6fe1b0dc3cbb52db3111059708efa5f8a8d04", size = 4637 },
+    { url = "https://files.pythonhosted.org/packages/61/54/1765507adad1b0c9bc6be10f09b249d425212bc0d9fef1efdfd872ee9807/pyobjc_framework_VideoSubscriberAccount-11.0-py3-none-any.whl", hash = "sha256:0095eddb5fc942f9e049bc4c683cf28c77ea60c60942552c3c48bf74c8fdca9b", size = 4709 },
 ]
 
 [[package]]
 name = "pyobjc-framework-videotoolbox"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -4272,33 +4179,29 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/19/06a028ffdb254cf621795158f7da56c6c0f201d53b40709095a5f60fe55d/pyobjc_framework_videotoolbox-10.3.2.tar.gz", hash = "sha256:8ddfa3d25d53d03d00847f63cfcc7c033aab54d9fc1fdd0d18ff60af17aa2b14", size = 66599 }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/2d/c031a132b142fcd20846cc1ac3ba92abaa58ec04164fd36ca978d9374f1c/pyobjc_framework_videotoolbox-11.0.tar.gz", hash = "sha256:a54ed8f8bcbdd2bdea2a296dc02a8a7d42f81e2b6ccbf4d1f10cec5e7a09bec0", size = 81157 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f4/ba94c7e311f68f9cda0456b8dc689158faf773c95e969b662ae9d75027f2/pyobjc_framework_VideoToolbox-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:32f68e12382812942582af7e7989eb6bad20842dfa7fc49d42d9e030ab9d7d68", size = 12414 },
-    { url = "https://files.pythonhosted.org/packages/99/a3/c1c8fa454053a18f1cbd4d31f33344824e052402475faf518fb551ef028d/pyobjc_framework_VideoToolbox-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:85cc24f28bf3e9f097ed18179444c8ad60e8c8e174b2f7a8e550044336bdf13b", size = 12428 },
-    { url = "https://files.pythonhosted.org/packages/f6/35/7ba035993cb0c5961734358c334a74661cbe17371c6e5026856a11ed1108/pyobjc_framework_VideoToolbox-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3553a087ad6be8bc99eada062a95aa03cf5128fcfb168c43564eed16f9fe80ed", size = 9969 },
-    { url = "https://files.pythonhosted.org/packages/be/c2/f95bd57feb9fad969ab61ebdb2147df308019cf9706ceef033d07abc26ea/pyobjc_framework_VideoToolbox-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:7bf688e46e5439237e34c575291615dc8ec3fd2a63723712ab9db708c39d385d", size = 12778 },
+    { url = "https://files.pythonhosted.org/packages/44/ae/ff697840bdcf3530e8fba84e2a606813eda1ee90be074f12e2857460cebf/pyobjc_framework_VideoToolbox-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:12af56190e65c3b60c6ca14fe69045e5ffb5908ea1363580506eb32603b80855", size = 13446 },
+    { url = "https://files.pythonhosted.org/packages/1e/ef/9e7230435da47016983a3c9ea7b1d5237b43fce2d8b2b923eb638b7694f5/pyobjc_framework_VideoToolbox-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4ed7f073bd8dfecca0da6359d5cd871b2f39144883930bddd41ca818447de608", size = 13451 },
 ]
 
 [[package]]
 name = "pyobjc-framework-virtualization"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/5d/df555942df3bcd7df6a6ed0830b5b4a0024f4fda00ee7cefaf61afc19e05/pyobjc_framework_virtualization-10.3.2.tar.gz", hash = "sha256:6b8cd5b69dd5197b96d6b907c9224ea4d05ef3bebad552cfebf331ed98c2d4eb", size = 61977 }
+sdist = { url = "https://files.pythonhosted.org/packages/65/8d/e57e1f2c5ac950dc3da6c977effde4a55b8b70424b1bdb97b5530559f5bc/pyobjc_framework_virtualization-11.0.tar.gz", hash = "sha256:03e1c1fa20950aa7c275e5f11f1257108b6d1c6a7403afb86f4e9d5fae87b73c", size = 78144 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/41/57fcaedd3ea5b13298fd4951d2728625cce94bf04412547f91737dd29a22/pyobjc_framework_Virtualization-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:68159f5947956a08f26c3f94ce2dc390ed721b0edbbe7ab757ca9cb3217130f9", size = 11550 },
-    { url = "https://files.pythonhosted.org/packages/7d/10/aa03e2dac3cdd9a32e04d6fb470d46dbcff106f9e146d17de818053f8c1c/pyobjc_framework_Virtualization-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:760100c421920927d301655138f8082b220a0af95e23bf86caf8d88bce102672", size = 11542 },
-    { url = "https://files.pythonhosted.org/packages/d9/1b/c681f3b43725cda8b49537ff05a640190e63e262005df720b8b2cb23cecd/pyobjc_framework_Virtualization-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c467afb44f2731ebd3836f63a888097ee1fc823b310d9c348c9a89d43bce9749", size = 8980 },
-    { url = "https://files.pythonhosted.org/packages/be/d8/588cf8a9106bbec33482744191ab5a93468947d3a04c9ce03ab86c64ba54/pyobjc_framework_Virtualization-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:a77afef5364c18c84f4b9b3c97a0dfaa037f34218ccea5f87f30d344eba86532", size = 12046 },
+    { url = "https://files.pythonhosted.org/packages/6b/c9/b2f8322d7ced14822270481be5b44f1846aa7c09b4b3cb52517dc1054f4b/pyobjc_framework_Virtualization-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:334712792136ffcf3c63a63cea01ce33d60309a82721c95e25f0cc26b95f72cc", size = 13417 },
+    { url = "https://files.pythonhosted.org/packages/1e/96/d64425811a4ef2c8b38914ea1a91bbd2aa6136bb79989e4821acd6d28e67/pyobjc_framework_Virtualization-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b848b1ab365906b11a507c8146e477c27d2bf56159d49d21fda15b93c2811ec", size = 13430 },
 ]
 
 [[package]]
 name = "pyobjc-framework-vision"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -4306,28 +4209,24 @@ dependencies = [
     { name = "pyobjc-framework-coreml" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/f9/f9063b8cdbb2210b51beadffabb7021d55a20b3e9693219c53e98d067c10/pyobjc_framework_vision-10.3.2.tar.gz", hash = "sha256:5cfea4a750657e2c8e7c8b0c26c7aac2578ba09ab8f66ffa0e2ee632410cacf3", size = 108990 }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/53/dc2e0562a177af9306efceb84bc21f5cf7470acaa8f28f64e62bf828b7e1/pyobjc_framework_vision-11.0.tar.gz", hash = "sha256:45342e5253c306dbcd056a68bff04ffbfa00e9ac300a02aabf2e81053b771e39", size = 133175 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/ef/16c0b66793d538402b125db5d579e18a40ac7163f154a2190a93a88796af/pyobjc_framework_Vision-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:cae03536f12ed5764ecfdcf9cf96b37e577cc6e8c466aeb23a6aa0682b45ae39", size = 17546 },
-    { url = "https://files.pythonhosted.org/packages/ec/2b/16ed6ddea51eca88c7b9676431d7b35767b9b97c10e25ec8b5d762009923/pyobjc_framework_Vision-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ba5ccd0bf12c29c2cdf1b52405c395929b5802e9120476b8e9a01af691ab33dc", size = 22021 },
-    { url = "https://files.pythonhosted.org/packages/ee/b5/02bd6bd54c456962ea9b1a09be96ce7af936e40b57555f035a3d79204d47/pyobjc_framework_Vision-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b7edc178ebeb621ba9a239449f8ae1fc6b643f60914ff2be4dad69e901ca331", size = 15580 },
-    { url = "https://files.pythonhosted.org/packages/b1/24/13648f9449a2406c0134f35cbdebe124c571b275b7b3061cf7bf3ceaf8ab/pyobjc_framework_Vision-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:1083e23ee4dae7cca8e2d094b1995909690b277c967975227d3395222c0c7377", size = 17469 },
+    { url = "https://files.pythonhosted.org/packages/7f/84/d23a745d46858409a1dca3e7f5cb3089c148ebb8d42e7a6289e1972ad650/pyobjc_framework_Vision-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ca7cc48332d804a02b5b17f31bed52dd4b7c323f9e4ff4b4e7ecd35d39cc0759", size = 21754 },
+    { url = "https://files.pythonhosted.org/packages/3a/80/6db9fc2a3f8b991860156f4700f979ad8aa1e9617b0efa720ee3b52e3602/pyobjc_framework_Vision-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1b07aa867dda47d2a4883cd969e248039988b49190ba097cbe9747156b5d1f30", size = 17099 },
 ]
 
 [[package]]
 name = "pyobjc-framework-webkit"
-version = "10.3.2"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/98/89187c121e130e11ce6c7ed86a2de10cb6d6c8994eb77ab2b81a060d1916/pyobjc_framework_webkit-10.3.2.tar.gz", hash = "sha256:b60d097a87867c252286855158cc35d991e2273f162f40f8e38e95153894bbbf", size = 611469 }
+sdist = { url = "https://files.pythonhosted.org/packages/79/4f/02a6270acf225c2a34339677e796002c77506238475059ae6e855358a40c/pyobjc_framework_webkit-11.0.tar.gz", hash = "sha256:fa6bedf9873786b3376a74ce2ea9dcd311f2a80f61e33dcbd931cc956aa29644", size = 767210 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/83/a4526fb64176b7e0d19ee20a8760548ef144227784aea5f0e1bf634c3ae2/pyobjc_framework_WebKit-10.3.2-cp36-abi3-macosx_10_13_universal2.whl", hash = "sha256:c72c1b0c5b72fd5203cd4b445e96494eab2518ef688629d2ea75dced95c236e9", size = 44898 },
-    { url = "https://files.pythonhosted.org/packages/f1/85/e8d439d84bed84a15bd22bb0c2a4c7ab9371a37d3038fbde478d1be4ee2a/pyobjc_framework_WebKit-10.3.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3ef315a185289c051f43f1d2aebf94a2cdd4408731d1d712972e2e130a17e632", size = 44879 },
-    { url = "https://files.pythonhosted.org/packages/3c/a4/df27ea5a5256e0a031ccdfc875636641dd807f1f882b95f8a61bb189b871/pyobjc_framework_WebKit-10.3.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f8e89d51511b0bf2d6ec8d8a0cf8e74b3451987fb10a3adf5d6181cc77c1260a", size = 32797 },
-    { url = "https://files.pythonhosted.org/packages/68/1a/06e6f8de19505c3807db47962308390e2d15e5729342c8382750a538762c/pyobjc_framework_WebKit-10.3.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:efce711d3cbe5ef34620002ae2189b802420e6e2923973ed4c59989443b5499f", size = 44847 },
+    { url = "https://files.pythonhosted.org/packages/47/63/6f04faa75c4c39c54007b256a8e13838c1de213d487f561937d342ec2eac/pyobjc_framework_WebKit-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:163abaa5a665b59626ef20cdc3dcc5e2e3fcd9830d5fc328507e13f663acd0ed", size = 44940 },
+    { url = "https://files.pythonhosted.org/packages/3e/61/934f03510e7f49454fbf6eeff8ad2eca5d8bfbe71aa4b8a034f8132af2fa/pyobjc_framework_WebKit-11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2e4911519e94822011d99fdb9addf4a176f45a79808dab18dc303293f4590f7c", size = 44901 },
 ]
 
 [[package]]
@@ -4830,15 +4729,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/4a/eccdcb8c2649d53440ae1902447b86e2e2ad1bc84207c80af9696fa07614/sentry_sdk-2.19.2.tar.gz", hash = "sha256:467df6e126ba242d39952375dd816fbee0f217d119bf454a8ce74cf1e7909e8d", size = 299047 }
+sdist = { url = "https://files.pythonhosted.org/packages/68/e8/6a366c0cd5e129dda6ecb20ff097f70b18182c248d4c27e813c21f98992a/sentry_sdk-2.20.0.tar.gz", hash = "sha256:afa82713a92facf847df3c6f63cec71eb488d826a50965def3d7722aa6f0fdab", size = 300125 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/4d/74597bb6bcc23abc774b8901277652c61331a9d4d0a8d1bdb20679b9bbcb/sentry_sdk-2.19.2-py2.py3-none-any.whl", hash = "sha256:ebdc08228b4d131128e568d696c210d846e5b9d70aa0327dec6b1272d9d40b84", size = 322942 },
+    { url = "https://files.pythonhosted.org/packages/e6/0f/6f7e6cd0f4a141752caef3f79300148422fdf2b8b68b531f30b2b0c0cbda/sentry_sdk-2.20.0-py2.py3-none-any.whl", hash = "sha256:c359a1edf950eb5e80cffd7d9111f3dbeef57994cb4415df37d39fda2cf22364", size = 322576 },
 ]
 
 [[package]]
@@ -5095,7 +4994,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
-    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
 ]
 
 [[package]]


### PR DESCRIPTION
uv new release 0.5.19 broke old `uv.lock` generated from before 0.5.19 (https://github.com/astral-sh/uv/issues/10654)