### PR TITLE
feat(replay): publish CarParams at beginning of stream

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -191,6 +191,7 @@ void Replay::startStream(const std::shared_ptr<Segment> segment) {
     auto bytes = words.asBytes();
     Params().put("CarParams", (const char *)bytes.begin(), bytes.size());
     Params().put("CarParamsPersistent", (const char *)bytes.begin(), bytes.size());
+    publishMessage(&(*it));
   } else {
     rWarning("failed to read CarParams from current segment");
   }


### PR DESCRIPTION
publish CarParams message at beginning of stream so that UI-altering parameters like `openpilotLongitudinalControl` that control chevron visibility appear immediately

open to pushback since this violates the idea of a "replay," but re-publishing this message from other scripts didn't seem to work.