### PR TITLE
raylib: fix crash from too many colors

### DIFF
--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -226,8 +226,12 @@ class ModelRenderer(Widget):
       i += 1 + (1 if (i + 2) < max_len else 0)
 
     # Store the gradient in the path object
-    self._exp_gradient.colors = segment_colors
-    self._exp_gradient.stops = gradient_stops
+    self._exp_gradient = Gradient(
+      start=(0.0, 1.0),  # Bottom of path
+      end=(0.0, 0.0),  # Top of path
+      colors=segment_colors,
+      stops=gradient_stops,
+    )
 
   def _update_lead_vehicle(self, d_rel, v_rel, point, rect):
     speed_buff, lead_buff = 10.0, 40.0

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, cast
 from openpilot.system.ui.lib.application import gui_app
 
-MAX_GRADIENT_COLORS = 15  # includes stops as well
+MAX_GRADIENT_COLORS = 20  # includes stops as well
 
 
 @dataclass

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -48,8 +48,8 @@ uniform vec4 fillColor;
 uniform int useGradient;
 uniform vec2 gradientStart;  // e.g. vec2(0, 0)
 uniform vec2 gradientEnd;    // e.g. vec2(0, screenHeight)
-uniform vec4 gradientColors[15];
-uniform float gradientStops[15];
+uniform vec4 gradientColors[20];
+uniform float gradientStops[20];
 uniform int gradientColorCount;
 
 vec4 getGradientColor(vec2 p) {


### PR DESCRIPTION
it was *too* rgb

iirc path can be up to 33, so that's ~17 colors. fix crash in replay route. surprised no one hit it