### PR TITLE
panda #2239: Remove panda submodule and switch to pandacan >=0.0.10 via pip

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "panda"]
-  path = panda
-  url = ../../commaai/panda.git
 [submodule "opendbc"]
   path = opendbc_repo
   url = ../../commaai/opendbc.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   # panda
   "libusb1",
   "spidev; platform_system == 'Linux'",
+  "pandacan >= 0.0.10",
 
   # modeld
   "onnx >= 1.14.0",

--- a/selfdrive/pandad/panda.h
+++ b/selfdrive/pandad/panda.h
@@ -11,8 +11,8 @@
 
 #include "cereal/gen/cpp/car.capnp.h"
 #include "cereal/gen/cpp/log.capnp.h"
-#include "panda/board/health.h"
-#include "panda/board/can.h"
+#include "health.h"
+#include "can.h"
 #include "selfdrive/pandad/panda_comms.h"
 
 #define USB_TX_SOFT_LIMIT   (0x100U)

--- a/tools/cabana/panda.h
+++ b/tools/cabana/panda.h
@@ -15,8 +15,8 @@
 
 #include "cereal/gen/cpp/car.capnp.h"
 #include "cereal/gen/cpp/log.capnp.h"
-#include "panda/board/health.h"
-#include "panda/board/can.h"
+#include "health.h"
+#include "can.h"
 
 #define USB_TX_SOFT_LIMIT   (0x100U)
 #define USBPACKET_MAX_SIZE  (0x40)


### PR DESCRIPTION
# Requirements
Needs pandacan 0.0.10 on pypi
# 
**Description**

Setup proper pip package #2239 for panda / pandacan.
All the needed work for the panda repo was already done.

https://github.com/commaai/panda/issues/2239 


**Verification**
Installed pandacan from git:
`pip install git+https://github.com/commaai/panda.git`

Built openpilot OK.

let me know if there is any other way I can test it


<img width="786" height="26" alt="image" src="https://github.com/user-attachments/assets/f3e05e9b-91d1-4713-9227-94b4d7944249" />

