### PR TITLE
ui: fix missing text segment after last emoji in `measure_text_cached`

### DIFF
--- a/system/ui/lib/text_measure.py
+++ b/system/ui/lib/text_measure.py
@@ -15,11 +15,13 @@ def measure_text_cached(font: rl.Font, text: str, font_size: int, spacing: int =
   # Measure normal characters without emojis, then add standard width for each found emoji
   emoji = find_emoji(text)
   if emoji:
-    non_emoji_text = ""
+    parts = []
     last_index = 0
     for start, end, _ in emoji:
-      non_emoji_text += text[last_index:start]
+      parts.append(text[last_index:start])
       last_index = end
+    parts.append(text[last_index:])
+    non_emoji_text = "".join(parts)
   else:
     non_emoji_text = text
 


### PR DESCRIPTION
Fixes a bug where text after the last emoji was not included in width measurements.

# Example:

**Input:**
"Hello 😀 World"

**Current behavior:**
non_emoji_text = "Hello  "  # Missing " World " after last emoji
