### PR TITLE
comma four: fix WiFi panel not starting at the top

### DIFF
--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -246,7 +246,8 @@ class Scroller(Widget):
   def show_event(self):
     super().show_event()
     if self._reset_scroll_at_show:
-      self.scroll_to(self.scroll_panel.get_offset())
+      # self.scroll_to(self.scroll_panel.get_offset())
+      self.scroll_panel.set_offset(0.0)
 
     for item in self._items:
       item.show_event()

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -246,7 +246,6 @@ class Scroller(Widget):
   def show_event(self):
     super().show_event()
     if self._reset_scroll_at_show:
-      # self.scroll_to(self.scroll_panel.get_offset())
       self.scroll_panel.set_offset(0.0)
 
     for item in self._items:


### PR DESCRIPTION
Sometimes it would start near the bottom

<img width="539" height="241" alt="image" src="https://github.com/user-attachments/assets/02af5620-e38f-4a44-a514-c852d285d4c9" />
