### PR TITLE
setup: fix uv install fail

### DIFF
--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Increase the pip timeout to handle TimeoutError
 export PIP_DEFAULT_TIMEOUT=200

--- a/tools/install_python_dependencies.sh
+++ b/tools/install_python_dependencies.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 
 if ! command -v "uv" > /dev/null 2>&1; then
   echo "installing uv..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+  curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv/install.sh | sh
   UV_BIN="$HOME/.local/bin"
   PATH="$UV_BIN:$PATH"
 fi

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-
-set -e
+set -euo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
fixes [this](https://github.com/commaai/openpilot/actions/runs/20142044902/job/57812073091) failed CI run:
```bash
Run ./tools/mac_setup.sh
==> Updating Homebrew...
==> Homebrew's analytics have entirely moved to our InfluxDB instance in the EU.
We gather less data than before and have destroyed all Google Analytics data:
  https://docs.brew.sh/Analytics
Please reconsider re-enabling analytics to help our volunteer maintainers with:
  brew analytics on
==> Homebrew is run entirely by unpaid volunteers. Please consider donating:
  https://github.com/Homebrew/brew#donations

Updated 3 taps (hashicorp/tap, homebrew/core and homebrew/cask).
==> New Formulae
mcp-scan: Constrain, log and scan your MCP connections for security vulnerabilities
mistral-vibe: Minimal CLI coding agent
tree-sitter@0.25: Incremental parsing library
==> New Casks
monocle-app: Window dimming utility
==> Outdated Formulae
awscli
bash
c-ares
cmake
deno
gh
glib
libgit2
libgpg-error
libpng
nginx
python@3.13
python@3.14
==> Outdated Casks
chromedriver
codeql
dotnet-sdk

You have 13 outdated formulae and 3 outdated casks installed.
You can upgrade them with brew upgrade
or list them with brew outdated.
Using git-lfs
Installing capnp
Installing coreutils
Installing eigen
Installing ffmpeg
Installing glfw
Using libusb
Using libtool
Using llvm
Installing openssl@3.0
Installing qt@5
Installing zeromq
Installing gcc-arm-embedded
Installing portaudio
Using gcc@13
`brew bundle` complete! 15 Brewfile dependencies now installed.
[ ] finished brew install t=47
installing uv...
curl: (56) The requested URL returned error: 504
updating uv...
/Users/runner/work/openpilot/openpilot/tools/install_python_dependencies.sh: line 20: uv: command not found
installing python packages...
/Users/runner/work/openpilot/openpilot/tools/install_python_dependencies.sh: line 23: uv: command not found
Error: Process completed with exit code 127.
```