### PR TITLE
raylib: Improve close settings x button

### DIFF
--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -83,7 +83,7 @@ class SettingsLayout(Widget):
 
     # Close button
     close_btn_rect = rl.Rectangle(
-      rect.x + (rect.width - CLOSE_BTN_SIZE) / 2, rect.y + 45, CLOSE_BTN_SIZE, CLOSE_BTN_SIZE
+      rect.x + (rect.width - CLOSE_BTN_SIZE) / 2, rect.y + 60, CLOSE_BTN_SIZE, CLOSE_BTN_SIZE
     )
 
     pressed = (rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT) and

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -12,6 +12,10 @@ from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.selfdrive.ui.layouts.network import NetworkLayout
 from openpilot.system.ui.lib.widget import Widget
 
+# Settings close button
+SETTINGS_CLOSE_TEXT = "×"
+SETTINGS_CLOSE_TEXT_Y_OFFSET = 8  # The '×' character isn't quite vertically centered in the font so we need to offset it a bit to fully center it
+
 # Constants
 SIDEBAR_WIDTH = 500
 CLOSE_BTN_SIZE = 200
@@ -25,10 +29,6 @@ CLOSE_BTN_COLOR = rl.Color(41, 41, 41, 255)
 CLOSE_BTN_PRESSED = rl.Color(59, 59, 59, 255)
 TEXT_NORMAL = rl.Color(128, 128, 128, 255)
 TEXT_SELECTED = rl.Color(255, 255, 255, 255)
-
-# Settings close button
-SETTINGS_CLOSE_TEXT = "×"
-SETTINGS_CLOSE_TEXT_OFFSET = rl.Vector2(2, 8) # The '×' character isn't quite centered in the font so we need to offset it a bit to fully center it
 
 
 class PanelType(IntEnum):
@@ -94,8 +94,8 @@ class SettingsLayout(Widget):
 
     close_text_size = measure_text_cached(self._font_weight, SETTINGS_CLOSE_TEXT, 140)
     close_text_pos = rl.Vector2(
-      close_btn_rect.x + (close_btn_rect.width - close_text_size.x) / 2 - SETTINGS_CLOSE_TEXT_OFFSET.x,
-      close_btn_rect.y + (close_btn_rect.height - close_text_size.y) / 2 - SETTINGS_CLOSE_TEXT_OFFSET.y,
+      close_btn_rect.x + (close_btn_rect.width - close_text_size.x) / 2,
+      close_btn_rect.y + (close_btn_rect.height - close_text_size.y) / 2 - SETTINGS_CLOSE_TEXT_Y_OFFSET,
     )
     rl.draw_text_ex(self._font_weight, SETTINGS_CLOSE_TEXT, close_text_pos, 140, 0, TEXT_SELECTED)
 

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -62,7 +62,7 @@ class SettingsLayout(Widget):
       PanelType.DEVELOPER: PanelInfo("Developer", DeveloperLayout()),
     }
 
-    self._font_weight = gui_app.font(FontWeight.MEDIUM)
+    self._font_medium = gui_app.font(FontWeight.MEDIUM)
 
     # Callbacks
     self._close_callback: Callable | None = None
@@ -92,12 +92,12 @@ class SettingsLayout(Widget):
     close_color = CLOSE_BTN_PRESSED if pressed else CLOSE_BTN_COLOR
     rl.draw_rectangle_rounded(close_btn_rect, 1.0, 20, close_color)
 
-    close_text_size = measure_text_cached(self._font_weight, SETTINGS_CLOSE_TEXT, 140)
+    close_text_size = measure_text_cached(self._font_medium, SETTINGS_CLOSE_TEXT, 140)
     close_text_pos = rl.Vector2(
       close_btn_rect.x + (close_btn_rect.width - close_text_size.x) / 2,
       close_btn_rect.y + (close_btn_rect.height - close_text_size.y) / 2 - SETTINGS_CLOSE_TEXT_Y_OFFSET,
     )
-    rl.draw_text_ex(self._font_weight, SETTINGS_CLOSE_TEXT, close_text_pos, 140, 0, TEXT_SELECTED)
+    rl.draw_text_ex(self._font_medium, SETTINGS_CLOSE_TEXT, close_text_pos, 140, 0, TEXT_SELECTED)
 
     # Store close button rect for click detection
     self._close_btn_rect = close_btn_rect
@@ -111,11 +111,11 @@ class SettingsLayout(Widget):
       is_selected = panel_type == self._current_panel
       text_color = TEXT_SELECTED if is_selected else TEXT_NORMAL
       # Draw button text (right-aligned)
-      text_size = measure_text_cached(self._font_weight, panel_info.name, 65)
+      text_size = measure_text_cached(self._font_medium, panel_info.name, 65)
       text_pos = rl.Vector2(
         button_rect.x + button_rect.width - text_size.x, button_rect.y + (button_rect.height - text_size.y) / 2
       )
-      rl.draw_text_ex(self._font_weight, panel_info.name, text_pos, 65, 0, text_color)
+      rl.draw_text_ex(self._font_medium, panel_info.name, text_pos, 65, 0, text_color)
 
       # Store button rect for click detection
       panel_info.button_rect = button_rect

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -14,7 +14,7 @@ from openpilot.system.ui.lib.widget import Widget
 
 # Import individual panels
 
-SETTINGS_CLOSE_TEXT = "X"
+SETTINGS_CLOSE_TEXT = "×"
 # Constants
 SIDEBAR_WIDTH = 500
 CLOSE_BTN_SIZE = 200

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -12,9 +12,6 @@ from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.selfdrive.ui.layouts.network import NetworkLayout
 from openpilot.system.ui.lib.widget import Widget
 
