### PR TITLE
tools/clip: fix SyntaxError in f-string due to unmatched brackets 

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -65,13 +65,13 @@ def get_meta_text(route: Route):
   origin_parts = metadata['git_remote'].split('/')
   origin = origin_parts[3] if len(origin_parts) > 3 else 'unknown'
   return ', '.join([
-    f'openpilot v{metadata['version']}',
-    f'route: {metadata['fullname']}',
-    f'car: {metadata['platform']}',
-    f'origin: {origin}',
-    f'branch: {metadata['git_branch']}',
-    f'commit: {metadata['git_commit'][:7]}',
-    f'modified: {str(metadata['git_dirty']).lower()}',
+    f"openpilot v{metadata['version']}",
+    f"route: {metadata['fullname']}",
+    f"car: {metadata['platform']}",
+    f"origin: {origin}",
+    f"branch: {metadata['git_branch']}",
+    f"commit: {metadata['git_commit'][:7]}",
+    f"modified: {str(metadata['git_dirty']).lower()}",
   ])
 
 


### PR DESCRIPTION
fixes a syntax error in run.py caused by unmatched brackets in an f-string. The issue was due to the use of single quotes inside the f-string, which conflicted with the outer single quotes. This caused both a linting error (`mypy`) and a runtime error when executing the script.

#### **Issue Details**:
- **Lint Error**:
  ```
  mypy..............................................[✗]
  tools/clip/run.py:68: error: f-string: unmatched '['  [syntax]
  ```
- **Runtime Error**:
  ```
  ./run.py --demo
    File "/home/dean/Projects/openpilot/tools/clip/./run.py", line 68
      f'openpilot v{metadata['version']}',
                              ^^^^^^^
  SyntaxError: f-string: unmatched '['
  ```