### PR TITLE
feat(clip): title and metadata overlay

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -167,7 +167,7 @@ def clip(data_dir: str | None, quality: Literal['low', 'high'], prefix: str, rou
 
   meta_text = get_meta_text(route)
   overlays = [
-    f"drawtext=text='{escape_ffmpeg_text(meta_text)}':fontfile=Inter.tff:fontcolor=white:fontsize=18:box=1:boxcolor=black@0.33:boxborderw=7:x=(w-text_w)/2:y=5.5:enable='between(t,1,10)'"
+    f"drawtext=text='{escape_ffmpeg_text(meta_text)}':fontfile=Inter.tff:fontcolor=white:fontsize=18:box=1:boxcolor=black@0.33:boxborderw=7:x=(w-text_w)/2:y=5.5:enable='between(t,1,5)'"
   ]
   if title:
     overlays.append(f"drawtext=text='{escape_ffmpeg_text(title)}':fontfile=Inter.tff:fontcolor=white:fontsize=32:box=1:boxcolor=black@0.33:boxborderw=10:x=(w-text_w)/2:y=53")

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -178,7 +178,9 @@ def clip(
   display = f':{randint(99, 999)}'
 
   meta_text = get_meta_text(meta)
-  overlays = [f"drawtext=text='{escape_ffmpeg_text(meta_text)}':fontfile=Inter.tff:fontcolor=white:fontsize=18:box=1:boxcolor=black@0.33:boxborderw=7:x=(w-text_w)/2:y=5.5:enable='between(t,1,10)'",]
+  overlays = [
+    f"drawtext=text='{escape_ffmpeg_text(meta_text)}':fontfile=Inter.tff:fontcolor=white:fontsize=18:box=1:boxcolor=black@0.33:boxborderw=7:x=(w-text_w)/2:y=5.5:enable='between(t,1,10)'"
+  ]
   if title:
     overlays.append(f"drawtext=text='{escape_ffmpeg_text(title)}':fontfile=Inter.tff:fontcolor=white:fontsize=32:box=1:boxcolor=black@0.33:boxborderw=10:x=(w-text_w)/2:y=53")
 

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -141,7 +141,7 @@ def validate_route(route: str):
 
 def validate_title(title: str):
   if len(title) > 80:
-    raise ArgumentTypeError('title must be less than 80 chars')
+    raise ArgumentTypeError('title must be no longer than 80 chars')
   return title
 
 

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -61,7 +61,6 @@ def escape_ffmpeg_text(value: str):
 
 
 def get_meta_text(route: Route):
-  logger.info('getting route metadata')
   metadata = route.get_metadata()
   origin_parts = metadata['git_remote'].split('/')
   origin = origin_parts[3] if len(origin_parts) > 3 else 'unknown'

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -33,6 +33,7 @@ function install_ubuntu_common_requirements() {
     git \
     git-lfs \
     ffmpeg \
+    fonts-inter \
     libavformat-dev \
     libavcodec-dev \
     libavdevice-dev \

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -21,6 +21,7 @@ class Route:
   def __init__(self, name, data_dir=None):
     self._name = RouteName(name)
     self.files = None
+    self.metadata = None
     if data_dir is not None:
       self._segments = self._get_segments_local(data_dir)
     else:
@@ -58,6 +59,12 @@ class Route:
   def qcamera_paths(self):
     qcamera_path_by_seg_num = {s.name.segment_num: s.qcamera_path for s in self._segments}
     return [qcamera_path_by_seg_num.get(i, None) for i in range(self.max_seg_number + 1)]
+
+  def get_metadata(self):
+    if not self.metadata:
+      api = CommaApi(get_token())
+      self.metadata = api.get('v1/route/' + self.name.canonical_name)
+    return self.metadata
 
   # TODO: refactor this, it's super repetitive
   def _get_segments_remote(self):


### PR DESCRIPTION
* add metadata and optional title overlay to clips
  * metadata is non-optional for now (should have traceability if questions arise). it shows for 4 seconds as to not be a distraction. starts at 1 second so it doesn't appear in video previews.
* title is escaped (slashes and other symbols work fine). emojis do not work as `ffmpeg` [does not support rendering them](https://trac.ffmpeg.org/ticket/5777).
* add route metadata fetching function (calls comma /v1/route API)

`tools/clip/run.py -t "// a drive up the 10 \\" d3cff3c1d3af097b/00000006--0df6ded53a/1080/1100`


https://github.com/user-attachments/assets/4a8886bc-ddc7-4cd7-abc9-d1cf837b3c2e

