### PR TITLE
camerad: use single instance of MemoryManager for all cameras

### DIFF
--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -76,6 +76,7 @@ public:
   int device_iommu = -1;
   int cdm_iommu = -1;
   int icp_device_iommu = -1;
+  MemoryManager mem_mgr;
 };
 
 class SpectraBuf {
@@ -196,7 +197,6 @@ public:
   SpectraOutputType output_type;
 
   CameraBuf buf;
-  MemoryManager mm;
   SpectraMaster *m;
 
 private:


### PR DESCRIPTION
1. Moved `mm` from `SpectraCamera` to `SpectraMaster`.
2. Renamed `mm` to `mem_mgr` for clearer naming.

This change consolidates memory management by using a single `MemoryManager` instance across all cameras, improving efficiency by reducing memory footprint and eliminating redundant buffer allocations.