### PR TITLE
jotpluggler: add icons, use monospace font, and fix ui quirks

### DIFF
--- a/tools/jotpluggler/assets/pause.png
+++ b/tools/jotpluggler/assets/pause.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ea96d8193eb9067a5efdc5d88a3099730ecafa40efcd09d7402bb3efd723603
+size 2305

--- a/tools/jotpluggler/assets/play.png
+++ b/tools/jotpluggler/assets/play.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53097ac5403b725ff1841dfa186ea770b4bb3714205824bde36ec3c2a0fb5dba
+size 2758

--- a/tools/jotpluggler/assets/split_h.png
+++ b/tools/jotpluggler/assets/split_h.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54dd035ff898d881509fa686c402a61af8ef5fb408b92414722da01f773b0d33
+size 2900

--- a/tools/jotpluggler/assets/split_v.png
+++ b/tools/jotpluggler/assets/split_v.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adbd4e5df1f58694dca9dde46d1d95b4e7471684e42e6bca9f41ea5d346e67c5
+size 3669

--- a/tools/jotpluggler/assets/x.png
+++ b/tools/jotpluggler/assets/x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d9c90cb0dd906e0b15e1f7f3fd9f0dfad3c3b0b34eeed7a7882768dc5f3961
+size 2053

--- a/tools/jotpluggler/datatree.py
+++ b/tools/jotpluggler/datatree.py
@@ -43,12 +43,13 @@ class DataTree:
 
   def create_ui(self, parent_tag: str):
     with dpg.child_window(parent=parent_tag, border=False, width=-1, height=-1):
-      dpg.add_text("Available Data")
+      dpg.add_text("Timeseries List")
       dpg.add_separator()
       dpg.add_input_text(tag="search_input", width=-1, hint="Search fields...", callback=self.search_data)
       dpg.add_separator()
-      with dpg.group(tag="data_tree_container"):
-        pass
+      with dpg.child_window(border=False, width=-1, height=-1):
+        with dpg.group(tag="data_tree_container"):
+          pass
 
   def _on_data_loaded(self, data: dict):
     with self._ui_lock:

--- a/tools/jotpluggler/layout.py
+++ b/tools/jotpluggler/layout.py
@@ -39,15 +39,18 @@ class PlotLayoutManager:
     panel_tag = self._path_to_tag(path, "panel")
     panel = layout["panel"]
     self.active_panels.append(panel)
+    text_size = int(13 * self.scale)
 
     with dpg.child_window(tag=panel_tag, parent=parent_tag, border=True, width=-1, height=-1, no_scrollbar=True):
       with dpg.group(horizontal=True):
-        dpg.add_input_text(default_value=panel.title, width=int(100 * self.scale), callback=lambda s, v: setattr(panel, "title", v))
-        dpg.add_combo(items=["Time Series"], default_value="Time Series", width=int(100 * self.scale))
-        dpg.add_button(label="Clear", callback=lambda: self.clear_panel(panel), width=int(40 * self.scale))
-        dpg.add_button(label="Delete", callback=lambda: self.delete_panel(path), width=int(40 * self.scale))
-        dpg.add_button(label="Split H", callback=lambda: self.split_panel(path, 0), width=int(50 * self.scale))
-        dpg.add_button(label="Split V", callback=lambda: self.split_panel(path, 1), width=int(50 * self.scale))
+        with dpg.child_window(width=-(text_size + 16), height=(text_size + 8), horizontal_scrollbar=True, no_scroll_with_mouse=True, border=False):
+          with dpg.group(horizontal=True):
+            dpg.add_input_text(default_value=panel.title, width=int(100 * self.scale), callback=lambda s, v: setattr(panel, "title", v))
+            dpg.add_combo(items=["Time Series"], default_value="Time Series", width=int(100 * self.scale))
+            dpg.add_button(label="Clear", callback=lambda: self.clear_panel(panel), width=int(40 * self.scale))
+            dpg.add_button(label="Split H", callback=lambda: self.split_panel(path, 0), width=int(50 * self.scale))
+            dpg.add_button(label="Split V", callback=lambda: self.split_panel(path, 1), width=int(50 * self.scale))
+        dpg.add_image_button(tag=f"{panel_tag}_x", texture_tag="x_texture", callback=lambda: self.delete_panel(path), width=text_size, height=text_size)
 
       dpg.add_separator()
 

