### PR TITLE
ui/wifi: fix no attribute error

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -138,6 +138,8 @@ class WifiManager:
       self._nm = DBusAddress(NM_PATH, bus_name=NM, interface=NM_IFACE)
     except FileNotFoundError:
       cloudlog.exception("Failed to connect to system D-Bus")
+      self._router_main = None
+      self._conn_monitor = None
       self._exit = True
 
     # Store wifi device path
@@ -752,6 +754,8 @@ class WifiManager:
       if self._state_thread.is_alive():
         self._state_thread.join()
 
-      self._router_main.close()
-      self._router_main.conn.close()
-      self._conn_monitor.close()
+      if self._router_main is not None:
+        self._router_main.close()
+        self._router_main.conn.close()
+      if self._conn_monitor is not None:
+        self._conn_monitor.close()


### PR DESCRIPTION
fixes
```
Traceback (most recent call last):
  File "/tmp/openpilot/openpilot/system/ui/lib/wifi_manager.py", line 136, in __init__
    self._router_main = DBusRouter(open_dbus_connection_threading(bus="SYSTEM"))  # used by scanner / general method calls
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/.venv/lib/python3.12/site-packages/jeepney/io/threading.py", line 118, in open_dbus_connection
    sock = prep_socket(bus_addr, enable_fds, timeout=auth_timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/.venv/lib/python3.12/site-packages/jeepney/io/blocking.py", line 291, in prep_socket
    with_sock_deadline(sock.connect, addr)
  File "/home/batman/.venv/lib/python3.12/site-packages/jeepney/io/blocking.py", line 288, in with_sock_deadline
    return meth(*args)
           ^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
Exception in thread Thread-2 (_monitor_state):
Traceback (most recent call last):
Exception in thread   File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
Thread-3 (worker):
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run

  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/tmp/openpilot/openpilot/system/ui/lib/wifi_manager.py", line 182, in worker
    self._target(*self._args, **self._kwargs)
  File "/tmp/openpilot/openpilot/system/ui/lib/wifi_manager.py", line 244, in _monitor_state
    if Params is not None and self._tethering_ssid not in self._get_connections():
           self._conn_monitor.send_and_get_reply(message_bus.AddMatch(rule))   
        ^ ^       ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ 
 AttributeError: 'WifiManager' object has no attribute '_conn_monitor'
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/openpilot/openpilot/system/ui/lib/wifi_manager.py", line 310, in _get_connections
    known_connections = self._router_main.send_and_get_reply(new_method_call(settings_addr, 'ListConnections')).body[0]
                        ^^^^^^^^^^^^^^^^^
AttributeError: 'WifiManager' object has no attribute '_router_main'
Error finding LTE connection: 'WifiManager' object has no attribute '_router_main'
Traceback (most recent call last):
  File "/tmp/openpilot/openpilot/system/ui/lib/wifi_manager.py", line 729, in _get_lte_connection_path
    known_connections = self._router_main.send_and_get_reply(new_method_call(settings_addr, 'ListConnections')).body[0]
                        ^^^^^^^^^^^^^^^^^
AttributeError: 'WifiManager' object has no attribute '_router_main'
No LTE connection found
Failed to fetch firehose stats: Expected a string value
Failed to fetch prime status: Expected a string value
failed to find ui window, assuming that it's in the top left (for Xvfb) list index out of range
Traceback (most recent call last):
  File "/tmp/openpilot/selfdrive/ui/tests/test_ui/raylib_screenshots.py", line 312, in <module>
    create_screenshots()
  File "/tmp/openpilot/selfdrive/ui/tests/test_ui/raylib_screenshots.py", line 308, in create_screenshots
    t.test_ui(name, setup)
  File "/tmp/openpilot/openpilot/selfdrive/test/helpers.py", line 65, in wrap
    with processes_context(processes, init_time, ignore_stopped):
  File "/usr/lib/python3.12/contextlib.py", line 144, in __exit__
    next(self.gen)
  File "/tmp/openpilot/openpilot/selfdrive/test/helpers.py", line 55, in processes_context
    assert all(managed_processes[name].proc.exitcode is None for name in processes if name not in ignore_stopped)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```