### PR TITLE
modeld: skip redundant cast, reshape, and flatten

### DIFF
--- a/selfdrive/modeld/dmonitoringmodeld.py
+++ b/selfdrive/modeld/dmonitoringmodeld.py
@@ -94,6 +94,7 @@ class ModelState:
 
 
     output = self.model_run(**self.tensor_inputs).contiguous().realize().uop.base.buffer.numpy()
+
     t2 = time.perf_counter()
     return output, t2 - t1
 

--- a/selfdrive/modeld/dmonitoringmodeld.py
+++ b/selfdrive/modeld/dmonitoringmodeld.py
@@ -93,8 +93,7 @@ class ModelState:
       self.tensor_inputs['input_img'] = Tensor(self.frame.buffer_from_cl(input_img_cl).reshape((1, MODEL_WIDTH*MODEL_HEIGHT)), dtype=dtypes.uint8).realize()
 
 
-    output = self.model_run(**self.tensor_inputs).numpy().flatten()
-
+    output = self.model_run(**self.tensor_inputs).contiguous().realize().uop.base.buffer.numpy()
     t2 = time.perf_counter()
     return output, t2 - t1
 

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -163,14 +163,14 @@ class ModelState:
     if prepare_only:
       return None
 
-    self.vision_output = self.vision_run(**self.vision_inputs).numpy().flatten()
+    self.vision_output = self.vision_run(**self.vision_inputs).contiguous().realize().uop.base.buffer.numpy()
     vision_outputs_dict = self.parser.parse_vision_outputs(self.slice_outputs(self.vision_output, self.vision_output_slices))
 
     self.full_features_buffer[0,:-1] = self.full_features_buffer[0,1:]
     self.full_features_buffer[0,-1] = vision_outputs_dict['hidden_state'][0, :]
     self.numpy_inputs['features_buffer'][:] = self.full_features_buffer[0, self.temporal_idxs]
 
-    self.policy_output = self.policy_run(**self.policy_inputs).numpy().flatten()
+    self.policy_output = self.policy_run(**self.policy_inputs).contiguous().realize().uop.base.buffer.numpy()
     policy_outputs_dict = self.parser.parse_policy_outputs(self.slice_outputs(self.policy_output, self.policy_output_slices))
 
     # TODO model only uses last value now


### PR DESCRIPTION
Removing the redundant operations improves `modeld.py` CPU usage from 32% to 24% and makes execution time ~2% faster

For `dmonitoringmodeld.py`, it improves CPU usage from 17% to 12% and makes execution time ~4% faster.

---



In tinygrad, `Tensor.numpy()` is essentially defined as
```
self.cast(self.dtype.base).contiguous().to("CPU").realize().uop.base.buffer.numpy().reshape(self.shape)
```

in `compile3.py`, we already cast to float32
```
  run_onnx_jit = TinyJit(lambda **kwargs:
                         next(iter(run_onnx({k:v.to(Device.DEFAULT) for k,v in kwargs.items()}).values())).cast('float32'), prune=True)
```

and in `modeld.py` and `dmonitoringmodeld.py`, `flatten()` is called after `.numpy()`, making the reshape redundant.

There is also an extra .to("CPU") which I think currently causes tinygrad to do a useless copy from CPU to NPY

gotta afford the hey comma cpu usage somehow

