### PR TITLE
ui: optimize matrix operations in scroller rendering

### DIFF
--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -224,12 +224,15 @@ class Scroller(Widget):
 
       # Scale each element around its own origin when scrolling
       scale = self._zoom_filter.x
-      rl.rl_push_matrix()
-      rl.rl_scalef(scale, scale, 1.0)
-      rl.rl_translatef((1 - scale) * (x + item.rect.width / 2) / scale,
-                       (1 - scale) * (y + item.rect.height / 2) / scale, 0)
-      item.render()
-      rl.rl_pop_matrix()
+      if scale != 1.0:
+        rl.rl_push_matrix()
+        rl.rl_scalef(scale, scale, 1.0)
+        rl.rl_translatef((1 - scale) * (x + item.rect.width / 2) / scale,
+                        (1 - scale) * (y + item.rect.height / 2) / scale, 0)
+        item.render()
+        rl.rl_pop_matrix()
+      else:
+        item.render()
 
     # Draw scroll indicator
     if SCROLL_BAR and not self._horizontal and len(visible_items) > 0:


### PR DESCRIPTION
Improves performance in the `Scroller` widget by avoiding expensive matrix push/pop operations when the zoom scale is 1.0 (no scaling).


**Performance Metrics** (mici ui execution on pc)

Metric | Before PR | After PR | Change
-- | -- | -- | --
tottime  | 0.042 s | 0.031 s | -26.2% (Direct time saved within _render)
cumtime  | 0.374 s | 0.314 s | -16.0% (Overall reduction in execution time)

