### PR TITLE
encoderd: fix SIGABRT caused by buffer extras out-of-sync with buffers

### DIFF
--- a/system/loggerd/encoder/v4l_encoder.h
+++ b/system/loggerd/encoder/v4l_encoder.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <array>
+#include <mutex>
+
 #include "common/queue.h"
 #include "system/loggerd/encoder/encoder.h"
 
@@ -20,7 +23,8 @@ private:
   int segment_num = -1;
   int counter = 0;
 
-  SafeQueue<VisionIpcBufExtra> extras;
+  std::mutex buffer_extras_mutex;
+  std::array<VisionIpcBufExtra, BUF_OUT_COUNT> buffer_extras = {};
 
   static void dequeue_handler(V4LEncoder *e);
   std::thread dequeue_handler_thread;


### PR DESCRIPTION
This PR fixes a synchronization issue between buffer extras and buffers that was causing a SIGABRT due to them being out of sync, leading to crashes during the encoder's operation.