### PR TITLE
Update fingerprints.py Tucson EUR 2022 Hybrid

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc_repo/opendbc/car/hyundai/fingerprints.py
@@ -1073,6 +1073,7 @@ FW_VERSIONS = {
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9260 14Y',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9100 14A',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9240 14T',
+      b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 1.00 99211-N9240 14Q',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NX4__               1.00 1.00 99110-N9100         ',


### PR DESCRIPTION
don't detect BSM

<!-- Please copy and paste the relevant template -->
CarParams:
{'carParams': {'alphaLongitudinalAvailable': False,
               'alternativeExperience': 0,
               'autoResumeSng': True,
               'brand': 'mock',
               'carFingerprint': 'MOCK',
               'carFw': [{'address': 1990,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'combinationMeter',
                          'fwVersion': b'\xf1\x00064',
                          'logging': True,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1998,
                          'subAddress': 0},
                         {'address': 1975,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'cornerRadar',
                          'fwVersion': b'\xf1\x003D',
                          'logging': True,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1983,
                          'subAddress': 0},
                         {'address': 2000,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'fwdRadar',
                          'fwVersion': b'\xf1\x00NX4__               1.01 1.02 99110-N9000         ',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 2008,
                          'subAddress': 0},
                         {'address': 1988,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'fwdCamera',
                          'fwVersion': b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 1.00 99211-N9240 14Q',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1996,
                          'subAddress': 0},
                         {'address': 1971,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'hvac',
                          'fwVersion': b"\xf1\x00NX4e  97255-CZ021CONTROL ASS'Y-HEV   1.04 NX4e HEV DATC(-)0.7 ",
                          'logging': True,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1979,
                          'subAddress': 0},
                         {'address': 2000,
                          'brand': 'hyundai',
                          'bus': 1,
                          'ecu': 'fwdRadar',
                          'fwVersion': b'\xf1\x00NX4__               1.01 1.02 99110-N9000         ',
                          'logging': False,
                          'obdMultiplexing': False,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 2008,
                          'subAddress': 0},
                         {'address': 2000,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'fwdRadar',
                          'fwVersion': b'\xf1\x8b "\x08%',
                          'logging': True,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x8b'],
                          'responseAddress': 2008,
                          'subAddress': 0},
                         {'address': 1990,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'combinationMeter',
                          'fwVersion': b'\xf1\x8b "\x08\'',
                          'logging': True,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x8b'],
                          'responseAddress': 1998,
                          'subAddress': 0},
                         {'address': 1988,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'fwdCamera',
                          'fwVersion': b'\xf1\x8b "\x10%',
                          'logging': True,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x8b'],
                          'responseAddress': 1996,
                          'subAddress': 0},
                         {'address': 1975,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'cornerRadar',
                          'fwVersion': b'\xf1\x8b "\x08\x08',
                          'logging': True,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x8b'],
                          'responseAddress': 1983,
                          'subAddress': 0}],
               'carVin': 'TMAJD811BNJ153832',
               'centerToFront': 1.350000023841858,
               'communityFeatureDEPRECATED': False,
               'dashcamOnly': True,
               'directAccelControlDEPRECATED': False,
               'enableApgsDEPRECATED': False,
               'enableBsm': False,
               'enableCameraDEPRECATED': False,
               'enableDsu': False,
               'enableGasInterceptorDEPRECATED': False,
               'fingerprintSource': 'can',
               'flags': 0,
               'fuzzyFingerprint': False,
               'hasStockCameraDEPRECATED': False,
               'isPandaBlackDEPRECATED': False,
               'lateralTuning': {'pid': {'kf': 0.0}},
               'longitudinalActuatorDelay': 0.15000000596046448,
               'longitudinalActuatorDelayLowerBoundDEPRECATED': 0.0,
               'longitudinalTuning': {'kf': 1.0, 'kiBP': [0.0], 'kiV': [0.0], 'kpBP': [0.0], 'kpV': [0.0]},
               'mass': 1836.0,
               'maxLateralAccel': 10.0,
               'maxSteeringAngleDegDEPRECATED': 0.0,
               'minEnableSpeed': -1.0,
               'minSpeedCanDEPRECATED': 0.0,
               'minSteerSpeed': 0.0,
               'networkLocation': 'fwdCamera',
               'notCar': False,
               'openpilotLongitudinalControl': False,
               'passive': True,
               'pcmCruise': True,
               'radarDelay': 0.0,
               'radarTimeStepDEPRECATED': 0.05000000074505806,
               'radarUnavailable': False,
               'rotationalInertia': 3139.534912109375,
               'safetyConfigs': [{'safetyModel': 'noOutput', 'safetyParam': 0, 'safetyParam2DEPRECATED': 0, 'safetyParamDEPRECATED': 0}],
               'safetyModelDEPRECATED': 'silent',
               'safetyModelPassiveDEPRECATED': 'silent',
               'safetyParamDEPRECATED': 0,
               'secOcKeyAvailable': False,
               'secOcRequired': False,
               'startAccel': 0.0,
               'startingAccelRateDEPRECATED': 0.0,
               'startingState': False,
               'steerActuatorDelay': 0.0,
               'steerAtStandstill': False,
               'steerControlType': 'torque',
               'steerLimitAlert': False,
               'steerLimitTimer': 1.0,
               'steerRateCostDEPRECATED': 0.0,
               'steerRatio': 13.0,
               'steerRatioRear': 0.0,
               'stopAccel': -2.0,
               'stoppingControlDEPRECATED': False,
               'stoppingDecelRate': 0.800000011920929,
               'tireStiffnessFactor': 1.0,
               'tireStiffnessFront': 201087.203125,
               'tireStiffnessRear': 317877.90625,
               'transmissionType': 'unknown',
               'vEgoStarting': 0.5,
               'vEgoStopping': 0.5,
               'wheelSpeedFactor': 1.0,
               'wheelbase': 2.700000047683716},
 'logMonoTime': 81407601530,
 'valid': True}

**Car**
Which car (make, model, year) this fingerprint is for
Hyunday Tucson 2022 Hybrid Europe with BSM

<!--- ***** Template: Car Bugfix *****

Don't recognize de car

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]

b25afc8f8295c6b3/00000000--36e0ce6484

-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

