### PR TITLE
ui:  boost onroad rendering performance with update-on-change strategy

### DIFF
--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -6,6 +6,7 @@ from openpilot.selfdrive.ui.layouts.home import HomeLayout
 from openpilot.selfdrive.ui.layouts.settings.settings import SettingsLayout, PanelType
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.selfdrive.ui.onroad.augmented_road_view import AugmentedRoadView
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.widget import Widget
 
 
@@ -82,6 +83,10 @@ class MainLayout(Widget):
     self._sidebar.set_visible(not self._sidebar.is_visible)
 
   def _render_main_content(self):
+    # Disable auto background clear during ONROAD mode to optimize rendering.
+    # Enable it in other modes to avoid visual artifacts.
+    gui_app.set_auto_clear_background(self._current_mode != MainState.ONROAD)
+
     # Render sidebar
     if self._sidebar.is_visible:
       self._sidebar.render(self._sidebar_rect)

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -63,6 +63,9 @@ ALERT_CRITICAL_REBOOT = Alert(
 class AlertRenderer(Widget):
   def __init__(self):
     super().__init__()
+
+    self._last_recv_frame = -1
+
     self.font_regular: rl.Font = gui_app.font(FontWeight.NORMAL)
     self.font_bold: rl.Font = gui_app.font(FontWeight.BOLD)
 
@@ -70,9 +73,13 @@ class AlertRenderer(Widget):
     """Generate the current alert based on selfdrive state."""
     ss = sm['selfdriveState']
 
+    recv_frame = sm.recv_frame['selfdriveState']
+    frame_updated = recv_frame != self._last_recv_frame
+    if frame_updated:
+      self._last_recv_frame = recv_frame
+
     # Check if selfdriveState messages have stopped arriving
-    if not sm.updated['selfdriveState']:
-      recv_frame = sm.recv_frame['selfdriveState']
+    if not frame_updated:
       time_since_onroad = (sm.frame - ui_state.started_frame) / DEFAULT_FPS
 
       # 1. Never received selfdriveState since going onroad

--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -99,6 +99,8 @@ class AugmentedRoadView(CameraView):
     # End clipping region
     rl.end_scissor_mode()
 
+  def render(self, rect: rl.Rectangle):
+    self._render(rect)
     # Handle click events if no HUD interaction occurred
     if not self._hud_renderer.handle_mouse_event():
       if self._click_callback and rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):

--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -85,6 +85,7 @@ class AugmentedRoadView(CameraView):
     # Draw the camera image as the background, aligned using calibration.
     # If CameraView didn't produce a new frame, skip drawing overlays to save CPU/GPU.
     if not super()._render(rect):
+      rl.end_scissor_mode()
       return
 
     # Draw all UI overlays
@@ -99,13 +100,14 @@ class AugmentedRoadView(CameraView):
     # End clipping region
     rl.end_scissor_mode()
 
-  def render(self, rect: rl.Rectangle):
+  def render(self, rect: rl.Rectangle = None) -> bool | int | None:
     self._render(rect)
     # Handle click events if no HUD interaction occurred
     if not self._hud_renderer.handle_mouse_event():
       if self._click_callback and rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
         if rl.check_collision_point_rec(rl.get_mouse_position(), self._content_rect):
           self._click_callback()
+    return None
 
   def _draw_border(self, rect: rl.Rectangle):
     border_color = BORDER_COLORS.get(ui_state.status, BORDER_COLORS[UIStatus.DISENGAGED])

--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -173,14 +173,14 @@ class CameraView(Widget):
     if buffer:
       self._texture_needs_update = True
       self.frame = buffer
-    elif not gui_app.auto_clear_background:
-      # No need to redraw - previous frame remains visible when background isn't auto-cleared
-      return False
 
     if not self.frame:
       self._draw_placeholder(rect)
       return False
 
+    # If no new frame and background isn't auto-cleared, skip redraw
+    if not buffer and not gui_app.auto_clear_background:
+      return False
 
     transform = self._calc_frame_matrix(rect)
     src_rect = rl.Rectangle(0, 0, float(self.frame.width), float(self.frame.height))

--- a/selfdrive/ui/onroad/driver_state.py
+++ b/selfdrive/ui/onroad/driver_state.py
@@ -45,6 +45,9 @@ class ArcData:
 class DriverStateRenderer(Widget):
   def __init__(self):
     super().__init__()
+
+    self._last_driver_state_frame = -1
+
     # Initial state with NumPy arrays
     self.face_kpts_draw = DEFAULT_FACE_KPTS_3D.copy()
     self.is_active = False
@@ -106,12 +109,14 @@ class DriverStateRenderer(Widget):
   def _update_state(self):
     """Update the driver monitoring state based on model data"""
     sm = ui_state.sm
