### PR TITLE
ui: fix modal show event firing after render

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -549,17 +549,17 @@ class GuiApplication:
 
   def _handle_modal_overlay(self) -> bool:
     if self._modal_overlay.overlay:
+      # Send show event to Widget
+      if not self._modal_overlay_shown and hasattr(self._modal_overlay.overlay, 'show_event'):
+        self._modal_overlay.overlay.show_event()
+        self._modal_overlay_shown = True
+
       if hasattr(self._modal_overlay.overlay, 'render'):
         result = self._modal_overlay.overlay.render(rl.Rectangle(0, 0, self.width, self.height))
       elif callable(self._modal_overlay.overlay):
         result = self._modal_overlay.overlay()
       else:
         raise Exception
-
-      # Send show event to Widget
-      if not self._modal_overlay_shown and hasattr(self._modal_overlay.overlay, 'show_event'):
-        self._modal_overlay.overlay.show_event()
-        self._modal_overlay_shown = True
 
       if result >= 0:
         # Clear the overlay and execute the callback


### PR DESCRIPTION
`show_event` must fire before `render`. very important for `NavWidget` as it does setup on the `show_event` hook

## before (note text flash before animation)

https://github.com/user-attachments/assets/2d1a8b7e-ef64-4e0e-92e6-8508bd6e62ac


## after

https://github.com/user-attachments/assets/94fec682-50d8-492f-b64d-dcba9da19335


