### PR TITLE
comma four setup improvements

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/developer.py
+++ b/selfdrive/ui/mici/layouts/settings/developer.py
@@ -1,7 +1,6 @@
 import pyray as rl
 from collections.abc import Callable
 
-from openpilot.common.time_helpers import system_time_valid
 from openpilot.system.ui.widgets.scroller import Scroller
 from openpilot.selfdrive.ui.mici.widgets.button import BigButton, BigToggle, BigParamControl, BigCircleParamControl
 from openpilot.selfdrive.ui.mici.widgets.dialog import BigDialog, BigInputDialog
@@ -10,6 +9,7 @@ from openpilot.system.ui.widgets import NavWidget
 from openpilot.selfdrive.ui.layouts.settings.common import restart_needed_callback
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.selfdrive.ui.widgets.ssh_key import SshKeyAction
+from openpilot.system.ui.mici_setup import NetworkConnectivityMonitor
 
 
 class DeveloperLayoutMici(NavWidget):
@@ -30,11 +30,25 @@ class DeveloperLayoutMici(NavWidget):
     def ssh_keys_callback():
       github_username = ui_state.params.get("GithubUsername") or ""
       dlg = BigInputDialog("enter GitHub username", github_username, confirm_callback=github_username_callback)
-      if not system_time_valid():
-        dlg = BigDialog("Please connect to Wi-Fi to fetch your key", "")
+
+      # Check for internet connectivity before showing input dialog
+      network_monitor = NetworkConnectivityMonitor()
+      network_monitor.start()
+
+      def modal_overlay_tick():
+        has_internet = network_monitor.network_connected.is_set()
+        if has_internet:
+          network_monitor.stop()
+          gui_app.set_modal_overlay(dlg)
+          gui_app.set_modal_overlay_tick(None)
+
+      if not network_monitor.network_connected.is_set():
+        waiting_dlg = BigDialog("waiting for internet...", "")
+        gui_app.set_modal_overlay(waiting_dlg)
+        gui_app.set_modal_overlay_tick(modal_overlay_tick)
+      else:
+        network_monitor.stop()
         gui_app.set_modal_overlay(dlg)
-        return
-      gui_app.set_modal_overlay(dlg)
 
     txt_ssh = gui_app.texture("icons_mici/settings/developer/ssh.png", 56, 64)
     github_username = ui_state.params.get("GithubUsername") or ""

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -83,8 +83,7 @@ class NetworkConnectivityMonitor:
           self.network_connected.set()
           if HARDWARE.get_network_type() == NetworkType.wifi:
             self.wifi_connected.set()
-        except Exception as e:
-          print(traceback.format_exception(e))
+        except Exception:
           self.reset()
       else:
         self.reset()
@@ -530,11 +529,7 @@ class Setup(Widget):
     self.download_thread = None
     self._wifi_manager = WifiManager()
     self._wifi_manager.set_active(True)
-    self._network_monitor = NetworkConnectivityMonitor(
-      # lambda: self.state in (SetupState.GETTING_STARTED, SetupState.SOFTWARE_SELECTION, SetupState.NETWORK_SETUP, SetupState.NETWORK_SETUP_CUSTOM_SOFTWARE)
-      # lambda: self.state not in (SetupState.CUSTOM_SOFTWARE, SetupState.DOWNLOADING, SetupState.DOWNLOAD_FAILED)
-      # lambda: True
-    )
+    self._network_monitor = NetworkConnectivityMonitor()
     self._network_monitor.start()
     self._prev_has_internet = False
     gui_app.set_modal_overlay_tick(self._modal_overlay_tick)
@@ -563,29 +558,21 @@ class Setup(Widget):
 
   def _update_state(self):
     self._wifi_manager.process_callbacks()
-    # print(SetupState(self.state).name)
 
   def _set_state(self, state: SetupState):
-    t = time.monotonic()
     self.state = state
     if self.state == SetupState.SOFTWARE_SELECTION:
       self._software_selection_page.reset()
     elif self.state == SetupState.CUSTOM_SOFTWARE_WARNING:
       self._custom_software_warning_page.reset()
-    print(f'{(time.monotonic() - t) * 1000}ms to set state {self.state.name}')
 
     if self.state in (SetupState.NETWORK_SETUP, SetupState.NETWORK_SETUP_CUSTOM_SOFTWARE):
       self._network_setup_page.show_event()
       self._network_monitor.reset()
-      print(f"{(time.monotonic() - t) * 1000}ms to start network monitor")
     else:
       self._network_setup_page.hide_event()
-      print(f"{(time.monotonic() - t) * 1000}ms to hide_evnt")
-      print(f"{(time.monotonic() - t) * 1000}ms to stop network monitor")
-    print(f"State changed to {self.state.name} in {(time.monotonic() - t) * 1000}ms")
 
   def _render(self, rect: rl.Rectangle):
-    print('has internet', self._network_monitor.network_connected.is_set())
     if self.state == SetupState.GETTING_STARTED:
       self._start_page.render(rect)
     elif self.state in (SetupState.NETWORK_SETUP, SetupState.NETWORK_SETUP_CUSTOM_SOFTWARE):

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import traceback
 from abc import abstractmethod
 import os
 import re


### PR DESCRIPTION
Always run network connectivity monitor for faster response. Slows down timeout to 1s, I see occasional timeouts where it flickers back to false and then true. Sets network connected before first render of main network page eliminates flickering.