### PR TITLE
feat(esim): remove bootstrap

### DIFF
--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -67,10 +67,6 @@ class ThermalConfig:
 
 class LPABase(ABC):
   @abstractmethod
-  def bootstrap(self) -> None:
-    pass
-
-  @abstractmethod
   def list_profiles(self) -> list[Profile]:
     pass
 

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -3,32 +3,10 @@
 import argparse
 import time
 from openpilot.system.hardware import HARDWARE
-from openpilot.system.hardware.base import LPABase
-
-
-def bootstrap(lpa: LPABase) -> None:
-  print('┌──────────────────────────────────────────────────────────────────────────────┐')
-  print('│ WARNING, PLEASE READ BEFORE PROCEEDING                                       │')
-  print('│                                                                              │')
-  print('│ this is an irreversible operation that will remove the comma-provisioned     │')
-  print('│ profile.                                                                     │')
-  print('│                                                                              │')
-  print('│ after this operation, you must purchase a new eSIM from comma in order to    │')
-  print('│ use the comma prime subscription again.                                      │')
-  print('└──────────────────────────────────────────────────────────────────────────────┘')
-  print()
-  for severity in ('sure', '100% sure'):
-    print(f'are you {severity} you want to proceed? (y/N) ', end='')
-    confirm = input()
-    if confirm != 'y':
-      print('aborting')
-      exit(0)
-  lpa.bootstrap()
 
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')
-  parser.add_argument('--bootstrap', action='store_true', help='bootstrap the eUICC (required before downloading profiles)')
   parser.add_argument('--backend', choices=['qmi', 'at'], default='qmi', help='use the specified backend, defaults to qmi')
   parser.add_argument('--switch', metavar='iccid', help='switch to profile')
   parser.add_argument('--delete', metavar='iccid', help='delete profile (warning: this cannot be undone)')
@@ -38,10 +16,7 @@ if __name__ == '__main__':
 
   mutated = False
   lpa = HARDWARE.get_sim_lpa()
-  if args.bootstrap:
-    bootstrap(lpa)
-    mutated = True
-  elif args.switch:
+  if args.switch:
     lpa.switch_profile(args.switch)
     mutated = True
   elif args.delete:

--- a/system/hardware/tici/esim.py
+++ b/system/hardware/tici/esim.py
@@ -40,7 +40,6 @@ class TiciLPA(LPABase):
     self._process_notifications()
 
   def download_profile(self, qr: str, nickname: str | None = None) -> None:
-    self._check_bootstrapped()
     msgs = self._invoke('profile', 'download', '-a', qr)
     self._validate_successful(msgs)
     new_profile = next((m for m in msgs if m['payload']['message'] == 'es8p_meatadata_parse'), None)
@@ -55,40 +54,12 @@ class TiciLPA(LPABase):
     self._validate_successful(self._invoke('profile', 'nickname', iccid, nickname))
 
   def switch_profile(self, iccid: str) -> None:
-    self._check_bootstrapped()
     self._validate_profile_exists(iccid)
     latest = self.get_active_profile()
     if latest and latest.iccid == iccid:
       return
     self._validate_successful(self._invoke('profile', 'enable', iccid))
     self._process_notifications()
-
-  def bootstrap(self) -> None:
-    """
-    find all comma-provisioned profiles and delete them. they conflict with user-provisioned profiles
-    and must be deleted.
-
-    **note**: this is a **very** destructive operation. you **must** purchase a new comma SIM in order
-              to use comma prime again.
-    """
-    if self._is_bootstrapped():
-      return
-
-    for p in self.list_profiles():
-      if self.is_comma_profile(p.iccid):
-        self._disable_profile(p.iccid)
-        self.delete_profile(p.iccid)
-
-  def _disable_profile(self, iccid: str) -> None:
-    self._validate_successful(self._invoke('profile', 'disable', iccid))
-    self._process_notifications()
-
-  def _check_bootstrapped(self) -> None:
-    assert self._is_bootstrapped(), 'eUICC is not bootstrapped, please bootstrap before performing this operation'
-
-  def _is_bootstrapped(self) -> bool:
-    """ check if any comma provisioned profiles are on the eUICC """
-    return not any(self.is_comma_profile(iccid) for iccid in (p.iccid for p in self.list_profiles()))
 
   def _invoke(self, *cmd: str):
     proc = subprocess.Popen(['sudo', '-E', 'lpac'] + list(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self.env)


### PR DESCRIPTION
we have a path forward for not wiping the eSIM profile that comes with comma devices: https://github.com/commaai/openpilot/issues/34924#issuecomment-3604669004

this is also dangerous to run on comma four since the eUICC is soldered on device.

keeping `is_comma_profile` as it's used here: https://github.com/commaai/openpilot/blob/a8cfa2e2feaf63fde0f34d6e036c0ad5498d02eb/system/hardware/tici/hardware.py#L511