### PR TITLE
raylib: fix experimental mode path gradient

### DIFF
--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -233,12 +233,6 @@ class ModelRenderer(Widget):
     self._exp_gradient['colors'] = segment_colors
     self._exp_gradient['stops'] = gradient_stops
 
-    # add 0 and 1 stops of duplicate colors
-    # ensure gradient starts at the complete bottom to prevent undefined colors in shader
-    if len(segment_colors):
-      self._exp_gradient['colors'].insert(0, segment_colors[0])
-      self._exp_gradient['stops'].insert(0, 0.0)
-
     for idx, (c, stop) in enumerate(zip(segment_colors, gradient_stops)):
       # print(idx, c, stop)
       if idx >= len(segment_colors) - 1:

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -112,7 +112,7 @@ class ModelRenderer(Widget):
 
     # Update model data when needed
     model_updated = sm.updated['modelV2']
-    if model_updated or sm.updated['radarState'] or self._transform_dirty or True:
+    if model_updated or sm.updated['radarState'] or self._transform_dirty:
       if model_updated:
         self._update_raw_points(model)
 

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -238,9 +238,10 @@ class ModelRenderer(Widget):
     self._exp_gradient['stops'] = gradient_stops
 
     # add 0 and 1 stops of duplicate colors
+    # ensure gradient starts at the complete bottom to prevent undefined colors in shader
     if len(segment_colors):
-      self._exp_gradient['colors'] = [segment_colors[0]] + self._exp_gradient['colors'] + [segment_colors[-1]]
-      self._exp_gradient['stops'] = [0.0] + self._exp_gradient['stops'] + [1.0]
+      self._exp_gradient['colors'].insert(0, segment_colors[0])
+      self._exp_gradient['stops'].insert(0, 0.0)
 
     for idx, (c, stop) in enumerate(zip(segment_colors, gradient_stops)):
       print(idx, c, stop)
@@ -250,7 +251,7 @@ class ModelRenderer(Widget):
       y = height * (1 - stop)
       # print('stop', stop, y)
       y_next = height * (1 - gradient_stops[idx + 1])
-      rl.draw_circle(x, y, 5, c)
+      rl.draw_circle(int(x), int(y), 5, c)
 
       print('y', y, 'y_next', y_next, 'height', height)
 

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -203,17 +203,15 @@ class ModelRenderer(Widget):
 
     i = 0
     while i < max_len:
-      print()
       # Some points are out of frame
-      track_idx = i  # max_len - i - 1  # flip idx to start from bottom right
-      track_y = self._path.projected_points[track_idx][1]
+      track_y = self._path.projected_points[i][1]
       if track_y < 0 or track_y > height:
         i += 1
         continue
 
       # Calculate color based on acceleration
+      # 0 is bottom, 1 is top
       lin_grad_point = (height - track_y) / height
-      # print('track_y', track_y, height, 'lin_grad_point', lin_grad_point)
 
       # speed up: 120, slow down: 0
       path_hue = max(min(60 + self._acceleration_x[i] * 35, 120), 0)
@@ -225,7 +223,6 @@ class ModelRenderer(Widget):
 
       # Use HSL to RGB conversion
       color = self._hsla_to_color(path_hue / 360.0, saturation, lightness, alpha)
-      # print('got color', (color.r, color.g, color.b, color.a), 'acceleration', self._acceleration_x[i])
 
       gradient_stops.append(lin_grad_point)
       segment_colors.append(color)
@@ -242,36 +239,6 @@ class ModelRenderer(Widget):
     if len(segment_colors):
       self._exp_gradient['colors'].insert(0, segment_colors[0])
       self._exp_gradient['stops'].insert(0, 0.0)
-
-    for idx, (c, stop) in enumerate(zip(segment_colors, gradient_stops)):
-      print(idx, c, stop)
-      if idx >= len(segment_colors) - 1:
-        continue
-      x = 50
-      y = height * (1 - stop)
-      # print('stop', stop, y)
-      y_next = height * (1 - gradient_stops[idx + 1])
-      rl.draw_circle(int(x), int(y), 5, c)
-
-      print('y', y, 'y_next', y_next, 'height', height)
-
-      rl.draw_rectangle_gradient_v(x * 2, y_next, 25, y - y_next,
-                                   segment_colors[idx + 1], c)
-
-    if len(self._path.projected_points):
-      min_track_y = min(self._path.projected_points[:, 1])
-    else:
-      min_track_y = 0.0
-    print(min_track_y, height)
-    print(min_track_y / height, 1 - min_track_y / height)
-
-    # 0 is bottom, 1 is top
-    # self._exp_gradient['colors'] = [rl.Color(255, 255, 255, 255),
-    #                                 rl.Color(0, 0, 0, 255)]
-    # self._exp_gradient['stops'] = [0.0, 1 - min_track_y / height]
-
-    print('\n')
-
 
   def _update_lead_vehicle(self, d_rel, v_rel, point, rect):
     speed_buff, lead_buff = 10.0, 40.0

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -4,7 +4,6 @@ import pyray as rl
 from cereal import messaging, car
 from dataclasses import dataclass, field
 from openpilot.common.params import Params
