### PR TITLE
WifiManager: always emit forgot callback

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -621,7 +621,7 @@ class WifiManager:
         conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
         self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
 
-      # FIXME: race here where connectionRemoved signal may arrive after we update all Network is_saved
+      # FIXME: race here where ConnectionRemoved signal may arrive after we update all Network is_saved
       self._update_networks()
       self._enqueue_callbacks(self._forgotten, ssid)
 

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -622,6 +622,7 @@ class WifiManager:
         self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
 
       # FIXME: race here where ConnectionRemoved signal may arrive after we update all Network is_saved
+      #  and keep the old ssid's is_saved=True
       self._update_networks()
       self._enqueue_callbacks(self._forgotten, ssid)
 

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -617,11 +617,11 @@ class WifiManager:
       conn_path = self._connections.get(ssid, None)
       if conn_path is None:
         cloudlog.warning(f"Trying to forget unknown connection: {ssid}")
-        return
+      else:
+        conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
+        self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
 
-      conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
-      self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
-
+      # FIXME: race here where connectionRemoved signal may arrive after we update all Network is_saved
       self._update_networks()
       self._enqueue_callbacks(self._forgotten, ssid)
 


### PR DESCRIPTION
https://github.com/commaai/openpilot/pull/37152 really makes it easy to discover bugs! we should just merge it

Possible to hit this when you somehow forget a network before it's in connections (from NewConnection signal), it should still emit forget