### PR TITLE
ui: extract Widget base class to separate lib/widget.py

### DIFF
--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -8,7 +8,8 @@ from openpilot.selfdrive.ui.widgets.exp_mode_button import ExperimentalModeButto
 from openpilot.selfdrive.ui.widgets.prime import PrimeWidget
 from openpilot.selfdrive.ui.widgets.setup import SetupWidget
 from openpilot.system.ui.lib.text_measure import measure_text_cached
-from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_TEXT_COLOR, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_TEXT_COLOR
+from openpilot.system.ui.lib.widget import Widget
 
 HEADER_HEIGHT = 80
 HEAD_BUTTON_FONT_SIZE = 40

--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -5,7 +5,7 @@ from openpilot.selfdrive.ui.layouts.home import HomeLayout
 from openpilot.selfdrive.ui.layouts.settings.settings import SettingsLayout
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.selfdrive.ui.onroad.augmented_road_view import AugmentedRoadView
-from openpilot.system.ui.lib.application import Widget
+from openpilot.system.ui.lib.widget import Widget
 
 
 class MainState(IntEnum):

--- a/selfdrive/ui/layouts/network.py
+++ b/selfdrive/ui/layouts/network.py
@@ -1,5 +1,5 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import Widget
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.system.ui.lib.wifi_manager import WifiManagerWrapper
 from openpilot.system.ui.widgets.network import WifiManagerUI
 

--- a/selfdrive/ui/layouts/settings/developer.py
+++ b/selfdrive/ui/layouts/settings/developer.py
@@ -1,5 +1,5 @@
-from openpilot.system.ui.lib.application import Widget
 from openpilot.system.ui.lib.list_view import ListView, toggle_item
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.common.params import Params
 from openpilot.selfdrive.ui.widgets.ssh_key import ssh_key_item
 

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -6,8 +6,9 @@ from openpilot.common.params import Params
 from openpilot.selfdrive.ui.onroad.driver_camera_dialog import DriverCameraDialog
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.hardware import TICI
-from openpilot.system.ui.lib.application import gui_app, Widget, DialogResult
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.list_view import ListView, text_item, button_item, dual_button_item
+from openpilot.system.ui.lib.widget import Widget, DialogResult
 from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog
 from openpilot.system.ui.widgets.option_dialog import MultiOptionDialog
 from openpilot.system.ui.widgets.confirm_dialog import confirm_dialog, alert_dialog

--- a/selfdrive/ui/layouts/settings/firehose.py
+++ b/selfdrive/ui/layouts/settings/firehose.py
@@ -5,9 +5,10 @@ import threading
 from openpilot.common.api import Api, api_get
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
-from openpilot.system.ui.lib.application import gui_app, Widget, FontWeight
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.wrap_text import wrap_text
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.selfdrive.ui.ui_state import ui_state
 
 

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -8,9 +8,10 @@ from openpilot.selfdrive.ui.layouts.settings.device import DeviceLayout
 from openpilot.selfdrive.ui.layouts.settings.firehose import FirehoseLayout
 from openpilot.selfdrive.ui.layouts.settings.software import SoftwareLayout
 from openpilot.selfdrive.ui.layouts.settings.toggles import TogglesLayout
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.selfdrive.ui.layouts.network import NetworkLayout
+from openpilot.system.ui.lib.widget import Widget
 
 # Import individual panels
 

--- a/selfdrive/ui/layouts/settings/software.py
+++ b/selfdrive/ui/layouts/settings/software.py
@@ -1,6 +1,7 @@
 from openpilot.common.params import Params
-from openpilot.system.ui.lib.application import gui_app, Widget, DialogResult
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.list_view import ListView, button_item, text_item
+from openpilot.system.ui.lib.widget import Widget, DialogResult
 from openpilot.system.ui.widgets.confirm_dialog import confirm_dialog
 
 

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -1,5 +1,5 @@
-from openpilot.system.ui.lib.application import Widget
 from openpilot.system.ui.lib.list_view import ListView, toggle_item
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.common.params import Params
 
 # Description constants

--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -8,7 +8,6 @@ from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.widget import Widget
 
-
 SIDEBAR_WIDTH = 300
 METRIC_HEIGHT = 126
 METRIC_WIDTH = 240

--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -4,8 +4,10 @@ from dataclasses import dataclass
 from collections.abc import Callable
 from cereal import log
 from openpilot.selfdrive.ui.ui_state import ui_state
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.lib.widget import Widget
+
 
 SIDEBAR_WIDTH = 300
 METRIC_HEIGHT = 126

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -3,9 +3,10 @@ import pyray as rl
 from dataclasses import dataclass
 from cereal import messaging, log
 from openpilot.system.hardware import TICI
