### PR TITLE
pandad: forward debug logs to cloudlog

### DIFF
--- a/selfdrive/pandad/panda.cc
+++ b/selfdrive/pandad/panda.cc
@@ -66,6 +66,25 @@ void Panda::set_alternative_experience(uint16_t alternative_experience) {
   handle->control_write(0xdf, alternative_experience, 0);
 }
 
+std::string Panda::serial_read(int port_number) {
+  std::string ret;
+  char buffer[USBPACKET_MAX_SIZE] = {};
+
+  while (true) {
+    int bytes_read = handle->control_read(0xe0, port_number, 0, (unsigned char *)buffer, USBPACKET_MAX_SIZE);
+    if (bytes_read <= 0) {
+      break;
+    }
+    ret.append(buffer, bytes_read);
+  }
+
+  return ret;
+}
+
+void Panda::set_uart_baud(int uart, int rate) {
+  handle->control_write(0xe4, uart, int(rate / 300));
+}
+
 cereal::PandaState::PandaType Panda::get_hw_type() {
   unsigned char hw_query[1] = {0};
 

--- a/selfdrive/pandad/panda.h
+++ b/selfdrive/pandad/panda.h
@@ -64,6 +64,8 @@ public:
   cereal::PandaState::PandaType get_hw_type();
   void set_safety_model(cereal::CarParams::SafetyModel safety_model, uint16_t safety_param=0U);
   void set_alternative_experience(uint16_t alternative_experience);
+  std::string serial_read(int port_number = 0);
+  void set_uart_baud(int uart, int rate);
   void set_fan_speed(uint16_t fan_speed);
   uint16_t get_fan_speed();
   void set_ir_pwr(uint16_t ir_pwr);

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -452,6 +452,14 @@ void pandad_run(std::vector<Panda *> &pandas) {
       send_peripheral_state(peripheral_panda, &pm);
     }
 
+    // Forward logs from pandas to cloudlog if available
+    for (auto *panda : pandas) {
+      std::string log = panda->serial_read();
+      if (!log.empty()) {
+        LOGD("%s", log.c_str());
+      }
+    }
+
     rk.keepTime();
   }
 


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/34843

The code block responsible for forwarding logs to cloudlog requires approximately 2 milliseconds to read and process logs when they are available. This overhead is acceptable and should not impact the main loop's execution frequency.

```C++
for (auto *panda : pandas) {
  std::string log = panda->serial_read();
  if (!log.empty()) {
    LOGD("%s", log.c_str());
  }
}

```