### PR TITLE
camerad: remove request_ids

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -310,10 +310,9 @@ void SpectraCamera::camera_open(VisionIpcServer *v, cl_device_id device_id, cl_c
 }
 
 void SpectraCamera::enqueue_req_multi(uint64_t start, int n, bool dp) {
-  for (uint64_t i = start; i < start + n; ++i) {
-    uint64_t idx = (i - 1) % ife_buf_depth;
-    request_ids[idx] = i;
-    enqueue_buffer(idx, dp);
+  for (uint64_t request_id = start; request_id < start + n; ++request_id) {
+    uint64_t idx = (request_id - 1) % ife_buf_depth;
+    enqueue_buffer(idx, request_id, dp);
   }
 }
 
@@ -904,10 +903,8 @@ void SpectraCamera::config_ife(int idx, int request_id, bool init) {
   assert(ret == 0);
 }
 
-void SpectraCamera::enqueue_buffer(int i, bool dp) {
+void SpectraCamera::enqueue_buffer(int i, uint64_t request_id, bool dp) {
   int ret;
-  uint64_t request_id = request_ids[i];
-
   // Before queuing up a new frame, wait for the
   // previous one in this slot (index) to come in.
   if (sync_objs_ife[i]) {

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -127,7 +127,7 @@ public:
   void config_ife(int idx, int request_id, bool init=false);
 
   int clear_req_queue();
-  void enqueue_buffer(int i, bool dp);
+  void enqueue_buffer(int i, uint64_t request_id, bool dp);
   void enqueue_req_multi(uint64_t start, int n, bool dp);
 
   int sensors_init();
@@ -187,7 +187,6 @@ public:
   int buf_handle_raw[MAX_IFE_BUFS] = {};
   int sync_objs_ife[MAX_IFE_BUFS] = {};
   int sync_objs_bps[MAX_IFE_BUFS] = {};
-  uint64_t request_ids[MAX_IFE_BUFS] = {};
   uint64_t request_id_last = 0;
   uint64_t frame_id_raw_last = 0;
   int64_t frame_id_offset = 0;


### PR DESCRIPTION
The `request_id` is now passed directly to `enqueue_buffer`, removing the need to store it in an array and retrieving it later.