### PR TITLE
raylib: fix texture wrapping filtering artifacts

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -312,6 +312,8 @@ class GuiApplication:
     texture = rl.load_texture_from_image(image)
     # Set texture filtering to smooth the result
     rl.set_texture_filter(texture, rl.TextureFilter.TEXTURE_FILTER_BILINEAR)
+    # prevent artifacts from wrapping coordinates
+    rl.set_texture_wrap(texture, rl.TextureWrap.TEXTURE_WRAP_CLAMP)
 
     rl.unload_image(image)
     return texture


### PR DESCRIPTION
Most noticeable on four UI

<img width="413" height="212" alt="image" src="https://github.com/user-attachments/assets/89439626-2d6b-4815-a631-79252ea5f87b" />
<img width="418" height="205" alt="image" src="https://github.com/user-attachments/assets/512f2e10-8765-4cf4-8ff8-e08986b9c62b" />
<img width="95" height="97" alt="image" src="https://github.com/user-attachments/assets/f29a8b13-0679-460d-9f6b-d556d5989ed3" />

New:

<img width="420" height="207" alt="image" src="https://github.com/user-attachments/assets/8050cad2-315b-4ecd-8479-e7bc70fa4717" />
<img width="420" height="203" alt="image" src="https://github.com/user-attachments/assets/8b1dd782-7fe9-4d08-b85a-0b950761a4c0" />
<img width="85" height="75" alt="image" src="https://github.com/user-attachments/assets/e6fb38b9-0197-4207-a182-86197815d7d3" />
