### PR TITLE
refactor(raylib): Fix and standardize rounded corners

### DIFF
--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -9,6 +9,7 @@ from openpilot.selfdrive.ui.layouts.settings.firehose import FirehoseLayout
 from openpilot.selfdrive.ui.layouts.settings.software import SoftwareLayout
 from openpilot.selfdrive.ui.layouts.settings.toggles import TogglesLayout
 from openpilot.system.ui.lib.application import gui_app, FontWeight, MousePos
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.widgets import Widget
 
@@ -21,6 +22,7 @@ SIDEBAR_WIDTH = 500
 CLOSE_BTN_SIZE = 200
 NAV_BTN_HEIGHT = 110
 PANEL_MARGIN = 50
+PANEL_BORDER_RADIUS = 20
 
 # Colors
 SIDEBAR_COLOR = rl.BLACK
@@ -43,7 +45,7 @@ class PanelType(IntEnum):
 @dataclass
 class PanelInfo:
   name: str
-  instance: object
+  instance: Widget
   button_rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
 
 
@@ -123,11 +125,9 @@ class SettingsLayout(Widget):
       y += NAV_BTN_HEIGHT
 
   def _draw_current_panel(self, rect: rl.Rectangle):
-    rl.draw_rectangle_rounded(
-      rl.Rectangle(rect.x + 10, rect.y + 10, rect.width - 20, rect.height - 20), 0.04, 30, PANEL_COLOR
-    )
+    panel_rect = rl.Rectangle(rect.x + 10, rect.y + 10, rect.width - 20, rect.height - 20)
+    rl.draw_rectangle_rounded(panel_rect, get_roundness(panel_rect, PANEL_BORDER_RADIUS), 30, PANEL_COLOR)
     content_rect = rl.Rectangle(rect.x + PANEL_MARGIN, rect.y + 25, rect.width - (PANEL_MARGIN * 2), rect.height - 50)
-    # rl.draw_rectangle_rounded(content_rect, 0.03, 30, PANEL_COLOR)
     panel = self._panels[self._current_panel]
     if panel.instance:
       panel.instance.render(content_rect)

--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from cereal import log
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app, FontWeight, MousePos
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.widgets import Widget
 
@@ -12,6 +13,7 @@ SIDEBAR_WIDTH = 300
 METRIC_HEIGHT = 126
 METRIC_WIDTH = 240
 METRIC_MARGIN = 30
+METRIC_BORDER_RADIUS = 20
 
 SETTINGS_BTN = rl.Rectangle(50, 35, 200, 117)
 HOME_BTN = rl.Rectangle(60, 860, 180, 180)
@@ -188,11 +190,11 @@ class Sidebar(Widget):
     # Draw colored left edge (clipped rounded rectangle)
     edge_rect = rl.Rectangle(metric_rect.x + 4, metric_rect.y + 4, 100, 118)
     rl.begin_scissor_mode(int(metric_rect.x + 4), int(metric_rect.y), 18, int(metric_rect.height))
-    rl.draw_rectangle_rounded(edge_rect, 0.18, 10, metric.color)
+    rl.draw_rectangle_rounded(edge_rect, get_roundness(edge_rect, METRIC_BORDER_RADIUS), 10, metric.color)
     rl.end_scissor_mode()
 
     # Draw border
-    rl.draw_rectangle_rounded_lines_ex(metric_rect, 0.15, 10, 2, Colors.METRIC_BORDER)
+    rl.draw_rectangle_rounded_lines_ex(metric_rect, get_roundness(metric_rect, METRIC_BORDER_RADIUS), 10, 2, Colors.METRIC_BORDER)
 
     # Draw text
     text = f"{metric.label}\n{metric.value}"

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -5,6 +5,7 @@ from cereal import messaging, log
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.hardware import TICI
 from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_FPS
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.label import gui_text_box
@@ -133,8 +134,7 @@ class AlertRenderer(Widget):
     color = ALERT_COLORS.get(alert.status, ALERT_COLORS[AlertStatus.normal])
 
     if alert.size != AlertSize.full:
-      roundness = ALERT_BORDER_RADIUS / (min(rect.width, rect.height) / 2)
-      rl.draw_rectangle_rounded(rect, roundness, 10, color)
+      rl.draw_rectangle_rounded(rect, get_roundness(rect, ALERT_BORDER_RADIUS), 10, color)
     else:
       rl.draw_rectangle_rec(rect, color)
 

