### PR TITLE
WifiUi: sort by real strength

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -716,8 +716,7 @@ class WifiManager:
         active_wifi_connection, _ = self._get_active_wifi_connection()
         networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections,
                                       self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
-        # sort with quantized strength to reduce jumping
-        networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -round(n.strength / 100 * 2), n.ssid.lower()))
+        networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -n.strength, n.ssid.lower()))
         self._networks = networks
 
         self._update_active_connection_info()


### PR DESCRIPTION
for https://github.com/commaai/openpilot/pull/37152

we no longer sort while scrolling, so not an issue. properly puts unifi at the top now