### PR TITLE
ui: stack manager

### DIFF
--- a/selfdrive/ui/layouts/main.py
+++ b/selfdrive/ui/layouts/main.py
@@ -36,10 +36,11 @@ class MainLayout(Widget):
     # Set callbacks
     self._setup_callbacks()
 
+    gui_app.stack.push(self)
     # Start onboarding if terms or training not completed
     self._onboarding_window = OnboardingWindow()
     if not self._onboarding_window.completed:
-      gui_app.set_modal_overlay(self._onboarding_window)
+      gui_app.stack.push(self._onboarding_window)
 
   def _render(self, _):
     self._handle_onroad_transition()

--- a/selfdrive/ui/layouts/onboarding.py
+++ b/selfdrive/ui/layouts/onboarding.py
@@ -194,11 +194,11 @@ class OnboardingWindow(Widget):
     ui_state.params.put("HasAcceptedTerms", terms_version)
     self._state = OnboardingState.ONBOARDING
     if self._training_done:
-      gui_app.set_modal_overlay(None)
+      gui_app.stack.pop()
 
   def _on_completed_training(self):
     ui_state.params.put("CompletedTrainingVersion", training_version)
-    gui_app.set_modal_overlay(None)
+    gui_app.stack.pop()
 
   def _render(self, _):
     if self._training_guide is None:

--- a/selfdrive/ui/layouts/settings/developer.py
+++ b/selfdrive/ui/layouts/settings/developer.py
@@ -175,9 +175,7 @@ class DeveloperLayout(Widget):
       # show confirmation dialog
       content = (f"<h1>{self._alpha_long_toggle.title}</h1><br>" +
                  f"<p>{self._alpha_long_toggle.description}</p>")
-
-      dlg = ConfirmDialog(content, tr("Enable"), rich=True)
-      gui_app.set_modal_overlay(dlg, callback=confirm_callback)
+      gui_app.stack.push(ConfirmDialog(content, tr("Enable"), rich=True), callback=confirm_callback)
 
     else:
       self._params.put_bool("AlphaLongitudinalEnabled", False)

--- a/selfdrive/ui/layouts/settings/software.py
+++ b/selfdrive/ui/layouts/settings/software.py
@@ -160,8 +160,7 @@ class SoftwareLayout(Widget):
       if result == DialogResult.CONFIRM:
         ui_state.params.put_bool("DoUninstall", True)
 
-    dialog = ConfirmDialog(tr("Are you sure you want to uninstall?"), tr("Uninstall"))
-    gui_app.set_modal_overlay(dialog, callback=handle_uninstall_confirmation)
+    gui_app.stack.push(ConfirmDialog(tr("Are you sure you want to uninstall?"), tr("Uninstall")), callback=handle_uninstall_confirmation)
 
   def _on_install_update(self):
     # Trigger reboot to install update
@@ -182,6 +181,7 @@ class SoftwareLayout(Widget):
     current_target = ui_state.params.get("UpdaterTargetBranch") or ""
     self._branch_dialog = MultiOptionDialog(tr("Select a branch"), branches, current_target)
 
+    # TODO: better return state (should not track dialog within class like this)
     def handle_selection(result):
       # Confirmed selection
       if result == DialogResult.CONFIRM and self._branch_dialog is not None and self._branch_dialog.selection:
@@ -191,4 +191,4 @@ class SoftwareLayout(Widget):
         os.system("pkill -SIGUSR1 -f system.updated.updated")
       self._branch_dialog = None
 
-    gui_app.set_modal_overlay(self._branch_dialog, callback=handle_selection)
+    gui_app.stack.push(self._branch_dialog, callback=handle_selection)

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -225,8 +225,7 @@ class TogglesLayout(Widget):
       # show confirmation dialog
       content = (f"<h1>{self._toggles['ExperimentalMode'].title}</h1><br>" +
                  f"<p>{self._toggles['ExperimentalMode'].description}</p>")
-      dlg = ConfirmDialog(content, tr("Enable"), rich=True)
-      gui_app.set_modal_overlay(dlg, callback=confirm_callback)
+      gui_app.stack.push(ConfirmDialog(content, tr("Enable"), rich=True), callback=confirm_callback)
     else:
       self._update_experimental_mode_icon()
       self._params.put_bool("ExperimentalMode", state)

--- a/selfdrive/ui/mici/layouts/main.py
+++ b/selfdrive/ui/mici/layouts/main.py
@@ -1,5 +1,4 @@
 import pyray as rl
-from enum import IntEnum
 import cereal.messaging as messaging
 from openpilot.selfdrive.ui.mici.layouts.home import MiciHomeLayout
 from openpilot.selfdrive.ui.mici.layouts.settings.settings import SettingsLayout
@@ -15,18 +14,12 @@ from openpilot.system.ui.lib.application import gui_app
 ONROAD_DELAY = 2.5  # seconds
 
 
-class MainState(IntEnum):
-  MAIN = 0
-  SETTINGS = 1
-
-
 class MiciMainLayout(Widget):
   def __init__(self):
     super().__init__()
 
     self._pm = messaging.PubMaster(['bookmarkButton'])
 
-    self._current_mode: MainState | None = None
     self._prev_onroad = False
     self._prev_standstill = False
     self._onroad_time_delay: float | None = None
@@ -35,12 +28,11 @@ class MiciMainLayout(Widget):
     # Initialize widgets
     self._home_layout = MiciHomeLayout()
     self._alerts_layout = MiciOffroadAlerts()
-    self._settings_layout = SettingsLayout()
     self._onroad_layout = AugmentedRoadView(bookmark_callback=self._on_bookmark_clicked)
     self._onboarding_window = OnboardingWindow()
 
     # Initialize widget rects
-    for widget in (self._home_layout, self._settings_layout, self._alerts_layout, self._onroad_layout):
+    for widget in (self._home_layout, self._alerts_layout, self._onroad_layout):
       # TODO: set parent rect and use it if never passed rect from render (like in Scroller)
       widget.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
 
