### PR TITLE
mici ui replay: refactor events to support custom delay

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -94,7 +94,7 @@ def run_replay():
   next_event_time = 0.0
 
   for should_render in gui_app.render():
-    if script_index < len(SCRIPT) and elapsed_time >= next_event_time:
+    while script_index < len(SCRIPT) and elapsed_time >= next_event_time:
       event = SCRIPT[script_index]
       handle_event(event)
       next_event_time += event.delay

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -33,14 +33,9 @@ class Event:
 
 
 SCRIPT = [
-  Event(delay=0.5),
+  Event(),
   Event(click=True),  # settings
   Event(click=True),  # toggles
-  Event(swipe_left=True, delay=1.5),  # explore toggles
-  Event(swipe_down=True),  # back to settings
-  Event(swipe_left=True, delay=1.5),  # explore settings
-  Event(swipe_down=True),  # back to home
-  Event(swipe_right=True),  # open alerts
   Event(),  # wait
 ]
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -33,10 +33,10 @@ class Event:
 
 
 SCRIPT = [
-  Event(),
-  Event(click=True),  # settings
-  Event(click=True),  # toggles
-  Event(),  # wait
+  Event(),  # wait for initialization
+  Event(click=True),  # open settings
+  Event(click=True),  # open toggles
+  Event(),  # wait to capture last event
 ]
 
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -101,6 +101,7 @@ def run_replay():
       script_index += 1
 
     ui_state.update()
+
     if should_render:
       main_layout.render()
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -36,7 +36,6 @@ SCRIPT = [
   Event(),  # wait for initialization
   Event(click=True),  # open settings
   Event(click=True),  # open toggles
-  Event(),  # wait to capture last event
 ]
 
 
@@ -108,7 +107,7 @@ def run_replay():
     elapsed_time += 1.0 / FPS
     frame += 1
 
-    if script_index >= len(SCRIPT):
+    if script_index >= len(SCRIPT) and elapsed_time >= next_event_time:
       break
 
   gui_app.close()

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -29,7 +29,7 @@ class Event:
   swipe_left: bool = False
   swipe_right: bool = False
   swipe_down: bool = False
-  delay: float = 1.0  # seconds to wait after the event before processing the next one
+  delay: float = 1.0  # seconds to wait after event
 
 
 SCRIPT = [


### PR DESCRIPTION
Instead of manually specifying the time using the FPS, which was ugly, we can just pass in the delay for how long the event should wait before moving to the next one. It's 1 second by default, which is the same. Also I renamed `DummyEvent` to `Event` since the former implies nothing is happening.

This will be more useful for adding future events with different durations.

Extended version of this PR can be found here: #37109. Consider just merging the latter to avoid me having to fix merge conflicts, but this one contains only the refactor without changing the events.