### PR TITLE
micd: fix thread safety by adding locking for shared state

### DIFF
--- a/system/micd.py
+++ b/system/micd.py
@@ -53,7 +53,7 @@ class Mic:
     self.sound_pressure_weighted = 0
     self.sound_pressure_level_weighted = 0
 
-    self.lock = threading.Lock()  # Add a lock for thread safety
+    self.lock = threading.Lock()
 
   def update(self):
     with self.lock:

--- a/system/micd.py
+++ b/system/micd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import numpy as np
 from functools import cache
+import threading
 
 from cereal import messaging
 from openpilot.common.realtime import Ratekeeper
@@ -52,12 +53,18 @@ class Mic:
     self.sound_pressure_weighted = 0
     self.sound_pressure_level_weighted = 0
 
-  def update(self):
-    msg = messaging.new_message('microphone', valid=True)
-    msg.microphone.soundPressure = float(self.sound_pressure)
-    msg.microphone.soundPressureWeighted = float(self.sound_pressure_weighted)
+    self.lock = threading.Lock()  # Add a lock for thread safety
 
-    msg.microphone.soundPressureWeightedDb = float(self.sound_pressure_level_weighted)
+  def update(self):
+    with self.lock:
+      sound_pressure = self.sound_pressure
+      sound_pressure_weighted = self.sound_pressure_weighted
+      sound_pressure_level_weighted = self.sound_pressure_level_weighted
+
+    msg = messaging.new_message('microphone', valid=True)
+    msg.microphone.soundPressure = float(sound_pressure)
+    msg.microphone.soundPressureWeighted = float(sound_pressure_weighted)
+    msg.microphone.soundPressureWeightedDb = float(sound_pressure_level_weighted)
 
     self.pm.send('microphone', msg)
     self.rk.keep_time()
@@ -69,17 +76,17 @@ class Mic:
 
     Logged A-weighted equivalents are rough approximations of the human-perceived loudness.
     """
+    with self.lock:
+      self.measurements = np.concatenate((self.measurements, indata[:, 0]))
 
-    self.measurements = np.concatenate((self.measurements, indata[:, 0]))
+      while self.measurements.size >= FFT_SAMPLES:
+        measurements = self.measurements[:FFT_SAMPLES]
 
-    while self.measurements.size >= FFT_SAMPLES:
-      measurements = self.measurements[:FFT_SAMPLES]
+        self.sound_pressure, _ = calculate_spl(measurements)
+        measurements_weighted = apply_a_weighting(measurements)
+        self.sound_pressure_weighted, self.sound_pressure_level_weighted = calculate_spl(measurements_weighted)
 
-      self.sound_pressure, _ = calculate_spl(measurements)
-      measurements_weighted = apply_a_weighting(measurements)
-      self.sound_pressure_weighted, self.sound_pressure_level_weighted = calculate_spl(measurements_weighted)
-
-      self.measurements = self.measurements[FFT_SAMPLES:]
+        self.measurements = self.measurements[FFT_SAMPLES:]
 
   @retry(attempts=7, delay=3)
   def get_stream(self, sd):


### PR DESCRIPTION
Fixes multiple threading issues in micd by adding a lock to protect shared state accessed by both the audio callback and the main update loop.

All reads and writes to shared variables are now guarded by this lock, this prevents race conditions and ensures consistent, correct operation when the callback and update methods are called from different threads. 