### PR TITLE
ui: update layout rects on change

### DIFF
--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -84,7 +84,6 @@ class HomeLayout(Widget):
       self._render_alerts_view()
 
   def _update_layout_rects(self):
-    print('hi2')
     self.header_rect = rl.Rectangle(
       self._rect.x + CONTENT_MARGIN, self._rect.y + CONTENT_MARGIN, self._rect.width - 2 * CONTENT_MARGIN, HEADER_HEIGHT
     )

--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -83,7 +83,7 @@ class HomeLayout(Widget):
     elif self.current_state == HomeLayoutState.ALERTS:
       self._render_alerts_view()
 
-  def _update_layout(self):
+  def _update_layout_rects(self):
     self.header_rect = rl.Rectangle(
       self._rect.x + CONTENT_MARGIN, self._rect.y + CONTENT_MARGIN, self._rect.width - 2 * CONTENT_MARGIN, HEADER_HEIGHT
     )

--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -84,6 +84,7 @@ class HomeLayout(Widget):
       self._render_alerts_view()
 
   def _update_layout_rects(self):
+    print('hi2')
     self.header_rect = rl.Rectangle(
       self._rect.x + CONTENT_MARGIN, self._rect.y + CONTENT_MARGIN, self._rect.width - 2 * CONTENT_MARGIN, HEADER_HEIGHT
     )

--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -83,7 +83,7 @@ class HomeLayout(Widget):
     elif self.current_state == HomeLayoutState.ALERTS:
       self._render_alerts_view()
 
-  def _update_layout_rects(self):
+  def _update_layout(self):
     self.header_rect = rl.Rectangle(
       self._rect.x + CONTENT_MARGIN, self._rect.y + CONTENT_MARGIN, self._rect.width - 2 * CONTENT_MARGIN, HEADER_HEIGHT
     )

--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -67,8 +67,6 @@ class HomeLayout(Widget):
     self.current_state = state
 
   def _render(self, rect: rl.Rectangle):
-    self._update_layout_rects(rect)
-
     current_time = time.time()
     if current_time - self.last_refresh >= REFRESH_INTERVAL:
       self._refresh()
@@ -85,16 +83,16 @@ class HomeLayout(Widget):
     elif self.current_state == HomeLayoutState.ALERTS:
       self._render_alerts_view()
 
-  def _update_layout_rects(self, rect: rl.Rectangle):
+  def _update_layout_rects(self):
     self.header_rect = rl.Rectangle(
-      rect.x + CONTENT_MARGIN, rect.y + CONTENT_MARGIN, rect.width - 2 * CONTENT_MARGIN, HEADER_HEIGHT
+      self._rect.x + CONTENT_MARGIN, self._rect.y + CONTENT_MARGIN, self._rect.width - 2 * CONTENT_MARGIN, HEADER_HEIGHT
     )
 
-    content_y = rect.y + CONTENT_MARGIN + HEADER_HEIGHT + SPACING
-    content_height = rect.height - CONTENT_MARGIN - HEADER_HEIGHT - SPACING - CONTENT_MARGIN
+    content_y = self._rect.y + CONTENT_MARGIN + HEADER_HEIGHT + SPACING
+    content_height = self._rect.height - CONTENT_MARGIN - HEADER_HEIGHT - SPACING - CONTENT_MARGIN
 
     self.content_rect = rl.Rectangle(
-      rect.x + CONTENT_MARGIN, content_y, rect.width - 2 * CONTENT_MARGIN, content_height
+      self._rect.x + CONTENT_MARGIN, content_y, self._rect.width - 2 * CONTENT_MARGIN, content_height
     )
 
     left_width = self.content_rect.width - RIGHT_COLUMN_WIDTH - SPACING

--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -42,7 +42,6 @@ class MainLayout(Widget):
     self._layouts[MainState.ONROAD].set_callbacks(on_click=self._on_onroad_clicked)
 
   def _update_layout_rects(self):
-    print('hi')
     self._sidebar_rect = rl.Rectangle(self._rect.x, self._rect.y, SIDEBAR_WIDTH, self._rect.height)
 
     x_offset = SIDEBAR_WIDTH if self._sidebar.is_visible else 0

--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -41,7 +41,7 @@ class MainLayout(Widget):
     self._layouts[MainState.SETTINGS].set_callbacks(on_close=self._set_mode_for_state)
     self._layouts[MainState.ONROAD].set_callbacks(on_click=self._on_onroad_clicked)
 
-  def _update_layout_rects(self):
+  def _update_layout(self):
     self._sidebar_rect = rl.Rectangle(self._rect.x, self._rect.y, SIDEBAR_WIDTH, self._rect.height)
 
     x_offset = SIDEBAR_WIDTH if self._sidebar.is_visible else 0

--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -30,8 +30,7 @@ class MainLayout(Widget):
     # Set callbacks
     self._setup_callbacks()
 
-  def _render(self, rect):
-    self._update_layout_rects(rect)
+  def _render(self, _):
     self._handle_onroad_transition()
     self._render_main_content()
 
