### PR TITLE
cabana: exclude SocketCAN on macOS

### DIFF
--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -88,12 +88,15 @@ assets_src = "assets/assets.qrc"
 cabana_env.Command(assets, assets_src, f"rcc $SOURCES -o $TARGET")
 cabana_env.Depends(assets, Glob('/assets/*', exclude=[assets, assets_src, "assets/assets.o"]))
 
-cabana_lib = cabana_env.Library("cabana_lib", ['mainwin.cc', 'streams/socketcanstream.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
-                                               'streams/routes.cc', 'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
-                                               'utils/export.cc', 'utils/util.cc', 'utils/elidedlabel.cc',
-                                               'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',
-                                               'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'panda.cc',
-                                               'cameraview.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc', 'tools/routeinfo.cc'], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
+cabana_srcs = ['mainwin.cc', 'streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'binaryview.cc', 'historylog.cc', 'videowidget.cc', 'signalview.cc',
+               'streams/routes.cc', 'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc',
+               'utils/export.cc', 'utils/util.cc', 'utils/elidedlabel.cc',
+               'chart/chartswidget.cc', 'chart/chart.cc', 'chart/signalselector.cc', 'chart/tiplabel.cc', 'chart/sparkline.cc',
+               'commands.cc', 'messageswidget.cc', 'streamselector.cc', 'settings.cc', 'panda.cc',
+               'cameraview.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc', 'tools/routeinfo.cc']
+if arch != "Darwin":
+  cabana_srcs += ['streams/socketcanstream.cc']
+cabana_lib = cabana_env.Library("cabana_lib", cabana_srcs, LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('_cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 
 if GetOption('extras'):

--- a/tools/cabana/cabana.cc
+++ b/tools/cabana/cabana.cc
@@ -5,7 +5,9 @@
 #include "tools/cabana/streams/devicestream.h"
 #include "tools/cabana/streams/pandastream.h"
 #include "tools/cabana/streams/replaystream.h"
+#ifdef __linux__
 #include "tools/cabana/streams/socketcanstream.h"
+#endif
 
 int main(int argc, char *argv[]) {
   QCoreApplication::setApplicationName("Cabana");
@@ -29,9 +31,11 @@ int main(int argc, char *argv[]) {
   cmd_parser.addOption({"msgq", "read can messages from the msgq"});
   cmd_parser.addOption({"panda", "read can messages from panda"});
   cmd_parser.addOption({"panda-serial", "read can messages from panda with given serial", "panda-serial"});
+#ifdef __linux__
   if (SocketCanStream::available()) {
     cmd_parser.addOption({"socketcan", "read can messages from given SocketCAN device", "socketcan"});
   }
+#endif
   cmd_parser.addOption({"zmq", "read can messages from zmq at the specified ip-address", "ip-address"});
   cmd_parser.addOption({"data_dir", "local directory with routes", "data_dir"});
   cmd_parser.addOption({"no-vipc", "do not output video"});
@@ -51,8 +55,10 @@ int main(int argc, char *argv[]) {
       qWarning() << e.what();
       return 0;
     }
+#ifdef __linux__
   } else if (SocketCanStream::available() && cmd_parser.isSet("socketcan")) {
     stream = new SocketCanStream(&app, {.device = cmd_parser.value("socketcan").toStdString()});
+#endif
   } else {
     uint32_t replay_flags = REPLAY_FLAG_NONE;
     if (cmd_parser.isSet("ecam")) replay_flags |= REPLAY_FLAG_ECAM;

--- a/tools/cabana/streamselector.cc
+++ b/tools/cabana/streamselector.cc
@@ -4,11 +4,12 @@
 #include <QLabel>
 #include <QPushButton>
 
-#include "streams/socketcanstream.h"
 #include "tools/cabana/streams/devicestream.h"
 #include "tools/cabana/streams/pandastream.h"
 #include "tools/cabana/streams/replaystream.h"
+#ifdef __linux__
 #include "tools/cabana/streams/socketcanstream.h"
+#endif
 
 StreamSelector::StreamSelector(QWidget *parent) : QDialog(parent) {
   setWindowTitle(tr("Open stream"));
@@ -35,9 +36,11 @@ StreamSelector::StreamSelector(QWidget *parent) : QDialog(parent) {
 
   addStreamWidget(new OpenReplayWidget, tr("&Replay"));
   addStreamWidget(new OpenPandaWidget, tr("&Panda"));
+#ifdef __linux__
   if (SocketCanStream::available()) {
     addStreamWidget(new OpenSocketCanWidget, tr("&SocketCAN"));
   }
+#endif
   addStreamWidget(new OpenDeviceWidget, tr("&Device"));
 
   QObject::connect(btn_box, &QDialogButtonBox::rejected, this, &QDialog::reject);


### PR DESCRIPTION
SocketCAN now uses raw Linux sockets, replacing QtSerialBus. (see #37523)
This broke macOS builds since linux/can.h doesn't exist.