### PR TITLE
Clean up four keyboard text rects

### DIFF
--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -185,19 +185,12 @@ class BigInputDialog(BigDialogBase):
     text = self._keyboard.text()
     candidate_char = self._keyboard.get_candidate_character()
     text_size = measure_text_cached(gui_app.font(FontWeight.ROMAN), text + candidate_char or self._hint_label.text, text_input_size)
-    text_x = PADDING * 2 + self._enter_img.width + 5
 
-    # text needs to move left if we're at the end where right button is
-    # text_rect = rl.Rectangle(text_x,
-    #                          int(self._rect.y + PADDING),
-    #                          # clip width to right button when in view
-    #                          int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width + 5),  # TODO: why 5?
-    #                          int(text_size.y))
+    bg_block_margin = 5
+    text_x = PADDING * 2 + self._enter_img.width + bg_block_margin
 
-    # draw rounded background for text input
-    bg_block_margin = 0#5
-    text_field_rect = rl.Rectangle(text_x - bg_block_margin, int(self._rect.y + PADDING) - 5,
-                                   int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width + 5) + bg_block_margin * 2 - 10,
+    text_field_rect = rl.Rectangle(text_x, int(self._rect.y + PADDING) - bg_block_margin,
+                                   int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width + 5) - bg_block_margin * 2,
                                    int(text_size.y))
 
     # draw text input

--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -16,7 +16,7 @@ from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.selfdrive.ui.mici.widgets.button import BigButton
 from openpilot.selfdrive.ui.mici.widgets.side_button import SideButton
 
-DEBUG = True
+DEBUG = False
 
 PADDING = 20
 
@@ -247,7 +247,6 @@ class BigInputDialog(BigDialogBase):
     # draw debugging rect bounds
     if DEBUG:
       rl.draw_rectangle_lines_ex(text_field_rect, 1, rl.Color(100, 100, 100, 255))
-      # rl.draw_rectangle_lines_ex(text_rect, 1, rl.Color(0, 255, 0, 255))
       rl.draw_rectangle_lines_ex(self._top_right_button_rect, 1, rl.Color(0, 255, 0, 255))
       rl.draw_rectangle_lines_ex(self._top_left_button_rect, 1, rl.Color(0, 255, 0, 255))
 

--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -16,7 +16,7 @@ from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.selfdrive.ui.mici.widgets.button import BigButton
 from openpilot.selfdrive.ui.mici.widgets.side_button import SideButton
 
-DEBUG = False
+DEBUG = True
 
 PADDING = 20
 
@@ -185,47 +185,48 @@ class BigInputDialog(BigDialogBase):
     text = self._keyboard.text()
     candidate_char = self._keyboard.get_candidate_character()
     text_size = measure_text_cached(gui_app.font(FontWeight.ROMAN), text + candidate_char or self._hint_label.text, text_input_size)
-    text_x = PADDING * 2 + self._enter_img.width
+    text_x = PADDING * 2 + self._enter_img.width + 5
 
     # text needs to move left if we're at the end where right button is
-    text_rect = rl.Rectangle(text_x,
-                             int(self._rect.y + PADDING),
-                             # clip width to right button when in view
-                             int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width + 5),  # TODO: why 5?
-                             int(text_size.y))
+    # text_rect = rl.Rectangle(text_x,
+    #                          int(self._rect.y + PADDING),
+    #                          # clip width to right button when in view
+    #                          int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width + 5),  # TODO: why 5?
+    #                          int(text_size.y))
 
     # draw rounded background for text input
-    bg_block_margin = 5
-    text_field_rect = rl.Rectangle(text_rect.x - bg_block_margin, text_rect.y - bg_block_margin,
-                                   text_rect.width + bg_block_margin * 2, text_input_size + bg_block_margin * 2)
+    bg_block_margin = 0#5
+    text_field_rect = rl.Rectangle(text_x - bg_block_margin, int(self._rect.y + PADDING) - 5,
+                                   int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width + 5) + bg_block_margin * 2 - 10,
+                                   int(text_size.y))
 
     # draw text input
     # push text left with a gradient on left side if too long
