### PR TITLE
cereal: fix frequency precision by changing from int to float

### DIFF
--- a/cereal/messaging/socketmaster.cc
+++ b/cereal/messaging/socketmaster.cc
@@ -33,7 +33,7 @@ MessageContext message_context;
 struct SubMaster::SubMessage {
   std::string name;
   SubSocket *socket = nullptr;
-  int freq = 0;
+  float freq = 0.0f;
   bool updated = false, alive = false, valid = false, ignore_alive;
   uint64_t rcv_time = 0, rcv_frame = 0;
   void *allocated_msg_reader = nullptr;

--- a/cereal/services.py
+++ b/cereal/services.py
@@ -109,12 +109,12 @@ def build_header():
   h += "#include <map>\n"
   h += "#include <string>\n"
 
-  h += "struct service { std::string name; bool should_log; int frequency; int decimation; };\n"
+  h += "struct service { std::string name; bool should_log; float frequency; int decimation; };\n"
   h += "static std::map<std::string, service> services = {\n"
   for k, v in SERVICE_LIST.items():
     should_log = "true" if v.should_log else "false"
     decimation = -1 if v.decimation is None else v.decimation
-    h += '  { "%s", {"%s", %s, %d, %d}},\n' % \
+    h += '  { "%s", {"%s", %s, %f, %d}},\n' % \
          (k, k, should_log, v.frequency, decimation)
   h += "};\n"
 


### PR DESCRIPTION




## Description
- frequencies are stored as float in cereal/services.py
- frequencies are used as ints

## Changes

- services.py build_header - Changed int frequency to float frequency in C++ struct definition
- Format string - Updated from %d to %f for frequency values in generated code
- socketmaster.cc - Changed int freq = 0 to float freq = 0.0f in SubMessage struct



### **🚨 Always-Alive Services Mask Real Problems**
```cpp
// Before fix: int freq = 0 (always true)
// After fix: float freq = 0.02 (proper timeout logic)
m->alive = (m->freq <= (1e-5) || ((current_time - m->rcv_time) * (1e-9)) < (10.0 / m->freq));
```

With `freq = 0`, the condition `(m->freq <= (1e-5))` was **always true**, making services appear alive even when they stopped sending data.

### **🔧 Specific Service Impacts:**

**1. `carParams` (0.02 Hz = every 50 seconds)**
**2. `clocks` (0.1 Hz = every 10 seconds)**  
**3. `procLog` (0.5 Hz = twice per second)**
**4. `thumbnail` (1/60 Hz ≈ every 60 seconds)**

### **🎯 System Manager Consequences:**

The system manager relies on service health monitoring to:
- Restart failed services
- Alert users to system issues  
- Ensure data integrity
- Maintain safe operation



**Verification**
82/82 tests passed ✅
test_generated_header passed ✅

<img width="1068" height="45" alt="image" src="https://github.com/user-attachments/assets/ccb8059e-97d2-492d-bac4-f13f9f254058" />









