### PR TITLE
Real dashcam-like video recording

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -1211,6 +1211,7 @@ struct EncodeIndex {
     fullHEVC @1;
     qcameraH264 @6;
     livestreamH264 @7;
+    qcameraHEVC @8;
 
     # deprecated
     bigBoxHEVCDEPRECATED @2;

--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2567,6 +2567,8 @@ struct Event {
     driverEncodeIdx @76 :EncodeIndex;
     wideRoadEncodeIdx @77 :EncodeIndex;
     qRoadEncodeIdx @90 :EncodeIndex;
+    qWideRoadEncodeIdx @150 :EncodeIndex;
+    qDriverEncodeIdx @151 :EncodeIndex;
 
     livestreamRoadEncodeIdx @117 :EncodeIndex;
     livestreamWideRoadEncodeIdx @118 :EncodeIndex;
@@ -2609,6 +2611,8 @@ struct Event {
     driverEncodeData @87 :EncodeData;
     wideRoadEncodeData @88 :EncodeData;
     qRoadEncodeData @89 :EncodeData;
+    qWideRoadEncodeData @152 :EncodeData;
+    qDriverEncodeData @153 :EncodeData;
     alertDebug @133 :DebugAlert;
 
     livestreamRoadEncodeData @120 :EncodeData;

--- a/cereal/services.py
+++ b/cereal/services.py
@@ -79,6 +79,8 @@ _services: dict[str, tuple] = {
   "navRoute": (True, 0.),
   "navThumbnail": (True, 0.),
   "qRoadEncodeIdx": (False, 20.),
+  "qWideRoadEncodeIdx": (False, 20.),
+  "qDriverEncodeIdx": (False, 20.),
   "userBookmark": (True, 0., 1),
   "soundPressure": (True, 10., 10),
   "rawAudioData": (False, 20.),
@@ -88,6 +90,8 @@ _services: dict[str, tuple] = {
   "driverEncodeData": (False, 20., None, QueueSize.BIG),
   "wideRoadEncodeData": (False, 20., None, QueueSize.BIG),
   "qRoadEncodeData": (False, 20., None, QueueSize.BIG),
+  "qWideRoadEncodeData": (False, 20., None, QueueSize.BIG),
+  "qDriverEncodeData": (False, 20., None, QueueSize.BIG),
 
   # debug
   "uiDebug": (True, 0., 1),

--- a/system/loggerd/encoder/ffmpeg_encoder.cc
+++ b/system/loggerd/encoder/ffmpeg_encoder.cc
@@ -46,9 +46,10 @@ FfmpegEncoder::~FfmpegEncoder() {
 }
 
 void FfmpegEncoder::encoder_open() {
-  auto codec_id = encoder_info.get_settings(in_width).encode_type == cereal::EncodeIndex::Type::QCAMERA_H264
-                      ? AV_CODEC_ID_H264
-                      : AV_CODEC_ID_FFVHUFF;
+  auto encode_type = encoder_info.get_settings(in_width).encode_type;
+  auto codec_id = encode_type == cereal::EncodeIndex::Type::QCAMERA_H264 ? AV_CODEC_ID_H264
+                : encode_type == cereal::EncodeIndex::Type::QCAMERA_H_E_V_C ? AV_CODEC_ID_HEVC
+                : AV_CODEC_ID_FFVHUFF;
   const AVCodec *codec = avcodec_find_encoder(codec_id);
 
   this->codec_ctx = avcodec_alloc_context3(codec);

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -43,7 +43,7 @@ struct EncoderSettings {
   }
 
   static EncoderSettings QcamEncoderSettings() {
-    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::FULL_H_E_V_C, .bitrate = 1'398'000, .gop_size = 15};
+    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::QCAMERA_H_E_V_C, .bitrate = 1'398'000, .gop_size = 15};
   }
 
   static EncoderSettings StreamEncoderSettings() {
@@ -124,21 +124,21 @@ const EncoderInfo stream_driver_encoder_info = {
 
 const EncoderInfo qcam_encoder_info = {
   .publish_name = "qRoadEncodeData",
-  .filename = "qcamera.hevc",
+  .filename = "qcamera.mp4",
   .get_settings = [](int){return EncoderSettings::QcamEncoderSettings();},
   INIT_ENCODE_FUNCTIONS(QRoadEncode),
 };
 
 const EncoderInfo qcam_wide_road_encoder_info = {
   .publish_name = "qWideRoadEncodeData",
-  .filename = "qecamera.hevc",
+  .filename = "qecamera.mp4",
   .get_settings = [](int){return EncoderSettings::QcamEncoderSettings();},
   INIT_ENCODE_FUNCTIONS(QWideRoadEncode),
 };
 
 const EncoderInfo qcam_driver_encoder_info = {
   .publish_name = "qDriverEncodeData",
-  .filename = "qdcamera.hevc",
+  .filename = "qdcamera.mp4",
   .record = Params().getBool("RecordFront"),
   .get_settings = [](int){return EncoderSettings::QcamEncoderSettings();},
   INIT_ENCODE_FUNCTIONS(QDriverEncode),

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -43,7 +43,7 @@ struct EncoderSettings {
   }
 
   static EncoderSettings QcamEncoderSettings() {
-    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::QCAMERA_H264, .bitrate = 256'000, .gop_size = 15};
+    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::FULL_H_E_V_C, .bitrate = 1'398'000, .gop_size = 15};
   }
 
   static EncoderSettings StreamEncoderSettings() {
@@ -124,12 +124,24 @@ const EncoderInfo stream_driver_encoder_info = {
 
 const EncoderInfo qcam_encoder_info = {
   .publish_name = "qRoadEncodeData",
-  .filename = "qcamera.ts",
+  .filename = "qcamera.hevc",
   .get_settings = [](int){return EncoderSettings::QcamEncoderSettings();},
-  .frame_width = 526,
-  .frame_height = 330,
-  .include_audio = Params().getBool("RecordAudio"),
   INIT_ENCODE_FUNCTIONS(QRoadEncode),
+};
+
+const EncoderInfo qcam_wide_road_encoder_info = {
+  .publish_name = "qWideRoadEncodeData",
+  .filename = "qecamera.hevc",
+  .get_settings = [](int){return EncoderSettings::QcamEncoderSettings();},
+  INIT_ENCODE_FUNCTIONS(QWideRoadEncode),
+};
+
+const EncoderInfo qcam_driver_encoder_info = {
+  .publish_name = "qDriverEncodeData",
+  .filename = "qdcamera.hevc",
+  .record = Params().getBool("RecordFront"),
+  .get_settings = [](int){return EncoderSettings::QcamEncoderSettings();},
+  INIT_ENCODE_FUNCTIONS(QDriverEncode),
 };
 
 const LogCameraInfo road_camera_info{
@@ -141,13 +153,13 @@ const LogCameraInfo road_camera_info{
 const LogCameraInfo wide_road_camera_info{
   .thread_name = "wide_road_cam_encoder",
   .stream_type = VISION_STREAM_WIDE_ROAD,
-  .encoder_infos = {main_wide_road_encoder_info}
+  .encoder_infos = {main_wide_road_encoder_info, qcam_wide_road_encoder_info}
 };
 
 const LogCameraInfo driver_camera_info{
   .thread_name = "driver_cam_encoder",
   .stream_type = VISION_STREAM_DRIVER,
-  .encoder_infos = {main_driver_encoder_info}
+  .encoder_infos = {main_driver_encoder_info, qcam_driver_encoder_info}
 };
 
 const LogCameraInfo stream_road_camera_info{

--- a/system/loggerd/loggerd.h
+++ b/system/loggerd/loggerd.h
@@ -43,7 +43,7 @@ struct EncoderSettings {
   }
 
   static EncoderSettings QcamEncoderSettings() {
-    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::QCAMERA_H_E_V_C, .bitrate = 1'398'000, .gop_size = 15};
+    return EncoderSettings{.encode_type = cereal::EncodeIndex::Type::QCAMERA_H264, .bitrate = 1'398'000, .gop_size = 15};
   }
 
   static EncoderSettings StreamEncoderSettings() {

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -21,7 +21,8 @@ VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, 
 
     // set codec correctly. needed?
     assert(codec != cereal::EncodeIndex::Type::FULL_H_E_V_C);
-    const AVCodec *avcodec = avcodec_find_encoder(raw ? AV_CODEC_ID_FFVHUFF : AV_CODEC_ID_H264);
+    bool is_hevc = (codec == cereal::EncodeIndex::Type::QCAMERA_H_E_V_C);
+    const AVCodec *avcodec = avcodec_find_encoder(raw ? AV_CODEC_ID_FFVHUFF : (is_hevc ? AV_CODEC_ID_HEVC : AV_CODEC_ID_H264));
     assert(avcodec);
 
     this->codec_ctx = avcodec_alloc_context3(avcodec);


### PR DESCRIPTION
Experiments towards https://github.com/commaai/openpilot/issues/34131. Putting this up for myself and for discussion.
* Records a qcam for all three cameras
* Bumps up the qcam bitrate to be more inline with dashcams
* Switches to HEVC for better size efficiency (unclear whether we can ship this due to Firefox + Android incompatibility)
* Switch to MP4 for better UX around raw files for users

---

comma connect and the upload strategy will need some rework to make this shippable. It's infeasible to upload qcameras with increased bitrates over a metered cellular connection, even for a single camera. I also tried smaller bumps in the bitrate, but you really want at least 10x what we do now.

We likely want to move connect to being more of a file explorer for the device's local storage with options for cloud backup.