### PR TITLE
lint: Add PLE rule to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ lint.select = [
   "TRY203", "TRY400", "TRY401", # try/excepts
   "RUF008", "RUF100",
   "TID251",
-  "PLR1704",
+  "PLE", "PLR1704",
 ]
 lint.ignore = [
   "E741",

--- a/system/updated/casync/casync.py
+++ b/system/updated/casync/casync.py
@@ -99,7 +99,7 @@ class DirectoryTarChunkReader(BinaryChunkReader):
     create_casync_tar_package(pathlib.Path(path), pathlib.Path(cache_file))
 
     self.f = open(cache_file, "rb")
-    return super().__init__(self.f)
+    super().__init__(self.f)
 
   def __del__(self):
     self.f.close()


### PR DESCRIPTION
Enables the following Ruff lint rule set (Pylint errors):
https://docs.astral.sh/ruff/rules/#error-ple

Also fixes the single error that was raised from this.