### PR TITLE
camerad: simplify buffer indexing in enqueue_req_multi

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -299,8 +299,9 @@ void SpectraCamera::camera_open(VisionIpcServer *v, cl_device_id device_id, cl_c
 
 void SpectraCamera::enqueue_req_multi(uint64_t start, int n, bool dp) {
   for (uint64_t i = start; i < start + n; ++i) {
-    request_ids[(i - 1) % ife_buf_depth] = i;
-    enqueue_buffer((i - 1) % ife_buf_depth, dp);
+    uint64_t idx = (i - 1) % ife_buf_depth;
+    request_ids[idx] = i;
+    enqueue_buffer(idx, dp);
   }
 }
 


### PR DESCRIPTION
Use a local variable for buffer index to eliminate redundant code.