### PR TITLE
feat(esim): bootstrap

### DIFF
--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -66,6 +66,10 @@ class ThermalConfig:
 
 class LPABase(ABC):
   @abstractmethod
+  def bootstrap(self) -> None:
+    pass
+
+  @abstractmethod
   def list_profiles(self) -> list[Profile]:
     pass
 
@@ -88,6 +92,9 @@ class LPABase(ABC):
   @abstractmethod
   def switch_profile(self, iccid: str) -> None:
     pass
+
+  def is_comma_profile(self, iccid: str) -> bool:
+    return any(iccid.startswith(prefix) for prefix in ('8985235'))
 
 class HardwareBase(ABC):
   @staticmethod

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -94,7 +94,7 @@ class LPABase(ABC):
     pass
 
   def is_comma_profile(self, iccid: str) -> bool:
-    return any(iccid.startswith(prefix) for prefix in ('8985235'))
+    return any(iccid.startswith(prefix) for prefix in ('8985235',))
 
 class HardwareBase(ABC):
   @staticmethod

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -3,10 +3,36 @@
 import argparse
 import time
 from openpilot.system.hardware import HARDWARE
+from openpilot.system.hardware.base import LPABase
+
+
+def bootstrap(lpa: LPABase) -> None:
+  print('┌──────────────────────────────────────────────────────────────────────────────┐')
+  print('│ WARNING, PLEASE READ BEFORE PROCEEDING                                       │')
+  print('│                                                                              │')
+  print('│ this is an irreversible operation that will remove the comma-provisioned     │')
+  print('│ profile.                                                                     │')
+  print('│                                                                              │')
+  print('│ you must purchase a new eSIM from comma in order to use the full comma       │')
+  print('│ comma prime subscription.                                                    │')
+  print('└──────────────────────────────────────────────────────────────────────────────┘')
+  print()
+  print('are you sure you want to proceed? (y/N) ', end='')
+  confirm = input()
+  if confirm != 'y':
+    print('aborting')
+    exit(0)
+  print('are you 100% sure you want to proceed? please acknowledge again. (y/N) ', end='')
+  confirm = input()
+  if confirm != 'y':
+    print('aborting')
+    exit(0)
+  lpa.bootstrap()
 
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')
+  parser.add_argument('--bootstrap', action='store_true', help='bootstrap the eUICC (required before downloading profiles)')
   parser.add_argument('--backend', choices=['qmi', 'at'], default='qmi', help='use the specified backend, defaults to qmi')
   parser.add_argument('--switch', metavar='iccid', help='switch to profile')
   parser.add_argument('--delete', metavar='iccid', help='delete profile (warning: this cannot be undone)')
@@ -16,7 +42,9 @@ if __name__ == '__main__':
 
   mutated = False
   lpa = HARDWARE.get_sim_lpa()
-  if args.switch:
+  if args.bootstrap:
+    bootstrap(lpa)
+  elif args.switch:
     lpa.switch_profile(args.switch)
     mutated = True
   elif args.delete:

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -44,6 +44,7 @@ if __name__ == '__main__':
   lpa = HARDWARE.get_sim_lpa()
   if args.bootstrap:
     bootstrap(lpa)
+    mutated = True
   elif args.switch:
     lpa.switch_profile(args.switch)
     mutated = True

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -17,16 +17,12 @@ def bootstrap(lpa: LPABase) -> None:
   print('│ comma prime subscription.                                                    │')
   print('└──────────────────────────────────────────────────────────────────────────────┘')
   print()
-  print('are you sure you want to proceed? (y/N) ', end='')
-  confirm = input()
-  if confirm != 'y':
-    print('aborting')
-    exit(0)
-  print('are you 100% sure you want to proceed? please acknowledge again. (y/N) ', end='')
-  confirm = input()
-  if confirm != 'y':
-    print('aborting')
-    exit(0)
+  for severity in ('sure', '100% sure'):
+    print(f'are you {severity} you want to proceed? (y/N) ', end='')
+    confirm = input()
+    if confirm != 'y':
+      print('aborting')
+      exit(0)
   lpa.bootstrap()
 
 

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -13,8 +13,8 @@ def bootstrap(lpa: LPABase) -> None:
   print('│ this is an irreversible operation that will remove the comma-provisioned     │')
   print('│ profile.                                                                     │')
   print('│                                                                              │')
