### PR TITLE
ui replay: record lossless to fix big replay diff

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -104,6 +104,7 @@ def main():
   if args.big:
     os.environ["BIG"] = "1"
   os.environ["RECORD"] = "1"
+  os.environ["RECORD_LOSSLESS"] = "1"  # Lossless is needed for deterministic output across different machines
   os.environ["RECORD_OUTPUT"] = os.path.join(DIFF_OUT_DIR, os.environ.get("RECORD_OUTPUT", f"{variant}_ui_replay.mp4"))
 
   print(f"Running {variant} UI replay...")

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -104,7 +104,7 @@ def main():
   if args.big:
     os.environ["BIG"] = "1"
   os.environ["RECORD"] = "1"
-  os.environ["RECORD_QUALITY"] = "0"  # Lossless (CRF 0) is needed for deterministic output across different machines
+  os.environ["RECORD_QUALITY"] = "0"  # Use CRF 0 ("lossless" encode) for deterministic output across different machines
   os.environ["RECORD_OUTPUT"] = os.path.join(DIFF_OUT_DIR, os.environ.get("RECORD_OUTPUT", f"{variant}_ui_replay.mp4"))
 
   print(f"Running {variant} UI replay...")

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -104,7 +104,7 @@ def main():
   if args.big:
     os.environ["BIG"] = "1"
   os.environ["RECORD"] = "1"
-  os.environ["RECORD_LOSSLESS"] = "1"  # Lossless is needed for deterministic output across different machines
+  os.environ["RECORD_QUALITY"] = "0"  # Lossless (CRF 0) is needed for deterministic output across different machines
   os.environ["RECORD_OUTPUT"] = os.path.join(DIFF_OUT_DIR, os.environ.get("RECORD_OUTPUT", f"{variant}_ui_replay.mp4"))
 
   print(f"Running {variant} UI replay...")

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -42,6 +42,7 @@ PROFILE_STATS = int(os.getenv("PROFILE_STATS", "100"))  # Number of functions to
 RECORD = os.getenv("RECORD") == "1"
 RECORD_OUTPUT = str(Path(os.getenv("RECORD_OUTPUT", "output")).with_suffix(".mp4"))
 RECORD_BITRATE = os.getenv("RECORD_BITRATE", "")  # Target bitrate e.g. "2000k"
+RECORD_LOSSLESS = os.getenv("RECORD_LOSSLESS") == "1"  # Use lossless recording quality (larger file size; can't be set with RECORD_BITRATE)
 RECORD_SPEED = int(os.getenv("RECORD_SPEED", "1"))  # Speed multiplier
 OFFSCREEN = os.getenv("OFFSCREEN") == "1"  # Disable FPS limiting for fast offline rendering
 
@@ -299,7 +300,10 @@ class GuiApplication:
           '-c:v', 'libx264',
           '-preset', 'ultrafast',
         ]
-        if RECORD_BITRATE:
+        if RECORD_LOSSLESS:
+          assert not RECORD_BITRATE, "RECORD_BITRATE and RECORD_LOSSLESS cannot be set together."
+          ffmpeg_args += ['-crf', '0']
+        elif RECORD_BITRATE:
           ffmpeg_args += ['-b:v', RECORD_BITRATE, '-maxrate', RECORD_BITRATE, '-bufsize', RECORD_BITRATE]
         ffmpeg_args += [
           '-y',                     # Overwrite existing file

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -41,8 +41,8 @@ PROFILE_RENDER = int(os.getenv("PROFILE_RENDER", "0"))
 PROFILE_STATS = int(os.getenv("PROFILE_STATS", "100"))  # Number of functions to show in profile output
 RECORD = os.getenv("RECORD") == "1"
 RECORD_OUTPUT = str(Path(os.getenv("RECORD_OUTPUT", "output")).with_suffix(".mp4"))
-RECORD_BITRATE = os.getenv("RECORD_BITRATE", "")  # Target bitrate e.g. "2000k"
-RECORD_LOSSLESS = os.getenv("RECORD_LOSSLESS") == "1"  # Use lossless recording quality (larger file size; can't be set with RECORD_BITRATE)
+RECORD_QUALITY = int(os.getenv("RECORD_QUALITY", "23"))  # Dynamic bitrate quality level (CRF); 0 is lossless, max is 51, default is 23 for x264
+RECORD_BITRATE = os.getenv("RECORD_BITRATE", "")  # Target bitrate e.g. "2000k" (overrides RECORD_QUALITY when set)
 RECORD_SPEED = int(os.getenv("RECORD_SPEED", "1"))  # Speed multiplier
 OFFSCREEN = os.getenv("OFFSCREEN") == "1"  # Disable FPS limiting for fast offline rendering
 
@@ -299,11 +299,10 @@ class GuiApplication:
           '-r', str(output_fps),    # Output frame rate (for speed multiplier)
           '-c:v', 'libx264',
           '-preset', 'ultrafast',
+          '-crf', str(RECORD_QUALITY)
         ]
