### PR TITLE
Scroll panel: adapt to content size shrinking

### DIFF
--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -73,8 +73,14 @@ class GuiScrollPanel2:
 
   def _update_state(self, bounds_size: float, content_size: float) -> None:
     """Runs per render frame, independent of mouse events. Updates auto-scrolling state and velocity."""
-    if self._state == ScrollState.AUTO_SCROLL:
-      max_offset, min_offset = self._get_offset_bounds(bounds_size, content_size)
+    max_offset, min_offset = self._get_offset_bounds(bounds_size, content_size)
+
+    if self._state == ScrollState.STEADY:
+      # if we find ourselves out of bounds, scroll back in (from external layout dimension changes, etc.)
+      if self.get_offset() > max_offset or self.get_offset() < min_offset:
+        self._state = ScrollState.AUTO_SCROLL
+
+    elif self._state == ScrollState.AUTO_SCROLL:
       # simple exponential return if out of bounds
       out_of_bounds = self.get_offset() > max_offset or self.get_offset() < min_offset
       if out_of_bounds and self._handle_out_of_bounds:


### PR DESCRIPTION
fix from https://github.com/commaai/openpilot/pull/37152

previously it would stay on the black space until you click, now it auto scrolls/rubber bands as if user dragged scroll panel there. this wasn't intended to be hit in the current ui, but may accidentally have been a state you could get into either with a touch bug or certain buttons disappearing based on sim status, or alpha long type, but very rare