### PR TITLE
selfdrived: add canError for radar can errors

### DIFF
--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -270,7 +270,9 @@ class SelfdriveD:
     if not REPLAY and self.rk.lagging:
       self.events.add(EventName.selfdrivedLagging)
     if not self.sm.valid['radarState']:
-      if self.sm['radarState'].radarErrors.radarUnavailableTemporary:
+      if self.sm['radarState'].radarErrors.canError:
+        self.events.add(EventName.canError)
+      elif self.sm['radarState'].radarErrors.radarUnavailableTemporary:
         self.events.add(EventName.radarTempUnavailable)
       else:
         self.events.add(EventName.radarFault)


### PR DESCRIPTION
@adeebshihadeh it shouldn't be a problem to add two canError events if both are true, right? We can move this check so that it only adds once if needed