### PR TITLE
add explicit include for cstdint instead of relying on leaky include

### DIFF
--- a/third_party/json11/json11.cpp
+++ b/third_party/json11/json11.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <limits>
+#include <cstdint>
 
 namespace json11 {
 


### PR DESCRIPTION
The json11 library currently relies on a leaky include of cstdint in older versions of gcc. Newer versions of gcc have fixed that leaky include which causes the build to fail. Explicitly adding the include allows for newer versions of gcc to successfully build the json11 code.