### PR TITLE
ci: setup uv and enable cache, reduces highest time spent in setup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -136,6 +136,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: "auto"
     - uses: ./.github/workflows/setup-with-retry
     - name: Static analysis
       timeout-minutes: 1
@@ -153,6 +157,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Install uv with all available options
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: "auto"
     - uses: ./.github/workflows/setup-with-retry
       id: setup-step
     - name: Build openpilot
@@ -178,6 +186,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: "auto"
     - uses: ./.github/workflows/setup-with-retry
       id: setup-step
     - name: Cache test routes
@@ -252,6 +264,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: "auto"
       - uses: ./.github/workflows/setup-with-retry
       - name: Build openpilot
         run: ${{ env.RUN }} "scons -j$(nproc)"
@@ -278,6 +294,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: "auto"
       - uses: ./.github/workflows/setup-with-retry
       - name: Build openpilot
         run: ${{ env.RUN }} "scons -j$(nproc)"


### PR DESCRIPTION
* used in 4 runs, static analysis, unit tests, process replay, raylib, and mici raylib jobs
* currently taking around 16% of execution time 16 seconds / 1 min 40

**Description**

Curious to see if this works

**Verification**

Let ci run
Potentially could tie as part of https://github.com/commaai/openpilot/issues/30706
