### PR TITLE
fix: openpilot unavailable with replay

### DIFF
--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -24,7 +24,6 @@ class DriverCameraDialog(NavWidget):
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))
     self.driver_state_renderer.load_icons()
-    self._pm = messaging.PubMaster(['selfdriveState'])
     if not no_escape:
       # TODO: this can grow unbounded, should be given some thought
       device.add_interactive_timeout_callback(self.stop_dmonitoringmodeld)
@@ -50,10 +49,12 @@ class DriverCameraDialog(NavWidget):
     self._publish_alert_sound(None)
     device.reset_interactive_timeout(300)
     ui_state.params.remove("DriverTooDistracted")
+    self._pm = messaging.PubMaster(['selfdriveState'])
 
   def hide_event(self):
     super().hide_event()
     device.reset_interactive_timeout()
+    self._pm = None
 
   def _handle_mouse_release(self, _):
     ui_state.params.remove("DriverTooDistracted")


### PR DESCRIPTION
only create PubMaster when dialog is shown, otherwise we need to block `selfdriveState` during a replay, causing UI to always show "openpilot unavailable"

Onboarding widget is always instantiated, and ultimately this class gets instantiated, where then PubMaster is created