### PR TITLE
locationd: Update outdated reference after cython removals

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,8 @@
   url = ../../commaai/msgq.git
 [submodule "rednose_repo"]
   path = rednose_repo
-  url = ../../commaai/rednose.git
+  url = ../../mpurnell1/rednose.git
+  branch = remove-ekf-cython
 [submodule "teleoprtc_repo"]
   path = teleoprtc_repo
   url = ../../commaai/teleoprtc

--- a/selfdrive/locationd/models/car_kf.py
+++ b/selfdrive/locationd/models/car_kf.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':  # Generating sympy
   import sympy as sp
   from rednose.helpers.ekf_sym import gen_code
 else:
-  from rednose.helpers.ekf_sym_pyx import EKF_sym_pyx
+  from rednose.helpers import EKFSym
 
 
 i = 0
@@ -163,7 +163,7 @@ class CarKalman(KalmanFilter):
 
   def __init__(self, generated_dir):
     dim_state, dim_state_err = CarKalman.initial_x.shape[0], CarKalman.P_initial.shape[0]
-    self.filter = EKF_sym_pyx(generated_dir, CarKalman.name, CarKalman.Q, CarKalman.initial_x, CarKalman.P_initial,
+    self.filter = EKFSym(generated_dir, CarKalman.name, CarKalman.Q, CarKalman.initial_x, CarKalman.P_initial,
                               dim_state, dim_state_err, global_vars=CarKalman.global_vars, logger=cloudlog)
 
   def set_globals(self, mass, rotational_inertia, center_to_front, center_to_rear, stiffness_front, stiffness_rear):

--- a/selfdrive/locationd/models/pose_kf.py
+++ b/selfdrive/locationd/models/pose_kf.py
@@ -12,7 +12,7 @@ if __name__=="__main__":
   from rednose.helpers.ekf_sym import gen_code
   from rednose.helpers.sympy_helpers import euler_rotate, rot_to_euler
 else:
-  from rednose.helpers.ekf_sym_pyx import EKF_sym_pyx
+  from rednose.helpers import EKFSym
 
 EARTH_G = 9.81
 
@@ -102,7 +102,7 @@ class PoseKalman(KalmanFilter):
 
   def __init__(self, generated_dir, max_rewind_age):
     dim_state, dim_state_err = PoseKalman.initial_x.shape[0], PoseKalman.initial_P.shape[0]
-    self.filter = EKF_sym_pyx(generated_dir, self.name, PoseKalman.Q, PoseKalman.initial_x, PoseKalman.initial_P,
+    self.filter = EKFSym(generated_dir, self.name, PoseKalman.Q, PoseKalman.initial_x, PoseKalman.initial_P,
                               dim_state, dim_state_err, max_rewind_age=max_rewind_age)
 
 


### PR DESCRIPTION
**Description**
Update the import in locationd once the related code in rednose has changed. This is part 8 of 10 of the larger PR to fully remove cython from openpilot. It depends on commaai/rednose#53

TODO:
- [ ] Remove the submodule change in this branch once the corresponding PR is merged

**Verification**
`op test selfdrive/locationd` before these changes:
<img width="1077" height="221" alt="image" src="https://github.com/user-attachments/assets/7a180f46-ec9f-41a1-9e57-931652490b8e" />

`op test selfdrive/locationd` after these changes:
<img width="1077" height="221" alt="image" src="https://github.com/user-attachments/assets/c0546131-ddb4-44b1-b6ac-003bd5942625" />
