### PR TITLE
Scroll panel 2: use float for offset

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/device.py
+++ b/selfdrive/ui/mici/layouts/settings/device.py
@@ -39,7 +39,7 @@ class MiciFccModal(NavWidget):
     content_height += self._fcc_logo.height + 20
 
     scroll_content_rect = rl.Rectangle(rect.x, rect.y, rect.width, content_height)
-    scroll_offset = self._scroll_panel.update(rect, scroll_content_rect.height)
+    scroll_offset = round(self._scroll_panel.update(rect, scroll_content_rect.height))
 
     fcc_pos = rl.Vector2(rect.x + 20, rect.y + 20 + scroll_offset)
 

--- a/selfdrive/ui/mici/layouts/settings/firehose.py
+++ b/selfdrive/ui/mici/layouts/settings/firehose.py
@@ -65,7 +65,7 @@ class FirehoseLayoutBase(Widget):
   def _render(self, rect: rl.Rectangle):
     # compute total content height for scrolling
     content_height = self._measure_content_height(rect)
-    scroll_offset = self._scroll_panel.update(rect, content_height)
+    scroll_offset = round(self._scroll_panel.update(rect, content_height))
 
     # start drawing with offset
     x = int(rect.x + 40)

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -87,7 +87,6 @@ class GuiScrollPanel2:
 
         # Steady once we are close enough to the target
         if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
-          self._velocity = 0.0
           self.set_offset(target)
           self._velocity = 0.0
           self._state = ScrollState.STEADY

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -8,7 +8,7 @@ from openpilot.system.ui.lib.application import gui_app, MouseEvent
 from openpilot.system.hardware import TICI
 from collections import deque
 
-MIN_VELOCITY = 2  # px/s, changes from auto scroll to steady state
+MIN_VELOCITY = 10  # px/s, changes from auto scroll to steady state
 MIN_VELOCITY_FOR_CLICKING = 2 * 60  # px/s, accepts clicks while auto scrolling below this velocity
 MIN_DRAG_PIXELS = 12
 AUTO_SCROLL_TC_SNAP = 0.025
@@ -87,6 +87,7 @@ class GuiScrollPanel2:
 
         # Steady once we are close enough to the target
         if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
+          self._velocity = 0.0
           self.set_offset(target)
           self._state = ScrollState.STEADY
 

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -65,15 +65,15 @@ class GuiScrollPanel2:
       print('Offset X:', self._offset.x, 'Y:', self._offset.y)
       print('New state:', self._state)
       print()
-    return self.get_offset()
+    return self.get_offset_float()
 
   def _update_state(self, bounds_size: float, content_size: float) -> None:
     """Runs per render frame, independent of mouse events. Updates auto-scrolling state and velocity."""
     if self._state == ScrollState.AUTO_SCROLL:
       # simple exponential return if out of bounds
-      out_of_bounds = self.get_offset() > 0 or self.get_offset() < (bounds_size - content_size)
+      out_of_bounds = self.get_offset_float() > 0 or self.get_offset_float() < (bounds_size - content_size)
       if out_of_bounds and self._handle_out_of_bounds:
-        if self.get_offset() < (bounds_size - content_size):  # too far right
+        if self.get_offset_float() < (bounds_size - content_size):  # too far right
           target = bounds_size - content_size
         else:  # too far left
           target = 0.0
@@ -81,8 +81,8 @@ class GuiScrollPanel2:
         dt = rl.get_frame_time() or 1e-6
         factor = 1.0 - math.exp(-BOUNCE_RETURN_RATE * dt)
 
-        dist = target - self.get_offset()
-        self.set_offset(self.get_offset() + dist * factor)  # ease toward the edge
+        dist = target - self.get_offset_float()
+        self.set_offset(self.get_offset_float() + dist * factor)  # ease toward the edge
         self._velocity *= (1.0 - factor)  # damp any leftover fling
 
         # Steady once we are close enough to the target
@@ -96,13 +96,13 @@ class GuiScrollPanel2:
 
       # Update the offset based on the current velocity
       dt = rl.get_frame_time()
-      self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
+      self.set_offset(self.get_offset_float() + self._velocity * dt)  # Adjust the offset based on velocity
       alpha = 1 - (dt / (self._AUTO_SCROLL_TC + dt))
       self._velocity *= alpha
 
   def _handle_mouse_event(self, mouse_event: MouseEvent, bounds: rl.Rectangle, bounds_size: float,
                           content_size: float) -> None:
-    out_of_bounds = self.get_offset() > 0 or self.get_offset() < (bounds_size - content_size)
+    out_of_bounds = self.get_offset_float() > 0 or self.get_offset_float() < (bounds_size - content_size)
     if DEBUG:
       print('Mouse event:', mouse_event)
 
@@ -180,8 +180,8 @@ class GuiScrollPanel2:
           delta_x *= 0.25
 
         # Update the offset based on the mouse movement
-        # Use internal _offset directly to preserve precision (don't round via get_offset())
-        # TODO: make get_offset return float
+        # Use internal _offset directly to preserve precision (don't round via get_offset_float())
+        # TODO: make get_offset_float return float
         current_offset = self._offset.x if self._horizontal else self._offset.y
         self.set_offset(current_offset + delta_x)
 
