### PR TITLE
remove unused #include "common/params.h" from hardware.h

### DIFF
--- a/system/hardware/tici/hardware.h
+++ b/system/hardware/tici/hardware.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <algorithm>  // for std::clamp
 
-#include "common/params.h"
 #include "common/util.h"
 #include "system/hardware/base.h"
 


### PR DESCRIPTION
it's unused after ui migration to python. remove it to reduces build dependencies.