### PR TITLE
pandad: fix premature USB panda recovery

### DIFF
--- a/selfdrive/pandad/pandad.py
+++ b/selfdrive/pandad/pandad.py
@@ -87,7 +87,7 @@ def main() -> None:
 
       # TODO: remove this in the next AGNOS
       # wait until USB is up before counting
-      if time.monotonic() < 25.:
+      if time.monotonic() < 35.:
         no_internal_panda_count = 0
 
       # Handle missing internal panda


### PR DESCRIPTION
Bump from https://github.com/commaai/openpilot/pull/31549

So far, I've flashed a comma three's panda FW back to https://github.com/commaai/panda/commit/80731c0aa7d7b52ba3df01db781accbfabaeb4ef and it always takes about 25-30s (`time.monotonic()`) before `Panda.list()` returns any USB pandas. On release builds, this causes pandad to put the panda into DFU mode and take extra time flashing it before comma three goes onroad. On master builds, scons delays us long enough for this not to be an issue.

Entering DFU causing the relay to flip is strange, was that somehow always an issue?