### PR TITLE
ui: fix LineSeparator horizontal centering issue

### DIFF
--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -18,7 +18,7 @@ class LineSeparator(Widget):
 
   def _render(self, _):
     rl.draw_line(int(self._rect.x) + LINE_PADDING, int(self._rect.y),
-                 int(self._rect.x + self._rect.width) - LINE_PADDING * 2, int(self._rect.y),
+                 int(self._rect.x + self._rect.width) - LINE_PADDING, int(self._rect.y),
                  LINE_COLOR)
 
 


### PR DESCRIPTION
Fixes an issue in `LineSeparator` where the line had uneven padding. The X2 now applies LINE_PADDING symmetrically, keeping the line centered within the list item.