### PR TITLE
LogReader: support connect URLs

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -233,10 +233,7 @@ def parse_indirect(identifier: str) -> str:
     path = ['/'.join(path[:2]), *path[2:]]  # recombine log id
 
     identifier = path[0]
-    if len(path) == 2:
-      # add selector
-      identifier = "/".join(path)
-    elif len(path) > 2:
+    if len(path) > 2:
       # convert url with seconds to segments
       start, end = int(path[1]) // 60, int(path[2]) // 60 + 1
       identifier = f"{identifier}/{start}:{end}"
@@ -244,6 +241,9 @@ def parse_indirect(identifier: str) -> str:
       # add selector if it exists
       if len(path) > 3:
         identifier += f"/{path[3]}"
+    else:
+      # add selector if it exists
+      identifier = "/".join(path)
 
   return identifier
 
@@ -257,9 +257,7 @@ def parse_direct(identifier: str):
 class LogReader:
   def _parse_identifier(self, identifier: str) -> list[str]:
     # useradmin, etc.
-    print('old identifier:', identifier)
     identifier = parse_indirect(identifier)
-    print('new identifier:', identifier)
 
     # direct url or file
     direct_parsed = parse_direct(identifier)

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -227,7 +227,24 @@ def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) 
 def parse_indirect(identifier: str) -> str:
   if "useradmin.comma.ai" in identifier:
     query = parse_qs(urlparse(identifier).query)
-    return query["onebox"][0]
+    identifier = query["onebox"][0]
+  elif "connect.comma.ai" in identifier:
+    path = urlparse(identifier).path.strip("/").split("/")
+    path = ['/'.join(path[:2]), *path[2:]]  # recombine log id
+
+    identifier = path[0]
+    if len(path) == 2:
+      # add selector
+      identifier = "/".join(path)
+    elif len(path) > 2:
+      # convert url with seconds to segments
+      start, end = int(path[1]) // 60, int(path[2]) // 60 + 1
+      identifier = f"{identifier}/{start}:{end}"
+
+      # add selector if it exists
+      if len(path) > 3:
+        identifier += f"/{path[3]}"
+
   return identifier
 
 
@@ -240,7 +257,9 @@ def parse_direct(identifier: str):
 class LogReader:
   def _parse_identifier(self, identifier: str) -> list[str]:
     # useradmin, etc.
+    print('old identifier:', identifier)
     identifier = parse_indirect(identifier)
+    print('new identifier:', identifier)
 
     # direct url or file
     direct_parsed = parse_direct(identifier)


### PR DESCRIPTION
I need this all the time, this will be super useful

```
LogReader("https://connect.comma.ai/d9b97c1d3b8c39b2/00000161--2c3b03f304/388/533/q")
```

Returns segments 6, 7, 8