### PR TITLE
add dependency to Install_ubuntu_dependencies.sh

### DIFF
--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -27,7 +27,7 @@ ensuring two main safety requirements.
    react. This means that while the system is engaged, the actuators are constrained
    to operate within reasonable limits[^1]. 
 
-For additional safety implementation details, refer to [panda safety model](https://github.com/commaai/panda#safety-model). For vehicle specific implementation of the safety concept, refer to [panda/board/safety/](https://github.com/commaai/panda/tree/master/board/safety).
+For additional safety implementation details, refer to [panda safety model](https://github.com/commaai/panda#safety-model).
 
 **Extra note**: comma.ai strongly discourages the use of openpilot forks with safety code either missing or
   not fully meeting the above requirements.

--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -59,6 +59,7 @@ function install_ubuntu_common_requirements() {
     opencl-headers \
     ocl-icd-libopencl1 \
     ocl-icd-opencl-dev \
+    pocl-opencl-icd \
     portaudio19-dev \
     qttools5-dev-tools \
     libqt5svg5-dev \


### PR DESCRIPTION
**Description**

Added pocl-opencl-icd to install_ubuntu_dependencies.sh - was required for me to run bridge_test.py on a fresh Ubuntu 24.04 install on a qemu vm and has been reported by others on the [discord](https://discordapp.com/channels/469524606043160576/1341609850458869771/1341644380938834006)

**Verification**

bridge_test.py now runs!

-->
