### PR TITLE
fix qcom decoder compilation on mac with platform check

### DIFF
--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -12,7 +12,9 @@ else:
   base_libs.append('OpenCL')
 
 replay_lib_src = ["replay.cc", "consoleui.cc", "camera.cc", "filereader.cc", "logreader.cc", "framereader.cc",
-                  "route.cc", "util.cc", "seg_mgr.cc", "timeline.cc", "api.cc", "qcom_decoder.cc"]
+                  "route.cc", "util.cc", "seg_mgr.cc", "timeline.cc", "api.cc"]
+if arch != "Darwin":
+  replay_lib_src.append("qcom_decoder.cc")
 replay_lib = replay_env.Library("replay", replay_lib_src, LIBS=base_libs, FRAMEWORKS=base_frameworks)
 Export('replay_lib')
 replay_libs = [replay_lib, 'avutil', 'avcodec', 'avformat', 'bz2', 'zstd', 'curl', 'yuv', 'ncurses'] + base_libs

--- a/tools/replay/framereader.cc
+++ b/tools/replay/framereader.cc
@@ -39,9 +39,12 @@ struct DecoderManager {
     }
 
     std::unique_ptr<VideoDecoder> decoder;
+    #ifndef __APPLE__
     if (Hardware::TICI() && hw_decoder) {
       decoder = std::make_unique<QcomVideoDecoder>();
-    } else {
+    } else
+    #endif
+    {
       decoder = std::make_unique<FFmpegVideoDecoder>();
     }
 
@@ -264,6 +267,7 @@ bool FFmpegVideoDecoder::copyBuffer(AVFrame *f, VisionBuf *buf) {
   return true;
 }
 
+#ifndef __APPLE__
 bool QcomVideoDecoder::open(AVCodecParameters *codecpar, bool hw_decoder) {
   if (codecpar->codec_id != AV_CODEC_ID_HEVC) {
     rError("Hardware decoder only supports HEVC codec");
@@ -305,3 +309,4 @@ bool QcomVideoDecoder::decode(FrameReader *reader, int idx, VisionBuf *buf) {
   }
   return result;
 }
+#endif

--- a/tools/replay/framereader.h
+++ b/tools/replay/framereader.h
@@ -6,7 +6,10 @@
 #include "msgq/visionipc/visionbuf.h"
 #include "tools/replay/filereader.h"
 #include "tools/replay/util.h"
+
+#ifndef __APPLE__
 #include "tools/replay/qcom_decoder.h"
+#endif
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -65,6 +68,7 @@ private:
   AVBufferRef *hw_device_ctx = nullptr;
 };
 
+#ifndef __APPLE__
 class QcomVideoDecoder : public VideoDecoder {
 public:
   QcomVideoDecoder() {};
@@ -75,3 +79,4 @@ public:
 private:
   MsmVidc msm_vidc = MsmVidc();
 };
+#endif


### PR DESCRIPTION
on macOS
```
In file included from tools/cabana/cabana.cc:5:
In file included from ./tools/cabana/mainwin.h:16:
In file included from ./tools/cabana/videowidget.h:17:
In file included from ./tools/cabana/streams/replaystream.h:11:
In file included from ./tools/replay/replay.h:11:
In file included from ./tools/replay/camera.h:10:
In file included from ./tools/replay/framereader.h:9:
./tools/replay/qcom_decoder.h:3:10: fatal error: 'linux/videodev2.h' file not found
    3 | #include <linux/videodev2.h>
```

caused by https://github.com/commaai/openpilot/pull/35821

should allow for https://github.com/commaai/openpilot/pull/36120 to pass