### PR TITLE
Replace ModemManager/mmcli modem flows with modem.py AT helpers

### DIFF
--- a/AUTODEV_REPORT.md
+++ b/AUTODEV_REPORT.md
@@ -1,0 +1,54 @@
+# AUTODEV Report - Issue #37277
+
+## Issue
+- #37277 - Replace ModemManager with modem.py
+- URL: https://github.com/commaai/openpilot/issues/37277
+
+## Changed files
+- `system/hardware/tici/modem.py`
+  - Added lightweight modem helper module with:
+    - serial AT command execution (`at_cmd`)
+    - locked serial context (`ModemPort`) for shared AT access
+    - assistance file upload support (`ModemPort.upload_file`)
+    - state file helpers for `/dev/shm/modem_state.txt` (`read_modem_state`, `write_modem_state`)
+- `system/qcomgpsd/qcomgpsd.py`
+  - Replaced `mmcli` AT command usage with `modem.py` helpers.
+  - Replaced assistance-data injection through `mmcli` with direct AT file upload path.
+  - Updated modem wait logic to use AT helper retries instead of `mmcli` subprocess calls.
+- `system/hardware/hardwared.py`
+  - Removed ModemManager restart loop in hardware state thread.
+- `system/hardware/tici/hardware.py`
+  - Added direct AT fallbacks (via `modem.py`) for modem version/IMEI/temperature retrieval when ModemManager DBus is unavailable.
+  - Made `get_sim_info` resilient when ModemManager is unavailable.
+  - Removed `mmcli` APN clear command from modem configuration path; replaced with direct AT command.
+- `system/qcomgpsd/tests/test_qcomgpsd.py`
+  - Updated integration test flow to use `lte` service / `lte.sh` actions instead of ModemManager service commands.
+  - Removed `mmcli` location-status assertion and replaced with AT-based GNSS state check.
+- `system/hardware/tici/restart_modem.sh`
+  - Removed ModemManager stop/debug usage; now restarts LTE service after modem power cycle.
+- `tests/test_modem_py.py`
+  - Added isolated unit tests for the new `modem.py` state-file helpers.
+
+## Validation commands
+1. RED (pre-implementation):
+   - `uv run --extra testing python -m pytest -q --noconftest -o addopts='' tests/test_modem_py.py`
+2. GREEN (post-implementation):
+   - `uv run --extra testing python -m pytest -q --noconftest -o addopts='' tests/test_modem_py.py`
+3. Lint:
+   - `uv run --extra testing ruff check system/hardware/tici/modem.py system/qcomgpsd/qcomgpsd.py system/hardware/hardwared.py system/hardware/tici/hardware.py system/qcomgpsd/tests/test_qcomgpsd.py tests/test_modem_py.py`
+4. Syntax compile:
+   - `uv run python -m py_compile system/hardware/tici/modem.py system/qcomgpsd/qcomgpsd.py system/hardware/hardwared.py system/hardware/tici/hardware.py system/qcomgpsd/tests/test_qcomgpsd.py tests/test_modem_py.py`
+5. Shell syntax:
+   - `bash -n system/hardware/tici/restart_modem.sh`
+
+## Validation results
+- RED step: failed as expected before implementation (missing `system/hardware/tici/modem.py`).
+- GREEN step: `4 passed`.
+- Ruff: passed (`All checks passed!`).
+- Python compile checks: passed (no output / no errors).
+- Shell syntax check: passed (no output / no errors).
+
+## Risks / follow-ups
+- `system/hardware/tici/hardware.py` still keeps ModemManager DBus primary path and now uses AT fallbacks; full ModemManager removal across all modem functionality is not yet complete.
+- Assistance-data injection now uses direct AT file upload; behavior should be hardware-verified on comma 3X/comma four.
+- Integration tests under `system/qcomgpsd/tests/test_qcomgpsd.py` are hardware-specific and were not executed in this environment.

--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -103,8 +103,6 @@ def hw_state_thread(end_event, hw_queue):
 
   modem_version = None
   modem_configured = False
-  modem_missing_count = 0
-  modem_restart_count = 0
 
   while not end_event.is_set():
     # these are expensive calls. update every 10s
@@ -121,18 +119,6 @@ def hw_state_thread(end_event, hw_queue):
 
           if modem_version is not None:
             cloudlog.event("modem version", version=modem_version)
