### PR TITLE
fix: egl fd dup fail

### DIFF
--- a/system/ui/lib/egl.py
+++ b/system/ui/lib/egl.py
@@ -133,7 +133,7 @@ def create_egl_image(width: int, height: int, stride: int, fd: int, uv_offset: i
   try:
     dup_fd = os.dup(fd)
   except OSError:
-    cloudlog.exception("Failed to duplicate fd")
+    cloudlog.exception("Failed to duplicate fd when creating EGL image")
     return None
 
   # Create image attributes for EGL

--- a/system/ui/lib/egl.py
+++ b/system/ui/lib/egl.py
@@ -129,6 +129,7 @@ def create_egl_image(width: int, height: int, stride: int, fd: int, uv_offset: i
   assert _egl.initialized, "EGL not initialized"
 
   # Duplicate fd since EGL needs it
+  # We need to handle OSError since the fd might be closed
   try:
     dup_fd = os.dup(fd)
   except OSError:

--- a/system/ui/lib/egl.py
+++ b/system/ui/lib/egl.py
@@ -129,7 +129,11 @@ def create_egl_image(width: int, height: int, stride: int, fd: int, uv_offset: i
   assert _egl.initialized, "EGL not initialized"
 
   # Duplicate fd since EGL needs it
-  dup_fd = os.dup(fd)
+  try:
+    dup_fd = os.dup(fd)
+  except OSError:
+    cloudlog.exception("Failed to duplicate fd")
+    return None
 
   # Create image attributes for EGL
   img_attrs = [


### PR DESCRIPTION
```
  File "/data/openpilot/openpilot/system/ui/lib/egl.py", line 132, in create_egl_image                                                                                                                             
    dup_fd = os.dup(fd)                                                                                                                                                                                            
             ^^^^^^^^^^                                                                                     
OSError: [Errno 9] Bad file descriptor
```

occasionally when switching streams on device, or a offroad->onroad transition or the same with my camera preview PR, we hit the case where the file descriptor is no longer valid. in this case, we should log and gracefully return no EGL image. the `CameraView` rendering pipeline will skip rendering this frame

this is needed for graceful handling but it does mask the root cause. feel free to leave open until root cause is determined