### PR TITLE
system/ui: disabled button styles

### DIFF
--- a/system/ui/lib/button.py
+++ b/system/ui/lib/button.py
@@ -49,6 +49,9 @@ def gui_button(
 ) -> int:
   result = 0
 
+  if button_style in (ButtonStyle.PRIMARY, ButtonStyle.DANGER) and not is_enabled:
+    button_style = ButtonStyle.NORMAL
+
   # Set background color based on button type
   bg_color = BUTTON_BACKGROUND_COLORS[button_style]
   if is_enabled and rl.check_collision_point_rec(rl.get_mouse_position(), rect):


### PR DESCRIPTION
For "primary"/"danger" buttons, use the normal button bg color with the disabled btn text color when the button is disabled

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

