### PR TITLE
ui: exclude developer-specific toggles in release branch

### DIFF
--- a/selfdrive/ui/qt/offroad/developer_panel.h
+++ b/selfdrive/ui/qt/offroad/developer_panel.h
@@ -9,13 +9,14 @@ public:
   void showEvent(QShowEvent *event) override;
 
 private:
+  void initDevToggles();
+
   Params params;
   ParamControl* joystickToggle;
   ParamControl* longManeuverToggle;
   ParamControl* alphaLongToggle;
 
-  bool is_release;
-  bool offroad;
+  bool offroad = false;
 
 private slots:
   void updateToggles(bool _offroad);


### PR DESCRIPTION
Prevents the creation of developer-specific toggles (`joystickToggle`, `longManeuverToggle`, `alphaLongToggle`) in release branches, as these are intended only for development environments. This change improves code clarity and reduces overhead in release builds.

Other changes:
1. Explicitly initialized the  `offroad` to false for consistent default behavior.
2. Replaced `findChildren<ParamControl *>()` with direct references to the relevant toggles for improved clarity.
3. Cleanup includes