### PR TITLE
fix: properly close file handles in pickle/file operations

### DIFF
--- a/selfdrive/debug/test_fw_query_on_routes.py
+++ b/selfdrive/debug/test_fw_query_on_routes.py
@@ -24,7 +24,8 @@ if __name__ == "__main__":
   args = parser.parse_args()
 
   if os.path.exists(args.route):
-    routes = list(open(args.route))
+    with open(args.route) as f:
+      routes = list(f)
   else:
     routes = [args.route]
 

--- a/selfdrive/modeld/compile_warp.py
+++ b/selfdrive/modeld/compile_warp.py
@@ -169,7 +169,8 @@ def compile_modeld_warp(cam_w, cam_h):
     pickle.dump(update_img_jit, f)
   print(f"  Saved to {pkl_path}")
 
-  jit = pickle.load(open(pkl_path, "rb"))
+  with open(pkl_path, "rb") as f:
+    jit = pickle.load(f)
   jit(*inputs)
 
 

--- a/selfdrive/test/process_replay/model_replay.py
+++ b/selfdrive/test/process_replay/model_replay.py
@@ -204,7 +204,8 @@ def get_frames():
   if os.path.isfile(cache_name) and not regen_cache:
     try:
       print(f"Loading frames from cache {cache_name}")
-      return pickle.load(open(cache_name, "rb"))
+      with open(cache_name, "rb") as f:
+        return pickle.load(f)
     except Exception as e:
       print(f"Failed to load frames from cache {cache_name}: {e}")
 
@@ -218,7 +219,8 @@ def get_frames():
       fr.get(fidx)
     fr.it = None
   print(f"Dumping frame cache {cache_name}")
-  pickle.dump(frs, open(cache_name, "wb"))
+  with open(cache_name, "wb") as f:
+    pickle.dump(frs, f)
   return frs
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes resource leaks in multiple files by using context managers to ensure file handles are properly closed.

## Changes

**selfdrive/test/process_replay/model_replay.py:**
- Line 207: Use `with open()` for pickle.load
- Line 221: Use `with open()` for pickle.dump

**selfdrive/modeld/compile_warp.py:**
- Line 172: Use `with open()` for pickle.load

**selfdrive/debug/test_fw_query_on_routes.py:**
- Line 27: Use `with open()` for reading route list

## Why

The previous implementations opened files without context managers (e.g., `pickle.load(open(...))`), which could leak file descriptors:
- If exceptions occur before the file is garbage collected
- In high-frequency usage scenarios where GC doesn't run immediately
- When files are opened repeatedly in tight loops

Using `with` statements ensures files are always properly closed, following Python best practices and preventing potential resource exhaustion.

## Testing

Existing tests should continue to pass. The changes are purely refactoring with no functional changes — just ensuring proper resource cleanup.