### PR TITLE
Route: remove more old file types

### DIFF
--- a/tools/lib/route.py
+++ b/tools/lib/route.py
@@ -12,7 +12,7 @@ from openpilot.tools.lib.helpers import RE
 
 QLOG_FILENAMES = ['qlog.bz2', 'qlog.zst', 'qlog']
 QCAMERA_FILENAMES = ['qcamera.ts']
-LOG_FILENAMES = ['rlog.bz2', 'raw_log.bz2', 'rlog.zst', 'rlog']
+LOG_FILENAMES = ['rlog.bz2', 'rlog.zst', 'rlog']
 CAMERA_FILENAMES = ['fcamera.hevc', 'video.hevc']
 DCAMERA_FILENAMES = ['dcamera.hevc']
 ECAMERA_FILENAMES = ['ecamera.hevc']


### PR DESCRIPTION
don't need these in Route for LogReader to work properly

These were for comma2k19 (added 6+ years ago): https://github.com/commaai/comma2k19/tree/master/Example_1/b0c9d2329ad1606b%7C2018-08-02--08-34-47/40

```
>>> from tools.lib.logreader import LogReader
>>> lr = LogReader('/home/batman/comma2k19/Example_1/b0c9d2329ad1606b|2018-08-02
--08-34-47/40/raw_log.bz2')                          
>>> len(list(lr))                                                               
75966
```