### PR TITLE
camerad: refactor `write_cont`  to support C arrays

### DIFF
--- a/system/camerad/cameras/cdm.cc
+++ b/system/camerad/cameras/cdm.cc
@@ -14,21 +14,21 @@ int write_dmi(uint8_t *dst, uint64_t *addr, uint32_t length, uint32_t dmi_addr, 
   return sizeof(struct cdm_dmi_cmd);
 }
 
-int write_cont(uint8_t *dst, uint32_t reg, const std::vector<uint32_t> &vals) {
+int write_cont(uint8_t *dst, uint32_t reg, const uint32_t *values, size_t value_count) {
   struct cdm_regcontinuous_cmd *cmd = (struct cdm_regcontinuous_cmd*)dst;
   cmd->cmd = CAM_CDM_CMD_REG_CONT;
-  cmd->count = vals.size();
+  cmd->count = value_count;
   cmd->offset = reg;
   cmd->reserved0 = 0;
   cmd->reserved1 = 0;
 
   uint32_t *vd = (uint32_t*)(dst + sizeof(struct cdm_regcontinuous_cmd));
-  for (int i = 0; i < vals.size(); i++) {
-    *vd = vals[i];
+  for (int i = 0; i < value_count; i++) {
+    *vd = values[i];
     vd++;
   }
 
-  return sizeof(struct cdm_regcontinuous_cmd) + vals.size()*sizeof(uint32_t);
+  return sizeof(struct cdm_regcontinuous_cmd) + value_count * sizeof(uint32_t);
 }
 
 int write_random(uint8_t *dst, const std::vector<uint32_t> &vals) {

--- a/system/camerad/cameras/cdm.h
+++ b/system/camerad/cameras/cdm.h
@@ -7,8 +7,18 @@
 #include <memory>
 
 // our helpers
+int write_cont(uint8_t *dst, uint32_t reg, const uint32_t *values, size_t value_count);
+
+template <std::size_t N>
+int write_cont(uint8_t *dst, uint32_t reg, const uint32_t (&values)[N]) {
+  return write_cont(dst, reg, values, N);
+}
+
+inline int write_cont(uint8_t *dst, uint32_t reg, const std::vector<uint32_t> &values) {
+  return write_cont(dst, reg, values.data(), values.size());
+}
+
 int write_random(uint8_t *dst, const std::vector<uint32_t> &vals);
-int write_cont(uint8_t *dst, uint32_t reg, const std::vector<uint32_t> &vals);
 int write_dmi(uint8_t *dst, uint64_t *addr, uint32_t length, uint32_t dmi_addr, uint8_t sel);
 
 // from drivers/media/platform/msm/camera/cam_cdm/cam_cdm_util.{c,h}


### PR DESCRIPTION
The refactor improves the performance of the `write_cont` function by removing the dependency on `std::vector` and switching to more efficient raw C arrays. This eliminates unnecessary memory allocations and copies, resulting in a more efficient implementation. The updates include:

1. Replacing std::vector with raw pointers and size for better memory management.
2. Adding a template overload to support fixed-size arrays.
3. Providing an inline helper to maintain compatibility with std::vector. (for passing `sensor->linearization_pts` to write_cont)