### PR TITLE
cleanup: modem config

### DIFF
--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -464,7 +464,7 @@ class Tici(HardwareBase):
 
     cmds = []
 
-    if self.get_device_type() in ("tizi", ):
+    if self.get_device_type() in ("tizi", "mici"):
       # clear out old blue prime initial APN
       os.system('mmcli -m any --3gpp-set-initial-eps-bearer-settings="apn="')
 

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -460,22 +460,19 @@ class Tici(HardwareBase):
     try:
       modem_revision = str(modem.Get(MM_MODEM, 'Revision', dbus_interface=DBUS_PROPS, timeout=TIMEOUT))
     except Exception:
-      modem_revision = None
+      modem_revision = ""
     finally:
       print(f"modem revision: {modem_revision}")
 
-    is_eg25 = modem_revision is not None and modem_revision.startswith("EG25")
-    is_eg916 = modem_revision is not None and modem_revision.startswith("EG916")
-
     cmds = []
-    if is_eg25 or is_eg916:
+    if modem_revision.startswith("EG25") or modem_revision.startswith("EG916"):
       # SIM hot swap
       cmds += [
         'AT+QSIMDET=1,0',
         'AT+QSIMSTAT=1',
       ]
 
-    if is_eg25:
+    if modem_revision.startswith("EG25"):
       # clear out old blue prime initial APN
       os.system('mmcli -m any --3gpp-set-initial-eps-bearer-settings="apn="')
 
@@ -485,7 +482,7 @@ class Tici(HardwareBase):
         'AT+QNVFW="/nv/item_files/ims/IMS_enable",00',
         'AT+QNVFW="/nv/item_files/modem/mmode/ue_usage_setting",01',
       ]
-    elif not is_eg916:
+    elif not modem_revision.startswith("EG916"):
       # this modem gets upset with too many AT commands
       if sim_id is None or len(sim_id) == 0:
         cmds += [

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -461,13 +461,13 @@ class Tici(HardwareBase):
       modem_revision = str(modem.Get(MM_MODEM, 'Revision', dbus_interface=DBUS_PROPS, timeout=TIMEOUT))
     except Exception:
       modem_revision = None
-
-    print(f"configuring modem: {modem_revision}")
-    cmds = []
+    finally:
+      print(f"modem revision: {modem_revision}")
 
     is_eg25 = modem_revision is not None and modem_revision.startswith("EG25")
     is_eg916 = modem_revision is not None and modem_revision.startswith("EG916")
 
+    cmds = []
     if is_eg25 or is_eg916:
       # SIM hot swap
       cmds += [

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -465,7 +465,7 @@ class Tici(HardwareBase):
       print(f"modem revision: {modem_revision}")
 
     cmds = []
-    if modem_revision.startswith("EG25") or modem_revision.startswith("EG916"):
+    if modem_revision.startswith(("EG25", "EG916")):
       # SIM hot swap
       cmds += [
         'AT+QSIMDET=1,0',


### PR DESCRIPTION
mici also needs `AT+QSIMDET=1,0` and `AT+QSIMSTAT=1`

otherwise SIM doesn't show up as "inserted" and switch commands don't cause it to re-register :-)

new behavior:
* mici will get hotswap commands configured at boot

### mici
```
  logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
  configuring modem
  modem revision: EG916QGLLGR01A05M04
  logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
  Failed to fetch prime status: System time is not valid, cannot generate token
```

### tizi
```
  logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
  configuring modem
  modem revision: EG25GGBR07A08M2G
  logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
  Successfully set initial EPS bearer properties
```
