### PR TITLE
ui/DeveloperPanel: initialize offroad state, refresh toggle, and cleanup Includes

### DIFF
--- a/selfdrive/ui/qt/offroad/developer_panel.cc
+++ b/selfdrive/ui/qt/offroad/developer_panel.cc
@@ -1,10 +1,6 @@
-#include <QDebug>
-#include <QProcess>
-
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
-#include "common/util.h"
 
 DeveloperPanel::DeveloperPanel(SettingsWindow *parent) : ListWidget(parent) {
   adbToggle = new ParamControl("AdbEnabled", tr("Enable ADB"),
@@ -89,6 +85,7 @@ void DeveloperPanel::updateToggles(bool _offroad) {
     longManeuverToggle->setEnabled(false);
     experimentalLongitudinalToggle->setVisible(false);
   }
+  experimentalLongitudinalToggle->refresh();
 
   offroad = _offroad;
 }

--- a/selfdrive/ui/qt/offroad/developer_panel.h
+++ b/selfdrive/ui/qt/offroad/developer_panel.h
@@ -15,7 +15,7 @@ private:
   ParamControl* longManeuverToggle;
   ParamControl* experimentalLongitudinalToggle;
   bool is_release;
-  bool offroad;
+  bool offroad = false;
 
 private slots:
   void updateToggles(bool _offroad);


### PR DESCRIPTION
1. Explicitly initialize `offroad` to false, ensure the panel created with a known state.
2. Refresh `experimentalLongitudinalToggle` after state updates
3. Cleanup of unnecessary includes