### PR TITLE
build: replace abspath with path in scons scripts to fix CI caching (…

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -21,7 +21,7 @@ AddOption('--ccflags', action='store', type='string', default='', help='pass arb
 AddOption('--minimal',
           action='store_false',
           dest='extras',
-          default=os.path.exists(File('#.gitattributes').abspath), # minimal by default on release branch (where there's no LFS)
+          default=File('#.gitattributes').exists(), # minimal by default on release branch (where there's no LFS)
           help='the minimum build to run openpilot. no tests, tools, etc.')
 
 # Detect platform
@@ -41,10 +41,10 @@ assert arch in [
 env = Environment(
   ENV={
     "PATH": os.environ['PATH'],
-    "PYTHONPATH": Dir("#").abspath + ':' + Dir(f"#third_party/acados").abspath,
-    "ACADOS_SOURCE_DIR": Dir("#third_party/acados").abspath,
-    "ACADOS_PYTHON_INTERFACE_PATH": Dir("#third_party/acados/acados_template").abspath,
-    "TERA_PATH": Dir("#").abspath + f"/third_party/acados/{arch}/t_renderer"
+    "PYTHONPATH": Dir("#").path + ':' + Dir(f"#third_party/acados").path,
+    "ACADOS_SOURCE_DIR": Dir("#third_party/acados").path,
+    "ACADOS_PYTHON_INTERFACE_PATH": Dir("#third_party/acados/acados_template").path,
+    "TERA_PATH": Dir("#").path + f"/third_party/acados/{arch}/t_renderer"
   },
   CC='clang',
   CXX='clang++',
@@ -86,7 +86,7 @@ env = Environment(
   ],
   RPATH=[],
   CYTHONCFILESUFFIX=".cpp",
-  COMPILATIONDB_USE_ABSPATH=True,
+  COMPILATIONDB_USE_ABSPATH=False,
   REDNOSE_ROOT="#",
   tools=["default", "cython", "compilation_db", "rednose_filter"],
   toolpath=["#site_scons/site_tools", "#rednose_repo/site_scons/site_tools"],

--- a/selfdrive/controls/lib/lateral_mpc_lib/SConscript
+++ b/selfdrive/controls/lib/lateral_mpc_lib/SConscript
@@ -59,9 +59,9 @@ acados_rel_path = Dir(gen).rel_path(Dir(f"#third_party/acados/{arch}/lib"))
 lenv["RPATH"] += [lenv.Literal(f'\\$$ORIGIN/{acados_rel_path}')]
 lenv.Clean(generated_files, Dir(gen))
 
-generated_lat = lenv.Command(generated_files,
+generated_lat = lenv.Command([f.path for f in generated_files],
                              source_list,
-                             f"cd {Dir('.').abspath} && python3 lat_mpc.py")
+                             f"cd {Dir('#')} && python3 {File('lat_mpc.py').path}")
 lenv.Depends(generated_lat, [msgq_python, common_python])
 
 lenv["CFLAGS"].append("-DACADOS_WITH_QPOASES")
@@ -83,15 +83,15 @@ libacados_ocp_solver_pxd = File(f'{gen}/acados_solver.pxd')
 libacados_ocp_solver_c = File(f'{gen}/acados_ocp_solver_pyx.c')
 
 lenv2 = envCython.Clone()
-lenv2["LIBPATH"] += [lib_solver[0].dir.abspath]
+lenv2["LIBPATH"] += [lib_solver[0].dir]
 lenv2["RPATH"] += [lenv2.Literal('\\$$ORIGIN')]
 lenv2.Command(libacados_ocp_solver_c,
   [acados_ocp_solver_pyx, acados_ocp_solver_common, libacados_ocp_solver_pxd],
   f'cython' + \
-  f' -o {libacados_ocp_solver_c.get_labspath()}' + \
-  f' -I {libacados_ocp_solver_pxd.get_dir().get_labspath()}' + \
-  f' -I {acados_ocp_solver_common.get_dir().get_labspath()}' + \
-  f' {acados_ocp_solver_pyx.get_labspath()}')
+  f' -o {libacados_ocp_solver_c.path}' + \
+  f' -I {libacados_ocp_solver_pxd.get_dir().path}' + \
+  f' -I {acados_ocp_solver_common.get_dir().path}' + \
+  f' {acados_ocp_solver_pyx.path}')
 lib_cython = lenv2.Program(f'{gen}/acados_ocp_solver_pyx.so', [libacados_ocp_solver_c], LIBS=['acados_ocp_solver_lat'])
 lenv2.Depends(lib_cython, lib_solver)
 lenv2.Depends(libacados_ocp_solver_c, np_version)

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
@@ -64,9 +64,9 @@ lenv = env.Clone()
 acados_rel_path = Dir(gen).rel_path(Dir(f"#third_party/acados/{arch}/lib"))
 lenv["RPATH"] += [lenv.Literal(f'\\$$ORIGIN/{acados_rel_path}')]
 lenv.Clean(generated_files, Dir(gen))
-generated_long = lenv.Command(generated_files,
+generated_long = lenv.Command([f.path for f in generated_files],
                               source_list,
-                              f"cd {Dir('.').abspath} && python3 long_mpc.py")
+                              f"cd {Dir('#')} && python3 {File('long_mpc.py').path}")
 lenv.Depends(generated_long, [msgq_python, common_python])
 
 lenv["CFLAGS"].append("-DACADOS_WITH_QPOASES")
@@ -88,15 +88,15 @@ libacados_ocp_solver_pxd = File(f'{gen}/acados_solver.pxd')
 libacados_ocp_solver_c = File(f'{gen}/acados_ocp_solver_pyx.c')
 
 lenv2 = envCython.Clone()
-lenv2["LIBPATH"] += [lib_solver[0].dir.abspath]
+lenv2["LIBPATH"] += [lib_solver[0].dir]
 lenv2["RPATH"] += [lenv2.Literal('\\$$ORIGIN')]
 lenv2.Command(libacados_ocp_solver_c,
   [acados_ocp_solver_pyx, acados_ocp_solver_common, libacados_ocp_solver_pxd],
   f'cython' + \
-  f' -o {libacados_ocp_solver_c.get_labspath()}' + \
-  f' -I {libacados_ocp_solver_pxd.get_dir().get_labspath()}' + \
-  f' -I {acados_ocp_solver_common.get_dir().get_labspath()}' + \
-  f' {acados_ocp_solver_pyx.get_labspath()}')
+  f' -o {libacados_ocp_solver_c.path}' + \
+  f' -I {libacados_ocp_solver_pxd.get_dir().path}' + \
+  f' -I {acados_ocp_solver_common.get_dir().path}' + \
+  f' {acados_ocp_solver_pyx.path}')
 lib_cython = lenv2.Program(f'{gen}/acados_ocp_solver_pyx.so', [libacados_ocp_solver_c], LIBS=['acados_ocp_solver_long'])
 lenv2.Depends(lib_cython, lib_solver)
 lenv2.Depends(libacados_ocp_solver_c, np_version)

--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -4,16 +4,15 @@ import glob
 Import('env', 'arch')
 lenv = env.Clone()
 
-tinygrad_root = env.Dir("#").abspath
-tinygrad_files = ["#"+x for x in glob.glob(env.Dir("#tinygrad_repo").relpath + "/**", recursive=True, root_dir=tinygrad_root)
-                  if 'pycache' not in x and os.path.isfile(os.path.join(tinygrad_root, x))]
+tinygrad_root = env.Dir("#")
+tinygrad_files = ["#"+x for x in glob.glob(env.Dir("#tinygrad_repo").path + "/**", recursive=True, root_dir=tinygrad_root.path)
+                  if 'pycache' not in x and os.path.isfile(os.path.join(tinygrad_root.path, x))]
 
 # Get model metadata
 for model_name in ['driving_vision', 'driving_policy', 'dmonitoring_model']:
-  fn = File(f"models/{model_name}").abspath
-  script_files = [File(Dir("#selfdrive/modeld").File("get_model_metadata.py").abspath)]
-  cmd = f'python3 {Dir("#selfdrive/modeld").abspath}/get_model_metadata.py {fn}.onnx'
-  lenv.Command(fn + "_metadata.pkl", [fn + ".onnx"] + tinygrad_files + script_files, cmd)
+  fn = File(f"models/{model_name}")
+  cmd = f'cd {env.Dir("#")} && python3 {script_files[0].path} {fn.path}.onnx'
+  lenv.Command(fn.path + "_metadata.pkl", [fn.path + ".onnx"] + tinygrad_files + script_files, cmd)
 
 # compile warp
 # THREADS=0 is need to prevent bug: https://github.com/tinygrad/tinygrad/issues/14689
@@ -24,22 +23,21 @@ tg_flags = {
 image_flag = {
      'larch64': 'IMAGE=2',
 }.get(arch, 'IMAGE=0')
-script_files = [File(Dir("#selfdrive/modeld").File("compile_warp.py").abspath)]
-cmd = f'{tg_flags} python3 {Dir("#selfdrive/modeld").abspath}/compile_warp.py '
+script_files = [Dir("#selfdrive/modeld").File("compile_warp.py")]
+cmd = f'cd {env.Dir("#")} && {tg_flags} python3 {script_files[0].path} '
 from openpilot.common.transformations.camera import _ar_ox_fisheye, _os_fisheye
 warp_targets = []
 for cam in [_ar_ox_fisheye, _os_fisheye]:
   w, h = cam.width, cam.height
-  warp_targets += [File(f"models/warp_{w}x{h}_tinygrad.pkl").abspath, File(f"models/dm_warp_{w}x{h}_tinygrad.pkl").abspath]
-lenv.Command(warp_targets, tinygrad_files + script_files, cmd)
+  warp_targets += [File(f"models/warp_{w}x{h}_tinygrad.pkl"), File(f"models/dm_warp_{w}x{h}_tinygrad.pkl")]
+lenv.Command([f.path for f in warp_targets], tinygrad_files + script_files, cmd)
 
 def tg_compile(flags, model_name):
-  pythonpath_string = 'PYTHONPATH="${PYTHONPATH}:' + env.Dir("#tinygrad_repo").abspath + '"'
-  fn = File(f"models/{model_name}").abspath
+  fn = File(f"models/{model_name}")
   return lenv.Command(
     fn + "_tinygrad.pkl",
     [fn + ".onnx"] + tinygrad_files,
-    f'{pythonpath_string} {flags} {image_flag} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {fn}_tinygrad.pkl'
+    action=f'cd {env.Dir("#")} && PYTHONPATH="$PYTHONPATH:{env.Dir("#tinygrad_repo").path}" {flags} {image_flag} python3 {env.Dir("#tinygrad_repo").path}/examples/openpilot/compile3.py {fn.path}.onnx {fn.path}_tinygrad.pkl',
   )
 
 # Compile small models
@@ -50,7 +48,7 @@ for model_name in ['driving_vision', 'driving_policy', 'dmonitoring_model']:
 if "USBGPU" in os.environ:
   import subprocess
   # because tg doesn't support multi-process
-  devs = subprocess.check_output('python3 -c "from tinygrad import Device; print(list(Device.get_available_devices()))"', shell=True, cwd=env.Dir('#').abspath)
+  devs = subprocess.check_output('python3 -c "from tinygrad import Device; print(list(Device.get_available_devices()))"', shell=True, cwd=env.Dir('#').path)
   if b"AMD" in devs:
     print("USB GPU detected... building")
     flags = "DEV=AMD AMD_IFACE=USB AMD_LLVM=1 NOLOCALS=0 IMAGE=0"

--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -9,6 +9,7 @@ tinygrad_files = ["#"+x for x in glob.glob(env.Dir("#tinygrad_repo").path + "/**
                   if 'pycache' not in x and os.path.isfile(os.path.join(tinygrad_root.path, x))]
 
 # Get model metadata
+script_files = [Dir("#selfdrive/modeld").File("get_model_metadata.py")]
 for model_name in ['driving_vision', 'driving_policy', 'dmonitoring_model']:
   fn = File(f"models/{model_name}")
   cmd = f'cd {env.Dir("#")} && python3 {script_files[0].path} {fn.path}.onnx'

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -8,22 +8,22 @@ Import('env', 'arch', 'common')
 generator = File("#selfdrive/assets/fonts/process.py")
 source_files = Glob("#selfdrive/assets/fonts/*.ttf") + Glob("#selfdrive/assets/fonts/*.otf")
 output_files = [
-  (f.abspath.split('.')[0] + ".fnt", f.abspath.split('.')[0] + ".png")
+  (f.path.split('.')[0] + ".fnt", f.path.split('.')[0] + ".png")
   for f in source_files
   if "NotoColor" not in f.name
 ]
 env.Command(
-  target=output_files,
+  target=[f.path for f in output_files],
   source=[generator, source_files],
-  action=f"python3 {generator}",
+  action=f"cd {env.Dir('#')} && python3 {generator.path}", # generator path is root-relative
 )
 
 # compile gettext .po -> .mo translations
-with open(File("translations/languages.json").abspath) as f:
+with open(File("translations/languages.json").path) as f:
   languages = json.loads(f.read())
 
 po_sources = [f"#selfdrive/ui/translations/app_{l}.po" for l in languages.values()]
-po_sources = [src for src in po_sources if os.path.exists(File(src).abspath)]
+po_sources = [src for src in po_sources if File(src).exists()] # Changed from os.path.exists() to File().exists()
 mo_targets = [src.replace(".po", ".mo") for src in po_sources]
 mo_build = []
 for src, tgt in zip(po_sources, mo_targets):

--- a/test_scons_paths.py
+++ b/test_scons_paths.py
@@ -1,0 +1,23 @@
+from SCons.Script import *
+import os
+
+env = Environment()
+
+def build_action(target, source, env):
+    print(f"Action CWD: {os.getcwd()}")
+    return None
+
+# Test nodes
+root_dir = Dir('#')
+sub_dir = Dir('selfdrive/ui')
+sub_file = File('selfdrive/ui/SConscript')
+
+print(f"Root Dir Path: [{root_dir.path}]")
+print(f"Sub Dir Path: [{sub_dir.path}]")
+print(f"Sub File Path: [{sub_file.path}]")
+
+# Test command expansion
+env.Command('test_target', sub_file, f"echo SOURCE: $SOURCE, TARGET: $TARGET, ROOT: {root_dir.path}")
+
+# Run a dummy build to see the expansion
+# (Usually we'd run 'scons -n' on this file)

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -89,6 +89,7 @@ cabana_env.Program('cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs
 if GetOption('extras'):
   cabana_env.Program('tests/test_cabana', ['tests/test_runner.cc', 'tests/test_cabana.cc', cabana_lib], LIBS=[cabana_libs])
 
+output_json_file = 'tools/cabana/dbc/car_fingerprint_to_dbc.json'
 generate_dbc = cabana_env.Command('#' + output_json_file,
                                   ['dbc/generate_dbc_json.py'],
                                   f"cd {env.Dir('#')} && python3 tools/cabana/dbc/generate_dbc_json.py --out " + output_json_file)

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -34,7 +34,7 @@ else:
   qt_libs = [f"Qt5{m}" for m in qt_modules]
   if arch == "larch64":
     qt_libs += ["GLESv2", "wayland-client"]
-    qt_env.PrependENVPath('PATH', Dir("#third_party/qt5/larch64/bin/").abspath)
+    qt_env.PrependENVPath('PATH', Dir("#third_party/qt5/larch64/bin/").path)
   elif arch != "Darwin":
     qt_libs += ["GL"]
 qt_env['QT3DIR'] = qt_env['QTDIR']
@@ -68,13 +68,14 @@ qt_libs = base_libs
 cabana_env = qt_env.Clone()
 
 cabana_libs = [cereal, messaging, visionipc, replay_lib, 'avutil', 'avcodec', 'avformat', 'bz2', 'zstd', 'curl', 'yuv', 'usb-1.0'] + qt_libs
-opendbc_path = '-DOPENDBC_FILE_PATH=\'"%s"\'' % (cabana_env.Dir("../../opendbc/dbc").abspath)
+cabana_env['ENV']['PATH'] = Dir("#tools/cabana/bin").path + ':' + cabana_env['ENV']['PATH']
+opendbc_path = f'-DOPENDBC_FILE_PATH=\'"{cabana_env.Dir("../../opendbc/dbc").path}"\''
 cabana_env['CXXFLAGS'] += [opendbc_path]
 
 # build assets
 assets = "assets/assets.cc"
 assets_src = "assets/assets.qrc"
-cabana_env.Command(assets, assets_src, f"rcc $SOURCES -o $TARGET")
+cabana_env.Command(assets, assets_src, f"cd {env.Dir('#')} && rcc {File(assets_src).path} -o {File(assets).path}")
 cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "assets/assets.o"]))
 
 cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/socketcanstream.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
@@ -88,8 +89,7 @@ cabana_env.Program('cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs
 if GetOption('extras'):
   cabana_env.Program('tests/test_cabana', ['tests/test_runner.cc', 'tests/test_cabana.cc', cabana_lib], LIBS=[cabana_libs])
 
-output_json_file = 'tools/cabana/dbc/car_fingerprint_to_dbc.json'
 generate_dbc = cabana_env.Command('#' + output_json_file,
                                   ['dbc/generate_dbc_json.py'],
-                                  "python3 tools/cabana/dbc/generate_dbc_json.py --out " + output_json_file)
+                                  f"cd {env.Dir('#')} && python3 tools/cabana/dbc/generate_dbc_json.py --out " + output_json_file)
 cabana_env.Depends(generate_dbc, ["#common", '#opendbc_repo', "#cereal", "#msgq_repo"])


### PR DESCRIPTION
…bounty #30161)

Replaces .abspath usage in SConstruct and SConscript files with stable relative .path attributes. This prevents cache invalidation in CI environments where the workspace location changes.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

