### PR TITLE
tools: update to commaCarSegments v2

### DIFF
--- a/tools/lib/comma_car_segments.py
+++ b/tools/lib/comma_car_segments.py
@@ -4,7 +4,7 @@ import requests
 
 # Forks with additional car support can fork the commaCarSegments repo on huggingface or host the LFS files themselves
 COMMA_CAR_SEGMENTS_REPO = os.environ.get("COMMA_CAR_SEGMENTS_REPO", "https://huggingface.co/datasets/commaai/commaCarSegments")
-COMMA_CAR_SEGMENTS_BRANCH = os.environ.get("COMMA_CAR_SEGMENTS_BRANCH", "main")
+COMMA_CAR_SEGMENTS_BRANCH = os.environ.get("COMMA_CAR_SEGMENTS_BRANCH", "v2")
 COMMA_CAR_SEGMENTS_LFS_INSTANCE = os.environ.get("COMMA_CAR_SEGMENTS_LFS_INSTANCE", COMMA_CAR_SEGMENTS_REPO)
 
 def get_comma_car_segments_database():
@@ -86,5 +86,5 @@ def get_repo_url(path):
     return get_repo_raw_url(path)
 
 
-def get_url(route, segment, file="rlog.bz2"):
+def get_url(route, segment, file="rlog.zst"):
   return get_repo_url(f"segments/{route.replace('|', '/')}/{segment}/{file}")


### PR DESCRIPTION
**Description**

Point the commaCarSegments client library at the new V2 dataset that just dropped, and switch the rlog file extension from `.bz2` to `.zst` to follow the compression type change.

**Verification**

Working for me in Jupyter Notebook, while on a project to clean up Honda gearbox messages.

There doesn't appear to be any non-ZST rlogs in the dataset.

```
jyoung@jy-workstation-ubuntu:~$ GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/datasets/commaai/commaCarSegments --branch v2
Cloning into 'commaCarSegments'...
remote: Enumerating objects: 1117442, done.
remote: Counting objects: 100% (484386/484386), done.
remote: Compressing objects: 100% (227613/227613), done.
remote: Total 1117442 (delta 0), reused 484386 (delta 0), pack-reused 633056 (from 1)
Receiving objects: 100% (1117442/1117442), 94.73 MiB | 39.94 MiB/s, done.
Resolving deltas: 100% (20094/20094), done.
Updating files: 100% (188887/188887), done.
jyoung@jy-workstation-ubuntu:~$ cd commaCarSegments/
jyoung@jy-workstation-ubuntu:~/commaCarSegments$ find . | grep "rlog\." | wc -l
188883
jyoung@jy-workstation-ubuntu:~/commaCarSegments$ find . | grep "\.bz2" | wc -l
0
jyoung@jy-workstation-ubuntu:~/commaCarSegments$ find . | grep "\.zst" | wc -l
188883
```