### PR TITLE
fix: decode only video packets in framereader

### DIFF
--- a/tools/replay/framereader.h
+++ b/tools/replay/framereader.h
@@ -29,6 +29,7 @@ public:
   VideoDecoder *decoder_ = nullptr;
   AVFormatContext *input_ctx = nullptr;
   int prev_idx = -1;
+  int video_stream_index = -1;
   struct PacketInfo {
     int flags;
     int64_t pos;


### PR DESCRIPTION
With the addition of audio in qcamera.ts, framereader.cc attempts to decode audio packets as video packets, leading to errors in cabana and replay when playing qcam videos. fixes https://github.com/commaai/openpilot/issues/35711

The changes here ignore the audio stream so that behavior remains the same as before the addition of an audio stream. 