-    if text_size.x > text_rect.width:
-      text_x -= text_size.x - text_rect.width
+    if text_size.x > text_field_rect.width:
+      text_x -= text_size.x - text_field_rect.width
 
-    rl.begin_scissor_mode(int(text_rect.x), int(text_rect.y), int(text_rect.width), int(text_rect.height))
-    rl.draw_text_ex(gui_app.font(FontWeight.ROMAN), text, rl.Vector2(text_x, text_rect.y), text_input_size, 0, rl.WHITE)
+    rl.begin_scissor_mode(int(text_field_rect.x), int(text_field_rect.y), int(text_field_rect.width), int(text_field_rect.height))
+    rl.draw_text_ex(gui_app.font(FontWeight.ROMAN), text, rl.Vector2(text_x, text_field_rect.y), text_input_size, 0, rl.WHITE)
 
     # draw grayed out character user is hovering over
     if candidate_char:
       candidate_char_size = measure_text_cached(gui_app.font(FontWeight.ROMAN), candidate_char, text_input_size)
       rl.draw_text_ex(gui_app.font(FontWeight.ROMAN), candidate_char,
-                      rl.Vector2(min(text_x + text_size.x, text_rect.x + text_rect.width) - candidate_char_size.x, text_rect.y),
+                      rl.Vector2(min(text_x + text_size.x, text_field_rect.x + text_field_rect.width) - candidate_char_size.x, text_field_rect.y),
                       text_input_size, 0, rl.Color(255, 255, 255, 128))
 
     rl.end_scissor_mode()
 
     # draw gradient on left side to indicate more text
