### PR TITLE
Low-pass filter LSM6DS3TR-C accelerometer on-chip

### DIFF
--- a/system/sensord/sensord.py
+++ b/system/sensord/sensord.py
@@ -44,7 +44,7 @@ def interrupt_loop(sensors: list[tuple[Sensor, str, bool]], event) -> None:
     if not events:
       cloudlog.error("poll timed out")
 
-      for sensor, service, interrupt in sensors:
+      for sensor, _, _ in sensors:
         sensor.interrupt_recovery()
 
       continue

--- a/system/sensord/sensord.py
+++ b/system/sensord/sensord.py
@@ -43,6 +43,10 @@ def interrupt_loop(sensors: list[tuple[Sensor, str, bool]], event) -> None:
     events = poller.poll(100)
     if not events:
       cloudlog.error("poll timed out")
+
+      for sensor, service, interrupt in sensors:
+        sensor.interrupt_recovery()
+
       continue
     if not (events[0][1] & (select.POLLIN | select.POLLPRI)):
       cloudlog.error("no poll events set")

--- a/system/sensord/sensors/i2c_sensor.py
+++ b/system/sensord/sensors/i2c_sensor.py
@@ -56,6 +56,9 @@ class Sensor:
     # unclear whether we need this...
     return (time.monotonic() - self.start_ts) > 0.5
 
+  def interrupt_recovery(self) -> None:
+    pass
+
   # *** helpers ***
   @staticmethod
   def wait():

--- a/system/sensord/sensors/lsm6ds3_accel.py
+++ b/system/sensord/sensors/lsm6ds3_accel.py
@@ -55,6 +55,7 @@ class LSM6DS3_Accel(Sensor):
 
     # reset chip before init
     self.write(self.LSM6DS3_ACCEL_I2C_REG_CTRL3_C, 0b1)
+    time.sleep(0.1)
 
     # self-test
     if os.getenv("LSM_SELF_TEST") == "1":
@@ -131,6 +132,13 @@ class LSM6DS3_Accel(Sensor):
     value = self.read(self.LSM6DS3_ACCEL_I2C_REG_CTRL1_XL, 1)[0]
     value &= 0x0F
     self.write(self.LSM6DS3_ACCEL_I2C_REG_CTRL1_XL, value)
+
+  def interrupt_recovery(self) -> None:
+    if self.source == log.SensorEventData.SensorSource.lsm6ds3trc:
+      # Blink FIFO into bypass to clear contents
+      self.write(self.LSM6DS3_ACCEL_I2C_REG_FIFO_CTRL5, self.LSM6DS3_ACCEL_FIFO_ODR_833Hz)
+      time.sleep(0.01)
+      self.write(self.LSM6DS3_ACCEL_I2C_REG_FIFO_CTRL5, self.LSM6DS3_ACCEL_FIFO_ODR_833Hz | self.LSM6DS3_ACCEL_FIFO_MODE_CONT)
 
   # *** self-test stuff ***
   def _wait_for_data_ready(self):


### PR DESCRIPTION
This is needed since we read out the chip at ~104Hz while the anti-aliasing analog filter is 400Hz.

Changes:
- the ODR is increased to 833Hz to avoid aliasing
- digital LFP is enabled at ODR/9 BW (93Hz)
- FIFO decimates the measurements 8x (to get ~104Hz back)

The second step doesn't quite hit Nyquist (93Hz > 104Hz/2), but the next "step" in bandwidth reduction would be ODR/50, which would give a bandwidth of 16.7Hz. Not sure if that's preferable @haraschax? Alternatively we can decrease the decimation to get a readout of ~208Hz

