### PR TITLE
tici: reduce GPU pwrlevel

### DIFF
--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -415,8 +415,8 @@ class Tici(HardwareBase):
 
     # *** GPU config ***
     # https://github.com/commaai/agnos-kernel-sdm845/blob/master/arch/arm64/boot/dts/qcom/sdm845-gpu.dtsi#L216
-    sudo_write("0", "/sys/class/kgsl/kgsl-3d0/min_pwrlevel")
-    sudo_write("0", "/sys/class/kgsl/kgsl-3d0/max_pwrlevel")
+    sudo_write("1", "/sys/class/kgsl/kgsl-3d0/min_pwrlevel")
+    sudo_write("1", "/sys/class/kgsl/kgsl-3d0/max_pwrlevel")
     sudo_write("1", "/sys/class/kgsl/kgsl-3d0/force_bus_on")
     sudo_write("1", "/sys/class/kgsl/kgsl-3d0/force_clk_on")
     sudo_write("1", "/sys/class/kgsl/kgsl-3d0/force_rail_on")


### PR DESCRIPTION
Closes #35619

With current openpilot load, GPU is driving the max temp, and we're now seeing a few onroad overheats.

![image](https://github.com/user-attachments/assets/ad198749-dc25-40ec-9b48-87db6f6e2a3f)
