### PR TITLE
tools: fix darwin compile errors

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -77,6 +77,9 @@ else:
 qt_libs = base_libs
 
 cabana_env = qt_env.Clone()
+if arch == "Darwin":
+  cabana_env['CPPPATH'] += [f"{brew_prefix}/include"]
+  cabana_env['LIBPATH'] += [f"{brew_prefix}/lib"]
 
 cabana_libs = [cereal, messaging, visionipc, replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'zstd', 'curl', 'yuv', 'usb-1.0'] + qt_libs
 opendbc_path = '-DOPENDBC_FILE_PATH=\'"%s"\'' % (cabana_env.Dir("../../opendbc/dbc").abspath)


### PR DESCRIPTION
MacOS 26.1 tahoe before linking:

1 error generated.
scons: *** [tools/cabana/cabana.o] Error 1
  [3/10] enqueue   3.26 ms -- total   5.36 ms
  [4/10] enqueue   1.98 ms -- total   4.00 ms
  [5/10] enqueue   1.26 ms -- total   3.08 ms
In file included from tools/cabana/streams/pandastream.cc:1:
In file included from ./tools/cabana/streams/pandastream.h:10:
./tools/cabana/panda.h:14:10: fatal error: 'libusb-1.0/libusb.h' file not found
   14 | #include <libusb-1.0/libusb.h>
      |          ^~~~~~~~~~~~~~~~~~~~~

after:
scons: done building targets.
<img width="1721" height="809" alt="Screenshot 2026-02-25 at 7 53 29 AM" src="https://github.com/user-attachments/assets/16e4985f-b754-4734-a1d9-e2e1b625ecf3" />
