### PR TITLE
 SConstruct: remove duplicate -lzmq link

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -340,7 +340,7 @@ SConscript(['opendbc_repo/SConscript'], exports={'env': env_swaglog})
 SConscript(['cereal/SConscript'])
 
 Import('socketmaster', 'msgq')
-messaging = [socketmaster, msgq, 'zmq', 'capnp', 'kj',]
+messaging = [socketmaster, msgq, 'capnp', 'kj',]
 Export('messaging')
 
 


### PR DESCRIPTION
remove duplicate -lzmq link:
> clang++ -o selfdrive/pandad/pandad -Wl,--as-needed -Wl,--no-undefined -Wl,-rpath=/home/dean/Projects/openpilot/third_party/acados/x86_64/lib selfdrive/pandad/main.o selfdrive/pandad/pandad.o selfdrive/pandad/panda_safety.o -Lthird_party/acados/x86_64/lib -Lthird_party/libyuv/x86_64/lib -L/usr/lib -L/usr/local/lib -Lmsgq_repo -Lthird_party -Lselfdrive/pandad -Lcommon -Lrednose/helpers selfdrive/pandad/libpanda.a -lusb-1.0 common/libcommon.a -ljson11 **-lzmq** cereal/libsocketmaster.a msgq_repo/libmsgq.a **-lzmq** -lcapnp -lkj -lpthread