### PR TITLE
improve webrtc stack for use in camera focusing

### DIFF
--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdlib>
 #include <vector>
 
 #include "cereal/messaging/messaging.h"
@@ -46,7 +47,8 @@ struct EncoderSettings {
   }
 
   static EncoderSettings StreamEncoderSettings() {
-    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::QCAMERA_H264, .bitrate = 1'000'000, .gop_size = 15};
+    int _stream_bitrate = getenv("STREAM_BITRATE") ? atoi(getenv("STREAM_BITRATE")) : 1'000'000;
+    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::QCAMERA_H264, .bitrate = _stream_bitrate , .gop_size = 15};
   }
 };
 

--- a/system/webrtc/device/video.py
+++ b/system/webrtc/device/video.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import av
+import time
 from teleoprtc.tracks import TiciVideoStreamTrack
 
 from cereal import messaging
@@ -32,10 +33,12 @@ class LiveStreamVideoStreamTrack(TiciVideoStreamTrack):
 
     packet = av.Packet(evta.header + evta.data)
     packet.time_base = self._time_base
-    packet.pts = self._pts
 
-    self.log_debug("track sending frame %s", self._pts)
-    self._pts += self._dt * self._clock_rate
+    if getattr(self,"_t0_ns", None) is None:
+      self._t0_ns = time.monotonic_ns()
+    self._pts =  ((time.monotonic_ns()-self._t0_ns) * self._clock_rate) // 1_000_000_000
+    packet.pts = self._pts
+    self.log_debug("track sending frame %d", self._pts)
 
     return packet
 

--- a/system/webrtc/device/video.py
+++ b/system/webrtc/device/video.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 
 import av
-
 from teleoprtc.tracks import TiciVideoStreamTrack
 
 from cereal import messaging

--- a/system/webrtc/device/video.py
+++ b/system/webrtc/device/video.py
@@ -21,6 +21,7 @@ class LiveStreamVideoStreamTrack(TiciVideoStreamTrack):
 
     self._sock = messaging.sub_sock(self.camera_to_sock_mapping[camera_type], conflate=True)
     self._pts = 0
+    self._t0_ns = time.monotonic_ns()
 
   async def recv(self):
     while True:
@@ -34,8 +35,6 @@ class LiveStreamVideoStreamTrack(TiciVideoStreamTrack):
     packet = av.Packet(evta.header + evta.data)
     packet.time_base = self._time_base
 
-    if getattr(self,"_t0_ns", None) is None:
-      self._t0_ns = time.monotonic_ns()
     self._pts =  ((time.monotonic_ns()-self._t0_ns) * self._clock_rate) // 1_000_000_000
     packet.pts = self._pts
     self.log_debug("track sending frame %d", self._pts)

--- a/system/webrtc/device/video.py
+++ b/system/webrtc/device/video.py
@@ -35,7 +35,7 @@ class LiveStreamVideoStreamTrack(TiciVideoStreamTrack):
     packet = av.Packet(evta.header + evta.data)
     packet.time_base = self._time_base
 
-    self._pts =  ((time.monotonic_ns()-self._t0_ns) * self._clock_rate) // 1_000_000_000
+    self._pts =  ((time.monotonic_ns() - self._t0_ns) * self._clock_rate) // 1_000_000_000
     packet.pts = self._pts
     self.log_debug("track sending frame %d", self._pts)
 

--- a/system/webrtc/device/video.py
+++ b/system/webrtc/device/video.py
@@ -1,7 +1,8 @@
 import asyncio
+import time
 
 import av
-import time
+
 from teleoprtc.tracks import TiciVideoStreamTrack
 
 from cereal import messaging

--- a/system/webrtc/tests/test_stream_session.py
+++ b/system/webrtc/tests/test_stream_session.py
@@ -84,7 +84,7 @@ class TestStreamSession:
       if i == 0:
         start_ns = time.monotonic_ns()
         start_pts = packet.pts
