### PR TITLE
tools: block `manage_athenad` in sim startup script

### DIFF
--- a/tools/sim/launch_openpilot.sh
+++ b/tools/sim/launch_openpilot.sh
@@ -6,7 +6,7 @@ export SIMULATION="1"
 export SKIP_FW_QUERY="1"
 export FINGERPRINT="HONDA_CIVIC_2022"
 
-export BLOCK="${BLOCK},camerad,loggerd,encoderd,micd,logmessaged"
+export BLOCK="${BLOCK},camerad,loggerd,encoderd,micd,logmessaged,manage_athenad"
 if [[ "$CI" ]]; then
   # TODO: offscreen UI should work
   export BLOCK="${BLOCK},ui"


### PR DESCRIPTION
**Description**

Currently, running `tools/sim/launch_openpilot.sh` spawns `manage_athenad`, which persists after the script exits and continuously respawns its child process `athenad`, requiring a manual `kill` of the parent process to stop it permanently.

This change adds `manage_athenad` to the `BLOCK` list of `tools/sim/launch_openpilot.sh` to prevent the parent process from spawning when we run sim.

**Verification**

- Before: `manage_athenad` is spawned when `tools/sim/launch_openpilot.sh` is executed. It stays alive after the script was killed.
- After: `manage_athenad` is no longer spawning when `tools/sim/launch_openpilot.sh` is executed.