### PR TITLE
common/params: ensure Params::readAll() only reads valid param files

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -192,7 +192,22 @@ std::string Params::get(const std::string &key, bool block) {
 
 std::map<std::string, std::string> Params::readAll() {
   FileLock file_lock(params_path + "/.lock");
-  return util::read_files_in_dir(getParamPath());
+
+  std::map<std::string, std::string> ret;
+
+  std::string path = getParamPath();
+  DIR *d = opendir(path.c_str());
+  if (!d) return ret;
+
+  struct dirent *de = nullptr;
+  while ((de = readdir(d))) {
+    if (de->d_type != DT_DIR && keys.find(de->d_name) != keys.end()) {
+      ret[de->d_name] = util::read_file(path + "/" + de->d_name);
+    }
+  }
+
+  closedir(d);
+  return ret;
 }
 
 void Params::clearAll(ParamKeyType key_type) {


### PR DESCRIPTION
Updates `Params::readAll()` to **explicitly check if each file is a valid param key** before reading, instead of relying on `util::read_files_in_dir`.  

This guarantees that only files corresponding to real params are read, making the function truly match its intended definition and semantics.  
It improves data integrity and system reliability by preventing unrelated files from being included in the result or written to `initdata` in `loggerd`, `bootlog`.