### PR TITLE
ui: flip driver camera horizontally

### DIFF
--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -179,6 +179,9 @@ class CameraView(Widget):
 
     transform = self._calc_frame_matrix(rect)
     src_rect = rl.Rectangle(0, 0, float(self.frame.width), float(self.frame.height))
+    # Flip driver camera horizontally
+    if self._stream_type == VisionStreamType.VISION_STREAM_DRIVER:
+      src_rect.width = -src_rect.width
 
     # Calculate scale
     scale_x = rect.width * transform[0, 0]  # zx


### PR DESCRIPTION
Mirrors the driver camera, consistent with the Qt Cameraview implementation.