--- a/tools/jotpluggler/layout.py
+++ b/tools/jotpluggler/layout.py
@@ -46,8 +46,8 @@ class PlotLayoutManager:
         dpg.add_combo(items=["Time Series"], default_value="Time Series", width=int(100 * self.scale))
         dpg.add_button(label="Clear", callback=lambda: self.clear_panel(panel), width=int(40 * self.scale))
         dpg.add_button(label="Delete", callback=lambda: self.delete_panel(path), width=int(40 * self.scale))
-        dpg.add_button(label="Split H", callback=lambda: self.split_panel(path, 0), width=int(40 * self.scale))
-        dpg.add_button(label="Split V", callback=lambda: self.split_panel(path, 1), width=int(40 * self.scale))
+        dpg.add_button(label="Split H", callback=lambda: self.split_panel(path, 0), width=int(50 * self.scale))
+        dpg.add_button(label="Split V", callback=lambda: self.split_panel(path, 1), width=int(50 * self.scale))
 
       dpg.add_separator()
 

--- a/tools/jotpluggler/layout.py
+++ b/tools/jotpluggler/layout.py
@@ -48,9 +48,9 @@ class PlotLayoutManager:
             dpg.add_input_text(default_value=panel.title, width=int(100 * self.scale), callback=lambda s, v: setattr(panel, "title", v))
             dpg.add_combo(items=["Time Series"], default_value="Time Series", width=int(100 * self.scale))
             dpg.add_button(label="Clear", callback=lambda: self.clear_panel(panel), width=int(40 * self.scale))
-            dpg.add_button(label="Split H", callback=lambda: self.split_panel(path, 0), width=int(50 * self.scale))
-            dpg.add_button(label="Split V", callback=lambda: self.split_panel(path, 1), width=int(50 * self.scale))
-        dpg.add_image_button(tag=f"{panel_tag}_x", texture_tag="x_texture", callback=lambda: self.delete_panel(path), width=text_size, height=text_size)
+            dpg.add_image_button(texture_tag="split_h_texture", callback=lambda: self.split_panel(path, 0), width=text_size, height=text_size)
+            dpg.add_image_button(texture_tag="split_v_texture", callback=lambda: self.split_panel(path, 1), width=text_size, height=text_size)
+        dpg.add_image_button(texture_tag="x_texture", callback=lambda: self.delete_panel(path), width=text_size, height=text_size)
 
       dpg.add_separator()
 

--- a/tools/jotpluggler/layout.py
+++ b/tools/jotpluggler/layout.py
@@ -25,25 +25,26 @@ class PlotLayoutManager:
     if dpg.does_item_exist(self.container_tag):
       dpg.delete_item(self.container_tag)
 
-    with dpg.child_window(tag=self.container_tag, parent=parent_tag, border=False, width=-1, height=-1, no_scrollbar=True):
+    with dpg.child_window(tag=self.container_tag, parent=parent_tag, border=False, width=-1, height=-1, no_scrollbar=True, no_scroll_with_mouse=True):
       container_width, container_height = dpg.get_item_rect_size(self.container_tag)
       self._create_ui_recursive(self.layout, self.container_tag, [], container_width, container_height)
 
   def _create_ui_recursive(self, layout: dict, parent_tag: str, path: list[int], width: int, height: int):
     if layout["type"] == "panel":
-      self._create_panel_ui(layout, parent_tag, path)
+      self._create_panel_ui(layout, parent_tag, path, width, height)
     else:
       self._create_split_ui(layout, parent_tag, path, width, height)
 
-  def _create_panel_ui(self, layout: dict, parent_tag: str, path: list[int]):
+  def _create_panel_ui(self, layout: dict, parent_tag: str, path: list[int], width: int, height:int):
     panel_tag = self._path_to_tag(path, "panel")
     panel = layout["panel"]
     self.active_panels.append(panel)
     text_size = int(13 * self.scale)
+    bar_height = (text_size+24) if width < int(279 * self.scale + 80) else (text_size+8) # adjust height to allow for scrollbar
 
-    with dpg.child_window(tag=panel_tag, parent=parent_tag, border=True, width=-1, height=-1, no_scrollbar=True):
+    with dpg.child_window(parent=parent_tag, border=True, width=-1, height=-1, no_scrollbar=True):
       with dpg.group(horizontal=True):
