### PR TITLE
ui: add CallbackManager for weak-referenced bound-method callbacks

### DIFF
--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -102,10 +102,10 @@ class TrainingGuideDMTutorial(Widget):
     self._dialog = DriverCameraSetupDialog(wrapped_continue_callback)
 
     # Disable driver monitoring model when device times out for inactivity
-    def inactivity_callback():
-      ui_state.params.put_bool("IsDriverViewEnabled", False)
+    device.add_interactive_timeout_callback(self.inactivity_callback)
 
-    device.add_interactive_timeout_callback(inactivity_callback)
+  def inactivity_callback(self):
+    ui_state.params.put_bool("IsDriverViewEnabled", False)
 
   def show_event(self):
     super().show_event()

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -34,7 +34,7 @@ class DriverCameraDialog(NavWidget):
     self._pm: messaging.PubMaster | None = None
     if not no_escape:
       # TODO: this can grow unbounded, should be given some thought
-      device.add_interactive_timeout_callback(lambda: gui_app.set_modal_overlay(None))
+      device.add_interactive_timeout_callback(self.close_dialog)
     self.set_back_callback(lambda: gui_app.set_modal_overlay(None))
     self.set_back_enabled(not no_escape)
 
@@ -59,6 +59,9 @@ class DriverCameraDialog(NavWidget):
     super().hide_event()
     ui_state.params.put_bool("IsDriverViewEnabled", False)
     device.reset_interactive_timeout()
+
+  def close_dialog(self):
+    gui_app.set_modal_overlay(None)
 
   def _handle_mouse_release(self, _):
     ui_state.params.remove("DriverTooDistracted")

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -33,7 +33,6 @@ class DriverCameraDialog(NavWidget):
     self.driver_state_renderer.load_icons()
     self._pm: messaging.PubMaster | None = None
     if not no_escape:
-      # TODO: this can grow unbounded, should be given some thought
       device.add_interactive_timeout_callback(self.close_dialog)
     self.set_back_callback(lambda: gui_app.set_modal_overlay(None))
     self.set_back_enabled(not no_escape)

--- a/selfdrive/ui/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/onroad/driver_camera_dialog.py
@@ -13,7 +13,6 @@ class DriverCameraDialog(CameraView):
   def __init__(self):
     super().__init__("camerad", VisionStreamType.VISION_STREAM_DRIVER)
     self.driver_state_renderer = DriverStateRenderer()
-    # TODO: this can grow unbounded, should be given some thought
     device.add_interactive_timeout_callback(self.stop_dmonitoringmodeld)
     ui_state.params.put_bool("IsDriverViewEnabled", True)
 

--- a/system/ui/lib/callback_manager.py
+++ b/system/ui/lib/callback_manager.py
@@ -1,0 +1,29 @@
+import weakref
+from collections.abc import Callable
+from typing import Any
+
+
+class CallbackManager:
+  def __init__(self):
+    self._callbacks: weakref.WeakSet[weakref.WeakMethod] = weakref.WeakSet()
+
+  def add(self, callback_method: Callable[..., Any]) -> None:
+    weak_cb = weakref.WeakMethod(callback_method)
+    self._callbacks.add(weak_cb)
+
+  def remove(self, callback_method: Callable[..., Any]) -> None:
+    weak_cb = weakref.WeakMethod(callback_method)
+    self._callbacks.discard(weak_cb)
+
+  def clear(self) -> None:
+    self._callbacks.clear()
+
+  def __call__(self, *args, **kwargs) -> None:
+    for weak_cb in list(self._callbacks):
+      callback = weak_cb()
+      if callback is not None:
+        # The listener instance is still alive, call the method
+        callback(*args, **kwargs)
+      else:
+        # The listener instance is gone. WeakSet handles automatic removal,
+        pass


### PR DESCRIPTION
Adds a `CallbackManager` that stores bound-method callbacks as weak references and automatically skips those whose objects have been garbage-collected. This prevents callback lists from keeping UI objects alive and avoids memory leaks.

Note: Clients no longer need to manually remove callbacks—dead callbacks are ignored automatically.

A separate PR can add a `SingleCallbackManager` for places (e.g., dialogs, buttons) that only need single weak-referenced callback.