### PR TITLE
WifiManager: fix all networks showing as connected when no active connection

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -737,7 +737,7 @@ class WifiManager:
 
         active_wifi_connection, _ = self._get_active_wifi_connection()
         networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections,
-                                      self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
+                                      active_wifi_connection is not None and self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -n.strength, n.ssid.lower()))
         self._networks = networks
 

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -737,7 +737,8 @@ class WifiManager:
 
         active_wifi_connection, _ = self._get_active_wifi_connection()
         networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections,
-                                      active_wifi_connection is not None and self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
+                                      active_wifi_connection is not None and
+                                      self._connections.get(ssid) == active_wifi_connection) for ssid, ap_list in aps.items()]
         networks.sort(key=lambda n: (-n.is_connected, -n.is_saved, -n.strength, n.ssid.lower()))
         self._networks = networks
 


### PR DESCRIPTION
awww it wanted credit

only saw this when stress testing the UI in some weird state, not sure when it's apparent. have a new method of keeping state in https://github.com/commaai/openpilot/pull/37152 that will replace this soon