### PR TITLE
modem: remove cavli-specific AT commands

### DIFF
--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -477,19 +477,6 @@ class Tici(HardwareBase):
         'AT+QNVFW="/nv/item_files/modem/mmode/ue_usage_setting",01',
       ]
 
-    # Quectel EG916
-    else:
-      # this modem gets upset with too many AT commands
-      if sim_id is None or len(sim_id) == 0:
-        cmds += [
-          # SIM sleep disable
-          'AT$QCSIMSLEEP=0',
-          'AT$QCSIMCFG=SimPowerSave,0',
-
-          # ethernet config
-          'AT$QCPCFG=usbNet,1',
-        ]
-
     for cmd in cmds:
       try:
         modem.Command(cmd, math.ceil(TIMEOUT), dbus_interface=MM_MODEM, timeout=TIMEOUT)


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/37607

these commands are not for EG916:

https://itbrainpower.net/downloadables/Quectel_EG9x_AT_Commands_Manual_V1.1.pdf

my guess is they are leftover from the Cavli delete, i find references to these in the Cavli AT manual:

https://itbrainpower.net/downloadables/C16QS_AT_Command_Manual_ERV_3_1.pdf

