### PR TITLE
ui: move INF_POINT to constant

### DIFF
--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -27,6 +27,7 @@ BORDER_COLORS = {
 
 WIDE_CAM_MAX_SPEED = 10.0  # m/s (22 mph)
 ROAD_CAM_MIN_SPEED = 15.0  # m/s (34 mph)
+INF_POINT = np.array([1000.0, 0.0, 0.0])
 
 
 class AugmentedRoadView(CameraView):
@@ -176,9 +177,8 @@ class AugmentedRoadView(CameraView):
     zoom = 2.0 if is_wide_camera else 1.1
 
     # Calculate transforms for vanishing point
-    inf_point = np.array([1000.0, 0.0, 0.0])
     calib_transform = intrinsic @ calibration
-    kep = calib_transform @ inf_point
+    kep = calib_transform @ INF_POINT
 
     # Calculate center points and dimensions
     x, y = self._content_rect.x, self._content_rect.y


### PR DESCRIPTION
Reduces redundant np array allocations each frame by defining INF_POINT as a constant