### PR TITLE
Fix steering arc artifacts

### DIFF
--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -24,7 +24,7 @@ class DriverCameraDialog(NavWidget):
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))
     self.driver_state_renderer.load_icons()
-    self._pm = messaging.PubMaster(['selfdriveState'])
+    # self._pm = messaging.PubMaster(['selfdriveState'])
     if not no_escape:
       # TODO: this can grow unbounded, should be given some thought
       device.add_interactive_timeout_callback(self.stop_dmonitoringmodeld)

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -24,7 +24,7 @@ class DriverCameraDialog(NavWidget):
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))
     self.driver_state_renderer.load_icons()
-    # self._pm = messaging.PubMaster(['selfdriveState'])
+    self._pm = messaging.PubMaster(['selfdriveState'])
     if not no_escape:
       # TODO: this can grow unbounded, should be given some thought
       device.add_interactive_timeout_callback(self.stop_dmonitoringmodeld)

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -44,7 +44,7 @@ def quantized_lru_cache(maxsize=128):
   return decorator
 
 
-@quantized_lru_cache(maxsize=256)
+# @quantized_lru_cache(maxsize=256)
 def arc_bar_pts(cx: float, cy: float,
                 r_mid: float, thickness: float,
                 a0_deg: float, a1_deg: float,
@@ -129,6 +129,11 @@ def arc_bar_pts(cx: float, cy: float,
   cap_start = get_cap(True, a0_deg)
 
   pts = np.vstack((outer, cap_end, inner, cap_start, outer[:1])).astype(np.float32)
+  print(pts)
+  # Rotate to start from middle for proper triangulation
+  mid = len(pts) // 2
+  print(len(outer), len(cap_end), len(inner), len(cap_start), len(pts))
+  pts = np.roll(pts, 10, axis=0)
 
   if DEBUG:
     n = len(pts)
@@ -138,6 +143,8 @@ def arc_bar_pts(cx: float, cy: float,
       t = j / n
       color = rl.Color(255, int(255 * (1 - t)), int(255 * t), 255)
       rl.draw_circle(int(x), int(y), 2, color)
+
+  # print(pts)
 
   return pts
 
@@ -207,10 +214,10 @@ class TorqueBar(Widget):
     bg_pts = arc_bar_pts(cx, cy, mid_r, torque_line_height, torque_start_angle, torque_end_angle)
     draw_polygon(rect, bg_pts, color=torque_line_bg_color)
 
-    # draw torque indicator line
-    a0s = top_angle
-    a1s = a0s + torque_bg_angle_span / 2 * self._torque_filter.x
-    sl_pts = arc_bar_pts(cx, cy, mid_r, torque_line_height, a0s, a1s)
+    # # draw torque indicator line
+    # a0s = top_angle
+    # a1s = a0s + torque_bg_angle_span / 2 * self._torque_filter.x
+    # sl_pts = arc_bar_pts(cx, cy, mid_r, torque_line_height, a0s, a1s)
 
     # draw beautiful gradient from center to 65% of the bg torque bar width
     start_grad_pt = cx / rect.width
@@ -244,7 +251,7 @@ class TorqueBar(Widget):
       stops=[0.0, 1.0],
     )
 
-    draw_polygon(rect, sl_pts, gradient=gradient)
+    # draw_polygon(rect, sl_pts, gradient=gradient)
 
     # draw center torque bar dot
     if abs(self._torque_filter.x) < 0.5:

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -212,10 +212,10 @@ class TorqueBar(Widget):
     bg_pts = arc_bar_pts(cx, cy, mid_r, torque_line_height, torque_start_angle, torque_end_angle)
     draw_polygon(rect, bg_pts, color=torque_line_bg_color)
 
-    # # draw torque indicator line
-    # a0s = top_angle
-    # a1s = a0s + torque_bg_angle_span / 2 * self._torque_filter.x
-    # sl_pts = arc_bar_pts(cx, cy, mid_r, torque_line_height, a0s, a1s)
+    # draw torque indicator line
+    a0s = top_angle
+    a1s = a0s + torque_bg_angle_span / 2 * self._torque_filter.x
+    sl_pts = arc_bar_pts(cx, cy, mid_r, torque_line_height, a0s, a1s)
 
     # draw beautiful gradient from center to 65% of the bg torque bar width
     start_grad_pt = cx / rect.width
@@ -249,7 +249,7 @@ class TorqueBar(Widget):
       stops=[0.0, 1.0],
     )
 
-    # draw_polygon(rect, sl_pts, gradient=gradient)
+    draw_polygon(rect, sl_pts, gradient=gradient)
 
     # draw center torque bar dot
     if abs(self._torque_filter.x) < 0.5:

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -129,9 +129,11 @@ def arc_bar_pts(cx: float, cy: float,
   cap_start = get_cap(True, a0_deg)
 
   pts = np.vstack((outer, cap_end, inner, cap_start, outer[:1])).astype(np.float32)
-  # Rotate to start from middle of cap_end for proper triangulation
-  cap_mid_idx = len(outer) + len(cap_end) // 2
-  pts = np.roll(pts, -cap_mid_idx, axis=0)
+  print(pts)
+  # Rotate to start from middle for proper triangulation
+  mid = len(pts) // 2
+  print(len(outer), len(cap_end), len(inner), len(cap_start), len(pts))
+  pts = np.roll(pts, 10, axis=0)
 
   if DEBUG:
     n = len(pts)

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -129,11 +129,8 @@ def arc_bar_pts(cx: float, cy: float,
   cap_start = get_cap(True, a0_deg)
 
   pts = np.vstack((outer, cap_end, inner, cap_start, outer[:1])).astype(np.float32)
-  print(pts)
-  # Rotate to start from middle for proper triangulation
-  mid = len(pts) // 2
-  print(len(outer), len(cap_end), len(inner), len(cap_start), len(pts))
-  pts = np.roll(pts, 10, axis=0)
+  # Rotate to start from middle of cap for proper triangulation
+  pts = np.roll(pts, cap_segs, axis=0)
 
   if DEBUG:
     n = len(pts)

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -142,8 +142,6 @@ def arc_bar_pts(cx: float, cy: float,
       color = rl.Color(255, int(255 * (1 - t)), int(255 * t), 255)
       rl.draw_circle(int(x), int(y), 2, color)
 
-  # print(pts)
-
   return pts
 
 

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -129,6 +129,7 @@ def arc_bar_pts(cx: float, cy: float,
   cap_start = get_cap(True, a0_deg)
 
   pts = np.vstack((outer, cap_end, inner, cap_start, outer[:1])).astype(np.float32)
+
   # Rotate to start from middle of cap for proper triangulation
   pts = np.roll(pts, cap_segs, axis=0)
 

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -44,7 +44,7 @@ def quantized_lru_cache(maxsize=128):
   return decorator
 
 
-# @quantized_lru_cache(maxsize=256)
+@quantized_lru_cache(maxsize=256)
 def arc_bar_pts(cx: float, cy: float,
                 r_mid: float, thickness: float,
                 a0_deg: float, a1_deg: float,

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -129,11 +129,9 @@ def arc_bar_pts(cx: float, cy: float,
   cap_start = get_cap(True, a0_deg)
 
   pts = np.vstack((outer, cap_end, inner, cap_start, outer[:1])).astype(np.float32)
-  print(pts)
-  # Rotate to start from middle for proper triangulation
-  mid = len(pts) // 2
-  print(len(outer), len(cap_end), len(inner), len(cap_start), len(pts))
-  pts = np.roll(pts, 10, axis=0)
+  # Rotate to start from middle of cap_end for proper triangulation
+  cap_mid_idx = len(outer) + len(cap_end) // 2
+  pts = np.roll(pts, -cap_mid_idx, axis=0)
 
   if DEBUG:
     n = len(pts)


### PR DESCRIPTION
@maxime-desroches this is what I meant by rotate. Gotta re-do the videos!

<img width="1050" height="973" alt="image" src="https://github.com/user-attachments/assets/db59909d-d214-4f11-9289-04a0e07c3649" />

---

This works because previously the polygon started at the outer edge, so triangles spanned a very large horizontal distance.

<img width="1608" height="212" alt="image" src="https://github.com/user-attachments/assets/5c5d9f11-993a-460f-94ed-f18f458d5c37" />

Now the polygon points start at the mid point of the cap, so it's structured way more like the path and lane lines, and triangles mainly span vertically.

<img width="1749" height="233" alt="image" src="https://github.com/user-attachments/assets/07c90c7d-a527-4491-8476-188fc46cf9a9" />
