### PR TITLE
Fix UI timing test

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -206,7 +206,7 @@ class TestOnroad:
     result += "-------------- UI Draw Timing ------------------\n"
     result += "------------------------------------------------\n"
 
-    # skip first few frames -- connecting to vipc
+    # other processes preempt ui while starting up
     offset = int(20 * LOG_OFFSET)
     ts = self.ts['uiDebug']['drawTimeMillis'][offset:]
     result += f"min  {min(ts):.2f}ms\n"

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -207,7 +207,8 @@ class TestOnroad:
     result += "------------------------------------------------\n"
 
     # skip first few frames -- connecting to vipc
-    ts = self.ts['uiDebug']['drawTimeMillis'][15:]
+    offset = int(20 * LOG_OFFSET)
+    ts = self.ts['uiDebug']['drawTimeMillis'][offset:]
     result += f"min  {min(ts):.2f}ms\n"
     result += f"max  {max(ts):.2f}ms\n"
     result += f"std  {np.std(ts):.2f}ms\n"

--- a/selfdrive/ui/mici/onroad/cameraview.py
+++ b/selfdrive/ui/mici/onroad/cameraview.py
@@ -107,7 +107,6 @@ else:
 class CameraView(Widget):
   def __init__(self, name: str, stream_type: VisionStreamType):
     super().__init__()
-    # TODO: implement a receiver and connect thread
     self._name = name
     # Primary stream
     self.client = VisionIpcClient(name, stream_type, conflate=True)

--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -68,7 +68,6 @@ else:
 class CameraView(Widget):
   def __init__(self, name: str, stream_type: VisionStreamType):
     super().__init__()
-    # TODO: implement a receiver and connect thread
     self._name = name
     # Primary stream
     self.client = VisionIpcClient(name, stream_type, conflate=True)


### PR DESCRIPTION
It's not due to anything specific in ui, as soon as CarParams is written, a multitude of other processes all start at once, lagging the ui for a split moment. Seems to get worse the more you restart openpilot, which could be related to magic memory leak. raylib and magic were merged together, so that might be why Qt never had this problem.

This almost had the right idea: https://github.com/commaai/openpilot/pull/36385

Every other timing test/memory usage test uses this offset, so add to ui.

---

Closes https://github.com/commaai/openpilot/issues/36781