### PR TITLE
refactor: driver monitor to QWidget

### DIFF
--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -52,9 +52,9 @@ void DriverViewWindow::paintGL() {
 
   const auto &sm = *(uiState()->sm);
   cereal::DriverStateV2::Reader driver_state = sm["driverStateV2"].getDriverStateV2();
-  bool current_is_rhd = driver_state.getWheelOnRightProb() > 0.5;
-  if (is_rhd != current_is_rhd) {
-    is_rhd = current_is_rhd;
+  bool new_is_rhd = driver_state.getWheelOnRightProb() > 0.5;
+  if (is_rhd != new_is_rhd) {
+    is_rhd = new_is_rhd;
     main_layout->removeWidget(driver_monitor);
     main_layout->addWidget(driver_monitor, 0, Qt::AlignBottom | (is_rhd ? Qt::AlignRight : Qt::AlignLeft));
   }

--- a/selfdrive/ui/qt/offroad/driverview.cc
+++ b/selfdrive/ui/qt/offroad/driverview.cc
@@ -1,15 +1,19 @@
 #include "selfdrive/ui/qt/offroad/driverview.h"
 
 #include <algorithm>
+#include <QVBoxLayout>
 #include <QPainter>
 
 #include "selfdrive/ui/qt/util.h"
 
 DriverViewWindow::DriverViewWindow(QWidget* parent) : CameraWidget("camerad", VISION_STREAM_DRIVER, parent) {
+  main_layout = new QVBoxLayout(this);
+  main_layout->setMargin(UI_BORDER_SIZE);
+  main_layout->setSpacing(0);
+
   driver_monitor = new DriverMonitorRenderer(this);
-  int x = rect().width();
-  int y = rect().bottom() - rect().height();
-  driver_monitor->move(x, y);
+  main_layout->addWidget(driver_monitor, 0, Qt::AlignBottom | Qt::AlignLeft);
+
   QObject::connect(this, &CameraWidget::clicked, this, &DriverViewWindow::done);
   QObject::connect(device(), &Device::interactiveTimeout, this, [this]() {
     if (isVisible()) {
@@ -48,7 +52,12 @@ void DriverViewWindow::paintGL() {
 
   const auto &sm = *(uiState()->sm);
   cereal::DriverStateV2::Reader driver_state = sm["driverStateV2"].getDriverStateV2();
-  bool is_rhd = driver_state.getWheelOnRightProb() > 0.5;
+  bool current_is_rhd = driver_state.getWheelOnRightProb() > 0.5;
+  if (is_rhd != current_is_rhd) {
+    is_rhd = current_is_rhd;
+    main_layout->removeWidget(driver_monitor);
+    main_layout->addWidget(driver_monitor, 0, Qt::AlignBottom | (is_rhd ? Qt::AlignRight : Qt::AlignLeft));
+  }
   auto driver_data = is_rhd ? driver_state.getRightDriverData() : driver_state.getLeftDriverData();
 
   bool face_detected = driver_data.getFaceProb() > 0.7;
@@ -70,8 +79,6 @@ void DriverViewWindow::paintGL() {
     p.setPen(QPen(QColor(255, 255, 255, alpha * 255), 10));
     p.drawRoundedRect(fbox_x - box_size / 2, fbox_y - box_size / 2, box_size, box_size, 35.0, 35.0);
   }
-
-  driver_monitor->render(&p);
 }
 
 mat4 DriverViewWindow::calcFrameMatrix() {

--- a/selfdrive/ui/qt/offroad/driverview.h
+++ b/selfdrive/ui/qt/offroad/driverview.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QVBoxLayout>
+
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 #include "selfdrive/ui/qt/onroad/driver_monitoring.h"
 
@@ -20,5 +22,7 @@ protected:
 
   Params params;
 private:
+  QVBoxLayout *main_layout;
   DriverMonitorRenderer *driver_monitor;
+  bool is_rhd = false;
 };

--- a/selfdrive/ui/qt/offroad/driverview.h
+++ b/selfdrive/ui/qt/offroad/driverview.h
@@ -19,5 +19,6 @@ protected:
   void paintGL() override;
 
   Params params;
-  DriverMonitorRenderer driver_monitor;
+private:
+  DriverMonitorRenderer *driver_monitor;
 };

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -19,9 +19,8 @@ AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget *par
   dmon = new DriverMonitorRenderer(this);
 
   experimental_btn = new ExperimentalButton(this);
-  auto direction = is_rhd ? Qt::AlignRight : Qt::AlignLeft;
   main_layout->addWidget(experimental_btn, 0, Qt::AlignTop | Qt::AlignRight);
-  main_layout->addWidget(dmon, 0, Qt::AlignBottom | direction);
+  main_layout->addWidget(dmon, 0, Qt::AlignBottom | Qt::AlignLeft);
 }
 
 void AnnotatedCameraWidget::updateState(const UIState &s) {

--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -18,13 +18,14 @@ public:
 private:
   QVBoxLayout *main_layout;
   ExperimentalButton *experimental_btn;
-  DriverMonitorRenderer dmon;
+  DriverMonitorRenderer *dmon;
   HudRenderer hud;
   ModelRenderer model;
   std::unique_ptr<PubMaster> pm;
 
   int skip_frame_count = 0;
   bool wide_cam_requested = false;
+  bool is_rhd = false;
 
 protected:
   void paintGL() override;

--- a/selfdrive/ui/qt/onroad/driver_monitoring.cc
+++ b/selfdrive/ui/qt/onroad/driver_monitoring.cc
@@ -24,6 +24,7 @@ DriverMonitorRenderer::DriverMonitorRenderer(QWidget *parent) : QWidget(parent),
 
   dm_img = loadPixmap("../assets/img_driver_face.png", {img_size + 5, img_size + 5});
   connect(uiState(), &UIState::uiUpdate, this, &DriverMonitorRenderer::updateState);
+  setAttribute(Qt::WA_OpaquePaintEvent);
 }
 
 void DriverMonitorRenderer::updateState(const UIState &s) {

--- a/selfdrive/ui/qt/onroad/driver_monitoring.cc
+++ b/selfdrive/ui/qt/onroad/driver_monitoring.cc
@@ -20,11 +20,13 @@ static const QColor DMON_ENGAGED_COLOR = QColor::fromRgbF(0.1, 0.945, 0.26);
 static const QColor DMON_DISENGAGED_COLOR = QColor::fromRgbF(0.545, 0.545, 0.545);
 
 DriverMonitorRenderer::DriverMonitorRenderer(QWidget *parent) : QWidget(parent), face_kpts_draw(std::size(DEFAULT_FACE_KPTS_3D)) {
-  setFixedSize(btn_size, btn_size);
-
-  dm_img = loadPixmap("../assets/img_driver_face.png", {img_size + 5, img_size + 5});
-  connect(uiState(), &UIState::uiUpdate, this, &DriverMonitorRenderer::updateState);
+  int bufferSpace = 5;
   setAttribute(Qt::WA_OpaquePaintEvent);
+  setAttribute(Qt::WA_TranslucentBackground);
+  setFixedSize(btn_size + bufferSpace, btn_size + bufferSpace);
+
+  dm_img = loadPixmap("../assets/img_driver_face.png", {img_size + bufferSpace, img_size + bufferSpace});
+  connect(uiState(), &UIState::uiUpdate, this, &DriverMonitorRenderer::updateState);
 }
 
 void DriverMonitorRenderer::updateState(const UIState &s) {

--- a/selfdrive/ui/qt/onroad/driver_monitoring.h
+++ b/selfdrive/ui/qt/onroad/driver_monitoring.h
@@ -2,15 +2,22 @@
 
 #include <vector>
 #include <QPainter>
+#include <QWidget>
+
 #include "selfdrive/ui/ui.h"
 
-class DriverMonitorRenderer {
+class DriverMonitorRenderer : public QWidget {
+  Q_OBJECT
+
 public:
-  DriverMonitorRenderer();
+  explicit DriverMonitorRenderer(QWidget *parent = nullptr);
   void updateState(const UIState &s);
-  void draw(QPainter &painter, const QRect &surface_rect);
+
+protected:
+  void paintEvent(QPaintEvent*) override;
 
 private:
+  void draw(QPainter &painter, const QRect &surface_rect);
   float driver_pose_vals[3] = {};
   float driver_pose_diff[3] = {};
   float driver_pose_sins[3] = {};


### PR DESCRIPTION
**Description**

When working on https://github.com/commaai/openpilot/pull/34892, i noticed that a few onroad UI elements were using different rendering methodologies which caused some elements to be missing when dumping the frame content. Converting to `QWidget` and signals for updating so that porting the UI for replay is simpler.

**Verification**

Ran `tools/replay --demo`, the UI element renders like before. Also, ran the offroad driver cam viewer on my Comma 3X and looks good.
