### PR TITLE
ui: enable VSYNC by default

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -14,7 +14,7 @@ FPS_LOG_INTERVAL = 5  # Seconds between logging FPS drops
 FPS_DROP_THRESHOLD = 0.9  # FPS drop threshold for triggering a warning
 FPS_CRITICAL_THRESHOLD = 0.5  # Critical threshold for triggering strict actions
 
-ENABLE_VSYNC = os.getenv("ENABLE_VSYNC") == "1"
+ENABLE_VSYNC = os.getenv("ENABLE_VSYNC", "1") == "1"
 SHOW_FPS = os.getenv("SHOW_FPS") == '1'
 STRICT_MODE = os.getenv("STRICT_MODE") == '1'
 SCALE = float(os.getenv("SCALE", "1.0"))


### PR DESCRIPTION
## Issue
Screen tearing and visual artifacts appear on devices because VSYNC is disabled by default.

## Solution
- Set `ENABLE_VSYNC=1` as the default in application.py
- Override still possible via `ENABLE_VSYNC=0` environment variable