### PR TITLE
WifiManager: fix is_connected flicker while roaming on low strength networks

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -94,13 +94,13 @@ class Network:
   ip_address: str = ""  # TODO: implement
 
   @classmethod
-  def from_dbus(cls, ssid: str, aps: list["AccessPoint"], is_saved: bool, connected_ssid: str | None = None) -> "Network":
+  def from_dbus(cls, ssid: str, aps: list["AccessPoint"], is_saved: bool, active_connection: bool) -> "Network":
     # we only want to show the strongest AP for each Network/SSID
     strongest_ap = max(aps, key=lambda ap: ap.strength)
     # uses ActiveConnection SSID (stable during AP roaming) instead of ActiveAccessPoint path
     # https://github.com/GNOME/gnome-shell/blob/3f8b174274fac7d69477523d4873ef8253e1ed49/js/ui/status/network.js#L810-L819
-    print((any(ap.is_connected for ap in aps)), connected_ssid, ssid)
-    is_connected = any(ap.is_connected for ap in aps)# or (ssid == connected_ssid)
+    print('test', ssid, (any(ap.is_connected for ap in aps)), active_connection)
+    is_connected = any(ap.is_connected for ap in aps) or active_connection
     security_type = get_security_type(strongest_ap.flags, strongest_ap.wpa_flags, strongest_ap.rsn_flags)
 
     return cls(
@@ -355,7 +355,8 @@ class WifiManager:
         if time.monotonic() - self._last_network_scan > SCAN_PERIOD_SECONDS:
           self._request_scan()
           self._last_network_scan = time.monotonic()
-      time.sleep(1 / 2.)
+        self._update_networks()
+      time.sleep(1 / 10.)
 
   def _wait_for_wifi_device(self):
     while not self._exit:
@@ -412,7 +413,8 @@ class WifiManager:
   def _get_active_connections(self):
     return self._router_main.send_and_get_reply(Properties(self._nm).get('ActiveConnections')).body[0][1]
 
-  def _get_connected_ssid(self) -> str | None:
+  def _get_active_connection(self) -> str | None:
+    # Returns first Connection path in ActiveConnections with Type 802-11-wireless
     for active_conn in self._get_active_connections():
       conn_addr = DBusAddress(active_conn, bus_name=NM, interface=NM_ACTIVE_CONNECTION_IFACE)
       reply = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
@@ -426,19 +428,53 @@ class WifiManager:
       if props.get('Type', ('s', ''))[1] == '802-11-wireless':
         conn_path = props.get('Connection', ('o', '/'))[1]
         if conn_path == '/':
-          return None
+          continue
 
-        settings = self._get_connection_settings(conn_path)
+        return conn_path
 
-        if len(settings) == 0:
-          cloudlog.warning(f"Failed to get connection settings for {conn_path}")
-          return None
-
-        ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
-        if ssid_val is not None:
-          return bytes(ssid_val[1]).decode('utf-8', 'replace')
+        # print('ActiveConnection:', active_conn, 'Connection path:', conn_path)
+        #
+        # settings = self._get_connection_settings(conn_path)
+        #
+        # if len(settings) == 0:
+        #   cloudlog.warning(f"Failed to get connection settings for {conn_path}")
+        #   return None
+        #
+        # ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
+        # if ssid_val is not None:
+        #   return bytes(ssid_val[1]).decode('utf-8', 'replace')
 
     return None
+
+  # def _get_connected_ssid(self) -> str | None:
+  #   for active_conn in self._get_active_connections():
+  #     conn_addr = DBusAddress(active_conn, bus_name=NM, interface=NM_ACTIVE_CONNECTION_IFACE)
+  #     reply = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
+  #
+  #     if reply.header.message_type == MessageType.error:
+  #       cloudlog.warning(f"Failed to get active connection properties for {active_conn}: {reply}")
+  #       continue
+  #
+  #     props = reply.body[0]
+  #
+  #     if props.get('Type', ('s', ''))[1] == '802-11-wireless':
+  #       conn_path = props.get('Connection', ('o', '/'))[1]
+  #       if conn_path == '/':
+  #         return None
+  #
+  #       print('ActiveConnection:', active_conn, 'Connection path:', conn_path)
+  #
+  #       settings = self._get_connection_settings(conn_path)
+  #
+  #       if len(settings) == 0:
+  #         cloudlog.warning(f"Failed to get connection settings for {conn_path}")
+  #         return None
+  #
+  #       ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
+  #       if ssid_val is not None:
+  #         return bytes(ssid_val[1]).decode('utf-8', 'replace')
+  #
+  #   return None
 
   def _get_connection_settings(self, conn_path: str) -> dict:
     conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
@@ -722,9 +758,10 @@ class WifiManager:
             # catch all for parsing errors
             cloudlog.exception(f"Failed to parse AP properties for {ap_path}")
 
-        connected_ssid = self._get_connected_ssid()
-        print('connected ssid', connected_ssid)
-        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, connected_ssid) for ssid, ap_list in aps.items()]
+        # connected_ssid = self._get_connected_ssid()
+        active_connection_path = self._get_active_connection()
+        print('_connections', self._connections)
+        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, self._connections.get(ssid) == active_connection_path) for ssid, ap_list in aps.items()]
         # sort with quantized strength to reduce jumping
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -round(n.strength / 100 * 2), n.ssid.lower()))
         self._networks = networks

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -709,9 +709,9 @@ class WifiManager:
             # catch all for parsing errors
             cloudlog.exception(f"Failed to parse AP properties for {ap_path}")
 
