### PR TITLE
loggerd: prevent deleter crash on stale directories

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -58,7 +58,17 @@ def deleter_thread(exit_event: threading.Event):
       for delete_dir in sorted(dirs, key=lambda d: (d in DELETE_LAST, d in preserved_dirs)):
         delete_path = os.path.join(Paths.log_root(), delete_dir)
 
-        if any(name.endswith(".lock") for name in os.listdir(delete_path)):
+        # Directory may disappear between listing candidates and iterating.
+        # Skip stale paths instead of crashing the deleter thread.
+        if not os.path.isdir(delete_path):
+          continue
+
+        try:
+          has_lock = any(name.endswith(".lock") for name in os.listdir(delete_path))
+        except FileNotFoundError:
+          continue
+
+        if has_lock:
           continue
 
         try:

--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -19,7 +19,11 @@ PRESERVE_COUNT = 5
 
 
 def has_preserve_xattr(d: str) -> bool:
-  return getxattr(os.path.join(Paths.log_root(), d), PRESERVE_ATTR_NAME) == PRESERVE_ATTR_VALUE
+  try:
+    return getxattr(os.path.join(Paths.log_root(), d), PRESERVE_ATTR_NAME) == PRESERVE_ATTR_VALUE
+  except OSError:
+    # Directory may disappear while deleter is running.
+    return False
 
 
 def get_preserved_segments(dirs_by_creation: list[str]) -> set[str]:

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -115,3 +115,18 @@ class TestDeleter(UploaderTestCase):
     self.join_thread()
 
     assert f_path.exists(), "File deleted when locked"
+
+  def test_skip_stale_directory(self):
+    f_path = self.make_file_with_data(self.seg_dir, self.f_type, 1)
+    stale_dir = "00000000--deadbeef00--0"
+    original_listdir_by_creation = deleter.listdir_by_creation
+
+    deleter.listdir_by_creation = lambda _root: [stale_dir, self.seg_dir]
+    try:
+      self.start_thread()
+      with Timeout(2, "Timeout waiting for file to be deleted with stale directory present"):
+        while f_path.exists():
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+      deleter.listdir_by_creation = original_listdir_by_creation


### PR DESCRIPTION
 ## Summary
  This fixes a `deleter` crash when a candidate log directory disappears between
  listing and iteration.

  ## Changes
  - In `system/loggerd/deleter.py`:
    - Skip non-existing directories before lock-file checks.
    - Catch `FileNotFoundError` around `os.listdir(delete_path)` and continue.
  - In `system/loggerd/tests/test_deleter.py`:
    - Add `test_skip_stale_directory` regression test to ensure stale paths are skipped
  and deletion proceeds.

  ## Why
  `deleter_thread` iterates over a snapshot of directories. Under concurrent changes, a
  directory may be removed before `os.listdir()` runs, causing an unhandled exception
  and thread crash.

  ## Validation
  - `python -m py_compile system/loggerd/deleter.py`
  - `python -m py_compile system/loggerd/tests/test_deleter.py`