### PR TITLE
Dockerfile.openpilot uv run scons

### DIFF
--- a/Dockerfile.openpilot
+++ b/Dockerfile.openpilot
@@ -9,4 +9,6 @@ WORKDIR ${OPENPILOT_PATH}
 
 COPY . ${OPENPILOT_PATH}/
 
-RUN scons --cache-readonly -j$(nproc)
+ENV UV_BIN="/home/batman/.local/bin/"
+ENV PATH="$UV_BIN:$PATH"
+RUN uv run scons --cache-readonly -j$(nproc)

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -71,8 +71,8 @@ USER $USER
 COPY --chown=$USER pyproject.toml uv.lock /home/$USER
 COPY --chown=$USER tools/install_python_dependencies.sh /home/$USER/tools/
 
-ENV UV_PROJECT_ENVIRONMENT=/home/$USER/.venv
-ENV PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
+ENV VIRTUAL_ENV=/home/$USER/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN cd /home/$USER && \
     tools/install_python_dependencies.sh && \
     rm -rf tools/ pyproject.toml uv.lock .cache

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -71,8 +71,8 @@ USER $USER
 COPY --chown=$USER pyproject.toml uv.lock /home/$USER
 COPY --chown=$USER tools/install_python_dependencies.sh /home/$USER/tools/
 
-ENV VIRTUAL_ENV=/home/$USER/.venv
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV UV_PROJECT_ENVIRONMENT=/home/$USER/.venv
+ENV PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
 RUN cd /home/$USER && \
     tools/install_python_dependencies.sh && \
     rm -rf tools/ pyproject.toml uv.lock .cache


### PR DESCRIPTION
Dockerfile.openpilot_base syncs venv in `/home/batman`, so `_openpilot.pth` points there
Dockerfile.openpilot then doesn't have openpilot on path when running scons and it fails on opendbc import (after [0c90bdb434666c5fbf347e8521e7b81375e02ff2](https://github.com/commaai/opendbc/commit/0c90bdb434666c5fbf347e8521e7b81375e02ff2))
`uv run scons` syncs venv again to have `_openpilot.pth` point to `$OPENPILOT_PATH`