### PR TITLE
params: move blocking read to Cython and remove C++ signal handling

### DIFF
--- a/common/params.h
+++ b/common/params.h
@@ -39,9 +39,9 @@ public:
   void clearAll(ParamKeyType type);
 
   // helpers for reading values
-  std::string get(const std::string &key, bool block = false);
-  inline bool getBool(const std::string &key, bool block = false) {
-    return get(key, block) == "1";
+  std::string get(const std::string &key);
+  inline bool getBool(const std::string &key) {
+    return get(key) == "1";
   }
   std::map<std::string, std::string> readAll();
 


### PR DESCRIPTION
re-open https://github.com/commaai/openpilot/pull/32367

The current C++ blocking read have signal handling issues:
1. Its custom signal handler prevents other modules from receiving SIGINT/SIGTERM signals during blocking read, leading to improper termination.
2. When multiple blocking reads occur concurrently in different threads, the later-read thread might restore the signal handler to the `params_sig_handler` installed by the preceding blocking read. This action permanently disables the default signal handler or the handler set up by the program, leading to improper signal handling within the program after blocking reads.

this PR replaces the problematic C++ blocking reads with Cython implementation. This new implementation delegates the handling of SIGINT and SIGTERM signals to Python's built-in mechanisms, ensuring smoother interruption management.

This PR removes C++ support for blocking reads (as they are no longer needed in the current C++ codebase), though they remain straightforward to implement if required:

```c++
while (!exit) {
  val = params.read(key);
  if (!val.empty()) break;

  util::sleep_for(100);
}
```
