### PR TITLE
CI: speed optimizations - use all cores, skip redundant work, parallelize

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,9 +84,10 @@ jobs:
       || fromJSON('["ubuntu-24.04"]') }}
     steps:
     - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - run: ./tools/op.sh setup
+    - name: Install dependencies
+      run: |
+        tools/setup_dependencies.sh
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
     - name: Static analysis
       timeout-minutes: 1
       run: scripts/lint/lint.sh
@@ -210,8 +211,12 @@ jobs:
       - name: Create UI Report
         run: |
           source selfdrive/test/setup_xvfb.sh
-          python3 selfdrive/ui/tests/diff/replay.py
-          python3 selfdrive/ui/tests/diff/replay.py --big
+          python3 selfdrive/ui/tests/diff/replay.py &
+          pid1=$!
+          python3 selfdrive/ui/tests/diff/replay.py --big &
+          pid2=$!
+          wait $pid1
+          wait $pid2
       - name: Upload UI Report
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,10 +45,7 @@ jobs:
     - name: Build devel
       timeout-minutes: 1
       run: TARGET_DIR=$STRIPPED_DIR release/build_stripped.sh
-    - name: Install dependencies
-      run: |
-        tools/setup_dependencies.sh
-        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+    - run: ./tools/op.sh setup
     - name: Build openpilot and run checks
       timeout-minutes: 30
       working-directory: ${{ env.STRIPPED_DIR }}
@@ -73,16 +70,7 @@ jobs:
       run: |
         FILTERED=$(echo "$PATH" | tr ':' '\n' | grep -v '/opt/homebrew' | tr '\n' ':')
         echo "PATH=${FILTERED}/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" >> $GITHUB_ENV
-    - name: Install dependencies
-      run: |
-        tools/setup_dependencies.sh
-        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-    - name: Getting LFS files
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
-      with:
-        timeout_minutes: 2
-        max_attempts: 3
-        command: git lfs pull
+    - run: ./tools/op.sh setup
     - name: Building openpilot
       run: scons
 
@@ -96,10 +84,9 @@ jobs:
       || fromJSON('["ubuntu-24.04"]') }}
     steps:
     - uses: actions/checkout@v6
-    - name: Install dependencies
-      run: |
-        tools/setup_dependencies.sh
-        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      with:
+        submodules: true
+    - run: ./tools/op.sh setup
     - name: Static analysis
       timeout-minutes: 1
       run: scripts/lint/lint.sh
@@ -116,16 +103,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-    - name: Install dependencies
-      run: |
-        tools/setup_dependencies.sh
-        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-    - name: Getting LFS files
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
-      with:
-        timeout_minutes: 2
-        max_attempts: 3
-        command: git lfs pull
+    - run: ./tools/op.sh setup
     - name: Build openpilot
       run: scons -j$(nproc)
     - name: Run unit tests
@@ -148,16 +126,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-    - name: Install dependencies
-      run: |
-        tools/setup_dependencies.sh
-        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-    - name: Getting LFS files
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
-      with:
-        timeout_minutes: 2
-        max_attempts: 3
-        command: git lfs pull
+    - run: ./tools/op.sh setup
     - name: Build openpilot
       run: scons -j$(nproc)
     - name: Run replay
@@ -235,16 +204,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Install dependencies
-        run: |
-          tools/setup_dependencies.sh
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-      - name: Getting LFS files
-        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
-        with:
-          timeout_minutes: 2
-          max_attempts: 3
-          command: git lfs pull
+      - run: ./tools/op.sh setup
       - name: Build openpilot
         run: scons -j$(nproc)
       - name: Create UI Report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -110,8 +110,8 @@ jobs:
       timeout-minutes: ${{ contains(runner.name, 'nsc') && 2 || 20 }}
       run: |
         source selfdrive/test/setup_xvfb.sh
-        # Pre-compile Python bytecode so each pytest worker doesn't need to
-        pytest --collect-only -m 'not slow' -qq
+        # Pre-compile Python bytecode so each pytest-xdist worker doesn't need to
+        python -m compileall -q -j0 common selfdrive system tools cereal
         MAX_EXAMPLES=1 pytest -m 'not slow'
 
   process_replay:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,10 @@ jobs:
     - name: Build devel
       timeout-minutes: 1
       run: TARGET_DIR=$STRIPPED_DIR release/build_stripped.sh
-    - run: ./tools/op.sh setup
+    - name: Install dependencies
+      run: |
+        tools/setup_dependencies.sh
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
     - name: Build openpilot and run checks
       timeout-minutes: 30
       working-directory: ${{ env.STRIPPED_DIR }}
@@ -70,7 +73,16 @@ jobs:
       run: |
         FILTERED=$(echo "$PATH" | tr ':' '\n' | grep -v '/opt/homebrew' | tr '\n' ':')
         echo "PATH=${FILTERED}/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" >> $GITHUB_ENV
