### PR TITLE
ui: don't clear LongitudinalManeuverMode param when going onroad

### DIFF
--- a/selfdrive/ui/layouts/settings/developer.py
+++ b/selfdrive/ui/layouts/settings/developer.py
@@ -123,8 +123,7 @@ class DeveloperLayout(Widget):
       long_man_enabled = ui_state.has_longitudinal_control and ui_state.is_offroad()
       self._long_maneuver_toggle.action_item.set_enabled(long_man_enabled)
       if not long_man_enabled:
-        self._long_maneuver_toggle.action_item.set_state(False)
-        self._params.put_bool("LongitudinalManeuverMode", False)
+        self._long_maneuver_toggle.action_item.set_state(self._params.get_bool("LongitudinalManeuverMode"))
     else:
       self._long_maneuver_toggle.action_item.set_enabled(False)
       self._alpha_long_toggle.set_visible(False)

--- a/selfdrive/ui/mici/layouts/settings/developer.py
+++ b/selfdrive/ui/mici/layouts/settings/developer.py
@@ -118,8 +118,7 @@ class DeveloperLayoutMici(NavScroller):
       long_man_enabled = ui_state.has_longitudinal_control and ui_state.is_offroad()
       self._long_maneuver_toggle.set_enabled(long_man_enabled)
       if not long_man_enabled:
-        self._long_maneuver_toggle.set_checked(False)
-        ui_state.params.put_bool("LongitudinalManeuverMode", False)
+        self._long_maneuver_toggle.set_checked(ui_state.params.get_bool("LongitudinalManeuverMode"))
     else:
       self._long_maneuver_toggle.set_enabled(False)
       self._alpha_long_toggle.set_visible(False)


### PR DESCRIPTION
## Summary
- Stop clearing `LongitudinalManeuverMode` param during the offroad-to-onroad transition in developer settings UI
- Toggle remains disabled (non-interactive) while onroad but now reflects the actual param state

## Problem
`_update_toggles()` runs on offroad transition. When going onroad, `is_offroad()` returns False, causing the code to force `LongitudinalManeuverMode` to False before the process manager evaluates `long_maneuver()`. This means `maneuversd` never starts, even though the user enabled the toggle while offroad.

Fixes #37160

## Test plan
- [ ] Enable "Longitudinal Maneuver Mode" while offroad → go onroad → verify `maneuversd` starts
- [ ] Toggle is disabled (grayed out) while onroad
- [ ] Toggle reflects correct state when returning offroad
- [ ] `ruff check` passes on both developer.py files