### PR TITLE
fix the CI Weekly Report workflow so it does not fail on forks

### DIFF
--- a/.github/workflows/ci_weekly_report.yaml
+++ b/.github/workflows/ci_weekly_report.yaml
@@ -38,7 +38,7 @@ jobs:
   report:
     needs: [ci_matrix_run]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && github.repository == 'commaai/openpilot'
     steps:
       - name: Get job results
         uses: actions/github-script@v7


### PR DESCRIPTION
This PR fixes the issue where the "weekly CI test report" workflow fails on forks, triggering unnecessary failure email notifications.

Currently, the setup job is correctly skipped on forks via a repository check, but the report job is configured with `if: always()`. This causes the report job to execute even when the setup is skipped, because the report generation is hard coded for `commaai`.