### PR TITLE
ui: replace "Hotspot" with link icon

### DIFF
--- a/selfdrive/assets/icons/link.png
+++ b/selfdrive/assets/icons/link.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a69514fe68dd1b4c73f28771640dcba10fc40989d1c7e771cb48bfd830fef206
+size 5713

--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -29,6 +29,7 @@ Sidebar::Sidebar(QWidget *parent) : QFrame(parent), onroad(false), flag_pressed(
   flag_img = loadPixmap("../assets/images/button_flag.png", home_btn.size());
   settings_img = loadPixmap("../assets/images/button_settings.png", settings_btn.size(), Qt::IgnoreAspectRatio);
   mic_img = loadPixmap("../assets/icons/microphone.png", QSize(30, 30));
+  link_img = loadPixmap("../assets/icons/link.png", QSize(60, 60));
 
   connect(this, &Sidebar::valueChanged, [=] { update(); });
 
@@ -150,7 +151,12 @@ void Sidebar::paintEvent(QPaintEvent *event) {
   p.setFont(InterFont(35));
   p.setPen(QColor(0xff, 0xff, 0xff));
   const QRect r = QRect(58, 247, width() - 100, 50);
-  p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter, net_type);
+
+  if (net_type == "Hotspot") {
+    p.drawPixmap(r.x(), r.y() + (r.height() - link_img.height()) / 2, link_img);
+  } else {
+    p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter, net_type);
+  }
 
   // metrics
   drawMetric(p, temp_status.first, temp_status.second, 338);

--- a/selfdrive/ui/qt/sidebar.h
+++ b/selfdrive/ui/qt/sidebar.h
@@ -37,7 +37,7 @@ protected:
   void mouseReleaseEvent(QMouseEvent *event) override;
   void drawMetric(QPainter &p, const QPair<QString, QString> &label, QColor c, int y);
 
-  QPixmap home_img, flag_img, settings_img, mic_img;
+  QPixmap home_img, flag_img, settings_img, mic_img, link_img;
   bool onroad, recording_audio, flag_pressed, settings_pressed, mic_indicator_pressed;
   const QMap<cereal::DeviceState::NetworkType, QString> network_type = {
     {cereal::DeviceState::NetworkType::NONE, tr("--")},


### PR DESCRIPTION
Before
<img width="2160" height="1080" alt="image" src="https://github.com/user-attachments/assets/94a86a85-0a73-42d9-a74f-89f6c963d17c" />

After
<img width="2160" height="1080" alt="image" src="https://github.com/user-attachments/assets/ec7f3f02-729d-43f9-8f00-94a07dd09586" />


Alternate options were abbreviations (Hotsp, Teth), scrolling text, or making the font smaller when the text is longer than available space. This seems to be the simplest option, not sure if it is intuitive enough.

I originally checked all the translations to see if there was anything over 5 characters, I didn't see that there was a ternary operator just for Hotspot that was separate from everything else...