### PR TITLE
raylib: move all font code to font module

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -11,9 +11,9 @@ from collections import deque
 from dataclasses import dataclass
 from typing import NamedTuple
 from importlib.resources import as_file, files
+from openpilot.common.realtime import Ratekeeper
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware import HARDWARE, PC, TICI
-from openpilot.common.realtime import Ratekeeper
 from openpilot.system.ui.lib.font import DEFAULT_TEXT_COLOR, DEFAULT_TEXT_SIZE, FONT_SCALE, FontWeight, FontManager
 
 _DEFAULT_FPS = int(os.getenv("FPS", 20 if TICI else 60))

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -108,6 +108,8 @@ class MouseState:
 
 class GuiApplication:
   def __init__(self, width: int, height: int):
+    self.fonts = FontManager()
+
     self._width = width
     self._height = height
 
@@ -125,8 +127,6 @@ class GuiApplication:
     self._window_close_requested = False
     self._trace_log_callback = None
     self._modal_overlay = ModalOverlay()
-
-    self.fonts = FontManager(self)
 
     self._mouse = MouseState(self._scale)
     self._mouse_events: list[MouseEvent] = []

--- a/system/ui/lib/emoji.py
+++ b/system/ui/lib/emoji.py
@@ -4,7 +4,7 @@ import re
 from PIL import Image, ImageDraw, ImageFont
 import pyray as rl
 
-from openpilot.system.ui.lib.application import FONT_DIR
+from openpilot.system.ui.lib.font import FONT_DIR
 
 _emoji_font: ImageFont.FreeTypeFont | None = None
 _cache: dict[str, rl.Texture] = {}

--- a/system/ui/lib/font.py
+++ b/system/ui/lib/font.py
@@ -30,8 +30,7 @@ class FontWeight(StrEnum):
 
 
 class FontManager:
-  def __init__(self, gui_app):
-    self.gui_app = gui_app
+  def __init__(self):
     self._fonts: dict[FontWeight, rl.Font] = {}
 
   def font(self, font_weight: FontWeight) -> rl.Font:

--- a/system/ui/lib/font.py
+++ b/system/ui/lib/font.py
@@ -1,0 +1,86 @@
+from importlib.resources import as_file, files
+import os
+import pyray as rl
+from enum import StrEnum
+from openpilot.system.ui.lib.multilang import TRANSLATIONS_DIR, UNIFONT_LANGUAGES, multilang
+from openpilot.common.swaglog import cloudlog
+
+ASSETS_DIR = files("openpilot.selfdrive").joinpath("assets")
+FONT_DIR = ASSETS_DIR.joinpath("fonts")
+
+DEFAULT_TEXT_SIZE = 60
+DEFAULT_TEXT_COLOR = rl.WHITE
+
+# Qt draws fonts accounting for ascent/descent differently, so compensate to match old styles
+# The real scales for the fonts below range from 1.212 to 1.266
+FONT_SCALE = 1.242
+
+
+class FontWeight(StrEnum):
+  THIN = "Inter-Thin.ttf"
+  EXTRA_LIGHT = "Inter-ExtraLight.ttf"
+  LIGHT = "Inter-Light.ttf"
+  NORMAL = "Inter-Regular.ttf"
+  MEDIUM = "Inter-Medium.ttf"
+  SEMI_BOLD = "Inter-SemiBold.ttf"
+  BOLD = "Inter-Bold.ttf"
+  EXTRA_BOLD = "Inter-ExtraBold.ttf"
+  BLACK = "Inter-Black.ttf"
+  UNIFONT = "unifont.otf"
+
+
+def font_fallback(font: rl.Font, gui_app) -> rl.Font:
+  """Fall back to unifont for languages that require it."""
+  if multilang.requires_unifont():
+    return gui_app.font(FontWeight.UNIFONT)
+  return font
+
+
+def load_fonts(gui_app):
+  """Load fonts into the provided GuiApplication instance (gui_app._fonts)."""
+  # Create a character set from our keyboard layouts
+  from openpilot.system.ui.widgets.keyboard import KEYBOARD_LAYOUTS
+
+  base_chars = set()
+  for layout in KEYBOARD_LAYOUTS.values():
+    base_chars.update(key for row in layout for key in row)
+  base_chars |= set("–‑✓×°§•")
+
+  # Load only the characters used in translations
+  unifont_chars = set(base_chars)
+  for language, code in multilang.languages.items():
+    unifont_chars |= set(language)
+    try:
+      with open(os.path.join(TRANSLATIONS_DIR, f"app_{code}.po")) as f:
+        lang_chars = set(f.read())
+        if code in UNIFONT_LANGUAGES:
+          unifont_chars |= lang_chars
+        else:
+          base_chars |= lang_chars
+    except FileNotFoundError:
+      cloudlog.warning(f"Translation file for language '{code}' not found when loading fonts.")
+
+  base_chars = "".join(base_chars)
+  cloudlog.debug(f"Loading fonts with {len(base_chars)} glyphs.")
+
+  unifont_chars = "".join(unifont_chars)
+  cloudlog.debug(f"Loading unifont with {len(unifont_chars)} glyphs.")
+
+  base_codepoint_count = rl.ffi.new("int *", 1)
+  base_codepoints = rl.load_codepoints(base_chars, base_codepoint_count)
+
+  unifont_codepoint_count = rl.ffi.new("int *", 1)
+  unifont_codepoints = rl.load_codepoints(unifont_chars, unifont_codepoint_count)
+
+  for font_weight_file in FontWeight:
+    with as_file(FONT_DIR.joinpath(font_weight_file)) as fspath:
+      if font_weight_file == FontWeight.UNIFONT:
+        font = rl.load_font_ex(fspath.as_posix(), 200, unifont_codepoints, unifont_codepoint_count[0])
+      else:
+        font = rl.load_font_ex(fspath.as_posix(), 200, base_codepoints, base_codepoint_count[0])
+      rl.set_texture_filter(font.texture, rl.TextureFilter.TEXTURE_FILTER_BILINEAR)
+      gui_app._fonts[font_weight_file] = font
+
+  rl.unload_codepoints(base_codepoints)
+  rl.unload_codepoints(unifont_codepoints)
+  rl.gui_set_font(gui_app._fonts[FontWeight.NORMAL])

