### PR TITLE
updated: fix skipped test case

### DIFF
--- a/system/updated/tests/test_base.py
+++ b/system/updated/tests/test_base.py
@@ -133,7 +133,7 @@ class TestBaseUpdate:
 class ParamsBaseUpdateTest(TestBaseUpdate):
   def _test_finalized_update(self, branch, version, agnos_version, release_notes):
     assert self.params.get("UpdaterNewDescription").startswith(f"{version} / {branch}")
-    assert self.params.get("UpdaterNewReleaseNotes") == f"{release_notes}\n"
+    assert self.params.get("UpdaterNewReleaseNotes") == f"{release_notes}\n".encode()
     super()._test_finalized_update(branch, version, agnos_version, release_notes)
 
   def send_check_for_updates_signal(self, updated: ManagerProcess):


### PR DESCRIPTION
**Description**

Tests were broken in [this commit](https://github.com/commaai/openpilot/commit/53ea77cad33a401c23a42050bacc6a9a3c5ce41d#diff-5e2a3b688ac83940e5a6253e671cfcde3e2b9100c4d3fbb08cf40e1a39773977R136) (merged into master in #35794), but it was not evident, because these tests are skipped during CI since they are marked as slow. Running them manually using `op test system/updated/tests/test_git.py` would result in 3 failures before this patch.

**Verification**
running the above command in master:
<img width="1314" height="90" alt="image" src="https://github.com/user-attachments/assets/9b6ef748-afb7-4017-9d91-1f53feef8f37" />

running the above command on this branch:
<img width="1314" height="22" alt="image" src="https://github.com/user-attachments/assets/2ea8d688-6443-4e5f-9b0c-6542b87079d1" />

