### PR TITLE
Restore bz2 replay compatibility

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -81,7 +81,7 @@ if arch == "Darwin":
   cabana_env['CPPPATH'] += [f"{brew_prefix}/include"]
   cabana_env['LIBPATH'] += [f"{brew_prefix}/lib"]
 
-cabana_libs = [cereal, messaging, visionipc, replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'zstd', 'curl', 'yuv', 'usb-1.0'] + qt_libs
+cabana_libs = [cereal, messaging, visionipc, replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'bz2', 'zstd', 'curl', 'yuv', 'usb-1.0'] + qt_libs
 opendbc_path = '-DOPENDBC_FILE_PATH=\'"%s"\'' % (cabana_env.Dir("../../opendbc/dbc").abspath)
 cabana_env['CXXFLAGS'] += [opendbc_path]
 

--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -12,7 +12,7 @@ if arch != "Darwin":
   replay_lib_src.append("qcom_decoder.cc")
 replay_lib = replay_env.Library("replay", replay_lib_src, LIBS=base_libs, FRAMEWORKS=base_frameworks)
 Export('replay_lib')
-replay_libs = [replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'zstd', 'curl', 'yuv', 'ncurses'] + base_libs
+replay_libs = [replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'bz2', 'zstd', 'curl', 'yuv', 'ncurses'] + base_libs
 replay_env.Program("replay", ["main.cc"], LIBS=replay_libs, FRAMEWORKS=base_frameworks)
 
 if GetOption('extras'):

