### PR TITLE
Make the speed blue

### DIFF
--- a/selfdrive/ui/qt/onroad/hud.cc
+++ b/selfdrive/ui/qt/onroad/hud.cc
@@ -104,6 +104,6 @@ void HudRenderer::drawText(QPainter &p, int x, int y, const QString &text, int a
   QRect real_rect = p.fontMetrics().boundingRect(text);
   real_rect.moveCenter({x, y - real_rect.height() / 2});
 
-  p.setPen(QColor(0xff, 0xff, 0xff, alpha));
+  p.setPen(QColor(0x00, 0x00, 0xff, alpha));
   p.drawText(real_rect.x(), real_rect.bottom(), text);
 }


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
This is for the demo car.

**Route**
This is for the demo route.

-->

<!--- ***** Template: Car Bugfix *****

**Description**

This makes the speed blue. I did this from the documentation.

**Verification**

I rebuilt the project and tested it from there.

**Route**

This only makes the speed blue.


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [+] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [+] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [+] route with openpilot:
- [+] route with stock system:
- [+] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

This makes the speed blue.

**Verification**

The test shows no regressions.


-->

