### PR TITLE
logger: add logVersion to InitData

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -156,6 +156,8 @@ struct InitData {
   gitSrcCommit @23 :Text;
   gitSrcCommitDate @24 :Text;
 
+  logVersion @25 : Int32;
+
   androidProperties @16 :Map(Text, Text);
 
   pandaInfo @8 :PandaInfo;

--- a/system/loggerd/logger.cc
+++ b/system/loggerd/logger.cc
@@ -20,6 +20,7 @@ kj::Array<capnp::word> logger_build_init_data() {
 
   init.setWallTimeNanos(wall_time);
   init.setVersion(COMMA_VERSION);
+  init.setLogVersion(cereal::LOG_VERSION);
   init.setDirty(!getenv("CLEAN"));
   init.setDeviceType(Hardware::get_device_type());
 


### PR DESCRIPTION
Adds a new `logVersion` field to the `InitData` struct to record the version of the capnp schema utilized in the logs. The `logVersion` field is defined as an Int32 (same as `cereal::LOG_VERSION`) and assigned field number 25, ensuring backward compatibility with older versions of the schema.
Versioning logs with the `logVersion` field simplifies schema management by making it easy to track, read, and migrate logs based on their version. 