### PR TITLE
raylib UI: implement easier to use Scroller

### DIFF
--- a/selfdrive/ui/layouts/settings/developer.py
+++ b/selfdrive/ui/layouts/settings/developer.py
@@ -1,4 +1,5 @@
-from openpilot.system.ui.lib.list_view import ListView, toggle_item
+from openpilot.system.ui.lib.list_view import toggle_item
+from openpilot.system.ui.lib.scroller import Scroller
 from openpilot.system.ui.lib.widget import Widget
 from openpilot.common.params import Params
 from openpilot.selfdrive.ui.widgets.ssh_key import ssh_key_item
@@ -49,10 +50,10 @@ class DeveloperLayout(Widget):
       ),
     ]
 
-    self._list_widget = ListView(items)
+    self._scroller = Scroller(items, line_separator=True, spacing=0)
 
   def _render(self, rect):
-    self._list_widget.render(rect)
+    self._scroller.render(rect)
 
   def _on_enable_adb(self): pass
   def _on_joystick_debug_mode(self): pass

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -7,7 +7,7 @@ from openpilot.selfdrive.ui.onroad.driver_camera_dialog import DriverCameraDialo
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.hardware import TICI
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.list_view import ListView, text_item, button_item, dual_button_item
+from openpilot.system.ui.lib.list_view import text_item, button_item, dual_button_item
 from openpilot.system.ui.lib.scroller import Scroller
 from openpilot.system.ui.lib.widget import Widget, DialogResult
 from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog
@@ -38,22 +38,7 @@ class DeviceLayout(Widget):
     self._fcc_dialog: HtmlRenderer | None = None
 
     items = self._initialize_items()
-    self._list_widget = ListView(items)
-
-    dongle_id = self._params.get("DongleId", encoding="utf-8") or "N/A"
-    serial = self._params.get("HardwareSerial") or "N/A"
-
-    self._scroller = Scroller([
-      text_item("Dongle ID", dongle_id),
-      text_item("Serial", serial),
-      button_item("Pair Device", "PAIR", DESCRIPTIONS['pair_device'], callback=self._pair_device),
-      button_item("Driver Camera", "PREVIEW", DESCRIPTIONS['driver_camera'], callback=self._show_driver_camera, enabled=ui_state.is_offroad),
-      button_item("Reset Calibration", "RESET", DESCRIPTIONS['reset_calibration'], callback=self._reset_calibration_prompt),
-      button_item("Regulatory", "VIEW", callback=self._on_regulatory, visible=TICI),
-      button_item("Review Training Guide", "REVIEW", DESCRIPTIONS['review_guide'], self._on_review_training_guide),
-      button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
-      dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
-    ], line_separator=True, spacing=0)
+    self._scroller = Scroller(items, line_separator=True, spacing=0)
 
   def _initialize_items(self):
     dongle_id = self._params.get("DongleId", encoding="utf-8") or "N/A"
@@ -75,7 +60,6 @@ class DeviceLayout(Widget):
   def _render(self, rect):
     print('scroller rect', rect.x, rect.y, rect.width, rect.height)
     self._scroller.render(rect)
-    # self._list_widget.render(rect)
     print()
 
   def _show_language_selection(self):

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -8,6 +8,7 @@ from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.hardware import TICI
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.list_view import ListView, text_item, button_item, dual_button_item
+from openpilot.system.ui.lib.scroller import Scroller
 from openpilot.system.ui.lib.widget import Widget, DialogResult
 from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog
 from openpilot.system.ui.widgets.option_dialog import MultiOptionDialog
@@ -39,6 +40,21 @@ class DeviceLayout(Widget):
     items = self._initialize_items()
     self._list_widget = ListView(items)
 
+    dongle_id = self._params.get("DongleId", encoding="utf-8") or "N/A"
+    serial = self._params.get("HardwareSerial") or "N/A"
+
+    self._scroller = Scroller([
+      text_item("Dongle ID", dongle_id),
+      text_item("Serial", serial),
+      button_item("Pair Device", "PAIR", DESCRIPTIONS['pair_device'], callback=self._pair_device),
+      button_item("Driver Camera", "PREVIEW", DESCRIPTIONS['driver_camera'], callback=self._show_driver_camera, enabled=ui_state.is_offroad),
+      button_item("Reset Calibration", "RESET", DESCRIPTIONS['reset_calibration'], callback=self._reset_calibration_prompt),
+      button_item("Regulatory", "VIEW", callback=self._on_regulatory, visible=TICI),
+      button_item("Review Training Guide", "REVIEW", DESCRIPTIONS['review_guide'], self._on_review_training_guide),
+      button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
+      dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
+    ])
+
   def _initialize_items(self):
     dongle_id = self._params.get("DongleId", encoding="utf-8") or "N/A"
     serial = self._params.get("HardwareSerial") or "N/A"
@@ -57,7 +73,10 @@ class DeviceLayout(Widget):
     return items
 
   def _render(self, rect):
-    self._list_widget.render(rect)
+    print('scroller rect', rect.x, rect.y, rect.width, rect.height)
+    self._scroller.render(rect)
+    # self._list_widget.render(rect)
+    print()
 
   def _show_language_selection(self):
     try:

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -50,11 +50,12 @@ class DeviceLayout(Widget):
       button_item("Pair Device", "PAIR", DESCRIPTIONS['pair_device'], callback=self._pair_device),
       button_item("Driver Camera", "PREVIEW", DESCRIPTIONS['driver_camera'], callback=self._show_driver_camera, enabled=ui_state.is_offroad),
       button_item("Reset Calibration", "RESET", DESCRIPTIONS['reset_calibration'], callback=self._reset_calibration_prompt),
