### PR TITLE
multilang: fix missing translation for longitudinal personality toggle description

### DIFF
--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -94,7 +94,7 @@ class TogglesLayout(Widget):
 
     self._long_personality_setting = multiple_button_item(
       lambda: tr("Driving Personality"),
-      DESCRIPTIONS["LongitudinalPersonality"],
+      lambda: tr(DESCRIPTIONS["LongitudinalPersonality"]),
       buttons=[lambda: tr("Aggressive"), lambda: tr("Standard"), lambda: tr("Relaxed")],
       button_width=255,
       callback=self._set_longitudinal_personality,


### PR DESCRIPTION
This setting is added separately, so it wasn't being translated when all the others are.

Wrapped in lamba to be consistent, but all the ones in this class seem to work fine without the lambda, so curious why this is necessary.

**Before:**
<img width="1074" height="535" alt="2025-10-23_19-44_1" src="https://github.com/user-attachments/assets/3f72ec13-25d5-430c-b786-4faeb7f3b17b" />

**After:**
<img width="1076" height="532" alt="2025-10-23_19-44" src="https://github.com/user-attachments/assets/ab5bc3dc-69ee-4f45-83af-cdb89c8aa63b" />
