### PR TITLE
raylib: fix shader antialiasing

### DIFF
--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -101,6 +101,7 @@ void main() {
 
   bool inside = isPointInsidePolygon(pixel);
   float sd = (inside ? 1.0 : -1.0) * distanceToEdge(pixel);
+
   // ~1 pixel wide anti-aliasing
   float w = max(0.75, fwidth(sd));
 

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -99,19 +99,12 @@ float distanceToEdge(vec2 p) {
 void main() {
   vec2 pixel = fragTexCoord * resolution;
 
-  // Compute pixel size for anti-aliasing
-  vec2 pixelGrad = vec2(dFdx(pixel.x), dFdy(pixel.y));
-  float pixelSize = length(pixelGrad);
-  float aaWidth = max(0.5, pixelSize * 1.5);
-
   bool inside = isPointInsidePolygon(pixel);
-  if (inside) {
-    finalColor = useGradient == 1 ? getGradientColor(pixel) : fillColor;
-    return;
-  }
+  float sd = (inside ? 1.0 : -1.0) * distanceToEdge(pixel);
+  // ~1 pixel wide anti-aliasing
+  float w = max(0.75, fwidth(sd));
 
-  float sd = -distanceToEdge(pixel);
-  float alpha = smoothstep(-aaWidth, aaWidth, sd);
+  float alpha = smoothstep(-w, w, sd);
   if (alpha > 0.0){
     vec4 color = useGradient == 1 ? getGradientColor(pixel) : fillColor;
     finalColor = vec4(color.rgb, color.a * alpha);


### PR DESCRIPTION
before:

<img width="2158" height="1080" alt="image" src="https://github.com/user-attachments/assets/2c9974e7-379c-4098-a08c-0a6b537059b8" />

<img width="498" height="101" alt="image" src="https://github.com/user-attachments/assets/bd29b56b-0596-4a0a-a068-bff0326e741b" />


after:

<img width="422" height="85" alt="image" src="https://github.com/user-attachments/assets/6a237469-f29a-4f21-bf6f-42e1f98d1df8" />

<img width="2155" height="1078" alt="image" src="https://github.com/user-attachments/assets/a9c5bcb4-a3bf-473c-804b-8b22267a7a70" />