-      button_item("Regulatory", "VIEW", callback=self._on_regulatory, visible=TICI),
+      regulatory_btn := button_item("Regulatory", "VIEW", callback=self._on_regulatory),
       button_item("Review Training Guide", "REVIEW", DESCRIPTIONS['review_guide'], self._on_review_training_guide),
       button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
       dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
     ]
+    regulatory_btn.set_visible(TICI)
     return items
 
   def _render(self, rect):

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -58,9 +58,7 @@ class DeviceLayout(Widget):
     return items
 
   def _render(self, rect):
-    print('scroller rect', rect.x, rect.y, rect.width, rect.height)
     self._scroller.render(rect)
-    print()
 
   def _show_language_selection(self):
     try:

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -53,7 +53,7 @@ class DeviceLayout(Widget):
       button_item("Review Training Guide", "REVIEW", DESCRIPTIONS['review_guide'], self._on_review_training_guide),
       button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
       dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
-    ])
+    ], line_separator=True, spacing=0)
 
   def _initialize_items(self):
     dongle_id = self._params.get("DongleId", encoding="utf-8") or "N/A"

--- a/selfdrive/ui/layouts/settings/software.py
+++ b/selfdrive/ui/layouts/settings/software.py
@@ -1,6 +1,7 @@
 from openpilot.common.params import Params
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.list_view import ListView, button_item, text_item
+from openpilot.system.ui.lib.list_view import button_item, text_item
+from openpilot.system.ui.lib.scroller import Scroller
 from openpilot.system.ui.lib.widget import Widget, DialogResult
 from openpilot.system.ui.widgets.confirm_dialog import confirm_dialog
 
@@ -11,7 +12,7 @@ class SoftwareLayout(Widget):
 
     self._params = Params()
     items = self._init_items()
-    self._list_widget = ListView(items)
+    self._scroller = Scroller(items, line_separator=True, spacing=0)
 
   def _init_items(self):
     items = [
@@ -24,7 +25,7 @@ class SoftwareLayout(Widget):
     return items
 
   def _render(self, rect):
-    self._list_widget.render(rect)
+    self._scroller.render(rect)
 
   def _on_download_update(self): pass
   def _on_install_update(self): pass

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -1,4 +1,5 @@
-from openpilot.system.ui.lib.list_view import ListView, multiple_button_item, toggle_item
+from openpilot.system.ui.lib.list_view import multiple_button_item, toggle_item
+from openpilot.system.ui.lib.scroller import Scroller
 from openpilot.system.ui.lib.widget import Widget
 from openpilot.common.params import Params
 
@@ -78,10 +79,10 @@ class TogglesLayout(Widget):
       ),
     ]
 
-    self._list_widget = ListView(items)
+    self._scroller = Scroller(items, line_separator=True, spacing=0)
 
   def _render(self, rect):
-    self._list_widget.render(rect)
+    self._scroller.render(rect)
 
   def _set_longitudinal_personality(self, button_index: int):
     self._params.put("LongitudinalPersonality", str(button_index))

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -146,7 +146,7 @@ class Device:
 
   def reset_interactive_timeout(self, timeout: int = -1) -> None:
     if timeout == -1:
-      timeout = 10 if ui_state.ignition else 300
+      timeout = 10 if ui_state.ignition else 30
     self._interaction_time = time.monotonic() + timeout
 
   def add_interactive_timeout_callback(self, callback: Callable):

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -146,7 +146,7 @@ class Device:
 
   def reset_interactive_timeout(self, timeout: int = -1) -> None:
     if timeout == -1:
-      timeout = 10 if ui_state.ignition else 30
+      timeout = 10 if ui_state.ignition else 300
     self._interaction_time = time.monotonic() + timeout
 
   def add_interactive_timeout_callback(self, callback: Callable):

--- a/selfdrive/ui/widgets/offroad_alerts.py
+++ b/selfdrive/ui/widgets/offroad_alerts.py
@@ -57,6 +57,7 @@ class AbstractAlert(Widget, ABC):
     self.content_rect = rl.Rectangle(0, 0, 0, 0)
     self.scroll_panel_rect = rl.Rectangle(0, 0, 0, 0)
     self.scroll_panel = GuiScrollPanel()
+    self.set_touch_valid_callback(self.scroll_panel.is_touch_valid)
 
   def set_dismiss_callback(self, callback: Callable):
     self.dismiss_callback = callback
@@ -70,8 +71,7 @@ class AbstractAlert(Widget, ABC):
     pass
 
   def handle_input(self, mouse_pos: rl.Vector2, mouse_clicked: bool) -> bool:
-    # TODO: fix scroll_panel.is_click_valid()
-    if not mouse_clicked:
+    if not mouse_clicked or not self._touch_valid():
       return False
 
     if rl.check_collision_point_rec(mouse_pos, self.dismiss_btn_rect):

--- a/selfdrive/ui/widgets/offroad_alerts.py
+++ b/selfdrive/ui/widgets/offroad_alerts.py
@@ -57,7 +57,6 @@ class AbstractAlert(Widget, ABC):
     self.content_rect = rl.Rectangle(0, 0, 0, 0)
     self.scroll_panel_rect = rl.Rectangle(0, 0, 0, 0)
     self.scroll_panel = GuiScrollPanel()
