### PR TITLE
WifiManager: fix more race conditions v2

### DIFF
--- a/system/ui/lib/tests/test_handle_state_change.py
+++ b/system/ui/lib/tests/test_handle_state_change.py
@@ -3,6 +3,9 @@
 Tests the state machine in isolation by constructing a WifiManager with mocked
 DBus, then calling _handle_state_change directly with NM state transitions.
 """
+import queue
+import threading
+
 import pytest
 from jeepney.low_level import MessageType
 from pytest_mock import MockerFixture
@@ -19,7 +22,8 @@ def _make_wm(mocker: MockerFixture, connections=None):
   wm._conn_monitor = mocker.MagicMock()
   wm._connections = dict(connections or {})
   wm._wifi_state = WifiState()
-  wm._user_epoch = 0
+  wm._action_queue = queue.Queue()
+  wm._init_lock = threading.Lock()
   wm._callback_queue = []
   wm._need_auth = []
   wm._activated = []
@@ -31,8 +35,10 @@ def _make_wm(mocker: MockerFixture, connections=None):
 
 def fire(wm: WifiManager, new_state: int, prev_state: int = NMDeviceState.UNKNOWN,
          reason: int = NMDeviceStateReason.NONE) -> None:
-  """Feed a state change into the handler."""
+  """Simulate the monitor thread: drain queue, run handler, drain again."""
+  wm._drain_queue()
   wm._handle_state_change(new_state, prev_state, reason)
+  wm._drain_queue()
 
 
 def fire_wpa_connect(wm: WifiManager) -> None:
@@ -335,13 +341,13 @@ class TestActivated:
 
 # ---------------------------------------------------------------------------
 # Thread races: _set_connecting on main thread vs _handle_state_change on monitor thread.
-# Uses side_effect on the DBus mock to simulate _set_connecting running mid-handler.
-# The epoch counter detects that a user action occurred during the slow DBus call
-# and discards the stale update.
+# Uses side_effect on the DBus mock to simulate _set_connecting (queue put) running
+# mid-handler. The handler checks `not action_queue.empty()` after the slow DBus call
+# and discards the stale update. The post-handler drain applies the user's intent.
 # ---------------------------------------------------------------------------
 # The deterministic fixes (skip DBus lookup when ssid already set, prev_state guard
 # on NEED_AUTH, DEACTIVATING clears CONNECTED on CONNECTION_REMOVED, CONNECTION_REMOVED
-# guard) shrink these race windows significantly. The epoch counter closes the
+# guard) shrink these race windows significantly. The queue-empty check closes the
 # remaining gaps.
 
 class TestThreadRaces:
@@ -349,7 +355,8 @@ class TestThreadRaces:
     """User taps B while PREPARE's DBus call is in flight for auto-connect.
 
     Monitor thread reads wifi_state (ssid=None), starts DBus call.
-    Main thread: _set_connecting("B"). Monitor thread writes back stale ssid from DBus.
+    Main thread: _set_connecting("B") queues action. Handler sees non-empty queue,
+    discards stale result. Post-handler drain applies CONNECTING("B").
     """
     wm = _make_wm(mocker, connections={"A": "/path/A", "B": "/path/B"})
 
@@ -367,8 +374,9 @@ class TestThreadRaces:
   def test_activated_race_user_tap_during_dbus(self, mocker):
     """User taps B right as A finishes connecting (ACTIVATED handler running).
 
-    Monitor thread reads wifi_state (A, CONNECTING), starts DBus call.
-    Main thread: _set_connecting("B"). Monitor thread writes (A, CONNECTED), losing B.
+    Monitor thread starts DBus call for ACTIVATED. Main thread: _set_connecting("B")
+    queues action. Handler sees non-empty queue, discards stale CONNECTED("A").
+    Post-handler drain applies CONNECTING("B").
     """
     wm = _make_wm(mocker, connections={"A": "/path/A", "B": "/path/B"})
     wm._set_connecting("A")
@@ -387,10 +395,10 @@ class TestThreadRaces:
   def test_init_wifi_state_race_user_tap_during_dbus(self, mocker):
     """User taps B while _init_wifi_state's DBus calls are in flight.
 
