### PR TITLE
system/ui: all font weights

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -23,14 +23,15 @@ ASSETS_DIR = files("openpilot.selfdrive").joinpath("assets")
 FONT_DIR = ASSETS_DIR.joinpath("fonts")
 
 class FontWeight(IntEnum):
-  BLACK = 0
-  BOLD = 1
-  EXTRA_BOLD = 2
-  EXTRA_LIGHT = 3
+  THIN = 0
+  EXTRA_LIGHT = 1
+  LIGHT = 2
+  NORMAL = 3
   MEDIUM = 4
-  NORMAL = 5
-  SEMI_BOLD = 6
-  THIN = 7
+  SEMI_BOLD = 5
+  BOLD = 6
+  EXTRA_BOLD = 7
+  BLACK = 8
 
 
 class GuiApplication:
@@ -153,14 +154,15 @@ class GuiApplication:
 
   def _load_fonts(self):
     font_files = (
-      "Inter-Black.ttf",
+      "Inter-Thin.ttf",
+      "Inter-ExtraLight.ttf",
+      "Inter-Light.ttf",
+      "Inter-Regular.ttf",
+      "Inter-Medium.ttf",
+      "Inter-SemiBold.ttf",
       "Inter-Bold.ttf",
       "Inter-ExtraBold.ttf",
-      "Inter-ExtraLight.ttf",
-      "Inter-Medium.ttf",
-      "Inter-Regular.ttf",
-      "Inter-SemiBold.ttf",
-      "Inter-Thin.ttf"
+      "Inter-Black.ttf",
       )
 
     for index, font_file in enumerate(font_files):


### PR DESCRIPTION
add missing `FontWeight.LIGHT`

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

