### PR TITLE
ui: fix is_touch_valid() incorrectly returning True during auto-scroll

### DIFF
--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -215,5 +215,4 @@ class GuiScrollPanel2:
     return self._state
 
   def is_touch_valid(self) -> bool:
-    # MIN_VELOCITY_FOR_CLICKING is checked in auto-scroll state
-    return bool(self._state != ScrollState.MANUAL_SCROLL)
+    return bool(self._state != ScrollState.MANUAL_SCROLL) or self._velocity < 1.0


### PR DESCRIPTION
Fixes a logic bug where `is_touch_valid()` returned True while the scroll panel was still in `AUTO_SCROLL` with velocity.
Because of this, the UI treated touches as valid clicks even when the content was still flinging, leading to accidental taps during scrolling.

Reproducing the bug:
1. Set params/UpdateAvailable and params/UpdaterNewReleaseNotes.
2. Start the UI
3. Drag-scroll the update alert.
When you release the mouse, the system mistakenly interprets the release as a valid click, and the reboot action is triggered even though the panel is still auto-scrolling:

  ```
  ...
  INFO: TEXTURE: [ID 1] Default texture unloaded successfully
  INFO: Window closed successfully
  REBOOT!
  REBOOT!
  REBOOT!
  ```

