### PR TITLE
LogReader: Support More Local Path Styles

### DIFF
--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -15,3 +15,5 @@ class RE:
 
   EXPLORER_FILE = fr'^(?P<segment_name>{SEGMENT_NAME})--(?P<file_name>[a-z]+\.[a-z0-9]+)$'
   OP_SEGMENT_DIR = fr'^(?P<segment_name>{SEGMENT_NAME})$'
+
+  DONGLE_LESS_SEGMENT_NAME = fr'^(?P<segment_name>{LOG_ID}(?:--|/)(?P<segment_num>[0-9]+))'


### PR DESCRIPTION
Currently, the local paths only supports these styles of local logs:
 - `/folder/<dongle id>|<route>`
 - `/folder/<dongle id>|<route>--<segments>`
 - `/folder/<dongle id>|<route>/<segments>`

This adds supports for the following:
 - `/folder/<dongle id>/<route>/<route>--<segments>`
 - `/folder/<dongle id>/<route>/<segments>`

Which is more align to the useradmin's path style: `<dongle id>/<route>/<segments>`