### PR TITLE
raylib html renderer: fixups

### DIFF
--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -60,7 +60,7 @@ class DeviceLayout(Widget):
       button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
       dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
     ]
-    # regulatory_btn.set_visible(TICI)
+    regulatory_btn.set_visible(TICI)
     return items
 
   def _render(self, rect):

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -60,7 +60,7 @@ class DeviceLayout(Widget):
       button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
       dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
     ]
-    regulatory_btn.set_visible(TICI)
+    # regulatory_btn.set_visible(TICI)
     return items
 
   def _render(self, rect):

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -1,4 +1,6 @@
 import re
+import time
+
 import pyray as rl
 from dataclasses import dataclass
 from enum import Enum
@@ -191,6 +193,7 @@ class HtmlRenderer(Widget):
     return current_y - rect.y
 
   def get_total_height(self, content_width: int) -> float:
+    t = time.monotonic()
     total_height = 0.0
     padding = 20
     usable_width = content_width - (padding * 2)
@@ -211,6 +214,7 @@ class HtmlRenderer(Widget):
 
       total_height += element.margin_bottom
 
+    print(f"HtmlRenderer.get_total_height took {(time.monotonic() - t) * 1000:.4f}ms")
     return total_height
 
   def _get_font(self, weight: FontWeight):

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -124,9 +124,6 @@ class HtmlRenderer(Widget):
         elif tag == ElementType.UL:
           self._indent_level = self._indent_level + 1 if is_start_tag else max(0, self._indent_level - 1)
 
-        # elif is_start_tag:
-        #   current_tag = tag
-
         elif is_start_tag or is_end_tag:
           # Always add content regardless of opening or closing tag
           close_tag()
@@ -151,6 +148,7 @@ class HtmlRenderer(Widget):
       font_weight=style["weight"],
       margin_top=style["margin_top"],
       margin_bottom=style["margin_bottom"],
+      indent_level=self._indent_level,
     )
 
     self.elements.append(element)
@@ -181,7 +179,8 @@ class HtmlRenderer(Widget):
           if current_y > rect.y + rect.height:
             break
 
-          rl.draw_text_ex(font, line, rl.Vector2(rect.x + padding, current_y), element.font_size, 0, self._text_color)
+          text_x = rect.x + (max(element.indent_level - 1, 0) * LIST_INDENT_PX)
+          rl.draw_text_ex(font, line, rl.Vector2(text_x + padding, current_y), element.font_size, 0, self._text_color)
 
           current_y += element.font_size * element.line_height
 

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -55,9 +55,6 @@ class HtmlRenderer(Widget):
     super().__init__()
     self._text_color = text_color
 
-    self._total_height = 0.0
-    self._height_needs_recompute = True
-    self._prev_content_width = -1
     self._normal_font = gui_app.font(FontWeight.NORMAL)
     self._bold_font = gui_app.font(FontWeight.BOLD)
     self._indent_level = 0
@@ -92,7 +89,6 @@ class HtmlRenderer(Widget):
 
   def parse_html_content(self, html_content: str) -> None:
     self.elements.clear()
-    self._height_needs_recompute = True
 
     # Remove HTML comments
     html_content = re.sub(r'<!--.*?-->', '', html_content, flags=re.DOTALL)
@@ -196,32 +192,27 @@ class HtmlRenderer(Widget):
     return current_y - rect.y
 
   def get_total_height(self, content_width: int) -> float:
-    if not self._height_needs_recompute and self._prev_content_width == content_width:
-      return self._total_height
-
-    self._total_height = 0.0
+    total_height = 0.0
     padding = 20
     usable_width = content_width - (padding * 2)
 
     for element in self.elements:
       if element.type == ElementType.BR:
-        self._total_height += element.margin_bottom
+        total_height += element.margin_bottom
         continue
 
-      self._total_height += element.margin_top
+      total_height += element.margin_top
 
       if element.content:
-        font = self._get_font(element.font_weight)
+        font = get_font(element.font_weight)
         wrapped_lines = wrap_text(font, element.content, element.font_size, int(usable_width))
 
         for _ in wrapped_lines:
-          self._total_height += element.font_size * element.line_height
+          total_height += element.font_size * element.line_height
 
-      self._total_height += element.margin_bottom
+      total_height += element.margin_bottom
 
