### PR TITLE
ui: add MouseState for centralized mouse handling and update widget event propagation

### DIFF
--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -10,7 +10,7 @@ from openpilot.selfdrive.ui.layouts.settings.toggles import TogglesLayout
 from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.selfdrive.ui.layouts.network import NetworkLayout
-from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.widget import Widget, MouseState
 
 # Import individual panels
 
@@ -70,7 +70,7 @@ class SettingsLayout(Widget):
   def set_callbacks(self, on_close: Callable):
     self._close_callback = on_close
 
-  def _render(self, rect: rl.Rectangle):
+  def _render(self, rect: rl.Rectangle) -> None:
     # Calculate layout
     sidebar_rect = rl.Rectangle(rect.x, rect.y, SIDEBAR_WIDTH, rect.height)
     panel_rect = rl.Rectangle(rect.x + SIDEBAR_WIDTH, rect.y, rect.width - SIDEBAR_WIDTH, rect.height)
@@ -87,8 +87,7 @@ class SettingsLayout(Widget):
       rect.x + (rect.width - CLOSE_BTN_SIZE) / 2, rect.y + 45, CLOSE_BTN_SIZE, CLOSE_BTN_SIZE
     )
 
-    pressed = (rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT) and
-               rl.check_collision_point_rec(rl.get_mouse_position(), close_btn_rect))
+    pressed = gui_app.mouse.check_down(close_btn_rect)
     close_color = CLOSE_BTN_PRESSED if pressed else CLOSE_BTN_COLOR
     rl.draw_rectangle_rounded(close_btn_rect, 1.0, 20, close_color)
 
@@ -132,16 +131,16 @@ class SettingsLayout(Widget):
     if panel.instance:
       panel.instance.render(content_rect)
 
-  def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:
+  def _on_mouse_clicked(self, mouse: MouseState) -> bool:
     # Check close button
-    if rl.check_collision_point_rec(mouse_pos, self._close_btn_rect):
+    if mouse.check_clicked(self._close_btn_rect):
       if self._close_callback:
         self._close_callback()
       return True
 
     # Check navigation buttons
     for panel_type, panel_info in self._panels.items():
-      if rl.check_collision_point_rec(mouse_pos, panel_info.button_rect):
+      if mouse.check_clicked(panel_info.button_rect):
         self.set_current_panel(panel_type)
         return True
 

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -87,7 +87,7 @@ class SettingsLayout(Widget):
       rect.x + (rect.width - CLOSE_BTN_SIZE) / 2, rect.y + 45, CLOSE_BTN_SIZE, CLOSE_BTN_SIZE
     )
 
-    pressed = gui_app.mouse.check_down(close_btn_rect)
+    pressed = gui_app.mouse.is_held_down_in(close_btn_rect)
     close_color = CLOSE_BTN_PRESSED if pressed else CLOSE_BTN_COLOR
     rl.draw_rectangle_rounded(close_btn_rect, 1.0, 20, close_color)
 
@@ -133,14 +133,14 @@ class SettingsLayout(Widget):
 
   def _on_mouse_clicked(self, mouse: MouseState) -> bool:
     # Check close button
-    if mouse.check_clicked(self._close_btn_rect):
+    if mouse.is_clicked_in(self._close_btn_rect):
       if self._close_callback:
         self._close_callback()
       return True
 
     # Check navigation buttons
     for panel_type, panel_info in self._panels.items():
-      if mouse.check_clicked(panel_info.button_rect):
+      if mouse.is_clicked_in(panel_info.button_rect):
         self.set_current_panel(panel_type)
         return True
 

--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -6,7 +6,7 @@ from cereal import log
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
-from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.widget import Widget, MouseState
 
 SIDEBAR_WIDTH = 300
 METRIC_HEIGHT = 126
@@ -135,25 +135,26 @@ class Sidebar(Widget):
     else:
       self._panda_status.update("VEHICLE", "ONLINE", Colors.GOOD)
 
-  def _handle_mouse_release(self, mouse_pos: rl.Vector2):
-    if rl.check_collision_point_rec(mouse_pos, SETTINGS_BTN):
+  def _on_mouse_clicked(self, mouse: MouseState) -> bool:
+    if mouse.check_clicked(SETTINGS_BTN):
       if self._on_settings_click:
         self._on_settings_click()
-    elif rl.check_collision_point_rec(mouse_pos, HOME_BTN) and ui_state.started:
+      return True
+    elif mouse.check_clicked(HOME_BTN) and ui_state.started:
       if self._on_flag_click:
         self._on_flag_click()
+      return True
+
+    return False
 
   def _draw_buttons(self, rect: rl.Rectangle):
-    mouse_pos = rl.get_mouse_position()
-    mouse_down = self._is_pressed and rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT)
-
     # Settings button
