### PR TITLE
native process: optimize constants

### DIFF
--- a/selfdrive/pandad/panda.cc
+++ b/selfdrive/pandad/panda.cc
@@ -269,12 +269,13 @@ bool Panda::unpack_can_buffer(uint8_t *data, uint32_t &size, std::vector<can_fra
     memcpy(&header, &data[pos], sizeof(can_header));
 
     const uint8_t data_len = dlc_to_len[header.data_len_code];
-    if (pos + sizeof(can_header) + data_len > size) {
+    const size_t msg_len = sizeof(can_header) + data_len;
+    if (pos + msg_len > size) {
       // we don't have all the data for this message yet
       break;
     }
 
-    if (calculate_checksum(&data[pos], sizeof(can_header) + data_len) != 0) {
+    if (calculate_checksum(&data[pos], msg_len) != 0) {
       LOGE("Panda CAN checksum failed");
       size = 0;
       can_reset_communications();
@@ -293,7 +294,7 @@ bool Panda::unpack_can_buffer(uint8_t *data, uint32_t &size, std::vector<can_fra
 
     canData.dat.assign((char *)&data[pos + sizeof(can_header)], data_len);
 
-    pos += sizeof(can_header) + data_len;
+    pos += msg_len;
   }
 
   // move the overflowing data to the beginning of the buffer for the next round

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -508,9 +508,10 @@ void pandad_main_thread(std::vector<std::string> serials) {
   }
 
   std::string serials_str;
-  for (int i = 0; i < serials.size(); i++) {
+  const size_t num_serials = serials.size();
+  for (size_t i = 0; i < num_serials; i++) {
     serials_str += serials[i];
-    if (i < serials.size() - 1) serials_str += ", ";
+    if (i < num_serials - 1) serials_str += ", ";
   }
   LOGW("connecting to pandas: %s", serials_str.c_str());
 

--- a/system/camerad/cameras/camera_common.cc
+++ b/system/camerad/cameras/camera_common.cc
@@ -76,8 +76,9 @@ float calculate_exposure_value(const CameraBuf *b, Rect ae_xywh, int x_skip, int
 
   unsigned int lum_total = 0;
   for (int y = ae_xywh.y; y < ae_xywh.y + ae_xywh.h; y += y_skip) {
+    const int row_offset = y * b->out_img_width;
     for (int x = ae_xywh.x; x < ae_xywh.x + ae_xywh.w; x += x_skip) {
-      uint8_t lum = pix_ptr[(y * b->out_img_width) + x];
+      uint8_t lum = pix_ptr[row_offset + x];
       lum_binning[lum]++;
       lum_total += 1;
     }

--- a/system/loggerd/encoderd.cc
+++ b/system/loggerd/encoderd.cc
@@ -53,6 +53,7 @@ void encoder_thread(EncoderdState *s, const LogCameraInfo &cam_info) {
 
   std::unique_ptr<JpegEncoder> jpeg_encoder;
 
+  const int frames_per_seg = SEGMENT_LENGTH * MAIN_FPS;
   int cur_seg = 0;
   while (!do_exit) {
     if (!vipc_client.connect(false)) {
@@ -99,7 +100,6 @@ void encoder_thread(EncoderdState *s, const LogCameraInfo &cam_info) {
       if (do_exit) break;
 
       // do rotation if required
-      const int frames_per_seg = SEGMENT_LENGTH * MAIN_FPS;
       if (cur_seg >= 0 && extra.frame_id >= ((cur_seg + 1) * frames_per_seg) + s->start_frame_id) {
         for (auto &e : encoders) {
           e->encoder_close();

--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -14,7 +14,7 @@
 ExitHandler do_exit;
 
 constexpr int MAX_QUEUE_SIZE = MAIN_FPS * 10;
-constexpr double SEGMENT_LENGTH_TIMEOUT = SEGMENT_LENGTH * 1.2;
+const double SEGMENT_LENGTH_TIMEOUT = SEGMENT_LENGTH * 1.2;
 
 struct LoggerdState {
   LoggerState logger;


### PR DESCRIPTION
## Summary

- Move constant calculations outside of hot loops to reduce runtime overhead
- `frames_per_seg` in encoderd: moved from inner frame loop to thread initialization
- `MAX_QUEUE_SIZE` and `SEGMENT_LENGTH_TIMEOUT` in loggerd: extracted as file-level constants

## Changes

**encoderd.cc:**
- Move `frames_per_seg = SEGMENT_LENGTH * MAIN_FPS` outside the frame processing loop (was calculated ~60 times/sec per camera)

**loggerd.cc:**
- Add `constexpr int MAX_QUEUE_SIZE = MAIN_FPS * 10`
- Add `const double SEGMENT_LENGTH_TIMEOUT = SEGMENT_LENGTH * 1.2`

**camera_common.cc:**
- Cache `y * out_img_width` as `row_offset` in outer loop (was calculated per pixel in exposure calculation)

**panda.cc:**
- Cache `sizeof(can_header) + data_len` as `msg_len` (was calculated 3 times per CAN message)

**pandad.cc:**
- Cache `serials.size()` as `num_serials` before loop
