### PR TITLE
ui(raylib): calculate spinner progress in set_text

### DIFF
--- a/system/ui/spinner.py
+++ b/system/ui/spinner.py
@@ -26,11 +26,17 @@ class Spinner:
     self._spinner_texture = gui_app.load_texture_from_image(os.path.join(BASEDIR, "selfdrive/assets/img_spinner_track.png"), TEXTURE_SIZE, TEXTURE_SIZE)
     self._rotation = 0.0
     self._text: str = ""
+    self._progress: int | None = None
     self._lock = threading.Lock()
 
   def set_text(self, text: str) -> None:
     with self._lock:
-      self._text = text
+      if text.isdigit():
+        self._progress = clamp(int(text), 0, 100)
+        self._text = ""
+      else:
+        self._progress = None
+        self._text = text
 
   def render(self):
     center = rl.Vector2(gui_app.width / 2.0, gui_app.height / 2.0)
@@ -49,23 +55,21 @@ class Spinner:
     rl.draw_texture_v(self._comma_texture, comma_position, rl.WHITE)
 
     # Display progress bar or text based on user input
-    text = None
+    y_pos = rl.get_screen_height() - MARGIN - PROGRESS_BAR_HEIGHT
     with self._lock:
+      progress = self._progress
       text = self._text
 
-    if text:
-      y_pos = rl.get_screen_height() - MARGIN - PROGRESS_BAR_HEIGHT
-      if text.isdigit():
-        progress = clamp(int(text), 0, 100)
-        bar = rl.Rectangle(center.x - PROGRESS_BAR_WIDTH / 2.0, y_pos, PROGRESS_BAR_WIDTH, PROGRESS_BAR_HEIGHT)
-        rl.draw_rectangle_rounded(bar, 1, 10, DARKGRAY)
+    if progress is not None:
+      bar = rl.Rectangle(center.x - PROGRESS_BAR_WIDTH / 2.0, y_pos, PROGRESS_BAR_WIDTH, PROGRESS_BAR_HEIGHT)
+      rl.draw_rectangle_rounded(bar, 1, 10, DARKGRAY)
 
-        bar.width *= progress / 100.0
-        rl.draw_rectangle_rounded(bar, 1, 10, rl.WHITE)
-      else:
-        text_size = rl.measure_text_ex(gui_app.font(), text, FONT_SIZE, 1.0)
-        rl.draw_text_ex(gui_app.font(), text,
-                        rl.Vector2(center.x - text_size.x / 2, y_pos), FONT_SIZE, 1.0, rl.WHITE)
+      bar.width *= progress / 100.0
+      rl.draw_rectangle_rounded(bar, 1, 10, rl.WHITE)
+    elif text:
+      text_size = rl.measure_text_ex(gui_app.font(), text, FONT_SIZE, 1.0)
+      rl.draw_text_ex(gui_app.font(), text,
+                      rl.Vector2(center.x - text_size.x / 2, y_pos), FONT_SIZE, 1.0, rl.WHITE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The spinner logic was refactored to calculate the progress or text ahead of time in the `set_text` method, instead of checking `text.isdigit()` in every render iteration. This change improves performance by avoiding unnecessary checks in the render loop, and will give greater benefits when text wrapping is implemented. The lock is used when reading `_progress` and `_text` to avoid race conditions.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

