### PR TITLE
ui: cache the version text to avoid redundant Params.get calls every frame

### DIFF
--- a/selfdrive/ui/layouts/home.py
+++ b/selfdrive/ui/layouts/home.py
@@ -45,6 +45,7 @@ class HomeLayout(Widget):
 
     self.update_available = False
     self.alert_count = 0
+    self._version_text = ""
     self._prev_update_available = False
     self._prev_alerts_present = False
 
@@ -178,7 +179,7 @@ class HomeLayout(Widget):
 
     version_rect = rl.Rectangle(self.header_rect.x + self.header_rect.width - version_text_width, self.header_rect.y,
                                 version_text_width, self.header_rect.height)
-    gui_label(version_rect, self._get_version_text(), 48, rl.WHITE, alignment=rl.GuiTextAlignment.TEXT_ALIGN_RIGHT)
+    gui_label(version_rect, self._version_text, 48, rl.WHITE, alignment=rl.GuiTextAlignment.TEXT_ALIGN_RIGHT)
 
   def _render_home_content(self):
     self._render_left_column()
@@ -209,7 +210,7 @@ class HomeLayout(Widget):
     self._setup_widget.render(setup_rect)
 
   def _refresh(self):
-    # TODO: implement _update_state with a timer
+    self._version_text = self._get_version_text()
     update_available = self.update_alert.refresh()
     alert_count = self.offroad_alert.refresh()
     alerts_present = alert_count > 0


### PR DESCRIPTION
1. Adds `_version_text` attribute, updated only during `_refresh` 
3. `_render_header` now uses the cached version text. 
3. remove obsolete TODO, since `_update_state` already uses timer
