### PR TITLE
fix first-interaction action inputs for v3

### DIFF
--- a/.github/workflows/auto_pr_review.yaml
+++ b/.github/workflows/auto_pr_review.yaml
@@ -39,8 +39,8 @@ jobs:
       uses: actions/first-interaction@v3
       if: github.event.pull_request.head.repo.full_name != 'commaai/openpilot'
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        pr-message: |
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_message: |
             <!-- _(run_id **${{ github.run_id }}**)_ -->
             Thanks for contributing to openpilot! In order for us to review your PR as quickly as possible, check the following:
             * Convert your PR to a draft unless it's ready to review


### PR DESCRIPTION
`actions/first-interaction@v3` renamed inputs from kebab-case to snake_case (`repo-token` → `repo_token`, `pr-message` → `pr_message`). The old names are silently ignored, causing the step to fail with "Input required and not supplied: issue_message".

- Failed run: https://github.com/commaai/openpilot/actions/runs/21862016151/job/63093368363
- Broken by: https://github.com/commaai/openpilot/pull/37020