### PR TITLE
Clean up DM dialog CameraView bound method

### DIFF
--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -16,9 +16,6 @@ EVENT_TO_INT = EventName.schema.enumerants
 
 
 class DriverCameraView(CameraView):
-  def __init__(self):
-    super().__init__("camerad", VisionStreamType.VISION_STREAM_DRIVER)
-
   def _calc_frame_matrix(self, rect: rl.Rectangle):
     base = super()._calc_frame_matrix(rect)
     driver_view_ratio = 1.5
@@ -30,7 +27,7 @@ class DriverCameraView(CameraView):
 class DriverCameraDialog(NavWidget):
   def __init__(self, no_escape=False):
     super().__init__()
-    self._camera_view = DriverCameraView()
+    self._camera_view = DriverCameraView("camerad", VisionStreamType.VISION_STREAM_DRIVER)
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))
     self.driver_state_renderer.load_icons()
@@ -115,7 +112,7 @@ class DriverCameraDialog(NavWidget):
       event_name = EVENT_TO_INT[dm_state.events[0].name]
       if event_name is not None and event_name in EVENTS and ET.PERMANENT in EVENTS[event_name]:
         msg.selfdriveState.alertSound = EVENTS[event_name][ET.PERMANENT].audible_alert
-    # self._pm.send('selfdriveState', msg)
+    self._pm.send('selfdriveState', msg)
 
   def _render_dm_alerts(self, rect: rl.Rectangle):
     """Render driver monitoring event names"""

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -15,12 +15,22 @@ EventName = log.OnroadEvent.EventName
 EVENT_TO_INT = EventName.schema.enumerants
 
 
+class DriverCameraView(CameraView):
+  def __init__(self):
+    super().__init__("camerad", VisionStreamType.VISION_STREAM_DRIVER)
+
+  def _calc_frame_matrix(self, rect: rl.Rectangle):
+    base = super()._calc_frame_matrix(rect)
+    driver_view_ratio = 1.5
+    base[0, 0] *= driver_view_ratio
+    base[1, 1] *= driver_view_ratio
+    return base
+
+
 class DriverCameraDialog(NavWidget):
   def __init__(self, no_escape=False):
     super().__init__()
-    self._camera_view = CameraView("camerad", VisionStreamType.VISION_STREAM_DRIVER)
-    self._original_calc_frame_matrix = self._camera_view._calc_frame_matrix
-    self._camera_view._calc_frame_matrix = self._calc_driver_frame_matrix
+    self._camera_view = DriverCameraView()
     self.driver_state_renderer = DriverStateRenderer(lines=True)
     self.driver_state_renderer.set_rect(rl.Rectangle(0, 0, 200, 200))
     self.driver_state_renderer.load_icons()
@@ -105,7 +115,7 @@ class DriverCameraDialog(NavWidget):
       event_name = EVENT_TO_INT[dm_state.events[0].name]
       if event_name is not None and event_name in EVENTS and ET.PERMANENT in EVENTS[event_name]:
         msg.selfdriveState.alertSound = EVENTS[event_name][ET.PERMANENT].audible_alert
-    self._pm.send('selfdriveState', msg)
+    # self._pm.send('selfdriveState', msg)
 
   def _render_dm_alerts(self, rect: rl.Rectangle):
     """Render driver monitoring event names"""

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -225,13 +225,6 @@ class DriverCameraDialog(NavWidget):
     glasses_prob = driver_data.sunglassesProb
     rl.draw_texture_v(self._glasses_texture, glasses_pos, rl.Color(70, 80, 161, int(255 * glasses_prob)))
 
-  def _calc_driver_frame_matrix(self, rect: rl.Rectangle):
-    base = self._original_calc_frame_matrix(rect)
-    driver_view_ratio = 1.5
-    base[0, 0] *= driver_view_ratio
-    base[1, 1] *= driver_view_ratio
-    return base
-
 
 if __name__ == "__main__":
   gui_app.init_window("Driver Camera View (mici)")


### PR DESCRIPTION
Split from https://github.com/commaai/openpilot/pull/36762

Doing this in smaller more manageable chunks, plus there should be something simpler than weakref that prevents this from happening again