### PR TITLE
cabana: fix UI hang when switching streams

### DIFF
--- a/tools/cabana/mainwin.cc
+++ b/tools/cabana/mainwin.cc
@@ -311,11 +311,19 @@ void MainWindow::loadFromClipboard(SourceSet s, bool close_all) {
 }
 
 void MainWindow::openStream(AbstractStream *stream, const QString &dbc_file) {
+  if (can) {
+    QObject::connect(can, &QObject::destroyed, this, [=]() { startStream(stream, dbc_file); });
+    can->deleteLater();
+  } else {
+    startStream(stream, dbc_file);
+  }
+}
+
+void MainWindow::startStream(AbstractStream *stream, QString dbc_file) {
   center_widget->clear();
   delete messages_widget;
   delete video_splitter;
 
-  delete can;
   can = stream;
   can->setParent(this);  // take ownership
   can->start();

--- a/tools/cabana/mainwin.h
+++ b/tools/cabana/mainwin.h
@@ -44,6 +44,7 @@ signals:
   void updateProgressBar(uint64_t cur, uint64_t total, bool success);
 
 protected:
+  void startStream(AbstractStream *stream, QString dbc_file);
   bool eventFilter(QObject *obj, QEvent *event) override;
   void remindSaveChanges();
   void closeFile(SourceSet s = SOURCE_ALL);

--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -63,7 +63,6 @@ void Replay::setupSegmentManager(bool has_filters) {
 }
 
 Replay::~Replay() {
-  seg_mgr_.reset();
   if (stream_thread_.joinable()) {
     rInfo("shutdown: in progress...");
     interruptStream([this]() {
@@ -74,6 +73,7 @@ Replay::~Replay() {
     rInfo("shutdown: done");
   }
   camera_server_.reset();
+  seg_mgr_.reset();
 }
 
 bool Replay::load() {


### PR DESCRIPTION
Switching streams could freeze the UI because the previous stream object was destroyed synchronously. Its destructor could trigger a `BlockingQueuedConnection` (see link below), which blocks the main thread and causes Cabana to hang:

https://github.com/commaai/openpilot/blob/8ffe3f287e735864368f4096f5563d52ee3f08d1/tools/cabana/streams/replaystream.cc#L62

Using `deleteLater()` defers the destruction to Qt’s event loop, avoiding the blocking call and preventing the hang.

**Reproduction steps:**
1. Run: `cabana "<route>"`
2. In the File menu, choose Open Stream and open another stream.
3. The UI may hang at this point.
