### PR TITLE
ui: implement reset calibration feature in device settings

### DIFF
--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -90,8 +90,8 @@ class DeviceLayout(Widget):
       callback=self._reset_calibration,
     )
 
-  def _reset_calibration(self):
-    if ui_state.engaged:
+  def _reset_calibration(self, result: int):
+    if ui_state.engaged or result != 1:
       return
 
     self._params.remove("CalibrationParams")

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -77,9 +77,6 @@ class DeviceLayout(Widget):
 
     gui_app.set_modal_overlay(self._driver_camera, callback=lambda result: setattr(self, '_driver_camera', None))
 
-  def _on_pair_device(self): pass
-  def _on_reset_calibration(self): pass
-
   def _on_reset_calibration(self):
     if ui_state.engaged:
       gui_app.set_modal_overlay(lambda: alert_dialog("Disengage to Reset Calibration"))
@@ -102,6 +99,5 @@ class DeviceLayout(Widget):
     self._params.put_bool("OnroadCycleRequested", True)
 
   def _on_pair_device(self): pass
-  def _on_driver_camera(self): pass
   def _on_review_training_guide(self): pass
   def _on_regulatory(self): pass

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -6,7 +6,7 @@ from openpilot.common.params import Params
 from openpilot.selfdrive.ui.onroad.driver_camera_dialog import DriverCameraDialog
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.hardware import TICI
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app, Widget, DialogResult
 from openpilot.system.ui.lib.list_view import ListView, text_item, button_item
 from openpilot.system.ui.widgets.option_dialog import MultiOptionDialog
 from openpilot.system.ui.widgets.confirm_dialog import confirm_dialog, alert_dialog
@@ -91,7 +91,7 @@ class DeviceLayout(Widget):
     )
 
   def _reset_calibration(self, result: int):
-    if ui_state.engaged or result != 1:
+    if ui_state.engaged or result != DialogResult.CONFIRM:
       return
 
     self._params.remove("CalibrationParams")

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -205,9 +205,11 @@ class GuiApplication:
           else:
             raise Exception
 
-          if result >= 0 and self._modal_overlay.callback is not None:
+          if result >= 0:
             # Execute callback with the result and clear the overlay
-            self._modal_overlay.callback(result)
+            if self._modal_overlay.callback is not None:
+              self._modal_overlay.callback(result)
+
             self._modal_overlay = ModalOverlay()
         else:
           yield

--- a/system/ui/widgets/confirm_dialog.py
+++ b/system/ui/widgets/confirm_dialog.py
@@ -63,5 +63,6 @@ def confirm_dialog(message: str, confirm_text: str, cancel_text: str = "Cancel")
 
   return result
 
+
 def alert_dialog(message: str, button_text: str = "OK") -> int:
   return confirm_dialog(message, button_text, cancel_text="")

--- a/system/ui/widgets/confirm_dialog.py
+++ b/system/ui/widgets/confirm_dialog.py
@@ -64,5 +64,5 @@ def confirm_dialog(message: str, confirm_text: str, cancel_text: str = "Cancel")
   return result
 
 
-def alert_dialog(message: str, button_text: str = "OK") -> int:
+def alert_dialog(message: str, button_text: str = "OK") -> DialogResult:
   return confirm_dialog(message, button_text, cancel_text="")

--- a/system/ui/widgets/confirm_dialog.py
+++ b/system/ui/widgets/confirm_dialog.py
@@ -1,5 +1,5 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import gui_app, DialogResult
+from openpilot.system.ui.lib.application import gui_app, DialogResult, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.label import gui_text_box
 
@@ -30,13 +30,14 @@ def confirm_dialog(message: str, confirm_text: str, cancel_text: str = "Cancel")
   rl.draw_rectangle_rec(dialog_rect, BACKGROUND_COLOR)
 
   # Draw the message in the dialog, centered
-  text_rect = rl.Rectangle(dialog_rect.x, dialog_rect.y, dialog_rect.width, dialog_rect.height - TEXT_AREA_HEIGHT_REDUCTION)
+  text_rect = rl.Rectangle(dialog_rect.x + MARGIN, dialog_rect.y, dialog_rect.width - 2 * MARGIN, dialog_rect.height - TEXT_AREA_HEIGHT_REDUCTION)
   gui_text_box(
     text_rect,
     message,
-    font_size=88,
+    font_size=70,
     alignment=rl.GuiTextAlignment.TEXT_ALIGN_CENTER,
     alignment_vertical=rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE,
+    font_weight=FontWeight.BOLD,
   )
 
   # Initialize result; -1 means no action taken yet
@@ -49,9 +50,18 @@ def confirm_dialog(message: str, confirm_text: str, cancel_text: str = "Cancel")
     result = DialogResult.CANCEL
 
   # Check for button clicks
-  if gui_button(yes_button, confirm_text, button_style=ButtonStyle.PRIMARY):
-    result = DialogResult.CONFIRM
-  if gui_button(no_button, cancel_text):
-    result = DialogResult.CANCEL
+  if cancel_text:
+    if gui_button(yes_button, confirm_text, button_style=ButtonStyle.PRIMARY):
+      result = DialogResult.CONFIRM
+    if gui_button(no_button, cancel_text):
+      result = DialogResult.CANCEL
+  else:
+    centered_button_x = dialog_rect.x + (dialog_rect.width - button_width) / 2
+    centered_yes_button = rl.Rectangle(centered_button_x, button_y, button_width, BUTTON_HEIGHT)
+    if gui_button(centered_yes_button, confirm_text, button_style=ButtonStyle.PRIMARY):
+      result = DialogResult.CONFIRM
 
   return result
+
+def alert_dialog(message: str, button_text: str = "OK") -> int:
+  return confirm_dialog(message, button_text, cancel_text="")


### PR DESCRIPTION
1. Added `alert_dialog()` function to display alert dialogs
2. Implement reset calibration feature in device settings

![2025-06-07_02-20](https://github.com/user-attachments/assets/b810d5aa-d298-43b9-bd07-27bbb3b6d1a9)
![2025-06-07_02-23](https://github.com/user-attachments/assets/7dabdb24-ea73-489a-a59e-097c67f05354)


I plan to first implement all the interactive settings in the Settings page. All other non-interactive settings will be handled later. This approach will help us identify issues and refine the interaction design of our current UI framework.