### PR TITLE
Rivian: enable torqued learning

### DIFF
--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -32,7 +32,7 @@ MIN_BUCKET_POINTS = np.array([100, 300, 500, 500, 500, 500, 300, 100])
 MIN_ENGAGE_BUFFER = 2  # secs
 
 VERSION = 1  # bump this to invalidate old parameter caches
-ALLOWED_CARS = ['toyota', 'hyundai']
+ALLOWED_CARS = ['toyota', 'hyundai', 'rivian']
 
 
 def slope2rot(slope):


### PR DESCRIPTION
Not sure why there's such a huge difference across cars, but the response looks mostly linear from -1 to 1 steer torque, which is good. We can enable torqued to improve control on the Rivians with less lateral acceleration.

Data from @gerrylum's R1T 2022 w/ quad motor:

left: LKAS toggled OFF, right: LKAS toggled ON (what https://github.com/commaai/opendbc/pull/2015 standardizes)

left: https://connect.comma.ai/2d2da5dea63b5c5e/00000000--f4f54c0e0f, https://connect.comma.ai/2d2da5dea63b5c5e/00000001--09df2a4d41

right: https://connect.comma.ai/2d2da5dea63b5c5e/00000003--300c74f7ad

![image](https://github.com/user-attachments/assets/3a4b942b-e651-4b0a-a2de-6890cdcc9cdb)

Data from our rented R1S 2023 w/ quad motor:

![image](https://github.com/user-attachments/assets/87de5e56-8180-49a9-99a4-847a253f386a)

Which also similarly matches the R1T 2023 we rented to do the initial port at the hackathon:

https://connect.comma.ai/bc095dc92e101734/000000e5--19c86a9b2f

![image](https://github.com/user-attachments/assets/1f3579ff-fee3-4774-bc3a-8ad2d2b4b400)