### PR TITLE
camerad: remove unused CameraState forward declaration

### DIFF
--- a/system/camerad/cameras/camera_common.h
+++ b/system/camerad/cameras/camera_common.h
@@ -18,7 +18,6 @@ typedef struct FrameMetadata {
 } FrameMetadata;
 
 class SpectraCamera;
-class CameraState;
 
 class CameraBuf {
 private:


### PR DESCRIPTION
Removes the forward declaration of CameraState from camera_common.h. The declaration is no longer needed here .