### PR TITLE
athenad: refactor deviceState handling with centralized SubMaster

### DIFF
--- a/system/athena/network_status.py
+++ b/system/athena/network_status.py
@@ -1,0 +1,26 @@
+import cereal.messaging as messaging
+import threading
+import time
+
+from cereal import log
+
+DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
+
+class NetworkStatus:
+  def __init__(self):
+    self._metered: bool = False
+    self._network_type: log.DeviceState.NetworkType = log.DeviceState.NetworkType.none
+    self._sm = messaging.SubMaster(['deviceState'])
+    self._lock = threading.Lock()
+
+  def update(self) -> None:
+    elapsed_time = time.monotonic() - self._sm.recv_time['deviceState']
+    if elapsed_time >= DEVICE_STATE_UPDATE_INTERVAL:
+        self._sm.update(0)
+        with self._lock:
+          self._metered = self._sm['deviceState'].networkMetered
+          self._network_type = self._sm['deviceState'].networkType.raw
+
+  def get_status(self) -> tuple[bool, log.DeviceState.NetworkType]:
+    with self._lock:
+      return self._metered, self._network_type


### PR DESCRIPTION
This PR introduces a `NetworkStatus` class to centralize `deviceState` management and improve efficiency.

Changes:
1. Single SubMaster Instance:
     Replaces the creation of multiple `SubMaster(['deviceState']) `instances in the `upload_handler` threads with a single shared instance, enhancing performance and reducing resource usage.
2. Thread-safe Access:
        Provides thread-safe methods to update and read network status (metered, network_type).
