### PR TITLE
Honda: Temporary test exception for driver regen paddle

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -430,7 +430,9 @@ class TestCarModelBase(unittest.TestCase):
         if self.CP.carFingerprint in (HONDA.HONDA_PILOT, HONDA.HONDA_RIDGELINE) and CS.brake > 0.05:
           brake_pressed = False
       checks['brakePressed'] += brake_pressed != self.safety.get_brake_pressed_prev()
-      checks['regenBraking'] += CS.regenBraking != self.safety.get_regen_braking_prev()
+      # TODO: remove this exception before closing commaai/opendbc#1100
+      if not (self.CP.brand == "honda" and self.CP.flags & HondaFlags.BOSCH):
+        checks['regenBraking'] += CS.regenBraking != self.safety.get_regen_braking_prev()
       checks['steeringDisengage'] += CS.steeringDisengage != self.safety.get_steering_disengage_prev()
 
       if self.CP.pcmCruise:


### PR DESCRIPTION
This is an incremental step toward fixing commaai/opendbc#1100.

Required for commaai/opendbc#2624.

The Honda port currently doesn't check driver regen braking state at all. Stock ACC disengages on the regen paddle, which results in an immediate `cruiseDisabled` disengage. OP long is presumably broken as well.

Adding regenBraking support to safety will be complicated because regen state is only available in an optional message. Per my discussion with @adeebshihadeh, for stock ACC / pcmCruise cars, a check in openpilot alone will do as a first step.