### PR TITLE
UI: Close the scaling detection window without uninitializing opengl

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -652,7 +652,7 @@ class GuiApplication:
      # Create temporary window to query monitor info
     rl.init_window(1, 1, "")
     w, h = rl.get_monitor_width(0), rl.get_monitor_height(0)
-    rl.close_window()
+    rl.glfw_destroy_window(rl.get_window_handle())
 
     if w == 0 or h == 0 or (w >= self._width and h >= self._height):
       return 1.0


### PR DESCRIPTION
On some desktop hardware the ui currently fails to start. This only happens when the _calculate_auto_scale function runs and thereby opens and closes a temporary window. The issue seems to be related to the OpenGLContext getting removed in the raylib close_window function. By directly destroying the glfw window the OpenGLContext does not get removed and the ui is able to start successfully.