### PR TITLE
ui: keyboard goes back on . or /

### DIFF
--- a/selfdrive/ui/mici/widgets/dialog.py
+++ b/selfdrive/ui/mici/widgets/dialog.py
@@ -103,11 +103,12 @@ class BigInputDialog(BigDialogBase):
                hint: str,
                default_text: str = "",
                minimum_length: int = 1,
-               confirm_callback: Callable[[str], None] | None = None):
+               confirm_callback: Callable[[str], None] | None = None,
+               auto_return_to_letters: str = ""):
     super().__init__()
     self._hint_label = UnifiedLabel(hint, font_size=35, text_color=rl.Color(255, 255, 255, int(255 * 0.35)),
                                     font_weight=FontWeight.MEDIUM)
-    self._keyboard = MiciKeyboard()
+    self._keyboard = MiciKeyboard(auto_return_to_letters=auto_return_to_letters)
     self._keyboard.set_text(default_text)
     self._keyboard.set_enabled(lambda: self.enabled and not self.is_dismissing)  # for nav stack + NavWidget
     self._minimum_length = minimum_length

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -623,7 +623,7 @@ class Setup(Widget):
           gui_app.pop_widgets_to(self._software_selection_page, instant=True)  # don't reset sliders
           self._download(url)
 
-      keyboard = BigInputDialog("custom software URL", confirm_callback=handle_keyboard_result)
+      keyboard = BigInputDialog("custom software URL...", confirm_callback=handle_keyboard_result, auto_return_to_letters="./")
       gui_app.push_widget(keyboard)
 
   def _download(self, url: str):

--- a/system/ui/widgets/mici_keyboard.py
+++ b/system/ui/widgets/mici_keyboard.py
@@ -146,8 +146,9 @@ class CapsState(IntEnum):
 
 
 class MiciKeyboard(Widget):
-  def __init__(self):
+  def __init__(self, auto_return_to_letters: str = ""):
     super().__init__()
+    self._auto_return_to_letters = auto_return_to_letters
 
     lower_chars = [
       "qwertyuiop",
@@ -303,6 +304,10 @@ class MiciKeyboard(Widget):
 
         # Reset caps state
         if self._caps_state == CapsState.UPPER:
+          self._set_uppercase(False)
+
+        # Switch back to letters after common URL delimiters
+        if self._closest_key[0].char in self._auto_return_to_letters and self._current_keys in (self._special_keys, self._super_special_keys):
           self._set_uppercase(False)
 
     # ensure minimum selected animation time


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/37264