### PR TITLE
ui: remove interactive timeout callbacks on widget hide

### DIFF
--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -109,15 +109,17 @@ class TrainingGuideDMTutorial(NavWidget):
     self._bad_face_page = DMBadFaceDetected()
 
     # Disable driver monitoring model when device times out for inactivity
-    def inactivity_callback():
-      ui_state.params.put_bool("IsDriverViewEnabled", False)
-
-    device.add_interactive_timeout_callback(inactivity_callback)
+    self._inactivity_callback = lambda: ui_state.params.put_bool("IsDriverViewEnabled", False)
 
   def show_event(self):
     super().show_event()
     self._dialog.show_event()
     self._progress.x = 0.0
+    device.add_interactive_timeout_callback(self._inactivity_callback)
+
+  def hide_event(self):
+    device.remove_interactive_timeout_callback(self._inactivity_callback)
+    super().hide_event()
 
   def _update_state(self):
     super()._update_state()

--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -108,8 +108,9 @@ class TrainingGuideDMTutorial(NavWidget):
     self._dialog = DriverCameraSetupDialog()
     self._bad_face_page = DMBadFaceDetected()
 
+  def _inactivity_callback(self):
     # Disable driver monitoring model when device times out for inactivity
-    self._inactivity_callback = lambda: ui_state.params.put_bool("IsDriverViewEnabled", False)
+    ui_state.params.put_bool("IsDriverViewEnabled", False)
 
   def show_event(self):
     super().show_event()
@@ -118,8 +119,8 @@ class TrainingGuideDMTutorial(NavWidget):
     device.add_interactive_timeout_callback(self._inactivity_callback)
 
   def hide_event(self):
-    device.remove_interactive_timeout_callback(self._inactivity_callback)
     super().hide_event()
+    device.remove_interactive_timeout_callback(self._inactivity_callback)
 
   def _update_state(self):
     super()._update_state()

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -231,8 +231,14 @@ class BaseDriverCameraDialog(Widget):
 class DriverCameraDialog(NavWidget, BaseDriverCameraDialog):
   def __init__(self):
     super().__init__()
-    # TODO: this can grow unbounded, should be given some thought
+
+  def show_event(self):
+    super().show_event()
     device.add_interactive_timeout_callback(gui_app.pop_widget)
+
+  def hide_event(self):
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
+    super().hide_event()
 
 
 if __name__ == "__main__":

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -229,16 +229,13 @@ class BaseDriverCameraDialog(Widget):
 
 
 class DriverCameraDialog(NavWidget, BaseDriverCameraDialog):
-  def __init__(self):
-    super().__init__()
-
   def show_event(self):
     super().show_event()
     device.add_interactive_timeout_callback(gui_app.pop_widget)
 
   def hide_event(self):
-    device.remove_interactive_timeout_callback(gui_app.pop_widget)
     super().hide_event()
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
 
 
 if __name__ == "__main__":

--- a/selfdrive/ui/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/onroad/driver_camera_dialog.py
@@ -20,8 +20,8 @@ class DriverCameraDialog(CameraView):
     device.add_interactive_timeout_callback(gui_app.pop_widget)
 
   def hide_event(self):
-    device.remove_interactive_timeout_callback(gui_app.pop_widget)
     super().hide_event()
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
     ui_state.params.put_bool("IsDriverViewEnabled", False)
     self.close()
 

--- a/selfdrive/ui/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/onroad/driver_camera_dialog.py
@@ -13,11 +13,14 @@ class DriverCameraDialog(CameraView):
   def __init__(self):
     super().__init__("camerad", VisionStreamType.VISION_STREAM_DRIVER)
     self.driver_state_renderer = DriverStateRenderer()
-    # TODO: this can grow unbounded, should be given some thought
-    device.add_interactive_timeout_callback(gui_app.pop_widget)
     ui_state.params.put_bool("IsDriverViewEnabled", True)
 
+  def show_event(self):
+    super().show_event()
+    device.add_interactive_timeout_callback(gui_app.pop_widget)
+
   def hide_event(self):
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
     super().hide_event()
     ui_state.params.put_bool("IsDriverViewEnabled", False)
     self.close()

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -220,6 +220,10 @@ class Device:
   def add_interactive_timeout_callback(self, callback: Callable):
     self._interactive_timeout_callbacks.append(callback)
 
+  def remove_interactive_timeout_callback(self, callback: Callable):
+    if callback in self._interactive_timeout_callbacks:
+      self._interactive_timeout_callbacks.remove(callback)
+
   def update(self):
     # do initial reset
     if self._interaction_time <= 0:


### PR DESCRIPTION
## Summary
- Add `remove_interactive_timeout_callback` to `Device` class, mirroring the existing `remove_nav_stack_tick` pattern
- Move callback registration from `__init__` to `show_event`/`hide_event` lifecycle for short-lived widgets (`DriverCameraDialog`, `TrainingGuideDMTutorial`)
- Remove stale TODO comments

## Problem
`Device.add_interactive_timeout_callback()` appends to a list but has no corresponding remove method. Short-lived widgets like `DriverCameraDialog` register callbacks in `__init__` that persist after the widget is destroyed, causing unbounded list growth and stale callbacks firing on timeout.

Fixes #37536

## Test plan
- [ ] Open and close driver camera dialog multiple times — callback list should not grow
- [ ] Interactive timeout still correctly dismisses the dialog when open
- [ ] Onboarding DM tutorial timeout still disables driver view
- [ ] `ruff check` passes on all modified files