### PR TITLE
Latcontrol torque test: ensure desired lateral accel buffer is consistent

### DIFF
--- a/selfdrive/controls/tests/test_latcontrol_torque_buffer.py
+++ b/selfdrive/controls/tests/test_latcontrol_torque_buffer.py
@@ -1,0 +1,36 @@
+from parameterized import parameterized
+
+from cereal import car, log
+from opendbc.car.car_helpers import interfaces
+from opendbc.car.toyota.values import CAR as TOYOTA
+from opendbc.car.vehicle_model import VehicleModel
+from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque, LAT_ACCEL_REQUEST_BUFFER_SECONDS
+
+def get_controller(car_name):
+  CarInterface = interfaces[car_name]
+  CP = CarInterface.get_non_essential_params(car_name)
+  CI = CarInterface(CP)
+  VM = VehicleModel(CP)
+  controller = LatControlTorque(CP.as_reader(), CI, DT_CTRL)
+  return controller, VM
+
+class TestLatControlTorqueBuffer:
+
+  @parameterized.expand([(TOYOTA.TOYOTA_COROLLA_TSS2,)])
+  def test_request_buffer_consistency(self, car_name):
+    buffer_steps = int(LAT_ACCEL_REQUEST_BUFFER_SECONDS / DT_CTRL)
+    controller, VM = get_controller(car_name)
+
+    CS = car.CarState.new_message()
+    CS.vEgo = 30
+    CS.steeringPressed = False
+    params = log.LiveParametersData.new_message()
+
+    for _ in range(buffer_steps):
+      controller.update(True, CS, VM, params, False, 0.001, False, 0.2)
+    assert all(val != 0 for val in controller.lat_accel_request_buffer)
+
+    for _ in range(buffer_steps):
+      controller.update(False, CS, VM, params, False, 0.0, False, 0.2)
+    assert all(val == 0 for val in controller.lat_accel_request_buffer)


### PR DESCRIPTION
Added test to make sure lat torque controller fills request buffer even when the controller is inactive