@@ -42,11 +41,12 @@ class MainLayout(Widget):
     self._layouts[MainState.SETTINGS].set_callbacks(on_close=self._set_mode_for_state)
     self._layouts[MainState.ONROAD].set_callbacks(on_click=self._on_onroad_clicked)
 
-  def _update_layout_rects(self, rect):
-    self._sidebar_rect = rl.Rectangle(rect.x, rect.y, SIDEBAR_WIDTH, rect.height)
+  def _update_layout_rects(self):
+    print('hi')
+    self._sidebar_rect = rl.Rectangle(self._rect.x, self._rect.y, SIDEBAR_WIDTH, self._rect.height)
 
     x_offset = SIDEBAR_WIDTH if self._sidebar.is_visible else 0
-    self._content_rect = rl.Rectangle(rect.y + x_offset, rect.y, rect.width - x_offset, rect.height)
+    self._content_rect = rl.Rectangle(self._rect.y + x_offset, self._rect.y, self._rect.width - x_offset, self._rect.height)
 
   def _handle_onroad_transition(self):
     if ui_state.started != self._prev_onroad:

--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -41,7 +41,7 @@ class MainLayout(Widget):
     self._layouts[MainState.SETTINGS].set_callbacks(on_close=self._set_mode_for_state)
     self._layouts[MainState.ONROAD].set_callbacks(on_click=self._on_onroad_clicked)
 
-  def _update_layout(self):
+  def _update_layout_rects(self):
     self._sidebar_rect = rl.Rectangle(self._rect.x, self._rect.y, SIDEBAR_WIDTH, self._rect.height)
 
     x_offset = SIDEBAR_WIDTH if self._sidebar.is_visible else 0

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -275,7 +275,7 @@ class ListView(Widget):
     self._total_height = 0
 
   def _render(self, rect: rl.Rectangle):
-    self._update_layout_rects()
+    self._update_layout()
 
     # Update layout and handle scrolling
     content_rect = rl.Rectangle(rect.x, rect.y, rect.width, self._total_height)
@@ -318,7 +318,7 @@ class ListView(Widget):
         return i
     return None
 
-  def _update_layout_rects(self):
+  def _update_layout(self):
     current_y = 0.0
     for item in self._items:
       if not item.is_visible:

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -275,7 +275,7 @@ class ListView(Widget):
     self._total_height = 0
 
   def _render(self, rect: rl.Rectangle):
-    self._update_layout()
+    self._update_layout_rects()
 
     # Update layout and handle scrolling
     content_rect = rl.Rectangle(rect.x, rect.y, rect.width, self._total_height)
@@ -318,7 +318,7 @@ class ListView(Widget):
         return i
     return None
 
-  def _update_layout(self):
+  def _update_layout_rects(self):
     current_y = 0.0
     for item in self._items:
       if not item.is_visible:

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -275,6 +275,8 @@ class ListView(Widget):
     self._total_height = 0
 
   def _render(self, rect: rl.Rectangle):
+    self._update_layout_rects()
+
     # Update layout and handle scrolling
     content_rect = rl.Rectangle(rect.x, rect.y, rect.width, self._total_height)
     scroll_offset = self.scroll_panel.handle_scroll(rect, content_rect)

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -272,12 +272,11 @@ class ListView(Widget):
     self.scroll_panel = GuiScrollPanel()
     self._font = gui_app.font(FontWeight.NORMAL)
     self._hovered_item = -1
+    self._total_height = 0
 
   def _render(self, rect: rl.Rectangle):
-    total_height = self._update_item_rects(rect)
-
     # Update layout and handle scrolling
-    content_rect = rl.Rectangle(rect.x, rect.y, rect.width, total_height)
+    content_rect = rl.Rectangle(rect.x, rect.y, rect.width, self._total_height)
     scroll_offset = self.scroll_panel.handle_scroll(rect, content_rect)
 
     # Handle mouse interaction
@@ -317,18 +316,18 @@ class ListView(Widget):
         return i
     return None
 
-  def _update_item_rects(self, container_rect: rl.Rectangle) -> float:
+  def _update_layout_rects(self):
     current_y = 0.0
     for item in self._items:
       if not item.is_visible:
-        item.rect = rl.Rectangle(container_rect.x, container_rect.y + current_y, container_rect.width, 0)
+        item.rect = rl.Rectangle(self._rect.x, self._rect.y + current_y, self._rect.width, 0)
         continue
 
-      content_width = item.get_content_width(int(container_rect.width - ITEM_PADDING * 2))
+      content_width = item.get_content_width(int(self._rect.width - ITEM_PADDING * 2))
       item_height = item.get_item_height(self._font, content_width)
-      item.rect = rl.Rectangle(container_rect.x, container_rect.y + current_y, container_rect.width, item_height)
+      item.rect = rl.Rectangle(self._rect.x, self._rect.y + current_y, self._rect.width, item_height)
       current_y += item_height
