### PR TITLE
autoconfigure adb shell properly

### DIFF
--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -66,6 +66,7 @@ ARG USER_UID=1001
 RUN useradd -m -s /bin/bash -u $USER_UID $USER
 RUN usermod -aG sudo $USER
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN echo "alias adb_shell='/home/$USER/tools/adb_shell.sh'" >> /home/$USER/.bashrc
 USER $USER
 
 COPY --chown=$USER pyproject.toml uv.lock /home/$USER


### PR DESCRIPTION
This aims to solve #34958 by using an alias adb shell for tools/adb_shell.sh.