-    settings_down = mouse_down and rl.check_collision_point_rec(mouse_pos, SETTINGS_BTN)
+    settings_down = gui_app.mouse.check_down(SETTINGS_BTN)
     tint = Colors.BUTTON_PRESSED if settings_down else Colors.BUTTON_NORMAL
     rl.draw_texture(self._settings_img, int(SETTINGS_BTN.x), int(SETTINGS_BTN.y), tint)
 
     # Home/Flag button
-    flag_pressed = mouse_down and rl.check_collision_point_rec(mouse_pos, HOME_BTN)
+    flag_pressed = gui_app.mouse.check_down(HOME_BTN)
     button_img = self._flag_img if ui_state.started else self._home_img
 
     tint = Colors.BUTTON_PRESSED if (ui_state.started and flag_pressed) else Colors.BUTTON_NORMAL

--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -136,11 +136,11 @@ class Sidebar(Widget):
       self._panda_status.update("VEHICLE", "ONLINE", Colors.GOOD)
 
   def _on_mouse_clicked(self, mouse: MouseState) -> bool:
-    if mouse.check_clicked(SETTINGS_BTN):
+    if mouse.is_clicked_in(SETTINGS_BTN):
       if self._on_settings_click:
         self._on_settings_click()
       return True
-    elif mouse.check_clicked(HOME_BTN) and ui_state.started:
+    elif mouse.is_clicked_in(HOME_BTN) and ui_state.started:
       if self._on_flag_click:
         self._on_flag_click()
       return True
@@ -149,12 +149,12 @@ class Sidebar(Widget):
 
   def _draw_buttons(self, rect: rl.Rectangle):
     # Settings button
-    settings_down = gui_app.mouse.check_down(SETTINGS_BTN)
+    settings_down = gui_app.mouse.is_held_down_in(SETTINGS_BTN)
     tint = Colors.BUTTON_PRESSED if settings_down else Colors.BUTTON_NORMAL
     rl.draw_texture(self._settings_img, int(SETTINGS_BTN.x), int(SETTINGS_BTN.y), tint)
 
     # Home/Flag button
-    flag_pressed = gui_app.mouse.check_down(HOME_BTN)
+    flag_pressed = gui_app.mouse.is_held_down_in(HOME_BTN)
     button_img = self._flag_img if ui_state.started else self._home_img
 
     tint = Colors.BUTTON_PRESSED if (ui_state.started and flag_pressed) else Colors.BUTTON_NORMAL

--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -10,8 +10,10 @@ from openpilot.selfdrive.ui.onroad.hud_renderer import HudRenderer
 from openpilot.selfdrive.ui.onroad.model_renderer import ModelRenderer
 from openpilot.selfdrive.ui.onroad.cameraview import CameraView
 from openpilot.system.ui.lib.application import gui_app
+from openpilot.system.ui.lib.mouse_state import MouseState
 from openpilot.common.transformations.camera import DEVICE_CAMERAS, DeviceCameraConfig, view_frame_from_device_frame
 from openpilot.common.transformations.orientation import rot_from_euler
+
 
 OpState = log.SelfdriveState.OpenpilotState
 CALIBRATED = log.LiveCalibrationData.Status.calibrated
@@ -100,11 +102,11 @@ class AugmentedRoadView(CameraView):
     # End clipping region
     rl.end_scissor_mode()
 
-    # Handle click events if no HUD interaction occurred
-    if not self._hud_renderer.handle_mouse_event():
-      if self._click_callback and rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
-        if rl.check_collision_point_rec(rl.get_mouse_position(), self._content_rect):
-          self._click_callback()
+  def _on_mouse_clicked(self, mouse: MouseState):
+    if self._click_callback:
+      self._click_callback()
+      return True
+    return False
 
   def _draw_border(self, rect: rl.Rectangle):
     border_color = BORDER_COLORS.get(ui_state.status, BORDER_COLORS[UIStatus.DISENGAGED])

--- a/selfdrive/ui/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/onroad/driver_camera_dialog.py
@@ -6,6 +6,8 @@ from openpilot.selfdrive.ui.onroad.driver_state import DriverStateRenderer
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.label import gui_label
+from openpilot.system.ui.lib.mouse_state import MouseState
+from openpilot.system.ui.lib.widget import DialogResult
 
 
 class DriverCameraDialog(CameraView):
@@ -16,9 +18,6 @@ class DriverCameraDialog(CameraView):
   def _render(self, rect):
     super()._render(rect)
 
-    if rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
-      return 1
-
     if not self.frame:
       gui_label(
         rect,
@@ -27,12 +26,14 @@ class DriverCameraDialog(CameraView):
         font_weight=FontWeight.BOLD,
         alignment=rl.GuiTextAlignment.TEXT_ALIGN_CENTER,
       )
-      return -1
+      return
 
     self._draw_face_detection(rect)
     self.driver_state_renderer.render(rect)
 
-    return -1
+  def _on_mouse_clicked(self, mouse: MouseState) -> bool:
+    gui_app.close_dialog(DialogResult.NO_ACTION)
+    return True
 
   def _draw_face_detection(self, rect: rl.Rectangle) -> None:
     driver_state = ui_state.sm["driverStateV2"]

