### PR TITLE
Fix vendored emoji font

### DIFF
--- a/selfdrive/assets/fonts/NotoColorEmoji-Regular.ttf
+++ b/selfdrive/assets/fonts/NotoColorEmoji-Regular.ttf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69f216a4ec672bb910d652678301ffe3094c44e5d03276e794ef793d936a1f1d
-size 25096376

--- a/selfdrive/assets/fonts/NotoColorEmoji.ttf
+++ b/selfdrive/assets/fonts/NotoColorEmoji.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93cdc4ee9aa40e2afceecc63da0ca05ec7aab4bec991ece51a6b52389f48a477
+size 10788068

--- a/system/ui/lib/emoji.py
+++ b/system/ui/lib/emoji.py
@@ -4,6 +4,8 @@ import re
 from PIL import Image, ImageDraw, ImageFont
 import pyray as rl
 
+from openpilot.system.ui.lib.application import FONT_DIR
+
 _cache: dict[str, rl.Texture] = {}
 
 EMOJI_REGEX = re.compile(
@@ -37,7 +39,7 @@ def emoji_tex(emoji):
   if emoji not in _cache:
     img = Image.new("RGBA", (128, 128), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
-    font = ImageFont.truetype("NotoColorEmoji", 109)
+    font = ImageFont.truetype(FONT_DIR.joinpath("NotoColorEmoji.ttf"), 109)
     draw.text((0, 0), emoji, font=font, embedded_color=True)
     buffer = io.BytesIO()
     img.save(buffer, format="PNG")


### PR DESCRIPTION
the one from google is 25mb and displays blank characters on my PC, 3X, and in CI. the one I found in /usr/share/fonts/truetype/noto is 10mb and works