### PR TITLE
fix(raylib): Show correct alert status

### DIFF
--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -96,7 +96,7 @@ class AlertRenderer(Widget):
       return None
 
     # Return current alert
-    return Alert(text1=ss.alertText1, text2=ss.alertText2, size=ss.alertSize, status=ss.alertStatus)
+    return Alert(text1=ss.alertText1, text2=ss.alertText2, size=ss.alertSize.raw, status=ss.alertStatus.raw)
 
   def _render(self, rect: rl.Rectangle) -> bool:
     alert = self.get_alert(ui_state.sm)

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -9,6 +9,9 @@ from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.widget import Widget
 from openpilot.selfdrive.ui.ui_state import ui_state
 
+AlertSize = log.SelfdriveState.AlertSize
+AlertStatus = log.SelfdriveState.AlertStatus
+
 ALERT_MARGIN = 40
 ALERT_PADDING = 60
 ALERT_LINE_SPACING = 45
@@ -23,9 +26,9 @@ SELFDRIVE_UNRESPONSIVE_TIMEOUT = 10  # Seconds
 
 # Constants
 ALERT_COLORS = {
-  log.SelfdriveState.AlertStatus.normal: rl.Color(0, 0, 0, 235),  # Black
-  log.SelfdriveState.AlertStatus.userPrompt: rl.Color(0xFE, 0x8C, 0x34, 235),  # Orange
-  log.SelfdriveState.AlertStatus.critical: rl.Color(0xC9, 0x22, 0x31, 235),  # Red
+  AlertStatus.normal: rl.Color(0, 0, 0, 235),  # Black
+  AlertStatus.userPrompt: rl.Color(0xFE, 0x8C, 0x34, 235),  # Orange
+  AlertStatus.critical: rl.Color(0xC9, 0x22, 0x31, 235),  # Red
 }
 
 
@@ -41,22 +44,22 @@ class Alert:
 ALERT_STARTUP_PENDING = Alert(
   text1="openpilot Unavailable",
   text2="Waiting to start",
-  size=log.SelfdriveState.AlertSize.mid,
-  status=log.SelfdriveState.AlertStatus.normal,
+  size=AlertSize.mid,
+  status=AlertStatus.normal,
 )
 
 ALERT_CRITICAL_TIMEOUT = Alert(
   text1="TAKE CONTROL IMMEDIATELY",
   text2="System Unresponsive",
-  size=log.SelfdriveState.AlertSize.full,
-  status=log.SelfdriveState.AlertStatus.critical,
+  size=AlertSize.full,
+  status=AlertStatus.critical,
 )
 
 ALERT_CRITICAL_REBOOT = Alert(
   text1="System Unresponsive",
   text2="Reboot Device",
-  size=log.SelfdriveState.AlertSize.full,
-  status=log.SelfdriveState.AlertStatus.critical,
+  size=AlertSize.full,
+  status=AlertStatus.critical,
 )
 
 
@@ -113,10 +116,10 @@ class AlertRenderer(Widget):
     return True
 
   def _get_alert_rect(self, rect: rl.Rectangle, size: int) -> rl.Rectangle:
-    if size == log.SelfdriveState.AlertSize.full:
+    if size == AlertSize.full:
       return rect
 
-    height = (ALERT_FONT_MEDIUM + 2 * ALERT_PADDING if size == log.SelfdriveState.AlertSize.small else
+    height = (ALERT_FONT_MEDIUM + 2 * ALERT_PADDING if size == AlertSize.small else
               ALERT_FONT_BIG + ALERT_LINE_SPACING + ALERT_FONT_SMALL + 2 * ALERT_PADDING)
 
     return rl.Rectangle(
@@ -127,19 +130,19 @@ class AlertRenderer(Widget):
     )
 
   def _draw_background(self, rect: rl.Rectangle, alert: Alert) -> None:
-    color = ALERT_COLORS.get(alert.status, ALERT_COLORS[log.SelfdriveState.AlertStatus.normal])
+    color = ALERT_COLORS.get(alert.status, ALERT_COLORS[AlertStatus.normal])
 
-    if alert.size != log.SelfdriveState.AlertSize.full:
+    if alert.size != AlertSize.full:
       roundness = ALERT_BORDER_RADIUS / (min(rect.width, rect.height) / 2)
       rl.draw_rectangle_rounded(rect, roundness, 10, color)
     else:
       rl.draw_rectangle_rec(rect, color)
 
   def _draw_text(self, rect: rl.Rectangle, alert: Alert) -> None:
-    if alert.size == log.SelfdriveState.AlertSize.small:
+    if alert.size == AlertSize.small:
       self._draw_centered(alert.text1, rect, self.font_bold, ALERT_FONT_MEDIUM)
 
-    elif alert.size == log.SelfdriveState.AlertSize.mid:
+    elif alert.size == AlertSize.mid:
       self._draw_centered(alert.text1, rect, self.font_bold, ALERT_FONT_BIG, center_y=False)
       rect.y += ALERT_FONT_BIG + ALERT_LINE_SPACING
       self._draw_centered(alert.text2, rect, self.font_regular, ALERT_FONT_SMALL, center_y=False)


### PR DESCRIPTION
The raylib alert renderer wasn't correctly parsing the capnp enum value for the alert size and status, which was leading causing it to always display `userPrompt` or `critical` status banners as `normal` (the fallback).

Fixed by appending `.raw` to the property. Also imported `AlertStatus` and `AlertSize` as vars for clarity.

### Before:
<img width="1043" height="498" alt="alert-warning-color-raylib-old" src="https://github.com/user-attachments/assets/677ec5c5-cc04-4a60-8549-4b520f7c94c9" />

### After:
<img width="1051" height="507" alt="alert-warning-color-raylib-new" src="https://github.com/user-attachments/assets/3b07c760-b5ce-445e-b179-9c03ddaf8320" />

