### PR TITLE
keyboard: use separate button instances for each layout row

### DIFF
--- a/system/ui/widgets/keyboard.py
+++ b/system/ui/widgets/keyboard.py
@@ -207,7 +207,6 @@ class Keyboard(Widget):
 
         if key == SHIFT_ACTIVE_KEY and self._caps_lock:
           button = self._special_keys[CAPS_LOCK_KEY]
-
         button.set_enabled(is_enabled)
         button.render(key_rect)
 


### PR DESCRIPTION
Fixes the duplicate period keys not working. They were reusing the same button instance before.

Of course, the simpler solution might be to replace one of them with a different symbol.