### PR TITLE
conftest: lazy-load imports to speed up pytest collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ allow-direct-references = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ignore=openpilot/ --ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ --ignore=teleoprtc_repo/ --ignore=msgq/  -Werror --strict-config --strict-markers --durations=10 -n auto --dist=loadgroup"
+addopts = "-Werror --strict-config --strict-markers --durations=10 -n auto --dist=loadgroup"
 cpp_files = "test_*"
 cpp_harness = "selfdrive/test/cpp_harness.py"
 python_files = "test_*.py"
@@ -171,6 +171,16 @@ testpaths = [
   "tools/replay",
   "tools/cabana",
   "cereal/messaging/tests",
+]
+# Use norecursedirs instead of --ignore flags for faster collection
+norecursedirs = [
+  "openpilot",
+  "opendbc",
+  "panda",
+  "rednose_repo",
+  "tinygrad_repo",
+  "teleoprtc_repo",
+  "msgq",
 ]
 
 [tool.codespell]


### PR DESCRIPTION
Fixes #32611

## Summary

This PR speeds up pytest collection by:

1. **Lazy-loading expensive imports in conftest.py** - Moves `OpenpilotPrefix`, `manager`, `TICI`, and `HARDWARE` imports from module-level to inside the fixtures where they're actually used. These imports are only needed when tests *run*, not during collection.

2. **Replacing TICI import with file check** - Instead of importing the entire `openpilot.system.hardware` module just to check `TICI`, uses a simple `os.path.isfile('/TICI')` check which is much faster.

3. **Using `norecursedirs` instead of `--ignore` flags** - The `norecursedirs` option is more efficient for pytest collection as it prevents pytest from even entering those directories, rather than ignoring them after discovery.

## Changes

- `conftest.py`: Move imports inside fixtures, add `_is_tici()` helper function
- `pyproject.toml`: Replace `--ignore` flags with `norecursedirs` configuration