@@ -54,11 +46,6 @@ class MiciMainLayout(Widget):
     # Disable scrolling when onroad is interacting with bookmark
     self._scroller.set_scrolling_enabled(lambda: not self._onroad_layout.is_swiping_left())
 
-    self._layouts = {
-      MainState.MAIN: self._scroller,
-      MainState.SETTINGS: self._settings_layout,
-    }
-
     # Set callbacks
     self._setup_callbacks()
 
@@ -69,7 +56,6 @@ class MiciMainLayout(Widget):
 
   def _setup_callbacks(self):
     self._home_layout.set_callbacks(on_settings=self._on_settings_clicked)
-    self._settings_layout.set_callbacks(on_close=self._on_settings_closed)
     self._onroad_layout.set_click_callback(lambda: self._scroll_to(self._home_layout))
     device.add_interactive_timeout_callback(self._set_mode_for_started)
 
@@ -78,10 +64,6 @@ class MiciMainLayout(Widget):
     self._scroller.scroll_to(layout_x, smooth=True)
 
   def _render(self, _):
-    # Initial show event
-    if self._current_mode is None:
-      self._set_mode(MainState.MAIN)
-
     if not self._setup:
       if self._alerts_layout.active_alerts() > 0:
         self._scroller.scroll_to(self._alerts_layout.rect.x)
@@ -89,21 +71,9 @@ class MiciMainLayout(Widget):
         self._scroller.scroll_to(self._rect.width)
       self._setup = True
 
-    # Render
-    if self._current_mode == MainState.MAIN:
-      self._scroller.render(self._rect)
-
-    elif self._current_mode == MainState.SETTINGS:
-      self._settings_layout.render(self._rect)
+    self._scroller.render(self._rect)
 
     self._handle_transitions()
-
-  def _set_mode(self, mode: MainState):
-    if mode != self._current_mode:
-      if self._current_mode is not None:
-        self._layouts[self._current_mode].hide_event()
-      self._layouts[mode].show_event()
-      self._current_mode = mode
 
   def _handle_transitions(self):
     if ui_state.started != self._prev_onroad:
@@ -121,7 +91,6 @@ class MiciMainLayout(Widget):
 
     CS = ui_state.sm["carState"]
     if not CS.standstill and self._prev_standstill:
-      self._set_mode(MainState.MAIN)
       self._scroll_to(self._onroad_layout)
     self._prev_standstill = CS.standstill
 
@@ -130,19 +99,15 @@ class MiciMainLayout(Widget):
       CS = ui_state.sm["carState"]
       # Only go onroad if car starts or is not at a standstill
       if not CS.standstill or onroad_transition:
-        self._set_mode(MainState.MAIN)
         self._scroll_to(self._onroad_layout)
     else:
       # Stay in settings if car turns off while in settings
-      if not onroad_transition or self._current_mode != MainState.SETTINGS:
-        self._set_mode(MainState.MAIN)
+      if not onroad_transition or gui_app.stack.depth() == 1:
         self._scroll_to(self._home_layout)
 
   def _on_settings_clicked(self):
-    self._set_mode(MainState.SETTINGS)
-
-  def _on_settings_closed(self):
-    self._set_mode(MainState.MAIN)
+    settings_layout = SettingsLayout()
+    gui_app.stack.push(settings_layout)
 
   def _on_bookmark_clicked(self):
     user_bookmark = messaging.new_message('bookmarkButton')

--- a/selfdrive/ui/mici/layouts/main.py
+++ b/selfdrive/ui/mici/layouts/main.py
@@ -37,6 +37,7 @@ class MiciMainLayout(Widget):
     self._alerts_layout = MiciOffroadAlerts()
     self._settings_layout = SettingsLayout()
     self._onroad_layout = AugmentedRoadView(bookmark_callback=self._on_bookmark_clicked)
+    self._onboarding_window = OnboardingWindow()
 
     # Initialize widget rects
     for widget in (self._home_layout, self._settings_layout, self._alerts_layout, self._onroad_layout):
@@ -62,9 +63,9 @@ class MiciMainLayout(Widget):
     self._setup_callbacks()
 
     # Start onboarding if terms or training not completed
-    self._onboarding_window = OnboardingWindow()
+    gui_app.stack.push(self)
     if not self._onboarding_window.completed:
-      gui_app.set_modal_overlay(self._onboarding_window)
+      gui_app.stack.push(self._onboarding_window)
 
   def _setup_callbacks(self):
     self._home_layout.set_callbacks(on_settings=self._on_settings_clicked)

--- a/selfdrive/ui/mici/layouts/main.py
+++ b/selfdrive/ui/mici/layouts/main.py
@@ -107,7 +107,13 @@ class MiciMainLayout(Widget):
 
   def _on_settings_clicked(self):
     settings_layout = SettingsLayout()
-    gui_app.stack.push(settings_layout)
+    def callback():
+      gui_app.stack.pop()
+      self._scroll_to(self._home_layout)
+    settings_layout.set_back_callback(callback)
+
+    # TODO: callback isnt working here
+    gui_app.stack.push(settings_layout, callback=callback)
 
   def _on_bookmark_clicked(self):
     user_bookmark = messaging.new_message('bookmarkButton')

--- a/selfdrive/ui/mici/layouts/main.py
+++ b/selfdrive/ui/mici/layouts/main.py
@@ -112,7 +112,7 @@ class MiciMainLayout(Widget):
       self._scroll_to(self._home_layout)
     settings_layout.set_back_callback(callback)
 
-    # TODO: callback isnt working here
+    # TODO: callback isn't working here
     gui_app.stack.push(settings_layout, callback=callback)
 
   def _on_bookmark_clicked(self):

--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -329,7 +329,7 @@ class OnboardingWindow(Widget):
 
   def close(self):
     ui_state.params.put_bool("IsDriverViewEnabled", False)
