### PR TITLE
cabana: replace deprecated Qt and OpenSSL functions

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -50,7 +50,6 @@ qt_flags = [
   "-DQT_MESSAGELOGCONTEXT",
 ]
 qt_env['CXXFLAGS'] += qt_flags
-qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 qt_env['LIBPATH'] += ['#selfdrive/ui', ]
 qt_env['LIBS'] = qt_libs
 

--- a/tools/cabana/chart/chart.cc
+++ b/tools/cabana/chart/chart.cc
@@ -324,7 +324,8 @@ void ChartView::updateSeries(const cabana::Signal *sig, const MessageEventsMap *
       if (!can->liveStreaming()) {
         s.segment_tree.build(s.vals);
       }
-      s.series->replace(QVector<QPointF>::fromStdVector(series_type == SeriesType::StepLine ? s.step_vals : s.vals));
+      const auto &points = series_type == SeriesType::StepLine ? s.step_vals : s.vals;
+      s.series->replace(QVector<QPointF>(points.cbegin(), points.cend()));
     }
   }
   updateAxisY();
@@ -382,7 +383,7 @@ void ChartView::updateAxisY() {
     QFontMetrics fm(axis_y->labelsFont());
     for (int i = 0; i < tick_count; i++) {
       qreal value = min_y + (i * (max_y - min_y) / (tick_count - 1));
-      max_label_width = std::max(max_label_width, fm.width(QString::number(value, 'f', n)));
+      max_label_width = std::max(max_label_width, fm.horizontalAdvance(QString::number(value, 'f', n)));
     }
 
     int title_spacing = unit.isEmpty() ? 0 : QFontMetrics(axis_y->titleFont()).size(Qt::TextSingleLine, unit).height();
@@ -838,7 +839,8 @@ void ChartView::setSeriesType(SeriesType type) {
     }
     for (auto &s : sigs) {
       s.series = createSeries(series_type, s.sig->color);
-      s.series->replace(QVector<QPointF>::fromStdVector(series_type == SeriesType::StepLine ? s.step_vals : s.vals));
+      const auto &points = series_type == SeriesType::StepLine ? s.step_vals : s.vals;
+      s.series->replace(QVector<QPointF>(points.cbegin(), points.cend()));
     }
     updateSeriesPoints();
     updateTitle();

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -265,7 +265,7 @@ QSize SignalItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QMo
       text += item->sig->type == cabana::Signal::Type::Multiplexor ? QString(" M ") : QString(" m%1 ").arg(item->sig->multiplex_value);
       spacing += (option.widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin) + 1) * 2;
     }
-    width = std::min<int>(option.widget->size().width() / 3.0, option.fontMetrics.width(text) + spacing);
+    width = std::min<int>(option.widget->size().width() / 3.0, option.fontMetrics.horizontalAdvance(text) + spacing);
   }
   return {width, option.fontMetrics.height() + option.widget->style()->pixelMetric(QStyle::PM_FocusFrameVMargin) * 2};
 }
@@ -308,7 +308,7 @@ void SignalItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
       // multiplexer indicator
       if (item->sig->type != cabana::Signal::Type::Normal) {
         QString indicator = item->sig->type == cabana::Signal::Type::Multiplexor ? QString(" M ") : QString(" m%1 ").arg(item->sig->multiplex_value);
-        QRect indicator_rect{rect.x(), rect.y(), option.fontMetrics.width(indicator), rect.height()};
+        QRect indicator_rect{rect.x(), rect.y(), option.fontMetrics.horizontalAdvance(indicator), rect.height()};
         painter->setBrush(Qt::gray);
         painter->setPen(Qt::NoPen);
         painter->drawRoundedRect(indicator_rect, 3, 3);
@@ -342,13 +342,13 @@ void SignalItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         painter->drawText(rect, Qt::AlignLeft | Qt::AlignTop, max);
         painter->drawText(rect, Qt::AlignLeft | Qt::AlignBottom, min);
         QFontMetrics fm(minmax_font);
-        value_adjust = std::max(fm.width(min), fm.width(max)) + 5;
+        value_adjust = std::max(fm.horizontalAdvance(min), fm.horizontalAdvance(max)) + 5;
       } else if (!item->sparkline.isEmpty() && item->sig->type == cabana::Signal::Type::Multiplexed) {
         // display freq of multiplexed signal
         painter->setFont(label_font);
         QString freq = QString("%1 hz").arg(item->sparkline.freq(), 0, 'g', 2);
         painter->drawText(rect.adjusted(5, 0, 0, 0), Qt::AlignLeft | Qt::AlignVCenter, freq);
-        value_adjust = QFontMetrics(label_font).width(freq) + 10;
+        value_adjust = QFontMetrics(label_font).horizontalAdvance(freq) + 10;
       }
       // signal value
       painter->setFont(option.font);
@@ -622,13 +622,13 @@ void SignalView::updateState(const std::set<MessageId> *msgs) {
     double value = 0;
     if (item->sig->getValue(last_msg.dat.data(), last_msg.dat.size(), &value)) {
       item->sig_val = item->sig->formatValue(value);
-      max_value_width = std::max(max_value_width, fontMetrics().width(item->sig_val));
+      max_value_width = std::max(max_value_width, fontMetrics().horizontalAdvance(item->sig_val));
     }
   }
 
   auto [first_visible, last_visible] = visibleSignalRange();
   if (first_visible.isValid() && last_visible.isValid()) {
-    const static int min_max_width = QFontMetrics(delegate->minmax_font).width("-000.00") + 5;
+    const static int min_max_width = QFontMetrics(delegate->minmax_font).horizontalAdvance("-000.00") + 5;
     int available_width = value_column_width - delegate->button_size.width();
     int value_width = std::min<int>(max_value_width + min_max_width, available_width / 2);
     QSize size(available_width - value_width,

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -134,7 +134,7 @@ void VideoWidget::createSpeedDropdown(QToolBar *toolbar) {
   QFont font = speed_btn->font();
   font.setBold(true);
   speed_btn->setFont(font);
-  speed_btn->setMinimumWidth(speed_btn->fontMetrics().width("0.05x  ") + style()->pixelMetric(QStyle::PM_MenuButtonIndicator));
+  speed_btn->setMinimumWidth(speed_btn->fontMetrics().horizontalAdvance("0.05x  ") + style()->pixelMetric(QStyle::PM_MenuButtonIndicator));
 }
 
 QWidget *VideoWidget::createCameraWidget() {


### PR DESCRIPTION
1. Replaced deprecated `QFontMetrics::width` with `QFontMetrics::horizontalAdvance`.
2. Updated cryptographic routines to use OpenSSL EVP APIs instead of deprecated RSA functions.
3. replaced deprecated `QVector::fromStdVector` with `QVector::QVector(begin, end)`