### PR TITLE
ui: prevent device pairing if no internet or system time is invalid

### DIFF
--- a/common/util.cc
+++ b/common/util.cc
@@ -294,4 +294,17 @@ std::string check_output(const std::string& command) {
   return result;
 }
 
+bool system_time_valid() {
+  // Default to August 26, 2024
+  tm min_tm = {.tm_year = 2024 - 1900, .tm_mon = 7, .tm_mday = 26};
+  time_t min_date = mktime(&min_tm);
+
+  struct stat st;
+  if (stat("/lib/systemd/systemd", &st) == 0) {
+    min_date = std::max(min_date, st.st_mtime + 86400);  // Add 1 day (86400 seconds)
+  }
+
+  return time(nullptr) > min_date;
+}
+
 }  // namespace util

--- a/common/util.h
+++ b/common/util.h
@@ -96,6 +96,8 @@ bool create_directories(const std::string &dir, mode_t mode);
 
 std::string check_output(const std::string& command);
 
+bool system_time_valid();
+
 inline void sleep_for(const int milliseconds) {
   if (milliseconds > 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -116,6 +116,14 @@ PairingPopup::PairingPopup(QWidget *parent) : DialogBase(parent) {
   hlayout->addWidget(qr, 1);
 }
 
+int PairingPopup::exec() {
+  if (!util::system_time_valid()) {
+    ConfirmationDialog::alert(tr("Please connect to Wi-Fi to complete initial pairing"), parentWidget());
+    return QDialog::Rejected;
+  }
+  return DialogBase::exec();
+}
+
 
 PrimeUserWidget::PrimeUserWidget(QWidget *parent) : QFrame(parent) {
   setObjectName("primeWidget");

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -118,7 +118,7 @@ PairingPopup::PairingPopup(QWidget *parent) : DialogBase(parent) {
 
 int PairingPopup::exec() {
   auto network_type = (*uiState()->sm)["deviceState"].getDeviceState().getNetworkType();
-  if (network_type == cereal::DeviceState::NetworkType::NONE || !util::system_time_valid()) {
+  if (!util::system_time_valid()) {
     ConfirmationDialog::alert(tr("Please connect to Wi-Fi to complete initial pairing"), parentWidget());
     return QDialog::Rejected;
   }

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -117,7 +117,8 @@ PairingPopup::PairingPopup(QWidget *parent) : DialogBase(parent) {
 }
 
 int PairingPopup::exec() {
-  if (!util::system_time_valid()) {
+  auto network_type = (*uiState()->sm)["deviceState"].getDeviceState().getNetworkType();
+  if (network_type == cereal::DeviceState::NetworkType::NONE || !util::system_time_valid()) {
     ConfirmationDialog::alert(tr("Please connect to Wi-Fi to complete initial pairing"), parentWidget());
     return QDialog::Rejected;
   }

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -117,7 +117,6 @@ PairingPopup::PairingPopup(QWidget *parent) : DialogBase(parent) {
 }
 
 int PairingPopup::exec() {
-  auto network_type = (*uiState()->sm)["deviceState"].getDeviceState().getNetworkType();
   if (!util::system_time_valid()) {
     ConfirmationDialog::alert(tr("Please connect to Wi-Fi to complete initial pairing"), parentWidget());
     return QDialog::Rejected;

--- a/selfdrive/ui/qt/widgets/prime.h
+++ b/selfdrive/ui/qt/widgets/prime.h
@@ -33,6 +33,7 @@ class PairingPopup : public DialogBase {
 
 public:
   explicit PairingPopup(QWidget* parent);
+  int exec() override;
 };
 
 

--- a/selfdrive/ui/translations/main_ar.ts
+++ b/selfdrive/ui/translations/main_ar.ts
@@ -460,6 +460,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>اجعل لـconnect.comma.ai إشارة مرجعية على شاشتك  الرئيسية من أجل استخدامه مثل أي تطبيق</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -455,6 +455,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>Füge connect.comma.ai als Lesezeichen auf deinem Homescreen hinzu um es wie eine App zu verwenden</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_es.ts
+++ b/selfdrive/ui/translations/main_es.ts
@@ -456,6 +456,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>Añada connect.comma.ai a su pantalla de inicio para usarlo como una aplicación</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -456,6 +456,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>Ajoutez connect.comma.ai à votre écran d&apos;accueil pour l&apos;utiliser comme une application</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -454,6 +454,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>「connect.comma.ai」をホーム画面に追加して、アプリのように使うことができます。</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -455,6 +455,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>connect.comma.ai를 앱처럼 사용하려면 홈 화면에 바로가기를 만드세요</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -456,6 +456,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>Salve connect.comma.ai como sua página inicial para utilizar como um app</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_th.ts
+++ b/selfdrive/ui/translations/main_th.ts
@@ -455,6 +455,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>จดจำ connect.comma.ai โดยการเพิ่มไปยังหน้าจอโฮม เพื่อใช้งานเหมือนเป็นแอปพลิเคชัน</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_tr.ts
+++ b/selfdrive/ui/translations/main_tr.ts
@@ -454,6 +454,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>Uygulama gibi kullanmak için connect.comma.ai sitesini yer işaretlerine ekleyin.</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -455,6 +455,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>将 connect.comma.ai 收藏到您的主屏幕，以便像应用程序一样使用它</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -455,6 +455,10 @@
         <source>Bookmark connect.comma.ai to your home screen to use it like an app</source>
         <translation>將 connect.comma.ai 加入您的主螢幕，以便像手機 App 一樣使用它</translation>
     </message>
+    <message>
+        <source>Please connect to Wi-Fi to complete initial pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ParamControl</name>


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/34399

Override `PairingPopup::exec()` to prompt the user to connect to Wi-Fi. This approach enables a straightforward user prompt without requiring changes to the pairing logic in the device settings and setup widget:


![Screenshot from 2025-01-17 11-51-50](https://github.com/user-attachments/assets/c3bae8cc-705f-411d-83fb-4c1c43b888dc)

