### PR TITLE
sim: fix "msg not found" errors

### DIFF
--- a/tools/sim/lib/simulated_car.py
+++ b/tools/sim/lib/simulated_car.py
@@ -46,7 +46,7 @@ class SimulatedCar:
 
     msg.append(self.packer.make_can_msg("SCM_BUTTONS", 0, {"CRUISE_BUTTONS": simulator_state.cruise_button}))
 
-    msg.append(self.packer.make_can_msg("GEARBOX", 0, {"GEAR": 4, "GEAR_SHIFTER": 8}))
+    msg.append(self.packer.make_can_msg("GEARBOX_AUTO", 0, {"GEAR_SHIFTER": 4}))
     msg.append(self.packer.make_can_msg("GAS_PEDAL_2", 0, {}))
     msg.append(self.packer.make_can_msg("SEATBELT_STATUS", 0, {"SEATBELT_DRIVER_LATCHED": 1}))
     msg.append(self.packer.make_can_msg("STEER_STATUS", 0, {"STEER_TORQUE_SENSOR": simulator_state.user_torque}))

--- a/tools/sim/lib/simulated_car.py
+++ b/tools/sim/lib/simulated_car.py
@@ -56,7 +56,6 @@ class SimulatedCar:
     msg.append(self.packer.make_can_msg("STEER_MOTOR_TORQUE", 0, {}))
     msg.append(self.packer.make_can_msg("EPB_STATUS", 0, {}))
     msg.append(self.packer.make_can_msg("DOORS_STATUS", 0, {}))
-    msg.append(self.packer.make_can_msg("CRUISE_PARAMS", 0, {}))
     msg.append(self.packer.make_can_msg("CRUISE", 0, {}))
     msg.append(self.packer.make_can_msg("CRUISE_FAULT_STATUS", 0, {}))
     msg.append(self.packer.make_can_msg("SCM_FEEDBACK", 0,


### PR DESCRIPTION
**Description**

Resolves #35892. The metadrive simulator uses a HONDA_CIVIC_2022 as its simulated car.  After the recent Honda cleanup and refactoring, the simulated car needs some corresponding updates.

**Verification**

`pytest tools/sim` no longer spams "msg not found" to console. ~~It doesn't actually pass, because openpilot massively oversteers the first turn and yeets the car off the road, but I'm pretty sure it was doing the same thing before.~~ It doesn't drive properly on my workstation, but it wasn't before. It seems to be driving fine in CI.

**Additional info**

The issue with GEARBOX is a straightforward regression from commaai/opendbc#2457, now fixed.

The chain of events on CRUISE_PARAMS is more interesting:
* I removed CRUISE_PARAMS from the generated 2022 Civic DBC in commaai/opendbc#2523, because it seemed to be a Nidec message that leaked into a Bosch DBC, and the Honda port doesn't use it at all.
* It was only in the sim packer because the simulated car was once a Nidec Civic #32087. The change to Bosch didn't throw errors at the time because that message leaked into the Bosch Civic DBC.
* The last vestige of CRUISE_PARAMS in the Honda port was removed in commaai/opendbc#2140.
* The last actual usage of CRUISE_PARAMS was removed in #22181.

The simulated car still engaged and drove, notwithstanding the aforementioned yeeting. We didn't throw a CAN error because CRUISE_PARAMS was never used on Bosch, and it so happens that HONDA_CIVIC_2022 is the one Honda that's allowed to have a manual transmission, which we auto-detect by absence of supported GEARBOX messages and just assume the car is in Drive.

I think the CAN packer should probably raise an exception or assertion when trying to pack a message or signal that doesn't exist, but that's a PR for another day.