### PR TITLE
camerad: split utility functions and memory manager into separate files

### DIFF
--- a/system/camerad/SConscript
+++ b/system/camerad/SConscript
@@ -4,6 +4,7 @@ libs = ['pthread', common, 'OpenCL', messaging, visionipc, gpucommon]
 
 if arch != "Darwin":
   camera_obj = env.Object(['cameras/camera_qcom2.cc', 'cameras/camera_common.cc', 'cameras/spectra.cc',
+                           'cameras/utils.cc', 'cameras/mem_mgr.cc',
                            'cameras/cdm.cc', 'sensors/ar0231.cc', 'sensors/ox03c10.cc', 'sensors/os04c10.cc'])
   env.Program('camerad', ['main.cc', camera_obj], LIBS=libs)
 

--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -102,16 +102,3 @@ float calculate_exposure_value(const CameraBuf *b, Rect ae_xywh, int x_skip, int
 
   return lum_med / 256.0;
 }
-
-int open_v4l_by_name_and_index(const char name[], int index, int flags) {
-  for (int v4l_index = 0; /**/; ++v4l_index) {
-    std::string v4l_name = util::read_file(util::string_format("/sys/class/video4linux/v4l-subdev%d/name", v4l_index));
-    if (v4l_name.empty()) return -1;
-    if (v4l_name.find(name) == 0) {
-      if (index == 0) {
-        return HANDLE_EINTR(open(util::string_format("/dev/v4l-subdev%d", v4l_index).c_str(), flags));
-      }
-      index--;
-    }
-  }
-}

--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -44,4 +44,3 @@ public:
 void camerad_thread();
 kj::Array<uint8_t> get_raw_frame_image(const CameraBuf *b);
 float calculate_exposure_value(const CameraBuf *b, Rect ae_xywh, int x_skip, int y_skip);
-int open_v4l_by_name_and_index(const char name[], int index = 0, int flags = O_RDWR | O_NONBLOCK);

