### PR TITLE
feat(esim): athena bindings + LPA input validations

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -557,6 +557,7 @@ def downloadEsimProfile(qr: str, profile_name: str):
 @dispatcher.add_method
 def switchEsimProfile(iccid: str):
   HARDWARE.get_sim_lpa().switch_profile(iccid)
+  HARDWARE.reboot_modem()
 
 
 @dispatcher.add_method

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -8,7 +8,6 @@ import json
 import os
 import queue
 import random
-import re
 import select
 import socket
 import sys

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -8,6 +8,7 @@ import json
 import os
 import queue
 import random
+import re
 import select
 import socket
 import sys
@@ -550,8 +551,8 @@ def getEsimProfiles():
 
 
 @dispatcher.add_method
-def downloadEsimProfile(qr: str, profile_name: str):
-  HARDWARE.get_sim_lpa().download_profile(qr, profile_name)
+def downloadEsimProfile(lpa_activation_code: str, profile_name: str):
+  HARDWARE.get_sim_lpa().download_profile(lpa_activation_code, profile_name)
 
 
 @dispatcher.add_method

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -545,6 +545,21 @@ def getNetworks():
 
 
 @dispatcher.add_method
+def getEsimProfiles():
+  return [asdict(p) for p in HARDWARE.get_sim_lpa().list_profiles()]
+
+
+@dispatcher.add_method
+def downloadEsimProfile(qr: str, profile_name: str):
+  HARDWARE.get_sim_lpa().download_profile(qr, profile_name)
+
+
+@dispatcher.add_method
+def switchEsimProfile(iccid: str):
+  HARDWARE.get_sim_lpa().switch_profile(iccid)
+
+
+@dispatcher.add_method
 def takeSnapshot() -> str | dict[str, str] | None:
   from openpilot.system.camerad.snapshot import jpeg_write, snapshot
   ret = snapshot()

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -555,7 +555,7 @@ def downloadEsimProfile(qr: str, profile_name: str):
 
 
 @dispatcher.add_method
-def switchEsimProfile(iccid: str):
+def setEsimProfile(iccid: str):
   HARDWARE.get_sim_lpa().switch_profile(iccid)
   HARDWARE.reboot_modem()
 

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -108,18 +108,14 @@ class TiciLPA(LPABase):
     self._validate_successful(self._invoke('notification', 'process', '-a', '-r'))
 
   def _validate_iccid(self, iccid: str) -> None:
-    if not re.match(r'^89\d{17,18}$', iccid):
-      raise ValueError('invalid ICCID format. expected format: 8988303000000614227')
+    assert re.match(r'^89\d{17,18}$', iccid), 'invalid ICCID format. expected format: 8988303000000614227'
 
   def _validate_lpa_activation_code(self, lpa_activation_code: str) -> None:
-    if not re.match(r'^LPA:1\$\w+\$\w+$', lpa_activation_code):
-      raise ValueError('invalid LPA activation code format. expected format: LPA:1$domain$code')
+    assert re.match(r'^LPA:1\$.+\$.+$', lpa_activation_code), 'invalid LPA activation code format. expected format: LPA:1$domain$code'
 
   def _validate_nickname(self, nickname: str) -> None:
-    if len(nickname) < 1 or len(nickname) > 16:
-      raise ValueError('nickname must be between 1 and 16 characters')
-    if not re.match(r'^[a-zA-Z0-9]+$', nickname):
-      raise ValueError('nickname must contain only alphanumeric characters')
+    assert len(nickname) >= 1 and len(nickname) <= 16, 'nickname must be between 1 and 16 characters'
+    assert re.match(r'^[a-zA-Z0-9-_ ]+$', nickname), 'nickname must contain only alphanumeric characters, hyphens, underscores, and spaces'
 
   def _validate_profile_exists(self, iccid: str) -> None:
     if not any(p.iccid == iccid for p in self.list_profiles()):


### PR DESCRIPTION
related: https://github.com/commaai/openpilot/issues/34924

not adding `delete_profile` here for now. too risky for user to accidentally delete profile and not be able to recover it.

---

### happy case (get profiles)
![image](https://github.com/user-attachments/assets/81c3d68c-935f-4a6e-b1f4-2edb0a05adc5)

### happy case (download profile)
[esim-athena.webm](https://github.com/user-attachments/assets/2dc69c3b-98b7-49d9-a327-d72ae498a378)


### sad case (enable invalid profile)
![image](https://github.com/user-attachments/assets/74d8da46-fd8c-4438-990c-05773b09b71e)
