### PR TITLE
tools: fix log suffix for commaCarSegments v2

### DIFF
--- a/tools/lib/comma_car_segments.py
+++ b/tools/lib/comma_car_segments.py
@@ -86,5 +86,5 @@ def get_repo_url(path):
     return get_repo_raw_url(path)
 
 
-def get_url(route, segment, file="rlog.bz2"):
+def get_url(route, segment, file="rlog.zst"):
   return get_repo_url(f"segments/{route.replace('|', '/')}/{segment}/{file}")


### PR DESCRIPTION
Partially reapply #35660: v2 was promoted to the main branch, but we still need the bz2 to zst change.