### PR TITLE
scons: support build on single processor

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,7 +17,7 @@ AGNOS = TICI
 
 Decider('MD5-timestamp')
 
-SetOption('num_jobs', int(os.cpu_count()/2))
+SetOption('num_jobs', max(1, int(os.cpu_count()/2)))
 
 AddOption('--kaitai',
           action='store_true',


### PR DESCRIPTION
I'm trying to set up openpilot in a container (default 1 CPU) launched using multipass, Canonical's turnkey VM hypervisor (tools/ PR in progress).

The current code returns num_jobs=0 lol