### PR TITLE
ui(raylib): update spinner vertical pos

### DIFF
--- a/system/ui/spinner.py
+++ b/system/ui/spinner.py
@@ -12,7 +12,6 @@ PROGRESS_BAR_WIDTH = 1000
 PROGRESS_BAR_HEIGHT = 20
 DEGREES_PER_SECOND = 360.0  # one full rotation per second
 MARGIN_H = 100
-SPACING = 150
 TEXTURE_SIZE = 360
 FONT_SIZE = 88
 LINE_HEIGHT = 96
@@ -49,12 +48,14 @@ class Spinner:
 
     if wrapped_lines:
       # Calculate total height required for spinner and text
-      total_height = TEXTURE_SIZE + SPACING + len(wrapped_lines) * LINE_HEIGHT
+      spacing = 50
+      total_height = TEXTURE_SIZE + spacing + len(wrapped_lines) * LINE_HEIGHT
       center_y = (gui_app.height - total_height) / 2.0 + TEXTURE_SIZE / 2.0
     else:
       # Center spinner vertically
+      spacing = 150
       center_y = gui_app.height / 2.0
-    y_pos = center_y + TEXTURE_SIZE / 2.0 + SPACING
+    y_pos = center_y + TEXTURE_SIZE / 2.0 + spacing
 
     center = rl.Vector2(gui_app.width / 2.0, center_y)
     spinner_origin = rl.Vector2(TEXTURE_SIZE / 2.0, TEXTURE_SIZE / 2.0)

--- a/system/ui/spinner.py
+++ b/system/ui/spinner.py
@@ -12,7 +12,7 @@ PROGRESS_BAR_WIDTH = 1000
 PROGRESS_BAR_HEIGHT = 20
 DEGREES_PER_SECOND = 360.0  # one full rotation per second
 MARGIN_H = 100
-MARGIN_V = 200
+SPACING = 150
 TEXTURE_SIZE = 360
 FONT_SIZE = 88
 LINE_HEIGHT = 96
@@ -43,7 +43,20 @@ class Spinner:
         self._wrapped_lines = wrap_text(text, FONT_SIZE, gui_app.width - MARGIN_H)
 
   def render(self):
-    center = rl.Vector2(gui_app.width / 2.0, gui_app.height / 2.0)
+    with self._lock:
+      progress = self._progress
+      wrapped_lines = self._wrapped_lines
+
+    if wrapped_lines:
+      # Calculate total height required for spinner and text
+      total_height = TEXTURE_SIZE + SPACING + len(wrapped_lines) * LINE_HEIGHT
+      center_y = (gui_app.height - total_height) / 2.0 + TEXTURE_SIZE / 2.0
+    else:
+      # Center spinner vertically
+      center_y = gui_app.height / 2.0
+    y_pos = center_y + TEXTURE_SIZE / 2.0 + SPACING
+
+    center = rl.Vector2(gui_app.width / 2.0, center_y)
     spinner_origin = rl.Vector2(TEXTURE_SIZE / 2.0, TEXTURE_SIZE / 2.0)
     comma_position = rl.Vector2(center.x - TEXTURE_SIZE / 2.0, center.y - TEXTURE_SIZE / 2.0)
 
@@ -57,11 +70,6 @@ class Spinner:
     rl.draw_texture_v(self._comma_texture, comma_position, rl.WHITE)
 
     # Display progress bar or text based on user input
-    y_pos = rl.get_screen_height() - MARGIN_V - PROGRESS_BAR_HEIGHT
-    with self._lock:
-      progress = self._progress
-      wrapped_lines = self._wrapped_lines
-
     if progress is not None:
       bar = rl.Rectangle(center.x - PROGRESS_BAR_WIDTH / 2.0, y_pos, PROGRESS_BAR_WIDTH, PROGRESS_BAR_HEIGHT)
       rl.draw_rectangle_rounded(bar, 1, 10, DARKGRAY)

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -21,6 +21,7 @@ def wrap_text(text, font_size, max_width):
 
   for paragraph in text.split("\n"):
     if not paragraph.strip():
+      # Don't add an empty line to the start of the list, ensuring wrap_text("") returns []
       if lines:
         lines.append("")
       continue

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -21,7 +21,8 @@ def wrap_text(text, font_size, max_width):
 
   for paragraph in text.split("\n"):
     if not paragraph.strip():
-      lines.append("")
+      if lines:
+        lines.append("")
       continue
     indent = re.match(r"^\s*", paragraph).group()
     current_line = indent

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -21,7 +21,7 @@ def wrap_text(text, font_size, max_width):
 
   for paragraph in text.split("\n"):
     if not paragraph.strip():
-      # Don't add an empty line to the start of the list, ensuring wrap_text("") returns []
+      # Don't add empty lines first, ensuring wrap_text("") returns []
       if lines:
         lines.append("")
       continue


### PR DESCRIPTION
Adjust the spinner vertical position when displaying text or a progress bar

- When displaying the progress bar, center the comma logo and spinner in the middle of the screen
- When displaying text, center the entire content vertically

Also updated `wrap_text` to not include an empty line in the array if it's the first line, so that `wrap_text("")` always returns `[]`

| | blank | progress | text |
| --- | --- | --- | --- |
| raylib |![raylib blank](https://github.com/user-attachments/assets/4c8237c0-3217-42bd-9079-9e0c130a63ca)|![raylib progress](https://github.com/user-attachments/assets/aee44185-2e2b-404f-9113-53a440a5eb23)|![raylib text](https://github.com/user-attachments/assets/23415b85-ec60-42a7-9bd9-acab5f975ee0)|
| qt | ![qt blank](https://github.com/user-attachments/assets/f17f9fbe-30d8-48ed-807d-d1ba82b41c30) | ![qt progress](https://github.com/user-attachments/assets/efcd39d5-b68a-4d9a-957c-641919ed2541) | ![qt text](https://github.com/user-attachments/assets/f9dd7cec-e878-4f24-9527-a9565ebba2eb) |
