### PR TITLE
ui: [fix] only show driver state icon when no alert is display

### DIFF
--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -8,7 +8,6 @@ from openpilot.selfdrive.ui.widgets.exp_mode_button import ExperimentalModeButto
 from openpilot.selfdrive.ui.widgets.prime import PrimeWidget
 from openpilot.selfdrive.ui.widgets.setup import SetupWidget
 from openpilot.system.ui.lib.text_measure import measure_text_cached
-from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_TEXT_COLOR, Widget
 
 HEADER_HEIGHT = 80

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -92,10 +92,10 @@ class AlertRenderer(Widget):
     # Return current alert
     return Alert(text1=ss.alertText1, text2=ss.alertText2, size=ss.alertSize, status=ss.alertStatus)
 
-  def _render(self, rect: rl.Rectangle) -> None:
+  def _render(self, rect: rl.Rectangle) -> bool:
     alert = self.get_alert(ui_state.sm)
     if not alert:
-      return
+      return False
 
     alert_rect = self._get_alert_rect(rect, alert.size)
     self._draw_background(alert_rect, alert)
@@ -107,6 +107,7 @@ class AlertRenderer(Widget):
       alert_rect.height - 2 * ALERT_PADDING
     )
     self._draw_text(text_rect, alert)
+    return True
 
   def _get_alert_rect(self, rect: rl.Rectangle, size: int) -> rl.Rectangle:
     if size == log.SelfdriveState.AlertSize.full:

--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -91,8 +91,8 @@ class AugmentedRoadView(CameraView):
     # Draw all UI overlays
     self.model_renderer.render(self._content_rect)
     self._hud_renderer.render(self._content_rect)
-    self.alert_renderer.render(self._content_rect)
-    self.driver_state_renderer.render(self._content_rect)
+    if not self.alert_renderer.render(self._content_rect):
+      self.driver_state_renderer.render(self._content_rect)
 
     # Custom UI extension point - add custom overlays here
     # Use self._content_rect for positioning within camera bounds

--- a/selfdrive/ui/onroad/driver_state.py
+++ b/selfdrive/ui/onroad/driver_state.py
@@ -110,8 +110,7 @@ class DriverStateRenderer(Widget):
   def _is_visible(self, sm):
     """Check if the visualization should be rendered."""
     return (sm.recv_frame['driverStateV2'] > ui_state.started_frame and
-            sm.seen['driverMonitoringState'] and
-            sm['selfdriveState'].alertSize == 0)
+            sm.seen['driverMonitoringState'])
 
   def _update_state(self, sm, rect):
     """Update the driver monitoring state based on model data"""


### PR DESCRIPTION
Ensures the Driver State icon is only shown when no alert is displayed.

Previously, we checked `sm['selfdriveState'].alertSize == 0` to control the Driver State icon, but this missed custom alerts managed by `AlertRender` (e.g., `ALERT_STARTUP_PENDING`). This issue also affects the QT UI.

![2025-06-09_23-51](https://github.com/user-attachments/assets/bd3e91b8-851f-4254-9f0a-469267032e02)


**Changes:**
- `alert_renderer.render` now returns `true` if any alert is visible, `false` otherwise.
- The Driver State icon is only drawn when `alert_renderer.render` returns `false`.

This ensures the icon never appears alongside any alert, making the UI cleaner