### PR TITLE
ui: only auto scale on PC if SCALE env not set

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -141,7 +141,7 @@ class GuiApplication:
     self._width = width
     self._height = height
 
-    if PC and SCALE == 1.0:
+    if PC and os.getenv("SCALE") is None:
       self._scale = self._calculate_auto_scale()
     else:
       self._scale = SCALE


### PR DESCRIPTION
Instead of checking if the SCALE is 1 (default), check if no SCALE is provided. I believe this was the original intent, and allows forcing a SCALE value of 1 if desired, which is necessary for me to run the screenshot tests on WSL.