### PR TITLE
system/ui: cache shader location

### DIFF
--- a/system/ui/widgets/cameraview.py
+++ b/system/ui/widgets/cameraview.py
@@ -60,6 +60,7 @@ class CameraView:
     self._texture_needs_update = True
     self.last_connection_attempt: float = 0.0
     self.shader = rl.load_shader_from_memory(VERTEX_SHADER, FRAME_FRAGMENT_SHADER)
+    self._texture1_loc: int = rl.get_shader_location(self.shader, "texture1") if not TICI else -1
 
     self.frame: VisionBuf | None = None
     self.texture_y: rl.Texture | None = None
@@ -188,7 +189,7 @@ class CameraView:
 
     # Render with shader
     rl.begin_shader_mode(self.shader)
-    rl.set_shader_value_texture(self.shader, rl.get_shader_location(self.shader, "texture1"), self.texture_uv)
+    rl.set_shader_value_texture(self.shader, self._texture1_loc, self.texture_uv)
     rl.draw_texture_pro(self.texture_y, src_rect, dst_rect, rl.Vector2(0, 0), 0.0, rl.WHITE)
     rl.end_shader_mode()
 


### PR DESCRIPTION
cached shader location  to avoid repeated `rl.get_shader_location ` calls.