### PR TITLE
messaging: integrate msgq runtime logger API

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -189,11 +189,8 @@ common = [_common, 'json11', 'zmq']
 Export('common')
 
 # Build messaging (cereal + msgq + socketmaster + their dependencies)
-# Enable swaglog include in submodules
-env_swaglog = env.Clone()
-env_swaglog['CXXFLAGS'].append('-DSWAGLOG="\\"common/swaglog.h\\""')
-SConscript(['msgq_repo/SConscript'], exports={'env': env_swaglog})
-SConscript(['opendbc_repo/SConscript'], exports={'env': env_swaglog})
+SConscript(['msgq_repo/SConscript'], exports={'env': env})
+SConscript(['opendbc_repo/SConscript'], exports={'env': env})
 
 SConscript(['cereal/SConscript'])
 

--- a/cereal/messaging/__init__.py
+++ b/cereal/messaging/__init__.py
@@ -11,9 +11,18 @@ from typing import Optional, List, Union, Dict
 
 from cereal import log
 from cereal.services import SERVICE_LIST
+from openpilot.common.swaglog import cloudlog
 from openpilot.common.utils import MovingAverage
 
 NO_TRAVERSAL_LIMIT = 2**64-1
+
+
+def _msgq_logger(level: int, file: str, line: int, message: str) -> None:
+  cloudlog.log(level, f"[msgq] {file}:{line} {message}")
+
+
+if hasattr(msgq, "set_logger"):
+  msgq.set_logger(_msgq_logger)
 
 
 def pub_sock(endpoint: str) -> PubSocket:

--- a/cereal/messaging/__init__.py
+++ b/cereal/messaging/__init__.py
@@ -24,6 +24,13 @@ def _msgq_logger(level: int, file: str, line: int, message: str) -> None:
 if hasattr(msgq, "set_logger"):
   msgq.set_logger(_msgq_logger)
 
+try:
+  from msgq import visionipc as msgq_visionipc
+  if hasattr(msgq_visionipc, "set_logger"):
+    msgq_visionipc.set_logger(_msgq_logger)
+except ImportError:
+  pass
+
 
 def pub_sock(endpoint: str) -> PubSocket:
   service = SERVICE_LIST.get(endpoint)

--- a/common/swaglog.cc
+++ b/common/swaglog.cc
@@ -15,9 +15,22 @@
 #include "common/version.h"
 #include "system/hardware/hw.h"
 
+extern "C" {
+typedef void (*msgq_logger_callback_t)(int level, const char *file, int line, const char *msg);
+void msgq_set_logger(msgq_logger_callback_t callback) __attribute__((weak));
+}
+
+static void msgq_log_to_cloudlog(int level, const char *file, int line, const char *msg) {
+  cloudlog_e(level, file, line, "msgq", "%s", msg);
+}
+
 class SwaglogState {
 public:
   SwaglogState() {
+    if (msgq_set_logger != nullptr) {
+      msgq_set_logger(msgq_log_to_cloudlog);
+    }
+
     zctx = zmq_ctx_new();
     sock = zmq_socket(zctx, ZMQ_PUSH);
 

--- a/system/camerad/SConscript
+++ b/system/camerad/SConscript
@@ -1,6 +1,6 @@
 Import('env', 'arch', 'messaging', 'common', 'visionipc')
 
-libs = [common, messaging, visionipc]
+libs = [common, visionipc, messaging]
 
 if arch != "Darwin":
   camera_obj = env.Object(['cameras/camera_qcom2.cc', 'cameras/camera_common.cc', 'cameras/spectra.cc',

--- a/system/loggerd/SConscript
+++ b/system/loggerd/SConscript
@@ -1,6 +1,6 @@
 Import('env', 'arch', 'messaging', 'common', 'visionipc')
 
-libs = [common, messaging, visionipc,
+libs = [common, visionipc, messaging,
         'avformat', 'avcodec', 'swresample', 'avutil', 'x264',
         'yuv', 'pthread', 'z', 'm', 'zstd']
 

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -65,7 +65,7 @@ qt_env['LIBPATH'] += ['#selfdrive/ui', ]
 qt_env['LIBS'] = qt_libs
 
 base_frameworks = qt_env['FRAMEWORKS']
-base_libs = [common, messaging, cereal, visionipc, 'm', 'ssl', 'crypto', 'pthread'] + qt_env["LIBS"]
+base_libs = [common, cereal, visionipc, messaging, 'm', 'ssl', 'crypto', 'pthread'] + qt_env["LIBS"]
 
 if arch == "Darwin":
   base_frameworks.append('QtCharts')
@@ -81,7 +81,7 @@ if arch == "Darwin":
   cabana_env['CPPPATH'] += [f"{brew_prefix}/include"]
   cabana_env['LIBPATH'] += [f"{brew_prefix}/lib"]
 
-cabana_libs = [cereal, messaging, visionipc, replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'zstd', 'curl', 'yuv', 'usb-1.0'] + qt_libs
+cabana_libs = [cereal, visionipc, messaging, replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'zstd', 'curl', 'yuv', 'usb-1.0'] + qt_libs
 opendbc_path = '-DOPENDBC_FILE_PATH=\'"%s"\'' % (cabana_env.Dir("../../opendbc/dbc").abspath)
 cabana_env['CXXFLAGS'] += [opendbc_path]
 

--- a/tools/replay/SConscript
+++ b/tools/replay/SConscript
@@ -4,7 +4,7 @@ replay_env = env.Clone()
 replay_env['CCFLAGS'] += ['-Wno-deprecated-declarations']
 
 base_frameworks = []
-base_libs = [common, messaging, cereal, visionipc, 'm', 'ssl', 'crypto', 'pthread']
+base_libs = [common, cereal, visionipc, messaging, 'm', 'ssl', 'crypto', 'pthread']
 
 replay_lib_src = ["replay.cc", "consoleui.cc", "camera.cc", "filereader.cc", "logreader.cc", "framereader.cc",
                   "route.cc", "util.cc", "seg_mgr.cc", "timeline.cc", "api.cc"]


### PR DESCRIPTION
## Summary
- consume msgq runtime logger API from https://github.com/commaai/msgq/pull/679
- remove the `SWAGLOG` compile-time include override for `msgq_repo` in `SConstruct`
- register msgq C++ logs to cloudlog via `common/swaglog.cc` using a weak `msgq_set_logger` hook
- register msgq Python logs in `cereal.messaging` via `msgq.set_logger()`
- fix static-link ordering for targets that link both `visionipc` and `msgq` symbols

## Validation
- `scons -j8 msgq_repo/msgq/ipc_pyx.so msgq_repo/msgq/visionipc/visionipc_pyx.so system/loggerd/encoderd tools/replay/replay`
- `PYTHONPATH=. python - <<'PY' ... import cereal.messaging; VisionIpcServer/VisionIpcClient connect smoke test ... PY`
- `PYTHONPATH=. pytest -q cereal/messaging/tests/test_pub_sub_master.py`
