### PR TITLE
uploader.py: fix empty string handing in AthenadRecentlyViewedRoutes parameter

### DIFF
--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -89,7 +89,7 @@ class Uploader:
 
   def list_upload_files(self, metered: bool) -> Iterator[tuple[str, str, str]]:
     r = self.params.get("AthenadRecentlyViewedRoutes", encoding="utf8")
-    requested_routes = [] if r is None else r.split(",")
+    requested_routes = [] if r is None else [route for route in r.split(",") if route]
 
     for logdir in listdir_by_creation(self.root):
       path = os.path.join(self.root, logdir)


### PR DESCRIPTION
The root cause is in `loggerd.cc` where route names are appended without checking if the current value is empty:
```c++
std::string routes = Params().get("AthenadRecentlyViewedRoutes");
params.put("AthenadRecentlyViewedRoutes", routes + "," + s->logger.routeName());

```
This causes a bug in the `uploader.py` where empty strings in `requested_routes` make the following `any` expression always return True because "".startswith("") is True for any string:

```python
if name == "qcamera.ts" and not any(logdir.startswith(r.split('|')[-1]) for r in requested_routes):
  continue
```
--------------

This fix ensures empty strings don't cause incorrect behavior when determining which routes need to be uploaded with higher priority.

