### PR TITLE
ui: cache toggle values in UIState

### DIFF
--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -105,13 +105,17 @@ class TogglesLayout(Widget):
     self._toggles = {}
     self._locked_toggles = set()
     for param, (title, desc, icon, needs_restart) in self._toggle_defs.items():
+      value = self._params.get_bool(param)
       toggle = toggle_item(
         title,
         desc,
-        self._params.get_bool(param),
+        value,
         callback=lambda state, p=param: self._toggle_callback(state, p),
         icon=icon,
       )
+
+      # initialize ui_state toggle values
+      ui_state.set_toggle_value(param, value)
 
       try:
         locked = self._params.get_bool(param + "Lock")
@@ -237,6 +241,8 @@ class TogglesLayout(Widget):
       return
 
     self._params.put_bool(param, state)
+    ui_state.set_toggle_value(param, state)
+
     if self._toggle_defs[param][3]:
       self._params.put_bool("OnroadCycleRequested", True)
 

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -78,7 +78,14 @@ class UIState:
     self._offroad_transition_callbacks: list[Callable[[], None]] = []
     self._engaged_transition_callbacks: list[Callable[[], None]] = []
 
+    self._toggle_values: dict[str, bool] = {}
     self.update_params()
+
+  def set_toggle_value(self, key: str, value: bool):
+    self._toggle_values[key] = value
+
+  def get_toggle_value(self, key: str) -> bool:
+    return self._toggle_values.get(key, False)
 
   def add_offroad_transition_callback(self, callback: Callable[[], None]):
     self._offroad_transition_callbacks.append(callback)
@@ -130,9 +137,8 @@ class UIState:
     self.started = self.sm["deviceState"].started and self.ignition
 
     # Update recording audio state
-    self.recording_audio = self.params.get_bool("RecordAudio") and self.started
-
-    self.is_metric = self.params.get_bool("IsMetric")
+    self.recording_audio = self.get_toggle_value("RecordAudio") and self.started
+    self.is_metric = self.get_toggle_value("IsMetric")
 
   def _update_status(self) -> None:
     if self.started and self.sm.updated["selfdriveState"]:


### PR DESCRIPTION
Added a `_toggle_values` dictionary to `uiState` to cache boolean parameters (e.g., `IsMetric`, `RecordAudio`). Previously, these values were read from disk on every update cycle, causing unnecessary I/O overhead.

Toggle values are now initialized once on load and updated only when the user changes them. Managing toggles in `TogglesLayout` centralizes the logic and simplifies adding new UI-affecting toggles.

Although an alternative approach could override `AugmentedRoadView.show_event` to update `uiState` on view display (similar to the Qt version), handling it in `TogglesLayout` keeps the logic cleaner and more extensible.

@sshane, what are your thoughts on this approach?