### PR TITLE
tools: add branch to remote tracking list on `op switch`

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -341,8 +341,8 @@ function op_switch() {
   fi
   BRANCH="$1"
 
+  git remote set-branches --add "$REMOTE" "$BRANCH"
   git fetch "$REMOTE" "$BRANCH"
-  git checkout -f FETCH_HEAD
   git checkout -B "$BRANCH" --track "$REMOTE"/"$BRANCH"
   git reset --hard "${REMOTE}/${BRANCH}"
   git clean -df


### PR DESCRIPTION
Add the branch for `op switch` to the remote's list of tracked branches, ensuring that `git checkout --track` completes successfully.

**The problem**

In a fresh install of openpilot, the `.git/config` looks like this:

```
[remote "origin"]
  url = https://github.com/commaai/openpilot.git
  fetch = +refs/heads/master:refs/remotes/origin/master
```

Running `op switch` hits a fatal error:

```
$ op switch enable-online-lag
From https://github.com/commaai/openpilot
 * branch                enable-online-lag -> FETCH_HEAD
Filtering content: 100% (3/3), 22.11 MiB | 9.07 MiB/s, done.
Note: switching to 'FETCH_HEAD'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 1aaf04b6b Merge remote-tracking branch 'origin/master' into enable-online-lag
M       opendbc_repo
M       panda
fatal: cannot set up tracking information; starting point 'origin/enable-online-lag' is not a branch
```

This is because the `remote.origin.fetch` config is restrictive - refs aren't created for branches other than `master` (or whichever branch was originally installed), and `git fetch "$REMOTE" "$BRANCH"` only updates the `FETCH_HEAD` ref. This causes `git checkout --track` to fail.

**The solution**

Using `git remote set-branches --add $REMOTE $BRANCH`, we can instruct git to track this branch on the remote, and subsequent fetches will create and update the ref for this remote branch. We can also remove the now redundant `git checkout FETCH_HEAD`.

The `.git/config` will now contain:
```
[remote "origin"]
  url = https://github.com/commaai/openpilot.git
  fetch = +refs/heads/master:refs/remotes/origin/master
  fetch = +refs/heads/enable-online-lag:refs/remotes/origin/enable-online-lag
```