### PR TITLE
Use panda as pip dependency instead of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "panda"]
-  path = panda
-  url = ../../commaai/panda.git
 [submodule "opendbc"]
   path = opendbc_repo
   url = ../../commaai/opendbc.git

--- a/SConstruct
+++ b/SConstruct
@@ -328,7 +328,6 @@ Export('messaging')
 
 
 # Build other submodules
-SConscript(['panda/SConscript'])
 
 # Build rednose library
 SConscript(['rednose/SConscript'])

--- a/panda/board/can.h
+++ b/panda/board/can.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "can_declarations.h"
+
+static const uint8_t PANDA_CAN_CNT = 3U;
+static const uint8_t PANDA_BUS_CNT = 3U;
+
+static const unsigned char dlc_to_len[] = {0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 12U, 16U, 20U, 24U, 32U, 48U, 64U};

--- a/panda/board/can_declarations.h
+++ b/panda/board/can_declarations.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// bump this when changing the CAN packet
+#define CAN_PACKET_VERSION 4
+
+#define CANPACKET_HEAD_SIZE 6U
+
+#if !defined(STM32F4)
+  #define CANFD
+  #define CANPACKET_DATA_SIZE_MAX 64U
+#else
+  #define CANPACKET_DATA_SIZE_MAX 8U
+#endif
+
+typedef struct {
+  unsigned char fd : 1;
+  unsigned char bus : 3;
+  unsigned char data_len_code : 4;  // lookup length with dlc_to_len
+  unsigned char rejected : 1;
+  unsigned char returned : 1;
+  unsigned char extended : 1;
+  unsigned int addr : 29;
+  unsigned char checksum;
+  unsigned char data[CANPACKET_DATA_SIZE_MAX];
+} __attribute__((packed, aligned(4))) CANPacket_t;
+
+#define GET_BUS(msg) ((msg)->bus)
+#define GET_LEN(msg) (dlc_to_len[(msg)->data_len_code])
+#define GET_ADDR(msg) ((msg)->addr)

--- a/panda/board/comms_definitions.h
+++ b/panda/board/comms_definitions.h
@@ -1,0 +1,12 @@
+typedef struct {
+  uint8_t request;
+  uint16_t param1;
+  uint16_t param2;
+  uint16_t length;
+} __attribute__((packed)) ControlPacket_t;
+
+int comms_control_handler(ControlPacket_t *req, uint8_t *resp);
+void comms_endpoint2_write(const uint8_t *data, uint32_t len);
+void comms_can_write(const uint8_t *data, uint32_t len);
+int comms_can_read(uint8_t *data, uint32_t max_len);
+void comms_can_reset(void);

--- a/panda/board/health.h
+++ b/panda/board/health.h
@@ -1,0 +1,61 @@
+// When changing these structs, python/__init__.py needs to be kept up to date!
+
+#define HEALTH_PACKET_VERSION 16
+struct __attribute__((packed)) health_t {
+  uint32_t uptime_pkt;
+  uint32_t voltage_pkt;
+  uint32_t current_pkt;
+  uint32_t safety_tx_blocked_pkt;
+  uint32_t safety_rx_invalid_pkt;
+  uint32_t tx_buffer_overflow_pkt;
+  uint32_t rx_buffer_overflow_pkt;
+  uint32_t faults_pkt;
+  uint8_t ignition_line_pkt;
+  uint8_t ignition_can_pkt;
+  uint8_t controls_allowed_pkt;
+  uint8_t car_harness_status_pkt;
+  uint8_t safety_mode_pkt;
+  uint16_t safety_param_pkt;
+  uint8_t fault_status_pkt;
+  uint8_t power_save_enabled_pkt;
+  uint8_t heartbeat_lost_pkt;
+  uint16_t alternative_experience_pkt;
+  float interrupt_load_pkt;
+  uint8_t fan_power;
+  uint8_t safety_rx_checks_invalid_pkt;
+  uint16_t spi_checksum_error_count_pkt;
+  uint8_t fan_stall_count;
+  uint16_t sbu1_voltage_mV;
+  uint16_t sbu2_voltage_mV;
+  uint8_t som_reset_triggered;
+};
+
+#define CAN_HEALTH_PACKET_VERSION 5
+typedef struct __attribute__((packed)) {
+  uint8_t bus_off;
+  uint32_t bus_off_cnt;
+  uint8_t error_warning;
+  uint8_t error_passive;
+  uint8_t last_error; // real time LEC value
+  uint8_t last_stored_error; // last LEC positive error code stored
+  uint8_t last_data_error; // DLEC (for CANFD only)
+  uint8_t last_data_stored_error; // last DLEC positive error code stored (for CANFD only)
+  uint8_t receive_error_cnt; // Actual state of the receive error counter, values between 0 and 127. FDCAN_ECR.REC
+  uint8_t transmit_error_cnt; // Actual state of the transmit error counter, values between 0 and 255. FDCAN_ECR.TEC
+  uint32_t total_error_cnt; // How many times any error interrupt was invoked
+  uint32_t total_tx_lost_cnt; // Tx event FIFO element lost
+  uint32_t total_rx_lost_cnt; // Rx FIFO 0 message lost due to FIFO full condition
+  uint32_t total_tx_cnt;
+  uint32_t total_rx_cnt;
+  uint32_t total_fwd_cnt; // Messages forwarded from one bus to another
+  uint32_t total_tx_checksum_error_cnt;
+  uint16_t can_speed;
+  uint16_t can_data_speed;
+  uint8_t canfd_enabled;
+  uint8_t brs_enabled;
+  uint8_t canfd_non_iso;
+  uint32_t irq0_call_rate;
+  uint32_t irq1_call_rate;
+  uint32_t irq2_call_rate;
+  uint32_t can_core_reset_cnt;
+} can_health_t;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
   # panda
   "libusb1",
