### PR TITLE
WifiManager: single source for known connections

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -263,7 +263,7 @@ class NetworkInfoPage(NavWidget):
     if self._network is None:
       return
 
-    self._connect_btn.set_full(not self._network.is_saved and not self._is_connecting)
+    self._connect_btn.set_full(not self._wifi_manager.is_connection_saved(self._network.ssid) and not self._is_connecting)
     if self._is_connecting:
       self._connect_btn.set_label("connecting...")
       self._connect_btn.set_enabled(False)
@@ -425,7 +425,7 @@ class WifiUIMici(BigMultiOptionDialog):
       cloudlog.warning(f"Trying to connect to unknown network: {ssid}")
       return
 
-    if network.is_saved:
+    if self._wifi_manager.is_connection_saved(network.ssid):
       self._wifi_manager.activate_connection(network.ssid)
       self._update_buttons()
     elif network.security_type == SecurityType.OPEN:

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -621,7 +621,6 @@ class WifiManager:
         conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
         self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
 
-
       # FIXME: race here where ConnectionRemoved signal may arrive after we update all Network is_saved
       #  and keep the old ssid's is_saved=True
       self._update_networks()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -631,13 +631,17 @@ class WifiManager:
 
     def worker():
       conn_path = self._connections.get(ssid, None)
-      if conn_path is not None:
-        if self._wifi_device is None:
-          cloudlog.warning("No WiFi device found")
-          return
+      if conn_path is None or self._wifi_device is None:
+        cloudlog.warning(f"Failed to activate connection for {ssid}: conn_path={conn_path}, wifi_device={self._wifi_device}")
+        self._set_connecting(None)
+        return
 
-        self._router_main.send(new_method_call(self._nm, 'ActivateConnection', 'ooo',
-                                               (conn_path, self._wifi_device, "/")))
+      reply = self._router_main.send_and_get_reply(new_method_call(self._nm, 'ActivateConnection', 'ooo',
+                                                                   (conn_path, self._wifi_device, "/")))
+
+      if reply.header.message_type == MessageType.error:
+        cloudlog.warning(f"Failed to activate connection for {ssid}: {reply}")
+        self._set_connecting(None)
 
     if block:
       worker()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -618,13 +618,11 @@ class WifiManager:
       else:
         conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
         self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
-        # self._connections.pop(ssid, None)
 
       # FIXME: race here where ConnectionRemoved signal may arrive after we update all Network is_saved
       #  and keep the old ssid's is_saved=True
-      self._enqueue_callbacks(self._forgotten, ssid)
-      time.sleep(1.)
       self._update_networks()
+      self._enqueue_callbacks(self._forgotten, ssid)
 
     if block:
       worker()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -620,11 +620,13 @@ class WifiManager:
       else:
         conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
         self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
+        # self._connections.pop(ssid, None)
 
       # FIXME: race here where ConnectionRemoved signal may arrive after we update all Network is_saved
       #  and keep the old ssid's is_saved=True
-      self._update_networks()
       self._enqueue_callbacks(self._forgotten, ssid)
+      time.sleep(1.)
+      self._update_networks()
 
     if block:
       worker()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -621,6 +621,7 @@ class WifiManager:
         conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
         self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
 
+
       # FIXME: race here where ConnectionRemoved signal may arrive after we update all Network is_saved
       #  and keep the old ssid's is_saved=True
       self._update_networks()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -619,8 +619,6 @@ class WifiManager:
         conn_addr = DBusAddress(conn_path, bus_name=NM, interface=NM_CONNECTION_IFACE)
         self._router_main.send_and_get_reply(new_method_call(conn_addr, 'Delete'))
 
-      # FIXME: race here where ConnectionRemoved signal may arrive after we update all Network is_saved
-      #  and keep the old ssid's is_saved=True
       self._update_networks()
       self._enqueue_callbacks(self._forgotten, ssid)
 

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -89,11 +89,10 @@ class Network:
   ssid: str
   strength: int
   security_type: SecurityType
-  is_saved: bool
   ip_address: str = ""  # TODO: implement
 
   @classmethod
-  def from_dbus(cls, ssid: str, aps: list["AccessPoint"], is_saved: bool) -> "Network":
+  def from_dbus(cls, ssid: str, aps: list["AccessPoint"]) -> "Network":
     # we only want to show the strongest AP for each Network/SSID
     strongest_ap = max(aps, key=lambda ap: ap.strength)
     security_type = get_security_type(strongest_ap.flags, strongest_ap.wpa_flags, strongest_ap.rsn_flags)
@@ -102,7 +101,6 @@ class Network:
       ssid=ssid,
       strength=strongest_ap.strength,
       security_type=security_type,
