### PR TITLE
replay: fix dangling pointers in logging calls

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -31,6 +31,8 @@ void Replay::setupServices(const std::vector<std::string> &allow, const std::vec
   sockets_.resize(event_schema.getUnionFields().size(), nullptr);
 
   std::vector<const char *> active_services;
+  active_services.reserve(services.size());
+
   for (const auto &[name, _] : services) {
     bool is_blocked = std::find(block.begin(), block.end(), name) != block.end();
     bool is_allowed = allow.empty() || std::find(allow.begin(), allow.end(), name) != allow.end();
@@ -40,7 +42,9 @@ void Replay::setupServices(const std::vector<std::string> &allow, const std::vec
       active_services.push_back(name.c_str());
     }
   }
-  rInfo("active services: %s", join(active_services, ", ").c_str());
+
+  std::string services_str = join(active_services, ", ");
+  rInfo("active services: %s", services_str.c_str());
   if (!sm_) {
     pm_ = std::make_unique<PubMaster>(active_services);
   }

--- a/tools/replay/seg_mgr.cc
+++ b/tools/replay/seg_mgr.cc
@@ -91,7 +91,8 @@ bool SegmentManager::mergeSegments(const SegmentMap::iterator &begin, const Segm
   auto &merged_events = merged_event_data->events;
   merged_events.reserve(total_event_count);
 
-  rDebug("merging segments: %s", join(segments_to_merge, ", ").c_str());
+  std::string segments_str = join(segments_to_merge, ", ");
+  rDebug("merging segments: %s", segments_str.c_str());
   for (int n : segments_to_merge) {
     const auto &events = segments_.at(n)->log->events;
     if (events.empty()) continue;


### PR DESCRIPTION
Fixed two cases where `join().c_str()` was passed directly to logging. `join()` returns a temporary `std::string`, so the `c_str()` pointer became dangling once the temporary was destroyed.

Also added reserve() for `active_services` vector to avoid unnecessary reallocations.