### PR TITLE
PlotJuggler: Updated layout for torque controller

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ quiet-level = 3
 # if you've got a short variable name that's getting flagged, add it here
 ignore-words-list = "bu,ro,te,ue,alo,hda,ois,nam,nams,ned,som,parm,setts,inout,warmup,bumb,nd,sie,preints,whit,indexIn,ws,uint,grey,deque,stdio,amin,BA,LITE,atEnd,UIs,errorString,arange,FocusIn,od,tim,relA,hist,copyable,jupyter,thead,TGE,abl,lite"
 builtin = "clear,rare,informal,code,names,en-GB_to_en-US"
-skip = "./third_party/*, ./tinygrad/*, ./tinygrad_repo/*, ./msgq/*, ./panda/*, ./opendbc/*, ./opendbc_repo/*, ./rednose/*, ./rednose_repo/*, ./teleoprtc/*, ./teleoprtc_repo/*, *.ts, uv.lock, *.onnx, ./cereal/gen/*, */c_generated_code/*, docs/assets/*"
+skip = "./third_party/*, ./tinygrad/*, ./tinygrad_repo/*, ./msgq/*, ./panda/*, ./opendbc/*, ./opendbc_repo/*, ./rednose/*, ./rednose_repo/*, ./teleoprtc/*, ./teleoprtc_repo/*, *.ts, uv.lock, *.onnx, ./cereal/gen/*, */c_generated_code/*, docs/assets/*, tools/plotjuggler/layouts/*"
 
 [tool.mypy]
 python_version = "3.11"

--- a/tools/plotjuggler/layouts/torque-controller.xml
+++ b/tools/plotjuggler/layouts/torque-controller.xml
@@ -1,77 +1,45 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <root>
- <tabbed_widget parent="main_window" name="Main Window">
+ <tabbed_widget name="Main Window" parent="main_window">
   <Tab containers="1" tab_name="Lateral Plan Conformance">
    <Container>
-    <DockSplitter count="4" sizes="0.25;0.25;0.25;0.25" orientation="-">
+    <DockSplitter orientation="-" count="4" sizes="0.250949;0.249051;0.250949;0.249051">
      <DockArea name="desired vs actual lateral acceleration (closer means better conformance to plan)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="3.586831" right="269.643117" left="0.000140" bottom="-2.354077"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="1.858161" bottom="-1.823407" right="1138.891674" left="0.000194"/>
        <limitY/>
-       <curve color="#1f77b4" name="/controlsState/lateralControlState/torqueState/actualLateralAccel"/>
-       <curve color="#d62728" name="/controlsState/lateralControlState/torqueState/desiredLateralAccel"/>
+       <curve name="/controlsState/lateralControlState/torqueState/actualLateralAccel" color="#1f77b4"/>
+       <curve name="/controlsState/lateralControlState/torqueState/desiredLateralAccel" color="#d62728"/>
       </plot>
      </DockArea>
      <DockArea name="desired vs actual lateral acceleration, road-roll factored out (closer means better conformance to plan)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="3.445087" right="269.643117" left="0.000140" bottom="-2.654874"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="2.749816" bottom="-3.723091" right="1138.891674" left="0.000194"/>
        <limitY/>
-       <curve color="#1ac938" name="Actual lateral accel (roll compensated)"/>
-       <curve color="#ff7f0e" name="Desired lateral accel (roll compensated)"/>
+       <curve name="Actual lateral accel (roll compensated)" color="#1ac938"/>
+       <curve name="Desired lateral accel (roll compensated)" color="#ff7f0e"/>
       </plot>
      </DockArea>
      <DockArea name="controller feed-forward vs actuator output (closer means controller prediction is more accurate)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="1.082031" right="269.643117" left="0.000140" bottom="-1.050781"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="1.978032" bottom="-1.570956" right="1138.891674" left="0.000194"/>
        <limitY/>
-       <curve color="#9467bd" name="/carOutput/actuatorsOutput/torque">
+       <curve name="/carOutput/actuatorsOutput/torque" color="#9467bd">
         <transform alias="/carOutput/actuatorsOutput/torque[Scale/Offset]" name="Scale/Offset">
-         <options value_scale="-1" time_offset="0" value_offset="0"/>
+         <options value_offset="0" value_scale="-1" time_offset="0"/>
         </transform>
        </curve>
