### PR TITLE
fix non-determinism in modeld build

### DIFF
--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -1,4 +1,5 @@
 import os
+import glob
 
 Import('env', 'envCython', 'arch', 'cereal', 'messaging', 'common', 'visionipc')
 lenv = env.Clone()
@@ -28,8 +29,7 @@ for pathdef, fn in {'TRANSFORM': 'transforms/transform.cl', 'LOADYUV': 'transfor
 cython_libs = envCython["LIBS"] + libs
 commonmodel_lib = lenv.Library('commonmodel', common_src)
 lenvCython.Program('models/commonmodel_pyx.so', 'models/commonmodel_pyx.pyx', LIBS=[commonmodel_lib, *cython_libs], FRAMEWORKS=frameworks)
-tinygrad_files = lenv.Glob("#tinygrad_repo/tinygrad/*.py") + lenv.Glob("#tinygrad_repo/tinygrad/**/*.py") + ["#tinygrad_repo/examples/openpilot/compile3.py"]
-
+tinygrad_files = sorted(["#"+x for x in glob.glob(env.Dir("#tinygrad_repo").relpath + "/**", recursive=True, root_dir=env.Dir("#").abspath) if 'pycache' not in x])
 
 # Get model metadata
 for model_name in ['driving_vision', 'driving_policy', 'dmonitoring_model']:

--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -1,5 +1,4 @@
 import os
-import glob
 
 Import('env', 'envCython', 'arch', 'cereal', 'messaging', 'common', 'visionipc')
 lenv = env.Clone()
@@ -29,7 +28,8 @@ for pathdef, fn in {'TRANSFORM': 'transforms/transform.cl', 'LOADYUV': 'transfor
 cython_libs = envCython["LIBS"] + libs
 commonmodel_lib = lenv.Library('commonmodel', common_src)
 lenvCython.Program('models/commonmodel_pyx.so', 'models/commonmodel_pyx.pyx', LIBS=[commonmodel_lib, *cython_libs], FRAMEWORKS=frameworks)
-tinygrad_files = ["#"+x for x in glob.glob(env.Dir("#tinygrad_repo").relpath + "/**", recursive=True, root_dir=env.Dir("#").abspath) if 'pycache' not in x]
+tinygrad_files = lenv.Glob("#tinygrad_repo/tinygrad/*.py") + lenv.Glob("#tinygrad_repo/tinygrad/**/*.py") + ["#tinygrad_repo/examples/openpilot/compile3.py"]
+
 
 # Get model metadata
 for model_name in ['driving_vision', 'driving_policy', 'dmonitoring_model']:


### PR DESCRIPTION
Use `Environment.Glob` instead of `glob.glob` to make model compilation deterministic.

This makes the models cacheable so build time is improved.

Noop builds for reference:

 * pre: compile is 31s https://github.com/kingarrrt/openpilot/actions/runs/21466211308/job/61828818066 
 * post: compile is 13s https://github.com/kingarrrt/openpilot/actions/runs/21466373783/job/61829308171 

