### PR TITLE
common/params.cc: Handle EINTR for fsync in Params::put to Improve Robustness

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -140,7 +140,7 @@ int Params::put(const char* key, const char* value, size_t value_size) {
     }
 
     // fsync to force persist the changes.
-    if ((result = fsync(tmp_fd)) < 0) break;
+    if ((result = HANDLE_EINTR(fsync(tmp_fd))) < 0) break;
 
     FileLock file_lock(params_path + "/.lock");
 


### PR DESCRIPTION
Wrap the `fsync` call in `Params::put` with `HANDLE_EINTR` to ensure the operation is retried if interrupted by a signal, instead of failing silently. 