### PR TITLE
onboarding: automatically go back after selecting network

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -313,11 +313,13 @@ class WifiUIMici(BigMultiOptionDialog):
   # Wait this long after user interacts with widget to update network list
   INACTIVITY_TIMEOUT = 1
 
-  def __init__(self, wifi_manager: WifiManager, back_callback: Callable):
+  def __init__(self, wifi_manager: WifiManager, back_callback: Callable, back_on_activate: bool = False):
     super().__init__([], None, None, right_btn_callback=None)
 
     # Set up back navigation
     self.set_back_callback(back_callback)
+    self.back_callback = back_callback
+    self.back_on_activate = back_on_activate
 
     self._network_info_page = NetworkInfoPage(wifi_manager, self._connect_to_network, self._forget_network, self._open_network_manage_page)
     self._network_info_page.set_connecting(lambda: self._connecting)
@@ -429,6 +431,10 @@ class WifiUIMici(BigMultiOptionDialog):
 
   def _on_activated(self):
     self._connecting = None
+    if self.back_on_activate:
+      # Close the overlay and go back
+      gui_app.set_modal_overlay(None)
+      self.back_callback()
 
   def _on_forgotten(self):
     self._connecting = None

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -318,7 +318,6 @@ class WifiUIMici(BigMultiOptionDialog):
 
     # Set up back navigation
     self.set_back_callback(back_callback)
-    self.back_callback = back_callback
     self.back_on_activate = back_on_activate
 
     self._network_info_page = NetworkInfoPage(wifi_manager, self._connect_to_network, self._forget_network, self._open_network_manage_page)
@@ -434,7 +433,7 @@ class WifiUIMici(BigMultiOptionDialog):
     if self.back_on_activate:
       # Close the overlay and go back
       gui_app.set_modal_overlay(None)
-      self.back_callback()
+      self._back_callback()
 
   def _on_forgotten(self):
     self._connecting = None

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -435,7 +435,7 @@ class NetworkSetupState(IntEnum):
 class NetworkSetupPage(Widget):
   def __init__(self, wifi_manager, continue_callback: Callable, back_callback: Callable):
     super().__init__()
-    self._wifi_ui = WifiUIMici(wifi_manager, back_callback=lambda: self.set_state(NetworkSetupState.MAIN))
+    self._wifi_ui = WifiUIMici(wifi_manager, back_callback=lambda: self.set_state(NetworkSetupState.MAIN), back_on_activate=True)
 
     self._no_wifi_txt = gui_app.texture("icons_mici/settings/network/wifi_strength_slash.png", 58, 50)
     self._wifi_full_txt = gui_app.texture("icons_mici/settings/network/wifi_strength_full.png", 58, 50)


### PR DESCRIPTION
After connecting to a WiFi network during onboarding, this PR makes it automatically go back to the network setup page so the user can continue to downloading, instead of remaining in the WiFi page.

This was based on [user feedback in Discord](https://discord.com/channels/469524606043160576/616456819027607567/1463811255276929159) about how the current flow was confusing. Also partly addresses #36916 

_**When the user connects...**_
<img width="531" height="235" alt="image" src="https://github.com/user-attachments/assets/d0ca484d-2205-447b-a069-d2ab47bc669b" />

**_... it will now go back to here:_**
<img width="534" height="235" alt="image" src="https://github.com/user-attachments/assets/be81c6c3-e154-4a9d-a065-62b5528b58b7" />
