### PR TITLE
ui: disable experimental mode and driving personality toggles

### DIFF
--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -191,6 +191,10 @@ class TogglesLayout(Widget):
 
         self._toggles["ExperimentalMode"].set_description("<b>" + long_desc + "</b><br><br>" + e2e_description)
     else:
+      self._toggles["ExperimentalMode"].action_item.set_enabled(False)
+      self._toggles["ExperimentalMode"].action_item.set_state(False)
+      self._long_personality_setting.action_item.set_enabled(False)
+      self._params.remove("ExperimentalMode")
       self._toggles["ExperimentalMode"].set_description(e2e_description)
 
     self._update_experimental_mode_icon()

--- a/selfdrive/ui/mici/layouts/settings/toggles.py
+++ b/selfdrive/ui/mici/layouts/settings/toggles.py
@@ -81,6 +81,11 @@ class TogglesLayoutMici(NavScroller):
         self._experimental_btn.set_checked(False)
         self._personality_toggle.set_visible(False)
         ui_state.params.remove("ExperimentalMode")
+    else:
+      self._experimental_btn.set_visible(False)
+      self._experimental_btn.set_checked(False)
+      self._personality_toggle.set_visible(False)
+      ui_state.params.remove("ExperimentalMode")
 
     # Refresh toggles from params to mirror external changes
     for key, item in self._refresh_toggles:


### PR DESCRIPTION
When `CarParamsPersistent` is not set, the Experimental Mode toggle and Driving Personality buttons were still interactive, allowing users to change settings.

Now mirrors the "no longitudinal control" behavior: disables toggles and removes the `ExperimentalMode` param.