-    gui_app.set_modal_overlay(None)
+    gui_app.stack.pop()
 
   def _on_terms_accepted(self):
     ui_state.params.put("HasAcceptedTerms", terms_version)

--- a/selfdrive/ui/mici/layouts/settings/developer.py
+++ b/selfdrive/ui/mici/layouts/settings/developer.py
@@ -17,6 +17,7 @@ class DeveloperLayoutMici(NavWidget):
     super().__init__()
     self.set_back_callback(back_callback)
 
+    # TODO: bug! callback should dictate success/fail for nested dialogs
     def github_username_callback(username: str):
       if username:
         ssh_keys = SshKeyAction()

--- a/selfdrive/ui/mici/layouts/settings/developer.py
+++ b/selfdrive/ui/mici/layouts/settings/developer.py
@@ -24,17 +24,14 @@ class DeveloperLayoutMici(NavWidget):
         if not ssh_keys._error_message:
           self._ssh_keys_btn.set_value(username)
         else:
-          dlg = BigDialog("", ssh_keys._error_message)
-          gui_app.set_modal_overlay(dlg)
+          gui_app.stack.push(BigDialog("", ssh_keys._error_message))
 
     def ssh_keys_callback():
       github_username = ui_state.params.get("GithubUsername") or ""
-      dlg = BigInputDialog("enter GitHub username", github_username, confirm_callback=github_username_callback)
       if not system_time_valid():
-        dlg = BigDialog("Please connect to Wi-Fi to fetch your key", "")
-        gui_app.set_modal_overlay(dlg)
-        return
-      gui_app.set_modal_overlay(dlg)
+        gui_app.stack.push(BigDialog("Please connect to Wi-Fi to fetch your key", ""))
+      else:
+        gui_app.stack.push(BigInputDialog("enter GitHub username", github_username, confirm_callback=github_username_callback))
 
     txt_ssh = gui_app.texture("icons_mici/settings/developer/ssh.png", 77, 44)
     github_username = ui_state.params.get("GithubUsername") or ""

--- a/selfdrive/ui/mici/layouts/settings/device.py
+++ b/selfdrive/ui/mici/layouts/settings/device.py
@@ -29,7 +29,7 @@ class MiciFccModal(NavWidget):
 
   def __init__(self, file_path: str | None = None, text: str | None = None):
     super().__init__()
-    self.set_back_callback(lambda: gui_app.set_modal_overlay(None))
+    self.set_back_callback(lambda: gui_app.stack.pop())
     self._content = HtmlRenderer(file_path=file_path, text=text)
     self._scroll_panel = GuiScrollPanel2(horizontal=False)
     self._fcc_logo = gui_app.texture("icons_mici/settings/device/fcc_logo.png", 76, 64)
@@ -72,13 +72,11 @@ def _engaged_confirmation_callback(callback: Callable, action_text: str):
       # TODO: check
       icon = "icons_mici/settings/comma_icon.png"
 
-    dlg: BigConfirmationDialogV2 | BigDialog = BigConfirmationDialogV2(f"slide to\n{action_text.lower()}", icon, red=red,
-                                                                       exit_on_confirm=action_text == "reset",
-                                                                       confirm_callback=confirm_callback)
-    gui_app.set_modal_overlay(dlg)
+    gui_app.stack.push(BigConfirmationDialogV2(f"slide to\n{action_text.lower()}", icon, red=red,
+                                                exit_on_confirm=action_text == "reset",
+                                                confirm_callback=confirm_callback))
   else:
-    dlg = BigDialog(f"Disengage to {action_text}", "")
-    gui_app.set_modal_overlay(dlg)
+    gui_app.stack.push(BigConfirmationDialogV2(f"Disengage to {action_text}", ""))
 
 
 class DeviceInfoLayoutMici(Widget):
@@ -138,14 +136,12 @@ class PairBigButton(BigButton):
     # TODO: show ad dialog when clicked if not prime
     if ui_state.prime_state.is_paired():
       return
-    dlg: BigDialog | PairingDialog
     if not system_time_valid():
-      dlg = BigDialog(tr("Please connect to Wi-Fi to complete initial pairing"), "")
+      gui_app.stack.push(BigDialog(tr("Please connect to Wi-Fi to complete initial pairing"), ""))
     elif UNREGISTERED_DONGLE_ID == (ui_state.params.get("DongleId") or UNREGISTERED_DONGLE_ID):
-      dlg = BigDialog(tr("Device must be registered with the comma.ai backend to pair"), "")
+      gui_app.stack.push(BigDialog(tr("Device must be registered with the comma.ai backend to pair"), ""))
     else:
-      dlg = PairingDialog()
-    gui_app.set_modal_overlay(dlg)
+      gui_app.stack.push(PairingDialog())
 
 
 UPDATER_TIMEOUT = 10.0  # seconds to wait for updater to respond
@@ -314,7 +310,7 @@ class DeviceLayoutMici(NavWidget):
       current_language = next(name for name, lang in self._languages.items() if lang == current_language_name)
 
       dlg = BigMultiOptionDialog(list(self._languages), default=current_language, right_btn_callback=selected_language_callback)
-      gui_app.set_modal_overlay(dlg)
+      gui_app.stack.push(dlg)
 
     # lang_button = BigButton("change language", "", "icons_mici/settings/device/language.png")
     # lang_button.set_click_callback(language_callback)
@@ -351,17 +347,13 @@ class DeviceLayoutMici(NavWidget):
     ui_state.add_offroad_transition_callback(self._offroad_transition)
 
   def _on_regulatory(self):
-    if not self._fcc_dialog:
-      self._fcc_dialog = MiciFccModal(os.path.join(BASEDIR, "selfdrive/assets/offroad/mici_fcc.html"))
-    gui_app.set_modal_overlay(self._fcc_dialog, callback=setattr(self, '_fcc_dialog', None))
+    gui_app.stack.push(MiciFccModal(os.path.join(BASEDIR, "selfdrive/assets/offroad/mici_fcc.html")))
 
   def _offroad_transition(self):
     self._power_off_btn.set_visible(ui_state.is_offroad())
 
   def _show_driver_camera(self):
