### PR TITLE
camerad: extract frame processing from handle_camera_event into processFrame

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1426,11 +1426,12 @@ bool SpectraCamera::processFrame(uint64_t request_id, int buf_idx, uint64_t fram
   // Update buffer and frame data
   buf.cur_buf_idx = buf_idx;
   buf.cur_frame_data = {
-      .frame_id = (uint32_t)(frame_id_raw - camera_sync_data[cc.camera_num].frame_id_offset),
-      .request_id = (uint32_t)request_id,
-      .timestamp_sof = timestamp,
-      .timestamp_eof = timestamp_eof,
-      .processing_time = float((nanos_since_boot() - timestamp_eof) * 1e-9)};
+    .frame_id = (uint32_t)(frame_id_raw - camera_sync_data[cc.camera_num].frame_id_offset),
+    .request_id = (uint32_t)request_id,
+    .timestamp_sof = timestamp,
+    .timestamp_eof = timestamp_eof,
+    .processing_time = float((nanos_since_boot() - timestamp_eof) * 1e-9)
+  };
 
   return true;
 }

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -198,6 +198,7 @@ public:
   SpectraMaster *m;
 
 private:
+  bool processFrame(uint64_t request_id, int buf_idx, uint64_t frame_id_raw, uint64_t timestamp);
   static bool syncFirstFrame(int camera_id, uint64_t request_id, uint64_t raw_id, uint64_t timestamp);
   struct SyncData {
     uint64_t timestamp;


### PR DESCRIPTION
Refactored `SpectraCamera::handle_camera_event` by moving frame processing logic into a new `processFrame` method for better readability and maintainability.