### PR TITLE
loggerd: remove deprecated av_init_packet usage

### DIFF
--- a/system/loggerd/encoder/ffmpeg_encoder.cc
+++ b/system/loggerd/encoder/ffmpeg_encoder.cc
@@ -1,5 +1,3 @@
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
 #include "system/loggerd/encoder/ffmpeg_encoder.h"
 
 #include <fcntl.h>
@@ -119,8 +117,7 @@ int FfmpegEncoder::encode_frame(VisionBuf* buf, VisionIpcBufExtra *extra) {
     ret = -1;
   }
 
-  AVPacket pkt;
-  av_init_packet(&pkt);
+  AVPacket pkt = {};
   pkt.data = NULL;
   pkt.size = 0;
   while (ret >= 0) {

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -1,4 +1,3 @@
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <cassert>
 
 #include "system/loggerd/video_writer.h"
@@ -114,8 +113,7 @@ void VideoWriter::write(uint8_t *data, int len, long long timestamp, bool codecc
       // input timestamps are in microseconds
       AVRational in_timebase = {1, 1000000};
 
-      AVPacket pkt;
-      av_init_packet(&pkt);
+      AVPacket pkt = {};
       pkt.data = data;
       pkt.size = len;
       pkt.stream_index = this->out_stream->index;


### PR DESCRIPTION
Replaces outdated `av_init_packet()` with C++ zero-initialization for `AVPacket`, aligning with current FFmpeg practices.