### PR TITLE
feat(athenad): priority uploads

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -53,7 +53,7 @@ MAX_RETRY_COUNT = 30  # Try for at most 5 minutes if upload fails immediately
 MAX_AGE = 31 * 24 * 3600  # seconds
 WS_FRAME_SIZE = 4096
 DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
-DEFAULT_UPLOAD_PRIORITY = 99 # lower number = higher priority. default will be 99
+DEFAULT_UPLOAD_PRIORITY = 99 # higher number = lower priority
 
 NetworkType = log.DeviceState.NetworkType
 
@@ -95,7 +95,7 @@ class UploadItem:
     return cls(d["path"], d["url"], d["headers"], d["created_at"], d["id"], d["retry_count"], d["current"],
                d["progress"], d["allow_cellular"], d["priority"])
 
-  def __lt__(self, other: UploadItem):
+  def __lt__(self, other):
     return self.priority < other.priority
 
   def __eq__(self, other):
@@ -103,7 +103,6 @@ class UploadItem:
       return NotImplemented
 
     return self.priority == other.priority
-
 
 dispatcher["echo"] = lambda s: s
 recv_queue: Queue[str] = queue.Queue()
@@ -411,7 +410,7 @@ def uploadFilesToUrls(files_data: list[UploadFileDict]) -> UploadFilesToUrlRespo
       created_at=int(time.time() * 1000),
       id=None,
       allow_cellular=file.allow_cellular,
-      priority=file.priority
+      priority=file.priority,
     )
     upload_id = hashlib.sha1(str(item).encode()).hexdigest()
     item = replace(item, id=upload_id)

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -77,6 +77,7 @@ class UploadFile:
 
 
 @dataclass
+@total_ordering
 class UploadItem:
   path: str
   url: str

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -53,7 +53,7 @@ MAX_RETRY_COUNT = 30  # Try for at most 5 minutes if upload fails immediately
 MAX_AGE = 31 * 24 * 3600  # seconds
 WS_FRAME_SIZE = 4096
 DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
-DEFAULT_UPLOAD_PRIORITY = 0
+DEFAULT_UPLOAD_PRIORITY = sys.maxsize # lower number = higher priority, so default is big
 
 NetworkType = log.DeviceState.NetworkType
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -100,6 +100,9 @@ class UploadItem:
 
   @classmethod
   def __eq__(cls, other: UploadItem):
+    if not isinstance(other, UploadItem):
+      return NotImplemented
+
     return cls.priority == other.priority
 
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -98,14 +98,13 @@ class UploadItem:
   def __lt__(self, other):
     if not isinstance(other, UploadItem):
       return NotImplemented
-
     return self.priority < other.priority
 
   def __eq__(self, other):
     if not isinstance(other, UploadItem):
       return NotImplemented
-
     return self.priority == other.priority
+
 
 dispatcher["echo"] = lambda s: s
 recv_queue: Queue[str] = queue.Queue()

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -53,7 +53,7 @@ MAX_RETRY_COUNT = 30  # Try for at most 5 minutes if upload fails immediately
 MAX_AGE = 31 * 24 * 3600  # seconds
 WS_FRAME_SIZE = 4096
 DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
-DEFAULT_UPLOAD_PRIORITY = sys.maxsize # lower number = higher priority, so default is big
+DEFAULT_UPLOAD_PRIORITY = 99 # lower number = higher priority. default will be 99
 
 NetworkType = log.DeviceState.NetworkType
 
@@ -61,6 +61,7 @@ UploadFileDict = dict[str, str | int | float | bool]
 UploadItemDict = dict[str, str | bool | int | float | dict[str, str]]
 
 UploadFilesToUrlResponse = dict[str, int | list[UploadItemDict] | list[str]]
+
 
 @dataclass
 class UploadFile:

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -17,7 +17,7 @@ import time
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from functools import partial, total_ordering
-from queue import Queue, PriorityQueue
+from queue import Queue
 from typing import cast
 from collections.abc import Callable
 
@@ -77,7 +77,6 @@ class UploadFile:
 
 
 @dataclass
-@total_ordering
 class UploadItem:
   path: str
   url: str

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -94,16 +94,8 @@ class UploadItem:
     return cls(d["path"], d["url"], d["headers"], d["created_at"], d["id"], d["retry_count"], d["current"],
                d["progress"], d["allow_cellular"], d["priority"])
 