-    if not self._driver_camera:
-      self._driver_camera = DriverCameraDialog()
-    gui_app.set_modal_overlay(self._driver_camera, callback=lambda result: setattr(self, '_driver_camera', None))
+    gui_app.stack.push(DriverCameraDialog())
 
   def _on_review_training_guide(self):
     if not self._training_guide:

--- a/selfdrive/ui/mici/layouts/settings/device.py
+++ b/selfdrive/ui/mici/layouts/settings/device.py
@@ -166,8 +166,7 @@ class UpdateOpenpilotBigButton(BigButton):
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
     if not system_time_valid():
-      dlg = BigDialog(tr("Please connect to Wi-Fi to update"), "")
-      gui_app.set_modal_overlay(dlg)
+      gui_app.stack.push(BigDialog(tr("Please connect to Wi-Fi to update"), ""))
       return
 
     self.set_enabled(False)

--- a/selfdrive/ui/mici/layouts/settings/network.py
+++ b/selfdrive/ui/mici/layouts/settings/network.py
@@ -1,7 +1,6 @@
 import math
 import numpy as np
 import pyray as rl
-from enum import IntEnum
 from collections.abc import Callable
 
 from openpilot.common.swaglog import cloudlog

--- a/selfdrive/ui/mici/layouts/settings/settings.py
+++ b/selfdrive/ui/mici/layouts/settings/settings.py
@@ -1,6 +1,4 @@
 import pyray as rl
-from dataclasses import dataclass
-from enum import IntEnum
 from collections.abc import Callable
 
 from openpilot.common.params import Params
@@ -12,41 +10,24 @@ from openpilot.selfdrive.ui.mici.layouts.settings.device import DeviceLayoutMici
 from openpilot.selfdrive.ui.mici.layouts.settings.developer import DeveloperLayoutMici
 from openpilot.selfdrive.ui.mici.layouts.settings.firehose import FirehoseLayoutMici
 from openpilot.system.ui.lib.application import gui_app, FontWeight
-from openpilot.system.ui.widgets import Widget, NavWidget
-
-
-class PanelType(IntEnum):
-  TOGGLES = 0
-  NETWORK = 1
-  DEVICE = 2
-  DEVELOPER = 3
-  USER_MANUAL = 4
-  FIREHOSE = 5
-
-
-@dataclass
-class PanelInfo:
-  name: str
-  instance: Widget
+from openpilot.system.ui.widgets import NavWidget
 
 
 class SettingsLayout(NavWidget):
   def __init__(self):
     super().__init__()
     self._params = Params()
-    self._current_panel = None  # PanelType.DEVICE
 
     toggles_btn = BigButton("toggles", "", "icons_mici/settings/toggles_icon.png")
-    toggles_btn.set_click_callback(lambda: self._set_current_panel(PanelType.TOGGLES))
+    toggles_btn.set_click_callback(lambda: gui_app.stack.push(TogglesLayoutMici(back_callback=lambda: gui_app.stack.pop())))
     network_btn = BigButton("network", "", "icons_mici/settings/network/wifi_strength_full.png")
-    network_btn.set_click_callback(lambda: self._set_current_panel(PanelType.NETWORK))
+    network_btn.set_click_callback(lambda: gui_app.stack.push(NetworkLayoutMici(back_callback=lambda: gui_app.stack.pop())))
     device_btn = BigButton("device", "", "icons_mici/settings/device_icon.png")
-    device_btn.set_click_callback(lambda: self._set_current_panel(PanelType.DEVICE))
+    device_btn.set_click_callback(lambda: gui_app.stack.push(DeviceLayoutMici(back_callback=lambda: gui_app.stack.pop())))
     developer_btn = BigButton("developer", "", "icons_mici/settings/developer_icon.png")
-    developer_btn.set_click_callback(lambda: self._set_current_panel(PanelType.DEVELOPER))
-
+    developer_btn.set_click_callback(lambda: gui_app.stack.push(DeveloperLayoutMici(back_callback=lambda: gui_app.stack.pop())))
     firehose_btn = BigButton("firehose", "", "icons_mici/settings/comma_icon.png")
