### PR TITLE
ui: fix momentum scrolling double-damping and offset drift in GuiScrollPanel2

### DIFF
--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -70,33 +70,36 @@ class GuiScrollPanel2:
   def _update_state(self, bounds_size: float, content_size: float) -> None:
     """Runs per render frame, independent of mouse events. Updates auto-scrolling state and velocity."""
     if self._state == ScrollState.AUTO_SCROLL:
+      dt = rl.get_frame_time() or 1e-6
+      current_offset = self._offset.x if self._horizontal else self._offset.y
+      min_offset = bounds_size - content_size
       # simple exponential return if out of bounds
-      out_of_bounds = self.get_offset() > 0 or self.get_offset() < (bounds_size - content_size)
+      out_of_bounds = current_offset > 0 or current_offset < min_offset
       if out_of_bounds and self._handle_out_of_bounds:
-        if self.get_offset() < (bounds_size - content_size):  # too far right
-          target = bounds_size - content_size
+        if current_offset < min_offset:  # too far right
+          target = min_offset
         else:  # too far left
           target = 0.0
 
-        dt = rl.get_frame_time() or 1e-6
         factor = 1.0 - math.exp(-BOUNCE_RETURN_RATE * dt)
-
-        dist = target - self.get_offset()
-        self.set_offset(self.get_offset() + dist * factor)  # ease toward the edge
+        dist = target - current_offset
+        self.set_offset(current_offset + dist * factor)  # ease toward the edge
         self._velocity *= (1.0 - factor)  # damp any leftover fling
 
         # Steady once we are close enough to the target
         if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
           self.set_offset(target)
+          self._velocity = 0.0
           self._state = ScrollState.STEADY
 
-      elif abs(self._velocity) < MIN_VELOCITY:
+        return
+
+      if abs(self._velocity) < MIN_VELOCITY:
         self._velocity = 0.0
         self._state = ScrollState.STEADY
 
       # Update the offset based on the current velocity
-      dt = rl.get_frame_time()
-      self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
+      self.set_offset(current_offset + self._velocity * dt)  # Adjust the offset based on velocity
       alpha = 1 - (dt / (self._AUTO_SCROLL_TC + dt))
       self._velocity *= alpha
 


### PR DESCRIPTION
Fixes momentum scrolling issues in `GuiScrollPanel2` by correcting bounce-back logic and improving offset precision.
  
**Key Fixes**
1. Double damping:
   **Bug**: Bounce-back and friction were both applied when out of bounds, causing stutter and fast velocity decay. 
    ```Python
      # Inside the out_of_bounds block, velocity is damped by the bounce factor:
      self.set_offset(self.get_offset() + dist * factor) 
      self._velocity *= (1.0 - factor)
      .....
      # Immediately after the if/elif structure, the standard auto-scroll decay is applied again:
      self.set_offset(self.get_offset() + self._velocity * dt) 
      alpha = 1 - (dt / (self._AUTO_SCROLL_TC + dt))
      self._velocity *= alpha
    
    ```
    **Fix**: Added an early return to make them mutually exclusive.

2. Offset drift:
  **Bug**: Sub-pixel precision lost every frame, `get_offset()` returns `int` → rounding on every physics step → velocity never decays properly,
  **Fix**: Now the offset is read once from the raw float value.

