### PR TITLE
cabana: add RouteInfo dialog to view and navigate route segment details

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -29,7 +29,7 @@ cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/socketcans
                                                'streams/routes.cc', 'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
                                                'utils/export.cc', 'utils/util.cc',
                                                'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',
-                                               'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
+                                               'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc', 'tools/routeinfo.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 
 if GetOption('extras'):

--- a/tools/cabana/tools/routeinfo.cc
+++ b/tools/cabana/tools/routeinfo.cc
@@ -1,0 +1,40 @@
+#include "tools/cabana/tools/routeinfo.h"
+#include <QHeaderView>
+#include <QScrollBar>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include "tools/cabana/streams/replaystream.h"
+
+RouteInfoDlg::RouteInfoDlg(QWidget *parent) : QDialog(parent) {
+  auto *replay = qobject_cast<ReplayStream *>(can)->getReplay();
+  setWindowTitle(tr("Route: %1").arg(QString::fromStdString(replay->route().name())));
+
+  auto *table = new QTableWidget(replay->route().segments().size(), 7, this);
+  table->setToolTip(tr("Click on a row to seek to the corresponding segment."));
+  table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  table->setSelectionBehavior(QAbstractItemView::SelectRows);
+  table->setSelectionMode(QAbstractItemView::SingleSelection);
+  table->setHorizontalHeaderLabels({"", "rlog", "fcam", "ecam", "dcam", "qlog", "qcam"});
+  table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+  table->verticalHeader()->setVisible(false);
+  table->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+  int row = 0;
+  for (const auto &[seg_num, seg] : replay->route().segments()) {
+    table->setItem(row, 0, new QTableWidgetItem(QString::number(seg_num)));
+    table->setItem(row, 1, new QTableWidgetItem(seg.rlog.empty() ? "--" : "Yes"));
+    table->setItem(row, 2, new QTableWidgetItem(seg.road_cam.empty() ? "--" : "Yes"));
+    table->setItem(row, 3, new QTableWidgetItem(seg.wide_road_cam.empty() ? "--" : "Yes"));
+    table->setItem(row, 4, new QTableWidgetItem(seg.driver_cam.empty() ? "--" : "Yes"));
+    table->setItem(row, 5, new QTableWidgetItem(seg.qlog.empty() ? "--" : "Yes"));
+    table->setItem(row, 6, new QTableWidgetItem(seg.qcamera.empty() ? "--" : "Yes"));
+    ++row;
+  }
+  table->setMinimumWidth(table->horizontalHeader()->length() + table->verticalScrollBar()->sizeHint().width());
+  table->setMinimumHeight(table->rowHeight(0) * std::min(table->rowCount(), 13) + table->horizontalHeader()->height() + table->frameWidth() * 2);
+
+  connect(table, &QTableWidget::itemClicked, [](QTableWidgetItem *item) { can->seekTo(item->row() * 60.0); });
+
+  QVBoxLayout *layout = new QVBoxLayout(this);
+  layout->addWidget(table);
+}

--- a/tools/cabana/tools/routeinfo.h
+++ b/tools/cabana/tools/routeinfo.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <QDialog>
+
+class RouteInfoDlg : public QDialog {
+  Q_OBJECT
+public:
+  RouteInfoDlg(QWidget *parent = nullptr);
+};

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -11,6 +11,8 @@
 #include <QVBoxLayout>
 #include <QtConcurrent>
 
+#include "tools/cabana/tools/routeinfo.h"
+
 const int MIN_VIDEO_HEIGHT = 100;
 const int THUMBNAIL_MARGIN = 3;
 
@@ -100,9 +102,12 @@ void VideoWidget::createPlaybackController() {
 
   if (!can->liveStreaming()) {
     toolbar->addAction(utils::icon("repeat"), tr("Loop playback"), this, &VideoWidget::loopPlaybackClicked);
+    createSpeedDropdown(toolbar);
+    toolbar->addSeparator();
+    toolbar->addAction(utils::icon("info-circle"), tr("View route details"), this, &VideoWidget::showRouteInfo);
+  } else {
+    createSpeedDropdown(toolbar);
   }
-
-  createSpeedDropdown(toolbar);
 }
 
 void VideoWidget::createSpeedDropdown(QToolBar *toolbar) {
@@ -228,6 +233,12 @@ void VideoWidget::showThumbnail(double seconds) {
   slider->thumbnail_dispaly_time = seconds;
   cam_widget->update();
   slider->update();
+}
+
+void VideoWidget::showRouteInfo() {
+  RouteInfoDlg *route_info = new RouteInfoDlg(this);
+  route_info->setAttribute(Qt::WA_DeleteOnClose);
+  route_info->show();
 }
 
 bool VideoWidget::eventFilter(QObject *obj, QEvent *event) {

--- a/tools/cabana/videowidget.h
+++ b/tools/cabana/videowidget.h
@@ -71,6 +71,7 @@ protected:
   void createSpeedDropdown(QToolBar *toolbar);
   void loopPlaybackClicked();
   void vipcAvailableStreamsUpdated(std::set<VisionStreamType> streams);
+  void showRouteInfo();
 
   StreamCameraView *cam_widget;
   QAction *time_display_action = nullptr;


### PR DESCRIPTION
1. Added a "View Route Details" button in the replay control bar.
2. Clicking the button opens a dialog that displays detailed information about the files in the route. The dialog uses a table to show the following details for each segment:
    - Segment number
    - File availability for rlog, fcam, ecam, dcam, qlog, and qcam

User can click on a row in the table to seek directly to the corresponding segment.

![2025-05-06_16-20](https://github.com/user-attachments/assets/8a7b267b-1be0-4b68-9201-8ab1dd13e3c1)


Use Cases:

1. Provides an overview of the uploaded files in the route.
2. Helps users quickly navigate to a specific segment.
3. Allows users to identify if the current segment is playing qlog

This feature improves usability by making it easier to inspect route details and navigate segments efficiently.



