### PR TITLE
camerad: sync initial frame ID

### DIFF
--- a/system/camerad/cameras/hw.h
+++ b/system/camerad/cameras/hw.h
@@ -53,3 +53,5 @@ const CameraConfig DRIVER_CAMERA_CONFIG = {
   .phy = CAM_ISP_IFE_IN_RES_PHY_2,
   .vignetting_correction = false,
 };
+
+const CameraConfig ALL_CAMERA_CONFIGS[] = {WIDE_ROAD_CAMERA_CONFIG, ROAD_CAMERA_CONFIG, DRIVER_CAMERA_CONFIG};

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1430,7 +1430,7 @@ bool SpectraCamera::syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t time
   if (first_frame_synced) return true;
 
   // Store the frame data for this camera
-  camera_sync_data[camera_id] = SyncData{raw_id, timestamp, (int64_t)raw_id + 1};
+  camera_sync_data[camera_id] = SyncData{raw_id, timestamp, raw_id + 1};
 
   // Ensure all cameras are up
   bool all_cams_up = true;

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1431,8 +1431,14 @@ bool SpectraCamera::syncFirstFrame(int camera_id, uint64_t main_id, uint64_t tim
   // Store the frame data for this camera
   camera_sync_data[camera_id] = SyncData{main_id, timestamp, offset};
 
-  // Check if we have data from all three cameras
-  if (camera_sync_data.size() == 3) {
+  // Count enabled cameras
+  int enabled_camera_count = 0;
+  for (const auto& config : ALL_CAMERA_CONFIGS) {
+    if (config.enabled) enabled_camera_count++;
+  }
+
+  // Check if we have data from all enabled cameras
+  if (camera_sync_data.size() == enabled_camera_count) {
     const int64_t threshold = 2 * 1e6;  // 2 milliseconds
     uint64_t reference_timestamp = camera_sync_data.begin()->second.timestamp;
 

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1402,13 +1402,18 @@ void SpectraCamera::handle_camera_event(const cam_req_mgr_message *event_data) {
     frame_id_raw_last = frame_id_raw;
     request_id_last = request_id;
 
-    auto &meta_data = buf.frame_metadata[buf_idx];
-    meta_data.frame_id = frame_id_raw - frame_id_offset;
-    meta_data.request_id = request_id;
-    meta_data.timestamp_sof = event_data->u.frame_msg.timestamp; // this is timestamped in the kernel's SOF IRQ callback
+    if (syncFirstFrame(cc.camera_num, frame_id_raw, timestamp, &frame_id_offset)) {
+      auto &meta_data = buf.frame_metadata[buf_idx];
+      meta_data.frame_id = frame_id_raw - frame_id_offset;
+      meta_data.request_id = request_id;
+      meta_data.timestamp_sof = timestamp; // this is timestamped in the kernel's SOF IRQ callback
 
-    // wait for this frame's EOF, then queue up the next one
-    enqueue_req_multi(request_id + ife_buf_depth, 1, 1);
+      // Dispatch the request
+      enqueue_req_multi(request_id + ife_buf_depth, 1, true);
+    } else {
+      // Frames not yet synced
+      enqueue_req_multi(request_id + ife_buf_depth, 1, false);
+    }
   } else { // not ready
     if (frame_id_raw > frame_id_raw_last + 10) {
       LOGE("camera %d reset after half second of no response", cc.camera_num);
@@ -1418,4 +1423,32 @@ void SpectraCamera::handle_camera_event(const cam_req_mgr_message *event_data) {
       skipped_last = true;
     }
   }
+}
+
+bool SpectraCamera::syncFirstFrame(int camera_id, uint64_t main_id, uint64_t timestamp, int64_t *offset) {
+  if (first_frame_synced) return true;
+
+  // Store the frame data for this camera
+  camera_sync_data[camera_id] = SyncData{main_id, timestamp, offset};
+
+  // Check if we have data from all three cameras
+  if (camera_sync_data.size() == 3) {
+    const int64_t threshold = 2 * 1e6;  // 2 milliseconds
+    uint64_t reference_timestamp = camera_sync_data.begin()->second.timestamp;
+
+    // Compare sof timestamps
+    for (const auto &[_, sync_data] : camera_sync_data) {
+      if (std::abs((int64_t)reference_timestamp - (int64_t)sync_data.timestamp) > threshold) {
+        return false;
+      }
+    }
+
+    // Adjust offsets to ensure all cameras start pushing frames from frame_id 0 in the next cycle
+    for (auto &[_, sync_data] : camera_sync_data) {
+      *(sync_data.idx_offset) = sync_data.main_id + 1;
+    }
+    first_frame_synced = true;  // Mark as synced
+  }
+
+  return false;
 }

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -201,8 +201,8 @@ public:
 private:
   bool syncFirstFrame(int camera_id, uint64_t frame_id, uint64_t timestamp, int64_t *offset);
   struct SyncData {
-    uint64_t timestamp;
     uint64_t main_id;
+    uint64_t timestamp;
     int64_t *idx_offset;
   };
   inline static std::map<int, SyncData> camera_sync_data;

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -3,6 +3,7 @@
 #include <sys/mman.h>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <utility>
 
@@ -199,12 +200,13 @@ public:
   SpectraMaster *m;
 
 private:
-  static bool syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t timestamp, int64_t *id_offset);
+  static bool syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t timestamp);
   struct SyncData {
     uint64_t raw_id;
     uint64_t timestamp;
-    int64_t *id_offset;
+    int64_t frame_id_offset = 0;
   };
   inline static std::map<int, SyncData> camera_sync_data;
   inline static bool first_frame_synced = false;
+  inline static std::mutex frame_sync_mutex;
 };

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -199,7 +199,7 @@ public:
   SpectraMaster *m;
 
 private:
-  bool syncFirstFrame(int camera_id, uint64_t frame_id, uint64_t timestamp, int64_t *offset);
+  static bool syncFirstFrame(int camera_id, uint64_t frame_id, uint64_t timestamp, int64_t *offset);
   struct SyncData {
     uint64_t main_id;
     uint64_t timestamp;

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -189,7 +189,7 @@ public:
   uint64_t request_ids[MAX_IFE_BUFS] = {};
   uint64_t request_id_last = 0;
   uint64_t frame_id_raw_last = 0;
-  uint64_t frame_id_offset = 0;
+  int64_t frame_id_offset = 0;
   bool skipped_last = true;
 
   SpectraOutputType output_type;
@@ -199,11 +199,11 @@ public:
   SpectraMaster *m;
 
 private:
-  static bool syncFirstFrame(int camera_id, uint64_t frame_id, uint64_t timestamp, int64_t *offset);
+  static bool syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t timestamp, int64_t *id_offset);
   struct SyncData {
-    uint64_t main_id;
+    uint64_t raw_id;
     uint64_t timestamp;
-    int64_t *idx_offset;
+    int64_t *id_offset;
   };
   inline static std::map<int, SyncData> camera_sync_data;
   inline static bool first_frame_synced = false;

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -197,4 +197,14 @@ public:
   CameraBuf buf;
   MemoryManager mm;
   SpectraMaster *m;
+
+private:
+  bool syncFirstFrame(int camera_id, uint64_t frame_id, uint64_t timestamp, int64_t *offset);
+  struct SyncData {
+    uint64_t timestamp;
+    uint64_t main_id;
+    int64_t *idx_offset;
+  };
+  inline static std::map<int, SyncData> camera_sync_data;
+  inline static bool first_frame_synced = false;
 };

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -204,7 +204,7 @@ private:
   struct SyncData {
     uint64_t raw_id;
     uint64_t timestamp;
-    int64_t frame_id_offset = 0;
+    uint64_t frame_id_offset = 0;
   };
   inline static std::map<int, SyncData> camera_sync_data;
   inline static bool first_frame_synced = false;


### PR DESCRIPTION
resolve: https://github.com/commaai/openpilot/issues/34612, synchronizes the initial frame IDs across all cameras once their SOF timestamps are aligned:

1. sof timestamp syncing: verifies that sof timestamps are within a threshold across all cameras.
2. Frame id Consistency: Adjusts the idx_offset to ensure that all cameras start pushing frames with frame_id = 0 in the next cycle.