### PR TITLE
UnifiedLabel: fix clipping descenders

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -253,7 +253,7 @@ class NetworkInfoPage(NavWidget):
       self._connect_btn.set_label("connect")
       self._connect_btn.set_enabled(True)
 
-    self._title.set_text('freaking jest123')
+    self._title.set_text(normalize_ssid(self._network.ssid))
     if self._network.security_type == SecurityType.OPEN:
       self._subtitle.set_text("open")
     elif self._network.security_type == SecurityType.UNSUPPORTED:
@@ -287,7 +287,7 @@ class NetworkInfoPage(NavWidget):
       self._rect.x + self._wifi_icon.rect.width + 32 + 32,
       self._rect.y + 32 - 16,
       self._rect.width - (self._wifi_icon.rect.width + 32 + 32),
-      self._title.get_content_height(48),
+      64,
     ))
 
     self._subtitle.render(rl.Rectangle(

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -287,7 +287,7 @@ class NetworkInfoPage(NavWidget):
       self._rect.x + self._wifi_icon.rect.width + 32 + 32,
       self._rect.y + 32 - 16,
       self._rect.width - (self._wifi_icon.rect.width + 32 + 32),
-      64,
+      self._title.get_content_height(48),
     ))
 
     self._subtitle.render(rl.Rectangle(

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -253,7 +253,7 @@ class NetworkInfoPage(NavWidget):
       self._connect_btn.set_label("connect")
       self._connect_btn.set_enabled(True)
 
-    self._title.set_text(normalize_ssid(self._network.ssid))
+    self._title.set_text('freaking jest123')
     if self._network.security_type == SecurityType.OPEN:
       self._subtitle.set_text("open")
     elif self._network.security_type == SecurityType.UNSUPPORTED:

--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -713,9 +713,8 @@ class UnifiedLabel(Widget):
 
     # Only scissor when we know there is a single scrolling line
     # Pad a little since descenders like g or j may overflow below rect
-    rl.draw_rectangle_lines_ex(self._rect, 1, rl.RED)
     if self._needs_scroll:
-      rl.begin_scissor_mode(int(self._rect.x), int(self._rect.y), int(self._rect.width), int(self._rect.height))
+      rl.begin_scissor_mode(int(self._rect.x), int(self._rect.y - self._font_size / 2), int(self._rect.width), int(self._rect.height + self._font_size))
 
     # Render each line
     current_y = start_y

--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -712,7 +712,7 @@ class UnifiedLabel(Widget):
       start_y = self._rect.y + (self._rect.height - total_visible_height) / 2
 
     # Only scissor when we know there is a single scrolling line
-    # Pad a little since descenders like g or j may overflow below rect
+    # Pad a little since descenders like g or j may overflow below rect from font_scale
     if self._needs_scroll:
       rl.begin_scissor_mode(int(self._rect.x), int(self._rect.y - self._font_size / 2), int(self._rect.width), int(self._rect.height + self._font_size))
 

--- a/system/ui/widgets/label.py
+++ b/system/ui/widgets/label.py
@@ -712,6 +712,8 @@ class UnifiedLabel(Widget):
       start_y = self._rect.y + (self._rect.height - total_visible_height) / 2
 
     # Only scissor when we know there is a single scrolling line
+    # Pad a little since descenders like g or j may overflow below rect
+    rl.draw_rectangle_lines_ex(self._rect, 1, rl.RED)
     if self._needs_scroll:
       rl.begin_scissor_mode(int(self._rect.x), int(self._rect.y), int(self._rect.width), int(self._rect.height))
 


### PR DESCRIPTION
g and j was clipped in wifi ui

This requires patching wifi ui with random wifi networks to catch in the diff tool. This is a safe change since it doesn't change layout, so will merge now