### PR TITLE
Refactor random_string in common/util.cc

### DIFF
--- a/common/util.cc
+++ b/common/util.cc
@@ -243,13 +243,15 @@ int random_int(int min, int max) {
 }
 
 std::string random_string(std::string::size_type length) {
-  const std::string chrs = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  static const char chrs[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  static constexpr size_t chr_count = sizeof(chrs) - 1;
+
   std::mt19937 rg{std::random_device{}()};
-  std::uniform_int_distribution<std::string::size_type> pick(0, chrs.length() - 1);
-  std::string s;
-  s.reserve(length);
-  while (length--) {
-    s += chrs[pick(rg)];
+  std::uniform_int_distribution<size_t> pick(0, chr_count - 1);
+
+  std::string s(length, '\0');
+  for (std::string::size_type i = 0; i < length; ++i) {
+    s[i] = chrs[pick(rg)];
   }
   return s;
 }


### PR DESCRIPTION
## Description

Refactor `random_string()` in `common/util.cc` for clarity and performance:

- **Static charset** — Use `static const char[]` instead of recreating the charset string on every call
- **Single allocation** — Use `std::string s(length, '\0')` + index assignment instead of `reserve` + `+=` in loop
- **Clearer loop** — Replace `while (length--)` with explicit `for` loop
- **Index type** — Use `size_t` for `uniform_int_distribution` (cleaner)

Behavior is unchanged: same signature, same output format (alphanumeric string of requested length).

## Verification

- Built with `scons` — no new warnings
- Ran verification program (`verify_random_string.cc`) before and after:
  - **BEFORE (original):** 18 passed, 0 failed
  - **AFTER (refactored):** 18 passed, 0 failed
- Checks: correct length, all chars in `0-9a-zA-Z`, lengths 0/1/8/32/64/256

## Checklist

- [x] No functional changes; output is identical in format
- [x] Same signature and return type
- [x] Compatible with C++11/14/17 and existing platforms
