### PR TITLE
ui: skip _draw_set_speed when alpha is 0

### DIFF
--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -224,11 +224,14 @@ class HudRenderer(Widget):
 
   def _draw_set_speed(self, rect: rl.Rectangle) -> None:
     """Draw the MAX speed indicator box."""
+    alpha = self._set_speed_alpha_filter.update(0 < rl.get_time() - self._set_speed_changed_time < SET_SPEED_PERSISTENCE and
+                                                self._can_draw_top_icons and self._engaged)
+    if alpha < 1e-2:
+      return
+
     x = rect.x
     y = rect.y
 
-    alpha = self._set_speed_alpha_filter.update(0 < rl.get_time() - self._set_speed_changed_time < SET_SPEED_PERSISTENCE and
-                                                self._can_draw_top_icons and self._engaged)
 
     # draw drop shadow
     circle_radius = 162 // 2

--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -232,7 +232,6 @@ class HudRenderer(Widget):
     x = rect.x
     y = rect.y
 
-
     # draw drop shadow
     circle_radius = 162 // 2
     rl.draw_circle_gradient(int(x + circle_radius), int(y + circle_radius), circle_radius,


### PR DESCRIPTION
Currently, `hud._draw_set_speed` calls `rl.draw_circle_gradient` and `rl.draw_text_ex` every frame, even when alpha=0. This results in unnecessary CPU/GPU work on device.
This PR adds an early return when `alpha < 1e-2`, making the behavior consistent with `TurnIntent.render`, which only draws when `alpha > 1e-2.`

https://github.com/commaai/openpilot/blob/10524353916f42908557a1711efd2a5b66169c7b/selfdrive/ui/mici/onroad/hud_renderer.py#L55-L64