### PR TITLE
ci: add docs label for docs folder or .md file changes

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -2,6 +2,10 @@ CI / testing:
   - changed-files:
     - any-glob-to-all-files: "{.github/**,**/test_*,**/test/**,Jenkinsfile}"
 
+docs:
+  - changed-files:
+    - any-glob-to-all-files: "{docs/**,**/*.md}"
+
 car:
   - changed-files:
     - any-glob-to-all-files: '{selfdrive/car/**,opendbc_repo}'


### PR DESCRIPTION
I thought this was already a thing, but it seems the docs label was used for car docs before opendbc was split out.