### PR TITLE
ui: Add RECORD=1 for direct frame recording

### DIFF
--- a/system/ui/README.md
+++ b/system/ui/README.md
@@ -10,6 +10,7 @@ Quick start:
 * set `BURN_IN=1` to get a burn-in heatmap version of the UI
 * set `GRID=50` to show a 50-pixel alignment grid overlay
 * set `MAGIC_DEBUG=1` to show every dropped frames (only on device)
+* set `RECORD=1` to record the screen, output defaults to `output.mp4` but can be set with `RECORD_OUTPUT`
 * https://www.raylib.com/cheatsheet/cheatsheet.html
 * https://electronstudio.github.io/raylib-python-cffi/README.html#quickstart
 

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -38,7 +38,7 @@ GRID_SIZE = int(os.getenv("GRID", "0"))
 PROFILE_RENDER = int(os.getenv("PROFILE_RENDER", "0"))
 PROFILE_STATS = int(os.getenv("PROFILE_STATS", "100"))  # Number of functions to show in profile output
 RECORD = os.getenv("RECORD") == "1"
-RECORD_OUTPUT = os.getenv("RECORD_OUTPUT", "output.mp4")
+RECORD_OUTPUT = os.getenv("RECORD_OUTPUT", "output").rstrip(".mp4") + ".mp4"
 
 GL_VERSION = """
 #version 300 es

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -39,7 +39,6 @@ PROFILE_RENDER = int(os.getenv("PROFILE_RENDER", "0"))
 PROFILE_STATS = int(os.getenv("PROFILE_STATS", "100"))  # Number of functions to show in profile output
 RECORD = os.getenv("RECORD") == "1"
 RECORD_OUTPUT = os.getenv("RECORD_OUTPUT", "output.mp4")
-RECORD_FRAMES = int(os.getenv("RECORD_FRAMES", "0"))
 
 GL_VERSION = """
 #version 300 es
@@ -460,10 +459,6 @@ class GuiApplication:
         self._render_profiler.enable()
 
       while not (self._window_close_requested or rl.window_should_close()):
-        if RECORD and RECORD_FRAMES > 0 and self._frame >= RECORD_FRAMES:
-          self.close()
-          return
-
         if PC:
           # Thread is not used on PC, need to manually add mouse events
           self._mouse._handle_mouse_event()

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -412,8 +412,13 @@ class GuiApplication:
   def close_ffmpeg(self):
     """Close ffmpeg process if recording"""
     if self._ffmpeg_proc is not None:
+      self._ffmpeg_proc.stdin.flush()  # ensure all data is written (we flush each frame anyway, but just in case)
       self._ffmpeg_proc.stdin.close()