-       <curve color="#1f77b4" name="/controlsState/lateralControlState/torqueState/f"/>
-       <curve color="#ff000f" name="/carState/steeringPressed"/>
+       <curve name="/controlsState/lateralControlState/torqueState/f" color="#1f77b4"/>
+       <curve name="/carState/steeringPressed" color="#ff000f"/>
       </plot>
      </DockArea>
      <DockArea name="vehicle speed">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="101.506277" right="269.643117" left="0.000140" bottom="-2.475763"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="105.981304" bottom="-2.709314" right="1138.891674" left="0.000194"/>
        <limitY/>
-       <curve color="#d62728" name="carState.vEgo mph"/>
-       <curve color="#1ac938" name="carState.vEgo kmh"/>
-       <curve color="#ff7f0e" name="/carState/vEgo"/>
-      </plot>
-     </DockArea>
-    </DockSplitter>
-   </Container>
-  </Tab>
-  <Tab containers="1" tab_name="Actuator Performance">
-   <Container>
-    <DockSplitter count="3" sizes="0.33361;0.33278;0.33361" orientation="-">
-     <DockArea name="offline-calculated vs online-learned lateral accel scaling factor, accel obtained from 100% actuator output">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="4.186453" right="269.490213" left="0.000000" bottom="3.175940"/>
-       <limitY/>
-       <curve color="#1f77b4" name="/liveTorqueParameters/latAccelFactorFiltered"/>
-       <curve color="#d62728" name="/liveTorqueParameters/latAccelFactorRaw"/>
-       <curve color="#1c9222" name="/carParams/lateralTuning/torque/latAccelFactor"/>
-      </plot>
-     </DockArea>
-     <DockArea name="learned lateral accel offset, vehicle-specific compensation to obtain true zero lateral accel">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="0.003035" right="269.490213" left="0.000000" bottom="-0.124417"/>
-       <limitY/>
-       <curve color="#1ac938" name="/liveTorqueParameters/latAccelOffsetFiltered"/>
-       <curve color="#ff7f0e" name="/liveTorqueParameters/latAccelOffsetRaw"/>
-      </plot>
-     </DockArea>
-     <DockArea name="offline-calculated vs online-learned EPS friction factor, necessary to start moving the steering wheel">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="0.121143" right="269.490213" left="0.000000" bottom="-0.002955"/>
-       <limitY/>
-       <curve color="#f14cc1" name="/liveTorqueParameters/frictionCoefficientFiltered"/>
-       <curve color="#9467bd" name="/liveTorqueParameters/frictionCoefficientRaw"/>
-       <curve color="#1c9222" name="/carParams/lateralTuning/torque/friction"/>
+       <curve name="carState.vEgo mph" color="#d62728"/>
+       <curve name="carState.vEgo kmh" color="#1ac938"/>
+       <curve name="/carState/vEgo" color="#ff7f0e"/>
       </plot>
      </DockArea>
     </DockSplitter>
@@ -79,115 +47,134 @@
   </Tab>
   <Tab containers="1" tab_name="Vehicle Dynamics">
    <Container>
-    <DockSplitter count="3" sizes="0.33361;0.33278;0.33361" orientation="-">
+    <DockSplitter orientation="-" count="3" sizes="0.334282;0.331437;0.334282">
      <DockArea name="configured-initial vs online-learned steerRatio, set configured value to match learned">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="12.903705" right="269.638801" left="0.000000" bottom="12.748092"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="19.665784" bottom="19.359553" right="1138.816328" left="0.000000"/>
        <limitY/>
-       <curve color="#1f77b4" name="/carParams/steerRatio"/>
-       <curve color="#1ac938" name="/liveParameters/steerRatio"/>
+       <curve name="/carParams/steerRatio" color="#1f77b4"/>
+       <curve name="/liveParameters/steerRatio" color="#1ac938"/>
       </plot>
      </DockArea>
      <DockArea name="configured-initial vs online-learned tireStiffnessRatio, set configured value to match learned">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="1.000520" right="269.638801" left="0.000000" bottom="0.999718"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="1.112210" bottom="0.995631" right="1138.816328" left="0.000000"/>
        <limitY/>
