### PR TITLE
installer: branch migration

### DIFF
--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -44,7 +44,7 @@ std::string migrated_branch;
 
 void branchMigration() {
   migrated_branch = BRANCH_STR;
-  if (Hardware::get_device_type() == cereal::InitData::DeviceType::PC) {
+  if (Hardware::get_device_type() == cereal::InitData::DeviceType::TICI) {
     if (std::find(tici_prebuilt_branches.begin(), tici_prebuilt_branches.end(), BRANCH_STR) != tici_prebuilt_branches.end()) {
       migrated_branch = "release-tici";
     } else if (BRANCH_STR == "master") {

--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -44,11 +44,16 @@ std::string migrated_branch;
 
 void branchMigration() {
   migrated_branch = BRANCH_STR;
-  if (Hardware::get_device_type() == cereal::InitData::DeviceType::TICI) {
+  cereal::InitData::DeviceType device_type = Hardware::get_device_type();
+  if (device_type == cereal::InitData::DeviceType::TICI) {
     if (std::find(tici_prebuilt_branches.begin(), tici_prebuilt_branches.end(), BRANCH_STR) != tici_prebuilt_branches.end()) {
       migrated_branch = "release-tici";
     } else if (BRANCH_STR == "master") {
       migrated_branch = "master-tici";
+    }
+  } else if (device_type == cereal::InitData::DeviceType::TIZI) {
+    if (BRANCH_STR == "release3") {
+      migrated_branch = "release-tizi";
     }
   }
 }

--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -209,7 +209,6 @@ int main(int argc, char *argv[]) {
   SetTextureFilter(font.texture, TEXTURE_FILTER_BILINEAR);
 
   branchMigration();
-  finishInstall();
 
   if (util::file_exists(CONTINUE_PATH)) {
     finishInstall();

--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -54,6 +54,8 @@ void branchMigration() {
   } else if (device_type == cereal::InitData::DeviceType::TIZI) {
     if (BRANCH_STR == "release3") {
       migrated_branch = "release-tizi";
+    } else if (BRANCH_STR == "release3-staging") {
+      migrated_branch = "release-tizi-staging";
     }
   }
 }

--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -369,7 +369,9 @@ class Setup(Widget):
 
       fd, tmpfile = tempfile.mkstemp(prefix="installer_")
 
-      headers = {"User-Agent": USER_AGENT, "X-openpilot-serial": HARDWARE.get_serial()}
+      headers = {"User-Agent": USER_AGENT,
+                 "X-openpilot-serial": HARDWARE.get_serial(),
+                 "X-openpilot-device-type": HARDWARE.get_device_type()}
       req = urllib.request.Request(self.download_url, headers=headers)
 
       with open(tmpfile, 'wb') as f, urllib.request.urlopen(req, timeout=30) as response:


### PR DESCRIPTION
Since we did not pass the device type from `setup` to the installer endpoint in older AGNOS version, we have to migrate here