### PR TITLE
util: fix read_file for files > 2GB

### DIFF
--- a/common/util.cc
+++ b/common/util.cc
@@ -12,6 +12,7 @@
 #include <iomanip>
 #include <random>
 #include <sstream>
+#include <limits>
 
 #ifdef __linux__
 #include <sys/prctl.h>
@@ -79,7 +80,8 @@ std::string read_file(const std::string& fn) {
   if (f.is_open()) {
     f.seekg(0, std::ios::end);
     std::streamsize size = f.tellg();
-    if (f.good() && size > 0) {
+    // seekg and tellg on a directory doesn't return pos_type(-1) but max(streamsize)
+    if (f.good() && size > 0 && size < std::numeric_limits<std::streamsize>::max()) {
       std::string result(size, '\0');
       f.seekg(0, std::ios::beg);
       f.read(result.data(), size);

--- a/common/util.cc
+++ b/common/util.cc
@@ -78,7 +78,7 @@ std::string read_file(const std::string& fn) {
   std::ifstream f(fn, std::ios::binary | std::ios::in);
   if (f.is_open()) {
     f.seekg(0, std::ios::end);
-    int size = f.tellg();
+    std::streamsize size = f.tellg();
     if (f.good() && size > 0) {
       std::string result(size, '\0');
       f.seekg(0, std::ios::beg);


### PR DESCRIPTION
**Description**

`int` could only handle maximum `2^31-1`, so `streamsize` is more appropriate here. `streamsize` here is implicitly converted from `streamoff`, which is also implicitly converted from `streampos` as the return type of `tellg`. And [cplusplus ref](https://cplusplus.com/reference/ios/streamoff/) says for `streamoff`
> It is a typdef of one the fundamental signed [integral types](https://cplusplus.com/is_integral) large enough to represent the maximum possible file size supported by the system.

**Verification**

I can load a 3GB `rlog` file into `replay` now, more is okay I suppose.