-    firehose_btn.set_click_callback(lambda: self._set_current_panel(PanelType.FIREHOSE))
+    firehose_btn.set_click_callback(lambda: gui_app.stack.push(FirehoseLayoutMici(back_callback=lambda: gui_app.stack.pop())))
 
     self._scroller = Scroller([
       toggles_btn,
@@ -60,15 +41,6 @@ class SettingsLayout(NavWidget):
 
     # Set up back navigation
     self.set_back_callback(self.close_settings)
-    self.set_back_enabled(lambda: self._current_panel is None)
-
-    self._panels = {
-      PanelType.TOGGLES: PanelInfo("Toggles", TogglesLayoutMici(back_callback=lambda: self._set_current_panel(None))),
-      PanelType.NETWORK: PanelInfo("Network", NetworkLayoutMici(back_callback=lambda: self._set_current_panel(None))),
-      PanelType.DEVICE: PanelInfo("Device", DeviceLayoutMici(back_callback=lambda: self._set_current_panel(None))),
-      PanelType.DEVELOPER: PanelInfo("Developer", DeveloperLayoutMici(back_callback=lambda: self._set_current_panel(None))),
-      PanelType.FIREHOSE: PanelInfo("Firehose", FirehoseLayoutMici(back_callback=lambda: self._set_current_panel(None))),
-    }
 
     self._font_medium = gui_app.font(FontWeight.MEDIUM)
 
@@ -77,37 +49,18 @@ class SettingsLayout(NavWidget):
 
   def show_event(self):
     super().show_event()
-    self._set_current_panel(None)
     self._scroller.show_event()
-    if self._current_panel is not None:
-      self._panels[self._current_panel].instance.show_event()
 
   def hide_event(self):
     super().hide_event()
-    if self._current_panel is not None:
-      self._panels[self._current_panel].instance.hide_event()
 
   def set_callbacks(self, on_close: Callable):
     self._close_callback = on_close
 
   def _render(self, rect: rl.Rectangle):
-    if self._current_panel is not None:
-      self._draw_current_panel()
-    else:
-      self._scroller.render(rect)
-
-  def _draw_current_panel(self):
-    panel = self._panels[self._current_panel]
-    panel.instance.render(self._rect)
-
-  def _set_current_panel(self, panel_type: PanelType | None):
-    if panel_type != self._current_panel:
-      if self._current_panel is not None:
-        self._panels[self._current_panel].instance.hide_event()
-      self._current_panel = panel_type
-      if self._current_panel is not None:
-        self._panels[self._current_panel].instance.show_event()
+    self._scroller.render(rect)
 
   def close_settings(self):
     if self._close_callback:
       self._close_callback()
+    gui_app.stack.pop()

--- a/selfdrive/ui/mici/layouts/settings/settings.py
+++ b/selfdrive/ui/mici/layouts/settings/settings.py
@@ -1,7 +1,5 @@
 import pyray as rl
-from collections.abc import Callable
 
-from openpilot.common.params import Params
 from openpilot.system.ui.widgets.scroller import Scroller
 from openpilot.selfdrive.ui.mici.widgets.button import BigButton
 from openpilot.selfdrive.ui.mici.layouts.settings.toggles import TogglesLayoutMici
@@ -9,14 +7,13 @@ from openpilot.selfdrive.ui.mici.layouts.settings.network import NetworkLayoutMi
 from openpilot.selfdrive.ui.mici.layouts.settings.device import DeviceLayoutMici, PairBigButton
 from openpilot.selfdrive.ui.mici.layouts.settings.developer import DeveloperLayoutMici
 from openpilot.selfdrive.ui.mici.layouts.settings.firehose import FirehoseLayoutMici
-from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.widgets import NavWidget
 
 
 class SettingsLayout(NavWidget):
   def __init__(self):
     super().__init__()
-    self._params = Params()
 
     toggles_btn = BigButton("toggles", "", "icons_mici/settings/toggles_icon.png")
     toggles_btn.set_click_callback(lambda: gui_app.stack.push(TogglesLayoutMici(back_callback=lambda: gui_app.stack.pop())))
@@ -39,14 +36,6 @@ class SettingsLayout(NavWidget):
       developer_btn,
     ], snap_items=False)
 
-    # Set up back navigation
-    self.set_back_callback(self.close_settings)
-
-    self._font_medium = gui_app.font(FontWeight.MEDIUM)
-
-    # Callbacks
-    self._close_callback: Callable | None = None
-
   def show_event(self):
     super().show_event()
     self._scroller.show_event()
@@ -54,13 +43,5 @@ class SettingsLayout(NavWidget):
   def hide_event(self):
     super().hide_event()
 
-  def set_callbacks(self, on_close: Callable):
-    self._close_callback = on_close
-
   def _render(self, rect: rl.Rectangle):
     self._scroller.render(rect)
-
-  def close_settings(self):
-    if self._close_callback:
-      self._close_callback()
-    gui_app.stack.pop()

--- a/selfdrive/ui/mici/layouts/settings/settings.py
+++ b/selfdrive/ui/mici/layouts/settings/settings.py
@@ -36,12 +36,5 @@ class SettingsLayout(NavWidget):
       developer_btn,
     ], snap_items=False)
 
-  def show_event(self):
-    super().show_event()
-    self._scroller.show_event()
-
-  def hide_event(self):
-    super().hide_event()
-
   def _render(self, rect: rl.Rectangle):
     self._scroller.render(rect)

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -42,7 +42,7 @@ class DriverCameraDialog(NavWidget):
 
   def stop_dmonitoringmodeld(self):
     ui_state.params.put_bool("IsDriverViewEnabled", False)
-    gui_app.set_modal_overlay(None)
+    gui_app.stack.pop()
 
   def show_event(self):
     super().show_event()

--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -31,7 +31,7 @@ class BigDialogBase(NavWidget, abc.ABC):
     self._right_btn = None
     if right_btn:
       def right_btn_callback_wrapper():
-        gui_app.set_modal_overlay(None)
+        gui_app.stack.pop()
         if right_btn_callback:
           right_btn_callback()
 
@@ -42,7 +42,7 @@ class BigDialogBase(NavWidget, abc.ABC):
 
   def _render(self, _) -> DialogResult:
     """
-    Allows `gui_app.set_modal_overlay(BigDialog(...))`.
+    Allows `gui_app.stack.push(BigDialog(...))`.
     The overlay runner keeps calling until result != NO_ACTION.
     """
     if self._right_btn:
@@ -392,4 +392,4 @@ class BigDialogButton(BigButton):
     super()._handle_mouse_release(mouse_pos)
 
     dlg = BigDialog(self.text, self._description)
-    gui_app.set_modal_overlay(dlg)
+    gui_app.stack.push(dlg)

--- a/selfdrive/ui/mici/widgets/pairing_dialog.py
+++ b/selfdrive/ui/mici/widgets/pairing_dialog.py
@@ -19,7 +19,7 @@ class PairingDialog(NavWidget):
 
   def __init__(self):
     super().__init__()
-    self.set_back_callback(lambda: gui_app.set_modal_overlay(None))
+    self.set_back_callback(lambda: gui_app.stack.pop())
     self._params = Params()
     self._qr_texture: rl.Texture | None = None
     self._last_qr_generation = float("-inf")

--- a/selfdrive/ui/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/onroad/driver_camera_dialog.py
@@ -19,7 +19,7 @@ class DriverCameraDialog(CameraView):
 
   def stop_dmonitoringmodeld(self):
     ui_state.params.put_bool("IsDriverViewEnabled", False)
-    gui_app.set_modal_overlay(None)
+    gui_app.stack.pop()
 
   def _handle_mouse_release(self, _):
     super()._handle_mouse_release(_)