-    self.set_touch_valid_callback(self.scroll_panel.is_touch_valid)
 
   def set_dismiss_callback(self, callback: Callable):
     self.dismiss_callback = callback
@@ -71,7 +70,7 @@ class AbstractAlert(Widget, ABC):
     pass
 
   def handle_input(self, mouse_pos: rl.Vector2, mouse_clicked: bool) -> bool:
-    if not mouse_clicked or not self._touch_valid():
+    if not mouse_clicked or not self.scroll_panel.is_touch_valid():
       return False
 
     if rl.check_collision_point_rec(mouse_pos, self.dismiss_btn_rect):

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -225,7 +225,7 @@ class GuiApplication:
     for layout in KEYBOARD_LAYOUTS.values():
       all_chars.update(key for row in layout for key in row)
     all_chars = "".join(all_chars)
-    all_chars += "–✓"
+    all_chars += "–✓°"
 
     codepoint_count = rl.ffi.new("int *", 1)
     codepoints = rl.load_codepoints(all_chars, codepoint_count)

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -243,9 +243,21 @@ class ListItem(Widget):
   def set_parent_rect(self, parent_rect: rl.Rectangle):
     self._rect.width = parent_rect.width #- (self._rect.x - max_rect.x)
 
+  def _handle_mouse_release(self, mouse_pos: rl.Vector2):
+    if not self.is_visible:
+      return
+
+    if self.description:
+      print('toggled description visibility for', self.title)
+      self.description_visible = not self.description_visible
+      self._rect.height = self.get_item_height(self._font, self._rect.width)
+
   def _render(self, _):
     if not self.is_visible:
       return
+
+    # if self._is_pressed:
+    #   raise Exception('clicked!', self.title)
 
     # y = int(self.rect.y + scroll_offset.y)
     # if y + self.rect.height <= rect.y or y >= rect.y + rect.height:
@@ -256,10 +268,11 @@ class ListItem(Widget):
 
     # Only draw title and icon for items that have them
     if self.title:
-      print('drawing title', self.title)
+      # print('drawing title', self.title)
       # Draw icon if present
       if self.icon:
-        print('drawing icon', self.icon)
+        # TODO: ICON not working
+        # print('drawing icon', self.icon)
         icon_texture = gui_app.texture(os.path.join("icons", self.icon), ICON_SIZE, ICON_SIZE)
         rl.draw_texture(icon_texture, int(content_x), int(self._rect.y + (ITEM_BASE_HEIGHT - icon_texture.width) // 2), rl.WHITE)
         text_x += ICON_SIZE + ITEM_PADDING
@@ -272,6 +285,7 @@ class ListItem(Widget):
     # Draw description if visible
     current_description = self.get_description()
     if self.description_visible and current_description and self._wrapped_description:
+      # raise Exception('drawing description', current_description)
       rl.draw_text_ex(
         self._font,
         self._wrapped_description,

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -43,16 +43,12 @@ def _resolve_value(value, default=""):
 class ItemAction(Widget, ABC):
   def __init__(self, width: int = 100, enabled: bool | Callable[[], bool] = True):
     super().__init__()
-    self.width = width
-    # self.set_rect(rl.Rectangle(0, 0, width, ITEM_BASE_HEIGHT))
+    self.set_rect(rl.Rectangle(0, 0, width, 0))
     self._enabled_source = enabled
 
   @property
   def enabled(self):
     return _resolve_value(self._enabled_source, False)
-
-  def get_width(self) -> int:
-    return self.width
 
 
 class ToggleAction(ItemAction):
@@ -355,15 +351,15 @@ class ListItem(Widget):
     return ITEM_BASE_HEIGHT
 
   def get_content_width(self, total_width: int) -> int:
-    if self.action_item and self.action_item.get_width() > 0:
-      return total_width - self.action_item.get_width() - RIGHT_ITEM_PADDING
+    if self.action_item and self.action_item.rect.width > 0:
+      return total_width - int(self.action_item.rect.width) - RIGHT_ITEM_PADDING
     return total_width
 
   def get_right_item_rect(self, item_rect: rl.Rectangle) -> rl.Rectangle:
     if not self.action_item:
       return rl.Rectangle(0, 0, 0, 0)
 
-    right_width = self.action_item.get_width()
+    right_width = self.action_item.rect.width
     if right_width == 0:  # Full width action (like DualButtonAction)
       return rl.Rectangle(item_rect.x + ITEM_PADDING, item_rect.y,
                           item_rect.width - (ITEM_PADDING * 2), ITEM_BASE_HEIGHT)

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -59,7 +59,7 @@ class ToggleAction(ItemAction):
 
   def _render(self, rect: rl.Rectangle) -> bool:
     self.toggle.set_enabled(self.enabled)
-    self.toggle.render(rl.Rectangle(rect.x, rect.y + (rect.height - TOGGLE_HEIGHT) / 2, self.width, TOGGLE_HEIGHT))
+    self.toggle.render(rl.Rectangle(rect.x, rect.y + (rect.height - TOGGLE_HEIGHT) / 2, self._rect.width, TOGGLE_HEIGHT))
     return False
 
   def set_state(self, state: bool):

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -198,7 +198,7 @@ class MultipleButtonAction(ItemAction):
 class ListItem(Widget):
   def __init__(self, title: str = "", icon: str | None = None, description: str | Callable[[], str] | None = None,
                description_visible: bool = False, callback: Callable | None = None,
-               action_item: ItemAction | None = None, visible: bool | Callable[[], bool] = True):
+               action_item: ItemAction | None = None):
     super().__init__()
     self.title = title
     self.icon = icon
@@ -206,7 +206,6 @@ class ListItem(Widget):
     self.description_visible = description_visible
     self.callback = callback
     self.action_item = action_item
-    self.visible = visible
 
     self.set_rect(rl.Rectangle(0, 0, ITEM_BASE_WIDTH, ITEM_BASE_HEIGHT))
     self._font = gui_app.font(FontWeight.NORMAL)
@@ -283,10 +282,6 @@ class ListItem(Widget):
         if self.callback:
           self.callback()
 
-  @property
-  def is_visible(self) -> bool:
-    return bool(_resolve_value(self.visible, True))
-
   def get_description(self):
     return _resolve_value(self.description, None)
 
@@ -330,36 +325,32 @@ class ListItem(Widget):
 
 
 # Factory functions
-def simple_item(title: str, callback: Callable | None = None, visible: bool | Callable[[], bool] = True) -> ListItem:
-  return ListItem(title=title, callback=callback, visible=visible)
+def simple_item(title: str, callback: Callable | None = None) -> ListItem:
+  return ListItem(title=title, callback=callback)
 
 
 def toggle_item(title: str, description: str | Callable[[], str] | None = None, initial_state: bool = False,
-                callback: Callable | None = None, icon: str = "", enabled: bool | Callable[[], bool] = True,
-                visible: bool | Callable[[], bool] = True) -> ListItem:
+                callback: Callable | None = None, icon: str = "", enabled: bool | Callable[[], bool] = True) -> ListItem:
   action = ToggleAction(initial_state=initial_state, enabled=enabled)
-  return ListItem(title=title, description=description, action_item=action, icon=icon, callback=callback, visible=visible)
+  return ListItem(title=title, description=description, action_item=action, icon=icon, callback=callback)
 
 
 def button_item(title: str, button_text: str | Callable[[], str], description: str | Callable[[], str] | None = None,
-                callback: Callable | None = None, enabled: bool | Callable[[], bool] = True,
-                visible: bool | Callable[[], bool] = True) -> ListItem:
+                callback: Callable | None = None, enabled: bool | Callable[[], bool] = True) -> ListItem:
   action = ButtonAction(text=button_text, enabled=enabled)
