### PR TITLE
fix: macOS CI

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -28,6 +28,8 @@ if [[ $(command -v brew) == "" ]]; then
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> $RC_FILE
     eval "$(/opt/homebrew/bin/brew shellenv)"
   fi
+else
+    brew up
 fi
 
 brew bundle --file=- <<-EOS


### PR DESCRIPTION
about 2 days ago, brew deprecated the [bundle](https://github.com/Homebrew/homebrew-bundle) tap and merged the command into brew itself. namespace runners have an old install which when calling bundle, taps `bundle` and fails because it is now empty.

call `brew up` if brew is already installed. this is needed until namespace runners are updated

this really isn't needed and adds Mac CI latency. should be reverted once the namespace Mac base is updated.