--- a/system/ui/lib/text_measure.py
+++ b/system/ui/lib/text_measure.py
@@ -1,6 +1,5 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.font import FONT_SCALE
+from openpilot.system.ui.lib.application import gui_app, FONT_SCALE
 from openpilot.system.ui.lib.emoji import find_emoji
 
 _cache: dict[int, rl.Vector2] = {}

--- a/system/ui/lib/text_measure.py
+++ b/system/ui/lib/text_measure.py
@@ -1,6 +1,6 @@
 import pyray as rl
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.font import FONT_SCALE, font_fallback
+from openpilot.system.ui.lib.font import FONT_SCALE
 from openpilot.system.ui.lib.emoji import find_emoji
 
 _cache: dict[int, rl.Vector2] = {}
@@ -8,7 +8,7 @@ _cache: dict[int, rl.Vector2] = {}
 
 def measure_text_cached(font: rl.Font, text: str, font_size: int, spacing: int = 0) -> rl.Vector2:
   """Caches text measurements to avoid redundant calculations."""
-  font = font_fallback(font, gui_app)
+  font = gui_app.fonts.font_fallback(font)
   key = hash((font.texture.id, text, font_size, spacing))
   if key in _cache:
     return _cache[key]

--- a/system/ui/lib/text_measure.py
+++ b/system/ui/lib/text_measure.py
@@ -1,5 +1,6 @@
 import pyray as rl
-from openpilot.system.ui.lib.application import FONT_SCALE, font_fallback
+from openpilot.system.ui.lib.application import gui_app
+from openpilot.system.ui.lib.font import FONT_SCALE, font_fallback
 from openpilot.system.ui.lib.emoji import find_emoji
 
 _cache: dict[int, rl.Vector2] = {}
@@ -7,7 +8,7 @@ _cache: dict[int, rl.Vector2] = {}
 
 def measure_text_cached(font: rl.Font, text: str, font_size: int, spacing: int = 0) -> rl.Vector2:
   """Caches text measurements to avoid redundant calculations."""
-  font = font_fallback(font)
+  font = font_fallback(font, gui_app)
   key = hash((font.texture.id, text, font_size, spacing))
   if key in _cache:
     return _cache[key]

--- a/system/ui/lib/wrap_text.py
+++ b/system/ui/lib/wrap_text.py
@@ -1,7 +1,6 @@
 import pyray as rl
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.text_measure import measure_text_cached
-from openpilot.system.ui.lib.application import font_fallback
 
 
 def _break_long_word(font: rl.Font, word: str, font_size: int, max_width: int) -> list[str]:
@@ -42,7 +41,7 @@ _cache: dict[int, list[str]] = {}
 
 
 def wrap_text(font: rl.Font, text: str, font_size: int, max_width: int) -> list[str]:
-  font = font_fallback(font, gui_app)
+  font = gui_app.fonts.font_fallback(font)
   key = hash((font.texture.id, text, font_size, max_width))
   if key in _cache:
     return _cache[key]

--- a/system/ui/lib/wrap_text.py
+++ b/system/ui/lib/wrap_text.py
@@ -1,4 +1,5 @@
 import pyray as rl
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.application import font_fallback
 
@@ -41,7 +42,7 @@ _cache: dict[int, list[str]] = {}
 
 
 def wrap_text(font: rl.Font, text: str, font_size: int, max_width: int) -> list[str]:
-  font = font_fallback(font)
+  font = font_fallback(font, gui_app)
   key = hash((font.texture.id, text, font_size, max_width))
   if key in _cache:
     return _cache[key]

--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -3,8 +3,7 @@ from itertools import zip_longest
 from typing import Union
 import pyray as rl
 
-from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.font import FontWeight, DEFAULT_TEXT_SIZE, DEFAULT_TEXT_COLOR, FONT_SCALE
+from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_TEXT_SIZE, DEFAULT_TEXT_COLOR, FONT_SCALE
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.utils import GuiStyleContext
 from openpilot.system.ui.lib.emoji import find_emoji, emoji_tex

--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -3,7 +3,8 @@ from itertools import zip_longest
 from typing import Union
 import pyray as rl
 
-from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_TEXT_SIZE, DEFAULT_TEXT_COLOR, FONT_SCALE
+from openpilot.system.ui.lib.application import gui_app
+from openpilot.system.ui.lib.font import FontWeight, DEFAULT_TEXT_SIZE, DEFAULT_TEXT_COLOR, FONT_SCALE
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.utils import GuiStyleContext
 from openpilot.system.ui.lib.emoji import find_emoji, emoji_tex


### PR DESCRIPTION
Moving to it's own module will make it easier to work on the font loading performance, such as loading in the background, etc.

**Note:**
A lot of places still import the font constants from `lib.application`, which is fine and still works, but we could move them to load from `lib.font` in the future.

<details>
<summary>Example</summary>

```diff
- from openpilot.system.ui.lib.application import gui_app, FontWeight, FONT_SCALE
+ from openpilot.system.ui.lib.application import gui_app
+ from openpilot.system.ui.lib.font import FontWeight, FONT_SCALE
```
</details>
