### PR TITLE
mici ui: if connected, don't show not connected

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/__init__.py
+++ b/selfdrive/ui/mici/layouts/settings/network/__init__.py
@@ -165,15 +165,16 @@ class NetworkLayoutMici(NavWidget):
     # Update wi-fi button with ssid and ip address
     # TODO: make sure we handle hidden ssids
     connecting_ssid = self._wifi_manager.connecting_to_ssid
-    connected_network = next((network for network in networks if network.is_connected), None)
+    connected_network = next((network for network in self._wifi_ui.networks.values() if network.is_connected), None)
+    # print('connecting_ssid', connecting_ssid, 'connected_network', connected_network)
     if connecting_ssid:
-      display_network = next((n for n in networks if n.ssid == connecting_ssid), None)
+      display_network = next((n for n in self._wifi_ui.networks.values() if n.ssid == connecting_ssid), None)
       self._wifi_button.set_text(normalize_ssid(connecting_ssid))
       self._wifi_button.set_value("connecting...")
     elif connected_network is not None:
       display_network = connected_network
       self._wifi_button.set_text(normalize_ssid(connected_network.ssid))
-      self._wifi_button.set_value(self._wifi_manager.ipv4_address or "not connected")
+      self._wifi_button.set_value(self._wifi_manager.ipv4_address or "obtaining IP...")
     else:
       display_network = None
       self._wifi_button.set_text("wi-fi")

--- a/selfdrive/ui/mici/layouts/settings/network/__init__.py
+++ b/selfdrive/ui/mici/layouts/settings/network/__init__.py
@@ -165,10 +165,9 @@ class NetworkLayoutMici(NavWidget):
     # Update wi-fi button with ssid and ip address
     # TODO: make sure we handle hidden ssids
     connecting_ssid = self._wifi_manager.connecting_to_ssid
-    connected_network = next((network for network in self._wifi_ui.networks.values() if network.is_connected), None)
-    # print('connecting_ssid', connecting_ssid, 'connected_network', connected_network)
+    connected_network = next((network for network in networks if network.is_connected), None)
     if connecting_ssid:
-      display_network = next((n for n in self._wifi_ui.networks.values() if n.ssid == connecting_ssid), None)
+      display_network = next((n for n in networks if n.ssid == connecting_ssid), None)
       self._wifi_button.set_text(normalize_ssid(connecting_ssid))
       self._wifi_button.set_value("connecting...")
     elif connected_network is not None:

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -731,9 +731,13 @@ class WifiManager:
 
     conn_path, props = self._get_active_wifi_connection()
 
+    print('Active connection path:', conn_path, props)
+
     if conn_path is not None and props is not None:
       # IPv4 address
       ip4config_path = props.get('Ip4Config', ('o', '/'))[1]
+
+      print('Has IP4 config:', ip4config_path)
 
       if ip4config_path != "/":
         ip4config_addr = DBusAddress(ip4config_path, bus_name=NM, interface=NM_IP4_CONFIG_IFACE)
@@ -743,6 +747,8 @@ class WifiManager:
           if 'address' in entry:
             ipv4_address = entry['address'][1]
             break
+        else:
+          print('NO IP address found in AddressData:', address_data)
 
       # Metered status
       settings = self._get_connection_settings(conn_path)

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -735,13 +735,9 @@ class WifiManager:
 
     conn_path, props = self._get_active_wifi_connection()
 
-    print('Active connection path:', conn_path, props)
-
     if conn_path is not None and props is not None:
       # IPv4 address
       ip4config_path = props.get('Ip4Config', ('o', '/'))[1]
-
-      print('Has IP4 config:', ip4config_path)
 
       if ip4config_path != "/":
         ip4config_addr = DBusAddress(ip4config_path, bus_name=NM, interface=NM_IP4_CONFIG_IFACE)
@@ -751,8 +747,6 @@ class WifiManager:
           if 'address' in entry:
             ipv4_address = entry['address'][1]
             break
-        else:
-          print('NO IP address found in AddressData:', address_data)
 
       # Metered status
       settings = self._get_connection_settings(conn_path)


### PR DESCRIPTION
we can have a "connected" network without IP in these states, as such don't show "not connected":
- user forgets active network with another saved and available, NM auto switches without setting `connecting_to_ssid` (it's only set from user action, can add support for this later)
- network is low strength and dropped, auto connects to another available (same as above)
- low strength network and is roaming to another AP or trying to re-connect altogether

in the future we can expose NM's automatic state changes without user action like these cases to show "connecting" but "obtaining IP" is also accurate at some point in the connecting progress. maybe it should show all of the states while connecting? it can go so fast that it looks like it flickers, so maybe not