### PR TITLE
pigeond: power cycle on reinit

### DIFF
--- a/system/ubloxd/pigeond.py
+++ b/system/ubloxd/pigeond.py
@@ -258,7 +258,7 @@ def deinitialize_and_exit(pigeon: TTYPigeon | None):
   set_power(False)
   sys.exit(0)
 
-def init(pigeon: TTYPigeon) -> tuple[TTYPigeon, messaging.PubMaster]:
+def init(pigeon: TTYPigeon) -> None:
   # register exit handler
   signal.signal(signal.SIGINT, lambda sig, frame: deinitialize_and_exit(pigeon))
 
@@ -268,7 +268,7 @@ def init(pigeon: TTYPigeon) -> tuple[TTYPigeon, messaging.PubMaster]:
   set_power(True)
   time.sleep(0.5)
 
-  init_baudrate()
+  init_baudrate(pigeon)
   init_pigeon(pigeon)
 
 def run_receiving(duration: int = 0):

--- a/system/ubloxd/pigeond.py
+++ b/system/ubloxd/pigeond.py
@@ -271,7 +271,7 @@ def init(pigeon: TTYPigeon) -> tuple[TTYPigeon, messaging.PubMaster]:
   init_baudrate()
   init_pigeon(pigeon)
 
-def run_receiving(pigeon: TTYPigeon, duration: int = 0):
+def run_receiving(duration: int = 0):
   pm = messaging.PubMaster(['ubloxRaw'])
 
   pigeon = TTYPigeon()


### PR DESCRIPTION
I shuffled some stuff around, but the actual change here is a power cycle for the re-init that seems to have gotten lost in the pigeond rewrite from a few years ago.

--- 

Unclear whether this actually changes anything, but I think it's more correct. I just noticed it after looking into some cases where the ublox raw messages are spaced multiple seconds apart, and in those cases pigeond is stuck re-initting for the whole route.

```
f4b52a2dabf77c7d/00000016--2af65039a3
```

<img width="1593" height="371" alt="image" src="https://github.com/user-attachments/assets/9a194084-8dca-487c-a78b-b7f00d4b7d25" />