### PR TITLE
hardware: make set_display_power not abstract

### DIFF
--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -130,7 +130,6 @@ class HardwareBase(ABC):
   def get_thermal_config(self):
     return ThermalConfig()
 
-  @abstractmethod
   def set_display_power(self, on: bool):
     pass
 

--- a/system/hardware/pc/hardware.py
+++ b/system/hardware/pc/hardware.py
@@ -53,9 +53,6 @@ class Pc(HardwareBase):
   def shutdown(self):
     print("SHUTDOWN!")
 
-  def set_display_power(self, on):
-    pass
-
   def set_screen_brightness(self, percentage):
     pass
 


### PR DESCRIPTION
follow-up to https://github.com/commaai/openpilot/pull/35060#discussion_r2058829397

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

