### PR TITLE
fix(clip): longer timeout for ffmpeg to finish

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -26,7 +26,7 @@ FRAMERATE = 20
 PIXEL_DEPTH = '24'
 RESOLUTION = '2160x1080'
 SECONDS_TO_WARM = 2
-PROC_WAIT_SECONDS = 5
+PROC_WAIT_SECONDS = 30
 
 REPLAY = str(Path(BASEDIR, 'tools/replay/replay').resolve())
 UI = str(Path(BASEDIR, 'selfdrive/ui/ui').resolve())


### PR DESCRIPTION
normally we wait the duration of the clip for ffmpeg to wrap up plus a buffer. increase that buffer to 30s in case it takes a bit longer for longer clips.