### PR TITLE
Revert "make test_onroad faster (#34704)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -77,8 +77,10 @@ def openpilot_class_fixture():
 
 
 @pytest.fixture(scope="function")
-def tici_setup_fixture(openpilot_function_fixture):
+def tici_setup_fixture(request, openpilot_function_fixture):
   """Ensure a consistent state for tests on-device. Needs the openpilot function fixture to run first."""
+  if 'skip_tici_setup' in request.keywords:
+    pytest.skip("Skipping tici setup fixture due to marker")
   HARDWARE.initialize_hardware()
   HARDWARE.set_power_save(False)
   os.system("pkill -9 -f athena")

--- a/conftest.py
+++ b/conftest.py
@@ -80,7 +80,7 @@ def openpilot_class_fixture():
 def tici_setup_fixture(request, openpilot_function_fixture):
   """Ensure a consistent state for tests on-device. Needs the openpilot function fixture to run first."""
   if 'skip_tici_setup' in request.keywords:
-    pytest.skip("Skipping tici setup fixture due to marker")
+    return
   HARDWARE.initialize_hardware()
   HARDWARE.set_power_save(False)
   os.system("pkill -9 -f athena")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ lint.select = [
   "E", "F", "W", "PIE", "C4", "ISC", "A", "B",
   "NPY", # numpy
   "UP",  # pyupgrade
-  "TRY302", "TRY400", "TRY401", # try/excepts
+  "TRY203", "TRY400", "TRY401", # try/excepts
   "RUF008", "RUF100",
   "TID251",
   "PLR1704",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ asyncio_default_fixture_loop_scope = "function"
 markers = [
   "slow: tests that take awhile to run and can be skipped with -m 'not slow'",
   "tici: tests that are only meant to run on the C3/C3X",
+  "skip_tici_setup: mark test to skip tici setup fixture"
 ]
 testpaths = [
   "common",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    skip_tici_setup: mark test to skip tici setup fixture

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    skip_tici_setup: mark test to skip tici setup fixture

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -140,11 +140,13 @@ class TestOnroad:
       cls.manager_st = time.monotonic()
       proc = subprocess.Popen(["python", manager_path])
 
-      # everything is up once we get a carState
       sm = messaging.SubMaster(['carState'])
       with Timeout(30, "controls didn't start"):
         while sm.recv_frame['carState'] < 0:
           sm.update(1000)
+
+      # give a sec for everything to get setup
+      time.sleep(2)
 
       route = params.get("CurrentRoute", encoding="utf-8")
       assert route is not None

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -151,7 +151,7 @@ class TestOnroad:
       route = params.get("CurrentRoute", encoding="utf-8")
       assert route is not None
 
-      segs = set(Path(Paths.log_root()).glob(f"{route}--*"))
+      segs = list(Path(Paths.log_root()).glob(f"{route}--*"))
       assert len(segs) == 1
 
       time.sleep(TEST_DURATION)

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -146,7 +146,7 @@ class TestOnroad:
           sm.update(1000)
 
       # give a sec for everything to get setup
-      time.sleep(2)
+      time.sleep(5)
 
       route = params.get("CurrentRoute", encoding="utf-8")
       assert route is not None

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -142,11 +142,8 @@ class TestOnroad:
 
       sm = messaging.SubMaster(['carState'])
       with Timeout(30, "controls didn't start"):
-        while sm.recv_frame['carState'] < 0:
+        while not sm.seen['carState']:
           sm.update(1000)
-
-      # give a sec for everything to get setup
-      time.sleep(5)
 
       route = params.get("CurrentRoute", encoding="utf-8")
       assert route is not None

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -113,6 +113,7 @@ def cputime_total(ct):
 
 
 @pytest.mark.tici
+@pytest.mark.skip_tici_setup
 class TestOnroad:
 
   @classmethod
@@ -176,7 +177,9 @@ class TestOnroad:
     cls.lrs = [list(LogReader(os.path.join(str(s), "rlog.zst"))) for s in cls.segments]
 
     cls.lr = cls.lrs[0]
+    st = time.monotonic()
     cls.ts = msgs_to_time_series(cls.lr)
+    print("msgs to time series", time.monotonic() - st)
     cls.log_path = cls.segments[0]
 
     cls.log_sizes = {}

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -23,6 +23,7 @@ from openpilot.selfdrive.test.helpers import set_params_enabled, release_only
 from openpilot.system.hardware import HARDWARE
 from openpilot.system.hardware.hw import Paths
 from openpilot.tools.lib.logreader import LogReader
+from openpilot.tools.lib.log_time_series import msgs_to_time_series
 
 """
 CPU usage budget
@@ -119,7 +120,8 @@ class TestOnroad:
     if "DEBUG" in os.environ:
       segs = filter(lambda x: os.path.exists(os.path.join(x, "rlog.zst")), Path(Paths.log_root()).iterdir())
       segs = sorted(segs, key=lambda x: x.stat().st_mtime)
-      cls.lr = list(LogReader(os.path.join(segs[-3], "rlog.zst")))
+      cls.lr = list(LogReader(os.path.join(segs[-1], "rlog.zst")))
+      cls.ts = msgs_to_time_series(cls.lr)
       return
 
     # setup env
@@ -173,7 +175,8 @@ class TestOnroad:
 
     cls.lrs = [list(LogReader(os.path.join(str(s), "rlog.zst"))) for s in cls.segments]
 
-    cls.lr = list(LogReader(os.path.join(str(cls.segments[0]), "rlog.zst")))
+    cls.lr = cls.lrs[0]
+    cls.ts = msgs_to_time_series(cls.lr)
     cls.log_path = cls.segments[0]
 
     cls.log_sizes = {}
@@ -198,7 +201,7 @@ class TestOnroad:
         assert len(msgs) >= math.floor(SERVICE_LIST[s].frequency*int(TEST_DURATION*0.8))
 
   def test_manager_starting_time(self):
-    st = self.msgs['managerState'][0].logMonoTime / 1e9
+    st = self.ts['managerState']['t'][0]
     assert (st - self.manager_st) < 10, f"manager.py took {st - self.manager_st}s to publish the first 'managerState' msg"
 
   def test_cloudlog_size(self):
@@ -226,7 +229,7 @@ class TestOnroad:
     result += "-------------- UI Draw Timing ------------------\n"
     result += "------------------------------------------------\n"
 
-    ts = [m.uiDebug.drawTimeMillis for m in self.msgs['uiDebug']]
+    ts = self.ts['uiDebug']['drawTimeMillis']
     result += f"min  {min(ts):.2f}ms\n"
     result += f"max  {max(ts):.2f}ms\n"
     result += f"std  {np.std(ts):.2f}ms\n"
@@ -319,7 +322,7 @@ class TestOnroad:
     result += "-----------------  SOF Timing ------------------\n"
     result += "------------------------------------------------\n"
     for name in ['roadCameraState', 'wideRoadCameraState', 'driverCameraState']:
-      ts = [getattr(m, m.which()).timestampSof for m in self.lr if name in m.which()]
+      ts = self.ts[name]['timestampSof']
       d_ms = np.diff(ts) / 1e6
       d50 = np.abs(d_ms-50)
       result += f"{name} sof delta vs 50ms: min  {min(d50):.2f}ms\n"
@@ -338,33 +341,30 @@ class TestOnroad:
         # sanity checks within a single cam
         for cam in cams:
           with subtests.test(test="frame_skips", camera=cam):
-            cam_log = [getattr(x, x.which()) for x in self.msgs[cam]]
-            assert set(np.diff([x.frameId for x in cam_log])) == {1, }, "Frame ID skips"
+            assert set(np.diff(self.ts[cam]['frameId'])) == {1, }, "Frame ID skips"
 
             # EOF > SOF
-            eof_sof_diff = np.array([x.timestampEof - x.timestampSof for x in cam_log])
+            eof_sof_diff = self.ts[cam]['timestampEof'] - self.ts[cam]['timestampSof']
             assert np.all(eof_sof_diff > 0)
             assert np.all(eof_sof_diff < 50*1e6)
 
-        fid = {c: [getattr(m, m.which()).frameId for m in self.msgs[c]] for c in cams}
-        first_fid = [min(x) for x in fid.values()]
+        first_fid = {c: min(self.ts[c]['frameId']) for c in cams}
         if cam.endswith('CameraState'):
           # camerad guarantees that all cams start on frame ID 0
           # (note loggerd also needs to start up fast enough to catch it)
-          assert set(first_fid) == {0, }, "Cameras don't start on frame ID 0"
+          assert set(first_fid.values()) == {0, }, "Cameras don't start on frame ID 0"
         else:
           # encoder guarantees all cams start on the same frame ID
-          assert len(set(first_fid)) == 1, "Cameras don't start on same frame ID"
+          assert len(set(first_fid.values())) == 1, "Cameras don't start on same frame ID"
 
         # we don't do a full segment rotation, so these might not match exactly
-        last_fid = [max(x) for x in fid.values()]
-        assert max(last_fid) - min(last_fid) < 10
+        last_fid = {c: max(self.ts[c]['frameId']) for c in cams}
+        assert max(last_fid.values()) - min(last_fid.values()) < 10
 
-        start, end = min(first_fid), min(last_fid)
-        all_ts = [[getattr(m, m.which()).timestampSof for m in self.msgs[c]] for c in cams]
+        start, end = min(first_fid.values()), min(last_fid.values())
         for i in range(end-start):
-          ts = [round(x[i]/1e6, 1) for x in all_ts]
-          diff = max(ts) - min(ts)
+          ts = {c: round(self.ts[c]['timestampSof'][i]/1e6, 1) for c in cams}
+          diff = (max(ts.values()) - min(ts.values()))
           assert diff < 2, f"Cameras not synced properly: frame_id={start+i}, {diff=:.1f}ms, {ts=}"
 
   def test_mpc_execution_timings(self):
@@ -438,12 +438,7 @@ class TestOnroad:
 
   @release_only
   def test_startup(self):
-    startup_alert = None
-    for msg in self.lrs[0]:
-      # can't use onroadEvents because the first msg can be dropped while loggerd is starting up
-      if msg.which() == "selfdriveState":
-        startup_alert = msg.selfdriveState.alertText1
-        break
+    startup_alert = self.ts['selfdriveState']['alertText1'][0]
     expected = EVENTS[log.OnroadEvent.EventName.startup][ET.PERMANENT].alert_text_1
     assert startup_alert == expected, "wrong startup alert"
 


### PR DESCRIPTION
This reverts commit 470ec46.

We shouldn't make the tests harder to work on for the sake of speed; it goes the other way around - *test speed* should make it easier to develop openpilot.

Takes 47s, 2s faster than the last master run. There was 1s of overhead on each test.