### PR TITLE
system/ui: fix cruise disabled state displaying "?" instead of "–"

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -192,10 +192,12 @@ class GuiApplication:
 
     # Create a character set from our keyboard layouts
     from openpilot.system.ui.widgets.keyboard import KEYBOARD_LAYOUTS
+    from openpilot.system.ui.onroad.hud_renderer import CRUISE_DISABLED_CHAR
     all_chars = set()
     for layout in KEYBOARD_LAYOUTS.values():
       all_chars.update(key for row in layout for key in row)
     all_chars = "".join(all_chars)
+    all_chars += CRUISE_DISABLED_CHAR
 
     codepoint_count = rl.ffi.new("int *", 1)
     codepoints = rl.load_codepoints(all_chars, codepoint_count)

--- a/system/ui/onroad/hud_renderer.py
+++ b/system/ui/onroad/hud_renderer.py
@@ -8,6 +8,7 @@ from enum import IntEnum
 # Constants
 SET_SPEED_NA = 255
 KM_TO_MILE = 0.621371
+CRUISE_DISABLED_CHAR = '–'
 
 
 @dataclass(frozen=True)
@@ -153,7 +154,7 @@ class HudRenderer:
       max_color,
     )
 
-    set_speed_text = "–" if not self.is_cruise_set else str(round(self.set_speed))
+    set_speed_text = CRUISE_DISABLED_CHAR if not self.is_cruise_set else str(round(self.set_speed))
     speed_text_width = self._measure_text(set_speed_text, self._font_bold, FONT_SIZES.set_speed, 'bold').x
     rl.draw_text_ex(
       self._font_bold,


### PR DESCRIPTION
before:
![Screenshot 2025-06-01 22:26:48](https://github.com/user-attachments/assets/7ed23b06-b9fa-4fb8-8bd5-7f2b6085cdd9)
after:
![Screenshot 2025-06-01 22:21:13](https://github.com/user-attachments/assets/e03fae1f-b2ae-4143-805d-a7f9042fc2ed)
