### PR TITLE
encoderd: enhance robustness of open() with HANDLE_EINTR Macro

### DIFF
--- a/system/loggerd/encoder/v4l_encoder.cc
+++ b/system/loggerd/encoder/v4l_encoder.cc
@@ -155,7 +155,7 @@ void V4LEncoder::dequeue_handler(V4LEncoder *e) {
 
 V4LEncoder::V4LEncoder(const EncoderInfo &encoder_info, int in_width, int in_height)
     : VideoEncoder(encoder_info, in_width, in_height) {
-  fd = open("/dev/v4l/by-path/platform-aa00000.qcom_vidc-video-index1", O_RDWR|O_NONBLOCK);
+  fd = HANDLE_EINTR(open("/dev/v4l/by-path/platform-aa00000.qcom_vidc-video-index1", O_RDWR|O_NONBLOCK));
   assert(fd >= 0);
 
   struct v4l2_capability cap;


### PR DESCRIPTION
We already handle `EINTR` for all other system calls except `open()` in `encoderd`. While `open()` is only called during initialization, it is still important to handle `EINTR` to ensure the call is safely retried if interrupted.