### PR TITLE
raylib screenshots: fix pair device screenshot

### DIFF
--- a/selfdrive/ui/tests/test_ui/raylib_screenshots.py
+++ b/selfdrive/ui/tests/test_ui/raylib_screenshots.py
@@ -105,7 +105,8 @@ def setup_keyboard(click, pm: PubMaster):
 
 
 def setup_pair_device(click, pm: PubMaster):
-  click(1950, 800)
+  setup_settings(click, pm)
+  click(2000, 450)
 
 
 def setup_offroad_alert(click, pm: PubMaster):


### PR DESCRIPTION
We should also include it in the list of images in the PR, but only exclude from the diff check (since the QR code isn't repeatable)

Here's the artifacts branch for this PR for confirmation: 
https://github.com/commaai/ci-artifacts/blob/openpilot/pr-36393-raylib-ui/pair_device.png

And from a recent PR:
https://github.com/commaai/ci-artifacts/blob/openpilot/pr-36439-raylib-ui/pair_device.png

...ok now it's working? 🤔