### PR TITLE
ui: add startup profiling

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -217,24 +217,22 @@ class GuiApplication:
     profiler = cProfile.Profile()
     start_time = time.monotonic()
     profiler.enable()
-    try:
-      yield
-    except Exception:
-      profiler.disable()
-      raise
-    else:
-      profiler.disable()
-      elapsed_ms = (time.monotonic() - start_time) * 1e3
 
-      stats_stream = io.StringIO()
-      pstats.Stats(profiler, stream=stats_stream).sort_stats("cumtime").print_stats(25)
-      print("\n=== Startup profile ===")
-      print(stats_stream.getvalue().rstrip())
+    # do the init
+    yield
 
-      green = "\033[92m"
-      reset = "\033[0m"
-      print(f"{green}UI window ready in {elapsed_ms:.1f} ms{reset}")
-      sys.exit(0)
+    profiler.disable()
+    elapsed_ms = (time.monotonic() - start_time) * 1e3
+
+    stats_stream = io.StringIO()
+    pstats.Stats(profiler, stream=stats_stream).sort_stats("cumtime").print_stats(25)
+    print("\n=== Startup profile ===")
+    print(stats_stream.getvalue().rstrip())
+
+    green = "\033[92m"
+    reset = "\033[0m"
+    print(f"{green}UI window ready in {elapsed_ms:.1f} ms{reset}")
+    sys.exit(0)
 
   def set_modal_overlay(self, overlay, callback: Callable | None = None):
     if self._modal_overlay.overlay is not None:


