### PR TITLE
params: improve nogil handling in multithreaded environments

### DIFF
--- a/common/tests/test_params.py
+++ b/common/tests/test_params.py
@@ -106,4 +106,4 @@ class TestParams:
     # sanity checks
     assert len(keys) > 20
     assert len(keys) == len(set(keys))
-    assert b"CarParams" in keys
+    assert "CarParams" in keys


### PR DESCRIPTION
Previously, not all C++ calls were wrapped in `nogil`, such as `checkKey` in `Params.get()`, which retained the GIL and blocked other Python threads during execution. This PR addresses these issues as follows:

1. Applied nogil to All C++ Calls.
2. Added `nogil` annotations to the `cdef extern from "common/params.h"` block to clearly indicate which are safe to call without the GIL.