### PR TITLE
ci: build on arm and upload docker images

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -10,8 +10,11 @@ env:
 
 jobs:
   build_prebuilt:
-    name: build prebuilt
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    name: build prebuilt (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     if: github.repository == 'commaai/openpilot'
     env:
       PUSH_IMAGE: true

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -67,12 +67,12 @@ jobs:
       run: release/check-submodules.sh
 
   build:
-    name: build (${{ matrix.os }})
     strategy:
       matrix:
         os:
           - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-amd64-8x16' || 'ubuntu-24.04' }}
           - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-arm64-8x16' || 'ubuntu-24.04-arm' }}
+    name: build (${{ matrix.os }})
     runs-on:
       - ${{ matrix.os }}
       - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-experiments:docker.builds.local-cache=separate' || matrix.os }}

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -67,9 +67,15 @@ jobs:
       run: release/check-submodules.sh
 
   build:
+    name: build (${{ matrix.os }})
+    strategy:
+      matrix:
+        os:
+          - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-amd64-8x16' || 'ubuntu-24.04' }}
+          - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-arm64-8x16' || 'ubuntu-24.04-arm' }}
     runs-on:
-      - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-amd64-8x16' || 'ubuntu-24.04' }}
-      - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-experiments:docker.builds.local-cache=separate' || 'ubuntu-24.04' }}
+      - ${{ matrix.os }}
+      - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-experiments:docker.builds.local-cache=separate' || matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
we don't currently package the openpilot base or compiled images in docker. this is needed to getting clips to work in Docker on M-series macs.

adding logic to build OP on ubuntu ARM instances (namespace for upstream + GH for forks)