### PR TITLE
WifiUi: bigger selected size

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -100,6 +100,8 @@ class WifiItem(BigDialogOptionButton):
     self._wifi_icon.set_current_network(network)
 
   def _render(self, _):
+    # rl.draw_rectangle_lines_ex(self._rect, 1, rl.RED)
+
     if self._network.is_connected:
       selected_x = int(self._rect.x - self._selected_txt.width / 2)
       selected_y = int(self._rect.y + (self._rect.height - self._selected_txt.height) / 2)

--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -275,7 +275,7 @@ class BigInputDialog(BigDialogBase):
 
 class BigDialogOptionButton(Widget):
   HEIGHT = 64
-  SELECTED_HEIGHT = 74
+  SELECTED_HEIGHT = 90
 
   def __init__(self, option: str):
     super().__init__()


### PR DESCRIPTION
<img width="1071" height="239" alt="image" src="https://github.com/user-attachments/assets/b8ac1948-17b8-463b-9b93-0b4bcc32241b" />

Instead of https://github.com/commaai/openpilot/pull/36904