### PR TITLE
camerad: fix crash during camera re-alignment

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -259,7 +259,7 @@ int SpectraCamera::clear_req_queue() {
   int ret = do_cam_control(m->video0_fd, CAM_REQ_MGR_FLUSH_REQ, &req_mgr_flush_request, sizeof(req_mgr_flush_request));
   LOGD("flushed all req: %d", ret);
 
-  if (icp_dev_handle) {
+  if (icp_dev_handle > 0) {
     struct cam_flush_dev_cmd cmd = {
       .session_handle = session_handle,
       .dev_handle = icp_dev_handle,


### PR DESCRIPTION
This PR resolves a crash during road camera re-alignment:

> camerad: system/camerad/cameras/spectra.cc:268: int SpectraCamera::clear_req_queue(): Assertion 'err == 0' failed.

The crash was caused by an incorrect check for `icp_dev_handle`. It should validate `icp_dev_handle > 0` to ensure the handle is valid before performing the flush operation.

This PR also resolves https://github.com/commaai/openpilot/issues/34597