### PR TITLE
pandad: close relay when openpilot goes offroad

### DIFF
--- a/selfdrive/pandad/panda_safety.cc
+++ b/selfdrive/pandad/panda_safety.cc
@@ -2,9 +2,7 @@
 #include "cereal/messaging/messaging.h"
 #include "common/swaglog.h"
 
-void PandaSafety::configureSafetyMode() {
-  bool is_onroad = params_.getBool("IsOnroad");
-
+void PandaSafety::configureSafetyMode(bool is_onroad) {
   if (is_onroad && !safety_configured_) {
     updateMultiplexingMode();
 

--- a/selfdrive/pandad/panda_safety.cc
+++ b/selfdrive/pandad/panda_safety.cc
@@ -2,10 +2,8 @@
 #include "cereal/messaging/messaging.h"
 #include "common/swaglog.h"
 
-void PandaSafety::configureSafetyMode() {
-  bool is_onroad = params_.getBool("IsOnroad");
-
-  if (is_onroad && !safety_configured_) {
+void PandaSafety::configureSafetyMode(bool started) {
+  if (started && !safety_configured_) {
     updateMultiplexingMode();
 
     auto car_params = fetchCarParams();
@@ -14,7 +12,7 @@ void PandaSafety::configureSafetyMode() {
       setSafetyMode(car_params);
       safety_configured_ = true;
     }
-  } else if (!is_onroad) {
+  } else if (!started) {
     initialized_ = false;
     safety_configured_ = false;
     log_once_ = false;

--- a/selfdrive/pandad/panda_safety.cc
+++ b/selfdrive/pandad/panda_safety.cc
@@ -2,8 +2,10 @@
 #include "cereal/messaging/messaging.h"
 #include "common/swaglog.h"
 
-void PandaSafety::configureSafetyMode(bool started) {
-  if (started && !safety_configured_) {
+void PandaSafety::configureSafetyMode() {
+  bool is_onroad = params_.getBool("IsOnroad");
+
+  if (is_onroad && !safety_configured_) {
     updateMultiplexingMode();
 
     auto car_params = fetchCarParams();
@@ -12,7 +14,7 @@ void PandaSafety::configureSafetyMode(bool started) {
       setSafetyMode(car_params);
       safety_configured_ = true;
     }
-  } else if (!started) {
+  } else if (!is_onroad) {
     initialized_ = false;
     safety_configured_ = false;
     log_once_ = false;

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -446,7 +446,7 @@ void pandad_run(std::vector<Panda *> &pandas) {
       engaged = sm.allAliveAndValid({"selfdriveState"}) && sm["selfdriveState"].getSelfdriveState().getEnabled();
       bool started = sm.allAliveAndValid({"deviceState"}) && sm["deviceState"].getDeviceState().getStarted();
       process_panda_state(pandas, &pm, engaged, started, spoofing_started);
-      panda_safety.configureSafetyMode(started);
+      panda_safety.configureSafetyMode();
     }
 
     // Send out peripheralState at 2Hz

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -444,7 +444,7 @@ void pandad_run(std::vector<Panda *> &pandas) {
     if (rk.frame() % 10 == 0) {
       sm.update(0);
       engaged = sm.allAliveAndValid({"selfdriveState"}) && sm["selfdriveState"].getSelfdriveState().getEnabled();
-      bool started = sm.allAliveAndValid({"deviceState"}) && sm["deviceState"].getDeviceState().getStarted();
+      bool started = sm["deviceState"].getDeviceState().getStarted();
       process_panda_state(pandas, &pm, engaged, started, spoofing_started);
       panda_safety.configureSafetyMode();
     }

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -256,7 +256,6 @@ std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> 
     }
 
     // set safety mode to NO_OUTPUT when car is off or we're not onroad. ELM327 is an alternative if we want to leverage athenad/connect
-    started = params_.getBool("IsOnroad");
     bool offroad = !ignition_local || !started;
     if (offroad && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
       panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -256,6 +256,7 @@ std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> 
     }
 
     // set safety mode to NO_OUTPUT when car is off or we're not onroad. ELM327 is an alternative if we want to leverage athenad/connect
+    started = params_.getBool("IsOnroad");
     bool offroad = !ignition_local || !started;
     if (offroad && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
       panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -188,7 +188,7 @@ void fill_panda_can_state(cereal::PandaState::PandaCanState::Builder &cs, const 
   cs.setCanCoreResetCnt(can_health.can_core_reset_cnt);
 }
 
-std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool spoofing_started) {
+std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool is_onroad, bool spoofing_started) {
   bool ignition_local = false;
   const uint32_t pandas_cnt = pandas.size();
 
@@ -256,9 +256,8 @@ std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> 
     }
 
     // set safety mode to NO_OUTPUT when car is off or we're not onroad. ELM327 is an alternative if we want to leverage athenad/connect
-    bool started = Params().getBool("IsOnroad");
-    bool offroad = !ignition_local || !started;
-    if (offroad && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
+    bool should_close_relay = !ignition_local || !is_onroad;
+    if (should_close_relay && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
       panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
     }
 
@@ -325,14 +324,14 @@ void send_peripheral_state(Panda *panda, PubMaster *pm) {
   pm->send("peripheralState", msg);
 }
 
-void process_panda_state(std::vector<Panda *> &pandas, PubMaster *pm, bool engaged, bool spoofing_started) {
+void process_panda_state(std::vector<Panda *> &pandas, PubMaster *pm, bool engaged, bool is_onroad, bool spoofing_started) {
   std::vector<std::string> connected_serials;
   for (Panda *p : pandas) {
     connected_serials.push_back(p->hw_serial());
   }
 
   {
-    auto ignition_opt = send_panda_states(pm, pandas, spoofing_started);
+    auto ignition_opt = send_panda_states(pm, pandas, is_onroad, spoofing_started);
     if (!ignition_opt) {
       LOGE("Failed to get ignition_opt");
       return;
@@ -426,11 +425,13 @@ void pandad_run(std::vector<Panda *> &pandas) {
   std::thread send_thread(can_send_thread, pandas, fake_send);
 
   RateKeeper rk("pandad", 100);
-  SubMaster sm({"selfdriveState", "deviceState"});
+  SubMaster sm({"selfdriveState"});
   PubMaster pm({"can", "pandaStates", "peripheralState"});
+  Params params;
   PandaSafety panda_safety(pandas);
   Panda *peripheral_panda = pandas[0];
   bool engaged = false;
+  bool is_onroad = false;
 
   // Main loop: receive CAN data and process states
   while (!do_exit && check_all_connected(pandas)) {
@@ -445,8 +446,9 @@ void pandad_run(std::vector<Panda *> &pandas) {
     if (rk.frame() % 10 == 0) {
       sm.update(0);
       engaged = sm.allAliveAndValid({"selfdriveState"}) && sm["selfdriveState"].getSelfdriveState().getEnabled();
-      process_panda_state(pandas, &pm, engaged, spoofing_started);
-      panda_safety.configureSafetyMode();
+      is_onroad = params.getBool("IsOnroad");
+      process_panda_state(pandas, &pm, engaged, is_onroad, spoofing_started);
+      panda_safety.configureSafetyMode(is_onroad);
     }
 
     // Send out peripheralState at 2Hz
@@ -471,7 +473,6 @@ void pandad_run(std::vector<Panda *> &pandas) {
   }
 
   // Close relay on exit to prevent a fault
-  const bool is_onroad = Params().getBool("IsOnroad");
   if (is_onroad && !engaged) {
     for (auto &p : pandas) {
       if (p->connected()) {

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -446,7 +446,7 @@ void pandad_run(std::vector<Panda *> &pandas) {
       engaged = sm.allAliveAndValid({"selfdriveState"}) && sm["selfdriveState"].getSelfdriveState().getEnabled();
       bool started = sm.allAliveAndValid({"deviceState"}) && sm["deviceState"].getDeviceState().getStarted();
       process_panda_state(pandas, &pm, engaged, started, spoofing_started);
-      panda_safety.configureSafetyMode();
+      panda_safety.configureSafetyMode(started);
     }
 
     // Send out peripheralState at 2Hz

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -424,10 +424,10 @@ void pandad_run(std::vector<Panda *> &pandas) {
   // Start the CAN send thread
   std::thread send_thread(can_send_thread, pandas, fake_send);
 
+  Params params;
   RateKeeper rk("pandad", 100);
   SubMaster sm({"selfdriveState"});
   PubMaster pm({"can", "pandaStates", "peripheralState"});
-  Params params;
   PandaSafety panda_safety(pandas);
   Panda *peripheral_panda = pandas[0];
   bool engaged = false;

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -188,7 +188,7 @@ void fill_panda_can_state(cereal::PandaState::PandaCanState::Builder &cs, const 
   cs.setCanCoreResetCnt(can_health.can_core_reset_cnt);
 }
 
-std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool spoofing_started) {
+std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool started, bool spoofing_started) {
   bool ignition_local = false;
   const uint32_t pandas_cnt = pandas.size();
 
@@ -255,8 +255,9 @@ std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> 
       panda->set_power_saving(power_save_desired);
     }
 
-    // set safety mode to NO_OUTPUT when car is off. ELM327 is an alternative if we want to leverage athenad/connect
-    if (!ignition_local && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
+    // set safety mode to NO_OUTPUT when car is off or we're not onroad. ELM327 is an alternative if we want to leverage athenad/connect
+    bool offroad = !ignition_local || !started;
+    if (offroad && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
       panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
     }
 
@@ -323,14 +324,14 @@ void send_peripheral_state(Panda *panda, PubMaster *pm) {
   pm->send("peripheralState", msg);
 }
 
-void process_panda_state(std::vector<Panda *> &pandas, PubMaster *pm, bool engaged, bool spoofing_started) {
+void process_panda_state(std::vector<Panda *> &pandas, PubMaster *pm, bool engaged, bool started, bool spoofing_started) {
   std::vector<std::string> connected_serials;
   for (Panda *p : pandas) {
     connected_serials.push_back(p->hw_serial());
   }
 
   {
-    auto ignition_opt = send_panda_states(pm, pandas, spoofing_started);
+    auto ignition_opt = send_panda_states(pm, pandas, started, spoofing_started);
     if (!ignition_opt) {
       LOGE("Failed to get ignition_opt");
       return;
@@ -424,7 +425,7 @@ void pandad_run(std::vector<Panda *> &pandas) {
   std::thread send_thread(can_send_thread, pandas, fake_send);
 
   RateKeeper rk("pandad", 100);
-  SubMaster sm({"selfdriveState"});
+  SubMaster sm({"selfdriveState", "deviceState"});
   PubMaster pm({"can", "pandaStates", "peripheralState"});
   PandaSafety panda_safety(pandas);
   Panda *peripheral_panda = pandas[0];
@@ -443,7 +444,8 @@ void pandad_run(std::vector<Panda *> &pandas) {
     if (rk.frame() % 10 == 0) {
       sm.update(0);
       engaged = sm.allAliveAndValid({"selfdriveState"}) && sm["selfdriveState"].getSelfdriveState().getEnabled();
-      process_panda_state(pandas, &pm, engaged, spoofing_started);
+      bool started = sm.allAliveAndValid({"deviceState"}) && sm["deviceState"].getDeviceState().getStarted();
+      process_panda_state(pandas, &pm, engaged, started, spoofing_started);
       panda_safety.configureSafetyMode();
     }
 

--- a/selfdrive/pandad/pandad.h
+++ b/selfdrive/pandad/pandad.h
@@ -11,7 +11,7 @@ void pandad_main_thread(std::vector<std::string> serials);
 class PandaSafety {
 public:
   PandaSafety(const std::vector<Panda *> &pandas) : pandas_(pandas) {}
-  void configureSafetyMode();
+  void configureSafetyMode(bool is_onroad);
 
 private:
   void updateMultiplexingMode();

--- a/selfdrive/pandad/tests/test_pandad_loopback.py
+++ b/selfdrive/pandad/tests/test_pandad_loopback.py
@@ -52,6 +52,7 @@ def setup_pandad(num_pandas):
 
   with Timeout(90, "pandad didn't set safety mode"):
     while any(ps.safetyModel != car.CarParams.SafetyModel.allOutput for ps in sm['pandaStates']):
+      pm.send("deviceState", device_state)
       sm.update(1000)
 
 def send_random_can_messages(sendcan, count, num_pandas=1):

--- a/selfdrive/pandad/tests/test_pandad_loopback.py
+++ b/selfdrive/pandad/tests/test_pandad_loopback.py
@@ -52,6 +52,8 @@ def setup_pandad(num_pandas):
 
   with Timeout(90, "pandad didn't set safety mode"):
     while any(ps.safetyModel != car.CarParams.SafetyModel.allOutput for ps in sm['pandaStates']):
+      device_state = messaging.new_message("deviceState")
+      device_state.deviceState.started = True
       pm.send("deviceState", device_state)
       sm.update(1000)
 

--- a/selfdrive/pandad/tests/test_pandad_loopback.py
+++ b/selfdrive/pandad/tests/test_pandad_loopback.py
@@ -40,6 +40,11 @@ def setup_pandad(num_pandas):
   safety_config.safetyModel = car.CarParams.SafetyModel.allOutput
   cp.safetyConfigs = [safety_config]*num_pandas
 
+  pm = messaging.PubMaster(["deviceState"])
+  device_state = messaging.new_message("deviceState")
+  device_state.deviceState.started = True
+  pm.send("deviceState", device_state)
+
   params.put_bool("IsOnroad", True)
   params.put_bool("FirmwareQueryDone", True)
   params.put_bool("ControlsReady", True)

--- a/selfdrive/pandad/tests/test_pandad_loopback.py
+++ b/selfdrive/pandad/tests/test_pandad_loopback.py
@@ -40,11 +40,6 @@ def setup_pandad(num_pandas):
   safety_config.safetyModel = car.CarParams.SafetyModel.allOutput
   cp.safetyConfigs = [safety_config]*num_pandas
 
-  pm = messaging.PubMaster(["deviceState"])
-  device_state = messaging.new_message("deviceState")
-  device_state.deviceState.started = True
-  pm.send("deviceState", device_state)
-
   params.put_bool("IsOnroad", True)
   params.put_bool("FirmwareQueryDone", True)
   params.put_bool("ControlsReady", True)
@@ -52,9 +47,6 @@ def setup_pandad(num_pandas):
 
   with Timeout(90, "pandad didn't set safety mode"):
     while any(ps.safetyModel != car.CarParams.SafetyModel.allOutput for ps in sm['pandaStates']):
-      device_state = messaging.new_message("deviceState")
-      device_state.deviceState.started = True
-      pm.send("deviceState", device_state)
       sm.update(1000)
 
 def send_random_can_messages(sendcan, count, num_pandas=1):


### PR DESCRIPTION
Closes https://github.com/commaai/openpilot/issues/35709.

Previously, the only user-facing way you could make openpilot go offroad was turning off the car ignition. pandad handled this by resetting the safety mode to NO_OUTPUT.

Then we added onroad cycling via toggles, but pandad only checked the ignition for resetting the safety mode. This kept the relay open and faulted the car, until openpilot set it to ELM327 for fingerprinting starting back up.

This bug also faulted the car if the device went offroad from `device_temp_good` going false.

---

Flipping the enable op toggle now:

```
      safetyModel = toyota,
      safetyModel = toyota,
      safetyModel = toyota,
      safetyModel = toyota,
      safetyModel = toyota,
      safetyModel = toyota,
      safetyModel = toyota,
      safetyModel = toyota,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = noOutput,
      safetyModel = elm327,
      safetyModel = elm327,
      safetyModel = elm327,
      safetyModel = elm327,
      safetyModel = elm327,
      safetyModel = elm327,
```