### PR TITLE
ui: remove lambda closures from translated strings

### DIFF
--- a/selfdrive/ui/layouts/settings/developer.py
+++ b/selfdrive/ui/layouts/settings/developer.py
@@ -6,7 +6,7 @@ from openpilot.system.ui.widgets.list_view import toggle_item
 from openpilot.system.ui.widgets.scroller_tici import Scroller
 from openpilot.system.ui.widgets.confirm_dialog import ConfirmDialog
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.multilang import tr, tr_noop
+from openpilot.system.ui.lib.multilang import tr, tr_lazy, tr_noop
 from openpilot.system.ui.widgets import DialogResult
 
 # Description constants
@@ -36,8 +36,8 @@ class DeveloperLayout(Widget):
 
     # Build items and keep references for callbacks/state updates
     self._adb_toggle = toggle_item(
-      lambda: tr("Enable ADB"),
-      description=lambda: tr(DESCRIPTIONS["enable_adb"]),
+      tr_lazy("Enable ADB"),
+      description=tr_lazy(DESCRIPTIONS["enable_adb"]),
       initial_state=self._params.get_bool("AdbEnabled"),
       callback=self._on_enable_adb,
       enabled=ui_state.is_offroad,
@@ -45,15 +45,15 @@ class DeveloperLayout(Widget):
 
     # SSH enable toggle + SSH key management
     self._ssh_toggle = toggle_item(
-      lambda: tr("Enable SSH"),
+      tr_lazy("Enable SSH"),
       description="",
       initial_state=self._params.get_bool("SshEnabled"),
       callback=self._on_enable_ssh,
     )
-    self._ssh_keys = ssh_key_item(lambda: tr("SSH Keys"), description=lambda: tr(DESCRIPTIONS["ssh_key"]))
+    self._ssh_keys = ssh_key_item(tr_lazy("SSH Keys"), description=tr_lazy(DESCRIPTIONS["ssh_key"]))
 
     self._joystick_toggle = toggle_item(
-      lambda: tr("Joystick Debug Mode"),
+      tr_lazy("Joystick Debug Mode"),
       description="",
       initial_state=self._params.get_bool("JoystickDebugMode"),
       callback=self._on_joystick_debug_mode,
@@ -61,22 +61,22 @@ class DeveloperLayout(Widget):
     )
 
     self._long_maneuver_toggle = toggle_item(
-      lambda: tr("Longitudinal Maneuver Mode"),
+      tr_lazy("Longitudinal Maneuver Mode"),
       description="",
       initial_state=self._params.get_bool("LongitudinalManeuverMode"),
       callback=self._on_long_maneuver_mode,
     )
 
     self._alpha_long_toggle = toggle_item(
-      lambda: tr("openpilot Longitudinal Control (Alpha)"),
-      description=lambda: tr(DESCRIPTIONS["alpha_longitudinal"]),
+      tr_lazy("openpilot Longitudinal Control (Alpha)"),
+      description=tr_lazy(DESCRIPTIONS["alpha_longitudinal"]),
       initial_state=self._params.get_bool("AlphaLongitudinalEnabled"),
       callback=self._on_alpha_long_enabled,
       enabled=lambda: not ui_state.engaged,
     )
 
     self._ui_debug_toggle = toggle_item(
-      lambda: tr("UI Debug Mode"),
+      tr_lazy("UI Debug Mode"),
       description="",
       initial_state=self._params.get_bool("ShowDebugInfo"),
       callback=self._on_enable_ui_debug,

--- a/selfdrive/ui/layouts/settings/device.py
+++ b/selfdrive/ui/layouts/settings/device.py
@@ -11,7 +11,7 @@ from openpilot.selfdrive.ui.layouts.onboarding import TrainingGuide
 from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog
 from openpilot.system.hardware import TICI
 from openpilot.system.ui.lib.application import FontWeight, gui_app
-from openpilot.system.ui.lib.multilang import multilang, tr, tr_noop
+from openpilot.system.ui.lib.multilang import multilang, tr, tr_lazy, tr_noop
 from openpilot.system.ui.widgets import Widget, DialogResult
 from openpilot.system.ui.widgets.confirm_dialog import ConfirmDialog, alert_dialog
 from openpilot.system.ui.widgets.html_render import HtmlModal
@@ -45,27 +45,27 @@ class DeviceLayout(Widget):
     ui_state.add_offroad_transition_callback(self._offroad_transition)
 
   def _initialize_items(self):
-    self._pair_device_btn = button_item(lambda: tr("Pair Device"), lambda: tr("PAIR"), lambda: tr(DESCRIPTIONS['pair_device']), callback=self._pair_device)
+    self._pair_device_btn = button_item(tr_lazy("Pair Device"), tr_lazy("PAIR"), tr_lazy(DESCRIPTIONS['pair_device']), callback=self._pair_device)
     self._pair_device_btn.set_visible(lambda: not ui_state.prime_state.is_paired())
 
-    self._reset_calib_btn = button_item(lambda: tr("Reset Calibration"), lambda: tr("RESET"), lambda: tr(DESCRIPTIONS['reset_calibration']),
+    self._reset_calib_btn = button_item(tr_lazy("Reset Calibration"), tr_lazy("RESET"), tr_lazy(DESCRIPTIONS['reset_calibration']),
                                         callback=self._reset_calibration_prompt)
     self._reset_calib_btn.set_description_opened_callback(self._update_calib_description)
 
-    self._power_off_btn = dual_button_item(lambda: tr("Reboot"), lambda: tr("Power Off"),
+    self._power_off_btn = dual_button_item(tr_lazy("Reboot"), tr_lazy("Power Off"),
                                            left_callback=self._reboot_prompt, right_callback=self._power_off_prompt)
 
     items = [
-      text_item(lambda: tr("Dongle ID"), self._params.get("DongleId") or (lambda: tr("N/A"))),
-      text_item(lambda: tr("Serial"), self._params.get("HardwareSerial") or (lambda: tr("N/A"))),
+      text_item(tr_lazy("Dongle ID"), self._params.get("DongleId") or (tr_lazy("N/A"))),
+      text_item(tr_lazy("Serial"), self._params.get("HardwareSerial") or (tr_lazy("N/A"))),
       self._pair_device_btn,
-      button_item(lambda: tr("Driver Camera"), lambda: tr("PREVIEW"), lambda: tr(DESCRIPTIONS['driver_camera']),
+      button_item(tr_lazy("Driver Camera"), tr_lazy("PREVIEW"), tr_lazy(DESCRIPTIONS['driver_camera']),
                   callback=self._show_driver_camera, enabled=ui_state.is_offroad),
       self._reset_calib_btn,
-      button_item(lambda: tr("Review Training Guide"), lambda: tr("REVIEW"), lambda: tr(DESCRIPTIONS['review_guide']),
+      button_item(tr_lazy("Review Training Guide"), tr_lazy("REVIEW"), tr_lazy(DESCRIPTIONS['review_guide']),
                   self._on_review_training_guide, enabled=ui_state.is_offroad),
-      regulatory_btn := button_item(lambda: tr("Regulatory"), lambda: tr("VIEW"), callback=self._on_regulatory, enabled=ui_state.is_offroad),
-      button_item(lambda: tr("Change Language"), lambda: tr("CHANGE"), callback=self._show_language_dialog),
+      regulatory_btn := button_item(tr_lazy("Regulatory"), tr_lazy("VIEW"), callback=self._on_regulatory, enabled=ui_state.is_offroad),
+      button_item(tr_lazy("Change Language"), tr_lazy("CHANGE"), callback=self._show_language_dialog),
       self._power_off_btn,
     ]
     regulatory_btn.set_visible(TICI)

--- a/selfdrive/ui/layouts/settings/software.py
+++ b/selfdrive/ui/layouts/settings/software.py
@@ -4,7 +4,7 @@ import datetime
 from openpilot.common.time_helpers import system_time_valid
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.multilang import tr, trn
+from openpilot.system.ui.lib.multilang import tr, tr_lazy, trn
 from openpilot.system.ui.widgets import Widget, DialogResult
 from openpilot.system.ui.widgets.confirm_dialog import ConfirmDialog
 from openpilot.system.ui.widgets.list_view import button_item, text_item, ListItem
@@ -52,12 +52,12 @@ class SoftwareLayout(Widget):
   def __init__(self):
     super().__init__()
 
-    self._onroad_label = ListItem(lambda: tr("Updates are only downloaded while the car is off."))
-    self._version_item = text_item(lambda: tr("Current Version"), ui_state.params.get("UpdaterCurrentDescription") or "")
-    self._download_btn = button_item(lambda: tr("Download"), lambda: tr("CHECK"), callback=self._on_download_update)
+    self._onroad_label = ListItem(tr_lazy("Updates are only downloaded while the car is off."))
+    self._version_item = text_item(tr_lazy("Current Version"), ui_state.params.get("UpdaterCurrentDescription") or "")
+    self._download_btn = button_item(tr_lazy("Download"), tr_lazy("CHECK"), callback=self._on_download_update)
 
     # Install button is initially hidden
-    self._install_btn = button_item(lambda: tr("Install Update"), lambda: tr("INSTALL"), callback=self._on_install_update)
+    self._install_btn = button_item(tr_lazy("Install Update"), tr_lazy("INSTALL"), callback=self._on_install_update)
     self._install_btn.set_visible(False)
 
     # Track waiting-for-updater transition to avoid brief re-enable while still idle
@@ -65,7 +65,7 @@ class SoftwareLayout(Widget):
     self._waiting_start_ts: float = 0.0
 
     # Branch switcher
-    self._branch_btn = button_item(lambda: tr("Target Branch"), lambda: tr("SELECT"), callback=self._on_select_branch)
+    self._branch_btn = button_item(tr_lazy("Target Branch"), tr_lazy("SELECT"), callback=self._on_select_branch)
     self._branch_btn.set_visible(not ui_state.params.get_bool("IsTestedBranch"))
     self._branch_btn.action_item.set_value(ui_state.params.get("UpdaterTargetBranch") or "")
     self._branch_dialog: MultiOptionDialog | None = None
@@ -76,7 +76,7 @@ class SoftwareLayout(Widget):
       self._download_btn,
       self._install_btn,
       self._branch_btn,
-      button_item(lambda: tr("Uninstall"), lambda: tr("UNINSTALL"), callback=self._on_uninstall),
+      button_item(tr_lazy("Uninstall"), tr_lazy("UNINSTALL"), callback=self._on_uninstall),
     ], line_separator=True, spacing=0)
 
   def show_event(self):

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -5,7 +5,7 @@ from openpilot.system.ui.widgets.list_view import multiple_button_item, toggle_i
 from openpilot.system.ui.widgets.scroller_tici import Scroller
 from openpilot.system.ui.widgets.confirm_dialog import ConfirmDialog
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.multilang import tr, tr_noop
+from openpilot.system.ui.lib.multilang import tr, tr_lazy, tr_noop
 from openpilot.system.ui.widgets import DialogResult
 from openpilot.selfdrive.ui.ui_state import ui_state
 
@@ -43,49 +43,49 @@ class TogglesLayout(Widget):
     # param, title, desc, icon, needs_restart
     self._toggle_defs = {
       "OpenpilotEnabledToggle": (
-        lambda: tr("Enable openpilot"),
+        tr_lazy("Enable openpilot"),
         DESCRIPTIONS["OpenpilotEnabledToggle"],
         "chffr_wheel.png",
         True,
       ),
       "ExperimentalMode": (
-        lambda: tr("Experimental Mode"),
+        tr_lazy("Experimental Mode"),
         "",
         "experimental_white.png",
         False,
       ),
       "DisengageOnAccelerator": (
-        lambda: tr("Disengage on Accelerator Pedal"),
+        tr_lazy("Disengage on Accelerator Pedal"),
         DESCRIPTIONS["DisengageOnAccelerator"],
         "disengage_on_accelerator.png",
         False,
       ),
       "IsLdwEnabled": (
-        lambda: tr("Enable Lane Departure Warnings"),
+        tr_lazy("Enable Lane Departure Warnings"),
         DESCRIPTIONS["IsLdwEnabled"],
         "warning.png",
         False,
       ),
       "AlwaysOnDM": (
-        lambda: tr("Always-On Driver Monitoring"),
+        tr_lazy("Always-On Driver Monitoring"),
         DESCRIPTIONS["AlwaysOnDM"],
         "monitoring.png",
         False,
       ),
       "RecordFront": (
-        lambda: tr("Record and Upload Driver Camera"),
+        tr_lazy("Record and Upload Driver Camera"),
         DESCRIPTIONS["RecordFront"],
         "monitoring.png",
         True,
       ),
       "RecordAudio": (
-        lambda: tr("Record and Upload Microphone Audio"),
+        tr_lazy("Record and Upload Microphone Audio"),
         DESCRIPTIONS["RecordAudio"],
         "microphone.png",
         True,
       ),
       "IsMetric": (
-        lambda: tr("Use Metric System"),
+        tr_lazy("Use Metric System"),
         DESCRIPTIONS["IsMetric"],
         "metric.png",
         False,
@@ -93,9 +93,9 @@ class TogglesLayout(Widget):
     }
 
     self._long_personality_setting = multiple_button_item(
-      lambda: tr("Driving Personality"),
-      lambda: tr(DESCRIPTIONS["LongitudinalPersonality"]),
-      buttons=[lambda: tr("Aggressive"), lambda: tr("Standard"), lambda: tr("Relaxed")],
+      tr_lazy("Driving Personality"),
+      tr_lazy(DESCRIPTIONS["LongitudinalPersonality"]),
+      buttons=[tr_lazy("Aggressive"), tr_lazy("Standard"), tr_lazy("Relaxed")],
       button_width=255,
       callback=self._set_longitudinal_personality,
       selected_index=self._params.get("LongitudinalPersonality", return_default=True),

--- a/selfdrive/ui/update_translations.py
+++ b/selfdrive/ui/update_translations.py
@@ -19,7 +19,7 @@ def update_translations():
         files.append(os.path.relpath(os.path.join(root, filename), BASEDIR))
 
   # Create main translation file
-  cmd = ("xgettext -L Python --keyword=tr --keyword=trn:1,2 --keyword=tr_noop --from-code=UTF-8 " +
+  cmd = ("xgettext -L Python --keyword=tr --keyword=trn:1,2 --keyword=tr_noop --keyword=tr_lazy --from-code=UTF-8 " +
          "--flag=tr:1:python-brace-format --flag=trn:1:python-brace-format --flag=trn:2:python-brace-format " +
          f"-D {BASEDIR} -o {POT_FILE} {' '.join(files)}")
 

--- a/selfdrive/ui/widgets/offroad_alerts.py
+++ b/selfdrive/ui/widgets/offroad_alerts.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from openpilot.common.params import Params
 from openpilot.system.hardware import HARDWARE
 from openpilot.system.ui.lib.application import gui_app, FontWeight, FONT_SCALE
-from openpilot.system.ui.lib.multilang import tr
+from openpilot.system.ui.lib.multilang import tr, tr_lazy
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.wrap_text import wrap_text
@@ -101,15 +101,15 @@ class AbstractAlert(Widget, ABC):
       if self.dismiss_callback:
         self.dismiss_callback()
 
-    self.dismiss_btn = ActionButton(lambda: tr("Close"))
+    self.dismiss_btn = ActionButton(tr_lazy("Close"))
 
-    self.snooze_btn = ActionButton(lambda: tr("Snooze Update"), style=ButtonStyle.DARK)
+    self.snooze_btn = ActionButton(tr_lazy("Snooze Update"), style=ButtonStyle.DARK)
     self.snooze_btn.set_click_callback(snooze_callback)
 
-    self.excessive_actuation_btn = ActionButton(lambda: tr("Acknowledge Excessive Actuation"), style=ButtonStyle.DARK, min_width=800)
+    self.excessive_actuation_btn = ActionButton(tr_lazy("Acknowledge Excessive Actuation"), style=ButtonStyle.DARK, min_width=800)
     self.excessive_actuation_btn.set_click_callback(excessive_actuation_callback)
 
-    self.reboot_btn = ActionButton(lambda: tr("Reboot and Update"), min_width=600)
+    self.reboot_btn = ActionButton(tr_lazy("Reboot and Update"), min_width=600)
     self.reboot_btn.set_click_callback(lambda: HARDWARE.reboot())
 
     # TODO: just use a Scroller?

--- a/selfdrive/ui/widgets/setup.py
+++ b/selfdrive/ui/widgets/setup.py
@@ -3,7 +3,7 @@ from openpilot.common.time_helpers import system_time_valid
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog
 from openpilot.system.ui.lib.application import gui_app, FontWeight, FONT_SCALE
-from openpilot.system.ui.lib.multilang import tr
+from openpilot.system.ui.lib.multilang import tr, tr_lazy
 from openpilot.system.ui.lib.wrap_text import wrap_text
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.confirm_dialog import alert_dialog
@@ -16,10 +16,10 @@ class SetupWidget(Widget):
     super().__init__()
     self._open_settings_callback = None
     self._pairing_dialog: PairingDialog | None = None
-    self._pair_device_btn = Button(lambda: tr("Pair device"), self._show_pairing, button_style=ButtonStyle.PRIMARY)
-    self._open_settings_btn = Button(lambda: tr("Open"), lambda: self._open_settings_callback() if self._open_settings_callback else None,
+    self._pair_device_btn = Button(tr_lazy("Pair device"), self._show_pairing, button_style=ButtonStyle.PRIMARY)
+    self._open_settings_btn = Button(tr_lazy("Open"), lambda: self._open_settings_callback() if self._open_settings_callback else None,
                                      button_style=ButtonStyle.PRIMARY)
-    self._firehose_label = Label(lambda: tr("🔥 Firehose Mode 🔥"), font_weight=FontWeight.MEDIUM, font_size=64)
+    self._firehose_label = Label(tr_lazy("🔥 Firehose Mode 🔥"), font_weight=FontWeight.MEDIUM, font_size=64)
 
   def set_open_settings_callback(self, callback):
     self._open_settings_callback = callback

--- a/system/ui/lib/multilang.py
+++ b/system/ui/lib/multilang.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+from functools import partial
 from importlib.resources import files
 import os
 import json
@@ -82,6 +84,8 @@ multilang.setup()
 
 tr, trn = multilang.tr, multilang.trn
 
+def tr_lazy(text: str) -> Callable[[], str]:
+  return partial(tr, text)
 
 # no-op marker for static strings translated later
 def tr_noop(s: str) -> str:

--- a/system/ui/widgets/keyboard.py
+++ b/system/ui/widgets/keyboard.py
@@ -5,7 +5,7 @@ from typing import Literal
 import pyray as rl
 
 from openpilot.system.ui.lib.application import gui_app, FontWeight
-from openpilot.system.ui.lib.multilang import tr
+from openpilot.system.ui.lib.multilang import tr_lazy
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.button import ButtonStyle, Button
 from openpilot.system.ui.widgets.inputbox import InputBox
@@ -78,7 +78,7 @@ class Keyboard(Widget):
     self._backspace_last_repeat: float = 0.0
 
     self._render_return_status = -1
-    self._cancel_button = Button(lambda: tr("Cancel"), self._cancel_button_callback)
+    self._cancel_button = Button(tr_lazy("Cancel"), self._cancel_button_callback)
 
     self._eye_button = Button("", self._eye_button_callback, button_style=ButtonStyle.TRANSPARENT)
 

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import pyray as rl
 from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.lib.multilang import tr
+from openpilot.system.ui.lib.multilang import tr, tr_lazy
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.wifi_manager import WifiManager, SecurityType, Network, MeteredType
 from openpilot.system.ui.widgets import Widget
@@ -117,42 +117,42 @@ class AdvancedNetworkSettings(Widget):
 
     # Tethering
     self._tethering_action = ToggleAction(initial_state=False)
-    tethering_btn = ListItem(lambda: tr("Enable Tethering"), action_item=self._tethering_action, callback=self._toggle_tethering)
+    tethering_btn = ListItem(tr_lazy("Enable Tethering"), action_item=self._tethering_action, callback=self._toggle_tethering)
 
     # Edit tethering password
-    self._tethering_password_action = ButtonAction(lambda: tr("EDIT"))
-    tethering_password_btn = ListItem(lambda: tr("Tethering Password"), action_item=self._tethering_password_action, callback=self._edit_tethering_password)
+    self._tethering_password_action = ButtonAction(tr_lazy("EDIT"))
+    tethering_password_btn = ListItem(tr_lazy("Tethering Password"), action_item=self._tethering_password_action, callback=self._edit_tethering_password)
 
     # Roaming toggle
     roaming_enabled = self._params.get_bool("GsmRoaming")
     self._roaming_action = ToggleAction(initial_state=roaming_enabled)
-    self._roaming_btn = ListItem(lambda: tr("Enable Roaming"), action_item=self._roaming_action, callback=self._toggle_roaming)
+    self._roaming_btn = ListItem(tr_lazy("Enable Roaming"), action_item=self._roaming_action, callback=self._toggle_roaming)
 
     # Cellular metered toggle
     cellular_metered = self._params.get_bool("GsmMetered")
     self._cellular_metered_action = ToggleAction(initial_state=cellular_metered)
-    self._cellular_metered_btn = ListItem(lambda: tr("Cellular Metered"),
-                                          description=lambda: tr("Prevent large data uploads when on a metered cellular connection"),
+    self._cellular_metered_btn = ListItem(tr_lazy("Cellular Metered"),
+                                          description=tr_lazy("Prevent large data uploads when on a metered cellular connection"),
                                           action_item=self._cellular_metered_action, callback=self._toggle_cellular_metered)
 
     # APN setting
-    self._apn_btn = button_item(lambda: tr("APN Setting"), lambda: tr("EDIT"), callback=self._edit_apn)
+    self._apn_btn = button_item(tr_lazy("APN Setting"), tr_lazy("EDIT"), callback=self._edit_apn)
 
     # Wi-Fi metered toggle
-    self._wifi_metered_action = MultipleButtonAction([lambda: tr("default"), lambda: tr("metered"), lambda: tr("unmetered")], 255, 0,
+    self._wifi_metered_action = MultipleButtonAction([tr_lazy("default"), tr_lazy("metered"), tr_lazy("unmetered")], 255, 0,
                                                      callback=self._toggle_wifi_metered)
-    wifi_metered_btn = ListItem(lambda: tr("Wi-Fi Network Metered"), description=lambda: tr("Prevent large data uploads when on a metered Wi-Fi connection"),
+    wifi_metered_btn = ListItem(tr_lazy("Wi-Fi Network Metered"), description=tr_lazy("Prevent large data uploads when on a metered Wi-Fi connection"),
                                 action_item=self._wifi_metered_action)
 
     items: list[Widget] = [
       tethering_btn,
       tethering_password_btn,
-      text_item(lambda: tr("IP Address"), lambda: self._wifi_manager.ipv4_address),
+      text_item(tr_lazy("IP Address"), lambda: self._wifi_manager.ipv4_address),
       self._roaming_btn,
       self._apn_btn,
       self._cellular_metered_btn,
       wifi_metered_btn,
-      button_item(lambda: tr("Hidden Network"), lambda: tr("CONNECT"), callback=self._connect_to_hidden_network),
+      button_item(tr_lazy("Hidden Network"), tr_lazy("CONNECT"), callback=self._connect_to_hidden_network),
     ]
 
     self._scroller = Scroller(items, line_separator=True, spacing=0)

--- a/system/ui/widgets/option_dialog.py
+++ b/system/ui/widgets/option_dialog.py
@@ -1,6 +1,6 @@
 import pyray as rl
 from openpilot.system.ui.lib.application import FontWeight
-from openpilot.system.ui.lib.multilang import tr
+from openpilot.system.ui.lib.multilang import tr_lazy
 from openpilot.system.ui.widgets import Widget, DialogResult
 from openpilot.system.ui.widgets.button import Button, ButtonStyle
 from openpilot.system.ui.widgets.label import gui_label
@@ -32,8 +32,8 @@ class MultiOptionDialog(Widget):
                                   text_padding=50, elide_right=True) for option in options]
     self.scroller = Scroller(self.option_buttons, spacing=LIST_ITEM_SPACING)
 
-    self.cancel_button = Button(lambda: tr("Cancel"), click_callback=lambda: self._set_result(DialogResult.CANCEL))
-    self.select_button = Button(lambda: tr("Select"), click_callback=lambda: self._set_result(DialogResult.CONFIRM), button_style=ButtonStyle.PRIMARY)
+    self.cancel_button = Button(tr_lazy("Cancel"), click_callback=lambda: self._set_result(DialogResult.CANCEL))
+    self.select_button = Button(tr_lazy("Select"), click_callback=lambda: self._set_result(DialogResult.CONFIRM), button_style=ButtonStyle.PRIMARY)
 
   def _set_result(self, result: DialogResult):
     self._result = result


### PR DESCRIPTION
This PR replaces all `lambda: tr("...")` patterns with a cleaner, partial-based lazy translation helper:
```Python

def tr_lazy(text: str) -> Callable[[], str]:
  return partial(tr, text)

```

Usage: `tr_lazy("text")` instead of `lambda: tr("text")`.
Behavior is identical — translation remains lazy and updates correctly on language change.

This removes unnecessary lambdas and closures and aligns the UI with common, Pythonic lazy-translation patterns. It also enables easy future optimization: if we want to optimize render performance (e.g., to run the UI at 60 Hz), the helper can be upgraded to cache per-language results and achieve zero per-frame overhead without changing UI code, for example:

```Python
class LazyTr:
    ...
    def __call__(self):
        if self._lang != multilang.language:
            self._cache = tr(self.key)
            self._lang = multilang.language
        return self._cache

def tr_lazy(text): return LazyTr(text)
```

In render(), this avoids repeated calls into the translation layer and is significantly faster than calling multilang.tr(text) on every frame.
