### PR TITLE
speed up car interface fuzz tests (2/2)

### DIFF
--- a/system/hardware/hw.h
+++ b/system/hardware/hw.h
@@ -19,6 +19,17 @@ namespace Path {
   }
 
   inline std::string comma_home() {
+    if (const char *env = getenv("OPENPILOT_COMMA_HOME")) {
+      std::string base = env;
+      if (!base.empty() && base.back() == '/') {
+        base.pop_back();
+      }
+      std::string prefix = Path::openpilot_prefix();
+      if (!prefix.empty()) {
+        base += "/" + prefix;
+      }
+      return base;
+    }
     return util::getenv("HOME") + "/.comma" + Path::openpilot_prefix();
   }
 
@@ -49,6 +60,9 @@ namespace Path {
   }
 
  inline std::string shm_path() {
+    if (const char *env = getenv("OPENPILOT_SHM_PATH")) {
+      return env;
+    }
     #ifdef __APPLE__
      return"/tmp";
     #else

--- a/system/hardware/hw.py
+++ b/system/hardware/hw.py
@@ -9,7 +9,12 @@ DEFAULT_DOWNLOAD_CACHE_ROOT = "/tmp/comma_download_cache"
 class Paths:
   @staticmethod
   def comma_home() -> str:
-    return os.path.join(str(Path.home()), ".comma" + os.environ.get("OPENPILOT_PREFIX", ""))
+    override = os.environ.get("OPENPILOT_COMMA_HOME")
+    if override:
+      prefix = os.environ.get("OPENPILOT_PREFIX", "")
+      return os.path.join(override, prefix) if prefix else override
+    prefix = os.environ.get("OPENPILOT_PREFIX", "")
+    return os.path.join(str(Path.home()), f".comma{prefix}")
 
   @staticmethod
   def log_root() -> str:
@@ -60,6 +65,9 @@ class Paths:
 
   @staticmethod
   def shm_path() -> str:
+    env_shm = os.environ.get("OPENPILOT_SHM_PATH")
+    if env_shm:
+      return env_shm
     if PC and platform.system() == "Darwin":
       return "/tmp"  # This is not really shared memory on macOS, but it's the closest we can get
     return "/dev/shm"


### PR DESCRIPTION
 **Description**

  - cache Hypothesis Cap'n Proto strategies in `selfdrive/test/fuzzy_generation.py:12`: class-level strategy cache keyed
  by schema, capped list sizes, and `st.one_of` union sampling. this removes the per-example strategy rebuild without
  reducing coverage.
  - memoize parsed DBC files in commaai/opendbc#2875 (`opendbc/can/dbc.py:80`), so each worker reads a DBC once
  instead of hundreds of times. The submodule pointer here depends on that PR.
  - allow overriding `COMMA_HOME` and the shared-memory path via `system/hardware/hw.py:12` and `system/hardware/
  hw.h:21`, so the prefix fixture can choose writable directories in sandboxed CI. defaults remain unchanged, so
  production behavior is preserved.

  **Verification**

```
  pytest --durations=0 selfdrive/car/tests/test_car_interfaces.py

 ================================================= test session starts
 ==================================================
 platform linux -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0
 Using --randomly-seed=796012491
 rootdir: /home/rey/openpilot
 configfile: pyproject.toml
 plugins: timeout-2.4.0, hypothesis-6.47.5, subtests-0.14.2, asyncio-1.2.0, cpp-2.6.0, randomly-4.0.1, repeat-0.9.4,
 xdist-3.7.1.dev24+g2b4372bd6, mock-3.15.1
 asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function,
 asyncio_default_test_loop_scope=function
 6 workers [236 items]
 ...
 ================================================= 236 passed in 24.70s =================================================
```


  companion PR in opendbc: https://github.com/commaai/opendbc/pull/2875

  Validation
  * Dongle ID: N/A (test-only change)
  * Route: N/A