### PR TITLE
qcomgps: fix NameError

### DIFF
--- a/system/qcomgpsd/qcomgpsd.py
+++ b/system/qcomgpsd/qcomgpsd.py
@@ -240,8 +240,11 @@ def main() -> NoReturn:
     cloudlog.warning("caught sig disabling quectel gps")
 
     gpio_set(GPIO.GNSS_PWR_EN, False)
-    teardown_quectel(diag)
-    cloudlog.warning("quectel cleanup done")
+    try:
+      teardown_quectel(diag)
+      cloudlog.warning("quectel cleanup done")
+    except NameError:
+      cloudlog.warning('quectel not yet setup')
 
     stop_download_event.set()
     assist_fetch_proc.kill()


### PR DESCRIPTION
Fixes https://commaai.sentry.io/issues/6256123317/?project=4507726145781760&project=77924&project=157615&project=4506181574918144&query=is%3Aunresolved%20age%3A-30d&referrer=issue-stream&statsPeriod=14d&stream_index=9

happens if process gets signal before diag is set up