### PR TITLE
camerad: remove unnecessary pthread linkage

### DIFF
--- a/system/camerad/SConscript
+++ b/system/camerad/SConscript
@@ -1,6 +1,6 @@
 Import('env', 'arch', 'messaging', 'common', 'gpucommon', 'visionipc')
 
-libs = ['pthread', common, 'OpenCL', messaging, visionipc, gpucommon]
+libs = [common, 'OpenCL', messaging, visionipc, gpucommon]
 
 if arch != "Darwin":
   camera_obj = env.Object(['cameras/camera_qcom2.cc', 'cameras/camera_common.cc', 'cameras/spectra.cc',


### PR DESCRIPTION
With camerad now single-threaded, pthread linkage is no longer needed.