-  print('│ you must purchase a new eSIM from comma in order to use the full comma       │')
-  print('│ comma prime subscription.                                                    │')
+  print('│ after this operation, you must purchase a new eSIM from comma in order to    │')
+  print('│ use the comma prime subscription again.                                      │')
   print('└──────────────────────────────────────────────────────────────────────────────┘')
   print()
   for severity in ('sure', '100% sure'):

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -69,7 +69,7 @@ class TiciLPA(LPABase):
     and must be deleted.
 
     **note**: this is a **very** destructive operation. you **must** purchase a new comma SIM in order
-              to use comma prime.
+              to use comma prime again.
     """
     if self._is_bootstrapped():
       return

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -71,9 +71,17 @@ class TiciLPA(LPABase):
     **note**: this is a **very** destructive operation. you **must** purchase a new comma SIM in order
               to use comma prime.
     """
+    if self._is_bootstrapped():
+      return
+
     for p in self.list_profiles():
       if self.is_comma_profile(p.iccid):
+        self._disable_profile(p.iccid)
         self.delete_profile(p.iccid)
+
+  def _disable_profile(self, iccid: str) -> None:
+    self._validate_successful(self._invoke('profile', 'disable', iccid))
+    self._process_notifications()
 
   def _check_bootstrapped(self) -> None:
     assert self._is_bootstrapped(), 'eUICC is not bootstrapped, please bootstrap before performing this operation'

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -40,6 +40,7 @@ class TiciLPA(LPABase):
     self._process_notifications()
 
   def download_profile(self, qr: str, nickname: str | None = None) -> None:
+    self._check_bootstrapped()
     msgs = self._invoke('profile', 'download', '-a', qr)
     self._validate_successful(msgs)
     new_profile = next((m for m in msgs if m['payload']['message'] == 'es8p_meatadata_parse'), None)
@@ -54,12 +55,32 @@ class TiciLPA(LPABase):
     self._validate_successful(self._invoke('profile', 'nickname', iccid, nickname))
 
   def switch_profile(self, iccid: str) -> None:
+    self._check_bootstrapped()
     self._validate_profile_exists(iccid)
     latest = self.get_active_profile()
     if latest and latest.iccid == iccid:
       return
     self._validate_successful(self._invoke('profile', 'enable', iccid))
     self._process_notifications()
+
+  def bootstrap(self) -> None:
+    """
+    find all comma-provisioned profiles and delete them. they conflict with user-provisioned profiles
+    and must be deleted.
+
+    **note**: this is a **very** destructive operation. you **must** purchase a new comma SIM in order
+              to use comma prime.
+    """
+    for p in self.list_profiles():
+      if self.is_comma_profile(p.iccid):
+        self.delete_profile(p.iccid)
+
+  def _check_bootstrapped(self) -> None:
+    assert self._is_bootstrapped(), 'eUICC is not bootstrapped, please bootstrap before performing this operation'
+
+  def _is_bootstrapped(self) -> bool:
+    """ check if any comma provisioned profiles are on the eUICC """
+    return not any(self.is_comma_profile(iccid) for iccid in (p.iccid for p in self.list_profiles()))
 
   def _invoke(self, *cmd: str):
     proc = subprocess.Popen(['sudo', '-E', 'lpac'] + list(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self.env)

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -487,7 +487,7 @@ class Tici(HardwareBase):
 
     # eSIM prime
     dest = "/etc/NetworkManager/system-connections/esim.nmconnection"
-    if sim_id.startswith('8985235') and not os.path.exists(dest):
+    if self.get_sim_lpa().is_comma_profile(sim_id) and not os.path.exists(dest):
       with open(Path(__file__).parent/'esim.nmconnection') as f, tempfile.NamedTemporaryFile(mode='w') as tf:
         dat = f.read()
         dat = dat.replace("sim-id=", f"sim-id={sim_id}")


### PR DESCRIPTION
https://github.com/commaai/openpilot/issues/34924

eUICCs must be "bootstrapped," comma prime profiles removed, in order to switch to user-loaded profiles. when the modem is rebooted after a switch to a user profile without "bootstrapping," the SIM falls back to the pre-loaded profile.

a clear warning and two acknowledgements are required to bootstrap the SIM card.

moved the "is comma profile" check into the LPA.