-      assert abs(i+ packet.pts - (start_pts + (((time.monotonic_ns()-start_ns) * VIDEO_CLOCK_RATE)//1_000_000_000))) < 450 #5ms
+      assert abs(i + packet.pts - (start_pts + (((time.monotonic_ns() - start_ns) * VIDEO_CLOCK_RATE) // 1_000_000_000))) < 450 #5ms
       assert packet.size == 0
 
   def test_input_audio_track(self, mocker):

--- a/system/webrtc/tests/test_stream_session.py
+++ b/system/webrtc/tests/test_stream_session.py
@@ -15,7 +15,6 @@ from cereal import messaging, log
 from openpilot.system.webrtc.webrtcd import CerealOutgoingMessageProxy, CerealIncomingMessageProxy
 from openpilot.system.webrtc.device.video import LiveStreamVideoStreamTrack
 from openpilot.system.webrtc.device.audio import AudioInputStreamTrack
-from openpilot.common.realtime import DT_DMON
 
 
 class TestStreamSession:

--- a/system/webrtc/tests/test_stream_session.py
+++ b/system/webrtc/tests/test_stream_session.py
@@ -82,8 +82,8 @@ class TestStreamSession:
       packet = self.loop.run_until_complete(track.recv())
       assert packet.time_base == VIDEO_TIME_BASE
       if i == 0:
-          start_ns = time.monotonic_ns()
-          start_pts = packet.pts
+        start_ns = time.monotonic_ns()
+        start_pts = packet.pts
       assert abs(i+ packet.pts - (start_pts + (((time.monotonic_ns()-start_ns) * VIDEO_CLOCK_RATE)//1_000_000_000))) < 450 #5ms
       assert packet.size == 0
 

--- a/system/webrtc/tests/test_stream_session.py
+++ b/system/webrtc/tests/test_stream_session.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import time
 # for aiortc and its dependencies
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -81,7 +82,10 @@ class TestStreamSession:
     for i in range(5):
       packet = self.loop.run_until_complete(track.recv())
       assert packet.time_base == VIDEO_TIME_BASE
-      assert packet.pts == int(i * DT_DMON * VIDEO_CLOCK_RATE)
+      if i == 0:
+          start_ns = time.monotonic_ns()
+          start_pts = packet.pts
+      assert abs(i+ packet.pts - (start_pts + (((time.monotonic_ns()-start_ns) * VIDEO_CLOCK_RATE)//1_000_000_000))) < 450 #5ms
       assert packet.size == 0
 
   def test_input_audio_track(self, mocker):

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -242,8 +242,8 @@ async def get_schema(request: 'web.Request'):
 async def post_notify(request: 'web.Request'):
   try:
     payload = await request.json()
-  except Exception:
-    raise web.HTTPBadRequest(text="Invalid JSON") from None
+  except e:
+    raise web.HTTPBadRequest(text="Invalid JSON") from e
 
   for session in list(request.app.get('streams', {}).values()):
     try:

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -242,7 +242,7 @@ async def get_schema(request: 'web.Request'):
 async def post_notify(request: 'web.Request'):
   try:
     payload = await request.json()
-  except e:
+  except Exception as e:
     raise web.HTTPBadRequest(text="Invalid JSON") from e
 
   for session in list(request.app.get('streams', {}).values()):

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -243,7 +243,7 @@ async def post_notify(request: 'web.Request'):
   try:
     payload = await request.json()
   except Exception:
-    raise web.HTTPBadRequest(text="Invalid JSON")
+    raise web.HTTPBadRequest(text="Invalid JSON") from None
 
   for session in list(request.app.get('streams', {}).values()):
     try:
@@ -251,6 +251,7 @@ async def post_notify(request: 'web.Request'):
       ch.send(json.dumps(payload))
     except Exception:
       continue
+
   return web.Response(status=200, text="OK")
 
 async def on_shutdown(app: 'web.Application'):


### PR DESCRIPTION
Small things I'm adding to use the webrtc stack for camera focusing

1) pts now updates based on system time. It used to be that it only incremented while camerad was running based on frame capture period. When hot-unplugging/hot-plugging cameras, pts would fall way behind what the browser expected, forcing it to add a huge delay to the stream.

2) STREAM_BITRATE env variable now allows picking loggerd stream bitrate at runtime. defaults to the same as before.

3) webrtc http server now exposes a "/notify" endpoint where processes can POST a json to broadcast it to all sessions' data channels. This is for running tests on device and reporting results to front end.