-       <curve color="#d62728" name="/carParams/tireStiffnessFactor"/>
-       <curve color="#ff7f0e" name="/liveParameters/stiffnessFactor"/>
+       <curve name="/carParams/tireStiffnessFactor" color="#d62728"/>
+       <curve name="/liveParameters/stiffnessFactor" color="#ff7f0e"/>
       </plot>
      </DockArea>
      <DockArea name="live steering angle offsets for straight-ahead driving, large values here may indicate alignment problems">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="-0.332067" right="269.638801" left="0.000000" bottom="-3.149970"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="-1.081041" bottom="-4.494133" right="1138.816328" left="0.000000"/>
        <limitY/>
-       <curve color="#f14cc1" name="/liveParameters/angleOffsetAverageDeg"/>
-       <curve color="#9467bd" name="/liveParameters/angleOffsetDeg"/>
+       <curve name="/liveParameters/angleOffsetAverageDeg" color="#f14cc1"/>
+       <curve name="/liveParameters/angleOffsetDeg" color="#9467bd"/>
       </plot>
      </DockArea>
     </DockSplitter>
    </Container>
   </Tab>
-  <Tab containers="1" tab_name="Controller PIF Terms">
+  <Tab containers="1" tab_name="Actuator Performance">
    <Container>
-    <DockSplitter count="3" sizes="0.33361;0.33278;0.33361" orientation="-">
-     <DockArea name="controller feed-forward vs actuator output (closer means controller prediction is more accurate)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="1.082031" right="269.643117" left="0.000140" bottom="-1.050781"/>
+    <DockSplitter orientation="-" count="3" sizes="0.333333;0.333333;0.333333">
+     <DockArea name="offline-calculated vs online-learned lateral accel scaling factor, accel obtained from 100% actuator output">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="1.216110" bottom="0.539474" right="1138.920072" left="0.000000"/>
        <limitY/>
-       <curve color="#9467bd" name="/carOutput/actuatorsOutput/torque">
+       <curve name="/liveTorqueParameters/latAccelFactorFiltered" color="#1f77b4"/>
+       <curve name="/liveTorqueParameters/latAccelFactorRaw" color="#d62728"/>
+       <curve name="/carParams/lateralTuning/torque/latAccelFactor" color="#1c9222"/>
+      </plot>
+     </DockArea>
+     <DockArea name="learned lateral accel offset, vehicle-specific compensation to obtain true zero lateral accel">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="-0.304367" bottom="-0.418688" right="1138.920072" left="0.000000"/>
+       <limitY/>
+       <curve name="/liveTorqueParameters/latAccelOffsetFiltered" color="#1ac938"/>
+       <curve name="/liveTorqueParameters/latAccelOffsetRaw" color="#ff7f0e"/>
+      </plot>
+     </DockArea>
+     <DockArea name="offline-calculated vs online-learned EPS friction factor, necessary to start moving the steering wheel">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="0.226389" bottom="0.158050" right="1138.920072" left="0.000000"/>
+       <limitY/>
+       <curve name="/liveTorqueParameters/frictionCoefficientFiltered" color="#f14cc1"/>
+       <curve name="/liveTorqueParameters/frictionCoefficientRaw" color="#9467bd"/>
+       <curve name="/carParams/lateralTuning/torque/friction" color="#1c9222"/>
+      </plot>
+     </DockArea>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <Tab containers="1" tab_name="Actuator Delay">
+   <Container>
+    <DockSplitter orientation="-" count="3" sizes="0.30441;0.358464;0.337127">
+     <DockArea name="actuator lag learning state, 0 = learning, 1 = learned/applying, 2 = invalid">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="1.025000" bottom="-0.025000" right="1138.749979" left="0.000000"/>
+       <limitY/>
+       <curve name="/liveDelay/status" color="#ff7f0e"/>
+      </plot>
+     </DockArea>
+     <DockArea name="offline default vs online estimated steering actuator lag">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="0.419648" bottom="0.318362" right="1138.749979" left="0.000000"/>
+       <limitY/>
+       <curve name="/liveDelay/lateralDelay" color="#1f77b4"/>
+       <curve name="/liveDelay/lateralDelayEstimate" color="#d62728"/>
+       <curve name="opendbc default steering lag" color="#1ac938"/>
+      </plot>
+     </DockArea>
+     <DockArea name="online estimated steering actuator lag, standard deviation">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="0.067320" bottom="-0.001642" right="1138.749979" left="0.000000"/>
+       <limitY/>
+       <curve name="/liveDelay/lateralDelayEstimateStd" color="#f14cc1"/>
+      </plot>
+     </DockArea>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <Tab containers="1" tab_name="Controls Performance">
+   <Container>
+    <DockSplitter orientation="-" count="4" sizes="0.265655;0.251898;0.245731;0.236717">
+     <DockArea name="rate-of-change limits on steering actuator (blue = original, green = rate-limited before CAN output)">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="1.050000" bottom="-1.050000" right="1138.891921" left="0.000194"/>
+       <limitY/>
+       <curve name="/carControl/actuators/torque" color="#0c00f2"/>
+       <curve name="/carOutput/actuatorsOutput/torque" color="#2cd63a"/>
+      </plot>
+     </DockArea>
+     <DockArea name="controller feed-forward vs actuator output (closer means controller prediction is more accurate)">
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="1.978032" bottom="-1.570956" right="1138.891921" left="0.000194"/>
+       <limitY/>
+       <curve name="/carOutput/actuatorsOutput/torque" color="#9467bd">
         <transform alias="/carOutput/actuatorsOutput/torque[Scale/Offset]" name="Scale/Offset">
