### PR TITLE
Feat/define v2v message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+***
+
+### **hC3-openpilot: A Research Fork for Human-in-the-Loop Connected Cruise Control**
+
+This repository contains a research-focused fork of `commaai/openpilot`, developed as part of the Human-in-the-Loop Connected Cruise Control (hC3) project at the University of Virginia. The primary goal of this fork is to implement and test the hC3 algorithm in a real-world, two-vehicle environment using Comma 3X hardware.
+
+This fork is not intended for general use but serves as a development platform for academic research into cooperative driving systems.
+
+**Key Features & Modifications:**
+
+*   **hC3 Longitudinal Control:** Implements a novel human-in-the-loop control algorithm that takes the driver's acceleration or deceleration commands and optimally adjusts them based on real-time data received from a preceding vehicle. This fork modifies the stock Adaptive Cruise Control (ACC) logic to integrate this cooperative driving strategy.
+*   **Vehicle-to-Vehicle (V2V) Communication:** Includes a custom-built V2V communication daemon that enables two Comma 3X devices to exchange critical data (e.g., acceleration, speed) over a standard Wi-Fi network. This facilitates the data sharing required for the hC3 algorithm to function.
+*   **Modular Integration:** The custom logic is implemented through new, dedicated openpilot daemons. This approach ensures a clean separation from the core openpilot code, allowing for coexistence with stock features and easier analysis.
+
+**Project Status:**
+
+This fork is an experimental build intended for academic research and field testing. It represents the transition of the hC3 algorithm from a virtual simulation environment to a practical, on-road application.
+
+**Disclaimer:**
+
+This is alpha-quality software for research purposes only. It is not a product. By installing this software, you accept all responsibility and liability for anything that might occur while you use it. The driver must remain attentive and ready to take control at all times. Use at your own risk.
+
+***
+
 <div align="center" style="text-align: center;">
 
 <h1>openpilot</h1>

--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2487,6 +2487,18 @@ struct Touch {
   value @4 :Int32;
 }
 
+struct V2VData {
+  logMonoTime @0 :UInt64;
+  vEgo @1 :Float32;
+  aEgo @2 :Float32;
+  status @3 :UInt8;
+}
+
+struct Hc3Control {
+  active @0 :Bool;
+  aTarget @1 :Float32;
+}
+
 struct Event {
   logMonoTime @0 :UInt64;  # nanoseconds
   valid @67 :Bool = true;


### PR DESCRIPTION
## Description

This pull request establishes the foundational data interface for the Human-in-the-Loop Connected Cruise Control (hC3) research project. The primary goal is to define the cereal messages that will be used for communication between the new hC3 components.

This refactor accomplishes the following:

- Defines V2VData message: A new struct is added to cereal/log.capnp to standardize the data packet broadcast from the lead vehicle to the following vehicle. This includes fields for speed, acceleration, and a timestamp for latency measurement.
- Defines hc3Control message: A new struct is added to cereal/log.capnp to serve as the output of the future hc3_daemon. It will communicate the algorithm's computed target acceleration to the controlsd process.
- Enables Parallel Development: By establishing this data contract, the V2V communication layer (Phase 1) and the core hC3 algorithm (Phase 2) can be developed independently and in parallel.

This change is purely additive and follows openpilot contribution guidelines by creating new message types rather than modifying existing ones, ensuring no impact on stock functionality.

## Verification

As this change only involves schema definitions in cereal/log.capnp, verification focuses on ensuring the project remains buildable and the new definitions are syntactically correct.

1. Checked out this branch on a local macOS development environment.
2. Activated the project's virtual environment (source.venv/bin/activate).
3. Ran the full compilation command: scons -j$(sysctl -n hw.ncpu).

The build completed successfully with no errors, confirming that the new message definitions are correctly integrated into the project.