### PR TITLE
tici/ui: fix memory leak in WiFi list

### DIFF
--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -444,6 +444,13 @@ class WifiManagerUI(Widget):
 
   def _on_network_updated(self, networks: list[Network]):
     self._networks = networks
+
+    # remove buttons for networks that disappeared
+    new_ssids = {n.ssid for n in networks}
+    for ssid in self._networks_buttons.keys() - new_ssids:
+      self._networks_buttons.pop(ssid, None)
+      self._forget_networks_buttons.pop(ssid, None)
+
     for n in self._networks:
       self._networks_buttons[n.ssid] = Button(n.ssid, partial(self._networks_buttons_callback, n), font_size=55,
                                               text_alignment=rl.GuiTextAlignment.TEXT_ALIGN_LEFT, button_style=ButtonStyle.TRANSPARENT_WHITE_TEXT)


### PR DESCRIPTION
Updates Tici `WifiManagerUI._on_network_updated` to delete button entries for SSIDs that no longer appear in the latest scan. This prevents stale UI items from lingering and also fixes a memory leak caused by unused button objects never being released.