-    self._prev_content_width = content_width
-    self._height_needs_recompute = False
-    return self._total_height
+    return total_height
 
   def _get_font(self, weight: FontWeight):
     if weight == FontWeight.BOLD:

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -33,11 +33,16 @@ class HtmlElement:
 
 
 class HtmlRenderer(Widget):
-  def __init__(self, file_path: str | None = None, text: str | None = None):
+  def __init__(self, file_path: str | None = None, text: str | None = None,
+               text_size: dict | None = None, text_color: rl.Color = rl.WHITE):
     super().__init__()
+    self._text_color = text_color
     self.elements: list[HtmlElement] = []
     self._normal_font = gui_app.font(FontWeight.NORMAL)
     self._bold_font = gui_app.font(FontWeight.BOLD)
+
+    if text_size is None:
+      text_size = {}
 
     self.styles: dict[ElementType, dict[str, Any]] = {
       ElementType.H1: {"size": 68, "weight": FontWeight.BOLD, "margin_top": 20, "margin_bottom": 16},
@@ -46,7 +51,7 @@ class HtmlRenderer(Widget):
       ElementType.H4: {"size": 48, "weight": FontWeight.BOLD, "margin_top": 16, "margin_bottom": 8},
       ElementType.H5: {"size": 44, "weight": FontWeight.BOLD, "margin_top": 12, "margin_bottom": 6},
       ElementType.H6: {"size": 40, "weight": FontWeight.BOLD, "margin_top": 10, "margin_bottom": 4},
-      ElementType.P: {"size": 38, "weight": FontWeight.NORMAL, "margin_top": 8, "margin_bottom": 12},
+      ElementType.P: {"size": text_size.get(ElementType.P, 38), "weight": FontWeight.NORMAL, "margin_top": 8, "margin_bottom": 12},
       ElementType.BR: {"size": 0, "weight": FontWeight.NORMAL, "margin_top": 0, "margin_bottom": 12},
     }
 
@@ -132,7 +137,7 @@ class HtmlRenderer(Widget):
           if current_y > rect.y + rect.height:
             break
 
-          rl.draw_text_ex(font, line, rl.Vector2(rect.x + padding, current_y), element.font_size, 0, rl.WHITE)
+          rl.draw_text_ex(font, line, rl.Vector2(rect.x + padding, current_y), element.font_size, 0, self._text_color)
 
           current_y += element.font_size * element.line_height
 

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -1,6 +1,4 @@
 import re
-import time
-
 import pyray as rl
 from dataclasses import dataclass
 from enum import Enum
@@ -193,7 +191,6 @@ class HtmlRenderer(Widget):
     return current_y - rect.y
 
   def get_total_height(self, content_width: int) -> float:
-    t = time.monotonic()
     total_height = 0.0
     padding = 20
     usable_width = content_width - (padding * 2)
@@ -214,7 +211,6 @@ class HtmlRenderer(Widget):
 
       total_height += element.margin_bottom
 
-    print(f"HtmlRenderer.get_total_height took {(time.monotonic() - t) * 1000:.4f}ms")
     return total_height
 
   def _get_font(self, weight: FontWeight):

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -27,7 +27,6 @@ class HtmlElement:
   content: str
   font_size: int
   font_weight: FontWeight
-  color: rl.Color
   margin_top: int
   margin_bottom: int
   line_height: float = 1.2
