### PR TITLE
fix(tools): correct python version check in op.sh

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -162,7 +162,7 @@ function op_check_python() {
     return 1
   fi
 
-  if python3 -c "from packaging.specifiers import SpecifierSet; import sys; exit(0 if '.'.join(map(str, sys.version_info[:3])) in SpecifierSet('$REQUIRED_PYTHON_VERSION') else 1)" 2>/dev/null; then
+  if python3 -c "from packaging.specifiers import SpecifierSet; import sys; exit(0 if '$INSTALLED_PYTHON_VERSION' in SpecifierSet('$REQUIRED_PYTHON_VERSION') else 1)" 2>/dev/null; then
     echo -e " ↳ [${GREEN}✔${NC}] $INSTALLED_PYTHON_VERSION detected."
   else
     echo -e " ↳ [${RED}✗${NC}] You need a python version satisfying '$REQUIRED_PYTHON_VERSION' to continue!"


### PR DESCRIPTION
Fixes #37063

Makes the Python version check more robust by switching from a simple comparison check for version strings like `3.11` and `3.13` to evaluating the versions using the `packaging.specifiers` Python package.

This now allow for 3 digits (e.g. `3.12.3`) and also will work with any combination of comparison operators (e.g. `>`, `<=`).

As far as I can tell, the "packaging" module is usually included in Ubuntu, but if not, it would need to be added to the Ubuntu script dependencies as "python3-packaging".