-    _init_wifi_state runs from set_active(True) or worker error paths. It does
-    2 DBus calls (device State property + _get_active_wifi_connection) then
-    unconditionally writes _wifi_state. If the user taps a network during those
-    calls, _set_connecting("B") is overwritten with stale NM ground truth.
+    _init_wifi_state runs from set_active(True) or worker error paths. It clears
+    stale queue items first, then does 2 DBus calls. If the user taps a network
+    during those calls, _set_connecting("B") queues a new action.
+    _init_wifi_state sees non-empty queue and skips the stale write.
     """
     wm = _make_wm(mocker, connections={"A": "/path/A", "B": "/path/B"})
     wm._wifi_device = "/dev/wifi0"
@@ -407,6 +415,7 @@ class TestThreadRaces:
     wm._get_active_wifi_connection.side_effect = user_taps_b_during_dbus
 
     wm._init_wifi_state()
+    wm._drain_queue()
 
     assert wm._wifi_state.ssid == "B"
     assert wm._wifi_state.status == ConnectStatus.CONNECTING

--- a/system/ui/lib/tests/test_handle_state_change.py
+++ b/system/ui/lib/tests/test_handle_state_change.py
@@ -33,6 +33,11 @@ def _make_wm(mocker: MockerFixture, connections=None):
   return wm
 
 
+def _set_connecting(wm: WifiManager, ssid: str):
+  """Test helper: simulate user tap by queuing a no-op action with the given ssid."""
+  wm._action_queue.put((lambda *a: None, (ssid,)))
+
+
 def fire(wm: WifiManager, new_state: int, prev_state: int = NMDeviceState.UNKNOWN,
          reason: int = NMDeviceStateReason.NONE) -> None:
   """Simulate the monitor thread: drain queue, run handler, drain again."""
@@ -80,7 +85,7 @@ class TestDisconnected:
   def test_connection_removed_keeps_other_connecting(self, mocker):
     """Forget A while connecting to B: CONNECTION_REMOVED for A must not clear B."""
     wm = _make_wm(mocker, connections={"B": "/path/B"})
-    wm._set_connecting("B")
+    _set_connecting(wm, "B")
 
     fire(wm, NMDeviceState.DISCONNECTED, reason=NMDeviceStateReason.CONNECTION_REMOVED)
 
@@ -145,7 +150,7 @@ class TestPrepareConfig:
     indicator briefly jump to the wrong network row then back.
     """
     wm = _make_wm(mocker, connections={"A": "/path/A", "B": "/path/B"})
-    wm._set_connecting("B")
+    _set_connecting(wm, "B")
     wm._get_active_wifi_connection.return_value = ("/path/A", {})
 
     fire(wm, NMDeviceState.PREPARE)
@@ -191,7 +196,7 @@ class TestNeedAuth:
     wm = _make_wm(mocker)
     cb = mocker.MagicMock()
     wm.add_callbacks(need_auth=cb)
-    wm._set_connecting("SecNet")
+    _set_connecting(wm, "SecNet")
 
     fire(wm, NMDeviceState.NEED_AUTH, prev_state=NMDeviceState.CONFIG,
          reason=NMDeviceStateReason.SUPPLICANT_DISCONNECT)
@@ -216,7 +221,7 @@ class TestNeedAuth:
     wm = _make_wm(mocker)
     cb = mocker.MagicMock()
     wm.add_callbacks(need_auth=cb)
-    wm._set_connecting("WeakNet")
+    _set_connecting(wm, "WeakNet")
 
     fire(wm, NMDeviceState.FAILED, reason=NMDeviceStateReason.NO_SECRETS)
 
@@ -234,7 +239,7 @@ class TestNeedAuth:
     wm = _make_wm(mocker)
     cb = mocker.MagicMock()
     wm.add_callbacks(need_auth=cb)
-    wm._set_connecting("BadPass")
+    _set_connecting(wm, "BadPass")
 
     fire(wm, NMDeviceState.NEED_AUTH, prev_state=NMDeviceState.CONFIG,
          reason=NMDeviceStateReason.SUPPLICANT_DISCONNECT)
@@ -267,8 +272,8 @@ class TestNeedAuth:
     wm = _make_wm(mocker)
     cb = mocker.MagicMock()
     wm.add_callbacks(need_auth=cb)
-    wm._set_connecting("A")
-    wm._set_connecting("B")
+    _set_connecting(wm, "A")
+    _set_connecting(wm, "B")
 
     fire(wm, NMDeviceState.NEED_AUTH, prev_state=NMDeviceState.DISCONNECTED,
          reason=NMDeviceStateReason.SUPPLICANT_DISCONNECT)
@@ -290,7 +295,7 @@ class TestPassthroughStates:
   ])
   def test_passthrough_is_noop(self, mocker, state):
     wm = _make_wm(mocker)
-    wm._set_connecting("Net")
+    _set_connecting(wm, "Net")
 
     fire(wm, state, reason=NMDeviceStateReason.NONE)
 
@@ -305,7 +310,7 @@ class TestActivated:
     wm = _make_wm(mocker, connections={"MyNet": "/path/mynet"})
     cb = mocker.MagicMock()
     wm.add_callbacks(activated=cb)
-    wm._set_connecting("MyNet")
+    _set_connecting(wm, "MyNet")
     wm._get_active_wifi_connection.return_value = ("/path/mynet", {})
 
     fire(wm, NMDeviceState.ACTIVATED)
@@ -319,7 +324,7 @@ class TestActivated:
   def test_conn_path_none_still_connected(self, mocker):
     """ACTIVATED but DBus returns None: status CONNECTED, ssid unchanged."""
     wm = _make_wm(mocker)
