### PR TITLE
camerad: Inline processing_time calculation during frame data initialization

### DIFF
--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -53,7 +53,6 @@ void CameraBuf::sendFrameToVipc() {
   }
 
   cur_yuv_buf = vipc_server->get_buffer(stream_type, cur_buf_idx);
-  cur_frame_data.processing_time = (double)(cur_frame_data.timestamp_end_of_isp - cur_frame_data.timestamp_eof)*1e-9;
 
   VisionIpcBufExtra extra = {
     cur_frame_data.frame_id,

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -14,7 +14,6 @@ typedef struct FrameMetadata {
   uint32_t request_id;
   uint64_t timestamp_sof;
   uint64_t timestamp_eof;
-  uint64_t timestamp_end_of_isp;
   float processing_time;
 } FrameMetadata;
 

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1403,7 +1403,6 @@ bool SpectraCamera::handle_camera_event(const cam_req_mgr_message *event_data) {
 
         // in IFE_PROCESSED mode, we can't know the true EOF, so recover it with sensor readout time
         uint64_t timestamp_eof = timestamp + sensor->readout_time_ns;
-        uint64_t timestamp_end_of_isp = nanos_since_boot();
 
         // Update buffer and frame data
         buf.cur_buf_idx = buf_idx;
@@ -1412,8 +1411,7 @@ bool SpectraCamera::handle_camera_event(const cam_req_mgr_message *event_data) {
           .request_id = (uint32_t)request_id,
           .timestamp_sof = timestamp,
           .timestamp_eof = timestamp_eof,
-          .timestamp_end_of_isp = timestamp_end_of_isp,
-          .processing_time = float((timestamp_end_of_isp - timestamp_eof) * 1e-9)
+          .processing_time = float((nanos_since_boot() - timestamp_eof) * 1e-9)
         };
         return true;
       }

--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1400,14 +1400,20 @@ bool SpectraCamera::handle_camera_event(const cam_req_mgr_message *event_data) {
       // wait for this frame's EOF, then queue up the next one
       if (enqueue_buffer(buf_idx, request_id + ife_buf_depth)) {
         // Frame is ready
+
+        // in IFE_PROCESSED mode, we can't know the true EOF, so recover it with sensor readout time
+        uint64_t timestamp_eof = timestamp + sensor->readout_time_ns;
+        uint64_t timestamp_end_of_isp = nanos_since_boot();
+
+        // Update buffer and frame data
         buf.cur_buf_idx = buf_idx;
         buf.cur_frame_data = {
           .frame_id = (uint32_t)(frame_id_raw - camera_sync_data[cc.camera_num].frame_id_offset),
           .request_id = (uint32_t)request_id,
           .timestamp_sof = timestamp,
-          // in IFE_PROCESSED mode, we can't know the true EOF, so recover it with sensor readout time
-          .timestamp_eof = timestamp + sensor->readout_time_ns,
-          .timestamp_end_of_isp = (uint64_t)nanos_since_boot(),
+          .timestamp_eof = timestamp_eof,
+          .timestamp_end_of_isp = timestamp_end_of_isp,
+          .processing_time = float((timestamp_end_of_isp - timestamp_eof) * 1e-9)
         };
         return true;
       }


### PR DESCRIPTION
The entire frame meta data is now updated in a single, unified step. Improving clarity and consistency by avoiding separate updates to `processing_time`