### PR TITLE
system/ui: add Icon widget and SVG support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
   "setuptools",
   "numpy >=2.0, <2.2", # Linting issues with mypy in 2.2
 
+  # ui
+  "cairosvg",
+
   # body / webrtcd
   "aiohttp",
   "aiortc",

--- a/system/ui/widgets/icon.py
+++ b/system/ui/widgets/icon.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import os
+
+import cairosvg
+import pyray as rl
+from openpilot.common.basedir import BASEDIR
+from openpilot.system.ui.lib.application import gui_app
+
+SVG_RENDER_SCALE = 2
+ORIGIN = rl.Vector2(0, 0)
+
+
+class Icon:
+  def __init__(self, asset_name: str, origin: rl.Vector2 = ORIGIN, invert = False):
+    self.origin = origin
+
+    asset_path = os.path.join(BASEDIR, "selfdrive", "assets", asset_name)
+    if asset_name.endswith(".svg"):
+      data = cairosvg.svg2png(url=asset_path, scale=SVG_RENDER_SCALE)
+      image = rl.load_image_from_memory(".png", bytes(data), len(data))
+    else:
+      image = rl.load_image(asset_path)
+
+    if invert:
+      rl.image_color_invert(image)
+
+    self.width = image.width
+    self.height = image.height
+    self.texture = rl.load_texture_from_image(image)
+    gui_app._textures.append(self.texture)
+    rl.unload_image(image)
+
+  def render(self, pos: rl.Vector2, width: float | None = None, height: float | None = None, scale: float = 1.0):
+    if width is not None and height is not None:
+      w = width
+      h = height
+    elif width is not None:
+      w = width
+      h = width * (self.height / self.width)
+    elif height is not None:
+      h = height
+      w = height * (self.width / self.height)
+    else:
+      w = self.width * scale
+      h = self.height * scale
+    rl.draw_texture_pro(self.texture, rl.Rectangle(0, 0, self.width, self.height), rl.Rectangle(pos.x, pos.y, w, h),
+                        rl.Vector2(self.origin.x * w, self.origin.y * h), 0, rl.WHITE)
+
+
+if __name__ == "__main__":
+  gui_app.init_window("Icon")
+  checkmark = Icon("img_circled_check.svg", origin=rl.Vector2(0.5, 0.5))
+  png = Icon("offroad/icon_warning.png")
+  experimental = Icon("img_experimental.svg")
+  experimental_grey = Icon("img_experimental_grey.svg", invert=True)
+  try:
+    for _ in gui_app.render():
+      checkmark.render(rl.Vector2(400, 400))
+      png.render(rl.Vector2(0, 0), height=128)
+      experimental.render(rl.Vector2(150, 150), scale=0.2)
+      experimental_grey.render(rl.Vector2(300, 150), scale=0.2)
+  finally:
+    gui_app.close()

--- a/system/ui/widgets/icon.py
+++ b/system/ui/widgets/icon.py
@@ -17,7 +17,7 @@ class Icon:
     asset_path = os.path.join(BASEDIR, "selfdrive", "assets", asset_name)
     if asset_name.endswith(".svg"):
       data = cairosvg.svg2png(url=asset_path, scale=SVG_RENDER_SCALE)
-      image = rl.load_image_from_memory(".png", bytes(data), len(data))
+      image = rl.load_image_from_memory(".png", bytes(data), len(data))  # type: ignore
     else:
       image = rl.load_image(asset_path)
 

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,34 @@ wheels = [
 ]
 
 [[package]]
+name = "cairocffi"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096, upload-time = "2024-06-18T10:56:06.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611, upload-time = "2024-06-18T10:55:59.489Z" },
+]
+
+[[package]]
+name = "cairosvg"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairocffi" },
+    { name = "cssselect2" },
+    { name = "defusedxml" },
+    { name = "pillow" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/2b/2bad43cd8047663f8fb768a0a6aef48fc8346e276a274bec3710f84bab63/cairosvg-2.8.0.tar.gz", hash = "sha256:d60fe75c238ffba3f8e21e06dad8727ecd2bcef8d3d55fc11f9286c08c5cc710", size = 8398397, upload-time = "2025-05-12T11:36:41.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/ed/e04ffd1043a47b4510fd8a1e0c4e1c6b5b27922ef53a578739ed3cfd1f32/cairosvg-2.8.0-py3-none-any.whl", hash = "sha256:f15836feea67a680f79938edf2efdd162793526b0b1cc2fd9ec257ebeafe2946", size = 45746, upload-time = "2025-05-12T11:36:37.364Z" },
+]
+
+[[package]]
 name = "casadi"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -437,6 +465,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/86/fd7f58fc498b3166f3a7e8e0cddb6e620fe1da35b02248b1bd59e95dbaaa/cssselect2-0.8.0.tar.gz", hash = "sha256:7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a", size = 35716, upload-time = "2025-03-05T14:46:07.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/e7/aa315e6a749d9b96c2504a1ba0ba031ba2d0517e972ce22682e3fccecb09/cssselect2-0.8.0-py3-none-any.whl", hash = "sha256:46fc70ebc41ced7a32cd42d58b1884d72ade23d21e5a4eaaf022401c13f0e76e", size = 15454, upload-time = "2025-03-05T14:46:06.463Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -481,6 +522,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/45/6a40fbe886d60a8c26f480e7d12535502b5ba123814b3b9a0b002ebca198/dbus_next-0.2.3.tar.gz", hash = "sha256:f4eae26909332ada528c0a3549dda8d4f088f9b365153952a408e28023a626a5", size = 71112, upload-time = "2021-07-25T22:11:28.398Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fc/c0a3f4c4eaa5a22fbef91713474666e13d0ea2a69c84532579490a9f2cc8/dbus_next-0.2.3-py3-none-any.whl", hash = "sha256:58948f9aff9db08316734c0be2a120f6dc502124d9642f55e90ac82ffb16a18b", size = 57885, upload-time = "2021-07-25T22:11:25.466Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1261,6 +1311,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiortc" },
+    { name = "cairosvg" },
     { name = "casadi" },
     { name = "cffi" },
     { name = "crcmod" },
@@ -1351,6 +1402,7 @@ requires-dist = [
     { name = "av", marker = "extra == 'dev'" },
     { name = "azure-identity", marker = "extra == 'dev'" },
     { name = "azure-storage-blob", marker = "extra == 'dev'" },
+    { name = "cairosvg", specifier = ">=2.8.0" },
     { name = "casadi", specifier = ">=3.6.6" },
     { name = "cffi" },
     { name = "codespell", marker = "extra == 'testing'" },
@@ -4944,6 +4996,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tinycss2"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5045,6 +5109,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Widget to draw images and SVGs

Raylib doesn't have native support for SVGs (it uses stbi which can import PNGs, JPGs...).

This adds [`cairosvg`](https://github.com/Kozea/CairoSVG) which renders SVGs, outputting a PNG image which we can upload to raylib

![image](https://github.com/user-attachments/assets/82421431-6483-43b3-b708-8aa0daf77fa8)

Split out from #35140 

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

