### PR TITLE
ui: fix crash caused by double shader unload in CameraView

### DIFF
--- a/selfdrive/ui/mici/onroad/cameraview.py
+++ b/selfdrive/ui/mici/onroad/cameraview.py
@@ -197,6 +197,7 @@ class CameraView(Widget):
     # Clean up shader
     if self.shader and self.shader.id:
       rl.unload_shader(self.shader)
+      self.shader.id = 0
 
     self.frame = None
     self.available_streams.clear()


### PR DESCRIPTION
Fixes a double-free issue in CameraView when close() is called multiple times.

```
INFO: FONT: Default font loaded successfully (224 glyphs)
INFO: SYSTEM: Working Directory: /home/dean/Projects/openpilot/selfdrive/ui
INFO: TEXTURE: [ID 2] Unloaded texture data from VRAM (GPU)
INFO: SHADER: [ID 3] Default shader unloaded successfully
INFO: TEXTURE: [ID 1] Default texture unloaded successfully
free(): double free detected in tcache 2
Aborted (core dumped)
```


The shader was being unloaded twice because the reference wasn’t cleared.
Setting self.shader = None after unload_shader() prevents repeated frees.