### PR TITLE
ui: ensure auto-scroll stops correctly near target

### DIFF
--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -88,6 +88,7 @@ class GuiScrollPanel2:
         # Steady once we are close enough to the target
         if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
           self.set_offset(target)
+          self._velocity = 0.0
           self._state = ScrollState.STEADY
 
       elif abs(self._velocity) < MIN_VELOCITY:


### PR DESCRIPTION
Prevents `GuiScrollPanel2` from overshooting or jittering near the target by zeroing velocity, ensuring smooth and precise auto-scroll stopping.