### PR TITLE
font: set font size to largest used size

### DIFF
--- a/selfdrive/assets/fonts/process.py
+++ b/selfdrive/assets/fonts/process.py
@@ -87,7 +87,7 @@ def _process_font(font_path: Path, codepoints: tuple[int, ...]):
 
   font_size = {
     "unifont.otf": 24,  # unifont is huge
-  }.get(font_path.name, 200)
+  }.get(font_path.name, 176)  # largest text size (current speed)
 
   data = font_path.read_bytes()
   file_buf = rl.ffi.new("unsigned char[]", data)

--- a/selfdrive/assets/fonts/process.py
+++ b/selfdrive/assets/fonts/process.py
@@ -87,7 +87,7 @@ def _process_font(font_path: Path, codepoints: tuple[int, ...]):
 
   font_size = {
     "unifont.otf": 24,  # unifont is huge
-  }.get(font_path.name, 176)  # largest text size (current speed)
+  }.get(font_path.name, 176)  # largest text size (current speed display)
 
   data = font_path.read_bytes()
   file_buf = rl.ffi.new("unsigned char[]", data)


### PR DESCRIPTION
The largest text seems to be the current speed, which is 176. We can almost certainly make it much smaller with minimal issues. It seems almost all texts are below 100.