### PR TITLE
Invalid LKAS setting alert: custom text per brand

### DIFF
--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -364,9 +364,9 @@ def invalid_lkas_setting_alert(CP: car.CarParams, CS: car.CarState, sm: messagin
   if CP.brand == "tesla":
     text = "Switch to Traffic Aware Cruise to engage"
   elif CP.brand == "mazda":
-    text = "LKAS Disabled: Enable stock LKAS to engage"
+    text = "LKAS Disabled: Turn on stock LKAS to engage"
   elif CP.brand == "nissan":
-    text = "LKAS Enabled: Disable stock LKAS to engage"
+    text = "LKAS Enabled: Turn off stock LKAS to engage"
   return NormalPermanentAlert("Invalid LKAS setting", text)
 
 

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -362,7 +362,7 @@ def personality_changed_alert(CP: car.CarParams, CS: car.CarState, sm: messaging
 def invalid_lkas_setting_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
   text = "Toggle stock LKAS on or off to engage"
   if CP.brand == "tesla":
-    text = "Switch to Traffic Aware Cruise Control to engage"
+    text = "Switch to Traffic-Aware Cruise Control to engage"
   elif CP.brand == "mazda":
     text = "Enable your car's LKAS to engage"
   elif CP.brand == "nissan":

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -359,6 +359,17 @@ def personality_changed_alert(CP: car.CarParams, CS: car.CarState, sm: messaging
   return NormalPermanentAlert(f"Driving Personality: {personality}", duration=1.5)
 
 
+def invalid_lkas_setting_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
+  text = "Toggle stock LKAS on or off to engage"
+  if CP.brand == "tesla":
+    text = "Enable Traffic Aware Cruise to Engage"
+  elif CP.brand == "mazda":
+    text = "Enable Adaptive Cruise to Engage"
+  elif CP.brand == "nissan":
+    text = "Enable Adaptive Cruise to Engage"
+  return NormalPermanentAlert("Invalid LKAS setting",
+                              "Toggle stock LKAS on or off to engage")
+
 
 EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   # ********** events with no alerts **********
@@ -412,8 +423,9 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   },
 
   EventName.invalidLkasSetting: {
-    ET.PERMANENT: NormalPermanentAlert("Invalid LKAS setting",
-                                       "Toggle stock LKAS on or off to engage"),
+    # ET.PERMANENT: NormalPermanentAlert("Invalid LKAS setting",
+    #                                    "Toggle stock LKAS on or off to engage"),
+    ET.PERMANENT: invalid_lkas_setting_alert,
     ET.NO_ENTRY: NoEntryAlert("Invalid LKAS setting"),
   },
 

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -362,13 +362,12 @@ def personality_changed_alert(CP: car.CarParams, CS: car.CarState, sm: messaging
 def invalid_lkas_setting_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
   text = "Toggle stock LKAS on or off to engage"
   if CP.brand == "tesla":
-    text = "Enable Traffic Aware Cruise to Engage"
+    text = "Switch to Traffic Aware Cruise to engage"
   elif CP.brand == "mazda":
-    text = "Enable Adaptive Cruise to Engage"
+    text = "LKAS Disabled: Enable stock LKAS to engage"
   elif CP.brand == "nissan":
-    text = "Enable Adaptive Cruise to Engage"
-  return NormalPermanentAlert("Invalid LKAS setting",
-                              "Toggle stock LKAS on or off to engage")
+    text = "LKAS Enabled: Disable stock LKAS to engage"
+  return NormalPermanentAlert("Invalid LKAS setting", text)
 
 
 EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -422,8 +422,6 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   },
 
   EventName.invalidLkasSetting: {
-    # ET.PERMANENT: NormalPermanentAlert("Invalid LKAS setting",
-    #                                    "Toggle stock LKAS on or off to engage"),
     ET.PERMANENT: invalid_lkas_setting_alert,
     ET.NO_ENTRY: NoEntryAlert("Invalid LKAS setting"),
   },

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -364,9 +364,9 @@ def invalid_lkas_setting_alert(CP: car.CarParams, CS: car.CarState, sm: messagin
   if CP.brand == "tesla":
     text = "Switch to Traffic Aware Cruise Control to engage"
   elif CP.brand == "mazda":
-    text = "LKAS Disabled: Turn on stock LKAS to engage"
+    text = "Enable your car's LKAS to engage"
   elif CP.brand == "nissan":
-    text = "LKAS Enabled: Turn off stock LKAS to engage"
+    text = "Disable your car's stock LKAS to engage"
   return NormalPermanentAlert("Invalid LKAS setting", text)
 
 

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -362,7 +362,7 @@ def personality_changed_alert(CP: car.CarParams, CS: car.CarState, sm: messaging
 def invalid_lkas_setting_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
   text = "Toggle stock LKAS on or off to engage"
   if CP.brand == "tesla":
-    text = "Switch to Traffic Aware Cruise to engage"
+    text = "Switch to Traffic Aware Cruise Control to engage"
   elif CP.brand == "mazda":
     text = "LKAS Disabled: Turn on stock LKAS to engage"
   elif CP.brand == "nissan":


### PR DESCRIPTION
Closes https://github.com/commaai/opendbc/issues/2322

We already follow this pattern for Honda. selfdrived doesn't have the car interface object, so we can't pass in anything outside of capnp just yet

https://github.com/commaai/openpilot/blob/618645f1d7eaec635514e712bac4582691b38862/selfdrive/selfdrived/events.py#L333-L337