### PR TITLE
ui/cameraview: gate `glDeleteTextures` to PC platforms only

### DIFF
--- a/selfdrive/ui/qt/widgets/cameraview.cc
+++ b/selfdrive/ui/qt/widgets/cameraview.cc
@@ -79,7 +79,9 @@ CameraWidget::~CameraWidget() {
     glDeleteVertexArrays(1, &frame_vao);
     glDeleteBuffers(1, &frame_vbo);
     glDeleteBuffers(1, &frame_ibo);
+#ifndef QCOM2
     glDeleteTextures(2, textures);
+#endif
   }
   doneCurrent();
 }


### PR DESCRIPTION
The `glGenTextures` function is only called on PC, as seen in the following code: 

https://github.com/commaai/openpilot/blob/3c3617088b77a135439cea4b5a6133fb0449be1e/selfdrive/ui/qt/widgets/cameraview.cc#L138-L144

This PR ensures `glDeleteTextures` is only called on PC, avoiding deletion on devices where textures are not generated.