### PR TITLE
fix emoji font path

### DIFF
--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -191,6 +191,7 @@ def create_screenshots():
   with OpenpilotPrefix():
     params = Params()
     params.put("DongleId", "123456789012345")
+    params.put("PrimeType", 1)
     for name, setup in CASES.items():
       t.test_ui(name, setup)
 

--- a/system/ui/lib/emoji.py
+++ b/system/ui/lib/emoji.py
@@ -33,21 +33,17 @@ EMOJI_REGEX = re.compile(
 )
 
 FONT_PATH = FONT_DIR.joinpath("NotoColorEmoji-Regular.ttf")
-FONT_SIZE = 109
 
 
 def find_emoji(text):
   return [(m.start(), m.end(), m.group()) for m in EMOJI_REGEX.finditer(text)]
 
+
 def emoji_tex(emoji):
   if emoji not in _cache:
     img = Image.new("RGBA", (128, 128), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
-    try:
-      font = ImageFont.truetype(FONT_PATH, size=FONT_SIZE)
-    except OSError as e:
-      print(f"Error loading font for emoji '${emoji}': {e}")
-      font = ImageFont.load_default(size=FONT_SIZE)
+    font = ImageFont.truetype(FONT_PATH, 109)
     draw.text((0, 0), emoji, font=font, embedded_color=True)
     buffer = io.BytesIO()
     img.save(buffer, format="PNG")

--- a/system/ui/lib/emoji.py
+++ b/system/ui/lib/emoji.py
@@ -4,6 +4,8 @@ import re
 from PIL import Image, ImageDraw, ImageFont
 import pyray as rl
 
+from openpilot.system.ui.lib.application import FONT_DIR
+
 _cache: dict[str, rl.Texture] = {}
 
 EMOJI_REGEX = re.compile(
@@ -30,6 +32,9 @@ EMOJI_REGEX = re.compile(
   flags=re.UNICODE
 )
 
+FONT_PATH = FONT_DIR.joinpath("NotoColorEmoji-Regular.ttf")
+
+
 def find_emoji(text):
   return [(m.start(), m.end(), m.group()) for m in EMOJI_REGEX.finditer(text)]
 
@@ -37,7 +42,7 @@ def emoji_tex(emoji):
   if emoji not in _cache:
     img = Image.new("RGBA", (128, 128), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
-    font = ImageFont.truetype("NotoColorEmoji", 109)
+    font = ImageFont.truetype(FONT_PATH, 109)
     draw.text((0, 0), emoji, font=font, embedded_color=True)
     buffer = io.BytesIO()
     img.save(buffer, format="PNG")

--- a/system/ui/lib/emoji.py
+++ b/system/ui/lib/emoji.py
@@ -32,18 +32,14 @@ EMOJI_REGEX = re.compile(
   flags=re.UNICODE
 )
 
-FONT_PATH = FONT_DIR.joinpath("NotoColorEmoji-Regular.ttf")
-
-
 def find_emoji(text):
   return [(m.start(), m.end(), m.group()) for m in EMOJI_REGEX.finditer(text)]
-
 
 def emoji_tex(emoji):
   if emoji not in _cache:
     img = Image.new("RGBA", (128, 128), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
-    font = ImageFont.truetype(FONT_PATH, 109)
+    font = ImageFont.truetype(FONT_DIR.joinpath("NotoColorEmoji-Regular.ttf"), 109)
     draw.text((0, 0), emoji, font=font, embedded_color=True)
     buffer = io.BytesIO()
     img.save(buffer, format="PNG")

--- a/system/ui/lib/emoji.py
+++ b/system/ui/lib/emoji.py
@@ -33,6 +33,7 @@ EMOJI_REGEX = re.compile(
 )
 
 FONT_PATH = FONT_DIR.joinpath("NotoColorEmoji-Regular.ttf")
+FONT_SIZE = 109
 
 
 def find_emoji(text):
@@ -42,7 +43,11 @@ def emoji_tex(emoji):
   if emoji not in _cache:
     img = Image.new("RGBA", (128, 128), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
-    font = ImageFont.truetype(FONT_PATH, 109)
+    try:
+      font = ImageFont.truetype(FONT_PATH, size=FONT_SIZE)
+    except OSError as e:
+      print(f"Error loading font for emoji '${emoji}': {e}")
+      font = ImageFont.load_default(size=FONT_SIZE)
     draw.text((0, 0), emoji, font=font, embedded_color=True)
     buffer = io.BytesIO()
     img.save(buffer, format="PNG")


### PR DESCRIPTION
The homescreen prime state is causing a crash due to an incorrect font path (firehose 🔥 emoji).