### PR TITLE
File sourcing: simplify return type

### DIFF
--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -222,19 +222,14 @@ def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) 
     for source in sources:
       try:
         files = source(sr, needed_seg_idxs, fn)
-        print('got files from source', source.__name__, files)
 
         # Build a dict of valid files
         valid_files |= files
-        print('valid_files', valid_files)
 
         # Don't check for segment files that have already been found
-        needed_seg_idxs = [idx for idx in needed_seg_idxs if valid_files.get(idx) is None]
-        print('needed_seg_idxs', needed_seg_idxs)
+        needed_seg_idxs = [idx for idx in needed_seg_idxs if idx not in valid_files]
 
         # We've found all files, return them
-        # if all(f is not None for f in valid_files.values()):
-        print()
         if len(needed_seg_idxs) == 0:
           return cast(list[str], list(valid_files.values()))
 

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -16,6 +16,8 @@ from collections.abc import Callable, Iterable, Iterator
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
+from fontTools.cffLib.width import missingdict
+
 from cereal import log as capnp_log
 from openpilot.common.swaglog import cloudlog
 from openpilot.tools.lib.comma_car_segments import get_url as get_comma_segments_url
@@ -238,6 +240,7 @@ def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) 
 
     if fn == try_fns[0]:
       missing_logs = list(valid_files.values()).count(None)
+      # missing_logs = len(needed_seg_idxs)
       if mode == ReadMode.AUTO:
         cloudlog.warning(f"{missing_logs}/{len(valid_files)} rlogs were not found, falling back to qlogs for those segments...")
       elif mode == ReadMode.AUTO_INTERACTIVE:

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -16,8 +16,6 @@ from collections.abc import Callable, Iterable, Iterator
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
-from fontTools.cffLib.width import missingdict
-
 from cereal import log as capnp_log
 from openpilot.common.swaglog import cloudlog
 from openpilot.tools.lib.comma_car_segments import get_url as get_comma_segments_url
@@ -240,7 +238,6 @@ def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) 
 
     if fn == try_fns[0]:
       missing_logs = list(valid_files.values()).count(None)
-      # missing_logs = len(needed_seg_idxs)
       if mode == ReadMode.AUTO:
         cloudlog.warning(f"{missing_logs}/{len(valid_files)} rlogs were not found, falling back to qlogs for those segments...")
       elif mode == ReadMode.AUTO_INTERACTIVE:

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -190,7 +190,7 @@ def eval_source(files: dict[int, list[str] | str]) -> dict[int, str]:
     if isinstance(urls, str):
       urls = [urls]
 
-    # Add first valid file URL or None
+    # Add first valid file URL
     for url in urls:
       if file_exists(url):
         valid_files[seg_idx] = url

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -227,9 +227,6 @@ def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) 
         # Build a dict of valid files
         valid_files |= files
         print('valid_files', valid_files)
-        # for idx, f in files.items():
-        #   if valid_files.get(idx) is None:
-        #     valid_files[idx] = f
 
         # Don't check for segment files that have already been found
         needed_seg_idxs = [idx for idx in needed_seg_idxs if valid_files.get(idx) is None]

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -237,15 +237,15 @@ def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) 
         exceptions[source.__name__] = e
 
     if fn == try_fns[0]:
-      missing_logs = list(valid_files.values()).count(None)
+      missing_logs = len(needed_seg_idxs)
       if mode == ReadMode.AUTO:
-        cloudlog.warning(f"{missing_logs}/{len(valid_files)} rlogs were not found, falling back to qlogs for those segments...")
+        cloudlog.warning(f"{missing_logs}/{len(sr.seg_idxs)} rlogs were not found, falling back to qlogs for those segments...")
       elif mode == ReadMode.AUTO_INTERACTIVE:
-        if input(f"{missing_logs}/{len(valid_files)} rlogs were not found, would you like to fallback to qlogs for those segments? (y/N) ").lower() != "y":
+        if input(f"{missing_logs}/{len(sr.seg_idxs)} rlogs were not found, would you like to fallback to qlogs for those segments? (y/N) ").lower() != "y":
           break
 
-  missing_logs = list(valid_files.values()).count(None)
-  raise LogsUnavailable(f"{missing_logs}/{len(valid_files)} logs were not found, please ensure all logs " +
+  missing_logs = len(needed_seg_idxs)
+  raise LogsUnavailable(f"{missing_logs}/{len(sr.seg_idxs)} logs were not found, please ensure all logs " +
                         "are uploaded. You can fall back to qlogs with '/a' selector at the end of the route name.\n\n" +
                         "Exceptions for sources:\n  - " + "\n  - ".join([f"{k}: {repr(v)}" for k, v in exceptions.items()]))
 


### PR DESCRIPTION
This `obj | None` pattern was sprinkled around LogReader and Route a few years ago when we added automatic sourcing to no good reason I can think of. Just adds misdirection. Now a `LogPath` is a real log path