### PR TITLE
add script to rasterize SVGs

### DIFF
--- a/selfdrive/assets/rasterize_svg.py
+++ b/selfdrive/assets/rasterize_svg.py
@@ -12,6 +12,8 @@ import argparse
 from pathlib import Path
 import cairosvg
 
+SVG_SCALE = 4
+
 def rasterize_svgs(directory=None, force=False):
   if directory is None:
     directory = os.path.dirname(os.path.abspath(__file__))
@@ -38,7 +40,7 @@ def rasterize_svgs(directory=None, force=False):
 
     print(f"Converting {svg_path.name} to {png_path.name}")
     try:
-      cairosvg.svg2png(url=str(svg_path), write_to=str(png_path), scale=4)
+      cairosvg.svg2png(url=str(svg_path), write_to=str(png_path), scale=SVG_SCALE)
       converted += 1
     except Exception as e:
       print(f"Failed to convert {svg_path.name}: {e}")

--- a/selfdrive/assets/rasterize_svg.py
+++ b/selfdrive/assets/rasterize_svg.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "cairosvg",
+# ]
+# ///
+
+import os
+import glob
+import argparse
+from pathlib import Path
+import cairosvg
+
+def rasterize_svgs(directory=None, force=False):
+  if directory is None:
+    directory = os.path.dirname(os.path.abspath(__file__))
+
+  svg_files = glob.glob(os.path.join(directory, "*.svg"))
+  print(f"Found {len(svg_files)} SVG files to convert")
+
+  converted = 0
+  skipped = 0
+
+  for svg_file in svg_files:
+    svg_path = Path(svg_file)
+    png_path = svg_path.with_suffix(".png")
+
+    # Check if PNG exists and is newer than SVG
+    if not force and png_path.exists():
+      svg_mtime = svg_path.stat().st_mtime
+      png_mtime = png_path.stat().st_mtime
+
+      if png_mtime >= svg_mtime:
+        print(f"Skipping {svg_path.name} (PNG is up to date)")
+        skipped += 1
+        continue
+
+    print(f"Converting {svg_path.name} to {png_path.name}")
+    try:
+      cairosvg.svg2png(url=str(svg_path), write_to=str(png_path), scale=4)
+      converted += 1
+    except Exception as e:
+      print(f"Failed to convert {svg_path.name}: {e}")
+
+  return converted, skipped
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Rasterize SVG files to PNG")
+  parser.add_argument("directory", nargs="?", help="Directory containing SVG files (default: script location)")
+  parser.add_argument("-f", "--force", action="store_true", help="Force regeneration of all PNGs")
+  args = parser.parse_args()
+
+  converted, skipped = rasterize_svgs(args.directory, args.force)
+  print(f"Finished: {converted} converted, {skipped} skipped")


### PR DESCRIPTION
Generate PNGs for all of the SVGs in `selfdrive/assets` so that they can be used in Raylib

Uses [script dependencies](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies) - run the script with `uv run ./selfdrive/assets/rasterize_svg.py`

I don't think I can upload PNGs to the GitLab LFS

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

