### PR TITLE
replay: use OpenSSL EVP API instead of deprecated SHA256 functions

### DIFF
--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -1,10 +1,9 @@
 Import('env', 'arch', 'common', 'messaging', 'visionipc', 'cereal')
 
 replay_env = env.Clone()
-replay_env['CCFLAGS'] += ['-Wno-deprecated-declarations']
 
 base_frameworks = []
-base_libs = [common, messaging, cereal, visionipc, 'm', 'ssl', 'crypto', 'pthread']
+base_libs = [common, messaging, cereal, visionipc, 'crypto', 'pthread']
 
 if arch == "Darwin":
   base_frameworks.append('OpenCL')


### PR DESCRIPTION
1. Updates the `sha256` function to use the OpenSSL EVP API instead of deprecated SHA256 functions.
2. Cleans up the `SConscript` file and removes the `-Wno-deprecated-declarations` flag.


