### PR TITLE
loggerd: remove unused zlib and libswscale linkage

### DIFF
--- a/system/loggerd/SConscript
+++ b/system/loggerd/SConscript
@@ -1,8 +1,8 @@
 Import('env', 'arch', 'messaging', 'common', 'visionipc')
 
 libs = [common, messaging, visionipc,
-        'z', 'avformat', 'avcodec', 'swscale',
-        'avutil', 'yuv', 'OpenCL', 'pthread', 'zstd']
+        'avformat', 'avcodec', 'avutil',
+        'yuv', 'OpenCL', 'pthread', 'zstd']
 
 src = ['logger.cc', 'zstd_writer.cc', 'video_writer.cc', 'encoder/encoder.cc', 'encoder/v4l_encoder.cc']
 if arch != "larch64":


### PR DESCRIPTION
removes the unnecessary linkage to the zlib (-lz) and libswscale (-lswscale) 