### PR TITLE
tools: add retry mechanism for API requests (and add tests)

### DIFF
--- a/tools/lib/api.py
+++ b/tools/lib/api.py
@@ -8,7 +8,7 @@ API_HOST = os.getenv('API_HOST', 'https://api.commadotai.com')
 # TODO: this should be merged into common.api
 
 
-class CallbackRetry(Retry):
+class LogCallbackRetry(Retry):
   def increment(self, method=None, url=None, *args, **kwargs):
     if url:
       cloudlog.warning(f"[API Failure] Retrying {method} {url}")
@@ -21,7 +21,7 @@ class CommaApi:
     if token:
       self.session.headers['Authorization'] = 'JWT ' + token
 
-      retries = CallbackRetry(total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+      retries = LogCallbackRetry(total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
       self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
   def request(self, method, endpoint, **kwargs):

--- a/tools/lib/api.py
+++ b/tools/lib/api.py
@@ -1,5 +1,6 @@
 import os
 import requests
+from requests.adapters import HTTPAdapter, Retry
 API_HOST = os.getenv('API_HOST', 'https://api.commadotai.com')
 
 # TODO: this should be merged into common.api
@@ -10,6 +11,9 @@ class CommaApi:
     self.session.headers['User-agent'] = 'OpenpilotTools'
     if token:
       self.session.headers['Authorization'] = 'JWT ' + token
+
+      retries = Retry(total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+      self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
   def request(self, method, endpoint, **kwargs):
     with self.session.request(method, API_HOST + '/' + endpoint, **kwargs) as resp:

--- a/tools/lib/tests/test_api.py
+++ b/tools/lib/tests/test_api.py
@@ -1,80 +1,79 @@
+import pytest
+from openpilot.tools.lib.api import LogCallbackRetry, CommaApi, UnauthorizedError, APIError
 
-import unittest
-from unittest.mock import patch, MagicMock
-from tools.lib.api import CallbackRetry
+class TestLogCallbackRetry:
+  def test_increment_logs_warning(self, mocker):
+    mock_cloudlog = mocker.patch("openpilot.tools.lib.api.cloudlog")
+    retry = LogCallbackRetry(total=1)
 
-class TestCallbackRetry(unittest.TestCase):
-  @patch("tools.lib.api.cloudlog")
-  def test_increment_logs_warning(self, mock_cloudlog):
-    retry = CallbackRetry(total=1)
-
-    # Simulate a retry increment
     retry.increment(method="GET", url="http://test.com")
 
-    # Verify cloudlog.warning was called with specific message
     mock_cloudlog.warning.assert_called_with("[API Failure] Retrying GET http://test.com")
 
-  @patch("tools.lib.api.cloudlog")
-  def test_increment_no_url(self, mock_cloudlog):
-    retry = CallbackRetry(total=1)
+  def test_increment_no_url(self, mocker):
+    mock_cloudlog = mocker.patch("openpilot.tools.lib.api.cloudlog")
+    retry = LogCallbackRetry(total=1)
 
-    # Simulate a retry increment without URL (shouldn't log)
     retry.increment(method="GET")
 
-    # Verify cloudlog.warning was NOT called
     mock_cloudlog.warning.assert_not_called()
 
-class TestCommaApi(unittest.TestCase):
-  def setUp(self):
-    from tools.lib.api import CommaApi
+  def test_retry_configuration(self):
+    from openpilot.tools.lib.api import LogCallbackRetry
+    from requests.adapters import HTTPAdapter
+
+    api = CommaApi(token="test_token")
+    adapter = api.session.adapters['https://']
+    assert isinstance(adapter, HTTPAdapter)
+    assert isinstance(adapter.max_retries, LogCallbackRetry)
+    assert adapter.max_retries.total == 5
+
+
+class TestCommaApi:
+  @pytest.fixture(autouse=True)
+  def setup(self):
     self.api = CommaApi()
 
   def test_init_token(self):
-    from tools.lib.api import CommaApi
     api = CommaApi(token="test_token")
-    self.assertEqual(api.session.headers['Authorization'], 'JWT test_token')
+    assert api.session.headers['Authorization'] == 'JWT test_token'
 
-  @patch("tools.lib.api.requests.Session.request")
-  def test_request_success(self, mock_request):
-    mock_resp = MagicMock()
+  def test_request_success(self, mocker):
+    mock_resp = mocker.MagicMock()
     mock_resp.json.return_value = {"key": "value"}
     mock_resp.status_code = 200
+    mock_request = mocker.patch("openpilot.tools.lib.api.requests.Session.request")
     mock_request.return_value.__enter__.return_value = mock_resp
 
     resp = self.api.request("GET", "test_endpoint")
-    self.assertEqual(resp, {"key": "value"})
+    assert resp == {"key": "value"}
 
-  @patch("tools.lib.api.requests.Session.request")
-  def test_request_unauthorized(self, mock_request):
-    from tools.lib.api import UnauthorizedError
-    mock_resp = MagicMock()
+  def test_request_unauthorized(self, mocker):
+    mock_resp = mocker.MagicMock()
     mock_resp.json.return_value = {"error": "unauthorized"}
     mock_resp.status_code = 401
+    mock_request = mocker.patch("openpilot.tools.lib.api.requests.Session.request")
     mock_request.return_value.__enter__.return_value = mock_resp
 
-    with self.assertRaises(UnauthorizedError):
+    with pytest.raises(UnauthorizedError):
       self.api.request("GET", "test_endpoint")
 
-  @patch("tools.lib.api.requests.Session.request")
-  def test_request_api_error(self, mock_request):
-    from tools.lib.api import APIError
-    mock_resp = MagicMock()
+  def test_request_api_error(self, mocker):
+    mock_resp = mocker.MagicMock()
     mock_resp.json.return_value = {"error": "server error", "description": "details"}
     mock_resp.status_code = 500
+    mock_request = mocker.patch("openpilot.tools.lib.api.requests.Session.request")
     mock_request.return_value.__enter__.return_value = mock_resp
 
-    with self.assertRaises(APIError) as cm:
+    with pytest.raises(APIError) as cm:
       self.api.request("GET", "test_endpoint")
-    self.assertEqual(cm.exception.status_code, 500)
-    self.assertIn("details", str(cm.exception))
+    assert cm.value.status_code == 500
+    assert "details" in str(cm.value)
 
-  @patch("tools.lib.api.CommaApi.request")
-  def test_get_post(self, mock_request):
+  def test_get_post(self, mocker):
+    mock_request = mocker.patch("openpilot.tools.lib.api.CommaApi.request")
     self.api.get("endpoint", param="1")
     mock_request.assert_called_with("GET", "endpoint", param="1")
 
     self.api.post("endpoint", data="2")
     mock_request.assert_called_with("POST", "endpoint", data="2")
-
-if __name__ == "__main__":
-  unittest.main()

--- a/tools/lib/tests/test_api.py
+++ b/tools/lib/tests/test_api.py
@@ -1,0 +1,80 @@
+
+import unittest
+from unittest.mock import patch, MagicMock
+from tools.lib.api import CallbackRetry
+
+class TestCallbackRetry(unittest.TestCase):
+  @patch("tools.lib.api.cloudlog")
+  def test_increment_logs_warning(self, mock_cloudlog):
+    retry = CallbackRetry(total=1)
+
+    # Simulate a retry increment
+    retry.increment(method="GET", url="http://test.com")
+
+    # Verify cloudlog.warning was called with specific message
+    mock_cloudlog.warning.assert_called_with("[API Failure] Retrying GET http://test.com")
+
+  @patch("tools.lib.api.cloudlog")
+  def test_increment_no_url(self, mock_cloudlog):
+    retry = CallbackRetry(total=1)
+
+    # Simulate a retry increment without URL (shouldn't log)
+    retry.increment(method="GET")
+
+    # Verify cloudlog.warning was NOT called
+    mock_cloudlog.warning.assert_not_called()
+
+class TestCommaApi(unittest.TestCase):
+  def setUp(self):
+    from tools.lib.api import CommaApi
+    self.api = CommaApi()
+
+  def test_init_token(self):
+    from tools.lib.api import CommaApi
+    api = CommaApi(token="test_token")
+    self.assertEqual(api.session.headers['Authorization'], 'JWT test_token')
+
+  @patch("tools.lib.api.requests.Session.request")
+  def test_request_success(self, mock_request):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"key": "value"}
+    mock_resp.status_code = 200
+    mock_request.return_value.__enter__.return_value = mock_resp
+
+    resp = self.api.request("GET", "test_endpoint")
+    self.assertEqual(resp, {"key": "value"})
+
+  @patch("tools.lib.api.requests.Session.request")
+  def test_request_unauthorized(self, mock_request):
+    from tools.lib.api import UnauthorizedError
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"error": "unauthorized"}
+    mock_resp.status_code = 401
+    mock_request.return_value.__enter__.return_value = mock_resp
+
+    with self.assertRaises(UnauthorizedError):
+      self.api.request("GET", "test_endpoint")
+
+  @patch("tools.lib.api.requests.Session.request")
+  def test_request_api_error(self, mock_request):
+    from tools.lib.api import APIError
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"error": "server error", "description": "details"}
+    mock_resp.status_code = 500
+    mock_request.return_value.__enter__.return_value = mock_resp
+
+    with self.assertRaises(APIError) as cm:
+      self.api.request("GET", "test_endpoint")
+    self.assertEqual(cm.exception.status_code, 500)
+    self.assertIn("details", str(cm.exception))
+
+  @patch("tools.lib.api.CommaApi.request")
+  def test_get_post(self, mock_request):
+    self.api.get("endpoint", param="1")
+    mock_request.assert_called_with("GET", "endpoint", param="1")
+
+    self.api.post("endpoint", data="2")
+    mock_request.assert_called_with("POST", "endpoint", data="2")
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
**Description**
This PR reopens #36617 and takes into consideration the discussion that happened [in the comments](https://github.com/commaai/openpilot/pull/36617#issuecomment-3604553995) after it had been closed. Since it has not been re-opened in a little while, I figured I would save sunny some work and recreate the PR myself, with the suggestions included. Tests are also added, both for the existing functionality, and the new retry mechanism.

**Verification**
`op test tools/lib` before these changes:
<img width="629" height="24" alt="image" src="https://github.com/user-attachments/assets/4a513cd2-e7ad-4162-9fe1-88b6f395c21d" />

`op test tools/lib` after these changes:
<img width="629" height="24" alt="image" src="https://github.com/user-attachments/assets/ab6c5c9f-6e8c-4adc-941b-06f5d9e03b9d" />
