### PR TITLE
Reapply "bump msgq (#34410)"

### DIFF
--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -91,9 +91,6 @@ void can_send_thread(std::vector<Panda *> pandas, bool fake_send) {
   while (!do_exit && check_all_connected(pandas)) {
     std::unique_ptr<Message> msg(subscriber->receive());
     if (!msg) {
-      if (errno == EINTR) {
-        do_exit = true;
-      }
       continue;
     }
 


### PR DESCRIPTION
Redo of https://github.com/commaai/openpilot/pull/34410

Need to ignore EINTR

I was wondering why we needed this for https://github.com/commaai/openpilot/pull/32103, because if msgq receives a termination signal, it will just set do_exit for us. However, this never worked because:

- manager sends kill signal to all processes in series (almost parallel)
- card gets SIGINT first and stops sending sendcan to pandad before pandad gets SIGINT
  - so now we're in the 100ms msgq recv timeout + msgq signal handler. pandad thus sees the SIGINT 50-100ms later than it's delivered, and this time without sendcan is enough to fault the car