### PR TITLE
WifiUi: fix up wrong password dialog

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -446,8 +446,14 @@ class WifiUIMici(BigMultiOptionDialog):
     hint = "wrong password..." if incorrect_password else "enter password..."
     dlg = BigInputDialog(hint, "", minimum_length=8,
                          confirm_callback=lambda _password: self._connect_with_password(ssid, _password))
-    # go back to the manage network page
-    gui_app.set_modal_overlay(dlg, self._open_network_manage_page)
+
+    def on_close(result=None):
+      gui_app.set_modal_overlay_tick(None)
+      self._open_network_manage_page(result)
+
+    # Process wifi callbacks while the keyboard is shown so forgotten clears connecting state
+    gui_app.set_modal_overlay_tick(self._wifi_manager.process_callbacks)
+    gui_app.set_modal_overlay(dlg, on_close)
 
   def _on_activated(self):
     print('RESET CONNECTING 1')

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -414,6 +414,7 @@ class WifiUIMici(BigMultiOptionDialog):
   def _connect_with_password(self, ssid: str, password: str):
     if password:
       self._connecting = ssid
+      print('SET CONNECTING', ssid)
       self._wifi_manager.connect_to_network(ssid, password)
       self._update_buttons()
 
@@ -449,12 +450,16 @@ class WifiUIMici(BigMultiOptionDialog):
     gui_app.set_modal_overlay(dlg, self._open_network_manage_page)
 
   def _on_activated(self):
+    print('RESET CONNECTING 1')
     self._connecting = None
 
   def _on_forgotten(self):
+    pass
+    print('RESET CONNECTING 2')
     self._connecting = None
 
   def _on_disconnected(self):
+    print('RESET CONNECTING 3')
     self._connecting = None
 
   def _render(self, _):

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -453,10 +453,10 @@ class WifiUIMici(BigMultiOptionDialog):
     print('RESET CONNECTING 1')
     self._connecting = None
 
-  def _on_forgotten(self):
-    pass
-    print('RESET CONNECTING 2')
-    self._connecting = None
+  def _on_forgotten(self, ssid):
+    if self._connecting == ssid:
+      print('RESET CONNECTING 2', ssid)
+      self._connecting = None
 
   def _on_disconnected(self):
     print('RESET CONNECTING 3')

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -414,7 +414,6 @@ class WifiUIMici(BigMultiOptionDialog):
   def _connect_with_password(self, ssid: str, password: str):
     if password:
       self._connecting = ssid
-      print('SET CONNECTING', ssid)
       self._wifi_manager.connect_to_network(ssid, password)
       self._update_buttons()
 
@@ -456,16 +455,13 @@ class WifiUIMici(BigMultiOptionDialog):
     gui_app.set_modal_overlay(dlg, on_close)
 
   def _on_activated(self):
-    print('RESET CONNECTING 1')
     self._connecting = None
 
   def _on_forgotten(self, ssid):
     if self._connecting == ssid:
-      print('RESET CONNECTING 2', ssid)
       self._connecting = None
 
   def _on_disconnected(self):
-    print('RESET CONNECTING 3')
     self._connecting = None
 
   def _render(self, _):

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -319,11 +319,9 @@ class WifiManager:
           # BAD PASSWORD
           if new_state == NMDeviceState.NEED_AUTH and change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT and len(self._connecting_to_ssid):
             print('need auth!')
-            t = time.monotonic()
-            self.forget_connection(self._connecting_to_ssid, block=True)
-            print('forgotten connection', time.monotonic() - t)
             self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
             self._connecting_to_ssid = ""
+            self.forget_connection(self._connecting_to_ssid, block=True)
 
           elif new_state == NMDeviceState.ACTIVATED:
             if len(self._activated):

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -320,8 +320,8 @@ class WifiManager:
           if new_state == NMDeviceState.NEED_AUTH and change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT and len(self._connecting_to_ssid):
             print('need auth!')
             self.forget_connection(self._connecting_to_ssid, block=True)
