### PR TITLE
system/ui: Use OPENPILOT_URL instead of google.com for network connectivity check

### DIFF
--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -123,7 +123,7 @@ class Setup:
     while not self.stop_network_check_thread.is_set():
       if self.state == SetupState.NETWORK_SETUP:
         try:
-          urllib.request.urlopen("https://google.com", timeout=2)
+          urllib.request.urlopen(OPENPILOT_URL, timeout=2)
           self.network_connected.set()
           if HARDWARE.get_network_type() == NetworkType.wifi:
             self.wifi_connected.set()


### PR DESCRIPTION
The network check uses "https://google.com", which may be blocked in some regions (e.g., China). This could cause false negatives for connectivity.

Now, the network connectivity check uses OPENPILOT_URL, matching the logic in the original C++ version:

https://github.com/commaai/openpilot/blob/master/selfdrive/ui/qt/setup/setup.cc#L221