### PR TITLE
ui(raylib): reduce spinner rotation artifact

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -53,7 +53,8 @@ class GuiApplication:
   def load_texture_from_image(self, file_name: str, width: int, height: int, alpha_premultiply = False):
     """Load and resize a texture, storing it for later automatic unloading."""
     image = rl.load_image(file_name)
-    if alpha_premultiply: rl.image_alpha_premultiply(image)
+    if alpha_premultiply:
+      rl.image_alpha_premultiply(image)
     rl.image_resize(image, width, height)
     texture = rl.load_texture_from_image(image)
     # Set texture filtering to smooth the result

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -50,9 +50,10 @@ class GuiApplication:
     self._set_styles()
     self._load_fonts()
 
-  def load_texture_from_image(self, file_name: str, width: int, height: int):
+  def load_texture_from_image(self, file_name: str, width: int, height: int, alpha_premultiply = False):
     """Load and resize a texture, storing it for later automatic unloading."""
     image = rl.load_image(file_name)
+    if alpha_premultiply: rl.image_alpha_premultiply(image)
     rl.image_resize(image, width, height)
     texture = rl.load_texture_from_image(image)
     # Set texture filtering to smooth the result

--- a/system/ui/spinner.py
+++ b/system/ui/spinner.py
@@ -23,7 +23,8 @@ def clamp(value, min_value, max_value):
 class Spinner:
   def __init__(self):
     self._comma_texture = gui_app.load_texture_from_image(os.path.join(BASEDIR, "selfdrive/assets/img_spinner_comma.png"), TEXTURE_SIZE, TEXTURE_SIZE)
-    self._spinner_texture = gui_app.load_texture_from_image(os.path.join(BASEDIR, "selfdrive/assets/img_spinner_track.png"), TEXTURE_SIZE, TEXTURE_SIZE)
+    self._spinner_texture = gui_app.load_texture_from_image(os.path.join(BASEDIR, "selfdrive/assets/img_spinner_track.png"), TEXTURE_SIZE, TEXTURE_SIZE,
+                                                            alpha_premultiply=True)
     self._rotation = 0.0
     self._text: str = ""
     self._progress: int | None = None


### PR DESCRIPTION
A visual artifact (white pixels) appeared on the edge of the rotating spinner track texture, likely due to RGB color bleed during bilinear filtering in Raylib.

Pre-multiplying the alpha channel of the spinner track image using `rl.image_alpha_premultiply` significantly reduces the visibility of the artifact.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

