### PR TITLE
mici ui replay: explore more of the UI

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -33,14 +33,9 @@ class Event:
 
 
 SCRIPT = [
-  Event(delay=0.5),
+  Event(),
   Event(click=True),  # settings
   Event(click=True),  # toggles
-  Event(swipe_left=True, delay=1.5),  # explore toggles
-  Event(swipe_down=True),  # back to settings
-  Event(swipe_left=True, delay=1.5),  # explore settings
-  Event(swipe_down=True),  # back to home
-  Event(swipe_right=True),  # open alerts
   Event(),  # wait
 ]
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -33,9 +33,19 @@ class Event:
 
 
 SCRIPT = [
-  Event(),  # wait for initialization
+  Event(delay=0.5),  # home page
+  Event(swipe_right=True, delay=0.75),  # open alerts
+  Event(swipe_left=True, delay=0.5),  # back to home
+  Event(swipe_left=True, delay=0.75),  # onroad view (system booting)
+  Event(click=True, delay=0.5),  # back to home
   Event(click=True),  # open settings
+  Event(swipe_left=True, delay=1.5),  # explore settings
+  Event(swipe_right=True),  # swipe back again
   Event(click=True),  # open toggles
+  Event(swipe_left=True, delay=1.5),  # explore toggles
+  Event(swipe_left=True),  # rest of toggles
+  Event(swipe_down=True, delay=0.5),  # back to settings
+  Event(swipe_down=True, delay=0.5),  # back to home
 ]
 
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -29,23 +29,26 @@ class Event:
   swipe_left: bool = False
   swipe_right: bool = False
   swipe_down: bool = False
-  delay: float = 1.0  # seconds to wait after the event before processing the next one
+  delay: float = 0.5  # seconds to wait after event
 
 
 SCRIPT = [
-  Event(delay=0.5),  # home page
+  Event(),  # home page
   Event(swipe_right=True, delay=0.75),  # open alerts
-  Event(swipe_left=True, delay=0.5),  # back to home
+  Event(swipe_left=True),  # back to home
   Event(swipe_left=True, delay=0.75),  # onroad view (system booting)
-  Event(click=True, delay=0.5),  # back to home
+  Event(click=True),  # back to home
   Event(click=True),  # open settings
-  Event(swipe_left=True, delay=1.5),  # explore settings
-  Event(swipe_right=True),  # swipe back again
+  Event(swipe_left=True, delay=1),  # explore settings
+  Event(click=True),  # open developer settings
+  Event(swipe_left=True, delay=1),  # explore developer settings
+  Event(swipe_down=True),  # back to settings
+  Event(swipe_right=True, delay=1),  # swipe back to beginning of settings
   Event(click=True),  # open toggles
-  Event(swipe_left=True, delay=1.5),  # explore toggles
+  Event(swipe_left=True, delay=1),  # explore toggles
   Event(swipe_left=True),  # rest of toggles
-  Event(swipe_down=True, delay=0.5),  # back to settings
-  Event(swipe_down=True, delay=0.5),  # back to home
+  Event(swipe_down=True),  # back to settings
+  Event(swipe_down=True),  # back to home
 ]
 
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -107,7 +107,7 @@ def run_replay():
   next_event_time = 0.0
 
   for should_render in gui_app.render():
-    if script_index < len(SCRIPT) and elapsed_time >= next_event_time:
+    while script_index < len(SCRIPT) and elapsed_time >= next_event_time:
       event = SCRIPT[script_index]
       handle_event(event)
       next_event_time += event.delay

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -33,10 +33,10 @@ class Event:
 
 
 SCRIPT = [
-  Event(),
-  Event(click=True),  # settings
-  Event(click=True),  # toggles
-  Event(),  # wait
+  Event(),  # wait for initialization
+  Event(click=True),  # open settings
+  Event(click=True),  # open toggles
+  Event(),  # wait to capture last event
 ]
 
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -101,6 +101,7 @@ def run_replay():
       script_index += 1
 
     ui_state.update()
+
     if should_render:
       main_layout.render()
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -36,7 +36,6 @@ SCRIPT = [
   Event(),  # wait for initialization
   Event(click=True),  # open settings
   Event(click=True),  # open toggles
-  Event(),  # wait to capture last event
 ]
 
 
@@ -108,7 +107,7 @@ def run_replay():
     elapsed_time += 1.0 / FPS
     frame += 1
 
-    if script_index >= len(SCRIPT):
+    if script_index >= len(SCRIPT) and elapsed_time >= next_event_time:
       break
 
   gui_app.close()


### PR DESCRIPTION
Implements #37106 (necessary to make this clean), but lowers the default delay to 0.5 and adds a lot more events for exploring more of the UI and increasing the coverage.

Re-implements some from #36818. The issue with swiping not being deterministic will be fixed in the next PR.

The diff tool doesn't show the entire clip since the old one is shorter, so here it is:

https://github.com/user-attachments/assets/8669a4fa-ebef-4e5d-b9ba-a0556ca645fc
