### PR TITLE
feat(esim): athena bindings

### DIFF
--- a/common/retry.py
+++ b/common/retry.py
@@ -1,21 +1,22 @@
 import time
 import functools
 
-from openpilot.common.swaglog import cloudlog
-
 
 def retry(attempts=3, delay=1.0, ignore_failure=False):
   def decorator(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+
       for _ in range(attempts):
         try:
           return func(*args, **kwargs)
         except Exception:
+          from openpilot.common.swaglog import cloudlog
           cloudlog.exception(f"{func.__name__} failed, trying again")
           time.sleep(delay)
 
       if ignore_failure:
+        from openpilot.common.swaglog import cloudlog
         cloudlog.error(f"{func.__name__} failed after retry")
       else:
         raise Exception(f"{func.__name__} failed after retry")

--- a/common/retry.py
+++ b/common/retry.py
@@ -6,7 +6,6 @@ def retry(attempts=3, delay=1.0, ignore_failure=False):
   def decorator(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-
       for _ in range(attempts):
         try:
           return func(*args, **kwargs)

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -561,6 +561,22 @@ def getNetworks():
 
 
 @dispatcher.add_method
+def getEsimProfiles():
+  return [asdict(p) for p in HARDWARE.get_sim_lpa().list_profiles()]
+
+
+@dispatcher.add_method
+def downloadEsimProfile(lpa_activation_code: str, profile_name: str):
+  HARDWARE.get_sim_lpa().download_profile(lpa_activation_code, profile_name)
+
+
+@dispatcher.add_method
+def setEsimProfile(iccid: str):
+  HARDWARE.get_sim_lpa().switch_profile(iccid)
+  HARDWARE.reboot_modem()
+
+
+@dispatcher.add_method
 def takeSnapshot() -> str | dict[str, str] | None:
   from openpilot.system.camerad.snapshot import jpeg_write, snapshot
   ret = snapshot()

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -561,7 +561,7 @@ def getNetworks():
 
 
 @dispatcher.add_method
-def getEsim():
+def describeSim():
   lpa = HARDWARE.get_sim_lpa()
   profiles = [asdict(p) for p in lpa.list_profiles()]
   is_bootstrapped = lpa.is_bootstrapped()
@@ -577,7 +577,7 @@ def bootstrapEsim():
 
 
 @dispatcher.add_method
-def downloadEsimProfile(lpa_activation_code: str, profile_name: str):
+def downloadSimProfile(lpa_activation_code: str, profile_name: str):
   lpa = HARDWARE.get_sim_lpa()
   lpa.validate_lpa_activation_code(lpa_activation_code)
   lpa.validate_nickname(profile_name)
@@ -585,7 +585,7 @@ def downloadEsimProfile(lpa_activation_code: str, profile_name: str):
 
 
 @dispatcher.add_method
-def setEsimProfile(iccid: str):
+def setSimProfile(iccid: str):
   lpa = HARDWARE.get_sim_lpa()
   lpa.validate_iccid(iccid)
   lpa.validate_profile_exists(iccid)

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -561,6 +561,12 @@ def getNetworks():
 
 
 @dispatcher.add_method
+def bootstrapSim(acknowledged: bool):
+  assert acknowledged, 'you must acknowledge the operation to proceed'
+  HARDWARE.get_sim_lpa().bootstrap()
+
+
+@dispatcher.add_method
 def describeSim():
   lpa = HARDWARE.get_sim_lpa()
   profiles = [asdict(p) for p in lpa.list_profiles()]
@@ -569,12 +575,6 @@ def describeSim():
     "profiles": profiles,
     "is_bootstrapped": is_bootstrapped
   }
-
-
-@dispatcher.add_method
-def bootstrapSim(acknowledged: bool):
-  assert acknowledged, 'you must acknowledge the operation to proceed'
-  HARDWARE.get_sim_lpa().bootstrap()
 
 
 @dispatcher.add_method

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -573,7 +573,7 @@ def describeSim():
 
 @dispatcher.add_method
 def bootstrapSim(acknowledged: bool):
-  assert acknowledged, 'you must acknowledge the risks of this operation'
+  assert acknowledged, 'you must acknowledge the operation to proceed'
   HARDWARE.get_sim_lpa().bootstrap()
 
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -572,7 +572,8 @@ def describeSim():
 
 
 @dispatcher.add_method
-def bootstrapEsim():
+def bootstrapSim(acknowledged: bool):
+  assert acknowledged, 'you must acknowledge the risks of this operation'
   HARDWARE.get_sim_lpa().bootstrap()
 
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -572,6 +572,11 @@ def getEsim():
 
 
 @dispatcher.add_method
+def bootstrapEsim():
+  HARDWARE.get_sim_lpa().bootstrap()
+
+
+@dispatcher.add_method
 def downloadEsimProfile(lpa_activation_code: str, profile_name: str):
   lpa = HARDWARE.get_sim_lpa()
   lpa.validate_lpa_activation_code(lpa_activation_code)

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -567,12 +567,18 @@ def getEsimProfiles():
 
 @dispatcher.add_method
 def downloadEsimProfile(lpa_activation_code: str, profile_name: str):
-  HARDWARE.get_sim_lpa().download_profile(lpa_activation_code, profile_name)
+  lpa = HARDWARE.get_sim_lpa()
+  lpa.validate_lpa_activation_code(lpa_activation_code)
+  lpa.validate_nickname(profile_name)
+  lpa.download_profile(lpa_activation_code, profile_name)
 
 
 @dispatcher.add_method
 def setEsimProfile(iccid: str):
-  HARDWARE.get_sim_lpa().switch_profile(iccid)
+  lpa = HARDWARE.get_sim_lpa()
+  lpa.validate_iccid(iccid)
+  lpa.validate_profile_exists(iccid)
+  lpa.switch_profile(iccid)
   HARDWARE.reboot_modem()
 
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -561,8 +561,14 @@ def getNetworks():
 
 
 @dispatcher.add_method
-def getEsimProfiles():
-  return [asdict(p) for p in HARDWARE.get_sim_lpa().list_profiles()]
+def getEsim():
+  lpa = HARDWARE.get_sim_lpa()
+  profiles = [asdict(p) for p in lpa.list_profiles()]
+  is_bootstrapped = lpa.is_bootstrapped()
+  return {
+    "profiles": profiles,
+    "is_bootstrapped": is_bootstrapped
+  }
 
 
 @dispatcher.add_method

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -10,9 +10,6 @@ NetworkType = log.DeviceState.NetworkType
 class LPAError(RuntimeError):
   pass
 
-class LPAProfileNotFoundError(LPAError):
-  pass
-
 @dataclass
 class Profile:
   iccid: str
@@ -97,24 +94,19 @@ class LPABase(ABC):
   def is_comma_profile(self, iccid: str) -> bool:
     return any(iccid.startswith(prefix) for prefix in ('8985235',))
 
-  def _validate_iccid(self, iccid: str) -> None:
+  def validate_iccid(self, iccid: str) -> None:
     # https://en.wikipedia.org/wiki/E.118#ICCID
     assert re.match(r'^89\d{17,18}$', iccid), 'invalid ICCID format. expected format: 8988303000000614227'
 
-  def _validate_lpa_activation_code(self, lpa_activation_code: str) -> None:
+  def validate_lpa_activation_code(self, lpa_activation_code: str) -> None:
     assert re.match(r'^LPA:1\$.+\$.+$', lpa_activation_code), 'invalid LPA activation code format. expected format: LPA:1$domain$code'
 
-  def _validate_nickname(self, nickname: str) -> None:
+  def validate_nickname(self, nickname: str) -> None:
     assert len(nickname) >= 1 and len(nickname) <= 16, 'nickname must be between 1 and 16 characters'
     assert re.match(r'^[a-zA-Z0-9-_ ]+$', nickname), 'nickname must contain only alphanumeric characters, hyphens, underscores, and spaces'
 
-  def _validate_profile_exists(self, iccid: str) -> None:
-    if not any(p.iccid == iccid for p in self.list_profiles()):
-      raise LPAProfileNotFoundError(f'profile {iccid} does not exist')
-
-  def _validate_successful(self, msgs: list[dict]) -> None:
-    assert len(msgs) > 0, 'expected at least one message'
-    assert msgs[-1]['payload']['message'] == 'success', 'expected success notification'
+  def validate_profile_exists(self, iccid: str) -> None:
+    assert any(p.iccid == iccid for p in self.list_profiles()), f'profile {iccid} does not exist'
 
 class HardwareBase(ABC):
   @staticmethod

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -98,6 +98,7 @@ class LPABase(ABC):
     return any(iccid.startswith(prefix) for prefix in ('8985235',))
 
   def _validate_iccid(self, iccid: str) -> None:
+    # https://en.wikipedia.org/wiki/E.118#ICCID
     assert re.match(r'^89\d{17,18}$', iccid), 'invalid ICCID format. expected format: 8988303000000614227'
 
   def _validate_lpa_activation_code(self, lpa_activation_code: str) -> None:

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -65,6 +65,9 @@ class ThermalConfig:
 class LPABase(ABC):
   @abstractmethod
   def bootstrap(self) -> None:
+
+  @abstractmethod
+  def is_bootstrapped(self) -> bool:
     pass
 
   @abstractmethod

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -16,6 +16,7 @@ class Profile:
   nickname: str
   enabled: bool
   provider: str
+  is_comma_profile: bool
 
 @dataclass
 class ThermalZone:

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -65,6 +65,7 @@ class ThermalConfig:
 class LPABase(ABC):
   @abstractmethod
   def bootstrap(self) -> None:
+    pass
 
   @abstractmethod
   def is_bootstrapped(self) -> bool:

--- a/system/hardware/tests/test_lpa_validation.py
+++ b/system/hardware/tests/test_lpa_validation.py
@@ -1,0 +1,80 @@
+import pytest
+
+from openpilot.system.hardware.base import LPABase, LPAProfileNotFoundError, Profile
+
+
+class TestLPABase(LPABase):
+
+  def list_profiles(self) -> list[Profile]:
+    return []
+
+  def get_active_profile(self) -> Profile | None:
+    return None
+
+  def delete_profile(self, iccid: str) -> None:
+    pass
+
+  def download_profile(self, qr: str, nickname: str | None = None) -> None:
+    pass
+
+  def nickname_profile(self, iccid: str, nickname: str) -> None:
+    pass
+
+  def switch_profile(self, iccid: str) -> None:
+    pass
+
+
+class TestLPAValidation:
+
+  def setup_method(self):
+    self.lpa = TestLPABase()
+
+  def test_validate_iccid(self):
+    self.lpa._validate_iccid('8988303000000614227')
+
+    with pytest.raises(AssertionError, match='invalid ICCID format'):
+      self.lpa._validate_iccid('')
+
+    with pytest.raises(AssertionError, match='invalid ICCID format'):
+      self.lpa._validate_iccid('1234567890123456789') # Doesn't start with 89
+
+  def test_validate_lpa_activation_code(self):
+    self.lpa._validate_lpa_activation_code('LPA:1$rsp.truphone.com$QRF-BETTERROAMING-PMRDGIR2EARDEIT5')
+
+    with pytest.raises(AssertionError, match='invalid LPA activation code format'):
+      self.lpa._validate_lpa_activation_code('')
+
+    with pytest.raises(AssertionError, match='invalid LPA activation code format'):
+      self.lpa._validate_lpa_activation_code('LPA:1$domain.com') # Missing third part
+
+  def test_validate_nickname(self):
+    self.lpa._validate_nickname('test_profile')
+
+    with pytest.raises(AssertionError, match='nickname must be between 1 and 16 characters'):
+      self.lpa._validate_nickname('')
+
+    with pytest.raises(AssertionError, match='nickname must contain only alphanumeric characters'):
+      self.lpa._validate_nickname('test.profile') # Contains invalid character
+
+  def test_validate_successful(self):
+    self.lpa._validate_successful([{'payload': {'message': 'success'}}])
+
+    with pytest.raises(AssertionError, match='expected at least one message'):
+      self.lpa._validate_successful([])
+
+    with pytest.raises(AssertionError, match='expected success notification'):
+      self.lpa._validate_successful([{'payload': {'message': 'error'}}])
+
+  def test_validate_profile_exists(self, mocker):
+    existing_profiles = [Profile(iccid='8988303000000614227', nickname='test1', enabled=True, provider='Test Provider')]
+
+    mocker.patch.object(self.lpa, 'list_profiles', return_value=existing_profiles)
+    self.lpa._validate_profile_exists('8988303000000614227')
+
+    mocker.patch.object(self.lpa, 'list_profiles', return_value=[])
+    with pytest.raises(LPAProfileNotFoundError, match='profile 8988303000000614227 does not exist'):
+      self.lpa._validate_profile_exists('8988303000000614227')
+
+    mocker.patch.object(self.lpa, 'list_profiles', return_value=existing_profiles)
+    with pytest.raises(LPAProfileNotFoundError, match='profile 8988303000000614229 does not exist'):
+      self.lpa._validate_profile_exists('8988303000000614229')

--- a/system/hardware/tests/test_lpa_validation.py
+++ b/system/hardware/tests/test_lpa_validation.py
@@ -1,9 +1,12 @@
 import pytest
 
-from openpilot.system.hardware.base import LPABase, LPAProfileNotFoundError, Profile
+from openpilot.system.hardware.base import LPABase, Profile
 
 
-class TestLPABase(LPABase):
+class MockLPA(LPABase):
+
+  def bootstrap(self) -> None:
+    pass
 
   def list_profiles(self) -> list[Profile]:
     return []
@@ -27,54 +30,45 @@ class TestLPABase(LPABase):
 class TestLPAValidation:
 
   def setup_method(self):
-    self.lpa = TestLPABase()
+    self.lpa = MockLPA()
 
   def test_validate_iccid(self):
-    self.lpa._validate_iccid('8988303000000614227')
+    self.lpa.validate_iccid('8988303000000614227')
 
     with pytest.raises(AssertionError, match='invalid ICCID format'):
-      self.lpa._validate_iccid('')
+      self.lpa.validate_iccid('')
 
     with pytest.raises(AssertionError, match='invalid ICCID format'):
-      self.lpa._validate_iccid('1234567890123456789') # Doesn't start with 89
+      self.lpa.validate_iccid('1234567890123456789') # Doesn't start with 89
 
   def test_validate_lpa_activation_code(self):
-    self.lpa._validate_lpa_activation_code('LPA:1$rsp.truphone.com$QRF-BETTERROAMING-PMRDGIR2EARDEIT5')
+    self.lpa.validate_lpa_activation_code('LPA:1$rsp.truphone.com$QRF-BETTERROAMING-PMRDGIR2EARDEIT5')
 
     with pytest.raises(AssertionError, match='invalid LPA activation code format'):
-      self.lpa._validate_lpa_activation_code('')
+      self.lpa.validate_lpa_activation_code('')
 
     with pytest.raises(AssertionError, match='invalid LPA activation code format'):
-      self.lpa._validate_lpa_activation_code('LPA:1$domain.com') # Missing third part
+      self.lpa.validate_lpa_activation_code('LPA:1$domain.com') # Missing third part
 
   def test_validate_nickname(self):
-    self.lpa._validate_nickname('test_profile')
+    self.lpa.validate_nickname('test_profile')
 
     with pytest.raises(AssertionError, match='nickname must be between 1 and 16 characters'):
-      self.lpa._validate_nickname('')
+      self.lpa.validate_nickname('')
 
     with pytest.raises(AssertionError, match='nickname must contain only alphanumeric characters'):
-      self.lpa._validate_nickname('test.profile') # Contains invalid character
-
-  def test_validate_successful(self):
-    self.lpa._validate_successful([{'payload': {'message': 'success'}}])
-
-    with pytest.raises(AssertionError, match='expected at least one message'):
-      self.lpa._validate_successful([])
-
-    with pytest.raises(AssertionError, match='expected success notification'):
-      self.lpa._validate_successful([{'payload': {'message': 'error'}}])
+      self.lpa.validate_nickname('test.profile') # Contains invalid character
 
   def test_validate_profile_exists(self, mocker):
     existing_profiles = [Profile(iccid='8988303000000614227', nickname='test1', enabled=True, provider='Test Provider')]
 
     mocker.patch.object(self.lpa, 'list_profiles', return_value=existing_profiles)
-    self.lpa._validate_profile_exists('8988303000000614227')
+    self.lpa.validate_profile_exists('8988303000000614227')
 
     mocker.patch.object(self.lpa, 'list_profiles', return_value=[])
-    with pytest.raises(LPAProfileNotFoundError, match='profile 8988303000000614227 does not exist'):
-      self.lpa._validate_profile_exists('8988303000000614227')
+    with pytest.raises(AssertionError, match='profile 8988303000000614227 does not exist'):
+      self.lpa.validate_profile_exists('8988303000000614227')
 
     mocker.patch.object(self.lpa, 'list_profiles', return_value=existing_profiles)
-    with pytest.raises(LPAProfileNotFoundError, match='profile 8988303000000614229 does not exist'):
-      self.lpa._validate_profile_exists('8988303000000614229')
+    with pytest.raises(AssertionError, match='profile 8988303000000614229 does not exist'):
+      self.lpa.validate_profile_exists('8988303000000614229')

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -134,3 +134,7 @@ class TiciLPA(LPABase):
     Process notifications stored on the eUICC, typically to activate/deactivate the profile with the carrier.
     """
     self._validate_successful(self._invoke('notification', 'process', '-a', '-r'))
+
+  def _validate_successful(self, msgs: list[dict]) -> None:
+    assert len(msgs) > 0, 'expected at least one message'
+    assert msgs[-1]['payload']['message'] == 'success', 'expected success notification'

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 from typing import Literal
 
-from openpilot.system.hardware.base import LPABase, LPAError, LPAProfileNotFoundError, Profile
+from openpilot.system.hardware.base import LPABase, LPAError, Profile
 
 class TiciLPA(LPABase):
   def __init__(self, interface: Literal['qmi', 'at'] = 'qmi'):
@@ -32,6 +32,7 @@ class TiciLPA(LPABase):
     return next((p for p in self.list_profiles() if p.enabled), None)
 
   def delete_profile(self, iccid: str) -> None:
+    self._validate_iccid(iccid)
     self._validate_profile_exists(iccid)
     latest = self.get_active_profile()
     if latest is not None and latest.iccid == iccid:
@@ -39,9 +40,13 @@ class TiciLPA(LPABase):
     self._validate_successful(self._invoke('profile', 'delete', iccid))
     self._process_notifications()
 
-  def download_profile(self, qr: str, nickname: str | None = None) -> None:
+  def download_profile(self, lpa_activation_code: str, nickname: str | None = None) -> None:
     self._check_bootstrapped()
-    msgs = self._invoke('profile', 'download', '-a', qr)
+    self._validate_lpa_activation_code(lpa_activation_code)
+    if nickname:
+      self._validate_nickname(nickname)
+
+    msgs = self._invoke('profile', 'download', '-a', lpa_activation_code)
     self._validate_successful(msgs)
     new_profile = next((m for m in msgs if m['payload']['message'] == 'es8p_meatadata_parse'), None)
     if new_profile is None:
@@ -51,11 +56,14 @@ class TiciLPA(LPABase):
     self._process_notifications()
 
   def nickname_profile(self, iccid: str, nickname: str) -> None:
+    self._validate_iccid(iccid)
     self._validate_profile_exists(iccid)
+    self._validate_nickname(nickname)
     self._validate_successful(self._invoke('profile', 'nickname', iccid, nickname))
 
   def switch_profile(self, iccid: str) -> None:
     self._check_bootstrapped()
+    self._validate_iccid(iccid)
     self._validate_profile_exists(iccid)
     latest = self.get_active_profile()
     if latest and latest.iccid == iccid:
@@ -126,10 +134,3 @@ class TiciLPA(LPABase):
     Process notifications stored on the eUICC, typically to activate/deactivate the profile with the carrier.
     """
     self._validate_successful(self._invoke('notification', 'process', '-a', '-r'))
-
-  def _validate_profile_exists(self, iccid: str) -> None:
-    if not any(p.iccid == iccid for p in self.list_profiles()):
-      raise LPAProfileNotFoundError(f'profile {iccid} does not exist')
-
-  def _validate_successful(self, msgs: list[dict]) -> None:
-    assert msgs[-1]['payload']['message'] == 'success', 'expected success notification'

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -87,16 +87,16 @@ class TiciLPA(LPABase):
         self._disable_profile(p.iccid)
         self.delete_profile(p.iccid)
 
+  def is_bootstrapped(self) -> bool:
+    """ check if any comma provisioned profiles are on the eUICC """
+    return not any(self.is_comma_profile(iccid) for iccid in (p.iccid for p in self.list_profiles()))
+
   def _disable_profile(self, iccid: str) -> None:
     self._validate_successful(self._invoke('profile', 'disable', iccid))
     self._process_notifications()
 
   def _check_bootstrapped(self) -> None:
-    assert self._is_bootstrapped(), 'eUICC is not bootstrapped, please bootstrap before performing this operation'
-
-  def _is_bootstrapped(self) -> bool:
-    """ check if any comma provisioned profiles are on the eUICC """
-    return not any(self.is_comma_profile(iccid) for iccid in (p.iccid for p in self.list_profiles()))
+    assert self.is_bootstrapped(), 'eUICC is not bootstrapped, please bootstrap before performing this operation'
 
   def _invoke(self, *cmd: str):
     proc = subprocess.Popen(['sudo', '-E', 'lpac'] + list(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self.env)

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -42,7 +42,7 @@ class TiciLPA(LPABase):
 
   def download_profile(self, lpa_activation_code: str, nickname: str | None = None) -> None:
     self._check_bootstrapped()
-    self._validate_lpa_activation_code(lpa_activation_code)
+    self.validate_lpa_activation_code(lpa_activation_code)
     if nickname:
       self.validate_nickname(nickname)
 

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -25,7 +25,8 @@ class TiciLPA(LPABase):
       iccid=p['iccid'],
       nickname=p['profileNickname'],
       enabled=p['profileState'] == 'enabled',
-      provider=p['serviceProviderName']
+      provider=p['serviceProviderName'],
+      is_comma_profile=self.is_comma_profile(p['iccid'])
     ) for p in msgs[-1]['payload']['data']]
 
   def get_active_profile(self) -> Profile | None:

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -80,7 +80,7 @@ class TiciLPA(LPABase):
     **note**: this is a **very** destructive operation. you **must** purchase a new comma SIM in order
               to use comma prime again.
     """
-    if self._is_bootstrapped():
+    if self.is_bootstrapped():
       return
 
     for p in self.list_profiles():

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -32,8 +32,8 @@ class TiciLPA(LPABase):
     return next((p for p in self.list_profiles() if p.enabled), None)
 
   def delete_profile(self, iccid: str) -> None:
-    self._validate_iccid(iccid)
-    self._validate_profile_exists(iccid)
+    self.validate_iccid(iccid)
+    self.validate_profile_exists(iccid)
     latest = self.get_active_profile()
     if latest is not None and latest.iccid == iccid:
       raise LPAError('cannot delete active profile, switch to another profile first')
@@ -44,7 +44,7 @@ class TiciLPA(LPABase):
     self._check_bootstrapped()
     self._validate_lpa_activation_code(lpa_activation_code)
     if nickname:
-      self._validate_nickname(nickname)
+      self.validate_nickname(nickname)
 
     msgs = self._invoke('profile', 'download', '-a', lpa_activation_code)
     self._validate_successful(msgs)
@@ -56,15 +56,15 @@ class TiciLPA(LPABase):
     self._process_notifications()
 
   def nickname_profile(self, iccid: str, nickname: str) -> None:
-    self._validate_iccid(iccid)
-    self._validate_profile_exists(iccid)
-    self._validate_nickname(nickname)
+    self.validate_iccid(iccid)
+    self.validate_profile_exists(iccid)
+    self.validate_nickname(nickname)
     self._validate_successful(self._invoke('profile', 'nickname', iccid, nickname))
 
   def switch_profile(self, iccid: str) -> None:
     self._check_bootstrapped()
-    self._validate_iccid(iccid)
-    self._validate_profile_exists(iccid)
+    self.validate_iccid(iccid)
+    self.validate_profile_exists(iccid)
     latest = self.get_active_profile()
     if latest and latest.iccid == iccid:
       return

--- a/system/hardware/tici/tests/test_esim.py
+++ b/system/hardware/tici/tests/test_esim.py
@@ -1,7 +1,6 @@
 import pytest
 
 from openpilot.system.hardware import HARDWARE, TICI
-from openpilot.system.hardware.base import LPAProfileNotFoundError
 
 # https://euicc-manual.osmocom.org/docs/rsp/known-test-profile
 # iccid is always the same for the given activation code
@@ -14,7 +13,7 @@ def cleanup():
   lpa = HARDWARE.get_sim_lpa()
   try:
     lpa.delete_profile(TEST_ICCID)
-  except LPAProfileNotFoundError:
+  except AssertionError:
     pass
   lpa.process_notifications()
 


### PR DESCRIPTION
related: https://github.com/commaai/openpilot/issues/34924

not adding `delete_profile` here for now. too risky for user to accidentally delete profile and not be able to recover it. can use `esim.py` to cleanup as an alternative

---

### happy case (get profiles)
![image](https://github.com/user-attachments/assets/81c3d68c-935f-4a6e-b1f4-2edb0a05adc5)

### happy case (download profile)
[esim-athena.webm](https://github.com/user-attachments/assets/2dc69c3b-98b7-49d9-a327-d72ae498a378)


### sad case (enable invalid profile)
![image](https://github.com/user-attachments/assets/74d8da46-fd8c-4438-990c-05773b09b71e)
