### PR TITLE
Honda - Rename AcuraWatch Plus to AcuraWatch

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -368,7 +368,7 @@ If your car has the following packages or features, then it's a good candidate f
 
 | Make | Required Package/Features |
 | ---- | ------------------------- |
-| Acura | Any car with AcuraWatch Plus will work. AcuraWatch Plus comes standard on many newer models. |
+| Acura | Any car with AcuraWatch will work. AcuraWatch comes standard on many newer models. |
 | Ford | Any car with Lane Centering will likely work. |
 | Honda | Any car with Honda Sensing will work. Honda Sensing comes standard on many newer models. |
 | Subaru | Any car with EyeSight will work. EyeSight comes standard on many newer models. |

--- a/selfdrive/car/CARS_template.md
+++ b/selfdrive/car/CARS_template.md
@@ -42,7 +42,7 @@ If your car has the following packages or features, then it's a good candidate f
 
 | Make | Required Package/Features |
 | ---- | ------------------------- |
-| Acura | Any car with AcuraWatch Plus will work. AcuraWatch Plus comes standard on many newer models. |
+| Acura | Any car with AcuraWatch will work. AcuraWatch comes standard on many newer models. |
 | Ford | Any car with Lane Centering will likely work. |
 | Honda | Any car with Honda Sensing will work. Honda Sensing comes standard on many newer models. |
 | Subaru | Any car with EyeSight will work. EyeSight comes standard on many newer models. |


### PR DESCRIPTION
AcuraWatch Plus has been rebranded to AcuraWatch

see: [https://www.google.com/search?q=acurawatch+plus](https://www.google.com/search?q=acurawatch+plus)