### PR TITLE
Add support for generating clang compilation database by default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -39,10 +39,6 @@ AddOption('--clazy',
           action='store_true',
           help='build with clazy')
 
-AddOption('--compile_db',
-          action='store_true',
-          help='build clang compilation database')
-
 AddOption('--ccflags',
           action='store',
           type='string',
@@ -214,8 +210,7 @@ if arch == "Darwin":
   darwin_rpath_link_flags = [f"-Wl,-rpath,{path}" for path in env["RPATH"]]
   env["LINKFLAGS"] += darwin_rpath_link_flags
 
-if GetOption('compile_db'):
-  env.CompilationDatabase('compile_commands.json')
+env.CompilationDatabase('compile_commands.json')
 
 # Setup cache dir
 cache_dir = '/data/scons_cache' if AGNOS else '/tmp/scons_cache'


### PR DESCRIPTION
> [!NOTE]
> Sister PRs: 
> * https://github.com/commaai/opendbc/pull/2428
> * https://github.com/commaai/panda/pull/2225

This updates the `compilation_db` functionality in **openpilot** to always generate `compile_commands.json` by default, without requiring the `--compile-db` flag.

_This feature was originally introduced in [commaai/openpilot#19533](https://github.com/commaai/openpilot/pull/19533) by @adeebshihadeh._

### What's changed
- **`compile_commands.json` is now generated by default**—the `--compile-db` argument is no longer required.
- This applies whether you're building openpilot on its own or including submodules like panda or opendbc.

### Behavior
- A full `compile_commands.json` is generated in the root of the openpilot repo.
- If panda or opendbc are included as submodules, their entries are included automatically, assuming their `SConscript` files are properly configured to support compilation DB generation.

This change ensures better out-of-the-box IDE support and tooling compatibility, improving the development experience across the full openpilot codebase.