-    wm._set_connecting("MyNet")
+    _set_connecting(wm, "MyNet")
 
     fire(wm, NMDeviceState.ACTIVATED)
 
@@ -329,7 +334,7 @@ class TestActivated:
   def test_activated_side_effects(self, mocker):
     """ACTIVATED persists the volatile connection to disk and updates active connection info."""
     wm = _make_wm(mocker, connections={"Net": "/path/net"})
-    wm._set_connecting("Net")
+    _set_connecting(wm, "Net")
     wm._get_active_wifi_connection.return_value = ("/path/net", {})
 
     fire(wm, NMDeviceState.ACTIVATED)
@@ -361,7 +366,7 @@ class TestThreadRaces:
     wm = _make_wm(mocker, connections={"A": "/path/A", "B": "/path/B"})
 
     def user_taps_b_during_dbus(*args, **kwargs):
-      wm._set_connecting("B")
+      _set_connecting(wm, "B")
       return ("/path/A", {})
 
     wm._get_active_wifi_connection.side_effect = user_taps_b_during_dbus
@@ -379,10 +384,10 @@ class TestThreadRaces:
     Post-handler drain applies CONNECTING("B").
     """
     wm = _make_wm(mocker, connections={"A": "/path/A", "B": "/path/B"})
-    wm._set_connecting("A")
+    _set_connecting(wm, "A")
 
     def user_taps_b_during_dbus(*args, **kwargs):
-      wm._set_connecting("B")
+      _set_connecting(wm, "B")
       return ("/path/A", {})
 
     wm._get_active_wifi_connection.side_effect = user_taps_b_during_dbus
@@ -409,7 +414,7 @@ class TestThreadRaces:
     wm._router_main.send_and_get_reply.return_value = state_reply
 
     def user_taps_b_during_dbus(*args, **kwargs):
-      wm._set_connecting("B")
+      _set_connecting(wm, "B")
       return ("/path/A", {})
 
     wm._get_active_wifi_connection.side_effect = user_taps_b_during_dbus
@@ -437,7 +442,7 @@ class TestFullSequences:
     wm = _make_wm(mocker, connections={"Home": "/path/home"})
     wm._get_active_wifi_connection.return_value = ("/path/home", {})
 
-    wm._set_connecting("Home")
+    _set_connecting(wm, "Home")
     fire(wm, NMDeviceState.PREPARE)
     fire(wm, NMDeviceState.CONFIG)
     fire(wm, NMDeviceState.NEED_AUTH)  # WPA handshake (reason=NONE)
@@ -472,7 +477,7 @@ class TestFullSequences:
     cb = mocker.MagicMock()
     wm.add_callbacks(need_auth=cb)
 
-    wm._set_connecting("Sec")
+    _set_connecting(wm, "Sec")
     fire(wm, NMDeviceState.PREPARE)
     fire(wm, NMDeviceState.CONFIG)
     fire(wm, NMDeviceState.NEED_AUTH)  # WPA handshake (reason=NONE)
@@ -492,7 +497,7 @@ class TestFullSequences:
 
     # Retry
     wm._callback_queue.clear()
-    wm._set_connecting("Sec")
+    _set_connecting(wm, "Sec")
     wm._get_active_wifi_connection.return_value = ("/path/sec", {})
     fire(wm, NMDeviceState.PREPARE)
     fire(wm, NMDeviceState.CONFIG)
@@ -511,7 +516,7 @@ class TestFullSequences:
     wm._wifi_state = WifiState(ssid="A", status=ConnectStatus.CONNECTED)
     wm._get_active_wifi_connection.return_value = ("/path/B", {})
 
-    wm._set_connecting("B")
+    _set_connecting(wm, "B")
 
     fire(wm, NMDeviceState.DEACTIVATING, prev_state=NMDeviceState.ACTIVATED,
          reason=NMDeviceStateReason.NEW_ACTIVATION)
@@ -546,7 +551,7 @@ class TestFullSequences:
     wm._wifi_state = WifiState(ssid="A", status=ConnectStatus.CONNECTED)
     wm._get_active_wifi_connection.return_value = ("/path/B", {})
 
-    wm._set_connecting("B")
+    _set_connecting(wm, "B")
 
     fire(wm, NMDeviceState.DEACTIVATING, prev_state=NMDeviceState.ACTIVATED,
          reason=NMDeviceStateReason.NEW_ACTIVATION)
@@ -585,7 +590,7 @@ class TestFullSequences:
     wm = _make_wm(mocker, connections={"A": "/path/A", "Other": "/path/other"})
     wm._get_active_wifi_connection.return_value = ("/path/other", {})
 
-    wm._set_connecting("A")
+    _set_connecting(wm, "A")
 
     fire(wm, NMDeviceState.PREPARE)
     fire(wm, NMDeviceState.CONFIG)
@@ -656,7 +661,7 @@ class TestFullSequences:
     wm = _make_wm(mocker, connections={"A": "/path/A"})
     wm._wifi_state = WifiState(ssid="A", status=ConnectStatus.CONNECTED)
 
-    wm._set_connecting("B")
+    _set_connecting(wm, "B")
     del wm._connections["A"]
     wm._connections["B"] = "/path/B"
 
@@ -694,7 +699,7 @@ class TestFullSequences:
     wm = _make_wm(mocker, connections={"A": "/path/A"})
     wm._wifi_state = WifiState(ssid="A", status=ConnectStatus.CONNECTED)
 
-    wm._set_connecting("B")
+    _set_connecting(wm, "B")
     del wm._connections["A"]
 
     fire(wm, NMDeviceState.DEACTIVATING, prev_state=NMDeviceState.ACTIVATED,
@@ -755,7 +760,7 @@ class TestFullSequences:
     cb = mocker.MagicMock()
     wm.add_callbacks(need_auth=cb)
 
-    wm._set_connecting("Hotspot")
+    _set_connecting(wm, "Hotspot")
     fire(wm, NMDeviceState.PREPARE)
     fire(wm, NMDeviceState.CONFIG)
     fire(wm, NMDeviceState.NEED_AUTH)  # WPA handshake (reason=NONE)
@@ -806,7 +811,7 @@ class TestFullSequences:
     cb = mocker.MagicMock()
     wm.add_callbacks(need_auth=cb)
 
-    wm._set_connecting("GoneNet")
+    _set_connecting(wm, "GoneNet")
     fire(wm, NMDeviceState.PREPARE)
     fire(wm, NMDeviceState.CONFIG)
     fire(wm, NMDeviceState.FAILED, reason=NMDeviceStateReason.SSID_NOT_FOUND)
@@ -821,7 +826,7 @@ class TestFullSequences:
     Full sequence: ... → FAILED(reason) → DISCONNECTED(NONE)
     """
     wm = _make_wm(mocker)
