### PR TITLE
Fix ui crashing replay/selfdrived

### DIFF
--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -24,7 +24,7 @@ class DriverCameraDialog(NavWidget):
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))
     self.driver_state_renderer.load_icons()
-    self._pm = None  # messaging.PubMaster(['selfdriveState'])
+    self._pm = None
     if not no_escape:
       # TODO: this can grow unbounded, should be given some thought
       device.add_interactive_timeout_callback(self.stop_dmonitoringmodeld)

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -31,7 +31,7 @@ class DriverCameraDialog(NavWidget):
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))
     self.driver_state_renderer.load_icons()
-    self._pm = None
+    self._pm: messaging.PubMaster | None = None
     if not no_escape:
       # TODO: this can grow unbounded, should be given some thought
       device.add_interactive_timeout_callback(lambda: gui_app.set_modal_overlay(None))


### PR DESCRIPTION
Retry https://github.com/commaai/openpilot/pull/36658

Stress tested going onroad/offroad with DM dialog and and training guide DM in close proximity + restarting ui onroad. All that matters should be not creating PubMaster on init. Deletion is handled gracefully within the Widget now

Still no memory leak