### PR TITLE
system/ui: remove special currency and symbol characters from keyboard

### DIFF
--- a/system/ui/widgets/keyboard.py
+++ b/system/ui/widgets/keyboard.py
@@ -44,7 +44,7 @@ KEYBOARD_LAYOUTS = {
   "specials": [
     ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
     ["_", "\\", "|", "~", "<", ">"],
-    [NUMERIC_KEY, ".", ",", "!", "'", BACKSPACE_KEY],
+    [NUMERIC_KEY, ".", ",", "?", "!", "'", BACKSPACE_KEY],
     [ABC_KEY, SPACE_KEY, ".", ENTER_KEY],
   ],
 }

--- a/system/ui/widgets/keyboard.py
+++ b/system/ui/widgets/keyboard.py
@@ -43,8 +43,8 @@ KEYBOARD_LAYOUTS = {
   ],
   "specials": [
     ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "•"],
-    [NUMERIC_KEY, ".", ",", "?", "!", "'", BACKSPACE_KEY],
+    ["_", "\\", "|", "~", "<", ">"],
+    [NUMERIC_KEY, ".", ",", "!", "'", BACKSPACE_KEY],
     [ABC_KEY, SPACE_KEY, ".", ENTER_KEY],
   ],
 }
@@ -112,6 +112,10 @@ class Keyboard:
 
         new_width = (key_width * 3 + h_space * 2) if key == SPACE_KEY else (key_width * 2 + h_space if key == ENTER_KEY else key_width)
         key_rect = rl.Rectangle(start_x, row_y_start + row * (key_height + v_space), new_width, key_height)
+        if (key_rect.x + key_rect.width) > (rect.x + rect.width):
+          key_rect.width = rect.x + rect.width - key_rect.x
+          new_width = key_rect.width
+
         start_x += new_width
 
         is_enabled = key != ENTER_KEY or len(self._input_box.text) >= self._min_text_size


### PR DESCRIPTION
Removes problematic special characters (€, £, ¥, •, ?) from the keyboard specials layout that were causing display issues.

These characters aren't needed anywhere in the OP. Supporting them properly would require additional font handling and significant `inputbox.py` modifications that aren't necessary for the system's functionality.

before:

![Screenshot 2025-05-20 13:43:02](https://github.com/user-attachments/assets/3428a5d9-3973-4914-b784-e3cba738400d)

after:

![Screenshot 2025-05-20 13:41:56](https://github.com/user-attachments/assets/77a4aab5-359d-4a0c-881a-fe73f132ef81)

