### PR TITLE
skip PythonProcess preimport on macOS

### DIFF
--- a/system/manager/process.py
+++ b/system/manager/process.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import platform
 import signal
 import time
 import subprocess
@@ -178,7 +179,7 @@ class PythonProcess(ManagerProcess):
     self.restart_if_crash = restart_if_crash
 
   def prepare(self) -> None:
-    if self.enabled:
+    if self.enabled and platform.system() != "Darwin":
       cloudlog.info(f"preimporting {self.module}")
       importlib.import_module(self.module)
 


### PR DESCRIPTION
Fixes #37504

`manager.py` module-level imports create OS threads (sentry) before `unblock_stdout()` calls
`os.forkpty()`. The forkpty child -- which never exec's -- then runs `prepare()`, which
preimports `selfdrive.ui.ui` → raylib → CoreFoundation. macOS kills the child (SIGSEGV)
because CoreFoundation was initialized inside a fork-without-exec of a multi-threaded process.

This skips preimport on Darwin. Modules are still imported normally when each child starts
via multiprocessing spawn (fork+exec → fresh interpreter). Only startup speed is affected
on macOS, no functional change on Linux.

`OBJC_DISABLE_INITIALIZE_FORK_SAFETY` doesn't work on macOS 14+. A full fix would be
reworking `unblock_stdout()` to avoid forkpty on macOS, but that's a bigger change.