### PR TITLE
macOS: fix font-noto-color-emoji

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -50,7 +50,7 @@ brew "zeromq"
 cask "gcc-arm-embedded"
 brew "portaudio"
 brew "gcc@13"
-brew "font-noto-color-emoji"
+cask "font-noto-color-emoji"
 EOS
 
 echo "[ ] finished brew install t=$SECONDS"


### PR DESCRIPTION
Fixes https://github.com/commaai/openpilot/pull/35913 on macOS

Before
```
Installing font-noto-color-emoji
Warning: "font-noto-color-emoji" formula is unreadable: No available formula with the name "font-noto-color-emoji".
Warning: No available formula with the name "font-noto-color-emoji".
Error: No formulae found for font-noto-color-emoji.
==> Searching for similarly named formulae...
Installing font-noto-color-emoji has failed!
"brew bundle" failed! 1 Brewfile dependency failed to install
 ↳ [✗] Dependencies installation failed!
 ```

 After
 ```
 Installing font-noto-color-emoji
"brew bundle" complete! 18 Brewfile dependencies now installed.
[ ] finished brew install t=4
```