### PR TITLE
mici ui replay: temp remove swipes

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -33,16 +33,9 @@ class DummyEvent:
 
 SCRIPT = [
   (0, DummyEvent()),
-  (FPS * 1, DummyEvent(swipe_right=True)),
-  (FPS * 2, DummyEvent(swipe_left=True)),
-  (FPS * 3, DummyEvent(swipe_left=True)),
-  (FPS * 4, DummyEvent(click=True)),
-  (FPS * 5, DummyEvent(click=True)),
-  (FPS * 6, DummyEvent(swipe_left=True)),
-  (FPS * 7, DummyEvent(swipe_left=True)),
-  (FPS * 8, DummyEvent(swipe_right=True)),
-  (FPS * 9, DummyEvent(swipe_down=True)),
-  (FPS * 10, DummyEvent()),
+  (FPS * 1, DummyEvent(click=True)),
+  (FPS * 2, DummyEvent(click=True)),
+  (FPS * 3, DummyEvent()),
 ]
 
 


### PR DESCRIPTION
we need this to start testing onroad alerts (since there's a delay to going onroad), but something is making this nondeterministic