### PR TITLE
Longitudinal control active on gas override

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -95,7 +95,7 @@ class Controls:
     standstill = abs(CS.vEgo) <= max(self.CP.minSteerSpeed, 0.3) or CS.standstill
     CC.latActive = self.sm['selfdriveState'].active and not CS.steerFaultTemporary and not CS.steerFaultPermanent and \
                    (not standstill or self.CP.steerAtStandstill)
-    CC.longActive = CC.enabled and not any(e.overrideLongitudinal for e in self.sm['onroadEvents']) and self.CP.openpilotLongitudinalControl
+    CC.longActive = CC.enabled and self.CP.openpilotLongitudinalControl
 
     actuators = CC.actuators
     actuators.longControlState = self.LoC.long_control_state
@@ -112,7 +112,9 @@ class Controls:
 
     # accel PID loop
     pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, CS.vCruise * CV.KPH_TO_MS)
-    actuators.accel = float(self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop, pid_accel_limits))
+    override_longitudinal = any(e.overrideLongitudinal for e in self.sm['onroadEvents'])
+    actuators.accel = float(self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop,
+                                            pid_accel_limits, freeze_integrator=override_longitudinal))
 
     # Steering PID loop and lateral MPC
     # Reset desired curvature to current to avoid violating the limits on engage

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -93,9 +93,10 @@ class Controls:
 
     # Check which actuators can be enabled
     standstill = abs(CS.vEgo) <= max(self.CP.minSteerSpeed, 0.3) or CS.standstill
+    override_longitudinal = any(e.overrideLongitudinal for e in self.sm['onroadEvents'])
     CC.latActive = self.sm['selfdriveState'].active and not CS.steerFaultTemporary and not CS.steerFaultPermanent and \
                    (not standstill or self.CP.steerAtStandstill)
-    CC.longActive = CC.enabled and self.CP.openpilotLongitudinalControl
+    CC.longActive = CC.enabled and self.CP.openpilotLongitudinalControl and (not override_longitudinal or self.CP.longActiveWithGasOverride)
 
     actuators = CC.actuators
     actuators.longControlState = self.LoC.long_control_state
@@ -112,7 +113,6 @@ class Controls:
 
     # accel PID loop
     pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, CS.vCruise * CV.KPH_TO_MS)
-    override_longitudinal = any(e.overrideLongitudinal for e in self.sm['onroadEvents'])
     actuators.accel = float(self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop,
                                             pid_accel_limits, freeze_integrator=override_longitudinal))
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -56,7 +56,7 @@ class LongControl:
   def reset(self):
     self.pid.reset()
 
-  def update(self, active, CS, a_target, should_stop, accel_limits):
+  def update(self, active, CS, a_target, should_stop, accel_limits, freeze_integrator=False):
     """Update longitudinal control. This updates the state machine and runs a PID loop"""
     self.pid.neg_limit = accel_limits[0]
     self.pid.pos_limit = accel_limits[1]
@@ -82,7 +82,8 @@ class LongControl:
     else:  # LongCtrlState.pid
       error = a_target - CS.aEgo
       output_accel = self.pid.update(error, speed=CS.vEgo,
-                                     feedforward=a_target)
+                                     feedforward=a_target,
+                                     freeze_integrator=freeze_integrator)
 
     self.last_output_accel = np.clip(output_accel, accel_limits[0], accel_limits[1])
     return self.last_output_accel

--- a/selfdrive/selfdrived/helpers.py
+++ b/selfdrive/selfdrived/helpers.py
@@ -26,7 +26,7 @@ class ExcessiveActuationCheck:
     # CS.aEgo can be noisy to bumps in the road, transitioning from standstill, losing traction, etc.
     # longitudinal
     accel_calibrated = calibrated_pose.acceleration.x
-    excessive_long_actuation = sm['carControl'].longActive and (accel_calibrated > ACCEL_MAX * 2 or accel_calibrated < ACCEL_MIN * 2)
+    excessive_long_actuation = sm['carControl'].longActive and ((not CS.gasPressed and accel_calibrated > ACCEL_MAX * 2) or accel_calibrated < ACCEL_MIN * 2)
 
     # lateral
     yaw_rate = calibrated_pose.angular_velocity.yaw

--- a/tools/joystick/joystickd.py
+++ b/tools/joystick/joystickd.py
@@ -31,7 +31,7 @@ def joystickd_thread():
     CC = cc_msg.carControl
     CC.enabled = sm['selfdriveState'].enabled
     CC.latActive = sm['selfdriveState'].active and not sm['carState'].steerFaultTemporary and not sm['carState'].steerFaultPermanent
-    CC.longActive = CC.enabled and not any(e.overrideLongitudinal for e in sm['onroadEvents']) and CP.openpilotLongitudinalControl
+    CC.longActive = CC.enabled and CP.openpilotLongitudinalControl
     CC.cruiseControl.cancel = sm['carState'].cruiseState.enabled and (not CC.enabled or not CP.pcmCruise)
     CC.hudControl.leadDistanceBars = 2
 


### PR DESCRIPTION
New behavior on gas override:
- longitudinal control remains active
- freezes PID integrator
- disables excessive (positive) acceleration warning

###  Blockers 
- [ ]  remove `&& !gas_pressed_prev` in https://github.com/commaai/opendbc/blob/master/opendbc/safety/longitudinal.h#L4
  - [ ]  delete `Disengage on Accelerator Pedal` UI setting
- [ ]  add `longActiveWithGasOverride` to CarParams and set to `False` in `interfaces.py`


### Tested cars, btw:
- Tesla HW3 - matches stock behavior 