-        with dpg.child_window(width=-(text_size + 16), height=(text_size + 8), horizontal_scrollbar=True, no_scroll_with_mouse=True, border=False):
+        with dpg.child_window(tag=panel_tag, width=-(text_size + 16), height=bar_height, horizontal_scrollbar=True, no_scroll_with_mouse=True, border=False):
           with dpg.group(horizontal=True):
             dpg.add_input_text(default_value=panel.title, width=int(100 * self.scale), callback=lambda s, v: setattr(panel, "title", v))
             dpg.add_combo(items=["Time Series"], default_value="Time Series", width=int(100 * self.scale))
@@ -180,11 +181,17 @@ class PlotLayoutManager:
             dpg.configure_item(container_tag, **{size_properties[orientation]: pane_sizes[i]})
             child_width, child_height = [(pane_sizes[i], available_sizes[1]), (available_sizes[0], pane_sizes[i])][orientation]
             self._resize_splits_recursive(child_layout, child_path, child_width, child_height)
+    else: # leaf node/panel - adjust bar height to allow for scrollbar
+      panel_tag = self._path_to_tag(path, "panel")
+      if width is not None and width < int(279 * self.scale + 80):  # scaled widths of the elements in top bar + fixed 8 padding on left and right of each item
+        dpg.configure_item(panel_tag, height=(int(13*self.scale) + 24))
+      else:
+        dpg.configure_item(panel_tag, height=(int(13*self.scale) + 8))
 
   def _get_split_geometry(self, layout: dict, available_size: tuple[int, int]) -> tuple[int, int, list[int]]:
     orientation = layout["orientation"]
     num_grips = len(layout["children"]) - 1
-    usable_size = max(self.min_pane_size, available_size[orientation] - (num_grips * self.grip_size))
+    usable_size = max(self.min_pane_size, available_size[orientation] - (num_grips * (self.grip_size + 8 * (2-orientation)))) # approximate, scaling is weird
     pane_sizes = [max(self.min_pane_size, int(usable_size * prop)) for prop in layout["proportions"]]
     return orientation, usable_size, pane_sizes
 

--- a/tools/jotpluggler/pluggle.py
+++ b/tools/jotpluggler/pluggle.py
@@ -111,7 +111,6 @@ class MainController:
         dpg.add_theme_style(dpg.mvPlotStyleVar_LineWeight, scaled_thickness, category=dpg.mvThemeCat_Plots)
         dpg.add_theme_color(dpg.mvPlotCol_Line, (255, 0, 0, 128), category=dpg.mvThemeCat_Plots)
 
-
   def on_data_loaded(self, data: dict):
     duration = data.get('duration', 0.0)
     self.playback_manager.set_route_duration(duration)
@@ -141,8 +140,10 @@ class MainController:
       print(os.path.join(script_dir, "assets", "play.png"))
       play_texture = dpg.load_image(os.path.join(script_dir, "assets", "play.png"))
       pause_texture = dpg.load_image(os.path.join(script_dir, "assets", "pause.png"))
+      x_texture = dpg.load_image(os.path.join(script_dir, "assets", "x.png"))
       dpg.add_static_texture(width=play_texture[0], height=play_texture[1], default_value=play_texture[3], tag="play_texture")
       dpg.add_static_texture(width=pause_texture[0], height=pause_texture[1], default_value=pause_texture[3], tag="pause_texture")
+      dpg.add_static_texture(width=x_texture[0], height=x_texture[1], default_value=x_texture[3], tag="x_texture")
 
     with dpg.window(tag="Primary Window"):
       with dpg.group(horizontal=True):

--- a/tools/jotpluggler/pluggle.py
+++ b/tools/jotpluggler/pluggle.py
@@ -137,17 +137,9 @@ class MainController:
   def setup_ui(self):
     with dpg.texture_registry():
       script_dir = os.path.dirname(os.path.realpath(__file__))
