### PR TITLE
mici_reset: skip slider dismiss animation before resetting page

### DIFF
--- a/system/ui/mici_reset.py
+++ b/system/ui/mici_reset.py
@@ -77,7 +77,7 @@ class Reset(Scroller):
     self._reset_failed_page = ResetFailedPage()
 
     self._reset_button = BigConfirmationCircleButton("reset &\nerase", gui_app.texture("icons_mici/settings/device/uninstall.png", 70, 70),
-                                                     self._start_reset, red=True)
+                                                     self._start_reset, exit_on_confirm=False, red=True)
     self._cancel_button = BigConfirmationCircleButton("cancel", gui_app.texture("icons_mici/setup/cancel.png", 64, 64),
                                                       gui_app.request_close, exit_on_confirm=False)
     self._reboot_button = BigConfirmationCircleButton("reboot\ndevice", gui_app.texture("icons_mici/settings/device/reboot.png", 64, 70),


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/e2d9c9b2-e655-406b-bf98-5294604941ee

## After

https://github.com/user-attachments/assets/9b7c6d72-9863-4186-a1d9-76ad6c28f1fd