### PR TITLE
fix: use correct display ID for WSL2 when setting up Xvfb

### DIFF
--- a/selfdrive/test/setup_xvfb.sh
+++ b/selfdrive/test/setup_xvfb.sh
@@ -2,7 +2,11 @@
 
 # Sets up a virtual display for running map renderer and simulator without an X11 display
 
-DISP_ID=99
+if uname -r | grep -q "WSL2"; then
+  DISP_ID=0 # WSLg uses display :0
+else
+  DISP_ID=99 # Standard Xvfb display
+fi
 export DISPLAY=:$DISP_ID
 
 sudo Xvfb $DISPLAY -screen 0 2160x1080x24 2>/dev/null &


### PR DESCRIPTION
WSL2 uses WSLg which only uses display :0

In order to get the UI screenshot tests running locally, I have to run the `selfdrive/test/setup_xvfb.sh` script first, but it just hangs on "Waiting for Xvfb..." without this fix.

Now it's still not a great experience because the screenshots are black, I think due to a fundamental WSL limitation, but at least the script runs and I can see the window.

Note: I specifically targeted WSL2 because it seems the display stuff is different on previous versions, but I have no way to verify so just leaving the behavior the same for those.