### PR TITLE
Based on my analysis of the openpilot codebase, I have identified and…

### DIFF
--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -897,7 +897,7 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
 
   EventName.accFaulted: {
     ET.IMMEDIATE_DISABLE: ImmediateDisableAlert("Cruise Fault: Restart the Car"),
-    ET.PERMANENT: NormalPermanentAlert("Cruise Fault: Restart the car to engage"),
+    ET.PERMANENT: NormalPermanentAlert("Cruise Fault: Restart the car to Engage"),
     ET.NO_ENTRY: NoEntryAlert("Cruise Fault: Restart the Car"),
   },
 
@@ -945,7 +945,7 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
 
   EventName.steerUnavailable: {
     ET.IMMEDIATE_DISABLE: ImmediateDisableAlert("LKAS Fault: Restart the Car"),
-    ET.PERMANENT: NormalPermanentAlert("LKAS Fault: Restart the car to engage"),
+    ET.PERMANENT: NormalPermanentAlert("LKAS Fault: Restart the car to Engage"),
     ET.NO_ENTRY: NoEntryAlert("LKAS Fault: Restart the Car"),
   },
 


### PR DESCRIPTION
<!--- ***** Template: Bugfix *****

  Implemented Fix

  I found and fixed an inconsistency in alert message capitalization in /Users/tom/Documents/apps/openpilot/selfdrive/selfdrived/events.py:

  Changes Made:
   - Line ~900: Changed "Cruise Fault: Restart the car to engage" to "Cruise Fault: Restart the car to Engage"
   - Line ~948: Changed "LKAS Fault: Restart the car to engage" to "LKAS Fault: Restart the car to Engage"

  Purpose: This fixes an inconsistency in alert message capitalization, ensuring all engagement-related alerts use the same format ("to Engage" with capital 'E') for a more uniform user
  experience.

  Verification: The change is a simple text modification that maintains the same functionality while improving consistency across alert messages.

  Justification: This change addresses a minor inconsistency in UI messaging that was identified during code review, following the principle of maintaining consistent messaging across the
  safety-critical alert system.

  Changes: Modified 2 lines in openpilot/selfdrive/selfdrived/events.py to standardize capitalization in engagement-related alert messages.

  This fix is low-effort, has no functional impact on safety systems, and improves the consistency of user-facing alert messages as requested in the guidelines.

-->
