### PR TITLE
ui: add retranslate_ui hook for dynamic language switching

### DIFF
--- a/selfdrive/ui/layouts/settings/developer.py
+++ b/selfdrive/ui/layouts/settings/developer.py
@@ -35,41 +35,34 @@ class DeveloperLayout(Widget):
     self._is_release = self._params.get_bool("IsReleaseBranch")
 
     # Build items and keep references for callbacks/state updates
-    self._adb_toggle = toggle_item(
-      lambda: tr("Enable ADB"),
-      description=lambda: tr(DESCRIPTIONS["enable_adb"]),
+    self._adb_toggle = toggle_item("", "",
       initial_state=self._params.get_bool("AdbEnabled"),
       callback=self._on_enable_adb,
       enabled=ui_state.is_offroad,
     )
 
     # SSH enable toggle + SSH key management
-    self._ssh_toggle = toggle_item(
-      lambda: tr("Enable SSH"),
+    self._ssh_toggle = toggle_item("",
       description="",
       initial_state=self._params.get_bool("SshEnabled"),
       callback=self._on_enable_ssh,
     )
-    self._ssh_keys = ssh_key_item(lambda: tr("SSH Keys"), description=lambda: tr(DESCRIPTIONS["ssh_key"]))
+    self._ssh_keys = ssh_key_item("", "")
 
-    self._joystick_toggle = toggle_item(
-      lambda: tr("Joystick Debug Mode"),
+    self._joystick_toggle = toggle_item("",
       description="",
       initial_state=self._params.get_bool("JoystickDebugMode"),
       callback=self._on_joystick_debug_mode,
       enabled=ui_state.is_offroad,
     )
 
-    self._long_maneuver_toggle = toggle_item(
-      lambda: tr("Longitudinal Maneuver Mode"),
+    self._long_maneuver_toggle = toggle_item("",
       description="",
       initial_state=self._params.get_bool("LongitudinalManeuverMode"),
       callback=self._on_long_maneuver_mode,
     )
 
-    self._alpha_long_toggle = toggle_item(
-      lambda: tr("openpilot Longitudinal Control (Alpha)"),
-      description=lambda: tr(DESCRIPTIONS["alpha_longitudinal"]),
+    self._alpha_long_toggle = toggle_item("", "",
       initial_state=self._params.get_bool("AlphaLongitudinalEnabled"),
       callback=self._on_alpha_long_enabled,
       enabled=lambda: not ui_state.engaged,
@@ -88,6 +81,17 @@ class DeveloperLayout(Widget):
 
     # Toggles should be not available to change in onroad state
     ui_state.add_offroad_transition_callback(self._update_toggles)
+
+  def retranslate_ui(self) -> None:
+    self._adb_toggle.set_title(tr("Enable ADB"))
+    self._adb_toggle.set_description(tr(DESCRIPTIONS["enable_adb"]))
+    self._ssh_toggle.set_title(tr("Enable SSH"))
+    self._ssh_keys.set_title(tr("SSH Keys"))
+    self._ssh_keys.set_description(tr(DESCRIPTIONS["ssh_key"]))
+    self._joystick_toggle.set_title(tr("Joystick Debug Mode"))
+    self._long_maneuver_toggle.set_title(tr("Longitudinal Maneuver Mode"))
+    self._alpha_long_toggle.set_title(tr("openpilot Longitudinal Control (Alpha)"))
+    self._alpha_long_toggle.set_description(tr(DESCRIPTIONS["alpha_longitudinal"]))
 
   def _render(self, rect):
     self._scroller.render(rect)

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -159,8 +159,17 @@ class GuiApplication:
     self._mouse = MouseState(self._scale)
     self._mouse_events: list[MouseEvent] = []
 
+    self._widgets: list[object] = []
     # Debug variables
     self._mouse_history: deque[MousePos] = deque(maxlen=MOUSE_THREAD_RATE)
+
+  def register_widget(self, widget: object) -> None:
+    self._widgets.append(widget)
+
+  def language_changed(self):
+    # Notify all widgets of language change
+    for widget in self._widgets:
+      widget.retranslate_ui()
 
   @property
   def target_fps(self):
@@ -362,6 +371,8 @@ class GuiApplication:
   def _load_fonts(self):
     # Create a character set from our keyboard layouts
     from openpilot.system.ui.widgets.keyboard import KEYBOARD_LAYOUTS
+
+    multilang.initialize(self)
 
     base_chars = set()
     for layout in KEYBOARD_LAYOUTS.values():

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -167,6 +167,8 @@ class GuiApplication:
     self._widgets.append(widget)
 
   def language_changed(self):
+    # TODO: Reload fonts with language-specific character sets
+
     # Notify all widgets of language change
     for widget in self._widgets:
       widget.retranslate_ui()

--- a/system/ui/lib/multilang.py
+++ b/system/ui/lib/multilang.py
@@ -26,6 +26,7 @@ UNIFONT_LANGUAGES = [
 
 class Multilang:
   def __init__(self):
+    self._gui_app = None
     self._params = Params() if Params is not None else None
     self._language: str = "en"
     self.languages = {}
@@ -41,6 +42,10 @@ class Multilang:
     """Certain languages require unifont to render their glyphs."""
     return self._language in UNIFONT_LANGUAGES
 
+  def initialize(self, gui_app=None)-> None:
+    self._gui_app = gui_app
+    self.setup()
+
   def setup(self):
     try:
       with open(os.path.join(TRANSLATIONS_DIR, f'app_{self._language}.mo'), 'rb') as fh:
@@ -48,6 +53,8 @@ class Multilang:
       translation.install()
       self._translation = translation
       cloudlog.warning(f"Loaded translations for language: {self._language}")
+      if self._gui_app is not None:
+        self._gui_app.language_changed()
     except FileNotFoundError:
       cloudlog.error(f"No translation file found for language: {self._language}, using default.")
       gettext.install('app')
@@ -77,7 +84,6 @@ class Multilang:
 
 
 multilang = Multilang()
-multilang.setup()
 
 tr, trn = multilang.tr, multilang.trn
 

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -12,6 +12,15 @@ class DialogResult(IntEnum):
 
 
 class Widget(abc.ABC):
+  def __init_subclass__(cls, **kwargs):
+    """Hook to call _post_init() after subclass __init__ completes."""
+    super().__init_subclass__(**kwargs)
+    original_init = cls.__init__
+    def wrapped_init(self, *args, **kwargs):
+      original_init(self, *args, **kwargs)
+      self._post_init()
+    cls.__init__ = wrapped_init
+
   def __init__(self):
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._parent_rect: rl.Rectangle | None = None
@@ -23,6 +32,11 @@ class Widget(abc.ABC):
     self._touch_valid_callback: Callable[[], bool] | None = None
     self._click_callback: Callable[[], None] | None = None
     self._multi_touch = False
+
+    gui_app.register_widget(self)
+
+  def _post_init(self) -> None:
+    self.retranslate_ui()
 
   @property
   def rect(self) -> rl.Rectangle:
@@ -74,6 +88,9 @@ class Widget(abc.ABC):
     self._rect.x, self._rect.y = x, y
     if changed:
       self._update_layout_rects()
+
+  def retranslate_ui(self) -> None:
+    """Override this method to set translatable text."""
 
   @property
   def _hit_rect(self) -> rl.Rectangle:

--- a/system/ui/widgets/list_view.py
+++ b/system/ui/widgets/list_view.py
@@ -402,6 +402,9 @@ class ListItem(Widget):
   def title(self):
     return _resolve_value(self._title, "")
 
+  def set_title(self, title: str | Callable[[], str]):
+    self._title = title
+
   @property
   def description(self):
     return _resolve_value(self._description, "")


### PR DESCRIPTION
Adds a `retranslate_ui()` hook to the Widget base class to support dynamic language switching, following a well-established pattern in modern UI frameworks (e.g., Qt’s `retranslateUi()`).

1. Introduces _post_init() and `retranslate_ui()`  hooks.
2. Widgets can override `retranslate_ui()` to update text and reload fonts when the language changes.
3. Allows instant UI text updates and language-specific font loading.
4. Fully backward-compatible with existing widgets.

Currently, only `develop.py` implements this hook for demonstration and easier review.

Next Steps

1. Apply retranslate_ui() to all widgets to support dynamic language switching without using `lambda: tr()` in every frame.
2. Refactor multi-language handling to load only the necessary fonts/codepoints for the active language before calling retranslate_ui() hooks.