### PR TITLE
fix(replay): search for route key in entire str

### DIFF
--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -121,7 +121,7 @@ bool Route::loadFromJson(const std::string &json) {
 bool Route::loadFromLocal() {
   std::string pattern = route_.timestamp + "--";
   for (const auto &entry : std::filesystem::directory_iterator(data_dir_)) {
-    if (entry.is_directory() && entry.path().filename().string().find(pattern) == 0) {
+    if (entry.is_directory() && entry.path().filename().string().find(pattern) != std::string::npos) {
       std::string segment = entry.path().string();
       int seg_num = std::atoi(segment.substr(segment.rfind("--") + 2).c_str());
 


### PR DESCRIPTION
**Description**

Command: `tools/replay/replay --data_dir "/home/trey/Downloads/routes" d3cff3c1d3af097b/00000020--95c02d0a62`
File tree of `/home/trey/Downloads/routes`:
```
routes
├── d3cff3c1d3af097b|00000020--95c02d0a62--0
│   ├── qcamera.ts
│   └── qlog.zst
├── d3cff3c1d3af097b|00000020--95c02d0a62--1
│   ├── qcamera.ts
│   └── qlog.zst
├── d3cff3c1d3af097b|00000020--95c02d0a62--2
│   ├── qcamera.ts
│   └── qlog.zst
├── d3cff3c1d3af097b|00000020--95c02d0a62--3
│   ├── qcamera.ts
│   └── qlog.zst
└── d3cff3c1d3af097b|00000020--95c02d0a62--4
    ├── qcamera.ts
    └── qlog.zst
```

The above command fails with this tree structure: `failed to load route: d3cff3c1d3af097b|00000020--95c02d0a62`
The root cause is the example file structure in the README has the dongle in front, so it doesn’t work:
```
# Example:
# If you have a local route stored at /path_to_routes with segments like:
# a2a0ccea32023010|2023-07-27--13-01-19--0
# a2a0ccea32023010|2023-07-27--13-01-19--1
# You can replay it like this:
tools/replay/replay "a2a0ccea32023010|2023-07-27--13-01-19" --data_dir="/path_to_routes"
```

With the included patch, I can load the local route.

