### PR TITLE
ui: (tici/tizi) ignore wheel scroll when out of bounds

### DIFF
--- a/system/ui/lib/scroll_panel.py
+++ b/system/ui/lib/scroll_panel.py
@@ -41,8 +41,12 @@ class GuiScrollPanel:
     if DEBUG:
       rl.draw_rectangle_lines(0, 0, abs(int(self._velocity_filter_y.x)), 10, rl.RED)
 
-    # Handle mouse wheel
-    self._offset_filter_y.x += rl.get_mouse_wheel_move() * MOUSE_WHEEL_SCROLL_SPEED
+    # Handle mouse wheel only when the mouse cursor is over this panel
+    mouse_wheel = rl.get_mouse_wheel_move()
+    if mouse_wheel != 0:
+      mouse_pos = rl.get_mouse_position()
+      if rl.check_collision_point_rec(mouse_pos, bounds):
+        self._offset_filter_y.x += mouse_wheel * MOUSE_WHEEL_SCROLL_SPEED
 
     max_scroll_distance = max(0, content.height - bounds.height)
     if self._scroll_state == ScrollState.IDLE:


### PR DESCRIPTION
ScrollPanel currently captures scroll wheel even when mouse is not over the scrollpanel. Touch scroll works fine - this only impacts wheel/trackpad scroll.

Before: Layout scrolls even when the mouse is over the sidebar

https://github.com/user-attachments/assets/de92ee8f-e958-48fe-9504-733c9abb4036


After: Layout does not scroll when mouse is over the sidebar, but scrolls as expected when mouse is over the layout

https://github.com/user-attachments/assets/a8976152-8033-464a-9840-6c4e2b4e6f7c

