### PR TITLE
camerad: clear request queue on exit

### DIFF
--- a/system/camerad/cameras/spectra.cc
+++ b/system/camerad/cameras/spectra.cc
@@ -1258,6 +1258,8 @@ void SpectraCamera::camera_close() {
   LOG("-- Stop devices %d", cc.camera_num);
 
   if (enabled) {
+    clear_req_queue();
+
     // ret = device_control(sensor_fd, CAM_STOP_DEV, session_handle, sensor_dev_handle);
     // LOGD("stop sensor: %d", ret);
     int ret = device_control(m->isp_fd, CAM_STOP_DEV, session_handle, isp_dev_handle);

--- a/system/camerad/main.cc
+++ b/system/camerad/main.cc
@@ -6,9 +6,8 @@
 #include "common/util.h"
 
 int main(int argc, char *argv[]) {
-  int ret = util::set_realtime_priority(53);
-  assert(ret == 0);
-  ret = util::set_core_affinity({6});
+  // doesn't need RT priority since we're using isolcpus
+  int ret = util::set_core_affinity({6});
   assert(ret == 0 || Params().getBool("IsOffroad")); // failure ok while offroad due to offlining cores
 
   camerad_thread();


### PR DESCRIPTION
fixes #3484

Both changes individually fix the issue but pushing both since it's most correct:
* clearing the request manager's queue
* no RT priority: allows the kernel threads to get scheduled. this wasn't an issue before since the kernel threads could run on any CPU