### PR TITLE
micd: deprecate unused field

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2476,7 +2476,8 @@ struct Microphone {
   # uncalibrated, A-weighted
   soundPressureWeighted @3 :Float32;
   soundPressureWeightedDb @1 :Float32;
-  filteredSoundPressureWeightedDb @2 :Float32;
+
+  filteredSoundPressureWeightedDbDEPRECATED @2 :Float32;
 }
 
 struct Touch {


### PR DESCRIPTION
confused me when looking into issue just now, best to deprecate it. removed in https://github.com/commaai/openpilot/pull/30620