-        # connected_ssid = self._get_connected_ssid()
         active_wifi_connection, _ = self._get_active_wifi_connection()
-        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
+        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections,
+                                      self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
         # sort with quantized strength to reduce jumping
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -round(n.strength / 100 * 2), n.ssid.lower()))
         self._networks = networks

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -712,9 +712,9 @@ class WifiManager:
             cloudlog.exception(f"Failed to parse AP properties for {ap_path}")
 
         # connected_ssid = self._get_connected_ssid()
-        active_connection_path = self._get_active_connection()
+        active_wifi_connection, _ = self._get_active_wifi_connection()
         print('_connections', self._connections)
-        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, self._connections.get(ssid) == active_connection_path) for ssid, ap_list in aps.items()]
+        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
         # sort with quantized strength to reduce jumping
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -round(n.strength / 100 * 2), n.ssid.lower()))
         self._networks = networks

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -355,8 +355,7 @@ class WifiManager:
         if time.monotonic() - self._last_network_scan > SCAN_PERIOD_SECONDS:
           self._request_scan()
           self._last_network_scan = time.monotonic()
-        self._update_networks()
-      time.sleep(1 / 10.)
+      time.sleep(1 / 2.)
 
   def _wait_for_wifi_device(self):
     while not self._exit:
@@ -427,54 +426,10 @@ class WifiManager:
 
       if props.get('Type', ('s', ''))[1] == '802-11-wireless':
         conn_path = props.get('Connection', ('o', '/'))[1]
-        if conn_path == '/':
-          continue
-
-        return conn_path
-
-        # print('ActiveConnection:', active_conn, 'Connection path:', conn_path)
-        #
-        # settings = self._get_connection_settings(conn_path)
-        #
-        # if len(settings) == 0:
-        #   cloudlog.warning(f"Failed to get connection settings for {conn_path}")
-        #   return None
-        #
-        # ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
-        # if ssid_val is not None:
-        #   return bytes(ssid_val[1]).decode('utf-8', 'replace')
+        if conn_path != '/':
+          return conn_path
 
     return None
-
-  # def _get_connected_ssid(self) -> str | None:
-  #   for active_conn in self._get_active_connections():
-  #     conn_addr = DBusAddress(active_conn, bus_name=NM, interface=NM_ACTIVE_CONNECTION_IFACE)
-  #     reply = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
-  #
-  #     if reply.header.message_type == MessageType.error:
-  #       cloudlog.warning(f"Failed to get active connection properties for {active_conn}: {reply}")
-  #       continue
-  #
-  #     props = reply.body[0]
-  #
-  #     if props.get('Type', ('s', ''))[1] == '802-11-wireless':
-  #       conn_path = props.get('Connection', ('o', '/'))[1]
-  #       if conn_path == '/':
-  #         return None
-  #
-  #       print('ActiveConnection:', active_conn, 'Connection path:', conn_path)
-  #
-  #       settings = self._get_connection_settings(conn_path)
-  #
-  #       if len(settings) == 0:
-  #         cloudlog.warning(f"Failed to get connection settings for {conn_path}")
-  #         return None
-  #
-  #       ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
-  #       if ssid_val is not None:
-  #         return bytes(ssid_val[1]).decode('utf-8', 'replace')
-  #
-  #   return None
 
   def _get_connection_settings(self, conn_path: str) -> dict:
     conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -97,9 +97,8 @@ class Network:
   def from_dbus(cls, ssid: str, aps: list["AccessPoint"], is_saved: bool, active_connection: bool) -> "Network":
     # we only want to show the strongest AP for each Network/SSID
     strongest_ap = max(aps, key=lambda ap: ap.strength)
-    # uses ActiveConnection SSID (stable during AP roaming) instead of ActiveAccessPoint path
+    # fall back to ActiveConnection during momentary AP roaming or low strength networks. matches GNOME shell behavior
     # https://github.com/GNOME/gnome-shell/blob/3f8b174274fac7d69477523d4873ef8253e1ed49/js/ui/status/network.js#L810-L819
