### PR TITLE
Hybrid latcontrol angle + torque

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -52,7 +52,7 @@ class Controls:
     self.VM = VehicleModel(self.CP)
     self.LaC: LatControl
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle and self.CP.lateralTuning.which() == 'torque':
-      self.LaC = LatControlAngleTorque(self.CP, self.CP_SP, self.CI)
+      self.LaC = LatControlAngleTorque(self.CP, self.CI)
     elif self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       self.LaC = LatControlAngle(self.CP, self.CI)
     elif self.CP.lateralTuning.which() == 'pid':

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -16,6 +16,7 @@ from openpilot.selfdrive.controls.lib.latcontrol import LatControl
 from openpilot.selfdrive.controls.lib.latcontrol_pid import LatControlPID
 from openpilot.selfdrive.controls.lib.latcontrol_angle import LatControlAngle, STEER_ANGLE_SATURATION_THRESHOLD
 from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque
+from openpilot.selfdrive.controls.lib.latcontrol_angle_torque import LatControlAngleTorque
 from openpilot.selfdrive.controls.lib.longcontrol import LongControl
 from openpilot.selfdrive.locationd.helpers import PoseCalibrator, Pose
 
@@ -50,7 +51,9 @@ class Controls:
     self.LoC = LongControl(self.CP)
     self.VM = VehicleModel(self.CP)
     self.LaC: LatControl
-    if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
+    if self.CP.steerControlType == car.CarParams.SteerControlType.angle and self.CP.lateralTuning.which() == 'torque':
+      self.LaC = LatControlAngleTorque(self.CP, self.CP_SP, self.CI)
+    elif self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       self.LaC = LatControlAngle(self.CP, self.CI)
     elif self.CP.lateralTuning.which() == 'pid':
       self.LaC = LatControlPID(self.CP, self.CI)

--- a/selfdrive/controls/lib/latcontrol_angle_torque.py
+++ b/selfdrive/controls/lib/latcontrol_angle_torque.py
@@ -1,0 +1,13 @@
+from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque
+from openpilot.selfdrive.controls.lib.latcontrol_angle import LatControlAngle
+
+
+class LatControlAngleTorque(LatControlTorque, LatControlAngle):
+  def __init__(self, CP, CP_SP, CI):
+    LatControlTorque.__init__(self, CP, CP_SP, CI)
+    LatControlAngle.__init__(self, CP, CP_SP, CI)
+
+  def update(self, active, CS, VM, params, steer_limited_by_controls, desired_curvature, calibrated_pose, curvature_limited):
+    torque, _, _ = LatControlTorque.update(self, active, CS, VM, params, steer_limited_by_controls, desired_curvature, calibrated_pose, curvature_limited)
+    _, angle, angle_log = LatControlAngle.update(self, active, CS, VM, params, steer_limited_by_controls, desired_curvature, calibrated_pose, curvature_limited)
+    return torque, angle, angle_log

--- a/selfdrive/controls/lib/latcontrol_angle_torque.py
+++ b/selfdrive/controls/lib/latcontrol_angle_torque.py
@@ -3,9 +3,9 @@ from openpilot.selfdrive.controls.lib.latcontrol_angle import LatControlAngle
 
 
 class LatControlAngleTorque(LatControlTorque, LatControlAngle):
-  def __init__(self, CP, CP_SP, CI):
-    LatControlTorque.__init__(self, CP, CP_SP, CI)
-    LatControlAngle.__init__(self, CP, CP_SP, CI)
+  def __init__(self, CP, CI):
+    LatControlTorque.__init__(self, CP, CI)
+    LatControlAngle.__init__(self, CP, CI)
 
   def update(self, active, CS, VM, params, steer_limited_by_controls, desired_curvature, calibrated_pose, curvature_limited):
     torque, _, _ = LatControlTorque.update(self, active, CS, VM, params, steer_limited_by_controls, desired_curvature, calibrated_pose, curvature_limited)


### PR DESCRIPTION
> [!NOTE]
> This is part of a bigger effort to port HKG Angle Steering vehicles (LFA2) 

--------
This hybrid controller has been deployed in SP for **HKG-LFA2** angle-steering vehicles.

Although the vehicle is angle-controlled, we are still required to provide a *Torque Reduction Gain* (`ADAS_ACIAnglTqRedcGainVal`), which effectively tells the EPS controller how much assist torque to apply for a given steering command.

While the precise semantics of this parameter are not fully documented, we've found that using this hybrid approach yields very acceptable steering performance. Notably, it avoids unnecessarily high torque requests that could strain the EPS during moderate steering maneuvers.

The new controller works by leveraging the torque output of the existing model designed for torque-based vehicles. We use this torque value—*almost as-is*—to compute the reduction gain on our angle-based platform. This allows for responsive behavior during sharp turns, while avoiding excessive EPS effort during less aggressive inputs.


<!--
potential questions that may come, and we may need to take some time to answer are:

* Why can’t we use a static torque reduction value then send whatever desired angle we want?
* What are the benefits of using this controller?
* Any data/plots to demonstrate that this hybrid controller does better during x/y/z scenario than plain angle controller?
* How did you validate the controller? Do you have tests for all the little things with this hybrid controller?

Maaaaaybe the way to do it is first merging angle steering without this, and thus without the dynamic torque reduction gain, which means insufficient torque for most cases, but at least it would show an iterative process ?

PS: if you are reading this, these are my notes from discussing with Sunny. They ain't secret.
-->