### PR TITLE
ci: switch to native install + cache to test speed

### DIFF
--- a/.github/workflows/setup-with-retry/action.yaml
+++ b/.github/workflows/setup-with-retry/action.yaml
@@ -13,25 +13,56 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: setup1
-      uses: ./.github/workflows/setup
-      continue-on-error: true
+       # 1) Checkout your repo
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+
+    # 2) Setup Python
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
       with:
-        is_retried: true
-    - if: steps.setup1.outcome == 'failure'
+        python-version: '3.8'
+
+       # 3) Cache pip wheels via your auto-cache action
+    - name: Cache pip
+      id: pip-cache
+      uses: ./.github/workflows/auto-cache
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+        save: 'true'
+
+
+    # 4) Cache APT packages via your auto-cache action
+    - name: Cache APT packages
+      id: apt-cache
+      uses: ./.github/workflows/auto-cache
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-${{ hashFiles('apt_requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-
+        save: 'true'
+
+         # 5) Native install of system + Python deps
+    - id: install
+      name: Install system & Python dependencies
       shell: bash
-      run: sleep ${{ inputs.sleep_time }}
-    - id: setup2
-      if: steps.setup1.outcome == 'failure'
-      uses: ./.github/workflows/setup
-      continue-on-error: true
-      with:
-        is_retried: true
-    - if: steps.setup2.outcome == 'failure'
+      run: |
+        sudo apt-get update -qq
+        xargs -a apt_requirements.txt sudo apt-get install -qq -y
+        pip install --no-cache-dir -r tools/requirements.txt
+
+      # 6) Retry logic if the above failed
+    - name: Retry install if it failed
+      if: steps.install.outcome == 'failure'
       shell: bash
-      run: sleep ${{ inputs.sleep_time }}
-    - id: setup3
-      if: steps.setup2.outcome == 'failure'
-      uses: ./.github/workflows/setup
-      with:
-        is_retried: true
+      run: |
+        echo "Initial install failed, sleeping for ${{ inputs.sleep_time }}s…"
+        sleep ${{ inputs.sleep_time }}
+        sudo apt-get update -qq
+        xargs -a apt_requirements.txt sudo apt-get install -qq -y
+        pip install --no-cache-dir -r tools/requirements.txt


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for
n/a
**Route**
A route with the fingerprint
n/a
-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 
n/a
**Verification**

Explain how you tested this bug fix. 
n/a
**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

n/a

-->

<!--- ***** Template: Car Port *****

**Checklist**

- [- ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [- ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [- ] route with openpilot:
- [ -] route with stock system:
- [N/A ] car harness used (if comma doesn't sell it, put N/A):


-->

 ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

It was CI/Testing challenge for creating a best time of the setup-with-retry stage to run in most of CI jobs. I have remove the docker, and checkout my repo to set up python natively, use the auto-cache action to restore save pip and apt caches, and installed system packages then added a install.

**Verification**

Explain how you tested the refactor for regressions. 

i did a draft pull request for my branch fast-ci-test, and gonna try merge to see the test results from there, i wasn't able run the test locally.