-
-        if AGNOS and modem_restart_count < 3 and HARDWARE.get_modem_version() is None:
-          # TODO: we may be able to remove this with a MM update
-          # ModemManager's probing on startup can fail
-          # rarely, restart the service to probe again.
-          # Also, AT commands sometimes timeout resulting in ModemManager not
-          # trying to use this modem anymore.
-          modem_missing_count += 1
-          if (modem_missing_count % 4) == 0:
-            modem_restart_count += 1
-            cloudlog.event("restarting ModemManager")
-            os.system("sudo systemctl restart --no-block ModemManager")
 
         tx, rx = HARDWARE.get_modem_data_usage()
 

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -13,6 +13,7 @@ from openpilot.common.gpio import gpio_set, gpio_init, get_irqs_for_action
 from openpilot.system.hardware.base import HardwareBase, LPABase, ThermalConfig, ThermalZone
 from openpilot.system.hardware.tici import iwlist
 from openpilot.system.hardware.tici.lpa import TiciLPA
+from openpilot.system.hardware.tici.modem import at_cmd as modem_at_cmd, read_modem_state
 from openpilot.system.hardware.tici.pins import GPIO
 from openpilot.system.hardware.tici.amplifier import Amplifier
 
@@ -179,18 +180,19 @@ class Tici(HardwareBase):
     return self.bus.get_object(NM, wwan_path)
 
   def get_sim_info(self):
-    modem = self.get_modem()
-    sim_path = modem.Get(MM_MODEM, 'Sim', dbus_interface=DBUS_PROPS, timeout=TIMEOUT)
+    try:
+      modem = self.get_modem()
+      sim_path = modem.Get(MM_MODEM, 'Sim', dbus_interface=DBUS_PROPS, timeout=TIMEOUT)
 
-    if sim_path == "/":
-      return {
-        'sim_id': '',
-        'mcc_mnc': None,
-        'network_type': ["Unknown"],
-        'sim_state': ["ABSENT"],
-        'data_connected': False
-      }
-    else:
+      if sim_path == "/":
+        return {
+          'sim_id': '',
+          'mcc_mnc': None,
+          'network_type': ["Unknown"],
+          'sim_state': ["ABSENT"],
+          'data_connected': False
+        }
+
       sim = self.bus.get_object(MM, sim_path)
       return {
         'sim_id': str(sim.Get(MM_SIM, 'SimIdentifier', dbus_interface=DBUS_PROPS, timeout=TIMEOUT)),
@@ -198,6 +200,14 @@ class Tici(HardwareBase):
         'network_type': ["Unknown"],
         'sim_state': ["READY"],
         'data_connected': modem.Get(MM_MODEM, 'State', dbus_interface=DBUS_PROPS, timeout=TIMEOUT) == MM_MODEM_STATE.CONNECTED,
+      }
+    except Exception:
+      return {
+        'sim_id': '',
+        'mcc_mnc': None,
+        'network_type': ["Unknown"],
+        'sim_state': ["UNKNOWN" if read_modem_state() is not None else "ABSENT"],
+        'data_connected': False,
       }
 
   def get_sim_lpa(self) -> LPABase:
@@ -207,7 +217,18 @@ class Tici(HardwareBase):
     if slot != 0:
       return ""
 
-    return str(self.get_modem().Get(MM_MODEM, 'EquipmentIdentifier', dbus_interface=DBUS_PROPS, timeout=TIMEOUT))
+    try:
+      return str(self.get_modem().Get(MM_MODEM, 'EquipmentIdentifier', dbus_interface=DBUS_PROPS, timeout=TIMEOUT))
+    except Exception:
+      resp = modem_at_cmd("AT+CGSN", timeout=TIMEOUT)
+      if resp is None:
+        return ""
+
+      for line in resp.splitlines():
+        stripped = line.strip()
+        if stripped and stripped not in ("OK", "ERROR") and not stripped.startswith("AT"):
+          return stripped
+      return ""
 
   def get_network_info(self):
     if self.get_device_type() == "mici":
@@ -299,6 +320,14 @@ class Tici(HardwareBase):
       modem = self.get_modem()
       return modem.Get(MM_MODEM, 'Revision', dbus_interface=DBUS_PROPS, timeout=TIMEOUT)
     except Exception:
