### PR TITLE
cabana SocketCanStream: support CAN-FD

### DIFF
--- a/tools/cabana/streams/socketcanstream.cc
+++ b/tools/cabana/streams/socketcanstream.cc
@@ -27,6 +27,7 @@ bool SocketCanStream::connect() {
   // These are expected and can be ignored, we don't need the advanced features of libsocketcan
   QString errorString;
   device.reset(QCanBus::instance()->createDevice("socketcan", config.device, &errorString));
+  device->setConfigurationParameter(QCanBusDevice::CanFdKey, true);
 
   if (!device) {
     qDebug() << "Failed to create SocketCAN device" << errorString;


### PR DESCRIPTION
Confirmed this does not break non-FD socketcan by creating a vcan that doesn't support FD:

```bash
ip link add dev vcan0 type vcan
ip link set vcan0 mtu 16
```