-      is_saved=is_saved,
     )
 
 
@@ -668,6 +666,9 @@ class WifiManager:
     # Check ssid, not connected_ssid, to also catch connecting state
     return self._wifi_state.ssid == self._tethering_ssid
 
+  def is_connection_saved(self, ssid: str) -> bool:
+    return ssid in self._connections
+
   def set_tethering_password(self, password: str):
     def worker():
       conn_path = self._connections.get(self._tethering_ssid, None)
@@ -807,8 +808,8 @@ class WifiManager:
             # catch all for parsing errors
             cloudlog.exception(f"Failed to parse AP properties for {ap_path}")
 
-        networks = [Network.from_dbus(ssid, ap_list, ssid in self._connections) for ssid, ap_list in aps.items()]
-        networks.sort(key=lambda n: (n.ssid != self._wifi_state.ssid, -n.is_saved, -n.strength, n.ssid.lower()))
+        networks = [Network.from_dbus(ssid, ap_list) for ssid, ap_list in aps.items()]
+        networks.sort(key=lambda n: (n.ssid != self._wifi_state.ssid, -self.is_connection_saved(n.ssid), -n.strength, n.ssid.lower()))
         self._networks = networks
 
         self._update_active_connection_info()

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -805,7 +805,7 @@ class WifiManager:
             cloudlog.exception(f"Failed to parse AP properties for {ap_path}")
 
         networks = [Network.from_dbus(ssid, ap_list) for ssid, ap_list in aps.items()]
-        networks.sort(key=lambda n: (n.ssid != self._wifi_state.ssid, -self.is_connection_saved(n.ssid), -n.strength, n.ssid.lower()))
+        networks.sort(key=lambda n: (n.ssid != self._wifi_state.ssid, not self.is_connection_saved(n.ssid), -n.strength, n.ssid.lower()))
         self._networks = networks
 
         self._update_active_connection_info()

--- a/system/ui/widgets/network.py
+++ b/system/ui/widgets/network.py
@@ -383,7 +383,7 @@ class WifiManagerUI(Widget):
       gui_label(status_text_rect, status_text, font_size=48, alignment=rl.GuiTextAlignment.TEXT_ALIGN_CENTER)
     else:
       # If the network is saved, show the "Forget" button
-      if network.is_saved:
+      if self._wifi_manager.is_connection_saved(network.ssid):
         forget_btn_rect = rl.Rectangle(
           security_icon_rect.x - self.btn_width - spacing,
           rect.y + (ITEM_HEIGHT - 80) / 2,
@@ -396,7 +396,7 @@ class WifiManagerUI(Widget):
     self._draw_signal_strength_icon(signal_icon_rect, network)
 
   def _networks_buttons_callback(self, network):
-    if not network.is_saved and network.security_type != SecurityType.OPEN:
+    if not self._wifi_manager.is_connection_saved(network.ssid) and network.security_type != SecurityType.OPEN:
       self.state = UIState.NEEDS_AUTH
       self._state_network = network
       self._password_retry = False
@@ -432,7 +432,7 @@ class WifiManagerUI(Widget):
   def connect_to_network(self, network: Network, password=''):
     self.state = UIState.CONNECTING
     self._state_network = network
-    if network.is_saved and not password:
+    if self._wifi_manager.is_connection_saved(network.ssid) and not password:
       self._wifi_manager.activate_connection(network.ssid)
     else:
       self._wifi_manager.connect_to_network(network.ssid, password)


### PR DESCRIPTION
we just moved from all the `Network`s holding their connected status to one global `WifiState` variable to check to reduce state mismatches in https://github.com/commaai/openpilot/pull/37258. Turns out we should also do the same for `is_known`. This is also how C++ wifimanager worked, seen below.

This fixes a race condition made easier in https://github.com/commaai/openpilot/pull/37152:

- user forgets connected and saved network
- we called update networks which updates is_saved
- however NM either sent us the connection removed signal late, or we were busy processing another signal
- so we still think it's saved when we set button back enabled, ui is eager and shows connect
- you click connect and it thinks it just needs to activate the connection which is not there, and that fails. stays connecting forever

there is probably a smaller window race here with the signals, but it's much better. before this we'd need to wait for another 5s scan cycle to update `Network`s, now it's checked on user pressing connect.

TODO:
- [x] guard `activate_connection` to reset connecting status back to None just in case, but not the correct fix

---

https://github.com/commaai/openpilot/blob/650946cd2ace2f55631f13466b1906249afada59/selfdrive/ui/qt/network/wifi_manager.cc#L231-L233

https://github.com/commaai/openpilot/blob/650946cd2ace2f55631f13466b1906249afada59/selfdrive/ui/qt/network/networking.cc#L85-L96