### PR TITLE
system/ui: define character set for loading fonts

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -194,10 +194,8 @@ class GuiApplication:
     from openpilot.system.ui.widgets.keyboard import KEYBOARD_LAYOUTS
     all_chars = ""
     for layout in KEYBOARD_LAYOUTS.values():
-      for row in layout:
-        for key in row:
-          all_chars += key
-    all_chars = "".join(set(all_chars))
+      all_chars.update(key for row in layout for key in row)
+    all_chars = "".join(all_chars)
 
     codepoint_count = rl.ffi.new("int *", 1)
     codepoints = rl.load_codepoints(all_chars, codepoint_count)

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -201,7 +201,6 @@ class GuiApplication:
 
     codepoint_count = rl.ffi.new("int *", 1)
     codepoints = rl.load_codepoints(all_chars, codepoint_count)
-    print(f"Loading {codepoint_count[0]} unique glyphs")
 
     for index, font_file in enumerate(font_files):
       with as_file(FONT_DIR.joinpath(font_file)) as fspath:

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -190,12 +190,26 @@ class GuiApplication:
       "Inter-Black.ttf",
     )
 
+    # Create a character set from our keyboard layouts
+    from openpilot.system.ui.widgets.keyboard import KEYBOARD_LAYOUTS
+    all_chars = ""
+    for layout in KEYBOARD_LAYOUTS.values():
+      for row in layout:
+        for key in row:
+          all_chars += key
+    all_chars = "".join(set(all_chars))
+
+    codepoint_count = rl.ffi.new("int *", 1)
+    codepoints = rl.load_codepoints(all_chars, codepoint_count)
+    print(f"Loading {codepoint_count[0]} unique glyphs")
+
     for index, font_file in enumerate(font_files):
       with as_file(FONT_DIR.joinpath(font_file)) as fspath:
-        font = rl.load_font_ex(fspath.as_posix(), 120, None, 0)
+        font = rl.load_font_ex(fspath.as_posix(), 120, codepoints, codepoint_count[0])
         rl.set_texture_filter(font.texture, rl.TextureFilter.TEXTURE_FILTER_BILINEAR)
         self._fonts[index] = font
 
+    rl.unload_codepoints(codepoints)
     rl.gui_set_font(self._fonts[FontWeight.NORMAL])
 
   def _set_styles(self):


### PR DESCRIPTION
Generate a character set for loading fonts using all the keys in the keyboard widget layouts

Resolves issue with missing special characters

<img width="1624" alt="Screenshot 2025-05-20 at 15 33 15" src="https://github.com/user-attachments/assets/3bc4cc11-1752-44ef-85ed-067287b8cd9b" />
