### PR TITLE
ci: update package management for `ui_preview`

### DIFF
--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -82,7 +82,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         id: find_diff
         run: >-
-          sudo apt-get install -y imagemagick
+          sudo apt-get update && sudo apt-get install -y imagemagick
 
           scenes=$(find ${{ github.workspace }}/pr_ui/*.png -type f -printf "%f\n" | cut -d '.' -f 1 | grep -v 'pair_device')
           A=($scenes)

--- a/selfdrive/ui/qt/offroad/developer_panel.cc
+++ b/selfdrive/ui/qt/offroad/developer_panel.cc
@@ -1,6 +1,6 @@
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
-#include "selfdrive/ui/qt/widgets/controls.h"  // test-ci
+#include "selfdrive/ui/qt/widgets/controls.h"
 
 DeveloperPanel::DeveloperPanel(SettingsWindow *parent) : ListWidget(parent) {
   adbToggle = new ParamControl("AdbEnabled", tr("Enable ADB"),

--- a/selfdrive/ui/qt/offroad/developer_panel.cc
+++ b/selfdrive/ui/qt/offroad/developer_panel.cc
@@ -1,6 +1,6 @@
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
-#include "selfdrive/ui/qt/widgets/controls.h"
+#include "selfdrive/ui/qt/widgets/controls.h"  // test-ci
 
 DeveloperPanel::DeveloperPanel(SettingsWindow *parent) : ListWidget(parent) {
   adbToggle = new ParamControl("AdbEnabled", tr("Enable ADB"),


### PR DESCRIPTION
Add `apt-get update` before installing ImageMagick to ensure the package list is up-to-date. This prevents potential installation issues due to outdated package information.

| Before (Failed) | After (Success) |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/85fff6b1-7049-4726-afaa-ea0675178e77) | ![image](https://github.com/user-attachments/assets/afbb25a5-1377-4548-ac74-ff547cb6c297) |