### PR TITLE
cabana: PandaStream use noOutput safety mode instead silent

### DIFF
--- a/tools/cabana/streams/pandastream.cc
+++ b/tools/cabana/streams/pandastream.cc
@@ -24,7 +24,7 @@ bool PandaStream::connect() {
     return false;
   }
 
-  panda->set_safety_model(cereal::CarParams::SafetyModel::SILENT);
+  panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
   for (int bus = 0; bus < config.bus_config.size(); bus++) {
     panda->set_can_speed_kbps(bus, config.bus_config[bus].can_speed_kbps);
 


### PR DESCRIPTION
Silent safety mode does not ACK anything, so it doesn't work when directly connected to an ECU.