### PR TITLE
camerad: refactor frame processing to direct handling

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -15,8 +15,6 @@ void CameraBuf::init(cl_device_id device_id, cl_context context, SpectraCamera *
   const SensorInfo *sensor = cam->sensor.get();
 
   is_raw = cam->output_type == ISP_RAW_OUTPUT;
-  frame_metadata = std::make_unique<FrameMetadata[]>(frame_buf_count);
-
   // RAW frames from ISP
   if (cam->output_type != ISP_IFE_PROCESSED) {
     camera_bufs_raw = std::make_unique<VisionBuf[]>(frame_buf_count);
@@ -48,15 +46,9 @@ CameraBuf::~CameraBuf() {
   }
 }
 
-bool CameraBuf::acquire() {
-  if (!safe_queue.try_pop(cur_buf_idx, 0)) return false;
+void CameraBuf::sendFrameToVipc() {
+  assert(cur_buf_idx >=0 && cur_buf_idx < frame_buf_count);
 
-  if (frame_metadata[cur_buf_idx].frame_id == -1) {
-    LOGE("no frame data? wtf");
-    return false;
-  }
-
-  cur_frame_data = frame_metadata[cur_buf_idx];
   if (camera_bufs_raw) {
     cur_camera_buf = &camera_bufs_raw[cur_buf_idx];
   }
@@ -71,12 +63,6 @@ bool CameraBuf::acquire() {
   };
   cur_yuv_buf->set_frame_id(cur_frame_data.frame_id);
   vipc_server->send(cur_yuv_buf, &extra);
-
-  return true;
-}
-
-void CameraBuf::queue(size_t buf_idx) {
-  safe_queue.push(buf_idx);
 }
 
 // common functions

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -4,7 +4,6 @@
 
 #include "cereal/messaging/messaging.h"
 #include "msgq/visionipc/visionipc_server.h"
-#include "common/queue.h"
 #include "common/util.h"
 
 
@@ -24,8 +23,6 @@ class CameraState;
 
 class CameraBuf {
 private:
-  int cur_buf_idx;
-  SafeQueue<int> safe_queue;
   int frame_buf_count;
   bool is_raw;
 
@@ -33,18 +30,17 @@ public:
   VisionIpcServer *vipc_server;
   VisionStreamType stream_type;
 
+  int cur_buf_idx;
   FrameMetadata cur_frame_data;
   VisionBuf *cur_yuv_buf;
   VisionBuf *cur_camera_buf;
   std::unique_ptr<VisionBuf[]> camera_bufs_raw;
-  std::unique_ptr<FrameMetadata[]> frame_metadata;
   int out_img_width, out_img_height;
 
   CameraBuf() = default;
   ~CameraBuf();
   void init(cl_device_id device_id, cl_context context, SpectraCamera *cam, VisionIpcServer * v, int frame_cnt, VisionStreamType type);
-  bool acquire();
-  void queue(size_t buf_idx);
+  void sendFrameToVipc();
 };
 
 void camerad_thread();

--- a/system/camerad/cameras/camera_qcom2.cc
+++ b/system/camerad/cameras/camera_qcom2.cc
@@ -221,7 +221,7 @@ void CameraState::set_camera_exposure(float grey_frac) {
 }
 
 void CameraState::sendState() {
-  if (!camera.buf.acquire()) return;
+  camera.buf.sendFrameToVipc();
 
   MessageBuilder msg;
   auto framed = (msg.initEvent().*camera.cc.init_camera_state)();
@@ -306,8 +306,9 @@ void camerad_thread() {
 
         for (auto &cam : cams) {
           if (event_data->session_hdl == cam->camera.session_handle) {
-            cam->camera.handle_camera_event(event_data);
-            cam->sendState();
+            if (cam->camera.handle_camera_event(event_data)) {
+              cam->sendState();
+            }
             break;
           }
         }

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <queue>
 #include <optional>
 #include <utility>
 
@@ -120,15 +121,15 @@ public:
   ~SpectraCamera();
 
   void camera_open(VisionIpcServer *v, cl_device_id device_id, cl_context ctx);
-  void handle_camera_event(const cam_req_mgr_message *event_data);
+  bool handle_camera_event(const cam_req_mgr_message *event_data);
   void camera_close();
   void camera_map_bufs();
   void config_bps(int idx, int request_id);
   void config_ife(int idx, int request_id, bool init=false);
 
   int clear_req_queue();
-  void enqueue_buffer(int i, bool dp);
-  void enqueue_req_multi(uint64_t start, int n, bool dp);
+  bool enqueue_buffer(int i, uint64_t request_id);
+  void enqueue_req_multi(uint64_t start, int n);
 
   int sensors_init();
   void sensors_start();


### PR DESCRIPTION
This refactor streamlines the frame processing workflow by replacing the previous multi-threaded queue-based approach with direct frame processing.

Key changes:

1. Removed `safe_queue` and `std::unique_ptr<FrameMetadata[]> frame_metadata` from the `CameraBuf` class, as the queue mechanism is no longer needed.
2. Eliminated the `bool dp` parameter from `enqueue_req_multi` and `enqueue_buffer` functions. `enqueue_buffer` now returns `true` to indicate when a frame is ready for processing, removing the need to queue frames.
3. Consolidated frame metadata updates into a single location, ensuring frame information is updated only when a frame is fully ready.

This refactor simplifies the frame processing logic, making it more natural and efficient for the single-threaded camerad workflow. It also resolves https://github.com/commaai/openpilot/issues/34648