-    wm._set_connecting("Net")
+    _set_connecting(wm, "Net")
 
     fire(wm, NMDeviceState.FAILED, reason=NMDeviceStateReason.NONE)
     assert wm._wifi_state.status == ConnectStatus.CONNECTING  # FAILED(NONE) is a no-op
@@ -881,7 +886,7 @@ class TestWorkerErrorRecovery:
 
     mock_init = self._mock_init_restores(wm, mocker, "A", ConnectStatus.CONNECTED)
 
-    wm.activate_connection("B", block=True)
+    wm._activate_connection("B")
 
     mock_init.assert_called_once()
     assert wm._wifi_state.ssid == "A"
@@ -902,13 +907,7 @@ class TestWorkerErrorRecovery:
 
     mock_init = self._mock_init_restores(wm, mocker, "A", ConnectStatus.CONNECTED)
 
-    # Run worker thread synchronously
-    workers = []
-    mocker.patch('openpilot.system.ui.lib.wifi_manager.threading.Thread',
-                 side_effect=lambda target, **kw: type('T', (), {'start': lambda self: workers.append(target)})())
-
-    wm.connect_to_network("B", "password123")
-    workers[-1]()
+    wm._connect_to_network("B", "password123")
 
     mock_init.assert_called_once()
     assert wm._wifi_state.ssid == "A"

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -173,12 +173,12 @@ class WifiManager:
     # Store wifi device path
     self._wifi_device: str | None = None
 
-    # State — _wifi_state is written by the monitor thread (signal handlers) and drained
-    # from _action_queue. The UI thread communicates user intent via the queue; the monitor
-    # thread drains it before each signal, so user actions always take priority.
+    # State — _wifi_state is written only by the monitor thread. The UI thread enqueues
+    # actions (callable, args) via _action_queue; the monitor thread drains it before
+    # each signal, sets _wifi_state to CONNECTING, and spawns the worker thread.
     self._connections: dict[str, str] = {}  # ssid -> connection path, updated via NM signals
     self._wifi_state: WifiState = WifiState()
-    self._action_queue: queue.Queue[WifiState] = queue.Queue()
+    self._action_queue: queue.Queue[tuple[Callable, tuple]] = queue.Queue()
     self._ipv4_address: str = ""
     self._current_network_metered: MeteredType = MeteredType.UNKNOWN
     self._tethering_password: str = ""
@@ -312,10 +312,6 @@ class WifiManager:
   def tethering_password(self) -> str:
     return self._tethering_password
 
-  def _set_connecting(self, ssid: str | None):
-    """Queue a user-initiated state change. Drained by the monitor thread."""
-    self._action_queue.put(WifiState(ssid=ssid, status=ConnectStatus.DISCONNECTED if ssid is None else ConnectStatus.CONNECTING))
-
   def _drain_queue(self):
     """Apply the latest pending user action. Only the last item matters (click A then B = B)."""
     latest = None
@@ -325,7 +321,9 @@ class WifiManager:
       except queue.Empty:
         break
     if latest is not None:
