### PR TITLE
ui(raylib): add thread-safe property access to WifiManagerWrapper

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -6,14 +6,13 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import TypeVar
 
 from dbus_next.aio import MessageBus
 from dbus_next import BusType, Variant, Message
 from dbus_next.errors import DBusError
 from dbus_next.constants import MessageType
 from openpilot.common.swaglog import cloudlog
-
-from typing import TypeVar
 
 T = TypeVar("T")
 

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -15,7 +15,7 @@ from openpilot.common.swaglog import cloudlog
 
 from typing import TypeVar
 
-T = TypeVar('T')  # Create a generic type variable
+T = TypeVar("T")
 
 # NetworkManager constants
 NM = "org.freedesktop.NetworkManager"
@@ -493,7 +493,7 @@ class WifiManagerWrapper:
     """Run a function synchronously in the async thread."""
     if not self._running or not self._loop or not self._manager:
       return default  # type: ignore
-    future: concurrent.futures.Future[T] = concurrent.futures.Future()
+    future = concurrent.futures.Future[T]()
 
     def wrapper() -> None:
       try:


### PR DESCRIPTION
Adds `_run_coroutine_sync` to `WifiManagerWrapper` for safe property and method access from the main UI thread, fixing thread-safety issues when retrieving data from the underlying `WifiManager` instance.