### PR TITLE
camerad: cleanup syncFirstFrame

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1431,7 +1431,9 @@ bool SpectraCamera::syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t time
   camera_sync_data[camera_id] = SyncData{timestamp, raw_id + 1};
 
   // Ensure all cameras are up
-  bool all_cams_up = camera_sync_data.size() == std::size(ALL_CAMERA_CONFIGS);
+  int enabled_camera_count = std::count_if(std::begin(ALL_CAMERA_CONFIGS), std::end(ALL_CAMERA_CONFIGS),
+                                           [](const auto &config) { return config.enabled; });
+  bool all_cams_up = camera_sync_data.size() == enabled_camera_count;
 
   // Wait until the timestamps line up
   bool all_cams_synced = true;

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1425,27 +1425,19 @@ void SpectraCamera::handle_camera_event(const cam_req_mgr_message *event_data) {
 }
 
 bool SpectraCamera::syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t timestamp) {
-  std::lock_guard lk(frame_sync_mutex);
-
   if (first_frame_synced) return true;
 
   // Store the frame data for this camera
-  camera_sync_data[camera_id] = SyncData{raw_id, timestamp, raw_id + 1};
+  camera_sync_data[camera_id] = SyncData{timestamp, raw_id + 1};
 
   // Ensure all cameras are up
-  bool all_cams_up = true;
-  for (const auto& config : ALL_CAMERA_CONFIGS) {
-    if (camera_sync_data.find(config.camera_num) == camera_sync_data.end()) {
-      all_cams_up = false;
-    }
-  }
+  bool all_cams_up = camera_sync_data.size() == std::size(ALL_CAMERA_CONFIGS);
 
   // Wait until the timestamps line up
   bool all_cams_synced = true;
-  uint64_t reference_timestamp = camera_sync_data.begin()->second.timestamp;
   for (const auto &[_, sync_data] : camera_sync_data) {
-    uint64_t diff = std::max(reference_timestamp, sync_data.timestamp) -
-                    std::min(reference_timestamp, sync_data.timestamp);
+    uint64_t diff = std::max(timestamp, sync_data.timestamp) -
+                    std::min(timestamp, sync_data.timestamp);
     if (diff > 2*1e6) {  // within 2ms
       all_cams_synced = false;
     }
@@ -1453,8 +1445,8 @@ bool SpectraCamera::syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t time
 
   if (all_cams_up && all_cams_synced) {
     first_frame_synced = true;
-    for (auto &[cam, sync_data] : camera_sync_data) {
-      LOGW("camera %d synced on frame_id_offset %ld timestamp %lu", cam, camera_sync_data[cam].frame_id_offset, camera_sync_data[cam].timestamp);
+    for (const auto&[cam, sync_data] : camera_sync_data) {
+      LOGW("camera %d synced on frame_id_offset %ld timestamp %lu", cam, sync_data.frame_id_offset, sync_data.timestamp);
     }
   }
 

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -202,11 +202,9 @@ public:
 private:
   static bool syncFirstFrame(int camera_id, uint64_t raw_id, uint64_t timestamp);
   struct SyncData {
-    uint64_t raw_id;
     uint64_t timestamp;
     uint64_t frame_id_offset = 0;
   };
   inline static std::map<int, SyncData> camera_sync_data;
   inline static bool first_frame_synced = false;
-  inline static std::mutex frame_sync_mutex;
 };


### PR DESCRIPTION
1. Remove mutex, since `syncFirstFrame` is called exclusively in `camerad_thread`(), locking is unnecessary.
2. Camera availability is checked by comparing the size of `camera_sync_data` with `ALL_CAMERA_CONFIGS`
3. The `timestamp` parameter is directly used for sof comparison
4. Simplified logging by directly using the `sync_data` object for logging, removing unnecessary map access.
5. remove raw_id from `struct SyncData`