### PR TITLE
test: optimize test_car_interfaces performance

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -16,6 +16,7 @@ from openpilot.selfdrive.controls.lib.longcontrol import LongControl
 from openpilot.selfdrive.test.fuzzy_generation import FuzzyGenerator
 
 MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '60'))
+DT_CTRL_NANOS = int(DT_CTRL * 1e9)  # 10ms in nanoseconds
 
 
 class TestCarInterfaces:
@@ -30,24 +31,26 @@ class TestCarInterfaces:
     car_params = car_interface.CP.as_reader()
 
     cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
-    # Run car interface
-    now_nanos = 0
-    CC = car.CarControl.new_message(**cc_msg)
-    CC = CC.as_reader()
-    for _ in range(10):
-      car_interface.update([])
-      car_interface.apply(CC, now_nanos)
-      now_nanos += DT_CTRL * 1e9  # 10 ms
 
-    CC = car.CarControl.new_message(**cc_msg)
-    CC.enabled = True
-    CC.latActive = True
-    CC.longActive = True
-    CC = CC.as_reader()
+    # Pre-create CC messages to avoid repeated creation in loops
+    CC_fuzzy = car.CarControl.new_message(**cc_msg).as_reader()
+    cc_msg['enabled'] = True
+    cc_msg['latActive'] = True
+    cc_msg['longActive'] = True
+    CC_enabled = car.CarControl.new_message(**cc_msg).as_reader()
+
+    # Run car interface with fuzzy input
+    now_nanos = 0
     for _ in range(10):
       car_interface.update([])
-      car_interface.apply(CC, now_nanos)
-      now_nanos += DT_CTRL * 1e9  # 10ms
+      car_interface.apply(CC_fuzzy, now_nanos)
+      now_nanos += DT_CTRL_NANOS
+
+    # Run with enabled=True
+    for _ in range(10):
+      car_interface.update([])
+      car_interface.apply(CC_enabled, now_nanos)
+      now_nanos += DT_CTRL_NANOS
 
     # Test controller initialization
     # TODO: wait until card refactor is merged to run controller a few times,


### PR DESCRIPTION
- Pre-compute DT_CTRL_NANOS constant to avoid repeated float multiplication
- Pre-create CC messages outside loops to avoid repeated message creation
- Reuse cc_msg dict for enabled state instead of creating new message

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

