### PR TITLE
webcam: improvements for mac

### DIFF
--- a/tools/webcam/README.md
+++ b/tools/webcam/README.md
@@ -1,22 +1,22 @@
 # Run openpilot with webcam on PC
 
 What's needed:
-- Ubuntu 24.04 ([WSL2 is not supported](https://github.com/commaai/openpilot/issues/34216))
+- Ubuntu 24.04 ([WSL2 is not supported](https://github.com/commaai/openpilot/issues/34216)) or macOS
 - GPU (recommended)
-- Two USB webcams, at least 720p and 78 degrees FOV (e.g. Logitech C920/C615)
-- [Car harness](https://comma.ai/shop/products/comma-car-harness) with black panda to connect to your car
-- [Panda paw](https://comma.ai/shop/products/panda-paw) or USB-A to USB-A cable to connect panda to your computer
-That's it!
+- One USB webcam, at least 720p and 78 degrees FOV (e.g. Logitech C920/C615, NexiGo N60)
+- [Car harness](https://comma.ai/shop/products/comma-car-harness)
+- [panda](https://comma.ai/shop/panda)
+- USB-A to USB-A cable to connect panda to your computer
 
 ## Setup openpilot
 - Follow [this readme](../README.md) to install and build the requirements
-- Install OpenCL Driver
+- Install OpenCL Driver (Ubuntu)
 ```
 sudo apt install pocl-opencl-icd
 ```
 
 ## Connect the hardware
-- Connect the road facing camera first, then the driver facing camera
+- Connect the camera first
 - Connect your computer to panda
 
 ## GO
@@ -24,12 +24,12 @@ sudo apt install pocl-opencl-icd
 USE_WEBCAM=1 system/manager/manager.py
 ```
 - Start the car, then the UI should show the road webcam's view
-- Adjust and secure the webcams.
+- Adjust and secure the webcam
 - Finish calibration and engage!
 
 ## Specify Cameras
 
-Use the `ROAD_CAM`, `DRIVER_CAM`, and optional `WIDE_CAM` environment variables to specify which camera is which (ie. `DRIVER_CAM=2` uses `/dev/video2` for the driver-facing camera):
+Use the `ROAD_CAM` (default 0) and optional `DRIVER_CAM`, `WIDE_CAM` environment variables to specify which camera is which (ie. `ROAD_CAM=1` uses `/dev/video1`, on Ubuntu, for the road camera):
 ```
-USE_WEBCAM=1 ROAD_CAM=4 WIDE_CAM=6 system/manager/manager.py
+USE_WEBCAM=1 ROAD_CAM=1 system/manager/manager.py
 ```

--- a/tools/webcam/camera.py
+++ b/tools/webcam/camera.py
@@ -10,7 +10,7 @@ class Camera:
     print(f"opening {cam_type_state} at {camera_id}")
 
     if platform.system() == "Darwin":
-      self.container = av.open(camera_id, format='avfoundation', container_options={"framerate": "20"})
+      self.container = av.open(camera_id, format='avfoundation', container_options={"framerate": "30"})
     else:
       self.container = av.open(f"/dev/video{camera_id}")
 

--- a/tools/webcam/camera.py
+++ b/tools/webcam/camera.py
@@ -1,16 +1,19 @@
 import av
+import platform
 
 class Camera:
   def __init__(self, cam_type_state, stream_type, camera_id):
-    try:
-      camera_id = int(camera_id)
-    except ValueError: # allow strings, ex: /dev/video0
-      pass
     self.cam_type_state = cam_type_state
     self.stream_type = stream_type
     self.cur_frame_id = 0
 
-    self.container = av.open(camera_id)
+    print(f"opening {cam_type_state} at {camera_id}")
+
+    if platform.system() == "Darwin":
+      self.container = av.open(camera_id, format='avfoundation', container_options={"framerate": "20"})
+    else:
+      self.container = av.open(f"/dev/video{camera_id}")
+
     assert self.container.streams.video, f"Can't open video stream for camera {camera_id}"
     self.video_stream = self.container.streams.video[0]
     self.W = self.video_stream.codec_context.width
@@ -22,8 +25,14 @@ class Camera:
     return frame.reformat(format='nv12').to_ndarray()
 
   def read_frames(self):
-    for frame in self.container.decode(self.video_stream):
-      img = frame.to_rgb().to_ndarray()[:,:, ::-1] # convert to bgr24
-      yuv = Camera.bgr2nv12(img)
-      yield yuv.data.tobytes()
-    self.container.close()
+    try:
+      while True:
+        try:
+          for frame in self.container.decode(self.video_stream):
+            img = frame.to_rgb().to_ndarray()[:,:, ::-1] # convert to bgr24
+            yuv = Camera.bgr2nv12(img)
+            yield yuv.data.tobytes()
+        except av.BlockingIOError:
+            pass
+    finally:
+      self.container.close()

--- a/tools/webcam/camerad.py
+++ b/tools/webcam/camerad.py
@@ -9,14 +9,19 @@ from cereal import messaging
 from openpilot.tools.webcam.camera import Camera
 from openpilot.common.realtime import Ratekeeper
 
+ROAD_CAM = os.getenv("ROAD_CAM", "0")
 WIDE_CAM = os.getenv("WIDE_CAM")
+DRIVER_CAM = os.getenv("DRIVER_CAM")
+
 CameraType = namedtuple("CameraType", ["msg_name", "stream_type", "cam_id"])
+
 CAMERAS = [
-  CameraType("roadCameraState", VisionStreamType.VISION_STREAM_ROAD, os.getenv("ROAD_CAM", "0")),
-  CameraType("driverCameraState", VisionStreamType.VISION_STREAM_DRIVER, os.getenv("DRIVER_CAM", "2")),
+  CameraType("roadCameraState", VisionStreamType.VISION_STREAM_ROAD, ROAD_CAM)
 ]
 if WIDE_CAM:
   CAMERAS.append(CameraType("wideRoadCameraState", VisionStreamType.VISION_STREAM_WIDE_ROAD, WIDE_CAM))
+if DRIVER_CAM:
+  CAMERAS.append(CameraType("driverCameraState", VisionStreamType.VISION_STREAM_DRIVER, DRIVER_CAM))
 
 class Camerad:
   def __init__(self):

--- a/tools/webcam/camerad.py
+++ b/tools/webcam/camerad.py
@@ -25,9 +25,7 @@ class Camerad:
 
     self.cameras = []
     for c in CAMERAS:
-      cam_device = f"/dev/video{c.cam_id}"
-      print(f"opening {c.msg_name} at {cam_device}")
-      cam = Camera(c.msg_name, c.stream_type, cam_device)
+      cam = Camera(c.msg_name, c.stream_type, c.cam_id)
       self.cameras.append(cam)
       self.vipc_server.create_buffers(c.stream_type, 20, cam.W, cam.H)
 


### PR DESCRIPTION
For https://github.com/commaai/openpilot/issues/35039 - fix up USB webcam support on mac:
- `av.open` requires camera_id e.g. "0", format="avfoundation" and container_options specifying framerate (otherwise it crashes from the start)
- after a random number of frames, decode will throw a `BlockingIOError` and needs to be ignored (otherwise camerad crashes)
- made DRIVER_CAM optional
- updated README

The improvements were taken from a `pyav` [example](https://pyav.basswood-io.com/docs/stable/cookbook/basics.html#recording-a-facecam).

Only tested on mac and with the "FaceTime HD Camera (Built-in)" (don't have an external webcam yet).