### PR TITLE
ci: add placeholder issue_message to fix first timers PR workflow errors

### DIFF
--- a/.github/workflows/auto_pr_review.yaml
+++ b/.github/workflows/auto_pr_review.yaml
@@ -40,7 +40,7 @@ jobs:
       if: github.event.pull_request.head.repo.full_name != 'commaai/openpilot'
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        issue_message: ""
+        issue_message: "."  # must be non-empty, but isn't used for pr target (temporary fix until https://github.com/actions/first-interaction/pull/403 is merged)
         pr_message: |
             <!-- _(run_id **${{ github.run_id }}**)_ -->
             Thanks for contributing to openpilot! In order for us to review your PR as quickly as possible, check the following:


### PR DESCRIPTION
Reopening #37155 since the issue is still present.

https://github.com/commaai/openpilot/pull/37155#issuecomment-3962273731

Once https://github.com/actions/first-interaction/pull/403 is merged I think this can be reverted