+      resp = modem_at_cmd("AT+CGMR", timeout=TIMEOUT)
+      if resp is None:
+        return None
+
+      for line in resp.splitlines():
+        stripped = line.strip()
+        if stripped and stripped not in ("OK", "ERROR") and not stripped.startswith("AT"):
+          return stripped
       return None
 
   def get_modem_temperatures(self):
@@ -308,6 +337,18 @@ class Tici(HardwareBase):
       temps = modem.Command("AT+QTEMP", math.ceil(timeout), dbus_interface=MM_MODEM, timeout=timeout)
       return list(filter(lambda t: t != 255, map(int, temps.split(' ')[1].split(','))))
     except Exception:
+      resp = modem_at_cmd("AT+QTEMP", timeout=timeout)
+      if resp is None:
+        return []
+
+      for line in resp.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("+QTEMP:"):
+          data = stripped.removeprefix("+QTEMP:").strip()
+          try:
+            return [t for t in map(int, data.split(',')) if t != 255]
+          except ValueError:
+            return []
       return []
 
 
@@ -459,14 +500,17 @@ class Tici(HardwareBase):
     sim_id = self.get_sim_info().get('sim_id', '')
 
     cmds = []
-    modem = self.get_modem()
+    try:
+      modem = self.get_modem()
+    except Exception:
+      modem = None
 
     # Quectel EG25
     if self.get_device_type() in ("tizi", ):
-      # clear out old blue prime initial APN
-      os.system('mmcli -m any --3gpp-set-initial-eps-bearer-settings="apn="')
-
       cmds += [
+        # clear out old blue prime initial APN
+        'AT+CGDCONT=1,"IPV4V6",""',
+
         # SIM hot swap
         'AT+QSIMDET=1,0',
         'AT+QSIMSTAT=1',
@@ -492,7 +536,10 @@ class Tici(HardwareBase):
 
     for cmd in cmds:
       try:
-        modem.Command(cmd, math.ceil(TIMEOUT), dbus_interface=MM_MODEM, timeout=TIMEOUT)
+        if modem is not None:
+          modem.Command(cmd, math.ceil(TIMEOUT), dbus_interface=MM_MODEM, timeout=TIMEOUT)
+        else:
+          modem_at_cmd(cmd, timeout=TIMEOUT)
       except Exception:
         pass
 

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import fcntl
+import os
+import time
+from collections.abc import Iterable
+from pathlib import Path
+
+import serial
+
+MODEM_STATE_PATH = Path("/dev/shm/modem_state.txt")
+MODEM_LOCK_PATH = Path("/tmp/modem_at.lock")
+DEFAULT_PORTS = ("/dev/ttyUSB2", "/dev/ttyUSB3", "/dev/ttyUSB0", "/dev/ttyACM0")
+DEFAULT_BAUDRATE = 115200
+READ_CHUNK_SIZE = 4096
+
+RESPONSE_TERMINATORS = ("OK", "ERROR", "+CME ERROR", "+CMS ERROR")
+
+
+def read_modem_state(state_path: os.PathLike[str] | str = MODEM_STATE_PATH) -> str | None:
+  try:
+    state = Path(state_path).read_text().strip()
+    return state or None
+  except OSError:
+    return None
+
+
+def write_modem_state(state: str, state_path: os.PathLike[str] | str = MODEM_STATE_PATH) -> None:
+  path = Path(state_path)
+  path.parent.mkdir(parents=True, exist_ok=True)
+  tmp_path = path.with_name(f"{path.name}.tmp")
+  tmp_path.write_text(f"{state}\n")
+  os.replace(tmp_path, path)
+
+
+class ModemPort:
+  def __init__(self, port: str, timeout: float = 1.0, baudrate: int = DEFAULT_BAUDRATE, lock_path: os.PathLike[str] | str = MODEM_LOCK_PATH):
+    self.port = port
+    self.timeout = timeout
+    self.baudrate = baudrate
+    self.lock_path = Path(lock_path)
+    self._serial: serial.Serial | None = None
+    self._lock_file = None
+
+  def __enter__(self):
+    self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+    self._lock_file = self.lock_path.open("w")
+    fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX)
+    self._serial = serial.Serial(self.port, baudrate=self.baudrate, timeout=self.timeout)
+    self._serial.reset_input_buffer()
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    if self._serial is not None:
+      self._serial.close()
+    if self._lock_file is not None:
+      fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_UN)
+      self._lock_file.close()
+
+  def _read_response(self, timeout: float) -> str | None:
+    assert self._serial is not None
+
+    deadline = time.monotonic() + timeout
+    response = bytearray()
+
+    while time.monotonic() < deadline:
+      waiting = max(self._serial.in_waiting, 1)
+      chunk = self._serial.read(min(waiting, READ_CHUNK_SIZE))
+      if chunk:
+        response.extend(chunk)
+        decoded = response.decode("utf-8", errors="ignore")
+        if any(term in decoded for term in RESPONSE_TERMINATORS):
+          return decoded.strip()
+      else:
+        time.sleep(0.01)
+
+    if not response:
+      return None
+    return response.decode("utf-8", errors="ignore").strip()
+
+  def cmd(self, cmd: str, timeout: float = 2.0) -> str | None:
+    assert self._serial is not None
+    self._serial.reset_input_buffer()
+    self._serial.write(f"{cmd}\r\n".encode())
+    return self._read_response(timeout=timeout)
+
+  def upload_file(self, local_path: os.PathLike[str] | str, remote_name: str, timeout: float = 60.0) -> bool:
+    assert self._serial is not None
+
+    payload = Path(local_path).read_bytes()
+    self._serial.reset_input_buffer()
+    self._serial.write(f'AT+QFUPL="{remote_name}",{len(payload)},{int(timeout)}\r\n'.encode())
+
+    connect_deadline = time.monotonic() + min(10.0, timeout)
+    connect_response = bytearray()
+    while time.monotonic() < connect_deadline:
+      waiting = max(self._serial.in_waiting, 1)
+      chunk = self._serial.read(min(waiting, READ_CHUNK_SIZE))
+      if chunk:
+        connect_response.extend(chunk)
+        if b"CONNECT" in connect_response:
+          break
+        if b"ERROR" in connect_response or b"+CME ERROR" in connect_response or b"+CMS ERROR" in connect_response:
+          return False
+      else:
+        time.sleep(0.01)
+    else:
+      return False
+
+    self._serial.write(payload)
+    response = self._read_response(timeout=timeout)
+    if response is None:
+      return False
+    return "OK" in response and "ERROR" not in response
+
+
+def _candidate_ports(port: str | None) -> Iterable[str]:
+  if port is not None:
+    yield port
+    return
+  yield from DEFAULT_PORTS
+
+
+def at_cmd(cmd: str, port: str | None = None, timeout: float = 2.0) -> str | None:
+  for candidate in _candidate_ports(port):
+    try:
+      with ModemPort(candidate, timeout=max(0.2, timeout)) as modem_port:
+        return modem_port.cmd(cmd, timeout=timeout)
+    except (serial.SerialException, PermissionError, OSError):
+      continue
+  return None

