### PR TITLE
`CI`: enable `macos` tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,6 @@ jobs:
 
   build_mac:
     name: build macOS
-    if: false # tmp disable due to brew install not working
     runs-on: ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-macos-8x14' || 'macos-latest' }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
It looks like there was a [SHA checksum problem](https://github.com/orgs/Homebrew/discussions/6577) on `14.3rel1` causing the failures to occur in CI.

I enabled it to see if it would still occur on a new release of `gcc-arm-embedded` and we get [passing builds](https://github.com/BBBmau/openpilot/actions/runs/21154398814/job/60836450227?pr=14)

We can merge as is, though there's other things that are still lacking in order to develop on macOS (one that I came across is `./ui.py` not rendering the route used from `selfdrive/replay --demo`)

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

