### PR TITLE
fix pair device screenshot

### DIFF
--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -93,7 +93,7 @@ def setup_keyboard(click, pm: PubMaster):
 
 
 def setup_pair_device(click, pm: PubMaster):
-  click(1950, 800)
+  click(1750, 900)
 
 
 def setup_offroad_alert(click, pm: PubMaster):


### PR DESCRIPTION
The pair device screenshot isn't showing ~because the coordinates are wrong~.

But why doesn't the PR tool tell us when images are removed?

Nevermind, it's uploaded in the artifacts but not showing in the preview...