### PR TITLE
ui(raylib): set display power and brightness on init

### DIFF
--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -131,6 +131,10 @@ class HardwareBase(ABC):
     return ThermalConfig()
 
   @abstractmethod
+  def set_display_power(self, on: bool):
+    pass
+
+  @abstractmethod
   def set_screen_brightness(self, percentage):
     pass
 

--- a/system/hardware/pc/hardware.py
+++ b/system/hardware/pc/hardware.py
@@ -53,6 +53,9 @@ class Pc(HardwareBase):
   def shutdown(self):
     print("SHUTDOWN!")
 
+  def set_display_power(self, on):
+    pass
+
   def set_screen_brightness(self, percentage):
     pass
 

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -341,6 +341,13 @@ class Tici(HardwareBase):
                          exhaust=exhaust,
                          case=case)
 
+  def set_display_power(self, on):
+    try:
+      with open("/sys/class/backlight/panel0-backlight/bl_power", "w") as f:
+        f.write("0" if on else "4")
+    except Exception:
+      pass
+
   def set_screen_brightness(self, percentage):
     try:
       with open("/sys/class/backlight/panel0-backlight/max_brightness") as f:

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -5,6 +5,7 @@ import pyray as rl
 from enum import IntEnum
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.swaglog import cloudlog
+from openpilot.system.hardware import HARDWARE
 
 DEFAULT_FPS = 60
 FPS_LOG_INTERVAL = 5  # Seconds between logging FPS drops
@@ -45,6 +46,9 @@ class GuiApplication:
 
   def init_window(self, title: str, fps: int=DEFAULT_FPS):
     atexit.register(self.close)  # Automatically call close() on exit
+
+    HARDWARE.set_display_power(True)
+    HARDWARE.set_screen_brightness(65)
 
     rl.set_config_flags(rl.ConfigFlags.FLAG_MSAA_4X_HINT | rl.ConfigFlags.FLAG_VSYNC_HINT)
     rl.init_window(self._width, self._height, title)


### PR DESCRIPTION
This matches the behaviour of [`initApp`](https://github.com/commaai/openpilot/blob/e85d833a800838bb11e6abc625f4130b5114ad9a/selfdrive/ui/qt/util.cc#L100) in Qt UI

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