--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -20,7 +20,6 @@ def main():
   else:
     main_layout = MiciMainLayout()
   main_layout.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
-  gui_app.stack.push(main_layout)
 
   for should_render in gui_app.render():
     ui_state.update()

--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -20,11 +20,11 @@ def main():
   else:
     main_layout = MiciMainLayout()
   main_layout.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
+  gui_app.stack.push(main_layout)
+
   for should_render in gui_app.render():
     ui_state.update()
     if should_render:
-      main_layout.render()
-
       # reaffine after power save offlines our core
       if TICI and os.sched_getaffinity(0) != cores:
         try:

--- a/selfdrive/ui/widgets/pairing_dialog.py
+++ b/selfdrive/ui/widgets/pairing_dialog.py
@@ -26,7 +26,7 @@ class PairingDialog(Widget):
     self.qr_texture: rl.Texture | None = None
     self.last_qr_generation = float('-inf')
     self._close_btn = IconButton(gui_app.texture("icons/close.png", 80, 80))
-    self._close_btn.set_click_callback(lambda: gui_app.set_modal_overlay(None))
+    self._close_btn.set_click_callback(lambda: gui_app.stack.pop())
 
   def _get_pairing_url(self) -> str:
     try:
@@ -69,7 +69,7 @@ class PairingDialog(Widget):
 
   def _update_state(self):
     if ui_state.prime_state.is_paired():
-      gui_app.set_modal_overlay(None)
+      gui_app.stack.pop()
 
   def _render(self, rect: rl.Rectangle) -> int:
     rl.clear_background(rl.Color(224, 224, 224, 255))

--- a/selfdrive/ui/widgets/setup.py
+++ b/selfdrive/ui/widgets/setup.py
@@ -88,14 +88,6 @@ class SetupWidget(Widget):
 
   def _show_pairing(self):
     if not system_time_valid():
-      dlg = alert_dialog(tr("Please connect to Wi-Fi to complete initial pairing"))
-      gui_app.set_modal_overlay(dlg)
-      return
-
-    if not self._pairing_dialog:
-      self._pairing_dialog = PairingDialog()
-    gui_app.set_modal_overlay(self._pairing_dialog, lambda result: setattr(self, '_pairing_dialog', None))
-
-  def __del__(self):
-    if self._pairing_dialog:
-      del self._pairing_dialog
+      gui_app.stack.push(alert_dialog(tr("Please connect to Wi-Fi to complete initial pairing")))
+    else:
+      gui_app.stack.push(PairingDialog())

--- a/selfdrive/ui/widgets/ssh_key.py
+++ b/selfdrive/ui/widgets/ssh_key.py
@@ -59,7 +59,7 @@ class SshKeyAction(ItemAction):
     # Show error dialog if there's an error
     if self._error_message:
       message = copy.copy(self._error_message)
-      gui_app.set_modal_overlay(alert_dialog(message))
+      gui_app.stack.push(alert_dialog(message))
       self._username = ""
       self._error_message = ""
 
@@ -87,7 +87,7 @@ class SshKeyAction(ItemAction):
     if self._state == SshKeyActionState.ADD:
       self._keyboard.reset()
       self._keyboard.set_title(tr("Enter your GitHub username"))
-      gui_app.set_modal_overlay(self._keyboard, callback=self._on_username_submit)
+      gui_app.stack.push(self._keyboard, callback=self._on_username_submit)
     elif self._state == SshKeyActionState.REMOVE:
       self._params.remove("GithubUsername")
       self._params.remove("GithubSshKeys")

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -8,7 +8,6 @@ import pyray as rl
 import threading
 import platform
 from contextlib import contextmanager
-from collections.abc import Callable
 from collections import deque
 from enum import StrEnum
 from typing import NamedTuple

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -440,10 +440,9 @@ class GuiApplication:
           rl.begin_drawing()
           rl.clear_background(rl.BLACK)
 
-        # Render topmost stack frame (always)
         self._stack_manager.render()
 
-        # Handle modal overlay rendering and input processing (for backward compatibility)
+        # TODO: bye bye this
         if self._handle_modal_overlay():
           yield False
         else:

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -200,7 +200,7 @@ class GuiApplication:
     self._frame = 0
     self._window_close_requested = False
     self._trace_log_callback = None
-    self._stack_manager = StackManager(rl.Rectangle(0, 0, width, height))
+    self._stack_manager = StackManager(rl.Rectangle(0, 0, self._scaled_width, self._scaled_height))
 
     self._mouse = MouseState(self._scale)
     self._mouse_events: list[MouseEvent] = []

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -300,14 +300,6 @@ class GuiApplication:
     print(f"{green}UI window ready in {elapsed_ms:.1f} ms{reset}")
     sys.exit(0)
 
-  def set_modal_overlay(self, overlay, callback: Callable | None = None):
-    if overlay is None:
-      # TODO: this is leaky!
-      if len(self._stack_manager._stack) > 1:
-        self._stack_manager.pop()
-    else:
-      self._stack_manager.push(overlay, callback=callback)
-
   def set_should_render(self, should_render: bool):
     self._should_render = should_render
 

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -37,10 +37,14 @@ class StackManager:
 
     return widget
 
+  def depth(self) -> int:
+    return len(self._stack)
+
   def render(self) -> None:
     if not self._stack:
       return
 
+    print(f"Rendering stack: {self._stack}")
     entry = self._stack[-1]
     widget = entry.widget
 

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -1,11 +1,10 @@
-from typing import Optional
 import pprint
 from collections.abc import Callable
 from dataclasses import dataclass
 
 import pyray as rl
 
-# TODO: actually use Widget, but theres a circular dependency
+# TODO: actually use Widget, but there is a circular dependency
 # TODO: wrap all widgets with NavWidget here
 
 
@@ -25,9 +24,9 @@ class StackManager:
     self._stack.append(StackEntry(widget=widget, callback=callback))
     self._top_shown = False
 
