### PR TITLE
Fix test_update_returns_state to flatten Kalman output

### DIFF
--- a/common/tests/test_simple_kalman.py
+++ b/common/tests/test_simple_kalman.py
@@ -24,6 +24,6 @@ class TestSimpleKalman:
     self.kf.set_x([[1.0], [1.0]])
     assert self.kf.x == [[1.0], [1.0]]
 
-  def update_returns_state(self):
+  def test_update_returns_state(self):
     x = self.kf.update(100)
-    assert x == self.kf.x
+    assert x == [i[0] for i in self.kf.x]


### PR DESCRIPTION
# Pull Request

## Purpose

Fix `test_update_returns_state` in `test_simple_kalman.py` where the test was incorrectly comparing a 1D list to a 2D list.

The original test:
```python
  def update_returns_state(self):
    x = self.kf.update(100)
    assert x == self.kf.x
```
The test did not had the `test_` prefix so it was never called.
incorrectly assumed that `x` (a 1D list) and `self.kf.x` (a 2D list) were directly comparable.  
This change adds `test_update_returns_state` to the set of tests and explicitly flattens `self.kf.x` during the assertion:
```python
  def test_update_returns_state(self):
    x = self.kf.update(100)
   assert x == [i[0] for i in self.kf.x]
```
This ensures a proper value comparison and prevents false test failures.

---

## Justification

- **Verification**: After this change, the tests pass without modifying the Kalman filter's internal representation.
- **Purpose**: To fix the test structure without altering code functionality.
- **Impact**: Minimal; strictly testing fix, no effect on runtime behavior or functionality.

---

## Testing

- Ran `pytest test_simple_kalman.py`.
- Confirmed that the test is passing.
- No regressions observed.
![image](https://github.com/user-attachments/assets/976e1a23-fa59-4bb1-b6b8-6a28d4865aac)

---

## Additional Notes

- The change was applied **in two locations** where identical `test_update_returns_state` functions exist.
- No functionality was modified, only the test's assertion logic.

