### PR TITLE
Added pocl-opencl-icd to install_ubuntu_dependencies.sh

### DIFF
--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -59,6 +59,7 @@ function install_ubuntu_common_requirements() {
     opencl-headers \
     ocl-icd-libopencl1 \
     ocl-icd-opencl-dev \
+    pocl-opencl-icd \
     portaudio19-dev \
     qttools5-dev-tools \
     libqt5svg5-dev \


### PR DESCRIPTION
**Description**

Added pocl-opencl-icd to install_ubuntu_dependencies.sh - was required for me to run bridge_test.py on a fresh Ubuntu 24.04 install on a qemu vm and has been reported by others on the [discord](https://discordapp.com/channels/469524606043160576/1341609850458869771/1341644380938834006)

**Verification**

bridge_test.py now runs!

