### PR TITLE
locationd: fix velocity calibration using wrong pose field

### DIFF
--- a/selfdrive/locationd/helpers.py
+++ b/selfdrive/locationd/helpers.py
@@ -172,7 +172,7 @@ class PoseCalibrator:
     ned_from_calib_euler = self._ned_from_calib(pose.orientation)
     angular_velocity_calib = self._transform_calib_from_device(pose.angular_velocity)
     acceleration_calib = self._transform_calib_from_device(pose.acceleration)
-    velocity_calib = self._transform_calib_from_device(pose.angular_velocity)
+    velocity_calib = self._transform_calib_from_device(pose.velocity)
 
     return Pose(ned_from_calib_euler, velocity_calib, acceleration_calib, angular_velocity_calib)
 


### PR DESCRIPTION
**Title:** `locationd: fix velocity calibration using wrong pose field`

---

**Description**

`PoseCalibrator.build_calibrated_pose()` in `selfdrive/locationd/helpers.py` had a copy-paste bug where `velocity_calib` was being computed from `pose.angular_velocity` instead of `pose.velocity`.

```python
# Before (incorrect)
velocity_calib = self._transform_calib_from_device(pose.angular_velocity)

# After (correct)
velocity_calib = self._transform_calib_from_device(pose.velocity)
```

This caused the calibrated pose to have angular velocity data in the velocity field, affecting downstream consumers like `controlsd`, `selfdrived`, `paramsd`, `torqued`, and `lagd`.

**Verification**

Code review - the fix is straightforward: each calibrated field should transform its corresponding input field:
- `angular_velocity_calib` ← `pose.angular_velocity` 
- `acceleration_calib` ← `pose.acceleration` 
- `velocity_calib` ← `pose.velocity` (was incorrectly using `pose.angular_velocity`)