-  return ListItem(title=title, description=description, action_item=action, callback=callback, visible=visible)
+  return ListItem(title=title, description=description, action_item=action, callback=callback)
 
 
 def text_item(title: str, value: str | Callable[[], str], description: str | Callable[[], str] | None = None,
-              callback: Callable | None = None, enabled: bool | Callable[[], bool] = True,
-              visible: bool | Callable[[], bool] = True) -> ListItem:
+              callback: Callable | None = None, enabled: bool | Callable[[], bool] = True) -> ListItem:
   action = TextAction(text=value, color=rl.Color(170, 170, 170, 255), enabled=enabled)
-  return ListItem(title=title, description=description, action_item=action, callback=callback, visible=visible)
+  return ListItem(title=title, description=description, action_item=action, callback=callback)
 
 
 def dual_button_item(left_text: str, right_text: str, left_callback: Callable = None, right_callback: Callable = None,
-                     description: str | Callable[[], str] | None = None, enabled: bool | Callable[[], bool] = True,
-                     visible: bool | Callable[[], bool] = True) -> ListItem:
+                     description: str | Callable[[], str] | None = None, enabled: bool | Callable[[], bool] = True) -> ListItem:
   action = DualButtonAction(left_text, right_text, left_callback, right_callback, enabled)
-  return ListItem(title="", description=description, action_item=action, visible=visible)
+  return ListItem(title="", description=description, action_item=action)
 
 
 def multiple_button_item(title: str, description: str, buttons: list[str], selected_index: int,

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -211,10 +211,10 @@ class ListItem(Widget):
     self._font = gui_app.font(FontWeight.NORMAL)
 
     # Cached properties for performance
-    self._wrapped_description = None
-    self._prev_description = None
-    self._prev_max_width = 0
-    self._description_height = 0
+    self._prev_max_width: int = 0
+    self._wrapped_description: str | None = None
+    self._prev_description: str | None = None
+    self._description_height: float = 0
 
   def set_parent_rect(self, parent_rect: rl.Rectangle):
     super().set_parent_rect(parent_rect)

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -11,10 +11,7 @@ from openpilot.system.ui.lib.widget import Widget
 
 ITEM_BASE_WIDTH = 600
 ITEM_BASE_HEIGHT = 170
-LINE_PADDING = 40
-LINE_COLOR = rl.GRAY
 ITEM_PADDING = 20
-ITEM_SPACING = 80
 ITEM_TEXT_FONT_SIZE = 50
 ITEM_TEXT_COLOR = rl.WHITE
 ITEM_DESC_TEXT_COLOR = rl.Color(128, 128, 128, 255)
@@ -39,7 +36,7 @@ def _resolve_value(value, default=""):
 
 # Abstract base class for right-side items
 class ItemAction(Widget, ABC):
-  def __init__(self, width: int = 100, enabled: bool | Callable[[], bool] = True):
+  def __init__(self, width: int = BUTTON_HEIGHT, enabled: bool | Callable[[], bool] = True):
     super().__init__()
     self.set_rect(rl.Rectangle(0, 0, width, 0))
     self._enabled_source = enabled
@@ -156,12 +153,12 @@ class MultipleButtonAction(ItemAction):
 
   def _render(self, rect: rl.Rectangle) -> bool:
     spacing = 20
-    button_y = rect.y + (rect.height - 100) / 2
+    button_y = rect.y + (rect.height - BUTTON_HEIGHT) / 2
     clicked = -1
 
     for i, text in enumerate(self.buttons):
       button_x = rect.x + i * (self.button_width + spacing)
-      button_rect = rl.Rectangle(button_x, button_y, self.button_width, 100)
+      button_rect = rl.Rectangle(button_x, button_y, self.button_width, BUTTON_HEIGHT)
 
       # Check button state
       mouse_pos = rl.get_mouse_position()
@@ -183,7 +180,7 @@ class MultipleButtonAction(ItemAction):
       # Draw text
       text_size = measure_text_cached(self._font, text, 40)
       text_x = button_x + (self.button_width - text_size.x) / 2
-      text_y = button_y + (100 - text_size.y) / 2
+      text_y = button_y + (BUTTON_HEIGHT - text_size.y) / 2
       rl.draw_text_ex(self._font, text, rl.Vector2(text_x, text_y), 40, 0, rl.Color(228, 228, 228, 255))
 
       # Handle click

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -250,7 +250,8 @@ class ListItem(Widget):
     if self.description:
       print('toggled description visibility for', self.title)
       self.description_visible = not self.description_visible
-      self._rect.height = self.get_item_height(self._font, self._rect.width)
+      content_width = self.get_content_width(int(self._rect.width - ITEM_PADDING * 2))
+      self._rect.height = self.get_item_height(self._font, content_width)
 
   def _render(self, _):
     if not self.is_visible:

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -44,6 +44,7 @@ class ItemAction(Widget, ABC):
   def __init__(self, width: int = 100, enabled: bool | Callable[[], bool] = True):
     super().__init__()
     self.width = width
+    # self.set_rect(rl.Rectangle(0, 0, width, ITEM_BASE_HEIGHT))
     self._enabled_source = enabled
 
   @property
@@ -246,6 +247,13 @@ class ListItem(Widget):
   def _handle_mouse_release(self, mouse_pos: rl.Vector2):
     if not self.is_visible:
       return
+
+    # Check not in action rect
+    if self.action_item:
+      action_rect = self.get_right_item_rect(self._rect)
+      if rl.check_collision_point_rec(mouse_pos, action_rect):
+        # Click was on right item, don't toggle description
+        return
 
     if self.description:
       print('toggled description visibility for', self.title)

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -298,7 +298,7 @@ class ListItem(Widget):
     # Draw right item if present
     if self.action_item:
       print('item rect', self._rect.x, self._rect.y, self._rect.width, self._rect.height)
-      rl.draw_rectangle_lines_ex(self._rect, 5, LINE_COLOR)
+      # rl.draw_rectangle_lines_ex(self._rect, 5, LINE_COLOR)
       right_rect = self.get_right_item_rect(self._rect)
       right_rect.y = self._rect.y
       if self.action_item.render(right_rect) and self.action_item.enabled:

--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -58,13 +58,15 @@ class GuiScrollPanel:
           if mouse_pos.x >= scrollbar_x:
             self._scroll_state = ScrollState.DRAGGING_SCROLLBAR
 
+        # TODO: hacky
+        # when clicking while moving, go straight into dragging
+        self._is_dragging = abs(self._velocity_y) > MIN_VELOCITY
         self._last_mouse_y = mouse_pos.y
         self._start_mouse_y = mouse_pos.y
         self._last_drag_time = current_time
         self._velocity_history.clear()
         self._velocity_y = 0.0
         self._bounce_offset = 0.0
-        self._is_dragging = False
 
     # Handle active dragging
     if self._scroll_state == ScrollState.DRAGGING_CONTENT or self._scroll_state == ScrollState.DRAGGING_SCROLLBAR:
@@ -166,14 +168,6 @@ class GuiScrollPanel:
         self._offset.y = -(max_scroll_y + MAX_BOUNCE_DISTANCE)
 
     return self._offset
-
-  def is_click_valid(self) -> bool:
-    # Check if this is a click rather than a drag
-    return (
-      self._scroll_state == ScrollState.IDLE
-      and not self._is_dragging
-      and rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT)
-    )
 
   def is_touch_valid(self):
     return not self._is_dragging

