### PR TITLE
add ssh hostname comma- prefix for convenience

### DIFF
--- a/tools/scripts/ssh.py
+++ b/tools/scripts/ssh.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
   if args.debug:
     command += ["-v"]
   command += [
-    f"comma@{dongle_id}",
+    f"comma@comma-{dongle_id}",
   ]
   if args.debug:
     print(" ".join([f"'{c}'" if " " in c else c for c in command]))


### PR DESCRIPTION
When you have a custom key set up for ssh and multiple vehicles, support the generic ssh config [described in the docs](https://docs.comma.ai/how-to/connect-to-comma/#sshcommaai-proxy) using `comma-*` for the hostname matching, preventing the need to specify `--key` when running `ssh.py`.