### PR TITLE
Get dlc_to_len from opendbc

### DIFF
--- a/selfdrive/pandad/panda.h
+++ b/selfdrive/pandad/panda.h
@@ -13,6 +13,7 @@
 #include "cereal/gen/cpp/log.capnp.h"
 #include "panda/board/health.h"
 #include "panda/board/can.h"
+#include "opendbc/safety/board/can_declarations.h"
 #include "selfdrive/pandad/panda_comms.h"
 
 #define USB_TX_SOFT_LIMIT   (0x100U)


### PR DESCRIPTION
**Description**

Get `dlc_to_len` from `opendbc/safety/board/can_declarations.h`. This is part of a refactor for opendbc/safety/board/can_declarations.h

This allows us to finally break free from duplicated code between panda and opendbc.

**Verification**

Compiled locally:

```
openpilot % scons
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: `.' is up to date.
scons: done building targets.
```

This must be merged after:

- https://github.com/commaai/opendbc/pull/2248
- https://github.com/commaai/panda/pull/2186