### PR TITLE
mici: green selected WiFi network indicator

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -97,7 +97,7 @@ class WifiItem(BigDialogOptionButton):
     if self._network.is_connected:
       selected_x = int(self._rect.x - self._selected_txt.width / 2)
       selected_y = int(self._rect.y + (self._rect.height - self._selected_txt.height) / 2)
-      rl.draw_texture(self._selected_txt, selected_x, selected_y, rl.WHITE)
+      rl.draw_texture(self._selected_txt, selected_x, selected_y, rl.GREEN)
 
     self._wifi_icon.set_scale((1.0 if self._selected else 0.65) * 0.7)
     self._wifi_icon.render(rl.Rectangle(


### PR DESCRIPTION
Instead of #37015, but this makes the existing selected network indicator stand out more. The old way wasn't immediately intuitive for me, at least on PC. Perhaps it looks better on device.

### Before:
<img width="536" height="237" alt="image" src="https://github.com/user-attachments/assets/5a17cfe9-395b-4291-a4d2-357b2c3bf380" />

### After:
<img width="533" height="238" alt="image" src="https://github.com/user-attachments/assets/d0d4a77e-0506-435c-8b7d-4e191c779c13" />