### PR TITLE
controlsd: speed up number checking

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import math
-from typing import SupportsFloat
+from numbers import Number
 
 from cereal import car, log
 import cereal.messaging as messaging
@@ -127,7 +127,7 @@ class Controls:
     # Ensure no NaNs/Infs
     for p in ACTUATOR_FIELDS:
       attr = getattr(actuators, p)
-      if not isinstance(attr, SupportsFloat):
+      if not isinstance(attr, Number):
         continue
 
       if not math.isfinite(attr):


### PR DESCRIPTION
Craze. py-spy says this one line went from 2.4% of all process replay samples/time (yes, not controlsd!) to 0.15% now

From https://github.com/commaai/openpilot/pull/35887

Found with:

```bash
./run_process_on_route.py d9b97c1d3b8c39b2/00000160--6ce3dd7c70/1 selfdrived controlsd radard plannerd calibrationd dmonitoringd locationd paramsd lagd ubloxd torqued &
REPLAY_PID=$!
py-spy record -p "$REPLAY_PID" -o proc_replay.svg --duration 10 --subprocesses
```

---

```
from typing import SupportsFloat
from numbers import Number
import time
t = time.monotonic()
for _ in range(1000000):
  isinstance(0.1, SupportsFloat)
print(time.monotonic() - t)

Out:
3.2478658948093653
```

and with Number:

```
0.2292018160223961
```