-    print('test', ssid, (any(ap.is_connected for ap in aps)), active_connection)
     is_connected = any(ap.is_connected for ap in aps) or active_connection
     security_type = get_security_type(strongest_ap.flags, strongest_ap.wpa_flags, strongest_ap.rsn_flags)
 
@@ -684,7 +683,6 @@ class WifiManager:
         wifi_addr = DBusAddress(self._wifi_device, NM, interface=NM_WIRELESS_IFACE)
         wifi_props = self._router_main.send_and_get_reply(Properties(wifi_addr).get_all()).body[0]
         active_ap_path = wifi_props.get('ActiveAccessPoint', ('o', '/'))[1]
-        print('active ap path', active_ap_path)
         ap_paths = wifi_props.get('AccessPoints', ('ao', []))[1]
 
         aps: dict[str, list[AccessPoint]] = {}
@@ -713,7 +711,6 @@ class WifiManager:
 
         # connected_ssid = self._get_connected_ssid()
         active_wifi_connection, _ = self._get_active_wifi_connection()
-        print('_connections', self._connections)
         networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
         # sort with quantized strength to reduce jumping
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -round(n.strength / 100 * 2), n.ssid.lower()))

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -94,10 +94,13 @@ class Network:
   ip_address: str = ""  # TODO: implement
 
   @classmethod
-  def from_dbus(cls, ssid: str, aps: list["AccessPoint"], is_saved: bool) -> "Network":
+  def from_dbus(cls, ssid: str, aps: list["AccessPoint"], is_saved: bool, connected_ssid: str | None = None) -> "Network":
     # we only want to show the strongest AP for each Network/SSID
     strongest_ap = max(aps, key=lambda ap: ap.strength)
-    is_connected = any(ap.is_connected for ap in aps)
+    # uses ActiveConnection SSID (stable during AP roaming) instead of ActiveAccessPoint path
+    # https://github.com/GNOME/gnome-shell/blob/3f8b174274fac7d69477523d4873ef8253e1ed49/js/ui/status/network.js#L810-L819
+    print((any(ap.is_connected for ap in aps)), connected_ssid, ssid)
+    is_connected = any(ap.is_connected for ap in aps)# or (ssid == connected_ssid)
     security_type = get_security_type(strongest_ap.flags, strongest_ap.wpa_flags, strongest_ap.rsn_flags)
 
     return cls(
@@ -352,7 +355,8 @@ class WifiManager:
         if time.monotonic() - self._last_network_scan > SCAN_PERIOD_SECONDS:
           self._request_scan()
           self._last_network_scan = time.monotonic()
-      time.sleep(1 / 2.)
+        self._update_networks()  # TODO: temporary 10hz for testing
+      time.sleep(1 / 10.)
 
   def _wait_for_wifi_device(self):
     while not self._exit:
@@ -408,6 +412,35 @@ class WifiManager:
 
   def _get_active_connections(self):
     return self._router_main.send_and_get_reply(Properties(self._nm).get('ActiveConnections')).body[0][1]
+
+  def _get_connected_ssid(self) -> str | None:
+    """Get SSID from ActiveConnections instead of ActiveAccessPoint — stable during AP roaming."""
+    for active_conn in self._get_active_connections():
+      conn_addr = DBusAddress(active_conn, bus_name=NM, interface=NM_ACTIVE_CONNECTION_IFACE)
+      reply = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
+      if reply.header.message_type == MessageType.error:
+        cloudlog.warning(f"Failed to get active connection properties for {active_conn}: {reply}")
+        continue
+
+      props = reply.body[0]
+      if props.get('Type', ('s', ''))[1] != '802-11-wireless':
+        continue
+
+      conn_path = props.get('Connection', ('o', '/'))[1]
+      if conn_path == '/':
+        return None
+
+      settings = self._get_connection_settings(conn_path)
+      if not settings:
+        return None
+
+      ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
+      if ssid_val is None:
+        return None
+
+      return bytes(ssid_val[1]).decode('utf-8', 'replace')
+
+    return None
 
   def _get_connection_settings(self, conn_path: str) -> dict:
     conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
@@ -660,10 +693,13 @@ class WifiManager:
           cloudlog.warning("No WiFi device found")
           return
 
+        connected_ssid = self._get_connected_ssid()
+
         # NOTE: AccessPoints property may exclude hidden APs (use GetAllAccessPoints method if needed)
         wifi_addr = DBusAddress(self._wifi_device, NM, interface=NM_WIRELESS_IFACE)
         wifi_props = self._router_main.send_and_get_reply(Properties(wifi_addr).get_all()).body[0]
         active_ap_path = wifi_props.get('ActiveAccessPoint', ('o', '/'))[1]
+        print('active ap path', active_ap_path)
         ap_paths = wifi_props.get('AccessPoints', ('ao', []))[1]
 
         aps: dict[str, list[AccessPoint]] = {}
@@ -690,7 +726,9 @@ class WifiManager:
             # catch all for parsing errors
             cloudlog.exception(f"Failed to parse AP properties for {ap_path}")
 
-        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections) for ssid, ap_list in aps.items()]
+        # print(aps)
+        # print()
+        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, connected_ssid) for ssid, ap_list in aps.items()]
         # sort with quantized strength to reduce jumping
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -round(n.strength / 100 * 2), n.ssid.lower()))
         self._networks = networks

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -355,8 +355,7 @@ class WifiManager:
         if time.monotonic() - self._last_network_scan > SCAN_PERIOD_SECONDS:
           self._request_scan()
           self._last_network_scan = time.monotonic()
