### PR TITLE
Toyota: allow sport gear

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -78,6 +78,7 @@ class CarSpecificEvents:
         events.add(EventName.manualRestart)
 
     elif self.CP.brand == 'toyota':
+      # TODO: when we check for unexpected disengagement, check gear not S1, S2, S3
       events = self.create_common_events(CS, CS_prev, extra_gears=[GearShifter.sport])
 
       if self.CP.openpilotLongitudinalControl:

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -78,7 +78,7 @@ class CarSpecificEvents:
         events.add(EventName.manualRestart)
 
     elif self.CP.brand == 'toyota':
-      events = self.create_common_events(CS, CS_prev)
+      events = self.create_common_events(CS, CS_prev, extra_gears=[GearShifter.sport])
 
       if self.CP.openpilotLongitudinalControl:
         if CS.cruiseState.standstill and not CS.brakePressed:
@@ -120,7 +120,7 @@ class CarSpecificEvents:
       #   events.add(EventName.steerTimeLimit)
 
     elif self.CP.brand == 'hyundai':
-      events = self.create_common_events(CS, CS_prev, extra_gears=(GearShifter.sport, GearShifter.manumatic),
+      events = self.create_common_events(CS, CS_prev, extra_gears=[GearShifter.sport, GearShifter.manumatic],
                                          pcm_enable=self.CP.pcmCruise, allow_button_cancel=False)
 
     else:

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -120,7 +120,7 @@ class CarSpecificEvents:
       #   events.add(EventName.steerTimeLimit)
 
     elif self.CP.brand == 'hyundai':
-      events = self.create_common_events(CS, CS_prev, extra_gears=[GearShifter.sport, GearShifter.manumatic],
+      events = self.create_common_events(CS, CS_prev, extra_gears=(GearShifter.sport, GearShifter.manumatic),
                                          pcm_enable=self.CP.pcmCruise, allow_button_cancel=False)
 
     else:


### PR DESCRIPTION
I engaged the other day in sport gear and didn't realize openpilot blocked engagement for a second, so I very minorly drifted in the lane. Don't see a reason to block this

Stock long works down to 4th gear. 1, 2, 3 block engage and disengage (handled by PCM, so it's free)

https://connect.comma.ai/f74abd5c7081c9b6/0000004e--61e61085d3