### PR TITLE
DM: fix always on permanent lockout

### DIFF
--- a/selfdrive/monitoring/helpers.py
+++ b/selfdrive/monitoring/helpers.py
@@ -309,15 +309,15 @@ class DriverMonitoring:
 
   def _update_events(self, driver_engaged, op_engaged, standstill, wrong_gear, car_speed):
     self._reset_events()
-    # Block engaging after max number of distrations or when alert active
+    # Block engaging until ignition cycle after max number or time of distractions
     if self.terminal_alert_cnt >= self.settings._MAX_TERMINAL_ALERTS or \
-       self.terminal_time >= self.settings._MAX_TERMINAL_DURATION or \
-       self.always_on and self.awareness <= self.threshold_prompt:
+       self.terminal_time >= self.settings._MAX_TERMINAL_DURATION:
       if not self.too_distracted:
         self.params.put_bool_nonblocking("DriverTooDistracted", True)
       self.too_distracted = True
 
-    if self.too_distracted:
+    # Always-on distraction lockout is temporary
+    if self.too_distracted or (self.always_on and self.awareness <= self.threshold_prompt):
       self.current_events.add(EventName.tooDistracted)
 
     always_on_valid = self.always_on and not wrong_gear


### PR DESCRIPTION
Regression from https://github.com/commaai/openpilot/pull/35710

I would like to point out the confusion of using the same alert with different lockout behaviors without a comment for the expected behavior, but I should have clarified before merging