### PR TITLE
pin pycapnp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   # core
   "cffi",
   "scons",
-  "pycapnp",
+  "pycapnp==2.1.0",
   "Cython",
   "setuptools",
   "numpy >=2.0",


### PR DESCRIPTION
Upstream pycapnp published a package that changes the API for capnp `Data` field types, capnproto/pycapnp#380.

This is probably not a hard change to accommodate, but pinning the package to un-break our builds until that change can be validated.

See also:
* commaai/opendbc#2790
* commaai/agnos-builder#488