### PR TITLE
firehose: add toggle to disable

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -26,6 +26,7 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"ControlsReady", CLEAR_ON_MANAGER_START | CLEAR_ON_ONROAD_TRANSITION},
     {"CurrentBootlog", PERSISTENT},
     {"CurrentRoute", CLEAR_ON_MANAGER_START | CLEAR_ON_ONROAD_TRANSITION},
+    {"DisableFirehoseMode", PERSISTENT},
     {"DisableLogging", CLEAR_ON_MANAGER_START | CLEAR_ON_ONROAD_TRANSITION},
     {"DisablePowerDown", PERSISTENT},
     {"DisableUpdates", PERSISTENT},

--- a/selfdrive/ui/qt/offroad/firehose.cc
+++ b/selfdrive/ui/qt/offroad/firehose.cc
@@ -47,6 +47,10 @@ FirehosePanel::FirehosePanel(SettingsWindow *parent) : QWidget((QWidget*)parent)
   toggle_label->setStyleSheet("font-size: 60px; font-weight: bold; color: white;");
   content_layout->addWidget(toggle_label);
 
+  disable_firehose = new ParamControl("DisableFirehoseMode", tr("Disable Firehose Mode"), "", "");
+  QObject::connect(disable_firehose, &ParamControl::toggleFlipped, this, &FirehosePanel::refresh);
+  content_layout->addWidget(disable_firehose);
+
   // Add contribution label
   contribution_label = new QLabel();
   contribution_label->setStyleSheet("font-size: 52px; margin-top: 10px; margin-bottom: 10px;");
@@ -101,12 +105,14 @@ void FirehosePanel::refresh() {
   auto networkType = deviceState.getNetworkType();
   bool networkMetered = deviceState.getNetworkMetered();
 
-  bool is_active = !networkMetered && (networkType != cereal::DeviceState::NetworkType::NONE);
-  if (is_active) {
-    toggle_label->setText(tr("ACTIVE"));
-    toggle_label->setStyleSheet("font-size: 60px; font-weight: bold; color: #2ecc71;");
-  } else {
+  if (networkMetered || networkType != cereal::DeviceState::NetworkType::NONE) {
     toggle_label->setText(tr("<span stylesheet='font-size: 60px; font-weight: bold; color: #e74c3c;'>INACTIVE</span>: connect to an unmetered network"));
     toggle_label->setStyleSheet("font-size: 60px;");
+  } else if (Params().getBool("DisableFirehoseMode")) {
+    toggle_label->setText(tr("<span stylesheet='font-size: 60px; font-weight: bold; color: #e74c3c;'>INACTIVE</span>: firehose mode disabled"));
+    toggle_label->setStyleSheet("font-size: 60px;");
+  } else {
+    toggle_label->setText(tr("ACTIVE"));
+    toggle_label->setStyleSheet("font-size: 60px; font-weight: bold; color: #2ecc71;");
   }
 }

--- a/selfdrive/ui/qt/offroad/firehose.h
+++ b/selfdrive/ui/qt/offroad/firehose.h
@@ -3,6 +3,7 @@
 #include <QWidget>
 #include <QVBoxLayout>
 #include <QLabel>
+#include "selfdrive/ui/qt/widgets/controls.h"
 #include "selfdrive/ui/qt/request_repeater.h"
 
 // Forward declarations
@@ -16,6 +17,7 @@ public:
 private:
   QVBoxLayout *layout;
 
+  ParamControl *disable_firehose;
   QLabel *detailed_instructions;
   QLabel *contribution_label;
   QLabel *toggle_label;

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -523,6 +523,12 @@ def getSshAuthorizedKeys() -> str:
 def getGithubUsername() -> str:
   return Params().get("GithubUsername", encoding='utf8') or ''
 
+
+@dispatcher.add_method
+def getFirehoseMode() -> bool:
+  return not Params().get_bool("DisableFirehoseMode")
+
+
 @dispatcher.add_method
 def getSimInfo():
   return HARDWARE.get_sim_info()


### PR DESCRIPTION
For some people it can be an annoyance or even costly to have the device upload gigabytes of data on any Wi-Fi network, so this PR adds a toggle to disable Firehose Mode and brings back the athena method for the backend to check.

I think being able to configure specific Wi-Fi networks as metered would be a better solution, but that has been awaited for quite a while and might come after the Raylib UI rewrite.

|active|inactive|
|---|---|
| ![Screenshot_20250323_121524](https://github.com/user-attachments/assets/f0a86e82-868c-430c-99ed-fa7373707e3e) | ![Screenshot_20250323_121520](https://github.com/user-attachments/assets/fe2620c4-01c8-41e9-96c2-a9b6a2516f93) |
| | ![Screenshot_20250323_122633](https://github.com/user-attachments/assets/133b251d-9a98-461c-b543-633856fd7054) |



<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

