### PR TITLE
Pass args to op auth

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -254,7 +254,7 @@ function op_setup() {
 
 function op_auth() {
   op_before_cmd
-  op_run_command tools/lib/auth.py
+  op_run_command tools/lib/auth.py "$@"
 }
 
 function op_activate_venv() {


### PR DESCRIPTION
Currently `op auth <anything>` just redirects to the google login. This allows for `op auth github` as well as `op auth --help` to work as expected.