### PR TITLE
replay: improve segment loading and event handling

### DIFF
--- a/tools/cabana/streams/abstractstream.cc
+++ b/tools/cabana/streams/abstractstream.cc
@@ -226,7 +226,7 @@ std::pair<CanEventIter, CanEventIter> AbstractStream::eventsInRange(const Messag
   if (!time_range) return {events.begin(), events.end()};
 
   auto first = std::lower_bound(events.begin(), events.end(), can->toMonoTime(time_range->first), CompareCanEvent());
-  auto last = std::upper_bound(events.begin(), events.end(), can->toMonoTime(time_range->second), CompareCanEvent());
+  auto last = std::upper_bound(first, events.end(), can->toMonoTime(time_range->second), CompareCanEvent());
   return {first, last};
 }
 

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -93,6 +93,7 @@ private:
   std::time_t route_date_time_;
   uint64_t route_start_ts_ = 0;
   std::atomic<uint64_t> cur_mono_time_ = 0;
+  cereal::Event::Which cur_which_ = cereal::Event::Which::INIT_DATA;
   double min_seconds_ = 0;
   double max_seconds_ = 0;
   SubMaster *sm_ = nullptr;

--- a/tools/replay/seg_mgr.h
+++ b/tools/replay/seg_mgr.h
@@ -45,7 +45,7 @@ private:
   std::mutex mutex_;
   std::condition_variable cv_;
   std::thread thread_;
-  std::atomic<int> cur_seg_num_ = -1;
+  int cur_seg_num_ = -1;
   bool needs_update_ = false;
   bool exit_ = false;
 


### PR DESCRIPTION
- Fix issue where replay continues to push the last event if the network is slow and the next segment takes time to load.
- Reduce segment loading lock time.
- Improve eventsInRange() efficiency by seeking from the first event instead of events.begin().