### PR TITLE
system/ui: add text measurement caching

### DIFF
--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -5,6 +5,7 @@ from cereal import messaging, log
 from openpilot.system.hardware import TICI
 from openpilot.system.ui.lib.application import gui_app, FontWeight, DEBUG_FPS
 from openpilot.system.ui.lib.label import gui_text_box
+from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.selfdrive.ui.ui_state import ui_state
 
 
@@ -64,7 +65,6 @@ class AlertRenderer:
   def __init__(self):
     self.font_regular: rl.Font = gui_app.font(FontWeight.NORMAL)
     self.font_bold: rl.Font = gui_app.font(FontWeight.BOLD)
-    self.font_metrics_cache: dict[tuple[str, int, str], rl.Vector2] = {}
 
   def get_alert(self, sm: messaging.SubMaster) -> Alert | None:
     """Generate the current alert based on selfdrive state."""
@@ -152,14 +152,8 @@ class AlertRenderer:
       text_rect.y = rect.y + rect.height // 2
       gui_text_box(text_rect, alert.text2, ALERT_FONT_BIG, alignment=align_ment)
 
-  def _measure_text(self, font: rl.Font, text: str, font_size: int, font_type: str) -> rl.Vector2:
-    key = (text, font_size, font_type)
-    if key not in self.font_metrics_cache:
-      self.font_metrics_cache[key] = rl.measure_text_ex(font, text, font_size, 0)
-    return self.font_metrics_cache[key]
-
   def _draw_centered(self, text, rect, font, font_size, center_y=True, color=rl.WHITE) -> None:
-    text_size = self._measure_text(font, text, font_size, 'bold' if font == self.font_bold else 'regular')
+    text_size = measure_text_cached(font, text, font_size)
     x = rect.x + (rect.width - text_size.x) / 2
     y = rect.y + ((rect.height - text_size.y) / 2 if center_y else 0)
     rl.draw_text_ex(font, text, rl.Vector2(x, y), font_size, 0, color)

--- a/system/ui/lib/text_measure.py
+++ b/system/ui/lib/text_measure.py
@@ -1,0 +1,13 @@
+import pyray as rl
+
+_cache: dict[int, rl.Vector2] = {}
+
+
+def measure_text_cached(font: rl.Font, text: str, font_size: int, spacing: int = 0) -> rl.Vector2:
+  key = hash((font.texture.id, text, font_size, spacing))
+  if key in _cache:
+    return _cache[key]
+
+  result = rl.measure_text_ex(font, text, font_size, spacing)
+  _cache[key] = result
+  return result


### PR DESCRIPTION
Introduces a centralized text measurement cache in `text_measure.py` to improve UI rendering performance by avoiding redundant calls to raylib's `measure_text_ex`