### PR TITLE
PC: Fix Panda DFU device permissions

### DIFF
--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -98,7 +98,7 @@ if [ -f "/etc/os-release" ]; then
   esac
 
   if [[ -d "/etc/udev/rules.d/" ]]; then
-    # Setup panda udev rules
+    # Setup jungle udev rules
     $SUDO tee /etc/udev/rules.d/12-panda_jungle.rules > /dev/null <<EOF
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddcf", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddef", MODE="0666"
@@ -107,15 +107,16 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddef", MODE="0666"
 
 EOF
 
-    # Setup jungle udev rules
+    # Setup panda udev rules
     $SUDO tee /etc/udev/rules.d/11-panda.rules > /dev/null <<EOF
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddcc", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddee", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcc", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
 EOF
 
-  $SUDO udevadm control --reload-rules && $SUDO udevadm trigger || true
+    $SUDO udevadm control --reload-rules && $SUDO udevadm trigger || true
   fi
 
 else


### PR DESCRIPTION
**Description**

On a supported Ubuntu installation, udev rules are added for Panda devices in their varying comma firmware personalities, but there is no udev rule for the DFU-mode device. This breaks DFU flashing and recovery on PC. The error the user gets is rather un-intuitive so it's hard to know this is a permissions issue.

```
(openpilot) jyoung@jy-workstation-ubuntu:~/openpilot/panda/board$ ./recover.py 
Cannot read termcap database;
using dumb terminal settings.
scons: Entering directory `/home/jyoung/openpilot/panda'
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: `board' is up to date.
scons: done building targets.
found 0 panda(s) in DFU - []
```

**Verification**

Added a udev rule to the Ubuntu setup scripts, along with some other fixes, and re-tested DFU flashing.

```
(openpilot) jyoung@jy-workstation-ubuntu:~/openpilot/panda/board$ ./recover.py 
Cannot read termcap database;
using dumb terminal settings.
scons: Entering directory `/home/jyoung/openpilot/panda'
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: `board' is up to date.
scons: done building targets.
putting 3e0036000851313339353335 in DFU mode
found 1 panda(s) in DFU - ['356935773331']
flashing 356935773331
programming 0 with length 1024
programming 1 with length 1024
programming 2 with length 1024
programming 3 with length 1024
programming 4 with length 1024
programming 5 with length 1024
programming 6 with length 1024
programming 7 with length 1024
programming 8 with length 1024
programming 9 with length 1024
programming 10 with length 1024
programming 11 with length 1024
programming 12 with length 1024
programming 13 with length 1024
programming 14 with length 1024
programming 15 with length 1024
programming 16 with length 1024
programming 17 with length 1024
programming 18 with length 1024
```