### PR TITLE
ui: child widget support

### DIFF
--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -111,6 +111,7 @@ class MiciHomeLayout(Widget):
     self._version_commit_label = MiciLabel("", font_size=36, color=rl.GRAY, font_weight=FontWeight.ROMAN)
 
   def show_event(self):
+    super().show_event()
     self._version_text = self._get_version_text()
     self._update_params()
 

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -14,8 +14,9 @@ except ImportError:
     awake = True
   device = Device()
 
-
 W = TypeVar('W', bound='Widget')
+
+DEBUG = True
 
 
 class DialogResult(IntEnum):
@@ -212,19 +213,27 @@ class Widget(abc.ABC):
     self._children.append(widget)
     return widget
 
+  _show_hide_depth = 0
+
   def show_event(self):
     """Called when widget becomes visible. Propagates to registered children."""
-    print(f"show_event: {type(self).__name__}")
+    if DEBUG:
+      print(f"{'  ' * Widget._show_hide_depth}show_event: {type(self).__name__}")
+      Widget._show_hide_depth += 1
     for child in self._children:
-      print(f"  show_event: {type(self).__name__} -> {type(child).__name__}")
       child.show_event()
+    if DEBUG:
+      Widget._show_hide_depth -= 1
 
   def hide_event(self):
     """Called when widget is hidden. Propagates to registered children."""
-    print(f"hide_event: {type(self).__name__}")
+    if DEBUG:
+      print(f"{'  ' * Widget._show_hide_depth}hide_event: {type(self).__name__}")
+      Widget._show_hide_depth += 1
     for child in self._children:
-      print(f"  hide_event: {type(self).__name__} -> {type(child).__name__}")
       child.hide_event()
