### PR TITLE
loggerd: remove redundant Params Construction

### DIFF
--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -203,7 +203,7 @@ void handle_user_flag(LoggerdState *s) {
 
   // mark route for uploading
   Params params;
-  std::string routes = Params().get("AthenadRecentlyViewedRoutes");
+  std::string routes = params.get("AthenadRecentlyViewedRoutes");
   params.put("AthenadRecentlyViewedRoutes", routes + "," + s->logger.routeName());
 
   prev_segment = s->logger.segment();


### PR DESCRIPTION
Removes an unnecessary `Params` object construction in the `handle_user_flag` function