### PR TITLE
raylib: fix "Reboot" button pressed style

### DIFF
--- a/system/ui/widgets/list_view.py
+++ b/system/ui/widgets/list_view.py
@@ -176,7 +176,7 @@ class DualButtonAction(ItemAction):
     super().__init__(width=0, enabled=enabled)  # Width 0 means use full width
     self.left_text, self.right_text = left_text, right_text
 
-    self.left_button = Button(left_text, click_callback=left_callback, button_style=ButtonStyle.LIST_ACTION, text_padding=0)
+    self.left_button = Button(left_text, click_callback=left_callback, button_style=ButtonStyle.NORMAL, text_padding=0)
     self.right_button = Button(right_text, click_callback=right_callback, button_style=ButtonStyle.DANGER, text_padding=0)
 
   def set_touch_valid_callback(self, touch_callback: Callable[[], bool]) -> None:


### PR DESCRIPTION
Changes the dual button action left button type from `LIST_ACTION` to `NORMAL`.

Normal state (unchanged):
<img width="769" height="96" alt="2025-10-21_12-47" src="https://github.com/user-attachments/assets/d0d3540f-9f34-4a31-a16b-b38e2a8b69e8" />

Old pressed state:
<img width="801" height="107" alt="2025-10-21_12-50" src="https://github.com/user-attachments/assets/82f58216-1da6-4aaf-b4ea-6b6307d5c631" />

New pressed state:
<img width="807" height="97" alt="2025-10-21_12-50_1" src="https://github.com/user-attachments/assets/cae63a7f-82dd-47fe-a9cc-8c326ff4785d" />
