### PR TITLE
manager: skip unblock_stdout on macOS to fix MetaDrive simulator

### DIFF
--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -209,7 +209,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-  unblock_stdout()
+  # os.forkpty() in unblock_stdout() crashes on macOS after raylib/AppKit initialization
+  if sys.platform != "darwin":
+    unblock_stdout()
 
   try:
     main()


### PR DESCRIPTION
## Summary

After the Qt→raylib UI migration, `os.forkpty()` in `unblock_stdout()` crashes on macOS because CoreFoundation/AppKit doesn't allow `fork()` after framework initialization. This prevents the MetaDrive simulator from running on macOS entirely.

- Skip `unblock_stdout()` on `darwin` — it's not needed for the simulator use case and causes an immediate crash

## Test plan

- [ ] Run `pytest tools/sim/tests/test_metadrive_bridge.py -v` on macOS — passes (tested on M3)
- [ ] Verified manager starts without crashing on macOS

Closes #33207

🤖 Generated with [Claude Code](https://claude.com/claude-code)