### PR TITLE
system/ui/setup: fix WiFi manager UI element overlap issues

### DIFF
--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -144,6 +144,10 @@ class Setup:
       self.network_check_thread.join()
 
   def render_network_setup(self, rect: rl.Rectangle):
+    if self.wifi_ui.require_full_screen:
+      self.wifi_ui.render(rect)
+      return
+
     title_rect = rl.Rectangle(rect.x + MARGIN, rect.y + MARGIN, rect.width - MARGIN * 2, TITLE_FONT_SIZE)
     gui_label(title_rect, "Connect to Wi-Fi", TITLE_FONT_SIZE, font_weight=FontWeight.MEDIUM)
 


### PR DESCRIPTION
Fixes UI rendering issues where the WiFi manager's popups  (keyboard, ,error messages) were being overlapped by other UI components.

before:

![Screenshot 2025-05-17 02:16:45](https://github.com/user-attachments/assets/a991a63e-10ae-4387-8512-f3cca5e33ed4)


after:

![Screenshot 2025-05-17 02:16:06](https://github.com/user-attachments/assets/d62ef686-3d94-4f9a-a6e6-c6c21c823adf)