-    if text_size.x > text_rect.width:
-      rl.draw_rectangle_gradient_h(int(text_rect.x), int(text_rect.y), 80, int(text_rect.height),
+    if text_size.x > text_field_rect.width:
+      rl.draw_rectangle_gradient_h(int(text_field_rect.x), int(text_field_rect.y), 80, int(text_field_rect.height),
                                    rl.BLACK, rl.BLANK)
 
     # draw cursor
     if text:
       blink_alpha = (math.sin(rl.get_time() * 6) + 1) / 2
-      cursor_x = min(text_x + text_size.x + 3, text_rect.x + text_rect.width)
-      rl.draw_rectangle_rounded(rl.Rectangle(int(cursor_x), int(text_rect.y), 4, int(text_size.y)),
+      cursor_x = min(text_x + text_size.x + 3, text_field_rect.x + text_field_rect.width)
+      rl.draw_rectangle_rounded(rl.Rectangle(int(cursor_x), int(text_field_rect.y), 4, int(text_size.y)),
                                 1, 4, rl.Color(255, 255, 255, int(255 * blink_alpha)))
 
     # draw backspace icon with nice fade
@@ -255,7 +256,7 @@ class BigInputDialog(BigDialogBase):
     # draw debugging rect bounds
     if DEBUG:
       rl.draw_rectangle_lines_ex(text_field_rect, 1, rl.Color(100, 100, 100, 255))
-      rl.draw_rectangle_lines_ex(text_rect, 1, rl.Color(0, 255, 0, 255))
+      # rl.draw_rectangle_lines_ex(text_rect, 1, rl.Color(0, 255, 0, 255))
       rl.draw_rectangle_lines_ex(self._top_right_button_rect, 1, rl.Color(0, 255, 0, 255))
       rl.draw_rectangle_lines_ex(self._top_left_button_rect, 1, rl.Color(0, 255, 0, 255))
 

--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -132,6 +132,7 @@ class BigConfirmationDialogV2(BigDialogBase):
 class BigInputDialog(BigDialogBase):
   BACK_TOUCH_AREA_PERCENTAGE = 0.2
   BACKSPACE_RATE = 25  # hz
+  TEXT_INPUT_SIZE = 35
 
   def __init__(self,
                hint: str,
@@ -179,16 +180,13 @@ class BigInputDialog(BigDialogBase):
       self._backspace_held_time = None
 
   def _render(self, _):
-    text_input_size = 35
-
     # draw current text so far below everything. text floats left but always stays in view
     text = self._keyboard.text()
     candidate_char = self._keyboard.get_candidate_character()
-    text_size = measure_text_cached(gui_app.font(FontWeight.ROMAN), text + candidate_char or self._hint_label.text, text_input_size)
+    text_size = measure_text_cached(gui_app.font(FontWeight.ROMAN), text + candidate_char or self._hint_label.text, self.TEXT_INPUT_SIZE)
 
     bg_block_margin = 5
     text_x = PADDING * 2 + self._enter_img.width + bg_block_margin
-
     text_field_rect = rl.Rectangle(text_x, int(self._rect.y + PADDING) - bg_block_margin,
                                    int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width) - bg_block_margin * 2,
                                    int(text_size.y))
@@ -199,14 +197,14 @@ class BigInputDialog(BigDialogBase):
       text_x -= text_size.x - text_field_rect.width
 
     rl.begin_scissor_mode(int(text_field_rect.x), int(text_field_rect.y), int(text_field_rect.width), int(text_field_rect.height))
-    rl.draw_text_ex(gui_app.font(FontWeight.ROMAN), text, rl.Vector2(text_x, text_field_rect.y), text_input_size, 0, rl.WHITE)
+    rl.draw_text_ex(gui_app.font(FontWeight.ROMAN), text, rl.Vector2(text_x, text_field_rect.y), self.TEXT_INPUT_SIZE, 0, rl.WHITE)
 
     # draw grayed out character user is hovering over
     if candidate_char:
-      candidate_char_size = measure_text_cached(gui_app.font(FontWeight.ROMAN), candidate_char, text_input_size)
+      candidate_char_size = measure_text_cached(gui_app.font(FontWeight.ROMAN), candidate_char, self.TEXT_INPUT_SIZE)
       rl.draw_text_ex(gui_app.font(FontWeight.ROMAN), candidate_char,
                       rl.Vector2(min(text_x + text_size.x, text_field_rect.x + text_field_rect.width) - candidate_char_size.x, text_field_rect.y),
-                      text_input_size, 0, rl.Color(255, 255, 255, 128))
+                      self.TEXT_INPUT_SIZE, 0, rl.Color(255, 255, 255, 128))
 
     rl.end_scissor_mode()
 

--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -190,7 +190,7 @@ class BigInputDialog(BigDialogBase):
     text_x = PADDING * 2 + self._enter_img.width + bg_block_margin
 
     text_field_rect = rl.Rectangle(text_x, int(self._rect.y + PADDING) - bg_block_margin,
-                                   int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width + 5) - bg_block_margin * 2,
+                                   int(self._rect.width - text_x - PADDING * 2 - self._enter_img.width) - bg_block_margin * 2,
                                    int(text_size.y))
 
     # draw text input


### PR DESCRIPTION
one instead of two. also more closely matches figma by accident

old:

<img width="534" height="238" alt="image" src="https://github.com/user-attachments/assets/ec165f28-dfcd-49cb-9d78-be80a572afaf" />

new (more vertically centered):

<img width="534" height="241" alt="image" src="https://github.com/user-attachments/assets/844c39ae-f041-4309-a588-bf01ac0f1809" />

old:

<img width="535" height="240" alt="image" src="https://github.com/user-attachments/assets/f83c7770-aff6-422d-b434-602b931f2932" />


new (more visually equal space on the right vs. left):

<img width="537" height="239" alt="image" src="https://github.com/user-attachments/assets/923caf12-1b3d-4ee1-b1be-637f686bf8ea" />
