### PR TITLE
ui: Add missing software panel translations

### DIFF
--- a/selfdrive/ui/translations/app_en.po
+++ b/selfdrive/ui/translations/app_en.po
@@ -793,7 +793,7 @@ msgstr "Review the rules, features, and limitations of openpilot"
 #: selfdrive/ui/layouts/settings/software.py:61
 #, python-format
 msgid "SELECT"
-msgstr ""
+msgstr "SELECT"
 
 #: selfdrive/ui/layouts/settings/developer.py:53
 #, python-format
@@ -813,7 +813,7 @@ msgstr "Select"
 #: selfdrive/ui/layouts/settings/software.py:183
 #, python-format
 msgid "Select a branch"
-msgstr ""
+msgstr "Select a branch"
 
 #: selfdrive/ui/layouts/settings/device.py:91
 #, python-format
@@ -870,7 +870,7 @@ msgstr "TEMP"
 #: selfdrive/ui/layouts/settings/software.py:61
 #, python-format
 msgid "Target Branch"
-msgstr ""
+msgstr "Target Branch"
 
 #: system/ui/widgets/network.py:124
 #, python-format


### PR DESCRIPTION
Add missing translations for target branch in the big UI software panel:

### Before:
<img width="2123" height="1062" alt="2026-02-27_17-54" src="https://github.com/user-attachments/assets/e016a32f-e358-4c9e-882c-cc4ff079d528" />

### After:
<img width="2117" height="1061" alt="2026-02-27_17-52" src="https://github.com/user-attachments/assets/6ddb5ca9-22b5-431c-bf55-9674b70f27ef" />
