### PR TITLE
setup: simplify cache branch

### DIFF
--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -125,6 +125,10 @@ int doInstall() {
   // cleanup previous install attempts
   run("rm -rf " TMP_INSTALL_PATH);
 
+  // TODO: always pull installer, don't write continue.sh here
+  //  make sure installer fails (doesn't write continue.sh) if fetch/checkout fails
+  //  make isntaller move atomic
+
   // do the install
   if (util::file_exists(INSTALL_PATH) && util::file_exists(VALID_CACHE_PATH)) {
     return cachedFetch(INSTALL_PATH);

--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -125,10 +125,6 @@ int doInstall() {
   // cleanup previous install attempts
   run("rm -rf " TMP_INSTALL_PATH);
 
-  // TODO: always pull installer, don't write continue.sh here
-  //  make sure installer fails (doesn't write continue.sh) if fetch/checkout fails
-  //  make isntaller move atomic
-
   // do the install
   if (util::file_exists(INSTALL_PATH) && util::file_exists(VALID_CACHE_PATH)) {
     return cachedFetch(INSTALL_PATH);

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -529,23 +529,6 @@ class Setup(Widget):
     # reset sliders after dismiss completes
     gui_app.pop_widgets_to(self._software_selection_page, self._software_selection_page.reset)
 
-  def _use_openpilot(self):
-    if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH) and False:
-      # TODO: always pull installer, don't write continue.sh here
-      #  make sure installer fails (doesn't write continue.sh) if fetch/checkout fails
-      #  make isntaller move atomic
-      # run_cmd(["chmod", "+x", TMP_CONTINUE_PATH])
-      # shutil.move(TMP_CONTINUE_PATH, CONTINUE_PATH)
-      # shutil.copyfile(INSTALLER_SOURCE_PATH, INSTALLER_DESTINATION_PATH)
-      shutil.copyfile(INSTALLER_SOURCE_PATH, TMP_INSTALLER_PATH)
-      os.rename(TMP_INSTALLER_PATH, INSTALLER_DESTINATION_PATH)
-
-      # give time for installer UI to take over
-      time.sleep(0.1)
-      gui_app.request_close()
-    else:
-      self._push_network_setup()
-
   def _push_network_setup(self, custom_software: bool = False):
     # to fire the correct continue callback later
     self._network_setup_page.set_custom_software(custom_software)

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -7,7 +7,6 @@ import time
 import urllib.request
 import urllib.error
 from urllib.parse import urlparse
-import shutil
 from collections.abc import Callable
 
 import pyray as rl

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -531,7 +531,6 @@ class Setup(Widget):
 
   def _use_openpilot(self):
     if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH) and False:
-      os.remove(VALID_CACHE_PATH)
       # with open(TMP_CONTINUE_PATH, "w") as f:
       #   f.write(CONTINUE)
       # TODO: always pull installer, don't write continue.sh here

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -36,19 +36,20 @@ NetworkType = log.DeviceState.NetworkType
 OPENPILOT_URL = "https://openpilot.comma.ai"
 USER_AGENT = f"AGNOSSetup-{HARDWARE.get_os_version()}"
 
-CONTINUE_PATH = "/data/continue.sh"
-TMP_CONTINUE_PATH = "/data/continue.sh.new"
+# CONTINUE_PATH = "/data/continue.sh"
+# TMP_CONTINUE_PATH = "/data/continue.sh.new"
 INSTALL_PATH = "/data/openpilot"
 VALID_CACHE_PATH = "/data/.openpilot_cache"
 INSTALLER_SOURCE_PATH = "/usr/comma/installer"
 INSTALLER_DESTINATION_PATH = "/tmp/installer"
+TMP_INSTALLER_PATH = "/tmp/installer.new"
 INSTALLER_URL_PATH = "/tmp/installer_url"
 
-CONTINUE = """#!/usr/bin/env bash
-
-cd /data/openpilot
-exec ./launch_openpilot.sh
-"""
+# CONTINUE = """#!/usr/bin/env bash
+#
+# cd /data/openpilot
+# exec ./launch_openpilot.sh
+# """
 
 
 class NetworkConnectivityMonitor:
@@ -531,11 +532,16 @@ class Setup(Widget):
   def _use_openpilot(self):
     if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH):
       os.remove(VALID_CACHE_PATH)
-      with open(TMP_CONTINUE_PATH, "w") as f:
-        f.write(CONTINUE)
-      run_cmd(["chmod", "+x", TMP_CONTINUE_PATH])
+      # with open(TMP_CONTINUE_PATH, "w") as f:
+      #   f.write(CONTINUE)
+      # TODO: always pull installer, don't write continue.sh here
+      #  make sure installer fails (doesn't write continue.sh) if fetch/checkout fails
+      #  make isntaller move atomic
+      # run_cmd(["chmod", "+x", TMP_CONTINUE_PATH])
       shutil.move(TMP_CONTINUE_PATH, CONTINUE_PATH)
-      shutil.copyfile(INSTALLER_SOURCE_PATH, INSTALLER_DESTINATION_PATH)
+      # shutil.copyfile(INSTALLER_SOURCE_PATH, INSTALLER_DESTINATION_PATH)
+      shutil.copyfile(INSTALLER_SOURCE_PATH, TMP_INSTALLER_PATH)
+      os.rename(TMP_INSTALLER_PATH, INSTALLER_DESTINATION_PATH)
 
       # give time for installer UI to take over
       time.sleep(0.1)

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -36,20 +36,8 @@ NetworkType = log.DeviceState.NetworkType
 OPENPILOT_URL = "https://openpilot.comma.ai"
 USER_AGENT = f"AGNOSSetup-{HARDWARE.get_os_version()}"
 
-# CONTINUE_PATH = "/data/continue.sh"
-# TMP_CONTINUE_PATH = "/data/continue.sh.new"
-INSTALL_PATH = "/data/openpilot"
-VALID_CACHE_PATH = "/data/.openpilot_cache"
-INSTALLER_SOURCE_PATH = "/usr/comma/installer"
 INSTALLER_DESTINATION_PATH = "/tmp/installer"
-TMP_INSTALLER_PATH = "/tmp/installer.new"
 INSTALLER_URL_PATH = "/tmp/installer_url"
-
-# CONTINUE = """#!/usr/bin/env bash
-#
-# cd /data/openpilot
-# exec ./launch_openpilot.sh
-# """
 
 
 class NetworkConnectivityMonitor:
@@ -598,7 +586,7 @@ class Setup(Widget):
         self._download_failed_reason = "No custom software found at this URL: " + self.download_url.replace("https://", "", 1)
         return
 
-      # TODO: this is unused?!
+      # NOTE: currently unused, for future logging
       with open(INSTALLER_URL_PATH, "w") as f:
         f.write(self.download_url)
 

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -500,7 +500,7 @@ class Setup(Widget):
 
     self._network_setup_page = NetworkSetupPage(self._network_monitor, self._network_setup_continue_callback, self._pop_to_software_selection)
 
-    self._software_selection_page = SoftwareSelectionPage(self._use_openpilot, lambda: gui_app.push_widget(self._custom_software_warning_page))
+    self._software_selection_page = SoftwareSelectionPage(self._push_network_setup, lambda: gui_app.push_widget(self._custom_software_warning_page))
 
     self._download_failed_page = FailedPage(self._pop_to_software_selection, icon="icons_mici/setup/red_warning.png")
 
@@ -530,7 +530,7 @@ class Setup(Widget):
     gui_app.pop_widgets_to(self._software_selection_page, self._software_selection_page.reset)
 
   def _use_openpilot(self):
-    if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH):
+    if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH) and False:
       os.remove(VALID_CACHE_PATH)
       # with open(TMP_CONTINUE_PATH, "w") as f:
       #   f.write(CONTINUE)
