### PR TITLE
feat(clip): delete get_metadata call

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -64,18 +64,23 @@ def escape_ffmpeg_text(value: str):
   return value
 
 
-def get_meta_text(route: Route):
-  metadata = route.get_metadata()
-  origin_parts = metadata['git_remote'].split('/')
+def get_logreader(route: Route):
+  return LogReader(route.qlog_paths()[0] if len(route.qlog_paths()) else route.name.canonical_name)
+
+
+def get_meta_text(lr: LogReader, route: Route):
+  init_data = lr.first('initData')
+  car_params = lr.first('carParams')
+  origin_parts = init_data.gitRemote.split('/')
   origin = origin_parts[3] if len(origin_parts) > 3 else 'unknown'
   return ', '.join([
-    f"openpilot v{metadata['version']}",
-    f"route: {metadata['fullname']}",
-    f"car: {metadata['platform']}",
+    f"openpilot v{init_data.version}",
+    f"route: {route.name.canonical_name}",
+    f"car: {car_params.carFingerprint}",
     f"origin: {origin}",
-    f"branch: {metadata['git_branch']}",
-    f"commit: {metadata['git_commit'][:7]}",
-    f"modified: {str(metadata['git_dirty']).lower()}",
+    f"branch: {init_data.gitBranch}",
+    f"commit: {init_data.gitCommit[:7]}",
+    f"modified: {str(init_data.dirty).lower()}",
   ])
 
 
@@ -116,8 +121,7 @@ def parse_args(parser: ArgumentParser):
   return args
 
 
-def populate_car_params(route: Route):
-  lr = LogReader(route.qlog_paths()[0] if len(route.qlog_paths()) else route.name.canonical_name)
+def populate_car_params(lr: LogReader):
   init_data = lr.first('initData')
   assert init_data is not None
 
@@ -188,6 +192,7 @@ def clip(
   title: str | None,
 ):
   logger.info(f'clipping route {route.name.canonical_name}, start={start} end={end} quality={quality} target_filesize={target_mb}MB')
+  lr = get_logreader(route)
 
   begin_at = max(start - SECONDS_TO_WARM, 0)
   duration = end - start
@@ -197,7 +202,7 @@ def clip(
   display = f':{randint(99, 999)}'
 
   box_style = 'box=1:boxcolor=black@0.33:boxborderw=7'
-  meta_text = get_meta_text(route)
+  meta_text = get_meta_text(lr, route)
   overlays = [
     # metadata overlay
     f"drawtext=text='{escape_ffmpeg_text(meta_text)}':fontfile={OPENPILOT_FONT}:fontcolor=white:fontsize=15:{box_style}:x=(w-text_w)/2:y=5.5:enable='between(t,1,5)'",
@@ -240,7 +245,7 @@ def clip(
   xvfb_cmd = ['Xvfb', display, '-terminate', '-screen', '0', f'{RESOLUTION}x{PIXEL_DEPTH}']
 
   with OpenpilotPrefix(prefix, shared_download_cache=True):
-    populate_car_params(route)
+    populate_car_params(lr)
 
     env = os.environ.copy()
     env['DISPLAY'] = display

--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -21,7 +21,6 @@ class Route:
   def __init__(self, name, data_dir=None):
     self._name = RouteName(name)
     self.files = None
-    self.metadata = None
     if data_dir is not None:
       self._segments = self._get_segments_local(data_dir)
     else:
@@ -59,12 +58,6 @@ class Route:
   def qcamera_paths(self):
     qcamera_path_by_seg_num = {s.name.segment_num: s.qcamera_path for s in self._segments}
     return [qcamera_path_by_seg_num.get(i, None) for i in range(self.max_seg_number + 1)]
-
-  def get_metadata(self):
-    if not self.metadata:
-      api = CommaApi(get_token())
-      self.metadata = api.get('v1/route/' + self.name.canonical_name)
-    return self.metadata
 
   # TODO: refactor this, it's super repetitive
   def _get_segments_remote(self):


### PR DESCRIPTION
before (incl. faster qlog):
```shell
❯ tools/clip/run.py d3cff3c1d3af097b/00000037--c1b93a179b/400/406
2025-05-14 15:35:32,783 clip.py INFO    clipping route d3cff3c1d3af097b|00000037--c1b93a179b, start=400 end=406 quality=high target_filesize=9.0MB
2025-05-14 15:35:33,567 clip.py INFO    waiting for replay to begin (loading segments, may take a while)...
```
784ms

after:
```shell
❯ tools/clip/run.py d3cff3c1d3af097b/00000037--c1b93a179b/400/406
2025-05-14 15:34:29,303 clip.py INFO    clipping route d3cff3c1d3af097b|00000037--c1b93a179b, start=400 end=406 quality=high target_filesize=9.0MB
2025-05-14 15:34:29,817 clip.py INFO    waiting for replay to begin (loading segments, may take a while)...
```
514ms

---
`tools/clip/run.py d3cff3c1d3af097b/00000037--c1b93a179b/400/406`

https://github.com/user-attachments/assets/be65c3d6-5cbb-444f-a6d8-8e55d89cf4ce


