### PR TITLE
ui: fix wrong dash character

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -224,7 +224,7 @@ class GuiApplication:
     for layout in KEYBOARD_LAYOUTS.values():
       all_chars.update(key for row in layout for key in row)
     all_chars = "".join(all_chars)
-    all_chars += "-✓"
+    all_chars += "–✓"
 
     codepoint_count = rl.ffi.new("int *", 1)
     codepoints = rl.load_codepoints(all_chars, codepoint_count)


### PR DESCRIPTION
correcting the character set to use en dash (–) instead of hyphen (-):


```diff
- all_chars += "-✓"
+ all_chars += "–✓"
```