### PR TITLE
loggerd: synchronize encoder's segment mumber with logger's current segment

### DIFF
--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -111,6 +111,11 @@ size_t write_encode_data(LoggerdState *s, cereal::Event::Reader event, RemoteEnc
   auto evt = bmsg.initEvent(event.getValid());
   evt.setLogMonoTime(event.getLogMonoTime());
   (evt.*(encoder_info.set_encode_idx_func))(idx);
+
+  // update its segment number to match the logger's
+  auto encoder_idx = (evt.*(encoder_info.get_encode_idx_func))();
+  encoder_idx.setSegmentNum(s->logger.segment());
+
   auto new_msg = bmsg.toBytes();
   s->logger.write((uint8_t *)new_msg.begin(), new_msg.size(), true);  // always in qlog?
   return new_msg.size();

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -22,6 +22,7 @@ const int QCAM_BITRATE = 256000;
 #define INIT_ENCODE_FUNCTIONS(encode_type)                                \
   .get_encode_data_func = &cereal::Event::Reader::get##encode_type##Data, \
   .set_encode_idx_func = &cereal::Event::Builder::set##encode_type##Idx,  \
+  .get_encode_idx_func = &cereal::Event::Builder::get##encode_type##Idx, \
   .init_encode_data_func = &cereal::Event::Builder::init##encode_type##Data
 
 const bool LOGGERD_TEST = getenv("LOGGERD_TEST");
@@ -43,6 +44,7 @@ public:
                                                          : cereal::EncodeIndex::Type::FULL_H_E_V_C;
   ::cereal::EncodeData::Reader (cereal::Event::Reader::*get_encode_data_func)() const;
   void (cereal::Event::Builder::*set_encode_idx_func)(::cereal::EncodeIndex::Reader);
+  cereal::EncodeIndex::Builder (cereal::Event::Builder::*get_encode_idx_func)();
   cereal::EncodeData::Builder (cereal::Event::Builder::*init_encode_data_func)();
 };
 


### PR DESCRIPTION
We currently synchronize the encoderd and loggerd to ensure video frames and log data are written to the same segment. However, the `segmentNum` in `EncoderIdx`, sourced from the encoder’s package, is written to the logger as-is. This value may not align with the logger’s current segment, causing a mismatch. As a result, replay tools may retrieve incorrect video frames, as they rely on `EncoderIdx.segmentNum`, which could reference an unrelated or invalid segment. This misalignment renders video files in the affected segments nearly unusable due to the encoder’s `segmentNum` being out of sync with the logger.

This PR update the encoder's `segmentNum` to match the logger's current segment number, ensuring consistent segment alignment between the encoder and logger. This fixes the issue with replay tools and ensures accurate frame retrieval.