-    - run: ./tools/op.sh setup
+    - name: Install dependencies
+      run: |
+        tools/setup_dependencies.sh
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+    - name: Getting LFS files
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      with:
+        timeout_minutes: 2
+        max_attempts: 3
+        command: git lfs pull
     - name: Building openpilot
       run: scons
 
@@ -104,7 +116,16 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-    - run: ./tools/op.sh setup
+    - name: Install dependencies
+      run: |
+        tools/setup_dependencies.sh
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+    - name: Getting LFS files
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      with:
+        timeout_minutes: 2
+        max_attempts: 3
+        command: git lfs pull
     - name: Build openpilot
       run: scons -j$(nproc)
     - name: Run unit tests
@@ -127,7 +148,16 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-    - run: ./tools/op.sh setup
+    - name: Install dependencies
+      run: |
+        tools/setup_dependencies.sh
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+    - name: Getting LFS files
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      with:
+        timeout_minutes: 2
+        max_attempts: 3
+        command: git lfs pull
     - name: Build openpilot
       run: scons -j$(nproc)
     - name: Run replay
@@ -205,7 +235,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - run: ./tools/op.sh setup
+      - name: Install dependencies
+        run: |
+          tools/setup_dependencies.sh
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - name: Getting LFS files
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          command: git lfs pull
       - name: Build openpilot
         run: scons -j$(nproc)
       - name: Create UI Report

--- a/SConstruct
+++ b/SConstruct
@@ -12,7 +12,7 @@ SCons.Warnings.warningAsException(True)
 
 Decider('MD5-timestamp')
 
-SetOption('num_jobs', max(1, int(os.cpu_count()/2)))
+SetOption('num_jobs', os.cpu_count() or 1)
 
 AddOption('--asan', action='store_true', help='turn on ASAN')
 AddOption('--ubsan', action='store_true', help='turn on UBSan')

--- a/selfdrive/locationd/test/test_paramsd.py
+++ b/selfdrive/locationd/test/test_paramsd.py
@@ -20,11 +20,14 @@ def get_random_live_parameters(CP):
 
 
 class TestParamsd:
+  @classmethod
+  def setup_class(cls):
+    cls.lr = migrate(LogReader(TEST_ROUTE), [migrate_carParams])
+    cls.CP = next(m for m in cls.lr if m.which() == "carParams").carParams
+
   def test_read_saved_params(self):
     params = Params()
-
-    lr = migrate(LogReader(TEST_ROUTE), [migrate_carParams])
-    CP = next(m for m in lr if m.which() == "carParams").carParams
+    CP = self.CP
 
     msg = get_random_live_parameters(CP)
     params.put("LiveParametersV2", msg.to_bytes())
@@ -41,9 +44,7 @@ class TestParamsd:
   # TODO Remove this test after the support for old format is removed
   def test_read_saved_params_old_format(self):
     params = Params()
-
-    lr = migrate(LogReader(TEST_ROUTE), [migrate_carParams])
-    CP = next(m for m in lr if m.which() == "carParams").carParams
+    CP = self.CP
 
     msg = get_random_live_parameters(CP)
     params.put("LiveParameters", msg.liveParameters.to_dict())

--- a/selfdrive/test/longitudinal_maneuvers/plant.py
+++ b/selfdrive/test/longitudinal_maneuvers/plant.py
@@ -25,6 +25,7 @@ class Plant:
       Plant.car_state = messaging.pub_sock('carState')
       Plant.plan = messaging.sub_sock('longitudinalPlan')
       Plant.messaging_initialized = True
+      time.sleep(0.1)
 
     self.v_lead_prev = 0.0
 
@@ -45,7 +46,6 @@ class Plant:
 
     self.rk = Ratekeeper(self.rate, print_delay_threshold=100.0)
     self.ts = 1. / self.rate
-    time.sleep(0.1)
     self.sm = messaging.SubMaster(['longitudinalPlan'])
 
     from opendbc.car.honda.values import CAR

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -13,7 +13,7 @@ class TestSoundd:
     sm = SubMaster(['selfdriveState'])
     pm = PubMaster(['selfdriveState'])
 
-    for _ in range(100):
+    for _ in range(10):
       cs = messaging.new_message('selfdriveState')
       cs.selfdriveState.enabled = True
 
@@ -25,9 +25,8 @@ class TestSoundd:
 
       assert not check_selfdrive_timeout_alert(sm)
 
-    for _ in range(SELFDRIVE_STATE_TIMEOUT * 110):
-      sm.update(0)
-      time.sleep(0.01)
+    time.sleep(SELFDRIVE_STATE_TIMEOUT + 0.5)
+    sm.update(0)
 
     assert check_selfdrive_timeout_alert(sm)
 

--- a/system/loggerd/tests/test_uploader.py
+++ b/system/loggerd/tests/test_uploader.py
@@ -73,7 +73,7 @@ class TestUploader(UploaderTestCase):
 
     self.start_thread()
     # allow enough time that files could upload twice if there is a bug in the logic