-         <options value_scale="-1.0" time_offset="0" value_offset="0"/>
+         <options value_offset="0" value_scale="-1.0" time_offset="0"/>
         </transform>
        </curve>
-       <curve color="#1f77b4" name="/controlsState/lateralControlState/torqueState/f"/>
-       <curve color="#ff000f" name="/carState/steeringPressed"/>
+       <curve name="/controlsState/lateralControlState/torqueState/f" color="#1f77b4"/>
+       <curve name="/carState/steeringPressed" color="#ff000f"/>
       </plot>
      </DockArea>
      <DockArea name="proportional, integral, and feed-forward terms (actuator output = sum of PIF terms)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="1.572946" right="269.643117" left="0.000140" bottom="-3.822608"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="2.099784" bottom="-4.027542" right="1138.891921" left="0.000194"/>
        <limitY/>
-       <curve color="#0ab027" name="/controlsState/lateralControlState/torqueState/f"/>
-       <curve color="#d62728" name="/controlsState/lateralControlState/torqueState/p"/>
-       <curve color="#ffaf00" name="/controlsState/lateralControlState/torqueState/i"/>
-       <curve color="#756a6a" name="Zero"/>
+       <curve name="/controlsState/lateralControlState/torqueState/f" color="#0ab027"/>
+       <curve name="/controlsState/lateralControlState/torqueState/p" color="#d62728"/>
+       <curve name="/controlsState/lateralControlState/torqueState/i" color="#ffaf00"/>
+       <curve name="Zero" color="#756a6a"/>
       </plot>
      </DockArea>
      <DockArea name="road roll angle, from openpilot localizer">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="0.059127" right="269.643117" left="0.000140" bottom="-0.031841"/>
+      <plot flip_y="false" style="Lines" mode="TimeSeries" flip_x="false">
+       <range top="0.109446" bottom="-0.045525" right="1138.891921" left="0.000194"/>
        <limitY/>