-  def pop(self) -> Optional[object]:
+  def pop(self) -> None:
     if not self._stack:
-      return None
+      return
 
     entry = self._stack.pop()
     widget = entry.widget
@@ -35,8 +34,6 @@ class StackManager:
 
     if hasattr(widget, 'hide_event'):
       widget.hide_event()
-
-    return widget
 
   def depth(self) -> int:
     return len(self._stack)

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -6,7 +6,7 @@ import pyray as rl
 
 # TODO: actually use Widget, but there is a circular dependency
 # TODO: wrap all widgets with NavWidget here
-# TODO: app shouldnt worry about stack.pop(), just define close behavior
+# TODO: app shouldn't worry about stack.pop(), just define close behavior
 # TODO: better define callbacks for results (dismiss, action)
 
 

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -6,6 +6,8 @@ import pyray as rl
 
 # TODO: actually use Widget, but there is a circular dependency
 # TODO: wrap all widgets with NavWidget here
+# TODO: app shouldnt worry about stack.pop(), just define close behavior
+# TODO: better define callbacks for results (dismiss, action)
 
 
 @dataclass

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import pprint
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -44,7 +45,6 @@ class StackManager:
     if not self._stack:
       return
 
-    print(f"Rendering stack: {self._stack}")
     entry = self._stack[-1]
     widget = entry.widget
 
@@ -52,6 +52,7 @@ class StackManager:
       if hasattr(widget, 'show_event'):
         widget.show_event()
       self._top_shown = True
+      print(f"Rendering stack: {pprint.pformat([x.widget.__class__.__name__ for x in self._stack], indent=2)}")
 
     result = None
     if hasattr(widget, 'render'):

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -63,6 +63,7 @@ class StackManager:
       raise TypeError(f"Widget must have a render() method or be callable, got {type(widget)}")
 
     if result is not None and result >= 0:
+      print(f"popping class {entry.widget.__class__.__name__} with result {result}")
       entry = self._stack.pop()
       self._top_shown = False
 

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -45,9 +45,6 @@ class StackManager:
     widget = entry.widget
 
     if not self._top_shown:
-      print(f"Stack size: {len(self._stack)}")
-      print(f"Showing top widget: {widget}")
-
       if hasattr(widget, 'show_event'):
         widget.show_event()
       self._top_shown = True

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -1,0 +1,68 @@
+from typing import Optional
+
+import pyray as rl
+
+# TODO: actually use Widget, but theres a circular dependency
+
+class StackManager:
+  def __init__(self, screen_rect: rl.Rectangle):
+    self._stack: list[object] = []
+    self._screen_rect = screen_rect
+    self._top_shown = False
+
+  def push(self, widget: object) -> None:
+    self._stack.append(widget)
+    self._top_shown = False
+
+    if hasattr(widget, 'set_rect'):
+      widget.set_rect(self._screen_rect)
+    if hasattr(widget, 'show_event'):
+      widget.show_event()
+    self._top_shown = True
+
+  def pop(self) -> Optional[object]:
+    if not self._stack:
+      return None
+
+    widget = self._stack.pop()
+    self._top_shown = False
+
+    if hasattr(widget, 'hide_event'):
+      widget.hide_event()
+
+    return widget
+
+  def clear(self) -> None:
+    while self._stack:
+      self.pop()
+
+  def replace(self, widget: object) -> None:
+    if self._stack:
+      self.pop()
+    self.push(widget)
+
+  @property
+  def top(self) -> Optional[object]:
+    return self._stack[-1] if self._stack else None
+
+  @property
+  def is_empty(self) -> bool:
+    return len(self._stack) == 0
+
+  def render(self) -> None:
+    if not self._stack:
+      return
+
+    top_widget = self._stack[-1]
+
+    if not self._top_shown:
+      top_widget.show_event()
+      self._top_shown = True
+
+    if hasattr(top_widget, 'render'):
+      result = top_widget.render(self._screen_rect)
+    else:
+      result = None
+
+    if result is not None and result != -1:
+      self.pop()

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -3,6 +3,7 @@ from typing import Optional
 import pyray as rl
 
 # TODO: actually use Widget, but theres a circular dependency
+# TODO: wrap all widgets with NavWidget here?
 
 class StackManager:
   def __init__(self, screen_rect: rl.Rectangle):
@@ -25,23 +26,6 @@ class StackManager:
       widget.hide_event()
 
     return widget
-
-  def clear(self) -> None:
-    while self._stack:
-      self.pop()
-
-  def replace(self, widget: object) -> None:
-    if self._stack:
-      self.pop()
-    self.push(widget)
-
-  @property
-  def top(self) -> Optional[object]:
-    return self._stack[-1] if self._stack else None
-
-  @property
-  def is_empty(self) -> bool:
-    return len(self._stack) == 0
 
   def render(self) -> None:
     if not self._stack:

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -14,12 +14,6 @@ class StackManager:
     self._stack.append(widget)
     self._top_shown = False
 
-    if hasattr(widget, 'set_rect'):
-      widget.set_rect(self._screen_rect)
-    if hasattr(widget, 'show_event'):
-      widget.show_event()
-    self._top_shown = True
-
   def pop(self) -> Optional[object]:
     if not self._stack:
       return None

--- a/system/ui/lib/stack_manager.py
+++ b/system/ui/lib/stack_manager.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import pyray as rl
 
 # TODO: actually use Widget, but theres a circular dependency
-# TODO: wrap all widgets with NavWidget here?
+# TODO: wrap all widgets with NavWidget here
 
 
 @dataclass

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -619,8 +619,7 @@ class Setup(Widget):
       if result == DialogResult.CANCEL:
         self._set_state(SetupState.SOFTWARE_SELECTION)
 
-    keyboard = BigInputDialog("custom software URL", confirm_callback=handle_keyboard_result)
-    gui_app.set_modal_overlay(keyboard, callback=handle_keyboard_exit)
+    gui_app.stack.push(BigInputDialog("custom software URL", confirm_callback=handle_keyboard_result), callback=handle_keyboard_exit)
 
   def use_openpilot(self):
     if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH):

