### PR TITLE
Add lagd calibration percentage

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2291,6 +2291,7 @@ struct LiveDelayData {
   lateralDelayEstimate @3 :Float32;
   lateralDelayEstimateStd @5 :Float32;
   points @4 :List(Float32);
+  calPerc @6 :Int8;
 
   enum Status {
     unestimated @0;

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -109,7 +109,6 @@ class Points:
     self.okay.append(okay)
     self.desired.append(desired)
     self.actual.append(actual)
-    print(len(self.times), len(self.desired), len(self.actual), len(self.okay), self.num_okay, okay)
 
   def get(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     return np.array(self.times), np.array(self.desired), np.array(self.actual), np.array(self.okay)
@@ -230,12 +229,7 @@ class LateralLagEstimator:
       liveDelay.lateralDelayEstimateStd = 0.0
 
     liveDelay.validBlocks = self.block_avg.valid_blocks
-    print(self.block_avg.valid_blocks, self.block_avg.idx, self.block_avg.block_size, self.min_valid_block_count)
-    print()
-    # progress_blocks = self.block_avg.valid_blocks + self.block_avg.idx / self.block_avg.block_size
-    # liveDelay.calPerc = min(100 * progress_blocks / self.min_valid_block_count, 100)
     liveDelay.calPerc = min(100 * (self.block_avg.valid_blocks * self.block_size + self.block_avg.idx) // (self.min_valid_block_count * self.block_size), 100)
-    print(f"LiveDelay calPerc: {liveDelay.calPerc}%")#, "lateralDelay:", liveDelay.lateralDelay, "lateralDelayEstimate:", liveDelay.lateralDelayEstimate)
     if debug:
       liveDelay.points = self.block_avg.values.flatten().tolist()
 
@@ -291,10 +285,6 @@ class LateralLagEstimator:
     )
     okay = self.lat_active and not self.steering_pressed and not self.steering_saturated and \
            fast and turning and has_recovered and calib_valid and sensors_valid and la_valid
-    if not okay:
-      print('has_recovered', has_recovered, 'okay', okay)
-
-    # print(la_desired, la_actual_pose)
 
     self.points.update(self.t, la_desired, la_actual_pose, okay)
 
@@ -355,7 +345,6 @@ def retrieve_initial_lag(params: Params, CP: car.CarParams):
     try:
       with log.Event.from_bytes(last_lag_data) as last_lag_msg, car.CarParams.from_bytes(last_carparams_data) as last_CP:
         ld = last_lag_msg.liveDelay
-        print(last_CP.carFingerprint, CP.carFingerprint)
         if last_CP.carFingerprint != CP.carFingerprint:
           raise Exception("Car model mismatch")
 
@@ -400,7 +389,6 @@ def main():
 
     # 4Hz driven by livePose
     if sm.frame % 5 == 0:
-      print('hjeere')
       lag_learner.update_estimate()
       lag_msg = lag_learner.get_msg(sm.all_checks(), DEBUG)
       lag_msg_dat = lag_msg.to_bytes()

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -229,6 +229,9 @@ class LateralLagEstimator:
       liveDelay.lateralDelayEstimateStd = 0.0
 
     liveDelay.validBlocks = self.block_avg.valid_blocks
+    liveDelay.calPerc = min(
+      100 * (self.block_avg.valid_blocks * self.block_avg.block_size + self.block_avg.idx) //
+      (self.min_valid_block_count * self.block_avg.block_size), 100)
     if debug:
       liveDelay.points = self.block_avg.values.flatten().tolist()
 

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -229,7 +229,8 @@ class LateralLagEstimator:
       liveDelay.lateralDelayEstimateStd = 0.0
 
     liveDelay.validBlocks = self.block_avg.valid_blocks
-    liveDelay.calPerc = min(100 * (self.block_avg.valid_blocks * self.block_size + self.block_avg.idx) // (self.min_valid_block_count * self.block_size), 100)
+    liveDelay.calPerc = min(100 * (self.block_avg.valid_blocks * self.block_size + self.block_avg.idx) //
+                            (self.min_valid_block_count * self.block_size), 100)
     if debug:
       liveDelay.points = self.block_avg.values.flatten().tolist()
 

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -396,7 +396,3 @@ def main():
 
       if sm.frame % 1200 == 0: # cache every 60 seconds
         params.put_nonblocking("LiveDelay", lag_msg_dat)
-
-
-if __name__ == "__main__":
-  main()

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -394,8 +394,8 @@ def main():
       lag_msg_dat = lag_msg.to_bytes()
       pm.send('liveDelay', lag_msg_dat)
 
-      # if sm.frame % 1200 == 0: # cache every 60 seconds
-      params.put_nonblocking("LiveDelay", lag_msg_dat)
+      if sm.frame % 1200 == 0: # cache every 60 seconds
+        params.put_nonblocking("LiveDelay", lag_msg_dat)
 
 
 if __name__ == "__main__":

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -229,9 +229,8 @@ class LateralLagEstimator:
       liveDelay.lateralDelayEstimateStd = 0.0
 
     liveDelay.validBlocks = self.block_avg.valid_blocks
-    liveDelay.calPerc = min(
-      100 * (self.block_avg.valid_blocks * self.block_avg.block_size + self.block_avg.idx) //
-      (self.min_valid_block_count * self.block_avg.block_size), 100)
+    progress_blocks = self.block_avg.valid_blocks + self.block_avg.idx / self.block_avg.block_size
+    liveDelay.calPerc = int(min(100 * progress_blocks / self.min_valid_block_count, 100))
     if debug:
       liveDelay.points = self.block_avg.values.flatten().tolist()
 

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -109,6 +109,7 @@ class Points:
     self.okay.append(okay)
     self.desired.append(desired)
     self.actual.append(actual)
+    print(len(self.times), len(self.desired), len(self.actual), len(self.okay), self.num_okay, okay)
 
   def get(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     return np.array(self.times), np.array(self.desired), np.array(self.actual), np.array(self.okay)
@@ -229,8 +230,12 @@ class LateralLagEstimator:
       liveDelay.lateralDelayEstimateStd = 0.0
 
     liveDelay.validBlocks = self.block_avg.valid_blocks
-    progress_blocks = self.block_avg.valid_blocks + self.block_avg.idx / self.block_avg.block_size
-    liveDelay.calPerc = int(min(100 * progress_blocks / self.min_valid_block_count, 100))
+    print(self.block_avg.valid_blocks, self.block_avg.idx, self.block_avg.block_size, self.min_valid_block_count)
+    print()
+    # progress_blocks = self.block_avg.valid_blocks + self.block_avg.idx / self.block_avg.block_size
+    # liveDelay.calPerc = min(100 * progress_blocks / self.min_valid_block_count, 100)
+    liveDelay.calPerc = min(100 * (self.block_avg.valid_blocks * self.block_size + self.block_avg.idx) // (self.min_valid_block_count * self.block_size), 100)
+    print(f"LiveDelay calPerc: {liveDelay.calPerc}%")#, "lateralDelay:", liveDelay.lateralDelay, "lateralDelayEstimate:", liveDelay.lateralDelayEstimate)
     if debug:
       liveDelay.points = self.block_avg.values.flatten().tolist()
 
@@ -286,6 +291,10 @@ class LateralLagEstimator:
     )
     okay = self.lat_active and not self.steering_pressed and not self.steering_saturated and \
            fast and turning and has_recovered and calib_valid and sensors_valid and la_valid
+    if not okay:
+      print('has_recovered', has_recovered, 'okay', okay)
+
+    # print(la_desired, la_actual_pose)
 
     self.points.update(self.t, la_desired, la_actual_pose, okay)
 
@@ -346,6 +355,7 @@ def retrieve_initial_lag(params: Params, CP: car.CarParams):
     try:
       with log.Event.from_bytes(last_lag_data) as last_lag_msg, car.CarParams.from_bytes(last_carparams_data) as last_CP:
         ld = last_lag_msg.liveDelay
+        print(last_CP.carFingerprint, CP.carFingerprint)
         if last_CP.carFingerprint != CP.carFingerprint:
           raise Exception("Car model mismatch")
 
@@ -390,10 +400,15 @@ def main():
 
     # 4Hz driven by livePose
     if sm.frame % 5 == 0:
+      print('hjeere')
       lag_learner.update_estimate()
       lag_msg = lag_learner.get_msg(sm.all_checks(), DEBUG)
       lag_msg_dat = lag_msg.to_bytes()
       pm.send('liveDelay', lag_msg_dat)
 
-      if sm.frame % 1200 == 0: # cache every 60 seconds
-        params.put_nonblocking("LiveDelay", lag_msg_dat)
+      # if sm.frame % 1200 == 0: # cache every 60 seconds
+      params.put_nonblocking("LiveDelay", lag_msg_dat)
+
+
+if __name__ == "__main__":
+  main()

--- a/selfdrive/locationd/test/test_lagd.py
+++ b/selfdrive/locationd/test/test_lagd.py
@@ -94,6 +94,7 @@ class TestLagd:
     assert np.allclose(msg.liveDelay.lateralDelay, estimator.initial_lag)
     assert np.allclose(msg.liveDelay.lateralDelayEstimate, estimator.initial_lag)
     assert msg.liveDelay.validBlocks == 0
+    assert msg.liveDelay.calPerc == 0
 
   def test_estimator_basics(self, subtests):
     for lag_frames in range(5):
@@ -107,6 +108,7 @@ class TestLagd:
         assert np.allclose(msg.liveDelay.lateralDelayEstimate, lag_frames * DT, atol=0.01)
         assert np.allclose(msg.liveDelay.lateralDelayEstimateStd, 0.0, atol=0.01)
         assert msg.liveDelay.validBlocks == BLOCK_NUM_NEEDED
+        assert msg.liveDelay.calPerc == 100
 
   def test_disabled_estimator(self):
     mocked_CP = car.CarParams(steerActuatorDelay=0.8)
@@ -119,6 +121,7 @@ class TestLagd:
     assert np.allclose(msg.liveDelay.lateralDelayEstimate, lag_frames * DT, atol=0.01)
     assert np.allclose(msg.liveDelay.lateralDelayEstimateStd, 0.0, atol=0.01)
     assert msg.liveDelay.validBlocks == BLOCK_NUM_NEEDED
+    assert msg.liveDelay.calPerc == 100
 
   def test_estimator_masking(self):
     mocked_CP, lag_frames = car.CarParams(steerActuatorDelay=0.8), random.randint(1, 19)
@@ -127,6 +130,7 @@ class TestLagd:
     msg = estimator.get_msg(True)
     assert np.allclose(msg.liveDelay.lateralDelayEstimate, lag_frames * DT, atol=0.01)
     assert np.allclose(msg.liveDelay.lateralDelayEstimateStd, 0.0, atol=0.01)
+    assert msg.liveDelay.calPerc == 100
 
   @pytest.mark.skipif(PC, reason="only on device")
   @pytest.mark.timeout(60)


### PR DESCRIPTION
## Summary
- publish calibration percentage in `lagd`
- add `calPerc` to `LiveDelayData` message definition
- test calibration percentage coverage

## Testing
- `pytest selfdrive/locationd/test/test_lagd.py -q` *(fails: ModuleNotFoundError: No module named 'openpilot.common.params_pyx')*

------
https://chatgpt.com/codex/tasks/task_e_68474b92ab6883339c844c63639595aa