### PR TITLE
VisionIPCClient: fix slow connect

### DIFF
--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -271,11 +271,11 @@ class AugmentedRoadView(CameraView):
 
     tlog("final overlays")
 
-    # print("*** AugmentedRoadView timing ***")
-    # for uid, tlist in times.items():
-    #   max_time = max(tlist) * 1000
-    #   avg_time = sum(tlist) / len(tlist) * 1000
-    #   print(f"  {uid}: max {max_time:.2f} ms, avg {avg_time:.2f} ms over {len(tlist)} calls")
+    print("*** AugmentedRoadView timing ***")
+    for uid, tlist in times.items():
+      max_time = max(tlist) * 1000
+      avg_time = sum(tlist) / len(tlist) * 1000
+      print(f"  {uid}: max {max_time:.2f} ms, avg {avg_time:.2f} ms over {len(tlist)} calls")
 
     # publish uiDebug
     msg = messaging.new_message('uiDebug')

--- a/selfdrive/ui/mici/onroad/cameraview.py
+++ b/selfdrive/ui/mici/onroad/cameraview.py
@@ -257,41 +257,41 @@ class CameraView(Widget):
     elif not self.client.is_connected():
       # ensure we clear the displayed frame when the connection is lost
       self.frame = None
-    #
-    # if not self.frame:
-    #   self._draw_placeholder(rect)
-    #   return
-    #
-    # tlog("recv")
-    #
-    # transform = self._calc_frame_matrix(rect)
-    # src_rect = rl.Rectangle(0, 0, float(self.frame.width), float(self.frame.height))
-    # # Flip driver camera horizontally
-    # if self._stream_type == VisionStreamType.VISION_STREAM_DRIVER:
-    #   src_rect.width = -src_rect.width
-    #
-    # # Calculate scale
-    # scale_x = rect.width * transform[0, 0]  # zx
-    # scale_y = rect.height * transform[1, 1]  # zy
-    #
-    # # Calculate base position (centered)
-    # x_offset = rect.x + (rect.width - scale_x) / 2
-    # y_offset = rect.y + (rect.height - scale_y) / 2
-    #
-    # x_offset += transform[0, 2] * rect.width / 2
-    # y_offset += transform[1, 2] * rect.height / 2
-    #
-    # dst_rect = rl.Rectangle(x_offset, y_offset, scale_x, scale_y)
-    #
-    # tlog("calc rects")
-    #
-    # # Render with appropriate method
-    # if TICI:
-    #   self._render_egl(src_rect, dst_rect)
-    # else:
-    #   self._render_textures(src_rect, dst_rect)
-    #
-    # tlog("render")
+
+    if not self.frame:
+      self._draw_placeholder(rect)
+      return
+
+    tlog("recv")
+
+    transform = self._calc_frame_matrix(rect)
+    src_rect = rl.Rectangle(0, 0, float(self.frame.width), float(self.frame.height))
+    # Flip driver camera horizontally
+    if self._stream_type == VisionStreamType.VISION_STREAM_DRIVER:
+      src_rect.width = -src_rect.width
+
+    # Calculate scale
+    scale_x = rect.width * transform[0, 0]  # zx
+    scale_y = rect.height * transform[1, 1]  # zy
+
+    # Calculate base position (centered)
+    x_offset = rect.x + (rect.width - scale_x) / 2
+    y_offset = rect.y + (rect.height - scale_y) / 2
+
+    x_offset += transform[0, 2] * rect.width / 2
+    y_offset += transform[1, 2] * rect.height / 2
+
+    dst_rect = rl.Rectangle(x_offset, y_offset, scale_x, scale_y)
+
+    tlog("calc rects")
+
+    # Render with appropriate method
+    if TICI:
+      self._render_egl(src_rect, dst_rect)
+    else:
+      self._render_textures(src_rect, dst_rect)
+
+    tlog("render")
 
     print("*** CameraView timings ***")
     for uid, tlist in times.items():
@@ -369,9 +369,12 @@ class CameraView(Widget):
         return False
       self.last_connection_attempt = current_time
 
-      if not self.client.connect(False) or not self.client.num_buffers:
+      t = time.monotonic()
+      ret = self.client.connect(False)
+      print((time.monotonic() - t) * 1000)
+      if not ret or not self.client.num_buffers:
         return False
-      return False
+      # return False
 
       cloudlog.debug(f"Connected to {self._name} stream: {self._stream_type}, buffers: {self.client.num_buffers}")
       self._initialize_textures()

--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -317,9 +317,13 @@ class CameraView(Widget):
 
     now_connected = self.client.is_connected()
     if now_connected != self._prev_connected:
+      t = time.monotonic()
       cloudlog.debug(f"Connected to {self._name} stream: {self._stream_type}, buffers: {self.client.num_buffers}")
       self._initialize_textures()
+      print(f"Initialized textures in {(time.monotonic() - t) * 1000:.2f} ms")
+      t = time.monotonic()
       self.available_streams = self.client.available_streams(self._name, block=False)
+      print(f"Fetched available streams in {(time.monotonic() - t) * 1000:.2f} ms")
 
     self._prev_connected = now_connected
 

--- a/tools/replay/camera.cc
+++ b/tools/replay/camera.cc
@@ -8,7 +8,7 @@
 #include "third_party/linux/include/msm_media_info.h"
 #include "tools/replay/util.h"
 
-const int BUFFER_COUNT = 40;
+const int BUFFER_COUNT = 127;
 
 std::tuple<size_t, size_t, size_t> get_nv12_info(int width, int height) {
   int nv12_width = VENUS_Y_STRIDE(COLOR_FMT_NV12, width);


### PR DESCRIPTION
~Can't reproduce on device anymore, but on PC:~

~Something about this is slow:~

~https://github.com/commaai/msgq/blob/e0ee68e69d1cb2e208ee13f1632b6e709e615a5a/msgq/visionipc/visionipc_client.cc#L68-L76~

~As well as this on re-connect:~

~https://github.com/commaai/msgq/blob/e0ee68e69d1cb2e208ee13f1632b6e709e615a5a/msgq/visionipc/visionipc_client.cc#L37-L42~

---

It looks like it's inconsistent because it relies on modeld, dmonitoringmodeld, and/or encoderd connecting to camerad at a certain time. This is the slow line for ui:

https://github.com/commaai/msgq/blob/e0ee68e69d1cb2e208ee13f1632b6e709e615a5a/msgq/visionipc/visionipc_client.cc#L57

Perhaps it wasn't reproducible on mici because startup timing is slightly different, earlier or later, missing the congestion of all the procs connecting.

And this handles incoming connections sequentially:

https://github.com/commaai/msgq/blob/e0ee68e69d1cb2e208ee13f1632b6e709e615a5a/msgq/visionipc/visionipc_server.cc#L86