### PR TITLE
Fix output_lataccel calculation in latcontrol_torque

### DIFF
--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -94,7 +94,11 @@ class LatControlTorque(LatControl):
       ff += get_friction(error + JERK_GAIN * desired_lateral_jerk, lateral_accel_deadzone, FRICTION_THRESHOLD, self.torque_params)
 
       freeze_integrator = steer_limited_by_safety or CS.steeringPressed or CS.vEgo < 5
-      output_lataccel = self.pid.update(pid_log.error, -measurement_rate, CS.vEgo, ff, freeze_integrator)
+      output_lataccel = self.pid.update(pid_log.error,                            #       setpoint - measurement
+                                        desired_lateral_jerk - measurement_rate,  # d/dt (setpoint - measurement)
+                                        feedforward=ff,
+                                        speed=CS.vEgo,
+                                        freeze_integrator=freeze_integrator)
       output_torque = self.torque_from_lateral_accel(output_lataccel, self.torque_params)
 
       pid_log.active = True


### PR DESCRIPTION
Will this fix ping pong on the Bolt? The derivative error term needs to be calculated as

$$
\frac{\mathrm d}{\mathrm d t} (\text{setpoint} - \text{measurement})
$$

but parent commit is missing the first term.