### PR TITLE
FrameReader: use HW accel if available

### DIFF
--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import json
+import logging
 from functools import cache
 from collections.abc import Iterator
 from collections import OrderedDict
@@ -10,6 +11,7 @@ from openpilot.tools.lib.filereader import FileReader, resolve_name
 from openpilot.tools.lib.exceptions import DataUnreadableError
 from openpilot.tools.lib.vidindex import hevc_index
 
+logger = logging.getLogger("tools")
 
 HEVC_SLICE_B = 0
 HEVC_SLICE_P = 1
@@ -20,10 +22,11 @@ def get_hw_accel() -> list[str]:
   """Detect and return the best available ffmpeg hardware acceleration."""
   priority = ("videotoolbox", "cuda", "vaapi", "d3d11va")
   result = subprocess.run(["ffmpeg", "-hwaccels"], capture_output=True, text=True, timeout=5)
-  available = set(result.stdout.lower().split())
   for accel in priority:
-    if accel in available:
+    if accel in result.stdout.lower():
+      logger.info(f"HW accelerated video decode found, using ffmpeg's {accel}")
       return ["-hwaccel", accel]
+  logger.warning("no HW accelerated video found with `ffmpeg -hwaccels`. falling back to ffmpeg CPU decode")
   return []
 
 
@@ -184,3 +187,7 @@ class FrameReader:
       self.fidx, frame = next(self.it)
       self._cache[self.fidx] = frame
     return self._cache[fidx]
+
+
+if __name__ == "__main__":
+  get_hw_accel()

--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -1,7 +1,7 @@
 import os
-import sys
 import subprocess
 import json
+from functools import cache
 from collections.abc import Iterator
 from collections import OrderedDict
 
@@ -14,6 +14,17 @@ from openpilot.tools.lib.vidindex import hevc_index
 HEVC_SLICE_B = 0
 HEVC_SLICE_P = 1
 HEVC_SLICE_I = 2
+
+@cache
+def get_hw_accel() -> list[str]:
+  """Detect and return the best available ffmpeg hardware acceleration."""
+  priority = ("videotoolbox", "cuda", "vaapi", "d3d11va")
+  result = subprocess.run(["ffmpeg", "-hwaccels"], capture_output=True, text=True, timeout=5)
+  available = set(result.stdout.lower().split())
+  for accel in priority:
+    if accel in available:
+      return ["-hwaccel", accel]
+  return []
 
 
 class LRUCache:
@@ -45,12 +56,9 @@ def assert_hvec(fn: str) -> None:
 
 def decompress_video_data(rawdat, w, h, pix_fmt="rgb24", vid_fmt='hevc') -> np.ndarray:
   threads = os.getenv("FFMPEG_THREADS", "0")
-  hw_accel = []
-  if sys.platform == "darwin":
-    hw_accel = ["-hwaccel", "videotoolbox"]
   args = ["ffmpeg", "-v", "quiet",
           "-threads", threads,
-          *hw_accel,
+          *get_hw_accel(),
           "-c:v", "hevc",
           "-vsync", "0",
           "-f", vid_fmt,

--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -44,8 +44,12 @@ def assert_hvec(fn: str) -> None:
 
 def decompress_video_data(rawdat, w, h, pix_fmt="rgb24", vid_fmt='hevc') -> np.ndarray:
   threads = os.getenv("FFMPEG_THREADS", "0")
+  hw_accel = []
+  if sys.platform == "darwin":
+    hw_accel = ["-hwaccel", "videotoolbox"]
   args = ["ffmpeg", "-v", "quiet",
           "-threads", threads,
+          *hw_accel,
           "-c:v", "hevc",
           "-vsync", "0",
           "-f", vid_fmt,

--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 import json
 from collections.abc import Iterator


### PR DESCRIPTION
ffmpeg CPU decode is actually pretty decent on my M2 air, but this is free perf
```
============================================================
FrameReader Benchmark: CPU vs VideoToolbox (macOS)
============================================================

Decoding 500 frames to rgb24...

CPU (best of 3):          5.551s  (90.1 fps)
VideoToolbox (best of 3): 4.358s  (114.7 fps)

Speedup: 1.27x (21.5% faster with VideoToolbox)
```