### PR TITLE
ui: optimize _map_line_to_polygon

### DIFF
--- a/selfdrive/ui/onroad/model_renderer.py
+++ b/selfdrive/ui/onroad/model_renderer.py
@@ -354,26 +354,25 @@ class ModelRenderer(Widget):
     if points.shape[0] == 0:
       return np.empty((0, 2), dtype=np.float32)
 
-    N = points.shape[0]
-    # Generate left and right 3D points in one array using broadcasting
-    offsets = np.array([[0, -y_off, z_off], [0, y_off, z_off]], dtype=np.float32)
-    points_3d = points[None, :, :] + offsets[:, None, :]  # Shape: 2xNx3
-    points_3d = points_3d.reshape(2 * N, 3)  # Shape: (2*N)x3
+    lr_points = np.stack((points, points), axis=1).astype(np.float32)
+    lr_points[:, 0, 1] -= y_off  # Left Y
+    lr_points[:, 1, 1] += y_off  # Right Y
+    lr_points[:, :, 2] += z_off  # Both z
 
     # Transform all points to projected space in one operation
-    proj = self._car_space_transform @ points_3d.T  # Shape: 3x(2*N)
-    proj = proj.reshape(3, 2, N)
-    left_proj = proj[:, 0, :]
-    right_proj = proj[:, 1, :]
+    proj = (self._car_space_transform @ lr_points.reshape(-1, 3).T).T.reshape(-1, 2, 3)
 
     # Filter points where z is sufficiently large
-    valid_proj = (np.abs(left_proj[2]) >= 1e-6) & (np.abs(right_proj[2]) >= 1e-6)
-    if not np.any(valid_proj):
+    z_vals = np.abs(proj[:, :, 2])
+    valid_pairs = (z_vals >= 1e-6).all(axis=1)
+    if not valid_pairs.any():
       return np.empty((0, 2), dtype=np.float32)
 
-    # Compute screen coordinates
-    left_screen = left_proj[:2, valid_proj] / left_proj[2, valid_proj][None, :]
-    right_screen = right_proj[:2, valid_proj] / right_proj[2, valid_proj][None, :]
+    proj = proj[valid_pairs]
+
+    screen = proj[:, :, :2] / proj[:, :, 2:3]
+    left_screen = screen[:, 0, :]
+    right_screen = screen[:, 1, :]
 
     # Define clip region bounds
     clip = self._clip_region
@@ -381,33 +380,32 @@ class ModelRenderer(Widget):
     y_min, y_max = clip.y, clip.y + clip.height
 
     # Filter points within clip region
