### PR TITLE
bump create-pull-request action to v8.1.0

### DIFF
--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           ${{ env.RUN }} "python3 selfdrive/ui/update_translations.py --vanish"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         with:
           author: Vehicle Researcher <user@comma.ai>
           commit-message: "Update translations"
@@ -59,7 +59,7 @@ jobs:
         python selfdrive/car/docs.py
         git add docs/CARS.md
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
+      uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
       with:
         author: Vehicle Researcher <user@comma.ai>
         token: ${{ secrets.ACTIONS_CREATE_PR_PAT }}


### PR DESCRIPTION
The pinned SHA was v6.0.4, incompatible with `actions/checkout@v6`, causing the "Duplicate header: Authorization" 400 error.

- Failed run: https://github.com/commaai/openpilot/actions/runs/21828828510
- Upstream issue: https://github.com/peter-evans/create-pull-request/issues/4272