-  @classmethod
-  def __lt__(cls, other: UploadItem):
-    return cls.priority < other.priority
-
-  @classmethod
-  def __eq__(cls, other):
-    if not isinstance(other, UploadItem):
-      return NotImplemented
-
-    return cls.priority == other.priority
+  def __lt__(self, other: UploadItem):
+    return self.priority < other.priority
 
 
 dispatcher["echo"] = lambda s: s

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -55,6 +55,9 @@ MAX_AGE = 31 * 24 * 3600  # seconds
 WS_FRAME_SIZE = 4096
 DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
 
+HIGH_PRIORITY = 999
+LOW_PRIORITY = 0
+
 NetworkType = log.DeviceState.NetworkType
 
 UploadFileDict = dict[str, str | int | float | bool]
@@ -62,21 +65,17 @@ UploadItemDict = dict[str, str | bool | int | float | dict[str, str]]
 
 UploadFilesToUrlResponse = dict[str, int | list[UploadItemDict] | list[str]]
 
-class Priority(Enum):
-  LOW = 0
-  HIGH = 999
-
 @dataclass
 class UploadFile:
   fn: str
   url: str
   headers: dict[str, str]
   allow_cellular: bool
-  priority: Priority = Priority.LOW
+  priority: int = LOW_PRIORITY
 
   @classmethod
   def from_dict(cls, d: dict) -> UploadFile:
-    return cls(d.get("fn", ""), d.get("url", ""), d.get("headers", {}), d.get("allow_cellular", False), d.get("priority", Priority.LOW))
+    return cls(d.get("fn", ""), d.get("url", ""), d.get("headers", {}), d.get("allow_cellular", False), d.get("priority", LOW_PRIORITY))
 
 
 @dataclass
@@ -91,7 +90,7 @@ class UploadItem:
   current: bool = False
   progress: float = 0
   allow_cellular: bool = False
-  priority: Priority = Priority.LOW
+  priority: int = LOW_PRIORITY
 
   @classmethod
   def from_dict(cls, d: dict) -> UploadItem:

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -99,7 +99,7 @@ class UploadItem:
     return cls.priority < other.priority
 
   @classmethod
-  def __eq__(cls, other: UploadItem):
+  def __eq__(cls, other):
     if not isinstance(other, UploadItem):
       return NotImplemented
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -17,7 +17,7 @@ import time
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from functools import partial, total_ordering
-from queue import Queue
+from queue import Queue, PriorityQueue
 from typing import cast
 from collections.abc import Callable
 
@@ -107,11 +107,11 @@ class UploadItem:
 
 
 dispatcher["echo"] = lambda s: s
-recv_queue: Queue[str] = queue.Queue()
-send_queue: Queue[str] = queue.Queue()
-upload_queue: Queue[UploadItem] = queue.PriorityQueue()
-low_priority_send_queue: Queue[str] = queue.Queue()
-log_recv_queue: Queue[str] = queue.Queue()
+recv_queue: Queue[str] = Queue()
+send_queue: Queue[str] = Queue()
+upload_queue: Queue[UploadItem] = PriorityQueue()
+low_priority_send_queue: Queue[str] = Queue()
+log_recv_queue: Queue[str] = Queue()
 cancelled_uploads: set[str] = set()
 
 cur_upload_items: dict[int, UploadItem | None] = {}

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -99,11 +99,11 @@ class UploadItem:
 
 
 dispatcher["echo"] = lambda s: s
-recv_queue: Queue[str] = Queue()
-send_queue: Queue[str] = Queue()
+recv_queue: Queue[str] = queue.Queue()
+send_queue: Queue[str] = queue.Queue()
 upload_queue: Queue[UploadItem] = PriorityQueue()
-low_priority_send_queue: Queue[str] = Queue()
-log_recv_queue: Queue[str] = Queue()
+low_priority_send_queue: Queue[str] = queue.Queue()
+log_recv_queue: Queue[str] = queue.Queue()
 cancelled_uploads: set[str] = set()
 
 cur_upload_items: dict[int, UploadItem | None] = {}

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -53,9 +53,7 @@ MAX_RETRY_COUNT = 30  # Try for at most 5 minutes if upload fails immediately
 MAX_AGE = 31 * 24 * 3600  # seconds
 WS_FRAME_SIZE = 4096
 DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
-
-HIGH_PRIORITY = 999
-LOW_PRIORITY = 0
+DEFAULT_UPLOAD_PRIORITY = 0
 
 NetworkType = log.DeviceState.NetworkType
 
@@ -70,11 +68,11 @@ class UploadFile:
   url: str
   headers: dict[str, str]
   allow_cellular: bool
