### PR TITLE
experiment with aLeadTau

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -12,8 +12,8 @@ from openpilot.common.swaglog import cloudlog
 from openpilot.common.simple_kalman import KF1D
 
 
-# Default lead acceleration decay set to 50% at 1s
-_LEAD_ACCEL_TAU = 1.4
+# Default lead acceleration decay set to 50% at 1.5s
+_LEAD_ACCEL_TAU = 0.6
 
 # radar tracks
 SPEED, ACCEL = 0, 1     # Kalman filter states enum

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -74,7 +74,8 @@ class Track:
 
     # Learn if constant acceleration
     if abs(self.aLeadK) < 0.5:
-      self.aLeadTau = _LEAD_ACCEL_TAU
+      self.aLeadTau = min(max(self.aLeadTau, 1e-2) * 1.1, _LEAD_ACCEL_TAU)
+      # self.aLeadTau += (_LEAD_ACCEL_TAU - self.aLeadTau) * 0.1  # shape back up isn't correct
     else:
       self.aLeadTau *= 0.9
 

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -13,7 +13,7 @@ from openpilot.common.simple_kalman import KF1D
 
 
 # Default lead acceleration decay set to 50% at 1s
-_LEAD_ACCEL_TAU = 1.5
+_LEAD_ACCEL_TAU = 1.4
 
 # radar tracks
 SPEED, ACCEL = 0, 1     # Kalman filter states enum


### PR DESCRIPTION
Prevents instant aLeadTau resets when aLeadK crosses zero, or when briefly dropping below the threshold. If the lead was just heavily decelerating, and is now slightly positive, we may be able to assume they will heavily accelerate as well, same with the opposite case.

Quicker recovery from braking:

![image](https://github.com/user-attachments/assets/c847d6d9-6094-41a7-912a-0e768248e9e8)

Here aLeadTau reset many times due to the lead's oscillating deceleration on an offramp. You can see the difference with the reset unwind. The peak deceleration will be much less than before (what causes discomfort):

![image](https://github.com/user-attachments/assets/8717df6f-a0ab-44fc-888d-e40c82af0293)

...and the planner generally now wants to go a little slower while in the steady state deceleration:

![image](https://github.com/user-attachments/assets/49fdac90-5da3-4abe-a205-763d5fd30620)