-from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_FPS, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_FPS
 from openpilot.system.ui.lib.label import gui_text_box
 from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.selfdrive.ui.ui_state import ui_state
 
 ALERT_MARGIN = 40

--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -5,8 +5,9 @@ import pyray as rl
 from openpilot.system.hardware import TICI
 from msgq.visionipc import VisionIpcClient, VisionStreamType, VisionBuf
 from openpilot.common.swaglog import cloudlog
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.egl import init_egl, create_egl_image, destroy_egl_image, bind_egl_image_to_texture, EGLImage
+from openpilot.system.ui.lib.widget import Widget
 
 CONNECTION_RETRY_INTERVAL = 0.2  # seconds between connection attempts
 

--- a/selfdrive/ui/onroad/driver_state.py
+++ b/selfdrive/ui/onroad/driver_state.py
@@ -5,7 +5,6 @@ from openpilot.selfdrive.ui.ui_state import ui_state, UI_BORDER_SIZE
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.widget import Widget
 
-
 # Default 3D coordinates for face keypoints as a NumPy array
 DEFAULT_FACE_KPTS_3D = np.array([
   [-5.98, -51.20, 8.00], [-17.64, -49.14, 8.00], [-23.81, -46.40, 8.00], [-29.98, -40.91, 8.00],

--- a/selfdrive/ui/onroad/driver_state.py
+++ b/selfdrive/ui/onroad/driver_state.py
@@ -2,7 +2,9 @@ import numpy as np
 import pyray as rl
 from dataclasses import dataclass
 from openpilot.selfdrive.ui.ui_state import ui_state, UI_BORDER_SIZE
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app
+from openpilot.system.ui.lib.widget import Widget
+
 
 # Default 3D coordinates for face keypoints as a NumPy array
 DEFAULT_FACE_KPTS_3D = np.array([

--- a/selfdrive/ui/onroad/exp_button.py
+++ b/selfdrive/ui/onroad/exp_button.py
@@ -2,7 +2,8 @@ import time
 import pyray as rl
 from cereal.messaging import SubMaster
 from openpilot.selfdrive.ui.ui_state import ui_state
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.common.params import Params
 
 

--- a/selfdrive/ui/onroad/hud_renderer.py
+++ b/selfdrive/ui/onroad/hud_renderer.py
@@ -3,9 +3,11 @@ from dataclasses import dataclass
 from cereal.messaging import SubMaster
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
 from openpilot.selfdrive.ui.onroad.exp_button import ExpButton
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.common.conversions import Conversions as CV
+from openpilot.system.ui.lib.widget import Widget
+
 
 # Constants
 SET_SPEED_NA = 255

--- a/selfdrive/ui/onroad/hud_renderer.py
+++ b/selfdrive/ui/onroad/hud_renderer.py
@@ -8,7 +8,6 @@ from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.common.conversions import Conversions as CV
 from openpilot.system.ui.lib.widget import Widget
 
-
 # Constants
 SET_SPEED_NA = 255
 KM_TO_MILE = 0.621371

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -5,9 +5,11 @@ from cereal import messaging, car
 from dataclasses import dataclass, field
 from openpilot.common.params import Params
 from openpilot.selfdrive.ui.ui_state import ui_state
-from openpilot.system.ui.lib.application import DEFAULT_FPS, Widget
+from openpilot.system.ui.lib.application import DEFAULT_FPS
 from openpilot.system.ui.lib.shader_polygon import draw_polygon
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.selfdrive.locationd.calibrationd import HEIGHT_INIT
+
 
 CLIP_MARGIN = 500
 MIN_DRAW_DISTANCE = 10.0

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -10,7 +10,6 @@ from openpilot.system.ui.lib.shader_polygon import draw_polygon
 from openpilot.system.ui.lib.widget import Widget
 from openpilot.selfdrive.locationd.calibrationd import HEIGHT_INIT
 
-
 CLIP_MARGIN = 500
 MIN_DRAW_DISTANCE = 10.0
 MAX_DRAW_DISTANCE = 100.0
@@ -385,12 +384,12 @@ class ModelRenderer(Widget):
 
     # Filter points within clip region
     left_in_clip = (
-        (left_screen[0] >= x_min) & (left_screen[0] <= x_max) &
-        (left_screen[1] >= y_min) & (left_screen[1] <= y_max)
+      (left_screen[0] >= x_min) & (left_screen[0] <= x_max) &
+      (left_screen[1] >= y_min) & (left_screen[1] <= y_max)
     )
     right_in_clip = (
-        (right_screen[0] >= x_min) & (right_screen[0] <= x_max) &
-        (right_screen[1] >= y_min) & (right_screen[1] <= y_max)
+      (right_screen[0] >= x_min) & (right_screen[0] <= x_max) &
+      (right_screen[1] >= y_min) & (right_screen[1] <= y_max)
     )
     both_in_clip = left_in_clip & right_in_clip
 
@@ -403,12 +402,12 @@ class ModelRenderer(Widget):
 
     # Handle Y-coordinate inversion on hills
     if not allow_invert and left_screen.shape[1] > 1:
-        y = left_screen[1, :]  # y-coordinates
-        keep = y == np.minimum.accumulate(y)
-        if not np.any(keep):
-            return np.empty((0, 2), dtype=np.float32)
-        left_screen = left_screen[:, keep]
-        right_screen = right_screen[:, keep]
+      y = left_screen[1, :]  # y-coordinates
+      keep = y == np.minimum.accumulate(y)
+      if not np.any(keep):
+        return np.empty((0, 2), dtype=np.float32)
+      left_screen = left_screen[:, keep]
+      right_screen = right_screen[:, keep]
 
     return np.vstack((left_screen.T, right_screen[:, ::-1].T)).astype(np.float32)
 

--- a/selfdrive/ui/widgets/exp_mode_button.py
+++ b/selfdrive/ui/widgets/exp_mode_button.py
@@ -1,7 +1,7 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import Widget
 from openpilot.common.params import Params
 from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.widget import Widget
 
 
 class ExperimentalModeButton(Widget):

--- a/selfdrive/ui/widgets/offroad_alerts.py
+++ b/selfdrive/ui/widgets/offroad_alerts.py
@@ -8,7 +8,8 @@ from openpilot.system.hardware import HARDWARE
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.wrap_text import wrap_text
 from openpilot.system.ui.lib.text_measure import measure_text_cached
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.widget import Widget
 
 
 class AlertColors:

--- a/selfdrive/ui/widgets/prime.py
+++ b/selfdrive/ui/widgets/prime.py
@@ -1,10 +1,11 @@
 import pyray as rl
 
 from openpilot.selfdrive.ui.ui_state import ui_state
-from openpilot.system.ui.lib.application import gui_app, Widget, FontWeight
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.wrap_text import wrap_text
 from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.lib.widget import Widget
 
 
 class PrimeWidget(Widget):

--- a/selfdrive/ui/widgets/setup.py
+++ b/selfdrive/ui/widgets/setup.py
@@ -2,9 +2,10 @@ import pyray as rl
 from openpilot.selfdrive.ui.lib.prime_state import PrimeType
 from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog
 from openpilot.selfdrive.ui.ui_state import ui_state
-from openpilot.system.ui.lib.application import gui_app, Widget, FontWeight
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.wrap_text import wrap_text
+from openpilot.system.ui.lib.widget import Widget
 
 
 class SetupWidget(Widget):

--- a/selfdrive/ui/widgets/ssh_key.py
+++ b/selfdrive/ui/widgets/ssh_key.py
@@ -5,7 +5,7 @@ import copy
 from enum import Enum
 
 from openpilot.common.params import Params
-from openpilot.system.ui.lib.application import gui_app, DialogResult, FontWeight
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.list_view import (
   ItemAction,
@@ -16,6 +16,7 @@ from openpilot.system.ui.lib.list_view import (
   BUTTON_WIDTH,
 )
 from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.lib.widget import DialogResult
 from openpilot.system.ui.widgets.confirm_dialog import alert_dialog
 from openpilot.system.ui.widgets.keyboard import Keyboard
 

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -1,4 +1,3 @@
-import abc
 import atexit
 import os
 import time
@@ -25,41 +24,6 @@ DEFAULT_TEXT_COLOR = rl.WHITE
 
 ASSETS_DIR = files("openpilot.selfdrive").joinpath("assets")
 FONT_DIR = ASSETS_DIR.joinpath("fonts")
-
-
-class DialogResult(IntEnum):
-  CANCEL = 0
-  CONFIRM = 1
-  NO_ACTION = -1
-
-
-class Widget(abc.ABC):
-  def __init__(self):
-    self._is_pressed = False
-
-  def render(self, rect: rl.Rectangle) -> bool | int | None:
-    ret = self._render(rect)
-
-    # Keep track of whether mouse down started within the widget's rectangle
-    mouse_pos = rl.get_mouse_position()
-    if rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
-      if rl.check_collision_point_rec(mouse_pos, rect):
-        self._is_pressed = True
-
-    if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
-      if self._is_pressed and rl.check_collision_point_rec(mouse_pos, rect):
-        self._handle_mouse_release(mouse_pos)
-      self._is_pressed = False
-
-    return ret
-
-  @abc.abstractmethod
-  def _render(self, rect: rl.Rectangle) -> bool | int | None:
-    """Render the widget within the given rectangle."""
-
-  def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:
-    """Handle mouse release events, if applicable."""
-    return False
 
 
 class FontWeight(IntEnum):

--- a/system/ui/lib/inputbox.py
+++ b/system/ui/lib/inputbox.py
@@ -1,7 +1,9 @@
 import pyray as rl
 import time
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.lib.widget import Widget
+
 
 PASSWORD_MASK_CHAR = "•"
 PASSWORD_MASK_DELAY = 1.5  # Seconds to show character before masking

--- a/system/ui/lib/inputbox.py
+++ b/system/ui/lib/inputbox.py
@@ -4,7 +4,6 @@ from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.widget import Widget
 
-
 PASSWORD_MASK_CHAR = "•"
 PASSWORD_MASK_DELAY = 1.5  # Seconds to show character before masking
 

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -4,11 +4,12 @@ from dataclasses import dataclass
 from collections.abc import Callable
 from abc import ABC
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.wrap_text import wrap_text
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.toggle import Toggle, WIDTH as TOGGLE_WIDTH, HEIGHT as TOGGLE_HEIGHT
+from openpilot.system.ui.lib.widget import Widget
 
 ITEM_BASE_HEIGHT = 170
 LINE_PADDING = 40

--- a/system/ui/lib/toggle.py
+++ b/system/ui/lib/toggle.py
@@ -1,5 +1,5 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import Widget
+from openpilot.system.ui.lib.widget import Widget
 
 ON_COLOR = rl.Color(51, 171, 76, 255)
 OFF_COLOR = rl.Color(0x39, 0x39, 0x39, 255)

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -1,0 +1,38 @@
+import abc
+import pyray as rl
+from enum import IntEnum
+
+
+class DialogResult(IntEnum):
+  CANCEL = 0
+  CONFIRM = 1
+  NO_ACTION = -1
+
+
+class Widget(abc.ABC):
+  def __init__(self):
+    self._is_pressed = False
+
+  def render(self, rect: rl.Rectangle) -> bool | int | None:
+    ret = self._render(rect)
+
+    # Keep track of whether mouse down started within the widget's rectangle
+    mouse_pos = rl.get_mouse_position()
+    if rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
+      if rl.check_collision_point_rec(mouse_pos, rect):
+        self._is_pressed = True
+
+    if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
+      if self._is_pressed and rl.check_collision_point_rec(mouse_pos, rect):
+        self._handle_mouse_release(mouse_pos)
+      self._is_pressed = False
+
+    return ret
+
+  @abc.abstractmethod
+  def _render(self, rect: rl.Rectangle) -> bool | int | None:
+    """Render the widget within the given rectangle."""
+
+  def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:
+    """Handle mouse release events, if applicable."""
+    return False

--- a/system/ui/reset.py
+++ b/system/ui/reset.py
@@ -11,7 +11,6 @@ from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.label import gui_label, gui_text_box
 from openpilot.system.ui.lib.widget import Widget
 
-
 NVME = "/dev/nvme0n1"
 USERDATA = "/dev/disk/by-partlabel/userdata"
 

--- a/system/ui/reset.py
+++ b/system/ui/reset.py
@@ -6,9 +6,11 @@ import threading
 from enum import IntEnum
 
 from openpilot.system.hardware import PC
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.label import gui_label, gui_text_box
+from openpilot.system.ui.lib.widget import Widget
+
 
 NVME = "/dev/nvme0n1"
 USERDATA = "/dev/disk/by-partlabel/userdata"

--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -16,7 +16,6 @@ from openpilot.system.ui.lib.widget import Widget
 from openpilot.system.ui.widgets.network import WifiManagerUI, WifiManagerWrapper
 from openpilot.system.ui.widgets.keyboard import Keyboard
 
-
 NetworkType = log.DeviceState.NetworkType
 
 MARGIN = 50

--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -9,11 +9,13 @@ import pyray as rl
 
 from cereal import log
 from openpilot.system.hardware import HARDWARE
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.label import gui_label, gui_text_box
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.system.ui.widgets.network import WifiManagerUI, WifiManagerWrapper
 from openpilot.system.ui.widgets.keyboard import Keyboard
+
 
 NetworkType = log.DeviceState.NetworkType
 

--- a/system/ui/spinner.py
+++ b/system/ui/spinner.py
@@ -3,8 +3,9 @@ import pyray as rl
 import select
 import sys
 
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.system.ui.text import wrap_text
 
 # Constants

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -9,7 +9,6 @@ from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.widget import Widget
 
-
 MARGIN = 50
 SPACING = 40
 FONT_SIZE = 72

--- a/system/ui/text.py
+++ b/system/ui/text.py
@@ -6,7 +6,9 @@ from openpilot.system.hardware import HARDWARE, PC
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app
+from openpilot.system.ui.lib.widget import Widget
+
 
 MARGIN = 50
 SPACING = 40

--- a/system/ui/updater.py
+++ b/system/ui/updater.py
@@ -6,10 +6,11 @@ import pyray as rl
 from enum import IntEnum
 
 from openpilot.system.hardware import HARDWARE
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.label import gui_text_box, gui_label
 from openpilot.system.ui.lib.wifi_manager import WifiManagerWrapper
+from openpilot.system.ui.lib.widget import Widget
 from openpilot.system.ui.widgets.network import WifiManagerUI
 
 # Constants

--- a/system/ui/widgets/confirm_dialog.py
+++ b/system/ui/widgets/confirm_dialog.py
@@ -4,7 +4,6 @@ from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.label import gui_text_box
 from openpilot.system.ui.lib.widget import DialogResult
 
-
 DIALOG_WIDTH = 1520
 DIALOG_HEIGHT = 600
 BUTTON_HEIGHT = 160

--- a/system/ui/widgets/confirm_dialog.py
+++ b/system/ui/widgets/confirm_dialog.py
@@ -1,7 +1,9 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import gui_app, DialogResult, FontWeight
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle
 from openpilot.system.ui.lib.label import gui_text_box
+from openpilot.system.ui.lib.widget import DialogResult
+
 
 DIALOG_WIDTH = 1520
 DIALOG_HEIGHT = 600

--- a/system/ui/widgets/keyboard.py
+++ b/system/ui/widgets/keyboard.py
@@ -7,7 +7,6 @@ from openpilot.system.ui.lib.inputbox import InputBox
 from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.widget import Widget
 
-
 KEY_FONT_SIZE = 96
 DOUBLE_CLICK_THRESHOLD = 0.5  # seconds
 DELETE_REPEAT_DELAY = 0.5

--- a/system/ui/widgets/keyboard.py
+++ b/system/ui/widgets/keyboard.py
@@ -1,10 +1,12 @@
 import time
 from typing import Literal
 import pyray as rl
-from openpilot.system.ui.lib.application import gui_app, FontWeight, Widget
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import ButtonStyle, gui_button
 from openpilot.system.ui.lib.inputbox import InputBox
 from openpilot.system.ui.lib.label import gui_label
+from openpilot.system.ui.lib.widget import Widget
+
 
 KEY_FONT_SIZE = 96
 DOUBLE_CLICK_THRESHOLD = 0.5  # seconds

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -3,13 +3,15 @@ from threading import Lock
 from typing import Literal
 
 import pyray as rl
-from openpilot.system.ui.lib.application import gui_app, Widget
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.button import ButtonStyle, gui_button
 from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.wifi_manager import NetworkInfo, WifiManagerCallbacks, WifiManagerWrapper, SecurityType
 from openpilot.system.ui.widgets.keyboard import Keyboard
 from openpilot.system.ui.widgets.confirm_dialog import confirm_dialog
+from openpilot.system.ui.lib.widget import Widget
+
 
 NM_DEVICE_STATE_NEED_AUTH = 60
 MIN_PASSWORD_LENGTH = 8

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -12,7 +12,6 @@ from openpilot.system.ui.widgets.keyboard import Keyboard
 from openpilot.system.ui.widgets.confirm_dialog import confirm_dialog
 from openpilot.system.ui.lib.widget import Widget
 
-
 NM_DEVICE_STATE_NEED_AUTH = 60
 MIN_PASSWORD_LENGTH = 8
 MAX_PASSWORD_LENGTH = 64

--- a/system/ui/widgets/option_dialog.py
+++ b/system/ui/widgets/option_dialog.py
@@ -5,7 +5,6 @@ from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.widget import Widget
 
-
 # Constants
 MARGIN = 50
 TITLE_FONT_SIZE = 70

--- a/system/ui/widgets/option_dialog.py
+++ b/system/ui/widgets/option_dialog.py
@@ -1,8 +1,10 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import Widget, FontWeight
+from openpilot.system.ui.lib.application import FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle, TextAlignment
 from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
+from openpilot.system.ui.lib.widget import Widget
+
 
 # Constants
 MARGIN = 50


### PR DESCRIPTION
Split the `Widget` base class from `application.py` into a dedicated `widget.py` module to improve code organization.