### PR TITLE
camerad:  cancel stalled requests on CAM_SYNC_WAIT timeout instead of full flush

### DIFF
--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -198,6 +198,7 @@ public:
   SpectraMaster *m;
 
 private:
+  int cancelStalledRequests(uint64_t request_id);
   static bool syncFirstFrame(int camera_id, uint64_t request_id, uint64_t raw_id, uint64_t timestamp);
   struct SyncData {
     uint64_t timestamp;


### PR DESCRIPTION
Modified `enqueue_buffer` to use `cancelStalledRequests` with `CAM_REQ_MGR_FLUSH_TYPE_CANCEL_REQ` to cancel only the stalled request on `CAM_SYNC_WAIT` timeout, rather than flushing everything.