### PR TITLE
test_onroad: ignore first few ui timing frames

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -206,7 +206,8 @@ class TestOnroad:
     result += "-------------- UI Draw Timing ------------------\n"
     result += "------------------------------------------------\n"
 
-    ts = self.ts['uiDebug']['drawTimeMillis']
+    # skip first few frames -- connecting to vipc
+    ts = self.ts['uiDebug']['drawTimeMillis'][10:]
     result += f"min  {min(ts):.2f}ms\n"
     result += f"max  {max(ts):.2f}ms\n"
     result += f"std  {np.std(ts):.2f}ms\n"

--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -68,6 +68,7 @@ else:
 class CameraView(Widget):
   def __init__(self, name: str, stream_type: VisionStreamType):
     super().__init__()
+    # TODO: implement a receiver and connect thread
     self._name = name
     # Primary stream
     self.client = VisionIpcClient(name, stream_type, conflate=True)


### PR DESCRIPTION
I was not able to notice any lag when going onroad by spamming to expand the sidebar. During this time, we show a static blue bg anyway so the effect is minimized further.

I was not able to reach a solution I was proud of out of https://github.com/commaai/openpilot/pull/36384 and https://github.com/commaai/openpilot/pull/36380. Additionally, both had random vipc buffer errors I could not pinpoint, probably due to missing locks or other thread safety issues. Both solutions also are not fully correct, we should implement the full thread from Qt which also gets frames so we can match the model to the camera frame, but that was a much bigger change and I couldn't make it in time.

I am more worried about shipping a bug that causes the UI to crash on release, now that we don't have a watchdog, than having an unnoticeable-by-design lag on startup (that I couldn't reproduce outside of test_onroad and have never seen in a car) 