### PR TITLE
Add LightningHard SOM FCCID to regulatory section

### DIFF
--- a/selfdrive/assets/offroad/fcc.html
+++ b/selfdrive/assets/offroad/fcc.html
@@ -7,7 +7,7 @@
 
   <h3>Authorized Components</h3>
 
-  <h5>Thundersoft TurboX D845 SOM or Comma.ai LightningHard SOM</h5>
+  <h5>Thundersoft TurboX D845 SOM or comma.ai LightningHard SOM</h5>
   <p>FCC ID: 2AOHHTURBOXSOMD845 or 2BFC6-LIGHTNINGH</p>
 
   <h5>Quectel/EG25-G</h5>

--- a/selfdrive/assets/offroad/fcc.html
+++ b/selfdrive/assets/offroad/fcc.html
@@ -3,12 +3,12 @@
   <h2>Supplier's Declaration of Conformity: 47 CFR § 2.1077 Compliance Information</h2>
 
   <h3>Unique Identifier</h3>
-  <p>comma three</p>
+  <p>comma three/3x</p>
 
   <h3>Authorized Components</h3>
 
-  <h5>Thundersoft TurboX D845 SOM</h5>
-  <p>FCC ID: 2AOHHTURBOXSOMD845</p>
+  <h5>Thundersoft TurboX D845 SOM or Comma.ai LightningHard SOM</h5>
+  <p>FCC ID: 2AOHHTURBOXSOMD845 or 2BFC6-LIGHTNINGH</p>
 
   <h5>Quectel/EG25-G</h5>
   <p>FCC ID: XMR201903EG25G</p>


### PR DESCRIPTION
**Description**

Update the regulatory fcc.html document with the 3x LightningHard SOM ID https://fccid.io/2BFC6-LIGHTNINGH

**Verification**

Not sure if having both in one is fine, or if we should detect SOM ID?

Totally fine to close also if an employee wants to take over, Was just curious when I got my new 3x to replace my 3 and saw it still said same SOM
