### PR TITLE
esim: faster switching

### DIFF
--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -59,10 +59,8 @@ class TiciLPA(LPABase):
   def _enable_profile(self, iccid: str) -> None:
     self._validate_profile_exists(iccid)
     latest = self.get_active_profile()
-    if latest:
-      if latest.iccid == iccid:
-        return
-      self._validate_successful(self._invoke('profile', 'disable', latest.iccid))
+    if latest and latest.iccid == iccid:
+      return
     self._validate_successful(self._invoke('profile', 'enable', iccid))
     self._process_notifications()
 

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -54,9 +54,6 @@ class TiciLPA(LPABase):
     self._validate_successful(self._invoke('profile', 'nickname', iccid, nickname))
 
   def switch_profile(self, iccid: str) -> None:
-    self._enable_profile(iccid)
-
-  def _enable_profile(self, iccid: str) -> None:
     self._validate_profile_exists(iccid)
     latest = self.get_active_profile()
     if latest and latest.iccid == iccid:


### PR DESCRIPTION
`lpac` doesn't need to disable current profile to enable another, it switches profiles automatically.