### PR TITLE
micd: compute only last full measurement window

### DIFF
--- a/system/micd.py
+++ b/system/micd.py
@@ -71,9 +71,10 @@ class Mic:
 
   def callback(self, indata, frames, time, status):
     """
-    Using amplitude measurements, calculate an uncalibrated sound pressure and
-    sound pressure level, then apply A‐weighting. Only the last full FFT window
-    is used to update the microphone state.
+    Using amplitude measurements, calculate an uncalibrated sound pressure and sound pressure level.
+    Then apply A-weighting to the raw amplitudes and run the same calculations again.
+
+    Logged A-weighted equivalents are rough approximations of the human-perceived loudness.
     """
     with self.lock:
       self.measurements = np.concatenate((self.measurements, indata[:, 0]))


### PR DESCRIPTION
This change reduces the amount of unnecessary work done by micd.
Previously, calculations would be done against every window and the
results discared.<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

