### PR TITLE
Add scrolling screenshots (raylib UI tests)

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -295,8 +295,7 @@ jobs:
         run: ${{ env.RUN }} "scons -j$(nproc)"
       - name: Create raylib UI Report
         run: >
-          ${{ env.RUN }} "apt-get update && apt-get install -y xdotool &&
-                          PYTHONWARNINGS=ignore &&
+          ${{ env.RUN }} "PYTHONWARNINGS=ignore &&
                           source selfdrive/test/setup_xvfb.sh &&
                           python3 selfdrive/ui/tests/test_ui/raylib_screenshots.py"
       - name: Upload Raylib UI Report

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -295,7 +295,8 @@ jobs:
         run: ${{ env.RUN }} "scons -j$(nproc)"
       - name: Create raylib UI Report
         run: >
-          ${{ env.RUN }} "PYTHONWARNINGS=ignore &&
+          ${{ env.RUN }} "apt-get update && apt-get install -y xdotool &&
+                          PYTHONWARNINGS=ignore &&
                           source selfdrive/test/setup_xvfb.sh &&
                           python3 selfdrive/ui/tests/test_ui/raylib_screenshots.py"
       - name: Upload Raylib UI Report

--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -5,9 +5,11 @@ import shutil
 import time
 import pathlib
 from collections import namedtuple
+from collections.abc import Callable
+from typing import NotRequired, TypedDict
 
 import pyautogui
-import pywinctl
+from PIL import ImageChops
 
 from cereal import log
 from cereal import messaging
@@ -23,6 +25,10 @@ TEST_DIR = pathlib.Path(__file__).parent
 TEST_OUTPUT_DIR = TEST_DIR / "raylib_report"
 SCREENSHOTS_DIR = TEST_OUTPUT_DIR / "screenshots"
 UI_DELAY = 0.2
+SCROLL_DELAY = 1.5  # Delay screenshot by this many seconds after scrolling (to allow scroll to settle)
+DEFAULT_SCROLL_AMOUNT = -20  # Good for most full screen scrollers
+MAX_SCREENSHOTS_PER_CASE = 8  # Maximum screenshots to generate while scrolling
+
 
 # Offroad alerts to test
 OFFROAD_ALERTS = ['Offroad_IsTakingSnapshot']
@@ -112,7 +118,16 @@ def setup_software_release_notes(click, pm: PubMaster):
   click(588, 110)  # expand description for current version
 
 
