### PR TITLE
Set USBGPU if eGPU is detected

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -77,6 +77,11 @@ function launch {
   # write tmux scrollback to a file
   tmux capture-pane -pq -S-1000 > /tmp/launch_log
 
+  # set USBGPU if egpu detected.
+  if lsusb -d "${USBDEV:-add1:0001}"; then
+    export USBGPU=1
+  fi
+
   # start manager
   cd system/manager
   if [ ! -f $DIR/prebuilt ]; then


### PR DESCRIPTION
Add USBGPU environment variable setting if eGPU is detected.

This would let usbgpu be set automatically (which would allow easier testing) if the device is present when openpilot is starting.