--- a/tools/replay/logreader.cc
+++ b/tools/replay/logreader.cc
@@ -9,7 +9,9 @@
 bool LogReader::load(const std::string &url, std::atomic<bool> *abort, bool local_cache, int chunk_size, int retries) {
   std::string data = FileReader(local_cache, chunk_size, retries).read(url, abort);
   if (!data.empty()) {
-    if (url.find(".zst") != std::string::npos || util::starts_with(data, "\x28\xB5\x2F\xFD")) {
+    if (url.find(".bz2") != std::string::npos || util::starts_with(data, "BZh9")) {
+      data = decompressBZ2(data, abort);
+    } else if (url.find(".zst") != std::string::npos || util::starts_with(data, "\x28\xB5\x2F\xFD")) {
       data = decompressZST(data, abort);
     }
   }

--- a/tools/replay/route.cc
+++ b/tools/replay/route.cc
@@ -174,9 +174,9 @@ void Route::addFileToSegment(int n, const std::string &file) {
   auto pos = name.find_last_of("--");
   name = pos != std::string::npos ? name.substr(pos + 2) : name;
 
-  if (name == "rlog.zst" || name == "rlog") {
+  if (name == "rlog.bz2" || name == "rlog.zst" || name == "rlog") {
     segments_[n].rlog = file;
-  } else if (name == "qlog.zst" || name == "qlog") {
+  } else if (name == "qlog.bz2" || name == "qlog.zst" || name == "qlog") {
     segments_[n].qlog = file;
   } else if (name == "fcamera.hevc") {
     segments_[n].road_cam = file;

--- a/tools/replay/tests/test_replay.cc
+++ b/tools/replay/tests/test_replay.cc
@@ -1,17 +1,131 @@
 #define CATCH_CONFIG_MAIN
+
+#include <bzlib.h>
+#include <zstd.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <string>
+
 #include "catch2/catch.hpp"
-#include "tools/replay/replay.h"
+#include "tools/replay/logreader.h"
+#include "tools/replay/route.h"
 
-const std::string TEST_RLOG_URL = "https://commadataci.blob.core.windows.net/openpilotci/0c94aa1e1296d7c6/2021-05-05--19-48-37/0/rlog.zst";
+namespace {
 
-TEST_CASE("LogReader") {
-  SECTION("corrupt log") {
-    FileReader reader(true);
-    std::string corrupt_content = reader.read(TEST_RLOG_URL);
-    corrupt_content.resize(corrupt_content.length() / 2);
-    corrupt_content = decompressZST(corrupt_content);
-    LogReader log;
-    REQUIRE(log.load(corrupt_content.data(), corrupt_content.size()));
-    REQUIRE(log.events.size() > 0);
+std::atomic<int> temp_dir_counter = 0;
+
+struct TempDir {
+  TempDir() {
+    auto now = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    const int id = temp_dir_counter.fetch_add(1);
+    path = std::filesystem::temp_directory_path() / ("openpilot-replay-test-" + std::to_string(now) + "-" + std::to_string(id));
+    std::filesystem::create_directories(path);
   }
+
+  ~TempDir() {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+  }
+
+  std::filesystem::path path;
+};
+
+std::string buildEvent(uint64_t mono_time, const std::string &fingerprint) {
+  MessageBuilder msg;
+  auto event = msg.initEvent(true);
+  event.setLogMonoTime(mono_time);
+  event.initCarParams().setCarFingerprint(fingerprint);
+
+  auto bytes = msg.toBytes();
+  return std::string(reinterpret_cast<const char *>(bytes.begin()), bytes.size());
+}
+
+std::string buildLogData() {
+  return buildEvent(100, "REPLAY_TEST_A") + buildEvent(200, "REPLAY_TEST_B");
+}
+
+std::string compressZst(const std::string &in) {
+  std::string out(ZSTD_compressBound(in.size()), '\0');
+  size_t compressed_size = ZSTD_compress(out.data(), out.size(), in.data(), in.size(), 1);
+  REQUIRE_FALSE(ZSTD_isError(compressed_size));
+  out.resize(compressed_size);
+  return out;
+}
+
+std::string compressBz2(const std::string &in) {
+  REQUIRE(in.size() <= std::numeric_limits<unsigned int>::max());
+  const auto input_size = static_cast<unsigned int>(in.size());
+  unsigned int out_size = input_size + (input_size / 100) + 601;
+  std::string out(out_size, '\0');
+  int ret = BZ2_bzBuffToBuffCompress(out.data(), &out_size, const_cast<char *>(in.data()), input_size, 9, 0, 30);
+  REQUIRE(ret == BZ_OK);
+  out.resize(out_size);
+  return out;
+}
+
+void writeBinaryFile(const std::filesystem::path &path, const std::string &data) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path, std::ios::binary);
+  REQUIRE(out.good());
+  out.write(data.data(), data.size());
+  REQUIRE(out.good());
+}
+
+}  // namespace
+
+TEST_CASE("LogReader loads local compressed logs") {
+  const std::string raw = buildLogData();
+
+  SECTION("bz2") {
+    TempDir tmp;
+    auto path = tmp.path / "rlog.bz2";
+    writeBinaryFile(path, compressBz2(raw));
+
+    LogReader log;
+    REQUIRE(log.load(path.string()));
+    REQUIRE(log.events.size() == 2);
+  }
+
+  SECTION("zst") {
+    TempDir tmp;
+    auto path = tmp.path / "rlog.zst";
+    writeBinaryFile(path, compressZst(raw));
+
+    LogReader log;
+    REQUIRE(log.load(path.string()));
+    REQUIRE(log.events.size() == 2);
+  }
+}
+
+TEST_CASE("LogReader parses available events from a corrupt log") {
+  const std::string event_a = buildEvent(100, "REPLAY_TEST_A");
+  const std::string event_b = buildEvent(200, "REPLAY_TEST_B");
+  const std::string corrupt_log = event_a + event_b.substr(0, event_b.size() / 2);
+
+  LogReader log;
+  REQUIRE(log.load(corrupt_log.data(), corrupt_log.size()));
+  REQUIRE(log.events.size() >= 1);
+}
+
+TEST_CASE("Route discovers local bz2 log files") {
+  TempDir tmp;
+  const std::string route_name = "a2a0ccea32023010|2023-07-27--13-01-19";
+  auto segment_dir = tmp.path / "a2a0ccea32023010|2023-07-27--13-01-19--0";
+  const std::string raw = buildLogData();
+
+  writeBinaryFile(segment_dir / "rlog.bz2", compressBz2(raw));
+  writeBinaryFile(segment_dir / "qlog.bz2", compressBz2(raw));
+
+  Route route(route_name, tmp.path.string());
+  REQUIRE(route.load());
+  REQUIRE(route.segments().size() == 1);
+
+  auto it = route.segments().find(0);
+  REQUIRE(it != route.segments().end());
+  REQUIRE(it->second.rlog.find("rlog.bz2") != std::string::npos);
+  REQUIRE(it->second.qlog.find("qlog.bz2") != std::string::npos);
 }

--- a/tools/replay/util.cc
+++ b/tools/replay/util.cc
@@ -1,5 +1,6 @@
 #include "tools/replay/util.h"
 
+#include <bzlib.h>
 #include <curl/curl.h>
 #include <openssl/sha.h>
 
@@ -277,6 +278,47 @@ bool httpDownload(const std::string &url, const std::string &file, size_t chunk_
   std::ofstream of(file, std::ios::binary | std::ios::out);
   of.seekp(size - 1).write("\0", 1);
   return httpDownload(url, of, chunk_size, size, abort);
+}
+
+std::string decompressBZ2(const std::string &in, std::atomic<bool> *abort) {
+  return decompressBZ2((std::byte *)in.data(), in.size(), abort);
+}
+
+std::string decompressBZ2(const std::byte *in, size_t in_size, std::atomic<bool> *abort) {
+  if (in_size == 0) return {};
+
+  bz_stream strm = {};
+  int bzerror = BZ2_bzDecompressInit(&strm, 0, 0);
+  assert(bzerror == BZ_OK);
+
+  strm.next_in = (char *)in;
+  strm.avail_in = in_size;
+  std::string out(in_size * 5, '\0');
+  do {
+    strm.next_out = (char *)(&out[strm.total_out_lo32]);
+    strm.avail_out = out.size() - strm.total_out_lo32;
+
+    const char *prev_write_pos = strm.next_out;
+    bzerror = BZ2_bzDecompress(&strm);
+    if (bzerror == BZ_OK && prev_write_pos == strm.next_out) {
+      // content is corrupt
+      bzerror = BZ_STREAM_END;
+      rWarning("decompressBZ2 error: content is corrupt");
+      break;
+    }
+
+    if (bzerror == BZ_OK && strm.avail_in > 0 && strm.avail_out == 0) {
+      out.resize(out.size() * 2);
+    }
+  } while (bzerror == BZ_OK && !(abort && *abort));
+
+  BZ2_bzDecompressEnd(&strm);
+  if (bzerror == BZ_STREAM_END && !(abort && *abort)) {
+    out.resize(strm.total_out_lo32);
+    out.shrink_to_fit();
+    return out;
+  }
+  return {};
 }
 
 std::string decompressZST(const std::string &in, std::atomic<bool> *abort) {

--- a/tools/replay/util.h
+++ b/tools/replay/util.h
@@ -48,6 +48,8 @@ private:
 
 std::string sha256(const std::string &str);
 void precise_nano_sleep(int64_t nanoseconds, std::atomic<bool> &interrupt_requested);
+std::string decompressBZ2(const std::string &in, std::atomic<bool> *abort = nullptr);
+std::string decompressBZ2(const std::byte *in, size_t in_size, std::atomic<bool> *abort = nullptr);
 std::string decompressZST(const std::string &in, std::atomic<bool> *abort = nullptr);
 std::string decompressZST(const std::byte *in, size_t in_size, std::atomic<bool> *abort = nullptr);
 std::string getUrlWithoutQuery(const std::string &url);

--- a/tools/setup_dependencies.sh
+++ b/tools/setup_dependencies.sh
@@ -41,6 +41,7 @@ function install_ubuntu_deps() {
   $SUDO apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
+    libbz2-dev \
     curl \
     libcurl4-openssl-dev \
     locales \


### PR DESCRIPTION
**Description**

Regression fix for PR [#37332](https://github.com/commaai/openpilot/pull/37332): replay/cabana lost backward compatibility with older `.bz2` logs (`rlog.bz2` / `qlog.bz2`), which broke loading older routes, including the official demo route (`a2a0ccea32023010|2023-07-27--13-01-19`).

This change restores native C++ bz2 compatibility by:
- Re-adding `.bz2` route file recognition in `Route::addFileToSegment` (`rlog.bz2`, `qlog.bz2`)
- Re-adding bz2 decompression helpers in replay utils
- Re-enabling bz2 decompression in `LogReader::load` (checked before zstd)
- Re-adding bz2 link deps for replay/cabana (`'bz2'`) and Ubuntu dependency (`libbz2-dev`)
- Replacing remote URL-dependent replay tests with deterministic local tests:
  - local `.bz2` and `.zst` log load
  - corrupt log partial-parse behavior
  - local route discovery of `rlog.bz2` / `qlog.bz2`

**Verification**

- Added deterministic regression coverage in `tools/replay/tests/test_replay.cc` for bz2/zst loading, corrupt-log handling, and local bz2 route discovery.
- `git diff --check` passes.
- Attempted to run replay C++ tests with:
  - `python3 -m SCons -j$(nproc) --extras tools/replay/tests/test_replay`
- Local environment blocker: build stopped early with `ModuleNotFoundError: No module named 'numpy'` (SConstruct import), so full test execution needs CI or an environment with build deps installed.