-CASES = {
+class CaseConfig(TypedDict):
+  scroll_amount: NotRequired[int]
+  scroll_enabled: NotRequired[bool]
+
+
+SetupFunction = Callable[[Callable[..., None], PubMaster], None]
+CaseValue = SetupFunction | tuple[SetupFunction, CaseConfig | None]
+
+# Value can be the setup function, or tuple of (setup func, config)
+CASES: dict[str, CaseValue] = {
   "homescreen": setup_homescreen,
   "settings_device": setup_settings,
   "settings_network": setup_settings_network,
@@ -120,10 +135,10 @@ CASES = {
   "settings_software": setup_settings_software,
   "settings_firehose": setup_settings_firehose,
   "settings_developer": setup_settings_developer,
-  "keyboard": setup_keyboard,
+  "keyboard": (setup_keyboard, {"scroll_enabled": False}),  # The blinking cursor makes it think there was a change when scrolling
   "pair_device": setup_pair_device,
-  "offroad_alert": setup_offroad_alert,
-  "homescreen_update_available": setup_homescreen_update_available,
+  "offroad_alert": (setup_offroad_alert, {"scroll_amount": -12}),  # smaller scrollable area
+  "homescreen_update_available": (setup_homescreen_update_available, {"scroll_amount": -12}),  # smaller scrollable area
   "confirmation_dialog": setup_confirmation_dialog,
   "software_release_notes": setup_software_release_notes,
 }
@@ -144,28 +159,84 @@ class TestUI:
       ds.clear_write_flag()
       time.sleep(0.05)
     time.sleep(0.5)
-    try:
-      self.ui = pywinctl.getWindowsWithTitle("UI")[0]
-    except Exception as e:
-      print(f"failed to find ui window, assuming that it's in the top left (for Xvfb) {e}")
-      self.ui = namedtuple("bb", ["left", "top", "width", "height"])(0, 0, 2160, 1080)
+    self.ui = namedtuple("bb", ["left", "top", "width", "height"])(0, 0, 2160, 1080)
 
-  def screenshot(self, name: str):
+  def screenshot(self):
     full_screenshot = pyautogui.screenshot()
     cropped = full_screenshot.crop((self.ui.left, self.ui.top, self.ui.left + self.ui.width, self.ui.top + self.ui.height))
-    cropped.save(SCREENSHOTS_DIR / f"{name}.png")
+    return cropped
+
+  def screenshot_and_save(self, name: str):
+    screenshot = self.screenshot()
+    screenshot.save(SCREENSHOTS_DIR / f"{name}.png")
+    return screenshot
+
+  def capture_scrollable(self, name: str, scroll_clicks: int, max_screenshots=MAX_SCREENSHOTS_PER_CASE):
+    # Take first screenshot
+    prev = self.screenshot_and_save(name)
+
+    # Scroll until there are no more changes or we reach the limit
+    for i in range(1, max_screenshots):
+      self.vscroll(scroll_clicks, delay=50)  # 50ms between scroll clicks; 20ms didn't work well for larger scrolls
+      time.sleep(SCROLL_DELAY)
+      curr = self.screenshot()
+
+      # Check for difference
+      try:
+        # TODO: This might need to be more robust to allow for small pixel diffs in case scrolling isn't consistent, but so far it seems to work
+        diff = ImageChops.difference(prev.convert('RGB'), curr.convert('RGB'))
+        if diff.getbbox() is None:
+          # no changes -> reached end
+          break
+      except Exception as e:
+        print(f"error comparing screenshots: {e}")
+        break
+
+      # Save the current page
+      curr.save(SCREENSHOTS_DIR / f"{name}_{i}.png")
+
+      prev = curr
 
   def click(self, x: int, y: int, *args, **kwargs):
     pyautogui.mouseDown(self.ui.left + x, self.ui.top + y, *args, **kwargs)
     time.sleep(0.01)
     pyautogui.mouseUp(self.ui.left + x, self.ui.top + y, *args, **kwargs)
 
+  def vscroll(self, clicks: int, delay=100):
+    """Perform vertical scroll using xdotool.
+
+    clicks: number of scroll clicks to perform (negative means scroll down)
+
+    delay: delay between scroll clicks in milliseconds
+    """
+    clicks = int(clicks)
+    if clicks == 0:
+      return
+    button = 4 if clicks > 0 else 5  # 4=up, 5=down
+    # Run xdotool command to scroll
+    result = os.system(f"xdotool click --repeat {abs(clicks)} --delay {delay} {button}")
+    if result != 0:
+      raise Exception("xdotool command failed (ensure xdotool is installed)")
+
   @with_processes(["ui"])
-  def test_ui(self, name, setup_case):
+  def test_ui(self, name: str, setup_case: SetupFunction, config: CaseConfig | None = None):
     self.setup()
-    time.sleep(UI_DELAY)  # wait for UI to start
+    time.sleep(UI_DELAY)  # Wait for UI to start
     setup_case(self.click, self.pm)
-    self.screenshot(name)
+    config = config or {}
+
+    # Just take a screenshot if scrolling is disabled
+    scroll_enabled = config.get("scroll_enabled", True)
+    if not scroll_enabled:
+      self.screenshot_and_save(name)
+      return
+
+    try:
+      scroll_clicks = config.get("scroll_amount", DEFAULT_SCROLL_AMOUNT)
+      self.capture_scrollable(name, scroll_clicks=scroll_clicks)
+    except Exception as e:
+      print(f"failed capturing scrollable page, falling back to single screenshot: {e}")
+      self.screenshot_and_save(name)
 
 
 def create_screenshots():
@@ -178,7 +249,8 @@ def create_screenshots():
     params = Params()
     params.put("DongleId", "123456789012345")
     for name, setup in CASES.items():
-      t.test_ui(name, setup)
+      setup_fn, cfg = setup if isinstance(setup, tuple) else (setup, None)
+      t.test_ui(name, setup_fn, cfg)
 
 
 if __name__ == "__main__":

--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import NotRequired, TypedDict
 
 import pyautogui
+import pywinctl
 from PIL import ImageChops
 
 from cereal import log
@@ -159,7 +160,11 @@ class TestUI:
       ds.clear_write_flag()
       time.sleep(0.05)
     time.sleep(0.5)
-    self.ui = namedtuple("bb", ["left", "top", "width", "height"])(0, 0, 2160, 1080)
+    try:
+      self.ui = pywinctl.getWindowsWithTitle("UI")[0]
+    except Exception as e:
+      print(f"failed to find ui window, assuming that it's in the top left (for Xvfb) {e}")
+      self.ui = namedtuple("bb", ["left", "top", "width", "height"])(0, 0, 2160, 1080)
 
   def screenshot(self):
     full_screenshot = pyautogui.screenshot()

--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -177,7 +177,7 @@ class TestUI:
 
     # Scroll until there are no more changes or we reach the limit
     for i in range(1, max_screenshots):
-      self.vscroll(scroll_clicks, delay=50)  # 50ms between scroll clicks; 20ms didn't work well for larger scrolls
+      self.scroll(scroll_clicks)
       time.sleep(SCROLL_DELAY)
       curr = self.screenshot()
 
@@ -202,21 +202,13 @@ class TestUI:
     time.sleep(0.01)
     pyautogui.mouseUp(self.ui.left + x, self.ui.top + y, *args, **kwargs)
 
-  def vscroll(self, clicks: int, delay=100):
-    """Perform vertical scroll using xdotool.
-
-    clicks: number of scroll clicks to perform (negative means scroll down)
-
-    delay: delay between scroll clicks in milliseconds
-    """
-    clicks = int(clicks)
+  def scroll(self, clicks: int, *args, **kwargs):
     if clicks == 0:
       return
-    button = 4 if clicks > 0 else 5  # 4=up, 5=down
-    # Run xdotool command to scroll
-    result = os.system(f"xdotool click --repeat {abs(clicks)} --delay {delay} {button}")
-    if result != 0:
-      raise Exception("xdotool command failed (ensure xdotool is installed)")
+    click = -1 if clicks < 0 else 1  # -1 = down, 1 = up
+    for _ in range(abs(clicks)):
+      pyautogui.scroll(click, *args, **kwargs)  # scroll for individual clicks since we need to delay between clicks
+      time.sleep(0.01)  # small delay between scroll clicks to work properly
 
   @with_processes(["ui"])
   def test_ui(self, name: str, setup_case: SetupFunction, config: CaseConfig | None = None):


### PR DESCRIPTION
**Summary:**
Implements scrolling in the raylib UI preview generation so that we can see all content on a page.

**Details:**
The first image has the same name as before, but appends `_1`, `_2`, etc., for the scrolled versions. It stops scrolling when no changes are detected in the image, or when the limit (default `8`) is reached.

`pyautogui.scroll()` doesn't use a delay betweel scroll clicks, which doesn't work properly in CI, so we just call it once per click and delay between.
