### PR TITLE
lateral torque PID uses true error_rate

### DIFF
--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -90,8 +90,8 @@ class LatControlTorque(LatControl):
       ff += get_friction(error, lateral_accel_deadzone, FRICTION_THRESHOLD, self.torque_params)
 
       freeze_integrator = steer_limited_by_safety or CS.steeringPressed or CS.vEgo < 5
-      output_lataccel = self.pid.update(pid_log.error,
-                                       -measurement_rate,
+      output_lataccel = self.pid.update(pid_log.error,                            #       setpoint - measurement
+                                        desired_lateral_jerk - measurement_rate,  # d/dt (setpoint - measurement)
                                         feedforward=ff,
                                         speed=CS.vEgo,
                                         freeze_integrator=freeze_integrator)


### PR DESCRIPTION
$$
\begin{align}
\text{error} &= (\text{desired accel}) - (\text{actual accel})
\\
\frac{\mathrm d}{\mathrm d t} \text{error} &= (\text{desired jerk}) - (\text{actual jerk})
\end{align}
$$