-from openpilot.system.ui.lib.application import gui_app
 from openpilot.selfdrive.locationd.calibrationd import HEIGHT_INIT
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import DEFAULT_FPS
@@ -233,40 +232,6 @@ class ModelRenderer(Widget):
     self._exp_gradient['colors'] = segment_colors
     self._exp_gradient['stops'] = gradient_stops
 
-    for idx, (c, stop) in enumerate(zip(segment_colors, gradient_stops)):
-      # print(idx, c, stop)
-      if idx >= len(segment_colors) - 1:
-        continue
-      x = 50
-      y = gui_app.height * (1 - stop)
-      # print('stop', stop, y)
-      y_next = gui_app.height * (1 - gradient_stops[idx + 1])
-      rl.draw_circle(int(x), int(y), 5, c)
-
-      # print('y', y, 'y_next', y_next, 'self._rect.height', self._rect.height)
-
-      rl.draw_rectangle_gradient_v(x * 2, y_next, 25, y - y_next,
-                                   segment_colors[idx + 1], c)
-
-    if len(self._path.projected_points):
-      min_track_y = min(self._path.projected_points[:, 1])
-    else:
-      min_track_y = 0.0
-    # print(min_track_y, self._rect.height)
-    # print(min_track_y / self._rect.height, 1 - min_track_y / self._rect.height)
-
-    if len(self._path.projected_points):
-      ys = self._path.projected_points[:, 1]
-      print("rect.y..y+h", self._rect.y, self._rect.y + self._rect.height,
-            "min/max projected y", float(ys.min()), float(ys.max()))
-
-    # 0 is bottom, 1 is top
-    # self._exp_gradient['colors'] = [rl.Color(255, 255, 255, 255),
-    #                                 rl.Color(0, 0, 0, 255)]
-    # self._exp_gradient['stops'] = [0.0, 1 - min_track_y / self._rect.height]
-
-    # print('\n')
-
   def _update_lead_vehicle(self, d_rel, v_rel, point, rect):
     speed_buff, lead_buff = 10.0, 40.0
 
@@ -317,10 +282,7 @@ class ModelRenderer(Widget):
     if self._experimental_mode:
       # Draw with acceleration coloring
       if len(self._exp_gradient['colors']) > 1:
-        # rect = rl.Rectangle(self._rect.x, self._rect.y + self._rect.height // 2, self._rect.width, self._rect.height)
-        rect = self._rect
-        # print(rect.x, rect.y, rect.width, rect.height)
-        draw_polygon(rect, self._path.projected_points, gradient=self._exp_gradient)
+        draw_polygon(self._rect, self._path.projected_points, gradient=self._exp_gradient)
       else:
         draw_polygon(self._rect, self._path.projected_points, rl.Color(255, 255, 255, 30))
     else:

--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -207,8 +207,7 @@ class ModelRenderer(Widget):
         i += 1
         continue
 
-      # Calculate color based on acceleration
-      # 0 is bottom, 1 is top
+      # Calculate color based on acceleration (0 is bottom, 1 is top)
       lin_grad_point = 1 - (track_y - self._rect.y) / self._rect.height
 
       # speed up: 120, slow down: 0

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -39,6 +39,10 @@ vec4 getGradientColor(vec2 pos) {
   float t = clamp(dot(pos - gradientStart, normalizedDir) / gradientLength, 0.0, 1.0);
 
   if (gradientColorCount <= 1) return gradientColors[0];
+
+  // handle t before first / after last stop
+  if (t <= gradientStops[0]) return gradientColors[0];
+  if (t >= gradientStops[gradientColorCount-1]) return gradientColors[gradientColorCount-1];
   for (int i = 0; i < gradientColorCount - 1; i++) {
     if (t >= gradientStops[i] && t <= gradientStops[i+1]) {
       float segmentT = (t - gradientStops[i]) / (gradientStops[i+1] - gradientStops[i]);


### PR DESCRIPTION
Wasn't working at all before

Left: QT, right: raylib before this PR

<img width="4187" height="1075" alt="image" src="https://github.com/user-attachments/assets/aff19823-1dc9-4404-ae76-996a92a4187d" />


Now matches QT and the debug points I visualized on the left: 

<img width="4317" height="1076" alt="image" src="https://github.com/user-attachments/assets/63503a0b-c9d4-40dc-bee9-dbb495180e21" />