### PR TITLE
ui replay: fix coverage reporting to include imports

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -16,7 +16,6 @@ from openpilot.common.params import Params
 from openpilot.system.version import terms_version, training_version
 from openpilot.system.ui.lib.application import gui_app, MousePos, MouseEvent
 from openpilot.selfdrive.ui.ui_state import ui_state
-from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout
 
 FPS = 60
 HEADLESS = os.getenv("WINDOWED", "0") == "1"
@@ -85,6 +84,9 @@ def run_replay():
   if not HEADLESS:
     rl.set_config_flags(rl.FLAG_WINDOW_HIDDEN)
   gui_app.init_window("ui diff test", fps=FPS)
+
+  from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout  # import here for coverage
+
   main_layout = MiciMainLayout()
   main_layout.set_rect(rl.Rectangle(0, 0, gui_app.width, gui_app.height))
 
@@ -117,7 +119,6 @@ def main():
   cov = coverage.coverage(source=['openpilot.selfdrive.ui.mici'])
   with cov.collect():
     run_replay()
-  cov.stop()
   cov.save()
   cov.report()
   cov.html_report(directory=os.path.join(DIFF_OUT_DIR, 'htmlcov'))


### PR DESCRIPTION
The coverage report in the mici ui replay test was excluding all the import lines due to the fact `MiciMainLayout` was being imported before coverage tracking was started.

Increases total coverage from 21% to 45%, which is more accurate (although I think it still excludes files that weren't imported at all).

### Before:
<details>
<summary>Coverage summary (old)</summary>

```
Name                                                     Stmts   Miss  Cover
----------------------------------------------------------------------------
selfdrive/ui/mici/layouts/home.py                          166     83    50%
selfdrive/ui/mici/layouts/main.py                           97     51    47%
selfdrive/ui/mici/layouts/offroad_alerts.py                188    121    36%
selfdrive/ui/mici/layouts/onboarding.py                    274    218    20%
selfdrive/ui/mici/layouts/settings/developer.py             92     54    41%
selfdrive/ui/mici/layouts/settings/device.py               255    205    20%
selfdrive/ui/mici/layouts/settings/firehose.py             151    127    16%
selfdrive/ui/mici/layouts/settings/network/__init__.py     116     84    28%
selfdrive/ui/mici/layouts/settings/network/wifi_ui.py      290    244    16%
selfdrive/ui/mici/layouts/settings/settings.py              78     43    45%
selfdrive/ui/mici/layouts/settings/toggles.py               56     26    54%
selfdrive/ui/mici/onroad/alert_renderer.py                 220    204     7%
selfdrive/ui/mici/onroad/augmented_road_view.py            237    200    16%
selfdrive/ui/mici/onroad/cameraview.py                     217    191    12%
selfdrive/ui/mici/onroad/confidence_ball.py                 44     41     7%
selfdrive/ui/mici/onroad/driver_camera_dialog.py           158    137    13%
selfdrive/ui/mici/onroad/driver_state.py                   137    109    20%
selfdrive/ui/mici/onroad/hud_renderer.py                   178    148    17%
selfdrive/ui/mici/onroad/model_renderer.py                 280    254     9%
selfdrive/ui/mici/onroad/torque_bar.py                     142    138     3%
selfdrive/ui/mici/widgets/button.py                        236    121    49%
selfdrive/ui/mici/widgets/dialog.py                        252    239     5%
----------------------------------------------------------------------------
TOTAL                                                     3864   3038    21%
```
</details>


### After:
<details>
<summary>Coverage summary (new)</summary>

```
Name                                                     Stmts   Miss  Cover
----------------------------------------------------------------------------
selfdrive/ui/mici/layouts/__init__.py                        0      0   100%
selfdrive/ui/mici/layouts/home.py                          166     51    69%
selfdrive/ui/mici/layouts/main.py                           97     24    75%
selfdrive/ui/mici/layouts/offroad_alerts.py                188     73    61%
selfdrive/ui/mici/layouts/onboarding.py                    274    134    51%
selfdrive/ui/mici/layouts/settings/developer.py             92     35    62%
selfdrive/ui/mici/layouts/settings/device.py               255    151    41%
selfdrive/ui/mici/layouts/settings/firehose.py             151     87    42%
selfdrive/ui/mici/layouts/settings/network/__init__.py     116     58    50%
selfdrive/ui/mici/layouts/settings/network/wifi_ui.py      290    179    38%
selfdrive/ui/mici/layouts/settings/settings.py              78      7    91%
selfdrive/ui/mici/layouts/settings/toggles.py               56     10    82%
selfdrive/ui/mici/onroad/__init__.py                         7      4    43%
selfdrive/ui/mici/onroad/alert_renderer.py                 220    148    33%
selfdrive/ui/mici/onroad/augmented_road_view.py            237    148    38%
selfdrive/ui/mici/onroad/cameraview.py                     217    154    29%
selfdrive/ui/mici/onroad/confidence_ball.py                 44     28    36%
selfdrive/ui/mici/onroad/driver_camera_dialog.py           158    107    32%
selfdrive/ui/mici/onroad/driver_state.py                   137     79    42%
selfdrive/ui/mici/onroad/hud_renderer.py                   178    105    41%
selfdrive/ui/mici/onroad/model_renderer.py                 280    207    26%
selfdrive/ui/mici/onroad/torque_bar.py                     142    109    23%
selfdrive/ui/mici/widgets/button.py                        236     51    78%
selfdrive/ui/mici/widgets/dialog.py                        252    180    29%
selfdrive/ui/mici/widgets/pairing_dialog.py                 86     64    26%
----------------------------------------------------------------------------
TOTAL                                                     3957   2193    45%
```
</details>