-      self._wifi_state = latest
+      fn, args = latest
+      self._wifi_state = WifiState(ssid=args[0], status=ConnectStatus.CONNECTING)
+      threading.Thread(target=fn, args=args, daemon=True).start()
 
   def _enqueue_callbacks(self, cbs: list[Callable], *args):
     for cb in cbs:
@@ -410,12 +408,12 @@ class WifiManager:
           self._handle_state_change(new_state, previous_state, change_reason)
 
   def _handle_state_change(self, new_state: int, prev_state: int, change_reason: int):
-    # Thread safety: _wifi_state is written by this handler (monitor thread) and by
-    # _drain_queue (also monitor thread). The UI thread communicates user intent via
-    # _action_queue; _drain_queue applies it before each handler invocation.
+    # Thread safety: _wifi_state is written only by the monitor thread — both this
+    # handler and _drain_queue run on it. The UI thread enqueues actions via
+    # _action_queue; _drain_queue applies them before each handler invocation.
     # Handlers with slow DBus calls check `not self._action_queue.empty()` after the
     # call — if the user acted during the call, the stale result is discarded and the
-    # next drain applies the user's intent.
+    # next drain spawns the new worker.
 
     # TODO: Handle (FAILED, SSID_NOT_FOUND) and emit for UI to show error
     #  Happens when network drops off after starting connection
@@ -635,55 +633,52 @@ class WifiManager:
     self._router_main.send_and_get_reply(new_method_call(settings_addr, 'AddConnection', 'a{sa{sv}}', (connection,)))
 
   def connect_to_network(self, ssid: str, password: str, hidden: bool = False):
-    self._set_connecting(ssid)
+    self._action_queue.put((self._connect_to_network, (ssid, password, hidden)))
 
-    def worker():
-      # Clear all connections that may already exist to the network we are connecting to
-      self.forget_connection(ssid, block=True)
+  def _connect_to_network(self, ssid: str, password: str, hidden: bool = False):
+    self.forget_connection(ssid, block=True)
 
