### PR TITLE
ui: remove unused members and variables

### DIFF
--- a/selfdrive/ui/mici/onroad/alert_renderer.py
+++ b/selfdrive/ui/mici/onroad/alert_renderer.py
@@ -89,10 +89,6 @@ ALERT_CRITICAL_REBOOT = Alert(
 class AlertRenderer(Widget):
   def __init__(self):
     super().__init__()
-    self.font_regular: rl.Font = gui_app.font(FontWeight.MEDIUM)
-    self.font_roman: rl.Font = gui_app.font(FontWeight.ROMAN)
-    self.font_bold: rl.Font = gui_app.font(FontWeight.BOLD)
-    self.font_display: rl.Font = gui_app.font(FontWeight.DISPLAY)
 
     self._alert_text1_label = UnifiedLabel(text="", font_size=ALERT_FONT_BIG, font_weight=FontWeight.DISPLAY, line_height=0.86,
                                            letter_spacing=-0.02)

--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -31,19 +31,7 @@ class FontSizes:
 @dataclass(frozen=True)
 class Colors:
   white: rl.Color = rl.WHITE
-  disengaged: rl.Color = rl.Color(145, 155, 149, 255)
-  override: rl.Color = rl.Color(145, 155, 149, 255)  # Added
-  engaged: rl.Color = rl.Color(128, 216, 166, 255)
-  disengaged_bg: rl.Color = rl.Color(0, 0, 0, 153)
-  override_bg: rl.Color = rl.Color(145, 155, 149, 204)
-  engaged_bg: rl.Color = rl.Color(128, 216, 166, 204)
-  grey: rl.Color = rl.Color(166, 166, 166, 255)
-  dark_grey: rl.Color = rl.Color(114, 114, 114, 255)
-  black_translucent: rl.Color = rl.Color(0, 0, 0, 166)
   white_translucent: rl.Color = rl.Color(255, 255, 255, 200)
-  border_translucent: rl.Color = rl.Color(255, 255, 255, 75)
-  header_gradient_start: rl.Color = rl.Color(0, 0, 0, 114)
-  header_gradient_end: rl.Color = rl.BLANK
 
 
 FONT_SIZES = FontSizes()


### PR DESCRIPTION
These members were copied from the larger UI but are never used in Mici UI.