### PR TITLE
ci: include assets path for UI label and preview

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -12,7 +12,7 @@ simulation:
 
 ui:
   - changed-files:
-    - any-glob-to-all-files: '{selfdrive/ui/**,system/ui/**}'
+    - any-glob-to-all-files: '{selfdrive/assets/**,selfdrive/ui/**,system/ui/**}'
 
 tools:
   - changed-files:

--- a/.github/workflows/raylib_ui_preview.yaml
+++ b/.github/workflows/raylib_ui_preview.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - 'master'
     paths:
+      - 'selfdrive/assets/**'
       - 'selfdrive/ui/**'
       - 'system/ui/**'
   workflow_dispatch:


### PR DESCRIPTION
Useful when changing the fonts or the pre-process script, as well as images or icons.

Technically `assets/sounds` isn't really UI, but I think it's worth the trade.