### PR TITLE
cabana: simplify streaming arguments

### DIFF
--- a/tools/cabana/README.md
+++ b/tools/cabana/README.md
@@ -14,11 +14,11 @@ Options:
   --demo                         use a demo route instead of providing your own
   --qcam                         load qcamera
   --ecam                         load wide road camera
-  --stream                       read can messages from live streaming
+  --msgq                         read can messages from msgq
   --panda                        read can messages from panda
   --panda-serial <panda-serial>  read can messages from panda with given serial
   --socketcan <socketcan>        read can messages from given SocketCAN device
-  --zmq <zmq>                    the ip address on which to receive zmq
+  --zmq <ip-address>             read can messages from zmq at the specified ip-address
                                  messages
   --data_dir <data_dir>          local directory with routes
   --no-vipc                      do not output video
@@ -68,7 +68,7 @@ cd /data/openpilot/cereal/messaging/
 Then Run Cabana with the device's IP address:
 
 ```shell
-cabana --stream --zmq <ipaddress>
+cabana --zmq <ipaddress>
 ```
 
 Replace &lt;ipaddress&gt; with your comma device's IP address.

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -26,13 +26,13 @@ int main(int argc, char *argv[]) {
   cmd_parser.addOption({"qcam", "load qcamera"});
   cmd_parser.addOption({"ecam", "load wide road camera"});
   cmd_parser.addOption({"dcam", "load driver camera"});
-  cmd_parser.addOption({"stream", "read can messages from live streaming"});
+  cmd_parser.addOption({"msgq", "read can messages from the msgq"});
   cmd_parser.addOption({"panda", "read can messages from panda"});
   cmd_parser.addOption({"panda-serial", "read can messages from panda with given serial", "panda-serial"});
   if (SocketCanStream::available()) {
     cmd_parser.addOption({"socketcan", "read can messages from given SocketCAN device", "socketcan"});
   }
-  cmd_parser.addOption({"zmq", "the ip address on which to receive zmq messages", "zmq"});
+  cmd_parser.addOption({"zmq", "the ip address on which to receive ZMQ messages", "ip address "});
   cmd_parser.addOption({"data_dir", "local directory with routes", "data_dir"});
   cmd_parser.addOption({"no-vipc", "do not output video"});
   cmd_parser.addOption({"dbc", "dbc file to open", "dbc"});
@@ -40,7 +40,9 @@ int main(int argc, char *argv[]) {
 
   AbstractStream *stream = nullptr;
 
-  if (cmd_parser.isSet("stream")) {
+  if (cmd_parser.isSet("msgq")) {
+    stream = new DeviceStream(&app);
+  } else if (cmd_parser.isSet("zmq")) {
     stream = new DeviceStream(&app, cmd_parser.value("zmq"));
   } else if (cmd_parser.isSet("panda") || cmd_parser.isSet("panda-serial")) {
     try {

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
   if (SocketCanStream::available()) {
     cmd_parser.addOption({"socketcan", "read can messages from given SocketCAN device", "socketcan"});
   }
-  cmd_parser.addOption({"zmq", "the ip address on which to receive ZMQ messages", "ip address "});
+  cmd_parser.addOption({"zmq", "read can messages from zmq at the specified ip-address", "ip-address"});
   cmd_parser.addOption({"data_dir", "local directory with routes", "data_dir"});
   cmd_parser.addOption({"no-vipc", "do not output video"});
   cmd_parser.addOption({"dbc", "dbc file to open", "dbc"});


### PR DESCRIPTION
Simplifies the command-line arguments for reading messages . The following changes were made:

read from zmq:
Before: `cabana --stream --zmq <ip address>`
After: `cabana --zmq <ip address>`

read from msgq:
Before: `cabana --stream`
After: `cabana --msgq`



this pr resolve the issue  https://github.com/commaai/openpilot/issues/34722:

> --zmq ip doesn't autofill it, you have to type it twice