### PR TITLE
fix(sim): remove alpha channel for improved performance

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_common.py
+++ b/tools/sim/bridge/metadrive/metadrive_common.py
@@ -13,11 +13,9 @@ class CopyRamRGBCamera(RGBCamera):
 
   def get_rgb_array_cpu(self):
     origin_img = self.cpu_texture
-    img = np.frombuffer(origin_img.getRamImageAs("RGBA").getData(), dtype=np.uint8)
-    img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 4))
-    img = img[:, :, :3]
-    # img = np.swapaxes(img, 1, 0)
-    img = img[::-1] # Flip on vertical axis
+    img = np.frombuffer(origin_img.getRamImageAs("RGB").getData(), dtype=np.uint8)
+    img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 3))
+    img = img[::-1]  # Flip on vertical axis
     return img
 
 


### PR DESCRIPTION
#37528 also fixed the coloring issues for me on WSL, but introduced additional performance overhead. Removing the alpha channel improves this a lot.

_Note: It still barely runs for me out of the box on WSL, so this only is noticeable after I've made some other adjustments (e.g. enable hardware acceleration with `GALLIUM_DRIVER=d3d12 op sim`_