### PR TITLE
nicer scons output

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -18,6 +18,7 @@ AddOption('--asan', action='store_true', help='turn on ASAN')
 AddOption('--ubsan', action='store_true', help='turn on UBSan')
 AddOption('--mutation', action='store_true', help='generate mutation-ready code')
 AddOption('--ccflags', action='store', type='string', default='', help='pass arbitrary flags over the command line')
+AddOption('--verbose', action='store_true', default=False, help='show full build commands')
 AddOption('--minimal',
           action='store_false',
           dest='extras',
@@ -147,6 +148,22 @@ if _extra_cc:
 # no --as-needed on mac linker
 if arch != "Darwin":
   env.Append(LINKFLAGS=["-Wl,--as-needed", "-Wl,--no-undefined"])
+
+# Shorter build output: show brief descriptions instead of full commands.
+# Full command lines are still printed on failure by scons.
+if not GetOption('verbose'):
+  for action, short in (
+    ("CC",     "CC"),
+    ("CXX",    "CXX"),
+    ("LINK",   "LINK"),
+    ("SHCC",   "CC"),
+    ("SHCXX",  "CXX"),
+    ("SHLINK", "LINK"),
+    ("AR",     "AR"),
+    ("RANLIB", "RANLIB"),
+    ("AS",     "AS"),
+  ):
+    env[f"{action}COMSTR"] = f"  [{short}] $TARGET"
 
 # progress output
 node_interval = 5


### PR DESCRIPTION
```bash
(openpilot) mac:clean_scons adeebshihadeh$ scons common/
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
capnpc --src-prefix=cereal cereal/log.capnp cereal/car.capnp cereal/legacy.capnp cereal/custom.capnp -o c++:cereal/gen/cpp/
  [CXX] common/util.o
  [CXX] common/ratekeeper.o
cythonize common/params_pyx.pyx
  [CXX] common/swaglog.o
  [CXX] common/params.o
  [CXX] third_party/json11/json11.o
  [CXX] common/tests/test_runner.o
  [AR] third_party/libjson11.a
  [RANLIB] third_party/libjson11.a
  [CXX] common/tests/test_params.o
  [CXX] common/tests/test_util.o
  [AR] common/libcommon.a
  [RANLIB] common/libcommon.a
  [CXX] common/tests/test_swaglog.o
Compiling /private/tmp/worktrees/tmp.fb2wUUlKCY/clean_scons/common/params_pyx.pyx because it changed.
[1/1] Cythonizing /private/tmp/worktrees/tmp.fb2wUUlKCY/clean_scons/common/params_pyx.pyx
  [CXX] common/params_pyx.o
  [LINK] common/params_pyx.so
  [LINK] common/tests/test_common
scons: done building targets.
(openpilot) mac:clean_scons adeebshihadeh$
```