-# Import individual panels
-
-SETTINGS_CLOSE_TEXT = "×" # TODO: Fix font rendering to support non-ascii
 # Constants
 SIDEBAR_WIDTH = 500
 CLOSE_BTN_SIZE = 200
@@ -28,6 +25,10 @@ CLOSE_BTN_COLOR = rl.Color(41, 41, 41, 255)
 CLOSE_BTN_PRESSED = rl.Color(59, 59, 59, 255)
 TEXT_NORMAL = rl.Color(128, 128, 128, 255)
 TEXT_SELECTED = rl.Color(255, 255, 255, 255)
+
+# Settings close button
+SETTINGS_CLOSE_TEXT = "×"
+SETTINGS_CLOSE_TEXT_OFFSET = rl.Vector2(2, 8) # The '×' character isn't quite centered in the font so we need to offset it a bit to fully center it
 
 
 class PanelType(IntEnum):
@@ -93,8 +94,8 @@ class SettingsLayout(Widget):
 
     close_text_size = measure_text_cached(self._font_weight, SETTINGS_CLOSE_TEXT, 140)
     close_text_pos = rl.Vector2(
-      close_btn_rect.x + (close_btn_rect.width - close_text_size.x) / 2,
-      close_btn_rect.y + (close_btn_rect.height - close_text_size.y) / 2,
+      close_btn_rect.x + (close_btn_rect.width - close_text_size.x) / 2 - SETTINGS_CLOSE_TEXT_OFFSET.x,
+      close_btn_rect.y + (close_btn_rect.height - close_text_size.y) / 2 - SETTINGS_CLOSE_TEXT_OFFSET.y,
     )
     rl.draw_text_ex(self._font_weight, SETTINGS_CLOSE_TEXT, close_text_pos, 140, 0, TEXT_SELECTED)
 

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -14,7 +14,7 @@ from openpilot.system.ui.lib.widget import Widget
 
 # Import individual panels
 
-SETTINGS_CLOSE_TEXT = "×"
+SETTINGS_CLOSE_TEXT = "×" # TODO: Fix font rendering to support non-ascii
 # Constants
 SIDEBAR_WIDTH = 500
 CLOSE_BTN_SIZE = 200

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -61,8 +61,7 @@ class SettingsLayout(Widget):
       PanelType.DEVELOPER: PanelInfo("Developer", DeveloperLayout()),
     }
 
-    self._font_medium = gui_app.font(FontWeight.MEDIUM)
-    self._font_bold = gui_app.font(FontWeight.SEMI_BOLD)
+    self._font_weight = gui_app.font(FontWeight.MEDIUM)
 
     # Callbacks
     self._close_callback: Callable | None = None
@@ -92,12 +91,12 @@ class SettingsLayout(Widget):
     close_color = CLOSE_BTN_PRESSED if pressed else CLOSE_BTN_COLOR
     rl.draw_rectangle_rounded(close_btn_rect, 1.0, 20, close_color)
 
-    close_text_size = measure_text_cached(self._font_bold, SETTINGS_CLOSE_TEXT, 140)
+    close_text_size = measure_text_cached(self._font_weight, SETTINGS_CLOSE_TEXT, 140)
     close_text_pos = rl.Vector2(
       close_btn_rect.x + (close_btn_rect.width - close_text_size.x) / 2,
       close_btn_rect.y + (close_btn_rect.height - close_text_size.y) / 2,
     )
-    rl.draw_text_ex(self._font_bold, SETTINGS_CLOSE_TEXT, close_text_pos, 140, 0, TEXT_SELECTED)
+    rl.draw_text_ex(self._font_weight, SETTINGS_CLOSE_TEXT, close_text_pos, 140, 0, TEXT_SELECTED)
 
     # Store close button rect for click detection
     self._close_btn_rect = close_btn_rect
@@ -111,11 +110,11 @@ class SettingsLayout(Widget):
       is_selected = panel_type == self._current_panel
       text_color = TEXT_SELECTED if is_selected else TEXT_NORMAL
       # Draw button text (right-aligned)
-      text_size = measure_text_cached(self._font_medium, panel_info.name, 65)
+      text_size = measure_text_cached(self._font_weight, panel_info.name, 65)
       text_pos = rl.Vector2(
         button_rect.x + button_rect.width - text_size.x, button_rect.y + (button_rect.height - text_size.y) / 2
       )
-      rl.draw_text_ex(self._font_medium, panel_info.name, text_pos, 65, 0, text_color)
+      rl.draw_text_ex(self._font_weight, panel_info.name, text_pos, 65, 0, text_color)
 
       # Store button rect for click detection
       panel_info.button_rect = button_rect

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -225,7 +225,7 @@ class GuiApplication:
     for layout in KEYBOARD_LAYOUTS.values():
       all_chars.update(key for row in layout for key in row)
     all_chars = "".join(all_chars)
-    all_chars += "–✓°"
+    all_chars += "–✓×°"
 
     codepoint_count = rl.ffi.new("int *", 1)
     codepoints = rl.load_codepoints(all_chars, codepoint_count)


### PR DESCRIPTION
Replaces the raylib close settings button text (ascii 'X' character) with the unicode '×' character. This matches the old UI much better.

### Before (raylib):
![sidebar-settings-close-button-raylib-old](https://github.com/user-attachments/assets/248c6211-e1d9-476f-bc6e-39a6be7fd6c4)

### After (raylib):
![sidebar-settings-close-button-raylib-new](https://github.com/user-attachments/assets/05cca0e4-312f-4ee3-94a3-2841df89bf9b)

### Old (QT):
![sidebar-settings-close-button-old](https://github.com/user-attachments/assets/8d1a8425-e200-4ad5-9828-76211597aa31)
