### PR TITLE
feat(esim): enable eSIM profile hotswapping

### DIFF
--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
-
+import subprocess
+import time
 from openpilot.system.hardware import HARDWARE
 
 
@@ -14,15 +15,16 @@ if __name__ == '__main__':
   parser.add_argument('--nickname', nargs=2, metavar=('iccid', 'name'), help='update the nickname for a profile')
   args = parser.parse_args()
 
+  mutated = False
   lpa = HARDWARE.get_sim_lpa()
   if args.switch:
     lpa.switch_profile(args.switch)
-    HARDWARE.reboot_modem()
+    mutated = True
   elif args.delete:
     confirm = input('are you sure you want to delete this profile? (y/N) ')
     if confirm == 'y':
       lpa.delete_profile(args.delete)
-      HARDWARE.reboot_modem()
+      mutated = True
     else:
       print('cancelled')
       exit(0)
@@ -32,6 +34,11 @@ if __name__ == '__main__':
     lpa.nickname_profile(args.nickname[0], args.nickname[1])
   else:
     parser.print_help()
+
+  if mutated:
+    HARDWARE.reboot_modem()
+    while subprocess.run(['mmcli', '-i', 'any']).returncode != 0:
+      time.sleep(.1)
 
   profiles = lpa.list_profiles()
   print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -4,12 +4,6 @@ import argparse
 
 from openpilot.system.hardware import HARDWARE
 
-def print_profiles():
-  lpa = HARDWARE.get_sim_lpa()
-  profiles = lpa.list_profiles()
-  print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')
-  for p in profiles:
-    print(f'- {p.iccid} (nickname: {p.nickname or "<none provided>"}) (provider: {p.provider}) - {"enabled" if p.enabled else "disabled"}')
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')
@@ -39,4 +33,7 @@ if __name__ == '__main__':
   else:
     parser.print_help()
 
-  print_profiles()
+  profiles = lpa.list_profiles()
+  print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')
+  for p in profiles:
+    print(f'- {p.iccid} (nickname: {p.nickname or "<none provided>"}) (provider: {p.provider}) - {"enabled" if p.enabled else "disabled"}')

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -4,6 +4,26 @@ import argparse
 import time
 from openpilot.system.hardware import HARDWARE
 
+def print_profiles():
+  attempts = 3
+  fetched = False
+  while not fetched and attempts > 0:
+    try:
+      lpa = HARDWARE.get_sim_lpa()
+      profiles = lpa.list_profiles()
+      fetched = True
+    except Exception:
+      time.sleep(.1)
+      attempts -= 1
+
+  if not fetched:
+    print('failed to fetch profiles, please try again')
+    return
+
+  print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')
+  for p in profiles:
+    print(f'- {p.iccid} (nickname: {p.nickname or "<none provided>"}) (provider: {p.provider}) - {"enabled" if p.enabled else "disabled"}')
+
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')
@@ -36,10 +56,5 @@ if __name__ == '__main__':
 
   if mutated:
     HARDWARE.reboot_modem()
-    # eUICC needs a small delay post-reboot before querying profiles
-    time.sleep(.5)
 
-  profiles = lpa.list_profiles()
-  print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')
-  for p in profiles:
-    print(f'- {p.iccid} (nickname: {p.nickname or "<none provided>"}) (provider: {p.provider}) - {"enabled" if p.enabled else "disabled"}')
+  print_profiles()

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 
 import argparse
+import time
 
 from openpilot.system.hardware import HARDWARE
 
+def reboot_modem_and_wait():
+  """
+  since we're calling the modem right after, we need to wait a bit
+  to ensure the modem is ready to receive commands
+  """
+  HARDWARE.reboot_modem()
+  time.sleep(1)
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')
@@ -17,11 +25,12 @@ if __name__ == '__main__':
   lpa = HARDWARE.get_sim_lpa()
   if args.switch:
     lpa.switch_profile(args.switch)
+    reboot_modem_and_wait()
   elif args.delete:
     confirm = input('are you sure you want to delete this profile? (y/N) ')
     if confirm == 'y':
       lpa.delete_profile(args.delete)
-      print('deleted profile, please restart device to apply changes')
+      reboot_modem_and_wait()
     else:
       print('cancelled')
       exit(0)

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import subprocess
 import time
 
 from openpilot.system.hardware import HARDWARE
@@ -11,7 +12,8 @@ def reboot_modem_and_wait():
   to ensure the modem is ready to receive commands
   """
   HARDWARE.reboot_modem()
-  time.sleep(1)
+  while subprocess.run(['mmcli', '-m', 'any', '--3gpp-set-initial-eps-bearer-settings="apn="']).returncode != 0:
+    time.sleep(.1)
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import subprocess
 import time
 from openpilot.system.hardware import HARDWARE
 
@@ -37,8 +36,8 @@ if __name__ == '__main__':
 
   if mutated:
     HARDWARE.reboot_modem()
-    while subprocess.run(['mmcli', '-i', 'any']).returncode != 0:
-      time.sleep(.1)
+    # eUICC needs a small delay post-reboot before querying profiles
+    time.sleep(.5)
 
   profiles = lpa.list_profiles()
   print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -4,26 +4,6 @@ import argparse
 import time
 from openpilot.system.hardware import HARDWARE
 
-def print_profiles():
-  attempts = 3
-  fetched = False
-  while not fetched and attempts > 0:
-    try:
-      lpa = HARDWARE.get_sim_lpa()
-      profiles = lpa.list_profiles()
-      fetched = True
-    except Exception:
-      time.sleep(.1)
-      attempts -= 1
-
-  if not fetched:
-    print('failed to fetch profiles, please try again')
-    return
-
-  print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')
-  for p in profiles:
-    print(f'- {p.iccid} (nickname: {p.nickname or "<none provided>"}) (provider: {p.provider}) - {"enabled" if p.enabled else "disabled"}')
-
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')
@@ -56,5 +36,10 @@ if __name__ == '__main__':
 
   if mutated:
     HARDWARE.reboot_modem()
+    # eUICC needs a small delay post-reboot before querying profiles
+    time.sleep(.5)
 
-  print_profiles()
+  profiles = lpa.list_profiles()
+  print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')
+  for p in profiles:
+    print(f'- {p.iccid} (nickname: {p.nickname or "<none provided>"}) (provider: {p.provider}) - {"enabled" if p.enabled else "disabled"}')


### PR DESCRIPTION
related: https://github.com/commaai/openpilot/issues/34924

* add `reboot_modem` to hardware.py to reboot modem and re-load the SIM profile
* remove `esim.nmconnection` as we can rely on the standard [`lte.nmconnection`](https://github.com/commaai/agnos-builder/blob/master/userspace/files/lte.nmconnection) in `agnos-builder`

testing:
* ran branch on device, took snapshot on new-connect / upload queue view

![image](https://github.com/user-attachments/assets/b27b45b3-9668-40c4-b1d2-2c9caf96ff65)

```
comma@comma-bb546e42:/data/openpilot$ nmcli con show lte | grep IP4
IP4.ADDRESS[1]:                         10.XXX.XX.XX/25
IP4.GATEWAY:                            10.XXX.XX.XX
IP4.ROUTE[1]:                           dst = 10.XXX.XX.0/25, nh = 0.0.0.0, mt = 1000
IP4.ROUTE[2]:                           dst = 0.0.0.0/0, nh = 10.XXX.XX.XX, mt = 1000
IP4.DNS[1]:                             212.2.127.254
IP4.DNS[2]:                             212.2.96.52
```

---
[hotswap.webm](https://github.com/user-attachments/assets/589258f6-a9c1-4e6f-989c-48126e743093)

