### PR TITLE
Fix mypy errors in 7 different files

### DIFF
--- a/common/realtime.py
+++ b/common/realtime.py
@@ -3,7 +3,8 @@ import gc
 import os
 import time
 from collections import deque
-from typing import Any
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
 
 from setproctitle import getproctitle
 
@@ -28,16 +29,14 @@ class Priority:
   CTRL_HIGH = 53
 
 
-try:
-  os_sched_setscheduler = os.sched_setscheduler  # type: ignore
-  os_sched_setaffinity = os.sched_setaffinity  # type: ignore
-except AttributeError:
-  # Provide stubs that do nothing if these functions don't exist
-  def os_sched_setscheduler(pid: int, policy: int, param: Any) -> None:
-    pass
+if TYPE_CHECKING:
+  # These type definitions are only used by mypy
+  os_sched_setscheduler: Callable[[int, int, Any], None]
+  os_sched_setaffinity: Callable[[int, list[int]], None]
 
-  def os_sched_setaffinity(pid: int, cpus: list[int]) -> None:
-    pass
+# Use getattr to handle cases where the OS doesn't support these functions
+os_sched_setscheduler = getattr(os, 'sched_setscheduler', lambda pid, policy, param: None)
+os_sched_setaffinity = getattr(os, 'sched_setaffinity', lambda pid, cpus: None)
 
 
 def set_realtime_priority(level: int) -> None:

--- a/common/realtime.py
+++ b/common/realtime.py
@@ -3,6 +3,7 @@ import gc
 import os
 import time
 from collections import deque
+from typing import Any
 
 from setproctitle import getproctitle
 
@@ -27,14 +28,26 @@ class Priority:
   CTRL_HIGH = 53
 
 
+try:
+  os_sched_setscheduler = os.sched_setscheduler  # type: ignore
+  os_sched_setaffinity = os.sched_setaffinity  # type: ignore
+except AttributeError:
+  # Provide stubs that do nothing if these functions don't exist
+  def os_sched_setscheduler(pid: int, policy: int, param: Any) -> None:
+    pass
+
+  def os_sched_setaffinity(pid: int, cpus: list[int]) -> None:
+    pass
+
+
 def set_realtime_priority(level: int) -> None:
   if not PC:
-    os.sched_setscheduler(0, os.SCHED_FIFO, os.sched_param(level))
+    os_sched_setscheduler(0, os.SCHED_FIFO, os.sched_param(level))
 
 
 def set_core_affinity(cores: list[int]) -> None:
   if not PC:
-    os.sched_setaffinity(0, cores)
+    os_sched_setaffinity(0, cores)
 
 
 def config_realtime_process(cores: int | list[int], priority: int) -> None:

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -762,13 +762,25 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
       onroad_prev = onroad
 
       if sock is not None:
-        # While not sending data, onroad, we can expect to time out in 7 + (7 * 2) = 21s
-        #                         offroad, we can expect to time out in 30 + (10 * 3) = 60s
-        # FIXME: TCP_USER_TIMEOUT is effectively 2x for some reason (32s), so it's mostly unused
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, 16000 if onroad else 0)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
+        # Set TCP keepalive parameters based on platform
+        if hasattr(socket, 'SO_KEEPALIVE'):
+          sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
+        # Platform specific keepalive options
+        if hasattr(socket, 'TCP_KEEPIDLE'):  # Linux
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
+        elif hasattr(socket, 'TCP_KEEPALIVE'):  # macOS
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 7 if onroad else 30)
+
+        # TCP_USER_TIMEOUT is Linux-specific
+        if hasattr(socket, 'TCP_USER_TIMEOUT'):
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, 16000 if onroad else 0)
+
+        # These options are available oncd both platforms
+        if hasattr(socket, 'TCP_KEEPINTVL'):
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
+        if hasattr(socket, 'TCP_KEEPCNT'):
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
 
     if end_event.wait(5):
       break

--- a/system/loggerd/xattr_cache.py
+++ b/system/loggerd/xattr_cache.py
@@ -1,13 +1,26 @@
 import os
 import errno
+from typing import Any
 
