### PR TITLE
LogReader: add time series helper

### DIFF
--- a/tools/lib/log_time_series.py
+++ b/tools/lib/log_time_series.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+
+def flatten_type_dict(d, sep="/", prefix=None):
+  res = {}
+  if isinstance(d, dict):
+    for key, val in d.items():
+      if prefix is None:
+        res.update(flatten_type_dict(val, prefix=key))
+      else:
+        res.update(flatten_type_dict(val, prefix=prefix + sep + key))
+    return res
+  elif isinstance(d, list):
+    return {prefix: np.array(d)}
+  else:
+    return {prefix: d}
+
+
+def get_message_dict(message, typ):
+  valid = message.valid
+  message = message._get(typ)
+  if not hasattr(message, 'to_dict'):
+    # TODO: support these
+    #print("skipping", typ)
+    return
+
+  msg_dict = message.to_dict(verbose=True)
+  msg_dict = flatten_type_dict(msg_dict)
+  msg_dict['_valid'] = valid
+  return msg_dict
+
+
+def append_dict(path, t, d, values, arrays=False):
+  if path not in values:
+    group = {}
+    group["t"] = []
+    for k in d:
+      group[k] = []
+    values[path] = group
+  else:
+    group = values[path]
+
+  if arrays:
+    group["t"] += t.tolist()
+    for k, v in d.items():
+      group[k] += v.tolist()
+  else:
+    group["t"].append(t)
+    for k, v in d.items():
+      group[k].append(v)
+
+
+def potentially_ragged_array(arr, dtype=None, **kwargs):
+  # TODO: is there a better way to detect inhomogeneous shapes?
+  try:
+    return np.array(arr, dtype=dtype, **kwargs)
+  except ValueError:
+    return np.array(arr, dtype=object, **kwargs)
+
+def msgs_to_time_series(msgs):
+  """
+    Convert an iterable of canonical capnp messages into a dictionary of time series.
+    Each time series has a value with key "t" which consists of monotonically increasing timestamps
+    in seconds.
+  """
+  values = {}
+  for msg in msgs:
+    typ = msg.which()
+
+    tm = msg.logMonoTime / 1.0e9
+    msg_dict = get_message_dict(msg, typ)
+    if msg_dict is not None:
+      append_dict(typ, tm, msg_dict, values)
+
+  # Sort values by time.
+  for group in values.values():
+    order = np.argsort(group["t"])
+    for name, group_values in group.items():
+      group[name] = potentially_ragged_array(group_values)[order]
+
+  return values
+
+
+if __name__ == "__main__":
+  import sys
+  from openpilot.tools.lib.logreader import LogReader
+  list(msgs_to_time_series(LogReader(sys.argv[1])))

--- a/tools/lib/log_time_series.py
+++ b/tools/lib/log_time_series.py
@@ -84,4 +84,6 @@ def msgs_to_time_series(msgs):
 if __name__ == "__main__":
   import sys
   from openpilot.tools.lib.logreader import LogReader
-  list(msgs_to_time_series(LogReader(sys.argv[1])))
+  m = msgs_to_time_series(LogReader(sys.argv[1]))
+  print(m['driverCameraState']['t'])
+  print(np.diff(m['driverCameraState']['timestampSof']))


### PR DESCRIPTION
```python
In [1]: import numpy as np

In [2]: from openpilot.tools.lib.logreader import LogReader

In [3]: from openpilot.tools.lib.log_time_series import msgs_to_time_series

In [4]: m = msgs_to_time_series(LogReader("26b4ce08deec79c4/00000075--ddae8389cd/0/q"))

In [5]: np.diff(m['driverCameraState']['timestampSof'])
Out[5]:
array([1000746823, 1000035833, 1000025000,  999889166,  999908176,
        999978802, 1000002916, 1000003594,  999985624, 1000001771,
       1000027708,  999991093,  999859010,  999940833, 1000020625,
       1000037447, 1000025313, 1000021978, 1000034739, 1000027448,
       1000030520, 1000019948, 1000041510, 1000061198,  999991041,
       1000034947, 1000034010, 1000016198, 1000030208, 1000024322,
       1000033281, 1001096619, 1001229537, 1001092534, 1001055527,
       1000997352, 1000956858, 1000866990, 1000803751, 1000770947,
       1000741003, 1000671384, 1000675149, 1000575895, 1000572713,
       1000553221, 1000481763, 1000470086, 1000449791, 1000418656,
       1000413179, 1000332789, 1000373669, 1000309593, 1000314984,
       1000290494, 1000275736, 1000262863, 1000250018, 1000233118])
```