### PR TITLE
ui: add auto camera switching based on speed in experimental mode

### DIFF
--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -54,8 +54,7 @@ class AugmentedRoadView(CameraView):
     if not ui_state.started:
       return
 
-    sm = ui_state.sm
-    self._switch_stream_if_needed(sm)
+    self._switch_stream_if_needed(ui_state.sm)
 
     # Update calibration before rendering
     self._update_calibration()
@@ -84,10 +83,10 @@ class AugmentedRoadView(CameraView):
     super().render(rect)
 
     # Draw all UI overlays
-    self.model_renderer.draw(self._content_rect, sm)
-    self._hud_renderer.draw(self._content_rect, sm)
-    self.alert_renderer.draw(self._content_rect, sm)
-    self.driver_state_renderer.draw(self._content_rect, sm)
+    self.model_renderer.render(self._content_rect)
+    self._hud_renderer.render(self._content_rect)
+    self.alert_renderer.render(self._content_rect)
+    self.driver_state_renderer.render(self._content_rect)
 
     # Custom UI extension point - add custom overlays here
     # Use self._content_rect for positioning within camera bounds

--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -25,6 +25,9 @@ BORDER_COLORS = {
   UIStatus.ENGAGED: rl.Color(0x17, 0x86, 0x44, 0xF1),      # Green for engaged state
 }
 
+WIDE_CAM_MAX_SPEED = 10.0  # m/s (22 mph)
+ROAD_CAM_MIN_SPEED = 15.0  # m/s (34 mph)
+
 
 class AugmentedRoadView(CameraView):
   def __init__(self, stream_type: VisionStreamType = VisionStreamType.VISION_STREAM_ROAD):
@@ -50,6 +53,9 @@ class AugmentedRoadView(CameraView):
     # Only render when system is started to avoid invalid data access
     if not ui_state.started:
       return
+
+    sm = ui_state.sm
+    self._switch_stream_if_needed(sm)
 
     # Update calibration before rendering
     self._update_calibration()
@@ -78,10 +84,10 @@ class AugmentedRoadView(CameraView):
     super().render(rect)
 
     # Draw all UI overlays
-    self.model_renderer.draw(self._content_rect, ui_state.sm)
-    self._hud_renderer.draw(self._content_rect, ui_state.sm)
-    self.alert_renderer.draw(self._content_rect, ui_state.sm)
-    self.driver_state_renderer.draw(self._content_rect, ui_state.sm)
+    self.model_renderer.draw(self._content_rect, sm)
+    self._hud_renderer.draw(self._content_rect, sm)
+    self.alert_renderer.draw(self._content_rect, sm)
+    self.driver_state_renderer.draw(self._content_rect, sm)
 
     # Custom UI extension point - add custom overlays here
     # Use self._content_rect for positioning within camera bounds
@@ -92,6 +98,22 @@ class AugmentedRoadView(CameraView):
   def _draw_border(self, rect: rl.Rectangle):
     border_color = BORDER_COLORS.get(ui_state.status, BORDER_COLORS[UIStatus.DISENGAGED])
     rl.draw_rectangle_lines_ex(rect, UI_BORDER_SIZE, border_color)
+
+  def _switch_stream_if_needed(self, sm):
+    if sm['selfdriveState'].experimentalMode and WIDE_CAM in self.available_streams:
+      v_ego = sm['carState'].vEgo
+      if v_ego < WIDE_CAM_MAX_SPEED:
+        target = WIDE_CAM
+      elif v_ego > ROAD_CAM_MIN_SPEED:
+        target = ROAD_CAM
+      else:
+        # Hysteresis zone - keep current stream
+        target = self.stream_type
+    else:
+      target = ROAD_CAM
+
+    if self.stream_type != target:
+      self.switch_stream(target)
 
   def _update_calibration(self):
     # Update device camera if not already set
@@ -128,7 +150,7 @@ class AugmentedRoadView(CameraView):
 
     # Get camera configuration
     device_camera = self.device_camera or DEFAULT_DEVICE_CAMERA
-    is_wide_camera = self.stream_type == VisionStreamType.VISION_STREAM_WIDE_ROAD
+    is_wide_camera = self.stream_type == WIDE_CAM
     intrinsic = device_camera.ecam.intrinsics if is_wide_camera else device_camera.fcam.intrinsics
     calibration = self.view_from_wide_calib if is_wide_camera else self.view_from_calib
     zoom = 2.0 if is_wide_camera else 1.1


### PR DESCRIPTION
1. Fetch `available_streams` in `CameraView` after connection to enable stream availability validation.
2. Implemented automatic camera switching in `AugmentedRoadView`
3. Updated demo app to check stream availability before switching streams on spacebar press.