### PR TITLE
ui: increase drag threshold to 12 pixels

### DIFF
--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -5,7 +5,7 @@ from enum import IntEnum
 MOUSE_WHEEL_SCROLL_SPEED = 30
 INERTIA_FRICTION = 0.92        # The rate at which the inertia slows down
 MIN_VELOCITY = 0.5             # Minimum velocity before stopping the inertia
-DRAG_THRESHOLD = 5             # Pixels of movement to consider it a drag, not a click
+DRAG_THRESHOLD = 12            # Pixels of movement to consider it a drag, not a click
 BOUNCE_FACTOR = 0.2            # Elastic bounce when scrolling past boundaries
 BOUNCE_RETURN_SPEED = 0.15     # How quickly it returns from the bounce
 MAX_BOUNCE_DISTANCE = 150      # Maximum distance for bounce effect


### PR DESCRIPTION
The previous 5-pixel threshold was too sensitive and often caused accidental drags from minor finger movement. Raising the threshold to 12 pixels helps prevent unintended drags and matches common industry standards for touch devices.