### PR TITLE
Fix checking of empty variables with 'set -u' in tools setup script

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -20,16 +20,16 @@ function agnos_init {
   if [ $(< /VERSION) != "$AGNOS_VERSION" ]; then
     AGNOS_PY="$DIR/system/hardware/tici/agnos.py"
     MANIFEST="$DIR/system/hardware/tici/agnos.json"
-    if $AGNOS_PY --verify $MANIFEST; then
+    if "$AGNOS_PY" --verify "$MANIFEST"; then
       sudo reboot
     fi
-    $DIR/system/hardware/tici/updater $AGNOS_PY $MANIFEST
+    "$DIR/system/hardware/tici/updater" "$AGNOS_PY" "$MANIFEST"
   fi
 }
 
 function launch {
   # Remove orphaned git lock if it exists on boot
-  [ -f "$DIR/.git/index.lock" ] && rm -f $DIR/.git/index.lock
+  [ -f "$DIR/.git/index.lock" ] && rm -f "$DIR/.git/index.lock"
 
   # Check to see if there's a valid overlay-based update available. Conditions
   # are as follows:
@@ -41,7 +41,7 @@ function launch {
   #    that completed successfully and synced to disk.
 
   if [ -f "${DIR}/.overlay_init" ]; then
-    find ${DIR}/.git -newer ${DIR}/.overlay_init | grep -q '.' 2> /dev/null
+    find "${DIR}/.git" -newer "${DIR}/.overlay_init" | grep -q '.' 2> /dev/null
     if [ $? -eq 0 ]; then
       echo "${DIR} has been modified, skipping overlay update installation"
     else
@@ -50,9 +50,9 @@ function launch {
           echo "Valid overlay update found, installing"
           LAUNCHER_LOCATION="${BASH_SOURCE[0]}"
 
-          mv $DIR /data/safe_staging/old_openpilot
-          mv "${STAGING_ROOT}/finalized" $DIR
-          cd $DIR
+          mv "$DIR" /data/safe_staging/old_openpilot
+          mv "${STAGING_ROOT}/finalized" "$DIR"
+          cd "$DIR"
 
           echo "Restarting launch script ${LAUNCHER_LOCATION}"
           unset AGNOS_VERSION
@@ -66,7 +66,7 @@ function launch {
   fi
 
   # handle pythonpath
-  ln -sfn $(pwd) /data/pythonpath
+  ln -sfn "$(pwd)" /data/pythonpath
   export PYTHONPATH="$PWD"
 
   # hardware specific init
@@ -79,7 +79,7 @@ function launch {
 
   # start manager
   cd system/manager
-  if [ ! -f $DIR/prebuilt ]; then
+  if [ ! -f "$DIR/prebuilt" ]; then
     ./build.py
   fi
   ./manager.py

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -6,7 +6,7 @@ GREEN='\033[0;32m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-if [ -z "$OPENPILOT_ROOT" ]; then
+if [ -z "${OPENPILOT_ROOT:-}" ]; then
   # default to current directory for installation
   OPENPILOT_ROOT="$(pwd)/openpilot"
 fi
@@ -79,7 +79,7 @@ function check_stdin() {
 function ask_dir() {
   echo -n "Enter directory in which to install openpilot (default $OPENPILOT_ROOT): "
 
-  if [[ -z $INTERACTIVE ]]; then
+  if [[ -z "${INTERACTIVE:-}" ]]; then
     echo -e "\nBecause your are running in non-interactive mode, the installation"
     echo -e "will default to $OPENPILOT_ROOT\n"
     return 0
@@ -111,7 +111,7 @@ function check_dir() {
     fi
 
     # by default, don't try installing in already existing directory
-    if [[ -z $INTERACTIVE ]]; then
+    if [[ -z "${INTERACTIVE:-}" ]]; then
       return 0
     fi
 
@@ -184,5 +184,5 @@ check_stdin
 ask_dir
 check_dir
 check_git
-[ -z $SKIP_GIT_CLONE ] && git_clone
+[[ -z "${SKIP_GIT_CLONE:-}" ]] && git_clone
 install_with_op


### PR DESCRIPTION
## Description

This PR fixes strict-mode (`set -euo pipefail`) unbound-variable failures in `tools/setup.sh`.

### Changes

- Use `${OPENPILOT_ROOT:-}` when checking whether `OPENPILOT_ROOT` is set.
- Use `${INTERACTIVE:-}` in non-interactive checks.
- Use `${SKIP_GIT_CLONE:-}` in the clone gate.

No behavior changes beyond preventing unintended exits caused by unset variables.

## Verification

- `bash -n tools/setup.sh` passes.
- Reasoning checks:
  - Running with `OPENPILOT_ROOT` unset no longer aborts at startup.
  - Non-interactive mode no longer aborts on unset `INTERACTIVE`.
  - Clone gate no longer aborts when `SKIP_GIT_CLONE` was never set.