### PR TITLE
ui(raylib): fix spinner artifact

### DIFF
--- a/system/ui/spinner.py
+++ b/system/ui/spinner.py
@@ -23,11 +23,20 @@ def clamp(value, min_value, max_value):
 class Spinner:
   def __init__(self):
     self._comma_texture = gui_app.load_texture_from_image(os.path.join(BASEDIR, "selfdrive/assets/img_spinner_comma.png"), TEXTURE_SIZE, TEXTURE_SIZE)
-    self._spinner_texture = gui_app.load_texture_from_image(os.path.join(BASEDIR, "selfdrive/assets/img_spinner_track.png"), TEXTURE_SIZE, TEXTURE_SIZE)
+    self._raw_spinner_texture = gui_app.load_texture_from_image(os.path.join(BASEDIR, "selfdrive/assets/img_spinner_track.png"), TEXTURE_SIZE, TEXTURE_SIZE)
     self._rotation = 0.0
     self._text: str = ""
     self._progress: int | None = None
     self._lock = threading.Lock()
+
+    # pre-render the spinner onto a black background
+    self._spinner_rt = rl.load_render_texture(TEXTURE_SIZE, TEXTURE_SIZE)
+    rl.begin_texture_mode(self._spinner_rt)
+    rl.clear_background(rl.BLANK)
+    rl.draw_texture(self._raw_spinner_texture, 0, 0, rl.WHITE)
+    rl.end_texture_mode()
+    rl.unload_texture(self._raw_spinner_texture)
+    rl.set_texture_filter(self._spinner_rt.texture, rl.TextureFilter.TEXTURE_FILTER_BILINEAR)
 
   def set_text(self, text: str) -> None:
     with self._lock:
@@ -47,7 +56,7 @@ class Spinner:
     self._rotation = (self._rotation + DEGREES_PER_SECOND * delta_time) % 360.0
 
     # Draw rotating spinner and static comma logo
-    rl.draw_texture_pro(self._spinner_texture, rl.Rectangle(0, 0, TEXTURE_SIZE, TEXTURE_SIZE),
+    rl.draw_texture_pro(self._spinner_rt.texture, rl.Rectangle(0, 0, TEXTURE_SIZE, TEXTURE_SIZE),
                         rl.Rectangle(center.x, center.y, TEXTURE_SIZE, TEXTURE_SIZE),
                         spinner_origin, self._rotation, rl.WHITE)
     rl.draw_texture_v(self._comma_texture, comma_position, rl.WHITE)


### PR DESCRIPTION
Pre-rendering the spinner texture onto a black background, before applying the rotation in the render loop, prevents the bleed of RGB data when the spinner is rotated to non-axis-aligned angles (not 0, 90, 180 or 270 degrees).

The Qt implementation effectively fixes this the same way by pre-rendering every rotation of the spinner track.

Alternatively, it might be possible to clean up the PNG to reduce this effect.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

