### PR TITLE
camerad: fix null dereference in camera_bufs_raw when accessing cur_camera_buf

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -57,7 +57,9 @@ bool CameraBuf::acquire() {
   }
 
   cur_frame_data = frame_metadata[cur_buf_idx];
-  cur_camera_buf = &camera_bufs_raw[cur_buf_idx];
+  if (camera_bufs_raw) {
+    cur_camera_buf = &camera_bufs_raw[cur_buf_idx];
+  }
 
   cur_yuv_buf = vipc_server->get_buffer(stream_type, cur_buf_idx);
   cur_frame_data.processing_time = (double)(cur_frame_data.timestamp_end_of_isp - cur_frame_data.timestamp_eof)*1e-9;


### PR DESCRIPTION
The issue occurs when `camera_bufs_raw` is not initialized, and dereferencing it directly can causes undefined behavior.