### PR TITLE
raylib: more closely match Qt alert sizes

### DIFF
--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -40,13 +40,13 @@ class Colors:
 
 
 NETWORK_TYPES = {
-  NetworkType.none: "Offline",
-  NetworkType.wifi: "WiFi",
+  NetworkType.none: "--",
+  NetworkType.wifi: "Wi-Fi",
+  NetworkType.ethernet: "ETH",
   NetworkType.cell2G: "2G",
   NetworkType.cell3G: "3G",
   NetworkType.cell4G: "LTE",
   NetworkType.cell5G: "5G",
-  NetworkType.ethernet: "Ethernet",
 }
 
 

--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -172,7 +172,7 @@ class Sidebar(Widget):
 
     # Microphone button
     if self._recording_audio:
-      self._mic_indicator_rect = rl.Rectangle(rect.x + rect.width - 138, rect.y + 245, 75, 40)
+      self._mic_indicator_rect = rl.Rectangle(rect.x + rect.width - 130, rect.y + 245, 75, 40)
 
       mic_pressed = mouse_down and rl.check_collision_point_rec(mouse_pos, self._mic_indicator_rect)
       bg_color = rl.Color(Colors.DANGER.r, Colors.DANGER.g, Colors.DANGER.b, int(255 * 0.65)) if mic_pressed else Colors.DANGER

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -31,9 +31,9 @@ SELFDRIVE_UNRESPONSIVE_TIMEOUT = 10  # Seconds
 
 # Constants
 ALERT_COLORS = {
-  AlertStatus.normal: rl.Color(0x15, 0x15, 0x15, 0xF1),  # #151515 with alpha 0xF1
+  AlertStatus.normal: rl.Color(0x15, 0x15, 0x15, 0xF1),      # #151515 with alpha 0xF1
   AlertStatus.userPrompt: rl.Color(0xDA, 0x6F, 0x25, 0xF1),  # #DA6F25 with alpha 0xF1
-  AlertStatus.critical: rl.Color(0xC9, 0x22, 0x31, 0xF1),  # #C92231 with alpha 0xF1
+  AlertStatus.critical: rl.Color(0xC9, 0x22, 0x31, 0xF1),    # #C92231 with alpha 0xF1
 }
 
 

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -21,10 +21,6 @@ ALERT_FONT_SMALL = 66
 ALERT_FONT_MEDIUM = 74
 ALERT_FONT_BIG = 88
 
