### PR TITLE
Fix Typos in Documentation and Comments in ACADOS Template

### DIFF
--- a/third_party/acados/acados_template/acados_ocp.py
+++ b/third_party/acados/acados_template/acados_ocp.py
@@ -2535,7 +2535,7 @@ class AcadosOcpOptions:
     @property
     def eps_sufficient_descent(self):
         """
-        Factor for sufficient descent (Armijo) conditon, see line_search_use_sufficient_descent.
+        Factor for sufficient descent (Armijo) condition, see line_search_use_sufficient_descent.
         Type: float,
         default: 1e-4.
         """

--- a/third_party/acados/acados_template/gnsf/reformulate_with_LOS.py
+++ b/third_party/acados/acados_template/gnsf/reformulate_with_LOS.py
@@ -38,7 +38,7 @@ from ..utils import casadi_length, idx_perm_to_ipiv, is_empty
 def reformulate_with_LOS(acados_ocp, gnsf, print_info):
 
     ## Description:
-    # This function takes an intitial transcription of the implicit ODE model
+    # This function takes an initial transcription of the implicit ODE model
     # "model" into "gnsf" and reformulates "gnsf" with a linear output system
     # (LOS), containing as many states of the model as possible.
     # Therefore it might be that the state vector and the implicit function

--- a/third_party/acados/acados_template/utils.py
+++ b/third_party/acados/acados_template/utils.py
@@ -359,7 +359,7 @@ def set_up_imported_gnsf_model(acados_ocp):
     # if not casadi_version == dump_casadi_version:
     #     print("WARNING: GNSF model was dumped with another CasADi version.\n"
     #             + "This might yield errors. Please use the same version for compatibility, serialize version: "
-    #             + dump_casadi_version + " current Python CasADi verison: " + casadi_version)
+    #             + dump_casadi_version + " current Python CasADi version: " + casadi_version)
     #     input("Press any key to attempt to continue...")
 
     # load model


### PR DESCRIPTION


Description:  
This pull request corrects several minor typographical errors in the documentation and comments within the ACADOS template codebase. Specifically, it fixes the spelling of the words "condition," "initial," and "version" in the following files:
- `acados_ocp.py`
- `reformulate_with_LOS.py`
- `utils.py`

These changes improve the clarity and professionalism of the code documentation and warning messages, but do not affect any functionality or logic.