-  priority: int = LOW_PRIORITY
+  priority: int = DEFAULT_UPLOAD_PRIORITY
 
   @classmethod
   def from_dict(cls, d: dict) -> UploadFile:
-    return cls(d.get("fn", ""), d.get("url", ""), d.get("headers", {}), d.get("allow_cellular", False), d.get("priority", LOW_PRIORITY))
+    return cls(d.get("fn", ""), d.get("url", ""), d.get("headers", {}), d.get("allow_cellular", False), d.get("priority", DEFAULT_UPLOAD_PRIORITY))
 
 
 @dataclass
@@ -89,7 +87,7 @@ class UploadItem:
   current: bool = False
   progress: float = 0
   allow_cellular: bool = False
-  priority: int = LOW_PRIORITY
+  priority: int = DEFAULT_UPLOAD_PRIORITY
 
   @classmethod
   def from_dict(cls, d: dict) -> UploadItem:

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -98,6 +98,10 @@ class UploadItem:
   def __lt__(cls, other: UploadItem):
     return cls.priority < other.priority
 
+  @classmethod
+  def __eq__(cls, other: UploadItem):
+    return cls.priority == other.priority
+
 
 dispatcher["echo"] = lambda s: s
 recv_queue: Queue[str] = queue.Queue()

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -16,7 +16,6 @@ import threading
 import time
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
-from enum import Enum
 from functools import partial, total_ordering
 from queue import Queue
 from typing import cast

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -98,11 +98,17 @@ class UploadItem:
   def __lt__(self, other: UploadItem):
     return self.priority < other.priority
 
+  def __eq__(self, other):
+    if not isinstance(other, UploadItem):
+      return NotImplemented
+
+    return self.priority == other.priority
+
 
 dispatcher["echo"] = lambda s: s
 recv_queue: Queue[str] = queue.Queue()
 send_queue: Queue[str] = queue.Queue()
-upload_queue: Queue[UploadItem] = PriorityQueue()
+upload_queue: Queue[UploadItem] = queue.PriorityQueue()
 low_priority_send_queue: Queue[str] = queue.Queue()
 log_recv_queue: Queue[str] = queue.Queue()
 cancelled_uploads: set[str] = set()

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -53,7 +53,7 @@ MAX_RETRY_COUNT = 30  # Try for at most 5 minutes if upload fails immediately
 MAX_AGE = 31 * 24 * 3600  # seconds
 WS_FRAME_SIZE = 4096
 DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
-DEFAULT_UPLOAD_PRIORITY = 99 # higher number = lower priority
+DEFAULT_UPLOAD_PRIORITY = 99  # higher number = lower priority
 
 NetworkType = log.DeviceState.NetworkType
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -96,6 +96,9 @@ class UploadItem:
                d["progress"], d["allow_cellular"], d["priority"])
 
   def __lt__(self, other):
+    if not isinstance(other, UploadItem):
+      return NotImplemented
+
     return self.priority < other.priority
 
   def __eq__(self, other):

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -322,6 +322,7 @@ class TestAthenadMethods:
     assert items[0]['current']
 
   def test_list_upload_queue_priority(self, host: str):
+    q = queue.PriorityQueue()
     fn1 = self._create_file('qlog.zst')
     fn2 = self._create_file('qlog2.zst')
     fn3 = self._create_file('qlog3.zst')
@@ -329,13 +330,13 @@ class TestAthenadMethods:
     item2 = athenad.UploadItem(path=fn2, url=f"{host}/qlog2.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=0)
     item3 = athenad.UploadItem(path=fn3, url=f"{host}/qlog3.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=500)
 
-    athenad.upload_queue.put_nowait(item1)
-    athenad.upload_queue.put_nowait(item2)
-    athenad.upload_queue.put_nowait(item3)
+    q.put_nowait(item1)
+    q.put_nowait(item2)
+    q.put_nowait(item3)
 
-    assert athenad.upload_queue.get().path == fn2
-    assert athenad.upload_queue.get().path == fn3
-    assert athenad.upload_queue.get().path == fn1
+    assert q.get().path == item2.path
+    assert q.get().path == item3.path
+    assert q.get().path == item1.path
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -336,11 +336,10 @@ class TestAthenadMethods:
         allow_cellular=True,
         priority=i
       )
-      athenad.upload_queue.put_nowait((i, item))
+      athenad.upload_queue.put_nowait(item)
 
     for i in sorted(priorities):
-      (_, actual) = athenad.upload_queue.get_nowait()
-      assert actual.priority == i
+      assert athenad.upload_queue.get_nowait().priority == i
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -321,6 +321,17 @@ class TestAthenadMethods:
     assert len(items) == 1
     assert items[0]['current']
 
+  def test_list_upload_queue_priority(self, host: str):
+    fn1 = self._create_file('qlog.zst')
+    fn2 = self._create_file('qlog2.zst')
+    item1 = athenad.UploadItem(path=fn1, url=f"{host}/qlog.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True)
+    item2 = athenad.UploadItem(path=fn2, url=f"{host}/qlog2.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=0)
+
+    athenad.upload_queue.put_nowait(item1)
+    athenad.upload_queue.put_nowait(item2)
+
+    assert athenad.upload_queue.get_nowait().url == f"{host}/qlog2.zst"
+
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},
                               created_at=int(time.time()*1000), id='id', allow_cellular=True)

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -336,10 +336,11 @@ class TestAthenadMethods:
         allow_cellular=True,
         priority=i
       )
