### PR TITLE
ui: fix shader polygon artifacts on device

### DIFF
--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -7,7 +7,7 @@ MAX_GRADIENT_COLORS = 15
 
 VERSION = """
 #version 300 es
-precision mediump float;
+precision highp float;
 """
 if platform.system() == "Darwin":
   VERSION = """
@@ -112,7 +112,7 @@ void main() {
     vec4 color = useGradient == 1 ? getGradientColor(pixel) : fillColor;
     finalColor = vec4(color.rgb, color.a * alpha);
   } else {
-    finalColor = vec4(0.0);
+    discard;
   }
 }
 """


### PR DESCRIPTION
Fixes visual artifacts in polygon shader rendering on device.
- Extra horizontal white blocks at the bottom or middle of the screen
- Occasional horizontal white lines inside polygons

## Cause

device GPU handle floating-point precision differently than desktop GPUs, leading to these rendering issues.