### PR TITLE
fix cycle offroad alerts

### DIFF
--- a/selfdrive/ui/tests/cycle_offroad_alerts.py
+++ b/selfdrive/ui/tests/cycle_offroad_alerts.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
   t = 10 if len(sys.argv) < 2 else int(sys.argv[1])
   while True:
     print("setting alert update")
+    params.put_bool("UpdateAvailable", True)
     params.put("UpdaterNewReleaseNotes", parse_release_notes(BASEDIR))
 
     time.sleep(t)

--- a/selfdrive/ui/tests/cycle_offroad_alerts.py
+++ b/selfdrive/ui/tests/cycle_offroad_alerts.py
@@ -7,6 +7,8 @@ import json
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert
+from openpilot.system.updated.updated import parse_release_notes
+
 
 if __name__ == "__main__":
   params = Params()
@@ -17,10 +19,7 @@ if __name__ == "__main__":
   t = 10 if len(sys.argv) < 2 else int(sys.argv[1])
   while True:
     print("setting alert update")
-    params.put_bool("UpdateAvailable", True)
-    r = open(os.path.join(BASEDIR, "RELEASES.md")).read()
-    r = r[:r.find('\n\n')]  # Slice latest release notes
-    params.put("UpdaterNewReleaseNotes", r + "\n")
+    params.put("UpdaterNewReleaseNotes", parse_release_notes(BASEDIR))
 
     time.sleep(t)
     params.put_bool("UpdateAvailable", False)

--- a/selfdrive/ui/tests/cycle_offroad_alerts.py
+++ b/selfdrive/ui/tests/cycle_offroad_alerts.py
@@ -9,7 +9,6 @@ from openpilot.common.params import Params
 from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert
 from openpilot.system.updated.updated import parse_release_notes
 
-
 if __name__ == "__main__":
   params = Params()
 


### PR DESCRIPTION
The script was failing due to the param value being a string instead of bytes. And previously it wouldn't show the rendered content. Now it will use `parse_release_notes` so I can properly debug the issues with the rendered release notes.