### PR TITLE
ci: fix flaky macOS build

### DIFF
--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -32,6 +32,10 @@ else
     brew up
 fi
 
+# Relink openssl
+brew unlink openssl@3 || true
+brew link overwrite openssl@3
+
 brew bundle --file=- <<-EOS
 brew "git-lfs"
 brew "capnp"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -34,7 +34,7 @@ fi
 
 # Relink openssl
 brew unlink openssl@3 || true
-brew link overwrite openssl@3
+brew link --overwrite openssl@3
 
 brew bundle --file=- <<-EOS
 brew "git-lfs"


### PR DESCRIPTION
Unlink and relink `openssl@3` in `mac_setup.sh`. Otherwise, it's hit or miss with my PRs whether the macOS build will succeed.

Failure example: https://github.com/commaai/openpilot/actions/runs/18534765840/job/52826803925?pr=36342