-      athenad.upload_queue.put_nowait(item)
+      athenad.upload_queue.put_nowait((i, item))
 
     for i in sorted(priorities):
-      assert athenad.upload_queue.get_nowait().priority == i
+      (_, actual) = athenad.upload_queue.get_nowait()
+      assert actual.priority == i
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -329,13 +329,13 @@ class TestAthenadMethods:
     item2 = athenad.UploadItem(path=fn2, url=f"{host}/qlog2.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=0)
     item3 = athenad.UploadItem(path=fn3, url=f"{host}/qlog3.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=500)
 
-    athenad.upload_queue.put_nowait((item1.priority, item1))
-    athenad.upload_queue.put_nowait((item2.priority, item2))
-    athenad.upload_queue.put_nowait((item3.priority, item3))
+    athenad.upload_queue.put_nowait(item1)
+    athenad.upload_queue.put_nowait(item2)
+    athenad.upload_queue.put_nowait(item3)
 
-    assert athenad.upload_queue.get_nowait()[-1].path == fn2
-    assert athenad.upload_queue.get_nowait()[-1].path == fn3
-    assert athenad.upload_queue.get_nowait()[-1].path == fn1
+    assert athenad.upload_queue.get().path == fn2
+    assert athenad.upload_queue.get().path == fn3
+    assert athenad.upload_queue.get().path == fn1
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -336,10 +336,10 @@ class TestAthenadMethods:
         allow_cellular=True,
         priority=i
       )
-      athenad.upload_queue.put_nowait(item)
+      athenad.upload_queue.put(item)
 
     for i in sorted(priorities):
-      assert athenad.upload_queue.get_nowait().priority == i
+      assert athenad.upload_queue.get().priority == i
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -324,13 +324,18 @@ class TestAthenadMethods:
   def test_list_upload_queue_priority(self, host: str):
     fn1 = self._create_file('qlog.zst')
     fn2 = self._create_file('qlog2.zst')
-    item1 = athenad.UploadItem(path=fn1, url=f"{host}/qlog.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True)
+    fn3 = self._create_file('qlog3.zst')
+    item1 = athenad.UploadItem(path=fn1, url=f"{host}/qlog.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=1000)
     item2 = athenad.UploadItem(path=fn2, url=f"{host}/qlog2.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=0)
+    item3 = athenad.UploadItem(path=fn3, url=f"{host}/qlog3.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=500)
 
     athenad.upload_queue.put_nowait(item1)
     athenad.upload_queue.put_nowait(item2)
+    athenad.upload_queue.put_nowait(item3)
 
-    assert athenad.upload_queue.get_nowait().url == f"{host}/qlog2.zst"
+    assert athenad.upload_queue.get_nowait().path == fn2
+    assert athenad.upload_queue.get_nowait().path == fn3
+    assert athenad.upload_queue.get_nowait().path == fn1
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -322,7 +322,9 @@ class TestAthenadMethods:
     assert items[0]['current']
 
   def test_list_upload_queue_priority(self, host: str):
-    for i in (100, 500, 0):
+    priorities = (25, 50, 99, 75, 0)
+
+    for i in priorities:
       fn = f'qlog_{i}.zst'
       fp = self._create_file(fn)
       item = athenad.UploadItem(
@@ -336,7 +338,7 @@ class TestAthenadMethods:
       )
       athenad.upload_queue.put_nowait(item)
 
-    for i in (0, 100, 500):
+    for i in sorted(priorities):
       assert athenad.upload_queue.get_nowait().priority == i
 
   def test_list_upload_queue(self):

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -336,10 +336,10 @@ class TestAthenadMethods:
         allow_cellular=True,
         priority=i
       )
-      athenad.upload_queue.put(item)
+      athenad.upload_queue.put_nowait(item)
 
     for i in sorted(priorities):
-      assert athenad.upload_queue.get().priority == i
+      assert athenad.upload_queue.get_nowait().priority == i
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -329,13 +329,13 @@ class TestAthenadMethods:
     item2 = athenad.UploadItem(path=fn2, url=f"{host}/qlog2.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=0)
     item3 = athenad.UploadItem(path=fn3, url=f"{host}/qlog3.zst", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=500)
 
-    athenad.upload_queue.put_nowait(item1)
-    athenad.upload_queue.put_nowait(item2)
-    athenad.upload_queue.put_nowait(item3)
+    athenad.upload_queue.put_nowait((item1.priority, item1))
+    athenad.upload_queue.put_nowait((item2.priority, item2))
+    athenad.upload_queue.put_nowait((item3.priority, item3))
 
-    assert athenad.upload_queue.get_nowait().path == fn2
-    assert athenad.upload_queue.get_nowait().path == fn3
-    assert athenad.upload_queue.get_nowait().path == fn1
+    assert athenad.upload_queue.get_nowait()[-1].path == fn2
+    assert athenad.upload_queue.get_nowait()[-1].path == fn3
+    assert athenad.upload_queue.get_nowait()[-1].path == fn1
 
   def test_list_upload_queue(self):
     item = athenad.UploadItem(path="qlog.zst", url="http://localhost:44444/qlog.zst", headers={},

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -76,7 +76,7 @@ class TestAthenadMethods:
       self.params.put(k, v)
     self.params.put_bool("GsmMetered", True)
 
-    athenad.upload_queue.queue.clear()
+    athenad.upload_queue = queue.PriorityQueue()
     athenad.cur_upload_items.clear()
     athenad.cancelled_uploads.clear()
 
@@ -321,7 +321,7 @@ class TestAthenadMethods:
     assert len(items) == 1
     assert items[0]['current']
 
-  def test_list_upload_queue_priority(self, host: str):
+  def test_list_upload_queue_priority(self):
     priorities = (25, 50, 99, 75, 0)
 
     for i in priorities:
@@ -329,7 +329,7 @@ class TestAthenadMethods:
       fp = self._create_file(fn)
       item = athenad.UploadItem(
         path=fp,
-        url=f"{host}/{fn}",
+        url=f"http://localhost:44444/{fn}",
         headers={},
         created_at=int(time.time()*1000),
         id='',

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -76,7 +76,7 @@ class TestAthenadMethods:
       self.params.put(k, v)
     self.params.put_bool("GsmMetered", True)
 
-    athenad.upload_queue = queue.Queue()
+    athenad.upload_queue.queue.clear()
     athenad.cur_upload_items.clear()
     athenad.cancelled_uploads.clear()
 

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -325,7 +325,15 @@ class TestAthenadMethods:
     for i in (100, 500, 0):
       fn = f'qlog_{i}.zst'
       fp = self._create_file(fn)
-      item = athenad.UploadItem(path=fp, url=f"{host}/{fn}", headers={}, created_at=int(time.time()*1000), id='', allow_cellular=True, priority=i)
+      item = athenad.UploadItem(
+        path=fp,
+        url=f"{host}/{fn}",
+        headers={},
+        created_at=int(time.time()*1000),
+        id='',
+        allow_cellular=True,
+        priority=i
+      )
       athenad.upload_queue.put_nowait(item)
 
     for i in (0, 100, 500):


### PR DESCRIPTION
**Description**

Closes https://github.com/commaai/openpilot/issues/34836

Today, Firehose uploads and user-requested uploads from Connect are treated the same. This is not ideal behavior if the user wants to upload routes immediately for a bug report and the queue is full of uploads for Firehose. The workaround is to clear the queue and retry the upload from Connect.

This PR adds an optional `priority` to requested file uploads in `athenad`. By default, all requests are marked `Low`. However, if the caller wishes to mark their uploads as "more important," then the upload queue will prioritize those requests when uploading.

The only caveat to this PR is that we won't reorder files currently being uploaded. Most connections are quick enough to finish uploading max 4 files before polling the new high-priority items in the queue.

PR to mark Connect uploads as high priority: https://github.com/commaai/connect/pull/557

**Verification**

Added test case to insert upload tasks with differing priorities. Polling the queue produces items in the correct order (smallest # to largest).