### PR TITLE
cabana: fix dark theme detection to work with system theme

### DIFF
--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -45,7 +45,7 @@ ChartView::ChartView(const std::pair<double, double> &x_range, ChartsWidget *par
   createToolButtons();
   setRubberBand(QChartView::HorizontalRubberBand);
   setMouseTracking(true);
-  setTheme(settings.theme == DARK_THEME ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight);
+  setTheme(utils::isDarkTheme() ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight);
   signal_value_font.setPointSize(9);
 
   QObject::connect(axis_y, &QValueAxis::rangeChanged, this, &ChartView::resetChartCache);
@@ -747,7 +747,7 @@ void ChartView::drawTimeline(QPainter *painter) {
   QRectF time_str_rect(QPointF(x - time_str_size.width() / 2.0, plot_area.bottom() + AXIS_X_TOP_MARGIN), time_str_size);
   QPainterPath path;
   path.addRoundedRect(time_str_rect, 3, 3);
-  painter->fillPath(path, settings.theme == DARK_THEME ? Qt::darkGray : Qt::gray);
+  painter->fillPath(path, utils::isDarkTheme() ? Qt::darkGray : Qt::gray);
   painter->setPen(palette().color(QPalette::BrightText));
   painter->setFont(axis_x->labelsFont());
   painter->drawText(time_str_rect, Qt::AlignCenter, time_str);

--- a/tools/cabana/chart/chartswidget.cc
+++ b/tools/cabana/chart/chartswidget.cc
@@ -254,7 +254,7 @@ void ChartsWidget::settingChanged() {
   if (std::exchange(current_theme, settings.theme) != current_theme) {
     undo_zoom_action->setIcon(utils::icon("arrow-counterclockwise"));
     redo_zoom_action->setIcon(utils::icon("arrow-clockwise"));
-    auto theme = settings.theme == DARK_THEME ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight;
+    auto theme = utils::isDarkTheme() ? QChart::QChart::ChartThemeDark : QChart::ChartThemeLight;
     for (auto c : charts) {
       c->setTheme(theme);
     }

--- a/tools/cabana/chart/tiplabel.cc
+++ b/tools/cabana/chart/tiplabel.cc
@@ -7,6 +7,7 @@
 #include <QToolTip>
 
 #include "tools/cabana/settings.h"
+#include "tools/cabana/utils/util.h"
 
 TipLabel::TipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::FramelessWindowHint) {
   setAttribute(Qt::WA_ShowWithoutActivating);
@@ -19,7 +20,7 @@ TipLabel::TipLabel(QWidget *parent) : QLabel(parent, Qt::ToolTip | Qt::Frameless
   font.setPointSizeF(8.34563465);
   setFont(font);
   auto palette = QToolTip::palette();
-  if (settings.theme != DARK_THEME) {
+  if (!utils::isDarkTheme()) {
     palette.setColor(QPalette::ToolTipBase, QApplication::palette().color(QPalette::Base));
     palette.setColor(QPalette::ToolTipText, QRgb(0x404044));  // same color as chart label brush
   }

--- a/tools/cabana/historylog.cc
+++ b/tools/cabana/historylog.cc
@@ -153,7 +153,7 @@ void HeaderView::paintSection(QPainter *painter, const QRect &rect, int logicalI
     painter->fillRect(rect, bg_role.value<QBrush>());
   }
   QString text = model()->headerData(logicalIndex, Qt::Horizontal, Qt::DisplayRole).toString();
-  painter->setPen(palette().color(settings.theme == DARK_THEME ? QPalette::BrightText : QPalette::Text));
+  painter->setPen(palette().color(utils::isDarkTheme() ? QPalette::BrightText : QPalette::Text));
   painter->drawText(rect.adjusted(5, 3, -5, -3), defaultAlignment(), text.replace(QChar('_'), ' '));
 }
 

--- a/tools/cabana/utils/util.cc
+++ b/tools/cabana/utils/util.cc
@@ -191,8 +191,15 @@ DoubleValidator::DoubleValidator(QObject *parent) : QDoubleValidator(parent) {
 }
 
 namespace utils {
+
+bool isDarkTheme() {
+  QColor windowColor = QApplication::palette().color(QPalette::Window);
+  return windowColor.lightness() < 128;
+}
+
 QPixmap icon(const QString &id) {
-  bool dark_theme = settings.theme == DARK_THEME;
+  bool dark_theme = isDarkTheme();
+
   QPixmap pm;
   QString key = "bootstrap_" % id % (dark_theme ? "1" : "0");
   if (!QPixmapCache::find(key, &pm)) {

--- a/tools/cabana/utils/util.h
+++ b/tools/cabana/utils/util.h
@@ -98,7 +98,9 @@ public:
 };
 
 namespace utils {
+
 QPixmap icon(const QString &id);
+bool isDarkTheme();
 void setTheme(int theme);
 QString formatSeconds(double sec, bool include_milliseconds = false, bool absolute_time = false);
 inline void drawStaticText(QPainter *p, const QRect &r, const QStaticText &text) {


### PR DESCRIPTION
This PR improves dark theme detection by checking if the window background lightness is below 128. It ensures icons, charts display correctly when the system uses a dark theme.
 
###  before:
 <img width="455" height="373" alt="Screenshot 2025-07-11 14:09:51" src="https://github.com/user-attachments/assets/b96f5541-9aaa-4f7f-bd5f-727c7ecc7e4a" />

###  after:

 <img width="455" height="373" alt="Screenshot 2025-07-11 14:08:59" src="https://github.com/user-attachments/assets/6258660a-05f8-4f81-a846-3dfa82876fd4" />
