### PR TITLE
ci: adjust power draw bounds

### DIFF
--- a/system/hardware/tici/tests/test_power_draw.py
+++ b/system/hardware/tici/tests/test_power_draw.py
@@ -31,9 +31,9 @@ class Proc:
 
 
 PROCS = [
-  Proc(['camerad'], 1.75, msgs=['roadCameraState', 'wideRoadCameraState', 'driverCameraState']),
+  Proc(['camerad'], 1.75, atol=0.4, msgs=['roadCameraState', 'wideRoadCameraState', 'driverCameraState']),
   Proc(['modeld'], 1.24, atol=0.2, msgs=['modelV2']),
-  Proc(['dmonitoringmodeld'], 0.7, msgs=['driverStateV2']),
+  Proc(['dmonitoringmodeld'], 0.7, atol=0.35, msgs=['driverStateV2']),
   Proc(['encoderd'], 0.23, msgs=[]),
 ]
 

--- a/system/hardware/tici/tests/test_power_draw.py
+++ b/system/hardware/tici/tests/test_power_draw.py
@@ -31,9 +31,9 @@ class Proc:
 
 
 PROCS = [
-  Proc(['camerad'], 1.75, atol=0.4, msgs=['roadCameraState', 'wideRoadCameraState', 'driverCameraState']),
+  Proc(['camerad'], 1.65, atol=0.4, msgs=['roadCameraState', 'wideRoadCameraState', 'driverCameraState']),
   Proc(['modeld'], 1.24, atol=0.2, msgs=['modelV2']),
-  Proc(['dmonitoringmodeld'], 0.7, atol=0.35, msgs=['driverStateV2']),
+  Proc(['dmonitoringmodeld'], 0.65, atol=0.35, msgs=['driverStateV2']),
   Proc(['encoderd'], 0.23, msgs=[]),
 ]
 


### PR DESCRIPTION
Failed with lower values in:
https://jenkins.comma.life/blue/organizations/jenkins/openpilot/detail/use-non-delay-action/9/pipeline#step-405-log-357
https://jenkins.comma.life/blue/organizations/jenkins/openpilot/detail/use-non-delay-action/7/pipeline#step-340-log-359