-    left_in_clip = (
-      (left_screen[0] >= x_min) & (left_screen[0] <= x_max) &
-      (left_screen[1] >= y_min) & (left_screen[1] <= y_max)
+    in_clip = (
+      (left_screen[:, 0] >= x_min) & (left_screen[:, 0] <= x_max) &
+      (left_screen[:, 1] >= y_min) & (left_screen[:, 1] <= y_max) &
+      (right_screen[:, 0] >= x_min) & (right_screen[:, 0] <= x_max) &
+      (right_screen[:, 1] >= y_min) & (right_screen[:, 1] <= y_max)
     )
-    right_in_clip = (
-      (right_screen[0] >= x_min) & (right_screen[0] <= x_max) &
-      (right_screen[1] >= y_min) & (right_screen[1] <= y_max)
-    )
-    both_in_clip = left_in_clip & right_in_clip
-
-    if not np.any(both_in_clip):
+    if not in_clip.any():
       return np.empty((0, 2), dtype=np.float32)
 
-    # Select valid and clipped points
-    left_screen = left_screen[:, both_in_clip]
-    right_screen = right_screen[:, both_in_clip]
+    left_screen = left_screen[in_clip]
+    right_screen = right_screen[in_clip]
 
-    # Handle Y-coordinate inversion on hills
-    if not allow_invert and left_screen.shape[1] > 1:
-      y = left_screen[1, :]  # y-coordinates
-      keep = y == np.minimum.accumulate(y)
-      if not np.any(keep):
+    if not allow_invert and left_screen.shape[0] > 1:
+      y_vals = left_screen[:, 1]
+      keep = y_vals == np.minimum.accumulate(y_vals)
+      if not keep.any():
         return np.empty((0, 2), dtype=np.float32)
-      left_screen = left_screen[:, keep]
-      right_screen = right_screen[:, keep]
+      left_screen = left_screen[keep]
+      right_screen = right_screen[keep]
 
-    return np.vstack((left_screen.T, right_screen[:, ::-1].T)).astype(np.float32)
+    k = left_screen.shape[0]
+    tri_strip = np.empty((k * 2, 2), dtype=np.float32)
+    tri_strip[0::2] = left_screen
+    tri_strip[1::2] = right_screen
+
+    return tri_strip
 
   @staticmethod
   def _hsla_to_color(h, s, l, a):

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -195,22 +195,6 @@ def _configure_shader_color(state: ShaderState, color: Optional[rl.Color],  # no
     state.fill_color_ptr[0:4] = [color.r / 255.0, color.g / 255.0, color.b / 255.0, color.a / 255.0]
     rl.set_shader_value(state.shader, state.locations['fillColor'], state.fill_color_ptr, UNIFORM_VEC4)
 
-
-def triangulate(pts: np.ndarray) -> list[tuple[float, float]]:
-  """Only supports simple polygons with two chains (ribbon)."""
-
-  # TODO: consider deduping close screenspace points
-  # interleave points to produce a triangle strip
-  assert len(pts) % 2 == 0, "Interleaving expects even number of points"
-
-  tri_strip = []
-  for i in range(len(pts) // 2):
-    tri_strip.append(pts[i])
-    tri_strip.append(pts[-i - 1])
-
-  return cast(list, np.array(tri_strip).tolist())
-
-
 def draw_polygon(origin_rect: rl.Rectangle, points: np.ndarray,
                  color: Optional[rl.Color] = None, gradient: Gradient | None = None):  # noqa: UP045
 
@@ -232,12 +216,9 @@ def draw_polygon(origin_rect: rl.Rectangle, points: np.ndarray,
   # Configure gradient shader
   _configure_shader_color(state, color, gradient, origin_rect)
 
-  # Triangulate via interleaving
-  tri_strip = triangulate(pts)
-
   # Draw strip, color here doesn't matter
   rl.begin_shader_mode(state.shader)
-  rl.draw_triangle_strip(tri_strip, len(tri_strip), rl.WHITE)
+  rl.draw_triangle_strip(points.tolist(), len(points), rl.WHITE)
   rl.end_shader_mode()
 
 


### PR DESCRIPTION
Optimized `_map_line_to_polygon` with pairwise projection, minimized reshaping, and generating the triangle strip directly without intermediate Python loops.

before (run `selfdrive/ui/tests/profile_onroad.py` ):
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     3606   34.184    0.009   34.184    0.009 {built-in method raylib._raylib_cffi.EndDrawing}
    10192    2.191    0.000    3.419    0.000 openpilot/selfdrive/ui/onroad/model_renderer.py:337(_map_line_to_polygon)
   306052    1.841    0.000   41.869    0.000 openpilot/.venv/lib/python3.11/site-packages/pyray/__init__.py:47(wrapped_func)
     2396    1.737    0.001    1.737    0.001 {built-in method raylib._raylib_cffi.UpdateTexture}
   116750    1.467    0.000    2.146    0.000 openpilot/.venv/lib/python3.11/site-packages/pyray/__init__.py:117(func)
    71401    1.030    0.000    1.030    0.000 {built-in method numpy.array}
    25137    0.965    0.000    1.754    0.000 openpilot/system/ui/lib/shader_polygon.py:199(triangulate)
    28730    0.757    0.000    0.757    0.000 {built-in method raylib._raylib_cffi.EndShaderMode}
```

after:

  ```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     3606   35.384    0.010   35.384    0.010 {built-in method raylib._raylib_cffi.EndDrawing}
    10192    1.987    0.000    2.768    0.000 openpilot/selfdrive/ui/onroad/model_renderer.py:335(_map_line_to_polygon)
   306052    1.925    0.000   43.395    0.000 openpilot/.venv/lib/python3.11/site-packages/pyray/__init__.py:47(wrapped_func)
     2396    1.844    0.001    1.844    0.001 {built-in method raylib._raylib_cffi.UpdateTexture}
   116750    1.543    0.000    2.256    0.000 openpilot/.venv/lib/python3.11/site-packages/pyray/__init__.py:117(func)
    28730    0.782    0.000    0.782    0.000 {built-in method raylib._raylib_cffi.EndShaderMode}

```


**Profiler comparison (before → after):**


  | Function | Time (s) Before | Time (s) After | Improvement |
  | -------- | -------- | -------- | -------- |
  | _map_line_to_polygon | 3.419 | 2.768 | ~19% faster |
  | shader_polygon.triangulate | 1.754 | — | eliminated |


This refactor keeps rendering output identical while reducing CPU overhead and simplifying the data flow between model rendering and shader polygon generation.



