### PR TITLE
bump retry count for `micd` and `soundd`

### DIFF
--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -124,7 +124,7 @@ class Soundd:
     volume = ((weighted_db - AMBIENT_DB) / DB_SCALE) * (MAX_VOLUME - MIN_VOLUME) + MIN_VOLUME
     return math.pow(10, (np.clip(volume, MIN_VOLUME, MAX_VOLUME) - 1))
 
-  @retry(attempts=7, delay=3)
+  @retry(attempts=10, delay=3)
   def get_stream(self, sd):
     # reload sounddevice to reinitialize portaudio
     sd._terminate()

--- a/system/micd.py
+++ b/system/micd.py
@@ -94,7 +94,7 @@ class Mic:
 
         self.measurements = self.measurements[FFT_SAMPLES:]
 
-  @retry(attempts=7, delay=3)
+  @retry(attempts=10, delay=3)
   def get_stream(self, sd):
     # reload sounddevice to reinitialize portaudio
     sd._terminate()


### PR DESCRIPTION
We generally wait 2 seconds for `Magic` to start compared to 6 seconds for `Weston`. 

With this diff, `ALSA` is not always ready once openpilot starts