### PR TITLE
test_models: convert can data to namedtuple

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -227,7 +227,7 @@ jobs:
     - name: Build openpilot
       run: ${{ env.RUN }} "scons -j$(nproc)"
     - name: Test car models
-      timeout-minutes: ${{ contains(runner.name, 'nsc') && (steps.routes-cache.outputs.cache-hit == 'true') && 1 || 20 }}
+      timeout-minutes: ${{ contains(runner.name, 'nsc') && (steps.routes-cache.outputs.cache-hit == 'true') && 1 || 3 }}
       run: |
         ${{ env.RUN }} "MAX_EXAMPLES=1 $PYTEST selfdrive/car/tests/test_models.py && \
                         chmod -R 777 /tmp/comma_download_cache"

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -387,11 +387,11 @@ class TestCarModelBase(unittest.TestCase):
       self.skipTest("no need to check panda safety for dashcamOnly")
 
     # warm up pass, as initial states may be different
-    # for can in self.can_msgs[:300]:
-    #   self.CI.update(can)
-    #   for msg in filter(lambda m: m.src < 64, can[1]):
-    #     to_send = libsafety_py.make_CANPacket(msg.address, msg.src % 4, msg.dat)
-    #     self.safety.safety_rx_hook(to_send)
+    for can in self.can_msgs[:300]:
+      self.CI.update(can)
+      for msg in filter(lambda m: m.src < 64, can[1]):
+        to_send = libsafety_py.make_CANPacket(msg.address, msg.src % 4, msg.dat)
+        self.safety.safety_rx_hook(to_send)
 
     controls_allowed_prev = False
     CS_prev = car.CarState.new_message()
@@ -401,10 +401,9 @@ class TestCarModelBase(unittest.TestCase):
       CS = self.CI.update(can).as_reader()
       for msg in filter(lambda m: m.src < 64, can[1]):
         to_send = libsafety_py.make_CANPacket(msg.address, msg.src % 4, msg.dat)
-        # ret = self.safety.safety_rx_hook(to_send)
-        # self.assertEqual(1, ret, f"safety rx failed ({ret=}): {(msg.address, msg.src % 4)}")
+        ret = self.safety.safety_rx_hook(to_send)
+        self.assertEqual(1, ret, f"safety rx failed ({ret=}): {(msg.address, msg.src % 4)}")
 
-      continue
       # Skip first frame so CS_prev is properly initialized
       if idx == 0:
         CS_prev = CS

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -1,5 +1,4 @@
 import time
-import capnp
 import os
 import pytest
 import random

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -82,7 +82,6 @@ class TestCarModelBase(unittest.TestCase):
     experimental_long = False
     for msg in lr:
       if msg.which() == "can":
-        # can_msgs.append((msg.logMonoTime, [CanData(can.address, can.dat, can.src) for can in msg.can]))
         can = can_capnp_to_list((msg.as_builder().to_bytes(),))[0]
         can_msgs.append((can[0], [CanData(*can) for can in can[1]]))
         if len(can_msgs) <= FRAME_FINGERPRINT:

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -85,7 +85,7 @@ class TestCarModelBase(unittest.TestCase):
         can = can_capnp_to_list((msg.as_builder().to_bytes(),))[0]
         can_msgs.append((can[0], [CanData(*can) for can in can[1]]))
         if len(can_msgs) <= FRAME_FINGERPRINT:
-          for m in msg.can:
+          for m in can_msgs[-1][1]:
             if m.src < 64:
               cls.fingerprint[m.src][m.address] = len(m.dat)
 

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -83,9 +83,8 @@ class TestCarModelBase(unittest.TestCase):
     for msg in lr:
       if msg.which() == "can":
         # can_msgs.append((msg.logMonoTime, [CanData(can.address, can.dat, can.src) for can in msg.can]))
-        tup = can_capnp_to_list((msg.as_builder().to_bytes(),))[0]
-        tup = (tup[0], [CanData(*can) for can in tup[1]])
-        can_msgs.append(tup)
+        can = can_capnp_to_list((msg.as_builder().to_bytes(),))[0]
+        can_msgs.append((can[0], [CanData(*can) for can in can[1]]))
         if len(can_msgs) <= FRAME_FINGERPRINT:
           for m in msg.can:
             if m.src < 64:

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -147,13 +147,10 @@ class TestCarModelBase(unittest.TestCase):
         raise unittest.SkipTest
       raise Exception(f"missing test route for {cls.platform}")
 
-    car_fw, can_msgs, experimental_long = cls.get_testing_data()
+    car_fw, cls.can_msgs, experimental_long = cls.get_testing_data()
 
     # if relay is expected to be open in the route
     cls.openpilot_enabled = cls.car_safety_mode_frame is not None
-
-    # TODO: isn't this already sorted?
-    cls.can_msgs = sorted(can_msgs, key=lambda msg: msg[0])
 
     cls.CarInterface, cls.CarController, cls.CarState, cls.RadarInterface = interfaces[cls.platform]
     cls.CP = cls.CarInterface.get_params(cls.platform,  cls.fingerprint, car_fw, experimental_long, docs=False)

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -167,17 +167,6 @@ class TestCarModelBase(unittest.TestCase):
     del cls.can_msgs
 
   def setUp(self):
-    # if self.CP.flags & HondaFlags.BOSCH_ALT_BRAKE.value:
-    #   raise Exception
-
-    # if self.CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and self.CP.openpilotLongitudinalControl:
-    #   raise Exception
-    #
-    # for msg in self.can_msgs:
-    #   for m in msg.can:
-    #     if self.test_route.car_model in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS):
-    #       assert not (m.src in (0, 1, 2) and m.address == 0x194), (m.src, m.address)
-
     self.CI = self.CarInterface(self.CP.copy(), self.CarController, self.CarState)
     assert self.CI
 

--- a/selfdrive/debug/check_can_parser_performance.py
+++ b/selfdrive/debug/check_can_parser_performance.py
@@ -6,7 +6,6 @@ from tqdm import tqdm
 from cereal import car
 from opendbc.car.tests.routes import CarTestRoute
 from openpilot.selfdrive.car.tests.test_models import TestCarModelBase
-from openpilot.selfdrive.pandad import can_capnp_to_list
 from openpilot.tools.plotjuggler.juggle import DEMO_ROUTE
 
 N_RUNS = 10
@@ -25,13 +24,11 @@ if __name__ == '__main__':
   CC = car.CarControl.new_message()
   ets = []
   for _ in tqdm(range(N_RUNS)):
-    msgs = [m.as_builder().to_bytes() for m in tm.can_msgs]
     start_t = time.process_time_ns()
-    for msg in msgs:
-      can_list = can_capnp_to_list([msg])
+    for msg in tm.can_msgs:
       for cp in tm.CI.can_parsers.values():
         if cp is not None:
-          cp.update_strings(can_list)
+          cp.update_strings(msg)
     ets.append((time.process_time_ns() - start_t) * 1e-6)
 
   print(f'{len(tm.can_msgs)} CAN packets, {N_RUNS} runs')


### PR DESCRIPTION
moves the slow part into the setup, since accessing the same fields isn't cached in pycapnp


with 32 jobs, the time goes from 130s to 106s