### PR TITLE
system/ui:  fix setup error: 'WifiManagerWrapper' object has no attribute 'request_scan'

### DIFF
--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -116,7 +116,6 @@ class Setup:
 
     if ret:
       self.state = SetupState.NETWORK_SETUP
-      self.wifi_manager.request_scan()
       self.start_network_check()
 
   def check_network_connectivity(self):


### PR DESCRIPTION
removes the invalid call to the non-existent `request_scan` function in the WiFi Manager. The WiFi Manager now automatically initiates a scan upon initialization.