### PR TITLE
BigButton: sublabel takes all available space

### DIFF
--- a/selfdrive/ui/mici/widgets/button.py
+++ b/selfdrive/ui/mici/widgets/button.py
@@ -218,9 +218,9 @@ class BigButton(Widget):
     self._label.render(label_rect)
 
     if self.value:
-      label_y = btn_y + self._rect.height - self.LABEL_VERTICAL_PADDING
-      sub_label_height = self._sub_label.get_content_height(self._width_hint())
-      sub_label_rect = rl.Rectangle(label_x, label_y - sub_label_height, self._width_hint(), sub_label_height)
+      label_y = btn_y + self.LABEL_VERTICAL_PADDING + self._label.get_content_height(self._width_hint())
+      sub_label_height = btn_y + self._rect.height - self.LABEL_VERTICAL_PADDING - label_y
+      sub_label_rect = rl.Rectangle(label_x, label_y, self._width_hint(), sub_label_height)
       self._sub_label.render(sub_label_rect)
 
     # ICON -------------------------------------------------------------------


### PR DESCRIPTION
so you can top/center align sublabels now

for https://github.com/commaai/openpilot/pull/37264

before:

<img width="535" height="244" alt="image" src="https://github.com/user-attachments/assets/01bf3bc4-f140-4432-86f9-481eec3c6f6e" />


after:

<img width="541" height="243" alt="image" src="https://github.com/user-attachments/assets/944d3141-d7dd-49bd-85b7-db18dc5b8727" />
