### PR TITLE
fix(clip): ignore unknown Params keys

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -130,7 +130,7 @@ def populate_car_params(route: Route):
     except UnknownKeyName:
       # forks of openpilot may have other Params keys configured. ignore these
       logger.warning(f'unknown key name {key}, skipping')
-  logger.info(f'persisted {len(entries)} CarParam(s)')
+  logger.debug('persisted CarParams')
 
 
 def start_proc(args: list[str], env: dict[str, str]):

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -129,7 +129,7 @@ def populate_car_params(route: Route):
       params.put(key, value)
     except UnknownKeyName:
       # forks of openpilot may have other Params keys configured. ignore these
-      logger.warning(f'unknown key name {key}, skipping')
+      logger.warning(f"unknown Params key '{key}', skipping")
   logger.debug('persisted CarParams')
 
 

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -128,6 +128,7 @@ def populate_car_params(route: Route):
     try:
       params.put(key, value)
     except UnknownKeyName:
+      # forks of openpilot may have other Params keys configured. ignore these
       logger.warning(f'unknown key name {key}, skipping')
   logger.info(f'persisted {len(entries)} CarParam(s)')
 

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -15,7 +15,7 @@ from typing import Literal
 
 from cereal.messaging import SubMaster
 from openpilot.common.basedir import BASEDIR
-from openpilot.common.params import Params
+from openpilot.common.params import Params, UnknownKeyName
 from openpilot.common.prefix import OpenpilotPrefix
 from openpilot.tools.lib.route import Route
 from openpilot.tools.lib.logreader import LogReader, ReadMode, comma_api_source
@@ -125,7 +125,10 @@ def populate_car_params(route: Route):
   entries = init_data.params.entries
   for cp in entries:
     key, value = cp.key, cp.value
-    params.put(key, value)
+    try:
+      params.put(key, value)
+    except UnknownKeyName:
+      logger.warning(f'unknown key name {key}, skipping')
   logger.info(f'persisted {len(entries)} CarParam(s)')
 
 


### PR DESCRIPTION
some forks or older routes may have other Params that aren't supported, ignore these

before: `tools/clip/run.py 2d2da5dea63b5c5e/00000005--725932e016/1259/1265` fails (sunnypilot route)
after: `tools/clip/run.py 2d2da5dea63b5c5e/00000005--725932e016/1259/1265` succeeds

https://github.com/user-attachments/assets/cc4ebffe-4ce4-45ee-ad7a-6f08bbe0d29f

---

```
❯ tools/clip/run.py 2d2da5dea63b5c5e/00000005--725932e016/1259/1265
2025-05-14 14:42:24,812 clip.py INFO    clipping route 2d2da5dea63b5c5e|00000005--725932e016, start=1259 end=1265 quality=high target_filesize=9.0MB
2025-05-14 14:42:26,457 clip.py WARNING unknown Params key 'ApiCache_DriveStats', skipping
2025-05-14 14:42:26,457 clip.py WARNING unknown Params key 'AutoLaneChangeBsmDelay', skipping
2025-05-14 14:42:26,457 clip.py WARNING unknown Params key 'AutoLaneChangeTimer', skipping
2025-05-14 14:42:26,458 clip.py WARNING unknown Params key 'CarParamsSPPersistent', skipping
2025-05-14 14:42:26,458 clip.py WARNING unknown Params key 'DynamicExperimentalControl', skipping
2025-05-14 14:42:26,459 clip.py WARNING unknown Params key 'HyundaiLongitudinalTuning', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'Mads', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'MadsMainCruiseAllowed', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'MadsPauseLateralOnBrake', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'MadsUnifiedEngagementMode', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'MaxTimeOffroad', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'ModelManager_LastSyncTime', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'ModelManager_ModelsCache', skipping
2025-05-14 14:42:26,461 clip.py WARNING unknown Params key 'ModelRunnerTypeCache', skipping
2025-05-14 14:42:26,462 clip.py WARNING unknown Params key 'NeuralNetworkLateralControl', skipping
2025-05-14 14:42:26,462 clip.py WARNING unknown Params key 'QuietMode', skipping
2025-05-14 14:42:26,462 clip.py WARNING unknown Params key 'SunnylinkdPid', skipping
2025-05-14 14:42:26,468 clip.py INFO    waiting for replay to begin (loading segments, may take a while)...
2025-05-14 14:42:30,191 clip.py INFO    recording in progress (6s)...
2025-05-14 14:42:36,340 clip.py INFO    recording complete: /home/trey/dev/openpilot/output.mp4
```
