### PR TITLE
selfdrived: don't block on carParams

### DIFF
--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -381,7 +381,7 @@ class SelfdriveD:
     self.sm.update(0)
 
     if not self.initialized:
-      all_valid = CS.canValid and self.sm.all_checks()
+      all_valid = CS.canValid and self.sm.all_checks() and self.CP_initialized
       timed_out = self.sm.frame * DT_CTRL > 6.
       if all_valid or timed_out or (SIMULATION and not REPLAY):
         available_streams = VisionIpcClient.available_streams("camerad", block=False)

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -477,16 +477,15 @@ class SelfdriveD:
 
   def params_thread(self, evt):
     while not evt.is_set():
-      self.is_metric = self.params.get_bool("IsMetric")
-      self.personality = self.read_personality_param()
-
-      if not self.CP_initialized:
+      if self.CP_initialized:
+        self.is_metric = self.params.get_bool("IsMetric")
+        self.experimental_mode = self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl
+        self.personality = self.read_personality_param()
+      else:
         CP = self.params.get("CarParams")
         if CP is not None:
           self.initialize_car_params(messaging.log_from_bytes(CP, car.CarParams))
           cloudlog.info("selfdrived got CarParams")
-      else:
-        self.experimental_mode = self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl
 
       time.sleep(0.1)
 

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -478,7 +478,6 @@ class SelfdriveD:
   def params_thread(self, evt):
     while not evt.is_set():
       self.is_metric = self.params.get_bool("IsMetric")
-      self.experimental_mode = self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl
       self.personality = self.read_personality_param()
 
       if not self.CP_initialized:
@@ -486,6 +485,8 @@ class SelfdriveD:
         if CP is not None:
           self.initialize_car_params(messaging.log_from_bytes(CP, car.CarParams))
           cloudlog.info("selfdrived got CarParams")
+      else:
+        self.experimental_mode = self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl
 
       time.sleep(0.1)
 

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -117,12 +117,6 @@ class SelfdriveD:
     if not self.CP.openpilotLongitudinalControl:
       self.params.remove("ExperimentalMode")
 
-    # cleanup old params
-    if not self.CP.experimentalLongitudinalAvailable:
-      self.params.remove("ExperimentalLongitudinalEnabled")
-    if not self.CP.openpilotLongitudinalControl:
-      self.params.remove("ExperimentalMode")
-
     car_recognized = self.CP.brand != 'mock'
 
     # Determine startup event


### PR DESCRIPTION
Closes https://github.com/commaai/openpilot/issues/34568

- blocks initializing on getting carParams
- in effect, doesn't show anything on screen. adds selfdriveInitializing event while fingerprinting (just a noEntry, but we won't get any carStates to know this yet)