+    if DEBUG:
+      Widget._show_hide_depth -= 1
 
   def dismiss(self, callback: Callable[[], None] | None = None):
     """Immediately dismiss the widget, firing the callback after."""

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -210,6 +210,7 @@ class Widget(abc.ABC):
     - If the widget is pushed onto the nav stack, do NOT register it (gui_app manages its lifecycle).
     - If the widget is rendered inline in _render(), register it.
     """
+    assert widget not in self._children, f"{type(widget).__name__} already a child of {type(self).__name__}"
     self._children.append(widget)
     return widget
 

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -35,7 +35,8 @@ class Widget(abc.ABC):
     self._is_visible: bool | Callable[[], bool] = True
 
     self.__is_pressed = [False] * MAX_TOUCH_SLOTS
-    self.__tracking_is_pressed = [False] * MAX_TOUCH_SLOTS  # if mouse/touch down started within rect
+    # if current mouse/touch down started within the widget's rectangle
+    self.__tracking_is_pressed = [False] * MAX_TOUCH_SLOTS
     self._touch_valid_callback: Callable[[], bool] | None = None
     self._click_delay: float | None = None  # seconds to hold is_pressed after release
     self._click_release_time: float | None = None

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -203,7 +203,11 @@ class Widget(abc.ABC):
     # Default implementation does nothing, can be overridden by subclasses
 
   def _child(self, widget: W) -> W:
-    """Register a widget as a child. Lifecycle events (show/hide) propagate to registered children."""
+    """
+    Register a widget as a child. Lifecycle events (show/hide) propagate to registered children.
+    - If the widget is pushed onto the nav stack, do NOT register it (gui_app manages its lifecycle).
+    - If the widget is rendered inline in _render(), register it.
+    """
     self._children.append(widget)
     return widget
 

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import pyray as rl
 from enum import IntEnum
+from typing import TypeVar
 from collections.abc import Callable
 from openpilot.system.ui.lib.application import gui_app, MousePos, MAX_TOUCH_SLOTS, MouseEvent
 
@@ -14,6 +15,9 @@ except ImportError:
   device = Device()
 
 
+W = TypeVar('W', bound='Widget')
+
+
 class DialogResult(IntEnum):
   CANCEL = 0
   CONFIRM = 1
@@ -22,6 +26,7 @@ class DialogResult(IntEnum):
 
 class Widget(abc.ABC):
   def __init__(self):
+    self._children: list[Widget] = []
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._parent_rect: rl.Rectangle | None = None
     self.__is_pressed = [False] * MAX_TOUCH_SLOTS
@@ -197,12 +202,24 @@ class Widget(abc.ABC):
     """Optionally handle mouse events. This is called before rendering."""
     # Default implementation does nothing, can be overridden by subclasses
 
+  def _child(self, widget: W) -> W:
+    """Register a widget as a child. Lifecycle events (show/hide) propagate to registered children."""
+    self._children.append(widget)
+    return widget
+
   def show_event(self):
-    """Optionally handle show event. Parent must manually call this"""
-    # TODO: iterate through all child objects, check for subclassing from Widget/Layout (Scroller)
+    """Called when widget becomes visible. Propagates to registered children."""
+    print(f"show_event: {type(self).__name__}")
+    for child in self._children:
+      print(f"  show_event: {type(self).__name__} -> {type(child).__name__}")
+      child.show_event()
 
   def hide_event(self):
-    """Optionally handle hide event. Parent must manually call this"""
+    """Called when widget is hidden. Propagates to registered children."""
+    print(f"hide_event: {type(self).__name__}")
+    for child in self._children:
+      print(f"  hide_event: {type(self).__name__} -> {type(child).__name__}")
+      child.hide_event()
 
   def dismiss(self, callback: Callable[[], None] | None = None):
     """Immediately dismiss the widget, firing the callback after."""

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -26,14 +26,15 @@ class DialogResult(IntEnum):
 
 class Widget(abc.ABC):
   def __init__(self):
-    self._children: list[Widget] = []
     self._rect: rl.Rectangle = rl.Rectangle(0, 0, 0, 0)
     self._parent_rect: rl.Rectangle | None = None
-    self.__is_pressed = [False] * MAX_TOUCH_SLOTS
-    # if current mouse/touch down started within the widget's rectangle
-    self.__tracking_is_pressed = [False] * MAX_TOUCH_SLOTS
+    self._children: list[Widget] = []
+
     self._enabled: bool | Callable[[], bool] = True
     self._is_visible: bool | Callable[[], bool] = True
+
+    self.__is_pressed = [False] * MAX_TOUCH_SLOTS
+    self.__tracking_is_pressed = [False] * MAX_TOUCH_SLOTS  # if mouse/touch down started within rect
     self._touch_valid_callback: Callable[[], bool] | None = None
     self._click_delay: float | None = None  # seconds to hold is_pressed after release
     self._click_release_time: float | None = None

--- a/system/ui/widgets/layouts.py
+++ b/system/ui/widgets/layouts.py
@@ -21,7 +21,6 @@ class HBoxLayout(Widget):
   def __init__(self, widgets: list[Widget] | None = None, spacing: int = 0,
                alignment: Alignment = Alignment.LEFT | Alignment.V_CENTER):
     super().__init__()
-    self._widgets: list[Widget] = []
     self._spacing = spacing
     self._alignment = alignment
 
@@ -31,13 +30,13 @@ class HBoxLayout(Widget):
 
   @property
   def widgets(self) -> list[Widget]:
-    return self._widgets
+    return self._children
 
   def add_widget(self, widget: Widget) -> None:
-    self._widgets.append(widget)
+    self._child(widget)
 
   def _render(self, _):
-    visible_widgets = [w for w in self._widgets if w.is_visible]
+    visible_widgets = [w for w in self._children if w.is_visible]
 
     cur_offset_x = 0
 

--- a/system/ui/widgets/layouts.py
+++ b/system/ui/widgets/layouts.py
@@ -21,6 +21,7 @@ class HBoxLayout(Widget):
   def __init__(self, widgets: list[Widget] | None = None, spacing: int = 0,
                alignment: Alignment = Alignment.LEFT | Alignment.V_CENTER):
     super().__init__()
+    self._widgets: list[Widget] = []
     self._spacing = spacing
     self._alignment = alignment
 
@@ -30,13 +31,13 @@ class HBoxLayout(Widget):
 
   @property
   def widgets(self) -> list[Widget]:
-    return self._children
+    return self._widgets
 
   def add_widget(self, widget: Widget) -> None:
-    self._child(widget)
+    self._widgets.append(widget)
 
   def _render(self, _):
-    visible_widgets = [w for w in self._children if w.is_visible]
+    visible_widgets = [w for w in self._widgets if w.is_visible]
 
     cur_offset_x = 0
 

--- a/system/ui/widgets/nav_widget.py
+++ b/system/ui/widgets/nav_widget.py
@@ -69,7 +69,7 @@ class NavWidget(Widget, abc.ABC):
     self._shown_callback: Callable[[], None] | None = None  # transient callback fired after show animation completes
 
     # TODO: move this state into NavBar
-    self._nav_bar = NavBar()
+    self._nav_bar = self._child(NavBar())
     self._nav_bar_show_time = 0.0
     self._nav_bar_y_filter = FirstOrderFilter(0.0, 0.1, 1 / gui_app.target_fps)
 
@@ -214,7 +214,6 @@ class NavWidget(Widget, abc.ABC):
 
   def show_event(self):
     super().show_event()
-    self._nav_bar.show_event()
 
     # Reset state
     self._drag_start_pos = None

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -422,17 +422,9 @@ class Scroller(Widget):
   """Wrapper for _Scroller so that children do not need to call events or pass down enabled for nav stack."""
   def __init__(self, **kwargs):
     super().__init__()
-    self._scroller = _Scroller([], **kwargs)
+    self._scroller = self._child(_Scroller([], **kwargs))
     # pass down enabled to child widget for nav stack
     self._scroller.set_enabled(lambda: self.enabled)
-
-  def show_event(self):
-    super().show_event()
-    self._scroller.show_event()
-
-  def hide_event(self):
-    super().hide_event()
-    self._scroller.hide_event()
 
   def _render(self, _):
     self._scroller.render(self._rect)

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -72,6 +72,7 @@ class _Scroller(Widget):
   def __init__(self, items: list[Widget], horizontal: bool = True, snap_items: bool = False, spacing: int = ITEM_SPACING,
                pad: int = ITEM_SPACING, scroll_indicator: bool = True, edge_shadows: bool = True):
     super().__init__()
+    self._items: list[Widget] = []
     self._horizontal = horizontal
     self._snap_items = snap_items
     self._spacing = spacing
@@ -136,14 +137,14 @@ class _Scroller(Widget):
 
   @property
   def items(self) -> list[Widget]:
-    return self._children
+    return self._items
 
   @property
   def content_size(self) -> float:
     return self._content_size
 
   def add_widget(self, item: Widget) -> None:
-    self._child(item)
+    self._items.append(item)
 
     # preserve original touch valid callback
     original_touch_valid_callback = item._touch_valid_callback
@@ -238,12 +239,12 @@ class _Scroller(Widget):
       cloudlog.warning(f"Already moving items, cannot move from {from_idx} to {to_idx}")
       return
 
-    item = self._children.pop(from_idx)
-    self._children.insert(to_idx, item)
+    item = self._items.pop(from_idx)
+    self._items.insert(to_idx, item)
 
     # store original position in content space of all affected widgets to animate from
     for idx in range(min(from_idx, to_idx), max(from_idx, to_idx) + 1):
-      affected_item = self._children[idx]
+      affected_item = self._items[idx]
       self._move_animations[affected_item] = FirstOrderFilter(affected_item.rect.x - self._scroll_offset, SCROLL_RC, 1 / gui_app.target_fps)
       self._pending_move.add(affected_item)
 
@@ -292,7 +293,7 @@ class _Scroller(Widget):
     return target_x, target_y
 
   def _layout(self):
-    self._visible_items = [item for item in self._children if item.is_visible]
+    self._visible_items = [item for item in self._items if item.is_visible]
 
     self._content_size = sum(item.rect.width if self._horizontal else item.rect.height for item in self._visible_items)
     self._content_size += self._spacing * (len(self._visible_items) - 1)
@@ -397,6 +398,8 @@ class _Scroller(Widget):
 
   def show_event(self):
     super().show_event()
+    for item in self._items:
+      item.show_event()
 
     if self._reset_scroll_at_show:
       self.scroll_panel.set_offset(0.0)
@@ -408,6 +411,11 @@ class _Scroller(Widget):
     self._pending_move.clear()
     self._scrolling_to = None, False
     self._scrolling_to_filter.x = 0.0
+
+  def hide_event(self):
+    super().hide_event()
+    for item in self._items:
+      item.hide_event()
 
 
 class Scroller(Widget):

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -72,7 +72,6 @@ class _Scroller(Widget):
   def __init__(self, items: list[Widget], horizontal: bool = True, snap_items: bool = False, spacing: int = ITEM_SPACING,
                pad: int = ITEM_SPACING, scroll_indicator: bool = True, edge_shadows: bool = True):
     super().__init__()
-    self._items: list[Widget] = []
     self._horizontal = horizontal
     self._snap_items = snap_items
     self._spacing = spacing
@@ -137,14 +136,14 @@ class _Scroller(Widget):
 
   @property
   def items(self) -> list[Widget]:
-    return self._items
+    return self._children
 
   @property
   def content_size(self) -> float:
     return self._content_size
 
   def add_widget(self, item: Widget) -> None:
-    self._items.append(item)
+    self._child(item)
 
     # preserve original touch valid callback
     original_touch_valid_callback = item._touch_valid_callback
@@ -239,12 +238,12 @@ class _Scroller(Widget):
       cloudlog.warning(f"Already moving items, cannot move from {from_idx} to {to_idx}")
       return
 
-    item = self._items.pop(from_idx)
-    self._items.insert(to_idx, item)
+    item = self._children.pop(from_idx)
+    self._children.insert(to_idx, item)
 
     # store original position in content space of all affected widgets to animate from
     for idx in range(min(from_idx, to_idx), max(from_idx, to_idx) + 1):
-      affected_item = self._items[idx]
+      affected_item = self._children[idx]
       self._move_animations[affected_item] = FirstOrderFilter(affected_item.rect.x - self._scroll_offset, SCROLL_RC, 1 / gui_app.target_fps)
       self._pending_move.add(affected_item)
 
@@ -293,7 +292,7 @@ class _Scroller(Widget):
     return target_x, target_y
 
   def _layout(self):
-    self._visible_items = [item for item in self._items if item.is_visible]
+    self._visible_items = [item for item in self._children if item.is_visible]
 
     self._content_size = sum(item.rect.width if self._horizontal else item.rect.height for item in self._visible_items)
     self._content_size += self._spacing * (len(self._visible_items) - 1)
@@ -398,8 +397,6 @@ class _Scroller(Widget):
 
   def show_event(self):
     super().show_event()
-    for item in self._items:
-      item.show_event()
 
     if self._reset_scroll_at_show:
       self.scroll_panel.set_offset(0.0)
@@ -411,11 +408,6 @@ class _Scroller(Widget):
     self._pending_move.clear()
     self._scrolling_to = None, False
     self._scrolling_to_filter.x = 0.0
-
-  def hide_event(self):
-    super().hide_event()
-    for item in self._items:
-      item.hide_event()
 
 
 class Scroller(Widget):


### PR DESCRIPTION
any widget that renders inline is a child widget, starting with scrollers

we start to be real ui framework with this :)

home:
```
batman@workstation-shane:~/openpilot$ ./selfdrive/ui/ui.py 
RAYLIB STATIC 5.5.0.4 LOADED
No LTE connection found
show_event: MiciMainLayout
  show_event: _Scroller
    show_event: MiciOffroadAlerts
      show_event: _Scroller
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
        show_event: AlertItem
    show_event: MiciHomeLayout
    show_event: AugmentedRoadView
```

settings:
```
show_event: SettingsLayout
  show_event: _Scroller
    show_event: SettingsBigButton
    show_event: SettingsBigButton
    show_event: SettingsBigButton
    show_event: PairBigButton
    show_event: SettingsBigButton
    show_event: SettingsBigButton
  show_event: NavBar
```