### PR TITLE
ui: delay click callback

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/device.py
+++ b/selfdrive/ui/mici/layouts/settings/device.py
@@ -117,6 +117,8 @@ class PairBigButton(BigButton):
     return 64
 
   def _update_state(self):
+    super()._update_state()
+
     if ui_state.prime_state.is_paired():
       self.set_text("paired")
       if ui_state.prime_state.is_prime():
@@ -164,6 +166,8 @@ class UpdateOpenpilotBigButton(BigButton):
       self.set_enabled(True)
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
+    super()._handle_mouse_release(mouse_pos)
+
     if not system_time_valid():
       dlg = BigDialog(tr("Please connect to Wi-Fi to update"), "")
       gui_app.push_widget(dlg)
@@ -191,6 +195,8 @@ class UpdateOpenpilotBigButton(BigButton):
       self.set_text("update openpilot")
 
   def _update_state(self):
+    super()._update_state()
+
     if ui_state.started:
       self.set_enabled(False)
       return

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -215,6 +215,8 @@ class WifiButton(BigButton):
     return self._wifi_manager.connected_ssid == self._network.ssid
 
   def _update_state(self):
+    super()._update_state()
+
     if any((self._network_missing, self._is_connecting, self._is_connected, self._network_forgetting,
             self._network.security_type == SecurityType.UNSUPPORTED)):
       self.set_enabled(False)

--- a/selfdrive/ui/mici/widgets/button.py
+++ b/selfdrive/ui/mici/widgets/button.py
@@ -36,6 +36,7 @@ class BigCircleButton(Widget):
     # State
     self.set_rect(rl.Rectangle(0, 0, 180, 180))
     self._scale_filter = BounceFilter(1.0, 0.1, 1 / gui_app.target_fps)
+    self._click_delay = 0.075
 
     # Icons
     self._txt_icon = gui_app.texture(icon, *icon_size)
@@ -117,6 +118,7 @@ class BigButton(Widget):
     self.set_icon(icon)
 
     self._scale_filter = BounceFilter(1.0, 0.1, 1 / gui_app.target_fps)
+    self._click_delay = 0.075
     self._shake_start: float | None = None
 
     self._rotate_icon_t: float | None = None

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -174,8 +174,8 @@ class Widget(abc.ABC):
     """Optionally update the widget's non-layout state. This is called before rendering."""
     if self._click_release_time is not None and self._should_fire_click():
       self._click_release_time = None
-      if self._click_callback:
-        self._click_callback()
+      # if self._click_callback:
+      #   self._click_callback()
 
   @abc.abstractmethod
   def _render(self, rect: rl.Rectangle) -> bool | int | None:
@@ -190,6 +190,8 @@ class Widget(abc.ABC):
   def _handle_mouse_release(self, mouse_pos: MousePos) -> None:
     """Optionally handle mouse release events."""
     self._click_release_time = rl.get_time()
+    if self._click_callback:
+      self._click_callback()
 
   def _handle_mouse_event(self, mouse_event: MouseEvent) -> None:
     """Optionally handle mouse events. This is called before rendering."""

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -53,7 +53,7 @@ class Widget(abc.ABC):
 
   @property
   def is_pressed(self) -> bool:
-    # if actually pressed or delaying click callback
+    # if actually pressed or holding after release
     return any(self.__is_pressed) or self._click_release_time is not None
 
   @property

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -30,6 +30,8 @@ class Widget(abc.ABC):
     self._enabled: bool | Callable[[], bool] = True
     self._is_visible: bool | Callable[[], bool] = True
     self._touch_valid_callback: Callable[[], bool] | None = None
+    self._click_delay: float | None = None  # seconds to hold is_pressed and delay click callback
+    self._click_release_time: float | None = None
     self._click_callback: Callable[[], None] | None = None
     self._multi_touch = False
     self.__was_awake = True
@@ -51,7 +53,8 @@ class Widget(abc.ABC):
 
   @property
   def is_pressed(self) -> bool:
-    return any(self.__is_pressed)
+    # if actually pressed or delaying click callback
+    return any(self.__is_pressed) or self._click_release_time is not None
 
   @property
   def enabled(self) -> bool:
@@ -169,6 +172,10 @@ class Widget(abc.ABC):
 
   def _update_state(self):
     """Optionally update the widget's non-layout state. This is called before rendering."""
+    if self._click_release_time is not None and self._should_fire_click():
+      self._click_release_time = None
+      if self._click_callback:
+        self._click_callback()
 
   @abc.abstractmethod
   def _render(self, rect: rl.Rectangle) -> bool | int | None:
@@ -182,12 +189,17 @@ class Widget(abc.ABC):
 
   def _handle_mouse_release(self, mouse_pos: MousePos) -> None:
     """Optionally handle mouse release events."""
-    if self._click_callback:
-      self._click_callback()
+    self._click_release_time = rl.get_time()
 
   def _handle_mouse_event(self, mouse_event: MouseEvent) -> None:
     """Optionally handle mouse events. This is called before rendering."""
     # Default implementation does nothing, can be overridden by subclasses
+
+  def _should_fire_click(self) -> bool:
+    """Waits for click delay before firing click callback, used for click animations."""
+    if self._click_delay is None:
+      return True
+    return (rl.get_time() - self._click_release_time) >= self._click_delay
 
   def show_event(self):
     """Optionally handle show event. Parent must manually call this"""

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -30,7 +30,7 @@ class Widget(abc.ABC):
     self._enabled: bool | Callable[[], bool] = True
     self._is_visible: bool | Callable[[], bool] = True
     self._touch_valid_callback: Callable[[], bool] | None = None
-    self._click_delay: float | None = None  # seconds to hold is_pressed and delay click callback
+    self._click_delay: float | None = None  # seconds to hold is_pressed after release
     self._click_release_time: float | None = None
     self._click_callback: Callable[[], None] | None = None
     self._multi_touch = False
@@ -100,6 +100,9 @@ class Widget(abc.ABC):
       self.set_rect(rect)
 
     self._update_state()
+
+    if self._click_release_time is not None and rl.get_time() >= self._click_release_time:
+      self._click_release_time = None
 
     if not self.is_visible:
       return None
@@ -172,10 +175,6 @@ class Widget(abc.ABC):
 
   def _update_state(self):
     """Optionally update the widget's non-layout state. This is called before rendering."""
-    if self._click_release_time is not None and self._should_fire_click():
-      self._click_release_time = None
-      # if self._click_callback:
-      #   self._click_callback()
 
   @abc.abstractmethod
   def _render(self, rect: rl.Rectangle) -> bool | int | None:
@@ -189,19 +188,14 @@ class Widget(abc.ABC):
 
   def _handle_mouse_release(self, mouse_pos: MousePos) -> None:
     """Optionally handle mouse release events."""
-    self._click_release_time = rl.get_time()
+    if self._click_delay is not None:
+      self._click_release_time = rl.get_time() + self._click_delay
     if self._click_callback:
       self._click_callback()
 
   def _handle_mouse_event(self, mouse_event: MouseEvent) -> None:
     """Optionally handle mouse events. This is called before rendering."""
     # Default implementation does nothing, can be overridden by subclasses
-
-  def _should_fire_click(self) -> bool:
-    """Waits for click delay before firing click callback, used for click animations."""
-    if self._click_delay is None:
-      return True
-    return (rl.get_time() - self._click_release_time) >= self._click_delay
 
   def show_event(self):
     """Optionally handle show event. Parent must manually call this"""


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/37501

same min pressed animation time as the mici keyboard. we don't have to delay for minimize animation since nav stack makes it look good

before this, you couldn't see click animation on device for bigbuttons if clicking fast

before:

https://github.com/user-attachments/assets/a277e6a8-47f2-4e9e-b792-550517484e22

after:

https://github.com/user-attachments/assets/7831eebb-bc7d-40df-8576-bee2175309aa