-    time.sleep(1)
+    time.sleep(0.25)
     self.join_thread()
 
     exp_order = self.gen_order([self.seg_num], [])
@@ -91,7 +91,7 @@ class TestUploader(UploaderTestCase):
 
     self.start_thread()
     # allow enough time that files could upload twice if there is a bug in the logic
-    time.sleep(1)
+    time.sleep(0.25)
     self.join_thread()
 
     exp_order = self.gen_order([self.seg_num], [])
@@ -110,7 +110,7 @@ class TestUploader(UploaderTestCase):
 
     self.start_thread()
     # allow enough time that files could upload twice if there is a bug in the logic
-    time.sleep(1)
+    time.sleep(0.25)
     self.join_thread()
 
     exp_order = self.gen_order([self.seg_num], [])
@@ -137,7 +137,7 @@ class TestUploader(UploaderTestCase):
 
     self.start_thread()
     # allow enough time that files could upload twice if there is a bug in the logic
-    time.sleep(1)
+    time.sleep(0.25)
     self.join_thread()
 
     assert len(log_handler.upload_ignored) == 0, "Some files were ignored"
@@ -155,7 +155,7 @@ class TestUploader(UploaderTestCase):
     f_paths = self.gen_files(lock=True, boot=False)
 
     # allow enough time that files should have been uploaded if they would be uploaded
-    time.sleep(1)
+    time.sleep(0.25)
     self.join_thread()
 
     for f_path in f_paths:
@@ -168,7 +168,7 @@ class TestUploader(UploaderTestCase):
 
     self.start_thread()
     # allow enough time that files could upload twice if there is a bug in the logic
-    time.sleep(1)
+    time.sleep(0.25)
     self.join_thread()
 
     assert len(log_handler.upload_order) == 0, "File uploaded again"

--- a/tools/setup_dependencies.sh
+++ b/tools/setup_dependencies.sh
@@ -88,11 +88,9 @@ function install_python_deps() {
     PATH="$UV_BIN:$PATH"
   fi
 
-  if [[ -z "$CI" ]]; then
-    echo "updating uv..."
-    # ok to fail, can also fail due to installing with brew
-    uv self update || true
-  fi
+  echo "updating uv..."
+  # ok to fail, can also fail due to installing with brew
+  uv self update || true
 
   echo "installing python packages..."
   uv sync --frozen --all-extras

--- a/tools/setup_dependencies.sh
+++ b/tools/setup_dependencies.sh
@@ -88,12 +88,14 @@ function install_python_deps() {
     PATH="$UV_BIN:$PATH"
   fi
 
-  echo "updating uv..."
-  # ok to fail, can also fail due to installing with brew
-  uv self update || true
+  if [[ -z "$CI" ]]; then
+    echo "updating uv..."
+    # ok to fail, can also fail due to installing with brew
+    uv self update || true
+  fi
 
   echo "installing python packages..."
-  uv sync --frozen --all-extras
+  uv sync --frozen --all-extras ${CI:+--no-install-project}
   source .venv/bin/activate
 
   if [[ "$(uname)" == 'Darwin' ]]; then

--- a/tools/setup_dependencies.sh
+++ b/tools/setup_dependencies.sh
@@ -95,7 +95,7 @@ function install_python_deps() {
   fi
 
   echo "installing python packages..."
-  uv sync --frozen --all-extras ${CI:+--no-install-project}
+  uv sync --frozen --all-extras
   source .venv/bin/activate
 
   if [[ "$(uname)" == 'Darwin' ]]; then


### PR DESCRIPTION
## Changes

| Change | Before | After |
|--------|--------|-------|
| SConstruct default parallelism | `cpu_count/2` | `cpu_count` |
| `uv self update` in CI | runs every time | skipped (just installed) |
| UI replay variants | sequential | parallel |
| bytecode precompilation | `pytest --collect-only` (7s) | `compileall -j0` (6s) |
| `test_longitudinal` Plant sleep | 0.1s per Plant (~60 inits) | 0.1s once |
| `test_paramsd` LogReader | fetched same route twice | shared via `setup_class` |
| `test_soundd` timeout test | 100+550 polling iterations | 10 iters + direct sleep |
| `test_uploader` sleeps | `sleep(1)` × 6 tests | `sleep(0.25)` × 6 tests |

### Job-level timings (namespace runners)

| Job | master | PR |
|-----|--------|----|
| build macOS | 66s | 49-52s |
| static analysis | 45s | 34-37s |
| build release | 75s | ~1m10s |
| Create UI Report | 1m54s | 1m34-42s |
| process replay | 2m6s | 1m44-51s |
| unit tests (pytest only) | 49.3s | 43.8-53s* |

*high variance on shared runners — test_uploader dropped out of top-20 slowest, longitudinal tests dropped ~2.8s each