### PR TITLE
fix(sim): use getRamImageAs for correct channel order

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_common.py
+++ b/tools/sim/bridge/metadrive/metadrive_common.py
@@ -13,9 +13,9 @@ class CopyRamRGBCamera(RGBCamera):
 
   def get_rgb_array_cpu(self):
     origin_img = self.cpu_texture
-    img = np.frombuffer(origin_img.getRamImage().getData(), dtype=np.uint8)
-    img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), -1))
-    img = img[:,:,:3] # RGBA to RGB
+    img = np.frombuffer(origin_img.getRamImageAs("RGBA").getData(), dtype=np.uint8)
+    img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 4))
+    img = img[:, :, :3]
     # img = np.swapaxes(img, 1, 0)
     img = img[::-1] # Flip on vertical axis
     return img


### PR DESCRIPTION
fixes #37526

`getRamImage()` returns panda3d's internal BGRA byte order. on macOS this means red and blue channels are swapped in the sim camera feed (teal trees, wrong colors everywhere).

`getRamImageAs("RGBA")` explicitly requests RGBA from panda3d, which handles the reordering internally. on linux where the format is already RGBA, this is a no-op.

ref: https://docs.panda3d.org/1.10/python/reference/panda3d.core.Texture#panda3d.core.Texture.getRamImageAs