-      print(os.path.join(script_dir, "assets", "play.png"))
-      play_texture = dpg.load_image(os.path.join(script_dir, "assets", "play.png"))
-      pause_texture = dpg.load_image(os.path.join(script_dir, "assets", "pause.png"))
-      x_texture = dpg.load_image(os.path.join(script_dir, "assets", "x.png"))
-      split_h_texture = dpg.load_image(os.path.join(script_dir, "assets", "split_h.png"))
-      split_v_texture = dpg.load_image(os.path.join(script_dir, "assets", "split_v.png"))
-      dpg.add_static_texture(width=play_texture[0], height=play_texture[1], default_value=play_texture[3], tag="play_texture")
-      dpg.add_static_texture(width=pause_texture[0], height=pause_texture[1], default_value=pause_texture[3], tag="pause_texture")
-      dpg.add_static_texture(width=x_texture[0], height=x_texture[1], default_value=x_texture[3], tag="x_texture")
-      dpg.add_static_texture(width=split_h_texture[0], height=split_h_texture[1], default_value=split_h_texture[3], tag="split_h_texture")
-      dpg.add_static_texture(width=split_v_texture[0], height=split_v_texture[1], default_value=split_v_texture[3], tag="split_v_texture")
+      for image in ["play", "pause", "x", "split_h", "split_v"]:
+        texture = dpg.load_image(os.path.join(script_dir, "assets", f"{image}.png"))
+        dpg.add_static_texture(width=texture[0], height=texture[1], default_value=texture[3], tag=f"{image}_texture")
 
     with dpg.window(tag="Primary Window"):
       with dpg.group(horizontal=True):

--- a/tools/jotpluggler/pluggle.py
+++ b/tools/jotpluggler/pluggle.py
@@ -162,13 +162,13 @@ class MainController:
 
         # Right panel - Plots and timeline
         with dpg.group(tag="right_panel"):
-          with dpg.child_window(label="Plot Window", border=True, height=-(30 + 13 * self.scale), tag="main_plot_area"):
+          with dpg.child_window(label="Plot Window", border=True, height=-(32 + 13 * self.scale), tag="main_plot_area"):
             self.plot_layout_manager.create_ui("main_plot_area")
 
           with dpg.child_window(label="Timeline", border=True):
             with dpg.table(header_row=False, borders_innerH=False, borders_innerV=False, borders_outerH=False, borders_outerV=False):
               btn_size = int(13 * self.scale)
-              dpg.add_table_column(width_fixed=True, init_width_or_weight=(btn_size + 5))  # Play button
+              dpg.add_table_column(width_fixed=True, init_width_or_weight=(btn_size + 8))  # Play button
               dpg.add_table_column(width_stretch=True)  # Timeline slider
               dpg.add_table_column(width_fixed=True, init_width_or_weight=int(50 * self.scale))  # FPS counter
               with dpg.table_row():

--- a/tools/jotpluggler/pluggle.py
+++ b/tools/jotpluggler/pluggle.py
@@ -218,7 +218,7 @@ def main(route_to_load=None):
     scale = 1
 
   with dpg.font_registry():
-    default_font = dpg.add_font(os.path.join(BASEDIR, "selfdrive/assets/fonts/Inter-Regular.ttf"), int(13 * scale))
+    default_font = dpg.add_font(os.path.join(BASEDIR, "selfdrive/assets/fonts/JetBrainsMono-Medium.ttf"), int(13 * scale))
   dpg.bind_font(default_font)
 
   viewport_width, viewport_height = int(1200 * scale), int(800 * scale)

--- a/tools/jotpluggler/pluggle.py
+++ b/tools/jotpluggler/pluggle.py
@@ -141,9 +141,13 @@ class MainController:
       play_texture = dpg.load_image(os.path.join(script_dir, "assets", "play.png"))
       pause_texture = dpg.load_image(os.path.join(script_dir, "assets", "pause.png"))
       x_texture = dpg.load_image(os.path.join(script_dir, "assets", "x.png"))
+      split_h_texture = dpg.load_image(os.path.join(script_dir, "assets", "split_h.png"))
+      split_v_texture = dpg.load_image(os.path.join(script_dir, "assets", "split_v.png"))
       dpg.add_static_texture(width=play_texture[0], height=play_texture[1], default_value=play_texture[3], tag="play_texture")
       dpg.add_static_texture(width=pause_texture[0], height=pause_texture[1], default_value=pause_texture[3], tag="pause_texture")
       dpg.add_static_texture(width=x_texture[0], height=x_texture[1], default_value=x_texture[3], tag="x_texture")
+      dpg.add_static_texture(width=split_h_texture[0], height=split_h_texture[1], default_value=split_h_texture[3], tag="split_h_texture")
+      dpg.add_static_texture(width=split_v_texture[0], height=split_v_texture[1], default_value=split_v_texture[3], tag="split_v_texture")
 
     with dpg.window(tag="Primary Window"):
       with dpg.group(horizontal=True):


### PR DESCRIPTION
use icons for play, pause, delete, and icons for splitting the panels

using the monospace font that comes with openpilot in assets, not sure if I like the font, but monospace is a lot better with the changing data

fixed a few scaling/ui quirks