--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -175,6 +175,9 @@ class GuiScrollPanel:
       and rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT)
     )
 
+  def is_touch_valid(self):
+    return not self._is_dragging
+
   def get_normalized_scroll_position(self) -> float:
     """Returns the current scroll position as a value from 0.0 to 1.0"""
     if not self._content_rect or not self._bounds_rect:

--- a/system/ui/lib/scroller.py
+++ b/system/ui/lib/scroller.py
@@ -1,14 +1,9 @@
-import os
 import pyray as rl
-from dataclasses import dataclass
-from collections.abc import Callable
-from abc import ABC, abstractmethod
 from openpilot.system.ui.lib.widget import Widget
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
-from openpilot.system.ui.lib.application import gui_app, FontWeight
 
-LINE_COLOR = rl.GRAY
 ITEM_SPACING = 40
+LINE_COLOR = rl.GRAY
 LINE_PADDING = 40
 
 
@@ -18,6 +13,7 @@ class LineSeparator(Widget):
     self._rect = rl.Rectangle(0, 0, 0, height)
 
   def set_parent_rect(self, parent_rect: rl.Rectangle) -> None:
+    super().set_parent_rect(parent_rect)
     self._rect.width = parent_rect.width
 
   def _render(self, _):
@@ -33,6 +29,7 @@ class Scroller(Widget):
     self._spacing = spacing
     self._line_separator = line_separator
     self._pad_end = pad_end