-       <curve color="#f14cc1" name="/liveParameters/roll"/>
-      </plot>
-     </DockArea>
-    </DockSplitter>
-   </Container>
-  </Tab>
-  <Tab containers="1" tab_name="Actuator Delay Estimation">
-   <Container>
-    <DockSplitter count="4" sizes="0.25;0.25;0.25;0.25" orientation="-">
-     <DockArea name="desired vs actual lateral acceleration (baseline)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="3.586831" right="269.943117" left="0.134774" bottom="-2.354077"/>
-       <limitY/>
-       <curve color="#ff7f0e" name="/controlsState/lateralControlState/torqueState/desiredLateralAccel"/>
-       <curve color="#1ac938" name="/controlsState/lateralControlState/torqueState/actualLateralAccel"/>
-      </plot>
-     </DockArea>
-     <DockArea name="desired vs actual lateral acceleration (desired shifted by +0.1s)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="3.586831" right="269.943117" left="0.134774" bottom="-2.354077"/>
-       <limitY/>
-       <curve color="#ff7f0e" name="/controlsState/lateralControlState/torqueState/desiredLateralAccel">
-        <transform alias="/controlsState/lateralControlState/torqueState/desiredLateralAccel[Scale/Offset]" name="Scale/Offset">
-         <options value_scale="1.0" time_offset="0.1" value_offset="0"/>
-        </transform>
-       </curve>
-       <curve color="#1ac938" name="/controlsState/lateralControlState/torqueState/actualLateralAccel"/>
-      </plot>
-     </DockArea>
-     <DockArea name="desired vs actual lateral acceleration (desired shifted by +0.2s)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="3.586831" right="269.943117" left="0.134774" bottom="-2.354077"/>
-       <limitY/>
-       <curve color="#ff7f0e" name="/controlsState/lateralControlState/torqueState/desiredLateralAccel">
-        <transform alias="/controlsState/lateralControlState/torqueState/desiredLateralAccel[Scale/Offset]" name="Scale/Offset">
-         <options value_scale="1.0" time_offset="0.2" value_offset="0"/>
-        </transform>
-       </curve>
-       <curve color="#1ac938" name="/controlsState/lateralControlState/torqueState/actualLateralAccel"/>
-      </plot>
-     </DockArea>
-     <DockArea name="desired vs actual lateral acceleration (desired shifted by +0.3s)">
-      <plot flip_x="false" style="Lines" flip_y="false" mode="TimeSeries">
-       <range top="3.586831" right="269.943117" left="0.134774" bottom="-2.354077"/>
-       <limitY/>
-       <curve color="#ff7f0e" name="/controlsState/lateralControlState/torqueState/desiredLateralAccel">
-        <transform alias="/controlsState/lateralControlState/torqueState/desiredLateralAccel[Scale/Offset]" name="Scale/Offset">
-         <options value_scale="1.0" time_offset="0.3" value_offset="0"/>
-        </transform>
-       </curve>
-       <curve color="#1ac938" name="/controlsState/lateralControlState/torqueState/actualLateralAccel"/>
+       <curve name="/liveParameters/roll" color="#f14cc1"/>
       </plot>
      </DockArea>
     </DockSplitter>
@@ -199,25 +186,34 @@
  <!-- - - - - - - - - - - - - - - -->
  <!-- - - - - - - - - - - - - - - -->
  <Plugins>
+  <plugin ID="DataLoad CSV">
+   <default delimiter="0" time_axis=""/>
+  </plugin>
   <plugin ID="DataLoad Rlog"/>
+  <plugin ID="DataLoad ULog"/>
   <plugin ID="Cereal Subscriber"/>
+  <plugin ID="UDP Server"/>
+  <plugin ID="ZMQ Subscriber"/>
+  <plugin ID="Fast Fourier Transform"/>
+  <plugin ID="Quaternion to RPY"/>
+  <plugin ID="Reactive Script Editor">
+   <library code="--[[ Helper function to create a series from arrays&#xa;&#xa; new_series: a series previously created with ScatterXY.new(name)&#xa; prefix:     prefix of the timeseries, before the index of the array&#xa; suffix_X:   suffix to complete the name of the series containing the X value. If [nil], use the index of the array.&#xa; suffix_Y:   suffix to complete the name of the series containing the Y value&#xa; timestamp:   usually the tracker_time variable&#xa;              &#xa; Example:&#xa; &#xa; Assuming we have multiple series in the form:&#xa; &#xa;   /trajectory/node.{X}/position/x&#xa;   /trajectory/node.{X}/position/y&#xa;   &#xa; where {N} is the index of the array (integer). We can create a reactive series from the array with:&#xa; &#xa;   new_series = ScatterXY.new(&quot;my_trajectory&quot;) &#xa;   CreateSeriesFromArray( new_series, &quot;/trajectory/node&quot;, &quot;position/x&quot;, &quot;position/y&quot;, tracker_time );&#xa;--]]&#xa;&#xa;function CreateSeriesFromArray( new_series, prefix, suffix_X, suffix_Y, timestamp )&#xa;  &#xa;  --- clear previous values&#xa;  new_series:clear()&#xa;  &#xa;  --- Append points to new_series&#xa;  index = 0&#xa;  while(true) do&#xa;&#xa;    x = index;&#xa;    -- if not nil, get the X coordinate from a series&#xa;    if suffix_X ~= nil then &#xa;      series_x = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_X) )&#xa;      if series_x == nil then break end&#xa;      x = series_x:atTime(timestamp)&#x9; &#xa;    end&#xa;    &#xa;    series_y = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_Y) )&#xa;    if series_y == nil then break end &#xa;    y = series_y:atTime(timestamp)&#xa;    &#xa;    new_series:push_back(x,y)&#xa;    index = index+1&#xa;  end&#xa;end&#xa;&#xa;--[[ Similar to the built-in function GetSeriesNames(), but select only the names with a give prefix. --]]&#xa;&#xa;function GetSeriesNamesByPrefix(prefix)&#xa;  -- GetSeriesNames(9 is a built-in function&#xa;  all_names = GetSeriesNames()&#xa;  filtered_names = {}&#xa;  for i, name in ipairs(all_names)  do&#xa;    -- check the prefix&#xa;    if name:find(prefix, 1, #prefix) then&#xa;      table.insert(filtered_names, name);&#xa;    end&#xa;  end&#xa;  return filtered_names&#xa;end&#xa;&#xa;--[[ Modify an existing series, applying offsets to all their X and Y values&#xa;&#xa; series: an existing timeseries, obtained with TimeseriesView.find(name)&#xa; delta_x: offset to apply to each x value&#xa; delta_y: offset to apply to each y value &#xa;  &#xa;--]]&#xa;&#xa;function ApplyOffsetInPlace(series, delta_x, delta_y)&#xa;  -- use C++ indeces, not Lua indeces&#xa;  for index=0, series:size()-1 do&#xa;    x,y = series:at(index)&#xa;    series:set(index, x + delta_x, y + delta_y)&#xa;  end&#xa;end&#xa;"/>
+   <scripts/>
+  </plugin>
+  <plugin ID="CSV Exporter"/>
  </Plugins>
  <!-- - - - - - - - - - - - - - - -->
  <!-- - - - - - - - - - - - - - - -->
  <customMathEquations>