--- a/selfdrive/ui/onroad/exp_button.py
+++ b/selfdrive/ui/onroad/exp_button.py
@@ -49,9 +49,8 @@ class ExpButton(Widget):
     center_x = int(self._rect.x + self._rect.width // 2)
     center_y = int(self._rect.y + self._rect.height // 2)
 
-    mouse_over = rl.check_collision_point_rec(rl.get_mouse_position(), self._rect)
-    mouse_down = rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT) and self._is_pressed
-    self._white_color.a = 180 if (mouse_down and mouse_over) or not self._engageable else 255
+    is_down = gui_app.mouse.check_down(self._rect)
+    self._white_color.a = 180 if is_down or not self._engageable else 255
 
     texture = self._txt_exp if self._held_or_actual_mode() else self._txt_wheel
     rl.draw_circle(center_x, center_y, self._rect.width / 2, self._black_bg)

--- a/selfdrive/ui/onroad/exp_button.py
+++ b/selfdrive/ui/onroad/exp_button.py
@@ -33,7 +33,7 @@ class ExpButton(Widget):
     self._engageable = selfdrive_state.engageable or selfdrive_state.enabled
 
   def _on_mouse_clicked(self, mouse: MouseState) -> bool:
-    if mouse.check_clicked(self._rect):
+    if mouse.is_clicked_in(self._rect):
       if self._is_toggle_allowed():
         new_mode = not self._experimental_mode
         self._params.put_bool("ExperimentalMode", new_mode)
@@ -48,7 +48,7 @@ class ExpButton(Widget):
     center_x = int(self._rect.x + self._rect.width // 2)
     center_y = int(self._rect.y + self._rect.height // 2)
 
-    is_down = gui_app.mouse.check_down(self._rect)
+    is_down = gui_app.mouse.is_held_down_in(self._rect)
     self._white_color.a = 180 if is_down or not self._engageable else 255
 
     texture = self._txt_exp if self._held_or_actual_mode() else self._txt_wheel

--- a/selfdrive/ui/onroad/exp_button.py
+++ b/selfdrive/ui/onroad/exp_button.py
@@ -2,7 +2,7 @@ import time
 import pyray as rl
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.widget import Widget, MouseState
 from openpilot.common.params import Params
 
 
@@ -32,10 +32,9 @@ class ExpButton(Widget):
     self._experimental_mode = selfdrive_state.experimentalMode
     self._engageable = selfdrive_state.engageable or selfdrive_state.enabled
 
-  def handle_mouse_event(self) -> bool:
-    if rl.check_collision_point_rec(rl.get_mouse_position(), self._rect):
-      if (rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT) and
-          self._is_toggle_allowed()):
+  def _on_mouse_clicked(self, mouse: MouseState) -> bool:
+    if mouse.check_clicked(self._rect):
+      if self._is_toggle_allowed():
         new_mode = not self._experimental_mode
         self._params.put_bool("ExperimentalMode", new_mode)
 

--- a/selfdrive/ui/onroad/hud_renderer.py
+++ b/selfdrive/ui/onroad/hud_renderer.py
@@ -120,9 +120,6 @@ class HudRenderer(Widget):
     button_y = rect.y + UI_CONFIG.border_size
     self._exp_button.render(rl.Rectangle(button_x, button_y, UI_CONFIG.button_size, UI_CONFIG.button_size))
 
-  def handle_mouse_event(self) -> bool:
-    return bool(self._exp_button.handle_mouse_event())
-
   def _draw_set_speed(self, rect: rl.Rectangle) -> None:
     """Draw the MAX speed indicator box."""
     set_speed_width = UI_CONFIG.set_speed_width_metric if ui_state.is_metric else UI_CONFIG.set_speed_width_imperial

--- a/selfdrive/ui/widgets/exp_mode_button.py
+++ b/selfdrive/ui/widgets/exp_mode_button.py
@@ -1,7 +1,7 @@
 import pyray as rl
 from openpilot.common.params import Params
 from openpilot.system.ui.lib.application import gui_app, FontWeight
-from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.widget import Widget, MouseState
 
 
 class ExperimentalModeButton(Widget):
@@ -14,13 +14,12 @@ class ExperimentalModeButton(Widget):
 
     self.params = Params()
     self.experimental_mode = self.params.get_bool("ExperimentalMode")
-    self.is_pressed = False
 
     self.chill_pixmap = gui_app.texture("icons/couch.png", self.img_width, self.img_width)
     self.experimental_pixmap = gui_app.texture("icons/experimental_grey.png", self.img_width, self.img_width)
 
-  def _get_gradient_colors(self):
-    alpha = 0xCC if self.is_pressed else 0xFF
+  def _get_gradient_colors(self, mouse_pressed: bool):
+    alpha = 0xCC if mouse_pressed else 0xFF
 
     if self.experimental_mode:
       return rl.Color(255, 155, 63, alpha), rl.Color(219, 56, 34, alpha)
@@ -28,23 +27,17 @@ class ExperimentalModeButton(Widget):
       return rl.Color(20, 255, 171, alpha), rl.Color(35, 149, 255, alpha)
 
   def _draw_gradient_background(self, rect):
-    start_color, end_color = self._get_gradient_colors()
+    start_color, end_color = self._get_gradient_colors(gui_app.mouse.is_held_down_in(rect))
     rl.draw_rectangle_gradient_h(int(rect.x), int(rect.y), int(rect.width), int(rect.height),
                                  start_color, end_color)
 
-  def _handle_interaction(self, rect):
-    mouse_pos = rl.get_mouse_position()
-    mouse_in_rect = rl.check_collision_point_rec(mouse_pos, rect)
-
-    self.is_pressed = mouse_in_rect and rl.is_mouse_button_down(rl.MOUSE_BUTTON_LEFT)
-    return mouse_in_rect and rl.is_mouse_button_released(rl.MOUSE_BUTTON_LEFT)
+  def _on_mouse_clicked(self, mouse: MouseState) -> bool:
+    self.experimental_mode = not self.experimental_mode
+    # TODO: Opening settings for ExperimentalMode
+    self.params.put_bool("ExperimentalMode", self.experimental_mode)
+    return True
 
   def _render(self, rect):
-    if self._handle_interaction(rect):
-      self.experimental_mode = not self.experimental_mode
-      # TODO: Opening settings for ExperimentalMode
-      self.params.put_bool("ExperimentalMode", self.experimental_mode)
-
     rl.draw_rectangle_rounded(rect, 0.08, 20, rl.Color(255, 255, 255, 255))
 
     rl.begin_scissor_mode(int(rect.x), int(rect.y), int(rect.width), int(rect.height))

--- a/selfdrive/ui/widgets/pairing_dialog.py
+++ b/selfdrive/ui/widgets/pairing_dialog.py
@@ -77,7 +77,7 @@ class PairingDialog(Widget):
     close_icon = gui_app.texture("icons/close.png", close_size, close_size)
     self._close_button = rl.Rectangle(content_rect.x, y, close_size, close_size)
 
-    is_down = gui_app.mouse.check_down(self._close_button)
+    is_down = gui_app.mouse.is_held_down_in(self._close_button)
     color = rl.Color(180, 180, 180, 150) if is_down else rl.WHITE
     rl.draw_texture(close_icon, int(content_rect.x), int(y), color)
 
@@ -106,7 +106,7 @@ class PairingDialog(Widget):
     self._render_qr_code(rl.Rectangle(qr_x, qr_y, qr_size, qr_size))
 
   def _on_mouse_clicked(self, mouse: MouseState) -> bool:
-    if mouse.check_clicked(self._close_button):
+    if mouse.is_clicked_in(self._close_button):
       gui_app.close_dialog(DialogResult.CANCEL)
       return True
     return False

--- a/system/ui/lib/button.py
+++ b/system/ui/lib/button.py
@@ -71,7 +71,7 @@ def gui_button(
 
   # Set background color based on button type
   bg_color = BUTTON_BACKGROUND_COLORS[button_style]
-  if is_enabled and gui_app.mouse.check_down(rect):
+  if is_enabled and gui_app.mouse.is_held_down_in(rect):
     bg_color = BUTTON_PRESSED_BACKGROUND_COLORS[button_style]
 
   # Draw the button with rounded corners
@@ -120,7 +120,7 @@ def gui_button(
     color = BUTTON_TEXT_COLOR[button_style] if is_enabled else BUTTON_DISABLED_TEXT_COLOR
     rl.draw_text_ex(font, text, text_pos, font_size, 0, color)
 
-  if is_enabled and gui_app.mouse.check_clicked(rect):
+  if is_enabled and gui_app.mouse.is_clicked_in(rect):
     gui_app.mouse.consumed = True
     return 1
   return 0

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -167,16 +167,12 @@ class MultipleButtonAction(ItemAction):
       button_x = rect.x + i * (self.button_width + spacing)
       button_rect = rl.Rectangle(button_x, button_y, self.button_width, 100)
 
-      # Check button state
-      mouse_pos = rl.get_mouse_position()
-      is_hovered = rl.check_collision_point_rec(mouse_pos, button_rect)
-      is_pressed = is_hovered and rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT)
       is_selected = i == self.selected_button
 
       # Button colors
       if is_selected:
         bg_color = rl.Color(51, 171, 76, 255)  # Green
-      elif is_pressed:
+      elif gui_app.mouse.is_held_down_in(button_rect):
         bg_color = rl.Color(74, 74, 74, 255)  # Dark gray
       else:
         bg_color = rl.Color(57, 57, 57, 255)  # Gray
@@ -191,7 +187,7 @@ class MultipleButtonAction(ItemAction):
       rl.draw_text_ex(self._font, text, rl.Vector2(text_x, text_y), 40, 0, rl.Color(228, 228, 228, 255))
 
       # Handle click
-      if is_hovered and rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
+      if gui_app.mouse.consume_clicked_in(button_rect):
         clicked = i
 
     if clicked >= 0:
@@ -282,8 +278,7 @@ class ListView(Widget):
     scroll_offset = self.scroll_panel.handle_scroll(rect, content_rect)
 
     # Handle mouse interaction
-    if self.scroll_panel.is_click_valid():
-      self._handle_mouse_interaction(rect, scroll_offset)
+    self._handle_mouse_interaction(rect, scroll_offset)
 
     # Set scissor mode for clipping
     rl.begin_scissor_mode(int(rect.x), int(rect.y), int(rect.width), int(rect.height))
@@ -396,7 +391,7 @@ class ListView(Widget):
             break
 
     # Handle click on main item (not right item)
-    if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT) and self._hovered_item >= 0:
+    if gui_app.mouse.is_clicked_in(rect) and self._hovered_item >= 0:
       item = self._items[self._hovered_item]
 
       # Check if click was on right item area
@@ -405,7 +400,7 @@ class ListView(Widget):
         adjusted_rect = rl.Rectangle(item.rect.x, item.rect.y + scroll_offset.y, item.rect.width, item.rect.height)
         right_rect = item.get_right_item_rect(adjusted_rect)
 
-        if rl.check_collision_point_rec(mouse_pos, right_rect):
+        if gui_app.mouse.is_clicked_in(right_rect):
           # Click was on right item, don't toggle description
           return
 

--- a/system/ui/lib/mouse_state.py
+++ b/system/ui/lib/mouse_state.py
@@ -40,15 +40,15 @@ class MouseState:
   def consumed(self, value: bool):
     self._consumed = value
 
-  def check_pressed(self, rect: rl.Rectangle) -> bool:
+  def is_pressed_in(self, rect: rl.Rectangle) -> bool:
     """Check if mouse was pressed inside the given rectangle."""
     return self.pressed and rl.check_collision_point_rec(self._position, rect)
 
-  def check_released(self, rect: rl.Rectangle) -> bool:
+  def is_released_in(self, rect: rl.Rectangle) -> bool:
     """Check if mouse was released inside the given rectangle."""
     return self.released and rl.check_collision_point_rec(self._position, rect)
 
-  def check_clicked(self, rect: rl.Rectangle) -> bool:
+  def is_clicked_in(self, rect: rl.Rectangle) -> bool:
     """
     Check for a click inside the rectangle:
     Mouse was pressed and released inside the same rect.
@@ -59,6 +59,15 @@ class MouseState:
       and rl.check_collision_point_rec(self._position, rect)
     )
 
-  def check_down(self, rect: rl.Rectangle) -> bool:
+  def consume_clicked_in(self, rect: rl.Rectangle) -> bool:
+    if self.is_clicked_in(rect):
+      self._consumed = True
+      return True
+    return False
+
+  def is_held_down_in(self, rect: rl.Rectangle) -> bool:
     """Check if mouse is currently held down after being pressed in the rectangle."""
     return self._is_down and not self._consumed and rl.check_collision_point_rec(self._pressed_pos, rect)
+
+  def consume_event(self) -> None:
+    self._consumed = True

--- a/system/ui/lib/mouse_state.py
+++ b/system/ui/lib/mouse_state.py
@@ -1,0 +1,64 @@
+import pyray as rl
+
+
+class MouseState:
+  def __init__(self):
+    self._position: rl.Vector2 = rl.Vector2(0, 0, 0, 0)
+    self._released: bool = False
+    self._consumed: bool = False
+    self._pressed_pos: rl.Vector2 = rl.Vector2(0, 0, 0, 0)
+    self._is_down: bool = False
+
+  def update(self):
+    """Update the mouse state for the current frame."""
+    self._consumed = False
+    self._position = rl.get_mouse_position()
+    self._pressed = rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT)
+    self._released = rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT)
+    self._is_down = rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT)
+
+    if self._pressed:
+      self._pressed_pos = self._position
+
+  @property
+  def position(self) -> rl.Vector2:
+    return self._position
+
+  @property
+  def pressed(self) -> bool:
+    return self._pressed and not self._consumed
+
+  @property
+  def released(self) -> bool:
+    return self._released and not self._consumed
+
+  @property
+  def consumed(self) -> bool:
+    return self._consumed
+
+  @consumed.setter
+  def consumed(self, value: bool):
+    self._consumed = value
+
+  def check_pressed(self, rect: rl.Rectangle) -> bool:
+    """Check if mouse was pressed inside the given rectangle."""
+    return self.pressed and rl.check_collision_point_rec(self._position, rect)
+
+  def check_released(self, rect: rl.Rectangle) -> bool:
+    """Check if mouse was released inside the given rectangle."""
+    return self.released and rl.check_collision_point_rec(self._position, rect)
+
+  def check_clicked(self, rect: rl.Rectangle) -> bool:
+    """
+    Check for a click inside the rectangle:
+    Mouse was pressed and released inside the same rect.
+    """
+    return (
+      self.released
+      and rl.check_collision_point_rec(self._pressed_pos, rect)
+      and rl.check_collision_point_rec(self._position, rect)
+    )
+
+  def check_down(self, rect: rl.Rectangle) -> bool:
+    """Check if mouse is currently held down after being pressed in the rectangle."""
+    return self._is_down and not self._consumed and rl.check_collision_point_rec(self._pressed_pos, rect)

--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -97,7 +97,7 @@ class GuiScrollPanel:
           self._is_dragging = True
 
         if self._scroll_state == ScrollState.DRAGGING_CONTENT:
-          gui_app.muse.consume_event()
+          gui_app.mouse.consume_event()
           # Add resistance at boundaries
           if (self._offset.y > 0 and delta_y > 0) or (self._offset.y < -max_scroll_y and delta_y < 0):
             delta_y *= BOUNCE_FACTOR

--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -124,6 +124,11 @@ class GuiScrollPanel:
             avg_velocity = weighted_velocity / total_weight
             self._velocity_y = avg_velocity * FLICK_MULTIPLIER
 
+        if self._is_dragging:
+          gui_app.mouse.consume_event()
+
+        self._is_dragging = False
+
         # Check bounds
         if self._offset.y > 0 or self._offset.y < -max_scroll_y:
           self._scroll_state = ScrollState.BOUNCING

--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -1,6 +1,7 @@
 import pyray as rl
 from enum import IntEnum
 
+
 # Scroll constants for smooth scrolling behavior
 MOUSE_WHEEL_SCROLL_SPEED = 30
 INERTIA_FRICTION = 0.92        # The rate at which the inertia slows down

--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -1,5 +1,6 @@
 import pyray as rl
 from enum import IntEnum
+from openpilot.system.ui.lib.application import gui_app
 
 
 # Scroll constants for smooth scrolling behavior
@@ -55,7 +56,7 @@ class GuiScrollPanel:
     max_scroll_y = max(content.height - bounds.height, 0)
 
     # Start dragging on mouse press
-    if rl.check_collision_point_rec(mouse_pos, bounds) and rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
+    if gui_app.mouse.is_pressed_in(bounds):
       if self._scroll_state == ScrollState.IDLE or self._scroll_state == ScrollState.BOUNCING:
         self._scroll_state = ScrollState.DRAGGING_CONTENT
         if self._show_vertical_scroll_bar:
@@ -74,7 +75,7 @@ class GuiScrollPanel:
 
     # Handle active dragging
     if self._scroll_state == ScrollState.DRAGGING_CONTENT or self._scroll_state == ScrollState.DRAGGING_SCROLLBAR:
-      if rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT):
+      if gui_app.mouse.is_held_down_in(bounds):
         delta_y = mouse_pos.y - self._last_mouse_y
 
         # Track velocity for inertia
@@ -91,9 +92,12 @@ class GuiScrollPanel:
         # Detect actual dragging
         total_drag = abs(mouse_pos.y - self._start_mouse_y)
         if total_drag > DRAG_THRESHOLD:
+          #consume the mouse event to prevent propagation
+          gui_app.mouse.consume_event()
           self._is_dragging = True
 
         if self._scroll_state == ScrollState.DRAGGING_CONTENT:
+          gui_app.muse.consume_event()
           # Add resistance at boundaries
           if (self._offset.y > 0 and delta_y > 0) or (self._offset.y < -max_scroll_y and delta_y < 0):
             delta_y *= BOUNCE_FACTOR

--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -92,20 +92,23 @@ class GuiScrollPanel:
         # Detect actual dragging
         total_drag = abs(mouse_pos.y - self._start_mouse_y)
         if total_drag > DRAG_THRESHOLD:
-          #consume the mouse event to prevent propagation
-          gui_app.mouse.consume_event()
           self._is_dragging = True
 
         if self._scroll_state == ScrollState.DRAGGING_CONTENT:
-          gui_app.mouse.consume_event()
+          # Only consume if we're actually dragging (past threshold)
+          if self._is_dragging:
+            gui_app.mouse.consume_event()
+
           # Add resistance at boundaries
           if (self._offset.y > 0 and delta_y > 0) or (self._offset.y < -max_scroll_y and delta_y < 0):
             delta_y *= BOUNCE_FACTOR
 
           self._offset.y += delta_y
         elif self._scroll_state == ScrollState.DRAGGING_SCROLLBAR:
-          scroll_ratio = content.height / bounds.height
-          self._offset.y -= delta_y * scroll_ratio
+            # Always consume for scrollbar dragging
+            gui_app.mouse.consume_event()
+            scroll_ratio = content.height / bounds.height
+            self._offset.y -= delta_y * scroll_ratio
 
         self._last_mouse_y = mouse_pos.y
 

--- a/system/ui/lib/toggle.py
+++ b/system/ui/lib/toggle.py
@@ -28,7 +28,7 @@ class Toggle(Widget):
     if not self._enabled:
       return 0
 
-    if gui_app.mouse.consume_clicked_int(self._rect):
+    if gui_app.mouse.consume_clicked_in(self._rect):
       self._state = not self._state
       self._target = 1.0 if self._state else 0.0
       return 1

--- a/system/ui/lib/toggle.py
+++ b/system/ui/lib/toggle.py
@@ -1,5 +1,6 @@
 import pyray as rl
 from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.application import gui_app
 
 ON_COLOR = rl.Color(51, 171, 76, 255)
 OFF_COLOR = rl.Color(0x39, 0x39, 0x39, 255)
@@ -27,11 +28,10 @@ class Toggle(Widget):
     if not self._enabled:
       return 0
 
-    if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
-      if rl.check_collision_point_rec(rl.get_mouse_position(), self._rect):
-        self._state = not self._state
-        self._target = 1.0 if self._state else 0.0
-        return 1
+    if gui_app.mouse.consume_clicked_int(self._rect):
+      self._state = not self._state
+      self._target = 1.0 if self._state else 0.0
+      return 1
     return 0
 
   def get_state(self):

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -43,7 +43,7 @@ class Widget(abc.ABC):
     ret = self._render(self._rect)
 
     # Check if mouse was clicked within the widget's rectangle
-    if gui_app.mouse.check_clicked(rect):
+    if gui_app.mouse.is_clicked_in(self._rect):
       result = self._on_mouse_clicked(gui_app.mouse)
       # If the event was handled, mark the mouse input as consumed
       if result:

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -2,18 +2,19 @@ import abc
 import pyray as rl
 from enum import IntEnum
 from collections.abc import Callable
+from openpilot.system.ui.lib.application import gui_app, MouseState
 
 
 class DialogResult(IntEnum):
   CANCEL = 0
   CONFIRM = 1
+  OK = 2
   NO_ACTION = -1
 
 
 class Widget(abc.ABC):
   def __init__(self):
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
-    self._is_pressed = False
     self._is_visible: bool | Callable[[], bool] = True
 
   @property
@@ -41,16 +42,12 @@ class Widget(abc.ABC):
 
     ret = self._render(self._rect)
 
-    # Keep track of whether mouse down started within the widget's rectangle
-    mouse_pos = rl.get_mouse_position()
-    if rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
-      if rl.check_collision_point_rec(mouse_pos, self._rect):
-        self._is_pressed = True
-
-    if rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
-      if self._is_pressed and rl.check_collision_point_rec(mouse_pos, self._rect):
-        self._handle_mouse_release(mouse_pos)
-      self._is_pressed = False
+    # Check if mouse was clicked within the widget's rectangle
+    if gui_app.mouse.check_clicked(rect):
+      result = self._on_mouse_clicked(gui_app.mouse)
+      # If the event was handled, mark the mouse input as consumed
+      if result:
+        gui_app.mouse.consumed = True
 
     return ret
 
@@ -64,6 +61,6 @@ class Widget(abc.ABC):
   def _update_layout_rects(self) -> None:
     """Optionally update any layout rects on Widget rect change."""
 
-  def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:
+  def _on_mouse_clicked(self, mouse: MouseState) -> bool:
     """Optionally handle mouse release events."""
     return False

--- a/system/ui/widgets/confirm_dialog.py
+++ b/system/ui/widgets/confirm_dialog.py
@@ -12,7 +12,7 @@ TEXT_AREA_HEIGHT_REDUCTION = 200
 BACKGROUND_COLOR = rl.Color(27, 27, 27, 255)
 
 
-def confirm_dialog(message: str, confirm_text: str, cancel_text: str = "Cancel") -> DialogResult:
+def confirm_dialog(message: str, confirm_text: str, cancel_text: str = "Cancel") -> None:
   dialog_x = (gui_app.width - DIALOG_WIDTH) / 2
   dialog_y = (gui_app.height - DIALOG_HEIGHT) / 2
   dialog_rect = rl.Rectangle(dialog_x, dialog_y, DIALOG_WIDTH, DIALOG_HEIGHT)
@@ -61,8 +61,9 @@ def confirm_dialog(message: str, confirm_text: str, cancel_text: str = "Cancel")
     if gui_button(centered_yes_button, confirm_text, button_style=ButtonStyle.PRIMARY):
       result = DialogResult.CONFIRM
 
-  return result
+  if result != DialogResult.NO_ACTION:
+    gui_app.close_dialog(result)
 
 
-def alert_dialog(message: str, button_text: str = "OK") -> DialogResult:
+def alert_dialog(message: str, button_text: str = "OK") -> None:
   return confirm_dialog(message, button_text, cancel_text="")

--- a/system/ui/widgets/keyboard.py
+++ b/system/ui/widgets/keyboard.py
@@ -5,7 +5,7 @@ from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import ButtonStyle, gui_button
 from openpilot.system.ui.lib.inputbox import InputBox
 from openpilot.system.ui.lib.label import gui_label
-from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.widget import Widget, DialogResult
 
 KEY_FONT_SIZE = 96
 DOUBLE_CLICK_THRESHOLD = 0.5  # seconds
@@ -103,7 +103,8 @@ class Keyboard(Widget):
     gui_label(rl.Rectangle(rect.x, rect.y + 95, rect.width, 60), self._sub_title, 55, font_weight=FontWeight.NORMAL)
     if gui_button(rl.Rectangle(rect.x + rect.width - 386, rect.y, 386, 125), "Cancel"):
       self.clear()
-      return 0
+      gui_app.close_dialog(DialogResult.CANCEL)
+      return
 
     # Draw input box and password toggle
     input_margin = 25
@@ -168,11 +169,10 @@ class Keyboard(Widget):
 
         if result:
           if key == ENTER_KEY:
-            return 1
+            gui_app.close_dialog(DialogResult.CONFIRM)
+            return
           else:
             self.handle_key_press(key)
-
-    return -1
 
   def _render_input_area(self, input_rect: rl.Rectangle):
     if self._show_password_toggle:
@@ -225,18 +225,3 @@ class Keyboard(Widget):
       self._input_box.add_char_at_cursor(key)
       if not self._caps_lock and self._layout_name == "uppercase":
         self._layout_name = "lowercase"
-
-
-if __name__ == "__main__":
-  gui_app.init_window("Keyboard")
-  keyboard = Keyboard(min_text_size=8, show_password_toggle=True)
-  for _ in gui_app.render():
-    keyboard.set_title("Keyboard Input", "Type your text below")
-    result = keyboard.render(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
-    if result == 1:
-      print(f"You typed: {keyboard.text}")
-      gui_app.request_close()
-    elif result == 0:
-      print("Canceled")
-      gui_app.request_close()
-  gui_app.close()

--- a/system/ui/widgets/option_dialog.py
+++ b/system/ui/widgets/option_dialog.py
@@ -1,9 +1,9 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import FontWeight
+from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.button import gui_button, ButtonStyle, TextAlignment
 from openpilot.system.ui.lib.label import gui_label
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
-from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.widget import Widget, DialogResult
 
 # Constants
 MARGIN = 50
@@ -61,11 +61,13 @@ class MultiOptionDialog(Widget):
     button_y = content_rect.y + content_rect.height - BUTTON_HEIGHT
     button_w = (content_rect.width - BUTTON_SPACING) / 2
 
+    result = DialogResult.NO_ACTION
     if gui_button(rl.Rectangle(content_rect.x, button_y, button_w, BUTTON_HEIGHT), "Cancel"):
-      return 0
+      result = DialogResult.CANCEL
 
     if gui_button(rl.Rectangle(content_rect.x + button_w + BUTTON_SPACING, button_y, button_w, BUTTON_HEIGHT),
                   "Select", is_enabled=self.selection != self.current, button_style=ButtonStyle.PRIMARY):
-      return 1
+      result = DialogResult.OK
 
-    return -1
+    if result != DialogResult.NO_ACTION:
+      gui_app.close_dialog(result)


### PR DESCRIPTION
Added a new `MouseState` class to centralize and simplify mouse event handling throughout the application. The `Widget` class has been refactored to utilize `MouseState` for mouse interactions. Key improvements include:

1. **Centralized Mouse Handling:** `MouseState` tracks mouse position, press, release, and click states, ensuring consistent and clear event management.
2. **Optimized Mouse Event Queries:**     Mouse status queries (e.g., `rl.get_mouse_position`, `rl.is_mouse_button_pressed`, etc.) are now performed only once per frame in `MouseState`. The results are then shared and reused by all widgets
3.  **Event Consumption & Propagation:** If a widget's `_on_mouse_xxx` handler returns `True`, the mouse event is marked as consumed, preventing it from being propagated to other widgets. This ensures only one widget processes each mouse event.
4. **Dialog Result Handling:** Dialogs now call `gui_app.close_dialog(result) `to close dialog and pass the dialog result to a callback, rather than returning a value from render.
5. **Unified Dialog Results:** All dialogs now return a `DialogResult` enum instead of magic numbers like -1, 0, or 1.
6. **Simplified Mouse Handling:** Mouse event handling and checks have been greatly simplified for better readability and maintainability.


@sshane : This PR does not refactor all widgets to use the new `MouseState` and the widget callback mechanism. Many widgets still use the old approach, and updating them all at once would be too large and error-prone. I will update the remaining widgets to use widget.`_on_mouse_xxx` methods for mouse event handling in future PRs, completing the transition step by step.
