### PR TITLE
Add Tesla to car_specific events

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -45,7 +45,7 @@ class CarSpecificEvents:
     if self.CP.brand in ('body', 'mock'):
       events = Events()
 
-    elif self.CP.brand in ('subaru', 'mazda'):
+    elif self.CP.brand in ('subaru', 'mazda', 'tesla'):
       events = self.create_common_events(CS, CS_prev)
 
     elif self.CP.brand == 'ford':


### PR DESCRIPTION
This is the only change needed (except for switching out the submodule) to get the Tesla car ports to work with upstream openpilot