### PR TITLE
fix(raylib): Correct icon for metric system toggle

### DIFF
--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -82,7 +82,7 @@ class TogglesLayout(Widget):
         icon="microphone.png",
       ),
       toggle_item(
-        "Use Metric System", DESCRIPTIONS["IsMetric"], self._params.get_bool("IsMetric"), icon="monitoring.png"
+        "Use Metric System", DESCRIPTIONS["IsMetric"], self._params.get_bool("IsMetric"), icon="metric.png"
       ),
     ]
 


### PR DESCRIPTION
### Before:
<img width="365" height="93" alt="settings-metric-system-icon-raylib-old" src="https://github.com/user-attachments/assets/097ff098-2076-45ef-8774-881cf4585068" />

### After:
<img width="432" height="89" alt="settings-metric-system-icon-raylib-new" src="https://github.com/user-attachments/assets/ccd9e10b-876e-4794-ba1c-16dd8e1d598f" />
