### PR TITLE
process replay: only enter prefix when interacting with process

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -274,13 +274,13 @@ class ProcessContainer:
     assert self.rc and self.pm and self.sockets and self.process.proc
 
     output_msgs = []
-    with self.prefix, Timeout(self.cfg.timeout, error_msg=f"timed out testing process {repr(self.cfg.proc_name)}"):
-      end_of_cycle = True
-      if self.cfg.should_recv_callback is not None:
-        end_of_cycle = self.cfg.should_recv_callback(msg, self.cfg, self.cnt)
+    end_of_cycle = True
+    if self.cfg.should_recv_callback is not None:
+      end_of_cycle = self.cfg.should_recv_callback(msg, self.cfg, self.cnt)
 
-      self.msg_queue.append(msg)
-      if end_of_cycle:
+    self.msg_queue.append(msg)
+    if end_of_cycle:
+      with self.prefix, Timeout(self.cfg.timeout, error_msg=f"timed out testing process {repr(self.cfg.proc_name)}"):
         # call recv to let sub-sockets reconnect, after we know the process is ready
         if self.cnt == 0:
           for s in self.sockets:

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -718,7 +718,6 @@ def _replay_multi_process(
     pbar = tqdm(total=len(external_pub_queue), disable=disable_progress)
     times = defaultdict(list)
     while len(external_pub_queue) != 0 or (len(internal_pub_index_heap) != 0 and not all(c.has_empty_queue for c in containers)):
-      t = time.monotonic()
       if len(internal_pub_index_heap) == 0 or (len(external_pub_queue) != 0 and external_pub_queue[0].logMonoTime < internal_pub_index_heap[0][0]):
         msg = external_pub_queue.pop(0)
         pbar.update(1)
@@ -726,9 +725,6 @@ def _replay_multi_process(
         _, index = heapq.heappop(internal_pub_index_heap)
         msg = internal_pub_queue[index]
 
-      # print(f'get msg took {time.monotonic() - t}s')
-
-      t = time.monotonic()
       target_containers = pubs_to_containers[msg.which()]
       for container in target_containers:
         t1 = time.monotonic()
@@ -739,10 +735,8 @@ def _replay_multi_process(
             internal_pub_queue.append(m)
             heapq.heappush(internal_pub_index_heap, (m.logMonoTime, len(internal_pub_queue) - 1))
         log_msgs.extend(output_msgs)
-        # print(f'run_step for {container.cfg.proc_name} took {time.monotonic() - t1}s')
-      # print(f'all run_steps took {time.monotonic() - t}s')
 
-    print("Average run_step times:")
+    print("Total run_step times:")
     for container, time_list in times.items():
       print(f"  {container}: {sum(time_list)}s")
     print('Total run_step time: {:.2f}s'.format(sum(sum(time_list) for time_list in times.values())))

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -274,13 +274,13 @@ class ProcessContainer:
     assert self.rc and self.pm and self.sockets and self.process.proc
 
     output_msgs = []
-    end_of_cycle = True
-    if self.cfg.should_recv_callback is not None:
-      end_of_cycle = self.cfg.should_recv_callback(msg, self.cfg, self.cnt)
+    with self.prefix, Timeout(self.cfg.timeout, error_msg=f"timed out testing process {repr(self.cfg.proc_name)}"):
+      end_of_cycle = True
+      if self.cfg.should_recv_callback is not None:
+        end_of_cycle = self.cfg.should_recv_callback(msg, self.cfg, self.cnt)
 
-    self.msg_queue.append(msg)
-    if end_of_cycle:
-      with self.prefix, Timeout(self.cfg.timeout, error_msg=f"timed out testing process {repr(self.cfg.proc_name)}"):
+      self.msg_queue.append(msg)
+      if end_of_cycle:
         # call recv to let sub-sockets reconnect, after we know the process is ready
         if self.cnt == 0:
           for s in self.sockets:


### PR DESCRIPTION
Only enter prefix when ready to send/receive msgs, not simply adding messages to queue (list)

---

benchmark command:

```bash
./run_process_on_route.py d9b97c1d3b8c39b2/00000160--6ce3dd7c70/1 selfdrived controlsd radard plannerd calibrationd dmonitoringd locationd paramsd lagd ubloxd torqued card
```

On master:

```
Total run_step times:
  selfdrived: 5.788743521086872s
  card: 1.0108267199248075s
  locationd: 0.4765220759436488s
  controlsd: 2.740807613823563s
  radard: 0.3774205078370869s
  plannerd: 0.9272696250118315s
  dmonitoringd: 0.545840504579246s
  calibrationd: 0.22642212361097336s
  paramsd: 0.2980232019908726s
  lagd: 0.5793828601017594s
  torqued: 0.6220222664996982s
Total run_step time: 13.59s
```

This PR:
```
Total run_step times:
  selfdrived: 5.424799048807472s
  card: 0.919613890349865s
  locationd: 0.3173013483174145s
  controlsd: 2.510532932356s
  radard: 0.28098296048119664s
  plannerd: 0.586313575040549s
  dmonitoringd: 0.3731035953387618s
  calibrationd: 0.17976072849705815s
  paramsd: 0.23841818049550056s
  lagd: 0.3673454560339451s
  torqued: 0.4409753093495965s
Total run_step time: 11.64s
```