### PR TITLE
multilang/sidebar: Use consistent interface status labels ("INTERFACE ONLINE/OFFLINE")

### DIFF
--- a/selfdrive/ui/layouts/sidebar.py
+++ b/selfdrive/ui/layouts/sidebar.py
@@ -139,9 +139,9 @@ class Sidebar(Widget):
 
   def _update_panda_status(self):
     if ui_state.panda_type == log.PandaState.PandaType.unknown:
-      self._panda_status.update(tr_noop("NO"), tr_noop("PANDA"), Colors.DANGER)
+      self._panda_status.update(tr_noop("INTERFACE"), tr_noop("OFFLINE"), Colors.DANGER)
     else:
-      self._panda_status.update(tr_noop("VEHICLE"), tr_noop("ONLINE"), Colors.GOOD)
+      self._panda_status.update(tr_noop("INTERFACE"), tr_noop("ONLINE"), Colors.GOOD)
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
     if rl.check_collision_point_rec(mouse_pos, SETTINGS_BTN):


### PR DESCRIPTION
Hi team,

I noticed that the current translation strings used for displaying the Panda/vehicle status are inconsistent and potentially confusing. The existing code displays “NO / PANDA” when the interface is not detected, but “VEHICLE / ONLINE” when it is:

```python
def _update_panda_status(self):
  if ui_state.panda_type == log.PandaState.PandaType.unknown:
    self._panda_status.update(tr_noop("NO"), tr_noop("PANDA"), Colors.DANGER)
  else:
    self._panda_status.update(tr_noop("VEHICLE"), tr_noop("ONLINE"), Colors.GOOD)
```

This mixes two different concepts (Panda hardware vs. vehicle) and results in UI text that is harder to translate and less intuitive for users.

Proposed change

This PR updates the status text to consistently refer to the interface being checked, using:

- INTERFACE OFFLINE
- INTERFACE ONLINE

```python
def _update_panda_status(self):
  if ui_state.panda_type == log.PandaState.PandaType.unknown:
    self._panda_status.update(tr_noop("INTERFACE"), tr_noop("OFFLINE"), Colors.DANGER)
  else:
    self._panda_status.update(tr_noop("INTERFACE"), tr_noop("ONLINE"), Colors.GOOD)
```

**Why this is beneficial**

- Consistency: Both states now refer to the same thing—the interface status.
- Clarity: “INTERFACE OFFLINE/ONLINE” avoids implying the entire vehicle is offline.
- Translation-friendly: The terms are symmetrical and easy for translators to handle.
- Accurate: The check is about whether the Panda interface is present, not vehicle connectivity.

If the team prefers more explicit wording (e.g., “PANDA OFFLINE/ONLINE”), I’m happy to update the PR accordingly, but I’ve chosen “INTERFACE” as the most neutral and user-friendly option.

Thanks!