### PR TITLE
Deprecate master-ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,4 +51,4 @@ jobs:
     - name: Push master-ci
       run: |
         unset TARGET_DIR
-        BRANCH=master-ci release/build_devel.sh
+        BRANCH=__nightly release/build_devel.sh

--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -312,7 +312,7 @@ A supported vehicle is one that just works when you install a comma device. All 
 |Volkswagen|Touran 2016-23|Adaptive Cruise Control (ACC) & Lane Assist|openpilot available[<sup>1,13</sup>](#footnotes)|0 mph|0 mph|[![star](assets/icon-star-full.svg)](##)|[![star](assets/icon-star-full.svg)](##)|<details><summary>Parts</summary><sub>- 1 USB-C coupler<br>- 1 VW J533 connector<br>- 1 comma 3X<br>- 1 comma power v2<br>- 1 harness box<br>- 1 long OBD-C cable<br>- 1 mount<br>- 1 right angle OBD-C cable (1.5 ft)<br><a href="https://comma.ai/shop/comma-3x.html?make=Volkswagen&model=Touran 2016-23">Buy Here</a></sub></details>||
 
 ### Footnotes
-<sup>1</sup>openpilot Longitudinal Control (Alpha) is available behind a toggle; the toggle is only available in non-release branches such as `devel` or `master-ci`. <br />
+<sup>1</sup>openpilot Longitudinal Control (Alpha) is available behind a toggle; the toggle is only available in non-release branches such as `devel` or `nightly-dev`. <br />
 <sup>2</sup>By default, this car will use the stock Adaptive Cruise Control (ACC) for longitudinal control. If the Driver Support Unit (DSU) is disconnected, openpilot ACC will replace stock ACC. <b><i>NOTE: disconnecting the DSU disables Automatic Emergency Braking (AEB).</i></b> <br />
 <sup>3</sup>Refers only to the Focus Mk4 (C519) available in Europe/China/Taiwan/Australasia, not the Focus Mk3 (C346) in North and South America/Southeast Asia. <br />
 <sup>4</sup>2019 Honda Civic 1.6L Diesel Sedan does not have ALC below 12mph. <br />

--- a/docs/contributing/roadmap.md
+++ b/docs/contributing/roadmap.md
@@ -16,7 +16,7 @@ a [learned simulator](https://youtu.be/EqQNZXqzFSI).
 * Always-on driver monitoring (behind a toggle)
 * GPS removed from the driving stack
 * 100KB qlogs
-* `master-ci` pushed after 1000 hours of hardware-in-the-loop testing
+* `nightly` pushed after 1000 hours of hardware-in-the-loop testing
 * Car interface code moved into [opendbc](https://github.com/commaai/opendbc)
 * openpilot on PC for Linux x86, Linux arm64, and Mac (Apple Silicon)
 

--- a/release/build_devel.sh
+++ b/release/build_devel.sh
@@ -19,15 +19,15 @@ cd $TARGET_DIR
 cp -r $SOURCE_DIR/.git $TARGET_DIR
 pre-commit uninstall || true
 
-echo "[-] bringing master-ci and devel in sync T=$SECONDS"
+echo "[-] bringing __nightly and devel in sync T=$SECONDS"
 cd $TARGET_DIR
 
-git fetch --depth 1 origin master-ci
+git fetch --depth 1 origin __nightly
 git fetch --depth 1 origin devel
 
-git checkout -f --track origin/master-ci
-git reset --hard master-ci
-git checkout master-ci
+git checkout -f --track origin/__nightly
+git reset --hard __nightly
+git checkout __nightly
 git reset --hard origin/devel
 git clean -xdff
 git lfs uninstall
@@ -81,7 +81,7 @@ fi
 
 if [ ! -z "$BRANCH" ]; then
   echo "[-] Pushing to $BRANCH T=$SECONDS"
-  git push -f origin master-ci:$BRANCH
+  git push -f origin __nightly:$BRANCH
 fi
 
 echo "[-] done T=$SECONDS, ready at $TARGET_DIR"

--- a/selfdrive/ui/qt/offroad/software_settings.cc
+++ b/selfdrive/ui/qt/offroad/software_settings.cc
@@ -54,7 +54,7 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
   connect(targetBranchBtn, &ButtonControl::clicked, [=]() {
     auto current = params.get("GitBranch");
     QStringList branches = QString::fromStdString(params.get("UpdaterAvailableBranches")).split(",");
-    for (QString b : {current.c_str(), "devel-staging", "devel", "nightly", "nightly-dev", "master-ci", "master"}) {
+    for (QString b : {current.c_str(), "devel-staging", "devel", "nightly", "nightly-dev", "master"}) {
       auto i = branches.indexOf(b);
       if (i >= 0) {
         branches.removeAt(i);


### PR DESCRIPTION
Superseded by the `nightly` series of branches:
* `nightly` for a daily release-style build of `master`
* `nightly-dev` for a daily development-style build of `master`