--- a/system/ui/tici_setup.py
+++ b/system/ui/tici_setup.py
@@ -339,7 +339,7 @@ class Setup(Widget):
 
     self.keyboard.reset(min_text_size=1)
     self.keyboard.set_title("Enter URL", "for Custom Software")
-    gui_app.set_modal_overlay(self.keyboard, callback=handle_keyboard_result)
+    gui_app.stack.push(self.keyboard, callback=handle_keyboard_result)
 
   def use_openpilot(self):
     if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH):

--- a/system/ui/widgets/html_render.py
+++ b/system/ui/widgets/html_render.py
@@ -260,7 +260,7 @@ class HtmlModal(Widget):
     super().__init__()
     self._content = HtmlRenderer(file_path=file_path, text=text)
     self._scroll_panel = GuiScrollPanel()
-    self._ok_button = Button(tr("OK"), click_callback=lambda: gui_app.set_modal_overlay(None), button_style=ButtonStyle.PRIMARY)
+    self._ok_button = Button(tr("OK"), click_callback=lambda: gui_app.stack.pop(), button_style=ButtonStyle.PRIMARY)
 
   def _render(self, rect: rl.Rectangle):
     margin = 50

--- a/system/ui/widgets/mici_keyboard.py
+++ b/system/ui/widgets/mici_keyboard.py
@@ -57,8 +57,6 @@ class Key(Widget):
     if not self._position_initialized:
       self._x_filter.x = x
       self._y_filter.x = y
-      # keep track of original position so dragging around feels consistent. also move touch area down a bit
-      self.original_position = rl.Vector2(x, y + KEY_TOUCH_AREA_OFFSET)
       self._position_initialized = True
 
     if not smooth:
@@ -67,6 +65,11 @@ class Key(Widget):
 
     self._rect.x = self._x_filter.update(x)
     self._rect.y = self._y_filter.update(y)
+
+    # TODO: understand fix
+    # Update original_position every time so it stays in sync when dialog moves (e.g., NavWidget swipe-away)
+    # keep track of original position so dragging around feels consistent. also move touch area down a bit
+    self.original_position = rl.Vector2(self._rect.x, self._rect.y + KEY_TOUCH_AREA_OFFSET)
 
   def set_alpha(self, alpha: float):
     self._alpha_filter.update(alpha)

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -203,7 +203,7 @@ class AdvancedNetworkSettings(Widget):
     self._keyboard.reset(min_text_size=0)
     self._keyboard.set_title(tr("Enter APN"), tr("leave blank for automatic configuration"))
     self._keyboard.set_text(current_apn)
-    gui_app.set_modal_overlay(self._keyboard, update_apn)
+    gui_app.stack.push(self._keyboard, callback=update_apn)
 
   def _toggle_cellular_metered(self):
     metered = self._cellular_metered_action.get_state()
@@ -235,11 +235,11 @@ class AdvancedNetworkSettings(Widget):
 
       self._keyboard.reset(min_text_size=0)
       self._keyboard.set_title(tr("Enter password"), tr("for \"{}\"").format(ssid))
-      gui_app.set_modal_overlay(self._keyboard, enter_password)
+      gui_app.stack.push(self._keyboard, callback=enter_password)
 
     self._keyboard.reset(min_text_size=1)
     self._keyboard.set_title(tr("Enter SSID"), "")
-    gui_app.set_modal_overlay(self._keyboard, connect_hidden)
+    gui_app.stack.push(self._keyboard, callback=connect_hidden)
 
   def _edit_tethering_password(self):
     def update_password(result):
@@ -253,7 +253,7 @@ class AdvancedNetworkSettings(Widget):
     self._keyboard.reset(min_text_size=MIN_PASSWORD_LENGTH)
     self._keyboard.set_title(tr("Enter new tethering password"), "")
     self._keyboard.set_text(self._wifi_manager.tethering_password)
-    gui_app.set_modal_overlay(self._keyboard, update_password)
+    gui_app.stack.push(self._keyboard, callback=update_password)
 
   def _update_state(self):
     self._wifi_manager.process_callbacks()
@@ -313,12 +313,12 @@ class WifiManagerUI(Widget):
     if self.state == UIState.NEEDS_AUTH and self._state_network:
       self.keyboard.set_title(tr("Wrong password") if self._password_retry else tr("Enter password"), tr("for \"{}\"").format(self._state_network.ssid))
       self.keyboard.reset(min_text_size=MIN_PASSWORD_LENGTH)
-      gui_app.set_modal_overlay(self.keyboard, lambda result: self._on_password_entered(cast(Network, self._state_network), result))
+      gui_app.stack.push(self.keyboard, callback=lambda result: self._on_password_entered(cast(Network, self._state_network), result))
     elif self.state == UIState.SHOW_FORGET_CONFIRM and self._state_network:
       confirm_dialog = ConfirmDialog("", tr("Forget"), tr("Cancel"))
       confirm_dialog.set_text(tr("Forget Wi-Fi Network \"{}\"?").format(self._state_network.ssid))
       confirm_dialog.reset()
-      gui_app.set_modal_overlay(confirm_dialog, callback=lambda result: self.on_forgot_confirm_finished(self._state_network, result))
+      gui_app.stack.push(confirm_dialog, callback=lambda result: self.on_forgot_confirm_finished(self._state_network, result))
     else:
       self._draw_network_list(rect)
 


### PR DESCRIPTION
move bespoke panel switching and bespoke modal handling into a single stack interface

likely going to break out changes from this, there are a few fundamental changes in this PR:
- set_modal_overlay no longer needed, use stack
- couple bugs found in keyboard renderer
- "modal" operated differently than normal "widget" as it had a return code and handled it uniquely. want to make this a general feature of Widget.
- i hate callback invoking pop, it should be simpler than this (dismiss should auto-handle pop if no action was taken)