### PR TITLE
LogReader: Auto interactive improvements

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -124,7 +124,8 @@ def auto_strategy(rlog_paths: list[LogPath], qlog_paths: list[LogPath], interact
   if missing_rlogs != 0 and missing_qlogs == 0:
     if interactive:
       if input(f"{missing_rlogs}/{len(rlog_paths)} rlogs were not found, would you like to fallback to qlogs for those segments? (y/n) ").lower() != "y":
-        return rlog_paths
+        cloudlog.warning(f"{missing_rlogs}/{len(rlog_paths)} rlogs were not found, returning only valid rlogs...")
+        return [rlog if valid_file(rlog) else None for rlog in rlog_paths]
     else:
       cloudlog.warning(f"{missing_rlogs}/{len(rlog_paths)} rlogs were not found, falling back to qlogs for those segments...")
 
@@ -209,6 +210,9 @@ def get_invalid_files(files):
 
 def check_source(source: Source, *args) -> list[LogPath]:
   files = source(*args)
+  if args[1] == ReadMode.AUTO_INTERACTIVE:
+    # if any files are invalid, return the valid ones
+    files = [f for f in files if f is not None and file_exists(f)]
   assert len(files) > 0, "No files on source"
   assert next(get_invalid_files(files), False) is False, "Some files are invalid"
   return files

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -120,7 +120,8 @@ def default_valid_file(fn: LogPath) -> bool:
 def auto_strategy(rlog_paths: list[LogPath], qlog_paths: list[LogPath], interactive: bool, valid_file: ValidFileCallable) -> list[LogPath]:
   # auto select logs based on availability
   missing_rlogs = [rlog is None or not valid_file(rlog) for rlog in rlog_paths].count(True)
-  if missing_rlogs != 0:
+  missing_qlogs = [qlog is None or not valid_file(qlog) for qlog in qlog_paths].count(True)
+  if missing_rlogs != 0 and missing_qlogs == 0:
     if interactive:
       if input(f"{missing_rlogs}/{len(rlog_paths)} rlogs were not found, would you like to fallback to qlogs for those segments? (y/n) ").lower() != "y":
         return rlog_paths


### PR DESCRIPTION
Currently, if the user does not fallback the qlogs, the program ends. This allows the valid rlogs to be used if the user does not fallback to qlogs. Also, it will try to fallback to qlogs even if the source doesn't have them so it asks every time.

Current:
```
./tools/plotjuggler/juggle.py '3b58edf884ab4eaf|00000035--783894e08a/3:5'
2/2 rlogs were not found, would you like to fallback to qlogs for those segments? (y/n) n
2/2 rlogs were not found, would you like to fallback to qlogs for those segments? (y/n) n
1/2 rlogs were not found, would you like to fallback to qlogs for those segments? (y/n) n
Traceback (most recent call last):
...
  - comma_api_source: AssertionError('Some files are invalid')
...

```

New:
```
1/2 rlogs were not found, would you like to fallback to qlogs for those segments? (y/n) n
1/2 rlogs were not found, returning only valid rlogs...
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.47s/it]
```