### PR TITLE
feat(lpa): at client + list profiles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ testpaths = [
 [tool.codespell]
 quiet-level = 3
 # if you've got a short variable name that's getting flagged, add it here
-ignore-words-list = "bu,ro,te,ue,alo,hda,ois,nam,nams,ned,som,parm,setts,inout,warmup,bumb,nd,sie,preints,whit,indexIn,ws,uint,grey,deque,stdio,amin,BA,LITE,atEnd,UIs,errorString,arange,FocusIn,od,tim,relA,hist,copyable,jupyter,thead,TGE,abl,lite"
+ignore-words-list = "bu,ro,te,ue,alo,hda,ois,nam,nams,ned,som,parm,setts,inout,warmup,bumb,nd,sie,preints,whit,indexIn,ws,uint,grey,deque,stdio,amin,BA,LITE,atEnd,UIs,errorString,arange,FocusIn,od,tim,relA,hist,copyable,jupyter,thead,TGE,abl,lite,ser"
 builtin = "clear,rare,informal,code,names,en-GB_to_en-US"
 skip = "./third_party/*, ./tinygrad/*, ./tinygrad_repo/*, ./msgq/*, ./panda/*, ./opendbc/*, ./opendbc_repo/*, ./rednose/*, ./rednose_repo/*, ./teleoprtc/*, ./teleoprtc_repo/*, *.po, uv.lock, *.onnx, ./cereal/gen/*, */c_generated_code/*, docs/assets/*, tools/plotjuggler/layouts/*, selfdrive/assets/offroad/mici_fcc.html"
 

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -45,7 +45,7 @@ class AtClient:
       self._serial = serial.Serial(device, baudrate=baud, timeout=timeout)
       self._serial.reset_input_buffer()
     except (serial.SerialException, PermissionError, OSError):
-      print(f"<< Serial port {device} unavailable, falling back to ModemManager D-Bus", file=sys.stderr)
+      pass
 
   def close(self) -> None:
     try:

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -92,7 +92,7 @@ class AtClient:
     try:
       result = str(self._get_modem().Command(cmd, math.ceil(self._timeout), dbus_interface=MM_MODEM, timeout=self._timeout))
     except Exception as e:
-      raise RuntimeError(f"AT command failed: {e}")
+      raise RuntimeError(f"AT command failed: {e}") from e
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     if self.debug:
       for line in lines:

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -10,7 +10,6 @@ import sys
 from collections.abc import Generator
 
 from openpilot.system.hardware.base import LPABase, Profile
-from openpilot.system.hardware.tici.hardware import MM, MM_MODEM
 
 
 DEFAULT_DEVICE = "/dev/ttyUSB2"
@@ -18,6 +17,8 @@ DEFAULT_BAUD = 9600
 DEFAULT_TIMEOUT = 5.0
 # https://euicc-manual.osmocom.org/docs/lpa/applet-id/
 ISDR_AID = "A0000005591010FFFFFFFF8900000100"
+MM = "org.freedesktop.ModemManager1"
+MM_MODEM = MM + ".Modem"
 ES10X_MSS = 120
 DEBUG = os.environ.get("DEBUG") == "1"
 

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -2,6 +2,7 @@
 
 import atexit
 import base64
+import math
 import os
 import serial
 import sys
@@ -16,6 +17,8 @@ DEFAULT_BAUD = 9600
 DEFAULT_TIMEOUT = 5.0
 # https://euicc-manual.osmocom.org/docs/lpa/applet-id/
 ISDR_AID = "A0000005591010FFFFFFFF8900000100"
+MM = "org.freedesktop.ModemManager1"
+MM_MODEM = MM + ".Modem"
 ES10X_MSS = 120
 DEBUG = os.environ.get("DEBUG") == "1"
 
@@ -34,10 +37,15 @@ def b64e(data: bytes) -> str:
 
 class AtClient:
   def __init__(self, device: str, baud: int, timeout: float, debug: bool) -> None:
-    self.serial = serial.Serial(device, baudrate=baud, timeout=timeout)
     self.debug = debug
     self.channel: str | None = None
-    self.serial.reset_input_buffer()
+    self._timeout = timeout
+    self._serial: serial.Serial | None = None
+    try:
+      self._serial = serial.Serial(device, baudrate=baud, timeout=timeout)
+      self._serial.reset_input_buffer()
+    except (serial.SerialException, PermissionError, OSError):
+      pass
 
   def close(self) -> None:
     try:
@@ -45,17 +53,18 @@ class AtClient:
         self.query(f"AT+CCHC={self.channel}")
         self.channel = None
     finally:
-      self.serial.close()
+      if self._serial:
+        self._serial.close()
 
-  def send(self, cmd: str) -> None:
+  def _send(self, cmd: str) -> None:
     if self.debug:
       print(f">> {cmd}", file=sys.stderr)
-    self.serial.write((cmd + "\r").encode("ascii"))
+    self._serial.write((cmd + "\r").encode("ascii"))
 
-  def expect(self) -> list[str]:
+  def _expect(self) -> list[str]:
     lines: list[str] = []
     while True:
-      raw = self.serial.readline()
+      raw = self._serial.readline()
       if not raw:
         raise TimeoutError("AT command timed out")
       line = raw.decode(errors="ignore").strip()
@@ -69,9 +78,32 @@ class AtClient:
         raise RuntimeError(f"AT command failed: {line}")
       lines.append(line)
 
+  def _get_modem(self):
+    import dbus
+    bus = dbus.SystemBus()
+    mm = bus.get_object(MM, '/org/freedesktop/ModemManager1')
+    objects = mm.GetManagedObjects(dbus_interface="org.freedesktop.DBus.ObjectManager", timeout=self._timeout)
+    modem_path = list(objects.keys())[0]
+    return bus.get_object(MM, modem_path)
+
+  def _dbus_query(self, cmd: str) -> list[str]:
+    if self.debug:
+      print(f">> {cmd} (dbus)", file=sys.stderr)
+    try:
+      result = str(self._get_modem().Command(cmd, math.ceil(self._timeout), dbus_interface=MM_MODEM, timeout=self._timeout))
+    except Exception as e:
+      raise RuntimeError(f"AT command failed: {e}")
+    lines = [line.strip() for line in result.splitlines() if line.strip()]
+    if self.debug:
+      for line in lines:
+        print(f"<< {line}", file=sys.stderr)
+    return lines
+
   def query(self, cmd: str) -> list[str]:
-    self.send(cmd)
-    return self.expect()
+    if self._serial:
+      self._send(cmd)
+      return self._expect()
+    return self._dbus_query(cmd)
 
   def open_isdr(self) -> None:
     # close any stale logical channel from a previous crashed session

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -1,12 +1,237 @@
+# SGP.22 v2.3: https://www.gsma.com/solutions-and-impact/technologies/esim/wp-content/uploads/2021/07/SGP.22-v2.3.pdf
+
+import atexit
+import base64
+import os
+import serial
+import sys
+
+from collections.abc import Generator
+
 from openpilot.system.hardware.base import LPABase, Profile
 
 
+DEFAULT_DEVICE = "/dev/ttyUSB2"
+DEFAULT_BAUD = 9600
+DEFAULT_TIMEOUT = 5.0
+# https://euicc-manual.osmocom.org/docs/lpa/applet-id/
+ISDR_AID = "A0000005591010FFFFFFFF8900000100"
+ES10X_MSS = 120
+DEBUG = os.environ.get("DEBUG") == "1"
+
+# TLV Tags
+TAG_ICCID = 0x5A
+TAG_PROFILE_INFO_LIST = 0xBF2D
+
+STATE_LABELS = {0: "disabled", 1: "enabled", 255: "unknown"}
+ICON_LABELS = {0: "jpeg", 1: "png", 255: "unknown"}
+CLASS_LABELS = {0: "test", 1: "provisioning", 2: "operational", 255: "unknown"}
+
+
+def b64e(data: bytes) -> str:
+  return base64.b64encode(data).decode("ascii")
+
+
+class AtClient:
+  def __init__(self, device: str, baud: int, timeout: float, debug: bool) -> None:
+    self.serial = serial.Serial(device, baudrate=baud, timeout=timeout)
+    self.debug = debug
+    self.channel: str | None = None
+    self.serial.reset_input_buffer()
+
+  def close(self) -> None:
+    try:
+      if self.channel:
+        self.query(f"AT+CCHC={self.channel}")
+        self.channel = None
+    finally:
+      self.serial.close()
+
+  def send(self, cmd: str) -> None:
+    if self.debug:
+      print(f">> {cmd}", file=sys.stderr)
+    self.serial.write((cmd + "\r").encode("ascii"))
+
+  def expect(self) -> list[str]:
+    lines: list[str] = []
+    while True:
+      raw = self.serial.readline()
+      if not raw:
+        raise TimeoutError("AT command timed out")
+      line = raw.decode(errors="ignore").strip()
+      if not line:
+        continue
+      if self.debug:
+        print(f"<< {line}", file=sys.stderr)
+      if line == "OK":
+        return lines
+      if line == "ERROR" or line.startswith("+CME ERROR"):
+        raise RuntimeError(f"AT command failed: {line}")
+      lines.append(line)
+
+  def query(self, cmd: str) -> list[str]:
+    self.send(cmd)
+    return self.expect()
+
+  def open_isdr(self) -> None:
+    # close any stale logical channel from a previous crashed session
+    try:
+      self.query("AT+CCHC=1")
+    except RuntimeError:
+      pass
+    for line in self.query(f'AT+CCHO="{ISDR_AID}"'):
+      if line.startswith("+CCHO:") and (ch := line.split(":", 1)[1].strip()):
+        self.channel = ch
+        return
+    raise RuntimeError("Failed to open ISD-R application")
+
+  def send_apdu(self, apdu: bytes) -> tuple[bytes, int, int]:
+    if not self.channel:
+      raise RuntimeError("Logical channel is not open")
+    hex_payload = apdu.hex().upper()
+    for line in self.query(f'AT+CGLA={self.channel},{len(hex_payload)},"{hex_payload}"'):
+      if line.startswith("+CGLA:"):
+        parts = line.split(":", 1)[1].split(",", 1)
+        if len(parts) == 2:
+          data = bytes.fromhex(parts[1].strip().strip('"'))
+          if len(data) >= 2:
+            return data[:-2], data[-2], data[-1]
+    raise RuntimeError("Missing +CGLA response")
+
+
+# --- TLV utilities ---
+
+def iter_tlv(data: bytes, with_positions: bool = False) -> Generator:
+  idx, length = 0, len(data)
+  while idx < length:
+    start_pos = idx
+    tag = data[idx]
+    idx += 1
+    if tag & 0x1F == 0x1F:  # Multi-byte tag
+      tag_value = tag
+      while idx < length:
+        next_byte = data[idx]
+        idx += 1
+        tag_value = (tag_value << 8) | next_byte
+        if not (next_byte & 0x80):
+          break
+    else:
+      tag_value = tag
+    if idx >= length:
+      break
+    size = data[idx]
+    idx += 1
+    if size & 0x80:  # Multi-byte length
+      num_bytes = size & 0x7F
+      if idx + num_bytes > length:
+        break
+      size = int.from_bytes(data[idx : idx + num_bytes], "big")
+      idx += num_bytes
+    if idx + size > length:
+      break
+    value = data[idx : idx + size]
+    idx += size
+    yield (tag_value, value, start_pos, idx) if with_positions else (tag_value, value)
+
+
+def find_tag(data: bytes, target: int) -> bytes | None:
+  return next((v for t, v in iter_tlv(data) if t == target), None)
+
+
+def tbcd_to_string(raw: bytes) -> str:
+  return "".join(str(n) for b in raw for n in (b & 0x0F, b >> 4) if n <= 9)
+
+
+# Profile field decoders: TLV tag -> (field_name, decoder)
+_PROFILE_FIELDS = {
+  TAG_ICCID: ("iccid", tbcd_to_string),
+  0x4F: ("isdpAid", lambda v: v.hex().upper()),
+  0x9F70: ("profileState", lambda v: STATE_LABELS.get(v[0], "unknown")),
+  0x90: ("profileNickname", lambda v: v.decode("utf-8", errors="ignore") or None),
+  0x91: ("serviceProviderName", lambda v: v.decode("utf-8", errors="ignore") or None),
+  0x92: ("profileName", lambda v: v.decode("utf-8", errors="ignore") or None),
+  0x93: ("iconType", lambda v: ICON_LABELS.get(v[0], "unknown")),
+  0x94: ("icon", b64e),
+  0x95: ("profileClass", lambda v: CLASS_LABELS.get(v[0], "unknown")),
+}
+
+
+def _decode_profile_fields(data: bytes) -> dict:
+  """Parse known profile metadata TLV fields into a dict."""
+  result = {}
+  for tag, value in iter_tlv(data):
+    if (field := _PROFILE_FIELDS.get(tag)):
+      result[field[0]] = field[1](value)
+  return result
+
+
+# --- ES10x command transport ---
+
+def es10x_command(client: AtClient, data: bytes) -> bytes:
+  response = bytearray()
+  sequence = 0
+  offset = 0
+  while offset < len(data):
+    chunk = data[offset : offset + ES10X_MSS]
+    offset += len(chunk)
+    is_last = offset == len(data)
+    apdu = bytes([0x80, 0xE2, 0x91 if is_last else 0x11, sequence & 0xFF, len(chunk)]) + chunk
+    segment, sw1, sw2 = client.send_apdu(apdu)
+    response.extend(segment)
+    while True:
+      if sw1 == 0x61:  # More data available
+        segment, sw1, sw2 = client.send_apdu(bytes([0x80, 0xC0, 0x00, 0x00, sw2 or 0]))
+        response.extend(segment)
+        continue
+      if (sw1 & 0xF0) == 0x90:
+        break
+      raise RuntimeError(f"APDU failed with SW={sw1:02X}{sw2:02X}")
+    sequence += 1
+  return bytes(response)
+
+
+# --- Profile operations ---
+
+def decode_profiles(blob: bytes) -> list[dict]:
+  root = find_tag(blob, TAG_PROFILE_INFO_LIST)
+  if root is None:
+    raise RuntimeError("Missing ProfileInfoList")
+  list_ok = find_tag(root, 0xA0)
+  if list_ok is None:
+    return []
+  defaults = {name: None for name, _ in _PROFILE_FIELDS.values()}
+  return [{**defaults, **_decode_profile_fields(value)} for tag, value in iter_tlv(list_ok) if tag == 0xE3]
+
+
+def list_profiles(client: AtClient) -> list[dict]:
+  return decode_profiles(es10x_command(client, TAG_PROFILE_INFO_LIST.to_bytes(2, "big") + b"\x00"))
+
+
 class TiciLPA(LPABase):
+  _instance = None
+
+  def __new__(cls):
+    if cls._instance is None:
+      cls._instance = super().__new__(cls)
+    return cls._instance
+
   def __init__(self):
-    pass
+    if hasattr(self, '_client'):
+      return
+    self._client = AtClient(DEFAULT_DEVICE, DEFAULT_BAUD, DEFAULT_TIMEOUT, debug=DEBUG)
+    self._client.open_isdr()
+    atexit.register(self._client.close)
 
   def list_profiles(self) -> list[Profile]:
-    return []
+    return [
+      Profile(
+        iccid=p.get("iccid", ""),
+        nickname=p.get("profileNickname") or "",
+        enabled=p.get("profileState") == "enabled",
+        provider=p.get("serviceProviderName") or "",
+      )
+      for p in list_profiles(self._client)
+    ]
 
   def get_active_profile(self) -> Profile | None:
     return None

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -45,7 +45,7 @@ class AtClient:
       self._serial = serial.Serial(device, baudrate=baud, timeout=timeout)
       self._serial.reset_input_buffer()
     except (serial.SerialException, PermissionError, OSError):
-      pass
+      print(f"<< Serial port {device} unavailable, falling back to ModemManager D-Bus", file=sys.stderr)
 
   def close(self) -> None:
     try:
@@ -58,7 +58,7 @@ class AtClient:
 
   def _send(self, cmd: str) -> None:
     if self.debug:
-      print(f">> {cmd}", file=sys.stderr)
+      print(f"SER >> {cmd}", file=sys.stderr)
     self._serial.write((cmd + "\r").encode("ascii"))
 
   def _expect(self) -> list[str]:
@@ -71,7 +71,7 @@ class AtClient:
       if not line:
         continue
       if self.debug:
-        print(f"<< {line}", file=sys.stderr)
+        print(f"SER << {line}", file=sys.stderr)
       if line == "OK":
         return lines
       if line == "ERROR" or line.startswith("+CME ERROR"):
@@ -88,7 +88,7 @@ class AtClient:
 
   def _dbus_query(self, cmd: str) -> list[str]:
     if self.debug:
-      print(f">> {cmd} (dbus)", file=sys.stderr)
+      print(f"DBUS >> {cmd}", file=sys.stderr)
     try:
       result = str(self._get_modem().Command(cmd, math.ceil(self._timeout), dbus_interface=MM_MODEM, timeout=self._timeout))
     except Exception as e:
@@ -96,7 +96,7 @@ class AtClient:
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     if self.debug:
       for line in lines:
-        print(f"<< {line}", file=sys.stderr)
+        print(f"DBUS << {line}", file=sys.stderr)
     return lines
 
   def query(self, cmd: str) -> list[str]:

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -10,6 +10,7 @@ import sys
 from collections.abc import Generator
 
 from openpilot.system.hardware.base import LPABase, Profile
+from openpilot.system.hardware.tici.hardware import MM, MM_MODEM
 
 
 DEFAULT_DEVICE = "/dev/ttyUSB2"
@@ -17,8 +18,6 @@ DEFAULT_BAUD = 9600
 DEFAULT_TIMEOUT = 5.0
 # https://euicc-manual.osmocom.org/docs/lpa/applet-id/
 ISDR_AID = "A0000005591010FFFFFFFF8900000100"
-MM = "org.freedesktop.ModemManager1"
-MM_MODEM = MM + ".Modem"
 ES10X_MSS = 120
 DEBUG = os.environ.get("DEBUG") == "1"
 


### PR DESCRIPTION
reapply https://github.com/commaai/openpilot/pull/37271 fixing bug in https://github.com/commaai/openpilot/pull/37322

adding a dbus backend for devices that don't have a free AT serial port for comms.

long term, i do not want to rely on MM or DBUS for comms. this is for backward compatibility.

### mici (new modem rules; serial available)
```
stdout:
  $ adb -s 725dfb9b forward tcp:2222 tcp:22 && ssh comma@localhost -p 2222 "cd /data/openpilot && PYTHONPATH=/data/openpilot DEBUG=1 /usr/local/venv/bin/python system/hardware/esim.py"
    3.1s
    2222
    usage: esim.py [-h] [--switch iccid] [--delete iccid] [--download qr name]
                   [--nickname iccid name]
    manage eSIM profiles on your comma device
    options:
      -h, --help            show this help message and exit
      --switch iccid        switch to profile
      --delete iccid        delete profile (warning: this cannot be undone)
      --download qr name    download a profile using QR code (format:
                            LPA:1$rsp.truphone.com$QRF-SPEEDTEST)
      --nickname iccid name
                            update the nickname for a profile
    comma.ai
    2 profiles:
    - 89852351224030086192 (nickname: <none provided>) (provider: Webbing) - enabled
    - 89852350725520357647 (nickname: <none provided>) (provider: Airalo) - disabled

stderr:
    SER >> AT+CCHC=1
    SER << OK
    SER >> AT+CCHO="A0000005591010FFFFFFFF8900000100"
    SER << +CCHO: 1
    SER << OK
    SER >> AT+CGLA=1,16,"80E2910003BF2D00"
    SER << +CGLA: 240,"BF2D73A071E3375A0A985832152204038016294F10A0000005591010FFFFFFFF89000010019F700101910757656262696E67920757656262696E67950102E3365A0A985832052755025367744F10A000000
    5591010FFFFFFFF89000012009F7001009106416972616C6F920757454242494E479501029000"
    SER << OK
    SER >> AT+CCHC=1
    SER << OK
```

### tizi (existing modem rules)
```
stdout:
  $ adb -s bb546e42 forward tcp:3333 tcp:22 && ssh comma@localhost -p 3333 "cd /data/openpilot && PYTHONPATH=/data/openpilot DEBUG=1 /usr/local/venv/bin/python system/hardware/esim.py"
    3.2s
    3333
    usage: esim.py [-h] [--switch iccid] [--delete iccid] [--download qr name]
                   [--nickname iccid name]
    manage eSIM profiles on your comma device
    options:
      -h, --help            show this help message and exit
      --switch iccid        switch to profile
      --delete iccid        delete profile (warning: this cannot be undone)
      --download qr name    download a profile using QR code (format:
                            LPA:1$rsp.truphone.com$QRF-SPEEDTEST)
      --nickname iccid name
                            update the nickname for a profile
    comma.ai
    3 profiles:
    - 89852350524090425011 (nickname: <none provided>) (provider: Webbing) - disabled
    - 89103000000457992002 (nickname: mm1) (provider: Connect) - enabled
    - 89103000000490854615 (nickname: <none provided>) (provider: Connect) - disabled

stderr:
    DBUS >> AT+CCHC=1
    DBUS >> AT+CCHO="A0000005591010FFFFFFFF8900000100"
    DBUS << +CCHO: 1
    DBUS >> AT+CGLA=1,16,"80E2910003BF2D00"
    DBUS << +CGLA: 4,"6100"
    DBUS >> AT+CGLA=1,10,"80C0000000"
    DBUS << +CGLA: 516,"BF2D820102A081FFE3375A0A985832052504092405114F10A0000005591010FFFFFFFF89000010019F700100910757656262696E67920757656262696E67950102E35B5A0A980103000040759902204F10
    A0000005591010FFFFFFFF89000012009F70010190036D6D319107436F6E6E656374922654656C6E615F4D49325F436F6E6E6563745F53504E5F4749445F43505F7630322E30362E3037950102E3675A0A98010300004009586451
    4F10A0000005591010FFFFFFFF89000013009F7001009107436F6E6E656374923754656C6E615F4D6F62694D61747465725F5265646F776E6C6F61645F446966666572656E745F446576696365735F7630342E306107"
    DBUS >> AT+CGLA=1,10,"80C0000007"
    DBUS << +CGLA: 18,"362E30349501029000"
    DBUS >> AT+CCHC=1
```

### tizi after rebooting just openpilot, where serial complained
```
SETLEN=1 panda/crypto/sign.py panda/board/obj/body_h7/main.bin panda/board/obj/body_h7.bin.signed panda/certs/debug
python3 /data/openpilot/selfdrive/modeld/external_pickle.py /data/openpilot/selfdrive/modeld/models/driving_vision_tinygrad.pkl.full /data/openpilot/selfdrive/modeld/models/driving_vision_
tinygrad.pkl 47185920
signing 73952 bytes
hash: ac3e01fd70abceda780c2813d08a20a7f76748d8
signing 65372 bytes
hash: 7a718b9c9138f8eb4ad67557fd7fa1a33d5ba202
Delete("/data/openpilot/selfdrive/modeld/models/driving_vision_tinygrad.pkl.full")
arm-none-eabi-gcc -o panda/board/obj/panda_jungle_h7/main.elf -Wl,--section-start,.isr_vector=0x8020000 -mcpu=cortex-m7 -mhard-float -DSTM32H7 -DSTM32H725xx -Iboard/stm32h7/inc -mfpu=fpv5-
d16 -DPANDA_JUNGLE -DALLOW_DEBUG -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -nostdlib -fno-builtin -std=gnu11 -fmax-errors=1 -Tpanda/board/stm32h7/stm32h7x5_flash.ld
 -fsingle-precision-constant -Os -g panda/board/stm32h7/board/obj/panda_jungle_h7startup_stm32h7x5xx.o panda/board/jungle/board/obj/panda_jungle_h7main.o
arm-none-eabi-objcopy -O binary panda/board/obj/panda_jungle_h7/main.elf panda/board/obj/panda_jungle_h7/main.bin
SETLEN=1 panda/crypto/sign.py panda/board/obj/panda_jungle_h7/main.bin panda/board/obj/panda_jungle_h7.bin.signed panda/certs/debug
signing 67308 bytes
hash: 1d084f775ee7a53f936fb154019eac89b1c6a6f4
scons: done building targets.
system/loggerd/bootlog.cc: bootlog to /data/media/0/realdata/boot/0000002e--274b65e56b.zst
gbm_create_device(156): Info: backend name is: msm_drm
Panda 3e0013000351323433323831 connected, version: DEV-e1da7dc9-DEBUG, signature 9b9090d25d6f81eb, expected b74f43026be0438c
flash: unlocking
INFO:panda:flash: unlocking
flash: erasing sectors 1 - 1
INFO:panda:flash: erasing sectors 1 - 1
No IRQs found for 'fts_ts'
configuring modem
Successfully set initial EPS bearer properties
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
flash: flashing
INFO:panda:flash: flashing
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
Changing gsm.auto-config to True
pid 321's current affinity list: 3
pid 321's new affinity list: 3
flash: resetting
INFO:panda:flash: resetting
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
selfdrive/pandad/main.cc: starting pandad
selfdrive/pandad/pandad.cc: connecting to panda: 3e0013000351323433323831
selfdrive/pandad/panda.cc: connected to 3e0013000351323433323831 over SPI
selfdrive/pandad/pandad.cc: connected to panda
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
logmessaged timed ui deleter pandad hardwared tombstoned updated uploader statsd
```