### PR TITLE
Split safety rx checks invalid into own event

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -56,6 +56,7 @@ struct OnroadEvent @0xc4fa6047f024e718 {
     calibrationInvalid @20;
     calibrationRecalibrating @21;
     controlsMismatch @22;
+    safetyChecksInvalid @94;
     pcmEnable @23;
     pcmDisable @24;
     radarFault @25;

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -885,6 +885,11 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.NO_ENTRY: NoEntryAlert("Controls Mismatch"),
   },
 
+  EventName.safetyChecksInvalid: {
+    ET.IMMEDIATE_DISABLE: ImmediateDisableAlert("Safety Checks Invalid"),
+    ET.NO_ENTRY: NoEntryAlert("Safety Checks Invalid"),
+  },
+
   # Sometimes the USB stack on the device can get into a bad state
   # causing the connection to the panda to be lost
   EventName.usbError: {

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -243,8 +243,10 @@ class SelfdriveD:
         safety_mismatch = pandaState.safetyModel not in IGNORED_SAFETY_MODES
 
       # safety mismatch allows some time for pandad to set the safety mode and publish it back from panda
-      if (safety_mismatch and self.sm.frame*DT_CTRL > 10.) or pandaState.safetyRxChecksInvalid or self.mismatch_counter >= 200:
+      if (safety_mismatch and self.sm.frame*DT_CTRL > 10.) or self.mismatch_counter >= 200:
         self.events.add(EventName.controlsMismatch)
+      elif pandaState.safetyRxChecksInvalid:
+        self.events.add(EventName.safetyChecksInvalid)
 
       if log.PandaState.FaultType.relayMalfunction in pandaState.faults:
         self.events.add(EventName.relayMalfunction)


### PR DESCRIPTION
`controlsMismatch` can be confusing since it covers a few things, especially when porting a new car and writing safety (seen at comma hack)