### PR TITLE
DM: auto reset audible alert coming to a stop

### DIFF
--- a/selfdrive/monitoring/helpers.py
+++ b/selfdrive/monitoring/helpers.py
@@ -382,6 +382,7 @@ class DriverMonitoring:
       if awareness_prev > 0.:
         self.terminal_alert_cnt += 1
     elif self.awareness <= self.threshold_prompt:
+      # prompt orange alert
       alert = EventName.promptDriverDistracted if self.active_monitoring_mode else EventName.promptDriverUnresponsive
     elif self.awareness <= self.threshold_pre:
       # pre green alert

--- a/selfdrive/monitoring/helpers.py
+++ b/selfdrive/monitoring/helpers.py
@@ -345,10 +345,14 @@ class DriverMonitoring:
       self._reset_awareness()
       return
 
-    driver_attentive = self.driver_distraction_filter.x < 0.37
     awareness_prev = self.awareness
+    _reaching_pre = self.awareness - self.step_change <= self.threshold_pre
+    _reaching_terminal = self.awareness - self.step_change <= 0
+    standstill_orange_exemption = standstill and _reaching_pre
+    always_on_red_exemption = always_on_valid and not op_engaged and _reaching_terminal
 
-    if (driver_attentive and self.face_detected and self.pose.low_std and self.awareness > 0):
+    if self.awareness > 0 and \
+       ((self.driver_distraction_filter.x < 0.37 and self.face_detected and self.pose.low_std) or standstill_orange_exemption):
       if driver_engaged:
         self._reset_awareness()
         return
@@ -361,19 +365,13 @@ class DriverMonitoring:
       if self.awareness > self.threshold_prompt:
         return
 
-    _reaching_pre = self.awareness - self.step_change <= self.threshold_pre
-    _reaching_audible = self.awareness - self.step_change <= self.threshold_prompt
-    _reaching_terminal = self.awareness - self.step_change <= 0
-    standstill_exemption = standstill and _reaching_pre
-    always_on_red_exemption = always_on_valid and not op_engaged and _reaching_terminal
-
     certainly_distracted = self.driver_distraction_filter.x > 0.63 and self.driver_distracted and self.face_detected
     maybe_distracted = self.hi_stds > self.settings._HI_STD_FALLBACK_TIME or not self.face_detected
 
     if certainly_distracted or maybe_distracted:
       # should always be counting if distracted unless at standstill and reaching green
       # also will not be reaching 0 if DM is active when not engaged
-      if not (standstill_exemption or always_on_red_exemption):
+      if not (standstill_orange_exemption or always_on_red_exemption):
         self.awareness = max(self.awareness - self.step_change, -0.1)
 
     alert = None
@@ -384,12 +382,7 @@ class DriverMonitoring:
       if awareness_prev > 0.:
         self.terminal_alert_cnt += 1
     elif self.awareness <= self.threshold_prompt:
-      if standstill:
-        # green alert at standstill
-        alert = EventName.preDriverDistracted if self.active_monitoring_mode else EventName.preDriverUnresponsive
-      else:
-        # prompt orange alert
-        alert = EventName.promptDriverDistracted if self.active_monitoring_mode else EventName.promptDriverUnresponsive
+      alert = EventName.promptDriverDistracted if self.active_monitoring_mode else EventName.promptDriverUnresponsive
     elif self.awareness <= self.threshold_pre:
       # pre green alert
       alert = EventName.preDriverDistracted if self.active_monitoring_mode else EventName.preDriverUnresponsive

--- a/selfdrive/monitoring/helpers.py
+++ b/selfdrive/monitoring/helpers.py
@@ -384,8 +384,12 @@ class DriverMonitoring:
       if awareness_prev > 0.:
         self.terminal_alert_cnt += 1
     elif self.awareness <= self.threshold_prompt:
-      # prompt orange alert
-      alert = EventName.promptDriverDistracted if self.active_monitoring_mode else EventName.promptDriverUnresponsive
+      if standstill:
+        # green alert at standstill
+        alert = EventName.preDriverDistracted if self.active_monitoring_mode else EventName.preDriverUnresponsive
+      else:
+        # prompt orange alert
+        alert = EventName.promptDriverDistracted if self.active_monitoring_mode else EventName.promptDriverUnresponsive
     elif self.awareness <= self.threshold_pre:
       # pre green alert
       alert = EventName.preDriverDistracted if self.active_monitoring_mode else EventName.preDriverUnresponsive

