### PR TITLE
ui: fix GuiScrollPanel drag threshold detection and state management

### DIFF
--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -5,7 +5,7 @@ from enum import IntEnum
 MOUSE_WHEEL_SCROLL_SPEED = 30
 INERTIA_FRICTION = 0.92        # The rate at which the inertia slows down
 MIN_VELOCITY = 0.5             # Minimum velocity before stopping the inertia
-DRAG_THRESHOLD = 12            # Pixels of movement to consider it a drag, not a click
+DRAG_THRESHOLD = 22            # Pixels of movement to consider it a drag, not a click
 BOUNCE_FACTOR = 0.2            # Elastic bounce when scrolling past boundaries
 BOUNCE_RETURN_SPEED = 0.15     # How quickly it returns from the bounce
 MAX_BOUNCE_DISTANCE = 150      # Maximum distance for bounce effect
@@ -15,9 +15,11 @@ VELOCITY_HISTORY_SIZE = 5      # Track velocity over multiple frames for smoothe
 
 class ScrollState(IntEnum):
   IDLE = 0
-  DRAGGING_CONTENT = 1
-  DRAGGING_SCROLLBAR = 2
-  BOUNCING = 3
+  POTENTIAL_DRAG = 1           # Waiting to see if movement exceeds threshold
+  DRAGGING_CONTENT = 2
+  DRAGGING_SCROLLBAR = 3
+  BOUNCING = 4
+  INERTIA = 5                  # Scrolling due to inertia after release
 
 
 class GuiScrollPanel:
@@ -53,15 +55,19 @@ class GuiScrollPanel:
     mouse_pos = rl.get_mouse_position()
     max_scroll_y = max(content.height - bounds.height, 0)
 
-    # Start dragging on mouse press
+    # Start potential drag on mouse press
     if rl.check_collision_point_rec(mouse_pos, bounds) and rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT):
-      if self._scroll_state == ScrollState.IDLE or self._scroll_state == ScrollState.BOUNCING:
-        self._scroll_state = ScrollState.DRAGGING_CONTENT
+      if self._scroll_state in (ScrollState.IDLE, ScrollState.BOUNCING, ScrollState.INERTIA):
+        # Check if clicking on scrollbar
         if self._show_vertical_scroll_bar:
           scrollbar_width = rl.gui_get_style(rl.GuiControl.LISTVIEW, rl.GuiListViewProperty.SCROLLBAR_WIDTH)
           scrollbar_x = bounds.x + bounds.width - scrollbar_width
           if mouse_pos.x >= scrollbar_x:
             self._scroll_state = ScrollState.DRAGGING_SCROLLBAR
+          else:
+            self._scroll_state = ScrollState.POTENTIAL_DRAG  # Wait for threshold
+        else:
+          self._scroll_state = ScrollState.POTENTIAL_DRAG  # Wait for threshold
 
         self._last_mouse_y = mouse_pos.y
         self._start_mouse_y = mouse_pos.y
@@ -71,8 +77,26 @@ class GuiScrollPanel:
         self._bounce_offset = 0.0
         self._is_dragging = False
 
+    # Handle potential drag (waiting for threshold)
+    elif self._scroll_state == ScrollState.POTENTIAL_DRAG:
+      if rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT):
+        total_drag_distance = abs(mouse_pos.y - self._start_mouse_y)
+
+        if total_drag_distance > DRAG_THRESHOLD:
+          # Threshold exceeded - start actual dragging
+          self._scroll_state = ScrollState.DRAGGING_CONTENT
+          self._is_dragging = True
+
+        # Update mouse position for velocity tracking
+        self._last_mouse_y = mouse_pos.y
+
+      elif rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
+        # Released before threshold - this was a click, not a drag
+        self._scroll_state = ScrollState.IDLE
+        self._is_dragging = False
+
     # Handle active dragging
-    if self._scroll_state == ScrollState.DRAGGING_CONTENT or self._scroll_state == ScrollState.DRAGGING_SCROLLBAR:
+    elif self._scroll_state in (ScrollState.DRAGGING_CONTENT, ScrollState.DRAGGING_SCROLLBAR):
       if rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT):
         delta_y = mouse_pos.y - self._last_mouse_y
 
@@ -87,11 +111,6 @@ class GuiScrollPanel:
 
         self._last_drag_time = current_time
 
