### PR TITLE
ui: [fix] remove unused gui_label import in HomeLayout

### DIFF
--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -8,7 +8,6 @@ from openpilot.selfdrive.ui.widgets.exp_mode_button import ExperimentalModeButto
 from openpilot.selfdrive.ui.widgets.prime import PrimeWidget
 from openpilot.selfdrive.ui.widgets.setup import SetupWidget
 from openpilot.system.ui.lib.text_measure import measure_text_cached
-from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_TEXT_COLOR, Widget
 
 HEADER_HEIGHT = 80


### PR DESCRIPTION
fixed the lint issue:
> 11 | from openpilot.system.ui.lib.label import gui_label
>    |                                           ^^^^^^^^^ F401
> 12 | from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_TEXT_COLOR, Widget
>    |
>    = help: Remove unused import: `openpilot.system.ui.lib.label.gui_label`
> check_added_large_files...........................[✔]
> check_shebang_scripts_are_executable..............[✔]
> check_shebang_format..............................[✔]
> check_nomerge_comments............................[✔]
> mypy..............................................[✗]
> Traceback (most recent call last):
>   File "/home/dean/Projects/openpilot/.venv/bin/mypy", line 10, in <module>
>     sys.exit(console_entry())