### PR TITLE
raylib: fix reset calibration description height calculation

### DIFF
--- a/system/ui/widgets/list_view.py
+++ b/system/ui/widgets/list_view.py
@@ -330,9 +330,7 @@ class ListItem(Widget):
       # do callback first in case receiver changes description
       if self.description_visible and self.description_opened_callback is not None:
         self.description_opened_callback()
-
-      content_width = int(self._rect.width - ITEM_PADDING * 2)
-      self._rect.height = self.get_item_height(self._font, content_width)
+      self._update_rect_height()
 
   def _update_state(self):
     # Detect changes if description is callback
@@ -394,6 +392,7 @@ class ListItem(Widget):
 
   def _parse_description(self, new_desc):
     self._html_renderer.parse_html_content(new_desc)
+    self._update_rect_height()
     self._prev_description = new_desc
 
   @property
@@ -413,6 +412,10 @@ class ListItem(Widget):
       description_height = self._html_renderer.get_total_height(max_width)
       height += description_height - (ITEM_BASE_HEIGHT - ITEM_DESC_V_OFFSET) + ITEM_PADDING
     return height
+
+  def _update_rect_height(self):
+    content_width = int(self._rect.width - ITEM_PADDING * 2)
+    self._rect.height = self.get_item_height(self._font, content_width)
 
   def get_right_item_rect(self, item_rect: rl.Rectangle) -> rl.Rectangle:
     if not self.action_item:

--- a/system/ui/widgets/list_view.py
+++ b/system/ui/widgets/list_view.py
@@ -390,7 +390,7 @@ class ListItem(Widget):
   def set_description(self, description: str | Callable[[], str] | None):
     self._description = description
 
-  def _parse_description(self, new_desc):
+  def _parse_description(self, new_desc: str):
     self._html_renderer.parse_html_content(new_desc)
     self._update_rect_height()
     self._prev_description = new_desc


### PR DESCRIPTION
The first time it's toggled, it doesn't calculate the height correctly since it only does it when the description visibility is updated, but the description can change afterward.

**Before:**
<img width="1073" height="535" alt="2025-10-23_13-55" src="https://github.com/user-attachments/assets/9f99e234-c750-4f53-a712-12c5b6cdfcbf" />

**After:**
<img width="1077" height="532" alt="2025-10-23_15-56" src="https://github.com/user-attachments/assets/cef14b9d-0e6e-4224-bfa8-5a71ecebaf55" />

Now it works, but I see a small flicker on the first frame or so where it's still using the incorrect height. It doesn't show up in screen recording however. But at least it's better than it was.