### PR TITLE
selfdrive/ui: enable conflate mode in VisionIpcClient to prevent stale frame rendering

### DIFF
--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -57,7 +57,7 @@ else:
 
 class CameraView:
   def __init__(self, name: str, stream_type: VisionStreamType):
-    self.client = VisionIpcClient(name, stream_type, False)
+    self.client = VisionIpcClient(name, stream_type, conflate=True)
     self._name = name
     self._stream_type = stream_type
 
@@ -90,7 +90,7 @@ class CameraView:
       self._clear_textures()
       self.frame = None
       self._stream_type = stream_type
-      self.client = VisionIpcClient(self._name, stream_type, False)
+      self.client = VisionIpcClient(self._name, stream_type, conflate=True)
 
   @property
   def stream_type(self) -> VisionStreamType:


### PR DESCRIPTION
Enabled conflate mode to prevent rendering stale video frames. Fixes issue https://github.com/commaai/openpilot/pull/35422#issuecomment-2937449465, the camera view showed outdated frames from the buffer queue when switching interfaces or during performance-related frame drops, causing a jarring user experience.