### PR TITLE
ui: only import layouts that are used

### DIFF
--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -5,8 +5,6 @@ import pyray as rl
 from openpilot.system.hardware import TICI
 from openpilot.common.realtime import config_realtime_process, set_core_affinity
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.selfdrive.ui.layouts.main import MainLayout
-from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout
 from openpilot.selfdrive.ui.ui_state import ui_state
 
 
@@ -16,8 +14,10 @@ def main():
 
   gui_app.init_window("UI")
   if gui_app.big_ui():
+    from openpilot.selfdrive.ui.layouts.main import MainLayout
     main_layout = MainLayout()
   else:
+    from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout
     main_layout = MiciMainLayout()
   main_layout.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
   for should_render in gui_app.render():

--- a/system/ui/reset.py
+++ b/system/ui/reset.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 from openpilot.system.ui.lib.application import gui_app
-import openpilot.system.ui.tici_reset as tici_reset
-import openpilot.system.ui.mici_reset as mici_reset
 
 
 def main():
   if gui_app.big_ui():
+    import openpilot.system.ui.tici_reset as tici_reset
     tici_reset.main()
   else:
+    import openpilot.system.ui.mici_reset as mici_reset
     mici_reset.main()
 
 

--- a/system/ui/setup.py
+++ b/system/ui/setup.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 from openpilot.system.ui.lib.application import gui_app
-import openpilot.system.ui.tici_setup as tici_setup
-import openpilot.system.ui.mici_setup as mici_setup
 
 
 def main():
   if gui_app.big_ui():
+    import openpilot.system.ui.tici_setup as tici_setup
     tici_setup.main()
   else:
+    import openpilot.system.ui.mici_setup as mici_setup
     mici_setup.main()
 
 

--- a/system/ui/updater.py
+++ b/system/ui/updater.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 from openpilot.system.ui.lib.application import gui_app
-import openpilot.system.ui.tici_updater as tici_updater
-import openpilot.system.ui.mici_updater as mici_updater
 
 
 def main():
   if gui_app.big_ui():
+    import openpilot.system.ui.tici_updater as tici_updater
     tici_updater.main()
   else:
+    import openpilot.system.ui.mici_updater as mici_updater
     mici_updater.main()
 
 


### PR DESCRIPTION
Avoid the overhead of loading all the big UI layouts on mici and vice-versa.
