### PR TITLE
ui: fix DriverCameraDialog leak

### DIFF
--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -83,9 +83,6 @@ class DriverCameraDialog(NavWidget):
   def _handle_mouse_release(self, _):
     ui_state.params.remove("DriverTooDistracted")
 
-  def _dismiss(self):
-    self.stop_dmonitoringmodeld()
-
   def close(self):
     if self._camera_view:
       self._camera_view.close()

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -1,5 +1,5 @@
-import pyray as rl
 import weakref
+import pyray as rl
 from cereal import log, messaging
 from msgq.visionipc import VisionStreamType
 from openpilot.selfdrive.ui.mici.onroad.cameraview import CameraView
@@ -14,6 +14,7 @@ from openpilot.system.ui.widgets.label import gui_label
 EventName = log.OnroadEvent.EventName
 
 EVENT_TO_INT = EventName.schema.enumerants
+
 
 class DriverCameraView(CameraView):
   def __init__(self):
@@ -37,6 +38,7 @@ class DriverCameraDialog(NavWidget):
     self._pm = messaging.PubMaster(['selfdriveState'])
 
     dialog_ref = weakref.ref(self)
+
     def _stop_dmonitoringmodeld():
       if dlg := dialog_ref():
         dlg.stop_dmonitoringmodeld()

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -31,6 +31,7 @@ class DriverCameraView(CameraView):
 class DriverCameraDialog(NavWidget):
   def __init__(self, no_escape=False):
     super().__init__()
+    # TODO: clean up offroad_transition_callback
     self._camera_view = DriverCameraView()
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -44,7 +44,6 @@ class DriverCameraDialog(NavWidget):
     self._stop_dmonitoringmodeld_callback = _stop_dmonitoringmodeld
 
     if not no_escape:
-      #TODO: this can grow unbounded, should be given some thought
       device.add_interactive_timeout_callback(self._stop_dmonitoringmodeld_callback)
 
     self.set_back_callback(self._stop_dmonitoringmodeld_callback)

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -209,6 +209,10 @@ class Device:
   def add_interactive_timeout_callback(self, callback: Callable):
     self._interactive_timeout_callbacks.append(callback)
 
+  def remove_interactive_timeout_callback(self, callback: Callable):
+    if callback in self._interactive_timeout_callbacks:
+      self._interactive_timeout_callbacks.remove(callback)
+
   def update(self):
     # do initial reset
     if self._interaction_time <= 0:


### PR DESCRIPTION
Fixes memory leak in `DriverCameraDialog` where dialog instances were not released after closing. The leak was caused by circular references that prevented Python’s garbage collector from reclaiming the dialog objects, including:

1. Assigning a bound method to `_camera_view._calc_frame_matrix` (`self._camera_view._calc_frame_matrix = self._calc_driver_frame_matrix`)
2. Storing bound methods in callbacks (`device.add_interactive_timeout_callback(self.stop_dmonitoringmodeld)` and `self.set_back_callback(self._dismiss))`

This PR breaks these reference cycles using weak references and explicit cleanup, ensuring that dialogs are properly released when closed.