### PR TITLE
UI: only show `onroad_fade.png` when engaged

### DIFF
--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -217,8 +217,9 @@ class AugmentedRoadView(CameraView):
     # Draw all UI overlays
     self._model_renderer.render(self._content_rect)
 
-    # Fade out bottom of overlays for looks
-    rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.WHITE)
+    # Fade out bottom of overlays for looks (only when engaged)
+    if ui_state.status != UIStatus.DISENGAGED:
+      rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.WHITE)
 
     alert_to_render, not_animating_out = self._alert_renderer.will_render()
 

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -14,7 +14,7 @@ from openpilot.selfdrive.ui.mici.onroad.cameraview import CameraView
 from openpilot.system.ui.lib.application import FontWeight, gui_app, MousePos, MouseEvent
 from openpilot.system.ui.widgets.label import UnifiedLabel
 from openpilot.system.ui.widgets import Widget
-from openpilot.common.filter_simple import BounceFilter
+from openpilot.common.filter_simple import BounceFilter, FirstOrderFilter
 from openpilot.common.transformations.camera import DEVICE_CAMERAS, DeviceCameraConfig, view_frame_from_device_frame
 from openpilot.common.transformations.orientation import rot_from_euler
 from enum import IntEnum
@@ -165,6 +165,7 @@ class AugmentedRoadView(CameraView):
                                        alignment_vertical=rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE)
 
     self._fade_texture = gui_app.texture("icons_mici/onroad/onroad_fade.png")
+    self._fade_alpha_filter = FirstOrderFilter(0, 0.1, 1 / gui_app.target_fps)
 
     # debug
     self._pm = messaging.PubMaster(['uiDebug'])
@@ -218,8 +219,9 @@ class AugmentedRoadView(CameraView):
     self._model_renderer.render(self._content_rect)
 
     # Fade out bottom of overlays for looks (only when engaged)
-    if ui_state.status != UIStatus.DISENGAGED:
-      rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.WHITE)
+    alpha = self._fade_alpha_filter.update(ui_state.status != UIStatus.DISENGAGED)
+    if alpha > 1e-2:
+      rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.Color(255, 255, 255, int(255 * alpha)))
 
     alert_to_render, not_animating_out = self._alert_renderer.will_render()
 

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -219,9 +219,10 @@ class AugmentedRoadView(CameraView):
     self._model_renderer.render(self._content_rect)
 
     # Fade out bottom of overlays for looks (only when engaged)
-    alpha = self._fade_alpha_filter.update(ui_state.status != UIStatus.DISENGAGED)
-    if alpha > 1e-2:
-      rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.Color(255, 255, 255, int(255 * alpha)))
+    fade_alpha = self._fade_alpha_filter.update(ui_state.status != UIStatus.DISENGAGED)
+    if fade_alpha > 1e-2:
+      rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0,
+                         rl.Color(255, 255, 255, int(255 * fade_alpha)))
 
     alert_to_render, not_animating_out = self._alert_renderer.will_render()
 


### PR DESCRIPTION
- show `onroad_fade.png`(btm black vignette) **_only_** when engaged like steering arc and `wheel.png` current behavior
- leaving the btm black vignette visible when **not engaged** does not help users or provide any meaningful utility and has so far only caused confusion. (i.e. refer to Discord messages below)
- I think leaving btm black vignette visible when **engaged** still has utility other than looks since it provides more contrast to the btm icons versus when it is **not engaged**
- video below shows it engaging and disengaging repeatedly to give a feel of how the change would look like in action
- move mouse outside of video frame so it is easier to see the UI change of the bottom black vignette


| New UI | Old UI |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/d54644ab-b0b6-47af-9de1-fe900c72df9d" controls width="400"></video> | <video src="https://github.com/user-attachments/assets/6851c899-d259-4b6b-a1a3-2e6964a332c6" controls width="400"></video> |

I don't own a comma four yet so I never personally noticed the btm black gradient when it was not engaged but it became more obvious this was an issue as I kept seeing the same message on discord

Usually I would install this UI change to my device to test it out and see if there were any quirks im missing, but for this UI PR, I only tested it by using the demo route

# Discord messages
Message Links: [msg-1](https://discord.com/channels/469524606043160576/1436852432503046294/1454651917580894270), [msg-2](https://discord.com/channels/469524606043160576/1436852432503046294/1454651917580894270), [msg-3](https://discord.com/channels/469524606043160576/1436852432503046294/1454651917580894270), [msg-4](https://discord.com/channels/469524606043160576/1436852432503046294/1454651917580894270)

<br>

<img width="100%" alt="discord-msg" src="https://github.com/user-attachments/assets/850e6ac9-cbc2-43b7-a958-d7116eec2a52" />


