### PR TITLE
loggerd: handle stray log root entries safely

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+﻿#!/usr/bin/env python3
 import os
 import shutil
 import threading
@@ -45,28 +45,44 @@ def get_preserved_segments(dirs_by_creation: list[str]) -> set[str]:
   return preserved
 
 
+def remove_path(delete_path: str) -> bool:
+  try:
+    if os.path.isdir(delete_path) and not os.path.islink(delete_path):
+      if any(name.endswith(".lock") for name in os.listdir(delete_path)):
+        return False
+      cloudlog.info(f"deleting {delete_path}")
+      shutil.rmtree(delete_path)
+    else:
+      cloudlog.info(f"deleting {delete_path}")
+      os.remove(delete_path)
+    return True
+  except OSError:
+    cloudlog.exception(f"issue deleting {delete_path}")
+    return False
+
+
 def deleter_thread(exit_event: threading.Event):
   while not exit_event.is_set():
     out_of_bytes = get_available_bytes(default=MIN_BYTES + 1) < MIN_BYTES
     out_of_percent = get_available_percent(default=MIN_PERCENT + 1) < MIN_PERCENT
 
     if out_of_percent or out_of_bytes:
-      dirs = listdir_by_creation(Paths.log_root())
+      log_root = Paths.log_root()
+      dirs = listdir_by_creation(log_root)
       preserved_dirs = get_preserved_segments(dirs)
+      try:
+        delete_order = sorted(name for name in os.listdir(log_root) if name not in dirs)
+      except OSError:
+        cloudlog.exception("issue listing log root")
+        exit_event.wait(.1)
+        continue
 
       # remove the earliest directory we can
-      for delete_dir in sorted(dirs, key=lambda d: (d in DELETE_LAST, d in preserved_dirs)):
-        delete_path = os.path.join(Paths.log_root(), delete_dir)
-
-        if any(name.endswith(".lock") for name in os.listdir(delete_path)):
-          continue
-
-        try:
-          cloudlog.info(f"deleting {delete_path}")
-          shutil.rmtree(delete_path)
+      delete_order.extend(sorted(dirs, key=lambda d: (d in DELETE_LAST, d in preserved_dirs)))
+      for delete_dir in delete_order:
+        delete_path = os.path.join(log_root, delete_dir)
+        if remove_path(delete_path):
           break
-        except OSError:
-          cloudlog.exception(f"issue deleting {delete_path}")
       exit_event.wait(.1)
     else:
       exit_event.wait(30)

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -1,11 +1,14 @@
+import os
+import random
 import time
 import threading
 from collections import namedtuple
-from pathlib import Path
 from collections.abc import Sequence
+from pathlib import Path
 
 import openpilot.system.loggerd.deleter as deleter
 from openpilot.common.timeout import Timeout, TimeoutException
+from openpilot.system.hardware.hw import Paths
 from openpilot.system.loggerd.tests.loggerd_tests_common import UploaderTestCase
 
 Stats = namedtuple("Stats", ['f_bavail', 'f_blocks', 'f_frsize'])
@@ -30,6 +33,19 @@ class TestDeleter(UploaderTestCase):
   def join_thread(self):
     self.end_event.set()
     self.del_thread.join()
+
+  @staticmethod
+  def path_exists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+  def make_random_log_root_dir(self, dirname: str, rng: random.Random) -> Path:
+    root_dir = Path(Paths.log_root()) / dirname
+    for i in range(rng.randint(1, 3)):
+      depth = rng.randint(0, 2)
+      nested_dir = "/".join(f"nested-{i}-{j}" for j in range(depth))
+      file_dir = f"{dirname}/{nested_dir}" if nested_dir else dirname
+      self.make_file_with_data(file_dir, f"file-{i}.bin", .01)
+    return root_dir
 
   def test_delete(self):
     f_path = self.make_file_with_data(self.seg_dir, self.f_type, 1)
@@ -115,3 +131,57 @@ class TestDeleter(UploaderTestCase):
     self.join_thread()
 
     assert f_path.exists(), "File deleted when locked"
+
+  def test_delete_mixed_log_root_entries(self):
+    rng = random.Random(0)
+
+    removable_paths = [self.make_file_with_data("", f"stray-{i}.bin", .01) for i in range(3)]
+    removable_paths += [self.make_random_log_root_dir(f"stray-dir-{i}", rng) for i in range(3)]
+
+    target_file = self.make_file_with_data("", "stray-target.bin", .01)
+    removable_paths.append(target_file)
+    file_link = Path(Paths.log_root()) / "stray-file-link"
+    file_link.symlink_to(target_file)
+    removable_paths.append(file_link)
+
+    target_dir = self.make_random_log_root_dir("stray-target-dir", rng)
+    removable_paths.append(target_dir)
+    dir_link = Path(Paths.log_root()) / "stray-dir-link"
+    dir_link.symlink_to(target_dir, target_is_directory=True)
+    removable_paths.append(dir_link)
+
+    locked_path = self.make_file_with_data(self.seg_dir, self.f_type, .01, lock=True)
+
+    self.start_thread()
+    try:
+      with Timeout(10, "Timeout waiting for mixed entries to be deleted"):
+        while any(self.path_exists(path) for path in removable_paths):
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+
+    assert locked_path.exists(), "Locked segment deleted while cleaning mixed entries"
+
+  def test_continue_after_listdir_failure(self, monkeypatch):
+    bad_dir = self.make_random_log_root_dir("bad-dir", random.Random(1))
+    file_path = self.make_file_with_data("", "cleanup-me.bin", .01)
+
+    original_listdir = deleter.os.listdir
+
+    def flaky_listdir(path):
+      if path == str(bad_dir):
+        raise OSError("boom")
+      return original_listdir(path)
+
+    monkeypatch.setattr(deleter.os, "listdir", flaky_listdir)
+
+    self.start_thread()
+    try:
+      with Timeout(5, "Timeout waiting for deleter to continue after listdir failure"):
+        while self.path_exists(file_path):
+          time.sleep(0.01)
+      assert self.del_thread.is_alive(), "Deleter thread died after listdir failure"
+    finally:
+      self.join_thread()
+
+    assert bad_dir.exists(), "Failing directory should still exist"


### PR DESCRIPTION
## Summary
- handle non-directory entries in the log root without crashing the deleter thread
- keep the existing segment deletion ordering while skipping locked directories
- add broader coverage for mixed files, directories, symlinks, and directory listing failures

## Verification
- `py -3 -m py_compile C:\Users\23615\Desktop\GitHub\openpilot-edit\system\loggerd\deleter.py C:\Users\23615\Desktop\GitHub\openpilot-edit\system\loggerd\tests\test_deleter.py`
- `wsl.exe -d Ubuntu -- python3 /mnt/c/Users/23615/Desktop/GitHub/verify_deleter_patch.py`
- full `pytest system/loggerd/tests/test_deleter.py -q` is still blocked in the lightweight sandbox because the repo's compiled `openpilot.common.params_pyx` extension is not built there yet

Closes #30102