### PR TITLE
ci: enable cache by default

### DIFF
--- a/.github/workflows/auto-cache/action.yaml
+++ b/.github/workflows/auto-cache/action.yaml
@@ -12,7 +12,7 @@ inputs:
     required: true
   save:
     description: 'whether to save the cache'
-    default: 'false'
+    default: 'true'
     required: false
 outputs:
   cache-hit:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -96,6 +96,7 @@ jobs:
       with:
         path: ~/Library/Caches/Homebrew
         key: brew-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
+        save: 'true'
         restore-keys: |
           brew-macos-${{ env.CACHE_COMMIT_DATE }}
           brew-macos
@@ -110,6 +111,7 @@ jobs:
       with:
         path: /tmp/scons_cache
         key: scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
+        save: 'true'
         restore-keys: |
           scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}
           scons-${{ runner.arch }}-macos

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -96,7 +96,6 @@ jobs:
       with:
         path: ~/Library/Caches/Homebrew
         key: brew-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
-        save: 'true'
         restore-keys: |
           brew-macos-${{ env.CACHE_COMMIT_DATE }}
           brew-macos
@@ -111,7 +110,6 @@ jobs:
       with:
         path: /tmp/scons_cache
         key: scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
-        save: 'true'
         restore-keys: |
           scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}
           scons-${{ runner.arch }}-macos


### PR DESCRIPTION
there *may* be a reason why this was disabled. feel free to close if there's a reason, but requesting that the reason be left in a comment for posterity.

the only references to this code i found were in these PRs and it does not explain why caching was explicitly opt-in:
https://github.com/commaai/openpilot/pull/31076
https://github.com/commaai/openpilot/pull/31078

cache should be on by default, and explicitly opted-out for whatever reason (e.g. to save on storage)

just for macos building:
build macOS w/o (7m 23s): https://github.com/commaai/openpilot/actions/runs/14826779948/job/41621012891?pr=35121
build macOS w/ (2m 56s): https://github.com/commaai/openpilot/actions/runs/14826864197/job/41621223468?pr=35121

60% faster