### PR TITLE
`op adb`: change directory to match ssh

### DIFF
--- a/tools/adb_shell.sh
+++ b/tools/adb_shell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env expect
 spawn adb shell
 expect "#"
-send "cd usr/comma\r"
+send "cd data/openpilot\r"
 send "export TERM=xterm-256color\r"
 send "su comma\r"
 send "clear\r"


### PR DESCRIPTION
ssh puts you directly in `data/openpilot` while adb shell places you in `usr/comma`

this just updates adb shell so that it's consistent with ssh

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

