### PR TITLE
Fixed development environment link in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Development is coordinated through [Discord](https://discord.comma.ai) and GitHu
 
 ### Getting Started
 
-* Setup your [development environment](../master/tools/)
+* Setup your [development environment](/tools/)
 * Join our [Discord](https://discord.comma.ai)
 * Docs are at https://docs.comma.ai and https://blog.comma.ai
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Development is coordinated through [Discord](https://discord.comma.ai) and GitHu
 
 ### Getting Started
 
-* Setup your [development environment](../tools/)
+* Setup your [development environment](../master/tools/)
 * Join our [Discord](https://discord.comma.ai)
 * Docs are at https://docs.comma.ai and https://blog.comma.ai
 


### PR DESCRIPTION
**Description**

This is a minor documentation fix. When clicking on the `development environment` link from the contributing section of the repo, the link was failing as it was using a relative path. Fixed it by changing the path to absolute.

The link that is failing:
<img width="948" height="925" alt="Screenshot 2025-08-18 at 1 55 17 AM" src="https://github.com/user-attachments/assets/e0e2110c-d331-421f-90fb-0424c74a2d79" />

**Verification**

Verified by clicking the link after the changes.

This is my first PR to openpilot 🎉 excited to contribute!