### PR TITLE
bump max python version to 3.13.0 and update reg.exp pattern VERSION

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openpilot"
-requires-python = ">= 3.12.3, < 3.13"
+requires-python = ">= 3.12.3, < 3.13.0"
 license = {text = "MIT License"}
 version = "0.1.0"
 description = "an open source driver assistance system"

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -163,7 +163,7 @@ function op_check_python() {
   else
     LB=$(echo $REQUIRED_PYTHON_VERSION | tr -d -c '[0-9,]' | cut -d ',' -f1)
     UB=$(echo $REQUIRED_PYTHON_VERSION | tr -d -c '[0-9,]' | cut -d ',' -f2)
-    VERSION=$(echo $INSTALLED_PYTHON_VERSION | grep -o '[0-9]\+\.[0-9]\+' | tr -d -c '[0-9]')
+    VERSION=$(echo $INSTALLED_PYTHON_VERSION | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | tr -d -c '[0-9]')
     if [[ $VERSION -ge LB && $VERSION -lt UB ]]; then
       echo -e " ↳ [${GREEN}✔${NC}] $INSTALLED_PYTHON_VERSION detected."
     else


### PR DESCRIPTION
tools/op.sh setup script errored in function op_check_python()

if [[ $VERSION -ge LB && $VERSION -lt UB ]]; then

if [ 3123 -ge 3120 ] && [ 3123 -lt 313 ]; then