@@ -538,7 +538,7 @@ class Setup(Widget):
       #  make sure installer fails (doesn't write continue.sh) if fetch/checkout fails
       #  make isntaller move atomic
       # run_cmd(["chmod", "+x", TMP_CONTINUE_PATH])
-      shutil.move(TMP_CONTINUE_PATH, CONTINUE_PATH)
+      # shutil.move(TMP_CONTINUE_PATH, CONTINUE_PATH)
       # shutil.copyfile(INSTALLER_SOURCE_PATH, INSTALLER_DESTINATION_PATH)
       shutil.copyfile(INSTALLER_SOURCE_PATH, TMP_INSTALLER_PATH)
       os.rename(TMP_INSTALLER_PATH, INSTALLER_DESTINATION_PATH)
@@ -618,13 +618,14 @@ class Setup(Widget):
         self._download_failed_reason = "No custom software found at this URL: " + self.download_url.replace("https://", "", 1)
         return
 
+      # TODO: this is unused?!
+      with open(INSTALLER_URL_PATH, "w") as f:
+        f.write(self.download_url)
+
       # AGNOS might try to execute the installer before this process exits.
       # Therefore, important to close the fd before renaming the installer.
       os.close(fd)
       os.rename(tmpfile, INSTALLER_DESTINATION_PATH)
