### PR TITLE
loggerd:  add unit tests and fix identified sync issues

### DIFF
--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -99,12 +99,11 @@ size_t write_encode_data(LoggerdState *s, cereal::Event::Reader event, RemoteEnc
 int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct RemoteEncoder &re, const EncoderInfo &encoder_info) {
   capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize() / sizeof(capnp::word)));
   auto event = cmsg.getRoot<cereal::Event>();
-  auto edata = (event.*(encoder_info.get_encode_data_func))();
-  auto idx = edata.getIdx();
+  auto encoder_idx = (event.*(encoder_info.get_encode_data_func))().getIdx();
 
   int bytes_count = 0;
   // Synchronize segment and process if aligned
-  if (re.syncSegment(s, name, idx.getSegmentNum(), s->logger.segment())) {
+  if (re.syncSegment(s, name, encoder_idx.getSegmentNum(), s->logger.segment())) {
     // Process any queued messages before the current one
     if (!re.q.empty()) {
       for (auto qmsg : re.q) {

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -161,7 +161,7 @@ struct LoggerdState {
 class RemoteEncoder {
 public:
   std::unique_ptr<VideoWriter> writer;
-  int encoderd_segment_offset;
+  int encoder_segment_offset;
   int current_segment = -1;
   std::vector<Message *> q;
   int dropped_frames = 0;
@@ -172,11 +172,11 @@ public:
   bool syncSegment(LoggerdState *s, const std::string &name, int encoder_segment_num, int log_segment_num) {
     if (!seen_first_packet) {
       seen_first_packet = true;
-      encoderd_segment_offset = log_segment_num;
-      LOGD("%s: has encoderd offset %d", name.c_str(), encoderd_segment_offset);
+      encoder_segment_offset = log_segment_num;
+      LOGD("%s: has encoderd offset %d", name.c_str(), encoder_segment_offset);
     }
-    int offset_segment_num = encoder_segment_num - encoderd_segment_offset;
-    printf("offset %d encoderd_segment_offset: %d, log_segment_num:%d\n", offset_segment_num, encoderd_segment_offset, log_segment_num);
+    int offset_segment_num = encoder_segment_num - encoder_segment_offset;
+    printf("offset %d encoder_segment_offset: %d, log_segment_num:%d\n", offset_segment_num, encoder_segment_offset, log_segment_num);
     if (offset_segment_num == log_segment_num) {
       // loggerd is now on the segment that matches this packet
 
@@ -202,11 +202,11 @@ public:
              s->ready_to_rotate.load(), s->max_waiting, name.c_str());
       }
     } else {
-      LOGE("%s: encoderd packet has a older segment!!! idx.getSegmentNum():%d s->logger.segment():%d re.encoderd_segment_offset:%d",
-           name.c_str(), encoder_segment_num, log_segment_num, encoderd_segment_offset);
+      LOGE("%s: encoderd packet has a older segment!!! idx.getSegmentNum():%d s->logger.segment():%d re.encoder_segment_offset:%d",
+           name.c_str(), encoder_segment_num, log_segment_num, encoder_segment_offset);
       // free the message, it's useless. this should never happen
       // actually, this can happen if you restart encoderd
-      encoderd_segment_offset = -log_segment_num;
+      encoder_segment_offset = -log_segment_num;
     }
     return false;
   }

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -11,6 +11,7 @@
 #include "common/util.h"
 
 #include "system/loggerd/logger.h"
+#include "system/loggerd/video_writer.h"
 
 constexpr int MAIN_FPS = 20;
 const int MAIN_BITRATE = 1e7;
@@ -147,3 +148,66 @@ const LogCameraInfo stream_driver_camera_info{
 
 const LogCameraInfo cameras_logged[] = {road_camera_info, wide_road_camera_info, driver_camera_info};
 const LogCameraInfo stream_cameras_logged[] = {stream_road_camera_info, stream_wide_road_camera_info, stream_driver_camera_info};
+
+struct LoggerdState {
+  LoggerState logger;
+  std::atomic<double> last_camera_seen_tms{0.0};
+  std::atomic<int> ready_to_rotate{0};  // count of encoders ready to rotate
+  int max_waiting = 0;
+  double last_rotate_tms = 0.;      // last rotate time in ms
+};
+
+
+class RemoteEncoder {
+public:
+  std::unique_ptr<VideoWriter> writer;
+  int encoderd_segment_offset;
+  int current_segment = -1;
+  std::vector<Message *> q;
+  int dropped_frames = 0;
+  bool recording = false;
+  bool marked_ready_to_rotate = false;
+  bool seen_first_packet = false;
+
+  bool syncSegment(LoggerdState *s, const std::string &name, int encoder_segment_num, int log_segment_num) {
+    if (!seen_first_packet) {
+      seen_first_packet = true;
+      encoderd_segment_offset = log_segment_num;
+      LOGD("%s: has encoderd offset %d", name.c_str(), encoderd_segment_offset);
+    }
+    int offset_segment_num = encoder_segment_num - encoderd_segment_offset;
+    printf("offset %d encoderd_segment_offset: %d, log_segment_num:%d\n", offset_segment_num, encoderd_segment_offset, log_segment_num);
+    if (offset_segment_num == log_segment_num) {
+      // loggerd is now on the segment that matches this packet
+
+      // if this is a new segment, we close any possible old segments, move to the new, and process any queued packets
+      if (current_segment != log_segment_num) {
+        if (recording) {
+          writer.reset();
+          recording = false;
+        }
+        current_segment = log_segment_num;
+        marked_ready_to_rotate = false;
+      }
+      return true;
+    }
+
+    if (offset_segment_num > log_segment_num) {
+      // encoderd packet has a newer segment, this means encoderd has rolled over
+      if (!marked_ready_to_rotate) {
+        marked_ready_to_rotate = true;
+        ++s->ready_to_rotate;
+        LOGD("rotate %d -> %d ready %d/%d for %s",
+             log_segment_num, offset_segment_num,
+             s->ready_to_rotate.load(), s->max_waiting, name.c_str());
+      }
+    } else {
+      LOGE("%s: encoderd packet has a older segment!!! idx.getSegmentNum():%d s->logger.segment():%d re.encoderd_segment_offset:%d",
+           name.c_str(), encoder_segment_num, log_segment_num, encoderd_segment_offset);
+      // free the message, it's useless. this should never happen
+      // actually, this can happen if you restart encoderd
+      encoderd_segment_offset = -log_segment_num;
+    }
+    return false;
+  }
+};

--- a/system/loggerd/tests/test_logger.cc
+++ b/system/loggerd/tests/test_logger.cc
@@ -150,6 +150,7 @@ TEST_CASE("RemoteEncoder::syncSegment robustness", "[sync]") {
     REQUIRE(encoder.encoder_segment_offset == 1);               // Adjusted: += (2 - 1) = 1
     REQUIRE(encoder.marked_ready_to_rotate == true);
     REQUIRE(state.ready_to_rotate == 1);
+    REQUIRE(encoder.syncSegment(&state, name, 2, 0) == false);
 
     // Logger advances to 1, encoder at 2
     state.ready_to_rotate = 0;

--- a/system/loggerd/tests/test_logger.cc
+++ b/system/loggerd/tests/test_logger.cc
@@ -81,14 +81,14 @@ TEST_CASE("RemoteEncoder::syncSegment robustness", "[sync]") {
   std::string name = "test_encoder";
 
   SECTION("Matching segment after offset set") {
-    REQUIRE(encoder.syncSegment(&state, name, 5, 5) == true);
-    REQUIRE(encoder.encoderd_segment_offset == 0);          // 5 - 5 = 0
+    REQUIRE(encoder.syncSegment(&state, name, 5, 5) == true);  // First packet sets offset
+    REQUIRE(encoder.encoder_segment_offset == 0);              // 5 - 5 = 0
     REQUIRE(encoder.current_segment == 5);
     REQUIRE(encoder.seen_first_packet == true);
     REQUIRE(encoder.marked_ready_to_rotate == false);
     REQUIRE(state.ready_to_rotate == 0);
 
-    REQUIRE(encoder.syncSegment(&state, name, 7, 7) == true);  // 7 - 0 = 7 == 7
+    REQUIRE(encoder.syncSegment(&state, name, 7, 7) == true);  // 7 - 0 = 7 matches 7
     REQUIRE(encoder.current_segment == 7);
     REQUIRE(encoder.recording == false);
     REQUIRE(encoder.marked_ready_to_rotate == false);
@@ -96,89 +96,108 @@ TEST_CASE("RemoteEncoder::syncSegment robustness", "[sync]") {
   }
 
   SECTION("Encoder restarts and sends segment 0") {
-    REQUIRE(encoder.syncSegment(&state, name, 1, 1) == true);
-    REQUIRE(encoder.encoderd_segment_offset == 0);          // 1 - 1 = 0
-    REQUIRE(encoder.current_segment == 1);
+    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);  // Initial sync
+    REQUIRE(encoder.encoder_segment_offset == 0);              // 1 - 1 = 0
+    REQUIRE(encoder.current_segment == 0);
 
-    REQUIRE(encoder.syncSegment(&state, name, 0, 2) == false);  // 0 - 0 = 0 < 2
-    REQUIRE(encoder.encoderd_segment_offset == -2);         // Adjusted to 0 - 2
+    REQUIRE(encoder.syncSegment(&state, name, 0, 2) == false);  // 0 - 0 = 0 < 2 (behind)
+    REQUIRE(encoder.encoder_segment_offset == -2);              // Adjusted to 0 - 2 = -2
     REQUIRE(encoder.marked_ready_to_rotate == false);
     REQUIRE(state.ready_to_rotate == 0);
 
-    REQUIRE(encoder.syncSegment(&state, name, 0, 2) == true);   // 0 - (-2) = 2 == 2
+    REQUIRE(encoder.syncSegment(&state, name, 0, 2) == true);  // 0 - (-2) = 2 matches 2
     REQUIRE(encoder.current_segment == 2);
     REQUIRE(encoder.marked_ready_to_rotate == false);
   }
 
   SECTION("Encoder restarts and sends segment greater than 0") {
-    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
-    REQUIRE(encoder.encoderd_segment_offset == 0);          // 0 - 0 = 0
+    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);  // Initial sync
+    REQUIRE(encoder.encoder_segment_offset == 0);              // 0 - 0 = 0
     REQUIRE(encoder.current_segment == 0);
 
-    REQUIRE(encoder.syncSegment(&state, name, 2, 3) == false);  // 2 - 0 = 2 < 3
-    REQUIRE(encoder.encoderd_segment_offset == -1);         // Adjusted to 2 - 3
+    REQUIRE(encoder.syncSegment(&state, name, 2, 3) == false);  // 2 - 0 = 2 < 3 (behind)
+    REQUIRE(encoder.encoder_segment_offset == -1);              // Adjusted to 2 - 3 = -1
     REQUIRE(encoder.marked_ready_to_rotate == false);
     REQUIRE(state.ready_to_rotate == 0);
 
-    REQUIRE(encoder.syncSegment(&state, name, 2, 3) == true);   // 2 - (-1) = 3 == 3
+    REQUIRE(encoder.syncSegment(&state, name, 2, 3) == true);  // 2 - (-1) = 3 matches 3
     REQUIRE(encoder.current_segment == 3);
   }
 
   SECTION("Logger restarts to lower segment") {
     REQUIRE(encoder.syncSegment(&state, name, 5, 5) == true);
-    REQUIRE(encoder.encoderd_segment_offset == 0);
+    REQUIRE(encoder.encoder_segment_offset == 0);
     REQUIRE(encoder.current_segment == 5);
 
-    // Logger restarts to segment 0, encoder continues at 6
-    REQUIRE(encoder.syncSegment(&state, name, 6, 0) == false);  // 6 - 0 = 6 > 0
+    // Logger restarts to 0, encoder at 6
+    REQUIRE(encoder.syncSegment(&state, name, 6, 0) == false);  // 6 - 0 = 6 > 0 (ahead)
     REQUIRE(encoder.marked_ready_to_rotate == true);
     REQUIRE(state.ready_to_rotate == 1);
-    REQUIRE(encoder.current_segment == 5);                  // Unchanged until sync
+    REQUIRE(encoder.current_segment == 5);  // Unchanged until sync
 
-    // Subsequent call with next segment
+    // Encoder advances to 7, logger still at 0
     REQUIRE(encoder.syncSegment(&state, name, 7, 0) == false);  // 7 - 0 = 7 > 0
-    REQUIRE(state.ready_to_rotate == 1);                    // No further increment
+    REQUIRE(state.ready_to_rotate == 1);                        // No further increment
   }
 
   SECTION("Encoder is ahead by more than one segment") {
     REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
-    REQUIRE(encoder.encoderd_segment_offset == 0);
+    REQUIRE(encoder.encoder_segment_offset == 0);
     REQUIRE(encoder.current_segment == 0);
 
+    // Encoder jumps to 2, logger at 0
     REQUIRE(encoder.syncSegment(&state, name, 2, 0) == false);  // 2 - 0 = 2 > 0
+    REQUIRE(encoder.encoder_segment_offset == 1);               // Adjusted: += (2 - 1) = 1
     REQUIRE(encoder.marked_ready_to_rotate == true);
     REQUIRE(state.ready_to_rotate == 1);
 
-    REQUIRE(encoder.syncSegment(&state, name, 3, 0) == false);  // 3 - 0 = 3 > 0
-    REQUIRE(state.ready_to_rotate == 1);                    // No additional increment
+    // Logger advances to 1, encoder at 2
+    state.ready_to_rotate = 0;
+    REQUIRE(encoder.syncSegment(&state, name, 2, 1) == true);  // 2 - 1 = 1 matches 1
+    REQUIRE(encoder.current_segment == 1);
+    REQUIRE(encoder.marked_ready_to_rotate == false);
+
+    REQUIRE(encoder.syncSegment(&state, name, 3, 1) == false);  // 3 - 0 = 3 > 0
+    REQUIRE(state.ready_to_rotate == 1);                        // No additional increment
   }
 
   SECTION("Sync after rotation") {
     REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
-    REQUIRE(encoder.encoderd_segment_offset == 0);
+    REQUIRE(encoder.encoder_segment_offset == 0);
 
     REQUIRE(encoder.syncSegment(&state, name, 1, 0) == false);  // 1 - 0 = 1 > 0
     REQUIRE(encoder.marked_ready_to_rotate == true);
     REQUIRE(state.ready_to_rotate == 1);
 
     // Simulate rotation: logger catches up to encoder
-    REQUIRE(encoder.syncSegment(&state, name, 1, 1) == true);   // 1 - 0 = 1 == 1
+    REQUIRE(encoder.syncSegment(&state, name, 1, 1) == true);  // 1 - 0 = 1 == 1
     REQUIRE(encoder.current_segment == 1);
     REQUIRE(encoder.marked_ready_to_rotate == false);
-    REQUIRE(state.ready_to_rotate == 1);                    // Not decremented here
+    REQUIRE(state.ready_to_rotate == 1);  // Not decremented here
   }
 
   SECTION("Encoder catches up after being behind") {
     REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
-    REQUIRE(encoder.encoderd_segment_offset == 0);
+    REQUIRE(encoder.encoder_segment_offset == 0);
 
     // Logger advances to 1, encoder sends 0
     REQUIRE(encoder.syncSegment(&state, name, 0, 1) == false);  // 0 - 0 = 0 < 1
-    REQUIRE(encoder.encoderd_segment_offset == -1);         // Adjusted to 0 - 1
+    REQUIRE(encoder.encoder_segment_offset == -1);              // Adjusted to 0 - 1
 
     // Logger advances to 2, encoder sends 1
-    REQUIRE(encoder.syncSegment(&state, name, 1, 2) == true);   // 1 - (-1) = 2 == 2
+    REQUIRE(encoder.syncSegment(&state, name, 1, 2) == true);  // 1 - (-1) = 2 == 2
     REQUIRE(encoder.current_segment == 2);
     REQUIRE(encoder.marked_ready_to_rotate == false);
+  }
+
+  SECTION("Recording reset on segment change") {
+    encoder.recording = true;                                  // Simulate active recording
+    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);  // Initial sync
+    REQUIRE(encoder.encoder_segment_offset == 0);
+    REQUIRE(encoder.current_segment == 0);
+
+    REQUIRE(encoder.syncSegment(&state, name, 1, 1) == true);  // 1 - 0 = 1 matches 1
+    REQUIRE(encoder.current_segment == 1);
+    REQUIRE(encoder.recording == false);  // Recording reset on segment change
   }
 }

--- a/system/loggerd/tests/test_logger.cc
+++ b/system/loggerd/tests/test_logger.cc
@@ -1,5 +1,6 @@
 #include "catch2/catch.hpp"
 #include "system/loggerd/logger.h"
+#include "system/loggerd/loggerd.h"
 
 typedef cereal::Sentinel::SentinelType SentinelType;
 
@@ -71,5 +72,113 @@ TEST_CASE("logger") {
   }
   for (int i = 0; i < segment_cnt; ++i) {
     verify_segment(log_root + "/" + route_name, i, segment_cnt, 1);
+  }
+}
+
+TEST_CASE("RemoteEncoder::syncSegment robustness", "[sync]") {
+  LoggerdState state;
+  RemoteEncoder encoder;
+  std::string name = "test_encoder";
+
+  SECTION("Matching segment after offset set") {
+    REQUIRE(encoder.syncSegment(&state, name, 5, 5) == true);
+    REQUIRE(encoder.encoderd_segment_offset == 0);          // 5 - 5 = 0
+    REQUIRE(encoder.current_segment == 5);
+    REQUIRE(encoder.seen_first_packet == true);
+    REQUIRE(encoder.marked_ready_to_rotate == false);
+    REQUIRE(state.ready_to_rotate == 0);
+
+    REQUIRE(encoder.syncSegment(&state, name, 7, 7) == true);  // 7 - 0 = 7 == 7
+    REQUIRE(encoder.current_segment == 7);
+    REQUIRE(encoder.recording == false);
+    REQUIRE(encoder.marked_ready_to_rotate == false);
+    REQUIRE(state.ready_to_rotate == 0);
+  }
+
+  SECTION("Encoder restarts and sends segment 0") {
+    REQUIRE(encoder.syncSegment(&state, name, 1, 1) == true);
+    REQUIRE(encoder.encoderd_segment_offset == 0);          // 1 - 1 = 0
+    REQUIRE(encoder.current_segment == 1);
+
+    REQUIRE(encoder.syncSegment(&state, name, 0, 2) == false);  // 0 - 0 = 0 < 2
+    REQUIRE(encoder.encoderd_segment_offset == -2);         // Adjusted to 0 - 2
+    REQUIRE(encoder.marked_ready_to_rotate == false);
+    REQUIRE(state.ready_to_rotate == 0);
+
+    REQUIRE(encoder.syncSegment(&state, name, 0, 2) == true);   // 0 - (-2) = 2 == 2
+    REQUIRE(encoder.current_segment == 2);
+    REQUIRE(encoder.marked_ready_to_rotate == false);
+  }
+
+  SECTION("Encoder restarts and sends segment greater than 0") {
+    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
+    REQUIRE(encoder.encoderd_segment_offset == 0);          // 0 - 0 = 0
+    REQUIRE(encoder.current_segment == 0);
+
+    REQUIRE(encoder.syncSegment(&state, name, 2, 3) == false);  // 2 - 0 = 2 < 3
+    REQUIRE(encoder.encoderd_segment_offset == -1);         // Adjusted to 2 - 3
+    REQUIRE(encoder.marked_ready_to_rotate == false);
+    REQUIRE(state.ready_to_rotate == 0);
+
+    REQUIRE(encoder.syncSegment(&state, name, 2, 3) == true);   // 2 - (-1) = 3 == 3
+    REQUIRE(encoder.current_segment == 3);
+  }
+
+  SECTION("Logger restarts to lower segment") {
+    REQUIRE(encoder.syncSegment(&state, name, 5, 5) == true);
+    REQUIRE(encoder.encoderd_segment_offset == 0);
+    REQUIRE(encoder.current_segment == 5);
+
+    // Logger restarts to segment 0, encoder continues at 6
+    REQUIRE(encoder.syncSegment(&state, name, 6, 0) == false);  // 6 - 0 = 6 > 0
+    REQUIRE(encoder.marked_ready_to_rotate == true);
+    REQUIRE(state.ready_to_rotate == 1);
+    REQUIRE(encoder.current_segment == 5);                  // Unchanged until sync
+
+    // Subsequent call with next segment
+    REQUIRE(encoder.syncSegment(&state, name, 7, 0) == false);  // 7 - 0 = 7 > 0
+    REQUIRE(state.ready_to_rotate == 1);                    // No further increment
+  }
+
+  SECTION("Encoder is ahead by more than one segment") {
+    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
+    REQUIRE(encoder.encoderd_segment_offset == 0);
+    REQUIRE(encoder.current_segment == 0);
+
+    REQUIRE(encoder.syncSegment(&state, name, 2, 0) == false);  // 2 - 0 = 2 > 0
+    REQUIRE(encoder.marked_ready_to_rotate == true);
+    REQUIRE(state.ready_to_rotate == 1);
+
+    REQUIRE(encoder.syncSegment(&state, name, 3, 0) == false);  // 3 - 0 = 3 > 0
+    REQUIRE(state.ready_to_rotate == 1);                    // No additional increment
+  }
+
+  SECTION("Sync after rotation") {
+    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
+    REQUIRE(encoder.encoderd_segment_offset == 0);
+
+    REQUIRE(encoder.syncSegment(&state, name, 1, 0) == false);  // 1 - 0 = 1 > 0
+    REQUIRE(encoder.marked_ready_to_rotate == true);
+    REQUIRE(state.ready_to_rotate == 1);
+
+    // Simulate rotation: logger catches up to encoder
+    REQUIRE(encoder.syncSegment(&state, name, 1, 1) == true);   // 1 - 0 = 1 == 1
+    REQUIRE(encoder.current_segment == 1);
+    REQUIRE(encoder.marked_ready_to_rotate == false);
+    REQUIRE(state.ready_to_rotate == 1);                    // Not decremented here
+  }
+
+  SECTION("Encoder catches up after being behind") {
+    REQUIRE(encoder.syncSegment(&state, name, 0, 0) == true);
+    REQUIRE(encoder.encoderd_segment_offset == 0);
+
+    // Logger advances to 1, encoder sends 0
+    REQUIRE(encoder.syncSegment(&state, name, 0, 1) == false);  // 0 - 0 = 0 < 1
+    REQUIRE(encoder.encoderd_segment_offset == -1);         // Adjusted to 0 - 1
+
+    // Logger advances to 2, encoder sends 1
+    REQUIRE(encoder.syncSegment(&state, name, 1, 2) == true);   // 1 - (-1) = 2 == 2
+    REQUIRE(encoder.current_segment == 2);
+    REQUIRE(encoder.marked_ready_to_rotate == false);
   }
 }


### PR DESCRIPTION
resolve: https://github.com/commaai/openpilot/issues/34839

This PR adds unit tests specifically aimed at resolving synchronization issues between encoderd and loggerd. While existing tests thoroughly cover logger rotation, these new test cases address the previously untested logic for synchronizing encoder segment numbers with logger segment numbers.

**Key Changes:**
1. Refactored the code to make unit testing feasible. Due to the original design, it was nearly impossible to unit test the synchronization logic. To enable testing, `LoggerdState` and `RemoteEncoder` classes were moved to `loggerd.h`.
2. The synchronization logic has been encapsulated into a new method `RemoteEncoder::syncSegment`, which can now be unit tested.

**Future Improvements:**
    As part of future work, `loggerd.h` can be split to separate configuration and logic. For instance, renaming `loggerd.h` to `encoder_config.h` and limiting `loggerd.h` to only contain declarations used by `loggerd.cc`. However, since this would introduce substantial changes, it will be addressed in a follow-up PR.
    
 