### PR TITLE
SConstruct: remove CPPPATH entries for libyuv and json11

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -185,8 +185,6 @@ env = Environment(
     "#third_party/acados/include/blasfeo/include",
     "#third_party/acados/include/hpipm/include",
     "#third_party/catch2/include",
-    "#third_party/libyuv/include",
-    "#third_party/json11",
     "#third_party/linux/include",
     "#third_party",
     "#msgq",


### PR DESCRIPTION
All source files already utilize the full include path for `libyuv` and `json11` dependencies. Therefore, including these directories in the CPPPATH is redundant and can be safely removed.