+
     self.scroll_panel = GuiScrollPanel()
 
     for item in items:
@@ -49,12 +46,9 @@ class Scroller(Widget):
     # TODO: don't draw items that are not in the viewport
     visible_items = [item for item in self._items if item.is_visible]
     content_height = sum(item.rect.height for item in visible_items) + self._spacing * (len(visible_items))
-    print('content height', content_height, 'rect height', self._rect.height)
     if not self._pad_end:
       content_height -= self._spacing
     scroll = self.scroll_panel.handle_scroll(self._rect, rl.Rectangle(0, 0, self._rect.width, content_height))
-    print(scroll.x, scroll.y)
-    # rl.draw_rectangle_lines_ex(self._rect, 5, LINE_COLOR)
 
     rl.begin_scissor_mode(int(self._rect.x), int(self._rect.y),
                           int(self._rect.width), int(self._rect.height))
@@ -63,15 +57,11 @@ class Scroller(Widget):
     for idx, item in enumerate(visible_items):
       if not item.is_visible:
         continue
-      # print(f"Rendering item {idx} at position {cur_height}")
-      # print('item height', item.rect.height)
 
       # Nicely lay out items vertically
-      # x = self._rect.x + cur_height + self._spacing * (idx != 0)
+      x = self._rect.x
       y = self._rect.y + cur_height + self._spacing * (idx != 0)
       cur_height += item.rect.height + self._spacing * (idx != 0)
-      x = self._rect.x# + self._spacing
-      # y = self._rect.y + (self._rect.height - item.rect.height) / 2
 
       # Consider scroll
       x += scroll.x
@@ -80,7 +70,6 @@ class Scroller(Widget):
       # Update item state
       item.set_position(x, y)
       item.set_parent_rect(self._rect)
-      # print('setting item position', item.rect.x, item.rect.y)
       item.render()
 
     rl.end_scissor_mode()

--- a/system/ui/lib/scroller.py
+++ b/system/ui/lib/scroller.py
@@ -39,8 +39,7 @@ class Scroller(Widget):
     if self._line_separator and len(self._items) > 0:
       self._items.append(LineSeparator())
     self._items.append(item)
-    item.set_click_valid_callback(self.scroll_panel.is_click_valid,
-                                  self.scroll_panel.is_touch_valid)
+    item.set_touch_valid_callback(self.scroll_panel.is_touch_valid)
 
   def _render(self, _):
     # TODO: don't draw items that are not in the viewport

--- a/system/ui/lib/scroller.py
+++ b/system/ui/lib/scroller.py
@@ -9,20 +9,38 @@ from openpilot.system.ui.lib.application import gui_app, FontWeight
 
 LINE_COLOR = rl.GRAY
 ITEM_SPACING = 40
+LINE_PADDING = 40
+
+
+class LineSeparator(Widget):
+  def __init__(self, height: int = 1):
+    super().__init__()
+    self._rect = rl.Rectangle(0, 0, 0, height)
+
+  def set_parent_rect(self, parent_rect: rl.Rectangle) -> None:
+    self._rect.width = parent_rect.width
+
+  def _render(self, _):
+    rl.draw_line(int(self._rect.x) + LINE_PADDING, int(self._rect.y),
+                 int(self._rect.x + self._rect.width) - LINE_PADDING * 2, int(self._rect.y),
+                 LINE_COLOR)
 
 
 class Scroller(Widget):
-  def __init__(self, items: list, pad_end: bool = True):
+  def __init__(self, items: list, spacing: int = ITEM_SPACING, line_separator: bool = False, pad_end: bool = True):
     super().__init__()
-    self._items: list = items
+    self._items = []
+    self._spacing = spacing
+    self._line_separator = line_separator
     self._pad_end = pad_end
     self.scroll_panel = GuiScrollPanel()
 
-    for item in self._items:
-      item.set_click_valid_callback(self.scroll_panel.is_click_valid,
-                                    self.scroll_panel.is_touch_valid)
+    for item in items:
+      self.add_widget(item)
 
   def add_widget(self, item: Widget) -> None:
+    if self._line_separator and len(self._items) > 0:
+      self._items.append(LineSeparator())
     self._items.append(item)
     item.set_click_valid_callback(self.scroll_panel.is_click_valid,
                                   self.scroll_panel.is_touch_valid)
@@ -30,13 +48,13 @@ class Scroller(Widget):
   def _render(self, _):
     # TODO: don't draw items that are not in the viewport
     visible_items = [item for item in self._items if item.is_visible]
-    content_height = sum(item.rect.height for item in visible_items) + ITEM_SPACING * (len(visible_items))
+    content_height = sum(item.rect.height for item in visible_items) + self._spacing * (len(visible_items))
     print('content height', content_height, 'rect height', self._rect.height)
     if not self._pad_end:
-      content_height -= ITEM_SPACING
+      content_height -= self._spacing
     scroll = self.scroll_panel.handle_scroll(self._rect, rl.Rectangle(0, 0, self._rect.width, content_height))
     print(scroll.x, scroll.y)
