### PR TITLE
fix: api token invalid before systime update

### DIFF
--- a/selfdrive/ui/lib/api_helpers.py
+++ b/selfdrive/ui/lib/api_helpers.py
@@ -1,4 +1,4 @@
-import time
+from datetime import datetime, UTC
 from functools import lru_cache
 from openpilot.common.api import Api
 
@@ -11,4 +11,4 @@ def _get_token(dongle_id: str, t: int):
 
 
 def get_token(dongle_id: str):
-  return _get_token(dongle_id, int(time.monotonic() / (TOKEN_EXPIRY_HOURS / 2 * 60 * 60)))
+  return _get_token(dongle_id, int(datetime.now(UTC).replace(tzinfo=None).timestamp() / (TOKEN_EXPIRY_HOURS / 2 * 60 * 60)))


### PR DESCRIPTION
partial fix of https://github.com/commaai/openpilot/issues/36453

api token is cached based on time. however, token is relative to `datetime.now` which gets updated once network connectivity is established.

https://github.com/commaai/openpilot/blob/94ca077e69e152ca849a27d1582b4885b1f994af/common/api.py#L26-L32

on a fresh boot, i get 401 errors from API after ssl certs are ready

token is now resilient to clock changes (it'll re-generate because of cache miss on time change or expiry)