### PR TITLE
DriverCameraDialog: proper clean up

### DIFF
--- a/selfdrive/ui/mici/onroad/cameraview.py
+++ b/selfdrive/ui/mici/onroad/cameraview.py
@@ -150,6 +150,11 @@ class CameraView(Widget):
 
     ui_state.add_offroad_transition_callback(self._offroad_transition)
 
+  # def hide_event(self):
+  #   super().hide_event()
+  #   # Clean up circular reference
+  #   ui_state.remove_offroad_transition_callback(self._offroad_transition)
+
   def _offroad_transition(self):
     # Reconnect if not first time going onroad
     if ui_state.is_onroad() and self.frame is not None:
@@ -203,6 +208,7 @@ class CameraView(Widget):
     self.client = None
 
   def __del__(self):
+    print('camera view cleaned up properly')
     self.close()
 
   def _calc_frame_matrix(self, rect: rl.Rectangle) -> np.ndarray:

--- a/selfdrive/ui/mici/onroad/cameraview.py
+++ b/selfdrive/ui/mici/onroad/cameraview.py
@@ -150,11 +150,6 @@ class CameraView(Widget):
 
     ui_state.add_offroad_transition_callback(self._offroad_transition)
 
-  # def hide_event(self):
-  #   super().hide_event()
-  #   # Clean up circular reference
-  #   ui_state.remove_offroad_transition_callback(self._offroad_transition)
-
   def _offroad_transition(self):
     # Reconnect if not first time going onroad
     if ui_state.is_onroad() and self.frame is not None:
@@ -208,7 +203,6 @@ class CameraView(Widget):
     self.client = None
 
   def __del__(self):
-    print('camera view cleaned up properly')
     self.close()
 
   def _calc_frame_matrix(self, rect: rl.Rectangle) -> np.ndarray:

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -34,8 +34,8 @@ class DriverCameraDialog(NavWidget):
     self._pm = messaging.PubMaster(['selfdriveState'])
     if not no_escape:
       # TODO: this can grow unbounded, should be given some thought
-      device.add_interactive_timeout_callback(self.stop_dmonitoringmodeld)
-    self.set_back_callback(self.stop_dmonitoringmodeld)
+      device.add_interactive_timeout_callback(lambda: gui_app.set_modal_overlay(None))
+    self.set_back_callback(lambda: gui_app.set_modal_overlay(None))
     self.set_back_enabled(not no_escape)
 
     # Load eye icons
@@ -47,10 +47,6 @@ class DriverCameraDialog(NavWidget):
 
     self._load_eye_textures()
 
-  def stop_dmonitoringmodeld(self):
-    ui_state.params.put_bool("IsDriverViewEnabled", False)
-    gui_app.set_modal_overlay(None)
-
   def show_event(self):
     super().show_event()
     ui_state.params.put_bool("IsDriverViewEnabled", True)
@@ -60,12 +56,13 @@ class DriverCameraDialog(NavWidget):
 
   def hide_event(self):
     super().hide_event()
+    ui_state.params.put_bool("IsDriverViewEnabled", False)
     device.reset_interactive_timeout()
 
   def _handle_mouse_release(self, _):
     ui_state.params.remove("DriverTooDistracted")
 
-  def close(self):
+  def __del__(self):
     if self._camera_view:
       self._camera_view.close()
 

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -63,6 +63,9 @@ class DriverCameraDialog(NavWidget):
     ui_state.params.remove("DriverTooDistracted")
 
   def __del__(self):
+    self.close()
+
+  def close(self):
     if self._camera_view:
       self._camera_view.close()
 


### PR DESCRIPTION
Takes what https://github.com/commaai/openpilot/pull/36773 does in `close`, but in `hide_event` for now. Fixes the +20MB leak every time you open driver camera by ensuring the dialog's deletion function is called. PubMaster was 10MB, CameraView was 10MB (both msgq buffers?)