### PR TITLE
paramsd: cache backwards compatibility

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -72,6 +72,7 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"LastUpdateException", CLEAR_ON_MANAGER_START},
     {"LastUpdateTime", PERSISTENT},
     {"LiveParameters", PERSISTENT},
+    {"LiveParametersV2", PERSISTENT},
     {"LiveTorqueParameters", PERSISTENT | DONT_LOG},
     {"LocationFilterInitialState", PERSISTENT},
     {"LongitudinalManeuverMode", CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION},

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -214,8 +214,9 @@ def migrate_cached_vehicle_params_if_needed(params_reader: Params):
     last_parameters_msg.liveParameters.stiffnessFactor = last_parameters_dict['stiffnessFactor']
     last_parameters_msg.liveParameters.angleOffsetAverageDeg = last_parameters_dict['angleOffsetAverageDeg']
     params_reader.put("LiveParametersV2", last_parameters_msg.to_bytes())
-  except Exception:
-    pass
+  except Exception as e:
+    cloudlog.error(f"Failed to migrate LiveParameters to LiveParametersV2: {e}")
+    params_reader.remove("LiveParameters")
 
 
 def retrieve_initial_vehicle_params(params_reader: Params, CP: car.CarParams, replay: bool, debug: bool):

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -200,9 +200,9 @@ def check_valid_with_hysteresis(current_valid: bool, val: float, threshold: floa
 
 
 # TODO: Remove this function after few releases (added in 0.9.9)
-def migrate_cached_vehicle_params_if_needed(params_reader: Params):
-  last_parameters_data_old = params_reader.get("LiveParameters")
-  last_parameters_data = params_reader.get("LiveParametersV2")
+def migrate_cached_vehicle_params_if_needed(params: Params):
+  last_parameters_data_old = params.get("LiveParameters")
+  last_parameters_data = params.get("LiveParametersV2")
   if last_parameters_data_old is None or last_parameters_data is not None:
     return
 
@@ -213,15 +213,15 @@ def migrate_cached_vehicle_params_if_needed(params_reader: Params):
     last_parameters_msg.liveParameters.steerRatio = last_parameters_dict['steerRatio']
     last_parameters_msg.liveParameters.stiffnessFactor = last_parameters_dict['stiffnessFactor']
     last_parameters_msg.liveParameters.angleOffsetAverageDeg = last_parameters_dict['angleOffsetAverageDeg']
-    params_reader.put("LiveParametersV2", last_parameters_msg.to_bytes())
+    params.put("LiveParametersV2", last_parameters_msg.to_bytes())
   except Exception as e:
     cloudlog.error(f"Failed to perform parameter migration: {e}")
-    params_reader.remove("LiveParameters")
+    params.remove("LiveParameters")
 
 
-def retrieve_initial_vehicle_params(params_reader: Params, CP: car.CarParams, replay: bool, debug: bool):
-  last_parameters_data = params_reader.get("LiveParametersV2")
-  last_carparams_data = params_reader.get("CarParamsPrevRoute")
+def retrieve_initial_vehicle_params(params: Params, CP: car.CarParams, replay: bool, debug: bool):
+  last_parameters_data = params.get("LiveParametersV2")
+  last_carparams_data = params.get("CarParamsPrevRoute")
 
   steer_ratio, stiffness_factor, angle_offset_deg, p_initial = CP.steerRatio, 1.0, 0.0, None
 
@@ -269,12 +269,12 @@ def main():
   pm = messaging.PubMaster(['liveParameters'])
   sm = messaging.SubMaster(['livePose', 'liveCalibration', 'carState'], poll='livePose')
 
-  params_reader = Params()
-  CP = messaging.log_from_bytes(params_reader.get("CarParams", block=True), car.CarParams)
+  params = Params()
+  CP = messaging.log_from_bytes(params.get("CarParams", block=True), car.CarParams)
 
-  migrate_cached_vehicle_params_if_needed(params_reader)
+  migrate_cached_vehicle_params_if_needed(params)
 
-  steer_ratio, stiffness_factor, angle_offset_deg, pInitial = retrieve_initial_vehicle_params(params_reader, CP, REPLAY, DEBUG)
+  steer_ratio, stiffness_factor, angle_offset_deg, pInitial = retrieve_initial_vehicle_params(params, CP, REPLAY, DEBUG)
   learner = VehicleParamsLearner(CP, steer_ratio, stiffness_factor, np.radians(angle_offset_deg), pInitial)
 
   while True:
@@ -290,7 +290,7 @@ def main():
 
       msg_dat = msg.to_bytes()
       if sm.frame % 1200 == 0:  # once a minute
-        params_reader.put_nonblocking("LiveParametersV2", msg_dat)
+        params.put_nonblocking("LiveParametersV2", msg_dat)
 
       pm.send('liveParameters', msg_dat)
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -215,7 +215,7 @@ def migrate_cached_vehicle_params_if_needed(params_reader: Params):
     last_parameters_msg.liveParameters.angleOffsetAverageDeg = last_parameters_dict['angleOffsetAverageDeg']
     params_reader.put("LiveParametersV2", last_parameters_msg.to_bytes())
   except Exception as e:
-    cloudlog.error(f"Failed to migrate LiveParameters to LiveParametersV2: {e}")
+    cloudlog.error(f"Failed to perform parameter migration: {e}")
     params_reader.remove("LiveParameters")
 
 

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -201,24 +201,25 @@ def check_valid_with_hysteresis(current_valid: bool, val: float, threshold: floa
 
 # TODO: Remove this function after few releases (added in 0.9.9)
 def migrate_cached_vehicle_params_if_needed(params_reader: Params):
-  last_parameters_data = params_reader.get("LiveParameters")
-  if last_parameters_data is None:
+  last_parameters_data_old = params_reader.get("LiveParameters")
+  last_parameters_data = params_reader.get("LiveParametersV2")
+  if last_parameters_data_old is None or last_parameters_data is not None:
     return
 
   try:
-    last_parameters_dict = json.loads(last_parameters_data)
+    last_parameters_dict = json.loads(last_parameters_data_old)
     last_parameters_msg = messaging.new_message('liveParameters')
     last_parameters_msg.liveParameters.valid = True
     last_parameters_msg.liveParameters.steerRatio = last_parameters_dict['steerRatio']
     last_parameters_msg.liveParameters.stiffnessFactor = last_parameters_dict['stiffnessFactor']
     last_parameters_msg.liveParameters.angleOffsetAverageDeg = last_parameters_dict['angleOffsetAverageDeg']
-    params_reader.put("LiveParameters", last_parameters_msg.to_bytes())
+    params_reader.put("LiveParametersV2", last_parameters_msg.to_bytes())
   except Exception:
     pass
 
 
 def retrieve_initial_vehicle_params(params_reader: Params, CP: car.CarParams, replay: bool, debug: bool):
-  last_parameters_data = params_reader.get("LiveParameters")
+  last_parameters_data = params_reader.get("LiveParametersV2")
   last_carparams_data = params_reader.get("CarParamsPrevRoute")
 
   steer_ratio, stiffness_factor, angle_offset_deg, p_initial = CP.steerRatio, 1.0, 0.0, None
@@ -288,7 +289,7 @@ def main():
 
       msg_dat = msg.to_bytes()
       if sm.frame % 1200 == 0:  # once a minute
-        params_reader.put_nonblocking("LiveParameters", msg_dat)
+        params_reader.put_nonblocking("LiveParametersV2", msg_dat)
 
       pm.send('liveParameters', msg_dat)
 

--- a/selfdrive/locationd/test/test_paramsd.py
+++ b/selfdrive/locationd/test/test_paramsd.py
@@ -28,8 +28,9 @@ class TestParamsd:
     CP = next(m for m in lr if m.which() == "carParams").carParams
 
     msg = get_random_live_parameters(CP)
-    params.put("LiveParameters", msg.to_bytes())
+    params.put("LiveParametersV2", msg.to_bytes())
     params.put("CarParamsPrevRoute", CP.as_builder().to_bytes())
+    params.remove("LiveParameters")
 
     migrate_cached_vehicle_params_if_needed(params) # this is not tested here but should not mess anything up or throw an error
     sr, sf, offset, p_init = retrieve_initial_vehicle_params(params, CP, replay=True, debug=True)
@@ -49,6 +50,7 @@ class TestParamsd:
     msg = get_random_live_parameters(CP)
     params.put("LiveParameters", json.dumps(msg.liveParameters.to_dict()))
     params.put("CarParamsPrevRoute", CP.as_builder().to_bytes())
+    params.remove("LiveParametersV2")
 
     migrate_cached_vehicle_params_if_needed(params)
     sr, sf, offset, _ = retrieve_initial_vehicle_params(params, CP, replay=True, debug=True)

--- a/selfdrive/locationd/test/test_paramsd.py
+++ b/selfdrive/locationd/test/test_paramsd.py
@@ -30,7 +30,6 @@ class TestParamsd:
     msg = get_random_live_parameters(CP)
     params.put("LiveParametersV2", msg.to_bytes())
     params.put("CarParamsPrevRoute", CP.as_builder().to_bytes())
-    params.remove("LiveParameters")
 
     migrate_cached_vehicle_params_if_needed(params) # this is not tested here but should not mess anything up or throw an error
     sr, sf, offset, p_init = retrieve_initial_vehicle_params(params, CP, replay=True, debug=True)
@@ -57,3 +56,4 @@ class TestParamsd:
     np.testing.assert_allclose(sr, msg.liveParameters.steerRatio)
     np.testing.assert_allclose(sf, msg.liveParameters.stiffnessFactor)
     np.testing.assert_allclose(offset, msg.liveParameters.angleOffsetAverageDeg)
+    assert params.get("LiveParametersV2") is not None

--- a/selfdrive/locationd/test/test_paramsd.py
+++ b/selfdrive/locationd/test/test_paramsd.py
@@ -57,3 +57,12 @@ class TestParamsd:
     np.testing.assert_allclose(sf, msg.liveParameters.stiffnessFactor)
     np.testing.assert_allclose(offset, msg.liveParameters.angleOffsetAverageDeg)
     assert params.get("LiveParametersV2") is not None
+
+  def test_read_saved_params_corrupted_old_format(self):
+    params = Params()
+    params.put("LiveParameters", b'\x00\x00\x02\x00\x01\x00:F\xde\xed\xae;')
+    params.remove("LiveParametersV2")
+
+    migrate_cached_vehicle_params_if_needed(params)
+    assert params.get("LiveParameters") is None
+    assert params.get("LiveParametersV2") is None


### PR DESCRIPTION
Fix https://github.com/commaai/openpilot/issues/34989

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

