### PR TITLE
WifiManager: fix need auth

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -435,6 +435,7 @@ class WifiUIMici(BigMultiOptionDialog):
     self._connecting = None
 
   def _on_forgotten(self):
+    print('forgotten!')
     self._connecting = None
 
   def _on_disconnected(self):

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -649,10 +649,11 @@ class WifiManager:
 
     for active_conn in self._get_active_connections():
       conn_addr = DBusAddress(active_conn, bus_name=NM, interface=NM_ACTIVE_CONNECTION_IFACE)
-      props = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
-      print('conn info update props', props)
-
-      props = props.body[0]
+      reply = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
+      if reply.header.message_type == MessageType.error:
+        cloudlog.warning(f"Failed to get active connection properties for {active_conn}: {reply}")
+        continue
+      props = reply.body[0]
       if props.get('Type', ('s', ''))[1] == '802-11-wireless':
         # IPv4 address
         ip4config_path = props.get('Ip4Config', ('o', '/'))[1]

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -266,6 +266,7 @@ class WifiManager:
           self._conn_monitor.filter(rules[1], bufsize=SIGNAL_QUEUE_SIZE) as new_conn_q,
           self._conn_monitor.filter(rules[2], bufsize=SIGNAL_QUEUE_SIZE) as removed_conn_q):
       while not self._exit:
+        print('active', self._active)
         if not self._active:
           time.sleep(1)
           continue
@@ -273,16 +274,20 @@ class WifiManager:
         try:
           self._conn_monitor.recv_messages(timeout=1)
         except TimeoutError:
+          print('TimeoutError')
           continue
 
+        print('no timeout, got msg')
         # Connection added/removed
         if len(new_conn_q) or len(removed_conn_q):
+          print('connection added!')
           new_conn_q.clear()
           removed_conn_q.clear()
           self._update_connections()
 
         # Device state changes
         while len(state_q):
+          print('got state change signal!')
           new_state, previous_state, change_reason = state_q.popleft().body
 
           # BAD PASSWORD

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -649,8 +649,10 @@ class WifiManager:
 
     for active_conn in self._get_active_connections():
       conn_addr = DBusAddress(active_conn, bus_name=NM, interface=NM_ACTIVE_CONNECTION_IFACE)
-      props = self._router_main.send_and_get_reply(Properties(conn_addr).get_all()).body[0]
+      props = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
+      print('conn info update props', props)
 
+      props = props.body[0]
       if props.get('Type', ('s', ''))[1] == '802-11-wireless':
         # IPv4 address
         ip4config_path = props.get('Ip4Config', ('o', '/'))[1]

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -286,10 +286,11 @@ class WifiManager:
           new_state, previous_state, change_reason = state_q.popleft().body
 
           # BAD PASSWORD
+          print((new_state, change_reason, self._connecting_to_ssid))
           if new_state == NMDeviceState.NEED_AUTH and change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT and len(self._connecting_to_ssid):
             self.forget_connection(self._connecting_to_ssid, block=True)
             self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
-            self._connecting_to_ssid = ""
+            # self._connecting_to_ssid = ""
 
           elif new_state == NMDeviceState.ACTIVATED:
             if len(self._activated):
@@ -297,9 +298,10 @@ class WifiManager:
             self._enqueue_callbacks(self._activated)
             self._connecting_to_ssid = ""
 
-          elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
-            self._connecting_to_ssid = ""
-            self._enqueue_callbacks(self._forgotten)
+          # elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
+          #   # TODO: weird
+          #   self._connecting_to_ssid = ""
+          #   self._enqueue_callbacks(self._forgotten)
 
   def _network_scanner(self):
     while not self._exit:

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -298,10 +298,10 @@ class WifiManager:
             self._enqueue_callbacks(self._activated)
             self._connecting_to_ssid = ""
 
-          # elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
-          #   # TODO: weird
-          #   self._connecting_to_ssid = ""
-          #   self._enqueue_callbacks(self._forgotten)
+          elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
+            # TODO: weird
+            self._connecting_to_ssid = ""
+            self._enqueue_callbacks(self._forgotten)
 
   def _network_scanner(self):
     while not self._exit:

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -439,8 +439,20 @@ class WifiManager:
         }
 
       settings_addr = DBusAddress(NM_SETTINGS_PATH, bus_name=NM, interface=NM_SETTINGS_IFACE)
-      self._router_main.send_and_get_reply(new_method_call(settings_addr, 'AddConnection', 'a{sa{sv}}', (connection,)))
-      self.activate_connection(ssid, block=True)
+      reply = self._router_main.send_and_get_reply(new_method_call(settings_addr, 'AddConnection', 'a{sa{sv}}', (connection,)))
+      if reply.header.message_type == MessageType.error:
+        cloudlog.warning(f"Failed to add connection for {ssid}: {reply}")
+        self._connecting_to_ssid = ""
+        return
+
+      conn_path = reply.body[0]
+      if self._wifi_device is None:
+        cloudlog.warning("No WiFi device found")
+        self._connecting_to_ssid = ""
+        return
+
+      self._router_main.send(new_method_call(self._nm, 'ActivateConnection', 'ooo',
+                                             (conn_path, self._wifi_device, "/")))
 
     threading.Thread(target=worker, daemon=True).start()
 


### PR DESCRIPTION
Strange, this section was setting connecting_to_ssid to "" before we got NEED_AUTH:

```
          elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
            self._connecting_to_ssid = ""
            self._enqueue_callbacks(self._forgotten)
```

the original C++ implementation didn't have this elif block at all, wonder why I added it: https://github.com/commaai/openpilot/blob/650946cd2ace2f55631f13466b1906249afada59/selfdrive/ui/qt/network/wifi_manager.cc#L274-L283