### PR TITLE
cleanup .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,8 @@ selfdrive/pandad/pandad
 cereal/services.h
 cereal/gen
 cereal/messaging/bridge
-selfdrive/logcatd/logcatd
 selfdrive/mapd/default_speeds_by_region.json
 system/proclogd/proclogd
-selfdrive/ui/translations/alerts_generated.h
 selfdrive/ui/translations/tmp
 selfdrive/test/longitudinal_maneuvers/out
 selfdrive/car/tests/cars_dump


### PR DESCRIPTION
1. logcatd is now located in the "system" folder.
2. alerts_generated.h has already been defined in the "selfdrive/ui/.gitignore".