-        self._update_networks()  # TODO: temporary 10hz for testing
-      time.sleep(1 / 10.)
+      time.sleep(1 / 2.)
 
   def _wait_for_wifi_device(self):
     while not self._exit:
@@ -414,31 +413,30 @@ class WifiManager:
     return self._router_main.send_and_get_reply(Properties(self._nm).get('ActiveConnections')).body[0][1]
 
   def _get_connected_ssid(self) -> str | None:
-    """Get SSID from ActiveConnections instead of ActiveAccessPoint — stable during AP roaming."""
     for active_conn in self._get_active_connections():
       conn_addr = DBusAddress(active_conn, bus_name=NM, interface=NM_ACTIVE_CONNECTION_IFACE)
       reply = self._router_main.send_and_get_reply(Properties(conn_addr).get_all())
+
       if reply.header.message_type == MessageType.error:
         cloudlog.warning(f"Failed to get active connection properties for {active_conn}: {reply}")
         continue
 
       props = reply.body[0]
-      if props.get('Type', ('s', ''))[1] != '802-11-wireless':
-        continue
 
-      conn_path = props.get('Connection', ('o', '/'))[1]
-      if conn_path == '/':
-        return None
+      if props.get('Type', ('s', ''))[1] == '802-11-wireless':
+        conn_path = props.get('Connection', ('o', '/'))[1]
+        if conn_path == '/':
+          return None
 
-      settings = self._get_connection_settings(conn_path)
-      if not settings:
-        return None
+        settings = self._get_connection_settings(conn_path)
 
-      ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
-      if ssid_val is None:
-        return None
+        if len(settings) == 0:
+          cloudlog.warning(f"Failed to get connection settings for {conn_path}")
+          return None
 
-      return bytes(ssid_val[1]).decode('utf-8', 'replace')
+        ssid_val = settings.get('802-11-wireless', {}).get('ssid', None)
+        if ssid_val is not None:
+          return bytes(ssid_val[1]).decode('utf-8', 'replace')
 
     return None
 
@@ -693,8 +691,6 @@ class WifiManager:
           cloudlog.warning("No WiFi device found")
           return
 
-        connected_ssid = self._get_connected_ssid()
-
         # NOTE: AccessPoints property may exclude hidden APs (use GetAllAccessPoints method if needed)
         wifi_addr = DBusAddress(self._wifi_device, NM, interface=NM_WIRELESS_IFACE)
         wifi_props = self._router_main.send_and_get_reply(Properties(wifi_addr).get_all()).body[0]
@@ -726,8 +722,8 @@ class WifiManager:
             # catch all for parsing errors
             cloudlog.exception(f"Failed to parse AP properties for {ap_path}")
 
-        # print(aps)
-        # print()
+        connected_ssid = self._get_connected_ssid()
+        print('connected ssid', connected_ssid)
         networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections, connected_ssid) for ssid, ap_list in aps.items()]
         # sort with quantized strength to reduce jumping
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -round(n.strength / 100 * 2), n.ssid.lower()))


### PR DESCRIPTION
from https://github.com/commaai/openpilot/pull/37152/commits/4f60f552e00164f07c8371a0c988053ca4092e1c

gnome uses both active AP and active connection as a fallback for some reason: https://github.com/GNOME/gnome-shell/blob/3f8b174274fac7d69477523d4873ef8253e1ed49/js/ui/status/network.js#L810-L819

- turn off hotspot long enough for active AP to be "/"
  - OLD: network shows "connect"
  - NEW: network stays "connected" until NM actually decides to stop trying to re-connect
- on low strength network, decides to roam to other APs
  - OLD: network flickers from "connected" to "connect" back and forth if it can't find a good strength AP
  - NEW: network stays "connected" until NM actually decides to stop trying to re-connect

we can additionally expose this re-connecting/activating state in the UI, but this fixes the flicker. if NM decides the network is gone or too low strength it will eventually drop to "connect" or "out of range", same as old behavior. but without the flickering while NM is trying to get a good connection