### PR TITLE
ui: increase settings nav btn height

### DIFF
--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -18,7 +18,7 @@ SETTINGS_CLOSE_TEXT = "X"
 # Constants
 SIDEBAR_WIDTH = 500
 CLOSE_BTN_SIZE = 200
-NAV_BTN_HEIGHT = 80
+NAV_BTN_HEIGHT = 110
 PANEL_MARGIN = 50
 
 # Colors
@@ -104,8 +104,6 @@ class SettingsLayout(Widget):
 
     # Navigation buttons
     y = rect.y + 300
-    button_spacing = 20
-
     for panel_type, panel_info in self._panels.items():
       button_rect = rl.Rectangle(rect.x + 50, y, rect.width - 150, NAV_BTN_HEIGHT)
 
@@ -122,7 +120,7 @@ class SettingsLayout(Widget):
       # Store button rect for click detection
       panel_info.button_rect = button_rect
 
-      y += NAV_BTN_HEIGHT + button_spacing
+      y += NAV_BTN_HEIGHT
 
   def _draw_current_panel(self, rect: rl.Rectangle):
     rl.draw_rectangle_rounded(


### PR DESCRIPTION
Increase Settings nav button height and remove spacing between buttons to make them easier to tap.

before 
![2025-06-13_22-03](https://github.com/user-attachments/assets/41cf5748-13f8-415b-be80-d4c0b9d6aadf)
after 
![2025-06-13_22-02](https://github.com/user-attachments/assets/ae9818df-d9c0-4b7a-99ad-55a249b6d62f)
