### PR TITLE
ui: fix cramped text by reverting line height to 1.2 in HTML renderer

### DIFF
--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -52,7 +52,7 @@ class HtmlElement:
   font_weight: FontWeight
   margin_top: int
   margin_bottom: int
-  line_height: float = 0.9  # matches Qt visually, unsure why not default 1.2
+  line_height: float = 1.2
   indent_level: int = 0
 
 


### PR DESCRIPTION
The previous PR (#36237) cut line_height from 1.2 to 0.9, causing lines to overlap by ~10% and look cramped, hurting readability. Revert to 1.2 to follow standard spacing (1.2–1.5) for clearer text.

**Before (Overlapped/Cramped)**

<img width="1322" height="475" alt="Screenshot from 2025-11-01 19-35-18" src="https://github.com/user-attachments/assets/5a147220-8db8-4bd1-9482-238661e44a27" />

**After:**

<img width="1329" height="565" alt="Screenshot from 2025-11-01 19-36-03" src="https://github.com/user-attachments/assets/38310919-4e77-4e84-89c6-cf80fcb8134a" />
