### PR TITLE
Add screenshot for experimental mode description (raylib UI test)

### DIFF
--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -112,6 +112,12 @@ def setup_software_release_notes(click, pm: PubMaster):
   click(588, 110)  # expand description for current version
 
 
+def setup_experimental_mode_description(click, pm: PubMaster):
+  setup_settings(click, pm)
+  setup_settings_toggles(click, pm)
+  click(1200, 280)  # expand description for experimental mode
+
+
 CASES = {
   "homescreen": setup_homescreen,
   "settings_device": setup_settings,
@@ -126,6 +132,7 @@ CASES = {
   "homescreen_update_available": setup_homescreen_update_available,
   "confirmation_dialog": setup_confirmation_dialog,
   "software_release_notes": setup_software_release_notes,
+  "experimental_mode_description": setup_experimental_mode_description,
 }
 
 

--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -113,7 +113,6 @@ def setup_software_release_notes(click, pm: PubMaster):
 
 
 def setup_experimental_mode_description(click, pm: PubMaster):
-  setup_settings(click, pm)
   setup_settings_toggles(click, pm)
   click(1200, 280)  # expand description for experimental mode
 


### PR DESCRIPTION
Adds a screenshot test case for the experimental mode description.

Part of it might be cut off at the bottom because we need scroll support. I figured out a better way to scroll that doesn't require xdotool, (updated my other PR also), so I can do that here if you like, or in a followup PR.

Ahh, it looks like it just barely fit after all.