--- a/system/hardware/tici/restart_modem.sh
+++ b/system/hardware/tici/restart_modem.sh
@@ -5,7 +5,6 @@
 #nmcli connection modify --temporary lte connection.autoconnect-retries 20
 sudo nmcli connection reload
 
-sudo systemctl stop ModemManager
 nmcli con down lte
 nmcli con down blue-prime
 
@@ -14,5 +13,4 @@ nmcli con down blue-prime
 /usr/comma/lte/lte.sh start
 
 sudo systemctl restart NetworkManager
-#sudo systemctl restart ModemManager
-sudo ModemManager --debug
+sudo systemctl restart lte

--- a/system/qcomgpsd/qcomgpsd.py
+++ b/system/qcomgpsd/qcomgpsd.py
@@ -7,7 +7,6 @@ import math
 import time
 import requests
 import shutil
-import subprocess
 import datetime
 from multiprocessing import Process, Event
 from typing import NoReturn
@@ -20,6 +19,7 @@ from openpilot.common.utils import retry
 from openpilot.common.time_helpers import system_time_valid
 from openpilot.system.hardware.tici.pins import GPIO
 from openpilot.common.swaglog import cloudlog
+from openpilot.system.hardware.tici.modem import ModemPort, at_cmd as modem_at_cmd
 from openpilot.system.qcomgpsd.modemdiag import ModemDiag, DIAG_LOG_F, setup_logs, send_recv
 from openpilot.system.qcomgpsd.structs import (dict_unpacker, position_report, relist,
                                               gps_measurement_report, gps_measurement_report_sv,
@@ -33,6 +33,7 @@ DEBUG = int(os.getenv("DEBUG", "0"))==1
 ASSIST_DATA_FILE = '/tmp/xtra3grc.bin'
 ASSIST_DATA_FILE_DOWNLOAD = ASSIST_DATA_FILE + '.download'
 ASSISTANCE_URL = 'http://xtrapath3.izatcloud.net/xtra3grc.bin'
+GPS_AT_PORT = os.getenv("QCOM_GPS_AT_PORT", "/dev/ttyUSB2")
 
 LOG_TYPES = [
   LOG_GNSS_GPS_MEASUREMENT_REPORT,
@@ -92,7 +93,10 @@ def try_setup_logs(diag, logs):
 
 @retry(attempts=3, delay=1.0)
 def at_cmd(cmd: str) -> str | None:
-  return subprocess.check_output(f"mmcli -m any --timeout 30 --command='{cmd}'", shell=True, encoding='utf8')
+  response = modem_at_cmd(cmd, port=GPS_AT_PORT, timeout=30)
+  if response is None:
+    raise TimeoutError(f"AT command timed out: {cmd}")
+  return response
 
 def gps_enabled() -> bool:
   return "QGPS: 1" in at_cmd("AT+QGPS?")
@@ -131,8 +135,9 @@ def downloader_loop(event):
 
 @retry(attempts=5, delay=0.2, ignore_failure=True)
 def inject_assistance():
-  cmd = f"mmcli -m any --timeout 30 --location-inject-assistance-data={ASSIST_DATA_FILE}"
-  subprocess.check_output(cmd, stderr=subprocess.PIPE, shell=True)
+  with ModemPort(GPS_AT_PORT, timeout=1.0) as modem:
+    if not modem.upload_file(ASSIST_DATA_FILE, "RAM:xtra3grc.bin"):
+      raise RuntimeError("failed to upload assistance data")
   cloudlog.info("successfully loaded assistance data")
 
 @retry(attempts=5, delay=1.0)
@@ -210,10 +215,12 @@ def teardown_quectel(diag):
 def wait_for_modem(cmd="AT+QGPS?"):
   cloudlog.warning("waiting for modem to come up")
   while True:
-    ret = subprocess.call(f"mmcli -m any --timeout 10 --command=\"{cmd}\"", stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
-    if ret == 0:
-      return
-    time.sleep(0.1)
+    try:
+      if at_cmd(cmd) is not None:
+        return
+    except Exception:
+      pass
+    time.sleep(0.5)
 
 
 def main() -> NoReturn:

--- a/system/qcomgpsd/tests/test_qcomgpsd.py
+++ b/system/qcomgpsd/tests/test_qcomgpsd.py
@@ -1,9 +1,7 @@
 import os
 import pytest
-import json
 import time
 import datetime
-import subprocess
 
 import cereal.messaging as messaging
 from openpilot.system.qcomgpsd.qcomgpsd import at_cmd, wait_for_modem
@@ -18,14 +16,14 @@ class TestRawgpsd:
   def setup_class(cls):
     os.environ['GPS_COLD_START'] = '1'
     os.system("sudo systemctl start systemd-resolved")
-    os.system("sudo systemctl restart ModemManager lte")
+    os.system("sudo systemctl restart lte")
     wait_for_modem()
 
   @classmethod
   def teardown_class(cls):
     managed_processes['qcomgpsd'].stop()
     os.system("sudo systemctl restart systemd-resolved")
-    os.system("sudo systemctl restart ModemManager lte")
+    os.system("sudo systemctl restart lte")
 
   def setup_method(self):
     self.sm = messaging.SubMaster(['qcomGnss', 'gpsLocation', 'gnssMeasurements'])
@@ -48,11 +46,11 @@ class TestRawgpsd:
     at_cmd("AT+QGPSDEL=0")
 
   def test_wait_for_modem(self):
-    os.system("sudo systemctl stop ModemManager")
+    os.system("/usr/comma/lte/lte.sh stop_blocking")
     managed_processes['qcomgpsd'].start()
     assert not self._wait_for_output(5)
 
-    os.system("sudo systemctl restart ModemManager")
+    os.system("/usr/comma/lte/lte.sh start")
     assert self._wait_for_output(30)
 
   def test_startup_time(self, subtests):
@@ -71,9 +69,8 @@ class TestRawgpsd:
         time.sleep(s)
         managed_processes['qcomgpsd'].stop()
 
-        ls = subprocess.check_output("mmcli -m any --location-status --output-json", shell=True, encoding='utf-8')
-        loc_status = json.loads(ls)
-        assert set(loc_status['modem']['location']['enabled']) <= {'3gpp-lac-ci'}
+        out = at_cmd("AT+QGPS?")
+        assert "QGPS: 0" in out or "ERROR" in out
 
 
   def check_assistance(self, should_be_loaded):

--- a/tests/test_modem_py.py
+++ b/tests/test_modem_py.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def load_modem_module():
+  module_path = Path(__file__).resolve().parents[1] / "system/hardware/tici/modem.py"
+  spec = importlib.util.spec_from_file_location("modem_module_under_test", module_path)
+  assert spec is not None
+  module = importlib.util.module_from_spec(spec)
+  assert spec.loader is not None
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_modem_module_file_exists():
+  module_path = Path(__file__).resolve().parents[1] / "system/hardware/tici/modem.py"
+  assert module_path.exists()
+
+
+def test_read_modem_state_missing_returns_none(tmp_path):
+  modem = load_modem_module()
+  missing = tmp_path / "missing_state.txt"
+  assert modem.read_modem_state(missing) is None
+
+
+def test_write_and_read_modem_state_roundtrip(tmp_path):
+  modem = load_modem_module()
+  state_path = tmp_path / "modem_state.txt"
+  modem.write_modem_state("CONNECTED", state_path)
+  assert modem.read_modem_state(state_path) == "CONNECTED"
+
+
+def test_read_modem_state_trims_whitespace(tmp_path):
+  modem = load_modem_module()
+  state_path = tmp_path / "modem_state.txt"
+  state_path.write_text("  CONNECTING\n")
+  assert modem.read_modem_state(state_path) == "CONNECTING"


### PR DESCRIPTION
Brief summary:
This PR removes key runtime dependencies on ModemManager/mmcli for modem operations and routes those paths through a new lightweight `modem.py` helper layer using direct AT access. It also updates modem restart/test flows to use LTE service behavior aligned with the new approach.

What changed:
- Added `system/hardware/tici/modem.py` with shared AT helpers: `at_cmd`, locked serial access via `ModemPort`, assistance file upload, and `/dev/shm/modem_state.txt` read/write helpers.
- Updated `system/qcomgpsd/qcomgpsd.py` to replace mmcli-based AT calls and assistance-data injection with `modem.py` helper calls and retry-based AT waits.
- Removed the ModemManager restart retry loop from `system/hardware/hardwared.py`.
- Updated `system/hardware/tici/hardware.py` to gracefully handle ModemManager DBus unavailability by adding AT fallbacks for IMEI/version/temperature, making `get_sim_info` resilient, and replacing APN clear mmcli usage with direct `AT+CGDCONT`.
- Updated `system/hardware/tici/restart_modem.sh` to restart LTE service after modem power cycling instead of controlling ModemManager.
- Updated `system/qcomgpsd/tests/test_qcomgpsd.py` to use LTE service actions and AT-based GNSS status checks.
- Added `tests/test_modem_py.py` unit coverage for modem state-file helpers.
- Added `AUTODEV_REPORT.md` documenting implementation, validation, and follow-ups.

Validation done:
- `uv run --extra testing python -m pytest -q --noconftest -o addopts='' tests/test_modem_py.py` (post-change): 4 passed.
- `uv run --extra testing ruff check system/hardware/tici/modem.py system/qcomgpsd/qcomgpsd.py system/hardware/hardwared.py system/hardware/tici/hardware.py system/qcomgpsd/tests/test_qcomgpsd.py tests/test_modem_py.py`: passed.
- `uv run python -m py_compile system/hardware/tici/modem.py system/qcomgpsd/qcomgpsd.py system/hardware/hardwared.py system/hardware/tici/hardware.py system/qcomgpsd/tests/test_qcomgpsd.py tests/test_modem_py.py`: passed.
- `bash -n system/hardware/tici/restart_modem.sh`: passed.

Risks/notes:
- `system/hardware/tici/hardware.py` still uses ModemManager DBus as the primary path with AT fallback; full ModemManager removal is not complete in this change.
- Assistance-data upload now uses direct AT file upload and should be hardware-verified on comma 3X/comma four.
- `system/qcomgpsd/tests/test_qcomgpsd.py` contains hardware-specific integration coverage that was not executed in this environment.