### PR TITLE
encoderd: ensure buffer state transitions atomic

### DIFF
--- a/system/loggerd/encoder/v4l_encoder.h
+++ b/system/loggerd/encoder/v4l_encoder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "common/queue.h"
 #include "system/loggerd/encoder/encoder.h"
 
@@ -14,6 +16,10 @@ public:
   void encoder_open(const char* path);
   void encoder_close();
 private:
+  void queue_buffer(v4l2_buf_type buf_type, uint32_t index, VisionBuf *buf, struct timeval timestamp={});
+  void dequeue_buffer(v4l2_buf_type buf_type, uint32_t *index = nullptr, uint32_t *bytesused = nullptr,
+                     uint32_t *flags = nullptr, struct timeval *timestamp = nullptr);
+  std::mutex mutex;
   int fd;
 
   bool is_open = false;


### PR DESCRIPTION
We currently queue buffers for `V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE` in `encode_frame()` and dequeue them in a separate thread `dequeue_handler()`. While this can work,  it can be unsafe without proper synchronization. Using `VIDIOC_QBUF` and `VIDIOC_DQBUF` to manage the same set of buffers across different threads can lead to race conditions.

This PR ensures that buffer transitions (queuing and dequeuing) are atomic, preventing thread conflicts. While some drivers and Linux kernel versions may provide thread safety for the buffer state transitions, it’s still a best practice to introduce light synchronization (mutex) to guarantee robustness and prevent potential issues.

resolve: https://github.com/commaai/openpilot/issues/26328