### PR TITLE
Reapply "Mypy: Got passing on macos (#34591)"

### DIFF
--- a/common/realtime.py
+++ b/common/realtime.py
@@ -1,6 +1,7 @@
 """Utilities for reading real time clocks and keeping soft real time constraints."""
 import gc
 import os
+import sys
 import time
 
 from setproctitle import getproctitle
@@ -28,13 +29,13 @@ class Priority:
 
 
 def set_core_affinity(cores: list[int]) -> None:
-  if not PC:
+  if sys.platform == 'linux' and not PC:
     os.sched_setaffinity(0, cores)
 
 
 def config_realtime_process(cores: int | list[int], priority: int) -> None:
   gc.disable()
-  if not PC:
+  if sys.platform == 'linux' and not PC:
     os.sched_setscheduler(0, os.SCHED_FIFO, os.sched_param(priority))
   c = cores if isinstance(cores, list) else [cores, ]
   set_core_affinity(c)

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -776,8 +776,11 @@ def ws_manage(ws: WebSocket, end_event: threading.Event) -> None:
         # While not sending data, onroad, we can expect to time out in 7 + (7 * 2) = 21s
         #                         offroad, we can expect to time out in 30 + (10 * 3) = 60s
         # FIXME: TCP_USER_TIMEOUT is effectively 2x for some reason (32s), so it's mostly unused
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, 16000 if onroad else 0)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
+        if sys.platform == 'linux':
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, 16000 if onroad else 0)
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 7 if onroad else 30)
+        elif sys.platform == 'darwin':
+          sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 7 if onroad else 30)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 7 if onroad else 10)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 2 if onroad else 3)
 

--- a/system/loggerd/xattr_cache.py
+++ b/system/loggerd/xattr_cache.py
@@ -11,7 +11,7 @@ def getxattr(path: str, attr_name: str) -> bytes | None:
       response = xattr.getxattr(path, attr_name)
     except OSError as e:
       # ENODATA (Linux) or ENOATTR (macOS) means attribute hasn't been set
-      if e.errno in (errno.ENODATA, errno.ENOATTR):
+      if e.errno == errno.ENODATA or (hasattr(errno, 'ENOATTR') and e.errno == errno.ENOATTR):
         response = None
       else:
         raise

--- a/system/loggerd/xattr_cache.py
+++ b/system/loggerd/xattr_cache.py
@@ -10,8 +10,8 @@ def getxattr(path: str, attr_name: str) -> bytes | None:
     try:
       response = xattr.getxattr(path, attr_name)
     except OSError as e:
-      # ENODATA means attribute hasn't been set
-      if e.errno == errno.ENODATA:
+      # ENODATA (Linux) or ENOATTR (macOS) means attribute hasn't been set
+      if e.errno in (errno.ENODATA, errno.ENOATTR):
         response = None
       else:
         raise

--- a/system/loggerd/xattr_cache.py
+++ b/system/loggerd/xattr_cache.py
@@ -1,5 +1,6 @@
-import os
 import errno
+
+import xattr
 
 _cached_attributes: dict[tuple, bytes | None] = {}
 
@@ -7,7 +8,7 @@ def getxattr(path: str, attr_name: str) -> bytes | None:
   key = (path, attr_name)
   if key not in _cached_attributes:
     try:
-      response = os.getxattr(path, attr_name)
+      response = xattr.getxattr(path, attr_name)
     except OSError as e:
       # ENODATA means attribute hasn't been set
       if e.errno == errno.ENODATA:
@@ -19,4 +20,4 @@ def getxattr(path: str, attr_name: str) -> bytes | None:
 
 def setxattr(path: str, attr_name: str, attr_value: bytes) -> None:
   _cached_attributes.pop((path, attr_name), None)
-  return os.setxattr(path, attr_name, attr_value)
+  xattr.setxattr(path, attr_name, attr_value)


### PR DESCRIPTION
Reapply https://github.com/commaai/openpilot/pull/34591 since it was reverted in 27b5a72.

Also added checking for ENOATTR since ENODATA is on Linux and ENOATTR on macOS. More [info](https://tech-kern.netbsd.narkive.com/JcRAFrPC/enoattr-vs-enodata).