### PR TITLE
ci: fix update translations by enable submodule checkout in repo maintenance

### DIFF
--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -16,6 +16,8 @@ jobs:
     if: github.repository == 'commaai/openpilot'
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: true
       - uses: ./.github/workflows/setup-with-retry
       - name: Update translations
         run: |


### PR DESCRIPTION
#### Description
###

The update_translations CI job fails because it doesn't check out submodules, leading to a broken cereal/car.capnp symlink

#### Verification
###

Tested with [`sunnypilot/sunnypilot`](https://github.com/sunnypilot/sunnypilot).
- Before (failed): https://github.com/sunnypilot/sunnypilot/actions/runs/22067333815/job/63762510814
- After (success): https://github.com/sunnypilot/sunnypilot/actions/runs/22121272111/job/63941603666