-#    {cereal::SelfdriveState::AlertSize::SMALL, 271},
-#    {cereal::SelfdriveState::AlertSize::MID, 420},
-#    {cereal::SelfdriveState::AlertSize::FULL, height()},
-
 ALERT_HEIGHTS = {
   AlertSize.small: 271,
   AlertSize.mid: 420,
@@ -35,9 +31,9 @@ SELFDRIVE_UNRESPONSIVE_TIMEOUT = 10  # Seconds
 
 # Constants
 ALERT_COLORS = {
-  AlertStatus.normal: rl.Color(0x15, 0x15, 0x15, 0xF1),      # #151515 with alpha 0xF1
+  AlertStatus.normal: rl.Color(0x15, 0x15, 0x15, 0xF1),  # #151515 with alpha 0xF1
   AlertStatus.userPrompt: rl.Color(0xDA, 0x6F, 0x25, 0xF1),  # #DA6F25 with alpha 0xF1
-  AlertStatus.critical: rl.Color(0xC9, 0x22, 0x31, 0xF1),    # #C92231 with alpha 0xF1
+  AlertStatus.critical: rl.Color(0xC9, 0x22, 0x31, 0xF1),  # #C92231 with alpha 0xF1
 }
 
 
@@ -129,13 +125,8 @@ class AlertRenderer(Widget):
       return rect
 
     h = ALERT_HEIGHTS.get(size, rect.height)
-
-    margin = ALERT_MARGIN
-    if size == AlertSize.full:
-      margin = 0
-
-    return rl.Rectangle(rect.x + margin, rect.y + rect.height - h + margin,
-                        rect.width - margin * 2, h - margin * 2)
+    return rl.Rectangle(rect.x + ALERT_MARGIN, rect.y + rect.height - h + ALERT_MARGIN,
+                        rect.width - ALERT_MARGIN * 2, h - ALERT_MARGIN * 2)
 
   def _draw_background(self, rect: rl.Rectangle, alert: Alert) -> None:
     color = ALERT_COLORS.get(alert.status, ALERT_COLORS[AlertStatus.normal])

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -21,6 +21,16 @@ ALERT_FONT_SMALL = 66
 ALERT_FONT_MEDIUM = 74
 ALERT_FONT_BIG = 88
 
+#    {cereal::SelfdriveState::AlertSize::SMALL, 271},
+#    {cereal::SelfdriveState::AlertSize::MID, 420},
+#    {cereal::SelfdriveState::AlertSize::FULL, height()},
+
+ALERT_HEIGHTS = {
+  AlertSize.small: 271,
+  AlertSize.mid: 420,
+}
+
+
 SELFDRIVE_STATE_TIMEOUT = 5  # Seconds
 SELFDRIVE_UNRESPONSIVE_TIMEOUT = 10  # Seconds
 
@@ -119,15 +129,26 @@ class AlertRenderer(Widget):
     if size == AlertSize.full:
       return rect
 
-    height = (ALERT_FONT_MEDIUM + 2 * ALERT_PADDING if size == AlertSize.small else
-              ALERT_FONT_BIG + ALERT_LINE_SPACING + ALERT_FONT_SMALL + 2 * ALERT_PADDING)
+    # height = (ALERT_FONT_MEDIUM + 2 * ALERT_PADDING if size == AlertSize.small else
+    #           ALERT_FONT_BIG + ALERT_LINE_SPACING + ALERT_FONT_SMALL + 2 * ALERT_PADDING)
 
-    return rl.Rectangle(
-      rect.x + ALERT_MARGIN,
-      rect.y + rect.height - ALERT_MARGIN - height,
-      rect.width - 2 * ALERT_MARGIN,
-      height
-    )
+    h = ALERT_HEIGHTS.get(size, rect.height)
+
+    # QRect r = QRect(0 + margin, height() - h + margin, width() - margin*2, h - margin*2);
+
+    margin, radius = ALERT_MARGIN, ALERT_BORDER_RADIUS
+    if size == AlertSize.full:
+      margin, radius = 0, 0
+
+    return rl.Rectangle(margin, rect.height - h,
+                        rect.x + rect.width - margin * 2, h - margin * 2)
+
+    # return rl.Rectangle(
+    #   rect.x + ALERT_MARGIN,
+    #   rect.y + rect.height - ALERT_MARGIN - height,
+    #   rect.width - 2 * ALERT_MARGIN,
+    #   height
+    # )
 
   def _draw_background(self, rect: rl.Rectangle, alert: Alert) -> None:
     color = ALERT_COLORS.get(alert.status, ALERT_COLORS[AlertStatus.normal])

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -30,7 +30,6 @@ ALERT_HEIGHTS = {
   AlertSize.mid: 420,
 }
 
-
 SELFDRIVE_STATE_TIMEOUT = 5  # Seconds
 SELFDRIVE_UNRESPONSIVE_TIMEOUT = 10  # Seconds
 
@@ -129,26 +128,14 @@ class AlertRenderer(Widget):
     if size == AlertSize.full:
       return rect
 
-    # height = (ALERT_FONT_MEDIUM + 2 * ALERT_PADDING if size == AlertSize.small else
-    #           ALERT_FONT_BIG + ALERT_LINE_SPACING + ALERT_FONT_SMALL + 2 * ALERT_PADDING)
-
     h = ALERT_HEIGHTS.get(size, rect.height)
 
-    # QRect r = QRect(0 + margin, height() - h + margin, width() - margin*2, h - margin*2);
-
-    margin, radius = ALERT_MARGIN, ALERT_BORDER_RADIUS
+    margin = ALERT_MARGIN
     if size == AlertSize.full:
-      margin, radius = 0, 0
+      margin = 0
 
-    return rl.Rectangle(margin, rect.height - h,
-                        rect.x + rect.width - margin * 2, h - margin * 2)
-
-    # return rl.Rectangle(
-    #   rect.x + ALERT_MARGIN,
-    #   rect.y + rect.height - ALERT_MARGIN - height,
-    #   rect.width - 2 * ALERT_MARGIN,
-    #   height
-    # )
+    return rl.Rectangle(rect.x + margin, rect.y + rect.height - h + margin,
+                        rect.width - margin * 2, h - margin * 2)
 
   def _draw_background(self, rect: rl.Rectangle, alert: Alert) -> None:
     color = ALERT_COLORS.get(alert.status, ALERT_COLORS[AlertStatus.normal])
@@ -173,7 +160,7 @@ class AlertRenderer(Widget):
       font_size1 = 132 if is_long else 177
       align_ment = rl.GuiTextAlignment.TEXT_ALIGN_CENTER
       vertical_align = rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE
-      text_rect = rl.Rectangle(rect.x, rect.y, rect.width, rect.height // 2)
+      text_rect = rl.Rectangle(rect.x, rect.y, rect.width, rect.height)
 
       gui_text_box(text_rect, alert.text1, font_size1, alignment=align_ment, alignment_vertical=vertical_align, font_weight=FontWeight.BOLD)
       text_rect.y = rect.y + rect.height // 2


### PR DESCRIPTION
full screen alert isn't fully centered because all of our labels suck and align at the top of the text, not middle