### PR TITLE
system/ui: fix FPS drop issues

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -12,6 +12,7 @@ FPS_LOG_INTERVAL = 5  # Seconds between logging FPS drops
 FPS_DROP_THRESHOLD = 0.9  # FPS drop threshold for triggering a warning
 FPS_CRITICAL_THRESHOLD = 0.5  # Critical threshold for triggering strict actions
 
+ENABLE_VSYNC = os.getenv("ENABLE_VSYNC") == "1"
 DEBUG_FPS = os.getenv("DEBUG_FPS") == '1'
 STRICT_MODE = os.getenv("STRICT_MODE") == '1'
 
@@ -52,9 +53,13 @@ class GuiApplication:
     HARDWARE.set_screen_brightness(65)
 
     self._set_log_callback()
-
     rl.set_trace_log_level(rl.TraceLogLevel.LOG_ALL)
-    rl.set_config_flags(rl.ConfigFlags.FLAG_MSAA_4X_HINT | rl.ConfigFlags.FLAG_VSYNC_HINT)
+
+    flags = rl.ConfigFlags.FLAG_MSAA_4X_HINT
+    if ENABLE_VSYNC:
+      flags |= rl.ConfigFlags.FLAG_VSYNC_HINT
+    rl.set_config_flags(flags)
+
     rl.init_window(self._width, self._height, title)
     rl.set_target_fps(fps)
 


### PR DESCRIPTION
Set VSYNC flag only when the environment variable is set to resolve FPS drop issues.

Issue Details:
- When the VSYNC flag is set, FPS periodically drops below the expected 60 Hz:
    ```
    FPS dropped below 60: 52
    FPS dropped below 60: 53
    FPS dropped below 60: 53

    ```
- Without the VSYNC flag, the UI remains stable at 60 Hz, ensuring smoother performance.