### PR TITLE
raylib: simpler callbacks

### DIFF
--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -21,7 +21,6 @@ class MainLayout(Widget):
     self._current_mode = MainState.HOME
     self._prev_onroad = False
     self._window_rect = None
-    self._current_callback: callable | None = None
 
     # Initialize layouts
     self._layouts = {MainState.HOME: HomeLayout(), MainState.SETTINGS: SettingsLayout(), MainState.ONROAD: AugmentedRoadView()}
@@ -33,24 +32,22 @@ class MainLayout(Widget):
     self._setup_callbacks()
 
   def render(self, rect):
-    self._current_callback = None
-
     self._update_layout_rects(rect)
     self._handle_onroad_transition()
     self._render_main_content()
     self._handle_input()
 
-    if self._current_callback:
-      self._current_callback()
-
   def _setup_callbacks(self):
-    self._sidebar.set_callbacks(
-      on_settings=lambda: setattr(self, '_current_callback', self._on_settings_clicked),
-      on_flag=lambda: setattr(self, '_current_callback', self._on_flag_clicked),
-    )
-    self._layouts[MainState.SETTINGS].set_callbacks(
-      on_close=lambda: setattr(self, '_current_callback', self._set_mode_for_state)
-    )
+    # self._sidebar.set_callbacks(
+    #   on_settings=lambda: setattr(self, '_current_callback', self._on_settings_clicked),
+    #   on_flag=lambda: setattr(self, '_current_callback', self._on_flag_clicked),
+    # )
+    self._sidebar.set_callbacks(on_settings=self._on_settings_clicked,
+                                on_flag=self._on_flag_clicked)
+    # self._layouts[MainState.SETTINGS].set_callbacks(
+    #   on_close=lambda: setattr(self, '_current_callback', self._set_mode_for_state)
+    # )
+    self._layouts[MainState.SETTINGS].set_callbacks(on_close=self._set_mode_for_state)
 
   def _update_layout_rects(self, rect):
     self._window_rect = rect

--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -38,15 +38,8 @@ class MainLayout(Widget):
     self._handle_input()
 
   def _setup_callbacks(self):
-    # self._sidebar.set_callbacks(
-    #   on_settings=lambda: setattr(self, '_current_callback', self._on_settings_clicked),
-    #   on_flag=lambda: setattr(self, '_current_callback', self._on_flag_clicked),
-    # )
     self._sidebar.set_callbacks(on_settings=self._on_settings_clicked,
                                 on_flag=self._on_flag_clicked)
-    # self._layouts[MainState.SETTINGS].set_callbacks(
-    #   on_close=lambda: setattr(self, '_current_callback', self._set_mode_for_state)
-    # )
     self._layouts[MainState.SETTINGS].set_callbacks(on_close=self._set_mode_for_state)
 
   def _update_layout_rects(self, rect):

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -82,6 +82,8 @@ class SettingsLayout(Widget):
     self._draw_sidebar(sidebar_rect)
     self._draw_current_panel(panel_rect)
 
+    print(rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT))
+
     if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
       self.handle_mouse_release(rl.get_mouse_position())
 

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -82,7 +82,8 @@ class SettingsLayout(Widget):
     self._draw_sidebar(sidebar_rect)
     self._draw_current_panel(panel_rect)
 
-    print(rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT))
+    print(rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT),
+          rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT))
 
     if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
       self.handle_mouse_release(rl.get_mouse_position())

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -83,9 +83,6 @@ class SettingsLayout(Widget):
     self._draw_sidebar(sidebar_rect)
     self._draw_current_panel(panel_rect)
 
-    print(rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT),
-          rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT))
-
   def _draw_sidebar(self, rect: rl.Rectangle):
     rl.draw_rectangle_rec(rect, SIDEBAR_COLOR)
 

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -82,8 +82,6 @@ class SettingsLayout(Widget):
     self._draw_sidebar(sidebar_rect)
     self._draw_current_panel(panel_rect)
 
-    print(rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT), rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT))
-
     if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
       self.handle_mouse_release(rl.get_mouse_position())
 


### PR DESCRIPTION
It seems simpler to me if the children widgets call the callback functions directly rather than telling the parent to run them via dynamic setattr.

This exposes some more touch/mouse press detection issues. Now mouse up when clicking settings will be handled by sidebar and settings, opening and closing it immediately.

We should handle this by ensuring the widget also gets the down event, not just released (a bug with other widgets too)