### PR TITLE
ci: fix first-interaction action missing required input

### DIFF
--- a/.github/workflows/auto_pr_review.yaml
+++ b/.github/workflows/auto_pr_review.yaml
@@ -40,6 +40,7 @@ jobs:
       if: github.event.pull_request.head.repo.full_name != 'commaai/openpilot'
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: ""
         pr_message: |
             <!-- _(run_id **${{ github.run_id }}**)_ -->
             Thanks for contributing to openpilot! In order for us to review your PR as quickly as possible, check the following:


### PR DESCRIPTION
`actions/first-interaction@v3` requires both `issue_message` and `pr_message` inputs in its source code, but only `pr_message` was provided. This causes the action to crash with:

```
Error: Input required and not supplied: issue_message
```

Since the workflow only triggers on `pull_request_target` and issue templates already provide guidance to first-time filers, `issue_message` is set to an empty string.