### PR TITLE
cabana: Fix slider visual inconsistency by adjusting groove height

### DIFF
--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -261,14 +261,23 @@ void Slider::paintEvent(QPaintEvent *ev) {
 
   QStyleOptionSlider opt;
   initStyleOption(&opt);
-  QRect r = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderGroove, this);
-  p.fillRect(r, timeline_colors[(int)TimelineType::None]);
+  QRect handle_rect = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+  QRect groove_rect = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderGroove, this);
+
+  // Adjust groove height to match handle height
+  int handle_height = handle_rect.height();
+  groove_rect.setHeight(handle_height * 0.5);
+  groove_rect.moveCenter(QPoint(groove_rect.center().x(), rect().center().y()));
+
+  p.fillRect(groove_rect, timeline_colors[(int)TimelineType::None]);
 
   double min = minimum() / factor;
   double max = maximum() / factor;
 
   auto fillRange = [&](double begin, double end, const QColor &color) {
     if (begin > max || end < min) return;
+
+    QRect r = groove_rect;
     r.setLeft(((std::max(min, begin) - min) / (max - min)) * width());
     r.setRight(((std::min(max, end) - min) / (max - min)) * width());
     p.fillRect(r, color);


### PR DESCRIPTION
On some platforms, the custom slider handle appears much smaller than the groove, causing a visual imbalance:
<img width="90" height="63" alt="Screenshot from 2025-07-11 12-59-05" src="https://github.com/user-attachments/assets/71fd02a4-d32e-49d6-b32c-3ac26dbc890b" />


This PR adjusts the groove height to better match the handle size, improving visual consistency while keeping a native look across platforms.