-  <snippet name="Zero">
+  <snippet name="carState.vEgo kmh">
    <global></global>
-   <function>return (0)</function>
-   <linked_source>/carState/canValid</linked_source>
+   <function>return value * 3.6</function>
+   <linked_source>/carState/vEgo</linked_source>
   </snippet>
-  <snippet name="Actual lateral accel (roll compensated)">
+  <snippet name="carState.vEgo mph">
    <global></global>
-   <function>return (value * v1 ^ 2) - (v2 * 9.81)</function>
-   <linked_source>/controlsState/curvature</linked_source>
-   <additional_sources>
-    <v1>/carState/vEgo</v1>
-    <v2>/liveParameters/roll</v2>
-   </additional_sources>
+   <function>return value * 2.23694</function>
+   <linked_source>/carState/vEgo</linked_source>
   </snippet>
   <snippet name="Desired lateral accel (roll compensated)">
    <global></global>
@@ -228,15 +224,24 @@
     <v2>/liveParameters/roll</v2>
    </additional_sources>
   </snippet>
-  <snippet name="carState.vEgo mph">
+  <snippet name="Actual lateral accel (roll compensated)">
    <global></global>
-   <function>return value * 2.23694</function>
-   <linked_source>/carState/vEgo</linked_source>
+   <function>return (value * v1 ^ 2) - (v2 * 9.81)</function>
+   <linked_source>/controlsState/curvature</linked_source>
+   <additional_sources>
+    <v1>/carState/vEgo</v1>
+    <v2>/liveParameters/roll</v2>
+   </additional_sources>
   </snippet>
-  <snippet name="carState.vEgo kmh">
+  <snippet name="opendbc default steering lag">
    <global></global>
-   <function>return value * 3.6</function>
-   <linked_source>/carState/vEgo</linked_source>
+   <function>return value + 0.2</function>
+   <linked_source>/carParams/steerActuatorDelay</linked_source>
+  </snippet>
+  <snippet name="Zero">
+   <global></global>
+   <function>return (0)</function>
+   <linked_source>/carState/canValid</linked_source>
   </snippet>
  </customMathEquations>
  <snippets/>


### PR DESCRIPTION
Updated the saved PJ layout for visualizing lateral acceleration torque control:

* Updated the actuator delay tab to show the new online learned values from `lagd`
* Updated the controls tab to show actuator rate-limiting in the car port

<img width="1989" height="1681" alt="image" src="https://github.com/user-attachments/assets/c5e6abd1-9106-4157-9113-224f65b06809" />

<img width="1989" height="1681" alt="image" src="https://github.com/user-attachments/assets/b0807f49-d16f-4be4-949a-f66978f196bf" />
