### PR TITLE
DriverCameraDialog: proper clean up

### DIFF
--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -47,6 +47,10 @@ class DriverCameraDialog(NavWidget):
 
     self._load_eye_textures()
 
+  def __del__(self):
+    print('del!')
+    self.close()
+
   def stop_dmonitoringmodeld(self):
     ui_state.params.put_bool("IsDriverViewEnabled", False)
     gui_app.set_modal_overlay(None)
@@ -61,6 +65,8 @@ class DriverCameraDialog(NavWidget):
   def hide_event(self):
     super().hide_event()
     device.reset_interactive_timeout()
+    device.remove_interactive_timeout_callback(self.stop_dmonitoringmodeld)
+    self.set_back_callback(None)
 
   def _handle_mouse_release(self, _):
     ui_state.params.remove("DriverTooDistracted")

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -209,6 +209,10 @@ class Device:
   def add_interactive_timeout_callback(self, callback: Callable):
     self._interactive_timeout_callbacks.append(callback)
 
+  def remove_interactive_timeout_callback(self, callback: Callable):
+    if callback in self._interactive_timeout_callbacks:
+      self._interactive_timeout_callbacks.remove(callback)
+
   def update(self):
     # do initial reset
     if self._interaction_time <= 0:

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -339,6 +339,9 @@ class GuiApplication:
 
   def set_modal_overlay(self, overlay, callback: Callable | None = None):
     if self._modal_overlay.overlay is not None:
+      if hasattr(self._modal_overlay.overlay, 'hide_event'):
+        self._modal_overlay.overlay.hide_event()
+
       if self._modal_overlay.callback is not None:
         self._modal_overlay.callback(-1)
 
@@ -556,6 +559,8 @@ class GuiApplication:
       if result >= 0:
         # Clear the overlay and execute the callback
         original_modal = self._modal_overlay
+        if hasattr(self._modal_overlay.overlay, 'hide_event'):
+          self._modal_overlay.overlay.hide_event()
         self._modal_overlay = ModalOverlay()
         if original_modal.callback is not None:
           original_modal.callback(result)

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -252,7 +252,7 @@ class NavWidget(Widget, abc.ABC):
   def set_back_enabled(self, enabled: bool | Callable[[], bool]) -> None:
     self._back_enabled = enabled
 
-  def set_back_callback(self, callback: Callable[[], None]) -> None:
+  def set_back_callback(self, callback: Callable[[], None] | None) -> None:
     self._back_callback = callback
 
   def _handle_mouse_event(self, mouse_event: MouseEvent) -> None:


### PR DESCRIPTION
now `__del__` is called without hacks, cleaning up PubMaster and closing the CameraView inside itself