### PR TITLE
#32536 Speedup test_car_interfaces.py

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -6,7 +6,7 @@ from hypothesis import Phase, given, settings
 from parameterized import parameterized
 
 from cereal import car
-from opendbc.car import DT_CTRL, gen_empty_fingerprint, structs
+from opendbc.car import DT_CTRL, gen_empty_fingerprint
 from opendbc.car.car_helpers import interfaces
 from opendbc.car.fw_versions import FW_QUERY_CONFIGS, FW_VERSIONS
 from opendbc.car.mock.values import CAR as MOCK
@@ -51,7 +51,7 @@ def car_fw_obj_list(draw):
       st.sampled_from(sorted(ALL_ECUS)),
     )
   )
-  return [structs.CarParams.CarFw(ecu=e[0], address=e[1], subAddress=e[2] or 0, request=draw(REQUEST_STRATEGY)) for e in entries]
+  return [CarParams.CarFw(ecu=e[0], address=e[1], subAddress=e[2] or 0, request=draw(REQUEST_STRATEGY)) for e in entries]
 
 
 PARAMS_STRATEGY = st.fixed_dictionaries(

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -24,10 +24,8 @@ DrawType = Callable[[st.SearchStrategy], Any]
 
 ALL_ECUS = {ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()}
 ALL_ECUS |= {ecu for config in FW_QUERY_CONFIGS.values() for ecu in config.extra_ecus}
-ALL_ECUS = sorted(ALL_ECUS)
 
 ALL_REQUESTS = {tuple(r.request) for config in FW_QUERY_CONFIGS.values() for r in config.requests}
-ALL_REQUESTS = sorted(ALL_REQUESTS)
 
 MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '60'))
 
@@ -47,14 +45,14 @@ def _build_fp(triples):
 
 FINGERPRINT_STRAT = st.builds(_build_fp, TRIPLE_FP_STRAT)
 
-REQUEST_STRAT = st.sampled_from(ALL_REQUESTS)
+REQUEST_STRAT = st.sampled_from(sorted(ALL_REQUESTS))
 
 
 @st.composite
 def car_fw_obj_list(draw):
   entries = draw(
     st.lists(
-      st.sampled_from(ALL_ECUS),
+      st.sampled_from(sorted(ALL_ECUS)),
     )
   )
   return [structs.CarParams.CarFw(ecu=e[0], address=e[1], subAddress=e[2] or 0, request=draw(REQUEST_STRAT)) for e in entries]

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -28,14 +28,14 @@ MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '60'))
 EMPTY_FINGERPRINT = gen_empty_fingerprint().keys()
 
 TRIPLE_FP_STRATEGY = st.lists(
-  st.tuples(st.sampled_from(tuple(EMPTY_FINGERPRINT)), st.integers(0, 0x7FF), st.integers(0, 64)),
+  st.tuples(st.sampled_from(tuple(EMPTY_FINGERPRINT)), st.integers(0, 0x800), st.integers(0, 64)),
 )
 
 
 def _build_fp(triples):
-  fp = {bus: {} for bus in EMPTY_FINGERPRINT}
-  for bus, msg_id, length in triples:
-    fp[bus][msg_id] = length
+  fp = {i: {} for i in EMPTY_FINGERPRINT}
+  for i, address, length in triples:
+    fp[i][address] = length
   return fp
 
 


### PR DESCRIPTION
https://github.com/commaai/openpilot/issues/32536 Speedup test_car_interfaces.py

[Related opendbc PR](https://github.com/commaai/opendbc/pull/2230)

**Description**
Increased the slowest test from ~1-1.5s seconds to a max of ~0.5-0.6s and total test execution time from ~16.5s to ~9s on M1 Pro (10 cores)

This was achieved by applying 3 optimizations. The first one concerns the test file, the other 2 concern opendbc, hence [Related opendbc PR](https://github.com/commaai/opendbc/pull/2230)
Both PRs can be merged completely independently of each other.

1. Build `hypothesis` strategies once instead of rebuilding them on each test case run: total execution time down from ~16.5s to ~12.2s
2. Precompute `KF1D` parameters for `CarStateBase.__init__()`: total time execution time went down from ~12.2s to ~9s
    - Rationale: `get_kalman_gain()` is non-probabilistic, has no side effects, and always takes a set of constant parameters 
4. Ford-specific optimization: cache `CANDefine` objects created during `CarState` construction, which decreased the per-car execution time from 0.8s (given all the above optimizations) to ~0.54s



**Verification**
Test results:
`pytest --durations=0 -vv selfdrive/car/tests/test_car_interfaces.py  > test_results.txt`

[test_results.txt](https://github.com/user-attachments/files/20153090/test_results.txt)

To estimate the test's total execution time, I used the following helper script, since `pytest` adds initial test session setup overhead to the total time:

`python estimate_total_exec_time.py test_results.txt`

```python
import multiprocessing
import re

def sum_test_durations(file_path):
    total_time = 0.0
    with open(file_path) as f:
        for line in f:
            match = re.search(r'(\d+\.\d+s)', line)
            if match:
                duration = float(match.group(1).rstrip('s'))
                total_time += duration

    total_time -= duration # NOTE: subtract the total test execution time that pytest spits at the end
    total_time /= multiprocessing.cpu_count()
    return total_time

if __name__ == '__main__':
    print(f"Total execution time: {sum_test_durations('test_results.txt'):.2f} seconds")
```

**Next Steps**
1. I plan to root cause the `hypothesis` slowdown, which was repeatedly mentioned in the issue discussion.
2. I plan to explore whether the 3rd optimization improves performance for other car models.





