### PR TITLE
deleter: handle non-openpilot created files

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -58,15 +58,24 @@ def deleter_thread(exit_event: threading.Event):
       for delete_dir in sorted(dirs, key=lambda d: (d in DELETE_LAST, d in preserved_dirs)):
         delete_path = os.path.join(Paths.log_root(), delete_dir)
 
-        if any(name.endswith(".lock") for name in os.listdir(delete_path)):
-          continue
-
         try:
-          cloudlog.info(f"deleting {delete_path}")
-          shutil.rmtree(delete_path)
+          # Check if path is a directory before checking for locks
+          if os.path.isdir(delete_path):
+            if any(name.endswith(".lock") for name in os.listdir(delete_path)):
+              continue
+            cloudlog.info(f"deleting directory {delete_path}")
+            shutil.rmtree(delete_path)
+          elif os.path.isfile(delete_path) or os.path.islink(delete_path):
+            # Delete stray files and symlinks
+            cloudlog.info(f"deleting file {delete_path}")
+            os.remove(delete_path)
+          else:
+            # Path doesn't exist or is unknown type
+            cloudlog.warning(f"unknown path type, attempting to delete {delete_path}")
+            os.remove(delete_path)
           break
-        except OSError:
-          cloudlog.exception(f"issue deleting {delete_path}")
+        except (OSError, FileNotFoundError) as e:
+          cloudlog.exception(f"issue deleting {delete_path}: {e}")
       exit_event.wait(.1)
     else:
       exit_event.wait(30)

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 
 import openpilot.system.loggerd.deleter as deleter
 from openpilot.common.timeout import Timeout, TimeoutException
-from openpilot.system.loggerd.tests.loggerd_tests_common import UploaderTestCase
+from openpilot.system.loggerd.tests.loggerd_tests_common import UploaderTestCase, create_random_file
 
 Stats = namedtuple("Stats", ['f_bavail', 'f_blocks', 'f_frsize'])
 
@@ -115,3 +115,191 @@ class TestDeleter(UploaderTestCase):
     self.join_thread()
 
     assert f_path.exists(), "File deleted when locked"