-        if RECORD_LOSSLESS:
-          assert not RECORD_BITRATE, "RECORD_BITRATE and RECORD_LOSSLESS cannot be set together."
-          ffmpeg_args += ['-crf', '0']
-        elif RECORD_BITRATE:
+        if RECORD_BITRATE:
+          # NOTE: Setting bitrate settings here will override CRF quality setting above
           ffmpeg_args += ['-b:v', RECORD_BITRATE, '-maxrate', RECORD_BITRATE, '-bufsize', RECORD_BITRATE]
         ffmpeg_args += [
           '-y',                     # Overwrite existing file

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -302,7 +302,7 @@ class GuiApplication:
           '-crf', str(RECORD_QUALITY)
         ]
         if RECORD_BITRATE:
-          # NOTE: Setting bitrate settings here will override CRF quality setting above
+          # NOTE: custom bitrate overrides crf setting
           ffmpeg_args += ['-b:v', RECORD_BITRATE, '-maxrate', RECORD_BITRATE, '-bufsize', RECORD_BITRATE]
         ffmpeg_args += [
           '-y',                     # Overwrite existing file

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -41,7 +41,7 @@ PROFILE_RENDER = int(os.getenv("PROFILE_RENDER", "0"))
 PROFILE_STATS = int(os.getenv("PROFILE_STATS", "100"))  # Number of functions to show in profile output
 RECORD = os.getenv("RECORD") == "1"
 RECORD_OUTPUT = str(Path(os.getenv("RECORD_OUTPUT", "output")).with_suffix(".mp4"))
-RECORD_QUALITY = int(os.getenv("RECORD_QUALITY", "23"))  # Dynamic bitrate quality level (CRF); 0 is lossless, max is 51, default is 23 for x264
+RECORD_QUALITY = int(os.getenv("RECORD_QUALITY", "23"))  # Dynamic bitrate quality level (CRF); 0 is lossless (bigger size), max is 51, default is 23 for x264
 RECORD_BITRATE = os.getenv("RECORD_BITRATE", "")  # Target bitrate e.g. "2000k" (overrides RECORD_QUALITY when set)
 RECORD_SPEED = int(os.getenv("RECORD_SPEED", "1"))  # Speed multiplier
 OFFSCREEN = os.getenv("OFFSCREEN") == "1"  # Disable FPS limiting for fast offline rendering


### PR DESCRIPTION
The tizi replay diff is interdeterministic in CI, due to tiny pixel differences (mostly on edges) of fonts and buttons. Example failure: https://github.com/commaai/openpilot/pull/37154#issuecomment-3910681127 This also fixes an issue where if only a few frames are changed it marks a lot more as changed than actually were.

After debugging this issue for several hours, _(and around $2 in LLM usage)_, I have found it is not related to rendering at all (including anti-aliasing), but is rather a recording issue caused by variations with lossy compression across different machines (possibly due to rounding differences or something in the CPU architecture).

Replaying the tizi clip on the same machine results in the same output, but in CI it can run on different machines. I've tested this out on my own fork by downloading the artifacts from CI in [my fork's PR](https://github.com/TheSecurityDev/openpilot-dev/pull/20) and comparing the clip to one generated locally until I got it to work.

Setting the constant rate factor to 0 `-crf 0` (lossless) finally fixed the issue and made the two replays the same. CRF is 23 by default. **Note:** It's still not strictly lossless because **yuv420p** is chroma subsampled. But it fixes our issues.

**This does come at a cost of a larger file size (around 8.14 MB vs 2.85 MB).**

**Example diff with red pixels where there are pixel differences:** (notice the square shapes, which is a clue that it's compression instead of rendering)

https://github.com/user-attachments/assets/0e9ffc6c-49fc-46ef-8860-103bd87974a1

