### PR TITLE
pandad: prefer ELM327 safety offroad with ignition on to keep harness…

### DIFF
--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -253,10 +253,19 @@ std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> 
       panda->set_power_saving(power_save_desired);
     }
 
-    // set safety mode to NO_OUTPUT when car is off or we're not onroad. ELM327 is an alternative if we want to leverage athenad/connect
-    bool should_close_relay = !ignition_local || !is_onroad;
-    if (should_close_relay && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
-      panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
+    // When ignition is on but we're not onroad yet, prefer ELM327 to keep the harness relay open and avoid faults
+    // on vehicles sensitive to relay closure (e.g., Ford Q4/F-150 Lightning). Once onroad, PandaSafety will set
+    // the definitive safety mode; when ignition is off, fall back to NO_OUTPUT.
+    if (ignition_local && !is_onroad) {
+      if (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::ELM327)) {
+        panda->set_safety_model(cereal::CarParams::SafetyModel::ELM327, 1U);
+      }
+    } else {
+      // set safety mode to NO_OUTPUT when car is off or we're not onroad
+      bool should_close_relay = !ignition_local || !is_onroad;
+      if (should_close_relay && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
+        panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
+      }
     }
 
     if (!panda->comms_healthy()) {


### PR DESCRIPTION
… relay open (mitigate Ford Lightning faults); set NO_OUTPUT only when ignition is off or on exit; Fixes commaai/openpilot#30302

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