-    rl.draw_rectangle_lines_ex(self._rect, 5, LINE_COLOR)
+    # rl.draw_rectangle_lines_ex(self._rect, 5, LINE_COLOR)
 
     rl.begin_scissor_mode(int(self._rect.x), int(self._rect.y),
                           int(self._rect.width), int(self._rect.height))
@@ -49,10 +67,10 @@ class Scroller(Widget):
       # print('item height', item.rect.height)
 
       # Nicely lay out items vertically
-      # x = self._rect.x + cur_height + ITEM_SPACING * (idx != 0)
-      y = self._rect.y + cur_height + ITEM_SPACING * (idx != 0)
-      cur_height += item.rect.height + ITEM_SPACING * (idx != 0)
-      x = self._rect.x# + ITEM_SPACING
+      # x = self._rect.x + cur_height + self._spacing * (idx != 0)
+      y = self._rect.y + cur_height + self._spacing * (idx != 0)
+      cur_height += item.rect.height + self._spacing * (idx != 0)
+      x = self._rect.x# + self._spacing
       # y = self._rect.y + (self._rect.height - item.rect.height) / 2
 
       # Consider scroll

--- a/system/ui/lib/scroller.py
+++ b/system/ui/lib/scroller.py
@@ -18,9 +18,9 @@ class Scroller(Widget):
     self._pad_end = pad_end
     self.scroll_panel = GuiScrollPanel()
 
-    # for item in self._items:
-    #   item.set_click_valid_callback(self.scroll_panel.is_click_valid,
-    #                                 self.scroll_panel.is_touch_valid)
+    for item in self._items:
+      item.set_click_valid_callback(self.scroll_panel.is_click_valid,
+                                    self.scroll_panel.is_touch_valid)
 
   def add_widget(self, item: Widget) -> None:
     self._items.append(item)
@@ -29,7 +29,6 @@ class Scroller(Widget):
 
   def _render(self, _):
     # TODO: don't draw items that are not in the viewport
-    print([item.rect.height for item in self._items])
     visible_items = [item for item in self._items if item.is_visible]
     content_height = sum(item.rect.height for item in visible_items) + ITEM_SPACING * (len(visible_items))
     print('content height', content_height, 'rect height', self._rect.height)

--- a/system/ui/lib/scroller.py
+++ b/system/ui/lib/scroller.py
@@ -23,9 +23,9 @@ class LineSeparator(Widget):
 
 
 class Scroller(Widget):
-  def __init__(self, items: list, spacing: int = ITEM_SPACING, line_separator: bool = False, pad_end: bool = True):
+  def __init__(self, items: list[Widget], spacing: int = ITEM_SPACING, line_separator: bool = False, pad_end: bool = True):
     super().__init__()
-    self._items = []
+    self._items: list[Widget] = []
     self._spacing = spacing
     self._line_separator = line_separator
     self._pad_end = pad_end

--- a/system/ui/lib/scroller.py
+++ b/system/ui/lib/scroller.py
@@ -1,0 +1,69 @@
+import os
+import pyray as rl
+from dataclasses import dataclass
+from collections.abc import Callable
+from abc import ABC, abstractmethod
+from openpilot.system.ui.lib.widget import Widget
+from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
+from openpilot.system.ui.lib.application import gui_app, FontWeight
+
+LINE_COLOR = rl.GRAY
+ITEM_SPACING = 40
+
+
+class Scroller(Widget):
+  def __init__(self, items: list, pad_end: bool = True):
+    super().__init__()
+    self._items: list = items
+    self._pad_end = pad_end
+    self.scroll_panel = GuiScrollPanel()
+
+    # for item in self._items:
+    #   item.set_click_valid_callback(self.scroll_panel.is_click_valid,
+    #                                 self.scroll_panel.is_touch_valid)
+
+  def add_widget(self, item: Widget) -> None:
+    self._items.append(item)
+    item.set_click_valid_callback(self.scroll_panel.is_click_valid,
+                                  self.scroll_panel.is_touch_valid)
+
+  def _render(self, _):
+    # TODO: don't draw items that are not in the viewport
+    print([item.rect.height for item in self._items])
+    visible_items = [item for item in self._items if item.is_visible]
+    content_height = sum(item.rect.height for item in visible_items) + ITEM_SPACING * (len(visible_items))
+    print('content height', content_height, 'rect height', self._rect.height)
+    if not self._pad_end:
+      content_height -= ITEM_SPACING
+    scroll = self.scroll_panel.handle_scroll(self._rect, rl.Rectangle(0, 0, self._rect.width, content_height))
+    print(scroll.x, scroll.y)
+    rl.draw_rectangle_lines_ex(self._rect, 5, LINE_COLOR)
+
+    rl.begin_scissor_mode(int(self._rect.x), int(self._rect.y),
+                          int(self._rect.width), int(self._rect.height))
+
+    cur_height = 0
+    for idx, item in enumerate(visible_items):
+      if not item.is_visible:
+        continue
+      # print(f"Rendering item {idx} at position {cur_height}")
+      # print('item height', item.rect.height)
+
+      # Nicely lay out items vertically
+      # x = self._rect.x + cur_height + ITEM_SPACING * (idx != 0)
+      y = self._rect.y + cur_height + ITEM_SPACING * (idx != 0)
+      cur_height += item.rect.height + ITEM_SPACING * (idx != 0)
+      x = self._rect.x# + ITEM_SPACING
+      # y = self._rect.y + (self._rect.height - item.rect.height) / 2
+
+      # Consider scroll
+      x += scroll.x
+      y += scroll.y
+
+      # Update item state
+      item.set_position(x, y)
+      item.set_parent_rect(self._rect)
+      # print('setting item position', item.rect.x, item.rect.y)
+      item.render()
+
+    rl.end_scissor_mode()

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -17,13 +17,10 @@ class Widget(abc.ABC):
     self._is_pressed = False
     self._enabled: bool = True
     self._is_visible: bool | Callable[[], bool] = True
