### PR TITLE
cabana: add imgui vendored dependency

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -48,6 +48,7 @@ if arch != "larch64":
   import ncurses
   import openssl3
   import python3_dev
+  import imgui
   import raylib
   import zeromq
   import zstd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
 
   # ui
   "raylib @ git+https://github.com/commaai/dependencies.git@releases#subdirectory=raylib",
+  "imgui @ git+https://github.com/commaai/dependencies.git@imgui-package#subdirectory=imgui",
   "qrcode",
   "jeepney",
 ]

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -2,6 +2,9 @@ import subprocess
 import os
 import shutil
 
+import imgui
+import raylib
+
 Import('env', 'arch', 'common', 'messaging', 'visionipc', 'cereal')
 
 # Detect Qt - skip build if not available
@@ -79,6 +82,16 @@ cabana_env = qt_env.Clone()
 if arch == "Darwin":
   cabana_env['CPPPATH'] += [f"{brew_prefix}/include"]
   cabana_env['LIBPATH'] += [f"{brew_prefix}/lib"]
+
+# imgui source compilation
+imgui_env = env.Clone()
+imgui_env['CPPPATH'] += [imgui.INCLUDE_DIR, raylib.INCLUDE_DIR]
+imgui_srcs = [os.path.join(imgui.SRC_DIR, f) for f in [
+  'imgui.cpp', 'imgui_draw.cpp', 'imgui_tables.cpp', 'imgui_widgets.cpp', 'imgui_demo.cpp',
+  'implot.cpp', 'implot_items.cpp',
+  'rlImGui.cpp',
+]]
+imgui_lib = imgui_env.Library('imgui', imgui_srcs)
 
 cabana_libs = [cereal, messaging, visionipc, replay_lib, 'avformat', 'avcodec', 'swresample', 'avutil', 'x264', 'z', 'bz2', 'zstd', 'yuv', 'usb-1.0'] + qt_libs
 opendbc_path = '-DOPENDBC_FILE_PATH=\'"%s"\'' % (cabana_env.Dir("../../opendbc/dbc").abspath)

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ wheels = [
 [[package]]
 name = "imgui"
 version = "1.92.7"
-source = { git = "https://github.com/commaai/dependencies.git?subdirectory=imgui&rev=imgui-package#5c0e851a4f6f7c9964acc667ddfb7cffd5459f44" }
+source = { git = "https://github.com/commaai/dependencies.git?subdirectory=imgui&rev=imgui-package#3b62a5f38f24c501fc68cf08b03d2cab85c91125" }
 
 [[package]]
 name = "iniconfig"

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,11 @@ wheels = [
 ]
 
 [[package]]
+name = "imgui"
+version = "1.92.7"
+source = { git = "https://github.com/commaai/dependencies.git?subdirectory=imgui&rev=imgui-package#5c0e851a4f6f7c9964acc667ddfb7cffd5459f44" }
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -801,6 +806,7 @@ dependencies = [
     { name = "eigen" },
     { name = "ffmpeg" },
     { name = "git-lfs" },
+    { name = "imgui" },
     { name = "inputs" },
     { name = "jeepney" },
     { name = "json-rpc" },
@@ -883,6 +889,7 @@ requires-dist = [
     { name = "gcc-arm-none-eabi", marker = "extra == 'dev'", git = "https://github.com/commaai/dependencies.git?subdirectory=gcc-arm-none-eabi&rev=releases" },
     { name = "git-lfs", git = "https://github.com/commaai/dependencies.git?subdirectory=git-lfs&rev=releases" },
     { name = "hypothesis", marker = "extra == 'testing'", specifier = "==6.47.*" },
+    { name = "imgui", git = "https://github.com/commaai/dependencies.git?subdirectory=imgui&rev=imgui-package" },
     { name = "inputs" },
     { name = "jeepney" },
     { name = "jinja2", marker = "extra == 'docs'" },


### PR DESCRIPTION
## Summary
- Add Dear ImGui 1.92.7 (docking branch) + ImPlot 0.18 + rlImGui as vendored dependency
- Source-only package from `commaai/dependencies` — compiled into `imgui.a` in cabana's SConscript
- Existing cabana build unchanged (still Qt-based), imgui available for future use
- Depends on https://github.com/commaai/dependencies/pull/39

## Test plan
- [ ] `uv sync` fetches imgui package successfully
- [ ] `scons tools/cabana/` still builds cabana normally
- [ ] imgui.a compiles from source without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)