### PR TITLE
ui: fix dialog leak

### DIFF
--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -29,11 +29,12 @@ class BigDialogBase(NavWidget, abc.ABC):
     self.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
 
     dialog_ref = weakref.ref(self)
+
     def back_clicked_callback():
       if dlg := dialog_ref():
         dlg._ret = DialogResult.CANCEL
-    self._back_callback_impl = back_clicked_callback
-    self.set_back_callback(self._back_callback_impl)
+
+    self.set_back_callback(back_clicked_callback)
 
     self._right_btn = None
     if right_btn:
@@ -165,6 +166,7 @@ class BigInputDialog(BigDialogBase):
     self._top_right_button_rect = rl.Rectangle(0, 0, 0, 0)
 
     dialog_ref = weakref.ref(self)
+
     def confirm_callback_wrapper():
       if dlg := dialog_ref():
         dlg._ret = DialogResult.CONFIRM


### PR DESCRIPTION
Fixes memory leak where dialogs like `BigDialog` and `BigInputDialog` were not garbage collected after being closed, causing gradual memory growth.

This PR breaks circular references between dialogs and their callbacks by using weakref.ref, ensuring dialogs are properly released.