### PR TITLE
`firehose`: switch to body on interactiveTimeout

### DIFF
--- a/selfdrive/ui/qt/body.cc
+++ b/selfdrive/ui/qt/body.cc
@@ -81,6 +81,10 @@ BodyWindow::BodyWindow(QWidget *parent) : fuel_filter(1.0, 5., 1. / UI_FREQ), QW
   QObject::connect(uiState(), &UIState::uiUpdate, this, &BodyWindow::updateState);
 }
 
+void BodyWindow::mousePressEvent(QMouseEvent *event) {
+    emit bodyClicked();
+}
+
 void BodyWindow::paintEvent(QPaintEvent *event) {
   QPainter p(this);
   p.setRenderHint(QPainter::Antialiasing);

--- a/selfdrive/ui/qt/body.h
+++ b/selfdrive/ui/qt/body.h
@@ -31,7 +31,10 @@ private:
   QMovie *awake, *sleep;
   RecordButton *btn;
   void paintEvent(QPaintEvent*) override;
-
+protected:
+  void mousePressEvent(QMouseEvent *event) override;
+signals:
+  void bodyClicked();
 private slots:
   void updateState(const UIState &s);
   void offroadTransition(bool onroad);

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -24,6 +24,9 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     homeWindow->showDriverView(true);
   });
 
+  bodyWindow = new BodyWindow(this);
+  main_layout->addWidget(bodyWindow);
+
   onboardingWindow = new OnboardingWindow(this);
   main_layout->addWidget(onboardingWindow);
   QObject::connect(onboardingWindow, &OnboardingWindow::onboardingDone, [=]() {
@@ -39,8 +42,11 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
     }
   });
   QObject::connect(device(), &Device::interactiveTimeout, [=]() {
+    auto params = Params();
     if (main_layout->currentWidget() == settingsWindow) {
       closeSettings();
+    } else if (main_layout->currentWidget() != bodyWindow && params.getBool("FirehoseMode")) {
+      main_layout->setCurrentWidget(bodyWindow);
     }
   });
 

--- a/selfdrive/ui/qt/window.cc
+++ b/selfdrive/ui/qt/window.cc
@@ -26,6 +26,12 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent) {
 
   bodyWindow = new BodyWindow(this);
   main_layout->addWidget(bodyWindow);
+  QObject::connect(bodyWindow, &BodyWindow::bodyClicked, [=]() {
+    auto params = Params();
+    if (params.getBool("FirehoseMode")) {
+      main_layout->setCurrentWidget(homeWindow);
+    }
+  });
 
   onboardingWindow = new OnboardingWindow(this);
   main_layout->addWidget(onboardingWindow);

--- a/selfdrive/ui/qt/window.h
+++ b/selfdrive/ui/qt/window.h
@@ -3,6 +3,8 @@
 #include <QStackedLayout>
 #include <QWidget>
 
+#include "common/params.h"
+#include "selfdrive/ui/qt/body.h"
 #include "selfdrive/ui/qt/home.h"
 #include "selfdrive/ui/qt/offroad/onboarding.h"
 #include "selfdrive/ui/qt/offroad/settings.h"
@@ -20,6 +22,7 @@ private:
 
   QStackedLayout *main_layout;
   HomeWindow *homeWindow;
+  BodyWindow *bodyWindow;
   SettingsWindow *settingsWindow;
   OnboardingWindow *onboardingWindow;
 };

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -181,8 +181,12 @@ void Device::updateWakefulness(const UIState &s) {
   } else if (interactive_timeout > 0 && --interactive_timeout == 0) {
     emit interactiveTimeout();
   }
-
-  setAwake(s.scene.ignition || interactive_timeout > 0);
+  auto params = Params();
+  if (params.getBool("FirehoseMode")) {
+    setAwake(true);
+  } else {
+    setAwake(s.scene.ignition || interactive_timeout > 0);
+  }
 }
 
 UIState *uiState() {


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

shows a sleeping billy during firehose mode instead of it just being a black screen.

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

