### PR TITLE
fix: properly close file handles in agnos.py

### DIFF
--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -258,7 +258,8 @@ def flash_partition(target_slot_number: int, partition: dict, cloudlog, standalo
 
 
 def swap(manifest_path: str, target_slot_number: int, cloudlog) -> None:
-  update = json.load(open(manifest_path))
+  with open(manifest_path) as f:
+    update = json.load(f)
   for partition in update:
     if not partition.get('full_check', False):
       clear_partition_hash(target_slot_number, partition)
@@ -273,7 +274,8 @@ def swap(manifest_path: str, target_slot_number: int, cloudlog) -> None:
 
 
 def flash_agnos_update(manifest_path: str, target_slot_number: int, cloudlog, standalone=False) -> None:
-  update = json.load(open(manifest_path))
+  with open(manifest_path) as f:
+    update = json.load(f)
 
   cloudlog.info(f"Target slot {target_slot_number}")
 
@@ -302,7 +304,8 @@ def flash_agnos_update(manifest_path: str, target_slot_number: int, cloudlog, st
 
 
 def verify_agnos_update(manifest_path: str, target_slot_number: int) -> bool:
-  update = json.load(open(manifest_path))
+  with open(manifest_path) as f:
+    update = json.load(f)
   return all(verify_partition(target_slot_number, partition) for partition in update)
 
 


### PR DESCRIPTION
## Summary

Fixes resource leaks in `system/hardware/tici/agnos.py` by using context managers to ensure file handles are properly closed after reading JSON manifests.

## Changes

- `swap()`: Use `with open()` context manager for reading manifest
- `flash_agnos_update()`: Use `with open()` context manager for reading manifest
- `verify_agnos_update()`: Use `with open()` context manager for reading manifest

## Why

The previous implementation opened files without context managers (`json.load(open(manifest_path))`), which could leak file descriptors if exceptions occur or in high-frequency usage scenarios. Using context managers ensures files are always properly closed, following Python best practices.

## Testing

Existing tests should continue to pass. The changes are purely refactoring with no functional changes.