### PR TITLE
encoderd: use AV_CODEC_ID_H264 codec for qcamera encoding

### DIFF
--- a/system/loggerd/encoder/ffmpeg_encoder.cc
+++ b/system/loggerd/encoder/ffmpeg_encoder.cc
@@ -48,7 +48,10 @@ FfmpegEncoder::~FfmpegEncoder() {
 }
 
 void FfmpegEncoder::encoder_open(const char* path) {
-  const AVCodec *codec = avcodec_find_encoder(AV_CODEC_ID_FFVHUFF);
+  auto codec_id = encoder_info.encode_type == cereal::EncodeIndex::Type::QCAMERA_H264
+                      ? AV_CODEC_ID_H264
+                      : AV_CODEC_ID_FFVHUFF;
+  const AVCodec *codec = avcodec_find_encoder(codec_id);
 
   this->codec_ctx = avcodec_alloc_context3(codec);
   assert(this->codec_ctx);


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/34492