### PR TITLE
ui: fix CameraView crash in mici due to stale frame

### DIFF
--- a/selfdrive/ui/mici/onroad/cameraview.py
+++ b/selfdrive/ui/mici/onroad/cameraview.py
@@ -198,6 +198,8 @@ class CameraView(Widget):
     if self.shader and self.shader.id:
       rl.unload_shader(self.shader)
 
+    self.frame = None
+    self.available_streams.clear()
     self.client = None
 
   def __del__(self):
@@ -234,6 +236,9 @@ class CameraView(Widget):
     if buffer:
       self._texture_needs_update = True
       self.frame = buffer
+    elif not self.client.is_connected():
+      # ensure we clear the displayed frame when the connection is lost
+      self.frame = None
 
     if not self.frame:
       self._draw_placeholder(rect)


### PR DESCRIPTION
Apply the same fix as #36563 to mici/CameraView to prevent crashes caused by stale or invalid frames.