### PR TITLE
tools: Handle smaller terminal sizes in replay

### DIFF
--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -115,7 +115,12 @@ void ConsoleUI::initWindows() {
     w[Win::Log] = newwin(log_height - 2, max_width - 2 * BORDER_SIZE, 18, BORDER_SIZE);
     scrollok(w[Win::Log], true);
   }
-  w[Win::Help] = newwin(5, max_width - (2 * BORDER_SIZE), max_height - 6, BORDER_SIZE);
+  if (max_height >= 23) {
+    w[Win::Help] = newwin(5, max_width - (2 * BORDER_SIZE), max_height - 6, BORDER_SIZE);
+  } else if (max_height >= 16) {
+    w[Win::Help] = newwin(1, max_width - (2 * BORDER_SIZE), max_height - 1, BORDER_SIZE);
+    mvwprintw(w[Win::Help], 0, 0, "Enlarge screen to list available commands");
+  }
 
   // set the title bar
   wbkgd(w[Win::Title], A_REVERSE);
@@ -124,7 +129,7 @@ void ConsoleUI::initWindows() {
   // show windows on the real screen
   refresh();
   displayTimelineDesc();
-  displayHelp();
+  if (max_height >= 23) displayHelp();
   updateSummary();
   updateTimeline();
   for (auto win : w) {

--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -117,7 +117,7 @@ void ConsoleUI::initWindows() {
   }
   if (max_height >= 23) {
     w[Win::Help] = newwin(5, max_width - (2 * BORDER_SIZE), max_height - 6, BORDER_SIZE);
-  } else if (max_height >= 16) {
+  } else if (max_height >= 17) {
     w[Win::Help] = newwin(1, max_width - (2 * BORDER_SIZE), max_height - 1, BORDER_SIZE);
     mvwprintw(w[Win::Help], 0, 0, "Enlarge screen to list available commands");
   }

--- a/tools/replay/consoleui.cc
+++ b/tools/replay/consoleui.cc
@@ -119,7 +119,7 @@ void ConsoleUI::initWindows() {
     w[Win::Help] = newwin(5, max_width - (2 * BORDER_SIZE), max_height - 6, BORDER_SIZE);
   } else if (max_height >= 17) {
     w[Win::Help] = newwin(1, max_width - (2 * BORDER_SIZE), max_height - 1, BORDER_SIZE);
-    mvwprintw(w[Win::Help], 0, 0, "Enlarge screen to list available commands");
+    mvwprintw(w[Win::Help], 0, 0, "Expand screen vertically to list available commands");
   }
 
   // set the title bar


### PR DESCRIPTION
**Description**

When running `op replay --demo` in VS Code (or any terminal with a custom size), the terminal height can be too small to display all the available commands. This was not being detected, leading to a bad experience for terminals smaller than 23 rows. The help is now only conditionally added, along with a suggestion to enlarge the terminal, if there is room.

**Verification**

op replay --demo on screen height < 23 before:
<img width="762" height="481" alt="image" src="https://github.com/user-attachments/assets/bcf3f55c-6dcd-45b6-8cd6-e6f6c1fdc775" />

op replay --demo on screen height < 17 before:
<img width="762" height="370" alt="image" src="https://github.com/user-attachments/assets/f96dc646-021f-4fcc-9c8b-242b83ae9b9d" />

op replay --demo on screen height < 23 after:
<img width="762" height="482" alt="image" src="https://github.com/user-attachments/assets/4b56a2c4-d2b8-4c09-9bdd-120c2419869c" />

op replay --demo on screen height < 17 after:
<img width="762" height="370" alt="image" src="https://github.com/user-attachments/assets/1bf207cf-f37b-4680-85ec-81fe4ab33dcf" />

