### PR TITLE
clips: improve overlays for mici

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -238,25 +238,56 @@ def draw_text_box(rl, text, x, y, size, gui_app, font, font_scale, color=None, c
   rl.draw_text_ex(font, text, rl.Vector2(x, y), size, 0, text_color)
 
 
-def render_overlays(rl, gui_app, font, font_scale, metadata, title, start_time, frame_idx, show_metadata, show_time):
+def _wrap_text_by_delimiter(text: str, rl, font, font_size: int, font_scale: float, max_width: int, delimiter: str = ", ") -> list[str]:
+  """Wrap text by splitting on delimiter when it exceeds max_width."""
+  words = text.split(delimiter)
+  lines: list[str] = []
+  current_line: list[str] = []
+  # Build lines word by word
+  for word in words:
+    current_line.append(word)
+    check_line = delimiter.join(current_line)
+    # Check if line exceeds max width
+    if rl.measure_text_ex(font, check_line, font_size * font_scale, 0).x > max_width:
+      current_line.pop()  # Line is too long, move word to next line
+      if current_line:
+        lines.append(delimiter.join(current_line))
+      current_line = [word]
+  # Add leftover words as last line
+  if current_line:
+    lines.append(delimiter.join(current_line))
+  return lines
+
+
+def render_overlays(rl, gui_app, font, font_scale, big, metadata, title, start_time, frame_idx, show_metadata, show_time):
+  metadata_size = 16 if big else 11
+  title_size = 32 if big else 24
+  time_size = 24 if big else 16
+
+  # Metadata overlay
   if show_metadata and metadata and frame_idx < FRAMERATE * 5:
     m = metadata
     text = ", ".join([f"openpilot v{m['version']}", f"route: {m['route']}", f"car: {m['car']}", f"origin: {m['origin']}",
                       f"branch: {m['branch']}", f"commit: {m['commit']}", f"modified: {m['modified']}"])
-    # Truncate if too wide (leave 20px margin on each side)
-    max_width = gui_app.width - 40
-    while rl.measure_text_ex(font, text, 15 * font_scale, 0).x > max_width and len(text) > 20:
-      text = text[:-4] + "..."
-    draw_text_box(rl, text, 0, 8, 15, gui_app, font, font_scale, center=True)
+    # Wrap text if too wide (leave margin on each side)
+    max_width = gui_app.width - (time_size * 6)  # roughly enough margin for the time overlay
+    lines = _wrap_text_by_delimiter(text, rl, font, metadata_size, font_scale, max_width)
 
+    # Draw wrapped metadata text
+    line_height = int(rl.measure_text_ex(font, "A", metadata_size * font_scale, 0).y) + 4  # line height with padding
+    for i, line in enumerate(lines):
+      draw_text_box(rl, line, 0, 6 + i * line_height, metadata_size, gui_app, font, font_scale, center=True)
+
+  # Title overlay
   if title:
-    draw_text_box(rl, title, 0, 60, 32, gui_app, font, font_scale, center=True)
+    draw_text_box(rl, title, 0, 60, title_size, gui_app, font, font_scale, center=True)
 
+  # Time overlay
   if show_time:
     t = start_time + frame_idx / FRAMERATE
     time_text = f"{int(t)//60:02d}:{int(t)%60:02d}"
-    time_width = int(rl.measure_text_ex(font, time_text, 24 * font_scale, 0).x)
-    draw_text_box(rl, time_text, gui_app.width - time_width - 45, 45, 24, gui_app, font, font_scale)
+    time_width = int(rl.measure_text_ex(font, time_text, time_size * font_scale, 0).x)
+    draw_text_box(rl, time_text, gui_app.width - time_width - 5, 0, time_size, gui_app, font, font_scale)
 
 
 def clip(route: Route, output: str, start: int, end: int, headless: bool = True, big: bool = False,
@@ -313,7 +344,7 @@ def clip(route: Route, output: str, start: int, end: int, headless: bool = True,
         ui_state.update()
         if should_render:
           road_view.render()
-          render_overlays(rl, gui_app, font, FONT_SCALE, metadata, title, start, frame_idx, show_metadata, show_time)
+          render_overlays(rl, gui_app, font, FONT_SCALE, big, metadata, title, start, frame_idx, show_metadata, show_time)
         frame_idx += 1
         pbar.update(1)
     timer.lap("render")

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -264,13 +264,22 @@ def render_overlays(rl, gui_app, font, font_scale, big, metadata, title, start_t
   title_size = 32 if big else 24
   time_size = 24 if big else 16
 
+  # Time overlay
+  time_width = 0
+  if show_time:
+    t = start_time + frame_idx / FRAMERATE
+    time_text = f"{int(t) // 60:02d}:{int(t) % 60:02d}"
+    time_width = int(rl.measure_text_ex(font, time_text, time_size * font_scale, 0).x)
+    draw_text_box(rl, time_text, gui_app.width - time_width - 5, 0, time_size, gui_app, font, font_scale)
+
   # Metadata overlay (first 5 seconds only)
   if show_metadata and metadata and frame_idx < FRAMERATE * 5:
     m = metadata
     text = ", ".join([f"openpilot v{m['version']}", f"route: {m['route']}", f"car: {m['car']}", f"origin: {m['origin']}",
                       f"branch: {m['branch']}", f"commit: {m['commit']}", f"modified: {m['modified']}"])
     # Wrap text if too wide (leave margin on each side)
-    max_width = gui_app.width - (time_size * 6)  # roughly enough margin for the time overlay
+    margin = 2 * (time_width + 10 if show_time else 20)  # leave enough margin for time overlay
+    max_width = gui_app.width - margin
     lines = _wrap_text_by_delimiter(text, rl, font, metadata_size, font_scale, max_width)
 
     # Draw wrapped metadata text
@@ -283,13 +292,6 @@ def render_overlays(rl, gui_app, font, font_scale, big, metadata, title, start_t
   # Title overlay
   if title:
     draw_text_box(rl, title, 0, 60, title_size, gui_app, font, font_scale, center=True)
-
-  # Time overlay
-  if show_time:
-    t = start_time + frame_idx / FRAMERATE
-    time_text = f"{int(t)//60:02d}:{int(t)%60:02d}"
-    time_width = int(rl.measure_text_ex(font, time_text, time_size * font_scale, 0).x)
-    draw_text_box(rl, time_text, gui_app.width - time_width - 5, 0, time_size, gui_app, font, font_scale)
 
 
 def clip(route: Route, output: str, start: int, end: int, headless: bool = True, big: bool = False,

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -274,9 +274,11 @@ def render_overlays(rl, gui_app, font, font_scale, big, metadata, title, start_t
     lines = _wrap_text_by_delimiter(text, rl, font, metadata_size, font_scale, max_width)
 
     # Draw wrapped metadata text
-    line_height = int(rl.measure_text_ex(font, "A", metadata_size * font_scale, 0).y) + 4  # line height with padding
-    for i, line in enumerate(lines):
-      draw_text_box(rl, line, 0, 6 + i * line_height, metadata_size, gui_app, font, font_scale, center=True)
+    y_offset = 6
+    for line in lines:
+      draw_text_box(rl, line, 0, y_offset, metadata_size, gui_app, font, font_scale, center=True)
+      line_height = int(rl.measure_text_ex(font, line, metadata_size * font_scale, 0).y) + 4
+      y_offset += line_height
 
   # Title overlay
   if title:

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -260,7 +260,7 @@ def _wrap_text_by_delimiter(text: str, rl, font, font_size: int, font_scale: flo
 
 
 def render_overlays(rl, gui_app, font, font_scale, big, metadata, title, start_time, frame_idx, show_metadata, show_time):
-  metadata_size = 16 if big else 11
+  metadata_size = 16 if big else 12
   title_size = 32 if big else 24
   time_size = 24 if big else 16
 

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -272,7 +272,7 @@ def render_overlays(rl, gui_app, font, font_scale, big, metadata, title, start_t
     time_width = int(rl.measure_text_ex(font, time_text, time_size * font_scale, 0).x)
     draw_text_box(rl, time_text, gui_app.width - time_width - 5, 0, time_size, gui_app, font, font_scale)
 
-  # Metadata overlay (first 5 seconds only)
+  # Metadata overlay (first 5 seconds)
   if show_metadata and metadata and frame_idx < FRAMERATE * 5:
     m = metadata
     text = ", ".join([f"openpilot v{m['version']}", f"route: {m['route']}", f"car: {m['car']}", f"origin: {m['origin']}",

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -264,7 +264,7 @@ def render_overlays(rl, gui_app, font, font_scale, big, metadata, title, start_t
   title_size = 32 if big else 24
   time_size = 24 if big else 16
 
-  # Metadata overlay
+  # Metadata overlay (first 5 seconds only)
   if show_metadata and metadata and frame_idx < FRAMERATE * 5:
     m = metadata
     text = ", ".join([f"openpilot v{m['version']}", f"route: {m['route']}", f"car: {m['car']}", f"origin: {m['origin']}",


### PR DESCRIPTION
**Summary of changes:**
1. Make the overlay texts smaller on mici.
2. Wrap the metadata text if it's too long instead of truncating.
3. Move the time overlay to the top right (looks better on mici especially).

### Clip comparisons:
| Old (mici) | New (mici) |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/af969260-e7d5-4044-bdcd-26c90a7710c7"/> | <video src="https://github.com/user-attachments/assets/83910a12-d062-4652-a600-24415dafa5cb" />|

#### Old (big):

https://github.com/user-attachments/assets/0df4552f-075d-4449-86ed-781d59090974

#### New (big):

https://github.com/user-attachments/assets/09c19b20-4c3d-4a5f-b972-a9ba943961a1