-
-      with open(INSTALLER_URL_PATH, "w") as f:
-        f.write(self.download_url)
 
       # give time for installer UI to take over
       time.sleep(0.1)

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -531,8 +531,6 @@ class Setup(Widget):
 
   def _use_openpilot(self):
     if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH) and False:
-      # with open(TMP_CONTINUE_PATH, "w") as f:
-      #   f.write(CONTINUE)
       # TODO: always pull installer, don't write continue.sh here
       #  make sure installer fails (doesn't write continue.sh) if fetch/checkout fails
       #  make isntaller move atomic

--- a/system/ui/tici_setup.py
+++ b/system/ui/tici_setup.py
@@ -7,12 +7,10 @@ import urllib.request
 import urllib.error
 from urllib.parse import urlparse
 from enum import IntEnum
-import shutil
 
 import pyray as rl
 
 from cereal import log
-from openpilot.common.utils import run_cmd
 from openpilot.system.hardware import HARDWARE
 from openpilot.system.ui.lib.scroll_panel import GuiScrollPanel
 from openpilot.system.ui.lib.application import gui_app, FontWeight, FONT_SCALE
@@ -35,20 +33,8 @@ BUTTON_SPACING = 50
 OPENPILOT_URL = "https://openpilot.comma.ai"
 USER_AGENT = f"AGNOSSetup-{HARDWARE.get_os_version()}"
 
-CONTINUE_PATH = "/data/continue.sh"
-TMP_CONTINUE_PATH = "/data/continue.sh.new"
-INSTALL_PATH = "/data/openpilot"
-VALID_CACHE_PATH = "/data/.openpilot_cache"
-INSTALLER_SOURCE_PATH = "/usr/comma/installer"
 INSTALLER_DESTINATION_PATH = "/tmp/installer"
-TMP_INSTALLER_PATH = "/tmp/installer.new"
 INSTALLER_URL_PATH = "/tmp/installer_url"
-
-CONTINUE = """#!/usr/bin/env bash
-
-cd /data/openpilot
-exec ./launch_openpilot.sh
-"""
 
 
 class SetupState(IntEnum):
@@ -344,22 +330,9 @@ class Setup(Widget):
     gui_app.push_widget(self.keyboard)
 
   def use_openpilot(self):
