### PR TITLE
Fix tethering connection disabling internet

### DIFF
--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -439,7 +439,7 @@ void WifiManager::addTetheringConnection() {
   address["prefix"] = 24u;
   connection["ipv4"]["address-data"] = QVariant::fromValue(IpConfig() << address);
   connection["ipv4"]["gateway"] = "192.168.43.1";
-  connection["ipv4"]["route-metric"] = 1100;
+  connection["ipv4"]["never-default"] = true;
   connection["ipv6"]["method"] = "ignore";
 
   asyncCall(NM_DBUS_PATH_SETTINGS, NM_DBUS_INTERFACE_SETTINGS, "AddConnection", QVariant::fromValue(connection));

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -439,6 +439,7 @@ void WifiManager::addTetheringConnection() {
   address["prefix"] = 24u;
   connection["ipv4"]["address-data"] = QVariant::fromValue(IpConfig() << address);
   connection["ipv4"]["gateway"] = "192.168.43.1";
+  connection["ipv4"]["never-default"] = true;
   connection["ipv6"]["method"] = "ignore";
 
   asyncCall(NM_DBUS_PATH_SETTINGS, NM_DBUS_INTERFACE_SETTINGS, "AddConnection", QVariant::fromValue(connection));

--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -439,7 +439,6 @@ void WifiManager::addTetheringConnection() {
   address["prefix"] = 24u;
   connection["ipv4"]["address-data"] = QVariant::fromValue(IpConfig() << address);
   connection["ipv4"]["gateway"] = "192.168.43.1";
-  connection["ipv4"]["never-default"] = true;
   connection["ipv6"]["method"] = "ignore";
 
   asyncCall(NM_DBUS_PATH_SETTINGS, NM_DBUS_INTERFACE_SETTINGS, "AddConnection", QVariant::fromValue(connection));


### PR DESCRIPTION
Closes https://github.com/commaai/openpilot/issues/34969

route-metric is ignored for shared connection methods now in the version of NM we have on 24.04:

```bash
comma@comma-7e8e41ad:/data/openpilot$ nmcli c modify 'openpilot connection unifi' ipv4.route-metric 1100
comma@comma-7e8e41ad:/data/openpilot$ nmcli c show 'openpilot connection unifi' | grep -E 'ipv4.route-metric|ipv4.method'
ipv4.method:                            auto
ipv4.route-metric:                      1100

comma@comma-7e8e41ad:/data/openpilot$ nmcli c modify Hotspot ipv4.route-metric 1100
comma@comma-7e8e41ad:/data/openpilot$ nmcli c show Hotspot | grep -E 'ipv4.route-metric|ipv4.method'
ipv4.method:                            shared
ipv4.route-metric:                      -1
```

We now set `never-default` which is documented as: `If TRUE, this connection will never be the default connection for this IP type, meaning it will never be assigned the default route by NetworkManager.` The connected devices still have no internet access as was previous behavior.

With hotspot on master:

```bash
comma@comma-7e8e41ad:/data/openpilot$ ping 8.8.4.4
PING 8.8.4.4 (8.8.4.4) 56(84) bytes of data.
From 192.168.43.1 icmp_seq=1 Destination Host Unreachable
```

```bash
comma@comma-7e8e41ad:/data/openpilot$ route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         192.168.43.1    0.0.0.0         UG    600    0        0 wlan0
0.0.0.0         10.211.35.213   0.0.0.0         UG    1000   0        0 wwan0
10.211.35.208   0.0.0.0         255.255.255.248 U     1000   0        0 wwan0
192.168.43.0    0.0.0.0         255.255.255.0   U     600    0        0 wlan0
```

With hotspot on this PR:

```bash
comma@comma-7e8e41ad:/data/openpilot$ ping 8.8.4.4
PING 8.8.4.4 (8.8.4.4) 56(84) bytes of data.
64 bytes from 8.8.4.4: icmp_seq=1 ttl=57 time=85.3 ms
```

```bash
comma@comma-7e8e41ad:/data/openpilot$ route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         10.211.35.213   0.0.0.0         UG    1000   0        0 wwan0
10.211.35.208   0.0.0.0         255.255.255.248 U     1000   0        0 wwan0
192.168.43.0    0.0.0.0         255.255.255.0   U     600    0        0 wlan0
```