### PR TITLE
ui: add mouse_events_enabled flag for efficient mouse event handling

### DIFF
--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -23,6 +23,7 @@ class Widget(abc.ABC):
     self._touch_valid_callback: Callable[[], bool] | None = None
     self._click_callback: Callable[[], None] | None = None
     self._multi_touch = False
+    self._mouse_events_enabled: bool = True
 
   @property
   def rect(self) -> rl.Rectangle:
@@ -38,6 +39,13 @@ class Widget(abc.ABC):
   def set_parent_rect(self, parent_rect: rl.Rectangle) -> None:
     """Can be used like size hint in QT"""
     self._parent_rect = parent_rect
+
+  @property
+  def mouse_events_enabled(self) -> bool:
+    return self._mouse_events_enabled
+
+  def set_mouse_events_enabled(self, enabled: bool) -> None:
+    self._mouse_events_enabled = enabled
 
   @property
   def is_pressed(self) -> bool:
@@ -94,7 +102,7 @@ class Widget(abc.ABC):
     ret = self._render(self._rect)
 
     # Keep track of whether mouse down started within the widget's rectangle
-    if self.enabled:
+    if self.enabled and self._mouse_events_enabled:
       for mouse_event in gui_app.mouse_events:
         if not self._multi_touch and mouse_event.slot != 0:
           continue

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -60,6 +60,7 @@ class HtmlRenderer(Widget):
   def __init__(self, file_path: str | None = None, text: str | None = None,
                text_size: dict | None = None, text_color: rl.Color = rl.WHITE, center_text: bool = False):
     super().__init__()
+    self.set_mouse_events_enabled(False)
     self._text_color = text_color
     self._center_text = center_text
     self._normal_font = gui_app.font(FontWeight.NORMAL)

--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -110,6 +110,7 @@ class Label(Widget):
                ):
 
     super().__init__()
+    self.set_mouse_events_enabled(False)
     self._font_weight = font_weight
     self._font = gui_app.font(self._font_weight)
     self._font_size = font_size


### PR DESCRIPTION
Introduces a `mouse_events_enabled` flag to the base Widget class, similar to Qt’s `WA_TransparentForMouseEvents` behavior.

Non-interactive widgets such as `Label` and `HtmlRenderer` now have mouse event handling disabled by default, preventing unnecessary event processing