### PR TITLE
tools: fix openssl segfault for replay and cabana

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -77,6 +77,8 @@ else:
 qt_libs = base_libs
 
 cabana_env = qt_env.Clone()
+if arch != "Darwin":
+  cabana_env.Append(LINKFLAGS=["-Wl,--exclude-libs,libssl.a", "-Wl,--exclude-libs,libcrypto.a"])
 if arch == "Darwin":
   cabana_env['CPPPATH'] += [f"{brew_prefix}/include"]
   cabana_env['LIBPATH'] += [f"{brew_prefix}/lib"]

--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -2,6 +2,8 @@ Import('env', 'arch', 'common', 'messaging', 'visionipc', 'cereal')
 
 replay_env = env.Clone()
 replay_env['CCFLAGS'] += ['-Wno-deprecated-declarations']
+if arch != "Darwin":
+  replay_env.Append(LINKFLAGS=["-Wl,--exclude-libs,libssl.a", "-Wl,--exclude-libs,libcrypto.a"])
 
 base_frameworks = []
 base_libs = [common, messaging, cereal, visionipc, 'm', 'ssl', 'crypto', 'pthread']


### PR DESCRIPTION
Fixes the segfaults in `replay` and `cabana` caused by a linking issue with the vendored OpenSSL package from pip that conflicts with the one built in the replay or cabana binary.

Relevant Discord thread: https://discord.com/channels/469524606043160576/1476126000495726623/1476151475628412958

<details>
<summary>Claude's analysis:</summary>

> The issue is clear: the vendored openssl3 package provides only static libraries, which get statically linked into the replay binary. Their symbols are exported in the binary's dynamic symbol table, and when libcurl.so.4 loads the system's libssl.so.3, calls to internal OpenSSL functions (like ossl_provider_libctx) resolve to the binary's bundled OpenSSL instead — which has an uninitialized library context, causing the crash.
>
> The fix is to add -Wl,--exclude-libs,libssl.a,libcrypto.a to hide the static OpenSSL symbols from the binary's dynamic symbol table:

</details>