### PR TITLE
prioritize CAN ignition

### DIFF
--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -11,6 +11,7 @@ from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.ui.lib.prime_state import PrimeState
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.hardware import HARDWARE, PC
+from openpilot.system.hardware.ignition_state import ignition_state
 
 BACKLIGHT_OFFROAD = 65 if HARDWARE.get_device_type() == "mici" else 50
 
@@ -122,7 +123,7 @@ class UIState:
         self.panda_type = panda_states[0].pandaType
         # Check ignition status across all pandas
         if self.panda_type != log.PandaState.PandaType.unknown:
-          self.ignition = any(state.ignitionLine or state.ignitionCan for state in panda_states)
+          self.ignition = ignition_state.update(panda_states)
     elif self.sm.frame - self.sm.recv_frame["pandaStates"] > 5 * rl.get_fps():
       self.panda_type = log.PandaState.PandaType.unknown
 

--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -23,6 +23,7 @@ from openpilot.system.statsd import statlog
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.power_monitoring import PowerMonitoring
 from openpilot.system.hardware.fan_controller import TiciFanController
+from openpilot.system.hardware.ignition_state import ignition_state
 from openpilot.system.version import terms_version, training_version
 from openpilot.system.athena.registration import UNREGISTERED_DONGLE_ID
 
@@ -228,7 +229,7 @@ def hardware_thread(end_event, hw_queue) -> None:
     if sm.updated['pandaStates'] and len(pandaStates) > 0:
 
       # Set ignition based on any panda connected
-      onroad_conditions["ignition"] = any(ps.ignitionLine or ps.ignitionCan for ps in pandaStates if ps.pandaType != log.PandaState.PandaType.unknown)
+      onroad_conditions["ignition"] = ignition_state.update(pandaStates)
 
       pandaState = pandaStates[0]
 

--- a/system/hardware/ignition_state.py
+++ b/system/hardware/ignition_state.py
@@ -1,0 +1,20 @@
+from cereal import log
+
+
+class IgnitionState:
+  def __init__(self):
+    self.ignition_can_seen = False
+
+  def update(self, panda_states) -> bool:
+    valid_states = [ps for ps in panda_states if ps.pandaType != log.PandaState.PandaType.unknown]
+    if not valid_states:
+      return False
+    # Prefer CAN ignition once detected to avoid false positives from ignitionLine,
+    # which can remain high after the car is turned off on some vehicles
+    if any(ps.ignitionCan for ps in valid_states):
+      self.ignition_can_seen = True
+      return True
+
+    return False if self.ignition_can_seen else any(ps.ignitionLine for ps in valid_states)
+
+ignition_state = IgnitionState()

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -20,6 +20,7 @@ from openpilot.system.athena.registration import register, UNREGISTERED_DONGLE_I
 from openpilot.common.swaglog import cloudlog, add_file_handler
 from openpilot.system.version import get_build_metadata
 from openpilot.system.hardware.hw import Paths
+from openpilot.system.hardware.ignition_state import ignition_state
 
 
 def manager_init() -> None:
@@ -137,7 +138,7 @@ def manager_thread() -> None:
     elif not started and started_prev:
       params.clear_all(ParamKeyFlag.CLEAR_ON_OFFROAD_TRANSITION)
 
-    ignition = any(ps.ignitionLine or ps.ignitionCan for ps in sm['pandaStates'] if ps.pandaType != log.PandaState.PandaType.unknown)
+    ignition = ignition_state.update(sm['pandaStates'])
     if ignition and not ignition_prev:
       params.clear_all(ParamKeyFlag.CLEAR_ON_IGNITION_ON)
 

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -6,7 +6,6 @@ import sys
 import time
 import traceback
 
-from cereal import log
 import cereal.messaging as messaging
 import openpilot.system.sentry as sentry
 from openpilot.common.utils import atomic_write


### PR DESCRIPTION
IGN line remains high in some cars after ignition is turned off, causing an incorrect onroad state. Added priority handling for CAN ignition which is a more accurate indicator of ignition status.

Validated against the full commaCarSegments dataset.

This is a prerequisite for updating the Mazda harness to use IGN line and eliminating the need for Comma Power.