### PR TITLE
feat(clip): faster qlog

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -116,8 +116,9 @@ def parse_args(parser: ArgumentParser):
 
 
 def populate_car_params(route: Route):
-  segment = route.name.canonical_name + '/0' # only get first segment qlog
-  lr = LogReader(segment, default_mode=ReadMode.QLOG, source=comma_api_source)
+  qlog_paths = route.qlog_paths()
+  assert len(qlog_paths) > 0, 'must have at least one qlog'
+  lr = LogReader(qlog_paths[0])
   init_data = lr.first('initData')
   assert init_data is not None
 

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -18,7 +18,7 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix
 from openpilot.tools.lib.route import Route
-from openpilot.tools.lib.logreader import LogReader, ReadMode, comma_api_source
+from openpilot.tools.lib.logreader import LogReader
 
 DEFAULT_OUTPUT = 'output.mp4'
 DEMO_START = 90

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -116,9 +116,7 @@ def parse_args(parser: ArgumentParser):
 
 
 def populate_car_params(route: Route):
-  qlog_paths = route.qlog_paths()
-  assert len(qlog_paths) > 0, 'must have at least one qlog'
-  lr = LogReader(qlog_paths[0])
+  lr = LogReader(route.qlog_paths()[0] if len(route.qlog_paths()) else route.name.canonical_name)
   init_data = lr.first('initData')
   assert init_data is not None
 


### PR DESCRIPTION
consistently about 25% faster to start clip

---

before:
```bash
❯ tools/clip/run.py d3cff3c1d3af097b/00000037--c1b93a179b/5/6
2025-05-14 15:02:55,003 clip.py INFO    clipping route d3cff3c1d3af097b|00000037--c1b93a179b, start=5 end=6 quality=high target_filesize=9.0MB
2025-05-14 15:02:56,190 clip.py INFO    persisted 65 CarParam(s)
```
1087ms

after:
```bash
❯ tools/clip/run.py d3cff3c1d3af097b/00000037--c1b93a179b/5/6
2025-05-14 15:02:00,207 clip.py INFO    clipping route d3cff3c1d3af097b|00000037--c1b93a179b, start=5 end=6 quality=high target_filesize=9.0MB
2025-05-14 15:02:01,033 clip.py INFO    persisted 65 CarParam(s)
```
826ms