-      self._ffmpeg_proc.wait(timeout=5)
+      try:
+        self._ffmpeg_proc.wait(timeout=5)
+      except subprocess.TimeoutExpired:
+        self._ffmpeg_proc.terminate()
+        self._ffmpeg_proc.wait()
 
   def close(self):
     if not rl.is_window_ready():

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -274,7 +274,9 @@ class GuiApplication:
           [
             'ffmpeg',
             '-hide_banner',
-            '-y',
+            '-v',
+            'warning',
+            '-stats',
             '-f',
             'rawvideo',
             '-pix_fmt',
@@ -289,6 +291,7 @@ class GuiApplication:
             'libx264',
             '-preset',
             'ultrafast',
+            '-y',  # Overwrite existing file
             '-f',
             'mp4',
             RECORD_OUTPUT,

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -412,6 +412,7 @@ class GuiApplication:
     """Close ffmpeg process if recording"""
     if self._ffmpeg_proc is not None:
       self._ffmpeg_proc.stdin.close()
+      self._ffmpeg_proc.wait(timeout=5)
 
   def close(self):
     if not rl.is_window_ready():

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from collections import deque
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from typing import NamedTuple
 from importlib.resources import as_file, files
 from openpilot.common.swaglog import cloudlog
@@ -38,7 +39,7 @@ GRID_SIZE = int(os.getenv("GRID", "0"))
 PROFILE_RENDER = int(os.getenv("PROFILE_RENDER", "0"))
 PROFILE_STATS = int(os.getenv("PROFILE_STATS", "100"))  # Number of functions to show in profile output
 RECORD = os.getenv("RECORD") == "1"
-RECORD_OUTPUT = os.getenv("RECORD_OUTPUT", "output").rstrip(".mp4") + ".mp4"
+RECORD_OUTPUT = str(Path(os.getenv("RECORD_OUTPUT", "output")).with_suffix(".mp4"))
 
 GL_VERSION = """
 #version 300 es

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -270,8 +270,12 @@ class GuiApplication:
       rl.init_window(self._scaled_width, self._scaled_height, title)
 
       if RECORD:
+        # Get actual render buffer dimensions (may differ from window size on HiDPI displays)
+        render_width = rl.get_render_width()
+        render_height = rl.get_render_height()
+
         # Start ffmpeg process for real-time video encoding
-        size = f'{self._scaled_width}x{self._scaled_height}'
+        size = f'{render_width}x{render_height}'
         ffmpeg_args = [
           ['ffmpeg'],
           ['-v', 'warning'],  # Reduce ffmpeg log spam
@@ -281,9 +285,9 @@ class GuiApplication:
           ['-s', size],  # Input resolution
           ['-r', str(fps)],  # Input frame rate
           ['-i', 'pipe:0'],  # Input from stdin
+          ['-vf', 'format=yuv420p'],  # Explicitly convert rgba to yuv420p
           ['-c:v', 'libx264'],  # Video codec
           ['-preset', 'ultrafast'],  # Encoding speed
-          ['-vf', 'format=yuv420p'],  # Explicitly convert rgba to yuv420p
           ['-y'],  # Overwrite existing file
           ['-f', 'mp4'],  # Output format
           [RECORD_OUTPUT],  # Output file path

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -8,6 +8,7 @@ import pyray as rl
 import threading
 import platform
 import subprocess
+import itertools
 from contextlib import contextmanager
 from collections.abc import Callable
 from collections import deque
@@ -270,32 +271,24 @@ class GuiApplication:
 
       if RECORD:
         # Start ffmpeg process for real-time video encoding
+        ffmpeg_args = [
+          ['ffmpeg'],
+          ['-v', 'warning'],  # Reduce ffmpeg log spam
+          ['-stats'],  # Show encoding progress
+          ['-f', 'rawvideo'],  # Input format
+          ['-pix_fmt', 'rgba'],  # Input pixel format )
+          ['-s', f'{self._scaled_width}x{self._scaled_height}'],  # Input resolution
+          ['-r', str(fps)],  # Input frame rate
+          ['-i', 'pipe:0'],  # Input from stdin
+          ['-c:v', 'libx264'],  # Video codec
+          ['-preset', 'ultrafast'],  # Encoding speed
+          ['-y'],  # Overwrite existing file
+          ['-f', 'mp4'],  # Output format
+          [RECORD_OUTPUT],  # Output file path
+        ]
+        flattened_args = list(itertools.chain.from_iterable(ffmpeg_args))
         self._ffmpeg_proc = subprocess.Popen(
-          [
-            'ffmpeg',
-            '-hide_banner',
-            '-v',
-            'warning',
-            '-stats',
-            '-f',
-            'rawvideo',
-            '-pix_fmt',
-            'rgba',
-            '-s',
-            f'{self._scaled_width}x{self._scaled_height}',
-            '-r',
-            str(fps),
-            '-i',
-            'pipe:0',
-            '-c:v',
-            'libx264',
-            '-preset',
-            'ultrafast',
-            '-y',  # Overwrite existing file
-            '-f',
-            'mp4',
-            RECORD_OUTPUT,
-          ],
+          flattened_args,
           stdin=subprocess.PIPE,
         )
 

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -273,6 +273,7 @@ class GuiApplication:
         self._ffmpeg_proc = subprocess.Popen(
           [
             'ffmpeg',
+            '-hide_banner',
             '-y',
             '-f',
             'rawvideo',

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -271,17 +271,19 @@ class GuiApplication:
 
       if RECORD:
         # Start ffmpeg process for real-time video encoding
+        size = f'{self._scaled_width}x{self._scaled_height}'
         ffmpeg_args = [
           ['ffmpeg'],
           ['-v', 'warning'],  # Reduce ffmpeg log spam
           ['-stats'],  # Show encoding progress
           ['-f', 'rawvideo'],  # Input format
-          ['-pix_fmt', 'rgba'],  # Input pixel format )
-          ['-s', f'{self._scaled_width}x{self._scaled_height}'],  # Input resolution
+          ['-pix_fmt', 'rgba'],  # Input pixel format
+          ['-s', size],  # Input resolution
           ['-r', str(fps)],  # Input frame rate
           ['-i', 'pipe:0'],  # Input from stdin
           ['-c:v', 'libx264'],  # Video codec
           ['-preset', 'ultrafast'],  # Encoding speed
+          ['-vf', 'format=yuv420p'],  # Explicitly convert rgba to yuv420p
           ['-y'],  # Overwrite existing file
           ['-f', 'mp4'],  # Output format
           [RECORD_OUTPUT],  # Output file path

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -8,7 +8,6 @@ import pyray as rl
 import threading
 import platform
 import subprocess
-import itertools
 from contextlib import contextmanager
 from collections.abc import Callable
 from collections import deque
@@ -281,24 +280,23 @@ class GuiApplication:
         # Start ffmpeg process for real-time video encoding
         size = f'{render_width}x{render_height}'
         ffmpeg_args = [
-          ['ffmpeg'],
-          ['-v', 'warning'],  # Reduce ffmpeg log spam
-          ['-stats'],  # Show encoding progress
-          ['-f', 'rawvideo'],  # Input format
-          ['-pix_fmt', 'rgba'],  # Input pixel format
-          ['-s', size],  # Input resolution
-          ['-r', str(fps)],  # Input frame rate
-          ['-i', 'pipe:0'],  # Input from stdin
-          ['-vf', 'format=yuv420p'],  # Explicitly convert rgba to yuv420p
-          ['-c:v', 'libx264'],  # Video codec
-          ['-preset', 'ultrafast'],  # Encoding speed
-          ['-y'],  # Overwrite existing file
-          ['-f', 'mp4'],  # Output format
-          [RECORD_OUTPUT],  # Output file path
+          'ffmpeg',
+          '-v', 'warning',          # Reduce ffmpeg log spam
+          '-stats',                 # Show encoding progress
+          '-f', 'rawvideo',         # Input format
+          '-pix_fmt', 'rgba',       # Input pixel format
+          '-s', size,               # Input resolution
+          '-r', str(fps),           # Input frame rate
+          '-i', 'pipe:0',           # Input from stdin
+          '-vf', 'format=yuv420p',  # Explicitly convert rgba to yuv420p
+          '-c:v', 'libx264',        # Video codec
+          '-preset', 'ultrafast',   # Encoding speed
+          '-y',                     # Overwrite existing file
+          '-f', 'mp4',              # Output format
+          RECORD_OUTPUT,            # Output file path
         ]
-        flattened_args = list(itertools.chain.from_iterable(ffmpeg_args))
         self._ffmpeg_proc = subprocess.Popen(
-          flattened_args,
+          ffmpeg_args,
           stdin=subprocess.PIPE,
         )
 

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -204,6 +204,10 @@ class GuiApplication:
 
     self._scaled_width = int(self._width * self._scale)
     self._scaled_height = int(self._height * self._scale)
+    if RECORD:
+      # Ensure dimensions are even for video encoding (libx264 requirement)
+      self._scaled_width = self._scaled_width if self._scaled_width % 2 == 0 else self._scaled_width + 1
+      self._scaled_height = self._scaled_height if self._scaled_height % 2 == 0 else self._scaled_height + 1
     self._render_texture: rl.RenderTexture | None = None
     self._burn_in_shader: rl.Shader | None = None
     self._ffmpeg_proc: subprocess.Popen | None = None

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -269,8 +269,6 @@ class GuiApplication:
 
       if RECORD:
         # Start ffmpeg process for real-time video encoding
-        width = self._width if self._render_texture else self._scaled_width
-        height = self._height if self._render_texture else self._scaled_height
         self._ffmpeg_proc = subprocess.Popen(
           [
             'ffmpeg',
@@ -280,7 +278,7 @@ class GuiApplication:
             '-pix_fmt',
             'rgba',
             '-s',
-            f'{width}x{height}',
+            f'{self._scaled_width}x{self._scaled_height}',
             '-r',
             str(fps),
             '-i',

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -205,7 +205,7 @@ class GuiApplication:
     self._scaled_height = int(self._height * self._scale)
     self._render_texture: rl.RenderTexture | None = None
     self._burn_in_shader: rl.Shader | None = None
-    self._ffmpeg_proc = None
+    self._ffmpeg_proc: subprocess.Popen | None = None
     self._textures: dict[str, rl.Texture] = {}
     self._target_fps: int = _DEFAULT_FPS
     self._last_fps_log_time: float = time.monotonic()

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -267,6 +267,7 @@ class GuiApplication:
       rl.set_config_flags(flags)
 
       rl.init_window(self._scaled_width, self._scaled_height, title)
+
       if RECORD:
         # Start ffmpeg process for real-time video encoding
         width = self._width if self._render_texture else self._scaled_width
@@ -295,6 +296,7 @@ class GuiApplication:
           ],
           stdin=subprocess.PIPE,
         )
+
       needs_render_texture = self._scale != 1.0 or BURN_IN_MODE
       if self._scale != 1.0:
         rl.set_mouse_scale(1 / self._scale, 1 / self._scale)


### PR DESCRIPTION
Partly addresses [#36460](https://github.com/commaai/openpilot/issues/36460) based on adeeb's suggestion [here](https://github.com/commaai/openpilot/pull/36551#pullrequestreview-3520892886)

This implements direct frame rendering (when `RECORD=1`) from raylib piped via ffmpeg in real-time to an output file (configured with `RECORD_OUTPUT`, defaults to `output.mp4`). It will keep recording until you stop the UI.

Can be used with current replay or other things in the future.
