### PR TITLE
sim: fix macOS MetaDrive support

### DIFF
--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -209,7 +209,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-  unblock_stdout()
+  # Skip unblock_stdout on macOS - os.forkpty() causes crashes with raylib/AppKit
+  if sys.platform != 'darwin':
+    unblock_stdout()
 
   try:
     main()


### PR DESCRIPTION
Fix MetaDrive simulator support on macOS. Two issues prevented the simulator from running:

  1. **processNotRunning errors**: `logcatd` and `proclogd` are Android-only processes that trigger engagement-blocking errors on macOS. These are now blocked in the simulation launch script.

  2. **CoreFoundation fork crash**: After the Qt→raylib UI migration, `os.forkpty()` in `unblock_stdout()` crashes on macOS because CoreFoundation/AppKit doesn't allow fork() after initialization. This is now skipped on macOS.

  Related bounty: [Get MetaDrive simulator working on macOS](https://github.com/commaai/openpilot/issues/33207)

  **Verification**

  Tested on macOS 14 (M3):
  - MetaDrive simulator launches successfully
  - openpilot UI displays correctly with `BIG=1`
  - openpilot engages and drives in simulation
  - Verified simulation completes laps without crashes

  **Known Issue**

  Camera view has a rendering artifact (diagonal distortion in corner) - this is an upstream panda3d/MetaDrive issue on macOS, not an openpilot bug.