### PR TITLE
ui/installer: replace time_valid() with util::system_time_valid() for consistency

### DIFF
--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -1,4 +1,3 @@
-#include <time.h>
 #include <unistd.h>
 
 #include <cstdlib>
@@ -11,6 +10,7 @@
 #include <QTimer>
 #include <QVBoxLayout>
 
+#include "common/util.h"
 #include "selfdrive/ui/installer/installer.h"
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/qt_window.h"
@@ -35,14 +35,6 @@ const QString CACHE_PATH = "/data/openpilot.cache";
 
 extern const uint8_t str_continue[] asm("_binary_selfdrive_ui_installer_continue_openpilot_sh_start");
 extern const uint8_t str_continue_end[] asm("_binary_selfdrive_ui_installer_continue_openpilot_sh_end");
-
-bool time_valid() {
-  time_t rawtime;
-  time(&rawtime);
-
-  struct tm * sys_time = gmtime(&rawtime);
-  return (1900 + sys_time->tm_year) >= 2020;
-}
 
 void run(const char* cmd) {
   int err = std::system(cmd);
@@ -103,7 +95,7 @@ void Installer::updateProgress(int percent) {
 
 void Installer::doInstall() {
   // wait for valid time
-  while (!time_valid()) {
+  while (!util::system_time_valid()) {
     usleep(500 * 1000);
     qDebug() << "Waiting for valid time";
   }


### PR DESCRIPTION
replaces the time_valid() function with util::system_time_valid() to ensure consistent time validation across the codebase