-            self._connecting_to_ssid = ""
             self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
+            self._connecting_to_ssid = ""
 
           elif new_state == NMDeviceState.ACTIVATED:
             if len(self._activated):

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -319,9 +319,9 @@ class WifiManager:
           # BAD PASSWORD
           if new_state == NMDeviceState.NEED_AUTH and change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT and len(self._connecting_to_ssid):
             print('need auth!')
-            self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
-            self._connecting_to_ssid = ""
             self.forget_connection(self._connecting_to_ssid, block=True)
+            self._connecting_to_ssid = ""
+            self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
 
           elif new_state == NMDeviceState.ACTIVATED:
             if len(self._activated):
@@ -329,9 +329,9 @@ class WifiManager:
             self._enqueue_callbacks(self._activated)
             self._connecting_to_ssid = ""
 
-          elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
-            self._connecting_to_ssid = ""
-            self._enqueue_callbacks(self._forgotten)
+          # elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
+          #   self._connecting_to_ssid = ""
+          #   self._enqueue_callbacks(self._forgotten)
 
   def _network_scanner(self):
     while not self._exit:

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -442,7 +442,7 @@ class WifiManager:
     def worker():
       # Clear all connections that may already exist to the network we are connecting to
       self._connecting_to_ssid = ssid
-      self.forget_connection(ssid, block=True, notify=False)
+      self.forget_connection(ssid, block=True)
 
       connection = {
         'connection': {
@@ -475,7 +475,7 @@ class WifiManager:
 
     threading.Thread(target=worker, daemon=True).start()
 
-  def forget_connection(self, ssid: str, block: bool = False, notify: bool = True):
+  def forget_connection(self, ssid: str, block: bool = False):
     def worker():
       conn_path = self._connections.get(ssid, None)
       if conn_path is not None:
@@ -484,8 +484,7 @@ class WifiManager:
 
         if len(self._forgotten):
           self._update_networks()
-        if notify:
-          self._enqueue_callbacks(self._forgotten, ssid)
+        self._enqueue_callbacks(self._forgotten, ssid)
 
     if block:
       worker()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -319,8 +319,8 @@ class WifiManager:
           # BAD PASSWORD
           if new_state == NMDeviceState.NEED_AUTH and change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT and len(self._connecting_to_ssid):
             print('need auth!')
-            self.forget_connection(self._connecting_to_ssid, block=True)
             self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
+            self.forget_connection(self._connecting_to_ssid, block=True)
             self._connecting_to_ssid = ""
 
           elif new_state == NMDeviceState.ACTIVATED:
@@ -446,7 +446,7 @@ class WifiManager:
     def worker():
       # Clear all connections that may already exist to the network we are connecting to
       self._connecting_to_ssid = ssid
-      self.forget_connection(ssid, block=True)
+      self.forget_connection(ssid, block=True, notify=False)
 
       connection = {
         'connection': {
@@ -479,7 +479,7 @@ class WifiManager:
 
     threading.Thread(target=worker, daemon=True).start()
 
-  def forget_connection(self, ssid: str, block: bool = False):
+  def forget_connection(self, ssid: str, block: bool = False, notify: bool = True):
     def worker():
       conn_path = self._connections.get(ssid, None)
       if conn_path is not None:
@@ -488,7 +488,8 @@ class WifiManager:
 
         if len(self._forgotten):
           self._update_networks()
-        self._enqueue_callbacks(self._forgotten, ssid)
+        if notify:
+          self._enqueue_callbacks(self._forgotten, ssid)
 
     if block:
       worker()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -329,10 +329,10 @@ class WifiManager:
             self._enqueue_callbacks(self._activated)
             self._connecting_to_ssid = ""
 
-          # elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
-          #   print('      WEIRD DISCONNECT')
-          #   # self._connecting_to_ssid = ""
-          #   # self._enqueue_callbacks(self._forgotten)
+          elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
+            print('      WEIRD DISCONNECT')
+            self._enqueue_callbacks(self._forgotten, self._connecting_to_ssid)
+            self._connecting_to_ssid = ""
 
   def _network_scanner(self):
     while not self._exit:

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -314,9 +314,14 @@ class WifiManager:
         while len(state_q):
           new_state, previous_state, change_reason = state_q.popleft().body
 
+          print('new_state', (new_state, change_reason))
+
           # BAD PASSWORD
           if new_state == NMDeviceState.NEED_AUTH and change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT and len(self._connecting_to_ssid):
+            print('need auth!')
+            t = time.monotonic()
             self.forget_connection(self._connecting_to_ssid, block=True)
+            print('forgotten connection', time.monotonic() - t)
             self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
             self._connecting_to_ssid = ""
 

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -183,7 +183,7 @@ class WifiManager:
     # Callbacks
     self._need_auth: list[Callable[[str], None]] = []
     self._activated: list[Callable[[], None]] = []
-    self._forgotten: list[Callable[[], None]] = []
+    self._forgotten: list[Callable[[str], None]] = []
     self._networks_updated: list[Callable[[list[Network]], None]] = []
     self._disconnected: list[Callable[[], None]] = []
 
@@ -211,7 +211,7 @@ class WifiManager:
 
   def add_callbacks(self, need_auth: Callable[[str], None] | None = None,
                     activated: Callable[[], None] | None = None,
-                    forgotten: Callable[[], None] | None = None,
+                    forgotten: Callable[[str], None] | None = None,
                     networks_updated: Callable[[list[Network]], None] | None = None,
                     disconnected: Callable[[], None] | None = None):
     if need_auth is not None:
@@ -330,8 +330,9 @@ class WifiManager:
             self._connecting_to_ssid = ""
 
           # elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
-          #   self._connecting_to_ssid = ""
-          #   self._enqueue_callbacks(self._forgotten)
+          #   print('      WEIRD DISCONNECT')
+          #   # self._connecting_to_ssid = ""
+          #   # self._enqueue_callbacks(self._forgotten)
 
   def _network_scanner(self):
     while not self._exit:
@@ -487,7 +488,7 @@ class WifiManager:
 
         if len(self._forgotten):
           self._update_networks()
-        self._enqueue_callbacks(self._forgotten)
+        self._enqueue_callbacks(self._forgotten, ssid)
 
     if block:
       worker()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -314,11 +314,8 @@ class WifiManager:
         while len(state_q):
           new_state, previous_state, change_reason = state_q.popleft().body
 
-          print('new_state', (new_state, change_reason))
-
           # BAD PASSWORD
           if new_state == NMDeviceState.NEED_AUTH and change_reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT and len(self._connecting_to_ssid):
-            print('need auth!')
             self._enqueue_callbacks(self._need_auth, self._connecting_to_ssid)
             self.forget_connection(self._connecting_to_ssid, block=True)
             self._connecting_to_ssid = ""
@@ -330,7 +327,6 @@ class WifiManager:
             self._connecting_to_ssid = ""
 
           elif new_state == NMDeviceState.DISCONNECTED and change_reason != NM_DEVICE_STATE_REASON_NEW_ACTIVATION:
-            print('      WEIRD DISCONNECT')
             self._enqueue_callbacks(self._forgotten, self._connecting_to_ssid)
             self._connecting_to_ssid = ""
 

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -463,7 +463,7 @@ class WifiManagerUI(Widget):
     if self.state == UIState.CONNECTING:
       self.state = UIState.IDLE
 
-  def _on_forgotten(self):
+  def _on_forgotten(self, _):
     if self.state == UIState.FORGETTING:
       self.state = UIState.IDLE
 


### PR DESCRIPTION
- forgetting network not connecting won't clear connecting
- shows wrong password dialog immediately, not after 2s (from slow network forget!)
  - then dismissing shows wifi forgotten immediately
  - or new password entry shows connecting state