+
+  def test_delete_stray_files(self):
+    """Test that stray files in log root are deleted properly"""
+    # Create stray files (not in segment directories)
+    stray_file1 = Path(Paths.log_root()) / "backup.tar.gz"
+    stray_file2 = Path(Paths.log_root()) / "notes.txt"
+    stray_file3 = Path(Paths.log_root()) / "data.zip"
+    
+    stray_file1.write_text("stray content")
+    stray_file2.write_text("stray content")
+    stray_file3.write_text("stray content")
+    
+    # Also create a normal segment directory
+    seg_path = self.make_file_with_data(self.seg_dir, self.f_type)
+    
+    self.start_thread()
+    
+    try:
+      with Timeout(5, "Timeout waiting for stray files to be deleted"):
+        while stray_file1.exists() or stray_file2.exists() or stray_file3.exists() or seg_path.exists():
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+    
+    # All files should be deleted
+    assert not stray_file1.exists(), "Stray file 1 not deleted"
+    assert not stray_file2.exists(), "Stray file 2 not deleted"
+    assert not stray_file3.exists(), "Stray file 3 not deleted"
+    assert not seg_path.exists(), "Segment not deleted"
+
+  def test_delete_stray_files_mixed(self):
+    """Test deleting stray files mixed with directories"""
+    # Create stray files
+    stray_file = Path(Paths.log_root()) / "stray.tar.gz"
+    stray_file.write_text("stray content")
+    
+    # Create segment directories
+    seg1 = self.make_file_with_data(self.seg_format.format(0), self.f_type)
+    seg2 = self.make_file_with_data(self.seg_format.format(1), self.f_type)
+    
+    # All should be deleted in order (oldest first)
+    self.assertDeleteOrder([seg1, seg2])
+    
+    # Stray file should also be deleted
+    assert not stray_file.exists(), "Stray file not deleted"
+
+  def test_delete_symlinks(self):
+    """Test that symlinks in log root are deleted properly"""
+    from openpilot.system.hardware.hw import Paths
+    
+    # Create a regular file to symlink to
+    target = Path(Paths.log_root()) / "target.txt"
+    target.write_text("target content")
+    
+    # Create a symlink
+    symlink = Path(Paths.log_root()) / "link.txt"
+    symlink.symlink_to(target)
+    
+    assert symlink.is_symlink(), "Symlink not created"
+    
+    self.start_thread()
+    
+    try:
+      with Timeout(5, "Timeout waiting for symlink to be deleted"):
+        while target.exists() or symlink.exists():
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+    
+    assert not symlink.exists(), "Symlink not deleted"
+    assert not target.exists(), "Target not deleted"
+
+  def test_delete_broken_symlink(self):
+    """Test that broken symlinks are deleted properly"""
+    from openpilot.system.hardware.hw import Paths
+    
+    # Create a symlink to non-existent target
+    symlink = Path(Paths.log_root()) / "broken_link"
+    try:
+      symlink.symlink_to("/nonexistent/path/to/file")
+      
+      assert symlink.is_symlink(), "Broken symlink not created"
+      assert not symlink.exists(), "Broken symlink should not exist() true"
+      
+      self.start_thread()
+      
+      try:
+        with Timeout(5, "Timeout waiting for broken symlink to be deleted"):
+          # Use is_symlink() to check since exists() returns False for broken symlinks
+          while symlink.is_symlink():
+            time.sleep(0.01)
+      finally:
+        self.join_thread()
+      
+      assert not symlink.is_symlink(), "Broken symlink not deleted"
+    except OSError:
+      # Some systems don't allow broken symlinks, skip test
+      pass
+
+  def test_delete_empty_directory(self):
+    """Test that empty directories are deleted properly"""
+    from openpilot.system.hardware.hw import Paths
+    
+    empty_dir = Path(Paths.log_root()) / "empty_dir"
+    empty_dir.mkdir(parents=True, exist_ok=True)
+    
+    assert empty_dir.exists() and empty_dir.is_dir(), "Empty directory not created"
+    
+    self.start_thread()
+    
+    try:
+      with Timeout(5, "Timeout waiting for empty directory to be deleted"):
+        while empty_dir.exists():
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+    
+    assert not empty_dir.exists(), "Empty directory not deleted"
+
+  def test_delete_stray_files_large(self):
+    """Test deleting large stray files"""
+    from openpilot.system.hardware.hw import Paths
+    
+    # Create a large stray file (simulate the original bug with .tar.gz)
+    large_file = Path(Paths.log_root()) / "2023-09-23.tar.gz"
+    # Create 10MB file
+    create_random_file(large_file, size_mb=10.0)
+    
+    assert large_file.exists(), "Large file not created"
+    
+    self.start_thread()
+    
+    try:
+      with Timeout(5, "Timeout waiting for large file to be deleted"):
+        while large_file.exists():
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+    
+    assert not large_file.exists(), "Large stray file not deleted"
+
+  def test_delete_nested_stray_structure(self):
+    """Test deleting stray nested directory structures"""
+    from openpilot.system.hardware.hw import Paths
+    
+    # Create nested structure not following segment naming convention
+    nested_dir = Path(Paths.log_root()) / "backup" / "old" / "data"
+    nested_dir.mkdir(parents=True, exist_ok=True)
+    
+    nested_file = nested_dir / "file.txt"
+    nested_file.write_text("nested content")
+    
+    root_stray = Path(Paths.log_root()) / "backup"
+    assert root_stray.exists(), "Nested structure not created"
+    
+    self.start_thread()
+    
+    try:
+      with Timeout(5, "Timeout waiting for nested structure to be deleted"):
+        while root_stray.exists():
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+    
+    assert not root_stray.exists(), "Nested stray structure not deleted"
+
+  def test_deleter_doesnt_crash_on_stray_files(self):
+    """Regression test for issue #30102 - deleter should not crash on stray files"""
+    from openpilot.system.hardware.hw import Paths
+    
+    # Reproduce the exact scenario from the bug report
+    stray_tarball = Path(Paths.log_root()) / "realdata" / "2023-09-23.tar.gz"
+    stray_tarball.parent.mkdir(parents=True, exist_ok=True)
+    create_random_file(stray_tarball, size_mb=1.0)
+    
+    seg_path = self.make_file_with_data(self.seg_dir, self.f_type)
+    
+    # Deleter thread should not crash and should continue running
+    self.start_thread()
+    
+    try:
+      with Timeout(5, "Timeout waiting for files to be deleted"):
+        while stray_tarball.exists() or seg_path.exists():
+          time.sleep(0.01)
+      # If we get here, deleter handled stray files properly
+      assert True, "Deleter handled stray files without crashing"
+    finally:
+      self.join_thread()


### PR DESCRIPTION
## Summary
Fixes #30102

This PR makes the deleter robust to handle stray files, symlinks, and non-standard directory structures in the log root, preventing crashes when encountering unexpected filesystem items.

## Problem
The deleter crashed when encountering files directly in the log root (e.g., `2023-09-23.tar.gz`), because it assumed all items in the log root were directories. Specifically:
1. `os.listdir(delete_path)` fails on files
2. `shutil.rmtree(delete_path)` fails on files

## Solution
- Check if path is a directory before calling `os.listdir()`
- Handle files and symlinks explicitly with `os.remove()`
- Use `shutil.rmtree()` only for directories
- Improved error handling with specific exception types
- Better logging to distinguish between deleting directories vs files

## Changes Made

### system/loggerd/deleter.py
- Added path type checking before attempting deletion
- Separated handling for directories, files, and symlinks
- Enhanced error messages for better debugging

### system/loggerd/tests/test_deleter.py
Added comprehensive test suite covering:
- Multiple stray files in log root
- Stray files mixed with segment directories
- Regular and broken symlinks
- Empty directories
- Large stray files (10MB+)
- Nested non-segment directory structures
- Regression test for the exact #30102 scenario

## Test Plan
- All existing tests pass
- 8 new tests added covering various edge cases
- Tested with stray `.tar.gz` files (original bug scenario)
- Tested with symlinks (broken and valid)
- Tested with empty directories and large files
- Tested with nested directory structures

## Related Issues
Closes #30102