-        # Detect actual dragging
-        total_drag = abs(mouse_pos.y - self._start_mouse_y)
-        if total_drag > DRAG_THRESHOLD:
-          self._is_dragging = True
-
         if self._scroll_state == ScrollState.DRAGGING_CONTENT:
           # Add resistance at boundaries
           if (self._offset.y > 0 and delta_y > 0) or (self._offset.y < -max_scroll_y and delta_y < 0):
@@ -99,14 +118,14 @@ class GuiScrollPanel:
 
           self._offset.y += delta_y
         elif self._scroll_state == ScrollState.DRAGGING_SCROLLBAR:
-          scroll_ratio = content.height / bounds.height
+          scroll_ratio = content.height / bounds.height if bounds.height > 0 else 1.0
           self._offset.y -= delta_y * scroll_ratio
 
         self._last_mouse_y = mouse_pos.y
 
       elif rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
-        # Calculate flick velocity
-        if self._velocity_history:
+        # Calculate flick velocity only if it was actual dragging
+        if self._velocity_history and self._is_dragging:
           total_weight = 0
           weighted_velocity = 0.0
 
@@ -119,9 +138,14 @@ class GuiScrollPanel:
             avg_velocity = weighted_velocity / total_weight
             self._velocity_y = avg_velocity * FLICK_MULTIPLIER
 
-        # Check bounds
+        # Reset drag state
+        self._is_dragging = False
+
+        # Determine next state
         if self._offset.y > 0 or self._offset.y < -max_scroll_y:
           self._scroll_state = ScrollState.BOUNCING
+        elif abs(self._velocity_y) > MIN_VELOCITY:
+          self._scroll_state = ScrollState.INERTIA
         else:
           self._scroll_state = ScrollState.IDLE
 
@@ -138,9 +162,11 @@ class GuiScrollPanel:
 
       if self._offset.y > 0 or self._offset.y < -max_scroll_y:
         self._scroll_state = ScrollState.BOUNCING
+      else:
+        self._scroll_state = ScrollState.IDLE
 
     # Apply inertia (continue scrolling after mouse release)
-    if self._scroll_state == ScrollState.IDLE:
+    if self._scroll_state == ScrollState.INERTIA:
       if abs(self._velocity_y) > MIN_VELOCITY:
         self._offset.y += self._velocity_y
         self._velocity_y *= INERTIA_FRICTION
@@ -149,6 +175,7 @@ class GuiScrollPanel:
           self._scroll_state = ScrollState.BOUNCING
       else:
         self._velocity_y = 0.0
+        self._scroll_state = ScrollState.IDLE
 
     # Handle bouncing effect
     elif self._scroll_state == ScrollState.BOUNCING:
@@ -166,8 +193,8 @@ class GuiScrollPanel:
         self._velocity_y = 0.0
         self._scroll_state = ScrollState.IDLE
 
-    # Limit bounce distance
-    if self._scroll_state != ScrollState.DRAGGING_CONTENT:
+    # Limit bounce distance (except during potential drag to allow threshold detection)
+    if self._scroll_state not in (ScrollState.DRAGGING_CONTENT, ScrollState.POTENTIAL_DRAG):
       if self._offset.y > MAX_BOUNCE_DISTANCE:
         self._offset.y = MAX_BOUNCE_DISTANCE
       elif self._offset.y < -(max_scroll_y + MAX_BOUNCE_DISTANCE):
@@ -178,8 +205,8 @@ class GuiScrollPanel:
   def is_click_valid(self) -> bool:
     # Check if this is a click rather than a drag
     return (
-      self._scroll_state == ScrollState.IDLE
-      and not self._is_dragging
+      not self._is_dragging
+      and self._scroll_state == ScrollState.IDLE
       and rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT)
     )
 


### PR DESCRIPTION
### Bug Fix:
Fixed GuiScrollPanel entering drag mode immediately on mouse press instead of waiting for the drag threshold to be exceeded.

### Changes:
- **Added POTENTIAL_DRAG state**: Waits for movement > DRAG_THRESHOLD  before entering actual drag mode
- **Added INERTIA state**: Separates inertia scrolling from idle state for better physics
- **Fixed drag threshold logic**: Only sets `_is_dragging = True` after threshold is exceeded
- **Improved click detection**: `is_click_valid()` now properly distinguishes clicks from drags
- **Better state transitions**: Clear progression from IDLE → POTENTIAL_DRAG → DRAGGING_CONTENT


**Note:**  
This PR focuses on scroll panel drag/click behavior. Mouse event propagation issues are addressed separately in [PR #35526](https://github.com/commaai/openpilot/pull/35526).