### PR TITLE
Update simulator to calculate and fill sensor values (IMUState)

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -113,11 +113,11 @@ class MetaDriveWorld(World):
 
       imu_update_interval = 1
       if since_last_check >= imu_update_interval:
-          state.set_accelerometer(self.prev_velocity, since_last_check)
-          state.set_gyroscope(self.prev_bearing, since_last_check)
+        state.set_accelerometer(self.prev_velocity, since_last_check)
+        state.set_gyroscope(self.prev_bearing, since_last_check)
 
-          self.prev_velocity = state.velocity
-          self.prev_bearing = state.bearing
+        self.prev_velocity = state.velocity
+        self.prev_bearing = state.bearing
 
 
       time_check_threshold = 29

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -113,8 +113,10 @@ class MetaDriveWorld(World):
 
       imu_update_interval = 1
       if since_last_check >= imu_update_interval:
-        state.set_accelerometer(self.prev_velocity, since_last_check)
-        state.set_gyroscope(self.prev_bearing, since_last_check)
+        prev_velocity = self.prev_velocity if self.prev_velocity is not None else state.velocity
+        prev_bearing = self.prev_bearing if self.prev_bearing is not None else state.bearing
+        state.set_accelerometer(prev_velocity, since_last_check)
+        state.set_gyroscope(prev_bearing, since_last_check)
 
         self.prev_velocity = state.velocity
         self.prev_bearing = state.bearing

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -58,7 +58,43 @@ class SimulatorState:
 
   @property
   def speed(self):
-    return math.sqrt(self.velocity.x ** 2 + self.velocity.y ** 2 + self.velocity.z ** 2)
+    return math.sqrt(self.velocity.x**2 + self.velocity.y**2 + self.velocity.z**2)
+
+  def set_acceleration(self, prev_velocity: vec3, dt: float) -> vec3:
+    if prev_velocity is None:  # First time
+      return
+
+    if dt <= 0:
+      raise ValueError("Time difference (dt) must be greater than zero.")
+
+    # Compute acceleration for each component
+    acc_x = (self.velocity.x - prev_velocity.x) / dt
+    acc_y = (self.velocity.y - prev_velocity.y) / dt
+    acc_z = (self.velocity.z - prev_velocity.z) / dt
+
+    # Return acceleration as a vec3
+    self.imu.accelerometer = vec3(acc_x, acc_y, acc_z)
+
+  def set_gyroscope(self, prev_bearing: float, dt: float) -> vec3:
+    """
+    Calculate a simple gyroscope reading based on the rate of change of bearing (yaw).
+    For more advanced scenarios, you could also estimate pitch and roll rates.
+    """
+    if prev_bearing is None:  # First time
+      return
+
+    if dt <= 0:
+      raise ValueError("Time difference (dt) must be greater than zero.")
+
+    if dt <= 0:
+      raise ValueError("Time difference (dt) must be greater than zero.")
+
+    # Calculate change in bearing (yaw)
+    delta_bearing = self.bearing - prev_bearing
+    yaw_rate = delta_bearing / dt
+
+    # For now, assume no pitch or roll rate 0 car probably not rotating along its axis and not tilting its nose most of the time
+    self.imu.gyroscope = vec3(0, 0, yaw_rate)
 
 
 class World(ABC):

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -62,10 +62,11 @@ class SimulatorState:
 
   def set_accelerometer(self, prev_velocity: vec3, dt: float) -> vec3:
     if prev_velocity is None:  # First time
-      return vec3(0, 0, 0)
+      prev_velocity = vec3(0, 0, 0)
 
     if dt <= 0:
-      raise ValueError("Time difference (dt) must be greater than zero.")
+      print("Warning: Time difference (dt) must be greater than zero. Skipping IMU update.")
+      return vec3(0, 0, 0)  # Return a default acceleration value
 
     # Compute acceleration for each component
     acc_x = (self.velocity.x - prev_velocity.x) / dt
@@ -85,7 +86,8 @@ class SimulatorState:
       prev_bearing = 0
 
     if dt <= 0:
-      raise ValueError("Time difference (dt) must be greater than zero.")
+      print("Warning: Time difference (dt) must be greater than zero. Skipping IMU update.")
+      return vec3(0, 0, 0)
 
     # Calculate change in bearing (yaw)
     delta_bearing = self.bearing - prev_bearing

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -61,8 +61,6 @@ class SimulatorState:
     return math.sqrt(self.velocity.x**2 + self.velocity.y**2 + self.velocity.z**2)
 
   def set_accelerometer(self, prev_velocity: vec3, dt: float) -> vec3:
-    if prev_velocity is None:  # First time
-      prev_velocity = vec3(0, 0, 0)
 
     if dt <= 0:
       print("Warning: Time difference (dt) must be greater than zero. Skipping IMU update.")
@@ -82,8 +80,6 @@ class SimulatorState:
     Calculate a simple gyroscope reading based on the rate of change of bearing (yaw).
     For more advanced scenarios, you could also estimate pitch and roll rates.
     """
-    if prev_bearing is None:  # First time
-      prev_bearing = 0
 
     if dt <= 0:
       print("Warning: Time difference (dt) must be greater than zero. Skipping IMU update.")

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -60,9 +60,9 @@ class SimulatorState:
   def speed(self):
     return math.sqrt(self.velocity.x**2 + self.velocity.y**2 + self.velocity.z**2)
 
-  def set_acceleration(self, prev_velocity: vec3, dt: float) -> vec3:
+  def set_accelerometer(self, prev_velocity: vec3, dt: float) -> vec3:
     if prev_velocity is None:  # First time
-      return
+      return vec3(0, 0, 0)
 
     if dt <= 0:
       raise ValueError("Time difference (dt) must be greater than zero.")
@@ -72,8 +72,9 @@ class SimulatorState:
     acc_y = (self.velocity.y - prev_velocity.y) / dt
     acc_z = (self.velocity.z - prev_velocity.z) / dt
 
-    # Return acceleration as a vec3
     self.imu.accelerometer = vec3(acc_x, acc_y, acc_z)
+    # Return acceleration as a vec3
+    return vec3(acc_x, acc_y, acc_z)
 
   def set_gyroscope(self, prev_bearing: float, dt: float) -> vec3:
     """
@@ -81,10 +82,7 @@ class SimulatorState:
     For more advanced scenarios, you could also estimate pitch and roll rates.
     """
     if prev_bearing is None:  # First time
-      return
-
-    if dt <= 0:
-      raise ValueError("Time difference (dt) must be greater than zero.")
+      prev_bearing = 0
 
     if dt <= 0:
       raise ValueError("Time difference (dt) must be greater than zero.")
@@ -93,8 +91,10 @@ class SimulatorState:
     delta_bearing = self.bearing - prev_bearing
     yaw_rate = delta_bearing / dt
 
-    # For now, assume no pitch or roll rate 0 car probably not rotating along its axis and not tilting its nose most of the time
     self.imu.gyroscope = vec3(0, 0, yaw_rate)
+
+    # For now, assume no pitch or roll rate 0 car probably not rotating along its axis and not tilting its nose most of the time
+    return vec3(0, 0, yaw_rate)
 
 
 class World(ABC):


### PR DESCRIPTION
**Description**

The IMUState in the simulator was not being updated, causing `locationd` to receive zeros for the accelerometer and gyroscope values. This led to `paramsd` learning a bad offset and impacting the system's ability to process vehicle motion correctly.

This fix calculates and updates:
1. **Bearing**: Directly retrieved from the `metadrive_vehicle_state` and stored in `state.imu.bearing`.
2. **Accelerometer**: Computed based on the change in velocity (`velocity`) over time (`dt`) and stored in `state.imu.accelerometer`.
3. **Gyroscope**: The yaw rate is calculated from the change in bearing over time (`dt`) and stored in `state.imu.gyroscope`.

These updates ensure that the IMU state provides meaningful data to `locationd`.

Fixes #[33721](https://github.com/commaai/openpilot/issues/33721)

---

**Verification**

The bug fix was tested with simulated vehicle state data:
- **Bearing**: Verified with "==", with md_vehicle.bearing
- **Accelerometer**: Computed using `velocity` changes between consecutive time steps and validated with expected output.
- **Gyroscope**: Yaw rate derived from bearing changes over time and logged to ensure accuracy.

Print statements were used during development to confirm:
- Previous and current velocity values for acceleration.
- Bearing and its changes for gyroscope values.
- Logs and output confirmed that the IMU state was updated consistently across simulation runs.

