### PR TITLE
setup: fix dangling pointer Issue in curl header setup

### DIFF
--- a/selfdrive/ui/qt/setup/setup.cc
+++ b/selfdrive/ui/qt/setup/setup.cc
@@ -48,7 +48,8 @@ void Setup::download(QString url) {
   auto version = util::read_file("/VERSION");
 
   struct curl_slist *list = NULL;
-  list = curl_slist_append(list, ("X-openpilot-serial: " + Hardware::get_serial()).c_str());
+  std::string header = "X-openpilot-serial: " + Hardware::get_serial();
+  list = curl_slist_append(list, header.c_str());
 
   char tmpfile[] = "/tmp/installer_XXXXXX";
   FILE *fp = fdopen(mkstemp(tmpfile), "wb");


### PR DESCRIPTION
This PR addresses a dangling pointer issue in the `Setup::download` , where a temporary string's `c_str()` was passed to `curl_slist_append`([reference](https://github.com/curl/curl/blob/acdb48272a53fe97f63e5437fce27c7036a9c43e/lib/slist.c#L61)). Since the temporary string was destroyed after the statement, this left CURL with an invalid pointer, potentially causing undefined behavior, including crashes or corrupted headers.