### PR TITLE
fix(clip): no empty frames

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -85,6 +85,7 @@ def run_replay():
   if not HEADLESS:
     rl.set_config_flags(rl.FLAG_WINDOW_HIDDEN)
   gui_app.init_window("ui diff test", fps=FPS)
+  gui_app.begin_recording()
   main_layout = MiciMainLayout()
   main_layout.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
 

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -344,7 +344,7 @@ def clip(route: Route, output: str, start: int, end: int, headless: bool = True,
           render_overlays(gui_app, font, big, metadata, title, start, frame_idx, show_metadata, show_time)
         if road_view_ready:
           gui_app.begin_recording()
-        if road_view.frame is not None:
+        if road_view.frame is not None and ui_state.started:
           road_view_ready = True
         frame_idx += 1
         pbar.update(1)

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -124,6 +124,14 @@ def patch_submaster(message_chunks, ui_state):
     sm.frame += 1
   ui_state.sm.update = mock_update
 
+  # Prevent _update_status from overwriting started_frame during onroad transition detection
+  # This fixes an issue where driver monitoring isn't immediately shown
+  _orig_update = ui_state.update
+  def clip_update():
+    _orig_update()
+    ui_state.started_frame = 0
+  ui_state.update = clip_update
+
 
 def get_frame_dimensions(camera_path: str) -> tuple[int, int]:
   """Get frame dimensions from a video file using ffprobe."""
@@ -323,6 +331,7 @@ def clip(route: Route, output: str, start: int, end: int, headless: bool = True,
     timer.lap("setup")
 
     frame_idx = 0
+    road_view_ready = False
     with tqdm.tqdm(total=len(message_chunks), desc="Rendering", unit="frame") as pbar:
       for should_render in gui_app.render():
         if frame_idx >= len(message_chunks):
@@ -333,6 +342,10 @@ def clip(route: Route, output: str, start: int, end: int, headless: bool = True,
         if should_render:
           road_view.render()
           render_overlays(gui_app, font, big, metadata, title, start, frame_idx, show_metadata, show_time)
+        if road_view_ready:
+          gui_app.begin_recording()
+        if road_view.frame is not None:
+          road_view_ready = True
         frame_idx += 1
         pbar.update(1)
     timer.lap("render")


### PR DESCRIPTION
dependent on https://github.com/commaai/openpilot/pull/37053

* start recording after the *first* road frame loads. this is for several reasons:
  * UI needs to "warmup" (vipc road frame isn't immediately available, results in black frames at begin)
  * frame calibration matrix needs at least one frame to compute, otherwise you see camera shift in the video
  * UI state needs one frame *after* first road frame to settle (engaged status, dmon, etc.)
  * see before/after to see this behavior

```bash
tools/clip/run.py --demo --start 150 --end 170 --big
```

## before

https://github.com/user-attachments/assets/5390fbda-1fb9-4312-87a9-12b6b07e3a9d

## after

https://github.com/user-attachments/assets/1b2376b4-878e-4da8-8a6a-b77d0acc363b