--- a/selfdrive/ui/onroad/hud_renderer.py
+++ b/selfdrive/ui/onroad/hud_renderer.py
@@ -4,6 +4,7 @@ from openpilot.common.conversions import Conversions as CV
 from openpilot.selfdrive.ui.onroad.exp_button import ExpButton
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
 from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.widgets import Widget
 
@@ -21,6 +22,7 @@ class UIConfig:
   set_speed_width_metric: int = 200
   set_speed_width_imperial: int = 172
   set_speed_height: int = 204
+  set_speed_border_radius: int = 20
   wheel_icon_size: int = 144
 
 
@@ -130,8 +132,9 @@ class HudRenderer(Widget):
     y = rect.y + 45
 
     set_speed_rect = rl.Rectangle(x, y, set_speed_width, UI_CONFIG.set_speed_height)
-    rl.draw_rectangle_rounded(set_speed_rect, 0.2, 30, COLORS.black_translucent)
-    rl.draw_rectangle_rounded_lines_ex(set_speed_rect, 0.2, 30, 6, COLORS.border_translucent)
+    set_speed_roundness = get_roundness(set_speed_rect, UI_CONFIG.set_speed_border_radius)
+    rl.draw_rectangle_rounded(set_speed_rect, set_speed_roundness, 30, COLORS.black_translucent)
+    rl.draw_rectangle_rounded_lines_ex(set_speed_rect, set_speed_roundness, 30, 6, COLORS.border_translucent)
 
     max_color = COLORS.grey
     set_speed_color = COLORS.dark_grey

--- a/selfdrive/ui/widgets/pairing_dialog.py
+++ b/selfdrive/ui/widgets/pairing_dialog.py
@@ -7,8 +7,9 @@ from openpilot.common.api import Api
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.params import Params
 from openpilot.system.ui.lib.application import FontWeight, gui_app
-from openpilot.system.ui.lib.wrap_text import wrap_text
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.lib.wrap_text import wrap_text
 
 
 class PairingDialog:
@@ -142,8 +143,8 @@ class PairingDialog:
       y += text_height + 50
 
   def _render_qr_code(self, rect: rl.Rectangle) -> None:
-    if not self.qr_texture:
-      rl.draw_rectangle_rounded(rect, 0.1, 20, rl.Color(240, 240, 240, 255))
+    if self.qr_texture:
+      rl.draw_rectangle_rounded(rect, get_roundness(rect, 30), 20, rl.Color(240, 240, 240, 255))
       error_font = gui_app.font(FontWeight.BOLD)
       rl.draw_text_ex(
         error_font, "QR Code Error", rl.Vector2(rect.x + 20, rect.y + rect.height // 2 - 15), 30, 0.0, rl.RED

--- a/selfdrive/ui/widgets/pairing_dialog.py
+++ b/selfdrive/ui/widgets/pairing_dialog.py
@@ -143,7 +143,7 @@ class PairingDialog:
       y += text_height + 50
 
   def _render_qr_code(self, rect: rl.Rectangle) -> None:
-    if self.qr_texture:
+    if not self.qr_texture:
       rl.draw_rectangle_rounded(rect, get_roundness(rect, 30), 20, rl.Color(240, 240, 240, 255))
       error_font = gui_app.font(FontWeight.BOLD)
       rl.draw_text_ex(

--- a/selfdrive/ui/widgets/prime.py
+++ b/selfdrive/ui/widgets/prime.py
@@ -2,10 +2,13 @@ import pyray as rl
 
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.wrap_text import wrap_text
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.label import gui_label
+
+BORDER_RADIUS = 10
 
 
 class PrimeWidget(Widget):
@@ -22,7 +25,7 @@ class PrimeWidget(Widget):
   def _render_for_non_prime_users(self, rect: rl.Rectangle):
     """Renders the advertisement for non-Prime users."""
 
-    rl.draw_rectangle_rounded(rect, 0.02, 10, self.PRIME_BG_COLOR)
+    rl.draw_rectangle_rounded(rect, get_roundness(rect, BORDER_RADIUS), 10, self.PRIME_BG_COLOR)
 
     # Layout
     x, y = rect.x + 80, rect.y + 90
@@ -52,7 +55,8 @@ class PrimeWidget(Widget):
   def _render_for_prime_user(self, rect: rl.Rectangle):
     """Renders the prime user widget with subscription status."""
 
-    rl.draw_rectangle_rounded(rl.Rectangle(rect.x, rect.y, rect.width, 230), 0.02, 10, self.PRIME_BG_COLOR)
+    panel_rect = rl.Rectangle(rect.x, rect.y, rect.width, 230)
+    rl.draw_rectangle_rounded(panel_rect, get_roundness(panel_rect, BORDER_RADIUS), 10, self.PRIME_BG_COLOR)
 
     x = rect.x + 56
     y = rect.y + 40

--- a/selfdrive/ui/widgets/setup.py
+++ b/selfdrive/ui/widgets/setup.py
@@ -3,9 +3,13 @@ from openpilot.selfdrive.ui.lib.prime_state import PrimeType
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog
 from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.wrap_text import wrap_text
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.button import gui_button, ButtonStyle
+
+BORDER_RADIUS = 10
+PANEL_COLOR = rl.Color(51, 51, 51, 255)
 
 
 class SetupWidget(Widget):
@@ -26,7 +30,8 @@ class SetupWidget(Widget):
   def _render_registration(self, rect: rl.Rectangle):
     """Render registration prompt."""
 
-    rl.draw_rectangle_rounded(rl.Rectangle(rect.x, rect.y, rect.width, 590), 0.02, 20, rl.Color(51, 51, 51, 255))
+    panel_rect = rl.Rectangle(rect.x, rect.y, rect.width, 590)
+    rl.draw_rectangle_rounded(panel_rect, get_roundness(panel_rect, BORDER_RADIUS), 20, PANEL_COLOR)
 
     x = rect.x + 64
     y = rect.y + 48
@@ -52,7 +57,8 @@ class SetupWidget(Widget):
   def _render_firehose_prompt(self, rect: rl.Rectangle):
     """Render firehose prompt widget."""
 
-    rl.draw_rectangle_rounded(rl.Rectangle(rect.x, rect.y, rect.width, 450), 0.02, 20, rl.Color(51, 51, 51, 255))
+    panel_rect = rl.Rectangle(rect.x, rect.y, rect.width, 450)
+    rl.draw_rectangle_rounded(panel_rect, get_roundness(panel_rect, BORDER_RADIUS), 20, PANEL_COLOR)
 
     # Content margins (56, 40, 56, 40)
     x = rect.x + 56

--- a/system/ui/lib/rounded_corners.py
+++ b/system/ui/lib/rounded_corners.py
@@ -1,7 +1,5 @@
 import pyray as rl
 
-DEFAULT_BORDER_RADIUS = 10
-
 
 def get_roundness(rect: rl.Rectangle, border_radius: int) -> float:
   """Calculate the roundness of a rectangle based on its width and height, given a border radius value in pixels.

--- a/system/ui/lib/rounded_corners.py
+++ b/system/ui/lib/rounded_corners.py
@@ -1,0 +1,10 @@
+import pyray as rl
+
+DEFAULT_BORDER_RADIUS = 10
+
+
+def get_roundness(rect: rl.Rectangle, border_radius: int) -> float:
+  """Calculate the roundness of a rectangle based on its width and height, given a border radius value in pixels.
+  This is used to standardize the roundness across rectangle with different sizes, since `draw_rectangle_rounded` doesn't use pixels.
+  """
+  return border_radius / (min(rect.width, rect.height) / 2)

--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -10,6 +10,7 @@ import pyray as rl
 from cereal import log
 from openpilot.system.hardware import HARDWARE
 from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.button import gui_button, ButtonStyle
 from openpilot.system.ui.widgets.keyboard import Keyboard
@@ -150,7 +151,7 @@ class Setup(Widget):
 
     wifi_rect = rl.Rectangle(rect.x + MARGIN, rect.y + TITLE_FONT_SIZE + MARGIN + 25, rect.width - MARGIN * 2,
                              rect.height - TITLE_FONT_SIZE - 25 - BUTTON_HEIGHT - MARGIN * 3)
-    rl.draw_rectangle_rounded(wifi_rect, 0.05, 10, rl.Color(51, 51, 51, 255))
+    rl.draw_rectangle_rounded(wifi_rect, get_roundness(wifi_rect, 15), 10, rl.Color(51, 51, 51, 255))
     wifi_content_rect = rl.Rectangle(wifi_rect.x + MARGIN, wifi_rect.y, wifi_rect.width - MARGIN * 2, wifi_rect.height)
     self.wifi_ui.render(wifi_content_rect)
 

--- a/system/ui/widgets/button.py
+++ b/system/ui/widgets/button.py
@@ -1,6 +1,7 @@
 import pyray as rl
 from enum import IntEnum
 from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 
 
@@ -102,7 +103,7 @@ def gui_button(
     _pressed_buttons.remove(button_id)
 
   # Draw the button with rounded corners
-  roundness = border_radius / (min(rect.width, rect.height) / 2)
+  roundness = get_roundness(rect, border_radius)
   if button_style != ButtonStyle.TRANSPARENT:
     rl.draw_rectangle_rounded(rect, roundness, 20, bg_color)
   else:

--- a/system/ui/widgets/option_dialog.py
+++ b/system/ui/widgets/option_dialog.py
@@ -1,5 +1,6 @@
 import pyray as rl
 from openpilot.system.ui.lib.application import FontWeight
+from openpilot.system.ui.lib.rounded_corners import get_roundness
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.button import gui_button, ButtonStyle, TextAlignment
@@ -7,6 +8,8 @@ from openpilot.system.ui.widgets.label import gui_label
 
 # Constants
 MARGIN = 50
+PANEL_COLOR = rl.Color(30, 30, 30, 255)
+PANEL_BORDER_RADIUS = 10
 TITLE_FONT_SIZE = 70
 ITEM_HEIGHT = 135
 BUTTON_SPACING = 50
@@ -26,7 +29,7 @@ class MultiOptionDialog(Widget):
 
   def _render(self, rect):
     dialog_rect = rl.Rectangle(rect.x + MARGIN, rect.y + MARGIN, rect.width - 2 * MARGIN, rect.height - 2 * MARGIN)
-    rl.draw_rectangle_rounded(dialog_rect, 0.02, 20, rl.Color(30, 30, 30, 255))
+    rl.draw_rectangle_rounded(dialog_rect, get_roundness(dialog_rect, PANEL_BORDER_RADIUS), 10, PANEL_COLOR)
 
     content_rect = rl.Rectangle(dialog_rect.x + MARGIN, dialog_rect.y + MARGIN,
                                 dialog_rect.width - 2 * MARGIN, dialog_rect.height - 2 * MARGIN)


### PR DESCRIPTION
Implement a `get_roundness` function that takes a rect and a `border_radius` (pixels) amount and returns the roundness value for raylib.

This allows us to use the same border radius for different-sized panels without having to guess the roundness value. This mainly fixes the inconsistent panel roundness on the home page. I also increased the metrics rounding to match the old UI.

**TODO:** The experimental mode button also needs rounded, but I will do that in a separate PR once this is merged.

### Home panels and metrics (before):
<img width="1080" height="536" alt="rounded-corners-raylib-old" src="https://github.com/user-attachments/assets/ca276c26-2dc1-4d90-abba-1063351c029b" />

### Home panels and metrics (after):
<img width="1079" height="537" alt="rounded-corners-raylib-new" src="https://github.com/user-attachments/assets/30c6ba98-1075-4fef-8e8f-a95849419caa" />

### Set speed (before):
<img width="123" height="135" alt="set-speed-raylib-old" src="https://github.com/user-attachments/assets/cc943482-f4aa-47a5-af53-24d0d1778a04" />

### Set speed (after):
<img width="125" height="131" alt="set-speed-raylib-new" src="https://github.com/user-attachments/assets/f5c63e9e-d364-4d3d-8d93-cd3b2e9300ed" />

### The ones below don't have much or any difference:

### Settings panel (before):
<img width="1079" height="539" alt="settings-panel-raylib-old" src="https://github.com/user-attachments/assets/eac38b77-eeef-4a1e-b186-a9c5f3ab4521" />

### Settings panel (after):
<img width="1076" height="537" alt="settings-panel-raylib-new" src="https://github.com/user-attachments/assets/7289e8d9-fd8d-4d62-aa0b-dfbe6bf1e954" />

### Network panel (before):
<img width="1085" height="538" alt="setup-network-raylib-old" src="https://github.com/user-attachments/assets/0a79bd8f-2793-4505-8b4b-3423da91ef22" />

### Network panel (after):
<img width="1076" height="537" alt="setup-network-raylib-new" src="https://github.com/user-attachments/assets/03824398-1271-495a-8795-e01c28523acf" />

### Alert (before):
<img width="1031" height="189" alt="alert-rounded-raylib-old" src="https://github.com/user-attachments/assets/109b2f74-ccd7-4fcd-88a7-85196e7bdd68" />

### Alert (after):
<img width="1031" height="193" alt="alert-rounded-raylib-new" src="https://github.com/user-attachments/assets/66ad377b-dc24-4e26-b8af-e699a2b377e1" />

