### PR TITLE
Add can ignition test

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -243,6 +243,11 @@ class TestCarModelBase(unittest.TestCase):
         if self.safety.safety_rx_hook(to_send) != 1:
           failed_addrs[hex(msg.address)] += 1
 
+        if self.CP.brand in ("gm", "mazda", "rivian", "tesla"):
+          self.assertTrue(self.safety.get_ignition_can())
+        else:
+          self.assertFalse(self.safety.get_ignition_can())
+
       # ensure all msgs defined in the addr checks are valid
       self.safety.safety_tick_current_safety_config()
       if t > 1e6:


### PR DESCRIPTION
**Description**

Adds a test to ensure that only GM, Tesla, Rivian, and Mazda get ignition from CAN bus.

For https://github.com/commaai/opendbc/issues/1834

**Verification**

This is a test-only change. Also have corresponding tests in opendbc.