### PR TITLE
replay: fix potential timestamp parsing error in Route::load

### DIFF
--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -50,9 +50,11 @@ bool Route::load() {
     return false;
   }
 
+  // Parse the timestamp from the route identifier (only applicable for old route formats).
   struct tm tm_time = {0};
-  strptime(route_.timestamp.c_str(), "%Y-%m-%d--%H-%M-%S", &tm_time);
-  date_time_ = mktime(&tm_time);
+  if (strptime(route_.timestamp.c_str(), "%Y-%m-%d--%H-%M-%S", &tm_time)) {
+    date_time_ = mktime(&tm_time);
+  }
 
   bool ret = data_dir_.empty() ? loadFromServer() : loadFromLocal();
   if (ret) {

--- a/tools/replay/route.h
+++ b/tools/replay/route.h
@@ -59,7 +59,7 @@ protected:
   RouteIdentifier route_ = {};
   std::string data_dir_;
   std::map<int, SegmentFile> segments_;
-  std::time_t date_time_;
+  std::time_t date_time_ = 0;
   RouteLoadError err_ = RouteLoadError::None;
 };
 


### PR DESCRIPTION
Improves the robustness of timestamp parsing in the `Route::load()` by adding a conditional check for the success of `strptime`. Previously, the code assumed that `strptime` would always succeed, which could lead to undefined behavior if the timestamp format was invalid or parsing failed.

