### PR TITLE
fix(clip): properly set exit code

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -5,6 +5,7 @@ import logging
 import os
 import platform
 import shutil
+import sys
 import time
 from argparse import ArgumentParser, ArgumentTypeError
 from collections.abc import Sequence
@@ -283,6 +284,7 @@ def main():
   p.add_argument('-s', '--start', help='start clipping at <start> seconds', type=int)
   p.add_argument('-t', '--title', help='overlay this title on the video (e.g. "Chill driving across the Golden Gate Bridge")', type=validate_title)
   args = parse_args(p)
+  exit_code = 1
   try:
     clip(
       data_dir=args.data_dir,
@@ -295,12 +297,14 @@ def main():
       target_mb=args.file_size,
       title=args.title,
     )
+    exit_code = 0
   except KeyboardInterrupt as e:
     logger.exception('interrupted by user', exc_info=e)
   except Exception as e:
     logger.exception('encountered error', exc_info=e)
   finally:
     atexit._run_exitfuncs()
+    sys.exit(exit_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```bash
> tools/clip/run.py dc7716b32bf25574/000000b8--6936dd04a0/603/608
2025-05-14 14:09:39,855 clip.py INFO    clipping route dc7716b32bf25574|000000b8--6936dd04a0, start=603 end=608 quality=high target_filesize=9.0MB
2025-05-14 14:09:40,913 clip.py INFO    persisted 57 CarParam(s)
2025-05-14 14:09:40,916 clip.py INFO    waiting for replay to begin (loading segments, may take a while)...
^C2025-05-14 14:09:42,084 clip.py ERROR interrupted by user
Traceback (most recent call last):
  File "/home/trey/dev/openpilot/tools/clip/run.py", line 289, in main
    clip(
  File "/home/trey/dev/openpilot/tools/clip/run.py", line 257, in clip
    time.sleep(SECONDS_TO_WARM)
KeyboardInterrupt

> echo $?
1
```