-    self._click_valid_callback: Callable[[], bool] | None = None
     self._touch_valid_callback: Callable[[], bool] | None = None
 
-  def set_click_valid_callback(self, click_callback: Callable[[], bool],
-                               touch_callback: Callable[[], bool]) -> None:
+  def set_touch_valid_callback(self, touch_callback: Callable[[], bool]) -> None:
     """Set a callback to determine if the widget can be clicked."""
-    self._click_valid_callback = click_callback
     self._touch_valid_callback = touch_callback
 
   def _touch_valid(self) -> bool:

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -15,7 +15,6 @@ class Widget(abc.ABC):
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._parent_rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._is_pressed = False
-    self._enabled: bool = True
     self._is_visible: bool | Callable[[], bool] = True
     self._touch_valid_callback: Callable[[], bool] | None = None
 
@@ -30,9 +29,6 @@ class Widget(abc.ABC):
   @property
   def is_visible(self) -> bool:
     return self._is_visible() if callable(self._is_visible) else self._is_visible
-
-  def set_enabled(self, enabled: bool) -> None:
-    self._enabled = enabled
 
   @property
   def rect(self) -> rl.Rectangle:
@@ -70,19 +66,18 @@ class Widget(abc.ABC):
     ret = self._render(self._rect)
 
     # Keep track of whether mouse down started within the widget's rectangle
-    if self._enabled:
-      mouse_pos = rl.get_mouse_position()
-      if rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT) and self._touch_valid():
-        if rl.check_collision_point_rec(mouse_pos, self._rect):
-          self._is_pressed = True
+    mouse_pos = rl.get_mouse_position()
+    if rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT) and self._touch_valid():
+      if rl.check_collision_point_rec(mouse_pos, self._rect):
+        self._is_pressed = True
 
-      elif not self._touch_valid():
-        self._is_pressed = False
+    elif not self._touch_valid():
+      self._is_pressed = False
 
-      elif rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
-        if self._is_pressed and rl.check_collision_point_rec(mouse_pos, self._rect):
-          self._handle_mouse_release(mouse_pos)
-        self._is_pressed = False
+    elif rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT):
+      if self._is_pressed and rl.check_collision_point_rec(mouse_pos, self._rect):
+        self._handle_mouse_release(mouse_pos)
+      self._is_pressed = False
 
     return ret
 

--- a/system/ui/lib/widget.py
+++ b/system/ui/lib/widget.py
@@ -13,7 +13,7 @@ class DialogResult(IntEnum):
 class Widget(abc.ABC):
   def __init__(self):
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
-    self._max_rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
+    self._parent_rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._is_pressed = False
     self._enabled: bool = True
     self._is_visible: bool | Callable[[], bool] = True
@@ -52,7 +52,8 @@ class Widget(abc.ABC):
       self._update_layout_rects()
 
   def set_parent_rect(self, parent_rect: rl.Rectangle) -> None:
-    """ Like size hint in QT """
+    """Can be used like size hint in QT"""
+    self._parent_rect = parent_rect
 
   def set_position(self, x: float, y: float) -> None:
     changed = (self._rect.x != x or self._rect.y != y)

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -117,7 +117,7 @@ class WifiManagerUI(Widget):
   def _draw_network_list(self, rect: rl.Rectangle):
     content_rect = rl.Rectangle(rect.x, rect.y, rect.width, len(self._networks) * ITEM_HEIGHT)
     offset = self.scroll_panel.handle_scroll(rect, content_rect)
-    clicked = self.scroll_panel.is_click_valid()
+    clicked = self.scroll_panel.is_touch_valid() and rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT)
 
     rl.begin_scissor_mode(int(rect.x), int(rect.y), int(rect.width), int(rect.height))
     for i, network in enumerate(self._networks):

--- a/system/ui/widgets/option_dialog.py
+++ b/system/ui/widgets/option_dialog.py
@@ -42,7 +42,7 @@ class MultiOptionDialog(Widget):
 
     # Scroll and render options
     offset = self.scroll.handle_scroll(view_rect, list_content_rect)
-    valid_click = self.scroll.is_click_valid()
+    valid_click = self.scroll.is_touch_valid() and rl.is_mouse_button_released(rl.MouseButton.MOUSE_BUTTON_LEFT)
 
     rl.begin_scissor_mode(int(view_rect.x), int(options_y), int(view_rect.width), int(options_h))
     for i, option in enumerate(self.options):


### PR DESCRIPTION
- replaces `ListView` with `Scroller`
- Add any widget you want to `Scroller`, no special non-`Widget` `ListItem` dataclass
- Each `Widget` handles its own rendering and behavior, instead of parent `ListView` rendering each and handling clicks. Makes things easy to extend and generic
- More similar to QT behavior

https://github.com/user-attachments/assets/d1aae3c1-b7f6-42a3-b7c6-e1024853e6d3