### PR TITLE
LogReader sourcing: check comma API source before CI source

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -298,7 +298,7 @@ class LogReader:
   def __init__(self, identifier: str | list[str], default_mode: ReadMode = ReadMode.RLOG,
                sources: list[Source] = None, sort_by_time=False, only_union_types=False):
     if sources is None:
-      sources = [internal_source, openpilotci_source, comma_api_source, comma_car_segments_source]
+      sources = [internal_source, comma_api_source, openpilotci_source, comma_car_segments_source]
 
     self.default_mode = default_mode
     self.sources = sources


### PR DESCRIPTION
Getting logs from normal API is more common than the few hundred in CI, saves a few seconds with https://github.com/commaai/openpilot/pull/35991