### PR TITLE
test_onroad: relax memory threshold

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -289,7 +289,7 @@ class TestOnroad:
 
     # check for big leaks. note that memory usage is
     # expected to go up while the MSGQ buffers fill up
-    assert np.average(mems) <= 65, "Average memory usage too high"
+    assert np.average(mems) <= 80, "Average memory usage too high"
     assert np.max(np.diff(mems)) <= 4, "Max memory increase too high"
     assert np.average(np.diff(mems)) <= 1, "Average memory increase too high"
 


### PR DESCRIPTION
I aggressively reduced this in https://github.com/commaai/openpilot/pull/36884, but it's possible (and perhaps likely) that there's some non-openpilot Ubuntu services contributed a lot of noise to this test.

Failure on master:
```python
=========================== short test summary info ============================

FAILED selfdrive/test/test_onroad.py::TestOnroad::test_memory_usage - AssertionError: Average memory usage too high

assert np.float64(66.0) <= 65

 +  where np.float64(66.0) = <function average at 0x7f8ea97af0>([66, 66, 66, 66, 66, 66, ...])

 +    where <function average at 0x7f8ea97af0> = np.average

======== 1 failed, 13 passed, 1 skipped, 101 subtests passed in 46.17s =========
```