### PR TITLE
CI: tmp disable macOS due to brew bug

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,6 +91,7 @@ jobs:
 
   build_mac:
     name: build macOS
+    if: false # tmp disable due to brew install not working
     runs-on: ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-macos-8x14' || 'macos-latest' }}
     steps:
     - uses: actions/checkout@v4

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -6,7 +6,7 @@ ROOT="$(cd $DIR/../ && pwd)"
 ARCH=$(uname -m)
 
 # homebrew update is slow
-export HOMEBREW_NO_AUTO_UPDATE=1
+#export HOMEBREW_NO_AUTO_UPDATE=1
 
 if [[ $SHELL == "/bin/zsh" ]]; then
   RC_FILE="$HOME/.zshrc"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -7,6 +7,8 @@ ARCH=$(uname -m)
 
 # homebrew update is slow
 #export HOMEBREW_NO_AUTO_UPDATE=1
+brew update
+brew doctor
 
 if [[ $SHELL == "/bin/zsh" ]]; then
   RC_FILE="$HOME/.zshrc"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ROOT="$(cd $DIR/../ && pwd)"
 ARCH=$(uname -m)
 
 # homebrew update is slow
-#export HOMEBREW_NO_AUTO_UPDATE=1
-brew update
-brew doctor
+export HOMEBREW_NO_AUTO_UPDATE=1
 
 if [[ $SHELL == "/bin/zsh" ]]; then
   RC_FILE="$HOME/.zshrc"

--- a/tools/mac_setup.sh
+++ b/tools/mac_setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -x
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ROOT="$(cd $DIR/../ && pwd)"


### PR DESCRIPTION
Last ~10 commits on master failed with:
```bash
Installing gcc-arm-embedded
==> Downloading https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-darwin-arm64-arm-none-eabi.pkg
Installing gcc-arm-embedded has failed!
Error: :user_agent must be :browser/:fake, :default, or a String
/opt/homebrew/Library/Homebrew/utils/curl.rb:124:in 'Utils::Curl#curl_args'
/opt/homebrew/Library/Homebrew/utils/curl.rb:179:in 'Utils::Curl#curl_with_workarounds'
/opt/homebrew/Library/Homebrew/utils/curl.rb:269:in 'Utils::Curl#curl_output'
/opt/homebrew/Library/Homebrew/download_strategy.rb:672:in 'CurlDownloadStrategy#curl_output'
/opt/homebrew/Library/Homebrew/utils/curl.rb:585:in 'Utils::Curl#curl_version'
/opt/homebrew/Library/Homebrew/utils/curl.rb:290:in 'Utils::Curl#curl_headers'
/opt/homebrew/Library/Homebrew/download_strategy.rb:560:in 'CurlDownloadStrategy#resolve_url_basename_time_file_size'
/opt/homebrew/Library/Homebrew/download_strategy.rb:476:in 'CurlDownloadStrategy#fetch'
/opt/homebrew/Library/Homebrew/downloadable.rb:139:in 'Downloadable#fetch'
/opt/homebrew/Library/Homebrew/cask/download.rb:57:in 'Cask::Download#fetch'
/opt/homebrew/Library/Homebrew/cask/installer.rb:249:in 'Cask::Installer#download'
/opt/homebrew/Library/Homebrew/cask/installer.rb:121:in 'Cask::Installer#fetch'
/opt/homebrew/Library/Homebrew/cask/installer.rb:153:in 'Cask::Installer#install'
/opt/homebrew/Library/Homebrew/cmd/install.rb:291:in 'block in Homebrew::Cmd::InstallCmd#run'
/opt/homebrew/Library/Homebrew/cmd/install.rb:280:in 'Array#each'
/opt/homebrew/Library/Homebrew/cmd/install.rb:280:in 'Homebrew::Cmd::InstallCmd#run'
/opt/homebrew/Library/Homebrew/brew.rb:101:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
Installing portaudio
Using gcc@13
`brew bundle` failed! 1 Brewfile dependency failed to install
Error: Process completed with exit code 1.
```