### PR TITLE
raylib: cache wrap text

### DIFF
--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -60,7 +60,7 @@ class DeviceLayout(Widget):
       button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
       dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
     ]
-    # regulatory_btn.set_visible(TICI)
+    regulatory_btn.set_visible(TICI)
     return items
 
   def _render(self, rect):

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -60,7 +60,7 @@ class DeviceLayout(Widget):
       button_item("Change Language", "CHANGE", callback=self._show_language_selection, enabled=ui_state.is_offroad),
       dual_button_item("Reboot", "Power Off", left_callback=self._reboot_prompt, right_callback=self._power_off_prompt),
     ]
-    regulatory_btn.set_visible(TICI)
+    # regulatory_btn.set_visible(TICI)
     return items
 
   def _render(self, rect):

--- a/system/ui/lib/wrap_text.py
+++ b/system/ui/lib/wrap_text.py
@@ -36,7 +36,14 @@ def _break_long_word(font: rl.Font, word: str, font_size: int, max_width: int) -
   return parts
 
 
+_cache: dict[int, list[str]] = {}
+
+
 def wrap_text(font: rl.Font, text: str, font_size: int, max_width: int) -> list[str]:
+  key = hash((font.texture.id, text, font_size, max_width))
+  if key in _cache:
+    return _cache[key]
+
   if not text or max_width <= 0:
     return []
 
@@ -100,4 +107,5 @@ def wrap_text(font: rl.Font, text: str, font_size: int, max_width: int) -> list[
     # Add all lines from this paragraph
     all_lines.extend(lines)
 
+  _cache[key] = all_lines
   return all_lines

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -1,6 +1,4 @@
 import re
-import time
-
 import pyray as rl
 from dataclasses import dataclass
 from enum import Enum
@@ -193,7 +191,6 @@ class HtmlRenderer(Widget):
     return current_y - rect.y
 
   def get_total_height(self, content_width: int) -> float:
-    t = time.monotonic()
     total_height = 0.0
     padding = 20
     usable_width = content_width - (padding * 2)
@@ -214,7 +211,6 @@ class HtmlRenderer(Widget):
 
       total_height += element.margin_bottom
 
-    print(f"HtmlRenderer.get_total_height took {(time.monotonic() - t) * 1000:.4f} ms for {len(self.elements)} elements")
     return total_height
 
   def _get_font(self, weight: FontWeight):

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -155,6 +155,7 @@ class HtmlRenderer(Widget):
     self.elements.append(element)
 
   def _render(self, rect: rl.Rectangle):
+    # TODO: speed up by removing duplicate calculations across renders
     current_y = rect.y
     padding = 20
     content_width = rect.width - (padding * 2)

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -1,4 +1,6 @@
 import re
+import time
+
 import pyray as rl
 from dataclasses import dataclass
 from enum import Enum
@@ -191,6 +193,7 @@ class HtmlRenderer(Widget):
     return current_y - rect.y
 
   def get_total_height(self, content_width: int) -> float:
+    t = time.monotonic()
     total_height = 0.0
     padding = 20
     usable_width = content_width - (padding * 2)
@@ -211,6 +214,7 @@ class HtmlRenderer(Widget):
 
       total_height += element.margin_bottom
 
+    print(f"HtmlRenderer.get_total_height took {(time.monotonic() - t) * 1000:.4f} ms for {len(self.elements)} elements")
     return total_height
 
   def _get_font(self, weight: FontWeight):


### PR DESCRIPTION
About 10x speed up for html renderer's get total height (7ms to 0.7ms on device, 0.8ms to 0.08ms on PC)

still pretty slow, but way better and simpler than approach from https://github.com/commaai/openpilot/pull/36257