### PR TITLE
fix nigthly build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         running-workflow-name: 'build master-ci'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         check-regexp: ^((?!.*(build prebuilt|create badges).*).)*$
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0


### PR DESCRIPTION
Reverts the update to v6 of the checkout action since it breaks auth

https://github.com/actions/checkout#whats-new