### PR TITLE
chore: bump minimum Python version to 3.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openpilot"
-requires-python = ">= 3.11, < 3.13"
+requires-python = ">= 3.12.3, < 3.13"
 license = {text = "MIT License"}
 version = "0.1.0"
 description = "an open source driver assistance system"


### PR DESCRIPTION
`uv` selected 3.12.0 when installing my venv, but it had issues building tinygrad, as noted [here](https://github.com/tinygrad/tinygrad/issues/8167#issuecomment-2537251202).

```
  File "/Users/trey/dev/openpilot/tinygrad/uop/ops.py", line 139, in key
    return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
                                                                                    ^^^^^
  File "/Users/trey/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/trey/dev/openpilot/tinygrad/uop/ops.py", line 139, in key
    return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trey/dev/openpilot/tinygrad/uop/__init__.py", line 8, in __repr__
    def __repr__(x): return str(x)
                            ^^^^^^
RecursionError: maximum recursion depth exceeded
python3 /Users/trey/dev/openpilot/selfdrive/modeld/get_model_metadata.py /Users/trey/dev/openpilot/selfdrive/modeld/models/driving_vision.onnx
scons: *** [selfdrive/modeld/models/dmonitoring_model_tinygrad.pkl] Error 1
```

enforcing minimum version of `3.12.3` to prevent build issues.

tested:
```
scons -c
tools/install_python_dependencies.sh
scons
```