### PR TITLE
ui: fix text wrapping for CJK languages

### DIFF
--- a/system/ui/lib/wrap_text.py
+++ b/system/ui/lib/wrap_text.py
@@ -1,47 +1,43 @@
 import pyray as rl
+import re
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.application import font_fallback
 
+# Regex for Unicode-aware tokenization: words, whitespace, symbols
+WORD_RE = re.compile(r'(\s+|[\w]+|[^\w\s])', re.UNICODE)
+_cache: dict[int, list[str]] = {}
 
 def _break_long_word(font: rl.Font, word: str, font_size: int, max_width: int) -> list[str]:
+  """Break a long word into parts that fit within max_width."""
   if not word:
     return []
-
   parts = []
   remaining = word
-
   while remaining:
     if measure_text_cached(font, remaining, font_size).x <= max_width:
       parts.append(remaining)
       break
-
     # Binary search for the longest substring that fits
     left, right = 1, len(remaining)
     best_fit = 1
-
     while left <= right:
       mid = (left + right) // 2
       substring = remaining[:mid]
       width = measure_text_cached(font, substring, font_size).x
-
       if width <= max_width:
         best_fit = mid
         left = mid + 1
       else:
         right = mid - 1
-
-    # Add the part that fits
     parts.append(remaining[:best_fit])
     remaining = remaining[best_fit:]
-
   return parts
 
-
-_cache: dict[int, list[str]] = {}
-
-
 def wrap_text(font: rl.Font, text: str, font_size: int, max_width: int) -> list[str]:
+  """Wrap text to fit within max_width, handling Unicode and whitespace properly."""
   font = font_fallback(font)
+  # Strip input text for consistent caching
+  text = text.strip()
   key = hash((font.texture.id, text, font_size, max_width))
   if key in _cache:
     return _cache[key]
@@ -49,58 +45,46 @@ def wrap_text(font: rl.Font, text: str, font_size: int, max_width: int) -> list[
   if not text or max_width <= 0:
     return []
 
-  # Split text by newlines first to preserve explicit line breaks
-  paragraphs = text.split('\n')
   all_lines: list[str] = []
-
-  for paragraph in paragraphs:
-    # Handle empty paragraphs (preserve empty lines)
-    if not paragraph.strip():
+  for paragraph in text.split('\n'):
+    if not paragraph:
       all_lines.append("")
       continue
 
-    # Process each paragraph separately
-    words = paragraph.split()
+    words = WORD_RE.findall(paragraph)
     if not words:
       all_lines.append("")
       continue
 
-    lines: list[str] = []
-    current_line: list[str] = []
-
+    current_line = ""
     for word in words:
-      word_width = int(measure_text_cached(font, word, font_size).x)
+      # Normalize whitespace to a single space
+      if word.isspace():
+        word = " "
+      word_width = measure_text_cached(font, word, font_size).x
 
-      # Check if word alone exceeds max width (need to break the word)
       if word_width > max_width:
-        # Finish current line if it has content
+        # Break long word
         if current_line:
-          lines.append(" ".join(current_line))
-          current_line = []
-
-        # Break the long word into parts
-        lines.extend(_break_long_word(font, word, font_size, max_width))
+          all_lines.append(current_line.strip())
+          current_line = ""
+        for part in _break_long_word(font, word, font_size, max_width):
+          all_lines.append(part.strip())
         continue
 
-      # Measure the actual joined string to get accurate width (accounts for kerning, etc.)
-      test_line = " ".join(current_line + [word]) if current_line else word
-      test_width = int(measure_text_cached(font, test_line, font_size).x)
+      test_line = current_line + word if current_line else word
+      test_width = measure_text_cached(font, test_line, font_size).x
 
-      # Check if word fits on current line
       if test_width <= max_width:
-        current_line.append(word)
+        current_line = test_line
       else:
-        # Start new line with this word
+        # Start new line, remove trailing space from previous line
         if current_line:
-          lines.append(" ".join(current_line))
-        current_line = [word]
+          all_lines.append(current_line.strip())
+        current_line = word if word != " " else ""  # Don't start with space
 
-    # Add remaining words
     if current_line:
-      lines.append(" ".join(current_line))
-
-    # Add all lines from this paragraph
-    all_lines.extend(lines)
+      all_lines.append(current_line.strip())
 
   _cache[key] = all_lines
   return all_lines


### PR DESCRIPTION
Previous implementation assumed space-separated words, breaking CJK text wrapping. Now detects CJK characters (Chinese/Japanese/Korean) and treats them as individual tokens while preserving Latin word boundaries. Also handles long words and mixed-script text.

| Before  | After |
| ------------- | ------------- |
| <img width="1299" height="254" alt="Screenshot from 2025-11-01 13-54-57" src="https://github.com/user-attachments/assets/10d74bde-d5d2-4818-878e-74b794558344" />  | <img width="1299" height="210" alt="Screenshot from 2025-11-01 13-57-41" src="https://github.com/user-attachments/assets/c5cea4e8-be22-409c-8cde-ae7728691b4e" />  |
| <img width="1353" height="415" alt="Screenshot from 2025-11-01 13-55-46" src="https://github.com/user-attachments/assets/2437a0d9-7358-4cc0-81f1-90f645a04c3c" />  | <img width="1314" height="369" alt="Screenshot from 2025-11-01 13-56-24" src="https://github.com/user-attachments/assets/0d7da38f-2474-43e2-9317-340f2a6bfe3c" />  |


