### PR TITLE
tools: fix Python version comparison using normalized semantic version format

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -161,9 +161,9 @@ function op_check_python() {
     loge "ERROR_PYTHON_NOT_FOUND"
     return 1
   else
-    LB=$(echo $REQUIRED_PYTHON_VERSION | tr -d -c '[0-9,]' | cut -d ',' -f1)
-    UB=$(echo $REQUIRED_PYTHON_VERSION | tr -d -c '[0-9,]' | cut -d ',' -f2)
-    VERSION=$(echo $INSTALLED_PYTHON_VERSION | grep -o '[0-9]\+\.[0-9]\+' | tr -d -c '[0-9]')
+    LB=$(echo $REQUIRED_PYTHON_VERSION | tr -d '",' | awk '{ split($4, v, "."); printf "%d%02d%02d", v[1], v[2], v[3] }')
+    UB=$(echo $REQUIRED_PYTHON_VERSION | tr -d '",' | awk '{ split($6, v, "."); printf "%d%02d%02d", v[1], v[2], v[3] }')
+    VERSION=$(echo $INSTALLED_PYTHON_VERSION | awk '{ split($2, v, "."); printf "%d%02d%02d", v[1], v[2], v[3] }')
     if [[ $VERSION -ge LB && $VERSION -lt UB ]]; then
       echo -e " ↳ [${GREEN}✔${NC}] $INSTALLED_PYTHON_VERSION detected."
     else


### PR DESCRIPTION
**Description**

- Fixes https://github.com/commaai/openpilot/issues/37063
- Introduced in https://github.com/commaai/openpilot/pull/37052, `tools/op.sh` incorrectly identified valid Python versions (e.g. `3.12.3`) as incompatible or older than requirements due to simply stripping dots (treating `3.12.3` as `3123`, numerically greater than `3.13` treated as `313`).
- Replaced version extraction logic to normalize versions into padded integers (e.g. `3.12.3` becomes `31203`) for correct numerical comparison.

**Verification**

- **Before**
```bash
$ ./tools/op.sh check
...
Checking for compatible python version...
LB=3123, UB=313, VERSION=312
 ↳ [✗] You need a python version satisfying  ">= 3.12.3, < 3.13" to continue!
 ```

- **After**
```bash
$ ./tools/op.sh check
...
Checking for compatible python version...
LB=31203, UB=31300, VERSION=31204
 ↳ [✔] Python 3.12.4 detected.
 ```