### PR TITLE
Reapply "ui(raylib): "exit" btn in text window on PC"

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -38,6 +38,10 @@ class GuiApplication:
     self._textures: list[rl.Texture] = []
     self._target_fps: int = DEFAULT_FPS
     self._last_fps_log_time: float = time.monotonic()
+    self._window_close_requested = False
+
+  def request_close(self):
+    self._window_close_requested = True
 
   def init_window(self, title: str, fps: int=DEFAULT_FPS):
     atexit.register(self.close)  # Automatically call close() on exit
@@ -80,7 +84,7 @@ class GuiApplication:
     rl.close_window()
 
   def render(self):
-    while not rl.window_should_close():
+    while not (self._window_close_requested or rl.window_should_close()):
       rl.begin_drawing()
       rl.clear_background(rl.BLACK)
 

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import re
+import sys
 import pyray as rl
-from openpilot.system.hardware import HARDWARE
+from openpilot.system.hardware import HARDWARE, PC
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.application import gui_app
@@ -58,9 +59,12 @@ class TextWindow:
     rl.end_scissor_mode()
 
     button_bounds = rl.Rectangle(gui_app.width - MARGIN - BUTTON_SIZE.x, gui_app.height - MARGIN - BUTTON_SIZE.y, BUTTON_SIZE.x, BUTTON_SIZE.y)
-    ret = gui_button(button_bounds, "Reboot", button_style=ButtonStyle.TRANSPARENT)
+    ret = gui_button(button_bounds, "Exit" if PC else "Reboot", button_style=ButtonStyle.TRANSPARENT)
     if ret:
-      HARDWARE.reboot()
+      if PC:
+        gui_app.close()
+      else:
+        HARDWARE.reboot()
     return ret
 
 

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -72,6 +72,7 @@ def show_text_in_window(text: str):
   text_window = TextWindow(text)
   for _ in gui_app.render():
     text_window.render()
+  gui_app.close()
 
 
 if __name__ == "__main__":

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import re
-import sys
 import pyray as rl
 from openpilot.system.hardware import HARDWARE, PC
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -61,7 +61,7 @@ class TextWindow:
     ret = gui_button(button_bounds, "Exit" if PC else "Reboot", button_style=ButtonStyle.TRANSPARENT)
     if ret:
       if PC:
-        gui_app.close()
+        gui_app.request_close()
       else:
         HARDWARE.reboot()
     return ret


### PR DESCRIPTION
This reverts commit 754f5aa95590f7bc98c8f4f8fbe3f7f2a0a18e96.

First attempt caused a seg fault when tapping Exit, as it unloaded the app before `rl.end_drawing` was called

Didn't initially notice this in the output