### PR TITLE
loggerd: fix audio truncation by processing remaining partial frames

### DIFF
--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -21,6 +21,7 @@ public:
 private:
   void initialize_audio(int sample_rate);
   void encode_and_write_audio_frame(AVFrame* frame);
+  void process_remaining_audio();
 
   std::string vid_path, lock_path;
   FILE *of = nullptr;


### PR DESCRIPTION
Fixes an audio truncation issue in the `VideoWriter` where the last portion of audio data could be lost if it didn't form a complete frame. Previously, any audio samples remaining in the buffer that were fewer than `audio_codec_ctx->frame_size` would be discarded during cleanup, resulting in truncated audio in the output file.