### PR TITLE
Tesla: remove steering pressed noEntry

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -38,6 +38,7 @@ class CarSpecificEvents:
     self.low_speed_alert = False
     self.no_steer_warning = False
     self.silent_steer_warning = True
+    self.steering_disengage_prev = False
 
     self.cruise_buttons: deque = deque([], maxlen=HYUNDAI_PREV_BUTTON_SAMPLES)
 
@@ -191,7 +192,7 @@ class CarSpecificEvents:
       events.add(EventName.accFaulted)
     if CS.steeringPressed:
       events.add(EventName.steerOverride)
-    if CS.steeringDisengage:
+    if CS.steeringDisengage and not self.steering_disengage_prev:
       events.add(EventName.steerDisengage)
     if CS.brakePressed and CS.standstill:
       events.add(EventName.preEnableStandstill)
@@ -205,6 +206,8 @@ class CarSpecificEvents:
       events.add(EventName.belowSteerSpeed)
     if CS.buttonEnable:
       events.add(EventName.buttonEnable)
+
+    self.steering_disengage_prev = CS.steeringDisengage
 
     # Handle cancel button presses
     for b in CS.buttonEvents:

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -672,7 +672,6 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
 
   EventName.steerDisengage: {
     ET.USER_DISABLE: EngagementAlert(AudibleAlert.disengage),
-    ET.NO_ENTRY: NoEntryAlert("Steering Pressed"),
   },
 
   EventName.preEnableStandstill: {


### PR DESCRIPTION
The EPS must allow some tolerance while engaging to not fault, as I wasn't able to engage while on a highway interchange due to me applying a lot of torque for the sharp turn/handsOnLevel at 3. This should fix the regression from https://github.com/commaai/openpilot/pull/35097

The safety that was just merged in assumes this rising edge behavior, so no changes are needed there