### PR TITLE
ui: move to GPU core

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -42,7 +42,7 @@ PROCS = {
   "./encoderd": 13.0,
   "./camerad": 10.0,
   "selfdrive.controls.plannerd": 8.0,
-  "selfdrive.ui.ui": 63.0,
+  "selfdrive.ui.ui": 40.0,
   "system.sensord.sensord": 13.0,
   "selfdrive.controls.radard": 2.0,
   "selfdrive.modeld.modeld": 22.0,

--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
+import os
 import pyray as rl
 
-from openpilot.common.realtime import config_realtime_process
+from openpilot.common.realtime import config_realtime_process, set_core_affinity
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.selfdrive.ui.layouts.main import MainLayout
 from openpilot.selfdrive.ui.ui_state import ui_state
 
 
 def main():
-  config_realtime_process([1, 2], 1)
+  cores = {7, }
+  config_realtime_process(0, 1)
 
   gui_app.init_window("UI")
   main_layout = MainLayout()
@@ -17,6 +19,13 @@ def main():
     ui_state.update()
     if should_render:
       main_layout.render()
+
+      # reaffine after power save offlines our core
+      if os.sched_getaffinity(0) != cores:
+        try:
+          set_core_affinity(list(cores))
+        except OSError:
+          pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
all GPU processes are now on core 7, which effectively bypasses the meh scheduler in the GPU driver