### PR TITLE
fix: replace 3 bare except clauses with except Exception

### DIFF
--- a/third_party/acados/acados_template/acados_ocp_solver.py
+++ b/third_party/acados/acados_template/acados_ocp_solver.py
@@ -1984,7 +1984,7 @@ class AcadosOcpSolver:
 
             try:
                 self.dlclose(self.shared_lib._handle)
-            except:
+            except Exception:
                 print(f"WARNING: acados Python interface could not close shared_lib handle of AcadosOcpSolver {self.model_name}.\n",
                      "Attempting to create a new one with the same name will likely result in the old one being used!")
                 pass

--- a/third_party/acados/acados_template/acados_sim_solver.py
+++ b/third_party/acados/acados_template/acados_sim_solver.py
@@ -552,7 +552,7 @@ class AcadosSimSolver:
 
             try:
                 self.dlclose(self.shared_lib._handle)
-            except:
+            except Exception:
                 print(f"WARNING: acados Python interface could not close shared_lib handle of AcadosSimSolver {self.model_name}.\n",
                      "Attempting to create a new one with the same name will likely result in the old one being used!")
                 pass

--- a/third_party/acados/acados_template/gnsf/check_reformulation.py
+++ b/third_party/acados/acados_template/gnsf/check_reformulation.py
@@ -131,7 +131,7 @@ def check_reformulation(model, gnsf, print_info):
                 A @ x0[I_x1] + B @ u0 + C_phi + c - E @ vertcat(x0dot[I_x1], z0[I_z1])
             )
             # gnsf_1 = (A @ x[I_x1] + B @ u + C_phi + c - E @ vertcat(xdot[I_x1], z[I_z1]))
-        except:
+        except Exception:
             import pdb
 
             pdb.set_trace()


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.