-    if not sm.updated["driverMonitoringState"]:
+    frame_updated = sm.recv_frame["driverStateV2"] != self._last_driver_state_frame
+    if not frame_updated:
       if (self._rect.x != self.last_rect.x or self._rect.y != self.last_rect.y or
           self._rect.width != self.last_rect.width or self._rect.height != self.last_rect.height):
         self._pre_calculate_drawing_elements()
         self.last_rect = self._rect
       return
+    self._last_driver_state_frame = sm.recv_frame["driverStateV2"]
 
     # Get monitoring state
     dm_state = sm["driverMonitoringState"]

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -47,6 +47,8 @@ class LeadVehicle:
 class ModelRenderer(Widget):
   def __init__(self):
     super().__init__()
+
+    self._last_model_frame = -1
     self._longitudinal_control = False
     self._experimental_mode = False
     self._blend_factor = 1.0
@@ -102,7 +104,11 @@ class ModelRenderer(Widget):
     live_calib = sm['liveCalibration']
     self._path_offset_z = live_calib.height[0] if live_calib.height else HEIGHT_INIT[0]
 
-    if sm.updated['carParams']:
+    model_updated = sm.recv_frame["modelV2"] != self._last_model_frame
+    if model_updated:
+      self._last_model_frame = sm.recv_frame["modelV2"]
+
+    if sm.valid['carParams']:
       self._longitudinal_control = sm['carParams'].openpilotLongitudinalControl
 
     model = sm['modelV2']
@@ -111,8 +117,7 @@ class ModelRenderer(Widget):
     render_lead_indicator = self._longitudinal_control and radar_state is not None
 
     # Update model data when needed
-    model_updated = sm.updated['modelV2']
-    if model_updated or sm.updated['radarState'] or self._transform_dirty:
+    if model_updated or self._transform_dirty:
       if model_updated:
         self._update_raw_points(model)
 

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -59,6 +59,7 @@ class GuiApplication:
     self._window_close_requested = False
     self._trace_log_callback = None
     self._modal_overlay = ModalOverlay()
+    self._auto_clear_background = True
 
   def request_close(self):
     self._window_close_requested = True
@@ -87,6 +88,18 @@ class GuiApplication:
     self._target_fps = fps
     self._set_styles()
     self._load_fonts()
+
+  @property
+  def auto_clear_background(self) -> bool:
+    """Check if automatic background clearing is enabled."""
+    return self._auto_clear_background
+
+  def set_auto_clear_background(self, auto_fill: bool):
+    """Enable or disable automatic background clearing."""
+    if auto_fill != self._auto_clear_background:
+      self._auto_clear_background = auto_fill
+      if auto_fill:
+        rl.clear_background(rl.BLACK)
 
   def set_modal_overlay(self, overlay, callback: Callable | None = None):
     self._modal_overlay = ModalOverlay(overlay=overlay, callback=callback)
@@ -155,9 +168,10 @@ class GuiApplication:
       while not (self._window_close_requested or rl.window_should_close()):
         if self._render_texture:
           rl.begin_texture_mode(self._render_texture)
-          rl.clear_background(rl.BLACK)
         else:
           rl.begin_drawing()
+
+        if self._auto_clear_background:
           rl.clear_background(rl.BLACK)
 
         # Handle modal overlay rendering and input processing
@@ -181,7 +195,8 @@ class GuiApplication:
         if self._render_texture:
           rl.end_texture_mode()
           rl.begin_drawing()
-          rl.clear_background(rl.BLACK)
+          if self._auto_clear_background:
+            rl.clear_background(rl.BLACK)
           src_rect = rl.Rectangle(0, 0, float(self._width), -float(self._height))
           dst_rect = rl.Rectangle(0, 0, float(self._scaled_width), float(self._scaled_height))
           rl.draw_texture_pro(self._render_texture.texture, src_rect, dst_rect, rl.Vector2(0, 0), 0.0, rl.WHITE)


### PR DESCRIPTION
Disable automatic background clearing in `ONROAD` mode, allowing `AugmentedRoadView` to use an update-on-change rendering strategy for better performance.

Key Changes

1. Background is only cleared in settings/home; in onroad mode, the camera feed serves as the background.
2. Overlays are redrawn only when a new camera frame is available.
3. Enhanced `CameraView._render()` logic to accurately detect frame updates.
4. Since `sm.update(0)` runs at 60Hz but camera frames update at 20Hz, using `sm.updated` to check for new data no longer works after this refactor. The logic was updated to use `recv_frame` for accurate frame change detection.

With this update, onroad mode runs efficiently at 60Hz but only refreshes when a new camera frame arrives (20Hz), significantly improving performance and reducing resource usage without impacting UI quality.