### PR TITLE
build: Arch linux build support

### DIFF
--- a/third_party/SConscript
+++ b/third_party/SConscript
@@ -1,4 +1,9 @@
-Import('env')
+Import('env', 'json_env')
 
-env.Library('json11', ['json11/json11.cpp'], CCFLAGS=env['CCFLAGS'] + ['-Wno-unqualified-std-cast-call'])
+json_env.Library(
+  'json11',
+  ['json11/json11.cpp'],
+  CCFLAGS=json_env['CCFLAGS'] + ['-Wno-unqualified-std-cast-call'],
+)
+
 env.Library('kaitai', ['kaitai/kaitaistream.cpp'], CPPDEFINES=['KS_STR_ENCODING_NONE'])

--- a/tools/arch_setup.sh
+++ b/tools/arch_setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+# NOTE: this is used in a docker build, so do not run any scripts here.
+
+"$DIR"/install_arch_dependencies.sh
+"$DIR"/install_python_dependencies.sh

--- a/tools/install_arch_dependencies.sh
+++ b/tools/install_arch_dependencies.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SUDO=""
+PACMAN_OPTS="--needed"
+INTERACTIVE=0
+
+# Use sudo if not root
+if [[ "$(id -u)" -ne 0 ]]; then
+	if ! command -v sudo >/dev/null 2>&1; then
+		echo "Please install sudo or run as root"
+		exit 1
+	fi
+	SUDO="sudo"
+fi
+
+# Check if stdin is open (interactive)
+if [ -t 0 ]; then
+	INTERACTIVE=1
+fi
+
+# Non-interactive pacman opts
+if [[ "$INTERACTIVE" -eq 0 ]]; then
+	PACMAN_OPTS="$PACMAN_OPTS --noconfirm --needed"
+fi
+
+install_arch_requirements() {
+
+  git lfs install || true
+
+	# Core toolchains & libs
+	$SUDO pacman -S $PACMAN_OPTS \
+		ca-certificates \
+		clang \
+		base-devel \
+		arm-none-eabi-gcc arm-none-eabi-binutils arm-none-eabi-newlib \
+		xz \
+		capnproto \
+		curl \
+		git git-lfs \
+		ffmpeg \
+		bzip2 \
+		eigen \
+		libffi \
+		glew \
+		mesa \
+		glfw \
+		glib2 \
+		libjpeg-turbo \
+		qt5-base qt5-tools qt5-svg qt5-x11extras qt5-charts \
+		ncurses \
+		openssl \
+		libusb \
+		zeromq \
+		zstd \
+		sqlite \
+		systemd-libs \
+		opencl-headers ocl-icd \
+		portaudio \
+		xorg-server-xvfb \
+		python python-pip \
+    arm-none-eabi-newlib
+
+    yay -S qt5-serialbus
+}
+
+# Detect OS using /etc/os-release
+if [[ -f "/etc/os-release" ]]; then
+	. /etc/os-release
+	if [[ "${ID:-}" == "arch"  ]]; then
+		install_arch_requirements
+	else
+		echo "$ID $VERSION_ID is unsupported here. This setup script is written for Arch-based systems."
+		if [[ "$INTERACTIVE" -eq 1 ]]; then
+			read -p "Attempt installation anyway? [y/N] " -r
+			echo ""
+			if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+				exit 1
+			fi
+			install_arch_requirements
+		else
+			exit 1
+		fi
+	fi
+
+	# udev rules
+	if [[ -d "/etc/udev/rules.d/" ]]; then
+		$SUDO tee /etc/udev/rules.d/12-panda_jungle.rules >/dev/null <<'EOF'
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddcf", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddef", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcf", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddef", MODE="0666"
+EOF
+
+		$SUDO tee /etc/udev/rules.d/11-panda.rules >/dev/null <<'EOF'
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddcc", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddee", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcc", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
+EOF
+
+		$SUDO udevadm control --reload-rules && $SUDO udevadm trigger || true
+	fi
+else
+	echo "No /etc/os-release found. Make sure you're on an Arch-based system."
+	exit 1
+fi


### PR DESCRIPTION
This change adds build support for Arch Linux to compile openpilot. The main changes include:
- Added a simple check to detect when we're running on Arch Linux by looking at `/etc/os-release`
- Updated the build system (SConstruct) to handle Arch Linux's pickier compiler defaults
- Made sure the build process works smoothly on Arch 

From what I understand there was some extra strictness on some things that didn't play nice with JSON 11.

I was able to get the simulator up and running (in Wayland nice! :+1: ) and poke around in it with this at least. Just got the device recently so still messing with things. Please let me know if there is anything in specific you would like me to test. 

Also if there is no interest in adding this from the maintainers that's fine as well and I can just store this in a branch somewhere in my fork for reference if I need to do it again. 

<img width="5065" height="2160" alt="image" src="https://github.com/user-attachments/assets/aa845edc-c704-40d4-b4c5-59d4bc183e3d" />

