### PR TITLE
ui: fix Immediate ALERT_STARTUP_PENDING after going onroad

### DIFF
--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -72,18 +72,20 @@ class AlertRenderer(Widget):
     # Check if selfdriveState messages have stopped arriving
     if not sm.updated['selfdriveState']:
       recv_frame = sm.recv_frame['selfdriveState']
-      if (sm.frame - recv_frame) > 5 * DEFAULT_FPS:
-        # Check if waiting to start
-        if recv_frame < ui_state.started_frame:
-          return ALERT_STARTUP_PENDING
+      time_since_onroad = (sm.frame - ui_state.started_frame) / DEFAULT_FPS
 
-        # Handle selfdrive timeout
-        if TICI:
-          ss_missing = time.monotonic() - sm.recv_time['selfdriveState']
-          if ss_missing > SELFDRIVE_STATE_TIMEOUT:
-            if ss.enabled and (ss_missing - SELFDRIVE_STATE_TIMEOUT) < SELFDRIVE_UNRESPONSIVE_TIMEOUT:
-              return ALERT_CRITICAL_TIMEOUT
-            return ALERT_CRITICAL_REBOOT
+      # 1. Never received selfdriveState since going onroad
+      waiting_for_startup = recv_frame < ui_state.started_frame
+      if waiting_for_startup and time_since_onroad > 5:
+        return ALERT_STARTUP_PENDING
+
+      # 2. Lost communication with selfdriveState after receiving it
+      if TICI and not waiting_for_startup:
+        ss_missing = time.monotonic() - sm.recv_time['selfdriveState']
+        if ss_missing > SELFDRIVE_STATE_TIMEOUT:
+          if ss.enabled and (ss_missing - SELFDRIVE_STATE_TIMEOUT) < SELFDRIVE_UNRESPONSIVE_TIMEOUT:
+            return ALERT_CRITICAL_TIMEOUT
+          return ALERT_CRITICAL_REBOOT
 
     # No alert if size is none
     if ss.alertSize == 0:


### PR DESCRIPTION
This PR fixes an issue where `ALERT_STARTUP_PENDING` could appear right after going onroad, instead of waiting the intended 5 seconds.

### Why this issue didn’t appear in Qt
- Qt runs at 20Hz so 5 seconds = 100 frames. 
- Raylib runs at 60Hz, so 5 seconds = 300 frames.
- This gives `selfdriveState` messages 3x more frames to arrive before triggering alerts in Qt,  additionally, Qt only updates UI alerts after receiving a vision frame, further reducing the chance of premature alerts.
-  As a result, the alert logic appeared to work correctly in Qt, so this issue was never noticed there.

### Solution
The fix implements more robust timeout detection:

- Better distinction between "never received selfdriveState" and "received then lost" conditions
- More accurate timing calculations with proper frame comparison
- Improved logic for separating normal startup from actual timeout conditions