### PR TITLE
macos: no logcatd and proclogd

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -342,13 +342,13 @@ SConscript(['rednose/SConscript'])
 
 # Build system services
 SConscript([
-  'system/proclogd/SConscript',
   'system/ubloxd/SConscript',
   'system/loggerd/SConscript',
 ])
 if arch != "Darwin":
   SConscript([
     'system/logcatd/SConscript',
+    'system/proclogd/SConscript',
   ])
 
 if arch == "larch64":

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -1,5 +1,6 @@
 import os
 import operator
+import platform
 
 from cereal import car
 from openpilot.common.params import Params
@@ -70,8 +71,8 @@ procs = [
 
   NativeProcess("camerad", "system/camerad", ["./camerad"], driverview, enabled=not WEBCAM),
   PythonProcess("webcamerad", "tools.webcam.camerad", driverview, enabled=WEBCAM),
-  NativeProcess("logcatd", "system/logcatd", ["./logcatd"], only_onroad),
-  NativeProcess("proclogd", "system/proclogd", ["./proclogd"], only_onroad),
+  NativeProcess("logcatd", "system/logcatd", ["./logcatd"], only_onroad, platform.system() != "Darwin"),
+  NativeProcess("proclogd", "system/proclogd", ["./proclogd"], only_onroad, platform.system() != "Darwin"),
   PythonProcess("micd", "system.micd", iscar),
   PythonProcess("timed", "system.timed", always_run, enabled=not PC),
 


### PR DESCRIPTION
Split from https://github.com/commaai/openpilot/pull/35143 (dirty comma zero):
- don't build `proclogd` on mac
- don't run `logcatd` and `proclogd` on mac