### PR TITLE
SecOCKey Restore button

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -17,7 +17,7 @@ qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 
 qt_util = qt_env.Library("qt_util", ["#selfdrive/ui/qt/api.cc", "#selfdrive/ui/qt/util.cc"], LIBS=base_libs)
 widgets_src = ["qt/widgets/input.cc", "qt/widgets/wifi.cc", "qt/prime_state.cc",
-               "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/controls.cc",
+               "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/secockey_restore.cc", "qt/widgets/controls.cc",
                "qt/widgets/offroad_alerts.cc", "qt/widgets/prime.cc", "qt/widgets/keyboard.cc",
                "qt/widgets/scrollview.cc", "qt/widgets/cameraview.cc", "#third_party/qrcode/QrCode.cc",
                "qt/request_repeater.cc", "qt/qt_window.cc", "qt/network/networking.cc", "qt/network/wifi_manager.cc"]

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -14,6 +14,7 @@
 #include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/widgets/prime.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
+#include "selfdrive/ui/qt/widgets/secockey_restore.h"
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
 
 TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
@@ -192,6 +193,7 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   setSpacing(50);
   addItem(new LabelControl(tr("Dongle ID"), getDongleId().value_or(tr("N/A"))));
   addItem(new LabelControl(tr("Serial"), params.get("HardwareSerial").c_str()));
+  addItem(new SecOCKeyRestore());
 
   pair_device = new ButtonControl(tr("Pair Device"), tr("PAIR"),
                                   tr("Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer."));

--- a/selfdrive/ui/qt/widgets/secockey_restore.cc
+++ b/selfdrive/ui/qt/widgets/secockey_restore.cc
@@ -1,0 +1,92 @@
+#include "selfdrive/ui/qt/widgets/secockey_restore.h"
+
+#include "common/params.h"
+#include "selfdrive/ui/qt/api.h"
+#include "selfdrive/ui/qt/widgets/input.h"
+
+SecOCKeyRestore::SecOCKeyRestore() :
+  ButtonControl(tr("Restore SecOC Key"), tr("RESTORE"), "") {
+
+  QObject::connect(this, &ButtonControl::clicked, [=]() {
+    setEnabled(false);
+
+    QString installed = QString::fromStdString(params.get("SecOCKey"));
+    QString archived = getArchive("/cache/params/SecOCKey");
+
+    if (isValid(installed)) {
+      if (isValid(archived) && archived != installed) {
+        bool overwrite = ConfirmationDialog(
+            tr("Installed: %1\n       New: %2\n\nInstall the new security key?").arg(installed, archived),
+            "Install", tr("Cancel"), true, this
+        ).exec();
+        if (overwrite) {
+          params.put("SecOCKey", archived.toStdString());
+        }
+      } else {
+        ConfirmationDialog::alert(tr("Security key already installed\n%1").arg(installed), this);
+      }
+    } else {
+      if (isValid(archived)) {
+        // Happy path
+        ConfirmationDialog::alert(tr("Security key restored and installed\n%1").arg(installed), this);
+      } else {
+        ConfirmationDialog::alert(tr("New security key not found"), this);
+      }
+    }
+
+    refresh(); // Live update
+  });
+
+  refresh(); // Initial draw
+}
+
+void SecOCKeyRestore::refresh() {
+  QString key = QString::fromStdString(params.get("SecOCKey"));
+  if (!key.length()) {
+    key = tr("Not Installed");
+  }
+  setDescription(key);
+  setEnabled(true);
+}
+
+QString SecOCKeyRestore::getArchive(QString filePath) {
+  QFile archiveFile(filePath);
+
+  // Archived key file doesn't exist
+  if (!archiveFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return "";
+  }
+
+  QTextStream in(&archiveFile);
+  QString key = in.readAll();
+  archiveFile.close();
+
+  // Archived key file can't be read
+  if (in.status() != QTextStream::Ok) {
+    return "";
+  }
+
+  // Archived key is not a valid key
+  if (!isValid(key)) {
+    return "";
+  }
+
+  // Return the key
+  return key;
+}
+
+// Check if the key is a 32 characters long hexadecimal string
+bool SecOCKeyRestore::isValid(QString key) {
+  if (key.length() != 32) {
+    return false;
+  }
+
+  // Check if each character is a valid hexadecimal digit (0-9, a-f)
+  for (QChar c : key) {
+    if (!c.isDigit() && !(c.isLower() && c >= 'a' && c <= 'f')) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/selfdrive/ui/qt/widgets/secockey_restore.h
+++ b/selfdrive/ui/qt/widgets/secockey_restore.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QPushButton>
+#include <QFile>
+
+#include "selfdrive/ui/qt/widgets/controls.h"
+
+class SecOCKeyRestore : public ButtonControl {
+  Q_OBJECT
+
+public:
+  SecOCKeyRestore();
+
+private:
+  Params params;
+
+  QString getArchive(QString);
+  bool isValid(QString);
+  void refresh();
+};


### PR DESCRIPTION
**Description**

Owners of Toyota Security Key (TSK) vehicles need to extract the security key and then and write it to `SecOCKey` param. The biggest hurdle for this is the SSH requirement, as many people have not used SSH or GitHub before.

Extracting the security key is now possible to do without SSH through a community-developed GUI application [TSK Manager](https://github.com/optskug/docs?tab=readme-ov-file#step-4a-run-the-exploit-using-tsk-manager). By pushing a GUI button, users are able to extract the security key and then write to 1. `/data/params/d/SecOCKey` to install the param and also to 2. `/cache/params/SecOCKey` to archive it.

While this works well for the initial extraction and putting the param before the initial openpilot installation, *reinstalling* openpilot remains to be cumbersome. Uninstalling openpilot deletes the param, so the users must SSH in and write the key again on each uninstall/reinstall.

This PR adds a settings button to restore the key that's archived in `/cache/params/SecOCKey` file onto `SecOCKey` param. This allows the users who already extracted and archived the key using TSK Manager to restore the key upon a reinstall without using SSH.

A shortcoming of this button is that `/cache/params/SecOCKey` archive file must already contain the key. The existing users who had used SSH in the past to extract the key (as opposed to using TSK Manager) don't have this file, but such people already have SSH configured so it's not difficult to guide them to create the archive file.

**Verification**
I've tested on my device for all code paths.