### PR TITLE
ui: avoid unnecessary text cache invalidation in UnifiedLabel

### DIFF
--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -446,7 +446,7 @@ class UnifiedLabel(Widget):
   def set_text(self, text: str | Callable[[], str]):
     """Update the text content."""
     self._text = text
-    self._cached_text = None  # Invalidate cache
+    # No need to update cache here, will be done on next render if needed
 
   @property
   def text(self) -> str:
@@ -463,15 +463,17 @@ class UnifiedLabel(Widget):
 
   def set_font_size(self, size: int):
     """Update the font size."""
-    self._font_size = size
-    self._spacing_pixels = size * self._letter_spacing  # Recalculate spacing
-    self._cached_text = None  # Invalidate cache
+    if self._font_size != size:
+      self._font_size = size
+      self._spacing_pixels = size * self._letter_spacing  # Recalculate spacing
+      self._cached_text = None  # Invalidate cache
 
   def set_letter_spacing(self, letter_spacing: float):
     """Update letter spacing (as percentage, e.g., 0.1 = 10%)."""
-    self._letter_spacing = letter_spacing
-    self._spacing_pixels = self._font_size * letter_spacing
-    self._cached_text = None  # Invalidate cache
+    if self._letter_spacing != letter_spacing:
+      self._letter_spacing = letter_spacing
+      self._spacing_pixels = self._font_size * letter_spacing
+      self._cached_text = None  # Invalidate cache
 
   def set_font_weight(self, font_weight: FontWeight):
     """Update the font weight."""


### PR DESCRIPTION
`UnifiedLabel` setters now skip updates when values haven't changed, avoiding unnecessary cache invalidation and text re-layout.

These setters are frequently called from render loops (e.g., https://github.com/commaai/openpilot/blob/d0c3972cc714664bb5869dccef5feda2b3022ae6/selfdrive/ui/mici/onroad/alert_renderer.py#L325-L329), which previously forced a full text re-layout every frame. This change removes that overhead  and improves render efficiency.