### PR TITLE
dont show wrong password for failed connections

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -384,6 +384,8 @@ class WifiManager:
         #    user-initiated connections already have ssid set via _set_connecting.
         while len(state_q):
           new_state, previous_state, change_reason = state_q.popleft().body
+          cloudlog.warning(f'New state: {NMDeviceState(new_state).name}, Prev state: {NMDeviceState(previous_state).name}, ' +
+                           f'Reason: {NMDeviceStateReason(change_reason).name}')
 
           # TODO: Handle (FAILED, SSID_NOT_FOUND) and emit for ui to show error
           #  Happens when network drops off after starting connection
@@ -408,7 +410,9 @@ class WifiManager:
           # BAD PASSWORD - use prev if current has already moved on to a new connection
           # - strong network rejects with NEED_AUTH+SUPPLICANT_DISCONNECT
           # - weak/gone network fails with FAILED+NO_SECRETS
-          elif ((new_state == NMDeviceState.NEED_AUTH and change_reason == NMDeviceStateReason.SUPPLICANT_DISCONNECT) or
+          elif ((new_state == NMDeviceState.NEED_AUTH and change_reason == NMDeviceStateReason.SUPPLICANT_DISCONNECT
+                 # only NEED_AUTH if not switching between networks
+                 and previous_state not in (NMDeviceState.DEACTIVATING, NMDeviceState.DISCONNECTED)) or
                 (new_state == NMDeviceState.FAILED and change_reason == NMDeviceStateReason.NO_SECRETS)):
 
             failed_ssid = self._wifi_state.prev_ssid or self._wifi_state.ssid


### PR DESCRIPTION
i was connecting to two known connections rapidly for a long time and got wrong password:

```
New state: DEACTIVATING, Reason: NEW_ACTIVATION
New state: DISCONNECTED, Reason: NEW_ACTIVATION
# incorrect wrong password shown in ui from below signal
New state: NEED_AUTH, Reason: SUPPLICANT_DISCONNECT
New state: PREPARE, Reason: NONE
New state: CONFIG, Reason: NONE
New state: NEED_AUTH, Reason: NONE
New state: PREPARE, Reason: NONE
New state: CONFIG, Reason: NONE
New state: IP_CONFIG, Reason: NONE
New state: IP_CHECK, Reason: NONE
New state: SECONDARIES, Reason: NONE
New state: ACTIVATED, Reason: NONE
```

however we can see the two prev states were disconnected, not CONFIG as we expect. so we can ignore if prev state is one of these two