### PR TITLE
camerad: rename set_exposure_target to calculate_exposure_value

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -90,7 +90,7 @@ kj::Array<uint8_t> get_raw_frame_image(const CameraBuf *b) {
   return kj::mv(frame_image);
 }
 
-float set_exposure_target(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip) {
+float calculate_exposure_value(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip) {
   int lum_med;
   uint32_t lum_binning[256] = {0};
   const uint8_t *pix_ptr = b->cur_yuv_buf->y;

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -49,5 +49,5 @@ public:
 
 void camerad_thread();
 kj::Array<uint8_t> get_raw_frame_image(const CameraBuf *b);
-float set_exposure_target(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip);
+float calculate_exposure_value(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip);
 int open_v4l_by_name_and_index(const char name[], int index = 0, int flags = O_RDWR | O_NONBLOCK);

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -261,7 +261,7 @@ void CameraState::run() {
       framed.setImage(get_raw_frame_image(&camera.buf));
     }
 
-    set_camera_exposure(set_exposure_target(&camera.buf, ae_xywh, 2, camera.cc.stream_type != VISION_STREAM_DRIVER ? 2 : 4));
+    set_camera_exposure(calculate_exposure_value(&camera.buf, ae_xywh, 2, camera.cc.stream_type != VISION_STREAM_DRIVER ? 2 : 4));
 
     // Send the message
     pm.send(camera.cc.publish_name, msg);

--- a/system/camerad/test/test_ae_gray.cc
+++ b/system/camerad/test/test_ae_gray.cc
@@ -27,7 +27,7 @@ float gts[TONE_SPLITS * TONE_SPLITS * TONE_SPLITS * TONE_SPLITS] = {
   0.000000};
 
 
-TEST_CASE("camera.test_set_exposure_target") {
+TEST_CASE("camera.test_calculate_exposure_value") {
   // set up fake camerabuf
   CameraBuf cb = {};
   VisionBuf vb = {};
@@ -61,7 +61,7 @@ TEST_CASE("camera.test_set_exposure_target") {
           memset(&fb_y[h_0*W+h_1*W], l[2], h_2*W);
           memset(&fb_y[h_0*W+h_1*W+h_2*W], l[3], h_3*W);
           memset(&fb_y[h_0*W+h_1*W+h_2*W+h_3*W], l[4], h_4*W);
-          float ev = set_exposure_target((const CameraBuf*) &cb, rect, 1, 1);
+          float ev = calculate_exposure_value((const CameraBuf*) &cb, rect, 1, 1);
           // printf("%d/%d/%d/%d/%d ev is %f\n", h_0, h_1, h_2, h_3, h_4, ev);
           // printf("%f\n", ev);
 


### PR DESCRIPTION
renames the `set_exposure_target` function to `calculate_exposure_value` to better reflect its purpose.