### PR TITLE
raylib: add danger button pressed style

### DIFF
--- a/system/ui/widgets/button.py
+++ b/system/ui/widgets/button.py
@@ -61,7 +61,7 @@ BUTTON_BACKGROUND_COLORS = {
 BUTTON_PRESSED_BACKGROUND_COLORS = {
   ButtonStyle.NORMAL: rl.Color(74, 74, 74, 255),
   ButtonStyle.PRIMARY: rl.Color(48, 73, 244, 255),
-  ButtonStyle.DANGER: rl.Color(255, 36, 36, 255),
+  ButtonStyle.DANGER: rl.Color(204, 0, 0, 255),
   ButtonStyle.TRANSPARENT: rl.BLACK,
   ButtonStyle.TRANSPARENT_WHITE_TEXT: rl.BLANK,
   ButtonStyle.TRANSPARENT_WHITE_BORDER: rl.BLANK,


### PR DESCRIPTION
**Before (pressed/unpressed):**
<img width="769" height="96" alt="2025-10-21_12-47" src="https://github.com/user-attachments/assets/ef0e4495-6325-40a6-9c28-360b5ca71d4f" />

**After (pressed):**
<img width="792" height="104" alt="2025-10-21_12-48" src="https://github.com/user-attachments/assets/e6f25707-5664-4f97-9cbf-52514996b487" />
