### PR TITLE
VW: Enable torqued

### DIFF
--- a/selfdrive/locationd/torqued.py
+++ b/selfdrive/locationd/torqued.py
@@ -33,7 +33,7 @@ MIN_BUCKET_POINTS = np.array([100, 300, 500, 500, 500, 500, 300, 100])
 MIN_ENGAGE_BUFFER = 2  # secs
 
 VERSION = 1  # bump this to invalidate old parameter caches
-ALLOWED_CARS = ['toyota', 'hyundai', 'rivian', 'honda']
+ALLOWED_CARS = ['toyota', 'hyundai', 'rivian', 'honda', 'volkswagen']
 
 
 def slope2rot(slope):


### PR DESCRIPTION
Enable torqued for VW PQ and MLB. It's not perfect, there's still a speed-dependent factor that I don't understand yet, but I need `latAccelOffset` populated otherwise I'm winding up integral to replace it and confusing the picture.

VW MQB will move off PIF someday, but it's unaffected until then.