### PR TITLE
Speedup docs build in CI with pip caching

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,11 +26,19 @@ jobs:
       with:
         submodules: true
 
+    # Cache pip dependencies
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-docs-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-docs-
+
     # Build
     - name: Build docs
       run: |
-        # TODO: can we install just the "docs" dependency group without the normal deps?
-        pip install mkdocs
+        pip install jinja2 natsort mkdocs
         mkdocs build
 
     # Push to docs.comma.ai


### PR DESCRIPTION
  Fixes #32687

  Added GitHub Actions caching for pip dependencies to reduce docs build time. The caching strategy stores pip's
  download cache between runs, eliminating redundant package downloads.

  Also explicitly installed only the required docs dependencies (jinja2, natsort, mkdocs) instead of just mkdocs,
  addressing the TODO comment.

  **Test results:** Build docs step completed in 5s - https://github.com/dholzric/openpilot/actions/runs/12408896127

