### PR TITLE
feat(clip): hydrate route's CarParams before starting UI

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -116,10 +116,12 @@ def parse_args(parser: ArgumentParser):
 
 
 def populate_car_params(route: Route):
-  lr = LogReader(route.name.canonical_name, default_mode=ReadMode.QLOG, source=comma_api_source)
-  params = Params()
+  segment = route.name.canonical_name + '/0' # only get first segment qlog
+  lr = LogReader(segment, default_mode=ReadMode.QLOG, source=comma_api_source)
   init_data = lr.first('initData')
   assert init_data is not None
+
+  params = Params()
   entries = init_data.params.entries
   for cp in entries:
     key, value = cp.key, cp.value

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -18,6 +18,7 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix
 from openpilot.tools.lib.route import Route
+from openpilot.tools.lib.logreader import LogReader, ReadMode, comma_api_source
 
 DEFAULT_OUTPUT = 'output.mp4'
 DEMO_START = 90
@@ -114,6 +115,18 @@ def parse_args(parser: ArgumentParser):
   return args
 
 
+def populate_car_params(route: Route):
+  lr = LogReader(route.name.canonical_name, default_mode=ReadMode.QLOG, source=comma_api_source)
+  params = Params()
+  init_data = lr.first('initData')
+  assert init_data is not None
+  entries = init_data.params.entries
+  for cp in entries:
+    key, value = cp.key, cp.value
+    params.put(key, value)
+  logger.info(f'persisted {len(entries)} CarParam(s)')
+
+
 def start_proc(args: list[str], env: dict[str, str]):
   return Popen(args, env=env, stdout=PIPE, stderr=PIPE)
 
@@ -167,7 +180,6 @@ def clip(
   end: int,
   target_mb: int,
   title: str | None,
-  use_metric: bool = False,
 ):
   logger.info(f'clipping route {route.name.canonical_name}, start={start} end={end} quality={quality} target_filesize={target_mb}MB')
 
@@ -222,16 +234,15 @@ def clip(
   xvfb_cmd = ['Xvfb', display, '-terminate', '-screen', '0', f'{RESOLUTION}x{PIXEL_DEPTH}']
 
   with OpenpilotPrefix(prefix, shared_download_cache=True):
+    populate_car_params(route)
+
     env = os.environ.copy()
     env['DISPLAY'] = display
 
     xvfb_proc = start_proc(xvfb_cmd, env)
     atexit.register(lambda: xvfb_proc.terminate())
-
     ui_proc = start_proc(ui_cmd, env)
     atexit.register(lambda: ui_proc.terminate())
-    Params().put('IsMetric', '1' if use_metric else '0')
-
     replay_proc = start_proc(replay_cmd, env)
     atexit.register(lambda: replay_proc.terminate())
     procs = [replay_proc, ui_proc, xvfb_proc]
@@ -268,7 +279,6 @@ def main():
   p.add_argument('-p', '--prefix', help='openpilot prefix', default=f'clip_{randint(100, 99999)}')
   p.add_argument('-q', '--quality', help='quality of camera (low = qcam, high = hevc)', choices=['low', 'high'], default='high')
   p.add_argument('-s', '--start', help='start clipping at <start> seconds', type=int)
-  p.add_argument('-m', '--metric', help='use metric units in ui (e.g. kph)', action='store_true')
   p.add_argument('-t', '--title', help='overlay this title on the video (e.g. "Chill driving across the Golden Gate Bridge")', type=validate_title)
   args = parse_args(p)
   try:
@@ -282,7 +292,6 @@ def main():
       end=args.end,
       target_mb=args.file_size,
       title=args.title,
-      use_metric=args.metric,
     )
   except KeyboardInterrupt as e:
     logger.exception('interrupted by user', exc_info=e)


### PR DESCRIPTION
deletes `--metric` and also translates over LHD/RHD, language, and other UI-modifying configurations.

`initData` frame has the rest of the metadata we need, can follow up with a PR to remove the `get_metadata()` call to comma API and just use this one