-    return current_y  # total height of all items
+    self._total_height = current_y  # total height of all items
 
   def _render_item(self, item: ListItem, y: int):
     content_x = item.rect.x + ITEM_PADDING

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -24,8 +24,11 @@ class Widget(abc.ABC):
     self._is_visible = visible
 
   def set_rect(self, rect: rl.Rectangle) -> None:
+    prev_rect = self._rect
     self._rect = rect
-    self._update_layout_rects()
+    if (rect.x != prev_rect.x or rect.y != prev_rect.y or
+        rect.width != prev_rect.width or rect.height != prev_rect.height):
+      self._update_layout_rects()
 
   def render(self, rect: rl.Rectangle = None) -> bool | int | None:
     if rect is not None:

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -24,11 +24,8 @@ class Widget(abc.ABC):
     self._is_visible = visible
 
   def set_rect(self, rect: rl.Rectangle) -> None:
-    prev_rect = self._rect
     self._rect = rect
-    if (rect.x != prev_rect.x or rect.y != prev_rect.y or
-        rect.width != prev_rect.width or rect.height != prev_rect.height):
-      self._update_layout_rects()
+    self._update_layout_rects()
 
   def render(self, rect: rl.Rectangle = None) -> bool | int | None:
     if rect is not None:

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -28,7 +28,7 @@ class Widget(abc.ABC):
     self._rect = rect
     if (rect.x != prev_rect.x or rect.y != prev_rect.y or
         rect.width != prev_rect.width or rect.height != prev_rect.height):
-      self._update_layout_rects()
+      self._update_layout()
 
   def render(self, rect: rl.Rectangle = None) -> bool | int | None:
     if rect is not None:
@@ -56,7 +56,7 @@ class Widget(abc.ABC):
   def _render(self, rect: rl.Rectangle) -> bool | int | None:
     """Render the widget within the given rectangle."""
 
-  def _update_layout_rects(self) -> None:
+  def _update_layout(self) -> None:
     """Optionally update any layout rects on Widget rect change."""
 
   def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -12,6 +12,7 @@ class DialogResult(IntEnum):
 
 class Widget(abc.ABC):
   def __init__(self):
+    self._prev_rect = rl.Rectangle(0, 0, 0, 0)
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._is_pressed = False
     self._is_visible: bool | Callable[[], bool] = True
@@ -25,6 +26,7 @@ class Widget(abc.ABC):
 
   def set_rect(self, rect: rl.Rectangle) -> None:
     self._rect = rect
+    self._update_layout_rects()
 
   def render(self, rect: rl.Rectangle = None) -> bool | int | None:
     if rect is not None:
@@ -55,3 +57,6 @@ class Widget(abc.ABC):
   def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:
     """Handle mouse release events, if applicable."""
     return False
+
+  def _update_layout_rects(self) -> None:
+    """Update the layout rectangles on change."""

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -28,7 +28,7 @@ class Widget(abc.ABC):
     self._rect = rect
     if (rect.x != prev_rect.x or rect.y != prev_rect.y or
         rect.width != prev_rect.width or rect.height != prev_rect.height):
-      self._update_layout()
+      self._update_layout_rects()
 
   def render(self, rect: rl.Rectangle = None) -> bool | int | None:
     if rect is not None:
@@ -56,7 +56,7 @@ class Widget(abc.ABC):
   def _render(self, rect: rl.Rectangle) -> bool | int | None:
     """Render the widget within the given rectangle."""
 
-  def _update_layout(self) -> None:
+  def _update_layout_rects(self) -> None:
     """Optionally update any layout rects on Widget rect change."""
 
   def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -12,7 +12,6 @@ class DialogResult(IntEnum):
 
 class Widget(abc.ABC):
   def __init__(self):
-    self._prev_rect = rl.Rectangle(0, 0, 0, 0)
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._is_pressed = False
     self._is_visible: bool | Callable[[], bool] = True
@@ -25,8 +24,11 @@ class Widget(abc.ABC):
     self._is_visible = visible
 
   def set_rect(self, rect: rl.Rectangle) -> None:
+    prev_rect = self._rect
     self._rect = rect
-    self._update_layout_rects()
+    if (rect.x != prev_rect.x or rect.y != prev_rect.y or
+        rect.width != prev_rect.width or rect.height != prev_rect.height):
+      self._update_layout_rects()
 
   def render(self, rect: rl.Rectangle = None) -> bool | int | None:
     if rect is not None:
@@ -54,9 +56,9 @@ class Widget(abc.ABC):
   def _render(self, rect: rl.Rectangle) -> bool | int | None:
     """Render the widget within the given rectangle."""
 
-  def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:
-    """Handle mouse release events, if applicable."""
-    return False
-
   def _update_layout_rects(self) -> None:
-    """Update the layout rectangles on change."""
+    """Optionally update any layout rects on Widget rect change."""
+
+  def _handle_mouse_release(self, mouse_pos: rl.Vector2) -> bool:
+    """Optionally handle mouse release events."""
+    return False


### PR DESCRIPTION
Mainly just removes manually calling `_update_layout_rects`, and now supports on-change children rect updates (ListView needs to always calculate since children can change without rect changing. This should be done in a clean way somehow. Layout change signals? cc @deanlee)