### PR TITLE
`op.sh`: adb

### DIFF
--- a/tools/adb_shell.sh
+++ b/tools/adb_shell.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env expect
+spawn adb shell
+expect "#"
+send "cd usr/comma\r"
+send "export TERM=xterm-256color\r"
+send "clear\r"
+interact

--- a/tools/adb_shell.sh
+++ b/tools/adb_shell.sh
@@ -3,5 +3,6 @@ spawn adb shell
 expect "#"
 send "cd usr/comma\r"
 send "export TERM=xterm-256color\r"
+send "su comma\r"
 send "clear\r"
 interact

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -393,6 +393,7 @@ function op_default() {
   echo -e "  ${BOLD}juggle${NC}       Run PlotJuggler"
   echo -e "  ${BOLD}replay${NC}       Run Replay"
   echo -e "  ${BOLD}cabana${NC}       Run Cabana"
+  echo -e "  ${BOLD}adb${NC}          Run adb shell"
   echo ""
   echo -e "${BOLD}${UNDERLINE}Commands [Testing]:${NC}"
   echo -e "  ${BOLD}sim${NC}          Run openpilot in a simulator"

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -268,6 +268,11 @@ function op_venv() {
   esac
 }
 
+function op_adb() {
+  op_before_cmd
+  op_run_command tools/adb_shell.sh
+}
+
 function op_check() {
   VERBOSE=1
   op_before_cmd
@@ -443,6 +448,7 @@ function _op() {
     stop )          shift 1; op_stop "$@" ;;
     restart )       shift 1; op_restart "$@" ;;
     post-commit )   shift 1; op_install_post_commit "$@" ;;
+    adb )           shift 1; op_adb "$@" ;;
     * ) op_default "$@" ;;
   esac
 }


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

makes it easier so that you automatiaclly put into directory `usr/comma` and `TERM=xterm-256-color`

leaving into draft since although this works it would be nice to go into adb shell as comma user and not root.

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

