### PR TITLE
v4l_encoder: used encoder_info.fps instead of hardcoded 20

### DIFF
--- a/system/loggerd/encoder/v4l_encoder.cc
+++ b/system/loggerd/encoder/v4l_encoder.cc
@@ -186,7 +186,7 @@ V4LEncoder::V4LEncoder(const EncoderInfo &encoder_info, int in_width, int in_hei
         // TODO: more stuff here? we don't know
         .timeperframe = {
           .numerator = 1,
-          .denominator = 20
+          .denominator = (unsigned int)encoder_info.fps
         }
       }
     }


### PR DESCRIPTION
Remove hardcoded 20 FPS, respects the value from `encoder_info.fps`.