@@ -41,14 +40,14 @@ class HtmlRenderer(Widget):
     self._bold_font = gui_app.font(FontWeight.BOLD)
 
     self.styles: dict[ElementType, dict[str, Any]] = {
-      ElementType.H1: {"size": 68, "weight": FontWeight.BOLD, "color": rl.BLACK, "margin_top": 20, "margin_bottom": 16},
-      ElementType.H2: {"size": 60, "weight": FontWeight.BOLD, "color": rl.BLACK, "margin_top": 24, "margin_bottom": 12},
-      ElementType.H3: {"size": 52, "weight": FontWeight.BOLD, "color": rl.BLACK, "margin_top": 20, "margin_bottom": 10},
-      ElementType.H4: {"size": 48, "weight": FontWeight.BOLD, "color": rl.BLACK, "margin_top": 16, "margin_bottom": 8},
-      ElementType.H5: {"size": 44, "weight": FontWeight.BOLD, "color": rl.BLACK, "margin_top": 12, "margin_bottom": 6},
-      ElementType.H6: {"size": 40, "weight": FontWeight.BOLD, "color": rl.BLACK, "margin_top": 10, "margin_bottom": 4},
-      ElementType.P: {"size": 38, "weight": FontWeight.NORMAL, "color": rl.Color(40, 40, 40, 255), "margin_top": 8, "margin_bottom": 12},
-      ElementType.BR: {"size": 0, "weight": FontWeight.NORMAL, "color": rl.BLACK, "margin_top": 0, "margin_bottom": 12},
+      ElementType.H1: {"size": 68, "weight": FontWeight.BOLD, "margin_top": 20, "margin_bottom": 16},
+      ElementType.H2: {"size": 60, "weight": FontWeight.BOLD, "margin_top": 24, "margin_bottom": 12},
+      ElementType.H3: {"size": 52, "weight": FontWeight.BOLD, "margin_top": 20, "margin_bottom": 10},
+      ElementType.H4: {"size": 48, "weight": FontWeight.BOLD, "margin_top": 16, "margin_bottom": 8},
+      ElementType.H5: {"size": 44, "weight": FontWeight.BOLD, "margin_top": 12, "margin_bottom": 6},
+      ElementType.H6: {"size": 40, "weight": FontWeight.BOLD, "margin_top": 10, "margin_bottom": 4},
+      ElementType.P: {"size": 38, "weight": FontWeight.NORMAL, "margin_top": 8, "margin_bottom": 12},
+      ElementType.BR: {"size": 0, "weight": FontWeight.NORMAL, "margin_top": 0, "margin_bottom": 12},
     }
 
     if file_path is not None:
@@ -101,7 +100,6 @@ class HtmlRenderer(Widget):
       content=content,
       font_size=style["size"],
       font_weight=style["weight"],
-      color=style["color"],
       margin_top=style["margin_top"],
       margin_bottom=style["margin_bottom"],
     )

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -11,6 +11,7 @@ from openpilot.system.ui.widgets.button import Button, ButtonStyle
 
 LIST_INDENT_PX = 40
 
+
 class ElementType(Enum):
   H1 = "h1"
   H2 = "h2"

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -197,31 +197,31 @@ class HtmlRenderer(Widget):
 
   def get_total_height(self, content_width: int) -> float:
     if not self._height_needs_recompute and self._prev_content_width == content_width:
-      return self.total_height
+      return self._total_height
 
-    self.total_height = 0.0
+    self._total_height = 0.0
     padding = 20
     usable_width = content_width - (padding * 2)
 
     for element in self.elements:
       if element.type == ElementType.BR:
-        self.total_height += element.margin_bottom
+        self._total_height += element.margin_bottom
         continue
 
-      self.total_height += element.margin_top
+      self._total_height += element.margin_top
 
       if element.content:
         font = self._get_font(element.font_weight)
         wrapped_lines = wrap_text(font, element.content, element.font_size, int(usable_width))
 
         for _ in wrapped_lines:
-          self.total_height += element.font_size * element.line_height
+          self._total_height += element.font_size * element.line_height
 
-      self.total_height += element.margin_bottom
+      self._total_height += element.margin_bottom
 
     self._prev_content_width = content_width
     self._height_needs_recompute = False
-    return self.total_height
+    return self._total_height
 
   def _get_font(self, weight: FontWeight):
     if weight == FontWeight.BOLD:

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -54,7 +54,6 @@ class HtmlRenderer(Widget):
                text_size: dict | None = None, text_color: rl.Color = rl.WHITE):
     super().__init__()
     self._text_color = text_color
-
     self._normal_font = gui_app.font(FontWeight.NORMAL)
     self._bold_font = gui_app.font(FontWeight.BOLD)
     self._indent_level = 0

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -203,7 +203,7 @@ class HtmlRenderer(Widget):
       total_height += element.margin_top
 
       if element.content:
-        font = get_font(element.font_weight)
+        font = self._get_font(element.font_weight)
         wrapped_lines = wrap_text(font, element.content, element.font_size, int(usable_width))
 
         for _ in wrapped_lines:


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/36245

- more robust parsing, supports missing tags like browsers
  - this means that the valid markdown HTML that updated gave us is now parsed properly (even though it was technically correct, the previous strict approach didn't work with it)
- support nested list indenting
- supports no tag text (to use in description of all list items), we don't lose text anymore -- again like browsers
- ~cache height~ - on 3X this takes up to 7ms to compute! will do in another PR though