### PR TITLE
Fix macos metadrive

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -117,6 +117,10 @@ elif arch == "Darwin":
     f"{brew_prefix}/include",
     f"{brew_prefix}/opt/openssl@3.0/include",
   ])
+  # Ensure native Apple Silicon builds always target arm64 - issue with linker especially
+  env.Append(CCFLAGS=["-arch", "arm64"])
+  env.Append(CXXFLAGS=["-arch", "arm64"])
+  env.Append(LINKFLAGS=["-arch", "arm64"])
 else:
   env.Append(LIBPATH=[
     "/usr/lib",

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -70,6 +70,18 @@ export PYCURL_SSL_LIBRARY=openssl
 $DIR/install_python_dependencies.sh
 echo "[ ] installed python dependencies t=$SECONDS"
 
+# Ensure pip is available in the venv and rebuild PyAudio for ARM64
+VENV_PYTHON="$ROOT/.venv/bin/python"
+
+if ! "$VENV_PYTHON" -m pip --version &>/dev/null; then
+    echo "[ ] Bootstrapping pip in venv"
+    curl -sS https://bootstrap.pypa.io/get-pip.py | arch -arm64 "$VENV_PYTHON"
+fi
+
+echo "[ ] Rebuilding PyAudio for ARM64"
+arch -arm64 "$VENV_PYTHON" -m pip uninstall -y pyaudio || true
+arch -arm64 "$VENV_PYTHON" -m pip install --no-binary :all: pyaudio
+
 # brew does not link qt5 by default
 # check if qt5 can be linked, if not, prompt the user to link it
 QT_BIN_LOCATION="$(command -v lupdate || :)"

--- a/tools/sim/tests/conftest.py
+++ b/tools/sim/tests/conftest.py
@@ -1,4 +1,8 @@
 import pytest
+import multiprocessing
+
+def pytest_configure(config):
+  multiprocessing.set_start_method("spawn", force=True)
 
 def pytest_addoption(parser):
   parser.addoption("--test_duration", action="store", default=60, type=int, help="Seconds to run metadrive drive")


### PR DESCRIPTION
Addresses #33207 
The PR fixes dependency issues on macos metal (pyaudio binaries weren't being compiled for arm64) and forces spawn multiprocessing for pytest. The sim now launches correctly on my machine.
The CI test still doesn't pass since the car crashes immediately, but as I understand this is not an issue with the platform and also happens on ubuntu (I read this on discord and also tested on my ubuntu machine).

I would be thankful to know if and how to iterate on this.