### PR TITLE
mici ship mode

### DIFF
--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -317,7 +317,12 @@ class Tici(HardwareBase):
   def get_som_power_draw(self):
     return (self.read_param_file("/sys/class/power_supply/bms/voltage_now", int) * self.read_param_file("/sys/class/power_supply/bms/current_now", int) / 1e12)
 
+  def set_ship_mode(self):
+    sudo_write("1", "/sys/devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/set_ship_mode")
+
   def shutdown(self):
+    if self.get_device_type() == "mici":
+      self.set_ship_mode() # turns off VPH_PWR after 13s
     os.system("sudo poweroff")
 
   def get_thermal_config(self):

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -323,6 +323,7 @@ class Tici(HardwareBase):
   def shutdown(self):
     if self.get_device_type() == "mici":
       self.set_ship_mode()  # starts 13s timer, then PMIC cuts VPH_PWR
+      gpio_set(GPIO.SOM_ST_IO, 0)  # stop fan
       os.system("sudo halt")  # clean shutdown without PS_HOLD release
     else:
       os.system("sudo poweroff")

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -322,11 +322,9 @@ class Tici(HardwareBase):
 
   def shutdown(self):
     if self.get_device_type() == "mici":
-      self.set_ship_mode()  # starts 13s timer, then PMIC cuts VPH_PWR
+      self.set_ship_mode()  # arms BATFET reversal, engaged on PS_HOLD release
       gpio_set(GPIO.SOM_ST_IO, 0)  # stop fan
-      os.system("sudo halt")  # clean shutdown without PS_HOLD release
-    else:
-      os.system("sudo poweroff")
+    os.system("sudo poweroff")
 
   def get_thermal_config(self):
     intake, exhaust, case = None, None, None

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -322,8 +322,10 @@ class Tici(HardwareBase):
 
   def shutdown(self):
     if self.get_device_type() == "mici":
-      self.set_ship_mode() # turns off VPH_PWR after 13s
-    os.system("sudo poweroff")
+      self.set_ship_mode()  # starts 13s timer, then PMIC cuts VPH_PWR
+      os.system("sudo halt")  # clean shutdown without PS_HOLD release
+    else:
+      os.system("sudo poweroff")
 
   def get_thermal_config(self):
     intake, exhaust, case = None, None, None

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -318,7 +318,7 @@ class Tici(HardwareBase):
     return (self.read_param_file("/sys/class/power_supply/bms/voltage_now", int) * self.read_param_file("/sys/class/power_supply/bms/current_now", int) / 1e12)
 
   def set_ship_mode(self):
-    sudo_write("1", "/sys/devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/set_ship_mode")
+    sudo_write("1", "/sys/class/power_supply/battery/set_ship_mode")
 
   def shutdown(self):
     if self.get_device_type() == "mici":

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -322,8 +322,8 @@ class Tici(HardwareBase):
 
   def shutdown(self):
     if self.get_device_type() == "mici":
-      self.set_ship_mode()  # arms BATFET reversal, engaged on PS_HOLD release
-      gpio_set(GPIO.SOM_ST_IO, 0)  # stop fan
+      self.set_ship_mode()  # switch off VPH_PWR
+      gpio_set(GPIO.SOM_ST_IO, 0)  # stop fan for ship mode
     os.system("sudo poweroff")
 
   def get_thermal_config(self):


### PR DESCRIPTION
**Description**
Ship mode switches off VPH_PWR from PMI8998 to save power.
It uses a different bootkick path to wake up, added to panda.

Due to different shutdown behavior, we need to stop the fan manually.

**Verification**
Baseline: 18.56mA @ 12.01V - 223mW
Ship mode: 13.42mA @ 12.00V - 161mW
