### PR TITLE
include audio in qcamera.ts

### DIFF
--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -62,6 +62,7 @@ struct RemoteEncoder {
   bool recording = false;
   bool marked_ready_to_rotate = false;
   bool seen_first_packet = false;
+  bool audio_initialized = false;
 };
 
 size_t write_encode_data(LoggerdState *s, cereal::Event::Reader event, RemoteEncoder &re, const EncoderInfo &encoder_info) {
@@ -80,11 +81,6 @@ size_t write_encode_data(LoggerdState *s, cereal::Event::Reader event, RemoteEnc
       }
       // if we aren't actually recording, don't create the writer
       if (encoder_info.record) {
-        assert(encoder_info.filename != NULL);
-        re.writer.reset(new VideoWriter(s->logger.segmentPath().c_str(),
-                                        encoder_info.filename, idx.getType() != cereal::EncodeIndex::Type::FULL_H_E_V_C,
-                                        edata.getWidth(), edata.getHeight(), encoder_info.fps, idx.getType(),
-                                        encoder_info.include_audio));
         // write the header
         auto header = edata.getHeader();
         re.writer->write((uint8_t *)header.begin(), header.size(), idx.getTimestampEof() / 1000, true, false);
@@ -139,13 +135,19 @@ int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct 
 
     // if this is a new segment, we close any possible old segments, move to the new, and process any queued packets
     if (re.current_segment != s->logger.segment()) {
-      if (re.recording) {
-        re.writer.reset();
+      if (encoder_info.record) {
+        assert(encoder_info.filename != NULL);
+        re.writer.reset(new VideoWriter(s->logger.segmentPath().c_str(),
+                                        encoder_info.filename, idx.getType() != cereal::EncodeIndex::Type::FULL_H_E_V_C,
+                                        edata.getWidth(), edata.getHeight(), encoder_info.fps, idx.getType()));
         re.recording = false;
+        re.audio_initialized = false;
       }
       re.current_segment = s->logger.segment();
       re.marked_ready_to_rotate = false;
       // we are in this segment now, process any queued messages before this one
+    }
+    if (re.audio_initialized || !encoder_info.include_audio) {
       if (!re.q.empty()) {
         for (auto qmsg : re.q) {
           capnp::FlatArrayMessageReader reader({(capnp::word *)qmsg->getData(), qmsg->getSize() / sizeof(capnp::word)});
@@ -154,9 +156,14 @@ int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct 
         }
         re.q.clear();
       }
+      bytes_count += write_encode_data(s, event, re, encoder_info);
+      delete msg;
+    } else if (re.q.size() > MAIN_FPS*10) {
+      LOGE_100("%s: dropping frame waiting for audio initialization, queue is too large", name.c_str());
+      delete msg;
+    } else {
+      re.q.push_back(msg); // queue up all the new segment messages, they go in after audio is initialized
     }
-    bytes_count += write_encode_data(s, event, re, encoder_info);
-    delete msg;
   } else if (offset_segment_num > s->logger.segment()) {
     // encoderd packet has a newer segment, this means encoderd has rolled over
     if (!re.marked_ready_to_rotate) {
@@ -288,9 +295,11 @@ void loggerd_thread() {
           capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize() / sizeof(capnp::word)));
           auto event = cmsg.getRoot<cereal::Event>();
           auto audio_data = event.getRawAudioData().getData();
+          auto sample_rate = event.getRawAudioData().getSampleRate();
           for (auto* encoder : encoders_with_audio) {
             if (encoder && encoder->writer) {
-              encoder->writer->write_audio((uint8_t*)audio_data.begin(), audio_data.size(), event.getLogMonoTime() / 1000);
+              encoder->writer->write_audio((uint8_t*)audio_data.begin(), audio_data.size(), event.getLogMonoTime() / 1000, sample_rate);
+              encoder->audio_initialized = true;
             }
           }
         }

--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -289,7 +289,7 @@ void loggerd_thread() {
         if (service.record_audio) {
           capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize() / sizeof(capnp::word)));
           auto event = cmsg.getRoot<cereal::Event>();
-          auto audio_data = event.getAudioData().getData();
+          auto audio_data = event.getRawAudioData().getData();
           for (auto* encoder : encoders_with_audio) {
             if (encoder && encoder->writer) {
               encoder->writer->write_audio((uint8_t*)audio_data.begin(), audio_data.size(), event.getLogMonoTime()/1000);

--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -256,15 +256,13 @@ void loggerd_thread() {
     for (const auto &encoder_info : cam.encoder_infos) {
       encoder_infos_dict[encoder_info.publish_name] = encoder_info;
       s.max_waiting++;
+    }
+  }
 
-      if (encoder_info.include_audio) {
-        for (auto& [sock, service] : service_state) {
-          if (service.name == encoder_info.publish_name) {
-            encoders_with_audio.push_back(&remote_encoders[sock]);
-            break;
-          }
-        }
-      }
+  for (auto &[sock, service] : service_state) {
+    auto it = encoder_infos_dict.find(service.name);
+    if (it != encoder_infos_dict.end() && it->second.include_audio) {
+      encoders_with_audio.push_back(&remote_encoders[sock]);
     }
   }
 
@@ -292,7 +290,7 @@ void loggerd_thread() {
           auto audio_data = event.getRawAudioData().getData();
           for (auto* encoder : encoders_with_audio) {
             if (encoder && encoder->writer) {
-              encoder->writer->write_audio((uint8_t*)audio_data.begin(), audio_data.size(), event.getLogMonoTime()/1000);
+              encoder->writer->write_audio((uint8_t*)audio_data.begin(), audio_data.size(), event.getLogMonoTime() / 1000);
             }
           }
         }

--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -79,7 +79,6 @@ size_t write_encode_data(LoggerdState *s, cereal::Event::Reader event, RemoteEnc
         LOGW("%s: dropped %d non iframe packets before init", encoder_info.publish_name, re.dropped_frames);
         re.dropped_frames = 0;
       }
-      // if we aren't actually recording, don't create the writer
       if (encoder_info.record) {
         // write the header
         auto header = edata.getHeader();
@@ -135,6 +134,7 @@ int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct 
 
     // if this is a new segment, we close any possible old segments, move to the new, and process any queued packets
     if (re.current_segment != s->logger.segment()) {
+      // if we aren't actually recording, don't create the writer
       if (encoder_info.record) {
         assert(encoder_info.filename != NULL);
         re.writer.reset(new VideoWriter(s->logger.segmentPath().c_str(),
@@ -145,9 +145,9 @@ int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct 
       }
       re.current_segment = s->logger.segment();
       re.marked_ready_to_rotate = false;
-      // we are in this segment now, process any queued messages before this one
     }
     if (re.audio_initialized || !encoder_info.include_audio) {
+      // we are in this segment now, process any queued messages before this one
       if (!re.q.empty()) {
         for (auto qmsg : re.q) {
           capnp::FlatArrayMessageReader reader({(capnp::word *)qmsg->getData(), qmsg->getSize() / sizeof(capnp::word)});

--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -291,10 +291,10 @@ void loggerd_thread() {
         } else if (service.record_audio) {
           capnp::FlatArrayMessageReader cmsg(kj::ArrayPtr<capnp::word>((capnp::word *)msg->getData(), msg->getSize() / sizeof(capnp::word)));
           auto event = cmsg.getRoot<cereal::Event>();
-          auto audio_data = event.getAudioData();
+          auto audio_data = event.getAudioData().getData();
           for (auto* encoder : encoders_with_audio) {
             if (encoder && encoder->writer) {
-              encoder->writer->write_audio(audio_data, event.getLogMonoTime());
+              encoder->writer->write_audio((uint8_t*)audio_data.begin(), audio_data.size(), event.getLogMonoTime()/1000);
             }
           }
           delete msg;

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -35,6 +35,7 @@ public:
   const char *thumbnail_name = NULL;
   const char *filename = NULL;
   bool record = true;
+  bool include_audio = false;
   int frame_width = -1;
   int frame_height = -1;
   int fps = MAIN_FPS;
@@ -106,6 +107,7 @@ const EncoderInfo qcam_encoder_info = {
   .encode_type = cereal::EncodeIndex::Type::QCAMERA_H264,
   .frame_width = 526,
   .frame_height = 330,
+  .include_audio = Params().getBool("RecordAudio"),
   INIT_ENCODE_FUNCTIONS(QRoadEncode),
 };
 

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -42,49 +42,46 @@ VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, 
     assert(this->out_stream);
 
     if (has_audio) {
-      if (this->ofmt_ctx->oformat->audio_codec == AV_CODEC_ID_NONE) {
-        LOGE("Output format '%s' does not support audio streams, continuing without audio. Please change the output format or the set include_audio to false.", this->ofmt_ctx->oformat->name);
-      } else {
-        const AVCodec *audio_avcodec = avcodec_find_encoder(AV_CODEC_ID_AAC);
-        assert(audio_avcodec);
-        this->audio_codec_ctx = avcodec_alloc_context3(audio_avcodec);
-        assert(this->audio_codec_ctx);
-        this->audio_codec_ctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
-        this->audio_codec_ctx->sample_rate = 16000; // from system/micd.py
-        #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
-        av_channel_layout_default(&this->audio_codec_ctx->ch_layout, 1);
-        #else
-        this->audio_codec_ctx->channel_layout = AV_CH_LAYOUT_MONO;
-        #endif
-        this->audio_codec_ctx->bit_rate = 32000;
-        this->audio_codec_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+      assert(this->ofmt_ctx->oformat->audio_codec != AV_CODEC_ID_NONE); // check output format supports audio streams
+      const AVCodec *audio_avcodec = avcodec_find_encoder(AV_CODEC_ID_AAC);
+      assert(audio_avcodec);
+      this->audio_codec_ctx = avcodec_alloc_context3(audio_avcodec);
+      assert(this->audio_codec_ctx);
+      this->audio_codec_ctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
+      this->audio_codec_ctx->sample_rate = 16000; // from system/micd.py
+      #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
+      av_channel_layout_default(&this->audio_codec_ctx->ch_layout, 1);
+      #else
+      this->audio_codec_ctx->channel_layout = AV_CH_LAYOUT_MONO;
+      #endif
+      this->audio_codec_ctx->bit_rate = 32000;
+      this->audio_codec_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
-        int err = avcodec_open2(this->audio_codec_ctx, audio_avcodec, NULL);
-        assert(err >= 0);
-        av_log_set_level(AV_LOG_WARNING); // hide "QAvg" info msgs at the end of every segment
+      int err = avcodec_open2(this->audio_codec_ctx, audio_avcodec, NULL);
+      assert(err >= 0);
+      av_log_set_level(AV_LOG_WARNING); // hide "QAvg" info msgs at the end of every segment
 
-        this->audio_stream = avformat_new_stream(this->ofmt_ctx, NULL);
-        assert(this->audio_stream);
-        err = avcodec_parameters_from_context(this->audio_stream->codecpar, this->audio_codec_ctx);
-        assert(err >= 0);
-        this->audio_stream->time_base = (AVRational){1, this->audio_codec_ctx->sample_rate};
+      this->audio_stream = avformat_new_stream(this->ofmt_ctx, NULL);
+      assert(this->audio_stream);
+      err = avcodec_parameters_from_context(this->audio_stream->codecpar, this->audio_codec_ctx);
+      assert(err >= 0);
+      this->audio_stream->time_base = (AVRational){1, this->audio_codec_ctx->sample_rate};
 
-        this->audio_frame = av_frame_alloc();
-        assert(this->audio_frame);
-        this->audio_frame->format = this->audio_codec_ctx->sample_fmt;
-        #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
-        av_channel_layout_copy(&this->audio_frame->ch_layout, &this->audio_codec_ctx->ch_layout);
-        #else
-        this->audio_frame->channel_layout = this->audio_codec_ctx->channel_layout;
-        #endif
-        this->audio_frame->sample_rate = this->audio_codec_ctx->sample_rate;
-        this->audio_frame->nb_samples = this->audio_codec_ctx->frame_size;
-        int ret = av_frame_get_buffer(this->audio_frame, 0);
-        if (ret < 0) {
-          LOGE("AUDIO: Failed to allocate frame buffer: %d", ret);
-          av_frame_free(&this->audio_frame);
-          this->audio_frame = nullptr;
-        }
+      this->audio_frame = av_frame_alloc();
+      assert(this->audio_frame);
+      this->audio_frame->format = this->audio_codec_ctx->sample_fmt;
+      #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
+      av_channel_layout_copy(&this->audio_frame->ch_layout, &this->audio_codec_ctx->ch_layout);
+      #else
+      this->audio_frame->channel_layout = this->audio_codec_ctx->channel_layout;
+      #endif
+      this->audio_frame->sample_rate = this->audio_codec_ctx->sample_rate;
+      this->audio_frame->nb_samples = this->audio_codec_ctx->frame_size;
+      int ret = av_frame_get_buffer(this->audio_frame, 0);
+      if (ret < 0) {
+        LOGE("AUDIO: Failed to allocate frame buffer: %d", ret);
+        av_frame_free(&this->audio_frame);
+        this->audio_frame = nullptr;
       }
     }
 

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -157,9 +157,8 @@ void VideoWriter::write_audio(uint8_t *data, int len, long long timestamp) {
   for (int i = 0; i < sample_count; i++) {
     audio_buffer.push_back(raw_samples[i] / 32768.0f);
   }
-  buffered_samples += sample_count;
 
-  while (buffered_samples >= audio_codec_ctx->frame_size) {
+  while (audio_buffer.size() >= audio_codec_ctx->frame_size) {
     audio_frame->pts = next_audio_pts;
 
     float *f_samples = reinterpret_cast<float*>(audio_frame->data[0]);
@@ -170,7 +169,6 @@ void VideoWriter::write_audio(uint8_t *data, int len, long long timestamp) {
     for (int i = 0; i < audio_codec_ctx->frame_size; i++) {
       audio_buffer.pop_front();
     }
-    buffered_samples -= audio_codec_ctx->frame_size;
 
     int send_result = avcodec_send_frame(audio_codec_ctx, audio_frame); // encode frames
     if (send_result >= 0) {

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -5,7 +5,7 @@
 #include "common/swaglog.h"
 #include "common/util.h"
 
-VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec, bool include_audio)
+VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec)
   : remuxing(remuxing) {
   vid_path = util::string_format("%s/%s", path, filename);
   lock_path = util::string_format("%s/%s.lock", path, filename);
@@ -41,45 +41,6 @@ VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, 
     this->out_stream = avformat_new_stream(this->ofmt_ctx, raw ? avcodec : NULL);
     assert(this->out_stream);
 
-    if (include_audio) {
-      assert(this->ofmt_ctx->oformat->audio_codec != AV_CODEC_ID_NONE); // check output format supports audio streams
-      const AVCodec *audio_avcodec = avcodec_find_encoder(AV_CODEC_ID_AAC);
-      assert(audio_avcodec);
-      this->audio_codec_ctx = avcodec_alloc_context3(audio_avcodec);
-      assert(this->audio_codec_ctx);
-      this->audio_codec_ctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
-      this->audio_codec_ctx->sample_rate = 16000; // from system/micd.py
-      #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
-      av_channel_layout_default(&this->audio_codec_ctx->ch_layout, 1);
-      #else
-      this->audio_codec_ctx->channel_layout = AV_CH_LAYOUT_MONO;
-      #endif
-      this->audio_codec_ctx->bit_rate = 32000;
-      this->audio_codec_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
-      this->audio_codec_ctx->time_base = (AVRational){1, audio_codec_ctx->sample_rate};
-      int err = avcodec_open2(this->audio_codec_ctx, audio_avcodec, NULL);
-      assert(err >= 0);
-      av_log_set_level(AV_LOG_WARNING); // hide "QAvg" info msgs at the end of every segment
-
-      this->audio_stream = avformat_new_stream(this->ofmt_ctx, NULL);
-      assert(this->audio_stream);
-      err = avcodec_parameters_from_context(this->audio_stream->codecpar, this->audio_codec_ctx);
-      assert(err >= 0);
-
-      this->audio_frame = av_frame_alloc();
-      assert(this->audio_frame);
-      this->audio_frame->format = this->audio_codec_ctx->sample_fmt;
-      #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
-      av_channel_layout_copy(&this->audio_frame->ch_layout, &this->audio_codec_ctx->ch_layout);
-      #else
-      this->audio_frame->channel_layout = this->audio_codec_ctx->channel_layout;
-      #endif
-      this->audio_frame->sample_rate = this->audio_codec_ctx->sample_rate;
-      this->audio_frame->nb_samples = this->audio_codec_ctx->frame_size;
-      err = av_frame_get_buffer(this->audio_frame, 0);
-      assert(err >= 0);
-    }
-
     int err = avio_open(&this->ofmt_ctx->pb, this->vid_path.c_str(), AVIO_FLAG_WRITE);
     assert(err >= 0);
 
@@ -87,6 +48,45 @@ VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, 
     this->of = util::safe_fopen(this->vid_path.c_str(), "wb");
     assert(this->of);
   }
+}
+
+void VideoWriter::initialize_audio(int sample_rate) {
+  assert(this->ofmt_ctx->oformat->audio_codec != AV_CODEC_ID_NONE); // check output format supports audio streams
+  const AVCodec *audio_avcodec = avcodec_find_encoder(AV_CODEC_ID_AAC);
+  assert(audio_avcodec);
+  this->audio_codec_ctx = avcodec_alloc_context3(audio_avcodec);
+  assert(this->audio_codec_ctx);
+  this->audio_codec_ctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
+  this->audio_codec_ctx->sample_rate = sample_rate;
+  #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
+  av_channel_layout_default(&this->audio_codec_ctx->ch_layout, 1);
+  #else
+  this->audio_codec_ctx->channel_layout = AV_CH_LAYOUT_MONO;
+  #endif
+  this->audio_codec_ctx->bit_rate = 32000;
+  this->audio_codec_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+  this->audio_codec_ctx->time_base = (AVRational){1, audio_codec_ctx->sample_rate};
+  int err = avcodec_open2(this->audio_codec_ctx, audio_avcodec, NULL);
+  assert(err >= 0);
+  av_log_set_level(AV_LOG_WARNING); // hide "QAvg" info msgs at the end of every segment
+
+  this->audio_stream = avformat_new_stream(this->ofmt_ctx, NULL);
+  assert(this->audio_stream);
+  err = avcodec_parameters_from_context(this->audio_stream->codecpar, this->audio_codec_ctx);
+  assert(err >= 0);
+
+  this->audio_frame = av_frame_alloc();
+  assert(this->audio_frame);
+  this->audio_frame->format = this->audio_codec_ctx->sample_fmt;
+  #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)  // FFmpeg 5.1+
+  av_channel_layout_copy(&this->audio_frame->ch_layout, &this->audio_codec_ctx->ch_layout);
+  #else
+  this->audio_frame->channel_layout = this->audio_codec_ctx->channel_layout;
+  #endif
+  this->audio_frame->sample_rate = this->audio_codec_ctx->sample_rate;
+  this->audio_frame->nb_samples = this->audio_codec_ctx->frame_size;
+  err = av_frame_get_buffer(this->audio_frame, 0);
+  assert(err >= 0);
 }
 
 void VideoWriter::write(uint8_t *data, int len, long long timestamp, bool codecconfig, bool keyframe) {
@@ -106,9 +106,9 @@ void VideoWriter::write(uint8_t *data, int len, long long timestamp, bool codecc
       }
       int err = avcodec_parameters_from_context(out_stream->codecpar, codec_ctx);
       assert(err >= 0);
-      err = avformat_write_header(ofmt_ctx, NULL);
-      assert(err >= 0);
-    } else {
+        err = avformat_write_header(ofmt_ctx, NULL);
+        assert(err >= 0);
+      } else {
       // input timestamps are in microseconds
       AVRational in_timebase = {1, 1000000};
 
@@ -135,8 +135,13 @@ void VideoWriter::write(uint8_t *data, int len, long long timestamp, bool codecc
   }
 }
 
-void VideoWriter::write_audio(uint8_t *data, int len, long long timestamp) {
-  if (!remuxing || !audio_codec_ctx) return;
+void VideoWriter::write_audio(uint8_t *data, int len, long long timestamp, int sample_rate) {
+  if (!remuxing) return;
+  if (!audio_initialized) {
+    initialize_audio(sample_rate);
+    audio_initialized = true;
+  }
+  if (!audio_codec_ctx) return;
 
   // sync logMonoTime of first audio packet with the timestampEof of first video packet
   if (audio_pts == 0) {
@@ -174,6 +179,7 @@ void VideoWriter::encode_and_write_audio_frame(AVFrame* frame) {
       if (err < 0) {
         LOGW("AUDIO: Write frame failed - error: %d", err);
       }
+      av_packet_unref(pkt);
     }
     av_packet_free(&pkt);
   } else {

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -151,12 +151,11 @@ void VideoWriter::write_audio(uint8_t *data, int len, long long timestamp) {
   // convert s16le samples to fltp and add to buffer
   const int16_t *raw_samples = reinterpret_cast<const int16_t*>(data);
   int sample_count = len / sizeof(int16_t);
-  audio_buffer.reserve(audio_buffer.size() + sample_count);
   constexpr float normalizer = 1.0f / 32768.0f;
-  std::transform(raw_samples, raw_samples + sample_count, std::back_inserter(audio_buffer),
-                 [](int16_t sample) {
-                     return sample * normalizer;
-                 });
+  const size_t original_size = audio_buffer.size();
+  audio_buffer.resize(original_size + sample_count);
+  std::transform(raw_samples, raw_samples + sample_count, audio_buffer.begin() + original_size,
+                [](int16_t sample) { return sample * normalizer; });
 
   while (audio_buffer.size() >= audio_codec_ctx->frame_size) {
     audio_frame->pts = next_audio_pts;

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -144,8 +144,6 @@ void VideoWriter::write_audio(uint8_t *data, int len, long long timestamp, int s
     audio_initialized = true;
   }
   if (!audio_codec_ctx) return;
-  if (!header_written) return; // header not written yet, skip processing audio frame
-
   // sync logMonoTime of first audio packet with the timestampEof of first video packet
   if (audio_pts == 0) {
     audio_pts = (timestamp * audio_codec_ctx->sample_rate) / 1000000ULL;
@@ -160,6 +158,7 @@ void VideoWriter::write_audio(uint8_t *data, int len, long long timestamp, int s
   std::transform(raw_samples, raw_samples + sample_count, audio_buffer.begin() + original_size,
                 [](int16_t sample) { return sample * normalizer; });
 
+  if (!header_written) return; // header not written yet, process audio frame after header is written
   while (audio_buffer.size() >= audio_codec_ctx->frame_size) {
     audio_frame->pts = audio_pts;
     float *f_samples = reinterpret_cast<float*>(audio_frame->data[0]);

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -106,7 +106,7 @@ void VideoWriter::write(uint8_t *data, int len, long long timestamp, bool codecc
       }
       int err = avcodec_parameters_from_context(out_stream->codecpar, codec_ctx);
       assert(err >= 0);
-      // if there is an audio stream, it must be intialized before this point
+      // if there is an audio stream, it must be initialized before this point
       err = avformat_write_header(ofmt_ctx, NULL);
       assert(err >= 0);
       header_written = true;

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -14,7 +14,7 @@ class VideoWriter {
 public:
   VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec, bool has_audio);
   void write(uint8_t *data, int len, long long timestamp, bool codecconfig, bool keyframe);
-  void write_audio(const cereal::AudioData::Reader &audio_data, uint64_t logMonoTime);
+  void write_audio(uint8_t *data, int len, long long timestamp);
   ~VideoWriter();
 
 private:
@@ -29,8 +29,7 @@ private:
   AVCodecContext *audio_codec_ctx = nullptr;
   AVFrame *audio_frame = nullptr;
   uint64_t next_audio_pts = 0;
-  int64_t last_audio_pts = 0;
-  uint64_t first_audio_logMonoTime = 0;
+  uint64_t first_audio_timestamp = 0;
   std::deque<float> audio_buffer;
   uint64_t buffered_samples = 0;
 

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -30,6 +30,7 @@ private:
   AVStream *out_stream;
 
   bool audio_initialized = false;
+  bool header_written = false;
   AVStream *audio_stream = nullptr;
   AVCodecContext *audio_codec_ctx = nullptr;
   AVFrame *audio_frame = nullptr;

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -12,12 +12,15 @@ extern "C" {
 
 class VideoWriter {
 public:
-  VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec, bool has_audio);
+  VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec, bool include_audio);
   void write(uint8_t *data, int len, long long timestamp, bool codecconfig, bool keyframe);
   void write_audio(uint8_t *data, int len, long long timestamp);
+
   ~VideoWriter();
 
 private:
+  void encode_and_write_audio_frame(AVFrame* frame);
+
   std::string vid_path, lock_path;
   FILE *of = nullptr;
 
@@ -28,8 +31,7 @@ private:
   AVStream *audio_stream = nullptr;
   AVCodecContext *audio_codec_ctx = nullptr;
   AVFrame *audio_frame = nullptr;
-  uint64_t next_audio_pts = 0;
-  uint64_t first_audio_timestamp = 0;
+  uint64_t audio_pts = 0;
   std::deque<float> audio_buffer;
 
   bool remuxing;

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <deque>
+#include <vector>
 
 extern "C" {
 #include <libavformat/avformat.h>
@@ -30,7 +30,7 @@ private:
   AVFrame *audio_frame = nullptr;
   uint64_t next_audio_pts = 0;
   uint64_t first_audio_timestamp = 0;
-  std::deque<float> audio_buffer;
+  std::vector<float> audio_buffer;
 
   bool remuxing;
 };

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <deque>
 
 extern "C" {
 #include <libavformat/avformat.h>
@@ -30,7 +30,7 @@ private:
   AVFrame *audio_frame = nullptr;
   uint64_t next_audio_pts = 0;
   uint64_t first_audio_timestamp = 0;
-  std::vector<float> audio_buffer;
+  std::deque<float> audio_buffer;
 
   bool remuxing;
 };

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -31,7 +31,6 @@ private:
   uint64_t next_audio_pts = 0;
   uint64_t first_audio_timestamp = 0;
   std::deque<float> audio_buffer;
-  uint64_t buffered_samples = 0;
 
   bool remuxing;
 };

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -12,13 +12,14 @@ extern "C" {
 
 class VideoWriter {
 public:
-  VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec, bool include_audio);
+  VideoWriter(const char *path, const char *filename, bool remuxing, int width, int height, int fps, cereal::EncodeIndex::Type codec);
   void write(uint8_t *data, int len, long long timestamp, bool codecconfig, bool keyframe);
-  void write_audio(uint8_t *data, int len, long long timestamp);
+  void write_audio(uint8_t *data, int len, long long timestamp, int sample_rate);
 
   ~VideoWriter();
 
 private:
+  void initialize_audio(int sample_rate);
   void encode_and_write_audio_frame(AVFrame* frame);
 
   std::string vid_path, lock_path;
@@ -28,6 +29,7 @@ private:
   AVFormatContext *ofmt_ctx;
   AVStream *out_stream;
 
+  bool audio_initialized = false;
   AVStream *audio_stream = nullptr;
   AVCodecContext *audio_codec_ctx = nullptr;
   AVFrame *audio_frame = nullptr;


### PR DESCRIPTION
depends on #35595

Stores microphone audio in qcamera.ts as an AAC encoded stream at 32kbps

Audio can be added to any video output that supports audio streams by adding `.include_audio` to the encoder info in loggerd.h. Audio codec and bitrate is set in video_writer.cc.