-    if os.path.isdir(INSTALL_PATH) and os.path.isfile(VALID_CACHE_PATH):
-      os.remove(VALID_CACHE_PATH)
-      with open(TMP_CONTINUE_PATH, "w") as f:
-        f.write(CONTINUE)
-      run_cmd(["chmod", "+x", TMP_CONTINUE_PATH])
-      shutil.move(TMP_CONTINUE_PATH, CONTINUE_PATH)
-      shutil.copyfile(INSTALLER_SOURCE_PATH, TMP_INSTALLER_PATH)
-      os.rename(TMP_INSTALLER_PATH, INSTALLER_DESTINATION_PATH)
-
-      # give time for installer UI to take over
-      time.sleep(0.1)
-      gui_app.request_close()
-    else:
-      self.state = SetupState.NETWORK_SETUP
-      self.stop_network_check_thread.clear()
-      self.start_network_check()
+    self.state = SetupState.NETWORK_SETUP
+    self.stop_network_check_thread.clear()
+    self.start_network_check()
 
   def download(self, url: str):
     # autocomplete incomplete URLs

--- a/system/ui/tici_setup.py
+++ b/system/ui/tici_setup.py
@@ -163,7 +163,9 @@ class Setup(Widget):
 
   def _software_selection_continue_button_callback(self):
     if self._software_selection_openpilot_button.selected:
-      self.use_openpilot()
+      self.state = SetupState.NETWORK_SETUP
+      self.stop_network_check_thread.clear()
+      self.start_network_check()
     else:
       self.state = SetupState.CUSTOM_SOFTWARE_WARNING
 
@@ -328,11 +330,6 @@ class Setup(Widget):
     self.keyboard.set_title("Enter URL", "for Custom Software")
     self.keyboard.set_callback(handle_keyboard_result)
     gui_app.push_widget(self.keyboard)
-
-  def use_openpilot(self):
-    self.state = SetupState.NETWORK_SETUP
-    self.stop_network_check_thread.clear()
-    self.start_network_check()
 
   def download(self, url: str):
     # autocomplete incomplete URLs

--- a/system/ui/tici_setup.py
+++ b/system/ui/tici_setup.py
@@ -41,6 +41,7 @@ INSTALL_PATH = "/data/openpilot"
 VALID_CACHE_PATH = "/data/.openpilot_cache"
 INSTALLER_SOURCE_PATH = "/usr/comma/installer"
 INSTALLER_DESTINATION_PATH = "/tmp/installer"
+TMP_INSTALLER_PATH = "/tmp/installer.new"
 INSTALLER_URL_PATH = "/tmp/installer_url"
 
 CONTINUE = """#!/usr/bin/env bash
@@ -349,7 +350,8 @@ class Setup(Widget):
         f.write(CONTINUE)
       run_cmd(["chmod", "+x", TMP_CONTINUE_PATH])
       shutil.move(TMP_CONTINUE_PATH, CONTINUE_PATH)
-      shutil.copyfile(INSTALLER_SOURCE_PATH, INSTALLER_DESTINATION_PATH)
+      shutil.copyfile(INSTALLER_SOURCE_PATH, TMP_INSTALLER_PATH)
+      os.rename(TMP_INSTALLER_PATH, INSTALLER_DESTINATION_PATH)
 
       # give time for installer UI to take over
       time.sleep(0.1)


### PR DESCRIPTION
cached installed broken since https://github.com/commaai/openpilot/pull/35960, silently wasn't running installer to fetch and checkout

on mici before https://github.com/commaai/flash/pull/191, flash.comma.ai was flashing a custom mici userdata with cache that likely had openpilot properly on release-mici (https://github.com/commaai/openpilot/commit/ccf7361798a2b7ff36f5065dffb602eb40c22302)

then we do a `fcopyfile` in setup which isn't atomic, and comma.sh may not run the installer:

log from comma.sh
```                                              
running installer                                                                                               
/usr/comma/comma.sh: line 101: /tmp/installer: Text file busy
```

then it continues to run continue.sh written from setup: https://github.com/commaai/agnos-builder/blob/6655610bc9d95aa42f169c27cae5a4520aedcf05/userspace/usr/comma/comma.sh#L78-L80

---

now after that flash PR, we flash userdata on release-tizi (built from https://github.com/commaai/agnos-builder/blob/master/scripts/build_userdata.sh), installer never runs to check out proper branch, and it breaks the install

and on tici, it sometimes silently doesn't fetch using cache