### PR TITLE
Update vehicle model reference to 2023 edition of Guiggiani's book

### DIFF
--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -93,8 +93,9 @@ class CarKalman(KalmanFilter):
     dim_state = CarKalman.initial_x.shape[0]
     name = CarKalman.name
 
-    # vehicle models comes from The Science of Vehicle Dynamics: Handling, Braking, and Ride of Road and Race Cars
-    # Model used is in 6.15 with formula from 6.198
+    # Linearized single-track lateral dynamics, equations 7.211-7.213
+    # Massimo Guiggiani, The Science of Vehicle Dynamics: Handling, Braking, and Ride of Road and Race Cars
+    # Springer Cham, 2023. doi: https://doi.org/10.1007/978-3-031-06461-6
 
     # globals
     global_vars = [sp.Symbol(name) for name in CarKalman.global_vars]


### PR DESCRIPTION
The edition in the comment is now out of press and unavailable online. Screenshot from page 329.

<img width="1009" height="954" alt="Screenshot From 2025-07-24 13-53-51" src="https://github.com/user-attachments/assets/365863a4-77e7-4c84-996b-ff97b5a17d72" />
