### PR TITLE
ui: override default interactive timeout

### DIFF
--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -221,6 +221,14 @@ class TrainingGuide(Widget):
       TrainingGuideRecordFront(continue_callback=on_continue),
     ]
 
+  def show_event(self):
+    super().show_event()
+    device.set_override_interactive_timeout(300)
+
+  def hide_event(self):
+    super().hide_event()
+    device.set_override_interactive_timeout(None)
+
   def _advance_step(self):
     if self._step < len(self._steps) - 1:
       self._step += 1

--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -96,7 +96,6 @@ class TrainingGuideDMTutorial(Widget):
     # Wrap the continue callback to restore settings
     def wrapped_continue_callback():
       device.set_offroad_brightness(None)
-      device.reset_interactive_timeout()
       continue_callback()
 
     self._dialog = DriverCameraSetupDialog(wrapped_continue_callback)
@@ -112,7 +111,6 @@ class TrainingGuideDMTutorial(Widget):
     self._dialog.show_event()
 
     device.set_offroad_brightness(100)
-    device.reset_interactive_timeout(300)  # 5 minutes
 
   def _update_state(self):
     super()._update_state()
@@ -318,6 +316,14 @@ class OnboardingWindow(Widget):
     self._terms = TermsPage(on_accept=self._on_terms_accepted, on_decline=self._on_terms_declined)
     self._training_guide = TrainingGuide(completed_callback=self._on_completed_training)
     self._decline_page = DeclinePage(back_callback=self._on_decline_back)
+
+  def show_event(self):
+    super().show_event()
+    device.set_override_interactive_timeout(300)
+
+  def hide_event(self):
+    super().hide_event()
+    device.set_override_interactive_timeout(None)
 
   @property
   def completed(self) -> bool:

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -51,14 +51,14 @@ class DriverCameraDialog(NavWidget):
     super().show_event()
     ui_state.params.put_bool("IsDriverViewEnabled", True)
     self._publish_alert_sound(None)
-    device.reset_interactive_timeout(300)
+    device.set_override_interactive_timeout(300)
     ui_state.params.remove("DriverTooDistracted")
     self._pm = messaging.PubMaster(['selfdriveState'])
 
   def hide_event(self):
     super().hide_event()
     ui_state.params.put_bool("IsDriverViewEnabled", False)
-    device.reset_interactive_timeout()
+    device.set_override_interactive_timeout(None)
 
   def _handle_mouse_release(self, _):
     ui_state.params.remove("DriverTooDistracted")

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -187,6 +187,7 @@ class Device:
   def __init__(self):
     self._ignition = False
     self._interaction_time: float = -1
+    self._override_interactive_timeout: int | None = None
     self._interactive_timeout_callbacks: list[Callable] = []
     self._prev_timed_out = False
     self._awake: bool = True
@@ -200,11 +201,21 @@ class Device:
   def awake(self) -> bool:
     return self._awake
 
-  def reset_interactive_timeout(self, timeout: int = -1) -> None:
-    if timeout == -1:
-      ignition_timeout = 10 if gui_app.big_ui() else 5
-      timeout = ignition_timeout if ui_state.ignition else 30
-    self._interaction_time = time.monotonic() + timeout
+  def set_override_interactive_timeout(self, timeout: int | None) -> None:
+    # Override the interactive timeout duration temporarily
+    self._override_interactive_timeout = timeout
+    self.reset_interactive_timeout()
+
+  @property
+  def interactive_timeout(self) -> int:
+    if self._override_interactive_timeout is not None:
+      return self._override_interactive_timeout
+
+    ignition_timeout = 10 if gui_app.big_ui() else 5
+    return ignition_timeout if ui_state.ignition else 30
+
+  def reset_interactive_timeout(self) -> None:
+    self._interaction_time = time.monotonic() + self.interactive_timeout
 
   def add_interactive_timeout_callback(self, callback: Callable):
     self._interactive_timeout_callbacks.append(callback)

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -204,7 +204,7 @@ class Device:
   def set_override_interactive_timeout(self, timeout: int | None) -> None:
     # Override the interactive timeout duration temporarily
     self._override_interactive_timeout = timeout
-    self.reset_interactive_timeout()
+    self._reset_interactive_timeout()
 
   @property
   def interactive_timeout(self) -> int:
@@ -214,7 +214,7 @@ class Device:
     ignition_timeout = 10 if gui_app.big_ui() else 5
     return ignition_timeout if ui_state.ignition else 30
 
-  def reset_interactive_timeout(self) -> None:
+  def _reset_interactive_timeout(self) -> None:
     self._interaction_time = time.monotonic() + self.interactive_timeout
 
   def add_interactive_timeout_callback(self, callback: Callable):
@@ -223,7 +223,7 @@ class Device:
   def update(self):
     # do initial reset
     if self._interaction_time <= 0:
-      self.reset_interactive_timeout()
+      self._reset_interactive_timeout()
 
     self._update_brightness()
     self._update_wakefulness()
@@ -263,7 +263,7 @@ class Device:
     self._ignition = ui_state.ignition
 
     if ignition_just_turned_off or any(ev.left_down for ev in gui_app.mouse_events):
-      self.reset_interactive_timeout()
+      self._reset_interactive_timeout()
 
     interaction_timeout = time.monotonic() > self._interaction_time
     if interaction_timeout and not self._prev_timed_out:

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -18,7 +18,6 @@ from openpilot.common.utils import run_cmd
 from openpilot.system.hardware import HARDWARE
 from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.wifi_manager import WifiManager
-from openpilot.selfdrive.ui.ui_state import device
 from openpilot.system.ui.lib.scroll_panel2 import GuiScrollPanel2
 from openpilot.system.ui.widgets import Widget, DialogResult
 from openpilot.system.ui.widgets.button import (IconButton, SmallButton, WideRoundedButton, SmallerRoundedButton,
@@ -225,10 +224,6 @@ class TermsPage(Widget):
     self._back_button.set_enabled(False)
     self._back_button.set_opacity(0.0)
     self._scroll_down_indicator.set_opacity(1.0)
-
-  def show_event(self):
-    super().show_event()
-    device.reset_interactive_timeout(300)
 
   @property
   @abstractmethod


### PR DESCRIPTION
for https://github.com/commaai/openpilot/pull/36896

so clicking while in the dm dialog doesn't reset the timeout back to 30s, this sets to 5m until close as you expect