### PR TITLE
mici: green network icon when connected

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -74,7 +74,7 @@ class WifiIcon(Widget):
       lock_scale = self._scale * 1.1
       lock_x = int(icon_x + 1 + strength_icon.width * self._scale - self._lock_txt.width * lock_scale / 2)
       lock_y = int(icon_y + 1 + strength_icon.height * self._scale - self._lock_txt.height * lock_scale / 2)
-      rl.draw_texture_ex(self._lock_txt, (lock_x, lock_y), 0.0, lock_scale, rl.WHITE)
+      rl.draw_texture_ex(self._lock_txt, (lock_x, lock_y), 0.0, lock_scale, icon_tint)
 
 
 class WifiItem(BigDialogOptionButton):

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -65,6 +65,7 @@ class WifiIcon(Widget):
 
     icon_x = int(self._rect.x + (self._rect.width - strength_icon.width * self._scale) // 2)
     icon_y = int(self._rect.y + (self._rect.height - strength_icon.height * self._scale) // 2)
+    # Render wifi strength icon (green if connected)
     icon_tint = rl.GREEN if self._network.is_connected else rl.WHITE
     rl.draw_texture_ex(strength_icon, (icon_x, icon_y), 0.0, self._scale, icon_tint)
 

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -65,7 +65,8 @@ class WifiIcon(Widget):
 
     icon_x = int(self._rect.x + (self._rect.width - strength_icon.width * self._scale) // 2)
     icon_y = int(self._rect.y + (self._rect.height - strength_icon.height * self._scale) // 2)
-    rl.draw_texture_ex(strength_icon, (icon_x, icon_y), 0.0, self._scale, rl.WHITE)
+    icon_tint = rl.GREEN if self._network.is_connected else rl.WHITE
+    rl.draw_texture_ex(strength_icon, (icon_x, icon_y), 0.0, self._scale, icon_tint)
 
     # Render lock icon at lower right of wifi icon if secured
     if self._network.security_type not in (SecurityType.OPEN, SecurityType.UNSUPPORTED):


### PR DESCRIPTION
Makes the WiFi icon green when connected to that network. This provides a visual indicator of which network is currently connected in the WiFi networks list.

**Update:** Ahh I missed that there's already a selected state shown as the white blur on the edge. It wasn't immediately obvious to me. I guess this isn't necessary then, but I will leave it open if you want it after all. Maybe if the blur was green instead of white it would be more obvious.

<img width="534" height="239" alt="image" src="https://github.com/user-attachments/assets/9777ee84-115c-4a2c-aabe-e6088d12bda6" />

<img width="535" height="233" alt="image" src="https://github.com/user-attachments/assets/4b2c33ad-5c4d-4ec7-a657-eafe91ec2cdb" />