### PR TITLE
op.sh: fallback to script's own location for openpilot root

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -62,7 +62,8 @@ function op_get_openpilot_dir() {
   done
 
   # Fallback to hardcoded directories if not found
-  for dir in "$HOME/openpilot" "/data/openpilot"; do
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+  for dir in "${SCRIPT_DIR%/tools}" "$HOME/openpilot" "/data/openpilot"; do
     if [[ -f "$dir/launch_openpilot.sh" ]]; then
       OPENPILOT_ROOT="$dir"
       return 0


### PR DESCRIPTION
Derive the openpilot directory from BASH_SOURCE when the working directory isn't inside the repo, so `op` commands work from anywhere without needing --dir.

Useful if openpilot is not in "$HOME/openpilot".