### PR TITLE
ui: include long personality toggle in toggle defs

### DIFF
--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -94,7 +94,7 @@ class TogglesLayout(Widget):
 
     self._long_personality_setting = multiple_button_item(
       lambda: tr("Driving Personality"),
-      DESCRIPTIONS["LongitudinalPersonality"],
+      lambda: tr(DESCRIPTIONS["LongitudinalPersonality"]),
       buttons=[lambda: tr("Aggressive"), lambda: tr("Standard"), lambda: tr("Relaxed")],
       button_width=255,
       callback=self._set_longitudinal_personality,


### PR DESCRIPTION
This includes the longitudinal personality toggle in the list of toggle definitions so it's automatically translated and gets initialized like the other toggles. Except since it's a special case (multi button item), we still have to handle it separately.

A bit more round-about way to solve #36446 