### PR TITLE
mici/ui: fix memory leak in WiFi list

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -393,7 +393,10 @@ class WifiUIMici(BigMultiOptionDialog):
       self.add_button(network_button)
 
     # remove networks no longer present
-    self._scroller._items[:] = [btn for btn in self._scroller._items if btn.option in self._networks]
+    to_remove = [btn for btn in self._scroller._items if btn.option not in self._networks]
+    for btn in to_remove:
+      btn.set_click_callback(None)
+      self._scroller._items.remove(btn)
 
   def _connect_with_password(self, ssid: str, password: str):
     if password:


### PR DESCRIPTION
Fixes a memory leak where removed WiFi network items were not released:

https://github.com/commaai/openpilot/pull/36801#issuecomment-3635514173