### PR DESCRIPTION
```bash
(openpilot) batman@workstation-adeeb2:~/fivepilot/selfdrive/ui$ LOGPRINT=warning PROFILE_STARTUP=1 ./ui.py
RAYLIB STATIC 5.5.0.2 LOADED
Loaded translations for language: en
INFO: Initializing raylib 5.5
INFO: Platform backend: DESKTOP (GLFW)
INFO: Supported raylib modules:
INFO:     > rcore:..... loaded (mandatory)
INFO:     > rlgl:...... loaded (mandatory)
INFO:     > rshapes:... loaded (optional)
INFO:     > rtextures:. loaded (optional)
INFO:     > rtext:..... loaded (optional)
INFO:     > rmodels:... loaded (optional)
INFO:     > raudio:.... loaded (optional)
INFO: DISPLAY: Device initialized successfully
INFO:     > Display size: 3840 x 2160
INFO:     > Screen size:  1 x 1
INFO:     > Render size:  1 x 1
INFO:     > Viewport offsets: 0, 0
INFO: GLAD: OpenGL extensions loaded successfully
INFO: GL: Supported extensions count: 401
INFO: GL: OpenGL device information:
INFO:     > Vendor:   NVIDIA Corporation
INFO:     > Renderer: NVIDIA GeForce RTX 3080/PCIe/SSE2
INFO:     > Version:  3.3.0 NVIDIA 565.57.01
INFO:     > GLSL:     3.30 NVIDIA via Cg compiler
INFO: GL: VAO extension detected, VAO functions loaded successfully
INFO: GL: NPOT textures extension detected, full NPOT textures supported
INFO: GL: DXT compressed textures supported
INFO: GL: ETC2/EAC compressed textures supported
INFO: PLATFORM: DESKTOP (GLFW - X11): Initialized successfully
INFO: TEXTURE: [ID 1] Texture loaded successfully (1x1 | R8G8B8A8 | 1 mipmaps)
INFO: TEXTURE: [ID 1] Default texture loaded successfully
INFO: SHADER: [ID 1] Vertex shader compiled successfully
INFO: SHADER: [ID 2] Fragment shader compiled successfully
INFO: SHADER: [ID 3] Program shader loaded successfully
INFO: SHADER: [ID 3] Default shader loaded successfully
INFO: RLGL: Render batch vertex buffers loaded successfully in RAM (CPU)
INFO: RLGL: Render batch vertex buffers loaded successfully in VRAM (GPU)
INFO: RLGL: Default OpenGL state initialized successfully
INFO: TEXTURE: [ID 2] Texture loaded successfully (128x128 | GRAY_ALPHA | 1 mipmaps)
INFO: FONT: Default font loaded successfully (224 glyphs)
INFO: SYSTEM: Working Directory: /home/batman/fivepilot/selfdrive/ui
INFO: TEXTURE: [ID 2] Unloaded texture data from VRAM (GPU)
INFO: SHADER: [ID 3] Default shader unloaded successfully
INFO: TEXTURE: [ID 1] Default texture unloaded successfully
INFO: Window closed successfully

=== Startup profile ===
         58274 function calls (55530 primitive calls) in 0.519 seconds

   Ordered by: cumulative time
   List reduced from 590 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       38    0.000    0.000    0.486    0.013 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/pyray/__init__.py:47(wrapped_func)
        1    0.003    0.003    0.385    0.385 /home/batman/fivepilot/openpilot/system/ui/lib/application.py:394(_load_fonts)
       10    0.379    0.038    0.379    0.038 {built-in method raylib._raylib_cffi.LoadFontEx}
        1    0.106    0.106    0.106    0.106 {built-in method raylib._raylib_cffi.InitWindow}
        1    0.000    0.000    0.028    0.028 /home/batman/fivepilot/openpilot/system/ui/lib/application.py:460(_set_log_callback)
        1    0.000    0.000    0.021    0.021 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/cffi/api.py:101(cdef)
        1    0.000    0.000    0.021    0.021 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/cffi/api.py:119(_cdef)
        1    0.000    0.000    0.021    0.021 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/cffi/cparser.py:370(parse)
        1    0.000    0.000    0.021    0.021 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/cffi/cparser.py:394(_internal_parse)
        1    0.000    0.000    0.021    0.021 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/cffi/cparser.py:307(_parse)
        1    0.000    0.000    0.020    0.020 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/cffi/cparser.py:50(_get_parser)
        1    0.000    0.000    0.020    0.020 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/pycparser/c_parser.py:19(__init__)
       22    0.000    0.000    0.016    0.001 /home/batman/.local/share/uv/python/cpython-3.11.4-linux-x86_64-gnu/lib/python3.11/re/__init__.py:225(compile)
       22    0.000    0.000    0.016    0.001 /home/batman/.local/share/uv/python/cpython-3.11.4-linux-x86_64-gnu/lib/python3.11/re/__init__.py:272(_compile)
       22    0.000    0.000    0.016    0.001 /home/batman/.local/share/uv/python/cpython-3.11.4-linux-x86_64-gnu/lib/python3.11/re/_compiler.py:738(compile)
        1    0.000    0.000    0.014    0.014 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/pycparser/c_lexer.py:57(build)
        1    0.000    0.000    0.014    0.014 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/pycparser/ply/lex.py:863(lex)
        1    0.000    0.000    0.013    0.013 /home/batman/fivepilot/.venv/lib/python3.11/site-packages/pycparser/ply/lex.py:211(readtab)
     14/3    0.000    0.000    0.011    0.004 <frozen importlib._bootstrap>:1165(_find_and_load)
     14/3    0.000    0.000    0.011    0.004 <frozen importlib._bootstrap>:1120(_find_and_load_unlocked)
       22    0.000    0.000    0.011    0.000 /home/batman/.local/share/uv/python/cpython-3.11.4-linux-x86_64-gnu/lib/python3.11/re/_parser.py:970(parse)
     13/3    0.000    0.000    0.011    0.004 <frozen importlib._bootstrap>:666(_load_unlocked)
     15/3    0.000    0.000    0.011    0.004 {built-in method builtins.exec}
   289/22    0.001    0.000    0.011    0.000 /home/batman/.local/share/uv/python/cpython-3.11.4-linux-x86_64-gnu/lib/python3.11/re/_parser.py:447(_parse_sub)
     13/3    0.000    0.000    0.010    0.003 <frozen importlib._bootstrap_external>:934(exec_module)
UI window ready in 518.7 ms
```