### PR TITLE
ui replay: Add progress bar

### DIFF
--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -4,9 +4,9 @@ import argparse
 import coverage
 import pyray as rl
 from tqdm import tqdm
-
 from typing import Literal
 from collections.abc import Callable
+
 from cereal.messaging import PubMaster
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix
@@ -62,7 +62,6 @@ def run_replay(variant: LayoutVariant) -> None:
   with tqdm(total=len(script), desc="Replaying") as pbar:
     for _ in gui_app.render():
       # Handle all events for the current frame
-      prev_index = script_index
       while script_index < len(script) and script[script_index][0] == frame:
         _, event = script[script_index]
         # Call setup function, if any
@@ -77,7 +76,7 @@ def run_replay(variant: LayoutVariant) -> None:
           send_fn = event.send_fn
         # Move to next script event
         script_index += 1
-      pbar.update(script_index - prev_index)
+        pbar.update(1)
 
       # Keep sending cereal messages for persistent states (onroad, alerts)
       if send_fn:

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -3,6 +3,7 @@ import os
 import argparse
 import coverage
 import pyray as rl
+from tqdm import tqdm
 
 from typing import Literal
 from collections.abc import Callable
@@ -58,33 +59,36 @@ def run_replay(variant: LayoutVariant) -> None:
   rl.get_time = lambda: frame / FPS
 
   # Main loop to replay events and render frames
-  for _ in gui_app.render():
-    # Handle all events for the current frame
-    while script_index < len(script) and script[script_index][0] == frame:
-      _, event = script[script_index]
-      # Call setup function, if any
-      if event.setup:
-        event.setup()
-      # Send mouse events to the application
-      if event.mouse_events:
-        with gui_app._mouse._lock:
-          gui_app._mouse._events.extend(event.mouse_events)
-      # Update persistent send function
-      if event.send_fn is not None:
-        send_fn = event.send_fn
-      # Move to next script event
-      script_index += 1
+  with tqdm(total=len(script), desc="Replaying") as pbar:
+    for _ in gui_app.render():
+      # Handle all events for the current frame
+      prev_index = script_index
+      while script_index < len(script) and script[script_index][0] == frame:
+        _, event = script[script_index]
+        # Call setup function, if any
+        if event.setup:
+          event.setup()
+        # Send mouse events to the application
+        if event.mouse_events:
+          with gui_app._mouse._lock:
+            gui_app._mouse._events.extend(event.mouse_events)
+        # Update persistent send function
+        if event.send_fn is not None:
+          send_fn = event.send_fn
+        # Move to next script event
+        script_index += 1
+      pbar.update(script_index - prev_index)
 
-    # Keep sending cereal messages for persistent states (onroad, alerts)
-    if send_fn:
-      send_fn()
+      # Keep sending cereal messages for persistent states (onroad, alerts)
+      if send_fn:
+        send_fn()
 
-    ui_state.update()
+      ui_state.update()
 
-    frame += 1
+      frame += 1
 
-    if script_index >= len(script):
-      break
+      if script_index >= len(script):
+        break
 
   gui_app.close()
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -59,7 +59,7 @@ def run_replay(variant: LayoutVariant) -> None:
   rl.get_time = lambda: frame / FPS
 
   # Main loop to replay events and render frames
-  with tqdm(total=len(script), desc="Replaying") as pbar:
+  with tqdm(total=script[-1][0], desc="Replaying", unit="frame") as pbar:
     for _ in gui_app.render():
       # Handle all events for the current frame
       while script_index < len(script) and script[script_index][0] == frame:
@@ -76,7 +76,6 @@ def run_replay(variant: LayoutVariant) -> None:
           send_fn = event.send_fn
         # Move to next script event
         script_index += 1
-        pbar.update(1)
 
       # Keep sending cereal messages for persistent states (onroad, alerts)
       if send_fn:
@@ -85,6 +84,7 @@ def run_replay(variant: LayoutVariant) -> None:
       ui_state.update()
 
       frame += 1
+      pbar.update(1)
 
       if script_index >= len(script):
         break

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -59,7 +59,7 @@ def run_replay(variant: LayoutVariant) -> None:
   rl.get_time = lambda: frame / FPS
 
   # Main loop to replay events and render frames
-  with tqdm(total=script[-1][0], desc="Replaying", unit="frame") as pbar:
+  with tqdm(total=script[-1][0], desc="Replaying", unit="frame", disable=bool(os.getenv("CI"))) as pbar:
     for _ in gui_app.render():
       # Handle all events for the current frame
       while script_index < len(script) and script[script_index][0] == frame:

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -3,10 +3,10 @@ import os
 import argparse
 import coverage
 import pyray as rl
+
 from tqdm import tqdm
 from typing import Literal
 from collections.abc import Callable
-
 from cereal.messaging import PubMaster
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -59,7 +59,7 @@ def run_replay(variant: LayoutVariant) -> None:
   rl.get_time = lambda: frame / FPS
 
   # Main loop to replay events and render frames
-  with tqdm(total=script[-1][0], desc="Replaying", unit="frame", disable=bool(os.getenv("CI"))) as pbar:
+  with tqdm(total=script[-1][0] + 1, desc="Replaying", unit="frame", disable=bool(os.getenv("CI"))) as pbar:
     for _ in gui_app.render():
       # Handle all events for the current frame
       while script_index < len(script) and script[script_index][0] == frame:


### PR DESCRIPTION
Adds a progress bar to the diff replay. Really useful when you're running the replay over and over while making adjustments to the script, especially as it gets longer. The expected duration doesn't help much because it renders faster than real-time in headless mode.

### Example:
```
Built replay script with 46 events and 814 frames (13.57 seconds)
Replaying:  23%|███████████████▌                                                    | 187/814 [00:04<00:12, 48.42frame/s]
```