### PR TITLE
tools/sim/tests: fix tools/sim/tests - ValueError: option names {'--t…

### DIFF
--- a/tools/sim/tests/conftest.py
+++ b/tools/sim/tests/conftest.py
@@ -1,7 +1,10 @@
 import pytest
 
 def pytest_addoption(parser):
-  parser.addoption("--test_duration", action="store", default=60, type=int, help="Seconds to run metadrive drive")
+  try:
+    parser.addoption("--test_duration", action="store", default=60, type=int, help="Seconds to run metadrive drive")
+  except ValueError:
+    pass # already added
 
 @pytest.fixture
 def test_duration(request):


### PR DESCRIPTION
…est_duration'} already added

**Description**

Attempting to run tests, collection threw value error locally, ERROR tools/sim/tests - ValueError: option names {'--test_duration'} already added

**Verification**

Reran tests to confirm things worked, just passing exception on failures