--- a/selfdrive/monitoring/test_monitoring.py
+++ b/selfdrive/monitoring/test_monitoring.py
@@ -189,6 +189,18 @@ class TestMonitoring:
     assert events[int((_redlight_time+0.5)/DT_DMON)].names[0] == EventName.preDriverDistracted
     assert events[int((_redlight_time+_pre_to_prompt+0.5)/DT_DMON)].names[0] == EventName.promptDriverDistracted
 
+  # engaged, distracted while moving, then car stops after reaching orange
+  #  - should downgrade to green alert when stopped, even if already in orange zone
+  def test_distracted_then_stops(self):
+    _stop_time = DISTRACTED_SECONDS_TO_ORANGE + 1  # stop 1 second after reaching orange
+    standstill_vector = always_false[:]
+    standstill_vector[int(_stop_time/DT_DMON):] = [True] * int((TEST_TIMESPAN-_stop_time)/DT_DMON)
+    events, _ = self._run_seq(always_distracted, always_false, always_true, standstill_vector)
+    # just before stopping: orange alert (car is moving, in orange zone)
+    assert events[int((_stop_time-0.1)/DT_DMON)].names[0] == EventName.promptDriverDistracted
+    # just after stopping: green alert (standstill downgrades orange to green)
+    assert events[int((_stop_time+0.5)/DT_DMON)].names[0] == EventName.preDriverDistracted
+
   # engaged, model is somehow uncertain and driver is distracted
   #  - should fall back to wheel touch after uncertain alert
   def test_somehow_indecisive_model(self):

--- a/selfdrive/monitoring/test_monitoring.py
+++ b/selfdrive/monitoring/test_monitoring.py
@@ -196,10 +196,9 @@ class TestMonitoring:
     standstill_vector = always_false[:]
     standstill_vector[int(_stop_time/DT_DMON):] = [True] * int((TEST_TIMESPAN-_stop_time)/DT_DMON)
     events, _ = self._run_seq(always_distracted, always_false, always_true, standstill_vector)
-    # just before stopping: orange alert (car is moving, in orange zone)
-    assert events[int((_stop_time-0.1)/DT_DMON)].names[0] == EventName.promptDriverDistracted
-    # just after stopping: green alert (standstill downgrades orange to green)
-    assert events[int((_stop_time+0.5)/DT_DMON)].names[0] == EventName.preDriverDistracted
+    # just before and briefly after stopping: orange alert; goes away quickly after stopped
+    assert events[int((_stop_time+0.1)/DT_DMON)].names[0] == EventName.promptDriverDistracted
+    assert len(events[int((_stop_time+0.5)/DT_DMON)]) == 0
 
   # engaged, model is somehow uncertain and driver is distracted
   #  - should fall back to wheel touch after uncertain alert

--- a/selfdrive/monitoring/test_monitoring.py
+++ b/selfdrive/monitoring/test_monitoring.py
@@ -190,7 +190,7 @@ class TestMonitoring:
     assert events[int((_redlight_time+_pre_to_prompt+0.5)/DT_DMON)].names[0] == EventName.promptDriverDistracted
 
   # engaged, distracted while moving, then car stops after reaching orange
-  #  - should downgrade to green alert when stopped, even if already in orange zone
+  #  - should reset timer to pre green at standstill
   def test_distracted_then_stops(self):
     _stop_time = DISTRACTED_SECONDS_TO_ORANGE + 1  # stop 1 second after reaching orange
     standstill_vector = always_false[:]


### PR DESCRIPTION
When awareness reaches orange while driving and the vehicle then stops, downgrade to `preDriverDistracted` (visual-only) instead of `promptDriverDistracted` (audible).

The existing `standstill_orange_exemption` pauses the countdown at the orange boundary, but doesn't handle the case where the driver was already past it when they stopped. The awareness value is preserved — only the alert level changes at standstill — so when the car moves again, it snaps back to orange immediately.

- Countdown: unchanged (pauses at orange boundary when stopped)
- Red alert: unchanged (safety)
- New test: `test_distracted_then_stops`

---

**EDIT:** The merged version takes a different approach. Instead of overriding the alert level at standstill, the `standstill_orange_exemption` is moved into the awareness *recovery* condition. When stopped and in the orange zone, the driver is treated as attentive, which triggers the existing recovery logic and awareness naturally climbs back above the prompt threshold. The audible alert disappears on its own rather than being masked. This avoids special-casing the alert selection and keeps the alert logic clean.