### PR TITLE
ui: fix vertical centering for multi-line labels

### DIFF
--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -173,7 +173,8 @@ class Label(Widget):
 
     text_size = self._text_size[0] if self._text_size else rl.Vector2(0.0, 0.0)
     if self._text_alignment_vertical == rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE:
-      text_pos = rl.Vector2(self._rect.x, (self._rect.y + (self._rect.height - text_size.y) // 2))
+      total_text_height = sum(ts.y for ts in self._text_size) or self._font_size * FONT_SCALE
+      text_pos = rl.Vector2(self._rect.x, (self._rect.y + (self._rect.height - total_text_height) // 2))
     else:
       text_pos = rl.Vector2(self._rect.x, self._rect.y)
 


### PR DESCRIPTION
Multi-line labels now use total text height for vertical centering instead of only the first line's height.