-      connection = {
-        'connection': {
-          'type': ('s', '802-11-wireless'),
-          'uuid': ('s', str(uuid.uuid4())),
-          'id': ('s', f'openpilot connection {ssid}'),
-          'autoconnect-retries': ('i', 0),
-        },
-        '802-11-wireless': {
-          'ssid': ('ay', ssid.encode("utf-8")),
-          'hidden': ('b', hidden),
-          'mode': ('s', 'infrastructure'),
-        },
-        'ipv4': {
-          'method': ('s', 'auto'),
-          'dns-priority': ('i', 600),
-        },
-        'ipv6': {'method': ('s', 'ignore')},
+    connection = {
+      'connection': {
+        'type': ('s', '802-11-wireless'),
+        'uuid': ('s', str(uuid.uuid4())),
+        'id': ('s', f'openpilot connection {ssid}'),
+        'autoconnect-retries': ('i', 0),
+      },
+      '802-11-wireless': {
+        'ssid': ('ay', ssid.encode("utf-8")),
+        'hidden': ('b', hidden),
+        'mode': ('s', 'infrastructure'),
+      },
+      'ipv4': {
+        'method': ('s', 'auto'),
+        'dns-priority': ('i', 600),
+      },
+      'ipv6': {'method': ('s', 'ignore')},
+    }
+
+    if password:
+      connection['802-11-wireless-security'] = {
+        'key-mgmt': ('s', 'wpa-psk'),
+        'auth-alg': ('s', 'open'),
+        'psk': ('s', password),
       }
 
-      if password:
-        connection['802-11-wireless-security'] = {
-          'key-mgmt': ('s', 'wpa-psk'),
-          'auth-alg': ('s', 'open'),
-          'psk': ('s', password),
-        }
+    # Volatile connection auto-deletes on disconnect (wrong password, user switches networks)
+    # Persisted to disk on ACTIVATED via Save()
+    if self._wifi_device is None:
+      cloudlog.warning("No WiFi device found")
+      # TODO: expose a failed connection state in the UI
+      self._init_wifi_state()
+      return
 
-      # Volatile connection auto-deletes on disconnect (wrong password, user switches networks)
-      # Persisted to disk on ACTIVATED via Save()
-      if self._wifi_device is None:
-        cloudlog.warning("No WiFi device found")
-        # TODO: expose a failed connection state in the UI
-        self._init_wifi_state()
-        return
+    reply = self._router_main.send_and_get_reply(new_method_call(self._nm, 'AddAndActivateConnection2', 'a{sa{sv}}ooa{sv}',
+                                                                 (connection, self._wifi_device, "/", {'persist': ('s', 'volatile')})))
 
-      reply = self._router_main.send_and_get_reply(new_method_call(self._nm, 'AddAndActivateConnection2', 'a{sa{sv}}ooa{sv}',
-                                                                   (connection, self._wifi_device, "/", {'persist': ('s', 'volatile')})))
-
-      if reply.header.message_type == MessageType.error:
-        cloudlog.warning(f"Failed to add and activate connection for {ssid}: {reply}")
-        # TODO: expose a failed connection state in the UI
-        self._init_wifi_state()
-
-    threading.Thread(target=worker, daemon=True).start()
+    if reply.header.message_type == MessageType.error:
+      cloudlog.warning(f"Failed to add and activate connection for {ssid}: {reply}")
+      # TODO: expose a failed connection state in the UI
+      self._init_wifi_state()
 
   def forget_connection(self, ssid: str, block: bool = False):
     def worker():
@@ -701,29 +696,24 @@ class WifiManager:
     else:
       threading.Thread(target=worker, daemon=True).start()
 
-  def activate_connection(self, ssid: str, block: bool = False):
-    self._set_connecting(ssid)
+  def activate_connection(self, ssid: str):
+    self._action_queue.put((self._activate_connection, (ssid,)))
 
-    def worker():
-      conn_path = self._connections.get(ssid, None)
-      if conn_path is None or self._wifi_device is None:
-        cloudlog.warning(f"Failed to activate connection for {ssid}: conn_path={conn_path}, wifi_device={self._wifi_device}")
-        # TODO: expose a failed connection state in the UI
-        self._init_wifi_state()
-        return
+  def _activate_connection(self, ssid: str):
+    conn_path = self._connections.get(ssid, None)
+    if conn_path is None or self._wifi_device is None:
+      cloudlog.warning(f"Failed to activate connection for {ssid}: conn_path={conn_path}, wifi_device={self._wifi_device}")
+      # TODO: expose a failed connection state in the UI
+      self._init_wifi_state()
+      return
 
-      reply = self._router_main.send_and_get_reply(new_method_call(self._nm, 'ActivateConnection', 'ooo',
-                                                                   (conn_path, self._wifi_device, "/")))
+    reply = self._router_main.send_and_get_reply(new_method_call(self._nm, 'ActivateConnection', 'ooo',
+                                                                 (conn_path, self._wifi_device, "/")))
 
-      if reply.header.message_type == MessageType.error:
-        cloudlog.warning(f"Failed to activate connection for {ssid}: {reply}")
-        # TODO: expose a failed connection state in the UI
-        self._init_wifi_state()
-
-    if block:
-      worker()
-    else:
-      threading.Thread(target=worker, daemon=True).start()
+    if reply.header.message_type == MessageType.error:
+      cloudlog.warning(f"Failed to activate connection for {ssid}: {reply}")
+      # TODO: expose a failed connection state in the UI
+      self._init_wifi_state()
 
   def _deactivate_connection(self, ssid: str):
     for active_conn in self._get_active_connections():
@@ -775,7 +765,7 @@ class WifiManager:
 
       self._tethering_password = password
       if self.is_tethering_active():
-        self.activate_connection(self._tethering_ssid, block=True)
+        self._activate_connection(self._tethering_ssid)
 
     threading.Thread(target=worker, daemon=True).start()
 
@@ -806,7 +796,7 @@ class WifiManager:
   def set_tethering_active(self, active: bool):
     def worker():
       if active:
-        self.activate_connection(self._tethering_ssid, block=True)
+        self._activate_connection(self._tethering_ssid)
 
         if not self._ipv4_forward:
           time.sleep(5)

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -1,10 +1,11 @@
 import atexit
+import queue
 import threading
 import time
 import uuid
 import subprocess
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any
 
@@ -145,7 +146,7 @@ class ConnectStatus(IntEnum):
   CONNECTED = 2
 
 
-@dataclass
+@dataclass(frozen=True)
 class WifiState:
   ssid: str | None = None
   status: ConnectStatus = ConnectStatus.DISCONNECTED
@@ -172,10 +173,12 @@ class WifiManager:
     # Store wifi device path
     self._wifi_device: str | None = None
 
-    # State
+    # State — _wifi_state is written by the monitor thread (signal handlers) and drained
+    # from _action_queue. The UI thread communicates user intent via the queue; the monitor
+    # thread drains it before each signal, so user actions always take priority.
     self._connections: dict[str, str] = {}  # ssid -> connection path, updated via NM signals
     self._wifi_state: WifiState = WifiState()
-    self._user_epoch: int = 0
+    self._action_queue: queue.Queue[WifiState] = queue.Queue()
     self._ipv4_address: str = ""
     self._current_network_metered: MeteredType = MeteredType.UNKNOWN
     self._tethering_password: str = ""
@@ -198,6 +201,7 @@ class WifiManager:
     self._disconnected: list[Callable[[], None]] = []
 
     self._scan_lock = threading.Lock()
+    self._init_lock = threading.Lock()
     self._scan_thread = threading.Thread(target=self._network_scanner, daemon=True)
     self._state_thread = threading.Thread(target=self._monitor_state, daemon=True)
     self._initialize()
@@ -223,29 +227,38 @@ class WifiManager:
 
   def _init_wifi_state(self, block: bool = True):
     def worker():
-      if self._wifi_device is None:
-        cloudlog.warning("No WiFi device found")
-        return
+      with self._init_lock:
+        if self._wifi_device is None:
+          cloudlog.warning("No WiFi device found")
+          return
 
-      epoch = self._user_epoch
+        # Discard stale queue items — we're about to re-read NM's ground truth.
+        # New actions arriving during the D-Bus calls below are detected by the
+        # queue-empty check at the end.
+        while not self._action_queue.empty():
+          try:
+            self._action_queue.get_nowait()
+          except queue.Empty:
+            break
 
-      dev_addr = DBusAddress(self._wifi_device, bus_name=NM, interface=NM_DEVICE_IFACE)
-      dev_state = self._router_main.send_and_get_reply(Properties(dev_addr).get('State')).body[0][1]
+        dev_addr = DBusAddress(self._wifi_device, bus_name=NM, interface=NM_DEVICE_IFACE)
+        dev_state = self._router_main.send_and_get_reply(Properties(dev_addr).get('State')).body[0][1]
 
-      wifi_state = WifiState()
-      if NMDeviceState.PREPARE <= dev_state <= NMDeviceState.SECONDARIES and dev_state != NMDeviceState.NEED_AUTH:
-        wifi_state.status = ConnectStatus.CONNECTING
-      elif dev_state == NMDeviceState.ACTIVATED:
-        wifi_state.status = ConnectStatus.CONNECTED
+        status = ConnectStatus.DISCONNECTED
+        if NMDeviceState.PREPARE <= dev_state <= NMDeviceState.SECONDARIES and dev_state != NMDeviceState.NEED_AUTH:
+          status = ConnectStatus.CONNECTING
+        elif dev_state == NMDeviceState.ACTIVATED:
+          status = ConnectStatus.CONNECTED
 
-      conn_path, _ = self._get_active_wifi_connection()
-      if conn_path:
-        wifi_state.ssid = next((s for s, p in self._connections.items() if p == conn_path), None)
+        ssid = None
+        conn_path, _ = self._get_active_wifi_connection()
+        if conn_path:
+          ssid = next((s for s, p in self._connections.items() if p == conn_path), None)
 
-      if self._user_epoch != epoch:
-        return
+        if not self._action_queue.empty():
+          return
 
-      self._wifi_state = wifi_state
+        self._wifi_state = WifiState(ssid=ssid, status=status)
 
     if block:
       worker()
@@ -300,9 +313,19 @@ class WifiManager:
     return self._tethering_password
 
   def _set_connecting(self, ssid: str | None):
-    # Called by user action, or sequentially from state change handler
-    self._user_epoch += 1
-    self._wifi_state = WifiState(ssid=ssid, status=ConnectStatus.DISCONNECTED if ssid is None else ConnectStatus.CONNECTING)
+    """Queue a user-initiated state change. Drained by the monitor thread."""
+    self._action_queue.put(WifiState(ssid=ssid, status=ConnectStatus.DISCONNECTED if ssid is None else ConnectStatus.CONNECTING))
+
+  def _drain_queue(self):
+    """Apply the latest pending user action. Only the last item matters (click A then B = B)."""
+    latest = None
+    while not self._action_queue.empty():
+      try:
+        latest = self._action_queue.get_nowait()
+      except queue.Empty:
+        break
+    if latest is not None:
+      self._wifi_state = latest
 
   def _enqueue_callbacks(self, cbs: list[Callable], *args):
     for cb in cbs:
@@ -359,8 +382,10 @@ class WifiManager:
           self._conn_monitor.filter(rules[2], bufsize=SIGNAL_QUEUE_SIZE) as removed_conn_q,
           self._conn_monitor.filter(rules[3], bufsize=SIGNAL_QUEUE_SIZE) as props_q):
       while not self._exit:
