### PR TITLE
mici setup: set WifiManager active on network setup page show

### DIFF
--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -371,6 +371,7 @@ class NetworkSetupPageBase(Scroller):
 
   def show_event(self):
     super().show_event()
+    self._wifi_manager.set_active(True)
     self._show_time = rl.get_time()
     self._prev_has_internet = False
     self._pending_has_internet_scroll = False

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -371,6 +371,7 @@ class NetworkSetupPageBase(Scroller):
 
   def show_event(self):
     super().show_event()
+    # make sure we populate strength and ip immediately if already have wifi
     self._wifi_manager.set_active(True)
     self._show_time = rl.get_time()
     self._prev_has_internet = False


### PR DESCRIPTION
wifi device is not ready by the time we call set_active after initialization, so networks are not populated until first 5s scan, and the currently connected network is empty strength in mici setup if already connected

only if already have wifi