### PR TITLE
Alert for stock LKAS

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -87,6 +87,7 @@ struct OnroadEvent @0xc4fa6047f024e718 {
     laneChange @50;
     lowMemory @51;
     stockAeb @52;
+    stockLkas @98;
     ldw @53;
     carUnrecognized @54;
     invalidLkasSetting @55;

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -119,6 +119,8 @@ class CarSpecificEvents:
       events.add(EventName.stockFcw)
     if CS.stockAeb:
       events.add(EventName.stockAeb)
+    if CS.stockLkas:
+      events.add(EventName.stockLkas)
     if CS.vEgo > MAX_CTRL_SPEED:
       events.add(EventName.speedTooHigh)
     if CS.cruiseState.nonAdaptive:

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -477,6 +477,15 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.NO_ENTRY: NoEntryAlert("Stock AEB: Risk of Collision"),
   },
 
+  EventName.stockLkas: {
+    ET.PERMANENT: Alert(
+      "TAKE CONTROL",
+      "Stock LKAS: Lane Departure Detected",
+      AlertStatus.critical, AlertSize.full,
+      Priority.HIGHEST, VisualAlert.fcw, AudibleAlert.none, 2.),
+    ET.NO_ENTRY: NoEntryAlert("Stock AEB: Risk of Collision"),
+  },
+
   EventName.fcw: {
     ET.PERMANENT: Alert(
       "BRAKE!",

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -482,8 +482,8 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
       "TAKE CONTROL",
       "Stock LKAS: Lane Departure Detected",
       AlertStatus.critical, AlertSize.full,
-      Priority.HIGHEST, VisualAlert.fcw, AudibleAlert.none, 2.),
-    ET.NO_ENTRY: NoEntryAlert("Stock AEB: Risk of Collision"),
+      Priority.HIGH, VisualAlert.fcw, AudibleAlert.none, 2.),
+    ET.NO_ENTRY: NoEntryAlert("Stock LKAS: Lane Departure Detected"),
   },
 
   EventName.fcw: {
@@ -1028,7 +1028,6 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.PERMANENT: audio_feedback_alert,
   },
 }
-
 
 if HARDWARE.get_device_type() == 'mici':
   EVENTS.update({

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -1029,6 +1029,7 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   },
 }
 
+
 if HARDWARE.get_device_type() == 'mici':
   EVENTS.update({
     EventName.preDriverDistracted: {


### PR DESCRIPTION
We alert for stock AEB and FCW but not LKAS, which is now something that we pass through with Tesla only for now.

This surfaces an API change for Tesla FSD 14, where the steering control enum swapped around normal angle control for lane departure, and lane departure control adds steering override ramp down behavior.

Without this with both openpilot and FSD enabled, FSD is able to control lateral while openpilot throws an alert about turning off FSD. With just openpilot enabled, LDA passthrough is silently broken.

https://github.com/commaai/opendbc/pull/2197