### PR TITLE
ui: only instantiate OnboardingWindow when onboarding is needed

### DIFF
--- a/selfdrive/ui/mici/layouts/main.py
+++ b/selfdrive/ui/mici/layouts/main.py
@@ -62,9 +62,8 @@ class MiciMainLayout(Widget):
     self._setup_callbacks()
 
     # Start onboarding if terms or training not completed
-    self._onboarding_window = OnboardingWindow()
-    if not self._onboarding_window.completed:
-      gui_app.set_modal_overlay(self._onboarding_window)
+    if not OnboardingWindow.completed():
+      gui_app.set_modal_overlay(OnboardingWindow())
 
   def _setup_callbacks(self):
     self._home_layout.set_callbacks(on_settings=self._on_settings_clicked)


### PR DESCRIPTION
`OnboardingWindow` is now created only when onboarding is required and destroyed after use, improving startup time, reducing resource usage, and preventing callbacks registered by `OnboardingWindow` from being triggered unnecessarily during the UI’s lifetime, which could cause unintended side effects.