### PR TITLE
hardwared: gracefully handle no thermal readings

### DIFF
--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -40,8 +40,8 @@ class ThermalZone:
     try:
       with open(f"/sys/devices/virtual/thermal/thermal_zone{self.zone_number}/temp") as f:
         return int(f.read()) / self.scale
-    except FileNotFoundError:
-      return 0
+    except Exception:
+      return float('nan')
 
 @dataclass
 class ThermalConfig:

--- a/system/hardware/fan_controller.py
+++ b/system/hardware/fan_controller.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import math
+
 import numpy as np
 
 from openpilot.common.pid import PIDController
@@ -16,6 +18,10 @@ class FanController:
     if ignition != self.last_ignition:
       self.controller.reset()
     self.last_ignition = ignition
+
+    # guard against NaN/Inf from failed sensor reads
+    if not math.isfinite(cur_temp):
+      cur_temp = 0.
 
     return int(self.controller.update(
                  error=(cur_temp - 75),  # temperature setpoint in C

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -117,12 +117,18 @@ class Tici(HardwareBase):
     return self.get_cmdline()['androidboot.serialno']
 
   def get_voltage(self):
-    with open("/sys/class/hwmon/hwmon1/in1_input") as f:
-      return int(f.read())
+    try:
+      with open("/sys/class/hwmon/hwmon1/in1_input") as f:
+        return int(f.read())
+    except Exception:
+      return 0
 
   def get_current(self):
-    with open("/sys/class/hwmon/hwmon1/curr1_input") as f:
-      return int(f.read())
+    try:
+      with open("/sys/class/hwmon/hwmon1/curr1_input") as f:
+        return int(f.read())
+    except Exception:
+      return 0
 
   def set_ir_power(self, percent: int):
     if self.get_device_type() == "tizi":


### PR DESCRIPTION
## Summary
- Return NaN instead of crashing when thermal sensor reads fail
- Filter out NaN values in downstream temperature calculations
- Add NaN guard in fan controller

## Test plan
- Simulate thermal sensor failure by making `/sys/devices/virtual/thermal/thermal_zone*/temp` unreadable
- Verify hardwared continues running without crash
- Verify fan control operates with fallback values

Fixes #36690
