### PR TITLE
url_file.py: remove the unnecessary str() wrapping around the hexdigest()

### DIFF
--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -16,8 +16,7 @@ CHUNK_SIZE = 1000 * K
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 def hash_256(link: str) -> str:
-  hsh = str(sha256((link.split("?")[0]).encode('utf-8')).hexdigest())
-  return hsh
+  return sha256((link.split("?")[0]).encode('utf-8')).hexdigest()
 
 
 class URLFileException(Exception):


### PR DESCRIPTION
Removed the unnecessary str() wrapping around the hexdigest() call, as hexdigest() already returns a string.