### PR TITLE
locationd: skip paramsd updates while in reverse

### DIFF
--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -119,7 +119,7 @@ class VehicleParamsLearner:
 
       in_linear_region = abs(steering_angle) < 45
       self.observed_speed = msg.vEgo
-      self.active = self.observed_speed > MIN_ACTIVE_SPEED and in_linear_region
+      self.active = self.observed_speed > MIN_ACTIVE_SPEED and in_linear_region and msg.gearShifter != car.CarState.GearShifter.reverse
 
       if self.active:
         self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[np.radians(steering_angle)]]))


### PR DESCRIPTION
## Summary
- Gate `paramsd` activation on `gearShifter != reverse` to prevent incorrect Kalman filter observations while driving in reverse

## Problem
CAN wheel speeds are always positive regardless of direction. When the car is in reverse, `paramsd` still observes positive `vEgo` and feeds it into the Kalman filter, causing tire stiffness to tank and degrading driving quality after switching back to forward.

Fixes #37458

## Test plan
- [ ] `ruff check` passes
- [ ] Process replay produces matching output
- [ ] Tire stiffness remains stable through reverse maneuvers (verified via route replay from issue)