--- a/system/camerad/cameras/mem_mgr.cc
+++ b/system/camerad/cameras/mem_mgr.cc
@@ -1,0 +1,108 @@
+#include "system/camerad/cameras/mem_mgr.h"
+
+#include <cstring>
+
+#include "common/swaglog.h"
+#include "system/camerad/cameras/utils.h"
+
+void *alloc_w_mmu_hdl(int video0_fd, int len, uint32_t *handle, int align, int flags, int mmu_hdl, int mmu_hdl2) {
+  struct cam_mem_mgr_alloc_cmd mem_mgr_alloc_cmd = {0};
+  mem_mgr_alloc_cmd.len = len;
+  mem_mgr_alloc_cmd.align = align;
+  mem_mgr_alloc_cmd.flags = flags;
+  mem_mgr_alloc_cmd.num_hdl = 0;
+  if (mmu_hdl != 0) {
+    mem_mgr_alloc_cmd.mmu_hdls[0] = mmu_hdl;
+    mem_mgr_alloc_cmd.num_hdl++;
+  }
+  if (mmu_hdl2 != 0) {
+    mem_mgr_alloc_cmd.mmu_hdls[1] = mmu_hdl2;
+    mem_mgr_alloc_cmd.num_hdl++;
+  }
+
+  do_cam_control(video0_fd, CAM_REQ_MGR_ALLOC_BUF, &mem_mgr_alloc_cmd, sizeof(mem_mgr_alloc_cmd));
+  *handle = mem_mgr_alloc_cmd.out.buf_handle;
+
+  void *ptr = NULL;
+  if (mem_mgr_alloc_cmd.out.fd > 0) {
+    ptr = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_SHARED, mem_mgr_alloc_cmd.out.fd, 0);
+    assert(ptr != MAP_FAILED);
+  }
+
+  // LOGD("allocated: %x %d %llx mapped %p", mem_mgr_alloc_cmd.out.buf_handle, mem_mgr_alloc_cmd.out.fd, mem_mgr_alloc_cmd.out.vaddr, ptr);
+
+  return ptr;
+}
+
+void release(int video0_fd, uint32_t handle) {
+  struct cam_mem_mgr_release_cmd mem_mgr_release_cmd = {0};
+  mem_mgr_release_cmd.buf_handle = handle;
+
+  int ret = do_cam_control(video0_fd, CAM_REQ_MGR_RELEASE_BUF, &mem_mgr_release_cmd, sizeof(mem_mgr_release_cmd));
+  assert(ret == 0);
+}
+
+// *** MemoryManager ***
+
+void *MemoryManager::alloc_buf(int size, uint32_t *handle) {
+  void *ptr;
+  auto &cache = cached_allocations[size];
+  if (!cache.empty()) {
+    ptr = cache.front();
+    cache.pop();
+    *handle = handle_lookup[ptr];
+  } else {
+    ptr = alloc_w_mmu_hdl(video0_fd, size, handle);
+    handle_lookup[ptr] = *handle;
+    size_lookup[ptr] = size;
+  }
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+void MemoryManager::free(void *ptr) {
+  cached_allocations[size_lookup[ptr]].push(ptr);
+}
+
+MemoryManager::~MemoryManager() {
+  for (auto &x : cached_allocations) {
+    while (!x.second.empty()) {
+      void *ptr = x.second.front();
+      x.second.pop();
+      LOGD("freeing cached allocation %p with size %d", ptr, size_lookup[ptr]);
+      munmap(ptr, size_lookup[ptr]);
+
+      // release fd
+      close(handle_lookup[ptr] >> 16);
+      release(video0_fd, handle_lookup[ptr]);
+
+      handle_lookup.erase(ptr);
+      size_lookup.erase(ptr);
+    }
+  }
+}
+
+// SpectraBuf
+
+SpectraBuf::~SpectraBuf() {
+  if (video_fd >= 0 && ptr) {
+    munmap(ptr, mmap_size);
+    release(video_fd, handle);
+  }
+}
+
+void SpectraBuf::init(int fd, int s, int a, bool shared_access, int mmu_hdl, int mmu_hdl2, int count) {
+  video_fd = fd;
+  size = s;
+  alignment = a;
+  mmap_size = aligned_size() * count;
+
+  uint32_t flags = CAM_MEM_FLAG_HW_READ_WRITE | CAM_MEM_FLAG_KMD_ACCESS | CAM_MEM_FLAG_UMD_ACCESS | CAM_MEM_FLAG_CMD_BUF_TYPE;
+  if (shared_access) {
+    flags |= CAM_MEM_FLAG_HW_SHARED_ACCESS;
+  }
+
+  void *p = alloc_w_mmu_hdl(video_fd, mmap_size, (uint32_t *)&handle, alignment, flags, mmu_hdl, mmu_hdl2);
+  ptr = (unsigned char *)p;
+  assert(ptr != NULL);
+}

--- a/system/camerad/cameras/mem_mgr.h
+++ b/system/camerad/cameras/mem_mgr.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <sys/mman.h>
+
+#include <cassert>
+#include <functional>
+#include <map>
+#include <memory>
+#include <queue>
+
+#include "common/util.h"
+#include "media/cam_req_mgr.h"
+
+void *alloc_w_mmu_hdl(int video0_fd, int len, uint32_t *handle, int align = 8,
+                      int flags = CAM_MEM_FLAG_KMD_ACCESS | CAM_MEM_FLAG_UMD_ACCESS | CAM_MEM_FLAG_CMD_BUF_TYPE,
+                      int mmu_hdl = 0, int mmu_hdl2 = 0);
+void release(int video0_fd, uint32_t handle);
+
+class MemoryManager {
+ public:
+  void init(int _video0_fd) { video0_fd = _video0_fd; }
+  ~MemoryManager();
+
+  template <class T>
+  auto alloc(int len, uint32_t *handle) {
+    return std::unique_ptr<T, std::function<void(void *)>>((T *)alloc_buf(len, handle), [this](void *ptr) { this->free(ptr); });
+  }
+
+ private:
+  void *alloc_buf(int len, uint32_t *handle);
+  void free(void *ptr);
+
+  std::map<void *, uint32_t> handle_lookup;
+  std::map<void *, int> size_lookup;
+  std::map<int, std::queue<void *>> cached_allocations;
+  int video0_fd;
+};
+
+class SpectraBuf {
+public:
+  SpectraBuf() = default;
+  ~SpectraBuf();
+  void init(int fd, int s, int a, bool shared_access, int mmu_hdl = 0, int mmu_hdl2 = 0, int count = 1);
+  uint32_t aligned_size() {
+    return ALIGNED_SIZE(size, alignment);
+  }
+
+  int video_fd = -1;
+  unsigned char *ptr = nullptr;
+  int size = 0, alignment = 0, handle = 0, mmap_size = 0;
+};

--- a/system/camerad/cameras/utils.cc
+++ b/system/camerad/cameras/utils.cc
@@ -1,0 +1,86 @@
+#include "system/camerad/cameras/utils.h"
+
+#include <sys/ioctl.h>
+
+#include "common/swaglog.h"
+#include "common/util.h"
+#include "media/cam_defs.h"
+#include "media/cam_sync.h"
+
+int do_cam_control(int fd, int op_code, void *handle, int size) {
+  struct cam_control camcontrol = {0};
+  camcontrol.op_code = op_code;
+  camcontrol.handle = (uint64_t)handle;
+  if (size == 0) {
+    camcontrol.size = 8;
+    camcontrol.handle_type = CAM_HANDLE_MEM_HANDLE;
+  } else {
+    camcontrol.size = size;
+    camcontrol.handle_type = CAM_HANDLE_USER_POINTER;
+  }
+
+  int ret = HANDLE_EINTR(ioctl(fd, VIDIOC_CAM_CONTROL, &camcontrol));
+  if (ret == -1) {
+    LOGE("VIDIOC_CAM_CONTROL error: op_code %d - errno %d", op_code, errno);
+  }
+  return ret;
+}
+
+int do_sync_control(int fd, uint32_t id, void *handle, uint32_t size) {
+  struct cam_private_ioctl_arg arg = {
+      .id = id,
+      .size = size,
+      .ioctl_ptr = (uint64_t)handle,
+  };
+  int ret = HANDLE_EINTR(ioctl(fd, CAM_PRIVATE_IOCTL_CMD, &arg));
+
+  int32_t ioctl_result = static_cast<int32_t>(arg.result);
+  if (ret < 0) {
+    LOGE("CAM_SYNC error: id %u - errno %d - ret %d - ioctl_result %d", id, errno, ret, ioctl_result);
+    return ret;
+  }
+  if (ioctl_result != 0) {
+    LOGE("CAM_SYNC error: id %u - errno %d - ret %d - ioctl_result %d", id, errno, ret, ioctl_result);
+    return ioctl_result;
+  }
+  return ret;
+}
+
+std::optional<int32_t> device_acquire(int fd, int32_t session_handle, void *data, uint32_t num_resources) {
+  struct cam_acquire_dev_cmd cmd = {
+      .session_handle = session_handle,
+      .handle_type = CAM_HANDLE_USER_POINTER,
+      .num_resources = (uint32_t)(data ? num_resources : 0),
+      .resource_hdl = (uint64_t)data,
+  };
+  int err = do_cam_control(fd, CAM_ACQUIRE_DEV, &cmd, sizeof(cmd));
+  return err == 0 ? std::make_optional(cmd.dev_handle) : std::nullopt;
+}
+
+int device_config(int fd, int32_t session_handle, int32_t dev_handle, uint64_t packet_handle) {
+  struct cam_config_dev_cmd cmd = {
+      .session_handle = session_handle,
+      .dev_handle = dev_handle,
+      .packet_handle = packet_handle,
+  };
+  return do_cam_control(fd, CAM_CONFIG_DEV, &cmd, sizeof(cmd));
+}
+
+int device_control(int fd, int op_code, int session_handle, int dev_handle) {
+  // start stop and release are all the same
+  struct cam_start_stop_dev_cmd cmd{.session_handle = session_handle, .dev_handle = dev_handle};
+  return do_cam_control(fd, op_code, &cmd, sizeof(cmd));
+}
+
+int open_v4l_by_name_and_index(const char name[], int index, int flags) {
+  for (int v4l_index = 0; /**/; ++v4l_index) {
+    std::string v4l_name = util::read_file(util::string_format("/sys/class/video4linux/v4l-subdev%d/name", v4l_index));
+    if (v4l_name.empty()) return -1;
+    if (v4l_name.find(name) == 0) {
+      if (index == 0) {
+        return HANDLE_EINTR(open(util::string_format("/dev/v4l-subdev%d", v4l_index).c_str(), flags));
+      }
+      index--;
+    }
+  }
+}

--- a/system/camerad/cameras/utils.h
+++ b/system/camerad/cameras/utils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <fcntl.h>
+
+#include <cstdint>
+#include <optional>
+
+int open_v4l_by_name_and_index(const char name[], int index = 0, int flags = O_RDWR | O_NONBLOCK);
+std::optional<int32_t> device_acquire(int fd, int32_t session_handle, void *data, uint32_t num_resources=1);
+int device_config(int fd, int32_t session_handle, int32_t dev_handle, uint64_t packet_handle);
+int device_control(int fd, int op_code, int session_handle, int dev_handle);
+int do_cam_control(int fd, int op_code, void *handle, int size);
+int do_sync_control(int fd, uint32_t id, void *handle, uint32_t size);
+


### PR DESCRIPTION
refactors `spectra.cc` and `spectra.h` by extracting utility functions and the memory manager classes into dedicated files for better modularity and maintainability.