### PR TITLE
fix(url_file): ensure seek position is always an integer

### DIFF
--- a/tools/lib/url_file.py
+++ b/tools/lib/url_file.py
@@ -164,7 +164,7 @@ class URLFile:
     return parts
 
   def seek(self, pos: int) -> None:
-    self._pos = pos
+    self._pos = int(pos)
 
   @property
   def name(self) -> str:


### PR DESCRIPTION
Fixes:
```python
openpilot/tools/lib/url_file.py:118: RuntimeWarning: overflow encountered in scalar subtract.
```