### PR TITLE
camerad: stress test

### DIFF
--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -128,8 +128,7 @@ public:
   void config_ife(int idx, int request_id, bool init=false);
 
   int clear_req_queue();
-  bool enqueue_buffer(int i, uint64_t request_id);
-  void enqueue_req_multi(uint64_t start, int n);
+  void enqueue_frame(uint64_t request_id);
 
   int sensors_init();
   void sensors_start();
@@ -190,8 +189,8 @@ public:
   int sync_objs_bps[MAX_IFE_BUFS] = {};
   uint64_t request_id_last = 0;
   uint64_t frame_id_raw_last = 0;
-  int64_t frame_id_offset = 0;
-  bool skipped_last = true;
+  int invalid_request_count = 0;
+  bool skip_expected = true;
 
   SpectraOutputType output_type;
 
@@ -199,6 +198,10 @@ public:
   SpectraMaster *m;
 
 private:
+  void clearAndRequeue(uint64_t from_request_id);
+  bool validateEvent(uint64_t request_id, uint64_t frame_id_raw);
+  bool waitForFrameReady(uint64_t request_id);
+  bool processFrame(int buf_idx, uint64_t request_id, uint64_t frame_id_raw, uint64_t timestamp);
   static bool syncFirstFrame(int camera_id, uint64_t request_id, uint64_t raw_id, uint64_t timestamp);
   struct SyncData {
     uint64_t timestamp;
@@ -208,11 +211,11 @@ private:
   inline static bool first_frame_synced = false;
 
   // a mode for stressing edge cases: realignment, sync failures, etc.
-  inline bool stress_test(const char* log, float prob=0.01) {
+  inline bool stress_test(const char* log, float prob=0.02) {
     static bool enable = getenv("SPECTRA_STRESS_TEST") != nullptr;
     bool triggered = enable && ((static_cast<double>(rand()) / RAND_MAX) < prob);
     if (triggered) {
-      LOGE("stress test: %s", log);
+      LOGE("stress test (cam %d): %s", cc.camera_num, log);
     }
     return triggered;
   }

--- a/system/camerad/cameras/spectra.h
+++ b/system/camerad/cameras/spectra.h
@@ -211,9 +211,9 @@ private:
   inline static bool first_frame_synced = false;
 
   // a mode for stressing edge cases: realignment, sync failures, etc.
-  inline bool stress_test(const char* log, float prob=0.02) {
-    static bool enable = getenv("SPECTRA_STRESS_TEST") != nullptr;
-    bool triggered = enable && ((static_cast<double>(rand()) / RAND_MAX) < prob);
+  inline bool stress_test(const char* log) {
+    static double prob = std::stod(util::getenv("SPECTRA_ERROR_PROB", "-1"));;
+    bool triggered = (prob > 0) && ((static_cast<double>(rand()) / RAND_MAX) < prob);
     if (triggered) {
       LOGE("stress test (cam %d): %s", cc.camera_num, log);
     }

--- a/system/camerad/test/test_camerad.py
+++ b/system/camerad/test/test_camerad.py
@@ -27,13 +27,12 @@ def run_and_log(procs, services, duration):
     for p in procs:
       assert managed_processes[p].proc.is_alive()
   finally:
-    print("killing camerad")
     for p in procs:
       managed_processes[p].stop()
 
   return logs
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def logs():
   logs = run_and_log(["camerad", ], CAMERAS, TEST_TIMESPAN)
   ts = msgs_to_time_series(logs)

--- a/system/camerad/test/test_camerad.py
+++ b/system/camerad/test/test_camerad.py
@@ -84,12 +84,12 @@ class TestCamerad:
       assert np.all((ts[c]['timestampEof'] - ts[c]['timestampSof']) > 0)
 
       # logMonoTime > SOF
-      assert np.all((ts[c]['t'] - ts[c]['timestampSof']/1e9) > 0.001)
-      assert np.all((ts[c]['t'] - ts[c]['timestampEof']/1e9) > 0.001)
+      assert np.all((ts[c]['t'] - ts[c]['timestampSof']/1e9) > 1e-7)
+      print((ts[c]['t'] - ts[c]['timestampEof']/1e9))
+      assert np.all((ts[c]['t'] - ts[c]['timestampEof']/1e9) > 1e-7)
 
-  @pytest.mark.skip("TODO: enable this")
   def test_stress_test(self):
-    os.environ['SPECTRA_STRESS_TEST'] = '1'
+    os.environ['SPECTRA_ERROR_PROB'] = '0.008'
     logs = run_and_log(["camerad", ], CAMERAS, 15)
     ts = msgs_to_time_series(logs)
 

--- a/system/camerad/test/test_camerad.py
+++ b/system/camerad/test/test_camerad.py
@@ -33,7 +33,7 @@ def run_and_log(procs, services, duration):
 
   return logs
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def logs():
   logs = run_and_log(["camerad", ], CAMERAS, TEST_TIMESPAN)
   ts = msgs_to_time_series(logs)
@@ -85,12 +85,11 @@ class TestCamerad:
 
       # logMonoTime > SOF
       assert np.all((ts[c]['t'] - ts[c]['timestampSof']/1e9) > 1e-7)
-      print((ts[c]['t'] - ts[c]['timestampEof']/1e9))
       assert np.all((ts[c]['t'] - ts[c]['timestampEof']/1e9) > 1e-7)
 
   def test_stress_test(self):
     os.environ['SPECTRA_ERROR_PROB'] = '0.008'
-    logs = run_and_log(["camerad", ], CAMERAS, 15)
+    logs = run_and_log(["camerad", ], CAMERAS, 10)
     ts = msgs_to_time_series(logs)
 
     # we should see some jumps from introduced errors

--- a/system/camerad/test/test_camerad.py
+++ b/system/camerad/test/test_camerad.py
@@ -27,12 +27,13 @@ def run_and_log(procs, services, duration):
     for p in procs:
       assert managed_processes[p].proc.is_alive()
   finally:
+    print("killing camerad")
     for p in procs:
       managed_processes[p].stop()
 
   return logs
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def logs():
   logs = run_and_log(["camerad", ], CAMERAS, TEST_TIMESPAN)
   ts = msgs_to_time_series(logs)


### PR DESCRIPTION
CI tests to add
- [x] stress all the requeue paths
- [x] `CameraState` matches `EncodeIdx` (i.e. nothing gets mixed up between camerad -> encoderd) https://github.com/commaai/openpilot/pull/34784
- [x] logMonoTime > EOF > SOF https://github.com/commaai/openpilot/pull/34785

manual checks for both BPS and IFE
-  [x] e2e test on frame timestamps
- [x] no tearing with stress test
- [x] other cameras keep running if one disconnects
- [x] no dmesg errors in normal operations
- [x] runs for hours with `SPECTRA_STRESS_TEST=1`

`roadEncodeIdx` (IFE, no stress test)
![image](https://github.com/user-attachments/assets/43aaef06-2507-4b22-9fa8-7e8d047c8537)

`driverEncodeIdx` (BPS, no stress test)
![image](https://github.com/user-attachments/assets/f444b774-e32e-4214-9254-182f73fe44bf)
