### PR TITLE
deleter: handle non-openpilot-created root entries

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -45,28 +45,55 @@ def get_preserved_segments(dirs_by_creation: list[str]) -> set[str]:
   return preserved
 
 
+def list_root_entries(root: str) -> list[str]:
+  try:
+    entries = os.listdir(root)
+  except OSError:
+    cloudlog.exception("list_root_entries failed")
+    return []
+
+  dirs_by_creation = [
+    d for d in listdir_by_creation(root)
+    if not os.path.islink(os.path.join(root, d))
+  ]
+  preserved_dirs = get_preserved_segments(dirs_by_creation)
+  dir_order = {d: i for i, d in enumerate(dirs_by_creation)}
+
+  return sorted(
+    entries,
+    key=lambda d: (d in DELETE_LAST, d in preserved_dirs, d in dir_order, dir_order.get(d, -1), d),
+  )
+
+
+def delete_root_entry(root: str, entry: str) -> bool:
+  delete_path = os.path.join(root, entry)
+
+  try:
+    is_dir = os.path.isdir(delete_path) and not os.path.islink(delete_path)
+    if is_dir and any(name.endswith(".lock") for name in os.listdir(delete_path)):
+      return False
+
+    cloudlog.info(f"deleting {delete_path}")
+    if is_dir:
+      shutil.rmtree(delete_path)
+    else:
+      os.remove(delete_path)
+    return True
+  except OSError:
+    cloudlog.exception(f"issue deleting {delete_path}")
+    return False
+
+
 def deleter_thread(exit_event: threading.Event):
   while not exit_event.is_set():
     out_of_bytes = get_available_bytes(default=MIN_BYTES + 1) < MIN_BYTES
     out_of_percent = get_available_percent(default=MIN_PERCENT + 1) < MIN_PERCENT
 
     if out_of_percent or out_of_bytes:
-      dirs = listdir_by_creation(Paths.log_root())
-      preserved_dirs = get_preserved_segments(dirs)
-
-      # remove the earliest directory we can
-      for delete_dir in sorted(dirs, key=lambda d: (d in DELETE_LAST, d in preserved_dirs)):
-        delete_path = os.path.join(Paths.log_root(), delete_dir)
-
-        if any(name.endswith(".lock") for name in os.listdir(delete_path)):
-          continue
-
-        try:
-          cloudlog.info(f"deleting {delete_path}")
-          shutil.rmtree(delete_path)
+      # remove the earliest root entry we can
+      for entry in list_root_entries(Paths.log_root()):
+        if delete_root_entry(Paths.log_root(), entry):
           break
-        except OSError:
-          cloudlog.exception(f"issue deleting {delete_path}")
       exit_event.wait(.1)
     else:
       exit_event.wait(30)

--- a/system/loggerd/tests/test_deleter.py
+++ b/system/loggerd/tests/test_deleter.py
@@ -1,3 +1,5 @@
+import os
+import random
 import time
 import threading
 from collections import namedtuple
@@ -6,7 +8,8 @@ from collections.abc import Sequence
 
 import openpilot.system.loggerd.deleter as deleter
 from openpilot.common.timeout import Timeout, TimeoutException
-from openpilot.system.loggerd.tests.loggerd_tests_common import UploaderTestCase
+from openpilot.system.loggerd.tests.loggerd_tests_common import UploaderTestCase, create_random_file
+from openpilot.system.hardware.hw import Paths
 
 Stats = namedtuple("Stats", ['f_bavail', 'f_blocks', 'f_frsize'])
 
@@ -64,6 +67,15 @@ class TestDeleter(UploaderTestCase):
 
     assert deleted_order == f_paths, "Files not deleted in expected order"
 
+  def assertDeleted(self, paths: Sequence[Path], timeout: int = 5) -> None:
+    self.start_thread()
+    try:
+      with Timeout(timeout, "Timeout waiting for paths to be deleted"):
+        while any(os.path.lexists(path) for path in paths):
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+
   def test_delete_order(self):
     self.assertDeleteOrder([
       self.make_file_with_data(self.seg_format.format(0), self.f_type),
@@ -115,3 +127,63 @@ class TestDeleter(UploaderTestCase):
     self.join_thread()
 
     assert f_path.exists(), "File deleted when locked"
+
+  def test_delete_random_mixed_entries(self):
+    rng = random.Random(0)
+    root = Path(Paths.log_root())
+    paths_to_delete: list[Path] = []
+
+    for i in range(6):
+      file_path = root / f"stray_file_{i}.bin"
+      create_random_file(file_path, 0.01)
+      paths_to_delete.append(file_path)
+
+    for i in range(4):
+      dir_path = root / f"stray_dir_{i}"
+      current = dir_path
+      for depth in range(rng.randint(1, 3)):
+        current /= f"nested_{depth}"
+        current.mkdir(parents=True, exist_ok=True)
+        for file_idx in range(rng.randint(1, 3)):
+          create_random_file(current / f"nested_file_{depth}_{file_idx}.bin", 0.01)
+      paths_to_delete.append(dir_path)
+
+    external_target = root.parent / "deleter_symlink_target.bin"
+    create_random_file(external_target, 0.01)
+    symlink_path = root / "stray_symlink"
+    os.symlink(external_target, symlink_path)
+    paths_to_delete.append(symlink_path)
+
+    try:
+      self.assertDeleted(paths_to_delete, timeout=10)
+      assert external_target.exists(), "Deleting a symlink should not remove its target"
+    finally:
+      if external_target.exists():
+        external_target.unlink()
+
+  def test_continue_after_entry_error(self, monkeypatch):
+    root = Path(Paths.log_root())
+    bad_dir = root / "0_bad_dir"
+    good_dir = root / "1_good_dir"
+
+    create_random_file(bad_dir / "nested" / "bad.bin", 0.01)
+    create_random_file(good_dir / "nested" / "good.bin", 0.01)
+
+    original_listdir = deleter.os.listdir
+
+    def fake_listdir(path):
+      if path == str(bad_dir):
+        raise PermissionError("permission denied")
+      return original_listdir(path)
+
+    monkeypatch.setattr(deleter.os, "listdir", fake_listdir)
+
+    self.start_thread()
+    try:
+      with Timeout(5, "Timeout waiting for good_dir to be deleted"):
+        while good_dir.exists():
+          time.sleep(0.01)
+    finally:
+      self.join_thread()
+
+    assert bad_dir.exists(), "The failing directory should remain after a deletion error"


### PR DESCRIPTION
Closes #30102.

The deleter currently assumes every entry under the log root is an openpilot segment directory. That breaks down when stray files, symlinks, or non-segment directories exist at the top level.

This change keeps the existing creation-based ordering for real directories, but makes deletion generic across all log-root entries:
- delete top-level files and symlinks with `os.remove`
- delete real directories with `shutil.rmtree`
- only perform the `.lock` check on real directories
- continue to the next candidate when deleting one entry raises `OSError`

Tests added:
- mixed top-level files, symlinks, and nested directories are deleted
- a deletion failure on one entry does not stop deletion of the next eligible entry

Verification:
- `pytest system/loggerd/tests/test_deleter.py -q`
- result: `8 passed in 3.09s`