-_cached_attributes: dict[tuple, bytes | None] = {}
+try:
+  # Tell mypy to ignore these lines since these functions may not exist
+  os_getxattr = os.getxattr  # type: ignore
+  os_setxattr = os.setxattr  # type: ignore
+except AttributeError:
+  # Fallback implementations if os doesn't support xattr
+  def os_getxattr(path: str, attr_name: str) -> bytes:
+    raise OSError(errno.ENOTSUP, "xattr not supported")
+
+  def os_setxattr(path: str, attr_name: str, attr_value: bytes) -> None:
+    raise OSError(errno.ENOTSUP, "xattr not supported")
+
+_cached_attributes: dict[tuple[str, str], bytes | None] = {}
 
 def getxattr(path: str, attr_name: str) -> bytes | None:
   key = (path, attr_name)
   if key not in _cached_attributes:
     try:
-      response = os.getxattr(path, attr_name)
+      response = os_getxattr(path, attr_name)
     except OSError as e:
       # ENODATA means attribute hasn't been set
       if e.errno == errno.ENODATA:
@@ -19,4 +32,4 @@ def getxattr(path: str, attr_name: str) -> bytes | None:
 
 def setxattr(path: str, attr_name: str, attr_value: bytes) -> None:
   _cached_attributes.pop((path, attr_name), None)
-  return os.setxattr(path, attr_name, attr_value)
+  os_setxattr(path, attr_name, attr_value)

--- a/system/loggerd/xattr_cache.py
+++ b/system/loggerd/xattr_cache.py
@@ -1,18 +1,25 @@
 import os
 import errno
-from typing import Any
+from typing import TYPE_CHECKING
+from os import PathLike
+from typing_extensions import Buffer
+from collections.abc import Callable
 
-try:
-  # Tell mypy to ignore these lines since these functions may not exist
-  os_getxattr = os.getxattr  # type: ignore
-  os_setxattr = os.setxattr  # type: ignore
-except AttributeError:
-  # Fallback implementations if os doesn't support xattr
-  def os_getxattr(path: str, attr_name: str) -> bytes:
-    raise OSError(errno.ENOTSUP, "xattr not supported")
+PathType = int | str | bytes | PathLike[str] | PathLike[bytes]
+XAttrName = str | bytes | PathLike[str] | PathLike[bytes]
 
-  def os_setxattr(path: str, attr_name: str, attr_value: bytes) -> None:
-    raise OSError(errno.ENOTSUP, "xattr not supported")
+if TYPE_CHECKING:
+  os_getxattr: Callable[[PathType, XAttrName, bool], bytes]
+  os_setxattr: Callable[[PathType, XAttrName, Buffer, int, bool], None]
+
+def _getxattr_fallback(path: PathType, attr_name: XAttrName, follow_symlinks: bool = True) -> bytes:
+  raise OSError(errno.ENOTSUP, "xattr not supported")
+
+def _setxattr_fallback(path: PathType, attr_name: XAttrName, attr_value: Buffer, flags: int = 0, follow_symlinks: bool = True) -> None:
+  raise OSError(errno.ENOTSUP, "xattr not supported")
+
+os_getxattr = getattr(os, 'getxattr', _getxattr_fallback)
+os_setxattr = getattr(os, 'setxattr', _setxattr_fallback)
 
 _cached_attributes: dict[tuple[str, str], bytes | None] = {}
 
@@ -20,7 +27,7 @@ def getxattr(path: str, attr_name: str) -> bytes | None:
   key = (path, attr_name)
   if key not in _cached_attributes:
     try:
-      response = os_getxattr(path, attr_name)
+      response = os_getxattr(path, attr_name, True)
     except OSError as e:
       # ENODATA means attribute hasn't been set
       if e.errno == errno.ENODATA:
@@ -32,4 +39,4 @@ def getxattr(path: str, attr_name: str) -> bytes | None:
 
 def setxattr(path: str, attr_name: str, attr_value: bytes) -> None:
   _cached_attributes.pop((path, attr_name), None)
-  os_setxattr(path, attr_name, attr_value)
+  os_setxattr(path, attr_name, attr_value, 0, True)


### PR DESCRIPTION
**Description**
There are 7 `mypy` errors in 3 files for the openpilot project, including undefined attr-defined and mismatching return values.

Original issue: https://github.com/commaai/openpilot/issues/33230


**Verification**

Tested bug fix by running mypy for the three different files and the whole directory.
For example, for the bug `system/loggerd/xattr_cache.py:22: error: Module has no attribute "setxattr"  [attr-defined]`, 
I ran `mypy system/loggerd/xattr_cache.py` and `mypy system/loggerd/` to ensure there was no issue.

![image](https://github.com/user-attachments/assets/1a2a2e69-9341-4dde-ad69-8abd1137f449)