+  "panda @ git+https://github.com/shreyanshjain7174/panda.git@14e67acf",
   "spidev; platform_system == 'Linux'",
 
   # modeld

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
   # panda
   "libusb1",
-  "panda @ git+https://github.com/shreyanshjain7174/panda.git@14e67acf",
+  "panda @ git+https://github.com/shreyanshjain7174/panda.git@edd7a9a0",
   "spidev; platform_system == 'Linux'",
 
   # modeld
@@ -139,7 +139,7 @@ allow-direct-references = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ignore=openpilot/ --ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ --ignore=teleoprtc_repo/ --ignore=msgq/  -Werror --strict-config --strict-markers --durations=10 -n auto --dist=loadgroup"
+addopts = "--ignore=openpilot/ --ignore=opendbc/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ --ignore=teleoprtc_repo/ --ignore=msgq/  -Werror --strict-config --strict-markers --durations=10 -n auto --dist=loadgroup"
 cpp_files = "test_*"
 cpp_harness = "selfdrive/test/cpp_harness.py"
 python_files = "test_*.py"
@@ -173,7 +173,7 @@ quiet-level = 3
 # if you've got a short variable name that's getting flagged, add it here
 ignore-words-list = "bu,ro,te,ue,alo,hda,ois,nam,nams,ned,som,parm,setts,inout,warmup,bumb,nd,sie,preints,whit,indexIn,ws,uint,grey,deque,stdio,amin,BA,LITE,atEnd,UIs,errorString,arange,FocusIn,od,tim,relA,hist,copyable,jupyter,thead,TGE,abl,lite"
 builtin = "clear,rare,informal,code,names,en-GB_to_en-US"
-skip = "./third_party/*, ./tinygrad/*, ./tinygrad_repo/*, ./msgq/*, ./panda/*, ./opendbc/*, ./opendbc_repo/*, ./rednose/*, ./rednose_repo/*, ./teleoprtc/*, ./teleoprtc_repo/*, *.ts, uv.lock, *.onnx, ./cereal/gen/*, */c_generated_code/*, docs/assets/*"
+skip = "./third_party/*, ./tinygrad/*, ./tinygrad_repo/*, ./msgq/*, ./opendbc/*, ./opendbc_repo/*, ./rednose/*, ./rednose_repo/*, ./teleoprtc/*, ./teleoprtc_repo/*, *.ts, uv.lock, *.onnx, ./cereal/gen/*, */c_generated_code/*, docs/assets/*"
 
 [tool.mypy]
 python_version = "3.11"
@@ -183,7 +183,6 @@ exclude = [
   "msgq_repo/",
   "opendbc/",
   "opendbc_repo/",
-  "panda/",
   "rednose/",
   "rednose_repo/",
   "tinygrad/",
@@ -238,7 +237,6 @@ target-version ="py311"
 exclude = [
   "body",
   "cereal",
-  "panda",
   "opendbc",
   "opendbc_repo",
   "rednose_repo",

--- a/selfdrive/debug/car/hyundai_enable_radar_points.py
+++ b/selfdrive/debug/car/hyundai_enable_radar_points.py
@@ -19,7 +19,7 @@ from subprocess import check_output, CalledProcessError
 from opendbc.car.carlog import carlog
 from opendbc.car.uds import UdsClient, SESSION_TYPE, DATA_IDENTIFIER_TYPE
 from opendbc.car.structs import CarParams
-from panda.python import Panda
+from panda import Panda
 
 class ConfigValues(NamedTuple):
   default_config: bytes

--- a/tools/replay/can_replay.py
+++ b/tools/replay/can_replay.py
@@ -10,7 +10,7 @@ os.environ['FILEREADER_CACHE'] = '1'
 from openpilot.common.realtime import config_realtime_process, Ratekeeper, DT_CTRL
 from openpilot.selfdrive.pandad import can_capnp_to_list
 from openpilot.tools.lib.logreader import LogReader
-from panda import PandaJungle
+from panda.board.jungle import PandaJungle
 
 # set both to cycle power or ignition
 PWR_ON = int(os.getenv("PWR_ON", "0"))


### PR DESCRIPTION
Replace the panda git submodule with a pip package dependency. This allows panda to be managed like
  other Python dependencies.

  The panda package now installs from the pip-compatible version in PR #2242.