+        self._drain_queue()
+
         try:
-          self._conn_monitor.recv_messages(timeout=1)
+          self._conn_monitor.recv_messages(timeout=0.1)
         except TimeoutError:
           continue
 
@@ -378,24 +403,19 @@ class WifiManager:
           if iface == NM_WIRELESS_IFACE and 'LastScan' in changed:
             self._update_networks()
 
-        # Device state changes
+        # Device state changes — drain queue between each handler so user actions take priority
         while len(state_q):
+          self._drain_queue()
           new_state, previous_state, change_reason = state_q.popleft().body
-
           self._handle_state_change(new_state, previous_state, change_reason)
 
   def _handle_state_change(self, new_state: int, prev_state: int, change_reason: int):
-    # Thread safety: _wifi_state is read/written by both the monitor thread (this handler)
-    # and the main thread (_set_connecting via connect/activate). PREPARE/CONFIG and ACTIVATED
-    # have a read-then-write pattern with a slow DBus call in between — if _set_connecting
-    # runs mid-call, the handler would overwrite the user's newer state with stale data.
-    #
-    # The _user_epoch counter solves this without locks. _set_connecting increments the epoch
-    # on every user action. Handlers snapshot the epoch before their DBus call and compare
-    # after: if it changed, a user action occurred during the call and the stale result is
-    # discarded. Combined with deterministic fixes (skip DBus lookup when ssid already set,
-    # DEACTIVATING clears CONNECTED on CONNECTION_REMOVED, CONNECTION_REMOVED guard),
-    # all known race windows are closed.
+    # Thread safety: _wifi_state is written by this handler (monitor thread) and by
+    # _drain_queue (also monitor thread). The UI thread communicates user intent via
+    # _action_queue; _drain_queue applies it before each handler invocation.
+    # Handlers with slow DBus calls check `not self._action_queue.empty()` after the
+    # call — if the user acted during the call, the stale result is discarded and the
+    # next drain applies the user's intent.
 
     # TODO: Handle (FAILED, SSID_NOT_FOUND) and emit for UI to show error
     #  Happens when network drops off after starting connection
