### PR TITLE
fix `is_dirty` when switching branch with `updated`

### DIFF
--- a/system/updated/updated.py
+++ b/system/updated/updated.py
@@ -113,6 +113,7 @@ def setup_git_options(cwd: str) -> None:
     ("protocol.version", "2"),
     ("gc.auto", "0"),
     ("gc.autoDetach", "false"),
+    ("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"),
   ]
   for option, value in git_cfg:
     run(["git", "config", option, value], cwd)
@@ -389,6 +390,7 @@ class Updater:
     cloudlog.info("git reset in progress")
     cmds = [
       ["git", "checkout", "--force", "--no-recurse-submodules", "-B", branch, "FETCH_HEAD"],
+      ["git", "branch", "--set-upstream-to", f"origin/{branch}"],
       ["git", "reset", "--hard"],
       ["git", "clean", "-xdff"],
       ["git", "submodule", "sync"],

--- a/system/version.py
+++ b/system/version.py
@@ -37,9 +37,7 @@ def is_prebuilt(path: str = BASEDIR) -> bool:
 
 @cache
 def is_dirty(cwd: str = BASEDIR) -> bool:
-  origin = get_origin()
-  branch = get_branch()
-  if not origin or not branch:
+  if not get_origin() or not get_short_branch():
     return True
 
   dirty = False
@@ -52,6 +50,9 @@ def is_dirty(cwd: str = BASEDIR) -> bool:
       except subprocess.CalledProcessError:
         pass
 
+      branch = get_branch()
+      if not branch:
+        return True
       dirty = (subprocess.call(["git", "diff-index", "--quiet", branch, "--"], cwd=cwd)) != 0
   except subprocess.CalledProcessError:
     cloudlog.exception("git subprocess failed while checking dirty")


### PR DESCRIPTION
Currently, if you switch branch with `updated`, your new branch will be marked as dirty since it does not have an upstream branch (only `release3` does)