### PR TITLE
ui diff: ensure video name matches output

### DIFF
--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -62,7 +62,7 @@ def find_differences(video1, video2):
     return different_frames, len(frames1)
 
 
-def generate_html_report(video1, video2, basedir, different_frames, total_frames):
+def generate_html_report(video1, video2, basedir, different_frames, total_frames, diff_video_name):
   chunks = []
   if different_frames:
     current_chunk = [different_frames[0]]
@@ -100,7 +100,7 @@ def generate_html_report(video1, video2, basedir, different_frames, total_frames
 <td width='33%'>
   <p><strong>Pixel Diff</strong></p>
   <video id='diffVideo' width='100%' autoplay muted loop>
-    <source src='{os.path.join(basedir, 'diff.mp4')}' type='video/mp4'>
+    <source src='{os.path.join(basedir, diff_video_name)}' type='video/mp4'>
     Your browser does not support the video tag.
   </video>
 </td>
@@ -162,8 +162,9 @@ def main():
   print(f"Output: {args.output}")
   print()
 
-  # Create diff video
-  diff_video_path = os.path.join(os.path.dirname(args.output), DIFF_OUT_DIR / "diff.mp4")
+  # Create diff video with name derived from output HTML
+  diff_video_name = Path(args.output).stem + '.mp4'
+  diff_video_path = str(DIFF_OUT_DIR / diff_video_name)
   create_diff_video(args.video1, args.video2, diff_video_path)
 
   different_frames, total_frames = find_differences(args.video1, args.video2)
@@ -173,7 +174,7 @@ def main():
 
   print()
   print("Generating HTML report...")
-  html = generate_html_report(args.video1, args.video2, args.basedir, different_frames, total_frames)
+  html = generate_html_report(args.video1, args.video2, args.basedir, different_frames, total_frames, diff_video_name)
 
   with open(DIFF_OUT_DIR / args.output, 'w') as f:
     f.write(html)

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -152,6 +152,9 @@ def main():
 
   args = parser.parse_args()
 
+  if not args.output.lower().endswith('.html'):
+    args.output += '.html'
+
   os.makedirs(DIFF_OUT_DIR, exist_ok=True)
 
   print("=" * 60)


### PR DESCRIPTION
Even though you can change the diff's output filename (e.g. `diff.html`), you can't change the video name (`diff.mp4`), so this just makes the `.mp4` use the same base name as the `.html`, and also adds `.html` to the output if it's excluded.

This will likely be needed for when the workflow needs to output separate reports for tizi and mici, since they will both try to use `diff.mp4` for the clip name, even with separate html report locations.

Split from #37198 since workflow changes were also removed.
