### PR TITLE
ui: fix thread-safety issue by passing a copy of the network list to callbacks

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -636,7 +636,7 @@ class WifiManager:
       self._update_ipv4_address()
       self._update_current_network_metered()
 
-      self._enqueue_callbacks(self._networks_updated, self._networks)
+      self._enqueue_callbacks(self._networks_updated, self._networks.copy())
 
   def _update_ipv4_address(self):
     if self._wifi_device is None:


### PR DESCRIPTION
Previously, the original mutable network list (`self._networks`) was passed directly to callbacks. This could cause race conditions.

Example from logging:
```

Enqueuing callback: <bound method NetworkLayoutMici._on_network_updated of <...NetworkLayoutMici object at 0x7f638b3e3390>> with args: id: 140065515005056
Processing network update in UI with arg id: 140065515005056
```

The same object ID appears in both threads, confirming that the mutable object was shared.

Change: Pass a copy of the network list to callbacks to ensure each thread works with an independent, thread-safe snapshot.