### PR TITLE
ui(raylib): constant spinner rotation speed

### DIFF
--- a/system/ui/spinner.py
+++ b/system/ui/spinner.py
@@ -9,7 +9,7 @@ from openpilot.system.ui.lib.application import gui_app
 # Constants
 PROGRESS_BAR_WIDTH = 1000
 PROGRESS_BAR_HEIGHT = 20
-ROTATION_TIME_SECONDS = 1.0  # Time for one full circle
+DEGREES_PER_SECOND = 360.0  # one full rotation per second
 MARGIN = 200
 TEXTURE_SIZE = 360
 FONT_SIZE = 80
@@ -43,10 +43,8 @@ class Spinner:
     spinner_origin = rl.Vector2(TEXTURE_SIZE / 2.0, TEXTURE_SIZE / 2.0)
     comma_position = rl.Vector2(center.x - TEXTURE_SIZE / 2.0, center.y - TEXTURE_SIZE / 2.0)
 
-    fps = rl.get_fps()
-    if fps > 0:
-      degrees_per_frame = 360.0 / (ROTATION_TIME_SECONDS * fps)
-      self._rotation = (self._rotation + degrees_per_frame) % 360.0
+    delta_time = rl.get_frame_time()
+    self._rotation = (self._rotation + DEGREES_PER_SECOND * delta_time) % 360.0
 
     # Draw rotating spinner and static comma logo
     rl.draw_texture_pro(self._spinner_texture, rl.Rectangle(0, 0, TEXTURE_SIZE, TEXTURE_SIZE),


### PR DESCRIPTION
Previously, the spinner rotation would start slow and ramp up as the reported FPS increased. With this change the spinner speed remains constant, and the implementation is simpler.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

