### PR TITLE
system/ui: add require_full_screen to WifiManagerUI

### DIFF
--- a/system/ui/updater.py
+++ b/system/ui/updater.py
@@ -110,7 +110,8 @@ class Updater:
     # Draw the Wi-Fi manager UI
     wifi_rect = rl.Rectangle(MARGIN + 50, MARGIN, gui_app.width - MARGIN * 2 - 100, gui_app.height - MARGIN * 2 - BUTTON_HEIGHT - 20)
     self.wifi_manager_ui.render(wifi_rect)
-
+    if self.wifi_manager_ui.require_full_screen:
+      return
 
     back_button_rect = rl.Rectangle(MARGIN, gui_app.height - MARGIN - BUTTON_HEIGHT, BUTTON_WIDTH, BUTTON_HEIGHT)
     if gui_button(back_button_rect, "Back"):

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -84,6 +84,11 @@ class WifiManagerUI:
       case _:
         self._draw_network_list(rect)
 
+  @property
+  def require_full_screen(self) -> bool:
+    """Check if the WiFi UI requires exclusive full-screen rendering."""
+    return isinstance(self.state, (StateNeedsAuth, StateShowForgetConfirm))
+
   def _draw_network_list(self, rect: rl.Rectangle):
     content_rect = rl.Rectangle(rect.x, rect.y, rect.width, len(self._networks) * ITEM_HEIGHT)
     offset = self.scroll_panel.handle_scroll(rect, content_rect)


### PR DESCRIPTION
Adds a `require_full_screen` property to the `WifiManagerUI` class that allows callers to detect when the WiFi UI is displaying a forget confirm dialog or password prompt that should block other UI elements from rendering.

### Testing:
Verified that the `system/ui/updater.py` screen properly handles WiFi password prompts by only rendering the password UI when active, avoiding UI element conflicts like before that `BACK` button overlapped displayed on top of keyboard:

![2025-05-13_02-49](https://github.com/user-attachments/assets/8402e6de-759a-4bfd-af68-c19367310ab3)
