### PR TITLE
selfdrived: disable HUD VisualAlert for belowSteerSpeed events

### DIFF
--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -243,7 +243,7 @@ def below_steer_speed_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.S
     f"Steer Unavailable Below {get_display_speed(CP.minSteerSpeed, metric)}",
     "",
     AlertStatus.userPrompt, AlertSize.small,
-    Priority.LOW, VisualAlert.steerRequired, AudibleAlert.prompt, 0.4)
+    Priority.LOW, VisualAlert.none, AudibleAlert.prompt, 0.4)
 
 
 def calibration_incomplete_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:


### PR DESCRIPTION
Don't send VisualAlert.steerRequired to the car when engaged with belowSteerSpeed.

* We communicate the event clearly and unobtrusively through the 3X UI, visually and audibly
* We shouldn't raise instrument cluster HUD events for routine, repetitive, expected events
* On some cars, the HUD steer-required alert is persistent and obnoxious, and prevents other HUD use

Solving this nuisance is a blocker to merging several new Honda ports. I want to keep the VisualAlert capability for promptDriverDistracted and the like, where it's more appropriate.

This being a (minor) global user-facing policy change, I'm requesting comma sign-off before merging.