### PR TITLE
mici ui replay: fix indeterminism with swiping and animations 

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -21,6 +21,11 @@ from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout
 FPS = 60
 HEADLESS = os.getenv("WINDOWED", "0") == "1"
 
+# Monkey-patch raylib timing functions for determinism
+_frame_count = 0
+rl.get_frame_time = lambda: 1.0 / FPS
+rl.get_time = lambda: _frame_count / FPS
+
 
 @dataclass
 class DummyEvent:
@@ -79,6 +84,7 @@ def handle_event(event: DummyEvent):
 
 
 def run_replay():
+  global _frame_count
   setup_state()
   os.makedirs(DIFF_OUT_DIR, exist_ok=True)
 
@@ -92,6 +98,8 @@ def run_replay():
   script_index = 0
 
   for should_render in gui_app.render():
+    _frame_count = frame
+
     while script_index < len(SCRIPT) and SCRIPT[script_index][0] == frame:
       _, event = SCRIPT[script_index]
       handle_event(event)

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -95,8 +95,6 @@ def run_replay():
   rl.get_time = lambda: frame / FPS
 
   for should_render in gui_app.render():
-    _frame_count = frame
-
     while script_index < len(SCRIPT) and SCRIPT[script_index][0] == frame:
       _, event = SCRIPT[script_index]
       handle_event(event)

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -21,11 +21,6 @@ from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout
 FPS = 60
 HEADLESS = os.getenv("WINDOWED", "0") == "1"
 
-# Monkey-patch raylib timing functions for determinism
-_frame_count = 0
-rl.get_frame_time = lambda: 1.0 / FPS
-rl.get_time = lambda: _frame_count / FPS
-
 
 @dataclass
 class DummyEvent:
@@ -84,7 +79,6 @@ def handle_event(event: DummyEvent):
 
 
 def run_replay():
-  global _frame_count
   setup_state()
   os.makedirs(DIFF_OUT_DIR, exist_ok=True)
 
@@ -94,8 +88,11 @@ def run_replay():
   main_layout = MiciMainLayout()
   main_layout.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
 
-  frame = 0
   script_index = 0
+  frame = 0
+  # Override raylib timing functions to return deterministic values based on frame count instead of real time
+  rl.get_frame_time = lambda: 1.0 / FPS
+  rl.get_time = lambda: frame / FPS
 
   for should_render in gui_app.render():
     _frame_count = frame


### PR DESCRIPTION
Fixes the indeterminism in the UI replay clips caused by swiping and other animations/gestures.

This seems like the simplest fix overall since `rl.get_frame_time` and `rl.get_time` are used in quite a few places, and without this patch, the animations are slightly different each time due to differences in the rendering timing.

**Note:** You can test this by applying #37109 and using the tool from #37107. Without this PR, you will see the two clips are different, but with this PR they should be identical.