### PR TITLE
test: fix test_rotation in test_loggerd.py

### DIFF
--- a/system/loggerd/tests/test_loggerd.py
+++ b/system/loggerd/tests/test_loggerd.py
@@ -180,14 +180,14 @@ class TestLoggerd:
       assert getattr(initData, initData_key) == v
       assert logged_params[param_key].decode() == v
 
-  @pytest.mark.skip("FIXME: encoderd sometimes crashes in CI when running with pytest-xdist")
+  @pytest.mark.xdist_group("camera_encoder_tests")  # setting xdist group ensures tests are run in same worker, prevents encoderd from crashing
   def test_rotation(self):
     Params().put("RecordFront", "1")
 
     expected_files = {"rlog.zst", "qlog.zst", "qcamera.ts", "fcamera.hevc", "dcamera.hevc", "ecamera.hevc"}
 
-    num_segs = random.randint(2, 5)
-    length = random.randint(1, 3)
+    num_segs = random.randint(2, 3)
+    length = random.randint(4, 5) # H264 encoder uses 40 lookahead frames and does B-frame reordering, so minimum 3 seconds before qcam output
 
     self._publish_camera_and_audio_messages(num_segs=num_segs, segment_length=length)
 


### PR DESCRIPTION
test_rotation uses encoderd on vipc frames, test was previously disabled since "encoderd sometimes crashes in CI when running with pytest-xdist"

this PR places the test_rotation test in an xdist-group, similar to the RecordAudio and RecordFront tests, which runs the tests utilizing encoderd in the same worker, preventing crashing

also fixes bug where minimum segment length was set from 1-3 seconds, so qcamera.ts would not show up in the test since the H264 encoder uses 40 lookahead frames and does b-frame reordering, which on average takes 57 frames before first output of the qRoadEncodeData message.