@@ -411,29 +431,26 @@ class WifiManager:
         self._wifi_state.ssid in self._connections):
         return
 
-      self._set_connecting(None)
+      self._wifi_state = WifiState()
 
     elif new_state in (NMDeviceState.PREPARE, NMDeviceState.CONFIG):
-      epoch = self._user_epoch
-
       if self._wifi_state.ssid is not None:
-        self._wifi_state = replace(self._wifi_state, status=ConnectStatus.CONNECTING)
+        self._wifi_state = WifiState(ssid=self._wifi_state.ssid, status=ConnectStatus.CONNECTING)
         return
 
       # Auto-connection when NetworkManager connects to known networks on its own (ssid=None): look up ssid from NM
-      wifi_state = replace(self._wifi_state, status=ConnectStatus.CONNECTING)
-
       conn_path, _ = self._get_active_wifi_connection(self._conn_monitor)
 
-      if self._user_epoch != epoch:
+      if not self._action_queue.empty():
         return
 
+      ssid = None
       if conn_path is None:
         cloudlog.warning("Failed to get active wifi connection during PREPARE/CONFIG state")
       else:
-        wifi_state.ssid = next((s for s, p in self._connections.items() if p == conn_path), None)
+        ssid = next((s for s, p in self._connections.items() if p == conn_path), None)
 
-      self._wifi_state = wifi_state
+      self._wifi_state = WifiState(ssid=ssid, status=ConnectStatus.CONNECTING)
 
     # BAD PASSWORD
     # - strong network rejects with NEED_AUTH+SUPPLICANT_DISCONNECT
@@ -448,7 +465,7 @@ class WifiManager:
       # prev_state=DISCONNECTED and must be ignored to avoid a false wrong-password callback.
       if self._wifi_state.ssid:
         self._enqueue_callbacks(self._need_auth, self._wifi_state.ssid)
-        self._set_connecting(None)
+        self._wifi_state = WifiState()
 
     elif new_state in (NMDeviceState.NEED_AUTH, NMDeviceState.IP_CONFIG, NMDeviceState.IP_CHECK,
                        NMDeviceState.SECONDARIES, NMDeviceState.FAILED):
@@ -456,20 +473,18 @@ class WifiManager:
 
     elif new_state == NMDeviceState.ACTIVATED:
       # Note that IP address from Ip4Config may not be propagated immediately and could take until the next scan results
-      epoch = self._user_epoch
-      wifi_state = replace(self._wifi_state, status=ConnectStatus.CONNECTED)
-
       conn_path, _ = self._get_active_wifi_connection(self._conn_monitor)
 
-      if self._user_epoch != epoch:
+      if not self._action_queue.empty():
         return
 
+      ssid = self._wifi_state.ssid
       if conn_path is None:
         cloudlog.warning("Failed to get active wifi connection during ACTIVATED state")
       else:
-        wifi_state.ssid = next((s for s, p in self._connections.items() if p == conn_path), None)
+        ssid = next((s for s, p in self._connections.items() if p == conn_path), ssid)
 
-      self._wifi_state = wifi_state
+      self._wifi_state = WifiState(ssid=ssid, status=ConnectStatus.CONNECTED)
       self._enqueue_callbacks(self._activated)
       self._update_active_connection_info()
 
@@ -486,7 +501,7 @@ class WifiManager:
       # (the forgotten callback fires between DEACTIVATING and DISCONNECTED).
       # Only clear CONNECTED — CONNECTING must be preserved for forget-A-connect-B.
       if change_reason == NMDeviceStateReason.CONNECTION_REMOVED and self._wifi_state.status == ConnectStatus.CONNECTED:
-        self._set_connecting(None)
+        self._wifi_state = WifiState()
 
   def _network_scanner(self):
     while not self._exit:


### PR DESCRIPTION
alternative to https://github.com/commaai/openpilot/pull/37411

this is not a huge priority, since we've fixed all of the real observed and theorized issues. this is mainly a clean up PR that rewrites how we fixed the races so any future maintainer doesn't need to be as careful. currently you have to know to NOT use long running DBus calls in the state thread without checking the `_user_epoch`