### PR TITLE
camerad: properly clean up sync objects after request flush

### DIFF
--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -114,6 +114,7 @@ public:
   void configICP();
   void configCSIPHY();
   void linkDevices();
+  void destroySyncObjectAt(int index);
 
   // *** state ***
 


### PR DESCRIPTION
This change ensures that sync objects are properly destroyed after flushing camera requests, preventing potential resource leaks and synchronization issues. It also addresses recurring `CAM_SYNC` errors during camera re-alignment, such as:

```
system/camerad/cameras/spectra.cc: camera 0 realign
camerad logmessaged timed dmonitoringmodeld ui pandad deleter dmonitoringd hardwared tombstoned updated uploader statsd
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 1
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 2
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 3
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 4
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 5
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 6
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 7
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 8
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 9
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 10
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 11
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 12
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 13
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 14
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 15
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 16
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 17
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 18
system/camerad/cameras/spectra.cc: camera 1 realign
system/camerad/cameras/spectra.cc: CAM_SYNC error: id 6 - errno 11 - ret 0 - ioctl_result -22
system/camerad/cameras/spectra.cc: failed to wait for sync: -22 39
.....

```