@@ -201,8 +201,11 @@ class GuiScrollPanel2:
   def _get_mouse_pos(self, mouse_event: MouseEvent) -> float:
     return mouse_event.pos.x if self._horizontal else mouse_event.pos.y
 
+  def get_offset_float(self) -> float:
+    return self._offset.x if self._horizontal else self._offset.y
+
   def get_offset(self) -> int:
-    return round(self._offset.x if self._horizontal else self._offset.y)
+    return round(self.get_offset_float())
 
   def set_offset(self, value: float) -> None:
     if self._horizontal:

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -65,15 +65,15 @@ class GuiScrollPanel2:
       print('Offset X:', self._offset.x, 'Y:', self._offset.y)
       print('New state:', self._state)
       print()
-    return self.get_offset_float()
+    return self.get_offset()
 
   def _update_state(self, bounds_size: float, content_size: float) -> None:
     """Runs per render frame, independent of mouse events. Updates auto-scrolling state and velocity."""
     if self._state == ScrollState.AUTO_SCROLL:
       # simple exponential return if out of bounds
-      out_of_bounds = self.get_offset_float() > 0 or self.get_offset_float() < (bounds_size - content_size)
+      out_of_bounds = self.get_offset() > 0 or self.get_offset() < (bounds_size - content_size)
       if out_of_bounds and self._handle_out_of_bounds:
-        if self.get_offset_float() < (bounds_size - content_size):  # too far right
+        if self.get_offset() < (bounds_size - content_size):  # too far right
           target = bounds_size - content_size
         else:  # too far left
           target = 0.0
@@ -81,8 +81,8 @@ class GuiScrollPanel2:
         dt = rl.get_frame_time() or 1e-6
         factor = 1.0 - math.exp(-BOUNCE_RETURN_RATE * dt)
 
-        dist = target - self.get_offset_float()
-        self.set_offset(self.get_offset_float() + dist * factor)  # ease toward the edge
+        dist = target - self.get_offset()
+        self.set_offset(self.get_offset() + dist * factor)  # ease toward the edge
         self._velocity *= (1.0 - factor)  # damp any leftover fling
 
         # Steady once we are close enough to the target
@@ -96,13 +96,13 @@ class GuiScrollPanel2:
 
       # Update the offset based on the current velocity
       dt = rl.get_frame_time()
-      self.set_offset(self.get_offset_float() + self._velocity * dt)  # Adjust the offset based on velocity
+      self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
       alpha = 1 - (dt / (self._AUTO_SCROLL_TC + dt))
       self._velocity *= alpha
 
   def _handle_mouse_event(self, mouse_event: MouseEvent, bounds: rl.Rectangle, bounds_size: float,
                           content_size: float) -> None:
-    out_of_bounds = self.get_offset_float() > 0 or self.get_offset_float() < (bounds_size - content_size)
+    out_of_bounds = self.get_offset() > 0 or self.get_offset() < (bounds_size - content_size)
     if DEBUG:
       print('Mouse event:', mouse_event)
 
@@ -180,8 +180,8 @@ class GuiScrollPanel2:
           delta_x *= 0.25
 
         # Update the offset based on the mouse movement
-        # Use internal _offset directly to preserve precision (don't round via get_offset_float())
-        # TODO: make get_offset_float return float
+        # Use internal _offset directly to preserve precision (don't round via get_offset())
+        # TODO: make get_offset return float
         current_offset = self._offset.x if self._horizontal else self._offset.y
         self.set_offset(current_offset + delta_x)
 
@@ -201,11 +201,8 @@ class GuiScrollPanel2:
   def _get_mouse_pos(self, mouse_event: MouseEvent) -> float:
     return mouse_event.pos.x if self._horizontal else mouse_event.pos.y
 
-  def get_offset_float(self) -> float:
+  def get_offset(self) -> float:
     return self._offset.x if self._horizontal else self._offset.y
-
-  def get_offset(self) -> int:
-    return round(self.get_offset_float())
 
   def set_offset(self, value: float) -> None:
     if self._horizontal:

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -244,7 +244,7 @@ class TermsPage(Widget):
     pass
 
   def _render(self, _):
-    scroll_offset = self._scroll_panel.update(self._rect, self._content_height + self._continue_button.rect.height + 16)
+    scroll_offset = round(self._scroll_panel.update(self._rect, self._content_height + self._continue_button.rect.height + 16))
 
     if scroll_offset <= self._scrolled_down_offset:
       # don't show back if not enabled

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -124,7 +124,7 @@ class Scroller(Widget):
     self.scroll_panel.set_enabled(scroll_enabled and self.enabled)
     self.scroll_panel.update(self._rect, content_size)
     if not self._snap_items:
-      return self.scroll_panel.get_offset()
+      return round(self.scroll_panel.get_offset())
 
     # Snap closest item to center
     center_pos = self._rect.x + self._rect.width / 2 if self._horizontal else self._rect.y + self._rect.height / 2


### PR DESCRIPTION
- Fixes manual movement deadzone in snapping mode (you could position widget not perfectly aligned, eg. see 1 or 2 px of onroad on home layout or wifi names never snapped exactly in the middle)
- Fixes auto scroll not stopping perfectly aligned on widgets in snapping mode (same as above)
- Fixes stopping auto scroll too early and abruptly in non-snapping mode


https://github.com/user-attachments/assets/7ec5363a-f8ea-4ada-8f86-84c3fc058820

