### PR TITLE
fix `is_dirty` when fetching branch with `updated`

### DIFF
--- a/system/updated/updated.py
+++ b/system/updated/updated.py
@@ -382,6 +382,8 @@ class Updater:
 
     setup_git_options(OVERLAY_MERGED)
 
+    run(["git", "config", "--replace-all", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], OVERLAY_MERGED)
+
     branch = self.target_branch
     git_fetch_output = run(["git", "fetch", "origin", branch], OVERLAY_MERGED)
     cloudlog.info("git fetch success: %s", git_fetch_output)
@@ -389,6 +391,7 @@ class Updater:
     cloudlog.info("git reset in progress")
     cmds = [
       ["git", "checkout", "--force", "--no-recurse-submodules", "-B", branch, "FETCH_HEAD"],
+      ["git", "branch", "--set-upstream-to", f"origin/{branch}"],
       ["git", "reset", "--hard"],
       ["git", "clean", "-xdff"],
       ["git", "submodule", "sync"],

--- a/system/version.py
+++ b/system/version.py
@@ -37,9 +37,7 @@ def is_prebuilt(path: str = BASEDIR) -> bool:
 
 @cache
 def is_dirty(cwd: str = BASEDIR) -> bool:
-  origin = get_origin()
-  branch = get_branch()
-  if not origin or not branch:
+  if not get_origin() or not get_short_branch():
     return True
 
   dirty = False
@@ -52,6 +50,9 @@ def is_dirty(cwd: str = BASEDIR) -> bool:
       except subprocess.CalledProcessError:
         pass
 
+      branch = get_branch()
+      if not branch:
+        return True
       dirty = (subprocess.call(["git", "diff-index", "--quiet", branch, "--"], cwd=cwd)) != 0
   except subprocess.CalledProcessError:
     cloudlog.exception("git subprocess failed while checking dirty")


### PR DESCRIPTION
Currently, if you switch branch with `updated`, your new branch will be marked as dirty since it does not have an upstream branch (only `release3` does)