### PR TITLE
cabana: fix bit mask calculation bug

### DIFF
--- a/tools/cabana/dbc/dbc.cc
+++ b/tools/cabana/dbc/dbc.cc
@@ -109,7 +109,7 @@ void cabana::Msg::update() {
 
       mask[i] |= ((1ULL << sz) - 1) << shift;
 
-      bits -= size;
+      bits -= sz;
       i = sig->is_little_endian ? i - 1 : i + 1;
     }
   }


### PR DESCRIPTION
**Bug:** In `cabana::Msg::update()`, the bit mask calculation incorrectly subtracts the entire message size from the bit counter instead of just the bits processed in each iteration.

**Fix:** Changed the decrement to use the correct value:

`bits -= sz;`