### PR TITLE
raylib: match QT colors for danger button style

### DIFF
--- a/system/ui/widgets/button.py
+++ b/system/ui/widgets/button.py
@@ -47,7 +47,7 @@ BUTTON_DISABLED_TEXT_COLORS = {
 BUTTON_BACKGROUND_COLORS = {
   ButtonStyle.NORMAL: rl.Color(51, 51, 51, 255),
   ButtonStyle.PRIMARY: rl.Color(70, 91, 234, 255),
-  ButtonStyle.DANGER: rl.Color(255, 36, 36, 255),
+  ButtonStyle.DANGER: rl.Color(226, 44, 44, 255),
   ButtonStyle.TRANSPARENT: rl.BLACK,
   ButtonStyle.TRANSPARENT_WHITE_TEXT: rl.BLANK,
   ButtonStyle.TRANSPARENT_WHITE_BORDER: rl.BLACK,
@@ -61,7 +61,7 @@ BUTTON_BACKGROUND_COLORS = {
 BUTTON_PRESSED_BACKGROUND_COLORS = {
   ButtonStyle.NORMAL: rl.Color(74, 74, 74, 255),
   ButtonStyle.PRIMARY: rl.Color(48, 73, 244, 255),
-  ButtonStyle.DANGER: rl.Color(204, 0, 0, 255),
+  ButtonStyle.DANGER: rl.Color(255, 36, 36, 255),
   ButtonStyle.TRANSPARENT: rl.BLACK,
   ButtonStyle.TRANSPARENT_WHITE_TEXT: rl.BLANK,
   ButtonStyle.TRANSPARENT_WHITE_BORDER: rl.BLANK,


### PR DESCRIPTION
This is exactly how it was on QT. The current non-pressed color is the QT pressed color, and pressed is brighter.

**Unpressed:**
<img width="809" height="85" alt="2025-10-22_19-11" src="https://github.com/user-attachments/assets/1f6e70da-4c53-438c-ba15-c8506bde4c5d" />
**Pressed:**
<img width="803" height="84" alt="2025-10-22_19-11_1" src="https://github.com/user-attachments/assets/28e4b0c8-88fd-4cfb-ada2-f5ba2614932b" />
