### PR TITLE
process replay: remove frequency based recv callback

### DIFF
--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -400,7 +400,7 @@ class ModeldCameraSyncRcvCallback:
 
 
 class MessageBasedRcvCallback:
-  def __init__(self, trigger_msg_type: str, first_frame: bool):
+  def __init__(self, trigger_msg_type: str, first_frame: bool = False):
     self.trigger_msg_type = trigger_msg_type
     self.first_frame = first_frame
 
@@ -443,7 +443,7 @@ CONFIGS = [
     subs=["carControl", "controlsState"],
     ignore=["logMonoTime", ],
     init_callback=get_car_params_callback,
-    should_recv_callback=MessageBasedRcvCallback("selfdriveState", False),
+    should_recv_callback=MessageBasedRcvCallback("selfdriveState"),
     tolerance=NUMPY_TOLERANCE,
   ),
   ProcessConfig(
@@ -498,7 +498,7 @@ CONFIGS = [
     ],
     subs=["livePose"],
     ignore=["logMonoTime"],
-    should_recv_callback=MessageBasedRcvCallback("cameraOdometry", False),
+    should_recv_callback=MessageBasedRcvCallback("cameraOdometry"),
     tolerance=NUMPY_TOLERANCE,
     unlocked_pubs=["accelerometer", "gyroscope"],
   ),
@@ -518,7 +518,7 @@ CONFIGS = [
     subs=["liveDelay"],
     ignore=["logMonoTime"],
     init_callback=get_car_params_callback,
-    should_recv_callback=MessageBasedRcvCallback("livePose", False),
+    should_recv_callback=MessageBasedRcvCallback("livePose"),
     tolerance=NUMPY_TOLERANCE,
   ),
   ProcessConfig(
@@ -554,7 +554,7 @@ CONFIGS = [
     pubs=["liveCalibration", "driverCameraState"],
     subs=["driverStateV2"],
     ignore=["logMonoTime", "driverStateV2.modelExecutionTime", "driverStateV2.gpuExecutionTime"],
-    should_recv_callback=MessageBasedRcvCallback("driverCameraState", False),
+    should_recv_callback=MessageBasedRcvCallback("driverCameraState"),
     tolerance=NUMPY_TOLERANCE,
     processing_time=0.020,
     main_pub=vipc_get_endpoint_name("camerad", meta_from_camera_state("driverCameraState").stream),

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -425,22 +425,6 @@ class MessageBasedRcvCallback:
     return msg.which() == self.trigger_msg_type
 
 
-# TODO: this is used interchangeably with MessageBasedRcvCallback when both procs poll? wtf?
-class FrequencyBasedRcvCallback:
-  def __init__(self, trigger_msg_type):
-    self.trigger_msg_type = trigger_msg_type
-
-  def __call__(self, msg, cfg, frame):
-    if msg.which() != self.trigger_msg_type:
-      return False
-
-    resp_sockets = [
-      s for s in cfg.subs
-      if frame % max(1, int(SERVICE_LIST[msg.which()].frequency / SERVICE_LIST[s].frequency)) == 0
-    ]
-    return bool(len(resp_sockets))
-
-
 def selfdrived_config_callback(params, cfg, lr):
   ublox = params.get_bool("UbloxAvailable")
   sub_keys = ({"gpsLocation", } if ublox else {"gpsLocationExternal", })
@@ -494,7 +478,7 @@ CONFIGS = [
     subs=["radarState"],
     ignore=["logMonoTime"],
     init_callback=get_car_params_callback,
-    should_recv_callback=FrequencyBasedRcvCallback("modelV2"),
+    should_recv_callback=MessageBasedRcvCallback("modelV2"),
   ),
   ProcessConfig(
     proc_name="plannerd",
@@ -502,7 +486,7 @@ CONFIGS = [
     subs=["longitudinalPlan", "driverAssistance"],
     ignore=["logMonoTime", "longitudinalPlan.processingDelay", "longitudinalPlan.solverExecutionTime"],
     init_callback=get_car_params_callback,
-    should_recv_callback=FrequencyBasedRcvCallback("modelV2"),
+    should_recv_callback=MessageBasedRcvCallback("modelV2"),
     tolerance=NUMPY_TOLERANCE,
   ),
   ProcessConfig(
@@ -518,7 +502,7 @@ CONFIGS = [
     pubs=["driverStateV2", "liveCalibration", "carState", "modelV2", "selfdriveState"],
     subs=["driverMonitoringState"],
     ignore=["logMonoTime"],
-    should_recv_callback=FrequencyBasedRcvCallback("driverStateV2"),
+    should_recv_callback=MessageBasedRcvCallback("driverStateV2"),
     tolerance=NUMPY_TOLERANCE,
   ),
   ProcessConfig(
@@ -538,7 +522,7 @@ CONFIGS = [
     subs=["liveParameters"],
     ignore=["logMonoTime"],
     init_callback=get_car_params_callback,
-    should_recv_callback=FrequencyBasedRcvCallback("livePose"),
+    should_recv_callback=MessageBasedRcvCallback("livePose"),
     tolerance=NUMPY_TOLERANCE,
     processing_time=0.004,
   ),

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -425,6 +425,7 @@ class MessageBasedRcvCallback:
     return msg.which() == self.trigger_msg_type
 
 
+# TODO: this is used interchangeably with MessageBasedRcvCallback when both procs poll? wtf?
 class FrequencyBasedRcvCallback:
   def __init__(self, trigger_msg_type):
     self.trigger_msg_type = trigger_msg_type


### PR DESCRIPTION
@fredyshox going to let you review first. I'm not really sure why these two are here, they both do similar things. The processes that use one or the other aren't different in that they both poll the services listed as the trigger msg.