### PR TITLE
fix: route fetch metadata when first log isnt uploaded

### DIFF
--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -208,7 +208,7 @@ class FrameQueue:
 
 def load_route_metadata(route):
   from openpilot.common.params import Params, UnknownKeyName
-  path = next((item for item in route.log_paths() if item is not None), None)
+  path = next((item for item in route.log_paths() if item), None)
   if not path:
     raise Exception('error getting route metadata: cannot find any uploaded logs')
   lr = LogReader(path)

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -208,7 +208,7 @@ class FrameQueue:
 
 def load_route_metadata(route):
   from openpilot.common.params import Params, UnknownKeyName
-  path = next((item for item in route.log_paths() if item is not None))
+  path = next((item for item in route.log_paths() if item is not None), None)
   if not path:
     raise Exception('error getting route metadata: cannot find any uploaded logs')
   lr = LogReader(path)

--- a/tools/clip/run.py
+++ b/tools/clip/run.py
@@ -208,7 +208,10 @@ class FrameQueue:
 
 def load_route_metadata(route):
   from openpilot.common.params import Params, UnknownKeyName
-  lr = LogReader(route.log_paths()[0])
+  path = next((item for item in route.log_paths() if item is not None))
+  if not path:
+    raise Exception('error getting route metadata: cannot find any uploaded logs')
+  lr = LogReader(path)
   init_data, car_params = lr.first('initData'), lr.first('carParams')
 
   params = Params()


### PR DESCRIPTION
bug: assumes at least first log is uploaded.
fix: find first; `initData` is published at least once per segment.