### PR TITLE
Log git diff inside submodules

### DIFF
--- a/system/updated/updated.py
+++ b/system/updated/updated.py
@@ -172,7 +172,7 @@ def init_overlay() -> None:
   run(["sudo"] + mount_cmd)
   run(["sudo", "chmod", "755", os.path.join(OVERLAY_METADATA, "work")])
 
-  git_diff = run(["git", "diff"], OVERLAY_MERGED)
+  git_diff = run(["git", "diff", "--submodule=diff"], OVERLAY_MERGED)
   params.put("GitDiff", git_diff)
   cloudlog.info(f"git diff output:\n{git_diff}")
 


### PR DESCRIPTION
Before:

```
batman@workstation-shane:~/openpilot$ git diff
diff --git a/opendbc_repo b/opendbc_repo
--- a/opendbc_repo
+++ b/opendbc_repo
@@ -1 +1 @@
-Subproject commit 00bb29c36c34849386d7ac07a31625413399badc
+Subproject commit 00bb29c36c34849386d7ac07a31625413399badc-dirty
```

Aftter:

```
batman@workstation-shane:~/openpilot$ git diff --submodule=diff
Submodule opendbc_repo contains modified content
diff --git a/opendbc_repo/opendbc/car/toyota/carcontroller.py b/opendbc_repo/opendbc/car/toyota/carcontroller.py
index 446621d..2c863f3 100644
--- a/opendbc_repo/opendbc/car/toyota/carcontroller.py
+++ b/opendbc_repo/opendbc/car/toyota/carcontroller.py
@@ -39,9 +39,9 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows
 
 
 def get_long_tune(CP, params):
-  kiBP = [0.]
+  kiBP = [0., 5]
   if CP.carFingerprint in TSS2_CAR:
-    kiV = [0.25]
+    kiV = [0.25, 0.5]
 
   else:
     kiBP = [0., 5., 35.]
```