### PR TITLE
`ui-preview`: fix keyboard screenshot

### DIFF
--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -127,7 +127,7 @@ def setup_body(click, pm: PubMaster):
 def setup_keyboard(click, pm: PubMaster):
   setup_settings_device(click, pm)
   click(250, 965)
-  click(1930, 440)
+  click(1930, 420)
 
 def setup_keyboard_uppercase(click, pm: PubMaster):
   setup_keyboard(click, pm)

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -127,7 +127,7 @@ def setup_body(click, pm: PubMaster):
 def setup_keyboard(click, pm: PubMaster):
   setup_settings_device(click, pm)
   click(250, 965)
-  click(1930, 228)
+  click(1930, 440)
 
 def setup_keyboard_uppercase(click, pm: PubMaster):
   setup_keyboard(click, pm)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

introduction of adb broke the diff checker due to the click being wrong. The alternative was to move back the ADD button where it was although I purposely set the adb toggle to be at the top for visual appeal.

If we're not fine with this PR change then I can move SSH keys back where it was.

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

